### PR TITLE
Xpetra: replace matrix diagonal

### DIFF
--- a/packages/stokhos/src/CMakeLists.txt
+++ b/packages/stokhos/src/CMakeLists.txt
@@ -623,6 +623,7 @@ IF (Stokhos_ENABLE_Sacado)
         Details::getDiagCopyWithoutOffsets
         Details::packCrsMatrix
         Details::unpackCrsMatrixAndCombine
+        replaceDiagonalCrsMatrix
         )
       SET(TPETRAEXT_ETI_CLASSES
         MatrixMatrix

--- a/packages/xpetra/src/CrsMatrix/Xpetra_CrsMatrix.hpp
+++ b/packages/xpetra/src/CrsMatrix/Xpetra_CrsMatrix.hpp
@@ -218,6 +218,9 @@ namespace Xpetra {
     //! Get a copy of the diagonal entries owned by this node, with local row indices, using row offsets.
     virtual void getLocalDiagCopy(Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > &diag, const Teuchos::ArrayView<const size_t> &offsets) const = 0;
 
+    //! Replace the diagonal entries of the matrix
+    virtual void replaceDiag(const Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> &diag) = 0;
+
     //! Left scale matrix using the given vector entries
     virtual void leftScale (const Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& x) = 0;
 

--- a/packages/xpetra/src/CrsMatrix/Xpetra_EpetraCrsMatrix.hpp
+++ b/packages/xpetra/src/CrsMatrix/Xpetra_EpetraCrsMatrix.hpp
@@ -204,6 +204,7 @@ public:
   void getLocalDiagCopy(Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > &diag) const {  }
   void getLocalDiagOffsets(Teuchos::ArrayRCP<size_t> &offsets) const { }
   void getLocalDiagCopy(Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > &diag, const Teuchos::ArrayView<const size_t> &offsets) const { }
+  void replaceDiag(const Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> &diag) { }
   void leftScale (const Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& x) { };
   void rightScale (const Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& x) { };
 
@@ -863,6 +864,11 @@ public:
   //! Get a copy of the diagonal entries owned by this node, with local row indices, using row offsets.
   void getLocalDiagCopy(Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > &diag, const Teuchos::ArrayView<const size_t> &offsets) const {
     TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraCrsMatrixT.getLocalDiagCopy using offsets is not implemented or supported.");
+  }
+
+  //! Replace the diagonal entries of the matrix
+  void replaceDiag(const Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> &diag) {
+    mtx_->ReplaceDiagonalValues (toEpetra<GlobalOrdinal,Node>(diag));
   }
 
   void leftScale (const Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& x) {
@@ -1634,7 +1640,7 @@ public:
     // Values
     values = Teuchos::arcp(mtx_->ExpertExtractValues(), lowerOffset, nnz, ownMemory);
   }
-  
+
   // Epetra always has global constants
   bool haveGlobalConstants() const  { return true;}
 
@@ -1841,6 +1847,11 @@ public:
   //! Get a copy of the diagonal entries owned by this node, with local row indices, using row offsets.
   void getLocalDiagCopy(Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > &diag, const Teuchos::ArrayView<const size_t> &offsets) const {
     TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraCrsMatrixT.getLocalDiagCopy using offsets is not implemented or supported.");
+  }
+
+  //! Replace the diagonal entries of the matrix
+  void replaceDiag(const Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> &diag) {
+    mtx_->ReplaceDiagonalValues (toEpetra<GlobalOrdinal,Node>(diag));
   }
 
   void leftScale (const Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& x) {

--- a/packages/xpetra/src/CrsMatrix/Xpetra_TpetraBlockCrsMatrix.hpp
+++ b/packages/xpetra/src/CrsMatrix/Xpetra_TpetraBlockCrsMatrix.hpp
@@ -369,6 +369,10 @@ namespace Xpetra {
     void getLocalDiagCopy(Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > &diag, const Teuchos::ArrayView<const size_t> &offsets) const
     {throw std::runtime_error("Xpetra::TpetraBlockCrsMatrix function not implemented");}
 
+    void replaceDiag(const Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> &diag) {
+      throw std::runtime_error("Xpetra::TpetraBlockCrsMatrix::replaceDiag: function not implemented");
+    }
+
     //! Left scale operator with given vector values
     void leftScale (const Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& x) {
       throw std::runtime_error("Xpetra::TpetraBlockCrsMatrix function not implemented");
@@ -733,6 +737,8 @@ namespace Xpetra {
     void getLocalDiagCopy(Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > &diag, const Teuchos::ArrayView<const size_t> &offsets) const
     {}
 
+    void replaceDiag(Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > &diag) const {    }
+
     void leftScale (const Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& x) { }
     void rightScale (const Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& x) { }
 
@@ -1080,6 +1086,8 @@ namespace Xpetra {
     //! Get a copy of the diagonal entries owned by this node, with local row indices.
     void getLocalDiagCopy(Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > &diag, const Teuchos::ArrayView<const size_t> &offsets) const
     {}
+
+    void replaceDiag(Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > &diag) const {    }
 
     void leftScale (const Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& x) { }
     void rightScale (const Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& x) { }

--- a/packages/xpetra/src/CrsMatrix/Xpetra_TpetraCrsMatrix.hpp
+++ b/packages/xpetra/src/CrsMatrix/Xpetra_TpetraCrsMatrix.hpp
@@ -55,13 +55,13 @@
 #include "Xpetra_TpetraConfigDefs.hpp"
 
 #include "Tpetra_CrsMatrix.hpp"
+#include "Tpetra_replaceDiagonalCrsMatrix.hpp"
 
 #include "Xpetra_CrsMatrix.hpp"
 #include "Xpetra_TpetraMap.hpp"
 #include "Xpetra_TpetraMultiVector.hpp"
 #include "Xpetra_TpetraVector.hpp"
 #include "Xpetra_TpetraCrsGraph.hpp"
-//#include "Xpetra_TpetraRowMatrix.hpp"
 #include "Xpetra_Exceptions.hpp"
 
 namespace Xpetra {
@@ -290,9 +290,9 @@ namespace Xpetra {
     void getAllValues(ArrayRCP<const size_t>& rowptr, ArrayRCP<const LocalOrdinal>& colind, ArrayRCP<const Scalar>& values) const
     { XPETRA_MONITOR("TpetraCrsMatrix::getAllValues"); mtx_->getAllValues(rowptr,colind,values); }
 
-    bool haveGlobalConstants() const 
+    bool haveGlobalConstants() const
     { return mtx_->haveGlobalConstants();}
-    
+
 //@}
 
     //! @name Transformational Methods
@@ -440,12 +440,11 @@ namespace Xpetra {
     TpetraCrsMatrix(const TpetraCrsMatrix& matrix)
       : mtx_ (matrix.mtx_->template clone<Node> (matrix.mtx_->getNode ())) {}
 
-    //! Get a copy of the diagonal entries owned by this node, with local row idices.
+    //! Get a copy of the diagonal entries owned by this node, with local row indices.
     void getLocalDiagCopy(Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > &diag) const {
       XPETRA_MONITOR("TpetraCrsMatrix::getLocalDiagCopy");
       XPETRA_DYNAMIC_CAST(TpetraVectorClass, diag, tDiag, "Xpetra::TpetraCrsMatrix.getLocalDiagCopy() only accept Xpetra::TpetraVector as input arguments.");
       mtx_->getLocalDiagCopy(*tDiag.getTpetra_Vector());
-      // mtx_->getLocalDiagCopy(toTpetra(diag));
     }
 
     //! Get offsets of the diagonal entries in the matrix.
@@ -457,9 +456,13 @@ namespace Xpetra {
     //! Get a copy of the diagonal entries owned by this node, with local row indices.
     void getLocalDiagCopy(Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > &diag, const Teuchos::ArrayView<const size_t> &offsets) const {
       XPETRA_MONITOR("TpetraCrsMatrix::getLocalDiagCopy");
-      //XPETRA_DYNAMIC_CAST(TpetraVectorClass, diag, tDiag, "Xpetra::TpetraCrsMatrix.getLocalDiagCopy() only accept Xpetra::TpetraVector as input arguments.");
-      //mtx_->getLocalDiagCopy(*tDiag.getTpetra_Vector(), offsets);
       mtx_->getLocalDiagCopy(*(toTpetra(diag)), offsets);
+    }
+
+    //! Replace the diagonal entries of the matrix
+    void replaceDiag(const Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> &diag) {
+      XPETRA_MONITOR("TpetraCrsMatrix::replaceDiag");
+      Tpetra::replaceDiagonalCrsMatrix(*mtx_, *(toTpetra(diag)));
     }
 
     //! Left scale operator with given vector values
@@ -757,7 +760,6 @@ namespace Xpetra {
     void getAllValues(ArrayRCP<const size_t>& rowptr, ArrayRCP<const LocalOrdinal>& colind, ArrayRCP<const Scalar>& values) const {  }
 
     bool haveGlobalConstants() const  { return false;}
-    
 
     //@}
 
@@ -893,6 +895,9 @@ namespace Xpetra {
 
     //! Get a copy of the diagonal entries owned by this node, with local row indices.
     void getLocalDiagCopy(Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > &diag, const Teuchos::ArrayView<const size_t> &offsets) const {  }
+
+    //! Replace the diagonal entries of the matrix
+    void replaceDiag(const Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> &diag) {  }
 
     //! Left scale operator with given vector values
     void leftScale (const Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& x) { }
@@ -1278,6 +1283,9 @@ namespace Xpetra {
 
     //! Get a copy of the diagonal entries owned by this node, with local row indices.
     void getLocalDiagCopy(Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > &diag, const Teuchos::ArrayView<const size_t> &offsets) const {  }
+
+    //! Replace the diagonal entries of the matrix
+    void replaceDiag(const Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> &diag) {  }
 
     //! Left scale operator with given vector values
     void leftScale (const Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& x) { }

--- a/packages/xpetra/test/CrsMatrix/CrsMatrix_UnitTests.cpp
+++ b/packages/xpetra/test/CrsMatrix/CrsMatrix_UnitTests.cpp
@@ -54,6 +54,7 @@
 
 #include <Xpetra_ConfigDefs.hpp>
 #include <Xpetra_DefaultPlatform.hpp>
+#include <Xpetra_Parameters.hpp>
 
 #include <Xpetra_Map.hpp>
 #include <Xpetra_MapExtractor.hpp>
@@ -415,6 +416,78 @@ namespace {
       }
     }
 
+  }
+
+  TEUCHOS_UNIT_TEST_TEMPLATE_5_DECL( CrsMatrix, replaceDiagonal, M, Scalar, LO, GO, Node )
+  {
+    typedef Teuchos::ScalarTraits<Scalar> STS;
+    typedef typename STS::magnitudeType MT;
+    const Scalar SC_ONE = STS::one();
+    const GO GO_ONE = Teuchos::OrdinalTraits<GO>::one();
+    // get a comm and node
+    RCP<const Teuchos::Comm<int> > comm = getDefaultComm();
+
+    M testMap(1,0,comm);
+    Xpetra::UnderlyingLib lib = testMap.lib();
+
+    // generate problem
+    GO nEle = Teuchos::as<GO>(2*comm->getSize());
+    const RCP<const Xpetra::Map<LO, GO, Node> > map =
+      Xpetra::MapFactory<LO, GO, Node>::Build(lib, nEle, 2, 0, comm);
+
+    RCP<Xpetra::CrsMatrix<Scalar, LO, GO, Node> > A =
+      Xpetra::CrsMatrixFactory<Scalar,LO,GO,Node>::Build(map, 3);
+    const Scalar rankAsScalar = static_cast<Scalar>(static_cast<MT>(comm->getRank()));
+
+    Teuchos::Array<Scalar> vals = {{SC_ONE, rankAsScalar + SC_ONE, SC_ONE}};
+    for(size_t lclRowIdx = 0; lclRowIdx < 2; ++lclRowIdx) {
+      const GO gblRowIdx = Teuchos::as<GO>(2*comm->getRank() + lclRowIdx);
+      Teuchos::Array<GO> cols = {{gblRowIdx - GO_ONE, gblRowIdx, gblRowIdx + GO_ONE}};
+
+      if((comm->getRank() == 0) && (lclRowIdx == 0)) { // First row of the matrix
+        A->insertGlobalValues(gblRowIdx, cols(1, 2), vals(1, 2));
+      } else if((comm->getRank() == comm->getSize() - 1) && (lclRowIdx == 1)) { // Last row of the matrix
+        A->insertGlobalValues(gblRowIdx, cols(0, 2), vals(0, 2));
+      } else {
+        A->insertGlobalValues(gblRowIdx, cols(), vals());
+      }
+    }
+
+    A->fillComplete();
+    TEST_ASSERT(A->isFillComplete());
+
+    comm->barrier ();
+    {
+      /* Replace the diagonal of the matrix by the ID of the owning MPI rank
+       *
+       * 1. Create map
+       * 2. Create vector with new diagonal values
+       * 3. Replace the diagonal
+       * 4. Test for
+       *    - successful replacement of diagonal values
+       *    - unchanged off-diagonal values (not implemented yet)
+       */
+
+      // Create vector with new diagonal values
+      RCP<Xpetra::Vector<Scalar, LO, GO, Node> > newDiag =
+        Xpetra::VectorFactory<Scalar, LO, GO, Node>::Build(A->getRowMap(), true);
+      newDiag->putScalar(rankAsScalar);
+
+      // Replace the diagonal
+      A->replaceDiag(*newDiag);
+
+      // Tests
+      {
+        RCP<Xpetra::Vector<Scalar, LO, GO, Node> > diagCopy =
+          Xpetra::VectorFactory<Scalar, LO, GO, Node>::Build(A->getRowMap(), true);
+        A->getLocalDiagCopy(*diagCopy);
+
+        Teuchos::ArrayRCP<const Scalar> diagCopyData = diagCopy->getData(0);
+
+        for (size_t i = 0; i < diagCopyData.size(); ++i)
+          TEST_EQUALITY_CONST(diagCopyData[i], rankAsScalar);
+      }
+    }
   }
 
 
@@ -1454,7 +1527,8 @@ namespace {
   TEUCHOS_UNIT_TEST_TEMPLATE_5_INSTANT(   CrsMatrix, Apply , M##LO##GO##Node , SC, LO, GO, Node ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_5_INSTANT(   CrsMatrix, ReplaceGlobalAndLocalValues, M##LO##GO##Node , SC, LO, GO, Node ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_5_INSTANT(   CrsMatrix, leftScale, M##LO##GO##Node , SC, LO, GO, Node ) \
-  TEUCHOS_UNIT_TEST_TEMPLATE_5_INSTANT(   CrsMatrix, rightScale, M##LO##GO##Node , SC, LO, GO, Node )
+  TEUCHOS_UNIT_TEST_TEMPLATE_5_INSTANT(   CrsMatrix, rightScale, M##LO##GO##Node , SC, LO, GO, Node ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_5_INSTANT(   CrsMatrix, replaceDiagonal, M##LO##GO##Node, SC, LO, GO, Node )
 // for Tpetra tests only
 #define UNIT_TEST_GROUP_ORDINAL_TPETRAONLY( SC, LO, GO, Node )                     \
   TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( CrsMatrix, TpetraDeepCopy, SC, LO, GO, Node ) \


### PR DESCRIPTION
@trilinos/xpetra 

## Description
Adding method to replace the diagonal of a CrsMatrix

## Motivation and Context
This addition is required to refactor the HHG driver in MueLu using Xpetra instead of Epetra.

## Related Issues

* Closes #4202
* Blocks #4084

## How Has This Been Tested?
A new unit-test has been added to `Xpetra_CrsMatrix`

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.