### PR TITLE
Tpetra: TAFC

### DIFF
--- a/packages/muelu/src/Misc/MueLu_RAPFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_RAPFactory_def.hpp
@@ -132,11 +132,9 @@ namespace MueLu {
 
       if (pL.get<bool>("rap: triple product") == false) {
         // Reuse pattern if available (multiple solve)
-        RCP<ParameterList> APparams;
+        RCP<ParameterList> APparams = rcp(new ParameterList);
         if(pL.isSublist("matrixmatrix: kernel params"))
-          APparams = rcp(new ParameterList(pL.sublist("matrixmatrix: kernel params")));
-        else
-          APparams = rcp(new ParameterList);
+          APparams->sublist("matrixmatrix: kernel params") = pL.sublist("matrixmatrix: kernel params");
 
         // By default, we don't need global constants for A*P
         APparams->set("compute global constants: temporaries",APparams->get("compute global constants: temporaries",false));
@@ -159,13 +157,9 @@ namespace MueLu {
         }
 
         // Reuse coarse matrix memory if available (multiple solve)
-        RCP<ParameterList> RAPparams;
+        RCP<ParameterList> RAPparams = rcp(new ParameterList);
         if(pL.isSublist("matrixmatrix: kernel params"))
-          RAPparams = rcp(new ParameterList(pL.sublist("matrixmatrix: kernel params")));
-        else
-          RAPparams = rcp(new ParameterList);
-
-
+          RAPparams->sublist("matrixmatrix: kernel params") = pL.sublist("matrixmatrix: kernel params");
 
         if (coarseLevel.IsAvailable("RAP reuse data", this)) {
           GetOStream(static_cast<MsgType>(Runtime0 | Test)) << "Reusing previous RAP data" << std::endl;
@@ -221,11 +215,9 @@ namespace MueLu {
         RAPparams->set("graph", Ac);
         Set(coarseLevel, "RAP reuse data", RAPparams);
       } else {
-        RCP<ParameterList> RAPparams;
+        RCP<ParameterList> RAPparams = rcp(new ParameterList);
         if(pL.isSublist("matrixmatrix: kernel params"))
-          RAPparams = rcp(new ParameterList(pL.sublist("matrixmatrix: kernel params")));
-        else
-          RAPparams = rcp(new ParameterList);
+          RAPparams->sublist("matrixmatrix: kernel params") = pL.sublist("matrixmatrix: kernel params");
 
         // We *always* need global constants for the RAP, but not for the temps
         RAPparams->set("compute global constants: temporaries",RAPparams->get("compute global constants: temporaries",false));

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_SaPFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_SaPFactory_def.hpp
@@ -131,11 +131,9 @@ namespace MueLu {
     RCP<Matrix> finalP;
 
     // Reuse pattern if available
-    RCP<ParameterList> APparams;
+    RCP<ParameterList> APparams = rcp(new ParameterList);;
     if(pL.isSublist("matrixmatrix: kernel params"))
-      APparams=rcp(new ParameterList(pL.sublist("matrixmatrix: kernel params")));
-    else
-      APparams= rcp(new ParameterList);
+      APparams->sublist("matrixmatrix: kernel params") = pL.sublist("matrixmatrix: kernel params");
 
     if (coarseLevel.IsAvailable("AP reuse data", this)) {
       GetOStream(static_cast<MsgType>(Runtime0 | Test)) << "Reusing previous AP data" << std::endl;

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
@@ -1576,8 +1576,9 @@ void mult_AT_B_newmatrix(
         int mm_optimization_core_count2 = params->get("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count);
         if(mm_optimization_core_count2<mm_optimization_core_count) mm_optimization_core_count=mm_optimization_core_count2;
         labelList_subList.set("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count,"Core Count above which the optimized neighbor discovery is used");
+        bool isMM = params_sublist.get("isMatrixMatrix_TransferAndFillComplete",false);
 
-        labelList_subList.set("isMatrixMatrix_TransferAndFillComplete",true,
+        labelList_subList.set("isMatrixMatrix_TransferAndFillComplete",isMM,
                       "This parameter should be set to true only for MatrixMatrix operations: the optimization in Epetra that was ported to Tpetra does _not_ take into account the possibility that for any given source PID, a particular GID may not exist on the target PID: i.e. a transfer operation. A fix for this general case is in development.");
         labelList.set("compute global constants",params->get("compute global constants",true));
     }
@@ -3291,11 +3292,8 @@ void import_and_extract_views(
     Teuchos::ParameterList labelList;
     labelList.set("Timer Label", label);
     auto & labelList_subList = labelList.sublist("matrixmatrix: kernel params",false);
-    labelList_subList.set("isMatrixMatrix_TransferAndFillComplete",true,
-                  "This parameter should be set to true only for MatrixMatrix operations, with source and target matricies that have non-pathalogical graphs");
-    labelList.set("isMatrixMatrix_TransferAndFillComplete",true,
-                  "This parameter should be set to true only for MatrixMatrix operations, with source and target matricies that have non-pathalogical graphs");
 
+    bool isMM = true;
     int mm_optimization_core_count=::Tpetra::Details::Behavior::TAFC_OptimizationCoreCount();
     // Minor speedup tweak - avoid computing the global constants
     Teuchos::ParameterList params_sublist;
@@ -3305,7 +3303,9 @@ void import_and_extract_views(
         mm_optimization_core_count = params_sublist.get("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count);
         int mm_optimization_core_count2 = params->get("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count);
         if(mm_optimization_core_count2<mm_optimization_core_count) mm_optimization_core_count=mm_optimization_core_count2;
+        isMM = params_sublist.get("isMatrixMatrix_TransferAndFillComplete",false);
     }
+    labelList_subList.set("isMatrixMatrix_TransferAndFillComplete",isMM);
     labelList_subList.set("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count);
     
     Aview.importMatrix = Tpetra::importAndFillCompleteCrsMatrix<crs_matrix_type>(rcpFromRef(A), *importer,

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
@@ -377,9 +377,11 @@ void Jacobi(Scalar omega,
       int mm_optimization_core_count2 = params->get("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count);
       if(mm_optimization_core_count2<mm_optimization_core_count) mm_optimization_core_count=mm_optimization_core_count2;
       bool isMM = slist.get("isMatrixMatrix_TransferAndFillComplete",false);
+      bool overrideAllreduce = slist.get("MM_TAFC_OverrideAllreduceCheck",false);
       auto & ip1slist = importParams1->sublist("matrixmatrix: kernel params",false);
       ip1slist.set("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count);
       ip1slist.set("isMatrixMatrix_TransferAndFillComplete",isMM);
+      ip1slist.set("MM_TAFC_OverrideAllreduceCheck",overrideAllreduce);
   }
 
   //Now import any needed remote rows and populate the Aview struct.
@@ -401,11 +403,13 @@ void Jacobi(Scalar omega,
       auto slist = params->sublist("matrixmatrix: kernel params",false);
       int mm_optimization_core_count = slist.get("MM_TAFC_OptimizationCoreCount",::Tpetra::Details::Behavior::TAFC_OptimizationCoreCount () );
       bool isMM = slist.get("isMatrixMatrix_TransferAndFillComplete",false);
+      bool overrideAllreduce = slist.get("MM_TAFC_OverrideAllreduceCheck",false);
       auto & ip2slist = importParams2->sublist("matrixmatrix: kernel params",false);
       int mm_optimization_core_count2 = params->get("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count);
       if(mm_optimization_core_count2<mm_optimization_core_count) mm_optimization_core_count=mm_optimization_core_count2;
       ip2slist.set("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count);
       ip2slist.set("isMatrixMatrix_TransferAndFillComplete",isMM);
+      ip2slist.set("MM_TAFC_OverrideAllreduceCheck",overrideAllreduce);
   }
 
   MMdetails::import_and_extract_views(*Bprime, targetMap_B, Bview, Aprime->getGraph()->getImporter(), false, label,importParams2);
@@ -1506,6 +1510,7 @@ void mult_AT_B_newmatrix(
       importParams1->set("compute global constants",params->get("compute global constants: temporaries",false));
       auto slist = params->sublist("matrixmatrix: kernel params",false);
       bool isMM = slist.get("isMatrixMatrix_TransferAndFillComplete",false);
+      bool overrideAllreduce = slist.get("MM_TAFC_OverrideAllreduceCheck",false);
       int mm_optimization_core_count=::Tpetra::Details::Behavior::TAFC_OptimizationCoreCount();
       mm_optimization_core_count = slist.get("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count);
       int mm_optimization_core_count2 = params->get("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count);
@@ -1513,6 +1518,7 @@ void mult_AT_B_newmatrix(
       auto & sip1 = importParams1->sublist("matrixmatrix: kernel params",false);
       sip1.set("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count);
       sip1.set("isMatrixMatrix_TransferAndFillComplete",isMM);
+      sip1.set("MM_TAFC_OverrideAllreduceCheck",overrideAllreduce);
   }
 
   MMdetails::import_and_extract_views(*Atrans, Atrans->getRowMap(), Aview, dummyImporter,true, label,importParams1);
@@ -1522,6 +1528,7 @@ void mult_AT_B_newmatrix(
       importParams2->set("compute global constants",params->get("compute global constants: temporaries",false));
       auto slist = params->sublist("matrixmatrix: kernel params",false);
       bool isMM = slist.get("isMatrixMatrix_TransferAndFillComplete",false);
+      bool overrideAllreduce = slist.get("MM_TAFC_OverrideAllreduceCheck",false);
       int mm_optimization_core_count=::Tpetra::Details::Behavior::TAFC_OptimizationCoreCount();
       mm_optimization_core_count = slist.get("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count);
       int mm_optimization_core_count2 = params->get("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count);
@@ -1529,6 +1536,7 @@ void mult_AT_B_newmatrix(
       auto & sip2 = importParams2->sublist("matrixmatrix: kernel params",false);
       sip2.set("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count);
       sip2.set("isMatrixMatrix_TransferAndFillComplete",isMM);
+      sip2.set("MM_TAFC_OverrideAllreduceCheck",overrideAllreduce);
   }
 
   if(B.getRowMap()->isSameAs(*Atrans->getColMap())){
@@ -1577,10 +1585,12 @@ void mult_AT_B_newmatrix(
         if(mm_optimization_core_count2<mm_optimization_core_count) mm_optimization_core_count=mm_optimization_core_count2;
         labelList_subList.set("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count,"Core Count above which the optimized neighbor discovery is used");
         bool isMM = params_sublist.get("isMatrixMatrix_TransferAndFillComplete",false);
+        bool overrideAllreduce = params_sublist.get("MM_TAFC_OverrideAllreduceCheck",false);
 
         labelList_subList.set("isMatrixMatrix_TransferAndFillComplete",isMM,
                       "This parameter should be set to true only for MatrixMatrix operations: the optimization in Epetra that was ported to Tpetra does _not_ take into account the possibility that for any given source PID, a particular GID may not exist on the target PID: i.e. a transfer operation. A fix for this general case is in development.");
         labelList.set("compute global constants",params->get("compute global constants",true));
+        labelList.set("MM_TAFC_OverrideAllreduceCheck",overrideAllreduce);
     }
     Ctemp->exportAndFillComplete(Crcp,*Ctemp->getGraph()->getExporter(),
                                  B.getDomainMap(),A.getDomainMap(),rcp(&labelList,false));
@@ -3294,6 +3304,7 @@ void import_and_extract_views(
     auto & labelList_subList = labelList.sublist("matrixmatrix: kernel params",false);
 
     bool isMM = true;
+    bool overrideAllreduce = false;
     int mm_optimization_core_count=::Tpetra::Details::Behavior::TAFC_OptimizationCoreCount();
     // Minor speedup tweak - avoid computing the global constants
     Teuchos::ParameterList params_sublist;
@@ -3304,9 +3315,11 @@ void import_and_extract_views(
         int mm_optimization_core_count2 = params->get("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count);
         if(mm_optimization_core_count2<mm_optimization_core_count) mm_optimization_core_count=mm_optimization_core_count2;
         isMM = params_sublist.get("isMatrixMatrix_TransferAndFillComplete",false);
+        overrideAllreduce = params_sublist.get("MM_TAFC_OverrideAllreduceCheck",false);
     }
     labelList_subList.set("isMatrixMatrix_TransferAndFillComplete",isMM);
     labelList_subList.set("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count);
+    labelList_subList.set("MM_TAFC_OverrideAllreduceCheck",overrideAllreduce);
     
     Aview.importMatrix = Tpetra::importAndFillCompleteCrsMatrix<crs_matrix_type>(rcpFromRef(A), *importer,
                                     A.getDomainMap(), importer->getTargetMap(), rcpFromRef(labelList));

--- a/packages/tpetra/core/ext/TpetraExt_TripleMatrixMultiply_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_TripleMatrixMultiply_def.hpp
@@ -297,20 +297,29 @@ namespace Tpetra {
 #endif
         Teuchos::ParameterList labelList;
         labelList.set("Timer Label", label);
+        Teuchos::ParameterList& labelList_subList = labelList.sublist("matrixmatrix: kernel params",false);
+
         RCP<crs_matrix_type> Acprime = rcpFromRef(Ac);
+        bool isMM = true;
+        bool overrideAllreduce = false;
+        int mm_optimization_core_count=::Tpetra::Details::Behavior::TAFC_OptimizationCoreCount();
         if(!params.is_null()) {
           Teuchos::ParameterList& params_sublist = params->sublist("matrixmatrix: kernel params",false);
-          Teuchos::ParameterList& labelList_subList = labelList.sublist("matrixmatrix: kernel params",false);
-          int mm_optimization_core_count = ::Tpetra::Details::Behavior::TAFC_OptimizationCoreCount();
+          mm_optimization_core_count = ::Tpetra::Details::Behavior::TAFC_OptimizationCoreCount();
           mm_optimization_core_count = params_sublist.get("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count);
           int mm_optimization_core_count2 = params->get("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count);
           if(mm_optimization_core_count2<mm_optimization_core_count) mm_optimization_core_count=mm_optimization_core_count2;
-          labelList_subList.set("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count,"Core Count above which the optimized neighbor discovery is used");
+          isMM = params_sublist.get("isMatrixMatrix_TransferAndFillComplete",false);
+          overrideAllreduce = params_sublist.get("MM_TAFC_OverrideAllreduceCheck",false);
 
-          labelList_subList.set("isMatrixMatrix_TransferAndFillComplete",true,
-                                "This parameter should be set to true only for MatrixMatrix operations: the optimization in Epetra that was ported to Tpetra does _not_ take into account the possibility that for any given source PID, a particular GID may not exist on the target PID: i.e. a transfer operation. A fix for this general case is in development.");
           labelList.set("compute global constants",params->get("compute global constants",true));
         }
+        labelList_subList.set("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count,"Core Count above which the optimized neighbor discovery is used");
+
+        labelList_subList.set("isMatrixMatrix_TransferAndFillComplete",isMM,
+                                "This parameter should be set to true only for MatrixMatrix operations: the optimization in Epetra that was ported to Tpetra does _not_ take into account the possibility that for any given source PID, a particular GID may not exist on the target PID: i.e. a transfer operation. A fix for this general case is in development.");
+        labelList_subList.set("MM_TAFC_OverrideAllreduceCheck",overrideAllreduce);
+
         export_type exporter = export_type(*Pprime->getGraph()->getImporter());
         Actemp->exportAndFillComplete(Acprime,
                                       exporter,

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -8186,9 +8186,10 @@ namespace Tpetra {
     bool reverseMode = false; // Are we in reverse mode?
     bool restrictComm = false; // Do we need to restrict the communicator?
 
-   int mm_optimization_core_count=::Tpetra::Details::Behavior::TAFC_OptimizationCoreCount();
-   RCP<ParameterList> matrixparams; // parameters for the destination matrix
-   if (! params.is_null ()) {
+    int mm_optimization_core_count=::Tpetra::Details::Behavior::TAFC_OptimizationCoreCount();
+    RCP<ParameterList> matrixparams; // parameters for the destination matrix
+    bool overrideAllreduce = false;
+    if (! params.is_null ()) {
       matrixparams = sublist (params, "CrsMatrix");
       reverseMode = params->get ("Reverse Mode", reverseMode);
       restrictComm = params->get ("Restrict Communicator", restrictComm);
@@ -8196,6 +8197,7 @@ namespace Tpetra {
       isMM = slist.get("isMatrixMatrix_TransferAndFillComplete",false);
       mm_optimization_core_count = slist.get("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count);
 
+      overrideAllreduce = slist.get("MM_TAFC_OverrideAllreduceCheck",false);
       if(getComm()->getSize() < mm_optimization_core_count && isMM)   isMM = false;
       if(reverseMode) isMM = false;
     }
@@ -8204,7 +8206,8 @@ namespace Tpetra {
    std::shared_ptr< ::Tpetra::Details::CommRequest> iallreduceRequest;
    int mismatch = 0;
    int reduced_mismatch = 0;
-   if (isMM) {
+   if (isMM && !overrideAllreduce) {
+
      // Test for pathological matrix transfer
      const bool source_vals = ! getGraph ()->getImporter ().is_null();
      const bool target_vals = ! (rowTransfer.getExportLIDs ().size() == 0 ||

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -9113,7 +9113,7 @@ namespace Tpetra {
       }
     }
 
-    if( isMM && !MyImporter.is_null()) {
+    if( isMM ) {
 #ifdef HAVE_TPETRA_MMM_TIMINGS
         Teuchos::TimeMonitor MMisMM (*TimeMonitor::getNewTimer(prefix + std::string("isMM Block")));
 #endif
@@ -9164,8 +9164,8 @@ namespace Tpetra {
           std::cerr << os.str ();
         }
 
-        Teuchos::ArrayView<const int>  EPID1 =  MyImporter->getExportPIDs();// SourceMatrix->graph->importer
-        Teuchos::ArrayView<const LO>   ELID1 =  MyImporter->getExportLIDs();
+        Teuchos::ArrayView<const int>  EPID1 = MyImporter.is_null() ? Teuchos::ArrayView<const int>() : MyImporter->getExportPIDs();
+        Teuchos::ArrayView<const LO>   ELID1 = MyImporter.is_null() ? Teuchos::ArrayView<const int>() : MyImporter->getExportLIDs();
 
         Teuchos::ArrayView<const int>  TEPID2  =  rowTransfer.getExportPIDs(); // row matrix
         Teuchos::ArrayView<const LO>   TELID2  =  rowTransfer.getExportLIDs();
@@ -9199,23 +9199,11 @@ namespace Tpetra {
           }
         }
 
-        if (verbose) {
-          std::ostringstream os;
-          os << *verbosePrefix << "sort, unique, & erase usrtg" << std::endl;
-          std::cerr << os.str ();
-        }
-
 // This sort can _not_ be omitted.[
         std::sort(usrtg.begin(),usrtg.end()); // default comparator does the right thing, now sorted in gid order
         auto eopg = std ::unique(usrtg.begin(),usrtg.end());
         // 25 Jul 2018: Could just ignore the entries at and after eopg.
         usrtg.erase(eopg,usrtg.end());
-
-        if (verbose) {
-          std::ostringstream os;
-          os << *verbosePrefix << "Done with sort, unique, & erase" << std::endl;
-          std::cerr << os.str ();
-        }
 
         const Array_size_type type2_us_size = usrtg.size();
         Teuchos::ArrayRCP<int>  EPID2=Teuchos::arcp(new int[type2_us_size],0,type2_us_size,true);

--- a/packages/tpetra/core/src/Tpetra_Import_Util2.hpp
+++ b/packages/tpetra/core/src/Tpetra_Import_Util2.hpp
@@ -214,6 +214,9 @@ reverseNeighborDiscovery(const CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, No
     const std::string prefix {" Import_Util2::ReverseND:: "};
     const std::string label ("IU2::Neighbor");
 
+    // There can be no neighbor discovery if you don't have an importer
+    if(MyImporter.is_null()) return;
+
     std::ostringstream errstr;
     bool error = false;
     auto const comm             = MyDomainMap->getComm();
@@ -226,11 +229,6 @@ reverseNeighborDiscovery(const CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, No
     auto ExportPIDs                 = RowTransfer.getExportPIDs();
     auto ExportLIDs                 = RowTransfer.getExportLIDs();
     auto NumExportLIDs              = RowTransfer.getNumExportIDs();
-
-    TEUCHOS_TEST_FOR_EXCEPTION(MyImporter.is_null(),
-                               std::logic_error,
-                               "Tpetra::reverseNeighborDiscovery "
-                               "Neighbor Discovery Should not be called with null Importer");
 
     Distributor & Distor            = MyImporter->getDistributor();
     const size_t NumRecvs           = Distor.getNumReceives();


### PR DESCRIPTION
@trilinos/tpetra 
@trilinos/muelu 

## Description
- Small fix to make sure that new TAFC is used everywhere in `Tpetra::MatrixMatrix`
- Add override parameter for iallreduce, in case the user knows that new TAFC will work
- Add code path for import without importer (Thanks, @DrBooom )
- Rework how kernel parameters are passed from MueLu.