### PR TITLE
Tpetra: Don't initialize scratch views in UnpackCrsMatrixAndCombineFunctor

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_unpackCrsMatrixAndCombine_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_unpackCrsMatrixAndCombine_def.hpp
@@ -256,10 +256,10 @@ struct UnpackCrsMatrixAndCombineFunctor {
     num_bytes_per_value (num_bytes_per_value_in),
     atomic (atomic_in),
     tokens (XS()),
-    lids_scratch ("lids_scratch", tokens.size() * max_num_ent),
-    gids_scratch ("gids_scratch", tokens.size() * max_num_ent),
-    pids_scratch ("pids_scratch", tokens.size() * max_num_ent),
-    vals_scratch ("vals_scratch", tokens.size() * max_num_ent)
+    lids_scratch (Kokkos::view_alloc("lids_scratch", Kokkos::WithoutInitializing), tokens.size() * max_num_ent),
+    gids_scratch (Kokkos::view_alloc("gids_scratch", Kokkos::WithoutInitializing), tokens.size() * max_num_ent),
+    pids_scratch (Kokkos::view_alloc("pids_scratch", Kokkos::WithoutInitializing), tokens.size() * max_num_ent),
+    vals_scratch (Kokkos::view_alloc("vals_scratch", Kokkos::WithoutInitializing), tokens.size() * max_num_ent)
   {}
 
   KOKKOS_INLINE_FUNCTION void init(value_type& dst) const


### PR DESCRIPTION
@trilinos/tpetra  @mhoemmen 

This saved ~50% of our load complete time in a 2 GPU run. Not a huge difference overall, but worthwhile.
