### PR TITLE
Issue #4430 : Try 2 to Remove deprecated inheritance of SerialDense m…

### DIFF
--- a/packages/teuchos/numerics/src/Teuchos_SerialBandDenseMatrix.hpp
+++ b/packages/teuchos/numerics/src/Teuchos_SerialBandDenseMatrix.hpp
@@ -130,7 +130,7 @@ the object.  Specifically:
 namespace Teuchos {
 
 template<typename OrdinalType, typename ScalarType>
-class SerialBandDenseMatrix : public CompObject, public Object, public BLAS<OrdinalType, ScalarType>
+class SerialBandDenseMatrix : public CompObject, public BLAS<OrdinalType, ScalarType>
 {
 public:
 
@@ -421,7 +421,7 @@ public:
 
   //! @name I/O methods.
   //@{
-  //! Print method.  Defines the behavior of the std::ostream << operator inherited from the Object class.
+  //! Print method.  Defines the behavior of the std::ostream << operator
   virtual void print(std::ostream& os) const;
 
   //@}
@@ -448,7 +448,6 @@ protected:
 template<typename OrdinalType, typename ScalarType>
 SerialBandDenseMatrix<OrdinalType, ScalarType>::SerialBandDenseMatrix ()
   : CompObject (),
-    Object(),
     BLAS<OrdinalType,ScalarType>(),
     numRows_ (0),
     numCols_ (0),
@@ -467,7 +466,6 @@ SerialBandDenseMatrix (OrdinalType numRows_in,
                        OrdinalType ku_in,
                        bool zeroOut)
   : CompObject (),
-    Object(),
     BLAS<OrdinalType,ScalarType>(),
     numRows_ (numRows_in),
     numCols_ (numCols_in),
@@ -493,7 +491,6 @@ SerialBandDenseMatrix (DataAccess CV,
                        OrdinalType kl_in,
                        OrdinalType ku_in)
   : CompObject (),
-    Object(),
     BLAS<OrdinalType,ScalarType>(),
     numRows_ (numRows_in),
     numCols_ (numCols_in),
@@ -515,7 +512,6 @@ template<typename OrdinalType, typename ScalarType>
 SerialBandDenseMatrix<OrdinalType, ScalarType>::
 SerialBandDenseMatrix (const SerialBandDenseMatrix<OrdinalType, ScalarType> &Source, ETransp trans)
   : CompObject (),
-    Object(),
     BLAS<OrdinalType,ScalarType>(),
     numRows_ (0),
     numCols_ (0),
@@ -574,7 +570,6 @@ SerialBandDenseMatrix (DataAccess CV,
                        OrdinalType numCols_in,
                        OrdinalType startCol)
   : CompObject (),
-    Object(),
     BLAS<OrdinalType,ScalarType>(),
     numRows_ (numRows_in),
     numCols_ (numCols_in),
@@ -1074,6 +1069,16 @@ void SerialBandDenseMatrix<OrdinalType, ScalarType>::copyMat(
     }
   }
 }
+
+#ifndef TEUCHOS_HIDE_DEPRECATED_CODE
+/// \brief Print the given SerialBandDenseMatrix to the given output stream.
+template<typename OrdinalType, typename ScalarType>
+std::ostream& operator<< (std::ostream& os, const Teuchos::SerialBandDenseMatrix<OrdinalType, ScalarType>& obj)
+{
+  obj.print (os);
+  return os;
+}
+#endif
 
 } // namespace Teuchos
 

--- a/packages/teuchos/numerics/src/Teuchos_SerialDenseMatrix.hpp
+++ b/packages/teuchos/numerics/src/Teuchos_SerialDenseMatrix.hpp
@@ -66,7 +66,7 @@
 namespace Teuchos {
 
 template<typename OrdinalType, typename ScalarType>
-class SerialDenseMatrix : public CompObject, public Object, public BLAS<OrdinalType, ScalarType>
+class SerialDenseMatrix : public CompObject, public BLAS<OrdinalType, ScalarType>
 {
 public:
 
@@ -383,7 +383,7 @@ public:
 
   //! @name I/O methods.
   //@{
-  //! Print method.  Defines the behavior of the std::ostream << operator inherited from the Object class.
+  //! Print method.  Defines the behavior of the std::ostream << operator
   virtual void print(std::ostream& os) const;
 
   //@}
@@ -408,14 +408,14 @@ protected:
 
 template<typename OrdinalType, typename ScalarType>
 SerialDenseMatrix<OrdinalType, ScalarType>::SerialDenseMatrix()
-  : CompObject(), Object(), BLAS<OrdinalType,ScalarType>(), numRows_(0), numCols_(0), stride_(0), valuesCopied_(false), values_(0)
+  : CompObject(), BLAS<OrdinalType,ScalarType>(), numRows_(0), numCols_(0), stride_(0), valuesCopied_(false), values_(0)
 {}
 
 template<typename OrdinalType, typename ScalarType>
 SerialDenseMatrix<OrdinalType, ScalarType>::SerialDenseMatrix(
   OrdinalType numRows_in, OrdinalType numCols_in, bool zeroOut
   )
-  : CompObject(), Object(), BLAS<OrdinalType,ScalarType>(), numRows_(numRows_in), numCols_(numCols_in), stride_(numRows_in)
+  : CompObject(), BLAS<OrdinalType,ScalarType>(), numRows_(numRows_in), numCols_(numCols_in), stride_(numRows_in)
 {
   values_ = new ScalarType[stride_*numCols_];
   valuesCopied_ = true;
@@ -428,7 +428,7 @@ SerialDenseMatrix<OrdinalType, ScalarType>::SerialDenseMatrix(
   DataAccess CV, ScalarType* values_in, OrdinalType stride_in, OrdinalType numRows_in,
   OrdinalType numCols_in
   )
-  : CompObject(), Object(), BLAS<OrdinalType,ScalarType>(), numRows_(numRows_in), numCols_(numCols_in), stride_(stride_in),
+  : CompObject(), BLAS<OrdinalType,ScalarType>(), numRows_(numRows_in), numCols_(numCols_in), stride_(stride_in),
     valuesCopied_(false), values_(values_in)
 {
   if(CV == Copy)
@@ -442,7 +442,7 @@ SerialDenseMatrix<OrdinalType, ScalarType>::SerialDenseMatrix(
 
 template<typename OrdinalType, typename ScalarType>
 SerialDenseMatrix<OrdinalType, ScalarType>::SerialDenseMatrix(const SerialDenseMatrix<OrdinalType, ScalarType> &Source, ETransp trans) 
-  : CompObject(), Object(), BLAS<OrdinalType,ScalarType>(), numRows_(0), numCols_(0), stride_(0), valuesCopied_(true), values_(0)
+  : CompObject(),BLAS<OrdinalType,ScalarType>(), numRows_(0), numCols_(0), stride_(0), valuesCopied_(true), values_(0)
 {
   if ( trans == Teuchos::NO_TRANS )
   {
@@ -1074,6 +1074,16 @@ void SerialDenseMatrix<OrdinalType, ScalarType>::copyMat(
     }
   }
 }
+
+#ifndef TEUCHOS_HIDE_DEPRECATED_CODE
+/// \brief Print the given SerialDenseMatrix to the given output stream.
+template<typename OrdinalType, typename ScalarType>
+std::ostream& operator<< (std::ostream& os, const Teuchos::SerialDenseMatrix<OrdinalType, ScalarType>& obj)
+{
+  obj.print (os);
+  return os;
+}
+#endif
 
 } // namespace Teuchos
 

--- a/packages/teuchos/numerics/src/Teuchos_SerialSymDenseMatrix.hpp
+++ b/packages/teuchos/numerics/src/Teuchos_SerialSymDenseMatrix.hpp
@@ -120,7 +120,7 @@ the object.  Specifically:
 namespace Teuchos {
 
 template<typename OrdinalType, typename ScalarType>
-class SerialSymDenseMatrix : public CompObject, public Object, public BLAS<OrdinalType,ScalarType>
+class SerialSymDenseMatrix : public CompObject, public BLAS<OrdinalType,ScalarType>
 {
  public:
 
@@ -401,7 +401,7 @@ class SerialSymDenseMatrix : public CompObject, public Object, public BLAS<Ordin
 
   //! @name I/O methods.
   //@{
-  //! Print method.  Defines the behavior of the std::ostream << operator inherited from the Object class.
+  //! Print method.  Defines the behavior of the std::ostream << operator
   virtual void print(std::ostream& os) const;
 
   //@}
@@ -439,13 +439,13 @@ class SerialSymDenseMatrix : public CompObject, public Object, public BLAS<Ordin
 
 template<typename OrdinalType, typename ScalarType>
 SerialSymDenseMatrix<OrdinalType, ScalarType>::SerialSymDenseMatrix()
-  : CompObject(), Object(), BLAS<OrdinalType,ScalarType>(), 
+  : CompObject(), BLAS<OrdinalType,ScalarType>(), 
     numRowCols_(0), stride_(0), valuesCopied_(false), values_(0), upper_(false), UPLO_('L')
 {}
 
 template<typename OrdinalType, typename ScalarType>
 SerialSymDenseMatrix<OrdinalType, ScalarType>::SerialSymDenseMatrix(OrdinalType numRowCols_in, bool zeroOut)
-  : CompObject(), Object(), BLAS<OrdinalType,ScalarType>(),
+  : CompObject(), BLAS<OrdinalType,ScalarType>(),
     numRowCols_(numRowCols_in), stride_(numRowCols_in), valuesCopied_(false), upper_(false), UPLO_('L')
 {
   values_ = new ScalarType[stride_*numRowCols_];
@@ -458,7 +458,7 @@ template<typename OrdinalType, typename ScalarType>
 SerialSymDenseMatrix<OrdinalType, ScalarType>::SerialSymDenseMatrix(
   DataAccess CV, bool upper_in, ScalarType* values_in, OrdinalType stride_in, OrdinalType numRowCols_in
   )
-  : CompObject(), Object(), BLAS<OrdinalType,ScalarType>(), 
+  : CompObject(), BLAS<OrdinalType,ScalarType>(), 
     numRowCols_(numRowCols_in), stride_(stride_in), valuesCopied_(false),
     values_(values_in), upper_(upper_in)
 {
@@ -478,7 +478,7 @@ SerialSymDenseMatrix<OrdinalType, ScalarType>::SerialSymDenseMatrix(
 
 template<typename OrdinalType, typename ScalarType>
 SerialSymDenseMatrix<OrdinalType, ScalarType>::SerialSymDenseMatrix(const SerialSymDenseMatrix<OrdinalType, ScalarType> &Source) 
-  : CompObject(), Object(), BLAS<OrdinalType,ScalarType>(), 
+  : CompObject(), BLAS<OrdinalType,ScalarType>(), 
     numRowCols_(Source.numRowCols_), stride_(0), valuesCopied_(true), 
     values_(0), upper_(Source.upper_), UPLO_(Source.UPLO_)
 {
@@ -507,7 +507,7 @@ template<typename OrdinalType, typename ScalarType>
 SerialSymDenseMatrix<OrdinalType, ScalarType>::SerialSymDenseMatrix(
                                                                     DataAccess CV, const SerialSymDenseMatrix<OrdinalType,
                                                                     ScalarType> &Source, OrdinalType numRowCols_in, OrdinalType startRowCol )
-  : CompObject(), Object(), BLAS<OrdinalType,ScalarType>(),
+  : CompObject(), BLAS<OrdinalType,ScalarType>(),
     numRowCols_(numRowCols_in), stride_(Source.stride_), valuesCopied_(false), upper_(Source.upper_), UPLO_(Source.UPLO_)
 {
   if(CV == Copy)
@@ -1174,6 +1174,16 @@ void SerialSymDenseMatrix<OrdinalType, ScalarType>::copyUPLOMat(
     }
   }
 }
+
+#ifndef TEUCHOS_HIDE_DEPRECATED_CODE
+/// \brief Print the given SerialSymDenseMatrix to the given output stream.
+template<typename OrdinalType, typename ScalarType>
+std::ostream& operator<< (std::ostream& os, const Teuchos::SerialSymDenseMatrix<OrdinalType, ScalarType>& obj)
+{
+  obj.print (os);
+  return os;
+}
+#endif
 
 } // namespace Teuchos
 


### PR DESCRIPTION
…atrices from Object

 - remove inheritance from Teuchos::Object of Teuchos::SerialDenseMatrix
   (which in turn includes Teuchos::SerialDenseVector),
   Teuchos::SerialBandDenseMatrix and Teuchos::SerialSymDenseMatrix
 - add operator<< for each class protected by TEUCHOS_HIDE_DEPRECATED_CODE
   to preserve backward compatibility and allow Dakota to explicitly disable

I tested that these changes allow existing client code in Trilinos to
compile, and all Teuchos tests/examples pass under GCC 4.8.4

@trilinos/teuchos 

## Description
<!--- Please describe your changes in detail. -->

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->

<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [ ] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
