### PR TITLE
zoltan2:  removing warnings for #3178

### DIFF
--- a/packages/zoltan2/src/algorithms/color/Zoltan2_AlgSerialGreedy.hpp
+++ b/packages/zoltan2/src/algorithms/color/Zoltan2_AlgSerialGreedy.hpp
@@ -216,12 +216,10 @@ class AlgSerialGreedy : public Algorithm<Adapter>
           // Pick least used available color.
           // Simple linear algorithm; could maintain a priority queue but not sure any faster?
           int leastUsedColor = 1;
-          lno_t leastUsedNumber = numVerticesWithColor[1];
           for (int c=1; c <= maxColor; c++){
             if (forbidden[c] != v){
               if (numVerticesWithColor[c] < leastUsedColor){
                 leastUsedColor = c;
-                leastUsedNumber = numVerticesWithColor[c];
               }
             }
           }

--- a/packages/zoltan2/src/directory/Zoltan2_Directory.hpp
+++ b/packages/zoltan2/src/directory/Zoltan2_Directory.hpp
@@ -360,11 +360,9 @@ class Zoltan2_Directory_Simple : public Zoltan2_Directory<gid_t, lid_t, user_t> 
         case Zoltan2_Directory<gid_t,lid_t,user_t>::Update_Mode::Aggregate:
           throw std::logic_error("Aggregate doesn't mean anything for single "
             "types. Must use Zoltan2_Directory_Vector class.");
-          break;
         case Zoltan2_Directory<gid_t,lid_t,user_t>::Update_Mode::AggregateAdd:
           throw std::logic_error("AggregateAdd doesn't mean anything for single "
             "types. Must use Zoltan2_Directory_Vector class.");
-          break;
       }
     }
 

--- a/packages/zoltan2/src/problems/Zoltan2_OrderingSolution.hpp
+++ b/packages/zoltan2/src/problems/Zoltan2_OrderingSolution.hpp
@@ -125,7 +125,7 @@ public:
     this->setHaveSeparatorRange(status);
     this->setHaveSeparatorTree(status);
  } 
-  /*! \brief Do we have the seperator range?
+  /*! \brief Do we have the separator range?
    */
   bool haveSeparatorRange() const
   {
@@ -139,14 +139,14 @@ public:
     haveSeparatorRange_ = status; 
   }
   
-  /*! \brief Do we have the seperator tree?
+  /*! \brief Do we have the separator tree?
    */
   bool haveSeparatorTree() const
   {
     return haveSeparatorTree_; 
   }
   
-  /*! \brief Do we have the seperators?
+  /*! \brief Do we have the separators?
    */
   bool haveSeparators() const
   {
@@ -242,14 +242,14 @@ public:
     return false;
   }
 
-  /*! \brief Get (local) seperator range by RCP.
+  /*! \brief Get (local) separator range by RCP.
    */
   inline const ArrayRCP<index_t> &getSeparatorRangeRCP() const
   {
     return separatorRange_;
   }
   
-  /*! \brief Get (local) seperator tree by RCP.
+  /*! \brief Get (local) separator tree by RCP.
    */
   inline const ArrayRCP<index_t> &getSeparatorTreeRCP() const
   {
@@ -276,14 +276,14 @@ public:
       return const_cast<ArrayRCP<index_t>& > (perm_);
   }
   
-  /*! \brief Get seperator range by const RCP.
+  /*! \brief Get separator range by const RCP.
    */
   inline ArrayRCP<index_t> &getSeparatorRangeRCPConst() const
   {
     return const_cast<ArrayRCP<index_t> & > (separatorRange_);
   }
   
-  /*! \brief Get seperator tree by const RCP.
+  /*! \brief Get separator tree by const RCP.
    */
   inline ArrayRCP<index_t> &getSeparatorTreeRCPConst() const
   {

--- a/packages/zoltan2/test/order/orderingScotch.cpp
+++ b/packages/zoltan2/test/order/orderingScotch.cpp
@@ -427,8 +427,30 @@ int mainExecute(int narg, char** arg, RCP<const Teuchos::Comm<int> > comm)
       if (testReturn) return testReturn;
     }
 
-    // TODO How do we validate TreeTab?
-    //      TreeTab root has -1, other values < NumBlocks
+    // How do we validate TreeTab?
+    // TreeTab root has -1, other values < NumBlocks
+    if (rank == 0 ) {
+      std::cout << "Checking Separator Tree" << std::endl;
+    }
+
+    if (checkLength) {
+      testReturn = (TreeTab[0] != -1);
+    }
+
+    if (testReturn) {
+      std::cout << "TreeTab[0] = " << TreeTab[0] << " != -1" << std::endl;
+      return testReturn;
+    }
+
+    for (size_t i=1; i< checkLength; i++){
+      testReturn = !(TreeTab[i] < NumBlocks);
+      if (testReturn) {
+        std::cout << "TreeTab[" << i << "] = " << TreeTab[i] << " >= NumBlocks "
+                  << " = " << NumBlocks << std::endl;
+        return testReturn;
+      }
+    }
+
     if (rank == 0 ) {
       std::cout << "Going to compute the bandwidth" << std::endl;
     }


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/<zoltan2> @ZUUL42 

## Description
Small changes to remove compiler warnings in #3178 
Added test of Separator Tree values in orderingScotch.cpp test, to remove compiler warning about unused TreeTab.
Removed unused variable in AlgSerialGreedy coloring.

## Related Issues
#3178 

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->

<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [ x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ x] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
- [ x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
