### PR TITLE
Reduce test problem sizes

### DIFF
--- a/packages/kokkos-kernels/unit_test/CMakeLists.txt
+++ b/packages/kokkos-kernels/unit_test/CMakeLists.txt
@@ -90,16 +90,16 @@ IF (Kokkos_ENABLE_OpenMP)
   
   APPEND_GLOB(OPENMP_BLAS_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/openmp/Test_OpenMP_Blas*.cpp)
 
-  IF (KOKKOS_ENABLE_DEBUG)
-    SET(DISABLE_SLOW_DGEMM_DOUBLE_TEST "--gtest_filter=-openmp.gemm_double")
-  ENDIF()
+  # IF (KOKKOS_ENABLE_DEBUG)
+  #   SET(DISABLE_SLOW_DGEMM_DOUBLE_TEST "--gtest_filter=-openmp.gemm_double")
+  # ENDIF()
 
   TRIBITS_ADD_EXECUTABLE_AND_TEST(
     blas_openmp
     SOURCES
       Test_Main.cpp
       ${OPENMP_BLAS_SOURCES}
-    ARGS ${DISABLE_SLOW_DGEMM_DOUBLE_TEST}
+#    ARGS ${DISABLE_SLOW_DGEMM_DOUBLE_TEST}
     COMM serial mpi
     NUM_MPI_PROCS 1
     TESTONLYLIBS kokkoskernels_gtest
@@ -146,16 +146,16 @@ IF (Kokkos_ENABLE_Serial)
   
   APPEND_GLOB(SERIAL_BLAS_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/serial/Test_Serial_Blas*.cpp)
 
-  IF (KOKKOS_ENABLE_DEBUG)
-    SET(DISABLE_SLOW_DGEMM_DOUBLE_TEST "--gtest_filter=-serial.gemm_double")
-  ENDIF()
+  # IF (KOKKOS_ENABLE_DEBUG)
+  #   SET(DISABLE_SLOW_DGEMM_DOUBLE_TEST "--gtest_filter=-serial.gemm_double")
+  # ENDIF()
 
   TRIBITS_ADD_EXECUTABLE_AND_TEST(
     blas_serial
     SOURCES
       Test_Main.cpp
       ${SERIAL_BLAS_SOURCES}
-    ARGS ${DISABLE_SLOW_DGEMM_DOUBLE_TEST}
+#    ARGS ${DISABLE_SLOW_DGEMM_DOUBLE_TEST}
     COMM serial mpi
     NUM_MPI_PROCS 1
     TESTONLYLIBS kokkoskernels_gtest

--- a/packages/kokkos-kernels/unit_test/blas/Test_Blas1_abs.hpp
+++ b/packages/kokkos-kernels/unit_test/blas/Test_Blas1_abs.hpp
@@ -153,7 +153,7 @@ int test_abs() {
   Test::impl_test_abs<view_type_a_ll, view_type_b_ll, Device>(0);
   Test::impl_test_abs<view_type_a_ll, view_type_b_ll, Device>(13);
   Test::impl_test_abs<view_type_a_ll, view_type_b_ll, Device>(1024);
-  Test::impl_test_abs<view_type_a_ll, view_type_b_ll, Device>(132231);
+  //Test::impl_test_abs<view_type_a_ll, view_type_b_ll, Device>(132231);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -162,7 +162,7 @@ int test_abs() {
   Test::impl_test_abs<view_type_a_lr, view_type_b_lr, Device>(0);
   Test::impl_test_abs<view_type_a_lr, view_type_b_lr, Device>(13);
   Test::impl_test_abs<view_type_a_lr, view_type_b_lr, Device>(1024);
-  Test::impl_test_abs<view_type_a_lr, view_type_b_lr, Device>(132231);
+  //Test::impl_test_abs<view_type_a_lr, view_type_b_lr, Device>(132231);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -171,7 +171,7 @@ int test_abs() {
   Test::impl_test_abs<view_type_a_ls, view_type_b_ls, Device>(0);
   Test::impl_test_abs<view_type_a_ls, view_type_b_ls, Device>(13);
   Test::impl_test_abs<view_type_a_ls, view_type_b_ls, Device>(1024);
-  Test::impl_test_abs<view_type_a_ls, view_type_b_ls, Device>(132231);
+  //Test::impl_test_abs<view_type_a_ls, view_type_b_ls, Device>(132231);
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
@@ -191,7 +191,7 @@ int test_abs_mv() {
   Test::impl_test_abs_mv<view_type_a_ll, view_type_b_ll, Device>(0,5);
   Test::impl_test_abs_mv<view_type_a_ll, view_type_b_ll, Device>(13,5);
   Test::impl_test_abs_mv<view_type_a_ll, view_type_b_ll, Device>(1024,5);
-  Test::impl_test_abs_mv<view_type_a_ll, view_type_b_ll, Device>(132231,5);
+  //Test::impl_test_abs_mv<view_type_a_ll, view_type_b_ll, Device>(132231,5);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -200,7 +200,7 @@ int test_abs_mv() {
   Test::impl_test_abs_mv<view_type_a_lr, view_type_b_lr, Device>(0,5);
   Test::impl_test_abs_mv<view_type_a_lr, view_type_b_lr, Device>(13,5);
   Test::impl_test_abs_mv<view_type_a_lr, view_type_b_lr, Device>(1024,5);
-  Test::impl_test_abs_mv<view_type_a_lr, view_type_b_lr, Device>(132231,5);
+  //Test::impl_test_abs_mv<view_type_a_lr, view_type_b_lr, Device>(132231,5);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -209,7 +209,7 @@ int test_abs_mv() {
   Test::impl_test_abs_mv<view_type_a_ls, view_type_b_ls, Device>(0,5);
   Test::impl_test_abs_mv<view_type_a_ls, view_type_b_ls, Device>(13,5);
   Test::impl_test_abs_mv<view_type_a_ls, view_type_b_ls, Device>(1024,5);
-  Test::impl_test_abs_mv<view_type_a_ls, view_type_b_ls, Device>(132231,5);
+  //Test::impl_test_abs_mv<view_type_a_ls, view_type_b_ls, Device>(132231,5);
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)

--- a/packages/kokkos-kernels/unit_test/blas/Test_Blas1_asum.hpp
+++ b/packages/kokkos-kernels/unit_test/blas/Test_Blas1_asum.hpp
@@ -57,7 +57,7 @@ int test_asum() {
   Test::impl_test_asum<view_type_a_ll, Device>(0);
   Test::impl_test_asum<view_type_a_ll, Device>(13);
   Test::impl_test_asum<view_type_a_ll, Device>(1024);
-  Test::impl_test_asum<view_type_a_ll, Device>(132231);
+  //Test::impl_test_asum<view_type_a_ll, Device>(132231);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -65,7 +65,7 @@ int test_asum() {
   Test::impl_test_asum<view_type_a_lr, Device>(0);
   Test::impl_test_asum<view_type_a_lr, Device>(13);
   Test::impl_test_asum<view_type_a_lr, Device>(1024);
-  Test::impl_test_asum<view_type_a_lr, Device>(132231);
+  //Test::impl_test_asum<view_type_a_lr, Device>(132231);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -73,7 +73,7 @@ int test_asum() {
   Test::impl_test_asum<view_type_a_ls, Device>(0);
   Test::impl_test_asum<view_type_a_ls, Device>(13);
   Test::impl_test_asum<view_type_a_ls, Device>(1024);
-  Test::impl_test_asum<view_type_a_ls, Device>(132231);
+  //Test::impl_test_asum<view_type_a_ls, Device>(132231);
 #endif
 
   return 1;

--- a/packages/kokkos-kernels/unit_test/blas/Test_Blas1_axpy.hpp
+++ b/packages/kokkos-kernels/unit_test/blas/Test_Blas1_axpy.hpp
@@ -144,7 +144,7 @@ int test_axpy() {
   Test::impl_test_axpy<view_type_a_ll, view_type_b_ll, Device>(0);
   Test::impl_test_axpy<view_type_a_ll, view_type_b_ll, Device>(13);
   Test::impl_test_axpy<view_type_a_ll, view_type_b_ll, Device>(1024);
-  Test::impl_test_axpy<view_type_a_ll, view_type_b_ll, Device>(132231);
+  //Test::impl_test_axpy<view_type_a_ll, view_type_b_ll, Device>(132231);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -153,7 +153,7 @@ int test_axpy() {
   Test::impl_test_axpy<view_type_a_lr, view_type_b_lr, Device>(0);
   Test::impl_test_axpy<view_type_a_lr, view_type_b_lr, Device>(13);
   Test::impl_test_axpy<view_type_a_lr, view_type_b_lr, Device>(1024);
-  Test::impl_test_axpy<view_type_a_lr, view_type_b_lr, Device>(132231);
+  //Test::impl_test_axpy<view_type_a_lr, view_type_b_lr, Device>(132231);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -162,7 +162,7 @@ int test_axpy() {
   Test::impl_test_axpy<view_type_a_ls, view_type_b_ls, Device>(0);
   Test::impl_test_axpy<view_type_a_ls, view_type_b_ls, Device>(13);
   Test::impl_test_axpy<view_type_a_ls, view_type_b_ls, Device>(1024);
-  Test::impl_test_axpy<view_type_a_ls, view_type_b_ls, Device>(132231);
+  //Test::impl_test_axpy<view_type_a_ls, view_type_b_ls, Device>(132231);
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
@@ -182,7 +182,7 @@ int test_axpy_mv() {
   Test::impl_test_axpy_mv<view_type_a_ll, view_type_b_ll, Device>(0,5);
   Test::impl_test_axpy_mv<view_type_a_ll, view_type_b_ll, Device>(13,5);
   Test::impl_test_axpy_mv<view_type_a_ll, view_type_b_ll, Device>(1024,5);
-  Test::impl_test_axpy_mv<view_type_a_ll, view_type_b_ll, Device>(132231,5);
+  //Test::impl_test_axpy_mv<view_type_a_ll, view_type_b_ll, Device>(132231,5);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -191,7 +191,7 @@ int test_axpy_mv() {
   Test::impl_test_axpy_mv<view_type_a_lr, view_type_b_lr, Device>(0,5);
   Test::impl_test_axpy_mv<view_type_a_lr, view_type_b_lr, Device>(13,5);
   Test::impl_test_axpy_mv<view_type_a_lr, view_type_b_lr, Device>(1024,5);
-  Test::impl_test_axpy_mv<view_type_a_lr, view_type_b_lr, Device>(132231,5);
+  //Test::impl_test_axpy_mv<view_type_a_lr, view_type_b_lr, Device>(132231,5);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -200,7 +200,7 @@ int test_axpy_mv() {
   Test::impl_test_axpy_mv<view_type_a_ls, view_type_b_ls, Device>(0,5);
   Test::impl_test_axpy_mv<view_type_a_ls, view_type_b_ls, Device>(13,5);
   Test::impl_test_axpy_mv<view_type_a_ls, view_type_b_ls, Device>(1024,5);
-  Test::impl_test_axpy_mv<view_type_a_ls, view_type_b_ls, Device>(132231,5);
+  //Test::impl_test_axpy_mv<view_type_a_ls, view_type_b_ls, Device>(132231,5);
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)

--- a/packages/kokkos-kernels/unit_test/blas/Test_Blas1_dot.hpp
+++ b/packages/kokkos-kernels/unit_test/blas/Test_Blas1_dot.hpp
@@ -151,7 +151,7 @@ int test_dot() {
   Test::impl_test_dot<view_type_a_ll, view_type_b_ll, Device>(0);
   Test::impl_test_dot<view_type_a_ll, view_type_b_ll, Device>(13);
   Test::impl_test_dot<view_type_a_ll, view_type_b_ll, Device>(1024);
-  Test::impl_test_dot<view_type_a_ll, view_type_b_ll, Device>(132231);
+  //Test::impl_test_dot<view_type_a_ll, view_type_b_ll, Device>(132231);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -160,7 +160,7 @@ int test_dot() {
   Test::impl_test_dot<view_type_a_lr, view_type_b_lr, Device>(0);
   Test::impl_test_dot<view_type_a_lr, view_type_b_lr, Device>(13);
   Test::impl_test_dot<view_type_a_lr, view_type_b_lr, Device>(1024);
-  Test::impl_test_dot<view_type_a_lr, view_type_b_lr, Device>(132231);
+  //Test::impl_test_dot<view_type_a_lr, view_type_b_lr, Device>(132231);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -169,7 +169,7 @@ int test_dot() {
   Test::impl_test_dot<view_type_a_ls, view_type_b_ls, Device>(0);
   Test::impl_test_dot<view_type_a_ls, view_type_b_ls, Device>(13);
   Test::impl_test_dot<view_type_a_ls, view_type_b_ls, Device>(1024);
-  Test::impl_test_dot<view_type_a_ls, view_type_b_ls, Device>(132231);
+  //Test::impl_test_dot<view_type_a_ls, view_type_b_ls, Device>(132231);
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
@@ -189,7 +189,7 @@ int test_dot_mv() {
   Test::impl_test_dot_mv<view_type_a_ll, view_type_b_ll, Device>(0,5);
   Test::impl_test_dot_mv<view_type_a_ll, view_type_b_ll, Device>(13,5);
   Test::impl_test_dot_mv<view_type_a_ll, view_type_b_ll, Device>(1024,5);
-  Test::impl_test_dot_mv<view_type_a_ll, view_type_b_ll, Device>(132231,5);
+  //Test::impl_test_dot_mv<view_type_a_ll, view_type_b_ll, Device>(132231,5);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -198,7 +198,7 @@ int test_dot_mv() {
   Test::impl_test_dot_mv<view_type_a_lr, view_type_b_lr, Device>(0,5);
   Test::impl_test_dot_mv<view_type_a_lr, view_type_b_lr, Device>(13,5);
   Test::impl_test_dot_mv<view_type_a_lr, view_type_b_lr, Device>(1024,5);
-  Test::impl_test_dot_mv<view_type_a_lr, view_type_b_lr, Device>(132231,5);
+  //Test::impl_test_dot_mv<view_type_a_lr, view_type_b_lr, Device>(132231,5);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -207,7 +207,7 @@ int test_dot_mv() {
   Test::impl_test_dot_mv<view_type_a_ls, view_type_b_ls, Device>(0,5);
   Test::impl_test_dot_mv<view_type_a_ls, view_type_b_ls, Device>(13,5);
   Test::impl_test_dot_mv<view_type_a_ls, view_type_b_ls, Device>(1024,5);
-  Test::impl_test_dot_mv<view_type_a_ls, view_type_b_ls, Device>(132231,5);
+  //Test::impl_test_dot_mv<view_type_a_ls, view_type_b_ls, Device>(132231,5);
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)

--- a/packages/kokkos-kernels/unit_test/blas/Test_Blas1_mult.hpp
+++ b/packages/kokkos-kernels/unit_test/blas/Test_Blas1_mult.hpp
@@ -175,7 +175,7 @@ int test_mult() {
   Test::impl_test_mult<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(0);
   Test::impl_test_mult<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(13);
   Test::impl_test_mult<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(1024);
-  Test::impl_test_mult<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(132231);
+  //Test::impl_test_mult<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(132231);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -185,7 +185,7 @@ int test_mult() {
   Test::impl_test_mult<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(0);
   Test::impl_test_mult<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(13);
   Test::impl_test_mult<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(1024);
-  Test::impl_test_mult<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(132231);
+  //Test::impl_test_mult<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(132231);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -195,7 +195,7 @@ int test_mult() {
   Test::impl_test_mult<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(0);
   Test::impl_test_mult<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(13);
   Test::impl_test_mult<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(1024);
-  Test::impl_test_mult<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(132231);
+  //Test::impl_test_mult<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(132231);
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
@@ -216,7 +216,7 @@ int test_mult_mv() {
   Test::impl_test_mult_mv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(0,5);
   Test::impl_test_mult_mv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(13,5);
   Test::impl_test_mult_mv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(1024,5);
-  Test::impl_test_mult_mv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(132231,5);
+  //Test::impl_test_mult_mv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(132231,5);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -226,7 +226,7 @@ int test_mult_mv() {
   Test::impl_test_mult_mv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(0,5);
   Test::impl_test_mult_mv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(13,5);
   Test::impl_test_mult_mv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(1024,5);
-  Test::impl_test_mult_mv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(132231,5);
+  //Test::impl_test_mult_mv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(132231,5);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -236,7 +236,7 @@ int test_mult_mv() {
   Test::impl_test_mult_mv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(0,5);
   Test::impl_test_mult_mv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(13,5);
   Test::impl_test_mult_mv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(1024,5);
-  Test::impl_test_mult_mv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(132231,5);
+  //Test::impl_test_mult_mv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(132231,5);
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)

--- a/packages/kokkos-kernels/unit_test/blas/Test_Blas1_nrm2.hpp
+++ b/packages/kokkos-kernels/unit_test/blas/Test_Blas1_nrm2.hpp
@@ -113,7 +113,7 @@ int test_nrm2() {
   Test::impl_test_nrm2<view_type_a_ll, Device>(0);
   Test::impl_test_nrm2<view_type_a_ll, Device>(13);
   Test::impl_test_nrm2<view_type_a_ll, Device>(1024);
-  Test::impl_test_nrm2<view_type_a_ll, Device>(132231);
+  //Test::impl_test_nrm2<view_type_a_ll, Device>(132231);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -121,7 +121,7 @@ int test_nrm2() {
   Test::impl_test_nrm2<view_type_a_lr, Device>(0);
   Test::impl_test_nrm2<view_type_a_lr, Device>(13);
   Test::impl_test_nrm2<view_type_a_lr, Device>(1024);
-  Test::impl_test_nrm2<view_type_a_lr, Device>(132231);
+  //Test::impl_test_nrm2<view_type_a_lr, Device>(132231);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -129,7 +129,7 @@ int test_nrm2() {
   Test::impl_test_nrm2<view_type_a_ls, Device>(0);
   Test::impl_test_nrm2<view_type_a_ls, Device>(13);
   Test::impl_test_nrm2<view_type_a_ls, Device>(1024);
-  Test::impl_test_nrm2<view_type_a_ls, Device>(132231);
+  //Test::impl_test_nrm2<view_type_a_ls, Device>(132231);
 #endif
 
   return 1;
@@ -143,7 +143,7 @@ int test_nrm2_mv() {
   Test::impl_test_nrm2_mv<view_type_a_ll, Device>(0,5);
   Test::impl_test_nrm2_mv<view_type_a_ll, Device>(13,5);
   Test::impl_test_nrm2_mv<view_type_a_ll, Device>(1024,5);
-  Test::impl_test_nrm2_mv<view_type_a_ll, Device>(132231,5);
+  //Test::impl_test_nrm2_mv<view_type_a_ll, Device>(132231,5);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -151,7 +151,7 @@ int test_nrm2_mv() {
   Test::impl_test_nrm2_mv<view_type_a_lr, Device>(0,5);
   Test::impl_test_nrm2_mv<view_type_a_lr, Device>(13,5);
   Test::impl_test_nrm2_mv<view_type_a_lr, Device>(1024,5);
-  Test::impl_test_nrm2_mv<view_type_a_lr, Device>(132231,5);
+  //Test::impl_test_nrm2_mv<view_type_a_lr, Device>(132231,5);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -159,7 +159,7 @@ int test_nrm2_mv() {
   Test::impl_test_nrm2_mv<view_type_a_ls, Device>(0,5);
   Test::impl_test_nrm2_mv<view_type_a_ls, Device>(13,5);
   Test::impl_test_nrm2_mv<view_type_a_ls, Device>(1024,5);
-  Test::impl_test_nrm2_mv<view_type_a_ls, Device>(132231,5);
+  //Test::impl_test_nrm2_mv<view_type_a_ls, Device>(132231,5);
 #endif
 
   return 1;

--- a/packages/kokkos-kernels/unit_test/blas/Test_Blas1_nrm2_squared.hpp
+++ b/packages/kokkos-kernels/unit_test/blas/Test_Blas1_nrm2_squared.hpp
@@ -117,7 +117,7 @@ int test_nrm2_squared() {
   Test::impl_test_nrm2_squared<view_type_a_ll, Device>(0);
   Test::impl_test_nrm2_squared<view_type_a_ll, Device>(13);
   Test::impl_test_nrm2_squared<view_type_a_ll, Device>(1024);
-  Test::impl_test_nrm2_squared<view_type_a_ll, Device>(132231);
+  //Test::impl_test_nrm2_squared<view_type_a_ll, Device>(132231);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -125,7 +125,7 @@ int test_nrm2_squared() {
   Test::impl_test_nrm2_squared<view_type_a_lr, Device>(0);
   Test::impl_test_nrm2_squared<view_type_a_lr, Device>(13);
   Test::impl_test_nrm2_squared<view_type_a_lr, Device>(1024);
-  Test::impl_test_nrm2_squared<view_type_a_lr, Device>(132231);
+  //Test::impl_test_nrm2_squared<view_type_a_lr, Device>(132231);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -133,7 +133,7 @@ int test_nrm2_squared() {
   Test::impl_test_nrm2_squared<view_type_a_ls, Device>(0);
   Test::impl_test_nrm2_squared<view_type_a_ls, Device>(13);
   Test::impl_test_nrm2_squared<view_type_a_ls, Device>(1024);
-  Test::impl_test_nrm2_squared<view_type_a_ls, Device>(132231);
+  //Test::impl_test_nrm2_squared<view_type_a_ls, Device>(132231);
 #endif
 
   return 1;
@@ -147,7 +147,7 @@ int test_nrm2_squared_mv() {
   Test::impl_test_nrm2_squared_mv<view_type_a_ll, Device>(0,5);
   Test::impl_test_nrm2_squared_mv<view_type_a_ll, Device>(13,5);
   Test::impl_test_nrm2_squared_mv<view_type_a_ll, Device>(1024,5);
-  Test::impl_test_nrm2_squared_mv<view_type_a_ll, Device>(132231,5);
+  //Test::impl_test_nrm2_squared_mv<view_type_a_ll, Device>(132231,5);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -155,7 +155,7 @@ int test_nrm2_squared_mv() {
   Test::impl_test_nrm2_squared_mv<view_type_a_lr, Device>(0,5);
   Test::impl_test_nrm2_squared_mv<view_type_a_lr, Device>(13,5);
   Test::impl_test_nrm2_squared_mv<view_type_a_lr, Device>(1024,5);
-  Test::impl_test_nrm2_squared_mv<view_type_a_lr, Device>(132231,5);
+  //Test::impl_test_nrm2_squared_mv<view_type_a_lr, Device>(132231,5);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -163,7 +163,7 @@ int test_nrm2_squared_mv() {
   Test::impl_test_nrm2_squared_mv<view_type_a_ls, Device>(0,5);
   Test::impl_test_nrm2_squared_mv<view_type_a_ls, Device>(13,5);
   Test::impl_test_nrm2_squared_mv<view_type_a_ls, Device>(1024,5);
-  Test::impl_test_nrm2_squared_mv<view_type_a_ls, Device>(132231,5);
+  //Test::impl_test_nrm2_squared_mv<view_type_a_ls, Device>(132231,5);
 #endif
 
   return 1;

--- a/packages/kokkos-kernels/unit_test/blas/Test_Blas1_nrminf.hpp
+++ b/packages/kokkos-kernels/unit_test/blas/Test_Blas1_nrminf.hpp
@@ -117,7 +117,7 @@ int test_nrminf() {
   Test::impl_test_nrminf<view_type_a_ll, Device>(0);
   Test::impl_test_nrminf<view_type_a_ll, Device>(13);
   Test::impl_test_nrminf<view_type_a_ll, Device>(1024);
-  Test::impl_test_nrminf<view_type_a_ll, Device>(132231);
+  //Test::impl_test_nrminf<view_type_a_ll, Device>(132231);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -125,7 +125,7 @@ int test_nrminf() {
   Test::impl_test_nrminf<view_type_a_lr, Device>(0);
   Test::impl_test_nrminf<view_type_a_lr, Device>(13);
   Test::impl_test_nrminf<view_type_a_lr, Device>(1024);
-  Test::impl_test_nrminf<view_type_a_lr, Device>(132231);
+  //Test::impl_test_nrminf<view_type_a_lr, Device>(132231);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -133,7 +133,7 @@ int test_nrminf() {
   Test::impl_test_nrminf<view_type_a_ls, Device>(0);
   Test::impl_test_nrminf<view_type_a_ls, Device>(13);
   Test::impl_test_nrminf<view_type_a_ls, Device>(1024);
-  Test::impl_test_nrminf<view_type_a_ls, Device>(132231);
+  //Test::impl_test_nrminf<view_type_a_ls, Device>(132231);
 #endif
 
   return 1;
@@ -147,7 +147,7 @@ int test_nrminf_mv() {
   Test::impl_test_nrminf_mv<view_type_a_ll, Device>(0,5);
   Test::impl_test_nrminf_mv<view_type_a_ll, Device>(13,5);
   Test::impl_test_nrminf_mv<view_type_a_ll, Device>(1024,5);
-  Test::impl_test_nrminf_mv<view_type_a_ll, Device>(132231,5);
+  //Test::impl_test_nrminf_mv<view_type_a_ll, Device>(132231,5);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -155,7 +155,7 @@ int test_nrminf_mv() {
   Test::impl_test_nrminf_mv<view_type_a_lr, Device>(0,5);
   Test::impl_test_nrminf_mv<view_type_a_lr, Device>(13,5);
   Test::impl_test_nrminf_mv<view_type_a_lr, Device>(1024,5);
-  Test::impl_test_nrminf_mv<view_type_a_lr, Device>(132231,5);
+  //Test::impl_test_nrminf_mv<view_type_a_lr, Device>(132231,5);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -163,7 +163,7 @@ int test_nrminf_mv() {
   Test::impl_test_nrminf_mv<view_type_a_ls, Device>(0,5);
   Test::impl_test_nrminf_mv<view_type_a_ls, Device>(13,5);
   Test::impl_test_nrminf_mv<view_type_a_ls, Device>(1024,5);
-  Test::impl_test_nrminf_mv<view_type_a_ls, Device>(132231,5);
+  //Test::impl_test_nrminf_mv<view_type_a_ls, Device>(132231,5);
 #endif
 
   return 1;}

--- a/packages/kokkos-kernels/unit_test/blas/Test_Blas1_reciprocal.hpp
+++ b/packages/kokkos-kernels/unit_test/blas/Test_Blas1_reciprocal.hpp
@@ -158,7 +158,7 @@ int test_reciprocal() {
   Test::impl_test_reciprocal<view_type_a_ll, view_type_b_ll, Device>(0);
   Test::impl_test_reciprocal<view_type_a_ll, view_type_b_ll, Device>(13);
   Test::impl_test_reciprocal<view_type_a_ll, view_type_b_ll, Device>(1024);
-  Test::impl_test_reciprocal<view_type_a_ll, view_type_b_ll, Device>(132231);
+  //Test::impl_test_reciprocal<view_type_a_ll, view_type_b_ll, Device>(132231);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -167,7 +167,7 @@ int test_reciprocal() {
   Test::impl_test_reciprocal<view_type_a_lr, view_type_b_lr, Device>(0);
   Test::impl_test_reciprocal<view_type_a_lr, view_type_b_lr, Device>(13);
   Test::impl_test_reciprocal<view_type_a_lr, view_type_b_lr, Device>(1024);
-  Test::impl_test_reciprocal<view_type_a_lr, view_type_b_lr, Device>(132231);
+  //Test::impl_test_reciprocal<view_type_a_lr, view_type_b_lr, Device>(132231);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -176,7 +176,7 @@ int test_reciprocal() {
   Test::impl_test_reciprocal<view_type_a_ls, view_type_b_ls, Device>(0);
   Test::impl_test_reciprocal<view_type_a_ls, view_type_b_ls, Device>(13);
   Test::impl_test_reciprocal<view_type_a_ls, view_type_b_ls, Device>(1024);
-  Test::impl_test_reciprocal<view_type_a_ls, view_type_b_ls, Device>(132231);
+  //Test::impl_test_reciprocal<view_type_a_ls, view_type_b_ls, Device>(132231);
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
@@ -196,7 +196,7 @@ int test_reciprocal_mv() {
   Test::impl_test_reciprocal_mv<view_type_a_ll, view_type_b_ll, Device>(0,5);
   Test::impl_test_reciprocal_mv<view_type_a_ll, view_type_b_ll, Device>(13,5);
   Test::impl_test_reciprocal_mv<view_type_a_ll, view_type_b_ll, Device>(1024,5);
-  Test::impl_test_reciprocal_mv<view_type_a_ll, view_type_b_ll, Device>(132231,5);
+  //Test::impl_test_reciprocal_mv<view_type_a_ll, view_type_b_ll, Device>(132231,5);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -205,7 +205,7 @@ int test_reciprocal_mv() {
   Test::impl_test_reciprocal_mv<view_type_a_lr, view_type_b_lr, Device>(0,5);
   Test::impl_test_reciprocal_mv<view_type_a_lr, view_type_b_lr, Device>(13,5);
   Test::impl_test_reciprocal_mv<view_type_a_lr, view_type_b_lr, Device>(1024,5);
-  Test::impl_test_reciprocal_mv<view_type_a_lr, view_type_b_lr, Device>(132231,5);
+  //Test::impl_test_reciprocal_mv<view_type_a_lr, view_type_b_lr, Device>(132231,5);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -214,7 +214,7 @@ int test_reciprocal_mv() {
   Test::impl_test_reciprocal_mv<view_type_a_ls, view_type_b_ls, Device>(0,5);
   Test::impl_test_reciprocal_mv<view_type_a_ls, view_type_b_ls, Device>(13,5);
   Test::impl_test_reciprocal_mv<view_type_a_ls, view_type_b_ls, Device>(1024,5);
-  Test::impl_test_reciprocal_mv<view_type_a_ls, view_type_b_ls, Device>(132231,5);
+  //Test::impl_test_reciprocal_mv<view_type_a_ls, view_type_b_ls, Device>(132231,5);
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)

--- a/packages/kokkos-kernels/unit_test/blas/Test_Blas1_scal.hpp
+++ b/packages/kokkos-kernels/unit_test/blas/Test_Blas1_scal.hpp
@@ -199,7 +199,7 @@ int test_scal() {
   Test::impl_test_scal<view_type_a_ll, view_type_b_ll, Device>(0);
   Test::impl_test_scal<view_type_a_ll, view_type_b_ll, Device>(13);
   Test::impl_test_scal<view_type_a_ll, view_type_b_ll, Device>(1024);
-  Test::impl_test_scal<view_type_a_ll, view_type_b_ll, Device>(132231);
+  //Test::impl_test_scal<view_type_a_ll, view_type_b_ll, Device>(132231);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -208,7 +208,7 @@ int test_scal() {
   Test::impl_test_scal<view_type_a_lr, view_type_b_lr, Device>(0);
   Test::impl_test_scal<view_type_a_lr, view_type_b_lr, Device>(13);
   Test::impl_test_scal<view_type_a_lr, view_type_b_lr, Device>(1024);
-  Test::impl_test_scal<view_type_a_lr, view_type_b_lr, Device>(132231);
+  //Test::impl_test_scal<view_type_a_lr, view_type_b_lr, Device>(132231);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -217,7 +217,7 @@ int test_scal() {
   Test::impl_test_scal<view_type_a_ls, view_type_b_ls, Device>(0);
   Test::impl_test_scal<view_type_a_ls, view_type_b_ls, Device>(13);
   Test::impl_test_scal<view_type_a_ls, view_type_b_ls, Device>(1024);
-  Test::impl_test_scal<view_type_a_ls, view_type_b_ls, Device>(132231);
+  //Test::impl_test_scal<view_type_a_ls, view_type_b_ls, Device>(132231);
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
@@ -237,7 +237,7 @@ int test_scal_mv() {
   Test::impl_test_scal_mv<view_type_a_ll, view_type_b_ll, Device>(0,5);
   Test::impl_test_scal_mv<view_type_a_ll, view_type_b_ll, Device>(13,5);
   Test::impl_test_scal_mv<view_type_a_ll, view_type_b_ll, Device>(1024,5);
-  Test::impl_test_scal_mv<view_type_a_ll, view_type_b_ll, Device>(132231,5);
+  //Test::impl_test_scal_mv<view_type_a_ll, view_type_b_ll, Device>(132231,5);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -246,7 +246,7 @@ int test_scal_mv() {
   Test::impl_test_scal_mv<view_type_a_lr, view_type_b_lr, Device>(0,5);
   Test::impl_test_scal_mv<view_type_a_lr, view_type_b_lr, Device>(13,5);
   Test::impl_test_scal_mv<view_type_a_lr, view_type_b_lr, Device>(1024,5);
-  Test::impl_test_scal_mv<view_type_a_lr, view_type_b_lr, Device>(132231,5);
+  //Test::impl_test_scal_mv<view_type_a_lr, view_type_b_lr, Device>(132231,5);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -255,7 +255,7 @@ int test_scal_mv() {
   Test::impl_test_scal_mv<view_type_a_ls, view_type_b_ls, Device>(0,5);
   Test::impl_test_scal_mv<view_type_a_ls, view_type_b_ls, Device>(13,5);
   Test::impl_test_scal_mv<view_type_a_ls, view_type_b_ls, Device>(1024,5);
-  Test::impl_test_scal_mv<view_type_a_ls, view_type_b_ls, Device>(132231,5);
+  //Test::impl_test_scal_mv<view_type_a_ls, view_type_b_ls, Device>(132231,5);
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)

--- a/packages/kokkos-kernels/unit_test/blas/Test_Blas1_sum.hpp
+++ b/packages/kokkos-kernels/unit_test/blas/Test_Blas1_sum.hpp
@@ -110,7 +110,7 @@ int test_sum() {
   Test::impl_test_sum<view_type_a_ll, Device>(0);
   Test::impl_test_sum<view_type_a_ll, Device>(13);
   Test::impl_test_sum<view_type_a_ll, Device>(1024);
-  Test::impl_test_sum<view_type_a_ll, Device>(132231);
+  //Test::impl_test_sum<view_type_a_ll, Device>(132231);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -118,7 +118,7 @@ int test_sum() {
   Test::impl_test_sum<view_type_a_lr, Device>(0);
   Test::impl_test_sum<view_type_a_lr, Device>(13);
   Test::impl_test_sum<view_type_a_lr, Device>(1024);
-  Test::impl_test_sum<view_type_a_lr, Device>(132231);
+  //Test::impl_test_sum<view_type_a_lr, Device>(132231);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -126,7 +126,7 @@ int test_sum() {
   Test::impl_test_sum<view_type_a_ls, Device>(0);
   Test::impl_test_sum<view_type_a_ls, Device>(13);
   Test::impl_test_sum<view_type_a_ls, Device>(1024);
-  Test::impl_test_sum<view_type_a_ls, Device>(132231);
+  //Test::impl_test_sum<view_type_a_ls, Device>(132231);
 #endif
 
   return 1;
@@ -140,7 +140,7 @@ int test_sum_mv() {
   Test::impl_test_sum_mv<view_type_a_ll, Device>(0,5);
   Test::impl_test_sum_mv<view_type_a_ll, Device>(13,5);
   Test::impl_test_sum_mv<view_type_a_ll, Device>(1024,5);
-  Test::impl_test_sum_mv<view_type_a_ll, Device>(132231,5);
+  //Test::impl_test_sum_mv<view_type_a_ll, Device>(132231,5);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -148,7 +148,7 @@ int test_sum_mv() {
   Test::impl_test_sum_mv<view_type_a_lr, Device>(0,5);
   Test::impl_test_sum_mv<view_type_a_lr, Device>(13,5);
   Test::impl_test_sum_mv<view_type_a_lr, Device>(1024,5);
-  Test::impl_test_sum_mv<view_type_a_lr, Device>(132231,5);
+  //Test::impl_test_sum_mv<view_type_a_lr, Device>(132231,5);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -156,7 +156,7 @@ int test_sum_mv() {
   Test::impl_test_sum_mv<view_type_a_ls, Device>(0,5);
   Test::impl_test_sum_mv<view_type_a_ls, Device>(13,5);
   Test::impl_test_sum_mv<view_type_a_ls, Device>(1024,5);
-  Test::impl_test_sum_mv<view_type_a_ls, Device>(132231,5);
+  //Test::impl_test_sum_mv<view_type_a_ls, Device>(132231,5);
 #endif
 
   return 1;

--- a/packages/kokkos-kernels/unit_test/blas/Test_Blas1_team_abs.hpp
+++ b/packages/kokkos-kernels/unit_test/blas/Test_Blas1_team_abs.hpp
@@ -187,8 +187,8 @@ int test_team_abs() {
   typedef Kokkos::View<ScalarB*, Kokkos::LayoutLeft, Device> view_type_b_ll;
   Test::impl_test_team_abs<view_type_a_ll, view_type_b_ll, Device>(0);
   Test::impl_test_team_abs<view_type_a_ll, view_type_b_ll, Device>(13);
-  Test::impl_test_team_abs<view_type_a_ll, view_type_b_ll, Device>(1024);
-  Test::impl_test_team_abs<view_type_a_ll, view_type_b_ll, Device>(132231);
+  Test::impl_test_team_abs<view_type_a_ll, view_type_b_ll, Device>(124);
+  //Test::impl_test_team_abs<view_type_a_ll, view_type_b_ll, Device>(132231);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -196,8 +196,8 @@ int test_team_abs() {
   typedef Kokkos::View<ScalarB*, Kokkos::LayoutRight, Device> view_type_b_lr;
   Test::impl_test_team_abs<view_type_a_lr, view_type_b_lr, Device>(0);
   Test::impl_test_team_abs<view_type_a_lr, view_type_b_lr, Device>(13);
-  Test::impl_test_team_abs<view_type_a_lr, view_type_b_lr, Device>(1024);
-  Test::impl_test_team_abs<view_type_a_lr, view_type_b_lr, Device>(132231);
+  Test::impl_test_team_abs<view_type_a_lr, view_type_b_lr, Device>(124);
+  //Test::impl_test_team_abs<view_type_a_lr, view_type_b_lr, Device>(132231);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -205,13 +205,13 @@ int test_team_abs() {
   typedef Kokkos::View<ScalarB*, Kokkos::LayoutStride, Device> view_type_b_ls;
   Test::impl_test_team_abs<view_type_a_ls, view_type_b_ls, Device>(0);
   Test::impl_test_team_abs<view_type_a_ls, view_type_b_ls, Device>(13);
-  Test::impl_test_team_abs<view_type_a_ls, view_type_b_ls, Device>(1024);
-  Test::impl_test_team_abs<view_type_a_ls, view_type_b_ls, Device>(132231);
+  Test::impl_test_team_abs<view_type_a_ls, view_type_b_ls, Device>(124);
+  //Test::impl_test_team_abs<view_type_a_ls, view_type_b_ls, Device>(132231);
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
-  Test::impl_test_team_abs<view_type_a_ls, view_type_b_ll, Device>(1024);
-  Test::impl_test_team_abs<view_type_a_ll, view_type_b_ls, Device>(1024);
+  Test::impl_test_team_abs<view_type_a_ls, view_type_b_ll, Device>(124);
+  Test::impl_test_team_abs<view_type_a_ll, view_type_b_ls, Device>(124);
 #endif
 
   return 1;
@@ -225,8 +225,8 @@ int test_team_abs_mv() {
   typedef Kokkos::View<ScalarB**, Kokkos::LayoutLeft, Device> view_type_b_ll;
   Test::impl_test_team_abs_mv<view_type_a_ll, view_type_b_ll, Device>(0,5);
   Test::impl_test_team_abs_mv<view_type_a_ll, view_type_b_ll, Device>(13,5);
-  Test::impl_test_team_abs_mv<view_type_a_ll, view_type_b_ll, Device>(1024,5);
-  Test::impl_test_team_abs_mv<view_type_a_ll, view_type_b_ll, Device>(132231,5);
+  Test::impl_test_team_abs_mv<view_type_a_ll, view_type_b_ll, Device>(124,5);
+  //Test::impl_test_team_abs_mv<view_type_a_ll, view_type_b_ll, Device>(132231,5);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -234,8 +234,8 @@ int test_team_abs_mv() {
   typedef Kokkos::View<ScalarB**, Kokkos::LayoutRight, Device> view_type_b_lr;
   Test::impl_test_team_abs_mv<view_type_a_lr, view_type_b_lr, Device>(0,5);
   Test::impl_test_team_abs_mv<view_type_a_lr, view_type_b_lr, Device>(13,5);
-  Test::impl_test_team_abs_mv<view_type_a_lr, view_type_b_lr, Device>(1024,5);
-  Test::impl_test_team_abs_mv<view_type_a_lr, view_type_b_lr, Device>(132231,5);
+  Test::impl_test_team_abs_mv<view_type_a_lr, view_type_b_lr, Device>(124,5);
+  //Test::impl_test_team_abs_mv<view_type_a_lr, view_type_b_lr, Device>(132231,5);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -243,13 +243,13 @@ int test_team_abs_mv() {
   typedef Kokkos::View<ScalarB**, Kokkos::LayoutStride, Device> view_type_b_ls;
   Test::impl_test_team_abs_mv<view_type_a_ls, view_type_b_ls, Device>(0,5);
   Test::impl_test_team_abs_mv<view_type_a_ls, view_type_b_ls, Device>(13,5);
-  Test::impl_test_team_abs_mv<view_type_a_ls, view_type_b_ls, Device>(1024,5);
-  Test::impl_test_team_abs_mv<view_type_a_ls, view_type_b_ls, Device>(132231,5);
+  Test::impl_test_team_abs_mv<view_type_a_ls, view_type_b_ls, Device>(124,5);
+  //Test::impl_test_team_abs_mv<view_type_a_ls, view_type_b_ls, Device>(132231,5);
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
-  Test::impl_test_team_abs_mv<view_type_a_ls, view_type_b_ll, Device>(1024,5);
-  Test::impl_test_team_abs_mv<view_type_a_ll, view_type_b_ls, Device>(1024,5);
+  Test::impl_test_team_abs_mv<view_type_a_ls, view_type_b_ll, Device>(124,5);
+  Test::impl_test_team_abs_mv<view_type_a_ll, view_type_b_ls, Device>(124,5);
 #endif
 
   return 1;

--- a/packages/kokkos-kernels/unit_test/blas/Test_Blas1_team_axpby.hpp
+++ b/packages/kokkos-kernels/unit_test/blas/Test_Blas1_team_axpby.hpp
@@ -184,8 +184,8 @@ int test_team_axpby() {
   typedef Kokkos::View<ScalarB*, Kokkos::LayoutLeft, Device> view_type_b_ll;
   Test::impl_test_team_axpby<view_type_a_ll, view_type_b_ll, Device>(0);
   Test::impl_test_team_axpby<view_type_a_ll, view_type_b_ll, Device>(13);
-  Test::impl_test_team_axpby<view_type_a_ll, view_type_b_ll, Device>(1024);
-  Test::impl_test_team_axpby<view_type_a_ll, view_type_b_ll, Device>(132231);
+  Test::impl_test_team_axpby<view_type_a_ll, view_type_b_ll, Device>(124);
+  //Test::impl_test_team_axpby<view_type_a_ll, view_type_b_ll, Device>(132231);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -193,8 +193,8 @@ int test_team_axpby() {
   typedef Kokkos::View<ScalarB*, Kokkos::LayoutRight, Device> view_type_b_lr;
   Test::impl_test_team_axpby<view_type_a_lr, view_type_b_lr, Device>(0);
   Test::impl_test_team_axpby<view_type_a_lr, view_type_b_lr, Device>(13);
-  Test::impl_test_team_axpby<view_type_a_lr, view_type_b_lr, Device>(1024);
-  Test::impl_test_team_axpby<view_type_a_lr, view_type_b_lr, Device>(132231);
+  Test::impl_test_team_axpby<view_type_a_lr, view_type_b_lr, Device>(124);
+  //Test::impl_test_team_axpby<view_type_a_lr, view_type_b_lr, Device>(132231);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -202,13 +202,13 @@ int test_team_axpby() {
   typedef Kokkos::View<ScalarB*, Kokkos::LayoutStride, Device> view_type_b_ls;
   Test::impl_test_team_axpby<view_type_a_ls, view_type_b_ls, Device>(0);
   Test::impl_test_team_axpby<view_type_a_ls, view_type_b_ls, Device>(13);
-  Test::impl_test_team_axpby<view_type_a_ls, view_type_b_ls, Device>(1024);
-  Test::impl_test_team_axpby<view_type_a_ls, view_type_b_ls, Device>(132231);
+  Test::impl_test_team_axpby<view_type_a_ls, view_type_b_ls, Device>(124);
+  //Test::impl_test_team_axpby<view_type_a_ls, view_type_b_ls, Device>(132231);
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
-  Test::impl_test_team_axpby<view_type_a_ls, view_type_b_ll, Device>(1024);
-  Test::impl_test_team_axpby<view_type_a_ll, view_type_b_ls, Device>(1024);
+  Test::impl_test_team_axpby<view_type_a_ls, view_type_b_ll, Device>(124);
+  Test::impl_test_team_axpby<view_type_a_ll, view_type_b_ls, Device>(124);
 #endif
 
   return 1;
@@ -222,8 +222,8 @@ int test_team_axpby_mv() {
   typedef Kokkos::View<ScalarB**, Kokkos::LayoutLeft, Device> view_type_b_ll;
   Test::impl_test_team_axpby_mv<view_type_a_ll, view_type_b_ll, Device>(0,5);
   Test::impl_test_team_axpby_mv<view_type_a_ll, view_type_b_ll, Device>(13,5);
-  Test::impl_test_team_axpby_mv<view_type_a_ll, view_type_b_ll, Device>(1024,5);
-  Test::impl_test_team_axpby_mv<view_type_a_ll, view_type_b_ll, Device>(132231,5);
+  Test::impl_test_team_axpby_mv<view_type_a_ll, view_type_b_ll, Device>(124,5);
+  //Test::impl_test_team_axpby_mv<view_type_a_ll, view_type_b_ll, Device>(132231,5);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -231,8 +231,8 @@ int test_team_axpby_mv() {
   typedef Kokkos::View<ScalarB**, Kokkos::LayoutRight, Device> view_type_b_lr;
   Test::impl_test_team_axpby_mv<view_type_a_lr, view_type_b_lr, Device>(0,5);
   Test::impl_test_team_axpby_mv<view_type_a_lr, view_type_b_lr, Device>(13,5);
-  Test::impl_test_team_axpby_mv<view_type_a_lr, view_type_b_lr, Device>(1024,5);
-  Test::impl_test_team_axpby_mv<view_type_a_lr, view_type_b_lr, Device>(132231,5);
+  Test::impl_test_team_axpby_mv<view_type_a_lr, view_type_b_lr, Device>(124,5);
+  //Test::impl_test_team_axpby_mv<view_type_a_lr, view_type_b_lr, Device>(132231,5);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -240,13 +240,13 @@ int test_team_axpby_mv() {
   typedef Kokkos::View<ScalarB**, Kokkos::LayoutStride, Device> view_type_b_ls;
   Test::impl_test_team_axpby_mv<view_type_a_ls, view_type_b_ls, Device>(0,5);
   Test::impl_test_team_axpby_mv<view_type_a_ls, view_type_b_ls, Device>(13,5);
-  Test::impl_test_team_axpby_mv<view_type_a_ls, view_type_b_ls, Device>(1024,5);
-  Test::impl_test_team_axpby_mv<view_type_a_ls, view_type_b_ls, Device>(132231,5);
+  Test::impl_test_team_axpby_mv<view_type_a_ls, view_type_b_ls, Device>(124,5);
+  //Test::impl_test_team_axpby_mv<view_type_a_ls, view_type_b_ls, Device>(132231,5);
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
-  Test::impl_test_team_axpby_mv<view_type_a_ls, view_type_b_ll, Device>(1024,5);
-  Test::impl_test_team_axpby_mv<view_type_a_ll, view_type_b_ls, Device>(1024,5);
+  Test::impl_test_team_axpby_mv<view_type_a_ls, view_type_b_ll, Device>(124,5);
+  Test::impl_test_team_axpby_mv<view_type_a_ll, view_type_b_ls, Device>(124,5);
 #endif
 
   return 1;

--- a/packages/kokkos-kernels/unit_test/blas/Test_Blas1_team_axpy.hpp
+++ b/packages/kokkos-kernels/unit_test/blas/Test_Blas1_team_axpy.hpp
@@ -179,8 +179,8 @@ int test_team_axpy() {
   typedef Kokkos::View<ScalarB*, Kokkos::LayoutLeft, Device> view_type_b_ll;
   Test::impl_test_team_axpy<view_type_a_ll, view_type_b_ll, Device>(0);
   Test::impl_test_team_axpy<view_type_a_ll, view_type_b_ll, Device>(13);
-  Test::impl_test_team_axpy<view_type_a_ll, view_type_b_ll, Device>(1024);
-  Test::impl_test_team_axpy<view_type_a_ll, view_type_b_ll, Device>(132231);
+  Test::impl_test_team_axpy<view_type_a_ll, view_type_b_ll, Device>(124);
+  //Test::impl_test_team_axpy<view_type_a_ll, view_type_b_ll, Device>(132231);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -188,8 +188,8 @@ int test_team_axpy() {
   typedef Kokkos::View<ScalarB*, Kokkos::LayoutRight, Device> view_type_b_lr;
   Test::impl_test_team_axpy<view_type_a_lr, view_type_b_lr, Device>(0);
   Test::impl_test_team_axpy<view_type_a_lr, view_type_b_lr, Device>(13);
-  Test::impl_test_team_axpy<view_type_a_lr, view_type_b_lr, Device>(1024);
-  Test::impl_test_team_axpy<view_type_a_lr, view_type_b_lr, Device>(132231);
+  Test::impl_test_team_axpy<view_type_a_lr, view_type_b_lr, Device>(124);
+  //Test::impl_test_team_axpy<view_type_a_lr, view_type_b_lr, Device>(132231);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -197,13 +197,13 @@ int test_team_axpy() {
   typedef Kokkos::View<ScalarB*, Kokkos::LayoutStride, Device> view_type_b_ls;
   Test::impl_test_team_axpy<view_type_a_ls, view_type_b_ls, Device>(0);
   Test::impl_test_team_axpy<view_type_a_ls, view_type_b_ls, Device>(13);
-  Test::impl_test_team_axpy<view_type_a_ls, view_type_b_ls, Device>(1024);
-  Test::impl_test_team_axpy<view_type_a_ls, view_type_b_ls, Device>(132231);
+  Test::impl_test_team_axpy<view_type_a_ls, view_type_b_ls, Device>(124);
+  //Test::impl_test_team_axpy<view_type_a_ls, view_type_b_ls, Device>(132231);
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
-  Test::impl_test_team_axpy<view_type_a_ls, view_type_b_ll, Device>(1024);
-  Test::impl_test_team_axpy<view_type_a_ll, view_type_b_ls, Device>(1024);
+  Test::impl_test_team_axpy<view_type_a_ls, view_type_b_ll, Device>(124);
+  Test::impl_test_team_axpy<view_type_a_ll, view_type_b_ls, Device>(124);
 #endif
 
   return 1;
@@ -217,8 +217,8 @@ int test_team_axpy_mv() {
   typedef Kokkos::View<ScalarB**, Kokkos::LayoutLeft, Device> view_type_b_ll;
   Test::impl_test_team_axpy_mv<view_type_a_ll, view_type_b_ll, Device>(0,5);
   Test::impl_test_team_axpy_mv<view_type_a_ll, view_type_b_ll, Device>(13,5);
-  Test::impl_test_team_axpy_mv<view_type_a_ll, view_type_b_ll, Device>(1024,5);
-  Test::impl_test_team_axpy_mv<view_type_a_ll, view_type_b_ll, Device>(132231,5);
+  Test::impl_test_team_axpy_mv<view_type_a_ll, view_type_b_ll, Device>(124,5);
+  //Test::impl_test_team_axpy_mv<view_type_a_ll, view_type_b_ll, Device>(132231,5);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -226,8 +226,8 @@ int test_team_axpy_mv() {
   typedef Kokkos::View<ScalarB**, Kokkos::LayoutRight, Device> view_type_b_lr;
   Test::impl_test_team_axpy_mv<view_type_a_lr, view_type_b_lr, Device>(0,5);
   Test::impl_test_team_axpy_mv<view_type_a_lr, view_type_b_lr, Device>(13,5);
-  Test::impl_test_team_axpy_mv<view_type_a_lr, view_type_b_lr, Device>(1024,5);
-  Test::impl_test_team_axpy_mv<view_type_a_lr, view_type_b_lr, Device>(132231,5);
+  Test::impl_test_team_axpy_mv<view_type_a_lr, view_type_b_lr, Device>(124,5);
+  //Test::impl_test_team_axpy_mv<view_type_a_lr, view_type_b_lr, Device>(132231,5);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -235,13 +235,13 @@ int test_team_axpy_mv() {
   typedef Kokkos::View<ScalarB**, Kokkos::LayoutStride, Device> view_type_b_ls;
   Test::impl_test_team_axpy_mv<view_type_a_ls, view_type_b_ls, Device>(0,5);
   Test::impl_test_team_axpy_mv<view_type_a_ls, view_type_b_ls, Device>(13,5);
-  Test::impl_test_team_axpy_mv<view_type_a_ls, view_type_b_ls, Device>(1024,5);
-  Test::impl_test_team_axpy_mv<view_type_a_ls, view_type_b_ls, Device>(132231,5);
+  Test::impl_test_team_axpy_mv<view_type_a_ls, view_type_b_ls, Device>(124,5);
+  //Test::impl_test_team_axpy_mv<view_type_a_ls, view_type_b_ls, Device>(132231,5);
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
-  Test::impl_test_team_axpy_mv<view_type_a_ls, view_type_b_ll, Device>(1024,5);
-  Test::impl_test_team_axpy_mv<view_type_a_ll, view_type_b_ls, Device>(1024,5);
+  Test::impl_test_team_axpy_mv<view_type_a_ls, view_type_b_ll, Device>(124,5);
+  Test::impl_test_team_axpy_mv<view_type_a_ll, view_type_b_ls, Device>(124,5);
 #endif
 
   return 1;

--- a/packages/kokkos-kernels/unit_test/blas/Test_Blas1_team_dot.hpp
+++ b/packages/kokkos-kernels/unit_test/blas/Test_Blas1_team_dot.hpp
@@ -226,8 +226,8 @@ int test_team_dot() {
   typedef Kokkos::View<ScalarB*, Kokkos::LayoutLeft, Device> view_type_b_ll;
   Test::impl_test_team_dot<view_type_a_ll, view_type_b_ll, Device>(0);
   Test::impl_test_team_dot<view_type_a_ll, view_type_b_ll, Device>(13);
-  Test::impl_test_team_dot<view_type_a_ll, view_type_b_ll, Device>(1024);
-  Test::impl_test_team_dot<view_type_a_ll, view_type_b_ll, Device>(132231);
+  Test::impl_test_team_dot<view_type_a_ll, view_type_b_ll, Device>(124);
+  //Test::impl_test_team_dot<view_type_a_ll, view_type_b_ll, Device>(132231);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -235,8 +235,8 @@ int test_team_dot() {
   typedef Kokkos::View<ScalarB*, Kokkos::LayoutRight, Device> view_type_b_lr;
   Test::impl_test_team_dot<view_type_a_lr, view_type_b_lr, Device>(0);
   Test::impl_test_team_dot<view_type_a_lr, view_type_b_lr, Device>(13);
-  Test::impl_test_team_dot<view_type_a_lr, view_type_b_lr, Device>(1024);
-  Test::impl_test_team_dot<view_type_a_lr, view_type_b_lr, Device>(132231);
+  Test::impl_test_team_dot<view_type_a_lr, view_type_b_lr, Device>(124);
+  //Test::impl_test_team_dot<view_type_a_lr, view_type_b_lr, Device>(132231);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -244,13 +244,13 @@ int test_team_dot() {
   typedef Kokkos::View<ScalarB*, Kokkos::LayoutStride, Device> view_type_b_ls;
   Test::impl_test_team_dot<view_type_a_ls, view_type_b_ls, Device>(0);
   Test::impl_test_team_dot<view_type_a_ls, view_type_b_ls, Device>(13);
-  Test::impl_test_team_dot<view_type_a_ls, view_type_b_ls, Device>(1024);
-  Test::impl_test_team_dot<view_type_a_ls, view_type_b_ls, Device>(132231);
+  Test::impl_test_team_dot<view_type_a_ls, view_type_b_ls, Device>(124);
+  //Test::impl_test_team_dot<view_type_a_ls, view_type_b_ls, Device>(132231);
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
-  Test::impl_test_team_dot<view_type_a_ls, view_type_b_ll, Device>(1024);
-  Test::impl_test_team_dot<view_type_a_ll, view_type_b_ls, Device>(1024);
+  Test::impl_test_team_dot<view_type_a_ls, view_type_b_ll, Device>(124);
+  Test::impl_test_team_dot<view_type_a_ll, view_type_b_ls, Device>(124);
 #endif
 
   return 1;
@@ -264,8 +264,8 @@ int test_team_dot_mv() {
   typedef Kokkos::View<ScalarB**, Kokkos::LayoutLeft, Device> view_type_b_ll;
   Test::impl_test_team_dot_mv<view_type_a_ll, view_type_b_ll, Device>(0,5);
   Test::impl_test_team_dot_mv<view_type_a_ll, view_type_b_ll, Device>(13,5);
-  Test::impl_test_team_dot_mv<view_type_a_ll, view_type_b_ll, Device>(1024,5);
-  Test::impl_test_team_dot_mv<view_type_a_ll, view_type_b_ll, Device>(132231,5);
+  Test::impl_test_team_dot_mv<view_type_a_ll, view_type_b_ll, Device>(124,5);
+  //Test::impl_test_team_dot_mv<view_type_a_ll, view_type_b_ll, Device>(132231,5);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -273,8 +273,8 @@ int test_team_dot_mv() {
   typedef Kokkos::View<ScalarB**, Kokkos::LayoutRight, Device> view_type_b_lr;
   Test::impl_test_team_dot_mv<view_type_a_lr, view_type_b_lr, Device>(0,5);
   Test::impl_test_team_dot_mv<view_type_a_lr, view_type_b_lr, Device>(13,5);
-  Test::impl_test_team_dot_mv<view_type_a_lr, view_type_b_lr, Device>(1024,5);
-  Test::impl_test_team_dot_mv<view_type_a_lr, view_type_b_lr, Device>(132231,5);
+  Test::impl_test_team_dot_mv<view_type_a_lr, view_type_b_lr, Device>(124,5);
+  //Test::impl_test_team_dot_mv<view_type_a_lr, view_type_b_lr, Device>(132231,5);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -282,13 +282,13 @@ int test_team_dot_mv() {
   typedef Kokkos::View<ScalarB**, Kokkos::LayoutStride, Device> view_type_b_ls;
   Test::impl_test_team_dot_mv<view_type_a_ls, view_type_b_ls, Device>(0,5);
   Test::impl_test_team_dot_mv<view_type_a_ls, view_type_b_ls, Device>(13,5);
-  Test::impl_test_team_dot_mv<view_type_a_ls, view_type_b_ls, Device>(1024,5);
-  Test::impl_test_team_dot_mv<view_type_a_ls, view_type_b_ls, Device>(132231,5);
+  Test::impl_test_team_dot_mv<view_type_a_ls, view_type_b_ls, Device>(124,5);
+  //Test::impl_test_team_dot_mv<view_type_a_ls, view_type_b_ls, Device>(132231,5);
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
-  Test::impl_test_team_dot_mv<view_type_a_ls, view_type_b_ll, Device>(1024,5);
-  Test::impl_test_team_dot_mv<view_type_a_ll, view_type_b_ls, Device>(1024,5);
+  Test::impl_test_team_dot_mv<view_type_a_ls, view_type_b_ll, Device>(124,5);
+  Test::impl_test_team_dot_mv<view_type_a_ll, view_type_b_ls, Device>(124,5);
 #endif
 
   return 1;

--- a/packages/kokkos-kernels/unit_test/blas/Test_Blas1_team_mult.hpp
+++ b/packages/kokkos-kernels/unit_test/blas/Test_Blas1_team_mult.hpp
@@ -208,8 +208,8 @@ int test_team_mult() {
   typedef Kokkos::View<ScalarC*, Kokkos::LayoutLeft, Device> view_type_c_ll;
   Test::impl_test_team_mult<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(0);
   Test::impl_test_team_mult<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(13);
-  Test::impl_test_team_mult<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(1024);
-  Test::impl_test_team_mult<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(132231);
+  Test::impl_test_team_mult<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(124);
+  //Test::impl_test_team_mult<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(132231);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -218,8 +218,8 @@ int test_team_mult() {
   typedef Kokkos::View<ScalarC*, Kokkos::LayoutRight, Device> view_type_c_lr;
   Test::impl_test_team_mult<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(0);
   Test::impl_test_team_mult<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(13);
-  Test::impl_test_team_mult<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(1024);
-  Test::impl_test_team_mult<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(132231);
+  Test::impl_test_team_mult<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(124);
+  //Test::impl_test_team_mult<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(132231);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -228,13 +228,13 @@ int test_team_mult() {
   typedef Kokkos::View<ScalarC*, Kokkos::LayoutStride, Device> view_type_c_ls;
   Test::impl_test_team_mult<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(0);
   Test::impl_test_team_mult<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(13);
-  Test::impl_test_team_mult<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(1024);
-  Test::impl_test_team_mult<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(132231);
+  Test::impl_test_team_mult<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(124);
+  //Test::impl_test_team_mult<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(132231);
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
-  Test::impl_test_team_mult<view_type_a_ls, view_type_b_ll, view_type_c_lr, Device>(1024);
-  Test::impl_test_team_mult<view_type_a_ll, view_type_b_ls, view_type_c_lr, Device>(1024);
+  Test::impl_test_team_mult<view_type_a_ls, view_type_b_ll, view_type_c_lr, Device>(124);
+  Test::impl_test_team_mult<view_type_a_ll, view_type_b_ls, view_type_c_lr, Device>(124);
 #endif
 
   return 1;
@@ -249,8 +249,8 @@ int test_team_mult_mv() {
   typedef Kokkos::View<ScalarC**, Kokkos::LayoutLeft, Device> view_type_c_ll;
   Test::impl_test_team_mult_mv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(0,5);
   Test::impl_test_team_mult_mv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(13,5);
-  Test::impl_test_team_mult_mv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(1024,5);
-  Test::impl_test_team_mult_mv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(132231,5);
+  Test::impl_test_team_mult_mv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(124,5);
+  //Test::impl_test_team_mult_mv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(132231,5);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -259,8 +259,8 @@ int test_team_mult_mv() {
   typedef Kokkos::View<ScalarC**, Kokkos::LayoutRight, Device> view_type_c_lr;
   Test::impl_test_team_mult_mv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(0,5);
   Test::impl_test_team_mult_mv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(13,5);
-  Test::impl_test_team_mult_mv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(1024,5);
-  Test::impl_test_team_mult_mv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(132231,5);
+  Test::impl_test_team_mult_mv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(124,5);
+  //Test::impl_test_team_mult_mv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(132231,5);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -269,13 +269,13 @@ int test_team_mult_mv() {
   typedef Kokkos::View<ScalarC**, Kokkos::LayoutStride, Device> view_type_c_ls;
   Test::impl_test_team_mult_mv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(0,5);
   Test::impl_test_team_mult_mv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(13,5);
-  Test::impl_test_team_mult_mv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(1024,5);
-  Test::impl_test_team_mult_mv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(132231,5);
+  Test::impl_test_team_mult_mv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(124,5);
+  //Test::impl_test_team_mult_mv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(132231,5);
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
-  Test::impl_test_team_mult_mv<view_type_a_ls, view_type_b_ll, view_type_c_lr, Device>(1024,5);
-  Test::impl_test_team_mult_mv<view_type_a_ll, view_type_b_ls, view_type_c_lr, Device>(1024,5);
+  Test::impl_test_team_mult_mv<view_type_a_ls, view_type_b_ll, view_type_c_lr, Device>(124,5);
+  Test::impl_test_team_mult_mv<view_type_a_ll, view_type_b_ls, view_type_c_lr, Device>(124,5);
 #endif
 
   return 1;

--- a/packages/kokkos-kernels/unit_test/blas/Test_Blas1_team_nrm2.hpp
+++ b/packages/kokkos-kernels/unit_test/blas/Test_Blas1_team_nrm2.hpp
@@ -85,24 +85,24 @@ int test_team_nrm2() {
   typedef Kokkos::View<ScalarA**, Kokkos::LayoutLeft, Device> view_type_a_ll;
   Test::impl_test_team_nrm2<view_type_a_ll, Device>(0,5);
   Test::impl_test_team_nrm2<view_type_a_ll, Device>(13,5);
-  Test::impl_test_team_nrm2<view_type_a_ll, Device>(1024,5);
-  Test::impl_test_team_nrm2<view_type_a_ll, Device>(132231,5);
+  Test::impl_test_team_nrm2<view_type_a_ll, Device>(124,5);
+  //Test::impl_test_team_nrm2<view_type_a_ll, Device>(132231,5);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
   typedef Kokkos::View<ScalarA**, Kokkos::LayoutRight, Device> view_type_a_lr;
   Test::impl_test_team_nrm2<view_type_a_lr, Device>(0,5);
   Test::impl_test_team_nrm2<view_type_a_lr, Device>(13,5);
-  Test::impl_test_team_nrm2<view_type_a_lr, Device>(1024,5);
-  Test::impl_test_team_nrm2<view_type_a_lr, Device>(132231,5);
+  Test::impl_test_team_nrm2<view_type_a_lr, Device>(124,5);
+  //Test::impl_test_team_nrm2<view_type_a_lr, Device>(132231,5);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
   typedef Kokkos::View<ScalarA**, Kokkos::LayoutStride, Device> view_type_a_ls;
   Test::impl_test_team_nrm2<view_type_a_ls, Device>(0,5);
   Test::impl_test_team_nrm2<view_type_a_ls, Device>(13,5);
-  Test::impl_test_team_nrm2<view_type_a_ls, Device>(1024,5);
-  Test::impl_test_team_nrm2<view_type_a_ls, Device>(132231,5);
+  Test::impl_test_team_nrm2<view_type_a_ls, Device>(124,5);
+  //Test::impl_test_team_nrm2<view_type_a_ls, Device>(132231,5);
 #endif
 
   return 1;

--- a/packages/kokkos-kernels/unit_test/blas/Test_Blas1_team_scal.hpp
+++ b/packages/kokkos-kernels/unit_test/blas/Test_Blas1_team_scal.hpp
@@ -239,8 +239,8 @@ int test_team_scal() {
   typedef Kokkos::View<ScalarB*, Kokkos::LayoutLeft, Device> view_type_b_ll;
   Test::impl_test_team_scal<view_type_a_ll, view_type_b_ll, Device>(0);
   Test::impl_test_team_scal<view_type_a_ll, view_type_b_ll, Device>(13);
-  Test::impl_test_team_scal<view_type_a_ll, view_type_b_ll, Device>(1024);
-  Test::impl_test_team_scal<view_type_a_ll, view_type_b_ll, Device>(132231);
+  Test::impl_test_team_scal<view_type_a_ll, view_type_b_ll, Device>(124);
+  //Test::impl_test_team_scal<view_type_a_ll, view_type_b_ll, Device>(132231);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -248,8 +248,8 @@ int test_team_scal() {
   typedef Kokkos::View<ScalarB*, Kokkos::LayoutRight, Device> view_type_b_lr;
   Test::impl_test_team_scal<view_type_a_lr, view_type_b_lr, Device>(0);
   Test::impl_test_team_scal<view_type_a_lr, view_type_b_lr, Device>(13);
-  Test::impl_test_team_scal<view_type_a_lr, view_type_b_lr, Device>(1024);
-  Test::impl_test_team_scal<view_type_a_lr, view_type_b_lr, Device>(132231);
+  Test::impl_test_team_scal<view_type_a_lr, view_type_b_lr, Device>(124);
+  //Test::impl_test_team_scal<view_type_a_lr, view_type_b_lr, Device>(132231);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -257,13 +257,13 @@ int test_team_scal() {
   typedef Kokkos::View<ScalarB*, Kokkos::LayoutStride, Device> view_type_b_ls;
   Test::impl_test_team_scal<view_type_a_ls, view_type_b_ls, Device>(0);
   Test::impl_test_team_scal<view_type_a_ls, view_type_b_ls, Device>(13);
-  Test::impl_test_team_scal<view_type_a_ls, view_type_b_ls, Device>(1024);
-  Test::impl_test_team_scal<view_type_a_ls, view_type_b_ls, Device>(132231);
+  Test::impl_test_team_scal<view_type_a_ls, view_type_b_ls, Device>(124);
+  //Test::impl_test_team_scal<view_type_a_ls, view_type_b_ls, Device>(132231);
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
-  Test::impl_test_team_scal<view_type_a_ls, view_type_b_ll, Device>(1024);
-  Test::impl_test_team_scal<view_type_a_ll, view_type_b_ls, Device>(1024);
+  Test::impl_test_team_scal<view_type_a_ls, view_type_b_ll, Device>(124);
+  Test::impl_test_team_scal<view_type_a_ll, view_type_b_ls, Device>(124);
 #endif
 
   return 1;
@@ -277,8 +277,8 @@ int test_team_scal_mv() {
   typedef Kokkos::View<ScalarB**, Kokkos::LayoutLeft, Device> view_type_b_ll;
   Test::impl_test_team_scal_mv<view_type_a_ll, view_type_b_ll, Device>(0,5);
   Test::impl_test_team_scal_mv<view_type_a_ll, view_type_b_ll, Device>(13,5);
-  Test::impl_test_team_scal_mv<view_type_a_ll, view_type_b_ll, Device>(1024,5);
-  Test::impl_test_team_scal_mv<view_type_a_ll, view_type_b_ll, Device>(132231,5);
+  Test::impl_test_team_scal_mv<view_type_a_ll, view_type_b_ll, Device>(124,5);
+  //Test::impl_test_team_scal_mv<view_type_a_ll, view_type_b_ll, Device>(132231,5);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -286,8 +286,8 @@ int test_team_scal_mv() {
   typedef Kokkos::View<ScalarB**, Kokkos::LayoutRight, Device> view_type_b_lr;
   Test::impl_test_team_scal_mv<view_type_a_lr, view_type_b_lr, Device>(0,5);
   Test::impl_test_team_scal_mv<view_type_a_lr, view_type_b_lr, Device>(13,5);
-  Test::impl_test_team_scal_mv<view_type_a_lr, view_type_b_lr, Device>(1024,5);
-  Test::impl_test_team_scal_mv<view_type_a_lr, view_type_b_lr, Device>(132231,5);
+  Test::impl_test_team_scal_mv<view_type_a_lr, view_type_b_lr, Device>(124,5);
+  //Test::impl_test_team_scal_mv<view_type_a_lr, view_type_b_lr, Device>(132231,5);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -295,13 +295,13 @@ int test_team_scal_mv() {
   typedef Kokkos::View<ScalarB**, Kokkos::LayoutStride, Device> view_type_b_ls;
   Test::impl_test_team_scal_mv<view_type_a_ls, view_type_b_ls, Device>(0,5);
   Test::impl_test_team_scal_mv<view_type_a_ls, view_type_b_ls, Device>(13,5);
-  Test::impl_test_team_scal_mv<view_type_a_ls, view_type_b_ls, Device>(1024,5);
-  Test::impl_test_team_scal_mv<view_type_a_ls, view_type_b_ls, Device>(132231,5);
+  Test::impl_test_team_scal_mv<view_type_a_ls, view_type_b_ls, Device>(124,5);
+  //Test::impl_test_team_scal_mv<view_type_a_ls, view_type_b_ls, Device>(132231,5);
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
-  Test::impl_test_team_scal_mv<view_type_a_ls, view_type_b_ll, Device>(1024,5);
-  Test::impl_test_team_scal_mv<view_type_a_ll, view_type_b_ls, Device>(1024,5);
+  Test::impl_test_team_scal_mv<view_type_a_ls, view_type_b_ll, Device>(124,5);
+  Test::impl_test_team_scal_mv<view_type_a_ll, view_type_b_ls, Device>(124,5);
 #endif
 
   return 1;

--- a/packages/kokkos-kernels/unit_test/blas/Test_Blas1_team_update.hpp
+++ b/packages/kokkos-kernels/unit_test/blas/Test_Blas1_team_update.hpp
@@ -212,8 +212,8 @@ int test_team_update() {
   typedef Kokkos::View<ScalarC*, Kokkos::LayoutLeft, Device> view_type_c_ll;
   Test::impl_test_team_update<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(0);
   Test::impl_test_team_update<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(13);
-  Test::impl_test_team_update<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(1024);
-  Test::impl_test_team_update<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(132231);
+  Test::impl_test_team_update<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(124);
+  //Test::impl_test_team_update<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(132231);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -222,8 +222,8 @@ int test_team_update() {
   typedef Kokkos::View<ScalarC*, Kokkos::LayoutRight, Device> view_type_c_lr;
   Test::impl_test_team_update<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(0);
   Test::impl_test_team_update<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(13);
-  Test::impl_test_team_update<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(1024);
-  Test::impl_test_team_update<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(132231);
+  Test::impl_test_team_update<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(124);
+  //Test::impl_test_team_update<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(132231);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -232,13 +232,13 @@ int test_team_update() {
   typedef Kokkos::View<ScalarC*, Kokkos::LayoutStride, Device> view_type_c_ls;
   Test::impl_test_team_update<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(0);
   Test::impl_test_team_update<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(13);
-  Test::impl_test_team_update<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(1024);
-  Test::impl_test_team_update<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(132231);
+  Test::impl_test_team_update<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(124);
+  //Test::impl_test_team_update<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(132231);
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
-  Test::impl_test_team_update<view_type_a_ls, view_type_b_ll, view_type_c_lr, Device>(1024);
-  Test::impl_test_team_update<view_type_a_ll, view_type_b_ls, view_type_c_lr, Device>(1024);
+  Test::impl_test_team_update<view_type_a_ls, view_type_b_ll, view_type_c_lr, Device>(124);
+  Test::impl_test_team_update<view_type_a_ll, view_type_b_ls, view_type_c_lr, Device>(124);
 #endif
 
   return 1;
@@ -253,8 +253,8 @@ int test_team_update_mv() {
   typedef Kokkos::View<ScalarC**, Kokkos::LayoutLeft, Device> view_type_c_ll;
   Test::impl_test_team_update_mv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(0,5);
   Test::impl_test_team_update_mv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(13,5);
-  Test::impl_test_team_update_mv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(1024,5);
-  Test::impl_test_team_update_mv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(132231,5);
+  Test::impl_test_team_update_mv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(124,5);
+  //Test::impl_test_team_update_mv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(132231,5);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -263,8 +263,8 @@ int test_team_update_mv() {
   typedef Kokkos::View<ScalarC**, Kokkos::LayoutRight, Device> view_type_c_lr;
   Test::impl_test_team_update_mv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(0,5);
   Test::impl_test_team_update_mv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(13,5);
-  Test::impl_test_team_update_mv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(1024,5);
-  Test::impl_test_team_update_mv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(132231,5);
+  Test::impl_test_team_update_mv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(124,5);
+  //Test::impl_test_team_update_mv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(132231,5);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -273,13 +273,13 @@ int test_team_update_mv() {
   typedef Kokkos::View<ScalarC**, Kokkos::LayoutStride, Device> view_type_c_ls;
   Test::impl_test_team_update_mv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(0,5);
   Test::impl_test_team_update_mv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(13,5);
-  Test::impl_test_team_update_mv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(1024,5);
-  Test::impl_test_team_update_mv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(132231,5);
+  Test::impl_test_team_update_mv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(124,5);
+  //Test::impl_test_team_update_mv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(132231,5);
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
-  Test::impl_test_team_update_mv<view_type_a_ls, view_type_b_ll, view_type_c_lr, Device>(1024,5);
-  Test::impl_test_team_update_mv<view_type_a_ll, view_type_b_ls, view_type_c_lr, Device>(1024,5);
+  Test::impl_test_team_update_mv<view_type_a_ls, view_type_b_ll, view_type_c_lr, Device>(124,5);
+  Test::impl_test_team_update_mv<view_type_a_ll, view_type_b_ls, view_type_c_lr, Device>(124,5);
 #endif
 
   return 1;

--- a/packages/kokkos-kernels/unit_test/blas/Test_Blas1_update.hpp
+++ b/packages/kokkos-kernels/unit_test/blas/Test_Blas1_update.hpp
@@ -179,7 +179,7 @@ int test_update() {
   Test::impl_test_update<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(0);
   Test::impl_test_update<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(13);
   Test::impl_test_update<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(1024);
-  Test::impl_test_update<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(132231);
+  //Test::impl_test_update<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(132231);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -189,7 +189,7 @@ int test_update() {
   Test::impl_test_update<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(0);
   Test::impl_test_update<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(13);
   Test::impl_test_update<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(1024);
-  Test::impl_test_update<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(132231);
+  //Test::impl_test_update<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(132231);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -199,7 +199,7 @@ int test_update() {
   Test::impl_test_update<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(0);
   Test::impl_test_update<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(13);
   Test::impl_test_update<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(1024);
-  Test::impl_test_update<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(132231);
+  //Test::impl_test_update<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(132231);
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)

--- a/packages/kokkos-kernels/unit_test/blas/Test_Blas2_gemv.hpp
+++ b/packages/kokkos-kernels/unit_test/blas/Test_Blas2_gemv.hpp
@@ -104,7 +104,7 @@ int test_gemv(const char* mode) {
   Test::impl_test_gemv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(mode,0,1024);
   Test::impl_test_gemv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(mode,13,1024);
   Test::impl_test_gemv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(mode,1024,1024);
-  Test::impl_test_gemv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(mode,132231,1024);
+  //Test::impl_test_gemv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(mode,132231,1024);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -114,7 +114,7 @@ int test_gemv(const char* mode) {
   Test::impl_test_gemv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(mode,0,1024);
   Test::impl_test_gemv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(mode,13,1024);
   Test::impl_test_gemv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(mode,1024,1024);
-  Test::impl_test_gemv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(mode,132231,1024);
+  //Test::impl_test_gemv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(mode,132231,1024);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -124,7 +124,7 @@ int test_gemv(const char* mode) {
   Test::impl_test_gemv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(mode,0,1024);
   Test::impl_test_gemv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(mode,13,1024);
   Test::impl_test_gemv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(mode,1024,1024);
-  Test::impl_test_gemv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(mode,132231,1024);
+  //Test::impl_test_gemv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(mode,132231,1024);
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)

--- a/packages/kokkos-kernels/unit_test/blas/Test_Blas2_team_gemv.hpp
+++ b/packages/kokkos-kernels/unit_test/blas/Test_Blas2_team_gemv.hpp
@@ -129,8 +129,8 @@ int test_team_gemv(const char* mode) {
   typedef Kokkos::View<ScalarY*, Kokkos::LayoutLeft, Device> view_type_c_ll;
   Test::impl_test_team_gemv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(mode,0,1024);
   Test::impl_test_team_gemv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(mode,13,1024);
-  Test::impl_test_team_gemv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(mode,1024,1024);
-  Test::impl_test_team_gemv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(mode,132231,1024);
+  Test::impl_test_team_gemv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(mode,124,124);
+  //Test::impl_test_team_gemv<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(mode,132231,1024);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -139,8 +139,8 @@ int test_team_gemv(const char* mode) {
   typedef Kokkos::View<ScalarY*, Kokkos::LayoutRight, Device> view_type_c_lr;
   Test::impl_test_team_gemv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(mode,0,1024);
   Test::impl_test_team_gemv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(mode,13,1024);
-  Test::impl_test_team_gemv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(mode,1024,1024);
-  Test::impl_test_team_gemv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(mode,132231,1024);
+  Test::impl_test_team_gemv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(mode,124,124);
+  //Test::impl_test_team_gemv<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(mode,132231,1024);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -149,13 +149,13 @@ int test_team_gemv(const char* mode) {
   typedef Kokkos::View<ScalarY*, Kokkos::LayoutStride, Device> view_type_c_ls;
   Test::impl_test_team_gemv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(mode,0,1024);
   Test::impl_test_team_gemv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(mode,13,1024);
-  Test::impl_test_team_gemv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(mode,1024,1024);
-  Test::impl_test_team_gemv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(mode,132231,1024);
+  Test::impl_test_team_gemv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(mode,124,124);
+  //Test::impl_test_team_gemv<view_type_a_ls, view_type_b_ls, view_type_c_ls, Device>(mode,132231,1024);
 #endif
 
 #if !defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS)
-  Test::impl_test_team_gemv<view_type_a_ls, view_type_b_ll, view_type_c_lr, Device>(mode,1024,1024);
-  Test::impl_test_team_gemv<view_type_a_ll, view_type_b_ls, view_type_c_lr, Device>(mode,1024,1024);
+  Test::impl_test_team_gemv<view_type_a_ls, view_type_b_ll, view_type_c_lr, Device>(mode,124,124);
+  Test::impl_test_team_gemv<view_type_a_ll, view_type_b_ls, view_type_c_lr, Device>(mode,124,124);
 #endif
 
   return 1;

--- a/packages/kokkos-kernels/unit_test/blas/Test_Blas3_gemm.hpp
+++ b/packages/kokkos-kernels/unit_test/blas/Test_Blas3_gemm.hpp
@@ -162,7 +162,7 @@ int test_gemm(const char* mode, ScalarA alpha, ScalarB beta) {
   Test::impl_test_gemm<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(&mode[0],&mode[1],13,15,17,alpha,beta);
   Test::impl_test_gemm<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(&mode[0],&mode[1],179,15,211,alpha,beta);
   Test::impl_test_gemm<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(&mode[0],&mode[1],12,3071,517,alpha,beta);
-  Test::impl_test_gemm<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(&mode[0],&mode[1],1024,1024,2048,alpha,beta);
+  //Test::impl_test_gemm<view_type_a_ll, view_type_b_ll, view_type_c_ll, Device>(&mode[0],&mode[1],1024,1024,2048,alpha,beta);
 #endif
 
 #if defined(KOKKOSKERNELS_INST_LAYOUTRIGHT) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))
@@ -173,7 +173,7 @@ int test_gemm(const char* mode, ScalarA alpha, ScalarB beta) {
   Test::impl_test_gemm<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(&mode[0],&mode[1],13,15,17,alpha,beta);
   Test::impl_test_gemm<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(&mode[0],&mode[1],179,15,211,alpha,beta);
   Test::impl_test_gemm<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(&mode[0],&mode[1],12,3071,517,alpha,beta);
-  Test::impl_test_gemm<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(&mode[0],&mode[1],1024,1024,2048,alpha,beta);
+  //Test::impl_test_gemm<view_type_a_lr, view_type_b_lr, view_type_c_lr, Device>(&mode[0],&mode[1],1024,1024,2048,alpha,beta);
 #endif
 /*
 #if defined(KOKKOSKERNELS_INST_LAYOUTSTRIDE) || (!defined(KOKKOSKERNELS_ETI_ONLY) && !defined(KOKKOSKERNELS_IMPL_CHECK_ETI_CALLS))


### PR DESCRIPTION

## Description

#4394 
PR test suffers from long kokkos kernels testing duration. We reduce unit test problem sizes

For level 3 operations, remove 1024,1024,2048 combinations
For level 3 operations, remove 132231 problem sizes
For level 1 operations, remove 132231 problem sizes
For team level operations, remove 132231 and reduce 1024 problem sizes to 124. It does not make sense that a single team process 132231 and 1024 size problem sizes. Team-level operations are mostly for small-mid size problems. It should not bigger than 1000.
