### PR TITLE
Framework: Adding OMP_NUM_THREADS to PR Testing

### DIFF
--- a/cmake/std/sems/PullRequestCuda9.2TestingEnv.sh
+++ b/cmake/std/sems/PullRequestCuda9.2TestingEnv.sh
@@ -18,3 +18,7 @@ export CUDA_LAUNCH_BLOCKING=1
 # Use manually installed cmake and ninja to try to avoid module loading
 # problems (see TRIL-208)
 export PATH=/ascldap/users/rabartl/install/white-ride/cmake-3.11.2/bin:/ascldap/users/rabartl/install/white-ride/ninja-1.8.2/bin:$PATH
+
+# add the OpenMP environment variable we need
+export OMP_NUM_THREADS=2
+

--- a/cmake/std/sems/PullRequestGCC4.9.3TestingEnv.sh
+++ b/cmake/std/sems/PullRequestGCC4.9.3TestingEnv.sh
@@ -34,4 +34,7 @@ module load atdm-env
 module load atdm-cmake/3.11.1
 module load atdm-ninja_fortran/1.7.2
 
+# add the OpenMP environment variable we need
+export OMP_NUM_THREADS=2
+
 

--- a/cmake/std/sems/PullRequestGCC4.9.3TestingEnvSERIAL.sh
+++ b/cmake/std/sems/PullRequestGCC4.9.3TestingEnvSERIAL.sh
@@ -33,4 +33,7 @@ module load atdm-env
 module load atdm-cmake/3.11.1
 module load atdm-ninja_fortran/1.7.2
 
+# add the OpenMP environment variable we need
+export OMP_NUM_THREADS=2
+
 

--- a/cmake/std/sems/PullRequestGCC7.2.0TestingEnv.sh
+++ b/cmake/std/sems/PullRequestGCC7.2.0TestingEnv.sh
@@ -34,3 +34,6 @@ module load atdm-env
 module load atdm-cmake/3.11.1
 module load atdm-ninja_fortran/1.7.2
 
+# add the OpenMP environment variable we need
+export OMP_NUM_THREADS=2
+

--- a/cmake/std/sems/PullRequestGCC7.3.0TestingEnv.sh
+++ b/cmake/std/sems/PullRequestGCC7.3.0TestingEnv.sh
@@ -34,3 +34,6 @@ module load atdm-env
 module load atdm-cmake/3.11.1
 module load atdm-ninja_fortran/1.7.2
 
+# add the OpenMP environment variable we need
+export OMP_NUM_THREADS=2
+

--- a/cmake/std/sems/PullRequestIntel17.0.1TestingEnv.sh
+++ b/cmake/std/sems/PullRequestIntel17.0.1TestingEnv.sh
@@ -39,3 +39,7 @@ module load sems-cmake/3.10.3
 module load atdm-env
 module load atdm-cmake/3.11.1
 module load atdm-ninja_fortran/1.7.2
+
+# add the OpenMP environment variable we need
+export OMP_NUM_THREADS=2
+


### PR DESCRIPTION
@trilinos/framework

Not all of the test configurations were setting `OMP_NUM_THREADS`, so this adds that to the configurations.

Setting `OMP_NUM_THREADS=2` initially, @jwillenbring will check with a few folks to see if setting this to 4 won't oversubscribe our systems. If that's fine, I'll update this to set it to 4.

Relates to #4394