### PR TITLE
Teko: Fixing explicit add to reuse memory if requested by user

### DIFF
--- a/packages/teko/src/Teko_Utilities.cpp
+++ b/packages/teko/src/Teko_Utilities.cpp
@@ -1942,13 +1942,11 @@ const ModifiableLinearOp explicitAdd(const LinearOp & opl,const LinearOp & opr,
      RCP<Thyra::PhysicallyBlockedLinearOpBase<double> > blocked_sum = Teuchos::rcp_dynamic_cast<Thyra::DefaultBlockedLinearOp<double>>(destOp);
      if(blocked_sum.is_null())
        blocked_sum = Thyra::defaultBlockedLinearOp<double>();
-     blocked_sum->beginBlockFill(numRows,numCols);
+
      for(int r = 0; r < numRows; ++r)
-       for(int c = 0; c < numCols; ++c){
-         auto block = explicitAdd(Thyra::scale(scalarl,blocked_opl->getBlock(r,c)),Thyra::scale(scalarr,blocked_opr->getBlock(r,c)),Teuchos::null);
-         blocked_sum->setNonconstBlock(r,c,block);
-       }
-     blocked_sum->endBlockFill();
+       for(int c = 0; c < numCols; ++c)
+         explicitAdd(Thyra::scale(scalarl,blocked_opl->getBlock(r,c)),Thyra::scale(scalarr,blocked_opr->getBlock(r,c)),blocked_sum->getNonconstBlock(r,c));
+
      return blocked_sum;
    }
 


### PR DESCRIPTION
Previously the passed in graph was ignored. This lead to problems
if you believed the data was being reused and also was a potential
performance issue

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/teko 

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->
<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
