### PR TITLE
Pamgen: Adding parse error (rather than segfault) if you put two geometries in one mesh

### DIFF
--- a/packages/pamgen/example/pamgen_test_driver.c
+++ b/packages/pamgen/example/pamgen_test_driver.c
@@ -243,7 +243,7 @@ int main(int argc, char** argv)
   fclose(infile);
 
   /*create the out_file_name*/
-  out_file_name = (char*)malloc(MAX_STR_LENGTH+1);
+  out_file_name = (char*)malloc(MAX_STR_LENGTH+100);
 
   for( rank = start_rank; rank != end_rank; rank ++){
     int cr_result;

--- a/packages/pamgen/parser/parser.C
+++ b/packages/pamgen/parser/parser.C
@@ -2,6 +2,7 @@
 
 #include "keyword.h"
 #include "parser.h"
+#include "parse_routines.h"
 
 #include <sstream>
 #include <ctype.h>
@@ -11,8 +12,8 @@
 #include <assert.h>
 #include <cstdlib>
 #include <iostream>
-using namespace std;
 
+using namespace std;
 
 namespace PAMGEN_NEVADA {
 
@@ -74,6 +75,7 @@ int Parse( Token_Stream *token_stream,
     token_stream->Set_Recovery_Flag(false);
     assert(match->func != 0);
     token_stream->pushNewInputBlock( match->name );
+    Allow_New_Mesh_Specification();
     match->func(token_stream, match->argument);
     token_stream->popInputBlock();
   }

--- a/packages/pamgen/src/parse_routines.C
+++ b/packages/pamgen/src/parse_routines.C
@@ -76,6 +76,8 @@ namespace PAMGEN_NEVADA {
   static long long sdimension;
   static long long * parse_error_count = NULL;
 
+  static bool has_specified_geometry_type;
+
 
   //This takes an integer and returns it in an English representation
   std::string EnglishNumber(long long the_number) {
@@ -163,6 +165,7 @@ namespace PAMGEN_NEVADA {
 
     Token_Stream token_stream(input_stream, Inline_Mesh_Desc::echo_stream, input_tree,0,0,true);
 
+    has_specified_geometry_type = false;
     PAMGEN_NEVADA::Parse(&token_stream,parse_table,TK_EXIT);
 
     if(!Inline_Mesh_Desc::im_static_storage) {
@@ -278,6 +281,7 @@ namespace PAMGEN_NEVADA {
     Token token;
     long long block_index = 0;
     long long cubit_axis = 0;
+    bool geometry_spec_error = false;
     {
 
       token = token_stream->Shift();
@@ -286,34 +290,42 @@ namespace PAMGEN_NEVADA {
       if(mesh_type == "RECTILINEAR" || mesh_type == "2DR" || mesh_type == "3DR" || mesh_type == "2DC"){
         Inline_Mesh_Desc::addDisc( new Cartesian_Inline_Mesh_Desc(sdimension ));
         Inline_Mesh_Desc::im_static_storage->inline_geometry_type = INLINE_CARTESIAN;
+        if(has_specified_geometry_type) geometry_spec_error = true; else has_specified_geometry_type = true;
       }
       else if(mesh_type == "SPHERICAL"){
         Inline_Mesh_Desc::addDisc( new Spherical_Inline_Mesh_Desc(sdimension ));
         Inline_Mesh_Desc::im_static_storage->inline_geometry_type = INLINE_SPHERICAL;
+        if(has_specified_geometry_type) geometry_spec_error = true; else has_specified_geometry_type = true;
       }
       else if(mesh_type == "CYLINDRICAL"){
         Inline_Mesh_Desc::addDisc( new Cylindrical_Inline_Mesh_Desc(sdimension ));
         Inline_Mesh_Desc::im_static_storage->inline_geometry_type = INLINE_CYLINDRICAL;
+        if(has_specified_geometry_type) geometry_spec_error = true; else has_specified_geometry_type = true;
       }
       else if(mesh_type == "CUBIT RADIAL"){
         Inline_Mesh_Desc::addDisc( new Radial_Inline_Mesh_Desc(sdimension ));
         Inline_Mesh_Desc::im_static_storage->inline_geometry_type = RADIAL;
+        if(has_specified_geometry_type) geometry_spec_error = true; else has_specified_geometry_type = true;
       }
       else if(mesh_type == "RADIAL"){
         Inline_Mesh_Desc::addDisc( new Radial_Inline_Mesh_Desc(sdimension ));
         Inline_Mesh_Desc::im_static_storage->inline_geometry_type = RADIAL;
+        if(has_specified_geometry_type) geometry_spec_error = true; else has_specified_geometry_type = true;
       }
       else if(mesh_type == "BRICK"){
         Inline_Mesh_Desc::addDisc( new Brick_Inline_Mesh_Desc(sdimension ));
         Inline_Mesh_Desc::im_static_storage->inline_geometry_type = RADIAL;
+        if(has_specified_geometry_type) geometry_spec_error = true; else has_specified_geometry_type = true;
       }
       else if(mesh_type == "CUBIT RADIAL TRISECTION"){
         Inline_Mesh_Desc::addDisc( new Radial_Trisection_Inline_Mesh_Desc(sdimension ));
         Inline_Mesh_Desc::im_static_storage->inline_geometry_type = RADIAL_TRISECTION;
+        if(has_specified_geometry_type) geometry_spec_error = true; else has_specified_geometry_type = true;
       }
       else if(mesh_type == "RADIAL TRISECTION"){
         Inline_Mesh_Desc::addDisc( new Radial_Trisection_Inline_Mesh_Desc(sdimension ));
         Inline_Mesh_Desc::im_static_storage->inline_geometry_type = RADIAL_TRISECTION;
+        if(has_specified_geometry_type) geometry_spec_error = true; else has_specified_geometry_type = true;
       }
       else if(mesh_type == "SET ASSIGN"){
       }
@@ -336,6 +348,9 @@ namespace PAMGEN_NEVADA {
       }
     }
 
+    if(geometry_spec_error) 
+      token_stream->Parse_Error("incorrect keyword ",
+                                "cannot specify more than one geometry type in a single mesh object");
 
     Keyword parameter_table[] = {
       {"STARTING BLOCK ID OFFSET", P_STARTING_BLOCK_NUMBER, Get_Real_Token},

--- a/packages/pamgen/src/parse_routines.C
+++ b/packages/pamgen/src/parse_routines.C
@@ -75,9 +75,9 @@ namespace PAMGEN_NEVADA {
 
   static long long sdimension;
   static long long * parse_error_count = NULL;
+  static bool has_specified_geometry_type=false;
 
-  static bool has_specified_geometry_type;
-
+  void Allow_New_Mesh_Specification(){ has_specified_geometry_type=false;}
 
   //This takes an integer and returns it in an English representation
   std::string EnglishNumber(long long the_number) {
@@ -144,8 +144,8 @@ namespace PAMGEN_NEVADA {
     /****************************************************************************/
   {
     // makes this a noop if an Inline_Mesh_Desc has alread been created.
-    if(Inline_Mesh_Desc::im_static_storage)return Inline_Mesh_Desc::im_static_storage;
-
+    if(Inline_Mesh_Desc::im_static_storage) return Inline_Mesh_Desc::im_static_storage;
+    Allow_New_Mesh_Specification();
 
     sdimension = incoming_dim;
     parse_error_count = & sparse_error_count;
@@ -165,7 +165,6 @@ namespace PAMGEN_NEVADA {
 
     Token_Stream token_stream(input_stream, Inline_Mesh_Desc::echo_stream, input_tree,0,0,true);
 
-    has_specified_geometry_type = false;
     PAMGEN_NEVADA::Parse(&token_stream,parse_table,TK_EXIT);
 
     if(!Inline_Mesh_Desc::im_static_storage) {
@@ -283,7 +282,6 @@ namespace PAMGEN_NEVADA {
     long long cubit_axis = 0;
     bool geometry_spec_error = false;
     {
-
       token = token_stream->Shift();
       std::string mesh_type = token.As_String();
 
@@ -348,9 +346,11 @@ namespace PAMGEN_NEVADA {
       }
     }
 
-    if(geometry_spec_error) 
+    if(geometry_spec_error)  {
       token_stream->Parse_Error("incorrect keyword ",
                                 "cannot specify more than one geometry type in a single mesh object");
+    }
+
 
     Keyword parameter_table[] = {
       {"STARTING BLOCK ID OFFSET", P_STARTING_BLOCK_NUMBER, Get_Real_Token},

--- a/packages/pamgen/src/parse_routines.C
+++ b/packages/pamgen/src/parse_routines.C
@@ -168,12 +168,12 @@ namespace PAMGEN_NEVADA {
     PAMGEN_NEVADA::Parse(&token_stream,parse_table,TK_EXIT);
 
     if(!Inline_Mesh_Desc::im_static_storage) {
-      free(parse_table);
+      delete parse_table;
       return Inline_Mesh_Desc::im_static_storage;
     }
 
     if(token_stream.Error_Count() != 0) {
-      free(parse_table);
+      delete parse_table;
       return NULL;
     }
 

--- a/packages/pamgen/src/parse_routines.h
+++ b/packages/pamgen/src/parse_routines.h
@@ -8,6 +8,9 @@ Token Parse_Topology_Modification(Token_Stream *token_stream, int);
 Token Parse_Inline_Mesh_Tok(Token_Stream *token_stream, int value);
 Token Parse_Inline_Mesh_3D_Tok(Token_Stream *token_stream, int value);
 Token Parse_Inline_Mesh_2D_Tok(Token_Stream *token_stream, int value);
+
+void Allow_New_Mesh_Specification();
+
 }//end of namespace PAMGEN_NEVADA
 #define parse_routinesH
 #endif


### PR DESCRIPTION
Auto-PR for SHA bd75711