### PR TITLE
Fix waterman/all_supported_builds.sh list

### DIFF
--- a/cmake/std/atdm/waterman/all_supported_builds.sh
+++ b/cmake/std/atdm/waterman/all_supported_builds.sh
@@ -4,6 +4,6 @@ export ATDM_CONFIG_ALL_SUPPORTED_BUILDS=(
   cuda-9.2-debug
   cuda-9.2-opt
   cuda-9.2-release-debug
-  gnu-debug-openmp
+  gnu-opt-openmp
   gnu-release-debug-openmp
   )


### PR DESCRIPTION
The supported build is gnu-opt-openmp not gnu-debug-openmp.
