### PR TITLE
Stratimikos Xpetra adapter: Remove superfluous copy in apply

### DIFF
--- a/packages/muelu/adapters/stratimikos/Thyra_XpetraLinearOp_def.hpp
+++ b/packages/muelu/adapters/stratimikos/Thyra_XpetraLinearOp_def.hpp
@@ -197,12 +197,6 @@ void XpetraLinearOp<Scalar,LocalOrdinal,GlobalOrdinal,Node>::applyImpl(
     rgMapExtractor = bA->getRangeMapExtractor();
     TEUCHOS_TEST_FOR_EXCEPT(Teuchos::is_null(rgMapExtractor));
   }
-
-  // copy back Xpetra results from tY to Thyra vector Y
-  Xpetra::ThyraUtils<Scalar,LocalOrdinal,GlobalOrdinal,Node>::updateThyra(
-      tY_inout,
-      rgMapExtractor,
-      Teuchos::rcpFromPtr(Y_inout));
 }
 
 


### PR DESCRIPTION
@trilinos/muelu 

## Description
Remove an unneeded copy in the apply of `Thyra::XpetraLinearOp`. As far as I can see, we are copying data inplace. Taking this statement out seems to work. Let's see what the autotester thinks..