### PR TITLE
Kokkos: Allow for types with non-trivial constructors in Kokkos_Atomic*

### DIFF
--- a/packages/kokkos/core/src/impl/Kokkos_Atomic_Fetch_Sub.hpp
+++ b/packages/kokkos/core/src/impl/Kokkos_Atomic_Fetch_Sub.hpp
@@ -89,7 +89,11 @@ __inline__ __device__
 T atomic_fetch_sub( volatile T * const dest ,
   typename Kokkos::Impl::enable_if< sizeof(T) == sizeof(int) , const T >::type val )
 {
-  union { int i ; T t ; } oldval , assume , newval ;
+  union U {
+    int i ;
+    T t ;
+    KOKKOS_INLINE_FUNCTION U() {}
+  } oldval , assume , newval ;
 
   oldval.t = *dest ;
 
@@ -108,7 +112,11 @@ T atomic_fetch_sub( volatile T * const dest ,
   typename Kokkos::Impl::enable_if< sizeof(T) != sizeof(int) &&
                                     sizeof(T) == sizeof(unsigned long long int) , const T >::type val )
 {
-  union { unsigned long long int i ; T t ; } oldval , assume , newval ;
+  union U {
+    unsigned long long int i ;
+    T t ;
+    KOKKOS_INLINE_FUNCTION U() {}
+  } oldval , assume , newval ;
 
   oldval.t = *dest ;
 
@@ -211,7 +219,11 @@ inline
 T atomic_fetch_sub( volatile T * const dest ,
   typename Kokkos::Impl::enable_if< sizeof(T) == sizeof(int) , const T >::type val )
 {
-  union { int i ; T t ; } assume , oldval , newval ;
+  union U {
+    int i ;
+    T t ;
+    KOKKOS_INLINE_FUNCTION U() {}
+  } oldval , assume , newval ;
 
 #if defined( KOKKOS_ENABLE_RFO_PREFETCH )
   _mm_prefetch( (const char*) dest, _MM_HINT_ET0 );
@@ -238,7 +250,11 @@ T atomic_fetch_sub( volatile T * const dest ,
   _mm_prefetch( (const char*) dest, _MM_HINT_ET0 );
 #endif
 
-  union { long i ; T t ; } assume , oldval , newval ;
+  union U {
+     long i ;
+     T t ;
+     KOKKOS_INLINE_FUNCTION U() {}
+   } oldval , assume , newval ;
 
   oldval.t = *dest ;
 

--- a/packages/kokkos/core/src/impl/Kokkos_Atomic_Generic.hpp
+++ b/packages/kokkos/core/src/impl/Kokkos_Atomic_Generic.hpp
@@ -156,7 +156,11 @@ T atomic_fetch_oper( const Oper& op, volatile T * const dest ,
   typename Kokkos::Impl::enable_if< sizeof(T) != sizeof(int) &&
                                     sizeof(T) == sizeof(unsigned long long int) , const T >::type val )
 {
-  union { unsigned long long int i ; T t ; } oldval , assume , newval ;
+  union U {
+    unsigned long long int i ;
+    T t ;
+    KOKKOS_INLINE_FUNCTION U() {}
+  } oldval , assume , newval ;
 
   oldval.t = *dest ;
 
@@ -175,7 +179,11 @@ T atomic_oper_fetch( const Oper& op, volatile T * const dest ,
   typename Kokkos::Impl::enable_if< sizeof(T) != sizeof(int) &&
                                     sizeof(T) == sizeof(unsigned long long int) , const T >::type val )
 {
-  union { unsigned long long int i ; T t ; } oldval , assume , newval ;
+  union U {
+    unsigned long long int i ;
+    T t ;
+    KOKKOS_INLINE_FUNCTION U() {}
+  } oldval , assume , newval ;
 
   oldval.t = *dest ;
 
@@ -193,7 +201,11 @@ KOKKOS_INLINE_FUNCTION
 T atomic_fetch_oper( const Oper& op, volatile T * const dest ,
   typename Kokkos::Impl::enable_if< sizeof(T) == sizeof(int) , const T >::type val )
 {
-  union { int i ; T t ; } oldval , assume , newval ;
+  union U {
+    int i ;
+    T t ;
+    KOKKOS_INLINE_FUNCTION U() {}
+  } oldval , assume , newval ;
 
   oldval.t = *dest ;
 
@@ -211,7 +223,11 @@ KOKKOS_INLINE_FUNCTION
 T atomic_oper_fetch( const Oper& op, volatile T * const dest ,
   typename Kokkos::Impl::enable_if< sizeof(T) == sizeof(int), const T >::type val )
 {
-  union { int i ; T t ; } oldval , assume , newval ;
+  union U {
+    int i ;
+    T t ;
+    KOKKOS_INLINE_FUNCTION U() {}
+  } oldval , assume , newval ;
 
   oldval.t = *dest ;
 


### PR DESCRIPTION
@trilinos/kokkos

## Description
This pull request mirrors https://github.com/kokkos/kokkos/pull/1997.
In particular, some of the `Kokkos::atomic_*` could not be used for types with a non-trivial default constructor.

## Motivation and Context
This change is required to allow using the respective functions with, e.g. `std::complex<float>`.

## Related Issues
Fixed https://github.com/kokkos/kokkos/issues/1964.

## How Has This Been Tested?
The changes were tested in https://github.com/kokkos/kokkos/pull/1997  and compiling [deal.II](https://github.com/dealii/dealii/) with `CUDA` support in `Trilinos` and `complex` scalar types proceeds further.

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.