### PR TITLE
Disable Panzer in clang-5.0.1 build for now (#4486)

### DIFF
--- a/cmake/ctest/drivers/atdm/cee-rhel6/drivers/Trilinos-atdm-cee-rhel6_clang-5.0.1_openmpi-1.10.2_serial_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/cee-rhel6/drivers/Trilinos-atdm-cee-rhel6_clang-5.0.1_openmpi-1.10.2_serial_static_opt.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
-export Trilinos_TRACK=ATDM
+if [ "${Trilinos_TRACK}" == "" ]; then
+  export Trilinos_TRACK=ATDM
+fi
+export Trilinos_EXCLUDE_PACKAGES=Panzer
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cee-rhel6/local-driver.sh


### PR DESCRIPTION
Temporary mitigation for #4486 

These Panzer build failures are bring down the SPARC Trilinos Integration
testing since they seem to be causing the install of Trilinos to not occur and
therefore the clang-5.0.1 build of SPARC can't pick this up.  Therefore, these
build failures have taking out SPARC Trilinos Integration testing.  Since
SPARC does not use Panzer and EMPIRE does not build with clang-5.0.1 on CEE
RHEL6, disabling Panzer in this build does not harm anything (other than
disabling the only automated clang testing of Panzer).

Once the build failures can be fixed, we can re-enable this.

I tested this on 'ceerws1113' using:

```
$ ./ctest-s-local-test-driver-cee-rhel6.sh cee-rhel6_clang-5.0.1_openmpi-1.10.2_serial_static_opt
```

which posed the configure to CDash shown [here](https://testing.sandia.gov/cdash-dev-view/viewConfigure.php?buildid=4615067) which showed:

```
Final set of non-enabled packages:  ... Panzer ... 21
```
