### PR TITLE
Change memory request from 1.7G per cpu to 1.8G

### DIFF
--- a/cmake/std/PullRequestLinuxDriver-Test.sh
+++ b/cmake/std/PullRequestLinuxDriver-Test.sh
@@ -349,11 +349,11 @@ weight=${JENKINS_JOB_WEIGHT:-29}
 n_cpu=$(lscpu | grep "^CPU(s):" | cut -d" " -f17)
 n_K=$(cat /proc/meminfo | grep MemTotal | cut -d" " -f8)
 let n_G=$n_K/1024000
-# this is aimed at keeping approximately 1.7G per core so we don't bottleneck
+# this is aimed at keeping approximately 1.8G per core so we don't bottleneck
 ## weight - the next bit works because the shell is only doing integer arithmetic
 let n_jobs=${n_cpu}/${weight}
 # using bc to get floating point input and integer output
-parallel_level=$(echo "$n_G/( 1.7*$n_jobs )" | bc )
+parallel_level=$(echo "$n_G/( 1.8*$n_jobs )" | bc )
 
 if [ ${parallel_level} -gt ${weight} ]; then
     parallel_level=${weight}


### PR DESCRIPTION
@trilinos/framework 

## Motivation and Context
This should help with the occasional failures on the 141-4 series.

