### PR TITLE
Allow Panzer testing in cee-rhel6 clang-5.0.1 build

### DIFF
--- a/cmake/ctest/drivers/atdm/cee-rhel6/drivers/Trilinos-atdm-cee-rhel6_clang-5.0.1_openmpi-1.10.2_serial_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/cee-rhel6/drivers/Trilinos-atdm-cee-rhel6_clang-5.0.1_openmpi-1.10.2_serial_static_opt.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
+
 if [ "${Trilinos_TRACK}" == "" ]; then
   export Trilinos_TRACK=ATDM
 fi
-export Trilinos_EXCLUDE_PACKAGES=Panzer
+
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cee-rhel6/local-driver.sh


### PR DESCRIPTION
Allow the enable of Panzer that was removed in commit  cb0da4ae99b539dedc176cd14038fbea182150c7 (see addresses #4486).

Panzer now builds and passes tests.

I tested this with on 'ceerws1113' with:

```
$ ./checkin-test-atdm-cee-rhel6.sh cee-rhel6_clang-5.0.1_openmpi-1.10.2_serial_static_opt  \
    --enable-packages=Panzer --local-do-all
```

which returned:

```
PASSED (NOT READY TO PUSH): Trilinos: ceerws1113

Tue Feb 26 15:00:10 MST 2019

Enabled Packages: Panzer

Build test results:
-------------------
1) cee-rhel6_clang-5.0.1_openmpi-1.10.2_serial_static_opt => passed: passed=173,notpassed=0 (24.69 min)
```
