### PR TITLE
Add some CUDA RDC shared builds (#2598, TRIL-262)

### DIFF
--- a/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-rdc-shared-release-debug-pt.sh
+++ b/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-rdc-shared-release-debug-pt.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+if [ "${Trilinos_TRACK}" == "" ] ; then
+  export Trilinos_TRACK=Specialized
+fi
+export ATDM_CONFIG_ENABLE_ALL_PACKAGES=TRUE
+#export Trilinos_ENABLE_SECONDARY_TESTED_CODE=OFF
+export ATDM_CONFIG_CONFIGURE_OPTIONS_FILES=cmake/std/atdm/ATDMDevEnvAllPtPackages.cmake
+export Trilinos_CTEST_DO_ALL_AT_ONCE=TRUE
+$WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ride/local-driver.sh

--- a/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-rdc-shared-release-debug.sh
+++ b/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-rdc-shared-release-debug.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+if [ "${Trilinos_TRACK}" == "" ] ; then
+  export Trilinos_TRACK=Specialized
+fi
+$WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ride/local-driver.sh

--- a/cmake/ctest/drivers/atdm/waterman/drivers/Trilinos-atdm-waterman-cuda-9.2-rdc-shared-release-debug.sh
+++ b/cmake/ctest/drivers/atdm/waterman/drivers/Trilinos-atdm-waterman-cuda-9.2-rdc-shared-release-debug.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+if [ "${Trilinos_TRACK}" == "" ] ; then
+  export Trilinos_TRACK=Specialized
+fi
+$WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/waterman/local-driver.sh


### PR DESCRIPTION
Related to #2598, #4501, #4502 

Since SPARC does shared CUDA builds, adding these builds makes sense.  There
is also some hope this will fix some of the link errors.

I tested this as described below.

On 'ride' I ran:

```
$ env ./ctest-s-local-test-driver.sh cuda-9.2-gnu-7.2.0-rdc-shared-release-debug-pt

***
*** ./ctest-s-local-test-driver.sh  cuda-9.2-gnu-7.2.0-rdc-shared-release-debug-pt
***

ATDM_TRILINOS_DIR = '/home/rabartl/Trilinos.base/Trilinos'

Load some env to get python, cmake, etc ...

Hostname 'ride6' matches known ATDM host 'ride' and system 'ride'
Setting compiler and build options for buld name 'default'
Using white/ride compiler stack GNU-7.2.0 to build DEBUG code with Kokkos node type SERIAL and KOKKOS_ARCH=Power8

Running builds: cuda-9.2-gnu-7.2.0-rdc-shared-release-debug-pt

Running Jenkins driver Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-rdc-shared-release-debug-pt.sh ...


real    217m17.182s
user    0m0.887s
sys     0m0.389s
```

This posted results to:

* https://testing.sandia.gov/cdash-dev-view/index.php?project=Trilinos&parentid=4633667

This showed build errors in the packages Kokkos, KokkosKernels, Sacado, ShyLU_Node, Intrepid, and Intrepid2.

On 'waterman' I ran:

```
$ ./ctest-s-local-test-driver.sh cuda-9.2-rdc-shared-release-debug

***
*** ./ctest-s-local-test-driver.sh  cuda-9.2-rdc-shared-release-debug
***

ATDM_TRILINOS_DIR = '/home/rabartl/Trilinos.base/Trilinos'

Load some env to get python, cmake, etc ...

Hostname 'waterman11' matches known ATDM host 'waterman' and system 'waterman'
Setting compiler and build options for buld name 'default'
Using waterman compiler stack GNU to build DEBUG code with Kokkos node type SERIAL and KOKKOS_ARCH=Power9

Running builds: cuda-9.2-rdc-shared-release-debug

Running Jenkins driver Trilinos-atdm-waterman-cuda-9.2-rdc-shared-release-debug.sh ...

Creating directory: Trilinos-atdm-waterman-cuda-9.2-rdc-shared-release-debug
Creating directory: SRC_AND_BUILD

real    110m18.727s
user    0m4.590s
sys     0m6.070s
```

This posted results to:

* https://testing.sandia.gov/cdash-dev-view/index.php?project=Trilinos&parentid=4636618

This showed build errors in libraries in Kokkos, KokkosKernels, Sacado, and Intrepid2.
