### PR TITLE
Remove testing of gnu-6.1.0 builds and make gnu-7.2.0 the default (TRIL-263)

### DIFF
--- a/cmake/std/atdm/sems-rhel6/all_supported_builds.sh
+++ b/cmake/std/atdm/sems-rhel6/all_supported_builds.sh
@@ -3,10 +3,6 @@
 export ATDM_CONFIG_CTEST_S_BUILD_NAME_PREFIX=Trilinos-atdm-
 
 export ATDM_CONFIG_ALL_SUPPORTED_BUILDS=(
-  sems-rhel6-gnu-6.1.0-openmp-debug
-  sems-rhel6-gnu-6.1.0-openmp-release
-  sems-rhel6-gnu-6.1.0-serial-debug
-  sems-rhel6-gnu-6.1.0-serial-release
   sems-rhel6-gnu-7.2.0-openmp-debug
   sems-rhel6-gnu-7.2.0-openmp-release
   sems-rhel6-gnu-7.2.0-openmp-release-debug

--- a/cmake/std/atdm/sems-rhel6/environment.sh
+++ b/cmake/std/atdm/sems-rhel6/environment.sh
@@ -11,7 +11,7 @@
 #
 
 if [ "$ATDM_CONFIG_COMPILER" == "DEFAULT" ] ; then
-  export ATDM_CONFIG_COMPILER=GNU-6.1.0
+  export ATDM_CONFIG_COMPILER=GNU-7.2.0
 elif [[ "$ATDM_CONFIG_COMPILER" == "CLANG"* ]]; then
   if [[ "$ATDM_CONFIG_COMPILER" == "CLANG" ]] ; then
     export ATDM_CONFIG_COMPILER=CLANG-3.9.0
@@ -27,7 +27,7 @@ elif [[ "$ATDM_CONFIG_COMPILER" == "CLANG"* ]]; then
   fi
 elif [[ "$ATDM_CONFIG_COMPILER" == "GNU"* ]]; then
   if [[ "$ATDM_CONFIG_COMPILER" == "GNU" ]] ; then
-    export ATDM_CONFIG_COMPILER=GNU-6.1.0
+    export ATDM_CONFIG_COMPILER=GNU-7.2.0
   elif [[ "$ATDM_CONFIG_COMPILER" != "GNU-6.1.0" ]] &&
     [[ "$ATDM_CONFIG_COMPILER" != "GNU-7.2.0" ]] ; then
     echo


### PR DESCRIPTION
None of the ATDM APPs need support for gnu-6.1.0 anymore. They are all using
gnu-7.2.0.  See [TRIL-263](https://sems-atlassian-son.sandia.gov/jira/browse/TRIL-263).

Now the default compiler and the default gnu compiler are gnu-7.2.0 on
'sems-rhel6'.

I tested this on my machine 'crf450' with:

```
$ ./checkin-test-atdm.sh all --enable-packages=Kokkos,Teuchos --local-do-all
```

and it returned:

```
PASSED (NOT READY TO PUSH): Trilinos: crf450.srn.sandia.gov

Mon Mar  4 09:26:54 MST 2019

Enabled Packages: Kokkos, Teuchos

Build test results:
-------------------
1) sems-rhel6-gnu-7.2.0-openmp-debug => passed: passed=164,notpassed=0 (1.55 min)
2) sems-rhel6-gnu-7.2.0-openmp-release => passed: passed=164,notpassed=0 (0.41 min)
3) sems-rhel6-gnu-7.2.0-openmp-release-debug => passed: passed=164,notpassed=0 (0.44 min)
4) sems-rhel6-gnu-7.2.0-openmp-complex-shared-release-debug => passed: passed=164,notpassed=0 (0.48 min)
5) sems-rhel6-intel-17.0.1-openmp-release => passed: passed=164,notpassed=0 (0.85 min)
```


