### PR TITLE
TriUtils: modifying CMakeLists.txt to avoid undefined reference with Epetra=OFF

### DIFF
--- a/packages/triutils/src/CMakeLists.txt
+++ b/packages/triutils/src/CMakeLists.txt
@@ -38,7 +38,6 @@ SET(SOURCES ${SOURCES}
   Trilinos_Util_scscres.cpp
   Trilinos_Util_smsrres.cpp
   Trilinos_Util_ssrcsr.cpp
-  Trilinos_Util_svbrres.cpp
   Trilinos_Util_write_vec.cpp
 )
 
@@ -60,10 +59,11 @@ IF (${PACKAGE_NAME}_ENABLE_Epetra)
   )
 
   SET(SOURCES ${SOURCES}
-    Trilinos_Util_distrib_vbr_matrix.cpp
-    Trilinos_Util_dusmm.cpp
     Trilinos_Util_create_vbr.cpp
     Trilinos_Util_distrib_msr_matrix.cpp
+    Trilinos_Util_distrib_vbr_matrix.cpp
+    Trilinos_Util_dusmm.cpp
+    Trilinos_Util_svbrres.cpp
     Trilinos_Util_ReadMatrixMarket2Epetra.cpp
     Trilinos_Util_ReadTriples2Epetra.cpp
     Trilinos_Util_CountMatrixMarket.cpp


### PR DESCRIPTION
@trilinos/triutils 

## Description
Moving Trilinos_Util_svbrres.cpp into the list of objects to be built only when Epetra is enabled due to its dependence on Trilinos_Util_dusmm.cpp (there is call to DGEMM that triggers this dependence).

## Motivation and Context
When building trilinos with Epetra=OFF the linker errors because of an undefined reference to `Trilinos_Util_dusmm`

## Related Issues

* Follows #4386

## How Has This Been Tested?
A local build with Epetra=OFF has been successful

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.