### PR TITLE
MueLu: modifying included file in hhg driver

### DIFF
--- a/packages/muelu/research/mmayr/hhg/Xpetra_RegionMatrix_decl.hpp
+++ b/packages/muelu/research/mmayr/hhg/Xpetra_RegionMatrix_decl.hpp
@@ -2,7 +2,7 @@
 #define XPETRA_REGION_MATRIX_DECL_HPP_
 
 //Ifpack2
-#include "Ifpack2_OverlappingRowMatrix_def.hpp"
+#include "Ifpack2_OverlappingRowMatrix.hpp"
 
 //MueLu
 #include <MueLu_Utilities.hpp>


### PR DESCRIPTION
@trilinos/muelu 

## Description
Ifpack2 requires to either include both Ifpack2_OverlappingRowMatrix_decl.hpp and Ifpack2_OverlappingRowMatrix_def.hpp or simply Ifpack2_OverlappingRowMatrix.hpp that is generated during ETI.
I am going with the second option but the first one might be more robust when ETI is OFF?

## Motivation and Context
The current code does not compile properly because of this bug

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 

## How Has This Been Tested?
A local build triggering the defect has been performed and after the modification is applied the defect is resolved.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.