### PR TITLE
Belos: Fix #4544

### DIFF
--- a/packages/belos/tpetra/src/Belos_Details_Tpetra_registerSolverFactory.cpp
+++ b/packages/belos/tpetra/src/Belos_Details_Tpetra_registerSolverFactory.cpp
@@ -60,6 +60,17 @@
 #include "BelosRCGSolMgr.hpp"
 #include "BelosTFQMRSolMgr.hpp"
 
+namespace BelosTpetra {
+namespace Impl {
+
+extern void register_CgPipeline (const bool verbose);
+extern void register_CgSingleReduce (const bool verbose);
+extern void register_GmresPipeline (const bool verbose);
+extern void register_GmresSingleReduce (const bool verbose);
+  
+} // namespace Impl
+} // namespace BelosTpetra  
+
 #include "TpetraCore_ETIHelperMacros.h"
 TPETRA_ETI_MANGLING_TYPEDEFS()
 
@@ -68,6 +79,11 @@ namespace Details {
 namespace Tpetra {
 
 void registerSolverFactory() {
+  ::BelosTpetra::Impl::register_CgPipeline (false);
+  ::BelosTpetra::Impl::register_CgSingleReduce (false);
+  ::BelosTpetra::Impl::register_GmresPipeline (false);
+  ::BelosTpetra::Impl::register_GmresSingleReduce (false);
+  
   #define BELOS_LCL_CALL_FOR_MANAGER(manager,name,SC, LO, GO, NT)   \
     Impl::registerSolverSubclassForTypes<                           \
       manager<SC,::Tpetra::MultiVector<SC, LO, GO, NT>,             \

--- a/packages/belos/tpetra/test/Native/diagonal_matrix.cpp
+++ b/packages/belos/tpetra/test/Native/diagonal_matrix.cpp
@@ -288,12 +288,8 @@ TEUCHOS_UNIT_TEST( TpetraNativeSolvers, Diagonal )
 namespace BelosTpetra {
 namespace Impl {
   extern void register_Cg (const bool verbose);
-  extern void register_CgPipeline (const bool verbose);
-  extern void register_CgSingleReduce (const bool verbose);
   extern void register_Gmres (const bool verbose);
   extern void register_GmresS (const bool verbose);  
-  extern void register_GmresPipeline (const bool verbose);  
-  extern void register_GmresSingleReduce (const bool verbose);
   extern void register_GmresSstep (const bool verbose);    
 } // namespace Impl
 } // namespace BelosTpetra
@@ -304,12 +300,8 @@ int main (int argc, char* argv[])
 
   constexpr bool verbose = false;
   BelosTpetra::Impl::register_Cg (verbose);
-  BelosTpetra::Impl::register_CgPipeline (verbose);
-  BelosTpetra::Impl::register_CgSingleReduce (verbose);
   BelosTpetra::Impl::register_Gmres (verbose);
-  BelosTpetra::Impl::register_GmresPipeline (verbose);
   BelosTpetra::Impl::register_GmresS (verbose);
-  BelosTpetra::Impl::register_GmresSingleReduce (verbose);
   BelosTpetra::Impl::register_GmresSstep (verbose);
   return Teuchos::UnitTestRepository::runUnitTestsFromMain (argc, argv);
 }

--- a/packages/belos/tpetra/test/Native/nonsymm_matrix.cpp
+++ b/packages/belos/tpetra/test/Native/nonsymm_matrix.cpp
@@ -316,12 +316,8 @@ TEUCHOS_UNIT_TEST( TpetraNativeSolvers, Diagonal )
 namespace BelosTpetra {
 namespace Impl {
   // extern void register_Cg (const bool verbose);
-  // extern void register_CgPipeline (const bool verbose);
-  // extern void register_CgSingleReduce (const bool verbose);
   extern void register_Gmres (const bool verbose);
-  extern void register_GmresPipeline (const bool verbose);
   extern void register_GmresS (const bool verbose);
-  extern void register_GmresSingleReduce (const bool verbose);
   extern void register_GmresSstep (const bool verbose);
 } // namespace Impl
 } // namespace BelosTpetra
@@ -332,12 +328,8 @@ int main (int argc, char* argv[])
 
   constexpr bool verbose = false;
   // BelosTpetra::Impl::register_Cg (verbose);
-  // BelosTpetra::Impl::register_CgPipeline (verbose);
-  // BelosTpetra::Impl::register_CgSingleReduce (verbose);
   BelosTpetra::Impl::register_Gmres (verbose);
-  BelosTpetra::Impl::register_GmresPipeline (verbose);
   BelosTpetra::Impl::register_GmresS (verbose);
-  BelosTpetra::Impl::register_GmresSingleReduce (verbose);
   BelosTpetra::Impl::register_GmresSstep (verbose);
   return Teuchos::UnitTestRepository::runUnitTestsFromMain (argc, argv);
 }


### PR DESCRIPTION
@trilinos/belos @jhux2 @iyamazaki 

Make sure that the new (pipelined and communication-avoiding) Tpetra-specific solvers get registered (at run time) with `Belos::SolverFactory`.  Once this change lands, we will be able to remove that registration from Nalu.  (Registration is idempotent; double registration is harmless.)