### PR TITLE
Amesos2: pardiso fixes

### DIFF
--- a/packages/amesos2/src/Amesos2_PardisoMKL_FunctionMap.hpp
+++ b/packages/amesos2/src/Amesos2_PardisoMKL_FunctionMap.hpp
@@ -67,7 +67,10 @@
 namespace Amesos2 {
 
   namespace PMKL {
-#   include "mkl_pardiso.h"
+    #ifdef __MKL_PARDISO_H
+      #undef __MKL_PARDISO_H
+    #endif
+    #include "mkl_pardiso.h"
   }
 
   /** \internal

--- a/packages/amesos2/src/Amesos2_PardisoMKL_TypeMap.hpp
+++ b/packages/amesos2/src/Amesos2_PardisoMKL_TypeMap.hpp
@@ -72,8 +72,14 @@ namespace Amesos2{
     //Update JDB 6.25.15
     //MKL has changed _INTEGER_t to deprecated
     //MKL has changed _INTEGER_t to define from typedef 
-    #include <mkl_dss.h>
+  #ifdef _MKL_TYPES_H_
+    #undef _MKL_TYPES_H_
+  #endif
     #include <mkl_types.h>
+  #ifdef __MKL_DSS_H
+    #undef __MKL_DSS_H
+  #endif
+    #include <mkl_dss.h>
     #undef _INTEGER_t
     typedef MKL_INT _INTEGER_t;
   } // end namespace PMKL
@@ -87,6 +93,7 @@ namespace Amesos2{
  * template specializations of the Teuchos::ValueTypeConversionTraits
  * class.
  */
+#ifdef HAVE_TEUCHOS_COMPLEX
 namespace Teuchos {
 
   template <typename TypeFrom>
@@ -181,7 +188,7 @@ namespace Teuchos {
   //@}  End Conversion group
 
 } // end namespace Teuchos
-
+#endif
 
 namespace Amesos2 {
 
@@ -193,6 +200,7 @@ namespace Amesos2 {
    * Additional nested types may be added without harm.  For an example, look at
    * Amesos2_Superlu_TypeMap.hpp
    */
+
   template <>
   struct TypeMap<PardisoMKL,float>
   {


### PR DESCRIPTION
Addresses issue #4458

@trilinos/amesos2 


## How Has This Been Tested?

Tested on blake testbed

### configuration

`module load cmake/3.12.3 intel/compilers/18.1.163 openmpi/2.1.2/intel/18.1.163`
`salloc -N 1`

```
TRILINOS_DIR=${PWD}/../..
TRILINOSINSTALLDIR=${PWD}/install
BUILDTYPE=release

rm -f CMakeCache.txt
rm -rf CMakeFiles

export BLAS_LIBRARIES="-mkl;${MKLROOT}/lib/intel64/libmkl_intel_lp64.a;${MKLROOT}/lib/intel64/libmkl_intel_thread.a;${MKLROOT}/lib/intel64/libmkl_core.a"
export LAPACK_LIBRARIES=${BLAS_LIBRARIES}

cmake \
-D Trilinos_DISABLE_ENABLED_FORWARD_DEP_PACKAGES:BOOL=ON \
-D CMAKE_INSTALL_PREFIX:PATH=${TRILINOSINSTALLDIR} \
-D CMAKE_BUILD_TYPE:STRING=${BUILDTYPE} \
-D TPL_ENABLE_MPI:BOOL=ON \
-D CMAKE_VERBOSE_MAKEFILE:BOOL=OFF \
-D BUILD_SHARED_LIBS:BOOL=OFF \
-D Teuchos_ENABLE_STACKTRACE:BOOL=ON \
-D Trilinos_ENABLE_Fortran:BOOL=OFF \
-D Trilinos_ENABLE_ALL_PACKAGES:BOOL=OFF \
-D Trilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=OFF \
-D Trilinos_ENABLE_SECONDARY_TESTED_CODE:BOOL=OFF \
-D KOKKOS_ARCH="SKX" \
-D Trilinos_ENABLE_Amesos2:BOOL=ON \
-D Amesos2_ENABLE_TESTS:BOOL=ON \
-D TPL_ENABLE_MKL:BOOL=ON \
-D MKL_LIBRARY_DIRS:FILEPATH="${MKLROOT}/lib/intel64" \
-D MKL_INCLUDE_DIRS:FILEPATH="${MKLROOT}/include" \
-D Trilinos_EXTRA_LINK_FLAGS:STRING="-Wl,--start-group ${MKLROOT}/lib/intel64/libmkl_intel_lp64.a ${MKLROOT}/lib/intel64/libmkl_core.a ${MKLROOT}/lib/intel64/libmkl_sequential.a ${MKLROOT}/lib/intel64/libmkl_blacs_openmpi_lp64.a -Wl,--end-group -lpthread -lm -ldl" \
-D TPL_ENABLE_PARDISO_MKL:BOOL=ON \
-D PARDISO_MKL_LIBRARY_DIRS:FILEPATH="${MKLROOT}/lib/intel64" \
-D PARDISO_MKL_INCLUDE_DIRS:FILEPATH="${MKLROOT}/include"\
-D TPL_ENABLE_BLAS:BOOL=ON \
  -D TPL_BLAS_LIBRARIES:PATH="${BLAS_LIBRARIES}" \
-D TPL_ENABLE_LAPACK:BOOL=ON \
  -D TPL_LAPACK_LIBRARIES:PATH="${LAPACK_LIBRARIES}" \
${TRILINOS_DIR}
```

### Amesos2 ctest results
```
bash-4.2$ cd packages/amesos2/
bash-4.2$ ctest
Test project /ascldap/users/ndellin/trilinos/Trilinos/Build/Issue-4458/packages/amesos2
    Start 1: Amesos2_KLU2_UnitTests_MPI_2
1/5 Test #1: Amesos2_KLU2_UnitTests_MPI_2 .........................   Passed    0.57 sec
    Start 2: Amesos2_Pardiso_MKL_Solver_Test_MPI_4
2/5 Test #2: Amesos2_Pardiso_MKL_Solver_Test_MPI_4 ................   Passed    0.62 sec
    Start 3: Amesos2_SolverFactory_UnitTests_MPI_4
3/5 Test #3: Amesos2_SolverFactory_UnitTests_MPI_4 ................   Passed    0.51 sec
    Start 4: Amesos2_Tpetra_MultiVector_Adapter_UnitTests_MPI_4
4/5 Test #4: Amesos2_Tpetra_MultiVector_Adapter_UnitTests_MPI_4 ...   Passed    0.51 sec
    Start 5: Amesos2_Tpetra_CrsMatrix_Adapter_UnitTests_MPI_4
5/5 Test #5: Amesos2_Tpetra_CrsMatrix_Adapter_UnitTests_MPI_4 .....   Passed    0.55 sec

100% tests passed, 0 tests failed out of 5

Label Time Summary:
Amesos2    =   9.90 sec*proc (5 tests)
```


<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->


<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
