### PR TITLE
Amesos2: Update SuperLU TypeMap

### DIFF
--- a/packages/amesos2/src/Amesos2_Superlu_TypeMap.hpp
+++ b/packages/amesos2/src/Amesos2_Superlu_TypeMap.hpp
@@ -166,11 +166,12 @@ namespace Teuchos {
  *
  * @{
  */
-template <typename TypeFrom>
-class ValueTypeConversionTraits<SLU::C::complex, TypeFrom>
+
+template <>
+class ValueTypeConversionTraits<SLU::C::complex, std::complex<float>>
 {
 public:
-  static SLU::C::complex convert( const TypeFrom t )
+  static SLU::C::complex convert( const std::complex<float> t )
     {
       SLU::C::complex ret;
       ret.r = Teuchos::as<float>(t.real());
@@ -178,7 +179,28 @@ public:
       return( ret );
     }
 
-  static SLU::C::complex safeConvert( const TypeFrom t )
+  static SLU::C::complex safeConvert( const std::complex<float> t )
+    {
+      SLU::C::complex ret;
+      ret.r = Teuchos::as<float>(t.real());
+      ret.i = Teuchos::as<float>(t.imag());
+      return( ret );
+    }
+};
+
+template <>
+class ValueTypeConversionTraits<SLU::C::complex, std::complex<double>>
+{
+public:
+  static SLU::C::complex convert( const std::complex<double> t )
+    {
+      SLU::C::complex ret;
+      ret.r = Teuchos::as<float>(t.real());
+      ret.i = Teuchos::as<float>(t.imag());
+      return( ret );
+    }
+
+  static SLU::C::complex safeConvert( const std::complex<double> t )
     {
       SLU::C::complex ret;
       ret.r = Teuchos::as<float>(t.real());
@@ -188,11 +210,11 @@ public:
 };
 
 
-template <typename TypeFrom>
-class ValueTypeConversionTraits<SLU::Z::doublecomplex, TypeFrom>
+template <>
+class ValueTypeConversionTraits<SLU::Z::doublecomplex, std::complex<float>>
 {
 public:
-  static SLU::Z::doublecomplex convert( const TypeFrom t )
+  static SLU::Z::doublecomplex convert( const std::complex<float> t )
     {
       SLU::Z::doublecomplex ret;
       ret.r = Teuchos::as<double>(t.real());
@@ -200,7 +222,28 @@ public:
       return( ret );
     }
 
-  static SLU::Z::doublecomplex safeConvert( const TypeFrom t )
+  static SLU::Z::doublecomplex safeConvert( const std::complex<float> t )
+    {
+      SLU::Z::doublecomplex ret;
+      ret.r = Teuchos::as<double>(t.real());
+      ret.i = Teuchos::as<double>(t.imag());
+      return( ret );
+    }
+};
+
+template <>
+class ValueTypeConversionTraits<SLU::Z::doublecomplex, std::complex<double>>
+{
+public:
+  static SLU::Z::doublecomplex convert( const std::complex<double> t )
+    {
+      SLU::Z::doublecomplex ret;
+      ret.r = Teuchos::as<double>(t.real());
+      ret.i = Teuchos::as<double>(t.imag());
+      return( ret );
+    }
+
+  static SLU::Z::doublecomplex safeConvert( const std::complex<double> t )
     {
       SLU::Z::doublecomplex ret;
       ret.r = Teuchos::as<double>(t.real());
@@ -211,48 +254,93 @@ public:
 
 
 // Also convert from SLU types
-template <typename TypeTo>
-class ValueTypeConversionTraits<TypeTo, SLU::C::complex>
+
+template <>
+class ValueTypeConversionTraits<std::complex<float>, SLU::C::complex>
 {
 public:
-  static TypeTo convert( const SLU::C::complex t )
+  static std::complex<float> convert( const SLU::C::complex t )
     {
-      typedef typename TypeTo::value_type value_type;
+      typedef typename std::complex<float>::value_type value_type;
       value_type ret_r = Teuchos::as<value_type>( t.r );
       value_type ret_i = Teuchos::as<value_type>( t.i );
-      return ( TypeTo( ret_r, ret_i ) );
+      return ( std::complex<float>( ret_r, ret_i ) );
     }
 
   // No special checks for safe Convert
-  static TypeTo safeConvert( const SLU::C::complex t )
+  static std::complex<float> safeConvert( const SLU::C::complex t )
     {
-      typedef typename TypeTo::value_type value_type;
+      typedef typename std::complex<float>::value_type value_type;
       value_type ret_r = Teuchos::as<value_type>( t.r );
       value_type ret_i = Teuchos::as<value_type>( t.i );
-      return ( TypeTo( ret_r, ret_i ) );
+      return ( std::complex<float>( ret_r, ret_i ) );
+    }
+};
+
+template <>
+class ValueTypeConversionTraits<std::complex<double>, SLU::C::complex>
+{
+public:
+  static std::complex<double> convert( const SLU::C::complex t )
+    {
+      typedef typename std::complex<double>::value_type value_type;
+      value_type ret_r = Teuchos::as<value_type>( t.r );
+      value_type ret_i = Teuchos::as<value_type>( t.i );
+      return ( std::complex<double>( ret_r, ret_i ) );
+    }
+
+  // No special checks for safe Convert
+  static std::complex<double> safeConvert( const SLU::C::complex t )
+    {
+      typedef typename std::complex<double>::value_type value_type;
+      value_type ret_r = Teuchos::as<value_type>( t.r );
+      value_type ret_i = Teuchos::as<value_type>( t.i );
+      return ( std::complex<double>( ret_r, ret_i ) );
     }
 };
 
 
-template <typename TypeTo>
-class ValueTypeConversionTraits<TypeTo, SLU::Z::doublecomplex>
+template <>
+class ValueTypeConversionTraits<std::complex<float>, SLU::Z::doublecomplex>
 {
 public:
-  static TypeTo convert( const SLU::Z::doublecomplex t )
+  static std::complex<float> convert( const SLU::Z::doublecomplex t )
     {
-      typedef typename TypeTo::value_type value_type;
+      typedef typename std::complex<float>::value_type value_type;
       value_type ret_r = Teuchos::as<value_type>( t.r );
       value_type ret_i = Teuchos::as<value_type>( t.i );
-      return ( TypeTo( ret_r, ret_i ) );
+      return ( std::complex<float>( ret_r, ret_i ) );
     }
 
   // No special checks for safe Convert
-  static TypeTo safeConvert( const SLU::Z::doublecomplex t )
+  static std::complex<float> safeConvert( const SLU::Z::doublecomplex t )
     {
-      typedef typename TypeTo::value_type value_type;
+      typedef typename std::complex<float>::value_type value_type;
       value_type ret_r = Teuchos::as<value_type>( t.r );
       value_type ret_i = Teuchos::as<value_type>( t.i );
-      return ( TypeTo( ret_r, ret_i ) );
+      return ( std::complex<float>( ret_r, ret_i ) );
+    }
+};
+
+template <>
+class ValueTypeConversionTraits<std::complex<double>, SLU::Z::doublecomplex>
+{
+public:
+  static std::complex<double> convert( const SLU::Z::doublecomplex t )
+    {
+      typedef typename std::complex<double>::value_type value_type;
+      value_type ret_r = Teuchos::as<value_type>( t.r );
+      value_type ret_i = Teuchos::as<value_type>( t.i );
+      return ( std::complex<double>( ret_r, ret_i ) );
+    }
+
+  // No special checks for safe Convert
+  static std::complex<double> safeConvert( const SLU::Z::doublecomplex t )
+    {
+      typedef typename std::complex<double>::value_type value_type;
+      value_type ret_r = Teuchos::as<value_type>( t.r );
+      value_type ret_i = Teuchos::as<value_type>( t.i );
+      return ( std::complex<double>( ret_r, ret_i ) );
     }
 };
 


### PR DESCRIPTION
This fixes an issue when enabling SuperLU and Umfpack with complex
double types enabled. Addresses issue #4563

Issue reported by Sam Browne.

@trilinos/amesos2 

## Testing

Tested with gcc/6.5 and mpich on MacOSX High Sierra

### Configuration

```
#!/bin/bash

TRILINOS_DIR=${PWD}/../..

TPL_PATH=/Users/ndellin/Research/TPL/GCC6.4

BLAS_PATH=${TPL_PATH}/BLAS-3.6.0
LAPACK_PATH=${TPL_PATH}/lapack-3.6.1

SCOTCH_PATH=${TPL_PATH}/scotch_6.0.3

PARMETIS_PATH=${TPL_PATH}/parmetis-4.0.3/install
METIS_PATH=${TPL_PATH}/metis-5.1.0/install

SUPERLU_PATH=${TPL_PATH}/SuperLU_4.3
SUPERLU_DIST_PATH=${TPL_PATH}/SuperLU_DIST_4.2

SS_PATH=${TPL_PATH}/SuiteSparse-4.1.0

export INSTALL_LOCATION=${PWD}/install

rm -rf CMake*

cmake \
 -D Trilinos_EXTRA_LINK_FLAGS:STRING="" \
 -D CMAKE_BUILD_TYPE:STRING=release \
 -D Trilinos_ENABLE_OpenMP:BOOL=OFF \
 -D TPL_ENABLE_Pthread:BOOL=OFF \
 -D TPL_ENABLE_CUDA:BOOL=OFF \
 -D TPL_ENABLE_MPI:BOOL=ON \
 -D CMAKE_CXX_COMPILER:STRING="`which mpicxx`" \
 -D CMAKE_C_COMPILER:STRING="`which mpicc`" \
 -D CMAKE_Fortran_COMPILER:STRING="`which mpif90`" \
 -D CMAKE_INSTALL_PREFIX:PATH="${INSTALL_LOCATION}" \
 -D CMAKE_EXTRA_LINK_FLAGS:STRING= \
 -D CMAKE_C_FLAGS:STRING=" -ftemplate-depth-128  -O2  -finline-functions  -Wno-inline  -w " \
 -D CMAKE_CXX_FLAGS:STRING=" -ftemplate-depth-128  -O2  -finline-functions  -Wno-inline  -w " \
 -D CMAKE_Fortran_FLAGS:STRING=" -ftemplate-depth-128  -O2  -finline-functions  -Wno-inline  -w " \
 -D HAVE_GCC_ABI_DEMANGLE:BOOL=ON \
 -D Trilinos_ENABLE_ALL_PACKAGES:BOOL=OFF \
 -D Trilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=OFF \
 -D Trilinos_ENABLE_Gtest:BOOL=OFF \
 -D Trilinos_ENABLE_EXPLICIT_INSTANTIATION:BOOL=OFF \
 -D Trilinos_SHOW_DEPRECATED_WARNINGS:BOOL=OFF \
 -D Trilinos_WARNINGS_AS_ERRORS_FLAGS:STRING="" \
 -D Trilinos_ASSERT_MISSING_PACKAGES:BOOL=OFF \
 -D Trilinos_ENABLE_COMPLEX_DOUBLE:BOOL=ON \
 \
 \
-D TPL_ENABLE_METIS:BOOL=ON \
  -D METIS_INCLUDE_DIRS:PATH="${METIS_PATH}/include" \
  -D METIS_LIBRARY_DIRS:PATH="${METIS_PATH}/lib" \
  -D METIS_LIBRARY_NAMES:STRING="metis" \
-D TPL_ENABLE_ParMETIS:BOOL=ON \
  -D ParMETIS_INCLUDE_DIRS:PATH="${PARMETIS_PATH}/include" \
  -D ParMETIS_LIBRARY_DIRS:PATH="${PARMETIS_PATH}/lib" \
  -D ParMETIS_LIBRARY_NAMES:STRING="parmetis" \
-D TPL_ENABLE_Scotch:BOOL=ON \
  -D Scotch_INCLUDE_DIRS:PATH="${SCOTCH_PATH}/include" \
  -D Scotch_LIBRARY_DIRS:PATH="${SCOTCH_PATH}/lib" \
  -D Scotch_LIBRARY_NAMES:STRING="scotch;scotcherr" \
-D TPL_ENABLE_BLAS:STRING=ON \
  -D BLAS_LIBRARY_DIRS:FILEPATH=${BLAS_PATH} \
  -D BLAS_LIBRARY_NAMES:STRING="blas" \
-D TPL_ENABLE_LAPACK:STRING=ON \
  -D LAPACK_INCLUDE_DIRS:FILEPATH="${LAPACK_PATH}/SRC" \
  -D LAPACK_LIBRARY_DIRS:FILEPATH=${LAPACK_PATH} \
  -D LAPACK_LIBRARY_NAMES:STRING="lapack" \
-D TPL_ENABLE_SuperLU:BOOL=ON \
  -D SuperLU_INCLUDE_DIRS:FILEPATH="${SUPERLU_PATH}/SRC" \
  -D SuperLU_LIBRARY_DIRS:FILEPATH="${SUPERLU_PATH}/lib" \
  -D SuperLU_LIBRARY_NAMES:STRING="superlu_4.3" \
-D TPL_ENABLE_UMFPACK:STRING=ON \
  -D UMFPACK_INCLUDE_DIRS:PATH="${SS_PATH}/UMFPACK/Include;${SS_PATH}/AMD/Include;${SS_PATH}/SuiteSparse_config"\
  -D UMFPACK_LIBRARY_DIRS:PATH="${SS_PATH}/UMFPACK/Lib;${SS_PATH}/AMD/Lib;${SS_PATH}/SuiteSparse_config"\
  -D UMFPACK_LIBRARY_NAMES:STRING="umfpack;amd;suitesparseconfig"\
  \
-D TPL_ENABLE_yaml-cpp:BOOL=OFF \
-D TPL_ENABLE_Boost:BOOL=OFF \
 \
 -DTrilinos_ENABLE_Zoltan:BOOL=ON \
 -DZoltan_ENABLE_Scotch:BOOL=OFF \
 -DTrilinos_ENABLE_Zoltan2:BOOL=ON \
 -DZoltan2_ENABLE_Scotch:BOOL=OFF \
 -DZoltan2_ENABLE_Experimental:BOOL=ON \
 -DZoltan2_ENABLE_HYPERGRAPHMODEL:BOOL=OFF \
 -DTrilinos_ENABLE_Shards:BOOL=ON \
 -DTrilinos_ENABLE_Mesquite:BOOL=OFF \
 -DTrilinos_ENABLE_Teuchos:BOOL=ON \
 -DTrilinos_ENABLE_RTOp:BOOL=ON \
 -DTrilinos_ENABLE_Epetra:BOOL=ON \
 -DTrilinos_ENABLE_EpetraExt:BOOL=ON \
 -DTrilinos_ENABLE_Triutils:BOOL=ON \
 -DTrilinos_ENABLE_Thyra:BOOL=ON \
 -DTrilinos_ENABLE_AztecOO:BOOL=ON \
 -DTrilinos_ENABLE_Amesos:BOOL=ON \
 -DTrilinos_ENABLE_Amesos2:BOOL=ON \
 -DTrilinos_ENABLE_Belos:BOOL=ON \
 -DTrilinos_ENABLE_Intrepid:BOOL=ON \
 -DTrilinos_ENABLE_Intrepid:BOOL=OFF \
 -DTrilinos_ENABLE_Intrepid2:BOOL=OFF \
 -DIntrepid_ENABLE_KokkosCore:BOOL=OFF \
 -DTrilinos_ENABLE_Ifpack:BOOL=ON \
 -DTrilinos_ENABLE_Ifpack2:BOOL=ON \
 -DTrilinos_ENABLE_Tpetra:BOOL=ON \
 -DTrilinos_ENABLE_Kokkos:BOOL=ON \
 -DTrilinos_ENABLE_KokkosCore:BOOL=ON \
 -DTrilinos_ENABLE_KokkosContainers:BOOL=ON \
 -DKokkos_ENABLE_Cuda_Relocatable_Device_Code:BOOL=OFF \
 -DKOKKOS_ENABLE_DEPRECATED_CODE:BOOL=OFF \
 -DKOKKOS_ENABLE_PROFILING:BOOL=ON \
 -DKokkos_ENABLE_SIERRA_BUILD:BOOL=OFF \
 -DTrilinos_ENABLE_KokkosTSQR:BOOL=OFF \
 -DTrilinos_ENABLE_Anasazi:BOOL=ON \
 -DTrilinos_ENABLE_ML:BOOL=ON \
 -DTrilinos_ENABLE_MueLu:BOOL=ON \
 -DTrilinos_ENABLE_Stratimikos:BOOL=ON \
 -DTrilinos_ENABLE_NOX:BOOL=ON \
 -DTrilinos_ENABLE_FEI:BOOL=ON \
 -DTrilinos_ENABLE_TrilinosCouplings:BOOL=ON \
 -DTrilinos_ENABLE_MOOCHO:BOOL=OFF \
 -DTrilinos_ENABLE_Sacado:BOOL=ON \
 -DSacado_ENABLE_KokkosCore:BOOL=ON \
 -DTrilinos_ENABLE_Stokhos:BOOL=ON \
 -DTrilinos_ENABLE_Pamgen:BOOL=ON \
 -DPamgen_ENABLE_Boost:BOOL=OFF \
 -DTrilinos_ENABLE_Rythmos:BOOL=ON \
 -DTrilinos_ENABLE_ThyraEpetraExtAdapters:BOOL=ON \
 -DTrilinos_ENABLE_Xpetra:BOOL=ON \
 -DTrilinos_ENABLE_ShyLU_NodeTacho:BOOL=ON \
 -DTacho_ENABLE_INT_INT:BOOL=ON \
 -DAmesos2_ENABLE_ShyLU_NodeTacho:BOOL=OFF \
 -DTrilinos_ENABLE_ShyLU_NodeHTS:BOOL=ON \
 -DTrilinos_ENABLE_ShyLUFastILU:BOOL=ON \
 -DTrilinos_ENABLE_Isorropia:BOOL=OFF \
 -DTrilinos_ENABLE_STKClassic:BOOL=OFF \
 -DTrilinos_ENABLE_STK:BOOL=OFF \
 -DTrilinos_ENABLE_SEACAS:BOOL=OFF \
 -DAmesos_ENABLE_SuperLU:BOOL=ON \
 -DAmesos2_ENABLE_TESTS:BOOL=ON \
 -DAmesos2_ENABLE_SuperLU:BOOL=ON \
 -DAmesos2_ENABLE_Umfpack:BOOL=ON \
 -DAztecOO_ENABLE_AZLU:BOOL=OFF \
 -DZoltan_ENABLE_METIS:BOOL=OFF \
 -DStokhos_ENABLE_Ifpack:BOOL=OFF \
 -DStokhos_ENABLE_ML:BOOL=OFF \
 -DStokhos_ENABLE_Anasazi:BOOL=OFF \
 -DStokhos_ENABLE_Sacado:BOOL=ON \
 -DStokhos_ENABLE_NOX:BOOL=OFF \
 -DStokhos_ENABLE_KokkosClassic:BOOL=OFF \
 -DStokhos_ENABLE_KokkosCore:BOOL=OFF \
 -DStokhos_ENABLE_Tpetra:BOOL=OFF \
 -DStokhos_ENABLE_Ifpack2:BOOL=OFF \
 -DStokhos_ENABLE_AztecOO:BOOL=OFF \
 -DStokhos_ENABLE_Stratimikos:BOOL=OFF \
 -DStokhos_ENABLE_Belos:BOOL=OFF \
 -DML_ENABLE_ParMETIS:BOOL=OFF \
 -DML_ENABLE_METIS:BOOL=OFF \
 -DNOX_ENABLE_ABSTRACT_IMPLEMENTATION_THYRA:BOOL=OFF \
 -DTrilinos_ENABLE_LINEAR_SOLVER_FACTORY_REGISTRATION:BOOL=ON \
 -DTrilinos_ENABLE_MiniTensor:BOOL=OFF \
 -DTpetra_INST_INT_LONG:BOOL=ON \
 -DTpetra_INST_INT_LONG_LONG:BOOL=OFF \
${TRILINOS_DIR}
```

### Amesos2 test results

```
s994290:amesos2 ndellin$ ctest
Test project /Users/ndellin/Research/trilinos/Trilinos/Build/Issue-SBrowne-umfpack/packages/amesos2
      Start  1: Amesos2_KLU2_UnitTests_MPI_2
 1/10 Test  #1: Amesos2_KLU2_UnitTests_MPI_2 .........................   Passed    0.19 sec
      Start  2: Amesos2_SuperLU_Solver_Test_MPI_4
 2/10 Test  #2: Amesos2_SuperLU_Solver_Test_MPI_4 ....................   Passed    0.35 sec
      Start  3: Amesos2_Superlu_UnitTests_MPI_2
 3/10 Test  #3: Amesos2_Superlu_UnitTests_MPI_2 ......................   Passed    0.12 sec
      Start  4: Amesos2_Umfpack_Solver_Test_MPI_4
 4/10 Test  #4: Amesos2_Umfpack_Solver_Test_MPI_4 ....................   Passed    0.32 sec
      Start  5: Amesos2_SolverFactory_UnitTests_MPI_4
 5/10 Test  #5: Amesos2_SolverFactory_UnitTests_MPI_4 ................   Passed    0.12 sec
      Start  6: Amesos2_Tpetra_MultiVector_Adapter_UnitTests_MPI_4
 6/10 Test  #6: Amesos2_Tpetra_MultiVector_Adapter_UnitTests_MPI_4 ...   Passed    0.11 sec
      Start  7: Amesos2_Tpetra_CrsMatrix_Adapter_UnitTests_MPI_4
 7/10 Test  #7: Amesos2_Tpetra_CrsMatrix_Adapter_UnitTests_MPI_4 .....   Passed    0.13 sec
      Start  8: Amesos2_Epetra_MultiVector_Adapter_UnitTests_MPI_4
 8/10 Test  #8: Amesos2_Epetra_MultiVector_Adapter_UnitTests_MPI_4 ...   Passed    0.11 sec
      Start  9: Amesos2_Epetra_RowMatrix_Adapter_UnitTests_MPI_4
 9/10 Test  #9: Amesos2_Epetra_RowMatrix_Adapter_UnitTests_MPI_4 .....   Passed    0.11 sec
      Start 10: Amesos2_CrsMatrix_Adapter_Consistency_Tests_MPI_4
10/10 Test #10: Amesos2_CrsMatrix_Adapter_Consistency_Tests_MPI_4 ....   Passed    0.13 sec

100% tests passed, 0 tests failed out of 10

Label Time Summary:
Amesos2    =   6.09 sec*proc (10 tests)

Total Test time (real) =   1.72 sec
```