### PR TITLE
MueLu/HHG: Remove dependency on ML package

### DIFF
--- a/packages/muelu/research/mmayr/composite_to_regions/src/CMakeLists.txt
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/CMakeLists.txt
@@ -6,7 +6,7 @@ APPEND_GLOB(SOURCES ${DIR}/*.cpp)
 # Executables
 #
 
-IF(${PACKAGE_NAME}_ENABLE_Epetra AND ${PACKAGE_NAME}_ENABLE_ML)
+IF(${PACKAGE_NAME}_ENABLE_Epetra)
 
   TRIBITS_ADD_EXECUTABLE(
     composite_to_region_driver 

--- a/packages/muelu/research/mmayr/composite_to_regions/src/main.cpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/main.cpp
@@ -55,7 +55,6 @@
 
 #define RegionsSpanProcs  1
 #define MultipleRegionsPerProc  2
-#include "ml_config.h"
 #ifdef HAVE_MPI
 #include "mpi.h"
 #include "Epetra_MpiComm.h"


### PR DESCRIPTION
@trilinos/muelu 

## Description
Remove the dependency of the MueLu HHG driver on `Trilinos_ENABLE_ML` as in fact ML is not required and used.

## Motivation and Context
This brings the MueLu HHG driver one step closer to a cleaner configuration.

## How Has This Been Tested?
Build and tests pass locally.

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
