### PR TITLE
Issue 3566

### DIFF
--- a/cmake/TPLs/FindTPLSuperLU.cmake
+++ b/cmake/TPLs/FindTPLSuperLU.cmake
@@ -56,7 +56,7 @@
 
 TRIBITS_TPL_FIND_INCLUDE_DIRS_AND_LIBRARIES( SuperLU
   REQUIRED_HEADERS supermatrix.h slu_ddefs.h
-  REQUIRED_LIBS_NAMES "superlu superlu_3.0 superlu_4.0 superlu_4.1 superlu_4.2 superlu_4.3 superlu_5.0 superlu_5.1.1"
+  REQUIRED_LIBS_NAMES "superlu superlu_3.0 superlu_4.0 superlu_4.1 superlu_4.2 superlu_4.3 superlu_5.0 superlu_5.1.1 superlu_5.2.1"
   )
 
 include(CheckCSourceCompiles)

--- a/packages/amesos2/src/Amesos2_Superlu_TypeMap.hpp
+++ b/packages/amesos2/src/Amesos2_Superlu_TypeMap.hpp
@@ -166,11 +166,12 @@ namespace Teuchos {
  *
  * @{
  */
-template <typename TypeFrom>
-class ValueTypeConversionTraits<SLU::C::complex, TypeFrom>
+
+template <>
+class ValueTypeConversionTraits<SLU::C::complex, std::complex<float>>
 {
 public:
-  static SLU::C::complex convert( const TypeFrom t )
+  static SLU::C::complex convert( const std::complex<float> t )
     {
       SLU::C::complex ret;
       ret.r = Teuchos::as<float>(t.real());
@@ -178,7 +179,28 @@ public:
       return( ret );
     }
 
-  static SLU::C::complex safeConvert( const TypeFrom t )
+  static SLU::C::complex safeConvert( const std::complex<float> t )
+    {
+      SLU::C::complex ret;
+      ret.r = Teuchos::as<float>(t.real());
+      ret.i = Teuchos::as<float>(t.imag());
+      return( ret );
+    }
+};
+
+template <>
+class ValueTypeConversionTraits<SLU::C::complex, std::complex<double>>
+{
+public:
+  static SLU::C::complex convert( const std::complex<double> t )
+    {
+      SLU::C::complex ret;
+      ret.r = Teuchos::as<float>(t.real());
+      ret.i = Teuchos::as<float>(t.imag());
+      return( ret );
+    }
+
+  static SLU::C::complex safeConvert( const std::complex<double> t )
     {
       SLU::C::complex ret;
       ret.r = Teuchos::as<float>(t.real());
@@ -188,11 +210,11 @@ public:
 };
 
 
-template <typename TypeFrom>
-class ValueTypeConversionTraits<SLU::Z::doublecomplex, TypeFrom>
+template <>
+class ValueTypeConversionTraits<SLU::Z::doublecomplex, std::complex<float>>
 {
 public:
-  static SLU::Z::doublecomplex convert( const TypeFrom t )
+  static SLU::Z::doublecomplex convert( const std::complex<float> t )
     {
       SLU::Z::doublecomplex ret;
       ret.r = Teuchos::as<double>(t.real());
@@ -200,7 +222,28 @@ public:
       return( ret );
     }
 
-  static SLU::Z::doublecomplex safeConvert( const TypeFrom t )
+  static SLU::Z::doublecomplex safeConvert( const std::complex<float> t )
+    {
+      SLU::Z::doublecomplex ret;
+      ret.r = Teuchos::as<double>(t.real());
+      ret.i = Teuchos::as<double>(t.imag());
+      return( ret );
+    }
+};
+
+template <>
+class ValueTypeConversionTraits<SLU::Z::doublecomplex, std::complex<double>>
+{
+public:
+  static SLU::Z::doublecomplex convert( const std::complex<double> t )
+    {
+      SLU::Z::doublecomplex ret;
+      ret.r = Teuchos::as<double>(t.real());
+      ret.i = Teuchos::as<double>(t.imag());
+      return( ret );
+    }
+
+  static SLU::Z::doublecomplex safeConvert( const std::complex<double> t )
     {
       SLU::Z::doublecomplex ret;
       ret.r = Teuchos::as<double>(t.real());
@@ -211,48 +254,93 @@ public:
 
 
 // Also convert from SLU types
-template <typename TypeTo>
-class ValueTypeConversionTraits<TypeTo, SLU::C::complex>
+
+template <>
+class ValueTypeConversionTraits<std::complex<float>, SLU::C::complex>
 {
 public:
-  static TypeTo convert( const SLU::C::complex t )
+  static std::complex<float> convert( const SLU::C::complex t )
     {
-      typedef typename TypeTo::value_type value_type;
+      typedef typename std::complex<float>::value_type value_type;
       value_type ret_r = Teuchos::as<value_type>( t.r );
       value_type ret_i = Teuchos::as<value_type>( t.i );
-      return ( TypeTo( ret_r, ret_i ) );
+      return ( std::complex<float>( ret_r, ret_i ) );
     }
 
   // No special checks for safe Convert
-  static TypeTo safeConvert( const SLU::C::complex t )
+  static std::complex<float> safeConvert( const SLU::C::complex t )
     {
-      typedef typename TypeTo::value_type value_type;
+      typedef typename std::complex<float>::value_type value_type;
       value_type ret_r = Teuchos::as<value_type>( t.r );
       value_type ret_i = Teuchos::as<value_type>( t.i );
-      return ( TypeTo( ret_r, ret_i ) );
+      return ( std::complex<float>( ret_r, ret_i ) );
+    }
+};
+
+template <>
+class ValueTypeConversionTraits<std::complex<double>, SLU::C::complex>
+{
+public:
+  static std::complex<double> convert( const SLU::C::complex t )
+    {
+      typedef typename std::complex<double>::value_type value_type;
+      value_type ret_r = Teuchos::as<value_type>( t.r );
+      value_type ret_i = Teuchos::as<value_type>( t.i );
+      return ( std::complex<double>( ret_r, ret_i ) );
+    }
+
+  // No special checks for safe Convert
+  static std::complex<double> safeConvert( const SLU::C::complex t )
+    {
+      typedef typename std::complex<double>::value_type value_type;
+      value_type ret_r = Teuchos::as<value_type>( t.r );
+      value_type ret_i = Teuchos::as<value_type>( t.i );
+      return ( std::complex<double>( ret_r, ret_i ) );
     }
 };
 
 
-template <typename TypeTo>
-class ValueTypeConversionTraits<TypeTo, SLU::Z::doublecomplex>
+template <>
+class ValueTypeConversionTraits<std::complex<float>, SLU::Z::doublecomplex>
 {
 public:
-  static TypeTo convert( const SLU::Z::doublecomplex t )
+  static std::complex<float> convert( const SLU::Z::doublecomplex t )
     {
-      typedef typename TypeTo::value_type value_type;
+      typedef typename std::complex<float>::value_type value_type;
       value_type ret_r = Teuchos::as<value_type>( t.r );
       value_type ret_i = Teuchos::as<value_type>( t.i );
-      return ( TypeTo( ret_r, ret_i ) );
+      return ( std::complex<float>( ret_r, ret_i ) );
     }
 
   // No special checks for safe Convert
-  static TypeTo safeConvert( const SLU::Z::doublecomplex t )
+  static std::complex<float> safeConvert( const SLU::Z::doublecomplex t )
     {
-      typedef typename TypeTo::value_type value_type;
+      typedef typename std::complex<float>::value_type value_type;
       value_type ret_r = Teuchos::as<value_type>( t.r );
       value_type ret_i = Teuchos::as<value_type>( t.i );
-      return ( TypeTo( ret_r, ret_i ) );
+      return ( std::complex<float>( ret_r, ret_i ) );
+    }
+};
+
+template <>
+class ValueTypeConversionTraits<std::complex<double>, SLU::Z::doublecomplex>
+{
+public:
+  static std::complex<double> convert( const SLU::Z::doublecomplex t )
+    {
+      typedef typename std::complex<double>::value_type value_type;
+      value_type ret_r = Teuchos::as<value_type>( t.r );
+      value_type ret_i = Teuchos::as<value_type>( t.i );
+      return ( std::complex<double>( ret_r, ret_i ) );
+    }
+
+  // No special checks for safe Convert
+  static std::complex<double> safeConvert( const SLU::Z::doublecomplex t )
+    {
+      typedef typename std::complex<double>::value_type value_type;
+      value_type ret_r = Teuchos::as<value_type>( t.r );
+      value_type ret_i = Teuchos::as<value_type>( t.i );
+      return ( std::complex<double>( ret_r, ret_i ) );
     }
 };
 

--- a/packages/amesos2/src/Amesos2_Superludist.cpp
+++ b/packages/amesos2/src/Amesos2_Superludist.cpp
@@ -58,14 +58,8 @@ namespace Amesos2 {
 #endif
 
 #ifdef HAVE_TPETRA_INST_INT_INT
-#ifdef HAVE_TPETRA_INST_FLOAT
-  AMESOS2_SOLVER_TPETRA_INST(Superludist,float,int,int);
-#endif
 #ifdef HAVE_TPETRA_INST_DOUBLE
   AMESOS2_SOLVER_TPETRA_INST(Superludist,double,int,int);
-#endif
-#ifdef HAVE_TPETRA_INST_COMPLEX_FLOAT
-  AMESOS2_SOLVER_TPETRA_INST(Superludist,std::complex<float>,int,int);
 #endif
 #ifdef HAVE_TPETRA_INST_COMPLEX_DOUBLE
   AMESOS2_SOLVER_TPETRA_INST(Superludist,std::complex<double>,int,int);
@@ -73,14 +67,8 @@ namespace Amesos2 {
 #endif
 
 #ifdef HAVE_TPETRA_INST_INT_UNSIGNED
-#ifdef HAVE_TPETRA_INST_FLOAT
-  AMESOS2_SOLVER_TPETRA_INST(Superludist,float,int,unsigned);
-#endif
 #ifdef HAVE_TPETRA_INST_DOUBLE
   AMESOS2_SOLVER_TPETRA_INST(Superludist,double,int,unsigned);
-#endif
-#ifdef HAVE_TPETRA_INST_COMPLEX_FLOAT
-  AMESOS2_SOLVER_TPETRA_INST(Superludist,std::complex<float>,int,unsigned);
 #endif
 #ifdef HAVE_TPETRA_INST_COMPLEX_DOUBLE
   AMESOS2_SOLVER_TPETRA_INST(Superludist,std::complex<double>,int,unsigned);
@@ -88,14 +76,8 @@ namespace Amesos2 {
 #endif
 
 #ifdef HAVE_TPETRA_INST_INT_LONG
-#ifdef HAVE_TPETRA_INST_FLOAT
-  AMESOS2_SOLVER_TPETRA_INST(Superludist,float,int,long);
-#endif
 #ifdef HAVE_TPETRA_INST_DOUBLE
   AMESOS2_SOLVER_TPETRA_INST(Superludist,double,int,long);
-#endif
-#ifdef HAVE_TPETRA_INST_COMPLEX_FLOAT
-  AMESOS2_SOLVER_TPETRA_INST(Superludist,std::complex<float>,int,long);
 #endif
 #ifdef HAVE_TPETRA_INST_COMPLEX_DOUBLE
   AMESOS2_SOLVER_TPETRA_INST(Superludist,std::complex<double>,int,long);
@@ -103,14 +85,8 @@ namespace Amesos2 {
 #endif
 
 #ifdef HAVE_TPETRA_INST_INT_UNSIGNED_LONG
-#ifdef HAVE_TPETRA_INST_FLOAT
-  AMESOS2_SOLVER_TPETRA_INST(Superludist,float,int,unsigned long);
-#endif
 #ifdef HAVE_TPETRA_INST_DOUBLE
   AMESOS2_SOLVER_TPETRA_INST(Superludist,double,int,unsigned long);
-#endif
-#ifdef HAVE_TPETRA_INST_COMPLEX_FLOAT
-  AMESOS2_SOLVER_TPETRA_INST(Superludist,std::complex<float>,int,unsigned long);
 #endif
 #ifdef HAVE_TPETRA_INST_COMPLEX_DOUBLE
   AMESOS2_SOLVER_TPETRA_INST(Superludist,std::complex<double>,int,unsigned long);
@@ -119,14 +95,8 @@ namespace Amesos2 {
 
 
 #ifdef HAVE_TPETRA_INST_INT_LONG_LONG
-#ifdef HAVE_TPETRA_INST_FLOAT
-  AMESOS2_SOLVER_TPETRA_INST(Superludist,float,int,long long);
-#endif
 #ifdef HAVE_TPETRA_INST_DOUBLE
   AMESOS2_SOLVER_TPETRA_INST(Superludist,double,int,long long);
-#endif
-#ifdef HAVE_TPETRA_INST_COMPLEX_FLOAT
-  AMESOS2_SOLVER_TPETRA_INST(Superludist,std::complex<float>,int,long long);
 #endif
 #ifdef HAVE_TPETRA_INST_COMPLEX_DOUBLE
   AMESOS2_SOLVER_TPETRA_INST(Superludist,std::complex<double>,int,long long);
@@ -233,23 +203,6 @@ TPETRA_ETI_MANGLING_TYPEDEFS()
 
 #if defined(HAVE_TPETRA_INST_SERIAL) && !defined(HAVE_TPETRA_DEFAULTNODE_SERIALWRAPPERNODE) && defined(HAVE_TPETRA_INST_DOUBLE) && defined(TPETRA_HAVE_KOKKOS_REFACTOR)
 #define NODETYPE Kokkos_Compat_KokkosSerialWrapperNode
-#ifdef HAVE_TPETRA_INST_FLOAT
-  #ifdef HAVE_TPETRA_INST_INT_INT
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(float, int, int, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_LONG
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(float, int, long, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_LONG_LONG
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(float, int, long long, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_UNSIGNED
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(float, int, unsigned int, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_UNSIGNED_LONG
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(float, int, unsigned long, NODETYPE)
-  #endif
-#endif
 #ifdef HAVE_TPETRA_INST_DOUBLE
     #ifdef HAVE_TPETRA_INST_INT_INT
       AMESOS2_SUPERLUDIST_LOCAL_INSTANT(double, int, int, NODETYPE)
@@ -266,23 +219,6 @@ TPETRA_ETI_MANGLING_TYPEDEFS()
     #ifdef HAVE_TPETRA_INST_INT_UNSIGNED_LONG
       AMESOS2_SUPERLUDIST_LOCAL_INSTANT(double, int, unsigned long, NODETYPE)
     #endif
-#endif
-#ifdef HAVE_TPETRA_INST_COMPLEX_FLOAT
-  #ifdef HAVE_TPETRA_INST_INT_INT
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(std::complex<float>, int, int, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_LONG
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(std::complex<float>, int, long, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_LONG_LONG
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(std::complex<float>, int, long long, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_UNSIGNED
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(std::complex<float>, int, unsigned int, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_UNSIGNED_LONG
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(std::complex<float>, int, unsigned long, NODETYPE)
-  #endif
 #endif
 #ifdef HAVE_TPETRA_INST_COMPLEX_DOUBLE
     #ifdef HAVE_TPETRA_INST_INT_INT
@@ -306,23 +242,6 @@ TPETRA_ETI_MANGLING_TYPEDEFS()
 
 #if defined(HAVE_TPETRA_INST_PTHREAD) && !defined(HAVE_TPETRA_DEFAULTNODE_THREADSWRAPPERNODE) && defined(HAVE_TPETRA_INST_DOUBLE) && defined(TPETRA_HAVE_KOKKOS_REFACTOR)
 #define NODETYPE Kokkos_Compat_KokkosThreadsWrapperNode
-#ifdef HAVE_TPETRA_INST_FLOAT
-  #ifdef HAVE_TPETRA_INST_INT_INT
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(float, int, int, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_LONG
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(float, int, long, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_LONG_LONG
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(float, int, long long, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_UNSIGNED
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(float, int, unsigned int, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_UNSIGNED_LONG
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(float, int, unsigned long, NODETYPE)
-  #endif
-#endif
 #ifdef HAVE_TPETRA_INST_DOUBLE
     #ifdef HAVE_TPETRA_INST_INT_INT
       AMESOS2_SUPERLUDIST_LOCAL_INSTANT(double, int, int, NODETYPE)
@@ -339,23 +258,6 @@ TPETRA_ETI_MANGLING_TYPEDEFS()
     #ifdef HAVE_TPETRA_INST_INT_UNSIGNED_LONG
       AMESOS2_SUPERLUDIST_LOCAL_INSTANT(double, int, unsigned long, NODETYPE)
     #endif
-#endif
-#ifdef HAVE_TPETRA_INST_COMPLEX_FLOAT
-  #ifdef HAVE_TPETRA_INST_INT_INT
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(std::complex<float>, int, int, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_LONG
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(std::complex<float>, int, long, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_LONG_LONG
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(std::complex<float>, int, long long, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_UNSIGNED
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(std::complex<float>, int, unsigned int, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_UNSIGNED_LONG
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(std::complex<float>, int, unsigned long, NODETYPE)
-  #endif
 #endif
 #ifdef HAVE_TPETRA_INST_COMPLEX_DOUBLE
     #ifdef HAVE_TPETRA_INST_INT_INT
@@ -379,23 +281,6 @@ TPETRA_ETI_MANGLING_TYPEDEFS()
 
 #if defined(HAVE_TPETRA_INST_OPENMP) && !defined(HAVE_TPETRA_DEFAULTNODE_OPENMPWRAPPERNODE) && defined(HAVE_TPETRA_INST_DOUBLE) && defined(TPETRA_HAVE_KOKKOS_REFACTOR)
 #define NODETYPE Kokkos_Compat_KokkosOpenMPWrapperNode
-#ifdef HAVE_TPETRA_INST_FLOAT
-  #ifdef HAVE_TPETRA_INST_INT_INT
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(float, int, int, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_LONG
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(float, int, long, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_LONG_LONG
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(float, int, long long, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_UNSIGNED
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(float, int, unsigned int, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_UNSIGNED_LONG
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(float, int, unsigned long, NODETYPE)
-  #endif
-#endif
 #ifdef HAVE_TPETRA_INST_DOUBLE
     #ifdef HAVE_TPETRA_INST_INT_INT
       AMESOS2_SUPERLUDIST_LOCAL_INSTANT(double, int, int, NODETYPE)
@@ -412,23 +297,6 @@ TPETRA_ETI_MANGLING_TYPEDEFS()
     #ifdef HAVE_TPETRA_INST_INT_UNSIGNED_LONG
       AMESOS2_SUPERLUDIST_LOCAL_INSTANT(double, int, unsigned long, NODETYPE)
     #endif
-#endif
-#ifdef HAVE_TPETRA_INST_COMPLEX_FLOAT
-  #ifdef HAVE_TPETRA_INST_INT_INT
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(std::complex<float>, int, int, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_LONG
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(std::complex<float>, int, long, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_LONG_LONG
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(std::complex<float>, int, long long, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_UNSIGNED
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(std::complex<float>, int, unsigned int, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_UNSIGNED_LONG
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(std::complex<float>, int, unsigned long, NODETYPE)
-  #endif
 #endif
 #ifdef HAVE_TPETRA_INST_COMPLEX_DOUBLE
     #ifdef HAVE_TPETRA_INST_INT_INT
@@ -452,23 +320,6 @@ TPETRA_ETI_MANGLING_TYPEDEFS()
 
 #if defined(HAVE_TPETRA_INST_CUDA) && !defined(HAVE_TPETRA_DEFAULTNODE_CUDAWRAPPERNODE) && defined(HAVE_TPETRA_INST_DOUBLE) && defined(TPETRA_HAVE_KOKKOS_REFACTOR)
 #define NODETYPE Kokkos_Compat_KokkosCudaWrapperNode
-#ifdef HAVE_TPETRA_INST_FLOAT
-  #ifdef HAVE_TPETRA_INST_INT_INT
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(float, int, int, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_LONG
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(float, int, long, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_LONG_LONG
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(float, int, long long, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_UNSIGNED
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(float, int, unsigned int, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_UNSIGNED_LONG
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(float, int, unsigned long, NODETYPE)
-  #endif
-#endif
 #ifdef HAVE_TPETRA_INST_DOUBLE
   #ifdef HAVE_TPETRA_INST_INT_INT
     AMESOS2_SUPERLUDIST_LOCAL_INSTANT(double, int, int, NODETYPE)
@@ -484,23 +335,6 @@ TPETRA_ETI_MANGLING_TYPEDEFS()
   #endif
   #ifdef HAVE_TPETRA_INST_INT_UNSIGNED_LONG
     AMESOS2_SUPERLUDIST_LOCAL_INSTANT(double, int, unsigned long, NODETYPE)
-  #endif
-#endif
-#ifdef HAVE_TPETRA_INST_COMPLEX_FLOAT
-  #ifdef HAVE_TPETRA_INST_INT_INT
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(std::complex<float>, int, int, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_LONG
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(std::complex<float>, int, long, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_LONG_LONG
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(std::complex<float>, int, long long, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_UNSIGNED
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(std::complex<float>, int, unsigned int, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_UNSIGNED_LONG
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(std::complex<float>, int, unsigned long, NODETYPE)
   #endif
 #endif
 #ifdef HAVE_TPETRA_INST_COMPLEX_DOUBLE


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/amesos2

## Description
    Amesos2: Fix for superludist when float is enabled
    
    Remove float and complex<float> from ETI since superludist only
    implements double and complex<double>
    Should address issue #3566

## Tested

Tested on MacOSX HighSierra, gcc/6.5, mpich, superludist 5.2.2