### PR TITLE
Teko: Adding a "describe" method to the ReorderedLinearOp

### DIFF
--- a/packages/teko/src/Teko_ReorderedLinearOp.cpp
+++ b/packages/teko/src/Teko_ReorderedLinearOp.cpp
@@ -34,4 +34,42 @@ void ReorderedLinearOp::implicitApply(const MultiVector & x, MultiVector & y,
    Thyra::apply(*blockedOp_,Thyra::NOTRANS,*reorderX,reorderY.ptr(),alpha,beta);
 }
 
+void ReorderedLinearOp::describe(Teuchos::FancyOStream & out_arg,
+                                 const Teuchos::EVerbosityLevel verbLevel) const
+{
+  using Teuchos::RCP;
+  using Teuchos::OSTab;
+
+  RCP<Teuchos::FancyOStream> out = rcp(&out_arg,false);
+  OSTab tab(out);
+  switch(verbLevel) {
+     case Teuchos::VERB_DEFAULT:
+     case Teuchos::VERB_LOW:
+        *out << this->description() << std::endl;
+        break;
+     case Teuchos::VERB_MEDIUM:
+     case Teuchos::VERB_HIGH:
+     case Teuchos::VERB_EXTREME:
+        {
+           *out << Teuchos::Describable::description() << "{"
+                << "rangeDim=" << this->range()->dim()
+                << ",domainDim=" << this->domain()->dim()
+                << "}\n";
+           {
+              OSTab tab(out);
+              *out << "[Blocked Op] = ";
+              *out << Teuchos::describe(*blockedOp_,verbLevel);
+           }
+           {
+              OSTab tab(out);
+              *out << "[Blocked Manager] = ";
+              *out << mgr_->toString() << std::endl;
+           }
+           break;
+        }
+     default:
+        TEUCHOS_TEST_FOR_EXCEPT(true); // Should never get here!
+  }
+}
+
 } // end namespace Teko

--- a/packages/teko/src/Teko_ReorderedLinearOp.hpp
+++ b/packages/teko/src/Teko_ReorderedLinearOp.hpp
@@ -91,6 +91,9 @@ public:
    virtual void implicitApply(const MultiVector & x, MultiVector & y,
               const double alpha = 1.0, const double beta = 0.0) const;
 
+   virtual void describe(Teuchos::FancyOStream &out_arg,
+                         const Teuchos::EVerbosityLevel verbLevel) const;
+
 private:
    VectorSpace range_;
    VectorSpace domain_;


### PR DESCRIPTION
Previously this printed the useless "ReorderedLinearOp" string. Now
it has information about the underlying operator.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/teko 

## Description
<!--- Please describe your changes in detail. -->
Changed the describe method

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
Trying to debug something and this didn't worked and slowed down the process. 
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

