### PR TITLE
Change post-push CI server to only rebuild by default (#482)

### DIFF
--- a/cmake/ctest/drivers/sems_ci/README
+++ b/cmake/ctest/drivers/sems_ci/README
@@ -12,10 +12,7 @@ To get this set up on a new machine, just do:
 
   mkdir <ci_base_dir>
   cd <ci_base_dir>/
-  git clone git@github.com:trilinos/Trilinos.git
-  cd Trilinos/
-  git checkout --track origin/develop
-  git branch -d master
+  git clone -b develop git@github.com:trilinos/Trilinos.git
 
 Then create a cronjob (or Jenkins job) that does:
 
@@ -45,7 +42,25 @@ loops.
 
 That is it!
 
-There are a few major weaknesses to this approach:
+To debug the setup, run the script with:
+
+  cd <ci_base_dir>/
+
+  env \
+    Trilinos_PACKAGES=Kokkos,Teuchos \
+    CTEST_DO_UPDATES=OFF \
+    CTEST_DO_SUBMIT=OFF \
+    TRILINOS_CI_SKIP_EMAILS=1 \
+  ./Trilinos/cmake/ctest/drivers/sems_ci/trilinos_ci_sever.sh \
+    &> trilinos_ci_sever.out
+
+and then kill the command once you see what you need to see.
+
+To have the CI build do a rebuild from scratch at the start, set the env var:
+
+  TRILINOS_CI_DO_INITIAL_REBUILD=1
+
+NOTE: There are a few major weaknesses to this approach:
 
 1) If a change is made to the build systems for Trilinos (i.e. in Trilinos or
 TriBITS), then the you may get an error since the version of

--- a/cmake/ctest/drivers/sems_ci/trilinos_ci_sever.sh
+++ b/cmake/ctest/drivers/sems_ci/trilinos_ci_sever.sh
@@ -34,16 +34,25 @@ source /etc/bashrc
 HOSTNAME=`hostname`
 MAILMSG=$TRILINOS_DIR/cmake/tribits/python_utils/mailmsg.py
 
-if [ "$TRILINOS_SKIP_CI_EMAILS" == "" ] ; then
+if [ "$TRILINOS_CI_SKIP_EMAILS" == "" ] ; then
   $MAILMSG "Starting Trilinos standrad CI testing server on '$HOSTNAME'"
 fi
 
 # A) Run the first build starting from scratch
 
-env CI_FIRST_ITERATION=1 \
-  CTEST_START_WITH_EMPTY_BINARY_DIRECTORY=TRUE \
-  CTEST_ENABLE_MODIFIED_PACKAGES_ONLY=OFF \
-  $BASE_COMMAND
+if [[ "${TRILINOS_CI_DO_INITIAL_REBUILD}" == "1" ]] ; then
+  echo
+  echo "Running initial build from scratch since TRILINOS_CI_DO_INITIAL_REBUILD='${TRILINOS_CI_DO_INITIAL_REBUILD}'"
+  echo
+  env CI_FIRST_ITERATION=1 \
+    CTEST_START_WITH_EMPTY_BINARY_DIRECTORY=TRUE \
+    CTEST_ENABLE_MODIFIED_PACKAGES_ONLY=OFF \
+    $BASE_COMMAND
+else
+  echo
+  echo "Skipping initial build from scratch since TRILINOS_CI_DO_INITIAL_REBUILD='${TRILINOS_CI_DO_INITIAL_REBUILD}'"
+  echo
+fi
 
 # B) Run a CI loop that will terminate on time
 
@@ -54,16 +63,16 @@ echo "CI_COMMAND = $CI_COMMAND"
 
 # B.2) Run the CI loop
 
-if [ "$TRILINOS_SKIP_CI_ITERATION" == "" ] ; then
+if [ "$TRILINOS_CI_SKIP_ITERATION" == "" ] ; then
   $TRILINOS_DIR/cmake/tribits/python_utils/generic-looping-demon.py \
   --command="$CI_COMMAND" \
   --today-run-till=$TODAY_RUN_TILL \
   --loop-interval=$LOOP_INTERVAL \
   --pause-file=$PAUSE_FILE
 else
-  echo "Skipping CI iterations because TRILINOS_SKIP_CI_ITERATION = '$TRILINOS_SKIP_CI_ITERATION' != ''"
+  echo "Skipping CI iterations because TRILINOS_CI_SKIP_ITERATION='$TRILINOS_CI_SKIP_ITERATION' != ''"
 fi
 
-if [ "$TRILINOS_SKIP_CI_EMAILS" == "" ] ; then
+if [ "$TRILINOS_CI_SKIP_EMAILS" == "" ] ; then
   $MAILMSG "Ending Trilinos standrad CI testing server on '$HOSTNAME'"
 fi


### PR DESCRIPTION
This will test to see how long we can go just rebuilding Trilinos without requiring a rebuild from scratch.  This will show how fast incremental rebulids can be with Trilinos using just 16 cores.

I tested this locally with:

```
$  env  \
    Trilinos_PACKAGES=Kokkos,Teuchos \
    CTEST_DO_UPDATES=OFF \
    CTEST_DO_SUBMIT=OFF \
    TRILINOS_CI_SKIP_EMAILS=1 \
  ./Trilinos/cmake/ctest/drivers/sems_ci/trilinos_ci_sever.sh &> trilinos_ci_sever.out
```

and

```
$  env  \
    Trilinos_PACKAGES=Kokkos,Teuchos \
    CTEST_DO_UPDATES=OFF \
    CTEST_DO_SUBMIT=OFF \
    TRILINOS_CI_SKIP_EMAILS=1 \
    TRILINOS_CI_DO_INITIAL_REBUILD=1 \
  ./Trilinos/cmake/ctest/drivers/sems_ci/trilinos_ci_sever.sh &> trilinos_ci_sever.out
```

and it looked like it was doing the right thing (not an initial rebuild at first and doing an initial rebuild from scratch in the second).
