### PR TITLE
Fix the default Intel compiler license server for 'sems-rhel7' env (TRIL-255)

### DIFF
--- a/cmake/std/atdm/README.md
+++ b/cmake/std/atdm/README.md
@@ -791,6 +791,13 @@ this can be overridden by setting the env var
 `ATDM_CONFIG_NUM_CORES_ON_MACHINE_OVERRIDE` running `source
 cmake/std/atdm/load-env.sh <build_name>`.
 
+NOTE: The default Intel compiler license server can be overridded by setting
+the env var:
+
+```
+$ export ATDM_CONFIG_LM_LICENSE_FILE_OVERRIDE=<some-url>
+```
+
 
 ### CEE RHEL6 Environment
 

--- a/cmake/std/atdm/sems-rhel7/all_supported_builds.sh
+++ b/cmake/std/atdm/sems-rhel7/all_supported_builds.sh
@@ -7,7 +7,7 @@ export ATDM_CONFIG_ALL_SUPPORTED_BUILDS=(
   sems-rhel7-cuda-9.2-Pascal60-complex-static-release-debug
   sems-rhel7-clang-3.9.0-openmp-complex-shared-release-debug
   sems-rhel7-gnu-7.2.0-openmp-complex-shared-release-debug
-  # sems-rhel7-intel-17.0.1-openmp-complex-shared-release-debug
+  sems-rhel7-intel-17.0.1-openmp-complex-shared-release-debug
   #sems-rhel7-clang-3.9.0-openmp-release-debug
   #sems-rhel7-clang-3.9.0-serial-release-debug
   #sems-rhel7-gnu-7.2.0-openmp-release-debug

--- a/cmake/std/atdm/sems-rhel7/environment.sh
+++ b/cmake/std/atdm/sems-rhel7/environment.sh
@@ -150,6 +150,10 @@ elif [[ "$ATDM_CONFIG_COMPILER" == "INTEL-17.0.1" ]] ; then
   export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SEMS_INTEL_ROOT/mkl/lib/intel64/
   export ATDM_CONFIG_LAPACK_LIBS="-mkl"
   export ATDM_CONFIG_BLAS_LIBS="-mkl"
+  export LM_LICENSE_FILE=28518@cee-infra009.sandia.gov
+  if [[ "${ATDM_CONFIG_LM_LICENSE_FILE_OVERRIDE}" != "" ]] ; then
+    export LM_LICENSE_FILE=${ATDM_CONFIG_LM_LICENSE_FILE_OVERRIDE}
+  fi
 elif [[ "$ATDM_CONFIG_COMPILER" == "CUDA-9.2" ]] ; then
   module load sems-gcc/7.2.0
   module load sems-cuda/9.2


### PR DESCRIPTION
This makes the Intel compiler run much much faster on the machines 'cortado' and 'ascicgpu15' where this was tested.

I tested this on 'ascicgpu15' using:

```
$ ./checkin-test-atdm.sh \
    sems-rhel7-intel-17.0.1-openmp-complex-shared-release-debug \
    --enable-packages=Kokkos,Teuchos --local-do-all --wipe-clean
```
and it returned:

```
PASSED (NOT READY TO PUSH): Trilinos: ascicgpu15

Thu Mar  7 09:51:48 MST 2019

Enabled Packages: Kokkos, Teuchos

Build test results:
-------------------
1) sems-rhel7-intel-17.0.1-openmp-complex-shared-release-debug => passed: passed=164,notpassed=0 (6.78 min)
```

So the intel build is still slow compared to the other builds but not 42 minutes slow like shown [here](https://sems-atlassian-son.sandia.gov/jira/browse/TRIL-264?focusedCommentId=26200&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-26200) with the default intel license server.