### PR TITLE
This disables the ROL_NonlinearProblemTest_MPI_4 test for cuda testing

### DIFF
--- a/cmake/std/PullRequestLinuxCuda9.2TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxCuda9.2TestingSettings.cmake
@@ -52,6 +52,7 @@ set (ROL_example_PDE-OPT_nonlinear-elliptic_example_02_MPI_4_DISABLE ON CACHE BO
 set (ROL_example_PDE-OPT_obstacle_example_01_MPI_4_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
 set (ROL_example_PDE-OPT_topo-opt_poisson_example_01_MPI_4_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
 set (ROL_test_elementwise_TpetraMultiVector_MPI_4_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
+set (ROL_NonlinearProblemTest_MPI_4_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
 set (TpetraCore_Core_initialize_where_tpetra_initializes_kokkos_MPI_1_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
 set (TpetraCore_Core_initialize_where_tpetra_initializes_mpi_and_user_initializes_kokkos_MPI_2_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
 set (TpetraCore_Core_initialize_where_user_initializes_kokkos_MPI_1_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")


### PR DESCRIPTION
While this runs in about 10 seconds on CPU machines it is running
anywhere from 400-600 on CUDA equipment.  This needs to be properly
triaged and repaired before re-enabling it.

@trilinos/framework 
@trilinos/rol 

## Description
Disabled this test until the ROL team can address it. This will allow other teams to get pull requests tested in a reasonable time frame.


## How Has This Been Tested?
Since this is just a test disable I expect that the PR testing is the best way to confirm it works as expected.

