### PR TITLE
Amesos2: Fix for superludist when float is enabled

### DIFF
--- a/cmake/TPLs/FindTPLSuperLU.cmake
+++ b/cmake/TPLs/FindTPLSuperLU.cmake
@@ -56,7 +56,7 @@
 
 TRIBITS_TPL_FIND_INCLUDE_DIRS_AND_LIBRARIES( SuperLU
   REQUIRED_HEADERS supermatrix.h slu_ddefs.h
-  REQUIRED_LIBS_NAMES "superlu superlu_3.0 superlu_4.0 superlu_4.1 superlu_4.2 superlu_4.3 superlu_5.0 superlu_5.1.1"
+  REQUIRED_LIBS_NAMES "superlu superlu_3.0 superlu_4.0 superlu_4.1 superlu_4.2 superlu_4.3 superlu_5.0 superlu_5.1.1 superlu_5.2.1"
   )
 
 include(CheckCSourceCompiles)

--- a/packages/amesos2/src/Amesos2_Superludist.cpp
+++ b/packages/amesos2/src/Amesos2_Superludist.cpp
@@ -58,14 +58,8 @@ namespace Amesos2 {
 #endif
 
 #ifdef HAVE_TPETRA_INST_INT_INT
-#ifdef HAVE_TPETRA_INST_FLOAT
-  AMESOS2_SOLVER_TPETRA_INST(Superludist,float,int,int);
-#endif
 #ifdef HAVE_TPETRA_INST_DOUBLE
   AMESOS2_SOLVER_TPETRA_INST(Superludist,double,int,int);
-#endif
-#ifdef HAVE_TPETRA_INST_COMPLEX_FLOAT
-  AMESOS2_SOLVER_TPETRA_INST(Superludist,std::complex<float>,int,int);
 #endif
 #ifdef HAVE_TPETRA_INST_COMPLEX_DOUBLE
   AMESOS2_SOLVER_TPETRA_INST(Superludist,std::complex<double>,int,int);
@@ -73,14 +67,8 @@ namespace Amesos2 {
 #endif
 
 #ifdef HAVE_TPETRA_INST_INT_UNSIGNED
-#ifdef HAVE_TPETRA_INST_FLOAT
-  AMESOS2_SOLVER_TPETRA_INST(Superludist,float,int,unsigned);
-#endif
 #ifdef HAVE_TPETRA_INST_DOUBLE
   AMESOS2_SOLVER_TPETRA_INST(Superludist,double,int,unsigned);
-#endif
-#ifdef HAVE_TPETRA_INST_COMPLEX_FLOAT
-  AMESOS2_SOLVER_TPETRA_INST(Superludist,std::complex<float>,int,unsigned);
 #endif
 #ifdef HAVE_TPETRA_INST_COMPLEX_DOUBLE
   AMESOS2_SOLVER_TPETRA_INST(Superludist,std::complex<double>,int,unsigned);
@@ -88,14 +76,8 @@ namespace Amesos2 {
 #endif
 
 #ifdef HAVE_TPETRA_INST_INT_LONG
-#ifdef HAVE_TPETRA_INST_FLOAT
-  AMESOS2_SOLVER_TPETRA_INST(Superludist,float,int,long);
-#endif
 #ifdef HAVE_TPETRA_INST_DOUBLE
   AMESOS2_SOLVER_TPETRA_INST(Superludist,double,int,long);
-#endif
-#ifdef HAVE_TPETRA_INST_COMPLEX_FLOAT
-  AMESOS2_SOLVER_TPETRA_INST(Superludist,std::complex<float>,int,long);
 #endif
 #ifdef HAVE_TPETRA_INST_COMPLEX_DOUBLE
   AMESOS2_SOLVER_TPETRA_INST(Superludist,std::complex<double>,int,long);
@@ -103,14 +85,8 @@ namespace Amesos2 {
 #endif
 
 #ifdef HAVE_TPETRA_INST_INT_LONG_LONG
-#ifdef HAVE_TPETRA_INST_FLOAT
-  AMESOS2_SOLVER_TPETRA_INST(Superludist,float,int,long long);
-#endif
 #ifdef HAVE_TPETRA_INST_DOUBLE
   AMESOS2_SOLVER_TPETRA_INST(Superludist,double,int,long long);
-#endif
-#ifdef HAVE_TPETRA_INST_COMPLEX_FLOAT
-  AMESOS2_SOLVER_TPETRA_INST(Superludist,std::complex<float>,int,long long);
 #endif
 #ifdef HAVE_TPETRA_INST_COMPLEX_DOUBLE
   AMESOS2_SOLVER_TPETRA_INST(Superludist,std::complex<double>,int,long long);
@@ -217,20 +193,6 @@ TPETRA_ETI_MANGLING_TYPEDEFS()
 
 #if defined(HAVE_TPETRA_INST_SERIAL) && !defined(HAVE_TPETRA_DEFAULTNODE_SERIALWRAPPERNODE) && defined(HAVE_TPETRA_INST_DOUBLE) && defined(TPETRA_HAVE_KOKKOS_REFACTOR)
 #define NODETYPE Kokkos_Compat_KokkosSerialWrapperNode
-#ifdef HAVE_TPETRA_INST_FLOAT
-  #ifdef HAVE_TPETRA_INST_INT_INT
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(float, int, int, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_LONG
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(float, int, long, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_LONG_LONG
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(float, int, long long, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_UNSIGNED
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(float, int, unsigned int, NODETYPE)
-  #endif
-#endif
 #ifdef HAVE_TPETRA_INST_DOUBLE
     #ifdef HAVE_TPETRA_INST_INT_INT
       AMESOS2_SUPERLUDIST_LOCAL_INSTANT(double, int, int, NODETYPE)
@@ -244,20 +206,6 @@ TPETRA_ETI_MANGLING_TYPEDEFS()
     #ifdef HAVE_TPETRA_INST_INT_UNSIGNED
       AMESOS2_SUPERLUDIST_LOCAL_INSTANT(double, int, unsigned int, NODETYPE)
     #endif
-#endif
-#ifdef HAVE_TPETRA_INST_COMPLEX_FLOAT
-  #ifdef HAVE_TPETRA_INST_INT_INT
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(std::complex<float>, int, int, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_LONG
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(std::complex<float>, int, long, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_LONG_LONG
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(std::complex<float>, int, long long, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_UNSIGNED
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(std::complex<float>, int, unsigned int, NODETYPE)
-  #endif
 #endif
 #ifdef HAVE_TPETRA_INST_COMPLEX_DOUBLE
     #ifdef HAVE_TPETRA_INST_INT_INT
@@ -278,20 +226,6 @@ TPETRA_ETI_MANGLING_TYPEDEFS()
 
 #if defined(HAVE_TPETRA_INST_PTHREAD) && !defined(HAVE_TPETRA_DEFAULTNODE_THREADSWRAPPERNODE) && defined(HAVE_TPETRA_INST_DOUBLE) && defined(TPETRA_HAVE_KOKKOS_REFACTOR)
 #define NODETYPE Kokkos_Compat_KokkosThreadsWrapperNode
-#ifdef HAVE_TPETRA_INST_FLOAT
-  #ifdef HAVE_TPETRA_INST_INT_INT
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(float, int, int, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_LONG
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(float, int, long, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_LONG_LONG
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(float, int, long long, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_UNSIGNED
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(float, int, unsigned int, NODETYPE)
-  #endif
-#endif
 #ifdef HAVE_TPETRA_INST_DOUBLE
     #ifdef HAVE_TPETRA_INST_INT_INT
       AMESOS2_SUPERLUDIST_LOCAL_INSTANT(double, int, int, NODETYPE)
@@ -305,20 +239,6 @@ TPETRA_ETI_MANGLING_TYPEDEFS()
     #ifdef HAVE_TPETRA_INST_INT_UNSIGNED
       AMESOS2_SUPERLUDIST_LOCAL_INSTANT(double, int, unsigned int, NODETYPE)
     #endif
-#endif
-#ifdef HAVE_TPETRA_INST_COMPLEX_FLOAT
-  #ifdef HAVE_TPETRA_INST_INT_INT
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(std::complex<float>, int, int, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_LONG
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(std::complex<float>, int, long, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_LONG_LONG
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(std::complex<float>, int, long long, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_UNSIGNED
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(std::complex<float>, int, unsigned int, NODETYPE)
-  #endif
 #endif
 #ifdef HAVE_TPETRA_INST_COMPLEX_DOUBLE
     #ifdef HAVE_TPETRA_INST_INT_INT
@@ -339,20 +259,6 @@ TPETRA_ETI_MANGLING_TYPEDEFS()
 
 #if defined(HAVE_TPETRA_INST_OPENMP) && !defined(HAVE_TPETRA_DEFAULTNODE_OPENMPWRAPPERNODE) && defined(HAVE_TPETRA_INST_DOUBLE) && defined(TPETRA_HAVE_KOKKOS_REFACTOR)
 #define NODETYPE Kokkos_Compat_KokkosOpenMPWrapperNode
-#ifdef HAVE_TPETRA_INST_FLOAT
-  #ifdef HAVE_TPETRA_INST_INT_INT
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(float, int, int, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_LONG
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(float, int, long, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_LONG_LONG
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(float, int, long long, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_UNSIGNED
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(float, int, unsigned int, NODETYPE)
-  #endif
-#endif
 #ifdef HAVE_TPETRA_INST_DOUBLE
     #ifdef HAVE_TPETRA_INST_INT_INT
       AMESOS2_SUPERLUDIST_LOCAL_INSTANT(double, int, int, NODETYPE)
@@ -366,20 +272,6 @@ TPETRA_ETI_MANGLING_TYPEDEFS()
     #ifdef HAVE_TPETRA_INST_INT_UNSIGNED
       AMESOS2_SUPERLUDIST_LOCAL_INSTANT(double, int, unsigned int, NODETYPE)
     #endif
-#endif
-#ifdef HAVE_TPETRA_INST_COMPLEX_FLOAT
-  #ifdef HAVE_TPETRA_INST_INT_INT
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(std::complex<float>, int, int, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_LONG
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(std::complex<float>, int, long, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_LONG_LONG
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(std::complex<float>, int, long long, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_UNSIGNED
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(std::complex<float>, int, unsigned int, NODETYPE)
-  #endif
 #endif
 #ifdef HAVE_TPETRA_INST_COMPLEX_DOUBLE
     #ifdef HAVE_TPETRA_INST_INT_INT
@@ -400,20 +292,6 @@ TPETRA_ETI_MANGLING_TYPEDEFS()
 
 #if defined(HAVE_TPETRA_INST_CUDA) && !defined(HAVE_TPETRA_DEFAULTNODE_CUDAWRAPPERNODE) && defined(HAVE_TPETRA_INST_DOUBLE) && defined(TPETRA_HAVE_KOKKOS_REFACTOR)
 #define NODETYPE Kokkos_Compat_KokkosCudaWrapperNode
-#ifdef HAVE_TPETRA_INST_FLOAT
-  #ifdef HAVE_TPETRA_INST_INT_INT
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(float, int, int, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_LONG
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(float, int, long, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_LONG_LONG
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(float, int, long long, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_UNSIGNED
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(float, int, unsigned int, NODETYPE)
-  #endif
-#endif
 #ifdef HAVE_TPETRA_INST_DOUBLE
   #ifdef HAVE_TPETRA_INST_INT_INT
     AMESOS2_SUPERLUDIST_LOCAL_INSTANT(double, int, int, NODETYPE)
@@ -426,20 +304,6 @@ TPETRA_ETI_MANGLING_TYPEDEFS()
   #endif
   #ifdef HAVE_TPETRA_INST_INT_UNSIGNED
     AMESOS2_SUPERLUDIST_LOCAL_INSTANT(double, int, unsigned int, NODETYPE)
-  #endif
-#endif
-#ifdef HAVE_TPETRA_INST_COMPLEX_FLOAT
-  #ifdef HAVE_TPETRA_INST_INT_INT
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(std::complex<float>, int, int, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_LONG
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(std::complex<float>, int, long, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_LONG_LONG
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(std::complex<float>, int, long long, NODETYPE)
-  #endif
-  #ifdef HAVE_TPETRA_INST_INT_UNSIGNED
-    AMESOS2_SUPERLUDIST_LOCAL_INSTANT(std::complex<float>, int, unsigned int, NODETYPE)
   #endif
 #endif
 #ifdef HAVE_TPETRA_INST_COMPLEX_DOUBLE


### PR DESCRIPTION
Remove float and complex<float> from ETI since suplerludist only
implements double and complex<double>
