### PR TITLE
Sacdo:  Fix std::pow(Fad,Const) again.

### DIFF
--- a/packages/sacado/src/Sacado_CacheFad_Ops.hpp
+++ b/packages/sacado/src/Sacado_CacheFad_Ops.hpp
@@ -1814,11 +1814,11 @@ namespace Sacado {
         const value_type_1 v1 = expr1.val();
         const value_type_2 v2 = expr2.val();
         v = std::pow(v1,v2);
-        if (v1 == value_type_1(0) || v2 == value_type_2(0)) {
+        if (v1 == value_type_1(0)) {
           a = value_type(0);
         }
         else {
-          a = v2*std::pow(v1,v2-value_type_2(1.0));
+          a = v*v2/v1;
         }
       }
 

--- a/packages/sacado/src/Sacado_ELRCacheFad_Ops.hpp
+++ b/packages/sacado/src/Sacado_ELRCacheFad_Ops.hpp
@@ -2573,11 +2573,11 @@ namespace Sacado {
         const value_type_1 v1 = expr1.val();
         const value_type_2 v2 = expr2.val();
         v = std::pow(v1,v2);
-        if (v1 == scalar_type(0.0) || v2 == scalar_type(0.0)) {
+        if (v1 == scalar_type(0.0)) {
           a = scalar_type(0.0);
         }
         else {
-          a = v2*std::pow(v1,v2-scalar_type(1.0));
+          a = v*v2/v1;
         }
       }
 

--- a/packages/sacado/src/Sacado_ELRFad_Ops.hpp
+++ b/packages/sacado/src/Sacado_ELRFad_Ops.hpp
@@ -895,9 +895,9 @@ FAD_BINARYOP_MACRO(pow,
                    expr1.val() == value_type(0) ? value_type(0) : value_type((expr2.dx(i)*std::log(expr1.val())+expr2.val()*expr1.dx(i)/expr1.val())*std::pow(expr1.val(),expr2.val())),
                    expr1.val() == value_type(0) ? value_type(0.0) : value_type((expr2.fastAccessDx(i)*std::log(expr1.val())+expr2.val()*expr1.fastAccessDx(i)/expr1.val())*std::pow(expr1.val(),expr2.val())),
                    expr1.val() == value_type(0) ? value_type(0) : value_type(expr2.dx(i)*std::log(expr1.val())*std::pow(expr1.val(),expr2.val())),
-                   expr2.val() == scalar_type(0) || expr1.val() == value_type(0.0) ? value_type(0.0) : value_type(expr2.val()*expr1.dx(i)*std::pow(expr1.val(),expr2.val()-scalar_type(1.0))),
+                   expr1.val() == value_type(0.0) ? value_type(0.0) : value_type(expr2.val()*expr1.dx(i)/expr1.val()*std::pow(expr1.val(),expr2.val())),
                    expr1.val() == value_type(0) ? value_type(0) : value_type(expr2.fastAccessDx(i)*std::log(expr1.val())*std::pow(expr1.val(),expr2.val())),
-                   expr2.val() == scalar_type(0) || expr1.val() == value_type(0.0) ? value_type(0.0) : value_type(expr2.val()*expr1.fastAccessDx(i)*std::pow(expr1.val(),expr2.val()-scalar_type(1.0))))
+                   expr1.val() == value_type(0.0) ? value_type(0.0) : value_type(expr2.val()*expr1.fastAccessDx(i)/expr1.val()*std::pow(expr1.val(),expr2.val())))
 FAD_BINARYOP_MACRO(max,
                    MaxOp,
                    expr1.val() >= expr2.val() ? expr1.val() : expr2.val(),

--- a/packages/sacado/src/Sacado_Fad_Ops.hpp
+++ b/packages/sacado/src/Sacado_Fad_Ops.hpp
@@ -1157,17 +1157,17 @@ namespace Sacado {
       KOKKOS_INLINE_FUNCTION
       const value_type dx(int i) const {
         using std::pow;
-        // Use formula (a(x)^b)' = b*a(x)^{b-1}*a'(x), check for b == 0 case
-        // Use scalar_type in (b-1) to prevent promoting to Fad when nesting
-        return if_then_else( c.val() == scalar_type(0.0) || expr1.val() == value_type(0.0), value_type(0.0), value_type(c.val()*expr1.dx(i)*pow(expr1.val(),c.val()-scalar_type(1.0))) );
+        // Don't use formula (a(x)^b)' = b*a(x)^{b-1}*a'(x)
+        // It seems less accurate and caused convergence problems in some codes
+        return if_then_else( expr1.val() == value_type(0.0), value_type(0.0), value_type(c.val()*expr1.dx(i)/expr1.val()*pow(expr1.val(),c.val())) );
       }
 
       KOKKOS_INLINE_FUNCTION
       const value_type fastAccessDx(int i) const {
         using std::pow;
-        // Use formula (a(x)^b)' = b*a(x)^{b-1}*a'(x), check for b == 0 case
-        // Use scalar_type in (b-1) to prevent promoting to Fad when nesting
-        return if_then_else( c.val() == scalar_type(0.0) || expr1.val() == value_type(0.0), value_type(0.0), value_type(c.val()*expr1.fastAccessDx(i)*pow(expr1.val(),c.val()-scalar_type(1.0))) );
+        // Don't use formula (a(x)^b)' = b*a(x)^{b-1}*a'(x)
+        // It seems less accurate and caused convergence problems in some codes
+        return if_then_else( expr1.val() == value_type(0.0), value_type(0.0), value_type(c.val()*expr1.fastAccessDx(i)/expr1.val()*pow(expr1.val(),c.val())));
       }
 
     protected:
@@ -1381,17 +1381,17 @@ namespace Sacado {
       KOKKOS_INLINE_FUNCTION
       const value_type dx(int i) const {
         using std::pow;
-        // Use formula (a(x)^b)' = b*a(x)^{b-1}*a'(x), check for b == 0 case
-        // Use scalar_type in (b-1) to prevent promoting to Fad when nesting
-        return c.val() == scalar_type(0.0) || expr1.val() == value_type(0.0) ? value_type(0.0) : value_type(c.val()*expr1.dx(i)*pow(expr1.val(),c.val()-scalar_type(1.0)));
+        // Don't use formula (a(x)^b)' = b*a(x)^{b-1}*a'(x)
+        // It seems less accurate and caused convergence problems in some codes
+        return expr1.val() == value_type(0.0) ? value_type(0.0) : value_type(c.val()*expr1.dx(i)/expr1.val()*pow(expr1.val(),c.val()));
       }
 
       KOKKOS_INLINE_FUNCTION
       const value_type fastAccessDx(int i) const {
         using std::pow;
-        // Use formula (a(x)^b)' = b*a(x)^{b-1}*a'(x), check for b == 0 case
-        // Use scalar_type in (b-1) to prevent promoting to Fad when nesting
-        return c.val() == scalar_type(0.0) || expr1.val() == value_type(0.0) ? value_type(0.0) : value_type(c.val()*expr1.fastAccessDx(i)*pow(expr1.val(),c.val()-scalar_type(1.0)));
+        // Don't use formula (a(x)^b)' = b*a(x)^{b-1}*a'(x)
+        // It seems less accurate and caused convergence problems in some codes
+        return expr1.val() == value_type(0.0) ? value_type(0.0) : value_type(c.val()*expr1.fastAccessDx(i)/expr1.val()*pow(expr1.val(),c.val()));
       }
 
     protected:

--- a/packages/sacado/src/new_design/Sacado_Fad_Exp_Ops.hpp
+++ b/packages/sacado/src/new_design/Sacado_Fad_Exp_Ops.hpp
@@ -742,8 +742,9 @@ namespace Sacado {
         if (sz1 > 0 && sz2 > 0)
           return if_then_else( expr1.val() == value_type(0.0), value_type(0.0), value_type((expr2.dx(i)*log(expr1.val())+expr2.val()*expr1.dx(i)/expr1.val())*pow(expr1.val(),expr2.val())) );
         else if (sz1 > 0)
-          // Use formula (a(x)^b)' = b*a(x)^{b-1}*a'(x), check for b == 0 case
-          return if_then_else( expr2.val() == value_type(0.0) || expr1.val() == value_type(0.0), value_type(0.0), value_type(expr2.val()*expr1.dx(i)*pow(expr1.val(),expr2.val()-scalar_type(1.0))) );
+          // Don't use formula (a(x)^b)' = b*a(x)^{b-1}*a'(x)
+          // It seems less accurate and caused convergence problems in some codes
+          return if_then_else(expr1.val() == value_type(0.0), value_type(0.0), value_type(expr2.val()*expr1.dx(i)/expr1.val()*pow(expr1.val(),expr2.val())) );
         else
           return if_then_else( expr1.val() == value_type(0.0), value_type(0.0), value_type(expr2.dx(i)*log(expr1.val())*pow(expr1.val(),expr2.val())) );
       }
@@ -796,17 +797,17 @@ namespace Sacado {
       KOKKOS_INLINE_FUNCTION
       value_type dx(int i) const {
         using std::pow;
-        // Use formula (a(x)^b)' = b*a(x)^{b-1}*a'(x), check for b == 0 case
-        // Use scalar_type in (b-1) to prevent promoting to Fad when nesting
-        return if_then_else( c == scalar_type(0.0) || expr1.val() == value_type(0.0), value_type(0.0), value_type(c*expr1.dx(i)*pow(expr1.val(),c-scalar_type(1.0))) );
+        // Don't use formula (a(x)^b)' = b*a(x)^{b-1}*a'(x)
+        // It seems less accurate and caused convergence problems in some codes
+        return if_then_else( expr1.val() == value_type(0.0), value_type(0.0), value_type(c*expr1.dx(i)/expr1.val()*pow(expr1.val(),c)) );
       }
 
       KOKKOS_INLINE_FUNCTION
       value_type fastAccessDx(int i) const {
         using std::pow;
-        // Use formula (a(x)^b)' = b*a(x)^{b-1}*a'(x), check for b == 0 case
-        // Use scalar_type in (b-1) to prevent promoting to Fad when nesting
-        return if_then_else( c == scalar_type(0.0) || expr1.val() == value_type(0.0), value_type(0.0), value_type(c*expr1.fastAccessDx(i)*pow(expr1.val(),c-scalar_type(1.0))) );
+        // Don't use formula (a(x)^b)' = b*a(x)^{b-1}*a'(x)
+        // It seems less accurate and caused convergence problems in some codes
+        return if_then_else( expr1.val() == value_type(0.0), value_type(0.0), value_type(c*expr1.fastAccessDx(i)/expr1.val()*pow(expr1.val(),c)) );
       }
 
     protected:
@@ -916,8 +917,9 @@ namespace Sacado {
         if (sz1 > 0 && sz2 > 0)
           return expr1.val() == value_type(0.0) ? value_type(0.0) : value_type((expr2.dx(i)*log(expr1.val())+expr2.val()*expr1.dx(i)/expr1.val())*pow(expr1.val(),expr2.val()));
         else if (sz1 > 0)
-          // Use formula (a(x)^b)' = b*a(x)^{b-1}*a'(x), check for b == 0 case
-          return expr2.val() == value_type(0.0) || expr1.val() == value_type(0.0) ? value_type(0.0) : value_type(expr2.val()*expr1.dx(i)*pow(expr1.val(),expr2.val()-scalar_type(1.0)));
+          // Don't use formula (a(x)^b)' = b*a(x)^{b-1}*a'(x)
+          // It seems less accurate and caused convergence problems in some codes
+          return expr1.val() == value_type(0.0) ? value_type(0.0) : value_type(expr2.val()*expr1.dx(i)/expr1.val()*pow(expr1.val(),expr2.val()));
         else
           return expr1.val() == value_type(0.0) ? value_type(0.0) : value_type(expr2.dx(i)*log(expr1.val())*pow(expr1.val(),expr2.val()));
       }
@@ -970,17 +972,17 @@ namespace Sacado {
       KOKKOS_INLINE_FUNCTION
       value_type dx(int i) const {
         using std::pow;
-        // Use formula (a(x)^b)' = b*a(x)^{b-1}*a'(x), check for b == 0 case
-        // Use scalar_type in (b-1) to prevent promoting to Fad when nesting
-        return c == scalar_type(0.0) || expr1.val() == value_type(0.0) ? value_type(0.0) : value_type(c*expr1.dx(i)*pow(expr1.val(),c-scalar_type(1.0)));
+        // Don't use formula (a(x)^b)' = b*a(x)^{b-1}*a'(x)
+        // It seems less accurate and caused convergence problems in some codes
+        return expr1.val() == value_type(0.0) ? value_type(0.0) : value_type(c*expr1.dx(i)/expr1.val()*pow(expr1.val(),c));
       }
 
       KOKKOS_INLINE_FUNCTION
       value_type fastAccessDx(int i) const {
         using std::pow;
-        // Use formula (a(x)^b)' = b*a(x)^{b-1}*a'(x), check for b == 0 case
-        // Use scalar_type in (b-1) to prevent promoting to Fad when nesting
-        return c == scalar_type(0.0) || expr1.val() == value_type(0.0) ? value_type(0.0) : value_type(c*expr1.fastAccessDx(i)*pow(expr1.val(),c-scalar_type(1.0)));
+        // Don't use formula (a(x)^b)' = b*a(x)^{b-1}*a'(x)
+        // It seems less accurate and caused convergence problems in some codes
+        return expr1.val() == value_type(0.0) ? value_type(0.0) : value_type(c*expr1.fastAccessDx(i)/expr1.val()*pow(expr1.val(),c));
       }
 
     protected:

--- a/packages/sacado/test/TestSuite/NestedFadUnitTests.hpp
+++ b/packages/sacado/test/TestSuite/NestedFadUnitTests.hpp
@@ -354,20 +354,15 @@ public:
     b = 0.0;
     c = pow(a, b);
     cc.val() = FadType(n2,1.0);
-#ifdef SACADO_NEW_FAD_DESIGN_IS_DEFAULT
-    for (int i=0; i<n1; ++i)
-      cc.fastAccessDx(i) = 0.0;
-#else
     for (int i=0; i<n1; ++i)
       cc.fastAccessDx(i) = FadType(n2,0.0);
-#endif
     COMPARE_NESTED_FADS(c, cc);
 
     // Constant scalar b == 0
     c = pow(a, b.val());
     cc.val() = FadType(n2,1.0);
     for (int i=0; i<n1; ++i)
-      cc.fastAccessDx(i) = 0.0;
+      cc.fastAccessDx(i) = FadType(n2,0.0);
     COMPARE_NESTED_FADS(c, cc);
     c = pow(a, b.val().val());
     COMPARE_NESTED_FADS(c, cc);

--- a/packages/stokhos/src/sacado/kokkos/vector/Fad/Sacado_Fad_Exp_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/Fad/Sacado_Fad_Exp_MP_Vector.hpp
@@ -1097,8 +1097,9 @@ namespace Sacado {
         if (sz1 > 0 && sz2 > 0)
           return if_then_else( expr1.val(j) == val_type(0.0), val_type(0.0), val_type((expr2.dx(i,j)*log(expr1.val(j))+expr2.val(j)*expr1.dx(i,j)/expr1.val(j))*pow(expr1.val(j),expr2.val(j))) );
         else if (sz1 > 0)
-          // Use formula (a(x)^b)' = b*a(x)^{b-1}*a'(x), check for b == 0 case
-          return if_then_else( expr2.val(j) == val_type(0.0), val_type(0.0), val_type(expr2.val(j)*expr1.dx(i,j)*pow(expr1.val(j),expr2.val(j)-val_type(1.0))) );
+          // Don't use formula (a(x)^b)' = b*a(x)^{b-1}*a'(x)
+          // It seems less accurate and caused convergence problems in some codes
+          return if_then_else( expr1.val(j) == val_type(0.0), val_type(0.0), val_type(expr2.val(j)*expr1.dx(i,j)/expr1.val(j)*pow(expr1.val(j),expr2.val(j))) );
         else
           return if_then_else( expr1.val(j) == val_type(0.0), val_type(0.0), val_type(expr2.dx(i,j)*log(expr1.val(j))*pow(expr1.val(j),expr2.val(j))) );
       }
@@ -1159,15 +1160,17 @@ namespace Sacado {
       KOKKOS_INLINE_FUNCTION
       val_type dx(int i, int j) const {
         using std::pow;
-        // Use formula (a(x)^b)' = b*a(x)^{b-1}*a'(x), check for b == 0 case
-        return if_then_else( c.fastAccessCoeff(j) == val_type(0.0), val_type(0.0), val_type(c.fastAccessCoeff(j)*expr1.dx(i,j)*pow(expr1.val(j),c.fastAccessCoeff(j)-val_type(1.0))) );
+        // Don't use formula (a(x)^b)' = b*a(x)^{b-1}*a'(x)
+        // It seems less accurate and caused convergence problems in some codes
+        return if_then_else( expr1.val(j) == val_type(0.0), val_type(0.0), val_type(c.fastAccessCoeff(j)*expr1.dx(i,j)/expr1.val(j)*pow(expr1.val(j),c.fastAccessCoeff(j))) );
       }
 
       KOKKOS_INLINE_FUNCTION
       val_type fastAccessDx(int i, int j) const {
         using std::pow;
-        // Use formula (a(x)^b)' = b*a(x)^{b-1}*a'(x), check for b == 0 case
-        return if_then_else( c.fastAccessCoeff(j) == val_type(0.0), val_type(0.0), val_type(c.fastAccessCoeff(j)*expr1.fastAccessDx(i,j)*pow(expr1.val(j),c.fastAccessCoeff(j)-val_type(1.0))) );
+        // Don't use formula (a(x)^b)' = b*a(x)^{b-1}*a'(x)
+        // It seems less accurate and caused convergence problems in some codes
+        return if_then_else( expr1.val(j) == val_type(0.0), val_type(0.0), val_type(c.fastAccessCoeff(j)*expr1.fastAccessDx(i,j)/expr1.val(j)*pow(expr1.val(j),c.fastAccessCoeff(j))) );
       }
 
     protected:
@@ -1293,8 +1296,9 @@ namespace Sacado {
         if (sz1 > 0 && sz2 > 0)
           return expr1.val(j) == val_type(0.0) ? val_type(0.0) : val_type((expr2.dx(i,j)*log(expr1.val(j))+expr2.val(j)*expr1.dx(i,j)/expr1.val(j))*pow(expr1.val(j),expr2.val(j)));
         else if (sz1 > 0)
-          // Use formula (a(x)^b)' = b*a(x)^{b-1}*a'(x), check for b == 0 case
-          return expr2.val(j) == val_type(0.0) ? val_type(0.0) : val_type(expr2.val(j)*expr1.dx(i,j)*pow(expr1.val(j),expr2.val(j)-val_type(1.0)));
+          // Don't use formula (a(x)^b)' = b*a(x)^{b-1}*a'(x)
+          // It seems less accurate and caused convergence problems in some codes
+          return expr1.val(j) == val_type(0.0) ? val_type(0.0) : val_type(expr2.val(j)*expr1.dx(i,j)/expr1.val(j)*pow(expr1.val(j),expr2.val(j)));
         else
           return expr1.val(j) == val_type(0.0) ? val_type(0.0) : val_type(expr2.dx(i,j)*log(expr1.val(j))*pow(expr1.val(j),expr2.val(j)));
       }
@@ -1355,15 +1359,17 @@ namespace Sacado {
       KOKKOS_INLINE_FUNCTION
       val_type dx(int i, int j) const {
         using std::pow;
-        // Use formula (a(x)^b)' = b*a(x)^{b-1}*a'(x), check for b == 0 case
-        return c.fastAccessCoeff(j) == val_type(0.0) ? val_type(0.0) : val_type(c.fastAccessCoeff(j)*expr1.dx(i,j)*pow(expr1.val(j),c.fastAccessCoeff(j)-val_type(1.0)));
+        // Don't use formula (a(x)^b)' = b*a(x)^{b-1}*a'(x)
+        // It seems less accurate and caused convergence problems in some codes
+        return expr1.val(j) == val_type(0.0) ? val_type(0.0) : val_type(c.fastAccessCoeff(j)*expr1.dx(i,j)/expr1.val(j)*pow(expr1.val(j),c.fastAccessCoeff(j)));
       }
 
       KOKKOS_INLINE_FUNCTION
       val_type fastAccessDx(int i, int j) const {
         using std::pow;
-        // Use formula (a(x)^b)' = b*a(x)^{b-1}*a'(x), check for b == 0 case
-        return c.fastAccessCoeff(j) == val_type(0.0) ? val_type(0.0) : val_type(c.fastAccessCoeff(j)*expr1.fastAccessDx(i,j)*pow(expr1.val(j),c.fastAccessCoeff(j)-val_type(1.0)));
+        // Don't use formula (a(x)^b)' = b*a(x)^{b-1}*a'(x)
+        // It seems less accurate and caused convergence problems in some codes
+        return expr1.val(j) == val_type(0.0) ? val_type(0.0) : val_type(c.fastAccessCoeff(j)*expr1.fastAccessDx(i,j)/expr1.val(j)*pow(expr1.val(j),c.fastAccessCoeff(j)));
       }
 
     protected:


### PR DESCRIPTION
My change of the formula for differentiating std:pow(x,y) with constant
y seems to be causing some numerical stability issues (which is
surprising because it just replaces x^y/x with x^{y-1}).  So I am
reverting that change and going back to the old formula.  I still want
to understand why it is problematic, but it is impacting a customer, so
I am changing it now anyway.  See here for the relevant discussion:

https://cee-gitlab.sandia.gov/Charon/tcad-charon/issues/96#note_179767