### PR TITLE
unload sems-python after loading sems-boost

### DIFF
--- a/cmake/std/atdm/common/toss3/environment.sh
+++ b/cmake/std/atdm/common/toss3/environment.sh
@@ -39,7 +39,8 @@ if [ "$ATDM_CONFIG_COMPILER" == "INTEL" ]; then
     module load sems-hdf5/1.8.12/parallel
     module load sems-netcdf/4.4.1/exo_parallel 
     module load sems-yaml_cpp/0.5.3/base 
-    module load sems-boost/1.59.0/base  
+    module load sems-boost/1.59.0/base
+    module unload sems-python/2.7.9
     module load intel/17.0.4.196
     module load mkl/17.0.4.196
     export BOOST_ROOT=$SEMS_BOOST_ROOT

--- a/cmake/std/atdm/sems-rhel6/environment.sh
+++ b/cmake/std/atdm/sems-rhel6/environment.sh
@@ -166,6 +166,7 @@ module load sems-netcdf/4.4.1/exo_parallel
 module load sems-hdf5/1.8.12/parallel
 module load sems-zlib/1.2.8/base
 module load sems-boost/1.59.0/base
+module unload sems-python/2.7.9 
 module load sems-superlu/4.3/base
 
 if [[ "${ATDM_CONFIG_SHARED_LIBS}" == "ON" ]] ; then

--- a/cmake/std/atdm/sems-rhel7/environment.sh
+++ b/cmake/std/atdm/sems-rhel7/environment.sh
@@ -183,6 +183,7 @@ module load sems-netcdf/4.4.1/exo_parallel
 module load sems-hdf5/1.8.12/parallel
 module load sems-zlib/1.2.8/base
 module load sems-boost/1.59.0/base
+module unload sems-python/2.7.9 
 module load sems-superlu/4.3/base
 
 if [[ "$ATDM_CONFIG_COMPILER" == "CUDA"* ]] && \


### PR DESCRIPTION
## Description
This just unloads the sems-python module that is automatically loaded by the sems-boost module on the rhel6 and rhel7 systems

## Motivation and Context
having this python loaded is annoying to developers and I don't think we need it

## How Has This Been Tested?
I ran builds on rhel6, rhel7, and chama and they seem fine 

@bartlettroscoe do you have any concerns about doing this? Scot requested this on his behalf and other empire folks
