### PR TITLE
Ifpack2 - for the testing with kokkos bound check

### DIFF
--- a/cmake/std/PullRequestLinuxCommonTestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxCommonTestingSettings.cmake
@@ -57,6 +57,9 @@ set (Zoltan2_orderingTestDriverExample_MPI_1_DISABLE ON CACHE BOOL "Set by defau
 # Disable long-failing Piro test until it can be fixed (#826)
 set (Piro_EpetraSolver_MPI_4_DISABLE ON CACHE BOOL "Set by default for PR testing")
 
+# Disable tests that timeout in PR testing until it can be fixed (#4614)
+set (PanzerAdaptersSTK_PoissonInterfaceExample_2d_diffsideids_MPI_1_DISABLE ON CACHE BOOL "Set by default for PR testing")
+
 # Options from SEMSDevEnv.cmake
 
 SET(CMAKE_C_COMPILER "$ENV{MPICC}" CACHE FILEPATH "Set by default for PR testing")

--- a/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
@@ -1751,8 +1751,10 @@ namespace Ifpack2 {
           Kokkos::parallel_for
             (Kokkos::ThreadVectorRange(member, vector_loop_size), [&](const local_ordinal_type &v) {
               const local_ordinal_type vbeg = v*internal_vector_length;
-	      extract(member, partidx+vbeg, npacks, vbeg);
-              factorize(member, i0, nrows, v, internal_vector_values, WW);
+              if (vbeg < npacks) {
+                extract(member, partidx+vbeg, npacks, vbeg);
+                factorize(member, i0, nrows, v, internal_vector_values, WW);
+              }
             });
         }
       }


### PR DESCRIPTION
## Description
Ifpack2 blodk tridiag solver fails when kokkos bound check is enabled. I put an additional index guard in extract routine. 

## Related Issues
#4597 

## How Has This Been Tested?
Tested on white P100.

@jjellio @jhux2 