### PR TITLE
Disable tests timing out in PR autotester

### DIFF
--- a/cmake/std/PullRequestLinuxCommonTestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxCommonTestingSettings.cmake
@@ -57,6 +57,11 @@ set (Zoltan2_orderingTestDriverExample_MPI_1_DISABLE ON CACHE BOOL "Set by defau
 # Disable long-failing Piro test until it can be fixed (#826)
 set (Piro_EpetraSolver_MPI_4_DISABLE ON CACHE BOOL "Set by default for PR testing")
 
+# Disable tests that timeout in PR testing until it can be fixed (#4614)
+set (ROL_example_PDE-OPT_0ld_adv-diff-react_example_02_MPI_4_DISABLE ON CACHE BOOL "Set by default for PR testing")
+set (ROL_example_PDE-OPT_navier-stokes_example_01_MPI_4_DISABLE ON CACHE BOOL "Set by default for PR testing")
+set (PanzerAdaptersSTK_PoissonInterfaceExample_2d_diffsideids_MPI_1_DISABLE ON CACHE BOOL "Set by default for PR testing")
+
 # Options from SEMSDevEnv.cmake
 
 SET(CMAKE_C_COMPILER "$ENV{MPICC}" CACHE FILEPATH "Set by default for PR testing")


### PR DESCRIPTION
Temporarily address #4614 to get PR tests passing.

Not adding AUTOMERGE label, will let @trilinos/framework make the call or close this PR with their preferred solution. 
