### PR TITLE
Explicitly use *.so or *.a libs for shared or static builds for 'sems-rhel6' env (CDOFA-41)

### DIFF
--- a/cmake/std/atdm/sems-rhel6/environment.sh
+++ b/cmake/std/atdm/sems-rhel6/environment.sh
@@ -182,11 +182,11 @@ export BOOST_ROOT=${SEMS_BOOST_ROOT}
 export HDF5_ROOT=${SEMS_HDF5_ROOT}
 export NETCDF_ROOT=${SEMS_NETCDF_ROOT}
 
-export ATDM_CONFIG_HDF5_LIBS="-L${SEMS_HDF5_ROOT}/lib;${SEMS_HDF5_ROOT}/lib/libhdf5_hl.a;${SEMS_HDF5_ROOT}/lib/libhdf5.a;-lz;-ldl"
-export ATDM_CONFIG_NETCDF_LIBS="-L${SEMS_BOOST_ROOT}/lib;-L${SEMS_NETCDF_ROOT}/lib;-L${SEMS_NETCDF_ROOT}/lib;-L${SEMS_PNETCDF_ROOT}/lib;-L${SEMS_HDF5_ROOT}/lib;${SEMS_BOOST_ROOT}/lib/libboost_program_options.${ATDM_CONFIG_TPL_LIB_EXT};${SEMS_BOOST_ROOT}/lib/libboost_system.${ATDM_CONFIG_TPL_LIB_EXT};${SEMS_NETCDF_ROOT}/lib/libnetcdf.a;${SEMS_NETCDF_ROOT}/lib/libpnetcdf.a;${SEMS_HDF5_ROOT}/lib/libhdf5_hl.a;${SEMS_HDF5_ROOT}/lib/libhdf5.a;-lz;-ldl;-lcurl"
+export ATDM_CONFIG_HDF5_LIBS="-L${SEMS_HDF5_ROOT}/lib;${SEMS_HDF5_ROOT}/lib/libhdf5_hl.${ATDM_CONFIG_TPL_LIB_EXT};${SEMS_HDF5_ROOT}/lib/libhdf5.${ATDM_CONFIG_TPL_LIB_EXT};${SEMS_ZLIB_ROOT}/lib/libz.${ATDM_CONFIG_TPL_LIB_EXT};-ldl"
+export ATDM_CONFIG_NETCDF_LIBS="-L${SEMS_BOOST_ROOT}/lib;-L${SEMS_NETCDF_ROOT}/lib;-L${SEMS_NETCDF_ROOT}/lib;-L${SEMS_PNETCDF_ROOT}/lib;-L${SEMS_HDF5_ROOT}/lib;${SEMS_BOOST_ROOT}/lib/libboost_program_options.${ATDM_CONFIG_TPL_LIB_EXT};${SEMS_BOOST_ROOT}/lib/libboost_system.${ATDM_CONFIG_TPL_LIB_EXT};${SEMS_NETCDF_ROOT}/lib/libnetcdf.${ATDM_CONFIG_TPL_LIB_EXT};${SEMS_NETCDF_ROOT}/lib/libpnetcdf.a;${SEMS_HDF5_ROOT}/lib/libhdf5_hl.${ATDM_CONFIG_TPL_LIB_EXT};${SEMS_HDF5_ROOT}/lib/libhdf5.${ATDM_CONFIG_TPL_LIB_EXT};${SEMS_ZLIB_ROOT}/lib/libz.${ATDM_CONFIG_TPL_LIB_EXT};-ldl;-lcurl"
 
-# NOTE: SEMS does not provide the correct *.so files for NetCDF so we can't
-# use them in a shared lib build :-(
+# NOTE: SEMS does not provide a *.a files for PNetCDF so we can't use them in
+# a shared lib build :-(
 
 # Set MPI wrappers
 export MPICC=`which mpicc`


### PR DESCRIPTION
This is the right thing to do and this shows how to explictly set which libs you use to try to get around a problem with Spack-installed shared library files (not for this env but for an 'spack-rhel6' env).

This changes just the libs for HDF5 and Netcdf.  The pnetcdf lib had to stay *.a because SEMS does not install a *.so for that lib.

I tested this on 'crf450' with:

```
$ cd /home/rabartl/Trilinos.base/BUILDS/ATDM/CHECKIN

$ ./checkin-test-atdm.sh  \
    sems-rhel6-gnu-7.2.0-openmp-static-release-debug \
    sems-rhel6-gnu-7.2.0-openmp-shared-release-debug \
    sems-rhel6-intel-17.0.1-openmp-release \
    --enable-packages=SEACAS --enable-fwd-packages --local-do-all
```

which returned:

```
PASSED (NOT READY TO PUSH): Trilinos: crf450.srn.sandia.gov

Wed Mar 13 17:13:06 MDT 2019

Enabled Packages: SEACAS

Build test results:
-------------------
1) sems-rhel6-gnu-7.2.0-openmp-static-release-debug => passed: passed=193,notpassed=0 (24.98 min)
2) sems-rhel6-gnu-7.2.0-openmp-shared-release-debug => passed: passed=193,notpassed=0 (22.19 min)
3) sems-rhel6-intel-17.0.1-openmp-release => passed: passed=193,notpassed=0 (36.02 min)
```

That should be a pretty good test for this change.
