### PR TITLE
Xpetra: Apply labels to wrapper and underlying object

### DIFF
--- a/packages/xpetra/src/CrsMatrix/Xpetra_EpetraCrsMatrix.hpp
+++ b/packages/xpetra/src/CrsMatrix/Xpetra_EpetraCrsMatrix.hpp
@@ -1098,7 +1098,10 @@ public:
 
   }
 
-  void setObjectLabel( const std::string &objectLabel ) {mtx_->SetLabel(objectLabel.c_str());}
+  void setObjectLabel( const std::string &objectLabel ) {
+    Teuchos::LabeledObject::setObjectLabel(objectLabel);
+    mtx_->SetLabel(objectLabel.c_str());
+  }
   //@}
 
   //! Deep copy constructor
@@ -2081,7 +2084,10 @@ public:
 
   }
 
-  void setObjectLabel( const std::string &objectLabel ) { mtx_->SetLabel(objectLabel.c_str());}
+  void setObjectLabel( const std::string &objectLabel ) {
+    Teuchos::LabeledObject::setObjectLabel(objectLabel);
+    mtx_->SetLabel(objectLabel.c_str());
+  }
   //@}
 
   //! Deep copy constructor

--- a/packages/xpetra/src/CrsMatrix/Xpetra_TpetraBlockCrsMatrix.hpp
+++ b/packages/xpetra/src/CrsMatrix/Xpetra_TpetraBlockCrsMatrix.hpp
@@ -321,7 +321,11 @@ namespace Xpetra {
 
     //! @name Overridden from Teuchos::LabeledObject
     //@{
-    void setObjectLabel( const std::string &objectLabel ) { XPETRA_MONITOR("TpetraCrsMatrix::setObjectLabel"); mtx_->setObjectLabel(objectLabel);}
+    void setObjectLabel( const std::string &objectLabel ) {
+      XPETRA_MONITOR("TpetraCrsMatrix::setObjectLabel");
+      Teuchos::LabeledObject::setObjectLabel(objectLabel);
+      mtx_->setObjectLabel(objectLabel);
+    }
     //@}
 
     //! Deep copy constructor

--- a/packages/xpetra/src/CrsMatrix/Xpetra_TpetraCrsMatrix.hpp
+++ b/packages/xpetra/src/CrsMatrix/Xpetra_TpetraCrsMatrix.hpp
@@ -438,7 +438,11 @@ namespace Xpetra {
 
     //! @name Overridden from Teuchos::LabeledObject
     //@{
-    void setObjectLabel( const std::string &objectLabel ) { XPETRA_MONITOR("TpetraCrsMatrix::setObjectLabel"); mtx_->setObjectLabel(objectLabel);}
+    void setObjectLabel( const std::string &objectLabel ) {
+      XPETRA_MONITOR("TpetraCrsMatrix::setObjectLabel");
+      Teuchos::LabeledObject::setObjectLabel(objectLabel);
+      mtx_->setObjectLabel(objectLabel);
+    }
     //@}
 
 

--- a/packages/xpetra/sup/Matrix/Xpetra_CrsMatrixWrap.hpp
+++ b/packages/xpetra/sup/Matrix/Xpetra_CrsMatrixWrap.hpp
@@ -600,7 +600,10 @@ public:
 
   //! @name Overridden from Teuchos::LabeledObject
   //@{
-  void setObjectLabel( const std::string &objectLabel ) { matrixData_->setObjectLabel(objectLabel);}
+  void setObjectLabel( const std::string &objectLabel ) {
+    Teuchos::LabeledObject::setObjectLabel(objectLabel);
+    matrixData_->setObjectLabel(objectLabel);
+  }
   //@}
 
 


### PR DESCRIPTION
@trilinos/xpetra 

## Description
`setObjectLabel` for matrix objects now applies the label to both the wrapper and the underlying matrix object. 

@pwxy 