### PR TITLE
Teuchos: VerboseObject fix filestreams

### DIFF
--- a/packages/teuchos/parameterlist/src/Teuchos_VerboseObjectParameterListHelpers.cpp
+++ b/packages/teuchos/parameterlist/src/Teuchos_VerboseObjectParameterListHelpers.cpp
@@ -117,19 +117,81 @@ void Teuchos::readVerboseObjectSublist(
   *verbLevel = VerbosityLevel_validator->getIntegralValue(
     voSublist,VerbosityLevel_name,VerbosityLevel_default
     );
+  // the default file string is nothing
   if (outputFileStr==OutputFile_default) {
     *oStream = null;
   }
+  // if a file is specified then output to an fstream
   else {
-    RCP<std::ofstream>
-      oFileStream = rcp(new std::ofstream(outputFileStr.c_str()));
-    TEUCHOS_TEST_FOR_EXCEPTION_PURE_MSG(
-      oFileStream->eof(), Exceptions::InvalidParameterValue,
-      "Error, the file \"" << outputFileStr << "\n given by the parameter\n"
-      "\'" << OutputFile_name << "\' in the sublist\n"
-      "\'" << voSublist.name() << "\' count not be opened for output!"
-      );
-    *oStream = fancyOStream(rcp_implicit_cast<std::ostream>(oFileStream));
+
+    // JJE: 14 March 2019
+    //  A fix for file output of an VerboseObject.
+    //
+    // This step is very important. With filestreams it does not make
+    // sense for multiple MPI ranks to open the same file.  Nor,
+    // does it seem inline with the OStream model that each stream
+    // represent a unique file. Perhaps, if that functionality is desired
+    // then the file name could be suffixed with the MPI Rank.
+    //
+    // A fundamental flaw with this implementation is that we have no knowledge
+    // of a communicator on which this OStream belongs. That makes the idea
+    // of using a rank ambiguous.
+    //
+    // The code below was added, and uses COMM_WORLD, because as-is
+    // this functionality was fundamentally broken. Without restricting
+    // the stream to a single rank, two severe consquences follow:
+    //   1) Each MPI process opens the file, which is not scalable;
+    //   2) Moreover, each MPI process *writes* to the file. Which
+    //      can give the illusion that things are working, if each
+    //      process writes exactly the same information (e.g., solver
+    //      convergence information for a bulk synchronous solve).
+    //      This introduces a terrible scalability problem, as the
+    //      filesystem is then tasked with coping with concurrent writes
+    //      to the same shared file, which is should make you cry a little.
+    //
+    // The resolution, is two fold:
+    //   1st, construct the ostream as a regular wrapper around cout
+    //   2nd, restrict the file creation and opening to a single process
+    //   Finally, map all ostreams except the fstream one to
+    //    a blackhole. Ensuring each rank has a functional stream
+    //    but that only one actually emits data to disk
+    //
+
+    // this could be a BlackHole, but calling setOutputToRootOnly does slightly
+    // more than simply blackhole output, it also disabled buffering across processes
+    *oStream = Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
+
+    // Until we resolve OS streams that are communicator aware, use rank 0
+    const int outputFileMPIRank = 0;
+
+    #if defined(HAVE_TEUCHOS_MPI)
+    const int rank = Teuchos::GlobalMPISession::getRank();
+    #else
+    const int rank = outputFileMPIRank;
+    #endif
+
+    if ( rank  == outputFileMPIRank) {
+      RCP<std::ofstream> oFileStream = rcp(new std::ofstream());
+      // If, in the future we decide to alter buffers, then
+      // change the fstream's buffer before calling open()
+
+      // open the fstream only on a single MPI process
+      oFileStream->open(outputFileStr);
+
+      TEUCHOS_TEST_FOR_EXCEPTION_PURE_MSG(
+        oFileStream->eof(), Exceptions::InvalidParameterValue,
+        "Error, the file \"" << outputFileStr << "\n given by the parameter\n"
+        "\'" << OutputFile_name << "\' in the sublist\n"
+        "\'" << voSublist.name() << "\' count not be opened for output!"
+        );
+      // wrap the fstream inside fancyOStream
+      *oStream = fancyOStream(rcp_implicit_cast<std::ostream>(oFileStream));
+    }
+
+    #if defined(HAVE_TEUCHOS_MPI)
+    // ensure that only one stream actually emits data
+    (*oStream)->setOutputToRootOnly(outputFileMPIRank);
+    #endif
   }
 #ifdef TEUCHOS_DEBUG
   voSublist.validateParameters(*getValidVerboseObjectSublist());


### PR DESCRIPTION
@trilinos/teuchos 

## Description

Currently, VerboseObject provides an option to allow output to be redirected to a file. Unfortunately, this feature results in every MPI process opening/writing the file, which is not typically what an OStream is used to accomplish. For file output, this implementation leads to extreme performance degradation with large parallel jobs.

This patch accomplishes two things:

1) It restricts file opening/writing to a single MPI process.
The implementation of this is problematic, because VerboseObject's sublist reader has no access to any Comm. Ideally, the interface should be refactored to allow a comm to be passed, so that the logic
can use the com to enforce which rank writes output.

For now, the implementation guards the use of Teuchos::GlobalMPISession to obtain the process' global rank, and uses this to restrict `std::ofstream` construction.

2) This patch provides a means to configure a large file buffer for the `ofstream`.
Implementing this is problematic as well. The question is where and how to store the allocated buffer. Extending the FancyOStream class to add storage for a buffer would imply that other OStreams could support buffer modifications (which is a much broader impact than configuring a file stream buffer - it isn't clear that any arbitrary OStream can support this.)

To handle construction and deallocation of the buffer, a static `std::vector` of `std::vector<char>` is stored in the associated source files' object code. This is not ideal, but it should result in the memory being deallocated at program exit (not FancyOStream deconstruction though).

Moreover, this implementation is not thread safe w.r.t. to creating this OStream object. Concurrency could be guarded using C++11's concurrency features (or possibly Kokkos if using Kokkos inside this package is allowed).

I am open to suggestions to handle any of the above issues better.  `GlobalMPISession` is guarded by the Teuchos macro, `HAVE_TEUCHOS_MPI`, and there is an implicit assumption that MPI has been initialized and that calling `GlobalMPISession::getRank` is safe.

I suppose if this patch isn't accepted, then this code path should really be eradicated, because it presented a very hard to identify scaling problem, simply due to a change in Stratimikos parameters in an XML file.


## How Has This Been Tested?
Full sems/std testing suite (release/gcc-7.3)

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes. - It is not obvious how to test this. The code has been verified by using the system tool 'strace' to ensure single process opening/writing of the file
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

closes #4731
