### PR TITLE
Tempus: Add ability to get alpha and beta from Steppers.

### DIFF
--- a/packages/tempus/src/Tempus_IntegratorBasic_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorBasic_impl.hpp
@@ -541,8 +541,7 @@ void IntegratorBasic<Scalar>::checkTimeStep()
       <<std::setw(11)<<std::setprecision(3)<<wsmd->getDt()
       << "  STEP FAILURE!! - ";
     if (wsmd->getSolutionStatus() == Status::FAILED) {
-      *out << "Solution Status = "
-           << toString(solutionHistory_->getWorkingState()->getSolutionStatus())
+      *out << "Solution Status = " << toString(wsmd->getSolutionStatus())
            << std::endl;
     } else if ((timeStepControl_->getStepType() == "Constant") and
                (wsmd->getDt() != timeStepControl_->getInitTimeStep())) {

--- a/packages/tempus/src/Tempus_IntegratorBasic_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorBasic_impl.hpp
@@ -40,7 +40,7 @@ IntegratorBasic<Scalar>::IntegratorBasic(
 {
   using Teuchos::RCP;
   RCP<StepperFactory<Scalar> > sf = Teuchos::rcp(new StepperFactory<Scalar>());
-  RCP<Stepper<Scalar> > stepper = sf->createStepper(model, stepperType);
+  RCP<Stepper<Scalar> > stepper = sf->createStepper(stepperType, model);
 
   this->setTempusParameterList(Teuchos::null);
   this->setStepperWStepper(stepper);
@@ -83,7 +83,7 @@ void IntegratorBasic<Scalar>::setStepper(
     std::string stepperName = integratorPL_->get<std::string>("Stepper Name");
 
     RCP<ParameterList> stepperPL = Teuchos::sublist(tempusPL_,stepperName,true);
-    stepper_ = sf->createStepper(model, stepperPL);
+    stepper_ = sf->createStepper(stepperPL, model);
   } else {
     stepper_->setModel(model);
   }
@@ -103,7 +103,7 @@ void IntegratorBasic<Scalar>::setStepper(
     std::string stepperName = integratorPL_->get<std::string>("Stepper Name");
 
     RCP<ParameterList> stepperPL = Teuchos::sublist(tempusPL_,stepperName,true);
-    stepper_ = sf->createStepper(models, stepperPL);
+    stepper_ = sf->createStepper(stepperPL, models);
   } else {
     stepper_->createSubSteppers(models);
   }

--- a/packages/tempus/src/Tempus_Stepper.hpp
+++ b/packages/tempus/src/Tempus_Stepper.hpp
@@ -125,6 +125,17 @@ public:
     virtual bool isMultiStepMethod() const = 0;
   //@}
 
+  virtual void modelWarning() const
+  {
+    Teuchos::RCP<Teuchos::FancyOStream> out = this->getOStream();
+    Teuchos::OSTab ostab(out,1,this->description());
+    *out << "Warning -- Constructing " << this->description()
+         << " without ModelEvaluator!\n"
+         << "  - Can reset ParameterList with setParameterList().\n"
+         << "  - Requires subsequent setModel() and initialize() calls\n"
+         << "    before calling takeStep().\n" << std::endl;
+  }
+
   /// \name Functions for Steppers with subSteppers (e.g., OperatorSplit)
   //@{
     virtual void createSubSteppers(

--- a/packages/tempus/src/Tempus_StepperBDF2_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperBDF2_decl.hpp
@@ -45,6 +45,15 @@ class StepperBDF2 : virtual public Tempus::StepperImplicit<Scalar>
 {
 public:
 
+  /** \brief Default constructor.
+   *
+   *  - Constructs with a default ParameterList.
+   *  - Can reset ParameterList with setParameterList().
+   *  - Requires subsequent setModel() and initialize() calls before calling
+   *    takeStep().
+  */
+  StepperBDF2();
+
   /// Constructor
   StepperBDF2(
     const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
@@ -80,14 +89,20 @@ public:
     virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
   //@}
 
+  /// Return alpha = d(xDot)/dx.
+  virtual Scalar getAlpha(const Scalar dt) const {return getAlpha(dt,dt);}
+  virtual Scalar getAlpha(const Scalar dt, const Scalar dtOld) const
+    { return (Scalar(2.0)*dt + dtOld)/(dt*(dt + dtOld)); }
+  /// Return beta  = d(x)/dx.
+  virtual Scalar getBeta (const Scalar   ) const { return Scalar(1.0); }
+
   /// Compute the first time step given the supplied startup stepper
   virtual void computeStartUp(
     const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory);
-    
-  /// Pass initial guess to Newton solver 
+
+  /// Pass initial guess to Newton solver
   virtual void setInitialGuess(Teuchos::RCP<const Thyra::VectorBase<Scalar> > initial_guess)
        {initial_guess_ = initial_guess;}
-
 
   /// Provide temporary xDot memory for Stepper if SolutionState doesn't.
   virtual Teuchos::RCP<Thyra::VectorBase<Scalar> > getXDotTemp(
@@ -111,11 +126,6 @@ public:
 
 private:
 
-  /// Default Constructor -- not allowed
-  StepperBDF2();
-
-private:
-
   Teuchos::RCP<Stepper<Scalar> >             startUpStepper_;
 
   Teuchos::RCP<StepperObserver<Scalar> >     stepperObserver_;
@@ -123,7 +133,7 @@ private:
   Scalar                                     order_;
 
   Teuchos::RCP<Thyra::VectorBase<Scalar> >   xDotTemp_;
-  Teuchos::RCP<const Thyra::VectorBase<Scalar> >      initial_guess_;  
+  Teuchos::RCP<const Thyra::VectorBase<Scalar> >      initial_guess_;
 };
 
 /** \brief Time-derivative interface for BDF2.

--- a/packages/tempus/src/Tempus_StepperBackwardEuler_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperBackwardEuler_decl.hpp
@@ -36,6 +36,15 @@ class StepperBackwardEuler :
 {
 public:
 
+  /** \brief Default constructor.
+   *
+   *  - Constructs with a default ParameterList.
+   *  - Can reset ParameterList with setParameterList().
+   *  - Requires subsequent setModel() and initialize() calls before calling
+   *    takeStep().
+  */
+  StepperBackwardEuler();
+
   /// Constructor
   StepperBackwardEuler(
     const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
@@ -57,7 +66,7 @@ public:
     virtual void takeStep(
       const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory);
 
-    /// Pass initial guess to Newton solver 
+    /// Pass initial guess to Newton solver
     virtual void setInitialGuess(Teuchos::RCP<const Thyra::VectorBase<Scalar> > initial_guess)
        {initial_guess_ = initial_guess;}
 
@@ -74,6 +83,11 @@ public:
     virtual bool isOneStepMethod()   const {return true;}
     virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
   //@}
+
+    /// Return alpha = d(xDot)/dx.
+  virtual Scalar getAlpha(const Scalar dt) const { return Scalar(1.0)/dt; }
+  /// Return beta  = d(x)/dx.
+  virtual Scalar getBeta (const Scalar   ) const { return Scalar(1.0); }
 
   /// Compute predictor given the supplied stepper
   virtual void computePredictor(
@@ -131,9 +145,6 @@ public:
 
 private:
 
-  /// Default Constructor -- not allowed
-  StepperBackwardEuler();
-
   /// Implementation of computeStep*() methods
   void computeStepResidDerivImpl(
     const Thyra::ModelEvaluatorBase::OutArgs<Scalar>& outArgs,
@@ -150,7 +161,7 @@ private:
   Teuchos::RCP<StepperBackwardEulerObserver<Scalar> > stepperBEObserver_;
 
   mutable Teuchos::RCP<Thyra::VectorBase<Scalar> >    xDotTemp_;
-  Teuchos::RCP<const Thyra::VectorBase<Scalar> >      initial_guess_;  
+  Teuchos::RCP<const Thyra::VectorBase<Scalar> >      initial_guess_;
 };
 
 /** \brief Time-derivative interface for Backward Euler.

--- a/packages/tempus/src/Tempus_StepperBackwardEuler_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperBackwardEuler_impl.hpp
@@ -22,19 +22,28 @@ namespace Tempus {
 template<class Scalar> class StepperFactory;
 
 
-// StepperBackwardEuler definitions:
+template<class Scalar>
+StepperBackwardEuler<Scalar>::StepperBackwardEuler()
+{
+  this->setParameterList(Teuchos::null);
+  this->modelWarning();
+}
+
+
 template<class Scalar>
 StepperBackwardEuler<Scalar>::StepperBackwardEuler(
   const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
   Teuchos::RCP<Teuchos::ParameterList> pList)
 {
-  using Teuchos::RCP;
-  using Teuchos::ParameterList;
-
-  // Set all the input parameters and call initialize
   this->setParameterList(pList);
-  this->setModel(appModel);
-  this->initialize();
+
+  if (appModel == Teuchos::null) {
+    this->modelWarning();
+  }
+  else {
+    this->setModel(appModel);
+    this->initialize();
+  }
 }
 
 
@@ -78,7 +87,7 @@ void StepperBackwardEuler<Scalar>::setPredictor(
       RCP<StepperFactory<Scalar> > sf =
         Teuchos::rcp(new StepperFactory<Scalar>());
       predictorStepper_ =
-        sf->createStepper(this->wrapperModel_->getAppModel(), predPL);
+        sf->createStepper(predPL, this->wrapperModel_->getAppModel());
     }
   } else {
     TEUCHOS_TEST_FOR_EXCEPTION( predictorName == predPL->name(),
@@ -93,7 +102,7 @@ void StepperBackwardEuler<Scalar>::setPredictor(
     RCP<StepperFactory<Scalar> > sf =
       Teuchos::rcp(new StepperFactory<Scalar>());
     predictorStepper_ =
-      sf->createStepper(this->wrapperModel_->getAppModel(), predPL);
+      sf->createStepper(predPL, this->wrapperModel_->getAppModel());
   }
 }
 

--- a/packages/tempus/src/Tempus_StepperDIRK_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperDIRK_decl.hpp
@@ -84,15 +84,25 @@ template<class Scalar>
 class StepperDIRK : virtual public Tempus::StepperImplicit<Scalar>
 {
 public:
-  /// Constructor to use default Stepper parameters.
-  StepperDIRK(
-    const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
-    std::string stepperType = "SDIRK 2 Stage 2nd order");
+
+   /** \brief Default constructor.
+   *
+   *  - Constructs with a default ParameterList.
+   *  - Can reset ParameterList with setParameterList().
+   *  - Requires subsequent setModel() and initialize() calls before calling
+   *    takeStep().
+  */
+  StepperDIRK();
 
   /// Constructor to specialize Stepper parameters.
   StepperDIRK(
     const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
     Teuchos::RCP<Teuchos::ParameterList> pList);
+
+  /// Constructor to use default Stepper parameters.
+  StepperDIRK(
+    const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
+    std::string stepperType = "SDIRK 2 Stage 2nd order");
 
   /// Constructor for StepperFactory.
   StepperDIRK(
@@ -137,6 +147,15 @@ public:
     virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
   //@}
 
+  /// Return alpha = d(xDot)/dx.
+  virtual Scalar getAlpha(const Scalar dt) const
+  {
+    const Teuchos::SerialDenseMatrix<int,Scalar> & A=DIRK_ButcherTableau_->A();
+    return Scalar(1.0)/(dt*A(0,0));  // Getting the first diagonal coeff!
+  }
+  /// Return beta  = d(x)/dx.
+  virtual Scalar getBeta (const Scalar   ) const { return Scalar(1.0); }
+
   /// Pass initial guess to Newton solver
   virtual void setInitialGuess(
     Teuchos::RCP<const Thyra::VectorBase<Scalar> > initial_guess)
@@ -157,11 +176,6 @@ public:
     virtual void describe(Teuchos::FancyOStream        & out,
                           const Teuchos::EVerbosityLevel verbLevel) const;
   //@}
-
-private:
-
-  /// Default Constructor -- not allowed
-  StepperDIRK();
 
 protected:
 

--- a/packages/tempus/src/Tempus_StepperDIRK_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperDIRK_impl.hpp
@@ -24,13 +24,11 @@ namespace Tempus {
 template<class Scalar> class StepperFactory;
 
 template<class Scalar>
-StepperDIRK<Scalar>::StepperDIRK(
-  const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
-  std::string stepperType)
+StepperDIRK<Scalar>::StepperDIRK()
 {
-  this->setTableau(stepperType);
-  this->setModel(appModel);
-  this->initialize();
+  this->setTableau();
+  this->setParameterList(Teuchos::null);
+  this->modelWarning();
 }
 
 template<class Scalar>
@@ -40,8 +38,30 @@ StepperDIRK<Scalar>::StepperDIRK(
 {
   this->setTableau(pList);
   this->setParameterList(pList);
-  this->setModel(appModel);
-  this->initialize();
+
+  if (appModel == Teuchos::null) {
+    this->modelWarning();
+  }
+  else {
+    this->setModel(appModel);
+    this->initialize();
+  }
+}
+
+template<class Scalar>
+StepperDIRK<Scalar>::StepperDIRK(
+  const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
+  std::string stepperType)
+{
+  this->setTableau(stepperType);
+
+  if (appModel == Teuchos::null) {
+    this->modelWarning();
+  }
+  else {
+    this->setModel(appModel);
+    this->initialize();
+  }
 }
 
 template<class Scalar>
@@ -52,8 +72,14 @@ StepperDIRK<Scalar>::StepperDIRK(
 {
   this->setTableau(stepperType);
   this->setParameterList(pList);
-  this->setModel(appModel);
-  this->initialize();
+
+  if (appModel == Teuchos::null) {
+    this->modelWarning();
+  }
+  else {
+    this->setModel(appModel);
+    this->initialize();
+  }
 }
 
 

--- a/packages/tempus/src/Tempus_StepperExplicitRK_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperExplicitRK_decl.hpp
@@ -65,15 +65,24 @@ class StepperExplicitRK : virtual public Tempus::Stepper<Scalar>
 {
 public:
 
-  /// Constructor to use default Stepper parameters.
-  StepperExplicitRK(
-    const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
-    std::string stepperType = "RK Explicit 4 Stage");
+  /** \brief Default constructor.
+   *
+   *  - Constructs with a default ParameterList.
+   *  - Can reset ParameterList with setParameterList().
+   *  - Requires subsequent setModel() and initialize() calls before calling
+   *    takeStep().
+  */
+  StepperExplicitRK();
 
   /// Constructor to specialize Stepper parameters.
   StepperExplicitRK(
     const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
     Teuchos::RCP<Teuchos::ParameterList> pList);
+
+  /// Constructor to use default Stepper parameters.
+  StepperExplicitRK(
+    const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
+    std::string stepperType = "RK Explicit 4 Stage");
 
   /// Constructor for StepperFactory.
   StepperExplicitRK(
@@ -149,11 +158,6 @@ public:
     virtual void describe(Teuchos::FancyOStream        & out,
                           const Teuchos::EVerbosityLevel verbLevel) const;
   //@}
-
-private:
-
-  /// Default Constructor -- not allowed
-  StepperExplicitRK();
 
 protected:
 

--- a/packages/tempus/src/Tempus_StepperExplicitRK_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperExplicitRK_impl.hpp
@@ -18,13 +18,11 @@
 namespace Tempus {
 
 template<class Scalar>
-StepperExplicitRK<Scalar>::StepperExplicitRK(
-  const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
-  std::string stepperType)
+StepperExplicitRK<Scalar>::StepperExplicitRK()
 {
-  this->setTableau(stepperType);
-  this->setModel(appModel);
-  this->initialize();
+  this->setTableau();
+  this->setParameterList(Teuchos::null);
+  this->modelWarning();
 }
 
 template<class Scalar>
@@ -34,8 +32,30 @@ StepperExplicitRK<Scalar>::StepperExplicitRK(
 {
   this->setTableau(pList);
   this->setParameterList(pList);
-  this->setModel(appModel);
-  this->initialize();
+
+  if (appModel == Teuchos::null) {
+    this->modelWarning();
+  }
+  else {
+    this->setModel(appModel);
+    this->initialize();
+  }
+}
+
+template<class Scalar>
+StepperExplicitRK<Scalar>::StepperExplicitRK(
+  const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
+  std::string stepperType)
+{
+  this->setTableau(stepperType);
+
+  if (appModel == Teuchos::null) {
+    this->modelWarning();
+  }
+  else {
+    this->setModel(appModel);
+    this->initialize();
+  }
 }
 
 template<class Scalar>
@@ -46,8 +66,14 @@ StepperExplicitRK<Scalar>::StepperExplicitRK(
 {
   this->setTableau(stepperType);
   this->setParameterList(pList);
-  this->setModel(appModel);
-  this->initialize();
+
+  if (appModel == Teuchos::null) {
+    this->modelWarning();
+  }
+  else {
+    this->setModel(appModel);
+    this->initialize();
+  }
 }
 
 template<class Scalar>

--- a/packages/tempus/src/Tempus_StepperFactory.hpp
+++ b/packages/tempus/src/Tempus_StepperFactory.hpp
@@ -46,8 +46,9 @@ public:
 
   /// Create default stepper from stepper type (e.g., "Forward Euler").
   Teuchos::RCP<Stepper<Scalar> > createStepper(
-    const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& model,
-    std::string stepperType = "Forward Euler")
+    std::string stepperType = "Forward Euler",
+    const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >&
+      model = Teuchos::null)
   {
     if (stepperType == "") stepperType = "Forward Euler";
     return this->createStepper(model, stepperType, Teuchos::null);
@@ -55,8 +56,9 @@ public:
 
   /// Create stepper from ParameterList with its details.
   Teuchos::RCP<Stepper<Scalar> > createStepper(
-    const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& model,
-    Teuchos::RCP<Teuchos::ParameterList> stepperPL)
+    Teuchos::RCP<Teuchos::ParameterList> stepperPL,
+    const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >&
+      model = Teuchos::null)
   {
     std::string stepperType = "Forward Euler";
     if (stepperPL != Teuchos::null)
@@ -66,8 +68,9 @@ public:
 
   /// Create stepper from ParameterList with its details.
   Teuchos::RCP<Stepper<Scalar> > createStepper(
-    std::vector<Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > > models,
-    Teuchos::RCP<Teuchos::ParameterList> stepperPL)
+    Teuchos::RCP<Teuchos::ParameterList> stepperPL,
+    std::vector<Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > >
+      models = Teuchos::null)
   {
     std::string stepperType = stepperPL->get<std::string>("Stepper Type");
     return this->createStepper(models, stepperType, stepperPL);

--- a/packages/tempus/src/Tempus_StepperForwardEuler_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperForwardEuler_decl.hpp
@@ -43,6 +43,15 @@ class StepperForwardEuler : virtual public Tempus::Stepper<Scalar>
 {
 public:
 
+  /** \brief Default constructor.
+   *
+   *  - Constructs with a default ParameterList.
+   *  - Can reset ParameterList with setParameterList().
+   *  - Requires subsequent setModel() and initialize() calls before calling
+   *    takeStep().
+  */
+  StepperForwardEuler();
+
   /// Constructor
   StepperForwardEuler(
     const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
@@ -117,11 +126,6 @@ public:
     virtual void describe(Teuchos::FancyOStream        & out,
                           const Teuchos::EVerbosityLevel verbLevel) const;
   //@}
-
-private:
-
-  /// Default Constructor -- not allowed
-  StepperForwardEuler();
 
 protected:
 

--- a/packages/tempus/src/Tempus_StepperForwardEuler_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperForwardEuler_impl.hpp
@@ -15,16 +15,27 @@
 
 namespace Tempus {
 
-// StepperForwardEuler definitions:
+template<class Scalar>
+StepperForwardEuler<Scalar>::StepperForwardEuler()
+{
+  this->setParameterList(Teuchos::null);
+  this->modelWarning();
+}
+
 template<class Scalar>
 StepperForwardEuler<Scalar>::StepperForwardEuler(
   const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
   Teuchos::RCP<Teuchos::ParameterList> pList)
 {
-  // Set all the input parameters and call initialize
   this->setParameterList(pList);
-  this->setModel(appModel);
-  this->initialize();
+
+  if (appModel == Teuchos::null) {
+    this->modelWarning();
+  }
+  else {
+    this->setModel(appModel);
+    this->initialize();
+  }
 }
 
 template<class Scalar>

--- a/packages/tempus/src/Tempus_StepperHHTAlpha_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperHHTAlpha_decl.hpp
@@ -42,6 +42,15 @@ class StepperHHTAlpha : virtual public Tempus::StepperImplicit<Scalar>
 {
 public:
 
+  /** \brief Default constructor.
+   *
+   *  - Constructs with a default ParameterList.
+   *  - Can reset ParameterList with setParameterList().
+   *  - Requires subsequent setModel() and initialize() calls before calling
+   *    takeStep().
+  */
+  StepperHHTAlpha();
+
   /// Constructor
   StepperHHTAlpha(
     const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
@@ -62,7 +71,7 @@ public:
     virtual void takeStep(
       const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory);
 
-    /// Pass initial guess to Newton solver (only relevant for implicit solvers) 
+    /// Pass initial guess to Newton solver (only relevant for implicit solvers)
     virtual void setInitialGuess(Teuchos::RCP<const Thyra::VectorBase<Scalar> > initial_guess)
        {initial_guess_ = initial_guess;}
 
@@ -82,6 +91,14 @@ public:
     virtual bool isOneStepMethod()   const {return true;}
     virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
   //@}
+
+  /// Return W_xDotxDot_coeff = d(xDotDot)/d(x).
+  virtual Scalar getW_xDotDot_coeff (const Scalar dt) const
+    { return Scalar(1.0)/(beta_*dt*dt); }
+  /// Return alpha = d(xDot)/d(x).
+  virtual Scalar getAlpha(const Scalar dt) const { return gamma_/(beta_*dt); }
+  /// Return beta  = d(x)/d(x).
+  virtual Scalar getBeta (const Scalar ) const { return Scalar(1.0); }
 
   /// \name ParameterList methods
   //@{
@@ -128,11 +145,6 @@ public:
                                const Thyra::VectorBase<Scalar>& dPred,
                                const Thyra::VectorBase<Scalar>& a,
                                const Scalar dt) const;
-
-private:
-
-  /// Default Constructor -- not allowed
-  StepperHHTAlpha();
 
 private:
 

--- a/packages/tempus/src/Tempus_StepperHHTAlpha_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperHHTAlpha_impl.hpp
@@ -22,6 +22,7 @@ namespace Tempus {
 // Forward Declaration for recursive includes (this Stepper <--> StepperFactory)
 template<class Scalar> class StepperFactory;
 
+
 template<class Scalar>
 void StepperHHTAlpha<Scalar>::
 predictVelocity(Thyra::VectorBase<Scalar>& vPred,
@@ -127,6 +128,19 @@ correctDisplacement(Thyra::VectorBase<Scalar>& d,
 
 
 template<class Scalar>
+StepperHHTAlpha<Scalar>::StepperHHTAlpha() :
+  out_(Teuchos::VerboseObjectBase::getDefaultOStream())
+{
+#ifdef VERBOSE_DEBUG_OUTPUT
+  *out_ << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
+#endif
+
+  this->setParameterList(Teuchos::null);
+  this->modelWarning();
+}
+
+
+template<class Scalar>
 StepperHHTAlpha<Scalar>::StepperHHTAlpha(
   const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
   Teuchos::RCP<Teuchos::ParameterList> pList) :
@@ -135,13 +149,16 @@ StepperHHTAlpha<Scalar>::StepperHHTAlpha(
 #ifdef VERBOSE_DEBUG_OUTPUT
   *out_ << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
 #endif
-  using Teuchos::RCP;
-  using Teuchos::ParameterList;
 
-  // Set all the input parameters and call initialize
   this->setParameterList(pList);
-  this->setModel(appModel);
-  this->initialize();
+
+  if (appModel == Teuchos::null) {
+    this->modelWarning();
+  }
+  else {
+    this->setModel(appModel);
+    this->initialize();
+  }
 }
 
 

--- a/packages/tempus/src/Tempus_StepperIMEX_RK_Partition_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RK_Partition_decl.hpp
@@ -229,15 +229,24 @@ class StepperIMEX_RK_Partition : virtual public Tempus::StepperImplicit<Scalar>
 {
 public:
 
-  /// Constructor to use default Stepper parameters.
-  StepperIMEX_RK_Partition(
-    const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
-    std::string stepperType = "Partitioned IMEX RK SSP2");
+  /** \brief Default constructor.
+   *
+   *  - Constructs with a default ParameterList.
+   *  - Can reset ParameterList with setParameterList().
+   *  - Requires subsequent setModel() and initialize() calls before calling
+   *    takeStep().
+  */
+  StepperIMEX_RK_Partition();
 
   /// Constructor to specialize Stepper parameters.
   StepperIMEX_RK_Partition(
     const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
     Teuchos::RCP<Teuchos::ParameterList> pList);
+
+  /// Constructor to use default Stepper parameters.
+  StepperIMEX_RK_Partition(
+    const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
+    std::string stepperType = "Partitioned IMEX RK SSP2");
 
   /// Constructor for StepperFactory.
   StepperIMEX_RK_Partition(
@@ -304,6 +313,15 @@ public:
 
   //@}
 
+    /// Return alpha = d(xDot)/dx.
+  virtual Scalar getAlpha(const Scalar dt) const
+  {
+    const Teuchos::SerialDenseMatrix<int,Scalar> & A = implicitTableau_->A();
+    return Scalar(1.0)/(dt*A(0,0));  // Getting the first diagonal coeff!
+  }
+  /// Return beta  = d(x)/dx.
+  virtual Scalar getBeta (const Scalar   ) const { return Scalar(1.0); }
+
   /// Pass initial guess to Newton solver (only relevant for implicit solvers)
   virtual void setInitialGuess(Teuchos::RCP<const Thyra::VectorBase<Scalar> > initial_guess)
      {initial_guess_ = initial_guess;}
@@ -334,11 +352,6 @@ public:
     const Teuchos::RCP<const Thyra::VectorBase<Scalar> > & X,
     Scalar time, Scalar stepSize, Scalar stageNumber,
     const Teuchos::RCP<Thyra::VectorBase<Scalar> > & F) const;
-
-private:
-
-  /// Default Constructor -- not allowed
-  StepperIMEX_RK_Partition();
 
 protected:
 

--- a/packages/tempus/src/Tempus_StepperIMEX_RK_Partition_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RK_Partition_impl.hpp
@@ -25,13 +25,11 @@ template<class Scalar> class StepperFactory;
 
 
 template<class Scalar>
-StepperIMEX_RK_Partition<Scalar>::StepperIMEX_RK_Partition(
-  const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
-  std::string stepperType)
+StepperIMEX_RK_Partition<Scalar>::StepperIMEX_RK_Partition()
 {
-  this->setTableaus(Teuchos::null, stepperType);
-  this->setModel(appModel);
-  this->initialize();
+  this->setTableaus(Teuchos::null, "Partitioned IMEX RK SSP2");
+  this->setParameterList(Teuchos::null);
+  this->modelWarning();
 }
 
 
@@ -42,8 +40,31 @@ StepperIMEX_RK_Partition<Scalar>::StepperIMEX_RK_Partition(
 {
   this->setTableaus(pList, "Partitioned IMEX RK SSP2");
   this->setParameterList(pList);
-  this->setModel(appModel);
-  this->initialize();
+
+  if (appModel == Teuchos::null) {
+    this->modelWarning();
+  }
+  else {
+    this->setModel(appModel);
+    this->initialize();
+  }
+}
+
+
+template<class Scalar>
+StepperIMEX_RK_Partition<Scalar>::StepperIMEX_RK_Partition(
+  const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
+  std::string stepperType)
+{
+  this->setTableaus(Teuchos::null, stepperType);
+
+  if (appModel == Teuchos::null) {
+    this->modelWarning();
+  }
+  else {
+    this->setModel(appModel);
+    this->initialize();
+  }
 }
 
 
@@ -55,8 +76,14 @@ StepperIMEX_RK_Partition<Scalar>::StepperIMEX_RK_Partition(
 {
   this->setTableaus(pList, stepperType);
   this->setParameterList(pList);
-  this->setModel(appModel);
-  this->initialize();
+
+  if (appModel == Teuchos::null) {
+    this->modelWarning();
+  }
+  else {
+    this->setModel(appModel);
+    this->initialize();
+  }
 }
 
 
@@ -675,8 +702,8 @@ Teuchos::RCP<const Teuchos::ParameterList>
 StepperIMEX_RK_Partition<Scalar>::getValidParameters() const
 {
   Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-  pl->setName("Default Stepper - IMEX RK SSP2");
-  pl->set("Stepper Type", "IMEX RK SSP2");
+  pl->setName("Default Stepper - Partitioned IMEX RK SSP2");
+  pl->set("Stepper Type", "Partitioned IMEX RK SSP2");
   pl->set("Zero Initial Guess", false);
   pl->set("Solver Name", "",
     "Name of ParameterList containing the solver specifications.");
@@ -689,8 +716,8 @@ Teuchos::RCP<Teuchos::ParameterList>
 StepperIMEX_RK_Partition<Scalar>::getDefaultParameters() const
 {
   Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
-  pl->setName("Default Stepper - IMEX RK SSP2");
-  pl->set<std::string>("Stepper Type", "IMEX RK SSP2");
+  pl->setName("Default Stepper - Partitioned IMEX RK SSP2");
+  pl->set<std::string>("Stepper Type", "Partitioned IMEX RK SSP2");
   pl->set<bool>       ("Zero Initial Guess", false);
   pl->set<std::string>("Solver Name", "Default Solver");
   Teuchos::RCP<Teuchos::ParameterList> solverPL=this->defaultSolverParameters();

--- a/packages/tempus/src/Tempus_StepperIMEX_RK_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RK_decl.hpp
@@ -231,15 +231,24 @@ class StepperIMEX_RK : virtual public Tempus::StepperImplicit<Scalar>
 {
 public:
 
-  /// Constructor to use default Stepper parameters.
-  StepperIMEX_RK(
-    const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
-    std::string stepperType = "IMEX RK SSP2");
+  /** \brief Default constructor.
+   *
+   *  - Constructs with a default ParameterList.
+   *  - Can reset ParameterList with setParameterList().
+   *  - Requires subsequent setModel() and initialize() calls before calling
+   *    takeStep().
+  */
+  StepperIMEX_RK();
 
   /// Constructor to specialize Stepper parameters.
   StepperIMEX_RK(
     const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
     Teuchos::RCP<Teuchos::ParameterList> pList);
+
+  /// Constructor to use default Stepper parameters.
+  StepperIMEX_RK(
+    const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
+    std::string stepperType = "IMEX RK SSP2");
 
   /// Constructor for StepperFactory.
   StepperIMEX_RK(
@@ -308,6 +317,15 @@ public:
     virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
   //@}
 
+  /// Return alpha = d(xDot)/dx.
+  virtual Scalar getAlpha(const Scalar dt) const
+  {
+    const Teuchos::SerialDenseMatrix<int,Scalar> & A = implicitTableau_->A();
+    return Scalar(1.0)/(dt*A(0,0));  // Getting the first diagonal coeff!
+  }
+  /// Return beta  = d(x)/dx.
+  virtual Scalar getBeta (const Scalar   ) const { return Scalar(1.0); }
+
   /// \name ParameterList methods
   //@{
     void setParameterList(const Teuchos::RCP<Teuchos::ParameterList> & pl);
@@ -333,11 +351,6 @@ public:
     const Teuchos::RCP<const Thyra::VectorBase<Scalar> > & X,
     Scalar time, Scalar stepSize, Scalar stageNumber,
     const Teuchos::RCP<Thyra::VectorBase<Scalar> > & F) const;
-
-private:
-
-  /// Default Constructor -- not allowed
-  StepperIMEX_RK();
 
 protected:
 

--- a/packages/tempus/src/Tempus_StepperIMEX_RK_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RK_impl.hpp
@@ -25,14 +25,11 @@ template<class Scalar> class StepperFactory;
 
 
 template<class Scalar>
-StepperIMEX_RK<Scalar>::StepperIMEX_RK(
-  const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
-  std::string stepperType)
+StepperIMEX_RK<Scalar>::StepperIMEX_RK()
 {
-  this->setTableaus(Teuchos::null, stepperType);
+  this->setTableaus(Teuchos::null, "IMEX RK SSP2");
   this->setParameterList(Teuchos::null);
-  this->setModel(appModel);
-  this->initialize();
+  this->modelWarning();
 }
 
 
@@ -43,8 +40,32 @@ StepperIMEX_RK<Scalar>::StepperIMEX_RK(
 {
   this->setTableaus(pList, "IMEX RK SSP2");
   this->setParameterList(pList);
-  this->setModel(appModel);
-  this->initialize();
+
+  if (appModel == Teuchos::null) {
+    this->modelWarning();
+  }
+  else {
+    this->setModel(appModel);
+    this->initialize();
+  }
+}
+
+
+template<class Scalar>
+StepperIMEX_RK<Scalar>::StepperIMEX_RK(
+  const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
+  std::string stepperType)
+{
+  this->setTableaus(Teuchos::null, stepperType);
+  this->setParameterList(Teuchos::null);
+
+  if (appModel == Teuchos::null) {
+    this->modelWarning();
+  }
+  else {
+    this->setModel(appModel);
+    this->initialize();
+  }
 }
 
 
@@ -56,8 +77,14 @@ StepperIMEX_RK<Scalar>::StepperIMEX_RK(
 {
   this->setTableaus(pList, stepperType);
   this->setParameterList(pList);
-  this->setModel(appModel);
-  this->initialize();
+
+  if (appModel == Teuchos::null) {
+    this->modelWarning();
+  }
+  else {
+    this->setModel(appModel);
+    this->initialize();
+  }
 }
 
 

--- a/packages/tempus/src/Tempus_StepperImplicit_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperImplicit_decl.hpp
@@ -48,6 +48,11 @@ public:
     virtual std::string getStepperType() const
      { return stepperPL_->get<std::string>("Stepper Type"); }
 
+    /// Return alpha = d(xDot)/dx.
+    virtual Scalar getAlpha(const Scalar dt) const = 0;
+    /// Return beta  = d(x)/dx.
+    virtual Scalar getBeta (const Scalar dt) const = 0;
+
     /// Solve problem using x in-place.
     const Thyra::SolveStatus<Scalar> solveImplicitODE(
       const Teuchos::RCP<Thyra::VectorBase<Scalar> > & x);

--- a/packages/tempus/src/Tempus_StepperLeapfrog_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperLeapfrog_decl.hpp
@@ -72,6 +72,15 @@ class StepperLeapfrog : virtual public Tempus::Stepper<Scalar>
 {
 public:
 
+  /** \brief Default constructor.
+   *
+   *  - Constructs with a default ParameterList.
+   *  - Can reset ParameterList with setParameterList().
+   *  - Requires subsequent setModel() and initialize() calls before calling
+   *    takeStep().
+  */
+  StepperLeapfrog();
+
   /// Constructor
   StepperLeapfrog(
     const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
@@ -147,11 +156,6 @@ public:
     virtual void describe(Teuchos::FancyOStream        & out,
                           const Teuchos::EVerbosityLevel verbLevel) const;
   //@}
-
-private:
-
-  /// Default Constructor -- not allowed
-  StepperLeapfrog();
 
 protected:
 

--- a/packages/tempus/src/Tempus_StepperLeapfrog_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperLeapfrog_impl.hpp
@@ -15,16 +15,27 @@
 
 namespace Tempus {
 
-// StepperLeapfrog definitions:
+template<class Scalar>
+StepperLeapfrog<Scalar>::StepperLeapfrog()
+{
+  this->setParameterList(Teuchos::null);
+  this->modelWarning();
+}
+
 template<class Scalar>
 StepperLeapfrog<Scalar>::StepperLeapfrog(
   const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
   Teuchos::RCP<Teuchos::ParameterList> pList)
 {
-  // Set all the input parameters and call initialize
   this->setParameterList(pList);
-  this->setModel(appModel);
-  this->initialize();
+
+  if (appModel == Teuchos::null) {
+    this->modelWarning();
+  }
+  else {
+    this->setModel(appModel);
+    this->initialize();
+  }
 }
 
 template<class Scalar>

--- a/packages/tempus/src/Tempus_StepperNewmarkExplicitAForm_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkExplicitAForm_decl.hpp
@@ -24,6 +24,15 @@ class StepperNewmarkExplicitAForm : virtual public Tempus::Stepper<Scalar>
 {
 public:
 
+  /** \brief Default constructor.
+   *
+   *  - Constructs with a default ParameterList.
+   *  - Can reset ParameterList with setParameterList().
+   *  - Requires subsequent setModel() and initialize() calls before calling
+   *    takeStep().
+  */
+  StepperNewmarkExplicitAForm();
+
   /// Constructor
   StepperNewmarkExplicitAForm(
     const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
@@ -114,16 +123,6 @@ public:
                              const Thyra::VectorBase<Scalar>& vPred,
                              const Thyra::VectorBase<Scalar>& a,
                              const Scalar dt) const;
-
-
-private:
-
-  /// Default Constructor -- not allowed
-
-private:
-
-  /// Default Constructor -- not allowed
-  StepperNewmarkExplicitAForm();
 
 protected:
 

--- a/packages/tempus/src/Tempus_StepperNewmarkExplicitAForm_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkExplicitAForm_impl.hpp
@@ -58,16 +58,31 @@ correctVelocity(Thyra::VectorBase<Scalar>& v,
 
 
 template<class Scalar>
+StepperNewmarkExplicitAForm<Scalar>::StepperNewmarkExplicitAForm() :
+  out_(Teuchos::VerboseObjectBase::getDefaultOStream())
+{
+  this->setParameterList(Teuchos::null);
+  this->modelWarning();
+}
+
+
+template<class Scalar>
 StepperNewmarkExplicitAForm<Scalar>::StepperNewmarkExplicitAForm(
   const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
   Teuchos::RCP<Teuchos::ParameterList> pList) :
   out_(Teuchos::VerboseObjectBase::getDefaultOStream())
 {
-  // Set all the input parameters and call initialize
   this->setParameterList(pList);
-  this->setModel(appModel);
-  this->initialize();
+
+  if (appModel == Teuchos::null) {
+    this->modelWarning();
+  }
+  else {
+    this->setModel(appModel);
+    this->initialize();
+  }
 }
+
 
 template<class Scalar>
 void StepperNewmarkExplicitAForm<Scalar>::setModel(

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_decl.hpp
@@ -43,6 +43,15 @@ class StepperNewmarkImplicitAForm
 {
 public:
 
+  /** \brief Default constructor.
+   *
+   *  - Constructs with a default ParameterList.
+   *  - Can reset ParameterList with setParameterList().
+   *  - Requires subsequent setModel() and initialize() calls before calling
+   *    takeStep().
+  */
+  StepperNewmarkImplicitAForm();
+
   /// Constructor
   StepperNewmarkImplicitAForm(
     const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
@@ -80,8 +89,15 @@ public:
     virtual bool isOneStepMethod()   const {return true;}
     virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
   //@}
-  
-  /// Pass initial guess to Newton solver  
+
+  /// Return W_xDotxDot_coeff = d(xDotDot)/d(xDotDot).
+  virtual Scalar getW_xDotDot_coeff (const Scalar) const {return Scalar(1.0);}
+  /// Return alpha = d(xDot)/d(xDotDot).
+  virtual Scalar getAlpha(const Scalar dt) const { return gamma_*dt; }
+  /// Return beta  = d(x)/d(xDotDot).
+  virtual Scalar getBeta (const Scalar dt) const { return beta_*dt*dt; }
+
+  /// Pass initial guess to Newton solver
   virtual void setInitialGuess(Teuchos::RCP<const Thyra::VectorBase<Scalar> > initial_guess)
        {initial_guess_ = initial_guess;}
 
@@ -121,12 +137,6 @@ public:
                                const Thyra::VectorBase<Scalar>& dPred,
                                const Thyra::VectorBase<Scalar>& a,
                                const Scalar dt) const;
-
-private:
-
-  /// Default Constructor -- not allowed
-  StepperNewmarkImplicitAForm();
-
 private:
 
   Thyra::ModelEvaluatorBase::InArgs<Scalar>                inArgs_;

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_impl.hpp
@@ -22,6 +22,7 @@ namespace Tempus {
 // Forward Declaration for recursive includes (this Stepper <--> StepperFactory)
 template<class Scalar> class StepperFactory;
 
+
 template<class Scalar>
 void StepperNewmarkImplicitAForm<Scalar>::
 predictVelocity(Thyra::VectorBase<Scalar>& vPred,
@@ -86,6 +87,19 @@ correctDisplacement(Thyra::VectorBase<Scalar>& d,
 
 
 template<class Scalar>
+StepperNewmarkImplicitAForm<Scalar>::StepperNewmarkImplicitAForm() :
+  out_(Teuchos::VerboseObjectBase::getDefaultOStream())
+{
+#ifdef VERBOSE_DEBUG_OUTPUT
+  *out_ << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
+#endif
+
+  this->setParameterList(Teuchos::null);
+  this->modelWarning();
+}
+
+
+template<class Scalar>
 StepperNewmarkImplicitAForm<Scalar>::StepperNewmarkImplicitAForm(
   const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
   Teuchos::RCP<Teuchos::ParameterList> pList) :
@@ -94,13 +108,16 @@ StepperNewmarkImplicitAForm<Scalar>::StepperNewmarkImplicitAForm(
 #ifdef VERBOSE_DEBUG_OUTPUT
   *out_ << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
 #endif
-  using Teuchos::RCP;
-  using Teuchos::ParameterList;
 
-  // Set all the input parameters and call initialize
   this->setParameterList(pList);
-  this->setModel(appModel);
-  this->initialize();
+
+  if (appModel == Teuchos::null) {
+    this->modelWarning();
+  }
+  else {
+    this->setModel(appModel);
+    this->initialize();
+  }
 }
 
 

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitDForm_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitDForm_decl.hpp
@@ -37,6 +37,16 @@ namespace Tempus {
 template <class Scalar>
 class StepperNewmarkImplicitDForm : virtual public Tempus::StepperImplicit<Scalar> {
  public:
+
+  /** \brief Default constructor.
+   *
+   *  - Constructs with a default ParameterList.
+   *  - Can reset ParameterList with setParameterList().
+   *  - Requires subsequent setModel() and initialize() calls before calling
+   *    takeStep().
+  */
+  StepperNewmarkImplicitDForm();
+
   /// Constructor
   StepperNewmarkImplicitDForm(
       const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar>>& appModel,
@@ -58,7 +68,7 @@ class StepperNewmarkImplicitDForm : virtual public Tempus::StepperImplicit<Scala
   virtual void
   takeStep(const Teuchos::RCP<SolutionHistory<Scalar>>& solutionHistory);
 
-  /// Pass initial guess to Newton solver  
+  /// Pass initial guess to Newton solver
   virtual void setInitialGuess(Teuchos::RCP<const Thyra::VectorBase<Scalar> > initial_guess)
        {initial_guess_ = initial_guess;}
 
@@ -87,6 +97,14 @@ class StepperNewmarkImplicitDForm : virtual public Tempus::StepperImplicit<Scala
   virtual bool isOneStepMethod()   const {return true;}
   virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
   //@}
+
+  /// Return W_xDotxDot_coeff = d(xDotDot)/d(x).
+  virtual Scalar getW_xDotDot_coeff (const Scalar dt) const
+    { return Scalar(1.0)/(beta_*dt*dt); }
+  /// Return alpha = d(xDot)/d(x).
+  virtual Scalar getAlpha(const Scalar dt) const { return gamma_/(beta_*dt); }
+  /// Return beta  = d(x)/d(x).
+  virtual Scalar getBeta (const Scalar ) const { return Scalar(1.0); }
 
   /// \name ParameterList methods
   //@{
@@ -137,11 +155,7 @@ class StepperNewmarkImplicitDForm : virtual public Tempus::StepperImplicit<Scala
       Thyra::VectorBase<Scalar>& a, const Thyra::VectorBase<Scalar>& dPred,
       const Thyra::VectorBase<Scalar>& d, const Scalar dt) const;
 
- private:
-  /// Default Constructor -- not allowed
-  StepperNewmarkImplicitDForm();
-
- private:
+ protected:
 
   Thyra::ModelEvaluatorBase::InArgs<Scalar> inArgs_;
   Thyra::ModelEvaluatorBase::OutArgs<Scalar> outArgs_;

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitDForm_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitDForm_impl.hpp
@@ -90,7 +90,17 @@ StepperNewmarkImplicitDForm<Scalar>::correctAcceleration(
   Thyra::V_StVpStV(Teuchos::ptrFromRef(a), c, d, -c, dPred);
 }
 
-// StepperNewmarkImplicitDForm definitions:
+template <class Scalar>
+StepperNewmarkImplicitDForm<Scalar>::StepperNewmarkImplicitDForm()
+    : out_(Teuchos::VerboseObjectBase::getDefaultOStream()) {
+#ifdef VERBOSE_DEBUG_OUTPUT
+  *out_ << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
+#endif
+
+  this->setParameterList(Teuchos::null);
+  this->modelWarning();
+}
+
 template <class Scalar>
 StepperNewmarkImplicitDForm<Scalar>::StepperNewmarkImplicitDForm(
     const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar>>& appModel,
@@ -99,13 +109,16 @@ StepperNewmarkImplicitDForm<Scalar>::StepperNewmarkImplicitDForm(
 #ifdef VERBOSE_DEBUG_OUTPUT
   *out_ << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
 #endif
-  using Teuchos::RCP;
-  using Teuchos::ParameterList;
 
-  // Set all the input parameters and call initialize
   this->setParameterList(pList);
-  this->setModel(appModel);
-  this->initialize();
+
+  if (appModel == Teuchos::null) {
+    this->modelWarning();
+  }
+  else {
+    this->setModel(appModel);
+    this->initialize();
+  }
 }
 
 template <class Scalar>

--- a/packages/tempus/src/Tempus_StepperOperatorSplit_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperOperatorSplit_decl.hpp
@@ -36,13 +36,19 @@ class StepperOperatorSplit : virtual public Tempus::Stepper<Scalar>
 {
 public:
 
+  /** \brief Default constructor.
+   *
+   *  - Constructs with a default ParameterList.
+   *  - Can reset ParameterList with setParameterList().
+   *  - Requires subsequent addStepper() and initialize() calls before calling
+   *    takeStep().
+  */
+  StepperOperatorSplit();
+
   /// Constructor
   StepperOperatorSplit(
     std::vector<Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > > appModels,
     Teuchos::RCP<Teuchos::ParameterList> pList);
-
-  /// Constructor which is setup except for models and steppers (i.e., addStepper()), and an initialize() before being used.
-  StepperOperatorSplit();
 
   /// \name Basic stepper methods
   //@{

--- a/packages/tempus/src/Tempus_StepperOperatorSplit_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperOperatorSplit_impl.hpp
@@ -16,6 +16,24 @@
 
 namespace Tempus {
 
+
+template<class Scalar>
+StepperOperatorSplit<Scalar>::StepperOperatorSplit()
+  : stepperPL_(Teuchos::null), OpSpSolnHistory_(Teuchos::null),
+    stepperOSObserver_(Teuchos::null)
+{
+  this->setParameterList(Teuchos::null);
+
+  Teuchos::RCP<Teuchos::FancyOStream> out = this->getOStream();
+  Teuchos::OSTab ostab(out,1,this->description());
+  *out << "Warning -- Constructing " << this->description()
+       << " without ModelEvaluators!\n"
+       << "  - Can reset ParameterList with setParameterList().\n"
+       << "  - Requires subsequent addStepper()/createSubSteppers()\n"
+       << "    and initialize() calls before calling takeStep().\n"
+       << std::endl;
+}
+
 template<class Scalar>
 StepperOperatorSplit<Scalar>::StepperOperatorSplit(
   std::vector<Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > > appModels,
@@ -24,19 +42,21 @@ StepperOperatorSplit<Scalar>::StepperOperatorSplit(
     stepperOSObserver_(Teuchos::null)
 {
   this->setParameterList(pList);
-  this->createSubSteppers(appModels);
-  this->initialize();
-}
 
-template<class Scalar>
-StepperOperatorSplit<Scalar>::StepperOperatorSplit()
-  : stepperPL_(Teuchos::null), OpSpSolnHistory_(Teuchos::null),
-    stepperOSObserver_(Teuchos::null)
-{
-  this->setParameterList(Teuchos::null);
-  // Still require
-  //  * Setting models and steppers, i.e., addStepper()
-  //  * Calling initialize()
+  if (appModels.empty()) {
+    Teuchos::RCP<Teuchos::FancyOStream> out = this->getOStream();
+    Teuchos::OSTab ostab(out,1,this->description());
+    *out << "Warning -- Constructing " << this->description()
+         << " without ModelEvaluators!\n"
+         << "  - Can reset ParameterList with setParameterList().\n"
+         << "  - Requires subsequent addStepper()/createSubSteppers\n"
+         << "    and initialize() calls before calling takeStep().\n"
+         << std::endl;
+  }
+  else {
+    this->createSubSteppers(appModels);
+    this->initialize();
+  }
 }
 
 template<class Scalar>
@@ -175,7 +195,7 @@ void StepperOperatorSplit<Scalar>::createSubSteppers(
 
   for (; aMI<appModels.end() || sLSI<stepperListStr.end(); aMI++, sLSI++) {
     RCP<ParameterList> subStepperPL = Teuchos::sublist(stepperPL_,*sLSI,true);
-    subStepperList_.push_back(sf->createStepper(*aMI, subStepperPL));
+    subStepperList_.push_back(sf->createStepper(subStepperPL, *aMI));
   }
 }
 

--- a/packages/tempus/src/Tempus_StepperStaggeredForwardSensitivity_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperStaggeredForwardSensitivity_decl.hpp
@@ -31,6 +31,15 @@ class StepperStaggeredForwardSensitivity :
 {
 public:
 
+  /** \brief Default constructor.
+   *
+   *  - Constructs with a default ParameterList.
+   *  - Can reset ParameterList with setParameterList().
+   *  - Requires subsequent setModel() and initialize() calls before calling
+   *    takeStep().
+  */
+  StepperStaggeredForwardSensitivity();
+
   /// Constructor
   /*!
    * The first parameter list argument supplies supplies regular stepper
@@ -146,13 +155,10 @@ public:
 
 private:
 
-  /// Default Constructor -- not allowed
-  StepperStaggeredForwardSensitivity();
-
   void setParams(const Teuchos::RCP<Teuchos::ParameterList> & pl,
                  const Teuchos::RCP<Teuchos::ParameterList> & spl);
 
-private:
+protected:
 
   Teuchos::RCP<Teuchos::ParameterList>               stepperPL_;
   Teuchos::RCP<Teuchos::ParameterList>               sensPL_;

--- a/packages/tempus/src/Tempus_StepperStaggeredForwardSensitivity_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperStaggeredForwardSensitivity_impl.hpp
@@ -23,7 +23,16 @@ namespace Tempus {
 // Forward Declaration for recursive includes (this Stepper <--> StepperFactory)
 template<class Scalar> class StepperFactory;
 
-// StepperStaggeredForwardSensitivity definitions:
+
+template<class Scalar>
+StepperStaggeredForwardSensitivity<Scalar>::
+StepperStaggeredForwardSensitivity()
+{
+  this->setParams(Teuchos::null, Teuchos::null);
+  this->modelWarning();
+}
+
+
 template<class Scalar>
 StepperStaggeredForwardSensitivity<Scalar>::
 StepperStaggeredForwardSensitivity(
@@ -31,9 +40,6 @@ StepperStaggeredForwardSensitivity(
   const Teuchos::RCP<Teuchos::ParameterList>& pList,
   const Teuchos::RCP<Teuchos::ParameterList>& sens_pList)
 {
-  using Teuchos::RCP;
-  using Teuchos::ParameterList;
-
   // Set all the input parameters and call initialize
   this->setParams(pList, sens_pList);
   this->setModel(appModel);
@@ -66,11 +72,11 @@ setModel(
   // Create state and sensitivity steppers
   RCP<StepperFactory<Scalar> > sf =Teuchos::rcp(new StepperFactory<Scalar>());
   if (stateStepper_ == Teuchos::null)
-    stateStepper_ = sf->createStepper(appModel, stepperPL_);
+    stateStepper_ = sf->createStepper(stepperPL_, appModel);
   else
     stateStepper_->setModel(appModel);
   if (sensitivityStepper_ == Teuchos::null)
-    sensitivityStepper_ = sf->createStepper(fsa_model_, stepperPL_);
+    sensitivityStepper_ = sf->createStepper(stepperPL_, fsa_model_);
   else
     sensitivityStepper_->setModel(fsa_model_);
 }

--- a/packages/tempus/src/Tempus_StepperTrapezoidal_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperTrapezoidal_decl.hpp
@@ -33,6 +33,15 @@ class StepperTrapezoidal : virtual public Tempus::StepperImplicit<Scalar>
 {
 public:
 
+  /** \brief Default constructor.
+   *
+   *  - Constructs with a default ParameterList.
+   *  - Can reset ParameterList with setParameterList().
+   *  - Requires subsequent setModel() and initialize() calls before calling
+   *    takeStep().
+  */
+  StepperTrapezoidal();
+
   /// Constructor
   StepperTrapezoidal(
     const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
@@ -63,8 +72,13 @@ public:
     virtual bool isOneStepMethod()   const {return true;}
     virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
   //@}
-    
-  /// Pass initial guess to Newton solver (only relevant for explicit schemes)  
+
+  /// Return alpha = d(xDot)/dx.
+  virtual Scalar getAlpha(const Scalar dt) const { return Scalar(2.0)/dt; }
+  /// Return beta  = d(x)/dx.
+  virtual Scalar getBeta (const Scalar   ) const { return Scalar(1.0); }
+
+  /// Pass initial guess to Newton solver (only relevant for explicit schemes)
   virtual void setInitialGuess(Teuchos::RCP<const Thyra::VectorBase<Scalar> > initial_guess)
      {initial_guess_ = initial_guess;}
 
@@ -87,11 +101,6 @@ public:
     virtual void describe(Teuchos::FancyOStream        & out,
                           const Teuchos::EVerbosityLevel verbLevel) const;
   //@}
-
-private:
-
-  /// Default Constructor -- not allowed
-  StepperTrapezoidal();
 
 private:
 

--- a/packages/tempus/src/Tempus_StepperTrapezoidal_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperTrapezoidal_impl.hpp
@@ -22,16 +22,28 @@ namespace Tempus {
 template<class Scalar> class StepperFactory;
 
 
-// StepperTrapezoidal definitions:
+template<class Scalar>
+StepperTrapezoidal<Scalar>::StepperTrapezoidal()
+{
+  this->setParameterList(Teuchos::null);
+  this->modelWarning();
+}
+
+
 template<class Scalar>
 StepperTrapezoidal<Scalar>::StepperTrapezoidal(
   const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
   Teuchos::RCP<Teuchos::ParameterList> pList)
 {
-  // Set all the input parameters and call initialize
   this->setParameterList(pList);
-  this->setModel(appModel);
-  this->initialize();
+
+  if (appModel == Teuchos::null) {
+    this->modelWarning();
+  }
+  else {
+    this->setModel(appModel);
+    this->initialize();
+  }
 }
 
 
@@ -99,7 +111,9 @@ void StepperTrapezoidal<Scalar>::takeStep(
 
     const Scalar time  = workingState->getTime();
     const Scalar dt    = workingState->getTimeStep();
-    const Scalar alpha = 2.0/dt;
+    const Scalar alpha = getAlpha(dt);
+    const Scalar beta  = getBeta (dt);
+
 
     // Setup TimeDerivative
     Teuchos::RCP<TimeDerivative<Scalar> > timeDer =
@@ -115,7 +129,7 @@ void StepperTrapezoidal<Scalar>::takeStep(
     if (inArgs.supports(MEB::IN_ARG_t        )) inArgs.set_t        (time);
     if (inArgs.supports(MEB::IN_ARG_step_size)) inArgs.set_step_size(dt);
     if (inArgs.supports(MEB::IN_ARG_alpha    )) inArgs.set_alpha    (alpha);
-    if (inArgs.supports(MEB::IN_ARG_beta     )) inArgs.set_beta     (1.0);
+    if (inArgs.supports(MEB::IN_ARG_beta     )) inArgs.set_beta     (beta);
 
     this->wrapperModel_->setForSolve(timeDer, inArgs, outArgs);
 

--- a/packages/tempus/src/Tempus_Types.hpp
+++ b/packages/tempus/src/Tempus_Types.hpp
@@ -22,15 +22,18 @@ enum Status {
 
 /** \brief Convert Status to string. */
 inline
-const char* toString(const Status status)
+const std::string toString(const Status status)
 {
+  std::string s = "Invalid Status!";
   switch(status) {
-    case PASSED:  return "PASSED";
-    case FAILED:  return "FAILED";
-    case WORKING: return "WORKING";
-    default:      TEUCHOS_TEST_FOR_EXCEPT("Invalid Status!");
+    case PASSED:  s = "PASSED";          break;
+    case FAILED:  s = "FAILED";          break;
+    case WORKING: s = "WORKING";         break;
+    default:      s = "Invalid Status!"; break;
   }
-  return "";  // Should not get here.
+  TEUCHOS_TEST_FOR_EXCEPTION(s == "Invalid Status!", std::logic_error,
+   "Error - Invalid status = " << status << "\n");
+  return s;
 }
 
 

--- a/packages/tempus/src/Tempus_WrapperModelEvaluatorPairPartIMEX_Basic_impl.hpp
+++ b/packages/tempus/src/Tempus_WrapperModelEvaluatorPairPartIMEX_Basic_impl.hpp
@@ -168,26 +168,34 @@ getIMEXVector(const Teuchos::RCP<Thyra::VectorBase<Scalar> > & full) const
   using Teuchos::RCP;
   using Teuchos::rcp_dynamic_cast;
 
-  if(full == Teuchos::null)
-    return Teuchos::null;
+  Teuchos::RCP<Thyra::VectorBase<Scalar> > vector;
+  if(full == Teuchos::null) {
+    vector = Teuchos::null;
+  }
+  else if(numExplicitOnlyBlocks_ == 0) {
+    vector = full;
+  }
+  else {
 
-  if(numExplicitOnlyBlocks_==0)
-    return full;
+    RCP<Thyra::ProductVectorBase<Scalar> > blk_full =
+      rcp_dynamic_cast<Thyra::ProductVectorBase<Scalar> >(full);
+    TEUCHOS_TEST_FOR_EXCEPTION( blk_full == Teuchos::null, std::logic_error,
+      "Error - WrapperModelEvaluatorPairPartIMEX_Basic::getIMEXVector()\n"
+      "  was given a VectorBase that could not be cast to a\n"
+      "  ProductVectorBase!\n");
+    int numBlocks = blk_full->productSpace()->numBlocks();
 
-  RCP<Thyra::ProductVectorBase<Scalar> > blk_full =
-    rcp_dynamic_cast<Thyra::ProductVectorBase<Scalar> >(full);
-  TEUCHOS_TEST_FOR_EXCEPTION( blk_full == Teuchos::null, std::logic_error,
-    "Error - WrapperModelEvaluatorPairPartIMEX_Basic::getIMEXVector()\n"
-    "  was given a VectorBase that could not be cast to a\n"
-    "  ProductVectorBase!\n");
-  int numBlocks = blk_full->productSpace()->numBlocks();
+    // special case where the implicit terms are not blocked
+    if(numBlocks == numExplicitOnlyBlocks_+1)
+      vector = blk_full->getNonconstVectorBlock(numExplicitOnlyBlocks_);
 
-  // special case where the implicit terms are not blocked
-  if(numBlocks==numExplicitOnlyBlocks_+1)
-    return blk_full->getNonconstVectorBlock(numExplicitOnlyBlocks_);
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      !( numExplicitOnlyBlocks_ == 0 || full == Teuchos::null ||
+         numBlocks == numExplicitOnlyBlocks_+1 ),
+      std::logic_error, "Error - Invalid values!\n");
+  }
 
-  TEUCHOS_ASSERT(false);
-  return Teuchos::null;
+  return vector;
 }
 
 template <typename Scalar>
@@ -198,26 +206,36 @@ getIMEXVector(const Teuchos::RCP<const Thyra::VectorBase<Scalar> > & full) const
   using Teuchos::RCP;
   using Teuchos::rcp_dynamic_cast;
 
-  if(full == Teuchos::null)
-    return Teuchos::null;
+  Teuchos::RCP<const Thyra::VectorBase<Scalar> > vector;
+  if(full == Teuchos::null) {
+    vector = Teuchos::null;
+  }
+  else if(numExplicitOnlyBlocks_ == 0) {
+    vector = full;
+  }
+  else {
 
-  if(numExplicitOnlyBlocks_==0)
-    return full;
+    // special case where the implicit terms are not blocked
 
-  RCP<const Thyra::ProductVectorBase<Scalar> > blk_full =
-    rcp_dynamic_cast<const Thyra::ProductVectorBase<Scalar> >(full);
-  TEUCHOS_TEST_FOR_EXCEPTION( blk_full == Teuchos::null, std::logic_error,
-    "Error - WrapperModelEvaluatorPairPartIMEX_Basic::getIMEXVector()\n"
-    "  was given a VectorBase that could not be cast to a\n"
-    "  ProductVectorBase!\n");
-  int numBlocks = blk_full->productSpace()->numBlocks();
+    RCP<const Thyra::ProductVectorBase<Scalar> > blk_full =
+      rcp_dynamic_cast<const Thyra::ProductVectorBase<Scalar> >(full);
+    TEUCHOS_TEST_FOR_EXCEPTION( blk_full == Teuchos::null, std::logic_error,
+      "Error - WrapperModelEvaluatorPairPartIMEX_Basic::getIMEXVector()\n"
+      "  was given a VectorBase that could not be cast to a\n"
+      "  ProductVectorBase!\n");
+    int numBlocks = blk_full->productSpace()->numBlocks();
 
-  // special case where the implicit terms are not blocked
-  if(numBlocks==numExplicitOnlyBlocks_+1)
-    return blk_full->getVectorBlock(numExplicitOnlyBlocks_);
+    // special case where the implicit terms are not blocked
+    if(numBlocks == numExplicitOnlyBlocks_+1)
+      vector = blk_full->getVectorBlock(numExplicitOnlyBlocks_);
 
-  TEUCHOS_ASSERT(false);
-  return Teuchos::null;
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      !( numExplicitOnlyBlocks_ == 0 || full == Teuchos::null ||
+         numBlocks == numExplicitOnlyBlocks_+1 ),
+      std::logic_error, "Error - Invalid values!\n");
+  }
+
+  return vector;
 }
 
 template <typename Scalar>
@@ -229,23 +247,30 @@ getExplicitOnlyVector(
   using Teuchos::RCP;
   using Teuchos::rcp_dynamic_cast;
 
-  if(numExplicitOnlyBlocks_ == 0 || full == Teuchos::null)
-    return Teuchos::null;
+  Teuchos::RCP<Thyra::VectorBase<Scalar> > vector;
+  if(numExplicitOnlyBlocks_ == 0 || full == Teuchos::null) {
+    vector = Teuchos::null;
+  }
+  else if(numExplicitOnlyBlocks_ == 1) {
 
-  RCP<Thyra::ProductVectorBase<Scalar> > blk_full =
-    rcp_dynamic_cast<Thyra::ProductVectorBase<Scalar> >(full);
-  TEUCHOS_TEST_FOR_EXCEPTION( blk_full == Teuchos::null, std::logic_error,
-    "Error - WrapperModelEvaluatorPairPartIMEX_Basic::getExplicitOnlyVector()\n"
-    "  was given a VectorBase that could not be cast to a ProductVectorBase!\n"
-    "  full = " << *full << "\n");
+    // special case where the explicit terms are not blocked
 
-  // special case where the explicit terms are not blocked
-  if(numExplicitOnlyBlocks_==1)
-    return blk_full->getNonconstVectorBlock(0);
+    RCP<Thyra::ProductVectorBase<Scalar> > blk_full =
+      rcp_dynamic_cast<Thyra::ProductVectorBase<Scalar> >(full);
+    TEUCHOS_TEST_FOR_EXCEPTION( blk_full == Teuchos::null, std::logic_error,
+      "Error - WrapperModelEvaluatorPairPartIMEX_Basic::getExplicitOnlyVector\n"
+      "  given a VectorBase that could not be cast to a ProductVectorBase!\n"
+      "  full = " << *full << "\n");
 
-  TEUCHOS_ASSERT(false);
-  return Teuchos::null;
+    vector = blk_full->getNonconstVectorBlock(0);
+  }
 
+  TEUCHOS_TEST_FOR_EXCEPTION(
+    !( (numExplicitOnlyBlocks_ == 0 || full == Teuchos::null) ||
+       (numExplicitOnlyBlocks_ == 1) ),
+    std::logic_error, "Error - Invalid values!\n");
+
+  return vector;
 }
 
 template <typename Scalar>
@@ -257,23 +282,31 @@ getExplicitOnlyVector(
   using Teuchos::RCP;
   using Teuchos::rcp_dynamic_cast;
 
-  if(numExplicitOnlyBlocks_ == 0 || full == Teuchos::null)
-    return Teuchos::null;
+  RCP<const Thyra::VectorBase<Scalar> > vector;
+  if(numExplicitOnlyBlocks_ == 0 || full == Teuchos::null) {
+    vector = Teuchos::null;
+  }
+  else if(numExplicitOnlyBlocks_ == 1) {
 
-  RCP<const Thyra::ProductVectorBase<Scalar> > blk_full =
-    rcp_dynamic_cast<const Thyra::ProductVectorBase<Scalar> >(full);
-  TEUCHOS_TEST_FOR_EXCEPTION( blk_full == Teuchos::null, std::logic_error,
-    "Error - WrapperModelEvaluatorPairPartIMEX_Basic::getExplicitOnlyVector()\n"
-    "  was given a VectorBase that could not be cast to a ProductVectorBase!\n"
-    "  full = " << *full << "\n");
+    // special case where the explicit terms are not blocked
 
-  // special case where the explicit terms are not blocked
-  if(numExplicitOnlyBlocks_==1)
-    return blk_full->getVectorBlock(0);
+    RCP<const Thyra::ProductVectorBase<Scalar> > blk_full =
+      rcp_dynamic_cast<const Thyra::ProductVectorBase<Scalar> >(full);
+    TEUCHOS_TEST_FOR_EXCEPTION( blk_full == Teuchos::null, std::logic_error,
+      "Error - WrapperModelEvaluatorPairPartIMEX_Basic::getExplicitOnlyVector\n"
+      "  given a VectorBase that could not be cast to a ProductVectorBase!\n"
+      "  full = " << *full << "\n");
 
-  TEUCHOS_ASSERT(false);
-  return Teuchos::null;
+    vector = blk_full->getVectorBlock(0);
 
+  }
+
+  TEUCHOS_TEST_FOR_EXCEPTION(
+    !( (numExplicitOnlyBlocks_ == 0 || full == Teuchos::null) ||
+       (numExplicitOnlyBlocks_ == 1) ),
+    std::logic_error, "Error - Invalid values!\n");
+
+  return vector;
 }
 
 template <typename Scalar>

--- a/packages/tempus/test/BackwardEuler/Tempus_BackwardEulerTest.cpp
+++ b/packages/tempus/test/BackwardEuler/Tempus_BackwardEulerTest.cpp
@@ -37,6 +37,8 @@
 namespace Tempus_Test {
 
 using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
 using Teuchos::ParameterList;
 using Teuchos::sublist;
 using Teuchos::getParametersFromXmlFile;
@@ -65,8 +67,7 @@ TEUCHOS_UNIT_TEST(BackwardEuler, ParameterList)
 
   // Setup the SinCosModel
   RCP<ParameterList> scm_pl = sublist(pList, "SinCosModel", true);
-  RCP<SinCosModel<double> > model =
-    Teuchos::rcp(new SinCosModel<double> (scm_pl));
+  auto model = rcp(new SinCosModel<double> (scm_pl));
 
   RCP<ParameterList> tempusPL  = sublist(pList, "Tempus", true);
 
@@ -114,24 +115,15 @@ TEUCHOS_UNIT_TEST(BackwardEuler, ConstructingFromDefaults)
   // Setup the SinCosModel
   RCP<ParameterList> scm_pl = sublist(pList, "SinCosModel", true);
   //RCP<SinCosModel<double> > model = sineCosineModel(scm_pl);
-  RCP<SinCosModel<double> > model =
-    Teuchos::rcp(new SinCosModel<double>(scm_pl));
+  auto model = rcp(new SinCosModel<double>(scm_pl));
 
   // Setup Stepper for field solve ----------------------------
-  RCP<Tempus::StepperBackwardEuler<double> > stepper =
-    Teuchos::rcp(new Tempus::StepperBackwardEuler<double>(model));
-  //{
-  //  // Setup a linear NOX solve
-  //  RCP<ParameterList> sPL = stepper->getNonconstParameterList();
-  //  std::string solverName = sPL->get<std::string>("Solver Name");
-  //  RCP<ParameterList> solverPL = Teuchos::sublist(sPL, solverName, true);
-  //  stepper->setSolver(solverPL);
-  //  stepper->initialize();
-  //}
+  auto stepper = rcp(new Tempus::StepperBackwardEuler<double>());
+  stepper->setModel(model);
+  stepper->initialize();
 
   // Setup TimeStepControl ------------------------------------
-  RCP<Tempus::TimeStepControl<double> > timeStepControl =
-    Teuchos::rcp(new Tempus::TimeStepControl<double>());
+  auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
   ParameterList tscPL = pl->sublist("Default Integrator")
                            .sublist("Time Step Control");
   timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
@@ -144,10 +136,9 @@ TEUCHOS_UNIT_TEST(BackwardEuler, ConstructingFromDefaults)
   // Setup initial condition SolutionState --------------------
   Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
     stepper->getModel()->getNominalValues();
-  RCP<Thyra::VectorBase<double> > icSolution =
-    Teuchos::rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
-  RCP<Tempus::SolutionState<double> > icState =
-      Teuchos::rcp(new Tempus::SolutionState<double>(icSolution));
+  auto icSolution =
+    rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
+  auto icState = rcp(new Tempus::SolutionState<double>(icSolution));
   icState->setTime    (timeStepControl->getInitTime());
   icState->setIndex   (timeStepControl->getInitIndex());
   icState->setTimeStep(0.0);
@@ -155,8 +146,7 @@ TEUCHOS_UNIT_TEST(BackwardEuler, ConstructingFromDefaults)
   icState->setSolutionStatus(Tempus::Status::PASSED);  // ICs are passing.
 
   // Setup SolutionHistory ------------------------------------
-  RCP<Tempus::SolutionHistory<double> > solutionHistory =
-    Teuchos::rcp(new Tempus::SolutionHistory<double>());
+  auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());
   solutionHistory->setName("Forward States");
   solutionHistory->setStorageType(Tempus::STORAGE_TYPE_STATIC);
   solutionHistory->setStorageLimit(2);
@@ -235,8 +225,7 @@ TEUCHOS_UNIT_TEST(BackwardEuler, SinCos)
     // Setup the SinCosModel
     RCP<ParameterList> scm_pl = sublist(pList, "SinCosModel", true);
     //RCP<SinCosModel<double> > model = sineCosineModel(scm_pl);
-    RCP<SinCosModel<double> > model =
-      Teuchos::rcp(new SinCosModel<double>(scm_pl));
+    auto model = rcp(new SinCosModel<double>(scm_pl));
 
     dt /= 2;
 
@@ -270,12 +259,10 @@ TEUCHOS_UNIT_TEST(BackwardEuler, SinCos)
         integrator->getSolutionHistory();
       writeSolution("Tempus_BackwardEuler_SinCos.dat", solutionHistory);
 
-      RCP<Tempus::SolutionHistory<double> > solnHistExact =
-        Teuchos::rcp(new Tempus::SolutionHistory<double>());
+      auto solnHistExact = rcp(new Tempus::SolutionHistory<double>());
       for (int i=0; i<solutionHistory->getNumStates(); i++) {
         double time_i = (*solutionHistory)[i]->getTime();
-        RCP<Tempus::SolutionState<double> > state =
-          Teuchos::rcp(new Tempus::SolutionState<double>(
+        auto state = rcp(new Tempus::SolutionState<double>(
             model->getExactSolution(time_i).get_x(),
             model->getExactSolution(time_i).get_x_dot()));
         state->setTime((*solutionHistory)[i]->getTime());
@@ -332,9 +319,9 @@ TEUCHOS_UNIT_TEST(BackwardEuler, CDR)
   // Create a communicator for Epetra objects
   RCP<Epetra_Comm> comm;
 #ifdef Tempus_ENABLE_MPI
-  comm = Teuchos::rcp(new Epetra_MpiComm(MPI_COMM_WORLD));
+  comm = rcp(new Epetra_MpiComm(MPI_COMM_WORLD));
 #else
-  comm = Teuchos::rcp(new Epetra_SerialComm);
+  comm = rcp(new Epetra_SerialComm);
 #endif
 
   RCP<Tempus::IntegratorBasic<double> > integrator;
@@ -359,24 +346,22 @@ TEUCHOS_UNIT_TEST(BackwardEuler, CDR)
     const double a_convection = model_pl->get<double>("a (convection)");
     const double k_source = model_pl->get<double>("k (source)");
 
-    RCP<Tempus_Test::CDR_Model<double>> model =
-      Teuchos::rcp(new Tempus_Test::CDR_Model<double>(comm,
-                                                      num_elements,
-                                                      left_end,
-                                                      right_end,
-                                                      a_convection,
-                                                      k_source));
+    auto model = rcp(new Tempus_Test::CDR_Model<double>(comm,
+                                                        num_elements,
+                                                        left_end,
+                                                        right_end,
+                                                        a_convection,
+                                                        k_source));
 
     // Set the factory
     ::Stratimikos::DefaultLinearSolverBuilder builder;
 
-    Teuchos::RCP<Teuchos::ParameterList> p =
-      Teuchos::rcp(new Teuchos::ParameterList);
+    auto p = rcp(new ParameterList);
     p->set("Linear Solver Type", "Belos");
     p->set("Preconditioner Type", "None");
     builder.setParameterList(p);
 
-    Teuchos::RCP< ::Thyra::LinearOpWithSolveFactoryBase<double> >
+    RCP< ::Thyra::LinearOpWithSolveFactoryBase<double> >
       lowsFactory = builder.createLinearSolveStrategy("");
 
     model->set_W_factory(lowsFactory);
@@ -505,8 +490,7 @@ TEUCHOS_UNIT_TEST(BackwardEuler, VanDerPol)
 
     // Setup the VanDerPolModel
     RCP<ParameterList> vdpm_pl = sublist(pList, "VanDerPolModel", true);
-    RCP<VanDerPolModel<double> > model =
-      Teuchos::rcp(new VanDerPolModel<double>(vdpm_pl));
+    auto model = rcp(new VanDerPolModel<double>(vdpm_pl));
 
     // Set the step size
     dt /= 2;
@@ -581,8 +565,7 @@ TEUCHOS_UNIT_TEST(BackwardEuler, OptInterface)
 
   // Setup the SinCosModel
   RCP<ParameterList> scm_pl = sublist(pList, "SinCosModel", true);
-  RCP<SinCosModel<double> > model =
-    Teuchos::rcp(new SinCosModel<double>(scm_pl));
+  auto model = rcp(new SinCosModel<double>(scm_pl));
 
   // Setup the Integrator
   RCP<ParameterList> pl = sublist(pList, "Tempus", true);

--- a/packages/tempus/test/DIRK/Tempus_DIRKTest.cpp
+++ b/packages/tempus/test/DIRK/Tempus_DIRKTest.cpp
@@ -25,7 +25,10 @@
 namespace Tempus_Test {
 
 using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
 using Teuchos::ParameterList;
+using Teuchos::parameterList;
 using Teuchos::sublist;
 using Teuchos::getParametersFromXmlFile;
 
@@ -70,8 +73,7 @@ TEUCHOS_UNIT_TEST(DIRK, ParameterList)
 
     // Setup the SinCosModel
     RCP<ParameterList> scm_pl = sublist(pList, "SinCosModel", true);
-    RCP<SinCosModel<double> > model =
-      Teuchos::rcp(new SinCosModel<double>(scm_pl));
+    auto model = rcp(new SinCosModel<double>(scm_pl));
 
     RCP<ParameterList> tempusPL  = sublist(pList, "Tempus", true);
     tempusPL->sublist("Default Stepper").set("Stepper Type", RKMethods[m]);
@@ -81,7 +83,7 @@ TEUCHOS_UNIT_TEST(DIRK, ParameterList)
         RKMethods[m] == "EDIRK 2 Stage Theta Method") {
       // Construct in the same order as default.
       RCP<ParameterList> stepperPL = sublist(tempusPL, "Default Stepper", true);
-      RCP<ParameterList> solverPL = Teuchos::parameterList();
+      RCP<ParameterList> solverPL = parameterList();
       *solverPL  = *(sublist(stepperPL, "Default Solver", true));
       tempusPL->sublist("Default Stepper").remove("Default Solver");
       tempusPL->sublist("Default Stepper")
@@ -92,7 +94,7 @@ TEUCHOS_UNIT_TEST(DIRK, ParameterList)
     } else if (RKMethods[m] == "SDIRK 2 Stage 2nd order") {
       // Construct in the same order as default.
       RCP<ParameterList> stepperPL = sublist(tempusPL, "Default Stepper", true);
-      RCP<ParameterList> solverPL = Teuchos::parameterList();
+      RCP<ParameterList> solverPL = parameterList();
       *solverPL  = *(sublist(stepperPL, "Default Solver", true));
       tempusPL->sublist("Default Stepper").remove("Default Solver");
       tempusPL->sublist("Default Stepper")
@@ -103,7 +105,7 @@ TEUCHOS_UNIT_TEST(DIRK, ParameterList)
     } else if (RKMethods[m] == "SDIRK 2 Stage 3rd order") {
       // Construct in the same order as default.
       RCP<ParameterList> stepperPL = sublist(tempusPL, "Default Stepper", true);
-      RCP<ParameterList> solverPL = Teuchos::parameterList();
+      RCP<ParameterList> solverPL = parameterList();
       *solverPL  = *(sublist(stepperPL, "Default Solver", true));
       tempusPL->sublist("Default Stepper").remove("Default Solver");
       tempusPL->sublist("Default Stepper").set("3rd Order A-stable", true);
@@ -171,16 +173,15 @@ TEUCHOS_UNIT_TEST(DIRK, ConstructingFromDefaults)
   // Setup the SinCosModel
   RCP<ParameterList> scm_pl = sublist(pList, "SinCosModel", true);
   //RCP<SinCosModel<double> > model = sineCosineModel(scm_pl);
-  RCP<SinCosModel<double> > model =
-    Teuchos::rcp(new SinCosModel<double>(scm_pl));
+  auto model = rcp(new SinCosModel<double>(scm_pl));
 
   // Setup Stepper for field solve ----------------------------
-  RCP<Tempus::StepperDIRK<double> > stepper =
-    Teuchos::rcp(new Tempus::StepperDIRK<double>(model));
+  auto stepper = rcp(new Tempus::StepperDIRK<double>());
+  stepper->setModel(model);
+  stepper->initialize();
 
   // Setup TimeStepControl ------------------------------------
-  RCP<Tempus::TimeStepControl<double> > timeStepControl =
-    Teuchos::rcp(new Tempus::TimeStepControl<double>());
+  auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
   ParameterList tscPL = pl->sublist("Default Integrator")
                            .sublist("Time Step Control");
   timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
@@ -193,10 +194,8 @@ TEUCHOS_UNIT_TEST(DIRK, ConstructingFromDefaults)
   // Setup initial condition SolutionState --------------------
   Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
     stepper->getModel()->getNominalValues();
-  RCP<Thyra::VectorBase<double> > icSolution =
-    Teuchos::rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
-  RCP<Tempus::SolutionState<double> > icState =
-      Teuchos::rcp(new Tempus::SolutionState<double>(icSolution));
+  auto icSolution = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
+  auto icState = rcp(new Tempus::SolutionState<double>(icSolution));
   icState->setTime    (timeStepControl->getInitTime());
   icState->setIndex   (timeStepControl->getInitIndex());
   icState->setTimeStep(0.0);
@@ -204,8 +203,7 @@ TEUCHOS_UNIT_TEST(DIRK, ConstructingFromDefaults)
   icState->setSolutionStatus(Tempus::Status::PASSED);  // ICs are passing.
 
   // Setup SolutionHistory ------------------------------------
-  RCP<Tempus::SolutionHistory<double> > solutionHistory =
-    Teuchos::rcp(new Tempus::SolutionHistory<double>());
+  auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());
   solutionHistory->setName("Forward States");
   solutionHistory->setStorageType(Tempus::STORAGE_TYPE_STATIC);
   solutionHistory->setStorageLimit(2);
@@ -314,8 +312,7 @@ TEUCHOS_UNIT_TEST(DIRK, SinCos)
 
       // Setup the SinCosModel
       RCP<ParameterList> scm_pl = sublist(pList, "SinCosModel", true);
-      RCP<SinCosModel<double> > model =
-        Teuchos::rcp(new SinCosModel<double>(scm_pl));
+      auto model = rcp(new SinCosModel<double>(scm_pl));
 
       // Set the Stepper
       RCP<ParameterList> pl = sublist(pList, "Tempus", true);
@@ -364,12 +361,10 @@ TEUCHOS_UNIT_TEST(DIRK, SinCos)
           integrator->getSolutionHistory();
         writeSolution("Tempus_"+RKMethod+"_SinCos.dat", solutionHistory);
 
-        RCP<Tempus::SolutionHistory<double> > solnHistExact =
-          Teuchos::rcp(new Tempus::SolutionHistory<double>());
+        auto solnHistExact = rcp(new Tempus::SolutionHistory<double>());
         for (int i=0; i<solutionHistory->getNumStates(); i++) {
           double time_i = (*solutionHistory)[i]->getTime();
-          RCP<Tempus::SolutionState<double> > state =
-            Teuchos::rcp(new Tempus::SolutionState<double>(
+          auto state = rcp(new Tempus::SolutionState<double>(
               model->getExactSolution(time_i).get_x(),
               model->getExactSolution(time_i).get_x_dot()));
           state->setTime((*solutionHistory)[i]->getTime());
@@ -449,8 +444,7 @@ TEUCHOS_UNIT_TEST(DIRK, VanDerPol)
 
     // Setup the VanDerPolModel
     RCP<ParameterList> vdpm_pl = sublist(pList, "VanDerPolModel", true);
-    RCP<VanDerPolModel<double> > model =
-      Teuchos::rcp(new VanDerPolModel<double>(vdpm_pl));
+    auto model = rcp(new VanDerPolModel<double>(vdpm_pl));
 
     // Set the Stepper
     RCP<ParameterList> pl = sublist(pList, "Tempus", true);
@@ -542,8 +536,7 @@ TEUCHOS_UNIT_TEST(DIRK, EmbeddedVanDerPol)
 
       // Setup the VanDerPolModel
       RCP<ParameterList> vdpm_pl = sublist(pList, "VanDerPolModel", true);
-      RCP<VanDerPolModel<double> > model =
-         Teuchos::rcp(new VanDerPolModel<double>(vdpm_pl));
+      auto model = rcp(new VanDerPolModel<double>(vdpm_pl));
 
       // Set the Integrator and Stepper
       RCP<ParameterList> pl = sublist(pList, "Tempus", true);

--- a/packages/tempus/test/ExplicitRK/Tempus_ExplicitRKTest.cpp
+++ b/packages/tempus/test/ExplicitRK/Tempus_ExplicitRKTest.cpp
@@ -26,6 +26,8 @@
 namespace Tempus_Test {
 
 using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
 using Teuchos::ParameterList;
 using Teuchos::sublist;
 using Teuchos::getParametersFromXmlFile;
@@ -73,8 +75,7 @@ TEUCHOS_UNIT_TEST(ExplicitRK, ParameterList)
 
     // Setup the SinCosModel
     RCP<ParameterList> scm_pl = sublist(pList, "SinCosModel", true);
-    RCP<SinCosModel<double> > model =
-      Teuchos::rcp(new SinCosModel<double>(scm_pl));
+    auto model = rcp(new SinCosModel<double>(scm_pl));
 
     // Set the Stepper
     RCP<ParameterList> tempusPL  = sublist(pList, "Tempus", true);
@@ -133,16 +134,15 @@ TEUCHOS_UNIT_TEST(ExplicitRK, ConstructingFromDefaults)
   // Setup the SinCosModel
   RCP<ParameterList> scm_pl = sublist(pList, "SinCosModel", true);
   //RCP<SinCosModel<double> > model = sineCosineModel(scm_pl);
-  RCP<SinCosModel<double> > model =
-    Teuchos::rcp(new SinCosModel<double>(scm_pl));
+  auto model = rcp(new SinCosModel<double>(scm_pl));
 
   // Setup Stepper for field solve ----------------------------
-  RCP<Tempus::StepperExplicitRK<double> > stepper =
-    Teuchos::rcp(new Tempus::StepperExplicitRK<double>(model));
+  auto stepper = rcp(new Tempus::StepperExplicitRK<double>());
+  stepper->setModel(model);
+  stepper->initialize();
 
   // Setup TimeStepControl ------------------------------------
-  RCP<Tempus::TimeStepControl<double> > timeStepControl =
-    Teuchos::rcp(new Tempus::TimeStepControl<double>());
+  auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
   ParameterList tscPL = pl->sublist("Demo Integrator")
                            .sublist("Time Step Control");
   timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
@@ -155,10 +155,8 @@ TEUCHOS_UNIT_TEST(ExplicitRK, ConstructingFromDefaults)
   // Setup initial condition SolutionState --------------------
   Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
     stepper->getModel()->getNominalValues();
-  RCP<Thyra::VectorBase<double> > icSolution =
-    Teuchos::rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
-  RCP<Tempus::SolutionState<double> > icState =
-      Teuchos::rcp(new Tempus::SolutionState<double>(icSolution));
+  auto icSolution = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
+  auto icState = rcp(new Tempus::SolutionState<double>(icSolution));
   icState->setTime    (timeStepControl->getInitTime());
   icState->setIndex   (timeStepControl->getInitIndex());
   icState->setTimeStep(0.0);
@@ -166,8 +164,7 @@ TEUCHOS_UNIT_TEST(ExplicitRK, ConstructingFromDefaults)
   icState->setSolutionStatus(Tempus::Status::PASSED);  // ICs are passing.
 
   // Setup SolutionHistory ------------------------------------
-  RCP<Tempus::SolutionHistory<double> > solutionHistory =
-    Teuchos::rcp(new Tempus::SolutionHistory<double>());
+  auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());
   solutionHistory->setName("Forward States");
   solutionHistory->setStorageType(Tempus::STORAGE_TYPE_STATIC);
   solutionHistory->setStorageLimit(2);
@@ -280,8 +277,7 @@ TEUCHOS_UNIT_TEST(ExplicitRK, SinCos)
       // Setup the SinCosModel
       RCP<ParameterList> scm_pl = sublist(pList, "SinCosModel", true);
       //RCP<SinCosModel<double> > model = sineCosineModel(scm_pl);
-      RCP<SinCosModel<double> > model =
-        Teuchos::rcp(new SinCosModel<double>(scm_pl));
+      auto model = rcp(new SinCosModel<double>(scm_pl));
 
       // Set the Stepper
       RCP<ParameterList> pl = sublist(pList, "Tempus", true);
@@ -330,12 +326,10 @@ TEUCHOS_UNIT_TEST(ExplicitRK, SinCos)
           integrator->getSolutionHistory();
         writeSolution("Tempus_"+RKMethod+"_SinCos.dat", solutionHistory);
 
-        RCP<Tempus::SolutionHistory<double> > solnHistExact =
-          Teuchos::rcp(new Tempus::SolutionHistory<double>());
+        auto solnHistExact = rcp(new Tempus::SolutionHistory<double>());
         for (int i=0; i<solutionHistory->getNumStates(); i++) {
           double time_i = (*solutionHistory)[i]->getTime();
-          RCP<Tempus::SolutionState<double> > state =
-            Teuchos::rcp(new Tempus::SolutionState<double>(
+          auto state = rcp(new Tempus::SolutionState<double>(
               model->getExactSolution(time_i).get_x(),
               model->getExactSolution(time_i).get_x_dot()));
           state->setTime((*solutionHistory)[i]->getTime());
@@ -414,8 +408,7 @@ TEUCHOS_UNIT_TEST(ExplicitRK, EmbeddedVanDerPol)
 
      // Setup the VanDerPolModel
      RCP<ParameterList> vdpm_pl = sublist(pList, "VanDerPolModel", true);
-     RCP<VanDerPolModel<double> > model =
-        Teuchos::rcp(new VanDerPolModel<double>(vdpm_pl));
+     auto model = rcp(new VanDerPolModel<double>(vdpm_pl));
 
 
      // Set the Integrator and Stepper

--- a/packages/tempus/test/ForwardEuler/Tempus_ForwardEulerTest.cpp
+++ b/packages/tempus/test/ForwardEuler/Tempus_ForwardEulerTest.cpp
@@ -26,6 +26,8 @@
 namespace Tempus_Test {
 
 using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
 using Teuchos::ParameterList;
 using Teuchos::sublist;
 using Teuchos::getParametersFromXmlFile;
@@ -58,8 +60,7 @@ TEUCHOS_UNIT_TEST(ForwardEuler, ParameterList)
 
   // Setup the SinCosModel
   RCP<ParameterList> scm_pl = sublist(pList, "SinCosModel", true);
-  RCP<SinCosModel<double> > model =
-    Teuchos::rcp(new SinCosModel<double> (scm_pl));
+  auto model = rcp(new SinCosModel<double> (scm_pl));
 
   RCP<ParameterList> tempusPL  = sublist(pList, "Tempus", true);
 
@@ -104,16 +105,15 @@ TEUCHOS_UNIT_TEST(ForwardEuler, ConstructingFromDefaults)
   // Setup the SinCosModel
   RCP<ParameterList> scm_pl = sublist(pList, "SinCosModel", true);
   //RCP<SinCosModel<double> > model = sineCosineModel(scm_pl);
-  RCP<SinCosModel<double> > model =
-    Teuchos::rcp(new SinCosModel<double>(scm_pl));
+  auto model = rcp(new SinCosModel<double>(scm_pl));
 
   // Setup Stepper for field solve ----------------------------
-  RCP<Tempus::StepperForwardEuler<double> > stepper =
-    Teuchos::rcp(new Tempus::StepperForwardEuler<double>(model));
+  auto stepper = rcp(new Tempus::StepperForwardEuler<double>());
+  stepper->setModel(model);
+  stepper->initialize();
 
   // Setup TimeStepControl ------------------------------------
-  RCP<Tempus::TimeStepControl<double> > timeStepControl =
-    Teuchos::rcp(new Tempus::TimeStepControl<double>());
+  auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
   ParameterList tscPL = pl->sublist("Demo Integrator")
                            .sublist("Time Step Control");
   timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
@@ -126,18 +126,15 @@ TEUCHOS_UNIT_TEST(ForwardEuler, ConstructingFromDefaults)
   // Setup initial condition SolutionState --------------------
   Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
     stepper->getModel()->getNominalValues();
-  RCP<Thyra::VectorBase<double> > icSolution =
-    Teuchos::rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
-  RCP<Tempus::SolutionState<double> > icState =
-      Teuchos::rcp(new Tempus::SolutionState<double>(icSolution));
+  auto icSolution = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
+  auto icState = rcp(new Tempus::SolutionState<double>(icSolution));
   icState->setTime    (timeStepControl->getInitTime());
   icState->setIndex   (timeStepControl->getInitIndex());
   icState->setTimeStep(0.0);
   icState->setSolutionStatus(Tempus::Status::PASSED);  // ICs are passing.
 
   // Setup SolutionHistory ------------------------------------
-  RCP<Tempus::SolutionHistory<double> > solutionHistory =
-    Teuchos::rcp(new Tempus::SolutionHistory<double>());
+  auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());
   solutionHistory->setName("Forward States");
   solutionHistory->setStorageType(Tempus::STORAGE_TYPE_STATIC);
   solutionHistory->setStorageLimit(2);
@@ -216,8 +213,7 @@ TEUCHOS_UNIT_TEST(ForwardEuler, SinCos)
     // Setup the SinCosModel
     RCP<ParameterList> scm_pl = sublist(pList, "SinCosModel", true);
     //RCP<SinCosModel<double> > model = sineCosineModel(scm_pl);
-    RCP<SinCosModel<double> > model =
-      Teuchos::rcp(new SinCosModel<double> (scm_pl));
+    auto model = rcp(new SinCosModel<double> (scm_pl));
 
     dt /= 2;
 
@@ -240,7 +236,7 @@ TEUCHOS_UNIT_TEST(ForwardEuler, SinCos)
     TEST_ASSERT(integratorStatus)
 
     // Test PhysicsState
-    Teuchos::RCP<Tempus::PhysicsState<double> > physicsState =
+    RCP<Tempus::PhysicsState<double> > physicsState =
       integrator->getSolutionHistory()->getCurrentState()->getPhysicsState();
     TEST_EQUALITY(physicsState->getName(), "Tempus::PhysicsState");
 
@@ -261,12 +257,10 @@ TEUCHOS_UNIT_TEST(ForwardEuler, SinCos)
         integrator->getSolutionHistory();
       writeSolution("Tempus_ForwardEuler_SinCos.dat", solutionHistory);
 
-      RCP<Tempus::SolutionHistory<double> > solnHistExact =
-        Teuchos::rcp(new Tempus::SolutionHistory<double>());
+      auto solnHistExact = rcp(new Tempus::SolutionHistory<double>());
       for (int i=0; i<solutionHistory->getNumStates(); i++) {
         double time_i = (*solutionHistory)[i]->getTime();
-        RCP<Tempus::SolutionState<double> > state =
-          Teuchos::rcp(new Tempus::SolutionState<double>(
+        auto state = rcp(new Tempus::SolutionState<double>(
             model->getExactSolution(time_i).get_x(),
             model->getExactSolution(time_i).get_x_dot()));
         state->setTime((*solutionHistory)[i]->getTime());
@@ -337,8 +331,7 @@ TEUCHOS_UNIT_TEST(ForwardEuler, VanDerPol)
 
     // Setup the VanDerPolModel
     RCP<ParameterList> vdpm_pl = sublist(pList, "VanDerPolModel", true);
-    RCP<VanDerPolModel<double> > model =
-      Teuchos::rcp(new VanDerPolModel<double>(vdpm_pl));
+    auto model = rcp(new VanDerPolModel<double>(vdpm_pl));
 
     // Set the step size
     dt /= 2;
@@ -432,8 +425,7 @@ TEUCHOS_UNIT_TEST(ForwardEuler, NumberTimeSteps)
 
     // Setup the VanDerPolModel
     RCP<ParameterList> vdpm_pl = sublist(pList, "VanDerPolModel", true);
-    RCP<VanDerPolModel<double> > model =
-      Teuchos::rcp(new VanDerPolModel<double>(vdpm_pl));
+    auto model = rcp(new VanDerPolModel<double>(vdpm_pl));
 
     // Setup the Integrator and reset initial time step
     RCP<ParameterList> pl = sublist(pList, "Tempus", true);

--- a/packages/tempus/test/HHTAlpha/Tempus_HHTAlphaTest.cpp
+++ b/packages/tempus/test/HHTAlpha/Tempus_HHTAlphaTest.cpp
@@ -37,6 +37,8 @@
 namespace Tempus_Test {
 
 using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
 using Teuchos::ParameterList;
 using Teuchos::sublist;
 using Teuchos::getParametersFromXmlFile;
@@ -66,8 +68,7 @@ TEUCHOS_UNIT_TEST(HHTAlpha, BallParabolic)
 
   // Setup the HarmonicOscillatorModel
   RCP<ParameterList> hom_pl = sublist(pList, "HarmonicOscillatorModel", true);
-  RCP<HarmonicOscillatorModel<double> > model =
-    Teuchos::rcp(new HarmonicOscillatorModel<double>(hom_pl));
+  auto model = rcp(new HarmonicOscillatorModel<double>(hom_pl));
 
   // Setup the Integrator and reset initial time step
   RCP<ParameterList> pl = sublist(pList, "Tempus", true);
@@ -135,16 +136,15 @@ TEUCHOS_UNIT_TEST(HHTAlpha, ConstructingFromDefaults)
 
   // Setup the HarmonicOscillatorModel
   RCP<ParameterList> hom_pl = sublist(pList, "HarmonicOscillatorModel", true);
-  RCP<HarmonicOscillatorModel<double> > model =
-    Teuchos::rcp(new HarmonicOscillatorModel<double>(hom_pl));
+  auto model = rcp(new HarmonicOscillatorModel<double>(hom_pl));
 
   // Setup Stepper for field solve ----------------------------
-  RCP<Tempus::StepperHHTAlpha<double> > stepper =
-    Teuchos::rcp(new Tempus::StepperHHTAlpha<double>(model));
+  auto stepper = rcp(new Tempus::StepperHHTAlpha<double>());
+  stepper->setModel(model);
+  stepper->initialize();
 
   // Setup TimeStepControl ------------------------------------
-  RCP<Tempus::TimeStepControl<double> > timeStepControl =
-    Teuchos::rcp(new Tempus::TimeStepControl<double>());
+  auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
   ParameterList tscPL = pl->sublist("Default Integrator")
                            .sublist("Time Step Control");
   timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
@@ -155,17 +155,12 @@ TEUCHOS_UNIT_TEST(HHTAlpha, ConstructingFromDefaults)
   timeStepControl->initialize();
 
   // Setup initial condition SolutionState --------------------
-  using Teuchos::rcp_const_cast;
   Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
     stepper->getModel()->getNominalValues();
-  RCP<Thyra::VectorBase<double> > icX =
-    rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
-  RCP<Thyra::VectorBase<double> > icXDot =
-    rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x_dot());
-  RCP<Thyra::VectorBase<double> > icXDotDot =
-    rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x_dot_dot());
-  RCP<Tempus::SolutionState<double> > icState =
-      Teuchos::rcp(new Tempus::SolutionState<double>(icX, icXDot, icXDotDot));
+  auto icX = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
+  auto icXDot = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x_dot());
+  auto icXDotDot = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x_dot_dot());
+  auto icState = rcp(new Tempus::SolutionState<double>(icX, icXDot, icXDotDot));
   icState->setTime    (timeStepControl->getInitTime());
   icState->setIndex   (timeStepControl->getInitIndex());
   icState->setTimeStep(0.0);
@@ -173,8 +168,7 @@ TEUCHOS_UNIT_TEST(HHTAlpha, ConstructingFromDefaults)
   icState->setSolutionStatus(Tempus::Status::PASSED);  // ICs are passing.
 
   // Setup SolutionHistory ------------------------------------
-  RCP<Tempus::SolutionHistory<double> > solutionHistory =
-    Teuchos::rcp(new Tempus::SolutionHistory<double>());
+  auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());
   solutionHistory->setName("Forward States");
   solutionHistory->setStorageType(Tempus::STORAGE_TYPE_STATIC);
   solutionHistory->setStorageLimit(2);
@@ -241,8 +235,7 @@ TEUCHOS_UNIT_TEST(HHTAlpha, SinCos_SecondOrder)
 
   // Setup the HarmonicOscillatorModel
   RCP<ParameterList> hom_pl = sublist(pList, "HarmonicOscillatorModel", true);
-  RCP<HarmonicOscillatorModel<double> > model =
-    Teuchos::rcp(new HarmonicOscillatorModel<double>(hom_pl));
+  auto model = rcp(new HarmonicOscillatorModel<double>(hom_pl));
 
   //Get k and m coefficients from model, needed for computing energy
   double k = hom_pl->get<double>("x coeff k");
@@ -288,12 +281,10 @@ TEUCHOS_UNIT_TEST(HHTAlpha, SinCos_SecondOrder)
         integrator->getSolutionHistory();
       writeSolution("Tempus_HHTAlpha_SinCos_SecondOrder.dat", solutionHistory);
 
-      RCP<Tempus::SolutionHistory<double> > solnHistExact =
-        Teuchos::rcp(new Tempus::SolutionHistory<double>());
+      auto solnHistExact = rcp(new Tempus::SolutionHistory<double>());
       for (int i=0; i<solutionHistory->getNumStates(); i++) {
         double time_i = (*solutionHistory)[i]->getTime();
-        RCP<Tempus::SolutionState<double> > state =
-          Teuchos::rcp(new Tempus::SolutionState<double>(
+        auto state = rcp(new Tempus::SolutionState<double>(
             model->getExactSolution(time_i).get_x(),
             model->getExactSolution(time_i).get_x_dot()));
         state->setTime((*solutionHistory)[i]->getTime());
@@ -389,8 +380,7 @@ TEUCHOS_UNIT_TEST(HHTAlpha, SinCos_FirstOrder)
 
   // Setup the HarmonicOscillatorModel
   RCP<ParameterList> hom_pl = sublist(pList, "HarmonicOscillatorModel", true);
-  RCP<HarmonicOscillatorModel<double> > model =
-    Teuchos::rcp(new HarmonicOscillatorModel<double>(hom_pl));
+  auto model = rcp(new HarmonicOscillatorModel<double>(hom_pl));
 
   //Get k and m coefficients from model, needed for computing energy
   double k = hom_pl->get<double>("x coeff k");
@@ -436,12 +426,10 @@ TEUCHOS_UNIT_TEST(HHTAlpha, SinCos_FirstOrder)
         integrator->getSolutionHistory();
       writeSolution("Tempus_HHTAlpha_SinCos_FirstOrder.dat", solutionHistory);
 
-      RCP<Tempus::SolutionHistory<double> > solnHistExact =
-        Teuchos::rcp(new Tempus::SolutionHistory<double>());
+      auto solnHistExact = rcp(new Tempus::SolutionHistory<double>());
       for (int i=0; i<solutionHistory->getNumStates(); i++) {
         double time_i = (*solutionHistory)[i]->getTime();
-        RCP<Tempus::SolutionState<double> > state =
-          Teuchos::rcp(new Tempus::SolutionState<double>(
+        auto state = rcp(new Tempus::SolutionState<double>(
             model->getExactSolution(time_i).get_x(),
             model->getExactSolution(time_i).get_x_dot()));
         state->setTime((*solutionHistory)[i]->getTime());
@@ -538,8 +526,7 @@ TEUCHOS_UNIT_TEST(HHTAlpha, SinCos_CD)
 
   // Setup the HarmonicOscillatorModel
   RCP<ParameterList> hom_pl = sublist(pList, "HarmonicOscillatorModel", true);
-  RCP<HarmonicOscillatorModel<double> > model =
-    Teuchos::rcp(new HarmonicOscillatorModel<double>(hom_pl));
+  auto model = rcp(new HarmonicOscillatorModel<double>(hom_pl));
 
   //Get k and m coefficients from model, needed for computing energy
   double k = hom_pl->get<double>("x coeff k");
@@ -585,12 +572,10 @@ TEUCHOS_UNIT_TEST(HHTAlpha, SinCos_CD)
         integrator->getSolutionHistory();
       writeSolution("Tempus_HHTAlpha_SinCos_ExplicitCD.dat", solutionHistory);
 
-      RCP<Tempus::SolutionHistory<double> > solnHistExact =
-        Teuchos::rcp(new Tempus::SolutionHistory<double>());
+      auto solnHistExact = rcp(new Tempus::SolutionHistory<double>());
       for (int i=0; i<solutionHistory->getNumStates(); i++) {
         double time_i = (*solutionHistory)[i]->getTime();
-        RCP<Tempus::SolutionState<double> > state =
-          Teuchos::rcp(new Tempus::SolutionState<double>(
+        auto state = rcp(new Tempus::SolutionState<double>(
             model->getExactSolution(time_i).get_x(),
             model->getExactSolution(time_i).get_x_dot()));
         state->setTime((*solutionHistory)[i]->getTime());

--- a/packages/tempus/test/IMEX_RK/Tempus_IMEX_RKTest.cpp
+++ b/packages/tempus/test/IMEX_RK/Tempus_IMEX_RKTest.cpp
@@ -26,6 +26,8 @@
 namespace Tempus_Test {
 
 using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
 using Teuchos::ParameterList;
 using Teuchos::sublist;
 using Teuchos::getParametersFromXmlFile;
@@ -53,26 +55,23 @@ TEUCHOS_UNIT_TEST(IMEX_RK, ConstructingFromDefaults)
 
   // Setup the explicit VanDerPol ModelEvaluator
   RCP<ParameterList> vdpmPL = sublist(pList, "VanDerPolModel", true);
-  RCP<VanDerPol_IMEX_ExplicitModel<double> > explicitModel =
-    Teuchos::rcp(new VanDerPol_IMEX_ExplicitModel<double>(vdpmPL));
+  auto explicitModel = rcp(new VanDerPol_IMEX_ExplicitModel<double>(vdpmPL));
 
   // Setup the implicit VanDerPol ModelEvaluator (reuse vdpmPL)
-  RCP<VanDerPol_IMEX_ImplicitModel<double> > implicitModel =
-    Teuchos::rcp(new VanDerPol_IMEX_ImplicitModel<double>(vdpmPL));
+  auto implicitModel = rcp(new VanDerPol_IMEX_ImplicitModel<double>(vdpmPL));
 
   // Setup the IMEX Pair ModelEvaluator
-  RCP<Tempus::WrapperModelEvaluatorPairIMEX_Basic<double> > model =
-      Teuchos::rcp(new Tempus::WrapperModelEvaluatorPairIMEX_Basic<double>(
+  auto model = rcp(new Tempus::WrapperModelEvaluatorPairIMEX_Basic<double>(
                                              explicitModel, implicitModel));
 
 
   // Setup Stepper for field solve ----------------------------
-  RCP<Tempus::StepperIMEX_RK<double> > stepper =
-    Teuchos::rcp(new Tempus::StepperIMEX_RK<double>(model));
+  auto stepper = rcp(new Tempus::StepperIMEX_RK<double>());
+  stepper->setModel(model);
+  stepper->initialize();
 
   // Setup TimeStepControl ------------------------------------
-  RCP<Tempus::TimeStepControl<double> > timeStepControl =
-    Teuchos::rcp(new Tempus::TimeStepControl<double>());
+  auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
   ParameterList tscPL = pl->sublist("Default Integrator")
                            .sublist("Time Step Control");
   timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
@@ -85,10 +84,8 @@ TEUCHOS_UNIT_TEST(IMEX_RK, ConstructingFromDefaults)
   // Setup initial condition SolutionState --------------------
   Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
     stepper->getModel()->getNominalValues();
-  RCP<Thyra::VectorBase<double> > icSolution =
-    Teuchos::rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
-  RCP<Tempus::SolutionState<double> > icState =
-      Teuchos::rcp(new Tempus::SolutionState<double>(icSolution));
+  auto icSolution = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
+  auto icState = rcp(new Tempus::SolutionState<double>(icSolution));
   icState->setTime    (timeStepControl->getInitTime());
   icState->setIndex   (timeStepControl->getInitIndex());
   icState->setTimeStep(0.0);
@@ -96,8 +93,7 @@ TEUCHOS_UNIT_TEST(IMEX_RK, ConstructingFromDefaults)
   icState->setSolutionStatus(Tempus::Status::PASSED);  // ICs are passing.
 
   // Setup SolutionHistory ------------------------------------
-  RCP<Tempus::SolutionHistory<double> > solutionHistory =
-    Teuchos::rcp(new Tempus::SolutionHistory<double>());
+  auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());
   solutionHistory->setName("Forward States");
   solutionHistory->setStorageType(Tempus::STORAGE_TYPE_STATIC);
   solutionHistory->setStorageLimit(2);
@@ -194,16 +190,13 @@ TEUCHOS_UNIT_TEST(IMEX_RK, VanDerPol)
 
       // Setup the explicit VanDerPol ModelEvaluator
       RCP<ParameterList> vdpmPL = sublist(pList, "VanDerPolModel", true);
-      RCP<VanDerPol_IMEX_ExplicitModel<double> > explicitModel =
-        Teuchos::rcp(new VanDerPol_IMEX_ExplicitModel<double>(vdpmPL));
+      auto explicitModel = rcp(new VanDerPol_IMEX_ExplicitModel<double>(vdpmPL));
 
       // Setup the implicit VanDerPol ModelEvaluator (reuse vdpmPL)
-      RCP<VanDerPol_IMEX_ImplicitModel<double> > implicitModel =
-        Teuchos::rcp(new VanDerPol_IMEX_ImplicitModel<double>(vdpmPL));
+      auto implicitModel = rcp(new VanDerPol_IMEX_ImplicitModel<double>(vdpmPL));
 
       // Setup the IMEX Pair ModelEvaluator
-      RCP<Tempus::WrapperModelEvaluatorPairIMEX_Basic<double> > model =
-          Teuchos::rcp(new Tempus::WrapperModelEvaluatorPairIMEX_Basic<double>(
+      auto model = rcp(new Tempus::WrapperModelEvaluatorPairIMEX_Basic<double>(
                                                  explicitModel, implicitModel));
 
       // Set the Stepper

--- a/packages/tempus/test/IMEX_RK_Partitioned/Tempus_IMEX_RK_PartitionedTest.cpp
+++ b/packages/tempus/test/IMEX_RK_Partitioned/Tempus_IMEX_RK_PartitionedTest.cpp
@@ -27,6 +27,8 @@
 namespace Tempus_Test {
 
 using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
 using Teuchos::ParameterList;
 using Teuchos::sublist;
 using Teuchos::getParametersFromXmlFile;
@@ -55,31 +57,26 @@ TEUCHOS_UNIT_TEST(IMEX_RK_Partitioned, ConstructingFromDefaults)
   // Setup the explicit VanDerPol ModelEvaluator
   RCP<ParameterList> vdpmPL = sublist(pList, "VanDerPolModel", true);
   const bool useProductVector = true;
-  RCP<VanDerPol_IMEX_ExplicitModel<double> > explicitModel =
-    Teuchos::rcp(new VanDerPol_IMEX_ExplicitModel<double>(vdpmPL,
-      useProductVector));
+  auto explicitModel = rcp(new VanDerPol_IMEX_ExplicitModel<double>(vdpmPL, useProductVector));
 
   // Setup the implicit VanDerPol ModelEvaluator (reuse vdpmPL)
-  RCP<VanDerPol_IMEXPart_ImplicitModel<double> > implicitModel =
-    Teuchos::rcp(new VanDerPol_IMEXPart_ImplicitModel<double>(vdpmPL));
+  auto implicitModel = rcp(new VanDerPol_IMEXPart_ImplicitModel<double>(vdpmPL));
 
   // Setup the IMEX Pair ModelEvaluator
   const int numExplicitBlocks = 1;
   const int parameterIndex = 4;
-  RCP<Tempus::WrapperModelEvaluatorPairPartIMEX_Basic<double> > model =
-      Teuchos::rcp(
-        new Tempus::WrapperModelEvaluatorPairPartIMEX_Basic<double>(
+  auto model = rcp(new Tempus::WrapperModelEvaluatorPairPartIMEX_Basic<double>(
                          explicitModel, implicitModel,
                          numExplicitBlocks, parameterIndex));
 
 
   // Setup Stepper for field solve ----------------------------
-  RCP<Tempus::StepperIMEX_RK_Partition<double> > stepper =
-    Teuchos::rcp(new Tempus::StepperIMEX_RK_Partition<double>(model));
+  auto stepper = rcp(new Tempus::StepperIMEX_RK_Partition<double>());
+  stepper->setModel(model);
+  stepper->initialize();
 
   // Setup TimeStepControl ------------------------------------
-  RCP<Tempus::TimeStepControl<double> > timeStepControl =
-    Teuchos::rcp(new Tempus::TimeStepControl<double>());
+  auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
   ParameterList tscPL = pl->sublist("Default Integrator")
                            .sublist("Time Step Control");
   timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
@@ -92,10 +89,8 @@ TEUCHOS_UNIT_TEST(IMEX_RK_Partitioned, ConstructingFromDefaults)
   // Setup initial condition SolutionState --------------------
   Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
     stepper->getModel()->getNominalValues();
-  RCP<Thyra::VectorBase<double> > icSolution =
-    Teuchos::rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
-  RCP<Tempus::SolutionState<double> > icState =
-      Teuchos::rcp(new Tempus::SolutionState<double>(icSolution));
+  auto icSolution = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
+  auto icState = rcp(new Tempus::SolutionState<double>(icSolution));
   icState->setTime    (timeStepControl->getInitTime());
   icState->setIndex   (timeStepControl->getInitIndex());
   icState->setTimeStep(0.0);
@@ -103,8 +98,7 @@ TEUCHOS_UNIT_TEST(IMEX_RK_Partitioned, ConstructingFromDefaults)
   icState->setSolutionStatus(Tempus::Status::PASSED);  // ICs are passing.
 
   // Setup SolutionHistory ------------------------------------
-  RCP<Tempus::SolutionHistory<double> > solutionHistory =
-    Teuchos::rcp(new Tempus::SolutionHistory<double>());
+  auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());
   solutionHistory->setName("Forward States");
   solutionHistory->setStorageType(Tempus::STORAGE_TYPE_STATIC);
   solutionHistory->setStorageLimit(2);
@@ -202,20 +196,18 @@ TEUCHOS_UNIT_TEST(IMEX_RK_Partitioned, VanDerPol)
       // Setup the explicit VanDerPol ModelEvaluator
       RCP<ParameterList> vdpmPL = sublist(pList, "VanDerPolModel", true);
       const bool useProductVector = true;
-      RCP<VanDerPol_IMEX_ExplicitModel<double> > explicitModel =
-        Teuchos::rcp(new VanDerPol_IMEX_ExplicitModel<double>(vdpmPL,
-          useProductVector));
+      auto explicitModel =
+        rcp(new VanDerPol_IMEX_ExplicitModel<double>(vdpmPL, useProductVector));
 
       // Setup the implicit VanDerPol ModelEvaluator (reuse vdpmPL)
-      RCP<VanDerPol_IMEXPart_ImplicitModel<double> > implicitModel =
-        Teuchos::rcp(new VanDerPol_IMEXPart_ImplicitModel<double>(vdpmPL));
+      auto implicitModel =
+        rcp(new VanDerPol_IMEXPart_ImplicitModel<double>(vdpmPL));
 
       // Setup the IMEX Pair ModelEvaluator
       const int numExplicitBlocks = 1;
       const int parameterIndex = 4;
-      RCP<Tempus::WrapperModelEvaluatorPairPartIMEX_Basic<double> > model =
-          Teuchos::rcp(
-            new Tempus::WrapperModelEvaluatorPairPartIMEX_Basic<double>(
+      auto model =
+        rcp(new Tempus::WrapperModelEvaluatorPairPartIMEX_Basic<double>(
                              explicitModel, implicitModel,
                              numExplicitBlocks, parameterIndex));
 

--- a/packages/tempus/test/Leapfrog/Tempus_LeapfrogTest.cpp
+++ b/packages/tempus/test/Leapfrog/Tempus_LeapfrogTest.cpp
@@ -34,6 +34,8 @@
 namespace Tempus_Test {
 
 using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
 using Teuchos::ParameterList;
 using Teuchos::sublist;
 using Teuchos::getParametersFromXmlFile;
@@ -62,16 +64,15 @@ TEUCHOS_UNIT_TEST(Leapfrog, ConstructingFromDefaults)
 
   // Setup the HarmonicOscillatorModel
   RCP<ParameterList> hom_pl = sublist(pList, "HarmonicOscillatorModel", true);
-  RCP<HarmonicOscillatorModel<double> > model =
-    Teuchos::rcp(new HarmonicOscillatorModel<double>(hom_pl));
+  auto model = rcp(new HarmonicOscillatorModel<double>(hom_pl));
 
   // Setup Stepper for field solve ----------------------------
-  RCP<Tempus::StepperLeapfrog<double> > stepper =
-    Teuchos::rcp(new Tempus::StepperLeapfrog<double>(model));
+  auto stepper = rcp(new Tempus::StepperLeapfrog<double>());
+  stepper->setModel(model);
+  stepper->initialize();
 
   // Setup TimeStepControl ------------------------------------
-  RCP<Tempus::TimeStepControl<double> > timeStepControl =
-    Teuchos::rcp(new Tempus::TimeStepControl<double>());
+  auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
   ParameterList tscPL = pl->sublist("Default Integrator")
                            .sublist("Time Step Control");
   timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
@@ -82,17 +83,12 @@ TEUCHOS_UNIT_TEST(Leapfrog, ConstructingFromDefaults)
   timeStepControl->initialize();
 
   // Setup initial condition SolutionState --------------------
-  using Teuchos::rcp_const_cast;
   Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
     stepper->getModel()->getNominalValues();
-  RCP<Thyra::VectorBase<double> > icX =
-    rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
-  RCP<Thyra::VectorBase<double> > icXDot =
-    rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x_dot());
-  RCP<Thyra::VectorBase<double> > icXDotDot =
-    rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x_dot_dot());
-  RCP<Tempus::SolutionState<double> > icState =
-      Teuchos::rcp(new Tempus::SolutionState<double>(icX, icXDot, icXDotDot));
+  auto icX = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
+  auto icXDot = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x_dot());
+  auto icXDotDot = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x_dot_dot());
+  auto icState = rcp(new Tempus::SolutionState<double>(icX, icXDot, icXDotDot));
   icState->setTime    (timeStepControl->getInitTime());
   icState->setIndex   (timeStepControl->getInitIndex());
   icState->setTimeStep(0.0);
@@ -100,8 +96,7 @@ TEUCHOS_UNIT_TEST(Leapfrog, ConstructingFromDefaults)
   icState->setSolutionStatus(Tempus::Status::PASSED);  // ICs are passing.
 
   // Setup SolutionHistory ------------------------------------
-  RCP<Tempus::SolutionHistory<double> > solutionHistory =
-    Teuchos::rcp(new Tempus::SolutionHistory<double>());
+  auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());
   solutionHistory->setName("Forward States");
   solutionHistory->setStorageType(Tempus::STORAGE_TYPE_STATIC);
   solutionHistory->setStorageLimit(2);
@@ -169,8 +164,7 @@ TEUCHOS_UNIT_TEST(Leapfrog, SinCos)
 
   // Setup the HarmonicOscillatorModel
   RCP<ParameterList> hom_pl = sublist(pList, "HarmonicOscillatorModel", true);
-  RCP<HarmonicOscillatorModel<double> > model =
-    Teuchos::rcp(new HarmonicOscillatorModel<double>(hom_pl));
+  auto model = rcp(new HarmonicOscillatorModel<double>(hom_pl));
 
 
   // Setup the Integrator and reset initial time step
@@ -207,12 +201,10 @@ TEUCHOS_UNIT_TEST(Leapfrog, SinCos)
         integrator->getSolutionHistory();
       writeSolution("Tempus_Leapfrog_SinCos.dat", solutionHistory);
 
-      RCP<Tempus::SolutionHistory<double> > solnHistExact =
-        Teuchos::rcp(new Tempus::SolutionHistory<double>());
+      auto solnHistExact = rcp(new Tempus::SolutionHistory<double>());
       for (int i=0; i<solutionHistory->getNumStates(); i++) {
         double time_i = (*solutionHistory)[i]->getTime();
-        RCP<Tempus::SolutionState<double> > state =
-          Teuchos::rcp(new Tempus::SolutionState<double>(
+        auto state = rcp(new Tempus::SolutionState<double>(
             model->getExactSolution(time_i).get_x(),
             model->getExactSolution(time_i).get_x_dot()));
         state->setTime((*solutionHistory)[i]->getTime());

--- a/packages/tempus/test/OperatorSplit/Tempus_OperatorSplitTest.cpp
+++ b/packages/tempus/test/OperatorSplit/Tempus_OperatorSplitTest.cpp
@@ -27,6 +27,8 @@
 namespace Tempus_Test {
 
 using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
 using Teuchos::ParameterList;
 using Teuchos::sublist;
 using Teuchos::getParametersFromXmlFile;
@@ -54,22 +56,17 @@ TEUCHOS_UNIT_TEST(OperatorSplit, ConstructingFromDefaults)
 
   // Setup the explicit VanDerPol ModelEvaluator
   RCP<ParameterList> vdpmPL = sublist(pList, "VanDerPolModel", true);
-  RCP<VanDerPol_IMEX_ExplicitModel<double> > explicitModel =
-    Teuchos::rcp(new VanDerPol_IMEX_ExplicitModel<double>(vdpmPL));
+  auto explicitModel = rcp(new VanDerPol_IMEX_ExplicitModel<double>(vdpmPL));
 
   // Setup the implicit VanDerPol ModelEvaluator (reuse vdpmPL)
-  RCP<VanDerPol_IMEX_ImplicitModel<double> > implicitModel =
-    Teuchos::rcp(new VanDerPol_IMEX_ImplicitModel<double>(vdpmPL));
+  auto implicitModel = rcp(new VanDerPol_IMEX_ImplicitModel<double>(vdpmPL));
 
 
   // Setup Stepper for field solve ----------------------------
-  RCP<Tempus::StepperOperatorSplit<double> > stepper =
-    Teuchos::rcp(new Tempus::StepperOperatorSplit<double>());
+  auto stepper = rcp(new Tempus::StepperOperatorSplit<double>());
 
-  RCP<Tempus::StepperForwardEuler<double> > subStepper1 =
-    Teuchos::rcp(new Tempus::StepperForwardEuler<double>(explicitModel));
-  RCP<Tempus::StepperBackwardEuler<double> > subStepper2 =
-    Teuchos::rcp(new Tempus::StepperBackwardEuler<double>(implicitModel));
+  auto subStepper1 = rcp(new Tempus::StepperForwardEuler<double>(explicitModel));
+  auto subStepper2 = rcp(new Tempus::StepperBackwardEuler<double>(implicitModel));
 
   stepper->addStepper(subStepper1);
   stepper->addStepper(subStepper2);
@@ -77,8 +74,7 @@ TEUCHOS_UNIT_TEST(OperatorSplit, ConstructingFromDefaults)
 
 
   // Setup TimeStepControl ------------------------------------
-  RCP<Tempus::TimeStepControl<double> > timeStepControl =
-    Teuchos::rcp(new Tempus::TimeStepControl<double>());
+  auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
   ParameterList tscPL = pl->sublist("Demo Integrator")
                            .sublist("Time Step Control");
   timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
@@ -91,10 +87,8 @@ TEUCHOS_UNIT_TEST(OperatorSplit, ConstructingFromDefaults)
   // Setup initial condition SolutionState --------------------
   Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
     stepper->getModel()->getNominalValues();
-  RCP<Thyra::VectorBase<double> > icSolution =
-    Teuchos::rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
-  RCP<Tempus::SolutionState<double> > icState =
-      Teuchos::rcp(new Tempus::SolutionState<double>(icSolution));
+  auto icSolution = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
+  auto icState = rcp(new Tempus::SolutionState<double>(icSolution));
   icState->setTime    (timeStepControl->getInitTime());
   icState->setIndex   (timeStepControl->getInitIndex());
   icState->setTimeStep(0.0);
@@ -102,8 +96,7 @@ TEUCHOS_UNIT_TEST(OperatorSplit, ConstructingFromDefaults)
   icState->setSolutionStatus(Tempus::Status::PASSED);  // ICs are passing.
 
   // Setup SolutionHistory ------------------------------------
-  RCP<Tempus::SolutionHistory<double> > solutionHistory =
-    Teuchos::rcp(new Tempus::SolutionHistory<double>());
+  auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());
   solutionHistory->setName("Forward States");
   solutionHistory->setStorageType(Tempus::STORAGE_TYPE_STATIC);
   solutionHistory->setStorageLimit(2);
@@ -167,15 +160,13 @@ TEUCHOS_UNIT_TEST(OperatorSplit, VanDerPol)
 
     // Setup the explicit VanDerPol ModelEvaluator
     RCP<ParameterList> vdpmPL = sublist(pList, "VanDerPolModel", true);
-    RCP<VanDerPol_IMEX_ExplicitModel<double> > explicitModel =
-      Teuchos::rcp(new VanDerPol_IMEX_ExplicitModel<double>(vdpmPL));
+    auto explicitModel = rcp(new VanDerPol_IMEX_ExplicitModel<double>(vdpmPL));
 
     // Setup the implicit VanDerPol ModelEvaluator (reuse vdpmPL)
-    RCP<VanDerPol_IMEX_ImplicitModel<double> > implicitModel =
-      Teuchos::rcp(new VanDerPol_IMEX_ImplicitModel<double>(vdpmPL));
+    auto implicitModel = rcp(new VanDerPol_IMEX_ImplicitModel<double>(vdpmPL));
 
     // Setup vector of models
-    std::vector<Teuchos::RCP<const Thyra::ModelEvaluator<double> > > models;
+    std::vector<RCP<const Thyra::ModelEvaluator<double> > > models;
     models.push_back(explicitModel);
     models.push_back(implicitModel);
 

--- a/packages/tempus/test/Trapezoidal/Tempus_TrapezoidalTest.cpp
+++ b/packages/tempus/test/Trapezoidal/Tempus_TrapezoidalTest.cpp
@@ -36,6 +36,8 @@
 namespace Tempus_Test {
 
 using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
 using Teuchos::ParameterList;
 using Teuchos::sublist;
 using Teuchos::getParametersFromXmlFile;
@@ -62,8 +64,7 @@ TEUCHOS_UNIT_TEST(Trapezoidal, ParameterList)
 
   // Setup the SinCosModel
   RCP<ParameterList> scm_pl = sublist(pList, "SinCosModel", true);
-  RCP<SinCosModel<double> > model =
-    Teuchos::rcp(new SinCosModel<double> (scm_pl));
+  auto model = rcp(new SinCosModel<double> (scm_pl));
 
   RCP<ParameterList> tempusPL  = sublist(pList, "Tempus", true);
 
@@ -108,24 +109,15 @@ TEUCHOS_UNIT_TEST(Trapezoidal, ConstructingFromDefaults)
   // Setup the SinCosModel
   RCP<ParameterList> scm_pl = sublist(pList, "SinCosModel", true);
   //RCP<SinCosModel<double> > model = sineCosineModel(scm_pl);
-  RCP<SinCosModel<double> > model =
-    Teuchos::rcp(new SinCosModel<double>(scm_pl));
+  auto model = rcp(new SinCosModel<double>(scm_pl));
 
   // Setup Stepper for field solve ----------------------------
-  RCP<Tempus::StepperTrapezoidal<double> > stepper =
-    Teuchos::rcp(new Tempus::StepperTrapezoidal<double>(model));
-  //{
-  //  // Setup a linear NOX solve
-  //  RCP<ParameterList> sPL = stepper->getNonconstParameterList();
-  //  std::string solverName = sPL->get<std::string>("Solver Name");
-  //  RCP<ParameterList> solverPL = Teuchos::sublist(sPL, solverName, true);
-  //  stepper->setSolver(solverPL);
-  //  stepper->initialize();
-  //}
+  auto stepper = rcp(new Tempus::StepperTrapezoidal<double>());
+  stepper->setModel(model);
+  stepper->initialize();
 
   // Setup TimeStepControl ------------------------------------
-  RCP<Tempus::TimeStepControl<double> > timeStepControl =
-    Teuchos::rcp(new Tempus::TimeStepControl<double>());
+  auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
   ParameterList tscPL = pl->sublist("Default Integrator")
                            .sublist("Time Step Control");
   timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
@@ -138,12 +130,10 @@ TEUCHOS_UNIT_TEST(Trapezoidal, ConstructingFromDefaults)
   // Setup initial condition SolutionState --------------------
   Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
     stepper->getModel()->getNominalValues();
-  RCP<Thyra::VectorBase<double> > icSoln =
-    Teuchos::rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
-  RCP<Thyra::VectorBase<double> > icSolnDot =
-    Teuchos::rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x_dot());
-  RCP<Tempus::SolutionState<double> > icState =
-      Teuchos::rcp(new Tempus::SolutionState<double>(icSoln,icSolnDot));
+  auto icSoln = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
+  auto icSolnDot =
+    rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x_dot());
+  auto icState = rcp(new Tempus::SolutionState<double>(icSoln,icSolnDot));
   icState->setTime    (timeStepControl->getInitTime());
   icState->setIndex   (timeStepControl->getInitIndex());
   icState->setTimeStep(0.0);
@@ -151,8 +141,7 @@ TEUCHOS_UNIT_TEST(Trapezoidal, ConstructingFromDefaults)
   icState->setSolutionStatus(Tempus::Status::PASSED);  // ICs are passing.
 
   // Setup SolutionHistory ------------------------------------
-  RCP<Tempus::SolutionHistory<double> > solutionHistory =
-    Teuchos::rcp(new Tempus::SolutionHistory<double>());
+  auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());
   solutionHistory->setName("Forward States");
   solutionHistory->setStorageType(Tempus::STORAGE_TYPE_STATIC);
   solutionHistory->setStorageLimit(2);
@@ -231,8 +220,7 @@ TEUCHOS_UNIT_TEST(Trapezoidal, SinCos)
     // Setup the SinCosModel
     RCP<ParameterList> scm_pl = sublist(pList, "SinCosModel", true);
     //RCP<SinCosModel<double> > model = sineCosineModel(scm_pl);
-    RCP<SinCosModel<double> > model =
-      Teuchos::rcp(new SinCosModel<double>(scm_pl));
+    auto model = rcp(new SinCosModel<double>(scm_pl));
 
     dt /= 2;
 
@@ -270,12 +258,10 @@ TEUCHOS_UNIT_TEST(Trapezoidal, SinCos)
         integrator->getSolutionHistory();
       writeSolution("Tempus_Trapezoidal_SinCos.dat", solutionHistory);
 
-      RCP<Tempus::SolutionHistory<double> > solnHistExact =
-        Teuchos::rcp(new Tempus::SolutionHistory<double>());
+      auto solnHistExact = rcp(new Tempus::SolutionHistory<double>());
       for (int i=0; i<solutionHistory->getNumStates(); i++) {
         double time_i = (*solutionHistory)[i]->getTime();
-        RCP<Tempus::SolutionState<double> > state =
-          Teuchos::rcp(new Tempus::SolutionState<double>(
+        auto state = rcp(new Tempus::SolutionState<double>(
             model->getExactSolution(time_i).get_x(),
             model->getExactSolution(time_i).get_x_dot()));
         state->setTime((*solutionHistory)[i]->getTime());
@@ -345,8 +331,7 @@ TEUCHOS_UNIT_TEST(Trapezoidal, VanDerPol)
 
     // Setup the VanDerPolModel
     RCP<ParameterList> vdpm_pl = sublist(pList, "VanDerPolModel", true);
-    RCP<VanDerPolModel<double> > model =
-      Teuchos::rcp(new VanDerPolModel<double>(vdpm_pl));
+    auto model = rcp(new VanDerPolModel<double>(vdpm_pl));
 
     // Set the step size
     dt /= 2;


### PR DESCRIPTION

@trilinos/tempus 

## Description
<!--- Please describe your changes in detail. -->
Getting alpha = d(xDot)/dx and beta = d(x)/dx from Steppers
to allow applications access to these through accessors.
Additionally application wanted to construct Steppers without
a ModelEvaluator.

 * Added accessors to alpha and beta from all implicit Steppers.
 * Added default constructors to all the Steppers, so we can
   construct them without a ModelEvaluator.
 * StepperFactory->createStepper() now has ModelEvaluator as
   last argument so by default it is Teuchos::null.
   - Tested default construction for all Steppers.
     . Passed all Tempus, Piro and ROL tests.

Miscellaneous:
 * Some cleanup of tests.

 #4632

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [x] These changes break backwards compatibility.
