### PR TITLE
Remove build cee-rhel6_gnu-4.9.3_openmpi-1.10.2_serial_shared_opt from nighlty testing (TRIL-243)

### DIFF
--- a/cmake/std/atdm/cee-rhel6/all_supported_builds.sh
+++ b/cmake/std/atdm/cee-rhel6/all_supported_builds.sh
@@ -4,7 +4,6 @@ export ATDM_CONFIG_CTEST_S_BUILD_NAME_PREFIX=Trilinos-atdm-
 
 export ATDM_CONFIG_ALL_SUPPORTED_BUILDS=(
   cee-rhel6_clang-5.0.1_openmpi-1.10.2_serial_static_opt   # SPARC CI build
-  cee-rhel6_gnu-4.9.3_openmpi-1.10.2_serial_shared_opt     # Old SPARC build
   cee-rhel6_gnu-7.2.0_openmpi-1.10.2_serial_shared_opt     # SPARC CI build
   cee-rhel6_intel-17.0.1_intelmpi-5.1.2_serial_static_opt  # SPARC Nightly Build
   cee-rhel6_intel-18.0.2_mpich2-3.2_openmp_static_opt      # SPARC CI build


### PR DESCRIPTION
SPARC does not need this build and since the gnu-7.2.0 build's test suite was
made to run fast (see [TRIL-269](https://sems-atlassian-son.sandia.gov/jira/browse/TRIL-269)), we don't need to compare against the old
gnu-4.9.3 build anymore (see [TRIL-243](https://sems-atlassian-son.sandia.gov/jira/browse/TRIL-243))

Note that I did not remove the env for the GNU 4.9.3 build in case someone
wants to test it locally.

NOTE: The automated builds that submit to CDash will automatically get updated with this one change because a local cron job with a script the reads this file will get called.

