### PR TITLE
move from 1.8G/core to 2.1

### DIFF
--- a/cmake/std/PullRequestLinuxDriver-Test.sh
+++ b/cmake/std/PullRequestLinuxDriver-Test.sh
@@ -349,11 +349,11 @@ weight=${JENKINS_JOB_WEIGHT:-29}
 n_cpu=$(lscpu | grep "^CPU(s):" | cut -d" " -f17)
 n_K=$(cat /proc/meminfo | grep MemTotal | cut -d" " -f8)
 let n_G=$n_K/1024000
-# this is aimed at keeping approximately 1.8G per core so we don't bottleneck
+# this is aimed at keeping approximately 2.1G per core so we don't bottleneck
 ## weight - the next bit works because the shell is only doing integer arithmetic
 let n_jobs=${n_cpu}/${weight}
 # using bc to get floating point input and integer output
-parallel_level=$(echo "$n_G/( 1.8*$n_jobs )" | bc )
+parallel_level=$(echo "$n_G/( 2.1*$n_jobs )" | bc )
 
 if [ ${parallel_level} -gt ${weight} ]; then
     parallel_level=${weight}


### PR DESCRIPTION
This is in response to several MueLu build failures
on full builds. Since this likely will relieve some
swapping it should help time on full builds or be a
wash. Might make small/medium builds a bit slower.

@trilinos/framework 

We will need to monitor to see if this is enough and let the MueLu team know whats going on.