### PR TITLE
Piro tempus solver albany fix

### DIFF
--- a/packages/piro/src/Piro_TempusSolver_Def.hpp
+++ b/packages/piro/src/Piro_TempusSolver_Def.hpp
@@ -944,9 +944,9 @@ setInitialState(Scalar t0,
       Teuchos::RCP<Thyra::VectorBase<Scalar> > xdot0,
       Teuchos::RCP<Thyra::VectorBase<Scalar> > xdotdot0) 
 {
-   fwdStateIntegrator->setInitialState(t0, x0, xdot0, xdotdot0); 
+   fwdStateIntegrator->initializeSolutionHistory(t0, x0, xdot0, xdotdot0); 
    //Reset observer.  This is necessary for correct observation of solution
-   //since setInitialState modifies the solutionHistory object.
+   //since initializeSolutionHistory modifies the solutionHistory object.
    setObserver(); 
  
 }


### PR DESCRIPTION
    Piro: fixing Albany compilation error by replacing setInitialState()
    with initializeSolutionHistory() per recent changes in Tempus.
