### PR TITLE
Belos:  Remove Unused Parameter Warnings

### DIFF
--- a/packages/belos/src/BelosGmresPolyOp.hpp
+++ b/packages/belos/src/BelosGmresPolyOp.hpp
@@ -274,7 +274,7 @@ namespace Belos {
     /*! \brief This routine casts the MultiVec to GmresPolyMv to retrieve the MV.  Then the above
         apply method is called.
     */
-    void Apply ( const MultiVec<ScalarType>& x, MultiVec<ScalarType>& y, ETrans trans=NOTRANS ) const 
+    void Apply ( const MultiVec<ScalarType>& x, MultiVec<ScalarType>& y, ETrans /* trans */=NOTRANS ) const
     {
       const GmresPolyMv<ScalarType,MV>& x_in = dynamic_cast<const GmresPolyMv<ScalarType,MV>&>(x);
       GmresPolyMv<ScalarType,MV>& y_in = dynamic_cast<GmresPolyMv<ScalarType,MV>&>(y);

--- a/packages/belos/src/BelosPseudoBlockStochasticCGIter.hpp
+++ b/packages/belos/src/BelosPseudoBlockStochasticCGIter.hpp
@@ -193,7 +193,7 @@ namespace Belos {
     
     //! Get the norms of the residuals native to the solver.
     //! \return A std::vector of length blockSize containing the native residuals.
-    Teuchos::RCP<const MV> getNativeResiduals( std::vector<MagnitudeType> *norms ) const { return R_; }
+    Teuchos::RCP<const MV> getNativeResiduals( std::vector<MagnitudeType> * /* norms */ ) const { return R_; }
     
     //! Get the current update to the linear system.
     /*! \note This method returns a null pointer because the linear problem is current.


### PR DESCRIPTION
@trilinos/belos 

## Description
Comment out unused parameters in function definitions to avoid `-Wunused-parameter` warnings.

## Motivation and Context
Clean build.