### PR TITLE
Sacado:  Remove Unused Parameter Warnings

### DIFF
--- a/packages/sacado/src/KokkosExp_View_Fad.hpp
+++ b/packages/sacado/src/KokkosExp_View_Fad.hpp
@@ -56,7 +56,7 @@ struct is_view_fad_contiguous { static const bool value = false; };
 template <typename view_type>
 KOKKOS_INLINE_FUNCTION
 constexpr unsigned
-dimension_scalar(const view_type& view) {
+dimension_scalar(const view_type& /* view */) {
   return 0;
 }
 

--- a/packages/sacado/src/Kokkos_DynRankView_Fad.hpp
+++ b/packages/sacado/src/Kokkos_DynRankView_Fad.hpp
@@ -167,7 +167,7 @@ struct DynRankDimTraits<Kokkos::Impl::ViewSpecializeSacadoFad> {
   // Compute the rank of the view from the nonzero layout arguments and possible hidden dim
   template <typename Layout, typename ... P>
   KOKKOS_INLINE_FUNCTION
-  static size_t computeRank( const ViewCtorProp<P...>& prop, const Layout& layout )
+  static size_t computeRank( const ViewCtorProp<P...>& /* prop */, const Layout& layout )
   {
     size_t rank = computeRank( layout.dimension[0]
                       , layout.dimension[1]

--- a/packages/sacado/src/Sacado_Fad_ViewStorage.hpp
+++ b/packages/sacado/src/Sacado_Fad_ViewStorage.hpp
@@ -145,7 +145,7 @@ namespace Sacado {
        * we zero out components when it is resized to zero above.
        */
       KOKKOS_INLINE_FUNCTION
-      void resizeAndZero(int sz) {}
+      void resizeAndZero(int /* sz */) {}
 
       //! Expand derivative array to size sz
       KOKKOS_INLINE_FUNCTION

--- a/packages/sacado/src/mpl/Sacado_mpl_for_each.hpp
+++ b/packages/sacado/src/mpl/Sacado_mpl_for_each.hpp
@@ -76,7 +76,7 @@ namespace Sacado {
     template <class Seq, class Iter1>
     struct for_each_no_kokkos<Seq, Iter1, Iter1> {
       template <typename Op>
-      for_each_no_kokkos(const Op& op) {}
+      for_each_no_kokkos(const Op& /* op */) {}
     };
 
   }


### PR DESCRIPTION
@trilinos/sacado 

## Description
Comment out unused parameters in function definitions to avoid `-Wunused-parameter` warnings.

## Motivation and Context
Clean build.