### PR TITLE
Tpetra:  Remove Unused Parameter Warnings

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_unpackCrsGraphAndCombine_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_unpackCrsGraphAndCombine_def.hpp
@@ -961,11 +961,11 @@ void
 unpackCrsGraphAndCombineNew(
     CrsGraph<LO, GO, Node>& /* sourceGraph */,
     const Kokkos::DualView<const typename CrsGraph<LO,GO,Node>::packet_type*,
-                           typename CrsGraph<LO,GO,Node>::buffer_device_type>& imports,
+                           typename CrsGraph<LO,GO,Node>::buffer_device_type>& /* imports */,
     const Kokkos::DualView<const size_t*,
-                           typename CrsGraph<LO,GO,Node>::buffer_device_type>& numPacketsPerLID,
+                           typename CrsGraph<LO,GO,Node>::buffer_device_type>& /* numPacketsPerLID */,
     const Kokkos::DualView<const LO*,
-                           typename CrsGraph<LO,GO,Node>::buffer_device_type>& importLIDs,
+                           typename CrsGraph<LO,GO,Node>::buffer_device_type>& /* importLIDs */,
     const size_t /* constantNumPackets */,
     Distributor& /* distor */,
     const CombineMode /* combineMode */)

--- a/packages/tpetra/core/src/Tpetra_FECrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_FECrsGraph_decl.hpp
@@ -307,7 +307,7 @@ namespace Tpetra {
     void
     fillComplete (const Teuchos::RCP<const map_type>& domainMap,
                   const Teuchos::RCP<const map_type>& rangeMap,
-                  const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null) {
+                  const Teuchos::RCP<Teuchos::ParameterList>& /* params */ = Teuchos::null) {
       domainMap_ = domainMap;
       rangeMap_ = rangeMap;
       endFill();
@@ -341,7 +341,7 @@ namespace Tpetra {
     ///   method's behavior.  See documentation of the three-argument
     ///   version of fillComplete (above) for valid parameters.
     void
-    fillComplete (const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null) {endFill();}
+    fillComplete (const Teuchos::RCP<Teuchos::ParameterList>& /* params */ = Teuchos::null) {endFill();}
 
 
   private:

--- a/packages/tpetra/core/src/Tpetra_FECrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_FECrsGraph_def.hpp
@@ -235,7 +235,7 @@ void FECrsGraph<LocalOrdinal, GlobalOrdinal, Node>::doOwnedPlusSharedToOwned(con
 
 
 template<class LocalOrdinal, class GlobalOrdinal, class Node>
-void FECrsGraph<LocalOrdinal, GlobalOrdinal, Node>::doOwnedToOwnedPlusShared(const CombineMode CM) {
+void FECrsGraph<LocalOrdinal, GlobalOrdinal, Node>::doOwnedToOwnedPlusShared(const CombineMode /* CM */) {
   // This should be a no-op for all of our purposes
 }//end doLocalToOverlap
 

--- a/packages/tpetra/core/src/Tpetra_FECrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_FECrsMatrix_def.hpp
@@ -99,7 +99,7 @@ void FECrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::doOwnedPlusSharedTo
 
 
 template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-void FECrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::doOwnedToOwnedPlusShared(const CombineMode CM) {
+void FECrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::doOwnedToOwnedPlusShared(const CombineMode /* CM */) {
   // This should be a no-op for all of our purposes
 }//end doLocalToOverlap
 

--- a/packages/tpetra/core/src/Tpetra_Import_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Import_def.hpp
@@ -101,7 +101,7 @@ namespace Tpetra {
   void
   Import<LocalOrdinal,GlobalOrdinal,Node>::
   init (const Teuchos::RCP<const map_type>& source,
-        const Teuchos::RCP<const map_type>& target,
+        const Teuchos::RCP<const map_type>& /* target */,
         bool useRemotePIDs,
         Teuchos::Array<int> & remotePIDs,
         const Teuchos::RCP<Teuchos::ParameterList>& plist)
@@ -133,6 +133,8 @@ namespace Tpetra {
     if(!plist.is_null())
       label = plist->get("Timer Label",label);
     std::string prefix = std::string("Tpetra ")+ label + std::string(":iport_ctor:preIData: ");
+#else
+    (void)plist;
 #endif
     {
 #ifdef HAVE_TPETRA_MMM_TIMINGS

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -1126,7 +1126,7 @@ namespace Tpetra {
   packAndPrepareNew (const SrcDistObject& sourceObj,
                      const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& exportLIDs,
                      Kokkos::DualView<impl_scalar_type*, buffer_device_type>& exports,
-                     Kokkos::DualView<size_t*, buffer_device_type> numExportPacketsPerLID,
+                     Kokkos::DualView<size_t*, buffer_device_type> /* numExportPacketsPerLID */,
                      size_t& constantNumPackets,
                      Distributor & /* distor */ )
   {


### PR DESCRIPTION
@trilinos/tpetra 

## Description
Comment out unused parameters in function definitions to avoid
`-Wunused-parameter` warnings.

## Motivation and Context
Clean build.