### PR TITLE
NOX:  Remove Unused Parameter Warnings

### DIFF
--- a/packages/nox/src/NOX_Observer.hpp
+++ b/packages/nox/src/NOX_Observer.hpp
@@ -100,16 +100,16 @@ public:
   virtual ~Observer() {}
 
   //! User defined method that will be executed at the start of a call to NOX::Solver::Generic::step().
-  virtual void runPreIterate(const NOX::Solver::Generic& solver) {}
+  virtual void runPreIterate(const NOX::Solver::Generic& /* solver */) {}
 
   //! User defined method that will be executed at the end of a call to NOX::Solver::Generic::step().
-  virtual void runPostIterate(const NOX::Solver::Generic& solver) {}
+  virtual void runPostIterate(const NOX::Solver::Generic& /* solver */) {}
 
   //! User defined method that will be executed at the start of a call to NOX::Solver::Generic::solve().
-  virtual void runPreSolve(const NOX::Solver::Generic& solver) {}
+  virtual void runPreSolve(const NOX::Solver::Generic& /* solver */) {}
 
   //! User defined method that will be executed at the end of a call to NOX::Solver::Generic::solve().
-  virtual void runPostSolve(const NOX::Solver::Generic& solver) {}
+  virtual void runPostSolve(const NOX::Solver::Generic& /* solver */) {}
 
   /** \brief User defined method that will be executed prior to the
       update of the solution vector during a call to
@@ -124,7 +124,7 @@ public:
       \param [in] update - the direction vector that will be used to update the solution.
       \param [in] solver - the nox solver
    */
-  virtual void runPreSolutionUpdate(const NOX::Abstract::Vector& update, const NOX::Solver::Generic& solver) {}
+  virtual void runPreSolutionUpdate(const NOX::Abstract::Vector& /* update */, const NOX::Solver::Generic& /* solver */) {}
 
   /** \brief User defined method that will be executed after the
       update of the solution vector during a call to
@@ -139,13 +139,13 @@ public:
 
       \param [in] solver - the nox solver
    */
-  virtual void runPostSolutionUpdate(const NOX::Solver::Generic& solver) {}
+  virtual void runPostSolutionUpdate(const NOX::Solver::Generic& /* solver */) {}
 
   //! User defined method that will be executed before a call to NOX::LineSearch::Generic::compute(). Only to be used in NOX::Solver::LineSearchBased!
-  virtual void runPreLineSearch(const NOX::Solver::Generic& solver) {}
+  virtual void runPreLineSearch(const NOX::Solver::Generic& /* solver */) {}
 
   //! User defined method that will be executed after a call to NOX::LineSearch::Generic::compute(). Only to be used in NOX::Solver::LineSearchBased!
-  virtual void runPostLineSearch(const NOX::Solver::Generic& solver) {}
+  virtual void runPostLineSearch(const NOX::Solver::Generic& /* solver */) {}
 }; // class PrePostOperator
 
 } // namespace NOX

--- a/packages/nox/src/NOX_Observer_Log.cpp
+++ b/packages/nox/src/NOX_Observer_Log.cpp
@@ -57,57 +57,57 @@ namespace NOX {
   ObserverLog::~ObserverLog() {}
 
   void ObserverLog::
-  runPreIterate(const NOX::Solver::Generic& solver)
+  runPreIterate(const NOX::Solver::Generic& /* solver */)
   {
     pre_it_count_ += 1;
     if (log_call_order_)
       call_order_.push_back("runPreIterate");
   }
 
-  void ObserverLog::runPostIterate(const NOX::Solver::Generic& solver)
+  void ObserverLog::runPostIterate(const NOX::Solver::Generic& /* solver */)
   {
     post_it_count_ += 1;
     if (log_call_order_)
       call_order_.push_back("runPostIterate");
   }
 
-  void ObserverLog::runPreSolve(const NOX::Solver::Generic& solver)
+  void ObserverLog::runPreSolve(const NOX::Solver::Generic& /* solver */)
   {
     pre_solve_count_ += 1;
     if (log_call_order_)
       call_order_.push_back("runPreSolve");
   }
 
-  void ObserverLog::runPostSolve(const NOX::Solver::Generic& solver)
+  void ObserverLog::runPostSolve(const NOX::Solver::Generic& /* solver */)
   {
     post_solve_count_ += 1;
     if (log_call_order_)
       call_order_.push_back("runPostSolve");
   }
 
-  void ObserverLog::runPreSolutionUpdate(const NOX::Abstract::Vector& update,
-                                         const NOX::Solver::Generic& solver)
+  void ObserverLog::runPreSolutionUpdate(const NOX::Abstract::Vector& /* update */,
+                                         const NOX::Solver::Generic& /* solver */)
   {
     pre_solution_update_count_ += 1;
     if (log_call_order_)
       call_order_.push_back("runPreSolutionUpdate");
   }
 
-  void ObserverLog::runPostSolutionUpdate(const NOX::Solver::Generic& solver)
+  void ObserverLog::runPostSolutionUpdate(const NOX::Solver::Generic& /* solver */)
   {
     post_solution_update_count_ += 1;
     if (log_call_order_)
       call_order_.push_back("runPostSolutionUpdate");
   }
 
-  void ObserverLog::runPreLineSearch(const NOX::Solver::Generic& solver)
+  void ObserverLog::runPreLineSearch(const NOX::Solver::Generic& /* solver */)
   {
     pre_linesearch_count_ += 1;
     if (log_call_order_)
       call_order_.push_back("runPreLineSearch");
   }
 
-  void ObserverLog::runPostLineSearch(const NOX::Solver::Generic& solver)
+  void ObserverLog::runPostLineSearch(const NOX::Solver::Generic& /* solver */)
   {
     post_linesearch_count_ += 1;
     if (log_call_order_)

--- a/packages/nox/src/NOX_SolverStats.hpp
+++ b/packages/nox/src/NOX_SolverStats.hpp
@@ -68,8 +68,8 @@ namespace NOX {
 
       void logLinearSolve(const bool converged,
                           const int numIterations,
-                          const double achievedTolerance,
-                          const double initialResidualNorm,
+                          const double /* achievedTolerance */,
+                          const double /* initialResidualNorm */,
                           const double finalResidualNorm)
       {
         lastLinearSolve_Converged = converged;


### PR DESCRIPTION
@trilinos/nox 

## Description
Comment out unused parameters in function definitions to avoid
`-Wunused-parameter` warnings.

## Motivation and Context
Clean build.