### PR TITLE
Intrepid2:  Remove Unused Parameter Warnings

### DIFF
--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_Basis.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_Basis.hpp
@@ -322,9 +322,9 @@ namespace Intrepid2 {
     */
     virtual
     void
-    getValues(       outputViewType outputValues,
-               const pointViewType  inputPoints,
-               const EOperator operatorType = OPERATOR_VALUE ) const {
+    getValues(       outputViewType /* outputValues */,
+               const pointViewType  /* inputPoints */,
+               const EOperator /* operatorType */ = OPERATOR_VALUE ) const {
       INTREPID2_TEST_FOR_EXCEPTION( true, std::logic_error,
                                     ">>> ERROR (Basis::getValues): this method (FEM) is not supported or should be over-riden accordingly by derived classes.");
     }
@@ -350,10 +350,10 @@ namespace Intrepid2 {
     */
     virtual
     void
-    getValues(        outputViewType outputValues,
-                const pointViewType  inputPoints,
-                const pointViewType  cellVertices,
-                const EOperator operatorType = OPERATOR_VALUE ) const {
+    getValues(        outputViewType /* outputValues */,
+                const pointViewType  /* inputPoints */,
+                const pointViewType  /* cellVertices */,
+                const EOperator /* operatorType */ = OPERATOR_VALUE ) const {
       INTREPID2_TEST_FOR_EXCEPTION( true, std::logic_error,
                                     ">>> ERROR (Basis::getValues): this method (FVM) is not supported or should be over-riden accordingly by derived classes.");
     }
@@ -364,7 +364,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoords( scalarViewType dofCoords ) const {
+    getDofCoords( scalarViewType /* dofCoords */ ) const {
       INTREPID2_TEST_FOR_EXCEPTION( true, std::logic_error,
                                     ">>> ERROR (Basis::getDofCoords): this method is not supported or should be over-riden accordingly by derived classes.");
     }
@@ -379,7 +379,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoeffs( scalarViewType dofCoeffs ) const {
+    getDofCoeffs( scalarViewType /* dofCoeffs */ ) const {
       INTREPID2_TEST_FOR_EXCEPTION( true, std::logic_error,
                                     ">>> ERROR (Basis::getDofCoeffs): this method is not supported or should be over-riden accordingly by derived classes.");
     }

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEM_ORTHDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEM_ORTHDef.hpp
@@ -298,10 +298,10 @@ bool hasDeriv,
 ordinal_type n>
 KOKKOS_INLINE_FUNCTION
 void OrthPolynomialTet<outputViewType,inputViewType,workViewType,hasDeriv,n>::generate(
-    outputViewType output,
-    const inputViewType  input,
-    workViewType   work,
-    const ordinal_type   order ) {
+    outputViewType /* output */,
+    const inputViewType  /* input */,
+    workViewType   /* work */,
+    const ordinal_type   /* order */ ) {
 #if 0 //#ifdef HAVE_INTREPID2_SACADO
 
 constexpr ordinal_type spaceDim = 3;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEM_ORTHDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEM_ORTHDef.hpp
@@ -227,10 +227,10 @@ bool hasDeriv,
 ordinal_type n>
 KOKKOS_INLINE_FUNCTION
 void OrthPolynomialTri<outputViewType,inputViewType,workViewType,hasDeriv,n>::generate(
-    outputViewType output,
-    const inputViewType  input,
-    workViewType   work,
-    const ordinal_type   order ) {
+    outputViewType /* output */,
+    const inputViewType  /* input */,
+    workViewType   /* work */,
+    const ordinal_type   /* order */ ) {
 #if 0   //#ifdef HAVE_INTREPID2_SACADO
 
 constexpr ordinal_type spaceDim = 2;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_C0_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_C0_FEMDef.hpp
@@ -59,7 +59,7 @@ namespace Intrepid2 {
     void
     Basis_HVOL_C0_FEM::Serial<opType>::
     getValues(       outputViewType output,
-               const inputViewType input ) {
+               const inputViewType /* input */ ) {
       switch (opType) {
       case OPERATOR_VALUE : {
         output.access(0) = 1.0;

--- a/packages/intrepid2/src/Discretization/Integration/Intrepid2_Cubature.hpp
+++ b/packages/intrepid2/src/Discretization/Integration/Intrepid2_Cubature.hpp
@@ -133,8 +133,8 @@ namespace Intrepid2 {
     */
     virtual
     void
-    getCubature( pointViewType  cubPoints,
-                 weightViewType cubWeights ) const {
+    getCubature( pointViewType  /* cubPoints */,
+                 weightViewType /* cubWeights */ ) const {
       INTREPID2_TEST_FOR_EXCEPTION( true, std::logic_error,
                                     ">>> ERROR (Cubature::getCubature): this method should be over-riden by derived classes.");
     }
@@ -148,9 +148,9 @@ namespace Intrepid2 {
     */
     virtual
     void
-    getCubature( pointViewType  cubPoints,
-                 weightViewType cubWeights,
-                 pointViewType  cellVertices) const {
+    getCubature( pointViewType  /* cubPoints */,
+                 weightViewType /* cubWeights */,
+                 pointViewType  /* cellVertices */) const {
       INTREPID2_TEST_FOR_EXCEPTION( true, std::logic_error,
                                     ">>> ERROR (Cubature::getCubature): this method should be over-riden by derived classes.");
     }

--- a/packages/intrepid2/src/Shared/Intrepid2_PointToolsDef.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_PointToolsDef.hpp
@@ -534,7 +534,7 @@ PointTools::
 warpShiftFace3D( Kokkos::DynRankView<pointValueType,pointProperties...>  dxy,
                  const ordinal_type order ,
                  const pointValueType pval ,
-                 const Kokkos::DynRankView<pointValueType,pointProperties...>  L1,
+                 const Kokkos::DynRankView<pointValueType,pointProperties...>  /* L1 */,
                  const Kokkos::DynRankView<pointValueType,pointProperties...>  L2,
                  const Kokkos::DynRankView<pointValueType,pointProperties...>  L3,
                  const Kokkos::DynRankView<pointValueType,pointProperties...> L4

--- a/packages/intrepid2/src/Shared/Intrepid2_Utils.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_Utils.hpp
@@ -196,7 +196,7 @@ namespace Intrepid2 {
   KOKKOS_FORCEINLINE_FUNCTION
   static void 
   unrollIndex(IdxType &i, IdxType &j, 
-              const DimType dim0,
+              const DimType /* dim0 */,
               const DimType dim1,
               const IterType iter) {
     // left index
@@ -296,7 +296,7 @@ namespace Intrepid2 {
   KOKKOS_INLINE_FUNCTION
   constexpr typename
   std::enable_if< std::is_pod<T>::value, unsigned >::type
-  dimension_scalar(const Kokkos::DynRankView<T, P...> view) {return 1;}
+  dimension_scalar(const Kokkos::DynRankView<T, P...> /* view */) {return 1;}
 
   template<typename T, typename ...P>
   KOKKOS_INLINE_FUNCTION


### PR DESCRIPTION
@trilinos/intrepid2 

## Description
Comment out parameter names in function definitions to avoid
`-Wunused-parameter` warnings.

## Motivation and Context
Clean build.