### PR TITLE
Zoltan2:  Remove Unused Parameter Warnings

### DIFF
--- a/packages/zoltan2/src/algorithms/Zoltan2_Algorithm.hpp
+++ b/packages/zoltan2/src/algorithms/Zoltan2_Algorithm.hpp
@@ -88,19 +88,19 @@ public:
   virtual ~Algorithm() {}
 
   //! \brief Ordering method
-  virtual int localOrder(const RCP<LocalOrderingSolution<lno_t> > &solution)
+  virtual int localOrder(const RCP<LocalOrderingSolution<lno_t> > &/* solution */)
   {
     Z2_THROW_NOT_IMPLEMENTED
   }
 
   //! \brief Ordering method
-  virtual int globalOrder(const RCP<GlobalOrderingSolution<gno_t> > &solution)
+  virtual int globalOrder(const RCP<GlobalOrderingSolution<gno_t> > &/* solution */)
   {
     Z2_THROW_NOT_IMPLEMENTED 
   }
   
   //! \brief Coloring method
-  virtual void color(const RCP<ColoringSolution<Adapter> > &solution) 
+  virtual void color(const RCP<ColoringSolution<Adapter> > &/* solution */) 
   {
     Z2_THROW_NOT_IMPLEMENTED
   }
@@ -111,19 +111,19 @@ public:
   }
 
   //! \brief Partitioning method
-  virtual void partition(const RCP<PartitioningSolution<Adapter> > &solution) 
+  virtual void partition(const RCP<PartitioningSolution<Adapter> > &/* solution */) 
   {
     Z2_THROW_NOT_IMPLEMENTED
   }
 
   //! \brief Matrix Partitioning method
-  virtual void partitionMatrix(const RCP<MatrixPartitioningSolution<Adapter> > &solution) 
+  virtual void partitionMatrix(const RCP<MatrixPartitioningSolution<Adapter> > &/* solution */) 
   {
     Z2_THROW_NOT_IMPLEMENTED
   }
 
   //! \brief Mapping method
-  virtual void map(const RCP<MappingSolution<Adapter> > &solution) 
+  virtual void map(const RCP<MappingSolution<Adapter> > &/* solution */) 
   {
     Z2_THROW_NOT_IMPLEMENTED
   }
@@ -135,12 +135,12 @@ public:
   }
 
   //! \brief  for partitioning methods, fill arrays with partition tree info
-  virtual void getPartitionTree(part_t numParts,
-                        part_t & numTreeVerts,
-                        std::vector<part_t> & permPartNums,
-                        std::vector<part_t> & splitRangeBeg,
-                        std::vector<part_t> & splitRangeEnd,
-                        std::vector<part_t> & treeVertParents) const
+  virtual void getPartitionTree(part_t /* numParts */,
+                        part_t & /* numTreeVerts */,
+                        std::vector<part_t> & /* permPartNums */,
+                        std::vector<part_t> & /* splitRangeBeg */,
+                        std::vector<part_t> & /* splitRangeEnd */,
+                        std::vector<part_t> & /* treeVertParents */) const
   {
     Z2_THROW_NOT_IMPLEMENTED
   }
@@ -165,7 +165,7 @@ public:
   //   \param dim : the number of dimensions specified for the point in space
   //   \param point : the coordinates of the point in space; array of size dim
   //   \return the part number of a part overlapping the given point
-  virtual part_t pointAssign(int dim, scalar_t *point) const
+  virtual part_t pointAssign(int /* dim */, scalar_t * /* point */) const
   {
     Z2_THROW_NOT_IMPLEMENTED
   }
@@ -183,8 +183,8 @@ public:
   //                     array of size dim
   //   \param nParts : (out) the number of parts overlapping the box
   //   \param parts :  (out) array of parts overlapping the box
-  virtual void boxAssign(int dim, scalar_t *lower, scalar_t *upper,
-                         size_t &nParts, part_t **partsFound) const
+  virtual void boxAssign(int /* dim */, scalar_t * /* lower */, scalar_t * /* upper */,
+                         size_t &/* nParts */, part_t ** /* partsFound */) const
   {
     Z2_THROW_NOT_IMPLEMENTED
   }
@@ -200,9 +200,9 @@ public:
   //                                               0 through i-1
   //  \param comAdj    (out) the neighboring parts
   virtual void getCommunicationGraph(
-    const PartitioningSolution<Adapter> *solution,
-    ArrayRCP<part_t> &comXAdj,
-    ArrayRCP<part_t> &comAdj)
+    const PartitioningSolution<Adapter> * /* solution */,
+    ArrayRCP<part_t> &/* comXAdj */,
+    ArrayRCP<part_t> &/* comAdj */)
     // TODO:  Should the return args be ArrayViews?
   {
     Z2_THROW_NOT_IMPLEMENTED
@@ -216,7 +216,7 @@ public:
   //  For example, AlgContiguousMapping can compute this function implicitly, 
   //  with no additional storage.  However, Mapping algorithms can skip this
   //  function and, instead, register their results in MappingSolution.
-  virtual int getRankForPart(part_t p)
+  virtual int getRankForPart(part_t /* p */)
   {
     Z2_THROW_NOT_IMPLEMENTED
   }
@@ -231,7 +231,7 @@ public:
   //  For example, AlgContiguousMapping can compute this function implicitly, 
   //  with no additional storage.  However, Mapping algorithms can skip this
   //  function and, instead, register their results in MappingSolution.
-  virtual void getMyPartsView(part_t &numParts, part_t *&parts)
+  virtual void getMyPartsView(part_t &/* numParts */, part_t *&/* parts */)
   {
     Z2_THROW_NOT_IMPLEMENTED
   }

--- a/packages/zoltan2/src/algorithms/order/Zoltan2_AlgAMD.hpp
+++ b/packages/zoltan2/src/algorithms/order/Zoltan2_AlgAMD.hpp
@@ -128,7 +128,7 @@ class AlgAMD : public Algorithm<Adapter>
     { }
 
     int globalOrder(
-      const RCP<GlobalOrderingSolution<typename Adapter::gno_t> > &solution) {
+      const RCP<GlobalOrderingSolution<typename Adapter::gno_t> > &/* solution */) {
         throw std::logic_error("AlgAMD does not yet support global ordering.");
     }
 
@@ -136,6 +136,7 @@ class AlgAMD : public Algorithm<Adapter>
       const RCP<LocalOrderingSolution<typename Adapter::lno_t> > &solution)
     {
 #ifndef HAVE_ZOLTAN2_AMD
+      (void)solution; // remove unused parameter warning
   throw std::runtime_error(
         "BUILD ERROR: AMD requested but not compiled into Zoltan2.\n"
         "Please set CMake flag Zoltan2_ENABLE_AMD:BOOL=ON.");

--- a/packages/zoltan2/src/algorithms/order/Zoltan2_AlgNatural.hpp
+++ b/packages/zoltan2/src/algorithms/order/Zoltan2_AlgNatural.hpp
@@ -79,7 +79,7 @@ class AlgNatural : public Algorithm<Adapter>
   {
   }
 
-  int globalOrder(const RCP<GlobalOrderingSolution<gno_t> > &solution) {
+  int globalOrder(const RCP<GlobalOrderingSolution<gno_t> > &/* solution */) {
     throw std::logic_error("AlgNatural does not yet support global ordering.");
   }
 

--- a/packages/zoltan2/src/algorithms/order/Zoltan2_AlgRCM.hpp
+++ b/packages/zoltan2/src/algorithms/order/Zoltan2_AlgRCM.hpp
@@ -83,7 +83,7 @@ class AlgRCM : public Algorithm<Adapter>
   {
   }
 
-  int globalOrder(const RCP<GlobalOrderingSolution<gno_t> > &solution)
+  int globalOrder(const RCP<GlobalOrderingSolution<gno_t> > &/* solution */)
   {
     throw std::logic_error("AlgRCM does not yet support global ordering.");
   }

--- a/packages/zoltan2/src/algorithms/order/Zoltan2_AlgRandom.hpp
+++ b/packages/zoltan2/src/algorithms/order/Zoltan2_AlgRandom.hpp
@@ -79,7 +79,7 @@ class AlgRandom : public Algorithm<Adapter>
   {
   }
 
-  int globalOrder(const RCP<GlobalOrderingSolution<gno_t> > &solution)
+  int globalOrder(const RCP<GlobalOrderingSolution<gno_t> > &/* solution */)
   {
     throw std::logic_error("AlgRandom does not yet support global ordering.");
   }

--- a/packages/zoltan2/src/algorithms/order/Zoltan2_AlgSortedDegree.hpp
+++ b/packages/zoltan2/src/algorithms/order/Zoltan2_AlgSortedDegree.hpp
@@ -83,7 +83,7 @@ class AlgSortedDegree : public Algorithm<Adapter>
   {
   }
 
-  int globalOrder(const RCP<GlobalOrderingSolution<gno_t> > &solution)
+  int globalOrder(const RCP<GlobalOrderingSolution<gno_t> > &/* solution */)
   {
      throw std::logic_error(
        "AlgSortedDegree does not yet support global ordering.");

--- a/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
+++ b/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
@@ -2761,7 +2761,7 @@ template <typename mj_scalar_t, typename mj_lno_t, typename mj_gno_t,
 void AlgMJ<mj_scalar_t, mj_lno_t, mj_gno_t, mj_part_t>::set_initial_coordinate_parts(
     mj_scalar_t &max_coordinate,
     mj_scalar_t &min_coordinate,
-    mj_part_t &concurrent_current_part_index,
+    mj_part_t &/* concurrent_current_part_index */,
     mj_lno_t coordinate_begin_index,
     mj_lno_t coordinate_end_index,
     mj_lno_t *mj_current_coordinate_permutations,
@@ -3107,7 +3107,7 @@ void AlgMJ<mj_scalar_t, mj_lno_t, mj_gno_t, mj_part_t>::mj_1D_part_get_thread_pa
     mj_lno_t coordinate_end_index,
     mj_scalar_t *mj_current_dim_coords,
     mj_scalar_t *temp_current_cut_coords,
-    bool *current_cut_status,
+    bool * /* current_cut_status */,
     double *my_current_part_weights,
     mj_scalar_t *my_current_left_closest,
     mj_scalar_t *my_current_right_closest){
@@ -3478,7 +3478,7 @@ template <typename mj_scalar_t, typename mj_lno_t, typename mj_gno_t,
           typename mj_part_t>
 void AlgMJ<mj_scalar_t, mj_lno_t, mj_gno_t, mj_part_t>::mj_create_new_partitions(
     mj_part_t num_parts,
-    mj_scalar_t *mj_current_dim_coords,
+    mj_scalar_t * /* mj_current_dim_coords */,
     mj_scalar_t *current_concurrent_cut_coordinate,
     mj_lno_t coordinate_begin,
     mj_lno_t coordinate_end,
@@ -3708,7 +3708,7 @@ void AlgMJ<mj_scalar_t, mj_lno_t, mj_gno_t, mj_part_t>::mj_create_new_partitions
 template <typename mj_scalar_t, typename mj_lno_t, typename mj_gno_t,
           typename mj_part_t>
 void AlgMJ<mj_scalar_t, mj_lno_t, mj_gno_t, mj_part_t>::mj_get_new_cut_coordinates(
-                const size_t &num_total_part,
+                const size_t &/* num_total_part */,
                 const mj_part_t &num_cuts,
                 const mj_scalar_t &max_coordinate,
                 const mj_scalar_t &min_coordinate,
@@ -6725,12 +6725,12 @@ public:
 
 template <typename Adapter>
 bool Zoltan2_AlgMJ<Adapter>::mj_premigrate_to_subset( int used_num_ranks, 
-				 int migration_selection_option,
+				 int /* migration_selection_option */,
 				 RCP<const Environment> mj_env_,
                                  RCP<const Comm<int> > mj_problemComm_,
                                  int coord_dim_,
                                  mj_lno_t num_local_coords_,
-                                 mj_gno_t num_global_coords_, size_t num_global_parts_,
+                                 mj_gno_t /* num_global_coords_ */, size_t /* num_global_parts_ */,
                                  const mj_gno_t *initial_mj_gnos_,
                                  mj_scalar_t **mj_coordinates_,
                                  int num_weights_per_coord_,
@@ -7499,7 +7499,7 @@ typename Adapter::part_t Zoltan2_AlgMJ<Adapter>::pointAssign(
 
 template <typename Adapter>
 void Zoltan2_AlgMJ<Adapter>::getCommunicationGraph(
-  const PartitioningSolution<Adapter> *solution,
+  const PartitioningSolution<Adapter> * /* solution */,
   ArrayRCP<typename Zoltan2_AlgMJ<Adapter>::mj_part_t> &comXAdj,
   ArrayRCP<typename Zoltan2_AlgMJ<Adapter>::mj_part_t> &comAdj)
 {

--- a/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgParMA.hpp
+++ b/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgParMA.hpp
@@ -82,9 +82,9 @@ class AlgParMA : public Algorithm<Adapter>
 public:
   typedef typename Adapter::user_t user_t;
 
-  AlgParMA(const RCP<const Environment> &env,
-           const RCP<const Comm<int> > &problemComm,
-           const RCP<const BaseAdapter<user_t> > &adapter)
+  AlgParMA(const RCP<const Environment> &/* env */,
+           const RCP<const Comm<int> > &/* problemComm */,
+           const RCP<const BaseAdapter<user_t> > &/* adapter */)
   {
     throw std::runtime_error(
           "BUILD ERROR:  ParMA requested but not compiled into Zoltan2.\n"

--- a/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgParMETIS.hpp
+++ b/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgParMETIS.hpp
@@ -65,9 +65,9 @@ template <typename Adapter>
 class AlgParMETIS : public Algorithm<Adapter>
 {
 public:
-  AlgParMETIS(const RCP<const Environment> &env,
-              const RCP<const Comm<int> > &problemComm,
-              const RCP<GraphModel<typename Adapter::base_adapter_t> > &model
+  AlgParMETIS(const RCP<const Environment> &/* env */,
+              const RCP<const Comm<int> > &/* problemComm */,
+              const RCP<GraphModel<typename Adapter::base_adapter_t> > &/* model */
   )
   {
     throw std::runtime_error(

--- a/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgPuLP.hpp
+++ b/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgPuLP.hpp
@@ -67,9 +67,9 @@ class AlgPuLP : public Algorithm<Adapter>
 {
 public:
   typedef typename Adapter::base_adapter_t base_adapter_t;
-  AlgPuLP(const RCP<const Environment> &env,
-          const RCP<const Comm<int> > &problemComm,
-          const RCP<const base_adapter_t> &adapter
+  AlgPuLP(const RCP<const Environment> &/* env */,
+          const RCP<const Comm<int> > &/* problemComm */,
+          const RCP<const base_adapter_t> &/* adapter */
   )
   {
     throw std::runtime_error(
@@ -79,7 +79,7 @@ public:
 
   /*! \brief Set up validators specific to this algorithm
   */
-  static void getValidParameters(ParameterList & pl)
+  static void getValidParameters(ParameterList & /* pl */)
   {
     // No parameters needed in this error-handling version of AlgPuLP
   }

--- a/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgScotch.hpp
+++ b/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgScotch.hpp
@@ -102,9 +102,9 @@ public:
   //            const RCP<const Comm<int> > &problemComm,
   //            const RCP<GraphModel<typename Adapter::base_adapter_t> > &model
   //) BDD: old inteface for reference
-  AlgPTScotch(const RCP<const Environment> &env,
-              const RCP<const Comm<int> > &problemComm,
-              const RCP<const base_adapter_t> &adapter
+  AlgPTScotch(const RCP<const Environment> &/* env */,
+              const RCP<const Comm<int> > &/* problemComm */,
+              const RCP<const base_adapter_t> &/* adapter */
   )
   {
     throw std::runtime_error(

--- a/packages/zoltan2/src/algorithms/partition/Zoltan2_MultiJagged_ReductionOps.hpp
+++ b/packages/zoltan2/src/algorithms/partition/Zoltan2_MultiJagged_ReductionOps.hpp
@@ -89,7 +89,7 @@ public:
 
     /*! \brief Implement Teuchos::ValueTypeReductionOp interface
      */
-    void reduce( const Ordinal count, const T inBuffer[], T inoutBuffer[]) const
+    void reduce( const Ordinal /* count */, const T inBuffer[], T inoutBuffer[]) const
     {
         if (reductionType == 0){
             Ordinal next=0;
@@ -153,7 +153,7 @@ public:
 
     /*! \brief Implement Teuchos::ValueTypeReductionOp interface
      */
-    void reduce( const Ordinal count, const T inBuffer[], T inoutBuffer[]) const
+    void reduce( const Ordinal /* count */, const T inBuffer[], T inoutBuffer[]) const
     {
         Ordinal next=0;
 

--- a/packages/zoltan2/src/algorithms/zoltan/Zoltan2_AlgZoltan.hpp
+++ b/packages/zoltan2/src/algorithms/zoltan/Zoltan2_AlgZoltan.hpp
@@ -138,7 +138,7 @@ private:
   }
 
   void setCallbacksGraph(
-    const RCP<const GraphAdapter<user_t,userCoord_t> > &adp)
+    const RCP<const GraphAdapter<user_t,userCoord_t> > &/* adp */)
   {
     // std::cout << "NotReadyForGraphCallbacksYet" << std::endl;
     // TODO

--- a/packages/zoltan2/src/algorithms/zoltan/Zoltan2_AlgZoltanCallbacks.hpp
+++ b/packages/zoltan2/src/algorithms/zoltan/Zoltan2_AlgZoltanCallbacks.hpp
@@ -123,8 +123,8 @@ static void zoltanObjList(void *data, int nGidEnt, int nLidEnt,
 ///////////////////////
 // ZOLTAN_PART_MULTI_FN
 template <typename Adapter>
-static void zoltanParts(void *data, int nGidEnt, int nLidEnt, int nObj,
-                        ZOLTAN_ID_PTR gids, ZOLTAN_ID_PTR lids,
+static void zoltanParts(void *data, int /* nGidEnt */, int nLidEnt, int nObj,
+                        ZOLTAN_ID_PTR /* gids */, ZOLTAN_ID_PTR lids,
                         int *parts, int *ierr)
 {
   typedef typename Adapter::lno_t lno_t;
@@ -153,8 +153,8 @@ static int zoltanNumGeom(void *data, int *ierr)
 ///////////////////////
 // ZOLTAN_GEOM_MULTI_FN
 template <typename Adapter>
-static void zoltanGeom(void *data, int nGidEnt, int nLidEnt, int nObj,
-                       ZOLTAN_ID_PTR gids, ZOLTAN_ID_PTR lids,
+static void zoltanGeom(void *data, int /* nGidEnt */, int nLidEnt, int nObj,
+                       ZOLTAN_ID_PTR /* gids */, ZOLTAN_ID_PTR lids,
                        int nDim, double *coords, int *ierr)
 {
   typedef typename Adapter::lno_t lno_t;
@@ -202,7 +202,7 @@ static void zoltanHGSizeCS_withGraphAdapter(void *data,
 // ZOLTAN_HG_CS_FN
 template <typename Adapter>
 static void zoltanHGCS_withGraphAdapter(void *data, int nGidEnt, int nLists, 
-                                        int nPins, int format, 
+                                        int /* nPins */, int /* format */, 
                                         ZOLTAN_ID_PTR listIds, int *listIdx,
                                         ZOLTAN_ID_PTR pinIds, int *ierr
 )
@@ -277,7 +277,7 @@ static void zoltanHGEdgeWts_withGraphAdapter(
   int nGidEnt, 
   int nLidEnt, 
   int nEdges, 
-  int eWgtDim, 
+  int /* eWgtDim */, 
   ZOLTAN_ID_PTR edgeGids, 
   ZOLTAN_ID_PTR edgeLids, 
   float *edgeWgts,

--- a/packages/zoltan2/src/directory/Zoltan2_Directory_Comm.cpp
+++ b/packages/zoltan2/src/directory/Zoltan2_Directory_Comm.cpp
@@ -369,7 +369,7 @@ int Zoltan2_Directory_Comm::invert_map(
   int      *pnrecvs,                   /* number of messages I receive */
   int       my_proc,                   /* my processor number */
   int       nprocs,                    /* total number of processors */
-  int       out_of_mem,                /* tell everyone I'm out of memory? */
+  int       /* out_of_mem */,          /* tell everyone I'm out of memory? */
   int       tag,                       /* message tag I can use */
   Teuchos::RCP<const Teuchos::Comm<int> > comm) /* communicator */
 {
@@ -858,8 +858,8 @@ int Zoltan2_Directory_Comm::do_post(
 
 int Zoltan2_Directory_Comm::do_wait(
   Zoltan2_Directory_Plan *plan,          /* communication data structure */
-  int tag,			                         /* message tag for communicating */
-  const Teuchos::ArrayRCP<char> &send_data, /* array of data I currently own */
+  int /* tag */,			                         /* message tag for communicating */
+  const Teuchos::ArrayRCP<char> &/* send_data */, /* array of data I currently own */
   int nbytes,                            /* msg size */
   Teuchos::ArrayRCP<char> &recv_data)		 /* array of data I'll own after comm */
 {
@@ -1653,7 +1653,7 @@ int Zoltan2_Directory_Comm::exchange_sizes(
   int      *total_recv_size,	        /* (returned) sum of all incoming sizes */
   int       my_proc,		              /* my processor number */
   int       tag,			                /* message tag I can use */
-  Teuchos::RCP<const Teuchos::Comm<int> > comm) {		/* communicator */
+  Teuchos::RCP<const Teuchos::Comm<int> > /* comm */) {		/* communicator */
 
   /* If sizes vary, then I need to communicate messaaage lengths */
   int self_index_to = -1;  /* location of self in procs_to */

--- a/packages/zoltan2/src/environment/Zoltan2_IntegerRangeList.hpp
+++ b/packages/zoltan2/src/environment/Zoltan2_IntegerRangeList.hpp
@@ -583,7 +583,7 @@ template <typename Integral>
 template <typename Integral>
   void IntegerRangeListValidator<Integral>::validate( 
     Teuchos::ParameterEntry  const& entry,
-    std::string const& paramName, std::string const& sublistName) const
+    std::string const& /* paramName */, std::string const& /* sublistName */) const
 {
   if (!entry.isType<std::string>()){
     return;  // already converted to an an array
@@ -635,7 +635,7 @@ template <typename Integral>
 
 template <typename Integral>
   void IntegerRangeListValidator<Integral>::validateAndModify( 
-    std::string const& paramName, std::string const& sublistName, 
+    std::string const& /* paramName */, std::string const& /* sublistName */, 
     Teuchos::ParameterEntry * entry) const
 {
   typedef typename Teuchos::Array<Integral>::size_type arraySize_t;

--- a/packages/zoltan2/src/input/Zoltan2_Adapter.hpp
+++ b/packages/zoltan2/src/input/Zoltan2_Adapter.hpp
@@ -131,7 +131,7 @@ public:
       \param ids will on return point to the list of the global Ids for 
         this process.
    */
-  virtual void getIDsKokkosView(Kokkos::View<gno_t *> &ids) const {
+  virtual void getIDsKokkosView(Kokkos::View<gno_t *> &/* ids */) const {
     Z2_THROW_NOT_IMPLEMENTED
   }
 
@@ -159,8 +159,8 @@ public:
   // *   getNumWeightsPerID > 0.
   // *   This function should not be called if getNumWeightsPerID is zero.
   // */ 
-  virtual void getWeightsKokkosView(Kokkos::View<scalar_t *> &wgt, 
-                              int idx = 0) const {
+  virtual void getWeightsKokkosView(Kokkos::View<scalar_t *> &/* wgt */, 
+                              int /* idx */ = 0) const {
     Z2_THROW_NOT_IMPLEMENTED
   }
 

--- a/packages/zoltan2/src/input/Zoltan2_GraphAdapter.hpp
+++ b/packages/zoltan2/src/input/Zoltan2_GraphAdapter.hpp
@@ -176,7 +176,7 @@ public:
       \param idx ranges from zero to one less than getNumWeightsPerVertex().
    */
   virtual void getVertexWeightsView(const scalar_t *&weights, int &stride,
-                                    int idx = 0) const
+                                    int /* idx */ = 0) const
   {
     weights = NULL;
     stride = 0;
@@ -187,7 +187,7 @@ public:
   /*! \brief Indicate whether vertex weight with index idx should be the
    *         global degree of the vertex
    */
-  virtual bool useDegreeAsVertexWeight(int idx) const
+  virtual bool useDegreeAsVertexWeight(int /* idx */) const
   {
     return false;
   }
@@ -203,7 +203,7 @@ public:
       \param idx ranges from zero to one less than getNumWeightsPerEdge().
    */
   virtual void getEdgeWeightsView(const scalar_t *&weights, int &stride,
-                                  int idx = 0) const
+                                  int /* idx */ = 0) const
   {
     weights = NULL;
     stride = 0;

--- a/packages/zoltan2/src/models/Zoltan2_CoordinateModel.hpp
+++ b/packages/zoltan2/src/models/Zoltan2_CoordinateModel.hpp
@@ -257,9 +257,9 @@ template <typename Adapter>
 template <typename AdapterWithCoords>
 void CoordinateModel<Adapter>::sharedConstructor(
     const AdapterWithCoords *ia,
-    const RCP<const Environment> &env,
+    const RCP<const Environment> &/* env */,
     const RCP<const Comm<int> > &comm,
-    modelFlag_t &flags)
+    modelFlag_t &/* flags */)
 {
   size_t nLocalIds = ia->getLocalNumIDs();
 

--- a/packages/zoltan2/src/models/Zoltan2_GraphModel.hpp
+++ b/packages/zoltan2/src/models/Zoltan2_GraphModel.hpp
@@ -118,9 +118,9 @@ public:
     const RCP<const Environment> &env, const RCP<const Comm<int> > &comm,
     modelFlag_t &modelflags);
 
-  GraphModel(const RCP<const VectorAdapter<userCoord_t> > &ia,
-    const RCP<const Environment> &env, const RCP<const Comm<int> > &comm,
-    modelFlag_t &flags)
+  GraphModel(const RCP<const VectorAdapter<userCoord_t> > &/* ia */,
+    const RCP<const Environment> &/* env */, const RCP<const Comm<int> > &/* comm */,
+    modelFlag_t &/* flags */)
   {
     throw std::runtime_error("cannot build GraphModel from VectorAdapter");
   }

--- a/packages/zoltan2/src/models/Zoltan2_IdentifierModel.hpp
+++ b/packages/zoltan2/src/models/Zoltan2_IdentifierModel.hpp
@@ -143,7 +143,7 @@ template <typename Adapter>
     const RCP<const Adapter> &ia,
     const RCP<const Environment> &env,
     const RCP<const Comm<int> > &comm,
-    modelFlag_t &modelFlags):
+    modelFlag_t &/* modelFlags */):
       numGlobalIdentifiers_(), env_(env), comm_(comm),
       gids_(), nUserWeights_(0), weights_()
 {

--- a/packages/zoltan2/src/problems/Zoltan2_OrderingProblem.hpp
+++ b/packages/zoltan2/src/problems/Zoltan2_OrderingProblem.hpp
@@ -230,7 +230,7 @@ private:
 
 ////////////////////////////////////////////////////////////////////////
 template <typename Adapter>
-void OrderingProblem<Adapter>::solve(bool updateInputData)
+void OrderingProblem<Adapter>::solve(bool /* updateInputData */)
 {
   HELLO;
 

--- a/packages/zoltan2/src/problems/Zoltan2_Problem.hpp
+++ b/packages/zoltan2/src/problems/Zoltan2_Problem.hpp
@@ -235,7 +235,7 @@ private:
 };
 
 template <typename Adapter>
-  void Problem<Adapter>::setupProblemEnvironment(ParameterList *params)
+  void Problem<Adapter>::setupProblemEnvironment(ParameterList * /* params */)
 {
   ParameterList &processedParameters = env_->getParametersNonConst();
   params_ = rcp<ParameterList>(&processedParameters, false);

--- a/packages/zoltan2/src/util/Zoltan2_EvaluateBaseClass.hpp
+++ b/packages/zoltan2/src/util/Zoltan2_EvaluateBaseClass.hpp
@@ -59,7 +59,7 @@ class EvaluateBaseClassRoot{
     virtual ~EvaluateBaseClassRoot() {} // required virtual declaration
 
     /*! \brief Print all metrics */
-    virtual void printMetrics(std::ostream &os) const {};
+    virtual void printMetrics(std::ostream &/* os */) const {};
 };
 
 template <typename Adapter>


### PR DESCRIPTION
@trilinos/zoltan2 

## Description
Comment out parameter names in function definitions to avoid
`-Wunused-parameter` warnings.

## Motivation and Context
Clean build.