### PR TITLE
Teko:  Remove Unused Parameter Warnings

### DIFF
--- a/packages/teko/src/Epetra/Teko_BasicMappingStrategy.cpp
+++ b/packages/teko/src/Epetra/Teko_BasicMappingStrategy.cpp
@@ -68,7 +68,7 @@ namespace Epetra {
 //       comm - Epetra_Comm object related to the map
 //
 BasicMappingStrategy::BasicMappingStrategy(const Teuchos::RCP<const Epetra_Map> & rMap,
-                                           const Teuchos::RCP<const Epetra_Map> & dMap, const Epetra_Comm & comm)
+                                           const Teuchos::RCP<const Epetra_Map> & dMap, const Epetra_Comm & /* comm */)
 {
    rangeMap_ = rMap;
    domainMap_ = dMap;

--- a/packages/teko/src/Epetra/Teko_BlockedEpetraOperator.hpp
+++ b/packages/teko/src/Epetra/Teko_BlockedEpetraOperator.hpp
@@ -127,10 +127,10 @@ public:
    // attribute set methods
    
    // don't use transpose...ever!
-   virtual int SetUseTranspose(bool useTranspose)
+   virtual int SetUseTranspose(bool /* useTranspose */)
    { return -1; }
 
-   virtual int ApplyInverse(const Epetra_MultiVector &X, Epetra_MultiVector &Y) const
+   virtual int ApplyInverse(const Epetra_MultiVector &/* X */, Epetra_MultiVector &/* Y */) const
    { TEUCHOS_ASSERT(false); return -1; }
 
    virtual double NormInf() const

--- a/packages/teko/src/Epetra/Teko_EpetraHelpers.hpp
+++ b/packages/teko/src/Epetra/Teko_EpetraHelpers.hpp
@@ -156,7 +156,7 @@ public:
    int Apply(const Epetra_MultiVector& X, Epetra_MultiVector& Y) const;
 
    //! Can't call ApplyInverse on a zeroed operator
-   int ApplyInverse(const Epetra_MultiVector& X, Epetra_MultiVector& Y) const
+   int ApplyInverse(const Epetra_MultiVector& /* X */, Epetra_MultiVector& /* Y */) const
    { return -1; }
 
    //!

--- a/packages/teko/src/Epetra/Teko_EpetraOperatorWrapper.cpp
+++ b/packages/teko/src/Epetra/Teko_EpetraOperatorWrapper.cpp
@@ -174,8 +174,8 @@ int EpetraOperatorWrapper::Apply(const Epetra_MultiVector& X, Epetra_MultiVector
 }
 
 
-int EpetraOperatorWrapper::ApplyInverse(const Epetra_MultiVector& X, 
-                                      Epetra_MultiVector& Y) const
+int EpetraOperatorWrapper::ApplyInverse(const Epetra_MultiVector& /* X */, 
+                                      Epetra_MultiVector& /* Y */) const
 {
   TEUCHOS_TEST_FOR_EXCEPTION(true, std::runtime_error,
                      "EpetraOperatorWrapper::ApplyInverse not implemented");

--- a/packages/teko/src/Epetra/Teko_InverseFactoryOperator.cpp
+++ b/packages/teko/src/Epetra/Teko_InverseFactoryOperator.cpp
@@ -133,7 +133,7 @@ void InverseFactoryOperator::buildInverseOperator(const Teuchos::RCP<const Epetr
    TEUCHOS_ASSERT(firstBuildComplete_==true);
 }
 
-void InverseFactoryOperator::buildInverseOperator(const Teuchos::RCP<Epetra_Operator> & A,bool clear)
+void InverseFactoryOperator::buildInverseOperator(const Teuchos::RCP<Epetra_Operator> & A,bool /* clear */)
 {
    setConstFwdOp_ = false;
 

--- a/packages/teko/src/Epetra/Teko_StridedEpetraOperator.hpp
+++ b/packages/teko/src/Epetra/Teko_StridedEpetraOperator.hpp
@@ -115,10 +115,10 @@ public:
    // attribute set methods
    
    // don't use transpose...ever!
-   virtual int SetUseTranspose(bool useTranspose)
+   virtual int SetUseTranspose(bool /* useTranspose */)
    { return -1; }
 
-   virtual int ApplyInverse(const Epetra_MultiVector &X, Epetra_MultiVector &Y) const
+   virtual int ApplyInverse(const Epetra_MultiVector &/* X */, Epetra_MultiVector &/* Y */) const
    { TEUCHOS_ASSERT(false); return -1; }
 
    virtual double NormInf() const

--- a/packages/teko/src/NS/Teko_InvLSCStrategy.cpp
+++ b/packages/teko/src/NS/Teko_InvLSCStrategy.cpp
@@ -156,22 +156,22 @@ void InvLSCStrategy::buildState(BlockedLinearOp & A,BlockPreconditionerState & s
 }
 
 // functions inherited from LSCStrategy
-LinearOp InvLSCStrategy::getInvBQBt(const BlockedLinearOp & A,BlockPreconditionerState & state) const
+LinearOp InvLSCStrategy::getInvBQBt(const BlockedLinearOp & /* A */,BlockPreconditionerState & state) const
 {
    return state.getInverse("invBQBtmC");
 }
 
-LinearOp InvLSCStrategy::getInvBHBt(const BlockedLinearOp & A,BlockPreconditionerState & state) const
+LinearOp InvLSCStrategy::getInvBHBt(const BlockedLinearOp & /* A */,BlockPreconditionerState & state) const
 {
    return state.getInverse("invBHBtmC");
 }
 
-LinearOp InvLSCStrategy::getInvF(const BlockedLinearOp & A,BlockPreconditionerState & state) const
+LinearOp InvLSCStrategy::getInvF(const BlockedLinearOp & /* A */,BlockPreconditionerState & state) const
 {
    return state.getInverse("invF");
 }
 
-LinearOp InvLSCStrategy::getOuterStabilization(const BlockedLinearOp & A,BlockPreconditionerState & state) const
+LinearOp InvLSCStrategy::getOuterStabilization(const BlockedLinearOp & /* A */,BlockPreconditionerState & state) const
 {
    LSCPrecondState * lscState = dynamic_cast<LSCPrecondState*>(&state);
    TEUCHOS_ASSERT(lscState!=0);
@@ -180,7 +180,7 @@ LinearOp InvLSCStrategy::getOuterStabilization(const BlockedLinearOp & A,BlockPr
    return lscState->aiD_;
 }
 
-LinearOp InvLSCStrategy::getInvMass(const BlockedLinearOp & A,BlockPreconditionerState & state) const
+LinearOp InvLSCStrategy::getInvMass(const BlockedLinearOp & /* A */,BlockPreconditionerState & state) const
 {
    LSCPrecondState * lscState = dynamic_cast<LSCPrecondState*>(&state);
    TEUCHOS_ASSERT(lscState!=0);

--- a/packages/teko/src/NS/Teko_InvLSCStrategy.hpp
+++ b/packages/teko/src/NS/Teko_InvLSCStrategy.hpp
@@ -134,7 +134,7 @@ public:
      */
    // virtual LinearOp getInvAlphaD(const BlockedLinearOp & A,BlockPreconditionerState & state) const;
    virtual LinearOp getOuterStabilization(const BlockedLinearOp & A,BlockPreconditionerState & state) const;
-   virtual LinearOp getInnerStabilization(const BlockedLinearOp & A,BlockPreconditionerState & state) const
+   virtual LinearOp getInnerStabilization(const BlockedLinearOp & /* A */,BlockPreconditionerState & /* state */) const
    { return Teuchos::null; }
 
    /** Get the inverse mass matrix.

--- a/packages/teko/src/NS/Teko_LSCSIMPLECStrategy.cpp
+++ b/packages/teko/src/NS/Teko_LSCSIMPLECStrategy.cpp
@@ -124,17 +124,17 @@ void LSCSIMPLECStrategy::buildState(BlockedLinearOp & A,BlockPreconditionerState
 }
 
 // functions inherited from LSCStrategy
-LinearOp LSCSIMPLECStrategy::getInvBQBt(const BlockedLinearOp & A,BlockPreconditionerState & state) const
+LinearOp LSCSIMPLECStrategy::getInvBQBt(const BlockedLinearOp & /* A */,BlockPreconditionerState & state) const
 {
    return state.getInverse("invBQBtmC");
 }
 
-LinearOp LSCSIMPLECStrategy::getInvBHBt(const BlockedLinearOp & A,BlockPreconditionerState & state) const
+LinearOp LSCSIMPLECStrategy::getInvBHBt(const BlockedLinearOp & /* A */,BlockPreconditionerState & state) const
 {
    return state.getInverse("invBQBtmC").getConst();
 }
 
-LinearOp LSCSIMPLECStrategy::getInvF(const BlockedLinearOp & A,BlockPreconditionerState & state) const
+LinearOp LSCSIMPLECStrategy::getInvF(const BlockedLinearOp & /* A */,BlockPreconditionerState & state) const
 {
    return state.getInverse("invF");
 }
@@ -150,7 +150,7 @@ LinearOp LSCSIMPLECStrategy::getInnerStabilization(const BlockedLinearOp & A,Blo
 }
 
 
-LinearOp LSCSIMPLECStrategy::getInvMass(const BlockedLinearOp & A,BlockPreconditionerState & state) const
+LinearOp LSCSIMPLECStrategy::getInvMass(const BlockedLinearOp & /* A */,BlockPreconditionerState & state) const
 {
    LSCPrecondState * lscState = dynamic_cast<LSCPrecondState*>(&state);
    TEUCHOS_ASSERT(lscState!=0);

--- a/packages/teko/src/NS/Teko_LSCSIMPLECStrategy.hpp
+++ b/packages/teko/src/NS/Teko_LSCSIMPLECStrategy.hpp
@@ -123,7 +123,7 @@ public:
      *
      * \returns The operator to stabilize the whole Schur complement.
      */
-   virtual LinearOp getOuterStabilization(const BlockedLinearOp & A,BlockPreconditionerState & state) const
+   virtual LinearOp getOuterStabilization(const BlockedLinearOp & /* A */,BlockPreconditionerState & /* state */) const
    { return Teuchos::null; }
 
    virtual LinearOp getInnerStabilization(const BlockedLinearOp & A,BlockPreconditionerState & state) const;
@@ -173,7 +173,7 @@ public:
    //! Set to true to use the Full LDU decomposition, false otherwise
    virtual void setUseFullLDU(bool val) { useFullLDU_ = val; }
 
-   virtual void setSymmetric(bool isSymmetric) { }
+   virtual void setSymmetric(bool /* isSymmetric */) { }
 
 protected:
    // how to invert the matrices

--- a/packages/teko/src/NS/Teko_LSCStrategy.hpp
+++ b/packages/teko/src/NS/Teko_LSCStrategy.hpp
@@ -231,13 +231,13 @@ public:
    virtual void setSymmetric(bool isSymmetric) = 0;
 
    //! Initialize from a parameter list
-   virtual void initializeFromParameterList(const Teuchos::ParameterList & pl,const InverseLibrary & invLib) {}
+   virtual void initializeFromParameterList(const Teuchos::ParameterList & /* pl */,const InverseLibrary & /* invLib */) {}
 
    //! For assiting in construction of the preconditioner
    virtual Teuchos::RCP<Teuchos::ParameterList> getRequestedParameters() const { return Teuchos::null;}
 
    //! For assiting in construction of the preconditioner
-   virtual bool updateRequestedParameters(const Teuchos::ParameterList & pl) { return true; }
+   virtual bool updateRequestedParameters(const Teuchos::ParameterList & /* pl */) { return true; }
 
    //! This method sets the request handler for this object
    void setRequestHandler(const Teuchos::RCP<RequestHandler> & rh)

--- a/packages/teko/src/NS/Teko_PCDStrategy.cpp
+++ b/packages/teko/src/NS/Teko_PCDStrategy.cpp
@@ -321,7 +321,7 @@ Teuchos::RCP<Teuchos::ParameterList> PCDStrategy::getRequestedParameters() const
 }
 
 //! For assiting in construction of the preconditioner
-bool PCDStrategy::updateRequestedParameters(const Teuchos::ParameterList & pl) 
+bool PCDStrategy::updateRequestedParameters(const Teuchos::ParameterList & /* pl */) 
 {
    TEUCHOS_ASSERT(false);
 

--- a/packages/teko/src/NS/Teko_PresLaplaceLSCStrategy.cpp
+++ b/packages/teko/src/NS/Teko_PresLaplaceLSCStrategy.cpp
@@ -125,23 +125,23 @@ void PresLaplaceLSCStrategy::buildState(BlockedLinearOp & A,BlockPreconditionerS
 }
 
 // functions inherited from LSCStrategy
-LinearOp PresLaplaceLSCStrategy::getInvBQBt(const BlockedLinearOp & A,BlockPreconditionerState & state) const
+LinearOp PresLaplaceLSCStrategy::getInvBQBt(const BlockedLinearOp & /* A */,BlockPreconditionerState & state) const
 {
    return state.getModifiableOp("invPresLap");
 }
 
-LinearOp PresLaplaceLSCStrategy::getInvBHBt(const BlockedLinearOp & A,BlockPreconditionerState & state) const
+LinearOp PresLaplaceLSCStrategy::getInvBHBt(const BlockedLinearOp & /* A */,BlockPreconditionerState & state) const
 {
    return state.getModifiableOp("invPresLap");
 }
 
-LinearOp PresLaplaceLSCStrategy::getInvF(const BlockedLinearOp & A,BlockPreconditionerState & state) const
+LinearOp PresLaplaceLSCStrategy::getInvF(const BlockedLinearOp & /* A */,BlockPreconditionerState & state) const
 {
    return state.getModifiableOp("invF");
 }
 
 // LinearOp PresLaplaceLSCStrategy::getInvAlphaD(const BlockedLinearOp & A,BlockPreconditionerState & state) const
-LinearOp PresLaplaceLSCStrategy::getOuterStabilization(const BlockedLinearOp & A,BlockPreconditionerState & state) const
+LinearOp PresLaplaceLSCStrategy::getOuterStabilization(const BlockedLinearOp & /* A */,BlockPreconditionerState & state) const
 {
    LSCPrecondState * lscState = dynamic_cast<LSCPrecondState*>(&state);
    TEUCHOS_ASSERT(lscState!=0);
@@ -150,7 +150,7 @@ LinearOp PresLaplaceLSCStrategy::getOuterStabilization(const BlockedLinearOp & A
    return lscState->aiD_;
 }
 
-LinearOp PresLaplaceLSCStrategy::getInvMass(const BlockedLinearOp & A,BlockPreconditionerState & state) const
+LinearOp PresLaplaceLSCStrategy::getInvMass(const BlockedLinearOp & /* A */,BlockPreconditionerState & state) const
 {
    LSCPrecondState * lscState = dynamic_cast<LSCPrecondState*>(&state);
    TEUCHOS_ASSERT(lscState!=0);

--- a/packages/teko/src/NS/Teko_PresLaplaceLSCStrategy.hpp
+++ b/packages/teko/src/NS/Teko_PresLaplaceLSCStrategy.hpp
@@ -128,7 +128,7 @@ public:
    // virtual LinearOp getInvAlphaD(const BlockedLinearOp & A,BlockPreconditionerState & state) const;
    virtual LinearOp getOuterStabilization(const BlockedLinearOp & A,BlockPreconditionerState & state) const;
 
-   virtual LinearOp getInnerStabilization(const BlockedLinearOp & A,BlockPreconditionerState & state) const
+   virtual LinearOp getInnerStabilization(const BlockedLinearOp & /* A */,BlockPreconditionerState & /* state */) const
    { return Teuchos::null; }
 
    /** Get the inverse mass matrix.

--- a/packages/teko/src/NS/Teko_StaticLSCStrategy.hpp
+++ b/packages/teko/src/NS/Teko_StaticLSCStrategy.hpp
@@ -76,7 +76,7 @@ public:
      * \param[in] state State object for storying reusable information about
      *                  the operator A.
      */
-   virtual void buildState(BlockedLinearOp & A,BlockPreconditionerState & state) const {}
+   virtual void buildState(BlockedLinearOp & /* A */,BlockPreconditionerState & /* state */) const {}
 
    /** Get the inverse of the \f$F\f$ block.
      *
@@ -86,7 +86,7 @@ public:
      *
      * \returns An (approximate) inverse of \f$F\f$.
      */
-   virtual LinearOp getInvF(const BlockedLinearOp & A,BlockPreconditionerState & state) const
+   virtual LinearOp getInvF(const BlockedLinearOp & /* A */,BlockPreconditionerState & /* state */) const
    { return invF_; }
 
    /** Get the inverse of \f$B Q_u^{-1} B^T\f$. 
@@ -97,7 +97,7 @@ public:
      *
      * \returns An (approximate) inverse of \f$B Q_u^{-1} B^T\f$.
      */
-   virtual LinearOp getInvBQBt(const BlockedLinearOp & A,BlockPreconditionerState & state) const
+   virtual LinearOp getInvBQBt(const BlockedLinearOp & /* A */,BlockPreconditionerState & /* state */) const
    { return invBQBtmC_; }
 
    /** Get the inverse of \f$B H B^T - \gamma C\f$. 
@@ -108,7 +108,7 @@ public:
      *
      * \returns An (approximate) inverse of \f$B H B^T - \gamma C\f$.
      */
-   virtual LinearOp getInvBHBt(const BlockedLinearOp & A,BlockPreconditionerState & state) const
+   virtual LinearOp getInvBHBt(const BlockedLinearOp & /* A */,BlockPreconditionerState & /* state */) const
    { return invBQBtmC_; }
 
    /** Get the inverse for stabilizing the whole Schur complement approximation.
@@ -119,10 +119,10 @@ public:
      *
      * \returns The operator to stabilize the whole Schur complement (\f$\alpha D^{-1} \f$).
      */
-   virtual LinearOp getOuterStabilization(const BlockedLinearOp & A,BlockPreconditionerState & state) const
+   virtual LinearOp getOuterStabilization(const BlockedLinearOp & /* A */,BlockPreconditionerState & /* state */) const
    { return invD_; }
 
-   virtual LinearOp getInnerStabilization(const BlockedLinearOp & A,BlockPreconditionerState & state) const
+   virtual LinearOp getInnerStabilization(const BlockedLinearOp & /* A */,BlockPreconditionerState & /* state */) const
    { return Teuchos::null; }
 
    /** Get the inverse mass matrix.
@@ -133,7 +133,7 @@ public:
      *
      * \returns The inverse of the mass matrix \f$Q_u\f$.
      */
-   virtual LinearOp getInvMass(const BlockedLinearOp & A,BlockPreconditionerState & state) const
+   virtual LinearOp getInvMass(const BlockedLinearOp & /* A */,BlockPreconditionerState & /* state */) const
    { return invMass_; }
 
    /** Get the \f$H\f$ scaling matrix.
@@ -144,7 +144,7 @@ public:
      *
      * \returns The \f$H\f$ scaling matrix.
      */
-   virtual LinearOp getHScaling(const BlockedLinearOp & A,BlockPreconditionerState & state) const
+   virtual LinearOp getHScaling(const BlockedLinearOp & /* A */,BlockPreconditionerState & /* state */) const
    { return invMass_; }
 
    /** Should the approximation of the inverse use a full LDU decomposition, or
@@ -160,7 +160,7 @@ public:
      *
      * \param[in] isSymmetric Is this operator symmetric?
      */
-   virtual void setSymmetric(bool isSymmetric) { }
+   virtual void setSymmetric(bool /* isSymmetric */) { }
 
 protected:
    // protected memebers

--- a/packages/teko/src/Teko_BlockInvDiagonalStrategy.hpp
+++ b/packages/teko/src/Teko_BlockInvDiagonalStrategy.hpp
@@ -107,7 +107,7 @@ public:
    /** returns an (approximate) inverse of the diagonal blocks of A
      * where A is closely related to the original source for invD0 and invD1
      */
-   virtual void getInvD(const BlockedLinearOp & A, BlockPreconditionerState & state,
+   virtual void getInvD(const BlockedLinearOp & /* A */, BlockPreconditionerState & /* state */,
                         std::vector<LinearOp> & invDiag) const
    { invDiag.clear(); invDiag = invDiag_; }
 

--- a/packages/teko/src/Teko_BlockedReordering.hpp
+++ b/packages/teko/src/Teko_BlockedReordering.hpp
@@ -232,17 +232,17 @@ public:
    virtual int GetNumBlocks() const { return 0; }
 
    //! Set the number of subblocks (this one does nothing b/c its a leaf)
-   virtual void SetNumBlocks(int sz) {}
+   virtual void SetNumBlocks(int /* sz */) {}
 
    //! Set the sub block, this does nothing b/c its a leaf
-   virtual void SetBlock(int blockIndex,int reorder) { }
+   virtual void SetBlock(int /* blockIndex */,int /* reorder */) { }
 
    //! Get a particular subblock...this returns null
-   virtual const Teuchos::RCP<BlockReorderManager> GetBlock(int blockIndex)
+   virtual const Teuchos::RCP<BlockReorderManager> GetBlock(int /* blockIndex */)
    { return Teuchos::null; }
 
    //! Get a particular subblock...this returns null
-   virtual const Teuchos::RCP<const BlockReorderManager> GetBlock(int blockIndex) const
+   virtual const Teuchos::RCP<const BlockReorderManager> GetBlock(int /* blockIndex */) const
    { return Teuchos::null; }
 
    //! Get the the index that is stored in this block

--- a/packages/teko/src/Teko_IdentityPreconditionerFactory.cpp
+++ b/packages/teko/src/Teko_IdentityPreconditionerFactory.cpp
@@ -59,7 +59,7 @@ IdentityPreconditionerFactory::IdentityPreconditionerFactory()
   : scaling_(1.0)
 { }
 
-LinearOp IdentityPreconditionerFactory::buildPreconditionerOperator(LinearOp & lo,PreconditionerState & state) const
+LinearOp IdentityPreconditionerFactory::buildPreconditionerOperator(LinearOp & lo,PreconditionerState & /* state */) const
 {
    return Thyra::scale(scaling_,Thyra::identity(rangeSpace(lo)));
 }

--- a/packages/teko/src/Teko_InverseFactory.hpp
+++ b/packages/teko/src/Teko_InverseFactory.hpp
@@ -95,7 +95,7 @@ public:
      * \returns New linear operator that functions as the inverse
      *          of <code>linearOp</code>.
      */
-   virtual InverseLinearOp buildInverse(const LinearOp & linearOp,const LinearOp & precOp) const
+   virtual InverseLinearOp buildInverse(const LinearOp & linearOp,const LinearOp & /* precOp */) const
    { return buildInverse(linearOp); }
 
    #if 0
@@ -158,7 +158,7 @@ public:
      *                        rebuilt using the <code>source</code>
      *                        object.
      */
-   virtual void rebuildInverse(const LinearOp & source,const LinearOp & precOp,InverseLinearOp & dest) const
+   virtual void rebuildInverse(const LinearOp & source,const LinearOp & /* precOp */,InverseLinearOp & dest) const
    { rebuildInverse(source,dest); }
 
    /** \brief A function that permits inspection of the parameters used to create
@@ -204,7 +204,7 @@ public:
      *
      * \note The default implementation returns true (it does nothing!).
      */
-   virtual bool updateRequestedParameters(const Teuchos::ParameterList & pl)
+   virtual bool updateRequestedParameters(const Teuchos::ParameterList & /* pl */)
    { return true; }
 
    //! Set the request handler with pointers to the appropriate callbacks
@@ -257,7 +257,7 @@ public:
      * \returns New linear operator that functions as the inverse
      *          of <code>linearOp</code>.
      */
-   virtual InverseLinearOp buildInverse(const LinearOp & linearOp) const
+   virtual InverseLinearOp buildInverse(const LinearOp & /* linearOp */) const
    { return Teuchos::rcp_const_cast<Thyra::LinearOpBase<double> >(this->inverse_); }
 
    /** \brief Pass in an already constructed inverse operator. Update
@@ -274,7 +274,7 @@ public:
      *                        rebuilt using the <code>source</code>
      *                        object.
      */
-   virtual void rebuildInverse(const LinearOp & source,InverseLinearOp & dest) const
+   virtual void rebuildInverse(const LinearOp & /* source */,InverseLinearOp & /* dest */) const
    { }
 
    /** \brief A function that permits inspection of the parameters used to create

--- a/packages/teko/src/Teko_LU2x2Strategy.hpp
+++ b/packages/teko/src/Teko_LU2x2Strategy.hpp
@@ -127,8 +127,8 @@ public:
      *
      * \note The default implementation does nothing.
      */
-   virtual void initializeFromParameterList(const Teuchos::ParameterList & settings,
-                                            const InverseLibrary & invLib)
+   virtual void initializeFromParameterList(const Teuchos::ParameterList & /* settings */,
+                                            const InverseLibrary & /* invLib */)
    { }
 
    /** \brief Request the additional parameters this preconditioner factory
@@ -161,7 +161,7 @@ public:
      *
      * \note The default implementation returns true (it does nothing!).
      */
-   virtual bool updateRequestedParameters(const Teuchos::ParameterList & pl)
+   virtual bool updateRequestedParameters(const Teuchos::ParameterList & /* pl */)
    { return true; }
 
    //! This method sets the request handler for this object
@@ -208,17 +208,17 @@ public:
 
    /** returns a static (approximate) inverse of F */
    virtual const Teko::LinearOp
-   getHatInvA00(const Teko::BlockedLinearOp & A,BlockPreconditionerState & state) const
+   getHatInvA00(const Teko::BlockedLinearOp & /* A */,BlockPreconditionerState & /* state */) const
    { return hatInvA00_; }
 
    /** returns a static (approximate) inverse of F */
    virtual const Teko::LinearOp
-   getTildeInvA00(const Teko::BlockedLinearOp & A,BlockPreconditionerState & state) const
+   getTildeInvA00(const Teko::BlockedLinearOp & /* A */,BlockPreconditionerState & /* state */) const
    { return tildeInvA00_; }
 
    /** returns a static (approximate) inverse of S = -D + L*inv(F)*U */
    virtual const Teko::LinearOp
-   getInvS(const Teko::BlockedLinearOp & A,BlockPreconditionerState & state) const
+   getInvS(const Teko::BlockedLinearOp & /* A */,BlockPreconditionerState & /* state */) const
    { return invS_; }
 
    //@}

--- a/packages/teko/src/Teko_MultPreconditionerFactory.cpp
+++ b/packages/teko/src/Teko_MultPreconditionerFactory.cpp
@@ -51,7 +51,7 @@ namespace Teko {
 using Teuchos::RCP;
 
 void MultPrecsLinearOp::implicitApply(const Teko::BlockedMultiVector & r, Teko::BlockedMultiVector & y,
-                     const double alpha, const double beta) const 
+                     const double /* alpha */, const double /* beta */) const 
 { 
    // Casting is a bit delicate. We basically use 
    //

--- a/packages/teko/src/Teko_NeumannSeriesPreconditionerFactory.hpp
+++ b/packages/teko/src/Teko_NeumannSeriesPreconditionerFactory.hpp
@@ -74,7 +74,7 @@ NeumannSeriesPreconditionerFactory<ScalarT>::NeumannSeriesPreconditionerFactory(
 
 //! is this operator compatiable with the preconditioner factory?
 template <typename ScalarT>
-bool NeumannSeriesPreconditionerFactory<ScalarT>::isCompatible(const Thyra::LinearOpSourceBase<ScalarT> &fwdOpSrc) const
+bool NeumannSeriesPreconditionerFactory<ScalarT>::isCompatible(const Thyra::LinearOpSourceBase<ScalarT> &/* fwdOpSrc */) const
 {
    return true;
 }
@@ -97,7 +97,7 @@ RCP<Thyra::PreconditionerBase<ScalarT> > NeumannSeriesPreconditionerFactory<Scal
 template <typename ScalarT>
 void NeumannSeriesPreconditionerFactory<ScalarT>::initializePrec(const RCP<const Thyra::LinearOpSourceBase<ScalarT> > & fwdOpSrc,
                     Thyra::PreconditionerBase<ScalarT> * prec,
-                    const Thyra::ESupportSolveUse supportSolveUse) const
+                    const Thyra::ESupportSolveUse /* supportSolveUse */) const
 {
    using Thyra::scale;
    using Thyra::add;
@@ -141,8 +141,8 @@ void NeumannSeriesPreconditionerFactory<ScalarT>::initializePrec(const RCP<const
 //! wipe clean a already initialized preconditioner object
 template <typename ScalarT>
 void NeumannSeriesPreconditionerFactory<ScalarT>::uninitializePrec(Thyra::PreconditionerBase<ScalarT> * prec, 
-                      RCP<const Thyra::LinearOpSourceBase<ScalarT> > * fwdOpSrc,
-                      Thyra::ESupportSolveUse *supportSolveUse) const
+                      RCP<const Thyra::LinearOpSourceBase<ScalarT> > * /* fwdOpSrc */,
+                      Thyra::ESupportSolveUse * /* supportSolveUse */) const
 {
    Thyra::DefaultPreconditioner<ScalarT> & dPrec = Teuchos::dyn_cast<Thyra::DefaultPreconditioner<ScalarT> >(*prec);
  

--- a/packages/teko/src/Teko_PreconditionerFactory.cpp
+++ b/packages/teko/src/Teko_PreconditionerFactory.cpp
@@ -101,7 +101,7 @@ RCP<Thyra::PreconditionerBase<double> > PreconditionerFactory::createPrec() cons
 //! initialize a newly created preconditioner object
 void PreconditionerFactory::initializePrec(const RCP<const LinearOpSourceBase<double> > & ASrc,
                     PreconditionerBase<double> * prec,
-                    const ESupportSolveUse supportSolveUse) const
+                    const ESupportSolveUse /* supportSolveUse */) const
 {
    // get the blocked linear operator
    LinearOp A = Teuchos::rcp_const_cast<Thyra::LinearOpBase<double> >(ASrc->getOp());
@@ -137,9 +137,9 @@ void PreconditionerFactory::initializePrec(const RCP<const LinearOpSourceBase<do
 }
 
 //! wipe clean a already initialized preconditioner object
-void PreconditionerFactory::uninitializePrec(PreconditionerBase<double> * prec, 
-                      RCP<const LinearOpSourceBase<double> > * fwdOpSrc,
-                      ESupportSolveUse *supportSolveUse) const
+void PreconditionerFactory::uninitializePrec(PreconditionerBase<double> * /* prec */, 
+                      RCP<const LinearOpSourceBase<double> > * /* fwdOpSrc */,
+                      ESupportSolveUse * /* supportSolveUse */) const
 {
    // Preconditioner * blkPrec = dynamic_cast<Preconditioner *>(prec);
 

--- a/packages/teko/src/Teko_PreconditionerFactory.hpp
+++ b/packages/teko/src/Teko_PreconditionerFactory.hpp
@@ -129,7 +129,7 @@ public:
      *
      * \note The default implementation does nothing.
      */
-   virtual void initializeFromParameterList(const Teuchos::ParameterList & settings)
+   virtual void initializeFromParameterList(const Teuchos::ParameterList & /* settings */)
    { }
 
    /** \brief Request the additional parameters this preconditioner factory
@@ -162,7 +162,7 @@ public:
      *
      * \note The default implementation returns true (it does nothing!).
      */
-   virtual bool updateRequestedParameters(const Teuchos::ParameterList & pl)
+   virtual bool updateRequestedParameters(const Teuchos::ParameterList & /* pl */)
    { return true; }
    
    //@}

--- a/packages/teko/src/Teko_PreconditionerState.cpp
+++ b/packages/teko/src/Teko_PreconditionerState.cpp
@@ -77,7 +77,7 @@ RCP<Teuchos::ParameterList> PreconditionerState::unsetParameterList()
 }
 
 //! Merge internal storage of another PreconditionerState object into this one
-void PreconditionerState::merge(const PreconditionerState & ps,int position)
+void PreconditionerState::merge(const PreconditionerState & ps,int /* position */)
 {
    // merge the two linearOps lists
    linearOps_.insert(ps.linearOps_.begin(),ps.linearOps_.end());

--- a/packages/teko/src/Teko_StratimikosFactory.cpp
+++ b/packages/teko/src/Teko_StratimikosFactory.cpp
@@ -76,7 +76,7 @@ StratimikosFactory::StratimikosFactory(const Teuchos::RCP<Stratimikos::DefaultLi
 
 
 // Overridden from PreconditionerFactoryBase
-bool StratimikosFactory::isCompatible(const Thyra::LinearOpSourceBase<double> &fwdOpSrc) const
+bool StratimikosFactory::isCompatible(const Thyra::LinearOpSourceBase<double> &/* fwdOpSrc */) const
 {
    using Teuchos::outArg;
 
@@ -106,13 +106,13 @@ bool StratimikosFactory::isCompatible(const Thyra::LinearOpSourceBase<double> &f
 }
 
 
-bool StratimikosFactory::applySupportsConj(Thyra::EConj conj) const
+bool StratimikosFactory::applySupportsConj(Thyra::EConj /* conj */) const
 {
   return false;
 }
 
 
-bool StratimikosFactory::applyTransposeSupportsConj(Thyra::EConj conj) const
+bool StratimikosFactory::applyTransposeSupportsConj(Thyra::EConj /* conj */) const
 {
   return false; // See comment below
 }
@@ -142,7 +142,7 @@ void StratimikosFactory::initializePrec(
 void StratimikosFactory::initializePrec_Thyra(
   const Teuchos::RCP<const Thyra::LinearOpSourceBase<double> > &fwdOpSrc,
   Thyra::PreconditionerBase<double> *prec,
-  const Thyra::ESupportSolveUse supportSolveUse
+  const Thyra::ESupportSolveUse /* supportSolveUse */
   ) const
 {
   using Teuchos::RCP;
@@ -244,7 +244,7 @@ void StratimikosFactory::initializePrec_Thyra(
 void StratimikosFactory::initializePrec_Epetra(
   const Teuchos::RCP<const Thyra::LinearOpSourceBase<double> > &fwdOpSrc,
   Thyra::PreconditionerBase<double> *prec,
-  const Thyra::ESupportSolveUse supportSolveUse
+  const Thyra::ESupportSolveUse /* supportSolveUse */
   ) const
 {
   using Teuchos::outArg;
@@ -405,9 +405,9 @@ void StratimikosFactory::initializePrec_Epetra(
 
 
 void StratimikosFactory::uninitializePrec(
-  Thyra::PreconditionerBase<double> *prec,
-  Teuchos::RCP<const Thyra::LinearOpSourceBase<double> > *fwdOp,
-  Thyra::ESupportSolveUse *supportSolveUse
+  Thyra::PreconditionerBase<double> * /* prec */,
+  Teuchos::RCP<const Thyra::LinearOpSourceBase<double> > * /* fwdOp */,
+  Thyra::ESupportSolveUse * /* supportSolveUse */
   ) const
 {
   TEUCHOS_TEST_FOR_EXCEPT(true);

--- a/packages/teko/src/Teko_Utilities.cpp
+++ b/packages/teko/src/Teko_Utilities.cpp
@@ -2488,6 +2488,8 @@ LinearOp probe(Teuchos::RCP<const Epetra_CrsGraph> &G,const LinearOp & Op){
   prober.probe(Mwrap,*Mat);
   return Thyra::epetraLinearOp(Mat);    
 #else
+  (void)G;
+  (void)Op;
   TEUCHOS_TEST_FOR_EXCEPTION(true,std::runtime_error,"Probe requires Isorropia");
 #endif
 }

--- a/packages/teko/src/Tpetra/Teko_BlockedTpetraOperator.hpp
+++ b/packages/teko/src/Tpetra/Teko_BlockedTpetraOperator.hpp
@@ -128,10 +128,10 @@ public:
    // attribute set methods
    
    // don't use transpose...ever!
-   virtual int SetUseTranspose(bool useTranspose)
+   virtual int SetUseTranspose(bool /* useTranspose */)
    { return -1; }
 
-   virtual int ApplyInverse(const Tpetra::MultiVector<ST,LO,GO,NT> &X, Tpetra::MultiVector<ST,LO,GO,NT> &Y) const
+   virtual int ApplyInverse(const Tpetra::MultiVector<ST,LO,GO,NT> &/* X */, Tpetra::MultiVector<ST,LO,GO,NT> &/* Y */) const
    { TEUCHOS_ASSERT(false); return -1; }
 
    virtual double NormInf() const

--- a/packages/teko/src/Tpetra/Teko_StridedTpetraOperator.hpp
+++ b/packages/teko/src/Tpetra/Teko_StridedTpetraOperator.hpp
@@ -116,10 +116,10 @@ public:
    // attribute set methods
    
    // don't use transpose...ever!
-   virtual int SetUseTranspose(bool useTranspose)
+   virtual int SetUseTranspose(bool /* useTranspose */)
    { return -1; }
 
-   virtual int applyInverse(const Tpetra::MultiVector<ST,LO,GO,NT>  &X, Tpetra::MultiVector<ST,LO,GO,NT>  &Y) const
+   virtual int applyInverse(const Tpetra::MultiVector<ST,LO,GO,NT>  &/* X */, Tpetra::MultiVector<ST,LO,GO,NT>  &/* Y */) const
    { TEUCHOS_ASSERT(false); return -1; }
 
    virtual ST NormInf() const

--- a/packages/teko/src/Tpetra/Teko_TpetraBasicMappingStrategy.cpp
+++ b/packages/teko/src/Tpetra/Teko_TpetraBasicMappingStrategy.cpp
@@ -68,7 +68,7 @@ namespace TpetraHelpers {
 //       comm - Epetra_Comm object related to the map
 //
 BasicMappingStrategy::BasicMappingStrategy(const Teuchos::RCP<const Tpetra::Map<LO,GO,NT> > & rMap,
-                                           const Teuchos::RCP<const Tpetra::Map<LO,GO,NT> > & dMap, const Teuchos::Comm<Thyra::Ordinal> & comm)
+                                           const Teuchos::RCP<const Tpetra::Map<LO,GO,NT> > & dMap, const Teuchos::Comm<Thyra::Ordinal> & /* comm */)
 {
    rangeMap_ = rMap;
    domainMap_ = dMap;

--- a/packages/teko/src/Tpetra/Teko_TpetraHelpers.hpp
+++ b/packages/teko/src/Tpetra/Teko_TpetraHelpers.hpp
@@ -192,7 +192,7 @@ public:
    void apply(const Tpetra::MultiVector<ST,LO,GO,NT> & X, Tpetra::MultiVector<ST,LO,GO,NT> & Y, Teuchos::ETransp mode=Teuchos::NO_TRANS, ST alpha=Teuchos::ScalarTraits< ST >::one(), ST beta=Teuchos::ScalarTraits< ST >::zero()) const;
 
    //! Can't call ApplyInverse on a zeroed operator
-   void applyInverse(const Tpetra::MultiVector<ST,LO,GO,NT>& X, Tpetra::MultiVector<ST,LO,GO,NT>& Y, Teuchos::ETransp mode=Teuchos::NO_TRANS, ST alpha=Teuchos::ScalarTraits< ST >::one(), ST beta=Teuchos::ScalarTraits< ST >::zero()) const
+   void applyInverse(const Tpetra::MultiVector<ST,LO,GO,NT>& /* X */, Tpetra::MultiVector<ST,LO,GO,NT>& /* Y */, Teuchos::ETransp /* mode */=Teuchos::NO_TRANS, ST /* alpha */=Teuchos::ScalarTraits< ST >::one(), ST /* beta */=Teuchos::ScalarTraits< ST >::zero()) const
    { TEUCHOS_TEST_FOR_EXCEPTION(true,std::runtime_error,"Can't call applyInverse on a ZeroedOperator"); }
 
    //!

--- a/packages/teko/src/Tpetra/Teko_TpetraInverseFactoryOperator.cpp
+++ b/packages/teko/src/Tpetra/Teko_TpetraInverseFactoryOperator.cpp
@@ -133,7 +133,7 @@ void InverseFactoryOperator::buildInverseOperator(const Teuchos::RCP<const Tpetr
    TEUCHOS_ASSERT(firstBuildComplete_==true);
 }
 
-void InverseFactoryOperator::buildInverseOperator(const Teuchos::RCP<Tpetra::Operator<ST,LO,GO,NT> > & A,bool clear)
+void InverseFactoryOperator::buildInverseOperator(const Teuchos::RCP<Tpetra::Operator<ST,LO,GO,NT> > & A,bool /* clear */)
 {
    setConstFwdOp_ = false;
 

--- a/packages/teko/src/Tpetra/Teko_TpetraOperatorWrapper.cpp
+++ b/packages/teko/src/Tpetra/Teko_TpetraOperatorWrapper.cpp
@@ -134,7 +134,7 @@ double TpetraOperatorWrapper::NormInf() const
   return 1.0;
 }
 
-void TpetraOperatorWrapper::apply(const Tpetra::MultiVector<ST,LO,GO,NT>& X, Tpetra::MultiVector<ST,LO,GO,NT>& Y,Teuchos::ETransp mode,ST alpha, ST beta) const
+void TpetraOperatorWrapper::apply(const Tpetra::MultiVector<ST,LO,GO,NT>& X, Tpetra::MultiVector<ST,LO,GO,NT>& Y,Teuchos::ETransp /* mode */,ST alpha, ST beta) const
 {
    if (!useTranspose_)
    {
@@ -165,8 +165,8 @@ void TpetraOperatorWrapper::apply(const Tpetra::MultiVector<ST,LO,GO,NT>& X, Tpe
 }
 
 
-void TpetraOperatorWrapper::applyInverse(const Tpetra::MultiVector<ST,LO,GO,NT>& X, 
-                                      Tpetra::MultiVector<ST,LO,GO,NT>& Y, Teuchos::ETransp mode, ST alpha, ST beta) const
+void TpetraOperatorWrapper::applyInverse(const Tpetra::MultiVector<ST,LO,GO,NT>& /* X */, 
+                                      Tpetra::MultiVector<ST,LO,GO,NT>& /* Y */, Teuchos::ETransp /* mode */, ST /* alpha */, ST /* beta */) const
 {
   TEUCHOS_TEST_FOR_EXCEPTION(true, std::runtime_error,
                      "TpetraOperatorWrapper::applyInverse not implemented");

--- a/packages/teko/src/Tpetra/Teko_TpetraThyraConverter.cpp
+++ b/packages/teko/src/Tpetra/Teko_TpetraThyraConverter.cpp
@@ -273,7 +273,7 @@ void thyraVSToTpetraMap(std::vector<GO> & myIndicies, int blockOffset, const Thy
 }
 
 // From a Thyra vector space create a compatable Tpetra_Map
-const RCP<Tpetra::Map<LO,GO,NT> > thyraVSToTpetraMap(const Thyra::VectorSpaceBase<ST> & vs,const RCP<const Teuchos::Comm<Thyra::Ordinal> > & comm)
+const RCP<Tpetra::Map<LO,GO,NT> > thyraVSToTpetraMap(const Thyra::VectorSpaceBase<ST> & vs,const RCP<const Teuchos::Comm<Thyra::Ordinal> > & /* comm */)
 {
    int localDim = 0;
    std::vector<GO> myGIDs;


### PR DESCRIPTION
@trilinos/teko 

## Description
Comment out parameter names in function definitions to avoid
`-Wunused-parameter` warnings.

## Motivation and Context
Clean build.