### PR TITLE
ML:  Remove Unused Parameter Warnings

### DIFF
--- a/packages/ml/src/Coarsen/ml_agg_min_energy.cpp
+++ b/packages/ml/src/Coarsen/ml_agg_min_energy.cpp
@@ -1700,7 +1700,7 @@ ML_Operator * ML_ODE_Strength_Matrix(ML_Operator * A, int num_steps, double t_fi
 // ---- Output----
 // Update is changed so that Update*Bone = 0 with the changes occuring only at allowed non-zeros
 
-void ML_Satisfy_Constraints(ML_Operator *Update, ML_Operator *Pattern, double *Bone, double *BtBinv, int * F, int numPDEs, int numDOFs, int numNodes, int NullDim)
+void ML_Satisfy_Constraints(ML_Operator *Update, ML_Operator *Pattern, double *Bone, double *BtBinv, int * F, int numPDEs, int numDOFs, int /* numNodes */, int NullDim)
 {
   int i, j, k, length, rowstart, rowend, counter, indx, nodeNullDim, node;
   int oneInt = 1;

--- a/packages/ml/src/LevelWrap/ml_LevelWrap.cpp
+++ b/packages/ml/src/LevelWrap/ml_LevelWrap.cpp
@@ -140,7 +140,7 @@ int ML_Epetra::LevelWrap::GenerateSmoother() {
 
 
 // Computes the preconditioner
-int ML_Epetra::LevelWrap::ComputePreconditioner(const bool CheckFiltering){
+int ML_Epetra::LevelWrap::ComputePreconditioner(const bool /* CheckFiltering */){
 #ifdef ML_TIMING
   double t_time,t_diff;
   StartTimer(&t_time);
@@ -304,7 +304,7 @@ int ML_Epetra::LevelWrap::ApplyInverse(const Epetra_MultiVector& B, Epetra_Multi
 
 
 // Print the individual operators in the multigrid hierarchy.
-void ML_Epetra::LevelWrap::Print(int level){
+void ML_Epetra::LevelWrap::Print(int /* level */){
   if(A1prec_!=Teuchos::null) A1prec_->Print(-1);
 }
 

--- a/packages/ml/src/LevelWrap/ml_LevelWrap.h
+++ b/packages/ml/src/LevelWrap/ml_LevelWrap.h
@@ -68,7 +68,7 @@ namespace ML_Epetra
     //@{ \name Mathematical functions.
 
     //! Apply the inverse of the preconditioner to an Epetra_MultiVector (NOT AVAILABLE)
-    int Apply(const Epetra_MultiVector& X, Epetra_MultiVector& Y) const {
+    int Apply(const Epetra_MultiVector& /* X */, Epetra_MultiVector& /* Y */) const {
       return(-1);}
 
     //! Apply the preconditioner w/ RHS B and get result X

--- a/packages/ml/src/MLAPI/MLAPI_DistributedMatrix.cpp
+++ b/packages/ml/src/MLAPI/MLAPI_DistributedMatrix.cpp
@@ -20,7 +20,7 @@
 #include <iomanip>
 
 std::ostream& MLAPI::DistributedMatrix::
-Print(std::ostream& os, const bool verbose) const
+Print(std::ostream& os, const bool /* verbose */) const
 {
   if (GetMyPID() == 0) {
 

--- a/packages/ml/src/MLAPI/MLAPI_DistributedMatrix.h
+++ b/packages/ml/src/MLAPI/MLAPI_DistributedMatrix.h
@@ -341,11 +341,11 @@ public:
 
 private:
 
-  DistributedMatrix(const DistributedMatrix& rhs)
+  DistributedMatrix(const DistributedMatrix& /* rhs */)
   {
   }
 
-  DistributedMatrix& operator=(const DistributedMatrix& rhs)
+  DistributedMatrix& operator=(const DistributedMatrix& /* rhs */)
   {
     return(*this);
   }

--- a/packages/ml/src/MLAPI/MLAPI_Eig.cpp
+++ b/packages/ml/src/MLAPI/MLAPI_Eig.cpp
@@ -86,6 +86,8 @@ double MaxEigAnasazi(const Operator& Op, const bool DiagonalScaling)
   ML_Anasazi_Get_SpectralNorm_Anasazi(Op.GetML_Operator(), 0, 10, 1e-5,
                                       ML_FALSE, DiagScal, &MaxEigen);
 #else
+  (void)Op;
+  (void)DiagonalScaling;
   //ML_THROW("Configure w/ --enable-epetra --enable-anasazi --enable-teuchos", -1);
   ML_THROW("Anasazi is no longer supported", -1);
 #endif

--- a/packages/ml/src/MLAPI/MLAPI_EpetraBaseOperator.h
+++ b/packages/ml/src/MLAPI/MLAPI_EpetraBaseOperator.h
@@ -63,7 +63,7 @@ public:
   }
 
   //! Sets the use of tranpose (NOT IMPLEMENTED).
-  virtual int SetUseTranspose(bool UseTransposeFlag)
+  virtual int SetUseTranspose(bool /* UseTransposeFlag */)
   {
     ML_CHK_ERR(-1);
   }
@@ -163,7 +163,7 @@ private:
   { }
 
   //! operator= (should not be used).
-  EpetraBaseOperator& operator=(const EpetraBaseOperator& rhs)
+  EpetraBaseOperator& operator=(const EpetraBaseOperator& /* rhs */)
   {
     return(*this);
   }

--- a/packages/ml/src/MLAPI/MLAPI_Gallery.cpp
+++ b/packages/ml/src/MLAPI/MLAPI_Gallery.cpp
@@ -41,6 +41,8 @@ Operator Gallery(const std::string ProblemType,
 
   return (A);
 #else
+  (void)ProblemType;
+  (void)MySpace;
   ML_THROW("Configure with --enable-galeri", -1);
 #endif
 

--- a/packages/ml/src/MLAPI/MLAPI_InverseOperator.cpp
+++ b/packages/ml/src/MLAPI/MLAPI_InverseOperator.cpp
@@ -386,7 +386,7 @@ InverseOperator::operator()(const MultiVector& LHS,
 }
 
 std::ostream&
-InverseOperator::Print(std::ostream& os, const bool verbose) const
+InverseOperator::Print(std::ostream& os, const bool /* verbose */) const
 {
 
   StackPush();

--- a/packages/ml/src/MLAPI/MLAPI_LoadBalanceInverseOperator.cpp
+++ b/packages/ml/src/MLAPI/MLAPI_LoadBalanceInverseOperator.cpp
@@ -183,7 +183,7 @@ MultiVector LoadBalanceInverseOperator::operator()(const MultiVector& LHS,
   return(RHS2);
 }
 
-std::ostream& LoadBalanceInverseOperator::Print(std::ostream& os, const bool verbose) const
+std::ostream& LoadBalanceInverseOperator::Print(std::ostream& os, const bool /* verbose */) const
 {
 
   StackPush();

--- a/packages/ml/src/MLAPI/MLAPI_MultiVector.h
+++ b/packages/ml/src/MLAPI/MLAPI_MultiVector.h
@@ -75,10 +75,10 @@ public:
   }
 
 private:
-  DoubleVector(const DoubleVector& rhs)
+  DoubleVector(const DoubleVector& /* rhs */)
   {}
 
-  DoubleVector& operator=(const DoubleVector& rhs)
+  DoubleVector& operator=(const DoubleVector& /* rhs */)
   {
     return(*this);
   }
@@ -333,7 +333,7 @@ public:
     return(*this);
   }
 
-  bool operator==(const MultiVector& rhs) const
+  bool operator==(const MultiVector& /* rhs */) const
   {
     return(false);
   }
@@ -939,6 +939,8 @@ private:
     if ((i < 0) || (i >= GetMyLength()))
       ML_THROW("Requested component " + GetString(i) +
                ", while MyLength() = " + GetString(GetMyLength()), -1);
+#else
+    (void)i;
 #endif
   }
 
@@ -949,6 +951,8 @@ private:
     if (v < 0 || v >= GetNumVectors())
       ML_THROW("Requested vector " + GetString(v) +
                ", while NumVectors() = " + GetString(GetNumVectors()), -1);
+#else
+    (void)v;
 #endif
   }
 

--- a/packages/ml/src/MLAPI/MLAPI_Operator_Utils.cpp
+++ b/packages/ml/src/MLAPI/MLAPI_Operator_Utils.cpp
@@ -74,7 +74,7 @@ Operator GetTranspose(const Operator& A, const bool byrow = true)
 }
 
 // ======================================================================
-Operator GetIdentity(const Space& DomainSpace, const Space& RangeSpace)
+Operator GetIdentity(const Space& DomainSpace, const Space& /* RangeSpace */)
 {
   ML_Operator* ML_eye = ML_Operator_Create(GetML_Comm());
   int size = DomainSpace.GetNumMyElements();
@@ -170,7 +170,7 @@ MultiVector GetDiagonal(const Operator& A, const int offset)
 // - the destructor deletes the double vector
 // ======================================================================
 
-static int diag_matvec(ML_Operator *Amat_in, int ilen, double p[],
+static int diag_matvec(ML_Operator *Amat_in, int /* ilen */, double p[],
                 int olen, double ap[])
 {
   double* D = (double*)Amat_in->data;
@@ -284,7 +284,7 @@ Operator GetJacobiIterationOperator(const Operator& Amat, double Damping)
 }
 
 // ======================================================================
-static int Ptent1D_matvec(ML_Operator *Amat_in, int ilen, double p[],
+static int Ptent1D_matvec(ML_Operator *Amat_in, int /* ilen */, double p[],
                 int olen, double ap[])
 {
   double* D = (double*)Amat_in->data;
@@ -321,7 +321,7 @@ static void Ptent1D_destroy(void* data)
 }
 
 // ======================================================================
-Operator GetPtent1D(const MultiVector& D, const int offset = 0)
+Operator GetPtent1D(const MultiVector& D, const int /* offset */ = 0)
 {
   if (D.GetNumVectors() != 1)
     ML_THROW("D.GetNumVectors() != 1", -1);

--- a/packages/ml/src/MatrixFree/ml_MatrixFreePreconditioner.cpp
+++ b/packages/ml/src/MatrixFree/ml_MatrixFreePreconditioner.cpp
@@ -178,14 +178,14 @@ ApplyInverse(const Epetra_MultiVector& B, Epetra_MultiVector& X) const
 
 // ============================================================================
 int ML_Epetra::MatrixFreePreconditioner::
-SetUseTranspose(bool UseTranspose)
+SetUseTranspose(bool /* UseTranspose */)
 {
   ML_RETURN(-1);
 }
 
 // ============================================================================
 int ML_Epetra::MatrixFreePreconditioner::
-Apply(const Epetra_MultiVector& X, Epetra_MultiVector& Y) const
+Apply(const Epetra_MultiVector& /* X */, Epetra_MultiVector& /* Y */) const
 {
   ML_RETURN(-1);
 }
@@ -1069,7 +1069,7 @@ TotalCPUTime() const
 
 // ============================================================================
 int ML_Epetra::MatrixFreePreconditioner::
-GetBlockDiagonal(const Epetra_CrsGraph& Graph, std::string DiagonalColoringType)
+GetBlockDiagonal(const Epetra_CrsGraph& Graph, std::string /* DiagonalColoringType */)
 {
   CrsGraph_MapColoring MapColoringTransform(CrsGraph_MapColoring::JONES_PLASSMAN,
                                             0, true, 0);

--- a/packages/ml/src/RefMaxwell/ml_EdgeMatrixFreePreconditioner.cpp
+++ b/packages/ml/src/RefMaxwell/ml_EdgeMatrixFreePreconditioner.cpp
@@ -78,7 +78,7 @@ ML_Epetra::EdgeMatrixFreePreconditioner::~EdgeMatrixFreePreconditioner(){
 
 // ================================================ ====== ==== ==== == =
 // Computes the preconditioner
-int ML_Epetra::EdgeMatrixFreePreconditioner::ComputePreconditioner(const bool CheckFiltering)
+int ML_Epetra::EdgeMatrixFreePreconditioner::ComputePreconditioner(const bool /* CheckFiltering */)
 {
   Teuchos::ParameterList dummy, ListCoarse;
 
@@ -451,7 +451,7 @@ int  ML_Epetra::EdgeMatrixFreePreconditioner::FormCoarseMatrix()
 
 // ================================================ ====== ==== ==== == =
 // Print the individual operators in the multigrid hierarchy.
-void ML_Epetra::EdgeMatrixFreePreconditioner::Print(int whichHierarchy)
+void ML_Epetra::EdgeMatrixFreePreconditioner::Print(int /* whichHierarchy */)
 {
   /*ofstream ofs("Pmat.edge.m");
     if(Prolongator_) Prolongator_->Print(ofs);*/

--- a/packages/ml/src/RefMaxwell/ml_EdgeMatrixFreePreconditioner.h
+++ b/packages/ml/src/RefMaxwell/ml_EdgeMatrixFreePreconditioner.h
@@ -97,7 +97,7 @@ namespace ML_Epetra
     int ReComputePreconditioner(){return(-1);}
 
     //! Apply the inverse of the preconditioner to an Epetra_MultiVector (NOT AVAILABLE)
-    int Apply(const Epetra_MultiVector& X, Epetra_MultiVector& Y) const {
+    int Apply(const Epetra_MultiVector& /* X */, Epetra_MultiVector& /* Y */) const {
       return(-1);}
 
     //! Apply the preconditioner to RHS B to get result X (X is also initial guess)
@@ -110,7 +110,7 @@ namespace ML_Epetra
     int DestroyPreconditioner();
 
     //! Sets use transpose (not implemented).
-    int SetUseTranspose(bool UseTranspose){return(-1);}
+    int SetUseTranspose(bool /* UseTranspose */){return(-1);}
 
     //! Returns the infinity norm (not implemented).
     double NormInf() const {return(0.0);};

--- a/packages/ml/src/RefMaxwell/ml_FaceMatrixFreePreconditioner.cpp
+++ b/packages/ml/src/RefMaxwell/ml_FaceMatrixFreePreconditioner.cpp
@@ -93,7 +93,7 @@ ML_Epetra::FaceMatrixFreePreconditioner::~FaceMatrixFreePreconditioner(){
 
 // ================================================ ====== ==== ==== == =
 // Computes the preconditioner
-int ML_Epetra::FaceMatrixFreePreconditioner::ComputePreconditioner(const bool CheckFiltering)
+int ML_Epetra::FaceMatrixFreePreconditioner::ComputePreconditioner(const bool /* CheckFiltering */)
 {
   Teuchos::ParameterList & ListCoarse=List_.sublist("face matrix free: coarse");
 
@@ -441,7 +441,7 @@ int  ML_Epetra::FaceMatrixFreePreconditioner::FormCoarseMatrix()
 
 // ================================================ ====== ==== ==== == =
 // Print the individual operators in the multigrid hierarchy.
-void ML_Epetra::FaceMatrixFreePreconditioner::Print(int whichHierarchy)
+void ML_Epetra::FaceMatrixFreePreconditioner::Print(int /* whichHierarchy */)
 {
   if(CoarsePC) CoarsePC->Print();
 }/*end Print*/

--- a/packages/ml/src/RefMaxwell/ml_FaceMatrixFreePreconditioner.h
+++ b/packages/ml/src/RefMaxwell/ml_FaceMatrixFreePreconditioner.h
@@ -100,7 +100,7 @@ namespace ML_Epetra
     int ReComputePreconditioner(){return(-1);}
 
     //! Apply the inverse of the preconditioner to an Epetra_MultiVector (NOT AVAILABLE)
-    int Apply(const Epetra_MultiVector& X, Epetra_MultiVector& Y) const {
+    int Apply(const Epetra_MultiVector& /* X */, Epetra_MultiVector& /* Y */) const {
       return(-1);}
 
     //! Apply the preconditioner to RHS B to get result X (X is also initial guess)
@@ -113,7 +113,7 @@ namespace ML_Epetra
     int DestroyPreconditioner();
 
     //! Sets use transpose (not implemented).
-    int SetUseTranspose(bool UseTranspose){return(-1);}
+    int SetUseTranspose(bool /* UseTranspose */){return(-1);}
 
     //! Returns the infinity norm (not implemented).
     double NormInf() const {return(0.0);};

--- a/packages/ml/src/RefMaxwell/ml_GradDiv.cpp
+++ b/packages/ml/src/RefMaxwell/ml_GradDiv.cpp
@@ -72,7 +72,7 @@ ML_Epetra::GradDivPreconditioner::~GradDivPreconditioner()
 
 // ================================================ ====== ==== ==== == =
 // Print the individual operators in the multigrid hierarchy.
-void ML_Epetra::GradDivPreconditioner::Print(int whichHierarchy){
+void ML_Epetra::GradDivPreconditioner::Print(int /* whichHierarchy */){
   //HAQ
   //  if(IsComputePreconditionerOK_ && FacePC && whichHierarchy==11) FacePC->Print(-1);
   //  if(IsComputePreconditionerOK_ && EdgePC && whichHierarchy==22) EdgePC->Print(-1);
@@ -81,7 +81,7 @@ void ML_Epetra::GradDivPreconditioner::Print(int whichHierarchy){
 
 // ================================================ ====== ==== ==== == =
 // Computes the preconditioner
-int ML_Epetra::GradDivPreconditioner::ComputePreconditioner(const bool CheckFiltering)
+int ML_Epetra::GradDivPreconditioner::ComputePreconditioner(const bool /* CheckFiltering */)
 {
 #ifdef ML_TIMING
   double t_time_start, t_time_curr, t_diff[5];

--- a/packages/ml/src/RefMaxwell/ml_GradDiv.h
+++ b/packages/ml/src/RefMaxwell/ml_GradDiv.h
@@ -82,7 +82,7 @@ namespace ML_Epetra
     //@{ \name Mathematical functions.
 
     //! Apply the inverse of the preconditioner to an Epetra_MultiVector (NOT AVAILABLE)
-    int Apply(const Epetra_MultiVector& X, Epetra_MultiVector& Y) const {
+    int Apply(const Epetra_MultiVector& /* X */, Epetra_MultiVector& /* Y */) const {
       return(-1);}
 
     //! Apply the preconditioner w/ RHS B and get result X
@@ -126,7 +126,7 @@ namespace ML_Epetra
     int DestroyPreconditioner();
 
     //! Sets use transpose (not implemented).
-    int SetUseTranspose(bool UseTranspose){return(-1);}
+    int SetUseTranspose(bool /* UseTranspose */){return(-1);}
 
     //! Returns the infinity norm (not implemented).
     double NormInf() const {return(0.0);};

--- a/packages/ml/src/RefMaxwell/ml_RefMaxwell.cpp
+++ b/packages/ml/src/RefMaxwell/ml_RefMaxwell.cpp
@@ -174,7 +174,7 @@ int ML_Epetra::RefMaxwellPreconditioner::ReComputePreconditioner() {
 
 // ================================================ ====== ==== ==== == =
 // Computes the preconditioner
-int ML_Epetra::RefMaxwellPreconditioner::ComputePreconditioner(const bool CheckFiltering)
+int ML_Epetra::RefMaxwellPreconditioner::ComputePreconditioner(const bool /* CheckFiltering */)
 {
 #ifdef ML_TIMING
   double t_time_start, t_time_curr, t_diff[7];

--- a/packages/ml/src/RefMaxwell/ml_RefMaxwell.h
+++ b/packages/ml/src/RefMaxwell/ml_RefMaxwell.h
@@ -100,7 +100,7 @@ namespace ML_Epetra
     //@{ \name Mathematical functions.
 
     //! Apply the inverse of the preconditioner to an Epetra_MultiVector (NOT AVAILABLE)
-    int Apply(const Epetra_MultiVector& X, Epetra_MultiVector& Y) const {
+    int Apply(const Epetra_MultiVector& /* X */, Epetra_MultiVector& /* Y */) const {
       return(-1);}
 
     //! Apply the preconditioner w/ RHS B and get result X
@@ -144,7 +144,7 @@ namespace ML_Epetra
     int DestroyPreconditioner();
 
     //! Sets use transpose (not implemented).
-    int SetUseTranspose(bool UseTranspose){return(-1);}
+    int SetUseTranspose(bool /* UseTranspose */){return(-1);}
 
     //! Returns the infinity norm (not implemented).
     double NormInf() const {return(0.0);};

--- a/packages/ml/src/RefMaxwell/ml_RefMaxwell_11_Operator.h
+++ b/packages/ml/src/RefMaxwell/ml_RefMaxwell_11_Operator.h
@@ -63,7 +63,7 @@ public:
   //@{
 
   //! Sets use transpose (not implemented).
-  virtual int SetUseTranspose(bool UseTranspose){return(-1);}
+  virtual int SetUseTranspose(bool /* UseTranspose */){return(-1);}
 
 
   //@}
@@ -84,7 +84,7 @@ public:
 
   //! Returns the result of a Epetra_Operator inverse applied to an
   //Epetra_MultiVector X in Y. NOT IMPLEMEMENTED!
-  virtual int ApplyInverse(const Epetra_MultiVector& X, Epetra_MultiVector& Y) const {return -1;}
+  virtual int ApplyInverse(const Epetra_MultiVector& /* X */, Epetra_MultiVector& /* Y */) const {return -1;}
 
 
   //! Computes C= <me> * A.  OptimizeStorage *must* be called for both A and the

--- a/packages/ml/src/Utils/Epetra_Multi_CrsMatrix.h
+++ b/packages/ml/src/Utils/Epetra_Multi_CrsMatrix.h
@@ -83,7 +83,7 @@ public:
 
   //! Returns the result of a Epetra_Operator inverse applied to an
   //Epetra_MultiVector X in Y. NOT IMPLEMEMENTED!
-  virtual int ApplyInverse(const Epetra_MultiVector& X, Epetra_MultiVector& Y) const {return -1;}
+  virtual int ApplyInverse(const Epetra_MultiVector& /* X */, Epetra_MultiVector& /* Y */) const {return -1;}
 
 
   //! Computes C= <me> * A

--- a/packages/ml/src/Utils/ml_DD_prec.cpp
+++ b/packages/ml/src/Utils/ml_DD_prec.cpp
@@ -12,8 +12,8 @@ extern "C" {
 #endif
 
 double ML_DD_OneLevel(ML_1Level *curr, double *sol, double *rhs,
-			int approx_all_zeros, ML_Comm *comm,
-			    int res_norm_or_not, ML *ml)
+			int approx_all_zeros, ML_Comm * /* comm */,
+			    int /* res_norm_or_not */, ML * /* ml */)
 {
 
   ML_Smoother * post = curr->post_smoother;
@@ -29,8 +29,8 @@ double ML_DD_OneLevel(ML_1Level *curr, double *sol, double *rhs,
 } /* ML_DD_OneLevel */
 
 double ML_DD_Additive(ML_1Level *curr, double *sol, double *rhs,
-			  int approx_all_zeros, ML_Comm *comm,
-			  int res_norm_or_not, ML *ml)
+			  int approx_all_zeros, ML_Comm * /* comm */,
+			  int /* res_norm_or_not */, ML * /* ml */)
 {
 
   ML_Operator * Amat = curr->Amat;
@@ -65,8 +65,8 @@ double ML_DD_Additive(ML_1Level *curr, double *sol, double *rhs,
 
 
 double ML_DD_Hybrid(ML_1Level *curr, double *sol, double *rhs,
-		    int approx_all_zeros, ML_Comm *comm,
-		    int res_norm_or_not, ML *ml)
+		    int approx_all_zeros, ML_Comm * /* comm */,
+		    int /* res_norm_or_not */, ML * /* ml */)
 {
 
   ML_Operator *Amat, *Rmat;
@@ -128,8 +128,8 @@ double ML_DD_Hybrid(ML_1Level *curr, double *sol, double *rhs,
 
 
 double ML_DD_Hybrid_2(ML_1Level *curr, double *sol, double *rhs,
-		      int approx_all_zeros, ML_Comm *comm,
-		      int res_norm_or_not, ML *ml)
+		      int approx_all_zeros, ML_Comm * /* comm */,
+		      int /* res_norm_or_not */, ML * /* ml */)
 {
   ML_Operator *Amat, *Rmat;
   ML_Smoother *pre,  *post;

--- a/packages/ml/src/Utils/ml_Ifpack_ML.h
+++ b/packages/ml/src/Utils/ml_Ifpack_ML.h
@@ -103,10 +103,10 @@ public:
   }
 
   //! Computes the condition number estimate, returns its value.
-  virtual double Condest(const Ifpack_CondestType CT = Ifpack_Cheap,
-                         const int MaxIters = 1550,
-                         const double Tol = 1e-9,
-                         Epetra_RowMatrix* matrix = 0)
+  virtual double Condest(const Ifpack_CondestType /* CT */ = Ifpack_Cheap,
+                         const int /* MaxIters */ = 1550,
+                         const double /* Tol */ = 1e-9,
+                         Epetra_RowMatrix* /* matrix */ = 0)
   {
     return(-1.0);
   }

--- a/packages/ml/src/Utils/ml_MultiLevelOperator.h
+++ b/packages/ml/src/Utils/ml_MultiLevelOperator.h
@@ -118,7 +118,7 @@ class MultiLevelOperator: public virtual Epetra_Operator {
     \param Y (Out) -A Epetra_MultiVector of dimension NumVectors containing result.
     \warning - This method has no effect and returns -1 as error code.
   */
-  int Apply(const Epetra_MultiVector& X, Epetra_MultiVector& Y) const {
+  int Apply(const Epetra_MultiVector& /* X */, Epetra_MultiVector& /* Y */) const {
     return(-1);}
 
   //! Returns the result of a Operator inverse applied to an Epetra_MultiVector X in Y.
@@ -191,7 +191,7 @@ class MultiLevelOperator: public virtual Epetra_Operator {
   { }
 
   //! Operator= (NOT DEFINED)
-  MultiLevelOperator& operator=(const MultiLevelOperator& RHS)
+  MultiLevelOperator& operator=(const MultiLevelOperator& /* RHS */)
   {
     return(*this);
   }

--- a/packages/ml/src/Utils/ml_MultiLevelPreconditioner.cpp
+++ b/packages/ml/src/Utils/ml_MultiLevelPreconditioner.cpp
@@ -4860,7 +4860,7 @@ int MLvariableDofAmalg(int nCols, const MLVec<int>& rowPtr,
                      int nNodes, int maxDofPerNode, const MLVec<int>& map,
                      const MLVec<double>& diag, double tol,
                      MLVec<int>& amalgRowPtr, MLVec<int>& amalgCols,
-                     struct wrappedCommStruct &framework,
+                     struct wrappedCommStruct &/* framework */,
                      MLVec<int>& myLocalNodeIds)
 {
 /******************************************************************************
@@ -5161,7 +5161,7 @@ int MLunamalgP(const MLVec<int>& amalgRowPtr, const MLVec<int>& amalgCols, const
    return(rowCount);
 }
 
-int MLfindEmptyRows(const MLVec<int>& rowPtr, const MLVec<int>& cols, const MLVec<double>& vals, MLVec<bool>& rowEmpty)
+int MLfindEmptyRows(const MLVec<int>& rowPtr, const MLVec<int>& /* cols */, const MLVec<double>& vals, MLVec<bool>& rowEmpty)
 {
 /******************************************************************************
   Find rows that have no nonzero entries.
@@ -5317,7 +5317,7 @@ int MLsortCols(const MLVec<int>& ARowPtr, MLVec<int>& ACols, MLVec<double>& AVal
  * the comments to buildCompressedA().
  */
 /****************************************************************************/
-int MergeShared(MLVec<int>& cols, MLVec<int>& rowZeros, MLVec<int>& colZeros,
+int MergeShared(MLVec<int>& /* cols */, MLVec<int>& rowZeros, MLVec<int>& colZeros,
                 MLVec<int>& groupHead, MLVec<int>& groupNext)
 {
    int vertOne, vertTwo, vertOneHead;

--- a/packages/ml/src/Utils/ml_MultiLevelPreconditioner.h
+++ b/packages/ml/src/Utils/ml_MultiLevelPreconditioner.h
@@ -438,7 +438,7 @@ public:
   //@{ \name Mathematical functions.
 
   //! Apply the inverse of the preconditioner to an Epetra_MultiVector (NOT AVAILABLE)
-  int Apply(const Epetra_MultiVector& X, Epetra_MultiVector& Y) const {
+  int Apply(const Epetra_MultiVector& /* X */, Epetra_MultiVector& /* Y */) const {
     return(-1);}
 
   //! Apply the preconditioner to an Epetra_MultiVector X, puts the result in Y
@@ -497,7 +497,7 @@ public:
   int SetOwnership(bool ownership){ ownership_ = ownership; return(-1);};
 
   //! Sets use transpose (not implemented).
-  int SetUseTranspose(bool useTranspose){return(-1);}
+  int SetUseTranspose(bool /* useTranspose */){return(-1);}
 
   //! Returns the infinity norm (not implemented).
   double NormInf() const {return(0.0);};
@@ -645,11 +645,11 @@ public:
 private:
 
   //! Copy constructor (NOT DEFINED)
-  MultiLevelPreconditioner(const MultiLevelPreconditioner & rhs)
+  MultiLevelPreconditioner(const MultiLevelPreconditioner & /* rhs */)
   {};
 
   //! operator = (NOT DEFINED)
-  MultiLevelPreconditioner & operator = (const MultiLevelPreconditioner & rhs)
+  MultiLevelPreconditioner & operator = (const MultiLevelPreconditioner & /* rhs */)
   {
     return *this;
   };

--- a/packages/ml/src/Utils/ml_MultiLevelPreconditioner_Defaults.cpp
+++ b/packages/ml/src/Utils/ml_MultiLevelPreconditioner_Defaults.cpp
@@ -104,8 +104,8 @@ void ML_OverwriteDefaults(ParameterList &inList, ParameterList &List,bool OverWr
         - \c "coarse: max size" \c = \c 128
  */
 int ML_Epetra::SetDefaultsSA(ParameterList & inList,
-                 Teuchos::RCP<std::vector<int> > &options,
-                 Teuchos::RCP<std::vector<double> > &params,
+                 Teuchos::RCP<std::vector<int> > &/* options */,
+                 Teuchos::RCP<std::vector<double> > &/* params */,
                  bool OverWrite)
 {
   ParameterList List;
@@ -301,8 +301,8 @@ int ML_Epetra::SetDefaultsDD_3Levels(ParameterList & inList,
        - \c "coarse: max size" \c = \c 128
  */
 int ML_Epetra::SetDefaultsMaxwell(ParameterList & inList,
-                 Teuchos::RCP<std::vector<int> > &options,
-                 Teuchos::RCP<std::vector<double> > &params,
+                 Teuchos::RCP<std::vector<int> > &/* options */,
+                 Teuchos::RCP<std::vector<double> > &/* params */,
                  bool OverWrite)
 {
   ParameterList List;
@@ -365,8 +365,8 @@ int ML_Epetra::SetDefaultsMaxwell(ParameterList & inList,
         - \c "coarse: max size" \c = \c 256
  */
 int ML_Epetra::SetDefaultsNSSA(ParameterList & inList,
-                 Teuchos::RCP<std::vector<int> > &options,
-                 Teuchos::RCP<std::vector<double> > &params,
+                 Teuchos::RCP<std::vector<int> > &/* options */,
+                 Teuchos::RCP<std::vector<double> > &/* params */,
                  bool OverWrite)
 {
   ParameterList List;

--- a/packages/ml/src/Utils/ml_RowMatrix.h
+++ b/packages/ml/src/Utils/ml_RowMatrix.h
@@ -137,8 +137,8 @@ class RowMatrix : public virtual Epetra_RowMatrix {
 
     \return Integer error code, set to 0 if successful.
   */
-    virtual int Solve(bool Upper, bool Trans, bool UnitDiagonal, const Epetra_MultiVector& X,
-		      Epetra_MultiVector& Y) const
+    virtual int Solve(bool /* Upper */, bool /* Trans */, bool /* UnitDiagonal */, const Epetra_MultiVector& /* X */,
+		      Epetra_MultiVector& /* Y */) const
     {
       ML_RETURN(-1); // not implemented
     }
@@ -149,8 +149,8 @@ class RowMatrix : public virtual Epetra_RowMatrix {
       ML_RETURN(Multiply(false,X,Y));
     }
 
-    virtual int ApplyInverse(const Epetra_MultiVector& X,
-			     Epetra_MultiVector& Y) const
+    virtual int ApplyInverse(const Epetra_MultiVector& /* X */,
+			     Epetra_MultiVector& /* Y */) const
     {
       ML_RETURN(-1);
     }
@@ -165,7 +165,7 @@ class RowMatrix : public virtual Epetra_RowMatrix {
 
     \return Integer error code, set to 0 if successful.
   */
-    virtual int InvRowSums(Epetra_Vector& x) const
+    virtual int InvRowSums(Epetra_Vector& /* x */) const
     {
       ML_RETURN(-1); // not implemented
     }
@@ -178,7 +178,7 @@ class RowMatrix : public virtual Epetra_RowMatrix {
 
     \return Integer error code, set to 0 if successful.
   */
-    virtual int LeftScale(const Epetra_Vector& x)
+    virtual int LeftScale(const Epetra_Vector& /* x */)
     {
       ML_RETURN(-1); // not implemented
     }
@@ -194,7 +194,7 @@ class RowMatrix : public virtual Epetra_RowMatrix {
 
     \return Integer error code, set to 0 if successful.
   */
-    virtual int InvColSums(Epetra_Vector& x) const
+    virtual int InvColSums(Epetra_Vector& /* x */) const
     {
       ML_RETURN(-1); // not implemented
     }
@@ -208,7 +208,7 @@ class RowMatrix : public virtual Epetra_RowMatrix {
 
     \return Integer error code, set to 0 if successful.
   */
-    virtual int RightScale(const Epetra_Vector& x)
+    virtual int RightScale(const Epetra_Vector& /* x */)
     {
       ML_RETURN(-1); // not implemented
     }
@@ -295,10 +295,10 @@ class RowMatrix : public virtual Epetra_RowMatrix {
   // following functions are required to derive Epetra_RowMatrix objects.
 
   //! Sets ownership.
-  int SetOwnership(bool ownership){return(-1);};
+  int SetOwnership(bool /* ownership */){return(-1);};
 
   //! Sets use transpose (not implemented).
-  int SetUseTranspose(bool UseTransposeFlag){return(-1);}
+  int SetUseTranspose(bool /* UseTransposeFlag */){return(-1);}
 
   //! Returns the current UseTranspose setting.
   bool UseTranspose() const {return(false);};

--- a/packages/ml/src/Utils/ml_epetra_utils.cpp
+++ b/packages/ml/src/Utils/ml_epetra_utils.cpp
@@ -118,7 +118,7 @@ int Epetra_ML_GetCrsDataptrs(ML_Operator *mlA, double **values, int **cols,
      return ierr;
 } //Epetra_ML_GetCrsDataptrs()
 
-int ML_Epetra_matvec(ML_Operator *data, int in, double *p, int out, double *ap)
+int ML_Epetra_matvec(ML_Operator *data, int /* in */, double *p, int /* out */, double *ap)
 {
   ML_Operator *mat_in;
 
@@ -148,8 +148,8 @@ int ML_Epetra_matvec(ML_Operator *data, int in, double *p, int out, double *ap)
 
 // ======================================================================
 
-int ML_Epetra_CrsMatrix_matvec(ML_Operator *data, int in, double *p,
-                                                  int out, double *ap)
+int ML_Epetra_CrsMatrix_matvec(ML_Operator *data, int /* in */, double *p,
+                                                  int /* out */, double *ap)
 {
   ML_Operator *mat_in;
 
@@ -178,8 +178,8 @@ int ML_Epetra_CrsMatrix_matvec(ML_Operator *data, int in, double *p,
 
 // ======================================================================
 
-int ML_Epetra_VbrMatrix_matvec(ML_Operator *data, int in, double *p,
-                                                  int out, double *ap)
+int ML_Epetra_VbrMatrix_matvec(ML_Operator *data, int /* in */, double *p,
+                                                  int /* out */, double *ap)
 {
   ML_Operator *mat_in;
 
@@ -197,8 +197,8 @@ int ML_Epetra_VbrMatrix_matvec(ML_Operator *data, int in, double *p,
 
 // ======================================================================
 
-int ML_Epetra_matvec_Filter(ML_Operator *mat_in, int in, double *p,
-                            int out, double *ap)
+int ML_Epetra_matvec_Filter(ML_Operator *mat_in, int /* in */, double *p,
+                            int /* out */, double *ap)
 {
   Epetra_RowMatrix *A = (Epetra_RowMatrix *) ML_Get_MyMatvecData(mat_in);
   int NumMyRows = A->NumMyRows();
@@ -233,9 +233,9 @@ int ML_Epetra_matvec_Filter(ML_Operator *mat_in, int in, double *p,
 // - ML_Epetra_VbrMatrix_getrow
 // ======================================================================
 
-int ML_Epetra_getrow(ML_Operator *data, int N_requested_rows, int requested_rows[],
-		    int allocated_space, int columns[], double values[],
-		    int row_lengths[])
+int ML_Epetra_getrow(ML_Operator * /* data */, int /* N_requested_rows */, int /* requested_rows */[],
+		    int /* allocated_space */, int /* columns */[], double /* values */[],
+		    int /* row_lengths */[])
 {
 
   std::cout << "Function ML_Epetra_getrow() is no longer supported." << std::endl;
@@ -963,7 +963,7 @@ void Epetra_CrsMatrix_Wrap_ML_Operator(ML_Operator * A, const Epetra_Comm &Comm,
 
 // ======================================================================
 //! Does an P^TAP for Epetra_CrsMatrices using ML's kernels.
-int ML_Epetra::Epetra_PtAP(const Epetra_CrsMatrix & A, const Epetra_CrsMatrix & P, Epetra_CrsMatrix *&Result,bool keep_zero_rows,bool verbose){
+int ML_Epetra::Epetra_PtAP(const Epetra_CrsMatrix & A, const Epetra_CrsMatrix & P, Epetra_CrsMatrix *&Result,bool keep_zero_rows,bool /* verbose */){
 #ifdef HAVE_ML_EPETRAEXT
   Epetra_CrsMatrix AP(Copy,A.RowMap(),0);
   Result = new Epetra_CrsMatrix(Copy,P.DomainMap(),0);
@@ -1423,8 +1423,8 @@ Epetra_RowMatrix* ML_Epetra::ModifyEpetraMatrixColMap(const Epetra_RowMatrix &A,
 
 // ======================================================================
 
-int ML_Epetra_CrsGraph_matvec(ML_Operator *data, int in, double *p,
-                              int out, double *ap)
+int ML_Epetra_CrsGraph_matvec(ML_Operator * /* data */, int /* in */, double * /* p */,
+                              int /* out */, double * /* ap */)
 {
   std::cerr << "ML_Epetra_CrsGraph_matvec() not implemented." << std::endl;
   ML_RETURN(-1);

--- a/packages/ml/src/Utils/ml_ifpack_wrap.cpp
+++ b/packages/ml/src/Utils/ml_ifpack_wrap.cpp
@@ -135,7 +135,7 @@ int ML_Gen_Smoother_Ifpack(ML *ml, const char* Type, int Overlap,
 
 int ML_Ifpack_Gen(ML *ml, const char* Type, int Overlap, int curr_level,
                   Teuchos::ParameterList& List,
-                  const Epetra_Comm& Comm,
+                  const Epetra_Comm& /* Comm */,
                   Ifpack_Handle_Type ** Ifpack_Handle,
                   int reuseSymbolic)
 {


### PR DESCRIPTION
@trilinos/ml 

## Description
Comment out parameter names in function definitions to avoid
`-Wunused-parameter` warnings.

## Motivation and Context
Clean build.