### PR TITLE
Nox: fix brusselator for intel compiler

### DIFF
--- a/packages/nox/test/epetra/LOCA_Brusselator_xyzt/brussXYZT_bdsdt.C
+++ b/packages/nox/test/epetra/LOCA_Brusselator_xyzt/brussXYZT_bdsdt.C
@@ -199,6 +199,9 @@ int main(int argc, char *argv[])
       Teuchos::rcp(new Teuchos::ParameterList);
     getParamList(&(*paramList), MyPID);
 
+    // Enable backtracking
+    paramList->sublist("NOX").sublist("Line Search").set("Method","Polynomial");
+
     // Sublist for "Linear Solver"
     Teuchos::ParameterList& lsParams =
       paramList->sublist("NOX").sublist("Direction").sublist("Newton").sublist("Linear Solver");


### PR DESCRIPTION
Closes #4725 

Test was taking 75 Newton steps to converge. Enabling line search drops this to 23 steps and makes it robust on intel compilers.