### PR TITLE
Tpetra: Fix #4729

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_Behavior.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Behavior.cpp
@@ -1,10 +1,8 @@
 #include "Tpetra_Details_Behavior.hpp"
 #include "TpetraCore_config.h"
 #include <algorithm> // std::transform
-#include <atomic> // std::atomic_thread_fence, std::memory_order_release
 #include <cstdlib> // std::getenv
 #include <cctype> // std::toupper
-#include <mutex> // std::call_once, std::once_flag
 #include <string>
 #include <map>
 #include <vector>
@@ -136,83 +134,31 @@ namespace { // (anonymous)
   }
 
   bool
-  idempotentlyGetEnvironmentVariableAsBool (std::once_flag& once_flag,
-                                            bool& value,
+  idempotentlyGetEnvironmentVariableAsBool (bool& value,
                                             bool& initialized,
                                             const char environmentVariableName[],
                                             const bool defaultValue)
   {
-    // The extra "initialized" check avoids the cost of synchronizing
-    // on the std::call_once for every call to this function.  We want
-    // it to be cheap to get the Boolean value, so that users aren't
-    // tempted to try to cache it themselves.
     if (! initialized) {
-      std::call_once (once_flag, [&] () {
-          value = getEnvironmentVariableAsBool (environmentVariableName,
-                                                defaultValue);
-          // http://preshing.com/20130922/acquire-and-release-fences/
-          //
-          // "A release fence prevents the memory reordering of any
-          // read or write which precedes it in program order with any
-          // write which follows it in program order."
-          //
-          // The point is to prevent the assignment to 'value' from
-          // getting reordered after the assignment to 'initialized'
-          // (the so-called "StoreStore" reordering).  That would be
-          // bad in this case, because then other threads might read
-          // 'initialized' as true, yet would fail to pick up the
-          // change to 'value'.
-          //
-          // It's harmless if other threads don't see the write to
-          // 'initialized', but did see the write to 'value'.  In that
-          // case, they would just attempt and fail to enter the
-          // std::call_once, and return (the correct value of)
-          // 'value'.
-          std::atomic_thread_fence (std::memory_order_release);
-
-          initialized = true;
-        });
+      value = getEnvironmentVariableAsBool (environmentVariableName,
+                                            defaultValue);
+      initialized = true;
     }
     return value;
   }
 
   bool
   idempotentlyGetNamedEnvironmentVariableAsBool (const char name[],
-                                                 std::once_flag& once_flag,
                                                  bool& initialized,
                                                  const char environmentVariableName[],
                                                  const bool defaultValue)
   {
     using BehaviorDetails::namedVariableMap_;
-    // The extra "initialized" check avoids the cost of synchronizing
-    // on the std::call_once for every call to this function.  We want
-    // it to be cheap to fill the namedVariableMap_, so that users aren't
-    // tempted to try to cache it themselves.
     if (! initialized) {
-      std::call_once (once_flag, [&] () {
-          setEnvironmentVariableMap (environmentVariableName,
-                                     namedVariableMap_,
-                                     defaultValue);
-          // http://preshing.com/20130922/acquire-and-release-fences/
-          //
-          // "A release fence prevents the memory reordering of any
-          // read or write which precedes it in program order with any
-          // write which follows it in program order."
-          //
-          // The point is to prevent the assignment to 'namedValueMap' from
-          // getting reordered after the assignment to 'initialized' (the
-          // so-called "StoreStore" reordering).  That would be bad in this
-          // case, because then other threads might read 'initialized' as true,
-          // yet would fail to pick up the change to 'namedValueMap'.
-          //
-          // It's harmless if other threads don't see the write to
-          // 'initialized', but did see the write to 'namedValueMap'.  In that
-          // case, they would just attempt and fail to enter the std::call_once,
-          // and return (the correct value of) 'namedValueMap'.
-          std::atomic_thread_fence (std::memory_order_release);
-
-          initialized = true;
-        });
+      setEnvironmentVariableMap (environmentVariableName,
+                                 namedVariableMap_,
+                                 defaultValue);
+      initialized = true;
     }
     auto thisEnvironmentVariableMap = namedVariableMap_[environmentVariableName];
     auto thisEnvironmentVariable = thisEnvironmentVariableMap.find(name);
@@ -248,11 +194,9 @@ bool Behavior::debug ()
   constexpr char envVarName[] = "TPETRA_DEBUG";
   constexpr bool defaultValue = debugDefault ();
 
-  static std::once_flag flag_;
   static bool value_ = defaultValue;
   static bool initialized_ = false;
-  return idempotentlyGetEnvironmentVariableAsBool (flag_,
-                                                   value_,
+  return idempotentlyGetEnvironmentVariableAsBool (value_,
                                                    initialized_,
                                                    envVarName,
                                                    defaultValue);
@@ -265,11 +209,9 @@ bool Behavior::verbose ()
   constexpr char envVarName[] = "TPETRA_VERBOSE";
   constexpr bool defaultValue = verboseDefault ();
 
-  static std::once_flag flag_;
   static bool value_ = defaultValue;
   static bool initialized_ = false;
-  return idempotentlyGetEnvironmentVariableAsBool (flag_,
-                                                   value_,
+  return idempotentlyGetEnvironmentVariableAsBool (value_,
                                                    initialized_,
                                                    envVarName,
                                                    defaultValue);
@@ -280,11 +222,9 @@ bool Behavior::assumeMpiIsCudaAware ()
   constexpr char envVarName[] = "TPETRA_ASSUME_CUDA_AWARE_MPI";
   constexpr bool defaultValue = assumeMpiIsCudaAwareDefault ();
 
-  static std::once_flag flag_;
   static bool value_ = defaultValue;
   static bool initialized_ = false;
-  return idempotentlyGetEnvironmentVariableAsBool (flag_,
-                                                   value_,
+  return idempotentlyGetEnvironmentVariableAsBool (value_,
                                                    initialized_,
                                                    envVarName,
                                                    defaultValue);
@@ -296,7 +236,7 @@ int Behavior::TAFC_OptimizationCoreCount ()
     static int savedval=-1;
     if(savedval!=-1) return savedval;
     const char* varVal = std::getenv ("MM_TAFC_OptimizationCoreCount");
-    if (varVal == NULL) {
+    if (varVal == nullptr) {
         savedval = 3000; 
         return savedval; 
     }
@@ -310,10 +250,8 @@ bool Behavior::debug (const char name[])
   constexpr char envVarName[] = "TPETRA_DEBUG";
   constexpr bool defaultValue = false;
 
-  static std::once_flag flag_;
   static bool initialized_ = false;
   return idempotentlyGetNamedEnvironmentVariableAsBool (name,
-                                                        flag_,
                                                         initialized_,
                                                         envVarName,
                                                         defaultValue);
@@ -326,10 +264,8 @@ bool Behavior::verbose (const char name[])
   constexpr char envVarName[] = "TPETRA_VERBOSE";
   constexpr bool defaultValue = false;
 
-  static std::once_flag flag_;
   static bool initialized_ = false;
   return idempotentlyGetNamedEnvironmentVariableAsBool (name,
-                                                        flag_,
                                                         initialized_,
                                                         envVarName,
                                                         defaultValue);

--- a/packages/tpetra/core/src/Tpetra_Details_DualViewUtil.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DualViewUtil.hpp
@@ -72,8 +72,6 @@ makeDualViewFromOwningHostView
    const typename Kokkos::DualView<ElementType*, DeviceType>::t_host& hostView)
 {
   using dual_view_type = Kokkos::DualView<ElementType*, DeviceType>;
-  using dev_view_type = typename dual_view_type::t_dev;
-  using host_view_type = typename dual_view_type::t_host;
 
   if (dv.extent (0) == hostView.extent (0)) {
     // We don't need to reallocate the device View.
@@ -96,7 +94,6 @@ makeDualViewFromArrayView (Kokkos::DualView<ElementType*, DeviceType>& dv,
                            const std::string& label)
 {
   using dual_view_type = Kokkos::DualView<ElementType*, DeviceType>;
-  using dev_view_type = typename dual_view_type::t_dev;
   using host_view_type = typename dual_view_type::t_host;
   using const_host_view_type = typename host_view_type::const_type;
 
@@ -116,7 +113,6 @@ makeDualViewFromVector (Kokkos::DualView<ElementType*, DeviceType>& dv,
                         const std::string& label)
 {
   using dual_view_type = Kokkos::DualView<ElementType*, DeviceType>;
-  using dev_view_type = typename dual_view_type::t_dev;
   using host_view_type = typename dual_view_type::t_host;
   using const_host_view_type = typename host_view_type::const_type;
 

--- a/packages/tpetra/core/src/Tpetra_Details_unpackCrsMatrixAndCombine_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_unpackCrsMatrixAndCombine_def.hpp
@@ -1163,18 +1163,16 @@ unpackCrsMatrixAndCombineNew (const CrsMatrix<ST, LO, GO, NT>& sourceMatrix,
 {
   using Tpetra::Details::castAwayConstDualView;
   using Kokkos::View;
-  typedef typename NT::device_type device_type;
-  typedef CrsMatrix<ST, LO, GO, NT> crs_matrix_type;
-  typedef typename crs_matrix_type::local_matrix_type local_matrix_type;
-  typedef DistObject<char, LO, GO, NT> dist_object_type;
-  typedef typename dist_object_type::buffer_device_type buffer_device_type;
-  typedef typename buffer_device_type::memory_space BMS;
-  typedef typename device_type::memory_space MS;
+  using crs_matrix_type = CrsMatrix<ST, LO, GO, NT>;
+  using dist_object_type = DistObject<char, LO, GO, NT>;
+  using device_type = typename crs_matrix_type::device_type;
+  using local_matrix_type = typename crs_matrix_type::local_matrix_type;
+  using buffer_device_type = typename dist_object_type::buffer_device_type;
 
-  static_assert (std::is_same<device_type,
-                   typename local_matrix_type::device_type>::value,
-                 "NT::device_type and LocalMatrix::device_type must be "
-                 "the same.");
+  static_assert
+    (std::is_same<device_type, typename local_matrix_type::device_type>::value,
+     "crs_matrix_type::device_type and local_matrix_type::device_type "
+     "must be the same.");
 
   {
     auto numPacketsPerLID_nc = castAwayConstDualView (numPacketsPerLID);

--- a/packages/tpetra/core/src/Tpetra_Import_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Import_def.hpp
@@ -112,7 +112,6 @@ namespace Tpetra {
     using Teuchos::Ptr;
     using Teuchos::rcp;
     using std::endl;
-    using data_type = ImportExportData<LocalOrdinal,GlobalOrdinal,Node>;
     ProfilingRegion regionImportInit ("Tpetra::Import::init");
 
     std::unique_ptr<std::string> verbPrefix;
@@ -1086,11 +1085,10 @@ namespace Tpetra {
     using Teuchos::Array;
     using Teuchos::ArrayView;
     using std::endl;
-    using LO = LocalOrdinal;
     using GO = GlobalOrdinal;
     typedef typename Array<int>::difference_type size_type;
     const char tfecfFuncName[] = "setupExport: ";
-    const char suffix[ ] = "  Please report this bug to the Tpetra developers.";
+    const char suffix[] = "  Please report this bug to the Tpetra developers.";
 
     std::unique_ptr<std::string> prefix;
     if (this->verbose ()) {
@@ -1208,7 +1206,7 @@ namespace Tpetra {
         // Pack and resize remoteProcIDs, remoteGIDs, and remoteLIDs_.
         size_type numValidRemote = 0;
 #ifdef HAVE_TPETRA_DEBUG
-        ArrayView<GlobalOrdinal> remoteGIDsPtr = remoteGIDsView;
+        ArrayView<GO> remoteGIDsPtr = remoteGIDsView;
 #else
         GO* const remoteGIDsPtr = remoteGIDsView.getRawPtr ();
 #endif // HAVE_TPETRA_DEBUG

--- a/packages/tpetra/core/src/Tpetra_computeRowAndColumnOneNorms_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_computeRowAndColumnOneNorms_def.hpp
@@ -440,7 +440,6 @@ public:
 
     const auto curRow = A_lcl_.rowConst (lclRow);
     const LO numEnt = curRow.length;
-    const bool assumeSymmetric = equib_.assumeSymmetric;
 
     mag_type rowNorm {0.0};
     val_type diagVal {0.0};

--- a/packages/tpetra/core/test/FEMultiVector/FEMultiVector_UnitTests.cpp
+++ b/packages/tpetra/core/test/FEMultiVector/FEMultiVector_UnitTests.cpp
@@ -39,16 +39,7 @@
 // ************************************************************************
 // @HEADER
 
-#include <Tpetra_ConfigDefs.hpp>
-#include <Tpetra_TestingUtilities.hpp>
-#include <Teuchos_UnitTestHarness.hpp>
-
-#include <map>
-#include <Teuchos_OrdinalTraits.hpp>
-#include <Teuchos_ScalarTraits.hpp>
-#include <Teuchos_VerboseObject.hpp>
-#include <Teuchos_as.hpp>
-#include <Teuchos_Tuple.hpp>
+#include "Tpetra_TestingUtilities.hpp"
 #include "Tpetra_CrsGraph.hpp"
 #include "Tpetra_CrsMatrix.hpp"
 #include "Tpetra_Core.hpp"
@@ -56,40 +47,19 @@
 #include "Tpetra_Map.hpp"
 #include "Tpetra_Util.hpp"
 #include "Tpetra_Import.hpp"
-#include "Tpetra_Export.hpp"
 #include "Tpetra_FEMultiVector.hpp"
 #include "Tpetra_Assembly_Helpers.hpp"
 #include "Tpetra_Details_gathervPrint.hpp"
-
-
-
-// Macro that marks a function as "possibly unused," in order to
-// suppress build warnings.
-#if ! defined(TRILINOS_UNUSED_FUNCTION)
-#  if defined(__GNUC__) || (defined(__INTEL_COMPILER) && !defined(_MSC_VER))
-#    define TRILINOS_UNUSED_FUNCTION __attribute__((__unused__))
-#  elif defined(__clang__)
-#    if __has_attribute(unused)
-#      define TRILINOS_UNUSED_FUNCTION __attribute__((__unused__))
-#    else
-#      define TRILINOS_UNUSED_FUNCTION
-#    endif // Clang has 'unused' attribute
-#  elif defined(__IBMCPP__)
-// IBM's C++ compiler for Blue Gene/Q (V12.1) implements 'used' but not 'unused'.
-//
-// http://pic.dhe.ibm.com/infocenter/compbg/v121v141/index.jsp
-#    define TRILINOS_UNUSED_FUNCTION
-#  else // some other compiler
-#    define TRILINOS_UNUSED_FUNCTION
-#  endif
-#endif // ! defined(TRILINOS_UNUSED_FUNCTION)
-
+#include "Teuchos_OrdinalTraits.hpp"
+#include "Teuchos_ScalarTraits.hpp"
+#include "Teuchos_VerboseObject.hpp"
+#include <map>
 
 namespace {
 
   template<class T1, class T2>
   void vector_check(size_t N, T1 & v1, T2 & v2) {
-    int myRank = v1.getMap()->getComm()->getRank();
+    const int myRank = v1.getMap()->getComm()->getRank();
     for(size_t i=0; i<N; i++)
       if(v1.getDataNonConst(0)[i] != v2.getDataNonConst(0)[i]) {
         std::stringstream oss;
@@ -98,32 +68,14 @@ namespace {
       }
   }
 
-
-  // Teuchos using statements
-   using Tpetra::TestingUtilities::getDefaultComm;
-
   using std::endl;
-  using std::copy;
-  using std::ostream_iterator;
-  using std::string;
 
   using Teuchos::RCP;
-  using Teuchos::ArrayRCP;
   using Teuchos::rcp;
-  using Teuchos::null;
   using Teuchos::Array;
-  using Teuchos::ArrayView;
   using Teuchos::Comm;
-  using Teuchos::Range1D;
-  using Teuchos::Tuple;
-  using Teuchos::as;
   using Teuchos::OrdinalTraits;
   using Teuchos::ScalarTraits;
-  using Teuchos::arrayView;
-  using Teuchos::tuple;
-  using Teuchos::NO_TRANS;
-  using Teuchos::TRANS;
-  using Teuchos::CONJ_TRANS;
   using Teuchos::VERB_DEFAULT;
   using Teuchos::VERB_NONE;
   using Teuchos::VERB_LOW;
@@ -131,36 +83,8 @@ namespace {
   using Teuchos::VERB_HIGH;
   using Teuchos::VERB_EXTREME;
 
-  using Tpetra::Map;
-  using Tpetra::MultiVector;
-  using Tpetra::global_size_t;
-  using Tpetra::GloballyDistributed;
-  typedef Tpetra::global_size_t GST;
-
-  
   using Tpetra::createContigMapWithNode;
-  using Tpetra::createLocalMapWithNode;
-
-  double errorTolSlack = 1.0e+2;
-
-
-
-   template <class Scalar>
-  typename Teuchos::ScalarTraits<Scalar>::magnitudeType testingTol() { return Teuchos::ScalarTraits<Scalar>::eps(); }
-  template <>
-  TRILINOS_UNUSED_FUNCTION int testingTol<int>() { return 0; }
-  template <>
-  TRILINOS_UNUSED_FUNCTION long testingTol<long>() { return 0; }
-  template <>
-  TRILINOS_UNUSED_FUNCTION long long testingTol<long long>() { return 0; }
-
-
-  //
-  // UNIT TEST SERVICE FUNCTIONS
-  //
-  
-
-
+  using GST = Tpetra::global_size_t;
 
   //
   // UNIT TESTS
@@ -168,13 +92,11 @@ namespace {
 
   TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( FEMultiVector, doImport, LO, GO, Scalar, NO )
   {
-
     const GST INVALID = Teuchos::OrdinalTraits<GST>::invalid ();
     const RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
     const int myRank = comm->getRank();
     const int numProcs = comm->getSize();
     if(numProcs==1) return;
-
 
     // Prepare for verbose output, if applicable.
     //    Teuchos::EVerbosityLevel verbLevel = verbose ? VERB_EXTREME : VERB_NONE;
@@ -213,7 +135,7 @@ namespace {
         if (myRank!=numProcs-1) {
           entry[0] = globalrow+1;
           graph->insertGlobalIndices (globalrow, entry());
-        }       
+        }
       }
       graph->fillComplete();
 
@@ -270,25 +192,18 @@ namespace {
     }
   }
 
-
-
-
-
-// ===============================================================================
-
- TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( FEMultiVector, AssemblyHelpers, LO , GO , Scalar , Node )
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( FEMultiVector, AssemblyHelpers, LO , GO , Scalar , Node )
   {
-  using Tpetra::Import; 
     const GST INVALID = Teuchos::OrdinalTraits<GST>::invalid ();
-    const RCP<const Comm<int> > comm = Tpetra::getDefaultComm();   
+    const RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
     int rank = comm->getRank();
     int size = comm->getSize();
 
     // create maps
     const size_t numLocal = 10;
     const size_t numOverlap = numLocal + (rank!=0) + (rank!=size-1);
-    RCP<const Map<LO,GO,Node> > map = createContigMapWithNode<LO,GO,Node>(INVALID,numLocal,comm);
-    
+    RCP<const Tpetra::Map<LO,GO,Node> > map = createContigMapWithNode<LO,GO,Node>(INVALID,numLocal,comm);
+
     Array<GO> overlapList(numOverlap);
     for(size_t i = 0; i< numLocal; i++) {
       overlapList[i] = map->getGlobalElement(i);
@@ -297,37 +212,24 @@ namespace {
     if(rank!=0)      {overlapList[iii] = overlapList[0]-1; iii++;}
     if(rank!=size-1) {overlapList[iii] = overlapList[numLocal-1]+1;}
 
+    RCP<const Tpetra::Map<LO,GO,Node> > overlapMap    = rcp(new Tpetra::Map<LO,GO,Node>(INVALID,overlapList(),0,comm));
+    RCP<const Tpetra::Import<LO,GO,Node> > importer   = rcp(new Tpetra::Import<LO,GO,Node>(map,overlapMap));
 
-    RCP<const Map<LO,GO,Node> > overlapMap    = rcp(new Map<LO,GO,Node>(INVALID,overlapList(),0,comm));
-    RCP<const Import<LO,GO,Node> > importer   = rcp(new Import<LO,GO,Node>(map,overlapMap));
-    
-    Tpetra::FEMultiVector<Scalar,LO,GO,Node> v1(map,importer,1); 
-    Tpetra::FEMultiVector<Scalar,LO,GO,Node> v2(map,importer,1); 
-    Tpetra::FEMultiVector<Scalar,LO,GO,Node> v3(map,importer,1); 
-
+    Tpetra::FEMultiVector<Scalar,LO,GO,Node> v1(map,importer,1);
+    Tpetra::FEMultiVector<Scalar,LO,GO,Node> v2(map,importer,1);
+    Tpetra::FEMultiVector<Scalar,LO,GO,Node> v3(map,importer,1);
 
     // Just check to make sure beginFill() / endFill() compile
     Tpetra::beginFill(v1,v2,v3);
 
     Tpetra::endFill(v1,v2,v3);
-
-
-
   }
 
-
-// ===============================================================================
-
-
-#define UNIT_TEST_GROUP( SC, LO, GO, NO  )                         \
+#define UNIT_TEST_GROUP( SC, LO, GO, NO ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( FEMultiVector, doImport, LO, GO, SC, NO ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( FEMultiVector, AssemblyHelpers, LO, GO, SC, NO )
 
- 
-
   TPETRA_ETI_MANGLING_TYPEDEFS()
-
-
 
   TPETRA_INSTANTIATE_TESTMV( UNIT_TEST_GROUP )
 }


### PR DESCRIPTION
@trilinos/tpetra 

## Description

  - Remove use of C++11 thread stuff from `Tpetra::Details::Behavior`.
  - Fix Tpetra build warnings observed on the Dashboard

## Motivation and Context

1. GCC annoyingly requires linking with libpthread in order for that stuff to work.  GCC apparently generates code that crashes, if Trilinos was not built with libpthread support.  I consider that a GCC bug, but we have to work around.
2. `std::call_once` etc. only help with thread safety of code that uses `std::thread` threads.  They don't help with other thread models, like OpenMP (or even Pthreads).  This reduces the value of this feature.

## Related Issues

* Closes #4729 