### PR TITLE
clean_workspace: correct flag and make command

### DIFF
--- a/commonTools/framework/clean_workspace/clean_workspace.py
+++ b/commonTools/framework/clean_workspace/clean_workspace.py
@@ -11,6 +11,8 @@ from __future__ import print_function
 import sys
 sys.dont_write_bytecode = True
 
+import os
+
 import argparse
 import subprocess
 
@@ -18,7 +20,7 @@ from clean_sentinel import clean_reference_date
 from clean_sentinel import last_clean_date
 from clean_sentinel import update_last_clean_date
 
-from Modules import Module as Moduler
+from Modules import module
 
 
 class Cleaner(object):
@@ -34,7 +36,8 @@ class Cleaner(object):
         self.args = self.parse_args()
         if self.args.dir is None:
             raise SystemExit("No directory passed - exiting!")
-        if self.args.force:
+        if self.args.force_clean:
+            print("Cleaning directory {clean_dir} due to command line option".format(clean_dir=self.args.dir))
             self.force_clean_space()
         else:
             self.clean_space_by_date()
@@ -59,12 +62,14 @@ class Cleaner(object):
              Load the module to enable ninja
              Run "make -C %s clean"
         """
-        Moduler.module('load', 'atdm-env')
-        Moduler.module('load', 'atdm-ninja_fortran/1.7.2')
-        subprocess.check_call(['make', '-C', self.args.dir, 'clean'])
+        module('load', 'atdm-env')
+        module('load', 'atdm-ninja_fortran/1.7.2')
+        os.chdir(self.args.dir)
+        subprocess.check_call(['make', 'clean'])
 
     def clean_space_by_date(self):
         if last_clean_date() < clean_reference_date():
+            print("Cleaning directory {clean_dir} due to newer reference date".format(clean_dir=self.args.dir))
             self.force_clean_space()
             update_last_clean_date()
         

--- a/commonTools/framework/clean_workspace/unittests/test_clean_all_jobs.py
+++ b/commonTools/framework/clean_workspace/unittests/test_clean_all_jobs.py
@@ -44,3 +44,6 @@ class TestRun(unittest.TestCase):
              mock.patch('sys.stderr', new_callable=StringIO):
             with self.assertRaises(SystemExit):
                 cleanRefInst.run()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/commonTools/framework/clean_workspace/unittests/test_clean_workspace.py
+++ b/commonTools/framework/clean_workspace/unittests/test_clean_workspace.py
@@ -25,29 +25,32 @@ class TestRun(unittest.TestCase):
         """If there is no dir attribute in the args raise SystemExit"""
         test_args = Namespace()
         setattr(test_args, 'dir', None)
-        setattr(test_args, 'force', False)
+        setattr(test_args, 'force_clean', False)
         with mock.patch.object(Cleaner, 'parse_args', return_value=test_args):
             cleanerInst = Cleaner()
-            with self.assertRaises(SystemExit):
+            with self.assertRaisesRegexp(SystemExit, "No directory passed - exiting!"):
                 cleanerInst.run()
 
 
     def test_force_calls_clean(self):
         """If force is passed go straight to cleanup"""
         test_args = Namespace()
-        setattr(test_args, 'dir', os.path.join(os.path.sep, 'dev', 'null'))
-        setattr(test_args, 'force', True)
+        setattr(test_args, 'dir', os.path.join(os.path.sep, 'dev', 'null', 'force_cleaned'))
+        setattr(test_args, 'force_clean', True)
         with mock.patch.object(Cleaner, 'parse_args', return_value=test_args):
             cleanerInst = Cleaner()
-            with mock.patch.object(Cleaner, 'force_clean_space') as force_clean:
+            with mock.patch.object(Cleaner, 'force_clean_space') as force_clean, \
+                 mock.patch('clean_workspace.print') as m_print:
                 cleanerInst.run()
             force_clean.assert_called_once()
+            m_print.assert_called_once_with("Cleaning directory /dev/null/force_cleaned "
+                                            "due to command line option")
 
     def test_dir_calls_clean_by_date(self):
         """If force is passed go straight to cleanup"""
         test_args = Namespace()
         setattr(test_args, 'dir', os.path.join(os.path.sep, 'dev', 'null'))
-        setattr(test_args, 'force', False)
+        setattr(test_args, 'force_clean', False)
         with mock.patch.object(Cleaner, 'parse_args', return_value=test_args):
             cleanerInst = Cleaner()
             with mock.patch.object(Cleaner, 'clean_space_by_date') as force_clean:
@@ -100,16 +103,17 @@ class TestForceCleanSpace(unittest.TestCase):
         """This function does the final cleanup  so its just module loads and a subprocess call"""
         test_args = Namespace()
         setattr(test_args, 'dir', os.path.join(os.path.sep, 'dev', 'null'))
-        setattr(test_args, 'force', True)
+        setattr(test_args, 'force_clean', True)
         cleanerInst = Cleaner()
         cleanerInst.args = test_args
-        with mock.patch('clean_workspace.Moduler.module') as mod, \
+        with mock.patch('clean_workspace.module') as mod, \
+             mock.patch('os.chdir') as m_chdir, \
              mock.patch('clean_workspace.subprocess.check_call') as check_call:
             cleanerInst.force_clean_space()
         mod.assert_has_calls([mock.call('load', 'atdm-env'),
                               mock.call('load', 'atdm-ninja_fortran/1.7.2')])
-        check_call.assert_called_once_with(['make', '-C',
-                                            test_args.dir, 'clean'])
+        m_chdir.assert_called_once_with(test_args.dir)
+        check_call.assert_called_once_with(['make', 'clean'])
 
 
 class TestCleanSpaceByDate(unittest.TestCase):
@@ -129,27 +133,39 @@ class TestCleanSpaceByDate(unittest.TestCase):
     def test_newer_reference_does_clean(self):
         """The default dates should result in no clean action"""
         testDate = datetime(2019, 2, 4, hour=10, minute=48)
+        test_args = Namespace()
+        setattr(test_args, "dir", os.path.join(os.path.sep, "dev", "null", "fake_directory"))
         with mock.patch('clean_workspace.clean_reference_date', return_value=testDate):
             cleanerInst = Cleaner()
+            cleanerInst.args = test_args
             with mock.patch.dict('os.environ',
                                  {'WORKSPACE': '/scratch/Trilinos/foo/bar'}):
                 with mock.patch('clean_workspace.Cleaner.force_clean_space') as force_clean, \
-                     mock.patch('clean_workspace.update_last_clean_date') as update:
+                     mock.patch('clean_workspace.update_last_clean_date') as update, \
+                     mock.patch('clean_workspace.print') as m_print:
                     cleanerInst.clean_space_by_date()
                 force_clean.assert_called_once()
                 update.assert_called_once()
+                m_print.assert_called_once_with("Cleaning directory /dev/null/fake_directory "
+                                                "due to newer reference date")
 
 
     def test_older_date_does_clean(self):
         """The default dates should result in no clean action"""
         testDate = datetime(2019, 2, 4, hour=10, minute=0)
+        test_args = Namespace()
+        setattr(test_args, "dir", os.path.join(os.path.sep, "dev", "null", "will_clean"))
         with mock.patch('clean_workspace.last_clean_date', return_value=testDate):
             cleanerInst = Cleaner()
+            cleanerInst.args = test_args
             with mock.patch('clean_workspace.Cleaner.force_clean_space') as force_clean, \
-                 mock.patch('clean_workspace.update_last_clean_date') as update:
+                 mock.patch('clean_workspace.update_last_clean_date') as update, \
+                 mock.patch('clean_workspace.print') as m_print:
                 cleanerInst.clean_space_by_date()
             force_clean.assert_called_once()
             update.assert_called_once()
+            m_print.assert_called_once_with("Cleaning directory /dev/null/will_clean "
+                                            "due to newer reference date")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
the --force-clean flag had two conflicting names
and the final   make command (make -C %s clean)
failed in an infinite recursion.  I just modified
it to cd to the directory first and then run 'make clean'

@trilinos/framework 

## How Has This Been Tested?
tested with the unit tests and I created a directory, built and used both the date and force options to clean it.