### PR TITLE
Pamgen:  Remove Unused Parameter Warnings

### DIFF
--- a/packages/pamgen/extra_functions/pamgen_extras.cpp
+++ b/packages/pamgen/extra_functions/pamgen_extras.cpp
@@ -15,7 +15,7 @@ void  Conform_Boundary_IDS(long long ** comm_entities,
     long long * proc_ids,
     long long * data_array,
     long long num_comm_pairs,
-    long long  rank)
+    long long  /* rank */)
   /*****************************************************************************/
 {
 #ifdef HAVE_MPI
@@ -77,7 +77,7 @@ void  Conform_Boundary_IDS(long long ** comm_entities,
 /*****************************************************************************/
 void  Conform_Boundary_IDS_topo_entity(std::vector < std:: vector < topo_entity * > > & topo_entities,
     long long * proc_ids,
-    long long  rank)
+    long long  /* rank */)
   /*****************************************************************************/
 {
 #ifdef HAVE_MPI
@@ -259,6 +259,8 @@ void calc_global_ids(std::vector < topo_entity * > eof_vec,
   aname << rank;
   aname << ".txt";
   ofstream fout(aname.str().c_str());
+#else
+  (void)fname_string;
 #endif
 
   //need to sort the edges_or_face vectors by their sorted global node ids

--- a/packages/pamgen/mesh_spec_lt/im_ex_c_interface.C
+++ b/packages/pamgen/mesh_spec_lt/im_ex_c_interface.C
@@ -7,7 +7,7 @@
 
 
 /*****************************************************************************/
-int im_ex_get_init (int   im_exoid,
+int im_ex_get_init (int   /* im_exoid */,
 		    char *title,
 		    int  *num_dim,
 		    int  *num_nodes,
@@ -32,7 +32,7 @@ int im_ex_get_init (int   im_exoid,
 }
 
 /*****************************************************************************/
-int im_ex_inquire (int   exoid,
+int im_ex_inquire (int   /* exoid */,
 		   int   req_info,
 		   int  *ret_int,
 		   float *ret_float,
@@ -182,7 +182,7 @@ int im_ex_inquire (int   exoid,
 }
 
 /*****************************************************************************/
-int im_ex_get_coord (int exoid,
+int im_ex_get_coord (int /* exoid */,
 		     void *x_coor,
 		     void *y_coor,
 		     void *z_coor)
@@ -209,7 +209,7 @@ int im_ex_get_coord (int exoid,
 }
 
 /*****************************************************************************/
-int im_ex_get_coord_names (int    exoid,
+int im_ex_get_coord_names (int    /* exoid */,
 			   char **coord_names)
 /*****************************************************************************/
 {
@@ -226,7 +226,7 @@ int im_ex_get_coord_names (int    exoid,
 }
 
 /*****************************************************************************/
-int im_ex_get_map (int  exoid, int *elem_map)
+int im_ex_get_map (int  /* exoid */, int *elem_map)
 /*****************************************************************************/
 {
   ms_lt::Mesh_Specification * ms = ms_lt::Mesh_Specification::first_ms_static_storage;
@@ -240,7 +240,7 @@ int im_ex_get_map (int  exoid, int *elem_map)
 }
 
 /*****************************************************************************/
-int im_ex_get_elem_num_map (int  exoid,
+int im_ex_get_elem_num_map (int  /* exoid */,
 			    int *elem_map)
 /*****************************************************************************/
 {
@@ -256,7 +256,7 @@ int im_ex_get_elem_num_map (int  exoid,
 }
 
 /*****************************************************************************/
-int im_ex_get_node_num_map (int  exoid,
+int im_ex_get_node_num_map (int  /* exoid */,
 			    int *node_map)
 /*****************************************************************************/
 {
@@ -272,7 +272,7 @@ int im_ex_get_node_num_map (int  exoid,
 }
 
 /*****************************************************************************/
-int im_ex_get_elem_blk_ids (int  exoid, int *ids)
+int im_ex_get_elem_blk_ids (int  /* exoid */, int *ids)
 /*****************************************************************************/
 {
   ms_lt::Mesh_Specification * ms = ms_lt::Mesh_Specification::first_ms_static_storage;
@@ -287,7 +287,7 @@ int im_ex_get_elem_blk_ids (int  exoid, int *ids)
 }
 
 /*****************************************************************************/
-int im_ex_get_elem_block (int   exoid,
+int im_ex_get_elem_block (int   /* exoid */,
 			  int   elem_blk_id,
 			  char *elem_type,
 			  int  *num_elem_this_blk, 
@@ -336,7 +336,7 @@ int im_ex_get_elem_block (int   exoid,
 // }
 
 /*****************************************************************************/
-int im_ex_get_elem_conn (int   exoid,
+int im_ex_get_elem_conn (int   /* exoid */,
 			 int   elem_blk_id,
 			 int  *connect)
 /*****************************************************************************/
@@ -364,7 +364,7 @@ int im_ex_get_elem_conn (int   exoid,
 }
 
 /*****************************************************************************/
-int im_ex_get_node_set_ids (int  exoid,
+int im_ex_get_node_set_ids (int  /* exoid */,
 			    int *ids)
 /*****************************************************************************/
 {
@@ -411,7 +411,7 @@ int get_ns_index(int nsid)
 }
 
 /*****************************************************************************/
-int im_ex_get_side_set_ids (int  exoid,
+int im_ex_get_side_set_ids (int  /* exoid */,
 			    int *ids)
 /*****************************************************************************/
 {
@@ -425,7 +425,7 @@ int im_ex_get_side_set_ids (int  exoid,
 }
 
 /*****************************************************************************/
-int im_ex_get_node_set_param (int exoid,
+int im_ex_get_node_set_param (int /* exoid */,
 			      int node_set_id,
 			      int * num_nodes_in_set,
 			      int * num_dist_in_set)
@@ -447,7 +447,7 @@ int im_ex_get_node_set_param (int exoid,
 }
 
 /*****************************************************************************/
-int im_ex_get_side_set_param (int exoid,
+int im_ex_get_side_set_param (int /* exoid */,
 			      int side_set_id,
 			      int * num_side_in_set,
 			      int * num_dist_in_set)
@@ -469,7 +469,7 @@ int im_ex_get_side_set_param (int exoid,
 }
 
 /*****************************************************************************/
-int im_ex_get_node_set (int   exoid,
+int im_ex_get_node_set (int   /* exoid */,
 			int   node_set_id,
 			int  *node_set_node_list)
 /*****************************************************************************/
@@ -490,7 +490,7 @@ int im_ex_get_node_set (int   exoid,
 }
 
 /*****************************************************************************/
-int im_ex_get_side_set (int   exoid,
+int im_ex_get_side_set (int   /* exoid */,
 			int   side_set_id,
 			int  *side_set_elem_list,
 			int  *side_set_side_list)
@@ -515,7 +515,7 @@ int im_ex_get_side_set (int   exoid,
 }
 
 /*****************************************************************************/
-int im_ex_get_side_set_node_list(int exoid,
+int im_ex_get_side_set_node_list(int /* exoid */,
 				 int side_set_id,
 				 int *side_set_node_cnt_list,
 				 int *side_set_node_list)
@@ -543,7 +543,7 @@ int im_ex_get_side_set_node_list(int exoid,
 }
 
 /*****************************************************************************/
-int im_ex_get_qa (int exoid,
+int im_ex_get_qa (int /* exoid */,
 		  char *qa_record[][4])
 /*****************************************************************************/
 {
@@ -566,7 +566,7 @@ int im_ex_get_qa (int exoid,
 }
 
 /*****************************************************************************/
-int im_ex_get_info (int exoid, char **info)
+int im_ex_get_info (int /* exoid */, char **info)
 /*****************************************************************************/
 {
   ms_lt::Mesh_Specification * ms = ms_lt::Mesh_Specification::first_ms_static_storage;
@@ -583,7 +583,7 @@ int im_ex_get_info (int exoid, char **info)
   return 0;
 }
 /*****************************************************************************/
-int im_ex_get_elem_blk_parent_mesh (int  exoid, int *ids)
+int im_ex_get_elem_blk_parent_mesh (int  /* exoid */, int *ids)
 /*****************************************************************************/
 {
   ms_lt::Mesh_Specification * ms = ms_lt::Mesh_Specification::first_ms_static_storage;
@@ -598,7 +598,7 @@ int im_ex_get_elem_blk_parent_mesh (int  exoid, int *ids)
 }
 
 /*****************************************************************************/
-int im_ex_get_ns_parent_mesh (int  exoid, int *ids)
+int im_ex_get_ns_parent_mesh (int  /* exoid */, int *ids)
 /*****************************************************************************/
 {
   ms_lt::Mesh_Specification * ms = ms_lt::Mesh_Specification::first_ms_static_storage;
@@ -612,7 +612,7 @@ int im_ex_get_ns_parent_mesh (int  exoid, int *ids)
   return 0;
 }
 /*****************************************************************************/
-int im_ex_get_ss_parent_mesh (int  exoid, int *ids)
+int im_ex_get_ss_parent_mesh (int  /* exoid */, int *ids)
 /*****************************************************************************/
 {
   ms_lt::Mesh_Specification * ms = ms_lt::Mesh_Specification::first_ms_static_storage;

--- a/packages/pamgen/mesh_spec_lt/im_ex_c_interface_l.C
+++ b/packages/pamgen/mesh_spec_lt/im_ex_c_interface_l.C
@@ -7,7 +7,7 @@
 
 
 /*****************************************************************************/
-int im_ex_get_init_l (int   im_exoid,
+int im_ex_get_init_l (int   /* im_exoid */,
 		    char *title,
 		    long long  *num_dim,
 		    long long  *num_nodes,
@@ -33,7 +33,7 @@ int im_ex_get_init_l (int   im_exoid,
 }
 
 /*****************************************************************************/
-int im_ex_inquire_l (int   exoid,
+int im_ex_inquire_l (int   /* exoid */,
 		   int   req_info,
 		   long long  *ret_int,
 		   float *ret_float,
@@ -183,7 +183,7 @@ int im_ex_inquire_l (int   exoid,
 }
 
 /*****************************************************************************/
-int im_ex_get_coord_l (int exoid,
+int im_ex_get_coord_l (int /* exoid */,
 		     void *x_coor,
 		     void *y_coor,
 		     void *z_coor)
@@ -210,7 +210,7 @@ int im_ex_get_coord_l (int exoid,
 }
 
 /*****************************************************************************/
-int im_ex_get_coord_names_l (int    exoid,
+int im_ex_get_coord_names_l (int    /* exoid */,
 			   char **coord_names)
 /*****************************************************************************/
 {
@@ -227,7 +227,7 @@ int im_ex_get_coord_names_l (int    exoid,
 }
 
 /*****************************************************************************/
-int im_ex_get_map_l (int  exoid, long long *elem_map)
+int im_ex_get_map_l (int  /* exoid */, long long *elem_map)
 /*****************************************************************************/
 {
   ms_lt::Mesh_Specification * ms = ms_lt::Mesh_Specification::first_ms_static_storage;
@@ -241,7 +241,7 @@ int im_ex_get_map_l (int  exoid, long long *elem_map)
 }
 
 /*****************************************************************************/
-int im_ex_get_elem_num_map_l (int  exoid,
+int im_ex_get_elem_num_map_l (int  /* exoid */,
 			    long long *elem_map)
 /*****************************************************************************/
 {
@@ -257,7 +257,7 @@ int im_ex_get_elem_num_map_l (int  exoid,
 }
 
 /*****************************************************************************/
-int im_ex_get_node_num_map_l (int  exoid,
+int im_ex_get_node_num_map_l (int  /* exoid */,
 			    long long *node_map)
 /*****************************************************************************/
 {
@@ -273,7 +273,7 @@ int im_ex_get_node_num_map_l (int  exoid,
 }
 
 /*****************************************************************************/
-int im_ex_get_elem_blk_ids_l (int  exoid, long long *ids)
+int im_ex_get_elem_blk_ids_l (int  /* exoid */, long long *ids)
 /*****************************************************************************/
 {
   ms_lt::Mesh_Specification * ms = ms_lt::Mesh_Specification::first_ms_static_storage;
@@ -288,7 +288,7 @@ int im_ex_get_elem_blk_ids_l (int  exoid, long long *ids)
 }
 
 /*****************************************************************************/
-int im_ex_get_elem_block_l (int   exoid,
+int im_ex_get_elem_block_l (int   /* exoid */,
 			  long long   elem_blk_id,
 			  char *elem_type,
 			  long long  *num_elem_this_blk, 
@@ -337,7 +337,7 @@ int im_ex_get_elem_block_l (int   exoid,
 // }
 
 /*****************************************************************************/
-int im_ex_get_elem_conn_l (int   exoid,
+int im_ex_get_elem_conn_l (int   /* exoid */,
 			 long long   elem_blk_id,
 			 long long  *connect)
 /*****************************************************************************/
@@ -365,7 +365,7 @@ int im_ex_get_elem_conn_l (int   exoid,
 }
 
 /*****************************************************************************/
-int im_ex_get_node_set_ids_l (int  exoid,
+int im_ex_get_node_set_ids_l (int  /* exoid */,
 			    long long *ids)
 /*****************************************************************************/
 {
@@ -412,7 +412,7 @@ int get_ns_index(long long nsid)
 }
 
 /*****************************************************************************/
-int im_ex_get_side_set_ids_l (int  exoid,
+int im_ex_get_side_set_ids_l (int  /* exoid */,
 			    long long *ids)
 /*****************************************************************************/
 {
@@ -426,7 +426,7 @@ int im_ex_get_side_set_ids_l (int  exoid,
 }
 
 /*****************************************************************************/
-int im_ex_get_node_set_param_l (int exoid,
+int im_ex_get_node_set_param_l (int /* exoid */,
 			      long long node_set_id,
 			      long long * num_nodes_in_set,
 			      long long * num_dist_in_set)
@@ -448,7 +448,7 @@ int im_ex_get_node_set_param_l (int exoid,
 }
 
 /*****************************************************************************/
-int im_ex_get_side_set_param_l (int exoid,
+int im_ex_get_side_set_param_l (int /* exoid */,
 			      long long side_set_id,
 			      long long * num_side_in_set,
 			      long long * num_dist_in_set)
@@ -470,7 +470,7 @@ int im_ex_get_side_set_param_l (int exoid,
 }
 
 /*****************************************************************************/
-int im_ex_get_node_set_l (int   exoid,
+int im_ex_get_node_set_l (int   /* exoid */,
 			long long   node_set_id,
 			long long  *node_set_node_list)
 /*****************************************************************************/
@@ -491,7 +491,7 @@ int im_ex_get_node_set_l (int   exoid,
 }
 
 /*****************************************************************************/
-int im_ex_get_side_set_l (int   exoid,
+int im_ex_get_side_set_l (int   /* exoid */,
 			long long   side_set_id,
 			long long  *side_set_elem_list,
 			long long  *side_set_side_list)
@@ -516,7 +516,7 @@ int im_ex_get_side_set_l (int   exoid,
 }
 
 /*****************************************************************************/
-int im_ex_get_side_set_node_list_l(int exoid,
+int im_ex_get_side_set_node_list_l(int /* exoid */,
 				 long long side_set_id,
 				 long long *side_set_node_cnt_list,
 				 long long *side_set_node_list)
@@ -544,7 +544,7 @@ int im_ex_get_side_set_node_list_l(int exoid,
 }
 
 /*****************************************************************************/
-int im_ex_get_qa_l (int exoid,
+int im_ex_get_qa_l (int /* exoid */,
 		  char *qa_record[][4])
 /*****************************************************************************/
 {
@@ -567,7 +567,7 @@ int im_ex_get_qa_l (int exoid,
 }
 
 /*****************************************************************************/
-int im_ex_get_info_l (int exoid, char **info)
+int im_ex_get_info_l (int /* exoid */, char **info)
 /*****************************************************************************/
 {
   ms_lt::Mesh_Specification * ms = ms_lt::Mesh_Specification::first_ms_static_storage;
@@ -586,7 +586,7 @@ int im_ex_get_info_l (int exoid, char **info)
 
 
 /*****************************************************************************/
-int  im_ex_get_elem_blk_parent_mesh_l (int  exoid, long long *ids)
+int  im_ex_get_elem_blk_parent_mesh_l (int  /* exoid */, long long *ids)
 /*****************************************************************************/
 {
   ms_lt::Mesh_Specification * ms = ms_lt::Mesh_Specification::first_ms_static_storage;
@@ -601,7 +601,7 @@ int  im_ex_get_elem_blk_parent_mesh_l (int  exoid, long long *ids)
 }
 
 /*****************************************************************************/
-int  im_ex_get_ns_parent_mesh_l (int  exoid, long long *ids)
+int  im_ex_get_ns_parent_mesh_l (int  /* exoid */, long long *ids)
 /*****************************************************************************/
 {
   ms_lt::Mesh_Specification * ms = ms_lt::Mesh_Specification::first_ms_static_storage;
@@ -616,7 +616,7 @@ int  im_ex_get_ns_parent_mesh_l (int  exoid, long long *ids)
 }
 
 /*****************************************************************************/
-int  im_ex_get_ss_parent_mesh_l (int  exoid, long long *ids)
+int  im_ex_get_ss_parent_mesh_l (int  /* exoid */, long long *ids)
 /*****************************************************************************/
 {
   ms_lt::Mesh_Specification * ms = ms_lt::Mesh_Specification::first_ms_static_storage;

--- a/packages/pamgen/mesh_spec_lt/im_ne_c_interface.C
+++ b/packages/pamgen/mesh_spec_lt/im_ne_c_interface.C
@@ -5,7 +5,7 @@
 
 
 /*****************************************************************************/
-int im_ne_get_init_global(int   neid, 		  /* NemesisI file ID */
+int im_ne_get_init_global(int   /* neid */, 		  /* NemesisI file ID */
 			  int  *num_nodes_g,	  /* Number of global FEM nodes */
 			  int  *num_elems_g,	  /* Number of global FEM elements */
 			  int  *num_elem_blks_g, /* Number of global elem blocks */
@@ -26,7 +26,7 @@ int im_ne_get_init_global(int   neid, 		  /* NemesisI file ID */
 }
 
 /*****************************************************************************/
-int im_ne_get_init_info(int   neid,		/* NemesisI file ID */
+int im_ne_get_init_info(int   /* neid */,		/* NemesisI file ID */
 			int  *num_proc,	/* Number of processors */
 			int  *num_proc_in_f,	/* Number of procs in this file */
 			char *ftype)
@@ -42,7 +42,7 @@ int im_ne_get_init_info(int   neid,		/* NemesisI file ID */
 }
 
 /*****************************************************************************/
-int im_ne_get_eb_info_global(int neid,		/* NemesisI file ID                 */
+int im_ne_get_eb_info_global(int /* neid */,		/* NemesisI file ID                 */
 			     int *el_blk_ids,	/* Vector of global element IDs     */
 			     int *el_blk_cnts	/* Vector of global element counts  */
 			     )
@@ -61,7 +61,7 @@ int im_ne_get_eb_info_global(int neid,		/* NemesisI file ID                 */
 }
 
 /*****************************************************************************/
-int im_ne_get_loadbal_param(int   neid, 	/* NetCDF/Exodus file ID */
+int im_ne_get_loadbal_param(int   /* neid */, 	/* NetCDF/Exodus file ID */
 			    int  *num_int_nodes,  /* Number of internal FEM nodes */
 			    int  *num_bor_nodes,  /* Number of border FEM nodes */
 			    int  *num_ext_nodes,  /* Number of external FEM nodes */
@@ -69,7 +69,7 @@ int im_ne_get_loadbal_param(int   neid, 	/* NetCDF/Exodus file ID */
 			    int  *num_bor_elems,  /* Number of border FEM elems */
 			    int  *num_node_cmaps, /* Number of nodal comm maps */
 			    int  *num_elem_cmaps, /* Number of elemental comm maps */
-			    int   processor         /* Processor ID */
+			    int   /* processor */         /* Processor ID */
 			    )
 /*****************************************************************************/
 {
@@ -89,10 +89,10 @@ int im_ne_get_loadbal_param(int   neid, 	/* NetCDF/Exodus file ID */
 }
 
 /*****************************************************************************/
-int im_ne_get_elem_map(int   neid,		/* NetCDF/Exodus file ID */
+int im_ne_get_elem_map(int   /* neid */,		/* NetCDF/Exodus file ID */
 		       int  *elem_mapi,	/* Internal element IDs */
 		       int  *elem_mapb,	/* Border element IDs */
-		       int   processor		/* Processor ID */
+		       int   /* processor */		/* Processor ID */
 		       )
 /*****************************************************************************/
 {
@@ -112,11 +112,11 @@ int im_ne_get_elem_map(int   neid,		/* NetCDF/Exodus file ID */
 }
 
 /*****************************************************************************/
-int im_ne_get_node_map(int   neid,		/* NetCDF/Exodus file ID */
+int im_ne_get_node_map(int   /* neid */,		/* NetCDF/Exodus file ID */
 		       int  *node_mapi,	/* Internal FEM node IDs */
 		       int  *node_mapb,	/* Border FEM node IDs */
 		       int  *node_mape,	/* External FEM node IDs */
-		       int   processor		/* Processor IDs */
+		       int   /* processor */		/* Processor IDs */
 		       )
 /*****************************************************************************/
 {
@@ -139,12 +139,12 @@ int im_ne_get_node_map(int   neid,		/* NetCDF/Exodus file ID */
 }
 
 /*****************************************************************************/
-int im_ne_get_cmap_params(int neid,                  /* NetCDF/Exodus file ID */
+int im_ne_get_cmap_params(int /* neid */,                  /* NetCDF/Exodus file ID */
 			  int *node_cmap_ids,        /* Nodal comm. map IDs */
 			  int *node_cmap_node_cnts,  /* Number of nodes in each map */
 			  int *elem_cmap_ids,        /* Elemental comm. map IDs */
 			  int *elem_cmap_elem_cnts,  /* Number of elems in each map */
-			  int  processor             /* This processor ID */
+			  int  /* processor */             /* This processor ID */
 			  )
 /*****************************************************************************/
 {
@@ -173,11 +173,11 @@ int im_ne_get_cmap_params(int neid,                  /* NetCDF/Exodus file ID */
 }
 
 /*****************************************************************************/
-int im_ne_get_node_cmap(int  neid,             /* NetCDF/Exodus file ID */
+int im_ne_get_node_cmap(int  /* neid */,             /* NetCDF/Exodus file ID */
 			int  map_id,           /* Map ID */
 			int *node_ids,         /* FEM node IDs */
 			int *proc_ids,         /* Processor IDs */
-			int  processor         /* This processor ID */
+			int  /* processor */         /* This processor ID */
 			)
 /*****************************************************************************/
 {
@@ -207,12 +207,12 @@ int im_ne_get_node_cmap(int  neid,             /* NetCDF/Exodus file ID */
 }
 
 /*****************************************************************************/
-int im_ne_get_elem_cmap(int  neid,     /* NetCDF/Exodus file ID */
+int im_ne_get_elem_cmap(int  /* neid */,     /* NetCDF/Exodus file ID */
 			int  map_id,   /* Elemental comm map ID */
 			int *elem_ids, /* Element IDs */
 			int *side_ids, /* Element side IDs */
 			int *proc_ids, /* Processor IDs */
-			int  processor /* This processor ID */
+			int  /* processor */ /* This processor ID */
 			)
 /*****************************************************************************/
 {
@@ -244,7 +244,7 @@ int im_ne_get_elem_cmap(int  neid,     /* NetCDF/Exodus file ID */
 }
 
 /*****************************************************************************/
-int im_ne_get_ns_param_global(int neid,	     /* NetCDF/Exodus file ID */
+int im_ne_get_ns_param_global(int /* neid */,	     /* NetCDF/Exodus file ID */
 			      int *ns_ids_glob,     /* Global IDs of node sets */
 			      int *ns_n_cnt_glob,   /* Count of nodes in node sets */
 			      int *ns_df_cnt_glob   /* Count of dist. factors in ns */
@@ -268,7 +268,7 @@ int im_ne_get_ns_param_global(int neid,	     /* NetCDF/Exodus file ID */
 }
 
 /*****************************************************************************/
-int im_ne_get_ss_param_global(int neid,	    /* NetCDF/Exodus file ID */
+int im_ne_get_ss_param_global(int /* neid */,	    /* NetCDF/Exodus file ID */
 			      int *ss_ids_glob,    /* Global side-set IDs */
 			      int *ss_s_cnt_glob,  /* Global side count */
 			      int *ss_df_cnt_glob  /* Global dist. factor count */

--- a/packages/pamgen/mesh_spec_lt/im_ne_c_interface_l.C
+++ b/packages/pamgen/mesh_spec_lt/im_ne_c_interface_l.C
@@ -5,7 +5,7 @@
 
 
 /*****************************************************************************/
-int im_ne_get_init_global_l(int   neid, 		  /* NemesisI file ID */
+int im_ne_get_init_global_l(int   /* neid */, 		  /* NemesisI file ID */
 			  long long  *num_nodes_g,	  /* Number of global FEM nodes */
 			  long long  *num_elems_g,	  /* Number of global FEM elements */
 			  long long  *num_elem_blks_g, /* Number of global elem blocks */
@@ -26,7 +26,7 @@ int im_ne_get_init_global_l(int   neid, 		  /* NemesisI file ID */
 }
 
 /*****************************************************************************/
-int im_ne_get_init_info_l(int   neid,		/* NemesisI file ID */
+int im_ne_get_init_info_l(int   /* neid */,		/* NemesisI file ID */
 			long long  *num_proc,	/* Number of processors */
 			long long  *num_proc_in_f,	/* Number of procs in this file */
 			char *ftype)
@@ -42,7 +42,7 @@ int im_ne_get_init_info_l(int   neid,		/* NemesisI file ID */
 }
 
 /*****************************************************************************/
-int im_ne_get_eb_info_global_l(int neid,		/* NemesisI file ID                 */
+int im_ne_get_eb_info_global_l(int /* neid */,		/* NemesisI file ID                 */
 			     long long *el_blk_ids,	/* Vector of global element IDs     */
 			     long long *el_blk_cnts	/* Vector of global element counts  */
 			     )
@@ -61,7 +61,7 @@ int im_ne_get_eb_info_global_l(int neid,		/* NemesisI file ID                 */
 }
 
 /*****************************************************************************/
-int im_ne_get_loadbal_param_l(int   neid, 	/* NetCDF/Exodus file ID */
+int im_ne_get_loadbal_param_l(int   /* neid */, 	/* NetCDF/Exodus file ID */
 			    long long  *num_int_nodes,  /* Number of internal FEM nodes */
 			    long long  *num_bor_nodes,  /* Number of border FEM nodes */
 			    long long  *num_ext_nodes,  /* Number of external FEM nodes */
@@ -69,7 +69,7 @@ int im_ne_get_loadbal_param_l(int   neid, 	/* NetCDF/Exodus file ID */
 			    long long  *num_bor_elems,  /* Number of border FEM elems */
 			    long long  *num_node_cmaps, /* Number of nodal comm maps */
 			    long long  *num_elem_cmaps, /* Number of elemental comm maps */
-			    long long   processor         /* Processor ID */
+			    long long   /* processor */         /* Processor ID */
 			    )
 /*****************************************************************************/
 {
@@ -89,10 +89,10 @@ int im_ne_get_loadbal_param_l(int   neid, 	/* NetCDF/Exodus file ID */
 }
 
 /*****************************************************************************/
-int im_ne_get_elem_map_l(int   neid,		/* NetCDF/Exodus file ID */
+int im_ne_get_elem_map_l(int   /* neid */,		/* NetCDF/Exodus file ID */
 		       long long  *elem_mapi,	/* Internal element IDs */
 		       long long  *elem_mapb,	/* Border element IDs */
-		       long long   processor		/* Processor ID */
+		       long long   /* processor */		/* Processor ID */
 		       )
 /*****************************************************************************/
 {
@@ -112,11 +112,11 @@ int im_ne_get_elem_map_l(int   neid,		/* NetCDF/Exodus file ID */
 }
 
 /*****************************************************************************/
-int im_ne_get_node_map_l(int   neid,		/* NetCDF/Exodus file ID */
+int im_ne_get_node_map_l(int   /* neid */,		/* NetCDF/Exodus file ID */
 		       long long  *node_mapi,	/* Internal FEM node IDs */
 		       long long  *node_mapb,	/* Border FEM node IDs */
 		       long long  *node_mape,	/* External FEM node IDs */
-		       long long   processor		/* Processor IDs */
+		       long long   /* processor */		/* Processor IDs */
 		       )
 /*****************************************************************************/
 {
@@ -139,12 +139,12 @@ int im_ne_get_node_map_l(int   neid,		/* NetCDF/Exodus file ID */
 }
 
 /*****************************************************************************/
-int im_ne_get_cmap_params_l(int neid,                  /* NetCDF/Exodus file ID */
+int im_ne_get_cmap_params_l(int /* neid */,                  /* NetCDF/Exodus file ID */
 			  long long *node_cmap_ids,        /* Nodal comm. map IDs */
 			  long long *node_cmap_node_cnts,  /* Number of nodes in each map */
 			  long long *elem_cmap_ids,        /* Elemental comm. map IDs */
 			  long long *elem_cmap_elem_cnts,  /* Number of elems in each map */
-			  long long  processor             /* This processor ID */
+			  long long  /* processor */             /* This processor ID */
 			  )
 /*****************************************************************************/
 {
@@ -173,11 +173,11 @@ int im_ne_get_cmap_params_l(int neid,                  /* NetCDF/Exodus file ID 
 }
 
 /*****************************************************************************/
-int im_ne_get_node_cmap_l(int  neid,             /* NetCDF/Exodus file ID */
+int im_ne_get_node_cmap_l(int  /* neid */,             /* NetCDF/Exodus file ID */
 			long long  map_id,           /* Map ID */
 			long long *node_ids,         /* FEM node IDs */
 			long long *proc_ids,         /* Processor IDs */
-			long long  processor         /* This processor ID */
+			long long  /* processor */         /* This processor ID */
 			)
 /*****************************************************************************/
 {
@@ -207,12 +207,12 @@ int im_ne_get_node_cmap_l(int  neid,             /* NetCDF/Exodus file ID */
 }
 
 /*****************************************************************************/
-int im_ne_get_elem_cmap_l(int  neid,     /* NetCDF/Exodus file ID */
+int im_ne_get_elem_cmap_l(int  /* neid */,     /* NetCDF/Exodus file ID */
 			long long  map_id,   /* Elemental comm map ID */
 			long long *elem_ids, /* Element IDs */
 			long long *side_ids, /* Element side IDs */
 			long long *proc_ids, /* Processor IDs */
-			long long  processor /* This processor ID */
+			long long  /* processor */ /* This processor ID */
 			)
 /*****************************************************************************/
 {
@@ -244,7 +244,7 @@ int im_ne_get_elem_cmap_l(int  neid,     /* NetCDF/Exodus file ID */
 }
 
 /*****************************************************************************/
-int im_ne_get_ns_param_global_l(int neid,	     /* NetCDF/Exodus file ID */
+int im_ne_get_ns_param_global_l(int /* neid */,	     /* NetCDF/Exodus file ID */
 			      long long *ns_ids_glob,     /* Global IDs of node sets */
 			      long long *ns_n_cnt_glob,   /* Count of nodes in node sets */
 			      long long *ns_df_cnt_glob   /* Count of dist. factors in ns */
@@ -268,7 +268,7 @@ int im_ne_get_ns_param_global_l(int neid,	     /* NetCDF/Exodus file ID */
 }
 
 /*****************************************************************************/
-int im_ne_get_ss_param_global_l(int neid,	    /* NetCDF/Exodus file ID */
+int im_ne_get_ss_param_global_l(int /* neid */,	    /* NetCDF/Exodus file ID */
 			      long long *ss_ids_glob,    /* Global side-set IDs */
 			      long long *ss_s_cnt_glob,  /* Global side count */
 			      long long *ss_df_cnt_glob  /* Global dist. factor count */
@@ -294,7 +294,7 @@ int im_ne_get_ss_param_global_l(int neid,	    /* NetCDF/Exodus file ID */
 
 
 /*****************************************************************************/
-int im_ne_get_global_ijk_l(int neid,
+int im_ne_get_global_ijk_l(int /* neid */,
                 long long *global_ijk)
 /*****************************************************************************/
 {
@@ -308,7 +308,7 @@ int im_ne_get_global_ijk_l(int neid,
 }
 
 /*****************************************************************************/
-int im_ne_get_num_ijk_l(int neid,
+int im_ne_get_num_ijk_l(int /* neid */,
                 long long *num_ijk)
 /*****************************************************************************/
 {
@@ -322,7 +322,7 @@ int im_ne_get_num_ijk_l(int neid,
 }
 
 /*****************************************************************************/
-int im_ne_get_local_num_ijk_l(int neid,
+int im_ne_get_local_num_ijk_l(int /* neid */,
                 long long *local_num_ijk)
 /*****************************************************************************/
 {

--- a/packages/pamgen/rtcompiler/Function.C
+++ b/packages/pamgen/rtcompiler/Function.C
@@ -188,7 +188,7 @@ Function::~Function()
 }
 
 /*****************************************************************************/
-void Function::checkType(unsigned int index, int size, int* addr, string& errs)
+void Function::checkType(unsigned int index, int size, int* /* addr */, string& errs)
 /*****************************************************************************/
 {
   CHECKARGERR((_vars[index].first->getType() != IntT  ||
@@ -198,7 +198,7 @@ void Function::checkType(unsigned int index, int size, int* addr, string& errs)
 }
 
 /*****************************************************************************/
-void Function::checkType(unsigned int index, int size, long* addr, string& errs)
+void Function::checkType(unsigned int index, int size, long* /* addr */, string& errs)
 /*****************************************************************************/
 {
   CHECKARGERR((_vars[index].first->getType() != LongT  ||
@@ -208,7 +208,7 @@ void Function::checkType(unsigned int index, int size, long* addr, string& errs)
 }
 
 /*****************************************************************************/
-void Function::checkType(unsigned int index, int size, float* addr, string& errs)
+void Function::checkType(unsigned int index, int size, float* /* addr */, string& errs)
 /*****************************************************************************/
 {
   CHECKARGERR((_vars[index].first->getType() != FloatT  ||
@@ -218,7 +218,7 @@ void Function::checkType(unsigned int index, int size, float* addr, string& errs
 }
 
 /*****************************************************************************/
-void Function::checkType(unsigned int index, int size, double* addr, string& errs)
+void Function::checkType(unsigned int index, int size, double* /* addr */, string& errs)
 /*****************************************************************************/
 {
   CHECKARGERR((_vars[index].first->getType() != DoubleT  ||
@@ -228,7 +228,7 @@ void Function::checkType(unsigned int index, int size, double* addr, string& err
 }
 
 /*****************************************************************************/
-void Function::checkType(unsigned int index, int size, char* addr,string& errs)
+void Function::checkType(unsigned int index, int size, char* /* addr */,string& errs)
 /*****************************************************************************/
 {
   CHECKARGERR((_vars[index].first->getType() != CharT  ||

--- a/packages/pamgen/rtcompiler/RTC_OperatorRTC.hh
+++ b/packages/pamgen/rtcompiler/RTC_OperatorRTC.hh
@@ -83,7 +83,7 @@ class AddO : public Operator
   AddO() : Operator("+", false, 6, true) {}
 
   void performOp(Value* arg1, Value* arg2, ScalarNumber<double>& store);
-  void performOp(Value* arg, ScalarNumber<double>& store) {assert(0);}
+  void performOp(Value* /* arg */, ScalarNumber<double>& /* store */) {assert(0);}
 };
 
 class SubtractO : public Operator
@@ -92,7 +92,7 @@ class SubtractO : public Operator
   SubtractO() : Operator("-", false, 6, true) {}
 
   void performOp(Value* arg1, Value* arg2, ScalarNumber<double>& store);
-  void performOp(Value* arg, ScalarNumber<double>& store) {assert(0);}
+  void performOp(Value* /* arg */, ScalarNumber<double>& /* store */) {assert(0);}
 };
 
 class MultiplyO : public Operator
@@ -101,7 +101,7 @@ class MultiplyO : public Operator
   MultiplyO() : Operator("*", false, 7, true) {}
 
   void performOp(Value* arg1, Value* arg2, ScalarNumber<double>& store);
-  void performOp(Value* arg, ScalarNumber<double>& store) {assert(0);}
+  void performOp(Value* /* arg */, ScalarNumber<double>& /* store */) {assert(0);}
 };
 
 class DivideO : public Operator
@@ -110,7 +110,7 @@ class DivideO : public Operator
   DivideO() : Operator("/", false, 7, true) {}
 
   void performOp(Value* arg1, Value* arg2, ScalarNumber<double>& store);
-  void performOp(Value* arg, ScalarNumber<double>& store) {assert(0);}
+  void performOp(Value* /* arg */, ScalarNumber<double>& /* store */) {assert(0);}
 };
 
 class EqualityO : public Operator
@@ -119,7 +119,7 @@ class EqualityO : public Operator
   EqualityO() : Operator("==", false, 3, true) {}
 
   void performOp(Value* arg1, Value* arg2, ScalarNumber<double>& store);
-  void performOp(Value* arg, ScalarNumber<double>& store) {assert(0);}
+  void performOp(Value* /* arg */, ScalarNumber<double>& /* store */) {assert(0);}
 };
 
 class GreaterO : public Operator
@@ -128,7 +128,7 @@ class GreaterO : public Operator
   GreaterO() : Operator(">", false, 4, true) {}
 
   void performOp(Value* arg1, Value* arg2, ScalarNumber<double>& store);
-  void performOp(Value* arg, ScalarNumber<double>& store) {assert(0);}
+  void performOp(Value* /* arg */, ScalarNumber<double>& /* store */) {assert(0);}
 };
 
 class LessO : public Operator
@@ -137,7 +137,7 @@ class LessO : public Operator
   LessO() : Operator("<", false, 4, true) {}
 
   void performOp(Value* arg1, Value* arg2, ScalarNumber<double>& store);
-  void performOp(Value* arg, ScalarNumber<double>& store) {assert(0);}
+  void performOp(Value* /* arg */, ScalarNumber<double>& /* store */) {assert(0);}
 };
 
 class GreaterEqualO : public Operator
@@ -146,7 +146,7 @@ class GreaterEqualO : public Operator
   GreaterEqualO() : Operator(">=", false, 4, true) {}
 
   void performOp(Value* arg1, Value* arg2, ScalarNumber<double>& store);
-  void performOp(Value* arg, ScalarNumber<double>& store) {assert(0);}
+  void performOp(Value* /* arg */, ScalarNumber<double>& /* store */) {assert(0);}
 };
 
 class LessEqualO : public Operator
@@ -155,7 +155,7 @@ class LessEqualO : public Operator
   LessEqualO() : Operator("<=", false, 4, true) {}
 
   void performOp(Value* arg1, Value* arg2, ScalarNumber<double>& store);
-  void performOp(Value* arg, ScalarNumber<double>& store) {assert(0);}
+  void performOp(Value* /* arg */, ScalarNumber<double>& /* store */) {assert(0);}
 };
 
 class AssignmentO : public Operator
@@ -164,7 +164,7 @@ class AssignmentO : public Operator
   AssignmentO() : Operator("=", false, 0, false) {}
 
   void performOp(Value* arg1, Value* arg2, ScalarNumber<double>& store);
-  void performOp(Value* arg, ScalarNumber<double>& store) {assert(0);}
+  void performOp(Value* /* arg */, ScalarNumber<double>& /* store */) {assert(0);}
 };
 
 class LogicOrO : public Operator
@@ -173,7 +173,7 @@ class LogicOrO : public Operator
   LogicOrO() : Operator("||", false, 1, true) {}
 
   void performOp(Value* arg1, Value* arg2, ScalarNumber<double>& store);
-  void performOp(Value* arg, ScalarNumber<double>& store) {assert(0);}
+  void performOp(Value* /* arg */, ScalarNumber<double>& /* store */) {assert(0);}
 };
 
 class LogicAndO : public Operator
@@ -182,7 +182,7 @@ class LogicAndO : public Operator
   LogicAndO() : Operator("&&", false, 2, true) {}
 
   void performOp(Value* arg1, Value* arg2, ScalarNumber<double>& store);
-  void performOp(Value* arg, ScalarNumber<double>& store) {assert(0);}
+  void performOp(Value* /* arg */, ScalarNumber<double>& /* store */) {assert(0);}
 };
 
 class InEqualityO : public Operator
@@ -191,7 +191,7 @@ class InEqualityO : public Operator
   InEqualityO() : Operator("!=", false, 3, true) {}
 
   void performOp(Value* arg1, Value* arg2, ScalarNumber<double>& store);
-  void performOp(Value* arg, ScalarNumber<double>& store) {assert(0);}
+  void performOp(Value* /* arg */, ScalarNumber<double>& /* store */) {assert(0);}
 };
 
 class ModuloO : public Operator
@@ -200,7 +200,7 @@ class ModuloO : public Operator
   ModuloO() : Operator("%", false, 7, true) {}
 
   void performOp(Value* arg1, Value* arg2, ScalarNumber<double>& store);
-  void performOp(Value* arg, ScalarNumber<double>& store) {assert(0);}
+  void performOp(Value* /* arg */, ScalarNumber<double>& /* store */) {assert(0);}
 };
 
 class ExponentO : public Operator
@@ -209,7 +209,7 @@ class ExponentO : public Operator
   ExponentO() : Operator("^", false, 8, false) {}
 
   void performOp(Value* arg1, Value* arg2, ScalarNumber<double>& store);
-  void performOp(Value* arg, ScalarNumber<double>& store) {assert(0);}
+  void performOp(Value* /* arg */, ScalarNumber<double>& /* store */) {assert(0);}
 };
 
 //Important - OpenParen, CloseParen, and ArrayInit are structural operators,
@@ -219,8 +219,8 @@ class OpenParenO : public Operator
  public:
   OpenParenO() : Operator("(", false, 0, true) {}
 
-  void performOp(Value* arg1, Value* arg2, ScalarNumber<double>& store) {assert(0);}
-  void performOp(Value* arg, ScalarNumber<double>& store) {assert(0);}
+  void performOp(Value* /* arg1 */, Value* /* arg2 */, ScalarNumber<double>& /* store */) {assert(0);}
+  void performOp(Value* /* arg */, ScalarNumber<double>& /* store */) {assert(0);}
 };
 
 class CloseParenO : public Operator
@@ -228,8 +228,8 @@ class CloseParenO : public Operator
  public:
   CloseParenO() : Operator(")", false, 0, true) {}
 
-  void performOp(Value* arg1, Value* arg2, ScalarNumber<double>& store){assert(0);}
-  void performOp(Value* arg, ScalarNumber<double>& store) {assert(0);}
+  void performOp(Value* /* arg1 */, Value* /* arg2 */, ScalarNumber<double>& /* store */){assert(0);}
+  void performOp(Value* /* arg */, ScalarNumber<double>& /* store */) {assert(0);}
 };
 
 class ArrayInitO : public Operator
@@ -237,8 +237,8 @@ class ArrayInitO : public Operator
  public:
   ArrayInitO() : Operator("init", false, 0, true) {}
 
-  void performOp(Value* arg1, Value* arg2, ScalarNumber<double>& store){assert(0);}
-  void performOp(Value* arg, ScalarNumber<double>& store) {assert(0);}
+  void performOp(Value* /* arg1 */, Value* /* arg2 */, ScalarNumber<double>& /* store */){assert(0);}
+  void performOp(Value* /* arg */, ScalarNumber<double>& /* store */) {assert(0);}
 };
 
 class NegationO : public Operator
@@ -246,7 +246,7 @@ class NegationO : public Operator
  public:
   NegationO() : Operator("_", true, 11, false) {}
 
-  void performOp(Value* arg1, Value* arg2, ScalarNumber<double>& store) {assert(0);}
+  void performOp(Value* /* arg1 */, Value* /* arg2 */, ScalarNumber<double>& /* store */) {assert(0);}
   void performOp(Value* arg, ScalarNumber<double>& store);
 };
 
@@ -255,7 +255,7 @@ class LogicNotO : public Operator
  public:
   LogicNotO() : Operator("!", true, 11, false) {}
 
-  void performOp(Value* arg1, Value* arg2, ScalarNumber<double>& store) {assert(0);}
+  void performOp(Value* /* arg1 */, Value* /* arg2 */, ScalarNumber<double>& /* store */) {assert(0);}
   void performOp(Value* arg, ScalarNumber<double>& store);
 };
 

--- a/packages/pamgen/rtcompiler/RTC_ValueRTC.hh
+++ b/packages/pamgen/rtcompiler/RTC_ValueRTC.hh
@@ -41,17 +41,17 @@ class Value: public Object
   /**
    * getValue -> Should not be called
    */
-  virtual double getArrayValue(long offset) const { assert(false); return 0;}
+  virtual double getArrayValue(long /* offset */) const { assert(false); return 0;}
 
   /**
    * setValue -> Should not be called
    */
-  virtual void setValue(double value) { assert(false); }
+  virtual void setValue(double /* value */) { assert(false); }
 
   /**
    * setArrayValue -> Should not be called
    */
-  virtual void setArrayValue(double value, long offset) { assert(false); }
+  virtual void setArrayValue(double /* value */, long /* offset */) { assert(false); }
 
   /**
    * getSize - The size of everything is zero, except for arrays

--- a/packages/pamgen/rtcompiler/RTC_VariableRTC.hh
+++ b/packages/pamgen/rtcompiler/RTC_VariableRTC.hh
@@ -49,7 +49,7 @@ class Variable: public Value
   /**
    * setSize - Applies to arrays only, no-op here
    */
-  virtual void setSize(long size) {}
+  virtual void setSize(long /* size */) {}
 
   /**
    * evaluateSizeExpr - Applies to arrays only, no-op here

--- a/packages/pamgen/src/element_density_function.C
+++ b/packages/pamgen/src/element_density_function.C
@@ -7,7 +7,7 @@ namespace PAMGEN_NEVADA {
   /*****************************************************************************/
   void Element_Density_Function::Display_Class(
       std::ostream& s,
-      const std::string &indent
+      const std::string &/* indent */
       )
   {
     s << std::endl

--- a/packages/pamgen/src/geometry_transform.C
+++ b/packages/pamgen/src/geometry_transform.C
@@ -4,7 +4,7 @@
 namespace PAMGEN_NEVADA {
 
 /*****************************************************************************/
-void Geometry_Transform::Display_Class(std::ostream& s, const std::string &indent)
+void Geometry_Transform::Display_Class(std::ostream& s, const std::string &/* indent */)
 /*****************************************************************************/
 {
   s << std::endl 

--- a/packages/pamgen/src/inline_mesh_desc.C
+++ b/packages/pamgen/src/inline_mesh_desc.C
@@ -1402,7 +1402,7 @@ void Inline_Mesh_Desc::get_l_i_j_k_from_element_number(long long el,
 //! A utility function to build up required bookkeeping objects.
 /****************************************************************************/
 void Inline_Mesh_Desc::get_l_i_j_k_from_node_number(long long nn,
-								 long long & l,
+								 long long & /* l */,
 								 long long & i,
 								 long long & j,
 								 long long & k)
@@ -1415,7 +1415,7 @@ void Inline_Mesh_Desc::get_l_i_j_k_from_node_number(long long nn,
 }
 
 /****************************************************************************/
-long long Inline_Mesh_Desc::get_element_number_from_l_i_j_k( long long  l,
+long long Inline_Mesh_Desc::get_element_number_from_l_i_j_k( long long  /* l */,
 						       long long  i,
 						       long long  j,
 						       long long  k)
@@ -1447,7 +1447,7 @@ long long Inline_Mesh_Desc::get_element_number_from_l_i_j_k( long long  l,
 }
 
 /****************************************************************************/
-long long Inline_Mesh_Desc::get_node_number_from_l_i_j_k( long long  l,
+long long Inline_Mesh_Desc::get_node_number_from_l_i_j_k( long long  /* l */,
 							  long long  i,
 							  long long  j,
 							  long long  k)

--- a/packages/pamgen/src/inline_mesh_desc.h
+++ b/packages/pamgen/src/inline_mesh_desc.h
@@ -70,9 +70,9 @@ namespace PAMGEN_NEVADA {
       long long Check_Spans();
 
       virtual void calculateSize(
-          long long & total_el_count,
-          long long & total_node_count,
-          long long & total_edge_count
+          long long & /* total_el_count */,
+          long long & /* total_node_count */,
+          long long & /* total_edge_count */
           )
       {
       };
@@ -328,10 +328,10 @@ namespace PAMGEN_NEVADA {
       // private:
       virtual long long Calc_Coord_Vectors();
       virtual void Populate_Coords(
-          double * coords,
-          std::vector<long long> & global_node_vector,
-          std::map <long long, long long> & global_node_map,
-          long long num_nodes
+          double * /* coords */,
+          std::vector<long long> & /* global_node_vector */,
+          std::map <long long, long long> & /* global_node_map */,
+          long long /* num_nodes */
           )
       {};
 

--- a/packages/pamgen/src/radial_trisection_inline_mesh_desc.C
+++ b/packages/pamgen/src/radial_trisection_inline_mesh_desc.C
@@ -1556,7 +1556,7 @@ LoopLimits Radial_Trisection_Inline_Mesh_Desc::get_tri_block_limits(bool is_bloc
 
 //! Reads in/creates the serial component of the unstructured mesh in parallel
 /****************************************************************************/
-void Radial_Trisection_Inline_Mesh_Desc::Calc_Serial_Component(const std::set <long long> &gloabl_element_ids,
+void Radial_Trisection_Inline_Mesh_Desc::Calc_Serial_Component(const std::set <long long> &/* gloabl_element_ids */,
                                                                const std::vector<long long> & global_node_vector)
 /****************************************************************************/
 {
@@ -2017,7 +2017,7 @@ void Radial_Trisection_Inline_Mesh_Desc::Populate_Map_and_Global_Element_List(lo
   }
 }
 /****************************************************************************/
-long long Radial_Trisection_Inline_Mesh_Desc::GetBlockBasedGlobalID(long long the_el,long long bct)
+long long Radial_Trisection_Inline_Mesh_Desc::GetBlockBasedGlobalID(long long the_el,long long /* bct */)
 /****************************************************************************/
 {
   long long l;


### PR DESCRIPTION
@trilinos/pamgen 

## Description
Comment out parameter names in function definitions to avoid
`-Wunused-parameter` warnings.

## Motivation and Context
Clean build.