### PR TITLE
Thyra:  Remove Unused Parameter Warnings

### DIFF
--- a/packages/thyra/adapters/epetra/src/Thyra_DiagonalEpetraLinearOpWithSolveFactory.cpp
+++ b/packages/thyra/adapters/epetra/src/Thyra_DiagonalEpetraLinearOpWithSolveFactory.cpp
@@ -85,7 +85,7 @@ DiagonalEpetraLinearOpWithSolveFactory::createOp() const
 void DiagonalEpetraLinearOpWithSolveFactory::initializeOp(
   const RCP<const LinearOpSourceBase<double> >    &fwdOpSrc
   ,LinearOpWithSolveBase<double>                                   *Op
-  ,const ESupportSolveUse                                          supportSolveUse
+  ,const ESupportSolveUse                                          /* supportSolveUse */
   ) const
 {
   using Teuchos::outArg;
@@ -126,7 +126,7 @@ void DiagonalEpetraLinearOpWithSolveFactory::uninitializeOp(
   ,RCP<const LinearOpSourceBase<double> >    *fwdOpSrc
   ,RCP<const PreconditionerBase<double> >    *prec
   ,RCP<const LinearOpSourceBase<double> >    *approxFwdOpSrc
-  ,ESupportSolveUse                                           *supportSolveUse
+  ,ESupportSolveUse                                           * /* supportSolveUse */
   ) const
 {
   using Teuchos::get_extra_data;
@@ -155,7 +155,7 @@ void DiagonalEpetraLinearOpWithSolveFactory::uninitializeOp(
 
 
 void DiagonalEpetraLinearOpWithSolveFactory::setParameterList(
-  RCP<Teuchos::ParameterList> const& paramList
+  RCP<Teuchos::ParameterList> const& /* paramList */
   )
 {}
 

--- a/packages/thyra/adapters/epetra/src/Thyra_EpetraLinearOp.cpp
+++ b/packages/thyra/adapters/epetra/src/Thyra_EpetraLinearOp.cpp
@@ -158,7 +158,7 @@ void EpetraLinearOp::partiallyInitialize(
 }
 
 
-void EpetraLinearOp::setFullyInitialized(bool isFullyInitialized)
+void EpetraLinearOp::setFullyInitialized(bool /* isFullyInitialized */)
 {
   // ToDo: Validate that everything matches up!
   isFullyInitialized_ = true;
@@ -599,7 +599,7 @@ void EpetraLinearOp::getRowStatImpl(
 RCP< const SpmdVectorSpaceBase<double> > 
 EpetraLinearOp::allocateDomain(
   const RCP<Epetra_Operator> &op,
-  EOpTransp op_trans
+  EOpTransp /* op_trans */
   ) const
 {
   return Teuchos::rcp_dynamic_cast<const SpmdVectorSpaceBase<double> >(
@@ -612,7 +612,7 @@ EpetraLinearOp::allocateDomain(
 RCP<const SpmdVectorSpaceBase<double> > 
 EpetraLinearOp::allocateRange(
   const RCP<Epetra_Operator> &op,
-  EOpTransp op_trans
+  EOpTransp /* op_trans */
   ) const
 {
   return Teuchos::rcp_dynamic_cast<const SpmdVectorSpaceBase<double> >(

--- a/packages/thyra/adapters/epetra/src/Thyra_EpetraOperatorViewExtractorStd.cpp
+++ b/packages/thyra/adapters/epetra/src/Thyra_EpetraOperatorViewExtractorStd.cpp
@@ -68,12 +68,12 @@ bool EpetraOperatorViewExtractorStd::isCompatible( const LinearOpBase<double> &f
 
 
 void EpetraOperatorViewExtractorStd::getNonconstEpetraOpView(
-  const RCP<LinearOpBase<double> > &fwdOp,
-  const Ptr<RCP<Epetra_Operator> > &epetraOp,
-  const Ptr<EOpTransp> &epetraOpTransp,
-  const Ptr<EApplyEpetraOpAs> &epetraOpApplyAs,
-  const Ptr<EAdjointEpetraOp> &epetraOpAdjointSupport,
-    const Ptr<double> &epetraOpScalar
+  const RCP<LinearOpBase<double> > &/* fwdOp */,
+  const Ptr<RCP<Epetra_Operator> > &/* epetraOp */,
+  const Ptr<EOpTransp> &/* epetraOpTransp */,
+  const Ptr<EApplyEpetraOpAs> &/* epetraOpApplyAs */,
+  const Ptr<EAdjointEpetraOp> &/* epetraOpAdjointSupport */,
+    const Ptr<double> &/* epetraOpScalar */
   ) const
 {
   TEUCHOS_TEST_FOR_EXCEPT(true);

--- a/packages/thyra/adapters/epetra/src/Thyra_EpetraOperatorWrapper.cpp
+++ b/packages/thyra/adapters/epetra/src/Thyra_EpetraOperatorWrapper.cpp
@@ -178,8 +178,8 @@ int EpetraOperatorWrapper::Apply(const Epetra_MultiVector& X,
 }
 
 
-int EpetraOperatorWrapper::ApplyInverse(const Epetra_MultiVector& X, 
-  Epetra_MultiVector& Y) const
+int EpetraOperatorWrapper::ApplyInverse(const Epetra_MultiVector& /* X */, 
+  Epetra_MultiVector& /* Y */) const
 {
   TEUCHOS_TEST_FOR_EXCEPTION(true, std::runtime_error,
     "EpetraOperatorWrapper::ApplyInverse not implemented");

--- a/packages/thyra/adapters/epetraext/src/model_evaluator/Thyra_EpetraModelEvaluator.cpp
+++ b/packages/thyra/adapters/epetraext/src/model_evaluator/Thyra_EpetraModelEvaluator.cpp
@@ -532,7 +532,7 @@ void EpetraModelEvaluator::reportFinalPoint(
 
 
 RCP<LinearOpBase<double> >
-EpetraModelEvaluator::create_DfDp_op_impl(int l) const
+EpetraModelEvaluator::create_DfDp_op_impl(int /* l */) const
 {
   TEUCHOS_TEST_FOR_EXCEPT(true);
   TEUCHOS_UNREACHABLE_RETURN(Teuchos::null);
@@ -540,7 +540,7 @@ EpetraModelEvaluator::create_DfDp_op_impl(int l) const
 
 
 RCP<LinearOpBase<double> >
-EpetraModelEvaluator::create_DgDx_dot_op_impl(int j) const
+EpetraModelEvaluator::create_DgDx_dot_op_impl(int /* j */) const
 {
   TEUCHOS_TEST_FOR_EXCEPT(true);
   TEUCHOS_UNREACHABLE_RETURN(Teuchos::null);
@@ -548,7 +548,7 @@ EpetraModelEvaluator::create_DgDx_dot_op_impl(int j) const
 
 
 RCP<LinearOpBase<double> >
-EpetraModelEvaluator::create_DgDx_op_impl(int j) const
+EpetraModelEvaluator::create_DgDx_op_impl(int /* j */) const
 {
   TEUCHOS_TEST_FOR_EXCEPT(true);
   TEUCHOS_UNREACHABLE_RETURN(Teuchos::null);
@@ -556,7 +556,7 @@ EpetraModelEvaluator::create_DgDx_op_impl(int j) const
 
 
 RCP<LinearOpBase<double> >
-EpetraModelEvaluator::create_DgDp_op_impl( int j, int l ) const
+EpetraModelEvaluator::create_DgDp_op_impl( int /* j */, int /* l */ ) const
 {
   TEUCHOS_TEST_FOR_EXCEPT(true);
   TEUCHOS_UNREACHABLE_RETURN(Teuchos::null);
@@ -1272,11 +1272,11 @@ void EpetraModelEvaluator::postEvalScalingSetup(
 
 
 void EpetraModelEvaluator::finishConvertingOutArgsFromEpetraToThyra(
-  const EpetraExt::ModelEvaluator::OutArgs &epetraOutArgs,
+  const EpetraExt::ModelEvaluator::OutArgs &/* epetraOutArgs */,
   RCP<LinearOpBase<double> > &W_op,
   RCP<EpetraLinearOp> &efwdW,
-  RCP<Epetra_Operator> &eW,
-  const ModelEvaluatorBase::OutArgs<double> &outArgs
+  RCP<Epetra_Operator> &/* eW */,
+  const ModelEvaluatorBase::OutArgs<double> &/* outArgs */
   ) const
 {
 
@@ -1650,8 +1650,8 @@ Thyra::convert(
 EpetraExt::ModelEvaluator::MPDerivative
 Thyra::convert(
   const ModelEvaluatorBase::MPDerivative &derivative,
-  const RCP<const Epetra_Map> &fnc_map,
-  const RCP<const Epetra_Map> &var_map
+  const RCP<const Epetra_Map> &/* fnc_map */,
+  const RCP<const Epetra_Map> &/* var_map */
   )
 {
   //typedef ModelEvaluatorBase MEB; // unused

--- a/packages/thyra/adapters/epetraext/src/transformer/Thyra_EpetraExtAddTransformer.cpp
+++ b/packages/thyra/adapters/epetraext/src/transformer/Thyra_EpetraExtAddTransformer.cpp
@@ -72,7 +72,7 @@ namespace Thyra {
 
 
 bool EpetraExtAddTransformer::isCompatible(
-      const LinearOpBase<double> &op_in) const
+      const LinearOpBase<double> &/* op_in */) const
 {
    TEUCHOS_TEST_FOR_EXCEPT(true);
    TEUCHOS_UNREACHABLE_RETURN(false);

--- a/packages/thyra/adapters/epetraext/src/transformer/Thyra_EpetraExtDiagScaledMatProdTransformer.cpp
+++ b/packages/thyra/adapters/epetraext/src/transformer/Thyra_EpetraExtDiagScaledMatProdTransformer.cpp
@@ -62,7 +62,7 @@ namespace Thyra {
 
 
 bool EpetraExtDiagScaledMatProdTransformer::isCompatible(
-      const LinearOpBase<double> &op_in) const
+      const LinearOpBase<double> &/* op_in */) const
 {
    TEUCHOS_TEST_FOR_EXCEPT(true);
    TEUCHOS_UNREACHABLE_RETURN(false);

--- a/packages/thyra/core/src/interfaces/nonlinear/model_evaluator/fundamental/Thyra_ModelEvaluatorBase_decl.hpp
+++ b/packages/thyra/core/src/interfaces/nonlinear/model_evaluator/fundamental/Thyra_ModelEvaluatorBase_decl.hpp
@@ -601,7 +601,7 @@ public:
     std::string description() const {return "\n";}
     /** \brief . */
     void describe( 
-      Teuchos::FancyOStream &out, const Teuchos::EVerbosityLevel verbLevel
+      Teuchos::FancyOStream &/* out */, const Teuchos::EVerbosityLevel /* verbLevel */
       ) const {}
   private:
     RCP<Stokhos::ProductEpetraMultiVector > mv_;
@@ -666,7 +666,7 @@ public:
     std::string description() const {return "\n";}
     /** \brief . */
     void describe( 
-      Teuchos::FancyOStream &out, const Teuchos::EVerbosityLevel verbLevel
+      Teuchos::FancyOStream &/* out */, const Teuchos::EVerbosityLevel /* verbLevel */
       ) const {}
   private:
     RCP<Stokhos::ProductEpetraOperator > lo_;

--- a/packages/thyra/core/src/interfaces/nonlinear/model_evaluator/fundamental/Thyra_ModelEvaluatorBase_def.hpp
+++ b/packages/thyra/core/src/interfaces/nonlinear/model_evaluator/fundamental/Thyra_ModelEvaluatorBase_def.hpp
@@ -123,7 +123,7 @@ bool ModelEvaluatorBase::InArgs<Scalar>::supports(EInArgsMembers arg) const
 }
 
 template<class Scalar>
-bool ModelEvaluatorBase::InArgs<Scalar>::supports(EInArgs_p_mp arg, int l) const
+bool ModelEvaluatorBase::InArgs<Scalar>::supports(EInArgs_p_mp /* arg */, int l) const
 {
   assert_l(l);
   return supports_p_mp_[l];
@@ -557,7 +557,7 @@ void ModelEvaluatorBase::InArgs<Scalar>::_setSupports(
 
 template<class Scalar>
 void ModelEvaluatorBase::InArgs<Scalar>::_setSupports(
-  EInArgs_p_mp arg, int l, bool supports_in
+  EInArgs_p_mp /* arg */, int l, bool supports_in
   )
 {
   assert_l(l);
@@ -620,7 +620,7 @@ void ModelEvaluatorBase::InArgs<Scalar>::assert_supports(
 
 template<class Scalar>
 void ModelEvaluatorBase::InArgs<Scalar>::assert_supports(
-  EInArgs_p_mp arg, int l
+  EInArgs_p_mp /* arg */, int l
   ) const
 {
   assert_l(l);
@@ -787,7 +787,7 @@ bool ModelEvaluatorBase::OutArgs<Scalar>::supports(
 template<class Scalar>
 const ModelEvaluatorBase::DerivativeSupport&
 ModelEvaluatorBase::OutArgs<Scalar>::supports(
-  EOutArgsDfDp arg, int l
+  EOutArgsDfDp /* arg */, int l
   ) const
 {
   assert_l(l);
@@ -798,7 +798,7 @@ ModelEvaluatorBase::OutArgs<Scalar>::supports(
 template<class Scalar>
 const ModelEvaluatorBase::DerivativeSupport&
 ModelEvaluatorBase::OutArgs<Scalar>::supports(
-  EOutArgsDgDx_dot arg, int j
+  EOutArgsDgDx_dot /* arg */, int j
   ) const
 {
   assert_j(j);
@@ -809,7 +809,7 @@ ModelEvaluatorBase::OutArgs<Scalar>::supports(
 template<class Scalar>
 const ModelEvaluatorBase::DerivativeSupport&
 ModelEvaluatorBase::OutArgs<Scalar>::supports(
-  EOutArgsDgDx arg, int j
+  EOutArgsDgDx /* arg */, int j
   ) const
 {
   assert_j(j);
@@ -820,7 +820,7 @@ ModelEvaluatorBase::OutArgs<Scalar>::supports(
 template<class Scalar>
 const ModelEvaluatorBase::DerivativeSupport&
 ModelEvaluatorBase::OutArgs<Scalar>::supports(
-  EOutArgsDgDp arg, int j, int l
+  EOutArgsDgDp /* arg */, int j, int l
   ) const
 {
   assert_j(j);
@@ -832,7 +832,7 @@ ModelEvaluatorBase::OutArgs<Scalar>::supports(
 template<class Scalar>
 bool
 ModelEvaluatorBase::OutArgs<Scalar>::supports(
-  EOutArgs_g_mp arg, int j
+  EOutArgs_g_mp /* arg */, int j
   ) const
 {
   assert_j(j);
@@ -842,7 +842,7 @@ ModelEvaluatorBase::OutArgs<Scalar>::supports(
 template<class Scalar>
 const ModelEvaluatorBase::DerivativeSupport&
 ModelEvaluatorBase::OutArgs<Scalar>::supports(
-  EOutArgsDfDp_mp arg, int l
+  EOutArgsDfDp_mp /* arg */, int l
   ) const
 {
   assert_l(l);
@@ -853,7 +853,7 @@ ModelEvaluatorBase::OutArgs<Scalar>::supports(
 template<class Scalar>
 const ModelEvaluatorBase::DerivativeSupport&
 ModelEvaluatorBase::OutArgs<Scalar>::supports(
-  EOutArgsDgDx_dot_mp arg, int j
+  EOutArgsDgDx_dot_mp /* arg */, int j
   ) const
 {
   assert_j(j);
@@ -864,7 +864,7 @@ ModelEvaluatorBase::OutArgs<Scalar>::supports(
 template<class Scalar>
 const ModelEvaluatorBase::DerivativeSupport&
 ModelEvaluatorBase::OutArgs<Scalar>::supports(
-  EOutArgsDgDx_mp arg, int j
+  EOutArgsDgDx_mp /* arg */, int j
   ) const
 {
   assert_j(j);
@@ -875,7 +875,7 @@ ModelEvaluatorBase::OutArgs<Scalar>::supports(
 template<class Scalar>
 const ModelEvaluatorBase::DerivativeSupport&
 ModelEvaluatorBase::OutArgs<Scalar>::supports(
-  EOutArgsDgDp_mp arg, int j, int l
+  EOutArgsDgDp_mp /* arg */, int j, int l
   ) const
 {
   assert_j(j);
@@ -1757,7 +1757,7 @@ void ModelEvaluatorBase::OutArgs<Scalar>::_setSupports(
 
 template<class Scalar>
 void ModelEvaluatorBase::OutArgs<Scalar>::_setSupports(
-  EOutArgsDfDp arg, int l, const DerivativeSupport& supports_in
+  EOutArgsDfDp /* arg */, int l, const DerivativeSupport& supports_in
   )
 {
   assert_supports(OUT_ARG_f);
@@ -1768,7 +1768,7 @@ void ModelEvaluatorBase::OutArgs<Scalar>::_setSupports(
 
 template<class Scalar>
 void ModelEvaluatorBase::OutArgs<Scalar>::_setSupports(
-  EOutArgsDgDx_dot arg, int j, const DerivativeSupport& supports_in
+  EOutArgsDgDx_dot /* arg */, int j, const DerivativeSupport& supports_in
   )
 {
   assert_j(j);
@@ -1778,7 +1778,7 @@ void ModelEvaluatorBase::OutArgs<Scalar>::_setSupports(
 
 template<class Scalar>
 void ModelEvaluatorBase::OutArgs<Scalar>::_setSupports(
-  EOutArgsDgDx arg, int j, const DerivativeSupport& supports_in
+  EOutArgsDgDx /* arg */, int j, const DerivativeSupport& supports_in
   )
 {
   assert_j(j);
@@ -1788,7 +1788,7 @@ void ModelEvaluatorBase::OutArgs<Scalar>::_setSupports(
 
 template<class Scalar>
 void ModelEvaluatorBase::OutArgs<Scalar>::_setSupports(
-  EOutArgsDgDp arg, int j, int l, const DerivativeSupport& supports_in
+  EOutArgsDgDp /* arg */, int j, int l, const DerivativeSupport& supports_in
   )
 {
   assert_j(j);
@@ -1799,7 +1799,7 @@ void ModelEvaluatorBase::OutArgs<Scalar>::_setSupports(
 
 template<class Scalar>
 void ModelEvaluatorBase::OutArgs<Scalar>::_setSupports(
-  EOutArgs_g_mp arg, int j, bool supports_in
+  EOutArgs_g_mp /* arg */, int j, bool supports_in
   )
 {
   //assert_supports(OUT_ARG_g_mp,j);
@@ -1810,7 +1810,7 @@ void ModelEvaluatorBase::OutArgs<Scalar>::_setSupports(
 
 template<class Scalar>
 void ModelEvaluatorBase::OutArgs<Scalar>::_setSupports(
-  EOutArgsDfDp_mp arg, int l, const DerivativeSupport& supports_in
+  EOutArgsDfDp_mp /* arg */, int l, const DerivativeSupport& supports_in
   )
 {
   assert_supports(OUT_ARG_f_mp); //JF this is not in epetraext ME
@@ -1821,7 +1821,7 @@ void ModelEvaluatorBase::OutArgs<Scalar>::_setSupports(
 
 template<class Scalar>
 void ModelEvaluatorBase::OutArgs<Scalar>::_setSupports(
-  EOutArgsDgDx_dot_mp arg, int j, const DerivativeSupport& supports_in
+  EOutArgsDgDx_dot_mp /* arg */, int j, const DerivativeSupport& supports_in
   )
 {
   assert_j(j);
@@ -1831,7 +1831,7 @@ void ModelEvaluatorBase::OutArgs<Scalar>::_setSupports(
 
 template<class Scalar>
 void ModelEvaluatorBase::OutArgs<Scalar>::_setSupports(
-  EOutArgsDgDx_mp arg, int j, const DerivativeSupport& supports_in
+  EOutArgsDgDx_mp /* arg */, int j, const DerivativeSupport& supports_in
   )
 {
   assert_j(j);
@@ -1841,7 +1841,7 @@ void ModelEvaluatorBase::OutArgs<Scalar>::_setSupports(
 
 template<class Scalar>
 void ModelEvaluatorBase::OutArgs<Scalar>::_setSupports(
-  EOutArgsDgDp_mp arg, int j, int l, const DerivativeSupport& supports_in
+  EOutArgsDgDp_mp /* arg */, int j, int l, const DerivativeSupport& supports_in
   )
 {
   assert_j(j);
@@ -2153,7 +2153,7 @@ void ModelEvaluatorBase::OutArgs<Scalar>::assert_supports(
 
 template<class Scalar>
 void ModelEvaluatorBase::OutArgs<Scalar>::assert_supports(
-  EOutArgs_g_mp arg, int j
+  EOutArgs_g_mp /* arg */, int j
   ) const
 {
   assert_j(j);

--- a/packages/thyra/core/src/interfaces/operator_solve/fundamental/Thyra_LinearOpWithSolveBase_decl.hpp
+++ b/packages/thyra/core/src/interfaces/operator_solve/fundamental/Thyra_LinearOpWithSolveBase_decl.hpp
@@ -466,8 +466,8 @@ protected:
   virtual bool solveSupportsImpl(EOpTransp transp) const;
 
   /** \brief Virtual implementation of <tt>solveSupports()</tt>. */
-  virtual bool solveSupportsNewImpl(EOpTransp transp,
-    const Ptr<const SolveCriteria<Scalar> > solveCriteria
+  virtual bool solveSupportsNewImpl(EOpTransp /* transp */,
+    const Ptr<const SolveCriteria<Scalar> > /* solveCriteria */
     ) const
     {
       TEUCHOS_TEST_FOR_EXCEPT(true);

--- a/packages/thyra/core/src/interfaces/operator_solve/fundamental/Thyra_LinearOpWithSolveFactoryBase_def.hpp
+++ b/packages/thyra/core/src/interfaces/operator_solve/fundamental/Thyra_LinearOpWithSolveFactoryBase_def.hpp
@@ -58,8 +58,8 @@ bool LinearOpWithSolveFactoryBase<Scalar>::acceptsPreconditionerFactory() const
 
 template<class Scalar>
 void LinearOpWithSolveFactoryBase<Scalar>::setPreconditionerFactory(
-  const RCP<PreconditionerFactoryBase<Scalar> > &precFactory
-  ,const std::string &precFactoryName
+  const RCP<PreconditionerFactoryBase<Scalar> > &/* precFactory */
+  ,const std::string &/* precFactoryName */
   )
 {
   TEUCHOS_TEST_FOR_EXCEPTION(
@@ -101,7 +101,7 @@ void LinearOpWithSolveFactoryBase<Scalar>::initializeAndReuseOp(
 
 template<class Scalar>
 bool LinearOpWithSolveFactoryBase<Scalar>::supportsPreconditionerInputType(
-  const EPreconditionerInputType precOpType
+  const EPreconditionerInputType /* precOpType */
   ) const
 {
   return false;
@@ -110,10 +110,10 @@ bool LinearOpWithSolveFactoryBase<Scalar>::supportsPreconditionerInputType(
 
 template<class Scalar>
 void LinearOpWithSolveFactoryBase<Scalar>::initializePreconditionedOp(
-  const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc
-  ,const RCP<const PreconditionerBase<Scalar> > &prec
-  ,LinearOpWithSolveBase<Scalar> *Op
-  ,const ESupportSolveUse supportSolveUse
+  const RCP<const LinearOpSourceBase<Scalar> > &/* fwdOpSrc */
+  ,const RCP<const PreconditionerBase<Scalar> > &/* prec */
+  ,LinearOpWithSolveBase<Scalar> * /* Op */
+  ,const ESupportSolveUse /* supportSolveUse */
   ) const
 {
   TEUCHOS_TEST_FOR_EXCEPTION(
@@ -126,10 +126,10 @@ void LinearOpWithSolveFactoryBase<Scalar>::initializePreconditionedOp(
 
 template<class Scalar>
 void LinearOpWithSolveFactoryBase<Scalar>::initializeApproxPreconditionedOp(
-  const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc
-  ,const RCP<const LinearOpSourceBase<Scalar> > &approxFwdOpSrc
-  ,LinearOpWithSolveBase<Scalar> *Op
-  ,const ESupportSolveUse supportSolveUse
+  const RCP<const LinearOpSourceBase<Scalar> > &/* fwdOpSrc */
+  ,const RCP<const LinearOpSourceBase<Scalar> > &/* approxFwdOpSrc */
+  ,LinearOpWithSolveBase<Scalar> * /* Op */
+  ,const ESupportSolveUse /* supportSolveUse */
   ) const
 {
   TEUCHOS_TEST_FOR_EXCEPTION(

--- a/packages/thyra/core/src/interfaces/operator_solve/fundamental/Thyra_PreconditionerFactoryBase_def.hpp
+++ b/packages/thyra/core/src/interfaces/operator_solve/fundamental/Thyra_PreconditionerFactoryBase_def.hpp
@@ -59,7 +59,7 @@ bool PreconditionerFactoryBase<Scalar>::applySupportsConj(EConj conj) const
 
 template<class Scalar>
 bool
-PreconditionerFactoryBase<Scalar>::applyTransposeSupportsConj(EConj conj) const
+PreconditionerFactoryBase<Scalar>::applyTransposeSupportsConj(EConj /* conj */) const
 {
   return false;
 }

--- a/packages/thyra/core/src/interfaces/operator_vector/fundamental/Thyra_VectorSpaceBase_def.hpp
+++ b/packages/thyra/core/src/interfaces/operator_vector/fundamental/Thyra_VectorSpaceBase_def.hpp
@@ -73,8 +73,8 @@ bool VectorSpaceBase<Scalar>::isEuclidean() const
 
 
 template<class Scalar>
-bool VectorSpaceBase<Scalar>::hasInCoreView(const Range1D& rng,
-  const EViewType viewType, const EStrideType strideType) const
+bool VectorSpaceBase<Scalar>::hasInCoreView(const Range1D& /* rng */,
+  const EViewType /* viewType */, const EStrideType /* strideType */) const
 {
   return false;
 }

--- a/packages/thyra/core/src/support/nonlinear/model_evaluator/client_support/Thyra_DirectionalFiniteDiffCalculator_decl.hpp
+++ b/packages/thyra/core/src/support/nonlinear/model_evaluator/client_support/Thyra_DirectionalFiniteDiffCalculator_decl.hpp
@@ -88,10 +88,10 @@ public:
   /** \brief . */
   SelectedDerivatives() {}
   /** \brief . */
-  SelectedDerivatives& supports( ModelEvaluatorBase::EOutArgsDfDp arg, int l )
+  SelectedDerivatives& supports( ModelEvaluatorBase::EOutArgsDfDp /* arg */, int l )
     { supports_DfDp_.push_back(l); return *this; }
   /** \brief . */
-  SelectedDerivatives& supports( ModelEvaluatorBase::EOutArgsDgDp arg, int j, int l )
+  SelectedDerivatives& supports( ModelEvaluatorBase::EOutArgsDgDp /* arg */, int j, int l )
     { supports_DgDp_.push_back(std::pair<int,int>(j,l)); return *this; }
   // These should be private but I am too lazy to deal with the porting
   // issues of friends ...

--- a/packages/thyra/core/src/support/nonlinear/model_evaluator/client_support/Thyra_DirectionalFiniteDiffCalculator_def.hpp
+++ b/packages/thyra/core/src/support/nonlinear/model_evaluator/client_support/Thyra_DirectionalFiniteDiffCalculator_def.hpp
@@ -160,6 +160,9 @@ private:
         << ", the space p_space("<<l<<") must be in-core so that they can"
         " act as the domain space for the multi-vector derivative!"
         );
+#else
+      (void)model;
+      (void)l;
 #endif
     }
 

--- a/packages/thyra/core/src/support/nonlinear/model_evaluator/client_support/Thyra_ResponseOnlyModelEvaluatorBase.hpp
+++ b/packages/thyra/core/src/support/nonlinear/model_evaluator/client_support/Thyra_ResponseOnlyModelEvaluatorBase.hpp
@@ -121,6 +121,8 @@ ResponseOnlyModelEvaluatorBase<Scalar>::get_p_names(int l) const
 {
 #ifdef TEUCHOS_DEBUG
   TEUCHOS_ASSERT_IN_RANGE_UPPER_EXCLUSIVE( l, 0, this->Np() );
+#else
+  (void)l;
 #endif
   return Teuchos::null;
 }
@@ -132,6 +134,8 @@ ResponseOnlyModelEvaluatorBase<Scalar>::get_g_names(int j) const
 {
 #ifdef TEUCHOS_DEBUG
   TEUCHOS_ASSERT_IN_RANGE_UPPER_EXCLUSIVE( j, 0, this->Ng() );
+#else
+  (void)j;
 #endif
   return Teuchos::ArrayView<const std::string>(Teuchos::null);
 }
@@ -220,8 +224,8 @@ ResponseOnlyModelEvaluatorBase<Scalar>::get_W_factory() const
 
 template<class Scalar>
 void ResponseOnlyModelEvaluatorBase<Scalar>::reportFinalPoint(
-  const ModelEvaluatorBase::InArgs<Scalar> &finalPoint,
-  const bool wasSolved
+  const ModelEvaluatorBase::InArgs<Scalar> &/* finalPoint */,
+  const bool /* wasSolved */
   )
 {
   // This final point is just ignored by default!

--- a/packages/thyra/core/src/support/nonlinear/model_evaluator/client_support/Thyra_StateFuncModelEvaluatorBase.hpp
+++ b/packages/thyra/core/src/support/nonlinear/model_evaluator/client_support/Thyra_StateFuncModelEvaluatorBase.hpp
@@ -105,7 +105,7 @@ public:
 
 template<class Scalar>
 RCP<const VectorSpaceBase<Scalar> >
-StateFuncModelEvaluatorBase<Scalar>::get_p_space(int l) const
+StateFuncModelEvaluatorBase<Scalar>::get_p_space(int /* l */) const
 {
   TEUCHOS_TEST_FOR_EXCEPTION(
     true,std::logic_error
@@ -118,7 +118,7 @@ StateFuncModelEvaluatorBase<Scalar>::get_p_space(int l) const
 
 template<class Scalar>
 RCP<const Teuchos::Array<std::string> >
-StateFuncModelEvaluatorBase<Scalar>::get_p_names(int l) const
+StateFuncModelEvaluatorBase<Scalar>::get_p_names(int /* l */) const
 {
   TEUCHOS_TEST_FOR_EXCEPTION(
     true,std::logic_error
@@ -131,7 +131,7 @@ StateFuncModelEvaluatorBase<Scalar>::get_p_names(int l) const
 
 template<class Scalar>
 RCP<const VectorSpaceBase<Scalar> >
-StateFuncModelEvaluatorBase<Scalar>::get_g_space(int j) const
+StateFuncModelEvaluatorBase<Scalar>::get_g_space(int /* j */) const
 {
   TEUCHOS_TEST_FOR_EXCEPTION(
     true,std::logic_error
@@ -145,7 +145,7 @@ StateFuncModelEvaluatorBase<Scalar>::get_g_space(int j) const
 
 template<class Scalar>
 Teuchos::ArrayView<const std::string>
-StateFuncModelEvaluatorBase<Scalar>::get_g_names(int j) const
+StateFuncModelEvaluatorBase<Scalar>::get_g_names(int /* j */) const
 {
   TEUCHOS_TEST_FOR_EXCEPTION(
     true,std::logic_error
@@ -206,8 +206,8 @@ StateFuncModelEvaluatorBase<Scalar>::get_W_factory() const
 
 template<class Scalar>
 void StateFuncModelEvaluatorBase<Scalar>::reportFinalPoint(
-  const ModelEvaluatorBase::InArgs<Scalar> &finalPoint,
-  const bool wasSolved
+  const ModelEvaluatorBase::InArgs<Scalar> &/* finalPoint */,
+  const bool /* wasSolved */
   )
 {
   // This final point is just ignored by default!

--- a/packages/thyra/core/src/support/operator_solve/client_support/Thyra_DefaultBlockedTriangularLinearOpWithSolveFactory_def.hpp
+++ b/packages/thyra/core/src/support/operator_solve/client_support/Thyra_DefaultBlockedTriangularLinearOpWithSolveFactory_def.hpp
@@ -177,8 +177,8 @@ DefaultBlockedTriangularLinearOpWithSolveFactory<Scalar>::acceptsPreconditionerF
 template<class Scalar>
 void
 DefaultBlockedTriangularLinearOpWithSolveFactory<Scalar>::setPreconditionerFactory(
-  const RCP<PreconditionerFactoryBase<Scalar> > &precFactory,
-  const std::string &precFactoryName
+  const RCP<PreconditionerFactoryBase<Scalar> > &/* precFactory */,
+  const std::string &/* precFactoryName */
   )
 {
   TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,
@@ -196,8 +196,8 @@ DefaultBlockedTriangularLinearOpWithSolveFactory<Scalar>::getPreconditionerFacto
 
 template<class Scalar>
 void DefaultBlockedTriangularLinearOpWithSolveFactory<Scalar>::unsetPreconditionerFactory(
-  RCP<PreconditionerFactoryBase<Scalar> > *precFactory,
-  std::string *precFactoryName
+  RCP<PreconditionerFactoryBase<Scalar> > * /* precFactory */,
+  std::string * /* precFactoryName */
   )
 {
   TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,
@@ -208,7 +208,7 @@ void DefaultBlockedTriangularLinearOpWithSolveFactory<Scalar>::unsetPrecondition
 template<class Scalar>
 bool
 DefaultBlockedTriangularLinearOpWithSolveFactory<Scalar>::isCompatible(
-  const LinearOpSourceBase<Scalar> &fwdOpSrc
+  const LinearOpSourceBase<Scalar> &/* fwdOpSrc */
   ) const
 {
   TEUCHOS_TEST_FOR_EXCEPT(true);
@@ -229,7 +229,7 @@ void
 DefaultBlockedTriangularLinearOpWithSolveFactory<Scalar>::initializeOp(
   const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
   LinearOpWithSolveBase<Scalar> *Op,
-  const ESupportSolveUse supportSolveUse
+  const ESupportSolveUse /* supportSolveUse */
   ) const
 {
 
@@ -306,8 +306,8 @@ DefaultBlockedTriangularLinearOpWithSolveFactory<Scalar>::initializeOp(
 template<class Scalar>
 void
 DefaultBlockedTriangularLinearOpWithSolveFactory<Scalar>::initializeAndReuseOp(
-  const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
-  LinearOpWithSolveBase<Scalar> *Op
+  const RCP<const LinearOpSourceBase<Scalar> > &/* fwdOpSrc */,
+  LinearOpWithSolveBase<Scalar> * /* Op */
   ) const
 {
   TEUCHOS_TEST_FOR_EXCEPT(true);
@@ -321,7 +321,7 @@ DefaultBlockedTriangularLinearOpWithSolveFactory<Scalar>::uninitializeOp(
   RCP<const LinearOpSourceBase<Scalar> > *fwdOpSrc,
   RCP<const PreconditionerBase<Scalar> > *prec,
   RCP<const LinearOpSourceBase<Scalar> > *approxFwdOpSrc,
-  ESupportSolveUse *supportSolveUse
+  ESupportSolveUse * /* supportSolveUse */
   ) const
 {
   using Teuchos::dyn_cast;
@@ -345,7 +345,7 @@ DefaultBlockedTriangularLinearOpWithSolveFactory<Scalar>::uninitializeOp(
 template<class Scalar>
 bool
 DefaultBlockedTriangularLinearOpWithSolveFactory<Scalar>::supportsPreconditionerInputType(
-  const EPreconditionerInputType precOpType
+  const EPreconditionerInputType /* precOpType */
   ) const
 {
   // We don't support any external preconditioners!
@@ -360,10 +360,10 @@ DefaultBlockedTriangularLinearOpWithSolveFactory<Scalar>::supportsPreconditioner
 template<class Scalar>
 void
 DefaultBlockedTriangularLinearOpWithSolveFactory<Scalar>::initializePreconditionedOp(
-  const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
-  const RCP<const PreconditionerBase<Scalar> > &prec,
-  LinearOpWithSolveBase<Scalar> *Op,
-  const ESupportSolveUse supportSolveUse
+  const RCP<const LinearOpSourceBase<Scalar> > &/* fwdOpSrc */,
+  const RCP<const PreconditionerBase<Scalar> > &/* prec */,
+  LinearOpWithSolveBase<Scalar> * /* Op */,
+  const ESupportSolveUse /* supportSolveUse */
   ) const
 {
   TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,
@@ -374,10 +374,10 @@ DefaultBlockedTriangularLinearOpWithSolveFactory<Scalar>::initializePrecondition
 template<class Scalar>
 void
 DefaultBlockedTriangularLinearOpWithSolveFactory<Scalar>::initializeApproxPreconditionedOp(
-  const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
-  const RCP<const LinearOpSourceBase<Scalar> > &approxFwdOpSrc,
-  LinearOpWithSolveBase<Scalar> *Op,
-  const ESupportSolveUse supportSolveUse
+  const RCP<const LinearOpSourceBase<Scalar> > &/* fwdOpSrc */,
+  const RCP<const LinearOpSourceBase<Scalar> > &/* approxFwdOpSrc */,
+  LinearOpWithSolveBase<Scalar> * /* Op */,
+  const ESupportSolveUse /* supportSolveUse */
   ) const
 {
   TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,

--- a/packages/thyra/core/src/support/operator_solve/client_support/Thyra_DefaultBlockedTriangularLinearOpWithSolve_def.hpp
+++ b/packages/thyra/core/src/support/operator_solve/client_support/Thyra_DefaultBlockedTriangularLinearOpWithSolve_def.hpp
@@ -152,6 +152,8 @@ void DefaultBlockedTriangularLinearOpWithSolve<Scalar>::beginBlockFill(
   using Teuchos::null;
 #ifdef THYRA_DEBUG
   TEUCHOS_ASSERT_EQUALITY(numRowBlocks, numColBlocks);
+#else
+  (void)numColBlocks;
 #endif
   assertBlockFillIsActive(false);
   numDiagBlocks_ = numRowBlocks;
@@ -202,8 +204,8 @@ bool DefaultBlockedTriangularLinearOpWithSolve<Scalar>::acceptsBlock(
 
 template<class Scalar>
 void DefaultBlockedTriangularLinearOpWithSolve<Scalar>::setNonconstBlock(
-  const int i, const int j,
-  const Teuchos::RCP<LinearOpBase<Scalar> > &block
+  const int /* i */, const int /* j */,
+  const Teuchos::RCP<LinearOpBase<Scalar> > &/* block */
   )
 {
   assertBlockFillIsActive(true);
@@ -213,8 +215,8 @@ void DefaultBlockedTriangularLinearOpWithSolve<Scalar>::setNonconstBlock(
 
 template<class Scalar>
 void DefaultBlockedTriangularLinearOpWithSolve<Scalar>::setBlock(
-  const int i, const int j,
-  const Teuchos::RCP<const LinearOpBase<Scalar> > &block
+  const int /* i */, const int /* j */,
+  const Teuchos::RCP<const LinearOpBase<Scalar> > &/* block */
   )
 {
   assertBlockFillIsActive(true);
@@ -608,6 +610,8 @@ void DefaultBlockedTriangularLinearOpWithSolve<Scalar>::assertBlockFillIsActive(
 {
 #ifdef THYRA_DEBUG
   TEUCHOS_TEST_FOR_EXCEPT(!(blockFillIsActive_==blockFillIsActive_in));
+#else
+  (void)blockFillIsActive_in;
 #endif
 }
 
@@ -626,6 +630,9 @@ void DefaultBlockedTriangularLinearOpWithSolve<Scalar>::assertBlockRowCol(
     !( 0 <= j && j < numDiagBlocks_ ), std::logic_error,
     "Error, j="<<j<<" does not fall in the range [0,"<<numDiagBlocks_-1<<"]!"
       );
+#else
+  (void)i;
+  (void)j;
 #endif
 }
 
@@ -648,6 +655,8 @@ void DefaultBlockedTriangularLinearOpWithSolve<Scalar>::setLOWSBlockImpl(
     "Error, this DefaultBlockedTriangularLinearOpWithSolve does not accept\n"
     "LOWSB objects for the block i="<<i<<", j="<<j<<"!"
     );
+#else
+  (void)j;
 #endif
   diagonalBlocks_[i] = block;
 }
@@ -669,6 +678,8 @@ void DefaultBlockedTriangularLinearOpWithSolve<Scalar>::assertAndSetBlockStructu
     );
   // ToDo: Make sure that all of the blocks are above or below the diagonal
   // but not both!
+#else
+  (void)blocks;
 #endif
   // ToDo: Set if this is an upper or lower triangular block operator.
 }

--- a/packages/thyra/core/src/support/operator_solve/client_support/Thyra_DefaultDiagonalLinearOpWithSolve_def.hpp
+++ b/packages/thyra/core/src/support/operator_solve/client_support/Thyra_DefaultDiagonalLinearOpWithSolve_def.hpp
@@ -89,7 +89,7 @@ DefaultDiagonalLinearOpWithSolve<Scalar>::solveSupportsImpl(
 template<class Scalar>
 bool
 DefaultDiagonalLinearOpWithSolve<Scalar>::solveSupportsSolveMeasureTypeImpl(
-  EOpTransp M_trans, const SolveMeasureType& solveMeasureType) const
+  EOpTransp M_trans, const SolveMeasureType& /* solveMeasureType */) const
 {
   return this->solveSupportsImpl(M_trans); // I am a direct solver!
 }
@@ -107,6 +107,8 @@ DefaultDiagonalLinearOpWithSolve<Scalar>::solveImpl(
 
 #ifdef THYRA_DEBUG
   TEUCHOS_ASSERT(this->solveSupportsImpl(transp));
+#else
+  (void)transp;
 #endif
 
   typedef Teuchos::ScalarTraits<Scalar> ST;

--- a/packages/thyra/core/src/support/operator_solve/client_support/Thyra_DefaultMultiVectorLinearOpWithSolve_def.hpp
+++ b/packages/thyra/core/src/support/operator_solve/client_support/Thyra_DefaultMultiVectorLinearOpWithSolve_def.hpp
@@ -280,6 +280,10 @@ void DefaultMultiVectorLinearOpWithSolve<Scalar>::validateInitialize(
     THYRA_ASSERT_VEC_SPACES(
       "DefaultMultiVectorLinearOpWithSolve<Scalar>::initialize(lows,multiVecRange,multiVecDomain)",
       *lows->domain(), *multiVecDomain->getBlock(0) );
+#else
+  (void)lows;
+  (void)multiVecRange;
+  (void)multiVecDomain;
 #endif
 }
 

--- a/packages/thyra/core/src/support/operator_solve/client_support/Thyra_DefaultSerialDenseLinearOpWithSolveFactory_def.hpp
+++ b/packages/thyra/core/src/support/operator_solve/client_support/Thyra_DefaultSerialDenseLinearOpWithSolveFactory_def.hpp
@@ -87,8 +87,8 @@ bool DefaultSerialDenseLinearOpWithSolveFactory<Scalar>::acceptsPreconditionerFa
 
 template<class Scalar>
 void DefaultSerialDenseLinearOpWithSolveFactory<Scalar>::setPreconditionerFactory(
-  const RCP<PreconditionerFactoryBase<Scalar> > &precFactory,
-  const std::string &precFactoryName
+  const RCP<PreconditionerFactoryBase<Scalar> > &/* precFactory */,
+  const std::string &/* precFactoryName */
   )
 {
   TEUCHOS_TEST_FOR_EXCEPT_MSG(true, "Error, we don't support a preconditioner factory!");
@@ -105,8 +105,8 @@ DefaultSerialDenseLinearOpWithSolveFactory<Scalar>::getPreconditionerFactory() c
 
 template<class Scalar>
 void DefaultSerialDenseLinearOpWithSolveFactory<Scalar>::unsetPreconditionerFactory(
-  RCP<PreconditionerFactoryBase<Scalar> > *precFactory,
-  std::string *precFactoryName
+  RCP<PreconditionerFactoryBase<Scalar> > * /* precFactory */,
+  std::string * /* precFactoryName */
   )
 {
   TEUCHOS_TEST_FOR_EXCEPT_MSG(true, "Error, we don't support a preconditioner factory!");
@@ -135,7 +135,7 @@ template<class Scalar>
 void DefaultSerialDenseLinearOpWithSolveFactory<Scalar>::initializeOp(
   const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
   LinearOpWithSolveBase<Scalar> *Op,
-  const ESupportSolveUse supportSolveUse
+  const ESupportSolveUse /* supportSolveUse */
   ) const
 {
 
@@ -176,7 +176,7 @@ void DefaultSerialDenseLinearOpWithSolveFactory<Scalar>::uninitializeOp(
   RCP<const LinearOpSourceBase<Scalar> > *fwdOpSrc,
   RCP<const PreconditionerBase<Scalar> > *prec,
   RCP<const LinearOpSourceBase<Scalar> > *approxFwdOpSrc,
-  ESupportSolveUse *supportSolveUse
+  ESupportSolveUse * /* supportSolveUse */
   ) const
 {
   using Teuchos::dyn_cast;
@@ -203,7 +203,7 @@ void DefaultSerialDenseLinearOpWithSolveFactory<Scalar>::uninitializeOp(
 
 template<class Scalar>
 bool DefaultSerialDenseLinearOpWithSolveFactory<Scalar>::supportsPreconditionerInputType(
-  const EPreconditionerInputType precOpType
+  const EPreconditionerInputType /* precOpType */
   ) const
 {
   // LAPACK does not support any external preconditioners!
@@ -213,10 +213,10 @@ bool DefaultSerialDenseLinearOpWithSolveFactory<Scalar>::supportsPreconditionerI
 
 template<class Scalar>
 void DefaultSerialDenseLinearOpWithSolveFactory<Scalar>::initializePreconditionedOp(
-  const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
-  const RCP<const PreconditionerBase<Scalar> > &prec,
-  LinearOpWithSolveBase<Scalar> *Op,
-  const ESupportSolveUse supportSolveUse
+  const RCP<const LinearOpSourceBase<Scalar> > &/* fwdOpSrc */,
+  const RCP<const PreconditionerBase<Scalar> > &/* prec */,
+  LinearOpWithSolveBase<Scalar> * /* Op */,
+  const ESupportSolveUse /* supportSolveUse */
   ) const
 {
   TEUCHOS_TEST_FOR_EXCEPT_MSG(true, "Error, we don't support an external preconditioner!");
@@ -225,10 +225,10 @@ void DefaultSerialDenseLinearOpWithSolveFactory<Scalar>::initializePreconditione
 
 template<class Scalar>
 void DefaultSerialDenseLinearOpWithSolveFactory<Scalar>::initializeApproxPreconditionedOp(
-  const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
-  const RCP<const LinearOpSourceBase<Scalar> > &approxFwdOpSrc,
-  LinearOpWithSolveBase<Scalar> *Op,
-  const ESupportSolveUse supportSolveUse
+  const RCP<const LinearOpSourceBase<Scalar> > &/* fwdOpSrc */,
+  const RCP<const LinearOpSourceBase<Scalar> > &/* approxFwdOpSrc */,
+  LinearOpWithSolveBase<Scalar> * /* Op */,
+  const ESupportSolveUse /* supportSolveUse */
   ) const
 {
   TEUCHOS_TEST_FOR_EXCEPT_MSG(true, "Error, we don't support an external preconditioner!");

--- a/packages/thyra/core/src/support/operator_solve/client_support/Thyra_DefaultSerialDenseLinearOpWithSolve_def.hpp
+++ b/packages/thyra/core/src/support/operator_solve/client_support/Thyra_DefaultSerialDenseLinearOpWithSolve_def.hpp
@@ -149,7 +149,7 @@ bool DefaultSerialDenseLinearOpWithSolve<Scalar>::solveSupportsImpl(
 
 template<class Scalar>
 bool DefaultSerialDenseLinearOpWithSolve<Scalar>::solveSupportsSolveMeasureTypeImpl(
-  EOpTransp M_trans, const SolveMeasureType& solveMeasureType) const
+  EOpTransp M_trans, const SolveMeasureType& /* solveMeasureType */) const
 {
   // We support all solve measures since we are a direct solver
   return this->solveSupportsImpl(M_trans);
@@ -162,7 +162,7 @@ DefaultSerialDenseLinearOpWithSolve<Scalar>::solveImpl(
   const EOpTransp M_trans,
   const MultiVectorBase<Scalar> &B,
   const Ptr<MultiVectorBase<Scalar> > &X,
-  const Ptr<const SolveCriteria<Scalar> > solveCriteria
+  const Ptr<const SolveCriteria<Scalar> > /* solveCriteria */
   ) const
 {
 #ifdef TEUCHOS_DEBUG

--- a/packages/thyra/core/src/support/operator_solve/client_support/Thyra_DelayedLinearOpWithSolveFactory_def.hpp
+++ b/packages/thyra/core/src/support/operator_solve/client_support/Thyra_DelayedLinearOpWithSolveFactory_def.hpp
@@ -175,7 +175,7 @@ DelayedLinearOpWithSolveFactory<Scalar>::getPreconditionerFactory() const
 template<class Scalar>
 void DelayedLinearOpWithSolveFactory<Scalar>::unsetPreconditionerFactory(
   RCP<PreconditionerFactoryBase<Scalar> > *precFactory,
-  std::string *precFactoryName
+  std::string * /* precFactoryName */
   )
 {
   lowsf_->unsetPreconditionerFactory(precFactory);
@@ -223,8 +223,8 @@ void DelayedLinearOpWithSolveFactory<Scalar>::initializeOp(
 
 template<class Scalar>
 void DelayedLinearOpWithSolveFactory<Scalar>::initializeAndReuseOp(
-  const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
-  LinearOpWithSolveBase<Scalar> *Op
+  const RCP<const LinearOpSourceBase<Scalar> > &/* fwdOpSrc */,
+  LinearOpWithSolveBase<Scalar> * /* Op */
   ) const
 {
   TEUCHOS_TEST_FOR_EXCEPT(true);

--- a/packages/thyra/core/src/support/operator_vector/adapter_support/Thyra_DefaultClusteredSpmdProductVectorSpace_def.hpp
+++ b/packages/thyra/core/src/support/operator_vector/adapter_support/Thyra_DefaultClusteredSpmdProductVectorSpace_def.hpp
@@ -220,7 +220,7 @@ bool DefaultClusteredSpmdProductVectorSpace<Scalar>::isEuclidean() const
 
 template<class Scalar>
 bool DefaultClusteredSpmdProductVectorSpace<Scalar>::hasInCoreView(
-  const Range1D& rng, const EViewType viewType, const EStrideType strideType
+  const Range1D& /* rng */, const EViewType /* viewType */, const EStrideType /* strideType */
   ) const
 {
   return false; // ToDo: Figure this out for real!

--- a/packages/thyra/core/src/support/operator_vector/adapter_support/Thyra_DefaultSpmdVectorSpace_def.hpp
+++ b/packages/thyra/core/src/support/operator_vector/adapter_support/Thyra_DefaultSpmdVectorSpace_def.hpp
@@ -223,7 +223,7 @@ DefaultSpmdVectorSpace<Scalar>::createMembersView(
 
 template<class Scalar>
 bool DefaultSpmdVectorSpace<Scalar>::hasInCoreView(
-  const Range1D& rng_in, const EViewType viewType, const EStrideType strideType
+  const Range1D& rng_in, const EViewType /* viewType */, const EStrideType /* strideType */
   ) const
 {
   const Range1D rng = full_range(rng_in,0,this->dim()-1);

--- a/packages/thyra/core/src/support/operator_vector/adapter_support/Thyra_apply_op_helper_def.hpp
+++ b/packages/thyra/core/src/support/operator_vector/adapter_support/Thyra_apply_op_helper_def.hpp
@@ -54,10 +54,10 @@ template<class Scalar>
 void Thyra::apply_op_validate_input(
   const std::string &func_name,
   const VectorSpaceBase<Scalar> &space,
-  const RTOpPack::RTOpT<Scalar> &op,
+  const RTOpPack::RTOpT<Scalar> &/* op */,
   const ArrayView<const Ptr<const VectorBase<Scalar> > > &vecs,
   const ArrayView<const Ptr<VectorBase<Scalar> > > &targ_vecs,
-  const Ptr<RTOpPack::ReductTarget> &reduct_obj,
+  const Ptr<RTOpPack::ReductTarget> &/* reduct_obj */,
   const Ordinal global_offset_in
   )
 {
@@ -79,10 +79,10 @@ void Thyra::apply_op_validate_input(
   const std::string &func_name,
   const VectorSpaceBase<Scalar> &domain,
   const VectorSpaceBase<Scalar> &range,
-  const RTOpPack::RTOpT<Scalar> &primary_op,
+  const RTOpPack::RTOpT<Scalar> &/* primary_op */,
   const ArrayView<const Ptr<const MultiVectorBase<Scalar> > > &multi_vecs,
   const ArrayView<const Ptr<MultiVectorBase<Scalar> > > &targ_multi_vecs,
-  const ArrayView<const Ptr<RTOpPack::ReductTarget> > &reduct_objs,
+  const ArrayView<const Ptr<RTOpPack::ReductTarget> > &/* reduct_objs */,
   const Ordinal primary_global_offset_in
   )
 {

--- a/packages/thyra/core/src/support/operator_vector/client_support/Thyra_DefaultBlockedLinearOp_def.hpp
+++ b/packages/thyra/core/src/support/operator_vector/client_support/Thyra_DefaultBlockedLinearOp_def.hpp
@@ -858,6 +858,8 @@ void DefaultBlockedLinearOp<Scalar>::assertBlockFillIsActive(
 {
 #ifdef TEUCHOS_DEBUG
   TEUCHOS_TEST_FOR_EXCEPT(!(blockFillIsActive_==wantedValue));
+#else
+  (void)wantedValue;
 #endif
 }
 
@@ -888,6 +890,9 @@ void DefaultBlockedLinearOp<Scalar>::assertBlockRowCol(
       ,"Error, j="<<j<<" does not fall in the range [0,"<<numColBlocks_-1<<"]!"
       );
   }
+#else
+  (void)i;
+  (void)j;
 #endif
 }
 

--- a/packages/thyra/core/src/support/operator_vector/client_support/Thyra_DefaultDiagonalLinearOp_def.hpp
+++ b/packages/thyra/core/src/support/operator_vector/client_support/Thyra_DefaultDiagonalLinearOp_def.hpp
@@ -185,7 +185,7 @@ DefaultDiagonalLinearOp<Scalar>::clone() const
 
 
 template<class Scalar>
-bool DefaultDiagonalLinearOp<Scalar>::opSupportedImpl(EOpTransp M_trans) const
+bool DefaultDiagonalLinearOp<Scalar>::opSupportedImpl(EOpTransp /* M_trans */) const
 {
   return true;
 }

--- a/packages/thyra/core/src/support/operator_vector/client_support/Thyra_DefaultIdentityLinearOp_def.hpp
+++ b/packages/thyra/core/src/support/operator_vector/client_support/Thyra_DefaultIdentityLinearOp_def.hpp
@@ -136,7 +136,7 @@ std::string DefaultIdentityLinearOp<Scalar>::description() const
 
 
 template<class Scalar>
-bool DefaultIdentityLinearOp<Scalar>::opSupportedImpl(EOpTransp M_trans) const
+bool DefaultIdentityLinearOp<Scalar>::opSupportedImpl(EOpTransp /* M_trans */) const
 {
   return true;
 }
@@ -157,6 +157,8 @@ void DefaultIdentityLinearOp<Scalar>::applyImpl(
   THYRA_ASSERT_LINEAR_OP_MULTIVEC_APPLY_SPACES(
     "DefaultIdentityLinearOp<Scalar>::apply(...)", *this, M_trans, X, &*Y
     );
+#else
+  (void)M_trans;
 #endif // TEUCHOS_DEBUG  
   Thyra::linear_combination<Scalar>(
     tuple<Scalar>(alpha)(),

--- a/packages/thyra/core/src/support/operator_vector/client_support/Thyra_DefaultMultiVectorProductVectorSpace_def.hpp
+++ b/packages/thyra/core/src/support/operator_vector/client_support/Thyra_DefaultMultiVectorProductVectorSpace_def.hpp
@@ -77,8 +77,8 @@ void DefaultMultiVectorProductVectorSpace<Scalar>::initialize(
 
 template<class Scalar>
 void DefaultMultiVectorProductVectorSpace<Scalar>::uninitialize(
-  Teuchos::RCP<const VectorSpaceBase<Scalar> > *space,
-  int *numColumns
+  Teuchos::RCP<const VectorSpaceBase<Scalar> > * /* space */,
+  int * /* numColumns */
   )
 {
   TEUCHOS_TEST_FOR_EXCEPT("ToDo: Implement when needed!");

--- a/packages/thyra/core/src/support/operator_vector/client_support/Thyra_DefaultMultiVectorProductVector_def.hpp
+++ b/packages/thyra/core/src/support/operator_vector/client_support/Thyra_DefaultMultiVectorProductVector_def.hpp
@@ -227,6 +227,8 @@ bool DefaultMultiVectorProductVector<Scalar>::blockIsConst(const int k) const
 {
 #ifdef TEUCHOS_DEBUG
   TEUCHOS_ASSERT_IN_RANGE_UPPER_EXCLUSIVE( k, 0, numBlocks_ );
+#else
+  (void)k;
 #endif
   return multiVec_.isConst();
 }
@@ -401,7 +403,7 @@ void DefaultMultiVectorProductVector<Scalar>::releaseDetachedVectorViewImpl(
 
 template <class Scalar>
 void DefaultMultiVectorProductVector<Scalar>::acquireNonconstDetachedVectorViewImpl(
-  const Range1D& rng_in, RTOpPack::SubVectorView<Scalar>* sub_vec
+  const Range1D& /* rng_in */, RTOpPack::SubVectorView<Scalar>* /* sub_vec */
   )
 {
   TEUCHOS_TEST_FOR_EXCEPT("ToDo: Implement DefaultMultiVectorProductVector<Scalar>::acquireNonconstDetachedVectorViewImpl(...)!");
@@ -410,7 +412,7 @@ void DefaultMultiVectorProductVector<Scalar>::acquireNonconstDetachedVectorViewI
 
 template <class Scalar>
 void DefaultMultiVectorProductVector<Scalar>::commitNonconstDetachedVectorViewImpl(
-  RTOpPack::SubVectorView<Scalar>* sub_vec
+  RTOpPack::SubVectorView<Scalar>* /* sub_vec */
   )
 {
   TEUCHOS_TEST_FOR_EXCEPT("ToDo: Implement DefaultMultiVectorProductVector<Scalar>::commitNonconstDetachedVectorViewImpl(...)!");
@@ -419,7 +421,7 @@ void DefaultMultiVectorProductVector<Scalar>::commitNonconstDetachedVectorViewIm
 
 template <class Scalar>
 void DefaultMultiVectorProductVector<Scalar>::setSubVectorImpl(
-  const RTOpPack::SparseSubVectorT<Scalar>& sub_vec
+  const RTOpPack::SparseSubVectorT<Scalar>& /* sub_vec */
   )
 {
   TEUCHOS_TEST_FOR_EXCEPT("ToDo: Implement DefaultMultiVectorProductVector<Scalar>::setSubVector(...)!");

--- a/packages/thyra/core/src/support/operator_vector/client_support/Thyra_DefaultProductMultiVector_decl.hpp
+++ b/packages/thyra/core/src/support/operator_vector/client_support/Thyra_DefaultProductMultiVector_decl.hpp
@@ -380,7 +380,7 @@ void DefaultProductMultiVector<Scalar>::assertInitialized() const
 
 template<class Scalar>
 inline
-void DefaultProductMultiVector<Scalar>::validateColIndex(const int j) const
+void DefaultProductMultiVector<Scalar>::validateColIndex(const int /* j */) const
 {}
 
 

--- a/packages/thyra/core/src/support/operator_vector/client_support/Thyra_DefaultProductMultiVector_def.hpp
+++ b/packages/thyra/core/src/support/operator_vector/client_support/Thyra_DefaultProductMultiVector_def.hpp
@@ -734,7 +734,7 @@ void DefaultProductMultiVector<Scalar>::commitNonconstDetachedMultiVectorViewImp
 
 
 template<class Scalar>
-bool DefaultProductMultiVector<Scalar>::opSupportedImpl(EOpTransp M_trans) const
+bool DefaultProductMultiVector<Scalar>::opSupportedImpl(EOpTransp /* M_trans */) const
 {
   return true; // We can do it all!
 }

--- a/packages/thyra/core/src/support/operator_vector/client_support/Thyra_DefaultZeroLinearOp_decl.hpp
+++ b/packages/thyra/core/src/support/operator_vector/client_support/Thyra_DefaultZeroLinearOp_decl.hpp
@@ -193,11 +193,11 @@ protected:
   { return true; }
  
   /** \brief . */ // Meaningless operation
-  virtual void scaleLeftImpl(const VectorBase< Scalar > &row_scaling)
+  virtual void scaleLeftImpl(const VectorBase< Scalar > &/* row_scaling */)
   { }
 
   /** \brief . */ // Meaningless operation
-  virtual void scaleRightImpl(const VectorBase< Scalar > &col_scaling)
+  virtual void scaleRightImpl(const VectorBase< Scalar > &/* col_scaling */)
   { }
 
   //@}

--- a/packages/thyra/core/src/support/operator_vector/client_support/Thyra_DefaultZeroLinearOp_def.hpp
+++ b/packages/thyra/core/src/support/operator_vector/client_support/Thyra_DefaultZeroLinearOp_def.hpp
@@ -142,7 +142,7 @@ std::string DefaultZeroLinearOp<Scalar>::description() const
 
 
 template<class Scalar>
-bool DefaultZeroLinearOp<Scalar>::opSupportedImpl(EOpTransp M_trans) const
+bool DefaultZeroLinearOp<Scalar>::opSupportedImpl(EOpTransp /* M_trans */) const
 {
   return true;
 }
@@ -153,7 +153,7 @@ void DefaultZeroLinearOp<Scalar>::applyImpl(
   const EOpTransp M_trans,
   const MultiVectorBase<Scalar> &X,
   const Ptr<MultiVectorBase<Scalar> > &Y,
-  const Scalar alpha,
+  const Scalar /* alpha */,
   const Scalar beta
   ) const
 {
@@ -161,6 +161,9 @@ void DefaultZeroLinearOp<Scalar>::applyImpl(
   THYRA_ASSERT_LINEAR_OP_MULTIVEC_APPLY_SPACES(
     "DefaultZeroLinearOp<Scalar>::apply(...)", *this, M_trans, X, &*Y
     );
+#else
+  (void)M_trans;
+  (void)X;
 #endif // TEUCHOS_DEBUG  
   scale(beta, Y);
 }
@@ -183,7 +186,7 @@ rowStatIsSupportedImpl(const RowStatLinearOpBaseUtils::ERowStat rowStat) const
 template<class Scalar>
 void DefaultZeroLinearOp<Scalar>::
 getRowStatImpl(
-    const RowStatLinearOpBaseUtils::ERowStat rowStat, 
+    const RowStatLinearOpBaseUtils::ERowStat /* rowStat */, 
     const Teuchos::Ptr<VectorBase< Scalar> > &rowStatVec) const
 { 
   Thyra::put_scalar(Teuchos::ScalarTraits<Scalar>::zero(),rowStatVec); 

--- a/packages/thyra/core/src/support/operator_vector/client_support/Thyra_MultiVectorStdOpsTester_def.hpp
+++ b/packages/thyra/core/src/support/operator_vector/client_support/Thyra_MultiVectorStdOpsTester_def.hpp
@@ -66,7 +66,7 @@ template <class Scalar>
 bool MultiVectorStdOpsTester<Scalar>::checkStdOps(
   const VectorSpaceBase<Scalar>    &vecSpc
   ,std::ostream                    *out
-  ,const bool                      &dumpAll
+  ,const bool                      &/* dumpAll */
   )
 {
   using Teuchos::as;

--- a/packages/thyra/core/src/support/operator_vector/client_support/Thyra_UniversalMultiVectorRandomizer.hpp
+++ b/packages/thyra/core/src/support/operator_vector/client_support/Thyra_UniversalMultiVectorRandomizer.hpp
@@ -100,7 +100,7 @@ universalMultiVectorRandomizer()
 
 
 template<class Scalar>
-bool UniversalMultiVectorRandomizer<Scalar>::isCompatible( const VectorSpaceBase<Scalar> &space ) const
+bool UniversalMultiVectorRandomizer<Scalar>::isCompatible( const VectorSpaceBase<Scalar> &/* space */ ) const
 {
   return true;
 }

--- a/packages/thyra/core/src/support/operator_vector/client_support/Thyra_VectorDefaultBase_def.hpp
+++ b/packages/thyra/core/src/support/operator_vector/client_support/Thyra_VectorDefaultBase_def.hpp
@@ -337,6 +337,8 @@ VectorDefaultBase<Scalar>::nonconstColImpl(Ordinal j)
 #endif
 #ifdef TEUCHOS_DEBUG
   TEUCHOS_TEST_FOR_EXCEPT( j != 0 );
+#else
+  (void)j;
 #endif
   return Teuchos::rcp(this,false);
 }
@@ -680,6 +682,8 @@ void VectorDefaultBase<Scalar>::validateColRng( const Range1D &col_rng ) const
 #ifdef TEUCHOS_DEBUG
   TEUCHOS_TEST_FOR_EXCEPT(
     !( col_rng.full_range() || ( col_rng.lbound() == 0 && col_rng.ubound() == 0) ) );
+#else
+  (void)col_rng;
 #endif
 }
 
@@ -691,6 +695,8 @@ void VectorDefaultBase<Scalar>::validateColIndexes(
 {
 #ifdef TEUCHOS_DEBUG
   TEUCHOS_TEST_FOR_EXCEPT( cols.size() != 1 || cols[0] != 0 );
+#else
+  (void)cols;
 #endif
 }
 

--- a/packages/thyra/core/test/nonlinear/models/Thyra_DiagonalQuadraticResponseOnlyModelEvaluator_def.hpp
+++ b/packages/thyra/core/test/nonlinear/models/Thyra_DiagonalQuadraticResponseOnlyModelEvaluator_def.hpp
@@ -209,6 +209,8 @@ DiagonalQuadraticResponseOnlyModelEvaluator<Scalar>::get_p_space(int l) const
 {
 #ifdef TEUCHOS_DEBUG
   TEUCHOS_ASSERT_IN_RANGE_UPPER_EXCLUSIVE( l, 0, Np_ );
+#else
+  (void)l;
 #endif
   return p_space_;
 }
@@ -220,6 +222,8 @@ DiagonalQuadraticResponseOnlyModelEvaluator<Scalar>::get_g_space(int j) const
 {
 #ifdef TEUCHOS_DEBUG
   TEUCHOS_ASSERT_IN_RANGE_UPPER_EXCLUSIVE( j, 0, Ng_ );
+#else
+  (void)j;
 #endif
   return g_space_;
 }

--- a/packages/thyra/core/test/nonlinear/models/Thyra_DummyTestModelEvaluator_def.hpp
+++ b/packages/thyra/core/test/nonlinear/models/Thyra_DummyTestModelEvaluator_def.hpp
@@ -169,7 +169,7 @@ DummyTestModelEvaluator<Scalar>::get_p_space(int l) const
 
 template<class Scalar>
 Teuchos::RCP<const Teuchos::Array<std::string> >
-DummyTestModelEvaluator<Scalar>::get_p_names(int l) const
+DummyTestModelEvaluator<Scalar>::get_p_names(int /* l */) const
 {
   return Teuchos::null;
 }
@@ -193,7 +193,7 @@ DummyTestModelEvaluator<Scalar>::get_g_space(int j) const
 
 template<class Scalar>
 Teuchos::ArrayView<const std::string>
-DummyTestModelEvaluator<Scalar>::get_g_names(int j) const
+DummyTestModelEvaluator<Scalar>::get_g_names(int /* j */) const
 {
   return g_names_;
 }
@@ -263,8 +263,8 @@ DummyTestModelEvaluator<Scalar>::createInArgs() const
 
 template<class Scalar>
 void DummyTestModelEvaluator<Scalar>::reportFinalPoint(
-  const ModelEvaluatorBase::InArgs<Scalar> &finalPoint,
-  const bool wasSolved
+  const ModelEvaluatorBase::InArgs<Scalar> &/* finalPoint */,
+  const bool /* wasSolved */
   )
 {
   // ToDo: Capture the final point and then provide in interface.
@@ -311,8 +311,8 @@ DummyTestModelEvaluator<Scalar>::createOutArgsImpl() const
 
 template<class Scalar>
 void DummyTestModelEvaluator<Scalar>::evalModelImpl(
-  const ModelEvaluatorBase::InArgs<Scalar> &inArgs,
-  const ModelEvaluatorBase::OutArgs<Scalar> &outArgs
+  const ModelEvaluatorBase::InArgs<Scalar> &/* inArgs */,
+  const ModelEvaluatorBase::OutArgs<Scalar> &/* outArgs */
   ) const
 {
   TEUCHOS_TEST_FOR_EXCEPT(true); // ToDo: Implement to just copy inArgs and outArgs!

--- a/packages/thyra/core/test/operator_vector/Thyra_SimpleDenseLinearOp.hpp
+++ b/packages/thyra/core/test/operator_vector/Thyra_SimpleDenseLinearOp.hpp
@@ -85,7 +85,7 @@ protected:
     { return mv_->domain(); }
 
   /** \brief . */
-  virtual bool opSupportedImpl(Thyra::EOpTransp M_trans) const
+  virtual bool opSupportedImpl(Thyra::EOpTransp /* M_trans */) const
     { return true; }
 
   /** \brief . */


### PR DESCRIPTION
@trilinos/thyra 

## Description
Comment out parameter names in function definitions to avoid
`-Wunused-parameter` warnings.

## Motivation and Context
Clean build.