### PR TITLE
Tpetra: Fix #4633 & #4639

### DIFF
--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_Cg.hpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_Cg.hpp
@@ -15,15 +15,13 @@ private:
   using base_type = Krylov<SC, MV, OP>;
 
 public:
-  Cg () :
-    base_type::Krylov ()
-  {}
+  Cg () = default;
 
   Cg (const Teuchos::RCP<const OP>& A) :
     base_type::Krylov (A)
   {}
 
-  virtual ~Cg () {}
+  virtual ~Cg () = default;
 
 protected:
   using vec_type = typename base_type::vec_type;

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_CgPipeline.hpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_CgPipeline.hpp
@@ -15,15 +15,13 @@ private:
   using base_type = Krylov<SC, MV, OP>;
 
 public:
-  CgPipeline () :
-    base_type::Krylov ()
-  {}
+  CgPipeline () = default;
 
   CgPipeline (const Teuchos::RCP<const OP>& A) :
     base_type::Krylov (A)
   {}
 
-  virtual ~CgPipeline () {}
+  virtual ~CgPipeline () = default;
 
 protected:
   using vec_type = typename base_type::vec_type;

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_CgSingleReduce.hpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_CgSingleReduce.hpp
@@ -15,15 +15,13 @@ private:
   using base_type = Krylov<SC, MV, OP>;
 
 public:
-  CgSingleReduce () :
-    base_type::Krylov ()
-  {}
+  CgSingleReduce () = default;
 
   CgSingleReduce (const Teuchos::RCP<const OP>& A) :
     base_type::Krylov (A)
   {}
 
-  virtual ~CgSingleReduce () {}
+  virtual ~CgSingleReduce () = default;
 
 protected:
   using vec_type = typename base_type::vec_type;

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_Gmres.hpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_Gmres.hpp
@@ -260,16 +260,13 @@ private:
   using dense_vector_type = Teuchos::SerialDenseVector<LO, SC>;
 
 public:
-  Gmres () :
-    Krylov<SC, MV, OP>::Krylov ()
-  {}
+  Gmres () = default;
 
   Gmres (const Teuchos::RCP<const OP>& A) :
     Krylov<SC, MV, OP>::Krylov (A)
   {}
 
-  virtual ~Gmres()
-  {}
+  virtual ~Gmres () = default;
 
   virtual void
   getParameters (Teuchos::ParameterList& params,

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresPipeline.hpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresPipeline.hpp
@@ -39,8 +39,7 @@ public:
     this->input_.computeRitzValues = true;
   }
 
-  virtual ~GmresPipeline ()
-  {}
+  virtual ~GmresPipeline () = default;
 
 private:
   SolverOutput<SC>

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresS.hpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresS.hpp
@@ -24,16 +24,13 @@ private:
   using vec_type = typename Krylov<SC, MV, OP>::vec_type;
 
 public:
-  GmresS () :
-    base_type::Gmres ()
-  {}
+  GmresS () = default;
 
   GmresS (const Teuchos::RCP<const OP>& A) :
     base_type::Gmres (A)
   {}
 
-  virtual ~GmresS ()
-  {}
+  virtual ~GmresS () = default;
 
   virtual void
   setParameters (Teuchos::ParameterList& params) {

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresSingleReduce.hpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresSingleReduce.hpp
@@ -38,8 +38,7 @@ public:
     this->input_.computeRitzValues = true;
   }
 
-  virtual ~GmresSingleReduce ()
-  {}
+  virtual ~GmresSingleReduce () = default;
 
   virtual void
   setParameters (Teuchos::ParameterList& params) {

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresSstep.hpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresSstep.hpp
@@ -140,8 +140,7 @@ public:
     this->input_.computeRitzValues = true;
   }
 
-  virtual ~GmresSstep ()
-  {}
+  virtual ~GmresSstep () = default;
 
   virtual void
   getParameters (Teuchos::ParameterList& params,

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_Krylov.hpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_Krylov.hpp
@@ -61,9 +61,7 @@ private:
   using device_type = typename MV::device_type;
 
 public:
-  Krylov () :
-    verbosity_ (0)
-  {}
+  Krylov () = default;
 
   Krylov (const Teuchos::RCP<const OP>& A) :
     Krylov ()
@@ -71,7 +69,7 @@ public:
     A_ = A;
   }
 
-  virtual ~Krylov () {}
+  virtual ~Krylov () = default;
 
   //! Set the matrix A in the linear system to solve.
   void setMatrix (const Teuchos::RCP<const OP>& A) {
@@ -385,7 +383,7 @@ private:
   Teuchos::RCP<const OP> A_;
   std::string precoType_;
   Teuchos::RCP<const OP> M_;
-  int verbosity_;
+  int verbosity_ = 0;
 };
 
 } // namespace Impl

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_SolverManager.hpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_SolverManager.hpp
@@ -31,7 +31,7 @@ public:
 						      params)
   {}
 
-  virtual ~SolverManager () {}
+  virtual ~SolverManager () = default;
 
   virtual Teuchos::RCP<Belos::SolverManager<SC, MV, OP> >
   clone () const override

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_SolverManagerBase.hpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_SolverManagerBase.hpp
@@ -41,7 +41,7 @@ public:
     }
   }
 
-  virtual ~SolverManagerBase () {}
+  virtual ~SolverManagerBase () = default;
 
   const linear_problem_type& getProblem () const override {
     const char prefix[] = "SolverManagerBase::getProblem: ";

--- a/packages/tpetra/core/src/Tpetra_Details_allReduceView.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_allReduceView.hpp
@@ -1,0 +1,218 @@
+// @HEADER
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services Package
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+
+#ifndef TPETRA_DETAILS_ALLREDUCEVIEW_HPP
+#define TPETRA_DETAILS_ALLREDUCEVIEW_HPP
+
+#include "Tpetra_Details_Behavior.hpp"
+#include "Tpetra_Details_isInterComm.hpp"
+#include "Kokkos_Core.hpp"
+#include "Teuchos_CommHelpers.hpp"
+#include <limits>
+#include <type_traits>
+
+/// \file Tpetra_Details_allReduceView.hpp
+/// \brief All-reduce a 1-D or 2-D Kokkos::View
+
+namespace { // (anonymous)
+
+// We can't assume C++14 yet, so we can't have templated constants.
+template<class ViewType>
+struct view_is_cuda_uvm {
+  static constexpr bool value =
+#ifdef KOKKOS_ENABLE_CUDA
+    std::is_same<typename ViewType::memory_space,
+		 Kokkos::CudaUVMSpace>::value;
+#else
+    false;
+#endif // KOKKOS_ENABLE_CUDA
+};
+
+template<class ViewType>
+struct MakeContiguousBuffer {
+  static constexpr bool is_contiguous_layout =
+    std::is_same<
+      typename ViewType::array_layout,
+      Kokkos::LayoutLeft>::value ||
+    std::is_same<
+      typename ViewType::array_layout,
+      Kokkos::LayoutRight>::value;
+  using contiguous_array_layout =
+    typename std::conditional<is_contiguous_layout,
+			      typename ViewType::array_layout,
+			      Kokkos::LayoutLeft>::type;
+  using contiguous_device_type =
+    typename std::conditional<
+      std::is_same<
+	typename ViewType::memory_space,
+	Kokkos::HostSpace>::value,
+      typename ViewType::device_type,
+      Kokkos::HostSpace::device_type>::type;
+  using contiguous_buffer_type =
+    Kokkos::View<typename ViewType::non_const_data_type,
+		 contiguous_array_layout,
+		 contiguous_device_type>;
+
+  static contiguous_array_layout
+  makeLayout (const ViewType& view)
+  {
+    // NOTE (mfh 17 Mar 2019) This would be a good chance to use if
+    // constexpr, once we have C++17.
+    return contiguous_array_layout (view.extent (0), view.extent (1),
+				    view.extent (2), view.extent (3),
+				    view.extent (4), view.extent (5),
+				    view.extent (6), view.extent (7));
+  }
+  
+  static contiguous_buffer_type
+  make (const ViewType& view)
+  {
+    using Kokkos::view_alloc;
+    using Kokkos::WithoutInitializing;
+    return contiguous_buffer_type
+      (view_alloc (view.label (), WithoutInitializing),
+       makeLayout (view));
+  }
+};
+
+template<class ViewType>
+typename MakeContiguousBuffer<ViewType>::contiguous_buffer_type
+makeContiguousBuffer (const ViewType& view)
+{
+  return MakeContiguousBuffer<ViewType>::make (view);
+}
+
+template<class ValueType>
+static void
+allReduceRawContiguous (ValueType output[],
+			const ValueType input[],
+			const size_t count,
+			const Teuchos::Comm<int>& comm)
+{
+  using Teuchos::outArg;
+  using Teuchos::REDUCE_SUM;
+  using Teuchos::reduceAll;
+  constexpr size_t max_int = size_t (std::numeric_limits<int>::max ());
+  TEUCHOS_ASSERT( count <= size_t (max_int) );
+  reduceAll<int, ValueType> (comm, REDUCE_SUM, static_cast<int> (count),
+			     input, output);
+}
+
+} // namespace (anonymous)
+
+namespace Tpetra {
+namespace Details {
+
+/// \brief All-reduce from input Kokkos::View to output Kokkos::View.
+///
+/// The two Views may alias one another.
+template<class InputViewType, class OutputViewType>
+static void
+allReduceView (const OutputViewType& output,
+	       const InputViewType& input,
+	       const Teuchos::Comm<int>& comm)
+{
+  // If all the right conditions hold, we may all-reduce directly from
+  // the input to the output.  Here are the relevant conditions:
+  //
+  // - assumeMpiCanAccessBuffers: May we safely assume that MPI may
+  //   read from the input View and write to the output View?  (Just
+  //   because MPI _can_, doesn't mean that doing so will be faster.)
+  // - Do input and output Views alias each other, and is the
+  //   communicator an intercommunicator?  (Intercommunicators do not
+  //   permit collectives to alias input and output buffers.)
+  // - Is either View noncontiguous?
+  //
+  // If either View is noncontiguous, we could use MPI_Type_Vector to
+  // create a noncontiguous MPI_Datatype, instead of packing and
+  // unpacking to resp. from a contiguous temporary buffer.  Since
+  // MPI_Allreduce requires that the input and output buffers both
+  // have the same MPI_Datatype, this optimization might only work if
+  // the MPI communicator is an intercommunicator.  Furthermore,
+  // creating an MPI_Datatype instance may require memory allocation
+  // anyway.  Thus, it's probably better just to use a temporary
+  // contiguous buffer.  We use a host buffer for that, since device
+  // buffers are slow to allocate.
+
+  const bool viewsAlias = output.data () == input.data ();
+  if (comm.getSize () == 1) {
+    if (! viewsAlias) {
+      // InputViewType and OutputViewType can't be AnonymousSpace
+      // Views, because deep_copy needs to know their memory spaces.
+      Kokkos::deep_copy (output, input);
+    }
+    return;
+  }
+
+  // We've had some experience that some MPI implementations do not
+  // perform well with UVM allocations.
+  const bool assumeMpiCanAccessBuffers =
+    ! view_is_cuda_uvm<OutputViewType>::value &&
+    ! view_is_cuda_uvm<InputViewType>::value &&
+    ::Tpetra::Details::Behavior::assumeMpiIsCudaAware ();
+
+  const bool needContiguousTemporaryBuffers =
+    ! assumeMpiCanAccessBuffers ||
+    ::Tpetra::Details::isInterComm (comm) ||
+    output.span_is_contiguous () || input.span_is_contiguous ();
+  if (needContiguousTemporaryBuffers) {
+    auto output_tmp = makeContiguousBuffer (output);
+    auto input_tmp = makeContiguousBuffer (input);
+    Kokkos::deep_copy (input_tmp, input);
+    // It's OK if LayoutLeft allocations have padding at the end of
+    // each row.  MPI might write to those padding bytes, but it's
+    // undefined behavior for users to use Kokkos to access whatever
+    // bytes are there, and the bytes there don't need to define valid
+    // ValueType instances.
+    allReduceRawContiguous (output_tmp.data (), input_tmp.data (),
+			    output_tmp.span (), comm);
+    Kokkos::deep_copy (output, output_tmp);
+  }
+  else {
+    allReduceRawContiguous (output.data (), input.data (),
+			    output.span (), comm);
+  }
+}
+
+} // namespace Details
+} // namespace Tpetra
+
+#endif // TPETRA_DETAILS_ALLREDUCEVIEW_HPP

--- a/packages/tpetra/core/src/Tpetra_Details_allReduceView.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_allReduceView.hpp
@@ -60,7 +60,7 @@ struct view_is_cuda_uvm {
   static constexpr bool value =
 #ifdef KOKKOS_ENABLE_CUDA
     std::is_same<typename ViewType::memory_space,
-		 Kokkos::CudaUVMSpace>::value;
+                 Kokkos::CudaUVMSpace>::value;
 #else
     false;
 #endif // KOKKOS_ENABLE_CUDA
@@ -77,19 +77,19 @@ struct MakeContiguousBuffer {
       Kokkos::LayoutRight>::value;
   using contiguous_array_layout =
     typename std::conditional<is_contiguous_layout,
-			      typename ViewType::array_layout,
-			      Kokkos::LayoutLeft>::type;
+                              typename ViewType::array_layout,
+                              Kokkos::LayoutLeft>::type;
   using contiguous_device_type =
     typename std::conditional<
       std::is_same<
-	typename ViewType::memory_space,
-	Kokkos::HostSpace>::value,
+        typename ViewType::memory_space,
+        Kokkos::HostSpace>::value,
       typename ViewType::device_type,
       Kokkos::HostSpace::device_type>::type;
   using contiguous_buffer_type =
     Kokkos::View<typename ViewType::non_const_data_type,
-		 contiguous_array_layout,
-		 contiguous_device_type>;
+                 contiguous_array_layout,
+                 contiguous_device_type>;
 
   static contiguous_array_layout
   makeLayout (const ViewType& view)
@@ -97,11 +97,11 @@ struct MakeContiguousBuffer {
     // NOTE (mfh 17 Mar 2019) This would be a good chance to use if
     // constexpr, once we have C++17.
     return contiguous_array_layout (view.extent (0), view.extent (1),
-				    view.extent (2), view.extent (3),
-				    view.extent (4), view.extent (5),
-				    view.extent (6), view.extent (7));
+                                    view.extent (2), view.extent (3),
+                                    view.extent (4), view.extent (5),
+                                    view.extent (6), view.extent (7));
   }
-  
+
   static contiguous_buffer_type
   make (const ViewType& view)
   {
@@ -123,9 +123,9 @@ makeContiguousBuffer (const ViewType& view)
 template<class ValueType>
 static void
 allReduceRawContiguous (ValueType output[],
-			const ValueType input[],
-			const size_t count,
-			const Teuchos::Comm<int>& comm)
+                        const ValueType input[],
+                        const size_t count,
+                        const Teuchos::Comm<int>& comm)
 {
   using Teuchos::outArg;
   using Teuchos::REDUCE_SUM;
@@ -133,7 +133,7 @@ allReduceRawContiguous (ValueType output[],
   constexpr size_t max_int = size_t (std::numeric_limits<int>::max ());
   TEUCHOS_ASSERT( count <= size_t (max_int) );
   reduceAll<int, ValueType> (comm, REDUCE_SUM, static_cast<int> (count),
-			     input, output);
+                             input, output);
 }
 
 } // namespace (anonymous)
@@ -147,8 +147,8 @@ namespace Details {
 template<class InputViewType, class OutputViewType>
 static void
 allReduceView (const OutputViewType& output,
-	       const InputViewType& input,
-	       const Teuchos::Comm<int>& comm)
+               const InputViewType& input,
+               const Teuchos::Comm<int>& comm)
 {
   // If all the right conditions hold, we may all-reduce directly from
   // the input to the output.  Here are the relevant conditions:
@@ -203,12 +203,12 @@ allReduceView (const OutputViewType& output,
     // bytes are there, and the bytes there don't need to define valid
     // ValueType instances.
     allReduceRawContiguous (output_tmp.data (), input_tmp.data (),
-			    output_tmp.span (), comm);
+                            output_tmp.span (), comm);
     Kokkos::deep_copy (output, output_tmp);
   }
   else {
     allReduceRawContiguous (output.data (), input.data (),
-			    output.span (), comm);
+                            output.span (), comm);
   }
 }
 

--- a/packages/tpetra/core/src/Tpetra_Import_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Import_def.hpp
@@ -298,8 +298,6 @@ namespace Tpetra {
     ArrayView<const GO> targetGIDs = target->getNodeElementList ();
     const size_type numSrcGids = sourceGIDs.size ();
     const size_type numTgtGids = targetGIDs.size ();
-    const size_type numGids = std::min (numSrcGids, numTgtGids);
-    const LO LINVALID = Teuchos::OrdinalTraits<LO>::invalid ();
 
     Array<GO> tRemoteGIDs;
     if (this->verbose ()) {

--- a/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
@@ -769,14 +769,11 @@ namespace Tpetra {
     Teuchos::RCP<MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node2> >
     clone (const Teuchos::RCP<Node2>& node2) const;
 
-    /// \brief Swaps the data from *this with the data and maps from mv
-    /// \param mv [in/out] a MultiVector
-    ///
-    /// Note: This is done with minimal copying of data
-    void swap(MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> & mv);
+    //! Swap contents of \c mv with contents of \c *this.
+    void swap (MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& mv);
 
     //! Destructor (virtual for memory safety of derived classes).
-    virtual ~MultiVector ();
+    virtual ~MultiVector () = default;
 
     //@}
     //! @name Post-construction modification routines

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -3747,7 +3747,6 @@ namespace Tpetra {
     else {
       for (size_t j = 0; j < numCols; ++j) {
 	const size_t srcCol = this->whichVectors_[j];
-	const size_t dstCol = j;
 	auto dstColView = Kokkos::subview (A_view, rowRange, j);
 
 	if (useHostVersion) {

--- a/packages/tpetra/core/src/Tpetra_computeRowAndColumnOneNorms_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_computeRowAndColumnOneNorms_def.hpp
@@ -398,9 +398,9 @@ public:
   using local_map_type = typename ::Tpetra::Map<LO, GO, NT>::local_map_type;
 
   ComputeLocalRowOneNorms (const equib_info_type& equib,   // in/out
-			   const local_matrix_type& A_lcl, // in
-			   const local_map_type& rowMap,   // in
-			   const local_map_type& colMap) : // in
+                           const local_matrix_type& A_lcl, // in
+                           const local_map_type& rowMap,   // in
+                           const local_map_type& colMap) : // in
     equib_ (equib),
     A_lcl_ (A_lcl),
     rowMap_ (rowMap),
@@ -551,7 +551,7 @@ public:
       if (lclCol == lclDiagColInd) {
         diagVal = curRow.value (k); // assume no repeats
       }
-      if (! assumeSymmetric) {
+      if (! equib_.assumeSymmetric) {
         Kokkos::atomic_add (&(equib_.colNorms[lclCol]), matrixAbsVal);
       }
     } // for each entry in row
@@ -570,7 +570,7 @@ public:
     // norms are the same as the global row norms).
     equib_.rowDiagonalEntries[lclRow] = diagVal;
     equib_.rowNorms[lclRow] = rowNorm;
-    if (! assumeSymmetric &&
+    if (! equib_.assumeSymmetric &&
         lclDiagColInd != Tpetra::Details::OrdinalTraits<LO>::invalid ()) {
       // Don't need an atomic update here, since this lclDiagColInd is
       // a one-to-one function of lclRow.
@@ -655,7 +655,7 @@ computeLocalRowAndColumnOneNorms_CrsMatrix (const Tpetra::CrsMatrix<SC, LO, GO, 
 /// \param A [in] The input sparse matrix A.
 template<class SC, class LO, class GO, class NT>
 EquilibrationInfo<typename Kokkos::ArithTraits<SC>::val_type,
-		  typename NT::device_type>
+                  typename NT::device_type>
 computeLocalRowOneNorms (const Tpetra::RowMatrix<SC, LO, GO, NT>& A)
 {
   using crs_matrix_type = Tpetra::CrsMatrix<SC, LO, GO, NT>;

--- a/packages/tpetra/core/src/Tpetra_computeRowAndColumnOneNorms_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_computeRowAndColumnOneNorms_def.hpp
@@ -533,7 +533,6 @@ public:
 
     const auto curRow = A_lcl_.rowConst (lclRow);
     const LO numEnt = curRow.length;
-    const bool assumeSymmetric = equib_.assumeSymmetric;
 
     mag_type rowNorm {0.0};
     val_type diagVal {0.0};

--- a/packages/tpetra/core/test/MultiVector/CMakeLists.txt
+++ b/packages/tpetra/core/test/MultiVector/CMakeLists.txt
@@ -117,3 +117,16 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   STANDARD_PASS_OUTPUT
   ${MAXNP}
   )
+
+# Regression test for Trilinos GitHub Issue #4639.
+# It must run with at least 2 MPI processes to exercise
+# the fix for that issue.
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  MV_reduce_strided
+  SOURCES
+    MV_reduce_strided
+    ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  COMM mpi
+  NUM_MPI_PROCS 2-4
+  STANDARD_PASS_OUTPUT
+  )

--- a/packages/tpetra/core/test/MultiVector/MV_reduce_strided.cpp
+++ b/packages/tpetra/core/test/MultiVector/MV_reduce_strided.cpp
@@ -1,0 +1,429 @@
+/*
+// @HEADER
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services Package
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+*/
+
+#include "Tpetra_TestingUtilities.hpp"
+#include "Tpetra_Map.hpp"
+#include "Tpetra_MultiVector.hpp"
+#include "Tpetra_Vector.hpp"
+#include "Teuchos_CommHelpers.hpp"
+//#include <type_traits>
+
+namespace { // (anonymous)
+
+template<class MapType>
+Teuchos::RCP<const MapType>
+makeLocalMap (const MapType& inputMap,
+	      const typename MapType::local_ordinal_type lclNumRows)
+{
+  Teuchos::RCP<MapType> map (new MapType (lclNumRows,
+					  inputMap.getIndexBase (),
+					  inputMap.getComm (),
+					  Tpetra::LocallyReplicated));
+  return Teuchos::rcp_const_cast<const MapType> (map);
+}
+
+template<class MV>
+bool multiVectorsLocallyEqual (Teuchos::FancyOStream& out,
+			       const MV& X, const MV& Y)
+{
+  using std::endl;
+  out << "Test MultiVector local equality" << endl;
+  Teuchos::OSTab tab1 (out);
+  
+  const size_t lclNumRows = X.getLocalLength ();
+  if (Y.getLocalLength () != lclNumRows) {
+    return false;
+  }
+  const size_t numCols = X.getNumVectors ();
+  if (Y.getNumVectors () != numCols) {
+    return false;
+  }
+
+  out << "Dimensions match" << endl;
+
+  // We don't want to change the user's sync state, so if we find
+  // ourselves needing to sync to host, we make a deep copy first.
+  MV X_copy;
+  MV Y_copy;
+  if (X.need_sync_host ()) {
+    X_copy = MV (X, Teuchos::Copy);
+    X_copy.sync_host ();
+  }
+  else {
+    X_copy = X; // harmless shallow copy
+  }
+  if (Y.need_sync_host ()) {
+    Y_copy = MV (Y, Teuchos::Copy);
+    Y_copy.sync_host ();
+  }
+  else {
+    Y_copy = Y; // harmless shallow copy
+  }
+
+  // Comparing a vector at a time avoids issues with noncontiguous MVs.
+  for (size_t j = 0; j < numCols; ++j) {
+    auto X_j = X_copy.getVector (j);
+    auto Y_j = Y_copy.getVector (j);
+    auto X_j_lcl_2d = X_j->getLocalViewHost ();
+    auto Y_j_lcl_2d = Y_j->getLocalViewHost ();
+    auto X_j_lcl = Kokkos::subview (X_j_lcl_2d, Kokkos::ALL (), 0);
+    auto Y_j_lcl = Kokkos::subview (Y_j_lcl_2d, Kokkos::ALL (), 0);
+
+    for (size_t i = 0; i < lclNumRows; ++i) {
+      if (X_j_lcl(i) != Y_j_lcl(i)) {
+	out << "Oh no! X(" << i << "," << j << ")=" << X_j_lcl(i) << " != Y(" << i << "," << j << ")=" << Y_j_lcl(i) << endl;
+	return false;
+      }
+    }
+  }
+
+  out << "Values match" << endl;  
+  return true;
+}
+
+template<class MV>
+bool multiVectorsEqual (Teuchos::FancyOStream& out,
+			const MV& X, const MV& Y)
+{
+  using std::endl;
+  out << "Test MultiVector global equality" << endl;
+  Teuchos::OSTab tab1 (out);
+  
+  const auto& X_map = * (X.getMap ());
+  const auto& Y_map = * (Y.getMap ());
+  if (! X_map.isSameAs (Y_map)) {
+    return false;
+  }
+
+  const bool lclEqual = multiVectorsLocallyEqual (out, X, Y);
+  if (lclEqual) {
+    out << "X and Y are locally equal" << endl;
+  }
+  else {
+    out << "X and Y are NOT locally equal" << endl;
+  }
+  const int lclEq = lclEqual ? 1 : 0;
+  int gblEq = 0;
+
+  using Teuchos::outArg;  
+  using Teuchos::reduceAll;
+  using Teuchos::REDUCE_MIN;
+  const auto& comm = * (X_map.getComm ());
+  reduceAll<int, int> (comm, REDUCE_MIN, lclEq, outArg (gblEq));
+
+  if (gblEq == 1) {
+    out << "X and Y are globally equal" << endl;
+  }
+  else {
+    out << "X and Y are NOT globally equal" << endl;
+  }
+  return gblEq == 1;
+}
+
+template<class MV>
+void reduceMultiVector (MV& Z)
+{
+  // Make a non-strided MultiVector, reduce on it, and copy back.
+  MV Z2 (Z, Teuchos::Copy);
+  Z2.reduce ();
+  Tpetra::deep_copy (Z, Z2);
+}
+
+template<class MV>
+void reduceMultiVector2 (MV& Z)
+{
+  using Teuchos::outArg;  
+  using Teuchos::reduceAll;
+  using Teuchos::REDUCE_SUM;
+  
+  if (Z.need_sync_host ()) {
+    Z.sync_host ();
+  }
+  Z.modify_host ();
+  
+  const size_t numRows = Z.getLocalLength ();
+  const size_t numCols = Z.getNumVectors ();
+  MV Z2 (Z.getMap (), Z.getNumVectors ());
+  Z2.sync_host ();
+  Z2.modify_host ();
+  const auto& comm = * (Z.getMap ()->getComm ());
+  
+  for (size_t j = 0; j < numCols; ++j) {
+    auto Z_j = Z.getVectorNonConst (j);
+    auto Z_j_lcl_2d = Z_j->getLocalViewHost ();
+    auto Z_j_lcl = Kokkos::subview (Z_j_lcl_2d, Kokkos::ALL (), 0);
+
+    auto Z2_j = Z2.getVectorNonConst (j);
+    auto Z2_j_lcl_2d = Z2_j->getLocalViewHost ();
+    auto Z2_j_lcl = Kokkos::subview (Z2_j_lcl_2d, Kokkos::ALL (), 0);
+
+    reduceAll (comm, REDUCE_SUM, static_cast<int> (numRows),
+	       Z_j_lcl.data (), Z2_j_lcl.data ());
+    Kokkos::deep_copy (Z_j_lcl, Z2_j_lcl);
+  }
+  Z.sync_device ();
+}
+  
+//
+// UNIT TESTS
+//
+
+TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( MultiVector, reduce_strided, Scalar, LocalOrdinal, GlobalOrdinal, Node )
+{
+  using Teuchos::RCP;
+  using Teuchos::rcp;
+  using std::endl;
+  using SC = Scalar;
+  using LO = LocalOrdinal;
+  using GO = GlobalOrdinal;
+  using NT = Node;
+  using MV = Tpetra::MultiVector<SC, LO, GO, NT>;
+  using map_type = typename MV::map_type;
+  using STS = Teuchos::ScalarTraits<SC>;
+  using mag_type = typename MV::mag_type;
+  using dual_view_type = typename MV::dual_view_type;
+  using pair_type = std::pair<size_t, size_t>;
+
+  out << "Test Tpetra::MultiVector::reduce "
+    "where stride is greater than local number of rows" << endl;
+  Teuchos::OSTab tab1 (out);
+
+  const auto comm = Tpetra::TestingUtilities::getDefaultComm ();
+  constexpr LO lclNumRows = 5;
+  constexpr LO numCols = 2;
+  constexpr GO indexBase = 0;
+  const GO gblNumRows = GO (comm->getSize ()) * GO (lclNumRows);
+
+  RCP<const map_type> map =
+    rcp (new map_type (gblNumRows, lclNumRows, indexBase, comm));
+  const auto lclMap = makeLocalMap (*map, lclNumRows);
+  
+  MV Z0 (lclMap, numCols);
+
+  // Fill each column of Z0 with a different number.  Start with 1
+  // instead of 0, because 0 is the default fill value.
+  {
+    SC curVal = STS::one ();
+    Z0.sync_host ();
+    Z0.modify_host ();
+    for (size_t j = 0; j < numCols; ++j) {
+      Z0.getVectorNonConst (j)->putScalar (curVal);
+      curVal += STS::one ();
+    }
+    Z0.sync_device ();
+  }
+  
+  MV Z1 (Z0, Teuchos::Copy);
+  Z1.reduce ();
+  {
+    const SC TWO = STS::one () + STS::one ();
+    
+    Z1.sync_host ();
+    auto Z1_lcl = Z1.getLocalViewHost ();
+    bool reduce_expected_result = true;
+    for (size_t j = 0; j < numCols; ++j) {
+      SC expectedVal = SC (mag_type (j+1)) *
+	SC (mag_type (comm->getSize ()));
+      for (size_t i = 0; i < lclNumRows; ++i) {
+	if (STS::magnitude (expectedVal - SC (Z1_lcl(i,j))) >= mag_type (lclNumRows) * STS::eps ()) {
+	  reduce_expected_result = false;
+	}
+      }
+    }
+    TEST_ASSERT( reduce_expected_result );
+    Z1.sync_device ();
+  }
+  Z1.describe (out, Teuchos::VERB_EXTREME);
+
+  MV Z2 (Z0, Teuchos::Copy);
+  reduceMultiVector (Z2);
+
+  const bool Z1_Z2_equal = multiVectorsEqual (out, Z1, Z2);
+  TEST_ASSERT( Z1_Z2_equal );
+
+  MV Z3 (Z0, Teuchos::Copy);
+  reduceMultiVector2 (Z3);
+
+  const bool Z1_Z3_equal = multiVectorsEqual (out, Z1, Z3);
+  TEST_ASSERT( Z1_Z3_equal );
+  
+  {
+    // Make sure Z4 has a stride greater than its number of rows.
+    const size_t Z4_stride = static_cast<size_t> (lclNumRows + 31);
+    dual_view_type Z4_dv_extra ("Z4", Z4_stride, numCols);
+    auto Z4_dv = Kokkos::subview (Z4_dv_extra,
+				  pair_type (0, lclNumRows),
+				  pair_type (0, numCols));
+    TEST_ASSERT( LO (Z4_dv.extent (0) == lclNumRows ) );
+    TEST_ASSERT( LO (Z4_dv.extent (1) == numCols ) );
+    TEST_ASSERT( LO (Z4_dv.d_view.extent (0) == lclNumRows ) );
+    TEST_ASSERT( LO (Z4_dv.d_view.extent (1) == numCols ) );		 
+    TEST_ASSERT( LO (Z4_dv.h_view.extent (0) == lclNumRows ) );
+    TEST_ASSERT( LO (Z4_dv.h_view.extent (1) == numCols ) );		 
+    // Kokkos could in theory insert padding in the row dimension.
+    TEST_ASSERT( size_t (Z4_dv.d_view.stride (1)) >= Z4_stride );
+    TEST_ASSERT( size_t (Z4_dv.h_view.stride (1)) >= Z4_stride );
+  
+    MV Z4 (lclMap, Z4_dv);
+    TEST_ASSERT( Z4_dv.d_view.data () == Z4.getLocalViewDevice ().data () );
+    TEST_ASSERT( Z4_dv.h_view.data () == Z4.getLocalViewHost ().data () );
+    TEST_ASSERT( Z4.isConstantStride () );
+    if (Z4.isConstantStride ()) {
+      TEST_ASSERT( size_t (Z4_dv.d_view.stride (1)) == Z4.getStride () );
+      TEST_ASSERT( size_t (Z4_dv.h_view.stride (1)) == Z4.getStride () );
+      // Kokkos could in theory insert padding in the row dimension.      
+      TEST_ASSERT( Z4.getStride () >= Z4_stride );
+    }
+    for (size_t j = 0; j < numCols; ++j) {
+      out << "Column j=" << j << " of Z4" << endl;
+      Teuchos::OSTab colTab (out);
+	
+      auto Z4_dv_j = Kokkos::subview (Z4_dv, Kokkos::ALL (), j);
+      
+      auto Z4_j_h = Z4.getVectorNonConst (j);
+      auto Z4_j_h_lcl_2d = Z4_j_h->getLocalViewHost ();
+      auto Z4_j_h_lcl = Kokkos::subview (Z4_j_h_lcl_2d, Kokkos::ALL (), 0);
+
+      TEST_ASSERT( Z4_j_h_lcl.data () == Z4_dv_j.h_view.data () );
+      if (Z4_j_h_lcl.data () != Z4_dv_j.h_view.data ()) {
+	out << "Z4_j_h_lcl.data() = " << Z4_j_h_lcl.data ()
+	    << ", Z4_dv_j.h_view.data() = " << Z4_dv_j.h_view.data ()
+	    << endl;
+      }
+      TEST_ASSERT( Z4_j_h_lcl.extent (0) == Z4_dv_j.h_view.extent (0) );
+      
+      auto Z4_j_d = Z4.getVectorNonConst (j);
+      auto Z4_j_d_lcl_2d = Z4_j_d->getLocalViewDevice ();
+      auto Z4_j_d_lcl = Kokkos::subview (Z4_j_d_lcl_2d, Kokkos::ALL (), 0);
+
+      TEST_ASSERT( Z4_j_d_lcl.data () == Z4_dv_j.d_view.data () );
+      if (Z4_j_d_lcl.data () != Z4_dv_j.d_view.data ()) {
+	out << "Z4_j_d_lcl.data() = " << Z4_j_d_lcl.data ()
+	    << ", Z4_dv_j.d_view.data() = " << Z4_dv_j.d_view.data ()
+	    << endl;
+      }
+      TEST_ASSERT( Z4_j_d_lcl.extent (0) == Z4_dv_j.d_view.extent (0) );
+
+      if (j == 0) {
+	TEST_ASSERT( Z4_j_h_lcl.data () == Z4_dv.h_view.data () );
+	TEST_ASSERT( Z4_j_d_lcl.data () == Z4_dv.d_view.data () );	
+      }
+    }
+
+    Tpetra::deep_copy (Z4, Z0);
+    const bool Z0_Z4_equal_before = multiVectorsEqual (out, Z0, Z4);
+    TEST_ASSERT( Z0_Z4_equal_before );
+
+    Z4.reduce ();
+    const bool Z1_Z4_equal_after_reduce = multiVectorsEqual (out, Z1, Z4);
+    TEST_ASSERT( Z1_Z4_equal_after_reduce );
+  }
+
+  {
+    // Make sure Z5 has a stride greater than its number of rows.
+    const size_t Z5_stride = Z0.getLocalLength () + lclNumRows;
+    dual_view_type Z5_dv_extra ("Z5", Z5_stride, numCols);
+    auto Z5_dv = Kokkos::subview (Z5_dv_extra,
+				  pair_type (0, lclNumRows),
+				  pair_type (0, numCols));
+    TEST_ASSERT( LO (Z5_dv.extent (0) == lclNumRows ) );
+    TEST_ASSERT( LO (Z5_dv.extent (1) == numCols ) );		 
+    // Kokkos could in theory insert padding in the row dimension.
+    TEST_ASSERT( size_t (Z5_dv.d_view.stride (1)) >= Z5_stride );
+    TEST_ASSERT( size_t (Z5_dv.h_view.stride (1)) >= Z5_stride );  
+  
+    MV Z5 (lclMap, Z5_dv);
+    Tpetra::deep_copy (Z5, Z0);
+
+    const bool Z0_Z5_equal_before = multiVectorsEqual (out, Z0, Z5);
+    TEST_ASSERT( Z0_Z5_equal_before );
+
+    reduceMultiVector (Z5);
+    const bool Z1_Z5_equal_after_reduceMultiVector =
+      multiVectorsEqual (out, Z1, Z5);
+    TEST_ASSERT( Z1_Z5_equal_after_reduceMultiVector );
+  }
+
+  {
+    // Make sure Z6 has a stride greater than its number of rows.
+    const size_t Z6_stride = Z0.getLocalLength () + lclNumRows;
+    dual_view_type Z6_dv_extra ("Z6", Z6_stride, numCols);
+    auto Z6_dv = Kokkos::subview (Z6_dv_extra,
+				  pair_type (0, lclNumRows),
+				  pair_type (0, numCols));
+    TEST_ASSERT( LO (Z6_dv.extent (0) == lclNumRows ) );
+    TEST_ASSERT( LO (Z6_dv.extent (1) == numCols ) );		 
+    // Kokkos could in theory insert padding in the row dimension.
+    TEST_ASSERT( size_t (Z6_dv.d_view.stride (1)) >= Z6_stride );
+    TEST_ASSERT( size_t (Z6_dv.h_view.stride (1)) >= Z6_stride );  
+  
+    MV Z6 (lclMap, Z6_dv);
+    Tpetra::deep_copy (Z6, Z0);
+
+    const bool Z0_Z6_equal_before = multiVectorsEqual (out, Z0, Z6);
+    TEST_ASSERT( Z0_Z6_equal_before );
+
+    reduceMultiVector2 (Z6);
+    const bool Z1_Z6_equal_after_reduceMultiVector2 =
+      multiVectorsEqual (out, Z1, Z6);
+    TEST_ASSERT( Z1_Z6_equal_after_reduceMultiVector2 );
+
+    out << endl << "Z1:" << endl;
+    Z1.describe (out, Teuchos::VERB_EXTREME);
+    out << endl << "Z6:" << endl;    
+    Z6.describe (out, Teuchos::VERB_EXTREME);
+  }
+}
+
+//
+// INSTANTIATIONS
+//
+
+#define UNIT_TEST_GROUP( SCALAR, LO, GO, NODE ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( MultiVector, reduce_strided, SCALAR, LO, GO, NODE )
+
+  TPETRA_ETI_MANGLING_TYPEDEFS()
+
+  TPETRA_INSTANTIATE_TESTMV( UNIT_TEST_GROUP )
+
+} // namespace (anonymous)

--- a/packages/tpetra/core/test/MultiVector/MV_reduce_strided.cpp
+++ b/packages/tpetra/core/test/MultiVector/MV_reduce_strided.cpp
@@ -53,23 +53,23 @@ namespace { // (anonymous)
 template<class MapType>
 Teuchos::RCP<const MapType>
 makeLocalMap (const MapType& inputMap,
-	      const typename MapType::local_ordinal_type lclNumRows)
+              const typename MapType::local_ordinal_type lclNumRows)
 {
   Teuchos::RCP<MapType> map (new MapType (lclNumRows,
-					  inputMap.getIndexBase (),
-					  inputMap.getComm (),
-					  Tpetra::LocallyReplicated));
+                                          inputMap.getIndexBase (),
+                                          inputMap.getComm (),
+                                          Tpetra::LocallyReplicated));
   return Teuchos::rcp_const_cast<const MapType> (map);
 }
 
 template<class MV>
 bool multiVectorsLocallyEqual (Teuchos::FancyOStream& out,
-			       const MV& X, const MV& Y)
+                               const MV& X, const MV& Y)
 {
   using std::endl;
   out << "Test MultiVector local equality" << endl;
   Teuchos::OSTab tab1 (out);
-  
+
   const size_t lclNumRows = X.getLocalLength ();
   if (Y.getLocalLength () != lclNumRows) {
     return false;
@@ -111,24 +111,24 @@ bool multiVectorsLocallyEqual (Teuchos::FancyOStream& out,
 
     for (size_t i = 0; i < lclNumRows; ++i) {
       if (X_j_lcl(i) != Y_j_lcl(i)) {
-	out << "Oh no! X(" << i << "," << j << ")=" << X_j_lcl(i) << " != Y(" << i << "," << j << ")=" << Y_j_lcl(i) << endl;
-	return false;
+        out << "Oh no! X(" << i << "," << j << ")=" << X_j_lcl(i) << " != Y(" << i << "," << j << ")=" << Y_j_lcl(i) << endl;
+        return false;
       }
     }
   }
 
-  out << "Values match" << endl;  
+  out << "Values match" << endl;
   return true;
 }
 
 template<class MV>
 bool multiVectorsEqual (Teuchos::FancyOStream& out,
-			const MV& X, const MV& Y)
+                        const MV& X, const MV& Y)
 {
   using std::endl;
   out << "Test MultiVector global equality" << endl;
   Teuchos::OSTab tab1 (out);
-  
+
   const auto& X_map = * (X.getMap ());
   const auto& Y_map = * (Y.getMap ());
   if (! X_map.isSameAs (Y_map)) {
@@ -145,7 +145,7 @@ bool multiVectorsEqual (Teuchos::FancyOStream& out,
   const int lclEq = lclEqual ? 1 : 0;
   int gblEq = 0;
 
-  using Teuchos::outArg;  
+  using Teuchos::outArg;
   using Teuchos::reduceAll;
   using Teuchos::REDUCE_MIN;
   const auto& comm = * (X_map.getComm ());
@@ -172,22 +172,22 @@ void reduceMultiVector (MV& Z)
 template<class MV>
 void reduceMultiVector2 (MV& Z)
 {
-  using Teuchos::outArg;  
+  using Teuchos::outArg;
   using Teuchos::reduceAll;
   using Teuchos::REDUCE_SUM;
-  
+
   if (Z.need_sync_host ()) {
     Z.sync_host ();
   }
   Z.modify_host ();
-  
+
   const size_t numRows = Z.getLocalLength ();
   const size_t numCols = Z.getNumVectors ();
   MV Z2 (Z.getMap (), Z.getNumVectors ());
   Z2.sync_host ();
   Z2.modify_host ();
   const auto& comm = * (Z.getMap ()->getComm ());
-  
+
   for (size_t j = 0; j < numCols; ++j) {
     auto Z_j = Z.getVectorNonConst (j);
     auto Z_j_lcl_2d = Z_j->getLocalViewHost ();
@@ -198,12 +198,12 @@ void reduceMultiVector2 (MV& Z)
     auto Z2_j_lcl = Kokkos::subview (Z2_j_lcl_2d, Kokkos::ALL (), 0);
 
     reduceAll (comm, REDUCE_SUM, static_cast<int> (numRows),
-	       Z_j_lcl.data (), Z2_j_lcl.data ());
+               Z_j_lcl.data (), Z2_j_lcl.data ());
     Kokkos::deep_copy (Z_j_lcl, Z2_j_lcl);
   }
   Z.sync_device ();
 }
-  
+
 //
 // UNIT TESTS
 //
@@ -237,7 +237,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( MultiVector, reduce_strided, Scalar, LocalOrd
   RCP<const map_type> map =
     rcp (new map_type (gblNumRows, lclNumRows, indexBase, comm));
   const auto lclMap = makeLocalMap (*map, lclNumRows);
-  
+
   MV Z0 (lclMap, numCols);
 
   // Fill each column of Z0 with a different number.  Start with 1
@@ -252,22 +252,22 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( MultiVector, reduce_strided, Scalar, LocalOrd
     }
     Z0.sync_device ();
   }
-  
+
   MV Z1 (Z0, Teuchos::Copy);
   Z1.reduce ();
   {
     const SC TWO = STS::one () + STS::one ();
-    
+
     Z1.sync_host ();
     auto Z1_lcl = Z1.getLocalViewHost ();
     bool reduce_expected_result = true;
     for (size_t j = 0; j < numCols; ++j) {
       SC expectedVal = SC (mag_type (j+1)) *
-	SC (mag_type (comm->getSize ()));
+        SC (mag_type (comm->getSize ()));
       for (size_t i = 0; i < lclNumRows; ++i) {
-	if (STS::magnitude (expectedVal - SC (Z1_lcl(i,j))) >= mag_type (lclNumRows) * STS::eps ()) {
-	  reduce_expected_result = false;
-	}
+        if (STS::magnitude (expectedVal - SC (Z1_lcl(i,j))) >= mag_type (lclNumRows) * STS::eps ()) {
+          reduce_expected_result = false;
+        }
       }
     }
     TEST_ASSERT( reduce_expected_result );
@@ -286,24 +286,24 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( MultiVector, reduce_strided, Scalar, LocalOrd
 
   const bool Z1_Z3_equal = multiVectorsEqual (out, Z1, Z3);
   TEST_ASSERT( Z1_Z3_equal );
-  
+
   {
     // Make sure Z4 has a stride greater than its number of rows.
     const size_t Z4_stride = static_cast<size_t> (lclNumRows + 31);
     dual_view_type Z4_dv_extra ("Z4", Z4_stride, numCols);
     auto Z4_dv = Kokkos::subview (Z4_dv_extra,
-				  pair_type (0, lclNumRows),
-				  pair_type (0, numCols));
+                                  pair_type (0, lclNumRows),
+                                  pair_type (0, numCols));
     TEST_ASSERT( LO (Z4_dv.extent (0) == lclNumRows ) );
     TEST_ASSERT( LO (Z4_dv.extent (1) == numCols ) );
     TEST_ASSERT( LO (Z4_dv.d_view.extent (0) == lclNumRows ) );
-    TEST_ASSERT( LO (Z4_dv.d_view.extent (1) == numCols ) );		 
+    TEST_ASSERT( LO (Z4_dv.d_view.extent (1) == numCols ) );
     TEST_ASSERT( LO (Z4_dv.h_view.extent (0) == lclNumRows ) );
-    TEST_ASSERT( LO (Z4_dv.h_view.extent (1) == numCols ) );		 
+    TEST_ASSERT( LO (Z4_dv.h_view.extent (1) == numCols ) );
     // Kokkos could in theory insert padding in the row dimension.
     TEST_ASSERT( size_t (Z4_dv.d_view.stride (1)) >= Z4_stride );
     TEST_ASSERT( size_t (Z4_dv.h_view.stride (1)) >= Z4_stride );
-  
+
     MV Z4 (lclMap, Z4_dv);
     TEST_ASSERT( Z4_dv.d_view.data () == Z4.getLocalViewDevice ().data () );
     TEST_ASSERT( Z4_dv.h_view.data () == Z4.getLocalViewHost ().data () );
@@ -311,42 +311,42 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( MultiVector, reduce_strided, Scalar, LocalOrd
     if (Z4.isConstantStride ()) {
       TEST_ASSERT( size_t (Z4_dv.d_view.stride (1)) == Z4.getStride () );
       TEST_ASSERT( size_t (Z4_dv.h_view.stride (1)) == Z4.getStride () );
-      // Kokkos could in theory insert padding in the row dimension.      
+      // Kokkos could in theory insert padding in the row dimension.
       TEST_ASSERT( Z4.getStride () >= Z4_stride );
     }
     for (size_t j = 0; j < numCols; ++j) {
       out << "Column j=" << j << " of Z4" << endl;
       Teuchos::OSTab colTab (out);
-	
+
       auto Z4_dv_j = Kokkos::subview (Z4_dv, Kokkos::ALL (), j);
-      
+
       auto Z4_j_h = Z4.getVectorNonConst (j);
       auto Z4_j_h_lcl_2d = Z4_j_h->getLocalViewHost ();
       auto Z4_j_h_lcl = Kokkos::subview (Z4_j_h_lcl_2d, Kokkos::ALL (), 0);
 
       TEST_ASSERT( Z4_j_h_lcl.data () == Z4_dv_j.h_view.data () );
       if (Z4_j_h_lcl.data () != Z4_dv_j.h_view.data ()) {
-	out << "Z4_j_h_lcl.data() = " << Z4_j_h_lcl.data ()
-	    << ", Z4_dv_j.h_view.data() = " << Z4_dv_j.h_view.data ()
-	    << endl;
+        out << "Z4_j_h_lcl.data() = " << Z4_j_h_lcl.data ()
+            << ", Z4_dv_j.h_view.data() = " << Z4_dv_j.h_view.data ()
+            << endl;
       }
       TEST_ASSERT( Z4_j_h_lcl.extent (0) == Z4_dv_j.h_view.extent (0) );
-      
+
       auto Z4_j_d = Z4.getVectorNonConst (j);
       auto Z4_j_d_lcl_2d = Z4_j_d->getLocalViewDevice ();
       auto Z4_j_d_lcl = Kokkos::subview (Z4_j_d_lcl_2d, Kokkos::ALL (), 0);
 
       TEST_ASSERT( Z4_j_d_lcl.data () == Z4_dv_j.d_view.data () );
       if (Z4_j_d_lcl.data () != Z4_dv_j.d_view.data ()) {
-	out << "Z4_j_d_lcl.data() = " << Z4_j_d_lcl.data ()
-	    << ", Z4_dv_j.d_view.data() = " << Z4_dv_j.d_view.data ()
-	    << endl;
+        out << "Z4_j_d_lcl.data() = " << Z4_j_d_lcl.data ()
+            << ", Z4_dv_j.d_view.data() = " << Z4_dv_j.d_view.data ()
+            << endl;
       }
       TEST_ASSERT( Z4_j_d_lcl.extent (0) == Z4_dv_j.d_view.extent (0) );
 
       if (j == 0) {
-	TEST_ASSERT( Z4_j_h_lcl.data () == Z4_dv.h_view.data () );
-	TEST_ASSERT( Z4_j_d_lcl.data () == Z4_dv.d_view.data () );	
+        TEST_ASSERT( Z4_j_h_lcl.data () == Z4_dv.h_view.data () );
+        TEST_ASSERT( Z4_j_d_lcl.data () == Z4_dv.d_view.data () );
       }
     }
 
@@ -364,14 +364,14 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( MultiVector, reduce_strided, Scalar, LocalOrd
     const size_t Z5_stride = Z0.getLocalLength () + lclNumRows;
     dual_view_type Z5_dv_extra ("Z5", Z5_stride, numCols);
     auto Z5_dv = Kokkos::subview (Z5_dv_extra,
-				  pair_type (0, lclNumRows),
-				  pair_type (0, numCols));
+                                  pair_type (0, lclNumRows),
+                                  pair_type (0, numCols));
     TEST_ASSERT( LO (Z5_dv.extent (0) == lclNumRows ) );
-    TEST_ASSERT( LO (Z5_dv.extent (1) == numCols ) );		 
+    TEST_ASSERT( LO (Z5_dv.extent (1) == numCols ) );
     // Kokkos could in theory insert padding in the row dimension.
     TEST_ASSERT( size_t (Z5_dv.d_view.stride (1)) >= Z5_stride );
-    TEST_ASSERT( size_t (Z5_dv.h_view.stride (1)) >= Z5_stride );  
-  
+    TEST_ASSERT( size_t (Z5_dv.h_view.stride (1)) >= Z5_stride );
+
     MV Z5 (lclMap, Z5_dv);
     Tpetra::deep_copy (Z5, Z0);
 
@@ -389,14 +389,14 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( MultiVector, reduce_strided, Scalar, LocalOrd
     const size_t Z6_stride = Z0.getLocalLength () + lclNumRows;
     dual_view_type Z6_dv_extra ("Z6", Z6_stride, numCols);
     auto Z6_dv = Kokkos::subview (Z6_dv_extra,
-				  pair_type (0, lclNumRows),
-				  pair_type (0, numCols));
+                                  pair_type (0, lclNumRows),
+                                  pair_type (0, numCols));
     TEST_ASSERT( LO (Z6_dv.extent (0) == lclNumRows ) );
-    TEST_ASSERT( LO (Z6_dv.extent (1) == numCols ) );		 
+    TEST_ASSERT( LO (Z6_dv.extent (1) == numCols ) );
     // Kokkos could in theory insert padding in the row dimension.
     TEST_ASSERT( size_t (Z6_dv.d_view.stride (1)) >= Z6_stride );
-    TEST_ASSERT( size_t (Z6_dv.h_view.stride (1)) >= Z6_stride );  
-  
+    TEST_ASSERT( size_t (Z6_dv.h_view.stride (1)) >= Z6_stride );
+
     MV Z6 (lclMap, Z6_dv);
     Tpetra::deep_copy (Z6, Z0);
 
@@ -410,7 +410,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( MultiVector, reduce_strided, Scalar, LocalOrd
 
     out << endl << "Z1:" << endl;
     Z1.describe (out, Teuchos::VERB_EXTREME);
-    out << endl << "Z6:" << endl;    
+    out << endl << "Z6:" << endl;
     Z6.describe (out, Teuchos::VERB_EXTREME);
   }
 }


### PR DESCRIPTION
@trilinos/tpetra @trilinos/belos @vbrunini 

## Description

This PR supersedes PR #4648.  I've extracted out the parts of #4648 that are actual bug fixes rather than optimizations.  Here they are:

  - Fix #4639 (an actual correctness bug in `Tpetra::MultiVector::reduce` that hindered solving #4626)
  - Fix #4633 (a strange thing in `Tpetra::MultiVector` that could lead to bugs, especially with `FEMultiVector`)
  - Clean up a few things in Belos

The part of PR #4648 I did _not_ include here is the fix for #4626.  That triggers a likely Intel compiler bug in PR tests, which is why I'm not including it.  I have a multiple-step work-around in progress; see PR #4734 for the start of that.

## Related Issues

* Closes #4639, #4633 
* Blocks #4626 
* Related to #4640, #4648, #4734 

## How Has This Been Tested?

With and without CUDA.