### PR TITLE
Tpetra: Fix #4680

### DIFF
--- a/packages/tpetra/core/inout/MatrixMarket_Tpetra.hpp
+++ b/packages/tpetra/core/inout/MatrixMarket_Tpetra.hpp
@@ -822,7 +822,7 @@ namespace Tpetra {
         // do first-touch reallocation (a NUMA (Non-Uniform Memory
         // Access) optimization on multicore CPUs).
         RCP<sparse_matrix_type> A =
-          rcp (new sparse_matrix_type (pRowMap, myNumEntriesPerRow,
+          rcp (new sparse_matrix_type (pRowMap, myNumEntriesPerRow (),
                                        DynamicProfile));
 
         // List of the global indices of my rows.
@@ -3902,7 +3902,7 @@ namespace Tpetra {
         // know how many entries there are in each row, so we can use
         // static profile.
         RCP<sparse_matrix_type> A_proc0 =
-          rcp (new sparse_matrix_type (gatherRowMap, gatherNumEntriesPerRow,
+          rcp (new sparse_matrix_type (gatherRowMap, gatherNumEntriesPerRow (),
                                        Tpetra::StaticProfile));
         if (myRank == rootRank) {
           if (debug) {

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -301,9 +301,9 @@ namespace Tpetra {
     typedef Kokkos::StaticCrsGraph<LocalOrdinal,
                                    Kokkos::LayoutLeft,
                                    execution_space> local_graph_type;
+
     //! DEPRECATED; use local_graph_type (above) instead.
     typedef local_graph_type LocalStaticCrsGraphType TPETRA_DEPRECATED;
-
     //! DEPRECATED; use <tt>local_graph_type::row_map_type</tt> instead.
     typedef typename local_graph_type::row_map_type t_RowPtrs TPETRA_DEPRECATED;
     //! DEPRECATED; use <tt>local_graph_type::row_map_type::non_const_type</tt> instead.
@@ -385,9 +385,18 @@ namespace Tpetra {
     ///   null, any missing parameters will be filled in with their
     ///   default values.
     CrsGraph (const Teuchos::RCP<const map_type>& rowMap,
+              const Teuchos::ArrayView<const size_t>& numEntPerRow,
+              const ProfileType pftype = DynamicProfile,
+              const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
+
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+    //! DEPRECATED; use the version that takes an ArrayView instead.
+    TPETRA_DEPRECATED
+    CrsGraph (const Teuchos::RCP<const map_type>& rowMap,
               const Teuchos::ArrayRCP<const size_t>& numEntPerRow,
               const ProfileType pftype = DynamicProfile,
               const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
 
     /// \brief Constructor specifying column Map and a single upper
     ///   bound for the number of entries in all rows on the calling
@@ -461,9 +470,19 @@ namespace Tpetra {
     ///   default values.
     CrsGraph (const Teuchos::RCP<const map_type>& rowMap,
               const Teuchos::RCP<const map_type>& colMap,
+              const Teuchos::ArrayView<const size_t>& numEntPerRow,
+              const ProfileType pftype = DynamicProfile,
+              const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
+
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+    //! DEPRECATED; use the version that takes an ArrayView instead.
+    TPETRA_DEPRECATED
+    CrsGraph (const Teuchos::RCP<const map_type>& rowMap,
+              const Teuchos::RCP<const map_type>& colMap,
               const Teuchos::ArrayRCP<const size_t>& numEntPerRow,
               const ProfileType pftype = DynamicProfile,
               const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
 
     /// \brief Constructor specifying column Map and arrays containing
     ///   the graph with sorted local indices.
@@ -2795,7 +2814,7 @@ namespace Tpetra {
                                                             graphparams));
             } else {
               clonedGraph = rcp (new output_crs_graph_type (clonedRowMap, clonedColMap,
-                                                            numEntriesPerRow, pftype,
+                                                            numEntriesPerRow (), pftype,
                                                             graphparams));
             }
           } else {
@@ -2805,7 +2824,7 @@ namespace Tpetra {
                                                             graphparams));
             } else {
               clonedGraph = rcp (new output_crs_graph_type (clonedRowMap,
-                                                            numEntriesPerRow,
+                                                            numEntriesPerRow (),
                                                             pftype, graphparams));
             }
           }

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -525,7 +525,7 @@ namespace Tpetra {
     ///
     /// \param rowMap [in] Distribution of rows of the matrix.
     ///
-    /// \param NumEntriesPerRowToAlloc [in] Maximum number of matrix
+    /// \param numEntPerRowToAlloc [in] Maximum number of matrix
     ///   entries to allocate for each row.  If
     ///   pftype==DynamicProfile, this is only a hint.  If
     ///   pftype==StaticProfile, this sets the amount of storage
@@ -539,10 +539,19 @@ namespace Tpetra {
     ///   null, any missing parameters will be filled in with their
     ///   default values.
     CrsMatrix (const Teuchos::RCP<const map_type>& rowMap,
-               const Teuchos::ArrayRCP<const size_t>& NumEntriesPerRowToAlloc,
-               ProfileType pftype = DynamicProfile,
+               const Teuchos::ArrayView<const size_t>& numEntPerRowToAlloc,
+               const ProfileType pftype = DynamicProfile,
                const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+    //! DEPRECATED; use the version that takes an ArrayView instead.
+    TPETRA_DEPRECATED
+    CrsMatrix (const Teuchos::RCP<const map_type>& rowMap,
+               const Teuchos::ArrayRCP<const size_t>& numEntPerRowToAlloc,
+               const ProfileType pftype = DynamicProfile,
+               const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+    
     /// \brief Constructor specifying column Map and fixed number of entries for each row.
     ///
     /// The column Map will be used to filter any matrix entries
@@ -552,7 +561,7 @@ namespace Tpetra {
     ///
     /// \param colMap [in] Distribution of columns of the matrix.
     ///
-    /// \param maxNumEntriesPerRow [in] Maximum number of matrix
+    /// \param maxNumEntPerRow [in] Maximum number of matrix
     ///   entries per row.  If pftype==DynamicProfile, this is only a
     ///   hint, and you can set this to zero without affecting
     ///   correctness.  If pftype==StaticProfile, this sets the amount
@@ -567,8 +576,8 @@ namespace Tpetra {
     ///   default values.
     CrsMatrix (const Teuchos::RCP<const map_type>& rowMap,
                const Teuchos::RCP<const map_type>& colMap,
-               size_t maxNumEntriesPerRow,
-               ProfileType pftype = DynamicProfile,
+               const size_t maxNumEntPerRow,
+               const ProfileType pftype = DynamicProfile,
                const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
     /// \brief Constructor specifying column Map and number of entries in each row.
@@ -580,7 +589,7 @@ namespace Tpetra {
     ///
     /// \param colMap [in] Distribution of columns of the matrix.
     ///
-    /// \param NumEntriesPerRowToAlloc [in] Maximum number of matrix
+    /// \param numEntPerRowToAlloc [in] Maximum number of matrix
     ///   entries to allocate for each row.  If
     ///   pftype==DynamicProfile, this is only a hint.  If
     ///   pftype==StaticProfile, this sets the amount of storage
@@ -595,10 +604,20 @@ namespace Tpetra {
     ///   default values.
     CrsMatrix (const Teuchos::RCP<const map_type>& rowMap,
                const Teuchos::RCP<const map_type>& colMap,
-               const Teuchos::ArrayRCP<const size_t>& NumEntriesPerRowToAlloc,
-               ProfileType pftype = DynamicProfile,
+               const Teuchos::ArrayView<const size_t>& numEntPerRowToAlloc,
+               const ProfileType pftype = DynamicProfile,
                const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+    //! DEPRECATED; use the version that takes an ArrayView instead.
+    TPETRA_DEPRECATED
+    CrsMatrix (const Teuchos::RCP<const map_type>& rowMap,
+               const Teuchos::RCP<const map_type>& colMap,
+               const Teuchos::ArrayRCP<const size_t>& numEntPerRowToAlloc,
+               const ProfileType pftype = DynamicProfile,
+               const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
+#endif // TPETRA_ENABLE_DEPRECATED_CODE    
+    
     /// \brief Constructor specifying a previously constructed graph.
     ///
     /// Calling this constructor fixes the graph structure of the
@@ -883,7 +902,7 @@ namespace Tpetra {
         }
         else {
           clonedMatrix = rcp (new CrsMatrix2 (clonedRowMap, clonedColMap,
-                                              numEntriesPerRow, pftype,
+                                              numEntriesPerRow (), pftype,
                                               matParams));
         }
       }
@@ -893,7 +912,8 @@ namespace Tpetra {
                                               pftype, matParams));
         }
         else {
-          clonedMatrix = rcp (new CrsMatrix2 (clonedRowMap, numEntriesPerRow,
+          clonedMatrix = rcp (new CrsMatrix2 (clonedRowMap,
+                                              numEntriesPerRow (),
                                               pftype, matParams));
         }
       }

--- a/packages/tpetra/core/src/Tpetra_RowMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_RowMatrix_def.hpp
@@ -62,7 +62,6 @@ namespace Tpetra {
        const Teuchos::RCP<Teuchos::ParameterList>& params) const
   {
     using Teuchos::Array;
-    using Teuchos::ArrayRCP;
     using Teuchos::ArrayView;
     using Teuchos::ParameterList;
     using Teuchos::RCP;
@@ -184,7 +183,7 @@ namespace Tpetra {
     // the actual per-row upper bound, we can use static profile.
     if (A_rowMap->isSameAs (*B_rowMap)) {
       const LO localNumRows = static_cast<LO> (A_rowMap->getNodeNumElements ());
-      ArrayRCP<size_t> C_maxNumEntriesPerRow (localNumRows, 0);
+      Array<size_t> C_maxNumEntriesPerRow (localNumRows, 0);
 
       // Get the number of entries in each row of A.
       if (alpha != STS::zero ()) {
@@ -202,10 +201,10 @@ namespace Tpetra {
       }
       // Construct the result matrix C.
       if (constructorSublist.is_null ()) {
-        C = rcp (new crs_matrix_type (C_rowMap, C_maxNumEntriesPerRow,
+        C = rcp (new crs_matrix_type (C_rowMap, C_maxNumEntriesPerRow (),
                                       StaticProfile));
       } else {
-        C = rcp (new crs_matrix_type (C_rowMap, C_maxNumEntriesPerRow,
+        C = rcp (new crs_matrix_type (C_rowMap, C_maxNumEntriesPerRow (),
                                       StaticProfile, constructorSublist));
       }
       // Since A and B have the same row Maps, we could add them

--- a/packages/tpetra/core/test/CrsGraph/CrsGraph_UnitTests0.cpp
+++ b/packages/tpetra/core/test/CrsGraph/CrsGraph_UnitTests0.cpp
@@ -165,7 +165,7 @@ namespace {
     // has the wrong length, as it does in this case.
     ArrayRCP<size_t> hints = arcp<size_t> (numLocal + 1);
     std::fill (hints.begin (), hints.end (), static_cast<size_t> (1));
-    TEST_THROW( badgraph = rcp (new graph_type (map, hints.persistingView (0, numLocal+1))),
+    TEST_THROW( badgraph = rcp (new graph_type (map, hints (0, numLocal+1))),
                 std::invalid_argument ); // too many entries
 
     // Make sure that the test passed on all processes.
@@ -176,7 +176,7 @@ namespace {
 
     // CrsGraph's constructor should throw if input allocation hint
     // has the wrong length, as it does in this case.
-    TEST_THROW( badgraph = rcp (new graph_type (map, hints.persistingView (0, numLocal-1))),
+    TEST_THROW( badgraph = rcp (new graph_type (map, hints (0, numLocal-1))),
                 std::invalid_argument ); // too few entries
 
     // Make sure that the test passed on all processes.
@@ -190,7 +190,7 @@ namespace {
     // build, but not for a release build.
 
     // hints[0] = Teuchos::OrdinalTraits<size_t>::invalid ();
-    // TEST_THROW( badgraph = rcp (new graph_type (map, hints.persistingView (0, numLocal))),
+    // TEST_THROW( badgraph = rcp (new graph_type (map, hints (0, numLocal))),
     //             std::invalid_argument ); // invalid value
 
     // // Make sure that the test passed on all processes.
@@ -855,7 +855,7 @@ namespace {
         }
         // create a diagonal graph, but where only my middle row has an entry
         ArrayRCP<size_t> toalloc = arcpClone<size_t>( tuple<size_t>(0,1,0) );
-        GRAPH ddgraph(map,toalloc,pftype);
+        GRAPH ddgraph(map, toalloc (), pftype);
         ddgraph.insertGlobalIndices(mymiddle, tuple<GO>(mymiddle));
         // before globalAssemble(), there should be one local entry on middle, none on the others
         ArrayView<const GO> myrow_gbl;

--- a/packages/tpetra/core/test/CrsGraph/CrsGraph_UnitTests_Swap.cpp
+++ b/packages/tpetra/core/test/CrsGraph/CrsGraph_UnitTests_Swap.cpp
@@ -342,7 +342,7 @@ class crsGraph_Swap_Tester
             }
         }
 
-        RCP<graph_type> output_graph(new graph_type(row_map, num_ent_per_row, Tpetra::StaticProfile));
+        RCP<graph_type> output_graph(new graph_type(row_map, num_ent_per_row (), Tpetra::StaticProfile));
 
         for(auto& r: gbl_rows)
         {

--- a/packages/tpetra/core/test/CrsMatrix/Bug5978.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/Bug5978.cpp
@@ -148,7 +148,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CrsMatrix, Bug5978, SC, LO, GO, NT)
   // 4.3.3 from confusing the non-template method assign(size_type,
   // const T&) from the template method assign(Iter, Iter).
   count.assign (rowGIDs.size (), static_cast<size_t> (1));
-  MatrixType A (rowMap, colMap, count);
+  MatrixType A (rowMap, colMap, count ());
 
   out << "Proc " << myRank << ": Filling matrix" << endl;
   comm->barrier ();

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests_Swap.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests_Swap.cpp
@@ -389,7 +389,7 @@ class crsMatrix_Swap_Tester
         // Create the Row Map
         RCP<const map_type> row_map(new map_type(gbl_num_rows, global_ids.data(), lcl_num_rows, 0, comm));
 
-        Teuchos::ArrayRCP<size_t> num_ent_per_row(lcl_num_rows);
+        Teuchos::Array<size_t> num_ent_per_row(lcl_num_rows);
         size_t                    idx = 0;
         for(auto& r: gbl_rows)
         {
@@ -411,7 +411,7 @@ class crsMatrix_Swap_Tester
             }
         }
 
-        RCP<graph_type> output_graph(new graph_type(row_map, num_ent_per_row, Tpetra::StaticProfile));
+        RCP<graph_type> output_graph(new graph_type(row_map, num_ent_per_row (), Tpetra::StaticProfile));
 
         for(auto& r: gbl_rows)
         {
@@ -569,7 +569,7 @@ class crsMatrix_Swap_Tester
         // Create the Row Map
         RCP<const map_type> row_map(new map_type(gbl_num_rows, global_ids.data(), lcl_num_rows, 0, comm));
 
-        Teuchos::ArrayRCP<size_t> num_ent_per_row(lcl_num_rows);
+        Teuchos::Array<size_t> num_ent_per_row(lcl_num_rows);
         size_t                    idx = 0;
         for(auto& r: gbl_vals)
         {

--- a/packages/tpetra/core/test/CrsMatrix/Tpetra_Test_CrsMatrix_WithGraph.hpp
+++ b/packages/tpetra/core/test/CrsMatrix/Tpetra_Test_CrsMatrix_WithGraph.hpp
@@ -579,9 +579,9 @@ inline void tupleToArray(Array<T> &arr, const tuple &tup)
     // Second test: use an array to bound from above the number of
     // entries in each row, and insert using local indices.
     {
-      ArrayRCP<size_t> nnzperrow = Teuchos::arcp<size_t> (numLocal);
+      Teuchos::Array<size_t> nnzperrow (numLocal);
       std::fill(nnzperrow.begin(), nnzperrow.end(), 3);
-      MAT bdmat (rmap, cmap, nnzperrow, Tpetra::StaticProfile);
+      MAT bdmat (rmap, cmap, nnzperrow (), Tpetra::StaticProfile);
       TEST_EQUALITY(bdmat.getRowMap(), rmap);
       TEST_EQUALITY_CONST(bdmat.hasColMap(), true);
       TEST_EQUALITY(bdmat.getColMap(), cmap);

--- a/packages/tpetra/core/test/RowMatrixTransposer/main.cpp
+++ b/packages/tpetra/core/test/RowMatrixTransposer/main.cpp
@@ -136,9 +136,9 @@ main (int argc, char* argv[])
     }
   }
 
-  // Create a Tpetra::Matrix using the Map, with a static allocation dictated by NumNz
-  crs_matrix_type A (map, NumNz, Tpetra::StaticProfile);
-  crs_matrix_type AT(map, NumNz, Tpetra::StaticProfile);
+  // Create a Tpetra::CrsMatrix using the Map, with a static allocation dictated by NumNz
+  crs_matrix_type A (map, NumNz (), Tpetra::StaticProfile);
+  crs_matrix_type AT(map, NumNz (), Tpetra::StaticProfile);
   RCP< crs_matrix_type > TestMatrix = Teuchos::null;
 
   // We are done with NumNZ

--- a/packages/tpetra/core/test/TpetraUtils_MatrixGenerator.hpp
+++ b/packages/tpetra/core/test/TpetraUtils_MatrixGenerator.hpp
@@ -266,11 +266,8 @@ namespace Tpetra {
 
         // Construct the CrsMatrix, using the row map, with the
         // constructor specifying the number of nonzeros for each row.
-        // Create with DynamicProfile, so that the fillComplete() can
-        // do first-touch reallocation (a NUMA (Non-Uniform Memory
-        // Access) optimization on multicore CPUs).
         RCP<sparse_matrix_type> A =
-          rcp (new sparse_matrix_type (pRowMap, myNumEntriesPerRow,
+          rcp (new sparse_matrix_type (pRowMap, myNumEntriesPerRow (),
                                        DynamicProfile));
 
         // List of the global indices of my rows.


### PR DESCRIPTION
@trilinos/tpetra 

## Description

Deprecate `Tpetra::CrsGraph` and `Tpetra::CrsMatrix` constructors that take `ArrayRCP<const size_t>` for the maximum number of entries per row.  Replace them with `ArrayView<const size_t>` constructors.

## Motivation and Context

Deprecation deadline for the next Trilinos release is coming soon.  Also, I can't get any other PRs through PR testing, so I might as well try something.

## Related Issues

* Closes #4680