### PR TITLE
Tempus:  Remove Unused Parameter Warnings

### DIFF
--- a/packages/tempus/src/Tempus_IntegratorAdjointSensitivity_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorAdjointSensitivity_impl.hpp
@@ -296,8 +296,8 @@ initializeSolutionHistory(Scalar t0,
   Teuchos::RCP<const Thyra::VectorBase<Scalar> > xdot0,
   Teuchos::RCP<const Thyra::VectorBase<Scalar> > xdotdot0,
   Teuchos::RCP<const Thyra::MultiVectorBase<Scalar> > DxDp0,
-  Teuchos::RCP<const Thyra::MultiVectorBase<Scalar> > DxdotDp0,
-  Teuchos::RCP<const Thyra::MultiVectorBase<Scalar> > DxdotdotDp0)
+  Teuchos::RCP<const Thyra::MultiVectorBase<Scalar> > /* DxdotDp0 */,
+  Teuchos::RCP<const Thyra::MultiVectorBase<Scalar> > /* DxdotdotDp0 */)
 {
   state_integrator_->initializeSolutionHistory(t0, x0, xdot0, xdotdot0);
   dxdp_init_ = DxDp0;

--- a/packages/tempus/src/Tempus_IntegratorForwardSensitivity_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorForwardSensitivity_impl.hpp
@@ -304,7 +304,7 @@ template <class Scalar>
 void
 IntegratorForwardSensitivity<Scalar>::
 createSensitivityModelAndStepper(
-  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model)
+  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& /* model */)
 {
   using Teuchos::rcp;
 

--- a/packages/tempus/src/Tempus_IntegratorObserverBasic_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorObserverBasic_impl.hpp
@@ -40,23 +40,23 @@ observeStartIntegrator(const Integrator<Scalar>& integrator){
 
 template<class Scalar>
 void IntegratorObserverBasic<Scalar>::
-observeStartTimeStep(const Integrator<Scalar>& integrator){}
+observeStartTimeStep(const Integrator<Scalar>& /* integrator */){}
 
 template<class Scalar>
 void IntegratorObserverBasic<Scalar>::
-observeNextTimeStep(const Integrator<Scalar>& integrator){}
+observeNextTimeStep(const Integrator<Scalar>& /* integrator */){}
 
 template<class Scalar>
 void IntegratorObserverBasic<Scalar>::
-observeBeforeTakeStep(const Integrator<Scalar>& integrator){}
+observeBeforeTakeStep(const Integrator<Scalar>& /* integrator */){}
 
 template<class Scalar>
 void IntegratorObserverBasic<Scalar>::
-observeAfterTakeStep(const Integrator<Scalar>& integrator){}
+observeAfterTakeStep(const Integrator<Scalar>& /* integrator */){}
 
 template<class Scalar>
 void IntegratorObserverBasic<Scalar>::
-observeAfterCheckTimeStep(const Integrator<Scalar>& integrator){}
+observeAfterCheckTimeStep(const Integrator<Scalar>& /* integrator */){}
 
 template<class Scalar>
 void IntegratorObserverBasic<Scalar>::

--- a/packages/tempus/src/Tempus_InterpolatorLagrange_decl.hpp
+++ b/packages/tempus/src/Tempus_InterpolatorLagrange_decl.hpp
@@ -46,7 +46,7 @@ public:
   //@{
   std::string description() const { return "Tempus::InterpolatorLagrange"; }
   void describe(Teuchos::FancyOStream &out,
-                const Teuchos::EVerbosityLevel verbLevel) const
+                const Teuchos::EVerbosityLevel /* verbLevel */) const
   { out << description() << "::describe" << std::endl; }
   //@}
 

--- a/packages/tempus/src/Tempus_PhysicsState_impl.hpp
+++ b/packages/tempus/src/Tempus_PhysicsState_impl.hpp
@@ -61,7 +61,7 @@ std::string PhysicsState<Scalar>::description() const
 template<class Scalar>
 void PhysicsState<Scalar>::describe(
   Teuchos::FancyOStream        & out,
-  const Teuchos::EVerbosityLevel verbLevel) const
+  const Teuchos::EVerbosityLevel /* verbLevel */) const
 {
   out << description() << "::describe" << std::endl
       << "  physicsName   = " << physicsName_ << std::endl;

--- a/packages/tempus/src/Tempus_SensitivityModelEvaluatorBase.hpp
+++ b/packages/tempus/src/Tempus_SensitivityModelEvaluatorBase.hpp
@@ -39,16 +39,16 @@ public:
 
   //! Set solution history from forward state evaluation (for interpolation)
   virtual void setForwardSolutionHistory(
-    const Teuchos::RCP<const Tempus::SolutionHistory<Scalar> >& sh) {}
+    const Teuchos::RCP<const Tempus::SolutionHistory<Scalar> >& /* sh */) {}
 
   //! Set solution state from forward state evaluation (for frozen state)
     virtual void setForwardSolutionState(
-      const Teuchos::RCP<const Tempus::SolutionState<Scalar> >& s) {}
+      const Teuchos::RCP<const Tempus::SolutionState<Scalar> >& /* s */) {}
 
   //! Set the solver of the underlying model if you want to reuse it
   virtual void setSolver(
-    const Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> >& solver,
-    const bool force_W_update) {}
+    const Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> >& /* solver */,
+    const bool /* force_W_update */) {}
 };
 
 } // namespace Tempus

--- a/packages/tempus/src/Tempus_Stepper.hpp
+++ b/packages/tempus/src/Tempus_Stepper.hpp
@@ -217,7 +217,7 @@ public:
   /// \name Functions for Steppers with subSteppers (e.g., OperatorSplit)
   //@{
     virtual void createSubSteppers(
-      std::vector<Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > > models){}
+      std::vector<Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > > /* models */){}
   //@}
 
   /// \name Helper functions

--- a/packages/tempus/src/Tempus_StepperBDF2Observer.hpp
+++ b/packages/tempus/src/Tempus_StepperBDF2Observer.hpp
@@ -45,23 +45,23 @@ public:
 
   /// Observe Stepper at beginning of takeStep.
   virtual void observeBeginTakeStep(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    Stepper<Scalar> & stepper){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    Stepper<Scalar> & /* stepper */){}
 
   /// Observe Stepper before nonlinear solve.
   virtual void observeBeforeSolve(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    StepperBDF2<Scalar> & stepperBDF2){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    StepperBDF2<Scalar> & /* stepperBDF2 */){}
 
   /// Observe Stepper after nonlinear solve.
   virtual void observeAfterSolve(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    StepperBDF2<Scalar> & stepperBDF2){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    StepperBDF2<Scalar> & /* stepperBDF2 */){}
 
   /// Observe Stepper at end of takeStep.
   virtual void observeEndTakeStep(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    Stepper<Scalar> & stepper){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    Stepper<Scalar> & /* stepper */){}
 };
 } // namespace Tempus
 #endif // Tempus_StepperBDF2Observer_hpp

--- a/packages/tempus/src/Tempus_StepperBDF2_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperBDF2_impl.hpp
@@ -304,7 +304,7 @@ std::string StepperBDF2<Scalar>::description() const
 template<class Scalar>
 void StepperBDF2<Scalar>::describe(
    Teuchos::FancyOStream               &out,
-   const Teuchos::EVerbosityLevel      verbLevel) const
+   const Teuchos::EVerbosityLevel      /* verbLevel */) const
 {
   out << description() << "::describe:" << std::endl
       << "wrapperModel_ = " << this->wrapperModel_->description() << std::endl;

--- a/packages/tempus/src/Tempus_StepperBackwardEulerObserver.hpp
+++ b/packages/tempus/src/Tempus_StepperBackwardEulerObserver.hpp
@@ -45,23 +45,23 @@ public:
 
   /// Observe Stepper at beginning of takeStep.
   virtual void observeBeginTakeStep(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    Stepper<Scalar> & stepper){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    Stepper<Scalar> & /* stepper */){}
 
   /// Observe Stepper before nonlinear solve.
   virtual void observeBeforeSolve(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    StepperBackwardEuler<Scalar> & stepperBE){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    StepperBackwardEuler<Scalar> & /* stepperBE */){}
 
   /// Observe Stepper after nonlinear solve.
   virtual void observeAfterSolve(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    StepperBackwardEuler<Scalar> & stepperBE){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    StepperBackwardEuler<Scalar> & /* stepperBE */){}
 
   /// Observe Stepper at end of takeStep.
   virtual void observeEndTakeStep(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    Stepper<Scalar> & stepper){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    Stepper<Scalar> & /* stepper */){}
 };
 } // namespace Tempus
 #endif // Tempus_StepperBackwardEulerObserver_hpp

--- a/packages/tempus/src/Tempus_StepperBackwardEuler_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperBackwardEuler_impl.hpp
@@ -276,7 +276,7 @@ std::string StepperBackwardEuler<Scalar>::description() const
 template<class Scalar>
 void StepperBackwardEuler<Scalar>::describe(
    Teuchos::FancyOStream               &out,
-   const Teuchos::EVerbosityLevel      verbLevel) const
+   const Teuchos::EVerbosityLevel      /* verbLevel */) const
 {
   out << description() << "::describe:" << std::endl
       << "wrapperModel_ = " << this->wrapperModel_->description() << std::endl;

--- a/packages/tempus/src/Tempus_StepperDIRKObserver.hpp
+++ b/packages/tempus/src/Tempus_StepperDIRKObserver.hpp
@@ -45,38 +45,38 @@ public:
 
   /// Observe Stepper at beginning of takeStep.
   virtual void observeBeginTakeStep(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    Stepper<Scalar> & stepper){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    Stepper<Scalar> & /* stepper */){}
 
   /// Observe Stepper at beginning of each stage.
   virtual void observeBeginStage(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    StepperDIRK<Scalar> & stepperDIRK){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    StepperDIRK<Scalar> & /* stepperDIRK */){}
 
   /// Observe Stepper before Explicit evaluation of Implicit ODE ME.
   virtual void observeBeforeExplicit(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    StepperDIRK<Scalar> & stepperDIRK){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    StepperDIRK<Scalar> & /* stepperDIRK */){}
 
   /// Observe Stepper before nonlinear solve.
   virtual void observeBeforeSolve(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    StepperDIRK<Scalar> & stepperDIRK){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    StepperDIRK<Scalar> & /* stepperDIRK */){}
 
   /// Observe Stepper after nonlinear solve.
   virtual void observeAfterSolve(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    StepperDIRK<Scalar> & stepperDIRK){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    StepperDIRK<Scalar> & /* stepperDIRK */){}
 
   /// Observe Stepper at end of each stage.
   virtual void observeEndStage(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    StepperDIRK<Scalar> & stepperDIRK){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    StepperDIRK<Scalar> & /* stepperDIRK */){}
 
   /// Observe Stepper at end of takeStep.
   virtual void observeEndTakeStep(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    Stepper<Scalar> & stepper){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    Stepper<Scalar> & /* stepper */){}
 };
 } // namespace Tempus
 #endif // Tempus_StepperDIRKObserver_hpp

--- a/packages/tempus/src/Tempus_StepperDIRK_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperDIRK_impl.hpp
@@ -380,7 +380,7 @@ std::string StepperDIRK<Scalar>::description() const
 template<class Scalar>
 void StepperDIRK<Scalar>::describe(
    Teuchos::FancyOStream               &out,
-   const Teuchos::EVerbosityLevel      verbLevel) const
+   const Teuchos::EVerbosityLevel      /* verbLevel */) const
 {
   out << description() << "::describe:" << std::endl
       << "wrapperModel_ = " << this->wrapperModel_->description() << std::endl;

--- a/packages/tempus/src/Tempus_StepperExplicitRKObserver.hpp
+++ b/packages/tempus/src/Tempus_StepperExplicitRKObserver.hpp
@@ -45,28 +45,28 @@ public:
 
   /// Observe Stepper at beginning of takeStep.
   virtual void observeBeginTakeStep(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    Stepper<Scalar> & stepper){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    Stepper<Scalar> & /* stepper */){}
 
   /// Observe Stepper at beginning of each stage.
   virtual void observeBeginStage(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    StepperExplicitRK<Scalar> & stepperExplicitRK){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    StepperExplicitRK<Scalar> & /* stepperExplicitRK */){}
 
   /// Observe Stepper before Explicit evaluation of Implicit ODE ME.
   virtual void observeBeforeExplicit(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    StepperExplicitRK<Scalar> & stepperExplicitRK){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    StepperExplicitRK<Scalar> & /* stepperExplicitRK */){}
 
   /// Observe Stepper at end of each stage.
   virtual void observeEndStage(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    StepperExplicitRK<Scalar> & stepperExplicitRK){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    StepperExplicitRK<Scalar> & /* stepperExplicitRK */){}
 
   /// Observe Stepper at end of takeStep.
   virtual void observeEndTakeStep(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    Stepper<Scalar> & stepper){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    Stepper<Scalar> & /* stepper */){}
 };
 } // namespace Tempus
 #endif // Tempus_StepperExplicitRKObserver_hpp

--- a/packages/tempus/src/Tempus_StepperExplicitRK_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperExplicitRK_impl.hpp
@@ -417,7 +417,7 @@ std::string StepperExplicitRK<Scalar>::description() const
 template<class Scalar>
 void StepperExplicitRK<Scalar>::describe(
    Teuchos::FancyOStream               &out,
-   const Teuchos::EVerbosityLevel      verbLevel) const
+   const Teuchos::EVerbosityLevel      /* verbLevel */) const
 {
   out << description() << "::describe:" << std::endl
       << "appModel_ = " << this->appModel_->description() << std::endl;

--- a/packages/tempus/src/Tempus_StepperExplicit_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperExplicit_decl.hpp
@@ -34,7 +34,7 @@ public:
       getModel(){return appModel_;}
 
     virtual Scalar getInitTimeStep(
-        const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory) const
+        const Teuchos::RCP<SolutionHistory<Scalar> >& /* solutionHistory */) const
       {return std::numeric_limits<Scalar>::max();}
 
     /// Set the initial conditions, make them consistent, and set needed memory.
@@ -58,7 +58,7 @@ public:
     /// Pass initial guess to Newton solver (only relevant for implicit solvers)
     //  thus a no-op for explicit steppers.
     virtual void setInitialGuess(
-      Teuchos::RCP<const Thyra::VectorBase<Scalar> > initial_guess){}
+      Teuchos::RCP<const Thyra::VectorBase<Scalar> > /* initial_guess */){}
 
     virtual bool isExplicit()         const {return true;}
     virtual bool isImplicit()         const {return false;}

--- a/packages/tempus/src/Tempus_StepperExplicit_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperExplicit_impl.hpp
@@ -227,7 +227,7 @@ void StepperExplicit<Scalar>::setInitialConditions(
 }
 
 template<class Scalar>
-void StepperExplicit<Scalar>::setSolver(std::string solverName)
+void StepperExplicit<Scalar>::setSolver(std::string /* solverName */)
 {
   Teuchos::RCP<Teuchos::FancyOStream> out = this->getOStream();
   Teuchos::OSTab ostab(out,1,"StepperExplicit::setSolver()");
@@ -238,7 +238,7 @@ void StepperExplicit<Scalar>::setSolver(std::string solverName)
 
 template<class Scalar>
 void StepperExplicit<Scalar>::setSolver(
-  Teuchos::RCP<Teuchos::ParameterList> solverPL)
+  Teuchos::RCP<Teuchos::ParameterList> /* solverPL */)
 {
   Teuchos::RCP<Teuchos::FancyOStream> out = this->getOStream();
   Teuchos::OSTab ostab(out,1,"StepperExplicit::setSolver()");
@@ -249,7 +249,7 @@ void StepperExplicit<Scalar>::setSolver(
 
 template<class Scalar>
 void StepperExplicit<Scalar>::setSolver(
-  Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > solver)
+  Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > /* solver */)
 {
   Teuchos::RCP<Teuchos::FancyOStream> out = this->getOStream();
   Teuchos::OSTab ostab(out,1,"StepperExplicit::setSolver()");

--- a/packages/tempus/src/Tempus_StepperForwardEulerObserver.hpp
+++ b/packages/tempus/src/Tempus_StepperForwardEulerObserver.hpp
@@ -45,18 +45,18 @@ public:
 
   /// Observe Stepper at beginning of takeStep.
   virtual void observeBeginTakeStep(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    Stepper<Scalar> & stepper){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    Stepper<Scalar> & /* stepper */){}
 
   /// Observe Stepper before Explicit ME evaluation.
   virtual void observeBeforeExplicit(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    StepperForwardEuler<Scalar> & stepperFE){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    StepperForwardEuler<Scalar> & /* stepperFE */){}
 
   /// Observe Stepper at end of takeStep.
   virtual void observeEndTakeStep(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    Stepper<Scalar> & stepper){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    Stepper<Scalar> & /* stepper */){}
 };
 } // namespace Tempus
 #endif // Tempus_StepperForwardEulerObserver_hpp

--- a/packages/tempus/src/Tempus_StepperForwardEuler_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperForwardEuler_impl.hpp
@@ -182,7 +182,7 @@ std::string StepperForwardEuler<Scalar>::description() const
 template<class Scalar>
 void StepperForwardEuler<Scalar>::describe(
    Teuchos::FancyOStream               &out,
-   const Teuchos::EVerbosityLevel      verbLevel) const
+   const Teuchos::EVerbosityLevel      /* verbLevel */) const
 {
   out << description() << "::describe:" << std::endl
       << "appModel_ = " << this->appModel_->description() << std::endl;

--- a/packages/tempus/src/Tempus_StepperHHTAlpha_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperHHTAlpha_decl.hpp
@@ -65,14 +65,14 @@ public:
       const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel);
 
     virtual void setObserver(
-      Teuchos::RCP<StepperObserver<Scalar> > obs = Teuchos::null){}
+      Teuchos::RCP<StepperObserver<Scalar> > /* obs */ = Teuchos::null){}
 
     /// Initialize during construction and after changing input parameters.
     virtual void initialize();
 
     /// Set the initial conditions and make them consistent.
     virtual void setInitialConditions (
-      const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory){}
+      const Teuchos::RCP<SolutionHistory<Scalar> >& /* solutionHistory */){}
 
     /// Take the specified timestep, dt, and return true if successful.
     virtual void takeStep(

--- a/packages/tempus/src/Tempus_StepperHHTAlpha_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperHHTAlpha_impl.hpp
@@ -342,7 +342,7 @@ std::string StepperHHTAlpha<Scalar>::description() const
 template<class Scalar>
 void StepperHHTAlpha<Scalar>::describe(
    Teuchos::FancyOStream               &out,
-   const Teuchos::EVerbosityLevel      verbLevel) const
+   const Teuchos::EVerbosityLevel      /* verbLevel */) const
 {
 #ifdef VERBOSE_DEBUG_OUTPUT
   *out_ << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";

--- a/packages/tempus/src/Tempus_StepperIMEX_RKObserver.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RKObserver.hpp
@@ -45,43 +45,43 @@ public:
 
   /// Observe Stepper at beginning of takeStep.
   virtual void observeBeginTakeStep(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    Stepper<Scalar> & stepper){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    Stepper<Scalar> & /* stepper */){}
 
   /// Observe Stepper at beginning of each stage.
   virtual void observeBeginStage(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    StepperIMEX_RK<Scalar> & stepperIMEX_RK){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    StepperIMEX_RK<Scalar> & /* stepperIMEX_RK */){}
 
   /// Observe Stepper before Explicit evaluation of Implicit ODE ME.
   virtual void observeBeforeImplicitExplicitly(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    StepperIMEX_RK<Scalar> & stepperIMEX_RK){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    StepperIMEX_RK<Scalar> & /* stepperIMEX_RK */){}
 
   /// Observe Stepper before nonlinear solve.
   virtual void observeBeforeSolve(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    StepperIMEX_RK<Scalar> & stepperIMEX_RK){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    StepperIMEX_RK<Scalar> & /* stepperIMEX_RK */){}
 
   /// Observe Stepper after nonlinear solve.
   virtual void observeAfterSolve(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    StepperIMEX_RK<Scalar> & stepperIMEX_RK){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    StepperIMEX_RK<Scalar> & /* stepperIMEX_RK */){}
 
   /// Observe Stepper before Explicit ME evaluation.
   virtual void observeBeforeExplicit(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    StepperIMEX_RK<Scalar> & stepperIMEX_RK){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    StepperIMEX_RK<Scalar> & /* stepperIMEX_RK */){}
 
   /// Observe Stepper at end of each stage.
   virtual void observeEndStage(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    StepperIMEX_RK<Scalar> & stepperIMEX_RK){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    StepperIMEX_RK<Scalar> & /* stepperIMEX_RK */){}
 
   /// Observe Stepper at end of takeStep.
   virtual void observeEndTakeStep(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    Stepper<Scalar> & stepper){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    Stepper<Scalar> & /* stepper */){}
 };
 } // namespace Tempus
 #endif // Tempus_StepperIMEX_RKObserver_hpp

--- a/packages/tempus/src/Tempus_StepperIMEX_RKPartObserver.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RKPartObserver.hpp
@@ -45,43 +45,43 @@ public:
 
   /// Observe Stepper at beginning of takeStep.
   virtual void observeBeginTakeStep(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    Stepper<Scalar> & stepper){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    Stepper<Scalar> & /* stepper */){}
 
   /// Observe Stepper at beginning of each stage.
   virtual void observeBeginStage(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    StepperIMEX_RK_Partition<Scalar> & stepperIMEX_RK_Part){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    StepperIMEX_RK_Partition<Scalar> & /* stepperIMEX_RK_Part */){}
 
   /// Observe Stepper before Explicit evaluation of Implicit ODE ME.
   virtual void observeBeforeImplicitExplicitly(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    StepperIMEX_RK_Partition<Scalar> & stepperIMEX_RK_Part){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    StepperIMEX_RK_Partition<Scalar> & /* stepperIMEX_RK_Part */){}
 
   /// Observe Stepper before nonlinear solve.
   virtual void observeBeforeSolve(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    StepperIMEX_RK_Partition<Scalar> & stepperIMEX_RK_Part){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    StepperIMEX_RK_Partition<Scalar> & /* stepperIMEX_RK_Part */){}
 
   /// Observe Stepper after nonlinear solve.
   virtual void observeAfterSolve(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    StepperIMEX_RK_Partition<Scalar> & stepperIMEX_RK_Part){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    StepperIMEX_RK_Partition<Scalar> & /* stepperIMEX_RK_Part */){}
 
   /// Observe Stepper before Explicit ME evaluation.
   virtual void observeBeforeExplicit(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    StepperIMEX_RK_Partition<Scalar> & stepperIMEX_RK_Part){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    StepperIMEX_RK_Partition<Scalar> & /* stepperIMEX_RK_Part */){}
 
   /// Observe Stepper at end of each stage.
   virtual void observeEndStage(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    StepperIMEX_RK_Partition<Scalar> & stepperIMEX_RK_Part){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    StepperIMEX_RK_Partition<Scalar> & /* stepperIMEX_RK_Part */){}
 
   /// Observe Stepper at end of takeStep.
   virtual void observeEndTakeStep(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    Stepper<Scalar> & stepper){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    Stepper<Scalar> & /* stepper */){}
 };
 } // namespace Tempus
 #endif // Tempus_StepperIMEX_RKPartObserver_hpp

--- a/packages/tempus/src/Tempus_StepperIMEX_RK_Partition_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RK_Partition_impl.hpp
@@ -723,7 +723,7 @@ std::string StepperIMEX_RK_Partition<Scalar>::description() const
 template<class Scalar>
 void StepperIMEX_RK_Partition<Scalar>::describe(
    Teuchos::FancyOStream               &out,
-   const Teuchos::EVerbosityLevel      verbLevel) const
+   const Teuchos::EVerbosityLevel      /* verbLevel */) const
 {
   out << description() << "::describe:" << std::endl
       << "wrapperModelPairIMEX = " << this->wrapperModel_->description()

--- a/packages/tempus/src/Tempus_StepperIMEX_RK_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RK_impl.hpp
@@ -678,7 +678,7 @@ std::string StepperIMEX_RK<Scalar>::description() const
 template<class Scalar>
 void StepperIMEX_RK<Scalar>::describe(
    Teuchos::FancyOStream               &out,
-   const Teuchos::EVerbosityLevel      verbLevel) const
+   const Teuchos::EVerbosityLevel      /* verbLevel */) const
 {
   Teuchos::RCP<WrapperModelEvaluatorPairIMEX<Scalar> > wrapperModelPairIMEX =
     Teuchos::rcp_dynamic_cast<WrapperModelEvaluatorPairIMEX<Scalar> >(

--- a/packages/tempus/src/Tempus_StepperImplicit_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperImplicit_decl.hpp
@@ -112,7 +112,7 @@ public:
     virtual bool getZeroInitialGuess() const
       { return stepperPL_->get<bool>("Zero Initial Guess", false); }
     virtual Scalar getInitTimeStep(
-        const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory) const
+        const Teuchos::RCP<SolutionHistory<Scalar> >& /* solutionHistory */) const
       {return Scalar(1.0e+99);}
 
     virtual bool getEmbedded() const

--- a/packages/tempus/src/Tempus_StepperLeapfrogObserver.hpp
+++ b/packages/tempus/src/Tempus_StepperLeapfrogObserver.hpp
@@ -45,33 +45,33 @@ public:
 
   /// Observe Stepper at beginning of takeStep.
   virtual void observeBeginTakeStep(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    Stepper<Scalar> & stepper){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    Stepper<Scalar> & /* stepper */){}
 
   /// Observe Stepper before updating xDot while initializing xDotDot
   virtual void observeBeforeXDotUpdateInitialize(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    StepperLeapfrog<Scalar> & stepperLF){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    StepperLeapfrog<Scalar> & /* stepperLF */){}
 
   /// Observe Stepper before updating x
   virtual void observeBeforeXUpdate(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    StepperLeapfrog<Scalar> & stepperLF){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    StepperLeapfrog<Scalar> & /* stepperLF */){}
 
   /// Observe Stepper before Explicit ME evaluation.
   virtual void observeBeforeExplicit(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    StepperLeapfrog<Scalar> & stepperLF){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    StepperLeapfrog<Scalar> & /* stepperLF */){}
 
   /// Observe Stepper before updating xDot
   virtual void observeBeforeXDotUpdate(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    StepperLeapfrog<Scalar> & stepperLF){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    StepperLeapfrog<Scalar> & /* stepperLF */){}
 
   /// Observe Stepper at end of takeStep.
   virtual void observeEndTakeStep(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    Stepper<Scalar> & stepper){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    Stepper<Scalar> & /* stepper */){}
 };
 } // namespace Tempus
 #endif // Tempus_StepperLeapfrogObserver_hpp

--- a/packages/tempus/src/Tempus_StepperLeapfrog_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperLeapfrog_decl.hpp
@@ -116,7 +116,7 @@ public:
     virtual Scalar getOrderMin() const {return 2.0;}
     virtual Scalar getOrderMax() const {return 2.0;}
     virtual Scalar getInitTimeStep(
-        const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory) const
+        const Teuchos::RCP<SolutionHistory<Scalar> >& /* solutionHistory */) const
       {return Scalar(1.0e+99);}
 
     virtual bool isExplicit()         const {return true;}

--- a/packages/tempus/src/Tempus_StepperLeapfrog_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperLeapfrog_impl.hpp
@@ -191,7 +191,7 @@ std::string StepperLeapfrog<Scalar>::description() const
 template<class Scalar>
 void StepperLeapfrog<Scalar>::describe(
    Teuchos::FancyOStream               &out,
-   const Teuchos::EVerbosityLevel      verbLevel) const
+   const Teuchos::EVerbosityLevel      /* verbLevel */) const
 {
   out << description() << "::describe:" << std::endl
       << "appModel_ = " << this->appModel_->description() << std::endl;

--- a/packages/tempus/src/Tempus_StepperNewmarkExplicitAForm_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkExplicitAForm_decl.hpp
@@ -77,7 +77,7 @@ public:
   /// \name Basic stepper methods
   //@{
     virtual void setObserver(
-      Teuchos::RCP<StepperObserver<Scalar> > obs = Teuchos::null){}
+      Teuchos::RCP<StepperObserver<Scalar> > /* obs */ = Teuchos::null){}
 
     /// Initialize during construction and after changing input parameters.
     virtual void initialize();
@@ -102,7 +102,7 @@ public:
     virtual Scalar getOrderMin() const {return 1.0;}
     virtual Scalar getOrderMax() const {return 2.0;}
     virtual Scalar getInitTimeStep(
-        const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory) const
+        const Teuchos::RCP<SolutionHistory<Scalar> >& /* solutionHistory */) const
       {return Scalar(1.0e+99);}
 
     virtual bool isExplicit()         const {return true;}

--- a/packages/tempus/src/Tempus_StepperNewmarkExplicitAForm_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkExplicitAForm_impl.hpp
@@ -314,7 +314,7 @@ std::string StepperNewmarkExplicitAForm<Scalar>::description() const
 template<class Scalar>
 void StepperNewmarkExplicitAForm<Scalar>::describe(
    Teuchos::FancyOStream               &out,
-   const Teuchos::EVerbosityLevel      verbLevel) const
+   const Teuchos::EVerbosityLevel      /* verbLevel */) const
 {
   out << description() << "::describe:" << std::endl
       << "appModel_ = " << this->appModel_->description() << std::endl;

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_decl.hpp
@@ -95,7 +95,7 @@ public:
       const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel);
 
     virtual void setObserver(
-      Teuchos::RCP<StepperObserver<Scalar> > obs = Teuchos::null){}
+      Teuchos::RCP<StepperObserver<Scalar> > /* obs */ = Teuchos::null){}
 
     /// Initialize during construction and after changing input parameters.
     virtual void initialize();

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_impl.hpp
@@ -424,7 +424,7 @@ std::string StepperNewmarkImplicitAForm<Scalar>::description() const
 template<class Scalar>
 void StepperNewmarkImplicitAForm<Scalar>::describe(
    Teuchos::FancyOStream               &out,
-   const Teuchos::EVerbosityLevel      verbLevel) const
+   const Teuchos::EVerbosityLevel      /* verbLevel */) const
 {
 #ifdef VERBOSE_DEBUG_OUTPUT
   *out_ << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitDForm_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitDForm_decl.hpp
@@ -60,7 +60,7 @@ class StepperNewmarkImplicitDForm : virtual public Tempus::StepperImplicit<Scala
   setModel(const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar>>& appModel);
 
   virtual void setObserver(
-    Teuchos::RCP<StepperObserver<Scalar> > obs = Teuchos::null){}
+    Teuchos::RCP<StepperObserver<Scalar> > /* obs */ = Teuchos::null){}
 
   /// Initialize during construction and after changing input parameters.
   virtual void
@@ -68,7 +68,7 @@ class StepperNewmarkImplicitDForm : virtual public Tempus::StepperImplicit<Scala
 
   /// Set the initial conditions and make them consistent.
   virtual void setInitialConditions (
-    const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory){}
+    const Teuchos::RCP<SolutionHistory<Scalar> >& /* solutionHistory */){}
 
   /// Take the specified timestep, dt, and return true if successful.
   virtual void

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitDForm_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitDForm_impl.hpp
@@ -393,7 +393,7 @@ template <class Scalar>
 void
 StepperNewmarkImplicitDForm<Scalar>::describe(
     Teuchos::FancyOStream& out,
-    const Teuchos::EVerbosityLevel verbLevel) const {
+    const Teuchos::EVerbosityLevel /* verbLevel */) const {
 #ifdef VERBOSE_DEBUG_OUTPUT
   *out_ << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
 #endif

--- a/packages/tempus/src/Tempus_StepperObserverBasic_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperObserverBasic_impl.hpp
@@ -26,14 +26,14 @@ template<class Scalar> StepperObserverBasic<Scalar>::~StepperObserverBasic(){}
 
 template<class Scalar>
 void StepperObserverBasic<Scalar>::observeBeginTakeStep(
-  Teuchos::RCP<SolutionHistory<Scalar> > sh,
-  Stepper<Scalar> & stepper)
+  Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+  Stepper<Scalar> & /* stepper */)
 {}
 
 template<class Scalar>
 void StepperObserverBasic<Scalar>::observeEndTakeStep(
-  Teuchos::RCP<SolutionHistory<Scalar> > sh,
-  Stepper<Scalar> & stepper)
+  Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+  Stepper<Scalar> & /* stepper */)
 {}
 
 } // namespace Tempus

--- a/packages/tempus/src/Tempus_StepperOperatorSplitObserver.hpp
+++ b/packages/tempus/src/Tempus_StepperOperatorSplitObserver.hpp
@@ -45,23 +45,23 @@ public:
 
   /// Observe Stepper at beginning of takeStep.
   virtual void observeBeginTakeStep(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    Stepper<Scalar> & stepper){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    Stepper<Scalar> & /* stepper */){}
 
   /// Observe Stepper before index subStepper->takeStep()
-  virtual void observeBeforeStepper(int index,
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    StepperOperatorSplit<Scalar> & stepperOS){}
+  virtual void observeBeforeStepper(int /* index */,
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    StepperOperatorSplit<Scalar> & /* stepperOS */){}
 
   /// Observe Stepper after index subStepper->takeStep()
-  virtual void observeAfterStepper(int index,
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    StepperOperatorSplit<Scalar> & stepperOS){}
+  virtual void observeAfterStepper(int /* index */,
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    StepperOperatorSplit<Scalar> & /* stepperOS */){}
 
   /// Observe Stepper at end of takeStep.
   virtual void observeEndTakeStep(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    Stepper<Scalar> & stepperOS){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    Stepper<Scalar> & /* stepperOS */){}
 };
 } // namespace Tempus
 #endif // Tempus_StepperOperatorSplitObserver_hpp

--- a/packages/tempus/src/Tempus_StepperOperatorSplit_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperOperatorSplit_decl.hpp
@@ -88,7 +88,7 @@ public:
 
     /// Pass initial guess to Newton solver
     virtual void setInitialGuess(
-      Teuchos::RCP<const Thyra::VectorBase<Scalar> > initial_guess){}
+      Teuchos::RCP<const Thyra::VectorBase<Scalar> > /* initial_guess */){}
 
    virtual std::string getStepperType() const
      { return stepperPL_->get<std::string>("Stepper Type"); }
@@ -102,7 +102,7 @@ public:
     virtual Scalar getOrderMax() const
       {return stepperPL_->get<int>("Maximum Order");}
     virtual Scalar getInitTimeStep(
-        const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory) const
+        const Teuchos::RCP<SolutionHistory<Scalar> >& /* solutionHistory */) const
       {return Scalar(1.0e+99);}
     virtual void setOrder   (Scalar ord)
       {stepperPL_->set<int>("Order", ord);}

--- a/packages/tempus/src/Tempus_StepperOperatorSplit_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperOperatorSplit_impl.hpp
@@ -107,7 +107,7 @@ StepperOperatorSplit<Scalar>::getModel()
 }
 
 template<class Scalar>
-void StepperOperatorSplit<Scalar>::setSolver(std::string solverName)
+void StepperOperatorSplit<Scalar>::setSolver(std::string /* solverName */)
 {
   Teuchos::RCP<Teuchos::FancyOStream> out = this->getOStream();
   Teuchos::OSTab ostab(out,1,"StepperOperatorSplit::setSolver()");
@@ -118,7 +118,7 @@ void StepperOperatorSplit<Scalar>::setSolver(std::string solverName)
 
 template<class Scalar>
 void StepperOperatorSplit<Scalar>::setSolver(
-  Teuchos::RCP<Teuchos::ParameterList> solverPL)
+  Teuchos::RCP<Teuchos::ParameterList> /* solverPL */)
 {
   Teuchos::RCP<Teuchos::FancyOStream> out = this->getOStream();
   Teuchos::OSTab ostab(out,1,"StepperOperatorSplit::setSolver()");
@@ -129,7 +129,7 @@ void StepperOperatorSplit<Scalar>::setSolver(
 
 template<class Scalar>
 void StepperOperatorSplit<Scalar>::setSolver(
-  Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > solver)
+  Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > /* solver */)
 {
   Teuchos::RCP<Teuchos::FancyOStream> out = this->getOStream();
   Teuchos::OSTab ostab(out,1,"StepperOperatorSplit::setSolver()");
@@ -353,7 +353,7 @@ std::string StepperOperatorSplit<Scalar>::description() const
 template<class Scalar>
 void StepperOperatorSplit<Scalar>::describe(
    Teuchos::FancyOStream               &out,
-   const Teuchos::EVerbosityLevel      verbLevel) const
+   const Teuchos::EVerbosityLevel      /* verbLevel */) const
 {
   out << description() << "::describe:" << std::endl;
 }

--- a/packages/tempus/src/Tempus_StepperStaggeredForwardSensitivity_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperStaggeredForwardSensitivity_decl.hpp
@@ -95,14 +95,14 @@ public:
 
     /// Set Observer
     virtual void setObserver(
-      Teuchos::RCP<StepperObserver<Scalar> > obs = Teuchos::null){}
+      Teuchos::RCP<StepperObserver<Scalar> > /* obs */ = Teuchos::null){}
 
     /// Initialize during construction and after changing input parameters.
     virtual void initialize();
 
     /// Set the initial conditions and make them consistent.
     virtual void setInitialConditions (
-      const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory){}
+      const Teuchos::RCP<SolutionHistory<Scalar> >& /* solutionHistory */){}
 
     /// Take the specified timestep, dt, and return true if successful.
     virtual void takeStep(
@@ -118,7 +118,7 @@ public:
     virtual Scalar getOrderMin() const {return stateStepper_->getOrderMin();}
     virtual Scalar getOrderMax() const {return stateStepper_->getOrderMax();}
     virtual Scalar getInitTimeStep(
-        const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory) const
+        const Teuchos::RCP<SolutionHistory<Scalar> >& /* solutionHistory */) const
       {return Scalar(1.0e+99);}
 
     virtual bool isExplicit()         const
@@ -154,7 +154,7 @@ public:
 
     /// Pass initial guess to Newton solver
     virtual void setInitialGuess(
-      Teuchos::RCP<const Thyra::VectorBase<Scalar> > initial_guess){}
+      Teuchos::RCP<const Thyra::VectorBase<Scalar> > /* initial_guess */){}
 
   /// \name ParameterList methods
   //@{

--- a/packages/tempus/src/Tempus_StepperState.hpp
+++ b/packages/tempus/src/Tempus_StepperState.hpp
@@ -61,7 +61,7 @@ public:
     virtual std::string description() const { return "Tempus::StepperState"; }
 
     virtual void describe(Teuchos::FancyOStream        & out,
-                          const Teuchos::EVerbosityLevel verbLevel) const
+                          const Teuchos::EVerbosityLevel /* verbLevel */) const
     {
       out << description() << "::describe" << std::endl
           << "  stepperName   = " << stepperName_ << std::endl;

--- a/packages/tempus/src/Tempus_StepperTrapezoidalObserver.hpp
+++ b/packages/tempus/src/Tempus_StepperTrapezoidalObserver.hpp
@@ -45,23 +45,23 @@ public:
 
   /// Observe Stepper at beginning of takeStep.
   virtual void observeBeginTakeStep(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    Stepper<Scalar> & stepper){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    Stepper<Scalar> & /* stepper */){}
 
   /// Observe Stepper before nonlinear solve.
   virtual void observeBeforeSolve(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    StepperTrapezoidal<Scalar> & stepperTrap){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    StepperTrapezoidal<Scalar> & /* stepperTrap */){}
 
   /// Observe Stepper after nonlinear solve.
   virtual void observeAfterSolve(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    StepperTrapezoidal<Scalar> & stepperTrap){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    StepperTrapezoidal<Scalar> & /* stepperTrap */){}
 
   /// Observe Stepper at end of takeStep.
   virtual void observeEndTakeStep(
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    Stepper<Scalar> & stepper){}
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    Stepper<Scalar> & /* stepper */){}
 };
 } // namespace Tempus
 #endif // Tempus_StepperTrapezoidalObserver_hpp

--- a/packages/tempus/src/Tempus_StepperTrapezoidal_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperTrapezoidal_impl.hpp
@@ -204,7 +204,7 @@ std::string StepperTrapezoidal<Scalar>::description() const
 template<class Scalar>
 void StepperTrapezoidal<Scalar>::describe(
    Teuchos::FancyOStream               &out,
-   const Teuchos::EVerbosityLevel      verbLevel) const
+   const Teuchos::EVerbosityLevel      /* verbLevel */) const
 {
   out << description() << "::describe:" << std::endl
       << "wrapperModel_ = " << this->wrapperModel_->description() << std::endl;

--- a/packages/tempus/src/Tempus_TimeStepControlStrategy.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategy.hpp
@@ -36,13 +36,13 @@ public:
 
   /// Determine the time step size.
   virtual void getNextTimeStep(
-    const TimeStepControl<Scalar> tsc,
-    Teuchos::RCP<SolutionHistory<Scalar> > sh,
-    Status & integratorStatus){}
+    const TimeStepControl<Scalar> /* tsc */,
+    Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+    Status & /* integratorStatus */){}
 
   /// \name Overridden from Teuchos::ParameterListAcceptor
   //@{
-    void setParameterList(const Teuchos::RCP<Teuchos::ParameterList> & pl){}
+    void setParameterList(const Teuchos::RCP<Teuchos::ParameterList> & /* pl */){}
     Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const
       { return  Teuchos::null;}
     Teuchos::RCP<Teuchos::ParameterList> getNonconstParameterList()

--- a/packages/tempus/src/Tempus_TimeStepControlStrategyBasicVS.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategyBasicVS.hpp
@@ -120,7 +120,7 @@ public:
   virtual void getNextTimeStep(
     const TimeStepControl<Scalar> tsc,
     Teuchos::RCP<SolutionHistory<Scalar> > solutionHistory,
-    Status & integratorStatus) override
+    Status & /* integratorStatus */) override
   {
     using Teuchos::RCP;
     RCP<SolutionState<Scalar> > workingState=solutionHistory->getWorkingState();

--- a/packages/tempus/src/Tempus_TimeStepControlStrategyIntegralController.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategyIntegralController.hpp
@@ -67,7 +67,7 @@ public:
   /** \brief Determine the time step size.*/
   virtual void getNextTimeStep(const TimeStepControl<Scalar> tsc,
     Teuchos::RCP<SolutionHistory<Scalar> > solutionHistory,
-    Status & integratorStatus) override
+    Status & /* integratorStatus */) override
   {
 
      // Take first step with initial time step provided

--- a/packages/tempus/src/Tempus_WrapperModelEvaluatorPairIMEX_Basic_decl.hpp
+++ b/packages/tempus/src/Tempus_WrapperModelEvaluatorPairIMEX_Basic_decl.hpp
@@ -84,7 +84,7 @@ public:
     virtual void setForSolve(Teuchos::RCP<TimeDerivative<Scalar> > timeDer,
       Thyra::ModelEvaluatorBase::InArgs<Scalar>  inArgs,
       Thyra::ModelEvaluatorBase::OutArgs<Scalar> outArgs,
-      EVALUATION_TYPE evaluationType = SOLVE_FOR_X)
+      EVALUATION_TYPE /* evaluationType */ = SOLVE_FOR_X)
     {
       timeDer_ = timeDer;
       wrapperImplicitInArgs_.setArgs(inArgs);

--- a/packages/tempus/src/Tempus_WrapperModelEvaluatorPairIMEX_Basic_impl.hpp
+++ b/packages/tempus/src/Tempus_WrapperModelEvaluatorPairIMEX_Basic_impl.hpp
@@ -48,7 +48,7 @@ template <typename Scalar>
 void
 WrapperModelEvaluatorPairIMEX_Basic<Scalar>::
 setAppModel(
-  const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > & me)
+  const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > & /* me */)
 {
   TEUCHOS_TEST_FOR_EXCEPTION( true, std::logic_error,
     "Error - WrapperModelEvaluatorPairIMEX_Basic<Scalar>::setAppModel\n"

--- a/packages/tempus/src/Tempus_WrapperModelEvaluatorPairPartIMEX_Basic_decl.hpp
+++ b/packages/tempus/src/Tempus_WrapperModelEvaluatorPairPartIMEX_Basic_decl.hpp
@@ -81,7 +81,7 @@ public:
     virtual void setForSolve(Teuchos::RCP<TimeDerivative<Scalar> > timeDer,
       Thyra::ModelEvaluatorBase::InArgs<Scalar>  inArgs,
       Thyra::ModelEvaluatorBase::OutArgs<Scalar> outArgs,
-      EVALUATION_TYPE evaluationType = SOLVE_FOR_X)
+      EVALUATION_TYPE /* evaluationType */ = SOLVE_FOR_X)
     {
       timeDer_ = timeDer;
       wrapperImplicitInArgs_.setArgs(inArgs);

--- a/packages/tempus/src/Tempus_WrapperModelEvaluatorPairPartIMEX_Basic_impl.hpp
+++ b/packages/tempus/src/Tempus_WrapperModelEvaluatorPairPartIMEX_Basic_impl.hpp
@@ -101,7 +101,7 @@ template <typename Scalar>
 void
 WrapperModelEvaluatorPairPartIMEX_Basic<Scalar>::
 setAppModel(
-  const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > & me)
+  const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > & /* me */)
 {
   TEUCHOS_TEST_FOR_EXCEPTION( true, std::logic_error,
     "Error - WrapperModelEvaluatorPairPartIMEX_Basic<Scalar>::setAppModel\n"

--- a/packages/tempus/src/Tempus_WrapperModelEvaluatorSecondOrder_decl.hpp
+++ b/packages/tempus/src/Tempus_WrapperModelEvaluatorSecondOrder_decl.hpp
@@ -171,7 +171,7 @@ public:
     virtual void setForSolve(Teuchos::RCP<TimeDerivative<Scalar> > timeDer,
       Thyra::ModelEvaluatorBase::InArgs<Scalar>   inArgs,
       Thyra::ModelEvaluatorBase::OutArgs<Scalar>  outArgs,
-      EVALUATION_TYPE evaluationType = SOLVE_FOR_X)
+      EVALUATION_TYPE /* evaluationType */ = SOLVE_FOR_X)
     {
       timeDer_ = timeDer;
       wrapperInArgs_.setArgs(inArgs);

--- a/packages/tempus/src/Thyra_AdjointPreconditioner.hpp
+++ b/packages/tempus/src/Thyra_AdjointPreconditioner.hpp
@@ -105,6 +105,8 @@ private:
     const RCP<const PreconditionerBase<Scalar> > &prec) {
 #ifdef TEUCHOS_DEBUG
     TEUCHOS_TEST_FOR_EXCEPT(is_null(prec));
+#else
+    (void)prec;
 #endif
   }
 

--- a/packages/tempus/src/Thyra_AdjointPreconditionerFactory.hpp
+++ b/packages/tempus/src/Thyra_AdjointPreconditionerFactory.hpp
@@ -178,6 +178,8 @@ private:
     const RCP<const PreconditionerFactoryBase<Scalar> > &prec_fac) {
 #ifdef TEUCHOS_DEBUG
     TEUCHOS_TEST_FOR_EXCEPT(is_null(prec_fac));
+#else
+    (void)prec_fac;
 #endif
   }
 

--- a/packages/tempus/src/Thyra_BlockedTriangularLinearOpWithSolveFactory.hpp
+++ b/packages/tempus/src/Thyra_BlockedTriangularLinearOpWithSolveFactory.hpp
@@ -379,8 +379,8 @@ template<class Scalar>
 void
 BlockedTriangularLinearOpWithSolveFactory<Scalar>::
 setPreconditionerFactory(
-  const RCP<PreconditionerFactoryBase<Scalar> > &precFactory,
-  const std::string &precFactoryName
+  const RCP<PreconditionerFactoryBase<Scalar> > &/* precFactory */,
+  const std::string &/* precFactoryName */
   )
 {
   TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,
@@ -398,8 +398,8 @@ getPreconditionerFactory() const
 template<class Scalar>
 void BlockedTriangularLinearOpWithSolveFactory<Scalar>::
 unsetPreconditionerFactory(
-  RCP<PreconditionerFactoryBase<Scalar> > *precFactory,
-  std::string *precFactoryName
+  RCP<PreconditionerFactoryBase<Scalar> > * /* precFactory */,
+  std::string * /* precFactoryName */
   )
 {
   TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,
@@ -410,7 +410,7 @@ template<class Scalar>
 bool
 BlockedTriangularLinearOpWithSolveFactory<Scalar>::
 isCompatible(
-  const LinearOpSourceBase<Scalar> &fwdOpSrc
+  const LinearOpSourceBase<Scalar> &/* fwdOpSrc */
   ) const
 {
   TEUCHOS_TEST_FOR_EXCEPT(true);
@@ -431,7 +431,7 @@ BlockedTriangularLinearOpWithSolveFactory<Scalar>::
 initializeOp(
   const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
   LinearOpWithSolveBase<Scalar> *Op,
-  const ESupportSolveUse supportSolveUse
+  const ESupportSolveUse /* supportSolveUse */
   ) const
 {
 
@@ -509,8 +509,8 @@ template<class Scalar>
 void
 BlockedTriangularLinearOpWithSolveFactory<Scalar>::
 initializeAndReuseOp(
-  const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
-  LinearOpWithSolveBase<Scalar> *Op
+  const RCP<const LinearOpSourceBase<Scalar> > &/* fwdOpSrc */,
+  LinearOpWithSolveBase<Scalar> * /* Op */
   ) const
 {
   TEUCHOS_TEST_FOR_EXCEPT(true);
@@ -524,7 +524,7 @@ uninitializeOp(
   RCP<const LinearOpSourceBase<Scalar> > *fwdOpSrc,
   RCP<const PreconditionerBase<Scalar> > *prec,
   RCP<const LinearOpSourceBase<Scalar> > *approxFwdOpSrc,
-  ESupportSolveUse *supportSolveUse
+  ESupportSolveUse * /* supportSolveUse */
   ) const
 {
   using Teuchos::dyn_cast;
@@ -548,7 +548,7 @@ template<class Scalar>
 bool
 BlockedTriangularLinearOpWithSolveFactory<Scalar>::
 supportsPreconditionerInputType(
-  const EPreconditionerInputType precOpType
+  const EPreconditionerInputType /* precOpType */
   ) const
 {
   // We don't support any external preconditioners!
@@ -563,10 +563,10 @@ template<class Scalar>
 void
 BlockedTriangularLinearOpWithSolveFactory<Scalar>::
 initializePreconditionedOp(
-  const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
-  const RCP<const PreconditionerBase<Scalar> > &prec,
-  LinearOpWithSolveBase<Scalar> *Op,
-  const ESupportSolveUse supportSolveUse
+  const RCP<const LinearOpSourceBase<Scalar> > &/* fwdOpSrc */,
+  const RCP<const PreconditionerBase<Scalar> > &/* prec */,
+  LinearOpWithSolveBase<Scalar> * /* Op */,
+  const ESupportSolveUse /* supportSolveUse */
   ) const
 {
   TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,
@@ -577,10 +577,10 @@ template<class Scalar>
 void
 BlockedTriangularLinearOpWithSolveFactory<Scalar>::
 initializeApproxPreconditionedOp(
-  const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
-  const RCP<const LinearOpSourceBase<Scalar> > &approxFwdOpSrc,
-  LinearOpWithSolveBase<Scalar> *Op,
-  const ESupportSolveUse supportSolveUse
+  const RCP<const LinearOpSourceBase<Scalar> > &/* fwdOpSrc */,
+  const RCP<const LinearOpSourceBase<Scalar> > &/* approxFwdOpSrc */,
+  LinearOpWithSolveBase<Scalar> * /* Op */,
+  const ESupportSolveUse /* supportSolveUse */
   ) const
 {
   TEUCHOS_TEST_FOR_EXCEPTION(true,std::logic_error,

--- a/packages/tempus/src/Thyra_MultiVectorLinearOp.hpp
+++ b/packages/tempus/src/Thyra_MultiVectorLinearOp.hpp
@@ -246,6 +246,10 @@ private:
       THYRA_ASSERT_VEC_SPACES(
         "MultiVectorLinearOp<Scalar>::initialize(op,multiVecRange,multiVecDomain)",
         *op->domain(), *multiVecDomain->getBlock(0) );
+#else
+    (void)op;
+    (void)multiVecRange;
+    (void)multiVecDomain;
 #endif
 }
 

--- a/packages/tempus/src/Thyra_MultiVectorPreconditioner.hpp
+++ b/packages/tempus/src/Thyra_MultiVectorPreconditioner.hpp
@@ -142,6 +142,10 @@ private:
     TEUCHOS_TEST_FOR_EXCEPT(is_null(multiVecRange));
     TEUCHOS_TEST_FOR_EXCEPT(is_null(multiVecDomain));
     TEUCHOS_TEST_FOR_EXCEPT( multiVecRange->numBlocks() != multiVecDomain->numBlocks() );
+#else
+    (void)prec;
+    (void)multiVecRange;
+    (void)multiVecDomain;
 #endif
   }
 

--- a/packages/tempus/src/Thyra_MultiVectorPreconditionerFactory.hpp
+++ b/packages/tempus/src/Thyra_MultiVectorPreconditionerFactory.hpp
@@ -202,6 +202,10 @@ private:
     TEUCHOS_TEST_FOR_EXCEPT(is_null(multiVecRange));
     TEUCHOS_TEST_FOR_EXCEPT(is_null(multiVecDomain));
     TEUCHOS_TEST_FOR_EXCEPT( multiVecRange->numBlocks() != multiVecDomain->numBlocks() );
+#else
+    (void)prec_fac;
+    (void)multiVecRange;
+    (void)multiVecDomain;
 #endif
   }
 

--- a/packages/tempus/src/Thyra_ReuseLinearOpWithSolveFactory.hpp
+++ b/packages/tempus/src/Thyra_ReuseLinearOpWithSolveFactory.hpp
@@ -358,8 +358,8 @@ template<class Scalar>
 void
 ReuseLinearOpWithSolveFactory<Scalar>::
 setPreconditionerFactory(
-  const RCP<PreconditionerFactoryBase<Scalar> > &precFactory,
-  const std::string &precFactoryName
+  const RCP<PreconditionerFactoryBase<Scalar> > &/* precFactory */,
+  const std::string &/* precFactoryName */
   )
 {
 }
@@ -375,8 +375,8 @@ getPreconditionerFactory() const
 template<class Scalar>
 void ReuseLinearOpWithSolveFactory<Scalar>::
 unsetPreconditionerFactory(
-  RCP<PreconditionerFactoryBase<Scalar> > *precFactory,
-  std::string *precFactoryName
+  RCP<PreconditionerFactoryBase<Scalar> > * /* precFactory */,
+  std::string * /* precFactoryName */
   )
 {
 }

--- a/packages/tempus/src/Thyra_ReusePreconditionerFactory.hpp
+++ b/packages/tempus/src/Thyra_ReusePreconditionerFactory.hpp
@@ -69,7 +69,7 @@ public:
   /** @name Overridden from ParameterListAcceptor (simple forwarding functions) */
   //@{
 
-  void setParameterList(RCP<ParameterList> const& paramList)
+  void setParameterList(RCP<ParameterList> const& /* paramList */)
   {
   }
 
@@ -100,22 +100,22 @@ public:
   /** @name Overridden from PreconditionerFactoryBase */
   //@{
 
-  bool isCompatible(const LinearOpSourceBase<Scalar> &fwdOpSrc) const
+  bool isCompatible(const LinearOpSourceBase<Scalar> &/* fwdOpSrc */) const
   { return false; }
 
    RCP<PreconditionerBase<Scalar> > createPrec() const
   { return prec_; }
 
   void initializePrec(
-    const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
-    PreconditionerBase<Scalar> *precOp,
-    const ESupportSolveUse supportSolveUse = SUPPORT_SOLVE_UNSPECIFIED
+    const RCP<const LinearOpSourceBase<Scalar> > &/* fwdOpSrc */,
+    PreconditionerBase<Scalar> * /* precOp */,
+    const ESupportSolveUse /* supportSolveUse */ = SUPPORT_SOLVE_UNSPECIFIED
     ) const
   {
   }
 
   void uninitializePrec(
-    PreconditionerBase<Scalar> *precOp,
+    PreconditionerBase<Scalar> * /* precOp */,
     RCP<const LinearOpSourceBase<Scalar> > *fwdOpSrc = NULL,
     ESupportSolveUse *supportSolveUse = NULL
     ) const

--- a/packages/tempus/src/Thyra_ScaledIdentityLinearOpWithSolve.hpp
+++ b/packages/tempus/src/Thyra_ScaledIdentityLinearOpWithSolve.hpp
@@ -69,7 +69,7 @@ protected:
 
   /** @name Overridden from LinearOpBase */
   //@{
-  bool opSupportedImpl(EOpTransp M_trans) const { return true; }
+  bool opSupportedImpl(EOpTransp /* M_trans */) const { return true; }
 
   void applyImpl(const EOpTransp M_trans,
                  const MultiVectorBase<Scalar>& X,
@@ -88,23 +88,23 @@ protected:
 
   /** @name Overridden from LinearOpWithSolveBase */
   //@{
-  bool solveSupportsImpl(EOpTransp M_trans) const { return true; }
+  bool solveSupportsImpl(EOpTransp /* M_trans */) const { return true; }
 
   bool solveSupportsNewImpl(
-    EOpTransp M_trans,
-    const Ptr< const SolveCriteria< Scalar > > solveCriteria) const
+    EOpTransp /* M_trans */,
+    const Ptr< const SolveCriteria< Scalar > > /* solveCriteria */) const
   { return true; }
 
   bool solveSupportsSolveMeasureTypeImpl(
-    EOpTransp M_trans,
-     const SolveMeasureType &solveMeasureType) const
+    EOpTransp /* M_trans */,
+     const SolveMeasureType &/* solveMeasureType */) const
   { return true; }
 
   SolveStatus< Scalar > solveImpl(
     const EOpTransp M_trans,
     const MultiVectorBase<Scalar>& B,
     const Ptr<MultiVectorBase<Scalar> >& X,
-    const Ptr< const SolveCriteria< Scalar > > solveCriteria) const
+    const Ptr< const SolveCriteria< Scalar > > /* solveCriteria */) const
   {
     typedef Teuchos::ScalarTraits<Scalar> ST;
     assign(X, ST::zero());
@@ -133,6 +133,8 @@ private:
     const RCP<const VectorSpaceBase<Scalar> >& space) {
 #ifdef TEUCHOS_DEBUG
     TEUCHOS_TEST_FOR_EXCEPT(is_null(space));
+#else
+    (void)space;
 #endif
 }
 

--- a/packages/tempus/src/Thyra_ScaledIdentityLinearOpWithSolveFactory.hpp
+++ b/packages/tempus/src/Thyra_ScaledIdentityLinearOpWithSolveFactory.hpp
@@ -47,7 +47,7 @@ public:
   /** @name Overridden from ParameterListAcceptor */
   //@{
 
-  void setParameterList(RCP<ParameterList> const& paramList) {}
+  void setParameterList(RCP<ParameterList> const& /* paramList */) {}
   RCP<ParameterList> getNonconstParameterList() { return Teuchos::parameterList(); }
   RCP<ParameterList> unsetParameterList() { return Teuchos::parameterList(); }
   RCP<const ParameterList> getParameterList() const { return Teuchos::parameterList(); }
@@ -63,8 +63,8 @@ public:
 
   /** \brief Throws exception. */
   virtual void setPreconditionerFactory(
-    const RCP<PreconditionerFactoryBase<Scalar> > &precFactory,
-    const std::string &precFactoryName
+    const RCP<PreconditionerFactoryBase<Scalar> > &/* precFactory */,
+    const std::string &/* precFactoryName */
     ) {}
 
   /** \brief Returns null . */
@@ -73,8 +73,8 @@ public:
 
   /** \brief Throws exception. */
   virtual void unsetPreconditionerFactory(
-    RCP<PreconditionerFactoryBase<Scalar> > *precFactory,
-    std::string *precFactoryName
+    RCP<PreconditionerFactoryBase<Scalar> > * /* precFactory */,
+    std::string * /* precFactoryName */
     ) {}
 
   virtual bool isCompatible(
@@ -111,21 +111,21 @@ public:
     ) const;
 
   virtual bool supportsPreconditionerInputType(
-    const EPreconditionerInputType precOpType
+    const EPreconditionerInputType /* precOpType */
     ) const { return false; }
 
   virtual void initializePreconditionedOp(
-    const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
-    const RCP<const PreconditionerBase<Scalar> > &prec,
-    LinearOpWithSolveBase<Scalar> *Op,
-    const ESupportSolveUse supportSolveUse
+    const RCP<const LinearOpSourceBase<Scalar> > &/* fwdOpSrc */,
+    const RCP<const PreconditionerBase<Scalar> > &/* prec */,
+    LinearOpWithSolveBase<Scalar> * /* Op */,
+    const ESupportSolveUse /* supportSolveUse */
     ) const {}
 
   virtual void initializeApproxPreconditionedOp(
-    const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
-    const RCP<const LinearOpSourceBase<Scalar> > &approxFwdOpSrc,
-    LinearOpWithSolveBase<Scalar> *Op,
-    const ESupportSolveUse supportSolveUse
+    const RCP<const LinearOpSourceBase<Scalar> > &/* fwdOpSrc */,
+    const RCP<const LinearOpSourceBase<Scalar> > &/* approxFwdOpSrc */,
+    LinearOpWithSolveBase<Scalar> * /* Op */,
+    const ESupportSolveUse /* supportSolveUse */
     ) const {}
 
   //@}
@@ -170,7 +170,7 @@ ScaledIdentityLinearOpWithSolveFactory<Scalar>::
 initializeOp(
   const RCP<const LinearOpSourceBase<Scalar> > &fwdOpSrc,
   LinearOpWithSolveBase<Scalar> *Op,
-  const ESupportSolveUse supportSolveUse
+  const ESupportSolveUse /* supportSolveUse */
   ) const
 {
   using Teuchos::dyn_cast;
@@ -197,17 +197,19 @@ template<class Scalar>
 void
 ScaledIdentityLinearOpWithSolveFactory<Scalar>::
 uninitializeOp(
-  LinearOpWithSolveBase<Scalar> *Op,
+  LinearOpWithSolveBase<Scalar> * Op,
   RCP<const LinearOpSourceBase<Scalar> > *fwdOpSrc,
   RCP<const PreconditionerBase<Scalar> > *prec,
   RCP<const LinearOpSourceBase<Scalar> > *approxFwdOpSrc,
-  ESupportSolveUse *supportSolveUse
+  ESupportSolveUse * /* supportSolveUse */
   ) const
 {
   using Teuchos::dyn_cast;
   using Teuchos::is_null;
 #ifdef TEUCHOS_DEBUG
   TEUCHOS_TEST_FOR_EXCEPT(0==Op);
+#else
+  (void)Op;
 #endif // TEUCHOS_DEBUG
   if (fwdOpSrc) *fwdOpSrc = Teuchos::null;
   if (prec) *prec = Teuchos::null;


### PR DESCRIPTION
@trilinos/tempus 

## Description
Comment out parameter names in function definitions to avoid
`-Wunused-parameter` warnings.

## Motivation and Context
Clean build.