### PR TITLE
Tempus fix fpes

### DIFF
--- a/packages/tempus/src/Tempus_StepperNewmarkExplicitAForm_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkExplicitAForm_impl.hpp
@@ -196,7 +196,9 @@ void StepperNewmarkExplicitAForm<Scalar>::setInitialConditions(
     auto f       = initialState->getX()->clone_v();
     this->evaluateExplicitODE(f, x, xDot, initialState->getTime());
     Thyra::Vp_StV(f.ptr(), Scalar(-1.0), *(xDotDot));
-    Scalar reldiff = Thyra::norm(*f)/Thyra::norm(*xDotDot);
+    Scalar reldiff = Thyra::norm(*f);
+    //The following logic is to prevent FPEs  
+    if (Thyra::norm(*xDotDot) > 1.0e-12) reldiff /= Thyra::norm(*xDotDot); 
 
     Scalar eps = Scalar(100.0)*std::abs(Teuchos::ScalarTraits<Scalar>::eps());
     if (reldiff > eps) {
@@ -314,7 +316,7 @@ std::string StepperNewmarkExplicitAForm<Scalar>::description() const
 template<class Scalar>
 void StepperNewmarkExplicitAForm<Scalar>::describe(
    Teuchos::FancyOStream               &out,
-   const Teuchos::EVerbosityLevel      /* verbLevel */) const
+   const Teuchos::EVerbosityLevel      verbLevel) const
 {
   out << description() << "::describe:" << std::endl
       << "appModel_ = " << this->appModel_->description() << std::endl;

--- a/packages/tempus/src/Tempus_StepperNewmarkExplicitAForm_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkExplicitAForm_impl.hpp
@@ -197,11 +197,11 @@ void StepperNewmarkExplicitAForm<Scalar>::setInitialConditions(
     this->evaluateExplicitODE(f, x, xDot, initialState->getTime());
     Thyra::Vp_StV(f.ptr(), Scalar(-1.0), *(xDotDot));
     Scalar reldiff = Thyra::norm(*f);
+    Scalar normxDotDot = Thyra::norm(*xDotDot); 
     //The following logic is to prevent FPEs  
-    if (Thyra::norm(*xDotDot) > 1.0e-12)
-      reldiff /= Thyra::norm(*xDotDot); 
-
     Scalar eps = Scalar(100.0)*std::abs(Teuchos::ScalarTraits<Scalar>::eps());
+    if (normxDotDot > eps*reldiff) reldiff /= normxDotDot;  
+
     if (reldiff > eps) {
       RCP<Teuchos::FancyOStream> out = this->getOStream();
       Teuchos::OSTab ostab(out,1,"StepperForwardEuler::setInitialConditions()");

--- a/packages/tempus/src/Tempus_StepperNewmarkExplicitAForm_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkExplicitAForm_impl.hpp
@@ -198,7 +198,8 @@ void StepperNewmarkExplicitAForm<Scalar>::setInitialConditions(
     Thyra::Vp_StV(f.ptr(), Scalar(-1.0), *(xDotDot));
     Scalar reldiff = Thyra::norm(*f);
     //The following logic is to prevent FPEs  
-    if (Thyra::norm(*xDotDot) > 1.0e-12) reldiff /= Thyra::norm(*xDotDot); 
+    if (Thyra::norm(*xDotDot) > 1.0e-12)
+      reldiff /= Thyra::norm(*xDotDot); 
 
     Scalar eps = Scalar(100.0)*std::abs(Teuchos::ScalarTraits<Scalar>::eps());
     if (reldiff > eps) {
@@ -316,7 +317,7 @@ std::string StepperNewmarkExplicitAForm<Scalar>::description() const
 template<class Scalar>
 void StepperNewmarkExplicitAForm<Scalar>::describe(
    Teuchos::FancyOStream               &out,
-   const Teuchos::EVerbosityLevel      /*verbLevel*/) const
+   const Teuchos::EVerbosityLevel      /* verbLevel */) const
 {
   out << description() << "::describe:" << std::endl
       << "appModel_ = " << this->appModel_->description() << std::endl;

--- a/packages/tempus/src/Tempus_StepperNewmarkExplicitAForm_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkExplicitAForm_impl.hpp
@@ -316,7 +316,7 @@ std::string StepperNewmarkExplicitAForm<Scalar>::description() const
 template<class Scalar>
 void StepperNewmarkExplicitAForm<Scalar>::describe(
    Teuchos::FancyOStream               &out,
-   const Teuchos::EVerbosityLevel      verbLevel) const
+   const Teuchos::EVerbosityLevel      /*verbLevel*/) const
 {
   out << description() << "::describe:" << std::endl
       << "appModel_ = " << this->appModel_->description() << std::endl;

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_impl.hpp
@@ -427,7 +427,7 @@ std::string StepperNewmarkImplicitAForm<Scalar>::description() const
 template<class Scalar>
 void StepperNewmarkImplicitAForm<Scalar>::describe(
    Teuchos::FancyOStream               &out,
-   const Teuchos::EVerbosityLevel      verbLevel) const
+   const Teuchos::EVerbosityLevel      /*verbLevel*/) const
 {
 #ifdef VERBOSE_DEBUG_OUTPUT
   *out_ << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_impl.hpp
@@ -292,11 +292,10 @@ void StepperNewmarkImplicitAForm<Scalar>::setInitialConditions(
     this->wrapperModel_->getAppModel()->evalModel(appInArgs, appOutArgs);
  
     Scalar reldiff = Thyra::norm(*f);
-    //The following logic prevents FPEs  
-    if (Thyra::norm(*x) > 1.0e-12)
-      reldiff /= Thyra::norm(*x);
- 
+    Scalar normx = Thyra::norm(*x); 
     Scalar eps = Scalar(100.0)*std::abs(Teuchos::ScalarTraits<Scalar>::eps());
+    if (normx > eps*reldiff) reldiff /= normx; 
+
     if (reldiff > eps) {
       RCP<Teuchos::FancyOStream> out = this->getOStream();
       Teuchos::OSTab ostab(out,1,

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_impl.hpp
@@ -293,7 +293,8 @@ void StepperNewmarkImplicitAForm<Scalar>::setInitialConditions(
  
     Scalar reldiff = Thyra::norm(*f);
     //The following logic prevents FPEs  
-    if (Thyra::norm(*x) > 1.0e-12) reldiff /= Thyra::norm(*x);
+    if (Thyra::norm(*x) > 1.0e-12)
+      reldiff /= Thyra::norm(*x);
  
     Scalar eps = Scalar(100.0)*std::abs(Teuchos::ScalarTraits<Scalar>::eps());
     if (reldiff > eps) {
@@ -427,7 +428,7 @@ std::string StepperNewmarkImplicitAForm<Scalar>::description() const
 template<class Scalar>
 void StepperNewmarkImplicitAForm<Scalar>::describe(
    Teuchos::FancyOStream               &out,
-   const Teuchos::EVerbosityLevel      /*verbLevel*/) const
+   const Teuchos::EVerbosityLevel      /* verbLevel */) const
 {
 #ifdef VERBOSE_DEBUG_OUTPUT
   *out_ << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_impl.hpp
@@ -290,8 +290,11 @@ void StepperNewmarkImplicitAForm<Scalar>::setInitialConditions(
     appInArgs.set_t        (initialState->getTime()    );
 
     this->wrapperModel_->getAppModel()->evalModel(appInArgs, appOutArgs);
-
-    Scalar reldiff = Thyra::norm(*f)/Thyra::norm(*x);
+ 
+    Scalar reldiff = Thyra::norm(*f);
+    //The following logic prevents FPEs  
+    if (Thyra::norm(*x) > 1.0e-12) reldiff /= Thyra::norm(*x);
+ 
     Scalar eps = Scalar(100.0)*std::abs(Teuchos::ScalarTraits<Scalar>::eps());
     if (reldiff > eps) {
       RCP<Teuchos::FancyOStream> out = this->getOStream();
@@ -424,7 +427,7 @@ std::string StepperNewmarkImplicitAForm<Scalar>::description() const
 template<class Scalar>
 void StepperNewmarkImplicitAForm<Scalar>::describe(
    Teuchos::FancyOStream               &out,
-   const Teuchos::EVerbosityLevel      /* verbLevel */) const
+   const Teuchos::EVerbosityLevel      verbLevel) const
 {
 #ifdef VERBOSE_DEBUG_OUTPUT
   *out_ << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";


### PR DESCRIPTION
This PR addressed the following Albany issue https://github.com/SNLComputation/Albany/issues/461 by fixing floating point exceptions in some of the Newmark steppers.  These were only showing up in a debug build with FPE checking on. 

All Tempus tests pass, as do all Albany Tempus tests with the fix. 