### PR TITLE
MueLu:  Remove Unused Parameter Warnings

### DIFF
--- a/packages/muelu/adapters/aztecoo/MueLu_AztecEpetraOperator.hpp
+++ b/packages/muelu/adapters/aztecoo/MueLu_AztecEpetraOperator.hpp
@@ -39,7 +39,7 @@ namespace MueLu {
 
     //@}
 
-    int SetUseTranspose(bool UseTransposeBool) { return -1; }
+    int SetUseTranspose(bool /* UseTransposeBool */) { return -1; }
 
     //! @name Mathematical functions
     //@{
@@ -53,7 +53,7 @@ namespace MueLu {
 
       \return Integer error code, set to 0 if successful.
     */
-    int Apply(const Epetra_MultiVector& X, Epetra_MultiVector& Y) const { return -1; }
+    int Apply(const Epetra_MultiVector& /* X */, Epetra_MultiVector& /* Y */) const { return -1; }
 
     //! Returns the result of a Epetra_Operator inverse applied to an Epetra_MultiVector X in Y.
     /*!

--- a/packages/muelu/adapters/epetra/MueLu_EpetraOperator.hpp
+++ b/packages/muelu/adapters/epetra/MueLu_EpetraOperator.hpp
@@ -83,7 +83,7 @@ namespace MueLu {
 
     //@}
 
-    int SetUseTranspose(bool UseTransposeBool) { return -1; }
+    int SetUseTranspose(bool /* UseTransposeBool */) { return -1; }
 
     //! @name Mathematical functions
     //@{
@@ -97,7 +97,7 @@ namespace MueLu {
 
       \return Integer error code, set to 0 if successful.
     */
-    int Apply(const Epetra_MultiVector& X, Epetra_MultiVector& Y) const { return -1; }
+    int Apply(const Epetra_MultiVector& /* X */, Epetra_MultiVector& /* Y */) const { return -1; }
 
     //! Returns the result of a Epetra_Operator inverse applied to an Epetra_MultiVector X in Y.
     /*!

--- a/packages/muelu/adapters/stratimikos/Thyra_MueLuPreconditionerFactory_decl.hpp
+++ b/packages/muelu/adapters/stratimikos/Thyra_MueLuPreconditionerFactory_decl.hpp
@@ -220,7 +220,7 @@ namespace Thyra {
     /** \brief . */
     void initializePrec(const Teuchos::RCP<const LinearOpSourceBase<Scalar> >& fwdOpSrc,
                         PreconditionerBase<Scalar>* prec,
-                        const ESupportSolveUse supportSolveUse
+                        const ESupportSolveUse /* supportSolveUse */
                        ) const {
       using Teuchos::rcp_dynamic_cast;
 

--- a/packages/muelu/adapters/stratimikos/Thyra_MueLuRefMaxwellPreconditionerFactory_decl.hpp
+++ b/packages/muelu/adapters/stratimikos/Thyra_MueLuRefMaxwellPreconditionerFactory_decl.hpp
@@ -221,7 +221,7 @@ namespace Thyra {
     /** \brief . */
     void initializePrec(const Teuchos::RCP<const LinearOpSourceBase<Scalar> >& fwdOpSrc,
                         PreconditionerBase<Scalar>* prec,
-                        const ESupportSolveUse supportSolveUse
+                        const ESupportSolveUse /* supportSolveUse */
                        ) const {
       using Teuchos::rcp_dynamic_cast;
 

--- a/packages/muelu/adapters/tpetra/MueLu_ShiftedLaplacianOperator_def.hpp
+++ b/packages/muelu/adapters/tpetra/MueLu_ShiftedLaplacianOperator_def.hpp
@@ -114,7 +114,7 @@ getRangeMap () const
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void ShiftedLaplacianOperator<Scalar,LocalOrdinal,GlobalOrdinal,Node>::apply(const Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>& X,
                                                                                Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>& Y,
-                                                                               Teuchos::ETransp mode, Scalar alpha, Scalar beta) const {
+                                                                               Teuchos::ETransp /* mode */, Scalar /* alpha */, Scalar /* beta */) const {
 
   typedef Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>        TMV;
   typedef Xpetra::TpetraMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>  XTMV;

--- a/packages/muelu/adapters/tpetra/MueLu_TpetraOperator_def.hpp
+++ b/packages/muelu/adapters/tpetra/MueLu_TpetraOperator_def.hpp
@@ -98,7 +98,7 @@ Teuchos::RCP<const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> > TpetraOperator
 template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void TpetraOperator<Scalar,LocalOrdinal,GlobalOrdinal,Node>::apply(const Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>& X,
                                                                                Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>& Y,
-                                                                               Teuchos::ETransp mode, Scalar alpha, Scalar beta) const {
+                                                                               Teuchos::ETransp /* mode */, Scalar /* alpha */, Scalar /* beta */) const {
   typedef Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>       TMV;
   typedef Xpetra::TpetraMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> XTMV;
 

--- a/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_def.hpp
+++ b/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_def.hpp
@@ -1663,9 +1663,9 @@ namespace MueLu {
 
   template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void RefMaxwell<Scalar,LocalOrdinal,GlobalOrdinal,Node>::apply (const MultiVector& RHS, MultiVector& X,
-                                                                  Teuchos::ETransp mode,
-                                                                  Scalar alpha,
-                                                                  Scalar beta) const {
+                                                                  Teuchos::ETransp /* mode */,
+                                                                  Scalar /* alpha */,
+                                                                  Scalar /* beta */) const {
 
     Teuchos::TimeMonitor tm(*Teuchos::TimeMonitor::getNewTimer("MueLu RefMaxwell: solve"));
 
@@ -1775,7 +1775,7 @@ namespace MueLu {
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void RefMaxwell<Scalar,LocalOrdinal,GlobalOrdinal,Node>::
-  describe(Teuchos::FancyOStream& out, const Teuchos::EVerbosityLevel verbLevel) const {
+  describe(Teuchos::FancyOStream& out, const Teuchos::EVerbosityLevel /* verbLevel */) const {
 
     std::ostringstream oss;
 

--- a/packages/muelu/adapters/xpetra/MueLu_XpetraOperator_decl.hpp
+++ b/packages/muelu/adapters/xpetra/MueLu_XpetraOperator_decl.hpp
@@ -100,9 +100,9 @@ namespace MueLu {
     */
     void apply(const Xpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>& X,
                                          Xpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>& Y,
-                                         Teuchos::ETransp mode = Teuchos::NO_TRANS,
-                                         Scalar alpha = Teuchos::ScalarTraits<Scalar>::one(),
-                                         Scalar beta  = Teuchos::ScalarTraits<Scalar>::one()) const{
+                                         Teuchos::ETransp /* mode */ = Teuchos::NO_TRANS,
+                                         Scalar /* alpha */ = Teuchos::ScalarTraits<Scalar>::one(),
+                                         Scalar /* beta */  = Teuchos::ScalarTraits<Scalar>::one()) const{
       try {
 #ifdef HAVE_MUELU_DEBUG
         typedef Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> Matrix;

--- a/packages/muelu/src/Graph/BrickAggregation/MueLu_BrickAggregationFactory_def.hpp
+++ b/packages/muelu/src/Graph/BrickAggregation/MueLu_BrickAggregationFactory_def.hpp
@@ -266,7 +266,7 @@ namespace MueLu {
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void BrickAggregationFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  Setup(const RCP<const Teuchos::Comm<int> >& comm, const RCP<Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::magnitudeType,LO,GO,NO> >& coords, const RCP<const Map>& map) const {
+  Setup(const RCP<const Teuchos::Comm<int> >& comm, const RCP<Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::magnitudeType,LO,GO,NO> >& coords, const RCP<const Map>& /* map */) const {
     nDim_ = coords->getNumVectors();
 
     x_    = coords->getData(0);

--- a/packages/muelu/src/Graph/MueLu_CoalesceDropFactory_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/MueLu_CoalesceDropFactory_kokkos_def.hpp
@@ -152,7 +152,7 @@ namespace MueLu {
 
       // Return true if we drop, false if not
       KOKKOS_INLINE_FUNCTION
-      bool operator()(LO row, LO col, SC val) const {
+      bool operator()(LO row, LO col, SC /* val */) const {
         // We avoid square root by using squared values
 
         // We ignore incoming value of val as we operate on an auxiliary
@@ -188,7 +188,7 @@ namespace MueLu {
                     typename rows_type::non_const_type rows_,
                     typename cols_type::non_const_type colsAux_,
                     typename vals_type::non_const_type valsAux_,
-                    bool reuseGraph_, bool lumping_, SC threshold_) :
+                    bool reuseGraph_, bool lumping_, SC /* threshold_ */) :
           A(A_),
           bndNodes(bndNodes_),
           dropFunctor(dropFunctor_),

--- a/packages/muelu/src/Graph/MueLu_Graph_decl.hpp
+++ b/packages/muelu/src/Graph/MueLu_Graph_decl.hpp
@@ -76,7 +76,7 @@ namespace MueLu {
 
     //! @name Constructors/Destructors.
     //@{
-    Graph(const RCP<const CrsGraph> & graph, const std::string & objectLabel="") : graph_(graph) {
+    Graph(const RCP<const CrsGraph> & graph, const std::string & /* objectLabel */="") : graph_(graph) {
       minLocalIndex_ = graph_->getDomainMap()->getMinLocalIndex();
       maxLocalIndex_ = graph_->getDomainMap()->getMaxLocalIndex();
     }

--- a/packages/muelu/src/Graph/MueLu_LWGraph_decl.hpp
+++ b/packages/muelu/src/Graph/MueLu_LWGraph_decl.hpp
@@ -116,7 +116,7 @@ namespace MueLu {
     //! Returns overlapping import map (nodes).
     const RCP<const Map>                 GetImportMap() const    { return importMap_; }
 
-    void SetBoundaryNodeMap(RCP<const Map> const &map)           { throw Exceptions::NotImplemented("LWGraph: Boundary node map not implemented."); }
+    void SetBoundaryNodeMap(RCP<const Map> const &/* map */)           { throw Exceptions::NotImplemented("LWGraph: Boundary node map not implemented."); }
 
     //! Return the list of vertices adjacent to the vertex 'v'.
     Teuchos::ArrayView<const LO> getNeighborVertices(LO i) const { return columns_.view(rows_[i], rows_[i+1]-rows_[i]); }

--- a/packages/muelu/src/Graph/MueLu_PreDropFunctionConstVal_def.hpp
+++ b/packages/muelu/src/Graph/MueLu_PreDropFunctionConstVal_def.hpp
@@ -59,7 +59,7 @@ namespace MueLu {
     : threshold_(threshold) { }
 
   template <class Scalar,class LocalOrdinal, class GlobalOrdinal, class Node>
-  bool PreDropFunctionConstVal<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Drop(size_t lrow, GlobalOrdinal grow, size_t k, LocalOrdinal lcid, GlobalOrdinal gcid, const Teuchos::ArrayView<const LocalOrdinal> & indices, const Teuchos::ArrayView<const Scalar> & vals) {
+  bool PreDropFunctionConstVal<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Drop(size_t /* lrow */, GlobalOrdinal grow, size_t k, LocalOrdinal /* lcid */, GlobalOrdinal gcid, const Teuchos::ArrayView<const LocalOrdinal> & /* indices */, const Teuchos::ArrayView<const Scalar> & vals) {
     if(Teuchos::ScalarTraits<Scalar>::magnitude(vals[k]) > Teuchos::ScalarTraits<Scalar>::magnitude(threshold_) || grow == gcid ) {
       return false; // keep values
     }

--- a/packages/muelu/src/Graph/MueLu_UnsmooshFactory_decl.hpp
+++ b/packages/muelu/src/Graph/MueLu_UnsmooshFactory_decl.hpp
@@ -121,7 +121,7 @@ namespace MueLu {
     //@}
 
     void Build (Level &fineLevel, Level &coarseLevel) const; // Build
-    void BuildP(Level &fineLevel, Level &coarseLevel) const {}; // TAW no real need for an extra BuildP routine. Just use Build
+    void BuildP(Level &/* fineLevel */, Level &/* coarseLevel */) const {}; // TAW no real need for an extra BuildP routine. Just use Build
 
   private:
 

--- a/packages/muelu/src/Graph/StructuredAggregation/MueLu_AggregationStructuredAlgorithm_decl.hpp
+++ b/packages/muelu/src/Graph/StructuredAggregation/MueLu_AggregationStructuredAlgorithm_decl.hpp
@@ -87,7 +87,7 @@ namespace MueLu {
     //@{
 
     //! Constructor.
-    AggregationStructuredAlgorithm(const RCP<const FactoryBase>& graphFact = Teuchos::null) { }
+    AggregationStructuredAlgorithm(const RCP<const FactoryBase>& /* graphFact */ = Teuchos::null) { }
 
     //! Destructor.
     virtual ~AggregationStructuredAlgorithm() { }

--- a/packages/muelu/src/Graph/StructuredAggregation/MueLu_AggregationStructuredAlgorithm_def.hpp
+++ b/packages/muelu/src/Graph/StructuredAggregation/MueLu_AggregationStructuredAlgorithm_def.hpp
@@ -67,7 +67,7 @@ namespace MueLu {
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   void AggregationStructuredAlgorithm<LocalOrdinal, GlobalOrdinal, Node>::
-  BuildAggregates(const Teuchos::ParameterList& params, const GraphBase& graph,
+  BuildAggregates(const Teuchos::ParameterList& /* params */, const GraphBase& graph,
                   Aggregates& aggregates, std::vector<unsigned>& aggStat,
                   LO& numNonAggregatedNodes) const {
     Monitor m(*this, "BuildAggregates");
@@ -270,7 +270,7 @@ namespace MueLu {
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   void AggregationStructuredAlgorithm<LocalOrdinal, GlobalOrdinal, Node>::
   ComputeGraphDataConstant(const GraphBase& graph, RCP<IndexManager>& geoData,
-                           const LO dofsPerNode, const int numInterpolationPoints,
+                           const LO dofsPerNode, const int /* numInterpolationPoints */,
                            ArrayRCP<size_t>& nnzOnRow, Array<size_t>& rowPtr,
                            Array<LO>& colIndex) const {
 
@@ -325,7 +325,7 @@ namespace MueLu {
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   void AggregationStructuredAlgorithm<LocalOrdinal, GlobalOrdinal, Node>::
-  ComputeGraphDataLinear(const GraphBase& graph, RCP<IndexManager>& geoData,
+  ComputeGraphDataLinear(const GraphBase& /* graph */, RCP<IndexManager>& geoData,
                          const LO dofsPerNode, const int numInterpolationPoints,
                          ArrayRCP<size_t>& nnzOnRow, Array<size_t>& rowPtr,
                          Array<LO>& colIndex) const {

--- a/packages/muelu/src/Graph/StructuredAggregation/MueLu_AggregationStructuredAlgorithm_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/StructuredAggregation/MueLu_AggregationStructuredAlgorithm_kokkos_decl.hpp
@@ -108,10 +108,10 @@ namespace MueLu {
 
     /*! @brief Local aggregation. */
 
-    void BuildAggregates(const Teuchos::ParameterList& params, const LWGraph_kokkos& graph,
-                         Aggregates_kokkos& aggregates,
-                         std::vector<unsigned>& aggStat,
-                         LO& numNonAggregatedNodes) const {};
+    void BuildAggregates(const Teuchos::ParameterList& /* params */, const LWGraph_kokkos& /* graph */,
+                         Aggregates_kokkos& /* aggregates */,
+                         std::vector<unsigned>& /* aggStat */,
+                         LO& /* numNonAggregatedNodes */) const {};
 
     void BuildAggregates(const Teuchos::ParameterList& params, const LWGraph_kokkos& graph,
                          Aggregates_kokkos& aggregates,

--- a/packages/muelu/src/Graph/StructuredAggregation/MueLu_AggregationStructuredAlgorithm_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/StructuredAggregation/MueLu_AggregationStructuredAlgorithm_kokkos_def.hpp
@@ -67,7 +67,7 @@ namespace MueLu {
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   void AggregationStructuredAlgorithm_kokkos<LocalOrdinal, GlobalOrdinal, Node>::
-  BuildAggregates(const Teuchos::ParameterList& params, const LWGraph_kokkos& graph,
+  BuildAggregates(const Teuchos::ParameterList& /* params */, const LWGraph_kokkos& graph,
                   Aggregates_kokkos& aggregates,
                   Kokkos::View<unsigned*, memory_space>& aggStat,
                   LO& numNonAggregatedNodes) const {

--- a/packages/muelu/src/Graph/StructuredAggregation/coupled/MueLu_LocalLexicographicIndexManager_def.hpp
+++ b/packages/muelu/src/Graph/StructuredAggregation/coupled/MueLu_LocalLexicographicIndexManager_def.hpp
@@ -113,7 +113,7 @@ namespace MueLu {
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   void LocalLexicographicIndexManager<LocalOrdinal, GlobalOrdinal, Node>::
-  getGhostedNodesData(const RCP<const Map>fineMap,
+  getGhostedNodesData(const RCP<const Map>/* fineMap */,
                       Array<LO>& ghostedNodeCoarseLIDs,
                       Array<int>& ghostedNodeCoarsePIDs,
                       Array<GO>& ghostedNodeCoarseGIDs) const {
@@ -394,7 +394,7 @@ namespace MueLu {
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   void LocalLexicographicIndexManager<LocalOrdinal, GlobalOrdinal, Node>::
-  getFineNodeGlobalTuple(const GO myGID, GO& i, GO& j, GO& k) const {
+  getFineNodeGlobalTuple(const GO /* myGID */, GO& /* i */, GO& /* j */, GO& /* k */) const {
   }
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -423,17 +423,17 @@ namespace MueLu {
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   void LocalLexicographicIndexManager<LocalOrdinal, GlobalOrdinal, Node>::
-  getFineNodeGID(const GO i, const GO j, const GO k, GO& myGID) const {
+  getFineNodeGID(const GO /* i */, const GO /* j */, const GO /* k */, GO& /* myGID */) const {
   }
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   void LocalLexicographicIndexManager<LocalOrdinal, GlobalOrdinal, Node>::
-  getFineNodeLID(const LO i, const LO j, const LO k, LO& myLID) const {
+  getFineNodeLID(const LO /* i */, const LO /* j */, const LO /* k */, LO& /* myLID */) const {
   }
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   void LocalLexicographicIndexManager<LocalOrdinal, GlobalOrdinal, Node>::
-  getCoarseNodeGlobalTuple(const GO myGID, GO& i, GO& j, GO& k) const {
+  getCoarseNodeGlobalTuple(const GO /* myGID */, GO& /* i */, GO& /* j */, GO& /* k */) const {
   }
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -448,12 +448,12 @@ namespace MueLu {
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   void LocalLexicographicIndexManager<LocalOrdinal, GlobalOrdinal, Node>::
-  getCoarseNodeGID(const GO i, const GO j, const GO k, GO& myGID) const {
+  getCoarseNodeGID(const GO /* i */, const GO /* j */, const GO /* k */, GO& /* myGID */) const {
   }
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   void LocalLexicographicIndexManager<LocalOrdinal, GlobalOrdinal, Node>::
-  getCoarseNodeLID(const LO i, const LO j, const LO k, LO& myLID) const {
+  getCoarseNodeLID(const LO /* i */, const LO /* j */, const LO /* k */, LO& /* myLID */) const {
   }
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -485,12 +485,12 @@ namespace MueLu {
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   void LocalLexicographicIndexManager<LocalOrdinal, GlobalOrdinal, Node>::
-  getGhostedNodeFineLID(const LO i, const LO j, const LO k, LO& myLID) const {
+  getGhostedNodeFineLID(const LO /* i */, const LO /* j */, const LO /* k */, LO& /* myLID */) const {
   }
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   void LocalLexicographicIndexManager<LocalOrdinal, GlobalOrdinal, Node>::
-  getGhostedNodeCoarseLID(const LO i, const LO j, const LO k, LO& myLID) const {
+  getGhostedNodeCoarseLID(const LO /* i */, const LO /* j */, const LO /* k */, LO& /* myLID */) const {
   }
 
 } //namespace MueLu

--- a/packages/muelu/src/Graph/StructuredAggregation/uncoupled/MueLu_UncoupledIndexManager_def.hpp
+++ b/packages/muelu/src/Graph/StructuredAggregation/uncoupled/MueLu_UncoupledIndexManager_def.hpp
@@ -90,10 +90,10 @@ namespace MueLu {
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   void UncoupledIndexManager<LocalOrdinal, GlobalOrdinal, Node>::
-  getGhostedNodesData(const RCP<const Map>fineMap,
+  getGhostedNodesData(const RCP<const Map>/* fineMap */,
                       Array<LO>&  ghostedNodeCoarseLIDs,
                       Array<int>& ghostedNodeCoarsePIDs,
-                      Array<GO>&  ghostedNodeCoarseGIDs) const {
+                      Array<GO>&  /* ghostedNodeCoarseGIDs */) const {
 
     // First we allocate memory for the outputs
     ghostedNodeCoarseLIDs.resize(this->getNumLocalGhostedNodes());
@@ -151,7 +151,7 @@ namespace MueLu {
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   void UncoupledIndexManager<LocalOrdinal, GlobalOrdinal, Node>::
-  getFineNodeGlobalTuple(const GO myGID, GO& i, GO& j, GO& k) const {
+  getFineNodeGlobalTuple(const GO /* myGID */, GO& /* i */, GO& /* j */, GO& /* k */) const {
   }
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -180,17 +180,17 @@ namespace MueLu {
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   void UncoupledIndexManager<LocalOrdinal, GlobalOrdinal, Node>::
-  getFineNodeGID(const GO i, const GO j, const GO k, GO& myGID) const {
+  getFineNodeGID(const GO /* i */, const GO /* j */, const GO /* k */, GO& /* myGID */) const {
   }
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   void UncoupledIndexManager<LocalOrdinal, GlobalOrdinal, Node>::
-  getFineNodeLID(const LO i, const LO j, const LO k, LO& myLID) const {
+  getFineNodeLID(const LO /* i */, const LO /* j */, const LO /* k */, LO& /* myLID */) const {
   }
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   void UncoupledIndexManager<LocalOrdinal, GlobalOrdinal, Node>::
-  getCoarseNodeGlobalTuple(const GO myGID, GO& i, GO& j, GO& k) const {
+  getCoarseNodeGlobalTuple(const GO /* myGID */, GO& /* i */, GO& /* j */, GO& /* k */) const {
   }
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -205,12 +205,12 @@ namespace MueLu {
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   void UncoupledIndexManager<LocalOrdinal, GlobalOrdinal, Node>::
-  getCoarseNodeGID(const GO i, const GO j, const GO k, GO& myGID) const {
+  getCoarseNodeGID(const GO /* i */, const GO /* j */, const GO /* k */, GO& /* myGID */) const {
   }
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   void UncoupledIndexManager<LocalOrdinal, GlobalOrdinal, Node>::
-  getCoarseNodeLID(const LO i, const LO j, const LO k, LO& myLID) const {
+  getCoarseNodeLID(const LO /* i */, const LO /* j */, const LO /* k */, LO& /* myLID */) const {
   }
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -221,17 +221,17 @@ namespace MueLu {
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   void UncoupledIndexManager<LocalOrdinal, GlobalOrdinal, Node>::
-  getCoarseNodeFineLID(const LO i, const LO j, const LO k, LO& myLID) const {
+  getCoarseNodeFineLID(const LO /* i */, const LO /* j */, const LO /* k */, LO& /* myLID */) const {
   }
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   void UncoupledIndexManager<LocalOrdinal, GlobalOrdinal, Node>::
-  getGhostedNodeFineLID(const LO i, const LO j, const LO k, LO& myLID) const {
+  getGhostedNodeFineLID(const LO /* i */, const LO /* j */, const LO /* k */, LO& /* myLID */) const {
   }
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   void UncoupledIndexManager<LocalOrdinal, GlobalOrdinal, Node>::
-  getGhostedNodeCoarseLID(const LO i, const LO j, const LO k, LO& myLID) const {
+  getGhostedNodeCoarseLID(const LO /* i */, const LO /* j */, const LO /* k */, LO& /* myLID */) const {
   }
 
 } //namespace MueLu

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase1Algorithm_decl.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase1Algorithm_decl.hpp
@@ -92,7 +92,7 @@ namespace MueLu {
     //@{
 
     //! Constructor.
-    AggregationPhase1Algorithm(const RCP<const FactoryBase>& graphFact = Teuchos::null) { }
+    AggregationPhase1Algorithm(const RCP<const FactoryBase>& /* graphFact */ = Teuchos::null) { }
 
     //! Destructor.
     virtual ~AggregationPhase1Algorithm() { }

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase1Algorithm_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase1Algorithm_kokkos_decl.hpp
@@ -96,7 +96,7 @@ namespace MueLu {
     //@{
 
     //! Constructor.
-    AggregationPhase1Algorithm_kokkos(const RCP<const FactoryBase>& graphFact = Teuchos::null) { }
+    AggregationPhase1Algorithm_kokkos(const RCP<const FactoryBase>& /* graphFact */ = Teuchos::null) { }
 
     //! Destructor.
     virtual ~AggregationPhase1Algorithm_kokkos() { }

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2aAlgorithm_decl.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2aAlgorithm_decl.hpp
@@ -91,7 +91,7 @@ namespace MueLu {
     //@{
 
     //! Constructor.
-    AggregationPhase2aAlgorithm(const RCP<const FactoryBase>& graphFact = Teuchos::null) { }
+    AggregationPhase2aAlgorithm(const RCP<const FactoryBase>& /* graphFact */ = Teuchos::null) { }
 
     //! Destructor.
     virtual ~AggregationPhase2aAlgorithm() { }

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2aAlgorithm_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2aAlgorithm_kokkos_decl.hpp
@@ -94,7 +94,7 @@ namespace MueLu {
     //@{
 
     //! Constructor.
-    AggregationPhase2aAlgorithm_kokkos(const RCP<const FactoryBase>& graphFact = Teuchos::null) { }
+    AggregationPhase2aAlgorithm_kokkos(const RCP<const FactoryBase>& /* graphFact */ = Teuchos::null) { }
 
     //! Destructor.
     virtual ~AggregationPhase2aAlgorithm_kokkos() { }

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2bAlgorithm_decl.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2bAlgorithm_decl.hpp
@@ -88,7 +88,7 @@ namespace MueLu {
     //@{
 
     //! Constructor.
-    AggregationPhase2bAlgorithm(const RCP<const FactoryBase>& graphFact = Teuchos::null) { }
+    AggregationPhase2bAlgorithm(const RCP<const FactoryBase>& /* graphFact */ = Teuchos::null) { }
 
     //! Destructor.
     virtual ~AggregationPhase2bAlgorithm() { }

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2bAlgorithm_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2bAlgorithm_def.hpp
@@ -63,7 +63,7 @@ namespace MueLu {
   // Try to stick unaggregated nodes into a neighboring aggregate if they are
   // not already too big
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
-  void AggregationPhase2bAlgorithm<LocalOrdinal, GlobalOrdinal, Node>::BuildAggregates(const ParameterList& params, const GraphBase& graph, Aggregates& aggregates, std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes) const {
+  void AggregationPhase2bAlgorithm<LocalOrdinal, GlobalOrdinal, Node>::BuildAggregates(const ParameterList& /* params */, const GraphBase& graph, Aggregates& aggregates, std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes) const {
     Monitor m(*this, "BuildAggregates");
 
     const LO  numRows = graph.GetNodeNumVertices();

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2bAlgorithm_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2bAlgorithm_kokkos_decl.hpp
@@ -91,7 +91,7 @@ namespace MueLu {
     //@{
 
     //! Constructor.
-    AggregationPhase2bAlgorithm_kokkos(const RCP<const FactoryBase>& graphFact = Teuchos::null) { }
+    AggregationPhase2bAlgorithm_kokkos(const RCP<const FactoryBase>& /* graphFact */ = Teuchos::null) { }
 
     //! Destructor.
     virtual ~AggregationPhase2bAlgorithm_kokkos() { }

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2bAlgorithm_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2bAlgorithm_kokkos_def.hpp
@@ -65,7 +65,7 @@ namespace MueLu {
   // Try to stick unaggregated nodes into a neighboring aggregate if they are
   // not already too big
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
-  void AggregationPhase2bAlgorithm_kokkos<LocalOrdinal, GlobalOrdinal, Node>::BuildAggregates(const ParameterList& params, const LWGraph_kokkos& graph, Aggregates_kokkos& aggregates, std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes) const {
+  void AggregationPhase2bAlgorithm_kokkos<LocalOrdinal, GlobalOrdinal, Node>::BuildAggregates(const ParameterList& /* params */, const LWGraph_kokkos& graph, Aggregates_kokkos& aggregates, std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes) const {
     Monitor m(*this, "BuildAggregates");
 
     const LO  numRows = graph.GetNodeNumVertices();

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase3Algorithm_decl.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase3Algorithm_decl.hpp
@@ -85,7 +85,7 @@ namespace MueLu {
     //@{
 
     //! Constructor.
-    AggregationPhase3Algorithm(const RCP<const FactoryBase>& graphFact = Teuchos::null) { }
+    AggregationPhase3Algorithm(const RCP<const FactoryBase>& /* graphFact */ = Teuchos::null) { }
 
     //! Destructor.
     virtual ~AggregationPhase3Algorithm() { }

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase3Algorithm_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase3Algorithm_kokkos_decl.hpp
@@ -89,7 +89,7 @@ namespace MueLu {
     //@{
 
     //! Constructor.
-    AggregationPhase3Algorithm_kokkos(const RCP<const FactoryBase>& graphFact = Teuchos::null) { }
+    AggregationPhase3Algorithm_kokkos(const RCP<const FactoryBase>& /* graphFact */ = Teuchos::null) { }
 
     //! Destructor.
     virtual ~AggregationPhase3Algorithm_kokkos() { }

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_InterfaceAggregationAlgorithm_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_InterfaceAggregationAlgorithm_def.hpp
@@ -69,12 +69,12 @@
 namespace MueLu {
 
 template <class LocalOrdinal, class GlobalOrdinal, class Node>
-InterfaceAggregationAlgorithm<LocalOrdinal, GlobalOrdinal, Node>::InterfaceAggregationAlgorithm(RCP<const FactoryBase> const &graphFact)
+InterfaceAggregationAlgorithm<LocalOrdinal, GlobalOrdinal, Node>::InterfaceAggregationAlgorithm(RCP<const FactoryBase> const &/* graphFact */)
 {
 }
 
 template <class LocalOrdinal, class GlobalOrdinal, class Node>
-void InterfaceAggregationAlgorithm<LocalOrdinal, GlobalOrdinal, Node>::BuildAggregates(Teuchos::ParameterList const & params, GraphBase const & graph, Aggregates & aggregates, std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes) const {
+void InterfaceAggregationAlgorithm<LocalOrdinal, GlobalOrdinal, Node>::BuildAggregates(Teuchos::ParameterList const & /* params */, GraphBase const & graph, Aggregates & aggregates, std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes) const {
   Monitor m(*this, "BuildAggregates");
 
   const LocalOrdinal nRows = graph.GetNodeNumVertices();

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_IsolatedNodeAggregationAlgorithm_decl.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_IsolatedNodeAggregationAlgorithm_decl.hpp
@@ -89,7 +89,7 @@ namespace MueLu {
     //@{
 
     //! Constructor.
-    IsolatedNodeAggregationAlgorithm(const RCP<const FactoryBase>& graphFact = Teuchos::null) { }
+    IsolatedNodeAggregationAlgorithm(const RCP<const FactoryBase>& /* graphFact */ = Teuchos::null) { }
 
     //! Destructor.
     virtual ~IsolatedNodeAggregationAlgorithm() { }

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_IsolatedNodeAggregationAlgorithm_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_IsolatedNodeAggregationAlgorithm_def.hpp
@@ -69,7 +69,7 @@
 namespace MueLu {
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
-  void IsolatedNodeAggregationAlgorithm<LocalOrdinal, GlobalOrdinal, Node>::BuildAggregates(const ParameterList& params, const GraphBase& graph, Aggregates& aggregates, std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes) const {
+  void IsolatedNodeAggregationAlgorithm<LocalOrdinal, GlobalOrdinal, Node>::BuildAggregates(const ParameterList& /* params */, const GraphBase& graph, Aggregates& /* aggregates */, std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes) const {
     Monitor m(*this, "BuildAggregates");
 
     const LO  numRows = graph.GetNodeNumVertices();

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_IsolatedNodeAggregationAlgorithm_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_IsolatedNodeAggregationAlgorithm_kokkos_decl.hpp
@@ -91,7 +91,7 @@ namespace MueLu {
     //@{
 
     //! Constructor.
-    IsolatedNodeAggregationAlgorithm_kokkos(const RCP<const FactoryBase>& graphFact = Teuchos::null) { }
+    IsolatedNodeAggregationAlgorithm_kokkos(const RCP<const FactoryBase>& /* graphFact */ = Teuchos::null) { }
 
     //! Destructor.
     virtual ~IsolatedNodeAggregationAlgorithm_kokkos() { }

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_IsolatedNodeAggregationAlgorithm_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_IsolatedNodeAggregationAlgorithm_kokkos_def.hpp
@@ -64,7 +64,7 @@ namespace MueLu {
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   void IsolatedNodeAggregationAlgorithm_kokkos<LocalOrdinal, GlobalOrdinal, Node>::
-  BuildAggregates(const ParameterList& params, const LWGraph_kokkos& graph, Aggregates_kokkos& aggregates, std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes) const {
+  BuildAggregates(const ParameterList& /* params */, const LWGraph_kokkos& graph, Aggregates_kokkos& /* aggregates */, std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes) const {
     Monitor m(*this, "BuildAggregates");
 
     const LO  numRows = graph.GetNodeNumVertices();

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_OnePtAggregationAlgorithm_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_OnePtAggregationAlgorithm_def.hpp
@@ -69,12 +69,12 @@
 namespace MueLu {
 
 template <class LocalOrdinal, class GlobalOrdinal, class Node>
-OnePtAggregationAlgorithm<LocalOrdinal, GlobalOrdinal, Node>::OnePtAggregationAlgorithm(RCP<const FactoryBase> const &graphFact)
+OnePtAggregationAlgorithm<LocalOrdinal, GlobalOrdinal, Node>::OnePtAggregationAlgorithm(RCP<const FactoryBase> const &/* graphFact */)
 {
 }
 
 template <class LocalOrdinal, class GlobalOrdinal, class Node>
-void OnePtAggregationAlgorithm<LocalOrdinal, GlobalOrdinal, Node>::BuildAggregates(Teuchos::ParameterList const & params, GraphBase const & graph, Aggregates & aggregates, std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes) const {
+void OnePtAggregationAlgorithm<LocalOrdinal, GlobalOrdinal, Node>::BuildAggregates(Teuchos::ParameterList const & /* params */, GraphBase const & graph, Aggregates & aggregates, std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes) const {
   Monitor m(*this, "BuildAggregates");
 
   const LocalOrdinal nRows = graph.GetNodeNumVertices();

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_OnePtAggregationAlgorithm_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_OnePtAggregationAlgorithm_kokkos_def.hpp
@@ -63,12 +63,12 @@
 namespace MueLu {
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
-  OnePtAggregationAlgorithm_kokkos<LocalOrdinal, GlobalOrdinal, Node>::OnePtAggregationAlgorithm_kokkos(RCP<const FactoryBase> const &graphFact)
+  OnePtAggregationAlgorithm_kokkos<LocalOrdinal, GlobalOrdinal, Node>::OnePtAggregationAlgorithm_kokkos(RCP<const FactoryBase> const &/* graphFact */)
   {
   }
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
-  void OnePtAggregationAlgorithm_kokkos<LocalOrdinal, GlobalOrdinal, Node>::BuildAggregates(Teuchos::ParameterList const & params, LWGraph_kokkos const & graph, Aggregates_kokkos & aggregates, std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes) const {
+  void OnePtAggregationAlgorithm_kokkos<LocalOrdinal, GlobalOrdinal, Node>::BuildAggregates(Teuchos::ParameterList const & /* params */, LWGraph_kokkos const & graph, Aggregates_kokkos & aggregates, std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes) const {
     Monitor m(*this, "BuildAggregates");
 
     const LocalOrdinal nRows = graph.GetNodeNumVertices();

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_PreserveDirichletAggregationAlgorithm_decl.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_PreserveDirichletAggregationAlgorithm_decl.hpp
@@ -92,7 +92,7 @@ namespace MueLu {
     //@{
 
     //! Constructor.
-    PreserveDirichletAggregationAlgorithm(const RCP<const FactoryBase>& graphFact = Teuchos::null) { }
+    PreserveDirichletAggregationAlgorithm(const RCP<const FactoryBase>& /* graphFact */ = Teuchos::null) { }
 
     //! Destructor.
     virtual ~PreserveDirichletAggregationAlgorithm() { }

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_PreserveDirichletAggregationAlgorithm_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_PreserveDirichletAggregationAlgorithm_kokkos_decl.hpp
@@ -96,7 +96,7 @@ namespace MueLu {
     //@{
 
     //! Constructor.
-    PreserveDirichletAggregationAlgorithm_kokkos(const RCP<const FactoryBase>& graphFact = Teuchos::null) { }
+    PreserveDirichletAggregationAlgorithm_kokkos(const RCP<const FactoryBase>& /* graphFact */ = Teuchos::null) { }
 
     //! Destructor.
     virtual ~PreserveDirichletAggregationAlgorithm_kokkos() { }

--- a/packages/muelu/src/Graph/UserAggregation/MueLu_UserAggregationFactory_def.hpp
+++ b/packages/muelu/src/Graph/UserAggregation/MueLu_UserAggregationFactory_def.hpp
@@ -74,7 +74,7 @@ namespace MueLu {
   }
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
-  void UserAggregationFactory<LocalOrdinal, GlobalOrdinal, Node>::DeclareInput(Level& currentLevel) const { }
+  void UserAggregationFactory<LocalOrdinal, GlobalOrdinal, Node>::DeclareInput(Level& /* currentLevel */) const { }
 
   /**
    * The function reads aggregate information from a file.

--- a/packages/muelu/src/Interface/MueLu_FactoryFactory_decl.hpp
+++ b/packages/muelu/src/Interface/MueLu_FactoryFactory_decl.hpp
@@ -706,7 +706,7 @@ namespace MueLu {
     }
 #endif
 
-    RCP<FactoryBase> BuildDirectSolver(const Teuchos::ParameterList& paramList, const FactoryMap& factoryMapIn, const FactoryManagerMap& factoryManagersIn) const {
+    RCP<FactoryBase> BuildDirectSolver(const Teuchos::ParameterList& paramList, const FactoryMap& /* factoryMapIn */, const FactoryManagerMap& /* factoryManagersIn */) const {
       if (paramList.begin() == paramList.end())
         return rcp(new SmootherFactory(rcp(new DirectSolver()), Teuchos::null));
 
@@ -807,7 +807,7 @@ namespace MueLu {
     }
 #endif
 
-    RCP<FactoryBase> BuildBlockedDirectSolver(const Teuchos::ParameterList& paramList, const FactoryMap& factoryMapIn, const FactoryManagerMap& factoryManagersIn) const {
+    RCP<FactoryBase> BuildBlockedDirectSolver(const Teuchos::ParameterList& /* paramList */, const FactoryMap& /* factoryMapIn */, const FactoryManagerMap& /* factoryManagersIn */) const {
       //if (paramList.begin() == paramList.end())
         return rcp(new SmootherFactory(rcp(new BlockedDirectSolver())));
 

--- a/packages/muelu/src/Interface/MueLu_HierarchyManager.hpp
+++ b/packages/muelu/src/Interface/MueLu_HierarchyManager.hpp
@@ -277,11 +277,11 @@ namespace MueLu {
   protected: //TODO: access function
 
     //! Setup Matrix object
-    virtual void SetupOperator(Operator& Op) const { }
+    virtual void SetupOperator(Operator& /* Op */) const { }
 
     //! Setup extra data
     // TODO: merge with SetupMatrix ?
-    virtual void SetupExtra(Hierarchy& H) const { }
+    virtual void SetupExtra(Hierarchy& /* H */) const { }
 
     // TODO this was private
     // Used in SetupHierarchy() to access levelManagers_

--- a/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
+++ b/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
@@ -849,7 +849,7 @@ namespace MueLu {
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   UpdateFactoryManager_CoarseSolvers(ParameterList& paramList, const ParameterList& defaultList,
-                                     FactoryManager& manager, int levelID, std::vector<keep_pair>& keeps) const
+                                     FactoryManager& manager, int /* levelID */, std::vector<keep_pair>& /* keeps */) const
   {
     // FIXME: should custom coarse solver check default list too?
     bool isCustomCoarseSolver =
@@ -1033,7 +1033,7 @@ namespace MueLu {
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   UpdateFactoryManager_RAP(ParameterList& paramList, const ParameterList& defaultList, FactoryManager& manager,
-                           int levelID, std::vector<keep_pair>& keeps) const
+                           int /* levelID */, std::vector<keep_pair>& keeps) const
   {
     if (paramList.isParameter("A") && !paramList.get<RCP<Matrix> >("A").is_null()) {
       // We have user matrix A
@@ -1141,8 +1141,8 @@ namespace MueLu {
   // =====================================================================================================
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  UpdateFactoryManager_Coordinates(ParameterList& paramList, const ParameterList& defaultList,
-                                   FactoryManager& manager, int levelID, std::vector<keep_pair>& keeps) const
+  UpdateFactoryManager_Coordinates(ParameterList& paramList, const ParameterList& /* defaultList */,
+                                   FactoryManager& manager, int /* levelID */, std::vector<keep_pair>& /* keeps */) const
   {
     bool have_userCO = false;
     if (paramList.isParameter("Coordinates") && !paramList.get<RCP<MultiVector> >("Coordinates").is_null())
@@ -1175,7 +1175,7 @@ namespace MueLu {
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   UpdateFactoryManager_Restriction(ParameterList& paramList, const ParameterList& defaultList,
-                                   FactoryManager& manager, int levelID, std::vector<keep_pair>& keeps) const
+                                   FactoryManager& manager, int /* levelID */, std::vector<keep_pair>& /* keeps */) const
   {
     MUELU_SET_VAR_2LIST(paramList, defaultList, "multigrid algorithm", std::string, multigridAlgo);
     bool have_userR = false;
@@ -1425,8 +1425,8 @@ namespace MueLu {
   // =====================================================================================================
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  UpdateFactoryManager_Nullspace(ParameterList& paramList, const ParameterList& defaultList, FactoryManager& manager,
-                                 int levelID, std::vector<keep_pair>& keeps, RCP<Factory> & nullSpaceFactory) const
+  UpdateFactoryManager_Nullspace(ParameterList& paramList, const ParameterList& /* defaultList */, FactoryManager& manager,
+                                 int /* levelID */, std::vector<keep_pair>& /* keeps */, RCP<Factory> & nullSpaceFactory) const
   {
     // Nullspace
     MUELU_KOKKOS_FACTORY(nullSpace, NullspaceFactory, NullspaceFactory_kokkos);
@@ -1448,7 +1448,7 @@ namespace MueLu {
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   UpdateFactoryManager_SemiCoarsen(ParameterList& paramList, const ParameterList& defaultList, FactoryManager& manager,
-                                   int levelID, std::vector<keep_pair>& keeps) const
+                                   int /* levelID */, std::vector<keep_pair>& /* keeps */) const
   {
     // === Semi-coarsening ===
     RCP<SemiCoarsenPFactory>  semicoarsenFactory = Teuchos::null;
@@ -1559,7 +1559,7 @@ namespace MueLu {
   // =====================================================================================================
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  UpdateFactoryManager_SA(ParameterList& paramList, const ParameterList& defaultList, FactoryManager& manager, int levelID, std::vector<keep_pair>& keeps) const {
+  UpdateFactoryManager_SA(ParameterList& paramList, const ParameterList& defaultList, FactoryManager& manager, int /* levelID */, std::vector<keep_pair>& keeps) const {
     // Smoothed aggregation
     MUELU_KOKKOS_FACTORY(P, SaPFactory, SaPFactory_kokkos);
     ParameterList Pparams;
@@ -1610,7 +1610,7 @@ namespace MueLu {
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   UpdateFactoryManager_Emin(ParameterList& paramList, const ParameterList& defaultList, FactoryManager& manager,
-                            int levelID, std::vector<keep_pair>& keeps) const
+                            int /* levelID */, std::vector<keep_pair>& /* keeps */) const
   {
     MUELU_SET_VAR_2LIST(paramList, defaultList, "emin: pattern", std::string, patternType);
     MUELU_SET_VAR_2LIST(paramList, defaultList, "reuse: type", std::string, reuseType);
@@ -1651,8 +1651,8 @@ namespace MueLu {
   // =====================================================================================================
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  UpdateFactoryManager_PG(ParameterList& paramList, const ParameterList& defaultList, FactoryManager& manager,
-                          int levelID, std::vector<keep_pair>& keeps) const
+  UpdateFactoryManager_PG(ParameterList& /* paramList */, const ParameterList& /* defaultList */, FactoryManager& manager,
+                          int /* levelID */, std::vector<keep_pair>& /* keeps */) const
   {
     TEUCHOS_TEST_FOR_EXCEPTION(this->implicitTranspose_, Exceptions::RuntimeError,
         "Implicit transpose not supported with Petrov-Galerkin smoothed transfer operators: Set \"transpose: use implicit\" to false!\n" \
@@ -1671,14 +1671,17 @@ namespace MueLu {
   // =====================================================================================================
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void ParameterListInterpreter<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  UpdateFactoryManager_Matlab(ParameterList& paramList, const ParameterList& defaultList, FactoryManager& manager,
-                              int levelID, std::vector<keep_pair>& keeps) const {
+  UpdateFactoryManager_Matlab(ParameterList& paramList, const ParameterList& /* defaultList */, FactoryManager& manager,
+                              int /* levelID */, std::vector<keep_pair>& /* keeps */) const {
 #ifdef HAVE_MUELU_MATLAB
     ParameterList Pparams = paramList.sublist("transfer: params");
     auto P = rcp(new TwoLevelMatlabFactory());
     P->SetParameterList(Pparams);
     P->SetFactory("P", manager.GetFactory("Ptent"));
     manager.SetFactory("P", P);
+#else
+    (void)paramList;
+    (void)manager;
 #endif
   }
 

--- a/packages/muelu/src/Misc/MueLu_BlockedCoordinatesTransferFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_BlockedCoordinatesTransferFactory_def.hpp
@@ -70,7 +70,7 @@ namespace MueLu {
   }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-  void BlockedCoordinatesTransferFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::DeclareInput(Level& fineLevel, Level& coarseLevel) const {
+  void BlockedCoordinatesTransferFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::DeclareInput(Level& /* fineLevel */, Level& coarseLevel) const {
     Input(coarseLevel, "CoarseMap");
 
     // Make sure the Level knows I need these sub-Factories
@@ -86,7 +86,7 @@ namespace MueLu {
   }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-  void BlockedCoordinatesTransferFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(Level & fineLevel, Level &coarseLevel) const {
+  void BlockedCoordinatesTransferFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(Level & /* fineLevel */, Level &coarseLevel) const {
     FactoryMonitor m(*this, "Build", coarseLevel);
 
     typedef Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::magnitudeType,LO,GO,NO> dMV;

--- a/packages/muelu/src/Misc/MueLu_DemoFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_DemoFactory_def.hpp
@@ -63,13 +63,13 @@ namespace MueLu {
   DemoFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::~DemoFactory() {}
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-  void DemoFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::DeclareInput(Level &currentLevel) const {
+  void DemoFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::DeclareInput(Level &/* currentLevel */) const {
     // TODO: declare input for factory
     //Input(currentLevel, varName_);
   }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-  void DemoFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(Level & currentLevel) const {
+  void DemoFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(Level & /* currentLevel */) const {
     // TODO: implement factory
   }
 

--- a/packages/muelu/src/Misc/MueLu_LineDetectionFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_LineDetectionFactory_def.hpp
@@ -253,7 +253,7 @@ namespace MueLu {
   }
 
   template <class Scalar,class LocalOrdinal, class GlobalOrdinal, class Node>
-  LocalOrdinal LineDetectionFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::ML_compute_line_info(LocalOrdinal LayerId[], LocalOrdinal VertLineId[], LocalOrdinal Ndof, LocalOrdinal DofsPerNode, LocalOrdinal MeshNumbering, LocalOrdinal NumNodesPerVertLine, Scalar *xvals, Scalar *yvals, Scalar *zvals, const Teuchos::Comm<int>& comm) const {
+  LocalOrdinal LineDetectionFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::ML_compute_line_info(LocalOrdinal LayerId[], LocalOrdinal VertLineId[], LocalOrdinal Ndof, LocalOrdinal DofsPerNode, LocalOrdinal MeshNumbering, LocalOrdinal NumNodesPerVertLine, Scalar *xvals, Scalar *yvals, Scalar *zvals, const Teuchos::Comm<int>& /* comm */) const {
 
     LO    Nnodes, NVertLines, MyNode;
     LO    NumCoords, next; //, subindex, subnext;

--- a/packages/muelu/src/MueCentral/MueLu_Describable.cpp
+++ b/packages/muelu/src/MueCentral/MueLu_Describable.cpp
@@ -52,7 +52,7 @@ namespace MueLu {
 
     Describable::~Describable() { }
 
-    void Describable::describe(Teuchos::FancyOStream &out_arg, const VerbLevel verbLevel) const {
+    void Describable::describe(Teuchos::FancyOStream &out_arg, const VerbLevel /* verbLevel */) const {
       Teuchos::RCP<Teuchos::FancyOStream> out = rcp(&out_arg,false); //JG: no idea why we have to do that, but it's how Teuchos::Describable::describe() is implemented
       Teuchos::OSTab tab(out);
       *out << this->description() << std::endl;

--- a/packages/muelu/src/MueCentral/MueLu_NoFactory.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_NoFactory.hpp
@@ -79,7 +79,7 @@ namespace MueLu {
     void CallBuild(Level& requestedLevel) const;
 
     //!
-    void CallDeclareInput(Level& requestedLevel) const { }
+    void CallDeclareInput(Level& /* requestedLevel */) const { }
 
     //@}
 

--- a/packages/muelu/src/MueCentral/MueLu_TopRAPFactory_def.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_TopRAPFactory_def.hpp
@@ -35,7 +35,7 @@ namespace MueLu {
   { }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-  TopRAPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::TopRAPFactory(RCP<const FactoryManagerBase> parentFactoryManagerFine, RCP<const FactoryManagerBase> parentFactoryManagerCoarse) :
+  TopRAPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::TopRAPFactory(RCP<const FactoryManagerBase> /* parentFactoryManagerFine */, RCP<const FactoryManagerBase> parentFactoryManagerCoarse) :
     PFact_ (parentFactoryManagerCoarse->GetFactory("P")),
     RFact_ (parentFactoryManagerCoarse->GetFactory("R")),
     AcFact_(parentFactoryManagerCoarse->GetFactory("A"))
@@ -45,14 +45,14 @@ namespace MueLu {
   TopRAPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::~TopRAPFactory() { }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-  void TopRAPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::DeclareInput(Level & fineLevel, Level & coarseLevel) const {
+  void TopRAPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::DeclareInput(Level & /* fineLevel */, Level & coarseLevel) const {
     if (PFact_  != Teuchos::null)                                       coarseLevel.DeclareInput("P", PFact_.get());
     if (RFact_  != Teuchos::null)                                       coarseLevel.DeclareInput("R", RFact_.get());
     if ((AcFact_ != Teuchos::null) && (AcFact_ != NoFactory::getRCP())) coarseLevel.DeclareInput("A", AcFact_.get());
   }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-  void TopRAPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(Level & fineLevel, Level & coarseLevel) const {
+  void TopRAPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(Level & /* fineLevel */, Level & coarseLevel) const {
     if ((PFact_ != Teuchos::null) && (PFact_ != NoFactory::getRCP())) {
       RCP<Operator> oP = coarseLevel.Get<RCP<Operator> >("P", PFact_.get());
       RCP<Matrix>    P = rcp_dynamic_cast<Matrix>(oP);

--- a/packages/muelu/src/MueCentral/MueLu_VariableContainer.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_VariableContainer.hpp
@@ -91,7 +91,7 @@ namespace MueLu {
 
     template<typename T>
     struct Getter {
-      static T& get(DataBase* data_, DataBase*& datah_) {
+      static T& get(DataBase* data_, DataBase*& /* datah_ */) {
         if ((data_ == NULL) || (data_->type() != typeid(T))) // NVR added guard to avoid determining typeName unless we will use it
         {
           const std::string typeName = Teuchos::TypeNameTraits<T>::name(); // calls Teuchos::demangleName(), which can be expensive

--- a/packages/muelu/src/Rebalancing/MueLu_RebalanceAcFactory_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RebalanceAcFactory_def.hpp
@@ -75,13 +75,13 @@ namespace MueLu {
   }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-  void RebalanceAcFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::DeclareInput(Level &fineLevel, Level &coarseLevel) const {
+  void RebalanceAcFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::DeclareInput(Level &/* fineLevel */, Level &coarseLevel) const {
     Input(coarseLevel, "A");
     Input(coarseLevel, "Importer");
   }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-  void RebalanceAcFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(Level &fineLevel, Level &coarseLevel) const {
+  void RebalanceAcFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(Level &/* fineLevel */, Level &coarseLevel) const {
     FactoryMonitor m(*this, "Computing Ac", coarseLevel);
     
     RCP<Matrix> originalAc = Get< RCP<Matrix> >(coarseLevel, "A");

--- a/packages/muelu/src/Rebalancing/MueLu_RebalanceTransferFactory_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_RebalanceTransferFactory_def.hpp
@@ -102,7 +102,7 @@ namespace MueLu {
   }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-  void RebalanceTransferFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::DeclareInput(Level& fineLevel, Level& coarseLevel) const {
+  void RebalanceTransferFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::DeclareInput(Level& /* fineLevel */, Level& coarseLevel) const {
     const ParameterList& pL = GetParameterList();
 
     if (pL.get<std::string>("type") == "Interpolation") {

--- a/packages/muelu/src/Rebalancing/MueLu_ZoltanInterface_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_ZoltanInterface_def.hpp
@@ -221,8 +221,8 @@ namespace MueLu {
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void ZoltanInterface<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  GetLocalNumberOfNonzeros(void *data, int NumGidEntries, int NumLidEntries, ZOLTAN_ID_PTR gids,
-                           ZOLTAN_ID_PTR lids, int wgtDim, float *weights, int *ierr) {
+  GetLocalNumberOfNonzeros(void *data, int NumGidEntries, int /* NumLidEntries */, ZOLTAN_ID_PTR gids,
+                           ZOLTAN_ID_PTR /* lids */, int /* wgtDim */, float *weights, int *ierr) {
     if (data == NULL || NumGidEntries < 1) {
       *ierr = ZOLTAN_FATAL;
       return;
@@ -280,8 +280,8 @@ namespace MueLu {
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void ZoltanInterface<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  GetProblemGeometry(void *data, int numGIDEntries, int numLIDEntries, int numObjectIDs,
-                     ZOLTAN_ID_PTR gids, ZOLTAN_ID_PTR lids, int dim, double *coordinates, int *ierr)
+  GetProblemGeometry(void *data, int /* numGIDEntries */, int /* numLIDEntries */, int numObjectIDs,
+                     ZOLTAN_ID_PTR /* gids */, ZOLTAN_ID_PTR /* lids */, int dim, double *coordinates, int *ierr)
   {
     if (data == NULL) {
       *ierr = ZOLTAN_FATAL;

--- a/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_IndefBlockedDiagonalSmoother_def.hpp
+++ b/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_IndefBlockedDiagonalSmoother_def.hpp
@@ -209,7 +209,7 @@ namespace MueLu {
   }
 
   template <class Scalar,class LocalOrdinal, class GlobalOrdinal, class Node>
-  void IndefBlockedDiagonalSmoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Apply(MultiVector& X, const MultiVector& B, bool InitialGuessIsZero) const
+  void IndefBlockedDiagonalSmoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Apply(MultiVector& X, const MultiVector& B, bool /* InitialGuessIsZero */) const
   {
     TEUCHOS_TEST_FOR_EXCEPTION(SmootherPrototype::IsSetup() == false, Exceptions::RuntimeError, "MueLu::IndefBlockedDiagonalSmoother::Apply(): Setup() has not been called");
 

--- a/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_TekoSmoother_decl.hpp
+++ b/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_TekoSmoother_decl.hpp
@@ -278,7 +278,7 @@ namespace MueLu {
     @param B right-hand side
     @param InitialGuessIsZero This option has no effect.
     */
-    void Apply(MultiVector& X, const MultiVector& B, bool InitialGuessIsZero = false) const {
+    void Apply(MultiVector& X, const MultiVector& B, bool /* InitialGuessIsZero */ = false) const {
       TEUCHOS_TEST_FOR_EXCEPTION(this->IsSetup() == false, Exceptions::RuntimeError,
                                  "MueLu::TekoSmoother::Apply(): Setup() has not been called");
 

--- a/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_UzawaSmoother_def.hpp
+++ b/packages/muelu/src/Smoothers/BlockedSmoothers/MueLu_UzawaSmoother_def.hpp
@@ -191,7 +191,7 @@ namespace MueLu {
   }
 
   template <class Scalar,class LocalOrdinal, class GlobalOrdinal, class Node>
-  void UzawaSmoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Apply(MultiVector& X, const MultiVector& B, bool InitialGuessIsZero) const
+  void UzawaSmoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Apply(MultiVector& X, const MultiVector& B, bool /* InitialGuessIsZero */) const
   {
     TEUCHOS_TEST_FOR_EXCEPTION(SmootherPrototype::IsSetup() == false, Exceptions::RuntimeError, "MueLu::UzawaSmoother::Apply(): Setup() has not been called");
 

--- a/packages/muelu/src/Smoothers/MueLu_Amesos2Smoother_def.hpp
+++ b/packages/muelu/src/Smoothers/MueLu_Amesos2Smoother_def.hpp
@@ -174,7 +174,7 @@ namespace MueLu {
   }
 
   template <class Scalar,class LocalOrdinal, class GlobalOrdinal, class Node>
-  void Amesos2Smoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Apply(MultiVector& X, const MultiVector& B, bool InitialGuessIsZero) const {
+  void Amesos2Smoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Apply(MultiVector& X, const MultiVector& B, bool /* InitialGuessIsZero */) const {
     TEUCHOS_TEST_FOR_EXCEPTION(SmootherPrototype::IsSetup() == false, Exceptions::RuntimeError, "MueLu::Amesos2Smoother::Apply(): Setup() has not been called");
 
     RCP<Tpetra_MultiVector> tX, tB;

--- a/packages/muelu/src/Smoothers/MueLu_AmesosSmoother.hpp
+++ b/packages/muelu/src/Smoothers/MueLu_AmesosSmoother.hpp
@@ -144,7 +144,7 @@ namespace MueLu {
         @param B right-hand side
         @param InitialGuessIsZero This option has no effect with this smoother
     */
-    void Apply(MultiVector& X, const MultiVector& B, bool InitialGuessIsZero = false) const;
+    void Apply(MultiVector& X, const MultiVector& B, bool /* InitialGuessIsZero */ = false) const;
 
     //@}
 
@@ -195,7 +195,7 @@ namespace MueLu {
   //! This function simplifies the usage of AmesosSmoother objects inside of templates as templates do not have to be specialized for <double, int, int> (see DirectSolver for an example).
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   RCP<MueLu::SmootherPrototype<Scalar, LocalOrdinal, GlobalOrdinal, Node> >
-  GetAmesosSmoother (const std::string& type = "", const Teuchos::ParameterList& paramList = Teuchos::ParameterList ()) {
+  GetAmesosSmoother (const std::string& /* type */ = "", const Teuchos::ParameterList& /* paramList */ = Teuchos::ParameterList ()) {
     TEUCHOS_TEST_FOR_EXCEPTION(true, Exceptions::RuntimeError,
                                "AmesosSmoother cannot be used with Scalar != double, LocalOrdinal != int, GlobalOrdinal != int");
     TEUCHOS_UNREACHABLE_RETURN(Teuchos::null);

--- a/packages/muelu/src/Smoothers/MueLu_Ifpack2Smoother_def.hpp
+++ b/packages/muelu/src/Smoothers/MueLu_Ifpack2Smoother_def.hpp
@@ -224,7 +224,7 @@ namespace MueLu {
   }
 
   template <class Scalar,class LocalOrdinal, class GlobalOrdinal, class Node>
-  void Ifpack2Smoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::SetupSchwarz(Level& currentLevel) {
+  void Ifpack2Smoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::SetupSchwarz(Level& /* currentLevel */) {
     typedef Tpetra::RowMatrix<SC,LO,GO,NO> tRowMatrix;
 
     bool reusePreconditioner = false;
@@ -626,7 +626,7 @@ namespace MueLu {
   }
 
   template <class Scalar,class LocalOrdinal, class GlobalOrdinal, class Node>
-  void Ifpack2Smoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::SetupGeneric(Level& currentLevel) {
+  void Ifpack2Smoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::SetupGeneric(Level& /* currentLevel */) {
     typedef Tpetra::RowMatrix<SC,LO,GO,NO> tRowMatrix;
 
     RCP<BlockedCrsMatrix> bA = rcp_dynamic_cast<BlockedCrsMatrix>(A_);

--- a/packages/muelu/src/Smoothers/MueLu_IfpackSmoother.hpp
+++ b/packages/muelu/src/Smoothers/MueLu_IfpackSmoother.hpp
@@ -204,9 +204,9 @@ namespace MueLu {
   //! This function simplifies the usage of IfpackSmoother objects inside of templates as templates do not have to be specialized for <double, int, int> (see DirectSolver for an example).
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   RCP<MueLu::SmootherPrototype<Scalar, LocalOrdinal, GlobalOrdinal, Node> >
-  GetIfpackSmoother (const std::string& type = "",
-                     const Teuchos::ParameterList& paramList = Teuchos::ParameterList (),
-                     const LocalOrdinal& overlap = 0)
+  GetIfpackSmoother (const std::string& /* type */ = "",
+                     const Teuchos::ParameterList& /* paramList */ = Teuchos::ParameterList (),
+                     const LocalOrdinal& /* overlap */ = 0)
   {
     TEUCHOS_TEST_FOR_EXCEPTION(true, Exceptions::RuntimeError, "IfpackSmoother cannot be used with Scalar != double, LocalOrdinal != int, GlobalOrdinal != int");
     TEUCHOS_UNREACHABLE_RETURN(Teuchos::null);

--- a/packages/muelu/src/Smoothers/MueLu_MergedSmoother_def.hpp
+++ b/packages/muelu/src/Smoothers/MueLu_MergedSmoother_def.hpp
@@ -123,7 +123,7 @@ namespace MueLu {
   }
 
   template <class Scalar,class LocalOrdinal, class GlobalOrdinal, class Node>
-  void MergedSmoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::print(Teuchos::FancyOStream& out, const VerbLevel verbLevel) const {
+  void MergedSmoother<Scalar, LocalOrdinal, GlobalOrdinal, Node>::print(Teuchos::FancyOStream& /* out */, const VerbLevel /* verbLevel */) const {
     throw Exceptions::NotImplemented("MueLu::MergedSmoother<>::Print() is not implemented");
   }
 

--- a/packages/muelu/src/Smoothers/MueLu_SmootherPrototype_decl.hpp
+++ b/packages/muelu/src/Smoothers/MueLu_SmootherPrototype_decl.hpp
@@ -125,7 +125,7 @@ namespace MueLu {
 
     //! @name Implements FactoryBase interface
     //@{
-    virtual void CallBuild(Level & requestedLevel) const {
+    virtual void CallBuild(Level & /* requestedLevel */) const {
       TEUCHOS_TEST_FOR_EXCEPT(true);
     }
 

--- a/packages/muelu/src/Transfers/BlackBox/MueLu_BlackBoxPFactory_def.hpp
+++ b/packages/muelu/src/Transfers/BlackBox/MueLu_BlackBoxPFactory_def.hpp
@@ -96,7 +96,7 @@ namespace MueLu {
 
   template <class Scalar,class LocalOrdinal, class GlobalOrdinal, class Node>
   void BlackBoxPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::DeclareInput(Level& fineLevel,
-                                                                                 Level& coarseLevel)
+                                                                                 Level& /* coarseLevel */)
     const {
     Input(fineLevel, "A");
     Input(fineLevel, "Nullspace");
@@ -1358,14 +1358,14 @@ namespace MueLu {
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void BlackBoxPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   ComputeLocalEntries(const RCP<const Matrix>& Aghost, const Array<LO> coarseRate,
-                      const Array<LO> endRate, const LO BlkSize, const Array<LO> elemInds,
-                      const Array<LO> lCoarseElementsPerDir, const LO numDimensions,
-                      const Array<LO> lFineNodesPerDir, const Array<GO> gFineNodesPerDir,
-                      const Array<GO> gIndices, const Array<LO> lCoarseNodesPerDir,
+                      const Array<LO> /* endRate */, const LO BlkSize, const Array<LO> elemInds,
+                      const Array<LO> /* lCoarseElementsPerDir */, const LO numDimensions,
+                      const Array<LO> lFineNodesPerDir, const Array<GO> /* gFineNodesPerDir */,
+                      const Array<GO> /* gIndices */, const Array<LO> /* lCoarseNodesPerDir */,
                       const Array<bool> ghostInterface, const Array<int> elementFlags,
-                      const std::string stencilType, const std::string blockStrategy,
+                      const std::string stencilType, const std::string /* blockStrategy */,
                       const Array<LO> elementNodesPerDir, const LO numNodesInElement,
-                      const Array<GO> colGIDs,
+                      const Array<GO> /* colGIDs */,
                       Teuchos::SerialDenseMatrix<LO,SC>& Pi, Teuchos::SerialDenseMatrix<LO,SC>& Pf,
                       Teuchos::SerialDenseMatrix<LO,SC>& Pe, Array<LO>& dofType,
                       Array<LO>& lDofInd) const {
@@ -1670,7 +1670,7 @@ namespace MueLu {
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void BlackBoxPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  CollapseStencil(const int type, const int orientation, const int collapseFlags[3],
+  CollapseStencil(const int type, const int orientation, const int /* collapseFlags */[3],
                   Array<SC>& stencil) const {
 
     if(type == 2) {// Face stencil collapse
@@ -1750,8 +1750,8 @@ namespace MueLu {
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void BlackBoxPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  FormatStencil(const LO BlkSize, const Array<bool> ghostInterface, const LO ie, const LO je,
-                const LO ke, const ArrayView<const SC> rowValues,const Array<LO> elementNodesPerDir,
+  FormatStencil(const LO BlkSize, const Array<bool> /* ghostInterface */, const LO /* ie */, const LO /* je */,
+                const LO /* ke */, const ArrayView<const SC> rowValues,const Array<LO> /* elementNodesPerDir */,
                 const int collapseFlags[3], const std::string stencilType, Array<SC>& stencil)
     const {
 
@@ -1945,7 +1945,7 @@ namespace MueLu {
                 const typename Teuchos::Array<LocalOrdinal>::iterator& first1,
                 const typename Teuchos::Array<LocalOrdinal>::iterator& last1,
                 const typename Teuchos::Array<LocalOrdinal>::iterator& first2,
-                const typename Teuchos::Array<LocalOrdinal>::iterator& last2) const
+                const typename Teuchos::Array<LocalOrdinal>::iterator& /* last2 */) const
   {
     typedef typename std::iterator_traits<typename Teuchos::Array<LocalOrdinal>::iterator>::difference_type DT;
     DT n = last1 - first1;

--- a/packages/muelu/src/Transfers/BlockedTransfers/MueLu_BlockedPFactory_def.hpp
+++ b/packages/muelu/src/Transfers/BlockedTransfers/MueLu_BlockedPFactory_def.hpp
@@ -103,7 +103,7 @@ namespace MueLu {
   }
 
   template <class Scalar,class LocalOrdinal, class GlobalOrdinal, class Node>
-  void BlockedPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::BuildP(Level& fineLevel, Level& coarseLevel) const
+  void BlockedPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::BuildP(Level& /* fineLevel */, Level& /* coarseLevel */) const
   { }
 
   template <class Scalar,class LocalOrdinal, class GlobalOrdinal, class Node>

--- a/packages/muelu/src/Transfers/Energy-Minimization/MueLu_Constraint_def.hpp
+++ b/packages/muelu/src/Transfers/Energy-Minimization/MueLu_Constraint_def.hpp
@@ -67,7 +67,7 @@
 namespace MueLu {
 
   template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-  void Constraint<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Setup(const MultiVector& B, const MultiVector& Bc, RCP<const CrsGraph> Ppattern) {
+  void Constraint<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Setup(const MultiVector& /* B */, const MultiVector& Bc, RCP<const CrsGraph> Ppattern) {
     const size_t NSDim = Bc.getNumVectors();
 
     Ppattern_ = Ppattern;

--- a/packages/muelu/src/Transfers/GeneralGeometric/MueLu_GeneralGeometricPFactory_def.hpp
+++ b/packages/muelu/src/Transfers/GeneralGeometric/MueLu_GeneralGeometricPFactory_def.hpp
@@ -105,7 +105,7 @@ namespace MueLu {
 
   template <class Scalar,class LocalOrdinal, class GlobalOrdinal, class Node>
   void GeneralGeometricPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  DeclareInput(Level& fineLevel, Level& coarseLevel) const {
+  DeclareInput(Level& fineLevel, Level& /* coarseLevel */) const {
     Input(fineLevel, "A");
     Input(fineLevel, "Nullspace");
     Input(fineLevel, "Coordinates");
@@ -329,7 +329,7 @@ namespace MueLu {
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void GeneralGeometricPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  MeshLayoutInterface(const int interpolationOrder, const LO blkSize, RCP<const Map> fineCoordsMap,
+  MeshLayoutInterface(const int /* interpolationOrder */, const LO /* blkSize */, RCP<const Map> fineCoordsMap,
                       RCP<GeometricData> myGeo, RCP<NodesIDs> ghostedCoarseNodes,
                       Array<Array<GO> >& lCoarseNodesGIDs) const{
     // The goal here is to produce maps that globally labels the mesh lexicographically.
@@ -564,7 +564,7 @@ namespace MueLu {
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void GeneralGeometricPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  GetCoarsePoints(const int interpolationOrder, const LO blkSize, RCP<const Map> fineCoordsMap,
+  GetCoarsePoints(const int /* interpolationOrder */, const LO /* blkSize */, RCP<const Map> fineCoordsMap,
                   RCP<GeometricData> myGeo, RCP<NodesIDs> ghostedCoarseNodes,
                   Array<Array<GO> >& lCoarseNodesGIDs) const{
     // Assuming perfect global lexicographic ordering of the mesh, produce two arrays:
@@ -1795,7 +1795,7 @@ namespace MueLu {
                 const typename Teuchos::Array<LocalOrdinal>::iterator& first1,
                 const typename Teuchos::Array<LocalOrdinal>::iterator& last1,
                 const typename Teuchos::Array<LocalOrdinal>::iterator& first2,
-                const typename Teuchos::Array<LocalOrdinal>::iterator& last2) const
+                const typename Teuchos::Array<LocalOrdinal>::iterator& /* last2 */) const
   {
     typedef typename std::iterator_traits<typename Teuchos::Array<LocalOrdinal>::iterator>::difference_type DT;
     DT n = last1 - first1;
@@ -1822,7 +1822,7 @@ namespace MueLu {
                 const typename Teuchos::Array<LocalOrdinal>::iterator& first1,
                 const typename Teuchos::Array<LocalOrdinal>::iterator& last1,
                 const typename Teuchos::Array<LocalOrdinal>::iterator& first2,
-                const typename Teuchos::Array<LocalOrdinal>::iterator& last2) const
+                const typename Teuchos::Array<LocalOrdinal>::iterator& /* last2 */) const
   {
     typedef typename std::iterator_traits<typename Teuchos::Array<LocalOrdinal>::iterator>::difference_type DT;
     DT n = last1 - first1;
@@ -1849,7 +1849,7 @@ namespace MueLu {
   void GeneralGeometricPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   GetGIDLocalLexicographic(const GO i, const GO j, const GO k,
                            const Array<LO> coarseNodeFineIndices, const RCP<GeometricData> myGeo,
-                           const LO myRankIndex, const LO pi, const LO pj, const LO pk,
+                           const LO myRankIndex, const LO pi, const LO pj, const LO /* pk */,
                            const typename std::vector<std::vector<GO> >::iterator blockStart,
                            const typename std::vector<std::vector<GO> >::iterator blockEnd,
                            GO& myGID, LO& myPID, LO& myLID) const {

--- a/packages/muelu/src/Transfers/GeneralGeometric/MueLu_GeometricInterpolationPFactory_def.hpp
+++ b/packages/muelu/src/Transfers/GeneralGeometric/MueLu_GeometricInterpolationPFactory_def.hpp
@@ -92,7 +92,7 @@ namespace MueLu {
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void GeometricInterpolationPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  DeclareInput(Level& fineLevel, Level& coarseLevel) const {
+  DeclareInput(Level& fineLevel, Level& /* coarseLevel */) const {
     const ParameterList& pL = GetParameterList();
 
     Input(fineLevel, "A");

--- a/packages/muelu/src/Transfers/Generic/MueLu_GenericRFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Generic/MueLu_GenericRFactory_def.hpp
@@ -66,7 +66,7 @@ namespace MueLu {
   }
 
   template <class Scalar,class LocalOrdinal, class GlobalOrdinal, class Node>
-  void GenericRFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::DeclareInput(Level &fineLevel, Level &coarseLevel) const {
+  void GenericRFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::DeclareInput(Level &/* fineLevel */, Level &coarseLevel) const {
     RCP<const FactoryBase> PFact1 = GetFactory("P");
     if (PFact1 == Teuchos::null) { PFact1 = coarseLevel.GetFactoryManager()->GetFactory("P"); }
     RCP<PFactory> PFact = Teuchos::rcp_const_cast<PFactory>(rcp_dynamic_cast<const PFactory>(PFact1));;
@@ -89,7 +89,7 @@ namespace MueLu {
   }
 
   template <class Scalar,class LocalOrdinal, class GlobalOrdinal, class Node>
-  void GenericRFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(Level & fineLevel, Level & coarseLevel) const {
+  void GenericRFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(Level & /* fineLevel */, Level & coarseLevel) const {
     FactoryMonitor m(*this, "Call prolongator factory for calculating restrictor", coarseLevel);
 
     RCP<const FactoryBase> PFact1 = GetFactory("P");

--- a/packages/muelu/src/Transfers/Generic/MueLu_TransPFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Generic/MueLu_TransPFactory_def.hpp
@@ -76,12 +76,12 @@ namespace MueLu {
   }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-  void TransPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::DeclareInput(Level& fineLevel, Level& coarseLevel) const {
+  void TransPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::DeclareInput(Level& /* fineLevel */, Level& coarseLevel) const {
     Input(coarseLevel, "P");
   }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-  void TransPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(Level& fineLevel, Level& coarseLevel) const {
+  void TransPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(Level& /* fineLevel */, Level& coarseLevel) const {
     FactoryMonitor m(*this, "Transpose P", coarseLevel);
     std::string label = "MueLu::TransP-" + Teuchos::toString(coarseLevel.GetLevelID());
 

--- a/packages/muelu/src/Transfers/PCoarsen/MueLu_IntrepidPCoarsenFactory_def.hpp
+++ b/packages/muelu/src/Transfers/PCoarsen/MueLu_IntrepidPCoarsenFactory_def.hpp
@@ -713,7 +713,7 @@ void IntrepidPCoarsenFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Generat
 
 /*********************************************************************************************************/
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-  void IntrepidPCoarsenFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::DeclareInput(Level &fineLevel, Level &coarseLevel) const {
+  void IntrepidPCoarsenFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::DeclareInput(Level &fineLevel, Level &/* coarseLevel */) const {
     Input(fineLevel, "A");
     Input(fineLevel, "pcoarsen: element to node map");
     Input(fineLevel, "Nullspace");

--- a/packages/muelu/src/Transfers/Petrov-Galerkin-SA/MueLu_PgPFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Petrov-Galerkin-SA/MueLu_PgPFactory_def.hpp
@@ -237,7 +237,7 @@ namespace MueLu {
   }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-  void PgPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::ComputeRowBasedOmega(Level& fineLevel, Level &coarseLevel, const RCP<Matrix>& A, const RCP<Matrix>& P0, const RCP<Matrix>& DinvAP0, RCP<Vector > & RowBasedOmega) const {
+  void PgPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::ComputeRowBasedOmega(Level& /* fineLevel */, Level &coarseLevel, const RCP<Matrix>& A, const RCP<Matrix>& P0, const RCP<Matrix>& DinvAP0, RCP<Vector > & RowBasedOmega) const {
     FactoryMonitor m(*this, "PgPFactory::ComputeRowBasedOmega", coarseLevel);
 
     typedef typename Teuchos::ScalarTraits<Scalar>::magnitudeType Magnitude;
@@ -686,7 +686,7 @@ namespace MueLu {
   }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-  void PgPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::BuildP(Level &fineLevel, Level &coarseLevel) const {
+  void PgPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::BuildP(Level &/* fineLevel */, Level &/* coarseLevel */) const {
     std::cout << "TODO: remove me" << std::endl;
   }
 

--- a/packages/muelu/src/Transfers/SemiCoarsen/MueLu_SemiCoarsenPFactory_def.hpp
+++ b/packages/muelu/src/Transfers/SemiCoarsen/MueLu_SemiCoarsenPFactory_def.hpp
@@ -83,7 +83,7 @@ namespace MueLu {
   }
 
   template <class Scalar,class LocalOrdinal, class GlobalOrdinal, class Node>
-  void SemiCoarsenPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::DeclareInput(Level& fineLevel, Level& coarseLevel) const {
+  void SemiCoarsenPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::DeclareInput(Level& fineLevel, Level& /* coarseLevel */) const {
     Input(fineLevel, "A");
     Input(fineLevel, "Nullspace");
 

--- a/packages/muelu/src/Transfers/SemiCoarsen/MueLu_ToggleCoordinatesTransferFactory_def.hpp
+++ b/packages/muelu/src/Transfers/SemiCoarsen/MueLu_ToggleCoordinatesTransferFactory_def.hpp
@@ -64,7 +64,7 @@ namespace MueLu {
   }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-  void ToggleCoordinatesTransferFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::DeclareInput(Level& fineLevel, Level& coarseLevel) const {
+  void ToggleCoordinatesTransferFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::DeclareInput(Level& /* fineLevel */, Level& coarseLevel) const {
     const ParameterList& pL = GetParameterList();
     TEUCHOS_TEST_FOR_EXCEPTION(!pL.isParameter("Chosen P"), Exceptions::RuntimeError, "MueLu::ToggleCoordinatesTransferFactory::DeclareInput: You have to set the 'Chosen P' parameter to a factory name of type TogglePFactory. The ToggleCoordinatesTransferFactory must be used together with a TogglePFactory!");
     Input(coarseLevel,"Chosen P");
@@ -76,7 +76,7 @@ namespace MueLu {
   }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-  void ToggleCoordinatesTransferFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(Level & fineLevel, Level &coarseLevel) const {
+  void ToggleCoordinatesTransferFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(Level & /* fineLevel */, Level &coarseLevel) const {
     FactoryMonitor m(*this, "Coordinate transfer toggle", coarseLevel);
 
     typedef Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::magnitudeType,LO,GO,NO> xdMV;

--- a/packages/muelu/src/Transfers/SemiCoarsen/MueLu_TogglePFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/SemiCoarsen/MueLu_TogglePFactory_decl.hpp
@@ -121,7 +121,7 @@ namespace MueLu {
     /*!  @brief Build method.   */
     void Build(Level& fineLevel, Level &coarseLevel) const;
 
-    void BuildP(Level &fineLevel, Level &coarseLevel) const { /* empty */ };
+    void BuildP(Level &/* fineLevel */, Level &/* coarseLevel */) const { /* empty */ };
     //@}
 
     //@{

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_def.hpp
@@ -99,7 +99,7 @@ namespace MueLu {
   }
 
   template <class Scalar,class LocalOrdinal, class GlobalOrdinal, class Node>
-  void TentativePFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::DeclareInput(Level& fineLevel, Level& coarseLevel) const {
+  void TentativePFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::DeclareInput(Level& fineLevel, Level& /* coarseLevel */) const {
 
     const ParameterList& pL = GetParameterList();
 

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_kokkos_def.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_kokkos_def.hpp
@@ -365,7 +365,7 @@ namespace MueLu {
       }
 
       // amount of shared memory
-      size_t team_shmem_size( int team_size ) const {
+      size_t team_shmem_size( int /* team_size */ ) const {
         if (doQRStep) {
           int m = maxAggDofSize;
           int n = fineNS.extent(1);
@@ -403,7 +403,7 @@ namespace MueLu {
   }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class DeviceType>
-  void TentativePFactory_kokkos<Scalar,LocalOrdinal,GlobalOrdinal,Kokkos::Compat::KokkosDeviceWrapperNode<DeviceType>>::DeclareInput(Level& fineLevel, Level& coarseLevel) const {
+  void TentativePFactory_kokkos<Scalar,LocalOrdinal,GlobalOrdinal,Kokkos::Compat::KokkosDeviceWrapperNode<DeviceType>>::DeclareInput(Level& fineLevel, Level& /* coarseLevel */) const {
 
     const ParameterList& pL = GetParameterList();
 
@@ -954,8 +954,8 @@ namespace MueLu {
 
   template <class Scalar,class LocalOrdinal, class GlobalOrdinal, class DeviceType>
   void TentativePFactory_kokkos<Scalar,LocalOrdinal,GlobalOrdinal,Kokkos::Compat::KokkosDeviceWrapperNode<DeviceType>>::
-  BuildPcoupled(RCP<Matrix> A, RCP<Aggregates_kokkos> aggregates, RCP<AmalgamationInfo> amalgInfo, RCP<MultiVector> fineNullspace,
-                RCP<const Map> coarseMap, RCP<Matrix>& Ptentative, RCP<MultiVector>& coarseNullspace) const {
+  BuildPcoupled(RCP<Matrix> /* A */, RCP<Aggregates_kokkos> /* aggregates */, RCP<AmalgamationInfo> /* amalgInfo */, RCP<MultiVector> /* fineNullspace */,
+                RCP<const Map> /* coarseMap */, RCP<Matrix>& /* Ptentative */, RCP<MultiVector>& /* coarseNullspace */) const {
     throw Exceptions::RuntimeError("MueLu: Construction of coupled tentative P is not implemented");
   }
 

--- a/packages/muelu/src/Transfers/User/MueLu_UserPFactory_def.hpp
+++ b/packages/muelu/src/Transfers/User/MueLu_UserPFactory_def.hpp
@@ -70,7 +70,7 @@ namespace MueLu {
   }
 
   template <class Scalar,class LocalOrdinal, class GlobalOrdinal, class Node>
-  void UserPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::DeclareInput(Level& fineLevel, Level& coarseLevel) const {
+  void UserPFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::DeclareInput(Level& fineLevel, Level& /* coarseLevel */) const {
     Input(fineLevel, "A");
     Input(fineLevel, "Nullspace");
   }

--- a/packages/muelu/src/Utils/MueLu_AggregationExportFactory_def.hpp
+++ b/packages/muelu/src/Utils/MueLu_AggregationExportFactory_def.hpp
@@ -367,7 +367,7 @@ namespace MueLu {
   }
 
   template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-  void AggregationExportFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::doJacksPlus_(std::vector<int>& vertices, std::vector<int>& geomSizes) const
+  void AggregationExportFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::doJacksPlus_(std::vector<int>& /* vertices */, std::vector<int>& /* geomSizes */) const
   {
     //TODO
   }

--- a/packages/muelu/src/Utils/MueLu_LocalPermutationStrategy_def.hpp
+++ b/packages/muelu/src/Utils/MueLu_LocalPermutationStrategy_def.hpp
@@ -49,7 +49,7 @@ namespace MueLu {
   }
 
   template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-  void LocalPermutationStrategy<Scalar, LocalOrdinal, GlobalOrdinal, Node>::BuildPermutation(const Teuchos::RCP<Matrix> & A, const Teuchos::RCP<const Map> permRowMap, Level & currentLevel, const FactoryBase* genFactory) const {
+  void LocalPermutationStrategy<Scalar, LocalOrdinal, GlobalOrdinal, Node>::BuildPermutation(const Teuchos::RCP<Matrix> & A, const Teuchos::RCP<const Map> /* permRowMap */, Level & currentLevel, const FactoryBase* genFactory) const {
 
     SC SC_ZERO = Teuchos::ScalarTraits<SC>::zero();
 

--- a/packages/muelu/src/Utils/MueLu_MatrixAnalysisFactory_def.hpp
+++ b/packages/muelu/src/Utils/MueLu_MatrixAnalysisFactory_def.hpp
@@ -77,12 +77,12 @@ RCP<const ParameterList> MatrixAnalysisFactory<Scalar, LocalOrdinal, GlobalOrdin
 }
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-void MatrixAnalysisFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::DeclareInput(Level &fineLevel, Level &coarseLevel) const {
+void MatrixAnalysisFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::DeclareInput(Level &fineLevel, Level &/* coarseLevel */) const {
   Input(fineLevel, "A");
 }
 
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-void MatrixAnalysisFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(Level &fineLevel, Level &coarseLevel) const {
+void MatrixAnalysisFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(Level &fineLevel, Level &/* coarseLevel */) const {
   FactoryMonitor m(*this, "MatrixAnalysis Factory ", fineLevel);
 
   Teuchos::RCP<Matrix> A = Get< Teuchos::RCP<Matrix> > (fineLevel, "A");

--- a/packages/muelu/src/Utils/MueLu_Memory.cpp
+++ b/packages/muelu/src/Utils/MueLu_Memory.cpp
@@ -139,7 +139,7 @@ namespace MueLu {
       }
     } //ReportTimeAndMemory
 #else
-    void ReportTimeAndMemory(Teuchos::Time const &timer, Teuchos::Comm<int> const &Comm)
+    void ReportTimeAndMemory(Teuchos::Time const &/* timer */, Teuchos::Comm<int> const &/* Comm */)
     {
       return;
     }

--- a/packages/muelu/src/Utils/MueLu_PerfUtils_def.hpp
+++ b/packages/muelu/src/Utils/MueLu_PerfUtils_def.hpp
@@ -289,7 +289,7 @@ namespace MueLu {
   }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-  std::string PerfUtils<Scalar, LocalOrdinal, GlobalOrdinal, Node>::CommPattern(const Matrix& A, const std::string& msgTag, RCP<const ParameterList> params) {
+  std::string PerfUtils<Scalar, LocalOrdinal, GlobalOrdinal, Node>::CommPattern(const Matrix& A, const std::string& msgTag, RCP<const ParameterList> /* params */) {
     if (!CheckMatrix(A))
       return "";
 

--- a/packages/muelu/src/Utils/MueLu_Utilities_decl.hpp
+++ b/packages/muelu/src/Utils/MueLu_Utilities_decl.hpp
@@ -700,7 +700,7 @@ namespace MueLu {
 #endif
     }
 
-    static void MyOldScaleMatrix_Epetra (Matrix& Op, const Teuchos::ArrayRCP<Scalar>& scalingVector, bool doFillComplete, bool doOptimizeStorage) {
+    static void MyOldScaleMatrix_Epetra (Matrix& Op, const Teuchos::ArrayRCP<Scalar>& scalingVector, bool /* doFillComplete */, bool /* doOptimizeStorage */) {
 #ifdef HAVE_MUELU_EPETRA
       try {
         //const Epetra_CrsMatrix& epOp = Utilities<double,int,int>::Op2NonConstEpetraCrs(Op);
@@ -730,7 +730,7 @@ namespace MueLu {
         Note: Currently, an error is thrown if the matrix isn't a Tpetra::CrsMatrix or Epetra_CrsMatrix.
         In principle, however, we could allow any Epetra_RowMatrix because the Epetra transposer does.
     */
-    static RCP<Matrix> Transpose(Matrix& Op, bool optimizeTranspose = false,const std::string & label = std::string(),const Teuchos::RCP<Teuchos::ParameterList> &params=Teuchos::null) {
+    static RCP<Matrix> Transpose(Matrix& Op, bool /* optimizeTranspose */ = false,const std::string & label = std::string(),const Teuchos::RCP<Teuchos::ParameterList> &params=Teuchos::null) {
       switch (Op.getRowMap()->lib()) {
         case Xpetra::UseTpetra: {
 #ifdef HAVE_MUELU_TPETRA

--- a/packages/muelu/src/Utils/MueLu_Utilities_def.hpp
+++ b/packages/muelu/src/Utils/MueLu_Utilities_def.hpp
@@ -379,7 +379,7 @@ namespace MueLu {
   }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-  void Utilities<Scalar, LocalOrdinal, GlobalOrdinal, Node>::MyOldScaleMatrix_Epetra(Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>& Op, const Teuchos::ArrayRCP<Scalar>& scalingVector, bool doFillComplete, bool doOptimizeStorage) {
+  void Utilities<Scalar, LocalOrdinal, GlobalOrdinal, Node>::MyOldScaleMatrix_Epetra(Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>& /* Op */, const Teuchos::ArrayRCP<Scalar>& /* scalingVector */, bool /* doFillComplete */, bool /* doOptimizeStorage */) {
     throw Exceptions::RuntimeError("MyOldScaleMatrix_Epetra: Epetra needs SC=double and LO=GO=int.");
   }
 
@@ -467,7 +467,7 @@ namespace MueLu {
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> >
   Utilities<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  Transpose (Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>& Op, bool optimizeTranspose,const std::string & label,const Teuchos::RCP<Teuchos::ParameterList> &params) {
+  Transpose (Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>& Op, bool /* optimizeTranspose */,const std::string & label,const Teuchos::RCP<Teuchos::ParameterList> &params) {
 #if defined(HAVE_MUELU_EPETRA) && defined(HAVE_MUELU_EPETRAEXT)
     std::string TorE = "epetra";
 #else

--- a/packages/muelu/src/Utils/MueLu_Utilities_kokkos_decl.hpp
+++ b/packages/muelu/src/Utils/MueLu_Utilities_kokkos_decl.hpp
@@ -562,7 +562,7 @@ namespace MueLu {
       Note: Currently, an error is thrown if the matrix isn't a Tpetra::CrsMatrix or Epetra_CrsMatrix.
       In principle, however, we could allow any Epetra_RowMatrix because the Epetra transposer does.
      */
-    static RCP<Matrix> Transpose(Matrix& Op, bool optimizeTranspose = false, const std::string & label = std::string(),const Teuchos::RCP<Teuchos::ParameterList> &params=Teuchos::null) {
+    static RCP<Matrix> Transpose(Matrix& Op, bool /* optimizeTranspose */ = false, const std::string & label = std::string(),const Teuchos::RCP<Teuchos::ParameterList> &params=Teuchos::null) {
       switch (Op.getRowMap()->lib()) {
       case Xpetra::UseTpetra:
       {

--- a/packages/muelu/src/Utils/MueLu_Utilities_kokkos_def.hpp
+++ b/packages/muelu/src/Utils/MueLu_Utilities_kokkos_def.hpp
@@ -258,7 +258,7 @@ namespace MueLu {
   }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-  void Utilities_kokkos<Scalar, LocalOrdinal, GlobalOrdinal, Node>::MyOldScaleMatrix_Epetra(Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>& Op, const Teuchos::ArrayRCP<Scalar>& scalingVector, bool doFillComplete, bool doOptimizeStorage) {
+  void Utilities_kokkos<Scalar, LocalOrdinal, GlobalOrdinal, Node>::MyOldScaleMatrix_Epetra(Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>& /* Op */, const Teuchos::ArrayRCP<Scalar>& /* scalingVector */, bool /* doFillComplete */, bool /* doOptimizeStorage */) {
     throw Exceptions::RuntimeError("MyOldScaleMatrix_Epetra: Epetra needs SC=double and LO=GO=int.");
   }
 

--- a/packages/muelu/src/Utils/MueLu_VisualizationHelpers_def.hpp
+++ b/packages/muelu/src/Utils/MueLu_VisualizationHelpers_def.hpp
@@ -85,7 +85,7 @@ namespace MueLu {
   }
 
   template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-  void VisualizationHelpers<Scalar, LocalOrdinal, GlobalOrdinal, Node>::doPointCloud(std::vector<int>& vertices, std::vector<int>& geomSizes, LO numLocalAggs, LO numFineNodes) {
+  void VisualizationHelpers<Scalar, LocalOrdinal, GlobalOrdinal, Node>::doPointCloud(std::vector<int>& vertices, std::vector<int>& geomSizes, LO /* numLocalAggs */, LO numFineNodes) {
     vertices.reserve(numFineNodes);
     geomSizes.reserve(numFineNodes);
     for(LocalOrdinal i = 0; i < numFineNodes; i++)
@@ -132,7 +132,7 @@ namespace MueLu {
   }
 
   template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-  void VisualizationHelpers<Scalar, LocalOrdinal, GlobalOrdinal, Node>::doConvexHulls2D(std::vector<int>& vertices, std::vector<int>& geomSizes, LO numLocalAggs, LO numFineNodes, const std::vector<bool>& isRoot, const ArrayRCP<LO>& vertex2AggId, const Teuchos::ArrayRCP<const typename Teuchos::ScalarTraits<Scalar>::coordinateType>& xCoords, const Teuchos::ArrayRCP<const typename Teuchos::ScalarTraits<Scalar>::coordinateType>& yCoords) {
+  void VisualizationHelpers<Scalar, LocalOrdinal, GlobalOrdinal, Node>::doConvexHulls2D(std::vector<int>& vertices, std::vector<int>& geomSizes, LO numLocalAggs, LO numFineNodes, const std::vector<bool>& /* isRoot */, const ArrayRCP<LO>& vertex2AggId, const Teuchos::ArrayRCP<const typename Teuchos::ScalarTraits<Scalar>::coordinateType>& xCoords, const Teuchos::ArrayRCP<const typename Teuchos::ScalarTraits<Scalar>::coordinateType>& yCoords) {
     for(int agg = 0; agg < numLocalAggs; agg++) {
       std::list<int> aggNodes;
       for(int i = 0; i < numFineNodes; i++) {
@@ -323,7 +323,7 @@ namespace MueLu {
 #endif
 
   template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-  void VisualizationHelpers<Scalar, LocalOrdinal, GlobalOrdinal, Node>::doConvexHulls3D(std::vector<int>& vertices, std::vector<int>& geomSizes, LO numLocalAggs, LO numFineNodes, const std::vector<bool>& isRoot, const ArrayRCP<LO>& vertex2AggId, const Teuchos::ArrayRCP<const typename Teuchos::ScalarTraits<Scalar>::coordinateType>& xCoords, const Teuchos::ArrayRCP<const typename Teuchos::ScalarTraits<Scalar>::coordinateType>& yCoords, const Teuchos::ArrayRCP<const typename Teuchos::ScalarTraits<Scalar>::coordinateType>& zCoords) {
+  void VisualizationHelpers<Scalar, LocalOrdinal, GlobalOrdinal, Node>::doConvexHulls3D(std::vector<int>& vertices, std::vector<int>& geomSizes, LO numLocalAggs, LO numFineNodes, const std::vector<bool>& /* isRoot */, const ArrayRCP<LO>& vertex2AggId, const Teuchos::ArrayRCP<const typename Teuchos::ScalarTraits<Scalar>::coordinateType>& xCoords, const Teuchos::ArrayRCP<const typename Teuchos::ScalarTraits<Scalar>::coordinateType>& yCoords, const Teuchos::ArrayRCP<const typename Teuchos::ScalarTraits<Scalar>::coordinateType>& zCoords) {
     //Use 3D quickhull algo.
     //Vector of node indices representing triangle vertices
     //Note: Calculate the hulls first since will only include point data for points in the hulls
@@ -762,7 +762,7 @@ namespace MueLu {
 #endif
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-  void VisualizationHelpers<Scalar, LocalOrdinal, GlobalOrdinal, Node>::doGraphEdges(std::vector<int>& vertices, std::vector<int>& geomSizes, Teuchos::RCP<GraphBase>& G, Teuchos::ArrayRCP<const typename Teuchos::ScalarTraits<Scalar>::coordinateType> & fx, Teuchos::ArrayRCP<const typename Teuchos::ScalarTraits<Scalar>::coordinateType> & fy, Teuchos::ArrayRCP<const typename Teuchos::ScalarTraits<Scalar>::coordinateType> & fz) {
+  void VisualizationHelpers<Scalar, LocalOrdinal, GlobalOrdinal, Node>::doGraphEdges(std::vector<int>& vertices, std::vector<int>& geomSizes, Teuchos::RCP<GraphBase>& G, Teuchos::ArrayRCP<const typename Teuchos::ScalarTraits<Scalar>::coordinateType> & /* fx */, Teuchos::ArrayRCP<const typename Teuchos::ScalarTraits<Scalar>::coordinateType> & /* fy */, Teuchos::ArrayRCP<const typename Teuchos::ScalarTraits<Scalar>::coordinateType> & /* fz */) {
     ArrayView<const Scalar> values;
     ArrayView<const LocalOrdinal> neighbors;
 
@@ -1237,7 +1237,7 @@ namespace MueLu {
   }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-  std::string VisualizationHelpers<Scalar, LocalOrdinal, GlobalOrdinal, Node>::getPVTUFileName(int numProcs, int myRank, int level, const Teuchos::ParameterList & pL) const {
+  std::string VisualizationHelpers<Scalar, LocalOrdinal, GlobalOrdinal, Node>::getPVTUFileName(int numProcs, int /* myRank */, int level, const Teuchos::ParameterList & pL) const {
     std::string filenameToWrite = getBaseFileName(numProcs, level, pL);
     std::string masterStem = filenameToWrite.substr(0, filenameToWrite.rfind(".vtu"));
     masterStem = this->replaceAll(masterStem, "%PROCID", "");
@@ -1326,7 +1326,7 @@ namespace MueLu {
   }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-  void VisualizationHelpers<Scalar, LocalOrdinal, GlobalOrdinal, Node>::writeFileVTKCells(std::ofstream & fout, std::vector<int> & uniqueFine, std::vector<LocalOrdinal> & vertices, std::vector<LocalOrdinal> & geomSize) const {
+  void VisualizationHelpers<Scalar, LocalOrdinal, GlobalOrdinal, Node>::writeFileVTKCells(std::ofstream & fout, std::vector<int> & /* uniqueFine */, std::vector<LocalOrdinal> & vertices, std::vector<LocalOrdinal> & geomSize) const {
     std::string indent = "      ";
     fout << "      <Cells>" << std::endl;
     fout << "        <DataArray type=\"Int32\" Name=\"connectivity\" format=\"ascii\">" << std::endl;
@@ -1386,7 +1386,7 @@ namespace MueLu {
 
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-  void VisualizationHelpers<Scalar, LocalOrdinal, GlobalOrdinal, Node>::writePVTU(std::ofstream& pvtu, std::string baseFname, int numProcs, bool bFineEdges, bool bCoarseEdges) const {
+  void VisualizationHelpers<Scalar, LocalOrdinal, GlobalOrdinal, Node>::writePVTU(std::ofstream& pvtu, std::string baseFname, int numProcs, bool bFineEdges, bool /* bCoarseEdges */) const {
     //If using vtk, filenameToWrite now contains final, correct ***.vtu filename (for the current proc)
     //So the root proc will need to use its own filenameToWrite to make a list of the filenames of all other procs to put in
     //pvtu file.


### PR DESCRIPTION
@trilinos/muelu 

## Description
Comment out parameter names in function definitions to avoid
`-Wunused-parameter` warnings.

## Motivation and Context
Clean build.