### PR TITLE
Belos: Fix #4626 (Tpetra specialization of MultiVecTraits)

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_StaticView.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_StaticView.hpp
@@ -181,25 +181,6 @@ getStatic2dDualView (const size_t num_rows, const size_t num_cols)
       typename h_view_type::device_type> (num_rows, num_cols);
   }
 
-  // mfh 25 Mar 2019: Save this for the actual MultiVector --
-  // we'll need a separate function that creates a MultiVector
-  // with static storage for its DualView.
-#if 0
-  const bool debug_mode = ::Tpetra::Details::Behavior::debug ();
-  if (debug_mode) {
-    // Filling with NaN is a cheap and effective way to tell if
-    // downstream code is trying to use a MultiVector's data without
-    // them having been initialized.  ArithTraits lets us call nan()
-    // even if the scalar type doesn't define it; it just returns some
-    // undefined value in the latter case.
-    const ValueType nan = Kokkos::ArithTraits<ValueType>::nan ();
-    Kokkos::deep_copy (d_view, nan);
-    if (h_view.data () != d_view.data ()) {
-      Kokkos::deep_copy (h_view, nan);
-    }
-  }
-#endif // 0
-
   return dual_view_type (d_view, h_view);
 }
 


### PR DESCRIPTION
@trilinos/belos @trilinos/tpetra @vbrunini 

## Description

Make the Tpetra specialization of Belos::MultiVecTraits use static CUDA allocations for temporary local MultiVectors (e.g., for `Tpetra::MultiVector::multiply` results).  The fix always creates contiguous allocations, so it does not depend on the fix for #4639 in PR #4747 (merged into develop yesterday).

This change supersedes PR #4648, which in turn superseded PR #4640.

## Motivation and Context

We've seen this improve GPU performance in solves.

## Related Issues

* Closes #4626 
* Related to #4648, #4734, #4640 