### PR TITLE
Remove file ATDMDevEnvAllPtPackages.cmake (#4502)

### DIFF
--- a/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-rdc-release-debug-pt-pbp.sh
+++ b/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-rdc-release-debug-pt-pbp.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=Specialized
-fi
-export ATDM_CONFIG_ENABLE_ALL_PACKAGES=TRUE
-#export Trilinos_ENABLE_SECONDARY_TESTED_CODE=OFF
-export ATDM_CONFIG_CONFIGURE_OPTIONS_FILES=cmake/std/atdm/ATDMDevEnvAllPtPackages.cmake
-export Trilinos_CTEST_DO_ALL_AT_ONCE=FALSE
-$WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ride/local-driver.sh

--- a/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-rdc-release-debug-pt.sh
+++ b/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-rdc-release-debug-pt.sh
@@ -2,8 +2,4 @@
 if [ "${Trilinos_TRACK}" == "" ] ; then
   export Trilinos_TRACK=Specialized
 fi
-export ATDM_CONFIG_ENABLE_ALL_PACKAGES=TRUE
-#export Trilinos_ENABLE_SECONDARY_TESTED_CODE=OFF
-export ATDM_CONFIG_CONFIGURE_OPTIONS_FILES=cmake/std/atdm/ATDMDevEnvAllPtPackages.cmake
-export Trilinos_CTEST_DO_ALL_AT_ONCE=TRUE
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ride/local-driver.sh

--- a/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-rdc-shared-release-debug-pt.sh
+++ b/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-rdc-shared-release-debug-pt.sh
@@ -2,8 +2,4 @@
 if [ "${Trilinos_TRACK}" == "" ] ; then
   export Trilinos_TRACK=Specialized
 fi
-export ATDM_CONFIG_ENABLE_ALL_PACKAGES=TRUE
-#export Trilinos_ENABLE_SECONDARY_TESTED_CODE=OFF
-export ATDM_CONFIG_CONFIGURE_OPTIONS_FILES=cmake/std/atdm/ATDMDevEnvAllPtPackages.cmake
-export Trilinos_CTEST_DO_ALL_AT_ONCE=TRUE
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ride/local-driver.sh

--- a/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-release-debug-pt.sh
+++ b/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-release-debug-pt.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
-#export Trilinos_TRACK=ATDM
-export ATDM_CONFIG_ENABLE_ALL_PACKAGES=TRUE
-#export Trilinos_ENABLE_SECONDARY_TESTED_CODE=OFF
-export ATDM_CONFIG_CONFIGURE_OPTIONS_FILES=cmake/std/atdm/ATDMDevEnvAllPtPackages.cmake
-export Trilinos_CTEST_DO_ALL_AT_ONCE=TRUE
-export Trilinos_CTEST_USE_NEW_AAO_FEATURES=ON
+if [ "${Trilinos_TRACK}" == "" ] ; then
+  export Trilinos_TRACK=Specialized
+fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ride/local-driver.sh

--- a/cmake/std/atdm/ATDMDevEnvAllPtPackages.cmake
+++ b/cmake/std/atdm/ATDMDevEnvAllPtPackages.cmake
@@ -1,7 +1,0 @@
-###############################################################################
-#
-#              ATDM Configuration for all Trilinos packages
-#
-###############################################################################
-
-INCLUDE("${CMAKE_CURRENT_LIST_DIR}/utils/ATDMDevEnv.cmake")


### PR DESCRIPTION
Now that the system automatically adjusts for all Primary Tested packages with the '-pt' and '_pt' matching, we don't need the file ATDMDevEnvAllPtPackages.cmake anymore.  (Related to #4502.)

Also, we don't need the build:

* Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-rdc-release-debug-pt-pbp.sh

anymore because the all-at-once build will pass now.

I tested this on 'ride' with:

```
./ctest-s-local-test-driver.sh cuda-9.2-gnu-7.2.0-rdc-release-debug-pt

***
*** ./ctest-s-local-test-driver.sh  cuda-9.2-gnu-7.2.0-rdc-release-debug-pt
***

ATDM_TRILINOS_DIR = '/home/rabartl/Trilinos.base/Trilinos'

Load some env to get python, cmake, etc ...

Hostname 'ride6' matches known ATDM host 'ride' and system 'ride'
Setting compiler and build options for buld name 'default'
Using white/ride compiler stack GNU-7.2.0 to build DEBUG code with Kokkos node type SERIAL and KOKKOS_ARCH=Power8

Running builds:
    cuda-9.2-gnu-7.2.0-rdc-release-debug-pt


Running Jenkins driver Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-rdc-release-debug-pt.sh ...
```

which submitted to:

* https://testing.sandia.gov/cdash-dev-view/index.php?project=Trilinos&parentid=4811487

confirming this fixed the configure (the build is still running).
