### PR TITLE
change the atdm sems-rhel7 env to use mkl-18.0.5

### DIFF
--- a/cmake/std/atdm/sems-rhel7/environment.sh
+++ b/cmake/std/atdm/sems-rhel7/environment.sh
@@ -144,21 +144,13 @@ elif [[ "$ATDM_CONFIG_COMPILER" == "GNU-7.2.0" ]] ; then
   export ATDM_CONFIG_BLAS_LIBS="-L${BLAS_ROOT}/lib;-lblas"
 elif [[ "$ATDM_CONFIG_COMPILER" == "INTEL-17.0.1" ]] ; then
   module load sems-intel/17.0.1
+  module load atdm-env
+  module load atdm-mkl/18.0.5
   export OMPI_CXX=`which icpc`
   export OMPI_CC=`which icc`
   export OMPI_FC=`which ifort`
-#  export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SEMS_INTEL_ROOT/mkl/lib/intel64/
-#  export ATDM_CONFIG_LAPACK_LIBS="-mkl"
-#  export ATDM_CONFIG_BLAS_LIBS="-mkl"
-  export LAPACK_ROOT=/usr/lib64/atlas
-  export ATDM_CONFIG_LAPACK_LIBS="-L${LAPACK_ROOT};-llapack"
-  export ATDM_CONFIG_BLAS_LIBS="-L${LAPACK_ROOT}/lib;-lblas"
-  # NOTE: Above, /usr/lib64/atlas/ does not exist on every SEMS RHEL7 machine
-  # (e.g. it does not exist on the machine 'ascicgpu14' and 'ascicgpu15') and
-  # therefore -L//usr/lib64/atlas will get ignored by the compiler on those
-  # machines.  Therefore, -lblas and -llapack will need to exist in the
-  # default system path or some other path given in LIBRARY_PATH and that BLAS
-  # and LAPACK must work for intel-17.0.1.
+  export ATDM_CONFIG_LAPACK_LIBS="-mkl"
+  export ATDM_CONFIG_BLAS_LIBS="-mkl"
   export LM_LICENSE_FILE=28518@cee-infra009.sandia.gov
   if [[ "${ATDM_CONFIG_LM_LICENSE_FILE_OVERRIDE}" != "" ]] ; then
     export LM_LICENSE_FILE=${ATDM_CONFIG_LM_LICENSE_FILE_OVERRIDE}


### PR DESCRIPTION
@bartlettroscoe 

## Description
use the new intel 18.0.5 mkl module on sems-rhel7 builds.  They still will use the intel-17 compiler but with the 18.0.5 mkl

## Motivation and Context
mkl-17 has been discovered to be the cause of test failures.  This was fixed in 18.0.5


## How Has This Been Tested?
On a sems rhel7 login machine I ran:
```
JOB_NAME=Trilinos-atdm-sems-rhel7-intel-17.0.1-openmp-complex-shared-release-debug

source $TRILINOS_SRC_DIR/cmake/std/atdm/load-env.sh $JOB_NAME

cmake \
  -GNinja \
  -DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/atdm/ATDMDevEnv.cmake,cmake/std/atdm/apps/empire/EMPIRETrilinosEnables.cmake \
  -DTrilinos_ENABLE_ALL_PACKAGES=ON \
  -DTrilinos_ENABLE_TESTS=ON \
  $TRILINOS_SRC_DIR

make NP=16

ctest -j8
```

and had all tests pass:
```
100% tests passed, 0 tests failed out of 2078

Subproject Time Summary:
Amesos2          =   7.59 sec*proc (8 tests)
Anasazi          = 156.94 sec*proc (101 tests)
Belos            = 193.23 sec*proc (116 tests)
Ifpack2          =  76.64 sec*proc (45 tests)
Intrepid2        = 238.89 sec*proc (260 tests)
Kokkos           = 102.51 sec*proc (27 tests)
KokkosKernels    = 332.23 sec*proc (8 tests)
MueLu            = 485.80 sec*proc (111 tests)
NOX              = 152.24 sec*proc (106 tests)
Panzer           = 1692.41 sec*proc (170 tests)
Phalanx          =  11.99 sec*proc (27 tests)
Piro             =  24.06 sec*proc (12 tests)
Rythmos          =  48.92 sec*proc (83 tests)
SEACAS           =  13.63 sec*proc (20 tests)
STK              =   3.05 sec*proc (4 tests)
Sacado           =  82.57 sec*proc (297 tests)
Stratimikos      =  25.46 sec*proc (39 tests)
Teko             =  44.70 sec*proc (18 tests)
Tempus           = 239.27 sec*proc (80 tests)
Teuchos          =  86.47 sec*proc (137 tests)
Thyra            =  54.04 sec*proc (82 tests)
Tpetra           = 243.46 sec*proc (198 tests)
Xpetra           =  42.77 sec*proc (18 tests)
Zoltan2          = 168.88 sec*proc (111 tests)
```
