### PR TITLE
WIP Tpetra: persistent MPI requests

### DIFF
--- a/packages/teuchos/comm/src/Teuchos_DefaultSerialComm.hpp
+++ b/packages/teuchos/comm/src/Teuchos_DefaultSerialComm.hpp
@@ -181,17 +181,48 @@ public:
   ireceive (const ArrayView<char> &Buffer,
             const int sourceRank,
             const int tag) const;
+  virtual RCP<CommRequest<Ordinal> > sendInit(
+    const ArrayView<const char> &sendBuffer,
+    const int destRank
+    ) const;
+  //! Variant of sendInit() that takes a tag.
+  virtual RCP<CommRequest<Ordinal> >
+  sendInit (const ArrayView<const char> &sendBuffer,
+         const int destRank,
+         const int tag) const;
+  /** \brief . */
+  virtual RCP<CommRequest<Ordinal> > receiveInit(
+    const ArrayView<char> &Buffer,
+    const int sourceRank
+    ) const;
+  /** \brief . */
+  virtual RCP<CommRequest<Ordinal> >
+  receiveInit (const ArrayView<char> &Buffer,
+            const int sourceRank,
+            const int tag) const;
   /** \brief . */
   virtual void waitAll(
-    const ArrayView<RCP<CommRequest<Ordinal> > > &requests
+    const ArrayView<RCP<CommRequest<Ordinal> > > &requests,
+    bool releaseRequests=true
     ) const;
   /** \brief . */
   virtual void
   waitAll (const ArrayView<RCP<CommRequest<Ordinal> > >& requests,
-           const ArrayView<RCP<CommStatus<Ordinal> > >& statuses) const;
+           const ArrayView<RCP<CommStatus<Ordinal> > >& statuses,
+           bool releaseRequests=true) const;
   /** \brief . */
   virtual RCP<CommStatus<Ordinal> >
   wait (const Ptr<RCP<CommRequest<Ordinal> > >& request) const;
+  /** \brief . */
+  virtual void
+  start (const Ptr<RCP<CommRequest<Ordinal> > >& request) const;
+  /** \brief . */
+  virtual void startAll(
+    const ArrayView<RCP<CommRequest<Ordinal> > > &requests
+    ) const;
+  /** \brief . */
+  virtual void
+  free (const Ptr<RCP<CommRequest<Ordinal> > >& request) const;
   /** \brief . */
   virtual RCP< Comm<Ordinal> > duplicate() const;
   /** \brief . */
@@ -472,7 +503,50 @@ ireceive (const ArrayView<char> &/*Buffer*/,
 
 
 template<typename Ordinal>
-void SerialComm<Ordinal>::waitAll (const ArrayView<RCP<CommRequest<Ordinal> > >& requests) const
+RCP<CommRequest<Ordinal> > SerialComm<Ordinal>::sendInit(
+  const ArrayView<const char> &/*sendBuffer*/,
+  const int /*destRank*/
+  ) const
+{
+  TEUCHOS_TEST_FOR_EXCEPTION( true, std::logic_error, "SerialComm<Ordinal>::sendInit: You cannot call sendInit when you only have one process." );
+}
+
+
+template<typename Ordinal>
+RCP<CommRequest<Ordinal> >
+SerialComm<Ordinal>::
+sendInit (const ArrayView<const char> &/*sendBuffer*/,
+       const int /*destRank*/,
+       const int /*tag*/) const
+{
+  TEUCHOS_TEST_FOR_EXCEPTION( true, std::logic_error, "SerialComm<Ordinal>::sendInit: You cannot call sendInit when you only have one process." );
+}
+
+
+template<typename Ordinal>
+RCP<CommRequest<Ordinal> > SerialComm<Ordinal>::receiveInit(
+  const ArrayView<char> &/*Buffer*/,
+  const int /*sourceRank*/
+  ) const
+{
+  TEUCHOS_TEST_FOR_EXCEPTION( true, std::logic_error, "SerialComm<Ordinal>::receiveInit: You cannot call isend when you only have one process." );
+}
+
+
+template<typename Ordinal>
+RCP<CommRequest<Ordinal> >
+SerialComm<Ordinal>::
+receiveInit (const ArrayView<char> &/*Buffer*/,
+          const int /*sourceRank*/,
+          const int /*tag*/) const
+{
+  TEUCHOS_TEST_FOR_EXCEPTION( true, std::logic_error, "SerialComm<Ordinal>::receiveInit: You cannot call isend when you only have one process." );
+}
+
+
+template<typename Ordinal>
+void SerialComm<Ordinal>::waitAll (const ArrayView<RCP<CommRequest<Ordinal> > >& requests,
+                                   bool releaseRequests) const
 {
   (void) requests;
   // There's nothing to wait on!
@@ -483,7 +557,8 @@ template<typename Ordinal>
 void
 SerialComm<Ordinal>::
 waitAll (const ArrayView<RCP<CommRequest<Ordinal> > >& requests,
-         const ArrayView<RCP<CommStatus<Ordinal> > >& statuses) const
+         const ArrayView<RCP<CommStatus<Ordinal> > >& statuses,
+         bool releaseRequests) const
 {
   TEUCHOS_TEST_FOR_EXCEPTION(statuses.size() < requests.size(),
     std::invalid_argument, "Teuchos::SerialComm::waitAll: There are not enough "
@@ -510,6 +585,34 @@ SerialComm<Ordinal>::wait (const Ptr<RCP<CommRequest<Ordinal> > > & request) con
   }
   *request = null;
   return rcp (new SerialCommStatus<Ordinal>);
+}
+
+template<typename Ordinal>
+void
+SerialComm<Ordinal>::start (const Ptr<RCP<CommRequest<Ordinal> > > & request) const
+{
+  (void) request;
+  TEUCHOS_TEST_FOR_EXCEPTION(request.getRawPtr() == NULL, std::invalid_argument,
+    "Teuchos::SerialComm::start: On input, the request pointer is null.");
+  *request = null;
+}
+
+template<typename Ordinal>
+void
+SerialComm<Ordinal>::free (const Ptr<RCP<CommRequest<Ordinal> > > & request) const
+{
+  (void) request;
+  TEUCHOS_TEST_FOR_EXCEPTION(request.getRawPtr() == NULL, std::invalid_argument,
+    "Teuchos::SerialComm::free: On input, the request pointer is null.");
+  *request = null;
+}
+
+
+template<typename Ordinal>
+void SerialComm<Ordinal>::startAll (const ArrayView<RCP<CommRequest<Ordinal> > >& requests) const
+{
+  (void) requests;
+  // There's nothing to start!
 }
 
 template< typename Ordinal>

--- a/packages/teuchos/kokkoscomm/src/Kokkos_TeuchosCommAdapters.hpp
+++ b/packages/teuchos/kokkoscomm/src/Kokkos_TeuchosCommAdapters.hpp
@@ -122,6 +122,33 @@ ireceive (const ViewType& recvBuffer,
 }
 
 
+//! Variant of sendInit() that takes a tag (and restores the correct order of arguments).
+template<typename Ordinal, class ViewType>
+typename std::enable_if<(Kokkos::Impl::is_view<ViewType>::value),RCP<CommRequest<Ordinal> >>::type
+sendInit (const ViewType& sendBuffer,
+          const int destRank,
+          const int tag,
+          const Comm<Ordinal>& comm)
+{
+  using Kokkos::Compat::persistingView;
+  // See Issue #1454: https://github.com/trilinos/Trilinos/issues/1454
+  typename ViewType::const_type sendBuffer_const = sendBuffer;
+  return sendInit (persistingView (sendBuffer_const), destRank, tag, comm);
+}
+
+//! Variant of receiveInit that takes a tag argument (and restores the correct order of arguments).
+template<typename Ordinal, class ViewType>
+typename std::enable_if<(Kokkos::Impl::is_view<ViewType>::value),RCP<CommRequest<Ordinal> >>::type
+receiveInit (const ViewType& recvBuffer,
+             const int sourceRank,
+             const int tag,
+             const Comm<Ordinal>& comm)
+{
+  using Kokkos::Compat::persistingView;
+  return receiveInit(persistingView(recvBuffer), sourceRank, tag, comm);
+}
+
+
 template<typename Ordinal, typename SendViewType, typename RecvViewType>
 typename std::enable_if<(Kokkos::Impl::is_view<SendViewType>::value && Kokkos::Impl::is_view<RecvViewType>::value)>::type
 reduceAll (const SendViewType& sendBuf,

--- a/packages/tpetra/core/src/Tpetra_Distributor.cpp
+++ b/packages/tpetra/core/src/Tpetra_Distributor.cpp
@@ -382,6 +382,9 @@ namespace Tpetra {
       // ParameterListAcceptor semantics require pointer identity of the
       // sublist passed to setParameterList(), so we save the pointer.
       this->setMyParamList (plist);
+
+      if (!reverseDistributor_.is_null())
+        reverseDistributor_->setParameterList (plist);
     }
   }
 


### PR DESCRIPTION
@trilinos/tpetra 

## Description
This PR adds the option to use persistent MPI communication in Tpetra. The defaults communication option is not changed. I tested this using MueLu, where this can be switched on for the solve phase only. There are probably quite a lot of cases where this will not work correctly, so I appreciate feedback! 