### PR TITLE
Werror domi fix

### DIFF
--- a/cmake/std/PullRequestLinuxGCC7.2.0TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxGCC7.2.0TestingSettings.cmake
@@ -27,7 +27,7 @@ set(CMAKE_CXX_FLAGS "-Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pra
 
 #set (Anasazi_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")
 #set (Belos_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")
-#set (Domi_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")
+set (Domi_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")
 #set (Epetra_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")
 set (EpetraExt_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")
 #set (FEI_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")

--- a/packages/domi/src/Domi_MDMap.hpp
+++ b/packages/domi/src/Domi_MDMap.hpp
@@ -1245,7 +1245,6 @@ getTpetraAxisMap(int axis,
     "invalid axis index = " << axis << " (number of dimensions = " <<
     numDims() << ")");
 #endif
-  int num_dims = numDims();
   Teuchos::RCP< const Teuchos::Comm< int > > teuchosComm =
     _mdComm->getTeuchosComm();
   Teuchos::Array< GlobalOrdinal > elements(getLocalDim(axis,withCommPad));

--- a/packages/domi/src/Domi_MDVector.hpp
+++ b/packages/domi/src/Domi_MDVector.hpp
@@ -2287,7 +2287,7 @@ getTpetraMultiVectorView() const
   for (int axis = 1; axis < newMdMap->numDims(); ++axis)
     stride *= newMdMap->getLocalDim(axis,true);
   TEUCHOS_TEST_FOR_EXCEPTION(
-    stride*numVectors > Teuchos::OrdinalTraits<GlobalOrdinal>::max(),
+    (long long int)(stride*numVectors) > Teuchos::OrdinalTraits<GlobalOrdinal>::max(),
     MapOrdinalError,
     "Buffer size " << stride*numVectors << " is too large for Tpetra "
     "GlobalOrdinal = " << typeid(GlobalOrdinal).name() );


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework
@trilinos/domi

## Description
<!--- Please describe your changes in detail. -->
This sets Werror for Domi in the GCC 7.2.0 PR build and makes a couple minor changes to take care of errors Werror creates.
## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
This is work toward #3178 turning Werror on for all packages and takes care of [these issues](https://testing.sandia.gov/cdash/index.php?project=Trilinos&parentid=4623048) for Domi from #4506.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
