### PR TITLE
Sacado:  Add method to clear parameter library.

### DIFF
--- a/packages/sacado/src/parameter/Sacado_ParameterLibraryBase.hpp
+++ b/packages/sacado/src/parameter/Sacado_ParameterLibraryBase.hpp
@@ -134,6 +134,9 @@ namespace Sacado {
      */
     void print(std::ostream& os, bool print_values = false) const;
 
+    //! Clear the library
+    void clear() { library = FamilyMap(); }
+
   private:
 
     //! Private to prohibit copying


### PR DESCRIPTION
Needed for, e.g., unit-tests in codes that need to recreate the
parameter library every test, but use a singleton library.