### PR TITLE
LOCA:  Add parameter and logic to compute eigenvalues on target step.

### DIFF
--- a/packages/nox/src-loca/src/LOCA_Description.H
+++ b/packages/nox/src-loca/src/LOCA_Description.H
@@ -167,6 +167,7 @@ The parameter list passed to the Stepper has two sublists, "LOCA" and "NOX".  Th
               </ul>
                 </ul>
       <li> <B>"Compute Eigenvalues"</B> -- [bool] (default: false) Flag for requesting eigenvalue calculation after each continuation step
+      <li> <B>"Compute Eigenvalues On Target Step"</B> -- [bool] (default: false) Compute eigenvalues after last continuation step when attempting to hit parameter target
           <li> <B>"Eigensolver"</B> sublist -- used by LOCA::Eigensolver::Factory to determine eigensolver strategies
           <ul>
           <li> <B>"Method"</B> -- [string] (default "Default") Choices are

--- a/packages/nox/src-loca/src/LOCA_Stepper.C
+++ b/packages/nox/src-loca/src/LOCA_Stepper.C
@@ -107,6 +107,7 @@ LOCA::Stepper::Stepper(
   minTangentFactor(0.1),
   tangentFactorExponent(1.0),
   calcEigenvalues(false),
+  calcEigenvaluesTargetStep(false),
   return_failed_on_max_steps(true),
   printOnlyConvergedSol(p->get("Write Only Converged Solution", true))
 {
@@ -150,6 +151,7 @@ LOCA::Stepper::Stepper(
   minTangentFactor(0.1),
   tangentFactorExponent(1.0),
   calcEigenvalues(false),
+  calcEigenvaluesTargetStep(false),
   return_failed_on_max_steps(true),
   printOnlyConvergedSol(p->get("Write Only Converged Solution", true))
 {
@@ -288,6 +290,7 @@ LOCA::Stepper::resetExceptLocaStatusTest(
   tangentFactorExponent =
     stepperList->get("Tangent Factor Exponent",1.0);
   calcEigenvalues = stepperList->get("Compute Eigenvalues",false);
+  calcEigenvaluesTargetStep = stepperList->get("Compute Eigenvalues On Target Step",false);
 
   // TODO Deprecated as moved to LOCA::StatusTest::MaxIters
   return_failed_on_max_steps =
@@ -520,6 +523,9 @@ LOCA::Stepper::finish(LOCA::Abstract::Iterator::IteratorStatus itStatus)
 
     // Solve step
     NOX::StatusTest::StatusType solverStatus = solverPtr->solve();
+
+    // Compute eigenvalues/eigenvectors if requested
+    if (calcEigenvaluesTargetStep) computeEigenData();
 
     // Allow continuation group to postprocess the step
     if (solverStatus == NOX::StatusTest::Converged)

--- a/packages/nox/src-loca/src/LOCA_Stepper.H
+++ b/packages/nox/src-loca/src/LOCA_Stepper.H
@@ -360,6 +360,9 @@ namespace LOCA {
     //! Flag indicating whether to compute eigenvalues after each step
     bool calcEigenvalues;
 
+    //! Flag indicating whether to compute eigenvalues on last (target) step
+    bool calcEigenvaluesTargetStep;
+
     //! Flag indicating whether to return failed upon reaching max steps
     bool return_failed_on_max_steps;
 


### PR DESCRIPTION
Previously the LOCA Stepper didn't compute any eigenvalues on the final
target step when LOCA attempts to hit the parameter bound.  I added
another parameter, "Compute Eigenvalues On Target Step", to enable this.
I didn't just use the existing parameter, "Compute Eigenvalues", because
that would change LOCA's default behavior when computing eigenvalues,
and was unsure of the consequences for existing applications.