### PR TITLE
Remove unused var (#4789)

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_StaticView.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_StaticView.hpp
@@ -165,7 +165,6 @@ getStatic2dDualView (const size_t num_rows, const size_t num_cols)
     Kokkos::DualView<ValueType**, Kokkos::LayoutLeft, DeviceType>;
   using d_view_type = typename dual_view_type::t_dev;
   using h_view_type = typename dual_view_type::t_host;
-  using host_device_type = typename h_view_type::device_type;
 
   auto d_view = getStatic2dView<ValueType, DeviceType> (num_rows, num_cols);
   // Preserve the invariant that Kokkos::create_mirror_view returns


### PR DESCRIPTION
CC: @trilinos/tpetra 

This one unused var warning brings down the entire1 -Werror builds of SPARC.

I tested this with SPARC and it fixed the build.

```
$ env  \
    ATDM_TRIL_SPARC_BUILDS_LIST=cee-rhel6_clang-5.0.1_openmpi-1.10.2_serial_static_opt \
    ATDM_TRIL_SPARC_USE_OFFICAL_INSTALL=1 \
    ATDM_TRIL_SPARC_ATDM_USE_INSTALL_DIR=/projects/atdm_devops/trilinos_installs/2019-03-30 \
    ATDM_TRIL_SPARC_SKIP_NATIVE_BUILD=1 \
  ./sparc-tril-dev-scripts/run_builds_and_tests.sh
```

and it passed with:

```
97% tests passed, 7 tests failed out of 278
```




