### PR TITLE
Tpetra: Fix #4797

### DIFF
--- a/packages/PyTrilinos/src/Tpetra.i
+++ b/packages/PyTrilinos/src/Tpetra.i
@@ -1133,7 +1133,6 @@ public:
   Teuchos::ArrayRCP<Teuchos::ArrayRCP<const Scalar> > get2dView() const;
   Teuchos::ArrayRCP<Scalar> get1dViewNonConst();
   Teuchos::ArrayRCP<Teuchos::ArrayRCP<Scalar> > get2dViewNonConst();
-  // dual_view_type getDualView() const;
   template<class TargetDeviceType>
   void sync();
   template<class TargetDeviceType>

--- a/packages/nox/test/tpetra/1DFEM_Functors.hpp
+++ b/packages/nox/test/tpetra/1DFEM_Functors.hpp
@@ -21,7 +21,7 @@ struct MeshFillFunctor
                   const Scalar& zMin,
                   const Scalar& dz,
                   const GO& minGID) :
-    coordsView_(coords.getDualView().d_view),
+    coordsView_(coords.getLocalViewDevice()),
     zMin_(zMin),
     dz_(dz),
     minGID_(minGID)
@@ -272,9 +272,9 @@ struct ResidualEvaluatorFunctor
                            const TpetraVectorType& x,
                            const TpetraVectorType& u,
                            const int& myRank) :
-    f_view_(f.getDualView().d_view),
-    x_view_(x.getDualView().d_view),
-    u_view_(u.getDualView().d_view),
+    f_view_(f.getLocalViewDevice()),
+    x_view_(x.getLocalViewDevice()),
+    u_view_(u.getLocalViewDevice()),
     row_map_(f.getMap()->getLocalMap()),
     col_map_(u.getMap()->getLocalMap()),
     myRank_(myRank)
@@ -348,8 +348,8 @@ struct JacobianEvaluatorFunctor
                            const TpetraVectorType& u,
                            const int& myRank) :
     J_local_(J.getLocalMatrix()),
-    x_view_(x.getDualView().d_view),
-    u_view_(u.getDualView().d_view),
+    x_view_(x.getLocalViewDevice()),
+    u_view_(u.getLocalViewDevice()),
     row_map_(J.getRowMap()->getLocalMap()),
     col_map_(J.getColMap()->getLocalMap()),
     myRank_(myRank)
@@ -434,8 +434,8 @@ struct PreconditionerEvaluatorFunctor
                                  const TpetraVectorType& u,
                                  const int& myRank) :
     M_local_(M.getLocalMatrix()),
-    x_view_(x.getDualView().d_view),
-    u_view_(u.getDualView().d_view),
+    x_view_(x.getLocalViewDevice()),
+    u_view_(u.getLocalViewDevice()),
     row_map_(M.getRowMap()->getLocalMap()),
     col_map_(M.getColMap()->getLocalMap()),
     myRank_(myRank)

--- a/packages/rol/adapters/tpetra/src/function/ROL_TpetraBoundConstraint.hpp
+++ b/packages/rol/adapters/tpetra/src/function/ROL_TpetraBoundConstraint.hpp
@@ -56,7 +56,7 @@
 
 namespace ROL {
 
-    namespace KokkosStructs { // Parallel for and reduce functions 
+    namespace KokkosStructs { // Parallel for and reduce functions
 
         //----------------------------------------------------------------------
         //
@@ -75,23 +75,23 @@ namespace ROL {
                 for(int j=0;j<M;++j) {
                     Real gap = U_(i,j)-L_(i,j);
                     if(gap<min) {
-                        min = gap; 
+                        min = gap;
                     }
-                }    
+                }
             }
 
             KOKKOS_INLINE_FUNCTION
             void init(Real &min) const {
-                min = U_(0,0)-L_(0,0);   
-            }          
-        
+                min = U_(0,0)-L_(0,0);
+            }
+
             KOKKOS_INLINE_FUNCTION
             void join(volatile Real &globalMin,
                       const volatile Real &localMin) const {
                 if(localMin<globalMin) {
-                    globalMin = localMin;    
+                    globalMin = localMin;
                 }
-            } 
+            }
         }; // End struct MinGap
 
         //----------------------------------------------------------------------
@@ -115,23 +115,23 @@ namespace ROL {
                     }
                 }
             }
-             
+
             KOKKOS_INLINE_FUNCTION
             void init(int &feasible) const {
-                feasible = 1; 
-            }            
+                feasible = 1;
+            }
 
             KOKKOS_INLINE_FUNCTION
             void join(volatile int &globalFeasible,
                       const volatile int &localFeasible) const {
                 globalFeasible *= localFeasible;
             }
-                 
-        }; // End struct Feasible 
+
+        }; // End struct Feasible
 
         //----------------------------------------------------------------------
         //
-        // Project x onto the bounds  
+        // Project x onto the bounds
         template<class Real, class V>
         struct Project {
             typedef typename V::execution_space execution_space;
@@ -146,14 +146,14 @@ namespace ROL {
                 const int M = L_.extent(1);
                 for(int j=0;j<M;++j) {
                     if( X_(i,j)<L_(i,j) ) {
-                        X_(i,j) = L_(i,j); 
+                        X_(i,j) = L_(i,j);
                     }
                     else if( X_(i,j)>U_(i,j) ) {
-                        X_(i,j) = U_(i,j); 
+                        X_(i,j) = U_(i,j);
                     }
-                }         
+                }
             }
-        };   // End struct Project             
+        };   // End struct Project
 
         //----------------------------------------------------------------------
         //
@@ -164,9 +164,9 @@ namespace ROL {
             V Y_; // Variable to be pruned
             V X_; // Optimization variable
             V L_; // Lower bounds
-            Real eps_;  
+            Real eps_;
 
-            PruneLowerActive(V &Y, const V &X, const V &L,  Real eps) : 
+            PruneLowerActive(V &Y, const V &X, const V &L,  Real eps) :
                 Y_(Y), X_(X), L_(L), eps_(eps) {}
 
             KOKKOS_INLINE_FUNCTION
@@ -175,7 +175,7 @@ namespace ROL {
                 for(int j=0;j<M;++j) {
                     if(X_(i,j)<=L_(i,j)+eps_) {
                         Y_(i,j) = 0.0;
-                    } 
+                    }
                 }
             }
         }; // End struct PruneLowerActive
@@ -189,9 +189,9 @@ namespace ROL {
             V Y_; // Variable to be pruned
             V X_; // Optimization variable
             V U_; // Upper bounds
-            Real eps_;  
+            Real eps_;
 
-            PruneUpperActive(V &Y, const V &X, const V &U, Real eps) : 
+            PruneUpperActive(V &Y, const V &X, const V &U, Real eps) :
                 Y_(Y), X_(X), U_(U), eps_(eps) {}
 
             KOKKOS_INLINE_FUNCTION
@@ -200,7 +200,7 @@ namespace ROL {
                 for(int j=0;j<M;++j) {
                     if(X_(i,j)>=U_(i,j)-eps_) {
                         Y_(i,j) = 0.0;
-                    } 
+                    }
                 }
             }
         }; // End struct PruneUpperActive
@@ -215,9 +215,9 @@ namespace ROL {
             V X_; // Optimization variable
             V L_; // Lower bounds
             V U_; // Upper bounds
-            Real eps_;  
+            Real eps_;
 
-            PruneActive(V &Y, const V &X, const V &L, const V &U, Real eps) : 
+            PruneActive(V &Y, const V &X, const V &L, const V &U, Real eps) :
                 Y_(Y), X_(X), L_(L), U_(U), eps_(eps) {}
 
             KOKKOS_INLINE_FUNCTION
@@ -226,10 +226,10 @@ namespace ROL {
                 for(int j=0;j<M;++j) {
                     if(X_(i,j)<=L_(i,j)+eps_) {
                         Y_(i,j) = 0.0;
-                    } 
+                    }
                     else if(X_(i,j)>=U_(i,j)-eps_) {
                         Y_(i,j) = 0.0;
-                    } 
+                    }
                 }
             }
         }; // End struct PruneActive
@@ -241,13 +241,13 @@ namespace ROL {
         struct GradPruneLowerActive {
             typedef typename V::execution_space execution_space;
             V Y_; // Variable to be pruned
-            V G_; // Gradient 
+            V G_; // Gradient
             V X_; // Optimization variable
             V L_; // Lower bounds
 
-            Real eps_;  
+            Real eps_;
 
-            GradPruneLowerActive(V &Y, const V &G, const V &X, const V &L,Real eps) : 
+            GradPruneLowerActive(V &Y, const V &G, const V &X, const V &L,Real eps) :
                 Y_(Y), G_(G), X_(X), L_(L), eps_(eps) {}
 
             KOKKOS_INLINE_FUNCTION
@@ -256,7 +256,7 @@ namespace ROL {
                 for(int j=0;j<M;++j) {
                     if( (X_(i,j)<=L_(i,j)+eps_) && G_(i,j) > 0.0 ) {
                         Y_(i,j) = 0.0;
-                    } 
+                    }
                 }
             }
         }; // End struct GradPruneLowerActive
@@ -268,13 +268,13 @@ namespace ROL {
         struct GradPruneUpperActive {
             typedef typename V::execution_space execution_space;
             V Y_; // Variable to be pruned
-            V G_; // Gradient 
+            V G_; // Gradient
             V X_; // Optimization variable
             V U_; // Upper bounds
 
-            Real eps_;  
+            Real eps_;
 
-            GradPruneUpperActive(V &Y, const V &G, const V &X, const V &U, Real eps) : 
+            GradPruneUpperActive(V &Y, const V &G, const V &X, const V &U, Real eps) :
                 Y_(Y), G_(G), X_(X), U_(U), eps_(eps) {}
 
             KOKKOS_INLINE_FUNCTION
@@ -283,14 +283,14 @@ namespace ROL {
                 for(int j=0;j<M;++j) {
                     if( (X_(i,j)>=U_(i,j)-eps_) && G_(i,j) < 0.0 ) {
                         Y_(i,j) = 0.0;
-                    } 
+                    }
                 }
             }
         }; // End struct GradPruneUpperActive
 
         //----------------------------------------------------------------------
         //
-        // Set variables to zero if they correspond to the active set 
+        // Set variables to zero if they correspond to the active set
         template<class Real, class V>
         struct GradPruneActive {
             typedef typename V::execution_space execution_space;
@@ -299,9 +299,9 @@ namespace ROL {
             V X_; // Optimization variable
             V L_; // Lower bounds
             V U_; // Upper bounds
-            Real eps_;  
+            Real eps_;
 
-            GradPruneActive(V &Y, const V &G, const V &X, const V &L, const V &U, Real eps) : 
+            GradPruneActive(V &Y, const V &G, const V &X, const V &L, const V &U, Real eps) :
                 Y_(Y), G_(G), X_(X), L_(L), U_(U), eps_(eps) {}
 
             KOKKOS_INLINE_FUNCTION
@@ -310,10 +310,10 @@ namespace ROL {
                 for(int j=0;j<M;++j) {
                     if(( X_(i,j)<=L_(i,j)+eps_) && (G_(i,j)>0.0))  {
                         Y_(i,j) = 0.0;
-                    } 
+                    }
                     else if(( X_(i,j)>=U_(i,j)-eps_) && (G_(i,j)<0.0) ) {
                         Y_(i,j) = 0.0;
-                    } 
+                    }
                 }
             }
         }; // End struct GradPruneActive
@@ -327,12 +327,12 @@ namespace ROL {
     template <class Real, class LO, class GO, class Node>
     class TpetraBoundConstraint : public BoundConstraint<Real> {
 
-         
+
         typedef Tpetra::MultiVector<Real,LO,GO,Node> MV;
         typedef ROL::Ptr<MV> MVP;
         typedef ROL::Ptr<const MV> CMVP;
         typedef TpetraMultiVector<Real,LO,GO,Node> TMV;
-        typedef ROL::Ptr<TMV> TMVP; 
+        typedef ROL::Ptr<TMV> TMVP;
         typedef typename MV::dual_view_type::t_dev ViewType;
 
         private:
@@ -345,7 +345,7 @@ namespace ROL {
             ViewType u_;           // Kokkos view of Upper bounds
             Real min_diff_;
             Real scale_;
-            ROL::Ptr<const Teuchos::Comm<int> > comm_; 
+            ROL::Ptr<const Teuchos::Comm<int> > comm_;
 
         ROL::Ptr<const MV> getVector( const ROL::Vector<Real>& x ) {
           return dynamic_cast<const TMV&>(x).getVector();
@@ -357,13 +357,13 @@ namespace ROL {
 
         public:
 
-            TpetraBoundConstraint(MVP lp, MVP up, Real scale = 1.0) :  
+            TpetraBoundConstraint(MVP lp, MVP up, Real scale = 1.0) :
                 gblDim_(lp->getGlobalLength()),
                 lclDim_(lp->getLocalLength()),
                 lp_(lp),
                 up_(up),
-                l_(lp->getDualView().d_view), 
-                u_(up->getDualView().d_view), 
+                l_(lp->getLocalViewDevice()),
+                u_(up->getLocalViewDevice()),
                 scale_(scale),
                 comm_(lp->getMap()->getComm()) {
 
@@ -371,24 +371,24 @@ namespace ROL {
                 Real lclMinGap = 0;
 
                 // Reduce for this MPI process
-                Kokkos::parallel_reduce(lclDim_,findmin,lclMinGap); 
+                Kokkos::parallel_reduce(lclDim_,findmin,lclMinGap);
 
                 Real gblMinGap;
 
-                // Reduce over MPI processes                 
+                // Reduce over MPI processes
                 Teuchos::reduceAll<int,Real>(*comm_,Teuchos::REDUCE_MIN,lclMinGap,Teuchos::outArg(gblMinGap));
-          
+
                 min_diff_ = 0.5*gblMinGap;
-            } 
-     
+            }
+
 
             bool isFeasible( const Vector<Real> &x ) {
                 auto xp = getVector(x);
 
                 int lclFeasible = 1;
-                 
-                ViewType x_lcl = xp->getDualView().d_view;
-                
+
+                ViewType x_lcl = xp->getLocalViewDevice();
+
                 KokkosStructs::Feasible<Real,ViewType> check(x_lcl, l_, u_);
 
                 Kokkos::parallel_reduce(lclDim_,check,lclFeasible);
@@ -398,19 +398,19 @@ namespace ROL {
                 Teuchos::reduceAll<int,Real>(*comm_,Teuchos::REDUCE_MIN,lclFeasible,Teuchos::outArg(gblFeasible));
 
                 return gblFeasible == 1 ? true : false;
-            }            
+            }
 
             void project( Vector<Real> &x ) {
 
                 auto xp = getVector(x);
-                
-                ViewType x_lcl = xp->getDualView().d_view;
+
+                ViewType x_lcl = xp->getLocalViewDevice();
 
                 KokkosStructs::Project<Real,ViewType> proj(x_lcl,l_,u_);
 
                 Kokkos::parallel_for(lclDim_,proj);
-            }   
- 
+            }
+
 
             void pruneLowerActive(Vector<Real> &v, const Vector<Real> &x, Real eps) {
                 auto xp = getVector(x);
@@ -418,70 +418,70 @@ namespace ROL {
 
                 Real epsn = std::min(scale_*eps,this->min_diff_);
 
-                ViewType x_lcl = xp->getDualView().d_view;
-                ViewType v_lcl = vp->getDualView().d_view;
+                ViewType x_lcl = xp->getLocalViewDevice();
+                ViewType v_lcl = vp->getLocalViewDevice();
 
                 KokkosStructs::PruneLowerActive<Real,ViewType> prune(v_lcl,x_lcl,l_,epsn);
 
-                Kokkos::parallel_for(lclDim_,prune);                
+                Kokkos::parallel_for(lclDim_,prune);
             }
-              
+
             void pruneUpperActive(Vector<Real> &v, const Vector<Real> &x, Real eps) {
                 auto xp = getVector(x);
                 auto vp = getVector(v);
 
                 Real epsn = std::min(scale_*eps,this->min_diff_);
 
-                ViewType x_lcl = xp->getDualView().d_view;
-                ViewType v_lcl = vp->getDualView().d_view;
+                ViewType x_lcl = xp->getLocalViewDevice();
+                ViewType v_lcl = vp->getLocalViewDevice();
 
                 KokkosStructs::PruneUpperActive<Real,ViewType> prune(v_lcl,x_lcl,u_,epsn);
 
-                Kokkos::parallel_for(lclDim_,prune);                
+                Kokkos::parallel_for(lclDim_,prune);
             }
-         
+
             void pruneActive(Vector<Real> &v, const Vector<Real> &x, Real eps) {
                 auto xp = getVector(x);
                 auto vp = getVector(v);
 
                 Real epsn = std::min(scale_*eps,this->min_diff_);
 
-                ViewType x_lcl = xp->getDualView().d_view;
-                ViewType v_lcl = vp->getDualView().d_view;
+                ViewType x_lcl = xp->getLocalViewDevice();
+                ViewType v_lcl = vp->getLocalViewDevice();
 
                 KokkosStructs::PruneActive<Real,ViewType> prune(v_lcl,x_lcl,l_,u_,epsn);
 
-                Kokkos::parallel_for(lclDim_,prune);                
+                Kokkos::parallel_for(lclDim_,prune);
             }
-         
+
             void pruneLowerActive(Vector<Real> &v, const Vector<Real> &g, const Vector<Real> &x, Real eps) {
                 auto xp = getVector(x);
                 auto gp = getVector(g);
                 auto vp = getVector(v);
                Real epsn = std::min(scale_*eps,this->min_diff_);
 
-                ViewType x_lcl = xp->getDualView().d_view;
-                ViewType g_lcl = gp->getDualView().d_view;
-                ViewType v_lcl = vp->getDualView().d_view;
+                ViewType x_lcl = xp->getLocalViewDevice();
+                ViewType g_lcl = gp->getLocalViewDevice();
+                ViewType v_lcl = vp->getLocalViewDevice();
 
                 KokkosStructs::GradPruneLowerActive<Real,ViewType> prune(v_lcl,g_lcl,x_lcl,l_,epsn);
 
-                Kokkos::parallel_for(lclDim_,prune);                
+                Kokkos::parallel_for(lclDim_,prune);
             }
-       
+
              void pruneUpperActive(Vector<Real> &v, const Vector<Real> &g, const Vector<Real> &x, Real eps) {
                 auto xp = getVector(x);
                 auto gp = getVector(g);
                 auto vp = getVector(v);
                 Real epsn = std::min(scale_*eps,this->min_diff_);
 
-                ViewType x_lcl = xp->getDualView().d_view;
-                ViewType g_lcl = gp->getDualView().d_view;
-                ViewType v_lcl = vp->getDualView().d_view;
+                ViewType x_lcl = xp->getLocalViewDevice();
+                ViewType g_lcl = gp->getLocalViewDevice();
+                ViewType v_lcl = vp->getLocalViewDevice();
 
                 KokkosStructs::GradPruneUpperActive<Real,ViewType> prune(v_lcl,g_lcl,x_lcl,u_,epsn);
 
-                Kokkos::parallel_for(lclDim_,prune);                
+                Kokkos::parallel_for(lclDim_,prune);
             }
 
             void pruneActive(Vector<Real> &v, const Vector<Real> &g, const Vector<Real> &x, Real eps) {
@@ -490,15 +490,15 @@ namespace ROL {
                 auto vp = getVector(v);
                 Real epsn = std::min(scale_*eps,this->min_diff_);
 
-                ViewType x_lcl = xp->getDualView().d_view;
-                ViewType g_lcl = gp->getDualView().d_view;
-                ViewType v_lcl = vp->getDualView().d_view;
+                ViewType x_lcl = xp->getLocalViewDevice();
+                ViewType g_lcl = gp->getLocalViewDevice();
+                ViewType v_lcl = vp->getLocalViewDevice();
 
                 KokkosStructs::GradPruneActive<Real,ViewType> prune(v_lcl,g_lcl,x_lcl,l_,u_,epsn);
 
-                Kokkos::parallel_for(lclDim_,prune);                
+                Kokkos::parallel_for(lclDim_,prune);
             }
-      }; // End class TpetraBoundConstraint 
+      }; // End class TpetraBoundConstraint
 
 } // End ROL Namespace
 

--- a/packages/rol/adapters/tpetra/src/vector/ROL_TpetraMultiVector.hpp
+++ b/packages/rol/adapters/tpetra/src/vector/ROL_TpetraMultiVector.hpp
@@ -79,7 +79,7 @@ namespace TPMultiVector {
       const int M = X_.extent(1);
       for(int j=0;j<M;++j) {
         X_(i,j) = f_->apply(X_(i,j));
-      } 
+      }
     }
   };
 
@@ -104,7 +104,7 @@ namespace TPMultiVector {
       for(int j=0;j<M;++j) {
         X_(i,j) = f_->apply(X_(i,j),Y_(i,j));
       }
-    } 
+    }
   };
 
   // Locally define a Kokkos wrapper functor for ReductionOp
@@ -288,7 +288,7 @@ private:
 
 public:
   void applyUnary( const Elementwise::UnaryFunction<Real> &f ) {
-    ViewType v_lcl =  tpetra_vec_->getDualView().d_view;
+    ViewType v_lcl =  tpetra_vec_->getLocalViewDevice();
 
     int lclDim = tpetra_vec_->getLocalLength();
     TPMultiVector::unaryFunc<Real,LO,GO,Node> func(v_lcl, &f);
@@ -305,8 +305,8 @@ public:
    const TpetraMultiVector &ex = dynamic_cast<const TpetraMultiVector&>(x);
    Ptr<const Tpetra::MultiVector<Real,LO,GO,Node> > xp = ex.getVector();
 
-    ViewType v_lcl = tpetra_vec_->getDualView().d_view;
-    ViewType x_lcl = xp->getDualView().d_view;
+    ViewType v_lcl = tpetra_vec_->getLocalViewDevice();
+    ViewType x_lcl = xp->getLocalViewDevice();
 
     int lclDim = tpetra_vec_->getLocalLength();
 
@@ -317,7 +317,7 @@ public:
   }
 
   Real reduce( const Elementwise::ReductionOp<Real> &r ) const {
-    ViewType v_lcl = tpetra_vec_->getDualView().d_view;
+    ViewType v_lcl = tpetra_vec_->getLocalViewDevice();
 
     int lclDim = tpetra_vec_->getLocalLength();
     TPMultiVector::reduceFunc<Real,LO,GO,Node> func(v_lcl, &r);

--- a/packages/stokhos/src/sacado/kokkos/pce/tpetra/Stokhos_Tpetra_UQ_PCE.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/tpetra/Stokhos_Tpetra_UQ_PCE.hpp
@@ -314,36 +314,28 @@ struct PackTraits< Sacado::UQ::PCE<S>, D > {
 namespace Kokkos {
   template <class S, class L, class G, class N>
   size_t dimension_scalar(const Tpetra::MultiVector<S,L,G,N>& mv) {
-    typedef Tpetra::MultiVector<S,L,G,N> MV;
-    typedef typename MV::dual_view_type dual_view_type;
-    typedef typename dual_view_type::t_dev device_type;
-    typedef typename dual_view_type::t_host host_type;
-    dual_view_type dual_view = mv.getDualView();
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-    if (dual_view.modified_host() > dual_view.modified_device())
-      return dimension_scalar(dual_view.template view<device_type>());
-#else
-    if ( dual_view.need_sync_device() )
-    { return dimension_scalar(dual_view.template view<device_type>()); }
-#endif
-    return dimension_scalar(dual_view.template view<host_type>());
+    if ( mv.need_sync_device() ) {
+      // NOTE (mfh 02 Apr 2019) This doesn't look right.  Shouldn't I
+      // want the most recently updated View, which in this case would
+      // be the host View?  However, this is what I found when I
+      // changed these lines not to call deprecated code, so I'm
+      // leaving it.
+      return dimension_scalar(mv.getLocalViewDevice());
+    }
+    return dimension_scalar(mv.getLocalViewHost());
   }
 
   template <class S, class L, class G, class N>
   size_t dimension_scalar(const Tpetra::Vector<S,L,G,N>& v) {
-    typedef Tpetra::Vector<S,L,G,N> V;
-    typedef typename V::dual_view_type dual_view_type;
-    typedef typename dual_view_type::t_dev device_type;
-    typedef typename dual_view_type::t_host host_type;
-    dual_view_type dual_view = v.getDualView();
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-    if (dual_view.modified_host() > dual_view.modified_device())
-      return dimension_scalar(dual_view.template view<device_type>());
-#else
-    if ( dual_view.need_sync_device() )
-    { return dimension_scalar(dual_view.template view<device_type>()); }
-#endif
-    return dimension_scalar(dual_view.template view<host_type>());
+    if ( v.need_sync_device() ) {
+      // NOTE (mfh 02 Apr 2019) This doesn't look right.  Shouldn't I
+      // want the most recently updated View, which in this case would
+      // be the host View?  However, this is what I found when I
+      // changed these lines not to call deprecated code, so I'm
+      // leaving it.
+      return dimension_scalar(v.getLocalViewDevice());
+    }
+    return dimension_scalar(v.getLocalViewHost());
   }
 }
 

--- a/packages/stokhos/src/sacado/kokkos/pce/tpetra/Stokhos_Tpetra_Utilities_UQ_PCE.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/tpetra/Stokhos_Tpetra_Utilities_UQ_PCE.hpp
@@ -234,7 +234,13 @@ namespace Stokhos {
     typedef typename FlatVector::dual_view_type flat_view_type;
 
     // Create flattenend view using special reshaping view assignment operator
-    flat_view_type flat_vals = vec.getDualView();
+    flat_view_type flat_vals (vec.getLocalViewDevice(), vec.getLocalViewHost());
+    if (vec.need_sync_device ()) {
+      flat_vals.modify_host ();
+    }
+    else if (vec.need_sync_host ()) {
+      flat_vals.modify_device ();
+    }
 
     // Create flat vector
     RCP<FlatVector> flat_vec = rcp(new FlatVector(flat_map, flat_vals));
@@ -264,7 +270,13 @@ namespace Stokhos {
     typedef typename FlatVector::dual_view_type flat_view_type;
 
     // Create flattenend view using special reshaping view assignment operator
-    flat_view_type flat_vals = vec.getDualView();
+    flat_view_type flat_vals (vec.getLocalViewDevice(), vec.getLocalViewHost());
+    if (vec.need_sync_device ()) {
+      flat_vals.modify_host ();
+    }
+    else if (vec.need_sync_host ()) {
+      flat_vals.modify_device ();
+    }
 
     // Create flat vector
     RCP<FlatVector> flat_vec = rcp(new FlatVector(flat_map, flat_vals));

--- a/packages/stokhos/src/sacado/kokkos/pce/tpetra/Tpetra_TsqrAdaptor_UQ_PCE.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/tpetra/Tpetra_TsqrAdaptor_UQ_PCE.hpp
@@ -361,12 +361,11 @@ namespace Tpetra {
       // type.  TSQR currently forbids MultiVector input with
       // nonconstant stride, so we need not worry about that here.
 
-      view_type pce_mv = A.getDualView();
-      flat_array_type flat_mv = pce_mv.d_view;
+      flat_array_type flat_mv = A.getLocalViewDevice();
 
       numRows = static_cast<ordinal_type> (flat_mv.extent(0));
       numCols = static_cast<ordinal_type> (flat_mv.extent(1));
-      A_ptr = flat_mv.ptr_on_device ();
+      A_ptr = flat_mv.data ();
 
       ordinal_type strides[2];
       flat_mv.stride (strides);

--- a/packages/stokhos/src/sacado/kokkos/vector/tpetra/Stokhos_Tpetra_Utilities_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/tpetra/Stokhos_Tpetra_Utilities_MP_Vector.hpp
@@ -457,7 +457,13 @@ namespace Stokhos {
     typedef typename FlatVector::dual_view_type flat_view_type;
 
     // Create flattenend view using special reshaping view assignment operator
-    flat_view_type flat_vals = vec.getDualView();
+    flat_view_type flat_vals (vec.getLocalViewDevice(), vec.getLocalViewHost());
+    if (vec.need_sync_device ()) {
+      flat_vals.modify_host ();
+    }
+    else if (vec.need_sync_host ()) {
+      flat_vals.modify_device ();
+    }
 
     // Create flat vector
     RCP<FlatVector> flat_vec = rcp(new FlatVector(flat_map, flat_vals));
@@ -487,7 +493,13 @@ namespace Stokhos {
     typedef typename FlatVector::dual_view_type flat_view_type;
 
     // Create flattenend view using special reshaping view assignment operator
-    flat_view_type flat_vals = vec.getDualView();
+    flat_view_type flat_vals (vec.getLocalViewDevice(), vec.getLocalViewHost());
+    if (vec.need_sync_device ()) {
+      flat_vals.modify_host ();
+    }
+    else if (vec.need_sync_host ()) {
+      flat_vals.modify_device ();
+    }
 
     // Create flat vector
     RCP<FlatVector> flat_vec = rcp(new FlatVector(flat_map, flat_vals));

--- a/packages/stokhos/src/sacado/kokkos/vector/tpetra/Tpetra_TsqrAdaptor_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/tpetra/Tpetra_TsqrAdaptor_MP_Vector.hpp
@@ -361,12 +361,11 @@ namespace Tpetra {
       // type.  TSQR currently forbids MultiVector input with
       // nonconstant stride, so we need not worry about that here.
 
-      view_type mp_mv = A.getDualView();
-      flat_array_type flat_mv = mp_mv.d_view;
+      flat_array_type flat_mv = A.getLocalViewDevice();
 
       numRows = static_cast<ordinal_type> (flat_mv.extent(0));
       numCols = static_cast<ordinal_type> (flat_mv.extent(1));
-      A_ptr = flat_mv.ptr_on_device ();
+      A_ptr = flat_mv.data ();
 
       ordinal_type strides[2];
       flat_mv.stride (strides);

--- a/packages/tpetra/core/src/Tpetra_Details_StaticView.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_StaticView.hpp
@@ -165,7 +165,6 @@ getStatic2dDualView (const size_t num_rows, const size_t num_cols)
     Kokkos::DualView<ValueType**, Kokkos::LayoutLeft, DeviceType>;
   using d_view_type = typename dual_view_type::t_dev;
   using h_view_type = typename dual_view_type::t_host;
-  using host_device_type = typename h_view_type::device_type;
 
   auto d_view = getStatic2dView<ValueType, DeviceType> (num_rows, num_cols);
   // Preserve the invariant that Kokkos::create_mirror_view returns

--- a/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
@@ -1423,21 +1423,32 @@ namespace Tpetra {
     //! Return non-const persisting pointers to values.
     Teuchos::ArrayRCP<Teuchos::ArrayRCP<Scalar> > get2dViewNonConst ();
 
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
     /// \brief Get the Kokkos::DualView which implements local storage.
     ///
-    /// \warning This method is scheduled for DEPRECATION.
+    /// \warning This method is DEPRECATED.  Do not call it any more.
     ///
-    /// \warning This method is ONLY for expert developers.  Its
-    ///   interface may change or it may disappear at any time.
+    /// If you want to sync or modify this MultiVector, call methods
+    /// with the same names as in <tt>Kokkos::DualView</tt>:
+    /// <ul>
+    /// <li> <tt>sync_device</tt> </li>
+    /// <li> <tt>sync_host</tt> </li>
+    /// <li> <tt>modify_device</tt> </li>
+    /// <li> <tt>modify_host</tt> </li>
+    /// </ul>
     ///
-    /// Instead of getting the Kokkos::DualView, we highly recommend
-    /// calling the templated getLocalView() method, that returns a
-    /// Kokkos::View of the MultiVector's data in a given memory
-    /// space.  Since that MultiVector itself implements DualView
-    /// semantics, it's much better to use MultiVector's interface to
-    /// do "DualView things," like calling modify(), need_sync(), and
-    /// sync().
-    dual_view_type getDualView () const;
+    /// If you want to get a Kokkos::View of this MultiVector's local
+    /// data, call <tt>getLocalViewDevice()</tt> to get a device-side
+    /// View, or <tt>getLocalViewHost()</tt> to get a host-side View.
+    ///
+    /// If you want to create a MultiVector that views this
+    /// MultiVector's local data, but with a different Map, use the
+    /// "offset view" constructor (see above).
+    dual_view_type TPETRA_DEPRECATED getDualView () const;
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+
+    //! Clear "modified" flags on both host and device sides.
+    void clear_sync_state ();
 
     /// \brief Update data on device or host only if data in the other
     ///   space has been marked as modified.
@@ -1459,34 +1470,26 @@ namespace Tpetra {
     ///   template parameter.
     template<class TargetDeviceType>
     void sync () {
-      getDualView ().template sync<TargetDeviceType> ();
+      view_.template sync<TargetDeviceType> ();
     }
 
     //! Synchronize to Host
-    inline void sync_host () {
-      getDualView().sync_host();
-    }
+    void sync_host ();
 
     //! Synchronize to Device
-    inline void sync_device () {
-      getDualView().sync_device();
-    }
+    void sync_device ();
 
     //! Whether this MultiVector needs synchronization to the given space.
     template<class TargetDeviceType>
     bool need_sync () const {
-      return getDualView ().template need_sync<TargetDeviceType> ();
+      return view_.template need_sync<TargetDeviceType> ();
     }
 
     //! Whether this MultiVector needs synchronization to the host.
-    inline bool need_sync_host () const {
-      return getDualView().need_sync_host();
-    }
+    bool need_sync_host () const;
 
     //! Whether this MultiVector needs synchronization to the device.
-    inline bool need_sync_device () const {
-      return getDualView().need_sync_device();
-    }
+    bool need_sync_device () const;
 
     /// \brief Mark data as modified on the given device \c TargetDeviceType.
     ///
@@ -1495,18 +1498,15 @@ namespace Tpetra {
     /// Otherwise, mark the host's data as modified.
     template<class TargetDeviceType>
     void modify () {
-      getDualView ().template modify<TargetDeviceType> ();
+      view_.template modify<TargetDeviceType> ();
     }
 
-    /// \brief Mark data as modified on the device
-    inline void modify_device () {
-      getDualView().modify_device();
-    }
+    //! Mark data as modified on the device side.
+    void modify_device ();
 
-    /// \brief Mark data as modified on the host
-    inline void modify_host () {
-      getDualView().modify_host();
-    }
+    //! Mark data as modified on the host side.
+    void modify_host ();
+
     /// \brief Return a view of the local data on a specific device.
     /// \tparam TargetDeviceType The Kokkos Device type whose data to return.
     ///
@@ -1546,18 +1546,14 @@ namespace Tpetra {
       typename dual_view_type::t_dev,
       typename dual_view_type::t_host>::type
     getLocalView () const {
-      return getDualView ().template view<TargetDeviceType> ();
+      return view_.template view<TargetDeviceType> ();
     }
 
-    /// Return a local view on the host
-    typename dual_view_type::t_host getLocalViewHost () const {
-      return getDualView().view_host();
-    }
+    //! A local Kokkos::View of host memory
+    typename dual_view_type::t_host getLocalViewHost () const;
 
-    /// Return a local view on the device
-    typename dual_view_type::t_dev getLocalViewDevice () const {
-      return getDualView().view_device();
-    }
+    //! A local Kokkos::View of device memory
+    typename dual_view_type::t_dev getLocalViewDevice () const;
 
     //@}
     //! @name Mathematical methods

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -1735,7 +1735,6 @@ namespace Tpetra {
     typedef Kokkos::View<dot_type*, Kokkos::HostSpace> RV;
     typedef MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> MV;
     typedef typename dual_view_type::t_dev XMV;
-    typedef typename MV::dual_view_type::t_dev::memory_space dev_memory_space;
     const char tfecfFuncName[] = "Tpetra::MultiVector::dot: ";
 
     ::Tpetra::Details::ProfilingRegion region ("Tpetra::MV::dot (Kokkos::View)");
@@ -1815,7 +1814,7 @@ namespace Tpetra {
 
       auto map = x.getMap ();
       Teuchos::RCP<const Teuchos::Comm<int> > comm =
-	map.is_null () ? Teuchos::null : map->getComm ();
+        map.is_null () ? Teuchos::null : map->getComm ();
       if (comm.is_null ()) {
         return Kokkos::ArithTraits<dot_type>::zero ();
       }
@@ -1832,11 +1831,11 @@ namespace Tpetra {
 
         // All non-unary kernels are executed on the device as per Tpetra policy.  Sync to device if needed.
         if (x.need_sync_device ()) {
-	  x.sync_device ();
-	}
+          x.sync_device ();
+        }
         if (y.need_sync_device ()) {
-	  const_cast<MV&>(y).sync_device ();
-	}
+          const_cast<MV&>(y).sync_device ();
+        }
 
         x.modify_device ();
         auto x_2d = x.getLocalViewDevice ();
@@ -2382,7 +2381,7 @@ namespace Tpetra {
     const bool useHostVersion = this->need_sync_device ();
     if (useHostVersion) {
       // DualView was last modified on host, so run the local kernel there.
-      auto X_lcl = subview (getDualView().view_host (),
+      auto X_lcl = subview (getLocalViewHost (),
                             rowRng, Kokkos::ALL ());
       // Compute the local sum of each column.
       Kokkos::View<impl_scalar_type*, Kokkos::HostSpace> lclSums ("MV::meanValue tmp", numVecs);
@@ -2569,6 +2568,9 @@ namespace Tpetra {
     using Teuchos::ArrayRCP;
     using Teuchos::Comm;
     using Teuchos::RCP;
+    using ST = Scalar;
+    using LO = LocalOrdinal;
+    using GO = GlobalOrdinal;
 
     // mfh 28 Mar 2013: This method doesn't forget whichVectors_, so
     // it might work if the MV is a column view of another MV.
@@ -2641,7 +2643,7 @@ namespace Tpetra {
       const size_t numCols = this->getNumVectors ();
 
       if (origNumRows != newNumRows || view_.extent (1) != numCols) {
-        view_ = allocDualView<Scalar, LocalOrdinal, GlobalOrdinal, Node> (newNumRows, numCols);
+        view_ = allocDualView<ST, LO, GO, Node> (newNumRows, numCols);
       }
     }
     else if (newMap.is_null ()) { // Case 2: current Map is nonnull, new Map is null
@@ -2649,7 +2651,7 @@ namespace Tpetra {
       // have 0 rows.  Keep the number of columns as before.
       const size_t newNumRows = static_cast<size_t> (0);
       const size_t numCols = this->getNumVectors ();
-      view_ = allocDualView<Scalar, LocalOrdinal, GlobalOrdinal, Node> (newNumRows, numCols);
+      view_ = allocDualView<ST, LO, GO, Node> (newNumRows, numCols);
     }
 
     this->map_ = newMap;
@@ -2660,12 +2662,15 @@ namespace Tpetra {
   MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   scale (const Scalar& alpha)
   {
-    const impl_scalar_type theAlpha = static_cast<impl_scalar_type> (alpha);
-    if (theAlpha == Kokkos::Details::ArithTraits<impl_scalar_type>::one ()) {
+    using Kokkos::ALL;
+    using IST = impl_scalar_type;
+
+    const IST theAlpha = static_cast<IST> (alpha);
+    if (theAlpha == Kokkos::ArithTraits<IST>::one ()) {
       return; // do nothing
     }
-    const size_t lclNumRows = this->getLocalLength ();
-    const size_t numVecs = this->getNumVectors ();
+    const size_t lclNumRows = getLocalLength ();
+    const size_t numVecs = getNumVectors ();
     const std::pair<size_t, size_t> rowRng (0, lclNumRows);
     const std::pair<size_t, size_t> colRng (0, numVecs);
 
@@ -2675,35 +2680,29 @@ namespace Tpetra {
     // IEEE 754 requires to be NaN.
 
     // If we need sync to device, then host has the most recent version.
-    const bool useHostVersion = this->need_sync_device ();
+    const bool useHostVersion = need_sync_device ();
     if (useHostVersion) {
-      auto Y_lcl =
-        Kokkos::subview (getDualView().view_host (),
-                         rowRng, Kokkos::ALL ());
+      auto Y_lcl = Kokkos::subview (getLocalViewHost (), rowRng, ALL ());
       if (isConstantStride ()) {
         KokkosBlas::scal (Y_lcl, theAlpha, Y_lcl);
       }
       else {
         for (size_t k = 0; k < numVecs; ++k) {
-          const size_t Y_col = this->isConstantStride () ? k :
-            this->whichVectors_[k];
-          auto Y_k = Kokkos::subview (Y_lcl, Kokkos::ALL (), Y_col);
+          const size_t Y_col = isConstantStride () ? k : whichVectors_[k];
+          auto Y_k = Kokkos::subview (Y_lcl, ALL (), Y_col);
           KokkosBlas::scal (Y_k, theAlpha, Y_k);
         }
       }
     }
     else { // work on device
-      auto Y_lcl =
-        Kokkos::subview (this->getLocalViewDevice (),
-                         rowRng, Kokkos::ALL ());
+      auto Y_lcl = Kokkos::subview (getLocalViewDevice (), rowRng, ALL ());
       if (isConstantStride ()) {
         KokkosBlas::scal (Y_lcl, theAlpha, Y_lcl);
       }
       else {
         for (size_t k = 0; k < numVecs; ++k) {
-          const size_t Y_col = this->isConstantStride () ? k :
-            this->whichVectors_[k];
-          auto Y_k = Kokkos::subview (Y_lcl, Kokkos::ALL (), Y_col);
+          const size_t Y_col = isConstantStride () ? k : whichVectors_[k];
+          auto Y_k = Kokkos::subview (Y_lcl, ALL (), Y_col);
           KokkosBlas::scal (Y_k, theAlpha, Y_k);
         }
       }
@@ -2789,12 +2788,12 @@ namespace Tpetra {
         KokkosBlas::scal (Y_lcl, alphas, Y_lcl);
       }
       else {
-	// FIXME (mfh 15 Mar 2019) We need one coefficient at a time,
-	// as values on host, so copy them to host.  Another approach
-	// would be to fix scal() so that it takes a 0-D View as the
-	// second argument.
-	auto alphas_h = Kokkos::create_mirror_view (alphas);
-	Kokkos::deep_copy (alphas_h, alphas);
+        // FIXME (mfh 15 Mar 2019) We need one coefficient at a time,
+        // as values on host, so copy them to host.  Another approach
+        // would be to fix scal() so that it takes a 0-D View as the
+        // second argument.
+        auto alphas_h = Kokkos::create_mirror_view (alphas);
+        Kokkos::deep_copy (alphas_h, alphas);
 
         for (size_t k = 0; k < numVecs; ++k) {
           const size_t Y_col = this->isConstantStride () ? k :
@@ -2815,8 +2814,6 @@ namespace Tpetra {
     using Kokkos::ALL;
     using Kokkos::subview;
     typedef MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> MV;
-    typedef typename dual_view_type::t_dev::memory_space dev_memory_space;
-
     const char tfecfFuncName[] = "scale: ";
 
     const size_t lclNumRows = getLocalLength ();
@@ -2872,9 +2869,7 @@ namespace Tpetra {
   MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   reciprocal (const MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& A)
   {
-    typedef MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> MV;
-    typedef typename MV::dual_view_type::t_dev::memory_space dev_memory_space;
-
+    using MV = MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
     const char tfecfFuncName[] = "reciprocal: ";
 
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
@@ -2923,10 +2918,9 @@ namespace Tpetra {
   MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   abs (const MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& A)
   {
-    typedef MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> MV;
-    typedef typename MV::dual_view_type::t_dev::memory_space dev_memory_space;
-
+    using MV = MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
     const char tfecfFuncName[] = "abs";
+
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
        getLocalLength () != A.getLocalLength (), std::runtime_error,
        ": MultiVectors do not have the same local length.  "
@@ -2978,8 +2972,7 @@ namespace Tpetra {
     const char tfecfFuncName[] = "update: ";
     using Kokkos::subview;
     using Kokkos::ALL;
-    typedef MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> MV;
-    typedef typename dual_view_type::t_dev::memory_space dev_memory_space;
+    using MV = MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
 
     ::Tpetra::Details::ProfilingRegion region ("Tpetra::MV::update(alpha,A,beta)");
 
@@ -3042,8 +3035,7 @@ namespace Tpetra {
   {
     using Kokkos::ALL;
     using Kokkos::subview;
-    typedef MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> MV;
-    typedef typename dual_view_type::t_dev::memory_space dev_memory_space;
+    using MV = MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
 
     const char tfecfFuncName[] = "update(alpha,A,beta,B,gamma): ";
 
@@ -3115,8 +3107,8 @@ namespace Tpetra {
   getData (size_t j) const
   {
     using Kokkos::ALL;
-    using Kokkos::subview;
-    typedef MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> MV;
+    using MV = MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
+    using IST = impl_scalar_type;
     const char tfecfFuncName[] = "getData: ";
 
     // Any MultiVector method that called the (classic) Kokkos Node's
@@ -3125,15 +3117,10 @@ namespace Tpetra {
     // well.
     const_cast<MV*> (this)->sync_host ();
 
-    // Get a host view of the entire MultiVector's data.
-    auto hostView = getDualView().view_host ();
-
-    // Get a subview of column j.
+    auto hostView = getLocalViewHost ();
     const size_t col = isConstantStride () ? j : whichVectors_[j];
-    auto hostView_j = subview (hostView, ALL (), col);
-
-    // Wrap up the subview of column j in an ArrayRCP<const impl_scalar_type>.
-    Teuchos::ArrayRCP<const impl_scalar_type> dataAsArcp =
+    auto hostView_j = Kokkos::subview (hostView, ALL (), col);
+    Teuchos::ArrayRCP<const IST> dataAsArcp =
       Kokkos::Compat::persistingView (hostView_j, 0, getLocalLength ());
 
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
@@ -3153,7 +3140,8 @@ namespace Tpetra {
   {
     using Kokkos::ALL;
     using Kokkos::subview;
-    typedef MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> MV;
+    using MV = MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
+    using IST = impl_scalar_type;
     const char tfecfFuncName[] = "getDataNonConst: ";
 
     // Any MultiVector method that called the (classic) Kokkos Node's
@@ -3161,20 +3149,14 @@ namespace Tpetra {
     // device->host synchronization.  Thus, we synchronize here as
     // well.
     const_cast<MV*> (this)->sync_host ();
-
     // Calling getDataNonConst() implies that the user plans to modify
     // the values in the MultiVector, so we mark the host data as modified.
-    this->modify_host ();
+    modify_host ();
 
-    // Get a host view of the entire MultiVector's data.
-    auto hostView = getDualView().view_host ();
-
-    // Get a subview of column j.
+    auto hostView = getLocalViewHost ();
     const size_t col = isConstantStride () ? j : whichVectors_[j];
     auto hostView_j = subview (hostView, ALL (), col);
-
-    // Wrap up the subview of column j in an ArrayRCP<const impl_scalar_type>.
-    Teuchos::ArrayRCP<impl_scalar_type> dataAsArcp =
+    Teuchos::ArrayRCP<IST> dataAsArcp =
       Kokkos::Compat::persistingView (hostView_j, 0, getLocalLength ());
 
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
@@ -3699,8 +3681,8 @@ namespace Tpetra {
     using host_view_type = typename dual_view_type::t_host;
     using IST = impl_scalar_type;
     using input_view_type = Kokkos::View<IST**, Kokkos::LayoutLeft,
-					 Kokkos::HostSpace,
-					 Kokkos::MemoryUnmanaged>;
+                                         Kokkos::HostSpace,
+                                         Kokkos::MemoryUnmanaged>;
     const char tfecfFuncName[] = "get1dCopy: ";
 
     const size_t numRows = this->getLocalLength ();
@@ -3720,7 +3702,7 @@ namespace Tpetra {
     const std::pair<size_t, size_t> colRange (0, numCols);
 
     input_view_type A_view_orig (reinterpret_cast<IST*> (A.getRawPtr ()),
-				 LDA, numCols);
+                                 LDA, numCols);
     auto A_view = Kokkos::subview (A_view_orig, rowRange, colRange);
 
     // Use the most recently updated version of this MultiVector's
@@ -3741,25 +3723,25 @@ namespace Tpetra {
 
     if (this->isConstantStride ()) {
       if (useHostVersion) {
-	Kokkos::deep_copy (A_view, srcView_host);
+        Kokkos::deep_copy (A_view, srcView_host);
       }
       else {
-	Kokkos::deep_copy (A_view, srcView_dev);
+        Kokkos::deep_copy (A_view, srcView_dev);
       }
     }
     else {
       for (size_t j = 0; j < numCols; ++j) {
-	const size_t srcCol = this->whichVectors_[j];
-	auto dstColView = Kokkos::subview (A_view, rowRange, j);
+        const size_t srcCol = this->whichVectors_[j];
+        auto dstColView = Kokkos::subview (A_view, rowRange, j);
 
-	if (useHostVersion) {
-	  auto srcColView_host = Kokkos::subview (srcView_host, rowRange, srcCol);
-	  Kokkos::deep_copy (dstColView, srcColView_host);
-	}
-	else {
-	  auto srcColView_dev = Kokkos::subview (srcView_dev, rowRange, srcCol);
-	  Kokkos::deep_copy (dstColView, srcColView_dev);
-	}
+        if (useHostVersion) {
+          auto srcColView_host = Kokkos::subview (srcView_host, rowRange, srcCol);
+          Kokkos::deep_copy (dstColView, srcColView_host);
+        }
+        else {
+          auto srcColView_dev = Kokkos::subview (srcView_dev, rowRange, srcCol);
+          Kokkos::deep_copy (dstColView, srcColView_dev);
+        }
       }
     }
   }
@@ -3817,9 +3799,7 @@ namespace Tpetra {
       if (markModified) {
         X.modify_host ();
       }
-      // get{1,2}dView() and get{1,2}dViewNonConst() all return a host
-      // view of the data.
-      return X.getDualView().view_host();
+      return X.getLocalViewHost ();
     }
   } // namespace (anonymous)
 
@@ -4123,7 +4103,7 @@ namespace Tpetra {
 
     {
       if (A_tmp->need_sync_device ()) {
-	const_cast<MV&> (*A_tmp).sync_device (); // const is a lie
+        const_cast<MV&> (*A_tmp).sync_device (); // const is a lie
       }
       const LO A_lclNumRows = A_tmp->getLocalLength ();
       const LO A_numVecs = A_tmp->getNumVectors ();
@@ -4133,7 +4113,7 @@ namespace Tpetra {
                                     std::make_pair (LO (0), A_numVecs));
 
       if (B_tmp->need_sync_device ()) {
-	const_cast<MV&> (*B_tmp).sync_device (); // const is a lie
+        const_cast<MV&> (*B_tmp).sync_device (); // const is a lie
       }
       const LO B_lclNumRows = B_tmp->getLocalLength ();
       const LO B_numVecs = B_tmp->getNumVectors ();
@@ -4143,7 +4123,7 @@ namespace Tpetra {
                                     std::make_pair (LO (0), B_numVecs));
 
       if (C_tmp->need_sync_device ()) {
-	const_cast<MV&> (*C_tmp).sync_device (); // const is a lie
+        const_cast<MV&> (*C_tmp).sync_device (); // const is a lie
       }
       const LO C_lclNumRows = C_tmp->getLocalLength ();
       const LO C_numVecs = C_tmp->getNumVectors ();
@@ -4159,7 +4139,7 @@ namespace Tpetra {
 
       ProfilingRegion regionGemm ("Tpetra::MV::multiply-call-gemm");
       KokkosBlas::gemm (&ctransA, &ctransB, alpha_IST, A_sub, B_sub,
-			beta_local, C_sub);
+                        beta_local, C_sub);
     }
 
     if (! isConstantStride ()) {
@@ -4186,10 +4166,8 @@ namespace Tpetra {
   {
     using Kokkos::ALL;
     using Kokkos::subview;
-    typedef MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> MV;
-    typedef Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> V;
-    typedef typename MV::dual_view_type::t_dev::memory_space dev_memory_space;
-
+    using MV = MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
+    using V = Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
     const char tfecfFuncName[] = "elementWiseMultiply: ";
 
     const size_t lclNumRows = this->getLocalLength ();
@@ -4417,6 +4395,69 @@ namespace Tpetra {
   }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  void
+  MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
+  clear_sync_state () {
+    view_.clear_sync_state ();
+  }
+
+  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  void
+  MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
+  sync_host () {
+    view_.sync_host ();
+  }
+
+  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  void
+  MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
+  sync_device () {
+    view_.sync_device ();
+  }
+
+  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  bool
+  MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
+  need_sync_host () const {
+    return view_.need_sync_host ();
+  }
+
+  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  bool
+  MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
+  need_sync_device () const {
+    return view_.need_sync_device ();
+  }
+
+  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  void
+  MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
+  modify_device () {
+    view_.modify_device ();
+  }
+
+  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  void
+  MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
+  modify_host () {
+    view_.modify_host ();
+  }
+
+  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  typename MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::dual_view_type::t_dev
+  MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
+  getLocalViewDevice () const {
+    return view_.view_device ();
+  }
+
+  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  typename MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::dual_view_type::t_host
+  MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
+  getLocalViewHost () const {
+    return view_.view_host ();
+  }
+
+  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   std::string
   MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   descriptionImpl (const std::string& className) const
@@ -4497,15 +4538,14 @@ namespace Tpetra {
         // VERB_EXTREME prints values.  Get a host View of the
         // Vector's local data, so we can print it.  (Don't assume
         // that we can access device data directly in host code.)
-        auto X_dual = this->getDualView ();
         typename dual_view_type::t_host X_host;
-        if (X_dual.need_sync_host ()) {
+        if (need_sync_host ()) {
           // Device memory has the latest version.  Don't actually
           // sync to host; that changes the Vector's state, and may
           // change future computations (that use the data's current
           // place to decide where to compute).  Instead, create a
           // temporary host copy and print that.
-          auto X_dev = this->getLocalViewDevice ();
+          auto X_dev = getLocalViewDevice ();
           auto X_host_copy = Kokkos::create_mirror_view (X_dev);
           Kokkos::deep_copy (X_host_copy, X_dev);
           X_host = X_host_copy;
@@ -4514,7 +4554,7 @@ namespace Tpetra {
           // Either host and device are in sync, or host has the
           // latest version of the Vector's data.  Thus, we can use
           // the host version directly.
-          X_host = getDualView ().view_host ();
+          X_host = getLocalViewHost ();
         }
         // The square braces [] and their contents are in Matlab
         // format, so users may copy and paste directly into Matlab.

--- a/packages/tpetra/core/src/Tpetra_computeRowAndColumnOneNorms_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_computeRowAndColumnOneNorms_def.hpp
@@ -902,11 +902,9 @@ globalizeColumnOneNorms (EquilibrationInfo<typename Kokkos::ArithTraits<SC>::val
     // domain Map to the column Map.
     std::unique_ptr<mv_type> rowNorms_colMap;
     if (imp.is_null ()) {
-      // Shallow copy of rowNorms_domMap, since the two must have the
-      // same Maps.
+      // Shallow copy of rowNorms_domMap.
       rowNorms_colMap =
-        std::unique_ptr<mv_type> (new mv_type (G->getColMap (),
-                                               rowNorms_domMap.getDualView ()));
+        std::unique_ptr<mv_type> (new mv_type (rowNorms_domMap, * (G->getColMap ())));
     }
     else {
       rowNorms_colMap =

--- a/packages/tpetra/core/test/MultiVector/Issue364.cpp
+++ b/packages/tpetra/core/test/MultiVector/Issue364.cpp
@@ -165,16 +165,12 @@ namespace { // (anonymous)
 
   TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( MultiVector, DualViewNoncontig, Node )
   {
-    typedef typename Tpetra::MultiVector<>::scalar_type Scalar;
-    typedef typename Tpetra::MultiVector<>::local_ordinal_type LO;
-    typedef typename Tpetra::MultiVector<>::global_ordinal_type GO;
-    typedef typename Tpetra::MultiVector<>::device_type DT;
-    typedef typename DT::memory_space dev_memory_space;
-    typedef Tpetra::Map<LO, GO, Node> map_type;
-    typedef Tpetra::MultiVector<Scalar, LO, GO, Node> MV;
-    typedef typename MV::impl_scalar_type IST;
-    typedef typename Kokkos::View<IST**, DT>::HostMirror::memory_space
-      host_memory_space;
+    using Scalar = typename Tpetra::MultiVector<>::scalar_type;
+    using LO = typename Tpetra::MultiVector<>::local_ordinal_type;
+    using GO = typename Tpetra::MultiVector<>::global_ordinal_type;
+    using map_type = Tpetra::Map<LO, GO, Node>;
+    using MV = Tpetra::MultiVector<Scalar, LO, GO, Node>;
+    using IST = typename MV::impl_scalar_type;
 
     const IST ONE = Kokkos::Details::ArithTraits<IST>::one ();
 
@@ -363,7 +359,7 @@ namespace { // (anonymous)
         auto X_lcl_j_1d = Kokkos::subview (X_lcl_j_2d, Kokkos::ALL (), 0);
 
         // auto X_copy_j = X_copy.getVector (j);
-        // auto X_copy_lcl_j_2d = X_copy_j->template getLocalView<dev_memory_space> ();
+        // auto X_copy_lcl_j_2d = X_copy_j->getLocalViewDevice ();
         // auto X_copy_lcl_j_1d = Kokkos::subview (X_copy_lcl_j_2d, Kokkos::ALL (), 0);
 
         const bool eq = vectorsEqual (X_sub_lcl_j_1d, X_lcl_j_1d);

--- a/packages/tpetra/core/test/MultiVector/MultiVector_UnitTests.cpp
+++ b/packages/tpetra/core/test/MultiVector/MultiVector_UnitTests.cpp
@@ -276,15 +276,15 @@ namespace {
       auto dcmv_map = defaultConstructedMultiVector.getMap ();
       TEST_ASSERT( dcmv_map.get () != nullptr );
       if (dcmv_map.get () != nullptr) {
-	TEST_EQUALITY( dcmv_map->getGlobalNumElements (),
-		       Tpetra::global_size_t (0) );
+        TEST_EQUALITY( dcmv_map->getGlobalNumElements (),
+                       Tpetra::global_size_t (0) );
       }
       vec_type defaultConstructedVector;
       auto dcv_map = defaultConstructedVector.getMap ();
       TEST_ASSERT( dcv_map.get () != nullptr );
       if (dcv_map.get () != nullptr) {
-	TEST_EQUALITY( dcv_map->getGlobalNumElements (),
-		       Tpetra::global_size_t (0) );
+        TEST_EQUALITY( dcv_map->getGlobalNumElements (),
+                       Tpetra::global_size_t (0) );
       }
     }
 
@@ -2171,12 +2171,10 @@ namespace {
           {
             std::ostringstream os;
             os << ">>> Proc " << comm->getSize ();
-            auto A_dv = A.getDualView ();
-            os << ": A.modified_host: " << (A_dv.need_sync_device ()?1:0);
-            os  << ", A.modified_device: " << (A_dv.need_sync_host ()?1:0);
-            auto B_dv = B.getDualView ();
-            os << ": B.modified_host: " << (B_dv.need_sync_device ()?1:0);
-            os << ", B.modified_device: " << (B_dv.need_sync_host ()?1:0);
+            os << ": A.modified_host: " << (A.need_sync_device ()?1:0);
+            os  << ", A.modified_device: " << (A.need_sync_host ()?1:0);
+            os << ": B.modified_host: " << (B.need_sync_device ()?1:0);
+            os << ", B.modified_device: " << (B.need_sync_host ()?1:0);
             os << std::endl;
             std::cerr << os.str ();
           }
@@ -3490,7 +3488,7 @@ namespace {
   //
   // This tests ensures that getLocalView() actually returns a view of
   // the data, NOT a deep copy.
-  TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( MultiVector, getDualView, LO, GO, Scalar, Node )
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( MultiVector, DualViewSemantics, LO, GO, Scalar, Node )
   {
     typedef Tpetra::global_size_t GST;
     typedef Tpetra::Map<LO, GO, Node> map_type;
@@ -3498,7 +3496,7 @@ namespace {
     typedef Teuchos::ScalarTraits<Scalar> STS;
     typedef typename MV::device_type device_type;
 
-    out << "Test: MultiVector, getDualView" << endl;
+    out << "Test: MultiVector's DualView semantics" << endl;
     Teuchos::OSTab tab0 (out);
 
     int lclSuccess = 1;
@@ -3870,9 +3868,8 @@ namespace {
     {
       std::ostringstream os;
       os << ">>> Proc " << comm->getSize ();
-      auto X_gbl_dv = X_gbl.getDualView ();
-      os << ": X_gbl.modified_host: " << (X_gbl_dv.need_sync_device()?1:0)
-         << ", X_gbl.modified_device: " << (X_gbl_dv.need_sync_host()?1:0);
+      os << ": X_gbl.modified_host: " << (X_gbl.need_sync_device()?1:0)
+         << ", X_gbl.modified_device: " << (X_gbl.need_sync_host()?1:0);
       os << std::endl;
       std::cerr << os.str ();
     }
@@ -4636,7 +4633,7 @@ namespace {
       TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( MultiVector, Typedefs          , LO, GO, SCALAR, NODE ) \
       TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( MultiVector, ReplaceMap        , LO, GO, SCALAR, NODE ) \
       TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( MultiVector, DeepCopy          , LO, GO, SCALAR, NODE ) \
-      TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( MultiVector, getDualView       , LO, GO, SCALAR, NODE ) \
+      TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( MultiVector, DualViewSemantics , LO, GO, SCALAR, NODE ) \
       TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( MultiVector, DualViewCtor      , LO, GO, SCALAR, NODE ) \
       TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( MultiVector, ViewCtor          , LO, GO, SCALAR, NODE ) \
       TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( MultiVector, SubViewSomeZeroRows, LO, GO, SCALAR, NODE ) \

--- a/packages/tpetra/core/test/Utils/TpetraUtils_crsUtils.cpp
+++ b/packages/tpetra/core/test/Utils/TpetraUtils_crsUtils.cpp
@@ -243,7 +243,7 @@ TEUCHOS_UNIT_TEST( TpetraUtils, insertIndices )
     size_t num_assigned = 4;
     vector<int> new_indices{0, 2, 4, 6, 8, 7, 5, 3, 1, 2, 6, 8, 4, 0};
     auto num_inserted = insertCrsIndices(0, row_ptrs, cur_indices, num_assigned, new_indices);
-    TEST_EQUALITY(num_inserted, 5);
+    TEST_EQUALITY(static_cast<int>(num_inserted), 5);
     vector<int> expected{1, 3, 5, 7, 0, 2, 4, 6, 8};
     TEST_ASSERT(compare_array_values(cur_indices, expected, expected.size()));
   }
@@ -255,7 +255,8 @@ TEUCHOS_UNIT_TEST( TpetraUtils, insertIndices )
     vector<int> new_indices{1, 0, 2};
     vector<int> expected{3, 6, 9, 12, 1, 0, 2, -1};
     auto num_inserted = insertCrsIndices(0, row_ptrs, cur_indices, num_assigned, new_indices);
-    TEST_EQUALITY(num_inserted, new_indices.size());
+    TEST_EQUALITY(static_cast<size_t>(num_inserted),
+                  static_cast<size_t>(new_indices.size()));
     TEST_ASSERT(compare_array_values(cur_indices, expected, expected.size()));
   }
 
@@ -265,7 +266,7 @@ TEUCHOS_UNIT_TEST( TpetraUtils, insertIndices )
     size_t num_assigned = 4;
     vector<int> new_indices{1, 0, 2, 5};
     auto num_inserted = insertCrsIndices(0, row_ptrs, cur_indices, num_assigned, new_indices);
-    TEST_EQUALITY(num_inserted, -1);
+    TEST_EQUALITY(static_cast<int>(num_inserted), -1);
   }
 
   {
@@ -296,7 +297,7 @@ TEUCHOS_UNIT_TEST( TpetraUtils, insertIndicesWithCallback )
         [&](const size_t k, const size_t start, const size_t offset){
           values[start+offset] += in_values[k];
         });
-    for (int k=0; k<expected_values.size(); k++)
+    for (size_t k=0; k<expected_values.size(); k++)
     {
       std::cout << "[" << k << "] = (" << expected_values[k] << ", " << values[k] << ")\n";
     }

--- a/packages/trilinoscouplings/examples/fenl/BelosSolve.hpp
+++ b/packages/trilinoscouplings/examples/fenl/BelosSolve.hpp
@@ -160,7 +160,7 @@ belos_solve(
     //Teuchos::RCP<VectorType> coords =
     Teuchos::RCP<Tpetra::MultiVector<double,LO,GO,N> > coords =
       Teuchos::rcp(new Tpetra::MultiVector<double,LO,GO,N>(x.getMap(), node_coords.extent(1)));
-    fill_coords(node_coords, coords->getDualView().d_view);
+    fill_coords(node_coords, coords->getLocalViewDevice());
 
     RCP<ParameterList> mueluParams = Teuchos::sublist(fenlParams, "MueLu");
     if (use_mean_based) {

--- a/packages/trilinoscouplings/examples/fenl/fenl_impl.hpp
+++ b/packages/trilinoscouplings/examples/fenl/fenl_impl.hpp
@@ -253,12 +253,7 @@ public:
     , g_nodal_solution( ColMap, 1 )
     , g_nodal_residual( RowMap, 1 )
     , g_nodal_delta(    RowMap, 1 )
-    , g_nodal_solution_no_overlap(
-        RowMap ,
-        Kokkos::subview( g_nodal_solution.getDualView()
-                       , std::pair<unsigned,unsigned>(0,fixture.node_count_owned())
-                       , Kokkos::ALL()
-                                            ) )
+    , g_nodal_solution_no_overlap (g_nodal_solution, *RowMap)
     , g_jacobian( RowMap, ColMap, LocalMatrixType( "jacobian" , mesh_to_graph.graph ) )
     , perf()
     , num_sensitivities(num_sens)
@@ -331,13 +326,7 @@ public:
         g_nodal_delta_dp =
           GlobalMultiVectorType( RowMap, num_sensitivities );
         g_nodal_solution_no_overlap_dp =
-          GlobalMultiVectorType(
-            RowMap ,
-            Kokkos::subview(
-              g_nodal_solution_dp.getDualView()
-              , std::pair<unsigned,unsigned>(0,fixture.node_count_owned())
-              , Kokkos::ALL()
-              ) );
+          GlobalMultiVectorType(g_nodal_solution_dp, *RowMap);
       }
     }
 
@@ -374,17 +363,16 @@ public:
 
       LocalMatrixType jacobian = g_jacobian.getLocalMatrix();
 
-      // Extract DualViews
-      const LocalDualVectorType k_nodal_solution = g_nodal_solution.getDualView();
-      const LocalDualVectorType k_nodal_residual = g_nodal_residual.getDualView();
-      const LocalDualVectorType k_nodal_delta    = g_nodal_delta   .getDualView();
+      const auto k_nodal_solution = g_nodal_solution.getLocalViewDevice();
+      const auto k_nodal_residual = g_nodal_residual.getLocalViewDevice();
+      const auto k_nodal_delta    = g_nodal_delta   .getLocalViewDevice();
 
       const LocalVectorType nodal_solution =
-        Kokkos::subview(k_nodal_solution.d_view,Kokkos::ALL(),0);
+        Kokkos::subview(k_nodal_solution,Kokkos::ALL(),0);
       const LocalVectorType nodal_residual =
-        Kokkos::subview(k_nodal_residual.d_view,Kokkos::ALL(),0);
+        Kokkos::subview(k_nodal_residual,Kokkos::ALL(),0);
       const LocalVectorType nodal_delta =
-        Kokkos::subview(k_nodal_delta.d_view,Kokkos::ALL(),0);
+        Kokkos::subview(k_nodal_delta,Kokkos::ALL(),0);
 
       LocalVectorType nodal_solution_no_overlap =
         Kokkos::subview(nodal_solution,std::pair<unsigned,unsigned>(0,fixture.node_count_owned()));
@@ -618,20 +606,12 @@ public:
           std::logic_error,
           "Response gradient length must match number of sensitivities specified in constuctor");
 
-        // Extract DualViews
-        const LocalDualVectorType k_nodal_solution_dp =
-          g_nodal_solution_dp.getDualView();
-        const LocalDualVectorType k_nodal_residual_dp =
-          g_nodal_residual_dp.getDualView();
-        const LocalDualVectorType k_nodal_delta_dp    =
-          g_nodal_delta_dp.getDualView();
-
-        const LocalMultiVectorType nodal_solution_dp =
-          k_nodal_solution_dp.d_view;
-        const LocalMultiVectorType nodal_residual_dp =
-          k_nodal_residual_dp.d_view;
-        const LocalMultiVectorType nodal_delta_dp =
-          k_nodal_delta_dp.d_view;
+        const auto nodal_solution_dp =
+          g_nodal_solution_dp.getLocalViewDevice();
+        const auto nodal_residual_dp =
+          g_nodal_residual_dp.getLocalViewDevice();
+        const auto nodal_delta_dp =
+          g_nodal_delta_dp.getLocalViewDevice();
 
         LocalMultiVectorType nodal_solution_no_overlap_dp =
           Kokkos::subview(


### PR DESCRIPTION
@trilinos/tpetra 

## Description

- Deprecate `Tpetra::MultiVector::getDualView` method.
- Remove all use of this method from Trilinos.
- Document how to get the same functionality elsewhere.

## Related Issues

* Closes #4797 
* Related to #333, #364 