### PR TITLE
Change PR testing from 2.1G to 3G per core

### DIFF
--- a/cmake/std/PullRequestLinuxDriver-Test.sh
+++ b/cmake/std/PullRequestLinuxDriver-Test.sh
@@ -349,11 +349,11 @@ weight=${JENKINS_JOB_WEIGHT:-29}
 n_cpu=$(lscpu | grep "^CPU(s):" | cut -d" " -f17)
 n_K=$(cat /proc/meminfo | grep MemTotal | cut -d" " -f8)
 let n_G=$n_K/1024000
-# this is aimed at keeping approximately 2.1G per core so we don't bottleneck
+# this is aimed at keeping approximately 3.0G per core so we don't bottleneck
 ## weight - the next bit works because the shell is only doing integer arithmetic
 let n_jobs=${n_cpu}/${weight}
 # using bc to get floating point input and integer output
-parallel_level=$(echo "$n_G/( 2.1*$n_jobs )" | bc )
+parallel_level=$(echo "$n_G/( 3.0*$n_jobs )" | bc )
 
 if [ ${parallel_level} -gt ${weight} ]; then
     parallel_level=${weight}


### PR DESCRIPTION
This is hopefully temporary as we know it will slow down
the PR testing - particulary in the moderate case where
smaller subsets are being built. This is needed due to
the large size of some MueLu objects and libraries when
building all of Trilinos. Later efforts should place a
ulimit on compile processes to keep this kind of
expansion in check.

## Related Issues

* Related to #4696 

