### PR TITLE
Albany Time Step Control through Piro 

### DIFF
--- a/packages/piro/src/Piro_ObserverToTempusIntegrationObserverAdapter.hpp
+++ b/packages/piro/src/Piro_ObserverToTempusIntegrationObserverAdapter.hpp
@@ -63,7 +63,8 @@ public:
     const Teuchos::RCP<const Tempus::SolutionHistory<Scalar> >& solutionHistory,
     const Teuchos::RCP<const Tempus::TimeStepControl<Scalar> >& timeStepControl,
     const Teuchos::RCP<Piro::ObserverBase<Scalar> > &wrappedObserver,
-    const bool supports_x_dotdot = false);
+    const bool supports_x_dotdot = false, 
+    const bool abort_on_fail_at_min_dt = false); 
 
   // Overridden from Tempus::IntegratorObserver
 
@@ -106,6 +107,8 @@ private:
   bool hasSensitivities_;
   Teuchos::RCP<ObserverBase<Scalar> > wrappedObserver_;
   bool supports_x_dotdot_;
+  Scalar previous_dt_; 
+  bool abort_on_fail_at_min_dt_; 
 };
 
 } // namespace Piro

--- a/packages/piro/src/Piro_TempusSolver.hpp
+++ b/packages/piro/src/Piro_TempusSolver.hpp
@@ -211,11 +211,6 @@ private:
 
   Scalar t_initial;
   Scalar t_final;
-  Scalar dt_initial; 
-  Scalar dt_min; 
-  Scalar dt_max; 
-  Scalar reduc_factor; 
-  Scalar ampl_factor; 
 
   int num_p;
   int num_g;

--- a/packages/piro/src/Piro_TempusSolver.hpp
+++ b/packages/piro/src/Piro_TempusSolver.hpp
@@ -237,6 +237,10 @@ private:
   //! Boolean to tell TempusSolver whether or not to abort if a transient solve fails 
   bool abort_on_failure_;
 
+  //! Boolean passed to observer - if true, solver will abort if it reaches 
+  //min_dt and is unable to converge.  This is the desired behavior when using Tempus 
+  //from Albany.  
+  bool abort_on_fail_at_min_dt_;
 
 };
 

--- a/packages/piro/src/Piro_TempusSolver.hpp
+++ b/packages/piro/src/Piro_TempusSolver.hpp
@@ -211,6 +211,11 @@ private:
 
   Scalar t_initial;
   Scalar t_final;
+  Scalar dt_initial; 
+  Scalar dt_min; 
+  Scalar dt_max; 
+  Scalar reduc_factor; 
+  Scalar ampl_factor; 
 
   int num_p;
   int num_g;
@@ -235,7 +240,8 @@ private:
   void setObserver(); 
 
   //! Boolean to tell TempusSolver whether or not to abort if a transient solve fails 
-  bool abort_on_failure_; 
+  bool abort_on_failure_;
+
 
 };
 

--- a/packages/piro/src/Piro_TempusSolver_Def.hpp
+++ b/packages/piro/src/Piro_TempusSolver_Def.hpp
@@ -222,13 +222,7 @@ void Piro::TempusSolver<Scalar>::initialize(
       *out << "\n    Using Tempus 'Time Step Control'.\n";
       RCP<Teuchos::ParameterList> timeStepControlPL = sublist(integratorPL, "Time Step Control", true);
       t_initial = timeStepControlPL->get<Scalar>("Initial Time", 0.0);
-      if (timeStepControlPL->isParameter("Final Time")) {
-        t_final = timeStepControlPL->get<Scalar>("Final Time");
-      }
-      else {
-        TEUCHOS_TEST_FOR_EXCEPTION(true, Teuchos::Exceptions::InvalidParameter, 
-            "\n Error!  'Time Step Control' Parameter List does not set Final Time, a required parameter!\n"); 
-      }
+      t_final = timeStepControlPL->get<Scalar>("Final Time", t_initial);
     }
     //*out << "tempusPL = " << *tempusPL << "\n";
     RCP<Teuchos::ParameterList> stepperPL = sublist(tempusPL, "Tempus Stepper", true);

--- a/packages/piro/src/Piro_TempusSolver_Def.hpp
+++ b/packages/piro/src/Piro_TempusSolver_Def.hpp
@@ -90,7 +90,8 @@ template <typename Scalar>
 Piro::TempusSolver<Scalar>::TempusSolver() :
 #endif
   out(Teuchos::VerboseObjectBase::getDefaultOStream()),
-  isInitialized(false)
+  isInitialized(false),
+  abort_on_fail_at_min_dt_(false)
 {
 #ifdef DEBUT_OUTPUT
   *out << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
@@ -175,6 +176,7 @@ void Piro::TempusSolver<Scalar>::initialize(
     RCP<Teuchos::ParameterList> albTimeStepControlPL = Teuchos::null; 
     if (tempusPL->isSublist("Albany Time Step Control Options")) {
       *out << "\n    Using 'Albany Time Step Control Options'.\n";
+      abort_on_fail_at_min_dt_ = true; 
       albTimeStepControlPL = sublist(tempusPL, "Albany Time Step Control Options"); 
       if (integratorPL->isSublist("Time Step Control")) {
         TEUCHOS_TEST_FOR_EXCEPTION(true, Teuchos::Exceptions::InvalidParameter, 
@@ -986,7 +988,7 @@ setObserver()
     const Teuchos::RCP<const Tempus::TimeStepControl<Scalar> > timeStepControl = fwdStateIntegrator->getTimeStepControl();
     //Create Tempus::IntegratorObserverBasic object
     observer = Teuchos::rcp(new ObserverToTempusIntegrationObserverAdapter<Scalar>(solutionHistory,
-                                timeStepControl, piroObserver_, supports_x_dotdot_));
+                                timeStepControl, piroObserver_, supports_x_dotdot_, abort_on_fail_at_min_dt_));
   }
   if (Teuchos::nonnull(observer)) {
     //Set observer in integrator


### PR DESCRIPTION
The purpose of this PR is to simplify how Tempus time step control is specified in an Albany input file.     The various options in the Tempus Time Step Control were confusing to Albany users, and there was a request to have a simpler time-step control algorithm that is easy to specify in Albany, where the time-step is amplified if a solve is successful, and reduced if a solve fails.  The idea is to cut down the number of parameters Albany users need to set / understand (e.g., Maximum / Minimum Value of Monitoring Function) by hiding all the detailed Tempus Time Step Control values in Piro. 

To address the feature request, this PR adds an option in Piro::TempusSolver to take 'Albany Time Step Control Options' sublist, in place of the Tempus->Tempus Integrator->Time Step Control timelist.  The new sublist can be used in place of 'Time Step Control' when calling Piro through Tempus (from Albany or other codes that call Tempus in this way).  The sublist takes the following 7 parameter:

  Initial Time
  Final Time
  Initial Time Step
  Minimum Time Step
  Maximum Time Step 
  Reduction Factor
  Amplification Factor 

These are (intentionally) analogous to the time-step control parameters that the Schwarz::Alternating solver in Albany takes.

In addition to this change, I have added logic to handle in the way Albany users expect the case where the Time Step dt is reduced down to the Minimum Time Step dt_min and the time-advancement with that dt fails.  In this scenario, the last solve will be repeated nConsecutiveFailuresMax-1 times unnecessarily without this PR.  In the PR, the solve terminates if the solver fails with dt = dt_min (there is no point to repeat the last solves with the same dt if the solve fails).   

All Piro tests, as do all Albany tests.  Once this PR is merged in, I will switch the Albany LCM tests to use the new PL in place of the Tempus -> Time Step Control one. 