### PR TITLE
Tempus: Add method to set Tableaus.

### DIFF
--- a/packages/tempus/src/Tempus_StepperDIRK_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperDIRK_decl.hpp
@@ -122,6 +122,9 @@ public:
     virtual void setTableau(
       Teuchos::RCP<Teuchos::ParameterList> pList = Teuchos::null);
 
+    virtual void setTableau(
+      Teuchos::RCP<const RKButcherTableau<Scalar> > DIRK_ButcherTableau);
+
     /// Initialize during construction and after changing input parameters.
     virtual void initialize();
 
@@ -182,8 +185,6 @@ public:
   //@}
 
 protected:
-
-  std::string                                            description_;
 
   Teuchos::RCP<const RKButcherTableau<Scalar> >          DIRK_ButcherTableau_;
 

--- a/packages/tempus/src/Tempus_StepperDIRK_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperDIRK_impl.hpp
@@ -89,14 +89,10 @@ void StepperDIRK<Scalar>::setTableau(std::string stepperType)
   if (stepperType == "") {
     this->setTableau();
   } else {
-    DIRK_ButcherTableau_ = createRKBT<Scalar>(stepperType, this->stepperPL_);
+    Teuchos::RCP<const RKButcherTableau<Scalar> > DIRK_ButcherTableau =
+      createRKBT<Scalar>(stepperType, this->stepperPL_);
+    this->setTableau(DIRK_ButcherTableau);
   }
-
-  TEUCHOS_TEST_FOR_EXCEPTION( DIRK_ButcherTableau_->isDIRK() != true,
-    std::logic_error,
-       "Error - StepperDIRK did not receive a DIRK Butcher Tableau!\n"
-    << "  Stepper Type = " << stepperType <<  "\n");
-  description_ = DIRK_ButcherTableau_->description();
 }
 
 
@@ -114,13 +110,22 @@ void StepperDIRK<Scalar>::setTableau(Teuchos::RCP<Teuchos::ParameterList> pList)
   std::string stepperType =
     this->stepperPL_->template get<std::string>("Stepper Type",
                                                 "SDIRK 2 Stage 2nd order");
-  DIRK_ButcherTableau_ = createRKBT<Scalar>(stepperType, this->stepperPL_);
+  Teuchos::RCP<const RKButcherTableau<Scalar> > DIRK_ButcherTableau =
+    createRKBT<Scalar>(stepperType, this->stepperPL_);
+  this->setTableau(DIRK_ButcherTableau);
+}
 
-  TEUCHOS_TEST_FOR_EXCEPTION( DIRK_ButcherTableau_->isDIRK() != true,
+
+template<class Scalar>
+void StepperDIRK<Scalar>::setTableau(
+  Teuchos::RCP<const RKButcherTableau<Scalar> > DIRK_ButcherTableau)
+{
+  DIRK_ButcherTableau_ = DIRK_ButcherTableau;
+
+  TEUCHOS_TEST_FOR_EXCEPTION(DIRK_ButcherTableau_->isDIRK() != true,
     std::logic_error,
-       "Error - StepperDIRK did not receive a DIRK Butcher Tableau!\n"
-    << "  Stepper Type = " << stepperType <<  "\n");
-  description_ = DIRK_ButcherTableau_->description();
+       "Error - StepperDIRK do not received a DIRK Butcher Tableau!\n" <<
+       "        Tableau = " << DIRK_ButcherTableau_->description() << "\n");
 }
 
 
@@ -373,7 +378,7 @@ getDefaultStepperState()
 template<class Scalar>
 std::string StepperDIRK<Scalar>::description() const
 {
-  return(description_);
+  return(DIRK_ButcherTableau_->description());
 }
 
 

--- a/packages/tempus/src/Tempus_StepperExplicitRK_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperExplicitRK_decl.hpp
@@ -126,6 +126,9 @@ public:
     virtual void setTableau(
       Teuchos::RCP<Teuchos::ParameterList> pList = Teuchos::null);
 
+    virtual void setTableau(
+      Teuchos::RCP<const RKButcherTableau<Scalar> > ERK_ButcherTableau);
+
     /// Initialize during construction and after changing input parameters.
     virtual void initialize();
 
@@ -175,8 +178,6 @@ public:
   //@}
 
 protected:
-
-  std::string                                            description_;
 
   Teuchos::RCP<const RKButcherTableau<Scalar> >          ERK_ButcherTableau_;
 

--- a/packages/tempus/src/Tempus_StepperExplicitRK_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperExplicitRK_impl.hpp
@@ -165,14 +165,10 @@ void StepperExplicitRK<Scalar>::setTableau(std::string stepperType)
   if (stepperType == "") {
     this->setTableau();
   } else {
-    ERK_ButcherTableau_ = createRKBT<Scalar>(stepperType, this->stepperPL_);
+    Teuchos::RCP<const RKButcherTableau<Scalar> > ERK_ButcherTableau =
+      createRKBT<Scalar>(stepperType, this->stepperPL_);
+    this->setTableau(ERK_ButcherTableau);
   }
-
-  TEUCHOS_TEST_FOR_EXCEPTION(ERK_ButcherTableau_->isImplicit() == true,
-    std::logic_error,
-       "Error - StepperExplicitRK received an implicit Butcher Tableau!\n"
-    << "  Stepper Type = " << stepperType << "\n");
-  description_ = ERK_ButcherTableau_->description();
 }
 
 template<class Scalar>
@@ -190,15 +186,23 @@ void StepperExplicitRK<Scalar>::setTableau(
   std::string stepperType =
     this->stepperPL_->template get<std::string>("Stepper Type",
                                                 "RK Explicit 4 Stage");
-  ERK_ButcherTableau_ = createRKBT<Scalar>(stepperType, this->stepperPL_);
+  Teuchos::RCP<const RKButcherTableau<Scalar> > ERK_ButcherTableau =
+    createRKBT<Scalar>(stepperType, this->stepperPL_);
+  this->setTableau(ERK_ButcherTableau);
+}
+
+template<class Scalar>
+void StepperExplicitRK<Scalar>::setTableau(
+  Teuchos::RCP<const RKButcherTableau<Scalar> > ERK_ButcherTableau)
+{
+  ERK_ButcherTableau_ = ERK_ButcherTableau;
 
   TEUCHOS_TEST_FOR_EXCEPTION(ERK_ButcherTableau_->isImplicit() == true,
     std::logic_error,
-       "Error - StepperExplicitRK received an implicit Butcher Tableau!\n"
-    << "  Stepper Type = " << stepperType << "\n");
-  description_ = ERK_ButcherTableau_->description();
-}
+       "Error - StepperExplicitRK received an implicit Butcher Tableau!\n" <<
+       "        Tableau = " << ERK_ButcherTableau_->description() << "\n");
 
+}
 
 template<class Scalar>
 void StepperExplicitRK<Scalar>::setObserver(
@@ -410,7 +414,7 @@ getDefaultStepperState()
 template<class Scalar>
 std::string StepperExplicitRK<Scalar>::description() const
 {
-  return(description_);
+  return(ERK_ButcherTableau_->description());
 }
 
 

--- a/packages/tempus/src/Tempus_StepperIMEX_RK_Partition_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RK_Partition_impl.hpp
@@ -247,11 +247,9 @@ void StepperIMEX_RK_Partition<Scalar>::setExplicitTableau(
   std::string stepperType,
   Teuchos::RCP<Teuchos::ParameterList> pList)
 {
-  explicitTableau_ = createRKBT<Scalar>(stepperType,pList);
-  TEUCHOS_TEST_FOR_EXCEPTION(explicitTableau_->isImplicit() == true,
-    std::logic_error,
-       "Error - Received an implicit Tableau for setExplicitTableau()!\n"
-    << "  Stepper Type = " << stepperType << "\n");
+  Teuchos::RCP<const RKButcherTableau<Scalar> > explicitTableau =
+    createRKBT<Scalar>(stepperType,pList);
+  this->setExplicitTableau(explicitTableau);
 }
 
 
@@ -261,8 +259,8 @@ void StepperIMEX_RK_Partition<Scalar>::setExplicitTableau(
 {
   TEUCHOS_TEST_FOR_EXCEPTION(explicitTableau->isImplicit() == true,
     std::logic_error,
-       "Error - Received an implicit Tableau for setExplicitTableau()!\n"
-    << "  explicitTableau = " << explicitTableau->description() << "\n");
+    "Error - Received an implicit Tableau for setExplicitTableau()!\n" <<
+    "        Tableau = " << explicitTableau->description() << "\n");
   explicitTableau_ = explicitTableau;
 }
 
@@ -272,14 +270,9 @@ void StepperIMEX_RK_Partition<Scalar>::setImplicitTableau(
   std::string stepperType,
   Teuchos::RCP<Teuchos::ParameterList> pList)
 {
-  implicitTableau_ = createRKBT<Scalar>(stepperType,pList);
-  //Teuchos::RCP<Teuchos::FancyOStream> out = this->getOStream();
-  //Teuchos::EVerbosityLevel verbLevel = this->getVerbLevel();
-  //implicitTableau_->describe(*out,verbLevel);
-  TEUCHOS_TEST_FOR_EXCEPTION( implicitTableau_->isDIRK() != true,
-    std::logic_error,
-       "Error - Did not receive a DIRK Tableau for setImplicitTableau()!\n"
-    << "  Stepper Type = " << stepperType << "\n");
+  Teuchos::RCP<const RKButcherTableau<Scalar> > implicitTableau =
+    createRKBT<Scalar>(stepperType,pList);
+  this->setImplicitTableau(implicitTableau);
 }
 
 
@@ -287,10 +280,10 @@ template<class Scalar>
 void StepperIMEX_RK_Partition<Scalar>::setImplicitTableau(
   Teuchos::RCP<const RKButcherTableau<Scalar> > implicitTableau)
 {
-  TEUCHOS_TEST_FOR_EXCEPTION( implicitTableau_->isDIRK() != true,
+  TEUCHOS_TEST_FOR_EXCEPTION( implicitTableau->isDIRK() != true,
     std::logic_error,
-       "Error - Did not receive a DIRK Tableau for setImplicitTableau()!\n"
-    << "  implicitTableau = " << implicitTableau->description() << "\n");
+    "Error - Did not receive a DIRK Tableau for setImplicitTableau()!\n" <<
+    "        Tableau = " << implicitTableau->description() << "\n");
   implicitTableau_ = implicitTableau;
 }
 

--- a/packages/tempus/src/Tempus_StepperIMEX_RK_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RK_impl.hpp
@@ -247,11 +247,9 @@ void StepperIMEX_RK<Scalar>::setExplicitTableau(
   std::string stepperType,
   Teuchos::RCP<Teuchos::ParameterList> pList)
 {
-  explicitTableau_ = createRKBT<Scalar>(stepperType,pList);
-  TEUCHOS_TEST_FOR_EXCEPTION(explicitTableau_->isImplicit() == true,
-    std::logic_error,
-       "Error - Received an implicit Tableau for setExplicitTableau()!\n"
-    << "  Stepper Type = " << stepperType << "\n");
+  Teuchos::RCP<const RKButcherTableau<Scalar> > explicitTableau =
+    createRKBT<Scalar>(stepperType,pList);
+  this->setExplicitTableau(explicitTableau);
 }
 
 
@@ -261,8 +259,8 @@ void StepperIMEX_RK<Scalar>::setExplicitTableau(
 {
   TEUCHOS_TEST_FOR_EXCEPTION(explicitTableau->isImplicit() == true,
     std::logic_error,
-       "Error - Received an implicit Tableau for setExplicitTableau()!\n"
-    << "  explicitTableau = " << explicitTableau->description() << "\n");
+    "Error - Received an implicit Tableau for setExplicitTableau()!\n" <<
+    "        Tableau = " << explicitTableau->description() << "\n");
   explicitTableau_ = explicitTableau;
 }
 
@@ -272,14 +270,9 @@ void StepperIMEX_RK<Scalar>::setImplicitTableau(
   std::string stepperType,
   Teuchos::RCP<Teuchos::ParameterList> pList)
 {
-  implicitTableau_ = createRKBT<Scalar>(stepperType,pList);
-  //Teuchos::RCP<Teuchos::FancyOStream> out = this->getOStream();
-  //Teuchos::EVerbosityLevel verbLevel = this->getVerbLevel();
-  //implicitTableau_->describe(*out,verbLevel);
-  TEUCHOS_TEST_FOR_EXCEPTION( implicitTableau_->isDIRK() != true,
-    std::logic_error,
-       "Error - Did not receive a DIRK Tableau for setImplicitTableau()!\n"
-    << "  Stepper Type = " << stepperType << "\n");
+  Teuchos::RCP<const RKButcherTableau<Scalar> > implicitTableau =
+    createRKBT<Scalar>(stepperType,pList);
+  this->setImplicitTableau(implicitTableau);
 }
 
 
@@ -287,10 +280,10 @@ template<class Scalar>
 void StepperIMEX_RK<Scalar>::setImplicitTableau(
   Teuchos::RCP<const RKButcherTableau<Scalar> > implicitTableau)
 {
-  TEUCHOS_TEST_FOR_EXCEPTION( implicitTableau_->isDIRK() != true,
+  TEUCHOS_TEST_FOR_EXCEPTION( implicitTableau->isDIRK() != true,
     std::logic_error,
-       "Error - Did not receive a DIRK Tableau for setImplicitTableau()!\n"
-    << "  implicitTableau = " << implicitTableau->description() << "\n");
+    "Error - Did not receive a DIRK Tableau for setImplicitTableau()!\n" <<
+    "        Tableau = " << implicitTableau->description() << "\n");
   implicitTableau_ = implicitTableau;
 }
 


### PR DESCRIPTION
To better setup RK methods, it is nice to set the Butcher Tableau
directly instead of through a ParameterList.  Added set method for
the tableaus for both ExplicitRK and DIRK.  The IMEX and IMEX
partitioned already have these methods.

Thanks to Kris Beckwith for pointing out these missing methods.

 #4821

@trilinos/tempus 

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.

