### PR TITLE
Disable tests in cuda rdc PT build already failing in non-rdc build (#4502)

### DIFF
--- a/cmake/std/atdm/ride/tweaks/CUDA_COMMON_TWEAKS.cmake
+++ b/cmake/std/atdm/ride/tweaks/CUDA_COMMON_TWEAKS.cmake
@@ -7,3 +7,32 @@ ATDM_SET_ENABLE(PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-4_DIS
 # Disable randomly failing MueLu tests (#2311)
 ATDM_SET_ENABLE(MueLu_ParameterListInterpreterTpetra_MPI_1_DISABLE ON)
 ATDM_SET_ENABLE(MueLu_ParameterListInterpreterTpetraHeavy_MPI_1_DISABLE ON)
+
+#
+# Disable tests already failing in the non-RDC build
+#
+
+IF (ATDM_CUDA_RDC)
+  # Disable ROL tests (see #3543)
+  ATDM_SET_ENABLE(ROL_example_PDE-OPT_0ld_adv-diff-react_example_01_MPI_4_DISABLE ON)
+  ATDM_SET_ENABLE(ROL_example_PDE-OPT_0ld_adv-diff-react_example_02_MPI_4_DISABLE ON)
+  ATDM_SET_ENABLE(ROL_example_PDE-OPT_0ld_poisson_example_01_MPI_4_DISABLE ON)
+  ATDM_SET_ENABLE(ROL_example_PDE-OPT_0ld_stefan-boltzmann_example_03_MPI_4_DISABLE ON)
+  ATDM_SET_ENABLE(ROL_example_PDE-OPT_navier-stokes_example_01_MPI_4_DISABLE ON)
+  ATDM_SET_ENABLE(ROL_example_PDE-OPT_navier-stokes_example_02_MPI_4_DISABLE ON)
+  ATDM_SET_ENABLE(ROL_example_PDE-OPT_nonlinear-elliptic_example_01_MPI_4_DISABLE ON)
+  ATDM_SET_ENABLE(ROL_example_PDE-OPT_nonlinear-elliptic_example_02_MPI_4_DISABLE ON)
+  ATDM_SET_ENABLE(ROL_example_PDE-OPT_obstacle_example_01_MPI_4_DISABLE ON)
+  ATDM_SET_ENABLE(ROL_example_PDE-OPT_stefan-boltzmann_example_01_MPI_4_DISABLE ON)
+  ATDM_SET_ENABLE(ROL_example_PDE-OPT_stefan-boltzmann_example_03_MPI_4_DISABLE ON)
+  ATDM_SET_ENABLE(ROL_example_PDE-OPT_topo-opt_poisson_example_01_MPI_4_DISABLE ON)
+  ATDM_SET_ENABLE(ROL_test_elementwise_TpetraMultiVector_MPI_4_DISABLE ON)
+  # Disable Zoltan tests (see #3749)
+  ATDM_SET_ENABLE(TrilinosCouplings_Example_Maxwell_MueLu_MPI_1_DISABLE ON)
+  ATDM_SET_ENABLE(TrilinosCouplings_Example_Maxwell_MueLu_MPI_4_DISABLE ON)
+  # Disable Zoltan tests (see #4042)
+  ATDM_SET_ENABLE(Zoltan_ch_ewgt_zoltan_parallel_DISABLE ON)
+  ATDM_SET_ENABLE(Zoltan_ch_grid20x19_zoltan_parallel_DISABLE ON)
+  ATDM_SET_ENABLE(Zoltan_ch_nograph_zoltan_parallel_DISABLE ON)
+  ATDM_SET_ENABLE(Zoltan_ch_simple_zoltan_parallel_DISABLE ON)
+ENDIF()


### PR DESCRIPTION
This disables tests already failing in the matching non-RDC build so those failures have nothing to do with RDC (see #4502).  This will allow us to promote this build to the "ATDM" group and maintain it.  This build is too expensive to run as a Trilinos PR build so the next best thing is to run it as a nightly build.

* Disables ROL tests from #3543
* Disables TrilinosCouplings tests from #3749
* Disables Zoltan tests from #4042

## How this was tested

I tested this on 'ride' with:

```
$ cd /home/rabartl/Trilinos.base/BUILDS/RIDE/CHECKIN/

$ ./checkin-test-atdm.sh \
     cuda-9.2-gnu-7.2.0-rdc-release-debug-pt \
     --enable-all-packages=on --configure
```

which showed the disables:

```
$ grep _DISABLE cuda-9.2-gnu-7.2.0-rdc-release-debug-pt/configure.out
...
-- Zoltan_ch_ewgt_zoltan_parallel: NOT added test because Zoltan_ch_ewgt_zoltan_parallel_DISABLE='ON'!
-- Zoltan_ch_grid20x19_zoltan_parallel: NOT added test because Zoltan_ch_grid20x19_zoltan_parallel_DISABLE='ON'!
-- Zoltan_ch_nograph_zoltan_parallel: NOT added test because Zoltan_ch_nograph_zoltan_parallel_DISABLE='ON'!
-- Zoltan_ch_simple_zoltan_parallel: NOT added test because Zoltan_ch_simple_zoltan_parallel_DISABLE='ON'!
...
-- ROL_test_elementwise_TpetraMultiVector_MPI_4: NOT added test because ROL_test_elementwise_TpetraMultiVector_MPI_4_DISABLE='ON'!
-- ROL_example_PDE-OPT_0ld_poisson_example_01_MPI_4: NOT added test because ROL_example_PDE-OPT_0ld_poisson_example_01_MPI_4_DISABLE='ON'!
-- ROL_example_PDE-OPT_0ld_stefan-boltzmann_example_03_MPI_4: NOT added test because ROL_example_PDE-OPT_0ld_stefan-boltzmann_example_03_MPI_4_DISABLE='ON'!
-- ROL_example_PDE-OPT_0ld_adv-diff-react_example_01_MPI_4: NOT added test because ROL_example_PDE-OPT_0ld_adv-diff-react_example_01_MPI_4_DISABLE='ON'!
-- ROL_example_PDE-OPT_0ld_adv-diff-react_example_02_MPI_4: NOT added test because ROL_example_PDE-OPT_0ld_adv-diff-react_example_02_MPI_4_DISABLE='ON'!
-- ROL_example_PDE-OPT_stefan-boltzmann_example_01_MPI_4: NOT added test because ROL_example_PDE-OPT_stefan-boltzmann_example_01_MPI_4_DISABLE='ON'!
-- ROL_example_PDE-OPT_stefan-boltzmann_example_03_MPI_4: NOT added test because ROL_example_PDE-OPT_stefan-boltzmann_example_03_MPI_4_DISABLE='ON'!
-- ROL_example_PDE-OPT_navier-stokes_example_01_MPI_4: NOT added test because ROL_example_PDE-OPT_navier-stokes_example_01_MPI_4_DISABLE='ON'!
-- ROL_example_PDE-OPT_navier-stokes_example_02_MPI_4: NOT added test because ROL_example_PDE-OPT_navier-stokes_example_02_MPI_4_DISABLE='ON'!
-- ROL_example_PDE-OPT_obstacle_example_01_MPI_4: NOT added test because ROL_example_PDE-OPT_obstacle_example_01_MPI_4_DISABLE='ON'!
-- ROL_example_PDE-OPT_nonlinear-elliptic_example_01_MPI_4: NOT added test because ROL_example_PDE-OPT_nonlinear-elliptic_example_01_MPI_4_DISABLE='ON'!
-- ROL_example_PDE-OPT_nonlinear-elliptic_example_02_MPI_4: NOT added test because ROL_example_PDE-OPT_nonlinear-elliptic_example_02_MPI_4_DISABLE='ON'!
-- ROL_example_PDE-OPT_topo-opt_poisson_example_01_MPI_4: NOT added test because ROL_example_PDE-OPT_topo-opt_poisson_example_01_MPI_4_DISABLE='ON'!
...
-- TrilinosCouplings_Example_Maxwell_MueLu_MPI_1: NOT added test because TrilinosCouplings_Example_Maxwell_MueLu_MPI_1_DISABLE='ON'!
-- TrilinosCouplings_Example_Maxwell_MueLu_MPI_4: NOT added test because TrilinosCouplings_Example_Maxwell_MueLu_MPI_4_DISABLE='ON'!
```

