### PR TITLE
Tpetra: Fix #4827; make more Tpetra classes follow Rule of Five

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -594,7 +594,27 @@ namespace Tpetra {
               const Teuchos::RCP<const map_type>& rangeMap = Teuchos::null,
               const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
-    //! Destructor.
+    //! Copy constructor (default).
+    CrsGraph (const CrsGraph<local_ordinal_type, global_ordinal_type, node_type>&) = default;
+
+    //! Assignment operator (default).
+    CrsGraph& operator= (const CrsGraph<local_ordinal_type, global_ordinal_type, node_type>&) = default;
+
+    //! Move constructor (default).
+    CrsGraph (CrsGraph<local_ordinal_type, global_ordinal_type, node_type>&&) = default;
+
+    //! Move assignment (default).
+    CrsGraph& operator= (CrsGraph<local_ordinal_type, global_ordinal_type, node_type>&&) = default;
+
+    /// \brief Destructor (virtual for memory safety of derived classes).
+    ///
+    /// \note To Tpetra developers: See the C++ Core Guidelines C.21
+    ///   ("If you define or <tt>=delete</tt> any default operation,
+    ///   define or <tt>=delete</tt> them all"), in particular the
+    ///   AbstractBase example, for why this destructor declaration
+    ///   implies that we need the above four <tt>=default</tt>
+    ///   declarations for copy construction, move construction, copy
+    ///   assignment, and move assignment.
     virtual ~CrsGraph () = default;
 
     /// \brief Create a cloned CrsGraph for a different Node type.

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -652,7 +652,8 @@ namespace Tpetra {
     explicit CrsMatrix (const Teuchos::RCP<const crs_graph_type>& graph,
                         const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
-    /// \brief Constructor specifying a previously constructed graph and entries array
+    /// \brief Constructor specifying a previously constructed graph
+    ///   and entries array
     ///
     /// Calling this constructor fixes the graph structure of the
     /// sparse matrix.  We say in this case that the matrix has a
@@ -1048,12 +1049,58 @@ namespace Tpetra {
       return clonedMatrix;
     }
 
-    //! Destructor.
-    virtual ~CrsMatrix ();
+    /// \brief Copy constructor (forbidden).
+    ///
+    /// \note There's no obvious reason why copy construction should
+    ///   ever have been forbidden, but it was historically, so I'm
+    ///   continuing the tradition for now.  Tpetra developers should
+    ///   feel free to change this, as long as they change the other
+    ///   three (move constructor, copy assignment, and move
+    ///   assignment) consistently.
+    CrsMatrix (const CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>&) = delete;
 
+    /// \brief Move constructor (forbidden).
+    ///
+    /// \note This is deleted for consistency with copy construction,
+    ///   which is also deleted.  Tpetra developers should feel free
+    ///   to change this, as long as they change the other three (copy
+    ///   constructor, copy assignment, and move assignment)
+    ///   consistently.
+    CrsMatrix (CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>&&) = delete;
+
+    /// \brief Copy assignment (forbidden).
+    ///
+    /// \note There's no obvious reason why copy assignment should
+    ///   ever have been forbidden, but it was historically, so I'm
+    ///   continuing the tradition for now.  Tpetra developers should
+    ///   feel free to change this, as long as they change the other
+    ///   three (copy constructor, move constructor, and move
+    ///   assignment) consistently.
+    CrsMatrix&
+    operator= (const CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>&) = delete;
+
+    /// \brief Move assignment (forbidden).
+    ///
+    /// \note This is deleted for consistency with copy assignment,
+    ///   which is also deleted.  Tpetra developers should feel free
+    ///   to change this, as long as they change the other three (copy
+    ///   constructor, move constructor, and copy assignment)
+    ///   consistently.
+    CrsMatrix&
+    operator= (CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>&&) = delete;
+
+    /// \brief Destructor (virtual for memory safety of derived classes).
+    ///
+    /// \note To Tpetra developers: See the C++ Core Guidelines C.21
+    ///   ("If you define or <tt>=delete</tt> any default operation,
+    ///   define or <tt>=delete</tt> them all"), in particular the
+    ///   AbstractBase example, for why this destructor declaration
+    ///   implies that we need the above four <tt>=delete</tt> (or
+    ///   <tt>=default</tt>) declarations for copy construction, move
+    ///   construction, copy assignment, and move assignment.
+    virtual ~CrsMatrix () = default;
 
   public:
-
     //@}
     //! @name Methods for inserting, modifying, or removing entries
     //@{
@@ -2714,7 +2761,8 @@ namespace Tpetra {
     ///
     /// The following is always true:
     /// \code
-    /// (! locallyIndexed() && ! globallyIndexed()) || (locallyIndexed() || globallyIndexed());
+    /// (! locallyIndexed() && ! globallyIndexed()) ||
+    ///   (locallyIndexed() || globallyIndexed());
     /// \endcode
     /// That is, a matrix may be neither locally nor globally indexed,
     /// but it can never be both.  Furthermore a matrix that is not
@@ -4351,14 +4399,6 @@ namespace Tpetra {
                              const Teuchos::RCP<const map_type>& domainMap = Teuchos::null,
                              const Teuchos::RCP<const map_type>& rangeMap = Teuchos::null,
                              const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null) const;
-    // We forbid copy construction by declaring this method private
-    // and not implementing it.
-    CrsMatrix (const CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>& rhs);
-
-    // We forbid assignment (operator=) by declaring this method
-    // private and not implementing it.
-    CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>&
-    operator= (const CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>& rhs);
 
     /// \brief Common implementation detail of insertGlobalValues and
     ///   insertGlobalValuesFiltered.

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -752,11 +752,6 @@ namespace Tpetra {
   }
 
   template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-  CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  ~CrsMatrix ()
-  {}
-
-  template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void
   CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   swap(CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> & crs_matrix)

--- a/packages/tpetra/core/src/Tpetra_Details_copyConvert.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_copyConvert.hpp
@@ -51,7 +51,7 @@
 
 #include "TpetraCore_config.h"
 #include "Kokkos_Core.hpp"
-#include "Kokkos_Complex.hpp"
+#include "Kokkos_ArithTraits.hpp"
 #include <sstream>
 #include <stdexcept>
 #include <type_traits>
@@ -65,11 +65,20 @@ namespace Details {
 //
 namespace { // (anonymous)
 
+  // We need separate implementations for both (T,complex) and
+  // (complex,T), but we can't just overload for both cases, because
+  // that would be ambiguous (e.g., (complex,complex)).
   template<class OutputValueType,
-           class InputValueType>
-  struct ConvertValue {
+           class InputValueType,
+           const bool outputIsComplex =
+             Kokkos::ArithTraits<OutputValueType>::is_complex,
+           const bool inputIsComplex =
+             Kokkos::ArithTraits<InputValueType>::is_complex>
+  struct ConvertValue
+  {
     static KOKKOS_INLINE_FUNCTION void
-    convert (OutputValueType& dst, const InputValueType& src) {
+    convert (OutputValueType& dst, const InputValueType& src)
+    {
       // This looks trivial, but it actually invokes OutputValueType's
       // constructor, so that needs to be marked as a __host__
       // __device__ function (e.g., via the KOKKOS_FUNCTION or
@@ -78,55 +87,107 @@ namespace { // (anonymous)
     }
   };
 
-  template<class RealType>
-  struct ConvertValue<RealType, Kokkos::complex<RealType> > {
+  template<class OutputRealType, class InputComplexType>
+  struct ConvertValue<OutputRealType, InputComplexType, false, true>
+  {
     static KOKKOS_INLINE_FUNCTION void
-    convert (RealType& dst, const Kokkos::complex<RealType>& src) {
-      // RealType's constructor needs to be marked as a __host__
-      // __device__ function (e.g., via the KOKKOS_FUNCTION or
-      // KOKKOS_INLINE_FUNCTION macros).
-      dst = RealType (src.real ());
+    convert (OutputRealType& dst,
+             const InputComplexType& src)
+    {
+      // OutputRealType's constructor needs to be marked with either
+      // KOKKOS_FUNCTION or KOKKOS_INLINE_FUNCTION.
+      using KAI = Kokkos::ArithTraits<InputComplexType>;
+      dst = OutputRealType (KAI::real (src));
     }
   };
+
+  template<class OutputComplexType, class InputRealType>
+  struct ConvertValue<OutputComplexType, InputRealType, true, false>
+  {
+    static KOKKOS_INLINE_FUNCTION void
+    convert (OutputComplexType& dst,
+             const InputRealType& src)
+    {
+      // OutputComplexType's constructor needs to be marked with
+      // either KOKKOS_FUNCTION or KOKKOS_INLINE_FUNCTION.
+      using output_mag_type =
+        typename Kokkos::ArithTraits<OutputComplexType>::mag_type;
+      using KAM = Kokkos::ArithTraits<output_mag_type>;
+      dst = OutputComplexType (src, KAM::zero ());
+    }
+  };
+  
+  template<class OutputValueType,
+           class InputValueType>
+  KOKKOS_INLINE_FUNCTION void
+  convertValue (OutputValueType& dst, const InputValueType& src) {
+    ConvertValue<OutputValueType, InputValueType>::convert (dst, src);
+  }
 
   /// \brief Functor that helps implement copyConvert (see below).
   ///
   /// \tparam OutputViewType Type of the output Kokkos::View.
   /// \tparam InputViewType Type of the input Kokkos::View.
   template<class OutputViewType,
+           class InputViewType,
+           const int rank = OutputViewType::Rank>
+  class CopyConvertFunctor {};
+
+  template<class OutputViewType,
            class InputViewType>
-  class CopyConvertFunctor {
+  class CopyConvertFunctor<OutputViewType, InputViewType, 1> {
   private:
+    static_assert
+    (OutputViewType::Rank == 1 && InputViewType::Rank == 1,
+     "CopyConvertFunctor (implements Tpetra::Details::copyConvert): "
+     "OutputViewType and InputViewType must both have rank 1.");
     OutputViewType dst_;
     InputViewType src_;
 
   public:
-    typedef typename std::decay<decltype (dst_[0])>::type output_type;
-    typedef typename OutputViewType::size_type index_type;
+    using index_type = typename OutputViewType::size_type;
 
-    CopyConvertFunctor (const OutputViewType& dst, const InputViewType& src) :
+    CopyConvertFunctor (const OutputViewType& dst,
+                        const InputViewType& src) :
       dst_ (dst),
       src_ (src)
-    {
-      // NOTE (mfh 29 Jan 2016): See kokkos/kokkos#178 for why we use
-      // a memory space, rather than an execution space, as the first
-      // argument of VerifyExecutionCanAccessMemorySpace.
-      static_assert (Kokkos::Impl::VerifyExecutionCanAccessMemorySpace<
-                       typename OutputViewType::memory_space,
-                       typename InputViewType::memory_space>::value,
-                     "CopyConvertFunctor (implements copyConvert): Output "
-                     "View's space must be able to access the input View's "
-                     "memory space.");
-      static_assert (OutputViewType::Rank == 1 && InputViewType::Rank == 1,
-                     "CopyConvertFunctor (implements copyConvert): "
-                     "OutputViewType and InputViewType must be rank-1 "
-                     "Kokkos::View specializations.");
-    }
+    {}
 
     KOKKOS_INLINE_FUNCTION void
-    operator () (const index_type& i) const {
-      using input_type = typename std::decay<decltype (src_[i])>::type;
-      ConvertValue<output_type, input_type>::convert (dst_(i), src_(i));
+    operator () (const index_type i) const {
+      convertValue (dst_(i), src_(i));
+    }
+  };
+
+  template<class OutputViewType,
+           class InputViewType>
+  class CopyConvertFunctor<OutputViewType, InputViewType, 2> {
+  public:
+    using index_type = typename OutputViewType::size_type;
+
+  private:
+    static_assert
+    (OutputViewType::Rank == 2 && InputViewType::Rank == 2,
+     "CopyConvertFunctor (implements Tpetra::Details::copyConvert): "
+     "OutputViewType and InputViewType must both have rank 2.");
+    OutputViewType dst_;
+    InputViewType src_;
+    index_type numCols_;
+
+  public:
+    CopyConvertFunctor (const OutputViewType& dst,
+                        const InputViewType& src) :
+      dst_ (dst),
+      src_ (src),
+      numCols_ (dst.extent (1))
+    {}
+
+    KOKKOS_INLINE_FUNCTION void
+    operator () (const index_type i) const {
+      const index_type numCols = numCols_;
+      for (index_type j = 0; j < numCols; ++j) {
+        convertValue (dst_(i,j), src_(i,j));
+      }
     }
   };
 
@@ -154,8 +215,6 @@ namespace { // (anonymous)
   template<class OutputViewType,
            class InputViewType,
            const bool canUseKokkosDeepCopy =
-             std::is_same<typename OutputViewType::array_layout,
-                          typename InputViewType::array_layout>::value &&
              std::is_same<typename OutputViewType::non_const_value_type,
                           typename InputViewType::non_const_value_type>::value,
            const bool outputExecSpaceCanAccessInputMemSpace =
@@ -163,7 +222,9 @@ namespace { // (anonymous)
                typename OutputViewType::memory_space,
                typename InputViewType::memory_space>::value>
   struct CopyConvertImpl {
-    static void run (const OutputViewType& dst, const InputViewType& src);
+    static void
+    run (const OutputViewType& dst,
+         const InputViewType& src);
   };
 
   // Specialization for canUseKokkosDeepCopy = true:
@@ -177,22 +238,22 @@ namespace { // (anonymous)
            class InputViewType,
            const bool outputExecSpaceCanAccessInputMemSpace>
   struct CopyConvertImpl<OutputViewType, InputViewType,
-                         true, outputExecSpaceCanAccessInputMemSpace> {
-    static void run (const OutputViewType& dst, const InputViewType& src) {
-      static_assert (std::is_same<typename OutputViewType::non_const_value_type,
-                       typename InputViewType::non_const_value_type>::value,
-                     "CopyConvertImpl (implementation of copyConvert): In order"
-                     " to call this specialization, the input and output must "
-                     "use the same offset type.");
-      static_assert (OutputViewType::Rank == 1 && InputViewType::Rank == 1,
+                         true, outputExecSpaceCanAccessInputMemSpace>
+  {
+    static void
+    run (const OutputViewType& dst,
+         const InputViewType& src)
+    {
+      static_assert (OutputViewType::Rank == InputViewType::Rank,
                      "CopyConvertImpl (implementation of copyConvert): "
-                     "OutputViewType and InputViewType must be rank-1 "
-                     "Kokkos::View specializations.");
-      static_assert (std::is_same<typename OutputViewType::array_layout,
-                       typename InputViewType::array_layout>::value,
-                     "CopyConvertImpl (implementation of copyConvert): In order"
-                     " to call this specialization, src and dst must have the "
-                     "the same array_layout.");
+                     "The two Views must have the same rank.");
+      constexpr bool same_value_type =
+        std::is_same<typename OutputViewType::non_const_value_type,
+                     typename InputViewType::non_const_value_type>::value;
+      static_assert (same_value_type,
+                     "CopyConvertImpl (implementation of copyConvert): In "
+                     "order to call this specialization, the input and output "
+                     "Views must have the same value type.");
       Kokkos::deep_copy (dst, src);
     }
   };
@@ -207,35 +268,42 @@ namespace { // (anonymous)
   struct CopyConvertImpl<OutputViewType,
                          InputViewType,
                          false,
-                         true> {
-    static void run (const OutputViewType& dst, const InputViewType& src) {
-      static_assert (! std::is_same<typename OutputViewType::array_layout,
-                         typename InputViewType::array_layout>::value ||
-                     ! std::is_same<typename OutputViewType::non_const_value_type,
-                         typename InputViewType::non_const_value_type>::value,
-                     "CopyConvertImpl (implementation of copyConvert): We "
-                     "should not be calling this specialization if "
-                     "OutputViewType and InputViewType have the same entry "
-                     "and layout types.");
-      static_assert (OutputViewType::Rank == 1 && InputViewType::Rank == 1,
+                         true>
+  {
+    static void
+    run (const OutputViewType& dst,
+         const InputViewType& src)
+    {
+      static_assert (OutputViewType::Rank == InputViewType::Rank,
                      "CopyConvertImpl (implementation of copyConvert): "
-                     "OutputViewType and InputViewType must both be rank-1 "
-                     "Kokkos::View types.");
+                     "The two Views must have the same rank.");
+      constexpr bool same_value_type =
+        std::is_same<typename OutputViewType::non_const_value_type,
+                     typename InputViewType::non_const_value_type>::value;
+      static_assert (! same_value_type,
+                     "CopyConvertImpl (implementation of copyConvert): We "
+                     "should not be calling this specialization if the two "
+                     "Views have the same value types.  It's correct to do "
+                     "so, but could be slower.");
       // NOTE (mfh 29 Jan 2016): See kokkos/kokkos#178 for why we use
       // a memory space, rather than an execution space, as the first
       // argument of VerifyExecutionCanAccessMemorySpace.
-      static_assert (Kokkos::Impl::VerifyExecutionCanAccessMemorySpace<
-                       typename OutputViewType::memory_space,
-                       typename InputViewType::memory_space>::value,
+      constexpr bool output_exec_space_can_access_input_mem_space =
+        Kokkos::Impl::VerifyExecutionCanAccessMemorySpace<
+          typename OutputViewType::memory_space,
+          typename InputViewType::memory_space>::value;
+      static_assert (output_exec_space_can_access_input_mem_space,
                      "CopyConvertImpl (implements copyConvert): In order to "
-                     "call this specialization, the output View's space must "
-                     "be able to access the input View's memory space.");
+                     "call this specialization, the output View's execution "
+                     "space must be able to access the input View's memory "
+                     "space.");
 
-      typedef CopyConvertFunctor<OutputViewType, InputViewType> functor_type;
-      typedef typename OutputViewType::execution_space execution_space;
-      typedef typename OutputViewType::size_type index_type;
-      typedef Kokkos::RangePolicy<execution_space, index_type> range_type;
-      Kokkos::parallel_for (range_type (0, dst.extent (0)),
+      using functor_type = CopyConvertFunctor<OutputViewType, InputViewType>;
+      using execution_space = typename OutputViewType::execution_space;
+      using index_type = typename OutputViewType::size_type;
+      using range_type = Kokkos::RangePolicy<execution_space, index_type>;
+      Kokkos::parallel_for ("Tpetra::Details::copyConvert",
+                            range_type (0, dst.extent (0)),
                             functor_type (dst, src));
     }
   };
@@ -259,43 +327,48 @@ namespace { // (anonymous)
   // offset type than Kokkos' host spaces.
   template<class OutputViewType,
            class InputViewType>
-  struct CopyConvertImpl<OutputViewType,
-                         InputViewType,
-                         false,
-                         false> {
-    static void run (const OutputViewType& dst, const InputViewType& src) {
+  struct CopyConvertImpl<OutputViewType, InputViewType, false, false>
+  {
+    static void
+    run (const OutputViewType& dst,
+         const InputViewType& src)
+    {
+      static_assert (OutputViewType::Rank == InputViewType::Rank,
+                     "CopyConvertImpl (implementation of copyConvert): "
+                     "OutputViewType and InputViewType must have the "
+                     "same rank.");
       const bool canUseKokkosDeepCopy =
-        std::is_same<typename OutputViewType::array_layout,
-          typename InputViewType::array_layout>::value &&
         std::is_same<typename OutputViewType::non_const_value_type,
           typename InputViewType::non_const_value_type>::value;
       static_assert (! canUseKokkosDeepCopy,
                      "CopyConvertImpl (implementation of copyConvert): We "
                      "should not be calling this specialization if we could "
                      "have used Kokkos::deep_copy instead.");
-      static_assert (OutputViewType::Rank == 1 && InputViewType::Rank == 1,
-                     "CopyConvertImpl (implementation of copyConvert): "
-                     "OutputViewType and InputViewType must both be rank-1 "
-                     "Kokkos::View types.");
+      constexpr bool output_exec_space_can_access_input_mem_space =
+        Kokkos::Impl::VerifyExecutionCanAccessMemorySpace<
+          typename OutputViewType::memory_space,
+          typename InputViewType::memory_space>::value;
+      static_assert (! output_exec_space_can_access_input_mem_space,
+                     "CopyConvertImpl (implements copyConvert): We should not "
+                     "call this specialization if the output View's execution "
+                     "space can access the input View's memory space.  It's "
+                     "correct, but may be slow.");
 
-      using Kokkos::ViewAllocateWithoutInitializing;
-      typedef Kokkos::View<typename InputViewType::non_const_value_type*,
-        typename InputViewType::array_layout,
-        typename OutputViewType::device_type> output_space_copy_type;
-      output_space_copy_type
-        outputSpaceCopy (ViewAllocateWithoutInitializing ("outputSpace"),
-                         src.extent (0));
-      Kokkos::deep_copy (outputSpaceCopy, src);
+      using output_memory_space = typename OutputViewType::memory_space;
+      auto src_outputSpaceCopy =
+        Kokkos::create_mirror_view (output_memory_space (), src);
+      Kokkos::deep_copy (src_outputSpaceCopy, src);
 
       // The output View's execution space can access
       // outputSpaceCopy's data, so we can run the functor now.
-      typedef CopyConvertFunctor<OutputViewType,
-        output_space_copy_type> functor_type;
-      typedef typename OutputViewType::execution_space execution_space;
-      typedef typename OutputViewType::size_type index_type;
-      typedef Kokkos::RangePolicy<execution_space, index_type> range_type;
+      using output_space_copy_type = decltype (src_outputSpaceCopy);
+      using functor_type =
+        CopyConvertFunctor<OutputViewType, output_space_copy_type>;
+      using execution_space = typename OutputViewType::execution_space;
+      using index_type = typename OutputViewType::size_type;
+      using range_type = Kokkos::RangePolicy<execution_space, index_type>;
       Kokkos::parallel_for (range_type (0, dst.extent (0)),
-                            functor_type (dst, outputSpaceCopy));
+                            functor_type (dst, src_outputSpaceCopy));
     }
   };
 } // namespace (anonymous)
@@ -315,16 +388,15 @@ copyConvert (const OutputViewType& dst,
              const InputViewType& src)
 {
   static_assert (Kokkos::Impl::is_view<OutputViewType>::value,
-                 "OutputViewType (the type of dst) must be a Kokkos::View.");
+                 "OutputViewType must be a Kokkos::View.");
   static_assert (Kokkos::Impl::is_view<InputViewType>::value,
-                 "InputViewType (the type of src) must be a Kokkos::View.");
+                 "InputViewType must be a Kokkos::View.");
   static_assert (std::is_same<typename OutputViewType::value_type,
                    typename OutputViewType::non_const_value_type>::value,
-                 "OutputViewType (the type of dst) must be a nonconst Kokkos::View.");
-  static_assert (static_cast<int> (OutputViewType::rank) == 1,
-                 "OutputViewType (the type of dst) must be a rank-1 Kokkos::View.");
-  static_assert (static_cast<int> (InputViewType::rank) == 1,
-                 "InputViewType (the type of src) must be a rank-1 Kokkos::View.");
+                 "OutputViewType must be a nonconst Kokkos::View.");
+  static_assert (OutputViewType::Rank == InputViewType::Rank,
+                 "src and dst must have the same rank.");
+
   if (dst.extent (0) != src.extent (0)) {
     std::ostringstream os;
     os << "Tpetra::Details::copyConvert: "
@@ -333,6 +405,15 @@ copyConvert (const OutputViewType& dst,
        << ".";
     throw std::invalid_argument (os.str ());
   }
+  if (OutputViewType::Rank > 1 && dst.extent (1) != src.extent (1)) {
+    std::ostringstream os;
+    os << "Tpetra::Details::copyConvert: "
+       << "dst.extent(1) = " << dst.extent (1)
+       << " != src.extent(1) = " << src.extent (1)
+       << ".";
+    throw std::invalid_argument (os.str ());
+  }
+
   // Canonicalize the View types in order to avoid redundant instantiations.
   typedef typename OutputViewType::non_const_type output_view_type;
   typedef typename InputViewType::const_type input_view_type;

--- a/packages/tpetra/core/src/Tpetra_Details_copyConvert.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_copyConvert.hpp
@@ -130,7 +130,7 @@ namespace { // (anonymous)
   /// \tparam InputViewType Type of the input Kokkos::View.
   template<class OutputViewType,
            class InputViewType,
-           const int rank = OutputViewType::Rank>
+           const int rank = static_cast<int> (OutputViewType::Rank)>
   class CopyConvertFunctor {};
 
   template<class OutputViewType,
@@ -138,7 +138,8 @@ namespace { // (anonymous)
   class CopyConvertFunctor<OutputViewType, InputViewType, 1> {
   private:
     static_assert
-    (OutputViewType::Rank == 1 && InputViewType::Rank == 1,
+    (static_cast<int> (OutputViewType::Rank) == 1 &&
+     static_cast<int> (InputViewType::Rank) == 1,
      "CopyConvertFunctor (implements Tpetra::Details::copyConvert): "
      "OutputViewType and InputViewType must both have rank 1.");
     OutputViewType dst_;
@@ -167,7 +168,8 @@ namespace { // (anonymous)
 
   private:
     static_assert
-    (OutputViewType::Rank == 2 && InputViewType::Rank == 2,
+    (static_cast<int> (OutputViewType::Rank) == 2 &&
+     static_cast<int> (InputViewType::Rank) == 2,
      "CopyConvertFunctor (implements Tpetra::Details::copyConvert): "
      "OutputViewType and InputViewType must both have rank 2.");
     OutputViewType dst_;
@@ -244,7 +246,8 @@ namespace { // (anonymous)
     run (const OutputViewType& dst,
          const InputViewType& src)
     {
-      static_assert (OutputViewType::Rank == InputViewType::Rank,
+      static_assert (static_cast<int> (OutputViewType::Rank) ==
+                     static_cast<int> (InputViewType::Rank),
                      "CopyConvertImpl (implementation of copyConvert): "
                      "The two Views must have the same rank.");
       constexpr bool same_value_type =
@@ -274,7 +277,8 @@ namespace { // (anonymous)
     run (const OutputViewType& dst,
          const InputViewType& src)
     {
-      static_assert (OutputViewType::Rank == InputViewType::Rank,
+      static_assert (static_cast<int> (OutputViewType::Rank) ==
+                     static_cast<int> (InputViewType::Rank),
                      "CopyConvertImpl (implementation of copyConvert): "
                      "The two Views must have the same rank.");
       constexpr bool same_value_type =
@@ -333,7 +337,8 @@ namespace { // (anonymous)
     run (const OutputViewType& dst,
          const InputViewType& src)
     {
-      static_assert (OutputViewType::Rank == InputViewType::Rank,
+      static_assert (static_cast<int> (OutputViewType::Rank) ==
+                     static_cast<int> (InputViewType::Rank),
                      "CopyConvertImpl (implementation of copyConvert): "
                      "OutputViewType and InputViewType must have the "
                      "same rank.");
@@ -394,7 +399,8 @@ copyConvert (const OutputViewType& dst,
   static_assert (std::is_same<typename OutputViewType::value_type,
                    typename OutputViewType::non_const_value_type>::value,
                  "OutputViewType must be a nonconst Kokkos::View.");
-  static_assert (OutputViewType::Rank == InputViewType::Rank,
+  static_assert (static_cast<int> (OutputViewType::Rank) ==
+                 static_cast<int> (InputViewType::Rank),
                  "src and dst must have the same rank.");
 
   if (dst.extent (0) != src.extent (0)) {
@@ -405,7 +411,8 @@ copyConvert (const OutputViewType& dst,
        << ".";
     throw std::invalid_argument (os.str ());
   }
-  if (OutputViewType::Rank > 1 && dst.extent (1) != src.extent (1)) {
+  if (static_cast<int> (OutputViewType::Rank) > 1 &&
+      dst.extent (1) != src.extent (1)) {
     std::ostringstream os;
     os << "Tpetra::Details::copyConvert: "
        << "dst.extent(1) = " << dst.extent (1)

--- a/packages/tpetra/core/src/Tpetra_DistObject_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_DistObject_decl.hpp
@@ -376,13 +376,32 @@ namespace Tpetra {
     //! @name Constructors and destructor
     //@{
 
-    //! Constructor.
+    /// \brief Constructor
+    ///
+    /// \param map [in] Map over which the object is distributed.
     explicit DistObject (const Teuchos::RCP<const map_type>& map);
 
-    //! Copy constructor.
-    DistObject (const DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>& rhs) = default;
+    //! Copy constructor (default).
+    DistObject (const DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>&) = default;
 
-    //! Destructor (virtual for memory safety of derived classes).
+    //! Assignment operator (default).
+    DistObject& operator= (const DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>&) = default;
+
+    //! Move constructor (default).
+    DistObject (DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>&&) = default;
+
+    //! Move assignment (default).
+    DistObject& operator= (DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>&&) = default;
+
+    /// \brief Destructor (virtual for memory safety of derived classes).
+    ///
+    /// \note To Tpetra developers: See the C++ Core Guidelines C.21
+    ///   ("If you define or <tt>=delete</tt> any default operation,
+    ///   define or <tt>=delete</tt> them all"), in particular the
+    ///   AbstractBase example, for why this destructor declaration
+    ///   implies that we need the above four <tt>=default</tt>
+    ///   declarations for copy construction, move construction, copy
+    ///   assignment, and move assignment.
     virtual ~DistObject () = default;
 
     //@}
@@ -467,7 +486,7 @@ namespace Tpetra {
     //
     /// This cannot be used if #2 is not true, OR there are permutes.
     /// The "source" maps still need to match
-    ///  
+    ///
     /// \param source [in] The "source" object for redistribution.
     /// \param exporter [in] Precomputed data redistribution plan.
     ///   Its <i>target</i> Map must be the same as the input DistObject's Map,

--- a/packages/tpetra/core/src/Tpetra_FECrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_FECrsGraph_decl.hpp
@@ -53,7 +53,7 @@
 #include "Tpetra_CrsGraph_decl.hpp"
 namespace Tpetra {
 
- 
+
   /// \class FECrsGraph
   /// \brief A distributed graph accessed by rows (adjacency lists)
   ///   and stored sparsely.
@@ -128,10 +128,10 @@ namespace Tpetra {
     /// \param ownedPlusSharedToOwnedimporter [in] Optional importer between the ownedMap and ownedPlusSharedMap
     ///   This will be calculated by FECrsGraph if it is not provided
     ///
-    /// \param domainMap [in] Optional domainMap for the owned graph.  If this is not provided, then ownedMap 
+    /// \param domainMap [in] Optional domainMap for the owned graph.  If this is not provided, then ownedMap
     ///   will be used for the domainMap in the call to endFill()
     ///
-    /// \param rangeMap [in] Optional domainMap for the owned graph.  If this is not provided, then ownedMap 
+    /// \param rangeMap [in] Optional domainMap for the owned graph.  If this is not provided, then ownedMap
     ///   will be used for the domainMap in the call to endFill()
     ///
     /// \param params [in/out] Optional list of parameters.  If not
@@ -159,10 +159,10 @@ namespace Tpetra {
     /// \param ownedPlusSharedToOwnedimporter [in] Optional importer between the ownedMap and ownedPlusSharedMap
     ///   This will be calculated by FECrsGraph if it is not provided
     ///
-    /// \param domainMap [in] Optional domainMap for the owned graph.  If this is not provided, then ownedMap 
+    /// \param domainMap [in] Optional domainMap for the owned graph.  If this is not provided, then ownedMap
     ///   will be used for the domainMap in the call to endFill()
     ///
-    /// \param rangeMap [in] Optional domainMap for the owned graph.  If this is not provided, then ownedMap 
+    /// \param rangeMap [in] Optional domainMap for the owned graph.  If this is not provided, then ownedMap
     ///   will be used for the domainMap in the call to endFill()
     ///
     /// \param params [in/out] Optional list of parameters.  If not
@@ -173,10 +173,10 @@ namespace Tpetra {
                 const Kokkos::DualView<const size_t*, execution_space>& numEntPerRow,
                 const Teuchos::RCP<const import_type> & ownedPlusSharedToOwnedimporter = Teuchos::null,
                 const Teuchos::RCP<const map_type> & domainMap = Teuchos::null,
-                const Teuchos::RCP<const map_type> & rangeMap = Teuchos::null,  
+                const Teuchos::RCP<const map_type> & rangeMap = Teuchos::null,
                 const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
-    
+
     /// \brief Constructor for locally-indexed assembly specifying a single upper bound for the
     ///   number of entries in all rows on the calling process.
     ///
@@ -184,7 +184,7 @@ namespace Tpetra {
     ///
     /// \param ownedPlusSharedRowMap [in] ownedMap plus the list of shared rows to which off-processor insertion is allowed
     ///
-    /// \param ownedPlusSharedColMap [in] list of owned and shared columns into which assertion is allowed. 
+    /// \param ownedPlusSharedColMap [in] list of owned and shared columns into which assertion is allowed.
     ///
     /// \param maxNumEntriesPerRow [in] Maximum number of graph
     ///   entries per row.  You cannot exceed this number of
@@ -193,10 +193,10 @@ namespace Tpetra {
     /// \param ownedPlusSharedToOwnedimporter [in] Optional importer between the ownedMap and ownedPlusSharedMap
     ///   This will be calculated by FECrsGraph if it is not provided
     ///
-    /// \param domainMap [in] Optional domainMap for the owned graph.  If this is not provided, then ownedMap 
+    /// \param domainMap [in] Optional domainMap for the owned graph.  If this is not provided, then ownedMap
     ///   will be used for the domainMap in the call to endFill()
     ///
-    /// \param rangeMap [in] Optional domainMap for the owned graph.  If this is not provided, then ownedMap 
+    /// \param rangeMap [in] Optional domainMap for the owned graph.  If this is not provided, then ownedMap
     ///   will be used for the domainMap in the call to endFill()
     ///
     /// \param params [in/out] Optional list of parameters.  If not
@@ -226,10 +226,10 @@ namespace Tpetra {
     /// \param ownedPlusSharedToOwnedimporter [in] Optional importer between the ownedMap and ownedPlusSharedMap
     ///   This will be calculated by FECrsGraph if it is not provided
     ///
-    /// \param domainMap [in] Optional domainMap for the owned graph.  If this is not provided, then ownedMap 
+    /// \param domainMap [in] Optional domainMap for the owned graph.  If this is not provided, then ownedMap
     ///   will be used for the domainMap in the call to endFill()
     ///
-    /// \param rangeMap [in] Optional domainMap for the owned graph.  If this is not provided, then ownedMap 
+    /// \param rangeMap [in] Optional domainMap for the owned graph.  If this is not provided, then ownedMap
     ///   will be used for the domainMap in the call to endFill()
     ///
     /// \param params [in/out] Optional list of parameters.  If not
@@ -241,11 +241,32 @@ namespace Tpetra {
                 const Kokkos::DualView<const size_t*, execution_space>& numEntPerRow,
                 const Teuchos::RCP<const import_type> & ownedPlusSharedToOwnedimporter = Teuchos::null,
                 const Teuchos::RCP<const map_type> & domainMap = Teuchos::null,
-                const Teuchos::RCP<const map_type> & rangeMap = Teuchos::null,  
+                const Teuchos::RCP<const map_type> & rangeMap = Teuchos::null,
                 const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
+    //! Copy constructor (forbidden).
+    FECrsGraph (const FECrsGraph<LocalOrdinal, GlobalOrdinal, Node>&) = delete;
 
-    //! Destructor.
+    //! Move constructor (forbidden).
+    FECrsGraph (FECrsGraph<LocalOrdinal, GlobalOrdinal, Node>&&) = delete;
+
+    //! Copy assignment (forbidden).
+    FECrsGraph&
+    operator= (const FECrsGraph<LocalOrdinal, GlobalOrdinal, Node>&) = delete;
+
+    //! Move assignment (forbidden).
+    FECrsGraph&
+    operator= (FECrsGraph<LocalOrdinal, GlobalOrdinal, Node>&&) = delete;
+
+    /// \brief Destructor (virtual for memory safety of derived classes).
+    ///
+    /// \note To Tpetra developers: See the C++ Core Guidelines C.21
+    ///   ("If you define or <tt>=delete</tt> any default operation,
+    ///   define or <tt>=delete</tt> them all"), in particular the
+    ///   AbstractBase example, for why this destructor declaration
+    ///   implies that we need the above four <tt>=delete</tt>
+    ///   declarations for copy construction, move construction, copy
+    ///   assignment, and move assignment.
     virtual ~FECrsGraph () = default;
 
     //@}
@@ -345,7 +366,7 @@ namespace Tpetra {
     /// Precondition: Must be FE_ACTIVE_OWNED mode
     void doOwnedToOwnedPlusShared(const CombineMode CM=Tpetra::ADD);
 
-  public: 
+  public:
     //! Switches which CrsGraph is active (without migrating data)
     void switchActiveCrsGraph();
     //@}
@@ -354,14 +375,6 @@ namespace Tpetra {
 
     // Common core guts of the constructor (the colMap argument is Teuchos::null if we're globally-indexed)
     void setup(const Teuchos::RCP<const map_type>  & ownedRowMap, const Teuchos::RCP<const map_type> & ownedPlusSharedRowMap,const Teuchos::RCP<const map_type> & ownedPlusSharedColMap, const Teuchos::RCP<Teuchos::ParameterList>& params);
-
-
-    // We forbid assignment (operator=) and copy construction
-    FECrsGraph<LocalOrdinal, GlobalOrdinal, Node>&
-    operator= (const FECrsGraph<LocalOrdinal, GlobalOrdinal, Node>&) = delete;
-
-    FECrsGraph (const FECrsGraph<LocalOrdinal, GlobalOrdinal, Node>&) = delete;
-
 
     // Enum for activity
     enum FEWhichActive
@@ -388,7 +401,7 @@ namespace Tpetra {
 
   }; // class FECrsGraph
 
- 
+
 } // namespace Tpetra
 
 #endif // TPETRA_FECRSGRAPH_DECL_HPP

--- a/packages/tpetra/core/src/Tpetra_FECrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_FECrsMatrix_decl.hpp
@@ -166,8 +166,29 @@ public:
     explicit FECrsMatrix (const Teuchos::RCP<const fe_crs_graph_type>& graph,
                           const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
-    //! Destructor.
-    virtual ~FECrsMatrix () {}
+    //! Copy constructor (forbidden).
+    FECrsMatrix (const FECrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>&) = delete;
+
+    //! Move constructor (forbidden).
+    FECrsMatrix (FECrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>&&) = delete;
+
+    //! Copy assignment (forbidden).
+    FECrsMatrix&
+    operator= (const FECrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>&) = delete;
+    //! Move assignment (forbidden).
+    FECrsMatrix&
+    operator= (FECrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>&&) = delete;
+
+    /// \brief Destructor (virtual for memory safety of derived classes).
+    ///
+    /// \note To Tpetra developers: See the C++ Core Guidelines C.21
+    ///   ("If you define or <tt>=delete</tt> any default operation,
+    ///   define or <tt>=delete</tt> them all"), in particular the
+    ///   AbstractBase example, for why this destructor declaration
+    ///   implies that we need the above four <tt>=delete</tt>
+    ///   declarations for copy construction, move construction, copy
+    ///   assignment, and move assignment.
+    virtual ~FECrsMatrix () = default;
 
     //! @name Transformational methods
     //@{
@@ -221,17 +242,8 @@ public:
     //! Switches which CrsGraph is active (without migrating data)
     void switchActiveCrsMatrix();
     //@}
-  
+
   private:
-    // We forbid assignment (operator=) and copy construction
-    FECrsMatrix<Scalar,LocalOrdinal, GlobalOrdinal, Node>&
-    operator= (const FECrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>&) = delete;
-
-    FECrsMatrix (const FECrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>&) = delete;
-
-
-
-
     // Enum for activity
     enum FEWhichActive
     {

--- a/packages/tpetra/core/src/Tpetra_FEMultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_FEMultiVector_decl.hpp
@@ -64,92 +64,116 @@ namespace Tpetra {
     public MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   {
   private:
-    friend ::Tpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
+    using base_type = ::Tpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
+    friend base_type;
+
   public:
     //! @name Typedefs to facilitate template metaprogramming.
     //@{
 
-    //! This class' first template parameter; the Scalar type.
-    typedef Scalar scalar_type;
-    //! This class' second template parameter; the type of local indices.
-    typedef LocalOrdinal local_ordinal_type;
-    //! This class' third template parameter; the type of global indices.
-    typedef GlobalOrdinal global_ordinal_type;
-    //! This class' fourth template parameter; the Kokkos Node type.
-    typedef Node node_type;
+    //! The type of each entry of the object.
+    using scalar_type = Scalar;
+    //! The type of the object's local indices.
+    using local_ordinal_type = LocalOrdinal;
+    //! The type of the object's global indices.
+    using global_ordinal_type = GlobalOrdinal;
 
-    //! The dual_view_type picked up from MultiVector
-    typedef typename MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::dual_view_type dual_view_type;
+    //! The object's Kokkos::Device specialization.
+    using device_type = typename base_type::device_type;
+
+    //! The object's Kokkos execution space.
+    using execution_space = typename base_type::execution_space;
+
+    //! Legacy typedef that will eventually disappear.
+    using node_type = Node;
+
+    //! Specialization of dual_view_type that this object may use.
+    using dual_view_type = typename base_type::dual_view_type;
 
     //! The type of the Map specialization used by this class.
-    typedef typename MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::map_type map_type;
+    using map_type = typename base_type::map_type;
 
-    //! Grab impl_scalar_type from superclass
-    typedef typename MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::impl_scalar_type impl_scalar_type;
+    //! The storage type of each entry of the object.
+    using impl_scalar_type = typename base_type::impl_scalar_type;
 
-    //! Grab dot_type from superclass
-    typedef typename MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::dot_type dot_type;
+    //! The type of this object's dot product result.
+    using dot_type = typename base_type::dot_type;
 
-    //! Grab mag_type from superclass
-    typedef typename MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::mag_type mag_type;
-
-    //! Grab device_type from superclass
-    typedef typename MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::device_type device_type;
-
-    //! Grab execution_space from superclass
-    typedef typename MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::execution_space execution_space;
-
-    //! The type of the base class of this class.
-    typedef MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> base_type;
+    //! The type of this object's norm result.
+    using mag_type = typename base_type::mag_type;
 
     //@}
     //! @name Constructors and destructor
     //@{
-    /// \brief Basic constructor.
-    /// \param map [in] Map describing the distribution of rows of the
-    ///   resulting MultiVector.  If the importer is not null, this must be the same as importer->getSourceMap()
-    /// \param importer [in] Import describing the distribution of rows of the the multivector in two separate modes.
-    ///   In the case of finite element assembly, importer->getSourceMap() should correspond to the uniquely owned entries in the domain map
-    ///   of the finite element problem.  importer->getTargetMap() should correspond to the overlapped entries needed for assembly.  The
-    ///   cannonical way to get this importer is to take the Import object associated with the CrsGraph for your finite element matrix.
-    /// \param numVectors [in] Number of columns of the resulting MultiVector.
-    // NOTE: A map AND an importer need to be arguments because in serial, the importer will be null
-    // This will default to importer->getTargetMap() being the active MultiVector
-    FEMultiVector(const Teuchos::RCP<const Map<LocalOrdinal,GlobalOrdinal,Node> > & map,
-                  const Teuchos::RCP<const Import<LocalOrdinal,GlobalOrdinal,Node> >& importer,
-                  const size_t numVecs,
-                  const bool zeroOut = true);
 
-    //! Destructor (virtual for memory safety of derived classes).
-    virtual ~FEMultiVector () {}
+    //! Default constructor (forbidden).
+    FEMultiVector () = delete;
+
+    /// \brief Basic constructor.
+    ///
+    /// \param map [in] Map describing the distribution of rows of the
+    ///   resulting MultiVector.  If the importer is not null, this
+    ///   must be the same as importer->getSourceMap().
+    ///
+    /// \param importer [in] Import describing the distribution of
+    ///   rows of the the multivector in two separate modes.  In the
+    ///   case of finite-element assembly, importer->getSourceMap()
+    ///   should correspond to the uniquely owned entries in the
+    ///   domain Map of the finite element problem.
+    ///   importer->getTargetMap() should correspond to the overlapped
+    ///   entries needed for assembly.  The canonical way to get this
+    ///   Import object is to take the Import object associated with
+    ///   the CrsGraph for your finite element matrix.
+    ///
+    /// \param numVectors [in] Number of columns of the resulting
+    ///   MultiVector.
+    ///
+    /// \note A Map AND an Import need to be arguments because in
+    ///   serial, the importer will be null.  This will default to
+    ///   importer->getTargetMap() being the active MultiVector.
+    FEMultiVector (const Teuchos::RCP<const map_type>& map,
+                   const Teuchos::RCP<const Import<local_ordinal_type, global_ordinal_type, node_type>>& importer,
+                   const size_t numVecs,
+                   const bool zeroOut = true);
+
+    //! Copy constructor (forbidden).
+    FEMultiVector (const FEMultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>&) = delete;
+
+    //! Move constructor (forbidden).
+    FEMultiVector (FEMultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>&&) = delete;
+
+    //! Copy assigment (forbidden).
+    FEMultiVector&
+    operator= (const FEMultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>&) = delete;
+
+    //! Move assigment (forbidden).
+    FEMultiVector&
+    operator= (FEMultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>&&) = delete;
+
+    /// \brief Destructor (virtual for memory safety of derived classes).
+    ///
+    /// \note To Tpetra developers: See the C++ Core Guidelines C.21
+    ///   ("If you define or <tt>=delete</tt> any default operation,
+    ///   define or <tt>=delete</tt> them all"), in particular the
+    ///   AbstractBase example, for why this destructor declaration
+    ///   implies that we need the above four <tt>=delete</tt>
+    ///   declarations for copy construction, move construction, copy
+    ///   assignment, and move assignment.
+    virtual ~FEMultiVector () = default;
 
     //@}
     //! @name Post-construction modification routines
     //@{
 
-    // ! Calls endFill()
-    void globalAssemble() {endFill();}
+    //! Declare the beginning of a phase of owned+shared modifications.
+    void beginFill ();
 
-    //! Calls doTargetToSource() and then activates the source map mode
-    void endFill()
-    {
-      if(*activeMultiVector_ == FE_ACTIVE_OWNED_PLUS_SHARED) {
-        doOwnedPlusSharedToOwned(Tpetra::ADD);
-        switchActiveMultiVector();
-      }
-      else
-        throw std::runtime_error("FEMultiVector: Owned+Shared MultiVector already active.  Cannot endFill()");
-    }
+    //! Declare the end of a phase of owned+shared modifications.
+    void endFill ();
 
-    //! Activates the target map mode
-    void beginFill()
-    {
-      // Note: This does not throw an error since the on construction, the FEMV is in owned+shared  mode.  Ergo, calling beginFill(),
-      // like one should expect to do in a rational universe, should not cause an error.
-      if(*activeMultiVector_ == FE_ACTIVE_OWNED) {
-        switchActiveMultiVector();
-      }
-    }
+    /// \brief Declare the end of a phase of owned+shared
+    ///   modifications; same as endFill().
+    void globalAssemble ();
 
     /// \brief Migrate data from the owned+shared to the owned multivector
     /// Since this is non-unique -> unique, we need a combine mode.
@@ -167,38 +191,33 @@ namespace Tpetra {
     //! Switches which Multivector is active (without migrating data)
     void switchActiveMultiVector();
 
-  private:
-    //! Default c'tor (private so it does not get used)
-    FEMultiVector() = delete;
-
   protected:
-    //@{
-    //! @name Internal routines and data structures
-
     /// \brief Replace the underlying Map in place.
     ///
     /// \warning FEMultiVector does not allow this and will throw if
     ///   you call this method.
     void replaceMap (const Teuchos::RCP<const map_type>& map);
 
-    // Enum for activity
+    //! Enum for activity
     enum FEWhichActive
     {
       FE_ACTIVE_OWNED_PLUS_SHARED,
       FE_ACTIVE_OWNED
     };
 
+    //! Whichever MultiVector is <i>not</i> currently active.
+    Teuchos::RCP<base_type> inactiveMultiVector_;
 
-    // This is whichever multivector isn't currently active
-    Teuchos::RCP< MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > inactiveMultiVector_;
-    // This is in RCP to make shallow copies of the FEMultiVector work correctly
+    /// \brief Whether the owned MultiVector or the owned plus shared
+    ///   MultiVector is active.
+    ///
+    /// This is an RCP in order to make shallow copies of the
+    /// FEMultiVector work correctly.
     Teuchos::RCP<FEWhichActive> activeMultiVector_;
 
-    // Importer
-    Teuchos::RCP<const Import<LocalOrdinal,GlobalOrdinal,Node> > importer_;
-
-    //@}
-  }; // class FEMultiVector
+    //! Import object used for communication between the two MultiVectors.
+    Teuchos::RCP<const Import<local_ordinal_type, global_ordinal_type, node_type>> importer_;
+  };
 
 } // namespace Tpetra
 

--- a/packages/tpetra/core/src/Tpetra_Map_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Map_decl.hpp
@@ -249,24 +249,26 @@ namespace Tpetra {
     //@{
 
     //! The type of local indices.
-    typedef LocalOrdinal local_ordinal_type;
+    using local_ordinal_type = LocalOrdinal;
+
     //! The type of global indices.
-    typedef GlobalOrdinal global_ordinal_type;
-    //! The type of the Kokkos Node.
-    typedef Node node_type;
+    using global_ordinal_type = GlobalOrdinal;
 
-    //! The Kokkos execution space.
-    typedef typename Node::execution_space execution_space;
-    //! The Kokkos memory space.
-    typedef typename Node::memory_space memory_space;
-
-    /// \brief The Kokkos device type over which to allocate Views and
-    ///   perform work.
+    /// \brief This class' Kokkos::Device specialization.
     ///
     /// A Kokkos::Device is an (execution_space, memory_space) pair.
     /// It defines where the Map's data live, and where Map might
     /// choose to execute parallel kernels.
-    typedef typename Node::device_type device_type;
+    using device_type = typename Node::device_type;
+
+    //! The Kokkos execution space.
+    using execution_space = typename device_type::execution_space;
+
+    //! The Kokkos memory space.
+    using memory_space = typename device_type::memory_space;
+
+    //! Legacy typedef that will go away at some point.
+    using node_type = Node;
 
     /// \brief Type of the "local" Map.
     ///
@@ -281,8 +283,10 @@ namespace Tpetra {
     /// communication, and can only access information that would
     /// never need MPI communication, no matter what kind of Map this
     /// is.
-    typedef ::Tpetra::Details::LocalMap<LocalOrdinal, GlobalOrdinal, device_type>
-      local_map_type;
+    using local_map_type =
+      ::Tpetra::Details::LocalMap<local_ordinal_type,
+                                  global_ordinal_type,
+                                  device_type>;
 
     //@}
     //! @name Constructors and destructor
@@ -340,11 +344,11 @@ namespace Tpetra {
      * \param node [in/out] (OPTIONAL; default usually suffices)
      *   Kokkos Node instance.
      */
-    Map (global_size_t numGlobalElements,
-         GlobalOrdinal indexBase,
-         const Teuchos::RCP<const Teuchos::Comm<int> > &comm,
-         LocalGlobal lg=GloballyDistributed,
-         const Teuchos::RCP<Node> &node = Teuchos::rcp (new Node));
+    Map (const global_size_t numGlobalElements,
+         const global_ordinal_type indexBase,
+         const Teuchos::RCP<const Teuchos::Comm<int>>& comm,
+         const LocalGlobal lg=GloballyDistributed,
+         const Teuchos::RCP<Node>& node = Teuchos::rcp (new Node));
 
     /** \brief Constructor with contiguous, possibly nonuniform
      *    distribution.
@@ -384,11 +388,11 @@ namespace Tpetra {
      * \param node [in/out] (OPTIONAL; default usually suffices)
      *   Kokkos Node instance.
      */
-    Map (global_size_t numGlobalElements,
-         size_t numLocalElements,
-         GlobalOrdinal indexBase,
-         const Teuchos::RCP<const Teuchos::Comm<int> > &comm,
-         const Teuchos::RCP<Node> &node = Teuchos::rcp (new Node));
+    Map (const global_size_t numGlobalElements,
+         const size_t numLocalElements,
+         const global_ordinal_type indexBase,
+         const Teuchos::RCP<const Teuchos::Comm<int>>& comm,
+         const Teuchos::RCP<Node>& node = Teuchos::rcp (new Node));
 
     /** \brief Constructor with arbitrary (possibly noncontiguous
      *   and/or nonuniform and/or overlapping) distribution, taking
@@ -547,8 +551,30 @@ namespace Tpetra {
     /// usual Map construction paths.
     Map ();
 
-    //! Destructor.
-    ~Map ();
+    //! Copy constructor (shallow copy).
+    Map (const Map<local_ordinal_type, global_ordinal_type, node_type>&) = default;
+
+    //! Move constructor (shallow move).
+    Map (Map<local_ordinal_type, global_ordinal_type, node_type>&&) = default;
+
+    //! Copy assigment (shallow copy).
+    Map&
+    operator= (const Map<local_ordinal_type, global_ordinal_type, node_type>&) = default;
+
+    //! Move assigment (shallow move).
+    Map&
+    operator= (Map<local_ordinal_type, global_ordinal_type, node_type>&&) = default;
+
+    /// \brief Destructor (virtual for memory safety of derived classes).
+    ///
+    /// \note To Tpetra developers: See the C++ Core Guidelines C.21
+    ///   ("If you define or <tt>=delete</tt> any default operation,
+    ///   define or <tt>=delete</tt> them all"), in particular the
+    ///   AbstractBase example, for why this destructor declaration
+    ///   implies that we need the above four <tt>=default</tt>
+    ///   declarations for copy construction, move construction, copy
+    ///   assignment, and move assignment.
+    virtual ~Map ();
 
     //@}
     //! @name Attributes
@@ -1577,4 +1603,3 @@ bool operator!= (const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> &map1,
 
 
 #endif // TPETRA_MAP_DECL_HPP
-

--- a/packages/tpetra/core/src/Tpetra_Map_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Map_def.hpp
@@ -87,11 +87,11 @@ namespace Tpetra {
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   Map<LocalOrdinal,GlobalOrdinal,Node>::
-  Map (global_size_t numGlobalElements,
-       GlobalOrdinal indexBase,
-       const Teuchos::RCP<const Teuchos::Comm<int> > &comm,
-       LocalGlobal lOrG,
-       const Teuchos::RCP<Node> &/* node */) :
+  Map (const global_size_t numGlobalElements,
+       const global_ordinal_type indexBase,
+       const Teuchos::RCP<const Teuchos::Comm<int>>& comm,
+       const LocalGlobal lOrG,
+       const Teuchos::RCP<Node>& /* node */) :
     comm_ (comm),
     uniform_ (true),
     directory_ (new Directory<LocalOrdinal, GlobalOrdinal, Node> ())
@@ -103,8 +103,8 @@ namespace Tpetra {
     using Teuchos::REDUCE_MIN;
     using Teuchos::REDUCE_MAX;
     using Teuchos::typeName;
-    typedef GlobalOrdinal GO;
-    typedef global_size_t GST;
+    using GO = global_ordinal_type;
+    using GST = global_size_t;
     const GST GSTI = Tpetra::Details::OrdinalTraits<GST>::invalid ();
 
     Tpetra::Details::initializeKokkos ();
@@ -240,11 +240,11 @@ namespace Tpetra {
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   Map<LocalOrdinal,GlobalOrdinal,Node>::
-  Map (global_size_t numGlobalElements,
-       size_t numLocalElements,
-       GlobalOrdinal indexBase,
-       const Teuchos::RCP<const Teuchos::Comm<int> > &comm,
-       const Teuchos::RCP<Node> &/* node */) :
+  Map (const global_size_t numGlobalElements,
+       const size_t numLocalElements,
+       const global_ordinal_type indexBase,
+       const Teuchos::RCP<const Teuchos::Comm<int>>& comm,
+       const Teuchos::RCP<Node>& /* node */) :
     comm_ (comm),
     uniform_ (false),
     directory_ (new Directory<LocalOrdinal, GlobalOrdinal, Node> ())
@@ -257,8 +257,8 @@ namespace Tpetra {
     using Teuchos::REDUCE_MAX;
     using Teuchos::REDUCE_SUM;
     using Teuchos::scan;
-    typedef GlobalOrdinal GO;
-    typedef global_size_t GST;
+    using GO = global_ordinal_type;
+    using GST = global_size_t;
     const GST GSTI = Tpetra::Details::OrdinalTraits<GST>::invalid ();
 
     Tpetra::Details::initializeKokkos ();

--- a/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
@@ -2563,8 +2563,8 @@ namespace Tpetra {
     }
     else {
       auto dstWhichVecs = getMultiVectorWhichVectors (dst);
-      auto srcWhichVecs = getMultiVectorWhichVectors (src);        
-      
+      auto srcWhichVecs = getMultiVectorWhichVectors (src);
+
       if (srcMostUpToDateOnDevice) {
         Details::localDeepCopy (dst.getLocalViewDevice (),
                                 src.getLocalViewDevice (),

--- a/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
@@ -2530,8 +2530,6 @@ namespace Tpetra {
   deep_copy (MultiVector<DS, DL, DG, DN>& dst,
              const MultiVector<SS, SL, SG, SN>& src)
   {
-    typedef typename DN::device_type DD;
-    //typedef typename SN::device_type SD;
     using ::Tpetra::getMultiVectorWhichVectors;
 
     TEUCHOS_TEST_FOR_EXCEPTION(
@@ -2549,244 +2547,39 @@ namespace Tpetra {
       "objects do not match.  src has " << src.getLocalLength () << " row(s) "
       << " and dst has " << dst.getLocalLength () << " row(s).");
 
+    const bool srcMostUpToDateOnDevice = ! src.need_sync_device ();
+    dst.clear_sync_state ();
+    dst.modify_device ();
+
     if (src.isConstantStride () && dst.isConstantStride ()) {
-      typedef typename MultiVector<DS, DL, DG, DN>::dual_view_type::t_host::execution_space HES;
-      typedef typename MultiVector<DS, DL, DG, DN>::dual_view_type::t_dev::execution_space DES;
-
-      // If we need sync to device, then host has the most recent version.
-      const bool useHostVersion = src.template need_sync<typename SN::device_type> ();
-
-      if (! useHostVersion) {
-        // Device memory has the most recent version of src.
-        dst.template modify<DES> (); // We are about to modify dst on device.
-        // Copy from src to dst on device.
+      if (srcMostUpToDateOnDevice) {
         Details::localDeepCopyConstStride (dst.getLocalViewDevice (),
                                            src.getLocalViewDevice ());
-        dst.sync_host (); // Sync dst from device to host.
       }
-      else { // Host memory has the most recent version of src.
-        dst.template modify<HES> (); // We are about to modify dst on host.
-        // Copy from src to dst on host.
-        Details::localDeepCopyConstStride (dst.getLocalViewHost (),
+      else {
+        Details::localDeepCopyConstStride (dst.getLocalViewDevice (),
                                            src.getLocalViewHost ());
-        dst.template sync<DES> (); // Sync dst from host to device.
       }
     }
     else {
-      typedef Kokkos::DualView<SL*, DD> whichvecs_type;
-      typedef typename whichvecs_type::t_dev::execution_space DES;
-      typedef typename whichvecs_type::t_host::execution_space HES;
-
-      if (dst.isConstantStride ()) {
-        const SL numWhichVecs =
-          static_cast<SL> (getMultiVectorWhichVectors (src).size ());
-        const std::string whichVecsLabel ("MV::deep_copy::whichVecs");
-
-        // We can't sync src, since it is only an input argument.
-        // Thus, we have to use the most recently modified version of
-        // src, which could be either the device or host version.
-        //
-        // If we need sync to device, then host has the most recent version.
-        const bool useHostVersion = src.template need_sync<typename SN::device_type> ();
-
-        if (! useHostVersion) { // Copy from the device version of src.
-          // whichVecs tells the kernel which vectors (columns) of src
-          // to copy.  Fill whichVecs on the host, and sync to device.
-          whichvecs_type whichVecs (whichVecsLabel, numWhichVecs);
-          whichVecs.modify_host ();
-
-          Teuchos::ArrayView<const size_t> src_whichVectors =
-            getMultiVectorWhichVectors (src);
-          for (SL i = 0; i < numWhichVecs; ++i) {
-            whichVecs.h_view(i) = static_cast<SL> (src_whichVectors[i]);
-          }
-          // Sync the host version of whichVecs to the device.
-          whichVecs.template sync<DES> ();
-
-          // Mark the device version of dst's DualView as modified.
-          dst.template modify<DES> ();
-          // Copy from the selected vectors of src to dst, on the device.
-          Details::localDeepCopy (dst.getLocalViewDevice (),
-                                  src.getLocalViewDevice (),
-                                  dst.isConstantStride (),
-                                  src.isConstantStride (),
-                                  whichVecs.d_view,
-                                  whichVecs.d_view);
-          // Sync dst's DualView to the host.  This is cheaper than
-          // repeating the above copy from src to dst on the host.
-          dst.sync_host ();
-        }
-        else { // host version of src was the most recently modified
-          // Copy from the host version of src.
-          //
-          // whichVecs tells the kernel which vectors (columns) of src
-          // to copy.  Fill whichVecs on the host, and use it there.
-          typedef Kokkos::View<SL*, HES> the_whichvecs_type;
-          the_whichvecs_type whichVecs (whichVecsLabel, numWhichVecs);
-          Teuchos::ArrayView<const size_t> src_whichVectors =
-            getMultiVectorWhichVectors (src);
-          for (SL i = 0; i < numWhichVecs; ++i) {
-            whichVecs(i) = static_cast<SL> (src_whichVectors[i]);
-          }
-          // Copy from the selected vectors of src to dst, on the
-          // host.  The function ignores the first instance of
-          // 'whichVecs' in this case.
-          Details::localDeepCopy (dst.getLocalViewHost (),
-                                  src.getLocalViewHost (),
-                                  dst.isConstantStride (),
-                                  src.isConstantStride (),
-                                  whichVecs, whichVecs);
-          // Sync dst back to the device, since we only copied on the host.
-          dst.template sync<DES> ();
-        }
+      auto dstWhichVecs = getMultiVectorWhichVectors (dst);
+      auto srcWhichVecs = getMultiVectorWhichVectors (src);        
+      
+      if (srcMostUpToDateOnDevice) {
+        Details::localDeepCopy (dst.getLocalViewDevice (),
+                                src.getLocalViewDevice (),
+                                dst.isConstantStride (),
+                                src.isConstantStride (),
+                                dstWhichVecs,
+                                srcWhichVecs);
       }
-      else { // dst is NOT constant stride
-        if (src.isConstantStride ()) {
-
-          // If we need sync to device, then host has the most recent version.
-          const bool useHostVersion = src.template need_sync<typename SN::device_type> ();
-
-          if (! useHostVersion) { // Copy from the device version of src.
-            // whichVecs tells the kernel which vectors (columns) of dst
-            // to copy.  Fill whichVecs on the host, and sync to device.
-            typedef Kokkos::DualView<DL*, DES> the_whichvecs_type;
-            const std::string whichVecsLabel ("MV::deep_copy::whichVecs");
-            Teuchos::ArrayView<const size_t> dst_whichVectors =
-              getMultiVectorWhichVectors (dst);
-            const DL numWhichVecs = static_cast<DL> (dst_whichVectors.size ());
-            the_whichvecs_type whichVecs (whichVecsLabel, numWhichVecs);
-            whichVecs.template modify<HES> ();
-            for (DL i = 0; i < numWhichVecs; ++i) {
-              whichVecs.h_view(i) = dst_whichVectors[i];
-            }
-            // Sync the host version of whichVecs to the device.
-            whichVecs.template sync<DES> ();
-
-            // Copy src to the selected vectors of dst, on the device.
-            Details::localDeepCopy (dst.template getLocalView<typename DN::device_type> (),
-                                    src.template getLocalView<typename SN::device_type> (),
-                                    dst.isConstantStride (),
-                                    src.isConstantStride (),
-                                    whichVecs.d_view,
-                                    whichVecs.d_view);
-            // We can't sync src and repeat the above copy on the
-            // host, so sync dst back to the host.
-            //
-            // FIXME (mfh 29 Jul 2014) This may overwrite columns that
-            // don't actually belong to dst's view.
-            dst.sync_host ();
-          }
-          else { // host version of src was the most recently modified
-            // Copy from the host version of src.
-            //
-            // whichVecs tells the kernel which vectors (columns) of src
-            // to copy.  Fill whichVecs on the host, and use it there.
-            typedef Kokkos::View<DL*, HES> the_whichvecs_type;
-            Teuchos::ArrayView<const size_t> dst_whichVectors =
-              getMultiVectorWhichVectors (dst);
-            const DL numWhichVecs = static_cast<DL> (dst_whichVectors.size ());
-            the_whichvecs_type whichVecs ("MV::deep_copy::whichVecs",
-                                          numWhichVecs);
-            for (DL i = 0; i < numWhichVecs; ++i) {
-              whichVecs(i) = static_cast<DL> (dst_whichVectors[i]);
-            }
-            // Copy from src to the selected vectors of dst, on the host.
-            Details::localDeepCopy (dst.getLocalViewHost (),
-                                    src.getLocalViewHost (),
-                                    dst.isConstantStride (),
-                                    src.isConstantStride (),
-                                    whichVecs, whichVecs);
-            // Sync dst back to the device, since we only copied on the host.
-            //
-            // FIXME (mfh 29 Jul 2014) This may overwrite columns that
-            // don't actually belong to dst's view.
-            dst.template sync<DES> ();
-          }
-        }
-        else { // neither src nor dst have constant stride
-
-          // If we need sync to device, then host has the most recent version.
-          const bool useHostVersion = src.template need_sync<typename SN::device_type> ();
-
-          if (! useHostVersion) { // Copy from the device version of src.
-            // whichVectorsDst tells the kernel which columns of dst
-            // to copy.  Fill it on the host, and sync to device.
-            Teuchos::ArrayView<const size_t> dst_whichVectors =
-              getMultiVectorWhichVectors (dst);
-            const DL dstNumWhichVecs =
-              static_cast<DL> (dst_whichVectors.size ());
-            Kokkos::DualView<DL*, DES> whichVecsDst ("MV::deep_copy::whichVecsDst",
-                                                     dstNumWhichVecs);
-            whichVecsDst.template modify<HES> ();
-            for (DL i = 0; i < dstNumWhichVecs; ++i) {
-              whichVecsDst.h_view(i) = static_cast<DL> (dst_whichVectors[i]);
-            }
-            // Sync the host version of whichVecsDst to the device.
-            whichVecsDst.template sync<DES> ();
-
-            // whichVectorsSrc tells the kernel which vectors
-            // (columns) of src to copy.  Fill it on the host, and
-            // sync to device.  Use the destination MultiVector's
-            // LocalOrdinal type here.
-            Teuchos::ArrayView<const size_t> src_whichVectors =
-              getMultiVectorWhichVectors (src);
-            const DL srcNumWhichVecs =
-              static_cast<DL> (src_whichVectors.size ());
-            Kokkos::DualView<DL*, DES> whichVecsSrc ("MV::deep_copy::whichVecsSrc",
-                                                     srcNumWhichVecs);
-            whichVecsSrc.template modify<HES> ();
-            for (DL i = 0; i < srcNumWhichVecs; ++i) {
-              whichVecsSrc.h_view(i) = static_cast<DL> (src_whichVectors[i]);
-            }
-            // Sync the host version of whichVecsSrc to the device.
-            whichVecsSrc.template sync<DES> ();
-
-            // Copy from the selected vectors of src to the selected
-            // vectors of dst, on the device.
-            Details::localDeepCopy (dst.template getLocalView<typename DN::device_type> (),
-                                    src.template getLocalView<typename SN::device_type> (),
-                                    dst.isConstantStride (),
-                                    src.isConstantStride (),
-                                    whichVecsDst.d_view,
-                                    whichVecsSrc.d_view);
-          }
-          else {
-            Teuchos::ArrayView<const size_t> dst_whichVectors =
-              getMultiVectorWhichVectors (dst);
-            const DL dstNumWhichVecs =
-              static_cast<DL> (dst_whichVectors.size ());
-            Kokkos::View<DL*, HES> whichVectorsDst ("dstWhichVecs",
-                                                    dstNumWhichVecs);
-            for (DL i = 0; i < dstNumWhichVecs; ++i) {
-              whichVectorsDst(i) = dst_whichVectors[i];
-            }
-
-            Teuchos::ArrayView<const size_t> src_whichVectors =
-              getMultiVectorWhichVectors (src);
-            // Use the destination MultiVector's LocalOrdinal type here.
-            const DL srcNumWhichVecs =
-              static_cast<DL> (src_whichVectors.size ());
-            Kokkos::View<DL*, HES> whichVectorsSrc ("srcWhichVecs",
-                                                    srcNumWhichVecs);
-            for (DL i = 0; i < srcNumWhichVecs; ++i) {
-              whichVectorsSrc(i) = src_whichVectors[i];
-            }
-
-            // Copy from the selected vectors of src to the selected
-            // vectors of dst, on the host.
-            Details::localDeepCopy (dst.getLocalViewHost (),
-                                    src.getLocalViewHost (),
-                                    dst.isConstantStride (),
-                                    src.isConstantStride (),
-                                    whichVectorsDst, whichVectorsSrc);
-            // We can't sync src and repeat the above copy on the
-            // host, so sync dst back to the host.
-            //
-            // FIXME (mfh 29 Jul 2014) This may overwrite columns that
-            // don't actually belong to dst's view.
-            dst.sync_host ();
-          }
-        }
+      else {
+        Details::localDeepCopy (dst.getLocalViewDevice (),
+                                src.getLocalViewHost (),
+                                dst.isConstantStride (),
+                                src.isConstantStride (),
+                                dstWhichVecs,
+                                srcWhichVecs);
       }
     }
   }

--- a/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
@@ -527,9 +527,6 @@ namespace Tpetra {
                  const size_t numVecs,
                  const bool zeroOut = true);
 
-    //! Copy constructor (shallow copy!).
-    MultiVector (const MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& source);
-
     /// \brief Copy constructor, with option to do deep or shallow copy.
     ///
     /// The current (so-called "Kokkos refactor," circa >= 2014/5)
@@ -802,6 +799,42 @@ namespace Tpetra {
                  const map_type& subMap,
                  const size_t offset = 0);
 
+    /// \brief Copy constructor (shallow copy).
+    ///
+    /// MultiVector's copy constructor always does a shallow copy.
+    /// Use the nonmember function <tt>Tpetra::deep_copy</tt> (see
+    /// below) to deep-copy one existing MultiVector to another, and
+    /// use the two-argument "copy constructor" (in this file, with
+    /// <tt>copyOrView=Teuchos::Copy</tt>) to create a MultiVector
+    /// that is a deep copy of an existing MultiVector.
+    MultiVector (const MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>&) = default;
+
+    //! Move constructor (shallow move).
+    MultiVector (MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>&&) = default;
+
+    /// \brief Copy assigment (shallow copy).
+    ///
+    /// MultiVector's copy constructor always does a shallow copy.
+    /// Use the nonmember function <tt>Tpetra::deep_copy</tt> (see
+    /// below) to deep-copy one existing MultiVector to another.
+    MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>&
+    operator= (const MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>&) = default;
+
+    //! Move assigment (shallow move).
+    MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>&
+    operator= (MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>&&) = default;
+
+    /// \brief Destructor (virtual for memory safety of derived classes).
+    ///
+    /// \note To Tpetra developers: See the C++ Core Guidelines C.21
+    ///   ("If you define or <tt>=delete</tt> any default operation,
+    ///   define or <tt>=delete</tt> them all"), in particular the
+    ///   AbstractBase example, for why this destructor declaration
+    ///   implies that we need the above four <tt>=default</tt>
+    ///   declarations for copy construction, move construction, copy
+    ///   assignment, and move assignment.
+    virtual ~MultiVector () = default;
+
     /// \brief Return a deep copy of this MultiVector, with a
     ///   different Node type.
     ///
@@ -816,9 +849,6 @@ namespace Tpetra {
 
     //! Swap contents of \c mv with contents of \c *this.
     void swap (MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& mv);
-
-    //! Destructor (virtual for memory safety of derived classes).
-    virtual ~MultiVector () = default;
 
     //@}
     //! @name Post-construction modification routines
@@ -1236,10 +1266,6 @@ namespace Tpetra {
     ///
     /// \pre isDistributed() == false
     void reduce();
-
-    //! Shallow copy: assign \c source to \c *this.
-    MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>&
-    operator= (const MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& source);
 
     //@}
 

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -363,15 +363,6 @@ namespace Tpetra {
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  MultiVector (const MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& source) :
-    base_type (source),
-    view_ (source.view_),
-    origView_ (source.origView_),
-    whichVectors_ (source.whichVectors_)
-  {}
-
-  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-  MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   MultiVector (const MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& source,
                const Teuchos::DataAccess copyOrView) :
     base_type (source),
@@ -3166,34 +3157,6 @@ namespace Tpetra {
 
     return Teuchos::arcp_reinterpret_cast<Scalar> (dataAsArcp);
   }
-
-  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-  MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>&
-  MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  operator= (const MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& source)
-  {
-    if (this != &source) {
-      base_type::operator= (source);
-      //
-      // operator= implements view semantics (shallow copy).
-      //
-
-      // Kokkos::View operator= also implements view semantics.
-      view_ = source.view_;
-      origView_ = source.origView_;
-
-      // NOTE (mfh 24 Mar 2014) Christian wrote here that assigning
-      // whichVectors_ is "probably not ok" (probably constitutes deep
-      // copy).  I would say that it's OK, because whichVectors_ is
-      // immutable (from the user's perspective); it's analogous to
-      // the dimensions or stride.  Once we make whichVectors_ a
-      // Kokkos::View instead of a Teuchos::Array, all debate will go
-      // away and we will unquestionably have view semantics.
-      whichVectors_ = source.whichVectors_;
-    }
-    return *this;
-  }
-
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   Teuchos::RCP<MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> >

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -4701,13 +4701,8 @@ namespace Tpetra {
   MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   assign (const MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& src)
   {
-    using LO = LocalOrdinal;
-    using DT = device_type;
-    using HMDT = typename dual_view_type::host_mirror_space::device_type;
     using ::Tpetra::Details::localDeepCopy;
-    using ::Tpetra::Details::localDeepCopyConstStride;
-    const char prefix[] = "Tpetra::deep_copy (MultiVector): ";
-    const bool debug = false;
+    const char prefix[] = "Tpetra::MultiVector::assign: ";
 
     TEUCHOS_TEST_FOR_EXCEPTION
       (this->getGlobalLength () != src.getGlobalLength () ||
@@ -4727,219 +4722,27 @@ namespace Tpetra {
     // contents in either memory space, and we don't want
     // DualView::modify to complain about "concurrent modification" of
     // host and device Views.
-    this->view_.clear_sync_state();
+    this->clear_sync_state();
+    this->modify_device ();
 
-    if (debug && this->getMap ()->getComm ()->getRank () == 0) {
-      std::cout << "*** MultiVector::assign: ";
-    }
+    // If need sync to device, then host has most recent version.
+    const bool src_last_updated_on_host = src.need_sync_device ();
 
-    if (src.isConstantStride () && this->isConstantStride ()) {
-      if (debug && this->getMap ()->getComm ()->getRank () == 0) {
-        std::cout << "Both *this and src have constant stride" << std::endl;
-      }
-
-      // If we need sync to device, then host has the most recent version.
-      const bool useHostVersion = src.need_sync_device ();
-
-      if (useHostVersion) { // Host memory has the most recent version of src.
-        // Copy from src to dst on host.
-        this->modify_host ();
-        localDeepCopyConstStride (this->getLocalViewHost (),
-                                  src.getLocalViewHost ());
-      }
-      else { // Device memory has the most recent version of src.
-        // Copy from src to dst on device.
-        this->modify_device ();
-        localDeepCopyConstStride (this->getLocalViewDevice (),
-                                  src.getLocalViewDevice ());
-      }
+    if (src_last_updated_on_host) {
+      localDeepCopy (this->getLocalViewDevice (),
+                     src.getLocalViewHost (),
+                     this->isConstantStride (),
+                     src.isConstantStride (),
+                     this->whichVectors_ (),
+                     src.whichVectors_ ());
     }
     else {
-      if (this->isConstantStride ()) {
-        if (debug && this->getMap ()->getComm ()->getRank () == 0) {
-          std::cout << "Only *this has constant stride";
-        }
-
-        const LO numWhichVecs = static_cast<LO> (src.whichVectors_.size ());
-        const std::string whichVecsLabel ("MV::deep_copy::whichVecs");
-
-        // We can't sync src, since it is only an input argument.
-        // Thus, we have to use the most recently modified version of
-        // src, device or host.
-        //
-        // If we need sync to device, then host has the most recent version.
-        const bool useHostVersion = src.need_sync_device ();
-        if (useHostVersion) { // host version of src most recently modified
-          if (debug && this->getMap ()->getComm ()->getRank () == 0) {
-            std::cout << "; Copy from host version of src" << std::endl;
-          }
-          // Copy from the host version of src.
-          //
-          // whichVecs tells the kernel which vectors (columns) of src
-          // to copy.  Fill whichVecs on the host, and use it there.
-          using whichvecs_type = Kokkos::View<LO*, HMDT>;
-          whichvecs_type srcWhichVecs (whichVecsLabel, numWhichVecs);
-          for (LO i = 0; i < numWhichVecs; ++i) {
-            srcWhichVecs(i) = static_cast<LO> (src.whichVectors_[i]);
-          }
-          // Copy from the selected vectors of src to dst, on the
-          // host.  The function ignores its dstWhichVecs argument in
-          // this case.
-          this->modify_host ();
-          localDeepCopy (this->getLocalViewHost (),
-                         src.getLocalViewHost (),
-                         true, false, srcWhichVecs, srcWhichVecs);
-        }
-        else { // copy from the device version of src
-          if (debug && this->getMap ()->getComm ()->getRank () == 0) {
-            std::cout << "; Copy from device version of src" << std::endl;
-          }
-          // Copy from the device version of src.
-          //
-          // whichVecs tells the kernel which vectors (columns) of src
-          // to copy.  Fill whichVecs on the host, and sync to device.
-          using whichvecs_type = Kokkos::DualView<LO*, DT>;
-          whichvecs_type srcWhichVecs (whichVecsLabel, numWhichVecs);
-          srcWhichVecs.modify_host ();
-          for (LO i = 0; i < numWhichVecs; ++i) {
-            srcWhichVecs.h_view(i) = static_cast<LO> (src.whichVectors_[i]);
-          }
-          // Sync the host version of srcWhichVecs to the device.
-          srcWhichVecs.sync_device ();
-
-          // Copy from the selected vectors of src to dst, on the
-          // device.  The function ignores its dstWhichVecs argument
-          // in this case.
-          this->modify_device ();
-          localDeepCopy (this->getLocalViewDevice (),
-                         src.getLocalViewDevice (),
-                         true, false, srcWhichVecs.d_view,
-                         srcWhichVecs.d_view);
-        }
-
-      }
-      else { // dst is NOT constant stride
-        if (src.isConstantStride ()) {
-          if (debug && this->getMap ()->getComm ()->getRank () == 0) {
-            std::cout << "Only src has constant stride" << std::endl;
-          }
-
-          // If we need sync to device, then host has the most recent version.
-          const bool useHostVersion = src.need_sync_device ();
-          if (useHostVersion) { // src most recently modified on host
-            // Copy from the host version of src.
-            //
-            // whichVecs tells the kernel which vectors (columns) of src
-            // to copy.  Fill whichVecs on the host, and use it there.
-            using whichvecs_type = Kokkos::View<LO*, HMDT>;
-            const LO numWhichVecs = static_cast<LO> (this->whichVectors_.size ());
-            whichvecs_type whichVecs ("MV::deep_copy::whichVecs", numWhichVecs);
-            for (LO i = 0; i < numWhichVecs; ++i) {
-              whichVecs(i) = static_cast<LO> (this->whichVectors_[i]);
-            }
-            // Copy from src to the selected vectors of dst, on the
-            // host.  The functor ignores its 4th arg in this case.
-            this->modify_host ();
-            localDeepCopy (this->getLocalViewHost (),
-                           src.getLocalViewHost (),
-                           this->isConstantStride (),
-                           src.isConstantStride (),
-                           whichVecs, whichVecs);
-          }
-          else { // Copy from the device version of src.
-            // whichVecs tells the kernel which vectors (columns) of dst
-            // to copy.  Fill whichVecs on the host, and sync to device.
-            using whichvecs_type = Kokkos::DualView<LO*, DT>;
-            const std::string whichVecsLabel ("MV::deep_copy::whichVecs");
-            const LO numWhichVecs = static_cast<LO> (this->whichVectors_.size ());
-            whichvecs_type whichVecs (whichVecsLabel, numWhichVecs);
-            whichVecs.modify_host ();
-            for (LO i = 0; i < numWhichVecs; ++i) {
-              whichVecs.h_view(i) = this->whichVectors_[i];
-            }
-            // Sync the host version of whichVecs to the device.
-            whichVecs.sync_device ();
-
-            // Copy src to the selected vectors of dst, on the device.
-            this->modify_device ();
-            localDeepCopy (this->getLocalViewDevice (),
-                           src.getLocalViewDevice (),
-                           this->isConstantStride (),
-                           src.isConstantStride (),
-                           whichVecs.d_view,
-                           whichVecs.d_view);
-          }
-        }
-        else { // neither src nor dst have constant stride
-          if (debug && this->getMap ()->getComm ()->getRank () == 0) {
-            std::cout << "Neither *this nor src has constant stride" << std::endl;
-          }
-
-          // If we need sync to device, then host has the most recent version.
-          const bool useHostVersion = src.need_sync_device ();
-          if (useHostVersion) { // copy from the host version of src
-            const LO dstNumWhichVecs = static_cast<LO> (this->whichVectors_.size ());
-            Kokkos::View<LO*, HMDT> whichVectorsDst ("dstWhichVecs", dstNumWhichVecs);
-            for (LO i = 0; i < dstNumWhichVecs; ++i) {
-              whichVectorsDst(i) = this->whichVectors_[i];
-            }
-
-            // Use the destination MultiVector's LocalOrdinal type here.
-            const LO srcNumWhichVecs = static_cast<LO> (src.whichVectors_.size ());
-            Kokkos::View<LO*, HMDT> whichVectorsSrc ("srcWhichVecs", srcNumWhichVecs);
-            for (LO i = 0; i < srcNumWhichVecs; ++i) {
-              whichVectorsSrc(i) = src.whichVectors_[i];
-            }
-
-            // Copy from the selected vectors of src to the selected
-            // vectors of dst, on the host.
-            this->modify_host ();
-            localDeepCopy (this->getLocalViewHost (),
-                           src.getLocalViewHost (),
-                           this->isConstantStride (),
-                           src.isConstantStride (),
-                           whichVectorsDst,
-                           whichVectorsSrc);
-          }
-          else { // copy from the device version of src
-            // whichVectorsDst tells the kernel which columns of dst
-            // to copy.  Fill it on the host, and sync to device.
-            const LO dstNumWhichVecs = static_cast<LO> (this->whichVectors_.size ());
-            Kokkos::DualView<LO*, DT> whichVecsDst ("MV::deep_copy::whichVecsDst",
-                                                    dstNumWhichVecs);
-            whichVecsDst.modify_host ();
-            for (LO i = 0; i < dstNumWhichVecs; ++i) {
-              whichVecsDst.h_view(i) = static_cast<LO> (this->whichVectors_[i]);
-            }
-            // Sync the host version of whichVecsDst to the device.
-            whichVecsDst.sync_device ();
-
-            // whichVectorsSrc tells the kernel which vectors
-            // (columns) of src to copy.  Fill it on the host, and
-            // sync to device.  Use the destination MultiVector's
-            // LocalOrdinal type here.
-            const LO srcNumWhichVecs = static_cast<LO> (src.whichVectors_.size ());
-            Kokkos::DualView<LO*, DT> whichVecsSrc ("MV::deep_copy::whichVecsSrc",
-                                                    srcNumWhichVecs);
-            whichVecsSrc.modify_host ();
-            for (LO i = 0; i < srcNumWhichVecs; ++i) {
-              whichVecsSrc.h_view(i) = static_cast<LO> (src.whichVectors_[i]);
-            }
-            // Sync the host version of whichVecsSrc to the device.
-            whichVecsSrc.sync_device ();
-
-            // Copy from the selected vectors of src to the selected
-            // vectors of dst, on the device.
-            this->modify_device ();
-            localDeepCopy (this->getLocalViewDevice (),
-                           src.getLocalViewDevice (),
-                           this->isConstantStride (),
-                           src.isConstantStride (),
-                           whichVecsDst.d_view,
-                           whichVecsSrc.d_view);
-          }
-        }
-      }
+      localDeepCopy (this->getLocalViewDevice (),
+                     src.getLocalViewDevice (),
+                     this->isConstantStride (),
+                     src.isConstantStride (),
+                     this->whichVectors_ (),
+                     src.whichVectors_ ());
     }
   }
 
@@ -4986,6 +4789,7 @@ namespace Tpetra {
   deep_copy (MultiVector<ST, LO, GO, NT>& dst,
              const Teuchos::SerialDenseMatrix<int, ST>& src)
   {
+    using ::Tpetra::Details::localDeepCopy;
     using MV = MultiVector<ST, LO, GO, NT>;
     using IST = typename MV::impl_scalar_type;
     using input_view_type =
@@ -4995,48 +4799,30 @@ namespace Tpetra {
 
     const LO numRows = static_cast<LO> (src.numRows ());
     const LO numCols = static_cast<LO> (src.numCols ());
-    TEUCHOS_ASSERT( numRows == static_cast<LO> (dst.getLocalLength ()) );
-    TEUCHOS_ASSERT( numCols == static_cast<LO> (dst.getNumVectors ()) );
+
+    TEUCHOS_TEST_FOR_EXCEPTION
+      (numRows != static_cast<LO> (dst.getLocalLength ()) ||
+       numCols != static_cast<LO> (dst.getNumVectors ()),
+       std::invalid_argument, "Tpetra::deep_copy: On Process "
+       << dst.getMap ()->getComm ()->getRank () << ", dst is "
+       << dst.getLocalLength () << " x " << dst.getNumVectors ()
+       << ", but src is " << numRows << " x " << numCols << ".");
 
     const IST* src_raw = reinterpret_cast<const IST*> (src.values ());
     input_view_type src_orig (src_raw, src.stride (), numCols);
     input_view_type src_view =
-      Kokkos::subview (src_orig, pair_type (0, numRows),
-                       pair_type (0, numCols));
+      Kokkos::subview (src_orig, pair_type (0, numRows), Kokkos::ALL ());
 
-    if (dst.need_sync_device ()) {
-      dst.modify_host ();
-      if (dst.isConstantStride ()) {
-        Kokkos::deep_copy (dst.getLocalViewHost (), src_view);
-      }
-      else {
-        for (LO col = 0; col < numCols; ++col) {
-          auto dst_col = dst.getVectorNonConst (size_t (col));
-          auto dst_col_lcl_h_2d = dst_col->getLocalViewHost ();
-          auto dst_col_lcl_h =
-            Kokkos::subview (dst_col_lcl_h_2d, Kokkos::ALL (), 0);
-          auto src_col = Kokkos::subview (src_view, Kokkos::ALL (), col);
-          Kokkos::deep_copy (dst_col_lcl_h, src_col);
-        }
-      }
-      dst.sync_device (); // solvers prefer output sync'd to device
-    }
-    else {
-      dst.modify_device ();
-      if (dst.isConstantStride ()) {
-        Kokkos::deep_copy (dst.getLocalViewDevice (), src_view);
-      }
-      else {
-        for (LO col = 0; col < numCols; ++col) {
-          auto dst_col = dst.getVectorNonConst (size_t (col));
-          auto dst_col_lcl_d_2d = dst_col->getLocalViewDevice ();
-          auto dst_col_lcl_d =
-            Kokkos::subview (dst_col_lcl_d_2d, Kokkos::ALL (), 0);
-          auto src_col = Kokkos::subview (src_view, Kokkos::ALL (), col);
-          Kokkos::deep_copy (dst_col_lcl_d, src_col);
-        }
-      }
-    }
+    dst.clear_sync_state ();
+    dst.modify_device ();
+    constexpr bool src_isConstantStride = true;
+    Teuchos::ArrayView<const size_t> srcWhichVectors (nullptr, 0);
+    localDeepCopy (dst.getLocalViewDevice (),
+                   src_view,
+                   dst.isConstantStride (),
+                   src_isConstantStride,
+                   getMultiVectorWhichVectors (dst),
+                   srcWhichVectors);
   }
 
   template <class ST, class LO, class GO, class NT>
@@ -5044,6 +4830,7 @@ namespace Tpetra {
   deep_copy (Teuchos::SerialDenseMatrix<int, ST>& dst,
              const MultiVector<ST, LO, GO, NT>& src)
   {
+    using ::Tpetra::Details::localDeepCopy;
     using MV = MultiVector<ST, LO, GO, NT>;
     using IST = typename MV::impl_scalar_type;
     using output_view_type =
@@ -5053,46 +4840,39 @@ namespace Tpetra {
 
     const LO numRows = static_cast<LO> (dst.numRows ());
     const LO numCols = static_cast<LO> (dst.numCols ());
-    TEUCHOS_ASSERT( numRows == LO (src.getLocalLength ()) );
-    TEUCHOS_ASSERT( numCols == LO (src.getNumVectors ()) );
+
+    TEUCHOS_TEST_FOR_EXCEPTION
+      (numRows != static_cast<LO> (src.getLocalLength ()) ||
+       numCols != static_cast<LO> (src.getNumVectors ()),
+       std::invalid_argument, "Tpetra::deep_copy: On Process "
+       << src.getMap ()->getComm ()->getRank () << ", src is "
+       << src.getLocalLength () << " x " << src.getNumVectors ()
+       << ", but dst is " << numRows << " x " << numCols << ".");
 
     IST* dst_raw = reinterpret_cast<IST*> (dst.values ());
     output_view_type dst_orig (dst_raw, dst.stride (), numCols);
     auto dst_view =
       Kokkos::subview (dst_orig, pair_type (0, numRows), Kokkos::ALL ());
 
-    if (src.need_sync_device () || ! src.need_sync_host ()) {
-      // Host has the most recent version of the data.  The different
-      // "if" test here favors the host version, even if the device
-      // version is also current.  This avoids device-to-host copies.
-      if (src.isConstantStride ()) {
-        Kokkos::deep_copy (dst_view, src.getLocalViewHost ());
-      }
-      else {
-        for (LO col = 0; col < numCols; ++col) {
-          auto src_col = src.getVector (size_t (col));
-          auto src_col_lcl_h_2d = src_col->getLocalViewHost ();
-          auto src_col_lcl_h =
-            Kokkos::subview (src_col_lcl_h_2d, Kokkos::ALL (), 0);
-          auto dst_col = Kokkos::subview (dst_view, Kokkos::ALL (), col);
-          Kokkos::deep_copy (dst_col, src_col_lcl_h);
-        }
-      }
+    constexpr bool dst_isConstantStride = true;
+    Teuchos::ArrayView<const size_t> dstWhichVectors (nullptr, 0);
+
+    // Prefer the host version of src's data.
+    if (src.need_sync_host ()) { // last modified on device
+      localDeepCopy (dst_view,
+                     src.getLocalViewDevice (),
+                     dst_isConstantStride,
+                     src.isConstantStride (),
+                     dstWhichVectors,
+                     getMultiVectorWhichVectors (src));
     }
     else {
-      if (src.isConstantStride ()) {
-        Kokkos::deep_copy (dst_view, src.getLocalViewDevice ());
-      }
-      else {
-        for (LO col = 0; col < numCols; ++col) {
-          auto src_col = src.getVector (size_t (col));
-          auto src_col_lcl_d_2d = src_col->getLocalViewDevice ();
-          auto src_col_lcl_d =
-            Kokkos::subview (src_col_lcl_d_2d, Kokkos::ALL (), 0);
-          auto dst_col = Kokkos::subview (dst_view, Kokkos::ALL (), col);
-          Kokkos::deep_copy (dst_col, src_col_lcl_d);
-        }
-      }
+      localDeepCopy (dst_view,
+                     src.getLocalViewHost (),
+                     dst_isConstantStride,
+                     src.isConstantStride (),
+                     dstWhichVectors,
+                     getMultiVectorWhichVectors (src));
     }
   }
 #endif // HAVE_TPETRACORE_TEUCHOSNUMERICS

--- a/packages/tpetra/core/src/Tpetra_Vector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Vector_decl.hpp
@@ -151,16 +151,6 @@ public:
   explicit Vector (const Teuchos::RCP<const map_type>& map,
                    const bool zeroOut = true);
 
-  /// \brief Copy constructor (always a shallow copy).
-  ///
-  /// In this, the Kokkos refactor version of Tpetra, the "copy
-  /// constructor" does a shallow copy.  Use the nonmember function
-  /// deep_copy() to do a deep copy from one existing Vector to
-  /// another, and use the two-argument copy constructor below (with
-  /// copyOrView=Teuchos::Copy) to create a Vector which is a deep
-  /// copy of an existing Vector.
-  Vector (const Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& source);
-
   /// \brief Copy constructor (shallow or deep copy).
   ///
   /// \param source [in] The Vector to copy.
@@ -229,8 +219,41 @@ public:
   Vector (const MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& X,
           const size_t j);
 
-  //! Destructor.
-  virtual ~Vector ();
+  /// \brief Copy constructor (shallow copy).
+  ///
+  /// Vector's copy constructor always does a shallow copy.  Use the
+  /// nonmember function <tt>Tpetra::deep_copy</tt> (see
+  /// <tt>Tpetra_MultiVector_decl.hpp</tt>) to deep-copy one existing
+  /// Vector to another, and use the two-argument "copy constructor"
+  /// below (with <tt>copyOrView=Teuchos::Copy</tt>) to create a
+  /// Vector that is a deep copy of an existing Vector.
+  Vector (const Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>&) = default;
+
+  //! Move constructor (shallow move).
+  Vector (Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>&&) = default;
+
+  /// \brief Copy assignment (shallow copy).
+  ///
+  /// Vector's copy assignment operator always does a shallow copy.
+  /// Use the nonmember function <tt>Tpetra::deep_copy</tt> (see
+  /// <tt>Tpetra_MultiVector_decl.hpp</tt>) to deep-copy one existing
+  /// Vector to another.
+  Vector& operator= (const Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>&) = default;
+
+  //! Move assigment (shallow move).
+  Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>&
+  operator= (Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>&&) = default;
+
+  /// \brief Destructor (virtual for memory safety of derived classes).
+  ///
+  /// \note To Tpetra developers: See the C++ Core Guidelines C.21
+  ///   ("If you define or <tt>=delete</tt> any default operation,
+  ///   define or <tt>=delete</tt> them all"), in particular the
+  ///   AbstractBase example, for why this destructor declaration
+  ///   implies that we need the above four <tt>=default</tt>
+  ///   declarations for copy construction, move construction, copy
+  ///   assignment, and move assignment.
+  virtual ~Vector () = default;
 
   //@}
   //! \name Clone method

--- a/packages/tpetra/core/src/Tpetra_Vector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Vector_def.hpp
@@ -73,12 +73,6 @@ namespace Tpetra {
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  Vector (const Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& source)
-    : base_type (source)
-  {}
-
-  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-  Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   Vector (const Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& source,
           const Teuchos::DataAccess copyOrView)
     : base_type (source, copyOrView)
@@ -119,11 +113,6 @@ namespace Tpetra {
   Vector (const MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& X,
           const size_t j)
     : base_type (X, j)
-  {}
-
-  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-  Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  ~Vector ()
   {}
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>

--- a/packages/tpetra/core/src/kokkos_refactor/Tpetra_KokkosRefactor_Details_MultiVectorLocalDeepCopy.hpp
+++ b/packages/tpetra/core/src/kokkos_refactor/Tpetra_KokkosRefactor_Details_MultiVectorLocalDeepCopy.hpp
@@ -45,233 +45,91 @@
 #define TPETRA_KOKKOS_REFACTOR_DETAILS_MULTI_VECTOR_LOCAL_DEEP_COPY_HPP
 
 #include "Kokkos_Core.hpp"
-#include "Kokkos_ArithTraits.hpp"
+#include "Tpetra_Details_copyConvert.hpp"
 
 namespace Tpetra {
 namespace Details {
 
-  // Functor for deep-copying between two 2-D Kokkos Views.
-  // This implements Tpetra::MultiVector deep copy, as in
-  //   - Tpetra::deep_copy
-  //   - Tpetra::MultiVector::assign
-  //   - Tpetra::MultiVector::createCopy
-  //   - The two-argument MultiVector copy constructor with
-  //     Teuchos::Copy as the second argument
-  //
-  // DstViewType and SrcViewType must be 2-D Kokkos Views.
-  // DstWhichVecsType and SrcWhichVecsType must be 1-D Kokkos Views
-  // whose value type is an integer.  They correspond to the "which
-  // vectors?" arrays for the destination and source Views,
-  // respectively.
-  //
-  // If DstConstStride is true, dstWhichVecs is ignored.  If
-  // SrcConstStride is true, srcWhichVecs is ignored.  These bool
-  // template parameters take advantage of compilers' ability to
-  // disable code inside an "if (false) { ... }" scope.
-  template<class DstViewType,
-           class SrcViewType,
-           class DstWhichVecsType,
-           class SrcWhichVecsType,
-           const bool DstConstStride,
-           const bool SrcConstStride>
-  struct LocalDeepCopyFunctor {
-    typedef typename DstViewType::execution_space execution_space;
-    typedef typename DstViewType::size_type index_type;
+/// \brief Implementation of Tpetra::MultiVector deep copy of local data.
+///
+/// This implements <tt>Tpetra::MultiVector</tt> deep copy, as in
+/// <ul>
+/// <li> <tt>Tpetra::deep_copy</tt> </li>
+/// <li> <tt>Tpetra::MultiVector::assign</tt> </li>
+/// <li> <tt>Tpetra::MultiVector::createCopy</tt> </li>
+/// <li> <tt>The two-argument MultiVector copy constructor with
+///          <tt>Teuchos::Copy</tt> as the second argument </li>
+/// </ul>
+///
+/// \param dst [in/out] Rank-2 <tt>Kokkos::View</tt>; destination of
+///   the copy
+///
+/// \param src [in] Rank-2 <tt>Kokkos::View</tt>; source of the copy
+///
+/// \param dstConstStride [in] Whether <tt>dst</tt> is "constant
+///   stride."  If so, then the <tt>j</tt>-th column of <tt>dst</tt>
+///   has index <tt>j</tt>.  If not, then it has index
+///   <tt>dstWhichVecs[j]</tt>.
+///
+/// \param srcConstStride [in] Whether <tt>src</tt> is "constant
+///   stride."  If so, then the <tt>j</tt>-th column of <tt>src</tt>
+///   has index <tt>j</tt>.  If not, then it has index
+///   <tt>srcWhichVecs[j]</tt>.
+///
+/// \param dstWhichVecs [in] Host-readable Rank-1 array of some kind,
+///   corresponding to <tt>dst.whichVectors_</tt>.  Need only be
+///   readable (from host) if <tt>dstConstStride</tt> is true.
+///
+/// \param srcWhichVecs [in] Host-readable Rank-1 array of some kind,
+///   corresponding to <tt>src.whichVectors_</tt>.  Need only be
+///   readable (from host) if <tt>srcConstStride</tt> is true.
+template<class DstViewType,
+         class SrcViewType,
+         class DstWhichVecsType,
+         class SrcWhichVecsType>
+void
+localDeepCopy (const DstViewType& dst,
+               const SrcViewType& src,
+               const bool dstConstStride,
+               const bool srcConstStride,
+               const DstWhichVecsType& dstWhichVecs,
+               const SrcWhichVecsType& srcWhichVecs)
+{
+  using Kokkos::ALL;
+  using Kokkos::subview;
+  using size_type = typename DstViewType::size_type;
 
-    DstViewType dst_;
-    SrcViewType src_;
-    DstWhichVecsType dstWhichVecs_;
-    SrcWhichVecsType srcWhichVecs_;
-    const index_type numVecs_;
-
-    // You may always call the 4-argument constructor.
-    // dstWhichVecs is ignored if DstConstStride is true.
-    // srcWhichVecs is ignored if SrcConstStride is true.
-    LocalDeepCopyFunctor (const DstViewType& dst,
-                          const SrcViewType& src,
-                          const DstWhichVecsType& dstWhichVecs,
-                          const SrcWhichVecsType& srcWhichVecs) :
-      dst_ (dst),
-      src_ (src),
-      dstWhichVecs_ (dstWhichVecs),
-      srcWhichVecs_ (srcWhichVecs),
-      numVecs_ (DstConstStride ? dst.extent (1) : dstWhichVecs.extent (0))
-    {
-      TEUCHOS_TEST_FOR_EXCEPTION(
-        ! DstConstStride && ! SrcConstStride &&
-        dstWhichVecs.extent (0) != srcWhichVecs.extent (0),
-        std::invalid_argument, "LocalDeepCopyFunctor (4-arg constructor): "
-        "Neither src nor dst have constant stride, but "
-        "dstWhichVecs.extent(0) = " << dstWhichVecs.extent (0)
-        << " != srcWhichVecs.extent(0) = " << srcWhichVecs.extent (0)
-        << ".");
-      TEUCHOS_TEST_FOR_EXCEPTION(
-        DstConstStride && ! SrcConstStride &&
-        srcWhichVecs.extent (0) != dst.extent (1),
-        std::invalid_argument, "LocalDeepCopyFunctor (4-arg constructor): "
-        "src does not have constant stride, but srcWhichVecs.extent(0) = "
-        << srcWhichVecs.extent (0) << " != dst.extent(1) = "
-        << dst.extent (1) << ".");
-      TEUCHOS_TEST_FOR_EXCEPTION(
-        ! DstConstStride && SrcConstStride &&
-        dstWhichVecs.extent (0) != src.extent (1),
-        std::invalid_argument, "LocalDeepCopyFunctor (4-arg constructor): "
-        "dst does not have constant stride, but dstWhichVecs.extent(0) = "
-        << dstWhichVecs.extent (0) << " != src.extent(1) = "
-        << src.extent (1) << ".");
-    }
-
-    // You may only call the 2-argument constructor if DstConstStride
-    // and SrcConstStride are both true.
-    LocalDeepCopyFunctor (const DstViewType& dst, const SrcViewType& src) :
-      dst_ (dst),
-      src_ (src),
-      numVecs_ (dst.extent (1))
-    {
-      TEUCHOS_TEST_FOR_EXCEPTION(
-        ! DstConstStride || ! SrcConstStride, std::logic_error,
-        "Tpetra::LocalDeepCopyFunctor: You may not use the constant-stride "
-        "constructor if either of the Boolean template parameters is false.");
-    }
-
-    void KOKKOS_INLINE_FUNCTION operator () (const index_type i) const {
-      if (DstConstStride) {
-        if (SrcConstStride) {
-          for (index_type j = 0; j < numVecs_; ++j) {
-            dst_(i,j) = src_(i,j);
-          }
-        } else {
-          for (index_type j = 0; j < numVecs_; ++j) {
-            dst_(i,j) = src_(i,srcWhichVecs_(j));
-          }
-        }
-      } else {
-        if (SrcConstStride) {
-          for (index_type j = 0; j < numVecs_; ++j) {
-            dst_(i,dstWhichVecs_(j)) = src_(i,j);
-          }
-        } else {
-          for (index_type j = 0; j < numVecs_; ++j) {
-            dst_(i,dstWhichVecs_(j)) = src_(i,srcWhichVecs_(j));
-          }
-        }
-      }
-    }
-  };
-
-  template<class DstViewType,
-           class SrcViewType = DstViewType,
-           class DstWhichVecsType = Kokkos::View<const typename DstViewType::size_type*, typename DstViewType::execution_space>,
-           class SrcWhichVecsType = Kokkos::View<const typename SrcViewType::size_type*, typename SrcViewType::execution_space> >
-  struct LocalDeepCopy {
-    typedef typename DstViewType::size_type index_type;
-
-    static void
-    run (const DstViewType& dst, const SrcViewType& src,
-         const bool dstConstStride, const bool srcConstStride)
-    {
-      TEUCHOS_TEST_FOR_EXCEPTION(
-        ! dstConstStride || ! srcConstStride, std::invalid_argument,
-        "LocalDeepCopy::run: You may only call the 4-argument version of this "
-        "function if dstConstStride and srcConstStride are both true.");
-
-      // FIXME (mfh 22 Jul 2014, 10 Dec 2014) Currently, it doesn't
-      // work to do a 2-D copy, even if both MultiVectors have
-      // constant stride.  This is because Kokkos can't currently tell
-      // the difference between padding (which permits a single
-      // deep_copy for the whole 2-D View) and stride > numRows (which
-      // does NOT permit a single deep_copy for the whole 2-D View).
-      // Carter is working on this, but for now, the temporary fix is
-      // to copy one column at a time.
-      //
-      // FIXME (mfh 10 Dec 2014) Call Kokkos::deep_copy if appropriate
-      // for dst and src.  See note above.
-      typedef LocalDeepCopyFunctor<DstViewType, SrcViewType,
-        DstWhichVecsType, SrcWhichVecsType, true, true> functor_type;
-      functor_type f (dst, src);
-      typedef typename DstViewType::execution_space execution_space;
-      typedef decltype (dst.extent (0)) size_type;
-      typedef Kokkos::RangePolicy<execution_space, size_type> range_type;
-
-      Kokkos::parallel_for ("Tpetra::Details::LocalDeepCopy(x,y,stride)",range_type (0, dst.extent (0)), f);
-    }
-
-    static void
-    run (const DstViewType& dst, const SrcViewType& src,
-         const bool dstConstStride, const bool srcConstStride,
-         const DstWhichVecsType& dstWhichVecs,
-         const SrcWhichVecsType& srcWhichVecs)
-    {
-      // FIXME (mfh 22 Jul 2014, 10 Dec 2014) Currently, it doesn't
-      // work to do a 2-D copy, even if both MultiVectors have
-      // constant stride.  This is because Kokkos can't currently tell
-      // the difference between padding (which permits a single
-      // deep_copy for the whole 2-D View) and stride > numRows (which
-      // does NOT permit a single deep_copy for the whole 2-D View).
-      // Carter is working on this, but for now, the temporary fix is
-      // to copy one column at a time.
-
-      typedef typename DstViewType::execution_space execution_space;
-      typedef decltype (dst.extent (0)) size_type;
-      typedef Kokkos::RangePolicy<execution_space, size_type> range_type;
-
-      if (dstConstStride) {
-        if (srcConstStride) {
-          // FIXME (mfh 10 Dec 2014) Do a Kokkos::deep_copy if
-          // appropriate for dst and src.  See note above.
-          typedef LocalDeepCopyFunctor<DstViewType, SrcViewType,
-            DstWhichVecsType, SrcWhichVecsType, true, true> functor_type;
-          functor_type f (dst, src);
-          Kokkos::parallel_for ("Tpetra::Details::LocalDeepCopy(x,y,stride,whichVecs,0)",range_type (0, dst.extent (0)), f);
-        }
-        else { // ! srcConstStride
-          typedef LocalDeepCopyFunctor<DstViewType, SrcViewType,
-            DstWhichVecsType, SrcWhichVecsType, true, false> functor_type;
-          functor_type f (dst, src, srcWhichVecs, srcWhichVecs);
-          Kokkos::parallel_for ("Tpetra::Details::LocalDeepCopy(x,y,stride,whichVecs,1)",range_type (0, dst.extent (0)), f);
-        }
-      }
-      else { // ! dstConstStride
-        if (srcConstStride) {
-          typedef LocalDeepCopyFunctor<DstViewType, SrcViewType,
-            DstWhichVecsType, SrcWhichVecsType, false, true> functor_type;
-          functor_type f (dst, src, dstWhichVecs, dstWhichVecs);
-          Kokkos::parallel_for ("Tpetra::Details::LocalDeepCopy(x,y,stride,whichVecs,2)",range_type (0, dst.extent (0)), f);
-        }
-        else { // ! srcConstStride
-          typedef LocalDeepCopyFunctor<DstViewType, SrcViewType,
-            DstWhichVecsType, SrcWhichVecsType, false, false> functor_type;
-          functor_type f (dst, src, dstWhichVecs, srcWhichVecs);
-          Kokkos::parallel_for ("Tpetra::Details::LocalDeepCopy(x,y,stride,whichVecs,3)",range_type (0, dst.extent (0)), f);
-        }
-      }
-    }
-  };
-
-
-  template<class DstViewType,
-           class SrcViewType,
-           class DstWhichVecsType,
-           class SrcWhichVecsType>
-  void
-  localDeepCopy (const DstViewType& dst, const SrcViewType& src,
-                 const bool dstConstStride, const bool srcConstStride,
-                 const DstWhichVecsType& dstWhichVecs,
-                 const SrcWhichVecsType& srcWhichVecs)
-  {
-    typedef LocalDeepCopy<DstViewType, SrcViewType,
-      DstWhichVecsType, SrcWhichVecsType> impl_type;
-    impl_type::run (dst, src, dstConstStride, srcConstStride,
-                    dstWhichVecs, srcWhichVecs);
+  if (dstConstStride && srcConstStride) {
+    ::Tpetra::Details::copyConvert (dst, src);
   }
+  else {
+    const size_type numCols = dstConstStride ?
+      static_cast<size_type> (srcWhichVecs.size ()) :
+      static_cast<size_type> (dstWhichVecs.size ());
+    for (size_type j = 0; j < numCols; ++j) {
+      const size_type dst_col = dstConstStride ? j :
+        static_cast<size_type> (dstWhichVecs[j]);
+      const auto dst_j = subview (dst, ALL (), dst_col);
+      const size_type src_col = srcConstStride ? j :
+        static_cast<size_type> (srcWhichVecs[j]);
+      const auto src_j = subview (src, ALL (), src_col);
 
-  template<class DstViewType, class SrcViewType>
-  void
-  localDeepCopyConstStride (const DstViewType& dst, const SrcViewType& src)
-  {
-    typedef LocalDeepCopy<DstViewType, SrcViewType> impl_type;
-    impl_type::run (dst, src, true, true);
+      ::Tpetra::Details::copyConvert (dst_j, src_j);
+    }
   }
+}
+
+/// \brief Implementation of Tpetra::MultiVector deep copy of local
+///   data, for when both the source and destination MultiVector
+///   objects have constant stride (isConstantStride() is true).
+template<class DstViewType,
+         class SrcViewType>
+void
+localDeepCopyConstStride (const DstViewType& dst,
+                          const SrcViewType& src)
+{
+  return ::Tpetra::Details::copyConvert (dst, src);
+}
 
 } // Details namespace
 } // Tpetra namespace

--- a/packages/tpetra/core/test/Utils/CMakeLists.txt
+++ b/packages/tpetra/core/test/Utils/CMakeLists.txt
@@ -65,7 +65,6 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   copyConvert
   SOURCES
     copyConvert
-    ${TEUCHOS_STD_UNIT_TEST_MAIN}
   ARGS ${ARGS}
   COMM serial mpi
   NUM_MPI_PROCS 1

--- a/packages/tpetra/core/test/Utils/copyConvert.cpp
+++ b/packages/tpetra/core/test/Utils/copyConvert.cpp
@@ -47,123 +47,402 @@
 
 namespace { // (anonymous)
 
-  //
-  // UNIT TESTS
-  //
-
-  template<class OutputViewType, class InputViewType>
-  void testCopyConvert (bool& success, std::ostream& out)
+  template<class OutputValueType,
+           class OutputArrayLayout,
+           class OutputDeviceType,
+           class InputValueType,
+           class InputArrayLayout,
+           class InputDeviceType>
+  void
+  testRank1CopyConvert (bool& success, Teuchos::FancyOStream& out)
   {
-    typedef typename OutputViewType::non_const_value_type output_value_type;
-    typedef typename InputViewType::non_const_value_type input_value_type;
-    typedef typename OutputViewType::execution_space output_execution_space;
-    typedef typename InputViewType::execution_space input_execution_space;
+    using Kokkos::view_alloc;
+    using Kokkos::WithoutInitializing;
+    using output_view_type =
+      Kokkos::View<OutputValueType*, OutputArrayLayout, OutputDeviceType>;
+    using input_view_type =
+      Kokkos::View<InputValueType*, InputArrayLayout, InputDeviceType>;
+    using output_value_type =
+      typename output_view_type::non_const_value_type;
+    using input_value_type =
+      typename input_view_type::non_const_value_type;
 
-    const int size = 42;
+    const int size = 5;
 
-    typename InputViewType::non_const_type x ("x", size);
+    input_view_type x (view_alloc ("x", WithoutInitializing), size);
+    output_view_type y (view_alloc ("y", WithoutInitializing), size);
+    Kokkos::fence (); // for UVM's sake
+
     auto x_h = Kokkos::create_mirror_view (x);
-    input_execution_space::fence (); // for UVM's sake
     for (int i = 0; i < size; ++i) {
       x_h(i) = static_cast<input_value_type> (i+1); // no entries are zero
     }
     Kokkos::deep_copy (x, x_h);
-    input_execution_space::fence (); // for UVM's sake
 
-    typename OutputViewType::non_const_type y ("y", size);
-    output_execution_space::fence (); // for UVM's sake
     Tpetra::Details::copyConvert (y, x);
-    output_execution_space::fence (); // for UVM's sake
+    Kokkos::fence (); // for UVM's sake
 
     auto y_h = Kokkos::create_mirror_view (y);
-    output_execution_space::fence (); // for UVM's sake
     Kokkos::deep_copy (y_h, y);
-    output_execution_space::fence (); // for UVM's sake
 
+    bool equal = true;
     for (int i = 0; i < size; ++i) {
-      const auto curEnt = y_h(i);
-      TEST_EQUALITY( curEnt, static_cast<output_value_type> (i+1) );
+      const output_value_type expected_val =
+        static_cast<output_value_type> (i+1);
+      const output_value_type actual_val = y_h(i);
+      if (actual_val != expected_val) {
+        equal = false;
+        break;
+      }
+    }
+
+    if (! equal) {
+      for (int i = 0; i < size; ++i) {
+        const output_value_type expected_val =
+          static_cast<output_value_type> (i+1);
+        const output_value_type actual_val = y_h(i);        
+        TEST_EQUALITY( actual_val, expected_val );
+      }
     }
   }
 
-  TEUCHOS_UNIT_TEST( TpetraUtils, copy_convert )
+  template<class OutputValueType,
+           class OutputArrayLayout,
+           class OutputDeviceType,
+           class InputValueType,
+           class InputArrayLayout,
+           class InputDeviceType>
+  void
+  testRank2CopyConvert (bool& success, Teuchos::FancyOStream& out)
   {
-    using Tpetra::Details::copyConvert;
-    typedef Tpetra::Map<> map_type;
-    typedef map_type::device_type default_device_type;
+    using Kokkos::view_alloc;
+    using Kokkos::WithoutInitializing;
+    using output_view_type =
+      Kokkos::View<OutputValueType**, OutputArrayLayout, OutputDeviceType>;
+    using input_view_type =
+      Kokkos::View<InputValueType**, InputArrayLayout, InputDeviceType>;
+    using output_value_type =
+      typename output_view_type::non_const_value_type;
+    using input_value_type =
+      typename input_view_type::non_const_value_type;
 
-    auto comm = Tpetra::TestingUtilities::getDefaultComm ();
-    // Create a Map just to ensure that Kokkos gets initialized and
-    // finalized correctly.
-    const map_type map (comm->getSize (), 1, 0, comm);
+    const int numRows = 7;
+    const int numCols = 11;
 
-    // Test the case where the Views have the same value types and
-    // memory spaces.
-    {
-      typedef int output_value_type;
-      typedef int input_value_type;
-      typedef default_device_type output_device_type;
-      typedef Kokkos::View<output_value_type*, output_device_type> output_view_type;
-      typedef default_device_type input_device_type;
-      typedef Kokkos::View<input_value_type*, input_device_type> input_view_type;
-      testCopyConvert<output_view_type, input_view_type> (success, out);
+    input_view_type x (view_alloc ("x", WithoutInitializing),
+                       numRows, numCols);
+    output_view_type y (view_alloc ("y", WithoutInitializing),
+                        numRows, numCols);
+    Kokkos::fence (); // for UVM's sake
+
+    auto x_h = Kokkos::create_mirror_view (x);
+    for (int i = 0; i < numRows; ++i) {
+      for (int j = 0; j < numCols; ++j) {
+        const input_value_type val =
+          static_cast<input_value_type> ((i+1) + numCols*(j+1));
+        x_h(i,j) = val;
+      }
+    }
+    Kokkos::deep_copy (x, x_h);
+
+    Tpetra::Details::copyConvert (y, x);
+    Kokkos::fence (); // for UVM's sake
+
+    auto y_h = Kokkos::create_mirror_view (y);
+    Kokkos::deep_copy (y_h, y);
+
+    bool equal = true;
+    for (int i = 0; i < numRows; ++i) {
+      for (int j = 0; j < numCols; ++j) {
+        const output_value_type expected_val =
+          static_cast<output_value_type> ((i+1) + numCols*(j+1));
+        const output_value_type actual_val = y_h(i,j);
+        if (expected_val != actual_val) {
+          equal = false;
+          break;
+        }
+      }
+      if (! equal) {
+        break;
+      }
     }
 
-    // Test the case where the Views have the same value types, but
-    // different memory spaces, such that the output View's execution
-    // space cannot access the source View's memory space.  This is
-    // only possible in a CUDA build.
-#ifdef KOKKOS_ENABLE_CUDA
+    if (! equal) {
+      for (int i = 0; i < numRows; ++i) {
+        for (int j = 0; j < numCols; ++j) {
+          const output_value_type expected_val =
+            static_cast<output_value_type> ((i+1) + numCols*(j+1));
+          const output_value_type actual_val = y_h(i,j);
+          TEST_EQUALITY( expected_val, actual_val );
+        }
+      }
+    }
+  }
+
+  template<class OutputValueType,
+           class OutputArrayLayout,
+           class OutputDeviceType,
+           class InputValueType,
+           class InputArrayLayout,
+           class InputDeviceType>
+  void
+  testCopyConvert (bool& success,
+                   Teuchos::FancyOStream& out,
+                   const char outputValueName[],
+                   const char inputValueName[])
+  {
+    out << "OutputValueType: " << outputValueName << std::endl
+        << "InputValueType: " << inputValueName << std::endl;
+    Teuchos::OSTab tab1 (out);
+    
+    testRank1CopyConvert<OutputValueType, OutputArrayLayout, OutputDeviceType,
+                         InputValueType, InputArrayLayout, InputDeviceType>
+      (success, out);
+    if (! success) {
+      out << "Returning early" << std::endl;
+      return;
+    }
+    testRank2CopyConvert<OutputValueType, OutputArrayLayout, OutputDeviceType,
+                         InputValueType, InputArrayLayout, InputDeviceType>
+      (success, out);
+  }
+
+  template<class OutputArrayLayout,
+           class OutputDeviceType,
+           class InputArrayLayout,
+           class InputDeviceType>
+  void
+  test_for_all_value_types (bool& success,
+                            Teuchos::FancyOStream& out,
+                            const char outputArrayLayoutName[],
+                            const char inputArrayLayoutName[])
+  {
+    out << "OutputArrayLayout: " << outputArrayLayoutName << std::endl
+        << "InputArrayLayout: " << inputArrayLayoutName << std::endl;
+    Teuchos::OSTab tab1 (out);
+
     {
-      typedef int output_value_type;
-      typedef int input_value_type;
-      // CudaUVMSpace is technically accessible from host, so use CudaSpace explicitly.
-      typedef Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace> output_device_type;
-      typedef Kokkos::View<output_value_type*, output_device_type> output_view_type;
-      typedef typename output_view_type::HostMirror::execution_space host_execution_space;
-      typedef Kokkos::Device<host_execution_space, Kokkos::HostSpace> input_device_type;
-      typedef Kokkos::View<input_value_type*, input_device_type> input_view_type;
-      testCopyConvert<output_view_type, input_view_type> (success, out);
+      using output_value_type = int;
+      using input_value_type = int;
+      testCopyConvert<output_value_type, OutputArrayLayout, OutputDeviceType,
+                      input_value_type, InputArrayLayout, InputDeviceType>
+        (success, out, "int", "int");
+      if (! success) {
+        out << "Returning early" << std::endl;
+        return;
+      }
+    }
+    {
+      using output_value_type = long long;
+      using input_value_type = int;
+      testCopyConvert<output_value_type, OutputArrayLayout, OutputDeviceType,
+                      input_value_type, InputArrayLayout, InputDeviceType>
+        (success, out, "long long", "int");
+      if (! success) {
+        out << "Returning early" << std::endl;
+        return;
+      }
+    }
+    {
+      using output_value_type = int;
+      using input_value_type = long long;
+      testCopyConvert<output_value_type, OutputArrayLayout, OutputDeviceType,
+                      input_value_type, InputArrayLayout, InputDeviceType>
+        (success, out, "int", "long long");
+      if (! success) {
+        out << "Returning early" << std::endl;
+        return;
+      }
+    }
+    {
+      using output_value_type = Kokkos::complex<float>;
+      using input_value_type = double;
+      testCopyConvert<output_value_type, OutputArrayLayout, OutputDeviceType,
+                      input_value_type, InputArrayLayout, InputDeviceType>
+        (success, out, "Kokkos::complex<float>", "double");
+      if (! success) {
+        out << "Returning early" << std::endl;
+        return;
+      }
+    }
+    {
+      using output_value_type = double;
+      using input_value_type = Kokkos::complex<float>;
+      testCopyConvert<output_value_type, OutputArrayLayout, OutputDeviceType,
+                      input_value_type, InputArrayLayout, InputDeviceType>
+        (success, out, "double", "Kokkos::complex<float>");
+      if (! success) {
+        out << "Returning early" << std::endl;
+        return;
+      }
+    }
+  }
+
+  template<class OutputDeviceType,
+           class InputDeviceType>
+  void
+  test_for_all_value_types_and_layouts
+  (bool& success, Teuchos::FancyOStream& out,
+   const char outputDeviceName[],
+   const char inputDeviceName[])
+  {
+    out << "OutputDeviceType: " << outputDeviceName << std::endl
+        << "InputDeviceType: " << inputDeviceName << std::endl;
+    Teuchos::OSTab tab1 (out);
+
+    {
+      using output_array_layout = Kokkos::LayoutLeft;
+      using input_array_layout = Kokkos::LayoutLeft;
+      test_for_all_value_types<output_array_layout,
+                               OutputDeviceType,
+                               input_array_layout,
+                               InputDeviceType> (success, out,
+                                                 "Left", "Left");
+    }
+    {
+      using output_array_layout = Kokkos::LayoutRight;
+      using input_array_layout = Kokkos::LayoutLeft;
+      test_for_all_value_types<output_array_layout,
+                               OutputDeviceType,
+                               input_array_layout,
+                               InputDeviceType> (success, out,
+                                                 "Right", "Left");
+    }
+    {
+      using output_array_layout = Kokkos::LayoutLeft;
+      using input_array_layout = Kokkos::LayoutRight;
+      test_for_all_value_types<output_array_layout,
+                               OutputDeviceType,
+                               input_array_layout,
+                               InputDeviceType> (success, out,
+                                                 "Left", "Right");
+    }
+    {
+      using output_array_layout = Kokkos::LayoutRight;
+      using input_array_layout = Kokkos::LayoutRight;
+      test_for_all_value_types<output_array_layout,
+                               OutputDeviceType,
+                               input_array_layout,
+                               InputDeviceType> (success, out,
+                                                 "Right", "Right");
+    }
+  }
+
+  void
+  test_for_all_value_types_and_layouts_and_devices
+  (bool& success, Teuchos::FancyOStream& out)
+  {
+    {
+      using output_device_type =
+        Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>;
+      using input_device_type =
+        Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>;
+      test_for_all_value_types_and_layouts<output_device_type,
+                                           input_device_type>
+        (success, out, "HostSpace", "HostSpace");
+    }
+
+#ifdef KOKKOS_ENABLE_CUDA
+    // CudaSpace
+    {
+      using output_device_type =
+        Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>;
+      using input_device_type =
+        Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>;
+      test_for_all_value_types_and_layouts<output_device_type,
+                                           input_device_type>
+        (success, out, "CudaSpace", "CudaSpace");
+    }
+    {
+      using output_device_type =
+        Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>;
+      using input_device_type =
+        Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>;
+      test_for_all_value_types_and_layouts<output_device_type,
+                                           input_device_type>
+        (success, out, "HostSpace", "CudaSpace");
+    }
+    {
+      using output_device_type =
+        Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>;
+      using input_device_type =
+        Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>;
+      test_for_all_value_types_and_layouts<output_device_type,
+                                           input_device_type>
+        (success, out, "CudaSpace", "HostSpace");
+    }
+
+    // Mixed CudaSpace and CudaUVMSpace
+    {
+      using output_device_type =
+        Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>;
+      using input_device_type =
+        Kokkos::Device<Kokkos::Cuda, Kokkos::CudaUVMSpace>;
+      test_for_all_value_types_and_layouts<output_device_type,
+                                           input_device_type>
+        (success, out, "CudaSpace", "CudaUVMSpace");
+    }
+    {
+      using output_device_type =
+        Kokkos::Device<Kokkos::Cuda, Kokkos::CudaUVMSpace>;
+      using input_device_type =
+        Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>;
+      test_for_all_value_types_and_layouts<output_device_type,
+                                           input_device_type>
+        (success, out, "CudaUVMSpace", "CudaSpace");
+    }
+
+    // CudaUVMSpace
+    {
+      using output_device_type =
+        Kokkos::Device<Kokkos::Cuda, Kokkos::CudaUVMSpace>;
+      using input_device_type =
+        Kokkos::Device<Kokkos::Cuda, Kokkos::CudaUVMSpace>;
+      test_for_all_value_types_and_layouts<output_device_type,
+                                           input_device_type>
+        (success, out, "CudaUVMSpace", "CudaUVMSpace");
+    }
+    {
+      using output_device_type =
+        Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>;
+      using input_device_type =
+        Kokkos::Device<Kokkos::Cuda, Kokkos::CudaUVMSpace>;
+      test_for_all_value_types_and_layouts<output_device_type,
+                                           input_device_type>
+        (success, out, "HostSpace", "CudaUVMSpace");
+    }
+    {
+      using output_device_type =
+        Kokkos::Device<Kokkos::Cuda, Kokkos::CudaUVMSpace>;
+      using input_device_type =
+        Kokkos::Device<Kokkos::DefaultHostExecutionSpace, Kokkos::HostSpace>;
+      test_for_all_value_types_and_layouts<output_device_type,
+                                           input_device_type>
+        (success, out, "CudaUVMSpace", "HostSpace");
     }
 #endif // KOKKOS_ENABLE_CUDA
+  }
 
-    // Test the case where the Views have different value types, but
-    // the same memory spaces.
-    {
-      // Input and output Views need to have distinct types that
-      // nevertheless can be converted one to the other (ignoring
-      // overflow).
-      typedef long output_value_type;
-      typedef short input_value_type;
-      typedef default_device_type output_device_type;
-      typedef Kokkos::View<output_value_type*, output_device_type> output_view_type;
-      typedef default_device_type input_device_type;
-      typedef Kokkos::View<input_value_type*, input_device_type> input_view_type;
-      testCopyConvert<output_view_type, input_view_type> (success, out);
-    }
+  //
+  // UNIT TESTS
+  //
 
-    // Test the case where the Views have different value types, and
-    // different memory spaces, such that the output View's execution
-    // space cannot access the source View's memory space.  This is
-    // only possible in a CUDA build.
-#ifdef KOKKOS_ENABLE_CUDA
-    {
-      // Input and output Views need to have distinct types that
-      // nevertheless can be converted one to the other (ignoring
-      // overflow).
-      typedef long output_value_type;
-      typedef short input_value_type;
-      // CudaUVMSpace is technically accessible from host, so use CudaSpace explicitly.
-      typedef Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace> output_device_type;
-      typedef Kokkos::View<output_value_type*, output_device_type> output_view_type;
-      typedef typename output_view_type::HostMirror::execution_space host_execution_space;
-      typedef Kokkos::Device<host_execution_space, Kokkos::HostSpace> input_device_type;
-      typedef Kokkos::View<input_value_type*, input_device_type> input_view_type;
-      testCopyConvert<output_view_type, input_view_type> (success, out);
-    }
-#endif // KOKKOS_ENABLE_CUDA
+  TEUCHOS_UNIT_TEST( TpetraUtils, CopyConvert )
+  {
+    test_for_all_value_types_and_layouts_and_devices (success, out);
   }
 
 } // namespace (anonymous)
 
-
+int
+main (int argc, char* argv[])
+{
+  // Initialize MPI (if enabled) before initializing Kokkos.  This
+  // lets MPI control things like pinning processes to sockets.
+  Teuchos::GlobalMPISession mpiSession (&argc, &argv);
+  Kokkos::initialize (argc, argv);
+  const int errCode =
+    Teuchos::UnitTestRepository::runUnitTestsFromMain (argc, argv);
+  Kokkos::finalize ();
+  return errCode;
+}


### PR DESCRIPTION
@trilinos/tpetra 

## Description

1. Fix #4827.
2. Make more Tpetra classes follow the Rule of Five (C++ Core Guidelines C.21).
3. Clean up FEMultiVector code, syntax, and documentation.

## Related Issues

* Closes #4827 
* Related to #4196, #3946, #3574 