### PR TITLE
KokkosKernels: Update d2_graph_color following deprecation

### DIFF
--- a/packages/kokkos-kernels/perf_test/graph/KokkosGraph_color_d2.cpp
+++ b/packages/kokkos-kernels/perf_test/graph/KokkosGraph_color_d2.cpp
@@ -493,7 +493,7 @@ void run_experiment(crsGraph_t crsGraph, Parameters params)
               << "    KExecSName     : " << Kokkos::DefaultExecutionSpace::name() << std::endl
               << "    Filename       : " << a_mtx_bin_file << std::endl
               << "    Num Verts      : " << crsGraph.numRows() << std::endl
-              << "    Num Edges      : " << crsGraph.entries.dimension_0() << std::endl
+              << "    Num Edges      : " << crsGraph.entries.extent(0) << std::endl
               << "    Concurrency    : " << Kokkos::DefaultExecutionSpace::concurrency() << std::endl
               << "    Algorithm      : " << label_algorithm << std::endl
               #if defined(USE_EXPERIMENTAL_MAXD2DEGREE) && USE_EXPERIMENTAL_MAXD2DEGREE
@@ -547,7 +547,7 @@ void run_experiment(crsGraph_t crsGraph, Parameters params)
               << "," << hostname
               << "," << currentDateTimeStr
               << "," << crsGraph.numRows()
-              << "," << crsGraph.entries.dimension_0()
+              << "," << crsGraph.entries.extent(0)
               << "," << Kokkos::DefaultExecutionSpace::name()
               << "," << label_algorithm
               << "," << Kokkos::DefaultExecutionSpace::concurrency()
@@ -585,7 +585,7 @@ void run_experiment(crsGraph_t crsGraph, Parameters params)
               << "," << hostname
               << "," << currentDateTimeStr
               << "," << crsGraph.numRows()
-              << "," << crsGraph.entries.dimension_0()
+              << "," << crsGraph.entries.extent(0)
               << "," << Kokkos::DefaultExecutionSpace::name()
               << "," << label_algorithm
               << "," << Kokkos::DefaultExecutionSpace::concurrency()

--- a/packages/kokkos-kernels/src/sparse/impl/KokkosSparse_spgemm_impl_color.hpp
+++ b/packages/kokkos-kernels/src/sparse/impl/KokkosSparse_spgemm_impl_color.hpp
@@ -513,7 +513,7 @@ void
       handle->get_graph_coloring_handle()->set_algorithm(KokkosGraph::COLORING_SERIAL2);
       //for now only sequential one exists.
       //find distance-2 graph coloring
-      KokkosGraph::Experimental::d2_graph_color
+      KokkosGraph::Experimental::graph_compute_distance2_color_serial
     <HandleType,
     c_row_view_t, c_nnz_view_t,
     row_lno_temp_work_view_t, nnz_lno_temp_work_view_t>


### PR DESCRIPTION
Addresses issue #4829

@trilinos/kokkos-kernels 