### PR TITLE
Tempus: improve interval output setup

### DIFF
--- a/packages/tempus/src/Tempus_IntegratorBasic_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorBasic_impl.hpp
@@ -498,6 +498,11 @@ void IntegratorBasic<Scalar>::startTimeStep()
     wsmd->setOutputScreen(false);
   else
     wsmd->setOutputScreen(true);
+
+  const int initial = timeStepControl_->getInitIndex();
+  const int interval = integratorPL_->get<int>("Screen Output Index Interval");
+  if ( (wsmd->getIStep() - initial) % interval == 0)
+    wsmd->setOutputScreen(true);
 }
 
 
@@ -610,18 +615,11 @@ void IntegratorBasic<Scalar>::parseScreenOutput()
     pos = str.find_first_of(delimiters, lastPos);
   }
 
-  int outputScreenIndexInterval =
-    integratorPL_->get<int>("Screen Output Index Interval", 1000000);
-  int outputScreen_i   = timeStepControl_->getInitIndex();
-  const int finalIStep = timeStepControl_->getFinalIndex();
-  while (outputScreen_i <= finalIStep) {
-    outputScreenIndices_.push_back(outputScreen_i);
-    outputScreen_i += outputScreenIndexInterval;
-  }
-
-  // order output indices
+  // order output indices and remove duplicates.
   std::sort(outputScreenIndices_.begin(),outputScreenIndices_.end());
-
+  outputScreenIndices_.erase(std::unique(outputScreenIndices_.begin(),
+                                         outputScreenIndices_.end()   ),
+                                         outputScreenIndices_.end()     );
   return;
 }
 


### PR DESCRIPTION
In the output interval and the screen output interval, all the
intervals are placed in a vector along with the specified output
times or indices, and then sorted. This allowed all the output times
and indices to be in one vector and searched. However when the
number of time steps reaches millions, the sort is far too expensive.
This reworks the interval specification so that it is not part
of the vector or sorting.

 #4836

@trilinos/tempus 

## How Has This Been Tested?
Passes all tests on Mac.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
