### PR TITLE
Tpetra: deprecate node args (phase one)

### DIFF
--- a/packages/anasazi/tpetra/example/CustomStatusTest/LOBPCGCustomStatusTest.cpp
+++ b/packages/anasazi/tpetra/example/CustomStatusTest/LOBPCGCustomStatusTest.cpp
@@ -270,8 +270,7 @@ main (int argc, char* argv[])
   }
 
   // Get the matrix
-  Teuchos::RCP<Tpetra::Map<>::node_type> node; // for type deduction
-  RCP<const CrsMatrix> A = Reader::readSparseFile (fileA, comm, node);
+  RCP<const CrsMatrix> A = Reader::readSparseFile (fileA, comm);
 
   // Create the folded operator, K = A^2
   RCP<FoldOp> K = rcp (new FoldOp (A));

--- a/packages/anasazi/tpetra/example/TraceMinDavidson/TraceMinDavidsonGeneralizedEx.cpp
+++ b/packages/anasazi/tpetra/example/TraceMinDavidson/TraceMinDavidsonGeneralizedEx.cpp
@@ -133,9 +133,8 @@ int main(int argc, char *argv[]) {
   //
   // Read the matrices from a file
   //
-  RCP<Tpetra::Map<>::node_type> node; // can be null
-  RCP<const CrsMatrix> K = Reader::readSparseFile(filenameA, comm, node);
-  RCP<const CrsMatrix> M = Reader::readSparseFile(filenameB, comm, node);
+  RCP<const CrsMatrix> K = Reader::readSparseFile(filenameA, comm);
+  RCP<const CrsMatrix> M = Reader::readSparseFile(filenameB, comm);
 
   //
   // Compute the norm of the matrix

--- a/packages/anasazi/tpetra/example/TraceMinDavidson/TraceMinDavidsonSpecTransEx.cpp
+++ b/packages/anasazi/tpetra/example/TraceMinDavidson/TraceMinDavidsonSpecTransEx.cpp
@@ -127,8 +127,7 @@ main (int argc, char *argv[])
   //
   // Read the matrices from a file
   //
-  RCP<Tpetra::Map<>::node_type> node; // can be null
-  RCP<const CrsMatrix> K = Tpetra::MatrixMarket::Reader<CrsMatrix>::readSparseFile(filenameA, comm, node);
+  RCP<const CrsMatrix> K = Tpetra::MatrixMarket::Reader<CrsMatrix>::readSparseFile(filenameA, comm);
 
   //
   // Compute the norm of the matrix

--- a/packages/anasazi/tpetra/src/TsqrTpetraTest.hpp
+++ b/packages/anasazi/tpetra/src/TsqrTpetraTest.hpp
@@ -156,8 +156,7 @@ namespace TSQR {
                  const node_ptr& node)
         {
           using Tpetra::createUniformContigMapWithNode;
-          return createUniformContigMapWithNode< LO, GO, Node > (nrowsGlobal,
-                                                                 comm, node);
+          return createUniformContigMapWithNode< LO, GO, Node > (nrowsGlobal, comm);
         }
 
         /// \brief Make a Tpetra test multivector for filling in.

--- a/packages/belos/tpetra/src/BelosTpetraTestFramework.hpp
+++ b/packages/belos/tpetra/src/BelosTpetraTestFramework.hpp
@@ -453,7 +453,7 @@ namespace Belos {
              << "\"" << endl;
         const bool callFillComplete = true;
         RCP<sparse_matrix_type> A =
-          reader_type::readSparseFile (filename, comm_, node_, callFillComplete,
+          reader_type::readSparseFile (filename, comm_, callFillComplete,
                                        tolerant_, debug_);
         return A;
       }

--- a/packages/belos/tpetra/src/BelosTpetraTestFramework.hpp
+++ b/packages/belos/tpetra/src/BelosTpetraTestFramework.hpp
@@ -155,10 +155,11 @@ namespace Belos {
         typedef global_ordinal_type GO;
         typedef node_type NT;
         RCP<const map_type> rowMap =
-          createUniformContigMapWithNode<LO, GO, NT> (numRows, comm_, node_);
+          createUniformContigMapWithNode<LO, GO, NT> (numRows, comm_);
         RCP<const map_type> rangeMap = rowMap;
         RCP<const map_type> domainMap =
-          createUniformContigMapWithNode<LO, GO, NT> (numCols, comm_, node_);
+          createUniformContigMapWithNode<LO, GO, NT> (numCols, comm_);
+
         // Convert the read-in matrix data into a Tpetra::CrsMatrix.
         typedef ArrayView<const int>::size_type size_type;
         ArrayView<const double> valView (val, static_cast<size_type> (nnz));
@@ -693,7 +694,7 @@ namespace Belos {
 
         // For a square matrix, we only need a Map for the range of the matrix.
         RCP<const map_type> pRangeMap =
-          createUniformContigMapWithNode<LO, GO, NT> (globalNumRows, comm_, node_);
+          createUniformContigMapWithNode<LO, GO, NT> (globalNumRows, comm_);
         // The sparse matrix object to fill.
         RCP<sparse_matrix_type> pMat = rcp (new sparse_matrix_type (pRangeMap, 0));
 
@@ -744,7 +745,8 @@ namespace Belos {
 
         // For a square matrix, we only need a Map for the range of the matrix.
         RCP<const map_type> pRangeMap =
-          createUniformContigMapWithNode<LO, GO, NT> (globalNumRows, comm_, node_);
+          createUniformContigMapWithNode<LO, GO, NT> (globalNumRows, comm_);
+
         // The sparse matrix object to fill.
         RCP<sparse_matrix_type> pMat = rcp (new sparse_matrix_type (pRangeMap, 0));
 

--- a/packages/belos/tpetra/test/BlockCG/test_bl_cg_complex_hb.cpp
+++ b/packages/belos/tpetra/test/BlockCG/test_bl_cg_complex_hb.cpp
@@ -77,7 +77,6 @@ int main(int argc, char *argv[]) {
   typedef Tpetra::MultiVector<ST>          MV;
   typedef Belos::OperatorTraits<ST,MV,OP> OPT;
   typedef Belos::MultiVecTraits<ST,MV>    MVT;
-  typedef Tpetra::MultiVector<ST>::node_type Node;
 
   GlobalMPISession mpisess(&argc,&argv,&cout);
 
@@ -85,10 +84,7 @@ int main(int argc, char *argv[]) {
 
   int MyPID = 0;
 
-  typedef Tpetra::Map<>::node_type Node;
-
   RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
-  RCP<Node>             node; // only for type deduction; null ok
 
   //
   // Get test parameters from command-line processor
@@ -131,7 +127,7 @@ int main(int argc, char *argv[]) {
   // Get the data from the HB file and build the Map,Matrix
   //
   RCP<CrsMatrix<ST> > A;
-  Tpetra::Utils::readHBMatrix(filename,comm,node,A);
+  Tpetra::Utils::readHBMatrix(filename,comm,A);
   RCP<const Tpetra::Map<> > map = A->getDomainMap();
 
   // Create initial vectors

--- a/packages/belos/tpetra/test/BlockCG/test_bl_cg_hb.cpp
+++ b/packages/belos/tpetra/test/BlockCG/test_bl_cg_hb.cpp
@@ -89,10 +89,7 @@ int main(int argc, char *argv[]) {
 
     int MyPID = 0;
 
-    typedef Tpetra::Map<>::node_type Node;
-
     RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
-    RCP<Node>             node; // only for type deduction; null ok
 
     //
     // Get test parameters from command-line processor
@@ -135,7 +132,7 @@ int main(int argc, char *argv[]) {
     // Get the data from the HB file and build the Map,Matrix
     //
     RCP<CrsMatrix<ST> > A;
-    Tpetra::Utils::readHBMatrix(filename,comm,node,A);
+    Tpetra::Utils::readHBMatrix(filename,comm,A);
     RCP<const Tpetra::Map<> > map = A->getDomainMap();
 
     // Create initial vectors

--- a/packages/belos/tpetra/test/BlockCG/test_pseudo_bl_cg_hb.cpp
+++ b/packages/belos/tpetra/test/BlockCG/test_pseudo_bl_cg_hb.cpp
@@ -89,10 +89,7 @@ int main(int argc, char *argv[]) {
 
     int MyPID = 0;
 
-    typedef Tpetra::Map<>::node_type Node;
-
     RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
-    RCP<Node>             node; // only for type deduction; null ok
 
     //
     // Get test parameters from command-line processor
@@ -135,7 +132,7 @@ int main(int argc, char *argv[]) {
     // Get the data from the HB file and build the Map,Matrix
     //
     RCP<CrsMatrix<ST> > A;
-    Tpetra::Utils::readHBMatrix(filename,comm,node,A);
+    Tpetra::Utils::readHBMatrix(filename,comm,A);
     RCP<const Tpetra::Map<> > map = A->getDomainMap();
 
     // Create initial vectors

--- a/packages/belos/tpetra/test/BlockCG/test_pseudo_stochastic_cg_hb.cpp
+++ b/packages/belos/tpetra/test/BlockCG/test_pseudo_stochastic_cg_hb.cpp
@@ -78,7 +78,6 @@ main (int argc, char *argv[])
   typedef Tpetra::MultiVector<ST>          MV;
   typedef Belos::OperatorTraits<ST,MV,OP> OPT;
   typedef Belos::MultiVecTraits<ST,MV>    MVT;
-  typedef MV::node_type             node_type;
 
   typedef Teuchos::CommandLineProcessor   CLP;
 
@@ -88,7 +87,6 @@ main (int argc, char *argv[])
   bool verbose = false;
   try {
     RCP<const Comm<int> > comm = Tpetra::getDefaultComm ();
-    RCP<node_type> node; // only for type deduction; null ok
 
     //
     // Get test parameters from command-line processor
@@ -139,7 +137,7 @@ main (int argc, char *argv[])
     // Get the data from the HB file and build the Map,Matrix
     //
     RCP<Tpetra::CrsMatrix<ST> > A;
-    Tpetra::Utils::readHBMatrix (filename, comm, node, A);
+    Tpetra::Utils::readHBMatrix (filename, comm, A);
     RCP<const Tpetra::Map<> > map = A->getDomainMap ();
 
     // Create initial vectors

--- a/packages/belos/tpetra/test/BlockGmres/test_bl_gmres_hb.cpp
+++ b/packages/belos/tpetra/test/BlockGmres/test_bl_gmres_hb.cpp
@@ -88,9 +88,7 @@ int main(int argc, char *argv[]) {
 
     int MyPID = 0;
 
-    typedef Tpetra::Map<>::node_type Node;
     RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
-    RCP<Node> node; // only for type deduction; null ok
     //
     // Get test parameters from command-line processor
     //
@@ -133,7 +131,7 @@ int main(int argc, char *argv[]) {
     // Get the data from the HB file and build the Map,Matrix
     //
     RCP<CrsMatrix<ST> > A;
-    Tpetra::Utils::readHBMatrix(filename,comm,node,A);
+    Tpetra::Utils::readHBMatrix(filename,comm,A);
     RCP<const Tpetra::Map<> > map = A->getDomainMap();
 
     // Create initial vectors

--- a/packages/belos/tpetra/test/BlockGmres/test_hybrid_gmres_hb.cpp
+++ b/packages/belos/tpetra/test/BlockGmres/test_hybrid_gmres_hb.cpp
@@ -88,9 +88,7 @@ int main(int argc, char *argv[]) {
 
     int MyPID = 0;
 
-    typedef Tpetra::Map<>::node_type Node;
     RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
-    RCP<Node> node; // only for type deduction; null ok
     //
     // Get test parameters from command-line processor
     //
@@ -142,7 +140,7 @@ int main(int argc, char *argv[]) {
     // Get the data from the HB file and build the Map,Matrix
     //
     RCP<CrsMatrix<ST> > A;
-    Tpetra::Utils::readHBMatrix(filename,comm,node,A);
+    Tpetra::Utils::readHBMatrix(filename,comm,A);
     RCP<const Tpetra::Map<> > map = A->getDomainMap();
 
     // Create initial vectors

--- a/packages/belos/tpetra/test/FixedPoint/test_fp_hb.cpp
+++ b/packages/belos/tpetra/test/FixedPoint/test_fp_hb.cpp
@@ -90,9 +90,7 @@ int main(int argc, char *argv[]) {
 
     int MyPID = 0;
 
-    typedef Tpetra::Map<>::node_type Node;
     RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
-    RCP<Node>             node; // only for type deduction; null ok
 
     //
     // Get test parameters from command-line processor
@@ -138,7 +136,7 @@ int main(int argc, char *argv[]) {
     // Get the data from the HB file and build the Map,Matrix
     //
     RCP<CrsMatrix<ST> > A;
-    Tpetra::Utils::readHBMatrix(filename,comm,node,A);
+    Tpetra::Utils::readHBMatrix(filename,comm,A);
     RCP<const Tpetra::Map<> > map = A->getDomainMap();
 
     // Create initial vectors

--- a/packages/ifpack2/test/belos/read_matrix.hpp
+++ b/packages/ifpack2/test/belos/read_matrix.hpp
@@ -84,7 +84,7 @@ read_matrix_hb (const std::string& hb_file,
   RCP<Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > A;
   {
     Teuchos::TimeMonitor timeMon (*timer);
-    Tpetra::Utils::readHBMatrix (hb_file, comm, node, A); // OK if node is null
+    Tpetra::Utils::readHBMatrix (hb_file, comm, A);
   }
   if (comm->getRank () == 0) {
     cout << "Proc 0: Time in seconds to read the Harwell-Boeing - format "

--- a/packages/shylu/shylu_dd/core/test/iterative_solver_interface_test.cpp
+++ b/packages/shylu/shylu_dd/core/test/iterative_solver_interface_test.cpp
@@ -101,13 +101,12 @@ int main(int argc, char** argv)
 
 
   Teuchos::ParameterList defaultParameters;
-  Teuchos::RCP <node_type> node = Teuchos::rcp(new node_type(defaultParameters));
 
   /*----------------Load a test matrix---------------*/
   string matrixFileName = "wathenSmall.mtx";
 
   //Get Matrix
-  Teuchos::RCP<Matrix_t> A = Tpetra::MatrixMarket::Reader<Matrix_t>::readSparseFile(matrixFileName, comm, node); //removed node
+  Teuchos::RCP<Matrix_t> A = Tpetra::MatrixMarket::Reader<Matrix_t>::readSparseFile(matrixFileName, comm); 
 
   if( &A == NULL)
     {

--- a/packages/shylu/shylu_dd/core/test/tpetra_interface_test.cpp
+++ b/packages/shylu/shylu_dd/core/test/tpetra_interface_test.cpp
@@ -101,13 +101,12 @@ int main(int argc, char** argv)
 
 
   Teuchos::ParameterList defaultParameters;
-  Teuchos::RCP <node_type> node = Teuchos::rcp(new node_type(defaultParameters));
 
   /*----------------Load a test matrix---------------*/
   string matrixFileName = "wathenSmall.mtx";
 
   //Get Matrix
-  Teuchos::RCP<Matrix_t> A = Tpetra::MatrixMarket::Reader<Matrix_t>::readSparseFile(matrixFileName, comm, node); //removed node
+  Teuchos::RCP<Matrix_t> A = Tpetra::MatrixMarket::Reader<Matrix_t>::readSparseFile(matrixFileName, comm);
 
   if( &A == NULL)
     {

--- a/packages/stokhos/src/sacado/kokkos/pce/tpetra/Stokhos_Tpetra_Utilities_UQ_PCE.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/tpetra/Stokhos_Tpetra_Utilities_UQ_PCE.hpp
@@ -60,7 +60,7 @@ namespace Stokhos {
                                  Kokkos::Compat::KokkosDeviceWrapperNode<Device> > >
   create_cijk_crs_graph(const CijkType& cijk,
                         const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
-                        const Teuchos::RCP<Kokkos::Compat::KokkosDeviceWrapperNode<Device> >& node,
+                        const Teuchos::RCP<Kokkos::Compat::KokkosDeviceWrapperNode<Device> >& /*node*/,
                         const size_t matrix_pce_size) {
     using Teuchos::RCP;
     using Teuchos::arrayView;
@@ -71,7 +71,7 @@ namespace Stokhos {
 
     const size_t pce_sz = cijk.dimension();
     RCP<const Map> map =
-      Tpetra::createLocalMapWithNode<LocalOrdinal,GlobalOrdinal>(pce_sz, comm);
+      Tpetra::createLocalMapWithNode<LocalOrdinal,GlobalOrdinal,Node>(pce_sz, comm);
     RCP<Graph> graph = Tpetra::createCrsGraph(map);
     if (matrix_pce_size == 1) {
       // Mean-based case -- graph is diagonal

--- a/packages/stokhos/src/sacado/kokkos/pce/tpetra/Stokhos_Tpetra_Utilities_UQ_PCE.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/tpetra/Stokhos_Tpetra_Utilities_UQ_PCE.hpp
@@ -71,7 +71,7 @@ namespace Stokhos {
 
     const size_t pce_sz = cijk.dimension();
     RCP<const Map> map =
-      Tpetra::createLocalMapWithNode<LocalOrdinal,GlobalOrdinal>(pce_sz, comm, node);
+      Tpetra::createLocalMapWithNode<LocalOrdinal,GlobalOrdinal>(pce_sz, comm);
     RCP<Graph> graph = Tpetra::createCrsGraph(map);
     if (matrix_pce_size == 1) {
       // Mean-based case -- graph is diagonal

--- a/packages/teko/tests/src/tLSCIntegrationTest_tpetra.cpp
+++ b/packages/teko/tests/src/tLSCIntegrationTest_tpetra.cpp
@@ -144,7 +144,7 @@ void tLSCIntegrationTest_tpetra::loadStableSystem()
       RCP<Tpetra::Vector<ST,LO,GO,NT> > vfull, temp;
  
       // read in rhs file 
-      vfull = Tpetra::MatrixMarket::Reader<Tpetra::Vector<ST,LO,GO,NT> >::readVectorFile("./data/lsc_rhs.mm",GetComm_tpetra(),Teuchos::null,fullMap_);
+      vfull = Tpetra::MatrixMarket::Reader<Tpetra::Vector<ST,LO,GO,NT> >::readVectorFile("./data/lsc_rhs.mm",GetComm_tpetra(),fullMap_);
 
       temp = rcp(new Tpetra::Vector<ST,LO,GO,NT>(sA_->getRangeMap()));
       temp->doExport(*vfull,exporter,Tpetra::INSERT);
@@ -156,7 +156,7 @@ void tLSCIntegrationTest_tpetra::loadStableSystem()
       RCP<Tpetra::Vector<ST,LO,GO,NT> > vfull, temp;
  
       // read in exact solution file 
-      vfull = Tpetra::MatrixMarket::Reader<Tpetra::Vector<ST,LO,GO,NT> >::readVectorFile("./data/lsc_exact_2.mm",GetComm_tpetra(),Teuchos::null,fullMap_);
+      vfull = Tpetra::MatrixMarket::Reader<Tpetra::Vector<ST,LO,GO,NT> >::readVectorFile("./data/lsc_exact_2.mm",GetComm_tpetra(),fullMap_);
 
       temp = rcp(new Tpetra::Vector<ST,LO,GO,NT>(sA_->getRangeMap()));
       temp->doExport(*vfull,exporter,Tpetra::INSERT);

--- a/packages/thyra/adapters/tpetra/src/Thyra_TpetraMultiVector_def.hpp
+++ b/packages/thyra/adapters/tpetra/src/Thyra_TpetraMultiVector_def.hpp
@@ -359,10 +359,9 @@ TpetraMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>::contigSubViewImpl(
 
   const RCP<const ScalarProdVectorSpaceBase<Scalar> > viewDomainSpace =
     tpetraVectorSpace<Scalar>(
-        Tpetra::createLocalMapWithNode<LocalOrdinal,GlobalOrdinal>(
+        Tpetra::createLocalMapWithNode<LocalOrdinal,GlobalOrdinal,Node>(
           tpetraView->getNumVectors(),
-          tpetraView->getMap()->getComm(),
-          tpetraView->getMap()->getNode()
+          tpetraView->getMap()->getComm()
           )
         );
 
@@ -390,10 +389,9 @@ TpetraMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>::nonconstContigSubView
 
   const RCP<const ScalarProdVectorSpaceBase<Scalar> > viewDomainSpace =
     tpetraVectorSpace<Scalar>(
-        Tpetra::createLocalMapWithNode<LocalOrdinal,GlobalOrdinal>(
+        Tpetra::createLocalMapWithNode<LocalOrdinal,GlobalOrdinal,Node>(
           tpetraView->getNumVectors(),
-          tpetraView->getMap()->getComm(),
-          tpetraView->getMap()->getNode()
+          tpetraView->getMap()->getComm()
           )
         );
 
@@ -424,10 +422,9 @@ TpetraMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>::nonContigSubViewImpl(
 
   const RCP<const ScalarProdVectorSpaceBase<Scalar> > viewDomainSpace =
     tpetraVectorSpace<Scalar>(
-        Tpetra::createLocalMapWithNode<LocalOrdinal,GlobalOrdinal>(
+        Tpetra::createLocalMapWithNode<LocalOrdinal,GlobalOrdinal,Node>(
           tpetraView->getNumVectors(),
-          tpetraView->getMap()->getComm(),
-          tpetraView->getMap()->getNode()
+          tpetraView->getMap()->getComm()
           )
         );
 
@@ -458,10 +455,9 @@ TpetraMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>::nonconstNonContigSubV
 
   const RCP<const ScalarProdVectorSpaceBase<Scalar> > viewDomainSpace =
     tpetraVectorSpace<Scalar>(
-        Tpetra::createLocalMapWithNode<LocalOrdinal,GlobalOrdinal>(
+        Tpetra::createLocalMapWithNode<LocalOrdinal,GlobalOrdinal,Node>(
           tpetraView->getNumVectors(),
-          tpetraView->getMap()->getComm(),
-          tpetraView->getMap()->getNode()
+          tpetraView->getMap()->getComm()
           )
         );
 

--- a/packages/thyra/adapters/tpetra/src/Thyra_TpetraThyraWrappers_def.hpp
+++ b/packages/thyra/adapters/tpetra/src/Thyra_TpetraThyraWrappers_def.hpp
@@ -91,7 +91,7 @@ getOrCreateLocallyReplicatedTpetraVectorSpace(
   else {
     tpetraSpace = tpetraVectorSpace<Scalar>(
       Tpetra::createLocalMapWithNode<LocalOrdinal,GlobalOrdinal>(
-        numCols, tpetraComm, tpetraNode 
+        numCols, tpetraComm
         )
       );
   }

--- a/packages/thyra/adapters/tpetra/src/Thyra_TpetraThyraWrappers_def.hpp
+++ b/packages/thyra/adapters/tpetra/src/Thyra_TpetraThyraWrappers_def.hpp
@@ -90,7 +90,7 @@ getOrCreateLocallyReplicatedTpetraVectorSpace(
   }
   else {
     tpetraSpace = tpetraVectorSpace<Scalar>(
-      Tpetra::createLocalMapWithNode<LocalOrdinal,GlobalOrdinal>(
+      Tpetra::createLocalMapWithNode<LocalOrdinal,GlobalOrdinal,Node>(
         numCols, tpetraComm
         )
       );

--- a/packages/thyra/adapters/tpetra/src/Thyra_TpetraVectorSpace_def.hpp
+++ b/packages/thyra/adapters/tpetra/src/Thyra_TpetraVectorSpace_def.hpp
@@ -101,7 +101,7 @@ TpetraVectorSpace<Scalar,LocalOrdinal,GlobalOrdinal,Node>::createMembers(int num
     weakSelfPtr_.create_strong().getConst(),
     tpetraVectorSpace<Scalar>(
       Tpetra::createLocalMapWithNode<LocalOrdinal, GlobalOrdinal, Node>(
-        numMembers, tpetraMap_->getComm(), tpetraMap_->getNode()
+        numMembers, tpetraMap_->getComm()
         )
       ),
     Teuchos::rcp(

--- a/packages/thyra/adapters/tpetra/src/Thyra_TpetraVector_def.hpp
+++ b/packages/thyra/adapters/tpetra/src/Thyra_TpetraVector_def.hpp
@@ -100,10 +100,9 @@ TpetraVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>::domain() const
 {
   if (domainSpace_.is_null()) {
     domainSpace_ = tpetraVectorSpace<Scalar>(
-      Tpetra::createLocalMapWithNode<LocalOrdinal,GlobalOrdinal>(
+      Tpetra::createLocalMapWithNode<LocalOrdinal,GlobalOrdinal,Node>(
         1,
-        tpetraVector_.getConstObj()->getMap()->getComm(),
-        tpetraVector_.getConstObj()->getMap()->getNode()
+        tpetraVector_.getConstObj()->getMap()->getComm()
         )
       );
   }

--- a/packages/thyra/adapters/tpetra/test/TpetraThyraWrappers_UnitTests.cpp
+++ b/packages/thyra/adapters/tpetra/test/TpetraThyraWrappers_UnitTests.cpp
@@ -334,7 +334,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( TpetraThyraWrappers, createMultiVector,
 
   const RCP<const TpetraMap_t> tpetraLocRepMap =
     Tpetra::createLocalMapWithNode<LO, GO>(
-      numCols, tpetraMap->getComm(), tpetraMap->getNode());
+      numCols, tpetraMap->getComm());
   const RCP<const VectorSpaceBase<Scalar> > domainVs =
     Thyra::createVectorSpace<Scalar>(tpetraLocRepMap);
 
@@ -385,7 +385,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( TpetraThyraWrappers, createConstMultiVector,
 
   const RCP<const TpetraMap_t> tpetraLocRepMap =
     Tpetra::createLocalMapWithNode<LO,GO>(
-      numCols, tpetraMap->getComm(), tpetraMap->getNode());
+      numCols, tpetraMap->getComm());
   const RCP<const VectorSpaceBase<Scalar> > domainVs =
     Thyra::createVectorSpace<Scalar>(tpetraLocRepMap);
 

--- a/packages/thyra/adapters/tpetra/test/TpetraThyraWrappers_UnitTests.cpp
+++ b/packages/thyra/adapters/tpetra/test/TpetraThyraWrappers_UnitTests.cpp
@@ -324,6 +324,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( TpetraThyraWrappers, createMultiVector,
 {
   typedef Tpetra::Map<>::local_ordinal_type LO;
   typedef Tpetra::Map<>::global_ordinal_type GO;
+  typedef Tpetra::Map<>::node_type NODE;
   typedef Thyra::TpetraOperatorVectorExtraction<Scalar> ConverterT;
 
   const int numCols = 3;
@@ -333,7 +334,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( TpetraThyraWrappers, createMultiVector,
     Thyra::createVectorSpace<Scalar>(tpetraMap);
 
   const RCP<const TpetraMap_t> tpetraLocRepMap =
-    Tpetra::createLocalMapWithNode<LO, GO>(
+    Tpetra::createLocalMapWithNode<LO,GO,NODE>(
       numCols, tpetraMap->getComm());
   const RCP<const VectorSpaceBase<Scalar> > domainVs =
     Thyra::createVectorSpace<Scalar>(tpetraLocRepMap);
@@ -375,6 +376,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( TpetraThyraWrappers, createConstMultiVector,
 {
   typedef Tpetra::Map<>::local_ordinal_type LO;
   typedef Tpetra::Map<>::global_ordinal_type GO;
+  typedef Tpetra::Map<>::node_type NODE;
   typedef Thyra::TpetraOperatorVectorExtraction<Scalar> ConverterT;
 
   const int numCols = 3;
@@ -384,7 +386,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( TpetraThyraWrappers, createConstMultiVector,
     Thyra::createVectorSpace<Scalar>(tpetraMap);
 
   const RCP<const TpetraMap_t> tpetraLocRepMap =
-    Tpetra::createLocalMapWithNode<LO,GO>(
+    Tpetra::createLocalMapWithNode<LO,GO,NODE>(
       numCols, tpetraMap->getComm());
   const RCP<const VectorSpaceBase<Scalar> > domainVs =
     Thyra::createVectorSpace<Scalar>(tpetraLocRepMap);

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_InsertGlobalIndices_DP.hpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_InsertGlobalIndices_DP.hpp
@@ -63,13 +63,14 @@
 
 namespace TpetraExamples
 {
-using comm_ptr_t = Teuchos::RCP<const Teuchos::Comm<int> >;
 
-int executeInsertGlobalIndicesDP_(const comm_ptr_t& comm, const struct CmdLineOpts& opts);
+int executeInsertGlobalIndicesDP_(const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
+                                  const struct CmdLineOpts& opts);
 
 
 
-int executeInsertGlobalIndicesDP(const comm_ptr_t& comm, const struct CmdLineOpts & opts)
+int executeInsertGlobalIndicesDP(const Teuchos::RCP<const Teuchos::Comm<int> >& comm, 
+                                 const struct CmdLineOpts & opts)
 {
   using Teuchos::RCP;
 
@@ -92,7 +93,8 @@ int executeInsertGlobalIndicesDP(const comm_ptr_t& comm, const struct CmdLineOpt
 
 
 
-int executeInsertGlobalIndicesDP_(const comm_ptr_t& comm, const struct CmdLineOpts& opts)
+int executeInsertGlobalIndicesDP_(const Teuchos::RCP<const Teuchos::Comm<int> >& comm, 
+                                  const struct CmdLineOpts& opts)
 {
   using Teuchos::RCP;
   using Teuchos::TimeMonitor;

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_InsertGlobalIndices_FE_SP.hpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_InsertGlobalIndices_FE_SP.hpp
@@ -64,13 +64,14 @@
 
 namespace TpetraExamples
 {
-using comm_ptr_t = Teuchos::RCP<const Teuchos::Comm<int> >;
 
-int executeInsertGlobalIndicesFESP_(const comm_ptr_t& comm, const struct CmdLineOpts& opts);
+int executeInsertGlobalIndicesFESP_(const Teuchos::RCP<const Teuchos::Comm<int> >& comm, 
+                                    const struct CmdLineOpts& opts);
 
 
 
-int executeInsertGlobalIndicesFESP(const comm_ptr_t& comm, const struct CmdLineOpts & opts)
+int executeInsertGlobalIndicesFESP(const Teuchos::RCP<const Teuchos::Comm<int> >& comm, 
+                                   const struct CmdLineOpts & opts)
 {
   using Teuchos::RCP;
 
@@ -93,7 +94,8 @@ int executeInsertGlobalIndicesFESP(const comm_ptr_t& comm, const struct CmdLineO
 
 
 
-int executeInsertGlobalIndicesFESP_(const comm_ptr_t& comm, const struct CmdLineOpts& opts)
+int executeInsertGlobalIndicesFESP_(const Teuchos::RCP<const Teuchos::Comm<int> >& comm, 
+                                    const struct CmdLineOpts& opts)
 {
   using Teuchos::RCP;
   using Teuchos::TimeMonitor;

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_LocalElementLoop_DP.hpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_LocalElementLoop_DP.hpp
@@ -60,13 +60,14 @@
 
 namespace TpetraExamples
 {
-using comm_ptr_t = Teuchos::RCP<const Teuchos::Comm<int> >;
 
-int executeLocalElementLoopDP_(const comm_ptr_t& comm, const struct CmdLineOpts& opts);
+int executeLocalElementLoopDP_(const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
+                               const struct CmdLineOpts& opts);
 
 
 
-int executeLocalElementLoopDP(const comm_ptr_t& comm, const struct CmdLineOpts & opts)
+int executeLocalElementLoopDP(const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
+                              const struct CmdLineOpts & opts)
 {
   using Teuchos::RCP;
 
@@ -89,7 +90,8 @@ int executeLocalElementLoopDP(const comm_ptr_t& comm, const struct CmdLineOpts &
 
 
 
-int executeLocalElementLoopDP_(const comm_ptr_t& comm, const struct CmdLineOpts& opts)
+int executeLocalElementLoopDP_(const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
+                               const struct CmdLineOpts& opts)
 {
   using Teuchos::RCP;
   using Teuchos::TimeMonitor;

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_TotalElementLoop_DP.hpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_TotalElementLoop_DP.hpp
@@ -60,13 +60,14 @@
 
 namespace TpetraExamples
 {
-using comm_ptr_t = Teuchos::RCP<const Teuchos::Comm<int> >;
 
-int executeTotalElementLoopDP_(const comm_ptr_t& comm, const struct CmdLineOpts& opts);
+int executeTotalElementLoopDP_(const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
+                               const struct CmdLineOpts& opts);
 
 
 
-int executeTotalElementLoopDP(const comm_ptr_t& comm, const struct CmdLineOpts & opts)
+int executeTotalElementLoopDP(const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
+                              const struct CmdLineOpts & opts)
 {
   using Teuchos::RCP;
 
@@ -89,7 +90,8 @@ int executeTotalElementLoopDP(const comm_ptr_t& comm, const struct CmdLineOpts &
 
 
 
-int executeTotalElementLoopDP_(const comm_ptr_t& comm, const struct CmdLineOpts& opts)
+int executeTotalElementLoopDP_(const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
+                               const struct CmdLineOpts& opts)
 {
   using Teuchos::RCP;
   using Teuchos::TimeMonitor;

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_TotalElementLoop_SP.hpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_TotalElementLoop_SP.hpp
@@ -61,13 +61,14 @@
 
 namespace TpetraExamples
 {
-using comm_ptr_t = Teuchos::RCP<const Teuchos::Comm<int> >;
 
-int executeTotalElementLoopSP_(const comm_ptr_t& comm, const struct CmdLineOpts& opts);
+int executeTotalElementLoopSP_(const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
+                               const struct CmdLineOpts& opts);
 
 
 
-int executeTotalElementLoopSP(const comm_ptr_t& comm, const struct CmdLineOpts & opts)
+int executeTotalElementLoopSP(const Teuchos::RCP<const Teuchos::Comm<int> >& comm, 
+                              const struct CmdLineOpts & opts)
 {
   using Teuchos::RCP;
 
@@ -90,7 +91,8 @@ int executeTotalElementLoopSP(const comm_ptr_t& comm, const struct CmdLineOpts &
 
 
 
-int executeTotalElementLoopSP_(const comm_ptr_t& comm, const struct CmdLineOpts& opts)
+int executeTotalElementLoopSP_(const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
+                               const struct CmdLineOpts& opts)
 {
   using Teuchos::RCP;
   using Teuchos::TimeMonitor;

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_main.cpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_main.cpp
@@ -63,8 +63,6 @@
 
 using namespace TpetraExamples;
 
-using comm_ptr_t = Teuchos::RCP<const Teuchos::Comm<int> >;
-
 
 int main (int argc, char *argv[]) 
 {
@@ -75,7 +73,7 @@ int main (int argc, char *argv[])
   
   // MPI boilerplate
   Tpetra::initialize(&argc, &argv);
-  comm_ptr_t comm = Tpetra::getDefaultComm();
+  Teuchos::RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm();
 
   // The output stream 'out' will ignore any output not from Process 0.
   RCP<Teuchos::FancyOStream> pOut = getOutputStream(*comm);

--- a/packages/tpetra/core/example/Lesson02-Map-Vector/lesson02_init_map_vec.cpp
+++ b/packages/tpetra/core/example/Lesson02-Map-Vector/lesson02_init_map_vec.cpp
@@ -253,7 +253,6 @@ exampleRoutine (const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
     Array<global_ordinal_type> elementList (numEltsPerProc);
 
     const int numProcs = comm->getSize ();
-    const int myRank = comm->getRank ();
     for (Array<global_ordinal_type>::size_type k = 0; k < numEltsPerProc; ++k) {
       elementList[k] = myRank + k*numProcs;
     }

--- a/packages/tpetra/core/example/advanced/MultiPrec/IRTRDriver.hpp
+++ b/packages/tpetra/core/example/advanced/MultiPrec/IRTRDriver.hpp
@@ -130,8 +130,7 @@ class IRTR_Driver {
     else {
       fillParams->set("Preserve Local Graph",true);
     }
-    RCP<Node> node = rcp (new Node ());
-    Tpetra::Utils::readHBMatrix (matrixFile, comm, node, A, rowMap, fillParams);
+    Tpetra::Utils::readHBMatrix (matrixFile, comm, A, rowMap, fillParams);
     rowMap = A->getRowMap ();
 
     testPassed = true;

--- a/packages/tpetra/core/example/advanced/MultiPrec/MultiPrecDriver.hpp
+++ b/packages/tpetra/core/example/advanced/MultiPrec/MultiPrecDriver.hpp
@@ -71,7 +71,7 @@ class MultiPrecDriver {
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE
   template <class Node> 
   TPETRA_DEPRECATED
-  void run(Teuchos::ParameterList &myMachPL, const Teuchos::RCP<const Teuchos::Comm<int> > &comm, const Teuchos::RCP<Node> &node) 
+  void run(Teuchos::ParameterList &myMachPL, const Teuchos::RCP<const Teuchos::Comm<int> > &comm, const Teuchos::RCP<Node> & /* node */) 
   {
     run<Node>(myMachPL, comm);
   }

--- a/packages/tpetra/core/example/advanced/MultiPrec/MultiPrecDriver.hpp
+++ b/packages/tpetra/core/example/advanced/MultiPrec/MultiPrecDriver.hpp
@@ -68,8 +68,17 @@ class MultiPrecDriver {
   // output
   bool                             testPassed;
 
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
   template <class Node> 
+  TPETRA_DEPRECATED
   void run(Teuchos::ParameterList &myMachPL, const Teuchos::RCP<const Teuchos::Comm<int> > &comm, const Teuchos::RCP<Node> &node) 
+  {
+    run<Node>(myMachPL, comm);
+  }
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+
+  template <class Node> 
+  void run(Teuchos::ParameterList &myMachPL, const Teuchos::RCP<const Teuchos::Comm<int> > &comm) 
   {
     using std::pair;
     using std::make_pair;
@@ -93,7 +102,7 @@ class MultiPrecDriver {
     typedef Tpetra::CrsMatrix<S,LO,GO,Node> CrsMatrix;
     typedef Tpetra::Vector<S,LO,GO,Node>       Vector;
 
-    *out << "Running test with Node==" << Teuchos::typeName(*node) << " on rank " << comm->getRank() << "/" << comm->getSize() << std::endl;
+    *out << "Running test on rank " << comm->getRank() << "/" << comm->getSize() << std::endl;
 
     // read the matrix
     RCP<CrsMatrix> A;
@@ -102,9 +111,6 @@ class MultiPrecDriver {
     fillParams->set("Preserve Local Graph",true);
     // must preserve the local graph in order to do convert() calls later
     Tpetra::Utils::readHBMatrix(matrixFile,comm,
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-                                node,
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
                                 A,rowMap,fillParams);
     rowMap = A->getRowMap();
 

--- a/packages/tpetra/core/example/advanced/MultiPrec/MultiPrecDriver.hpp
+++ b/packages/tpetra/core/example/advanced/MultiPrec/MultiPrecDriver.hpp
@@ -101,7 +101,11 @@ class MultiPrecDriver {
     RCP<ParameterList> fillParams = parameterList();
     fillParams->set("Preserve Local Graph",true);
     // must preserve the local graph in order to do convert() calls later
-    Tpetra::Utils::readHBMatrix(matrixFile,comm,node,A,rowMap,fillParams);
+    Tpetra::Utils::readHBMatrix(matrixFile,comm,
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                                node,
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+                                A,rowMap,fillParams);
     rowMap = A->getRowMap();
 
     // init the solver stack

--- a/packages/tpetra/core/guide/src/Examples/SourceCode/map_cyclic.cpp
+++ b/packages/tpetra/core/guide/src/Examples/SourceCode/map_cyclic.cpp
@@ -73,7 +73,6 @@ main (int argc, char *argv[])
       Array<global_ordinal_type>::size_type numEltsPerProc = 5;
       Array<global_ordinal_type> elementList(numEltsPerProc);
       const int numProcs = comm->getSize();
-      const int myRank = comm->getRank();
       for (Array<global_ordinal_type>::size_type k = 0; k < numEltsPerProc; ++k) {
         elementList[k] = myRank + k*numProcs;
       }

--- a/packages/tpetra/core/guide/src/Examples/SourceCode/vector.cpp
+++ b/packages/tpetra/core/guide/src/Examples/SourceCode/vector.cpp
@@ -88,7 +88,6 @@ main (int argc, char *argv[])
       Array<global_ordinal_type>::size_type numEltsPerProc = 5;
       Array<global_ordinal_type> elementList (numEltsPerProc);
       const int numProcs = comm->getSize ();
-      const int myRank = comm->getRank ();
       for (Array<global_ordinal_type>::size_type k = 0; k < numEltsPerProc; ++k) {
         elementList[k] = myRank + k*numProcs;
       }

--- a/packages/tpetra/core/inout/MatrixMarket_Tpetra.hpp
+++ b/packages/tpetra/core/inout/MatrixMarket_Tpetra.hpp
@@ -237,7 +237,7 @@ namespace Tpetra {
       static Teuchos::RCP<const map_type>
       makeRangeMap (const Teuchos::RCP<const comm_type>& pComm,
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE  
-                    const TPETRA_DEPRECATED Teuchos::RCP<node_type>& pNode,
+                    const Teuchos::RCP<node_type>& TPETRA_DEPRECATED pNode,
 #endif // TPETRA_ENABLE_DEPRECATED_CODE
                     const global_ordinal_type numRows)
       {
@@ -292,7 +292,7 @@ namespace Tpetra {
       makeRowMap (const Teuchos::RCP<const map_type>& pRowMap,
                   const Teuchos::RCP<const comm_type>& pComm,
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE
-                  const TPETRA_DEPRECATED Teuchos::RCP<node_type>& pNode,
+                  const Teuchos::RCP<node_type>& TPETRA_DEPRECATED pNode,
 #endif // TPETRA_ENABLE_DEPRECATED_CODE
                   const global_ordinal_type numRows)
       {
@@ -356,8 +356,11 @@ namespace Tpetra {
           return pRangeMap;
         } else {
           return createUniformContigMapWithNode<LO,GO,NT> (numCols,
-                                                           pRangeMap->getComm (),
-                                                           pRangeMap->getNode ());
+                                                           pRangeMap->getComm ()
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                                                           , pRangeMap->getNode ()
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+                                                          );
         }
       }
 
@@ -1324,7 +1327,7 @@ namespace Tpetra {
       readSparseGraphHelper (std::istream& in,
                              const Teuchos::RCP<const Teuchos::Comm<int> >& pComm,
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE
-                             const TPETRA_DEPRECATED Teuchos::RCP<node_type>& pNode,
+                             const Teuchos::RCP<node_type>& TPETRA_DEPRECATED pNode,
 #endif // TPETRA_ENABLE_DEPRECATED_CODE
                              const Teuchos::RCP<const map_type>& rowMap,
                              Teuchos::RCP<const map_type>& colMap,
@@ -4423,7 +4426,7 @@ namespace Tpetra {
       readDenseImpl (std::istream& in,
                      const Teuchos::RCP<const comm_type>& comm,
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE
-                     const TPETRA_DEPRECATED Teuchos::RCP<node_type>& pNode,
+                     const Teuchos::RCP<node_type>& TPETRA_DEPRECATED pNode,
 #endif // TPETRA_ENABLE_DEPRECATED_CODE
                      Teuchos::RCP<const map_type>& map,
                      const Teuchos::RCP<Teuchos::FancyOStream>& err,
@@ -4670,7 +4673,11 @@ namespace Tpetra {
           const size_t localNumRows = (myRank == 0) ? numRows : 0;
           // At this point, map exists and has a nonnull node.
           proc0Map = createContigMapWithNode<LO, GO, NT> (numRows, localNumRows,
-                                                          comm, map->getNode ());
+                                                          comm
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                                                          , map->getNode ()
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+                                                          );
         }
         else { // The user supplied a Map.
           proc0Map = Details::computeGatherMap<map_type> (map, err, debug);
@@ -5194,7 +5201,11 @@ namespace Tpetra {
           const size_t localNumRows = (myRank == 0) ? numRows : 0;
           // At this point, map exists and has a nonnull node.
           proc0Map = createContigMapWithNode<LO, GO, NT> (numRows, localNumRows,
-                                                          comm, map->getNode ());
+                                                          comm
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                                                          , map->getNode ()
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+                                                          );
         }
         else { // The user supplied a Map.
           proc0Map = Details::computeGatherMap<map_type> (map, err, debug);

--- a/packages/tpetra/core/inout/MatrixMarket_Tpetra.hpp
+++ b/packages/tpetra/core/inout/MatrixMarket_Tpetra.hpp
@@ -206,10 +206,12 @@ namespace Tpetra {
       typedef Teuchos::Comm<int> comm_type;
       typedef Map<local_ordinal_type, global_ordinal_type, node_type> map_type;
 
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
       // DEPRECATED typedefs for backwards compatibility.
-      typedef Teuchos::RCP<const comm_type> comm_ptr;
-      typedef Teuchos::RCP<const map_type> map_ptr;
-      typedef Teuchos::RCP<node_type> node_ptr;
+      typedef Teuchos::RCP<const comm_type> comm_ptr TPETRA_DEPRECATED;
+      typedef Teuchos::RCP<const map_type> map_ptr TPETRA_DEPRECATED;
+      typedef Teuchos::RCP<node_type> node_ptr TPETRA_DEPRECATED;
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
 
     private:
       /// \typedef size_type
@@ -226,26 +228,34 @@ namespace Tpetra {
       /// constructs.
       ///
       /// \param pComm [in] Global communicator.
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
       /// \param pNode [in] Kokkos Node object.
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
       /// \param numRows [in] Global number of rows in the matrix.
       ///
       /// \return Range map to be used for constructing a CrsMatrix.
       static Teuchos::RCP<const map_type>
       makeRangeMap (const Teuchos::RCP<const comm_type>& pComm,
-                    const Teuchos::RCP<node_type>& pNode,
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE  
+                    const TPETRA_DEPRECATED Teuchos::RCP<node_type>& pNode,
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
                     const global_ordinal_type numRows)
       {
         // Return a conventional, uniformly partitioned, contiguous map.
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
         if (pNode.is_null ()) {
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
           return rcp (new map_type (static_cast<global_size_t> (numRows),
                                     static_cast<global_ordinal_type> (0),
                                     pComm, GloballyDistributed));
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
         }
         else {
           return rcp (new map_type (static_cast<global_size_t> (numRows),
                                     static_cast<global_ordinal_type> (0),
                                     pComm, GloballyDistributed, pNode));
         }
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
       }
 
       /// \brief Compute initial row map, or verify an existing one.
@@ -271,7 +281,9 @@ namespace Tpetra {
       ///   typical case is to pass in null here, which is why we call
       ///   this routine "makeRowMap".
       /// \param pComm [in] Global communicator.
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
       /// \param pNode [in] Kokkos Node object.
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
       /// \param numRows [in] Global number of rows in the matrix.  If
       ///   pRowMap is nonnull, used only for error checking.
       ///
@@ -279,22 +291,28 @@ namespace Tpetra {
       static Teuchos::RCP<const map_type>
       makeRowMap (const Teuchos::RCP<const map_type>& pRowMap,
                   const Teuchos::RCP<const comm_type>& pComm,
-                  const Teuchos::RCP<node_type>& pNode,
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                  const TPETRA_DEPRECATED Teuchos::RCP<node_type>& pNode,
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
                   const global_ordinal_type numRows)
       {
         // If the caller didn't provide a map, return a conventional,
         // uniformly partitioned, contiguous map.
         if (pRowMap.is_null ()) {
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
           if (pNode.is_null ()) {
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
             return rcp (new map_type (static_cast<global_size_t> (numRows),
                                       static_cast<global_ordinal_type> (0),
                                       pComm, GloballyDistributed));
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
           }
           else {
             return rcp (new map_type (static_cast<global_size_t> (numRows),
                                       static_cast<global_ordinal_type> (0),
                                       pComm, GloballyDistributed, pNode));
           }
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
         }
         else {
           TEUCHOS_TEST_FOR_EXCEPTION
@@ -1305,7 +1323,9 @@ namespace Tpetra {
       static Teuchos::RCP<sparse_graph_type>
       readSparseGraphHelper (std::istream& in,
                              const Teuchos::RCP<const Teuchos::Comm<int> >& pComm,
-                             const Teuchos::RCP<node_type>& pNode,
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                             const TPETRA_DEPRECATED Teuchos::RCP<node_type>& pNode,
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
                              const Teuchos::RCP<const map_type>& rowMap,
                              Teuchos::RCP<const map_type>& colMap,
                              const Teuchos::RCP<Teuchos::ParameterList>& constructorParams,
@@ -1560,10 +1580,18 @@ namespace Tpetra {
           indexBase = rowMap->getIndexBase();
         }
         if(myRank == rootRank) {
-          proc0Map = rcp(new map_type(dims[0],dims[0],indexBase,pComm,pNode));
+          proc0Map = rcp(new map_type(dims[0],dims[0],indexBase,pComm
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                                      ,pNode
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+                                      ));
         }
         else {
-          proc0Map = rcp(new map_type(dims[0],0,indexBase,pComm,pNode));
+          proc0Map = rcp(new map_type(dims[0],0,indexBase,pComm
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                                     ,pNode
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+                                      ));
         }
 
         // Create the graph where the root owns EVERYTHING
@@ -1592,7 +1620,11 @@ namespace Tpetra {
         {
           // Create a map describing the distribution we actually want
           RCP<map_type> distMap =
-              rcp(new map_type(dims[0],0,pComm,GloballyDistributed,pNode));
+              rcp(new map_type(dims[0],0,pComm,GloballyDistributed
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                               ,pNode
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+                              ));
 
           // Create the graph with that distribution too
           distGraph = rcp(new sparse_graph_type(distMap,colMap,0,DynamicProfile,constructorParams));
@@ -1644,13 +1676,14 @@ namespace Tpetra {
       ///   anyone else.
       static Teuchos::RCP<sparse_graph_type>
       readSparseGraphFile (const std::string& filename,
-                           const Teuchos::RCP<const Teuchos::Comm<int> >& pComm,
+                           const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
                            const bool callFillComplete=true,
                            const bool tolerant=false,
                            const bool debug=false)
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
       {
         // Call the overload below.
-        return readSparseGraphFile (filename, pComm, Teuchos::null,
+        return readSparseGraphFile (filename, comm, Teuchos::null,
                                     callFillComplete, tolerant, debug);
       }
 
@@ -1660,13 +1693,14 @@ namespace Tpetra {
       ///
       /// Please don't call this method; call the one above.
       /// DO NOT CREATE EXPLICIT NODE OBJECTS.
-      static Teuchos::RCP<sparse_graph_type>
+      static Teuchos::RCP<sparse_graph_type>  TPETRA_DEPRECATED
       readSparseGraphFile (const std::string& filename,
                            const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
-                           const Teuchos::RCP<node_type>& node,
+                           const Teuchos::RCP<node_type>& pNode,
                            const bool callFillComplete=true,
                            const bool tolerant=false,
                            const bool debug=false)
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
       {
         using Teuchos::broadcast;
         using Teuchos::outArg;
@@ -1690,7 +1724,11 @@ namespace Tpetra {
         TEUCHOS_TEST_FOR_EXCEPTION
           (opened == 0, std::runtime_error, "readSparseGraphFile: "
            "Failed to open file \"" << filename << "\" on Process 0.");
-        return readSparseGraph (in, comm, node, callFillComplete,
+        return readSparseGraph (in, comm, 
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                                pNode,
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+                                callFillComplete,
                                 tolerant, debug);
         // We can rely on the destructor of the input stream to close
         // the file on scope exit, even if readSparseGraph() throws an
@@ -1732,6 +1770,7 @@ namespace Tpetra {
                            const Teuchos::RCP<Teuchos::ParameterList>& fillCompleteParams,
                            const bool tolerant=false,
                            const bool debug=false)
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
       {
         // Call the overload below.
         return readSparseGraphFile (filename, pComm, Teuchos::null,
@@ -1745,7 +1784,7 @@ namespace Tpetra {
       ///
       /// Please don't call this method; call the one above.
       /// DO NOT CREATE EXPLICIT NODE OBJECTS.
-      static Teuchos::RCP<sparse_graph_type>
+      static Teuchos::RCP<sparse_graph_type> TPETRA_DEPRECATED
       readSparseGraphFile (const std::string& filename,
                            const Teuchos::RCP<const Teuchos::Comm<int> >& pComm,
                            const Teuchos::RCP<node_type>& pNode,
@@ -1753,6 +1792,7 @@ namespace Tpetra {
                            const Teuchos::RCP<Teuchos::ParameterList>& fillCompleteParams,
                            const bool tolerant=false,
                            const bool debug=false)
+#endif  // TPETRA_ENABLE_DEPRECATED_CODE
       {
         using Teuchos::broadcast;
         using Teuchos::outArg;
@@ -1779,7 +1819,11 @@ namespace Tpetra {
         if (pComm->getRank () == 0) { // only open the input file on Process 0
           in.open (filename.c_str ());
         }
-        return readSparseGraph (in, pComm, pNode, constructorParams,
+        return readSparseGraph (in, pComm, 
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                                pNode,
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+                                constructorParams,
                                 fillCompleteParams, tolerant, debug);
         // We can rely on the destructor of the input stream to close
         // the file on scope exit, even if readSparseGraph() throws an
@@ -1902,6 +1946,7 @@ namespace Tpetra {
                        const bool callFillComplete=true,
                        const bool tolerant=false,
                        const bool debug=false)
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
       {
         // Call the overload below.
         return readSparseGraph (in, pComm, Teuchos::null, callFillComplete,
@@ -1909,20 +1954,25 @@ namespace Tpetra {
       }
 
       //! Variant of readSparseGraph() above that takes a Node object.
-      static Teuchos::RCP<sparse_graph_type>
+      static Teuchos::RCP<sparse_graph_type> TPETRA_DEPRECATED
       readSparseGraph (std::istream& in,
                        const Teuchos::RCP<const Teuchos::Comm<int> >& pComm,
                        const Teuchos::RCP<node_type>& pNode,
                        const bool callFillComplete=true,
                        const bool tolerant=false,
                        const bool debug=false)
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
       {
         Teuchos::RCP<const map_type> fakeRowMap;
         Teuchos::RCP<const map_type> fakeColMap;
         Teuchos::RCP<Teuchos::ParameterList> fakeCtorParams;
 
         Teuchos::RCP<sparse_graph_type> graph =
-          readSparseGraphHelper (in, pComm, pNode, fakeRowMap, fakeColMap,
+          readSparseGraphHelper (in, pComm, 
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                                 pNode,
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+                                 fakeRowMap, fakeColMap,
                                  fakeCtorParams, tolerant, debug);
         if (callFillComplete) {
           graph->fillComplete ();
@@ -1966,6 +2016,7 @@ namespace Tpetra {
                        const Teuchos::RCP<Teuchos::ParameterList>& fillCompleteParams,
                        const bool tolerant=false,
                        const bool debug=false)
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
       {
         // Call the overload below.
         return readSparseGraph (in, pComm, Teuchos::null, constructorParams,
@@ -1973,7 +2024,7 @@ namespace Tpetra {
       }
 
       //! Variant of the above readSparseGraph() method that takes a Kokkos Node.
-      static Teuchos::RCP<sparse_graph_type>
+      static Teuchos::RCP<sparse_graph_type> TPETRA_DEPRECATED
       readSparseGraph (std::istream& in,
                        const Teuchos::RCP<const Teuchos::Comm<int> >& pComm,
                        const Teuchos::RCP<node_type>& pNode,
@@ -1981,11 +2032,16 @@ namespace Tpetra {
                        const Teuchos::RCP<Teuchos::ParameterList>& fillCompleteParams,
                        const bool tolerant=false,
                        const bool debug=false)
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
       {
         Teuchos::RCP<const map_type> fakeRowMap;
         Teuchos::RCP<const map_type> fakeColMap;
         Teuchos::RCP<sparse_graph_type> graph =
-          readSparseGraphHelper (in, pComm, pNode, fakeRowMap, fakeColMap,
+          readSparseGraphHelper (in, pComm, 
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                                 pNode,
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+                                 fakeRowMap, fakeColMap,
                                  constructorParams, tolerant, debug);
         graph->fillComplete (fillCompleteParams);
         return graph;
@@ -2042,7 +2098,10 @@ namespace Tpetra {
                        const bool debug=false)
       {
         Teuchos::RCP<sparse_graph_type> graph =
-          readSparseGraphHelper (in, rowMap->getComm (), rowMap->getNode (),
+          readSparseGraphHelper (in, rowMap->getComm (), 
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                                 rowMap->getNode (),
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
                                  rowMap, colMap, Teuchos::null, tolerant,
                                  debug);
         if (callFillComplete) {
@@ -2080,18 +2139,20 @@ namespace Tpetra {
                       const bool callFillComplete=true,
                       const bool tolerant=false,
                       const bool debug=false)
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
       {
         return readSparseFile (filename, pComm, Teuchos::null, callFillComplete, tolerant, debug);
       }
 
       //! Variant of readSparseFile that takes a Node object.
-      static Teuchos::RCP<sparse_matrix_type>
+      static Teuchos::RCP<sparse_matrix_type>  TPETRA_DEPRECATED
       readSparseFile (const std::string& filename,
                       const Teuchos::RCP<const Teuchos::Comm<int> >& pComm,
                       const Teuchos::RCP<node_type>& pNode,
                       const bool callFillComplete=true,
                       const bool tolerant=false,
                       const bool debug=false)
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
       {
         const int myRank = pComm->getRank ();
         std::ifstream in;
@@ -2106,7 +2167,11 @@ namespace Tpetra {
         // readSparse could do that too, by checking the status of the
         // std::ostream.
 
-        return readSparse (in, pComm, pNode, callFillComplete, tolerant, debug);
+        return readSparse (in, pComm,
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                           pNode,
+#endif
+                           callFillComplete, tolerant, debug);
         // We can rely on the destructor of the input stream to close
         // the file on scope exit, even if readSparse() throws an
         // exception.
@@ -2147,6 +2212,7 @@ namespace Tpetra {
                       const Teuchos::RCP<Teuchos::ParameterList>& fillCompleteParams,
                       const bool tolerant=false,
                       const bool debug=false)
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
       {
         return readSparseFile (filename, pComm, Teuchos::null,
                                constructorParams, fillCompleteParams,
@@ -2154,7 +2220,7 @@ namespace Tpetra {
       }
 
       //! Variant of readSparseFile above that takes a Node object.
-      static Teuchos::RCP<sparse_matrix_type>
+      static Teuchos::RCP<sparse_matrix_type>  TPETRA_DEPRECATED
       readSparseFile (const std::string& filename,
                       const Teuchos::RCP<const Teuchos::Comm<int> >& pComm,
                       const Teuchos::RCP<node_type>& pNode,
@@ -2162,12 +2228,17 @@ namespace Tpetra {
                       const Teuchos::RCP<Teuchos::ParameterList>& fillCompleteParams,
                       const bool tolerant=false,
                       const bool debug=false)
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
       {
         std::ifstream in;
         if (pComm->getRank () == 0) { // only open on Process 0
           in.open (filename.c_str ());
         }
-        return readSparse (in, pComm, pNode, constructorParams,
+        return readSparse (in, pComm,
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                           pNode,
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+                           constructorParams,
                            fillCompleteParams, tolerant, debug);
       }
 
@@ -2285,18 +2356,20 @@ namespace Tpetra {
                   const bool callFillComplete=true,
                   const bool tolerant=false,
                   const bool debug=false)
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
       {
         return readSparse (in, pComm, Teuchos::null, callFillComplete, tolerant, debug);
       }
 
       //! Variant of readSparse() above that takes a Node object.
-      static Teuchos::RCP<sparse_matrix_type>
+      static Teuchos::RCP<sparse_matrix_type>  TPETRA_DEPRECATED
       readSparse (std::istream& in,
                   const Teuchos::RCP<const Teuchos::Comm<int> >& pComm,
                   const Teuchos::RCP<node_type>& pNode,
                   const bool callFillComplete=true,
                   const bool tolerant=false,
                   const bool debug=false)
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
       {
         using Teuchos::MatrixMarket::Banner;
         using Teuchos::arcp;
@@ -2709,10 +2782,18 @@ namespace Tpetra {
         // and the distribution of its rows.  Creating a Map is a
         // collective operation, so we don't have to do a broadcast of
         // a success Boolean.
-        RCP<const map_type> pRangeMap = makeRangeMap (pComm, pNode, dims[0]);
+        RCP<const map_type> pRangeMap = makeRangeMap (pComm, 
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                                                      pNode, 
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+                                                      dims[0]);
         RCP<const map_type> pDomainMap =
           makeDomainMap (pRangeMap, dims[0], dims[1]);
-        RCP<const map_type> pRowMap = makeRowMap (null, pComm, pNode, dims[0]);
+        RCP<const map_type> pRowMap = makeRowMap (null, pComm,
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                                                  pNode,
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+                                                  dims[0]);
 
         if (debug && myRank == rootRank) {
           cerr << "-- Distributing the matrix data" << endl;
@@ -2850,13 +2931,14 @@ namespace Tpetra {
                   const Teuchos::RCP<Teuchos::ParameterList>& fillCompleteParams,
                   const bool tolerant=false,
                   const bool debug=false)
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
       {
         return readSparse (in, pComm, Teuchos::null, constructorParams,
                            fillCompleteParams, tolerant, debug);
       }
 
       //! Variant of the above readSparse() method that takes a Kokkos Node.
-      static Teuchos::RCP<sparse_matrix_type>
+      static Teuchos::RCP<sparse_matrix_type>  TPETRA_DEPRECATED
       readSparse (std::istream& in,
                   const Teuchos::RCP<const Teuchos::Comm<int> >& pComm,
                   const Teuchos::RCP<node_type>& pNode,
@@ -2864,6 +2946,7 @@ namespace Tpetra {
                   const Teuchos::RCP<Teuchos::ParameterList>& fillCompleteParams,
                   const bool tolerant=false,
                   const bool debug=false)
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
       {
         using Teuchos::MatrixMarket::Banner;
         using Teuchos::arcp;
@@ -3275,10 +3358,18 @@ namespace Tpetra {
         // and the distribution of its rows.  Creating a Map is a
         // collective operation, so we don't have to do a broadcast of
         // a success Boolean.
-        RCP<const map_type> pRangeMap = makeRangeMap (pComm, pNode, dims[0]);
+        RCP<const map_type> pRangeMap = makeRangeMap (pComm, 
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                                                      pNode,
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+                                                      dims[0]);
         RCP<const map_type> pDomainMap =
           makeDomainMap (pRangeMap, dims[0], dims[1]);
-        RCP<const map_type> pRowMap = makeRowMap (null, pComm, pNode, dims[0]);
+        RCP<const map_type> pRowMap = makeRowMap (null, pComm,
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                                                  pNode,
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+                                                  dims[0]);
 
         if (debug && myRank == rootRank) {
           cerr << "-- Distributing the matrix data" << endl;
@@ -4016,7 +4107,9 @@ namespace Tpetra {
       ///   only accessed on Rank 0 of the given communicator.
       /// \param comm [in] Communicator containing all process(es)
       ///   over which the dense matrix will be distributed.
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
       /// \param node [in] Kokkos Node object.
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
       /// \param map [in/out] On input: if nonnull, the map describing
       ///   how to distribute the vector (not modified).  In this
       ///   case, the map's communicator and node must equal \c comm
@@ -4043,11 +4136,12 @@ namespace Tpetra {
         return readDense (in, comm, map, tolerant, debug);
       }
 
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
       //! Variant of readDenseMatrix (see above) that takes a Node.
-      static Teuchos::RCP<multivector_type>
+      static Teuchos::RCP<multivector_type>  TPETRA_DEPRECATED
       readDenseFile (const std::string& filename,
                      const Teuchos::RCP<const comm_type>& comm,
-                     const Teuchos::RCP<node_type>& node,
+                     const Teuchos::RCP<node_type>& pNode,
                      Teuchos::RCP<const map_type>& map,
                      const bool tolerant=false,
                      const bool debug=false)
@@ -4056,8 +4150,9 @@ namespace Tpetra {
         if (comm->getRank () == 0) { // Only open the file on Proc 0.
           in.open (filename.c_str ()); // Destructor closes safely
         }
-        return readDense (in, comm, node, map, tolerant, debug);
+        return readDense (in, comm, pNode, map, tolerant, debug);
       }
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
 
       /// \brief Read a Vector from the given Matrix Market file.
       ///
@@ -4102,12 +4197,13 @@ namespace Tpetra {
         return readVector (in, comm, map, tolerant, debug);
       }
 
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
       /// \brief Like readVectorFile() (see above), but with a
       ///   supplied Node object.
-      static Teuchos::RCP<vector_type>
+      static Teuchos::RCP<vector_type>  TPETRA_DEPRECATED
       readVectorFile (const std::string& filename,
                       const Teuchos::RCP<const comm_type>& comm,
-                      const Teuchos::RCP<node_type>& node,
+                      const Teuchos::RCP<node_type>& pNode,
                       Teuchos::RCP<const map_type>& map,
                       const bool tolerant=false,
                       const bool debug=false)
@@ -4116,8 +4212,9 @@ namespace Tpetra {
         if (comm->getRank () == 0) { // Only open the file on Proc 0.
           in.open (filename.c_str ()); // Destructor closes safely
         }
-        return readVector (in, comm, node, map, tolerant, debug);
+        return readVector (in, comm, pNode, map, tolerant, debug);
       }
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
 
       /// \brief Read dense matrix (as a MultiVector) from the given
       ///   Matrix Market input stream.
@@ -4173,7 +4270,9 @@ namespace Tpetra {
       ///   communicator.
       /// \param comm [in] Communicator containing all process(es)
       ///   over which the dense matrix will be distributed.
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
       /// \param node [in] Kokkos Node object.
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
       /// \param map [in/out] On input: if nonnull, the map describing
       ///   how to distribute the vector (not modified).  In this
       ///   case, the map's communicator and node must equal comm
@@ -4192,22 +4291,28 @@ namespace Tpetra {
                  Teuchos::RCP<const map_type>& map,
                  const bool tolerant=false,
                  const bool debug=false)
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
       {
         return readDense (in, comm, Teuchos::null, map, tolerant, debug);
       }
 
       //! Variant of readDense (see above) that takes a Node.
-      static Teuchos::RCP<multivector_type>
+      static Teuchos::RCP<multivector_type>  TPETRA_DEPRECATED
       readDense (std::istream& in,
                  const Teuchos::RCP<const comm_type>& comm,
-                 const Teuchos::RCP<node_type>& node,
+                 const Teuchos::RCP<node_type>& pNode,
                  Teuchos::RCP<const map_type>& map,
                  const bool tolerant=false,
                  const bool debug=false)
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
       {
         Teuchos::RCP<Teuchos::FancyOStream> err =
           Teuchos::getFancyOStream (Teuchos::rcpFromRef (std::cerr));
-        return readDenseImpl<scalar_type> (in, comm, node, map,
+        return readDenseImpl<scalar_type> (in, comm, 
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                                           pNode,
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+                                           map,
                                            err, tolerant, debug);
       }
 
@@ -4218,6 +4323,7 @@ namespace Tpetra {
                   Teuchos::RCP<const map_type>& map,
                   const bool tolerant=false,
                   const bool debug=false)
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
       {
         Teuchos::RCP<Teuchos::FancyOStream> err =
           Teuchos::getFancyOStream (Teuchos::rcpFromRef (std::cerr));
@@ -4226,17 +4332,22 @@ namespace Tpetra {
       }
 
       //! Read Vector from the given Matrix Market input stream, with a supplied Node.
-      static Teuchos::RCP<vector_type>
+      static Teuchos::RCP<vector_type> TPETRA_DEPRECATED
       readVector (std::istream& in,
                  const Teuchos::RCP<const comm_type>& comm,
-                 const Teuchos::RCP<node_type>& node,
+                 const Teuchos::RCP<node_type>& pNode,
                  Teuchos::RCP<const map_type>& map,
                  const bool tolerant=false,
                  const bool debug=false)
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
       {
         Teuchos::RCP<Teuchos::FancyOStream> err =
           Teuchos::getFancyOStream (Teuchos::rcpFromRef (std::cerr));
-        return readVectorImpl<scalar_type> (in, comm, node, map,
+        return readVectorImpl<scalar_type> (in, comm,
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE 
+                                            pNode,
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+                                            map,
                                             err, tolerant, debug);
       }
 
@@ -4265,18 +4376,20 @@ namespace Tpetra {
                    const Teuchos::RCP<const comm_type>& comm,
                    const bool tolerant=false,
                    const bool debug=false)
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
       {
         return readMapFile (filename, comm, Teuchos::null, tolerant, debug);
       }
 
       /// \brief Variant of readMapFile (above) that takes an explicit
       ///   Node instance.
-      static Teuchos::RCP<const map_type>
+      static Teuchos::RCP<const map_type>  TPETRA_DEPRECATED
       readMapFile (const std::string& filename,
                    const Teuchos::RCP<const comm_type>& comm,
-                   const Teuchos::RCP<node_type>& node,
+                   const Teuchos::RCP<node_type>& pNode,
                    const bool tolerant=false,
                    const bool debug=false)
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
       {
         using Teuchos::inOutArg;
         using Teuchos::broadcast;
@@ -4294,7 +4407,11 @@ namespace Tpetra {
           success == 0, std::runtime_error,
           "Tpetra::MatrixMarket::Reader::readMapFile: "
           "Failed to read file \"" << filename << "\" on Process 0.");
-        return readMap (in, comm, node, tolerant, debug);
+        return readMap (in, comm,
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                        pNode,
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+                        tolerant, debug);
       }
 
     private:
@@ -4305,7 +4422,9 @@ namespace Tpetra {
                                      node_type> >
       readDenseImpl (std::istream& in,
                      const Teuchos::RCP<const comm_type>& comm,
-                     const Teuchos::RCP<node_type>& node,
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                     const TPETRA_DEPRECATED Teuchos::RCP<node_type>& pNode,
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
                      Teuchos::RCP<const map_type>& map,
                      const Teuchos::RCP<Teuchos::FancyOStream>& err,
                      const bool tolerant=false,
@@ -4539,11 +4658,15 @@ namespace Tpetra {
           // The user didn't supply a Map.  Make a contiguous
           // distributed Map for them, using the read-in multivector
           // dimensions.
-          if (node.is_null ()) {
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+          if (pNode.is_null ()) {
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
             map = createUniformContigMapWithNode<LO, GO, NT> (numRows, comm);
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
           } else {
-            map = createUniformContigMapWithNode<LO, GO, NT> (numRows, comm, node);
+            map = createUniformContigMapWithNode<LO, GO, NT> (numRows, comm, pNode);
           }
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
           const size_t localNumRows = (myRank == 0) ? numRows : 0;
           // At this point, map exists and has a nonnull node.
           proc0Map = createContigMapWithNode<LO, GO, NT> (numRows, localNumRows,
@@ -4817,7 +4940,9 @@ namespace Tpetra {
                                      node_type> >
       readVectorImpl (std::istream& in,
                       const Teuchos::RCP<const comm_type>& comm,
-                      const Teuchos::RCP<node_type>& node, // allowed to be null
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                      const Teuchos::RCP<node_type>& pNode, // allowed to be null
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
                       Teuchos::RCP<const map_type>& map,
                       const Teuchos::RCP<Teuchos::FancyOStream>& err,
                       const bool tolerant=false,
@@ -5057,11 +5182,15 @@ namespace Tpetra {
           // The user didn't supply a Map.  Make a contiguous
           // distributed Map for them, using the read-in multivector
           // dimensions.
-          if (node.is_null ()) {
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+          if (pNode.is_null ()) {
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
             map = createUniformContigMapWithNode<LO, GO, NT> (numRows, comm);
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
           } else {
-            map = createUniformContigMapWithNode<LO, GO, NT> (numRows, comm, node);
+            map = createUniformContigMapWithNode<LO, GO, NT> (numRows, comm, pNode);
           }
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
           const size_t localNumRows = (myRank == 0) ? numRows : 0;
           // At this point, map exists and has a nonnull node.
           proc0Map = createContigMapWithNode<LO, GO, NT> (numRows, localNumRows,
@@ -5342,7 +5471,9 @@ namespace Tpetra {
       ///   given communicator.
       /// \param comm [in] Communicator containing all process(es)
       ///   over which the Map will be distributed.
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
       /// \param node [in] Kokkos Node object.
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
       /// \param tolerant [in] Whether to read the data tolerantly
       ///   from the file.
       /// \param debug [in] Whether to produce copious status output
@@ -5359,19 +5490,21 @@ namespace Tpetra {
         return readMap (in, comm, err, tolerant, debug);
       }
 
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
       /// \brief Variant of readMap (above) that takes an explicit
       ///   Node instance.
-      static Teuchos::RCP<const map_type>
+      static Teuchos::RCP<const map_type>  TPETRA_DEPRECATED
       readMap (std::istream& in,
                const Teuchos::RCP<const comm_type>& comm,
-               const Teuchos::RCP<node_type>& node,
+               const Teuchos::RCP<node_type>& pNode,
                const bool tolerant=false,
                const bool debug=false)
       {
         Teuchos::RCP<Teuchos::FancyOStream> err =
           Teuchos::getFancyOStream (Teuchos::rcpFromRef (std::cerr));
-        return readMap (in, comm, node, err, tolerant, debug);
+        return readMap (in, comm, pNode, err, tolerant, debug);
       }
+#endif
 
       /// \brief Read Map (as a MultiVector) from the given input
       ///   stream, with optional debugging output stream.
@@ -5404,19 +5537,21 @@ namespace Tpetra {
                const Teuchos::RCP<Teuchos::FancyOStream>& err,
                const bool tolerant=false,
                const bool debug=false)
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
       {
         return readMap (in, comm, Teuchos::null, err, tolerant, debug);
       }
 
       /// \brief Variant of readMap (above) that takes an explicit
       ///   Node instance.
-      static Teuchos::RCP<const map_type>
+      static Teuchos::RCP<const map_type>  TPETRA_DEPRECATED
       readMap (std::istream& in,
                const Teuchos::RCP<const comm_type>& comm,
-               const Teuchos::RCP<node_type>& node,
+               const Teuchos::RCP<node_type>& pNode,
                const Teuchos::RCP<Teuchos::FancyOStream>& err,
                const bool tolerant=false,
                const bool debug=false)
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
       {
         using Teuchos::arcp;
         using Teuchos::Array;
@@ -5497,7 +5632,11 @@ namespace Tpetra {
             // This is currently the only place where we use the
             // 'tolerant' argument.  Later, if we want to be clever,
             // we could have tolerant mode allow PIDs out of order.
-            data = readDenseImpl<GO> (in, proc0Comm, node, dataMap,
+            data = readDenseImpl<GO> (in, proc0Comm,
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                                      pNode,
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+                                      dataMap,
                                       err, tolerant, debug);
             (void) dataMap; // Silence "unused" warnings
             if (data.is_null ()) {
@@ -5733,12 +5872,16 @@ namespace Tpetra {
         int gblSuccess = 0; // output argument
         std::ostringstream errStrm;
         try {
-          if (node.is_null ()) {
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+          if (pNode.is_null ()) {
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
             newMap = rcp (new map_type (INVALID, myGids (), indexBase, comm));
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
           }
           else {
-            newMap = rcp (new map_type (INVALID, myGids (), indexBase, comm, node));
+            newMap = rcp (new map_type (INVALID, myGids (), indexBase, comm, pNode));
           }
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
         }
         catch (std::exception& e) {
           lclSuccess = 0;

--- a/packages/tpetra/core/inout/MatrixMarket_Tpetra.hpp
+++ b/packages/tpetra/core/inout/MatrixMarket_Tpetra.hpp
@@ -4053,7 +4053,7 @@ namespace Tpetra {
                      const bool tolerant=false,
                      const bool debug=false)
       {
-        readDenseFile(filename, comm, map, tolerant, debug);
+        return readDenseFile(filename, comm, map, tolerant, debug);
       }
 #endif // TPETRA_ENABLE_DEPRECATED_CODE
 
@@ -4230,7 +4230,7 @@ namespace Tpetra {
                  const bool tolerant=false,
                  const bool debug=false)
       {
-        readVector(in, comm,  map, tolerant, debug);
+        return readVector(in, comm,  map, tolerant, debug);
       }
 #endif // TPETRA_ENABLE_DEPRECATED_CODE
 
@@ -5354,9 +5354,9 @@ namespace Tpetra {
                const bool tolerant=false,
                const bool debug=false)
       {
-        readMap(in, comm, tolerant, debug);
+        return readMap(in, comm, tolerant, debug);
       }
-#endif
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
 
       /// \brief Read Map (as a MultiVector) from the given input
       ///   stream, with optional debugging output stream.

--- a/packages/tpetra/core/inout/MatrixMarket_Tpetra.hpp
+++ b/packages/tpetra/core/inout/MatrixMarket_Tpetra.hpp
@@ -228,34 +228,17 @@ namespace Tpetra {
       /// constructs.
       ///
       /// \param pComm [in] Global communicator.
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-      /// \param pNode [in] Kokkos Node object.
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
       /// \param numRows [in] Global number of rows in the matrix.
       ///
       /// \return Range map to be used for constructing a CrsMatrix.
       static Teuchos::RCP<const map_type>
       makeRangeMap (const Teuchos::RCP<const comm_type>& pComm,
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE  
-                    const Teuchos::RCP<node_type>& TPETRA_DEPRECATED pNode,
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
                     const global_ordinal_type numRows)
       {
         // Return a conventional, uniformly partitioned, contiguous map.
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-        if (pNode.is_null ()) {
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
-          return rcp (new map_type (static_cast<global_size_t> (numRows),
-                                    static_cast<global_ordinal_type> (0),
-                                    pComm, GloballyDistributed));
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-        }
-        else {
-          return rcp (new map_type (static_cast<global_size_t> (numRows),
-                                    static_cast<global_ordinal_type> (0),
-                                    pComm, GloballyDistributed, pNode));
-        }
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
+        return rcp (new map_type (static_cast<global_size_t> (numRows),
+                                  static_cast<global_ordinal_type> (0),
+                                  pComm, GloballyDistributed));
       }
 
       /// \brief Compute initial row map, or verify an existing one.
@@ -281,9 +264,6 @@ namespace Tpetra {
       ///   typical case is to pass in null here, which is why we call
       ///   this routine "makeRowMap".
       /// \param pComm [in] Global communicator.
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-      /// \param pNode [in] Kokkos Node object.
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
       /// \param numRows [in] Global number of rows in the matrix.  If
       ///   pRowMap is nonnull, used only for error checking.
       ///
@@ -291,28 +271,14 @@ namespace Tpetra {
       static Teuchos::RCP<const map_type>
       makeRowMap (const Teuchos::RCP<const map_type>& pRowMap,
                   const Teuchos::RCP<const comm_type>& pComm,
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-                  const Teuchos::RCP<node_type>& TPETRA_DEPRECATED pNode,
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
                   const global_ordinal_type numRows)
       {
         // If the caller didn't provide a map, return a conventional,
         // uniformly partitioned, contiguous map.
         if (pRowMap.is_null ()) {
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-          if (pNode.is_null ()) {
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
-            return rcp (new map_type (static_cast<global_size_t> (numRows),
-                                      static_cast<global_ordinal_type> (0),
-                                      pComm, GloballyDistributed));
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-          }
-          else {
-            return rcp (new map_type (static_cast<global_size_t> (numRows),
-                                      static_cast<global_ordinal_type> (0),
-                                      pComm, GloballyDistributed, pNode));
-          }
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
+          return rcp (new map_type (static_cast<global_size_t> (numRows),
+                                    static_cast<global_ordinal_type> (0),
+                                    pComm, GloballyDistributed));
         }
         else {
           TEUCHOS_TEST_FOR_EXCEPTION
@@ -356,11 +322,7 @@ namespace Tpetra {
           return pRangeMap;
         } else {
           return createUniformContigMapWithNode<LO,GO,NT> (numCols,
-                                                           pRangeMap->getComm ()
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-                                                           , pRangeMap->getNode ()
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
-                                                          );
+                                                           pRangeMap->getComm ());
         }
       }
 
@@ -1326,9 +1288,6 @@ namespace Tpetra {
       static Teuchos::RCP<sparse_graph_type>
       readSparseGraphHelper (std::istream& in,
                              const Teuchos::RCP<const Teuchos::Comm<int> >& pComm,
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-                             const Teuchos::RCP<node_type>& TPETRA_DEPRECATED pNode,
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
                              const Teuchos::RCP<const map_type>& rowMap,
                              Teuchos::RCP<const map_type>& colMap,
                              const Teuchos::RCP<Teuchos::ParameterList>& constructorParams,
@@ -1583,18 +1542,10 @@ namespace Tpetra {
           indexBase = rowMap->getIndexBase();
         }
         if(myRank == rootRank) {
-          proc0Map = rcp(new map_type(dims[0],dims[0],indexBase,pComm
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-                                      ,pNode
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
-                                      ));
+          proc0Map = rcp(new map_type(dims[0],dims[0],indexBase,pComm));
         }
         else {
-          proc0Map = rcp(new map_type(dims[0],0,indexBase,pComm
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-                                     ,pNode
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
-                                      ));
+          proc0Map = rcp(new map_type(dims[0],0,indexBase,pComm));
         }
 
         // Create the graph where the root owns EVERYTHING
@@ -1623,11 +1574,7 @@ namespace Tpetra {
         {
           // Create a map describing the distribution we actually want
           RCP<map_type> distMap =
-              rcp(new map_type(dims[0],0,pComm,GloballyDistributed
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-                               ,pNode
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
-                              ));
+              rcp(new map_type(dims[0],0,pComm,GloballyDistributed));
 
           // Create the graph with that distribution too
           distGraph = rcp(new sparse_graph_type(distMap,colMap,0,DynamicProfile,constructorParams));
@@ -1683,27 +1630,6 @@ namespace Tpetra {
                            const bool callFillComplete=true,
                            const bool tolerant=false,
                            const bool debug=false)
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-      {
-        // Call the overload below.
-        return readSparseGraphFile (filename, comm, Teuchos::null,
-                                    callFillComplete, tolerant, debug);
-      }
-
-      /// \brief Variant of readSparseGraphFile (filename, comm,
-      ///   callFillComplete, tolerant, debug) that takes a Node
-      ///   object.
-      ///
-      /// Please don't call this method; call the one above.
-      /// DO NOT CREATE EXPLICIT NODE OBJECTS.
-      static Teuchos::RCP<sparse_graph_type>  TPETRA_DEPRECATED
-      readSparseGraphFile (const std::string& filename,
-                           const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
-                           const Teuchos::RCP<node_type>& pNode,
-                           const bool callFillComplete=true,
-                           const bool tolerant=false,
-                           const bool debug=false)
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
       {
         using Teuchos::broadcast;
         using Teuchos::outArg;
@@ -1728,15 +1654,33 @@ namespace Tpetra {
           (opened == 0, std::runtime_error, "readSparseGraphFile: "
            "Failed to open file \"" << filename << "\" on Process 0.");
         return readSparseGraph (in, comm, 
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-                                pNode,
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
                                 callFillComplete,
                                 tolerant, debug);
         // We can rely on the destructor of the input stream to close
         // the file on scope exit, even if readSparseGraph() throws an
         // exception.
       }
+
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+      /// \brief Variant of readSparseGraphFile (filename, comm,
+      ///   callFillComplete, tolerant, debug) that takes a Node
+      ///   object.
+      ///
+      /// Please don't call this method; call the one above.
+      /// DO NOT CREATE EXPLICIT NODE OBJECTS.
+      static Teuchos::RCP<sparse_graph_type>  TPETRA_DEPRECATED
+      readSparseGraphFile (const std::string& filename,
+                           const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
+                           const Teuchos::RCP<node_type>& /* pNode*/,
+                           const bool callFillComplete=true,
+                           const bool tolerant=false,
+                           const bool debug=false)
+      {
+        // Call the overload below.
+        return readSparseGraphFile (filename, comm, 
+                                    callFillComplete, tolerant, debug);
+      }
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
 
       /// \brief Read sparse graph from the given Matrix Market file.
       ///
@@ -1773,29 +1717,6 @@ namespace Tpetra {
                            const Teuchos::RCP<Teuchos::ParameterList>& fillCompleteParams,
                            const bool tolerant=false,
                            const bool debug=false)
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-      {
-        // Call the overload below.
-        return readSparseGraphFile (filename, pComm, Teuchos::null,
-                                    constructorParams, fillCompleteParams,
-                                    tolerant, debug);
-      }
-
-      /// \brief Variant of readSparseGraphFile (filename, comm,
-      ///   constructorParams, fillCompleteParams, tolerant, debug)
-      ///   that takes a Node object.
-      ///
-      /// Please don't call this method; call the one above.
-      /// DO NOT CREATE EXPLICIT NODE OBJECTS.
-      static Teuchos::RCP<sparse_graph_type> TPETRA_DEPRECATED
-      readSparseGraphFile (const std::string& filename,
-                           const Teuchos::RCP<const Teuchos::Comm<int> >& pComm,
-                           const Teuchos::RCP<node_type>& pNode,
-                           const Teuchos::RCP<Teuchos::ParameterList>& constructorParams,
-                           const Teuchos::RCP<Teuchos::ParameterList>& fillCompleteParams,
-                           const bool tolerant=false,
-                           const bool debug=false)
-#endif  // TPETRA_ENABLE_DEPRECATED_CODE
       {
         using Teuchos::broadcast;
         using Teuchos::outArg;
@@ -1823,15 +1744,35 @@ namespace Tpetra {
           in.open (filename.c_str ());
         }
         return readSparseGraph (in, pComm, 
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-                                pNode,
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
                                 constructorParams,
                                 fillCompleteParams, tolerant, debug);
         // We can rely on the destructor of the input stream to close
         // the file on scope exit, even if readSparseGraph() throws an
         // exception.
       }
+
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+      /// \brief Variant of readSparseGraphFile (filename, comm,
+      ///   constructorParams, fillCompleteParams, tolerant, debug)
+      ///   that takes a Node object.
+      ///
+      /// Please don't call this method; call the one above.
+      /// DO NOT CREATE EXPLICIT NODE OBJECTS.
+      static Teuchos::RCP<sparse_graph_type> TPETRA_DEPRECATED
+      readSparseGraphFile (const std::string& filename,
+                           const Teuchos::RCP<const Teuchos::Comm<int> >& pComm,
+                           const Teuchos::RCP<node_type>& /*pNode*/,
+                           const Teuchos::RCP<Teuchos::ParameterList>& constructorParams,
+                           const Teuchos::RCP<Teuchos::ParameterList>& fillCompleteParams,
+                           const bool tolerant=false,
+                           const bool debug=false)
+      {
+        // Call the overload below.
+        return readSparseGraphFile (filename, pComm,
+                                    constructorParams, fillCompleteParams,
+                                    tolerant, debug);
+      }
+#endif  // TPETRA_ENABLE_DEPRECATED_CODE
 
       /// \brief Read sparse graph from the given Matrix Market file,
       ///   with provided Maps.
@@ -1949,22 +1890,6 @@ namespace Tpetra {
                        const bool callFillComplete=true,
                        const bool tolerant=false,
                        const bool debug=false)
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-      {
-        // Call the overload below.
-        return readSparseGraph (in, pComm, Teuchos::null, callFillComplete,
-                                tolerant, debug);
-      }
-
-      //! Variant of readSparseGraph() above that takes a Node object.
-      static Teuchos::RCP<sparse_graph_type> TPETRA_DEPRECATED
-      readSparseGraph (std::istream& in,
-                       const Teuchos::RCP<const Teuchos::Comm<int> >& pComm,
-                       const Teuchos::RCP<node_type>& pNode,
-                       const bool callFillComplete=true,
-                       const bool tolerant=false,
-                       const bool debug=false)
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
       {
         Teuchos::RCP<const map_type> fakeRowMap;
         Teuchos::RCP<const map_type> fakeColMap;
@@ -1972,9 +1897,6 @@ namespace Tpetra {
 
         Teuchos::RCP<sparse_graph_type> graph =
           readSparseGraphHelper (in, pComm, 
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-                                 pNode,
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
                                  fakeRowMap, fakeColMap,
                                  fakeCtorParams, tolerant, debug);
         if (callFillComplete) {
@@ -1982,6 +1904,22 @@ namespace Tpetra {
         }
         return graph;
       }
+
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+      //! Variant of readSparseGraph() above that takes a Node object.
+      static Teuchos::RCP<sparse_graph_type> TPETRA_DEPRECATED
+      readSparseGraph (std::istream& in,
+                       const Teuchos::RCP<const Teuchos::Comm<int> >& pComm,
+                       const Teuchos::RCP<node_type>& /* pNode */,
+                       const bool callFillComplete=true,
+                       const bool tolerant=false,
+                       const bool debug=false)
+      {
+        // Call the overload below.
+        return readSparseGraph (in, pComm, callFillComplete,
+                                tolerant, debug);
+      }
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
 
       /// \brief Read sparse graph from the given Matrix Market input
       ///   stream.
@@ -2019,36 +1957,33 @@ namespace Tpetra {
                        const Teuchos::RCP<Teuchos::ParameterList>& fillCompleteParams,
                        const bool tolerant=false,
                        const bool debug=false)
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-      {
-        // Call the overload below.
-        return readSparseGraph (in, pComm, Teuchos::null, constructorParams,
-                                fillCompleteParams, tolerant, debug);
-      }
-
-      //! Variant of the above readSparseGraph() method that takes a Kokkos Node.
-      static Teuchos::RCP<sparse_graph_type> TPETRA_DEPRECATED
-      readSparseGraph (std::istream& in,
-                       const Teuchos::RCP<const Teuchos::Comm<int> >& pComm,
-                       const Teuchos::RCP<node_type>& pNode,
-                       const Teuchos::RCP<Teuchos::ParameterList>& constructorParams,
-                       const Teuchos::RCP<Teuchos::ParameterList>& fillCompleteParams,
-                       const bool tolerant=false,
-                       const bool debug=false)
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
       {
         Teuchos::RCP<const map_type> fakeRowMap;
         Teuchos::RCP<const map_type> fakeColMap;
         Teuchos::RCP<sparse_graph_type> graph =
           readSparseGraphHelper (in, pComm, 
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-                                 pNode,
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
                                  fakeRowMap, fakeColMap,
                                  constructorParams, tolerant, debug);
         graph->fillComplete (fillCompleteParams);
         return graph;
       }
+
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+      //! Variant of the above readSparseGraph() method that takes a Kokkos Node.
+      static Teuchos::RCP<sparse_graph_type> TPETRA_DEPRECATED
+      readSparseGraph (std::istream& in,
+                       const Teuchos::RCP<const Teuchos::Comm<int> >& pComm,
+                       const Teuchos::RCP<node_type>& /* pNode */,
+                       const Teuchos::RCP<Teuchos::ParameterList>& constructorParams,
+                       const Teuchos::RCP<Teuchos::ParameterList>& fillCompleteParams,
+                       const bool tolerant=false,
+                       const bool debug=false)
+      {
+        // Call the overload below.
+        return readSparseGraph (in, pComm, constructorParams,
+                                fillCompleteParams, tolerant, debug);
+      }
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
 
       /// \brief Read sparse matrix from the given Matrix Market input
       ///   stream, with provided Maps.
@@ -2102,9 +2037,6 @@ namespace Tpetra {
       {
         Teuchos::RCP<sparse_graph_type> graph =
           readSparseGraphHelper (in, rowMap->getComm (), 
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-                                 rowMap->getNode (),
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
                                  rowMap, colMap, Teuchos::null, tolerant,
                                  debug);
         if (callFillComplete) {
@@ -2142,20 +2074,6 @@ namespace Tpetra {
                       const bool callFillComplete=true,
                       const bool tolerant=false,
                       const bool debug=false)
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-      {
-        return readSparseFile (filename, pComm, Teuchos::null, callFillComplete, tolerant, debug);
-      }
-
-      //! Variant of readSparseFile that takes a Node object.
-      static Teuchos::RCP<sparse_matrix_type>  TPETRA_DEPRECATED
-      readSparseFile (const std::string& filename,
-                      const Teuchos::RCP<const Teuchos::Comm<int> >& pComm,
-                      const Teuchos::RCP<node_type>& pNode,
-                      const bool callFillComplete=true,
-                      const bool tolerant=false,
-                      const bool debug=false)
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
       {
         const int myRank = pComm->getRank ();
         std::ifstream in;
@@ -2170,15 +2088,25 @@ namespace Tpetra {
         // readSparse could do that too, by checking the status of the
         // std::ostream.
 
-        return readSparse (in, pComm,
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-                           pNode,
-#endif
-                           callFillComplete, tolerant, debug);
+        return readSparse (in, pComm, callFillComplete, tolerant, debug);
         // We can rely on the destructor of the input stream to close
         // the file on scope exit, even if readSparse() throws an
         // exception.
       }
+
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+      //! Variant of readSparseFile that takes a Node object.
+      static Teuchos::RCP<sparse_matrix_type>  TPETRA_DEPRECATED
+      readSparseFile (const std::string& filename,
+                      const Teuchos::RCP<const Teuchos::Comm<int> >& pComm,
+                      const Teuchos::RCP<node_type>& /* pNode */,
+                      const bool callFillComplete=true,
+                      const bool tolerant=false,
+                      const bool debug=false)
+      {
+        return readSparseFile (filename, pComm, callFillComplete, tolerant, debug);
+      }
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
 
       /// \brief Read sparse matrix from the given Matrix Market file.
       ///
@@ -2215,35 +2143,31 @@ namespace Tpetra {
                       const Teuchos::RCP<Teuchos::ParameterList>& fillCompleteParams,
                       const bool tolerant=false,
                       const bool debug=false)
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-      {
-        return readSparseFile (filename, pComm, Teuchos::null,
-                               constructorParams, fillCompleteParams,
-                               tolerant, debug);
-      }
-
-      //! Variant of readSparseFile above that takes a Node object.
-      static Teuchos::RCP<sparse_matrix_type>  TPETRA_DEPRECATED
-      readSparseFile (const std::string& filename,
-                      const Teuchos::RCP<const Teuchos::Comm<int> >& pComm,
-                      const Teuchos::RCP<node_type>& pNode,
-                      const Teuchos::RCP<Teuchos::ParameterList>& constructorParams,
-                      const Teuchos::RCP<Teuchos::ParameterList>& fillCompleteParams,
-                      const bool tolerant=false,
-                      const bool debug=false)
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
       {
         std::ifstream in;
         if (pComm->getRank () == 0) { // only open on Process 0
           in.open (filename.c_str ());
         }
-        return readSparse (in, pComm,
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-                           pNode,
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
-                           constructorParams,
+        return readSparse (in, pComm, constructorParams,
                            fillCompleteParams, tolerant, debug);
       }
+
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+      //! Variant of readSparseFile above that takes a Node object.
+      static Teuchos::RCP<sparse_matrix_type>  TPETRA_DEPRECATED
+      readSparseFile (const std::string& filename,
+                      const Teuchos::RCP<const Teuchos::Comm<int> >& pComm,
+                      const Teuchos::RCP<node_type>& /* pNode */,
+                      const Teuchos::RCP<Teuchos::ParameterList>& constructorParams,
+                      const Teuchos::RCP<Teuchos::ParameterList>& fillCompleteParams,
+                      const bool tolerant=false,
+                      const bool debug=false)
+      {
+        return readSparseFile (filename, pComm,
+                               constructorParams, fillCompleteParams,
+                               tolerant, debug);
+      }
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
 
       /// \brief Read sparse matrix from the given Matrix Market file,
       ///   with provided Maps.
@@ -2359,20 +2283,6 @@ namespace Tpetra {
                   const bool callFillComplete=true,
                   const bool tolerant=false,
                   const bool debug=false)
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-      {
-        return readSparse (in, pComm, Teuchos::null, callFillComplete, tolerant, debug);
-      }
-
-      //! Variant of readSparse() above that takes a Node object.
-      static Teuchos::RCP<sparse_matrix_type>  TPETRA_DEPRECATED
-      readSparse (std::istream& in,
-                  const Teuchos::RCP<const Teuchos::Comm<int> >& pComm,
-                  const Teuchos::RCP<node_type>& pNode,
-                  const bool callFillComplete=true,
-                  const bool tolerant=false,
-                  const bool debug=false)
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
       {
         using Teuchos::MatrixMarket::Banner;
         using Teuchos::arcp;
@@ -2785,18 +2695,10 @@ namespace Tpetra {
         // and the distribution of its rows.  Creating a Map is a
         // collective operation, so we don't have to do a broadcast of
         // a success Boolean.
-        RCP<const map_type> pRangeMap = makeRangeMap (pComm, 
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-                                                      pNode, 
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
-                                                      dims[0]);
+        RCP<const map_type> pRangeMap = makeRangeMap (pComm, dims[0]);
         RCP<const map_type> pDomainMap =
           makeDomainMap (pRangeMap, dims[0], dims[1]);
-        RCP<const map_type> pRowMap = makeRowMap (null, pComm,
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-                                                  pNode,
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
-                                                  dims[0]);
+        RCP<const map_type> pRowMap = makeRowMap (null, pComm, dims[0]);
 
         if (debug && myRank == rootRank) {
           cerr << "-- Distributing the matrix data" << endl;
@@ -2898,6 +2800,19 @@ namespace Tpetra {
         return pMatrix;
       }
 
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+      //! Variant of readSparse() above that takes a Node object.
+      static Teuchos::RCP<sparse_matrix_type>  TPETRA_DEPRECATED
+      readSparse (std::istream& in,
+                  const Teuchos::RCP<const Teuchos::Comm<int> >& pComm,
+                  const Teuchos::RCP<node_type>& /* pNode */,
+                  const bool callFillComplete=true,
+                  const bool tolerant=false,
+                  const bool debug=false)
+      {
+        return readSparse (in, pComm, callFillComplete, tolerant, debug);
+      }
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
 
       /// \brief Read sparse matrix from the given Matrix Market input stream.
       ///
@@ -2934,22 +2849,6 @@ namespace Tpetra {
                   const Teuchos::RCP<Teuchos::ParameterList>& fillCompleteParams,
                   const bool tolerant=false,
                   const bool debug=false)
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-      {
-        return readSparse (in, pComm, Teuchos::null, constructorParams,
-                           fillCompleteParams, tolerant, debug);
-      }
-
-      //! Variant of the above readSparse() method that takes a Kokkos Node.
-      static Teuchos::RCP<sparse_matrix_type>  TPETRA_DEPRECATED
-      readSparse (std::istream& in,
-                  const Teuchos::RCP<const Teuchos::Comm<int> >& pComm,
-                  const Teuchos::RCP<node_type>& pNode,
-                  const Teuchos::RCP<Teuchos::ParameterList>& constructorParams,
-                  const Teuchos::RCP<Teuchos::ParameterList>& fillCompleteParams,
-                  const bool tolerant=false,
-                  const bool debug=false)
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
       {
         using Teuchos::MatrixMarket::Banner;
         using Teuchos::arcp;
@@ -3361,18 +3260,10 @@ namespace Tpetra {
         // and the distribution of its rows.  Creating a Map is a
         // collective operation, so we don't have to do a broadcast of
         // a success Boolean.
-        RCP<const map_type> pRangeMap = makeRangeMap (pComm, 
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-                                                      pNode,
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
-                                                      dims[0]);
+        RCP<const map_type> pRangeMap = makeRangeMap (pComm, dims[0]);
         RCP<const map_type> pDomainMap =
           makeDomainMap (pRangeMap, dims[0], dims[1]);
-        RCP<const map_type> pRowMap = makeRowMap (null, pComm,
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-                                                  pNode,
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
-                                                  dims[0]);
+        RCP<const map_type> pRowMap = makeRowMap (null, pComm, dims[0]);
 
         if (debug && myRank == rootRank) {
           cerr << "-- Distributing the matrix data" << endl;
@@ -3465,6 +3356,22 @@ namespace Tpetra {
         }
         return pMatrix;
       }
+
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+      //! Variant of the above readSparse() method that takes a Kokkos Node.
+      static Teuchos::RCP<sparse_matrix_type>  TPETRA_DEPRECATED
+      readSparse (std::istream& in,
+                  const Teuchos::RCP<const Teuchos::Comm<int> >& pComm,
+                  const Teuchos::RCP<node_type>& /* pNode */,
+                  const Teuchos::RCP<Teuchos::ParameterList>& constructorParams,
+                  const Teuchos::RCP<Teuchos::ParameterList>& fillCompleteParams,
+                  const bool tolerant=false,
+                  const bool debug=false)
+      {
+        return readSparse (in, pComm, constructorParams,
+                           fillCompleteParams, tolerant, debug);
+      }
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
 
       /// \brief Read sparse matrix from the given Matrix Market input
       ///   stream, with provided Maps.
@@ -4110,9 +4017,6 @@ namespace Tpetra {
       ///   only accessed on Rank 0 of the given communicator.
       /// \param comm [in] Communicator containing all process(es)
       ///   over which the dense matrix will be distributed.
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-      /// \param node [in] Kokkos Node object.
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
       /// \param map [in/out] On input: if nonnull, the map describing
       ///   how to distribute the vector (not modified).  In this
       ///   case, the map's communicator and node must equal \c comm
@@ -4144,16 +4048,12 @@ namespace Tpetra {
       static Teuchos::RCP<multivector_type>  TPETRA_DEPRECATED
       readDenseFile (const std::string& filename,
                      const Teuchos::RCP<const comm_type>& comm,
-                     const Teuchos::RCP<node_type>& pNode,
+                     const Teuchos::RCP<node_type>& /* pNode*/,
                      Teuchos::RCP<const map_type>& map,
                      const bool tolerant=false,
                      const bool debug=false)
       {
-        std::ifstream in;
-        if (comm->getRank () == 0) { // Only open the file on Proc 0.
-          in.open (filename.c_str ()); // Destructor closes safely
-        }
-        return readDense (in, comm, pNode, map, tolerant, debug);
+        readDenseFile(filename, comm, map, tolerant, debug);
       }
 #endif // TPETRA_ENABLE_DEPRECATED_CODE
 
@@ -4206,16 +4106,12 @@ namespace Tpetra {
       static Teuchos::RCP<vector_type>  TPETRA_DEPRECATED
       readVectorFile (const std::string& filename,
                       const Teuchos::RCP<const comm_type>& comm,
-                      const Teuchos::RCP<node_type>& pNode,
+                      const Teuchos::RCP<node_type>& /* pNode */,
                       Teuchos::RCP<const map_type>& map,
                       const bool tolerant=false,
                       const bool debug=false)
       {
-        std::ifstream in;
-        if (comm->getRank () == 0) { // Only open the file on Proc 0.
-          in.open (filename.c_str ()); // Destructor closes safely
-        }
-        return readVector (in, comm, pNode, map, tolerant, debug);
+        return readVectorFile(filename, comm, map, tolerant, debug);
       }
 #endif // TPETRA_ENABLE_DEPRECATED_CODE
 
@@ -4273,9 +4169,6 @@ namespace Tpetra {
       ///   communicator.
       /// \param comm [in] Communicator containing all process(es)
       ///   over which the dense matrix will be distributed.
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-      /// \param node [in] Kokkos Node object.
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
       /// \param map [in/out] On input: if nonnull, the map describing
       ///   how to distribute the vector (not modified).  In this
       ///   case, the map's communicator and node must equal comm
@@ -4294,30 +4187,25 @@ namespace Tpetra {
                  Teuchos::RCP<const map_type>& map,
                  const bool tolerant=false,
                  const bool debug=false)
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
       {
-        return readDense (in, comm, Teuchos::null, map, tolerant, debug);
+        Teuchos::RCP<Teuchos::FancyOStream> err =
+          Teuchos::getFancyOStream (Teuchos::rcpFromRef (std::cerr));
+        return readDenseImpl<scalar_type> (in, comm, map, err, tolerant, debug);
       }
 
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
       //! Variant of readDense (see above) that takes a Node.
       static Teuchos::RCP<multivector_type>  TPETRA_DEPRECATED
       readDense (std::istream& in,
                  const Teuchos::RCP<const comm_type>& comm,
-                 const Teuchos::RCP<node_type>& pNode,
+                 const Teuchos::RCP<node_type>& /* pNode */,
                  Teuchos::RCP<const map_type>& map,
                  const bool tolerant=false,
                  const bool debug=false)
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
       {
-        Teuchos::RCP<Teuchos::FancyOStream> err =
-          Teuchos::getFancyOStream (Teuchos::rcpFromRef (std::cerr));
-        return readDenseImpl<scalar_type> (in, comm, 
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-                                           pNode,
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
-                                           map,
-                                           err, tolerant, debug);
+        return readDense (in, comm, map, tolerant, debug);
       }
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
 
       //! Read Vector from the given Matrix Market input stream.
       static Teuchos::RCP<vector_type>
@@ -4326,33 +4214,25 @@ namespace Tpetra {
                   Teuchos::RCP<const map_type>& map,
                   const bool tolerant=false,
                   const bool debug=false)
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
       {
         Teuchos::RCP<Teuchos::FancyOStream> err =
           Teuchos::getFancyOStream (Teuchos::rcpFromRef (std::cerr));
-        return readVectorImpl<scalar_type> (in, comm, Teuchos::null, map,
-                                            err, tolerant, debug);
+        return readVectorImpl<scalar_type> (in, comm, map, err, tolerant, debug);
       }
 
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
       //! Read Vector from the given Matrix Market input stream, with a supplied Node.
       static Teuchos::RCP<vector_type> TPETRA_DEPRECATED
       readVector (std::istream& in,
                  const Teuchos::RCP<const comm_type>& comm,
-                 const Teuchos::RCP<node_type>& pNode,
+                 const Teuchos::RCP<node_type>& /* pNode */,
                  Teuchos::RCP<const map_type>& map,
                  const bool tolerant=false,
                  const bool debug=false)
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
       {
-        Teuchos::RCP<Teuchos::FancyOStream> err =
-          Teuchos::getFancyOStream (Teuchos::rcpFromRef (std::cerr));
-        return readVectorImpl<scalar_type> (in, comm,
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE 
-                                            pNode,
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
-                                            map,
-                                            err, tolerant, debug);
+        readVector(in, comm,  map, tolerant, debug);
       }
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
 
       /// \brief Read Map (as a MultiVector) from the given
       ///   Matrix Market file.
@@ -4379,20 +4259,6 @@ namespace Tpetra {
                    const Teuchos::RCP<const comm_type>& comm,
                    const bool tolerant=false,
                    const bool debug=false)
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-      {
-        return readMapFile (filename, comm, Teuchos::null, tolerant, debug);
-      }
-
-      /// \brief Variant of readMapFile (above) that takes an explicit
-      ///   Node instance.
-      static Teuchos::RCP<const map_type>  TPETRA_DEPRECATED
-      readMapFile (const std::string& filename,
-                   const Teuchos::RCP<const comm_type>& comm,
-                   const Teuchos::RCP<node_type>& pNode,
-                   const bool tolerant=false,
-                   const bool debug=false)
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
       {
         using Teuchos::inOutArg;
         using Teuchos::broadcast;
@@ -4410,12 +4276,22 @@ namespace Tpetra {
           success == 0, std::runtime_error,
           "Tpetra::MatrixMarket::Reader::readMapFile: "
           "Failed to read file \"" << filename << "\" on Process 0.");
-        return readMap (in, comm,
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-                        pNode,
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
-                        tolerant, debug);
+        return readMap (in, comm, tolerant, debug);
       }
+
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+      /// \brief Variant of readMapFile (above) that takes an explicit
+      ///   Node instance.
+      static Teuchos::RCP<const map_type>  TPETRA_DEPRECATED
+      readMapFile (const std::string& filename,
+                   const Teuchos::RCP<const comm_type>& comm,
+                   const Teuchos::RCP<node_type>& /* pNode */,
+                   const bool tolerant=false,
+                   const bool debug=false)
+      {
+        return readMapFile (filename, comm, tolerant, debug);
+      }
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
 
     private:
       template<class MultiVectorScalarType>
@@ -4425,9 +4301,6 @@ namespace Tpetra {
                                      node_type> >
       readDenseImpl (std::istream& in,
                      const Teuchos::RCP<const comm_type>& comm,
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-                     const Teuchos::RCP<node_type>& TPETRA_DEPRECATED pNode,
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
                      Teuchos::RCP<const map_type>& map,
                      const Teuchos::RCP<Teuchos::FancyOStream>& err,
                      const bool tolerant=false,
@@ -4661,23 +4534,11 @@ namespace Tpetra {
           // The user didn't supply a Map.  Make a contiguous
           // distributed Map for them, using the read-in multivector
           // dimensions.
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-          if (pNode.is_null ()) {
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
-            map = createUniformContigMapWithNode<LO, GO, NT> (numRows, comm);
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-          } else {
-            map = createUniformContigMapWithNode<LO, GO, NT> (numRows, comm, pNode);
-          }
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
+          map = createUniformContigMapWithNode<LO, GO, NT> (numRows, comm);
           const size_t localNumRows = (myRank == 0) ? numRows : 0;
           // At this point, map exists and has a nonnull node.
           proc0Map = createContigMapWithNode<LO, GO, NT> (numRows, localNumRows,
-                                                          comm
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-                                                          , map->getNode ()
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
-                                                          );
+                                                          comm);
         }
         else { // The user supplied a Map.
           proc0Map = Details::computeGatherMap<map_type> (map, err, debug);
@@ -4947,9 +4808,6 @@ namespace Tpetra {
                                      node_type> >
       readVectorImpl (std::istream& in,
                       const Teuchos::RCP<const comm_type>& comm,
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-                      const Teuchos::RCP<node_type>& pNode, // allowed to be null
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
                       Teuchos::RCP<const map_type>& map,
                       const Teuchos::RCP<Teuchos::FancyOStream>& err,
                       const bool tolerant=false,
@@ -5189,23 +5047,11 @@ namespace Tpetra {
           // The user didn't supply a Map.  Make a contiguous
           // distributed Map for them, using the read-in multivector
           // dimensions.
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-          if (pNode.is_null ()) {
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
-            map = createUniformContigMapWithNode<LO, GO, NT> (numRows, comm);
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-          } else {
-            map = createUniformContigMapWithNode<LO, GO, NT> (numRows, comm, pNode);
-          }
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
+          map = createUniformContigMapWithNode<LO, GO, NT> (numRows, comm);
           const size_t localNumRows = (myRank == 0) ? numRows : 0;
           // At this point, map exists and has a nonnull node.
           proc0Map = createContigMapWithNode<LO, GO, NT> (numRows, localNumRows,
-                                                          comm
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-                                                          , map->getNode ()
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
-                                                          );
+                                                          comm);
         }
         else { // The user supplied a Map.
           proc0Map = Details::computeGatherMap<map_type> (map, err, debug);
@@ -5482,9 +5328,6 @@ namespace Tpetra {
       ///   given communicator.
       /// \param comm [in] Communicator containing all process(es)
       ///   over which the Map will be distributed.
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-      /// \param node [in] Kokkos Node object.
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
       /// \param tolerant [in] Whether to read the data tolerantly
       ///   from the file.
       /// \param debug [in] Whether to produce copious status output
@@ -5507,13 +5350,11 @@ namespace Tpetra {
       static Teuchos::RCP<const map_type>  TPETRA_DEPRECATED
       readMap (std::istream& in,
                const Teuchos::RCP<const comm_type>& comm,
-               const Teuchos::RCP<node_type>& pNode,
+               const Teuchos::RCP<node_type>& /* pNode */,
                const bool tolerant=false,
                const bool debug=false)
       {
-        Teuchos::RCP<Teuchos::FancyOStream> err =
-          Teuchos::getFancyOStream (Teuchos::rcpFromRef (std::cerr));
-        return readMap (in, comm, pNode, err, tolerant, debug);
+        readMap(in, comm, tolerant, debug);
       }
 #endif
 
@@ -5548,21 +5389,6 @@ namespace Tpetra {
                const Teuchos::RCP<Teuchos::FancyOStream>& err,
                const bool tolerant=false,
                const bool debug=false)
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-      {
-        return readMap (in, comm, Teuchos::null, err, tolerant, debug);
-      }
-
-      /// \brief Variant of readMap (above) that takes an explicit
-      ///   Node instance.
-      static Teuchos::RCP<const map_type>  TPETRA_DEPRECATED
-      readMap (std::istream& in,
-               const Teuchos::RCP<const comm_type>& comm,
-               const Teuchos::RCP<node_type>& pNode,
-               const Teuchos::RCP<Teuchos::FancyOStream>& err,
-               const bool tolerant=false,
-               const bool debug=false)
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
       {
         using Teuchos::arcp;
         using Teuchos::Array;
@@ -5643,12 +5469,7 @@ namespace Tpetra {
             // This is currently the only place where we use the
             // 'tolerant' argument.  Later, if we want to be clever,
             // we could have tolerant mode allow PIDs out of order.
-            data = readDenseImpl<GO> (in, proc0Comm,
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-                                      pNode,
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
-                                      dataMap,
-                                      err, tolerant, debug);
+            data = readDenseImpl<GO> (in, proc0Comm, dataMap, err, tolerant, debug);
             (void) dataMap; // Silence "unused" warnings
             if (data.is_null ()) {
               readSuccess = 0;
@@ -5883,16 +5704,7 @@ namespace Tpetra {
         int gblSuccess = 0; // output argument
         std::ostringstream errStrm;
         try {
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-          if (pNode.is_null ()) {
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
-            newMap = rcp (new map_type (INVALID, myGids (), indexBase, comm));
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-          }
-          else {
-            newMap = rcp (new map_type (INVALID, myGids (), indexBase, comm, pNode));
-          }
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
+          newMap = rcp (new map_type (INVALID, myGids (), indexBase, comm));
         }
         catch (std::exception& e) {
           lclSuccess = 0;
@@ -5924,6 +5736,21 @@ namespace Tpetra {
         }
         return newMap;
       }
+
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+      /// \brief Variant of readMap (above) that takes an explicit
+      ///   Node instance.
+      static Teuchos::RCP<const map_type>  TPETRA_DEPRECATED
+      readMap (std::istream& in,
+               const Teuchos::RCP<const comm_type>& comm,
+               const Teuchos::RCP<node_type>& /* pNode */,
+               const Teuchos::RCP<Teuchos::FancyOStream>& err,
+               const bool tolerant=false,
+               const bool debug=false)
+      {
+        return readMap (in, comm, err, tolerant, debug);
+      }
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
 
     private:
 

--- a/packages/tpetra/core/inout/Tpetra_MatrixIO_decl.hpp
+++ b/packages/tpetra/core/inout/Tpetra_MatrixIO_decl.hpp
@@ -79,22 +79,25 @@ namespace Tpetra {
 
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE
     template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+    TPETRA_DEPRECATED
     void
     generateMatrix (const Teuchos::RCP<Teuchos::ParameterList>& plist,
                     const Teuchos::RCP<const Teuchos::Comm<int> > &comm,
                     const Teuchos::RCP<Node> &node,
                     Teuchos::RCP<Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> >& A);
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
 
     template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+    TPETRA_DEPRECATED
     void
     generateMatrix (const Teuchos::RCP<Teuchos::ParameterList>& plist,
                     const Teuchos::RCP<const Teuchos::Comm<int> > &comm,
                     Teuchos::RCP<Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> >& A);
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
 
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE
     template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
     void
+    TPETRA_DEPRECATED
     readHBMatrix (const std::string &filename,
                   const Teuchos::RCP<const Teuchos::Comm<int> > &comm,
                   const Teuchos::RCP<Node> &node,

--- a/packages/tpetra/core/inout/Tpetra_MatrixIO_decl.hpp
+++ b/packages/tpetra/core/inout/Tpetra_MatrixIO_decl.hpp
@@ -77,22 +77,22 @@ namespace Tpetra {
                      Teuchos::ArrayRCP<int> &rowind,
                      Teuchos::ArrayRCP<double> &val);
 
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
     template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
     void
     generateMatrix (const Teuchos::RCP<Teuchos::ParameterList>& plist,
                     const Teuchos::RCP<const Teuchos::Comm<int> > &comm,
                     const Teuchos::RCP<Node> &node,
                     Teuchos::RCP<Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> >& A);
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
 
     template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
     void
     generateMatrix (const Teuchos::RCP<Teuchos::ParameterList>& plist,
                     const Teuchos::RCP<const Teuchos::Comm<int> > &comm,
-                    Teuchos::RCP<Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> >& A)
-    {
-      generateMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> (plist, comm, Teuchos::null, A);
-    }
+                    Teuchos::RCP<Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> >& A);
 
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
     template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
     void
     readHBMatrix (const std::string &filename,
@@ -101,6 +101,7 @@ namespace Tpetra {
                   Teuchos::RCP<Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > &A,
                   Teuchos::RCP<const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> > rowMap = Teuchos::null,
                   const Teuchos::RCP<Teuchos::ParameterList> &params = Teuchos::null);
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
 
     template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
     void
@@ -108,10 +109,7 @@ namespace Tpetra {
                   const Teuchos::RCP<const Teuchos::Comm<int> > &comm,
                   Teuchos::RCP<Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > &A,
                   Teuchos::RCP<const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> > rowMap = Teuchos::null,
-                  const Teuchos::RCP<Teuchos::ParameterList> &params = Teuchos::null)
-    {
-      readHBMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> (filename, comm, Teuchos::null, A, rowMap, params);
-    }
+                  const Teuchos::RCP<Teuchos::ParameterList> &params = Teuchos::null);
 
   } // end of Tpetra::Utils namespace
 } // end of Tpetra namespace

--- a/packages/tpetra/core/inout/Tpetra_MatrixIO_def.hpp
+++ b/packages/tpetra/core/inout/Tpetra_MatrixIO_def.hpp
@@ -55,8 +55,20 @@ template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void
 generateMatrix (const Teuchos::RCP<Teuchos::ParameterList> &plist,
                 const Teuchos::RCP<const Teuchos::Comm<int> > &comm,
+                Teuchos::RCP<Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > &A)
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+{
+  generateMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> (plist, comm, Teuchos::null, A);
+}
+
+template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+TPETRA_DEPRECATED
+void
+generateMatrix (const Teuchos::RCP<Teuchos::ParameterList> &plist,
+                const Teuchos::RCP<const Teuchos::Comm<int> > &comm,
                 const Teuchos::RCP<Node> &node,
                 Teuchos::RCP<Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > &A)
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
 {
   using Teuchos::as;
   typedef Teuchos::ScalarTraits<Scalar> ST;
@@ -73,16 +85,20 @@ generateMatrix (const Teuchos::RCP<Teuchos::ParameterList> &plist,
     const GlobalOrdinal gS2 = gridSize*gridSize;
     const GlobalOrdinal numRows = gS2*gridSize;
     Teuchos::RCP<map_type> rowMap;
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
     if (node.is_null ()) {
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
       rowMap = Teuchos::rcp (new map_type (static_cast<global_size_t> (numRows),
                                            static_cast<GlobalOrdinal> (0),
                                            comm, GloballyDistributed));
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
     }
     else {
       rowMap = Teuchos::rcp (new map_type (static_cast<global_size_t> (numRows),
                                            static_cast<GlobalOrdinal> (0),
                                            comm, GloballyDistributed, node));
     }
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
     A = rcp(new Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>(rowMap,7,Tpetra::StaticProfile));
     // fill matrix, one row at a time
     Teuchos::Array<GlobalOrdinal> neighbors;
@@ -113,15 +129,28 @@ generateMatrix (const Teuchos::RCP<Teuchos::ParameterList> &plist,
   }
 }
 
-
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void
 readHBMatrix (const std::string &filename,
               const Teuchos::RCP<const Teuchos::Comm<int> > &comm,
-              const Teuchos::RCP<Node> &node,
               Teuchos::RCP< Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > &A,
               Teuchos::RCP< const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> > rowMap,
               const Teuchos::RCP<Teuchos::ParameterList> &params)
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+{
+  readHBMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>(filename, comm, Teuchos::null, A, rowMap, params);
+}
+
+template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+TPETRA_DEPRECATED
+void
+readHBMatrix (const std::string &filename,
+              const Teuchos::RCP<const Teuchos::Comm<int> > &comm,
+              const TPETRA_DEPRECATED Teuchos::RCP<Node> &node,
+              Teuchos::RCP< Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > &A,
+              Teuchos::RCP< const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> > rowMap,
+              const Teuchos::RCP<Teuchos::ParameterList> &params)
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
 {
   typedef Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> map_type;
 
@@ -227,16 +256,20 @@ readHBMatrix (const std::string &filename,
   broadcast(*comm,0,&numCols);
   // create map with uniform partitioning
   if (rowMap == Teuchos::null) {
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
     if (node.is_null ()) {
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
       rowMap = Teuchos::rcp (new map_type (static_cast<global_size_t> (numRows),
                                            static_cast<GlobalOrdinal> (0),
                                            comm, GloballyDistributed));
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
     }
     else {
       rowMap = Teuchos::rcp (new map_type (static_cast<global_size_t> (numRows),
                                            static_cast<GlobalOrdinal> (0),
                                            comm, GloballyDistributed, node));
     }
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
   }
   else {
     TEUCHOS_TEST_FOR_EXCEPTION( rowMap->getGlobalNumElements() != (global_size_t)numRows, std::runtime_error,
@@ -271,12 +304,16 @@ readHBMatrix (const std::string &filename,
     domMap = rowMap;
   }
   else {
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
     if (node.is_null ()) {
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
       domMap = createUniformContigMapWithNode<LocalOrdinal,GlobalOrdinal,Node>(numCols,comm);
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
     }
     else {
       domMap = createUniformContigMapWithNode<LocalOrdinal,GlobalOrdinal,Node>(numCols,comm,node);
     }
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
   }
   A = rcp(new Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>(rowMap, myNNZ (), Tpetra::StaticProfile));
   // free this locally, A will keep it allocated as long as it is needed by A (up until allocation of nonzeros)
@@ -311,7 +348,21 @@ readHBMatrix (const std::string &filename,
 // Must be expanded from within the Tpetra::Utils namespace!
 //
 
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+
 #define TPETRA_MATRIXIO_INSTANT(SCALAR,LO,GO,NODE) \
+  template void \
+  readHBMatrix< SCALAR, LO, GO, NODE > (const std::string&, \
+                                        const Teuchos::RCP<const Teuchos::Comm<int> > &, \
+                                        Teuchos::RCP<CrsMatrix< SCALAR, LO, GO, NODE > >&, \
+                                        Teuchos::RCP<const Tpetra::Map< LO, GO, NODE> >, \
+                                        const Teuchos::RCP<Teuchos::ParameterList>& ); \
+  \
+  template void \
+  generateMatrix< SCALAR, LO, GO, NODE> (const Teuchos::RCP<Teuchos::ParameterList>&, \
+                                         const Teuchos::RCP<const Teuchos::Comm<int> > &, \
+                                         Teuchos::RCP<CrsMatrix< SCALAR, LO, GO, NODE > >& ); \
+ \
   template void \
   readHBMatrix< SCALAR, LO, GO, NODE > (const std::string&, \
                                         const Teuchos::RCP<const Teuchos::Comm<int> > &, \
@@ -326,5 +377,22 @@ readHBMatrix (const std::string &filename,
                                          const Teuchos::RCP< NODE > &,\
                                          Teuchos::RCP<CrsMatrix< SCALAR, LO, GO, NODE > >& );
 
+#else // !TPETRA_ENABLE_DEPRECATED_CODE
+
+#define TPETRA_MATRIXIO_INSTANT(SCALAR,LO,GO,NODE) \
+  template void \
+  readHBMatrix< SCALAR, LO, GO, NODE > (const std::string&, \
+                                        const Teuchos::RCP<const Teuchos::Comm<int> > &, \
+                                        Teuchos::RCP<CrsMatrix< SCALAR, LO, GO, NODE > >&, \
+                                        Teuchos::RCP<const Tpetra::Map< LO, GO, NODE> >, \
+                                        const Teuchos::RCP<Teuchos::ParameterList>& ); \
+  \
+  template void \
+  generateMatrix< SCALAR, LO, GO, NODE> (const Teuchos::RCP<Teuchos::ParameterList>&, \
+                                         const Teuchos::RCP<const Teuchos::Comm<int> > &, \
+                                         Teuchos::RCP<CrsMatrix< SCALAR, LO, GO, NODE > >& );
+
+
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
 
 #endif

--- a/packages/tpetra/core/inout/Tpetra_MatrixIO_def.hpp
+++ b/packages/tpetra/core/inout/Tpetra_MatrixIO_def.hpp
@@ -51,12 +51,13 @@
 namespace Tpetra {
 namespace Utils {
 
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+TPETRA_DEPRECATED
 void
 generateMatrix (const Teuchos::RCP<Teuchos::ParameterList> &plist,
                 const Teuchos::RCP<const Teuchos::Comm<int> > &comm,
                 Teuchos::RCP<Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > &A)
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
 {
   generateMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> (plist, comm, Teuchos::null, A);
 }
@@ -66,9 +67,8 @@ TPETRA_DEPRECATED
 void
 generateMatrix (const Teuchos::RCP<Teuchos::ParameterList> &plist,
                 const Teuchos::RCP<const Teuchos::Comm<int> > &comm,
-                const Teuchos::RCP<Node> &node,
+                const Teuchos::RCP<Node> & /* node */,
                 Teuchos::RCP<Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > &A)
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
 {
   using Teuchos::as;
   typedef Teuchos::ScalarTraits<Scalar> ST;
@@ -85,20 +85,9 @@ generateMatrix (const Teuchos::RCP<Teuchos::ParameterList> &plist,
     const GlobalOrdinal gS2 = gridSize*gridSize;
     const GlobalOrdinal numRows = gS2*gridSize;
     Teuchos::RCP<map_type> rowMap;
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-    if (node.is_null ()) {
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
-      rowMap = Teuchos::rcp (new map_type (static_cast<global_size_t> (numRows),
-                                           static_cast<GlobalOrdinal> (0),
-                                           comm, GloballyDistributed));
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-    }
-    else {
-      rowMap = Teuchos::rcp (new map_type (static_cast<global_size_t> (numRows),
-                                           static_cast<GlobalOrdinal> (0),
-                                           comm, GloballyDistributed, node));
-    }
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
+    rowMap = Teuchos::rcp (new map_type (static_cast<global_size_t> (numRows),
+                                         static_cast<GlobalOrdinal> (0),
+                                         comm, GloballyDistributed));
     A = rcp(new Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>(rowMap,7,Tpetra::StaticProfile));
     // fill matrix, one row at a time
     Teuchos::Array<GlobalOrdinal> neighbors;
@@ -128,29 +117,15 @@ generateMatrix (const Teuchos::RCP<Teuchos::ParameterList> &plist,
         "Tpetra::Utils::generateMatrix(): ParameterList specified unsupported ""mat_type"".");
   }
 }
-
-template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-void
-readHBMatrix (const std::string &filename,
-              const Teuchos::RCP<const Teuchos::Comm<int> > &comm,
-              Teuchos::RCP< Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > &A,
-              Teuchos::RCP< const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> > rowMap,
-              const Teuchos::RCP<Teuchos::ParameterList> &params)
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-{
-  readHBMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>(filename, comm, Teuchos::null, A, rowMap, params);
-}
-
-template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-TPETRA_DEPRECATED
-void
-readHBMatrix (const std::string &filename,
-              const Teuchos::RCP<const Teuchos::Comm<int> > &comm,
-              const TPETRA_DEPRECATED Teuchos::RCP<Node> &node,
-              Teuchos::RCP< Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > &A,
-              Teuchos::RCP< const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> > rowMap,
-              const Teuchos::RCP<Teuchos::ParameterList> &params)
 #endif // TPETRA_ENABLE_DEPRECATED_CODE
+
+template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+void
+readHBMatrix (const std::string &filename,
+              const Teuchos::RCP<const Teuchos::Comm<int> > &comm,
+              Teuchos::RCP< Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > &A,
+              Teuchos::RCP< const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> > rowMap,
+              const Teuchos::RCP<Teuchos::ParameterList> &params)
 {
   typedef Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> map_type;
 
@@ -256,20 +231,9 @@ readHBMatrix (const std::string &filename,
   broadcast(*comm,0,&numCols);
   // create map with uniform partitioning
   if (rowMap == Teuchos::null) {
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-    if (node.is_null ()) {
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
-      rowMap = Teuchos::rcp (new map_type (static_cast<global_size_t> (numRows),
-                                           static_cast<GlobalOrdinal> (0),
-                                           comm, GloballyDistributed));
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-    }
-    else {
-      rowMap = Teuchos::rcp (new map_type (static_cast<global_size_t> (numRows),
-                                           static_cast<GlobalOrdinal> (0),
-                                           comm, GloballyDistributed, node));
-    }
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
+    rowMap = Teuchos::rcp (new map_type (static_cast<global_size_t> (numRows),
+                                         static_cast<GlobalOrdinal> (0),
+                                         comm, GloballyDistributed));
   }
   else {
     TEUCHOS_TEST_FOR_EXCEPTION( rowMap->getGlobalNumElements() != (global_size_t)numRows, std::runtime_error,
@@ -304,16 +268,7 @@ readHBMatrix (const std::string &filename,
     domMap = rowMap;
   }
   else {
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-    if (node.is_null ()) {
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
-      domMap = createUniformContigMapWithNode<LocalOrdinal,GlobalOrdinal,Node>(numCols,comm);
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-    }
-    else {
-      domMap = createUniformContigMapWithNode<LocalOrdinal,GlobalOrdinal,Node>(numCols,comm,node);
-    }
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
+    domMap = createUniformContigMapWithNode<LocalOrdinal,GlobalOrdinal,Node>(numCols,comm);
   }
   A = rcp(new Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>(rowMap, myNNZ (), Tpetra::StaticProfile));
   // free this locally, A will keep it allocated as long as it is needed by A (up until allocation of nonzeros)
@@ -339,6 +294,22 @@ readHBMatrix (const std::string &filename,
   rowptrs = Teuchos::null;
   A->fillComplete(domMap,rowMap,params);
 }
+
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+TPETRA_DEPRECATED
+void
+readHBMatrix (const std::string &filename,
+              const Teuchos::RCP<const Teuchos::Comm<int> > &comm,
+              const Teuchos::RCP<Node> &/* node */,
+              Teuchos::RCP< Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > &A,
+              Teuchos::RCP< const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> > rowMap,
+              const Teuchos::RCP<Teuchos::ParameterList> &params)
+{
+  readHBMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>(filename, comm, A, rowMap, params);
+}
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+
 } // namespace Utils
 } // namespace Tpetra
 
@@ -385,12 +356,7 @@ readHBMatrix (const std::string &filename,
                                         const Teuchos::RCP<const Teuchos::Comm<int> > &, \
                                         Teuchos::RCP<CrsMatrix< SCALAR, LO, GO, NODE > >&, \
                                         Teuchos::RCP<const Tpetra::Map< LO, GO, NODE> >, \
-                                        const Teuchos::RCP<Teuchos::ParameterList>& ); \
-  \
-  template void \
-  generateMatrix< SCALAR, LO, GO, NODE> (const Teuchos::RCP<Teuchos::ParameterList>&, \
-                                         const Teuchos::RCP<const Teuchos::Comm<int> > &, \
-                                         Teuchos::RCP<CrsMatrix< SCALAR, LO, GO, NODE > >& );
+                                        const Teuchos::RCP<Teuchos::ParameterList>& ); 
 
 
 #endif // TPETRA_ENABLE_DEPRECATED_CODE

--- a/packages/tpetra/core/src/Tpetra_CrsMatrixMultiplyOp.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrixMultiplyOp.hpp
@@ -235,7 +235,6 @@ namespace Tpetra {
       using Teuchos::rcpFromRef;
       using Teuchos::rcp_const_cast;
       typedef Scalar OS;
-      typedef Map<LocalOrdinal, GlobalOrdinal, Node> map_type;
       typedef Export<LocalOrdinal, GlobalOrdinal, Node> export_type;
       typedef Import<LocalOrdinal, GlobalOrdinal, Node> import_type;
       typedef MultiVector<OS, LocalOrdinal, GlobalOrdinal, Node> OSMV;
@@ -474,7 +473,6 @@ namespace Tpetra {
       using Teuchos::rcpFromRef;
       using Teuchos::rcp_const_cast;
       typedef Scalar OS;
-      typedef Map<LocalOrdinal, GlobalOrdinal, Node> map_type;
       typedef Export<LocalOrdinal, GlobalOrdinal, Node> export_type;
       typedef Import<LocalOrdinal, GlobalOrdinal, Node> import_type;
       typedef MultiVector<OS, LocalOrdinal, GlobalOrdinal, Node> OSMV;
@@ -1007,7 +1005,6 @@ namespace Tpetra {
       using Teuchos::RCP;
       using Teuchos::rcp;
       typedef Import<LocalOrdinal,GlobalOrdinal,Node> import_type;
-      typedef Map<LocalOrdinal,GlobalOrdinal,Node> map_type;
 
       const size_t numVecs = X_domainMap.getNumVectors ();
       RCP<const import_type> importer = matrix_->getGraph ()->getImporter ();
@@ -1072,7 +1069,6 @@ namespace Tpetra {
       using Teuchos::RCP;
       using Teuchos::rcp;
       typedef Export<LocalOrdinal,GlobalOrdinal,Node> export_type;
-      typedef Map<LocalOrdinal,GlobalOrdinal,Node> map_type;
 
       const size_t numVecs = Y_rangeMap.getNumVectors ();
       RCP<const export_type> exporter = matrix_->getGraph ()->getExporter ();

--- a/packages/tpetra/core/src/Tpetra_Import_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Import_def.hpp
@@ -296,8 +296,6 @@ namespace Tpetra {
 
     ArrayView<const GO> sourceGIDs = source->getNodeElementList ();
     ArrayView<const GO> targetGIDs = target->getNodeElementList ();
-    const size_type numSrcGids = sourceGIDs.size ();
-    const size_type numTgtGids = targetGIDs.size ();
 
     Array<GO> tRemoteGIDs;
     if (this->verbose ()) {

--- a/packages/tpetra/core/src/Tpetra_Map_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Map_decl.hpp
@@ -1336,20 +1336,21 @@ namespace Tpetra {
   ///
   /// \param comm [in] The Map's communicator.
   ///
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-  /// \param node [in] The Kokkos Node instance.  If not provided, we
-  ///   will construct an instance for you.
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
   ///
   /// \relatesalso Map
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   Teuchos::RCP<const Map<LocalOrdinal,GlobalOrdinal,Node> >
   createLocalMapWithNode (const size_t numElements,
-                          const Teuchos::RCP<const Teuchos::Comm<int> >& comm
+                          const Teuchos::RCP<const Teuchos::Comm<int> >& comm);
+
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE
-                          , const Teuchos::RCP<Node>& TPETRA_DEPRECATED node = Teuchos::null
+  template <class LocalOrdinal, class GlobalOrdinal, class Node>
+  TPETRA_DEPRECATED
+  Teuchos::RCP<const Map<LocalOrdinal,GlobalOrdinal,Node> >
+  createLocalMapWithNode (const size_t numElements,
+                          const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
+                          const Teuchos::RCP<Node>& node);
 #endif // TPETRA_ENABLE_DEPRECATED_CODE
-                          );
 
   /// \brief Non-member constructor for a uniformly distributed,
   ///   contiguous Map with the default Kokkos Node.
@@ -1372,11 +1373,16 @@ namespace Tpetra {
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   Teuchos::RCP<const Map<LocalOrdinal,GlobalOrdinal,Node> >
   createUniformContigMapWithNode (const global_size_t numElements,
-                                  const Teuchos::RCP<const Teuchos::Comm<int> >& comm
+                                  const Teuchos::RCP<const Teuchos::Comm<int> >& comm);
+
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE
-                                  , const Teuchos::RCP<Node>& TPETRA_DEPRECATED node = Teuchos::null
+  template <class LocalOrdinal, class GlobalOrdinal, class Node>
+  TPETRA_DEPRECATED
+  Teuchos::RCP<const Map<LocalOrdinal,GlobalOrdinal,Node> >
+  createUniformContigMapWithNode (const global_size_t numElements,
+                                  const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
+                                  const Teuchos::RCP<Node>& node);
 #endif // TPETRA_ENABLE_DEPRECATED_CODE
-                                 );
 
   /// \brief Non-member constructor for a (potentially) non-uniformly
   ///   distributed, contiguous Map using the default Kokkos::Device.
@@ -1402,11 +1408,17 @@ namespace Tpetra {
   Teuchos::RCP<const Map<LocalOrdinal,GlobalOrdinal,Node> >
   createContigMapWithNode (const global_size_t numElements,
                            const size_t localNumElements,
-                           const Teuchos::RCP<const Teuchos::Comm<int> >& comm
+                           const Teuchos::RCP<const Teuchos::Comm<int> >& comm);
+
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE
-                           , const Teuchos::RCP<Node>& TPETRA_DEPRECATED node = Teuchos::null
+  template <class LocalOrdinal, class GlobalOrdinal, class Node>
+  TPETRA_DEPRECATED
+  Teuchos::RCP<const Map<LocalOrdinal,GlobalOrdinal,Node> >
+  createContigMapWithNode (const global_size_t numElements,
+                           const size_t localNumElements,
+                           const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
+                           const Teuchos::RCP<Node>& node);
 #endif // TPETRA_ENABLE_DEPRECATED_CODE
-                          );
 
   /// \brief Nonmember constructor for a non-contiguous Map using the
   ///   default Kokkos::Device type.
@@ -1429,11 +1441,15 @@ namespace Tpetra {
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   Teuchos::RCP< const Map<LocalOrdinal,GlobalOrdinal,Node> >
   createNonContigMapWithNode (const Teuchos::ArrayView<const GlobalOrdinal> &elementList,
-                              const Teuchos::RCP<const Teuchos::Comm<int> > &comm
+                              const Teuchos::RCP<const Teuchos::Comm<int> > &comm);
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE
-                              , const Teuchos::RCP<Node>& TPETRA_DEPRECATED node = Teuchos::null
+  template <class LocalOrdinal, class GlobalOrdinal, class Node>
+  TPETRA_DEPRECATED
+  Teuchos::RCP< const Map<LocalOrdinal,GlobalOrdinal,Node> >
+  createNonContigMapWithNode (const Teuchos::ArrayView<const GlobalOrdinal> &elementList,
+                              const Teuchos::RCP<const Teuchos::Comm<int> > &comm,
+                              const Teuchos::RCP<Node>& node);
 #endif // TPETRA_ENABLE_DEPRECATED_CODE
-                             );
 
   /// \brief Nonmember constructor for a contiguous Map with
   ///   user-defined weights and a user-specified, possibly nondefault
@@ -1442,15 +1458,15 @@ namespace Tpetra {
   /// The Map is configured to use zero-based indexing.
   ///
   /// \relatesalso Map
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
+  TPETRA_DEPRECATED
   Teuchos::RCP<const Map<LocalOrdinal, GlobalOrdinal, Node> >
   createWeightedContigMapWithNode (const int thisNodeWeight,
                                    const global_size_t numElements,
-                                   const Teuchos::RCP<const Teuchos::Comm<int> > &comm
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-                                   , const Teuchos::RCP<Node>& TPETRA_DEPRECATED node = Teuchos::null
+                                   const Teuchos::RCP<const Teuchos::Comm<int> > &comm,
+                                   const Teuchos::RCP<Node>& node = Teuchos::null);
 #endif // TPETRA_ENABLE_DEPRECATED_CODE
-                                  );
 
   /// \brief Creates a one-to-one version of the given Map where each
   ///   GID lives on only one process.

--- a/packages/tpetra/core/src/Tpetra_Map_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Map_decl.hpp
@@ -1336,15 +1336,20 @@ namespace Tpetra {
   ///
   /// \param comm [in] The Map's communicator.
   ///
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
   /// \param node [in] The Kokkos Node instance.  If not provided, we
   ///   will construct an instance for you.
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
   ///
   /// \relatesalso Map
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   Teuchos::RCP<const Map<LocalOrdinal,GlobalOrdinal,Node> >
   createLocalMapWithNode (const size_t numElements,
-                          const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
-                          const Teuchos::RCP<Node>& node = Teuchos::null);
+                          const Teuchos::RCP<const Teuchos::Comm<int> >& comm
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                          , const Teuchos::RCP<Node>& TPETRA_DEPRECATED node = Teuchos::null
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+                          );
 
   /// \brief Non-member constructor for a uniformly distributed,
   ///   contiguous Map with the default Kokkos Node.
@@ -1367,8 +1372,11 @@ namespace Tpetra {
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   Teuchos::RCP<const Map<LocalOrdinal,GlobalOrdinal,Node> >
   createUniformContigMapWithNode (const global_size_t numElements,
-                                  const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
-                                  const Teuchos::RCP<Node>& node = Teuchos::null);
+                                  const Teuchos::RCP<const Teuchos::Comm<int> >& comm
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                                  , const Teuchos::RCP<Node>& TPETRA_DEPRECATED node = Teuchos::null
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+                                 );
 
   /// \brief Non-member constructor for a (potentially) non-uniformly
   ///   distributed, contiguous Map using the default Kokkos::Device.
@@ -1394,8 +1402,11 @@ namespace Tpetra {
   Teuchos::RCP<const Map<LocalOrdinal,GlobalOrdinal,Node> >
   createContigMapWithNode (const global_size_t numElements,
                            const size_t localNumElements,
-                           const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
-                           const Teuchos::RCP<Node>& node = Teuchos::null);
+                           const Teuchos::RCP<const Teuchos::Comm<int> >& comm
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                           , const Teuchos::RCP<Node>& TPETRA_DEPRECATED node = Teuchos::null
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+                          );
 
   /// \brief Nonmember constructor for a non-contiguous Map using the
   ///   default Kokkos::Device type.
@@ -1418,8 +1429,11 @@ namespace Tpetra {
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   Teuchos::RCP< const Map<LocalOrdinal,GlobalOrdinal,Node> >
   createNonContigMapWithNode (const Teuchos::ArrayView<const GlobalOrdinal> &elementList,
-                              const Teuchos::RCP<const Teuchos::Comm<int> > &comm,
-                              const Teuchos::RCP<Node>& node = Teuchos::null);
+                              const Teuchos::RCP<const Teuchos::Comm<int> > &comm
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                              , const Teuchos::RCP<Node>& TPETRA_DEPRECATED node = Teuchos::null
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+                             );
 
   /// \brief Nonmember constructor for a contiguous Map with
   ///   user-defined weights and a user-specified, possibly nondefault
@@ -1432,8 +1446,11 @@ namespace Tpetra {
   Teuchos::RCP<const Map<LocalOrdinal, GlobalOrdinal, Node> >
   createWeightedContigMapWithNode (const int thisNodeWeight,
                                    const global_size_t numElements,
-                                   const Teuchos::RCP<const Teuchos::Comm<int> > &comm,
-                                   const Teuchos::RCP<Node>& node = Teuchos::null);
+                                   const Teuchos::RCP<const Teuchos::Comm<int> > &comm
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                                   , const Teuchos::RCP<Node>& TPETRA_DEPRECATED node = Teuchos::null
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+                                  );
 
   /// \brief Creates a one-to-one version of the given Map where each
   ///   GID lives on only one process.

--- a/packages/tpetra/core/src/Tpetra_Map_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Map_def.hpp
@@ -2046,7 +2046,7 @@ TPETRA_DEPRECATED
 Teuchos::RCP< const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> >
 Tpetra::createUniformContigMapWithNode (const global_size_t numElements,
                                         const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
-                                        const Teuchos::RCP<Node>& node
+                                        const Teuchos::RCP<Node>& /* node */
 )
 {
   return Tpetra::createUniformContigMapWithNode<LocalOrdinal,GlobalOrdinal,Node>
@@ -2073,7 +2073,7 @@ TPETRA_DEPRECATED
 Teuchos::RCP< const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> >
 Tpetra::createLocalMapWithNode (const size_t numElements,
                                 const Teuchos::RCP<const Teuchos::Comm<int> >& comm, 
-                                const Teuchos::RCP<Node>& node
+                                const Teuchos::RCP<Node>& /* node */
 )
 {
   return Tpetra::createLocalMapWithNode<LocalOrdinal,GlobalOrdinal,Node>

--- a/packages/tpetra/core/src/Tpetra_Map_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Map_def.hpp
@@ -2043,26 +2043,36 @@ Tpetra::createUniformContigMap (const global_size_t numElements,
 template <class LocalOrdinal, class GlobalOrdinal, class Node>
 Teuchos::RCP< const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> >
 Tpetra::createUniformContigMapWithNode (const global_size_t numElements,
-                                        const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
-                                        const Teuchos::RCP<Node>& node)
+                                        const Teuchos::RCP<const Teuchos::Comm<int> >& comm
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                                        , const Teuchos::RCP<Node>& TPETRA_DEPRECATED node
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+)
 {
   using Teuchos::rcp;
   typedef Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> map_type;
   const GlobalOrdinal indexBase = static_cast<GlobalOrdinal> (0);
 
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
   if (node.is_null ()) {
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
     return rcp (new map_type (numElements, indexBase, comm, GloballyDistributed));
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
   }
   else {
     return rcp (new map_type (numElements, indexBase, comm, GloballyDistributed, node));
   }
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
 }
 
 template <class LocalOrdinal, class GlobalOrdinal, class Node>
 Teuchos::RCP< const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> >
 Tpetra::createLocalMapWithNode (const size_t numElements,
-                                const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
-                                const Teuchos::RCP<Node>& node)
+                                const Teuchos::RCP<const Teuchos::Comm<int> >& comm
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                                , const Teuchos::RCP<Node>& TPETRA_DEPRECATED node
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+)
 {
   using Tpetra::global_size_t;
   using Teuchos::rcp;
@@ -2070,20 +2080,27 @@ Tpetra::createLocalMapWithNode (const size_t numElements,
   const GlobalOrdinal indexBase = static_cast<GlobalOrdinal> (0);
   const global_size_t globalNumElts = static_cast<global_size_t> (numElements);
 
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
   if (node.is_null ()) {
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
     return rcp (new map_type (globalNumElts, indexBase, comm, LocallyReplicated));
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
   }
   else {
     return rcp (new map_type (globalNumElts, indexBase, comm, LocallyReplicated, node));
   }
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
 }
 
 template <class LocalOrdinal, class GlobalOrdinal, class Node>
 Teuchos::RCP< const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> >
 Tpetra::createContigMapWithNode (const Tpetra::global_size_t numElements,
                                  const size_t localNumElements,
-                                 const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
-                                 const Teuchos::RCP<Node>& /* node */)
+                                 const Teuchos::RCP<const Teuchos::Comm<int> >& comm
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                                 , const Teuchos::RCP<Node>& TPETRA_DEPRECATED /* node */
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+)
 {
   using Teuchos::rcp;
   using map_type = Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node>;
@@ -2122,8 +2139,11 @@ Tpetra::createNonContigMap(const Teuchos::ArrayView<const GlobalOrdinal>& elemen
 template <class LocalOrdinal, class GlobalOrdinal, class Node>
 Teuchos::RCP< const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> >
 Tpetra::createNonContigMapWithNode (const Teuchos::ArrayView<const GlobalOrdinal>& elementList,
-                                    const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
-                                    const Teuchos::RCP<Node>& /* node */)
+                                    const Teuchos::RCP<const Teuchos::Comm<int> >& comm
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                                    , const Teuchos::RCP<Node>& TPETRA_DEPRECATED /* node */
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+)
 {
   using Teuchos::rcp;
   using map_type = Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node>;
@@ -2141,8 +2161,11 @@ template <class LocalOrdinal, class GlobalOrdinal, class Node>
 Teuchos::RCP< const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> >
 Tpetra::createWeightedContigMapWithNode (const int myWeight,
                                          const Tpetra::global_size_t numElements,
-                                         const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
-                                         const Teuchos::RCP<Node>& /* node */)
+                                         const Teuchos::RCP<const Teuchos::Comm<int> >& comm
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                                         , const Teuchos::RCP<Node>& TPETRA_DEPRECATED /* node */
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+)
 {
   Teuchos::RCP< Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> > map;
   int sumOfWeights, elemsLeft, localNumElements;
@@ -2291,6 +2314,8 @@ Tpetra::createOneToOne (const Teuchos::RCP<const Tpetra::Map<LocalOrdinal,Global
 //
 
 //! Explicit instantiation macro supporting the Map class. Instantiates the class and the non-member constructors.
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+
 #define TPETRA_MAP_INSTANT(LO,GO,NODE) \
   \
   template class Map< LO , GO , NODE >; \
@@ -2329,6 +2354,42 @@ Tpetra::createOneToOne (const Teuchos::RCP<const Tpetra::Map<LocalOrdinal,Global
   createOneToOne (const Teuchos::RCP<const Map<LO,GO,NODE> >& M, \
                   const Tpetra::Details::TieBreak<LO,GO>& tie_break); \
 
+#else // !TPETRA_ENABLE_DEPRECATED_CODE
+
+#define TPETRA_MAP_INSTANT(LO,GO,NODE) \
+  \
+  template class Map< LO , GO , NODE >; \
+  \
+  template Teuchos::RCP< const Map<LO,GO,NODE> > \
+  createLocalMapWithNode<LO,GO,NODE> (const size_t numElements, \
+                                      const Teuchos::RCP< const Teuchos::Comm< int > >& comm); \
+  \
+  template Teuchos::RCP< const Map<LO,GO,NODE> > \
+  createContigMapWithNode<LO,GO,NODE> (const global_size_t numElements, \
+                                       const size_t localNumElements,   \
+                                       const Teuchos::RCP< const Teuchos::Comm< int > >& comm); \
+  \
+  template Teuchos::RCP< const Map<LO,GO,NODE> > \
+  createNonContigMapWithNode(const Teuchos::ArrayView<const GO> &elementList, \
+                             const Teuchos::RCP<const Teuchos::Comm<int> > &comm); \
+  \
+  template Teuchos::RCP< const Map<LO,GO,NODE> > \
+  createUniformContigMapWithNode<LO,GO,NODE> (const global_size_t numElements, \
+                                              const Teuchos::RCP< const Teuchos::Comm< int > >& comm); \
+  \
+  template Teuchos::RCP< const Map<LO,GO,NODE> > \
+  createWeightedContigMapWithNode<LO,GO,NODE> (const int thisNodeWeight, \
+                                               const global_size_t numElements, \
+                                               const Teuchos::RCP< const Teuchos::Comm< int > >& comm); \
+  \
+  template Teuchos::RCP<const Map<LO,GO,NODE> > \
+  createOneToOne (const Teuchos::RCP<const Map<LO,GO,NODE> >& M); \
+  \
+  template Teuchos::RCP<const Map<LO,GO,NODE> > \
+  createOneToOne (const Teuchos::RCP<const Map<LO,GO,NODE> >& M, \
+                  const Tpetra::Details::TieBreak<LO,GO>& tie_break); \
+
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
 
 //! Explicit instantiation macro supporting the Map class, on the default node for specified ordinals.
 #define TPETRA_MAP_INSTANT_DEFAULTNODE(LO,GO) \

--- a/packages/tpetra/core/src/Tpetra_Map_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Map_def.hpp
@@ -2040,38 +2040,51 @@ Tpetra::createUniformContigMap (const global_size_t numElements,
   return createUniformContigMapWithNode<LO, GO, NT> (numElements, comm);
 }
 
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+template <class LocalOrdinal, class GlobalOrdinal, class Node>
+TPETRA_DEPRECATED
+Teuchos::RCP< const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> >
+Tpetra::createUniformContigMapWithNode (const global_size_t numElements,
+                                        const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
+                                        const Teuchos::RCP<Node>& node
+)
+{
+  return Tpetra::createUniformContigMapWithNode<LocalOrdinal,GlobalOrdinal,Node>
+                 (numElements, comm);
+}
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+
 template <class LocalOrdinal, class GlobalOrdinal, class Node>
 Teuchos::RCP< const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> >
 Tpetra::createUniformContigMapWithNode (const global_size_t numElements,
                                         const Teuchos::RCP<const Teuchos::Comm<int> >& comm
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-                                        , const Teuchos::RCP<Node>& TPETRA_DEPRECATED node
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
 )
 {
   using Teuchos::rcp;
   typedef Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> map_type;
   const GlobalOrdinal indexBase = static_cast<GlobalOrdinal> (0);
 
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-  if (node.is_null ()) {
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
-    return rcp (new map_type (numElements, indexBase, comm, GloballyDistributed));
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-  }
-  else {
-    return rcp (new map_type (numElements, indexBase, comm, GloballyDistributed, node));
-  }
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
+  return rcp (new map_type (numElements, indexBase, comm, GloballyDistributed));
 }
+
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+template <class LocalOrdinal, class GlobalOrdinal, class Node>
+TPETRA_DEPRECATED
+Teuchos::RCP< const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> >
+Tpetra::createLocalMapWithNode (const size_t numElements,
+                                const Teuchos::RCP<const Teuchos::Comm<int> >& comm, 
+                                const Teuchos::RCP<Node>& node
+)
+{
+  return Tpetra::createLocalMapWithNode<LocalOrdinal,GlobalOrdinal,Node>
+                 (numElements, comm);
+}
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
 
 template <class LocalOrdinal, class GlobalOrdinal, class Node>
 Teuchos::RCP< const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> >
 Tpetra::createLocalMapWithNode (const size_t numElements,
                                 const Teuchos::RCP<const Teuchos::Comm<int> >& comm
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-                                , const Teuchos::RCP<Node>& TPETRA_DEPRECATED node
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
 )
 {
   using Tpetra::global_size_t;
@@ -2080,26 +2093,29 @@ Tpetra::createLocalMapWithNode (const size_t numElements,
   const GlobalOrdinal indexBase = static_cast<GlobalOrdinal> (0);
   const global_size_t globalNumElts = static_cast<global_size_t> (numElements);
 
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-  if (node.is_null ()) {
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
-    return rcp (new map_type (globalNumElts, indexBase, comm, LocallyReplicated));
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-  }
-  else {
-    return rcp (new map_type (globalNumElts, indexBase, comm, LocallyReplicated, node));
-  }
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
+  return rcp (new map_type (globalNumElts, indexBase, comm, LocallyReplicated));
 }
+
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+template <class LocalOrdinal, class GlobalOrdinal, class Node>
+TPETRA_DEPRECATED
+Teuchos::RCP< const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> >
+Tpetra::createContigMapWithNode (const Tpetra::global_size_t numElements,
+                                 const size_t localNumElements,
+                                 const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
+                                 const Teuchos::RCP<Node>& /* node */
+)
+{
+  return Tpetra::createContigMapWithNode<LocalOrdinal,GlobalOrdinal,Node>
+                 (numElements, localNumElements, comm);
+}
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
 
 template <class LocalOrdinal, class GlobalOrdinal, class Node>
 Teuchos::RCP< const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> >
 Tpetra::createContigMapWithNode (const Tpetra::global_size_t numElements,
                                  const size_t localNumElements,
                                  const Teuchos::RCP<const Teuchos::Comm<int> >& comm
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-                                 , const Teuchos::RCP<Node>& TPETRA_DEPRECATED /* node */
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
 )
 {
   using Teuchos::rcp;
@@ -2136,13 +2152,24 @@ Tpetra::createNonContigMap(const Teuchos::ArrayView<const GlobalOrdinal>& elemen
 }
 
 
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+template <class LocalOrdinal, class GlobalOrdinal, class Node>
+TPETRA_DEPRECATED
+Teuchos::RCP< const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> >
+Tpetra::createNonContigMapWithNode (const Teuchos::ArrayView<const GlobalOrdinal>& elementList,
+                                    const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
+                                    const Teuchos::RCP<Node>& /* node */
+)
+{
+  return Tpetra::createNonContigMapWithNode<LocalOrdinal,GlobalOrdinal,Node>
+                 (elementList, comm);
+}
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+
 template <class LocalOrdinal, class GlobalOrdinal, class Node>
 Teuchos::RCP< const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> >
 Tpetra::createNonContigMapWithNode (const Teuchos::ArrayView<const GlobalOrdinal>& elementList,
                                     const Teuchos::RCP<const Teuchos::Comm<int> >& comm
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-                                    , const Teuchos::RCP<Node>& TPETRA_DEPRECATED /* node */
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
 )
 {
   using Teuchos::rcp;
@@ -2157,14 +2184,14 @@ Tpetra::createNonContigMapWithNode (const Teuchos::ArrayView<const GlobalOrdinal
   return rcp (new map_type (INV, elementList, indexBase, comm));
 }
 
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
 template <class LocalOrdinal, class GlobalOrdinal, class Node>
+TPETRA_DEPRECATED
 Teuchos::RCP< const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> >
 Tpetra::createWeightedContigMapWithNode (const int myWeight,
                                          const Tpetra::global_size_t numElements,
-                                         const Teuchos::RCP<const Teuchos::Comm<int> >& comm
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-                                         , const Teuchos::RCP<Node>& TPETRA_DEPRECATED /* node */
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
+                                         const Teuchos::RCP<const Teuchos::Comm<int> >& comm,
+                                         const Teuchos::RCP<Node>& /* node */
 )
 {
   Teuchos::RCP< Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> > map;
@@ -2191,6 +2218,7 @@ Tpetra::createWeightedContigMapWithNode (const int myWeight,
   // std::cout << "(after) localNumElements: " << localNumElements << std::endl;
   return createContigMapWithNode<LocalOrdinal,GlobalOrdinal,Node>(numElements,localNumElements,comm);
 }
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
 
 
 template<class LO, class GO, class NT>
@@ -2322,6 +2350,23 @@ Tpetra::createOneToOne (const Teuchos::RCP<const Tpetra::Map<LocalOrdinal,Global
   \
   template Teuchos::RCP< const Map<LO,GO,NODE> > \
   createLocalMapWithNode<LO,GO,NODE> (const size_t numElements, \
+                                      const Teuchos::RCP< const Teuchos::Comm< int > >& comm); \
+  \
+  template Teuchos::RCP< const Map<LO,GO,NODE> > \
+  createContigMapWithNode<LO,GO,NODE> (const global_size_t numElements, \
+                                       const size_t localNumElements,   \
+                                       const Teuchos::RCP< const Teuchos::Comm< int > >& comm); \
+  \
+  template Teuchos::RCP< const Map<LO,GO,NODE> > \
+  createNonContigMapWithNode(const Teuchos::ArrayView<const GO> &elementList, \
+                             const Teuchos::RCP<const Teuchos::Comm<int> > &comm); \
+  \
+  template Teuchos::RCP< const Map<LO,GO,NODE> > \
+  createUniformContigMapWithNode<LO,GO,NODE> (const global_size_t numElements, \
+                                              const Teuchos::RCP< const Teuchos::Comm< int > >& comm); \
+  \
+  template Teuchos::RCP< const Map<LO,GO,NODE> > \
+  createLocalMapWithNode<LO,GO,NODE> (const size_t numElements, \
                                       const Teuchos::RCP< const Teuchos::Comm< int > >& comm, \
                                       const Teuchos::RCP< NODE >& node); \
   \
@@ -2376,11 +2421,6 @@ Tpetra::createOneToOne (const Teuchos::RCP<const Tpetra::Map<LocalOrdinal,Global
   template Teuchos::RCP< const Map<LO,GO,NODE> > \
   createUniformContigMapWithNode<LO,GO,NODE> (const global_size_t numElements, \
                                               const Teuchos::RCP< const Teuchos::Comm< int > >& comm); \
-  \
-  template Teuchos::RCP< const Map<LO,GO,NODE> > \
-  createWeightedContigMapWithNode<LO,GO,NODE> (const int thisNodeWeight, \
-                                               const global_size_t numElements, \
-                                               const Teuchos::RCP< const Teuchos::Comm< int > >& comm); \
   \
   template Teuchos::RCP<const Map<LO,GO,NODE> > \
   createOneToOne (const Teuchos::RCP<const Map<LO,GO,NODE> >& M); \

--- a/packages/tpetra/core/src/Tpetra_MultiVectorFiller.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVectorFiller.hpp
@@ -1608,7 +1608,6 @@ namespace Tpetra {
                            const Teuchos::RCP<Teuchos::FancyOStream>& outStream,
                            const Teuchos::EVerbosityLevel verbLevel)
     {
-      using Tpetra::createContigMapWithNode;
       using Teuchos::FancyOStream;
       using Teuchos::getFancyOStream;
       using Teuchos::oblackholestream;

--- a/packages/tpetra/core/test/BugTests/BugTests.cpp
+++ b/packages/tpetra/core/test/BugTests/BugTests.cpp
@@ -112,12 +112,9 @@ namespace {
     const int myImageID = comm->getRank();
     RCP<const crs_matrix_type> readMatrix, testMatrix;
 
-    // readHBMatrix wants a Node instance, so we need to save it.
-    RCP<map_type::node_type> node;
     {
       // this is what the file looks like: 1 3 4 9
       RCP<const map_type> rng = Tpetra::createUniformContigMap<LO, GO>(1,comm);
-      node = rng->getNode (); // save the Node instance for readHBMatrix
       RCP<const map_type> dom = Tpetra::createUniformContigMap<LO, GO>(4,comm);
       RCP<crs_matrix_type> A = Tpetra::createCrsMatrix<SC, LO, GO>(rng);
       if (myImageID == 0) {
@@ -128,7 +125,7 @@ namespace {
     }
     {
       RCP<crs_matrix_type> A;
-      Tpetra::Utils::readHBMatrix("addA2.hb", comm, node, A);
+      Tpetra::Utils::readHBMatrix("addA2.hb", comm, A);
       readMatrix = A;
     }
     // test that *readMatrix == *testMatrix

--- a/packages/tpetra/core/test/CrsGraph/CrsGraph_UnitTests_Swap.cpp
+++ b/packages/tpetra/core/test/CrsGraph/CrsGraph_UnitTests_Swap.cpp
@@ -242,7 +242,6 @@ class crsGraph_Swap_Tester
         using Teuchos::Comm;
         using Teuchos::RCP;
 
-        using graph_type           = Tpetra::CrsGraph<LocalOrdinal, GlobalOrdinal, Node>;      // Tpetra CrsGraph type
         using map_type             = Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>;           // Tpetra Map type
         using map_rows_type        = std::map<GlobalOrdinal, int>;                   // map rows to pid's
         using vec_go_type          = std::vector<GlobalOrdinal>;                     // vector of GlobalOrdinals

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_LeftRightScale.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_LeftRightScale.cpp
@@ -90,10 +90,7 @@ namespace {
   using Tpetra::RowMatrix;
   using Tpetra::Import;
   using Tpetra::global_size_t;
-  using Tpetra::createNonContigMapWithNode;
   using Tpetra::createUniformContigMapWithNode;
-  using Tpetra::createContigMapWithNode;
-  using Tpetra::createLocalMapWithNode;
   using Tpetra::createVector;
   using Tpetra::createCrsMatrix;
   using Tpetra::ProfileType;

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_NodeConversion.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_NodeConversion.cpp
@@ -74,10 +74,7 @@ namespace {
   using Tpetra::RowMatrix;
   using Tpetra::Import;
   using Tpetra::global_size_t;
-  using Tpetra::createNonContigMapWithNode;
   using Tpetra::createUniformContigMapWithNode;
-  using Tpetra::createContigMapWithNode;
-  using Tpetra::createLocalMapWithNode;
   using Tpetra::createVector;
   using Tpetra::createCrsMatrix;
   using Tpetra::ProfileType;
@@ -121,13 +118,12 @@ namespace {
 
     // These variables exist only to help clone's type deduction.
     // It's OK for them to be null.
-    RCP<N1> n1;
     RCP<N2> n2;
 
     // Create a uniform contiguous distributed Map with numLocal
     // indices on each MPI process.
     RCP<const Map1> map1 =
-      createUniformContigMapWithNode<LO, GO, N1> (numGlobal, comm, n1);
+      createUniformContigMapWithNode<LO, GO, N1> (numGlobal, comm);
     RCP<Mat1> A1 = createCrsMatrix<SCALAR> (map1, 3);
 
     // empty source, not filled

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_NonlocalAfterResume.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_NonlocalAfterResume.cpp
@@ -66,9 +66,7 @@ namespace {
   using Tpetra::Import;
   using Tpetra::global_size_t;
   using Tpetra::createNonContigMapWithNode;
-  using Tpetra::createUniformContigMapWithNode;
   using Tpetra::createContigMapWithNode;
-  using Tpetra::createLocalMapWithNode;
   using Tpetra::createVector;
   using Tpetra::createCrsMatrix;
   using Tpetra::ProfileType;

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_NonlocalSumInto.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_NonlocalSumInto.cpp
@@ -78,7 +78,6 @@
 TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( CrsMatrix, NonlocalSumInto, LocalOrdinalType, GlobalOrdinalType, ScalarType, NodeType )
 {
   using Tpetra::createContigMapWithNode;
-  using Tpetra::createNonContigMapWithNode;
   using Tpetra::global_size_t;
   using Tpetra::Map;
   using Teuchos::Array;

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_NonlocalSumInto_Ignore.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_NonlocalSumInto_Ignore.cpp
@@ -90,7 +90,6 @@
 TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( CrsMatrix, NonlocalSumInto_Ignore, LocalOrdinalType, GlobalOrdinalType, ScalarType, NodeType )
 {
   using Tpetra::createContigMapWithNode;
-  using Tpetra::createNonContigMapWithNode;
   using Tpetra::global_size_t;
   using Tpetra::Map;
   using Teuchos::Array;

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_ReplaceDomainMapAndImporter.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_ReplaceDomainMapAndImporter.cpp
@@ -79,10 +79,7 @@ namespace {
   using Tpetra::RowMatrix;
   using Tpetra::Import;
   using Tpetra::global_size_t;
-  using Tpetra::createNonContigMapWithNode;
-  using Tpetra::createUniformContigMapWithNode;
   using Tpetra::createContigMapWithNode;
-  using Tpetra::createLocalMapWithNode;
   using Tpetra::createVector;
   using Tpetra::createCrsMatrix;
   using Tpetra::ProfileType;

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests2.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests2.cpp
@@ -144,8 +144,6 @@ namespace {
   using Tpetra::RowMatrix;
   using Tpetra::Import;
   using Tpetra::global_size_t;
-  using Tpetra::createNonContigMapWithNode;
-  using Tpetra::createUniformContigMapWithNode;
   using Tpetra::createContigMapWithNode;
   using Tpetra::createLocalMapWithNode;
   using Tpetra::createVector;

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests3.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests3.cpp
@@ -135,8 +135,6 @@ namespace {
   using Tpetra::RowMatrix;
   using Tpetra::Import;
   using Tpetra::global_size_t;
-  using Tpetra::createNonContigMapWithNode;
-  using Tpetra::createUniformContigMapWithNode;
   using Tpetra::createContigMapWithNode;
   using Tpetra::createLocalMapWithNode;
   using Tpetra::createVector;

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests4.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests4.cpp
@@ -139,10 +139,7 @@ namespace {
   using Tpetra::RowMatrix;
   using Tpetra::Import;
   using Tpetra::global_size_t;
-  using Tpetra::createNonContigMapWithNode;
-  using Tpetra::createUniformContigMapWithNode;
   using Tpetra::createContigMapWithNode;
-  using Tpetra::createLocalMapWithNode;
   using Tpetra::createCrsMatrix;
   using Tpetra::ProfileType;
   using Tpetra::StaticProfile;

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests_Swap.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests_Swap.cpp
@@ -311,7 +311,6 @@ class crsMatrix_Swap_Tester
         using Teuchos::Comm;
         using Teuchos::RCP;
 
-        using graph_type           = Tpetra::CrsGraph<LocalOrdinal, GlobalOrdinal, Node>;     // Tpetra CrsGraph type
         using map_type             = Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>;          // Tpetra Map type
         using map_rows_type        = std::map<GlobalOrdinal, int>;                            // map rows to pid's
         using vec_go_type          = std::vector<GlobalOrdinal>;                              // vector of GlobalOrdinals
@@ -474,7 +473,6 @@ class crsMatrix_Swap_Tester
         using vec_go_type          = std::vector<GlobalOrdinal>;                                        // vector of GlobalOrdinals
         using map_row_to_cols_type = std::map<GlobalOrdinal, vec_go_type>;                              // Map rows to columns
 
-        using matrix_type          = Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>;      // Tpetra CrsMatrix type
         using vec_scalar_type      = std::vector<Scalar>;                                               // Vector of Scalars
         using map_row_to_vals_type = std::map<GlobalOrdinal, vec_scalar_type>;
 

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_gaussSeidel.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_gaussSeidel.cpp
@@ -104,7 +104,6 @@ namespace {
 TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( CrsMatrix, gaussSeidelSerial, LocalOrdinalType, GlobalOrdinalType, ScalarType, NodeType )
 {
   using Tpetra::createContigMapWithNode;
-  using Tpetra::createNonContigMapWithNode;
   using Tpetra::createMultiVector;
   using Tpetra::global_size_t;
   using Tpetra::Map;
@@ -579,7 +578,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( CrsMatrix, gaussSeidelSerial, LocalOrdinalTyp
 TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( CrsMatrix, reorderedGaussSeidelSerial, LocalOrdinalType, GlobalOrdinalType, ScalarType, NodeType )
 {
   using Tpetra::createContigMapWithNode;
-  using Tpetra::createNonContigMapWithNode;
   using Tpetra::createMultiVector;
   using Tpetra::global_size_t;
   using Tpetra::Map;

--- a/packages/tpetra/core/test/CrsMatrix/Equilibration.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/Equilibration.cpp
@@ -201,7 +201,6 @@ testCrsMatrixEquality (bool& success,
       out << "lclRow: " << lclRow << endl;
       Teuchos::OSTab tab2 (out);
 
-      using size_type = typename decltype (A_actual_lcl.graph)::size_type;
       out << "Expected values: [";
       for (size_type k = ptr_h[lclRow]; k < ptr_h[lclRow+1]; ++k) {
         out << expected_val_h[k];

--- a/packages/tpetra/core/test/ImportExport/ImportExport_UnitTests.cpp
+++ b/packages/tpetra/core/test/ImportExport/ImportExport_UnitTests.cpp
@@ -88,7 +88,6 @@ namespace {
   using std::ostream_iterator;
   using std::endl;
 
-  using Tpetra::createContigMap;
   using Tpetra::createContigMapWithNode;
 
   // bool testMpi = true;

--- a/packages/tpetra/core/test/ImportExport2/ImportExport2_UnitTests.cpp
+++ b/packages/tpetra/core/test/ImportExport2/ImportExport2_UnitTests.cpp
@@ -2026,7 +2026,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( Import_Util, UnpackAndCombineWithOwningPIDs, 
   RCP<const MapType> MapSource, MapTarget;
 
   const bool debug = ::Tpetra::Details::Behavior::debug ();
-  const bool verbose = ::Tpetra::Details::Behavior::verbose ();
+  verbose = ::Tpetra::Details::Behavior::verbose ();
   std::unique_ptr<std::string> prefix;
   if (verbose) {
     std::ostringstream os;

--- a/packages/tpetra/core/test/Map/Map_UnitTests.cpp
+++ b/packages/tpetra/core/test/Map/Map_UnitTests.cpp
@@ -426,7 +426,7 @@ namespace {
     RCP<N2> n2 (new N2);
 
     // create a contiguous uniform distributed map with numLocal entries per node
-    RCP<const Map1> map1 = createUniformContigMapWithNode<LO, GO, N1> (numGlobal, comm, n1);
+    RCP<const Map1> map1 = createUniformContigMapWithNode<LO, GO, N1> (numGlobal, comm);
     RCP<const Map2> map2 = map1->clone (n2);
     RCP<const Map1> map1b = map2->clone (n1);
     TEST_ASSERT( map1->isCompatible (*map1b) );

--- a/packages/tpetra/core/test/MatrixMatrix/MatrixMatrix_UnitTests.cpp
+++ b/packages/tpetra/core/test/MatrixMatrix/MatrixMatrix_UnitTests.cpp
@@ -1127,9 +1127,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Tpetra_MatMat, range_row_test, SC, LO, GO, NT)
   RCP<Matrix_t > dummy =
     getIdentityMatrix<SC,LO,GO,NT> (newOut, globalNumRows, comm);
 
-  // This is just to fulfill syntax requirements.  It could even be null.
-  RCP<NT> node = dummy->getNode ();
-
 //Create "B"
   Array<GO> myRows = tuple<GO>(
     rank*numRowsPerProc,
@@ -1154,12 +1151,12 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Tpetra_MatMat, range_row_test, SC, LO, GO, NT)
 
   newOut << "Create row, range, and domain Maps of B" << endl;
   RCP<const Map_t > bRowMap =
-    Tpetra::createNonContigMapWithNode<LO,GO,NT>(myRows, comm, node);
+    Tpetra::createNonContigMapWithNode<LO,GO,NT>(myRows, comm);
   RCP<const Map_t > bRangeMap =
-    Tpetra::createNonContigMapWithNode<LO,GO,NT>(rangeElements, comm, node);
+    Tpetra::createNonContigMapWithNode<LO,GO,NT>(rangeElements, comm);
   //We divide by 2 to make the matrix tall and "skinny"
   RCP<const Map_t > bDomainMap =
-    Tpetra::createUniformContigMapWithNode<LO,GO,NT>(globalNumRows/2, comm, node);
+    Tpetra::createUniformContigMapWithNode<LO,GO,NT>(globalNumRows/2, comm);
 
   newOut << "Create identityMatrix" << endl;
   RCP<Matrix_t > identityMatrix =
@@ -1225,9 +1222,9 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Tpetra_MatMat, range_row_test, SC, LO, GO, NT)
   newOut << bTransRangeElements << endl;
 
   RCP<const Map_t > bTransRangeMap =
-    Tpetra::createNonContigMapWithNode<LO,GO,NT>(bTransRangeElements, comm, node);
+    Tpetra::createNonContigMapWithNode<LO,GO,NT>(bTransRangeElements, comm);
   RCP<const Map_t > bTransDomainMap =
-    Tpetra::createUniformContigMapWithNode<LO,GO,NT>(globalNumRows, comm, node);
+    Tpetra::createUniformContigMapWithNode<LO,GO,NT>(globalNumRows, comm);
 
   newOut << "Compute identity * transpose(bTrans)" << endl;
   Tpetra::MatrixMatrix::Multiply(*identity2,false,*bMatrix, true, *bTrans, false);
@@ -1328,10 +1325,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Tpetra_MatMat, ATI_range_row_test, SC, LO, GO,
   RCP<Matrix_t> identityMatrix =
     getIdentityMatrix<SC,LO,GO,NT> (newOut, globalNumRows, comm);
 
-  // NOTE (mfh 05 Jun 2016) This may even be null.  It exists at this
-  // point only for the syntax.
-  RCP<NT> node = identityMatrix->getNode ();
-
   newOut << "Create Maps for matrix aMat" << endl;
   Array<GO> aMyRows = tuple<GO>(
     rank*numRowsPerProc,
@@ -1339,9 +1332,9 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Tpetra_MatMat, ATI_range_row_test, SC, LO, GO,
     rank*numRowsPerProc+2,
     rank*numRowsPerProc+3);
   RCP<const Map_t> aRowMap =
-    Tpetra::createNonContigMapWithNode<LO,GO,NT>(aMyRows, comm, node);
+    Tpetra::createNonContigMapWithNode<LO,GO,NT>(aMyRows, comm);
   RCP<const Map_t> aDomainMap =
-    Tpetra::createUniformContigMapWithNode<LO,GO,NT>(globalNumRows/2, comm, node);
+    Tpetra::createUniformContigMapWithNode<LO,GO,NT>(globalNumRows/2, comm);
   Array<GO> aRangeElements;
   if(rank == 0){
     aRangeElements = tuple<GO>(
@@ -1358,7 +1351,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Tpetra_MatMat, ATI_range_row_test, SC, LO, GO,
       (rank-1)*numRowsPerProc+3);
   }
   RCP<const Map<LO,GO,NT> > aRangeMap =
-    Tpetra::createNonContigMapWithNode<LO,GO,NT>(aRangeElements, comm, node);
+    Tpetra::createNonContigMapWithNode<LO,GO,NT>(aRangeElements, comm);
 
   newOut << "Create matrix aMat" << endl;
   RCP<Matrix_t> aMat =

--- a/packages/tpetra/core/test/MultiVector/MV_reduce_strided.cpp
+++ b/packages/tpetra/core/test/MultiVector/MV_reduce_strided.cpp
@@ -256,8 +256,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( MultiVector, reduce_strided, Scalar, LocalOrd
   MV Z1 (Z0, Teuchos::Copy);
   Z1.reduce ();
   {
-    const SC TWO = STS::one () + STS::one ();
-
     Z1.sync_host ();
     auto Z1_lcl = Z1.getLocalViewHost ();
     bool reduce_expected_result = true;

--- a/packages/tpetra/core/test/PerformanceCGSolve/cg-solve_file.hpp
+++ b/packages/tpetra/core/test/PerformanceCGSolve/cg-solve_file.hpp
@@ -366,7 +366,10 @@ run (int argc, char *argv[])
   if (nsize < 0) {
     typedef Tpetra::MatrixMarket::Reader<crs_matrix_type> reader_type;
     b = reader_type::readVectorFile (filename_vector, map->getComm (),
-                                     map->getNode (), map);
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                                     map->getNode (),
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+                                     map);
   } else {
     typedef Tpetra::Utils::MatrixGenerator<crs_matrix_type> gen_type;
     b = gen_type::generate_miniFE_vector (nsize, map->getComm (),

--- a/packages/tpetra/core/test/PerformanceCGSolve/cg-solve_file.hpp
+++ b/packages/tpetra/core/test/PerformanceCGSolve/cg-solve_file.hpp
@@ -343,7 +343,7 @@ run (int argc, char *argv[])
     A = Tpetra::MatrixMarket::Reader<crs_matrix_type>::readSparseFile (filename, comm);
   }
   else {
-    A = Tpetra::Utils::MatrixGenerator<crs_matrix_type>::generate_miniFE_matrix (nsize, comm, Teuchos::null);
+    A = Tpetra::Utils::MatrixGenerator<crs_matrix_type>::generate_miniFE_matrix (nsize, comm);
   }
 
   if (printMatrix) {
@@ -372,8 +372,11 @@ run (int argc, char *argv[])
                                      map);
   } else {
     typedef Tpetra::Utils::MatrixGenerator<crs_matrix_type> gen_type;
-    b = gen_type::generate_miniFE_vector (nsize, map->getComm (),
-                                          map->getNode ());
+    b = gen_type::generate_miniFE_vector (nsize, map->getComm ()
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                                          , map->getNode ()
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+                                         );
   }
 
   // The vector x on input is the initial guess for the CG solve.

--- a/packages/tpetra/core/test/TpetraUtils_MatrixGenerator.hpp
+++ b/packages/tpetra/core/test/TpetraUtils_MatrixGenerator.hpp
@@ -111,14 +111,20 @@ namespace Tpetra {
 
       static Teuchos::RCP<const map_type>
       makeRangeMap (const Teuchos::RCP<const comm_type>& pComm,
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
                     const Teuchos::RCP<node_type>& pNode,
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
                     const global_ordinal_type numRows)
       {
         using Teuchos::rcp;
         // A conventional, uniformly partitioned, contiguous map.
         return rcp (new map_type (static_cast<global_size_t> (numRows),
                                   static_cast<global_ordinal_type> (0),
-                                  pComm, GloballyDistributed, pNode));
+                                  pComm, GloballyDistributed
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                                  , pNode
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+                                  ));
       }
 
       /// \brief Compute initial row map, or verify an existing one.
@@ -144,7 +150,9 @@ namespace Tpetra {
       ///   typical case is to pass in null here, which is why we call
       ///   this routine "makeRowMap".
       /// \param pComm [in] Global communicator.
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
       /// \param pNode [in] Kokkos Node object.
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
       /// \param numRows [in] Global number of rows in the matrix.  If
       ///   pRowMap is nonnull, used only for error checking.
       ///
@@ -152,7 +160,9 @@ namespace Tpetra {
       static Teuchos::RCP<const map_type>
       makeRowMap (const Teuchos::RCP<const map_type>& pRowMap,
                   const Teuchos::RCP<const comm_type>& pComm,
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
                   const Teuchos::RCP<node_type>& pNode,
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
                   const global_ordinal_type numRows)
       {
         using Teuchos::rcp;
@@ -161,7 +171,11 @@ namespace Tpetra {
         if (pRowMap.is_null()) {
           return rcp (new map_type (static_cast<global_size_t> (numRows),
                                     static_cast<global_ordinal_type> (0),
-                                    pComm, GloballyDistributed, pNode));
+                                    pComm, GloballyDistributed
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                                    , pNode
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+                                   ));
         } else {
           TEUCHOS_TEST_FOR_EXCEPTION(
             ! pRowMap->isDistributed () && pComm->getSize () > 1,
@@ -207,8 +221,11 @@ namespace Tpetra {
           return pRangeMap;
         } else {
           return createUniformContigMapWithNode<LO,GO,NT> (numCols,
-                                                           pRangeMap->getComm (),
-                                                           pRangeMap->getNode ());
+                                                           pRangeMap->getComm ()
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                                                           ,pRangeMap->getNode ()
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+                                                          );
         }
       }
 
@@ -547,13 +564,25 @@ namespace Tpetra {
 
     public:
 
+      static Teuchos::RCP<SparseMatrixType>
+      generate_miniFE_matrix (int nx,
+                              const Teuchos::RCP<const Teuchos::Comm<int> >& pComm,
+                              const bool callFillComplete=true,
+                              const bool debug = false) 
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+      {
+        return generate_miniFE_matrix(nx, pComm, Teuchos::null, callFillComplete, 
+                                      debug);
+      }
 
       static Teuchos::RCP<SparseMatrixType>
+      TPETRA_DEPRECATED
       generate_miniFE_matrix (int nx,
                               const Teuchos::RCP<const Teuchos::Comm<int> >& pComm,
                               const Teuchos::RCP<node_type>& pNode,
                               const bool callFillComplete=true,
                               const bool debug = false)
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
       {
         using Teuchos::ArrayRCP;
         using Teuchos::null;
@@ -582,9 +611,17 @@ namespace Tpetra {
         dims[1] = nrows;
         dims[2] = nnz;
 
-        Teuchos::RCP<const map_type> pRangeMap = makeRangeMap (pComm, pNode, dims[0]);
+        Teuchos::RCP<const map_type> pRangeMap = makeRangeMap (pComm, 
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                                                               pNode,
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+                                                               dims[0]);
         Teuchos::RCP<const map_type> pDomainMap = makeDomainMap (pRangeMap, dims[0], dims[1]);
-        Teuchos::RCP<const map_type> pRowMap = makeRowMap (null, pComm, pNode, dims[0]);
+        Teuchos::RCP<const map_type> pRowMap = makeRowMap (null, pComm,
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                                                           pNode,
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+                                                           dims[0]);
 
         size_t startrow = pRowMap->getMinGlobalIndex();
         size_t endrow = pRowMap->getMaxGlobalIndex()+1;
@@ -724,9 +761,25 @@ namespace Tpetra {
                                             node_type> >
        generate_miniFE_vector(
            int nx,
+           const Teuchos::RCP<const Teuchos::Comm<int> >& pComm
+       ) 
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+       {
+         return generate_miniFE_vector(nx, pComm, Teuchos::null);
+       }
+
+       static Teuchos::RCP<Tpetra::Vector<scalar_type,
+                                            local_ordinal_type,
+                                            global_ordinal_type,
+                                            node_type> >
+       TPETRA_DEPRECATED
+       generate_miniFE_vector(
+           int nx,
            const Teuchos::RCP<const Teuchos::Comm<int> >& pComm,
            const Teuchos::RCP<node_type>& pNode
-           ) {
+       ) 
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+       {
          using Teuchos::ArrayRCP;
          using Teuchos::RCP;
          using Teuchos::Tuple;
@@ -746,7 +799,11 @@ namespace Tpetra {
          const global_size_t numRows = static_cast<global_size_t> (dims[0]);
          // const size_t numCols = static_cast<size_t> (dims[1]);
 
-         RCP<const map_type> map = createUniformContigMapWithNode<LO, GO, NT> (numRows, pComm, pNode);
+         RCP<const map_type> map = createUniformContigMapWithNode<LO, GO, NT> (numRows, pComm
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+         , pNode
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+         );
          int start = map->getMinGlobalIndex();
          int end = map->getMaxGlobalIndex()+1;
 

--- a/packages/tpetra/core/test/Tpetra_TestingUtilities.hpp
+++ b/packages/tpetra/core/test/Tpetra_TestingUtilities.hpp
@@ -59,16 +59,16 @@
 
 #define TPETRA_GLOBAL_SUCCESS_CHECK(out,comm,success)  \
   { \
-    int lclSuccess = success ? 1 : 0; \
-    int gblSuccess = 1; \
-    Teuchos::reduceAll<int, int>(*comm, Teuchos::REDUCE_MIN, lclSuccess, Teuchos::outArg (gblSuccess)); \
-    if (gblSuccess == 1) { \
+    int tgscLclSuccess = success ? 1 : 0; \
+    int tgscGblSuccess = 1; \
+    Teuchos::reduceAll<int, int>(*comm, Teuchos::REDUCE_MIN, tgscLclSuccess, Teuchos::outArg (tgscGblSuccess)); \
+    if (tgscGblSuccess == 1) { \
       out << "Succeeded on all processes!" << endl; \
     } else { \
       out << "FAILED on at least one process!" << endl; \
     } \
-    TEST_EQUALITY_CONST(gblSuccess, 1);  \
-    success = (bool) gblSuccess; \
+    TEST_EQUALITY_CONST(tgscGblSuccess, 1);  \
+    success = (bool) tgscGblSuccess; \
   }
 
 

--- a/packages/tpetra/core/test/inout/Bug5800.cpp
+++ b/packages/tpetra/core/test/inout/Bug5800.cpp
@@ -181,7 +181,11 @@ namespace {
       // map needs to be a nonconst RCP to const MapType, because
       // readDense would set map to a computed Map on output if if
       // were null on input.
-      return reader_type::readDense (in, map->getComm (), map->getNode (), map);
+      return reader_type::readDense (in, map->getComm (),
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                                     map->getNode (),
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+                                     map);
     }
 
     // Ensure that X and Y have the same dimensions, and that the

--- a/packages/tpetra/core/test/inout/Bug6288.cpp
+++ b/packages/tpetra/core/test/inout/Bug6288.cpp
@@ -117,9 +117,16 @@ testImpl (Teuchos::FancyOStream& out,
 
   std::istringstream mapInFile (mapOutFile.str ());
   RCP<const map_type> readMap =
-    reader_type::readMap (mapInFile, comm, origMap->getNode (), false, false);
+    reader_type::readMap (mapInFile, comm,
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                          origMap->getNode (), 
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+                          false, false);
   std::istringstream mvInFile (mvOutFile.str ());
-  RCP<MV> read_mv = reader_type::readDense (mvInFile, comm, origMap->getNode (),
+  RCP<MV> read_mv = reader_type::readDense (mvInFile, comm, 
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+                                            origMap->getNode (),
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
                                             readMap, false, false);
 
   out << "Write MultiVector again" << endl;

--- a/packages/xpetra/sup/Utils/Xpetra_IO.hpp
+++ b/packages/xpetra/sup/Utils/Xpetra_IO.hpp
@@ -405,12 +405,9 @@ namespace Xpetra {
 
           typedef Tpetra::MatrixMarket::Reader<sparse_matrix_type> reader_type;
 
-          //RCP<Node> node = Xpetra::DefaultPlatform::getDefaultPlatform().getNode();
-          Teuchos::ParameterList pl = Teuchos::ParameterList();
-          RCP<Node> node = rcp(new Node(pl));
           bool callFillComplete = true;
 
-          RCP<sparse_matrix_type> tA = reader_type::readSparseFile(fileName, comm, node, callFillComplete);
+          RCP<sparse_matrix_type> tA = reader_type::readSparseFile(fileName, comm, callFillComplete);
 
           if (tA.is_null())
             throw Exceptions::RuntimeError("The Tpetra::CrsMatrix returned from readSparseFile() is null.");
@@ -611,7 +608,7 @@ namespace Xpetra {
         typedef Tpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>            multivector_type;
 
         RCP<const map_type>   temp = toTpetra(map);
-        RCP<multivector_type> TMV  = reader_type::readDenseFile(fileName,map->getComm(),map->getNode(),temp);
+        RCP<multivector_type> TMV  = reader_type::readDenseFile(fileName,map->getComm(),temp);
         RCP<MultiVector>      rmv  = Xpetra::toXpetra(TMV);
         return rmv;
 #else
@@ -632,9 +629,7 @@ namespace Xpetra {
         typedef Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> sparse_matrix_type;
         typedef Tpetra::MatrixMarket::Reader<sparse_matrix_type>                          reader_type;
 
-        RCP<Node> node = rcp(new Node());
-
-        RCP<const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> > tMap = reader_type::readMapFile(fileName, comm, node);
+        RCP<const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> > tMap = reader_type::readMapFile(fileName, comm);
         if (tMap.is_null())
           throw Exceptions::RuntimeError("The Tpetra::Map returned from readSparseFile() is null.");
 
@@ -989,12 +984,9 @@ namespace Xpetra {
 
           typedef Tpetra::MatrixMarket::Reader<sparse_matrix_type> reader_type;
 
-          //RCP<Node> node = Xpetra::DefaultPlatform::getDefaultPlatform().getNode();
-          Teuchos::ParameterList pl = Teuchos::ParameterList();
-          RCP<Node> node = rcp(new Node(pl));
           bool callFillComplete = true;
 
-          RCP<sparse_matrix_type> tA = reader_type::readSparseFile(fileName, comm, node, callFillComplete);
+          RCP<sparse_matrix_type> tA = reader_type::readSparseFile(fileName, comm, callFillComplete);
 
           if (tA.is_null())
             throw Exceptions::RuntimeError("The Tpetra::CrsMatrix returned from readSparseFile() is null.");
@@ -1212,7 +1204,7 @@ namespace Xpetra {
         typedef Tpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>            multivector_type;
 
         RCP<const map_type>   temp = toTpetra(map);
-        RCP<multivector_type> TMV  = reader_type::readDenseFile(fileName,map->getComm(),map->getNode(),temp);
+        RCP<multivector_type> TMV  = reader_type::readDenseFile(fileName,map->getComm(),temp);
         RCP<Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> >      rmv  = Xpetra::toXpetra(TMV);
         return rmv;
 # endif
@@ -1252,9 +1244,7 @@ namespace Xpetra {
         typedef Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> sparse_matrix_type;
         typedef Tpetra::MatrixMarket::Reader<sparse_matrix_type>                          reader_type;
 
-        RCP<Node> node = rcp(new Node());
-
-        RCP<const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> > tMap = reader_type::readMapFile(fileName, comm, node);
+        RCP<const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> > tMap = reader_type::readMapFile(fileName, comm);
         if (tMap.is_null())
           throw Exceptions::RuntimeError("The Tpetra::Map returned from readSparseFile() is null.");
 

--- a/packages/xpetra/test/MatrixMatrix/MatrixMatrix_UnitTests.cpp
+++ b/packages/xpetra/test/MatrixMatrix/MatrixMatrix_UnitTests.cpp
@@ -394,18 +394,15 @@ namespace {
       LO nEle = 6;
       const RCP<const MapClass> map = MapFactoryClass::Build(lib, nEle, 0, comm);
 
-      // get node
-      Teuchos::RCP<Node> pNode = map->getNode();
-
       // read in matrices
       typedef Tpetra::MatrixMarket::Reader<Tpetra::CrsMatrix<Scalar, LO, GO, Node> > reader_type;
 
-      Teuchos::RCP<Tpetra::CrsMatrix<Scalar,LO,GO,Node> > tpA = reader_type::readSparseFile("A.mat",comm,pNode );
-      Teuchos::RCP<Tpetra::CrsMatrix<Scalar,LO,GO,Node> > tpB = reader_type::readSparseFile("B.mat",comm,pNode );
-      Teuchos::RCP<Tpetra::CrsMatrix<Scalar,LO,GO,Node> > tpAB = reader_type::readSparseFile("AB.mat",comm,pNode );
-      Teuchos::RCP<Tpetra::CrsMatrix<Scalar,LO,GO,Node> > tpAtB = reader_type::readSparseFile("AtB.mat",comm,pNode );
-      Teuchos::RCP<Tpetra::CrsMatrix<Scalar,LO,GO,Node> > tpABt = reader_type::readSparseFile("ABt.mat",comm,pNode );
-      Teuchos::RCP<Tpetra::CrsMatrix<Scalar,LO,GO,Node> > tpAtBt = reader_type::readSparseFile("AtBt.mat",comm,pNode );
+      Teuchos::RCP<Tpetra::CrsMatrix<Scalar,LO,GO,Node> > tpA = reader_type::readSparseFile("A.mat",comm);
+      Teuchos::RCP<Tpetra::CrsMatrix<Scalar,LO,GO,Node> > tpB = reader_type::readSparseFile("B.mat",comm);
+      Teuchos::RCP<Tpetra::CrsMatrix<Scalar,LO,GO,Node> > tpAB = reader_type::readSparseFile("AB.mat",comm);
+      Teuchos::RCP<Tpetra::CrsMatrix<Scalar,LO,GO,Node> > tpAtB = reader_type::readSparseFile("AtB.mat",comm);
+      Teuchos::RCP<Tpetra::CrsMatrix<Scalar,LO,GO,Node> > tpABt = reader_type::readSparseFile("ABt.mat",comm);
+      Teuchos::RCP<Tpetra::CrsMatrix<Scalar,LO,GO,Node> > tpAtBt = reader_type::readSparseFile("AtBt.mat",comm);
 
       // transform to Xpetra
       Teuchos::RCP<CrsMatrixClass> xAmat = Teuchos::rcp(new MA(tpA));


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra

## Description
We are deprecating use of Node as an argument to functions.
These commits deprecate node arguments in readSparse*, readHBMatrix, generateMatrix, create*MapWithNode, and generate_miniFE_*.  Tests calling these functions have been updated.

More work remains to be done, but getting it all into one PR may be onerous.  I'd like to see how these changes do in PR testing.  Then I can add other work to this PR, or create a phase-two PR.
## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
Users should not create Node instances.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->
Tested with and without TPETRA_ENABLE_DEPRECATE_NODE on mac with clang.
Tested with Tpetra build and MueLu build with all optional dependencies on.
10 tests (of 287) fail in all builds:
         37 - Belos_gcrodr_hb_MPI_4 (Failed)
         66 - Belos_BlockGmresPoly_Epetra_File_Ex_0_MPI_4 (Failed)
         67 - Belos_BlockGmresPoly_Epetra_File_Ex_1_MPI_4 (Failed)
         85 - Belos_CustomSolverFactory_MPI_4 (Failed)
        175 - MueLu_MasterList_MPI_1 (Failed)
        201 - MueLu_UnitTestsBlockedTpetra_MPI_1 (Failed)
        226 - MueLu_CreateOperatorEpetra_MPI_1 (Failed)
        227 - MueLu_CreateOperatorEpetra_MPI_4 (Failed)
        232 - MueLu_CreateOperatorTpetra_MPI_1 (Failed)
        233 - MueLu_CreateOperatorTpetra_MPI_4 (Failed)

<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [ x] My code follows the code style of the affected package(s).
- [ x] My change requires a change to the documentation.  
- [x ] I have updated the documentation accordingly. (DOXYGEN IN ifdef BLOCKS, TOO)
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.  (SEE 10 TESTS ABOVE)
- [ ] No new compiler warnings were introduced.  (MANY DEPRECATION WARNINGS INTRODUCED)
- [ x] These changes break backwards compatibility. (THAT'S THE POINT)

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
