### PR TITLE
Xpetra:  Remove Unused Parameter Warnings

### DIFF
--- a/packages/xpetra/src/BlockedCrsMatrix/Xpetra_BlockReorderManager.hpp
+++ b/packages/xpetra/src/BlockedCrsMatrix/Xpetra_BlockReorderManager.hpp
@@ -165,13 +165,13 @@ public:
   }
 
   virtual size_t GetNumBlocks() const { return 0; }
-  virtual void SetNumBlocks(size_t sz) {}
-  virtual void SetBlock(int blockIndex, int reorder) { }
-  virtual void SetBlock(int blockIndex, const Teuchos::RCP<BlockReorderManager> & reorder) {}
-  virtual const Teuchos::RCP<BlockReorderManager> GetBlock(int blockIndex) {
+  virtual void SetNumBlocks(size_t /* sz */) {}
+  virtual void SetBlock(int /* blockIndex */, int /* reorder */) { }
+  virtual void SetBlock(int /* blockIndex */, const Teuchos::RCP<BlockReorderManager> & /* reorder */) {}
+  virtual const Teuchos::RCP<BlockReorderManager> GetBlock(int /* blockIndex */) {
     return Teuchos::null;
   }
-  virtual const Teuchos::RCP<const BlockReorderManager> GetBlock(int blockIndex)const {
+  virtual const Teuchos::RCP<const BlockReorderManager> GetBlock(int /* blockIndex */)const {
     return Teuchos::null;
   }
   //! Get the index that is stored in this block/leaf

--- a/packages/xpetra/src/BlockedCrsMatrix/Xpetra_BlockedCrsMatrix.hpp
+++ b/packages/xpetra/src/BlockedCrsMatrix/Xpetra_BlockedCrsMatrix.hpp
@@ -171,7 +171,7 @@ namespace Xpetra {
      * \param npr extimated number of entries per row in each block(!)
      * \param pftype Xpetra profile type
      */
-    BlockedCrsMatrix(const Teuchos::RCP<const Thyra::BlockedLinearOpBase<Scalar> >& thyraOp, const Teuchos::RCP<const Teuchos::Comm<int> >& comm)
+    BlockedCrsMatrix(const Teuchos::RCP<const Thyra::BlockedLinearOpBase<Scalar> >& thyraOp, const Teuchos::RCP<const Teuchos::Comm<int> >& /* comm */)
       : is_diagonal_(true), thyraOp_(thyraOp)
     {
       // extract information from Thyra blocked operator and rebuilt information

--- a/packages/xpetra/src/BlockedMap/Xpetra_BlockedMap.hpp
+++ b/packages/xpetra/src/BlockedMap/Xpetra_BlockedMap.hpp
@@ -281,13 +281,13 @@ namespace Xpetra {
     virtual GlobalOrdinal getGlobalElement(LocalOrdinal localIndex) const { return fullmap_->getGlobalElement(localIndex); };
 
     //! Return the process ranks and corresponding local indices for the given global indices.
-    virtual LookupStatus getRemoteIndexList(const Teuchos::ArrayView< const GlobalOrdinal > &GIDList, const Teuchos::ArrayView< int > &nodeIDList, const Teuchos::ArrayView< LocalOrdinal > &LIDList) const {
+    virtual LookupStatus getRemoteIndexList(const Teuchos::ArrayView< const GlobalOrdinal > &/* GIDList */, const Teuchos::ArrayView< int > &/* nodeIDList */, const Teuchos::ArrayView< LocalOrdinal > &/* LIDList */) const {
       throw Xpetra::Exceptions::RuntimeError("BlockedMap::getRemoteIndexList: routine not implemented.");
       TEUCHOS_UNREACHABLE_RETURN(IDNotPresent);
     };
 
     //! Return the process ranks for the given global indices.
-    virtual LookupStatus getRemoteIndexList(const Teuchos::ArrayView< const GlobalOrdinal > &GIDList, const Teuchos::ArrayView< int > &nodeIDList) const {
+    virtual LookupStatus getRemoteIndexList(const Teuchos::ArrayView< const GlobalOrdinal > &/* GIDList */, const Teuchos::ArrayView< int > &/* nodeIDList */) const {
       throw Xpetra::Exceptions::RuntimeError("BlockedMap::getRemoteIndexList: routine not implemented.");
       TEUCHOS_UNREACHABLE_RETURN(IDNotPresent);
     };
@@ -415,7 +415,7 @@ namespace Xpetra {
 
 
     //! Replace this Map's communicator with a subset communicator.
-    virtual RCP< const Xpetra::Map< LocalOrdinal, GlobalOrdinal, Node > > replaceCommWithSubset(const Teuchos::RCP< const Teuchos::Comm< int > > &newComm) const {
+    virtual RCP< const Xpetra::Map< LocalOrdinal, GlobalOrdinal, Node > > replaceCommWithSubset(const Teuchos::RCP< const Teuchos::Comm< int > > &/* newComm */) const {
       throw Xpetra::Exceptions::RuntimeError("BlockedMap::replaceCommWithSubset: routine not implemented.");
     }
 

--- a/packages/xpetra/src/BlockedMultiVector/Xpetra_BlockedMultiVector.hpp
+++ b/packages/xpetra/src/BlockedMultiVector/Xpetra_BlockedMultiVector.hpp
@@ -269,22 +269,22 @@ namespace Xpetra {
     //@{
 
     //! Replace value, using global (row) index.
-    virtual void replaceGlobalValue(GlobalOrdinal globalRow, size_t vectorIndex, const Scalar &value) {
+    virtual void replaceGlobalValue(GlobalOrdinal /* globalRow */, size_t /* vectorIndex */, const Scalar &/* value */) {
       throw Xpetra::Exceptions::RuntimeError("BlockedMultiVector::replaceGlobalValue: Not (yet) supported by BlockedMultiVector.");
     }
 
     //! Add value to existing value, using global (row) index.
-    virtual void sumIntoGlobalValue(GlobalOrdinal globalRow, size_t vectorIndex, const Scalar &value) {
+    virtual void sumIntoGlobalValue(GlobalOrdinal /* globalRow */, size_t /* vectorIndex */, const Scalar &/* value */) {
       throw Xpetra::Exceptions::RuntimeError("BlockedMultiVector::sumIntoGlobalValue: Not (yet) supported by BlockedMultiVector.");
     }
 
     //! Replace value, using local (row) index.
-    virtual void replaceLocalValue(LocalOrdinal myRow, size_t vectorIndex, const Scalar &value) {
+    virtual void replaceLocalValue(LocalOrdinal /* myRow */, size_t /* vectorIndex */, const Scalar &/* value */) {
       throw Xpetra::Exceptions::RuntimeError("BlockedMultiVector::replaceLocalValue: Not supported by BlockedMultiVector.");
     }
 
     //! Add value to existing value, using local (row) index.
-    virtual void sumIntoLocalValue(LocalOrdinal myRow, size_t vectorIndex, const Scalar &value) {
+    virtual void sumIntoLocalValue(LocalOrdinal /* myRow */, size_t /* vectorIndex */, const Scalar &/* value */) {
       throw Xpetra::Exceptions::RuntimeError("BlockedMultiVector::sumIntoLocalValue:Not (yet) supported by BlockedMultiVector.");
     }
 
@@ -345,17 +345,17 @@ namespace Xpetra {
     //@{
 
     //! Compute dot product of each corresponding pair of vectors, dots[i] = this[i].dot(A[i]).
-    virtual void dot(const MultiVector&A, const Teuchos::ArrayView< Scalar > &dots) const {
+    virtual void dot(const MultiVector&/* A */, const Teuchos::ArrayView< Scalar > &/* dots */) const {
       throw Xpetra::Exceptions::RuntimeError("BlockedMultiVector::dot: Not (yet) supported by BlockedMultiVector.");
     }
 
     //! Put element-wise absolute values of input Multi-vector in target: A = abs(this).
-    virtual void abs(const MultiVector&A) {
+    virtual void abs(const MultiVector&/* A */) {
       throw Xpetra::Exceptions::RuntimeError("BlockedMultiVector::abs: Not (yet) supported by BlockedMultiVector.");
     }
 
     //! Put element-wise reciprocal values of input Multi-vector in target, this(i,j) = 1/A(i,j).
-    virtual void reciprocal(const MultiVector&A) {
+    virtual void reciprocal(const MultiVector&/* A */) {
       throw Xpetra::Exceptions::RuntimeError("BlockedMultiVector::reciprocal: Not (yet) supported by BlockedMultiVector.");
     }
 
@@ -516,12 +516,12 @@ namespace Xpetra {
     }
 
     //! Compute mean (average) value of each vector in multi-vector. The outcome of this routine is undefined for non-floating point scalar types (e.g., int).
-    virtual void meanValue(const Teuchos::ArrayView< Scalar > &means) const {
+    virtual void meanValue(const Teuchos::ArrayView< Scalar > &/* means */) const {
       throw Xpetra::Exceptions::RuntimeError("BlockedMultiVector::meanValue: Not (yet) supported by BlockedMultiVector.");
     }
 
     //! Matrix-matrix multiplication: this = beta*this + alpha*op(A)*op(B).
-    virtual void multiply(Teuchos::ETransp transA, Teuchos::ETransp transB, const Scalar &alpha, const MultiVector&A, const MultiVector&B, const Scalar &beta) {
+    virtual void multiply(Teuchos::ETransp /* transA */, Teuchos::ETransp /* transB */, const Scalar &/* alpha */, const MultiVector&/* A */, const MultiVector&/* B */, const Scalar &/* beta */) {
       throw Xpetra::Exceptions::RuntimeError("BlockedMultiVector::multiply: Not (yet) supported by BlockedMultiVector.");
     }
 
@@ -636,22 +636,22 @@ namespace Xpetra {
     }
 
     //! Import.
-    virtual void doImport(const DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node> &source, const Import& importer, CombineMode CM) {
+    virtual void doImport(const DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node> &/* source */, const Import& /* importer */, CombineMode /* CM */) {
       throw Xpetra::Exceptions::RuntimeError("BlockedMultiVector::doImport: Not supported by BlockedMultiVector.");
     }
 
     //! Export.
-    virtual void doExport(const DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node> &dest, const Import& importer, CombineMode CM) {
+    virtual void doExport(const DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node> &/* dest */, const Import& /* importer */, CombineMode /* CM */) {
       throw Xpetra::Exceptions::RuntimeError("BlockedMultiVector::doExport: Not supported by BlockedMultiVector.");
     }
 
     //! Import (using an Exporter).
-    virtual void doImport(const DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node> &source, const Export& exporter, CombineMode CM) {
+    virtual void doImport(const DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node> &/* source */, const Export& /* exporter */, CombineMode /* CM */) {
       throw Xpetra::Exceptions::RuntimeError("BlockedMultiVector::doImport: Not supported by BlockedMultiVector.");
     }
 
     //! Export (using an Importer).
-    virtual void doExport(const DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node> &dest, const Export& exporter, CombineMode CM) {
+    virtual void doExport(const DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node> &/* dest */, const Export& /* exporter */, CombineMode /* CM */) {
       throw Xpetra::Exceptions::RuntimeError("BlockedMultiVector::doExport: Not supported by BlockedMultiVector.");
     }
 
@@ -742,6 +742,7 @@ namespace Xpetra {
       XPETRA_MONITOR("BlockedMultiVector::getMultiVector(r,bThyraMode)");
       TEUCHOS_TEST_FOR_EXCEPTION(r > map_->getNumMaps(), std::out_of_range, "Error, r = " << r << " is too big. The BlockedMultiVector only contains " << map_->getNumMaps() << " partial blocks.");
       XPETRA_TEST_FOR_EXCEPTION(map_->getThyraMode() != bThyraMode, Xpetra::Exceptions::RuntimeError, "BlockedMultiVector::getMultiVector: inconsistent Thyra mode");
+      (void)bThyraMode; // avoid unused parameter warning when HAVE_XPETRA_DEBUG isn't defined
       return vv_[r];
     }
 
@@ -755,6 +756,7 @@ namespace Xpetra {
       XPETRA_TEST_FOR_EXCEPTION(r >= map_->getNumMaps(), std::out_of_range, "Error, r = " << r << " is too big. The BlockedMultiVector only contains " << map_->getNumMaps() << " partial blocks.");
       XPETRA_TEST_FOR_EXCEPTION(numVectors_ != v->getNumVectors(),Xpetra::Exceptions::RuntimeError,"The BlockedMultiVectors expects " << getNumVectors() << " vectors. The provided partial multivector has " << v->getNumVectors() << " vectors.");
       XPETRA_TEST_FOR_EXCEPTION(map_->getThyraMode() != bThyraMode, Xpetra::Exceptions::RuntimeError, "BlockedMultiVector::setMultiVector: inconsistent Thyra mode");
+      (void)bThyraMode; // avoid unused parameter warning when HAVE_XPETRA_DEBUG isn't defined
       Teuchos::RCP<MultiVector> vv = Teuchos::rcp_const_cast<MultiVector>(v);
       TEUCHOS_TEST_FOR_EXCEPTION(vv==Teuchos::null, Xpetra::Exceptions::RuntimeError, "Partial vector must not be Teuchos::null");
       vv_[r] = vv;

--- a/packages/xpetra/src/BlockedVector/Xpetra_BlockedVector.hpp
+++ b/packages/xpetra/src/BlockedVector/Xpetra_BlockedVector.hpp
@@ -355,7 +355,7 @@ namespace Xpetra {
     }
 
     //! Compute mean (average) value of each vector in vector. The outcome of this routine is undefined for non-floating point scalar types (e.g., int).
-    virtual void meanValue(const Teuchos::ArrayView< Scalar > &means) const {
+    virtual void meanValue(const Teuchos::ArrayView< Scalar > &/* means */) const {
       throw Xpetra::Exceptions::RuntimeError("BlockedVector::meanValue: Not (yet) supported by BlockedVector.");
     }
 
@@ -364,21 +364,21 @@ namespace Xpetra {
     }
 
     //! Matrix-matrix multiplication: this = beta*this + alpha*op(A)*op(B).
-    virtual void multiply(Teuchos::ETransp transA, Teuchos::ETransp transB, const Scalar &alpha, const Vector&A, const Vector&B, const Scalar &beta) {
+    virtual void multiply(Teuchos::ETransp /* transA */, Teuchos::ETransp /* transB */, const Scalar &/* alpha */, const Vector&/* A */, const Vector&/* B */, const Scalar &/* beta */) {
       throw Xpetra::Exceptions::RuntimeError("BlockedVector::multiply: Not (yet) supported by BlockedVector.");
     }
 
-    virtual void multiply(Teuchos::ETransp transA, Teuchos::ETransp transB, const Scalar &alpha, const MultiVector&A, const MultiVector&B, const Scalar &beta) {
+    virtual void multiply(Teuchos::ETransp /* transA */, Teuchos::ETransp /* transB */, const Scalar &/* alpha */, const MultiVector&/* A */, const MultiVector&/* B */, const Scalar &/* beta */) {
       throw Xpetra::Exceptions::RuntimeError("BlockedVector::multiply: Not (yet) supported by BlockedVector.");
     }
 
 
-    virtual void elementWiseMultiply(Scalar scalarAB, const Xpetra::Vector<Scalar,LocalOrdinal,GlobalOrdinal,Node>&A, const MultiVector&B, Scalar scalarThis) {
+    virtual void elementWiseMultiply(Scalar /* scalarAB */, const Xpetra::Vector<Scalar,LocalOrdinal,GlobalOrdinal,Node>&/* A */, const MultiVector&/* B */, Scalar /* scalarThis */) {
       throw Xpetra::Exceptions::RuntimeError("BlockedVector::elementWiseMultiply: Not (yet) supported by BlockedVector.");
     }
 
     //! Element-wise multiply of a Vector A with a Vector B.
-    virtual void elementWiseMultiply(Scalar scalarAB, const Xpetra::Vector<Scalar,LocalOrdinal,GlobalOrdinal,Node>&A, const Vector&B, Scalar scalarThis) {
+    virtual void elementWiseMultiply(Scalar /* scalarAB */, const Xpetra::Vector<Scalar,LocalOrdinal,GlobalOrdinal,Node>&A, const Vector&B, Scalar /* scalarThis */) {
       XPETRA_TEST_FOR_EXCEPTION(B.getMap()->isSameAs(*(this->getMap()))==false, Xpetra::Exceptions::RuntimeError, "BlockedVector::elementWiseMultipy: B must have same blocked map than this.");
       TEUCHOS_TEST_FOR_EXCEPTION(A.getMap()->getNodeNumElements() != B.getMap()->getNodeNumElements(), Xpetra::Exceptions::RuntimeError, "BlockedVector::elementWiseMultipy: A has " << A.getMap()->getNodeNumElements() << " elements, B has " << B.getMap()->getNodeNumElements() << ".");
       TEUCHOS_TEST_FOR_EXCEPTION(A.getMap()->getGlobalNumElements() != B.getMap()->getGlobalNumElements(), Xpetra::Exceptions::RuntimeError, "BlockedVector::elementWiseMultipy: A has " << A.getMap()->getGlobalNumElements() << " elements, B has " << B.getMap()->getGlobalNumElements() << ".");
@@ -422,7 +422,7 @@ namespace Xpetra {
     }
 
     //! Local number of rows on the calling process.
-    virtual bool isSameSize(const Xpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> & vec) const {
+    virtual bool isSameSize(const Xpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> & /* vec */) const {
       throw Xpetra::Exceptions::RuntimeError("BlockedVector::isSameSize: routine not implemented. It has no value as one must iterate on the partial vectors.");
       TEUCHOS_UNREACHABLE_RETURN(0);
     }
@@ -449,22 +449,22 @@ namespace Xpetra {
     }
 
     //! Import.
-    virtual void doImport(const DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node> &source, const Import& importer, CombineMode CM) {
+    virtual void doImport(const DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node> &/* source */, const Import& /* importer */, CombineMode /* CM */) {
       throw Xpetra::Exceptions::RuntimeError("BlockedVector::doImport: Not supported by BlockedVector.");
     }
 
     //! Export.
-    virtual void doExport(const DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node> &dest, const Import& importer, CombineMode CM) {
+    virtual void doExport(const DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node> &/* dest */, const Import& /* importer */, CombineMode /* CM */) {
       throw Xpetra::Exceptions::RuntimeError("BlockedVector::doExport: Not supported by BlockedVector.");
     }
 
     //! Import (using an Exporter).
-    virtual void doImport(const DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node> &source, const Export& exporter, CombineMode CM) {
+    virtual void doImport(const DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node> &/* source */, const Export& /* exporter */, CombineMode /* CM */) {
       throw Xpetra::Exceptions::RuntimeError("BlockedVector::doImport: Not supported by BlockedVector.");
     }
 
     //! Export (using an Importer).
-    virtual void doExport(const DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node> &dest, const Export& exporter, CombineMode CM) {
+    virtual void doExport(const DistObject<Scalar, LocalOrdinal, GlobalOrdinal, Node> &/* dest */, const Export& /* exporter */, CombineMode /* CM */) {
       throw Xpetra::Exceptions::RuntimeError("BlockedVector::doExport: Not supported by BlockedVector.");
     }
 

--- a/packages/xpetra/src/CrsGraph/Xpetra_EpetraCrsGraph.hpp
+++ b/packages/xpetra/src/CrsGraph/Xpetra_EpetraCrsGraph.hpp
@@ -358,7 +358,7 @@ public:
   //! @name Constructor/Destructor Methods
   //@{
   //! Constructor specifying fixed number of entries for each row.
-  EpetraCrsGraphT(const RCP< const map_type > &rowMap, size_t maxNumEntriesPerRow, ProfileType pftype=DynamicProfile, const RCP< Teuchos::ParameterList > &plist=Teuchos::null)
+  EpetraCrsGraphT(const RCP< const map_type > &rowMap, size_t maxNumEntriesPerRow, ProfileType pftype=DynamicProfile, const RCP< Teuchos::ParameterList > &/* plist */=Teuchos::null)
 : graph_(Teuchos::rcp(new Epetra_CrsGraph(Copy, toEpetra<GlobalOrdinal,Node>(rowMap), maxNumEntriesPerRow, toEpetra(pftype)))) { }
 
 
@@ -367,12 +367,12 @@ public:
   //EpetraCrsGraphT(const RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &rowMap, const ArrayRCP< const size_t > &NumEntriesPerRowToAlloc, ProfileType pftype=DynamicProfile, const RCP< ParameterList > &params=null);
 
   //! Constructor specifying column Map and fixed number of entries for each row.
-  EpetraCrsGraphT(const RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &rowMap, const RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &colMap, size_t maxNumEntriesPerRow, ProfileType pftype=DynamicProfile, const Teuchos::RCP< Teuchos::ParameterList > &plist=null)
+  EpetraCrsGraphT(const RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &rowMap, const RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &colMap, size_t maxNumEntriesPerRow, ProfileType pftype=DynamicProfile, const Teuchos::RCP< Teuchos::ParameterList > &/* plist */=null)
   : graph_(Teuchos::rcp(new Epetra_CrsGraph(Copy, toEpetra<GlobalOrdinal,Node>(rowMap), toEpetra<GlobalOrdinal,Node>(colMap), maxNumEntriesPerRow, toEpetra(pftype)))) { }
 
   ////! Constructor specifying column Map and number of entries in each row.
   // Definition not in cpp, so comment out
-  EpetraCrsGraphT(const RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &rowMap, const RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &colMap, const ArrayRCP< const size_t > &NumEntriesPerRowToAlloc, ProfileType pftype=DynamicProfile, const RCP< ParameterList > &params=null) {
+  EpetraCrsGraphT(const RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &rowMap, const RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &colMap, const ArrayRCP< const size_t > &NumEntriesPerRowToAlloc, ProfileType pftype=DynamicProfile, const RCP< ParameterList > &/* params */=null) {
     Teuchos::Array<int> numEntriesPerRowToAlloc(NumEntriesPerRowToAlloc.begin(), NumEntriesPerRowToAlloc.end()); // convert array of "size_t" to array of "int"
     graph_ = Teuchos::rcp(new Epetra_CrsGraph(Copy, toEpetra<GlobalOrdinal,Node>(rowMap), toEpetra<GlobalOrdinal,Node>(colMap), numEntriesPerRowToAlloc.getRawPtr(), toEpetra(pftype)));
   }
@@ -380,31 +380,31 @@ public:
 #ifdef HAVE_XPETRA_KOKKOS_REFACTOR
 #ifdef HAVE_XPETRA_TPETRA
   //! Constructor specifying column Map, number of entries in each row and column indices in each row.
-  EpetraCrsGraphT(const RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &rowMap,
-                  const RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &colMap,
-                  const typename local_graph_type::row_map_type& rowPointers,
-                  const typename local_graph_type::entries_type::non_const_type& columnIndices,
-                  const RCP< Teuchos::ParameterList > &plist=Teuchos::null) {
+  EpetraCrsGraphT(const RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &/* rowMap */,
+                  const RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &/* colMap */,
+                  const typename local_graph_type::row_map_type& /* rowPointers */,
+                  const typename local_graph_type::entries_type::non_const_type& /* columnIndices */,
+                  const RCP< Teuchos::ParameterList > &/* plist */=Teuchos::null) {
     TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::NotImplemented,
                                "Epetra does not support CrsGraph constructors using Kokkos Views!");
   }
 
   //! Constructor specifying column Map, number of entries in each row and column indices in each row.
-  EpetraCrsGraphT(const RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &rowMap,
-                  const RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &colMap,
-                  const local_graph_type& lclGraph,
-                  const RCP< Teuchos::ParameterList > &plist=Teuchos::null) {
+  EpetraCrsGraphT(const RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &/* rowMap */,
+                  const RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &/* colMap */,
+                  const local_graph_type& /* lclGraph */,
+                  const RCP< Teuchos::ParameterList > &/* plist */=Teuchos::null) {
     TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::NotImplemented,
                                "Epetra does not support CrsGraph constructors using a local graph!");
   }
 
   //! Constructor specifying column Map, number of entries in each row and column indices in each row.
-  EpetraCrsGraphT(const local_graph_type& lclGraph,
-                  const RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &rowMap,
-                  const RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &colMap,
-                  const Teuchos::RCP<const map_type>& domainMap = Teuchos::null,
-                  const Teuchos::RCP<const map_type>& rangeMap = Teuchos::null,
-                  const RCP< Teuchos::ParameterList > &plist=Teuchos::null) {
+  EpetraCrsGraphT(const local_graph_type& /* lclGraph */,
+                  const RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &/* rowMap */,
+                  const RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &/* colMap */,
+                  const Teuchos::RCP<const map_type>& /* domainMap */ = Teuchos::null,
+                  const Teuchos::RCP<const map_type>& /* rangeMap */ = Teuchos::null,
+                  const RCP< Teuchos::ParameterList > &/* plist */=Teuchos::null) {
     TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::NotImplemented,
                                "Epetra does not support CrsGraph constructors using a local graph!");
   }
@@ -600,7 +600,7 @@ public:
   std::string description() const { XPETRA_MONITOR("EpetraCrsGraphT::description"); return "NotImplemented"; }
 
   //! Print the object with some verbosity level to an FancyOStream object.
-  void describe(Teuchos::FancyOStream &out, const Teuchos::EVerbosityLevel verbLevel=Teuchos::Describable::verbLevel_default) const {
+  void describe(Teuchos::FancyOStream &out, const Teuchos::EVerbosityLevel /* verbLevel */=Teuchos::Describable::verbLevel_default) const {
     XPETRA_MONITOR("EpetraCrsGraphT::describe");
 
     out << "EpetraCrsGraphT::describe : Warning, verbosity level is ignored by this method." << std::endl;
@@ -720,7 +720,7 @@ public:
   //! @name Constructor/Destructor Methods
   //@{
   //! Constructor specifying fixed number of entries for each row.
-  EpetraCrsGraphT(const RCP< const map_type > &rowMap, size_t maxNumEntriesPerRow, ProfileType pftype=DynamicProfile, const RCP< Teuchos::ParameterList > &plist=Teuchos::null)
+  EpetraCrsGraphT(const RCP< const map_type > &rowMap, size_t maxNumEntriesPerRow, ProfileType pftype=DynamicProfile, const RCP< Teuchos::ParameterList > &/* plist */=Teuchos::null)
 : graph_(Teuchos::rcp(new Epetra_CrsGraph(Copy, toEpetra<GlobalOrdinal,Node>(rowMap), maxNumEntriesPerRow, toEpetra(pftype)))) { }
 
 
@@ -729,12 +729,12 @@ public:
   //EpetraCrsGraphT(const RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &rowMap, const ArrayRCP< const size_t > &NumEntriesPerRowToAlloc, ProfileType pftype=DynamicProfile, const RCP< ParameterList > &params=null);
 
   //! Constructor specifying column Map and fixed number of entries for each row.
-  EpetraCrsGraphT(const RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &rowMap, const RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &colMap, size_t maxNumEntriesPerRow, ProfileType pftype=DynamicProfile, const Teuchos::RCP< Teuchos::ParameterList > &plist=null)
+  EpetraCrsGraphT(const RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &rowMap, const RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &colMap, size_t maxNumEntriesPerRow, ProfileType pftype=DynamicProfile, const Teuchos::RCP< Teuchos::ParameterList > &/* plist */=null)
   : graph_(Teuchos::rcp(new Epetra_CrsGraph(Copy, toEpetra<GlobalOrdinal,Node>(rowMap), toEpetra<GlobalOrdinal,Node>(colMap), maxNumEntriesPerRow, toEpetra(pftype)))) { }
 
   ////! Constructor specifying column Map and number of entries in each row.
   // Definition not in cpp, so comment out
-  EpetraCrsGraphT(const RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &rowMap, const RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &colMap, const ArrayRCP< const size_t > &NumEntriesPerRowToAlloc, ProfileType pftype=DynamicProfile, const RCP< ParameterList > &params=null) {
+  EpetraCrsGraphT(const RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &rowMap, const RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &colMap, const ArrayRCP< const size_t > &NumEntriesPerRowToAlloc, ProfileType pftype=DynamicProfile, const RCP< ParameterList > &/* params */=null) {
     Teuchos::Array<int> numEntriesPerRowToAlloc(NumEntriesPerRowToAlloc.begin(), NumEntriesPerRowToAlloc.end()); // convert array of "size_t" to array of "int"
     graph_ = Teuchos::rcp(new Epetra_CrsGraph(Copy, toEpetra<GlobalOrdinal,Node>(rowMap), toEpetra<GlobalOrdinal,Node>(colMap), numEntriesPerRowToAlloc.getRawPtr(), toEpetra(pftype)));
   }
@@ -742,31 +742,31 @@ public:
 #ifdef HAVE_XPETRA_KOKKOS_REFACTOR
 #ifdef HAVE_XPETRA_TPETRA
   //! Constructor specifying column Map, number of entries in each row and column indices in each row.
-  EpetraCrsGraphT(const RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &rowMap,
-                  const RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &colMap,
-                  const typename local_graph_type::row_map_type& rowPointers,
-                  const typename local_graph_type::entries_type::non_const_type& columnIndices,
-                  const RCP< Teuchos::ParameterList > &plist=Teuchos::null) {
+  EpetraCrsGraphT(const RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &/* rowMap */,
+                  const RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &/* colMap */,
+                  const typename local_graph_type::row_map_type& /* rowPointers */,
+                  const typename local_graph_type::entries_type::non_const_type& /* columnIndices */,
+                  const RCP< Teuchos::ParameterList > &/* plist */=Teuchos::null) {
     TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::NotImplemented,
                                "Epetra does not support CrsGraph constructors using Kokkos Views!");
   }
 
   //! Constructor specifying column Map, number of entries in each row and column indices in each row.
-  EpetraCrsGraphT(const RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &rowMap,
-                  const RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &colMap,
-                  const local_graph_type& lclGraph,
-                  const RCP< Teuchos::ParameterList > &plist=Teuchos::null) {
+  EpetraCrsGraphT(const RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &/* rowMap */,
+                  const RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &/* colMap */,
+                  const local_graph_type& /* lclGraph */,
+                  const RCP< Teuchos::ParameterList > &/* plist */=Teuchos::null) {
     TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::NotImplemented,
                                "Epetra does not support CrsGraph constructors using a local graph!");
   }
 
   //! Constructor specifying column Map, number of entries in each row and column indices in each row.
-  EpetraCrsGraphT(const local_graph_type& lclGraph,
-                  const RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &rowMap,
-                  const RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &colMap,
-                  const Teuchos::RCP<const map_type>& domainMap = Teuchos::null,
-                  const Teuchos::RCP<const map_type>& rangeMap = Teuchos::null,
-                  const RCP< Teuchos::ParameterList > &plist=Teuchos::null) {
+  EpetraCrsGraphT(const local_graph_type& /* lclGraph */,
+                  const RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &/* rowMap */,
+                  const RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &/* colMap */,
+                  const Teuchos::RCP<const map_type>& /* domainMap */ = Teuchos::null,
+                  const Teuchos::RCP<const map_type>& /* rangeMap */ = Teuchos::null,
+                  const RCP< Teuchos::ParameterList > &/* plist */=Teuchos::null) {
     TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::NotImplemented,
                                "Epetra does not support CrsGraph constructors using a local graph!");
   }
@@ -960,7 +960,7 @@ public:
   std::string description() const { XPETRA_MONITOR("EpetraCrsGraphT::description"); return "NotImplemented"; }
 
   //! Print the object with some verbosity level to an FancyOStream object.
-  void describe(Teuchos::FancyOStream &out, const Teuchos::EVerbosityLevel verbLevel=Teuchos::Describable::verbLevel_default) const {
+  void describe(Teuchos::FancyOStream &out, const Teuchos::EVerbosityLevel /* verbLevel */=Teuchos::Describable::verbLevel_default) const {
     XPETRA_MONITOR("EpetraCrsGraphT::describe");
 
     out << "EpetraCrsGraphT::describe : Warning, verbosity level is ignored by this method." << std::endl;

--- a/packages/xpetra/src/CrsMatrix/Xpetra_EpetraCrsMatrix.hpp
+++ b/packages/xpetra/src/CrsMatrix/Xpetra_EpetraCrsMatrix.hpp
@@ -283,13 +283,13 @@ public:
   //@{
 
   //! Constructor specifying fixed number of entries for each row.
-  EpetraCrsMatrixT(const Teuchos::RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &rowMap, size_t maxNumEntriesPerRow, ProfileType pftype=DynamicProfile, const Teuchos::RCP< Teuchos::ParameterList > &plist = Teuchos::null)
+  EpetraCrsMatrixT(const Teuchos::RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &rowMap, size_t maxNumEntriesPerRow, ProfileType pftype=DynamicProfile, const Teuchos::RCP< Teuchos::ParameterList > &/* plist */ = Teuchos::null)
 : mtx_(Teuchos::rcp(new Epetra_CrsMatrix(Copy, toEpetra<GlobalOrdinal,Node>(rowMap), maxNumEntriesPerRow, toEpetra(pftype)))), isFillResumed_(false)
 { }
 
 
   //! Constructor specifying (possibly different) number of entries in each row.
-  EpetraCrsMatrixT(const Teuchos::RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &rowMap, const ArrayRCP< const size_t > &NumEntriesPerRowToAlloc, ProfileType pftype=DynamicProfile, const Teuchos::RCP< Teuchos::ParameterList > &plist=Teuchos::null)
+  EpetraCrsMatrixT(const Teuchos::RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &rowMap, const ArrayRCP< const size_t > &NumEntriesPerRowToAlloc, ProfileType pftype=DynamicProfile, const Teuchos::RCP< Teuchos::ParameterList > &/* plist */=Teuchos::null)
   : isFillResumed_(false)
   {
     Teuchos::Array<int> numEntriesPerRowToAlloc(NumEntriesPerRowToAlloc.begin(), NumEntriesPerRowToAlloc.end()); // convert array of "size_t" to array of "int"
@@ -298,13 +298,13 @@ public:
 
 
   //! Constructor specifying column Map and fixed number of entries for each row.
-  EpetraCrsMatrixT(const Teuchos::RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &rowMap, const Teuchos::RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &colMap, size_t maxNumEntriesPerRow, ProfileType pftype=DynamicProfile, const Teuchos::RCP< Teuchos::ParameterList > &plist=Teuchos::null)
+  EpetraCrsMatrixT(const Teuchos::RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &rowMap, const Teuchos::RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &colMap, size_t maxNumEntriesPerRow, ProfileType pftype=DynamicProfile, const Teuchos::RCP< Teuchos::ParameterList > &/* plist */=Teuchos::null)
   : mtx_(Teuchos::rcp(new Epetra_CrsMatrix(Copy, toEpetra<GlobalOrdinal,Node>(rowMap), toEpetra<GlobalOrdinal,Node>(colMap), maxNumEntriesPerRow, toEpetra(pftype)))), isFillResumed_(false)
   { }
 
 
   //! Constructor specifying column Map and number of entries in each row.
-  EpetraCrsMatrixT(const Teuchos::RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &rowMap, const Teuchos::RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &colMap, const ArrayRCP< const size_t > &NumEntriesPerRowToAlloc, ProfileType pftype=DynamicProfile, const Teuchos::RCP< Teuchos::ParameterList > &plist=Teuchos::null)
+  EpetraCrsMatrixT(const Teuchos::RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &rowMap, const Teuchos::RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &colMap, const ArrayRCP< const size_t > &NumEntriesPerRowToAlloc, ProfileType pftype=DynamicProfile, const Teuchos::RCP< Teuchos::ParameterList > &/* plist */=Teuchos::null)
   : isFillResumed_(false)
   {
     Teuchos::Array<int> numEntriesPerRowToAlloc(NumEntriesPerRowToAlloc.begin(), NumEntriesPerRowToAlloc.end()); // convert array of "size_t" to array of "int"
@@ -313,7 +313,7 @@ public:
 
 
   //! Constructor specifying a previously constructed graph.
-  EpetraCrsMatrixT(const Teuchos::RCP< const CrsGraph< LocalOrdinal, GlobalOrdinal, Node> > &graph, const Teuchos::RCP< Teuchos::ParameterList > &plist=Teuchos::null)
+  EpetraCrsMatrixT(const Teuchos::RCP< const CrsGraph< LocalOrdinal, GlobalOrdinal, Node> > &graph, const Teuchos::RCP< Teuchos::ParameterList > &/* plist */=Teuchos::null)
   : mtx_(Teuchos::rcp(new Epetra_CrsMatrix(Copy, toEpetra<GlobalOrdinal,Node>(graph)))), isFillResumed_(false)
   { }
 
@@ -665,7 +665,7 @@ public:
                                                   const RCP<const Map<LocalOrdinal,GlobalOrdinal,Node> > & rangeMap,
                                                   const RCP<const Import<LocalOrdinal,GlobalOrdinal,Node> > &importer=Teuchos::null,
                                                   const RCP<const Export<LocalOrdinal,GlobalOrdinal,Node> > &exporter=Teuchos::null,
-                                                  const RCP<ParameterList> & params=Teuchos::null) {
+                                                  const RCP<ParameterList> & /* params */=Teuchos::null) {
      XPETRA_MONITOR("EpetraCrsMatrixT::expertStaticFillComplete");
 
      // For Epetra matrices, resumeFill() is a fictive operation.
@@ -694,7 +694,7 @@ public:
   //@{
 
   //!
-  void resumeFill(const RCP< ParameterList > &params=Teuchos::null) {
+  void resumeFill(const RCP< ParameterList > &/* params */=Teuchos::null) {
     XPETRA_MONITOR("EpetraCrsMatrixT::resumeFill");
 
     // According to Tpetra documentation, resumeFill() may be called repeatedly.
@@ -858,12 +858,12 @@ public:
   }
 
   //! Get offsets of the diagonal entries in the matrix.
-  void getLocalDiagOffsets(Teuchos::ArrayRCP<size_t> &offsets) const {
+  void getLocalDiagOffsets(Teuchos::ArrayRCP<size_t> &/* offsets */) const {
     TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraCrsMatrixT.getLocalDiagOffsets() is not implemented or supported.");
   }
 
   //! Get a copy of the diagonal entries owned by this node, with local row indices, using row offsets.
-  void getLocalDiagCopy(Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > &diag, const Teuchos::ArrayView<const size_t> &offsets) const {
+  void getLocalDiagCopy(Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > &/* diag */, const Teuchos::ArrayView<const size_t> &/* offsets */) const {
     TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraCrsMatrixT.getLocalDiagCopy using offsets is not implemented or supported.");
   }
 
@@ -1169,7 +1169,7 @@ public:
     TEUCHOS_TEST_FOR_EXCEPTION(err != 0, std::runtime_error, "Catch error code returned by Epetra.");
   }
 
-  void removeEmptyProcessesInPlace (const Teuchos::RCP<const Map<LocalOrdinal, GlobalOrdinal, Node> >& newMap) { }
+  void removeEmptyProcessesInPlace (const Teuchos::RCP<const Map<LocalOrdinal, GlobalOrdinal, Node> >& /* newMap */) { }
 
   //@}
 
@@ -1222,9 +1222,9 @@ public:
     return localMatrix_;
   }
 
-  void setAllValues (const typename local_matrix_type::row_map_type& ptr,
-                     const typename local_matrix_type::StaticCrsGraphType::entries_type::non_const_type& ind,
-                     const typename local_matrix_type::values_type& val)
+  void setAllValues (const typename local_matrix_type::row_map_type& /* ptr */,
+                     const typename local_matrix_type::StaticCrsGraphType::entries_type::non_const_type& /* ind */,
+                     const typename local_matrix_type::values_type& /* val */)
   {
     TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::RuntimeError,
                                "Xpetra::EpetraCrsMatrix::setAllValues is not implemented");
@@ -1275,13 +1275,13 @@ public:
   //@{
 
   //! Constructor specifying fixed number of entries for each row.
-  EpetraCrsMatrixT(const Teuchos::RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &rowMap, size_t maxNumEntriesPerRow, ProfileType pftype=DynamicProfile, const Teuchos::RCP< Teuchos::ParameterList > &plist = Teuchos::null)
+  EpetraCrsMatrixT(const Teuchos::RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &rowMap, size_t maxNumEntriesPerRow, ProfileType pftype=DynamicProfile, const Teuchos::RCP< Teuchos::ParameterList > &/* plist */ = Teuchos::null)
 : mtx_(Teuchos::rcp(new Epetra_CrsMatrix(Copy, toEpetra<GlobalOrdinal,Node>(rowMap), maxNumEntriesPerRow, toEpetra(pftype)))), isFillResumed_(false)
 { }
 
 
   //! Constructor specifying (possibly different) number of entries in each row.
-  EpetraCrsMatrixT(const Teuchos::RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &rowMap, const ArrayRCP< const size_t > &NumEntriesPerRowToAlloc, ProfileType pftype=DynamicProfile, const Teuchos::RCP< Teuchos::ParameterList > &plist=Teuchos::null)
+  EpetraCrsMatrixT(const Teuchos::RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &rowMap, const ArrayRCP< const size_t > &NumEntriesPerRowToAlloc, ProfileType pftype=DynamicProfile, const Teuchos::RCP< Teuchos::ParameterList > &/* plist */=Teuchos::null)
   : isFillResumed_(false)
   {
     Teuchos::Array<int> numEntriesPerRowToAlloc(NumEntriesPerRowToAlloc.begin(), NumEntriesPerRowToAlloc.end()); // convert array of "size_t" to array of "int"
@@ -1290,13 +1290,13 @@ public:
 
 
   //! Constructor specifying column Map and fixed number of entries for each row.
-  EpetraCrsMatrixT(const Teuchos::RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &rowMap, const Teuchos::RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &colMap, size_t maxNumEntriesPerRow, ProfileType pftype=DynamicProfile, const Teuchos::RCP< Teuchos::ParameterList > &plist=Teuchos::null)
+  EpetraCrsMatrixT(const Teuchos::RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &rowMap, const Teuchos::RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &colMap, size_t maxNumEntriesPerRow, ProfileType pftype=DynamicProfile, const Teuchos::RCP< Teuchos::ParameterList > &/* plist */=Teuchos::null)
   : mtx_(Teuchos::rcp(new Epetra_CrsMatrix(Copy, toEpetra<GlobalOrdinal,Node>(rowMap), toEpetra<GlobalOrdinal,Node>(colMap), maxNumEntriesPerRow, toEpetra(pftype)))), isFillResumed_(false)
   { }
 
 
   //! Constructor specifying column Map and number of entries in each row.
-  EpetraCrsMatrixT(const Teuchos::RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &rowMap, const Teuchos::RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &colMap, const ArrayRCP< const size_t > &NumEntriesPerRowToAlloc, ProfileType pftype=DynamicProfile, const Teuchos::RCP< Teuchos::ParameterList > &plist=Teuchos::null)
+  EpetraCrsMatrixT(const Teuchos::RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &rowMap, const Teuchos::RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &colMap, const ArrayRCP< const size_t > &NumEntriesPerRowToAlloc, ProfileType pftype=DynamicProfile, const Teuchos::RCP< Teuchos::ParameterList > &/* plist */=Teuchos::null)
   : isFillResumed_(false)
   {
     Teuchos::Array<int> numEntriesPerRowToAlloc(NumEntriesPerRowToAlloc.begin(), NumEntriesPerRowToAlloc.end()); // convert array of "size_t" to array of "int"
@@ -1305,7 +1305,7 @@ public:
 
 
   //! Constructor specifying a previously constructed graph.
-  EpetraCrsMatrixT(const Teuchos::RCP< const CrsGraph< LocalOrdinal, GlobalOrdinal, Node> > &graph, const Teuchos::RCP< Teuchos::ParameterList > &plist=Teuchos::null)
+  EpetraCrsMatrixT(const Teuchos::RCP< const CrsGraph< LocalOrdinal, GlobalOrdinal, Node> > &graph, const Teuchos::RCP< Teuchos::ParameterList > &/* plist */=Teuchos::null)
   : mtx_(Teuchos::rcp(new Epetra_CrsMatrix(Copy, toEpetra<GlobalOrdinal,Node>(graph)))), isFillResumed_(false)
   { }
 
@@ -1654,7 +1654,7 @@ public:
                                                   const RCP<const Map<LocalOrdinal,GlobalOrdinal,Node> > & rangeMap,
                                                   const RCP<const Import<LocalOrdinal,GlobalOrdinal,Node> > &importer=Teuchos::null,
                                                   const RCP<const Export<LocalOrdinal,GlobalOrdinal,Node> > &exporter=Teuchos::null,
-                                                  const RCP<ParameterList> & params=Teuchos::null) {
+                                                  const RCP<ParameterList> & /* params */=Teuchos::null) {
      XPETRA_MONITOR("EpetraCrsMatrixT::expertStaticFillComplete");
 
      // For Epetra matrices, resumeFill() is a fictive operation.
@@ -1683,7 +1683,7 @@ public:
   //@{
 
   //!
-  void resumeFill(const RCP< ParameterList > &params=Teuchos::null) {
+  void resumeFill(const RCP< ParameterList > &/* params */=Teuchos::null) {
     XPETRA_MONITOR("EpetraCrsMatrixT::resumeFill");
 
     // According to Tpetra documentation, resumeFill() may be called repeatedly.
@@ -1844,12 +1844,12 @@ public:
   void getLocalDiagCopy(Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > &diag) const { XPETRA_MONITOR("EpetraCrsMatrixT::getLocalDiagCopy"); mtx_->ExtractDiagonalCopy(toEpetra<GlobalOrdinal,Node>(diag)); }
 
   //! Get offsets of the diagonal entries in the matrix.
-  void getLocalDiagOffsets(Teuchos::ArrayRCP<size_t> &offsets) const {
+  void getLocalDiagOffsets(Teuchos::ArrayRCP<size_t> &/* offsets */) const {
     TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraCrsMatrixT.getLocalDiagOffsets() is not implemented or supported.");
   }
 
   //! Get a copy of the diagonal entries owned by this node, with local row indices, using row offsets.
-  void getLocalDiagCopy(Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > &diag, const Teuchos::ArrayView<const size_t> &offsets) const {
+  void getLocalDiagCopy(Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > &/* diag */, const Teuchos::ArrayView<const size_t> &/* offsets */) const {
     TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraCrsMatrixT.getLocalDiagCopy using offsets is not implemented or supported.");
   }
 
@@ -2155,7 +2155,7 @@ public:
     TEUCHOS_TEST_FOR_EXCEPTION(err != 0, std::runtime_error, "Catch error code returned by Epetra.");
   }
 
-  void removeEmptyProcessesInPlace (const Teuchos::RCP<const Map<LocalOrdinal, GlobalOrdinal, Node> >& newMap) { }
+  void removeEmptyProcessesInPlace (const Teuchos::RCP<const Map<LocalOrdinal, GlobalOrdinal, Node> >& /* newMap */) { }
 
   //@}
 
@@ -2208,9 +2208,9 @@ public:
     return localMatrix_;
   }
 
-  void setAllValues (const typename local_matrix_type::row_map_type& ptr,
-                     const typename local_matrix_type::StaticCrsGraphType::entries_type::non_const_type& ind,
-                     const typename local_matrix_type::values_type& val)
+  void setAllValues (const typename local_matrix_type::row_map_type& /* ptr */,
+                     const typename local_matrix_type::StaticCrsGraphType::entries_type::non_const_type& /* ind */,
+                     const typename local_matrix_type::values_type& /* val */)
   {
     TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::RuntimeError,
                                "Xpetra::EpetraCrsMatrix::setAllValues is not implemented");

--- a/packages/xpetra/src/Map/Xpetra_EpetraMap.hpp
+++ b/packages/xpetra/src/Map/Xpetra_EpetraMap.hpp
@@ -147,13 +147,13 @@ namespace Xpetra {
     GlobalOrdinal getMaxAllGlobalIndex() const { return 0; }
 
     //! The local index corresponding to the given global index.
-    LocalOrdinal getLocalElement(GlobalOrdinal globalIndex) const { return 0; }
+    LocalOrdinal getLocalElement(GlobalOrdinal /* globalIndex */) const { return 0; }
 
     //! Return the process ranks and corresponding local indices for the given global indices.
-    LookupStatus getRemoteIndexList(const Teuchos::ArrayView< const GlobalOrdinal > &GIDList, const Teuchos::ArrayView< int > &nodeIDList, const Teuchos::ArrayView< LocalOrdinal > &LIDList) const { return Xpetra::IDNotPresent; }
+    LookupStatus getRemoteIndexList(const Teuchos::ArrayView< const GlobalOrdinal > &/* GIDList */, const Teuchos::ArrayView< int > &/* nodeIDList */, const Teuchos::ArrayView< LocalOrdinal > &/* LIDList */) const { return Xpetra::IDNotPresent; }
 
     //! Return the process ranks for the given global indices.
-    LookupStatus getRemoteIndexList(const Teuchos::ArrayView< const GlobalOrdinal > &GIDList, const Teuchos::ArrayView< int > &nodeIDList) const { return Xpetra::IDNotPresent; }
+    LookupStatus getRemoteIndexList(const Teuchos::ArrayView< const GlobalOrdinal > &/* GIDList */, const Teuchos::ArrayView< int > &/* nodeIDList */) const { return Xpetra::IDNotPresent; }
 
     //! Return a view of the global indices owned by this process.
     //Teuchos::ArrayView< const GlobalOrdinal > getNodeElementList() const;
@@ -165,10 +165,10 @@ namespace Xpetra {
     //@{
 
     //! Whether the given local index is valid for this Map on this process.
-    bool isNodeLocalElement(LocalOrdinal localIndex) const { return false; }
+    bool isNodeLocalElement(LocalOrdinal /* localIndex */) const { return false; }
 
     //! Whether the given global index is valid for this Map on this process.
-    bool isNodeGlobalElement(GlobalOrdinal globalIndex) const { return false; }
+    bool isNodeGlobalElement(GlobalOrdinal /* globalIndex */) const { return false; }
 
     //! True if this Map is distributed contiguously, else false.
     bool isContiguous() const { return false; }
@@ -177,10 +177,10 @@ namespace Xpetra {
     bool isDistributed() const { return false; }
 
     //! True if and only if map is compatible with this Map.
-    bool isCompatible(const Map< LocalOrdinal, GlobalOrdinal, Node > &map) const { return false; }
+    bool isCompatible(const Map< LocalOrdinal, GlobalOrdinal, Node > &/* map */) const { return false; }
 
     //! True if and only if map is identical to this Map.
-    bool isSameAs(const Map< LocalOrdinal, GlobalOrdinal, Node > &map) const { return false; }
+    bool isSameAs(const Map< LocalOrdinal, GlobalOrdinal, Node > &/* map */) const { return false; }
 
     //@}
 
@@ -205,7 +205,7 @@ namespace Xpetra {
     std::string description() const { return std::string(""); }
 
     //! Print this object with the given verbosity level to the given Teuchos::FancyOStream.
-    void describe(Teuchos::FancyOStream &out, const Teuchos::EVerbosityLevel verbLevel=Teuchos::Describable::verbLevel_default) const {  }
+    void describe(Teuchos::FancyOStream &/* out */, const Teuchos::EVerbosityLevel /* verbLevel */=Teuchos::Describable::verbLevel_default) const {  }
 
     //@}
 
@@ -216,12 +216,12 @@ namespace Xpetra {
     RCP<const Map<int,GlobalOrdinal,Node> > removeEmptyProcesses() const { return Teuchos::null; }
 
     //! Replace this Map's communicator with a subset communicator.
-    RCP<const Map<int,GlobalOrdinal,Node> > replaceCommWithSubset(const Teuchos::RCP< const Teuchos::Comm< int > > &newComm) const { return Teuchos::null; }
+    RCP<const Map<int,GlobalOrdinal,Node> > replaceCommWithSubset(const Teuchos::RCP< const Teuchos::Comm< int > > &/* newComm */) const { return Teuchos::null; }
 
     //@}
 
     //! Return the global index for a given local index.  Note that this returns -1 if not found on this processor.  (This is different than Epetra's behavior!)
-    GlobalOrdinal getGlobalElement(LocalOrdinal localIndex) const { return -1; }
+    GlobalOrdinal getGlobalElement(LocalOrdinal /* localIndex */) const { return -1; }
 
     //! @name Xpetra specific
     //@{
@@ -290,7 +290,7 @@ namespace Xpetra {
                GlobalOrdinal indexBase,
                const Teuchos::RCP< const Teuchos::Comm< int > > &comm,
                LocalGlobal lg=GloballyDistributed,
-               const Teuchos::RCP< Node > &node = Teuchos::rcp(new Node))
+               const Teuchos::RCP< Node > &/* node */ = Teuchos::rcp(new Node))
     {
       // This test come from Tpetra (Epetra doesn't check if numGlobalElements,indexBase are equivalent across images).
       // In addition, for the test TEST_THROW(M map((myImageID == 0 ? GSTI : 0),0,comm), std::invalid_argument), only one node throw an exception and there is a dead lock.
@@ -342,7 +342,7 @@ namespace Xpetra {
     }
 
     //! Constructor with a user-defined contiguous distribution.
-    EpetraMapT(global_size_t numGlobalElements, size_t numLocalElements, GlobalOrdinal indexBase, const Teuchos::RCP< const Teuchos::Comm< int > > &comm, const Teuchos::RCP< Node > &node=Teuchos::rcp(new Node))
+    EpetraMapT(global_size_t numGlobalElements, size_t numLocalElements, GlobalOrdinal indexBase, const Teuchos::RCP< const Teuchos::Comm< int > > &comm, const Teuchos::RCP< Node > &/* node */=Teuchos::rcp(new Node))
     {
       // This test come from Tpetra
       using Teuchos::outArg;
@@ -446,7 +446,7 @@ namespace Xpetra {
                const Teuchos::ArrayView< const GlobalOrdinal > &elementList,
                GlobalOrdinal indexBase,
                const Teuchos::RCP< const Teuchos::Comm< int > > &comm,
-               const Teuchos::RCP< Node > &node = Teuchos::rcp(new Node))
+               const Teuchos::RCP< Node > &/* node */ = Teuchos::rcp(new Node))
     {
       if (numGlobalElements == Teuchos::OrdinalTraits<global_size_t>::invalid()) {
         IF_EPETRA_EXCEPTION_THEN_THROW_GLOBAL_INVALID_ARG((map_ = (rcp(new Epetra_BlockMap(-1, static_cast<int>(elementList.size()), elementList.getRawPtr(), 1, indexBase, *toEpetra(comm))))));
@@ -650,7 +650,7 @@ namespace Xpetra {
     }
 
     //! Replace this Map's communicator with a subset communicator.
-    RCP<const Map<int,GlobalOrdinal,Node> > replaceCommWithSubset(const Teuchos::RCP< const Teuchos::Comm< int > > &newComm) const {
+    RCP<const Map<int,GlobalOrdinal,Node> > replaceCommWithSubset(const Teuchos::RCP< const Teuchos::Comm< int > > &/* newComm */) const {
       throw std::runtime_error("Xpetra::EpetraMapT::replaceCommWithSubset has not yet been implemented.");
       TEUCHOS_UNREACHABLE_RETURN(Teuchos::null);
     }
@@ -817,7 +817,7 @@ namespace Xpetra {
                GlobalOrdinal indexBase,
                const Teuchos::RCP< const Teuchos::Comm< int > > &comm,
                LocalGlobal lg=GloballyDistributed,
-               const Teuchos::RCP< Node > &node = Teuchos::rcp(new Node)) {
+               const Teuchos::RCP< Node > &/* node */ = Teuchos::rcp(new Node)) {
       // This test come from Tpetra (Epetra doesn't check if numGlobalElements,indexBase are equivalent across images).
       // In addition, for the test TEST_THROW(M map((myImageID == 0 ? GSTI : 0),0,comm), std::invalid_argument), only one node throw an exception and there is a dead lock.
       std::string errPrefix;
@@ -868,7 +868,7 @@ namespace Xpetra {
     }
 
     //! Constructor with a user-defined contiguous distribution.
-    EpetraMapT(global_size_t numGlobalElements, size_t numLocalElements, GlobalOrdinal indexBase, const Teuchos::RCP< const Teuchos::Comm< int > > &comm, const Teuchos::RCP< Node > &node=Teuchos::rcp(new Node)) {
+    EpetraMapT(global_size_t numGlobalElements, size_t numLocalElements, GlobalOrdinal indexBase, const Teuchos::RCP< const Teuchos::Comm< int > > &comm, const Teuchos::RCP< Node > &/* node */=Teuchos::rcp(new Node)) {
       // This test come from Tpetra
       using Teuchos::outArg;
 
@@ -971,7 +971,7 @@ namespace Xpetra {
                const Teuchos::ArrayView< const GlobalOrdinal > &elementList,
                GlobalOrdinal indexBase,
                const Teuchos::RCP< const Teuchos::Comm< int > > &comm,
-               const Teuchos::RCP< Node > &node = Teuchos::rcp(new Node)) {
+               const Teuchos::RCP< Node > &/* node */ = Teuchos::rcp(new Node)) {
       if (numGlobalElements == Teuchos::OrdinalTraits<global_size_t>::invalid()) {
         IF_EPETRA_EXCEPTION_THEN_THROW_GLOBAL_INVALID_ARG((map_ = (rcp(new Epetra_BlockMap(-1, elementList.size(), elementList.getRawPtr(), 1, indexBase, *toEpetra(comm))))));
       } else {
@@ -1174,7 +1174,7 @@ namespace Xpetra {
     }
 
     //! Replace this Map's communicator with a subset communicator.
-    RCP<const Map<int,GlobalOrdinal,Node> > replaceCommWithSubset(const Teuchos::RCP< const Teuchos::Comm< int > > &newComm) const {
+    RCP<const Map<int,GlobalOrdinal,Node> > replaceCommWithSubset(const Teuchos::RCP< const Teuchos::Comm< int > > &/* newComm */) const {
       throw std::runtime_error("Xpetra::EpetraMapT::replaceCommWithSubset has not yet been implemented.");
       // return Teuchos::null; // unreachable
     }

--- a/packages/xpetra/src/MultiVector/Xpetra_EpetraIntMultiVector.hpp
+++ b/packages/xpetra/src/MultiVector/Xpetra_EpetraIntMultiVector.hpp
@@ -404,7 +404,7 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
     }
 
     //! Set multi-vector values from array of pointers using Teuchos memory management classes. (copy).
-    EpetraIntMultiVectorT(const Teuchos::RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &map, const Teuchos::ArrayView< const Teuchos::ArrayView< const Scalar > > &ArrayOfPtrs, size_t NumVectors) {
+    EpetraIntMultiVectorT(const Teuchos::RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &/* map */, const Teuchos::ArrayView< const Teuchos::ArrayView< const Scalar > > &/* ArrayOfPtrs */, size_t /* NumVectors */) {
       TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::RuntimeError,
         "Xpetra::EpetraIntMultiVector only available for GO=int or GO=long long with EpetraNode (Serial or OpenMP depending on configuration)");
     }
@@ -425,12 +425,12 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
       }
 
       //! Set multi-vector values to random numbers.
-      void randomize(bool bUseXpetraImplementation = true) { XPETRA_MONITOR("EpetraIntMultiVectorT::randomize"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraIntMultiVectorT::randomize(): Functionnality not available in Epetra"); }
+      void randomize(bool /* bUseXpetraImplementation */ = true) { XPETRA_MONITOR("EpetraIntMultiVectorT::randomize"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraIntMultiVectorT::randomize(): Functionnality not available in Epetra"); }
 
 
       //! Set seed for Random function.
       /** Note: this method does not exist in Tpetra interface. Added for MueLu. */
-      void setSeed(unsigned int seed) { XPETRA_MONITOR("EpetraIntMultiVectorT::setSeed"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraIntMultiVectorT::setSeed(): Functionnality not available in Epetra"); }
+      void setSeed(unsigned int /* seed */) { XPETRA_MONITOR("EpetraIntMultiVectorT::setSeed"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraIntMultiVectorT::setSeed(): Functionnality not available in Epetra"); }
 
 
       //@}
@@ -439,12 +439,12 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
       //@{
 
       //! Return a Vector which is a const view of column j.
-      Teuchos::RCP< const Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > > getVector(size_t j) const {
+      Teuchos::RCP< const Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > > getVector(size_t /* j */) const {
          TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
        }
 
       //! Return a Vector which is a nonconst view of column j.
-      Teuchos::RCP< Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > > getVectorNonConst(size_t j) {
+      Teuchos::RCP< Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > > getVectorNonConst(size_t /* j */) {
         TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
       }
 
@@ -479,8 +479,8 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
       //! @name Mathematical methods
       //@{
       //! Computes dot product of each corresponding pair of vectors, dots[i] = this[i].dot(A[i])
-      void dot(const MultiVector<int,int,GlobalOrdinal,Node> &A,
-               const Teuchos::ArrayView<int> &dots) const {
+      void dot(const MultiVector<int,int,GlobalOrdinal,Node> &/* A */,
+               const Teuchos::ArrayView<int> &/* dots */) const {
         XPETRA_MONITOR("EpetraIntMultiVectorT::dot");
 
         //XPETRA_DYNAMIC_CAST(const EpetraMultiVectorT, A, eA, "This Xpetra::EpetraMultiVectorT method only accept Xpetra::EpetraMultiVectorT as input arguments.");
@@ -489,14 +489,14 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
       }
 
       //! Puts element-wise absolute values of input Multi-vector in target: A = abs(this)
-      void abs(const MultiVector<int,int,GlobalOrdinal,Node> &A) {
+      void abs(const MultiVector<int,int,GlobalOrdinal,Node> &/* A */) {
         XPETRA_MONITOR("EpetraIntMultiVectorT::abs");
         TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented,
                                    "This function is not available in Epetra_IntMultiVector");
       }
 
       //! Puts element-wise reciprocal values of input Multi-vector in target, this(i,j) = 1/A(i,j).
-      void reciprocal(const MultiVector<int,int,GlobalOrdinal,Node> &A) {
+      void reciprocal(const MultiVector<int,int,GlobalOrdinal,Node> &/* A */) {
         XPETRA_MONITOR("EpetraIntMultiVectorT::reciprocal");
 
         //XPETRA_DYNAMIC_CAST(const EpetraMultiVectorT, A, eA, "This Xpetra::EpetraMultiVectorT method only accept Xpetra::EpetraMultiVectorT as input arguments.");
@@ -504,19 +504,19 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
       }
 
       //! Scale the current values of a multi-vector, this = alpha*this.
-      void scale(const int &alpha) {
+      void scale(const int &/* alpha */) {
         XPETRA_MONITOR("EpetraIntMultiVectorT::scale");
         TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
       }
 
       //! Scale the current values of a multi-vector, this[j] = alpha[j]*this[j].
-      void scale (Teuchos::ArrayView< const int > alpha) {
+      void scale (Teuchos::ArrayView< const int > /* alpha */) {
         XPETRA_MONITOR("EpetraIntMultiVectorT::scale");
         TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
       }
 
       //! Update multi-vector values with scaled values of A, this = beta*this + alpha*A.
-      void update(const int &alpha, const MultiVector<int,int,GlobalOrdinal,Node> &A, const int &beta) {
+      void update(const int &/* alpha */, const MultiVector<int,int,GlobalOrdinal,Node> &/* A */, const int &/* beta */) {
         XPETRA_MONITOR("EpetraIntMultiVectorT::update");
 
         // XPETRA_DYNAMIC_CAST(const EpetraMultiVectorT, A, eA, "This Xpetra::EpetraMultiVectorT method only accept Xpetra::EpetraMultiVectorT as input arguments.");
@@ -524,7 +524,7 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
       }
 
       //! Update multi-vector with scaled values of A and B, this = gamma*this + alpha*A + beta*B.
-      void update(const int &alpha, const MultiVector<int,int,GlobalOrdinal,Node> &A, const int &beta, const MultiVector<int,int,GlobalOrdinal,Node> &B, const int &gamma) {
+      void update(const int &/* alpha */, const MultiVector<int,int,GlobalOrdinal,Node> &/* A */, const int &/* beta */, const MultiVector<int,int,GlobalOrdinal,Node> &/* B */, const int &/* gamma */) {
         XPETRA_MONITOR("EpetraIntMultiVectorT::update");
 
         //XPETRA_DYNAMIC_CAST(const EpetraMultiVectorT, A, eA, "This Xpetra::EpetraMultiVectorT method only accept Xpetra::EpetraMultiVectorT as input arguments.");
@@ -533,25 +533,25 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
       }
 
       //! Compute 1-norm of each vector in multi-vector.
-      void norm1(const Teuchos::ArrayView<Teuchos::ScalarTraits<int>::magnitudeType> &norms) const { XPETRA_MONITOR("EpetraIntMultiVectorT::norm1"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+      void norm1(const Teuchos::ArrayView<Teuchos::ScalarTraits<int>::magnitudeType> &/* norms */) const { XPETRA_MONITOR("EpetraIntMultiVectorT::norm1"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
 
       //! Compute 2-norm of each vector in multi-vector.
-      void norm2(const Teuchos::ArrayView<Teuchos::ScalarTraits<int>::magnitudeType> &norms) const { XPETRA_MONITOR("EpetraIntMultiVectorT::norm2"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+      void norm2(const Teuchos::ArrayView<Teuchos::ScalarTraits<int>::magnitudeType> &/* norms */) const { XPETRA_MONITOR("EpetraIntMultiVectorT::norm2"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
 
       //! Compute Inf-norm of each vector in multi-vector.
-      void normInf(const Teuchos::ArrayView<Teuchos::ScalarTraits<int>::magnitudeType> &norms) const { XPETRA_MONITOR("EpetraIntMultiVectorT::normInf"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+      void normInf(const Teuchos::ArrayView<Teuchos::ScalarTraits<int>::magnitudeType> &/* norms */) const { XPETRA_MONITOR("EpetraIntMultiVectorT::normInf"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
 
       //! Compute mean (average) value of each vector in multi-vector.
-      void meanValue(const Teuchos::ArrayView<int> &means) const { XPETRA_MONITOR("EpetraIntMultiVectorT::meanValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+      void meanValue(const Teuchos::ArrayView<int> &/* means */) const { XPETRA_MONITOR("EpetraIntMultiVectorT::meanValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
 
       //! Compute max value of each vector in multi-vector.
-      void maxValue(const Teuchos::ArrayView<int> &maxs) const { XPETRA_MONITOR("EpetraIntMultiVectorT::maxValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+      void maxValue(const Teuchos::ArrayView<int> &/* maxs */) const { XPETRA_MONITOR("EpetraIntMultiVectorT::maxValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
 
       //! Matrix-Matrix multiplication, this = beta*this + alpha*op(A)*op(B).
-      void multiply(Teuchos::ETransp transA, Teuchos::ETransp transB, const int &alpha, const MultiVector<int,int,GlobalOrdinal,Node> &A, const MultiVector<int,int,GlobalOrdinal,Node> &B, const int &beta) { XPETRA_MONITOR("EpetraIntMultiVectorT::multiply"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Not available in Epetra"); }
+      void multiply(Teuchos::ETransp /* transA */, Teuchos::ETransp /* transB */, const int &/* alpha */, const MultiVector<int,int,GlobalOrdinal,Node> &/* A */, const MultiVector<int,int,GlobalOrdinal,Node> &/* B */, const int &/* beta */) { XPETRA_MONITOR("EpetraIntMultiVectorT::multiply"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Not available in Epetra"); }
 
       //! Element-wise multiply of a Vector A with a EpetraMultiVector B.
-      void elementWiseMultiply(int scalarAB, const Vector<int,int,GlobalOrdinal,Node> &A, const MultiVector<int,int,GlobalOrdinal,Node> &B, int scalarThis) {
+      void elementWiseMultiply(int /* scalarAB */, const Vector<int,int,GlobalOrdinal,Node> &/* A */, const MultiVector<int,int,GlobalOrdinal,Node> &/* B */, int /* scalarThis */) {
           XPETRA_MONITOR("EpetraIntMultiVectorT::elementWiseMultiply");
           TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra_EpetraIntMultiVector: elementWiseMultiply not implemented because Epetra_IntMultiVector does not support this operation");
         }
@@ -848,7 +848,7 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
     }
 
     //! Set multi-vector values from array of pointers using Teuchos memory management classes. (copy).
-    EpetraIntMultiVectorT(const Teuchos::RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &map, const Teuchos::ArrayView< const Teuchos::ArrayView< const Scalar > > &ArrayOfPtrs, size_t NumVectors) {
+    EpetraIntMultiVectorT(const Teuchos::RCP< const Map< LocalOrdinal, GlobalOrdinal, Node > > &/* map */, const Teuchos::ArrayView< const Teuchos::ArrayView< const Scalar > > &/* ArrayOfPtrs */, size_t /* NumVectors */) {
       TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::RuntimeError,
         "Xpetra::EpetraIntMultiVector only available for GO=int or GO=long long with EpetraNode (Serial or OpenMP depending on configuration)");
     }
@@ -869,12 +869,12 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
       }
 
       //! Set multi-vector values to random numbers.
-      void randomize(bool bUseXpetraImplementation = true) { XPETRA_MONITOR("EpetraIntMultiVectorT::randomize"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraIntMultiVectorT::randomize(): Functionnality not available in Epetra"); }
+      void randomize(bool /* bUseXpetraImplementation */ = true) { XPETRA_MONITOR("EpetraIntMultiVectorT::randomize"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraIntMultiVectorT::randomize(): Functionnality not available in Epetra"); }
 
 
       //! Set seed for Random function.
       /** Note: this method does not exist in Tpetra interface. Added for MueLu. */
-      void setSeed(unsigned int seed) { XPETRA_MONITOR("EpetraIntMultiVectorT::setSeed"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraIntMultiVectorT::setSeed(): Functionnality not available in Epetra"); }
+      void setSeed(unsigned int /* seed */) { XPETRA_MONITOR("EpetraIntMultiVectorT::setSeed"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraIntMultiVectorT::setSeed(): Functionnality not available in Epetra"); }
 
 
       //@}
@@ -883,12 +883,12 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
       //@{
 
       //! Return a Vector which is a const view of column j.
-      Teuchos::RCP< const Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > > getVector(size_t j) const {
+      Teuchos::RCP< const Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > > getVector(size_t /* j */) const {
          TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
        }
 
       //! Return a Vector which is a nonconst view of column j.
-      Teuchos::RCP< Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > > getVectorNonConst(size_t j) {
+      Teuchos::RCP< Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > > getVectorNonConst(size_t /* j */) {
         TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
       }
 
@@ -923,8 +923,8 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
       //! @name Mathematical methods
       //@{
       //! Computes dot product of each corresponding pair of vectors, dots[i] = this[i].dot(A[i])
-      void dot(const MultiVector<int,int,GlobalOrdinal,Node> &A,
-               const Teuchos::ArrayView<int> &dots) const {
+      void dot(const MultiVector<int,int,GlobalOrdinal,Node> &/* A */,
+               const Teuchos::ArrayView<int> &/* dots */) const {
         XPETRA_MONITOR("EpetraIntMultiVectorT::dot");
 
         //XPETRA_DYNAMIC_CAST(const EpetraMultiVectorT, A, eA, "This Xpetra::EpetraMultiVectorT method only accept Xpetra::EpetraMultiVectorT as input arguments.");
@@ -932,33 +932,33 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
       }
 
       //! Puts element-wise absolute values of input Multi-vector in target: A = abs(this)
-      void abs(const MultiVector<int,int,GlobalOrdinal,Node> &A) {
+      void abs(const MultiVector<int,int,GlobalOrdinal,Node> &/* A */) {
         XPETRA_MONITOR("EpetraIntMultiVectorT::abs");
         TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented,
                                    "This function is not available in Epetra_IntMultiVector");
       }
 
       //! Puts element-wise reciprocal values of input Multi-vector in target, this(i,j) = 1/A(i,j).
-      void reciprocal(const MultiVector<int,int,GlobalOrdinal,Node> &A) {
+      void reciprocal(const MultiVector<int,int,GlobalOrdinal,Node> &/* A */) {
         XPETRA_MONITOR("EpetraIntMultiVectorT::reciprocal");
         TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented,
                                    "This function is not implemented in Epetra_IntMultiVector");
       }
 
       //! Scale the current values of a multi-vector, this = alpha*this.
-      void scale(const int &alpha) {
+      void scale(const int &/* alpha */) {
         XPETRA_MONITOR("EpetraIntMultiVectorT::scale");
         TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
       }
 
       //! Scale the current values of a multi-vector, this[j] = alpha[j]*this[j].
-      void scale (Teuchos::ArrayView< const int > alpha) {
+      void scale (Teuchos::ArrayView< const int > /* alpha */) {
         XPETRA_MONITOR("EpetraIntMultiVectorT::scale");
         TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
       }
 
       //! Update multi-vector values with scaled values of A, this = beta*this + alpha*A.
-      void update(const int &alpha, const MultiVector<int,int,GlobalOrdinal,Node> &A, const int &beta) {
+      void update(const int &/* alpha */, const MultiVector<int,int,GlobalOrdinal,Node> &/* A */, const int &/* beta */) {
         XPETRA_MONITOR("EpetraIntMultiVectorT::update");
 
         // XPETRA_DYNAMIC_CAST(const EpetraMultiVectorT, A, eA, "This Xpetra::EpetraMultiVectorT method only accept Xpetra::EpetraMultiVectorT as input arguments.");
@@ -966,7 +966,7 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
       }
 
       //! Update multi-vector with scaled values of A and B, this = gamma*this + alpha*A + beta*B.
-      void update(const int &alpha, const MultiVector<int,int,GlobalOrdinal,Node> &A, const int &beta, const MultiVector<int,int,GlobalOrdinal,Node> &B, const int &gamma) {
+      void update(const int &/* alpha */, const MultiVector<int,int,GlobalOrdinal,Node> &/* A */, const int &/* beta */, const MultiVector<int,int,GlobalOrdinal,Node> &/* B */, const int &/* gamma */) {
         XPETRA_MONITOR("EpetraIntMultiVectorT::update");
 
         //XPETRA_DYNAMIC_CAST(const EpetraMultiVectorT, A, eA, "This Xpetra::EpetraMultiVectorT method only accept Xpetra::EpetraMultiVectorT as input arguments.");
@@ -975,25 +975,25 @@ const Epetra_IntMultiVector & toEpetra(const MultiVector<int, int, GlobalOrdinal
       }
 
       //! Compute 1-norm of each vector in multi-vector.
-      void norm1(const Teuchos::ArrayView<Teuchos::ScalarTraits<int>::magnitudeType> &norms) const { XPETRA_MONITOR("EpetraIntMultiVectorT::norm1"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+      void norm1(const Teuchos::ArrayView<Teuchos::ScalarTraits<int>::magnitudeType> &/* norms */) const { XPETRA_MONITOR("EpetraIntMultiVectorT::norm1"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
 
       //! Compute 2-norm of each vector in multi-vector.
-      void norm2(const Teuchos::ArrayView<Teuchos::ScalarTraits<int>::magnitudeType> &norms) const { XPETRA_MONITOR("EpetraIntMultiVectorT::norm2"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+      void norm2(const Teuchos::ArrayView<Teuchos::ScalarTraits<int>::magnitudeType> &/* norms */) const { XPETRA_MONITOR("EpetraIntMultiVectorT::norm2"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
 
       //! Compute Inf-norm of each vector in multi-vector.
-      void normInf(const Teuchos::ArrayView<Teuchos::ScalarTraits<int>::magnitudeType> &norms) const { XPETRA_MONITOR("EpetraIntMultiVectorT::normInf"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+      void normInf(const Teuchos::ArrayView<Teuchos::ScalarTraits<int>::magnitudeType> &/* norms */) const { XPETRA_MONITOR("EpetraIntMultiVectorT::normInf"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
 
       //! Compute mean (average) value of each vector in multi-vector.
-      void meanValue(const Teuchos::ArrayView<int> &means) const { XPETRA_MONITOR("EpetraIntMultiVectorT::meanValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+      void meanValue(const Teuchos::ArrayView<int> &/* means */) const { XPETRA_MONITOR("EpetraIntMultiVectorT::meanValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
 
       //! Compute max value of each vector in multi-vector.
-      void maxValue(const Teuchos::ArrayView<int> &maxs) const { XPETRA_MONITOR("EpetraIntMultiVectorT::maxValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+      void maxValue(const Teuchos::ArrayView<int> &/* maxs */) const { XPETRA_MONITOR("EpetraIntMultiVectorT::maxValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
 
       //! Matrix-Matrix multiplication, this = beta*this + alpha*op(A)*op(B).
-      void multiply(Teuchos::ETransp transA, Teuchos::ETransp transB, const int &alpha, const MultiVector<int,int,GlobalOrdinal,Node> &A, const MultiVector<int,int,GlobalOrdinal,Node> &B, const int &beta) { XPETRA_MONITOR("EpetraIntMultiVectorT::multiply"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Not available in Epetra"); }
+      void multiply(Teuchos::ETransp /* transA */, Teuchos::ETransp /* transB */, const int &/* alpha */, const MultiVector<int,int,GlobalOrdinal,Node> &/* A */, const MultiVector<int,int,GlobalOrdinal,Node> &/* B */, const int &/* beta */) { XPETRA_MONITOR("EpetraIntMultiVectorT::multiply"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Not available in Epetra"); }
 
       //! Element-wise multiply of a Vector A with a EpetraMultiVector B.
-      void elementWiseMultiply(int scalarAB, const Vector<int,int,GlobalOrdinal,Node> &A, const MultiVector<int,int,GlobalOrdinal,Node> &B, int scalarThis) {
+      void elementWiseMultiply(int /* scalarAB */, const Vector<int,int,GlobalOrdinal,Node> &/* A */, const MultiVector<int,int,GlobalOrdinal,Node> &/* B */, int /* scalarThis */) {
           XPETRA_MONITOR("EpetraIntMultiVectorT::elementWiseMultiply");
           TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra_EpetraIntMultiVector: elementWiseMultiply not implemented because Epetra_IntMultiVector does not support this operation");
         }

--- a/packages/xpetra/src/MultiVector/Xpetra_EpetraMultiVector.hpp
+++ b/packages/xpetra/src/MultiVector/Xpetra_EpetraMultiVector.hpp
@@ -543,7 +543,7 @@ namespace Xpetra {
     }
 
     //! Print the object with the given verbosity level to a FancyOStream.
-    void describe(Teuchos::FancyOStream &out, const Teuchos::EVerbosityLevel verbLevel=Teuchos::Describable::verbLevel_default) const {
+    void describe(Teuchos::FancyOStream &out, const Teuchos::EVerbosityLevel /* verbLevel */=Teuchos::Describable::verbLevel_default) const {
       XPETRA_MONITOR("EpetraMultiVectorT::describe");
       vec_->Print(out);
     }
@@ -957,7 +957,7 @@ namespace Xpetra {
     }
 
     //! Print the object with the given verbosity level to a FancyOStream.
-    void describe(Teuchos::FancyOStream &out, const Teuchos::EVerbosityLevel verbLevel=Teuchos::Describable::verbLevel_default) const {
+    void describe(Teuchos::FancyOStream &out, const Teuchos::EVerbosityLevel /* verbLevel */=Teuchos::Describable::verbLevel_default) const {
       XPETRA_MONITOR("EpetraMultiVectorT::describe");
       vec_->Print(out);
     }

--- a/packages/xpetra/src/Operator/Xpetra_Operator.hpp
+++ b/packages/xpetra/src/Operator/Xpetra_Operator.hpp
@@ -113,7 +113,7 @@ namespace Xpetra {
 
     //@}
 
-    virtual void removeEmptyProcessesInPlace(const RCP<const Map>& newMap) { }
+    virtual void removeEmptyProcessesInPlace(const RCP<const Map>& /* newMap */) { }
   };
 
 } // Xpetra namespace

--- a/packages/xpetra/src/Vector/Xpetra_EpetraIntVector.hpp
+++ b/packages/xpetra/src/Vector/Xpetra_EpetraIntVector.hpp
@@ -396,7 +396,7 @@ const Epetra_IntVector & toEpetra(const Vector<int, int, GlobalOrdinal, Node> &)
       //@{
 
       //! TODO missing comment
-      int dot(const Vector<Scalar,LocalOrdinal,GlobalOrdinal,Node> &a) const { XPETRA_MONITOR("EpetraIntVectorT::dot"); TEUCHOS_TEST_FOR_EXCEPTION(-1, Xpetra::Exceptions::NotImplemented, "TODO"); TEUCHOS_UNREACHABLE_RETURN(-1); }
+      int dot(const Vector<Scalar,LocalOrdinal,GlobalOrdinal,Node> &/* a */) const { XPETRA_MONITOR("EpetraIntVectorT::dot"); TEUCHOS_TEST_FOR_EXCEPTION(-1, Xpetra::Exceptions::NotImplemented, "TODO"); TEUCHOS_UNREACHABLE_RETURN(-1); }
 
 
       //! Return 1-norm of this Vector.
@@ -422,10 +422,10 @@ const Epetra_IntVector & toEpetra(const Vector<int, int, GlobalOrdinal, Node> &)
       //@{
 
       //! Replace current value at the specified location with specified value.
-      void replaceGlobalValue(GlobalOrdinal globalRow, const Scalar &value) { XPETRA_MONITOR("EpetraIntVectorT::replaceGlobalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+      void replaceGlobalValue(GlobalOrdinal /* globalRow */, const Scalar &/* value */) { XPETRA_MONITOR("EpetraIntVectorT::replaceGlobalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
 
       //! Adds specified value to existing value at the specified location.
-      void sumIntoGlobalValue(GlobalOrdinal globalRow, const Scalar &value) { XPETRA_MONITOR("EpetraIntVectorT::sumIntoGlobalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+      void sumIntoGlobalValue(GlobalOrdinal /* globalRow */, const Scalar &/* value */) { XPETRA_MONITOR("EpetraIntVectorT::sumIntoGlobalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
 
       //! Replace current value at the specified location with specified values.
       void replaceLocalValue(LocalOrdinal myRow, const Scalar &value) { XPETRA_MONITOR("EpetraIntVectorT::replaceLocalValue");(*vec_)[myRow] = value; }
@@ -437,12 +437,12 @@ const Epetra_IntVector & toEpetra(const Vector<int, int, GlobalOrdinal, Node> &)
       void putScalar(const int &value) {  vec_->PutValue(value); }
 
       //! Set multi-vector values to random numbers.
-      void randomize(bool bUseXpetraImplementation = true) { XPETRA_MONITOR("EpetraIntVectorT::randomize"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraIntVectorT::randomize(): Functionnality not available in Epetra"); }
+      void randomize(bool /* bUseXpetraImplementation */ = true) { XPETRA_MONITOR("EpetraIntVectorT::randomize"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraIntVectorT::randomize(): Functionnality not available in Epetra"); }
 
 
       //! Set seed for Random function.
       /** Note: this method does not exist in Tpetra interface. Added for MueLu. */
-      void setSeed(unsigned int seed) { XPETRA_MONITOR("EpetraIntVectorT::setSeed"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraIntVectorT::setSeed(): Functionnality not available in Epetra"); }
+      void setSeed(unsigned int /* seed */) { XPETRA_MONITOR("EpetraIntVectorT::setSeed"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraIntVectorT::setSeed(): Functionnality not available in Epetra"); }
 
 
       //@}
@@ -451,18 +451,18 @@ const Epetra_IntVector & toEpetra(const Vector<int, int, GlobalOrdinal, Node> &)
       //@{
 
       //! Return a Vector which is a const view of column j.
-      Teuchos::RCP< const Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > > getVector(size_t j) const {
+      Teuchos::RCP< const Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > > getVector(size_t /* j */) const {
          TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
        }
 
       //! Return a Vector which is a nonconst view of column j.
-      Teuchos::RCP< Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > > getVectorNonConst(size_t j) {
+      Teuchos::RCP< Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > > getVectorNonConst(size_t /* j */) {
         TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
       }
 
       //! Const Local vector access function.
       //! View of the local values in a particular vector of this multi-vector.
-      Teuchos::ArrayRCP<const int> getData(size_t j) const {
+      Teuchos::ArrayRCP<const int> getData(size_t /* j */) const {
         XPETRA_MONITOR("EpetraIntVectorT::getData");
 
         int * data = vec_->Values();
@@ -473,7 +473,7 @@ const Epetra_IntVector & toEpetra(const Vector<int, int, GlobalOrdinal, Node> &)
 
       //! Local vector access function.
       //! View of the local values in a particular vector of this multi-vector.
-      Teuchos::ArrayRCP<int> getDataNonConst(size_t j) {
+      Teuchos::ArrayRCP<int> getDataNonConst(size_t /* j */) {
         XPETRA_MONITOR("EpetraIntVectorT::getDataNonConst");
 
         int * data = vec_->Values();
@@ -487,7 +487,7 @@ const Epetra_IntVector & toEpetra(const Vector<int, int, GlobalOrdinal, Node> &)
       //! @name Mathematical methods
       //@{
       //! Computes dot product of each corresponding pair of vectors, dots[i] = this[i].dot(A[i])
-      void dot(const MultiVector<int,int,GlobalOrdinal,Node> &A, const Teuchos::ArrayView<int> &dots) const {
+      void dot(const MultiVector<int,int,GlobalOrdinal,Node> &/* A */, const Teuchos::ArrayView<int> &/* dots */) const {
         XPETRA_MONITOR("EpetraIntVectorT::dot");
 
         //XPETRA_DYNAMIC_CAST(const EpetraMultiVectorT, A, eA, "This Xpetra::EpetraMultiVectorT method only accept Xpetra::EpetraMultiVectorT as input arguments.");
@@ -495,7 +495,7 @@ const Epetra_IntVector & toEpetra(const Vector<int, int, GlobalOrdinal, Node> &)
       }
 
       //! Puts element-wise absolute values of input Multi-vector in target: A = abs(this)
-      void abs(const MultiVector<int,int,GlobalOrdinal,Node> &A) {
+      void abs(const MultiVector<int,int,GlobalOrdinal,Node> &/* A */) {
         XPETRA_MONITOR("EpetraIntVectorT::abs");
 
         //XPETRA_DYNAMIC_CAST(const EpetraMultiVectorT, A, eA, "This Xpetra::EpetraMultiVectorT method only accept Xpetra::EpetraMultiVectorT as input arguments.");
@@ -503,7 +503,7 @@ const Epetra_IntVector & toEpetra(const Vector<int, int, GlobalOrdinal, Node> &)
       }
 
       //! Puts element-wise reciprocal values of input Multi-vector in target, this(i,j) = 1/A(i,j).
-      void reciprocal(const MultiVector<int,int,GlobalOrdinal,Node> &A) {
+      void reciprocal(const MultiVector<int,int,GlobalOrdinal,Node> &/* A */) {
         XPETRA_MONITOR("EpetraIntVectorT::reciprocal");
 
         //XPETRA_DYNAMIC_CAST(const EpetraMultiVectorT, A, eA, "This Xpetra::EpetraMultiVectorT method only accept Xpetra::EpetraMultiVectorT as input arguments.");
@@ -511,19 +511,19 @@ const Epetra_IntVector & toEpetra(const Vector<int, int, GlobalOrdinal, Node> &)
       }
 
       //! Scale the current values of a multi-vector, this = alpha*this.
-      void scale(const int &alpha) {
+      void scale(const int &/* alpha */) {
         XPETRA_MONITOR("EpetraIntVectorT::scale");
         TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
       }
 
       //! Scale the current values of a multi-vector, this[j] = alpha[j]*this[j].
-      void scale (Teuchos::ArrayView< const int > alpha) {
+      void scale (Teuchos::ArrayView< const int > /* alpha */) {
         XPETRA_MONITOR("EpetraIntVectorT::scale");
         TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
       }
 
       //! Update multi-vector values with scaled values of A, this = beta*this + alpha*A.
-      void update(const int &alpha, const MultiVector<int,int,GlobalOrdinal,Node> &A, const int &beta) {
+      void update(const int &/* alpha */, const MultiVector<int,int,GlobalOrdinal,Node> &/* A */, const int &/* beta */) {
         XPETRA_MONITOR("EpetraIntVectorT::update");
 
         // XPETRA_DYNAMIC_CAST(const EpetraMultiVectorT, A, eA, "This Xpetra::EpetraMultiVectorT method only accept Xpetra::EpetraMultiVectorT as input arguments.");
@@ -531,7 +531,7 @@ const Epetra_IntVector & toEpetra(const Vector<int, int, GlobalOrdinal, Node> &)
       }
 
       //! Update multi-vector with scaled values of A and B, this = gamma*this + alpha*A + beta*B.
-      void update(const int &alpha, const MultiVector<int,int,GlobalOrdinal,Node> &A, const int &beta, const MultiVector<int,int,GlobalOrdinal,Node> &B, const int &gamma) {
+      void update(const int &/* alpha */, const MultiVector<int,int,GlobalOrdinal,Node> &/* A */, const int &/* beta */, const MultiVector<int,int,GlobalOrdinal,Node> &/* B */, const int &/* gamma */) {
         XPETRA_MONITOR("EpetraIntVectorT::update");
 
         //XPETRA_DYNAMIC_CAST(const EpetraMultiVectorT, A, eA, "This Xpetra::EpetraMultiVectorT method only accept Xpetra::EpetraMultiVectorT as input arguments.");
@@ -540,25 +540,25 @@ const Epetra_IntVector & toEpetra(const Vector<int, int, GlobalOrdinal, Node> &)
       }
 
       //! Compute 1-norm of each vector in multi-vector.
-      void norm1(const Teuchos::ArrayView<Teuchos::ScalarTraits<int>::magnitudeType> &norms) const { XPETRA_MONITOR("EpetraIntVectorT::norm1"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+      void norm1(const Teuchos::ArrayView<Teuchos::ScalarTraits<int>::magnitudeType> &/* norms */) const { XPETRA_MONITOR("EpetraIntVectorT::norm1"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
 
       //! Compute 2-norm of each vector in multi-vector.
-      void norm2(const Teuchos::ArrayView<Teuchos::ScalarTraits<int>::magnitudeType> &norms) const { XPETRA_MONITOR("EpetraIntVectorT::norm2"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+      void norm2(const Teuchos::ArrayView<Teuchos::ScalarTraits<int>::magnitudeType> &/* norms */) const { XPETRA_MONITOR("EpetraIntVectorT::norm2"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
 
       //! Compute Inf-norm of each vector in multi-vector.
-      void normInf(const Teuchos::ArrayView<Teuchos::ScalarTraits<int>::magnitudeType> &norms) const { XPETRA_MONITOR("EpetraIntVectorT::normInf"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+      void normInf(const Teuchos::ArrayView<Teuchos::ScalarTraits<int>::magnitudeType> &/* norms */) const { XPETRA_MONITOR("EpetraIntVectorT::normInf"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
 
       //! Compute mean (average) value of each vector in multi-vector.
-      void meanValue(const Teuchos::ArrayView<int> &means) const { XPETRA_MONITOR("EpetraIntVectorT::meanValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+      void meanValue(const Teuchos::ArrayView<int> &/* means */) const { XPETRA_MONITOR("EpetraIntVectorT::meanValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
 
       //! Compute max value of each vector in multi-vector.
-      void maxValue(const Teuchos::ArrayView<int> &maxs) const { XPETRA_MONITOR("EpetraIntVectorT::maxValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+      void maxValue(const Teuchos::ArrayView<int> &/* maxs */) const { XPETRA_MONITOR("EpetraIntVectorT::maxValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
 
       //! Matrix-Matrix multiplication, this = beta*this + alpha*op(A)*op(B).
-      void multiply(Teuchos::ETransp transA, Teuchos::ETransp transB, const int &alpha, const MultiVector<int,int,GlobalOrdinal,Node> &A, const MultiVector<int,int,GlobalOrdinal,Node> &B, const int &beta) { XPETRA_MONITOR("EpetraIntVectorT::multiply"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Not available in Epetra"); }
+      void multiply(Teuchos::ETransp /* transA */, Teuchos::ETransp /* transB */, const int &/* alpha */, const MultiVector<int,int,GlobalOrdinal,Node> &/* A */, const MultiVector<int,int,GlobalOrdinal,Node> &/* B */, const int &/* beta */) { XPETRA_MONITOR("EpetraIntVectorT::multiply"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Not available in Epetra"); }
 
       //! Element-wise multiply of a Vector A with a EpetraMultiVector B.
-      void elementWiseMultiply(int scalarAB, const Vector<int,int,GlobalOrdinal,Node> &A, const MultiVector<int,int,GlobalOrdinal,Node> &B, int scalarThis) {
+      void elementWiseMultiply(int /* scalarAB */, const Vector<int,int,GlobalOrdinal,Node> &/* A */, const MultiVector<int,int,GlobalOrdinal,Node> &/* B */, int /* scalarThis */) {
           XPETRA_MONITOR("EpetraIntVectorT::elementWiseMultiply");
           TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra_EpetraIntVector: elementWiseMultiply not implemented because Epetra_IntVector does not support this operation");
         }
@@ -569,16 +569,16 @@ const Epetra_IntVector & toEpetra(const Vector<int, int, GlobalOrdinal, Node> &)
       //@{
 
       //! Replace value, using global (row) index.
-      void replaceGlobalValue(GlobalOrdinal globalRow, size_t vectorIndex, const Scalar &value) { XPETRA_MONITOR("EpetraIntVectorT::replaceGlobalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+      void replaceGlobalValue(GlobalOrdinal /* globalRow */, size_t /* vectorIndex */, const Scalar &/* value */) { XPETRA_MONITOR("EpetraIntVectorT::replaceGlobalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
 
       //! Add value to existing value, using global (row) index.
-      void sumIntoGlobalValue(GlobalOrdinal globalRow, size_t vectorIndex, const Scalar &value) { XPETRA_MONITOR("EpetraIntVectorT::sumIntoGlobalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+      void sumIntoGlobalValue(GlobalOrdinal /* globalRow */, size_t /* vectorIndex */, const Scalar &/* value */) { XPETRA_MONITOR("EpetraIntVectorT::sumIntoGlobalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
 
       //! Replace value, using local (row) index.
-      void replaceLocalValue(LocalOrdinal myRow, size_t vectorIndex, const Scalar &value) { XPETRA_MONITOR("EpetraIntVectorT::replaceLocalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+      void replaceLocalValue(LocalOrdinal /* myRow */, size_t /* vectorIndex */, const Scalar &/* value */) { XPETRA_MONITOR("EpetraIntVectorT::replaceLocalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
 
       //! Add value to existing value, using local (row) index.
-      void sumIntoLocalValue(LocalOrdinal myRow, size_t vectorIndex, const Scalar &value) { XPETRA_MONITOR("EpetraIntVectorT::sumIntoLocalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+      void sumIntoLocalValue(LocalOrdinal /* myRow */, size_t /* vectorIndex */, const Scalar &/* value */) { XPETRA_MONITOR("EpetraIntVectorT::sumIntoLocalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
 
       //@}
 
@@ -701,7 +701,7 @@ const Epetra_IntVector & toEpetra(const Vector<int, int, GlobalOrdinal, Node> &)
         TEUCHOS_TEST_FOR_EXCEPTION(err != 0, std::runtime_error, "Catch error code returned by Epetra.");
       }
 
-      void replaceMap(const RCP<const Map<int, GlobalOrdinal, Node> >& map) {
+      void replaceMap(const RCP<const Map<int, GlobalOrdinal, Node> >& /* map */) {
         // do nothing
       }
 
@@ -835,7 +835,7 @@ const Epetra_IntVector & toEpetra(const Vector<int, int, GlobalOrdinal, Node> &)
       //@{
 
       //! TODO missing comment
-      int dot(const Vector<Scalar,LocalOrdinal,GlobalOrdinal,Node> &a) const { XPETRA_MONITOR("EpetraIntVectorT::dot"); TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::NotImplemented, "TODO"); /* return -1; */ }
+      int dot(const Vector<Scalar,LocalOrdinal,GlobalOrdinal,Node> &/* a */) const { XPETRA_MONITOR("EpetraIntVectorT::dot"); TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::NotImplemented, "TODO"); /* return -1; */ }
 
 
       //! Return 1-norm of this Vector.
@@ -860,10 +860,10 @@ const Epetra_IntVector & toEpetra(const Vector<int, int, GlobalOrdinal, Node> &)
       //@{
 
       //! Replace current value at the specified location with specified value.
-      void replaceGlobalValue(GlobalOrdinal globalRow, const Scalar &value) { XPETRA_MONITOR("EpetraIntVectorT::replaceGlobalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+      void replaceGlobalValue(GlobalOrdinal /* globalRow */, const Scalar &/* value */) { XPETRA_MONITOR("EpetraIntVectorT::replaceGlobalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
 
       //! Adds specified value to existing value at the specified location.
-      void sumIntoGlobalValue(GlobalOrdinal globalRow, const Scalar &value) { XPETRA_MONITOR("EpetraIntVectorT::sumIntoGlobalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+      void sumIntoGlobalValue(GlobalOrdinal /* globalRow */, const Scalar &/* value */) { XPETRA_MONITOR("EpetraIntVectorT::sumIntoGlobalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
 
       //! Replace current value at the specified location with specified values.
       void replaceLocalValue(LocalOrdinal myRow, const Scalar &value) { XPETRA_MONITOR("EpetraIntVectorT::replaceLocalValue");(*vec_)[myRow] = value;}
@@ -875,12 +875,12 @@ const Epetra_IntVector & toEpetra(const Vector<int, int, GlobalOrdinal, Node> &)
       void putScalar(const int &value) {  vec_->PutValue(value); }
 
       //! Set multi-vector values to random numbers.
-      void randomize(bool bUseXpetraImplementation = true) { XPETRA_MONITOR("EpetraIntVectorT::randomize"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraIntVectorT::randomize(): Functionnality not available in Epetra"); }
+      void randomize(bool /* bUseXpetraImplementation */ = true) { XPETRA_MONITOR("EpetraIntVectorT::randomize"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraIntVectorT::randomize(): Functionnality not available in Epetra"); }
 
 
       //! Set seed for Random function.
       /** Note: this method does not exist in Tpetra interface. Added for MueLu. */
-      void setSeed(unsigned int seed) { XPETRA_MONITOR("EpetraIntVectorT::setSeed"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraIntVectorT::setSeed(): Functionnality not available in Epetra"); }
+      void setSeed(unsigned int /* seed */) { XPETRA_MONITOR("EpetraIntVectorT::setSeed"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra::EpetraIntVectorT::setSeed(): Functionnality not available in Epetra"); }
 
 
       //@}
@@ -889,18 +889,18 @@ const Epetra_IntVector & toEpetra(const Vector<int, int, GlobalOrdinal, Node> &)
       //@{
 
       //! Return a Vector which is a const view of column j.
-      Teuchos::RCP< const Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > > getVector(size_t j) const {
+      Teuchos::RCP< const Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > > getVector(size_t /* j */) const {
          TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
        }
 
       //! Return a Vector which is a nonconst view of column j.
-      Teuchos::RCP< Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > > getVectorNonConst(size_t j) {
+      Teuchos::RCP< Vector< Scalar, LocalOrdinal, GlobalOrdinal, Node > > getVectorNonConst(size_t /* j */) {
         TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
       }
 
       //! Const Local vector access function.
       //! View of the local values in a particular vector of this multi-vector.
-      Teuchos::ArrayRCP<const int> getData(size_t j) const {
+      Teuchos::ArrayRCP<const int> getData(size_t /* j */) const {
         XPETRA_MONITOR("EpetraIntVectorT::getData");
 
         int * data = vec_->Values();
@@ -911,7 +911,7 @@ const Epetra_IntVector & toEpetra(const Vector<int, int, GlobalOrdinal, Node> &)
 
       //! Local vector access function.
       //! View of the local values in a particular vector of this multi-vector.
-      Teuchos::ArrayRCP<int> getDataNonConst(size_t j) {
+      Teuchos::ArrayRCP<int> getDataNonConst(size_t /* j */) {
         XPETRA_MONITOR("EpetraIntVectorT::getDataNonConst");
 
         int * data = vec_->Values();
@@ -925,7 +925,7 @@ const Epetra_IntVector & toEpetra(const Vector<int, int, GlobalOrdinal, Node> &)
       //! @name Mathematical methods
       //@{
       //! Computes dot product of each corresponding pair of vectors, dots[i] = this[i].dot(A[i])
-      void dot(const MultiVector<int,int,GlobalOrdinal,Node> &A, const Teuchos::ArrayView<int> &dots) const {
+      void dot(const MultiVector<int,int,GlobalOrdinal,Node> &/* A */, const Teuchos::ArrayView<int> &/* dots */) const {
         XPETRA_MONITOR("EpetraIntVectorT::dot");
 
         //XPETRA_DYNAMIC_CAST(const EpetraMultiVectorT, A, eA, "This Xpetra::EpetraMultiVectorT method only accept Xpetra::EpetraMultiVectorT as input arguments.");
@@ -933,7 +933,7 @@ const Epetra_IntVector & toEpetra(const Vector<int, int, GlobalOrdinal, Node> &)
       }
 
       //! Puts element-wise absolute values of input Multi-vector in target: A = abs(this)
-      void abs(const MultiVector<int,int,GlobalOrdinal,Node> &A) {
+      void abs(const MultiVector<int,int,GlobalOrdinal,Node> &/* A */) {
         XPETRA_MONITOR("EpetraIntVectorT::abs");
 
         //XPETRA_DYNAMIC_CAST(const EpetraMultiVectorT, A, eA, "This Xpetra::EpetraMultiVectorT method only accept Xpetra::EpetraMultiVectorT as input arguments.");
@@ -941,7 +941,7 @@ const Epetra_IntVector & toEpetra(const Vector<int, int, GlobalOrdinal, Node> &)
       }
 
       //! Puts element-wise reciprocal values of input Multi-vector in target, this(i,j) = 1/A(i,j).
-      void reciprocal(const MultiVector<int,int,GlobalOrdinal,Node> &A) {
+      void reciprocal(const MultiVector<int,int,GlobalOrdinal,Node> &/* A */) {
         XPETRA_MONITOR("EpetraIntVectorT::reciprocal");
 
         //XPETRA_DYNAMIC_CAST(const EpetraMultiVectorT, A, eA, "This Xpetra::EpetraMultiVectorT method only accept Xpetra::EpetraMultiVectorT as input arguments.");
@@ -949,19 +949,19 @@ const Epetra_IntVector & toEpetra(const Vector<int, int, GlobalOrdinal, Node> &)
       }
 
       //! Scale the current values of a multi-vector, this = alpha*this.
-      void scale(const int &alpha) {
+      void scale(const int &/* alpha */) {
         XPETRA_MONITOR("EpetraIntVectorT::scale");
         TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
       }
 
       //! Scale the current values of a multi-vector, this[j] = alpha[j]*this[j].
-      void scale (Teuchos::ArrayView< const int > alpha) {
+      void scale (Teuchos::ArrayView< const int > /* alpha */) {
         XPETRA_MONITOR("EpetraIntVectorT::scale");
         TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO");
       }
 
       //! Update multi-vector values with scaled values of A, this = beta*this + alpha*A.
-      void update(const int &alpha, const MultiVector<int,int,GlobalOrdinal,Node> &A, const int &beta) {
+      void update(const int &/* alpha */, const MultiVector<int,int,GlobalOrdinal,Node> &/* A */, const int &/* beta */) {
         XPETRA_MONITOR("EpetraIntVectorT::update");
 
         // XPETRA_DYNAMIC_CAST(const EpetraMultiVectorT, A, eA, "This Xpetra::EpetraMultiVectorT method only accept Xpetra::EpetraMultiVectorT as input arguments.");
@@ -969,7 +969,7 @@ const Epetra_IntVector & toEpetra(const Vector<int, int, GlobalOrdinal, Node> &)
       }
 
       //! Update multi-vector with scaled values of A and B, this = gamma*this + alpha*A + beta*B.
-      void update(const int &alpha, const MultiVector<int,int,GlobalOrdinal,Node> &A, const int &beta, const MultiVector<int,int,GlobalOrdinal,Node> &B, const int &gamma) {
+      void update(const int &/* alpha */, const MultiVector<int,int,GlobalOrdinal,Node> &/* A */, const int &/* beta */, const MultiVector<int,int,GlobalOrdinal,Node> &/* B */, const int &/* gamma */) {
         XPETRA_MONITOR("EpetraIntVectorT::update");
 
         //XPETRA_DYNAMIC_CAST(const EpetraMultiVectorT, A, eA, "This Xpetra::EpetraMultiVectorT method only accept Xpetra::EpetraMultiVectorT as input arguments.");
@@ -978,25 +978,25 @@ const Epetra_IntVector & toEpetra(const Vector<int, int, GlobalOrdinal, Node> &)
       }
 
       //! Compute 1-norm of each vector in multi-vector.
-      void norm1(const Teuchos::ArrayView<Teuchos::ScalarTraits<int>::magnitudeType> &norms) const { XPETRA_MONITOR("EpetraIntVectorT::norm1"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+      void norm1(const Teuchos::ArrayView<Teuchos::ScalarTraits<int>::magnitudeType> &/* norms */) const { XPETRA_MONITOR("EpetraIntVectorT::norm1"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
 
       //! Compute 2-norm of each vector in multi-vector.
-      void norm2(const Teuchos::ArrayView<Teuchos::ScalarTraits<int>::magnitudeType> &norms) const { XPETRA_MONITOR("EpetraIntVectorT::norm2"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+      void norm2(const Teuchos::ArrayView<Teuchos::ScalarTraits<int>::magnitudeType> &/* norms */) const { XPETRA_MONITOR("EpetraIntVectorT::norm2"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
 
       //! Compute Inf-norm of each vector in multi-vector.
-      void normInf(const Teuchos::ArrayView<Teuchos::ScalarTraits<int>::magnitudeType> &norms) const { XPETRA_MONITOR("EpetraIntVectorT::normInf"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+      void normInf(const Teuchos::ArrayView<Teuchos::ScalarTraits<int>::magnitudeType> &/* norms */) const { XPETRA_MONITOR("EpetraIntVectorT::normInf"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
 
       //! Compute mean (average) value of each vector in multi-vector.
-      void meanValue(const Teuchos::ArrayView<int> &means) const { XPETRA_MONITOR("EpetraIntVectorT::meanValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+      void meanValue(const Teuchos::ArrayView<int> &/* means */) const { XPETRA_MONITOR("EpetraIntVectorT::meanValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
 
       //! Compute max value of each vector in multi-vector.
-      void maxValue(const Teuchos::ArrayView<int> &maxs) const { XPETRA_MONITOR("EpetraIntVectorT::maxValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+      void maxValue(const Teuchos::ArrayView<int> &/* maxs */) const { XPETRA_MONITOR("EpetraIntVectorT::maxValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
 
       //! Matrix-Matrix multiplication, this = beta*this + alpha*op(A)*op(B).
-      void multiply(Teuchos::ETransp transA, Teuchos::ETransp transB, const int &alpha, const MultiVector<int,int,GlobalOrdinal,Node> &A, const MultiVector<int,int,GlobalOrdinal,Node> &B, const int &beta) { XPETRA_MONITOR("EpetraIntVectorT::multiply"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Not available in Epetra"); }
+      void multiply(Teuchos::ETransp /* transA */, Teuchos::ETransp /* transB */, const int &/* alpha */, const MultiVector<int,int,GlobalOrdinal,Node> &/* A */, const MultiVector<int,int,GlobalOrdinal,Node> &/* B */, const int &/* beta */) { XPETRA_MONITOR("EpetraIntVectorT::multiply"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Not available in Epetra"); }
 
       //! Element-wise multiply of a Vector A with a EpetraMultiVector B.
-      void elementWiseMultiply(int scalarAB, const Vector<int,int,GlobalOrdinal,Node> &A, const MultiVector<int,int,GlobalOrdinal,Node> &B, int scalarThis) {
+      void elementWiseMultiply(int /* scalarAB */, const Vector<int,int,GlobalOrdinal,Node> &/* A */, const MultiVector<int,int,GlobalOrdinal,Node> &/* B */, int /* scalarThis */) {
           XPETRA_MONITOR("EpetraIntVectorT::elementWiseMultiply");
           TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "Xpetra_EpetraIntVector: elementWiseMultiply not implemented because Epetra_IntVector does not support this operation");
         }
@@ -1007,16 +1007,16 @@ const Epetra_IntVector & toEpetra(const Vector<int, int, GlobalOrdinal, Node> &)
       //@{
 
       //! Replace value, using global (row) index.
-      void replaceGlobalValue(GlobalOrdinal globalRow, size_t vectorIndex, const Scalar &value) { XPETRA_MONITOR("EpetraIntVectorT::replaceGlobalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+      void replaceGlobalValue(GlobalOrdinal /* globalRow */, size_t /* vectorIndex */, const Scalar &/* value */) { XPETRA_MONITOR("EpetraIntVectorT::replaceGlobalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
 
       //! Add value to existing value, using global (row) index.
-      void sumIntoGlobalValue(GlobalOrdinal globalRow, size_t vectorIndex, const Scalar &value) { XPETRA_MONITOR("EpetraIntVectorT::sumIntoGlobalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+      void sumIntoGlobalValue(GlobalOrdinal /* globalRow */, size_t /* vectorIndex */, const Scalar &/* value */) { XPETRA_MONITOR("EpetraIntVectorT::sumIntoGlobalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
 
       //! Replace value, using local (row) index.
-      void replaceLocalValue(LocalOrdinal myRow, size_t vectorIndex, const Scalar &value) { XPETRA_MONITOR("EpetraIntVectorT::replaceLocalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+      void replaceLocalValue(LocalOrdinal /* myRow */, size_t /* vectorIndex */, const Scalar &/* value */) { XPETRA_MONITOR("EpetraIntVectorT::replaceLocalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
 
       //! Add value to existing value, using local (row) index.
-      void sumIntoLocalValue(LocalOrdinal myRow, size_t vectorIndex, const Scalar &value) { XPETRA_MONITOR("EpetraIntVectorT::sumIntoLocalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
+      void sumIntoLocalValue(LocalOrdinal /* myRow */, size_t /* vectorIndex */, const Scalar &/* value */) { XPETRA_MONITOR("EpetraIntVectorT::sumIntoLocalValue"); TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "TODO"); }
 
       //@}
 
@@ -1139,7 +1139,7 @@ const Epetra_IntVector & toEpetra(const Vector<int, int, GlobalOrdinal, Node> &)
         TEUCHOS_TEST_FOR_EXCEPTION(err != 0, std::runtime_error, "Catch error code returned by Epetra.");
       }
 
-      void replaceMap(const RCP<const Map<int, GlobalOrdinal, Node> >& map) {
+      void replaceMap(const RCP<const Map<int, GlobalOrdinal, Node> >& /* map */) {
         // do nothing
       }
 

--- a/packages/xpetra/sup/StridedMap/Xpetra_StridedMap.hpp
+++ b/packages/xpetra/sup/StridedMap/Xpetra_StridedMap.hpp
@@ -387,7 +387,7 @@ namespace Xpetra {
       TEUCHOS_TEST_FOR_EXCEPTION(CheckConsistency() == false, Exceptions::RuntimeError, "StridedTpetraMap::StridedTpetraMap: CheckConsistency() == false");
     }
 
-    StridedMap(const RCP<const Map>& map, std::vector<size_t>& stridingInfo, GlobalOrdinal indexBase, LocalOrdinal stridedBlockId = -1, GlobalOrdinal offset = 0)
+    StridedMap(const RCP<const Map>& map, std::vector<size_t>& stridingInfo, GlobalOrdinal /* indexBase */, LocalOrdinal stridedBlockId = -1, GlobalOrdinal offset = 0)
     : stridingInfo_(stridingInfo), stridedBlockId_(stridedBlockId), offset_(offset), indexBase_(map->getIndexBase())
     {
       // TAW: 11/24/15

--- a/packages/xpetra/sup/StridedMap/Xpetra_StridedMapFactory.hpp
+++ b/packages/xpetra/sup/StridedMap/Xpetra_StridedMapFactory.hpp
@@ -153,7 +153,7 @@ namespace Xpetra {
            std::vector<size_t>& stridingInfo,
            const Teuchos::RCP<const Teuchos::Comm<int> > &comm,
            LocalOrdinal stridedBlockId = -1, // FIXME (mfh 03 Sep 2014) This breaks if LocalOrdinal is unsigned
-           GlobalOrdinal offset = 0,
+           GlobalOrdinal /* offset */ = 0,
            const Teuchos::RCP<Node> &node = Teuchos::rcp(new Node))
     {
       return rcp (new StridedMap (lib, numGlobalElements, elementList,

--- a/packages/xpetra/sup/Utils/Xpetra_IO.hpp
+++ b/packages/xpetra/sup/Utils/Xpetra_IO.hpp
@@ -104,7 +104,7 @@ namespace Xpetra {
   // This non-member templated function exists so that the matrix-matrix multiply will compile if Epetra, Tpetra, and ML are enabled.
   template<class SC,class LO,class GO,class NO>
   RCP<Xpetra::CrsMatrixWrap<SC,LO,GO,NO> >
-  Convert_Epetra_CrsMatrix_ToXpetra_CrsMatrixWrap (RCP<Epetra_CrsMatrix> &epAB) {
+  Convert_Epetra_CrsMatrix_ToXpetra_CrsMatrixWrap (RCP<Epetra_CrsMatrix> &/* epAB */) {
     TEUCHOS_TEST_FOR_EXCEPTION(true, Exceptions::RuntimeError,
       "Convert_Epetra_CrsMatrix_ToXpetra_CrsMatrixWrap cannot be used with Scalar != double, LocalOrdinal != int, GlobalOrdinal != int");
     TEUCHOS_UNREACHABLE_RETURN(Teuchos::null);

--- a/packages/xpetra/sup/Utils/Xpetra_MatrixMatrix.hpp
+++ b/packages/xpetra/sup/Utils/Xpetra_MatrixMatrix.hpp
@@ -1119,6 +1119,9 @@ Note: this class is not in the Xpetra_UseShortNames.hpp
 
       return result;
 #else // no MUELU_ML
+      (void)epA;
+      (void)epB;
+      (void)fos;
       TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::RuntimeError,
                                  "No ML multiplication available. This feature is currently not supported by Xpetra.");
        TEUCHOS_UNREACHABLE_RETURN(Teuchos::null);
@@ -1734,9 +1737,9 @@ Note: this class is not in the Xpetra_UseShortNames.hpp
 
 #if defined(HAVE_XPETRA_EPETRA) && defined(HAVE_XPETRA_EPETRAEXT)
     // Michael Gee's MLMultiply
-    static RCP<Epetra_CrsMatrix> MLTwoMatrixMultiply(const Epetra_CrsMatrix& epA,
-                                                     const Epetra_CrsMatrix& epB,
-                                                     Teuchos::FancyOStream& fos) {
+    static RCP<Epetra_CrsMatrix> MLTwoMatrixMultiply(const Epetra_CrsMatrix& /* epA */,
+                                                     const Epetra_CrsMatrix& /* epB */,
+                                                     Teuchos::FancyOStream& /* fos */) {
       TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::RuntimeError,
                                  "No ML multiplication available. This feature is currently not supported by Xpetra.");
       TEUCHOS_UNREACHABLE_RETURN(Teuchos::null);


### PR DESCRIPTION
@trilinos/xpetra 

## Description
Comment out parameter names in function definitions to avoid
`-Wunused-parameter` warnings.

## Motivation and Context
Clean build.