### PR TITLE
Tpetra: Fix #4852 (make CrsGraph implement "new" DistObject interface)

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -1265,12 +1265,6 @@ namespace Tpetra {
     useNewInterface () override;
 
     virtual void
-    copyAndPermute (const SrcDistObject& source,
-                    const size_t numSameIDs,
-                    const Teuchos::ArrayView<const local_ordinal_type>& permuteToLIDs,
-                    const Teuchos::ArrayView<const local_ordinal_type>& permuteFromLIDs) override;
-
-    virtual void
     copyAndPermuteNew (const SrcDistObject& source,
                        const size_t numSameIDs,
                        const Kokkos::DualView<const local_ordinal_type*,
@@ -1306,14 +1300,6 @@ namespace Tpetra {
                             buffer_device_type> numPacketsPerLID) const;
 
     virtual void
-    packAndPrepare (const SrcDistObject& source,
-                    const Teuchos::ArrayView<const local_ordinal_type>& exportLIDs,
-                    Teuchos::Array<global_ordinal_type>& exports,
-                    const Teuchos::ArrayView<size_t>& numPacketsPerLID,
-                    size_t& constantNumPackets,
-                    Distributor& distor) override;
-
-    virtual void
     packAndPrepareNew (const SrcDistObject& source,
                        const Kokkos::DualView<const local_ordinal_type*,
                          buffer_device_type>& exportLIDs,
@@ -1347,14 +1333,6 @@ namespace Tpetra {
                          buffer_device_type> numPacketsPerLID,
                        size_t& constantNumPackets,
                        Distributor& distor) const;
-
-    virtual void
-    unpackAndCombine (const Teuchos::ArrayView<const local_ordinal_type>& importLIDs,
-                      const Teuchos::ArrayView<const global_ordinal_type>& imports,
-                      const Teuchos::ArrayView<size_t>& numPacketsPerLID,
-                      size_t constantNumPackets,
-                      Distributor& distor,
-                      CombineMode CM) override;
 
     virtual void
     unpackAndCombineNew (const Kokkos::DualView<const local_ordinal_type*,

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -2091,9 +2091,8 @@ namespace Tpetra {
   {
     typedef impl_scalar_type IST;
     typedef GlobalOrdinal GO;
-    const char tfecfFuncName[] = "insertGlobalValuesImpl: ";
-
 #ifdef HAVE_TPETRA_DEBUG
+    const char tfecfFuncName[] = "insertGlobalValuesImpl: ";
     const size_t origNumEnt = graph.getNumEntriesInLocalRow (rowInfo.localRow);
 #endif // HAVE_TPETRA_DEBUG
 
@@ -2109,8 +2108,7 @@ namespace Tpetra {
       rowInfo = graph.getRowInfo (rowInfo.localRow);
     }
 
-    if (this->getProfileType() == StaticProfile)
-    {
+    if (this->getProfileType () == StaticProfile) {
       Teuchos::ArrayView<IST> valsView = this->getViewNonConst(rowInfo);
       auto fun = [&](size_t const k, size_t const /*start*/, size_t const offset) {
                    valsView[offset] += vals[k]; };
@@ -2119,8 +2117,7 @@ namespace Tpetra {
         graph.insertGlobalIndicesImpl(rowInfo, gblColInds, numInputEnt, cb);
       newNumEnt = curNumEnt + numInserted;
     }
-    else
-    {
+    else {
       // NOTE (DYNAMICPROFILE_REMOVAL) remove this block
       newNumEnt = curNumEnt + numInputEnt;
       if (newNumEnt > rowInfo.allocSize) {

--- a/packages/tpetra/core/src/Tpetra_Details_packCrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_packCrsGraph_decl.hpp
@@ -160,14 +160,24 @@ packCrsGraph (const CrsGraph<LO, GO, NT>& sourceGraph,
 template<typename LO, typename GO, typename NT>
 void
 packCrsGraphNew (const CrsGraph<LO, GO, NT>& sourceGraph,
-                 Kokkos::DualView<typename CrsGraph<LO,GO,NT>::packet_type*,
-                                  typename CrsGraph<LO,GO,NT>::buffer_device_type>&
-                                  exports,
-                 const Kokkos::DualView<size_t*,
-                                        typename CrsGraph<LO,GO,NT>::buffer_device_type>&
-                                        numPacketsPerLID,
-                 const Kokkos::DualView<const LO*, typename NT::device_type>& exportLIDs,
+                 const Kokkos::DualView<
+                   const LO*,
+                   typename CrsGraph<LO, GO, NT>::buffer_device_type
+                 >& exportLIDs,
+                 const Kokkos::DualView<
+                   const int*,
+                   typename CrsGraph<LO, GO, NT>::buffer_device_type
+                 >& exportPIDs,
+                 Kokkos::DualView<
+                   typename CrsGraph<LO, GO, NT>::packet_type*,
+                   typename CrsGraph<LO, GO, NT>::buffer_device_type
+                 >& exports,
+                 Kokkos::DualView<
+                   size_t*,
+                   typename CrsGraph<LO, GO, NT>::buffer_device_type
+                 > numPacketsPerLID,
                  size_t& constantNumPackets,
+                 const bool pack_pids,
                  Distributor& distor);
 
 /// \brief Pack specified entries of the given local sparse graph for


### PR DESCRIPTION
@trilinos/tpetra 

## Description

  - Make `Tpetra::CrsGraph` implement the "new" DistObject interface
  - Fix build warning (unused variable) in `Tpetra::CrsMatrix`

## Related Issues

* Closes #4852 
* Part of #4853 

## How Has This Been Tested?

  - Lots of packages with GCC + OpenMP
  - Some packages with CUDA 9.2 + GCC