### PR TITLE
MueLu: deprecate adapters

### DIFF
--- a/packages/muelu/CMakeLists.txt
+++ b/packages/muelu/CMakeLists.txt
@@ -57,6 +57,33 @@ ENDIF()
 TRIBITS_ADD_DEBUG_OPTION()
 TRIBITS_ADD_SHOW_DEPRECATED_WARNINGS_OPTION()
 
+TRIBITS_ADD_OPTION_AND_DEFINE(
+  ${PACKAGE_NAME}_ENABLE_DEPRECATED_CODE
+  HAVE_${PACKAGE_NAME_UC}_DEPRECATED_CODE
+  "Whether MueLu enables deprecated code (that is, anything marked with the MUELU_DEPRECATED macro) at compile time.  Default is ON (deprecated code enabled).  If OFF, then deprecated code does not exist."
+  YES
+)
+IF (HAVE_${PACKAGE_NAME_UC}_DEPRECATED_CODE)
+  MESSAGE(STATUS "MueLu: Enabling deprecated code")
+ELSE ()
+  MESSAGE(STATUS "MueLu: Disabling deprecated code")
+ENDIF ()
+
+IF (NOT ${PACKAGE_NAME}_ENABLE_DEPRECATED_CODE AND ${PACKAGE_NAME}_ENABLE_DEPRECATED_TESTS)
+  MESSAGE(FATAL_ERROR "MueLu: You cannot enable deprecated tests when deprecated codes is disabled!")
+ENDIF ()
+
+TRIBITS_ADD_OPTION_AND_DEFINE(
+  ${PACKAGE_NAME}_ENABLE_DEPRECATED_TESTS
+  HAVE_${PACKAGE_NAME_UC}_DEPRECATED_TESTS
+  "Whether MueLu compiles and run tests (or areas of a test) that contain deprecated code (that is, anything marked with the MUELU_DEPRECATED macro).  Default is OFF (deprecated tests disabled).  If ON, then deprecated tests are compiled and tested."
+  NO
+)
+
+IF (HAVE_${PACKAGE_NAME_UC}_DEPRECATED_TESTS)
+  MESSAGE(STATUS "MueLu: Enabling deprecated tests")
+ENDIF ()
+
 IF (${PACKAGE_NAME}_ENABLE_Epetra AND NOT ${PACKAGE_NAME}_ENABLE_EpetraExt)
   MESSAGE(FATAL_ERROR "You have enabled Epetra, but not EpetraExt. MueLu requires that either both are enabled, or both are disabled. Please either disable Epetra, or enable EpetraExt.")
 ENDIF()

--- a/packages/muelu/adapters/epetra/MueLu_CreateEpetraPreconditioner.cpp
+++ b/packages/muelu/adapters/epetra/MueLu_CreateEpetraPreconditioner.cpp
@@ -29,38 +29,192 @@ namespace MueLu {
     Given a EpetraCrs_Matrix, this function returns a constructed MueLu preconditioner.
     @param[in] inA Matrix
     @param[in] paramListIn Parameter list
-    @param[in] inCoords (optional) Coordinates.  The first vector is x, the second (if necessary) y, the third (if necessary) z.
-    @param[in] inNullspace (optional) Near nullspace of the matrix.
     */
   Teuchos::RCP<MueLu::EpetraOperator>
   CreateEpetraPreconditioner(const Teuchos::RCP<Epetra_CrsMatrix>&   inA,
                              // FIXME: why is it non-const
-                             Teuchos::ParameterList& paramListIn,
-                             const Teuchos::RCP<Epetra_MultiVector>& inCoords    = Teuchos::null,
-                             const Teuchos::RCP<Epetra_MultiVector>& inNullspace = Teuchos::null)
+                             Teuchos::ParameterList& paramListIn)
   {
-    typedef double              SC;
-    typedef int                 LO;
-    typedef int                 GO;
-    typedef Xpetra::EpetraNode  NO;
+    using SC = double;
+    using LO = int;
+    using GO = int;
+    using NO = Xpetra::EpetraNode;
 
-    using   Teuchos::ParameterList;
+    using Teuchos::ParameterList;
 
-    typedef Xpetra::MultiVector<SC, LO, GO, NO>     MultiVector;
-    typedef Xpetra::Matrix<SC, LO, GO, NO>          Matrix;
-    typedef Hierarchy<SC,LO,GO,NO>                  Hierarchy;
-    typedef HierarchyManager<SC,LO,GO,NO>           HierarchyManager;
+    using MultiVector      = Xpetra::MultiVector<SC, LO, GO, NO>;
+    using Matrix           = Xpetra::Matrix<SC, LO, GO, NO>;
+    using Hierarchy        = Hierarchy<SC,LO,GO,NO>;
+    using HierarchyManager = HierarchyManager<SC,LO,GO,NO>;
+
+    Teuchos::ParameterList& userList = paramListIn.sublist("user data");
+    if (userList.isParameter("Coordinates")) {
+      RCP<Xpetra::MultiVector<typename Teuchos::ScalarTraits<SC>::coordinateType,LO,GO,NO> > coordinates = Teuchos::null;
+      try {
+        coordinates = EpetraMultiVector_To_XpetraMultiVector<typename Teuchos::ScalarTraits<SC>::coordinateType,LO,GO,NO>(userList.get<RCP<Epetra_MultiVector> >("Coordinates"));
+      } catch(Teuchos::Exceptions::InvalidParameterType) {
+        coordinates = userList.get<RCP<Xpetra::MultiVector<typename Teuchos::ScalarTraits<SC>::coordinateType, LO, GO, NO> > >("Coordinates");
+      }
+      if(Teuchos::nonnull(coordinates)){
+        userList.set<RCP<Xpetra::MultiVector<typename Teuchos::ScalarTraits<SC>::coordinateType,LO,GO,NO> > >("Coordinates", coordinates);
+      }
+    }
+    if (userList.isParameter("Nullspace")) {
+      RCP<Xpetra::MultiVector<typename Teuchos::ScalarTraits<SC>::coordinateType,LO,GO,NO> > nullspace = Teuchos::null;
+      try {
+        nullspace = EpetraMultiVector_To_XpetraMultiVector<SC,LO,GO,NO>(userList.get<RCP<Epetra_MultiVector> >("Nullspace"));
+      } catch(Teuchos::Exceptions::InvalidParameterType) {
+        nullspace = userList.get<RCP<Xpetra::MultiVector<SC, LO, GO, NO> > >("Nullspace");
+      }
+      if(Teuchos::nonnull(nullspace)){
+        userList.set<RCP<Xpetra::MultiVector<typename Teuchos::ScalarTraits<SC>::coordinateType,LO,GO,NO> > >("Nullspace", nullspace);
+      }
+    }
 
     RCP<Matrix> A = EpetraCrs_To_XpetraMatrix<SC, LO, GO, NO>(inA);
+    RCP<Hierarchy> H = MueLu::CreateXpetraPreconditioner<SC,LO,GO,NO>(A, paramListIn);
+    return rcp(new EpetraOperator(H));
+  }
+
+  /*!
+    @brief Helper function to create a MueLu preconditioner that can be used by Epetra.
+    @ingroup MueLuAdapters
+    Given a Epetra_CrsMatrix, this function returns a constructed MueLu preconditioner.
+    @param[in] inA Matrix
+    @param[in] xmlFileName XML file containing MueLu options.
+    */
+  Teuchos::RCP<MueLu::EpetraOperator>
+  CreateEpetraPreconditioner(const Teuchos::RCP<Epetra_CrsMatrix>  & A,
+                             const std::string& xmlFileName)
+  {
+    Teuchos::ParameterList paramList;
+    Teuchos::updateParametersFromXmlFileAndBroadcast(xmlFileName, Teuchos::Ptr<Teuchos::ParameterList>(&paramList), *Xpetra::toXpetra(A->Comm()));
+
+    return CreateEpetraPreconditioner(A, paramList);
+  }
+
+  /*!
+    @brief Helper function to create a MueLu preconditioner that can be used by Epetra.
+    @ingroup MueLuAdapters
+    Given a Epetra_CrsMatrix, this function returns a constructed MueLu preconditioner.
+    @param[in] inA Matrix.
+    */
+  Teuchos::RCP<MueLu::EpetraOperator>
+  CreateEpetraPreconditioner(const Teuchos::RCP<Epetra_CrsMatrix>  & A)
+  {
+    Teuchos::ParameterList paramList;
+    return CreateEpetraPreconditioner(A, paramList);
+  }
+
+  void ReuseEpetraPreconditioner(const Teuchos::RCP<Epetra_CrsMatrix>& inA, MueLu::EpetraOperator& Op) {
+    using SC = double;
+    using LO = int;
+    using GO = int;
+    using NO = Xpetra::EpetraNode;
+
+    using Teuchos::ParameterList;
+
+    using Matrix           = Xpetra::Matrix<SC, LO, GO, NO>;
+    using Hierarchy        = Hierarchy<SC,LO,GO,NO>;
+
+    RCP<Hierarchy> H = Op.GetHierarchy();
+    RCP<Matrix>    A = EpetraCrs_To_XpetraMatrix<SC,LO,GO,NO>(inA);
+
+    MueLu::ReuseXpetraPreconditioner<SC,LO,GO,NO>(A, H);
+  }
+
+#ifdef HAVE_MUELU_DEPRECATED_CODE
+
+  /*!
+    @brief Helper function to create a MueLu preconditioner that can be used by Epetra.
+    @ingroup MueLuAdapters
+    Given a EpetraCrs_Matrix, this function returns a constructed MueLu preconditioner.
+    @param[in] inA Matrix
+    @param[in] paramListIn Parameter list
+    @param[in] inCoords Coordinates.  The first vector is x, the second (if necessary) y, the third (if necessary) z.
+    @param[in] inNullspace Near nullspace of the matrix.
+    */
+  MUELU_DEPRECATED
+  Teuchos::RCP<MueLu::EpetraOperator>
+  CreateEpetraPreconditioner(const Teuchos::RCP<Epetra_CrsMatrix>&   inA,
+                             // FIXME: why is it non-const
+                             Teuchos::ParameterList& paramListIn,
+                             const Teuchos::RCP<Epetra_MultiVector>& inCoords,
+                             const Teuchos::RCP<Epetra_MultiVector>& inNullspace)
+  {
+    using SC = double;
+    using LO = int;
+    using GO = int;
+    using NO = Xpetra::EpetraNode;
+
+    using Teuchos::ParameterList;
+
+    using MultiVector      = Xpetra::MultiVector<SC, LO, GO, NO>;
+    using Matrix           = Xpetra::Matrix<SC, LO, GO, NO>;
+    using Hierarchy        = Hierarchy<SC,LO,GO,NO>;
+    using HierarchyManager = HierarchyManager<SC,LO,GO,NO>;
+
+    RCP<Matrix> A = EpetraCrs_To_XpetraMatrix<SC, LO, GO, NO>(inA);
+
+    Teuchos::ParameterList& userParamList = paramListIn.sublist("user data");
     RCP<MultiVector> coordinates = Teuchos::null;
-    if (inCoords != Teuchos::null) {
+    if (Teuchos::nonnull(inCoords)) {
       coordinates = EpetraMultiVector_To_XpetraMultiVector<SC,LO,GO,NO>(inCoords);
     }
+    if (Teuchos::nonnull(coordinates)) {
+      userParamList.set<RCP<MultiVector> >("Coordinates", coordinates);
+    }
     RCP<MultiVector> nullspace = Teuchos::null;
-    if (inNullspace != Teuchos::null) {
+    if (Teuchos::nonnull(inNullspace)) {
       nullspace = EpetraMultiVector_To_XpetraMultiVector<SC, LO, GO, NO>(inNullspace);
     }
-    RCP<Hierarchy> H = MueLu::CreateXpetraPreconditioner<SC,LO,GO,NO>(A,paramListIn,coordinates,nullspace);
+    if (Teuchos::nonnull(nullspace)) {
+      userParamList.set<RCP<MultiVector> >("Nullspace", nullspace);
+    }
+
+    RCP<Hierarchy> H = MueLu::CreateXpetraPreconditioner<SC,LO,GO,NO>(A, paramListIn);
+    return rcp(new EpetraOperator(H));
+  }
+
+  /*!
+    @brief Helper function to create a MueLu preconditioner that can be used by Epetra.
+    @ingroup MueLuAdapters
+    Given a EpetraCrs_Matrix, this function returns a constructed MueLu preconditioner.
+    @param[in] inA Matrix
+    @param[in] paramListIn Parameter list
+    @param[in] inCoords Coordinates.  The first vector is x, the second (if necessary) y, the third (if necessary) z.
+    */
+  MUELU_DEPRECATED
+  Teuchos::RCP<MueLu::EpetraOperator>
+  CreateEpetraPreconditioner(const Teuchos::RCP<Epetra_CrsMatrix>&   inA,
+                             // FIXME: why is it non-const
+                             Teuchos::ParameterList& paramListIn,
+                             const Teuchos::RCP<Epetra_MultiVector>& inCoords)
+  {
+    using SC = double;
+    using LO = int;
+    using GO = int;
+    using NO = Xpetra::EpetraNode;
+
+    using Teuchos::ParameterList;
+
+    using MultiVector      = Xpetra::MultiVector<SC, LO, GO, NO>;
+    using Matrix           = Xpetra::Matrix<SC, LO, GO, NO>;
+    using Hierarchy        = Hierarchy<SC,LO,GO,NO>;
+    using HierarchyManager = HierarchyManager<SC,LO,GO,NO>;
+
+    RCP<Matrix> A = EpetraCrs_To_XpetraMatrix<SC, LO, GO, NO>(inA);
+
+    Teuchos::ParameterList& userParamList = paramListIn.sublist("user data");
+    RCP<MultiVector> coordinates = Teuchos::null;
+    if (Teuchos::nonnull(inCoords)) {
+      coordinates = EpetraMultiVector_To_XpetraMultiVector<SC,LO,GO,NO>(inCoords);
+    }
+    if (Teuchos::nonnull(coordinates)) {
+      userParamList.set<RCP<MultiVector> >("Coordinates", coordinates);
+    }
+
+    RCP<Hierarchy> H = MueLu::CreateXpetraPreconditioner<SC,LO,GO,NO>(A, paramListIn);
     return rcp(new EpetraOperator(H));
   }
 
@@ -72,12 +226,71 @@ namespace MueLu {
     @param[in] inCoords (optional) Coordinates.  The first vector is x, the second (if necessary) y, the third (if necessary) z.
     @param[in] inNullspace (optional) Near nullspace of the matrix.
     */
+  MUELU_DEPRECATED
   Teuchos::RCP<MueLu::EpetraOperator>
   CreateEpetraPreconditioner(const Teuchos::RCP<Epetra_CrsMatrix>  & inA,
-                             const Teuchos::RCP<Epetra_MultiVector>& inCoords    = Teuchos::null,
-                             const Teuchos::RCP<Epetra_MultiVector>& inNullspace = Teuchos::null) {
+                             const Teuchos::RCP<Epetra_MultiVector>& inCoords,
+                             const Teuchos::RCP<Epetra_MultiVector>& inNullspace) {
+    using SC = double;
+    using LO = int;
+    using GO = int;
+    using NO = Xpetra::EpetraNode;
+
+    using MultiVector = Xpetra::MultiVector<SC, LO, GO, NO>;
+
     Teuchos::ParameterList paramList;
-    return CreateEpetraPreconditioner(inA, paramList, inCoords, inNullspace);
+    Teuchos::ParameterList& userParamList = paramList.sublist("user data");
+
+    RCP<MultiVector> coordinates = Teuchos::null;
+    if (Teuchos::nonnull(inCoords)) {
+      coordinates = EpetraMultiVector_To_XpetraMultiVector<SC,LO,GO,NO>(inCoords);
+    }
+    if (Teuchos::nonnull(coordinates)) {
+      userParamList.set<RCP<MultiVector> >("Coordinates", coordinates);
+    }
+
+    RCP<MultiVector> nullspace = Teuchos::null;
+    if (Teuchos::nonnull(inNullspace)) {
+      nullspace = EpetraMultiVector_To_XpetraMultiVector<SC,LO,GO,NO>(inNullspace);
+    }
+    if (Teuchos::nonnull(nullspace)) {
+      userParamList.set<const Teuchos::RCP<MultiVector> >("Nullspace", nullspace);
+    }
+
+    return CreateEpetraPreconditioner(inA, paramList);
+  }
+
+  /*!
+    @brief Helper function to create a MueLu preconditioner that can be used by Epetra.
+    @ingroup MueLuAdapters
+    Given a Epetra_CrsMatrix, this function returns a constructed MueLu preconditioner.
+    @param[in] inA Matrix
+    @param[in] inCoords (optional) Coordinates.  The first vector is x, the second (if necessary) y, the third (if necessary) z.
+    @param[in] inNullspace (optional) Near nullspace of the matrix.
+    */
+  MUELU_DEPRECATED
+  Teuchos::RCP<MueLu::EpetraOperator>
+  CreateEpetraPreconditioner(const Teuchos::RCP<Epetra_CrsMatrix>  & inA,
+                             const Teuchos::RCP<Epetra_MultiVector>& inCoords) {
+    using SC = double;
+    using LO = int;
+    using GO = int;
+    using NO = Xpetra::EpetraNode;
+
+    using MultiVector = Xpetra::MultiVector<SC, LO, GO, NO>;
+
+    Teuchos::ParameterList paramList;
+    Teuchos::ParameterList& userParamList = paramList.sublist("user data");
+
+    RCP<MultiVector> coordinates = Teuchos::null;
+    if (Teuchos::nonnull(inCoords)) {
+      coordinates = EpetraMultiVector_To_XpetraMultiVector<SC,LO,GO,NO>(inCoords);
+    }
+    if (Teuchos::nonnull(coordinates)) {
+      userParamList.set<RCP<MultiVector> >("Coordinates", coordinates);
+    }
+
+    return CreateEpetraPreconditioner(inA, paramList);
   }
 
   /*!
@@ -86,35 +299,83 @@ namespace MueLu {
     Given a Epetra_CrsMatrix, this function returns a constructed MueLu preconditioner.
     @param[in] inA Matrix
     @param[in] xmlFileName XML file containing MueLu options
-    @param[in] inCoords (optional) Coordinates.  The first vector is x, the second (if necessary) y, the third (if necessary) z.
-    @param[in] inNullspace (optional) Near nullspace of the matrix.
+    @param[in] inCoords Coordinates.  The first vector is x, the second (if necessary) y, the third (if necessary) z.
+    @param[in] inNullspace Near nullspace of the matrix.
     */
+  MUELU_DEPRECATED
   Teuchos::RCP<MueLu::EpetraOperator>
   CreateEpetraPreconditioner(const Teuchos::RCP<Epetra_CrsMatrix>  & A,
                              const std::string& xmlFileName,
-                             const Teuchos::RCP<Epetra_MultiVector>& inCoords    = Teuchos::null,
-                             const Teuchos::RCP<Epetra_MultiVector>& inNullspace = Teuchos::null)
+                             const Teuchos::RCP<Epetra_MultiVector>& inCoords,
+                             const Teuchos::RCP<Epetra_MultiVector>& inNullspace)
   {
+    using SC = double;
+    using LO = int;
+    using GO = int;
+    using NO = Xpetra::EpetraNode;
+
+    using MultiVector = Xpetra::MultiVector<SC, LO, GO, NO>;
+
     Teuchos::ParameterList paramList;
     Teuchos::updateParametersFromXmlFileAndBroadcast(xmlFileName, Teuchos::Ptr<Teuchos::ParameterList>(&paramList), *Xpetra::toXpetra(A->Comm()));
+    Teuchos::ParameterList& userParamList = paramList.sublist("user data");
 
-    return CreateEpetraPreconditioner(A, paramList, inCoords, inNullspace);
+    RCP<MultiVector> coordinates = Teuchos::null;
+    if (inCoords != Teuchos::null) {
+      coordinates = EpetraMultiVector_To_XpetraMultiVector<SC,LO,GO,NO>(inCoords);
+    }
+    if (Teuchos::nonnull(coordinates)) {
+      userParamList.set<RCP<MultiVector> >("Coordinates", coordinates);
+    }
+
+    RCP<MultiVector> nullspace = Teuchos::null;
+    if (inCoords != Teuchos::null) {
+      nullspace = EpetraMultiVector_To_XpetraMultiVector<SC,LO,GO,NO>(inNullspace);
+    }
+    if (Teuchos::nonnull(nullspace)) {
+      userParamList.set<const Teuchos::RCP<MultiVector> >("Nullspace", nullspace);
+    }
+
+    return CreateEpetraPreconditioner(A, paramList);
   }
 
-  void ReuseEpetraPreconditioner(const Teuchos::RCP<Epetra_CrsMatrix>& inA, MueLu::EpetraOperator& Op) {
-    typedef double             SC;
-    typedef int                LO;
-    typedef int                GO;
-    typedef Xpetra::EpetraNode NO;
+  /*!
+    @brief Helper function to create a MueLu preconditioner that can be used by Epetra.
+    @ingroup MueLuAdapters
+    Given a Epetra_CrsMatrix, this function returns a constructed MueLu preconditioner.
+    @param[in] inA Matrix
+    @param[in] xmlFileName XML file containing MueLu options
+    @param[in] inCoords Coordinates.  The first vector is x, the second (if necessary) y, the third (if necessary) z.
+    */
+  MUELU_DEPRECATED
+  Teuchos::RCP<MueLu::EpetraOperator>
+  CreateEpetraPreconditioner(const Teuchos::RCP<Epetra_CrsMatrix>  & A,
+                             const std::string& xmlFileName,
+                             const Teuchos::RCP<Epetra_MultiVector>& inCoords)
+  {
+    using SC = double;
+    using LO = int;
+    using GO = int;
+    using NO = Xpetra::EpetraNode;
 
-    typedef Xpetra::Matrix<SC,LO,GO,NO>     Matrix;
-    typedef MueLu ::Hierarchy<SC,LO,GO,NO>  Hierarchy;
+    using MultiVector = Xpetra::MultiVector<SC, LO, GO, NO>;
 
-    RCP<Hierarchy> H = Op.GetHierarchy();
-    RCP<Matrix>    A = EpetraCrs_To_XpetraMatrix<SC,LO,GO,NO>(inA);
+    Teuchos::ParameterList paramList;
+    Teuchos::updateParametersFromXmlFileAndBroadcast(xmlFileName, Teuchos::Ptr<Teuchos::ParameterList>(&paramList), *Xpetra::toXpetra(A->Comm()));
+    Teuchos::ParameterList& userParamList = paramList.sublist("user data");
 
-    MueLu::ReuseXpetraPreconditioner<SC,LO,GO,NO>(A, H);
+    RCP<MultiVector> coordinates = Teuchos::null;
+    if (inCoords != Teuchos::null) {
+      coordinates = EpetraMultiVector_To_XpetraMultiVector<SC,LO,GO,NO>(inCoords);
+    }
+    if (Teuchos::nonnull(coordinates)) {
+      userParamList.set<RCP<MultiVector> >("Coordinates", coordinates);
+    }
+
+    return CreateEpetraPreconditioner(A, paramList);
   }
+
+#endif // HAVE_MUELU_DEPRECATED_CODE
 
 } //namespace
 #endif // HAVE_MUELU_SERIAL and HAVE_MUELU_EPETRA

--- a/packages/muelu/adapters/epetra/MueLu_CreateEpetraPreconditioner.hpp
+++ b/packages/muelu/adapters/epetra/MueLu_CreateEpetraPreconditioner.hpp
@@ -21,28 +21,69 @@ namespace MueLu {
     Given a EpetraCrs_Matrix, this function returns a constructed MueLu preconditioner.
     @param[in] inA Matrix
     @param[in] paramListIn Parameter list
-    @param[in] inCoords (optional) Coordinates.  The first vector is x, the second (if necessary) y, the third (if necessary) z.
-    @param[in] inNullspace (optional) Near nullspace of the matrix.
     */
   Teuchos::RCP<MueLu::EpetraOperator>
   CreateEpetraPreconditioner(const Teuchos::RCP<Epetra_CrsMatrix>&   inA,
                              // FIXME: why is it non-const
-                             Teuchos::ParameterList& paramListIn,
-                             const Teuchos::RCP<Epetra_MultiVector>& inCoords    = Teuchos::null,
-                             const Teuchos::RCP<Epetra_MultiVector>& inNullspace = Teuchos::null);
+                             Teuchos::ParameterList& paramListIn);
 
   /*!
     @brief Helper function to create a MueLu preconditioner that can be used by Epetra.
     @ingroup MueLuAdapters
     Given a Epetra_CrsMatrix, this function returns a constructed MueLu preconditioner.
     @param[in] inA Matrix
-    @param[in] inCoords (optional) Coordinates.  The first vector is x, the second (if necessary) y, the third (if necessary) z.
-    @param[in] inNullspace (optional) Near nullspace of the matrix.
+    @param[in] xmlFileName XML file containing MueLu options.
     */
   Teuchos::RCP<MueLu::EpetraOperator>
-  CreateEpetraPreconditioner(const Teuchos::RCP<Epetra_CrsMatrix>  & inA,
-                             const Teuchos::RCP<Epetra_MultiVector>& inCoords    = Teuchos::null,
-                             const Teuchos::RCP<Epetra_MultiVector>& inNullspace = Teuchos::null);
+  CreateEpetraPreconditioner(const Teuchos::RCP<Epetra_CrsMatrix>  & A,
+                             const std::string& xmlFileName);
+
+  /*!
+    @brief Helper function to create a MueLu preconditioner that can be used by Epetra.
+    @ingroup MueLuAdapters
+    Given a Epetra_CrsMatrix, this function returns a constructed MueLu preconditioner.
+    @param[in] inA Matrix
+    */
+  Teuchos::RCP<MueLu::EpetraOperator>
+  CreateEpetraPreconditioner(const Teuchos::RCP<Epetra_CrsMatrix>  & A,
+                             const std::string& xmlFileName);
+
+  void ReuseEpetraPreconditioner(const Teuchos::RCP<Epetra_CrsMatrix>& inA, MueLu::EpetraOperator& Op);
+
+
+#ifdef HAVE_MUELU_DEPRECATED_CODE
+
+  /*!
+    @brief Helper function to create a MueLu preconditioner that can be used by Epetra.
+    @ingroup MueLuAdapters
+    Given a EpetraCrs_Matrix, this function returns a constructed MueLu preconditioner.
+    @param[in] inA Matrix
+    @param[in] paramListIn Parameter list
+    @param[in] inCoords Coordinates.  The first vector is x, the second (if necessary) y, the third (if necessary) z.
+    */
+  MUELU_DEPRECATED
+  Teuchos::RCP<MueLu::EpetraOperator>
+  CreateEpetraPreconditioner(const Teuchos::RCP<Epetra_CrsMatrix>&   inA,
+                             // FIXME: why is it non-const
+                             Teuchos::ParameterList& paramListIn,
+                             const Teuchos::RCP<Epetra_MultiVector>& inCoords,
+                             const Teuchos::RCP<Epetra_MultiVector>& inNullspace);
+
+  /*!
+    @brief Helper function to create a MueLu preconditioner that can be used by Epetra.
+    @ingroup MueLuAdapters
+    Given a EpetraCrs_Matrix, this function returns a constructed MueLu preconditioner.
+    @param[in] inA Matrix
+    @param[in] paramListIn Parameter list
+    @param[in] inCoords Coordinates.  The first vector is x, the second (if necessary) y, the third (if necessary) z.
+    @param[in] inNullspace Near nullspace of the matrix.
+    */
+  MUELU_DEPRECATED
+  Teuchos::RCP<MueLu::EpetraOperator>
+  CreateEpetraPreconditioner(const Teuchos::RCP<Epetra_CrsMatrix>&   inA,
+                             // FIXME: why is it non-const
+                             Teuchos::ParameterList& paramListIn,
+                             const Teuchos::RCP<Epetra_MultiVector>& inCoords);
 
   /*!
     @brief Helper function to create a MueLu preconditioner that can be used by Epetra.
@@ -50,16 +91,45 @@ namespace MueLu {
     Given a Epetra_CrsMatrix, this function returns a constructed MueLu preconditioner.
     @param[in] inA Matrix
     @param[in] xmlFileName XML file containing MueLu options
-    @param[in] inCoords (optional) Coordinates.  The first vector is x, the second (if necessary) y, the third (if necessary) z.
-    @param[in] inNullspace (optional) Near nullspace of the matrix.
+    @param[in] inCoords Coordinates.  The first vector is x, the second (if necessary) y, the third (if necessary) z.
+    @param[in] inNullspace Near nullspace of the matrix.
     */
+  MUELU_DEPRECATED
   Teuchos::RCP<MueLu::EpetraOperator>
   CreateEpetraPreconditioner(const Teuchos::RCP<Epetra_CrsMatrix>  & A,
                              const std::string& xmlFileName,
+                             const Teuchos::RCP<Epetra_MultiVector>& inCoords,
+                             const Teuchos::RCP<Epetra_MultiVector>& inNullspace);
+
+  /*!
+    @brief Helper function to create a MueLu preconditioner that can be used by Epetra.
+    @ingroup MueLuAdapters
+    Given a Epetra_CrsMatrix, this function returns a constructed MueLu preconditioner.
+    @param[in] inA Matrix
+    @param[in] xmlFileName XML file containing MueLu options
+    @param[in] inCoords Coordinates.  The first vector is x, the second (if necessary) y, the third (if necessary) z.
+    */
+  MUELU_DEPRECATED
+  Teuchos::RCP<MueLu::EpetraOperator>
+  CreateEpetraPreconditioner(const Teuchos::RCP<Epetra_CrsMatrix>  & A,
+                             const std::string& xmlFileName,
+                             const Teuchos::RCP<Epetra_MultiVector>& inCoords);
+
+  /*!
+    @brief Helper function to create a MueLu preconditioner that can be used by Epetra.
+    @ingroup MueLuAdapters
+    Given a Epetra_CrsMatrix, this function returns a constructed MueLu preconditioner.
+    @param[in] inA Matrix
+    @param[in] inCoords (optional) Coordinates.  The first vector is x, the second (if necessary) y, the third (if necessary) z.
+    @param[in] inNullspace (optional) Near nullspace of the matrix.
+    */
+  MUELU_DEPRECATED
+  Teuchos::RCP<MueLu::EpetraOperator>
+  CreateEpetraPreconditioner(const Teuchos::RCP<Epetra_CrsMatrix>  & inA,
                              const Teuchos::RCP<Epetra_MultiVector>& inCoords    = Teuchos::null,
                              const Teuchos::RCP<Epetra_MultiVector>& inNullspace = Teuchos::null);
 
-  void ReuseEpetraPreconditioner(const Teuchos::RCP<Epetra_CrsMatrix>& inA, MueLu::EpetraOperator& Op);
+#endif
 
 } //namespace
 #endif // HAVE_MUELU_SERIAL and HAVE_MUELU_EPETRA

--- a/packages/muelu/adapters/stratimikos/Thyra_MueLuPreconditionerFactory_decl.hpp
+++ b/packages/muelu/adapters/stratimikos/Thyra_MueLuPreconditionerFactory_decl.hpp
@@ -371,7 +371,15 @@ namespace Thyra {
         }
 #endif
         // build a new MueLu hierarchy
-        H = MueLu::CreateXpetraPreconditioner(A, paramList, coordinates, nullspace);
+        const std::string userName = "user data";
+        Teuchos::ParameterList& userParamList = paramList.sublist(userName);
+        if(Teuchos::nonnull(coordinates)) {
+          userParamList.set<RCP<XpMultVecDouble> >("Coordinates", coordinates);
+        }
+        if(Teuchos::nonnull(nullspace)) {
+          userParamList.set<RCP<XpMultVec> >("Nullspace", nullspace);
+        }
+        H = MueLu::CreateXpetraPreconditioner(A, paramList);
 
       } else {
         // reuse old MueLu hierarchy stored in MueLu Tpetra/Epetra operator and put in new matrix

--- a/packages/muelu/adapters/stratimikos/Thyra_MueLuPreconditionerFactory_def.hpp
+++ b/packages/muelu/adapters/stratimikos/Thyra_MueLuPreconditionerFactory_def.hpp
@@ -98,7 +98,7 @@ namespace Thyra {
     typedef Xpetra::BlockedCrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> XpBlockedCrsMat;
     typedef Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>           XpMat;
     typedef Xpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>      XpMultVec;
-    typedef Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::magnitudeType,LocalOrdinal,GlobalOrdinal,Node>      XpMultVecDouble;
+    typedef Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::coordinateType,LocalOrdinal,GlobalOrdinal,Node>      XpMultVecDouble;
     typedef Thyra::LinearOpBase<Scalar>                                      ThyLinOpBase;
 #ifdef HAVE_MUELU_TPETRA
     typedef MueLu::TpetraOperator<Scalar,LocalOrdinal,GlobalOrdinal,Node> MueTpOp;
@@ -188,7 +188,7 @@ namespace Thyra {
 
     if (startingOver == true) {
       // extract coordinates from parameter list
-      Teuchos::RCP<XpMultVecDouble> coordinates = Teuchos::null;
+      RCP<XpMultVecDouble> coordinates = Teuchos::null;
       coordinates = MueLu::Utilities<Scalar,LocalOrdinal,GlobalOrdinal,Node>::ExtractCoordinatesFromParameterList(paramList);
 
       // TODO check for Xpetra or Thyra vectors?
@@ -206,7 +206,14 @@ namespace Thyra {
       }
 #endif
       // build a new MueLu hierarchy
-      H = MueLu::CreateXpetraPreconditioner(A, paramList, coordinates, nullspace);
+      ParameterList& userParamList = paramList.sublist("user data");
+      if(Teuchos::nonnull(coordinates)) {
+        userParamList.set<RCP<XpMultVecDouble> >("Coordinates", coordinates);
+      }
+      if(Teuchos::nonnull(nullspace)) {
+        userParamList.set<RCP<XpMultVec> >("Nullspace", nullspace);
+      }
+      H = MueLu::CreateXpetraPreconditioner(A, paramList);
 
     } else {
       // reuse old MueLu hierarchy stored in MueLu Tpetra/Epetra operator and put in new matrix

--- a/packages/muelu/adapters/xpetra/MueLu_CreateXpetraPreconditioner.hpp
+++ b/packages/muelu/adapters/xpetra/MueLu_CreateXpetraPreconditioner.hpp
@@ -28,27 +28,29 @@
 #include <stdlib.h>
 
 namespace MueLu {
+
   /*!
     @brief Helper function to create a MueLu preconditioner that can be used by Xpetra.
     @ingroup MueLuAdapters
     Given an Xpetra::Matrix, this function returns a constructed MueLu preconditioner.
     @param[in] inA Matrix
     @param[in] inParamList Parameter list
-    @param[in] inCoords (optional) Coordinates.  The first vector is x, the second (if necessary) y, the third (if necessary) z.
-    @param[in] inNullspace (optional) Near nullspace of the matrix.
   */
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   Teuchos::RCP<MueLu::Hierarchy<Scalar,LocalOrdinal,GlobalOrdinal,Node> >
   CreateXpetraPreconditioner(Teuchos::RCP<Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > op,
-                             const Teuchos::ParameterList& inParamList,
-                             Teuchos::RCP<Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::magnitudeType, LocalOrdinal, GlobalOrdinal, Node> > coords = Teuchos::null,
-                             Teuchos::RCP<Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > nullspace = Teuchos::null) {
-    typedef MueLu::HierarchyManager<Scalar,LocalOrdinal,GlobalOrdinal,Node> HierarchyManager;
-    typedef MueLu::HierarchyUtils<Scalar,LocalOrdinal,GlobalOrdinal,Node> HierarchyUtils;
-    typedef MueLu::Hierarchy<Scalar,LocalOrdinal,GlobalOrdinal,Node> Hierarchy;
-    typedef MueLu::MLParameterListInterpreter<Scalar,LocalOrdinal,GlobalOrdinal,Node> MLParameterListInterpreter;
-    typedef MueLu::ParameterListInterpreter<Scalar,LocalOrdinal,GlobalOrdinal,Node> ParameterListInterpreter;
+                             const Teuchos::ParameterList& inParamList) {
+    using SC = Scalar;
+    using LO = LocalOrdinal;
+    using GO = GlobalOrdinal;
+    using NO = Node;
+
+    using HierarchyManager = MueLu::HierarchyManager<SC, LO, GO, NO>;
+    using HierarchyUtils = MueLu::HierarchyUtils<SC, LO, GO, NO>;
+    using Hierarchy = MueLu::Hierarchy<SC, LO, GO, NO>;
+    using MLParameterListInterpreter = MLParameterListInterpreter<SC, LO, GO, NO>;
+    using ParameterListInterpreter = ParameterListInterpreter<SC, LO, GO, NO>;
 
     bool hasParamList = inParamList.numParams();
 
@@ -91,14 +93,6 @@ namespace MueLu {
     // Set fine level operator
     H->GetLevel(0)->Set("A", op);
     H->SetProcRankVerbose(op->getDomainMap()->getComm()->getRank());
-
-    // Set coordinates if available
-    if (coords != Teuchos::null)
-      H->GetLevel(0)->Set("Coordinates", coords);
-
-    // Set nullspace if available
-    if (nullspace != Teuchos::null)
-      H->GetLevel(0)->Set("Nullspace", nullspace);
 
     mueLuFactory->SetupHierarchy(*H);
 
@@ -120,77 +114,35 @@ namespace MueLu {
     return H;
   }
 
+  /*!
+    @brief Helper function to create a MueLu preconditioner that can be used by Xpetra.
+    @ingroup MueLuAdapters
+    Given an Xpetra::Matrix, this function returns a constructed MueLu preconditioner.
+    @param[in] inA Matrix
+    @param[in] xmlFileName std::string
+  */
+
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   Teuchos::RCP<MueLu::Hierarchy<Scalar,LocalOrdinal,GlobalOrdinal,Node> >
   CreateXpetraPreconditioner(Teuchos::RCP<Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > op,
-                             const Teuchos::ParameterList& inParamList,
-                             const Teuchos::ParameterList& dummy) {
-    typedef MueLu::HierarchyManager<Scalar,LocalOrdinal,GlobalOrdinal,Node> HierarchyManager;
-    typedef MueLu::HierarchyUtils<Scalar,LocalOrdinal,GlobalOrdinal,Node> HierarchyUtils;
-    typedef MueLu::Hierarchy<Scalar,LocalOrdinal,GlobalOrdinal,Node> Hierarchy;
-    typedef MueLu::MLParameterListInterpreter<Scalar,LocalOrdinal,GlobalOrdinal,Node> MLParameterListInterpreter;
-    typedef MueLu::ParameterListInterpreter<Scalar,LocalOrdinal,GlobalOrdinal,Node> ParameterListInterpreter;
+                             const std::string& xmlFileName) {
+    Teuchos::ParameterList paramList;
+    Teuchos::updateParametersFromXmlFileAndBroadcast(xmlFileName, Teuchos::Ptr<Teuchos::ParameterList>(&paramList), *op->getDomainMap()->getComm());
+    return CreateXpetraPreconditioner<Scalar, LocalOrdinal, GlobalOrdinal, Node>(op, paramList);
+  }
 
-    bool hasParamList = inParamList.numParams();
+  /*!
+    @brief Helper function to create a MueLu preconditioner that can be used by Xpetra.
+    @ingroup MueLuAdapters
+    Given an Xpetra::Matrix, this function returns a constructed MueLu preconditioner.
+    @param[in] inA Matrix
+  */
 
-    RCP<HierarchyManager> mueLuFactory;
-
-    // Rip off non-serializable data before validation
-    Teuchos::ParameterList nonSerialList,paramList;
-    MueLu::ExtractNonSerializableData(inParamList, paramList, nonSerialList);
-
-    std::string label;
-    if (hasParamList && paramList.isParameter("hierarchy label")) {
-      label = paramList.get<std::string>("hierarchy label");
-      paramList.remove("hierarchy label");
-    } else
-      label = op->getObjectLabel();
-
-    std::string timerName;
-    if (label != "")
-      timerName = "MueLu setup time (" + label + ")";
-    else
-      timerName = "MueLu setup time";
-    RCP<Teuchos::Time> tm = Teuchos::TimeMonitor::getNewTimer(timerName);
-    tm->start();
-
-    std::string syntaxStr = "parameterlist: syntax";
-    if (hasParamList && paramList.isParameter(syntaxStr) && paramList.get<std::string>(syntaxStr) == "ml") {
-      paramList.remove(syntaxStr);
-      mueLuFactory = rcp(new MLParameterListInterpreter(paramList));
-    } else {
-      mueLuFactory = rcp(new ParameterListInterpreter(paramList,op->getDomainMap()->getComm()));
-    }
-
-    // Create Hierarchy
-    RCP<Hierarchy> H = mueLuFactory->CreateHierarchy(label);
-    H->setlib(op->getDomainMap()->lib());
-
-    // Stick the non-serializible data on the hierarchy.
-    HierarchyUtils::AddNonSerializableDataToHierarchy(*mueLuFactory,*H, nonSerialList);
-
-    // Set fine level operator
-    H->GetLevel(0)->Set("A", op);
-    H->SetProcRankVerbose(op->getDomainMap()->getComm()->getRank());
-
-    mueLuFactory->SetupHierarchy(*H);
-
-    tm->stop();
-    tm->incrementNumCalls();
-
-    if (H->GetVerbLevel() & Statistics0) {
-      const bool alwaysWriteLocal = true;
-      const bool writeGlobalStats = true;
-      const bool writeZeroTimers  = false;
-      const bool ignoreZeroTimers = true;
-      const std::string filter    = timerName;
-      Teuchos::TimeMonitor::summarize(op->getRowMap()->getComm().ptr(), std::cout, alwaysWriteLocal, writeGlobalStats,
-                                      writeZeroTimers, Teuchos::Union, filter, ignoreZeroTimers);
-    }
-
-    tm->reset();
-
-    return H;
+  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  Teuchos::RCP<MueLu::Hierarchy<Scalar,LocalOrdinal,GlobalOrdinal,Node> >
+  CreateXpetraPreconditioner(Teuchos::RCP<Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > op) {
+    Teuchos::ParameterList paramList;
+    return CreateXpetraPreconditioner<Scalar, LocalOrdinal, GlobalOrdinal, Node>(op, paramList);
   }
 
   /*!
@@ -255,6 +207,65 @@ namespace MueLu {
 
     tm->reset();
   }
+
+
+#ifdef HAVE_MUELU_DEPRECATED_CODE
+
+  /*!
+    @brief Helper function to create a MueLu preconditioner that can be used by Xpetra.
+    @ingroup MueLuAdapters
+    Given an Xpetra::Matrix, this function returns a constructed MueLu preconditioner.
+    @param[in] inA Matrix
+    @param[in] inParamList Parameter list
+    @param[in] inCoords  Coordinates.  The first vector is x, the second (if necessary) y, the third (if necessary) z.
+    @param[in] inNullspace Near nullspace of the matrix.
+  */
+
+  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  MUELU_DEPRECATED
+  Teuchos::RCP<MueLu::Hierarchy<Scalar,LocalOrdinal,GlobalOrdinal,Node> >
+  CreateXpetraPreconditioner(Teuchos::RCP<Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > op,
+                             const Teuchos::ParameterList& inParamList,
+                             Teuchos::RCP<Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::coordinateType, LocalOrdinal, GlobalOrdinal, Node> > coords,
+                             Teuchos::RCP<Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > nullspace) {
+
+    Teuchos::ParameterList userParamList = inParamList.sublist("user data");
+    if (Teuchos::nonnull(coords)) {
+      userParamList.set<RCP<Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::coordinateType, LocalOrdinal, GlobalOrdinal, Node> > >("Coordinates", coords);
+    }
+    if(Teuchos::nonnull(nullspace)) {
+      userParamList.set<RCP<Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >("Nullspace", nullspace);
+    }
+
+    return CreateXpetraPreconditioner(op, inParamList);
+
+  }
+
+  /*!
+    @brief Helper function to create a MueLu preconditioner that can be used by Xpetra.
+    @ingroup MueLuAdapters
+    Given an Xpetra::Matrix, this function returns a constructed MueLu preconditioner.
+    @param[in] inA Matrix
+    @param[in] inParamList Parameter list
+    @param[in] inCoords (optional) Coordinates.  The first vector is x, the second (if necessary) y, the third (if necessary) z.
+  */
+
+  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  MUELU_DEPRECATED
+  Teuchos::RCP<MueLu::Hierarchy<Scalar,LocalOrdinal,GlobalOrdinal,Node> >
+  CreateXpetraPreconditioner(Teuchos::RCP<Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > op,
+                             const Teuchos::ParameterList& inParamList,
+                             Teuchos::RCP<Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::coordinateType, LocalOrdinal, GlobalOrdinal, Node> > coords) {
+
+    Teuchos::ParameterList mueluParams = inParamList;
+    Teuchos::ParameterList& userParamList = mueluParams.sublist("user data");
+    if (Teuchos::nonnull(coords)) {
+      userParamList.set<RCP<Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::coordinateType, LocalOrdinal, GlobalOrdinal, Node> > >("Coordinates", coords);
+    }
+    return CreateXpetraPreconditioner(op, mueluParams);
+  }
+
+#endif // HAVE_MUELU_DEPRECATED_CODE
 
 } //namespace
 

--- a/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_def.hpp
+++ b/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_def.hpp
@@ -473,7 +473,9 @@ namespace MueLu {
 #endif
       if (!AH_.is_null()) {
         int oldRank = SetProcRankVerbose(AH_->getDomainMap()->getComm()->getRank());
-        HierarchyH_ = MueLu::CreateXpetraPreconditioner(AH_, precList11_, CoordsH_);
+        ParameterList& userParamList = precList11_.sublist("user data");
+        userParamList.set<RCP<RealValuedMultiVector> >("Coordinates", CoordsH_);
+        HierarchyH_ = MueLu::CreateXpetraPreconditioner(AH_, precList11_);
         SetProcRankVerbose(oldRank);
       }
       VerboseObject::SetDefaultVerbLevel(verbMap[verbosityLevel]);
@@ -640,7 +642,9 @@ namespace MueLu {
 
       if (!A22_.is_null()) {
         int oldRank = SetProcRankVerbose(A22_->getDomainMap()->getComm()->getRank());
-        Hierarchy22_ = MueLu::CreateXpetraPreconditioner(A22_, precList22_, Coords_);
+        ParameterList& userParamList = precList22_.sublist("user data");
+        userParamList.set<RCP<RealValuedMultiVector> >("Coordinates", Coords_);
+        Hierarchy22_ = MueLu::CreateXpetraPreconditioner(A22_, precList22_);
         SetProcRankVerbose(oldRank);
       }
       VerboseObject::SetDefaultVerbLevel(verbMap[verbosityLevel]);

--- a/packages/muelu/cmake/MueLu_config.hpp.in
+++ b/packages/muelu/cmake/MueLu_config.hpp.in
@@ -27,6 +27,10 @@
 
 #cmakedefine HAVE_MUELU_KOKKOS_REFACTOR_USE_BY_DEFAULT
 
+#cmakedefine HAVE_MUELU_DEPRECATED_CODE
+
+#cmakedefine HAVE_MUELU_DEPRECATED_TESTS
+
 /* Optional Dependencies */
 
 #cmakedefine HAVE_MUELU_AMESOS
@@ -100,7 +104,7 @@
 #cmakedefine HAVE_MUELU_OPENMP
 #cmakedefine HAVE_MUELU_CUDA
 
-/*  
+/*
  If deprecated warnings are on, and the compiler supports them, then
  define MUELU_DEPRECATED to emit deprecated warnings.  Otherwise,
  give it an empty definition.

--- a/packages/muelu/example/advanced/levelwrap/LevelWrap.cpp
+++ b/packages/muelu/example/advanced/levelwrap/LevelWrap.cpp
@@ -136,8 +136,7 @@ namespace MueLuExamples {
     using Teuchos::rcp;
 
     Teuchos::RCP<MueLu::Hierarchy<Scalar,LocalOrdinal,GlobalOrdinal,Node> > H =
-        MueLu::CreateXpetraPreconditioner<Scalar,LocalOrdinal,GlobalOrdinal,Node>(
-            A, MueLuList, Teuchos::null, Teuchos::null);
+        MueLu::CreateXpetraPreconditioner<Scalar,LocalOrdinal,GlobalOrdinal,Node>(A, MueLuList);
 
     typedef Xpetra::MultiVector <Scalar,LocalOrdinal,GlobalOrdinal,Node> MV;
     typedef Belos::OperatorT<MV>                                         OP;

--- a/packages/muelu/example/advanced/multiplesolve/ReuseSequence.cpp
+++ b/packages/muelu/example/advanced/multiplesolve/ReuseSequence.cpp
@@ -479,7 +479,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib &lib,  int a
 
     RCP<Matrix>           A;
     RCP<const Map>        map;
-    RCP<RealValuedMultiVector>  coordinates;
+    RCP<RealValuedMultiVector> coordinates;
     RCP<MultiVector>      nullspace;
 
     tensor.setT(0);
@@ -493,7 +493,9 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib &lib,  int a
     RCP<Vector> B = VectorFactory::Build(map);
     A->apply(*X, *B);
 
-    RCP<Hierarchy> H = MueLu::CreateXpetraPreconditioner(A, paramList, coordinates);
+    Teuchos::ParameterList userParamList = paramList.sublist("user data");
+    userParamList.set<RCP<RealValuedMultiVector> >("Coordinates", coordinates);
+    RCP<Hierarchy> H = MueLu::CreateXpetraPreconditioner(A, paramList);
 
     for (size_t t = 1; t < numSteps; t++) {
       out << thinSeparator << " Step " << t << " " << thinSeparator << std::endl;
@@ -505,7 +507,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib &lib,  int a
 
       tc = high_resolution_clock::now();
       if (solveType == "none")
-        H = MueLu::CreateXpetraPreconditioner(A, paramList, coordinates);
+        H = MueLu::CreateXpetraPreconditioner(A, paramList);
       else
         MueLu::ReuseXpetraPreconditioner(A, H);
       setup_time[k*numSteps + t] = duration_cast<duration<double>>(high_resolution_clock::now() - tc);

--- a/packages/muelu/example/advanced/multiplesolve/StandardReuse.cpp
+++ b/packages/muelu/example/advanced/multiplesolve/StandardReuse.cpp
@@ -241,6 +241,8 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib &lib, int ar
   paramList.set("verbosity", "none");
   if (xmlFileName != "")
     Teuchos::updateParametersFromXmlFileAndBroadcast(xmlFileName, Teuchos::Ptr<Teuchos::ParameterList>(&paramList), *comm);
+  Teuchos::ParameterList userParamList = paramList.sublist("user data");
+  userParamList.set<RCP<RealValuedMultiVector> >("Coordinates", coordinates);
 
   out << "Parameter list:" << std::endl << paramList << std::endl;
 
@@ -260,7 +262,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib &lib, int ar
         tm->start();
 
       A->SetMaxEigenvalueEstimate(-one);
-      H = MueLu::CreateXpetraPreconditioner(A, paramList, coordinates);
+      H = MueLu::CreateXpetraPreconditioner(A, paramList);
 
       // Stop timing
       if (!(numRebuilds && i == 0)) {
@@ -275,7 +277,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib &lib, int ar
 
     // Run a build for matrix B to record its convergence
     B->SetMaxEigenvalueEstimate(-one);
-    H = MueLu::CreateXpetraPreconditioner(B, paramList, coordinates);
+    H = MueLu::CreateXpetraPreconditioner(B, paramList);
 
     X->putScalar(zero);
     H->Iterate(*Y, *X, nIts);
@@ -298,7 +300,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib &lib, int ar
     paramList.set("reuse: type", reuseTypes[k]);
 
     out << thinSeparator << " " << reuseTypes[k] << " (initial) " << thinSeparator << std::endl;
-    RCP<Hierarchy> H = MueLu::CreateXpetraPreconditioner(A, paramList, coordinates);
+    RCP<Hierarchy> H = MueLu::CreateXpetraPreconditioner(A, paramList);
 
     X->putScalar(zero);
     H->Iterate(*Y, *X, nIts);

--- a/packages/muelu/research/mmayr/composite_to_regions/src/main.cpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/main.cpp
@@ -1769,7 +1769,7 @@ int main(int argc, char *argv[]) {
       std::string aggregationRegionType = setAggregationTypePerRegion(problemType, myRank);
 
       // create nullspace vector
-      RCP<Epetra_Vector> nullspace = rcp(new Epetra_Vector(*revisedRowMapPerGrp[j]));
+      RCP<Epetra_MultiVector> nullspace = rcp(new Epetra_MultiVector(*revisedRowMapPerGrp[j], 1));
       nullspace->PutScalar(1.0);
 
       // create dummy coordinates vector
@@ -1784,10 +1784,11 @@ int main(int argc, char *argv[]) {
       Teuchos::ParameterList& userParamList = mueluParams->sublist(userName);
       userParamList.set<Array<int> >("Array<LO> lNodesPerDim", lNodesPerDim);
       userParamList.set<std::string>("string aggregationRegionType", aggregationRegionType);
+      userParamList.set<RCP<Epetra_MultiVector> >("Coordinates", coordinates);
+      userParamList.set<RCP<Epetra_MultiVector> >("Nullspace", nullspace);
 
       // Setup hierarchy
-      RCP<MueLu::EpetraOperator> eH = MueLu::CreateEpetraPreconditioner(regionGrpMats[j], *mueluParams,
-          coordinates, nullspace);
+      RCP<MueLu::EpetraOperator> eH = MueLu::CreateEpetraPreconditioner(regionGrpMats[j], *mueluParams);
       regGrpHierarchy[j] = eH->GetHierarchy();
     }
 

--- a/packages/muelu/research/tawiesn/aria/Driver.cpp
+++ b/packages/muelu/research/tawiesn/aria/Driver.cpp
@@ -389,7 +389,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib lib, int arg
     userParamList.set("ArrayRCP<LO> DofPresent", dofPresent);
 
     RCP<Hierarchy> H;
-    H = MueLu::CreateXpetraPreconditioner(DistributedMatrix, paramList, paramList /*coordinates*/);
+    H = MueLu::CreateXpetraPreconditioner(DistributedMatrix, paramList);
 
 #ifdef HAVE_MUELU_BELOS
     {

--- a/packages/muelu/src/Interface/MueLu_HierarchyManager.hpp
+++ b/packages/muelu/src/Interface/MueLu_HierarchyManager.hpp
@@ -141,7 +141,7 @@ namespace MueLu {
       if (l0->IsAvailable("Nullspace")) {
         RCP<Matrix> A = Teuchos::rcp_dynamic_cast<Matrix>(Op);
         if (A != Teuchos::null) {
-          Teuchos::RCP<MultiVector> nullspace = l0->Get<RCP<MultiVector>>("Nullspace");
+          Teuchos::RCP<MultiVector> nullspace = l0->Get<RCP<MultiVector> >("Nullspace");
           TEUCHOS_TEST_FOR_EXCEPTION(static_cast<size_t>(A->GetFixedBlockSize()) > nullspace->getNumVectors(), Exceptions::RuntimeError, "user-provided nullspace has fewer vectors (" << nullspace->getNumVectors() << ") than number of PDE equations (" << A->GetFixedBlockSize() << ")");
         } else {
           this->GetOStream(Warnings0) << "Skipping dimension check of user-supplied nullspace because user-supplied operator is not a matrix" << std::endl;
@@ -243,7 +243,6 @@ namespace MueLu {
       }
       // FIXME: Should allow specification of NumVectors on parameterlist
       H.AllocateLevelMultiVectors(1);
-      
       H.describe(H.GetOStream(Runtime0), verbosity_);
 
       // When we reuse hierarchy, it is necessary that we don't

--- a/packages/muelu/src/Utils/MueLu_Utilities.cpp
+++ b/packages/muelu/src/Utils/MueLu_Utilities.cpp
@@ -80,7 +80,7 @@ namespace MueLu {
       if (inList.isSublist(levelName) && ((levelName.find("level ") == 0 && levelName.size() > 6) || levelName.find("user data") == 0)) {
         int levelID = strtol(levelName.substr(6).c_str(), 0, 0);
         bool userFlag = true;
-        if(levelName.find("user data") == std::string::npos) { // if "user data" is not found in levelName, switc userFlag and set levelID
+        if(levelName.find("user data") == std::string::npos) { // if "user data" is not found in levelName, switch userFlag and set levelID
           userFlag = false;
           levelID = strtol(levelName.substr(6).c_str(), 0, 0);
           if (maxLevel < levelID)
@@ -96,7 +96,8 @@ namespace MueLu {
 #ifdef HAVE_MUELU_INTREPID2 // For the IntrepidPCoarsenFactory
               || name == "pcoarsen: element to node map"
 #endif
-              ) {
+              )
+          {
             nonSerialList.sublist(levelName).setEntry(name, it2->second);
           }
 #ifdef HAVE_MUELU_MATLAB
@@ -261,7 +262,7 @@ bool IsParamValidVariable(const std::string& name)
    // Generates a communicator whose only members are other ranks of the baseComm on my node
   Teuchos::RCP<const Teuchos::Comm<int> > GenerateNodeComm(RCP<const Teuchos::Comm<int> > & baseComm, int &NodeId, const int reductionFactor) {
 #ifdef HAVE_MPI
-       int numRanks = baseComm->getSize();       
+       int numRanks = baseComm->getSize();
        if(numRanks == 1) {NodeId = baseComm->getRank(); return baseComm;}
 
        // Get an integer from the hostname
@@ -270,7 +271,7 @@ bool IsParamValidVariable(const std::string& name)
        MPI_Get_processor_name(hostname,&len);
        struct hostent * host = gethostbyname(hostname);
        int myaddr = (int) htonl(inet_network(inet_ntoa(*(struct in_addr *)host->h_addr)));
-       
+
        // All-to-all exchange of address integers
        std::vector<int> addressList(numRanks);
        Teuchos::gatherAll(*baseComm,1,&myaddr,numRanks,&addressList[0]);
@@ -289,7 +290,7 @@ bool IsParamValidVariable(const std::string& name)
        NodeId = numNodes;
 
        // Generate nodal communicator
-       Teuchos::RCP<const Teuchos::Comm<int> > newComm =  baseComm->split(NodeId,baseComm->getRank());   
+       Teuchos::RCP<const Teuchos::Comm<int> > newComm =  baseComm->split(NodeId,baseComm->getRank());
 
        // If we want to divide nodes up (for really beefy nodes), we do so here
        if(reductionFactor != 1) {
@@ -305,17 +306,17 @@ bool IsParamValidVariable(const std::string& name)
          }
          coresPerNode = std::max(numRanks - lastI, coresPerNode);
 
-         // Can we chop that up? 
+         // Can we chop that up?
          if(coresPerNode % reductionFactor != 0)
            throw std::runtime_error("Reduction factor does not evently divide # cores per node");
-         int reducedCPN = coresPerNode / reductionFactor;        
+         int reducedCPN = coresPerNode / reductionFactor;
          int nodeDivision = newComm->getRank() / reducedCPN;
-         
+
          NodeId = numNodes * reductionFactor + nodeDivision;
-         newComm =  baseComm->split(NodeId,baseComm->getRank());  
+         newComm =  baseComm->split(NodeId,baseComm->getRank());
        }
 
-       return newComm;       
+       return newComm;
 #else
        NodeId = baseComm->getRank();
        return baseComm;

--- a/packages/muelu/test/scaling/DriverCore.hpp
+++ b/packages/muelu/test/scaling/DriverCore.hpp
@@ -73,7 +73,7 @@
 #endif
 #endif
 
-// Cuda 
+// Cuda
 #ifdef HAVE_MUELU_CUDA
 #include "cuda_profiler_api.h"
 #endif
@@ -152,7 +152,7 @@ void PreconditionerSetup(Teuchos::RCP<Xpetra::Matrix<Scalar,LocalOrdinal,GlobalO
                          Teuchos::RCP<Xpetra::Operator<Scalar,LocalOrdinal,GlobalOrdinal,Node> > & Prec) {
 #include <MueLu_UseShortNames.hpp>
   using Teuchos::RCP;
-  Xpetra::UnderlyingLib lib = A->getRowMap()->lib();  
+  Xpetra::UnderlyingLib lib = A->getRowMap()->lib();
   typedef typename Teuchos::ScalarTraits<SC>::coordinateType coordinate_type;
   typedef Xpetra::MultiVector<coordinate_type,LO,GO,NO> CoordinateMultiVector;
   // =========================================================================
@@ -168,10 +168,9 @@ void PreconditionerSetup(Teuchos::RCP<Xpetra::Matrix<Scalar,LocalOrdinal,GlobalO
      A->SetMaxEigenvalueEstimate(-Teuchos::ScalarTraits<SC>::one());
      if(useAMGX) {
 #if defined(HAVE_MUELU_AMGX) and defined(HAVE_MUELU_TPETRA)
-       Teuchos::ParameterList dummyList;
        RCP<Tpetra::CrsMatrix<SC,LO,GO,NO> > Ac      = Utilities::Op2NonConstTpetraCrs(A);
        RCP<Tpetra::Operator<SC,LO,GO,NO> > At       = Teuchos::rcp_dynamic_cast<Tpetra::Operator<SC,LO,GO,NO> >(Ac);
-       RCP<MueLu::TpetraOperator<SC,LO,GO,NO> > Top = MueLu::CreateTpetraPreconditioner(At, mueluList, dummyList);
+       RCP<MueLu::TpetraOperator<SC,LO,GO,NO> > Top = MueLu::CreateTpetraPreconditioner(At, mueluList);
        Prec = Teuchos::rcp(new Xpetra::TpetraOperator<SC,LO,GO,NO>(Top));
 #endif
      } else if(useML) {
@@ -192,7 +191,7 @@ void PreconditionerSetup(Teuchos::RCP<Xpetra::Matrix<Scalar,LocalOrdinal,GlobalO
        userParamList.set<RCP<CoordinateMultiVector> >("Coordinates", coordinates);
        userParamList.set<RCP<Xpetra::MultiVector<SC,LO,GO,NO>> >("Nullspace", nullspace);
        userParamList.set<Teuchos::Array<LO> >("Array<LO> lNodesPerDim", lNodesPerDim);
-       H = MueLu::CreateXpetraPreconditioner(A, mueluList, mueluList);
+       H = MueLu::CreateXpetraPreconditioner(A, mueluList);
      }
    }
 #ifdef HAVE_MUELU_CUDA
@@ -225,7 +224,7 @@ void SystemSolve(Teuchos::RCP<Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,N
   using Teuchos::RCP;
   using Teuchos::rcp;
   using Teuchos::TimeMonitor;
-  Xpetra::UnderlyingLib lib = A->getRowMap()->lib();  
+  Xpetra::UnderlyingLib lib = A->getRowMap()->lib();
   typedef Teuchos::ScalarTraits<SC> STS;
   SC zero = STS::zero();
 
@@ -263,7 +262,7 @@ void SystemSolve(Teuchos::RCP<Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,N
     RCP<TimeMonitor> tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("Driver: 3 - LHS and RHS initialization")));
     X->putScalar(zero);
     tm = Teuchos::null;
-      
+
     if (solveType == "none") {
       // Do not perform a solve
     } else if (solveType == "matvec") {
@@ -317,16 +316,16 @@ void SystemSolve(Teuchos::RCP<Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,N
         H->IsPreconditioner(true);
         belosPrec = rcp(new Belos::MueLuOp <SC, LO, GO, NO>(H)); // Turns a MueLu::Hierarchy object into a Belos operator
       }
-      
+
       // Construct a Belos LinearProblem object
       RCP<Belos::LinearProblem<SC, MV, OP> > belosProblem = rcp(new Belos::LinearProblem<SC, MV, OP>(belosOp, X, B));
       if(solvePreconditioned) belosProblem->setRightPrec(belosPrec);
-      
+
       bool set = belosProblem->setProblem();
       if (set == false) {
         throw MueLu::Exceptions::RuntimeError("ERROR:  Belos::LinearProblem failed to set up correctly!");
       }
-      
+
       // Belos parameter list
       RCP<Teuchos::ParameterList> belosList = Teuchos::parameterList();
       belosList->set("Maximum Iterations",    maxIts); // Maximum number of iterations allowed
@@ -336,16 +335,16 @@ void SystemSolve(Teuchos::RCP<Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,N
       belosList->set("Output Style",          Belos::Brief);
       if (!scaleResidualHist)
         belosList->set("Implicit Residual Scaling", "None");
-      
+
       // Create an iterative solver manager
       Belos::SolverFactory<SC, MV, OP> solverFactory;
       RCP< Belos::SolverManager<SC, MV, OP> > solver = solverFactory.create(belosType, belosList);
       solver->setProblem(belosProblem);
-      
+
       // Perform solve
       Belos::ReturnType ret = Belos::Unconverged;
       ret = solver->solve();
-      
+
       // Get the number of iterations for this solve.
       out << "Number of iterations performed for this solve: " << solver->getNumIters() << std::endl;
       // Check convergence
@@ -361,7 +360,7 @@ void SystemSolve(Teuchos::RCP<Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdinal,N
       throw MueLu::Exceptions::RuntimeError("Unknown solver type: \"" + solveType + "\"");
     }
   }// end resolves
-  
+
 }
 
 #endif

--- a/packages/muelu/test/scaling/ImportPerformance.cpp
+++ b/packages/muelu/test/scaling/ImportPerformance.cpp
@@ -468,7 +468,7 @@ int main_(Teuchos::CommandLineProcessor &clp,  Xpetra::UnderlyingLib &lib, int a
     // =========================================================================
     typedef Teuchos::ScalarTraits<SC> STS;
     SC one = STS::one();
-    typedef typename STS::magnitudeType real_type;
+    typedef typename STS::coordinateType real_type;
     typedef Xpetra::MultiVector<real_type,LO,GO,NO> RealValuedMultiVector;
 
     // =========================================================================
@@ -684,7 +684,9 @@ int main_(Teuchos::CommandLineProcessor &clp,  Xpetra::UnderlyingLib &lib, int a
                 auto MueLuSU_D2 = TimeMonitor(*TimeMonitor::getNewTimer("Driver: 2 - MueLu Setup"));
 
                 A->SetMaxEigenvalueEstimate(-one);
-                H = MueLu::CreateXpetraPreconditioner(A, mueluList, coordinates);
+                Teuchos::ParameterList& userParamList = mueluList.sublist("user data");
+                userParamList.set<RCP<RealValuedMultiVector> >("Coordinates", coordinates);
+                H = MueLu::CreateXpetraPreconditioner(A, mueluList);
                 comm->barrier();
             }
 

--- a/packages/muelu/test/structured/Driver_Structured.cpp
+++ b/packages/muelu/test/structured/Driver_Structured.cpp
@@ -343,7 +343,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
     userParamList.set("Mdiag",Mdiag);
 
 
-    H = MueLu::CreateXpetraPreconditioner(A, paramList, paramList);
+    H = MueLu::CreateXpetraPreconditioner(A, paramList);
 
 
     comm->barrier();

--- a/packages/muelu/test/unit_tests/Adapters/AmgxOperatorAdapter.cpp
+++ b/packages/muelu/test/unit_tests/Adapters/AmgxOperatorAdapter.cpp
@@ -92,35 +92,35 @@ namespace MueLuTests {
       RCP<const Teuchos::Comm<int> > comm = TestHelpers::Parameters::getDefaultComm();
       int nx;
       //disable amgx test in parallel
-      if(comm->getSize() > 1) 
+      if(comm->getSize() > 1)
 	return;
       else
 	nx = 91;
 
       //matrix
-      RCP<Matrix> Op = TestHelpers::TestFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build2DPoisson(nx, -1, Xpetra::UseTpetra); 
+      RCP<Matrix> Op = TestHelpers::TestFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build2DPoisson(nx, -1, Xpetra::UseTpetra);
       RCP<Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > tpA = MueLu::Utilities<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Op2NonConstTpetraCrs(Op);
       RCP<Tpetra::Operator<Scalar,LocalOrdinal,GlobalOrdinal,Node> > tOp = tpA;
       Teuchos::ParameterList params, dummyList;
       params.set("use external multigrid package", "amgx");
       Teuchos::ParameterList subList = params.sublist("amgx:params", false);
       params.sublist("amgx:params").set("json file", "test.json");
-      RCP<MueLu::TpetraOperator<Scalar,LocalOrdinal,GlobalOrdinal,Node> > tH = MueLu::CreateTpetraPreconditioner(tOp, params,dummyList);
-      
+      RCP<MueLu::TpetraOperator<Scalar,LocalOrdinal,GlobalOrdinal,Node> > tH = MueLu::CreateTpetraPreconditioner(tOp, params);
+
       RCP<AMGXOperator> aH = Teuchos::rcp_dynamic_cast<AMGXOperator>(tH);
       TEST_EQUALITY(aH->sizeA()==nx*nx/comm->getSize(), true);
-   
+
       RCP<MultiVector> RHS = MultiVectorFactory::Build(Op->getRowMap(), 1);
       RCP<MultiVector> X   = MultiVectorFactory::Build(Op->getRowMap(), 1);
 
       //RHS=1, zero initial guess
       RHS->putScalar( (double) 1.0);
       X->putScalar( (double) 0.0);
-      
+
       aH->apply(*(MueLu::Utilities<Scalar, LocalOrdinal, GlobalOrdinal, Node>::MV2TpetraMV(RHS)),*(MueLu::Utilities<Scalar, LocalOrdinal, GlobalOrdinal, Node>::MV2NonConstTpetraMV(X)));
       //if(comm->getSize() == 1) TEST_EQUALITY(aH->iters()==16,true);
       TEST_EQUALITY(aH->getStatus()==0, true);
-      
+
     } else {
 
       out << "This test is enabled only for linAlgebra=Tpetra." << std::endl;

--- a/packages/muelu/test/unit_tests/Adapters/CreatePreconditioner.cpp
+++ b/packages/muelu/test/unit_tests/Adapters/CreatePreconditioner.cpp
@@ -74,15 +74,13 @@
 #include "MueLu_EpetraOperator.hpp"
 #endif
 
+// #ifdef HAVE_MUELU_DEPRECATED_CODE
+// #define OLD_HAVE_MUELU_DEPRECATED_CODE HAVE_MUELU_DEPRECATED_CODE
+// #undef HAVE_MUELU_DEPRECATED_CODE
+// #endif
+
 namespace MueLuTests {
 
-// Ignore all deprecated declarations
-// We could have done that for every call to Create[ET]petraPreconditioner, but
-// it's a pain, there are 25+ of those.
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
   TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(PetraOperator, CreatePreconditioner, Scalar, LocalOrdinal, GlobalOrdinal, Node)
   {
 #   include "MueLu_UseShortNames.hpp"
@@ -143,6 +141,8 @@ namespace MueLuTests {
       out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
           Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
 
+#ifdef HAVE_MUELU_DEPRECATED_TESTS
+
       out << "Testing deprecated method" << std::endl;
       tH = MueLu::CreateTpetraPreconditioner<SC,LO,GO,NO>(tpA, xmlFileName);
       tH->apply(*(Utils::MV2TpetraMV(RHS1)), *(Utils::MV2NonConstTpetraMV(X1)));
@@ -196,6 +196,8 @@ namespace MueLuTests {
       tH->apply(*(Utils::MV2TpetraMV(RHS1)), *(Utils::MV2NonConstTpetraMV(X1)));
       out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
           Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
+#endif // HAVE_MUELU_DEPRECATED_TESTS
+
 #endif
 
 #else
@@ -241,6 +243,21 @@ namespace MueLuTests {
       RCP<Epetra_MultiVector> epcoordinates = MueLu::Utilities<real_type,LO,GO,NO>::MV2NonConstEpetraMV(coordinates);
       RCP<Epetra_MultiVector> epnullspace   = Utils::MV2NonConstEpetraMV(nullspace);
 
+      Teuchos::ParameterList paramList;
+      Teuchos::updateParametersFromXmlFileAndBroadcast(xmlFileName, Teuchos::Ptr<Teuchos::ParameterList>(&paramList), *map->getComm());
+      Teuchos::ParameterList& userParamList = paramList.sublist("user data");
+      userParamList.set<RCP<Epetra_MultiVector> >("Coordinates", epcoordinates);
+      userParamList.set<RCP<Epetra_MultiVector> >("Nullspace", epnullspace);
+
+      eH = MueLu::CreateEpetraPreconditioner(epA, paramList);
+
+      X1->putScalar(Teuchos::ScalarTraits<SC>::zero());
+      eH->Apply(*(Utils::MV2EpetraMV(RHS1)), *(Utils::MV2NonConstEpetraMV(X1)));
+      out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
+          Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
+
+#ifdef HAVE_MUELU_DEPRECATED_TESTS
+
       eH = MueLu::CreateEpetraPreconditioner(epA, xmlFileName, epcoordinates);
 
       X1->putScalar(Teuchos::ScalarTraits<SC>::zero());
@@ -254,6 +271,8 @@ namespace MueLuTests {
       eH->Apply(*(Utils::MV2EpetraMV(RHS1)), *(Utils::MV2NonConstEpetraMV(X1)));
       out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
           Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
+#endif // HAVE_MUELU_DEPRECATED_TESTS
+
 #endif
 
 #else
@@ -323,16 +342,34 @@ namespace MueLuTests {
       out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
           Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
 
+#ifdef HAVE_MUELU_DEPRECATED_TESTS
+
       out << "Testing deprecated method" << std::endl;
       tH = MueLu::CreateTpetraPreconditioner<SC,LO,GO,NO>(tpA,mylist);
       tH->apply(*(Utils::MV2TpetraMV(RHS1)), *(Utils::MV2NonConstTpetraMV(X1)));
       out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
           Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
 
+#endif // HAVE_MUELU_DEPRECATED_TESTS
+
       mylist.set("xml parameter file","testWithRebalance.xml");
 
       RCP<Tpetra::MultiVector<real_type,LO,GO,NO> > tpcoordinates = MueLu::Utilities<real_type,LO,GO,NO>::MV2NonConstTpetraMV(coordinates);
       RCP<Tpetra::MultiVector<SC,LO,GO,NO> > tpnullspace   = Utils::MV2NonConstTpetraMV(nullspace);
+
+      std::string mueluXML = mylist.get("xml parameter file", "");
+      Teuchos::ParameterList mueluList;
+      Teuchos::updateParametersFromXmlFileAndBroadcast(mueluXML, Teuchos::Ptr<Teuchos::ParameterList>(&mueluList), *map->getComm());
+      Teuchos::ParameterList& userParamList = mueluList.sublist("user data");
+      userParamList.set<RCP<Tpetra::MultiVector<real_type,LO,GO,NO> > >("Coordinates", tpcoordinates);
+      userParamList.set<RCP<Tpetra::MultiVector<SC,LO,GO,NO> > >("Nullspace", tpnullspace);
+      tH = MueLu::CreateTpetraPreconditioner<SC,LO,GO,NO>(RCP<tpetra_operator_type>(tpA), mueluList);
+      X1->putScalar(Teuchos::ScalarTraits<SC>::zero());
+      tH->apply(*(Utils::MV2TpetraMV(RHS1)), *(Utils::MV2NonConstTpetraMV(X1)));
+      out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
+          Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
+
+#ifdef HAVE_MUELU_DEPRECATED_TESTS
 
       tH = MueLu::CreateTpetraPreconditioner<SC,LO,GO,NO>(RCP<tpetra_operator_type>(tpA), mylist, tpcoordinates);
       X1->putScalar(Teuchos::ScalarTraits<SC>::zero());
@@ -359,6 +396,9 @@ namespace MueLuTests {
       tH->apply(*(Utils::MV2TpetraMV(RHS1)), *(Utils::MV2NonConstTpetraMV(X1)));
       out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
           Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
+
+#endif // HAVE_MUELU_DEPRECATED_TESTS
+
 #endif
 
 #else
@@ -403,6 +443,14 @@ namespace MueLuTests {
       RCP<Epetra_MultiVector> epcoordinates = MueLu::Utilities<real_type,LO,GO,NO>::MV2NonConstEpetraMV(coordinates);
       RCP<Epetra_MultiVector> epnullspace   = Utils::MV2NonConstEpetraMV(nullspace);
 
+      Teuchos::ParameterList paramList = mylist;
+      Teuchos::ParameterList& userParamList = paramList.sublist("user data");
+      userParamList.set<RCP<Epetra_MultiVector> >("Coordinates", epcoordinates);
+      userParamList.set<RCP<Epetra_MultiVector> >("Nullspace", epnullspace);
+      eH = MueLu::CreateEpetraPreconditioner(epA, paramList);
+
+#ifdef HAVE_MUELU_DEPRECATED_TESTS
+
       eH = MueLu::CreateEpetraPreconditioner(epA, mylist, epcoordinates);
 
       X1->putScalar(Teuchos::ScalarTraits<SC>::zero());
@@ -416,6 +464,8 @@ namespace MueLuTests {
       eH->Apply(*(Utils::MV2EpetraMV(RHS1)), *(Utils::MV2NonConstEpetraMV(X1)));
       out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
           Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
+#endif // HAVE_MUELU_DEPRECATED_TESTS
+
 #endif
 
 #else
@@ -439,7 +489,7 @@ namespace MueLuTests {
 
     using Teuchos::RCP;
     typedef MueLu::Utilities<SC,LO,GO,NO> Utils;
-    typedef typename Teuchos::ScalarTraits<Scalar>::magnitudeType real_type;
+    typedef typename Teuchos::ScalarTraits<Scalar>::coordinateType real_type;
     typedef Xpetra::MultiVector<real_type,LO,GO,NO> dMultiVector;
 
 #if defined(HAVE_MUELU_ZOLTAN) && defined(HAVE_MPI)
@@ -498,7 +548,19 @@ namespace MueLuTests {
         RCP<Tpetra::MultiVector<real_type,LO,GO,NO> > tpcoordinates = MueLu::Utilities<real_type,LO,GO,NO>::MV2NonConstTpetraMV(coordinates);
         RCP<Tpetra::MultiVector<SC,LO,GO,NO> > tpnullspace   = Utils::MV2NonConstTpetraMV(nullspace);
 
-        RCP<MueLu::TpetraOperator<SC,LO,GO,NO> > tH = MueLu::CreateTpetraPreconditioner<SC,LO,GO,NO>(RCP<tpetra_operator_type>(tpA), xmlFileName, tpcoordinates);
+        Teuchos::ParameterList paramList;
+        Teuchos::updateParametersFromXmlFileAndBroadcast(xmlFileName, Teuchos::Ptr<Teuchos::ParameterList>(&paramList), *tpA->getDomainMap()->getComm());
+        Teuchos::ParameterList& userParamList = paramList.sublist("user data");
+        userParamList.set<RCP<Tpetra::MultiVector<real_type,LO,GO,NO> > >("Coordinates", tpcoordinates);
+        userParamList.set<RCP<Tpetra::MultiVector<SC,LO,GO,NO> > >("Nullspace", tpnullspace);
+        RCP<MueLu::TpetraOperator<SC,LO,GO,NO> > tH = MueLu::CreateTpetraPreconditioner<SC,LO,GO,NO>(RCP<tpetra_operator_type>(tpA), paramList);
+        tH->apply(*(Utils::MV2TpetraMV(RHS1)), *(Utils::MV2NonConstTpetraMV(X1)));
+        out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
+            Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
+
+#ifdef HAVE_MUELU_DEPRECATED_TESTS
+
+        tH = MueLu::CreateTpetraPreconditioner<SC,LO,GO,NO>(RCP<tpetra_operator_type>(tpA), xmlFileName, tpcoordinates);
         tH->apply(*(Utils::MV2TpetraMV(RHS1)), *(Utils::MV2NonConstTpetraMV(X1)));
         out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
             Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
@@ -521,6 +583,8 @@ namespace MueLuTests {
         tH->apply(*(Utils::MV2TpetraMV(RHS1)), *(Utils::MV2NonConstTpetraMV(X1)));
         out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
             Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
+
+#endif // HAVE_MUELU_DEPRECATED_TESTS
 #else
         std::cout << "Skip PetraOperator::CreatePreconditioner_PDESystem: Tpetra is not available (with GO=int enabled)" << std::endl;
 #endif // #if defined(HAVE_MUELU_TPETRA) && defined(HAVE_MUELU_TPETRA_INST_INT_INT)
@@ -567,7 +631,22 @@ namespace MueLuTests {
         RCP<Epetra_MultiVector> epcoordinates = MueLu::Utilities<real_type,LO,GO,NO>::MV2NonConstEpetraMV(coordinates);
         RCP<Epetra_MultiVector> epnullspace   = Utils::MV2NonConstEpetraMV(nullspace);
 
-        RCP<MueLu::EpetraOperator> eH = MueLu::CreateEpetraPreconditioner(epA, xmlFileName, epcoordinates);
+        Teuchos::ParameterList paramList;
+        Teuchos::updateParametersFromXmlFileAndBroadcast(xmlFileName,
+                                                         Teuchos::Ptr<Teuchos::ParameterList>(&paramList),
+                                                         *map->getComm());
+        Teuchos::ParameterList& userParamList = paramList.sublist("user data");
+        userParamList.set<RCP<Epetra_MultiVector> >("Coordinates", epcoordinates);
+        userParamList.set<RCP<Epetra_MultiVector> >("Nullspace",   epnullspace);
+        RCP<MueLu::EpetraOperator> eH = MueLu::CreateEpetraPreconditioner(epA, paramList);
+
+        eH->Apply(*(Utils::MV2EpetraMV(RHS1)), *(Utils::MV2NonConstEpetraMV(X1)));
+        out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
+            Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
+
+#ifdef HAVE_MUELU_DEPRECATED_TESTS
+
+        eH = MueLu::CreateEpetraPreconditioner(epA, xmlFileName, epcoordinates);
 
         eH->Apply(*(Utils::MV2EpetraMV(RHS1)), *(Utils::MV2NonConstEpetraMV(X1)));
         out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
@@ -579,6 +658,8 @@ namespace MueLuTests {
         eH->Apply(*(Utils::MV2EpetraMV(RHS1)), *(Utils::MV2NonConstEpetraMV(X1)));
         out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
             Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
+#endif // HAVE_MUELU_DEPRECATED_TESTS
+
 #else
         std::cout << "Skip PetraOperator::CreatePreconditioner_PDESystem: Epetra is not available" << std::endl;
 #endif
@@ -635,11 +716,15 @@ namespace MueLuTests {
       out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
           Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
 
+#ifdef HAVE_MUELU_DEPRECATED_TESTS
+
       out << "Testing deprecated method" << std::endl;
       tH = MueLu::CreateTpetraPreconditioner<SC,LO,GO,NO>(tpA, xmlFileName);
       tH->apply(*(Utils::MV2TpetraMV(RHS1)), *(Utils::MV2NonConstTpetraMV(X1)));
       out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
           Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
+
+#endif // HAVE_MUELU_DEPRECATED_TESTS
 
       // Reuse preconditioner
       MueLu::ReuseTpetraPreconditioner(tpA, *tH);
@@ -693,9 +778,6 @@ namespace MueLuTests {
       TEUCHOS_TEST_FOR_EXCEPTION(true, MueLu::Exceptions::InvalidArgument, "Unknown Xpetra lib");
     }
   }
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
 
 #  define MUELU_ETI_GROUP(Scalar, LO, GO, Node) \
   TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(PetraOperator, CreatePreconditioner, Scalar, LO, GO, Node) \
@@ -706,3 +788,8 @@ namespace MueLuTests {
 #include <MueLu_ETI_4arg.hpp>
 
 }//namespace MueLuTests
+
+// #ifdef OLD_HAVE_MUELU_DEPRECATED_CODE
+// #define HAVE_MUELU_DEPRECATED_CODE OLD_HAVE_MUELU_DEPRECATED_CODE
+// #undef OLD_HAVE_MUELU_DEPRECATED_CODE
+// #endif

--- a/packages/muelu/test/unit_tests/Hierarchy.cpp
+++ b/packages/muelu/test/unit_tests/Hierarchy.cpp
@@ -124,9 +124,10 @@ namespace MueLuTests {
     MueLuList.set("coarse: max size",numRows-1); // make it so we want two levels
     MueLuList.set("max levels",2);
 
+    Teuchos::ParameterList userParamList = MueLuList.sublist("user data");
+    userParamList.set<RCP<RealValuedMultiVector> >("Coordinates", coordinates);
     Teuchos::RCP<MueLu::Hierarchy<Scalar,LocalOrdinal,GlobalOrdinal,Node> > H =
-        MueLu::CreateXpetraPreconditioner<Scalar,LocalOrdinal,GlobalOrdinal,Node>(
-            A, MueLuList, coordinates, Teuchos::null);
+        MueLu::CreateXpetraPreconditioner<Scalar,LocalOrdinal,GlobalOrdinal,Node>(A, MueLuList);
 
     // confirm that we did get a hierarchy with two levels -- a sanity check for this test
     TEST_EQUALITY(2, H->GetGlobalNumLevels());

--- a/packages/muelu/test/unit_tests/RAPShiftFactory.cpp
+++ b/packages/muelu/test/unit_tests/RAPShiftFactory.cpp
@@ -287,7 +287,7 @@ namespace MueLuTests {
     typedef TestHelpers::TestFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node> test_factory;
     typedef typename Teuchos::ScalarTraits<Scalar>::magnitudeType MT;
 
-    typedef typename Teuchos::ScalarTraits<SC>::magnitudeType real_type;
+    typedef typename Teuchos::ScalarTraits<SC>::coordinateType real_type;
     typedef typename Xpetra::MultiVector<real_type,LO,GO,NO> RealValuedMultiVector;
 
     using Teuchos::RCP;
@@ -347,7 +347,9 @@ namespace MueLuTests {
     pLevel0.set("M",A);
 
     // Build hierarchy
-    RCP<Hierarchy> H = MueLu::CreateXpetraPreconditioner<SC,LO,GO,NO>(A,*Params, coordinates, Teuchos::null);
+    Teuchos::ParameterList& userParamList = Params->sublist("user data");
+    userParamList.set<RCP<RealValuedMultiVector> >("Coordinates", coordinates);
+    RCP<Hierarchy> H = MueLu::CreateXpetraPreconditioner<SC,LO,GO,NO>(A,*Params);
 
     // Ready the test vector
     RCP<Level> Level1 = H->GetLevel(1);
@@ -423,7 +425,9 @@ namespace MueLuTests {
     pLevel0.set("M",A);
 
     // Build hierarchy
-    RCP<Hierarchy> H = MueLu::CreateXpetraPreconditioner<SC,LO,GO,NO>(A,*Params,coordinates,Teuchos::null);
+    Teuchos::ParameterList& userParamList = Params->sublist("user data");
+    userParamList.set<RCP<RealValuedMultiVector> >("Coordinates", coordinates);
+    RCP<Hierarchy> H = MueLu::CreateXpetraPreconditioner<SC,LO,GO,NO>(A,*Params);
 
     // Ready the test vector
     RCP<Level> Level1 = H->GetLevel(1);
@@ -486,7 +490,7 @@ namespace MueLuTests {
     galeriList.set("nx", nx);
     RCP<RealValuedMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<SC,LO,GO,Map,RealValuedMultiVector>("1D", A->getRowMap(), galeriList);
 
-    // Extract the diagonal of A 
+    // Extract the diagonal of A
     RCP<Vector> Mdiag = Xpetra::VectorFactory<SC,LO,GO,NO>::Build(A->getRowMap(),false);
     A->getLocalDiagCopy(*Mdiag);
 
@@ -506,7 +510,9 @@ namespace MueLuTests {
     pLevel0.set("Mdiag",Mdiag);
 
     // Build hierarchy
-    RCP<Hierarchy> H = MueLu::CreateXpetraPreconditioner<SC,LO,GO,NO>(A,*Params,coordinates,Teuchos::null);
+    Teuchos::ParameterList& userParamList = Params->sublist("user data");
+    userParamList.set<RCP<RealValuedMultiVector> >("Coordinates", coordinates);
+    RCP<Hierarchy> H = MueLu::CreateXpetraPreconditioner<SC,LO,GO,NO>(A,*Params);
 
     // Ready the test vector
     RCP<Level> Level1 = H->GetLevel(1);
@@ -572,7 +578,7 @@ namespace MueLuTests {
     galeriList.set("nx", nx);
     RCP<RealValuedMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<SC,LO,GO,Map,RealValuedMultiVector>("1D", A->getRowMap(), galeriList);
 
-    // Extract the diagonal of A 
+    // Extract the diagonal of A
     RCP<Vector> Mdiag = Xpetra::VectorFactory<SC,LO,GO,NO>::Build(A->getRowMap(),false);
     A->getLocalDiagCopy(*Mdiag);
 
@@ -591,7 +597,9 @@ namespace MueLuTests {
     pLevel0.set("Mdiag",Mdiag);
 
     // Build hierarchy
-    RCP<Hierarchy> H = MueLu::CreateXpetraPreconditioner<SC,LO,GO,NO>(A,*Params,coordinates,Teuchos::null);
+    Teuchos::ParameterList& userParamList = Params->sublist("user data");
+    userParamList.set<RCP<RealValuedMultiVector> >("Coordinates", coordinates);
+    RCP<Hierarchy> H = MueLu::CreateXpetraPreconditioner<SC,LO,GO,NO>(A,*Params);
 
     // Ready the test vector
     RCP<Level> Level1 = H->GetLevel(1);
@@ -656,7 +664,7 @@ namespace MueLuTests {
     galeriList.set("nx", nx);
     RCP<RealValuedMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<SC,LO,GO,Map,RealValuedMultiVector>("1D", A->getRowMap(), galeriList);
 
-    // Extract the diagonal of A 
+    // Extract the diagonal of A
     RCP<Vector> Mdiag = Xpetra::VectorFactory<SC,LO,GO,NO>::Build(A->getRowMap(),false);
     A->getLocalDiagCopy(*Mdiag);
 
@@ -664,7 +672,7 @@ namespace MueLuTests {
     double shift = 2.0;
     Teuchos::Array<double> shifts(2); shifts[0]=1.0; shifts[1]=shifts[0]+shift;
     RCP<Teuchos::ParameterList> Params = rcp(new Teuchos::ParameterList);
-    Params->set("rap: algorithm","shift");    
+    Params->set("rap: algorithm","shift");
     Params->set("rap: shift array",shifts);
     Params->set("rap: shift diagonal M",true);
     Params->set("rap: shift low storage",true);
@@ -676,7 +684,9 @@ namespace MueLuTests {
     pLevel0.set("Mdiag",Mdiag);
 
     // Build hierarchy
-    RCP<Hierarchy> H = MueLu::CreateXpetraPreconditioner<SC,LO,GO,NO>(A,*Params,coordinates,Teuchos::null);
+    Teuchos::ParameterList& userParamList = Params->sublist("user data");
+    userParamList.set<RCP<RealValuedMultiVector> >("Coordinates", coordinates);
+    RCP<Hierarchy> H = MueLu::CreateXpetraPreconditioner<SC,LO,GO,NO>(A,*Params);
 
     // Ready the test vector
     RCP<Level> Level1 = H->GetLevel(1);
@@ -740,7 +750,7 @@ namespace MueLuTests {
     galeriList.set("nx", nx);
     RCP<RealValuedMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<SC,LO,GO,Map,RealValuedMultiVector>("1D", A->getRowMap(), galeriList);
 
-    // Extract the diagonal of A 
+    // Extract the diagonal of A
     RCP<Vector> Mdiag = Xpetra::VectorFactory<SC,LO,GO,NO>::Build(A->getRowMap(),false);
     A->getLocalDiagCopy(*Mdiag);
 
@@ -748,7 +758,7 @@ namespace MueLuTests {
     double shift = 1.0;
     Teuchos::Array<double> cfls(2); cfls[0]=1.0; cfls[1]=cfls[0] - 1/(1.0+shift);
     RCP<Teuchos::ParameterList> Params = rcp(new Teuchos::ParameterList);
-    Params->set("rap: algorithm","shift");    
+    Params->set("rap: algorithm","shift");
     Params->set("rap: shift diagonal M",true);
     Params->set("rap: shift low storage",true);
     Params->set("rap: cfl array",cfls);
@@ -761,10 +771,12 @@ namespace MueLuTests {
     Teuchos::ParameterList & user = Params->sublist("user data");
     user.set("double deltaT",1.0);
     user.set("double cfl",1.0);
-    
+
 
     // Build hierarchy
-    RCP<Hierarchy> H = MueLu::CreateXpetraPreconditioner<SC,LO,GO,NO>(A,*Params,coordinates,Teuchos::null);
+    Teuchos::ParameterList& userParamList = Params->sublist("user data");
+    userParamList.set<RCP<RealValuedMultiVector> >("Coordinates", coordinates);
+    RCP<Hierarchy> H = MueLu::CreateXpetraPreconditioner<SC,LO,GO,NO>(A,*Params);
 
     // Ready the test vector
     RCP<Level> Level1 = H->GetLevel(1);
@@ -815,4 +827,3 @@ namespace MueLuTests {
 #include <MueLu_ETI_4arg.hpp>
 
 } // namespace MueLuTests
-

--- a/packages/muelu/test/unit_tests/UserData/CreateXpetraPreconditioner.cpp
+++ b/packages/muelu/test/unit_tests/UserData/CreateXpetraPreconditioner.cpp
@@ -145,7 +145,7 @@ namespace MueLuTests {
     myArrayLO[4] = 3;
     userParamList.set<Array<LO> >("Array<LO> myArray<LO>", myArrayLO);
 
-    RCP<Hierarchy> xH = MueLu::CreateXpetraPreconditioner<SC,LO,GO,NO>(Op, *inParamList, *inParamList);
+    RCP<Hierarchy> xH = MueLu::CreateXpetraPreconditioner<SC,LO,GO,NO>(Op, *inParamList);
 
     // Extract variables on level 0 and check that they are unchanged.
     RCP<MueLu::Level> level0 = xH->GetLevel();

--- a/packages/muelu/test/vardofpernode/VarDofDriver.cpp
+++ b/packages/muelu/test/vardofpernode/VarDofDriver.cpp
@@ -389,7 +389,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib lib, int arg
     userParamList.set("ArrayRCP<LO> DofPresent", dofPresent);
 
     RCP<Hierarchy> H;
-    H = MueLu::CreateXpetraPreconditioner(DistributedMatrix, paramList, paramList /*coordinates*/);
+    H = MueLu::CreateXpetraPreconditioner(DistributedMatrix, paramList);
 
 #ifdef HAVE_MUELU_BELOS
     {

--- a/packages/trilinoscouplings/examples/fenl/MueLuPreconditioner.hpp
+++ b/packages/trilinoscouplings/examples/fenl/MueLuPreconditioner.hpp
@@ -52,16 +52,23 @@ namespace Example {
 
   template<class S, class LO, class GO, class N>
   Teuchos::RCP<Tpetra::Operator<S,LO,GO,N> >
-  build_muelu_preconditioner(
-    const Teuchos::RCP<Tpetra::CrsMatrix<S,LO,GO,N> >& A,
-    const Teuchos::RCP<Teuchos::ParameterList>& mueluParams,
-    const Teuchos::RCP<Tpetra::MultiVector<double,LO,GO,N> >& coords)
+  build_muelu_preconditioner(const Teuchos::RCP<Tpetra::CrsMatrix<S,LO,GO,N> >& A,
+                             const Teuchos::RCP<Teuchos::ParameterList>& mueluParams,
+                             const Teuchos::RCP<Tpetra::MultiVector<double,LO,GO,N> >& coords)
   {
-    typedef Tpetra::Operator<S,LO,GO,N> OperatorType;
-    typedef MueLu::TpetraOperator<S,LO,GO,N> PreconditionerType;
-    Teuchos::RCP<OperatorType> A_op = A;
-    Teuchos::RCP<PreconditionerType> mueluPreconditioner =
-      MueLu::CreateTpetraPreconditioner(A_op,*mueluParams,coords);
+    using Teuchos::RCP;
+    using OperatorType       = Tpetra::Operator<S,LO,GO,N>;
+    using PreconditionerType = MueLu::TpetraOperator<S,LO,GO,N>;
+
+    RCP<OperatorType> A_op = A;
+
+    Teuchos::ParameterList& userList = mueluParams->sublist("user data");
+    if (coords != Teuchos::null) {
+      userList.set<RCP<Tpetra::MultiVector<double,LO,GO,N> > >("Coordinates", coords);
+    }
+    RCP<PreconditionerType> mueluPreconditioner
+      = MueLu::CreateTpetraPreconditioner(A_op, *mueluParams);
+
     return mueluPreconditioner;
   }
 

--- a/packages/trilinoscouplings/examples/scaling/HybridIntrepidPoisson2D_Pamgen_Tpetra_main.cpp
+++ b/packages/trilinoscouplings/examples/scaling/HybridIntrepidPoisson2D_Pamgen_Tpetra_main.cpp
@@ -311,6 +311,7 @@ main (int argc, char *argv[])
       // Setup preconditioner
       std::string prec_type = inputList.get ("Preconditioner", "None");
       RCP<operator_type> M;
+      RCP<operator_type> opA(A);
       {
         TEUCHOS_FUNC_TIME_MONITOR_DIFF("Total Preconditioner Setup", total_prec);
 
@@ -319,14 +320,14 @@ main (int argc, char *argv[])
 	  for(int i=0; i<numMueluRebuilds+1; i++) {
 	    if (inputList.isSublist("MueLu")) {
 	      ParameterList mueluParams = inputList.sublist("MueLu");
-          const std::string userName = "user data";
-          Teuchos::ParameterList& userParamList = mueluParams.sublist(userName);
-          userParamList.set<Teuchos::Array<LO> >("Array<LO> lNodesPerDim", lNodesPerDim);
-          userParamList.set< RCP<Tpetra::MultiVector<double,LO,GO,Node>> >("Coordinates", coordinates);
-          userParamList.set< std::string >("string aggregationRegionType", regionType);
-	      M = MueLu::CreateTpetraPreconditioner<ST,LO,GO,Node>(A,mueluParams,mueluParams);
+              const std::string userName = "user data";
+              Teuchos::ParameterList& userParamList = mueluParams.sublist(userName);
+              userParamList.set<Teuchos::Array<LO> >("Array<LO> lNodesPerDim", lNodesPerDim);
+              userParamList.set< RCP<Tpetra::MultiVector<double,LO,GO,Node>> >("Coordinates", coordinates);
+              userParamList.set< std::string >("string aggregationRegionType", regionType);
+	      M = MueLu::CreateTpetraPreconditioner<ST,LO,GO,Node>(opA, mueluParams);
 	    } else {
-	      M = MueLu::CreateTpetraPreconditioner<ST,LO,GO,Node>(A);
+	      M = MueLu::CreateTpetraPreconditioner<ST,LO,GO,Node>(opA);
 	    }
 	  }
 #else // NOT HAVE_TRILINOSCOUPLINGS_MUELU

--- a/packages/trilinoscouplings/examples/scaling/HybridIntrepidPoisson3D_Pamgen_Tpetra_main.cpp
+++ b/packages/trilinoscouplings/examples/scaling/HybridIntrepidPoisson3D_Pamgen_Tpetra_main.cpp
@@ -311,6 +311,7 @@ main (int argc, char *argv[])
       // Setup preconditioner
       std::string prec_type = inputList.get ("Preconditioner", "None");
       RCP<operator_type> M;
+      RCP<operator_type> opA(A);
       {
         TEUCHOS_FUNC_TIME_MONITOR_DIFF("Total Preconditioner Setup", total_prec);
 
@@ -324,9 +325,9 @@ main (int argc, char *argv[])
           userParamList.set<Teuchos::Array<LO> >("Array<LO> lNodesPerDim", lNodesPerDim);
           userParamList.set< RCP<Tpetra::MultiVector<double,LO,GO,Node>> >("Coordinates", coordinates);
           userParamList.set< std::string >("string aggregationRegionType", regionType);
-	      M = MueLu::CreateTpetraPreconditioner<ST,LO,GO,Node>(A,mueluParams,mueluParams);
+	      M = MueLu::CreateTpetraPreconditioner<ST,LO,GO,Node>(opA, mueluParams);
 	    } else {
-	      M = MueLu::CreateTpetraPreconditioner<ST,LO,GO,Node>(A);
+	      M = MueLu::CreateTpetraPreconditioner<ST,LO,GO,Node>(opA);
 	    }
 	  }
 #else // NOT HAVE_TRILINOSCOUPLINGS_MUELU

--- a/packages/trilinoscouplings/examples/scaling/IntrepidPoisson_Pamgen_Tpetra_main.cpp
+++ b/packages/trilinoscouplings/examples/scaling/IntrepidPoisson_Pamgen_Tpetra_main.cpp
@@ -304,11 +304,12 @@ main (int argc, char *argv[])
       // Setup preconditioner
       std::string prec_type = inputList.get ("Preconditioner", "None");
       RCP<operator_type> M;
+      RCP<operator_type> opA(A);
       {
         TEUCHOS_FUNC_TIME_MONITOR_DIFF("Total Preconditioner Setup", total_prec);
 
         if (prec_type == "MueLu") {
-#ifdef HAVE_TRILINOSCOUPLINGS_MUELU         
+#ifdef HAVE_TRILINOSCOUPLINGS_MUELU
 #ifdef HAVE_TRILINOSCOUPLINGS_AVATAR
           // If we have Avatar, then let's use it
           if (inputList.isSublist("Avatar-MueLu")) {
@@ -332,9 +333,9 @@ main (int argc, char *argv[])
 	    if (inputList.isSublist("MueLu")) {
 	      ParameterList mueluParams = inputList.sublist("MueLu");
               mueluParams.sublist("user data").set("Coordinates",coords);
-              M = MueLu::CreateTpetraPreconditioner<ST,LO,GO,Node>(A,mueluParams);
+              M = MueLu::CreateTpetraPreconditioner<ST,LO,GO,Node>(opA,mueluParams);
             } else {
-              M = MueLu::CreateTpetraPreconditioner<ST,LO,GO,Node>(A);
+              M = MueLu::CreateTpetraPreconditioner<ST,LO,GO,Node>(opA);
             }
           }
 #else // NOT HAVE_TRILINOSCOUPLINGS_MUELU

--- a/packages/trilinoscouplings/examples/scaling/StructuredIntrepidPoisson_Pamgen_Tpetra_main.cpp
+++ b/packages/trilinoscouplings/examples/scaling/StructuredIntrepidPoisson_Pamgen_Tpetra_main.cpp
@@ -298,6 +298,7 @@ main (int argc, char *argv[])
       // Setup preconditioner
       std::string prec_type = inputList.get ("Preconditioner", "None");
       RCP<operator_type> M;
+      RCP<operator_type> opA(A);
       {
         TEUCHOS_FUNC_TIME_MONITOR_DIFF("Total Preconditioner Setup", total_prec);
 
@@ -310,9 +311,9 @@ main (int argc, char *argv[])
               Teuchos::ParameterList& userParamList = mueluParams.sublist(userName);
               userParamList.set<RCP<realmultivector_type> >("Coordinates", Coordinates);
               userParamList.set<Teuchos::Array<LO> >("Array<LO> lNodesPerDim", lNodesPerDim);
-              M = MueLu::CreateTpetraPreconditioner<ST,LO,GO,Node>(A,mueluParams,mueluParams);
+              M = MueLu::CreateTpetraPreconditioner<ST,LO,GO,Node>(opA, mueluParams);
             } else {
-              M = MueLu::CreateTpetraPreconditioner<ST,LO,GO,Node>(A);
+              M = MueLu::CreateTpetraPreconditioner<ST,LO,GO,Node>(opA);
             }
           }
 #else // NOT HAVE_TRILINOSCOUPLINGS_MUELU


### PR DESCRIPTION
@trilinos/muelu 

## Description
Deprecating all CreateT/E/XpetraConstructor except for one accepting an operator and a parameter list


## Motivation and Context
This will give more uniformity and reduce maintenance

## Related Issues

* Closes #4868
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of #4728
* Composed of 

## How Has This Been Tested?
So far this is a work in progress but I plan on testing it with a local build of MueLu, all tests and examples should pass and compile without warnings.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.