### PR TITLE
Don't allow Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-rdc-release-debug-pt to run on 'ride7' (ATDV-155)

### DIFF
--- a/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-rdc-release-debug-pt.sh
+++ b/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-rdc-release-debug-pt.sh
@@ -2,4 +2,5 @@
 if [ "${Trilinos_TRACK}" == "" ] ; then
   export Trilinos_TRACK=Specialized
 fi
+export EXCLUDE_NODES_FROM_BSUB="-R hname!=ride7"
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ride/local-driver.sh

--- a/cmake/ctest/drivers/atdm/ride/local-driver.sh
+++ b/cmake/ctest/drivers/atdm/ride/local-driver.sh
@@ -8,8 +8,10 @@ if [ "${Trilinos_CTEST_DO_ALL_AT_ONCE}" == "" ] ; then
   export Trilinos_CTEST_DO_ALL_AT_ONCE=TRUE
 fi
 
-if [ "${ATDM_CONFIG_KNOWN_HOSTNAME}" == "white" ] ; then
-  EXCLUDE_NODES_FROM_BSUB="-R hname!=white26&&hname!=white27"
+if [ "${EXCLUDE_NODES_FROM_BSUB}" == "" ] ; then
+  if [ "${ATDM_CONFIG_KNOWN_HOSTNAME}" == "white" ] ; then
+    EXCLUDE_NODES_FROM_BSUB="-R hname!=white26&&hname!=white27"
+  fi
 fi
 
 source $WORKSPACE/Trilinos/cmake/std/atdm/load-env.sh $JOB_NAME


### PR DESCRIPTION
## Description

It seems this node times out the build at 12 hours every time this build is runs on the node 'ride7' so just don't run this (expensive) build on that node :-)  (See [ATDV-155](https://sems-atlassian-srn.sandia.gov/browse/ATDV-155)).

## How was this tested?

I tested this with on 'ride' with:

```
$ cd /home/rabartl/Trilinos.base2/BUILDS/RIDE/CTEST_S/

$ env Trilinos_PACKAGES=Kokkos \
  ./ctest-s-local-test-driver.sh cuda-9.2-gnu-7.2.0-rdc-release-debug-pt

...
```

The file:

* Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-rdc-release-debug-pt/smart-jenkins-driver.out

showed:

```
+ bsub -x -Is -q rhel7F -n 16 -J Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-rdc-release-debug-pt -W 12:00 -R 'hname!=ride7' /ascldap/users/rabartl/Trilinos.base2/BUILDS/RIDE/CTEST
***Forced exclusive execution
Job <855489> is submitted to queue <rhel7F>.
<<Waiting for dispatch ...>>
<<Starting on ride10>>
```

That looks like the right exclusion argument `-R 'hname!=ride7'` to me.
