### PR TITLE
ShyLU/FROSch: Global insert for coarse basis instead of local insert

### DIFF
--- a/packages/shylu/shylu_dd/frosch/src/CoarseSpaces/FROSch_CoarseSpace_decl.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/CoarseSpaces/FROSch_CoarseSpace_decl.hpp
@@ -76,6 +76,7 @@ namespace FROSch {
         typedef unsigned UN;
         
         typedef Teuchos::Array<LO> LOVec;
+        typedef Teuchos::Array<GO> GOVec;        
         typedef Teuchos::ArrayRCP<LO> LOVecPtr;
         typedef Teuchos::ArrayRCP<LOVecPtr> LOVecPtr2D;
         

--- a/packages/shylu/shylu_dd/frosch/src/CoarseSpaces/FROSch_CoarseSpace_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/CoarseSpaces/FROSch_CoarseSpace_def.hpp
@@ -121,7 +121,7 @@ namespace FROSch {
         
         LO iD;
         SC valueTmp;
-        LOVec indices;
+        GOVec indices;
         SCVec values;
 
         for (UN i=0; i<AssembledBasis_->getLocalLength(); i++) {
@@ -130,14 +130,14 @@ namespace FROSch {
             for (UN j=0; j<AssembledBasis_->getNumVectors(); j++) {
                 valueTmp=AssembledBasis_->getData(j)[i];
                 if (fabs(valueTmp)>treshold) {
-                    indices.push_back(j);
+                    indices.push_back( AssembledBasisMap_->getGlobalElement(j) );
                     values.push_back(valueTmp);
                 }
             }
             iD = rowMap->getLocalElement(repeatedMap->getGlobalElement(i));
             
             if (iD!=-1) {
-                GlobalBasisMatrix_->insertLocalValues(iD,indices(),values());
+                GlobalBasisMatrix_->insertGlobalValues( repeatedMap->getGlobalElement(i) ,indices(),values());
             }
         }
         GlobalBasisMatrix_->fillComplete(AssembledBasisMap_,rowMap);

--- a/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_GDSWCoarseOperator_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_GDSWCoarseOperator_def.hpp
@@ -390,13 +390,13 @@ namespace FROSch {
                     straightEdges = DDInterface_->getStraightEdges();
                     straightEdges->buildEntityMap(nodesMap);
                     
-                    if (useShortEdgeTranslations) {
+                    if (useStraightEdgeTranslations) {
                         MultiVectorPtrVecPtr translations = this->computeTranslations(blockId,straightEdges);
                         for (UN i=0; i<translations.size(); i++) {
                             this->InterfaceCoarseSpaces_[blockId]->addSubspace(straightEdges->getEntityMap(),translations[i]);
                         }
                     }
-                    if (useShortEdgeRotations) {
+                    if (useStraightEdgeRotations) {
                         MultiVectorPtrVecPtr rotations = this->computeRotations(blockId,dimension,nodeList,straightEdges);
                         for (UN i=0; i<rotations.size(); i++) {
                             this->InterfaceCoarseSpaces_[blockId]->addSubspace(straightEdges->getEntityMap(),rotations[i]);
@@ -408,13 +408,13 @@ namespace FROSch {
                     edges = DDInterface_->getEdges();
                     edges->buildEntityMap(nodesMap);
                     
-                    if (useShortEdgeTranslations) {
+                    if (useEdgeTranslations) {
                         MultiVectorPtrVecPtr translations = this->computeTranslations(blockId,edges);
                         for (UN i=0; i<translations.size(); i++) {
                             this->InterfaceCoarseSpaces_[blockId]->addSubspace(edges->getEntityMap(),translations[i]);
                         }
                     }
-                    if (useShortEdgeRotations) {
+                    if (useEdgeRotations) {
                         MultiVectorPtrVecPtr rotations = this->computeRotations(blockId,dimension,nodeList,edges);
                         for (UN i=0; i<rotations.size(); i++) {
                             this->InterfaceCoarseSpaces_[blockId]->addSubspace(edges->getEntityMap(),rotations[i]);
@@ -426,13 +426,13 @@ namespace FROSch {
                     faces = DDInterface_->getFaces();
                     faces->buildEntityMap(nodesMap);
                     
-                    if (useShortEdgeTranslations) {
+                    if (useFaceTranslations) {
                         MultiVectorPtrVecPtr translations = this->computeTranslations(blockId,faces);
                         for (UN i=0; i<translations.size(); i++) {
                             this->InterfaceCoarseSpaces_[blockId]->addSubspace(faces->getEntityMap(),translations[i]);
                         }
                     }
-                    if (useShortEdgeRotations) {
+                    if (useFaceRotations) {
                         MultiVectorPtrVecPtr rotations = this->computeRotations(blockId,dimension,nodeList,faces);
                         for (UN i=0; i<rotations.size(); i++) {
                             this->InterfaceCoarseSpaces_[blockId]->addSubspace(faces->getEntityMap(),rotations[i]);


### PR DESCRIPTION
@trilinos/shylu 

## Description
This PR changes the insert method from a local insert to a global insert for the coarse basis matrix in FROSch. Furthermore, the GDSWCoarseOperator now uses the different coarse components correctly; the correct boolean variables are used now. 

## Motivation and Context
A local insert relies on the same local ordering of `rowMap` and `repeatedMap`.
The global insert to the coarse basis matrix always inserts at the correct position. 

## How Has This Been Tested?
All tests passed. 

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.
