### PR TITLE
Extend ATDM Trilinos 'waterman' builds to support SPARC (ATDV-151)

### DIFF
--- a/cmake/std/atdm/waterman/environment.sh
+++ b/cmake/std/atdm/waterman/environment.sh
@@ -52,6 +52,7 @@ fi
 
 echo "Using waterman compiler stack $ATDM_CONFIG_COMPILER to build $ATDM_CONFIG_BUILD_TYPE code with Kokkos node type $ATDM_CONFIG_NODE_TYPE and KOKKOS_ARCH=$ATDM_CONFIG_KOKKOS_ARCH"
 
+export ATDM_CONFIG_ENABLE_SPARC_SETTINGS=ON
 export ATDM_CONFIG_USE_NINJA=ON
 
 if [[ "$ATDM_CONFIG_COMPILER" == "CUDA"* ]] && \
@@ -121,15 +122,48 @@ else
     return
 fi
 
+# CMake and ninja
+module swap cmake/3.6.2 cmake/3.12.3
+module load ninja/1.7.2
+
+# HWLOC
+
 export ATDM_CONFIG_USE_HWLOC=OFF
 
-export ATDM_CONFIG_HDF5_LIBS="-L${HDF5_ROOT}/lib;${HDF5_ROOT}/lib/libhdf5_hl.a;${HDF5_ROOT}/lib/libhdf5.a;-lz;-ldl"
-export ATDM_CONFIG_NETCDF_LIBS="-L${BOOST_ROOT}/lib;-L${NETCDF_ROOT}/lib;-L${NETCDF_ROOT}/lib;-L${PNETCDF_ROOT}/lib;-L${HDF5_ROOT}/lib;${BOOST_ROOT}/lib/libboost_program_options.a;${BOOST_ROOT}/lib/libboost_system.a;${NETCDF_ROOT}/lib/libnetcdf.a;${PNETCDF_ROOT}/lib/libpnetcdf.a;${HDF5_ROOT}/lib/libhdf5_hl.a;${HDF5_ROOT}/lib/libhdf5.a;-lz;-ldl"
+# Let's see if the TPLs loaded by devpack/20180517/openmpi/2.1.2/gcc/7.2.0/cuda/9.2.88 work for SPARC?
 
-# Use manually installed cmake and ninja to try to avoid module loading
-# problems (see TRIL-208).  NOTE: These were build for Power8 on 'white' and
-# 'ride' but they also seem to work just fine on Power9 'waterman' as well :-)
-export PATH=/ascldap/users/rabartl/install/white-ride/cmake-3.11.2/bin:/ascldap/users/rabartl/install/white-ride/ninja-1.8.2/bin:$PATH
+export ATDM_CONFIG_BINUTILS_LIBS="${BINUTILS_ROOT}/lib/libbfd.a;${BINUTILS_ROOT}/lib/libiberty.a"
+
+#CGNS_ROOT=/home/projects/sparc/tpls/waterman/cgns-develop/waterman-gpu_gcc-7.2.0_cuda-9.2.88_openmpi-2.1.2
+#HDF5_ROOT=/home/projects/sparc/tpls/waterman/hdf5-1.8.20/waterman-gpu_gcc-7.2.0_cuda-9.2.88_openmpi-2.1.2
+#METIS_ROOT=/home/projects/sparc/tpls/waterman/parmetis-4.0.3/waterman-gpu_gcc-7.2.0_cuda-9.2.88_openmpi-2.1.2
+#NETCDF_ROOT=/home/projects/sparc/tpls/waterman/netcdf-4.6.1/waterman-gpu_gcc-7.2.0_cuda-9.2.88_openmpi-2.1.2
+#PARMETIS_ROOT=/home/projects/sparc/tpls/waterman/parmetis-4.0.3/waterman-gpu_gcc-7.2.0_cuda-9.2.88_openmpi-2.1.2
+#PNETCDF_ROOT=/home/projects/sparc/tpls/waterman/pnetcdf-1.10.0/waterman-gpu_gcc-7.2.0_cuda-9.2.88_openmpi-2.1.2
+#SGM_ROOT=/home/projects/sparc/tpls/waterman/sgm-develop/waterman-gpu_gcc-7.2.0_cuda-9.2.88_openmpi-2.1.2
+#SUPERLUDIST_ROOT=/home/projects/sparc/tpls/waterman/superlu_dist-4.2/waterman-gpu_gcc-7.2.0_cuda-9.2.88_openmpi-2.1.2
+
+# HDF5 and Netcdf
+
+# NOTE: HDF5_ROOT and NETCDF_ROOT should already be set in env from above
+# module loads!
+
+# However, set the direct libs for HDF5 and NetCDF in case we use that option
+# for building (see env var ATDM_CONFIG_USE_SPARC_TPL_FIND_SETTINGS).
+
+export ATDM_CONFIG_HDF5_LIBS="-L${HDF5_ROOT}/lib;${HDF5_ROOT}/lib/libhdf5_hl.a;${HDF5_ROOT}/lib/libhdf5.a;-lz;-ldl"
+
+export ATDM_CONFIG_NETCDF_LIBS="-L${BOOST_ROOT}/lib;-L${NETCDF_ROOT}/lib;-L${NETCDF_ROOT}/lib;-L${SEMS_PNETCDF_ROOT}/lib;-L${HDF5_ROOT}/lib;${BOOST_ROOT}/lib/libboost_program_options.a;${BOOST_ROOT}/lib/libboost_system.a;${NETCDF_ROOT}/lib/libnetcdf.a;${PNETCDF_ROOT}/lib/libpnetcdf.a;${HDF5_ROOT}/lib/libhdf5_hl.a;${HDF5_ROOT}/lib/libhdf5.a;-lz;-ldl;-lcurl"
+
+#export ATDM_CONFIG_HDF5_LIBS="-L${HDF5_ROOT}/lib;${HDF5_ROOT}/lib/libhdf5_hl.a;${HDF5_ROOT}/lib/libhdf5.a;-lz;-ldl"
+#export ATDM_CONFIG_NETCDF_LIBS="-L${BOOST_ROOT}/lib;-L${NETCDF_ROOT}/lib;-L${NETCDF_ROOT}/lib;-L${PNETCDF_ROOT}/lib;-L${HDF5_ROOT}/lib;${BOOST_ROOT}/lib/libboost_program_options.a;${BOOST_ROOT}/lib/libboost_system.a;${NETCDF_ROOT}/lib/libnetcdf.a;${PNETCDF_ROOT}/lib/libpnetcdf.a;${HDF5_ROOT}/lib/libhdf5_hl.a;${HDF5_ROOT}/lib/libhdf5.a;-lz;-ldl"
+
+# SuperLUDist
+
+if [[ "${ATDM_CONFIG_SUPERLUDIST_INCLUDE_DIRS}" == "" ]] ; then
+  export ATDM_CONFIG_SUPERLUDIST_INCLUDE_DIRS=${SUPERLUDIST_ROOT}/include
+  export ATDM_CONFIG_SUPERLUDIST_LIBS="${SUPERLUDIST_ROOT}/lib/libsuperlu_dist.a;${METIS_ROOT}/lib/libmetis.a"
+fi
 
 # Set MPI wrappers
 export MPICC=`which mpicc`

--- a/cmake/std/atdm/waterman/tweaks/ALL_COMMON_TWEAKS.cmake
+++ b/cmake/std/atdm/waterman/tweaks/ALL_COMMON_TWEAKS.cmake
@@ -1,0 +1,4 @@
+
+# Disable known failures for SPARC Trilinos configuration (#3632)
+ATDM_SET_ENABLE(PanzerAdaptersIOSS_tIOSSConnManager2_MPI_2_DISABLE ON)
+ATDM_SET_ENABLE(PanzerAdaptersIOSS_tIOSSConnManager3_MPI_3_DISABLE ON)

--- a/cmake/std/atdm/waterman/tweaks/CUDA-9.2_RELEASE-DEBUG_CUDA_POWER9_VOLTA70.cmake
+++ b/cmake/std/atdm/waterman/tweaks/CUDA-9.2_RELEASE-DEBUG_CUDA_POWER9_VOLTA70.cmake
@@ -1,7 +1,7 @@
 INCLUDE("${CMAKE_CURRENT_LIST_DIR}/CUDA_COMMON_TWEAKS.cmake")
 INCLUDE("${CMAKE_CURRENT_LIST_DIR}/ALL_COMMON_TWEAKS.cmake")
 
-#Tests regularaly failing see issue #3939
+# Tests regularaly failing see issue #3939
 ATDM_SET_ENABLE(PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-1_DISABLE ON)
 ATDM_SET_ENABLE(PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-3_DISABLE ON)
 ATDM_SET_ENABLE(PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-4_DISABLE ON)

--- a/cmake/std/atdm/waterman/tweaks/CUDA_COMMON_TWEAKS.cmake
+++ b/cmake/std/atdm/waterman/tweaks/CUDA_COMMON_TWEAKS.cmake
@@ -1,3 +1,5 @@
 # This test fails consistently (#2751)
 ATDM_SET_ENABLE(PanzerAdaptersSTK_MixedPoissonExample-ConvTest-Hex-Order-3_DISABLE ON)
 
+# Disable known falure for ROL CUDA builds (#3543)
+ATDM_SET_ENABLE(ROL_test_elementwise_TpetraMultiVector_MPI_4_DISABLE ON)


### PR DESCRIPTION
## Description

This PR branch extends the ATDM Trilinos builds on 'waterman' to add the extra TPLs and Trilinos packages needed by SPARC.  We need to be supporting SPARC on 'waterman' and extend the SPARC Trilinos Integration testing to include a CUDA build on 'waterman' (see [ATDV-151](https://sems-atlassian-srn.sandia.gov/browse/ATDV-151)).

## How this was tested

I tested this on 'waterman' with:

```
$ cd /home/rabartl/Trilinos.base/BUILDS/WATERMAN/CTEST_S/

$ ./ctest-s-local-test-driver.sh cuda-9.2-release-debug

 *** 
 *** ./ctest-s-local-test-driver.sh cuda-9.2-release-debug
 ***

ATDM_TRILINOS_DIR = '/home/rabartl/Trilinos.base/Trilinos'

Load some env to get python, cmake, etc ...

Hostname 'waterman11' matches known ATDM host 'waterman' and system 'waterman'
 Setting compiler and build options for buld name 'default'
 Using waterman compiler stack GNU to build DEBUG code with Kokkos node type SERIAL and KOKKOS_ARCH=Power9

Running builds:
 cuda-9.2-release-debug

Running Jenkins driver Trilinos-atdm-waterman-cuda-9.2-release-debug.sh ...

real 157m31.812s
 user 0m1.116s
 sys 0m0.896s
```

This posted to CDash at:

* https://testing.sandia.gov/cdash-dev-view/index.php?project=Trilinos&parentid=4862704

Wow, that passed all 2199 tests! Even the test `MueLu_FixedMatrixPattern-Tpetra_MPI`_4 is working as that failed in a prior trial (see [this comment in ATDV-151](https://sems-atlassian-srn.sandia.gov/browse/ATDV-151?focusedCommentId=33153&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-33153)). 

I also tested this against SPARC 'master' and it worked (see [this comment in ATDV-151](https://sems-atlassian-srn.sandia.gov/browse/ATDV-151?focusedCommentId=33336&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-33336))

I did not test the other builds but if the build `waterman-cuda-9.2-release-debug` works, then all of the other builds should likely work as well.
