### PR TITLE
Tpetra: Fix #4861 (make BlockMultiVector implement "new" DistObject interface)

### DIFF
--- a/packages/ifpack2/example/RelaxationWithEquilibration.cpp
+++ b/packages/ifpack2/example/RelaxationWithEquilibration.cpp
@@ -1325,10 +1325,7 @@ elementWiseMultiplyMultiVector (MultiVectorType& X,
                                       typename ScalingFactorsViewType::non_const_value_type
                                     >::value)
 {
-  using device_type = typename MultiVectorType::device_type;
-  using dev_memory_space = typename device_type::memory_space;
   using index_type = typename MultiVectorType::local_ordinal_type;
-
   const index_type lclNumRows = static_cast<index_type> (X.getLocalLength ());
 
   if (X.need_sync_device ()) {
@@ -1531,10 +1528,7 @@ elementWiseDivideMultiVector (MultiVectorType& X,
                                     typename ScalingFactorsViewType::non_const_value_type
                                   >::value)
 {
-  using device_type = typename MultiVectorType::device_type;
-  using dev_memory_space = typename device_type::memory_space;
   using index_type = typename MultiVectorType::local_ordinal_type;
-
   const index_type lclNumRows = static_cast<index_type> (X.getLocalLength ());
 
   if (X.need_sync_device ()) {

--- a/packages/ifpack2/src/Ifpack2_Experimental_RBILUK_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Experimental_RBILUK_def.hpp
@@ -43,20 +43,20 @@
 #ifndef IFPACK2_EXPERIMENTAL_CRSRBILUK_DEF_HPP
 #define IFPACK2_EXPERIMENTAL_CRSRBILUK_DEF_HPP
 
-#include <Tpetra_Experimental_BlockMultiVector.hpp>
-#include<Ifpack2_OverlappingRowMatrix.hpp>
-#include<Ifpack2_LocalFilter.hpp>
-#include <Ifpack2_Experimental_RBILUK.hpp>
-#include <Ifpack2_Utilities.hpp>
-#include <Ifpack2_RILUK.hpp>
+#include "Tpetra_Experimental_BlockMultiVector.hpp"
+#include "Tpetra_Experimental_BlockView.hpp"
+#include "Ifpack2_OverlappingRowMatrix.hpp"
+#include "Ifpack2_LocalFilter.hpp"
+#include "Ifpack2_Utilities.hpp"
+#include "Ifpack2_RILUK.hpp"
 
 //#define IFPACK2_RBILUK_INITIAL
 #define IFPACK2_RBILUK_INITIAL_NOKK
 
 #ifndef IFPACK2_RBILUK_INITIAL_NOKK
-#include <KokkosBatched_Gemm_Decl.hpp>
-#include <KokkosBatched_Gemm_Serial_Impl.hpp>
-#include <KokkosBatched_Util.hpp>
+#include "KokkosBatched_Gemm_Decl.hpp"
+#include "KokkosBatched_Gemm_Serial_Impl.hpp"
+#include "KokkosBatched_Util.hpp"
 #endif
 
 namespace Ifpack2 {

--- a/packages/ifpack2/src/Ifpack2_Relaxation_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Relaxation_def.hpp
@@ -47,19 +47,12 @@
 #include "Teuchos_TimeMonitor.hpp"
 #include "Tpetra_CrsMatrix.hpp"
 #include "Tpetra_Experimental_BlockCrsMatrix.hpp"
+#include "Tpetra_Experimental_BlockView.hpp"
 #include "Ifpack2_Utilities.hpp"
-#include "Ifpack2_Relaxation_decl.hpp"
 #include "MatrixMarket_Tpetra.hpp"
 #include <cstdlib>
 #include <sstream>
 #include "KokkosSparse_gauss_seidel.hpp"
-
-
-// mfh 28 Mar 2013: Uncomment out these three lines to compute
-// statistics on diagonal entries in compute().
-// #ifndef IFPACK2_RELAXATION_COMPUTE_DIAGONAL_STATS
-// #  define IFPACK2_RELAXATION_COMPUTE_DIAGONAL_STATS 1
-// #endif // IFPACK2_RELAXATION_COMPUTE_DIAGONAL_STATS
 
 namespace {
   // Validate that a given int is nonnegative.
@@ -154,7 +147,7 @@ template<class MatrixType>
 void Relaxation<MatrixType>::updateCachedMultiVector(const Teuchos::RCP<const Tpetra::Map<local_ordinal_type,global_ordinal_type,node_type> > & map, size_t numVecs) const{
   // Allocate a multivector if the cached one isn't perfect
   // Note: We check for map pointer equality here since it is much cheaper than isSameAs()
-  if(cachedMV_.is_null() || &*map != &*cachedMV_->getMap() || cachedMV_->getNumVectors() !=numVecs) 
+  if(cachedMV_.is_null() || &*map != &*cachedMV_->getMap() || cachedMV_->getNumVectors() !=numVecs)
     cachedMV_ = Teuchos::rcp(new Tpetra::MultiVector<scalar_type,local_ordinal_type,global_ordinal_type,node_type>(map, numVecs, false));
 }
 
@@ -755,7 +748,7 @@ void Relaxation<MatrixType>::computeBlockCrs ()
   using Teuchos::reduceAll;
   typedef local_ordinal_type LO;
   typedef typename node_type::device_type device_type;
-  
+
   const std::string timerName ("Ifpack2::Relaxation::computeBlockCrs");
   Teuchos::RCP<Teuchos::Time> timer = Teuchos::TimeMonitor::lookupCounter (timerName);
   if (timer.is_null ()) {

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestRBILUK.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestRBILUK.cpp
@@ -60,6 +60,7 @@
 #include "Tpetra_Core.hpp"
 #include "Tpetra_Experimental_BlockCrsMatrix.hpp"
 #include "Tpetra_Experimental_BlockMultiVector.hpp"
+#include "Tpetra_Experimental_BlockView.hpp"
 #include "Tpetra_MatrixIO.hpp"
 #include "Tpetra_RowMatrix.hpp"
 

--- a/packages/tpetra/core/example/advanced/Benchmarks/blockCrsMatrixMatVec.cpp
+++ b/packages/tpetra/core/example/advanced/Benchmarks/blockCrsMatrixMatVec.cpp
@@ -49,6 +49,7 @@
 
 #include "Tpetra_Experimental_BlockCrsMatrix.hpp"
 #include "Tpetra_Experimental_BlockCrsMatrix_Helpers.hpp"
+#include "Tpetra_Experimental_BlockView.hpp"
 #include "Tpetra_CrsGraph.hpp"
 #include "Tpetra_CrsMatrix.hpp"
 #include "Tpetra_Core.hpp"
@@ -621,14 +622,14 @@ main (int argc, char* argv[])
       setCmdLineOpts (opts, clp);
       int result = parseCmdLineOpts (clp, argc, argv);
       if (result == 1) { // help printed
-	return EXIT_SUCCESS;
+        return EXIT_SUCCESS;
       }
       else if (result == -1) { // parse error
-	return EXIT_FAILURE;
+        return EXIT_FAILURE;
       }
       result = checkCmdLineOpts (out, *comm, opts);
       if (result != 0) {
-	return EXIT_FAILURE;
+        return EXIT_FAILURE;
       }
     }
 
@@ -657,12 +658,12 @@ main (int argc, char* argv[])
     }
     else {
       auto timer =
-	TimeMonitor::getNewCounter ("Tpetra BlockCrsMatrix apply (mat-vec)");
+        TimeMonitor::getNewCounter ("Tpetra BlockCrsMatrix apply (mat-vec)");
       {
-	TimeMonitor timeMon (*timer);
-	for (int trial = 0; trial < opts.numTrials; ++trial) {
-	  A->apply (X, Y);
-	}
+        TimeMonitor timeMon (*timer);
+        for (int trial = 0; trial < opts.numTrials; ++trial) {
+          A->apply (X, Y);
+        }
       }
     }
 
@@ -670,7 +671,7 @@ main (int argc, char* argv[])
       TimeMonitor::report (comm.ptr (), out);
     }
   }
-  
+
   if (success) {
     return EXIT_SUCCESS;
   }

--- a/packages/tpetra/core/src/CMakeLists.txt
+++ b/packages/tpetra/core/src/CMakeLists.txt
@@ -333,6 +333,22 @@ IF (${PACKAGE_NAME}_ENABLE_EXPLICIT_INSTANTIATION)
   TPETRA_PROCESS_ALL_SLGN_TEMPLATES(BLOCKCRSMATRIX_OUTPUT_FILES "Tpetra_ETI_SC_LO_GO_NT.tmpl" "Experimental_BlockCrsMatrix" "EXPERIMENTAL_BLOCKCRSMATRIX" "${TpetraCore_ETI_SCALARS_NO_ORDS}" "${TpetraCore_ETI_LORDS}" "${TpetraCore_ETI_GORDS}" "${TpetraCore_ETI_NODES}" FALSE)
   LIST(APPEND SOURCES ${BLOCKCRSMATRIX_OUTPUT_FILES})
 
+  # Generate ETI .cpp files for Tpetra::Experimental::BlockMultiVector.
+  TPETRA_PROCESS_ALL_SLGN_TEMPLATES(BLOCKMULTIVECTOR_OUTPUT_FILES "Tpetra_ETI_SC_LO_GO_NT.tmpl" "Experimental_BlockMultiVector" "EXPERIMENTAL_BLOCKMULTIVECTOR" "${TpetraCore_ETI_SCALARS_NO_ORDS}" "${TpetraCore_ETI_LORDS}" "${TpetraCore_ETI_GORDS}" "${TpetraCore_ETI_NODES}" FALSE)
+  LIST(APPEND SOURCES ${BLOCKMULTIVECTOR_OUTPUT_FILES})
+
+  # Don't add ETI for packBlockMultiVector and unpackBlockMultiVector
+  # quite just yet.  I want to make sure that the ETI we just added
+  # for BlockMultiVector and BlockVector works correctly.
+
+  # Generate ETI .cpp files for Tpetra::Details::packBlockMultiVector.
+  #TPETRA_PROCESS_ALL_SLGN_TEMPLATES(PACKBLOCKMULTIVECTOR_OUTPUT_FILES "Tpetra_ETI_SC_LO_GO_NT.tmpl" "Details_packBlockMultiVector" "DETAILS_PACKBLOCKMULTIVECTOR" "${TpetraCore_ETI_SCALARS_NO_ORDS}" "${TpetraCore_ETI_LORDS}" "${TpetraCore_ETI_GORDS}" "${TpetraCore_ETI_NODES}" FALSE)
+  #LIST(APPEND SOURCES ${PACKBLOCKMULTIVECTOR_OUTPUT_FILES})
+
+  # Generate ETI .cpp files for Tpetra::Details::unpackBlockMultiVector.
+  #TPETRA_PROCESS_ALL_SLGN_TEMPLATES(UNPACKBLOCKMULTIVECTOR_OUTPUT_FILES "Tpetra_ETI_SC_LO_GO_NT.tmpl" "Details_unpackBlockMultiVector" "DETAILS_UNPACKBLOCKMULTIVECTOR" "${TpetraCore_ETI_SCALARS_NO_ORDS}" "${TpetraCore_ETI_LORDS}" "${TpetraCore_ETI_GORDS}" "${TpetraCore_ETI_NODES}" FALSE)
+  #LIST(APPEND SOURCES ${UNPACKBLOCKMULTIVECTOR_OUTPUT_FILES})
+
   # Generate ETI .cpp files for Tpetra::Experimental::BlockCrsMatrix helpers.
   TPETRA_PROCESS_ALL_SLGN_TEMPLATES(BLOCKCRSMATRIX_HELPER_OUTPUT_FILES "Tpetra_ETI_SC_LO_GO_NT.tmpl"
   "Experimental_BlockCrsMatrix_Helpers" "EXPERIMENTAL_BLOCKCRSMATRIX_HELPERS" "${TpetraCore_ETI_SCALARS_NO_ORDS}" "${TpetraCore_ETI_LORDS}" "${TpetraCore_ETI_GORDS}" "${TpetraCore_ETI_NODES}" FALSE)

--- a/packages/tpetra/core/src/CMakeLists.txt
+++ b/packages/tpetra/core/src/CMakeLists.txt
@@ -337,18 +337,6 @@ IF (${PACKAGE_NAME}_ENABLE_EXPLICIT_INSTANTIATION)
   TPETRA_PROCESS_ALL_SLGN_TEMPLATES(BLOCKMULTIVECTOR_OUTPUT_FILES "Tpetra_ETI_SC_LO_GO_NT.tmpl" "Experimental_BlockMultiVector" "EXPERIMENTAL_BLOCKMULTIVECTOR" "${TpetraCore_ETI_SCALARS_NO_ORDS}" "${TpetraCore_ETI_LORDS}" "${TpetraCore_ETI_GORDS}" "${TpetraCore_ETI_NODES}" FALSE)
   LIST(APPEND SOURCES ${BLOCKMULTIVECTOR_OUTPUT_FILES})
 
-  # Don't add ETI for packBlockMultiVector and unpackBlockMultiVector
-  # quite just yet.  I want to make sure that the ETI we just added
-  # for BlockMultiVector and BlockVector works correctly.
-
-  # Generate ETI .cpp files for Tpetra::Details::packBlockMultiVector.
-  #TPETRA_PROCESS_ALL_SLGN_TEMPLATES(PACKBLOCKMULTIVECTOR_OUTPUT_FILES "Tpetra_ETI_SC_LO_GO_NT.tmpl" "Details_packBlockMultiVector" "DETAILS_PACKBLOCKMULTIVECTOR" "${TpetraCore_ETI_SCALARS_NO_ORDS}" "${TpetraCore_ETI_LORDS}" "${TpetraCore_ETI_GORDS}" "${TpetraCore_ETI_NODES}" FALSE)
-  #LIST(APPEND SOURCES ${PACKBLOCKMULTIVECTOR_OUTPUT_FILES})
-
-  # Generate ETI .cpp files for Tpetra::Details::unpackBlockMultiVector.
-  #TPETRA_PROCESS_ALL_SLGN_TEMPLATES(UNPACKBLOCKMULTIVECTOR_OUTPUT_FILES "Tpetra_ETI_SC_LO_GO_NT.tmpl" "Details_unpackBlockMultiVector" "DETAILS_UNPACKBLOCKMULTIVECTOR" "${TpetraCore_ETI_SCALARS_NO_ORDS}" "${TpetraCore_ETI_LORDS}" "${TpetraCore_ETI_GORDS}" "${TpetraCore_ETI_NODES}" FALSE)
-  #LIST(APPEND SOURCES ${UNPACKBLOCKMULTIVECTOR_OUTPUT_FILES})
-
   # Generate ETI .cpp files for Tpetra::Experimental::BlockCrsMatrix helpers.
   TPETRA_PROCESS_ALL_SLGN_TEMPLATES(BLOCKCRSMATRIX_HELPER_OUTPUT_FILES "Tpetra_ETI_SC_LO_GO_NT.tmpl"
   "Experimental_BlockCrsMatrix_Helpers" "EXPERIMENTAL_BLOCKCRSMATRIX_HELPERS" "${TpetraCore_ETI_SCALARS_NO_ORDS}" "${TpetraCore_ETI_LORDS}" "${TpetraCore_ETI_GORDS}" "${TpetraCore_ETI_NODES}" FALSE)

--- a/packages/tpetra/core/src/Tpetra_Experimental_BlockCrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Experimental_BlockCrsMatrix_decl.hpp
@@ -47,7 +47,7 @@
 
 #include "Tpetra_CrsGraph.hpp"
 #include "Tpetra_RowMatrix.hpp"
-#include "Tpetra_Experimental_BlockMultiVector.hpp"
+#include "Tpetra_Experimental_BlockMultiVector_decl.hpp"
 #include "Tpetra_CrsMatrix_decl.hpp"
 
 namespace Tpetra {

--- a/packages/tpetra/core/src/Tpetra_Experimental_BlockCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Experimental_BlockCrsMatrix_def.hpp
@@ -48,6 +48,8 @@
 #include "Tpetra_Details_Behavior.hpp"
 #include "Tpetra_Details_PackTraits.hpp"
 #include "Tpetra_Details_Profiling.hpp"
+#include "Tpetra_Experimental_BlockMultiVector.hpp"
+#include "Tpetra_Experimental_BlockView.hpp"
 
 #include "Teuchos_TimeMonitor.hpp"
 #ifdef HAVE_TPETRA_DEBUG

--- a/packages/tpetra/core/src/Tpetra_Experimental_BlockMultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Experimental_BlockMultiVector_decl.hpp
@@ -45,8 +45,8 @@
 #include "Tpetra_Experimental_BlockMultiVector_fwd.hpp"
 #include "Tpetra_Experimental_BlockCrsMatrix_fwd.hpp"
 #include "Tpetra_MultiVector.hpp"
-#include "Tpetra_Experimental_BlockView.hpp"
-#include "Teuchos_OrdinalTraits.hpp"
+#include <memory>
+#include <utility>
 
 namespace Tpetra {
 namespace Experimental {
@@ -147,38 +147,39 @@ class BlockMultiVector :
     public Tpetra::DistObject<Scalar, LO, GO, Node>
 {
 private:
-  typedef Tpetra::DistObject<Scalar, LO, GO, Node> dist_object_type;
-  typedef Teuchos::ScalarTraits<Scalar> STS;
-
-protected:
-  typedef Scalar packet_type;
+  using dist_object_type = Tpetra::DistObject<Scalar, LO, GO, Node>;
+  using STS = Teuchos::ScalarTraits<Scalar>;
+  using packet_type = typename dist_object_type::packet_type;
 
 public:
   //! \name Typedefs to facilitate template metaprogramming.
   //@{
 
   //! The specialization of Tpetra::Map that this class uses.
-  typedef Tpetra::Map<LO, GO, Node> map_type;
+  using map_type = Tpetra::Map<LO, GO, Node>;
   //! The specialization of Tpetra::MultiVector that this class uses.
-  typedef Tpetra::MultiVector<Scalar, LO, GO, Node> mv_type;
+  using mv_type = Tpetra::MultiVector<Scalar, LO, GO, Node>;
 
-  //! The type of entries in the matrix.
-  typedef Scalar scalar_type;
-  /// \brief The implementation type of entries in the matrix.
+  //! The type of entries in the object.
+  using scalar_type = Scalar;
+  /// \brief The implementation type of entries in the object.
   ///
   /// Letting scalar_type and impl_scalar_type differ addresses
   /// Tpetra's work-around to deal with missing device macros and
   /// volatile overloads in types like std::complex<T>.
-  typedef typename mv_type::impl_scalar_type impl_scalar_type;
+  using impl_scalar_type = typename mv_type::impl_scalar_type;
   //! The type of local indices.
-  typedef LO local_ordinal_type;
+  using local_ordinal_type = LO;
   //! The type of global indices.
-  typedef GO global_ordinal_type;
+  using global_ordinal_type = GO;
   //! The Kokkos Device type.
-  typedef typename Node::device_type device_type;
+  using device_type = typename mv_type::device_type;
 
-  //! The Kokkos Node type.
-  typedef Node node_type;
+  //! The Kokkos Node type; a legacy thing that will go away at some point.
+  using node_type = Node;
+
+  //! Kokkos::Device specialization used for communication buffers.
+  using buffer_device_type = typename dist_object_type::buffer_device_type;
 
   /// \brief "Block view" of all degrees of freedom at a mesh point,
   ///   for a single column of the MultiVector.
@@ -602,27 +603,38 @@ protected:
 
   virtual bool checkSizes (const Tpetra::SrcDistObject& source);
 
-  virtual void
-  copyAndPermute (const Tpetra::SrcDistObject& source,
-                  const size_t numSameIDs,
-                  const Teuchos::ArrayView<const LO>& permuteToLIDs,
-                  const Teuchos::ArrayView<const LO>& permuteFromLIDs);
+  virtual bool useNewInterface ();
 
   virtual void
-  packAndPrepare (const Tpetra::SrcDistObject& source,
-                  const Teuchos::ArrayView<const LO>& exportLIDs,
-                  Teuchos::Array<impl_scalar_type>& exports,
-                  const Teuchos::ArrayView<size_t>& numPacketsPerLID,
-                  size_t& constantNumPackets,
-                  Tpetra::Distributor& distor);
+  copyAndPermuteNew (const SrcDistObject& source,
+                     const size_t numSameIDs,
+                     const Kokkos::DualView<const local_ordinal_type*,
+                       buffer_device_type>& permuteToLIDs,
+                     const Kokkos::DualView<const local_ordinal_type*,
+                       buffer_device_type>& permuteFromLIDs);
 
   virtual void
-  unpackAndCombine (const Teuchos::ArrayView<const LO> &importLIDs,
-                    const Teuchos::ArrayView<const impl_scalar_type> &imports,
-                    const Teuchos::ArrayView<size_t> &numPacketsPerLID,
-                    const size_t constantNumPackets,
-                    Tpetra::Distributor& distor,
-                    Tpetra::CombineMode CM);
+  packAndPrepareNew (const SrcDistObject& source,
+                     const Kokkos::DualView<const local_ordinal_type*,
+                       buffer_device_type>& exportLIDs,
+                     Kokkos::DualView<packet_type*,
+                       buffer_device_type>& exports,
+                     Kokkos::DualView<size_t*,
+                       buffer_device_type> numPacketsPerLID,
+                     size_t& constantNumPackets,
+                     Distributor& distor);
+
+  virtual void
+  unpackAndCombineNew (const Kokkos::DualView<const local_ordinal_type*,
+                         buffer_device_type>& importLIDs,
+                       Kokkos::DualView<packet_type*,
+                         buffer_device_type> imports,
+                       Kokkos::DualView<size_t*,
+                         buffer_device_type> numPacketsPerLID,
+                       const size_t constantNumPackets,
+                       Distributor& distor,
+                       const CombineMode combineMode);
+
   //@}
 
 protected:
@@ -643,10 +655,7 @@ protected:
 
   /// \brief True if and only if \c meshLocalIndex is a valid local
   ///   index in the mesh Map.
-  bool isValidLocalMeshIndex (const LO meshLocalIndex) const {
-    return meshLocalIndex != Teuchos::OrdinalTraits<LO>::invalid () &&
-      meshMap_.isNodeLocalElement (meshLocalIndex);
-  }
+  bool isValidLocalMeshIndex (const LO meshLocalIndex) const;
 
 private:
   /// \brief Mesh Map given to constructor.
@@ -693,6 +702,70 @@ private:
 
   static Teuchos::RCP<const BlockMultiVector<Scalar, LO, GO, Node> >
   getBlockMultiVectorFromSrcDistObject (const Tpetra::SrcDistObject& src);
+
+  /// \brief Implementation of copyAndPermuteNew.
+  ///
+  /// \tparam LO The type of local indices.
+  /// \tparam GO The type of global indices.
+  /// \tparam NT The Node type.
+  ///
+  /// \param tgt [in] "Target" object of an Export or Import operation
+  ///   on a BlockMultiVector.
+  /// \param src [in] "Source" object of an Export or Import operation
+  ///   on a BlockMultiVector.
+  /// \param numSameIDs [in] See DistObject::copyAndPermuteNew.
+  /// \param permuteToLIDs [in] See DistObject::copyAndPermuteNew.
+  /// \param permuteFromLIDs [in] See DistObject::copyAndPermuteNew.
+  ///
+  /// \return (Error code, pointer to error message).  If no error,
+  ///   then error code is zero and error message pointer is null.
+  std::pair<int, std::unique_ptr<std::string>>
+  copyAndPermuteNewImpl
+    (const BlockMultiVector<Scalar, LO, GO, Node>& src,
+     const size_t numSameIDs,
+     const Kokkos::DualView<
+       const local_ordinal_type*,
+       buffer_device_type
+     >& permuteToLIDs,
+     const Kokkos::DualView<
+       const local_ordinal_type*,
+       buffer_device_type
+     >& permuteFromLIDs);
+
+  std::pair<int, std::unique_ptr<std::string>>
+  packAndPrepareNewImpl
+    (const Kokkos::DualView<
+       const local_ordinal_type*,
+       buffer_device_type
+     >& exportLIDs,
+     Kokkos::DualView<
+       impl_scalar_type*,
+       buffer_device_type
+     >& exports,
+     Kokkos::DualView<
+       size_t*,
+       buffer_device_type
+     > /* numPacketsPerLID */,
+     size_t& constantNumPackets,
+     Distributor& /* distor */ ) const;
+
+  std::pair<int, std::unique_ptr<std::string>>
+  unpackAndCombineNewImpl
+    (const Kokkos::DualView<
+       const local_ordinal_type*,
+       buffer_device_type
+     >& importLIDs,
+     Kokkos::DualView<
+       impl_scalar_type*,
+       buffer_device_type
+     > imports,
+     Kokkos::DualView<
+       size_t*,
+       buffer_device_type
+     > numPacketsPerLID,
+     const size_t constantNumPackets,
+     Distributor& distor,
+     const CombineMode combineMode);
 };
 
 } // namespace Experimental

--- a/packages/tpetra/core/src/Tpetra_Experimental_BlockMultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Experimental_BlockMultiVector_def.hpp
@@ -42,7 +42,9 @@
 #ifndef TPETRA_EXPERIMENTAL_BLOCKMULTIVECTOR_DEF_HPP
 #define TPETRA_EXPERIMENTAL_BLOCKMULTIVECTOR_DEF_HPP
 
-#include "Tpetra_Experimental_BlockMultiVector_decl.hpp"
+#include "Tpetra_Details_Behavior.hpp"
+#include "Tpetra_Experimental_BlockView.hpp"
+#include "Teuchos_OrdinalTraits.hpp"
 
 namespace { // anonymous
 
@@ -484,155 +486,402 @@ checkSizes (const Tpetra::SrcDistObject& src)
 }
 
 template<class Scalar, class LO, class GO, class Node>
-void BlockMultiVector<Scalar, LO, GO, Node>::
-copyAndPermute (const Tpetra::SrcDistObject& src,
-                const size_t numSameIDs,
-                const Teuchos::ArrayView<const LO>& permuteToLIDs,
-                const Teuchos::ArrayView<const LO>& permuteFromLIDs)
+bool BlockMultiVector<Scalar, LO, GO, Node>::
+useNewInterface ()
 {
-  const char tfecfFuncName[] = "copyAndPermute: ";
-  TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
-    permuteToLIDs.size() != permuteFromLIDs.size(), std::runtime_error,
-    "permuteToLIDs and permuteFromLIDs must have the same size."
-    << std::endl << "permuteToLIDs.size() = " << permuteToLIDs.size ()
-    << " != permuteFromLIDs.size() = " << permuteFromLIDs.size () << ".");
+  return true;
+}
 
-  typedef BlockMultiVector<Scalar, LO, GO, Node> BMV;
-  Teuchos::RCP<const BMV> srcAsBmvPtr = getBlockMultiVectorFromSrcDistObject (src);
-  TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
-    srcAsBmvPtr.is_null (), std::invalid_argument,
-    "The source of an Import or Export to a BlockMultiVector "
-    "must also be a BlockMultiVector.");
-  const BMV& srcAsBmv = *srcAsBmvPtr;
+template<class SC, class LO, class GO, class NT>
+std::pair<int, std::unique_ptr<std::string>>
+BlockMultiVector<SC, LO, GO, NT>::
+copyAndPermuteNewImpl
+  (const BlockMultiVector<SC, LO, GO, NT>& src,
+   const size_t numSameIDs,
+   const Kokkos::DualView<
+     const local_ordinal_type*,
+     buffer_device_type
+   >& permuteToLIDs,
+   const Kokkos::DualView<
+     const local_ordinal_type*,
+     buffer_device_type
+   >& permuteFromLIDs)
+{
+  using std::endl;
+  const char tfecfFuncName[] = "copyAndPermuteNewImpl: ";
+  std::unique_ptr<std::string> errMsg;
+  const bool debug = ::Tpetra::Details::Behavior::debug ("BlockMultiVector");
+  const int myRank = src.getMap ()->getComm ()->getRank ();
 
+  std::unique_ptr<std::string> prefix;
+  if (debug) {
+    std::ostringstream os;
+    os << "Proc " << myRank << ": " << tfecfFuncName;
+    prefix = std::unique_ptr<std::string> (new std::string (os.str ()));
+    os << "Start" << endl;
+    std::cerr << os.str ();
+  }
+  if (permuteToLIDs.need_sync_host () || permuteFromLIDs.need_sync_host ()) {
+    std::ostringstream os;
+    os << "Proc " << myRank << ": " << tfecfFuncName << "permuteToLIDs and/or "
+      "permuteFromLIDs need sync to host.  This should never happen.";
+    errMsg = std::unique_ptr<std::string> (new std::string (os.str ()));
+    return { -1, std::move (errMsg) };
+  }
+
+  const size_t numPermuteLIDs = static_cast<size_t> (permuteToLIDs.extent (0));
+  if (static_cast<size_t> (permuteFromLIDs.extent (0)) != numPermuteLIDs) {
+    std::ostringstream os;
+    os << "Proc " << myRank << ": " << tfecfFuncName
+       << "permuteToLIDs.extent(0) = " << numPermuteLIDs
+       << " != permuteFromLIDs.extent(0) = " << permuteFromLIDs.extent (0)
+       << ".";
+    errMsg = std::unique_ptr<std::string> (new std::string (os.str ()));
+    return { -2, std::move (errMsg) };
+  }
+
+  const size_t numVecs = static_cast<size_t> (src.getNumVectors ());
+  if (debug) {
+    std::ostringstream os;
+    os << *prefix << "Sames: numSameIDs=" << numSameIDs
+       << ", numVecs=" << numVecs << endl;
+    std::cerr << os.str ();
+  }
   // FIXME (mfh 23 Apr 2014) This implementation is sequential and
   // assumes UVM.
-
-  const LO numVecs = getNumVectors ();
-  const LO numSame = static_cast<LO> (numSameIDs);
-  for (LO j = 0; j < numVecs; ++j) {
-    for (LO lclRow = 0; lclRow < numSame; ++lclRow) {
-      deep_copy (getLocalBlock (lclRow, j), srcAsBmv.getLocalBlock (lclRow, j));
+  for (size_t j = 0; j < numVecs; ++j) {
+    for (size_t lclRow = 0; lclRow < numSameIDs; ++lclRow) {
+      deep_copy (this->getLocalBlock (lclRow, j),
+                 src.getLocalBlock (lclRow, j));
     }
   }
+
+  if (debug) {
+    std::ostringstream os;
+    os << *prefix << "Permutes: numPermuteLIDs=" << numPermuteLIDs << endl;
+    std::cerr << os.str ();
+  }
+  auto permuteToLIDs_h = permuteToLIDs.view_host ();
+  auto permuteFromLIDs_h = permuteFromLIDs.view_host ();
 
   // FIXME (mfh 20 June 2012) For an Export with duplicate GIDs on the
   // same process, this merges their values by replacement of the last
   // encountered GID, not by the specified merge rule (such as ADD).
-  const LO numPermuteLIDs = static_cast<LO> (permuteToLIDs.size ());
-  for (LO j = 0; j < numVecs; ++j) {
-    for (LO k = numSame; k < numPermuteLIDs; ++k) {
-      deep_copy (getLocalBlock (permuteToLIDs[k], j), srcAsBmv.getLocalBlock (permuteFromLIDs[k], j));
+  for (size_t j = 0; j < numVecs; ++j) {
+    for (size_t k = numSameIDs; k < numPermuteLIDs; ++k) {
+      deep_copy (this->getLocalBlock (permuteToLIDs_h[k], j),
+                 src.getLocalBlock (permuteFromLIDs_h[k], j));
     }
   }
+
+  if (debug) {
+    std::ostringstream os;
+    os << *prefix << "Done" << endl;
+    std::cerr << os.str ();
+  }
+  return { 0, std::move (errMsg) };
 }
 
 template<class Scalar, class LO, class GO, class Node>
 void BlockMultiVector<Scalar, LO, GO, Node>::
-packAndPrepare (const Tpetra::SrcDistObject& src,
-                const Teuchos::ArrayView<const LO>& exportLIDs,
-                Teuchos::Array<impl_scalar_type>& exports,
-                const Teuchos::ArrayView<size_t>& /* numPacketsPerLID */,
-                size_t& constantNumPackets,
-                Tpetra::Distributor& /* distor */)
+copyAndPermuteNew (const SrcDistObject& src,
+                   const size_t numSameIDs,
+                   const Kokkos::DualView<const local_ordinal_type*,
+                     buffer_device_type>& permuteToLIDs,
+                   const Kokkos::DualView<const local_ordinal_type*,
+                     buffer_device_type>& permuteFromLIDs)
 {
-  typedef BlockMultiVector<Scalar, LO, GO, Node> BMV;
-  typedef typename Teuchos::ArrayView<const LO>::size_type size_type;
-  const char tfecfFuncName[] = "packAndPrepare: ";
+  const char tfecfFuncName[] = "copyAndPermuteNew: ";
 
-  Teuchos::RCP<const BMV> srcAsBmvPtr = getBlockMultiVectorFromSrcDistObject (src);
-  TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
-    srcAsBmvPtr.is_null (), std::invalid_argument,
-    "The source of an Import or Export to a BlockMultiVector "
-    "must also be a BlockMultiVector.");
-  const BMV& srcAsBmv = *srcAsBmvPtr;
+  auto srcPtr = getBlockMultiVectorFromSrcDistObject (src);
+  TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+    (srcPtr.is_null (), std::invalid_argument,
+     "The source of an Import or Export to a BlockMultiVector "
+     "must also be a BlockMultiVector.");
+  const auto ret = copyAndPermuteNewImpl (*srcPtr, numSameIDs,
+                                          permuteToLIDs, permuteFromLIDs);
+  // TODO (mfh 15 Apr 2019) Instead of throwing here, which could
+  // cause an MPI parallel hang, we should record the error in *this
+  // (the target BMV instance).
+  TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+    (ret.first != 0, std::runtime_error, "copyAndPermuteNewImpl "
+     "reports an error: " << * (ret.second));
+}
 
-  const LO numVecs = getNumVectors ();
-  const LO blockSize = getBlockSize ();
+template<class SC, class LO, class GO, class NT>
+std::pair<int, std::unique_ptr<std::string>>
+BlockMultiVector<SC, LO, GO, NT>::
+packAndPrepareNewImpl
+  (const Kokkos::DualView<
+     const local_ordinal_type*,
+     buffer_device_type
+   >& exportLIDs,
+   Kokkos::DualView<
+     impl_scalar_type*,
+     buffer_device_type
+   >& exports,
+   Kokkos::DualView<
+     size_t*,
+     buffer_device_type
+   > /* numPacketsPerLID */,
+   size_t& constantNumPackets,
+   Distributor& /* distor */ ) const
+{
+  using std::endl;
+  using IST = impl_scalar_type;
+  using exports_dv_type = Kokkos::DualView<packet_type*, buffer_device_type>;
+  using host_device_type = typename exports_dv_type::t_host::device_type;
+  using dst_little_vec_type = Kokkos::View<IST*, host_device_type,
+    Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  const char tfecfFuncName[] = "packAndPrepareNewImpl: ";
+  std::unique_ptr<std::string> errMsg;
+  const bool debug = ::Tpetra::Details::Behavior::debug ("BlockMultiVector");
+
+  std::unique_ptr<std::string> prefix;
+  if (debug) {
+    const int myRank = this->getMap ()->getComm ()->getRank ();
+    std::ostringstream os;
+    os << "Proc " << myRank << ": " << tfecfFuncName;
+    prefix = std::unique_ptr<std::string> (new std::string (os.str ()));
+    os << "Start" << endl;
+    std::cerr << os.str ();
+  }
+  if (exportLIDs.need_sync_host ()) {
+    const int myRank = this->getMap ()->getComm ()->getRank ();
+    std::ostringstream os;
+    os << "Proc " << myRank << ": " << tfecfFuncName << "exportLIDs "
+      "needs sync to host.  This should never happen.";
+    errMsg = std::unique_ptr<std::string> (new std::string (os.str ()));
+    return { -1, std::move (errMsg) };
+  }
+
+  const size_t numVecs = static_cast<size_t> (this->getNumVectors ());
+  const size_t blockSize = static_cast<size_t> (this->getBlockSize ());
 
   // Number of things to pack per LID is the block size, times the
   // number of columns.  Input LIDs correspond to the mesh points, not
   // the degrees of freedom (DOFs).
-  constantNumPackets =
-    static_cast<size_t> (blockSize) * static_cast<size_t> (numVecs);
-  const size_type numMeshLIDs = exportLIDs.size ();
+  constantNumPackets = blockSize * numVecs;
+  const size_t numMeshLIDs = static_cast<size_t> (exportLIDs.extent (0));
+  const size_t requiredExportsSize = numMeshLIDs * blockSize * numVecs;
 
-  const size_type requiredExportsSize = numMeshLIDs *
-    static_cast<size_type> (blockSize) * static_cast<size_type> (numVecs);
-  exports.resize (requiredExportsSize);
+  if (static_cast<size_t> (exports.extent (0)) != requiredExportsSize) {
+    exports = exports_dv_type ();
+    exports = exports_dv_type ("exports", requiredExportsSize);
+  }
+  exports.clear_sync_state ();
+  exports.modify_host ();
+  auto exports_h = exports.view_host ();
+  auto exportLIDs_h = exportLIDs.view_host ();
 
   try {
-    size_type curExportPos = 0;
-    for (size_type meshLidIndex = 0; meshLidIndex < numMeshLIDs; ++meshLidIndex) {
-      for (LO j = 0; j < numVecs; ++j, curExportPos += blockSize) {
-        const LO meshLid = exportLIDs[meshLidIndex];
-        impl_scalar_type* const curExportPtr = &exports[curExportPos];
-        typename little_vec_type::HostMirror X_dst (curExportPtr, blockSize);
-        auto X_src = srcAsBmv.getLocalBlock (meshLid, j);
+    size_t curExportPos = 0;
+    for (size_t meshLidIndex = 0; meshLidIndex < numMeshLIDs; ++meshLidIndex) {
+      for (size_t j = 0; j < numVecs; ++j, curExportPos += blockSize) {
+        const LO meshLid = exportLIDs_h[meshLidIndex];
+
+        IST* const curExportPtr = &exports_h[curExportPos];
+        dst_little_vec_type X_dst (curExportPtr, blockSize);
+        auto X_src = this->getLocalBlock (meshLid, j);
 
         Kokkos::deep_copy (X_dst, X_src);
       }
     }
-  } catch (std::exception& e) {
-    TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
-      true, std::logic_error, "Oh no!  packAndPrepare on Process "
-      << meshMap_.getComm ()->getRank () << " raised the following exception: "
-      << e.what ());
   }
+  catch (std::exception& e) {
+    const int myRank = this->getMap ()->getComm ()->getRank ();
+    std::ostringstream os;
+    os << "Proc " << myRank << ": " << tfecfFuncName
+       << " threw an exception: " << e.what ();
+    errMsg = std::unique_ptr<std::string> (new std::string (os.str ()));
+    return { -2, std::move (errMsg) };
+  }
+
+  if (debug) {
+    std::ostringstream os;
+    os << *prefix << "Done" << endl;
+    std::cerr << os.str ();
+  }
+  return { 0, std::move (errMsg) };
 }
 
 template<class Scalar, class LO, class GO, class Node>
 void BlockMultiVector<Scalar, LO, GO, Node>::
-unpackAndCombine (const Teuchos::ArrayView<const LO>& importLIDs,
-                  const Teuchos::ArrayView<const impl_scalar_type>& imports,
-                  const Teuchos::ArrayView<size_t>& /* numPacketsPerLID */,
-                  const size_t /* constantNumPackets */,
-                  Tpetra::Distributor& /* distor */,
-                  Tpetra::CombineMode CM)
+packAndPrepareNew (const SrcDistObject& src,
+                   const Kokkos::DualView<const local_ordinal_type*,
+                     buffer_device_type>& exportLIDs,
+                   Kokkos::DualView<packet_type*,
+                     buffer_device_type>& exports,
+                   Kokkos::DualView<size_t*,
+                     buffer_device_type> numPacketsPerLID,
+                   size_t& constantNumPackets,
+                   Distributor& distor)
 {
-  typedef typename Teuchos::ArrayView<const LO>::size_type size_type;
-  const char tfecfFuncName[] = "unpackAndCombine: ";
+  const char tfecfFuncName[] = "packAndPrepareNew: ";
 
-  TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
-    CM != ADD && CM != REPLACE && CM != INSERT && CM != ABSMAX && CM != ZERO,
-    std::invalid_argument, "Invalid CombineMode: " << CM << ".  Valid "
-    "CombineMode values are ADD, REPLACE, INSERT, ABSMAX, and ZERO.");
+  auto srcAsBmvPtr = getBlockMultiVectorFromSrcDistObject (src);
+  TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+    (srcAsBmvPtr.is_null (), std::invalid_argument,
+     "The source of an Import or Export to a BlockMultiVector "
+     "must also be a BlockMultiVector.");
+  const auto ret =
+    srcAsBmvPtr->packAndPrepareNewImpl (exportLIDs, exports,
+                                        numPacketsPerLID,
+                                        constantNumPackets, distor);
+  // TODO (mfh 15 Apr 2019) Instead of throwing here, which could
+  // cause an MPI parallel hang, we should record the error in *this
+  // (the target BMV instance).
+  TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+    (ret.first != 0, std::runtime_error, "packAndPrepareNewImpl "
+     "reports an error: " << * (ret.second));
+}
 
-  if (CM == ZERO) {
-    return; // Combining does nothing, so we don't have to combine anything.
+template<class SC, class LO, class GO, class NT>
+std::pair<int, std::unique_ptr<std::string>>
+BlockMultiVector<SC, LO, GO, NT>::
+unpackAndCombineNewImpl
+  (const Kokkos::DualView<
+     const local_ordinal_type*,
+     buffer_device_type
+   >& importLIDs,
+   Kokkos::DualView<
+     impl_scalar_type*,
+     buffer_device_type
+   > imports,
+   Kokkos::DualView<
+     size_t*,
+     buffer_device_type
+   > numPacketsPerLID,
+   const size_t constantNumPackets,
+   Distributor& distor,
+   const CombineMode combineMode)
+{
+  using std::endl;
+  using IST = impl_scalar_type;
+  using KAT = Kokkos::ArithTraits<IST>;
+  using imports_dv_type = Kokkos::DualView<packet_type*, buffer_device_type>;
+  using host_device_type = typename imports_dv_type::t_host::device_type;
+  using src_little_vec_type = Kokkos::View<const IST*, host_device_type,
+    Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  const char tfecfFuncName[] = "unpackAndCombineNewImpl: ";
+  std::unique_ptr<std::string> errMsg;
+  const bool debug = ::Tpetra::Details::Behavior::debug ("BlockMultiVector");
+
+  std::unique_ptr<std::string> prefix;
+  if (debug) {
+    const int myRank = this->getMap ()->getComm ()->getRank ();
+    std::ostringstream os;
+    os << "Proc " << myRank << ": " << tfecfFuncName;
+    prefix = std::unique_ptr<std::string> (new std::string (os.str ()));
+    os << "Start" << endl;
+    std::cerr << os.str ();
+  }
+
+  if (combineMode != ADD && combineMode != REPLACE &&
+      combineMode != INSERT && combineMode != ABSMAX &&
+      combineMode != ZERO) {
+    std::ostringstream os;
+    os << tfecfFuncName << "Invalid CombineMode: " << combineMode << ".  "
+      "Valid CombineMode values: ADD, REPLACE, INSERT, ABSMAX, and ZERO.";
+    errMsg = std::unique_ptr<std::string> (new std::string (os.str ()));
+    return { -1, std::move (errMsg) };
+  }
+  if (combineMode == ZERO) {
+    return { 0, std::move (errMsg) };
+  }
+
+  if (importLIDs.need_sync_host ()) {
+    const int myRank = this->getMap ()->getComm ()->getRank ();
+    std::ostringstream os;
+    os << "Proc " << myRank << ": " << tfecfFuncName << "importLIDs "
+      "needs sync to host.  This should never happen.";
+    errMsg = std::unique_ptr<std::string> (new std::string (os.str ()));
+    return { -2, std::move (errMsg) };
   }
 
   // Number of things to pack per LID is the block size.
   // Input LIDs correspond to the mesh points, not the DOFs.
-  const size_type numMeshLIDs = importLIDs.size ();
-  const LO blockSize = getBlockSize ();
-  const LO numVecs = getNumVectors ();
+  const size_t numMeshLIDs = static_cast<size_t> (importLIDs.extent (0));
+  const size_t blockSize = static_cast<size_t> (this->getBlockSize ());
+  const size_t numVecs = static_cast<size_t> (this->getNumVectors ());
 
-  const size_type requiredImportsSize = numMeshLIDs *
-    static_cast<size_type> (blockSize) * static_cast<size_type> (numVecs);
-  TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
-    imports.size () < requiredImportsSize, std::logic_error,
-    ": imports.size () = " << imports.size ()
-    << " < requiredImportsSize = " << requiredImportsSize << ".");
+  const size_t requiredImportsSize = numMeshLIDs * blockSize * numVecs;
+  if (static_cast<size_t> (imports.extent (0)) < requiredImportsSize) {
+    const int myRank = this->getMap ()->getComm ()->getRank ();
+    std::ostringstream os;
+    os << "Proc " << myRank << ": " << tfecfFuncName << "imports.extent(0) = "
+       << imports.extent (0) << " < requiredImportsSize = "
+       << requiredImportsSize << ".";
+    errMsg = std::unique_ptr<std::string> (new std::string (os.str ()));
+    return { -3, std::move (errMsg) };
+  }
 
-  size_type curImportPos = 0;
-  for (size_type meshLidIndex = 0; meshLidIndex < numMeshLIDs; ++meshLidIndex) {
-    for (LO j = 0; j < numVecs; ++j, curImportPos += blockSize) {
-      const LO meshLid = importLIDs[meshLidIndex];
-      const impl_scalar_type* const curImportPtr = &imports[curImportPos];
+  auto importLIDs_h = importLIDs.view_host ();
+  if (imports.need_sync_host ()) {
+    imports.sync_host ();
+  }
+  auto imports_h = imports.view_host ();
 
-      typename const_little_vec_type::HostMirror::const_type X_src (curImportPtr, blockSize);
-      auto X_dst = getLocalBlock (meshLid, j);
+  size_t curImportPos = 0;
+  for (size_t meshLidIndex = 0; meshLidIndex < numMeshLIDs; ++meshLidIndex) {
+    for (size_t j = 0; j < numVecs; ++j, curImportPos += blockSize) {
+      const LO meshLid = importLIDs_h[meshLidIndex];
+      const IST* const curImportPtr = &imports_h[curImportPos];
 
-      if (CM == INSERT || CM == REPLACE) {
+      src_little_vec_type X_src (curImportPtr, blockSize);
+      auto X_dst = this->getLocalBlock (meshLid, j);
+
+      if (combineMode == INSERT || combineMode == REPLACE) {
         deep_copy (X_dst, X_src);
-      } else if (CM == ADD) {
-        AXPY (static_cast<impl_scalar_type> (STS::one ()), X_src, X_dst);
-      } else if (CM == ABSMAX) {
-        Impl::absMax (X_dst, X_src);
+      }
+      else if (combineMode == ADD) {
+        using ::Tpetra::Experimental::AXPY;
+        AXPY (static_cast<IST> (KAT::one ()), X_src, X_dst);
+      }
+      else if (combineMode == ABSMAX) {
+        ::Tpetra::Experimental::Impl::absMax (X_dst, X_src);
       }
     }
   }
+
+  if (debug) {
+    std::ostringstream os;
+    os << *prefix << "Done" << endl;
+    std::cerr << os.str ();
+  }
+  return { 0, std::move (errMsg) };
+}
+
+template<class Scalar, class LO, class GO, class Node>
+void BlockMultiVector<Scalar, LO, GO, Node>::
+unpackAndCombineNew (const Kokkos::DualView<const local_ordinal_type*,
+                       buffer_device_type>& importLIDs,
+                     Kokkos::DualView<packet_type*,
+                       buffer_device_type> imports,
+                     Kokkos::DualView<size_t*,
+                       buffer_device_type> numPacketsPerLID,
+                     const size_t constantNumPackets,
+                     Distributor& distor,
+                     const CombineMode combineMode)
+{
+  const char tfecfFuncName[] = "unpackAndCombineNew: ";
+  const auto ret =
+    unpackAndCombineNewImpl (importLIDs, imports, numPacketsPerLID,
+                             constantNumPackets, distor, combineMode);
+  // TODO (mfh 15 Apr 2019) Instead of throwing here, which could
+  // cause an MPI parallel hang, we should record the error in *this
+  // (the target BMV instance).
+  TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+    (ret.first != 0, std::runtime_error, "unpackAndCombineNewImpl "
+     "reports an error: " << * (ret.second));
+}
+
+template<class Scalar, class LO, class GO, class Node>
+bool BlockMultiVector<Scalar, LO, GO, Node>::
+isValidLocalMeshIndex (const LO meshLocalIndex) const
+{
+  return meshLocalIndex != Teuchos::OrdinalTraits<LO>::invalid () &&
+    meshMap_.isNodeLocalElement (meshLocalIndex);
 }
 
 template<class Scalar, class LO, class GO, class Node>

--- a/packages/tpetra/core/test/Block/BlockCrsMatrix.cpp
+++ b/packages/tpetra/core/test/Block/BlockCrsMatrix.cpp
@@ -47,6 +47,7 @@
 #include "Tpetra_BlockCrsMatrix.hpp"
 #include "Tpetra_BlockCrsMatrix_Helpers.hpp"
 #include "Tpetra_BlockVector.hpp"
+#include "Tpetra_Experimental_BlockView.hpp"
 #include "Tpetra_Details_gathervPrint.hpp"
 
 namespace {

--- a/packages/tpetra/core/test/Block/BlockMultiVector2.cpp
+++ b/packages/tpetra/core/test/Block/BlockMultiVector2.cpp
@@ -43,6 +43,7 @@
 
 #include "Tpetra_TestingUtilities.hpp"
 #include "Tpetra_BlockMultiVector.hpp"
+#include "Tpetra_Experimental_BlockView.hpp"
 #include "Teuchos_SerialDenseMatrix.hpp"
 #include "Teuchos_LAPACK.hpp"
 #include "Teuchos_TypeNameTraits.hpp"


### PR DESCRIPTION
@trilinos/tpetra @trilinos/ifpack2 

This supersedes PR #4862.

## Description

  - Make `Tpetra::BlockMultiVector` implement the "new" DistObject interface
  - Avoid header file includes in BlockCrsMatrix and BlockMultiVector
  - Fix some build warnings in Ifpack2 and Tpetra 

## Related Issues

* Closes #4861 
* Blocks #4853 
* Follows #4854 
* Related to #3137 