### PR TITLE
Exclude 'ride14' from running pure 'debug' builds (ATDV-159)

### DIFF
--- a/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-debug.sh
+++ b/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-debug.sh
@@ -2,4 +2,5 @@
 if [ "${Trilinos_TRACK}" == "" ] ; then
   export Trilinos_TRACK=ATDM
 fi
+export EXCLUDE_NODES_FROM_BSUB="-R hname!=ride14"
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ride/local-driver.sh

--- a/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-gnu-7.2.0-openmp-debug.sh
+++ b/cmake/ctest/drivers/atdm/ride/drivers/Trilinos-atdm-white-ride-gnu-7.2.0-openmp-debug.sh
@@ -2,4 +2,5 @@
 if [ "$Trilinos_TRACK" == "" ] ; then
   export Trilinos_TRACK=ATDM
 fi
+export EXCLUDE_NODES_FROM_BSUB="-R hname!=ride14"
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ride/local-driver.sh


### PR DESCRIPTION
## Description

Seems that 'ride14' triggers several timeouts in the pure 'debug' builds but other nodes don't show any of these timeouts.  This occurred 3 different times and all on 'ride14' (see [ATDV-159](https://sems-atlassian-srn.sandia.gov/browse/ATDV-159)).

Seems that 'ride14' runs the other builds okay so this seems like a safe change to make.

## How Has This Been Tested?

I tested this on 'ride' with:

```
$ cd /home/rabartl/Trilinos.base/BUILDS/RIDE/CTEST_S/

$ env Trilinos_PACKAGES=Kokkos \
    ./ctest-s-local-test-driver.sh cuda-9.2-gnu-7.2.0-debug gnu-7.2.0-openmp-debug

***
*** ./ctest-s-local-test-driver.sh  cuda-9.2-gnu-7.2.0-debug gnu-7.2.0-openmp-debug
***

ATDM_TRILINOS_DIR = '/home/rabartl/Trilinos.base/Trilinos'

Load some env to get python, cmake, etc ...

Hostname 'ride6' matches known ATDM host 'ride' and system 'ride'
Setting compiler and build options for buld name 'default'
Using white/ride compiler stack GNU-7.2.0 to build DEBUG code with Kokkos node type SERIAL and KOKKOS_ARCH=Power8

Running builds:
    cuda-9.2-gnu-7.2.0-debug
    gnu-7.2.0-openmp-debug


Running Jenkins driver Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-debug.sh ...

Creating directory: Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-debug
Creating directory: SRC_AND_BUILD

real    6m26.240s
user    0m0.641s
sys     0m0.235s

Running Jenkins driver Trilinos-atdm-white-ride-gnu-7.2.0-openmp-debug.sh ...

Creating directory: Trilinos-atdm-white-ride-gnu-7.2.0-openmp-debug
Creating directory: SRC_AND_BUILD

real    4m59.635s
user    0m0.686s
sys     0m0.200s
```

The local output showed:

```
+ bsub -x -Is -q rhel7F -n 16 -J Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-debug -W 12:00 -R 'hname!=ride14' /ascldap/users/rabartl/Trilinos.base/BUILDS/RIDE/CTEST_S/Trilinos-atdm-white-ride-cuda-9.2-gnu-7.2.0-debug/Trilinos/cmake/ctest/drivers/atdm/ctest-s-driver.sh
***Forced exclusive execution
Job <855577> is submitted to queue <rhel7F>.
<<Waiting for dispatch ...>>
<<Starting on ride10>>
```

and

```
+ bsub -x -Is -q rhel7F -n 16 -J Trilinos-atdm-white-ride-gnu-7.2.0-openmp-debug -W 12:00 -R 'hname!=ride14' /ascldap/users/rabartl/Trilinos.base/BUILDS/RIDE/CTEST_S/Trilinos-atdm-white-ride-gnu-7.2.0-openmp-debug/Trilinos/cmake/ctest/drivers/atdm/ctest-s-driver.sh
***Forced exclusive execution
Job <855580> is submitted to queue <rhel7F>.
<<Waiting for dispatch ...>>
<<Starting on ride13>>
```

This submitted to:

* https://testing.sandia.gov/cdash-dev-view/index.php?project=Trilinos&date=2019-04-15&filtercount=3&showfilters=1&filtercombine=and&field1=buildname&compare1=65&value1=Trilinos-atdm-white-ride-&field2=site&compare2=65&value2=ride&field3=groupname&compare3=61&value3=Experimental

That looks right to me.
