### PR TITLE
clean_workspace.py: move from atdm  module for ninja to sems module

### DIFF
--- a/commonTools/framework/clean_workspace/clean_workspace.py
+++ b/commonTools/framework/clean_workspace/clean_workspace.py
@@ -62,8 +62,8 @@ class Cleaner(object):
              Load the module to enable ninja
              Run "make -C %s clean"
         """
-        module('load', 'atdm-env')
-        module('load', 'atdm-ninja_fortran/1.7.2')
+        module('load', 'sems-env')
+        module('load', 'sems-ninja_fortran/1.8.2')
         os.chdir(self.args.dir)
         subprocess.check_call(['make', 'clean'])
 

--- a/commonTools/framework/clean_workspace/unittests/test_clean_workspace.py
+++ b/commonTools/framework/clean_workspace/unittests/test_clean_workspace.py
@@ -110,8 +110,8 @@ class TestForceCleanSpace(unittest.TestCase):
              mock.patch('os.chdir') as m_chdir, \
              mock.patch('clean_workspace.subprocess.check_call') as check_call:
             cleanerInst.force_clean_space()
-        mod.assert_has_calls([mock.call('load', 'atdm-env'),
-                              mock.call('load', 'atdm-ninja_fortran/1.7.2')])
+        mod.assert_has_calls([mock.call('load', 'sems-env'),
+                              mock.call('load', 'sems-ninja_fortran/1.8.2')])
         m_chdir.assert_called_once_with(test_args.dir)
         check_call.assert_called_once_with(['make', 'clean'])
 


### PR DESCRIPTION
For whatever reason, the atdm module has a dependency
on a compiler set already being loaded. Not that this
is needed....

## Motivation and Context
I am attempting to make sure we can rapidly and safely restart all compilation if incremental builds get locked up.  Then I will test and enable incremental PR builds.

