### PR TITLE
Xpetra:  deprecate node args in map construxtors (small fix for #4888)

### DIFF
--- a/packages/xpetra/src/Map/Xpetra_EpetraMap.hpp
+++ b/packages/xpetra/src/Map/Xpetra_EpetraMap.hpp
@@ -94,7 +94,7 @@ namespace Xpetra {
                GlobalOrdinal indexBase,
                const Teuchos::RCP< const Teuchos::Comm< int > > &comm,
                LocalGlobal lg,
-               const Teuchos::RCP< Node > &node) 
+               const Teuchos::RCP< Node > &/*node*/) 
       : EpetraMapT(numGlobalElements, indexBase, comm, lg)
     {}
 #endif // TPETRA_ENABLE_DEPRECATED_CODE

--- a/packages/xpetra/src/Map/Xpetra_TpetraMap.hpp
+++ b/packages/xpetra/src/Map/Xpetra_TpetraMap.hpp
@@ -435,8 +435,8 @@ namespace Xpetra {
     TpetraMap (global_size_t numGlobalElements,
                GlobalOrdinal indexBase,
                const Teuchos::RCP< const Teuchos::Comm< int > > &comm,
-               LocalGlobal lg=GloballyDistributed,
-               const Teuchos::RCP< Node > &node = Teuchos::rcp(new Node)) 
+               LocalGlobal lg,
+               const Teuchos::RCP< Node > & /*node*/)
      : TpetraMap(numGlobalElements, indexBase, comm, lg)
     {}
 #endif // TPETRA_ENABLE_DEPRECATED_CODE
@@ -636,7 +636,7 @@ namespace Xpetra {
     TpetraMap (global_size_t numGlobalElements,
                GlobalOrdinal indexBase,
                const Teuchos::RCP< const Teuchos::Comm< int > > &comm,
-               LocalGlobal lg=GloballyDistributed,
+               LocalGlobal lg,
                const Teuchos::RCP< Node > & /* node */) 
       : TpetraMap(numGlobalElements, indexBase, comm, lg)
     {}


### PR DESCRIPTION

@trilinos/xpetra @etphipp 

## Description
Fix compilation error reported by @etphipp but not caught by PR tests.
Xpetra compilation error when Tpetra_ENABLE_DEPRECATED_CODE=OFF.
See #4888 



## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->
```
cmake \
-D Trilinos_ENABLE_EXPLICIT_INSTANTIATION:BOOL=ON \
-D Tpetra_INST_INT_INT:BOOL=ON \
-D Tpetra_INST_INT_LONG_LONG:BOOL=OFF \
-D CMAKE_BUILD_TYPE:STRING="DEBUG" \
-D CMAKE_INSTALL_PREFIX:FILEPATH="/Users/kddevin/code/Trilinos/Obj_node_dep" \
-D CMAKE_VERBOSE_MAKEFILE:BOOL=OFF \
\
-D MPI_BIN_DIR:PATH="/Users/kddevin/InstalledSoftware/openmpi-1.8.3_clang/bin" \
-D TPL_ENABLE_MPI:BOOL=ON \
-D MPI_EXEC_MAX_NUMPROCS:STRING=11 \
\
-D TPL_ENABLE_BinUtils:BOOL=OFF \
-D TPL_ENABLE_Pthread:BOOL=OFF \
\
-D CMAKE_C_FLAGS:STRING="-Wall  -pedantic -Wno-unknown-pragmas -Wno-narrowing -Wno-inline -Wshadow -Wdeprecated-declarations -Wempty-body  -Wignored-qualifiers -Wmissing-field-initializers  -Wsign-compare  -Wtype-limits   -Wuninitialized -Winit-self -fstrict-aliasing -Wno-long-long" \
-D CMAKE_CXX_FLAGS:STRING="-Wall -pedantic -Wno-unknown-pragmas -Wno-narrowing -Wno-delete-non-virtual-dtor -Wno-inline -Wshadow -Wdeprecated-declarations -Wempty-body  -Wignored-qualifiers -Wmissing-field-initializers  -Wsign-compare  -Wtype-limits   -Wuninitialized -Winit-self -fstrict-aliasing" \
\
-D Trilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=ON \
-D Trilinos_ENABLE_TESTS:BOOL=ON \
-D Trilinos_ENABLE_EXAMPLES:BOOL=ON \
\
-D Trilinos_ENABLE_SHADOW_WARNINGS:BOOL=ON \
-D Trilinos_VERBOSE_CONFIGURE:BOOL=OFF \
-D Trilinos_ENABLE_Fortran:BOOL=OFF \
\
-D Tpetra_ENABLE_DEPRECATED_CODE:BOOL=OFF \
\
-D Trilinos_ENABLE_Stokhos:BOOL=ON \
-D Trilinos_ENABLE_Nox:BOOL=ON \
-D Trilinos_ENABLE_ROL:BOOL=ON \
-D Trilinos_ENABLE_MiniTensor:BOOL=OFF \
-D ROL_ENABLE_MiniTensor:BOOL=OFF \
-D Trilinos_ENABLE_Panzer:BOOL=ON \
-D Trilinos_ENABLE_PanzerAdaptersSTK:BOOL=OFF \
-D Trilinos_ENABLE_PanzerAdaptersIOSS:BOOL=OFF \
-D Trilinos_ENABLE_Thyra:BOOL=ON \
-D Trilinos_ENABLE_MueLu:BOOL=ON \
-D Trilinos_ENABLE_Anasazi:BOOL=ON \
-D Trilinos_ENABLE_Belos:BOOL=ON \
\
-D Teuchos_ENABLE_STACKTRACE:BOOL=OFF \
-D Teuchos_ENABLE_LONG_LONG_INT:BOOL=ON
```
<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [ ] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
