### PR TITLE
Tpetra: Fix #4853 (deprecate "old" DistObject interface)

### DIFF
--- a/packages/tpetra/core/inout/Tpetra_Details_CooMatrix.hpp
+++ b/packages/tpetra/core/inout/Tpetra_Details_CooMatrix.hpp
@@ -994,12 +994,6 @@ protected:
     return ! (* (this->localError_));
   }
 
-  /// \brief Whether the subclass implements the "old" or "new"
-  ///   (Kokkos-friendly) interface (it implements the "new"
-  ///   interface).
-  virtual bool useNewInterface () { return true; }
-
-
   //! Kokkos::Device specialization for DistObject communication buffers.
   using buffer_device_type =
     typename ::Tpetra::DistObject<char, LO, GO, NT>::buffer_device_type;

--- a/packages/tpetra/core/inout/Tpetra_Details_CooMatrix.hpp
+++ b/packages/tpetra/core/inout/Tpetra_Details_CooMatrix.hpp
@@ -998,19 +998,22 @@ protected:
   using buffer_device_type =
     typename ::Tpetra::DistObject<char, LO, GO, NT>::buffer_device_type;
 
-  /// \brief While we do use the "new" Kokkos::DualView - based
-  ///   interface, we don't currently use device Views.
   virtual void
-  copyAndPermuteNew (const ::Tpetra::SrcDistObject& sourceObject,
-                     const size_t numSameIDs,
-                     const Kokkos::DualView<const LO*,
-                       buffer_device_type>& permuteToLIDs,
-                     const Kokkos::DualView<const LO*,
-                       buffer_device_type>& permuteFromLIDs)
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+  copyAndPermuteNew
+#else // TPETRA_ENABLE_DEPRECATED_CODE
+  copyAndPermute
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+  (const ::Tpetra::SrcDistObject& sourceObject,
+   const size_t numSameIDs,
+   const Kokkos::DualView<const LO*,
+     buffer_device_type>& permuteToLIDs,
+   const Kokkos::DualView<const LO*,
+     buffer_device_type>& permuteFromLIDs)
   {
     using std::endl;
     using this_type = CooMatrix<SC, LO, GO, NT>;
-    const char prefix[] = "Tpetra::Details::CooMatrix::copyAndPermuteNew: ";
+    const char prefix[] = "Tpetra::Details::CooMatrix::copyAndPermute: ";
 
     // There's no communication in this method, so it's safe just to
     // return on error.
@@ -1200,24 +1203,27 @@ protected:
     }
   }
 
-  /// \brief While we do use the "new" Kokkos::DualView - based
-  ///   interface, we don't currently use device Views.
   virtual void
-  packAndPrepareNew (const ::Tpetra::SrcDistObject& sourceObject,
-                     const Kokkos::DualView<const local_ordinal_type*,
-                       buffer_device_type>& exportLIDs,
-                     Kokkos::DualView<packet_type*,
-                       buffer_device_type>& exports,
-                     Kokkos::DualView<size_t*,
-                       buffer_device_type> numPacketsPerLID,
-                     size_t& constantNumPackets,
-                     ::Tpetra::Distributor& /* distor */)
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+  packAndPrepareNew
+#else // TPETRA_ENABLE_DEPRECATED_CODE
+  packAndPrepare
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+  (const ::Tpetra::SrcDistObject& sourceObject,
+   const Kokkos::DualView<const local_ordinal_type*,
+     buffer_device_type>& exportLIDs,
+   Kokkos::DualView<packet_type*,
+     buffer_device_type>& exports,
+   Kokkos::DualView<size_t*,
+     buffer_device_type> numPacketsPerLID,
+   size_t& constantNumPackets,
+   ::Tpetra::Distributor& /* distor */)
   {
     using Teuchos::Comm;
     using Teuchos::RCP;
     using std::endl;
     using this_type = CooMatrix<SC, LO, GO, NT>;
-    const char prefix[] = "Tpetra::Details::CooMatrix::packAndPrepareNew: ";
+    const char prefix[] = "Tpetra::Details::CooMatrix::packAndPrepare: ";
     const char suffix[] = "  This should never happen.  "
       "Please report this bug to the Tpetra developers.";
 
@@ -1398,23 +1404,26 @@ protected:
     }
   }
 
-  /// \brief While we do use the "new" Kokkos::DualView - based
-  ///   interface, we don't currently use device Views.
   virtual void
-  unpackAndCombineNew (const Kokkos::DualView<const local_ordinal_type*,
-                         buffer_device_type>& importLIDs,
-                       Kokkos::DualView<packet_type*,
-                         buffer_device_type> imports,
-                       Kokkos::DualView<size_t*,
-                         buffer_device_type> numPacketsPerLID,
-                       const size_t /* constantNumPackets */,
-                       ::Tpetra::Distributor& /* distor */,
-                       const ::Tpetra::CombineMode /* combineMode */)
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+  unpackAndCombineNew
+#else // TPETRA_ENABLE_DEPRECATED_CODE
+  unpackAndCombine
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+  (const Kokkos::DualView<const local_ordinal_type*,
+     buffer_device_type>& importLIDs,
+   Kokkos::DualView<packet_type*,
+     buffer_device_type> imports,
+   Kokkos::DualView<size_t*,
+     buffer_device_type> numPacketsPerLID,
+   const size_t /* constantNumPackets */,
+   ::Tpetra::Distributor& /* distor */,
+   const ::Tpetra::CombineMode /* combineMode */)
   {
     using Teuchos::Comm;
     using Teuchos::RCP;
     using std::endl;
-    const char prefix[] = "Tpetra::Details::CooMatrix::unpackAndCombineNew: ";
+    const char prefix[] = "Tpetra::Details::CooMatrix::unpackAndCombine: ";
     const char suffix[] = "  This should never happen.  "
       "Please report this bug to the Tpetra developers.";
 

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -1284,12 +1284,17 @@ namespace Tpetra {
     checkSizes (const SrcDistObject& source) override;
 
     virtual void
-    copyAndPermuteNew (const SrcDistObject& source,
-                       const size_t numSameIDs,
-                       const Kokkos::DualView<const local_ordinal_type*,
-                         buffer_device_type>& permuteToLIDs,
-                       const Kokkos::DualView<const local_ordinal_type*,
-                         buffer_device_type>& permuteFromLIDs) override;
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+    copyAndPermuteNew
+#else // TPETRA_ENABLE_DEPRECATED_CODE
+    copyAndPermute
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+    (const SrcDistObject& source,
+     const size_t numSameIDs,
+     const Kokkos::DualView<const local_ordinal_type*,
+       buffer_device_type>& permuteToLIDs,
+     const Kokkos::DualView<const local_ordinal_type*,
+       buffer_device_type>& permuteFromLIDs) override;
 
     void
     applyCrsPadding (const Kokkos::UnorderedMap<local_ordinal_type, size_t, device_type>& padding);
@@ -1319,15 +1324,20 @@ namespace Tpetra {
                             buffer_device_type> numPacketsPerLID) const;
 
     virtual void
-    packAndPrepareNew (const SrcDistObject& source,
-                       const Kokkos::DualView<const local_ordinal_type*,
-                         buffer_device_type>& exportLIDs,
-                       Kokkos::DualView<packet_type*,
-                         buffer_device_type>& exports,
-                       Kokkos::DualView<size_t*,
-                         buffer_device_type> numPacketsPerLID,
-                       size_t& constantNumPackets,
-                       Distributor& distor) override;
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+    packAndPrepareNew
+#else // TPETRA_ENABLE_DEPRECATED_CODE
+    packAndPrepare
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+    (const SrcDistObject& source,
+     const Kokkos::DualView<const local_ordinal_type*,
+       buffer_device_type>& exportLIDs,
+     Kokkos::DualView<packet_type*,
+       buffer_device_type>& exports,
+     Kokkos::DualView<size_t*,
+       buffer_device_type> numPacketsPerLID,
+     size_t& constantNumPackets,
+     Distributor& distor) override;
 
     virtual void
     pack (const Teuchos::ArrayView<const local_ordinal_type>& exportLIDs,
@@ -1354,15 +1364,21 @@ namespace Tpetra {
                        Distributor& distor) const;
 
     virtual void
-    unpackAndCombineNew (const Kokkos::DualView<const local_ordinal_type*,
-                           buffer_device_type>& importLIDs,
-                         Kokkos::DualView<packet_type*,
-                           buffer_device_type> imports,
-                         Kokkos::DualView<size_t*,
-                           buffer_device_type> numPacketsPerLID,
-                         const size_t constantNumPackets,
-                         Distributor& distor,
-                         const CombineMode combineMode) override;
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+    unpackAndCombineNew
+#else // TPETRA_ENABLE_DEPRECATED_CODE
+    unpackAndCombine
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+    (const Kokkos::DualView<const local_ordinal_type*,
+       buffer_device_type>& importLIDs,
+     Kokkos::DualView<packet_type*,
+       buffer_device_type> imports,
+     Kokkos::DualView<size_t*,
+       buffer_device_type> numPacketsPerLID,
+     const size_t constantNumPackets,
+     Distributor& distor,
+     const CombineMode combineMode) override;
+
     //@}
     //! \name Advanced methods, at increased risk of deprecation.
     //@{

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -1283,9 +1283,6 @@ namespace Tpetra {
     virtual bool
     checkSizes (const SrcDistObject& source) override;
 
-    virtual bool
-    useNewInterface () override;
-
     virtual void
     copyAndPermuteNew (const SrcDistObject& source,
                        const size_t numSameIDs,

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -5557,14 +5557,6 @@ namespace Tpetra {
   }
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
-  bool
-  CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
-  useNewInterface ()
-  {
-    return true;
-  }
-
-  template <class LocalOrdinal, class GlobalOrdinal, class Node>
   void
   CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
   copyAndPermuteNew (const SrcDistObject& source,

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -5559,26 +5559,31 @@ namespace Tpetra {
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   void
   CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
-  copyAndPermuteNew (const SrcDistObject& source,
-                     const size_t numSameIDs,
-                     const Kokkos::DualView<const local_ordinal_type*,
-                       buffer_device_type>& permuteToLIDs,
-                     const Kokkos::DualView<const local_ordinal_type*,
-                       buffer_device_type>& permuteFromLIDs)
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+  copyAndPermuteNew
+#else // TPETRA_ENABLE_DEPRECATED_CODE
+  copyAndPermute
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+  (const SrcDistObject& source,
+   const size_t numSameIDs,
+   const Kokkos::DualView<const local_ordinal_type*,
+     buffer_device_type>& permuteToLIDs,
+   const Kokkos::DualView<const local_ordinal_type*,
+     buffer_device_type>& permuteFromLIDs)
   {
     using std::endl;
     using LO = local_ordinal_type;
     using GO = global_ordinal_type;
     using this_type = CrsGraph<LO, GO, node_type>;
     using row_graph_type = RowGraph<LO, GO, node_type>;
-    const char tfecfFuncName[] = "copyAndPermuteNew: ";
+    const char tfecfFuncName[] = "copyAndPermute: ";
     const bool debug = ::Tpetra::Details::Behavior::debug ("CrsGraph");
 
     std::unique_ptr<std::string> prefix;
     if (debug) {
       std::ostringstream os;
       const int myRank = this->getMap ()->getComm ()->getRank ();
-      os << "Proc " << myRank << ": Tpetra::CrsGraph::copyAndPermuteNew: ";
+      os << "Proc " << myRank << ": Tpetra::CrsGraph::copyAndPermute: ";
       prefix = std::unique_ptr<std::string> (new std::string (os.str ()));
       os << endl;
       std::cerr << os.str ();
@@ -5928,15 +5933,20 @@ namespace Tpetra {
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   void
   CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
-  packAndPrepareNew (const SrcDistObject& source,
-                     const Kokkos::DualView<const local_ordinal_type*,
-                       buffer_device_type>& exportLIDs,
-                     Kokkos::DualView<packet_type*,
-                       buffer_device_type>& exports,
-                     Kokkos::DualView<size_t*,
-                       buffer_device_type> numPacketsPerLID,
-                     size_t& constantNumPackets,
-                     Distributor& distor)
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+  packAndPrepareNew
+#else // TPETRA_ENABLE_DEPRECATED_CODE
+  packAndPrepare
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+  (const SrcDistObject& source,
+   const Kokkos::DualView<const local_ordinal_type*,
+     buffer_device_type>& exportLIDs,
+   Kokkos::DualView<packet_type*,
+     buffer_device_type>& exports,
+   Kokkos::DualView<size_t*,
+     buffer_device_type> numPacketsPerLID,
+   size_t& constantNumPackets,
+   Distributor& distor)
   {
     using Tpetra::Details::ProfilingRegion;
     using GO = global_ordinal_type;
@@ -5945,15 +5955,15 @@ namespace Tpetra {
       CrsGraph<local_ordinal_type, global_ordinal_type, node_type>;
     using row_graph_type =
       RowGraph<local_ordinal_type, global_ordinal_type, node_type>;
-    const char tfecfFuncName[] = "packAndPrepareNew: ";
-    ProfilingRegion region_papn ("Tpetra::CrsGraph::packAndPrepareNew");
+    const char tfecfFuncName[] = "packAndPrepare: ";
+    ProfilingRegion region_papn ("Tpetra::CrsGraph::packAndPrepare");
 
     const bool debug = ::Tpetra::Details::Behavior::debug ("CrsGraph");
     std::unique_ptr<std::string> prefix;
     if (debug) {
       std::ostringstream os;
       const int myRank = this->getMap ()->getComm ()->getRank ();
-      os << "Proc " << myRank << ": Tpetra::CrsGraph::packAndPrepareNew: ";
+      os << "Proc " << myRank << ": Tpetra::CrsGraph::packAndPrepare: ";
       prefix = std::unique_ptr<std::string> (new std::string (os.str ()));
       os << "Start" << endl;
       std::cerr << os.str ();
@@ -6556,27 +6566,32 @@ namespace Tpetra {
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   void
   CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
-  unpackAndCombineNew (const Kokkos::DualView<const local_ordinal_type*,
-                         buffer_device_type>& importLIDs,
-                       Kokkos::DualView<packet_type*,
-                         buffer_device_type> imports,
-                       Kokkos::DualView<size_t*,
-                         buffer_device_type> numPacketsPerLID,
-                       const size_t /* constantNumPackets */,
-                       Distributor& /* distor */,
-                       const CombineMode /* combineMode */ )
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+  unpackAndCombineNew
+#else // TPETRA_ENABLE_DEPRECATED_CODE
+  unpackAndCombine
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+  (const Kokkos::DualView<const local_ordinal_type*,
+     buffer_device_type>& importLIDs,
+   Kokkos::DualView<packet_type*,
+     buffer_device_type> imports,
+   Kokkos::DualView<size_t*,
+     buffer_device_type> numPacketsPerLID,
+   const size_t /* constantNumPackets */,
+   Distributor& /* distor */,
+   const CombineMode /* combineMode */ )
   {
     using std::endl;
     using LO = local_ordinal_type;
     using GO = global_ordinal_type;
-    const char tfecfFuncName[] = "unpackAndCombineNew: ";
+    const char tfecfFuncName[] = "unpackAndCombine: ";
     const bool debug = ::Tpetra::Details::Behavior::debug ("CrsGraph");
 
     std::unique_ptr<std::string> prefix;
     if (debug) {
       std::ostringstream os;
       const int myRank = this->getMap ()->getComm ()->getRank ();
-      os << "Proc " << myRank << ": Tpetra::CrsGraph::unpackAndCombineNew: ";
+      os << "Proc " << myRank << ": Tpetra::CrsGraph::unpackAndCombine: ";
       prefix = std::unique_ptr<std::string> (new std::string (os.str ()));
       os << endl;
       std::cerr << os.str ();

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -3883,46 +3883,33 @@ namespace Tpetra {
     virtual bool
     checkSizes (const SrcDistObject& source) override;
 
-    /// \brief Whether the subclass implements the "old" or "new"
-    ///   (Kokkos-friendly) interface.
-    ///
-    /// The "old" interface consists of copyAndPermute,
-    /// packAndPrepare, and unpackAndCombine.  The "new" interface
-    /// consists of copyAndPermuteNew, packAndPrepareNew, and
-    /// unpackAndCombineNew.  We prefer the new interface, because it
-    /// facilitates thread parallelization using Kokkos data
-    /// structures.
-    ///
-    /// At some point, we will remove the old interface, and rename
-    /// the "new" interface (by removing "New" from the methods'
-    /// names), so that it becomes the only interface.
-    virtual bool
-    useNewInterface () override;
-
   private:
-
     void
     copyAndPermuteImpl (const RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>& source,
                         const size_t numSameIDs,
                         const LocalOrdinal permuteToLIDs[],
                         const LocalOrdinal permuteFromLIDs[],
                         const size_t numPermutes);
-
   protected:
     virtual void
     copyAndPermuteNew (const SrcDistObject& source,
                        const size_t numSameIDs,
-                       const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& permuteToLIDs,
-                       const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& permuteFromLIDs) override;
+                       const Kokkos::DualView<
+                         const local_ordinal_type*,
+                         buffer_device_type>& permuteToLIDs,
+                       const Kokkos::DualView<
+                         const local_ordinal_type*,
+                         buffer_device_type>& permuteFromLIDs) override;
 
     virtual void
     packAndPrepareNew (const SrcDistObject& source,
-                       const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& exportLIDs,
+                       const Kokkos::DualView<
+                         const local_ordinal_type*,
+                         buffer_device_type>& exportLIDs,
                        Kokkos::DualView<char*, buffer_device_type>& exports,
                        Kokkos::DualView<size_t*, buffer_device_type> numPacketsPerLID,
                        size_t& constantNumPackets,
                        Distributor& distor) override;
-
   private:
     /// \brief Unpack the imported column indices and values, and
     ///   combine into matrix.

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -3892,69 +3892,85 @@ namespace Tpetra {
                         const size_t numPermutes);
   protected:
     virtual void
-    copyAndPermuteNew (const SrcDistObject& source,
-                       const size_t numSameIDs,
-                       const Kokkos::DualView<
-                         const local_ordinal_type*,
-                         buffer_device_type>& permuteToLIDs,
-                       const Kokkos::DualView<
-                         const local_ordinal_type*,
-                         buffer_device_type>& permuteFromLIDs) override;
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+    copyAndPermuteNew
+#else // TPETRA_ENABLE_DEPRECATED_CODE
+    copyAndPermute
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+    (const SrcDistObject& source,
+     const size_t numSameIDs,
+     const Kokkos::DualView<
+       const local_ordinal_type*,
+       buffer_device_type>& permuteToLIDs,
+     const Kokkos::DualView<
+       const local_ordinal_type*,
+       buffer_device_type>& permuteFromLIDs) override;
 
     virtual void
-    packAndPrepareNew (const SrcDistObject& source,
-                       const Kokkos::DualView<
-                         const local_ordinal_type*,
-                         buffer_device_type>& exportLIDs,
-                       Kokkos::DualView<char*, buffer_device_type>& exports,
-                       Kokkos::DualView<size_t*, buffer_device_type> numPacketsPerLID,
-                       size_t& constantNumPackets,
-                       Distributor& distor) override;
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+    packAndPrepareNew
+#else // TPETRA_ENABLE_DEPRECATED_CODE
+    packAndPrepare
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+    (const SrcDistObject& source,
+     const Kokkos::DualView<
+       const local_ordinal_type*,
+       buffer_device_type>& exportLIDs,
+     Kokkos::DualView<char*, buffer_device_type>& exports,
+     Kokkos::DualView<size_t*, buffer_device_type> numPacketsPerLID,
+     size_t& constantNumPackets,
+     Distributor& distor) override;
+
   private:
     /// \brief Unpack the imported column indices and values, and
     ///   combine into matrix.
     void
-    unpackAndCombineNewImpl (const Kokkos::DualView<const local_ordinal_type*,
-                               buffer_device_type>& importLIDs,
-                             const Kokkos::DualView<const char*,
-                               buffer_device_type>& imports,
-                             const Kokkos::DualView<const size_t*,
-                               buffer_device_type>& numPacketsPerLID,
-                             const size_t constantNumPackets,
-                             Distributor& distor,
-                             const CombineMode combineMode,
-                             const bool atomic = useAtomicUpdatesByDefault);
-    /// \brief Implementation of unpackAndCombineNewImpl for when the
+    unpackAndCombineImpl (const Kokkos::DualView<const local_ordinal_type*,
+                            buffer_device_type>& importLIDs,
+                          const Kokkos::DualView<const char*,
+                            buffer_device_type>& imports,
+                          const Kokkos::DualView<const size_t*,
+                            buffer_device_type>& numPacketsPerLID,
+                          const size_t constantNumPackets,
+                          Distributor& distor,
+                          const CombineMode combineMode,
+                          const bool atomic = useAtomicUpdatesByDefault);
+
+    /// \brief Implementation of unpackAndCombineImpl for when the
     ///   target matrix's structure may change.
     void
-    unpackAndCombineNewImplNonStatic (const Kokkos::DualView<const local_ordinal_type*,
-                                        buffer_device_type>& importLIDs,
-                                      const Kokkos::DualView<const char*,
-                                        buffer_device_type>& imports,
-                                      const Kokkos::DualView<const size_t*,
-                                        buffer_device_type>& numPacketsPerLID,
-                                      const size_t constantNumPackets,
-                                      Distributor& distor,
-                                      const CombineMode combineMode);
+    unpackAndCombineImplNonStatic (const Kokkos::DualView<const local_ordinal_type*,
+                                     buffer_device_type>& importLIDs,
+                                   const Kokkos::DualView<const char*,
+                                     buffer_device_type>& imports,
+                                   const Kokkos::DualView<const size_t*,
+                                     buffer_device_type>& numPacketsPerLID,
+                                   const size_t constantNumPackets,
+                                   Distributor& distor,
+                                   const CombineMode combineMode);
 
   public:
     /// \brief Unpack the imported column indices and values, and
-    ///   combine into matrix; implements "new" DistObject interface.
+    ///   combine into matrix.
     ///
-    /// \warning The allowed \c combineMode depends on whether the
+    /// \warning The allowed CombineMode depends on whether the
     ///   matrix's graph is static or dynamic.  ADD, REPLACE, and
-    ///   ABSMAX are valid for a static graph, but INSERT is not.
-    ///   ADD and INSERT are valid for a dynamic graph; ABSMAX and
-    ///   REPLACE have not yet been implemented (and would require
-    ///   serious changes to matrix assembly in order to implement
-    ///   sensibly).
+    ///   ABSMAX are valid for a static graph, but INSERT is not.  ADD
+    ///   and INSERT are valid for a dynamic graph; ABSMAX and REPLACE
+    ///   have not yet been implemented (and would require serious
+    ///   changes to matrix assembly in order to implement sensibly).
     void
-    unpackAndCombineNew (const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& importLIDs,
-                         Kokkos::DualView<char*, buffer_device_type> imports,
-                         Kokkos::DualView<size_t*, buffer_device_type> numPacketsPerLID,
-                         const size_t constantNumPackets,
-                         Distributor& distor,
-                         const CombineMode CM) override;
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+    unpackAndCombineNew
+#else // TPETRA_ENABLE_DEPRECATED_CODE
+    unpackAndCombine
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+    (const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& importLIDs,
+     Kokkos::DualView<char*, buffer_device_type> imports,
+     Kokkos::DualView<size_t*, buffer_device_type> numPacketsPerLID,
+     const size_t constantNumPackets,
+     Distributor& distor,
+     const CombineMode CM) override;
 
     /// \brief Pack this object's data for an Import or Export.
     ///
@@ -4071,9 +4087,9 @@ namespace Tpetra {
              Distributor& dist) const;
 
   private:
-    /// \brief Pack this matrix (part of implementation of packAndPrepareNew).
+    /// \brief Pack this matrix (part of implementation of packAndPrepare).
     ///
-    /// This method helps implement packAndPrepareNew.
+    /// This method helps implement packAndPrepare.
     ///
     /// Call this only when this matrix (which is the source matrix to
     /// pack) does not yet have a KokkosSparse::CrsMatrix.
@@ -4187,7 +4203,7 @@ namespace Tpetra {
 
     /// \brief Allocate space for packNew() to pack entries to send.
     ///
-    /// This is part of the implementation of packAndPrepareNew, which
+    /// This is part of the implementation of packAndPrepare, which
     /// helps implement the "new" DistObject interface.
     ///
     /// \param exports [in/out] Pack buffer to (re)allocate.

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -752,7 +752,7 @@ namespace Tpetra {
   }
 
 
-  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>    
+  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::CrsMatrix(const CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>& source,
                                                                   const Teuchos::DataAccess copyOrView)
     :CrsMatrix(source.getCrsGraph(),source.getLocalValuesView())
@@ -762,10 +762,10 @@ namespace Tpetra {
 
     if (copyOrView == Teuchos::Copy) {
       typename local_matrix_type::values_type vals = source.getLocalValuesView();
-      typename local_matrix_type::values_type newvals; 
+      typename local_matrix_type::values_type newvals;
       Kokkos::resize(newvals,vals.extent(0));
       Kokkos::deep_copy(newvals,vals);
-      k_values1D_ = newvals;   
+      k_values1D_ = newvals;
       if (source.isFillComplete ()) {
         this->fillComplete(source.getDomainMap(),source.getRangeMap());
       }
@@ -781,7 +781,7 @@ namespace Tpetra {
                                             << Teuchos::View << ".");
     }
   }
-  
+
 
 
   template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -6621,14 +6621,6 @@ namespace Tpetra {
     const row_matrix_type* srcRowMat =
       dynamic_cast<const row_matrix_type*> (&source);
     return (srcRowMat != NULL);
-  }
-
-  template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-  bool
-  CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  useNewInterface ()
-  {
-    return true;
   }
 
   template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -6772,18 +6772,23 @@ namespace Tpetra {
   template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void
   CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  copyAndPermuteNew (const SrcDistObject& srcObj,
-                     const size_t numSameIDs,
-                     const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& permuteToLIDs,
-                     const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& permuteFromLIDs)
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+  copyAndPermuteNew
+#else // TPETRA_ENABLE_DEPRECATED_CODE
+  copyAndPermute
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+  (const SrcDistObject& srcObj,
+   const size_t numSameIDs,
+   const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& permuteToLIDs,
+   const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& permuteFromLIDs)
   {
     using Tpetra::Details::dualViewStatusToString;
     using Tpetra::Details::ProfilingRegion;
     using std::endl;
 
     // Method name string for TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC.
-    const char tfecfFuncName[] = "copyAndPermuteNew: ";
-    ProfilingRegion regionCAP ("Tpetra::CrsMatrix::copyAndPermuteNew");
+    const char tfecfFuncName[] = "copyAndPermute: ";
+    ProfilingRegion regionCAP ("Tpetra::CrsMatrix::copyAndPermute");
 
     const bool verbose = ::Tpetra::Details::Behavior::verbose ();
     std::unique_ptr<std::string> prefix;
@@ -6798,7 +6803,7 @@ namespace Tpetra {
       }
       prefix = [myRank] () {
         std::ostringstream pfxStrm;
-        pfxStrm << "Proc " << myRank << ": Tpetra::CrsMatrix::copyAndPermuteNew: ";
+        pfxStrm << "Proc " << myRank << ": Tpetra::CrsMatrix::copyAndPermute: ";
         return std::unique_ptr<std::string> (new std::string (pfxStrm.str ()));
       } ();
       std::ostringstream os;
@@ -6839,12 +6844,17 @@ namespace Tpetra {
   template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void
   CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  packAndPrepareNew (const SrcDistObject& source,
-                     const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& exportLIDs,
-                     Kokkos::DualView<char*, buffer_device_type>& exports,
-                     Kokkos::DualView<size_t*, buffer_device_type> numPacketsPerLID,
-                     size_t& constantNumPackets,
-                     Distributor& distor)
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+  packAndPrepareNew
+#else // TPETRA_ENABLE_DEPRECATED_CODE
+  packAndPrepare
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+  (const SrcDistObject& source,
+   const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& exportLIDs,
+   Kokkos::DualView<char*, buffer_device_type>& exports,
+   Kokkos::DualView<size_t*, buffer_device_type> numPacketsPerLID,
+   size_t& constantNumPackets,
+   Distributor& distor)
   {
     using Tpetra::Details::dualViewStatusToString;
     using Tpetra::Details::ProfilingRegion;
@@ -6854,8 +6864,8 @@ namespace Tpetra {
     using std::endl;
     typedef LocalOrdinal LO;
     typedef GlobalOrdinal GO;
-    const char tfecfFuncName[] = "packAndPrepareNew: ";
-    ProfilingRegion regionPAP ("Tpetra::CrsMatrix::packAndPrepareNew");
+    const char tfecfFuncName[] = "packAndPrepare: ";
+    ProfilingRegion regionPAP ("Tpetra::CrsMatrix::packAndPrepare");
 
     const bool debug = ::Tpetra::Details::Behavior::debug ();
     const bool verbose = ::Tpetra::Details::Behavior::verbose ();
@@ -6872,7 +6882,7 @@ namespace Tpetra {
     if (verbose) {
       prefix = [myRank] () {
         std::ostringstream pfxStrm;
-        pfxStrm << "Proc " << myRank << ": Tpetra::CrsMatrix::packAndPrepareNew: ";
+        pfxStrm << "Proc " << myRank << ": Tpetra::CrsMatrix::packAndPrepare: ";
         return std::unique_ptr<std::string> (new std::string (pfxStrm.str ()));
       } ();
       std::ostringstream os;
@@ -7035,7 +7045,7 @@ namespace Tpetra {
 
     if (verbose) {
       std::ostringstream os;
-      os << *prefix << "packAndPrepareNew: Done!" << endl
+      os << *prefix << "packAndPrepare: Done!" << endl
          << *prefix << "  "
          << dualViewStatusToString (exportLIDs, "exportLIDs")
          << endl
@@ -7335,7 +7345,7 @@ namespace Tpetra {
            size_t& constantNumPackets,
            Distributor& dist) const
   {
-    // The call to packNew in packAndPrepareNew catches and handles any exceptions.
+    // The call to packNew in packAndPrepare catches and handles any exceptions.
     if (this->isStaticGraph ()) {
       using ::Tpetra::Details::packCrsMatrixNew;
       packCrsMatrixNew (*this, exports, numPacketsPerLID, exportLIDs,
@@ -7642,18 +7652,23 @@ namespace Tpetra {
   template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void
   CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  unpackAndCombineNew (const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& importLIDs,
-                       Kokkos::DualView<char*, buffer_device_type> imports,
-                       Kokkos::DualView<size_t*, buffer_device_type> numPacketsPerLID,
-                       const size_t constantNumPackets,
-                       Distributor& distor,
-                       const CombineMode combineMode)
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+  unpackAndCombineNew
+#else // TPETRA_ENABLE_DEPRECATED_CODE
+  unpackAndCombine
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+  (const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& importLIDs,
+   Kokkos::DualView<char*, buffer_device_type> imports,
+   Kokkos::DualView<size_t*, buffer_device_type> numPacketsPerLID,
+   const size_t constantNumPackets,
+   Distributor& distor,
+   const CombineMode combineMode)
   {
     using Tpetra::Details::dualViewStatusToString;
     using Tpetra::Details::ProfilingRegion;
     using std::endl;
-    const char tfecfFuncName[] = "unpackAndCombineNew: ";
-    ProfilingRegion regionUAC ("Tpetra::CrsMatrix::unpackAndCombineNew");
+    const char tfecfFuncName[] = "unpackAndCombine: ";
+    ProfilingRegion regionUAC ("Tpetra::CrsMatrix::unpackAndCombine");
 
     const bool debug = ::Tpetra::Details::Behavior::debug ();
     const bool verbose = ::Tpetra::Details::Behavior::verbose ();
@@ -7675,7 +7690,7 @@ namespace Tpetra {
       }
       prefix = [myRank] () {
         std::ostringstream pfxStrm;
-        pfxStrm << "Proc " << myRank << ": Tpetra::CrsMatrix::unpackAndCombineNew: ";
+        pfxStrm << "Proc " << myRank << ": Tpetra::CrsMatrix::unpackAndCombine: ";
         return std::unique_ptr<std::string> (new std::string (pfxStrm.str ()));
       } ();
       std::ostringstream os;
@@ -7722,8 +7737,8 @@ namespace Tpetra {
       std::unique_ptr<std::ostringstream> msg (new std::ostringstream ());
       int lclBad = 0;
       try {
-        this->unpackAndCombineNewImpl (importLIDs, imports, numPacketsPerLID,
-                                       constantNumPackets, distor, combineMode);
+        this->unpackAndCombineImpl (importLIDs, imports, numPacketsPerLID,
+                                    constantNumPackets, distor, combineMode);
       } catch (std::exception& e) {
         lclBad = 1;
         *msg << e.what ();
@@ -7742,14 +7757,14 @@ namespace Tpetra {
         msg = std::unique_ptr<std::ostringstream> (new std::ostringstream ());
         ::Tpetra::Details::gathervPrint (*msg, os.str (), comm);
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-          (true, std::logic_error, std::endl << "unpackAndCombineNewImpl() "
+          (true, std::logic_error, std::endl << "unpackAndCombineImpl "
            "threw an exception on one or more participating processes: "
            << endl << msg->str ());
       }
     }
     else {
-      this->unpackAndCombineNewImpl (importLIDs, imports, numPacketsPerLID,
-                                     constantNumPackets, distor, combineMode);
+      this->unpackAndCombineImpl (importLIDs, imports, numPacketsPerLID,
+                                  constantNumPackets, distor, combineMode);
     }
 
     if (verbose) {
@@ -7771,16 +7786,16 @@ namespace Tpetra {
   template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void
   CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  unpackAndCombineNewImpl (const Kokkos::DualView<const local_ordinal_type*,
-                             buffer_device_type>& importLIDs,
-                           const Kokkos::DualView<const char*,
-                             buffer_device_type>& imports,
-                           const Kokkos::DualView<const size_t*,
-                             buffer_device_type>& numPacketsPerLID,
-                           const size_t constantNumPackets,
-                           Distributor & distor,
-                           const CombineMode combineMode,
-                           const bool atomic)
+  unpackAndCombineImpl (const Kokkos::DualView<const local_ordinal_type*,
+                          buffer_device_type>& importLIDs,
+                        const Kokkos::DualView<const char*,
+                          buffer_device_type>& imports,
+                        const Kokkos::DualView<const size_t*,
+                          buffer_device_type>& numPacketsPerLID,
+                        const size_t constantNumPackets,
+                        Distributor & distor,
+                        const CombineMode combineMode,
+                        const bool atomic)
   {
     // Exception are caught and handled upstream, so we just call the
     // implementations directly.
@@ -7791,25 +7806,25 @@ namespace Tpetra {
                                     distor, combineMode, atomic);
     }
     else {
-      this->unpackAndCombineNewImplNonStatic (importLIDs, imports,
-                                              numPacketsPerLID,
-                                              constantNumPackets,
-                                              distor, combineMode);
+      this->unpackAndCombineImplNonStatic (importLIDs, imports,
+                                           numPacketsPerLID,
+                                           constantNumPackets,
+                                           distor, combineMode);
     }
   }
 
   template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void
   CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  unpackAndCombineNewImplNonStatic (const Kokkos::DualView<const local_ordinal_type*,
-                                      buffer_device_type>& importLIDs,
-                                    const Kokkos::DualView<const char*,
-                                      buffer_device_type>& imports,
-                                    const Kokkos::DualView<const size_t*,
-                                      buffer_device_type>& numPacketsPerLID,
-                                    const size_t /* constantNumPackets */,
-                                    Distributor& /* distor */,
-                                    const CombineMode combineMode)
+  unpackAndCombineImplNonStatic (const Kokkos::DualView<const local_ordinal_type*,
+                                   buffer_device_type>& importLIDs,
+                                 const Kokkos::DualView<const char*,
+                                   buffer_device_type>& imports,
+                                 const Kokkos::DualView<const size_t*,
+                                   buffer_device_type>& numPacketsPerLID,
+                                 const size_t /* constantNumPackets */,
+                                 Distributor& /* distor */,
+                                 const CombineMode combineMode)
   {
     using Kokkos::View;
     using Kokkos::subview;
@@ -7827,7 +7842,7 @@ namespace Tpetra {
                       typename View<int*, HES>::size_type> pair_type;
     typedef View<GO*, HES, MemoryUnmanaged> gids_out_type;
     typedef View<ST*, HES, MemoryUnmanaged> vals_out_type;
-    const char tfecfFuncName[] = "unpackAndCombineNewImplNonStatic: ";
+    const char tfecfFuncName[] = "unpackAndCombineImplNonStatic: ";
 
     // mfh 18 Oct 2017: Set TPETRA_VERBOSE to true for copious debug
     // output to std::cerr on every MPI process.  This is unwise for
@@ -7847,7 +7862,7 @@ namespace Tpetra {
       prefix = [myRank] () {
         std::ostringstream pfxStrm;
         pfxStrm << "Proc " << myRank << ": Tpetra::CrsMatrix::"
-        "unpackAndCombineNewImplNonStatic: ";
+        "unpackAndCombineImplNonStatic: ";
         return std::unique_ptr<std::string> (new std::string (pfxStrm.str ()));
       } ();
 

--- a/packages/tpetra/core/src/Tpetra_Details_packCrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_packCrsGraph_decl.hpp
@@ -149,13 +149,13 @@ packCrsGraph (const CrsGraph<LO, GO, NT>& sourceGraph,
 /// \param exportLIDs [in] Local indices of the rows to pack.
 ///
 /// \param constantNumPackets [out] Same as the constantNumPackets
-///   output argument of Tpetra::DistObject::packAndPrepareNew (which
+///   output argument of Tpetra::DistObject::packAndPrepare (which
 ///   see).
 ///
 /// \param distor [in] (Not used.)
 ///
 /// This method implements CrsGraph::packNew, and thus
-/// CrsGraph::packAndPrepareNew, for the case where the graph to
+/// CrsGraph::packAndPrepare, for the case where the graph to
 /// pack has a valid KokkosSparse::CrsGraph.
 template<typename LO, typename GO, typename NT>
 void

--- a/packages/tpetra/core/src/Tpetra_Details_packCrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_packCrsMatrix_decl.hpp
@@ -155,13 +155,13 @@ packCrsMatrix (const CrsMatrix<ST, LO, GO, NT>& sourceMatrix,
 /// \param exportLIDs [in] Local indices of the rows to pack.
 ///
 /// \param constantNumPackets [out] Same as the constantNumPackets
-///   output argument of Tpetra::DistObject::packAndPrepareNew (which
+///   output argument of Tpetra::DistObject::packAndPrepare (which
 ///   see).
 ///
 /// \param distor [in] (Not used.)
 ///
 /// This method implements CrsMatrix::packNew, and thus
-/// CrsMatrix::packAndPrepareNew, for the case where the matrix to
+/// CrsMatrix::packAndPrepare, for the case where the matrix to
 /// pack has a valid KokkosSparse::CrsMatrix.
 template<typename ST, typename LO, typename GO, typename NT>
 void

--- a/packages/tpetra/core/src/Tpetra_DistObject_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_DistObject_decl.hpp
@@ -305,9 +305,9 @@ namespace Tpetra {
   /// <i>must</i> implement at least the following methods:
   /// <ul>
   /// <li> checkSizes() </li>
-  /// <li> copyAndPermuteNew() </li>
-  /// <li> packAndPrepareNew() </li>
-  /// <li> unpackAndCombineNew() </li>
+  /// <li> copyAndPermute() </li>
+  /// <li> packAndPrepare() </li>
+  /// <li> unpackAndCombine() </li>
   /// </ul>
   /// You <i>may</i> also implement constantNumberOfPackets(), if
   /// appropriate.
@@ -400,11 +400,13 @@ namespace Tpetra {
     /// Import, else use doExport() with a precomputed Export object.
     ///
     /// "Restricted Mode" does two things:
-    /// 1) Skips copyAndPermute
-    /// 2) Allows the "target" map of the transfer to be a subset of the map of this, in a "locallyFitted" sense.
-    //
-    /// This cannot be used if #2 is not true, OR there are permutes.
-    /// The "source" maps still need to match
+    /// <ol>
+    /// <li> Skips copyAndPermute </li>
+    /// <li> Allows the "target" Map of the transfer to be a subset of
+    ///      the Map of <tt>*this</tt>, in a "locallyFitted" sense. </li>
+    /// </ol>
+    /// This cannot be used if (2) is not true, OR there are permutes.
+    /// The "source" maps still need to match.
     ///
     /// \param source [in] The "source" object for redistribution.
     /// \param importer [in] Precomputed data redistribution plan.
@@ -415,7 +417,8 @@ namespace Tpetra {
     void
     doImport (const SrcDistObject& source,
               const Import<LocalOrdinal, GlobalOrdinal, Node>& importer,
-              CombineMode CM, bool restrictedMode = false);
+              const CombineMode CM,
+              const bool restrictedMode = false);
 
     /// \brief Export data into this object using an Export object
     ///   ("forward mode").
@@ -430,11 +433,13 @@ namespace Tpetra {
     /// Export, else use doImport() with a precomputed Import object.
     ///
     /// "Restricted Mode" does two things:
-    /// 1) Skips copyAndPermute
-    /// 2) Allows the "target" map of the transfer to be a subset of the map of this, in a "locallyFitted" sense.
-    //
-    /// This cannot be used if #2 is not true, OR there are permutes.
-    /// The "source" maps still need to match
+    /// <ol>
+    /// <li> Skips copyAndPermute </li>
+    /// <li> Allows the "target" Map of the transfer to be a subset of
+    ///      the Map of <tt>*this</tt>, in a "locallyFitted" sense. </li>
+    /// </ol>
+    /// This cannot be used if (2) is not true, OR there are permutes.
+    /// The "source" maps still need to match.
     ///
     /// \param source [in] The "source" object for redistribution.
     /// \param exporter [in] Precomputed data redistribution plan.
@@ -445,7 +450,8 @@ namespace Tpetra {
     void
     doExport (const SrcDistObject& source,
               const Export<LocalOrdinal, GlobalOrdinal, Node>& exporter,
-              CombineMode CM, bool restrictedMode = false);
+              const CombineMode CM,
+              const bool restrictedMode = false);
 
     /// \brief Import data into this object using an Export object
     ///   ("reverse mode").
@@ -460,11 +466,13 @@ namespace Tpetra {
     /// case.
     ///
     /// "Restricted Mode" does two things:
-    /// 1) Skips copyAndPermute
-    /// 2) Allows the "target" map of the transfer to be a subset of the map of this, in a "locallyFitted" sense.
-    //
-    /// This cannot be used if #2 is not true, OR there are permutes.
-    /// The "source" maps still need to match
+    /// <ol>
+    /// <li> Skips copyAndPermute </li>
+    /// <li> Allows the "target" Map of the transfer to be a subset of
+    ///      the Map of <tt>*this</tt>, in a "locallyFitted" sense. </li>
+    /// </ol>
+    /// This cannot be used if (2) is not true, OR there are permutes.
+    /// The "source" maps still need to match.
     ///
     /// \param source [in] The "source" object for redistribution.
     /// \param exporter [in] Precomputed data redistribution plan.
@@ -476,7 +484,8 @@ namespace Tpetra {
     void
     doImport (const SrcDistObject& source,
               const Export<LocalOrdinal, GlobalOrdinal, Node>& exporter,
-              CombineMode CM, bool restrictedMode = false);
+              const CombineMode CM,
+              const bool restrictedMode = false);
 
     /// \brief Export data into this object using an Import object
     ///   ("reverse mode").
@@ -491,11 +500,13 @@ namespace Tpetra {
     /// case.
     ///
     /// "Restricted Mode" does two things:
-    /// 1) Skips copyAndPermute
-    /// 2) Allows the "target" map of the transfer to be a subset of the map of this, in a "locallyFitted" sense.
-    //
-    /// This cannot be used if #2 is not true, OR there are permutes.
-    /// The "source" maps still need to match
+    /// <ol>
+    /// <li> Skips copyAndPermute </li>
+    /// <li> Allows the "target" Map of the transfer to be a subset of
+    ///      the Map of <tt>*this</tt>, in a "locallyFitted" sense. </li>
+    /// </ol>
+    /// This cannot be used if (2) is not true, OR there are permutes.
+    /// The "source" maps still need to match.
     ///
     /// \param source [in] The "source" object for redistribution.
     /// \param importer [in] Precomputed data redistribution plan.
@@ -507,7 +518,8 @@ namespace Tpetra {
     void
     doExport (const SrcDistObject& source,
               const Import<LocalOrdinal, GlobalOrdinal, Node>& importer,
-              CombineMode CM, bool restrictedMode = false);
+              const CombineMode CM,
+              const bool restrictedMode = false);
 
     //@}
     //! @name Attribute accessor methods
@@ -776,6 +788,7 @@ namespace Tpetra {
     virtual bool
     checkSizes (const SrcDistObject& source) = 0;
 
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
     /// \brief Perform copies and permutations that are local to the
     ///   calling (MPI) process.
     ///
@@ -809,7 +822,43 @@ namespace Tpetra {
                          buffer_device_type>& permuteToLIDs,
                        const Kokkos::DualView<const local_ordinal_type*,
                          buffer_device_type>& permuteFromLIDs);
+#else // TPETRA_ENABLE_DEPRECATED_CODE
+    /// \brief Perform copies and permutations that are local to the
+    ///   calling (MPI) process.
+    ///
+    /// Subclasses <i>must</i> reimplement this function.  Its default
+    /// implementation does nothing.  Note that the <t>target</i>
+    /// object of the Export or Import, namely <tt>*this</tt>, packs
+    /// the <i>source</i> object's data.
+    ///
+    /// \pre permuteToLIDs and permuteFromLIDs are sync'd to both host
+    ///   and device.  That is,
+    ///   <tt>permuteToLIDs.need_sync_host()</tt>,
+    ///   <tt>permuteToLIDs.need_sync_device()</tt>,
+    ///   <tt>permuteFromLIDs.need_sync_host()</tt>, and
+    ///   <tt>permuteFromLIDs.need_sync_device()</tt> are all false.
+    ///
+    /// \param source [in] On entry, the source object of the Export
+    ///   or Import operation.
+    /// \param numSameIDs [in] The number of elements that are the
+    ///   same on the source and target objects.  These elements live
+    ///   on the same process in both the source and target objects.
+    /// \param permuteToLIDs [in] List of the elements that are
+    ///   permuted.  They are listed by their local index (LID) in the
+    ///   destination object.
+    /// \param permuteFromLIDs [in] List of the elements that are
+    ///   permuted.  They are listed by their local index (LID) in the
+    ///   source object.
+    virtual void
+    copyAndPermute (const SrcDistObject& source,
+                    const size_t numSameIDs,
+                    const Kokkos::DualView<const local_ordinal_type*,
+                      buffer_device_type>& permuteToLIDs,
+                    const Kokkos::DualView<const local_ordinal_type*,
+                      buffer_device_type>& permuteFromLIDs);
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
 
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
     /// \brief Pack data and metadata for communication (sends).
     ///
     /// Subclasses <i>must</i> reimplement this function.  Its default
@@ -860,7 +909,60 @@ namespace Tpetra {
                          buffer_device_type> numPacketsPerLID,
                        size_t& constantNumPackets,
                        Distributor& distor);
+#else // TPETRA_ENABLE_DEPRECATED_CODE
+    /// \brief Pack data and metadata for communication (sends).
+    ///
+    /// Subclasses <i>must</i> reimplement this function.  Its default
+    /// implementation does nothing.  Note that the <t>target</i>
+    /// object of the Export or Import, namely <tt>*this</tt>, packs
+    /// the <i>source</i> object's data.
+    ///
+    /// \pre exportLIDs is sync'd to both host and device.  That is,
+    ///   <tt>exportLIDs.need_sync_host ()</tt> and
+    ///   <tt>exportLIDs.need_sync_device()</tt> are both false.
+    ///
+    /// \param source [in] Source object for the redistribution.
+    ///
+    /// \param exportLIDs [in] List of the entries (as local IDs in
+    ///   the source object) that Tpetra will send to other processes.
+    ///
+    /// \param exports [out] On exit, the packed data to send.
+    ///   Implementations must reallocate this as needed (prefer
+    ///   reusing the existing allocation if possible), and may modify
+    ///   and/or sync this wherever they like.
+    ///
+    /// \param numPacketsPerLID [out] On exit, the implementation of
+    ///   this method must do one of two things: either set
+    ///   <tt>numPacketsPerLID[i]</tt> to the number of packets to be
+    ///   packed for <tt>exportLIDs[i]</tt> and set
+    ///   <tt>constantNumPackets</tt> to zero, or set
+    ///   <tt>constantNumPackets</tt> to a nonzero value.  If the
+    ///   latter, the implementation must not modify the entries of
+    ///   <tt>numPacketsPerLID</tt>.  If the former, the
+    ///   implementation may sync <tt>numPacketsPerLID</tt> this
+    ///   wherever it likes, either to host or to device.  The
+    ///   allocation belongs to DistObject, not to subclasses; don't
+    ///   be tempted to change this to pass by reference.
+    ///
+    /// \param constantNumPackets [out] On exit, 0 if the number of
+    ///   packets per LID could differ, else (if nonzero) the number
+    ///   of packets per LID (which must be constant).
+    ///
+    /// \param distor [in] The Distributor object we are using.  Most
+    ///   implementations will not use this.
+    virtual void
+    packAndPrepare (const SrcDistObject& source,
+                    const Kokkos::DualView<const local_ordinal_type*,
+                      buffer_device_type>& exportLIDs,
+                    Kokkos::DualView<packet_type*,
+                      buffer_device_type>& exports,
+                    Kokkos::DualView<size_t*,
+                      buffer_device_type> numPacketsPerLID,
+                    size_t& constantNumPackets,
+                    Distributor& distor);
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
 
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
     /// \brief Perform any unpacking and combining after
     ///   communication.
     ///
@@ -913,31 +1015,66 @@ namespace Tpetra {
                          const size_t constantNumPackets,
                          Distributor& distor,
                          const CombineMode combineMode);
+#else // TPETRA_ENABLE_DEPRECATED_CODE
+    /// \brief Perform any unpacking and combining after
+    ///   communication.
+    ///
+    /// Subclasses <i>must</i> reimplement this function.  Its default
+    /// implementation does nothing.  Note that the <t>target</i>
+    /// object of the Export or Import, namely <tt>*this</tt>, unpacks
+    /// the received data into itself, possibly modifying its entries.
+    ///
+    /// \pre importLIDs is sync'd to both host and device.  That is,
+    ///   <tt>importLIDs.need_sync_host ()</tt> and
+    ///   <tt>importLIDs.need_sync_device()</tt> are both false.
+    ///
+    /// \param importLIDs [in] List of the entries (as LIDs in the
+    ///   destination object) we received from other processes.
+    ///
+    /// \param imports [in/out] On input: Buffer of received data to
+    ///   unpack.  DistObject promises nothing about where this is
+    ///   sync'd.  Implementations may sync this wherever they like,
+    ///   either to host or to device.  The allocation belongs to
+    ///   DistObject, not to subclasses; don't be tempted to change
+    ///   this to pass by reference.
+    ///
+    /// \param numPacketsPerLID [in/out] On input: If
+    ///   <tt>constantNumPackets</tt> is zero, then
+    ///   <tt>numPacketsPerLID[i]</tt> contains the number of packets
+    ///   imported for </tt>importLIDs[i]</tt>.  DistObject promises
+    ///   nothing about where this is sync'd.  Implementations may
+    ///   sync this wherever they like, either to host or to device.
+    ///   The allocation belongs to DistObject, not to subclasses;
+    ///   don't be tempted to change this to pass by reference.
+    ///
+    /// \param constantNumPackets [in] If nonzero, then the number of
+    ///   packets per LID is the same for all entries ("constant") and
+    ///   <tt>constantNumPackets</tt> is that number.  If zero, then
+    ///   <tt>numPacketsPerLID[i]</tt> is the number of packets to
+    ///   unpack for LID <tt>importLIDs[i]</tt>.
+    ///
+    /// \param distor [in] The Distributor object we are using.  Most
+    ///   implementations will not use this.
+    ///
+    /// \param combineMode [in] The CombineMode to use when combining
+    ///   the imported entries with existing entries.
+    virtual void
+    unpackAndCombine (const Kokkos::DualView<const local_ordinal_type*,
+                        buffer_device_type>& importLIDs,
+                      Kokkos::DualView<packet_type*,
+                        buffer_device_type> imports,
+                      Kokkos::DualView<size_t*,
+                        buffer_device_type> numPacketsPerLID,
+                      const size_t constantNumPackets,
+                      Distributor& distor,
+                      const CombineMode combineMode);
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
 
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE
     /// \brief Whether the subclass implements the "new" or "old" interface.
     ///
     /// \warning This method is DEPRECATED.  Do not call it, and do
     ///   not implement it in your subclasses of DistObject.
-    ///
-    /// The "new" interface consists of the following methods:
-    /// <ul>
-    /// <li> copyAndPermuteNew </li>
-    /// <li> packAndPrepareNew </li>
-    /// <li> unpackAndCombineNew </li>
-    /// </ul>
-    /// The "old" interface has been deprecated (see GitHub issue
-    /// #4853) and will be removed soon.  It consists of the following
-    /// methods:
-    /// <ul>
-    /// <li> copyAndPermute </li>
-    /// <li> packAndPrepare </li>
-    /// <li> unpackAndCombine </li>
-    /// </ul>
-    /// The <tt>checkSizes</tt> method belongs to both interfaces.
-    ///
-    /// The old interface is deprecated.  New subclasses of DistObject
-    /// must always implement the new interface.
     virtual bool TPETRA_DEPRECATED useNewInterface () { return true; }
 
     /// \brief Perform copies and permutations that are local to this
@@ -1026,7 +1163,7 @@ namespace Tpetra {
     /// \return Whether we actually reallocated.
     ///
     /// We don't need a "reallocExportsIfNeeded" method, because
-    /// <tt>exports_</tt> always gets passed into packAndPrepareNew()
+    /// <tt>exports_</tt> always gets passed into packAndPrepare()
     /// by nonconst reference.  Thus, that method can resize the
     /// DualView without needing to call other DistObject methods.
     bool

--- a/packages/tpetra/core/src/Tpetra_DistObject_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_DistObject_decl.hpp
@@ -301,41 +301,20 @@ namespace Tpetra {
   ///
   /// \section Tpetra_DistObject_ImplSubclass How to implement a subclass
   ///
-  /// If you want to implement your own DistObject subclass, you have
-  /// two choices of interface to implement: "old" (using Teuchos
-  /// memory management classes, like Teuchos::ArrayRCP and
-  /// Teuchos::ArrayView) or "new" (using Kokkos memory management
-  /// classes, like Kokkos::View and Kokkos::DualView).  Prefer new to
-  /// old.  The new interface gives you more options for thread
-  /// parallelism and use of the GPU.
-  ///
-  /// If you intend to implement the new interface, you must override
-  /// useNewInterface() to return \c true.  In that case, your class
-  /// must override the following methods:
+  /// If you want to implement your own DistObject subclass, you
+  /// <i>must</i> implement at least the following methods:
   /// <ul>
-  /// <li> constantNumberOfPackets() </li>
   /// <li> checkSizes() </li>
   /// <li> copyAndPermuteNew() </li>
   /// <li> packAndPrepareNew() </li>
   /// <li> unpackAndCombineNew() </li>
   /// </ul>
-  /// Comments in the implementation of doTransferNew() explain how
-  /// DistObject uses these methods to pack and unpack data for
-  /// redistribution.
+  /// You <i>may</i> also implement constantNumberOfPackets(), if
+  /// appropriate.
   ///
-  /// If you choose to implement the old interface (not recommended),
-  /// you should override the following methods instead:
-  /// <ul>
-  /// <li> constantNumberOfPackets() </li>
-  /// <li> checkSizes() </li>
-  /// <li> copyAndPermute() </li>
-  /// <li> packAndPrepare() </li>
-  /// <li> unpackAndCombine() </li>
-  /// </ul>
-  /// In this case, you may also wish to implement createViews(),
-  /// createViewsNonConst(), and releaseViews().  Comments in the
-  /// implementation of doTransfer() explain how DistObject uses all
-  /// these methods to pack and unpack data for redistribution.
+  /// There is also an "old" interface, which is deprecated (see
+  /// GitHub Issue #4853) and will be removed soon.  Do not implement
+  /// the "old" interface.
   ///
   /// DistObject implements SrcDistObject, because we presume that if
   /// an object can be the target of an Import or Export, it can also
@@ -703,19 +682,20 @@ namespace Tpetra {
     ///
     /// \return Whether we actually reallocated either of the arrays.
     ///
-    /// \warning This is an implementation detail of doTransferOld()
-    ///   and doTransferNew().  This needs to be protected, but that
-    ///   doesn't mean users should call this method.
+    /// \warning This is an implementation detail of doTransferNew().
+    ///   This needs to be protected, but that doesn't mean users
+    ///   should call this method.
     virtual bool
     reallocArraysForNumPacketsPerLid (const size_t numExportLIDs,
                                       const size_t numImportLIDs);
 
-    /// \brief Implementation of doTransfer for when useNewInterface()
-    ///   is false.
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+    /// \brief Implementation of doTransfer for the "old" DistObject
+    ///   interface.
     ///
-    /// LID arrays come from the Transfer object given to doTransfer.
-    /// They <i>always</i> point to host memory.
-    virtual void
+    /// \warning This method is DEPRECATED.  Do not call it, and do
+    ///   not implement it in your subclasses of DistObject.
+    virtual void TPETRA_DEPRECATED
     doTransferOld (const SrcDistObject& src,
                    CombineMode CM,
                    size_t numSameIDs,
@@ -726,6 +706,7 @@ namespace Tpetra {
                    Distributor &distor,
                    ReverseOption revOp,
                    const bool restrictedMode);
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
 
     /// \typedef buffer_memory_space
     /// \brief Kokkos memory space for communication buffers.
@@ -755,8 +736,7 @@ namespace Tpetra {
       Kokkos::Device<typename device_type::execution_space,
                      buffer_memory_space>;
   protected:
-    /// \brief Implementation of doTransfer for when useNewInterface()
-    ///   is true.
+    /// \brief Implementation detail of doTransfer.
     ///
     /// LID DualViews come from the Transfer object given to
     /// doTransfer.  They are <i>always</i> sync'd on both host and
@@ -796,55 +776,13 @@ namespace Tpetra {
     virtual bool
     checkSizes (const SrcDistObject& source) = 0;
 
-    /// \brief Whether the subclass implements the "old" or "new"
-    ///   (Kokkos-friendly) interface.
+    /// \brief Perform copies and permutations that are local to the
+    ///   calling (MPI) process.
     ///
-    /// The "old" interface consists of copyAndPermute,
-    /// packAndPrepare, and unpackAndCombine.  The "new" interface
-    /// consists of copyAndPermuteNew, packAndPrepareNew, and
-    /// unpackAndCombineNew.  The old interface is deprecated; new
-    /// subclasses of DistObject must always implement the new
-    /// interface.
-    virtual bool useNewInterface () { return false; }
-
-    /// \brief Perform copies and permutations that are local to this
-    ///   process; old interface version.
-    ///
-    /// Subclasses for which <tt>useNewInterface()</tt> is false
-    /// <i>must</i> reimplement this function.  Its default
-    /// implementation does nothing.  Note that the <t>target</i>
-    /// object of the Export or Import, namely <tt>*this</tt>, copies
-    /// the <i>source</i> object's data.
-    ///
-    /// \pre <tt>this->useNewInterface()</tt> is false.
-    ///
-    /// \param source [in] On entry, the source object of the Export
-    ///   or Import operation.
-    /// \param numSameIDs [in] The number of elements that are the
-    ///   same on the source and target objects.  These elements live
-    ///   on the same process in both the source and target objects.
-    /// \param permuteToLIDs [in] List of the elements that are
-    ///   permuted.  They are listed by their local index (LID) in the
-    ///   destination object.
-    /// \param permuteFromLIDs [in] List of the elements that are
-    ///   permuted.  They are listed by their local index (LID) in the
-    ///   source object.
-    virtual void
-    copyAndPermute (const SrcDistObject& source,
-                    const size_t numSameIDs,
-                    const Teuchos::ArrayView<const local_ordinal_type>& permuteToLIDs,
-                    const Teuchos::ArrayView<const local_ordinal_type>& permuteFromLIDs);
-
-    /// \brief Perform copies and permutations that are local to this
-    ///   process; new interface version.
-    ///
-    /// Subclasses for which <tt>useNewInterface()</tt> is true
-    /// <i>must</i> reimplement this function.  Its default
+    /// Subclasses <i>must</i> reimplement this function.  Its default
     /// implementation does nothing.  Note that the <t>target</i>
     /// object of the Export or Import, namely <tt>*this</tt>, packs
     /// the <i>source</i> object's data.
-    ///
-    /// \pre <tt>this->useNewInterface()</tt> is true.
     ///
     /// \pre permuteToLIDs and permuteFromLIDs are sync'd to both host
     ///   and device.  That is,
@@ -872,59 +810,12 @@ namespace Tpetra {
                        const Kokkos::DualView<const local_ordinal_type*,
                          buffer_device_type>& permuteFromLIDs);
 
-    /// \brief Pack data and metadata for communication (sends);
-    ///   old interface version.
+    /// \brief Pack data and metadata for communication (sends).
     ///
-    /// Subclasses for which <tt>useNewInterface()</tt> is false
-    /// <i>must</i> reimplement this function.  Its default
+    /// Subclasses <i>must</i> reimplement this function.  Its default
     /// implementation does nothing.  Note that the <t>target</i>
     /// object of the Export or Import, namely <tt>*this</tt>, packs
     /// the <i>source</i> object's data.
-    ///
-    /// \pre <tt>this->useNewInterface()</tt> is false.
-    ///
-    /// \param source [in] Source object for the redistribution.
-    ///
-    /// \param exportLIDs [in] List of the entries (as local IDs in
-    ///   the source object) that Tpetra will send to other processes.
-    ///
-    /// \param exports [out] On exit, the packed data to send.
-    ///   Implementations must reallocate this as needed (prefer
-    ///   reusing the existing allocation if possible).
-    ///
-    /// \param numPacketsPerLID [out] On exit, the implementation of
-    ///   must do one of two things: either set
-    ///   <tt>numPacketsPerLID[i]</tt> to the number of packets to be
-    ///   packed for <tt>exportLIDs[i]</tt> and set
-    ///   <tt>constantNumPackets</tt> to zero, or set
-    ///   <tt>constantNumPackets</tt> to a nonzero value.  If the
-    ///   latter, the implementation must not modify the entries of
-    ///   <tt>numPacketsPerLID</tt>.
-    ///
-    /// \param constantNumPackets [out] On exit, 0 if the number of
-    ///   packets per LID could differ, else (if nonzero) the number
-    ///   of packets per LID (which must be constant).
-    ///
-    /// \param distor [in] The Distributor object we are using.  Most
-    ///   implementations will not use this.
-    virtual void
-    packAndPrepare (const SrcDistObject& source,
-                    const Teuchos::ArrayView<const local_ordinal_type>& exportLIDs,
-                    Teuchos::Array<packet_type>& exports,
-                    const Teuchos::ArrayView<size_t>& numPacketsPerLID,
-                    size_t& constantNumPackets,
-                    Distributor& distor);
-
-    /// \brief Pack data and metadata for communication (sends);
-    ///   new interface version.
-    ///
-    /// Subclasses for which <tt>useNewInterface()</tt> is true
-    /// <i>must</i> reimplement this function.  Its default
-    /// implementation does nothing.  Note that the <t>target</i>
-    /// object of the Export or Import, namely <tt>*this</tt>, packs
-    /// the <i>source</i> object's data.
-    ///
-    /// \pre <tt>this->useNewInterface()</tt> is true.
     ///
     /// \pre exportLIDs is sync'd to both host and device.  That is,
     ///   <tt>exportLIDs.need_sync_host ()</tt> and
@@ -971,55 +862,12 @@ namespace Tpetra {
                        Distributor& distor);
 
     /// \brief Perform any unpacking and combining after
-    ///   communication; old interface version.
+    ///   communication.
     ///
-    /// Subclasses for which <tt>useNewInterface()</tt> is false
-    /// <i>must</i> reimplement this function.  Its default
+    /// Subclasses <i>must</i> reimplement this function.  Its default
     /// implementation does nothing.  Note that the <t>target</i>
     /// object of the Export or Import, namely <tt>*this</tt>, unpacks
     /// the received data into itself, possibly modifying its entries.
-    ///
-    /// \pre <tt>this->useNewInterface()</tt> is false.
-    ///
-    /// \param importLIDs [in] List of the entries (as LIDs in the
-    ///   destination object) we received from other processes.
-    ///
-    /// \param imports [in] Buffer of received data to unpack.
-    ///
-    /// \param numPacketsPerLID [in/out] On input: If
-    ///   <tt>constantNumPackets</tt> is zero, then
-    ///   <tt>numPacketsPerLID[i]</tt> contains the number of packets
-    ///   imported for </tt>importLIDs[i]</tt>.
-    ///
-    /// \param constantNumPackets [in] If nonzero, then the number of
-    ///   packets per LID is the same for all entries ("constant") and
-    ///   <tt>constantNumPackets</tt> is that number.  If zero, then
-    ///   <tt>numPacketsPerLID[i]</tt> is the number of packets to
-    ///   unpack for LID <tt>importLIDs[i]</tt>.
-    ///
-    /// \param distor [in] The Distributor object we are using.  Most
-    ///   implementations will not use this.
-    ///
-    /// \param combineMode [in] The CombineMode to use when combining the
-    ///   imported entries with existing entries.
-    virtual void
-    unpackAndCombine (const Teuchos::ArrayView<const local_ordinal_type>& importLIDs,
-                      const Teuchos::ArrayView<const packet_type>& imports,
-                      const Teuchos::ArrayView<size_t>& numPacketsPerLID,
-                      const size_t constantNumPackets,
-                      Distributor& distor,
-                      const CombineMode combineMode);
-
-    /// \brief Perform any unpacking and combining after
-    ///   communication; new interface version.
-    ///
-    /// Subclasses for which <tt>useNewInterface()</tt> is true
-    /// <i>must</i> reimplement this function.  Its default
-    /// implementation does nothing.  Note that the <t>target</i>
-    /// object of the Export or Import, namely <tt>*this</tt>, unpacks
-    /// the received data into itself, possibly modifying its entries.
-    ///
-    /// \pre <tt>this->useNewInterface()</tt> is true.
     ///
     /// \pre importLIDs is sync'd to both host and device.  That is,
     ///   <tt>importLIDs.need_sync_host ()</tt> and
@@ -1065,48 +913,91 @@ namespace Tpetra {
                          const size_t constantNumPackets,
                          Distributor& distor,
                          const CombineMode combineMode);
+
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+    /// \brief Whether the subclass implements the "new" or "old" interface.
+    ///
+    /// \warning This method is DEPRECATED.  Do not call it, and do
+    ///   not implement it in your subclasses of DistObject.
+    ///
+    /// The "new" interface consists of the following methods:
+    /// <ul>
+    /// <li> copyAndPermuteNew </li>
+    /// <li> packAndPrepareNew </li>
+    /// <li> unpackAndCombineNew </li>
+    /// </ul>
+    /// The "old" interface has been deprecated (see GitHub issue
+    /// #4853) and will be removed soon.  It consists of the following
+    /// methods:
+    /// <ul>
+    /// <li> copyAndPermute </li>
+    /// <li> packAndPrepare </li>
+    /// <li> unpackAndCombine </li>
+    /// </ul>
+    /// The <tt>checkSizes</tt> method belongs to both interfaces.
+    ///
+    /// The old interface is deprecated.  New subclasses of DistObject
+    /// must always implement the new interface.
+    virtual bool TPETRA_DEPRECATED useNewInterface () { return true; }
+
+    /// \brief Perform copies and permutations that are local to this
+    ///   process; old interface version.
+    ///
+    /// \warning This method is DEPRECATED.  Do not call it, and do
+    ///   not implement it in your subclasses of DistObject.
+    virtual void TPETRA_DEPRECATED
+    copyAndPermute (const SrcDistObject& source,
+                    const size_t numSameIDs,
+                    const Teuchos::ArrayView<const local_ordinal_type>& permuteToLIDs,
+                    const Teuchos::ArrayView<const local_ordinal_type>& permuteFromLIDs);
+
+    /// \brief Pack data and metadata for communication (sends);
+    ///   old interface version.
+    ///
+    /// \warning This method is DEPRECATED.  Do not call it, and do
+    ///   not implement it in your subclasses of DistObject.
+    virtual void TPETRA_DEPRECATED
+    packAndPrepare (const SrcDistObject& source,
+                    const Teuchos::ArrayView<const local_ordinal_type>& exportLIDs,
+                    Teuchos::Array<packet_type>& exports,
+                    const Teuchos::ArrayView<size_t>& numPacketsPerLID,
+                    size_t& constantNumPackets,
+                    Distributor& distor);
+
+    /// \brief Perform any unpacking and combining after
+    ///   communication; old interface version.
+    ///
+    /// \warning This method is DEPRECATED.  Do not call it, and do
+    ///   not implement it in your subclasses of DistObject.
+    virtual void TPETRA_DEPRECATED
+    unpackAndCombine (const Teuchos::ArrayView<const local_ordinal_type>& importLIDs,
+                      const Teuchos::ArrayView<const packet_type>& imports,
+                      const Teuchos::ArrayView<size_t>& numPacketsPerLID,
+                      const size_t constantNumPackets,
+                      Distributor& distor,
+                      const CombineMode combineMode);
     //@}
 
     /// \brief Hook for creating a const view.
     ///
-    /// doTransfer() calls this on the source object.  By default,
-    /// it does nothing, but the source object can use this as a hint
-    /// to fetch data from a compute buffer on an off-CPU device (such
-    /// as a GPU) into host memory.
-    virtual void createViews () const;
+    /// \warning This method is DEPRECATED.  Do not call it, and do
+    ///   not implement it in your subclasses of DistObject.
+    virtual void TPETRA_DEPRECATED
+    createViews () const;
 
     /// \brief Hook for creating a nonconst view.
     ///
-    /// doTransfer() calls this on the destination (<tt>*this</tt>)
-    /// object.  By default, it does nothing, but the destination
-    /// object can use this as a hint to fetch data from a compute
-    /// buffer on an off-CPU device (such as a GPU) into host memory.
-    ///
-    /// \param rwo [in] Whether to create a write-only or a
-    ///   read-and-write view.  For Kokkos Node types where compute
-    ///   buffers live in a separate memory space (e.g., in the device
-    ///   memory of a discrete accelerator like a GPU), a write-only
-    ///   view only requires copying from host memory to the compute
-    ///   buffer, whereas a read-and-write view requires copying both
-    ///   ways (once to read, from the compute buffer to host memory,
-    ///   and once to write, back to the compute buffer).
-    virtual void createViewsNonConst (KokkosClassic::ReadWriteOption rwo);
+    /// \warning This method is DEPRECATED.  Do not call it, and do
+    ///   not implement it in your subclasses of DistObject.
+    virtual void TPETRA_DEPRECATED
+    createViewsNonConst (KokkosClassic::ReadWriteOption rwo);
 
     /// \brief Hook for releasing views.
     ///
     /// \note This is no longer called (and is therefore no longer
-    ///   needed) for subclasses for which useNewInterface() returns
-    ///   \c true.
-    ///
-    /// doTransfer() calls this on both the source and destination
-    /// objects, once it no longer needs to access that object's data.
-    /// By default, this method does nothing.  Implementations may use
-    /// this as a hint to free host memory which is a view of a
-    /// compute buffer, once the host memory view is no longer needed.
-    /// Some implementations may prefer to mirror compute buffers in
-    /// host memory; for these implementations, releaseViews() may do
-    /// nothing.
-    virtual void releaseViews () const;
+    ///   needed) for subclasses that implement the "new" interface.
+    virtual void TPETRA_DEPRECATED releaseViews () const;
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
 
     //! The Map over which this object is distributed.
     Teuchos::RCP<const map_type> map_;

--- a/packages/tpetra/core/src/Tpetra_DistObject_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_DistObject_def.hpp
@@ -273,7 +273,8 @@ namespace Tpetra {
   DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
   doImport (const SrcDistObject& source,
             const Import<LocalOrdinal, GlobalOrdinal, Node>& importer,
-            CombineMode CM, bool restrictedMode)
+            const CombineMode CM,
+            const bool restrictedMode)
   {
     using std::endl;
     const char modeString[] = "doImport (forward mode)";
@@ -314,7 +315,8 @@ namespace Tpetra {
   DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
   doExport (const SrcDistObject& source,
             const Export<LocalOrdinal, GlobalOrdinal, Node>& exporter,
-            CombineMode CM, bool restrictedMode)
+            const CombineMode CM,
+            const bool restrictedMode)
   {
     using std::endl;
     const char modeString[] = "doExport (forward mode)";
@@ -356,7 +358,8 @@ namespace Tpetra {
   DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
   doImport (const SrcDistObject& source,
             const Export<LocalOrdinal, GlobalOrdinal, Node>& exporter,
-            CombineMode CM, bool restrictedMode)
+            const CombineMode CM,
+            const bool restrictedMode)
   {
     using std::endl;
     const char modeString[] = "doImport (reverse mode)";
@@ -398,7 +401,8 @@ namespace Tpetra {
   DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
   doExport (const SrcDistObject& source,
             const Import<LocalOrdinal, GlobalOrdinal, Node> & importer,
-            CombineMode CM, bool restrictedMode)
+            const CombineMode CM,
+            const bool restrictedMode)
   {
     using std::endl;
     const char modeString[] = "doExport (reverse mode)";
@@ -826,11 +830,11 @@ namespace Tpetra {
       // There is at least one GID to copy or permute.
       if (verbose) {
         std::ostringstream os;
-        os << *prefix << "2. copyAndPermuteNew" << endl;
+        os << *prefix << "2. copyAndPermute" << endl;
         std::cerr << os.str ();
       }
       ProfilingRegion region_cp
-        ("Tpetra::DistObject::doTransferNew::copyAndPermuteNew");
+        ("Tpetra::DistObject::doTransferNew::copyAndPermute");
 #ifdef HAVE_TPETRA_TRANSFER_TIMERS
       // FIXME (mfh 04 Feb 2019) Deprecate Teuchos::TimeMonitor in favor
       // of Kokkos profiling.
@@ -841,14 +845,19 @@ namespace Tpetra {
         // There is at least one GID to copy or permute.
         if (verbose) {
           std::ostringstream os;
-          os << *prefix << "2. copyAndPermuteNew" << endl;
+          os << *prefix << "2. copyAndPermute" << endl;
           std::cerr << os.str ();
         }
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
         this->copyAndPermuteNew (src, numSameIDs, permuteToLIDs,
                                  permuteFromLIDs);
+#else // TPETRA_ENABLE_DEPRECATED_CODE
+        this->copyAndPermute (src, numSameIDs, permuteToLIDs,
+                              permuteFromLIDs);
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
         if (verbose) {
           std::ostringstream os;
-          os << *prefix << "After copyAndPermuteNew:" << endl
+          os << *prefix << "After copyAndPermute:" << endl
              << *prefix << "  "
              << dualViewStatusToString (permuteToLIDs, "permuteToLIDs")
              << endl
@@ -895,14 +904,14 @@ namespace Tpetra {
 
       if (verbose) {
         std::ostringstream os;
-        os << *prefix << "4. packAndPrepareNew: before, "
+        os << *prefix << "4. packAndPrepare: before, "
            << dualViewStatusToString (this->exports_, "exports_")
            << endl;
         std::cerr << os.str ();
       }
       {
         ProfilingRegion region_pp
-          ("Tpetra::DistObject::doTransferNew::packAndPrepareNew");
+          ("Tpetra::DistObject::doTransferNew::packAndPrepare");
 #ifdef HAVE_TPETRA_TRANSFER_TIMERS
         // FIXME (mfh 04 Feb 2019) Deprecate Teuchos::TimeMonitor in
         // favor of Kokkos profiling.
@@ -916,18 +925,24 @@ namespace Tpetra {
         // source will fill the numExportPacketsPerLID_ array.
 
         // FIXME (mfh 18 Oct 2017) if (! commOnHost), sync to device?
-        // Alternately, make packAndPrepareNew take a "commOnHost"
+        // Alternately, make packAndPrepare take a "commOnHost"
         // argument to tell it where to leave the data?
         //
         // NOTE (mfh 04 Feb 2019) Subclasses of DistObject should have
         // the freedom to pack and unpack either on host or device.
         // We should prefer sync'ing only on demand.  Thus, we can
-        // answer the above question: packAndPrepareNew should not
+        // answer the above question: packAndPrepare should not
         // take a commOnHost argument, and doTransferNew should sync
         // where needed, if needed.
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
         this->packAndPrepareNew (src, exportLIDs, this->exports_,
                                  this->numExportPacketsPerLID_,
                                  constantNumPackets, distor);
+#else // TPETRA_ENABLE_DEPRECATED_CODE
+        this->packAndPrepare (src, exportLIDs, this->exports_,
+                              this->numExportPacketsPerLID_,
+                              constantNumPackets, distor);
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
         if (commOnHost) {
           if (this->exports_.need_sync_host ()) {
             this->exports_.sync_host ();
@@ -941,7 +956,7 @@ namespace Tpetra {
       }
       if (verbose) {
         std::ostringstream os;
-        os << *prefix << "5.1. After packAndPrepareNew, "
+        os << *prefix << "5.1. After packAndPrepare, "
            << dualViewStatusToString (this->exports_, "exports_")
            << endl;
         std::cerr << os.str ();
@@ -1233,11 +1248,11 @@ namespace Tpetra {
 
         if (verbose) {
           std::ostringstream os;
-          os << *prefix << "8. unpackAndCombineNew" << endl;
+          os << *prefix << "8. unpackAndCombine" << endl;
           std::cerr << os.str ();
         }
         ProfilingRegion region_uc
-          ("Tpetra::DistObject::doTransferNew::unpackAndCombineNew");
+          ("Tpetra::DistObject::doTransferNew::unpackAndCombine");
 #ifdef HAVE_TPETRA_TRANSFER_TIMERS
         // FIXME (mfh 04 Feb 2019) Deprecate Teuchos::TimeMonitor in
         // favor of Kokkos profiling.
@@ -1251,9 +1266,15 @@ namespace Tpetra {
         // FIXME (mfh 26 Apr 2016) Check that all input DualViews
         // were most recently updated in the same memory space, and
         // sync them to the same place (based on commOnHost) if not.
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
         this->unpackAndCombineNew (remoteLIDs, this->imports_,
                                    this->numImportPacketsPerLID_,
                                    constantNumPackets, distor, CM);
+#else // TPETRA_ENABLE_DEPRECATED_CODE
+        this->unpackAndCombine (remoteLIDs, this->imports_,
+                                this->numImportPacketsPerLID_,
+                                constantNumPackets, distor, CM);
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
       } // if (needCommunication)
     } // if (CM != ZERO)
 
@@ -1796,40 +1817,63 @@ namespace Tpetra {
   template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
   void
   DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
-  copyAndPermuteNew (const SrcDistObject&,
-                     const size_t,
-                     const Kokkos::DualView<const local_ordinal_type*,
-                       buffer_device_type>&,
-                     const Kokkos::DualView<const local_ordinal_type*,
-                       buffer_device_type>&)
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+  copyAndPermuteNew
+#else // TPETRA_ENABLE_DEPRECATED_CODE
+  copyAndPermute
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+  (const SrcDistObject&,
+   const size_t,
+   const Kokkos::DualView<
+     const local_ordinal_type*,
+     buffer_device_type>&,
+   const Kokkos::DualView<
+     const local_ordinal_type*,
+     buffer_device_type>&)
   {}
 
   template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
   void
   DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
-  packAndPrepareNew (const SrcDistObject&,
-                     const Kokkos::DualView<const local_ordinal_type*,
-                       buffer_device_type>&,
-                     Kokkos::DualView<packet_type*,
-                       buffer_device_type>&,
-                     Kokkos::DualView<size_t*,
-                       buffer_device_type>,
-                     size_t&,
-                     Distributor&)
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+  packAndPrepareNew
+#else // TPETRA_ENABLE_DEPRECATED_CODE
+  packAndPrepare
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+  (const SrcDistObject&,
+   const Kokkos::DualView<
+     const local_ordinal_type*,
+     buffer_device_type>&,
+   Kokkos::DualView<
+     packet_type*,
+     buffer_device_type>&,
+   Kokkos::DualView<
+     size_t*,
+     buffer_device_type>,
+   size_t&,
+   Distributor&)
   {}
 
   template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
   void
   DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
-  unpackAndCombineNew (const Kokkos::DualView<const local_ordinal_type*,
-                         buffer_device_type>& /* importLIDs */,
-                       Kokkos::DualView<packet_type*,
-                         buffer_device_type> /* imports */,
-                       Kokkos::DualView<size_t*,
-                         buffer_device_type> /* numPacketsPerLID */,
-                       const size_t /* constantNumPackets */,
-                       Distributor& /* distor */,
-                       const CombineMode /* combineMode */)
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+  unpackAndCombineNew
+#else // TPETRA_ENABLE_DEPRECATED_CODE
+  unpackAndCombine
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+  (const Kokkos::DualView<
+     const local_ordinal_type*,
+     buffer_device_type>& /* importLIDs */,
+   Kokkos::DualView<
+     packet_type*,
+     buffer_device_type> /* imports */,
+   Kokkos::DualView<
+     size_t*,
+     buffer_device_type> /* numPacketsPerLID */,
+   const size_t /* constantNumPackets */,
+   Distributor& /* distor */,
+   const CombineMode /* combineMode */)
   {}
 
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE

--- a/packages/tpetra/core/src/Tpetra_DistObject_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_DistObject_def.hpp
@@ -60,6 +60,37 @@
 
 namespace Tpetra {
 
+  namespace { // (anonymous)
+    template<class DeviceType, class IndexType = size_t>
+    struct SumFunctor {
+      SumFunctor (const Kokkos::View<const size_t*, DeviceType>& viewToSum) :
+        viewToSum_ (viewToSum) {}
+      KOKKOS_INLINE_FUNCTION void operator() (const IndexType i, size_t& lclSum) const {
+        lclSum += viewToSum_(i);
+      }
+      Kokkos::View<const size_t*, DeviceType> viewToSum_;
+    };
+
+    template<class DeviceType, class IndexType = size_t>
+    size_t
+    countTotalImportPackets (const Kokkos::View<const size_t*, DeviceType>& numImportPacketsPerLID)
+    {
+      using Kokkos::parallel_reduce;
+      typedef DeviceType DT;
+      typedef typename DT::execution_space DES;
+      typedef Kokkos::RangePolicy<DES, IndexType> range_type;
+
+      const IndexType numOut = numImportPacketsPerLID.extent (0);
+      size_t totalImportPackets = 0;
+      parallel_reduce ("Count import packets",
+                       range_type (0, numOut),
+                       SumFunctor<DeviceType, IndexType> (numImportPacketsPerLID),
+                       totalImportPackets);
+      return totalImportPackets;
+    }
+  } // namespace (anonymous)
+
+
   template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
   DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
   DistObject (const Teuchos::RCP<const map_type>& map) :
@@ -449,10 +480,11 @@ namespace Tpetra {
 
     // "Restricted Mode" does two things:
     // 1) Skips copyAndPermute
-    // 2) Allows the "target" map of the transfer to be a subset of the map of this, in a "locallyFitted" sense.
+    // 2) Allows the "target" Map of the transfer to be a subset of
+    //    the Map of *this, in a "locallyFitted" sense.
     //
     // This cannot be used if #2 is not true, OR there are permutes.
-    // Source maps still need to match
+    // Source Maps still need to match
 
     // mfh 18 Oct 2017: Set TPETRA_DEBUG to true to enable extra debug
     // checks.  These may communicate more.
@@ -484,24 +516,26 @@ namespace Tpetra {
         TEUCHOS_TEST_FOR_EXCEPTION
           (! myMapLocallyFittedTransferTgtMap , std::invalid_argument,
            "Tpetra::DistObject::" << modeString << ": For forward-mode "
-           "communication using restricted mode, Export/Import object's target Map "
-           " must be locally fitted (in the sense of Tpetra::Map::isLocallyFitted) to target DistObject's Map");
+           "communication using restricted mode, Export/Import object's "
+           "target Map must be locally fitted (in the sense of "
+           "Tpetra::Map::isLocallyFitted) to target DistObject's Map.");
       }
       else { // if (restrictedMode && revOp == DoReverse) {
         const bool myMapLocallyFittedTransferSrcMap =
-          this->getMap ()->isLocallyFitted (* (transfer.getSourceMap ()));   
+          this->getMap ()->isLocallyFitted (* (transfer.getSourceMap ()));
         TEUCHOS_TEST_FOR_EXCEPTION
           (! myMapLocallyFittedTransferSrcMap, std::invalid_argument,
            "Tpetra::DistObject::" << modeString << ": For reverse-mode "
-           "communication using restricted mode, Export/Import object's source Map "
-           " must be  locally fitted (in the sense of Tpetra::Map::isLocallyFitted) to target DistObject's Map");
+           "communication using restricted mode, Export/Import object's "
+           "source Map must be locally fitted (in the sense of "
+           "Tpetra::Map::isLocallyFitted) to target DistObject's Map.");
       }
 
       // SrcDistObject need not even _have_ Maps.  However, if the
       // source object is a DistObject, it has a Map, and we may
       // compare that Map with the Transfer's Maps.
       const this_type* srcDistObj = dynamic_cast<const this_type*> (&src);
-      if (srcDistObj != NULL) {
+      if (srcDistObj != nullptr) {
         if (revOp == DoForward) {
           const bool srcMapSameAsImportSrcMap =
             srcDistObj->getMap ()->isSameAs (* (transfer.getSourceMap ()));
@@ -526,16 +560,21 @@ namespace Tpetra {
     const size_t numSameIDs = transfer.getNumSameIDs ();
     Distributor& distor = transfer.getDistributor ();
 
-    if (debug) {
-      if (restrictedMode && (transfer.getPermuteToLIDs_dv().extent(0) != 0 || transfer.getPermuteFromLIDs_dv().extent(0) !=0)) {
-        TEUCHOS_TEST_FOR_EXCEPTION
-          (1, std::invalid_argument,
-           "Tpetra::DistObject::" << modeString << ": transfer object "
-           "cannot have permutes in restricted mode ");
-      }
-    }
-    
-    if (this->useNewInterface ()) {
+    TEUCHOS_TEST_FOR_EXCEPTION
+      (debug && restrictedMode &&
+       (transfer.getPermuteToLIDs_dv().extent(0) != 0 ||
+        transfer.getPermuteFromLIDs_dv().extent(0) != 0),
+       std::invalid_argument,
+       "Tpetra::DistObject::" << modeString << ": Transfer object "
+       "cannot have permutes in restricted mode.");
+
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+    const bool useTheNewInterface = this->useNewInterface ();
+#else
+    const bool useTheNewInterface = true;
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+
+    if (useTheNewInterface) {
       using ::Tpetra::Details::Behavior;
       // Do we need all communication buffers to live on host?
       const bool commOnHost = ! Behavior::assumeMpiIsCudaAware ();
@@ -561,7 +600,9 @@ namespace Tpetra {
       doTransferNew (src, CM, numSameIDs, permToLIDs, permFromLIDs,
                      remoteLIDs, exportLIDs, distor, revOp, commOnHost,restrictedMode);
     }
-    else {
+
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+    if (! useTheNewInterface) {
       if (verbose) {
         std::ostringstream os;
         os << *prefix << "doTransfer: Use old interface" << endl;
@@ -578,6 +619,7 @@ namespace Tpetra {
       doTransferOld (src, CM, numSameIDs, permToLIDs, permFromLIDs,
                      remoteLIDs, exportLIDs, distor, revOp, restrictedMode);
     }
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
 
     if (verbose) {
       std::ostringstream os;
@@ -690,633 +732,6 @@ namespace Tpetra {
 
     return firstReallocated || secondReallocated;
   }
-
-  template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
-  void
-  DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
-  doTransferOld (const SrcDistObject& src,
-              CombineMode CM,
-              size_t numSameIDs,
-              const Teuchos::ArrayView<const LocalOrdinal>& permuteToLIDs,
-              const Teuchos::ArrayView<const LocalOrdinal>& permuteFromLIDs,
-              const Teuchos::ArrayView<const LocalOrdinal>& remoteLIDs,
-              const Teuchos::ArrayView<const LocalOrdinal>& exportLIDs,
-              Distributor &distor,
-              ReverseOption revOp,
-              const bool restrictedMode)
-  {
-    using ::Tpetra::Details::getArrayViewFromDualView;
-    using ::Tpetra::Details::ProfilingRegion;
-    using ::Tpetra::Details::reallocDualViewIfNeeded;
-    using std::endl;
-    const char prefixRaw[] = "Tpetra::DistObject::doTransferOld: ";
-
-    ProfilingRegion region_doTransferOld ("Tpetra::DistObject::doTransferOld");
-#ifdef HAVE_TPETRA_TRANSFER_TIMERS
-    // FIXME (mfh 04 Feb 2019) Remove Teuchos::TimeMonitor and use
-    // Kokkos profiling instead.
-    Teuchos::TimeMonitor doXferMon (*doXferTimer_);
-#endif // HAVE_TPETRA_TRANSFER_TIMERS
-
-    const bool verbose = ::Tpetra::Details::Behavior::verbose ();
-    std::unique_ptr<std::string> prefix;
-    if (verbose) {
-      auto map = this->getMap ();
-      auto comm = map.is_null () ? Teuchos::null : map->getComm ();
-      const int myRank = comm.is_null () ? -1 : comm->getRank ();
-      std::ostringstream os;
-      os << "Proc " << myRank << ": " << prefixRaw;
-      prefix = std::unique_ptr<std::string> (new std::string (os.str ()));
-    }
-
-    TEUCHOS_TEST_FOR_EXCEPTION(
-      ! checkSizes (src), std::invalid_argument,
-      prefixRaw << "checkSizes() indicates that the "
-      "destination object is not a legal target for redistribution from the "
-      "source object.  This probably means that they do not have the same "
-      "dimensions.  For example, MultiVectors must have the same number of "
-      "rows and columns.");
-    KokkosClassic::ReadWriteOption rwo = KokkosClassic::ReadWrite;
-    if (CM == INSERT || CM == REPLACE) {
-      const size_t numIDsToWrite = numSameIDs +
-        static_cast<size_t> (permuteToLIDs.size ()) +
-        static_cast<size_t> (remoteLIDs.size ());
-      if (numIDsToWrite == this->getMap ()->getNodeNumElements ()) {
-        // We're overwriting all of our local data in the destination
-        // object, so a write-only view suffices.
-        //
-        // FIXME (mfh 10 Apr 2012) This doesn't make sense for a
-        // CrsMatrix with a dynamic graph.  INSERT mode could mean
-        // that we're adding new entries to the object, but we don't
-        // want to get rid of the old ones.
-        rwo = KokkosClassic::WriteOnly;
-      }
-    }
-
-    if (verbose) {
-      std::ostringstream os;
-      os << *prefix << "ReadWriteOption: ";
-      if (rwo == KokkosClassic::ReadWrite) {
-        os << "ReadWrite";
-      }
-      else if (rwo == KokkosClassic::WriteOnly) {
-        os << "ReadWrite";
-      }
-      else {
-        os << "Something else; weird!";
-      }
-      os << endl;
-      std::cerr << os.str ();
-    }
-
-    // Tell the source to create a read-only view of its data.  On a
-    // discrete accelerator such as a GPU, this brings EVERYTHING from
-    // device memory to host memory.
-    //
-    // FIXME (mfh 23 Mar 2012) By passing in the list of GIDs (or
-    // rather, local LIDs to send) and packet counts, createViews()
-    // could create a "sparse view" that only brings in the necessary
-    // data from device to host memory.
-    const this_type* srcDistObj = dynamic_cast<const this_type*> (&src);
-    if (srcDistObj != NULL) {
-      if (verbose) {
-        std::ostringstream os;
-        os << *prefix << "Call srcDistObject->createViews()" << endl;
-        std::cerr << os.str ();
-      }
-      srcDistObj->createViews ();
-    }
-    else {
-      if (verbose) {
-        std::ostringstream os;
-        os << *prefix << "Source object has a different type than target object"
-           << endl;
-        std::cerr << os.str ();
-      }
-    }
-
-    // Tell the target to create a view of its data.  Depending on
-    // rwo, this could be a write-only view or a read-and-write view.
-    // On a discrete accelerator such as a GPU, a write-only view only
-    // requires a transfer from host to device memory.  A
-    // read-and-write view requires a two-way transfer.  This has the
-    // same problem as createViews(): it transfers EVERYTHING, not
-    // just the necessary data.
-    //
-    // FIXME (mfh 23 Mar 2012) By passing in the list of GIDs (or
-    // rather, local LIDs into which to receive) and packet counts,
-    // createViewsNonConst() could create a "sparse view" that only
-    // transfers the necessary data.
-    if (verbose) {
-      std::ostringstream os;
-      os << *prefix << "Call createViewsNonConst" << endl;
-      std::cerr << os.str ();
-    }
-    this->createViewsNonConst (rwo);
-
-    if (!restrictedMode && numSameIDs + permuteToLIDs.size()) {
-#ifdef HAVE_TPETRA_TRANSFER_TIMERS
-      Teuchos::TimeMonitor copyAndPermuteMon (*copyAndPermuteTimer_);
-#endif // HAVE_TPETRA_TRANSFER_TIMERS
-      if (verbose) {
-        std::ostringstream os;
-        os << *prefix << "Call copyAndPermute" << endl;
-        std::cerr << os.str ();
-      }
-      // There is at least one GID to copy or permute.
-      copyAndPermute (src, numSameIDs, permuteToLIDs, permuteFromLIDs);
-    }
-    else {
-      if (verbose) {
-        std::ostringstream os;
-        os << *prefix << "Skipping copyAndPermute" << endl;
-        std::cerr << os.str ();
-      }
-    }
-
-    // The method may return zero even if the implementation actually
-    // does have a constant number of packets per LID.  However, if it
-    // returns nonzero, we may use this information to avoid
-    // (re)allocating num{Ex,Im}portPacketsPerLID_.  packAndPrepare()
-    // will set this to its final value.
-    //
-    // We only need this if CM != ZERO, but it has to be lifted out of
-    // that scope because there are multiple tests for CM != ZERO.
-    size_t constantNumPackets = this->constantNumberOfPackets ();
-    if (verbose) {
-      std::ostringstream os;
-      os << *prefix << "constantNumPackets=" << constantNumPackets << endl;
-      std::cerr << os.str ();
-    }
-
-    // We only need to pack communication buffers if the combine mode
-    // is not ZERO. A "ZERO combine mode" means that the results are
-    // the same as if we had received all zeros, and added them to the
-    // existing values. That means we don't need to communicate.
-    if (CM != ZERO) {
-      if (constantNumPackets == 0) {
-        this->reallocArraysForNumPacketsPerLid (exportLIDs.size (),
-                                                remoteLIDs.size ());
-      }
-
-      if (verbose) {
-        std::ostringstream os;
-        os << *prefix << "Preparing for packAndPrepare" << endl;
-        std::cerr << os.str ();
-      }
-      {
-#ifdef HAVE_TPETRA_TRANSFER_TIMERS
-        Teuchos::TimeMonitor packAndPrepareMon (*packAndPrepareTimer_);
-#endif // HAVE_TPETRA_TRANSFER_TIMERS
-        // Ask the source to pack data.  Also ask it whether there are a
-        // constant number of packets per element (constantNumPackets is
-        // an output argument).  If there are, constantNumPackets will
-        // come back nonzero.  Otherwise, the source will fill the
-        // numExportPacketsPerLID_ array.
-        numExportPacketsPerLID_.modify_host ();
-        Teuchos::ArrayView<size_t> numExportPacketsPerLID =
-          getArrayViewFromDualView (numExportPacketsPerLID_);
-
-        // FIXME (mfh 26 Apr 2016) For backwards compatibility, use
-        // the old packAndPrepare interface that takes and resizes the
-        // exports buffer as a Teuchos::Array<packet_type>.  Then,
-        // copy out that buffer into the host version of exports_.
-
-        Teuchos::Array<packet_type> exportsOld;
-        if (verbose) {
-          std::ostringstream os;
-          os << *prefix << "Call packAndPrepare" << endl;
-          std::cerr << os.str ();
-        }
-        packAndPrepare (src, exportLIDs, exportsOld, numExportPacketsPerLID,
-                        constantNumPackets, distor);
-        const size_t exportsLen = static_cast<size_t> (exportsOld.size ());
-        reallocDualViewIfNeeded (this->exports_, exportsLen, "exports");
-        Kokkos::View<const packet_type*, Kokkos::HostSpace,
-          Kokkos::MemoryUnmanaged> exportsOldK (exportsOld.getRawPtr (),
-                                                exportsLen);
-        exports_.modify_host ();
-        Kokkos::deep_copy (exports_.view_host (),
-                           exportsOldK);
-      }
-    }
-
-    // We don't need the source's data anymore, so it can let go of
-    // its views.  On an accelerator device with a separate memory
-    // space (like a GPU), this frees host memory, since device memory
-    // has the "master" version of the data.
-    if (srcDistObj != nullptr) {
-      if (verbose) {
-        std::ostringstream os;
-        os << *prefix << "Call srcDistObj->releaseViews()" << endl;
-        std::cerr << os.str ();
-      }
-      srcDistObj->releaseViews ();
-    }
-    else {
-      if (verbose) {
-        std::ostringstream os;
-        os << *prefix << "Skipping srcDistObj->releaseViews()" << endl;
-        std::cerr << os.str ();
-      }
-    }
-
-    // We only need to send data if the combine mode is not ZERO.
-    if (CM != ZERO) {
-      if (constantNumPackets != 0) {
-        // There are a constant number of packets per element.  We
-        // already know (from the number of "remote" (incoming)
-        // elements) how many incoming elements we expect, so we can
-        // resize the buffer accordingly.
-        const size_t rbufLen = remoteLIDs.size() * constantNumPackets;
-        if (verbose) {
-          std::ostringstream os;
-          os << *prefix << "Const # packets: imports_.extent(0)="
-             << imports_.extent (0) << ", ; calling reallocImportsIfNeeded("
-            "rbufLen=" << rbufLen << ", verbose=true)" << endl;
-          std::cerr << os.str ();
-        }
-        reallocImportsIfNeeded (rbufLen, verbose, prefix.get ());
-      }
-
-      // Do we need to do communication (via doPostsAndWaits)?
-      bool needCommunication = true;
-      if (revOp == DoReverse && ! isDistributed ()) {
-        needCommunication = false;
-      }
-      // FIXME (mfh 30 Jun 2013): Checking whether the source object
-      // is distributed requires a cast to DistObject.  If it's not a
-      // DistObject, then I'm not quite sure what to do.  Perhaps it
-      // would be more appropriate for SrcDistObject to have an
-      // isDistributed() method.  For now, I'll just assume that we
-      // need to do communication unless the cast succeeds and the
-      // source is not distributed.
-      else if (revOp == DoForward && srcDistObj != NULL &&
-               ! srcDistObj->isDistributed ()) {
-        needCommunication = false;
-      }
-
-      if (verbose) {
-        std::ostringstream os;
-        os << *prefix << "needCommunication="
-           << (needCommunication ? "true" : "false")
-           << ", revOp="
-           << (revOp == DoReverse ? "DoReverse" : "DoForward") << endl;
-        std::cerr << os.str ();
-      }
-
-      if (needCommunication) {
-        if (revOp == DoReverse) {
-#ifdef HAVE_TPETRA_TRANSFER_TIMERS
-          Teuchos::TimeMonitor doPostsAndWaitsMon (*doPostsAndWaitsTimer_);
-#endif // HAVE_TPETRA_TRANSFER_TIMERS
-          if (constantNumPackets == 0) { //variable num-packets-per-LID:
-            // First communicate the number of packets per LID to receive.
-
-            // Make sure that host has the latest version, since we're
-            // using the version on host.  If host has the latest
-            // version already, syncing to host does nothing.
-            numExportPacketsPerLID_.sync_host ();
-            Teuchos::ArrayView<const size_t> numExportPacketsPerLID =
-              getArrayViewFromDualView (numExportPacketsPerLID_);
-
-            // numImportPacketsPerLID_ is the output array here, so
-            // mark it as modified.  It's strictly output, so we don't
-            // have to sync from device.
-            //numImportPacketsPerLID_.sync_host ();
-            numImportPacketsPerLID_.modify_host ();
-            Teuchos::ArrayView<size_t> numImportPacketsPerLID =
-              getArrayViewFromDualView (numImportPacketsPerLID_);
-
-            if (verbose) {
-              std::ostringstream os;
-              os << *prefix << "Call doReversePostsAndWaits (3-arg)" << endl;
-              std::cerr << os.str ();
-            }
-            distor.doReversePostsAndWaits (numExportPacketsPerLID, 1,
-                                           numImportPacketsPerLID);
-
-            if (verbose) {
-              std::ostringstream os;
-              os << *prefix << "Compute totalImportPackets" << endl;
-              std::cerr << os.str ();
-            }
-            size_t totalImportPackets = 0;
-            {
-              typedef typename Kokkos::DualView<size_t*,
-                device_type>::t_host::execution_space host_exec_space;
-              typedef Kokkos::RangePolicy<host_exec_space, Array_size_type> range_type;
-              const size_t* const arrayToSum = numImportPacketsPerLID.getRawPtr ();
-              Kokkos::parallel_reduce ("Count import packets",
-                                       range_type (0, numImportPacketsPerLID.size ()),
-                                       [=] (const Array_size_type& i, size_t& lclSum) {
-                                         lclSum += arrayToSum[i];
-                                       }, totalImportPackets);
-            }
-
-            if (verbose) {
-              std::ostringstream os;
-              os << *prefix << "totalImportPackets=" << totalImportPackets
-                 << "; calling reallocImportsIfNeeded" << endl;
-              std::cerr << os.str ();
-            }
-            reallocImportsIfNeeded (totalImportPackets, verbose, prefix.get ());
-
-            // We don't need to sync imports_, because it is only for
-            // output here.  Similarly, we don't need to mark exports_
-            // as modified, since it is read only here. This legacy
-            // version of doTransfer only uses host arrays.
-            imports_.modify_host ();
-            Teuchos::ArrayView<packet_type> hostImports =
-              getArrayViewFromDualView (imports_);
-            exports_.sync_host ();
-            Teuchos::ArrayView<const packet_type> hostExports =
-              getArrayViewFromDualView (exports_);
-
-            if (verbose) {
-              std::ostringstream os;
-              os << *prefix << "Call doReversePostsAndWaits (4-arg)"
-                 << endl;
-              std::cerr << os.str ();
-            }
-            distor.doReversePostsAndWaits (hostExports,
-                                           numExportPacketsPerLID,
-                                           hostImports,
-                                           numImportPacketsPerLID);
-          }
-          else {
-            // We don't need to sync imports_, because it is only for
-            // output here.  Similarly, we don't need to mark exports_
-            // as modified, since it is read only here. This legacy
-            // version of doTransfer only uses host arrays.
-            imports_.modify_host ();
-            Teuchos::ArrayView<packet_type> hostImports =
-              getArrayViewFromDualView (imports_);
-            exports_.sync_host ();
-            Teuchos::ArrayView<const packet_type> hostExports =
-              getArrayViewFromDualView (exports_);
-
-            if (verbose) {
-              std::ostringstream os;
-              os << *prefix << "Call doReversePostsAndWaits (3-arg)"
-                 << endl;
-              std::cerr << os.str ();
-            }
-            distor.doReversePostsAndWaits (hostExports,
-                                           constantNumPackets,
-                                           hostImports);
-          }
-        }
-        else { // revOp == DoForward
-#ifdef HAVE_TPETRA_TRANSFER_TIMERS
-          Teuchos::TimeMonitor doPostsAndWaitsMon (*doPostsAndWaitsTimer_);
-#endif // HAVE_TPETRA_TRANSFER_TIMERS
-          if (constantNumPackets == 0) { //variable num-packets-per-LID:
-            // First communicate the number of packets per LID to receive.
-
-            // Make sure that host has the latest version, since we're
-            // using the version on host.  If host has the latest
-            // version already, syncing to host does nothing.
-            numExportPacketsPerLID_.sync_host ();
-            Teuchos::ArrayView<const size_t> numExportPacketsPerLID =
-              getArrayViewFromDualView (numExportPacketsPerLID_);
-
-            // numImportPacketsPerLID_ is the output array here, so
-            // mark it as modified.  It's strictly output, so we don't
-            // have to sync from device.
-            //numImportPacketsPerLID_.sync_host ();
-            numImportPacketsPerLID_.modify_host ();
-            Teuchos::ArrayView<size_t> numImportPacketsPerLID =
-              getArrayViewFromDualView (numImportPacketsPerLID_);
-
-            if (verbose) {
-              std::ostringstream os;
-              os << *prefix << "Call doPostsAndWaits (3-arg)" << endl;
-              std::cerr << os.str ();
-            }
-            distor.doPostsAndWaits (numExportPacketsPerLID, 1,
-                                    numImportPacketsPerLID);
-
-            if (verbose) {
-              std::ostringstream os;
-              os << *prefix << "Compute totalImportPackets" << endl;
-              std::cerr << os.str ();
-            }
-            size_t totalImportPackets = 0;
-            {
-              typedef typename Kokkos::DualView<size_t*,
-                device_type>::t_host::execution_space host_exec_space;
-              typedef Kokkos::RangePolicy<host_exec_space, Array_size_type> range_type;
-              const size_t* const arrayToSum = numImportPacketsPerLID.getRawPtr ();
-              Kokkos::parallel_reduce ("Count import packets",
-                                       range_type (0, numImportPacketsPerLID.size ()),
-                                       [=] (const Array_size_type& i, size_t& lclSum) {
-                                         lclSum += arrayToSum[i];
-                                       }, totalImportPackets);
-            }
-
-            if (verbose) {
-              std::ostringstream os;
-              os << *prefix << "totalImportPackets=" << totalImportPackets
-                 << "; calling reallocImportsIfNeeded" << endl;
-              std::cerr << os.str ();
-            }
-            reallocImportsIfNeeded (totalImportPackets, verbose, prefix.get ());
-
-            // We don't need to sync imports_, because it is only for
-            // output here.  Similarly, we don't need to mark exports_
-            // as modified, since it is read only here. This legacy
-            // version of doTransfer only uses host arrays.
-            imports_.modify_host ();
-            Teuchos::ArrayView<packet_type> hostImports =
-              getArrayViewFromDualView (imports_);
-            exports_.sync_host ();
-            Teuchos::ArrayView<const packet_type> hostExports =
-              getArrayViewFromDualView (exports_);
-
-            if (verbose) {
-              std::ostringstream os;
-              os << *prefix << "Call doPostsAndWaits (4-arg)" << endl;
-              std::cerr << os.str ();
-            }
-            distor.doPostsAndWaits (hostExports,
-                                    numExportPacketsPerLID,
-                                    hostImports,
-                                    numImportPacketsPerLID);
-          }
-          else {
-            // We don't need to sync imports_, because it is only for
-            // output here.  Similarly, we don't need to mark exports_
-            // as modified, since it is read only here. This legacy
-            // version of doTransfer only uses host arrays.
-            imports_.modify_host ();
-            Teuchos::ArrayView<packet_type> hostImports =
-              getArrayViewFromDualView (imports_);
-            exports_.sync_host ();
-            Teuchos::ArrayView<const packet_type> hostExports =
-              getArrayViewFromDualView (exports_);
-
-            if (verbose) {
-              std::ostringstream os;
-              os << *prefix << "Call doPostsAndWaits (3-arg)" << endl;
-              std::cerr << os.str ();
-            }
-            distor.doPostsAndWaits (hostExports,
-                                    constantNumPackets,
-                                    hostImports);
-          }
-        }
-
-        if (verbose) {
-          std::ostringstream os;
-          os << *prefix << "Preparing for unpackAndCombine" << endl;
-          std::cerr << os.str ();
-        }
-        {
-#ifdef HAVE_TPETRA_TRANSFER_TIMERS
-          Teuchos::TimeMonitor unpackAndCombineMon (*unpackAndCombineTimer_);
-#endif // HAVE_TPETRA_TRANSFER_TIMERS
-
-          // We don't need to sync imports_, because it is only for
-          // output here.  This legacy version of doTransfer only uses
-          // host arrays.
-          imports_.modify_host ();
-          Teuchos::ArrayView<packet_type> hostImports =
-            getArrayViewFromDualView (imports_);
-          // NOTE (mfh 25 Apr 2016) unpackAndCombine doesn't actually
-          // change its numImportPacketsPerLID argument, so we don't
-          // have to mark it modified here.
-          numImportPacketsPerLID_.sync_host ();
-          // FIXME (mfh 25 Apr 2016) unpackAndCombine doesn't actually
-          // change its numImportPacketsPerLID argument, so we should
-          // be able to use a const Teuchos::ArrayView here.
-          Teuchos::ArrayView<size_t> numImportPacketsPerLID =
-            getArrayViewFromDualView (numImportPacketsPerLID_);
-
-          if (verbose) {
-            std::ostringstream os;
-            os << *prefix << "Call unpackAndCombine" << endl;
-            std::cerr << os.str ();
-          }
-          unpackAndCombine (remoteLIDs, hostImports, numImportPacketsPerLID,
-                            constantNumPackets, distor, CM);
-        }
-      }
-    } // if (CM != ZERO)
-
-    if (verbose) {
-      std::ostringstream os;
-      os << *prefix << "Call releaseViews()" << endl;
-      std::cerr << os.str ();
-    }
-    this->releaseViews ();
-
-    if (verbose) {
-      std::ostringstream os;
-      os << *prefix << "Done!" << endl;
-      std::cerr << os.str ();
-    }
-  }
-
-  namespace { // (anonymous)
-    template<class DeviceType, class IndexType = size_t>
-    struct SumFunctor {
-      SumFunctor (const Kokkos::View<const size_t*, DeviceType>& viewToSum) :
-        viewToSum_ (viewToSum) {}
-      KOKKOS_FUNCTION void operator() (const IndexType& i, size_t& lclSum) const {
-        lclSum += viewToSum_(i);
-      }
-      Kokkos::View<const size_t*, DeviceType> viewToSum_;
-    };
-
-    template<class DeviceType, class IndexType = size_t>
-    size_t
-    countTotalImportPackets (const Kokkos::View<const size_t*, DeviceType>& numImportPacketsPerLID)
-    {
-      using Kokkos::parallel_reduce;
-      typedef DeviceType DT;
-      typedef typename DT::execution_space DES;
-      typedef Kokkos::RangePolicy<DES, IndexType> range_type;
-
-      const IndexType numOut = numImportPacketsPerLID.extent (0);
-      size_t totalImportPackets = 0;
-      parallel_reduce ("Count import packets",
-                       range_type (0, numOut),
-                       SumFunctor<DeviceType, IndexType> (numImportPacketsPerLID),
-                       totalImportPackets);
-      return totalImportPackets;
-    }
-  } // namespace (anonymous)
-
-  template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
-  void
-  DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
-  copyAndPermute (const SrcDistObject& /* source */,
-                  const size_t /* numSameIDs */,
-                  const Teuchos::ArrayView<const local_ordinal_type>& /* permuteToLIDs */,
-                  const Teuchos::ArrayView<const local_ordinal_type>& /* permuteFromLIDs */)
-  {}
-
-  template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
-  void
-  DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
-  copyAndPermuteNew (const SrcDistObject&,
-                     const size_t,
-                     const Kokkos::DualView<const local_ordinal_type*,
-                       buffer_device_type>&,
-                     const Kokkos::DualView<const local_ordinal_type*,
-                       buffer_device_type>&)
-  {}
-
-  template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
-  void
-  DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
-  packAndPrepare (const SrcDistObject& /* source */,
-                  const Teuchos::ArrayView<const local_ordinal_type>& /* exportLIDs */,
-                  Teuchos::Array<packet_type>& /* exports */,
-                  const Teuchos::ArrayView<size_t>& /* numPacketsPerLID */,
-                  size_t& /* constantNumPackets */,
-                  Distributor& /* distor */)
-  {}
-
-  template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
-  void
-  DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
-  packAndPrepareNew (const SrcDistObject&,
-                     const Kokkos::DualView<const local_ordinal_type*,
-                       buffer_device_type>&,
-                     Kokkos::DualView<packet_type*,
-                       buffer_device_type>&,
-                     Kokkos::DualView<size_t*,
-                       buffer_device_type>,
-                     size_t&,
-                     Distributor&)
-  {}
-
-  template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
-  void
-  DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
-  unpackAndCombine (const Teuchos::ArrayView<const local_ordinal_type>& /* importLIDs */,
-                    const Teuchos::ArrayView<const packet_type>& /* imports */,
-                    const Teuchos::ArrayView<size_t>& /* numPacketsPerLID */,
-                    const size_t /* constantNumPackets */,
-                    Distributor& /* distor */,
-                    const CombineMode /* combineMode */)
-  {}
-
-  template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
-  void
-  DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
-  unpackAndCombineNew (const Kokkos::DualView<const local_ordinal_type*,
-                         buffer_device_type>& /* importLIDs */,
-                       Kokkos::DualView<packet_type*,
-                         buffer_device_type> /* imports */,
-                       Kokkos::DualView<size_t*,
-                         buffer_device_type> /* numPacketsPerLID */,
-                       const size_t /* constantNumPackets */,
-                       Distributor& /* distor */,
-                       const CombineMode /* combineMode */)
-  {}
 
   template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
   void
@@ -1849,6 +1264,625 @@ namespace Tpetra {
     }
   }
 
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+  template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
+  void TPETRA_DEPRECATED
+  DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
+  doTransferOld (const SrcDistObject& src,
+                 CombineMode CM,
+                 size_t numSameIDs,
+                 const Teuchos::ArrayView<const LocalOrdinal>& permuteToLIDs,
+                 const Teuchos::ArrayView<const LocalOrdinal>& permuteFromLIDs,
+                 const Teuchos::ArrayView<const LocalOrdinal>& remoteLIDs,
+                 const Teuchos::ArrayView<const LocalOrdinal>& exportLIDs,
+                 Distributor& distor,
+                 ReverseOption revOp,
+                 const bool restrictedMode)
+  {
+    using ::Tpetra::Details::getArrayViewFromDualView;
+    using ::Tpetra::Details::ProfilingRegion;
+    using ::Tpetra::Details::reallocDualViewIfNeeded;
+    using std::endl;
+    const char prefixRaw[] = "Tpetra::DistObject::doTransferOld: ";
+
+    ProfilingRegion region_doTransferOld ("Tpetra::DistObject::doTransferOld");
+#ifdef HAVE_TPETRA_TRANSFER_TIMERS
+    // FIXME (mfh 04 Feb 2019) Remove Teuchos::TimeMonitor and use
+    // Kokkos profiling instead.
+    Teuchos::TimeMonitor doXferMon (*doXferTimer_);
+#endif // HAVE_TPETRA_TRANSFER_TIMERS
+
+    const bool verbose = ::Tpetra::Details::Behavior::verbose ();
+    std::unique_ptr<std::string> prefix;
+    if (verbose) {
+      auto map = this->getMap ();
+      auto comm = map.is_null () ? Teuchos::null : map->getComm ();
+      const int myRank = comm.is_null () ? -1 : comm->getRank ();
+      std::ostringstream os;
+      os << "Proc " << myRank << ": " << prefixRaw;
+      prefix = std::unique_ptr<std::string> (new std::string (os.str ()));
+    }
+
+    TEUCHOS_TEST_FOR_EXCEPTION(
+      ! checkSizes (src), std::invalid_argument,
+      prefixRaw << "checkSizes() indicates that the "
+      "destination object is not a legal target for redistribution from the "
+      "source object.  This probably means that they do not have the same "
+      "dimensions.  For example, MultiVectors must have the same number of "
+      "rows and columns.");
+    KokkosClassic::ReadWriteOption rwo = KokkosClassic::ReadWrite;
+    if (CM == INSERT || CM == REPLACE) {
+      const size_t numIDsToWrite = numSameIDs +
+        static_cast<size_t> (permuteToLIDs.size ()) +
+        static_cast<size_t> (remoteLIDs.size ());
+      if (numIDsToWrite == this->getMap ()->getNodeNumElements ()) {
+        // We're overwriting all of our local data in the destination
+        // object, so a write-only view suffices.
+        //
+        // FIXME (mfh 10 Apr 2012) This doesn't make sense for a
+        // CrsMatrix with a dynamic graph.  INSERT mode could mean
+        // that we're adding new entries to the object, but we don't
+        // want to get rid of the old ones.
+        rwo = KokkosClassic::WriteOnly;
+      }
+    }
+
+    if (verbose) {
+      std::ostringstream os;
+      os << *prefix << "ReadWriteOption: ";
+      if (rwo == KokkosClassic::ReadWrite) {
+        os << "ReadWrite";
+      }
+      else if (rwo == KokkosClassic::WriteOnly) {
+        os << "ReadWrite";
+      }
+      else {
+        os << "Something else; weird!";
+      }
+      os << endl;
+      std::cerr << os.str ();
+    }
+
+    // Tell the source to create a read-only view of its data.  On a
+    // discrete accelerator such as a GPU, this brings EVERYTHING from
+    // device memory to host memory.
+    //
+    // FIXME (mfh 23 Mar 2012) By passing in the list of GIDs (or
+    // rather, local LIDs to send) and packet counts, createViews()
+    // could create a "sparse view" that only brings in the necessary
+    // data from device to host memory.
+    const this_type* srcDistObj = dynamic_cast<const this_type*> (&src);
+    if (srcDistObj != NULL) {
+      if (verbose) {
+        std::ostringstream os;
+        os << *prefix << "Call srcDistObject->createViews()" << endl;
+        std::cerr << os.str ();
+      }
+      srcDistObj->createViews ();
+    }
+    else {
+      if (verbose) {
+        std::ostringstream os;
+        os << *prefix << "Source object has a different type than target object"
+           << endl;
+        std::cerr << os.str ();
+      }
+    }
+
+    // Tell the target to create a view of its data.  Depending on
+    // rwo, this could be a write-only view or a read-and-write view.
+    // On a discrete accelerator such as a GPU, a write-only view only
+    // requires a transfer from host to device memory.  A
+    // read-and-write view requires a two-way transfer.  This has the
+    // same problem as createViews(): it transfers EVERYTHING, not
+    // just the necessary data.
+    //
+    // FIXME (mfh 23 Mar 2012) By passing in the list of GIDs (or
+    // rather, local LIDs into which to receive) and packet counts,
+    // createViewsNonConst() could create a "sparse view" that only
+    // transfers the necessary data.
+    if (verbose) {
+      std::ostringstream os;
+      os << *prefix << "Call createViewsNonConst" << endl;
+      std::cerr << os.str ();
+    }
+    this->createViewsNonConst (rwo);
+
+    if (!restrictedMode && numSameIDs + permuteToLIDs.size()) {
+#ifdef HAVE_TPETRA_TRANSFER_TIMERS
+      Teuchos::TimeMonitor copyAndPermuteMon (*copyAndPermuteTimer_);
+#endif // HAVE_TPETRA_TRANSFER_TIMERS
+      if (verbose) {
+        std::ostringstream os;
+        os << *prefix << "Call copyAndPermute" << endl;
+        std::cerr << os.str ();
+      }
+      // There is at least one GID to copy or permute.
+      copyAndPermute (src, numSameIDs, permuteToLIDs, permuteFromLIDs);
+    }
+    else {
+      if (verbose) {
+        std::ostringstream os;
+        os << *prefix << "Skipping copyAndPermute" << endl;
+        std::cerr << os.str ();
+      }
+    }
+
+    // The method may return zero even if the implementation actually
+    // does have a constant number of packets per LID.  However, if it
+    // returns nonzero, we may use this information to avoid
+    // (re)allocating num{Ex,Im}portPacketsPerLID_.  packAndPrepare()
+    // will set this to its final value.
+    //
+    // We only need this if CM != ZERO, but it has to be lifted out of
+    // that scope because there are multiple tests for CM != ZERO.
+    size_t constantNumPackets = this->constantNumberOfPackets ();
+    if (verbose) {
+      std::ostringstream os;
+      os << *prefix << "constantNumPackets=" << constantNumPackets << endl;
+      std::cerr << os.str ();
+    }
+
+    // We only need to pack communication buffers if the combine mode
+    // is not ZERO. A "ZERO combine mode" means that the results are
+    // the same as if we had received all zeros, and added them to the
+    // existing values. That means we don't need to communicate.
+    if (CM != ZERO) {
+      if (constantNumPackets == 0) {
+        this->reallocArraysForNumPacketsPerLid (exportLIDs.size (),
+                                                remoteLIDs.size ());
+      }
+
+      if (verbose) {
+        std::ostringstream os;
+        os << *prefix << "Preparing for packAndPrepare" << endl;
+        std::cerr << os.str ();
+      }
+      {
+#ifdef HAVE_TPETRA_TRANSFER_TIMERS
+        Teuchos::TimeMonitor packAndPrepareMon (*packAndPrepareTimer_);
+#endif // HAVE_TPETRA_TRANSFER_TIMERS
+        // Ask the source to pack data.  Also ask it whether there are a
+        // constant number of packets per element (constantNumPackets is
+        // an output argument).  If there are, constantNumPackets will
+        // come back nonzero.  Otherwise, the source will fill the
+        // numExportPacketsPerLID_ array.
+        numExportPacketsPerLID_.modify_host ();
+        Teuchos::ArrayView<size_t> numExportPacketsPerLID =
+          getArrayViewFromDualView (numExportPacketsPerLID_);
+
+        // FIXME (mfh 26 Apr 2016) For backwards compatibility, use
+        // the old packAndPrepare interface that takes and resizes the
+        // exports buffer as a Teuchos::Array<packet_type>.  Then,
+        // copy out that buffer into the host version of exports_.
+
+        Teuchos::Array<packet_type> exportsOld;
+        if (verbose) {
+          std::ostringstream os;
+          os << *prefix << "Call packAndPrepare" << endl;
+          std::cerr << os.str ();
+        }
+        packAndPrepare (src, exportLIDs, exportsOld, numExportPacketsPerLID,
+                        constantNumPackets, distor);
+        const size_t exportsLen = static_cast<size_t> (exportsOld.size ());
+        reallocDualViewIfNeeded (this->exports_, exportsLen, "exports");
+        Kokkos::View<const packet_type*, Kokkos::HostSpace,
+          Kokkos::MemoryUnmanaged> exportsOldK (exportsOld.getRawPtr (),
+                                                exportsLen);
+        exports_.modify_host ();
+        Kokkos::deep_copy (exports_.view_host (),
+                           exportsOldK);
+      }
+    }
+
+    // We don't need the source's data anymore, so it can let go of
+    // its views.  On an accelerator device with a separate memory
+    // space (like a GPU), this frees host memory, since device memory
+    // has the "master" version of the data.
+    if (srcDistObj != nullptr) {
+      if (verbose) {
+        std::ostringstream os;
+        os << *prefix << "Call srcDistObj->releaseViews()" << endl;
+        std::cerr << os.str ();
+      }
+      srcDistObj->releaseViews ();
+    }
+    else {
+      if (verbose) {
+        std::ostringstream os;
+        os << *prefix << "Skipping srcDistObj->releaseViews()" << endl;
+        std::cerr << os.str ();
+      }
+    }
+
+    // We only need to send data if the combine mode is not ZERO.
+    if (CM != ZERO) {
+      if (constantNumPackets != 0) {
+        // There are a constant number of packets per element.  We
+        // already know (from the number of "remote" (incoming)
+        // elements) how many incoming elements we expect, so we can
+        // resize the buffer accordingly.
+        const size_t rbufLen = remoteLIDs.size() * constantNumPackets;
+        if (verbose) {
+          std::ostringstream os;
+          os << *prefix << "Const # packets: imports_.extent(0)="
+             << imports_.extent (0) << ", ; calling reallocImportsIfNeeded("
+            "rbufLen=" << rbufLen << ", verbose=true)" << endl;
+          std::cerr << os.str ();
+        }
+        reallocImportsIfNeeded (rbufLen, verbose, prefix.get ());
+      }
+
+      // Do we need to do communication (via doPostsAndWaits)?
+      bool needCommunication = true;
+      if (revOp == DoReverse && ! isDistributed ()) {
+        needCommunication = false;
+      }
+      // FIXME (mfh 30 Jun 2013): Checking whether the source object
+      // is distributed requires a cast to DistObject.  If it's not a
+      // DistObject, then I'm not quite sure what to do.  Perhaps it
+      // would be more appropriate for SrcDistObject to have an
+      // isDistributed() method.  For now, I'll just assume that we
+      // need to do communication unless the cast succeeds and the
+      // source is not distributed.
+      else if (revOp == DoForward && srcDistObj != NULL &&
+               ! srcDistObj->isDistributed ()) {
+        needCommunication = false;
+      }
+
+      if (verbose) {
+        std::ostringstream os;
+        os << *prefix << "needCommunication="
+           << (needCommunication ? "true" : "false")
+           << ", revOp="
+           << (revOp == DoReverse ? "DoReverse" : "DoForward") << endl;
+        std::cerr << os.str ();
+      }
+
+      if (needCommunication) {
+        if (revOp == DoReverse) {
+#ifdef HAVE_TPETRA_TRANSFER_TIMERS
+          Teuchos::TimeMonitor doPostsAndWaitsMon (*doPostsAndWaitsTimer_);
+#endif // HAVE_TPETRA_TRANSFER_TIMERS
+          if (constantNumPackets == 0) { //variable num-packets-per-LID:
+            // First communicate the number of packets per LID to receive.
+
+            // Make sure that host has the latest version, since we're
+            // using the version on host.  If host has the latest
+            // version already, syncing to host does nothing.
+            numExportPacketsPerLID_.sync_host ();
+            Teuchos::ArrayView<const size_t> numExportPacketsPerLID =
+              getArrayViewFromDualView (numExportPacketsPerLID_);
+
+            // numImportPacketsPerLID_ is the output array here, so
+            // mark it as modified.  It's strictly output, so we don't
+            // have to sync from device.
+            //numImportPacketsPerLID_.sync_host ();
+            numImportPacketsPerLID_.modify_host ();
+            Teuchos::ArrayView<size_t> numImportPacketsPerLID =
+              getArrayViewFromDualView (numImportPacketsPerLID_);
+
+            if (verbose) {
+              std::ostringstream os;
+              os << *prefix << "Call doReversePostsAndWaits (3-arg)" << endl;
+              std::cerr << os.str ();
+            }
+            distor.doReversePostsAndWaits (numExportPacketsPerLID, 1,
+                                           numImportPacketsPerLID);
+
+            if (verbose) {
+              std::ostringstream os;
+              os << *prefix << "Compute totalImportPackets" << endl;
+              std::cerr << os.str ();
+            }
+            size_t totalImportPackets = 0;
+            {
+              typedef typename Kokkos::DualView<size_t*,
+                device_type>::t_host::execution_space host_exec_space;
+              typedef Kokkos::RangePolicy<host_exec_space, Array_size_type> range_type;
+              const size_t* const arrayToSum = numImportPacketsPerLID.getRawPtr ();
+              Kokkos::parallel_reduce ("Count import packets",
+                                       range_type (0, numImportPacketsPerLID.size ()),
+                                       [=] (const Array_size_type& i, size_t& lclSum) {
+                                         lclSum += arrayToSum[i];
+                                       }, totalImportPackets);
+            }
+
+            if (verbose) {
+              std::ostringstream os;
+              os << *prefix << "totalImportPackets=" << totalImportPackets
+                 << "; calling reallocImportsIfNeeded" << endl;
+              std::cerr << os.str ();
+            }
+            reallocImportsIfNeeded (totalImportPackets, verbose, prefix.get ());
+
+            // We don't need to sync imports_, because it is only for
+            // output here.  Similarly, we don't need to mark exports_
+            // as modified, since it is read only here. This legacy
+            // version of doTransfer only uses host arrays.
+            imports_.modify_host ();
+            Teuchos::ArrayView<packet_type> hostImports =
+              getArrayViewFromDualView (imports_);
+            exports_.sync_host ();
+            Teuchos::ArrayView<const packet_type> hostExports =
+              getArrayViewFromDualView (exports_);
+
+            if (verbose) {
+              std::ostringstream os;
+              os << *prefix << "Call doReversePostsAndWaits (4-arg)"
+                 << endl;
+              std::cerr << os.str ();
+            }
+            distor.doReversePostsAndWaits (hostExports,
+                                           numExportPacketsPerLID,
+                                           hostImports,
+                                           numImportPacketsPerLID);
+          }
+          else {
+            // We don't need to sync imports_, because it is only for
+            // output here.  Similarly, we don't need to mark exports_
+            // as modified, since it is read only here. This legacy
+            // version of doTransfer only uses host arrays.
+            imports_.modify_host ();
+            Teuchos::ArrayView<packet_type> hostImports =
+              getArrayViewFromDualView (imports_);
+            exports_.sync_host ();
+            Teuchos::ArrayView<const packet_type> hostExports =
+              getArrayViewFromDualView (exports_);
+
+            if (verbose) {
+              std::ostringstream os;
+              os << *prefix << "Call doReversePostsAndWaits (3-arg)"
+                 << endl;
+              std::cerr << os.str ();
+            }
+            distor.doReversePostsAndWaits (hostExports,
+                                           constantNumPackets,
+                                           hostImports);
+          }
+        }
+        else { // revOp == DoForward
+#ifdef HAVE_TPETRA_TRANSFER_TIMERS
+          Teuchos::TimeMonitor doPostsAndWaitsMon (*doPostsAndWaitsTimer_);
+#endif // HAVE_TPETRA_TRANSFER_TIMERS
+          if (constantNumPackets == 0) { //variable num-packets-per-LID:
+            // First communicate the number of packets per LID to receive.
+
+            // Make sure that host has the latest version, since we're
+            // using the version on host.  If host has the latest
+            // version already, syncing to host does nothing.
+            numExportPacketsPerLID_.sync_host ();
+            Teuchos::ArrayView<const size_t> numExportPacketsPerLID =
+              getArrayViewFromDualView (numExportPacketsPerLID_);
+
+            // numImportPacketsPerLID_ is the output array here, so
+            // mark it as modified.  It's strictly output, so we don't
+            // have to sync from device.
+            //numImportPacketsPerLID_.sync_host ();
+            numImportPacketsPerLID_.modify_host ();
+            Teuchos::ArrayView<size_t> numImportPacketsPerLID =
+              getArrayViewFromDualView (numImportPacketsPerLID_);
+
+            if (verbose) {
+              std::ostringstream os;
+              os << *prefix << "Call doPostsAndWaits (3-arg)" << endl;
+              std::cerr << os.str ();
+            }
+            distor.doPostsAndWaits (numExportPacketsPerLID, 1,
+                                    numImportPacketsPerLID);
+
+            if (verbose) {
+              std::ostringstream os;
+              os << *prefix << "Compute totalImportPackets" << endl;
+              std::cerr << os.str ();
+            }
+            size_t totalImportPackets = 0;
+            {
+              typedef typename Kokkos::DualView<size_t*,
+                device_type>::t_host::execution_space host_exec_space;
+              typedef Kokkos::RangePolicy<host_exec_space, Array_size_type> range_type;
+              const size_t* const arrayToSum = numImportPacketsPerLID.getRawPtr ();
+              Kokkos::parallel_reduce ("Count import packets",
+                                       range_type (0, numImportPacketsPerLID.size ()),
+                                       [=] (const Array_size_type& i, size_t& lclSum) {
+                                         lclSum += arrayToSum[i];
+                                       }, totalImportPackets);
+            }
+
+            if (verbose) {
+              std::ostringstream os;
+              os << *prefix << "totalImportPackets=" << totalImportPackets
+                 << "; calling reallocImportsIfNeeded" << endl;
+              std::cerr << os.str ();
+            }
+            reallocImportsIfNeeded (totalImportPackets, verbose, prefix.get ());
+
+            // We don't need to sync imports_, because it is only for
+            // output here.  Similarly, we don't need to mark exports_
+            // as modified, since it is read only here. This legacy
+            // version of doTransfer only uses host arrays.
+            imports_.modify_host ();
+            Teuchos::ArrayView<packet_type> hostImports =
+              getArrayViewFromDualView (imports_);
+            exports_.sync_host ();
+            Teuchos::ArrayView<const packet_type> hostExports =
+              getArrayViewFromDualView (exports_);
+
+            if (verbose) {
+              std::ostringstream os;
+              os << *prefix << "Call doPostsAndWaits (4-arg)" << endl;
+              std::cerr << os.str ();
+            }
+            distor.doPostsAndWaits (hostExports,
+                                    numExportPacketsPerLID,
+                                    hostImports,
+                                    numImportPacketsPerLID);
+          }
+          else {
+            // We don't need to sync imports_, because it is only for
+            // output here.  Similarly, we don't need to mark exports_
+            // as modified, since it is read only here. This legacy
+            // version of doTransfer only uses host arrays.
+            imports_.modify_host ();
+            Teuchos::ArrayView<packet_type> hostImports =
+              getArrayViewFromDualView (imports_);
+            exports_.sync_host ();
+            Teuchos::ArrayView<const packet_type> hostExports =
+              getArrayViewFromDualView (exports_);
+
+            if (verbose) {
+              std::ostringstream os;
+              os << *prefix << "Call doPostsAndWaits (3-arg)" << endl;
+              std::cerr << os.str ();
+            }
+            distor.doPostsAndWaits (hostExports,
+                                    constantNumPackets,
+                                    hostImports);
+          }
+        }
+
+        if (verbose) {
+          std::ostringstream os;
+          os << *prefix << "Preparing for unpackAndCombine" << endl;
+          std::cerr << os.str ();
+        }
+        {
+#ifdef HAVE_TPETRA_TRANSFER_TIMERS
+          Teuchos::TimeMonitor unpackAndCombineMon (*unpackAndCombineTimer_);
+#endif // HAVE_TPETRA_TRANSFER_TIMERS
+
+          // We don't need to sync imports_, because it is only for
+          // output here.  This legacy version of doTransfer only uses
+          // host arrays.
+          imports_.modify_host ();
+          Teuchos::ArrayView<packet_type> hostImports =
+            getArrayViewFromDualView (imports_);
+          // NOTE (mfh 25 Apr 2016) unpackAndCombine doesn't actually
+          // change its numImportPacketsPerLID argument, so we don't
+          // have to mark it modified here.
+          numImportPacketsPerLID_.sync_host ();
+          // FIXME (mfh 25 Apr 2016) unpackAndCombine doesn't actually
+          // change its numImportPacketsPerLID argument, so we should
+          // be able to use a const Teuchos::ArrayView here.
+          Teuchos::ArrayView<size_t> numImportPacketsPerLID =
+            getArrayViewFromDualView (numImportPacketsPerLID_);
+
+          if (verbose) {
+            std::ostringstream os;
+            os << *prefix << "Call unpackAndCombine" << endl;
+            std::cerr << os.str ();
+          }
+          unpackAndCombine (remoteLIDs, hostImports, numImportPacketsPerLID,
+                            constantNumPackets, distor, CM);
+        }
+      }
+    } // if (CM != ZERO)
+
+    if (verbose) {
+      std::ostringstream os;
+      os << *prefix << "Call releaseViews()" << endl;
+      std::cerr << os.str ();
+    }
+    this->releaseViews ();
+
+    if (verbose) {
+      std::ostringstream os;
+      os << *prefix << "Done!" << endl;
+      std::cerr << os.str ();
+    }
+  }
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+
+  template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
+  void
+  DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
+  copyAndPermuteNew (const SrcDistObject&,
+                     const size_t,
+                     const Kokkos::DualView<const local_ordinal_type*,
+                       buffer_device_type>&,
+                     const Kokkos::DualView<const local_ordinal_type*,
+                       buffer_device_type>&)
+  {}
+
+  template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
+  void
+  DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
+  packAndPrepareNew (const SrcDistObject&,
+                     const Kokkos::DualView<const local_ordinal_type*,
+                       buffer_device_type>&,
+                     Kokkos::DualView<packet_type*,
+                       buffer_device_type>&,
+                     Kokkos::DualView<size_t*,
+                       buffer_device_type>,
+                     size_t&,
+                     Distributor&)
+  {}
+
+  template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
+  void
+  DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
+  unpackAndCombineNew (const Kokkos::DualView<const local_ordinal_type*,
+                         buffer_device_type>& /* importLIDs */,
+                       Kokkos::DualView<packet_type*,
+                         buffer_device_type> /* imports */,
+                       Kokkos::DualView<size_t*,
+                         buffer_device_type> /* numPacketsPerLID */,
+                       const size_t /* constantNumPackets */,
+                       Distributor& /* distor */,
+                       const CombineMode /* combineMode */)
+  {}
+
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+  template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
+  void TPETRA_DEPRECATED
+  DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
+  copyAndPermute (const SrcDistObject& /* source */,
+                  const size_t /* numSameIDs */,
+                  const Teuchos::ArrayView<const local_ordinal_type>& /* permuteToLIDs */,
+                  const Teuchos::ArrayView<const local_ordinal_type>& /* permuteFromLIDs */)
+  {}
+
+  template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
+  void TPETRA_DEPRECATED
+  DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
+  packAndPrepare (const SrcDistObject& /* source */,
+                  const Teuchos::ArrayView<const local_ordinal_type>& /* exportLIDs */,
+                  Teuchos::Array<packet_type>& /* exports */,
+                  const Teuchos::ArrayView<size_t>& /* numPacketsPerLID */,
+                  size_t& /* constantNumPackets */,
+                  Distributor& /* distor */)
+  {}
+
+  template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
+  void TPETRA_DEPRECATED
+  DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
+  unpackAndCombine (const Teuchos::ArrayView<const local_ordinal_type>& /* importLIDs */,
+                    const Teuchos::ArrayView<const packet_type>& /* imports */,
+                    const Teuchos::ArrayView<size_t>& /* numPacketsPerLID */,
+                    const size_t /* constantNumPackets */,
+                    Distributor& /* distor */,
+                    const CombineMode /* combineMode */)
+  {}
+
+  template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
+  void TPETRA_DEPRECATED
+  DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
+  createViews () const
+  {}
+
+  template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
+  void TPETRA_DEPRECATED
+  DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
+  createViewsNonConst (KokkosClassic::ReadWriteOption /*rwo*/)
+  {}
+
+  template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
+  void TPETRA_DEPRECATED
+  DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
+  releaseViews () const
+  {}
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+
   template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
   void
   DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
@@ -1863,24 +1897,6 @@ namespace Tpetra {
     RCP<FancyOStream> out = getFancyOStream (rcpFromRef (os));
     this->describe (*out, Teuchos::VERB_DEFAULT);
   }
-
-  template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
-  void
-  DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
-  createViews () const
-  {}
-
-  template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
-  void
-  DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
-  createViewsNonConst (KokkosClassic::ReadWriteOption /*rwo*/)
-  {}
-
-  template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
-  void
-  DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
-  releaseViews () const
-  {}
 
   template<class DistObjectType>
   void

--- a/packages/tpetra/core/src/Tpetra_Experimental_BlockCrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Experimental_BlockCrsMatrix_decl.hpp
@@ -749,34 +749,49 @@ protected:
   virtual bool checkSizes (const ::Tpetra::SrcDistObject& source);
 
   virtual void
-  copyAndPermuteNew (const SrcDistObject& sourceObj,
-                     const size_t numSameIDs,
-                     const Kokkos::DualView<const local_ordinal_type*,
-                       buffer_device_type>& permuteToLIDs,
-                     const Kokkos::DualView<const local_ordinal_type*,
-                       buffer_device_type>& permuteFromLIDs);
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+  copyAndPermuteNew
+#else // TPETRA_ENABLE_DEPRECATED_CODE
+  copyAndPermute
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+  (const SrcDistObject& sourceObj,
+   const size_t numSameIDs,
+   const Kokkos::DualView<const local_ordinal_type*,
+     buffer_device_type>& permuteToLIDs,
+   const Kokkos::DualView<const local_ordinal_type*,
+     buffer_device_type>& permuteFromLIDs);
 
   virtual void
-  packAndPrepareNew (const SrcDistObject& sourceObj,
-                     const Kokkos::DualView<const local_ordinal_type*,
-                       buffer_device_type>& exportLIDs,
-                     Kokkos::DualView<packet_type*,
-                       buffer_device_type>& exports,
-                     Kokkos::DualView<size_t*,
-                       buffer_device_type> numPacketsPerLID,
-                     size_t& constantNumPackets,
-                     Distributor& /* distor */);
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+  packAndPrepareNew
+#else // TPETRA_ENABLE_DEPRECATED_CODE
+  packAndPrepare
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+  (const SrcDistObject& sourceObj,
+   const Kokkos::DualView<const local_ordinal_type*,
+     buffer_device_type>& exportLIDs,
+   Kokkos::DualView<packet_type*,
+     buffer_device_type>& exports,
+   Kokkos::DualView<size_t*,
+     buffer_device_type> numPacketsPerLID,
+   size_t& constantNumPackets,
+   Distributor& /* distor */);
 
   virtual void
-  unpackAndCombineNew (const Kokkos::DualView<const local_ordinal_type*,
-                         buffer_device_type>& importLIDs,
-                       Kokkos::DualView<packet_type*,
-                         buffer_device_type> imports,
-                       Kokkos::DualView<size_t*,
-                         buffer_device_type> numPacketsPerLID,
-                       const size_t constantNumPackets,
-                       Distributor& /* distor */,
-                       const CombineMode combineMode);
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+  unpackAndCombineNew
+#else // TPETRA_ENABLE_DEPRECATED_CODE
+  unpackAndCombine
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+  (const Kokkos::DualView<const local_ordinal_type*,
+     buffer_device_type>& importLIDs,
+   Kokkos::DualView<packet_type*,
+     buffer_device_type> imports,
+   Kokkos::DualView<size_t*,
+     buffer_device_type> numPacketsPerLID,
+   const size_t constantNumPackets,
+   Distributor& /* distor */,
+   const CombineMode combineMode);
   //@}
 
 private:

--- a/packages/tpetra/core/src/Tpetra_Experimental_BlockCrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Experimental_BlockCrsMatrix_decl.hpp
@@ -739,18 +739,14 @@ protected:
   /// Users don't have to worry about these methods.
   //@{
 
-  virtual bool checkSizes (const ::Tpetra::SrcDistObject& source);
-  //! Whether this class implements the old or new interface of DistObject.
-  virtual bool useNewInterface () {
-    return true;
-  }
-
   /// \typedef buffer_device_type
   /// \brief Kokkos::Device specialization for communication buffers.
   ///
   /// See #1088 for why this is not just <tt>device_type::device_type</tt>.
   using buffer_device_type = typename DistObject<Scalar, LO, GO,
                                                  Node>::buffer_device_type;
+
+  virtual bool checkSizes (const ::Tpetra::SrcDistObject& source);
 
   virtual void
   copyAndPermuteNew (const SrcDistObject& sourceObj,

--- a/packages/tpetra/core/src/Tpetra_Experimental_BlockCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Experimental_BlockCrsMatrix_def.hpp
@@ -2179,12 +2179,17 @@ public:
   template<class Scalar, class LO, class GO, class Node>
   void
   BlockCrsMatrix<Scalar, LO, GO, Node>::
-  copyAndPermuteNew (const ::Tpetra::SrcDistObject& source,
-                     const size_t numSameIDs,
-                     const Kokkos::DualView<const local_ordinal_type*,
-                       buffer_device_type>& permuteToLIDs,
-                     const Kokkos::DualView<const local_ordinal_type*,
-                       buffer_device_type>& permuteFromLIDs)
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+  copyAndPermuteNew
+#else // TPETRA_ENABLE_DEPRECATED_CODE
+  copyAndPermute
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+  (const ::Tpetra::SrcDistObject& source,
+   const size_t numSameIDs,
+   const Kokkos::DualView<const local_ordinal_type*,
+     buffer_device_type>& permuteToLIDs,
+   const Kokkos::DualView<const local_ordinal_type*,
+     buffer_device_type>& permuteFromLIDs)
   {
     using ::Tpetra::Details::Behavior;
     using ::Tpetra::Details::dualViewStatusToString;
@@ -2192,7 +2197,7 @@ public:
     using std::endl;
     using this_type = BlockCrsMatrix<Scalar, LO, GO, Node>;
 
-    ProfilingRegion profile_region("Tpetra::BlockCrsMatrix::copyAndPermuteNew");
+    ProfilingRegion profile_region("Tpetra::BlockCrsMatrix::copyAndPermute");
     const bool debug = Behavior::debug();
     const bool verbose = Behavior::verbose();
 
@@ -2201,7 +2206,7 @@ public:
     {
       std::ostringstream os;
       const int myRank = this->graph_.getRowMap ()->getComm ()->getRank ();
-      os << "Proc " << myRank << ": BlockCrsMatrix::copyAndPermuteNew : " << endl;
+      os << "Proc " << myRank << ": BlockCrsMatrix::copyAndPermute : " << endl;
       prefix = os.str();
     }
 
@@ -2837,15 +2842,20 @@ public:
   template<class Scalar, class LO, class GO, class Node>
   void
   BlockCrsMatrix<Scalar, LO, GO, Node>::
-  packAndPrepareNew (const ::Tpetra::SrcDistObject& source,
-                     const Kokkos::DualView<const local_ordinal_type*,
-                       buffer_device_type>& exportLIDs,
-                     Kokkos::DualView<packet_type*,
-                       buffer_device_type>& exports, // output
-                     Kokkos::DualView<size_t*,
-                       buffer_device_type> numPacketsPerLID, // output
-                     size_t& constantNumPackets,
-                     Distributor& /* distor */)
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+  packAndPrepareNew
+#else // TPETRA_ENABLE_DEPRECATED_CODE
+  packAndPrepare
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+  (const ::Tpetra::SrcDistObject& source,
+   const Kokkos::DualView<const local_ordinal_type*,
+     buffer_device_type>& exportLIDs,
+   Kokkos::DualView<packet_type*,
+     buffer_device_type>& exports, // output
+   Kokkos::DualView<size_t*,
+     buffer_device_type> numPacketsPerLID, // output
+   size_t& constantNumPackets,
+   Distributor& /* distor */)
   {
     using ::Tpetra::Details::Behavior;
     using ::Tpetra::Details::dualViewStatusToString;
@@ -2856,7 +2866,7 @@ public:
 
     typedef BlockCrsMatrix<Scalar, LO, GO, Node> this_type;
 
-    ProfilingRegion profile_region("Tpetra::BlockCrsMatrix::packAndPrepareNew");
+    ProfilingRegion profile_region("Tpetra::BlockCrsMatrix::packAndPrepare");
 
     const bool debug = Behavior::debug();
     const bool verbose = Behavior::verbose();
@@ -2866,7 +2876,7 @@ public:
     {
       std::ostringstream os;
       const int myRank = this->graph_.getRowMap ()->getComm ()->getRank ();
-      os << "Proc " << myRank << ": BlockCrsMatrix::packAndPrepareNew : " << std::endl;
+      os << "Proc " << myRank << ": BlockCrsMatrix::packAndPrepare: " << std::endl;
       prefix = os.str();
     }
 
@@ -3085,15 +3095,20 @@ public:
   template<class Scalar, class LO, class GO, class Node>
   void
   BlockCrsMatrix<Scalar, LO, GO, Node>::
-  unpackAndCombineNew (const Kokkos::DualView<const local_ordinal_type*,
-                         buffer_device_type>& importLIDs,
-                       Kokkos::DualView<packet_type*,
-                         buffer_device_type> imports,
-                       Kokkos::DualView<size_t*,
-                         buffer_device_type> numPacketsPerLID,
-                       const size_t /* constantNumPackets */,
-                       Distributor& /* distor */,
-                       const CombineMode combineMode)
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+  unpackAndCombineNew
+#else // TPETRA_ENABLE_DEPRECATED_CODE
+  unpackAndCombine
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+  (const Kokkos::DualView<const local_ordinal_type*,
+     buffer_device_type>& importLIDs,
+   Kokkos::DualView<packet_type*,
+     buffer_device_type> imports,
+   Kokkos::DualView<size_t*,
+     buffer_device_type> numPacketsPerLID,
+   const size_t /* constantNumPackets */,
+   Distributor& /* distor */,
+   const CombineMode combineMode)
   {
     using ::Tpetra::Details::Behavior;
     using ::Tpetra::Details::dualViewStatusToString;
@@ -3103,7 +3118,7 @@ public:
     using host_exec =
       typename Kokkos::View<int*, device_type>::HostMirror::execution_space;
 
-    ProfilingRegion profile_region("Tpetra::BlockCrsMatrix::unpackAndCombineNew");
+    ProfilingRegion profile_region("Tpetra::BlockCrsMatrix::unpackAndCombine");
     const bool verbose = Behavior::verbose ();
 
     // Define this function prefix
@@ -3113,7 +3128,7 @@ public:
       auto map = this->graph_.getRowMap ();
       auto comm = map.is_null () ? Teuchos::null : map->getComm ();
       const int myRank = comm.is_null () ? -1 : comm->getRank ();
-      os << "Proc " << myRank << ": Tpetra::BlockCrsMatrix::unpackAndCombineNew: ";
+      os << "Proc " << myRank << ": Tpetra::BlockCrsMatrix::unpackAndCombine: ";
       prefix = os.str ();
       if (verbose) {
         os << "Start" << endl;
@@ -3260,7 +3275,7 @@ public:
     {
       const auto policy = Kokkos::RangePolicy<host_exec>(size_t(0), numImportLIDs+1);
       Kokkos::parallel_scan
-        ("Tpetra::BlockCrsMatrix::unpackAndCombineNew: offsets", policy,
+        ("Tpetra::BlockCrsMatrix::unpackAndCombine: offsets", policy,
          [=] (const size_t &i, size_t &update, const bool &final) {
           if (final) offset(i) = update;
           update += (i == numImportLIDs ? 0 : numPacketsPerLIDHost(i));
@@ -3285,7 +3300,7 @@ public:
       using host_scratch_space = typename host_exec::scratch_memory_space;
       using pair_type = Kokkos::pair<size_t, size_t>;
       Kokkos::parallel_for
-        ("Tpetra::BlockCrsMatrix::unpackAndCombineNew: unpack", policy,
+        ("Tpetra::BlockCrsMatrix::unpackAndCombine: unpack", policy,
          [=] (const typename policy_type::member_type& member) {
           const size_t i = member.league_rank();
 

--- a/packages/tpetra/core/src/Tpetra_Experimental_BlockMultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Experimental_BlockMultiVector_decl.hpp
@@ -604,34 +604,49 @@ protected:
   virtual bool checkSizes (const Tpetra::SrcDistObject& source);
 
   virtual void
-  copyAndPermuteNew (const SrcDistObject& source,
-                     const size_t numSameIDs,
-                     const Kokkos::DualView<const local_ordinal_type*,
-                       buffer_device_type>& permuteToLIDs,
-                     const Kokkos::DualView<const local_ordinal_type*,
-                       buffer_device_type>& permuteFromLIDs);
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+  copyAndPermuteNew
+#else // TPETRA_ENABLE_DEPRECATED_CODE
+  copyAndPermute
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+  (const SrcDistObject& source,
+   const size_t numSameIDs,
+   const Kokkos::DualView<const local_ordinal_type*,
+     buffer_device_type>& permuteToLIDs,
+   const Kokkos::DualView<const local_ordinal_type*,
+     buffer_device_type>& permuteFromLIDs);
 
   virtual void
-  packAndPrepareNew (const SrcDistObject& source,
-                     const Kokkos::DualView<const local_ordinal_type*,
-                       buffer_device_type>& exportLIDs,
-                     Kokkos::DualView<packet_type*,
-                       buffer_device_type>& exports,
-                     Kokkos::DualView<size_t*,
-                       buffer_device_type> numPacketsPerLID,
-                     size_t& constantNumPackets,
-                     Distributor& distor);
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+  packAndPrepareNew
+#else // TPETRA_ENABLE_DEPRECATED_CODE
+  packAndPrepare
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+  (const SrcDistObject& source,
+   const Kokkos::DualView<const local_ordinal_type*,
+     buffer_device_type>& exportLIDs,
+   Kokkos::DualView<packet_type*,
+     buffer_device_type>& exports,
+   Kokkos::DualView<size_t*,
+     buffer_device_type> numPacketsPerLID,
+   size_t& constantNumPackets,
+   Distributor& distor);
 
   virtual void
-  unpackAndCombineNew (const Kokkos::DualView<const local_ordinal_type*,
-                         buffer_device_type>& importLIDs,
-                       Kokkos::DualView<packet_type*,
-                         buffer_device_type> imports,
-                       Kokkos::DualView<size_t*,
-                         buffer_device_type> numPacketsPerLID,
-                       const size_t constantNumPackets,
-                       Distributor& distor,
-                       const CombineMode combineMode);
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+  unpackAndCombineNew
+#else // TPETRA_ENABLE_DEPRECATED_CODE
+  unpackAndCombine
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+  (const Kokkos::DualView<const local_ordinal_type*,
+     buffer_device_type>& importLIDs,
+   Kokkos::DualView<packet_type*,
+     buffer_device_type> imports,
+   Kokkos::DualView<size_t*,
+     buffer_device_type> numPacketsPerLID,
+   const size_t constantNumPackets,
+   Distributor& distor,
+   const CombineMode combineMode);
 
   //@}
 
@@ -701,7 +716,7 @@ private:
   static Teuchos::RCP<const BlockMultiVector<Scalar, LO, GO, Node> >
   getBlockMultiVectorFromSrcDistObject (const Tpetra::SrcDistObject& src);
 
-  /// \brief Implementation of copyAndPermuteNew.
+  /// \brief Implementation of copyAndPermute.
   ///
   /// \tparam LO The type of local indices.
   /// \tparam GO The type of global indices.
@@ -711,14 +726,14 @@ private:
   ///   on a BlockMultiVector.
   /// \param src [in] "Source" object of an Export or Import operation
   ///   on a BlockMultiVector.
-  /// \param numSameIDs [in] See DistObject::copyAndPermuteNew.
-  /// \param permuteToLIDs [in] See DistObject::copyAndPermuteNew.
-  /// \param permuteFromLIDs [in] See DistObject::copyAndPermuteNew.
+  /// \param numSameIDs [in] See DistObject::copyAndPermute.
+  /// \param permuteToLIDs [in] See DistObject::copyAndPermute.
+  /// \param permuteFromLIDs [in] See DistObject::copyAndPermute.
   ///
   /// \return (Error code, pointer to error message).  If no error,
   ///   then error code is zero and error message pointer is null.
   std::pair<int, std::unique_ptr<std::string>>
-  copyAndPermuteNewImpl
+  copyAndPermuteImpl
     (const BlockMultiVector<Scalar, LO, GO, Node>& src,
      const size_t numSameIDs,
      const Kokkos::DualView<
@@ -731,7 +746,7 @@ private:
      >& permuteFromLIDs);
 
   std::pair<int, std::unique_ptr<std::string>>
-  packAndPrepareNewImpl
+  packAndPrepareImpl
     (const Kokkos::DualView<
        const local_ordinal_type*,
        buffer_device_type
@@ -748,7 +763,7 @@ private:
      Distributor& /* distor */ ) const;
 
   std::pair<int, std::unique_ptr<std::string>>
-  unpackAndCombineNewImpl
+  unpackAndCombineImpl
     (const Kokkos::DualView<
        const local_ordinal_type*,
        buffer_device_type

--- a/packages/tpetra/core/src/Tpetra_Experimental_BlockMultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Experimental_BlockMultiVector_decl.hpp
@@ -603,8 +603,6 @@ protected:
 
   virtual bool checkSizes (const Tpetra::SrcDistObject& source);
 
-  virtual bool useNewInterface ();
-
   virtual void
   copyAndPermuteNew (const SrcDistObject& source,
                      const size_t numSameIDs,

--- a/packages/tpetra/core/src/Tpetra_Experimental_BlockMultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Experimental_BlockMultiVector_def.hpp
@@ -485,13 +485,6 @@ checkSizes (const Tpetra::SrcDistObject& src)
   return ! getMultiVectorFromSrcDistObject (src).is_null ();
 }
 
-template<class Scalar, class LO, class GO, class Node>
-bool BlockMultiVector<Scalar, LO, GO, Node>::
-useNewInterface ()
-{
-  return true;
-}
-
 template<class SC, class LO, class GO, class NT>
 std::pair<int, std::unique_ptr<std::string>>
 BlockMultiVector<SC, LO, GO, NT>::

--- a/packages/tpetra/core/src/Tpetra_Experimental_BlockMultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Experimental_BlockMultiVector_def.hpp
@@ -488,7 +488,7 @@ checkSizes (const Tpetra::SrcDistObject& src)
 template<class SC, class LO, class GO, class NT>
 std::pair<int, std::unique_ptr<std::string>>
 BlockMultiVector<SC, LO, GO, NT>::
-copyAndPermuteNewImpl
+copyAndPermuteImpl
   (const BlockMultiVector<SC, LO, GO, NT>& src,
    const size_t numSameIDs,
    const Kokkos::DualView<
@@ -501,7 +501,7 @@ copyAndPermuteNewImpl
    >& permuteFromLIDs)
 {
   using std::endl;
-  const char tfecfFuncName[] = "copyAndPermuteNewImpl: ";
+  const char tfecfFuncName[] = "copyAndPermuteImpl: ";
   std::unique_ptr<std::string> errMsg;
   const bool debug = ::Tpetra::Details::Behavior::debug ("BlockMultiVector");
   const int myRank = src.getMap ()->getComm ()->getRank ();
@@ -577,34 +577,39 @@ copyAndPermuteNewImpl
 
 template<class Scalar, class LO, class GO, class Node>
 void BlockMultiVector<Scalar, LO, GO, Node>::
-copyAndPermuteNew (const SrcDistObject& src,
-                   const size_t numSameIDs,
-                   const Kokkos::DualView<const local_ordinal_type*,
-                     buffer_device_type>& permuteToLIDs,
-                   const Kokkos::DualView<const local_ordinal_type*,
-                     buffer_device_type>& permuteFromLIDs)
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+copyAndPermuteNew
+#else // TPETRA_ENABLE_DEPRECATED_CODE
+copyAndPermute
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+(const SrcDistObject& src,
+ const size_t numSameIDs,
+ const Kokkos::DualView<const local_ordinal_type*,
+   buffer_device_type>& permuteToLIDs,
+ const Kokkos::DualView<const local_ordinal_type*,
+   buffer_device_type>& permuteFromLIDs)
 {
-  const char tfecfFuncName[] = "copyAndPermuteNew: ";
+  const char tfecfFuncName[] = "copyAndPermute: ";
 
   auto srcPtr = getBlockMultiVectorFromSrcDistObject (src);
   TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
     (srcPtr.is_null (), std::invalid_argument,
      "The source of an Import or Export to a BlockMultiVector "
      "must also be a BlockMultiVector.");
-  const auto ret = copyAndPermuteNewImpl (*srcPtr, numSameIDs,
-                                          permuteToLIDs, permuteFromLIDs);
+  const auto ret = copyAndPermuteImpl (*srcPtr, numSameIDs,
+                                       permuteToLIDs, permuteFromLIDs);
   // TODO (mfh 15 Apr 2019) Instead of throwing here, which could
   // cause an MPI parallel hang, we should record the error in *this
   // (the target BMV instance).
   TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-    (ret.first != 0, std::runtime_error, "copyAndPermuteNewImpl "
+    (ret.first != 0, std::runtime_error, "copyAndPermuteImpl "
      "reports an error: " << * (ret.second));
 }
 
 template<class SC, class LO, class GO, class NT>
 std::pair<int, std::unique_ptr<std::string>>
 BlockMultiVector<SC, LO, GO, NT>::
-packAndPrepareNewImpl
+packAndPrepareImpl
   (const Kokkos::DualView<
      const local_ordinal_type*,
      buffer_device_type
@@ -626,7 +631,7 @@ packAndPrepareNewImpl
   using host_device_type = typename exports_dv_type::t_host::device_type;
   using dst_little_vec_type = Kokkos::View<IST*, host_device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
-  const char tfecfFuncName[] = "packAndPrepareNewImpl: ";
+  const char tfecfFuncName[] = "packAndPrepareImpl: ";
   std::unique_ptr<std::string> errMsg;
   const bool debug = ::Tpetra::Details::Behavior::debug ("BlockMultiVector");
 
@@ -700,17 +705,22 @@ packAndPrepareNewImpl
 
 template<class Scalar, class LO, class GO, class Node>
 void BlockMultiVector<Scalar, LO, GO, Node>::
-packAndPrepareNew (const SrcDistObject& src,
-                   const Kokkos::DualView<const local_ordinal_type*,
-                     buffer_device_type>& exportLIDs,
-                   Kokkos::DualView<packet_type*,
-                     buffer_device_type>& exports,
-                   Kokkos::DualView<size_t*,
-                     buffer_device_type> numPacketsPerLID,
-                   size_t& constantNumPackets,
-                   Distributor& distor)
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+packAndPrepareNew
+#else // TPETRA_ENABLE_DEPRECATED_CODE
+packAndPrepare
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+(const SrcDistObject& src,
+ const Kokkos::DualView<const local_ordinal_type*,
+   buffer_device_type>& exportLIDs,
+ Kokkos::DualView<packet_type*,
+   buffer_device_type>& exports,
+ Kokkos::DualView<size_t*,
+   buffer_device_type> numPacketsPerLID,
+ size_t& constantNumPackets,
+ Distributor& distor)
 {
-  const char tfecfFuncName[] = "packAndPrepareNew: ";
+  const char tfecfFuncName[] = "packAndPrepare: ";
 
   auto srcAsBmvPtr = getBlockMultiVectorFromSrcDistObject (src);
   TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
@@ -718,21 +728,21 @@ packAndPrepareNew (const SrcDistObject& src,
      "The source of an Import or Export to a BlockMultiVector "
      "must also be a BlockMultiVector.");
   const auto ret =
-    srcAsBmvPtr->packAndPrepareNewImpl (exportLIDs, exports,
-                                        numPacketsPerLID,
-                                        constantNumPackets, distor);
+    srcAsBmvPtr->packAndPrepareImpl (exportLIDs, exports,
+                                     numPacketsPerLID,
+                                     constantNumPackets, distor);
   // TODO (mfh 15 Apr 2019) Instead of throwing here, which could
   // cause an MPI parallel hang, we should record the error in *this
   // (the target BMV instance).
   TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-    (ret.first != 0, std::runtime_error, "packAndPrepareNewImpl "
+    (ret.first != 0, std::runtime_error, "packAndPrepareImpl "
      "reports an error: " << * (ret.second));
 }
 
 template<class SC, class LO, class GO, class NT>
 std::pair<int, std::unique_ptr<std::string>>
 BlockMultiVector<SC, LO, GO, NT>::
-unpackAndCombineNewImpl
+unpackAndCombineImpl
   (const Kokkos::DualView<
      const local_ordinal_type*,
      buffer_device_type
@@ -756,7 +766,7 @@ unpackAndCombineNewImpl
   using host_device_type = typename imports_dv_type::t_host::device_type;
   using src_little_vec_type = Kokkos::View<const IST*, host_device_type,
     Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
-  const char tfecfFuncName[] = "unpackAndCombineNewImpl: ";
+  const char tfecfFuncName[] = "unpackAndCombineImpl: ";
   std::unique_ptr<std::string> errMsg;
   const bool debug = ::Tpetra::Details::Behavior::debug ("BlockMultiVector");
 
@@ -847,25 +857,30 @@ unpackAndCombineNewImpl
 
 template<class Scalar, class LO, class GO, class Node>
 void BlockMultiVector<Scalar, LO, GO, Node>::
-unpackAndCombineNew (const Kokkos::DualView<const local_ordinal_type*,
-                       buffer_device_type>& importLIDs,
-                     Kokkos::DualView<packet_type*,
-                       buffer_device_type> imports,
-                     Kokkos::DualView<size_t*,
-                       buffer_device_type> numPacketsPerLID,
-                     const size_t constantNumPackets,
-                     Distributor& distor,
-                     const CombineMode combineMode)
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+unpackAndCombineNew
+#else // TPETRA_ENABLE_DEPRECATED_CODE
+unpackAndCombine
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+(const Kokkos::DualView<const local_ordinal_type*,
+   buffer_device_type>& importLIDs,
+ Kokkos::DualView<packet_type*,
+   buffer_device_type> imports,
+ Kokkos::DualView<size_t*,
+   buffer_device_type> numPacketsPerLID,
+ const size_t constantNumPackets,
+ Distributor& distor,
+ const CombineMode combineMode)
 {
-  const char tfecfFuncName[] = "unpackAndCombineNew: ";
+  const char tfecfFuncName[] = "unpackAndCombine: ";
   const auto ret =
-    unpackAndCombineNewImpl (importLIDs, imports, numPacketsPerLID,
-                             constantNumPackets, distor, combineMode);
+    unpackAndCombineImpl (importLIDs, imports, numPacketsPerLID,
+                          constantNumPackets, distor, combineMode);
   // TODO (mfh 15 Apr 2019) Instead of throwing here, which could
   // cause an MPI parallel hang, we should record the error in *this
   // (the target BMV instance).
   TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-    (ret.first != 0, std::runtime_error, "unpackAndCombineNewImpl "
+    (ret.first != 0, std::runtime_error, "unpackAndCombineImpl "
      "reports an error: " << * (ret.second));
 }
 

--- a/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
@@ -2444,38 +2444,53 @@ namespace Tpetra {
     virtual size_t constantNumberOfPackets () const;
 
     virtual void
-    copyAndPermuteNew (const SrcDistObject& sourceObj,
-                       const size_t numSameIDs,
-                       const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& permuteToLIDs,
-                       const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& permuteFromLIDs);
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+    copyAndPermuteNew
+#else // TPETRA_ENABLE_DEPRECATED_CODE
+    copyAndPermute
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+    (const SrcDistObject& sourceObj,
+     const size_t numSameIDs,
+     const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& permuteToLIDs,
+     const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& permuteFromLIDs);
 
     virtual void
-    packAndPrepareNew (const SrcDistObject& sourceObj,
-                       const Kokkos::DualView<
-                         const local_ordinal_type*,
-                         buffer_device_type>& exportLIDs,
-                       Kokkos::DualView<
-                         impl_scalar_type*,
-                         buffer_device_type>& exports,
-                       Kokkos::DualView<
-                         size_t*,
-                         buffer_device_type> /* numPacketsPerLID */,
-                       size_t& constantNumPackets,
-                       Distributor& /* distor */);
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+    packAndPrepareNew
+#else // TPETRA_ENABLE_DEPRECATED_CODE
+    packAndPrepare
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+    (const SrcDistObject& sourceObj,
+     const Kokkos::DualView<
+       const local_ordinal_type*,
+       buffer_device_type>& exportLIDs,
+     Kokkos::DualView<
+       impl_scalar_type*,
+       buffer_device_type>& exports,
+     Kokkos::DualView<
+       size_t*,
+       buffer_device_type> /* numPacketsPerLID */,
+     size_t& constantNumPackets,
+     Distributor& /* distor */);
 
     virtual void
-    unpackAndCombineNew (const Kokkos::DualView<
-                           const local_ordinal_type*,
-                           buffer_device_type>& importLIDs,
-                         Kokkos::DualView<
-                           impl_scalar_type*,
-                           buffer_device_type> imports,
-                         Kokkos::DualView<
-                           size_t*,
-                           buffer_device_type> /* numPacketsPerLID */,
-                         const size_t constantNumPackets,
-                         Distributor& /* distor */,
-                         const CombineMode CM);
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+    unpackAndCombineNew
+#else // TPETRA_ENABLE_DEPRECATED_CODE
+    unpackAndCombine
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+    (const Kokkos::DualView<
+       const local_ordinal_type*,
+       buffer_device_type>& importLIDs,
+     Kokkos::DualView<
+       impl_scalar_type*,
+       buffer_device_type> imports,
+     Kokkos::DualView<
+       size_t*,
+       buffer_device_type> /* numPacketsPerLID */,
+     const size_t constantNumPackets,
+     Distributor& /* distor */,
+     const CombineMode CM);
     //@}
   }; // class MultiVector
 

--- a/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
@@ -2443,9 +2443,6 @@ namespace Tpetra {
     //! Number of packets to send per LID
     virtual size_t constantNumberOfPackets () const;
 
-    //! Whether this class implements the old or new interface of DistObject.
-    virtual bool useNewInterface () { return true; }
-
     virtual void
     copyAndPermuteNew (const SrcDistObject& sourceObj,
                        const size_t numSameIDs,

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -867,10 +867,15 @@ namespace Tpetra {
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void
   MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  copyAndPermuteNew (const SrcDistObject& sourceObj,
-                     const size_t numSameIDs,
-                     const Kokkos::DualView<const LocalOrdinal*, buffer_device_type>& permuteToLIDs,
-                     const Kokkos::DualView<const LocalOrdinal*, buffer_device_type>& permuteFromLIDs)
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+  copyAndPermuteNew
+#else // TPETRA_ENABLE_DEPRECATED_CODE
+  copyAndPermute
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+  (const SrcDistObject& sourceObj,
+   const size_t numSameIDs,
+   const Kokkos::DualView<const LocalOrdinal*, buffer_device_type>& permuteToLIDs,
+   const Kokkos::DualView<const LocalOrdinal*, buffer_device_type>& permuteFromLIDs)
   {
     using ::Tpetra::Details::Behavior;
     using ::Tpetra::Details::getDualViewCopyFromArrayView;
@@ -880,8 +885,8 @@ namespace Tpetra {
     using KokkosRefactor::Details::permute_array_multi_column_variable_stride;
     using Kokkos::Compat::create_const_view;
     using MV = MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
-    const char tfecfFuncName[] = "copyAndPermuteNew: ";
-    ProfilingRegion regionCAP ("Tpetra::MultiVector::copyAndPermuteNew");
+    const char tfecfFuncName[] = "copyAndPermute: ";
+    ProfilingRegion regionCAP ("Tpetra::MultiVector::copyAndPermute");
 
     const bool verbose = Behavior::verbose ();
     std::unique_ptr<std::string> prefix;
@@ -890,7 +895,7 @@ namespace Tpetra {
       auto comm = map.is_null () ? Teuchos::null : map->getComm ();
       const int myRank = comm.is_null () ? -1 : comm->getRank ();
       std::ostringstream os;
-      os << "Proc " << myRank << ": MV::copyAndPermuteNew: ";
+      os << "Proc " << myRank << ": MV::copyAndPermute: ";
       prefix = std::unique_ptr<std::string> (new std::string (os.str ()));
       os << "Start" << endl;
       std::cerr << os.str ();
@@ -1174,12 +1179,17 @@ namespace Tpetra {
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void
   MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  packAndPrepareNew (const SrcDistObject& sourceObj,
-                     const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& exportLIDs,
-                     Kokkos::DualView<impl_scalar_type*, buffer_device_type>& exports,
-                     Kokkos::DualView<size_t*, buffer_device_type> /* numExportPacketsPerLID */,
-                     size_t& constantNumPackets,
-                     Distributor & /* distor */ )
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+  packAndPrepareNew
+#else // TPETRA_ENABLE_DEPRECATED_CODE
+  packAndPrepare
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+  (const SrcDistObject& sourceObj,
+   const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& exportLIDs,
+   Kokkos::DualView<impl_scalar_type*, buffer_device_type>& exports,
+   Kokkos::DualView<size_t*, buffer_device_type> /* numExportPacketsPerLID */,
+   size_t& constantNumPackets,
+   Distributor & /* distor */ )
   {
     using ::Tpetra::Details::Behavior;
     using ::Tpetra::Details::ProfilingRegion;
@@ -1188,8 +1198,8 @@ namespace Tpetra {
     using Kokkos::Compat::getKokkosViewDeepCopy;
     using std::endl;
     using MV = MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
-    const char tfecfFuncName[] = "packAndPrepareNew: ";
-    ProfilingRegion regionPAP ("Tpetra::MultiVector::packAndPrepareNew");
+    const char tfecfFuncName[] = "packAndPrepare: ";
+    ProfilingRegion regionPAP ("Tpetra::MultiVector::packAndPrepare");
 
     // mfh 09 Sep 2016, 26 Sep 2017: The pack and unpack functions now
     // have the option to check indices.  We do so when Tpetra is in
@@ -1210,7 +1220,7 @@ namespace Tpetra {
       auto comm = map.is_null () ? Teuchos::null : map->getComm ();
       const int myRank = comm.is_null () ? -1 : comm->getRank ();
       std::ostringstream os;
-      os << "Proc " << myRank << ": MV::packAndPrepareNew: ";
+      os << "Proc " << myRank << ": MV::packAndPrepare: ";
       prefix = std::unique_ptr<std::string> (new std::string (os.str ()));
       os << "Start" << endl;
       std::cerr << os.str ();
@@ -1418,12 +1428,17 @@ namespace Tpetra {
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void
   MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  unpackAndCombineNew (const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& importLIDs,
-                       Kokkos::DualView<impl_scalar_type*, buffer_device_type> imports,
-                       Kokkos::DualView<size_t*, buffer_device_type> /* numPacketsPerLID */,
-                       const size_t constantNumPackets,
-                       Distributor& /* distor */,
-                       const CombineMode CM)
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+  unpackAndCombineNew
+#else // TPETRA_ENABLE_DEPRECATED_CODE
+  unpackAndCombine
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+  (const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& importLIDs,
+   Kokkos::DualView<impl_scalar_type*, buffer_device_type> imports,
+   Kokkos::DualView<size_t*, buffer_device_type> /* numPacketsPerLID */,
+   const size_t constantNumPackets,
+   Distributor& /* distor */,
+   const CombineMode CM)
   {
     using ::Tpetra::Details::Behavior;
     using ::Tpetra::Details::ProfilingRegion;
@@ -1432,8 +1447,8 @@ namespace Tpetra {
     using Kokkos::Compat::getKokkosViewDeepCopy;
     using std::endl;
     using IST = impl_scalar_type;
-    const char tfecfFuncName[] = "unpackAndCombineNew: ";
-    ProfilingRegion regionUAC ("Tpetra::MultiVector::unpackAndCombineNew");
+    const char tfecfFuncName[] = "unpackAndCombine: ";
+    ProfilingRegion regionUAC ("Tpetra::MultiVector::unpackAndCombine");
 
     // mfh 09 Sep 2016, 26 Sep 2017: The pack and unpack functions now
     // have the option to check indices.  We do so when Tpetra is in
@@ -1450,7 +1465,7 @@ namespace Tpetra {
       auto comm = map.is_null () ? Teuchos::null : map->getComm ();
       const int myRank = comm.is_null () ? -1 : comm->getRank ();
       std::ostringstream os;
-      os << "Proc " << myRank << ": MV::packAndPrepareNew: ";
+      os << "Proc " << myRank << ": MV::packAndPrepare: ";
       prefix = std::unique_ptr<std::string> (new std::string (os.str ()));
       os << "Start" << endl;
       std::cerr << os.str ();

--- a/packages/tpetra/core/test/ImportExport/ImportExport_UnitTests.cpp
+++ b/packages/tpetra/core/test/ImportExport/ImportExport_UnitTests.cpp
@@ -163,7 +163,7 @@ namespace {
       }
       else {
         MV mineParent(smap,2+numVectors);
-	MV neigParent(tmap,2+numVectors);
+        MV neigParent(tmap,2+numVectors);
         TEUCHOS_TEST_FOR_EXCEPTION(numVectors != 5, std::logic_error, "Test assumption broken.");
         mvMine = mineParent.subViewNonConst(tuple<size_t>(0,6,3,4,5));
         mvWithNeighbors = neigParent.subViewNonConst(tuple<size_t>(0,6,3,4,5));
@@ -349,7 +349,9 @@ namespace {
     using Tpetra::createNonContigMapWithNode;
 
     // test ABSMAX CombineMode
-    // test with local and remote entries, as copyAndPermute() and unpackAndCombine() both need to be tested
+    //
+    // The test includes both local and remote entries, to exercise
+    // both copying and permuting, and unpacking and combining.
     typedef Tpetra::Vector<>::scalar_type SC;
     typedef Tpetra::Vector<SC,LO,GO,Node> Vec;
     const global_size_t INVALID = OrdinalTraits<global_size_t>::invalid();
@@ -464,7 +466,7 @@ namespace {
     }
     TEST_EQUALITY(all_is_well,true);
 
-    
+
     bool isvalid=Tpetra::Import_Util::checkImportValidity(Importer);
     if(!isvalid) {
       std::ostringstream oss;
@@ -474,7 +476,7 @@ namespace {
     }
 
     TEST_EQUALITY(isvalid,true);
-    
+
   }
 
   //


### PR DESCRIPTION
@trilinos/tpetra 

## Description

  1. Deprecate "old" `Tpetra::DistObject` interface.
  2. If deprecated code is disabled in Tpetra, rename copyAndPermuteNew to copyAndPermute, packAndPrepareNew to packAndPrepare, and unpackAndCombineNew to unpackAndCombine.

## Related Issues

* Closes #4853 

## How Has This Been Tested?

I built Tpetra, both with and without deprecated Tpetra code enabled.  There appear to be no downstream subclasses of `Tpetra::DistObject` in Trilinos.