### PR TITLE
KokkosKernels: Patching in test size reduction to D2GC unit test

### DIFF
--- a/packages/kokkos-kernels/unit_test/graph/Test_Graph_graph_color_distance2.hpp
+++ b/packages/kokkos-kernels/unit_test/graph/Test_Graph_graph_color_distance2.hpp
@@ -112,11 +112,7 @@ run_graphcolor_d2(crsMat_type                                                   
 
 
     // Print out messages based on coloring validation check.
-    if(d2_coloring_is_valid)
-    {
-        std::cout << std::endl << "Distance-2 Graph Coloring is VALID" << std::endl << std::endl;
-    }
-    else
+    if(!d2_coloring_is_valid)
     {
         std::cout << std::endl
                   << "Distance-2 Graph Coloring is NOT VALID" << std::endl
@@ -253,8 +249,8 @@ test_coloring_d2(lno_type numRows, size_type nnz, lno_type bandwidth, lno_type r
 #define EXECUTE_TEST(SCALAR, ORDINAL, OFFSET, DEVICE)                                           \
     TEST_F(TestCategory, graph##_##graph_color_d2##_##SCALAR##_##ORDINAL##_##OFFSET##_##DEVICE) \
     {                                                                                           \
-        test_coloring_d2<SCALAR, ORDINAL, OFFSET, DEVICE>(50000, 50000 * 30, 200, 10);          \
-        test_coloring_d2<SCALAR, ORDINAL, OFFSET, DEVICE>(50000, 50000 * 30, 100, 10);          \
+        test_coloring_d2<SCALAR, ORDINAL, OFFSET, DEVICE>(5000, 5000 * 30, 200, 10);          \
+        test_coloring_d2<SCALAR, ORDINAL, OFFSET, DEVICE>(5000, 5000 * 30, 100, 10);          \
     }
 #if defined(KOKKOSKERNELS_INST_DOUBLE)
 #if(defined(KOKKOSKERNELS_INST_ORDINAL_INT) && defined(KOKKOSKERNELS_INST_OFFSET_INT)) \


### PR DESCRIPTION
@trilinos/kokkos-kernels 
@ndellingwood 

Patching in the [change from Kokkos-Kernels][1] that reduces the problem size for the D2GC problem by 10x.

Relates to #4847 

[1]: https://github.com/kokkos/kokkos-kernels/pull/415