### PR TITLE
Xpetra:  deprecating Node args (one more small fix)

### DIFF
--- a/packages/xpetra/src/Map/Xpetra_TpetraMap.hpp
+++ b/packages/xpetra/src/Map/Xpetra_TpetraMap.hpp
@@ -454,7 +454,7 @@ namespace Xpetra {
                size_t numLocalElements,
                GlobalOrdinal indexBase,
                const Teuchos::RCP< const Teuchos::Comm< int > > &comm,
-               const Teuchos::RCP< Node > &node = Teuchos::rcp(new Node)) 
+               const Teuchos::RCP< Node > & /*node */) 
       : TpetraMap(numGlobalElements, numLocalElements, indexBase, comm)
     {}
 #endif // TPETRA_ENABLE_DEPRECATED_CODE
@@ -472,7 +472,7 @@ namespace Xpetra {
                const Teuchos::ArrayView< const GlobalOrdinal > &elementList,
                GlobalOrdinal indexBase,
                const Teuchos::RCP< const Teuchos::Comm< int > > &comm,
-               const Teuchos::RCP< Node > &node = Teuchos::rcp(new Node))
+               const Teuchos::RCP< Node > & /* node */)
       : TpetraMap(numGlobalElements, elementList, indexBase, comm)
     {}
 #endif // TPETRA_ENABLE_DEPRECATED_CODE


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/xpetra 

## Description
Another small fix to the deprecation of Node args in methods.

## Motivation and Context
#4943 
#4932 

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## How Has This Been Tested?

See #4932 

<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [ ] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
