### PR TITLE
Tpetra:  restore original ETI types for normImpl

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_normImpl.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_normImpl.cpp
@@ -50,21 +50,11 @@
 #include "Tpetra_Details_normImpl_def.hpp"
 #include "TpetraCore_ETIHelperMacros.h"
 
-
-#if defined(HAVE_TPETRA_INST_INT_INT)
-// don't need to do anything; Scalar=int is already added
-# define TPETRA_DETAILS_NORMIMPL_INSTANT_INT( NODE )
-#else 
-# define TPETRA_DETAILS_NORMIMPL_INSTANT_INT( NODE ) \
-  TPETRA_DETAILS_NORMIMPL_INSTANT( int, NODE )
-#endif 
-
 namespace Tpetra {
 
   TPETRA_ETI_MANGLING_TYPEDEFS()
 
   TPETRA_INSTANTIATE_SN( TPETRA_DETAILS_NORMIMPL_INSTANT )
-  TPETRA_INSTANTIATE_N( TPETRA_DETAILS_NORMIMPL_INSTANT_INT )
 
 #ifdef HAVE_TPETRA_INST_CUDA
 
@@ -76,9 +66,6 @@ namespace Tpetra {
   TPETRA_DETAILS_NORMIMPL_INSTANT( S, cuda_host_mirror_device_type )
 
   TPETRA_INSTANTIATE_S( TPETRA_DETAILS_NORMIMPL_INSTANT_CUDAHOSTMIRROR )
-#if ! defined(HAVE_TPETRA_INST_INT_INT)
-  TPETRA_DETAILS_NORMIMPL_INSTANT_CUDAHOSTMIRROR( int )
-#endif 
 
 #endif // HAVE_TPETRA_INST_CUDA
 


### PR DESCRIPTION
This reverts commit 665ede02ff3f99d18cb436acf9c73693e942c427.

This PR reverts the changes suggested in #4951 and pushed in #4956 
Although these changes worked fine with PR testing both with and without deprecated code, they caused build failures in Albany #4962

@trilinos/tpetra These changes may cause builds with Tpetra_ENABLE_DEPRECATED_CODE=OFF to have link errors; the short term workaround is to use global ordinal = INT instead of LONG LONG.


<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra @ikalash 

