### PR TITLE
Tempus: Tempus Output After Passing Output Time

### DIFF
--- a/packages/tempus/src/Tempus_TimeStepControl_decl.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControl_decl.hpp
@@ -117,6 +117,8 @@ public:
       { return tscPL_->get<int>   ("Maximum Order"); }
     virtual std::string getStepType() const
       { return tscPL_->get<std::string>("Integrator Step Type"); }
+    virtual bool getOutputExactly() const
+      { return tscPL_->get<bool>("Output Exactly On Output Times"); }
     virtual std::vector<int> getOutputIndices() const
       { return outputIndices_; }
     virtual std::vector<Scalar> getOutputTimes() const
@@ -160,6 +162,8 @@ public:
       { tscPL_->set<int>   ("Maximum Order"            , MaxOrder    ); }
     virtual void setStepType(std::string StepType)
       { tscPL_->set<std::string>("Integrator Step Type", StepType    ); }
+    virtual void setOutputExactly(bool OutputExactly)
+      { tscPL_->get<bool>("Output Exactly On Output Times", OutputExactly); }
     virtual void setOutputIndices(std::vector<int> OutputIndices)
       { outputIndices_ = OutputIndices;
         std::ostringstream ss;

--- a/packages/tempus/src/Tempus_TimeStepControl_impl.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControl_impl.hpp
@@ -77,11 +77,9 @@ void TimeStepControl<Scalar>::getNextTimeStep(
     const int iStep = metaData->getIStep();
     int order = metaData->getOrder();
     Scalar dt = metaData->getDt();
-    bool output = metaData->getOutput();
+    bool output = false;
 
     RCP<StepperState<Scalar> > stepperState = workingState->getStepperState();
-
-    output = false;
 
     if (getStepType() == "Variable") {
       // If last time step was adjusted for output, reinstate previous dt.
@@ -139,7 +137,8 @@ void TimeStepControl<Scalar>::getNextTimeStep(
     const int iInterval = tscPL_->get<int>("Output Index Interval");
     if ( (iStep - getInitIndex()) % iInterval == 0) output = true;
 
-    // Adjust time step to hit output times (if Variable timestep).
+    // Check if we need to output in the next timestep based on
+    // outputTimes_ or "Output Time Interval".
     Scalar reltol = 1.0e-6;
     const Scalar endTime = lastTime+dt+getMinTimeStep();
     bool checkOutput = false;
@@ -164,9 +163,12 @@ void TimeStepControl<Scalar>::getNextTimeStep(
     }
 
     if (checkOutput == true) {
-      if (std::abs((lastTime+dt-oTime)/(lastTime+dt)) < reltol) {
-        output = true;
-        if (getStepType() == "Variable") {
+      const bool outputExactly =
+        tscPL_->get<bool>("Output Exactly On Output Times");
+      if (getStepType() == "Variable" && outputExactly == true) {
+        // Adjust time step to hit output times.
+        if (std::abs((lastTime+dt-oTime)/(lastTime+dt)) < reltol) {
+          output = true;
           if (printChanges) *out << changeDT(iStep, dt, oTime - lastTime,
             "Adjusting dt for numerical roundoff to hit the next output time.");
           // Next output time IS VERY near next time (<reltol away from it),
@@ -174,11 +176,9 @@ void TimeStepControl<Scalar>::getNextTimeStep(
           outputAdjustedDt_ = true;
           dtAfterOutput_ = dt;
           dt = oTime - lastTime;
-        }
-      } else if (lastTime*(1.0+reltol) < oTime &&
-                 oTime < (lastTime+dt-getMinTimeStep())*(1.0+reltol)) {
-        output = true;
-        if (getStepType() == "Variable") {
+        } else if (lastTime*(1.0+reltol) < oTime &&
+                   oTime < (lastTime+dt-getMinTimeStep())*(1.0+reltol)) {
+          output = true;
           if (printChanges) *out << changeDT(iStep, dt, oTime - lastTime,
             "Adjusting dt to hit the next output time.");
           // Next output time is not near next time
@@ -187,9 +187,7 @@ void TimeStepControl<Scalar>::getNextTimeStep(
           outputAdjustedDt_ = true;
           dtAfterOutput_ = dt;
           dt = oTime - lastTime;
-        }
-      } else {
-        if (getStepType() == "Variable") {
+        } else {
           if (printChanges) *out << changeDT(iStep, dt, (oTime - lastTime)/2.0,
             "The next output time is within the minimum dt of the next time. "
             "Adjusting dt to take two steps.");
@@ -198,6 +196,11 @@ void TimeStepControl<Scalar>::getNextTimeStep(
           // Take two time steps to get to next output time.
           dt = (oTime - lastTime)/2.0;
         }
+      } else {
+        // Stepping over output time and want this time step for output,
+        // but do not want to change dt. Either because of 'Constant' time
+        // step or user specification, "Output Exactly On Output Times"=false.
+        output = true;
       }
     }
 
@@ -561,6 +564,12 @@ TimeStepControl<Scalar>::getValidParameters() const
     "the time step to be modified.\n"
     "  'Constant' - Integrator will take constant time step sizes.\n"
     "  'Variable' - Integrator will allow changes to the time step size.\n");
+
+  pl->set<bool>("Output Exactly On Output Times", true,
+    "This determines if the timestep size will be adjusted to exactly land\n"
+    "on the output times for 'Variable' timestepping (default=true).\n"
+    "When set to 'false' or for 'Constant' time stepping, the timestep\n"
+    "following the output time will be flagged for output.\n");
 
   pl->set<std::string>("Output Time List", "",
     "Comma deliminated list of output times");

--- a/packages/tempus/test/ExplicitRK/Tempus_ExplicitRK_VanDerPol.xml
+++ b/packages/tempus/test/ExplicitRK/Tempus_ExplicitRK_VanDerPol.xml
@@ -112,7 +112,9 @@
                 <Parameter name="Maximum Absolute Error" type="double" value="1.0e-3"/>
                 <Parameter name="Maximum Relative Error" type="double" value="1.0e-3"/>
                 <Parameter name="Output Index Interval"  type="int"    value="1"/>
-                <Parameter name="Integrator Step Type"  type="string" value="Variable"/>
+                <Parameter name="Integrator Step Type"   type="string" value="Variable"/>
+                <Parameter name="Output Exactly On Output Times"  type="bool" value="false"/>
+                <Parameter name="Output Time List"       type="string" value="0.12"/>
                 <Parameter name="Maximum Number of Stepper Failures" type="int" value="12"/>
                 <Parameter name="Maximum Number of Consecutive Stepper Failures" type="int" value="5"/>
                 <ParameterList name="Time Step Control Strategy">

--- a/packages/tempus/test/Integrator/Tempus_IntegratorBasic_ref.xml
+++ b/packages/tempus/test/Integrator/Tempus_IntegratorBasic_ref.xml
@@ -24,6 +24,7 @@
       <Parameter docString="" id="13" isDefault="true" isUsed="true" name="Maximum Absolute Error" type="double" value="1.00000000000000002e-08"/>
       <Parameter docString="" id="14" isDefault="true" isUsed="true" name="Maximum Relative Error" type="double" value="1.00000000000000002e-08"/>
       <Parameter docString="" id="18" isDefault="true" isUsed="true" name="Integrator Step Type" type="string" value="Variable"/>
+      <Parameter docString="" id="37" isDefault="true" isUsed="true" name="Output Exactly On Output Times" type="bool" value="true"/>
       <Parameter docString="" id="19" isDefault="true" isUsed="true" name="Output Time List" type="string" value=""/>
       <Parameter docString="" id="20" isDefault="true" isUsed="true" name="Output Index List" type="string" value=""/>
       <Parameter docString="" id="21" isDefault="true" isUsed="true" name="Output Time Interval" type="double" value="1.0e+99"/>

--- a/packages/tempus/test/Integrator/Tempus_IntegratorBasic_ref2.xml
+++ b/packages/tempus/test/Integrator/Tempus_IntegratorBasic_ref2.xml
@@ -26,6 +26,7 @@
       <Parameter docString="" id="15" isDefault="true" isUsed="true" name="Maximum Absolute Error" type="double" value="1.00000000000000002e-08"/>
       <Parameter docString="" id="16" isDefault="true" isUsed="true" name="Maximum Relative Error" type="double" value="1.00000000000000002e-08"/>
       <Parameter docString="" id="20" isDefault="true" isUsed="true" name="Integrator Step Type" type="string" value="Variable"/>
+      <Parameter docString="" id="37" isDefault="true" isUsed="true" name="Output Exactly On Output Times" type="bool" value="true"/>
       <Parameter docString="" id="21" isDefault="true" isUsed="true" name="Output Time List" type="string" value=""/>
       <Parameter docString="" id="22" isDefault="true" isUsed="true" name="Output Index List" type="string" value=""/>
       <Parameter docString="" id="23" isDefault="true" isUsed="true" name="Output Time Interval" type="double" value="1.0e+99"/>


### PR DESCRIPTION
Added a new parameter to the TimeStepControl, "Output Exactly On
Output Times", that controls if the timestep size will be adjusted
to exactly land on the output times for 'Variable' timestepping
(default=true).  When set to 'false' or for 'Constant' time stepping,
the timestep following the output time will be flagged for output,
and the timestep size will not be adjusted.

Modified Tempus_ExplicitRKTest::EmbeddedVanDerPol test to cover
new feature.  All tests pass.

 #4964

@trilinos/tempus 

## Checklist
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.

