### PR TITLE
Tempus: Add accessor to WrapperModelEvaluator

### DIFF
--- a/packages/tempus/src/Tempus_StepperImplicit_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperImplicit_decl.hpp
@@ -58,6 +58,8 @@ public:
       const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& appModel);
     virtual Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >
       getModel(){return wrapperModel_->getAppModel();}
+    virtual Teuchos::RCP<const WrapperModelEvaluator<Scalar> >
+      getWrapperModel(){return wrapperModel_;}
 
     /// Set solver via ParameterList solver name.
     virtual void setSolver(std::string solverName);


### PR DESCRIPTION
For a segregated linear solve, EMPIRE needs access to the
WrapperModelEvaluator to get to alpha and beta. Adding simple
accessors to it.  All tests pass.

 #4970

@trilinos/tempus 

## Checklist
- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] All existing tests passed.
- [x] No new compiler warnings were introduced.
