### PR TITLE
Amesos2,Tpetra: Fix #3752 (remove HAVE_STD_NEW_COUNT_SYNTAX macro)

### DIFF
--- a/packages/amesos2/cmake/Amesos2_config.h.in
+++ b/packages/amesos2/cmake/Amesos2_config.h.in
@@ -54,9 +54,6 @@
  * Config Options *
  ******************/
 
-/* define if new form of std::count is supported */
-#cmakedefine HAVE_STD_NEW_COUNT_SYNTAX
-
 /* Define if want to build amesos2-debug */
 #cmakedefine HAVE_AMESOS2_DEBUG
 

--- a/packages/tpetra/core/cmake/TpetraCore_config.h.in
+++ b/packages/tpetra/core/cmake/TpetraCore_config.h.in
@@ -5,9 +5,6 @@
 /* Define whether Tpetra enables deprecated code at compile time. */
 #cmakedefine TPETRA_ENABLE_DEPRECATED_CODE
 
-/* define if new form of std::count is supported */
-#cmakedefine HAVE_STD_NEW_COUNT_SYNTAX
-
 /* Define if want to build with epetra enabled */
 #cmakedefine HAVE_TPETRACORE_EPETRA
 #ifdef HAVE_TPETRACORE_EPETRA


### PR DESCRIPTION
@trilinos/amesos2 @trilinos/tpetra

## Description

Remove definition of `HAVE_STD_NEW_COUNT_SYNTAX` macro from Amesos2 and Tpetra.

## Related Issues

* Closes #3752 