### PR TITLE
Fix case for optional missing component (#2689)

### DIFF
--- a/cmake/tribits/core/installation/TribitsProjectConfigTemplate.cmake.in
+++ b/cmake/tribits/core/installation/TribitsProjectConfigTemplate.cmake.in
@@ -107,32 +107,32 @@ ENDIF()
 # the required components wasn't found.
 SET(${PROJECT_NAME}_FOUND TRUE)
 FOREACH(comp ${PDOLLAR}{COMPONENTS_LIST})
-   SET(
-     INCLUDE_FILE
-     ${PDOLLAR}{CMAKE_CURRENT_LIST_DIR}/../${PDOLLAR}{comp}/${PDOLLAR}{comp}Config.cmake
-     )
-   IF (EXISTS ${PDOLLAR}{INCLUDE_FILE})
-       # Set ${PROJECT_NAME}_<component>_FOUND.
-       SET(${PROJECT_NAME}_${PDOLLAR}{comp}_FOUND TRUE)
-       # Include the package file.
-       INCLUDE(${PDOLLAR}{INCLUDE_FILE})
-       # Add variables to lists.
-       LIST(APPEND ${PROJECT_NAME}_INCLUDE_DIRS ${PDOLLAR}{${PDOLLAR}{comp}_INCLUDE_DIRS})
-       LIST(APPEND ${PROJECT_NAME}_LIBRARY_DIRS ${PDOLLAR}{${PDOLLAR}{comp}_LIBRARY_DIRS})
-       LIST(APPEND ${PROJECT_NAME}_LIBRARIES ${PDOLLAR}{${PDOLLAR}{comp}_LIBRARIES})
-       LIST(APPEND ${PROJECT_NAME}_TPL_INCLUDE_DIRS ${PDOLLAR}{${PDOLLAR}{comp}_TPL_INCLUDE_DIRS})
-       LIST(APPEND ${PROJECT_NAME}_TPL_LIBRARY_DIRS ${PDOLLAR}{${PDOLLAR}{comp}_TPL_LIBRARY_DIRS})
-       LIST(APPEND ${PROJECT_NAME}_TPL_LIBRARIES ${PDOLLAR}{${PDOLLAR}{comp}_TPL_LIBRARIES})
-   ELSE()
-       # Component not found.
-       MESSAGE(WARNING "Component \"${PDOLLAR}{comp}\" NOT found.")
-       # Set ${PROJECT_NAME}_<component>_FOUND to FALSE.
-       SET(${PROJECT_NAME}_${PDOLLAR}{comp}_FOUND FALSE)
-       # Set ${PROJECT_NAME}_FOUND to FALSE if component is not optional.
-       IF(${PROJECT_NAME}_FIND_REQUIRED_${PDOLLAR}{comp})
-           SET(${PROJECT_NAME}_FOUND FALSE)
-       ENDIF()
+  SET(
+    INCLUDE_FILE
+    ${PDOLLAR}{CMAKE_CURRENT_LIST_DIR}/../${PDOLLAR}{comp}/${PDOLLAR}{comp}Config.cmake
+    )
+ IF (EXISTS ${PDOLLAR}{INCLUDE_FILE})
+   # Set ${PROJECT_NAME}_<component>_FOUND.
+   SET(${PROJECT_NAME}_${PDOLLAR}{comp}_FOUND TRUE)
+   # Include the package file.
+   INCLUDE(${PDOLLAR}{INCLUDE_FILE})
+   # Add variables to lists.
+   LIST(APPEND ${PROJECT_NAME}_INCLUDE_DIRS ${PDOLLAR}{${PDOLLAR}{comp}_INCLUDE_DIRS})
+   LIST(APPEND ${PROJECT_NAME}_LIBRARY_DIRS ${PDOLLAR}{${PDOLLAR}{comp}_LIBRARY_DIRS})
+   LIST(APPEND ${PROJECT_NAME}_LIBRARIES ${PDOLLAR}{${PDOLLAR}{comp}_LIBRARIES})
+   LIST(APPEND ${PROJECT_NAME}_TPL_INCLUDE_DIRS ${PDOLLAR}{${PDOLLAR}{comp}_TPL_INCLUDE_DIRS})
+   LIST(APPEND ${PROJECT_NAME}_TPL_LIBRARY_DIRS ${PDOLLAR}{${PDOLLAR}{comp}_TPL_LIBRARY_DIRS})
+   LIST(APPEND ${PROJECT_NAME}_TPL_LIBRARIES ${PDOLLAR}{${PDOLLAR}{comp}_TPL_LIBRARIES})
+ ELSE()
+   # Component not found.
+   MESSAGE(WARNING "Component \"${PDOLLAR}{comp}\" NOT found.")
+   # Set ${PROJECT_NAME}_<component>_FOUND to FALSE.
+   SET(${PROJECT_NAME}_${PDOLLAR}{comp}_FOUND FALSE)
+   # Set ${PROJECT_NAME}_FOUND to FALSE if component is not optional.
+   IF(${PROJECT_NAME}_FIND_REQUIRED_${PDOLLAR}{comp})
+     SET(${PROJECT_NAME}_FOUND FALSE)
    ENDIF()
+ ENDIF()
 ENDFOREACH()
 
 # Resolve absolute paths and remove duplicate paths
@@ -197,12 +197,3 @@ SET(${PROJECT_NAME}_PACKAGE_LIST "${FULL_PACKAGE_SET}")
 
 ## The TPLs enabled for this project
 SET(${PROJECT_NAME}_TPL_LIST "${FULL_TPL_SET}")
-
-## Load configurations for enabled packages in components list
-FOREACH(comp ${PDOLLAR}{COMPONENTS_LIST})
-  SET(
-    PACKAGE_CONFIG_INCLUDE_FILE
-    "${PDOLLAR}{CMAKE_CURRENT_LIST_DIR}/../${PDOLLAR}{comp}/${PDOLLAR}{comp}Config.cmake"
-    )
-  INCLUDE("${PDOLLAR}{PACKAGE_CONFIG_INCLUDE_FILE}")
-ENDFOREACH()


### PR DESCRIPTION
 My last commit (for #2689) broke the use case where an optional component (TriBITS package) is missing (i.e. was not enabled).  This broke the SPARC use case where it looks for TriKota but TriKota can be missing.

I added tests for that use case and strengthened the existing test (in TriBITS).

I also made the indentation consistent (two spaces).

## How was this tested?

I added strong unit tests to TriBITS itself for this use case and I tested against SPARC itself.  See details below.

<details>

<summary><b>Detailed testing against SPARC</b> (Click to expand)</summary>

. 

**(4/23/2019)**

Looks like the changes I made in TriBITS commit TriBITSPub/TriBITS@3b02ce8:

```
3b02ce8 "Make usage of <Package>Config.cmake robust when there are broken packages (trilinos/Trilinos#2689)"
Author: Roscoe A. Bartlett <rabartl@sandia.gov>
Date:   Thu Apr 18 17:36:32 2019 -0600 (4 days ago)

M       test/core/ExamplesUnitTests/DummyPackageClientCMakeLists.txt
M       test/core/ExamplesUnitTests/RunDummyPackageClientBulid.cmake
M       test/ctest_driver/TribitsExampleProject/CMakeLists.txt
M       tribits/core/installation/TribitsProjectConfigTemplate.cmake.in
M       tribits/core/package_arch/TribitsWriteClientExportFiles.cmake
```

actually broke the usage of `TrilinosConfig.cmake` by SPARC.  The error message shown [here](http://compsim-dashboard.sandia.gov/cdash/viewConfigure.php?buildid=109225) shows:

```
CMake Warning at /projects/atdm_devops/trilinos_installs/2019-04-22/cee-rhel6_intel-17.0.1_intelmpi-5.1.2_serial_static_opt/lib/cmake/Trilinos/TrilinosConfig.cmake:140 (MESSAGE):
  Component "TriKota" NOT found.
Call Stack (most recent call first):
  CMakeLists.txt:192 (find_package)
  CMakeLists.txt:256 (find_package_Trilinos)


CMake Error at /projects/atdm_devops/trilinos_installs/2019-04-22/cee-rhel6_intel-17.0.1_intelmpi-5.1.2_serial_static_opt/lib/cmake/Trilinos/TrilinosConfig.cmake:219 (INCLUDE):
  INCLUDE could not find load file:

    /projects/atdm_devops/trilinos_installs/2019-04-22/cee-rhel6_intel-17.0.1_intelmpi-5.1.2_serial_static_opt/lib/cmake/Trilinos/../TriKota/TriKotaConfig.cmake
Call Stack (most recent call first):
  CMakeLists.txt:192 (find_package)
  CMakeLists.txt:256 (find_package_Trilinos)
```

The problem is the code at the bottom of the file `TrilinosConfig.cmake`:

```
## Load configurations for enabled packages in components list
FOREACH(comp ${PDOLLAR}{COMPONENTS_LIST})
  SET(
    PACKAGE_CONFIG_INCLUDE_FILE
    "${PDOLLAR}{CMAKE_CURRENT_LIST_DIR}/../${PDOLLAR}{comp}/${PDOLLAR}{comp}Config.cmake"
    )
  INCLUDE("${PDOLLAR}{PACKAGE_CONFIG_INCLUDE_FILE}")
ENDFOREACH()
```

The problem is that it unconditionally includes the files for all of the requested components.  In the case fo SPARC, they request more components than they actually need (TriKota in this case).  Turns out that the `<Package>Config.cmake` files were already being included in the code earlier in this file so we don't even need this loop.

I tested ripping that code out of the installed file:

* `/projects/atdm_devops/trilinos_installs/2019-04-23/cee-rhel6_clang-5.0.1_openmpi-1.10.2_serial_static_opt/lib/cmake/Trilinos/TrilinosConfig.cmake`

and SPARC built and tested just fine:

```
$ env \
    ATDM_TRIL_SPARC_BUILDS_LIST=cee-rhel6_clang-5.0.1_openmpi-1.10.2_serial_static_opt \
    ATDM_TRIL_SPARC_SKIP_NATIVE_BUILD=1 \
    ATDM_TRIL_SPARC_ATDM_USE_INSTALL_DIR=/projects/atdm_devops/trilinos_installs/2019-04-23 \
  ./sparc-tril-dev-scripts/run_builds_and_tests.sh

Running the builds:
  cee-rhel6_clang-5.0.1_openmpi-1.10.2_serial_static_opt

./sparc-tril-dev-scripts/build_and_test_atdm_trilinos_and_sparc.sh \
   cee-rhel6_clang-5.0.1_openmpi-1.10.2_serial_static_opt "" ""


real    23m24.309s
user    191m33.039s
sys     5m59.603s

    Trilinos_DIR=/projects/atdm_devops/trilinos_installs/2019-04-23/cee-rhel6_clang-5.0.1_openmpi-1.10.2_serial_static_opt/lib/cmake/Trilinos

100% tests passed, 0 tests failed out of 280
```

So this confirms that you don't need this last loop.  (I should have seen that from my earlier edit of this file.)

So I need to extend the TriBITS test suite to cover the SPARC use case (i.e. asking for components that never even got enabled).  I also want to make this work a little smoother too.

</summary>


 