### PR TITLE
Amesos2: Fix #4992

### DIFF
--- a/packages/amesos2/CMakeLists.txt
+++ b/packages/amesos2/CMakeLists.txt
@@ -13,11 +13,7 @@ SET(${PACKAGE_NAME_UC}_RELEASE_DATE "07/28/2011")
 #
 
 IF (NOT Tpetra_INST_INT_INT)
-
-   MESSAGE(WARNING "*****Amesos2 will not provide Epetra Matrix Support with Tpetra_INST_INT_INT OFF.*****")
    MESSAGE(WARNING "*****Amesos2 will not provide MUMPS Support with Tpetra_INST_INT_INT OFF.*****")
-
-
 ENDIF ()
 
 IF (Amesos2_ENABLE_UMFPACK)

--- a/packages/amesos2/example/CMakeLists.txt
+++ b/packages/amesos2/example/CMakeLists.txt
@@ -58,34 +58,26 @@ TRIBITS_ADD_EXECUTABLE(
 #   )
 
 
-IF (Tpetra_INST_INT_INT)
 TRIBITS_ADD_EXECUTABLE(
   QuickSolve
   SOURCES quick_solve
   )
-ENDIF ()
 
-IF (Tpetra_INST_INT_INT)
  TRIBITS_ADD_EXECUTABLE(
    SimpleSolveFileExample
   SOURCES SimpleSolve_File
  )
-ENDIF ()
 
 
-IF (Tpetra_INST_INT_INT)
 IF (${PACKAGE_NAME}_ENABLE_Epetra AND ${PACKAGE_NAME}_ENABLE_EpetraExt)
   TRIBITS_ADD_EXECUTABLE(
     QuickSolveEpetra
     SOURCES quick_solve_epetra
   )
 ENDIF()
-ENDIF()
 
-IF (Tpetra_INST_INT_INT)
 TRIBITS_COPY_FILES_TO_BINARY_DIR(Amesos2_SimpleSolve_File
   SOURCE_FILES arc130.mtx
   SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../test/matrices/
   DEST_DIR ${CMAKE_CURRENT_BINARY_DIR}
   )
-ENDIF()

--- a/packages/amesos2/src/Amesos2_AbstractConcreteMatrixAdapter_def.hpp
+++ b/packages/amesos2/src/Amesos2_AbstractConcreteMatrixAdapter_def.hpp
@@ -2,7 +2,7 @@
 //
 // ***********************************************************************
 //
-//           Amesos2: Templated Direct Sparse Solver Package 
+//           Amesos2: Templated Direct Sparse Solver Package
 //                  Copyright 2011 Sandia Corporation
 //
 // Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
@@ -46,10 +46,8 @@
 
 #include "Amesos2_TpetraRowMatrix_AbstractMatrixAdapter_def.hpp"
 
-#ifdef HAVE_TPETRA_INST_INT_INT
 #ifdef HAVE_AMESOS2_EPETRA
 #include "Amesos2_EpetraRowMatrix_AbstractMatrixAdapter_def.hpp"
-#endif
 #endif
 
 #endif

--- a/packages/amesos2/src/Amesos2_Basker.cpp
+++ b/packages/amesos2/src/Amesos2_Basker.cpp
@@ -50,10 +50,8 @@
 
 namespace Amesos2 {
 
-#ifdef HAVE_TPETRA_INST_INT_INT
 #ifdef HAVE_AMESOS2_EPETRA
   AMESOS2_SOLVER_EPETRA_INST(Basker);
-#endif
 #endif
 
 #ifdef HAVE_TPETRA_INST_INT_INT

--- a/packages/amesos2/src/Amesos2_ConcreteMatrixAdapter_decl.hpp
+++ b/packages/amesos2/src/Amesos2_ConcreteMatrixAdapter_decl.hpp
@@ -2,7 +2,7 @@
 //
 // ***********************************************************************
 //
-//           Amesos2: Templated Direct Sparse Solver Package 
+//           Amesos2: Templated Direct Sparse Solver Package
 //                  Copyright 2011 Sandia Corporation
 //
 // Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
@@ -54,10 +54,8 @@ namespace Amesos2 {
 
 #include "Amesos2_TpetraCrsMatrix_MatrixAdapter_decl.hpp"
 
-#ifdef HAVE_TPETRA_INST_INT_INT
 #ifdef HAVE_AMESOS2_EPETRA
 #  include "Amesos2_EpetraCrsMatrix_MatrixAdapter_decl.hpp"
 #endif
-#endif
 
-#endif	// AMESOS2_CONCRETEMATRIXADAPTER_DECL_HPP
+#endif  // AMESOS2_CONCRETEMATRIXADAPTER_DECL_HPP

--- a/packages/amesos2/src/Amesos2_Details_LinearSolverFactory.cpp
+++ b/packages/amesos2/src/Amesos2_Details_LinearSolverFactory.cpp
@@ -53,13 +53,11 @@
 // for making Tpetra's macros work.
 #include "TpetraCore_ETIHelperMacros.h"
 
-#ifdef HAVE_TPETRA_INST_INT_INT
 #ifdef HAVE_AMESOS2_EPETRA
 // Do explicit instantiation of Amesos2::Details::LinearSolverFactory,
 // for Epetra objects.
 template class Amesos2::Details::LinearSolverFactory<Epetra_MultiVector, Epetra_Operator, double>;
 #endif // HAVE_AMESOS2_EPETRA
-#endif // HAVE_TPETRA_INST_INT_INT
 
 // Define typedefs that make the Tpetra macros work.
 TPETRA_ETI_MANGLING_TYPEDEFS()

--- a/packages/amesos2/src/Amesos2_Details_LinearSolverFactory_def.hpp
+++ b/packages/amesos2/src/Amesos2_Details_LinearSolverFactory_def.hpp
@@ -56,11 +56,9 @@
 #include <type_traits>
 
 
-#ifdef HAVE_TPETRA_INST_INT_INT
 #ifdef HAVE_AMESOS2_EPETRA
 #  include "Epetra_CrsMatrix.h"
 #endif // HAVE_AMESOS2_EPETRA
-#endif // HAVE_TPETRA_INST_INT_INT
 
 // mfh 23 Jul 2015: Tpetra is currently a required dependency of Amesos2.
 #ifndef HAVE_AMESOS2_TPETRA
@@ -84,13 +82,11 @@ struct GetMatrixType {
   typedef int type; // flag (see below)
 
 
-#ifdef HAVE_TPETRA_INST_INT_INT
 #ifdef HAVE_AMESOS2_EPETRA
   static_assert(! std::is_same<OP, Epetra_MultiVector>::value,
                 "Amesos2::Details::GetMatrixType: OP = Epetra_MultiVector.  "
                 "This probably means that you mixed up MV and OP.");
 #endif // HAVE_AMESOS2_EPETRA
-#endif // HAVE_TPETRA_INST_INT_INT
 
 #ifdef HAVE_AMESOS2_TPETRA
   static_assert(! std::is_same<OP, Tpetra::MultiVector<typename OP::scalar_type,
@@ -101,14 +97,12 @@ struct GetMatrixType {
 #endif // HAVE_AMESOS2_TPETRA
 };
 
-#ifdef HAVE_TPETRA_INST_INT_INT
 #ifdef HAVE_AMESOS2_EPETRA
 template<>
 struct GetMatrixType<Epetra_Operator> {
   typedef Epetra_CrsMatrix type;
 };
 #endif // HAVE_AMESOS2_EPETRA
-#endif // HAVE_TPETRA_INST_INT_INT
 
 
 #ifdef HAVE_AMESOS2_TPETRA
@@ -124,7 +118,6 @@ class LinearSolver :
     virtual public Teuchos::Describable
 {
 
-#ifdef HAVE_TPETRA_INST_INT_INT
 #ifdef HAVE_AMESOS2_EPETRA
   static_assert(! std::is_same<OP, Epetra_MultiVector>::value,
                 "Amesos2::Details::LinearSolver: OP = Epetra_MultiVector.  "
@@ -133,7 +126,6 @@ class LinearSolver :
                 "Amesos2::Details::LinearSolver: MV = Epetra_Operator.  "
                 "This probably means that you mixed up MV and OP.");
 #endif // HAVE_AMESOS2_EPETRA
-#endif // HAVE_TPETRA_INST_INT_INT
 
 public:
   /// \brief Type of the CrsMatrix specialization corresponding to OP.

--- a/packages/amesos2/src/Amesos2_Details_registerLinearSolverFactory.cpp
+++ b/packages/amesos2/src/Amesos2_Details_registerLinearSolverFactory.cpp
@@ -48,12 +48,10 @@
 #include "Tpetra_MultiVector.hpp"
 #include "Tpetra_Operator.hpp"
 
-#ifdef HAVE_TPETRA_INST_INT_INT
 #ifdef HAVE_AMESOS2_EPETRA
 #  include "Epetra_MultiVector.h"
 #  include "Epetra_Operator.h"
 #endif // HAVE_AMESOS2_EPETRA
-#endif
 
 #include "TpetraCore_ETIHelperMacros.h"
 
@@ -90,12 +88,10 @@ registerLinearSolverFactory ()
 
   // If Epetra is enabled in Amesos2, also register Amesos2's
   // LinearSolverFactory for Epetra objects.
-#ifdef HAVE_TPETRA_INST_INT_INT
 #ifdef HAVE_AMESOS2_EPETRA
   ::Amesos2::Details::LinearSolverFactory<Epetra_MultiVector,
     Epetra_Operator, double>::registerLinearSolverFactory ();
 #endif // HAVE_AMESOS2_EPETRA
-#endif // HAVE_TPETRA_INST_INT_INT
 }
 
 } // namespace Details

--- a/packages/amesos2/src/Amesos2_EpetraMultiVecAdapter_decl.hpp
+++ b/packages/amesos2/src/Amesos2_EpetraMultiVecAdapter_decl.hpp
@@ -2,7 +2,7 @@
 //
 // ***********************************************************************
 //
-//           Amesos2: Templated Direct Sparse Solver Package 
+//           Amesos2: Templated Direct Sparse Solver Package
 //                  Copyright 2011 Sandia Corporation
 //
 // Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
@@ -47,7 +47,7 @@
   \date   Tue Jul 20 23:34:52 CDT 2010
 
   \brief  Amesos2::MultiVecAdapter specialization for the
-	  Epetra_MultiVector class.
+          Epetra_MultiVector class.
 */
 
 #ifndef AMESOS2_EPETRA_MULTIVEC_ADAPTER_DECL_HPP
@@ -79,15 +79,15 @@ namespace Amesos2 {
     // public type definitions
     typedef double                                                scalar_t;
     typedef int                                            local_ordinal_t;
-    typedef int                                           global_ordinal_t;
+    typedef Tpetra::Map<>::global_ordinal_type            global_ordinal_t;
     typedef size_t                                           global_size_t;
-    typedef Tpetra::Map<>::node_type  node_t;
+    typedef Tpetra::Map<>::node_type                                node_t;
     typedef Epetra_MultiVector                                  multivec_t;
 
     friend Teuchos::RCP<MultiVecAdapter<multivec_t> > createMultiVecAdapter<>(Teuchos::RCP<multivec_t>);
     friend Teuchos::RCP<const MultiVecAdapter<multivec_t> > createConstMultiVecAdapter<>(Teuchos::RCP<const multivec_t>);
 
-  
+
     static const char* name;
 
 
@@ -102,11 +102,10 @@ namespace Amesos2 {
      */
     MultiVecAdapter( const Teuchos::RCP<multivec_t>& m );
 
-  
+
   public:
 
-    ~MultiVecAdapter()
-    { }
+    ~MultiVecAdapter() = default;
 
 
     /// Checks whether this multi-vector is local to the calling node.
@@ -177,11 +176,11 @@ namespace Amesos2 {
      *  Each multi-vector is \c lda apart in memory.
      */
     void get1dCopy( const Teuchos::ArrayView<scalar_t>& A,
-		    size_t lda,
-		    Teuchos::Ptr<
-		    const Tpetra::Map<local_ordinal_t,
-		    global_ordinal_t,
-		    node_t> > distribution_map,
+                    size_t lda,
+                    Teuchos::Ptr<
+                    const Tpetra::Map<local_ordinal_t,
+                    global_ordinal_t,
+                    node_t> > distribution_map,
         EDistribution distribution) const;
 
 
@@ -216,11 +215,11 @@ namespace Amesos2 {
      * \param newVals The values to be exported into the global space.
      */
     void put1dData( const Teuchos::ArrayView<const scalar_t>& new_data,
-		    size_t lda,
-		    Teuchos::Ptr<
-		    const Tpetra::Map<local_ordinal_t,
-		    global_ordinal_t,
-		    node_t> > source_map,
+                    size_t lda,
+                    Teuchos::Ptr<
+                    const Tpetra::Map<local_ordinal_t,
+                    global_ordinal_t,
+                    node_t> > source_map,
         EDistribution distribution );
 
 

--- a/packages/amesos2/src/Amesos2_ExplicitInstantiationHelpers.hpp
+++ b/packages/amesos2/src/Amesos2_ExplicitInstantiationHelpers.hpp
@@ -47,14 +47,12 @@
 
 #include <Tpetra_CrsMatrix.hpp>
 
-#ifdef HAVE_TPETRA_INST_INT_INT
 #ifdef HAVE_AMESOS2_EPETRA
 #include <Epetra_CrsMatrix.h>
 
 #define AMESOS2_SOLVER_EPETRA_INST(SOLVERNAME) \
   template class SOLVERNAME<Epetra_CrsMatrix, Epetra_MultiVector>
 #endif  // HAVE_AMESOS2_EPETRA
-#endif  // HAVE_TPETRA_INST_INT_INT
 
 #define AMESOS2_SOLVER_TPETRA_INST(SOLVERNAME,S,LO,GO) \
   template class SOLVERNAME<Tpetra::CrsMatrix<S, LO, GO>, Tpetra::MultiVector<S, LO, GO> >

--- a/packages/amesos2/src/Amesos2_KLU2.cpp
+++ b/packages/amesos2/src/Amesos2_KLU2.cpp
@@ -50,10 +50,8 @@
 
 namespace Amesos2 {
 
-#ifdef HAVE_TPETRA_INST_INT_INT
 #ifdef HAVE_AMESOS2_EPETRA
   AMESOS2_SOLVER_EPETRA_INST(KLU2);
-#endif
 #endif
 
 }

--- a/packages/amesos2/src/Amesos2_Lapack.cpp
+++ b/packages/amesos2/src/Amesos2_Lapack.cpp
@@ -49,12 +49,9 @@
 #  include "Amesos2_Lapack_def.hpp"
 #  include "Amesos2_ExplicitInstantiationHelpers.hpp"
 
-
-#ifdef HAVE_TPETRA_INST_INT_INT
-namespace Amesos2 {
 #ifdef HAVE_AMESOS2_EPETRA
+namespace Amesos2 {
   AMESOS2_SOLVER_EPETRA_INST(Lapack);
-#endif
 }
 #endif
 
@@ -153,7 +150,7 @@ TPETRA_ETI_MANGLING_TYPEDEFS()
   #endif
 #endif
 #ifdef HAVE_TPETRA_INST_DOUBLE
-    #ifdef HAVE_TPETRA_INST_INT_INT   
+    #ifdef HAVE_TPETRA_INST_INT_INT
       AMESOS2_LAPACK_LOCAL_INSTANT(double, int, int, NODETYPE)
     #endif
     #ifdef HAVE_TPETRA_INST_INT_LONG
@@ -200,7 +197,7 @@ TPETRA_ETI_MANGLING_TYPEDEFS()
 #if defined(HAVE_TPETRA_INST_PTHREAD) && !defined(HAVE_TPETRA_DEFAULTNODE_THREADSWRAPPERNODE) && defined(HAVE_TPETRA_INST_DOUBLE) && defined(TPETRA_HAVE_KOKKOS_REFACTOR)
 #define NODETYPE Kokkos_Compat_KokkosThreadsWrapperNode
 #ifdef HAVE_TPETRA_INST_FLOAT
-  #ifdef HAVE_TPETRA_INST_INT_INT 
+  #ifdef HAVE_TPETRA_INST_INT_INT
     AMESOS2_LAPACK_LOCAL_INSTANT(float, int, int, NODETYPE)
   #endif
   #ifdef HAVE_TPETRA_INST_INT_LONG

--- a/packages/amesos2/src/Amesos2_MUMPS.cpp
+++ b/packages/amesos2/src/Amesos2_MUMPS.cpp
@@ -49,10 +49,8 @@
 #  include "Amesos2_ExplicitInstantiationHelpers.hpp"
 
 namespace Amesos2 {
-#ifdef HAVE_TPETRA_INST_INT_INT
 #ifdef HAVE_AMESOS2_EPETRA
   AMESOS2_SOLVER_EPETRA_INST(MUMPS);
-#endif
 #endif
 }
 

--- a/packages/amesos2/src/Amesos2_MatrixTraits.hpp
+++ b/packages/amesos2/src/Amesos2_MatrixTraits.hpp
@@ -50,14 +50,12 @@
 #include <Tpetra_CrsMatrix.hpp>
 
 
-#ifdef HAVE_TPETRA_INST_INT_INT
 #ifdef HAVE_AMESOS2_EPETRA
 #  include <Epetra_RowMatrix.h>
 #  include <Epetra_CrsMatrix.h>
 // #  include <Epetra_MsrMatrix.h>
 #  include <Epetra_VbrMatrix.h>
 // and perhaps some others later...
-#endif
 #endif
 
 #include "Amesos2_Util.hpp"
@@ -119,14 +117,13 @@ namespace Amesos2 {
   };
 
 
-#ifdef HAVE_TPETRA_INST_INT_INT
 #ifdef HAVE_AMESOS2_EPETRA
 
   template <>
   struct MatrixTraits<Epetra_RowMatrix> {
     typedef double scalar_t;
     typedef int local_ordinal_t;
-    typedef int global_ordinal_t;
+    typedef Tpetra::Map<>::global_ordinal_type global_ordinal_t;
     typedef Tpetra::Map<>::node_type node_t;
 
     typedef Epetra_RowMatrix matrix_type;
@@ -142,7 +139,7 @@ namespace Amesos2 {
   struct MatrixTraits<Epetra_CrsMatrix> {
     typedef double scalar_t;
     typedef int local_ordinal_t;
-    typedef int global_ordinal_t;
+    typedef Tpetra::Map<>::global_ordinal_type global_ordinal_t;
     typedef Tpetra::Map<>::node_type node_t;
 
     typedef Epetra_CrsMatrix matrix_type;
@@ -158,7 +155,7 @@ namespace Amesos2 {
   // struct MatrixTraits<Epetra_MsrMatrix> {
   //   typedef double scalar_t;
   //   typedef int local_ordinal_t;
-  //   typedef int global_ordinal_t;
+  //   typedef Tpetra::Map<>::global_ordinal_type global_ordinal_t;
   //   typedef Tpetra::Map<>::node_type node_t;
 
   //   typedef row_access major_access;
@@ -168,7 +165,7 @@ namespace Amesos2 {
   struct MatrixTraits<Epetra_VbrMatrix> {
     typedef double scalar_t;
     typedef int local_ordinal_t;
-    typedef int global_ordinal_t;
+    typedef Tpetra::Map<>::global_ordinal_type global_ordinal_t;
     typedef Tpetra::Map<>::node_type node_t;
 
     typedef Epetra_VbrMatrix matrix_type;
@@ -180,7 +177,6 @@ namespace Amesos2 {
     typedef row_access major_access;
   };
 
-#endif
 #endif
 
 }

--- a/packages/amesos2/src/Amesos2_PardisoMKL.cpp
+++ b/packages/amesos2/src/Amesos2_PardisoMKL.cpp
@@ -53,10 +53,8 @@
 
 namespace Amesos2 {
 
-#ifdef HAVE_TPETRA_INST_INT_INT
 #ifdef HAVE_AMESOS2_EPETRA
   AMESOS2_SOLVER_EPETRA_INST(PardisoMKL);
-#endif
 #endif
 
 }
@@ -307,7 +305,7 @@ TPETRA_ETI_MANGLING_TYPEDEFS()
   #endif
 #endif
 #ifdef HAVE_TPETRA_INST_COMPLEX_DOUBLE
-    #ifdef HAVE_TPETRA_INST_INT_INT 
+    #ifdef HAVE_TPETRA_INST_INT_INT
      AMESOS2_PARDISOMKL_LOCAL_INSTANT(std::complex<double>, int, int, NODETYPE)
     #endif
     #ifdef HAVE_TPETRA_INST_INT_LONG

--- a/packages/amesos2/src/Amesos2_ShyLUBasker.cpp
+++ b/packages/amesos2/src/Amesos2_ShyLUBasker.cpp
@@ -50,10 +50,8 @@
 
 namespace Amesos2 {
 
-#ifdef HAVE_TPETRA_INST_INT_INT
 #ifdef HAVE_AMESOS2_EPETRA
   AMESOS2_SOLVER_EPETRA_INST(ShyLUBasker);
-#endif
 #endif
 
 #ifdef HAVE_TPETRA_INST_INT_INT

--- a/packages/amesos2/src/Amesos2_Superlu.cpp
+++ b/packages/amesos2/src/Amesos2_Superlu.cpp
@@ -51,10 +51,8 @@
 
 namespace Amesos2 {
 
-#ifdef HAVE_TPETRA_INST_INT_INT
 #ifdef HAVE_AMESOS2_EPETRA
   AMESOS2_SOLVER_EPETRA_INST(Superlu);
-#endif
 #endif
 
 } // namespace Amesos2

--- a/packages/amesos2/src/Amesos2_Superlumt.cpp
+++ b/packages/amesos2/src/Amesos2_Superlumt.cpp
@@ -54,10 +54,8 @@
 
 namespace Amesos2 {
 
-#ifdef HAVE_TPETRA_INST_INT_INT
 #ifdef HAVE_AMESOS2_EPETRA
   AMESOS2_SOLVER_EPETRA_INST(Superlumt);
-#endif
 #endif
 
 }

--- a/packages/amesos2/src/Amesos2_Tacho.cpp
+++ b/packages/amesos2/src/Amesos2_Tacho.cpp
@@ -49,16 +49,11 @@
 #  include "Amesos2_ExplicitInstantiationHelpers.hpp"
 
 
-
-namespace Amesos2 {
-
-#ifdef HAVE_TPETRA_INST_INT_INT
 #ifdef HAVE_AMESOS2_EPETRA
+namespace Amesos2 {
   AMESOS2_SOLVER_EPETRA_INST(TachoSolver);
-#endif
-#endif
-
 }
+#endif
 
 
 #ifdef HAVE_TPETRA_INST_INT_INT

--- a/packages/amesos2/src/Amesos2_Umfpack.cpp
+++ b/packages/amesos2/src/Amesos2_Umfpack.cpp
@@ -49,15 +49,13 @@
 #include "Amesos2_ExplicitInstantiationHelpers.hpp"
 #include "TpetraCore_ETIHelperMacros.h"
 
-namespace Amesos2 {
 
-#ifdef HAVE_TPETRA_INST_INT_INT
 #ifdef HAVE_AMESOS2_EPETRA
+namespace Amesos2 {
   AMESOS2_SOLVER_EPETRA_INST(Umfpack);
-#endif
+} // namespace Amesos2
 #endif
 
-} // namespace Amesos2
 
 #define AMESOS2_UMFPACK_LOCAL_INSTANT(S,LO,GO,N) \
   template class Amesos2::Umfpack<Tpetra::CrsMatrix<S, LO, GO, N>, \

--- a/packages/amesos2/src/Amesos2_Util.cpp
+++ b/packages/amesos2/src/Amesos2_Util.cpp
@@ -50,16 +50,16 @@
 #  include <Teuchos_DefaultMpiComm.hpp>
 #  ifdef HAVE_AMESOS2_EPETRA
 #    include <Teuchos_OpaqueWrapper.hpp>
-#  endif
-#endif
+#  endif // HAVE_AMESOS2_EPETRA
+#endif // HAVE_MPI
 
 #ifdef HAVE_AMESOS2_EPETRA
 #  include <Epetra_Map.h>
 #  ifdef HAVE_MPI
 #    include <Epetra_MpiComm.h>
-#  endif
+#  endif // HAVE_MPI
 #  include <Epetra_SerialComm.h>
-#endif
+#endif // HAVE_AMESOS2_EPETRA
 
 #ifdef HAVE_AMESOS2_EPETRA
 const Teuchos::RCP<const Teuchos::Comm<int> >
@@ -77,7 +77,7 @@ Amesos2::Util::to_teuchos_comm(Teuchos::RCP<const Epetra_Comm> c)
       rawMpiComm = Teuchos::opaqueWrapper(mpiEpetraComm->Comm());
     return Teuchos::createMpiComm<int>(rawMpiComm);
   } else
-#endif
+#endif // HAVE_MPI
     if( rcp_dynamic_cast<const Epetra_SerialComm>(c) != Teuchos::null )
       return Teuchos::createSerialComm<int>();
     else
@@ -101,7 +101,7 @@ Amesos2::Util::to_epetra_comm(Teuchos::RCP<const Teuchos::Comm<int> > c)
       mpiComm = rcp(new Epetra_MpiComm(*rawMpiComm()));
     return mpiComm;
   }
-#else
+#else // NOT HAVE_MPI
   Teuchos::RCP<const Teuchos::SerialComm<int> >
     serialTeuchosComm = rcp_dynamic_cast<const Teuchos::SerialComm<int> >(c);
 
@@ -109,11 +109,11 @@ Amesos2::Util::to_epetra_comm(Teuchos::RCP<const Teuchos::Comm<int> > c)
     Teuchos::RCP<const Epetra_SerialComm> serialComm = rcp(new Epetra_SerialComm());
     return serialComm;
   }
-#endif  // HAVE_MPI
+#endif // HAVE_MPI
 
   return Teuchos::null;
 }
-#endif  // HAVE_AMESOS2_EPETRA
+#endif // HAVE_AMESOS2_EPETRA
 
 /// Prints a line of 80 "-"s on out.
 void Amesos2::Util::printLine( Teuchos::FancyOStream& out )

--- a/packages/amesos2/src/Amesos2_Util.cpp
+++ b/packages/amesos2/src/Amesos2_Util.cpp
@@ -2,7 +2,7 @@
 //
 // ***********************************************************************
 //
-//           Amesos2: Templated Direct Sparse Solver Package 
+//           Amesos2: Templated Direct Sparse Solver Package
 //                  Copyright 2011 Sandia Corporation
 //
 // Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
@@ -53,7 +53,6 @@
 #  endif
 #endif
 
-#ifdef HAVE_TPETRA_INST_INT_INT
 #ifdef HAVE_AMESOS2_EPETRA
 #  include <Epetra_Map.h>
 #  ifdef HAVE_MPI
@@ -61,9 +60,7 @@
 #  endif
 #  include <Epetra_SerialComm.h>
 #endif
-#endif
 
-#ifdef HAVE_TPETRA_INST_INT_INT
 #ifdef HAVE_AMESOS2_EPETRA
 const Teuchos::RCP<const Teuchos::Comm<int> >
 Amesos2::Util::to_teuchos_comm(Teuchos::RCP<const Epetra_Comm> c)
@@ -112,12 +109,11 @@ Amesos2::Util::to_epetra_comm(Teuchos::RCP<const Teuchos::Comm<int> > c)
     Teuchos::RCP<const Epetra_SerialComm> serialComm = rcp(new Epetra_SerialComm());
     return serialComm;
   }
-#endif	// HAVE_MPI
+#endif  // HAVE_MPI
 
   return Teuchos::null;
 }
-#endif	// HAVE_AMESOS2_EPETRA
-#endif  // HAVE_TPETRA_INST_INT_INT
+#endif  // HAVE_AMESOS2_EPETRA
 
 /// Prints a line of 80 "-"s on out.
 void Amesos2::Util::printLine( Teuchos::FancyOStream& out )

--- a/packages/amesos2/src/Amesos2_VectorTraits.hpp
+++ b/packages/amesos2/src/Amesos2_VectorTraits.hpp
@@ -50,11 +50,9 @@
 #include <Tpetra_MultiVector.hpp>
 
 
-#ifdef HAVE_TPETRA_INST_INT_INT
 #ifdef HAVE_AMESOS2_EPETRA
 #  include <Epetra_MultiVector.h>
 // and perhaps some others later...
-#endif
 #endif
 
 namespace Amesos2 {
@@ -85,21 +83,19 @@ namespace Amesos2 {
     typedef typename multivector_type::impl_scalar_type  ptr_scalar_type; // TODO Make this a pointer
   };
 
-#ifdef HAVE_TPETRA_INST_INT_INT
 #ifdef HAVE_AMESOS2_EPETRA
 
   template <>
   struct VectorTraits<Epetra_MultiVector> {
     typedef double scalar_t;
     typedef int local_ordinal_t;
-    typedef int global_ordinal_t;
+    typedef Tpetra::Map<>::global_ordinal_type global_ordinal_t;
     typedef Tpetra::Map<>::node_type node_t;
 
     typedef Epetra_MultiVector multivector_type;
     typedef double ptr_scalar_type; // TODO Make this a pointer
   };
 
-#endif
 #endif
 
 }

--- a/packages/amesos2/src/CMakeLists.txt
+++ b/packages/amesos2/src/CMakeLists.txt
@@ -388,7 +388,6 @@ IF (${PACKAGE_NAME}_ENABLE_MUMPS)
 ENDIF()
 
 
-IF (Tpetra_INST_INT_INT)
 IF (${PACKAGE_NAME}_ENABLE_Epetra)
   APPEND_SET(HEADERS
     Amesos2_EpetraRowMatrix_AbstractMatrixAdapter.hpp
@@ -412,7 +411,6 @@ IF (${PACKAGE_NAME}_ENABLE_Epetra)
     Amesos2_EpetraCrsMatrix_MatrixAdapter.cpp
     Amesos2_EpetraMultiVecAdapter.cpp
     )
-ENDIF()
 ENDIF()
 
 IF (${PACKAGE_NAME}_ENABLE_TrilinosSS)

--- a/packages/amesos2/test/adapters/CMakeLists.txt
+++ b/packages/amesos2/test/adapters/CMakeLists.txt
@@ -18,9 +18,6 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   )
 
 
-## Epetra needs tpetra<int,int> 
-
-IF (Tpetra_INST_INT_INT)
 IF (${PACKAGE_NAME}_ENABLE_Epetra)
   TRIBITS_ADD_EXECUTABLE_AND_TEST(
     Epetra_MultiVector_Adapter_UnitTests
@@ -51,5 +48,4 @@ IF (${PACKAGE_NAME}_ENABLE_Epetra)
       STANDARD_PASS_OUTPUT
       )
   ENDIF()
-ENDIF()
 ENDIF()

--- a/packages/amesos2/test/adapters/CrsMatrix_Adapter_Consistency_Tests.cpp
+++ b/packages/amesos2/test/adapters/CrsMatrix_Adapter_Consistency_Tests.cpp
@@ -45,10 +45,10 @@
  * \file   CrsMatrix_Adapter_Consistency_Tests.cpp
  * \author Eric Bavier <etbavie@muenster.srn.sandia.gov>
  * \date   Fri Jul 15 07:36:37 2011
- * 
+ *
  * \brief Checks consistency between the Epetra_CrsMatrix and
  * Tpetra::CrsMatrix adapters.
- * 
+ *
  * For the same input matrices, the adapters should return the same
  * output values.  These tests only check double scalar and int
  * ordinal.
@@ -105,7 +105,7 @@ namespace {
   using Amesos2::MatrixAdapter;
 
   using Amesos2::Meta::is_same;
-  
+
   using Amesos2::Util::to_teuchos_comm;
 
   using Amesos2::ROOTED;
@@ -162,7 +162,7 @@ namespace {
     }
     return(r);
   }
-  
+
   template<typename T>
   bool contains(const ArrayView<T> a, T t)
   {
@@ -179,7 +179,7 @@ namespace {
     // by the Tpetra::CrsMatrix
     // Check equality of mapped method calls
     typedef Epetra_CrsMatrix EMAT;
-    typedef Tpetra::CrsMatrix<double,int,int> TMAT;
+    typedef Tpetra::CrsMatrix<double> TMAT;
     typedef MatrixAdapter<EMAT> EADAPT;
     typedef MatrixAdapter<TMAT> TADAPT;
 
@@ -213,7 +213,7 @@ namespace {
     /* Test the getCrs() method of MatrixAdapter.
      */
     typedef Epetra_CrsMatrix EMAT;
-    typedef Tpetra::CrsMatrix<double,int,int> TMAT;
+    typedef Tpetra::CrsMatrix<double> TMAT;
     typedef MatrixAdapter<EMAT> EADAPT;
     typedef MatrixAdapter<TMAT> TADAPT;
 
@@ -261,7 +261,7 @@ namespace {
      * representation should be valid on all processors
      */
     typedef Epetra_CrsMatrix EMAT;
-    typedef Tpetra::CrsMatrix<double,int,int> TMAT;
+    typedef Tpetra::CrsMatrix<double> TMAT;
     typedef MatrixAdapter<EMAT> EADAPT;
     typedef MatrixAdapter<TMAT> TADAPT;
 
@@ -308,7 +308,7 @@ namespace {
      * test matrix that we construct on the fly.
      */
     typedef Epetra_CrsMatrix EMAT;
-    typedef Tpetra::CrsMatrix<double,int,int> TMAT;
+    typedef Tpetra::CrsMatrix<double> TMAT;
     typedef MatrixAdapter<EMAT> EADAPT;
     typedef MatrixAdapter<TMAT> TADAPT;
 
@@ -347,14 +347,14 @@ namespace {
     TADAPT::global_size_t my_num_rows = OrdinalTraits<TADAPT::global_size_t>::zero();
     if ( numprocs > 1 ){
       if ( rank < 2 ){
-	my_num_rows = g_num_rows / 2;
+        my_num_rows = g_num_rows / 2;
       }
       // If we have an odd number of rows, rank=0 gets the remainder
       if ( rank == 0 ) my_num_rows += g_num_rows % 2;
-    } else {			// We only have 1 proc, then she just takes it all
+    } else {                    // We only have 1 proc, then she just takes it all
       my_num_rows = g_num_rows;
     }
-    const Tpetra::Map<int,int> half_map(g_num_rows, my_num_rows, 0, tcomm);
+    const Tpetra::Map<> half_map(g_num_rows, my_num_rows, 0, tcomm);
 
     tadapter->getCrs(tnzvals, tcolind, trowptr, tnnz, Teuchos::ptrInArg(half_map), SORTED_INDICES, Amesos2::DISTRIBUTED); // ROOTED = default distribution
     eadapter->getCrs(enzvals, ecolind, erowptr, ennz, Teuchos::ptrInArg(half_map), SORTED_INDICES, Amesos2::DISTRIBUTED);
@@ -370,7 +370,7 @@ namespace {
       TEST_EQUALITY(tnnz, ennz);
       TEST_EQUALITY_CONST(trowptr[my_num_rows], tnnz);
       TEST_EQUALITY_CONST(erowptr[my_num_rows], ennz);
-	
+
       TEST_COMPARE_ARRAYS(tnzvals.view(0,tnnz), enzvals.view(0,ennz));
       TEST_COMPARE_ARRAYS(tcolind.view(0,tnnz), ecolind.view(0,ennz));
       TEST_COMPARE_ARRAYS(trowptr.view(0,my_num_rows), erowptr.view(0,my_num_rows));
@@ -378,7 +378,7 @@ namespace {
       TEST_EQUALITY(tnnz, ennz);
       TEST_EQUALITY_CONST(trowptr[my_num_rows], tnnz);
       TEST_EQUALITY_CONST(erowptr[my_num_rows], ennz);
-	
+
       TEST_COMPARE_ARRAYS(tnzvals.view(0,tnnz), enzvals.view(0,ennz));
       TEST_COMPARE_ARRAYS(tcolind.view(0,tnnz), ecolind.view(0,ennz));
       TEST_COMPARE_ARRAYS(trowptr.view(0,my_num_rows), erowptr.view(0,my_num_rows));
@@ -386,4 +386,4 @@ namespace {
   }
 } // end anonymous namespace
 
-  
+

--- a/packages/amesos2/test/adapters/Epetra_RowMatrix_Adapter_UnitTests.cpp
+++ b/packages/amesos2/test/adapters/Epetra_RowMatrix_Adapter_UnitTests.cpp
@@ -106,8 +106,8 @@ namespace {
     clp.setOption("filedir",&filedir,"Directory of matrix files.");
     clp.addOutputSetupOptions(true);
     clp.setOption("test-mpi", "test-serial", &testMpi,
-		  "Test Serial by default (for now) or force MPI test.  In a serial build,"
-		  " this option is ignored and a serial comm is always used." );
+                  "Test Serial by default (for now) or force MPI test.  In a serial build,"
+                  " this option is ignored and a serial comm is always used." );
   }
 
   const RCP<Epetra_Comm> getDefaultComm()
@@ -138,7 +138,7 @@ namespace {
     }
     return(r);
   }
-  
+
   template<typename T>
   bool contains(const ArrayView<T> a, T t)
   {
@@ -170,7 +170,7 @@ namespace {
     const int num_eqn = 100;
 
     Epetra_Map Map(num_eqn, 0, *comm);
-  
+
     // Get update list and number of local equations from newly created Map.
 
     int NumMyElements = Map.NumMyElements();
@@ -179,7 +179,7 @@ namespace {
     Map.MyGlobalElements(&MyGlobalElements[0]);
 
     // Create an integer vector NumNz that is used to build the Petra Matrix.
-    // NumNz[i] is the Number of OFF-DIAGONAL term for the ith global equation 
+    // NumNz[i] is the Number of OFF-DIAGONAL term for the ith global equation
     // on this processor
 
     std::vector<int> NumNz(NumMyElements);
@@ -190,15 +190,15 @@ namespace {
 
     // Create a Epetra_Matrix
     Teuchos::RCP<Epetra_CrsMatrix> eye = rcp(new Epetra_CrsMatrix(Copy, Map, &NumNz[0]));
-  
+
     std::vector<double> Values(2);
     std::vector<int> Indices(2);
     double one = 1.0;
-  
+
     for (int i = 0; i < NumMyElements; ++i)
       {
-	int ierr = eye->InsertGlobalValues(MyGlobalElements[i], 1, &one, &MyGlobalElements[i]);
-	TEUCHOS_TEST_FOR_EXCEPTION(ierr != 0,std::runtime_error,"Error inserting value into matrix");
+        int ierr = eye->InsertGlobalValues(MyGlobalElements[i], 1, &one, &MyGlobalElements[i]);
+        TEUCHOS_TEST_FOR_EXCEPTION(ierr != 0,std::runtime_error,"Error inserting value into matrix");
       }
 
     eye->FillComplete();
@@ -207,7 +207,8 @@ namespace {
     // The following should all pass at compile time
     TEST_ASSERT( (is_same<double,ADAPT::scalar_t>::value) );
     TEST_ASSERT( (is_same<int,ADAPT::local_ordinal_t>::value) );
-    TEST_ASSERT( (is_same<int,ADAPT::global_ordinal_t>::value) );
+    // mfh 23 Apr 2019: I have removed the requirement that
+    // ADAPT::global_ordinal_t == int.
     TEST_ASSERT( (is_same<size_t,ADAPT::global_size_t>::value) );
     TEST_ASSERT( (is_same<MAT,ADAPT::matrix_t>::value) );
 
@@ -228,7 +229,7 @@ namespace {
     const int num_eqn = 100;
 
     Epetra_Map Map(num_eqn, 0, *comm);
-  
+
     // Get update list and number of local equations from newly created Map.
 
     int NumMyElements = Map.NumMyElements();
@@ -237,7 +238,7 @@ namespace {
     Map.MyGlobalElements(&MyGlobalElements[0]);
 
     // Create an integer vector NumNz that is used to build the Petra Matrix.
-    // NumNz[i] is the Number of OFF-DIAGONAL term for the ith global equation 
+    // NumNz[i] is the Number of OFF-DIAGONAL term for the ith global equation
     // on this processor
 
     std::vector<int> NumNz(NumMyElements);
@@ -248,15 +249,15 @@ namespace {
 
     // Create a Epetra_Matrix
     Teuchos::RCP<Epetra_CrsMatrix> eye = rcp(new Epetra_CrsMatrix(Copy, Map, &NumNz[0]));
-  
+
     std::vector<double> Values(2);
     std::vector<int> Indices(2);
     double one = 1.0;
-  
+
     for (int i = 0; i < NumMyElements; ++i)
       {
-	int ierr = eye->InsertGlobalValues(MyGlobalElements[i], 1, &one, &MyGlobalElements[i]);
-	TEUCHOS_TEST_FOR_EXCEPTION(ierr != 0,std::runtime_error,"Error inserting value into matrix");
+        int ierr = eye->InsertGlobalValues(MyGlobalElements[i], 1, &one, &MyGlobalElements[i]);
+        TEUCHOS_TEST_FOR_EXCEPTION(ierr != 0,std::runtime_error,"Error inserting value into matrix");
       }
 
     eye->FillComplete();
@@ -277,8 +278,10 @@ namespace {
     typedef Epetra_CrsMatrix MAT;
     typedef MatrixAdapter<MAT> ADAPT;
 
+    std::cerr << "CRS_Serial test" << std::endl;
+
     /* We will be using the following matrix for this test:
-     * 
+     *
      * [ [ 7,  0,  -3, 0,  -1, 0 ]
      *   [ 2,  8,  0,  0,  0,  0 ]
      *   [ 0,  0,  1,  0,  0,  0 ]
@@ -293,7 +296,7 @@ namespace {
     const int num_eqn = 6;
 
     Epetra_Map Map(num_eqn, 0, *comm);
-  
+
     // Get update list and number of local equations from newly created Map.
 
     int NumMyElements = Map.NumMyElements();
@@ -302,40 +305,42 @@ namespace {
     Map.MyGlobalElements(&MyGlobalElements[0]);
 
     // Create an integer vector NumNz that is used to build the Petra Matrix.
-    // NumNz[i] is the Number of OFF-DIAGONAL term for the ith global equation 
+    // NumNz[i] is the Number of OFF-DIAGONAL term for the ith global equation
     // on this processor
 
     int NumNz[] = {3, 2, 1, 2, 2, 2};
 
     // Create a Epetra_Matrix
     Teuchos::RCP<Epetra_CrsMatrix> mat = rcp(new Epetra_CrsMatrix(Copy, Map, NumNz));
-  
+
     // Construct matrix
     mat->InsertGlobalValues(0,NumNz[0],
-			    tuple<ADAPT::scalar_t>(7,-3,-1).getRawPtr(),
-			    tuple<ADAPT::global_ordinal_t>(0,2,4).getRawPtr());
+                            tuple<ADAPT::scalar_t>(7,-3,-1).getRawPtr(),
+                            tuple<int>(0,2,4).getRawPtr());
     mat->InsertGlobalValues(1,NumNz[1],
-			    tuple<ADAPT::scalar_t>(2,8).getRawPtr(),
-			    tuple<ADAPT::global_ordinal_t>(0,1).getRawPtr());
+                            tuple<ADAPT::scalar_t>(2,8).getRawPtr(),
+                            tuple<int>(0,1).getRawPtr());
     mat->InsertGlobalValues(2,NumNz[2],
-			    tuple<ADAPT::scalar_t>(1).getRawPtr(),
-			    tuple<ADAPT::global_ordinal_t>(2).getRawPtr());
+                            tuple<ADAPT::scalar_t>(1).getRawPtr(),
+                            tuple<int>(2).getRawPtr());
     mat->InsertGlobalValues(3,NumNz[3],
-			    tuple<ADAPT::scalar_t>(-3,5).getRawPtr(),
-			    tuple<ADAPT::global_ordinal_t>(0,3).getRawPtr());
+                            tuple<ADAPT::scalar_t>(-3,5).getRawPtr(),
+                            tuple<int>(0,3).getRawPtr());
     mat->InsertGlobalValues(4,NumNz[4],
-			    tuple<ADAPT::scalar_t>(-1,4).getRawPtr(),
-			    tuple<ADAPT::global_ordinal_t>(1,4).getRawPtr());
+                            tuple<ADAPT::scalar_t>(-1,4).getRawPtr(),
+                            tuple<int>(1,4).getRawPtr());
     mat->InsertGlobalValues(5,NumNz[5],
-			    tuple<ADAPT::scalar_t>(-2,6).getRawPtr(),
-			    tuple<ADAPT::global_ordinal_t>(3,5).getRawPtr());
+                            tuple<ADAPT::scalar_t>(-2,6).getRawPtr(),
+                            tuple<int>(3,5).getRawPtr());
     mat->FillComplete();
 
     // Print for sanity sake
     // RCP<FancyOStream> os = getDefaultOStream();
     // mat->describe(*os,Teuchos::VERB_EXTREME);
 
-    RCP<ADAPT> adapter = Amesos2::createMatrixAdapter<MAT>(mat);
+    std::cerr << "Make adapter" << std::endl;
+    RCP<ADAPT> adapter;
+    TEST_NOTHROW( adapter = Amesos2::createMatrixAdapter<MAT>(mat) );
 
     Array<ADAPT::scalar_t> nzvals_test(tuple<ADAPT::scalar_t>(7,-3,-1,2,8,1,-3,5,-1,4,-2,6));
     Array<ADAPT::global_ordinal_t> colind_test(tuple<ADAPT::global_ordinal_t>(0,2,4,0,1,2,0,3,1,4,3,5));
@@ -346,6 +351,7 @@ namespace {
     Array<ADAPT::global_size_t> rowptr(adapter->getGlobalNumRows() + 1);
     size_t nnz;
 
+    std::cerr << "Call adapter->getCrs" << std::endl;
     adapter->getCrs(nzvals,colind,rowptr,nnz,ROOTED);
 
     // getCrs does not guarantee the sorted-ness of the column
@@ -363,6 +369,7 @@ namespace {
     // Check now a rooted, sorted-indices repr //
     /////////////////////////////////////////////
 
+    std::cerr << "Call adapter->getCrs (2)" << std::endl;
     adapter->getCrs(nzvals,colind,rowptr,nnz,ROOTED,Amesos2::SORTED_INDICES);
 
     if ( rank == 0 ){
@@ -372,6 +379,8 @@ namespace {
       TEST_COMPARE_ARRAYS(rowptr, rowptr_test);
       TEST_EQUALITY_CONST(nnz, 12);
     }
+
+    std::cerr << "Reached end of test" << std::endl;
   }
 
   TEUCHOS_UNIT_TEST( CrsMatrixAdapter, CRS_Replicated )
@@ -381,12 +390,12 @@ namespace {
      */
     typedef Epetra_CrsMatrix MAT;
     typedef MatrixAdapter<MAT> ADAPT;
-    typedef int GO;
+    typedef Tpetra::Map<>::global_ordinal_type GO;
     typedef int global_size_t;
     typedef std::pair<double,GO> my_pair_t;
 
     /* We will be using the following matrix for this test:
-     * 
+     *
      * [ [ 7,  0,  -3, 0,  -1, 0 ]
      *   [ 2,  8,  0,  0,  0,  0 ]
      *   [ 0,  0,  1,  0,  0,  0 ]
@@ -400,7 +409,7 @@ namespace {
     const int num_eqn = 6;
 
     Epetra_Map Map(num_eqn, 0, *comm);
-  
+
     // Get update list and number of local equations from newly created Map.
 
     int NumMyElements = Map.NumMyElements();
@@ -409,33 +418,33 @@ namespace {
     Map.MyGlobalElements(&MyGlobalElements[0]);
 
     // Create an integer vector NumNz that is used to build the Petra Matrix.
-    // NumNz[i] is the Number of OFF-DIAGONAL term for the ith global equation 
+    // NumNz[i] is the Number of OFF-DIAGONAL term for the ith global equation
     // on this processor
 
     int NumNz[] = {3, 2, 1, 2, 2, 2};
 
     // Create a Epetra_Matrix
     Teuchos::RCP<Epetra_CrsMatrix> mat = rcp(new Epetra_CrsMatrix(Copy, Map, NumNz));
-  
+
     // Construct matrix
     mat->InsertGlobalValues(0,NumNz[0],
-			    tuple<ADAPT::scalar_t>(7,-3,-1).getRawPtr(),
-			    tuple<ADAPT::global_ordinal_t>(0,2,4).getRawPtr());
+                            tuple<ADAPT::scalar_t>(7,-3,-1).getRawPtr(),
+                            tuple<int>(0,2,4).getRawPtr());
     mat->InsertGlobalValues(1,NumNz[1],
-			    tuple<ADAPT::scalar_t>(2,8).getRawPtr(),
-			    tuple<ADAPT::global_ordinal_t>(0,1).getRawPtr());
+                            tuple<ADAPT::scalar_t>(2,8).getRawPtr(),
+                            tuple<int>(0,1).getRawPtr());
     mat->InsertGlobalValues(2,NumNz[2],
-			    tuple<ADAPT::scalar_t>(1).getRawPtr(),
-			    tuple<ADAPT::global_ordinal_t>(2).getRawPtr());
+                            tuple<ADAPT::scalar_t>(1).getRawPtr(),
+                            tuple<int>(2).getRawPtr());
     mat->InsertGlobalValues(3,NumNz[3],
-			    tuple<ADAPT::scalar_t>(-3,5).getRawPtr(),
-			    tuple<ADAPT::global_ordinal_t>(0,3).getRawPtr());
+                            tuple<ADAPT::scalar_t>(-3,5).getRawPtr(),
+                            tuple<int>(0,3).getRawPtr());
     mat->InsertGlobalValues(4,NumNz[4],
-			    tuple<ADAPT::scalar_t>(-1,4).getRawPtr(),
-			    tuple<ADAPT::global_ordinal_t>(1,4).getRawPtr());
+                            tuple<ADAPT::scalar_t>(-1,4).getRawPtr(),
+                            tuple<int>(1,4).getRawPtr());
     mat->InsertGlobalValues(5,NumNz[5],
-			    tuple<ADAPT::scalar_t>(-2,6).getRawPtr(),
-			    tuple<ADAPT::global_ordinal_t>(3,5).getRawPtr());
+                            tuple<ADAPT::scalar_t>(-2,6).getRawPtr(),
+                            tuple<int>(3,5).getRawPtr());
     mat->FillComplete();
 
     // Print for sanity sake
@@ -460,7 +469,7 @@ namespace {
     adapter->getCrs(nzvals,colind,rowptr,nnz,GLOBALLY_REPLICATED);
 
     // All processes check
-    
+
     // getCrs() does not guarantee a permutation of the non-zero
     // values and the column indices in the Arbitrary case, we just
     // know that they need to match up with what is expected.
@@ -472,11 +481,11 @@ namespace {
       TEST_ASSERT( rp < as<global_size_t>(nzvals.size()) );
       TEST_ASSERT( rp < as<global_size_t>(colind.size()) );
       const RCP<Array<my_pair_t> > expected_pairs
-	= zip(nzvals_test.view(rp,row_nnz), colind_test.view(rp,row_nnz));
+        = zip(nzvals_test.view(rp,row_nnz), colind_test.view(rp,row_nnz));
       const RCP<Array<my_pair_t> > got_pairs
-	= zip(nzvals.view(rp,row_nnz), colind.view(rp,row_nnz));
+        = zip(nzvals.view(rp,row_nnz), colind.view(rp,row_nnz));
       for ( global_size_t i = 0; i < row_nnz; ++i ){
-	TEST_ASSERT( contains((*got_pairs)(), (*expected_pairs)[i]) );
+        TEST_ASSERT( contains((*got_pairs)(), (*expected_pairs)[i]) );
       }
     }
     TEST_COMPARE_ARRAYS(rowptr, rowptr_test);
@@ -487,7 +496,7 @@ namespace {
     ///////////////////////////////////////////
 
     adapter->getCrs(nzvals,colind,rowptr,nnz,
-		    GLOBALLY_REPLICATED,Amesos2::SORTED_INDICES);
+                    GLOBALLY_REPLICATED,Amesos2::SORTED_INDICES);
 
     TEST_COMPARE_ARRAYS(nzvals, nzvals_test);
     TEST_COMPARE_ARRAYS(colind, colind_test);
@@ -504,7 +513,7 @@ namespace {
     typedef MatrixAdapter<MAT> ADAPT;
 
     /* We will be using the following matrix for this test:
-     * 
+     *
      * [ [ 7,  0,  -3, 0,  -1, 0 ]
      *   [ 2,  8,  0,  0,  0,  0 ]
      *   [ 0,  0,  1,  0,  0,  0 ]
@@ -520,7 +529,7 @@ namespace {
     const int num_eqn = 6;
 
     Epetra_Map Map(num_eqn, 0, *comm);
-  
+
     // Get update list and number of local equations from newly created Map.
 
     int NumMyElements = Map.NumMyElements();
@@ -529,33 +538,33 @@ namespace {
     Map.MyGlobalElements(&MyGlobalElements[0]);
 
     // Create an integer vector NumNz that is used to build the Petra Matrix.
-    // NumNz[i] is the Number of OFF-DIAGONAL term for the ith global equation 
+    // NumNz[i] is the Number of OFF-DIAGONAL term for the ith global equation
     // on this processor
 
     int NumNz[] = {3, 2, 1, 2, 2, 2};
 
     // Create a Epetra_Matrix
     Teuchos::RCP<Epetra_CrsMatrix> mat = rcp(new Epetra_CrsMatrix(Copy, Map, NumNz));
-  
+
     // Construct matrix
     mat->InsertGlobalValues(0,NumNz[0],
-			    tuple<ADAPT::scalar_t>(7,-3,-1).getRawPtr(),
-			    tuple<ADAPT::global_ordinal_t>(0,2,4).getRawPtr());
+                            tuple<ADAPT::scalar_t>(7,-3,-1).getRawPtr(),
+                            tuple<int>(0,2,4).getRawPtr());
     mat->InsertGlobalValues(1,NumNz[1],
-			    tuple<ADAPT::scalar_t>(2,8).getRawPtr(),
-			    tuple<ADAPT::global_ordinal_t>(0,1).getRawPtr());
+                            tuple<ADAPT::scalar_t>(2,8).getRawPtr(),
+                            tuple<int>(0,1).getRawPtr());
     mat->InsertGlobalValues(2,NumNz[2],
-			    tuple<ADAPT::scalar_t>(1).getRawPtr(),
-			    tuple<ADAPT::global_ordinal_t>(2).getRawPtr());
+                            tuple<ADAPT::scalar_t>(1).getRawPtr(),
+                            tuple<int>(2).getRawPtr());
     mat->InsertGlobalValues(3,NumNz[3],
-			    tuple<ADAPT::scalar_t>(-3,5).getRawPtr(),
-			    tuple<ADAPT::global_ordinal_t>(0,3).getRawPtr());
+                            tuple<ADAPT::scalar_t>(-3,5).getRawPtr(),
+                            tuple<int>(0,3).getRawPtr());
     mat->InsertGlobalValues(4,NumNz[4],
-			    tuple<ADAPT::scalar_t>(-1,4).getRawPtr(),
-			    tuple<ADAPT::global_ordinal_t>(1,4).getRawPtr());
+                            tuple<ADAPT::scalar_t>(-1,4).getRawPtr(),
+                            tuple<int>(1,4).getRawPtr());
     mat->InsertGlobalValues(5,NumNz[5],
-			    tuple<ADAPT::scalar_t>(-2,6).getRawPtr(),
-			    tuple<ADAPT::global_ordinal_t>(3,5).getRawPtr());
+                            tuple<ADAPT::scalar_t>(-2,6).getRawPtr(),
+                            tuple<int>(3,5).getRawPtr());
     mat->FillComplete();
 
     // Print for sanity sake
@@ -581,13 +590,13 @@ namespace {
     size_t my_num_rows = OrdinalTraits<size_t>::zero();
     if ( numprocs > 1 ){
       if ( rank < 2 ){
-	my_num_rows = 3;		// total num_rows is 6
+        my_num_rows = 3;                // total num_rows is 6
       }
-    } else {			// We only have 1 proc, then she just takes it all
+    } else {                    // We only have 1 proc, then she just takes it all
       my_num_rows = 6;
     }
-    const Tpetra::Map<int,int> half_map(6, my_num_rows, 0,
-					to_teuchos_comm(comm));
+    const Tpetra::Map<> half_map(6, my_num_rows, 0,
+                                 to_teuchos_comm(comm));
 
     adapter->getCrs(nzvals,colind,rowptr,nnz, Teuchos::ptrInArg(half_map), Amesos2::SORTED_INDICES, Amesos2::DISTRIBUTED); // ROOTED = default distribution
 
@@ -622,7 +631,7 @@ namespace {
     typedef MatrixAdapter<MAT> ADAPT;
 
     /* We will be using the following matrix for this test:
-     * 
+     *
      * [ [ 7,  0,  -3, 0,  -1, 0 ]
      *   [ 2,  8,  0,  0,  0,  0 ]
      *   [ 0,  0,  1,  0,  0,  0 ]
@@ -636,7 +645,7 @@ namespace {
     const int num_eqn = 6;
 
     Epetra_Map Map(num_eqn, 0, *comm);
-  
+
     // Get update list and number of local equations from newly created Map.
 
     int NumMyElements = Map.NumMyElements();
@@ -645,33 +654,33 @@ namespace {
     Map.MyGlobalElements(&MyGlobalElements[0]);
 
     // Create an integer vector NumNz that is used to build the Petra Matrix.
-    // NumNz[i] is the Number of OFF-DIAGONAL term for the ith global equation 
+    // NumNz[i] is the Number of OFF-DIAGONAL term for the ith global equation
     // on this processor
 
     int NumNz[] = {3, 2, 1, 2, 2, 2};
 
     // Create a Epetra_Matrix
     Teuchos::RCP<Epetra_CrsMatrix> mat = rcp(new Epetra_CrsMatrix(Copy, Map, NumNz));
-  
+
     // Construct matrix
     mat->InsertGlobalValues(0,NumNz[0],
-			    tuple<ADAPT::scalar_t>(7,-3,-1).getRawPtr(),
-			    tuple<ADAPT::global_ordinal_t>(0,2,4).getRawPtr());
+                            tuple<ADAPT::scalar_t>(7,-3,-1).getRawPtr(),
+                            tuple<int>(0,2,4).getRawPtr());
     mat->InsertGlobalValues(1,NumNz[1],
-			    tuple<ADAPT::scalar_t>(2,8).getRawPtr(),
-			    tuple<ADAPT::global_ordinal_t>(0,1).getRawPtr());
+                            tuple<ADAPT::scalar_t>(2,8).getRawPtr(),
+                            tuple<int>(0,1).getRawPtr());
     mat->InsertGlobalValues(2,NumNz[2],
-			    tuple<ADAPT::scalar_t>(1).getRawPtr(),
-			    tuple<ADAPT::global_ordinal_t>(2).getRawPtr());
+                            tuple<ADAPT::scalar_t>(1).getRawPtr(),
+                            tuple<int>(2).getRawPtr());
     mat->InsertGlobalValues(3,NumNz[3],
-			    tuple<ADAPT::scalar_t>(-3,5).getRawPtr(),
-			    tuple<ADAPT::global_ordinal_t>(0,3).getRawPtr());
+                            tuple<ADAPT::scalar_t>(-3,5).getRawPtr(),
+                            tuple<int>(0,3).getRawPtr());
     mat->InsertGlobalValues(4,NumNz[4],
-			    tuple<ADAPT::scalar_t>(-1,4).getRawPtr(),
-			    tuple<ADAPT::global_ordinal_t>(1,4).getRawPtr());
+                            tuple<ADAPT::scalar_t>(-1,4).getRawPtr(),
+                            tuple<int>(1,4).getRawPtr());
     mat->InsertGlobalValues(5,NumNz[5],
-			    tuple<ADAPT::scalar_t>(-2,6).getRawPtr(),
-			    tuple<ADAPT::global_ordinal_t>(3,5).getRawPtr());
+                            tuple<ADAPT::scalar_t>(-2,6).getRawPtr(),
+                            tuple<int>(3,5).getRawPtr());
     mat->FillComplete();
 
     // Print for sanity sake


### PR DESCRIPTION
@trilinos/amesos2

## Description

- Permit Amesos2_ENABLE_Epetra=ON with Tpetra_INST_INT_INT=OFF.
- Fix Amesos2's build for that case.

This took me about an hour to do and required only trivial index conversions.

## Motivation and Context

@rppawlo needs this for Empire.  Tpetra developers want to deprecate and remove template parameters like GlobalOrdinal.  It's trivial to do index conversions, especially for a package like Amesos2, where the solves will take much longer than any index conversions that need to happen.

## Related Issues

* Closes #4992 
* Related to #3234