### PR TITLE
Tpetra: fix clang compilation of test using clone

### DIFF
--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_NodeConversion.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_NodeConversion.cpp
@@ -103,6 +103,7 @@ namespace {
   ////
   TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( CrsMatrix, NodeConversion, N2 )
   {
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
     typedef Tpetra::Map<> Map1;
     typedef Tpetra::CrsMatrix<>::scalar_type SCALAR;
     typedef Map1::local_ordinal_type LO;
@@ -188,6 +189,7 @@ namespace {
       TEST_EQUALITY_CONST( A2->getNodeNumEntries(), A1->getNodeNumEntries()+numLocal-2 );
     }
 
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
   }
 
 //


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Description
Added TPETRA_ENABLE_DEPRECATED_CODE guards around test using CrsMatrix::clone

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
When compiling with clang and TPETRA_ENABLE_DEPRECATED_CODE=OFF, I got compiler errors.
```
/Users//code/Trilinos/packages/tpetra/core/test/CrsMatrix/CrsMatrix_NodeConversion.cpp:138:35: error: 'clone' following the 'template' keyword does not refer to a template
      RCP<Mat2> A2 = A1->template clone<N2>(n2,plClone);
                         ~~~~~~~~ ^~~~~
/Users//code/Trilinos/packages/tpetra/core/test/CrsMatrix/CrsMatrix_NodeConversion.cpp:138:40: error: expected unqualified-id
      RCP<Mat2> A2 = A1->template clone<N2>(n2,plClone);
                                       ^
/Users//code/Trilinos/packages/tpetra/core/test/CrsMatrix/CrsMatrix_NodeConversion.cpp:138:41: error: 'N2' does not refer to a value
      RCP<Mat2> A2 = A1->template clone<N2>(n2,plClone);
                                        ^
/Users//code/Trilinos/packages/tpetra/core/test/CrsMatrix/CrsMatrix_NodeConversion.cpp:104:65: note: declared here
  TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( CrsMatrix, NodeConversion, N2 )
```


## Related Issues

#4900 

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->

Mac using clang
```
-D Trilinos_ENABLE_Tpetra:BOOL=ON \
-D Tpetra_ENABLE_TESTS:BOOL=ON \
-D Tpetra_ENABLE_EXAMPLES:BOOL=ON \
-D Tpetra_ENABLE_DEPRECATED_CODE:BOOL=OFF \
```



<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [ ] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
