### PR TITLE
MueLu: fixing call to kokkos refactor method in Xpetra::EpetraMap, closes #5019

### DIFF
--- a/packages/muelu/example/advanced/levelwrap/LevelWrap.cpp
+++ b/packages/muelu/example/advanced/levelwrap/LevelWrap.cpp
@@ -135,6 +135,7 @@ namespace MueLuExamples {
 #include "MueLu_UseShortNames.hpp"
     using Teuchos::rcp;
 
+    if(lib == Xpetra::UseEpetra) {MueLuList.set("use kokkos refactor", false);}
     Teuchos::RCP<MueLu::Hierarchy<Scalar,LocalOrdinal,GlobalOrdinal,Node> > H =
         MueLu::CreateXpetraPreconditioner<Scalar,LocalOrdinal,GlobalOrdinal,Node>(A, MueLuList);
 

--- a/packages/muelu/example/advanced/multiplesolve/StandardReuse.cpp
+++ b/packages/muelu/example/advanced/multiplesolve/StandardReuse.cpp
@@ -239,12 +239,15 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib &lib, int ar
 
   Teuchos::ParameterList paramList;
   paramList.set("verbosity", "none");
-  if (xmlFileName != "")
+  if(lib == Xpetra::UseEpetra) {
+    out << "Setting: \"use kokkos refactor\" to: false" << std::endl;
+    paramList.set("use kokkos refactor", false);
+  }
+  if (xmlFileName != "") {
     Teuchos::updateParametersFromXmlFileAndBroadcast(xmlFileName, Teuchos::Ptr<Teuchos::ParameterList>(&paramList), *comm);
+  }
   Teuchos::ParameterList userParamList = paramList.sublist("user data");
   userParamList.set<RCP<RealValuedMultiVector> >("Coordinates", coordinates);
-
-  out << "Parameter list:" << std::endl << paramList << std::endl;
 
   // =========================================================================
   // Setup #1 (no reuse)

--- a/packages/muelu/test/interface/CreateOperator.cpp
+++ b/packages/muelu/test/interface/CreateOperator.cpp
@@ -293,7 +293,9 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib lib, int arg
 
     bool useKokkos = false;
 #if defined(HAVE_MUELU_KOKKOS_REFACTOR) && defined(HAVE_MUELU_KOKKOS_REFACTOR_USE_BY_DEFAULT)
-    useKokkos = true;
+    if(lib == Xpetra::UseTpetra) {
+      useKokkos = true;
+    }
 #endif
     clp.setOption("kokkosRefactor", "noKokkosRefactor", &useKokkos, "use kokkos refactor");
 

--- a/packages/muelu/test/interface/ParameterListInterpreter.cpp
+++ b/packages/muelu/test/interface/ParameterListInterpreter.cpp
@@ -97,7 +97,9 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
   std::string xmlForceFile = "";
   bool useKokkos = false;
 #if defined(HAVE_MUELU_KOKKOS_REFACTOR) && defined(HAVE_MUELU_KOKKOS_REFACTOR_USE_BY_DEFAULT)
-  useKokkos = true;
+  if(lib == Xpetra::UseTpetra) {
+    useKokkos = true;
+  }
 #endif
   clp.setOption("kokkosRefactor", "noKokkosRefactor", &useKokkos, "use kokkos refactor");
   clp.setOption("heavytests", "noheavytests",  &runHeavyTests, "whether to exercise tests that take a long time to run");

--- a/packages/muelu/test/scaling/ImportPerformance.cpp
+++ b/packages/muelu/test/scaling/ImportPerformance.cpp
@@ -684,6 +684,7 @@ int main_(Teuchos::CommandLineProcessor &clp,  Xpetra::UnderlyingLib &lib, int a
                 auto MueLuSU_D2 = TimeMonitor(*TimeMonitor::getNewTimer("Driver: 2 - MueLu Setup"));
 
                 A->SetMaxEigenvalueEstimate(-one);
+                if(lib == Xpetra::UseEpetra) {mueluList.set("use kokkos refactor", false);}
                 Teuchos::ParameterList& userParamList = mueluList.sublist("user data");
                 userParamList.set<RCP<RealValuedMultiVector> >("Coordinates", coordinates);
                 H = MueLu::CreateXpetraPreconditioner(A, mueluList);

--- a/packages/muelu/test/unit_tests/Adapters/CreatePreconditioner.cpp
+++ b/packages/muelu/test/unit_tests/Adapters/CreatePreconditioner.cpp
@@ -635,6 +635,7 @@ namespace MueLuTests {
         Teuchos::updateParametersFromXmlFileAndBroadcast(xmlFileName,
                                                          Teuchos::Ptr<Teuchos::ParameterList>(&paramList),
                                                          *map->getComm());
+        paramList.set("use kokkos refactor", false); // Done to avoid having kokkos factories called with Epetra
         Teuchos::ParameterList& userParamList = paramList.sublist("user data");
         userParamList.set<RCP<Epetra_MultiVector> >("Coordinates", epcoordinates);
         userParamList.set<RCP<Epetra_MultiVector> >("Nullspace",   epnullspace);
@@ -757,7 +758,12 @@ namespace MueLuTests {
 
       RCP<Epetra_CrsMatrix> epA = MueLu::Utilities<SC,LO,GO,NO>::Op2NonConstEpetraCrs(Op);
 
-      RCP<MueLu::EpetraOperator> eH = MueLu::CreateEpetraPreconditioner(epA, xmlFileName);
+      Teuchos::ParameterList paramList;
+      Teuchos::updateParametersFromXmlFileAndBroadcast(xmlFileName,
+                                                       Teuchos::Ptr<Teuchos::ParameterList>(&paramList),
+                                                       *map->getComm());
+      paramList.set("use kokkos refactor", false);
+      RCP<MueLu::EpetraOperator> eH = MueLu::CreateEpetraPreconditioner(epA, paramList);
 
       eH->Apply(*(Utils::MV2EpetraMV(RHS1)), *(Utils::MV2NonConstEpetraMV(X1)));
       out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<

--- a/packages/muelu/test/unit_tests/Hierarchy.cpp
+++ b/packages/muelu/test/unit_tests/Hierarchy.cpp
@@ -124,6 +124,10 @@ namespace MueLuTests {
     MueLuList.set("coarse: max size",numRows-1); // make it so we want two levels
     MueLuList.set("max levels",2);
 
+    if(A->getRowMap()->lib() == Xpetra::UseEpetra) {
+      MueLuList.set("use kokkos refactor", false);
+    }
+
     Teuchos::ParameterList userParamList = MueLuList.sublist("user data");
     userParamList.set<RCP<RealValuedMultiVector> >("Coordinates", coordinates);
     Teuchos::RCP<MueLu::Hierarchy<Scalar,LocalOrdinal,GlobalOrdinal,Node> > H =

--- a/packages/muelu/test/unit_tests/RAPShiftFactory.cpp
+++ b/packages/muelu/test/unit_tests/RAPShiftFactory.cpp
@@ -595,6 +595,9 @@ namespace MueLuTests {
     Params->set("max levels",2);
     Teuchos::ParameterList & pLevel0 = Params->sublist("level 0");
     pLevel0.set("Mdiag",Mdiag);
+    if(A->getRowMap()->lib() == Xpetra::UseEpetra) {
+      Params->set("use kokkos refactor", false);
+    }
 
     // Build hierarchy
     Teuchos::ParameterList& userParamList = Params->sublist("user data");
@@ -682,6 +685,9 @@ namespace MueLuTests {
     Params->set("max levels",2);
     Teuchos::ParameterList & pLevel0 = Params->sublist("level 0");
     pLevel0.set("Mdiag",Mdiag);
+    if(A->getRowMap()->lib() == Xpetra::UseEpetra) {
+      Params->set("use kokkos refactor", false);
+    }
 
     // Build hierarchy
     Teuchos::ParameterList& userParamList = Params->sublist("user data");
@@ -767,6 +773,9 @@ namespace MueLuTests {
     Params->set("max levels",4);
     Teuchos::ParameterList & pLevel0 = Params->sublist("level 0");
     pLevel0.set("Mdiag",Mdiag);
+    if(A->getRowMap()->lib() == Xpetra::UseEpetra) {
+      Params->set("use kokkos refactor", false);
+    }
     Teuchos::ParameterList & user = Params->sublist("user data");
     user.set("double deltaT",1.0);
     user.set("double cfl",1.0);

--- a/packages/muelu/test/unit_tests/UserData/CreateXpetraPreconditioner.cpp
+++ b/packages/muelu/test/unit_tests/UserData/CreateXpetraPreconditioner.cpp
@@ -93,6 +93,9 @@ namespace MueLuTests {
 
     std::string xmlFileName = "UserData/test.xml";
     Teuchos::RCP<Teuchos::ParameterList> inParamList = Teuchos::getParametersFromXmlFile(xmlFileName);
+    if(lib == Xpetra::UseEpetra) {
+      inParamList->sublist("Hierarchy").set("use kokkos refactor", false);
+    }
 
     typedef typename Teuchos::ScalarTraits<SC>::magnitudeType magnitude_type;
 


### PR DESCRIPTION
@trilinos/muelu 

## Description
We need to make sure that the ParameterListInterpreter does not call kokkos factories when we run with lib==Xpetra::UseEpetra

## Motivation and Context
This will allow our nightly builds to have test passing.

## Related Issues

* Closes #5019 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 

## How Has This Been Tested?
This has been tested locally and all MueLu tests pass

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [x] These changes break backwards compatibility.