### PR TITLE
TrilinosCouplings: Fix #5029

### DIFF
--- a/packages/trilinoscouplings/examples/fenl/fenl_ensemble.hpp
+++ b/packages/trilinoscouplings/examples/fenl/fenl_ensemble.hpp
@@ -52,6 +52,7 @@
 
 #if defined( HAVE_STOKHOS_BELOS )
 #include "Belos_TpetraAdapter_MP_Vector.hpp"
+#include "BelosPseudoBlockCGSolMgr.hpp"
 #endif
 
 #if defined( HAVE_STOKHOS_MUELU )


### PR DESCRIPTION
@trilinos/trilinoscouplings

## Description

Fix #5029 (missing header file include in TrilinosCouplings example).

## Related Issues

* Closes #5029 