### PR TITLE
Tpetra: Fix #5038 (spurious "unused function" build warnings)

### DIFF
--- a/packages/tpetra/core/src/CMakeLists.txt
+++ b/packages/tpetra/core/src/CMakeLists.txt
@@ -414,5 +414,5 @@ SET_PROPERTY(
 # / from this directory, or to / from the 'impl' subdirectory.  That ensures
 # that running "make" will also rerun CMake in order to regenerate Makefiles.
 #
-# Here is another such change.  Behold, I make yet another change, and another.
+# Here is another such change.  Verily, I make yet another change.
 #

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -85,17 +85,6 @@ namespace Tpetra {
 
 namespace { // (anonymous)
 
-  std::shared_ptr< ::Tpetra::Details::CommRequest>
-  iallreduceIntRaw (const int& localValue,
-                    int& globalValue,
-                    const ::Teuchos::EReductionType op,
-                    const Teuchos::Comm<int>& comm)
-  {
-    Kokkos::View<const int*, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> > localView (&localValue,1);
-    Kokkos::View<int*, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> > globalView (&globalValue, 1);
-    return ::Tpetra::Details::iallreduce (localView, globalView, op, comm);
-  }
-
   template<class T, class BinaryFunction>
   T atomic_binary_function_update (volatile T* const dest,
                                    const T& inputVal,
@@ -8463,8 +8452,9 @@ namespace Tpetra {
      const bool target_vals = ! (rowTransfer.getExportLIDs ().size() == 0 ||
                                  rowTransfer.getRemoteLIDs ().size() == 0);
      mismatch = (source_vals != target_vals) ? 1 : 0;
-     iallreduceRequest = iallreduceIntRaw (mismatch, reduced_mismatch,
-                                           Teuchos::REDUCE_MAX, * (getComm ()));
+     iallreduceRequest =
+       ::Tpetra::Details::iallreduce (mismatch, reduced_mismatch,
+                                      Teuchos::REDUCE_MAX, * (getComm ()));
    }
 
 #ifdef HAVE_TPETRA_MMM_TIMINGS

--- a/packages/tpetra/core/src/Tpetra_Details_iallreduce.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_iallreduce.cpp
@@ -343,6 +343,25 @@ iallreduceRawVoid (const void* sendbuf,
 #endif // HAVE_TPETRACORE_MPI
 
 } // namespace Impl
+
+std::shared_ptr<CommRequest>
+iallreduce (const int localValue,
+            int& globalValue,
+            const ::Teuchos::EReductionType op,
+            const ::Teuchos::Comm<int>& comm)
+{
+  using input_view_type =
+    Kokkos::View<const int*, Kokkos::HostSpace,
+      Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  using output_view_type =
+    Kokkos::View<int*, Kokkos::HostSpace,
+      Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+
+  input_view_type localView (&localValue, 1);
+  output_view_type globalView (&globalValue, 1);
+  return ::Tpetra::Details::iallreduce (localView, globalView, op, comm);
+}
+
 } // namespace Details
 } // namespace Tpetra
 

--- a/packages/tpetra/core/src/Tpetra_Details_iallreduce.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_iallreduce.hpp
@@ -847,6 +847,12 @@ iallreduce (const InputViewType& sendbuf,
   return impl_type::iallreduce (sendbuf, recvbuf, op, comm);
 }
 
+std::shared_ptr<CommRequest>
+iallreduce (const int localValue,
+            int& globalValue,
+            const ::Teuchos::EReductionType op,
+            const ::Teuchos::Comm<int>& comm);
+
 } // namespace Details
 } // namespace Tpetra
 

--- a/packages/tpetra/core/src/Tpetra_Details_makeValidVerboseStream.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_makeValidVerboseStream.cpp
@@ -1,0 +1,59 @@
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services Package
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+
+#include "Tpetra_Details_makeValidVerboseStream.hpp"
+#include <iostream>
+
+namespace Tpetra {
+namespace Details {
+
+Teuchos::RCP<Teuchos::FancyOStream>
+makeValidVerboseStream (const Teuchos::RCP<Teuchos::FancyOStream>& out)
+{
+  if (out.is_null ()) {
+    return Teuchos::getFancyOStream (Teuchos::rcpFromRef (std::cerr));
+  }
+  else {
+    return out;
+  }
+}
+
+} // namespace Details
+} // namespace Tpetra

--- a/packages/tpetra/core/src/Tpetra_Details_makeValidVerboseStream.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_makeValidVerboseStream.hpp
@@ -1,0 +1,57 @@
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services Package
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+
+#ifndef TPETRA_DETAILS_MAKEVALIDVERBOSESTREAM_HPP
+#define TPETRA_DETAILS_MAKEVALIDVERBOSESTREAM_HPP
+
+#include "TpetraCore_config.h"
+#include "Teuchos_FancyOStream.hpp"
+
+namespace Tpetra {
+namespace Details {
+
+Teuchos::RCP<Teuchos::FancyOStream>
+makeValidVerboseStream (const Teuchos::RCP<Teuchos::FancyOStream>& out =
+                        Teuchos::null);
+
+} // namespace Details
+} // namespace Tpetra
+
+#endif // TPETRA_DETAILS_MAKEVALIDVERBOSESTREAM_HPP

--- a/packages/tpetra/core/src/Tpetra_Distributor.cpp
+++ b/packages/tpetra/core/src/Tpetra_Distributor.cpp
@@ -40,26 +40,10 @@
 
 #include "Tpetra_Distributor.hpp"
 #include "Tpetra_Details_gathervPrint.hpp"
+#include "Tpetra_Details_makeValidVerboseStream.hpp"
 #include "Teuchos_StandardParameterEntryValidators.hpp"
 #include "Teuchos_VerboseObjectParameterListHelpers.hpp"
 #include <numeric>
-
-namespace { // (anonymous)
-
-  Teuchos::RCP<Teuchos::FancyOStream>
-  makeValidVerboseStream (const Teuchos::RCP<Teuchos::FancyOStream>& out =
-                          Teuchos::null)
-  {
-    if (out.is_null ()) {
-      return Teuchos::getFancyOStream (Teuchos::rcpFromRef (std::cerr));
-    }
-    else {
-      return out;
-    }
-  }
-
-} // namespace (anonymous)
-
 
 namespace Tpetra {
   namespace Details {
@@ -164,7 +148,7 @@ namespace Tpetra {
                const Teuchos::RCP<Teuchos::FancyOStream>& out,
                const Teuchos::RCP<Teuchos::ParameterList>& plist)
     : comm_ (comm)
-    , out_ (makeValidVerboseStream (out))
+    , out_ (::Tpetra::Details::makeValidVerboseStream (out))
     , howInitialized_ (Details::DISTRIBUTOR_NOT_INITIALIZED)
     , sendType_ (Details::DISTRIBUTOR_SEND)
     , barrierBetween_ (barrierBetween_default)

--- a/packages/tpetra/core/src/Tpetra_ImportExportData_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_ImportExportData_def.hpp
@@ -43,46 +43,9 @@
 #define TPETRA_IMPORTEXPORTDATA_DEF_HPP
 
 #include "Tpetra_Map.hpp"
+#include "Tpetra_Details_makeValidVerboseStream.hpp"
 #include "Teuchos_FancyOStream.hpp"
 #include "Teuchos_ParameterList.hpp"
-
-namespace { // (anonymous)
-
-  Teuchos::RCP<Teuchos::FancyOStream>
-  makeValidVerboseStream (const Teuchos::RCP<Teuchos::FancyOStream>& out =
-			  Teuchos::null)
-  {
-    if (out.is_null ()) {
-      try {
-	return Teuchos::getFancyOStream (Teuchos::rcpFromRef (std::cerr));
-      }
-      catch (std::exception& e) {
-	TEUCHOS_TEST_FOR_EXCEPTION
-	  (true, std::logic_error, "getFancyOStream threw: " << e.what ());
-      }
-      catch (...) {
-	TEUCHOS_TEST_FOR_EXCEPTION
-	  (true, std::logic_error, "getFancyOStream threw an exception "
-	   "not a subclass of std::exception.");
-      }
-    }
-    else {
-      try {
-	return out;
-      }
-      catch (std::exception& e) {
-	TEUCHOS_TEST_FOR_EXCEPTION
-	  (true, std::logic_error, "Returning 'out' threw: " << e.what ());
-      }
-      catch (...) {
-	TEUCHOS_TEST_FOR_EXCEPTION
-	  (true, std::logic_error, "Returning 'out' threw an exception "
-	   "not a subclass of std::exception.");
-      }
-    }
-  }
-
-} // namespace (anonymous)
 
 namespace Tpetra {
 
@@ -94,14 +57,14 @@ namespace Tpetra {
                     const Teuchos::RCP<Teuchos::ParameterList>& plist) :
     source_ (source), // NOT allowed to be null
     target_ (target), // allowed to be null
-    out_ (makeValidVerboseStream (out)),
+    out_ (::Tpetra::Details::makeValidVerboseStream (out)),
     numSameIDs_ (0), // Import/Export constructor may change this
     distributor_ (source->getComm (), out_, plist), // Im/Ex ctor will init
     isLocallyComplete_ (true) // Im/Ex ctor may change this
   {
     TEUCHOS_ASSERT( ! out_.is_null () );
   }
-  
+
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   ImportExportData<LocalOrdinal, GlobalOrdinal, Node>::
   ImportExportData (const Teuchos::RCP<const map_type>& source,
@@ -132,7 +95,7 @@ namespace Tpetra {
   {
     using Teuchos::ArrayView;
     using data_type = ImportExportData<LocalOrdinal, GlobalOrdinal, Node>;
-  
+
     auto tData = Teuchos::rcp (new data_type (target_, source_, out_));
 
     // Things that stay the same


### PR DESCRIPTION
@trilinos/tpetra

## Description

Fix spurious "unused function" build warnings in Tpetra.

## Motivation and Context

The build warnings block Sierra/Trilinos integration.

## Related Issues

* Closes #5038 