### PR TITLE
WIP: Improve 'mutrino' test run-times some (ATDV-131, TRIL-219)

### DIFF
--- a/cmake/ctest/drivers/atdm/mutrino/drivers/Trilinos-atdm-mutrino-intel-debug-openmp-HSW.sh.BACKUP.1159.sh
+++ b/cmake/ctest/drivers/atdm/mutrino/drivers/Trilinos-atdm-mutrino-intel-debug-openmp-HSW.sh.BACKUP.1159.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=ATDM
-fi
-export SALLOC_CTEST_TIME_LIMIT_MINUTES=300 # 5 hour time limit
-$WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/mutrino/local-driver.sh

--- a/cmake/ctest/drivers/atdm/mutrino/drivers/Trilinos-atdm-mutrino-intel-debug-openmp-HSW.sh.BACKUP.1253.sh
+++ b/cmake/ctest/drivers/atdm/mutrino/drivers/Trilinos-atdm-mutrino-intel-debug-openmp-HSW.sh.BACKUP.1253.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=ATDM
-fi
-export SALLOC_CTEST_TIME_LIMIT_MINUTES=300 # 5 hour time limit
-$WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/mutrino/local-driver.sh

--- a/cmake/ctest/drivers/atdm/mutrino/drivers/Trilinos-atdm-mutrino-intel-debug-openmp-HSW.sh.REMOTE.1159.sh
+++ b/cmake/ctest/drivers/atdm/mutrino/drivers/Trilinos-atdm-mutrino-intel-debug-openmp-HSW.sh.REMOTE.1159.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=ATDM
-fi
-export SALLOC_CTEST_TIME_LIMIT_MINUTES=300 # 5 hour time limit
-$WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/mutrino/local-driver.sh

--- a/cmake/ctest/drivers/atdm/mutrino/drivers/Trilinos-atdm-mutrino-intel-debug-openmp-HSW.sh.REMOTE.1253.sh
+++ b/cmake/ctest/drivers/atdm/mutrino/drivers/Trilinos-atdm-mutrino-intel-debug-openmp-HSW.sh.REMOTE.1253.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=ATDM
-fi
-export SALLOC_CTEST_TIME_LIMIT_MINUTES=300 # 5 hour time limit
-$WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/mutrino/local-driver.sh

--- a/cmake/std/atdm/mutrino/environment.sh
+++ b/cmake/std/atdm/mutrino/environment.sh
@@ -44,7 +44,7 @@ if [ "$ATDM_CONFIG_COMPILER" == "INTEL" ] && [ "$ATDM_CONFIG_KOKKOS_ARCH" == "HS
     export OMP_NUM_THREADS=2
     export OMP_PROC_BIND=false
     unset OMP_PLACES
-    export ATDM_CONFIG_MPI_POST_FLAGS="--hint=nomultithread;--cpus-per-task=$OMP_NUM_THREADS"
+    export ATDM_CONFIG_MPI_POST_FLAGS="--cpus-per-task=$OMP_NUM_THREADS"
     export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=4
     # HSW nodes have 32 cores but currently running with just `ctest -j4`
     # seems to give the fastest wall-clock time, at least for the Panzer test
@@ -55,7 +55,7 @@ elif [ "$ATDM_CONFIG_COMPILER" == "INTEL" ] && [ "$ATDM_CONFIG_KOKKOS_ARCH" == "
     export OMP_NUM_THREADS=2
     export OMP_PROC_BIND=false
     unset OMP_PLACES
-    export ATDM_CONFIG_MPI_POST_FLAGS="--hint=nomultithread;--cpus-per-task=$OMP_NUM_THREADS"
+    export ATDM_CONFIG_MPI_POST_FLAGS="--cpus-per-task=$OMP_NUM_THREADS"
     export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=4
     # HSW nodes have 64 cores but currently running with just `ctest -j4`
     # seems to give the fastest wall-clock time, at least for the Panzer test
@@ -165,7 +165,7 @@ function atdm_run_script_on_compute_node {
   touch $output_file
 
   if [ "$ATDM_CONFIG_KOKKOS_ARCH" == "KNL" ] ; then
-    ATDM_CONFIG_SBATCH_EXTRA_ARGS="-p knl -C cache --hint=multithread"
+    ATDM_CONFIG_SBATCH_EXTRA_ARGS="-p knl -C cache"
   elif [ "$ATDM_CONFIG_KOKKOS_ARCH" == "HSW" ] ; then
     ATDM_CONFIG_SBATCH_EXTRA_ARGS=
   else

--- a/cmake/std/atdm/mutrino/environment.sh
+++ b/cmake/std/atdm/mutrino/environment.sh
@@ -39,15 +39,15 @@ export ATDM_CONFIG_MPI_EXEC="/opt/slurm/bin/srun"
 export ATDM_CONFIG_MPI_EXEC_NUMPROCS_FLAG="--ntasks"
 export ATDM_CONFIG_MPI_PRE_FLAGS="--mpi=pmi2;--gres=none"
 
-export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=8
-# NOTE: Using -j8 instead of -j16 for ctest is to try to avoid 'srun' "Job
-# <jobid> step creation temporarily disabled" failures on 'mutrino' (see
-# TRIL-214).
-
 if [ "$ATDM_CONFIG_COMPILER" == "INTEL" ] && [ "$ATDM_CONFIG_KOKKOS_ARCH" == "HSW"  ]; then
     module use /projects/EMPIRE/mutrino/tpls/hsw/modulefiles
     export OMP_NUM_THREADS=2
-    export ATDM_CONFIG_MPI_POST_FLAGS="-c 4"
+    export OMP_PROC_BIND=false
+    unset OMP_PLACES
+    export ATDM_CONFIG_MPI_POST_FLAGS="--hint=nomultithread;--cpus-per-task=$OMP_NUM_THREADS"
+    export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=12
+    # HSW nodes only have 32 cores so let's be a little conservative and not
+    # use all 32/2 = 16 cores.
 elif [ "$ATDM_CONFIG_COMPILER" == "INTEL" ] && [ "$ATDM_CONFIG_KOKKOS_ARCH" == "KNL"  ]; then
     module use /projects/EMPIRE/mutrino/tpls/knl/modulefiles
     export SLURM_TASKS_PER_NODE=16
@@ -55,6 +55,9 @@ elif [ "$ATDM_CONFIG_COMPILER" == "INTEL" ] && [ "$ATDM_CONFIG_KOKKOS_ARCH" == "
     export OMP_PROC_BIND=false
     unset OMP_PLACES
     export ATDM_CONFIG_MPI_POST_FLAGS="--hint=nomultithread;--cpus-per-task=$OMP_NUM_THREADS"
+    export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=24
+    # KNL nodes have 64 codes but let's be a little conservative and not us
+    # all of the 64/2 = 32 cores.
 else
     echo
     echo "***"

--- a/cmake/std/atdm/mutrino/environment.sh
+++ b/cmake/std/atdm/mutrino/environment.sh
@@ -45,10 +45,10 @@ if [ "$ATDM_CONFIG_COMPILER" == "INTEL" ] && [ "$ATDM_CONFIG_KOKKOS_ARCH" == "HS
     export OMP_PROC_BIND=false
     unset OMP_PLACES
     export ATDM_CONFIG_MPI_POST_FLAGS="--cpus-per-task=$OMP_NUM_THREADS"
-    export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=4
-    # HSW nodes have 32 cores but currently running with just `ctest -j4`
-    # seems to give the fastest wall-clock time, at least for the Panzer test
-    # suite (see ATDV-131).
+    export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=14
+    # HSW nodes have 32 cores and with OMP_NUM_THREDS=2, we could use -j16
+    # with ctest but are being a little conservative with 14 (or 28 total
+    # cores used out of 32).
 elif [ "$ATDM_CONFIG_COMPILER" == "INTEL" ] && [ "$ATDM_CONFIG_KOKKOS_ARCH" == "KNL"  ]; then
     module use /projects/EMPIRE/mutrino/tpls/knl/modulefiles
     export SLURM_TASKS_PER_NODE=16
@@ -56,10 +56,10 @@ elif [ "$ATDM_CONFIG_COMPILER" == "INTEL" ] && [ "$ATDM_CONFIG_KOKKOS_ARCH" == "
     export OMP_PROC_BIND=false
     unset OMP_PLACES
     export ATDM_CONFIG_MPI_POST_FLAGS="--cpus-per-task=$OMP_NUM_THREADS"
-    export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=4
-    # HSW nodes have 64 cores but currently running with just `ctest -j4`
-    # seems to give the fastest wall-clock time, at least for the Panzer test
-    # suite (see ATDV-131).
+    export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=24
+    # HSW nodes have 64 cores and with OMP_NUM_THREDS=2, we could use -j32
+    # with ctest but are being a little conservative with 24 (or 48 total
+    # cores used out of 64).
 else
     echo
     echo "***"

--- a/cmake/std/atdm/mutrino/environment.sh
+++ b/cmake/std/atdm/mutrino/environment.sh
@@ -45,9 +45,10 @@ if [ "$ATDM_CONFIG_COMPILER" == "INTEL" ] && [ "$ATDM_CONFIG_KOKKOS_ARCH" == "HS
     export OMP_PROC_BIND=false
     unset OMP_PLACES
     export ATDM_CONFIG_MPI_POST_FLAGS="--hint=nomultithread;--cpus-per-task=$OMP_NUM_THREADS"
-    export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=12
-    # HSW nodes only have 32 cores so let's be a little conservative and not
-    # use all 32/2 = 16 cores.
+    export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=4
+    # HSW nodes have 32 cores but currently running with just `ctest -j4`
+    # seems to give the fastest wall-clock time, at least for the Panzer test
+    # suite (see ATDV-131).
 elif [ "$ATDM_CONFIG_COMPILER" == "INTEL" ] && [ "$ATDM_CONFIG_KOKKOS_ARCH" == "KNL"  ]; then
     module use /projects/EMPIRE/mutrino/tpls/knl/modulefiles
     export SLURM_TASKS_PER_NODE=16
@@ -55,9 +56,10 @@ elif [ "$ATDM_CONFIG_COMPILER" == "INTEL" ] && [ "$ATDM_CONFIG_KOKKOS_ARCH" == "
     export OMP_PROC_BIND=false
     unset OMP_PLACES
     export ATDM_CONFIG_MPI_POST_FLAGS="--hint=nomultithread;--cpus-per-task=$OMP_NUM_THREADS"
-    export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=24
-    # KNL nodes have 64 codes but let's be a little conservative and not us
-    # all of the 64/2 = 32 cores.
+    export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=4
+    # HSW nodes have 64 cores but currently running with just `ctest -j4`
+    # seems to give the fastest wall-clock time, at least for the Panzer test
+    # suite (see ATDV-131).
 else
     echo
     echo "***"

--- a/cmake/std/atdm/mutrino/environment.sh
+++ b/cmake/std/atdm/mutrino/environment.sh
@@ -37,7 +37,7 @@ export ATDM_CONFIG_MPI_EXEC="/opt/slurm/bin/srun"
 
 # srun does not accept "-np" for # of processors
 export ATDM_CONFIG_MPI_EXEC_NUMPROCS_FLAG="--ntasks"
-export ATDM_CONFIG_MPI_PRE_FLAGS="--mpi=pmi2;--ntasks-per-node;36"
+export ATDM_CONFIG_MPI_PRE_FLAGS="--mpi=pmi2;--gres=none"
 
 export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=8
 # NOTE: Using -j8 instead of -j16 for ctest is to try to avoid 'srun' "Job
@@ -52,10 +52,9 @@ elif [ "$ATDM_CONFIG_COMPILER" == "INTEL" ] && [ "$ATDM_CONFIG_KOKKOS_ARCH" == "
     module use /projects/EMPIRE/mutrino/tpls/knl/modulefiles
     export SLURM_TASKS_PER_NODE=16
     export OMP_NUM_THREADS=2
-    export OMP_PLACES=threads
-    export OMP_PROC_BIND=spread
-    export ATDM_CONFIG_MPI_POST_FLAGS="--hint=nomultithread;-c 4"
-    export ATDM_CONFIG_SBATCH_OPTIONS="-p knl -C cache --hint=multithread"
+    export OMP_PROC_BIND=false
+    unset OMP_PLACES
+    export ATDM_CONFIG_MPI_POST_FLAGS="--hint=nomultithread;--cpus-per-task=$OMP_NUM_THREADS"
 else
     echo
     echo "***"

--- a/cmake/std/atdm/mutrino/environment.sh
+++ b/cmake/std/atdm/mutrino/environment.sh
@@ -104,7 +104,7 @@ export ATDM_CONFIG_COMPLETED_ENV_SETUP=TRUE
 #
 # Usage:
 #
-#   atdm_run_script_on_comput_node <script_to_run> <output_file> \
+#   atdm_run_script_on_compute_node <script_to_run> <output_file> \
 #     [<timeout>] [<account>]
 #
 # If <timeout> and/or <account> are not given, then defaults are provided that
@@ -112,8 +112,8 @@ export ATDM_CONFIG_COMPLETED_ENV_SETUP=TRUE
 #
 # In this case, sbatch is used to run the script but it also sends ouptut to
 # STDOUT in real-time while it is running in addition to writing to the
-# <outout_file>.  The job name for the sbatch script is taken from the env var
-# 'ATDM_CONFIG_BUILD_NAME'.  This works for local builds since ATDM_CONFIG_BUILD_NAME.
+# <oupout_file>.  The job name for the sbatch job is taken from the env var
+# 'ATDM_CONFIG_BUILD_NAME'.  This even works for local builds.
 #
 # Note that you can pass in the script to run with arguments such as with
 # "<some-script> <arg1> <arg2>" and it will work.  But note that this has to


### PR DESCRIPTION
CC: @fryeguy52 

These improvements are based on the work by Brad King at Kitware in:

* https://gitlab.kitware.com/snl/project-1/issues/91

Also see [ATDV-131](https://sems-atlassian-srn.sandia.gov/browse/ATDV-131)

## How was this tested?

I ran this  on 'mutrino' in some extensive testing in summarized in [ATDV-131](https://sems-atlassian-srn.sandia.gov/browse/ATDV-131?focusedCommentId=34363&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-34363).  The final commit to use `ctest -j4` for both the builds was verified on 'mutrino' with:

```
$  env \
      Trilinos_PACKAGES=Panzer \
      CTEST_START_WITH_EMPTY_BINARY_DIRECTORY=FALSE \
      CTEST_DO_CONFIGURE=OFF \
      CTEST_DO_BUILD=FALSE \
    ./ctest-s-local-test-driver.sh intel-opt-openmp-HSW intel-opt-openmp-KNL
***
*** ./ctest-s-local-test-driver.sh  intel-opt-openmp-HSW intel-opt-openmp-KNL
***

ATDM_TRILINOS_DIR = '/home/rabartl/Trilinos.base/Trilinos'

Load some env to get python, cmake, etc ...

Hostname 'mutrino' matches known ATDM host 'mutrino' and system 'mutrino'
Setting compiler and build options for buld name 'default'
Using mutrino compiler stack INTEL to build DEBUG code with Kokkos node type SERIAL and KOKKOS_ARCH=HSW

Running builds:
    intel-opt-openmp-HSW
    intel-opt-openmp-KNL


Running Jenkins driver Trilinos-atdm-mutrino-intel-opt-openmp-HSW.sh ...


real    6m15.261s
user    0m2.926s
sys     0m0.814s

Running Jenkins driver Trilinos-atdm-mutrino-intel-opt-openmp-KNL.sh ...


real    14m15.213s
user    0m2.558s
sys     0m0.617s
```

which posted to CDash builds:

* HSW: https://testing.sandia.gov/cdash/index.php?project=Trilinos&parentid=4976653
* KNL:  https://testing.sandia.gov/cdash/index.php?project=Trilinos&parentid=4976655
