### PR TITLE
Panzer:  Create ZeroContributedField Evaluator

### DIFF
--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ZeroContributedField.cpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ZeroContributedField.cpp
@@ -1,0 +1,60 @@
+// @HEADER
+// ***********************************************************************
+//
+//           Panzer: A partial differential equation assembly
+//       engine for strongly coupled complex multiphysics systems
+//                 Copyright (2011) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Roger P. Pawlowski (rppawlo@sandia.gov) and
+// Eric C. Cyr (eccyr@sandia.gov)
+// ***********************************************************************
+// @HEADER
+
+///////////////////////////////////////////////////////////////////////////////
+//
+//  Include Files
+//
+///////////////////////////////////////////////////////////////////////////////
+
+// Panzer
+#include "PanzerDiscFE_config.hpp"
+#include "Panzer_ExplicitTemplateInstantiation.hpp"
+#include "Panzer_ZeroContributedField.hpp"
+#include "Panzer_ZeroContributedField_impl.hpp"
+
+///////////////////////////////////////////////////////////////////////////////
+//
+//  Instantiate the class.
+//
+///////////////////////////////////////////////////////////////////////////////
+PANZER_INSTANTIATE_TEMPLATE_CLASS_TWO_T(panzer::ZeroContributedField)

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ZeroContributedField.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ZeroContributedField.hpp
@@ -1,0 +1,113 @@
+// @HEADER
+// ***********************************************************************
+//
+//           Panzer: A partial differential equation assembly
+//       engine for strongly coupled complex multiphysics systems
+//                 Copyright (2011) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Roger P. Pawlowski (rppawlo@sandia.gov) and
+// Eric C. Cyr (eccyr@sandia.gov)
+// ***********************************************************************
+// @HEADER
+
+#ifndef   PANZER_ZEROCONTRIBUTEDFIELD_HPP
+#define   PANZER_ZEROCONTRIBUTEDFIELD_HPP
+
+///////////////////////////////////////////////////////////////////////////////
+//
+//  Include Files
+//
+///////////////////////////////////////////////////////////////////////////////
+
+// Panzer
+#include "Panzer_Evaluator_WithBaseImpl.hpp"
+
+// Phalanx
+#include "Phalanx_Evaluator_Derived.hpp"
+#include "Phalanx_MDField.hpp"
+
+namespace panzer
+{
+  /**
+   *  \brief Build a field using a specified data layout, and set it to zero.
+   *
+   *  Used to initialize a field to zero before other `Evaluator`s contribute
+   *  to it.
+   */
+  template<typename EvalT, typename Traits>
+  class ZeroContributedField
+    :
+    public panzer::EvaluatorWithBaseImpl<Traits>,
+    public PHX::EvaluatorDerived<EvalT, Traits>
+  {
+    public:
+
+      /**
+       *  \brief Constructor.
+       *
+       *  Given the field name and layout, create the field to be initialized
+       *  to zero.
+       *
+       *  \param[in] fieldName The name of the field to be initialized to zero.
+       *  \param[in] layout    The data layout to use when creating the field.
+       */
+      ZeroContributedField(
+        const std::string& fieldName,
+        PHX::DataLayout&   layout);
+
+      /**
+       *  \brief Evaluate the field.
+       *
+       *  Set the field to zero.
+       */
+      void
+      evaluateFields(
+        typename Traits::EvalData d) override;
+
+    private:
+
+      /**
+       *  \brief The scalar data type.
+       */
+      using ScalarT = typename EvalT::ScalarT;
+
+      /**
+       *  \brief The field being initialized to zero.
+       */
+      PHX::MDField<ScalarT> field_;
+
+  }; // end of class ZeroContributedField
+
+} // end of namespace panzer
+
+#endif // PANZER_ZEROCONTRIBUTEDFIELD_HPP

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ZeroContributedField_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ZeroContributedField_impl.hpp
@@ -1,0 +1,82 @@
+// @HEADER
+// ***********************************************************************
+//
+//           Panzer: A partial differential equation assembly
+//       engine for strongly coupled complex multiphysics systems
+//                 Copyright (2011) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Roger P. Pawlowski (rppawlo@sandia.gov) and
+// Eric C. Cyr (eccyr@sandia.gov)
+// ***********************************************************************
+// @HEADER
+
+#ifndef   PANZER_ZEROCONTRIBUTEDFIELD_IMPL_HPP
+#define   PANZER_ZEROCONTRIBUTEDFIELD_IMPL_HPP
+
+namespace panzer
+{
+  /////////////////////////////////////////////////////////////////////////////
+  //
+  //  Constructor
+  //
+  /////////////////////////////////////////////////////////////////////////////
+  template<typename EvalT, typename Traits>
+  ZeroContributedField<EvalT, Traits>::
+  ZeroContributedField(
+    const std::string& fieldName,
+    PHX::DataLayout&   layout)
+  {
+    using PHX::MDField;
+    using Teuchos::rcpFromRef;
+    field_ = MDField<ScalarT>(fieldName, rcpFromRef(layout));
+    this->addEvaluatedField(field_);
+    this->setName("ZeroContributedField:  " + field_.fieldTag().identifier());
+  } // end of Constructor
+
+  /////////////////////////////////////////////////////////////////////////////
+  //
+  //  evaluateFields()
+  //
+  /////////////////////////////////////////////////////////////////////////////
+  template<typename EvalT, typename Traits>
+  void
+  ZeroContributedField<EvalT, Traits>::
+  evaluateFields(
+    typename Traits::EvalData /* d */)
+  {
+    field_.deep_copy(ScalarT(0.0));
+  } // end of evaluateFields()
+
+} // end of namespace panzer
+
+#endif // PANZER_ZEROCONTRIBUTEDFIELD_IMPL_HPP


### PR DESCRIPTION
@trilinos/panzer 

## Description
Create an `Evaluator` for the sake of initializing a contributed field to zero.

## Motivation and Context
This will make it such that we can switch more `Evaluator`s over to `CONTRIBUTES`-style evaluation.  This is currently needed by work underway in Drekar, but it will also benefit Charon and perhaps others.