### PR TITLE
Teuchos:   added deprecation warnings that were missing in #ifdef'ed deprecated code

### DIFF
--- a/packages/teuchos/numerics/src/Teuchos_SerialBandDenseMatrix.hpp
+++ b/packages/teuchos/numerics/src/Teuchos_SerialBandDenseMatrix.hpp
@@ -1073,6 +1073,7 @@ void SerialBandDenseMatrix<OrdinalType, ScalarType>::copyMat(
 #ifndef TEUCHOS_HIDE_DEPRECATED_CODE
 /// \brief Print the given SerialBandDenseMatrix to the given output stream.
 template<typename OrdinalType, typename ScalarType>
+TEUCHOS_DEPRECATED
 std::ostream& operator<< (std::ostream& os, const Teuchos::SerialBandDenseMatrix<OrdinalType, ScalarType>& obj)
 {
   obj.print (os);

--- a/packages/teuchos/numerics/src/Teuchos_SerialDenseMatrix.hpp
+++ b/packages/teuchos/numerics/src/Teuchos_SerialDenseMatrix.hpp
@@ -1078,6 +1078,7 @@ void SerialDenseMatrix<OrdinalType, ScalarType>::copyMat(
 #ifndef TEUCHOS_HIDE_DEPRECATED_CODE
 /// \brief Print the given SerialDenseMatrix to the given output stream.
 template<typename OrdinalType, typename ScalarType>
+TEUCHOS_DEPRECATED
 std::ostream& operator<< (std::ostream& os, const Teuchos::SerialDenseMatrix<OrdinalType, ScalarType>& obj)
 {
   obj.print (os);

--- a/packages/teuchos/numerics/src/Teuchos_SerialSymDenseMatrix.hpp
+++ b/packages/teuchos/numerics/src/Teuchos_SerialSymDenseMatrix.hpp
@@ -1178,6 +1178,7 @@ void SerialSymDenseMatrix<OrdinalType, ScalarType>::copyUPLOMat(
 #ifndef TEUCHOS_HIDE_DEPRECATED_CODE
 /// \brief Print the given SerialSymDenseMatrix to the given output stream.
 template<typename OrdinalType, typename ScalarType>
+TEUCHOS_DEPRECATED
 std::ostream& operator<< (std::ostream& os, const Teuchos::SerialSymDenseMatrix<OrdinalType, ScalarType>& obj)
 {
   obj.print (os);


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/teuchos 

## Description
Methods in Teuchos were #ifdef'ed as deprecated, but did not include TEUCHOS_DEPRECATED warnings.  Now they do.

This PR will need to be cherry-picked to the 12.6 release branch.

## Related Issues
#4430 #4330 #4258 

## How Has This Been Tested?
Compilation on mac clang.
Warnings appear as expected; no other behavior changes from this PR.