### PR TITLE
MueLu: fix bug in unit-test CreatePreconditioner for #5074

### DIFF
--- a/packages/muelu/test/unit_tests/Adapters/CreatePreconditioner.cpp
+++ b/packages/muelu/test/unit_tests/Adapters/CreatePreconditioner.cpp
@@ -44,6 +44,7 @@
 //
 // @HEADER
 #include <Teuchos_UnitTestHarness.hpp>
+#include <Teuchos_XMLParameterListHelpers.hpp>
 
 #include "MueLu_TestHelpers.hpp"
 #include "MueLu_Version.hpp"


### PR DESCRIPTION
@trilinos/muelu 

## Description
Adding the header: `<Teuchos_XMLParameterListHelpers.hpp>` in the unit-test `CreatePreconditioner.cpp`.

## Motivation and Context
This will allow proper compilation of the unit-test when Tpetra is disabled.

## Related Issues

* Closes #5074 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 

## How Has This Been Tested?
I tested the fix on the machine that performs this nightly test. The change results in a passing build and test.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.
