### PR TITLE
Install MiniEM

### DIFF
--- a/packages/panzer/mini-em/example/BlockPrec/CMakeLists.txt
+++ b/packages/panzer/mini-em/example/BlockPrec/CMakeLists.txt
@@ -23,6 +23,25 @@ TRIBITS_COPY_FILES_TO_BINARY_DIR(CopyBlockPrecFiles
   DEST_DIR ${CMAKE_CURRENT_BINARY_DIR}
   )
 
+# rather than list all files like above, I glob all xmls
+FILE(GLOB ${PACKAGE_NAME}_InputFiles *.xml)
+
+# allow the user to override the install location and
+# provide a simple defintion for the default
+# EXAMPLE_INSTALL_DIR/Panzer/
+IF (NOT DEFINED ${PACKAGE_NAME}_INSTALL_PREFIX)
+  SET(${PACKAGE_NAME}_INSTALL_PREFIX "${${PROJECT_NAME}_INSTALL_EXAMPLE_DIR}/${PACKAGE_NAME}/")
+ELSE()
+  # inform the user where it will go, since they overrode the default
+  PRINT_VAR(${PACKAGE_NAME}_INSTALL_PREFIX)
+ENDIF()
+
+INSTALL(FILES ${${PACKAGE_NAME}_InputFiles}
+        DESTINATION ${${PACKAGE_NAME}_INSTALL_PREFIX}
+       )
+INSTALL(TARGETS "${PACKAGE_NAME}_BlockPrec"
+        COMPONENT ${PACKAGE_NAME} RUNTIME DESTINATION ${${PACKAGE_NAME}_INSTALL_PREFIX})
+
 #################################################
 # Augmentation solver
 


### PR DESCRIPTION
This adds a target to install MiniEM as well as the needed input files

Closes: #5083



@trilinos/panzer @egphill @cgcgcg @bartlettroscoe 

## Motivation and Context
Make performance tracking easier since most teams install Trilinos and need the apps to be usable from the install directory

## Related Issues
Closes: #5083

## How Has This Been Tested?
Tested on White

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.


 @bartlettroscoe I could not find a way to get Tribits to install arbitrary files. In this case, we need to install the `xml` input files. They really don't make sense inside `lib/` or `include/`

If there is a better way to do this, please let me know. The motivation is to allow easier performance tracking, since the build tree is usually blown away.