### PR TITLE
MueLu: linear region mg capability

### DIFF
--- a/packages/muelu/research/regionMG/examples/structured/CMakeLists.txt
+++ b/packages/muelu/research/regionMG/examples/structured/CMakeLists.txt
@@ -12,7 +12,7 @@ IF (${PACKAGE_NAME}_ENABLE_Tpetra AND ${PACKAGE_NAME}_ENABLE_Amesos2)
     )
 
   TRIBITS_COPY_FILES_TO_BINARY_DIR(StructuredRegion_cp
-    SOURCE_FILES structured_1dof.xml
+    SOURCE_FILES structured_1dof.xml structured_linear_1dof.xml
     )
 
   TRIBITS_ADD_TEST(
@@ -27,6 +27,22 @@ IF (${PACKAGE_NAME}_ENABLE_Tpetra AND ${PACKAGE_NAME}_ENABLE_Amesos2)
     StructuredRegionDriver
     NAME "Structured_Region_Star2D_Tpetra"
     ARGS "--linAlgebra=Tpetra --xml=structured_1dof.xml --matrixType=Star2D --nx=10 --ny=10"
+    COMM serial mpi
+    NUM_MPI_PROCS 4
+    )
+
+  TRIBITS_ADD_TEST(
+    StructuredRegionDriver
+    NAME "Structured_Region_Linear_Star2D_Tpetra"
+    ARGS "--linAlgebra=Tpetra --xml=structured_linear_1dof.xml --matrixType=Star2D --nx=10 --ny=10"
+    COMM serial mpi
+    NUM_MPI_PROCS 1
+    )
+
+  TRIBITS_ADD_TEST(
+    StructuredRegionDriver
+    NAME "Structured_Region_Linear_Star2D_Tpetra"
+    ARGS "--linAlgebra=Tpetra --xml=structured_linear_1dof.xml --matrixType=Star2D --nx=10 --ny=10"
     COMM serial mpi
     NUM_MPI_PROCS 4
     )

--- a/packages/muelu/research/regionMG/examples/structured/structured_linear_1dof.xml
+++ b/packages/muelu/research/regionMG/examples/structured/structured_linear_1dof.xml
@@ -18,7 +18,7 @@
       <Parameter name="factory"                                   type="string" value="StructuredAggregationFactory"/>
       <Parameter name="aggregation: coupling"                     type="string" value="uncoupled"/>
       <Parameter name="aggregation: output type"                  type="string" value="CrsGraph"/>
-      <Parameter name="aggregation: coarsening order"             type="int"    value="0"/>
+      <Parameter name="aggregation: coarsening order"             type="int"    value="1"/>
       <Parameter name="aggregation: coarsening rate"              type="string" value="{2}"/>
       <Parameter name="Graph"                                     type="string" value="myCoalesceDropFact"/>
     </ParameterList>
@@ -32,7 +32,7 @@
     <ParameterList name="myProlongatorFact">
       <Parameter name="factory"                             type="string" value="GeometricInterpolationPFactory"/>
       <Parameter name="interp: build coarse coordinates"    type="bool"   value="true"/>
-      <Parameter name="interp: interpolation order"         type="int"    value="0"/>
+      <Parameter name="interp: interpolation order"         type="int"    value="1"/>
       <Parameter name="prolongatorGraph"                    type="string" value="myAggregationFact"/>
       <Parameter name="coarseCoordinatesFineMap"            type="string" value="myAggregationFact"/>
       <Parameter name="coarseCoordinatesMap"                type="string" value="myAggregationFact"/>


### PR DESCRIPTION
The idea is to only look at what happens to point injected from the fine level to the coarse level as these are equivalent to root points. These nodes are easily detected as their corresponding rows in the prolongator contain only one entry.
Also adding a couple of command line options to drive the solver more finely and using command line argument in linear convergence criteria.

@trilinos/muelu 

## Description
I am adding some logic in the function that creates coarse composite maps so that it can handle the case of piece-wise linear prolongator. This adds a good new capability to the code and might also allow to obtain faster convergence at large scale.
I am also hooking the MG parameters and the command line arguments more logically together which will allow us to drive the simulation more easily.

## Motivation and Context
This provides a logical extension of the current work on region MG and rationalizes the command line input parameters.

## Related Issues

* Closes #5069 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## How Has This Been Tested?
Local tests have been performed and manual inspection of output data has been done for the new algorithm

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.