### PR TITLE
Xpetra: Fix xpetra tpetravector eti

### DIFF
--- a/packages/xpetra/src/Vector/Xpetra_TpetraVector_def.hpp
+++ b/packages/xpetra/src/Vector/Xpetra_TpetraVector_def.hpp
@@ -174,7 +174,10 @@ template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
     typedef EpetraNode Node;
 
 #undef XPETRA_TPETRAMULTIVECTOR_SHORT
+#undef XPETRA_TPETRAVECTOR_SHORT
 #include "Xpetra_UseShortNames.hpp"
+#define XPETRA_TPETRAMULTIVECTOR_SHORT
+#define XPETRA_TPETRAVECTOR_SHORT
 
   public:
 
@@ -332,7 +335,10 @@ template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
     typedef EpetraNode Node;
 
 #undef XPETRA_TPETRAMULTIVECTOR_SHORT
+#undef XPETRA_TPETRAVECTOR_SHORT
 #include "Xpetra_UseShortNames.hpp"
+#define XPETRA_TPETRAMULTIVECTOR_SHORT
+#define XPETRA_TPETRAVECTOR_SHORT
 
   public:
 


### PR DESCRIPTION
@trilinos/muelu @trilinos/xpetra @csiefer2 

## Description
Misplaced typedef created by the ShortName header...


## Motivation and Context
Broke things: see #5061

Fixes: #5061

## Testing
Using @kddevin cmake + sems clang atdm modules
```
source ..//cmake/std/atdm/load-env.sh Trilinos-atdm-clang-release-debug

 cmake  -GNinja  -DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/atdm/ATDMDevEnv.cmake  -DTrilinos_ENABLE_TESTS=ON -D Trilinos_ENABLE_MueLu=ON -D Trilinos_ENABLE_EXPLICIT_INSTANTIATION:BOOL=ON -D Tpetra_INST_INT_INT:BOOL=ON -D Tpetra_INST_INT_LONG_LONG:BOOL=OFF -D CMAKE_BUILD_TYPE:STRING="DEBUG" -D TPL_ENABLE_MPI:BOOL=ON -D TPL_ENABLE_BinUtils:BOOL=OFF -D TPL_ENABLE_Pthread:BOOL=OFF -D CMAKE_C_FLAGS:STRING="-Wall  -pedantic -Wno-unknown-pragmas -Wno-narrowing -Wno-inline -Wshadow -Wdeprecated-declarations -Wempty-body  -Wignored-qualifiers -Wmissing-field-initializers  -Wsign-compare  -Wtype-limits   -Wuninitialized -Winit-self -fstrict-aliasing -Wno-long-long" -D CMAKE_CXX_FLAGS:STRING="-Wall -pedantic -Wno-unknown-pragmas -Wno-narrowing -Wno-delete-non-virtual-dtor -Wno-inline -Wshadow -Wdeprecated-declarations -Wempty-body  -Wignored-qualifiers -Wmissing-field-initializers  -Wsign-compare  -Wtype-limits   -Wuninitialized -Winit-self -fstrict-aliasing" -D Trilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=ON -D Trilinos_ENABLE_TESTS:BOOL=ON -D Trilinos_ENABLE_EXAMPLES:BOOL=ON -D Trilinos_ENABLE_SHADOW_WARNINGS:BOOL=ON -D Trilinos_VERBOSE_CONFIGURE:BOOL=OFF -D Trilinos_ENABLE_Fortran:BOOL=OFF -D Trilinos_ENABLE_Stokhos:BOOL=ON -D Trilinos_ENABLE_Nox:BOOL=ON -D Trilinos_ENABLE_ROL:BOOL=ON -D ROL_ENABLE_EXAMPLES:BOOL=OFF -D Trilinos_ENABLE_MiniTensor:BOOL=OFF -D ROL_ENABLE_MiniTensor:BOOL=OFF -D Trilinos_ENABLE_Panzer:BOOL=ON -D Trilinos_ENABLE_Tempus:BOOL=ON -D Trilinos_ENABLE_PanzerAdaptersSTK:BOOL=OFF -D Trilinos_ENABLE_PanzerAdaptersIOSS:BOOL=OFF -D Trilinos_ENABLE_Thyra:BOOL=ON -D Trilinos_ENABLE_MueLu:BOOL=ON -D Trilinos_ENABLE_Anasazi:BOOL=ON -D Trilinos_ENABLE_Belos:BOOL=ON -D Trilinos_ENABLE_TrilinosCouplings:BOOL=ON -D Trilinos_ENABLE_STKIO:BOOL=OFF -D Trilinos_ENABLE_STKUtil:BOOL=OFF -D Teuchos_ENABLE_STACKTRACE:BOOL=OFF ..
```

Built/Linked the MueLu driver which requires the Xpetra TpetraVector source file.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

