### PR TITLE
Move the gcc 4.8.4 build to use static libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,6 @@ rsync.*
 # Eclipse IDE
 .project
 .settings/
+
+# pycharm ide
+.idea

--- a/cmake/std/PullRequestLinuxGCC4.8.4TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxGCC4.8.4TestingSettings.cmake
@@ -27,5 +27,8 @@ set (ShyLU_DDFROSch_test_frosch_laplacian_epetra_2d_gdsw_MPI_4_DISABLE ON CACHE 
 set (ShyLU_DDFROSch_test_frosch_laplacian_epetra_2d_rgdsw_MPI_4_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
 set (ShyLU_DDFROSch_test_frosch_interfacesets_2D_MPI_4_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
 
+# this build is different from the others in using static libraries
+set (BUILD_SHARED_LIBS OFF CACHE BOOL "Off by default for PR testing in GCC 4.8.4")
+
 include("${CMAKE_CURRENT_LIST_DIR}/PullRequestLinuxCommonTestingSettings.cmake")
 

--- a/cmake/std/sems/PullRequestGCC4.8.4TestingEnv.sh
+++ b/cmake/std/sems/PullRequestGCC4.8.4TestingEnv.sh
@@ -27,16 +27,7 @@ module load sems-superlu/4.3/base
 #   so this will pull in the SEMS cmake 3.10.3 version
 #   for Trilinos compatibility.
 module load sems-cmake/3.10.3
-
-# Using CMake and Ninja modules from the ATDM project space.
-# SEMS does not yet supply a recent enough version of CMake
-# for the single configure/build/test capability. We are also
-# using a custom version of Ninja (with Fortran support not
-# available in main-line Ninja) to significantly speed up
-# compile and link times.
-module load atdm-env
-module load atdm-cmake/3.11.1
-module load atdm-ninja_fortran/1.7.2
+module load sems-ninja_fortran/1.8.2
 
 # add the OpenMP environment variable we need
 export OMP_NUM_THREADS=2


### PR DESCRIPTION
@trilinos/framework 

## Description
This is the changes needed to the PR environment and scripts to get the gcc 4.8.4 build to use static libraries. Note that the build still fails on some missing template instantiations so this cannot merge until those issues are resolved.

## Motivation and Context
Builds for external customers should work withe either shared or static libraries

## Related Issues

* Closes #5058 

## How Has This Been Tested?
I used the instructions at https://github.com/trilinos/Trilinos/wiki/Reproducing-PR-Testing-Errors to build this locally.


## Checklist

- [ x ] My commit messages mention the appropriate GitHub issue numbers.
- [ ] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

Additional issues for the template problems will be created directly.