### PR TITLE
Tpetra: Attempt to Fix #5117

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -2568,21 +2568,30 @@ namespace Tpetra {
   /// \brief Nonmember function to create an empty CrsGraph given a
   ///   row Map and the max number of entries allowed locally per row.
   ///
-  /// \return A dynamically allocated (DynamicProfile) graph with
-  ///   specified number of nonzeros per row (defaults to zero).
+  /// \return A graph with a specified maximum number of nonzeros per
+  ///   row (defaults to zero, which is generally not useful).
   /// \relatesalso CrsGraph
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   Teuchos::RCP<CrsGraph<LocalOrdinal, GlobalOrdinal, Node> >
-  createCrsGraph (const Teuchos::RCP<const Map<LocalOrdinal, GlobalOrdinal, Node> > &map,
-                  size_t maxNumEntriesPerRow = 0,
-                  const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null)
+  createCrsGraph (const Teuchos::RCP<const Map<LocalOrdinal,
+                    GlobalOrdinal, Node> >& map,
+                  const size_t maxNumEntriesPerRow = 0,
+                  const Teuchos::RCP<Teuchos::ParameterList>& params =
+                    Teuchos::null)
   {
     using Teuchos::rcp;
-    typedef CrsGraph<LocalOrdinal, GlobalOrdinal, Node> graph_type;
-    return rcp (new graph_type (map, maxNumEntriesPerRow, DynamicProfile, params));
+    using graph_type = CrsGraph<LocalOrdinal, GlobalOrdinal, Node>;
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+    const ProfileType profileType = DynamicProfile;
+#else
+    const ProfileType profileType = StaticProfile;
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+    return rcp (new graph_type (map, maxNumEntriesPerRow,
+                                profileType, params));
   }
 
-  /// \brief Nonmember CrsGraph constructor that fuses Import and fillComplete().
+  /// \brief Nonmember CrsGraph constructor that fuses Import and
+  ///   fillComplete().
   /// \relatesalso CrsGraph
   /// \tparam CrsGraphType A specialization of CrsGraph.
   ///

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -5034,9 +5034,14 @@ namespace Tpetra {
                    size_t maxNumEntriesPerRow = 0,
                    const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null)
   {
-    typedef CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> matrix_type;
+    using matrix_type = CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+    const ProfileType profileType = DynamicProfile;
+#else
+    const ProfileType profileType = StaticProfile;
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
     return Teuchos::rcp (new matrix_type (map, maxNumEntriesPerRow,
-                                          DynamicProfile, params));
+                                          profileType, params));
   }
 
   template<class CrsMatrixType>

--- a/packages/tpetra/core/test/BugTests/BlankRowBugTest.cpp
+++ b/packages/tpetra/core/test/BugTests/BlankRowBugTest.cpp
@@ -76,7 +76,7 @@ namespace {
     }
     destRowMap = Tpetra::createNonContigMap<LO, GO> (tuple<GO> (0, 1), comm);
 
-    RCP<crs_matrix_type> srcMat = Tpetra::createCrsMatrix<SC>(sourceRowMap);
+    RCP<crs_matrix_type> srcMat = Tpetra::createCrsMatrix<SC>(sourceRowMap, 1);
     if (rank == 0) {
       srcMat->insertGlobalValues (static_cast<GO> (0), tuple<GO> (0), tuple<SC> (1.0));
     }
@@ -91,7 +91,7 @@ namespace {
       TEST_EQUALITY_CONST( srcMat->getNumEntriesInGlobalRow(1), static_cast<size_t> (0) );
     }
 
-    RCP<crs_matrix_type> dstMat = Tpetra::createCrsMatrix<SC> (destRowMap);
+    RCP<crs_matrix_type> dstMat = Tpetra::createCrsMatrix<SC> (destRowMap, 1);
     RCP<const import_type> importer = Tpetra::createImport (sourceRowMap, destRowMap);
     // global row 1 in srcMat is empty: this is a null communication to dstMat
     dstMat->doImport (*srcMat, *importer, Tpetra::INSERT);

--- a/packages/tpetra/core/test/BugTests/BugTests.cpp
+++ b/packages/tpetra/core/test/BugTests/BugTests.cpp
@@ -116,7 +116,7 @@ namespace {
       // this is what the file looks like: 1 3 4 9
       RCP<const map_type> rng = Tpetra::createUniformContigMap<LO, GO>(1,comm);
       RCP<const map_type> dom = Tpetra::createUniformContigMap<LO, GO>(4,comm);
-      RCP<crs_matrix_type> A = Tpetra::createCrsMatrix<SC, LO, GO>(rng);
+      RCP<crs_matrix_type> A = Tpetra::createCrsMatrix<SC, LO, GO>(rng, 4);
       if (myImageID == 0) {
         A->insertGlobalValues( 0, Teuchos::tuple<GO>(0,1,2,3), Teuchos::tuple<SC>(1.0,3.0,4.0,9.0) );
       }

--- a/packages/tpetra/core/test/CrsGraph/CrsGraph_Issue601.cpp
+++ b/packages/tpetra/core/test/CrsGraph/CrsGraph_Issue601.cpp
@@ -97,15 +97,25 @@ namespace { // (anonymous)
     RCP<const map_type> rowMap =
       rcp (new map_type (INV, myGblRowInds (), indexBase, comm));
 
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
     Tpetra::ProfileType profileTypes[] = { Tpetra::DynamicProfile, Tpetra::StaticProfile };
+#else
+    Tpetra::ProfileType profileTypes[] = { Tpetra::StaticProfile };
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
     bool insertLocalEntryValues[] = { true, false };
 
     // Test both dynamic and static profile.
     for (Tpetra::ProfileType profileType : profileTypes) {
 
-      out << "ProfileType: "
-          << ((profileType == Tpetra::DynamicProfile) ? "Dynamic" : "Static")
+      out << "ProfileType: ";
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+      out << ((profileType == Tpetra::DynamicProfile) ?
+              "Dynamic" :
+              "Static")
           << "Profile" << endl;
+#else
+      out << "StaticProfile" << endl;
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
       Teuchos::OSTab tab2 (out);
 
       // Test both with no local entries before globalAssemble(), and

--- a/packages/tpetra/core/test/CrsGraph/CrsGraph_UnitTests1.cpp
+++ b/packages/tpetra/core/test/CrsGraph/CrsGraph_UnitTests1.cpp
@@ -48,7 +48,9 @@
 
 namespace { // (anonymous)
   using Tpetra::TestingUtilities::getDefaultComm;
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
   using Tpetra::DynamicProfile;
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
   using Tpetra::ProfileType;
   using Tpetra::StaticProfile;
   using Teuchos::arcp;
@@ -137,12 +139,14 @@ namespace { // (anonymous)
       GRAPH graph(map,1,StaticProfile);
       graph.fillComplete();
     }
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
     {
       // create dynamic-profile graph, fill-complete without inserting
       // (and therefore, without allocating)
       GRAPH graph(map,1,DynamicProfile);
       graph.fillComplete();
     }
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
 
     int lclSuccess = success ? 1 : 0;
     int gblSuccess = 1;
@@ -456,7 +460,12 @@ namespace { // (anonymous)
     RCP<const map_type> map = rcp (new map_type (INVALID, 1, 0, comm));
     RCP<ParameterList> params = parameterList();
     {
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
       GRAPH graph(map,map,0,DynamicProfile);
+#else
+      GRAPH graph(map,map,1,StaticProfile);
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+
       TEST_EQUALITY_CONST( graph.isFillActive(),   true );
       TEST_EQUALITY_CONST( graph.isFillComplete(), false );
       graph.insertLocalIndices( 0, tuple<LO>(0) );
@@ -471,7 +480,12 @@ namespace { // (anonymous)
       TEST_THROW( graph.fillComplete(),                        std::runtime_error );
     }
     {
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
       GRAPH graph(map,map,0,DynamicProfile);
+#else
+      GRAPH graph(map,map,1,StaticProfile);
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+
       TEST_EQUALITY_CONST( graph.isFillActive(),   true );
       TEST_EQUALITY_CONST( graph.isFillComplete(), false );
       graph.insertLocalIndices( 0, tuple<LO>(0) );
@@ -681,4 +695,3 @@ namespace { // (anonymous)
     TPETRA_INSTANTIATE_LGN( UNIT_TEST_GROUP_DEBUG_AND_RELEASE )
 
 } // namespace (anonymous)
-

--- a/packages/tpetra/core/test/CrsGraph/CrsGraph_UnitTests_Swap.cpp
+++ b/packages/tpetra/core/test/CrsGraph/CrsGraph_UnitTests_Swap.cpp
@@ -412,9 +412,6 @@ using Teuchos::VERB_HIGH;
 using Teuchos::VERB_LOW;
 using Teuchos::VERB_MEDIUM;
 using Teuchos::VERB_NONE;
-using Tpetra::DynamicProfile;
-using Tpetra::ProfileType;
-using Tpetra::StaticProfile;
 using Tpetra::TestingUtilities::getDefaultComm;
 typedef Tpetra::global_size_t GST;
 

--- a/packages/tpetra/core/test/CrsGraph/CrsGraph_insertGlobalIndicesFiltered.cpp
+++ b/packages/tpetra/core/test/CrsGraph/CrsGraph_insertGlobalIndicesFiltered.cpp
@@ -133,8 +133,13 @@ namespace { // (anonymous)
     // Buffer for storing output of getGlobalRowCopy.
     Teuchos::Array<GO> gblColIndsBuf (maxNumEntPerRow);
 
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
     const Tpetra::ProfileType profileTypes[2] =
       {Tpetra::DynamicProfile, Tpetra::StaticProfile};
+#else
+    const Tpetra::ProfileType profileTypes[1] =
+      {Tpetra::StaticProfile};
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
     for (auto profileType_src : profileTypes) {
       crs_graph_type graph_src (rowMap_src, maxNumEntPerRow, profileType_src);
       for (LO lclRow = 0; lclRow < lclNumRows; ++lclRow) {
@@ -191,5 +196,3 @@ namespace { // (anonymous)
   TPETRA_INSTANTIATE_LGN( UNIT_TEST_GROUP )
 
 } // namespace (anonymous)
-
-

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_LeftRightScale.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_LeftRightScale.cpp
@@ -93,11 +93,6 @@ namespace {
   using Tpetra::createUniformContigMapWithNode;
   using Tpetra::createVector;
   using Tpetra::createCrsMatrix;
-  using Tpetra::ProfileType;
-  using Tpetra::StaticProfile;
-  using Tpetra::DynamicProfile;
-  using Tpetra::OptimizeOption;
-  using Tpetra::GloballyDistributed;
   using Tpetra::INSERT;
 
   TEUCHOS_STATIC_SETUP()

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_NonlocalAfterResume.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_NonlocalAfterResume.cpp
@@ -71,7 +71,6 @@ namespace {
   using Tpetra::createCrsMatrix;
   using Tpetra::ProfileType;
   using Tpetra::StaticProfile;
-  using Tpetra::DynamicProfile;
   using Tpetra::OptimizeOption;
   using Tpetra::DoOptimizeStorage;
   using Tpetra::DoNotOptimizeStorage;
@@ -164,7 +163,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( CrsMatrix, NonlocalAfterResume, LO, GO, Scala
     //----------------------------------------------------------------------
     // put in diagonal, locally
     //----------------------------------------------------------------------
-    Tpetra::CrsMatrix<Scalar,LO,GO,Node> matrix(rmap,cmap,3,DynamicProfile);
+    Tpetra::CrsMatrix<Scalar,LO,GO,Node> matrix(rmap,cmap,3);
     for (GO r=rmap->getMinGlobalIndex(); r <= rmap->getMaxGlobalIndex(); ++r) {
       matrix.insertGlobalValues(r,tuple(r),tuple(ST::one()));
     }

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_PackUnpack.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_PackUnpack.cpp
@@ -353,9 +353,12 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CrsMatrix, PackThenUnpackAndCombine, SC, LO, G
       int curNumErrors = 0;
       LO num_indices = static_cast<LO>(A_indices.size());
       for (LO i=0; i<num_indices; i++) {
-        if (! essentially_equal<SC>(2.0 * A_values[i], B_values[i])) {
+        using mag_type = typename Kokkos::ArithTraits<SC>::mag_type;
+        if (! essentially_equal<SC>(mag_type (2.0) * A_values[i],
+                                    B_values[i])) {
           errStrm << "ERROR: Proc " << world_rank << ", row " << loc_row
-                  << ", 2*A[" << i << "]=" << 2.0 * A_values[i] << ", but "
+                  << ", 2*A[" << i << "]=" << mag_type (2.0) * A_values[i]
+                  << ", but "
                   <<     "B[" << i << "]=" <<   B_values[i] << "!\n";
           ++curNumErrors;
         }

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_ReplaceDomainMapAndImporter.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_ReplaceDomainMapAndImporter.cpp
@@ -82,13 +82,6 @@ namespace {
   using Tpetra::createContigMapWithNode;
   using Tpetra::createVector;
   using Tpetra::createCrsMatrix;
-  using Tpetra::ProfileType;
-  using Tpetra::StaticProfile;
-  using Tpetra::DynamicProfile;
-  using Tpetra::OptimizeOption;
-  using Tpetra::DoOptimizeStorage;
-  using Tpetra::DoNotOptimizeStorage;
-  using Tpetra::GloballyDistributed;
   using Tpetra::INSERT;
 
   TEUCHOS_STATIC_SETUP()

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests.cpp
@@ -113,13 +113,14 @@ namespace { // (anonymous)
     {
       RCPMap map  = createContigMapWithNode<LO,GO,Node>(INVALID,numLocal,comm);
       MV mv(map,1);
-      zero = rcp( new MAT(map,0,Tpetra::DynamicProfile) );
+      zero = rcp( new MAT(map,0) );
       TEST_THROW(zero->apply(mv,mv), std::runtime_error);
+#ifndef TPETRA_ENABLE_DEPRECATED_CODE
 #   if defined(HAVE_TPETRA_THROW_EFFICIENCY_WARNINGS)
       // throw exception because we required increased allocation
       TEST_THROW(zero->insertGlobalValues(map->getMinGlobalIndex(),tuple<GO>(0),tuple<Scalar>(ST::one())), std::runtime_error);
 #   endif
-      TEST_ASSERT( zero->getProfileType() == Tpetra::DynamicProfile );
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
       zero->fillComplete();
     }
     STD_TESTS((*zero));
@@ -187,7 +188,6 @@ namespace { // (anonymous)
       for (size_t i=0; i<numLocal; ++i) {
         eye_crs->insertGlobalValues(base+i,tuple<GO>(base+i),tuple<Scalar>(ST::one()));
       }
-      TEST_ASSERT( eye_crs->getProfileType() == Tpetra::DynamicProfile );
       eye_crs->fillComplete();
       eye = eye_crs;
     }

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests2.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests2.cpp
@@ -150,7 +150,6 @@ namespace {
   using Tpetra::createCrsMatrix;
   using Tpetra::ProfileType;
   using Tpetra::StaticProfile;
-  using Tpetra::DynamicProfile;
   using Tpetra::OptimizeOption;
   using Tpetra::DoOptimizeStorage;
   using Tpetra::DoNotOptimizeStorage;
@@ -261,14 +260,16 @@ inline void tupleToArray(Array<T> &arr, const tuple &tup)
     RCP<const map_type> lclmap = createLocalMapWithNode<LO,GO,Node> (P, comm);
 
     // create the matrix
-    MAT A(rowmap,P,DynamicProfile);
+    MAT A(rowmap,P);
     for (GO i=0; i<static_cast<GO>(M); ++i) {
       for (GO j=0; j<static_cast<GO>(P); ++j) {
         A.insertGlobalValues( M*myImageID+i, tuple<GO>(j), tuple<Scalar>(M*myImageID+i + j*M*N) );
       }
     }
     // call fillComplete()
-    TEST_EQUALITY_CONST( A.getProfileType() == DynamicProfile, true );
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+    TEST_ASSERT( A.getProfileType() == Tpetra::DynamicProfile );
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
     A.fillComplete(lclmap,rowmap);
     // build the input multivector X
     MV X(lclmap,numVecs);
@@ -631,5 +632,3 @@ inline void tupleToArray(Array<T> &arr, const tuple &tup)
   TPETRA_INSTANTIATE_SLGN( UNIT_TEST_GROUP )
 
 }
-
-

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests3.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests3.cpp
@@ -141,7 +141,9 @@ namespace {
   using Tpetra::createCrsMatrix;
   using Tpetra::ProfileType;
   using Tpetra::StaticProfile;
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
   using Tpetra::DynamicProfile;
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
   using Tpetra::OptimizeOption;
   using Tpetra::DoOptimizeStorage;
   using Tpetra::DoNotOptimizeStorage;
@@ -223,8 +225,8 @@ inline void tupleToArray(Array<T> &arr, const tuple &tup)
     {
       // send in a parameterlist, check the defaults
       RCP<ParameterList> defparams = parameterList();
-      // create dynamic-profile matrix, fill-complete without inserting (and therefore, without allocating)
-      MAT matrix(map,1,DynamicProfile);
+      // create matrix, fill-complete without inserting (and therefore, without allocating)
+      MAT matrix(map,1);
       matrix.fillComplete(defparams);
       TEST_EQUALITY_CONST(defparams->get<bool>("Optimize Storage"), true);
     }
@@ -236,6 +238,7 @@ inline void tupleToArray(Array<T> &arr, const tuple &tup)
       graph.fillComplete(defparams);
       TEST_EQUALITY_CONST(defparams->get<bool>("Optimize Storage"), true);
     }
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
     {
       // send in a parameterlist, check the defaults
       RCP<ParameterList> defparams = parameterList();
@@ -244,6 +247,7 @@ inline void tupleToArray(Array<T> &arr, const tuple &tup)
       graph.fillComplete(defparams);
       TEST_EQUALITY_CONST(defparams->get<bool>("Optimize Storage"), true);
     }
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
   }
 
   ////
@@ -282,7 +286,12 @@ inline void tupleToArray(Array<T> &arr, const tuple &tup)
     RCP<Map<LO,GO,Node> > cmap = rcp( new Map<LO,GO,Node>(INVALID,ginds(),0,comm) );
     RCP<ParameterList> params = parameterList();
     for (int T=0; T<4; ++T) {
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
       ProfileType pftype = ( (T & 1) == 1 ) ? StaticProfile : DynamicProfile;
+#else
+      ProfileType pftype = StaticProfile;
+#endif //TPETRA_ENABLE_DEPRECATED_CODE
+
       params->set("Optimize Storage",((T & 2) == 2));
       MAT matrix(rmap,cmap, ginds.size(), pftype);   // only allocate as much room as necessary
       RowMatrix<Scalar,LO,GO,Node> &rowmatrix = matrix;
@@ -416,7 +425,9 @@ inline void tupleToArray(Array<T> &arr, const tuple &tup)
 
     // call fillComplete()
     out << "Call fillComplete on the matrix" << endl;
-    TEST_EQUALITY_CONST( A.getProfileType() == DynamicProfile, true );
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+    TEST_ASSERT( A.getProfileType() == DynamicProfile );
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
     A.fillComplete (lclmap, rowmap);
     A.describe (out, VERB_LOW);
 

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests4.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests4.cpp
@@ -143,7 +143,9 @@ namespace {
   using Tpetra::createCrsMatrix;
   using Tpetra::ProfileType;
   using Tpetra::StaticProfile;
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
   using Tpetra::DynamicProfile;
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
   using Tpetra::OptimizeOption;
   using Tpetra::DoOptimizeStorage;
   using Tpetra::DoNotOptimizeStorage;
@@ -366,7 +368,11 @@ inline void tupleToArray(Array<T> &arr, const tuple &tup)
     RCP<const Map<LO,GO,Node> > map = createContigMapWithNode<LO,GO,Node>(INVALID,1,comm);
     const Scalar SZERO = ScalarTraits<Scalar>::zero();
     {
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
       MAT matrix(map,map,0,DynamicProfile);
+#else
+      MAT matrix(map,map,1);
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
       TEST_EQUALITY_CONST( matrix.isFillActive(),   true );
       TEST_EQUALITY_CONST( matrix.isFillComplete(), false );
       matrix.insertLocalValues( 0, tuple<LO>(0), tuple<Scalar>(0) );
@@ -401,7 +407,11 @@ inline void tupleToArray(Array<T> &arr, const tuple &tup)
       TEST_THROW( matrix.fillComplete(),        std::runtime_error );
     }
     {
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
       MAT matrix(map,map,0,DynamicProfile);
+#else
+      MAT matrix(map,map,2); // just in case insert doesn't merge
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
       TEST_EQUALITY_CONST( matrix.isFillActive(),   true );
       TEST_EQUALITY_CONST( matrix.isFillComplete(), false );
       matrix.insertLocalValues( 0, tuple<LO>(0), tuple<Scalar>(0) );
@@ -610,7 +620,11 @@ inline void tupleToArray(Array<T> &arr, const tuple &tup)
     auto map = createContigMapWithNode<LO, GO, Node> (INVALID, 1, comm);
 
     // construct matrix
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
     CrsMatrix<Scalar,LO,GO,Node> A (map, map, 0, DynamicProfile);
+#else
+    CrsMatrix<Scalar,LO,GO,Node> A (map, map, 1);
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
     A.insertLocalValues (0, tuple<LO> (0), tuple<Scalar> (STS::zero ()));
     A.fillComplete (map, map);
 

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests_Swap.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests_Swap.cpp
@@ -785,9 +785,6 @@ using Teuchos::VERB_HIGH;
 using Teuchos::VERB_LOW;
 using Teuchos::VERB_MEDIUM;
 using Teuchos::VERB_NONE;
-using Tpetra::DynamicProfile;
-using Tpetra::ProfileType;
-using Tpetra::StaticProfile;
 using Tpetra::TestingUtilities::getDefaultComm;
 typedef Tpetra::global_size_t GST;
 

--- a/packages/tpetra/core/test/CrsMatrix/Regression/Albany182.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/Regression/Albany182.cpp
@@ -957,7 +957,7 @@ namespace { // (anonymous)
       expectedColumnMapFromNonoverlappingCrsMatrix<map_type> (comm);
 
     if (false) {
-      out << "Target matrix is {DynamicProfile, globally indexed}" << endl;
+      out << "Target matrix is {globally indexed}" << endl;
       Teuchos::OSTab tab2 (out);
 
       out << "Create target matrix (A_nonoverlapping)" << endl;
@@ -1003,14 +1003,21 @@ namespace { // (anonymous)
     }
 
     using Tpetra::ProfileType;
-    using Tpetra::DynamicProfile;
-    using Tpetra::StaticProfile;
-    for (ProfileType profileType : {DynamicProfile, StaticProfile}) {
+    const ProfileType profileTypes[] = {
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+      Tpetra::DynamicProfile,
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+      Tpetra::StaticProfile
+    };
+
+    for (ProfileType profileType : profileTypes) {
       out << ">>> Target matrix is {";
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
       if (profileType == Tpetra::DynamicProfile) {
         out << "DynamicProfile";
       }
-      else {
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+      if (profileType == Tpetra::StaticProfile) {
         out << "StaticProfile";
       }
       out << ", locally indexed}" << endl;
@@ -1219,5 +1226,3 @@ namespace { // (anonymous)
 #endif // HAVE_TPETRA_INST_INT_LONG_LONG
 
 } // namespace (anonymous)
-
-

--- a/packages/tpetra/core/test/ImportExport2/ImportExport2_CrsSortingUtils.cpp
+++ b/packages/tpetra/core/test/ImportExport2/ImportExport2_CrsSortingUtils.cpp
@@ -286,8 +286,14 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( Import_Util, SortCrsEntries, Scalar, LO, GO)
     // merge/shrink
     vals2.resize(new_num_entries);
     vals_rand.resize(new_num_entries);
-    for (size_type i=0; i<new_num_entries; i++) vals2[i] = 2.*vals[i];
-    TEST_COMPARE_FLOATING_ARRAYS(vals2, vals_rand, 1.e-12);
+
+    using mag_type = typename Kokkos::ArithTraits<scalar_type>::mag_type;
+    for (size_type i=0; i<new_num_entries; i++) {
+      vals2[i] = mag_type (2.0) * vals[i];
+    }
+    // FIXME (mfh 06 May 2019) I didn't pick this tolerance.
+    // It should be a function of scalar_type.
+    TEST_COMPARE_FLOATING_ARRAYS(vals2, vals_rand, mag_type (1.e-12));
 
     //
     // Sort the GIDs w/o values

--- a/packages/tpetra/core/test/TpetraUtils_MatrixGenerator.hpp
+++ b/packages/tpetra/core/test/TpetraUtils_MatrixGenerator.hpp
@@ -284,8 +284,7 @@ namespace Tpetra {
         // Construct the CrsMatrix, using the row map, with the
         // constructor specifying the number of nonzeros for each row.
         RCP<sparse_matrix_type> A =
-          rcp (new sparse_matrix_type (pRowMap, myNumEntriesPerRow (),
-                                       DynamicProfile));
+          rcp (new sparse_matrix_type (pRowMap, myNumEntriesPerRow ()));
 
         // List of the global indices of my rows.
         // They may or may not be contiguous.


### PR DESCRIPTION
@trilinos/tpetra 

## Description

First attempt at fixing #5117.  NOT ALL THE TESTS PASS with the current changes!  The following TpetraCore tests still fail:
```
	 35 - TpetraCore_CrsGraph_UnitTests0_MPI_4 (Failed)
	 51 - TpetraCore_CrsMatrix_NonlocalAfterResume_MPI_4 (Failed)
	 62 - TpetraCore_CrsMatrix_Bug6171_MPI_2 (Failed)
	 72 - TpetraCore_Albany182_MPI_4 (Failed)
	 97 - TpetraCore_ImportExport2_UnitTests_MPI_4 (Failed)
	 99 - TpetraCore_MatrixMarket_Tpetra_CrsMatrix_InOutTest_MPI_4 (Failed)
	100 - TpetraCore_MatrixMarket_Tpetra_CrsGraph_InOutTest_MPI_4 (Failed)
	101 - TpetraCore_MatrixMarket_Operator_Test_MPI_4 (Failed)
	132 - TpetraCore_MatrixMatrix_UnitTests_MPI_4 (Failed)
	133 - TpetraCore_AddProfiling_UnitTests_MPI_4 (Failed)
	135 - TpetraCore_MultiVector_UnitTests_MPI_4 (Failed)
	161 - TpetraCore_RowMatrixTransposer_test_MPI_4 (Failed)
	171 - TpetraCore_lesson05_redistribution_MPI_4 (Failed)
	175 - TpetraCore_FEMAssembly_InsertGlobalIndicesDP_MPI_4 (Failed)
	176 - TpetraCore_FEMAssembly_LocalElementLoopDP_MPI_4 (Failed)
	177 - TpetraCore_FEMAssembly_TotalElementLoopDP_MPI_4 (Failed)
	189 - TpetraCore_guide_power_method_1_MPI_4 (Failed)
	190 - TpetraCore_guide_matrix_fill_1_MPI_4 (Failed)
	193 - TpetraCore_guide_data_redist_1_MPI_4 (Failed)
```

## Related Issues

* Closes #5117 
