### PR TITLE
MueLu: print msg if regionMG coarseSolver is not setup properly

### DIFF
--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
@@ -1715,9 +1715,19 @@ void vCycle(const int l, ///< ID of current level
 
   /* Solve!
    *
+   * Calling solve() on the coarseSolver sould just do a triangular solve, since symbolic
+   * and numeric factorization are supposed to have happened during hierarchy setup.
+   * Here, we just check if they're done and print message if not.
+   *
    * We don't have to change the map of tX and tB since we have configured the Amesos2 solver
    * during its construction to work with non-continous maps.
    */
+  if (not coarseSolver->getStatus().symbolicFactorizationDone())
+    *fos << "Symbolic factorization should have been done during hierarchy setup, "
+        "but actually is missing. Anyway ... just do it right now." << std::endl;
+  if (not coarseSolver->getStatus().numericFactorizationDone())
+    *fos << "Numeric factorization should have been done during hierarchy setup, "
+        "but actually is missing. Anyway ... just do it right now." << std::endl;
   coarseSolver->solve(tX.ptr(), tB.ptr());
 
   // Transform back to region format


### PR DESCRIPTION
@trilinos/muelu 

## Description

Just before the actual solve, we check, if all necessary factorizations have actually been pre-computed, and print a message to the screen, if not.

## Motivation and Context

The coarse solver is setup during the setup of the region hierarchy, where we also compute its symbolic and numeric factorization. To this end, the factorizations should be ready to use, when it comes to solving the coarse problem inside the V-cycle.

## Related Issues

* Follows #5087 

## How Has This Been Tested?
I ran the regionMG tests locally.

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.