### PR TITLE
swap gcc module in ATDM sems-rhel6 intel-17 builds

### DIFF
--- a/cmake/std/atdm/sems-rhel6/environment.sh
+++ b/cmake/std/atdm/sems-rhel6/environment.sh
@@ -147,6 +147,7 @@ elif [[ "$ATDM_CONFIG_COMPILER" == "GNU-7.2.0" ]] ; then
   export ATDM_CONFIG_BLAS_LIBS="-L${BLAS_ROOT}/lib;-lblas"
 elif [[ "$ATDM_CONFIG_COMPILER" == "INTEL-17.0.1" ]] ; then
   module load sems-intel/17.0.1
+  module swap sems-gcc/4.8.4 sems-gcc/4.9.3
   export OMPI_CXX=`which icpc`
   export OMPI_CC=`which icc`
   export OMPI_FC=`which ifort`


### PR DESCRIPTION
@bartlettroscoe

## Description
swap the gcc version on rhel6 intel 17 atdm builds from gcc-4.8.4 to gcc-4.9.3. 

For motivation, see [ATDV-157](https://sems-atlassian-srn.sandia.gov/browse/ATDV-157) (allow EMPIRE to use C++14 features).

## How Has This Been Tested?
[this query](https://testing.sandia.gov/cdash/index.php?project=Trilinos&date=2019-05-06&filtercount=5&showfilters=1&filtercombine=and&field1=site&compare1=63&value1=sems&field2=site&compare2=63&value2=rhel6&field3=buildname&compare3=63&value3=intel&field4=buildstarttime&compare4=83&value4=2019-05-06&field5=buildstarttime&compare5=84&value5=2019-05-07) shows builds using each version of gcc and there are no test failures in either
