### PR TITLE
MueLu: add interface scaling to compositeToRegional()

### DIFF
--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
@@ -1478,7 +1478,7 @@ std::vector<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >
 computeResidual(std::vector<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regRes, ///< residual (to be evaluated)
                 const std::vector<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regX, ///< left-hand side (solution)
                 const std::vector<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regB, ///< right-hand side (forcing term)
-                const std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regionGrpMats,
+                const std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regionGrpMats, ///< matrix in region format
                 const RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > mapComp, ///< composite map, computed by removing GIDs > numDofs in revisedRowMapPerGrp
                 const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > rowMapPerGrp, ///< row maps in region layout [in] requires the mapping of GIDs on fine mesh to "filter GIDs"
                 const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > revisedRowMapPerGrp, ///< revised row maps in region layout [in] (actually extracted from regionGrpMats)

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionMatrix_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionMatrix_def.hpp
@@ -181,9 +181,7 @@ void compositeToRegionalWithInterfaceScaling(
     inverseInterfaceScaling->reciprocal(*interfaceScaling[j]);
 
     // Do the actual scaling
-    RCP<Vector> tmpResult = VectorFactory::Build(regVecs[j]->getMap());
-    tmpResult->elementWiseMultiply(one, *regVecs[j], *inverseInterfaceScaling, zero);
-    regVecs[j]->update(one, *tmpResult, zero);
+    regVecs[j]->elementWiseMultiply(one, *regVecs[j], *inverseInterfaceScaling, zero);
   }
 
   return;

--- a/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
+++ b/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
@@ -1269,8 +1269,8 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
 
     std::vector<RCP<Vector> > quasiRegB(maxRegPerProc);
     std::vector<RCP<Vector> > regB(maxRegPerProc);
-    compositeToRegional(B, quasiRegB, regB, maxRegPerProc, rowMapPerGrp,
-                        revisedRowMapPerGrp, rowImportPerGrp);
+    compositeToRegionalWithInterfaceScaling(B, quasiRegB, regB, maxRegPerProc, rowMapPerGrp,
+                        revisedRowMapPerGrp, rowImportPerGrp, regInterfaceScalings[0]);
 
     //    printRegionalObject<Vector>("regB 0", regB, myRank, *fos);
 


### PR DESCRIPTION
@trilinos/muelu 

## Description

Add `compositeToRegionalWithInterfaceScaling()` in order to scale interface values by 1/N with N being the number of adjacent regions. 

## Motivation and Context

This should fix 2x as large residuals at region interfaces as reported in #5135.

## Related Issues

* Related to #5135 

## How Has This Been Tested?

- Build and tests pass locally.
- The residual mismatch as described in #5135 is not seen anymore. @rstumin can hopefully confirm this as well.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [x] These changes break backwards compatibility.