### PR TITLE
Fix warnings and set Werror for Triutils in GCC 7.2.0 build

### DIFF
--- a/cmake/std/PullRequestLinuxGCC7.2.0TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxGCC7.2.0TestingSettings.cmake
@@ -74,7 +74,7 @@ set (Thyra_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as erro
 set (Tpetra_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")
 set (TrilinosCouplings_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")
 set (TrilinosSS_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")
-#set (Triutils_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")
+set (Triutils_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")
 set (Xpetra_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")
 #set (Zoltan_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")
 set (Zoltan2_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")

--- a/packages/triutils/src/Trilinos_Util_ReadHpc2Epetra.cpp
+++ b/packages/triutils/src/Trilinos_Util_ReadHpc2Epetra.cpp
@@ -80,7 +80,9 @@ void Trilinos_Util_ReadHpc2Epetra_internal(
     exit(1);
   }
   int_type numGlobalEquations, total_nnz;
+#ifdef DEBUG
   int cnt;
+#endif
   // mfh 24 Mar 2015: We use temporaries of the type corresponding to
   // the sscanf format specifiers, in order to avoid compiler warnings
   // about the sscanf output arguments' types not matching their
@@ -89,10 +91,15 @@ void Trilinos_Util_ReadHpc2Epetra_internal(
   // the warning is easy to fix.
   if(sizeof(int) == sizeof(int_type)) {
     int numGlobalEquations_int, total_nnz_int;
-
-    cnt = fscanf(in_file,"%d",&numGlobalEquations_int);
+#ifdef DEBUG
+    cnt =
+#endif
+    fscanf(in_file,"%d",&numGlobalEquations_int);
     assert(cnt > 0);
-    cnt = fscanf(in_file,"%d",&total_nnz_int);
+#ifdef DEBUG
+    cnt =
+#endif
+    fscanf(in_file,"%d",&total_nnz_int);
     assert(cnt > 0);
 
     numGlobalEquations = static_cast<int_type> (numGlobalEquations_int);
@@ -100,10 +107,15 @@ void Trilinos_Util_ReadHpc2Epetra_internal(
   }
   else if(sizeof(long long) == sizeof(int_type)) {
     long long numGlobalEquations_ll, total_nnz_ll;
-
-    cnt = fscanf(in_file,"%lld",&numGlobalEquations_ll);
+#ifdef DEBUG
+    cnt =
+#endif
+    fscanf(in_file,"%lld",&numGlobalEquations_ll);
     assert(cnt > 0);
-    cnt = fscanf(in_file,"%lld",&total_nnz_ll);
+#ifdef DEBUG
+    cnt =
+#endif
+    fscanf(in_file,"%lld",&total_nnz_ll);
     assert(cnt > 0);
 
     numGlobalEquations = static_cast<int_type> (numGlobalEquations_ll);
@@ -136,7 +148,10 @@ void Trilinos_Util_ReadHpc2Epetra_internal(
   int max_nnz = 0;
 
   for (int i=0; i<numGlobalEquations; i++) {
-    cnt = fscanf(in_file, "%d",lp); /* row #, nnz in row */
+#ifdef DEBUG
+    cnt =
+#endif
+    fscanf(in_file, "%d",lp); /* row #, nnz in row */
     assert(cnt > 0);
     if (map->MyGID(i)) max_nnz = EPETRA_MAX(max_nnz,l);
   }
@@ -148,7 +163,10 @@ void Trilinos_Util_ReadHpc2Epetra_internal(
   {
     for (int_type i=0; i<numGlobalEquations; i++) {
       int cur_nnz;
-      cnt = fscanf(in_file, "%d",&cur_nnz);
+#ifdef DEBUG
+      cnt =
+#endif
+      fscanf(in_file, "%d",&cur_nnz);
       assert(cnt > 0);
       if (map->MyGID(i)) // See if nnz for row should be added
       {
@@ -157,7 +175,10 @@ void Trilinos_Util_ReadHpc2Epetra_internal(
         int nnz_kept = 0;
         for (int j=0; j<cur_nnz; j++)
         {
-          cnt = fscanf(in_file, "%lf %d",vp,lp);
+#ifdef DEBUG
+          cnt =
+#endif
+          fscanf(in_file, "%lf %d",vp,lp);
           assert(cnt > 0);
           if (v!=0.0) {
             list_of_vals[nnz_kept] = v;
@@ -169,7 +190,10 @@ void Trilinos_Util_ReadHpc2Epetra_internal(
       }
       else
         for (int j=0; j<cur_nnz; j++) {
-          cnt = fscanf(in_file, "%lf %d",vp,lp); // otherwise read and discard
+#ifdef DEBUG
+          cnt =
+#endif
+          fscanf(in_file, "%lf %d",vp,lp); // otherwise read and discard
           assert(cnt > 0);
         }
     }
@@ -183,14 +207,20 @@ void Trilinos_Util_ReadHpc2Epetra_internal(
           std::cout << "Process "<< rank <<" of "
                     << size <<" getting RHS " << i
                     << std::endl;
-        cnt = fscanf(in_file, "%lf %lf %lf",&xt, &bt, &xxt);
+#ifdef DEBUG
+        cnt =
+#endif
+        fscanf(in_file, "%lf %lf %lf",&xt, &bt, &xxt);
         assert(cnt > 0);
         int cur_local_row = map->LID(i);
         (*x)[cur_local_row] = xt;
         (*b)[cur_local_row] = bt;
         (*xexact)[cur_local_row] = xxt;
       } else {
-        cnt = fscanf(in_file, "%lf %lf %lf",vp, vp, vp); // or thrown away
+#ifdef DEBUG
+        cnt =
+#endif
+        fscanf(in_file, "%lf %lf %lf",vp, vp, vp); // or thrown away
         assert(cnt > 0);
       }
     }

--- a/packages/triutils/src/Trilinos_Util_iohb.cpp
+++ b/packages/triutils/src/Trilinos_Util_iohb.cpp
@@ -822,7 +822,7 @@ int writeHB_mat_double(const char* filename, int M, int N,
        }
     } else out_file = stdout;
 
-    if ( Ptrfmt == NULL ) strcpy(Ptrfmt, "(8I10)");
+    if ( Ptrfmt != NULL ) strcpy(Ptrfmt, "(8I10)");
     ParseIfmt(Ptrfmt,&Ptrperline,&Ptrwidth);
     std::sprintf(pformat,"%%%dd",Ptrwidth);
     ptrcrd = (N+1)/Ptrperline;
@@ -835,7 +835,7 @@ int writeHB_mat_double(const char* filename, int M, int N,
     if ( nz%Indperline != 0) indcrd++;
 
     if ( Type[0] != 'P' ) {          /* Skip if pattern only  */
-      if ( Valfmt == NULL ) strcpy(Valfmt, "(4E20.13)");
+      if ( Valfmt != NULL ) strcpy(Valfmt, "(4E20.13)");
       ParseRfmt(Valfmt,&Valperline,&Valwidth,&Valprec,&Valflag);
       if (Valflag == 'D') *std::strchr(Valfmt,'D') = 'E';
       if (Valflag == 'F')
@@ -1430,7 +1430,7 @@ int writeHB_mat_char(const char* filename, int M, int N,
        }
     } else out_file = stdout;
 
-    if ( Ptrfmt == NULL ) strcpy(Ptrfmt, "(8I10)");
+    if ( Ptrfmt != NULL ) strcpy(Ptrfmt, "(8I10)");
     ParseIfmt(Ptrfmt,&Ptrperline,&Ptrwidth);
     std::sprintf(pformat,"%%%dd",Ptrwidth);
 
@@ -1439,7 +1439,7 @@ int writeHB_mat_char(const char* filename, int M, int N,
     std::sprintf(iformat,"%%%dd",Indwidth);
 
     if ( Type[0] != 'P' ) {          /* Skip if pattern only  */
-      if ( Valfmt == NULL ) strcpy(Valfmt, "(4E20.13)");
+      if ( Valfmt != NULL ) strcpy(Valfmt, "(4E20.13)");
       ParseRfmt(Valfmt,&Valperline,&Valwidth,&Valprec,&Valflag);
       std::sprintf(vformat,"%%%ds",Valwidth);
     }


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework
@trilinos/triutils 

## Description
<!--- Please describe your changes in detail. -->
Fixed warnings and set Werror for Triutils in the GC 7.2.0 PR build.
Wrapped variable in #ifdef DEBUG Werror sees as unused only by asserts and reversed NULL checks protecting strcpys.
## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->
This completes #4511 and is work toward Issue #3178, eventually setting -Werror for all packages.
<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.