### PR TITLE
Fix warnings and set Werror for Isorropia in GCC 7.2.0 build

### DIFF
--- a/cmake/std/PullRequestLinuxGCC7.2.0TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxGCC7.2.0TestingSettings.cmake
@@ -41,7 +41,7 @@ set (Ifpack_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as err
 set (Ifpack2_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")
 set (Intrepid_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")
 set (Intrepid2_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")
-#set (Isorropia_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")
+set (Isorropia_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")
 set (Kokkos_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")
 set (KokkosKernels_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")
 set (MiniTensor_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")

--- a/packages/isorropia/example/probe_tridiag.cpp
+++ b/packages/isorropia/example/probe_tridiag.cpp
@@ -77,7 +77,10 @@ int main(int argc, char *argv[])
 
     std::vector<int> NumNz(NumMyElements);
 
-    int i, ierr;
+    int i;
+#ifdef DEBUG
+    int ierr;
+#endif
     for (i=0; i<NumMyElements; i++)
     {
         if (MyGlobalElements[i]==0 ||
@@ -116,17 +119,26 @@ int main(int argc, char *argv[])
             Indices[1] = MyGlobalElements[i]+1;
             NumEntries = 2;
         }
-        ierr = A.InsertGlobalValues(MyGlobalElements[i], NumEntries,
+#ifdef DEBUG
+        ierr =
+#endif
+        A.InsertGlobalValues(MyGlobalElements[i], NumEntries,
                         &Values[0], &Indices[0]);
         assert(ierr==0);
         // Put in the diagonal entry
-        ierr = A.InsertGlobalValues(MyGlobalElements[i], 1, &two,
+#ifdef DEBUG
+        ierr =
+#endif
+        A.InsertGlobalValues(MyGlobalElements[i], 1, &two,
                         &MyGlobalElements[i]);
         assert(ierr==0);
     }
 
     // Finish up matrix construction
-    ierr = A.FillComplete();
+#ifdef DEBUG
+    ierr =
+#endif
+    A.FillComplete();
     assert(ierr==0);
 
     std::cout << A << std::endl;
@@ -162,7 +174,10 @@ int main(int argc, char *argv[])
             Indices[1] = MyGlobalElements[i]+1;
             NumEntries = 2;
         }
-        ierr = G1.InsertGlobalIndices(MyGlobalElements[i], NumEntries,
+#ifdef DEBUG
+        ierr =
+#endif
+        G1.InsertGlobalIndices(MyGlobalElements[i], NumEntries,
                         &Indices[0]);
         assert(ierr==0);
         // Put in the diagonal entry

--- a/packages/isorropia/example/probe_tridiag.cpp
+++ b/packages/isorropia/example/probe_tridiag.cpp
@@ -78,7 +78,7 @@ int main(int argc, char *argv[])
     std::vector<int> NumNz(NumMyElements);
 
     int i;
-#ifdef DEBUG
+#ifndef NDEBUG
     int ierr;
 #endif
     for (i=0; i<NumMyElements; i++)
@@ -119,14 +119,14 @@ int main(int argc, char *argv[])
             Indices[1] = MyGlobalElements[i]+1;
             NumEntries = 2;
         }
-#ifdef DEBUG
+#ifndef NDEBUG
         ierr =
 #endif
         A.InsertGlobalValues(MyGlobalElements[i], NumEntries,
                         &Values[0], &Indices[0]);
         assert(ierr==0);
         // Put in the diagonal entry
-#ifdef DEBUG
+#ifndef NDEBUG
         ierr =
 #endif
         A.InsertGlobalValues(MyGlobalElements[i], 1, &two,
@@ -135,7 +135,7 @@ int main(int argc, char *argv[])
     }
 
     // Finish up matrix construction
-#ifdef DEBUG
+#ifndef NDEBUG
     ierr =
 #endif
     A.FillComplete();
@@ -174,7 +174,7 @@ int main(int argc, char *argv[])
             Indices[1] = MyGlobalElements[i]+1;
             NumEntries = 2;
         }
-#ifdef DEBUG
+#ifndef NDEBUG
         ierr =
 #endif
         G1.InsertGlobalIndices(MyGlobalElements[i], NumEntries,


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework
@trilinos/isorropia

## Description
<!--- Please describe your changes in detail. -->
Fixed warnings and set Werror for Isorropia in the GC 7.2.0 PR build.
Wrapped variable in #ifdef DEBUG Werror sees as unused only by asserts.
## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->
This completes #5105 and is work toward Issue #3178, eventually setting -Werror for all packages.
<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.