### PR TITLE
Ifpack2 - fix for #5148

### DIFF
--- a/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
@@ -2041,11 +2041,11 @@ namespace KB = KokkosBatched::Experimental;
 	  KB::Trsm<member_type,
 		   KB::Side::Left,KB::Uplo::Lower,KB::Trans::NoTranspose,KB::Diag::Unit,
 		   default_mode_type,default_algo_type>
-            ::invoke(member, 1.0, W, A);
+            ::invoke(member, one, W, A);
 	  KB::Trsm<member_type,
 		   KB::Side::Left,KB::Uplo::Upper,KB::Trans::NoTranspose,KB::Diag::NonUnit,
 		   default_mode_type,default_algo_type>
-            ::invoke(member, 1.0, W, A);
+            ::invoke(member, one, W, A);
 	}
       }
 


### PR DESCRIPTION
@trilinos/ifpack2 

## Description

change 1.0 into scalar_type(1.0)

## Motivation and Context

KokkosKernels does not allow simd<float> and double arithmetic operations.  The caller should match the type.
 
## Related Issues

#5148 
