### PR TITLE
MueLu: add inverse scaling of composite residual

### DIFF
--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
@@ -82,6 +82,41 @@ using Teuchos::Array;
 using Teuchos::ArrayView;
 using Teuchos::ParameterList;
 
+/*! \brief Apply scaling to interface DOFs
+ *
+ * The vector scalingFactors contains the number of adjacent regions for every DOFs.
+ * In the interior of a region, this is always 1. On region interfaces, this is >1.
+ *
+ * We often need to scale interface entries by 1/N with N being the number of adjacent regions.
+ * This can be achieved by setting \c inverseScaling to \c true.
+ */
+template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+void scaleInterfaceDOFs(std::vector<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regVec, ///< Vector to be scaled
+    const std::vector<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& scalingFactors, ///< Vector with scaling factors
+    bool inverseScaling ///< Divide by scaling factors (yes/no?)
+    )
+{
+  using Vector = Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
+  using VectorFactory = Xpetra::VectorFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
+
+  const Scalar zero = Teuchos::ScalarTraits<Scalar>::zero();
+  const Scalar one = Teuchos::ScalarTraits<Scalar>::one();
+
+  for (std::size_t j = 0; j < regVec.size(); j++)
+  {
+    if (inverseScaling)
+    {
+      RCP<Vector> inverseScalingFactors = VectorFactory::Build(scalingFactors[j]->getMap());
+      inverseScalingFactors->reciprocal(*scalingFactors[j]);
+      regVec[j]->elementWiseMultiply(one, *regVec[j], *inverseScalingFactors, zero);
+    }
+    else
+    {
+      regVec[j]->elementWiseMultiply(one, *regVec[j], *scalingFactors[j], zero);
+    }
+  }
+}
+
 /*! \brief Transform regional matrix to composite layout
  *
  *  Starting from a \c Matrix in regional layout, we
@@ -1633,16 +1668,14 @@ void vCycle(const int l, ///< ID of current level
     computeResidual(regRes, fineRegX, fineRegB, regMatrices[l], compRowMaps[l],
                     quasiRegRowMaps[l], regRowMaps[l], regRowImporters[l]);
 
+    scaleInterfaceDOFs(regRes, regInterfaceScalings[l], true);
+
     // Transfer to coarse level
     std::vector<RCP<Vector> > coarseRegX(maxRegPerProc);
     std::vector<RCP<Vector> > coarseRegB(maxRegPerProc);
     for (int j = 0; j < maxRegPerProc; j++) {
       coarseRegX[j] = VectorFactory::Build(regRowMaps[l+1][j], true);
       coarseRegB[j] = VectorFactory::Build(regRowMaps[l+1][j], true);
-
-      RCP<Vector> inverseInterfaceScaling = VectorFactory::Build(regInterfaceScalings[l][j]->getMap());
-      inverseInterfaceScaling->reciprocal(*regInterfaceScalings[l][j]);
-      regRes[j]->elementWiseMultiply(SC_ONE, *regRes[j], *inverseInterfaceScaling, SC_ZERO);
 
       regProlong[l+1][j]->apply(*regRes[j], *coarseRegB[j], Teuchos::TRANS);
       TEUCHOS_ASSERT(regProlong[l+1][j]->getRangeMap()->isSameAs(*regRes[j]->getMap()));

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
@@ -1640,7 +1640,9 @@ void vCycle(const int l, ///< ID of current level
       coarseRegX[j] = VectorFactory::Build(regRowMaps[l+1][j], true);
       coarseRegB[j] = VectorFactory::Build(regRowMaps[l+1][j], true);
 
-      regRes[j]->elementWiseMultiply(SC_ONE, *regRes[j], *((regInterfaceScalings[l])[j]), SC_ZERO);
+      RCP<Vector> inverseInterfaceScaling = VectorFactory::Build(regInterfaceScalings[l][j]->getMap());
+      inverseInterfaceScaling->reciprocal(*regInterfaceScalings[l][j]);
+      regRes[j]->elementWiseMultiply(SC_ONE, *regRes[j], *inverseInterfaceScaling, SC_ZERO);
 
       regProlong[l+1][j]->apply(*regRes[j], *coarseRegB[j], Teuchos::TRANS);
       TEUCHOS_ASSERT(regProlong[l+1][j]->getRangeMap()->isSameAs(*regRes[j]->getMap()));

--- a/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
+++ b/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
@@ -1309,16 +1309,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
           computeResidual(regRes, regX, regB, regionGrpMats, dofMap,
               rowMapPerGrp, revisedRowMapPerGrp, rowImportPerGrp);
 
-          for (int j = 0; j < maxRegPerProc; j++) {
-            TEUCHOS_ASSERT(!(regInterfaceScalings[0])[j].is_null());
-
-            // Compute inverse factors, which are later to be used for scaling
-            RCP<Vector> inverseInterfaceScaling = VectorFactory::Build((regInterfaceScalings[0])[j]->getMap());
-            inverseInterfaceScaling->reciprocal(*((regInterfaceScalings[0])[j]));
-
-            // Do the actual scaling
-            regRes[j]->elementWiseMultiply(one, *regRes[j], *inverseInterfaceScaling, zero);
-          }
+          scaleInterfaceDOFs(regRes, regInterfaceScalings[0], true);
         }
 
         compRes = VectorFactory::Build(dofMap, true);


### PR DESCRIPTION
@trilinos/muelu 

## Description

When moving the residual from regional to composite, we need a scaling of interface values. This adds the scaling just prior to the convergence check in the outer fix-point iteration.

Maybe we need another scaling on the coarse level before entering the direct solver.

## Motivation and Context

As reported in #5135, the composite residual is twice as large at the interface as expected. Not good. This should address this.

## Related Issues

* Part of #5135

## How Has This Been Tested?

Builds locally. Compared composite residual as computed via r=b-Ax (with x=0) and computed via the region framework before entering the V-cycle. Now, they match.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.