### PR TITLE
MueLu: fixing configuration of no_int_no_serial nightly build on trap…

### DIFF
--- a/cmake/ctest/drivers/trappist/ctest_linux_nightly_mpi_release_muelu_no_int_no_serial_openmp_trappist.cmake
+++ b/cmake/ctest/drivers/trappist/ctest_linux_nightly_mpi_release_muelu_no_int_no_serial_openmp_trappist.cmake
@@ -89,6 +89,7 @@ SET(EXTRA_CONFIGURE_OPTIONS
   "-DTPL_ENABLE_HWLOC:BOOL=OFF"
 
   ### PACKAGES CONFIGURATION ###
+  "-DTrilinos_ENABLE_Epetra:BOOL=OFF"
   "-DMueLu_ENABLE_Experimental:BOOL=ON"
   "-DXpetra_ENABLE_Experimental:BOOL=ON"
 )


### PR DESCRIPTION
@trilinos/muelu 

## Description
The nightly build `Linux-GCC-5.3.0-OPENMPI_1.10.1_RELEASE_DEV_MueLu_NO_INT_NO_SERIAL_OPENMP` is failing at configure time due to an error thrown by Xpetra.

## Motivation and Context
The goal is to fix the configuration of said nightly to get coverage for the `no int` build back in the nightlies.


## Related Issues

* Closes #5180
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 