### PR TITLE
Piro: reporting final point to the wrapped ME at the end of NOX solve

### DIFF
--- a/packages/piro/src/Piro_InvertMassMatrixDecorator_Def.hpp
+++ b/packages/piro/src/Piro_InvertMassMatrixDecorator_Def.hpp
@@ -312,13 +312,10 @@ template<typename Scalar>
 void
 Piro::InvertMassMatrixDecorator<Scalar>::reportFinalPoint(
 #endif
-    const Thyra::ModelEvaluatorBase::InArgs<Scalar>& /* finalPoint */,
-    const bool /* wasSolved */)
+    const Thyra::ModelEvaluatorBase::InArgs<Scalar>& finalPoint,
+    const bool wasSolved)
 {
-  // TODO
-  TEUCHOS_TEST_FOR_EXCEPTION(true,
-         Teuchos::Exceptions::InvalidParameter,
-         "Calling reportFinalPoint in Piro_InvertMassMatrixDecorator_Def.hpp line 215" << std::endl);
+  model->reportFinalPoint(finalPoint,wasSolved);
 }
 
 #ifdef ALBANY_BUILD

--- a/packages/piro/src/Piro_NOXSolver_Def.hpp
+++ b/packages/piro/src/Piro_NOXSolver_Def.hpp
@@ -182,6 +182,12 @@ void Piro::NOXSolver<Scalar>::evalModelImpl(
           std::runtime_error,
           "Nonlinear solver failed to converge");
     }
+
+    auto final_point = model->createInArgs();
+    if (final_point.supports(Thyra::ModelEvaluatorBase::IN_ARG_x)) {
+      final_point.set_x(solver->get_current_x());
+    }
+    model->reportFinalPoint(final_point,solve_status.solveStatus==Thyra::SOLVE_STATUS_CONVERGED);
   }
 
   // Retrieve final solution to evaluate underlying model

--- a/packages/piro/src/Piro_TrapezoidRuleSolver_Def.hpp
+++ b/packages/piro/src/Piro_TrapezoidRuleSolver_Def.hpp
@@ -479,10 +479,7 @@ Piro::TrapezoidDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node>::reportFinal
     const Thyra::ModelEvaluatorBase::InArgs<Scalar>& finalPoint,
     const bool wasSolved)
 {
-  // TODO
-  TEUCHOS_TEST_FOR_EXCEPTION(true,
-         Teuchos::Exceptions::InvalidParameter,
-         "Calling reportFinalPoint in Piro_TrapezoidDecorator_Def.hpp" << std::endl);
+  this->getNonconstUnderlyingModel()->reportFinalPoint(finalPoint,wasSolved);
 }
 
 template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>

--- a/packages/piro/test/MockModelEval_A_Tpetra.cpp
+++ b/packages/piro/test/MockModelEval_A_Tpetra.cpp
@@ -223,12 +223,9 @@ MockModelEval_A_Tpetra::createInArgs() const
 
 void
 MockModelEval_A_Tpetra::reportFinalPoint(
-    const Thyra::ModelEvaluatorBase::InArgs<double>& finalPoint,
-    const bool wasSolved) {
-  TEUCHOS_TEST_FOR_EXCEPTION(
-      true,
-      Teuchos::Exceptions::InvalidParameter,
-      "Calling reportFinalPoint in " << __FILE__ << " line " << __LINE__ << std::endl);
+    const Thyra::ModelEvaluatorBase::InArgs<double>& /* finalPoint */,
+    const bool /* wasSolved */) {
+  // Do nothing  
 }
 
 Thyra::ModelEvaluatorBase::OutArgs<double>


### PR DESCRIPTION
@trilinos/nox 

## Description
<!--- Please describe your changes in detail. -->

Make Piro::NOXSolver set the final point into the underlying model. If the underlying model overrides `reportFinalPoint`, then other customers of the model can grab the final solution for their own use.

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->

I have two customers of a model ME: the NOXSolver, and another class, call it MyClass. Unfortunately, MyClass does not have access to the NOXSolver, so upon completion of the NOX solve, it can't get the solution from the NOX solver (in principle, it does not even know that the ME used to solve the model was Piro::NOXSolver either). With this modification, Piro::NOXSolver can set the solution in the model, so that MyClass can later access it (assuming that the underlying ME overrides `reportFinalPoint`, and can expose the reported final point, but that's not a concern of Piro::NOXSolver).

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
