### PR TITLE
MueLu: region driver coordinates

### DIFF
--- a/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
+++ b/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
@@ -1174,8 +1174,11 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
   nullspace[0]->putScalar(one);
 
   // create region coordinates vector
-  regionCoordinates[0] = Xpetra::MultiVectorFactory<real_type,LO,GO,NO>::Build(revisedRowMapPerGrp[0],
+  regionCoordinates[0] = Xpetra::MultiVectorFactory<real_type,LO,GO,NO>::Build(rowMapPerGrp[0],
                                                                                numDimensions);
+  regionCoordinates[0]->doImport(*coordinates, *rowImportPerGrp[0], Xpetra::INSERT);
+  regionCoordinates[0]->replaceMap(revisedRowMapPerGrp[0]);
+
   using Tpetra_CrsMatrix = Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
   using Tpetra_MultiVector = Tpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
 

--- a/packages/muelu/src/Transfers/GeneralGeometric/MueLu_GeometricInterpolationPFactory_def.hpp
+++ b/packages/muelu/src/Transfers/GeneralGeometric/MueLu_GeometricInterpolationPFactory_def.hpp
@@ -49,6 +49,8 @@
 #include "Xpetra_CrsGraph.hpp"
 #include "Xpetra_CrsMatrixUtils.hpp"
 
+#include "Xpetra_IO.hpp"
+
 #include "MueLu_MasterList.hpp"
 #include "MueLu_Monitor.hpp"
 #include "MueLu_Aggregates.hpp"


### PR DESCRIPTION
@trilinos/muelu 

## Description
Fixing coordinates in the region driver, the logic around them was never properly put in place...

## Motivation and Context
This fixes a bug which prevents from computing the appropriate prolongator in region format