### PR TITLE
MueLu: region driver lexicographic regions in 3D

### DIFF
--- a/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
+++ b/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
@@ -556,6 +556,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
       receivePIDs[countIDs] = myRank - procsPerDim[0] - 1
           - procsPerDim[1]*procsPerDim[0];
       ++countIDs;
+
       // Receive front-bottom edge nodes
       for(LO i = 0; i < lNodesPerDim[0]; ++i) {
         receiveGIDs[countIDs] = startGID - gNodesPerDim[0]*gNodesPerDim[1]
@@ -563,15 +564,14 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
         receivePIDs[countIDs] = myRank - procsPerDim[0]*procsPerDim[1] - procsPerDim[0];
         ++countIDs;
       }
-      // Receive left-bottom edge nodes
+
+      // Recieve left-bottom edge nodes
       for(LO j = 0; j < lNodesPerDim[1]; ++j) {
         receiveGIDs[countIDs] = startGID - gNodesPerDim[0]*gNodesPerDim[1]
               - 1 + j*gNodesPerDim[0];
         receivePIDs[countIDs] = myRank - procsPerDim[0]*procsPerDim[1] - 1;
         ++countIDs;
-      }
-      // Receive bottom face nodes
-      for(LO j = 0; j < lNodesPerDim[1]; ++j) {
+        // Recieve bottom face nodes
         for(LO i = 0; i < lNodesPerDim[0]; ++i) {
           receiveGIDs[countIDs] = startGID - gNodesPerDim[0]*gNodesPerDim[1]
               + i
@@ -580,24 +580,21 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
           ++countIDs;
         }
       }
+
       // Receive front-left edge nodes
-      for(LO k = 0; k < lNodesPerDim[1]; ++k) {
+      for(LO k = 0; k < lNodesPerDim[2]; ++k) {
         receiveGIDs[countIDs] = startGID - gNodesPerDim[0]
               - 1 + k*gNodesPerDim[0]*gNodesPerDim[1];
         receivePIDs[countIDs] = myRank - procsPerDim[0] - 1;
         ++countIDs;
-      }
-      // Receive front face nodes
-      for(LO k = 0; k < lNodesPerDim[2]; ++k) {
+        // Receive front face nodes
         for(LO i = 0; i < lNodesPerDim[0]; ++i) {
           receiveGIDs[countIDs] = startGID - gNodesPerDim[0] + i
               + k*(gNodesPerDim[1]*gNodesPerDim[0]);
           receivePIDs[countIDs] = myRank - procsPerDim[0];
           ++countIDs;
         }
-      }
-      // Receive left face nodes
-      for(LO k = 0; k < lNodesPerDim[2]; ++k) {
+        // Receive left face nodes
         for(LO j = 0; j < lNodesPerDim[1]; ++j) {
           receiveGIDs[countIDs] = startGID - 1
               + j*gNodesPerDim[0]
@@ -656,9 +653,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
           + startGID - gNodesPerDim[1]*gNodesPerDim[0] - 1;
         receivePIDs[countIDs] =  myRank - procsPerDim[1]*procsPerDim[0] - 1;
         ++countIDs;
-      }
-      // Receive bottom face nodes
-      for(LO j = 0; j < lNodesPerDim[1]; ++j) {
+        // Receive bottom face nodes
         for(LO i = 0; i < lNodesPerDim[0]; ++i) {
           receiveGIDs[countIDs] = j*gNodesPerDim[0] + i
             + startGID - gNodesPerDim[1]*gNodesPerDim[0];
@@ -689,18 +684,14 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
           + startGID - gNodesPerDim[0] - 1;
         receivePIDs[countIDs] =  myRank - procsPerDim[0] - 1;
         ++countIDs;
-      }
-      // Receive front face nodes
-      for(LO k = 0; k < lNodesPerDim[2]; ++k) {
+        // Receive front face nodes
         for(LO i = 0; i < lNodesPerDim[0]; ++i) {
           receiveGIDs[countIDs] = k*gNodesPerDim[1]*gNodesPerDim[0] + i
             + startGID - gNodesPerDim[0];
           receivePIDs[countIDs] = myRank - procsPerDim[0];
           ++countIDs;
         }
-      }
-      // Receive left face nodes
-      for(LO k = 0; k < lNodesPerDim[2]; ++k) {
+        // Receive left face nodes
         for(LO j = 0; j < lNodesPerDim[1]; ++j) {
           receiveGIDs[countIDs] = k*gNodesPerDim[1]*gNodesPerDim[0] + j*gNodesPerDim[0]
             + startGID - 1;


### PR DESCRIPTION

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/muelu 

## Description
Slight change to the structured region driver so that region created for the 3D problem have a lexicographic ordering.

## Motivation and Context
The structured regions need lexicographical ordering.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->

<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
