### PR TITLE
Fix warnings and set Werror for Amesos in GCC 7.2.0 build

### DIFF
--- a/cmake/std/PullRequestLinuxGCC7.2.0TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxGCC7.2.0TestingSettings.cmake
@@ -25,7 +25,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/PullRequestLinuxCommonTestingSettings.cmake")
 # Adding warnings as errors flags to this PR build
 set(CMAKE_CXX_FLAGS "-Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-nonnull-compare -Wno-address -Wno-inline -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS" CACHE STRING "Warning settings")
 
-#set (Amesos_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")
+set (Amesos_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")
 set (Amesos2_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")
 #set (Anasazi_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")
 #set (AztecOO_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")

--- a/packages/amesos/src/CrsMatrixTranspose.cpp
+++ b/packages/amesos/src/CrsMatrixTranspose.cpp
@@ -50,8 +50,9 @@
 
 int CrsMatrixTranspose( Epetra_CrsMatrix *In,  Epetra_CrsMatrix *Out ) { 
 
+#ifndef NDEBUG
   int ierr = 0;
-   
+#endif
   int iam = In->Comm().MyPID() ;
 
   long long numentries = In->NumGlobalNonzeros64();
@@ -80,7 +81,10 @@ int CrsMatrixTranspose( Epetra_CrsMatrix *In,  Epetra_CrsMatrix *Out ) {
     std::vector <int>RowsPerCol( numcols ) ; 
     for ( int i = 0 ; i < numcols ; i++ ) RowsPerCol[i] = 0 ; 
     for ( int MyRow = 0; MyRow <numrows; MyRow++ ) {
-      ierr = In->ExtractMyRowView( MyRow, NumRowEntries, RowValues, ColIndices );
+#ifndef NDEBUG
+      ierr =
+#endif
+      In->ExtractMyRowView( MyRow, NumRowEntries, RowValues, ColIndices );
       assert( ierr == 0 ) ;
       for ( int j = 0; j < NumRowEntries; j++ ) { 
 	RowsPerCol[ ColIndices[j] ] ++ ; 
@@ -98,7 +102,10 @@ int CrsMatrixTranspose( Epetra_CrsMatrix *In,  Epetra_CrsMatrix *Out ) {
     //  Populate Ai and Aval 
     //
     for ( int MyRow = 0; MyRow <numrows; MyRow++ ) {
-      ierr = In->ExtractMyRowView( MyRow, NumRowEntries, RowValues, ColIndices );
+#ifndef NDEBUG
+      ierr =
+#endif
+      In->ExtractMyRowView( MyRow, NumRowEntries, RowValues, ColIndices );
       assert( ierr == 0 ) ;
       for ( int j = 0; j < NumRowEntries; j++ ) { 
 	Ai[ nextAp[ ColIndices[j] ] ] = MyRow ; 
@@ -122,7 +129,10 @@ int CrsMatrixTranspose( Epetra_CrsMatrix *In,  Epetra_CrsMatrix *Out ) {
     assert( In->NumMyRows() == 0 ) ; 
   }
 
-  ierr = Out->FillComplete();
+#ifndef NDEBUG
+  ierr =
+#endif
+  Out->FillComplete();
   assert( ierr==0 ) ;
   return 0 ; 
 }

--- a/packages/amesos/test/TestOptions/CreateTridi.cpp
+++ b/packages/amesos/test/TestOptions/CreateTridi.cpp
@@ -58,8 +58,9 @@ int CreateTridi(Epetra_CrsMatrix& A)
 
   double *Values = new double[3];
   int *Indices = new int[3];
+#ifndef NDEBUG
   int NumEntries;
-  
+#endif
   for (int i=0; i<NumMyElements; i++)
     {
     if (MyGlobalElements[i]==0)
@@ -68,7 +69,9 @@ int CreateTridi(Epetra_CrsMatrix& A)
 	Indices[1] = 1;
 	Values[0] = 2.0;
 	Values[1] = -1.0;
+#ifndef NDEBUG
 	NumEntries = 2;
+#endif
       }
     else if (MyGlobalElements[i] == NumGlobalElements-1)
       {
@@ -76,7 +79,9 @@ int CreateTridi(Epetra_CrsMatrix& A)
 	Indices[1] = NumGlobalElements-2;
 	Values[0] = 2.0;
 	Values[1] = -1.0;
+#ifndef NDEBUG
 	NumEntries = 2;
+#endif
       }
     else
       {
@@ -86,7 +91,9 @@ int CreateTridi(Epetra_CrsMatrix& A)
 	Values[0] = -1.0; 
 	Values[1] = 2.0;
 	Values[2] = -1.0;
+#ifndef NDEBUG
 	NumEntries = 3;
+#endif
       }
     
     assert(A.InsertGlobalValues(MyGlobalElements[i], NumEntries, Values, Indices)==0);
@@ -121,8 +128,9 @@ int CreateTridiPlus(Epetra_CrsMatrix& A)
 
   double *Values = new double[3];
   int *Indices = new int[3];
+#ifndef NDEBUG
   int NumEntries;
-  
+#endif
   for (int i=0; i<NumMyElements; i++)
     {
     if (MyGlobalElements[i]==0)
@@ -133,7 +141,9 @@ int CreateTridiPlus(Epetra_CrsMatrix& A)
 	Values[0] = 2.0;
 	Values[1] = -1.0;
 	Values[2] = -0.5;
+#ifndef NDEBUG
 	NumEntries = 3;
+#endif
       }
     else if (MyGlobalElements[i] == NumGlobalElements-1)
       {
@@ -143,7 +153,9 @@ int CreateTridiPlus(Epetra_CrsMatrix& A)
 	Values[0] = 2.0;
 	Values[1] = -1.0;
 	Values[2] = -0.5;
+#ifndef NDEBUG
 	NumEntries = 3;
+#endif
       }
     else
       {
@@ -153,7 +165,9 @@ int CreateTridiPlus(Epetra_CrsMatrix& A)
 	Values[0] = -1.0; 
 	Values[1] = 2.0;
 	Values[2] = -1.0;
+#ifndef NDEBUG
 	NumEntries = 3;
+#endif
       }
     
     assert(A.InsertGlobalValues(MyGlobalElements[i], NumEntries, Values, Indices)==0);

--- a/packages/amesos/test/TestOptions/NewMatNewMap.cpp
+++ b/packages/amesos/test/TestOptions/NewMatNewMap.cpp
@@ -68,9 +68,9 @@ RCP<Epetra_CrsMatrix> NewMatNewMap(Epetra_CrsMatrix& In,
   if ( Diagonal == 2 ) { 
     assert( ReindexRowMap==0 && ReindexColMap == 0 ) ; 
   }
-
+#ifndef NDEBUG
   int ierr = 0;
-
+#endif
   int (*RowPermute)(int in) = 0;
   int (*ColPermute)(int in) = 0;
 
@@ -268,7 +268,10 @@ RCP<Epetra_CrsMatrix> NewMatNewMap(Epetra_CrsMatrix& In,
     {
 
       int NumIndicesThisRow = 0;
-      ierr = In.ExtractMyRowCopy( i, 
+#ifndef NDEBUG
+      ierr =
+#endif
+	  In.ExtractMyRowCopy( i,
 				   In.MaxNumEntries(),
 				   NumIndicesThisRow,
 				   &ThisRowValues[0],
@@ -314,7 +317,10 @@ RCP<Epetra_CrsMatrix> NewMatNewMap(Epetra_CrsMatrix& In,
 	NumIndicesThisRow++  ;
 
       } 
-      ierr = Out->InsertGlobalValues( MyPermutedGlobalRowElements[i], 
+#ifndef NDEBUG
+      ierr =
+#endif
+	  Out->InsertGlobalValues( MyPermutedGlobalRowElements[i],
 				       NumIndicesThisRow,
 				       &ThisRowValues[0],
 				       &PermutedGlobalColIndices[0] );
@@ -358,10 +364,16 @@ RCP<Epetra_CrsMatrix> NewMatNewMap(Epetra_CrsMatrix& In,
     break;
   }
 #if 0
-  ierr = Out->FillComplete( *PermutedDomainMap, *PermutedRangeMap );
+#ifndef NDEBUG
+  ierr =
+#endif
+  Out->FillComplete( *PermutedDomainMap, *PermutedRangeMap );
   assert( ierr == 0 );
 #else
-  ierr = Out->FillComplete( *OutDomainMap, *OutRangeMap );
+#ifndef NDEBUG
+  ierr =
+#endif
+  Out->FillComplete( *OutDomainMap, *OutRangeMap );
   assert( ierr == 0 );
 #endif
 

--- a/packages/amesos/test/TestOptions/PerformOneSolveAndTest.cpp
+++ b/packages/amesos/test/TestOptions/PerformOneSolveAndTest.cpp
@@ -91,9 +91,9 @@ int PerformOneSolveAndTest( const char* AmesosClass,
 			    double& relresidual,
 			    int ExpectedError )
 {
-
+#ifndef NDEBUG
   int ierr = 0;
-
+#endif
   bool AddToAllDiagonalElements =  ParamList.get( "AddZeroToDiag", false ) ;
 
 
@@ -121,12 +121,18 @@ int PerformOneSolveAndTest( const char* AmesosClass,
   case 2:
     MyMat->OptimizeStorage(); 
     MyRowMat = &*MyMat ; 
-    bool OptStorage = MyMat->StorageOptimized();
+#ifndef NDEBUG
+    bool OptStorage =
+#endif
+    MyMat->StorageOptimized();
     assert( OptStorage) ; 
     break;
   }
-  bool OptStorage = MyMat->StorageOptimized();
-  
+#ifndef NDEBUG
+  bool OptStorage =
+#endif
+  MyMat->StorageOptimized();
+
   Epetra_CrsMatrix* MatPtr = &*MyMat ;
 
   const std::string AC = AmesosClass ;
@@ -165,10 +171,16 @@ int PerformOneSolveAndTest( const char* AmesosClass,
     Epetra_Vector AddConstVecToDiag( MyMatWithDiag->RowMap() );
     AddConstVecToDiag.PutScalar( AddToDiag );
 
-    ierr = MyMatWithDiag->ExtractDiagonalCopy( Diag );
+#ifndef NDEBUG
+    ierr =
+#endif
+    MyMatWithDiag->ExtractDiagonalCopy( Diag );
     assert( ierr == 0 );
     Diag.Update( 1.0, AddConstVecToDiag, 1.0 ) ; 
-    ierr = MyMatWithDiag->ReplaceDiagonalValues( Diag );   // This may return 1 indicating that structurally non-zero elements were left untouched. 
+#ifndef NDEBUG
+    ierr =
+#endif
+    MyMatWithDiag->ReplaceDiagonalValues( Diag );   // This may return 1 indicating that structurally non-zero elements were left untouched.
     assert( ierr >= 0 );
 
       InMat->SetTracebackMode( oldtracebackmode ) ;   

--- a/packages/amesos/test/TestOptions/TestOptions.cpp
+++ b/packages/amesos/test/TestOptions/TestOptions.cpp
@@ -155,12 +155,15 @@ int CreateCrsMatrix( const char *in_filename, const Epetra_Comm &Comm,
 
   Epetra_CrsMatrix *serialA ;
   Epetra_CrsMatrix *transposeA;
-
+#ifndef NDEBUG
   int ierr = 0;
-
+#endif
   if ( transpose ) {
     transposeA = new Epetra_CrsMatrix( Copy, *readMap, 0 );
-    ierr = CrsMatrixTranspose( readA, transposeA );
+#ifndef NDEBUG
+    ierr =
+#endif
+    CrsMatrixTranspose( readA, transposeA );
     assert( ierr == 0 );
     serialA = transposeA ;
     delete readA;
@@ -191,7 +194,10 @@ int CreateCrsMatrix( const char *in_filename, const Epetra_Comm &Comm,
 
     Epetra_CrsMatrix *Amat = new Epetra_CrsMatrix( Copy, DistMap, 0 );
     Amat->Export(*serialA, exporter, Add);
-    ierr = Amat->FillComplete();
+#ifndef NDEBUG
+    ierr =
+#endif
+    Amat->FillComplete();
     assert(ierr == 0);
 
     Matrix = Amat;

--- a/packages/amesos/test/Test_Epetra_CrsMatrix/cxx_main.cpp
+++ b/packages/amesos/test/Test_Epetra_CrsMatrix/cxx_main.cpp
@@ -165,9 +165,9 @@ int main(int argc, char *argv[])
   SolverType.push_back("Amesos_Mumps");
   SolverType.push_back("Amesos_Dscpack");
   SolverType.push_back("Amesos_Scalapack");
-
+#ifndef NDEBUG
   bool res;
-
+#endif
   // If a given test fails, than the code stops, due to the assert()
   // statement.
   for (unsigned int i = 0 ; i < SolverType.size() ; ++i) 
@@ -179,7 +179,10 @@ int main(int argc, char *argv[])
       if (1) {
 	// solve with matrix
 	Teuchos::ParameterList AmesosList;
-	res = TestAmesos((char*)Solver.c_str(), AmesosList, false, 
+#ifndef NDEBUG
+	res =
+#endif
+    TestAmesos((char*)Solver.c_str(), AmesosList, false,
                          &Matrix, &LHS, &RHS);
         assert (res == true);
       }
@@ -187,7 +190,10 @@ int main(int argc, char *argv[])
 	// solve transpose with matrix
 	if (Solver != "Amesos_Superludist") {// still not implementes
 	  Teuchos::ParameterList AmesosList;
-	  res  = TestAmesos((char*)Solver.c_str(), AmesosList, true, 
+#ifndef NDEBUG
+	  res  =
+#endif
+      TestAmesos((char*)Solver.c_str(), AmesosList, true,
                             &Matrix, &LHS, &RHS);
           assert (res == true);
 	}

--- a/packages/amesos/test/Test_Epetra_RowMatrix/cxx_main.cpp
+++ b/packages/amesos/test/Test_Epetra_RowMatrix/cxx_main.cpp
@@ -124,9 +124,9 @@ void driver(Epetra_Comm& Comm, const bool IsSymmetric, const bool UseTranspose,
   Amesos_TestRowMatrix A(Matrix);
 
   Amesos Factory;  
-  
+#ifndef NDEBUG
   bool res;
-
+#endif
   // If a given test fails, than the code stops, bue to the assert()
   // statement.
   for (unsigned int i = 0 ; i < SolverType.size() ; ++i) 
@@ -138,13 +138,19 @@ void driver(Epetra_Comm& Comm, const bool IsSymmetric, const bool UseTranspose,
       // solve with matrix
       Teuchos::ParameterList AmesosList;
       AmesosList.set("Redistribute",true);
-      res = TestAmesos((char*)Solver.c_str(), AmesosList, false, 
+#ifndef NDEBUG
+      res =
+#endif
+      TestAmesos((char*)Solver.c_str(), AmesosList, false,
                        &A, &LHS, &RHS);
       assert (res == true);
       if (UseTranspose) {
         // solve transpose with matrix
         Teuchos::ParameterList AmesosList;
-        res  = TestAmesos((char*)Solver.c_str(), AmesosList, true, 
+#ifndef NDEBUG
+        res  = 
+#endif
+        TestAmesos((char*)Solver.c_str(), AmesosList, true,
                           &A, &LHS, &RHS);
         assert (res == true);
       }


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework 
@trilinos/amesos 

## Description
<!--- Please describe your changes in detail. -->
Fixed warnings and set Werror for Amesos in the GC 7.2.0 PR build.
Wrapped variables only used by asserts in #ifndef NDEBUG Werror sees as unused.
## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
This completes #5102 and is work toward Issue #3178, eventually setting -Werror for all packages.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->
This was tested in debug and release Jenkins builds.
<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
