### PR TITLE
Ifpack2: Fix #5225

### DIFF
--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestRelaxation.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestRelaxation.cpp
@@ -199,7 +199,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2Relaxation, Test2, Scalar, LocalOrdinal
                 y.template getLocalView<Kokkos::HostSpace> ().data ());
 #else
   TEST_EQUALITY(x.getLocalViewHost ().data (),
-                y.template getLocalViewHost ().data ());
+                y.getLocalViewHost ().data ());
 #endif
 
   prec.apply(x, y);


### PR DESCRIPTION
@trilinos/ifpack2

## Description

Fix Clang build error in test.

## Motivation and Context

The build issue hinders ATDM-related `Ifpack2::Chebyshev` optimization work.

## Related Issues

* Closes #5225 

## How Has This Been Tested?

Local build of Ifpack2 tests with stock Mac on Clang, with Kokkos deprecated code disabled.