### PR TITLE
MueLu: fix structured aggregation with linear interpolation

### DIFF
--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
@@ -1028,7 +1028,7 @@ void MakeCoarseLevelMaps2(const int maxRegPerGID,
     size_t countComposites = 0, countDuplicates = 0;
     Array<LO> fineDuplicateLIDs(numFineDuplicateNodes);
     for(size_t regionIdx = 0; regionIdx < numFineRegionNodes; ++regionIdx) {
-      if(compositeToRegionLIDs[countComposites] == regionIdx) {
+      if(compositeToRegionLIDs[countComposites] == static_cast<LO>(regionIdx)) {
         ++countComposites;
       } else {
         fineDuplicateLIDs[countDuplicates] = regionIdx;

--- a/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
+++ b/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
@@ -147,7 +147,6 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
   SC zero = STS::zero(), one = STS::one();
   using real_type = typename STS::coordinateType;
   using RealValuedMultiVector = Xpetra::MultiVector<real_type,LO,GO,NO>;
-  const real_type realOne = Teuchos::ScalarTraits<real_type>::one();
 
   // =========================================================================
   // Parameters initialization
@@ -1278,7 +1277,6 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
     /////////////////////////////////////////////////////////////////////////
 
     // define max iteration counts
-    const int maxFineIter = 20;
     const int maxCoarseIter = 100;
 
     // Prepare output of residual norm to file
@@ -1293,6 +1291,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
       }
 
     // Richardson iterations
+    typename Teuchos::ScalarTraits<Scalar>::magnitudeType normResIni;
     for (int cycle = 0; cycle < maxIts; ++cycle) {
       // check for convergence
       {
@@ -1310,6 +1309,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
         regionalToComposite(regRes, compRes, maxRegPerProc, rowMapPerGrp,
                             rowImportPerGrp, Xpetra::ADD);
         typename Teuchos::ScalarTraits<Scalar>::magnitudeType normRes = compRes->norm2();
+        if(cycle == 0) { normResIni = normRes; }
 
         // Output current residual norm to screen (on proc 0 only)
         if (myRank == 0)
@@ -1318,7 +1318,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
             (*log) << cycle << "\t" << normRes << "\n";
           }
 
-        if (normRes < tol)
+        if ((normRes/normResIni) < tol)
           break;
       }
 

--- a/packages/muelu/research/tawiesn/aria/Driver.cpp
+++ b/packages/muelu/research/tawiesn/aria/Driver.cpp
@@ -152,7 +152,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib lib, int arg
     // =========================================================================
     // Convenient definitions
     // =========================================================================
-    SC zero = Teuchos::ScalarTraits<SC>::zero(), one = Teuchos::ScalarTraits<SC>::one();
+    SC zero = Teuchos::ScalarTraits<SC>::zero();
 
     // Instead of checking each time for rank, create a rank 0 stream
     RCP<Teuchos::FancyOStream> fancy = Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
@@ -376,7 +376,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib lib, int arg
 
     temp = IO::ReadMultiVector ("rhs.mm", dofLinearMap);
     RHS->doImport(*temp, *dofImporter, Xpetra::INSERT);
-    LHS->putScalar(Teuchos::ScalarTraits<Scalar>::zero());
+    LHS->putScalar(zero);
 
     // MueLu part
 

--- a/packages/muelu/src/Graph/StructuredAggregation/MueLu_AggregationStructuredAlgorithm_def.hpp
+++ b/packages/muelu/src/Graph/StructuredAggregation/MueLu_AggregationStructuredAlgorithm_def.hpp
@@ -336,7 +336,6 @@ namespace MueLu {
     Array<LO> ghostedIdx(3,0);
     Array<LO> coarseIdx(3,0);
     Array<LO> ijkRem(3,0);
-    int rate = 0;
     const LO coarsePointOffset[8][3] = {{0, 0, 0}, {1, 0, 0}, {0, 1, 0}, {1, 1, 0},
                                         {0, 0, 1}, {1, 0, 1}, {0, 1, 1}, {1, 1, 1}};
 
@@ -347,15 +346,16 @@ namespace MueLu {
       for(int dim=0; dim < numDimensions; dim++){
         coarseIdx[dim] = ghostedIdx[dim] / geoData->getCoarseningRate(dim);
         ijkRem[dim]    = ghostedIdx[dim] % geoData->getCoarseningRate(dim);
-        if(ghostedIdx[dim] - geoData->getOffset(dim)
-           < geoData->getLocalFineNodesInDir(dim) - geoData->getCoarseningEndRate(dim)) {
-          rate = geoData->getCoarseningRate(dim);
+        if(coupled) {
+          if (geoData->getStartGhostedCoarseNode(dim)*geoData->getCoarseningRate(dim)
+                       > geoData->getStartIndex(dim)) {
+            --coarseIdx[dim];
+          }
         } else {
-          rate = geoData->getCoarseningEndRate(dim);
+          if(ghostedIdx[dim] == geoData->getLocalFineNodesInDir(dim) - 1) {
+            coarseIdx[dim] = geoData->getLocalCoarseNodesInDir(dim) - 1;
+          }
         }
-        if(ijkRem[dim] > (rate / 2)) {++coarseIdx[dim];}
-        if(coupled && (geoData->getStartGhostedCoarseNode(dim)*geoData->getCoarseningRate(dim)
-                       > geoData->getStartIndex(dim))) {--coarseIdx[dim];}
       }
 
       // Fill Graph

--- a/packages/muelu/src/Graph/StructuredAggregation/MueLu_StructuredAggregationFactory_def.hpp
+++ b/packages/muelu/src/Graph/StructuredAggregation/MueLu_StructuredAggregationFactory_def.hpp
@@ -305,6 +305,7 @@ namespace MueLu {
       myStructuredAlgorithm = rcp(new AggregationStructuredAlgorithm(graphFact));
 
     if(interpolationOrder == 0 && outputAggregates){
+      // Create aggregates for prolongation
       RCP<Aggregates> aggregates = rcp(new Aggregates(graph->GetDomainMap()));
       aggregates->setObjectLabel("ST");
       aggregates->SetIndexManager(geoData);
@@ -323,7 +324,7 @@ namespace MueLu {
       Set(currentLevel, "Aggregates", aggregates);
 
     } else {
-      // Create Coarse Data
+      // Create the graph of the prolongator
       RCP<CrsGraph> myGraph;
       myStructuredAlgorithm->BuildGraph(*graph, geoData, dofsPerNode, myGraph,
                                         coarseCoordinatesFineMap, coarseCoordinatesMap);


### PR DESCRIPTION
When one uses linear interpolation, the reference coarse point associated with a given fine point is not the same as the reference coarse point chosen for piece wise constant interpolation.
This should be fixed now.

@trilinos/muelu 

## Description
The graph generated by structured aggregation is wrong when linear interpolation is requested.

## Motivation and Context
This fixes an algorithmic bug that leads to severely degraded performance.

## How Has This Been Tested?
This has been tested on my local machine and algorithmic correctness is verified by checking a small example by hand.

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.
