### PR TITLE
Xpetra: guard use of EpetraNode in Xpetra::TpetraOperator specialization.

### DIFF
--- a/packages/xpetra/src/Operator/Xpetra_TpetraOperator.hpp
+++ b/packages/xpetra/src/Operator/Xpetra_TpetraOperator.hpp
@@ -195,7 +195,7 @@ namespace Xpetra {
 #endif
 
 
-#if ((!defined(HAVE_TPETRA_INST_SERIAL)) && (!defined(HAVE_TPETRA_INST_INT_LONG_LONG)))
+#if ((!defined(HAVE_TPETRA_INST_SERIAL)) && (!defined(HAVE_TPETRA_INST_INT_LONG_LONG)) && defined(HAVE_XPETRA_EPETRA))
   // specialization for Tpetra Map on EpetraNode and GO=int
   template <>
   class TpetraOperator<double, int, long long, EpetraNode>


### PR DESCRIPTION
Fix issue #5251.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trilinos/trilinos/5252)
<!-- Reviewable:end -->
