### PR TITLE
Xpetra: fix Xpetra::Tpetra_operator specialization 

### DIFF
--- a/packages/xpetra/src/Operator/Xpetra_TpetraOperator.hpp
+++ b/packages/xpetra/src/Operator/Xpetra_TpetraOperator.hpp
@@ -131,7 +131,7 @@ namespace Xpetra {
 
 
 
-#if ((!defined(HAVE_TPETRA_INST_SERIAL)) && (!defined(HAVE_TPETRA_INST_INT_INT)))
+#if ((!defined(HAVE_TPETRA_INST_SERIAL)) && (!defined(HAVE_TPETRA_INST_INT_INT)) && defined(HAVE_XPETRA_EPETRA))
   // specialization for Tpetra Map on EpetraNode and GO=int
   template <>
   class TpetraOperator<double, int, int, EpetraNode>


### PR DESCRIPTION
@trilinos/xpetra 

## Description
It looks like the guard in `Xpetra_TpetraOperator.hpp` for the specialization of the class on `EpetraNode` does not check that Epetra has been enabled.

## Motivation and Context
I am observing build failures when Tpetra has no int and no serial instantiation and Epetra is not enabled.


## Related Issues

* Closes #5293
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of

## How Has This Been Tested?
A local build was successfully performed with the problematic configuration.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
