### PR TITLE
Xpetra: fix MultiVector unit-test for Epetra=OFF configuration, see issue #5300

### DIFF
--- a/packages/muelu/test/unit_tests/Adapters/CreatePreconditioner.cpp
+++ b/packages/muelu/test/unit_tests/Adapters/CreatePreconditioner.cpp
@@ -98,8 +98,6 @@ namespace MueLuTests {
     Xpetra::UnderlyingLib          lib  = TestHelpers::Parameters::getLib();
     RCP<const Teuchos::Comm<int> > comm = TestHelpers::Parameters::getDefaultComm();
 
-    GO nx = 1000;
-
     std::string xmlFileName = "test.xml";
 
     if (lib == Xpetra::UseTpetra) {
@@ -111,6 +109,7 @@ namespace MueLuTests {
       typedef Tpetra::MultiVector<real_type,LO,GO,NO> dtpetra_multivector_type;
 
       // Matrix
+      GO nx = 1000;
       RCP<Matrix>     Op  = TestHelpers::TestFactory<SC, LO, GO, NO>::Build1DPoisson(nx * comm->getSize(), lib);
       RCP<const Map > map = Op->getRowMap();
 
@@ -209,6 +208,7 @@ namespace MueLuTests {
 #ifdef HAVE_MUELU_EPETRA
 
       // Matrix
+      GO nx = 1000;
       RCP<Matrix>     Op  = TestHelpers::TestFactory<SC, LO, GO, NO>::Build1DPoisson(nx * comm->getSize(), lib);
       RCP<const Map > map = Op->getRowMap();
 
@@ -304,8 +304,6 @@ namespace MueLuTests {
     Xpetra::UnderlyingLib          lib  = TestHelpers::Parameters::getLib();
     RCP<const Teuchos::Comm<int> > comm = TestHelpers::Parameters::getDefaultComm();
 
-    GO nx = 1000;
-
     Teuchos::ParameterList mylist;
     mylist.set("xml parameter file","test.xml");
 
@@ -314,6 +312,7 @@ namespace MueLuTests {
       typedef Tpetra::Operator<SC,LO,GO,NO> tpetra_operator_type;
 
       // Matrix
+      GO nx = 1000;
       RCP<Matrix>     Op  = TestHelpers::TestFactory<SC, LO, GO, NO>::Build1DPoisson(nx * comm->getSize(), lib);
       RCP<const Map > map = Op->getRowMap();
 
@@ -409,6 +408,7 @@ namespace MueLuTests {
     } else if (lib == Xpetra::UseEpetra) {
 #ifdef HAVE_MUELU_EPETRA
       // Matrix
+      GO nx = 1000;
       RCP<Matrix>     Op  = TestHelpers::TestFactory<SC, LO, GO, NO>::Build1DPoisson(nx * comm->getSize(), lib);
       RCP<const Map > map = Op->getRowMap();
 
@@ -498,8 +498,6 @@ namespace MueLuTests {
     Xpetra::UnderlyingLib          lib  = TestHelpers::Parameters::getLib();
     RCP<const Teuchos::Comm<int> > comm = TestHelpers::Parameters::getDefaultComm();
 
-    GO nx = 972;
-
     for (int k = 0; k < 2; k++) {
       std::string xmlFileName;
       if (k == 0) xmlFileName = "testPDE.xml";
@@ -512,6 +510,7 @@ namespace MueLuTests {
         int numPDEs=3;
 
         // Matrix
+        GO nx = 972;
         RCP<Matrix>     Op  = TestHelpers::TestFactory<SC, LO, GO, NO>::Build1DPoisson(nx * comm->getSize(), lib);
         RCP<const Map > map = Op->getRowMap();
 
@@ -595,6 +594,7 @@ namespace MueLuTests {
         int numPDEs=3;
 
         // Matrix
+        GO nx = 972;
         RCP<Matrix>     Op  = TestHelpers::TestFactory<SC, LO, GO, NO>::Build1DPoisson(nx * comm->getSize(), lib);
         RCP<const Map > map = Op->getRowMap();
 
@@ -688,7 +688,6 @@ namespace MueLuTests {
     Xpetra::UnderlyingLib          lib  = TestHelpers::Parameters::getLib();
     RCP<const Teuchos::Comm<int> > comm = TestHelpers::Parameters::getDefaultComm();
 
-    GO nx = 1000;
     std::string xmlFileName = "testReuse.xml";
 
     if (lib == Xpetra::UseTpetra) {
@@ -696,6 +695,7 @@ namespace MueLuTests {
       typedef Tpetra::Operator<SC,LO,GO,NO> tpetra_operator_type;
 
       // Matrix
+      GO nx = 1000;
       RCP<Matrix>     Op  = TestHelpers::TestFactory<SC, LO, GO, NO>::Build1DPoisson(nx * comm->getSize(), lib);
       RCP<const Map > map = Op->getRowMap();
 
@@ -742,6 +742,7 @@ namespace MueLuTests {
     } else if (lib == Xpetra::UseEpetra) {
 #ifdef HAVE_MUELU_EPETRA
       // Matrix
+      GO nx = 1000;
       RCP<Matrix>     Op  = TestHelpers::TestFactory<SC, LO, GO, NO>::Build1DPoisson(nx * comm->getSize(), lib);
       RCP<const Map > map = Op->getRowMap();
 

--- a/packages/xpetra/test/MultiVector/MultiVector_UnitTests.cpp
+++ b/packages/xpetra/test/MultiVector/MultiVector_UnitTests.cpp
@@ -538,18 +538,22 @@ namespace {
     TEST_EQUALITY( mvec.getGlobalLength(), numRanks*numLocal );
 
     // Norms are not computed by Epetra_IntMultiVector so far
-    if(!is_same<typename MV::node_type, Xpetra::EpetraNode>::value &&
-       !(is_same<typename MV::scalar_type, int>::value || is_same<typename MV::scalar_type, long long int>::value)) {
-      std::cout << "Running the norm tests!" << std::endl;
-      // we zeroed it out in the constructor; all norms should be zero
-      Array<Magnitude> norms(numVecs), zeros(numVecs);
-      std::fill(zeros.begin(),zeros.end(),ScalarTraits<Magnitude>::zero());
-      mvec.norm2(norms);
-      TEST_COMPARE_FLOATING_ARRAYS(norms,zeros,ScalarTraits<Magnitude>::zero());
-      mvec.norm1(norms);
-      TEST_COMPARE_FLOATING_ARRAYS(norms,zeros,ScalarTraits<Magnitude>::zero());
-      mvec.normInf(norms);
-      TEST_COMPARE_FLOATING_ARRAYS(norms,zeros,ScalarTraits<Magnitude>::zero());
+    #ifdef HAVE_XPETRA_EPETRA
+    if(!is_same<typename MV::node_type, Xpetra::EpetraNode>::value)
+    #endif
+    {
+      if(!(is_same<typename MV::scalar_type, int>::value || is_same<typename MV::scalar_type, long long int>::value)) {
+        std::cout << "Running the norm tests!" << std::endl;
+        // we zeroed it out in the constructor; all norms should be zero
+        Array<Magnitude> norms(numVecs), zeros(numVecs);
+        std::fill(zeros.begin(),zeros.end(),ScalarTraits<Magnitude>::zero());
+        mvec.norm2(norms);
+        TEST_COMPARE_FLOATING_ARRAYS(norms,zeros,ScalarTraits<Magnitude>::zero());
+        mvec.norm1(norms);
+        TEST_COMPARE_FLOATING_ARRAYS(norms,zeros,ScalarTraits<Magnitude>::zero());
+        mvec.normInf(norms);
+        TEST_COMPARE_FLOATING_ARRAYS(norms,zeros,ScalarTraits<Magnitude>::zero());
+      }
     }
 
     Scalar testValue = 2, sumValue = 3;


### PR DESCRIPTION


Also fixing small warning in MueLu unit-tests for Epetra=OFF build:
Moved a variable declaration around to make sure it is not un-used.

@trilinos/xpetra 

## Description
The MultiVector unit-test in Xpetra does not build properly if Epetra is turned OFF

## Motivation and Context
This is a simple fix that adds a preprocessor guard around the Xpetra::EpetraNode check in the unit-test to avoid build error when Epetra is OFF.

## Related Issues

* Closes #5300 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 

## How Has This Been Tested?
I performed a local build with Epetra=OFF and the unit-test was built correctly.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.