### PR TITLE
MueLu: Fix #5151.

### DIFF
--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_kokkos_def.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_kokkos_def.hpp
@@ -514,7 +514,7 @@ namespace MueLu {
 
                                  auto aggregate = aggGraph.rowConst(i);
 
-                                 typename Teuchos::ScalarTraits<Scalar>::coordinateType sum = 0.0; // do not use Scalar here (Stokhos)
+                                 coordinate_type sum = 0.0; // do not use Scalar here (Stokhos)
                                  for (size_t colID = 0; colID < static_cast<size_t>(aggregate.length); colID++)
                                    sum += fineCoordsRandomView(aggregate(colID),j);
 
@@ -566,6 +566,7 @@ namespace MueLu {
     const size_t NSDim    = fineNullspace->getNumVectors();
 
     typedef Kokkos::ArithTraits<SC>     ATS;
+    using impl_ATS = Kokkos::ArithTraits<typename ATS::val_type>;
     const SC zero = ATS::zero(), one = ATS::one();
 
     const LO INVALID = Teuchos::OrdinalTraits<LO>::invalid();
@@ -760,13 +761,13 @@ namespace MueLu {
             // Extract the piece of the nullspace corresponding to the aggregate, and
             // put it in the flat array, "localQR" (in column major format) for the
             // QR routine. Trivial in 1D.
-            auto norm = ATS::magnitude(zero);
+            auto norm = impl_ATS::magnitude(zero);
 
             // Calculate QR by hand
             // FIXME: shouldn't there be stridedblock here?
             // FIXME_KOKKOS: shouldn't there be stridedblock here?
             for (decltype(aggSize) k = 0; k < aggSize; k++) {
-              auto dnorm = ATS::magnitude(fineNSRandom(agg2RowMapLO(aggRows(agg)+k),0));
+              auto dnorm = impl_ATS::magnitude(fineNSRandom(agg2RowMapLO(aggRows(agg)+k),0));
               norm += dnorm*dnorm;
             }
             norm = sqrt(norm);
@@ -857,7 +858,7 @@ namespace MueLu {
         Kokkos::parallel_for("MueLu:TentativePF:BuildUncoupled:for2", range_type(0, nnzEstimate),
           KOKKOS_LAMBDA(const LO j) {
             colsAux(j) = INVALID;
-            valsAux(j) = zero;
+            valsAux(j) = impl_ATS::zero();
           });
       }
 

--- a/packages/muelu/src/Utils/MueLu_Utilities_kokkos_def.hpp
+++ b/packages/muelu/src/Utils/MueLu_Utilities_kokkos_def.hpp
@@ -414,6 +414,7 @@ namespace MueLu {
   DetectDirichletCols(const Xpetra::Matrix<SC,LO,GO,NO>& A,
                       const Kokkos::View<const bool*, typename NO::device_type>& dirichletRows) {
     using ATS        = Kokkos::ArithTraits<SC>;
+    using impl_ATS = Kokkos::ArithTraits<typename ATS::val_type>;
     using range_type = Kokkos::RangePolicy<LO, typename NO::execution_space>;
 
     SC zero = ATS::zero();
@@ -453,8 +454,8 @@ namespace MueLu {
     const typename ATS::magnitudeType eps = 2.0*ATS::eps();
 
     Kokkos::parallel_for("MueLu:Utils::DetectDirichletCols2", range_type(0,numColEntries),
-                         KOKKOS_LAMBDA(const size_t i) {
-                           dirichletCols(i) = ATS::magnitude(myCols(i,0))>eps;
+                         KOKKOS_LAMBDA (const size_t i) {
+                           dirichletCols(i) = impl_ATS::magnitude(myCols(i,0))>eps;
                          });
     return dirichletCols;
   }


### PR DESCRIPTION
Apparently many of the ```ATS=Kokkos::ArithTraits<std::complex<T>>``` functions
can't be used in GPU kernels. Need to use ```Kokkos::ArithTraits<ATS::val_type>```
to get the versions that work on the GPU.

@trilinos/MueLu

## Related Issues

* Closes #5151 
