### PR TITLE
(DO NOT MERGE) Tpetra: Fix #5117 (make TpetraCore build w/ deprecated code disabled)

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -349,7 +349,7 @@ namespace Tpetra {
     ///   default values.
     CrsGraph (const Teuchos::RCP<const map_type>& rowMap,
               const size_t maxNumEntriesPerRow,
-	      const ProfileType pftype = TPETRA_DEFAULT_PROFILE_TYPE,
+              const ProfileType pftype = TPETRA_DEFAULT_PROFILE_TYPE,
               const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
     /// \brief Constructor specifying a (possibly different) upper
@@ -371,7 +371,7 @@ namespace Tpetra {
     ///   default values.
     CrsGraph (const Teuchos::RCP<const map_type>& rowMap,
               const Kokkos::DualView<const size_t*, execution_space>& numEntPerRow,
-	      const ProfileType pftype = TPETRA_DEFAULT_PROFILE_TYPE,
+              const ProfileType pftype = TPETRA_DEFAULT_PROFILE_TYPE,
               const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
     /// \brief Constructor specifying a (possibly different) upper
@@ -394,7 +394,7 @@ namespace Tpetra {
     ///   default values.
     CrsGraph (const Teuchos::RCP<const map_type>& rowMap,
               const Teuchos::ArrayView<const size_t>& numEntPerRow,
-	      const ProfileType pftype = TPETRA_DEFAULT_PROFILE_TYPE,
+              const ProfileType pftype = TPETRA_DEFAULT_PROFILE_TYPE,
               const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE
@@ -402,7 +402,7 @@ namespace Tpetra {
     TPETRA_DEPRECATED
     CrsGraph (const Teuchos::RCP<const map_type>& rowMap,
               const Teuchos::ArrayRCP<const size_t>& numEntPerRow,
-	      const ProfileType pftype = DynamicProfile,
+              const ProfileType pftype = DynamicProfile,
               const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 #endif // TPETRA_ENABLE_DEPRECATED_CODE
 
@@ -430,7 +430,7 @@ namespace Tpetra {
     CrsGraph (const Teuchos::RCP<const map_type>& rowMap,
               const Teuchos::RCP<const map_type>& colMap,
               const size_t maxNumEntriesPerRow,
-	      const ProfileType pftype = TPETRA_DEFAULT_PROFILE_TYPE,
+              const ProfileType pftype = TPETRA_DEFAULT_PROFILE_TYPE,
               const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
     /// \brief Constructor specifying column Map and number of entries in each row.
@@ -454,7 +454,7 @@ namespace Tpetra {
     CrsGraph (const Teuchos::RCP<const map_type>& rowMap,
               const Teuchos::RCP<const map_type>& colMap,
               const Kokkos::DualView<const size_t*, execution_space>& numEntPerRow,
-	      const ProfileType pftype = TPETRA_DEFAULT_PROFILE_TYPE,
+              const ProfileType pftype = TPETRA_DEFAULT_PROFILE_TYPE,
               const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
     /// \brief Constructor specifying column Map and number of entries
@@ -479,7 +479,7 @@ namespace Tpetra {
     CrsGraph (const Teuchos::RCP<const map_type>& rowMap,
               const Teuchos::RCP<const map_type>& colMap,
               const Teuchos::ArrayView<const size_t>& numEntPerRow,
-	      const ProfileType pftype = TPETRA_DEFAULT_PROFILE_TYPE,
+              const ProfileType pftype = TPETRA_DEFAULT_PROFILE_TYPE,
               const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE
@@ -488,7 +488,7 @@ namespace Tpetra {
     CrsGraph (const Teuchos::RCP<const map_type>& rowMap,
               const Teuchos::RCP<const map_type>& colMap,
               const Teuchos::ArrayRCP<const size_t>& numEntPerRow,
-	      const ProfileType pftype = DynamicProfile,
+              const ProfileType pftype = DynamicProfile,
               const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 #endif // TPETRA_ENABLE_DEPRECATED_CODE
 
@@ -2571,13 +2571,16 @@ namespace Tpetra {
   /// \relatesalso CrsGraph
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   Teuchos::RCP<CrsGraph<LocalOrdinal, GlobalOrdinal, Node> >
-  createCrsGraph (const Teuchos::RCP<const Map<LocalOrdinal, GlobalOrdinal, Node> > &map,
+  createCrsGraph (const Teuchos::RCP<const Map<LocalOrdinal, GlobalOrdinal, Node>>& map,
                   size_t maxNumEntriesPerRow = 0,
                   const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null)
   {
     using Teuchos::rcp;
-    typedef CrsGraph<LocalOrdinal, GlobalOrdinal, Node> graph_type;
-    return rcp (new graph_type (map, maxNumEntriesPerRow, DynamicProfile, params));
+    using graph_type = CrsGraph<LocalOrdinal, GlobalOrdinal, Node>;
+
+    const ProfileType profileType = TPETRA_DEFAULT_PROFILE_TYPE;
+    return rcp (new graph_type (map, maxNumEntriesPerRow,
+                                profileType, params));
   }
 
   /// \brief Nonmember CrsGraph constructor that fuses Import and fillComplete().

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -527,7 +527,7 @@ namespace Tpetra {
     ///   default values.
     CrsMatrix (const Teuchos::RCP<const map_type>& rowMap,
                const size_t maxNumEntriesPerRow,
-	       const ProfileType pftype = TPETRA_DEFAULT_PROFILE_TYPE,
+               const ProfileType pftype = TPETRA_DEFAULT_PROFILE_TYPE,
                const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
     /// \brief Constructor specifying (possibly different) number of entries in each row.
@@ -549,7 +549,7 @@ namespace Tpetra {
     ///   default values.
     CrsMatrix (const Teuchos::RCP<const map_type>& rowMap,
                const Teuchos::ArrayView<const size_t>& numEntPerRowToAlloc,
-	       const ProfileType pftype = TPETRA_DEFAULT_PROFILE_TYPE,
+               const ProfileType pftype = TPETRA_DEFAULT_PROFILE_TYPE,
                const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE
@@ -586,7 +586,7 @@ namespace Tpetra {
     CrsMatrix (const Teuchos::RCP<const map_type>& rowMap,
                const Teuchos::RCP<const map_type>& colMap,
                const size_t maxNumEntPerRow,
-	       const ProfileType pftype = TPETRA_DEFAULT_PROFILE_TYPE,
+               const ProfileType pftype = TPETRA_DEFAULT_PROFILE_TYPE,
                const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
     /// \brief Constructor specifying column Map and number of entries in each row.
@@ -614,7 +614,7 @@ namespace Tpetra {
     CrsMatrix (const Teuchos::RCP<const map_type>& rowMap,
                const Teuchos::RCP<const map_type>& colMap,
                const Teuchos::ArrayView<const size_t>& numEntPerRowToAlloc,
-	       const ProfileType pftype = TPETRA_DEFAULT_PROFILE_TYPE,
+               const ProfileType pftype = TPETRA_DEFAULT_PROFILE_TYPE,
                const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE
@@ -5033,13 +5033,16 @@ namespace Tpetra {
    */
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   Teuchos::RCP<CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> >
-  createCrsMatrix (const Teuchos::RCP<const Map<LocalOrdinal, GlobalOrdinal, Node> >& map,
+  createCrsMatrix (const Teuchos::RCP<const Map<LocalOrdinal, GlobalOrdinal, Node>>& map,
                    size_t maxNumEntriesPerRow = 0,
                    const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null)
   {
-    typedef CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> matrix_type;
-    return Teuchos::rcp (new matrix_type (map, maxNumEntriesPerRow,
-                                          DynamicProfile, params));
+    using Teuchos::rcp;
+    using matrix_type = CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
+
+    const ProfileType profileType = TPETRA_DEFAULT_PROFILE_TYPE;
+    return rcp (new matrix_type (map, maxNumEntriesPerRow,
+                                 profileType, params));
   }
 
   template<class CrsMatrixType>

--- a/packages/tpetra/core/test/BugTests/BlankRowBugTest.cpp
+++ b/packages/tpetra/core/test/BugTests/BlankRowBugTest.cpp
@@ -49,17 +49,18 @@
 namespace {
 
   using Teuchos::RCP;
+  using Teuchos::rcp;
   using Teuchos::Comm;
   using Teuchos::tuple;
 
   TEUCHOS_UNIT_TEST(CrsMatrix, BlankRowImport)
   {
-    typedef Tpetra::Map<>                     map_type;
-    typedef map_type::local_ordinal_type      LO;
-    typedef map_type::global_ordinal_type     GO;
-    typedef Tpetra::CrsMatrix<>::scalar_type  SC;
-    typedef Tpetra::CrsMatrix<>               crs_matrix_type;
-    typedef Tpetra::Import<LO, GO>            import_type;
+    using map_type = Tpetra::Map<>;
+    using LO = map_type::local_ordinal_type;
+    using GO = map_type::global_ordinal_type;
+    using crs_matrix_type = Tpetra::CrsMatrix<>;
+    using SC = crs_matrix_type::scalar_type;
+    using import_type = Tpetra::Import<LO, GO>;
 
     RCP<const Comm<int> > comm = Tpetra::getDefaultComm ();
     // We run this test explicitly in MPI mode with 2 processors as described in
@@ -76,7 +77,7 @@ namespace {
     }
     destRowMap = Tpetra::createNonContigMap<LO, GO> (tuple<GO> (0, 1), comm);
 
-    RCP<crs_matrix_type> srcMat = Tpetra::createCrsMatrix<SC>(sourceRowMap);
+    RCP<crs_matrix_type> srcMat = rcp (new crs_matrix_type (sourceRowMap, 1));
     if (rank == 0) {
       srcMat->insertGlobalValues (static_cast<GO> (0), tuple<GO> (0), tuple<SC> (1.0));
     }

--- a/packages/tpetra/core/test/BugTests/BugTests.cpp
+++ b/packages/tpetra/core/test/BugTests/BugTests.cpp
@@ -99,15 +99,12 @@ namespace {
   TEUCHOS_UNIT_TEST( readHBMatrix, Bug5072_ReadOneRowMPI )
   {
     // failure reading 1x4 matrix under MPI
-    // typedef int                       LO;
-    // typedef int                       GO;
     typedef Tpetra::Map<> map_type;
     typedef map_type::local_ordinal_type LO;
     typedef map_type::global_ordinal_type GO;
     typedef Tpetra::CrsMatrix<> crs_matrix_type;
     typedef typename crs_matrix_type::scalar_type SC;
 
-    // create a comm
     RCP<const Comm<int> > comm = getDefaultComm();
     const int myImageID = comm->getRank();
     RCP<const crs_matrix_type> readMatrix, testMatrix;
@@ -116,7 +113,7 @@ namespace {
       // this is what the file looks like: 1 3 4 9
       RCP<const map_type> rng = Tpetra::createUniformContigMap<LO, GO>(1,comm);
       RCP<const map_type> dom = Tpetra::createUniformContigMap<LO, GO>(4,comm);
-      RCP<crs_matrix_type> A = Tpetra::createCrsMatrix<SC, LO, GO>(rng);
+      RCP<crs_matrix_type> A = rcp (new crs_matrix_type (rng, 4));
       if (myImageID == 0) {
         A->insertGlobalValues( 0, Teuchos::tuple<GO>(0,1,2,3), Teuchos::tuple<SC>(1.0,3.0,4.0,9.0) );
       }
@@ -174,7 +171,7 @@ namespace {
   {
     // test bug where map test checks that maps are the same object, instead of checking that maps are equivalent
 
-    using std::endl;    
+    using std::endl;
     // mfh 06 Aug 2017: There was no obvious reason why this test
     // required LO=int and GO=int, nor did the original Bug 5129 bug
     // report depend on specific LO or GO types, so I relaxed this
@@ -188,7 +185,7 @@ namespace {
     // this still has to be bigger than LO
     typedef int GO;
 #endif // 1
-    
+
     RCP<const Comm<int> > comm = getDefaultComm();
     const bool verbose = Tpetra::Details::Behavior::verbose ();
     std::unique_ptr<std::string> prefix;
@@ -207,7 +204,7 @@ namespace {
       os << *prefix << "Create Maps" << endl;
       std::cerr << os.str ();
     }
-    
+
     RCP<const Map<LO,GO> > mapImportIn  = Tpetra::createUniformContigMap<LO,GO>(numGlobal, comm);
     RCP<const Map<LO,GO> > mapImportOut = Tpetra::createUniformContigMap<LO,GO>(numGlobal, comm);
     RCP<const Map<LO,GO> > mapIn        = Tpetra::createUniformContigMap<LO,GO>(numGlobal, comm);

--- a/packages/tpetra/core/test/CrsGraph/CrsGraph_Issue601.cpp
+++ b/packages/tpetra/core/test/CrsGraph/CrsGraph_Issue601.cpp
@@ -97,14 +97,18 @@ namespace { // (anonymous)
     RCP<const map_type> rowMap =
       rcp (new map_type (INV, myGblRowInds (), indexBase, comm));
 
-    Tpetra::ProfileType profileTypes[] = { Tpetra::DynamicProfile, Tpetra::StaticProfile };
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+    const Tpetra::ProfileType profileTypes[2] =
+      { Tpetra::DynamicProfile, Tpetra::StaticProfile };
+#else
+    const Tpetra::ProfileType profileTypes[1] =
+      { Tpetra::StaticProfile };
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
     bool insertLocalEntryValues[] = { true, false };
 
-    // Test both dynamic and static profile.
     for (Tpetra::ProfileType profileType : profileTypes) {
-
       out << "ProfileType: "
-          << ((profileType == Tpetra::DynamicProfile) ? "Dynamic" : "Static")
+          << ((profileType == Tpetra::StaticProfile) ? "Static" : "Dynamic")
           << "Profile" << endl;
       Teuchos::OSTab tab2 (out);
 

--- a/packages/tpetra/core/test/CrsGraph/CrsGraph_UnitTests0.cpp
+++ b/packages/tpetra/core/test/CrsGraph/CrsGraph_UnitTests0.cpp
@@ -584,10 +584,14 @@ namespace {
 
         RCP<row_graph_type> test_row;
         {
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
           // allocate with no space
           RCP<crs_graph_type> test_crs = rcp (new crs_graph_type (map, 0));
           // invalid, because none are allocated yet
           TEST_EQUALITY_CONST( test_crs->getNodeAllocationSize(), STINV );
+#else
+          RCP<crs_graph_type> test_crs = rcp (new crs_graph_type (map, 1));
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
           if (myRank != 1) {
             test_crs->insertGlobalIndices (map->getMinGlobalIndex (),
                                            tuple<GO> (map->getMinGlobalIndex ()));

--- a/packages/tpetra/core/test/CrsGraph/CrsGraph_UnitTests1.cpp
+++ b/packages/tpetra/core/test/CrsGraph/CrsGraph_UnitTests1.cpp
@@ -48,7 +48,6 @@
 
 namespace { // (anonymous)
   using Tpetra::TestingUtilities::getDefaultComm;
-  using Tpetra::DynamicProfile;
   using Tpetra::ProfileType;
   using Tpetra::StaticProfile;
   using Teuchos::arcp;
@@ -137,12 +136,14 @@ namespace { // (anonymous)
       GRAPH graph(map,1,StaticProfile);
       graph.fillComplete();
     }
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
     {
       // create dynamic-profile graph, fill-complete without inserting
       // (and therefore, without allocating)
-      GRAPH graph(map,1,DynamicProfile);
+      GRAPH graph(map,1,Tpetra::DynamicProfile);
       graph.fillComplete();
     }
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
 
     int lclSuccess = success ? 1 : 0;
     int gblSuccess = 1;
@@ -456,7 +457,13 @@ namespace { // (anonymous)
     RCP<const map_type> map = rcp (new map_type (INVALID, 1, 0, comm));
     RCP<ParameterList> params = parameterList();
     {
-      GRAPH graph(map,map,0,DynamicProfile);
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+      GRAPH graph(map,map,0,Tpetra::DynamicProfile);
+#else
+      // mfh 04 Jun 2019: leave extra space just in case
+      // insertLocalIndices doesn't merge.
+      GRAPH graph(map,map,2);
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
       TEST_EQUALITY_CONST( graph.isFillActive(),   true );
       TEST_EQUALITY_CONST( graph.isFillComplete(), false );
       graph.insertLocalIndices( 0, tuple<LO>(0) );
@@ -471,7 +478,13 @@ namespace { // (anonymous)
       TEST_THROW( graph.fillComplete(),                        std::runtime_error );
     }
     {
-      GRAPH graph(map,map,0,DynamicProfile);
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+      GRAPH graph(map,map,0,Tpetra::DynamicProfile);
+#else
+      // mfh 04 Jun 2019: leave extra space just in case
+      // insertLocalIndices doesn't merge.
+      GRAPH graph(map,map,2);
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
       TEST_EQUALITY_CONST( graph.isFillActive(),   true );
       TEST_EQUALITY_CONST( graph.isFillComplete(), false );
       graph.insertLocalIndices( 0, tuple<LO>(0) );

--- a/packages/tpetra/core/test/CrsGraph/CrsGraph_UnitTests_Swap.cpp
+++ b/packages/tpetra/core/test/CrsGraph/CrsGraph_UnitTests_Swap.cpp
@@ -62,9 +62,9 @@ class crsGraph_Swap_Tester
 {
     using Scalar                   = int;                                                   // Not really used for CrsGraph construction but
                                                                                             // we keep this around since the CrsMatrix::swap
-                                                                                            // test is constructing its graphs the same way 
-                                                                                            // so hanging onto this to keep the structs in 
-                                                                                            // this file happy (this does not get passed to 
+                                                                                            // test is constructing its graphs the same way
+                                                                                            // so hanging onto this to keep the structs in
+                                                                                            // this file happy (this does not get passed to
                                                                                             // anything in Tpetra in this test).
     using comm_type                = Teuchos::RCP<const Teuchos::Comm<int>>;                // The comm type
     using graph_type               = Tpetra::CrsGraph<LocalOrdinal, GlobalOrdinal, Node>;   // Tpetra CrsGraph type
@@ -412,7 +412,6 @@ using Teuchos::VERB_HIGH;
 using Teuchos::VERB_LOW;
 using Teuchos::VERB_MEDIUM;
 using Teuchos::VERB_NONE;
-using Tpetra::DynamicProfile;
 using Tpetra::ProfileType;
 using Tpetra::StaticProfile;
 using Tpetra::TestingUtilities::getDefaultComm;

--- a/packages/tpetra/core/test/CrsGraph/CrsGraph_insertGlobalIndicesFiltered.cpp
+++ b/packages/tpetra/core/test/CrsGraph/CrsGraph_insertGlobalIndicesFiltered.cpp
@@ -133,9 +133,15 @@ namespace { // (anonymous)
     // Buffer for storing output of getGlobalRowCopy.
     Teuchos::Array<GO> gblColIndsBuf (maxNumEntPerRow);
 
-    const Tpetra::ProfileType profileTypes[2] =
+    using Tpetra::ProfileType;
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+    const ProfileType profileTypes[2] =
       {Tpetra::DynamicProfile, Tpetra::StaticProfile};
-    for (auto profileType_src : profileTypes) {
+#else
+    const ProfileType profileTypes[1] = {Tpetra::StaticProfile};
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+
+    for (ProfileType profileType_src : profileTypes) {
       crs_graph_type graph_src (rowMap_src, maxNumEntPerRow, profileType_src);
       for (LO lclRow = 0; lclRow < lclNumRows; ++lclRow) {
         const GO gblRow = rowMap_src->getGlobalElement (lclRow);

--- a/packages/tpetra/core/test/CrsMatrix/Bug6171.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/Bug6171.cpp
@@ -127,7 +127,11 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CrsMatrix, Bug6171, SC, LO, GO, NT)
     ! rowMap->isOneToOne (), std::logic_error,
     "In this test, the row Map is supposed to be one to one.");
 
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
   RCP<CrsMatrixType> matrix = rcp (new CrsMatrixType (rowMap, 0));
+#else
+  RCP<CrsMatrixType> matrix = rcp (new CrsMatrixType (rowMap, 2));
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
   for (size_t i = 0; i < static_cast<size_t> (globalIDs.size ()); ++i) {
     matrix->insertGlobalValues (globalIDs[i],
                                 ArrayView<const GO> (indices[i]),

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_LeftRightScale.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_LeftRightScale.cpp
@@ -95,7 +95,6 @@ namespace {
   using Tpetra::createCrsMatrix;
   using Tpetra::ProfileType;
   using Tpetra::StaticProfile;
-  using Tpetra::DynamicProfile;
   using Tpetra::OptimizeOption;
   using Tpetra::GloballyDistributed;
   using Tpetra::INSERT;

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_NonlocalAfterResume.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_NonlocalAfterResume.cpp
@@ -71,7 +71,6 @@ namespace {
   using Tpetra::createCrsMatrix;
   using Tpetra::ProfileType;
   using Tpetra::StaticProfile;
-  using Tpetra::DynamicProfile;
   using Tpetra::OptimizeOption;
   using Tpetra::DoOptimizeStorage;
   using Tpetra::DoNotOptimizeStorage;
@@ -164,7 +163,13 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( CrsMatrix, NonlocalAfterResume, LO, GO, Scala
     //----------------------------------------------------------------------
     // put in diagonal, locally
     //----------------------------------------------------------------------
-    Tpetra::CrsMatrix<Scalar,LO,GO,Node> matrix(rmap,cmap,3,DynamicProfile);
+
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+    Tpetra::CrsMatrix<Scalar,LO,GO,Node> matrix(rmap, cmap, 3, Tpetra::DynamicProfile);
+#else
+    Tpetra::CrsMatrix<Scalar,LO,GO,Node> matrix(rmap, cmap, 3);
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+
     for (GO r=rmap->getMinGlobalIndex(); r <= rmap->getMaxGlobalIndex(); ++r) {
       matrix.insertGlobalValues(r,tuple(r),tuple(ST::one()));
     }

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_ReplaceDomainMapAndImporter.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_ReplaceDomainMapAndImporter.cpp
@@ -84,7 +84,6 @@ namespace {
   using Tpetra::createCrsMatrix;
   using Tpetra::ProfileType;
   using Tpetra::StaticProfile;
-  using Tpetra::DynamicProfile;
   using Tpetra::OptimizeOption;
   using Tpetra::DoOptimizeStorage;
   using Tpetra::DoNotOptimizeStorage;

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests.cpp
@@ -113,13 +113,19 @@ namespace { // (anonymous)
     {
       RCPMap map  = createContigMapWithNode<LO,GO,Node>(INVALID,numLocal,comm);
       MV mv(map,1);
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
       zero = rcp( new MAT(map,0,Tpetra::DynamicProfile) );
+#else
+      zero = rcp( new MAT(map,0) );
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
       TEST_THROW(zero->apply(mv,mv), std::runtime_error);
 #   if defined(HAVE_TPETRA_THROW_EFFICIENCY_WARNINGS)
       // throw exception because we required increased allocation
       TEST_THROW(zero->insertGlobalValues(map->getMinGlobalIndex(),tuple<GO>(0),tuple<Scalar>(ST::one())), std::runtime_error);
 #   endif
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
       TEST_ASSERT( zero->getProfileType() == Tpetra::DynamicProfile );
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
       zero->fillComplete();
     }
     STD_TESTS((*zero));
@@ -187,7 +193,9 @@ namespace { // (anonymous)
       for (size_t i=0; i<numLocal; ++i) {
         eye_crs->insertGlobalValues(base+i,tuple<GO>(base+i),tuple<Scalar>(ST::one()));
       }
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
       TEST_ASSERT( eye_crs->getProfileType() == Tpetra::DynamicProfile );
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
       eye_crs->fillComplete();
       eye = eye_crs;
     }

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests2.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests2.cpp
@@ -150,7 +150,6 @@ namespace {
   using Tpetra::createCrsMatrix;
   using Tpetra::ProfileType;
   using Tpetra::StaticProfile;
-  using Tpetra::DynamicProfile;
   using Tpetra::OptimizeOption;
   using Tpetra::DoOptimizeStorage;
   using Tpetra::DoNotOptimizeStorage;
@@ -261,14 +260,20 @@ inline void tupleToArray(Array<T> &arr, const tuple &tup)
     RCP<const map_type> lclmap = createLocalMapWithNode<LO,GO,Node> (P, comm);
 
     // create the matrix
-    MAT A(rowmap,P,DynamicProfile);
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+    MAT A(rowmap, P, Tpetra::DynamicProfile);
+#else
+    MAT A(rowmap, P);
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
     for (GO i=0; i<static_cast<GO>(M); ++i) {
       for (GO j=0; j<static_cast<GO>(P); ++j) {
         A.insertGlobalValues( M*myImageID+i, tuple<GO>(j), tuple<Scalar>(M*myImageID+i + j*M*N) );
       }
     }
     // call fillComplete()
-    TEST_EQUALITY_CONST( A.getProfileType() == DynamicProfile, true );
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+    TEST_ASSERT( A.getProfileType() == Tpetra::DynamicProfile );
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
     A.fillComplete(lclmap,rowmap);
     // build the input multivector X
     MV X(lclmap,numVecs);

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests4.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests4.cpp
@@ -143,7 +143,6 @@ namespace {
   using Tpetra::createCrsMatrix;
   using Tpetra::ProfileType;
   using Tpetra::StaticProfile;
-  using Tpetra::DynamicProfile;
   using Tpetra::OptimizeOption;
   using Tpetra::DoOptimizeStorage;
   using Tpetra::DoNotOptimizeStorage;
@@ -366,7 +365,7 @@ inline void tupleToArray(Array<T> &arr, const tuple &tup)
     RCP<const Map<LO,GO,Node> > map = createContigMapWithNode<LO,GO,Node>(INVALID,1,comm);
     const Scalar SZERO = ScalarTraits<Scalar>::zero();
     {
-      MAT matrix(map,map,0,DynamicProfile);
+      MAT matrix(map,map,1);
       TEST_EQUALITY_CONST( matrix.isFillActive(),   true );
       TEST_EQUALITY_CONST( matrix.isFillComplete(), false );
       matrix.insertLocalValues( 0, tuple<LO>(0), tuple<Scalar>(0) );
@@ -401,7 +400,13 @@ inline void tupleToArray(Array<T> &arr, const tuple &tup)
       TEST_THROW( matrix.fillComplete(),        std::runtime_error );
     }
     {
-      MAT matrix(map,map,0,DynamicProfile);
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+      MAT matrix(map,map,0,Tpetra::DynamicProfile);
+#else
+      // mfh 04 Jun 2019: Leave enough space for duplicates, for now.
+      // This may not actually be necessary.
+      MAT matrix(map,map,2);
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
       TEST_EQUALITY_CONST( matrix.isFillActive(),   true );
       TEST_EQUALITY_CONST( matrix.isFillComplete(), false );
       matrix.insertLocalValues( 0, tuple<LO>(0), tuple<Scalar>(0) );
@@ -610,7 +615,11 @@ inline void tupleToArray(Array<T> &arr, const tuple &tup)
     auto map = createContigMapWithNode<LO, GO, Node> (INVALID, 1, comm);
 
     // construct matrix
-    CrsMatrix<Scalar,LO,GO,Node> A (map, map, 0, DynamicProfile);
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+    CrsMatrix<Scalar,LO,GO,Node> A (map, map, 0, Tpetra::DynamicProfile);
+#else
+    CrsMatrix<Scalar,LO,GO,Node> A (map, map, 1);
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
     A.insertLocalValues (0, tuple<LO> (0), tuple<Scalar> (STS::zero ()));
     A.fillComplete (map, map);
 

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests_Swap.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests_Swap.cpp
@@ -785,8 +785,6 @@ using Teuchos::VERB_HIGH;
 using Teuchos::VERB_LOW;
 using Teuchos::VERB_MEDIUM;
 using Teuchos::VERB_NONE;
-using Tpetra::DynamicProfile;
-using Tpetra::ProfileType;
 using Tpetra::StaticProfile;
 using Tpetra::TestingUtilities::getDefaultComm;
 typedef Tpetra::global_size_t GST;

--- a/packages/tpetra/core/test/CrsMatrix/Regression/Albany182.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/Regression/Albany182.cpp
@@ -1003,15 +1003,20 @@ namespace { // (anonymous)
     }
 
     using Tpetra::ProfileType;
-    using Tpetra::DynamicProfile;
     using Tpetra::StaticProfile;
-    for (ProfileType profileType : {DynamicProfile, StaticProfile}) {
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+    using Tpetra::DynamicProfile;
+    const ProfileType profileTypes[2] = {DynamicProfile, StaticProfile};
+#else
+    const ProfileType profileTypes[1] = {StaticProfile};
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+    for (ProfileType profileType : profileTypes) {
       out << ">>> Target matrix is {";
-      if (profileType == Tpetra::DynamicProfile) {
-        out << "DynamicProfile";
+      if (profileType == Tpetra::StaticProfile) {
+        out << "StaticProfile";
       }
       else {
-        out << "StaticProfile";
+        out << "DynamicProfile";
       }
       out << ", locally indexed}" << endl;
       Teuchos::OSTab tab2 (out);

--- a/packages/tpetra/core/test/CrsMatrix/Regression/Albany182.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/Regression/Albany182.cpp
@@ -372,78 +372,107 @@ namespace { // (anonymous)
 
   template<class CrsMatrixType>
   void
-  insertIntoOverlappingCrsMatrix (CrsMatrixType& A)
+  insertIntoOverlappingCrsMatrix (bool& success,
+                                  Teuchos::FancyOStream& out,
+                                  CrsMatrixType& A)
   {
-    typedef typename CrsMatrixType::scalar_type ST;
-    typedef typename CrsMatrixType::local_ordinal_type LO;
-    typedef typename CrsMatrixType::global_ordinal_type GO;
-    //typedef typename CrsMatrixType::map_type map_type;
+    using std::endl;
+    using ST = typename CrsMatrixType::scalar_type;
+    using LO = typename CrsMatrixType::local_ordinal_type;
+    using GO = typename CrsMatrixType::global_ordinal_type;
     static_assert (std::is_same<ST, double>::value,
                    "CrsMatrixType::scalar_type must be double "
                    "in order for this test to work.");
 
     const int myRank = A.getMap ()->getComm ()->getRank ();
-    if (myRank == 0) {
-      const GO gblRow = 0;
-      constexpr LO numEnt = 5;
-      const GO inds[numEnt] = {0, 1, 3, 4, 5};
-      const ST vals[numEnt] = {0.0, 1.0, 3.0, 4.0, 5.0};
-      A.insertGlobalValues (gblRow, numEnt, vals, inds);
+    try {
+      if (myRank == 0) {
+        const GO gblRow = 0;
+        constexpr LO numEnt = 5;
+        const GO inds[numEnt] = {0, 1, 3, 4, 5};
+        const ST vals[numEnt] = {0.0, 1.0, 3.0, 4.0, 5.0};
+        A.insertGlobalValues (gblRow, numEnt, vals, inds);
+      }
+      else if (myRank == 1) {
+        const GO gblRow = 0;
+        constexpr LO numEnt = 4;
+        const GO inds[numEnt] = {1, 2, 3, 5};
+        const ST vals[numEnt] = {1.0, 2.0, 3.0, 5.0};
+        A.insertGlobalValues (gblRow, numEnt, vals, inds);
+      }
+      else if (myRank == 2) {
+        const GO gblRow = 1;
+        constexpr LO numEnt = 5;
+        const GO inds[numEnt] = {3, 4, 6, 7, 8};
+        const ST vals[numEnt] = {3.0, 4.0, 6.0, 7.0, 8.0};
+        A.insertGlobalValues (gblRow, numEnt, vals, inds);
+      }
+      else if (myRank == 3) {
+        const GO gblRow = 1;
+        constexpr LO numEnt = 5;
+        const GO inds[numEnt] = {4, 5, 6, 8, 9};
+        const ST vals[numEnt] = {4.0, 5.0, 6.0, 8.0, 9.0};
+        A.insertGlobalValues (gblRow, numEnt, vals, inds);
+      }
     }
-    else if (myRank == 1) {
-      const GO gblRow = 0;
-      constexpr LO numEnt = 4;
-      const GO inds[numEnt] = {1, 2, 3, 5};
-      const ST vals[numEnt] = {1.0, 2.0, 3.0, 5.0};
-      A.insertGlobalValues (gblRow, numEnt, vals, inds);
+    catch (std::exception& e) {
+      TEST_ASSERT( false );
+      out << "A.insertGlobalValues(...) threw an exception: "
+          << e.what () << endl;
     }
-    else if (myRank == 2) {
-      const GO gblRow = 1;
-      constexpr LO numEnt = 5;
-      const GO inds[numEnt] = {3, 4, 6, 7, 8};
-      const ST vals[numEnt] = {3.0, 4.0, 6.0, 7.0, 8.0};
-      A.insertGlobalValues (gblRow, numEnt, vals, inds);
-    }
-    else if (myRank == 3) {
-      const GO gblRow = 1;
-      constexpr LO numEnt = 5;
-      const GO inds[numEnt] = {4, 5, 6, 8, 9};
-      const ST vals[numEnt] = {4.0, 5.0, 6.0, 8.0, 9.0};
-      A.insertGlobalValues (gblRow, numEnt, vals, inds);
+    catch (...) {
+      TEST_ASSERT( false );
+      out << "A.insertGlobalValues(...) threw an exception not a "
+        "subclass of std::exception" << endl;
     }
   }
 
   template<class CrsGraphType>
   void
-  insertIntoOverlappingCrsGraph (CrsGraphType& G)
+  insertIntoOverlappingCrsGraph (bool& success,
+                                 Teuchos::FancyOStream& out,
+                                 CrsGraphType& G)
   {
+    using std::endl;
     typedef typename CrsGraphType::local_ordinal_type LO;
     typedef typename CrsGraphType::global_ordinal_type GO;
 
     const int myRank = G.getMap ()->getComm ()->getRank ();
-    if (myRank == 0) {
-      const GO gblRow = 0;
-      constexpr LO numEnt = 5;
-      const GO inds[numEnt] = {0, 1, 3, 4, 5};
-      G.insertGlobalIndices (gblRow, numEnt, inds);
+    try {
+      if (myRank == 0) {
+        const GO gblRow = 0;
+        constexpr LO numEnt = 5;
+        const GO inds[numEnt] = {0, 1, 3, 4, 5};
+        G.insertGlobalIndices (gblRow, numEnt, inds);
+      }
+      else if (myRank == 1) {
+        const GO gblRow = 0;
+        constexpr LO numEnt = 4;
+        const GO inds[numEnt] = {1, 2, 3, 5};
+        G.insertGlobalIndices (gblRow, numEnt, inds);
+      }
+      else if (myRank == 2) {
+        const GO gblRow = 1;
+        constexpr LO numEnt = 5;
+        const GO inds[numEnt] = {3, 4, 6, 7, 8};
+        G.insertGlobalIndices (gblRow, numEnt, inds);
+      }
+      else if (myRank == 3) {
+        const GO gblRow = 1;
+        constexpr LO numEnt = 5;
+        const GO inds[numEnt] = {4, 5, 6, 8, 9};
+        G.insertGlobalIndices (gblRow, numEnt, inds);
+      }
     }
-    else if (myRank == 1) {
-      const GO gblRow = 0;
-      constexpr LO numEnt = 4;
-      const GO inds[numEnt] = {1, 2, 3, 5};
-      G.insertGlobalIndices (gblRow, numEnt, inds);
+    catch (std::exception& e) {
+      TEST_ASSERT( false );
+      out << "G.insertGlobalIndices(...) threw an exception: "
+          << e.what () << endl;
     }
-    else if (myRank == 2) {
-      const GO gblRow = 1;
-      constexpr LO numEnt = 5;
-      const GO inds[numEnt] = {3, 4, 6, 7, 8};
-      G.insertGlobalIndices (gblRow, numEnt, inds);
-    }
-    else if (myRank == 3) {
-      const GO gblRow = 1;
-      constexpr LO numEnt = 5;
-      const GO inds[numEnt] = {4, 5, 6, 8, 9};
-      G.insertGlobalIndices (gblRow, numEnt, inds);
+    catch (...) {
+      TEST_ASSERT( false );
+      out << "G.insertGlobalIndices(...) threw an exception not a "
+        "subclass of std::exception" << endl;
     }
   }
 
@@ -648,8 +677,8 @@ namespace { // (anonymous)
 
   template<class CrsMatrixType>
   Teuchos::RCP<CrsMatrixType>
-  buildOverlappingCrsMatrix (Teuchos::FancyOStream& out,
-                             bool& success,
+  buildOverlappingCrsMatrix (bool& success,
+                             Teuchos::FancyOStream& out,
                              const bool staticGraph,
                              const bool verbose,
                              const Teuchos::RCP<const Teuchos::Comm<int> >& comm)
@@ -667,14 +696,29 @@ namespace { // (anonymous)
 
     RCP<CrsMatrixType> A;
     if (! staticGraph) {
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
       A = rcp (new CrsMatrixType (rowMap, 0));
-      insertIntoOverlappingCrsMatrix (*A);
+#else
+      // mfh 04 Jun 2019: 5 is a magic number here, the maximum number
+      // of column indices on any process, on any row, that
+      // insertIntoOverlappingCrsMatrix will insert.
+      A = rcp (new CrsMatrixType (rowMap, 5));
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+      insertIntoOverlappingCrsMatrix (success, out, *A);
     }
     else {
       using Teuchos::rcp_const_cast;
-      typedef typename CrsMatrixType::crs_graph_type crs_graph_type;
+      using crs_graph_type = typename CrsMatrixType::crs_graph_type;
+
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
       RCP<crs_graph_type> G (new crs_graph_type (rowMap, 0));
-      insertIntoOverlappingCrsGraph (*G);
+#else
+      // mfh 04 Jun 2019: 5 is a magic number here, the maximum number
+      // of column indices on any process, on any row, that
+      // insertIntoOverlappingCrsGraph will insert.
+      RCP<crs_graph_type> G (new crs_graph_type (rowMap, 5));
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+      insertIntoOverlappingCrsGraph (success, out, *G);
       G->fillComplete (domainMap, rangeMap);
       // typedef typename CrsMatrixType::device_type::execution_space execution_space;
       // execution_space::fence ();
@@ -1026,8 +1070,34 @@ namespace { // (anonymous)
         rcp (new CrsMatrixType (rowMap_nonoverlapping, colMap_expected,
                                 maxNumEntPerRow, profileType));
       export_type exp (A_overlapping.getRowMap (), rowMap_nonoverlapping);
-      A_nonoverlapping->doExport (A_overlapping, exp, Tpetra::ADD);
-      A_nonoverlapping->fillComplete (domMap, ranMap);
+      try {
+        A_nonoverlapping->doExport (A_overlapping, exp, Tpetra::ADD);
+      }
+      catch (std::exception& e) {
+        TEST_ASSERT( false );
+        out << "A_nonoverlapping->doExport(A_overlapping,exp,ADD) "
+          "threw an exception: " << e.what () << endl;
+      }
+      catch (...) {
+        TEST_ASSERT( false );
+        out << "A_nonoverlapping->doExport(A_overlapping,exp,ADD) "
+          "threw an exception not a subclass of std::exception" << endl;
+      }
+
+      try {
+        A_nonoverlapping->fillComplete (domMap, ranMap);
+      }
+      catch (std::exception& e) {
+        TEST_ASSERT( false );
+        out << "A_nonoverlapping->fillComplete(domMap,ranMap) "
+          "threw an exception: " << e.what () << endl;
+      }
+      catch (...) {
+        TEST_ASSERT( false );
+        out << "A_nonoverlapping->fillComplete(domMap,ranMap) "
+          "threw an exception not a subclass of std::exception" << endl;
+      }
+
       //execution_space::fence ();
       const map_type* colMapPtr = A_nonoverlapping->getColMap ().getRawPtr ();
       const bool colMapsSame =
@@ -1142,11 +1212,17 @@ namespace { // (anonymous)
     for (bool staticGraph : {true, false}) {
       out << "Source matrix: staticGraph=" << (staticGraph ? "true" : "false")
           << endl;
-      RCP<crs_matrix_type> A_overlapping =
-        buildOverlappingCrsMatrix<crs_matrix_type> (out, success,
-                                                    staticGraph,
-                                                    verbose,
-                                                    comm);
+      RCP<crs_matrix_type> A_overlapping;
+      try {
+        using CRS = crs_matrix_type;
+        A_overlapping =
+          buildOverlappingCrsMatrix<CRS> (success, out, staticGraph,
+                                          verbose, comm);
+      }
+      catch (...) {
+        out << "buildOverlappingCrsMatrix threw an exception" << endl;
+        TEST_ASSERT( false );
+      }
       lclSuccess = success ? 1 : 0;
       gblSuccess = 0; // output argument
       reduceAll<int, int> (*comm, REDUCE_MIN, lclSuccess, outArg (gblSuccess));

--- a/packages/tpetra/core/test/TpetraUtils_MatrixGenerator.hpp
+++ b/packages/tpetra/core/test/TpetraUtils_MatrixGenerator.hpp
@@ -260,8 +260,7 @@ namespace Tpetra {
         using Teuchos::null;
         using std::cerr;
         using std::endl;
-        // Typedef to make certain type declarations shorter.
-        typedef global_ordinal_type GO;
+        using GO = global_ordinal_type;
 
         // The row pointer array always has at least one entry, even
         // if the matrix has zero rows.  myNumEntriesPerRow, myColInd,
@@ -284,8 +283,7 @@ namespace Tpetra {
         // Construct the CrsMatrix, using the row map, with the
         // constructor specifying the number of nonzeros for each row.
         RCP<sparse_matrix_type> A =
-          rcp (new sparse_matrix_type (pRowMap, myNumEntriesPerRow (),
-                                       DynamicProfile));
+          rcp (new sparse_matrix_type (pRowMap, myNumEntriesPerRow ()));
 
         // List of the global indices of my rows.
         // They may or may not be contiguous.
@@ -563,10 +561,10 @@ namespace Tpetra {
       generate_miniFE_matrix (int nx,
                               const Teuchos::RCP<const Teuchos::Comm<int> >& pComm,
                               const bool callFillComplete=true,
-                              const bool debug = false) 
+                              const bool debug = false)
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE
       {
-        return generate_miniFE_matrix(nx, pComm, Teuchos::null, callFillComplete, 
+        return generate_miniFE_matrix(nx, pComm, Teuchos::null, callFillComplete,
                                       debug);
       }
 
@@ -606,7 +604,7 @@ namespace Tpetra {
         dims[1] = nrows;
         dims[2] = nnz;
 
-        Teuchos::RCP<const map_type> pRangeMap = makeRangeMap (pComm, 
+        Teuchos::RCP<const map_type> pRangeMap = makeRangeMap (pComm,
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE
                                                                pNode,
 #endif // TPETRA_ENABLE_DEPRECATED_CODE
@@ -757,7 +755,7 @@ namespace Tpetra {
        generate_miniFE_vector(
            int nx,
            const Teuchos::RCP<const Teuchos::Comm<int> >& pComm
-       ) 
+       )
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE
        {
          return generate_miniFE_vector(nx, pComm, Teuchos::null);
@@ -772,7 +770,7 @@ namespace Tpetra {
            int nx,
            const Teuchos::RCP<const Teuchos::Comm<int> >& pComm,
            const Teuchos::RCP<node_type>& pNode
-       ) 
+       )
 #endif // TPETRA_ENABLE_DEPRECATED_CODE
        {
          using Teuchos::ArrayRCP;


### PR DESCRIPTION
@trilinos/tpetra 

## Description

Make TpetraCore build with deprecated code disabled (`Tpetra_ENABLE_DEPRECATED_CODE=OFF` and `KOKKOS_ENABLE_DEPRECATED_CODE=OFF`).  Some tests still fail in that case, but at least we can get the build working so that users can try the deprecation.

## Related Issues

* Closes #5117 
* Related to #5118 