### PR TITLE
Tpetra: Fix #4627

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Experimental_BlockMultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Experimental_BlockMultiVector_decl.hpp
@@ -217,6 +217,30 @@ public:
   //! \name Constructors
   //@{
 
+  /// \brief Default constructor.
+  ///
+  /// Creates an empty BlockMultiVector.  An empty BlockMultiVector
+  /// has zero rows, and block size zero.
+  BlockMultiVector ();
+
+  //! Copy constructor (shallow copy).
+  BlockMultiVector (const BlockMultiVector<Scalar, LO, GO, Node>&) = default;
+
+  //! Move constructor (shallow move).
+  BlockMultiVector (BlockMultiVector<Scalar, LO, GO, Node>&&) = default;
+
+  //! Copy assigment (shallow copy).
+  BlockMultiVector<Scalar, LO, GO, Node>&
+  operator= (const BlockMultiVector<Scalar, LO, GO, Node>&) = default;
+
+  //! Move assigment (shallow move).
+  BlockMultiVector<Scalar, LO, GO, Node>&
+  operator= (BlockMultiVector<Scalar, LO, GO, Node>&&) = default;
+
+  //! "Copy constructor" with option to deep copy.
+  BlockMultiVector (const BlockMultiVector<Scalar, LO, GO, Node>& in,
+                    const Teuchos::DataAccess copyOrView);
+
   /// \brief Constructor that takes a mesh Map, a block size, and a
   ///   number of vectors (columns).
   ///
@@ -292,12 +316,6 @@ public:
   BlockMultiVector (const BlockMultiVector<Scalar, LO, GO, Node>& X,
                     const map_type& newMeshMap,
                     const size_t offset = 0);
-
-  /// \brief Default constructor.
-  ///
-  /// Creates an empty BlockMultiVector.  An empty BlockMultiVector
-  /// has zero rows, and block size zero.
-  BlockMultiVector ();
 
   //@}
   //! \name Access to Maps, the block size, and a MultiVector view.

--- a/packages/tpetra/core/src/Tpetra_Experimental_BlockVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Experimental_BlockVector_decl.hpp
@@ -141,6 +141,30 @@ public:
   //! \name Constructors
   //@{
 
+  /// \brief Default constructor.
+  ///
+  /// Creates an empty BlockVector.  An empty BlockVector has zero
+  /// rows, and block size zero.
+  BlockVector ();
+
+  //! Copy constructor (shallow copy).
+  BlockVector (const BlockVector<Scalar, LO, GO, Node>&) = default;
+
+  //! Move constructor (shallow move).
+  BlockVector (BlockVector<Scalar, LO, GO, Node>&&) = default;
+
+  //! Copy assigment (shallow copy).
+  BlockVector<Scalar, LO, GO, Node>&
+  operator= (const BlockVector<Scalar, LO, GO, Node>&) = default;
+
+  //! Move assigment (shallow move).
+  BlockVector<Scalar, LO, GO, Node>&
+  operator= (BlockVector<Scalar, LO, GO, Node>&&) = default;
+
+  //! "Copy constructor" with option to deep copy.
+  BlockVector (const BlockVector<Scalar, LO, GO, Node>& in,
+               const Teuchos::DataAccess copyOrView);
+
   /// \brief Constructor that takes a mesh Map and a block size.
   ///
   /// \param meshMap [in] Map that describes the distribution of mesh
@@ -229,12 +253,6 @@ public:
   BlockVector (const BlockVector<Scalar, LO, GO, Node>& X,
                const map_type& newMeshMap,
                const size_t offset = 0);
-
-  /// \brief Default constructor.
-  ///
-  /// Creates an empty BlockVector.  An empty BlockVector has zero
-  /// rows, and block size zero.
-  BlockVector ();
 
   //@}
   //! \name Access to Maps, the block size, and a Vector view.

--- a/packages/tpetra/core/src/Tpetra_Experimental_BlockVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Experimental_BlockVector_def.hpp
@@ -47,6 +47,19 @@ namespace Experimental {
 
   template<class Scalar, class LO, class GO, class Node>
   BlockVector<Scalar, LO, GO, Node>::
+  BlockVector () :
+    base_type ()
+  {}
+
+  template<class Scalar, class LO, class GO, class Node>
+  BlockVector<Scalar, LO, GO, Node>::
+  BlockVector (const BlockVector<Scalar, LO, GO, Node>& in,
+               const Teuchos::DataAccess copyOrView) :
+    base_type (in, copyOrView)
+  {}
+
+  template<class Scalar, class LO, class GO, class Node>
+  BlockVector<Scalar, LO, GO, Node>::
   BlockVector (const map_type& meshMap, const LO blockSize) :
     base_type (meshMap, blockSize, 1)
   {}
@@ -98,14 +111,9 @@ namespace Experimental {
   {}
 
   template<class Scalar, class LO, class GO, class Node>
-  BlockVector<Scalar, LO, GO, Node>::
-  BlockVector () : base_type () {}
-
-  template<class Scalar, class LO, class GO, class Node>
   typename BlockVector<Scalar, LO, GO, Node>::vec_type
   BlockVector<Scalar, LO, GO, Node>::getVectorView () {
     Teuchos::RCP<vec_type> vPtr = this->mv_.getVectorNonConst (0);
-    vPtr->setCopyOrView (Teuchos::View);
     return *vPtr; // shallow copy
   }
 
@@ -122,7 +130,6 @@ namespace Experimental {
   replaceGlobalValues (const GO globalRowIndex, const Scalar vals[]) const {
     return ((const base_type*) this)->replaceGlobalValues (globalRowIndex, 0, vals);
   }
-
 
   template<class Scalar, class LO, class GO, class Node>
   bool
@@ -152,17 +159,6 @@ namespace Experimental {
     return ((const base_type*) this)->getGlobalRowView (globalRowIndex, 0, vals);
   }
 
-  /// \brief Get a view of the degrees of freedom at the given mesh point.
-  ///
-  /// \warning This method's interface may change or disappear at any
-  ///   time.  Please do not rely on it in your code yet.
-  ///
-  /// The preferred way to refer to little_vec_type is to get it from
-  /// BlockVector's typedef.  This is because different
-  /// specializations of BlockVector reserve the right to use
-  /// different types to implement little_vec_type.  This gives us a
-  /// porting strategy to move from "classic" Tpetra to the Kokkos
-  /// refactor version.
   template<class Scalar, class LO, class GO, class Node>
   typename BlockVector<Scalar, LO, GO, Node>::little_vec_type
   BlockVector<Scalar, LO, GO, Node>::
@@ -170,7 +166,8 @@ namespace Experimental {
   {
     if (! this->isValidLocalMeshIndex (localRowIndex)) {
       return little_vec_type ();
-    } else {
+    }
+    else {
       const size_t blockSize = this->getBlockSize ();
       const size_t offset = localRowIndex * blockSize;
       return little_vec_type (this->getRawPtr () + offset, blockSize);

--- a/packages/tpetra/core/test/Block/BlockMultiVector.cpp
+++ b/packages/tpetra/core/test/Block/BlockMultiVector.cpp
@@ -135,6 +135,38 @@ namespace {
     map_type pointMap = BMV::makePointMap (meshMap, blockSize);
     TEST_ASSERT( pointMap.isSameAs (X.getPointMap ()) );
 
+    // Test BlockMultiVector's two-argument "copy constructor" that
+    // can make either a deep or a shallow copy.
+    {
+      BMV X2 (X, Teuchos::Copy);
+      auto X2_map = X2.getMap ();
+      const bool maps_ok = ! X2_map.is_null () &&
+        ! X.getMap ().is_null () &
+        X2_map->isSameAs (* (X.getMap ()));
+      TEST_ASSERT( maps_ok );
+
+      auto X_mv_h = X.getMultiVectorView ().getLocalViewHost ();
+      auto X2_mv_h = X2.getMultiVectorView ().getLocalViewHost ();
+      TEST_ASSERT( X_mv_h.extent (0) == X2_mv_h.extent (0) &&
+                   X_mv_h.extent (1) == X2_mv_h.extent (1) &&
+                   X_mv_h.data () != X2_mv_h.data () );
+    }
+
+    {
+      BMV X2 (X, Teuchos::View);
+      auto X2_map = X2.getMap ();
+      const bool maps_ok = ! X2_map.is_null () &&
+        ! X.getMap ().is_null () &
+        X2_map->isSameAs (* (X.getMap ()));
+      TEST_ASSERT( maps_ok );
+
+      auto X_mv_h = X.getMultiVectorView ().getLocalViewHost ();
+      auto X2_mv_h = X2.getMultiVectorView ().getLocalViewHost ();
+      TEST_ASSERT( X_mv_h.extent (0) == X2_mv_h.extent (0) &&
+                   X_mv_h.extent (1) == X2_mv_h.extent (1) &&
+                   X_mv_h.data () == X2_mv_h.data () );
+    }
+
     // Exercise the four-argument constructor (that uses an existing
     // point Map).
     BMV Y (meshMap, pointMap, blockSize, numVecs);
@@ -173,6 +205,38 @@ namespace {
                    V2.getLocalViewHost ().data () );
     TEST_EQUALITY( V1->getLocalViewDevice ().data (),
                    V2.getLocalViewDevice ().data () );
+
+    // Test BlockVector's two-argument "copy constructor" that can
+    // make either a deep or a shallow copy.
+    {
+      BV V_a (V, Teuchos::Copy);
+      auto V_a_map = V_a.getMap ();
+      const bool maps_ok = ! V_a_map.is_null () &&
+        ! V.getMap ().is_null () &
+        V_a_map->isSameAs (* (V.getMap ()));
+      TEST_ASSERT( maps_ok );
+
+      auto V_v_h = V.getVectorView ().getLocalViewHost ();
+      auto V_a_v_h = V_a.getVectorView ().getLocalViewHost ();
+      TEST_ASSERT( V_v_h.extent (0) == V_a_v_h.extent (0) &&
+                   V_v_h.extent (1) == V_a_v_h.extent (1) &&
+                   V_v_h.data () != V_a_v_h.data () );
+    }
+
+    {
+      BV V_a (V, Teuchos::View);
+      auto V_a_map = V_a.getMap ();
+      const bool maps_ok = ! V_a_map.is_null () &&
+        ! V.getMap ().is_null () &
+        V_a_map->isSameAs (* (V.getMap ()));
+      TEST_ASSERT( maps_ok );
+
+      auto V_v_h = V.getVectorView ().getLocalViewHost ();
+      auto V_a_v_h = V_a.getVectorView ().getLocalViewHost ();
+      TEST_ASSERT( V_v_h.extent (0) == V_a_v_h.extent (0) &&
+                   V_v_h.extent (1) == V_a_v_h.extent (1) &&
+                   V_v_h.data () == V_a_v_h.data () );
+    }
   }
 
   // Test BlockMultiVector::getMultiVectorView.  It must return a


### PR DESCRIPTION
@trilinos/tpetra @fnrizzi 

## Description

1. Add `= default` copy and move constructors and copy and move
   assignment operators to both BlockMultiVector and BlockVector.

2. Add two-argument "copy constructors" to both BlockMultiVector and
   BlockVector, just like MultiVector and Vector already have, that
   give users the option to deep copy or shallow copy.

3. Add tests for the two-argument "copy constructors."  They pass.

## Motivation and Context

SPARC wants this.

## Related Issues

* Closes #4627 