### PR TITLE
MueLu: updating some tests/unit_tests, see issue #5310

### DIFF
--- a/packages/muelu/research/regionMG/examples/structured/CMakeLists.txt
+++ b/packages/muelu/research/regionMG/examples/structured/CMakeLists.txt
@@ -18,7 +18,7 @@ IF (${PACKAGE_NAME}_ENABLE_Tpetra AND ${PACKAGE_NAME}_ENABLE_Amesos2)
   TRIBITS_ADD_TEST(
     StructuredRegionDriver
     NAME "Structured_Region_Star2D_Tpetra"
-    ARGS "--linAlgebra=Tpetra --xml=structured_1dof.xml --matrixType=Star2D --nx=10 --ny=10"
+    ARGS "--linAlgebra=Tpetra --xml=structured_1dof.xml --matrixType=Star2D --nx=10 --ny=10 --smootherIts=2"
     COMM serial mpi
     NUM_MPI_PROCS 1
     )
@@ -26,7 +26,7 @@ IF (${PACKAGE_NAME}_ENABLE_Tpetra AND ${PACKAGE_NAME}_ENABLE_Amesos2)
   TRIBITS_ADD_TEST(
     StructuredRegionDriver
     NAME "Structured_Region_Star2D_Tpetra"
-    ARGS "--linAlgebra=Tpetra --xml=structured_1dof.xml --matrixType=Star2D --nx=10 --ny=10"
+    ARGS "--linAlgebra=Tpetra --xml=structured_1dof.xml --matrixType=Star2D --nx=10 --ny=10 --smootherIts=2"
     COMM serial mpi
     NUM_MPI_PROCS 4
     )
@@ -34,7 +34,7 @@ IF (${PACKAGE_NAME}_ENABLE_Tpetra AND ${PACKAGE_NAME}_ENABLE_Amesos2)
   TRIBITS_ADD_TEST(
     StructuredRegionDriver
     NAME "Structured_Region_Linear_Star2D_Tpetra"
-    ARGS "--linAlgebra=Tpetra --xml=structured_linear_1dof.xml --matrixType=Star2D --nx=10 --ny=10"
+    ARGS "--linAlgebra=Tpetra --xml=structured_linear_1dof.xml --matrixType=Star2D --nx=10 --ny=10 --smootherIts=2"
     COMM serial mpi
     NUM_MPI_PROCS 1
     )
@@ -42,7 +42,7 @@ IF (${PACKAGE_NAME}_ENABLE_Tpetra AND ${PACKAGE_NAME}_ENABLE_Amesos2)
   TRIBITS_ADD_TEST(
     StructuredRegionDriver
     NAME "Structured_Region_Linear_Star2D_Tpetra"
-    ARGS "--linAlgebra=Tpetra --xml=structured_linear_1dof.xml --matrixType=Star2D --nx=10 --ny=10"
+    ARGS "--linAlgebra=Tpetra --xml=structured_linear_1dof.xml --matrixType=Star2D --nx=10 --ny=10 --smootherIts=2"
     COMM serial mpi
     NUM_MPI_PROCS 4
     )
@@ -50,7 +50,7 @@ IF (${PACKAGE_NAME}_ENABLE_Tpetra AND ${PACKAGE_NAME}_ENABLE_Amesos2)
   TRIBITS_ADD_TEST(
     StructuredRegionDriver
     NAME "Structured_Region_Brick3D_Tpetra"
-    ARGS "--linAlgebra=Tpetra --xml=structured_1dof.xml --matrixType=Brick3D --nx=10 --ny=10 --nz=10"
+    ARGS "--linAlgebra=Tpetra --xml=structured_1dof.xml --matrixType=Brick3D --nx=10 --ny=10 --nz=10 --smootherIts=2"
     COMM serial mpi
     NUM_MPI_PROCS 1
     )
@@ -58,7 +58,7 @@ IF (${PACKAGE_NAME}_ENABLE_Tpetra AND ${PACKAGE_NAME}_ENABLE_Amesos2)
   TRIBITS_ADD_TEST(
     StructuredRegionDriver
     NAME "Structured_Region_Brick3D_Tpetra"
-    ARGS "--linAlgebra=Tpetra --xml=structured_1dof.xml --matrixType=Brick3D --nx=10 --ny=10 --nz=10"
+    ARGS "--linAlgebra=Tpetra --xml=structured_1dof.xml --matrixType=Brick3D --nx=10 --ny=10 --nz=10 --smootherIts=2"
     COMM serial mpi
     NUM_MPI_PROCS 4
     )
@@ -66,7 +66,7 @@ IF (${PACKAGE_NAME}_ENABLE_Tpetra AND ${PACKAGE_NAME}_ENABLE_Amesos2)
   TRIBITS_ADD_TEST(
     StructuredRegionDriver
     NAME "Structured_Region_Linear_Brick3D_Tpetra"
-    ARGS "--linAlgebra=Tpetra --xml=structured_linear_1dof.xml --matrixType=Brick3D --nx=10 --ny=10 --nz=10"
+    ARGS "--linAlgebra=Tpetra --xml=structured_linear_1dof.xml --matrixType=Brick3D --nx=10 --ny=10 --nz=10 --smootherIts=2"
     COMM serial mpi
     NUM_MPI_PROCS 1
     )
@@ -74,7 +74,7 @@ IF (${PACKAGE_NAME}_ENABLE_Tpetra AND ${PACKAGE_NAME}_ENABLE_Amesos2)
   TRIBITS_ADD_TEST(
     StructuredRegionDriver
     NAME "Structured_Region_Linear_Brick3D_Tpetra"
-    ARGS "--linAlgebra=Tpetra --xml=structured_linear_1dof.xml --matrixType=Brick3D --nx=10 --ny=10 --nz=10"
+    ARGS "--linAlgebra=Tpetra --xml=structured_linear_1dof.xml --matrixType=Brick3D --nx=10 --ny=10 --nz=10 --smootherIts=2"
     COMM serial mpi
     NUM_MPI_PROCS 4
     )

--- a/packages/muelu/test/unit_tests/StructuredAggregationFactory.cpp
+++ b/packages/muelu/test/unit_tests/StructuredAggregationFactory.cpp
@@ -1383,10 +1383,10 @@ namespace MueLuTests {
           prolongatorGraph->getLocalRowView(rowIdx, rowIndices);
 
           if(interpolationOrder == 0) {
-            if(rowIndices[0] != indicesConstant[rowIdx]) {++numErrors;}
+            if(rowIndices[0] != indicesConstant[rankOffsets[myRank] + rowIdx]) {++numErrors;}
           } else {
             for(size_t entryIdx = 0; entryIdx < prolongatorGraph->getNumEntriesInLocalRow(rowIdx); ++entryIdx) {
-              if(rowIndices[entryIdx] != indicesLinear[rowOffset[rowIdx] + entryIdx]) {++numErrors;}
+              if(rowIndices[entryIdx] != indicesLinear[rowOffset[rankOffsets[myRank] + rowIdx] + entryIdx]) {++numErrors;}
             }
           }
         }
@@ -1543,10 +1543,10 @@ namespace MueLuTests {
           prolongatorGraph->getLocalRowView(rowIdx, rowIndices);
 
           if(interpolationOrder == 0) {
-            if(rowIndices[0] != indicesConstant[rowIdx]) {++numErrors;}
+            if(rowIndices[0] != indicesConstant[rankOffsets[myRank] + rowIdx]) {++numErrors;}
           } else {
             for(size_t entryIdx = 0; entryIdx < prolongatorGraph->getNumEntriesInLocalRow(rowIdx); ++entryIdx) {
-              if(rowIndices[entryIdx] != indicesLinear[rowOffset[rowIdx] + entryIdx]) {++numErrors;}
+              if(rowIndices[entryIdx] != indicesLinear[rowOffset[rankOffsets[myRank] + rowIdx] + entryIdx]) {++numErrors;}
             }
           }
         }

--- a/packages/muelu/test/unit_tests_kokkos/TentativePFactory_kokkos.cpp
+++ b/packages/muelu/test/unit_tests_kokkos/TentativePFactory_kokkos.cpp
@@ -150,14 +150,14 @@ namespace MueLuTests {
     diff->norm2(norms);
     for (LO i=0; i<NSdim; ++i) {
       out << "||diff_" << i << "||_2 = " << norms[i] << std::endl;
-      TEST_EQUALITY(norms[i] < 100*TMT::eps(), true);
+      TEST_COMPARE_CONST(norms[i], <, 100*TMT::eps());
     }
 
     Teuchos::ArrayRCP<const double> col1 = coarseNullSpace->getData(0);
     Teuchos::ArrayRCP<const double> col2 = coarseNullSpace->getData(1);
     TEST_EQUALITY(col1.size() == col2.size(), true);
 
-  } //MakeTentative  Lapack QR
+  } // MakeTentative  Lapack QR
 #endif
 
   TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TentativePFactory_kokkos, MakeTentative, Scalar, LocalOrdinal, GlobalOrdinal, Node)
@@ -245,7 +245,7 @@ namespace MueLuTests {
     diff->norm2(norms);
     for (LO i = 0; i < NSdim; ++i) {
       out << "||diff_" << i << "||_2 = " << norms[i] << std::endl;
-      TEST_EQUALITY(norms[i] < 100*TMT::eps(), true);
+      TEST_COMPARE_CONST(norms[i], <, 100*TMT::eps());
     }
 
     // Check normalization and orthogonality of prolongator columns by
@@ -253,13 +253,14 @@ namespace MueLuTests {
     RCP<Matrix> PtentTPtent = MatrixMatrix::Multiply(*Ptent, true, *Ptent, false, out);
     RCP<Vector> diagVec     = VectorFactory::Build(PtentTPtent->getRowMap());
     PtentTPtent->getLocalDiagCopy(*diagVec);
+    if (STS::name().find("complex") == std::string::npos) { //skip check for Scalar=complex
+      TEST_EQUALITY(diagVec->norm1(), diagVec->getGlobalLength());
+      TEST_FLOATING_EQUALITY(diagVec->normInf(), TMT::one(), 100*TMT::eps());
+    }
     if (STS::name().find("complex") == std::string::npos) //skip check for Scalar=complex
-      TEST_EQUALITY(diagVec->norm1(),                     diagVec->getGlobalLength());
-    TEST_EQUALITY(diagVec->normInf()-1 < 100*TMT::eps(),         true);
-    if (STS::name().find("complex") == std::string::npos) //skip check for Scalar=complex
-    TEST_EQUALITY(diagVec->meanValue(),                 1.0);
+      TEST_FLOATING_EQUALITY(STS::magnitude(diagVec->meanValue()), TMT::one(), 100*TMT::eps());
     TEST_EQUALITY(PtentTPtent->getGlobalNumEntries(),   diagVec->getGlobalLength());
-  }
+  } // MakeTentative
 
   TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TentativePFactory_kokkos, MakeTentativeVectorBasedUsingDefaultNullSpace, Scalar, LocalOrdinal, GlobalOrdinal, Node)
   {
@@ -351,7 +352,7 @@ namespace MueLuTests {
     Array<magnitude_type> norms(NSdim);
     diff->norm2(norms);
     for (decltype(NSdim) i = 0; i < NSdim; ++i)
-      TEST_EQUALITY(norms[i] < 100*TMT::eps(), true);
+      TEST_COMPARE_CONST(norms[i], <, 100*TMT::eps());
 
     // Check normalization and orthogonality of prolongator columns by
     // making sure that P^T*P = I
@@ -359,12 +360,12 @@ namespace MueLuTests {
     RCP<Vector> diagVec     = VectorFactory::Build(PtentTPtent->getRowMap());
     PtentTPtent->getLocalDiagCopy(*diagVec);
     if (STS::name().find("complex") == std::string::npos) //skip check for Scalar=complex
-      TEST_EQUALITY(STS::magnitude(diagVec->norm1() - diagVec->getGlobalLength()) < 100*TMT::eps(), true);
-    TEST_EQUALITY(STS::magnitude(diagVec->normInf() - 1.0) < 100*TMT::eps(), true);
+      TEST_FLOATING_EQUALITY(diagVec->norm1(), STS::magnitude(diagVec->getGlobalLength()), 100*TMT::eps());
+    TEST_FLOATING_EQUALITY(diagVec->normInf(), TMT::one(), 100*TMT::eps());
     if (STS::name().find("complex") == std::string::npos) //skip check for Scalar=complex
-      TEST_EQUALITY(Teuchos::ScalarTraits<SC>::magnitude(diagVec->meanValue() - 1.0) < 100*TMT::eps(), true);
+      TEST_FLOATING_EQUALITY(STS::magnitude(diagVec->meanValue()), TMT::one(), 100*TMT::eps());
     TEST_EQUALITY(PtentTPtent->getGlobalNumEntries(), diagVec->getGlobalLength());
-  }
+  } // MakeTentativeVectorBasedUsingDefaultNullSpace
 
   TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(TentativePFactory_kokkos, MakeTentativeUsingDefaultNullSpace, Scalar, LocalOrdinal, GlobalOrdinal, Node)
   {
@@ -446,7 +447,7 @@ namespace MueLuTests {
     Teuchos::Array<magnitude_type> norms(NSdim);
     diff->norm2(norms);
     for (LO i=0; i<NSdim; ++i)
-      TEST_EQUALITY(norms[i] < 100*TMT::eps(), true);
+      TEST_COMPARE_CONST(norms[i], <, 100*TMT::eps());
 
   } //MakeTentativeUsingDefaultNullSpace
 
@@ -639,7 +640,11 @@ namespace MueLuTests {
 
     RCP<const Teuchos::Comm<int> > comm = Teuchos::DefaultComm<int>::getComm();
 
-    Teuchos::Array<Teuchos::ScalarTraits<SC>::magnitudeType> results(2);
+    using TST            = Teuchos::ScalarTraits<SC>;
+    using magnitude_type = typename TST::magnitudeType;
+    using TMT            = Teuchos::ScalarTraits<magnitudeType>;
+
+    Teuchos::Array<magnitude_type> results(2);
 
     // run test only on 1 proc
     if(comm->getSize() == 1)
@@ -666,7 +671,7 @@ namespace MueLuTests {
         // build nullspace
         RCP<MultiVector> nullSpace = MultiVectorFactory::Build(map,1);
         nullSpace->putScalar( (SC) 1.0);
-        Teuchos::Array<Teuchos::ScalarTraits<SC>::magnitudeType> norms(1);
+        Teuchos::Array<magnitude_type> norms(1);
         nullSpace->norm1(norms);
         if (comm->getRank() == 0)
           out << "||NS|| = " << norms[0] << std::endl;
@@ -733,9 +738,9 @@ namespace MueLuTests {
         Teuchos::RCP<Xpetra::Matrix<Scalar,LO,GO,Node> > PtentTPtent = Xpetra::MatrixMatrix<Scalar,LO,GO,Node>::Multiply(*P1,true,*P1,false,out);
         Teuchos::RCP<Xpetra::Vector<Scalar,LO,GO,Node> > diagVec = Xpetra::VectorFactory<Scalar,LO,GO,Node>::Build(PtentTPtent->getRowMap());
         PtentTPtent->getLocalDiagCopy(*diagVec);
-        TEST_EQUALITY(diagVec->norm1()-diagVec->getGlobalLength() < 1e-12, true);
-        TEST_EQUALITY(diagVec->normInf()-1 < 1e-12, true);
-        TEST_EQUALITY(diagVec->meanValue()-1 < 1e-12, true);
+        TEST_FLOATING_EQUALITY(diagVec->norm1(), TST::magnitude(diagVec->getGlobalLength()), 100*TMT:eps());
+        TEST_FLOATING_EQUALITY(diagVec->normInf(), TMT::one(), 100*TMT:eps());
+        TEST_FLOATING_EQUALITY(diagVec->meanValue(), TMT::one(), 100*TMT:eps());
         TEST_EQUALITY(PtentTPtent->getGlobalNumEntries(), diagVec->getGlobalLength());
 
         // Define RHS
@@ -762,7 +767,7 @@ namespace MueLuTests {
         }
       }
 
-      TEST_FLOATING_EQUALITY(results[0], results[1], 1e-14); // check results of EPETRA vs TPETRA
+      TEST_FLOATING_EQUALITY(results[0], results[1], 100*TMT::eps()); // check results of EPETRA vs TPETRA
     } // comm->getSize == 1
 
   } // TentativePFactory_EpetraVsTpetra


### PR DESCRIPTION
@trilinos/muelu 

## Description
Three updates are made to the testing infrastructure of MueLu:
      1) Fixing a bug in Structured Aggregation unit_test
      2) Using more appropriate Teuchos macros in TentativePFactory_kokkos unit_test
      3) reducing the amount of smoothing in StructuredRegion to speed up these tests

## Motivation and Context
This should both lead to more verbose errors when these tests are failing and it should also lead to more passing tests.

## Related Issues

* Closes #5310 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 

## How Has This Been Tested?
Local build and test passed fine

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.