### PR TITLE
Panzer: fix multiblock test for order check

### DIFF
--- a/packages/panzer/adapters-stk/example/MixedPoissonExample/CMakeLists.txt
+++ b/packages/panzer/adapters-stk/example/MixedPoissonExample/CMakeLists.txt
@@ -81,7 +81,7 @@ FOREACH( ORDER 1)
     TEST_2 CMND python
       ARGS ${CMAKE_CURRENT_SOURCE_DIR}/convergence_rate.py
          ${ORDER}
-         MPE-ConvTest-Hex-p${ORDER}-
+         MPE-Multiblock-ConvTest-Hex-p${ORDER}-
          6
          12
       PASS_REGULAR_EXPRESSION "Test Passed"


### PR DESCRIPTION
This fixes the multiblock test and could account for some of the random failures mentioned in #5179  but does not explain why the other tests are failing.