### PR TITLE
MueLu: fixing some issues in MakeQuasiRegionMatrix logic

### DIFF
--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionMatrix_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionMatrix_def.hpp
@@ -73,10 +73,10 @@ using Teuchos::Array;
  *
  */
 template<class LocalOrdinal, class GlobalOrdinal, class Node>
-std::vector<int> findCommonRegions(const GlobalOrdinal nodeA, ///< GID of first node
-                                   const GlobalOrdinal nodeB, ///< GID of second node
-                                   const Xpetra::MultiVector<LocalOrdinal, LocalOrdinal, GlobalOrdinal, Node>& nodesToRegions ///< mapping of nodes to regions
-                                   )
+Teuchos::Array<int> findCommonRegions(const GlobalOrdinal nodeA, ///< GID of first node
+                                      const GlobalOrdinal nodeB, ///< GID of second node
+                                      const Xpetra::MultiVector<LocalOrdinal, LocalOrdinal, GlobalOrdinal, Node>& nodesToRegions ///< mapping of nodes to regions
+                                      )
 {
 #include "Xpetra_UseShortNamesOrdinal.hpp"
 
@@ -101,7 +101,7 @@ std::vector<int> findCommonRegions(const GlobalOrdinal nodeA, ///< GID of first 
   commonRegions.resize(it - commonRegions.begin());
 
   // remove '-1' entries
-  std::vector<int> finalCommonRegions;
+  Teuchos::Array<int> finalCommonRegions;
   for (std::size_t i = 0; i < commonRegions.size(); ++i) {
     if (commonRegions[i] != -1)
       finalCommonRegions.push_back(commonRegions[i]);
@@ -503,35 +503,33 @@ void MakeQuasiregionMatrices(const RCP<Xpetra::CrsMatrixWrap<Scalar, LocalOrdina
    */
 
 
-  // copy and modify the composite matrix
-  RCP<Matrix> ACompSplit = MatrixFactory::BuildCopy(AComp);
-  ACompSplit->resumeFill();
+  // // copy and modify the composite matrix
+  // RCP<Matrix> ACompSplit = MatrixFactory::BuildCopy(AComp);
+  // ACompSplit->resumeFill();
 
-  for (LocalOrdinal row = 0; row < Teuchos::as<LocalOrdinal>(ACompSplit->getNodeNumRows()); row++) { // loop over local rows of composite matrix
-    GlobalOrdinal rowGID = ACompSplit->getRowMap()->getGlobalElement(row);
-    std::size_t numEntries = ACompSplit->getNumEntriesInLocalRow(row); // number of entries in this row
-    Teuchos::Array<Scalar> vals(numEntries); // non-zeros in this row
-    Teuchos::Array<LocalOrdinal> inds(numEntries); // local column indices
-    ACompSplit->getLocalRowCopy(row, inds, vals, numEntries);
+  // for (LocalOrdinal row = 0; row < Teuchos::as<LocalOrdinal>(ACompSplit->getNodeNumRows()); row++) { // loop over local rows of composite matrix
+  //   GlobalOrdinal rowGID = ACompSplit->getRowMap()->getGlobalElement(row);
+  //   std::size_t numEntries = ACompSplit->getNumEntriesInLocalRow(row); // number of entries in this row
+  //   Teuchos::Array<Scalar> vals(numEntries); // non-zeros in this row
+  //   Teuchos::Array<LocalOrdinal> inds(numEntries); // local column indices
+  //   ACompSplit->getLocalRowCopy(row, inds, vals, numEntries);
 
-    for (std::size_t c = 0; c < Teuchos::as<std::size_t>(inds.size()); ++c) { // loop over all entries in this row
-      LocalOrdinal col = inds[c];
-      GlobalOrdinal colGID = ACompSplit->getColMap()->getGlobalElement(col);
-      std::vector<int> commonRegions;
-      if (rowGID != colGID) { // Skip the diagonal entry. It will be processed later.
-        commonRegions = findCommonRegions(rowGID, colGID, *regionsPerGIDWithGhosts);
-      }
+  //   for (std::size_t c = 0; c < Teuchos::as<std::size_t>(inds.size()); ++c) { // loop over all entries in this row
+  //     LocalOrdinal col = inds[c];
+  //     GlobalOrdinal colGID = ACompSplit->getColMap()->getGlobalElement(col);
+  //     Array<int> commonRegions;
+  //     if (rowGID != colGID) { // Skip the diagonal entry. It will be processed later.
+  //       commonRegions = findCommonRegions(rowGID, colGID, *regionsPerGIDWithGhosts);
+  //     }
 
-      if (commonRegions.size() > 1) {
-        vals[c] *= (1.0/ ((double) commonRegions.size())) ;
-      }
-    }
+  //     if (commonRegions.size() > 1) {
+  //       vals[c] *= (1.0 / static_cast<double>(commonRegions.size()));
+  //     }
+  //   }
 
-    ACompSplit->replaceLocalValues(row, inds, vals);
-  }
-
-//  ACompSplit->fillComplete();
-  ACompSplit->fillComplete(AComp->getDomainMap(), AComp->getRangeMap());
+  //   ACompSplit->replaceLocalValues(row, inds, vals);
+  // }
+  // ACompSplit->fillComplete(AComp->getDomainMap(), AComp->getRangeMap());
 
   // Import data from ACompSplit into the quasiRegion matrices
   // Since the stencil size does not grow between composite and region format
@@ -540,11 +538,35 @@ void MakeQuasiregionMatrices(const RCP<Xpetra::CrsMatrixWrap<Scalar, LocalOrdina
   for (int j = 0; j < maxRegPerProc; j++) {
     quasiRegionGrpMats[j] = MatrixFactory::Build(rowMapPerGrp[j],
                                                  colMapPerGrp[j],
-                                                 ACompSplit->getCrsGraph()->getNodeMaxNumRowEntries(),
+                                                 AComp->getCrsGraph()->getNodeMaxNumRowEntries(),
                                                  Xpetra::DynamicProfile);
-    quasiRegionGrpMats[j]->doImport(*ACompSplit,
+    quasiRegionGrpMats[j]->doImport(*AComp,
                                     *(rowImportPerGrp[j]),
                                     Xpetra::INSERT);
+
+    for (LO row = 0; row < Teuchos::as<LO>(quasiRegionGrpMats[j]->getNodeNumRows()); ++row) { // loop over local rows of composite matrix
+      GO rowGID = rowMapPerGrp[j]->getGlobalElement(row);
+      std::size_t numEntries = quasiRegionGrpMats[j]->getNumEntriesInLocalRow(row); // number of entries in this row
+      Teuchos::Array<SC> vals(numEntries); // non-zeros in this row
+      Teuchos::Array<LO> inds(numEntries); // local column indices
+      quasiRegionGrpMats[j]->getLocalRowCopy(row, inds, vals, numEntries);
+
+      for (std::size_t c = 0; c < Teuchos::as<std::size_t>(inds.size()); ++c) { // loop over all entries in this row
+        LocalOrdinal col = inds[c];
+        GlobalOrdinal colGID = colMapPerGrp[j]->getGlobalElement(col);
+        Array<int> commonRegions;
+        if (rowGID != colGID) { // Skip the diagonal entry. It will be processed later.
+          commonRegions = findCommonRegions(rowGID, colGID, *regionsPerGIDWithGhosts);
+        }
+
+        if (commonRegions.size() > 1) {
+          vals[c] *= (1.0 / static_cast<double>(commonRegions.size()));
+        }
+      }
+
+      quasiRegionGrpMats[j]->replaceLocalValues(row, inds, vals);
+    }
+
     quasiRegionGrpMats[j]->fillComplete();
   }
 }

--- a/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
+++ b/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
@@ -1089,8 +1089,10 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
     }
   } // end of regionsPerGIDView's scope
 
+  // sleep(1);
   // if(myRank == 0) std::cout << "regionsPerGID:" << std::endl;
   // regionsPerGID->describe(*Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout)), Teuchos::VERB_EXTREME);
+  // sleep(1);
 
   comm->barrier();
   tm = Teuchos::null;
@@ -1119,12 +1121,14 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
   colImportPerGrp[0] = ImportFactory::Build(dofMap, colMapPerGrp[0]);
 
   RCP<Xpetra::MultiVector<LO, LO, GO, NO> > regionsPerGIDWithGhosts
-    = Xpetra::MultiVectorFactory<LO, LO, GO, NO>::Build(A->getColMap(), maxRegPerGID, false);
+    = Xpetra::MultiVectorFactory<LO, LO, GO, NO>::Build(rowMapPerGrp[0], maxRegPerGID, false);
   RCP<Import> regionsPerGIDImport = ImportFactory::Build(A->getRowMap(), A->getColMap());
-  regionsPerGIDWithGhosts->doImport(*regionsPerGID, *regionsPerGIDImport, Xpetra::INSERT);
+  regionsPerGIDWithGhosts->doImport(*regionsPerGID, *rowImportPerGrp[0], Xpetra::INSERT);
 
+  // sleep(1);
   // if(myRank == 0) std::cout << "regionsPerGIDWithGhosts:" << std::endl;
   // regionsPerGIDWithGhosts->describe(*Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout)), Teuchos::VERB_EXTREME);
+  // sleep(1);
 
   std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > quasiRegionGrpMats(1);
   MakeQuasiregionMatrices(Teuchos::rcp_dynamic_cast<CrsMatrixWrap>(A), maxRegPerProc,
@@ -1136,14 +1140,20 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
                      revisedRowMapPerGrp, revisedColMapPerGrp,
                      rowImportPerGrp, maxRegPerProc, quasiRegionGrpMats, regionGrpMats);
 
+  // sleep(1);
   // if(myRank == 0) std::cout << "composite A:" << std::endl;
   // A->describe(*Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout)), Teuchos::VERB_EXTREME);
+  // sleep(1);
 
+  // sleep(1);
   // if(myRank == 0) std::cout << "quasi-region A:" << std::endl;
   // quasiRegionGrpMats[0]->describe(*Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout)), Teuchos::VERB_EXTREME);
+  // sleep(1);
 
+  // sleep(1);
   // if(myRank == 0) std::cout << "region A:" << std::endl;
   // regionGrpMats[0]->describe(*Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout)), Teuchos::VERB_EXTREME);
+  // sleep(1);
 
   comm->barrier();
   tm = Teuchos::null;


### PR DESCRIPTION
@trilinos/muelu 

## Description
Two parts of the regionMG code are modified:
- `regionsPerGIDWithGhost` is now built using `rowMapPerGrp` instead of `AComp->getColMap()` which makes it independent of the discretization use to build `AComp`
- the construction of `quasiRegionMatrix` has been modified due to some logic error...

## Motivation and Context
This fixes a logic error which could potentially lead to bugs down the road when running more complex problems.

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to #5135 
* Part of 
* Composed of 

## How Has This Been Tested?
I have done a local build and local test of my modifications.

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.
