### PR TITLE
Use -D_GLIBCXX_USE_CXX11_ABI=0 to allow using gcc-7.2.0 with intel-180.5 with boost (#5335)

### DIFF
--- a/cmake/std/atdm/sems-rhel7/environment.sh
+++ b/cmake/std/atdm/sems-rhel7/environment.sh
@@ -41,13 +41,14 @@ elif [[ "$ATDM_CONFIG_COMPILER" == "GNU"* ]]; then
 elif [[ "$ATDM_CONFIG_COMPILER" == "INTEL"* ]]; then
   if [[ "$ATDM_CONFIG_COMPILER" == "INTEL" ]] ; then
     export ATDM_CONFIG_COMPILER=INTEL-18.0.5
-  elif [[ "$ATDM_CONFIG_COMPILER" != "INTEL-17.0.1" ]] ; then
+  elif [[ "$ATDM_CONFIG_COMPILER" != "INTEL-17.0.1" ]] || [[ "$ATDM_CONFIG_COMPILER" != "INTEL-18.0.5" ]]; then
     echo
     echo "***"
     echo "*** ERROR: INTEL COMPILER=$ATDM_CONFIG_COMPILER is not supported!"
     echo "*** Only INTEL compilers supported on this system are:"
-    echo "***   intel (defaults to intel-17.0.1)"
+    echo "***   intel (defaults to intel-18.0.5)"
     echo "***   intel-17.0.1"
+    echo "***   intel-18.0.5"
     echo "***"
     return
   fi

--- a/cmake/std/atdm/sems-rhel7/environment.sh
+++ b/cmake/std/atdm/sems-rhel7/environment.sh
@@ -41,7 +41,8 @@ elif [[ "$ATDM_CONFIG_COMPILER" == "GNU"* ]]; then
 elif [[ "$ATDM_CONFIG_COMPILER" == "INTEL"* ]]; then
   if [[ "$ATDM_CONFIG_COMPILER" == "INTEL" ]] ; then
     export ATDM_CONFIG_COMPILER=INTEL-18.0.5
-  elif [[ "$ATDM_CONFIG_COMPILER" != "INTEL-17.0.1" ]] || [[ "$ATDM_CONFIG_COMPILER" != "INTEL-18.0.5" ]]; then
+  elif [[ "$ATDM_CONFIG_COMPILER" != "INTEL-17.0.1" ]] \
+    && [[ "$ATDM_CONFIG_COMPILER" != "INTEL-18.0.5" ]]; then
     echo
     echo "***"
     echo "*** ERROR: INTEL COMPILER=$ATDM_CONFIG_COMPILER is not supported!"

--- a/cmake/std/atdm/sems-rhel7/environment.sh
+++ b/cmake/std/atdm/sems-rhel7/environment.sh
@@ -165,6 +165,7 @@ elif [[ "$ATDM_CONFIG_COMPILER" == "INTEL-18.0.5" ]] ; then
   module load sems-intel/18.0.5
   module load atdm-env
   module load atdm-mkl/18.0.5
+  export ATDM_CONFIG_CXX_FLAGS="-D_GLIBCXX_USE_CXX11_ABI=0"
   export OMPI_CXX=`which icpc`
   export OMPI_CC=`which icc`
   export OMPI_FC=`which ifort`

--- a/cmake/std/atdm/utils/set_build_options.sh
+++ b/cmake/std/atdm/utils/set_build_options.sh
@@ -117,8 +117,14 @@ elif [[ $ATDM_CONFIG_BUILD_NAME == *"gnu"* ]]; then
   export ATDM_CONFIG_COMPILER=GNU
 elif [[ $ATDM_CONFIG_BUILD_NAME == *"intel-17.0.1"* ]]; then
  export ATDM_CONFIG_COMPILER=INTEL-17.0.1
+elif [[ $ATDM_CONFIG_BUILD_NAME == *"intel-17"* ]]; then
+ export ATDM_CONFIG_COMPILER=INTEL-17.0.1
 elif [[ $ATDM_CONFIG_BUILD_NAME == *"intel-18.0.2"* ]]; then
  export ATDM_CONFIG_COMPILER=INTEL-18.0.2
+elif [[ $ATDM_CONFIG_BUILD_NAME == *"intel-18.0.5"* ]]; then
+ export ATDM_CONFIG_COMPILER=INTEL-18.0.5
+elif [[ $ATDM_CONFIG_BUILD_NAME == *"intel-18"* ]]; then
+ export ATDM_CONFIG_COMPILER=INTEL-18.0.5
 elif [[ $ATDM_CONFIG_BUILD_NAME == *"intel"* ]]; then
  export ATDM_CONFIG_COMPILER=INTEL
 elif [[ $ATDM_CONFIG_BUILD_NAME == *"clang-3.9.0"* ]]; then


### PR DESCRIPTION
CC: @krcb 

This change switches Intel 18.0.5 with the GCC 7.2.0 backend to match the ABI
used with the SEMS-built Boost lib built with Intel 18.0.5 with the GCC 4.9.3
backend.

This appears to fix the link issues and all of the STK and Panzer tests build
and pass on the machine where there were problems (see #5335).

I tested this on 'ascicgpu15' with:

```
$ ./checkin-test-atdm.sh \
    sems-rhel7-intel-18.0.5-openmp-complex-shared-release-debug \
    --enable-packages=STK,Panzer --local-do-all --make-options=-j10 --ctest-options=j10
```

which returned:

```
1) sems-rhel7-intel-18.0.5-openmp-complex-shared-release-debug Results:
-----------------------------------------------------------------------

  passed: Trilinos/sems-rhel7-intel-18.0.5-openmp-complex-shared-release-debug: passed=170,notpassed=0
  
  Tue Jun 11 09:19:34 MDT 2019
  
  Enabled Packages: STK, Panzer
  Hostname: ascicgpu15
  Source Dir: /scratch/rabartl/Trilinos.base/Trilinos/cmake/tribits/ci_support/../../..
  Build Dir: /scratch/rabartl/Trilinos.base/BUILDS/ATDM/SEMS-RHEL7/CHECKIN/sems-rhel7-intel-18.0.5-openmp-complex-shared-release-debug
  
  CMake Cache Varibles: -GNinja -DTrilinos_TRIBITS_DIR:PATH=/scratch/rabartl/Trilinos.base/Trilinos/cmake/tribits -DTrilinos_ENABLE_TESTS:BOOL=ON -DTrilinos_TEST_CATEGORIES:STRING=NIGHTLY -DTrilinos_ALLOW_NO_PACKAGES:BOOL=OFF -DDART_TESTING_TIMEOUT:STRING=600.0 -GNinja -DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/atdm/ATDMDevEnv.cmake -DTrilinos_TRACE_ADD_TEST=ON -DTrilinos_ENABLE_STK:BOOL=ON -DTrilinos_ENABLE_Panzer:BOOL=ON -DTrilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=ON -DTrilinos_ENABLE_ALL_FORWARD_DEP_PACKAGES:BOOL=OFF
  Make Options: -j10
  CTest Options: j10
  
  Pull: Not Performed
  Configure: Passed (1.47 min)
  Build: Passed (71.59 min)
  Test: Passed (5.10 min)
  
  100% tests passed, 0 tests failed out of 170
  
  Subproject Time Summary:
  Panzer    = 1038.66 sec*proc (167 tests)
  STK       =   1.57 sec*proc (3 tests)
  
  Total Test time (real) = 306.25 sec
  
  Total time for sems-rhel7-intel-18.0.5-openmp-complex-shared-release-debug = 78.16 min

```


