### PR TITLE
Set python executable for cmake

### DIFF
--- a/cmake/std/PullRequestLinuxPython2.cmake
+++ b/cmake/std/PullRequestLinuxPython2.cmake
@@ -14,5 +14,7 @@
 set (TFW_Python2_Testing ON CACHE BOOL "Set by default for PR testing")
 set (TFW_Python_Testing ON CACHE BOOL "Set by default for PR testing")
 
+set(PYTHON_EXECUTABLE /projects/sierra/linux_rh7/install/Python/2.7.15/bin/python CACHE FILEPATH "Set by default for PR testing")
+
 include("${CMAKE_CURRENT_LIST_DIR}/PullRequestLinuxCommonTestingSettings.cmake")
 

--- a/cmake/std/PullRequestLinuxPython3.cmake
+++ b/cmake/std/PullRequestLinuxPython3.cmake
@@ -14,5 +14,7 @@
 set (TFW_Python3_Testing ON CACHE BOOL "Set by default for PR testing")
 set (TFW_Python_Testing ON CACHE BOOL "Set by default for PR testing")
 
+set(PYTHON_EXECUTABLE /projects/sierra/linux_rh7/install/Python/3.6.3/bin/python CACHE FILEPATH "Set by default for PR testing")
+
 include("${CMAKE_CURRENT_LIST_DIR}/PullRequestLinuxCommonTestingSettings.cmake")
 

--- a/cmake/std/sems/PullRequestPython2TestingEnv.sh
+++ b/cmake/std/sems/PullRequestPython2TestingEnv.sh
@@ -33,11 +33,8 @@ module load sems-ninja_fortran/1.8.2
 # to one that has the mock packages installed
 module unload sems-python
 # module load sierra-python/2.7.15 - permissions do not allow this, but the execs are ok
-PATH=/projects/sierra/linux_rh7/install/Python/2.7.15/bin:${PATH}
+export PATH=/projects/sierra/linux_rh7/install/Python/2.7.15/bin:${PATH}
 PATH=/projects/sierra/linux_rh7/install/Python/extras/bin:${PATH}
-PYTHONPATH=/projects/sierra/linux_rh7/install/Python/extras/lib/python2.7/site-packages:${PYTHONPATH}
-MANPATH=/projects/sierra/linux_rh7/install/Python/2.7.15/share/man:${MANPATH}
+export PYTHONPATH=/projects/sierra/linux_rh7/install/Python/extras/lib/python2.7/site-packages:${PYTHONPATH}
+export MANPATH=/projects/sierra/linux_rh7/install/Python/2.7.15/share/man:${MANPATH}
 unset PYTHONHOME 
-
-# add the OpenMP environment variable we need
-export OMP_NUM_THREADS=2

--- a/cmake/std/sems/PullRequestPython3TestingEnv.sh
+++ b/cmake/std/sems/PullRequestPython3TestingEnv.sh
@@ -37,12 +37,9 @@ module load atdm-ninja_fortran/1.7.2
 # to one that has the proper sym-links from python -> python3
 module unload sems-python
 # module load sierra-python/3.6.3 - permissions do not allow this, but the execs are ok
-PATH=/projects/sierra/linux_rh7/install/Python/3.6..3/bin:${PATH}
+export PATH=/projects/sierra/linux_rh7/install/Python/3.6..3/bin:${PATH}
 PATH=/projects/sierra/linux_rh7/install/Python/extras/bin:${PATH}
-PYTHONPATH=/projects/sierra/linux_rh7/install/Python/extras/lib/python3.6/site-packages:${PYTHONPATH}
-MANPATH=/projects/sierra/linux_rh7/install/Python/3.6.3/share/man:${MANPATH}
+export PYTHONPATH=/projects/sierra/linux_rh7/install/Python/extras/lib/python3.6/site-packages:${PYTHONPATH}
+export MANPATH=/projects/sierra/linux_rh7/install/Python/3.6.3/share/man:${MANPATH}
 unset PYTHONHOME 
-
-# add the OpenMP environment variable we need
-export OMP_NUM_THREADS=2
 

--- a/cmake/std/sems/PullRequestPython3TestingEnv.sh
+++ b/cmake/std/sems/PullRequestPython3TestingEnv.sh
@@ -37,7 +37,7 @@ module load atdm-ninja_fortran/1.7.2
 # to one that has the proper sym-links from python -> python3
 module unload sems-python
 # module load sierra-python/3.6.3 - permissions do not allow this, but the execs are ok
-export PATH=/projects/sierra/linux_rh7/install/Python/3.6..3/bin:${PATH}
+export PATH=/projects/sierra/linux_rh7/install/Python/3.6.3/bin:${PATH}
 PATH=/projects/sierra/linux_rh7/install/Python/extras/bin:${PATH}
 export PYTHONPATH=/projects/sierra/linux_rh7/install/Python/extras/lib/python3.6/site-packages:${PYTHONPATH}
 export MANPATH=/projects/sierra/linux_rh7/install/Python/3.6.3/share/man:${MANPATH}


### PR DESCRIPTION
Not sure why it still uses /usr/bin even though this one is
first in the path. This allow the tests to run, but they still need to be added to the autotester list.

@trilinos/framework

## How Has This Been Tested?
I ran this by hand on my blade and will run this PR against the Jenkins jobs Trilinos_pullrequest_python_2 and Trilinos_pullrequest_python_3

