### PR TITLE
Add a few more mocks.

### DIFF
--- a/commonTools/framework/clean_workspace/unittests/test_clean_sentinel.py
+++ b/commonTools/framework/clean_workspace/unittests/test_clean_sentinel.py
@@ -36,7 +36,8 @@ class TestCleanReferenceDate(unittest.TestCase):
         """Test that the function returns the expected date"""
         testDate = datetime(2019, 2, 4, hour=10, minute=45,
                             second=0, microsecond=0, tzinfo=None)
-        self.assertEqual(testDate, clean_reference_date())
+        with mock.patch("clean_sentinel.open", side_effect=IOError):
+            self.assertEqual(testDate, clean_reference_date())
 
     def test_stored_date(self):
         """If a different date has been stored make sure it gets retrieved"""

--- a/commonTools/framework/clean_workspace/unittests/test_clean_workspace.py
+++ b/commonTools/framework/clean_workspace/unittests/test_clean_workspace.py
@@ -138,7 +138,8 @@ class TestCleanSpaceByDate(unittest.TestCase):
         with mock.patch.dict('os.environ',
                              {'WORKSPACE': '/scratch/Trilinos/foo/bar'}):
             with mock.patch('clean_workspace.Cleaner.force_clean_space') as force_clean, \
-                 mock.patch('clean_workspace.update_last_clean_date') as update:
+                 mock.patch('clean_workspace.update_last_clean_date') as update, \
+                 mock.patch("clean_sentinel.open", side_effect=IOError):
                 cleanerInst.clean_space_by_date()
             force_clean.assert_not_called()
             update.assert_not_called()
@@ -174,7 +175,8 @@ class TestCleanSpaceByDate(unittest.TestCase):
             cleanerInst.args = test_args
             with mock.patch('clean_workspace.Cleaner.force_clean_space') as force_clean, \
                  mock.patch('clean_workspace.update_last_clean_date') as update, \
-                 mock.patch('clean_workspace.print') as m_print:
+                 mock.patch('clean_workspace.print') as m_print, \
+                 mock.patch("clean_sentinel.open", side_effect=IOError):
                 cleanerInst.clean_space_by_date()
             force_clean.assert_called_once_with()
             update.assert_called_once_with()


### PR DESCRIPTION
These tests would fail if run as trilinos and if the reference date
file was available. This adds a mock to  make the tests think no
reference file is available.

@trilinos/framework 

## Description
Needed for adding this to the PR testing.