### PR TITLE
Teuchos:  ostream deprecation following strategy in #5085

### DIFF
--- a/packages/anasazi/epetra/test/OrthoManager/cxx_gentest.cpp
+++ b/packages/anasazi/epetra/test/OrthoManager/cxx_gentest.cpp
@@ -287,7 +287,7 @@ int main(int argc, char *argv[])
       lapack.POTRF('U',yTx1.numCols(),yTx1.values(),yTx1.stride(),&info);
       TEUCHOS_TEST_FOR_EXCEPTION(info != 0,std::runtime_error,
           "New <Y1,X1> not s.p.d.: couldn't computed Cholesky: info == " << info
-          << "\nyTx1: \n" << yTx1);
+          << "\nyTx1: \n" << Print(yTx1));
 
       // X2 ortho to Y1
       MVT::MvRandom(*X2);
@@ -347,7 +347,7 @@ int main(int argc, char *argv[])
       lapack.POTRF('U',yTx2.numCols(),yTx2.values(),yTx2.stride(),&info);
       TEUCHOS_TEST_FOR_EXCEPTION(info != 0,std::runtime_error,
           "New <Y2,X2> not s.p.d.: couldn't computed Cholesky: info == " << info
-          << "\nyTx2: \n" << yTx2);
+          << "\nyTx2: \n" << Print(yTx2));
     }
     MyOM->stream(Warnings) << endl;
 

--- a/packages/anasazi/epetra/test/OrthoManager/cxx_gentest.cpp
+++ b/packages/anasazi/epetra/test/OrthoManager/cxx_gentest.cpp
@@ -287,7 +287,7 @@ int main(int argc, char *argv[])
       lapack.POTRF('U',yTx1.numCols(),yTx1.values(),yTx1.stride(),&info);
       TEUCHOS_TEST_FOR_EXCEPTION(info != 0,std::runtime_error,
           "New <Y1,X1> not s.p.d.: couldn't computed Cholesky: info == " << info
-          << "\nyTx1: \n" << Print(yTx1));
+          << "\nyTx1: \n" << printMat(yTx1));
 
       // X2 ortho to Y1
       MVT::MvRandom(*X2);
@@ -347,7 +347,7 @@ int main(int argc, char *argv[])
       lapack.POTRF('U',yTx2.numCols(),yTx2.values(),yTx2.stride(),&info);
       TEUCHOS_TEST_FOR_EXCEPTION(info != 0,std::runtime_error,
           "New <Y2,X2> not s.p.d.: couldn't computed Cholesky: info == " << info
-          << "\nyTx2: \n" << Print(yTx2));
+          << "\nyTx2: \n" << printMat(yTx2));
     }
     MyOM->stream(Warnings) << endl;
 

--- a/packages/anasazi/epetra/test/OrthoManager/cxx_mattest.cpp
+++ b/packages/anasazi/epetra/test/OrthoManager/cxx_mattest.cpp
@@ -661,13 +661,13 @@ int testProjectAndNormalizeMat(RCP<MatOrthoManager<ST,MV,OP> > OM,
           if (err > ATOL*TOL) {
             sout << "S\n" << *S << endl;
             sout << "S_out\n" << *S_outs[o] << endl;
-            sout << "B_out\n" << *B_outs[o] << endl;
+            sout << "B_out\n" << Print(*B_outs[o]) << endl;
             if (C_outs[o].size() > 0) {
               sout << "X1\n" << *X1 << endl;
-              sout << "C_out[1]\n" << *C_outs[o][0] << endl;
+              sout << "C_out[1]\n" << Print(*C_outs[o][0]) << endl;
               if (C_outs[o].size() > 1) {
                 sout << "X22n" << *X2 << endl;
-                sout << "C_out[2]\n" << *C_outs[o][1] << endl;
+                sout << "C_out[2]\n" << Print(*C_outs[o][1]) << endl;
               }
             }
           }

--- a/packages/anasazi/epetra/test/OrthoManager/cxx_mattest.cpp
+++ b/packages/anasazi/epetra/test/OrthoManager/cxx_mattest.cpp
@@ -661,13 +661,13 @@ int testProjectAndNormalizeMat(RCP<MatOrthoManager<ST,MV,OP> > OM,
           if (err > ATOL*TOL) {
             sout << "S\n" << *S << endl;
             sout << "S_out\n" << *S_outs[o] << endl;
-            sout << "B_out\n" << Print(*B_outs[o]) << endl;
+            sout << "B_out\n" << printMat(*B_outs[o]) << endl;
             if (C_outs[o].size() > 0) {
               sout << "X1\n" << *X1 << endl;
-              sout << "C_out[1]\n" << Print(*C_outs[o][0]) << endl;
+              sout << "C_out[1]\n" << printMat(*C_outs[o][0]) << endl;
               if (C_outs[o].size() > 1) {
                 sout << "X22n" << *X2 << endl;
-                sout << "C_out[2]\n" << Print(*C_outs[o][1]) << endl;
+                sout << "C_out[2]\n" << printMat(*C_outs[o][1]) << endl;
               }
             }
           }

--- a/packages/anasazi/src/AnasaziBlockDavidsonSolMgr.hpp
+++ b/packages/anasazi/src/AnasaziBlockDavidsonSolMgr.hpp
@@ -680,7 +680,7 @@ BlockDavidsonSolMgr<ScalarType,MV,OP>::solve() {
           {
             std::stringstream os;
             os << "KK before HEEV...\n"
-              << *state.KK << "\n";
+              << Print(*state.KK) << "\n";
             *out << os.str();
           }
 #       endif
@@ -696,7 +696,7 @@ BlockDavidsonSolMgr<ScalarType,MV,OP>::solve() {
             *out << "Ritz values from heev(KK):\n";
             for (unsigned int i=0; i<theta.size(); i++) *out << theta[i] << " ";
             os << "\nRitz vectors from heev(KK):\n" 
-                                                 << S << "\n";
+                                                 << Print(S) << "\n";
             *out << os.str();
           }
 #       endif
@@ -716,7 +716,7 @@ BlockDavidsonSolMgr<ScalarType,MV,OP>::solve() {
             *out << "Ritz values from heev(KK) after sorting:\n";
             std::copy(theta.begin(), theta.end(), std::ostream_iterator<ScalarType>(*out, " "));
             os << "\nRitz vectors from heev(KK) after sorting:\n" 
-              << S << "\n";
+              << Print(S) << "\n";
             *out << os.str();
           }
 #       endif
@@ -727,7 +727,7 @@ BlockDavidsonSolMgr<ScalarType,MV,OP>::solve() {
           {
             std::stringstream os;
             os << "Significant primitive Ritz vectors:\n"
-              << Sr << "\n";
+              << Print(Sr) << "\n";
             *out << os.str();
           }
 #       endif
@@ -757,7 +757,7 @@ BlockDavidsonSolMgr<ScalarType,MV,OP>::solve() {
           {
             std::stringstream os;
             os << "Sr'*KK*Sr:\n"
-              << newKK << "\n";
+              << Print(newKK) << "\n";
             *out << os.str();
           }
 #       endif

--- a/packages/anasazi/src/AnasaziBlockDavidsonSolMgr.hpp
+++ b/packages/anasazi/src/AnasaziBlockDavidsonSolMgr.hpp
@@ -680,7 +680,7 @@ BlockDavidsonSolMgr<ScalarType,MV,OP>::solve() {
           {
             std::stringstream os;
             os << "KK before HEEV...\n"
-              << Print(*state.KK) << "\n";
+              << printMat(*state.KK) << "\n";
             *out << os.str();
           }
 #       endif
@@ -696,7 +696,7 @@ BlockDavidsonSolMgr<ScalarType,MV,OP>::solve() {
             *out << "Ritz values from heev(KK):\n";
             for (unsigned int i=0; i<theta.size(); i++) *out << theta[i] << " ";
             os << "\nRitz vectors from heev(KK):\n" 
-                                                 << Print(S) << "\n";
+                                                 << printMat(S) << "\n";
             *out << os.str();
           }
 #       endif
@@ -716,7 +716,7 @@ BlockDavidsonSolMgr<ScalarType,MV,OP>::solve() {
             *out << "Ritz values from heev(KK) after sorting:\n";
             std::copy(theta.begin(), theta.end(), std::ostream_iterator<ScalarType>(*out, " "));
             os << "\nRitz vectors from heev(KK) after sorting:\n" 
-              << Print(S) << "\n";
+              << printMat(S) << "\n";
             *out << os.str();
           }
 #       endif
@@ -727,7 +727,7 @@ BlockDavidsonSolMgr<ScalarType,MV,OP>::solve() {
           {
             std::stringstream os;
             os << "Significant primitive Ritz vectors:\n"
-              << Print(Sr) << "\n";
+              << printMat(Sr) << "\n";
             *out << os.str();
           }
 #       endif
@@ -757,7 +757,7 @@ BlockDavidsonSolMgr<ScalarType,MV,OP>::solve() {
           {
             std::stringstream os;
             os << "Sr'*KK*Sr:\n"
-              << Print(newKK) << "\n";
+              << printMat(newKK) << "\n";
             *out << os.str();
           }
 #       endif

--- a/packages/anasazi/src/AnasaziIRTR.hpp
+++ b/packages/anasazi/src/AnasaziIRTR.hpp
@@ -889,15 +889,15 @@ namespace Anasazi {
         MVT::MvTransMv(ONE,*this->delta_,*this->Adelta_,AA);
         MVT::MvTransMv(ONE,*this->delta_,*this->Bdelta_,BB);
       }
-      this->om_->stream(Debug) << "AA: " << std::endl << AA << std::endl;;
-      this->om_->stream(Debug) << "BB: " << std::endl << BB << std::endl;;
+      this->om_->stream(Debug) << "AA: " << std::endl << Print(AA) << std::endl;;
+      this->om_->stream(Debug) << "BB: " << std::endl << Print(BB) << std::endl;;
       {
 #ifdef ANASAZI_TEUCHOS_TIME_MONITOR
         TimeMonitor lcltimer( *this->timerDS_ );
 #endif
         ret = Utils::directSolver(AA.numRows(),AA,Teuchos::rcpFromRef(BB),S,newtheta,rank,1);
       }
-      this->om_->stream(Debug) << "S: " << std::endl << S << std::endl;;
+      this->om_->stream(Debug) << "S: " << std::endl << Print(S) << std::endl;;
       TEUCHOS_TEST_FOR_EXCEPTION(ret != 0,std::logic_error,"Anasazi::IRTR::iterate(): failure solving projected eigenproblem after retraction. ret == " << ret);
       TEUCHOS_TEST_FOR_EXCEPTION(rank != AA.numRows(),RTRRitzFailure,"Anasazi::IRTR::iterate(): retracted iterate failed in Ritz analysis. rank == " << rank);
 

--- a/packages/anasazi/src/AnasaziIRTR.hpp
+++ b/packages/anasazi/src/AnasaziIRTR.hpp
@@ -889,15 +889,15 @@ namespace Anasazi {
         MVT::MvTransMv(ONE,*this->delta_,*this->Adelta_,AA);
         MVT::MvTransMv(ONE,*this->delta_,*this->Bdelta_,BB);
       }
-      this->om_->stream(Debug) << "AA: " << std::endl << Print(AA) << std::endl;;
-      this->om_->stream(Debug) << "BB: " << std::endl << Print(BB) << std::endl;;
+      this->om_->stream(Debug) << "AA: " << std::endl << printMat(AA) << std::endl;;
+      this->om_->stream(Debug) << "BB: " << std::endl << printMat(BB) << std::endl;;
       {
 #ifdef ANASAZI_TEUCHOS_TIME_MONITOR
         TimeMonitor lcltimer( *this->timerDS_ );
 #endif
         ret = Utils::directSolver(AA.numRows(),AA,Teuchos::rcpFromRef(BB),S,newtheta,rank,1);
       }
-      this->om_->stream(Debug) << "S: " << std::endl << Print(S) << std::endl;;
+      this->om_->stream(Debug) << "S: " << std::endl << printMat(S) << std::endl;;
       TEUCHOS_TEST_FOR_EXCEPTION(ret != 0,std::logic_error,"Anasazi::IRTR::iterate(): failure solving projected eigenproblem after retraction. ret == " << ret);
       TEUCHOS_TEST_FOR_EXCEPTION(rank != AA.numRows(),RTRRitzFailure,"Anasazi::IRTR::iterate(): retracted iterate failed in Ritz analysis. rank == " << rank);
 

--- a/packages/anasazi/src/AnasaziSIRTR.hpp
+++ b/packages/anasazi/src/AnasaziSIRTR.hpp
@@ -925,8 +925,8 @@ namespace Anasazi {
 #endif
         MVT::MvTransMv(ONE,*XpEta,*XpEta,BB);
       }
-      this->om_->stream(Debug) << "AA: " << std::endl << AA << std::endl;;
-      this->om_->stream(Debug) << "BB: " << std::endl << BB << std::endl;;
+      this->om_->stream(Debug) << "AA: " << std::endl << Print(AA) << std::endl;;
+      this->om_->stream(Debug) << "BB: " << std::endl << Print(BB) << std::endl;;
       // do the direct solve
       // save old theta first
       std::vector<MagnitudeType> oldtheta(this->theta_);
@@ -936,8 +936,8 @@ namespace Anasazi {
 #endif
         ret = Utils::directSolver(this->blockSize_,AA,Teuchos::rcpFromRef(BB),S,this->theta_,rank,1);
       }
-      this->om_->stream(Debug) << "S: " << std::endl << S << std::endl;;
-      TEUCHOS_TEST_FOR_EXCEPTION(ret != 0,std::logic_error,"Anasazi::SIRTR::iterate(): failure solving projected eigenproblem after retraction. ret == " << ret << "AA: " << AA << std::endl << "BB: " << BB << std::endl);
+      this->om_->stream(Debug) << "S: " << std::endl << Print(S) << std::endl;;
+      TEUCHOS_TEST_FOR_EXCEPTION(ret != 0,std::logic_error,"Anasazi::SIRTR::iterate(): failure solving projected eigenproblem after retraction. ret == " << ret << "AA: " << Print(AA) << std::endl << "BB: " << Print(BB) << std::endl);
       TEUCHOS_TEST_FOR_EXCEPTION(rank != this->blockSize_,RTRRitzFailure,"Anasazi::SIRTR::iterate(): retracted iterate failed in Ritz analysis. rank == " << rank);
 
       //

--- a/packages/anasazi/src/AnasaziSIRTR.hpp
+++ b/packages/anasazi/src/AnasaziSIRTR.hpp
@@ -925,8 +925,8 @@ namespace Anasazi {
 #endif
         MVT::MvTransMv(ONE,*XpEta,*XpEta,BB);
       }
-      this->om_->stream(Debug) << "AA: " << std::endl << Print(AA) << std::endl;;
-      this->om_->stream(Debug) << "BB: " << std::endl << Print(BB) << std::endl;;
+      this->om_->stream(Debug) << "AA: " << std::endl << printMat(AA) << std::endl;;
+      this->om_->stream(Debug) << "BB: " << std::endl << printMat(BB) << std::endl;;
       // do the direct solve
       // save old theta first
       std::vector<MagnitudeType> oldtheta(this->theta_);
@@ -936,8 +936,8 @@ namespace Anasazi {
 #endif
         ret = Utils::directSolver(this->blockSize_,AA,Teuchos::rcpFromRef(BB),S,this->theta_,rank,1);
       }
-      this->om_->stream(Debug) << "S: " << std::endl << Print(S) << std::endl;;
-      TEUCHOS_TEST_FOR_EXCEPTION(ret != 0,std::logic_error,"Anasazi::SIRTR::iterate(): failure solving projected eigenproblem after retraction. ret == " << ret << "AA: " << Print(AA) << std::endl << "BB: " << Print(BB) << std::endl);
+      this->om_->stream(Debug) << "S: " << std::endl << printMat(S) << std::endl;;
+      TEUCHOS_TEST_FOR_EXCEPTION(ret != 0,std::logic_error,"Anasazi::SIRTR::iterate(): failure solving projected eigenproblem after retraction. ret == " << ret << "AA: " << printMat(AA) << std::endl << "BB: " << printMat(BB) << std::endl);
       TEUCHOS_TEST_FOR_EXCEPTION(rank != this->blockSize_,RTRRitzFailure,"Anasazi::SIRTR::iterate(): retracted iterate failed in Ritz analysis. rank == " << rank);
 
       //

--- a/packages/belos/src/BelosLSQRIter.hpp
+++ b/packages/belos/src/BelosLSQRIter.hpp
@@ -578,13 +578,13 @@ class LSQRIter : virtual public Belos::Iteration<ScalarType,MV,OP> {
           // 2. confirm that U is a unit vector
           Teuchos::SerialDenseMatrix<int,ScalarType> uotuo(1,1);
           MVT::MvTransMv( one, *U_, *U_, uotuo );
-          std::cout << "<U, U> = " << Print(uotuo) << std::endl;
+          std::cout << "<U, U> = " << printMat(uotuo) << std::endl;
           // 3. print alpha =  <V, A'U>
           std::cout << "alpha = "  << alpha[0] << std::endl;
           // 4. compute < AV, U> which ought to be alpha
           Teuchos::SerialDenseMatrix<int,ScalarType> utav(1,1);
           MVT::MvTransMv( one, *AV, *U_, utav );
-          std::cout << "<AV, U> = alpha = " << Print(utav) << std::endl;
+          std::cout << "<AV, U> = alpha = " << printMat(utav) << std::endl;
         }
 
       MVT::MvAddMv( one, *AV, -alpha[0], *U_, *U_ ); // uNew := Av - uOld alphaOld

--- a/packages/belos/src/BelosLSQRIter.hpp
+++ b/packages/belos/src/BelosLSQRIter.hpp
@@ -578,13 +578,13 @@ class LSQRIter : virtual public Belos::Iteration<ScalarType,MV,OP> {
           // 2. confirm that U is a unit vector
           Teuchos::SerialDenseMatrix<int,ScalarType> uotuo(1,1);
           MVT::MvTransMv( one, *U_, *U_, uotuo );
-          std::cout << "<U, U> = " << uotuo << std::endl;
+          std::cout << "<U, U> = " << Print(uotuo) << std::endl;
           // 3. print alpha =  <V, A'U>
           std::cout << "alpha = "  << alpha[0] << std::endl;
           // 4. compute < AV, U> which ought to be alpha
           Teuchos::SerialDenseMatrix<int,ScalarType> utav(1,1);
           MVT::MvTransMv( one, *AV, *U_, utav );
-          std::cout << "<AV, U> = alpha = " << utav << std::endl;
+          std::cout << "<AV, U> = alpha = " << Print(utav) << std::endl;
         }
 
       MVT::MvAddMv( one, *AV, -alpha[0], *U_, *U_ ); // uNew := Av - uOld alphaOld

--- a/packages/rol/adapters/teuchos/test/function/test_01.cpp
+++ b/packages/rol/adapters/teuchos/test/function/test_01.cpp
@@ -243,10 +243,10 @@ int main( int argc, char *argv[] ) {
       }
     }
 
-    *outStream << "\nA = " << *A;
-    *outStream << "\nb = " << *b;
-    *outStream << "\nC = " << *C;
-    *outStream << "\nd = " << *d;
+    *outStream << "\nA = " << Print(*A);
+    *outStream << "\nb = " << Print(*b);
+    *outStream << "\nC = " << Print(*C);
+    *outStream << "\nd = " << Print(*d);
     
 
     auto x = rcp( new Vector{Nopt,1} );

--- a/packages/rol/adapters/teuchos/test/function/test_01.cpp
+++ b/packages/rol/adapters/teuchos/test/function/test_01.cpp
@@ -243,10 +243,10 @@ int main( int argc, char *argv[] ) {
       }
     }
 
-    *outStream << "\nA = " << Print(*A);
-    *outStream << "\nb = " << Print(*b);
-    *outStream << "\nC = " << Print(*C);
-    *outStream << "\nd = " << Print(*d);
+    *outStream << "\nA = " << printMat(*A);
+    *outStream << "\nb = " << printMat(*b);
+    *outStream << "\nC = " << printMat(*C);
+    *outStream << "\nd = " << printMat(*d);
     
 
     auto x = rcp( new Vector{Nopt,1} );

--- a/packages/rol/example/dense-hessian/example_01.cpp
+++ b/packages/rol/example/dense-hessian/example_01.cpp
@@ -113,8 +113,8 @@ int main(int argc, char *argv[]) {
     // Compute dense Hessian.
     Teuchos::SerialDenseMatrix<int, RealT> H = ROL::computeDenseHessian(obj, x);
     Teuchos::SerialDenseMatrix<int, RealT> H_scaled = ROL::computeScaledDenseHessian(obj, x);
-    *outStream << H;
-    *outStream << H_scaled;
+    *outStream << printMat(H);
+    *outStream << printMat(H_scaled);
 
     // Compute Hessian error.
     Teuchos::SerialDenseMatrix<int, RealT> H_true(2, 2);

--- a/packages/stokhos/src/Stokhos_GSReducedPCEBasisBaseImp.hpp
+++ b/packages/stokhos/src/Stokhos_GSReducedPCEBasisBaseImp.hpp
@@ -226,7 +226,7 @@ print(std::ostream& os) const
 {
   os << "Gram-Schmidt basis of order " << p << ", dimension " << d 
      << ", and size " << sz << ".  Matrix coefficients:\n";
-  os << Qp << std::endl;
+  os << Print(Qp) << std::endl;
   os << "Basis vector norms (squared):\n\t";
   for (ordinal_type i=0; i<sz; i++)
     os << norms[i] << " ";

--- a/packages/stokhos/src/Stokhos_GSReducedPCEBasisBaseImp.hpp
+++ b/packages/stokhos/src/Stokhos_GSReducedPCEBasisBaseImp.hpp
@@ -226,7 +226,7 @@ print(std::ostream& os) const
 {
   os << "Gram-Schmidt basis of order " << p << ", dimension " << d 
      << ", and size " << sz << ".  Matrix coefficients:\n";
-  os << Print(Qp) << std::endl;
+  os << printMat(Qp) << std::endl;
   os << "Basis vector norms (squared):\n\t";
   for (ordinal_type i=0; i<sz; i++)
     os << norms[i] << " ";

--- a/packages/stokhos/src/Stokhos_GramSchmidtBasisImp.hpp
+++ b/packages/stokhos/src/Stokhos_GramSchmidtBasisImp.hpp
@@ -259,7 +259,7 @@ print(std::ostream& os) const
 {
   os << "Gram-Schmidt basis of order " << p << ", dimension " << d 
      << ", and size " << sz << ".  Matrix coefficients:\n";
-  os << Print(gs_mat) << std::endl;
+  os << printMat(gs_mat) << std::endl;
   os << "Basis vector norms (squared):\n\t";
   for (ordinal_type i=0; i<sz; i++)
     os << norms[i] << " ";

--- a/packages/stokhos/src/Stokhos_GramSchmidtBasisImp.hpp
+++ b/packages/stokhos/src/Stokhos_GramSchmidtBasisImp.hpp
@@ -259,7 +259,7 @@ print(std::ostream& os) const
 {
   os << "Gram-Schmidt basis of order " << p << ", dimension " << d 
      << ", and size " << sz << ".  Matrix coefficients:\n";
-  os << gs_mat << std::endl;
+  os << Print(gs_mat) << std::endl;
   os << "Basis vector norms (squared):\n\t";
   for (ordinal_type i=0; i<sz; i++)
     os << norms[i] << " ";

--- a/packages/stokhos/src/Stokhos_MonomialProjGramSchmidtPCEBasis2Imp.hpp
+++ b/packages/stokhos/src/Stokhos_MonomialProjGramSchmidtPCEBasis2Imp.hpp
@@ -379,7 +379,7 @@ print(std::ostream& os) const
 {
   os << "Gram-Schmidt basis of order " << p << ", dimension " << d 
      << ", and size " << sz << ".  Matrix coefficients:\n";
-  os << Print(Qp) << std::endl;
+  os << printMat(Qp) << std::endl;
   os << "Basis vector norms (squared):\n\t";
   for (ordinal_type i=0; i<sz; i++)
     os << norms[i] << " ";

--- a/packages/stokhos/src/Stokhos_MonomialProjGramSchmidtPCEBasis2Imp.hpp
+++ b/packages/stokhos/src/Stokhos_MonomialProjGramSchmidtPCEBasis2Imp.hpp
@@ -379,7 +379,7 @@ print(std::ostream& os) const
 {
   os << "Gram-Schmidt basis of order " << p << ", dimension " << d 
      << ", and size " << sz << ".  Matrix coefficients:\n";
-  os << Qp << std::endl;
+  os << Print(Qp) << std::endl;
   os << "Basis vector norms (squared):\n\t";
   for (ordinal_type i=0; i<sz; i++)
     os << norms[i] << " ";

--- a/packages/stokhos/src/Stokhos_ProductLanczosGramSchmidtPCEBasisImp.hpp
+++ b/packages/stokhos/src/Stokhos_ProductLanczosGramSchmidtPCEBasisImp.hpp
@@ -309,7 +309,7 @@ print(std::ostream& os) const
   os << "Product Lanczos Gram-Schmidt basis of order " << p << ", dimension " 
      << d 
      << ", and size " << sz << ".  Matrix coefficients:\n";
-  os << Print(Qp) << std::endl;
+  os << printMat(Qp) << std::endl;
   os << "Basis vector norms (squared):\n\t";
   for (ordinal_type i=0; i<sz; i++)
     os << norms[i] << " ";

--- a/packages/stokhos/src/Stokhos_ProductLanczosGramSchmidtPCEBasisImp.hpp
+++ b/packages/stokhos/src/Stokhos_ProductLanczosGramSchmidtPCEBasisImp.hpp
@@ -309,7 +309,7 @@ print(std::ostream& os) const
   os << "Product Lanczos Gram-Schmidt basis of order " << p << ", dimension " 
      << d 
      << ", and size " << sz << ".  Matrix coefficients:\n";
-  os << Qp << std::endl;
+  os << Print(Qp) << std::endl;
   os << "Basis vector norms (squared):\n\t";
   for (ordinal_type i=0; i<sz; i++)
     os << norms[i] << " ";

--- a/packages/stokhos/test/UnitTest/Stokhos_GramSchmidtUnitTest.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_GramSchmidtUnitTest.cpp
@@ -235,7 +235,7 @@ namespace GramSchmidtTest {
     if (!success) {
       out << "\n Error, mat.normInf() < tol = " << mat.normInf() 
 	  << " < " << tol << ": failed!\n";
-      out << "mat = " << mat << std::endl;
+      out << "mat = " << Print(mat) << std::endl;
     }
   }
 

--- a/packages/stokhos/test/UnitTest/Stokhos_GramSchmidtUnitTest.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_GramSchmidtUnitTest.cpp
@@ -235,7 +235,7 @@ namespace GramSchmidtTest {
     if (!success) {
       out << "\n Error, mat.normInf() < tol = " << mat.normInf() 
 	  << " < " << tol << ": failed!\n";
-      out << "mat = " << Print(mat) << std::endl;
+      out << "mat = " << printMat(mat) << std::endl;
     }
   }
 

--- a/packages/stokhos/test/UnitTest/Stokhos_HermiteBasisUnitTest.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_HermiteBasisUnitTest.cpp
@@ -136,7 +136,7 @@ namespace HermiteBasisUnitTest {
     if (!success) {
       out << "\n Error, mat.normInf() < atol = " << mat.normInf() 
 	  << " < " << setup.atol << ": failed!\n";
-      out << "mat = " << mat << std::endl;
+      out << "mat = " << Print(mat) << std::endl;
     }
   }
 

--- a/packages/stokhos/test/UnitTest/Stokhos_HermiteBasisUnitTest.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_HermiteBasisUnitTest.cpp
@@ -136,7 +136,7 @@ namespace HermiteBasisUnitTest {
     if (!success) {
       out << "\n Error, mat.normInf() < atol = " << mat.normInf() 
 	  << " < " << setup.atol << ": failed!\n";
-      out << "mat = " << Print(mat) << std::endl;
+      out << "mat = " << printMat(mat) << std::endl;
     }
   }
 

--- a/packages/stokhos/test/UnitTest/Stokhos_LanczosUnitTest.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_LanczosUnitTest.cpp
@@ -211,7 +211,7 @@ namespace BASENAME ## TAG {						\
     if (!success) {							\
       out << "\n Error, mat.normInf() < atol = " << mat.normInf()	\
 	  << " < " << setup.atol << ": failed!\n";			\
-      out << "mat = " << Print(mat) << std::endl;			\
+      out << "mat = " << printMat(mat) << std::endl;			\
     }									\
   }									\
 									\

--- a/packages/stokhos/test/UnitTest/Stokhos_LanczosUnitTest.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_LanczosUnitTest.cpp
@@ -211,7 +211,7 @@ namespace BASENAME ## TAG {						\
     if (!success) {							\
       out << "\n Error, mat.normInf() < atol = " << mat.normInf()	\
 	  << " < " << setup.atol << ": failed!\n";			\
-      out << "mat = " << mat << std::endl;				\
+      out << "mat = " << Print(mat) << std::endl;			\
     }									\
   }									\
 									\

--- a/packages/stokhos/test/UnitTest/Stokhos_LegendreBasisUnitTest.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_LegendreBasisUnitTest.cpp
@@ -133,7 +133,7 @@ namespace LegendreBasisUnitTest {
     if (!success) {
       out << "\n Error, mat.normInf() < atol = " << mat.normInf() 
 	  << " < " << setup.atol << ": failed!\n";
-      out << "mat = " << mat << std::endl;
+      out << "mat = " << Print(mat) << std::endl;
     }
   }
 

--- a/packages/stokhos/test/UnitTest/Stokhos_LegendreBasisUnitTest.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_LegendreBasisUnitTest.cpp
@@ -133,7 +133,7 @@ namespace LegendreBasisUnitTest {
     if (!success) {
       out << "\n Error, mat.normInf() < atol = " << mat.normInf() 
 	  << " < " << setup.atol << ": failed!\n";
-      out << "mat = " << Print(mat) << std::endl;
+      out << "mat = " << printMat(mat) << std::endl;
     }
   }
 

--- a/packages/stokhos/test/UnitTest/Stokhos_NormalizedHermiteBasisUnitTest.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_NormalizedHermiteBasisUnitTest.cpp
@@ -136,7 +136,7 @@ namespace HermiteBasisUnitTest {
     if (!success) {
       out << "\n Error, mat.normInf() < atol = " << mat.normInf() 
 	  << " < " << setup.atol << ": failed!\n";
-      out << "mat = " << mat << std::endl;
+      out << "mat = " << Print(mat) << std::endl;
     }
   }
 

--- a/packages/stokhos/test/UnitTest/Stokhos_NormalizedHermiteBasisUnitTest.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_NormalizedHermiteBasisUnitTest.cpp
@@ -136,7 +136,7 @@ namespace HermiteBasisUnitTest {
     if (!success) {
       out << "\n Error, mat.normInf() < atol = " << mat.normInf() 
 	  << " < " << setup.atol << ": failed!\n";
-      out << "mat = " << Print(mat) << std::endl;
+      out << "mat = " << printMat(mat) << std::endl;
     }
   }
 

--- a/packages/stokhos/test/UnitTest/Stokhos_NormalizedLegendreBasisUnitTest.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_NormalizedLegendreBasisUnitTest.cpp
@@ -133,7 +133,7 @@ namespace LegendreBasisUnitTest {
     if (!success) {
       out << "\n Error, mat.normInf() < atol = " << mat.normInf() 
 	  << " < " << setup.atol << ": failed!\n";
-      out << "mat = " << mat << std::endl;
+      out << "mat = " << Print(mat) << std::endl;
     }
   }
 

--- a/packages/stokhos/test/UnitTest/Stokhos_NormalizedLegendreBasisUnitTest.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_NormalizedLegendreBasisUnitTest.cpp
@@ -133,7 +133,7 @@ namespace LegendreBasisUnitTest {
     if (!success) {
       out << "\n Error, mat.normInf() < atol = " << mat.normInf() 
 	  << " < " << setup.atol << ": failed!\n";
-      out << "mat = " << Print(mat) << std::endl;
+      out << "mat = " << printMat(mat) << std::endl;
     }
   }
 

--- a/packages/stokhos/test/UnitTest/Stokhos_StieltjesUnitTest.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_StieltjesUnitTest.cpp
@@ -202,7 +202,7 @@ namespace StieltjesCosTest {
     if (!success) {
       out << "\n Error, mat.normInf() < atol = " << mat.normInf() 
 	  << " < " << setup.atol << ": failed!\n";
-      out << "mat = " << Print(mat) << std::endl;
+      out << "mat = " << printMat(mat) << std::endl;
     }
   }
 
@@ -285,7 +285,7 @@ namespace StieltjesSinTest {
     if (!success) {
       out << "\n Error, mat.normInf() < atol = " << mat.normInf() 
 	  << " < " << setup.atol << ": failed!\n";
-      out << "mat = " << Print(mat) << std::endl;
+      out << "mat = " << printMat(mat) << std::endl;
     }
   }
 
@@ -368,7 +368,7 @@ namespace StieltjesExpTest {
     if (!success) {
       out << "\n Error, mat.normInf() < atol = " << mat.normInf() 
 	  << " < " << setup.atol << ": failed!\n";
-      out << "mat = " << Print(mat) << std::endl;
+      out << "mat = " << printMat(mat) << std::endl;
     }
   }
 

--- a/packages/stokhos/test/UnitTest/Stokhos_StieltjesUnitTest.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_StieltjesUnitTest.cpp
@@ -202,7 +202,7 @@ namespace StieltjesCosTest {
     if (!success) {
       out << "\n Error, mat.normInf() < atol = " << mat.normInf() 
 	  << " < " << setup.atol << ": failed!\n";
-      out << "mat = " << mat << std::endl;
+      out << "mat = " << Print(mat) << std::endl;
     }
   }
 
@@ -285,7 +285,7 @@ namespace StieltjesSinTest {
     if (!success) {
       out << "\n Error, mat.normInf() < atol = " << mat.normInf() 
 	  << " < " << setup.atol << ": failed!\n";
-      out << "mat = " << mat << std::endl;
+      out << "mat = " << Print(mat) << std::endl;
     }
   }
 
@@ -368,7 +368,7 @@ namespace StieltjesExpTest {
     if (!success) {
       out << "\n Error, mat.normInf() < atol = " << mat.normInf() 
 	  << " < " << setup.atol << ": failed!\n";
-      out << "mat = " << mat << std::endl;
+      out << "mat = " << Print(mat) << std::endl;
     }
   }
 

--- a/packages/tempus/src/Tempus_RKButcherTableau.hpp
+++ b/packages/tempus/src/Tempus_RKButcherTableau.hpp
@@ -176,10 +176,10 @@ class RKButcherTableau :
           out << this->description() << std::endl;
           out << this->getDescription() << std::endl;
           out << "number of Stages = " << this->numStages() << std::endl;
-          out << "A = " << Print(this->A()) << std::endl;
-          out << "b = " << Print(this->b()) << std::endl;
-          out << "c = " << Print(this->c()) << std::endl;
-          out << "bstar = " << Print(this->bstar()) << std::endl;
+          out << "A = " << printMat(this->A()) << std::endl;
+          out << "b = " << printMat(this->b()) << std::endl;
+          out << "c = " << printMat(this->c()) << std::endl;
+          out << "bstar = " << printMat(this->bstar()) << std::endl;
           out << "order    = " << this->order()    << std::endl;
           out << "orderMin = " << this->orderMin() << std::endl;
           out << "orderMax = " << this->orderMax() << std::endl;

--- a/packages/tempus/src/Tempus_RKButcherTableau.hpp
+++ b/packages/tempus/src/Tempus_RKButcherTableau.hpp
@@ -176,10 +176,10 @@ class RKButcherTableau :
           out << this->description() << std::endl;
           out << this->getDescription() << std::endl;
           out << "number of Stages = " << this->numStages() << std::endl;
-          out << "A = " << this->A() << std::endl;
-          out << "b = " << this->b() << std::endl;
-          out << "c = " << this->c() << std::endl;
-          out << "bstar = " << this->bstar() << std::endl;
+          out << "A = " << Print(this->A()) << std::endl;
+          out << "b = " << Print(this->b()) << std::endl;
+          out << "c = " << Print(this->c()) << std::endl;
+          out << "bstar = " << Print(this->bstar()) << std::endl;
           out << "order    = " << this->order()    << std::endl;
           out << "orderMin = " << this->orderMin() << std::endl;
           out << "orderMax = " << this->orderMax() << std::endl;

--- a/packages/teuchos/numerics/example/DenseMatrix/cxx_main.cpp
+++ b/packages/teuchos/numerics/example/DenseMatrix/cxx_main.cpp
@@ -141,8 +141,8 @@ int main(int argc, char* argv[])
     std::cout << "Teuchos::SerialDenseSolver::solve() returned : " << info << std::endl;
 
   // A matrix can be sent to the output stream:
-  std::cout<< std::endl << My_Matrix << std::endl;
-  std::cout<< X << std::endl;
+  std::cout<< std::endl << Print(My_Matrix) << std::endl;
+  std::cout<< Print(X) << std::endl;
 
   return 0;
 }

--- a/packages/teuchos/numerics/example/DenseMatrix/cxx_main.cpp
+++ b/packages/teuchos/numerics/example/DenseMatrix/cxx_main.cpp
@@ -141,8 +141,8 @@ int main(int argc, char* argv[])
     std::cout << "Teuchos::SerialDenseSolver::solve() returned : " << info << std::endl;
 
   // A matrix can be sent to the output stream:
-  std::cout<< std::endl << Print(My_Matrix) << std::endl;
-  std::cout<< Print(X) << std::endl;
+  std::cout<< std::endl << printMat(My_Matrix) << std::endl;
+  std::cout<< printMat(X) << std::endl;
 
   return 0;
 }

--- a/packages/teuchos/numerics/example/DenseMatrix/cxx_main_sym.cpp
+++ b/packages/teuchos/numerics/example/DenseMatrix/cxx_main_sym.cpp
@@ -145,8 +145,8 @@ int main(int argc, char* argv[])
   Teuchos::symMatTripleProduct<int,double>( Teuchos::TRANS, alpha, A2, W, C2 );
 
   // A matrix can be sent to the output stream:
-  std::cout<< Print(My_Matrix) << std::endl;
-  std::cout<< Print(X) << std::endl;
+  std::cout<< printMat(My_Matrix) << std::endl;
+  std::cout<< printMat(X) << std::endl;
 
   return 0;
 }

--- a/packages/teuchos/numerics/example/DenseMatrix/cxx_main_sym.cpp
+++ b/packages/teuchos/numerics/example/DenseMatrix/cxx_main_sym.cpp
@@ -145,8 +145,8 @@ int main(int argc, char* argv[])
   Teuchos::symMatTripleProduct<int,double>( Teuchos::TRANS, alpha, A2, W, C2 );
 
   // A matrix can be sent to the output stream:
-  std::cout<< My_Matrix << std::endl;
-  std::cout<< X << std::endl;
+  std::cout<< Print(My_Matrix) << std::endl;
+  std::cout<< Print(X) << std::endl;
 
   return 0;
 }

--- a/packages/teuchos/numerics/example/LAPACK/cxx_main.cpp
+++ b/packages/teuchos/numerics/example/LAPACK/cxx_main.cpp
@@ -69,7 +69,7 @@ int main(int argc, char* argv[])
 		ipiv, My_Vector.values(), My_Vector.stride(), &info );
 
   // Print out the solution.
-  std::cout << My_Vector << std::endl;
+  std::cout << Print(My_Vector) << std::endl;
 
   return 0;
 }

--- a/packages/teuchos/numerics/example/LAPACK/cxx_main.cpp
+++ b/packages/teuchos/numerics/example/LAPACK/cxx_main.cpp
@@ -69,7 +69,7 @@ int main(int argc, char* argv[])
 		ipiv, My_Vector.values(), My_Vector.stride(), &info );
 
   // Print out the solution.
-  std::cout << Print(My_Vector) << std::endl;
+  std::cout << printMat(My_Vector) << std::endl;
 
   return 0;
 }

--- a/packages/teuchos/numerics/src/Teuchos_SerialBandDenseMatrix.hpp
+++ b/packages/teuchos/numerics/src/Teuchos_SerialBandDenseMatrix.hpp
@@ -1114,7 +1114,7 @@ operator<<(std::ostream &out,
 /// \brief Return SerialBandDenseMatrix ostream manipulator Use as:
 template<typename OrdinalType, typename ScalarType> 
 SerialBandDenseMatrixPrinter<OrdinalType,ScalarType>
-Print(const SerialBandDenseMatrix<OrdinalType,ScalarType> &obj) 
+printMat(const SerialBandDenseMatrix<OrdinalType,ScalarType> &obj) 
 { 
   return SerialBandDenseMatrixPrinter<OrdinalType,ScalarType>(obj); 
 }

--- a/packages/teuchos/numerics/src/Teuchos_SerialBandDenseMatrix.hpp
+++ b/packages/teuchos/numerics/src/Teuchos_SerialBandDenseMatrix.hpp
@@ -422,7 +422,11 @@ public:
   //! @name I/O methods.
   //@{
   //! Print method.  Defines the behavior of the std::ostream << operator
+#ifndef TEUCHOS_HIDE_DEPRECATED_CODE
   virtual void print(std::ostream& os) const;
+#else
+  virtual std::ostream& print(std::ostream& os) const;
+#endif
 
   //@}
 protected:
@@ -992,7 +996,11 @@ int SerialBandDenseMatrix<OrdinalType, ScalarType>::scale( const SerialBandDense
 }
 
 template<typename OrdinalType, typename ScalarType>
+#ifndef TEUCHOS_HIDE_DEPRECATED_CODE
 void SerialBandDenseMatrix<OrdinalType, ScalarType>::print(std::ostream& os) const
+#else
+std::ostream& SerialBandDenseMatrix<OrdinalType, ScalarType>::print(std::ostream& os) const
+#endif
 {
   os << std::endl;
   if(valuesCopied_)
@@ -1015,6 +1023,9 @@ void SerialBandDenseMatrix<OrdinalType, ScalarType>::print(std::ostream& os) con
       os << std::endl;
     }
   }
+#ifdef TEUCHOS_HIDE_DEPRECATED_CODE
+  return os;
+#endif
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -1079,6 +1090,35 @@ std::ostream& operator<< (std::ostream& os, const Teuchos::SerialBandDenseMatrix
   return os;
 }
 #endif
+
+/// \brief Ostream manipulator for SerialBandDenseMatrix 
+template<typename OrdinalType, typename ScalarType> 
+struct SerialBandDenseMatrixPrinter {
+public:
+  const SerialBandDenseMatrix<OrdinalType,ScalarType> &obj; 
+  SerialBandDenseMatrixPrinter(
+        const SerialBandDenseMatrix<OrdinalType,ScalarType> &obj_in)
+      : obj(obj_in) {}
+};
+
+/// \brief Output SerialBandDenseMatrix object through its stream manipulator. 
+template<typename OrdinalType, typename ScalarType> 
+std::ostream&
+operator<<(std::ostream &out, 
+           const SerialBandDenseMatrixPrinter<OrdinalType,ScalarType> printer)
+{
+  printer.obj.print(out);
+  return out;
+}
+
+/// \brief Return SerialBandDenseMatrix ostream manipulator Use as:
+template<typename OrdinalType, typename ScalarType> 
+SerialBandDenseMatrixPrinter<OrdinalType,ScalarType>
+Print(const SerialBandDenseMatrix<OrdinalType,ScalarType> &obj) 
+{ 
+  return SerialBandDenseMatrixPrinter<OrdinalType,ScalarType>(obj); 
+}
+
 
 } // namespace Teuchos
 

--- a/packages/teuchos/numerics/src/Teuchos_SerialDenseMatrix.hpp
+++ b/packages/teuchos/numerics/src/Teuchos_SerialDenseMatrix.hpp
@@ -384,7 +384,11 @@ public:
   //! @name I/O methods.
   //@{
   //! Print method.  Defines the behavior of the std::ostream << operator
+#ifndef TEUCHOS_HIDE_DEPRECATED_CODE
   virtual void print(std::ostream& os) const;
+#else
+  virtual std::ostream& print(std::ostream& os) const;
+#endif
 
   //@}
 protected:
@@ -1001,7 +1005,11 @@ int SerialDenseMatrix<OrdinalType, ScalarType>::multiply (ESide sideA, ScalarTyp
 }
 
 template<typename OrdinalType, typename ScalarType>
+#ifndef TEUCHOS_HIDE_DEPRECATED_CODE
 void SerialDenseMatrix<OrdinalType, ScalarType>::print(std::ostream& os) const
+#else
+std::ostream& SerialDenseMatrix<OrdinalType, ScalarType>::print(std::ostream& os) const
+#endif
 {
   os << std::endl;
   if(valuesCopied_)
@@ -1021,6 +1029,9 @@ void SerialDenseMatrix<OrdinalType, ScalarType>::print(std::ostream& os) const
       os << std::endl;
     }
   }
+#ifdef TEUCHOS_HIDE_DEPRECATED_CODE
+  return os;
+#endif
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -1084,6 +1095,35 @@ std::ostream& operator<< (std::ostream& os, const Teuchos::SerialDenseMatrix<Ord
   return os;
 }
 #endif
+
+/// \brief Ostream manipulator for SerialDenseMatrix 
+template<typename OrdinalType, typename ScalarType>
+struct SerialDenseMatrixPrinter {
+public:
+  const SerialDenseMatrix<OrdinalType,ScalarType> &obj;
+  SerialDenseMatrixPrinter(
+        const SerialDenseMatrix<OrdinalType,ScalarType> &obj_in)
+      : obj(obj_in) {}
+};
+
+/// \brief Output SerialDenseMatrix object through its stream manipulator. 
+template<typename OrdinalType, typename ScalarType>
+std::ostream&
+operator<<(std::ostream &out,
+           const SerialDenseMatrixPrinter<OrdinalType,ScalarType> printer)
+{
+  printer.obj.print(out);
+  return out;
+}
+
+/// \brief Return SerialDenseMatrix ostream manipulator Use as:
+template<typename OrdinalType, typename ScalarType>
+SerialDenseMatrixPrinter<OrdinalType,ScalarType>
+Print(const SerialDenseMatrix<OrdinalType,ScalarType> &obj)
+{
+  return SerialDenseMatrixPrinter<OrdinalType,ScalarType>(obj);
+}
+
 
 } // namespace Teuchos
 

--- a/packages/teuchos/numerics/src/Teuchos_SerialDenseMatrix.hpp
+++ b/packages/teuchos/numerics/src/Teuchos_SerialDenseMatrix.hpp
@@ -1119,7 +1119,7 @@ operator<<(std::ostream &out,
 /// \brief Return SerialDenseMatrix ostream manipulator Use as:
 template<typename OrdinalType, typename ScalarType>
 SerialDenseMatrixPrinter<OrdinalType,ScalarType>
-Print(const SerialDenseMatrix<OrdinalType,ScalarType> &obj)
+printMat(const SerialDenseMatrix<OrdinalType,ScalarType> &obj)
 {
   return SerialDenseMatrixPrinter<OrdinalType,ScalarType>(obj);
 }

--- a/packages/teuchos/numerics/src/Teuchos_SerialDenseVector.hpp
+++ b/packages/teuchos/numerics/src/Teuchos_SerialDenseVector.hpp
@@ -373,7 +373,7 @@ operator<<(std::ostream &out,
 /// \brief Return SerialDenseVector ostream manipulator Use as:
 template<typename OrdinalType, typename ScalarType>
 SerialDenseVectorPrinter<OrdinalType,ScalarType>
-Print(const SerialDenseVector<OrdinalType,ScalarType> &obj)
+printMat(const SerialDenseVector<OrdinalType,ScalarType> &obj)
 {
   return SerialDenseVectorPrinter<OrdinalType,ScalarType>(obj);
 }

--- a/packages/teuchos/numerics/src/Teuchos_SerialDenseVector.hpp
+++ b/packages/teuchos/numerics/src/Teuchos_SerialDenseVector.hpp
@@ -210,7 +210,11 @@ namespace Teuchos {
   //! @name I/O methods.
   //@{
     //! Print method.  Define the behavior of the std::ostream << operator inherited from the Object class.
+#ifndef TEUCHOS_HIDE_DEPRECATED_CODE
     virtual void print(std::ostream& os) const;
+#else
+    std::ostream& print(std::ostream& os) const;
+#endif
   //@}
 };
 
@@ -281,7 +285,11 @@ namespace Teuchos {
   }
 
   template<typename OrdinalType, typename ScalarType>
+#ifndef TEUCHOS_HIDE_DEPRECATED_CODE
   void SerialDenseVector<OrdinalType, ScalarType>::print(std::ostream& os) const
+#else
+  std::ostream& SerialDenseVector<OrdinalType, ScalarType>::print(std::ostream& os) const
+#endif
   {
     os << std::endl;
     if(this->valuesCopied_)
@@ -297,6 +305,9 @@ namespace Teuchos {
       }
       os << std::endl;
     }
+#ifdef TEUCHOS_HIDE_DEPRECATED_CODE
+    return os;
+#endif
   }
 
   //----------------------------------------------------------------------------------------------------
@@ -338,6 +349,35 @@ namespace Teuchos {
 #endif
     return(this->values_[index]);
   }
+
+/// \brief Ostream manipulator for SerialDenseVector 
+template<typename OrdinalType, typename ScalarType>
+struct SerialDenseVectorPrinter {
+public:
+  const SerialDenseVector<OrdinalType,ScalarType> &obj;
+  SerialDenseVectorPrinter(
+        const SerialDenseVector<OrdinalType,ScalarType> &obj_in)
+      : obj(obj_in) {}
+};
+
+/// \brief Output SerialDenseVector object through its stream manipulator. 
+template<typename OrdinalType, typename ScalarType>
+std::ostream&
+operator<<(std::ostream &out,
+           const SerialDenseVectorPrinter<OrdinalType,ScalarType> printer)
+{
+  printer.obj.print(out);
+  return out;
+}
+
+/// \brief Return SerialDenseVector ostream manipulator Use as:
+template<typename OrdinalType, typename ScalarType>
+SerialDenseVectorPrinter<OrdinalType,ScalarType>
+Print(const SerialDenseVector<OrdinalType,ScalarType> &obj)
+{
+  return SerialDenseVectorPrinter<OrdinalType,ScalarType>(obj);
+}
+
 
 } // namespace Teuchos
 

--- a/packages/teuchos/numerics/src/Teuchos_SerialSymDenseMatrix.hpp
+++ b/packages/teuchos/numerics/src/Teuchos_SerialSymDenseMatrix.hpp
@@ -1219,7 +1219,7 @@ operator<<(std::ostream &out,
 /// \brief Return SerialSymDenseMatrix ostream manipulator Use as:
 template<typename OrdinalType, typename ScalarType>
 SerialSymDenseMatrixPrinter<OrdinalType,ScalarType>
-Print(const SerialSymDenseMatrix<OrdinalType,ScalarType> &obj)
+printMat(const SerialSymDenseMatrix<OrdinalType,ScalarType> &obj)
 {
   return SerialSymDenseMatrixPrinter<OrdinalType,ScalarType>(obj);
 }

--- a/packages/teuchos/numerics/src/Teuchos_SerialSymDenseMatrix.hpp
+++ b/packages/teuchos/numerics/src/Teuchos_SerialSymDenseMatrix.hpp
@@ -402,7 +402,11 @@ class SerialSymDenseMatrix : public CompObject, public BLAS<OrdinalType,ScalarTy
   //! @name I/O methods.
   //@{
   //! Print method.  Defines the behavior of the std::ostream << operator
+#ifndef TEUCHOS_HIDE_DEPRECATED_CODE
   virtual void print(std::ostream& os) const;
+#else
+  virtual std::ostream& print(std::ostream& os) const;
+#endif
 
   //@}
 
@@ -1010,7 +1014,11 @@ int SerialSymDenseMatrix<OrdinalType, ScalarType>::scale( const SerialSymDenseMa
 */
 
 template<typename OrdinalType, typename ScalarType>
+#ifndef TEUCHOS_HIDE_DEPRECATED_CODE
 void SerialSymDenseMatrix<OrdinalType, ScalarType>::print(std::ostream& os) const
+#else
+std::ostream& SerialSymDenseMatrix<OrdinalType, ScalarType>::print(std::ostream& os) const
+#endif
 {
   os << std::endl;
   if(valuesCopied_)
@@ -1033,6 +1041,9 @@ void SerialSymDenseMatrix<OrdinalType, ScalarType>::print(std::ostream& os) cons
       os << std::endl;
     }
   }
+#ifdef TEUCHOS_HIDE_DEPRECATED_CODE
+  return os;
+#endif
 }
 
 //----------------------------------------------------------------------------------------------------
@@ -1184,6 +1195,35 @@ std::ostream& operator<< (std::ostream& os, const Teuchos::SerialSymDenseMatrix<
   return os;
 }
 #endif
+
+/// \brief Ostream manipulator for SerialSymDenseMatrix 
+template<typename OrdinalType, typename ScalarType>
+struct SerialSymDenseMatrixPrinter {
+public:
+  const SerialSymDenseMatrix<OrdinalType,ScalarType> &obj;
+  SerialSymDenseMatrixPrinter(
+        const SerialSymDenseMatrix<OrdinalType,ScalarType> &obj_in)
+      : obj(obj_in) {}
+};
+
+/// \brief Output SerialSymDenseMatrix object through its stream manipulator. 
+template<typename OrdinalType, typename ScalarType>
+std::ostream&
+operator<<(std::ostream &out,
+           const SerialSymDenseMatrixPrinter<OrdinalType,ScalarType> printer)
+{
+  printer.obj.print(out);
+  return out;
+}
+
+/// \brief Return SerialSymDenseMatrix ostream manipulator Use as:
+template<typename OrdinalType, typename ScalarType>
+SerialSymDenseMatrixPrinter<OrdinalType,ScalarType>
+Print(const SerialSymDenseMatrix<OrdinalType,ScalarType> &obj)
+{
+  return SerialSymDenseMatrixPrinter<OrdinalType,ScalarType>(obj);
+}
+
 
 } // namespace Teuchos
 


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/teuchos @rhoope @mseldre 


## Description
#5085 includes a suggested strategy for ostream deprecation in serial dense matrices.
This PR implements those suggestions.




## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
See conversations in  #4430  #4330 #5085 

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->

With deprecated code ON:
```
-D Trilinos_ENABLE_Teuchos:BOOL=ON \
-D Teuchos_ENABLE_TESTS:BOOL=ON \
-D Teuchos_ENABLE_EXAMPLES:BOOL=ON \
-D Trilinos_ENABLE_Anasazi:BOOL=ON \
-D Anasazi_ENABLE_TESTS:BOOL=ON \
-D Anasazi_ENABLE_EXAMPLES:BOOL=ON \
-D Trilinos_ENABLE_Belos:BOOL=ON \
-D Belos_ENABLE_TESTS:BOOL=ON \
-D Belos_ENABLE_EXAMPLES:BOOL=ON \
-D Trilinos_ENABLE_Tempus:BOOL=ON \
-D Tempus_ENABLE_TESTS:BOOL=ON \
-D Tempus_ENABLE_EXAMPLES:BOOL=ON \
-D Trilinos_ENABLE_Stokhos:BOOL=ON \
-D Stokhos_ENABLE_TESTS:BOOL=ON \
-D Stokhos_ENABLE_EXAMPLES:BOOL=ON \
-D TPL_ENABLE_Boost:BOOL=OFF \
```
and with deprecated code OFF:
```
-D Trilinos_ENABLE_Tpetra:BOOL=ON \
-D Tpetra_ENABLE_DEPRECATED_CODE:BOOL=OFF \
-D Xpetra_ENABLE_Epetra:BOOL=OFF \
-D Tpetra_INST_INT_INT:BOOL=ON \
-D Teuchos_HIDE_DEPRECATED_CODE:BOOL=ON \
-D Trilinos_ENABLE_Teuchos:BOOL=ON \
-D Teuchos_ENABLE_TESTS:BOOL=ON \
-D Teuchos_ENABLE_EXAMPLES:BOOL=ON \
-D Trilinos_ENABLE_Anasazi:BOOL=ON \
-D Anasazi_ENABLE_TESTS:BOOL=ON \
-D Anasazi_ENABLE_EXAMPLES:BOOL=ON \
-D Trilinos_ENABLE_Belos:BOOL=ON \
-D Belos_ENABLE_TESTS:BOOL=ON \
-D Belos_ENABLE_EXAMPLES:BOOL=ON \
-D Trilinos_ENABLE_Tempus:BOOL=ON \
-D Tempus_ENABLE_TESTS:BOOL=ON \
-D Tempus_ENABLE_EXAMPLES:BOOL=ON \
-D Trilinos_ENABLE_Stokhos:BOOL=ON \
-D Stokhos_ENABLE_TESTS:BOOL=ON \
-D Stokhos_ENABLE_EXAMPLES:BOOL=ON \
-D Trilinos_ENABLE_MueLu:BOOL=OFF \
-D TPL_ENABLE_Boost:BOOL=OFF \
```

Some tests fail in both cases, but errors appear unrelated to these changes.
My old mac laptop probably could not handle the workload.

<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [x ] My commit messages mention the appropriate GitHub issue numbers.
- [x ] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ x] No new compiler warnings were introduced.
- [x ] These changes break backwards compatibility. (by design)

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
