### PR TITLE
Re-enable test KokkosCore_UnitTest_Serial

### DIFF
--- a/cmake/std/PullRequestLinuxIntelTestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxIntelTestingSettings.cmake
@@ -14,7 +14,6 @@
 set (MueLu_UnitTestsEpetra_MPI_1_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
 set (MueLu_UnitTestsEpetra_MPI_4_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
 set (MueLu_UnitTestsTpetra_MPI_1_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
-set (KokkosCore_UnitTest_Serial_MPI_1_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
 
 # (Temporarily) Disable randomly failing ROL test (#3103)
 set (ROL_example_poisson-inversion_example_01_MPI_1_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")


### PR DESCRIPTION
This was fixed some time back and I missed re-enabling this test

@trilinos/kokkos 
@trilinos/framework 

## Description
This just re-enables a test that was fixed in Kokkos and pulled into Trlinos in #3796

## Motivation and Context
resolves #2846

