### PR TITLE
MueLu: triple product defaults, Maxwell test

### DIFF
--- a/packages/muelu/src/Interface/MueLu_ML2MueLuParameterTranslator.cpp
+++ b/packages/muelu/src/Interface/MueLu_ML2MueLuParameterTranslator.cpp
@@ -207,7 +207,7 @@ namespace MueLu {
 #else
     if (defaultVals != "") {
         // If no validator available: issue a warning and set parameter value to false in the output list
-        *out << "Warning: MueLu_ENABLE_ML=OFF. No ML default values available." << std::endl;
+        *out << "Warning: MueLu_ENABLE_ML=OFF and/or MueLu_ENABLE_Epetra=OFF. No ML default values available." << std::endl;
     }
 #endif // HAVE_MUELU_ML
 
@@ -236,7 +236,7 @@ namespace MueLu {
                                    "ERROR: ML's Teuchos::ParameterList contains incorrect parameter!");
 #else
         // If no validator available: issue a warning and set parameter value to false in the output list
-        *out << "Warning: MueLu_ENABLE_ML=OFF. The parameter list cannot be validated." << std::endl;
+        *out << "Warning: MueLu_ENABLE_ML=OFF and/or MueLu_ENABLE_Epetra=OFF. The parameter list cannot be validated." << std::endl;
         paramList.set("ML validate parameter list", false);
 
 #endif // HAVE_MUELU_ML

--- a/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
+++ b/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
@@ -1067,7 +1067,14 @@ namespace MueLu {
       RAPparams.sublist("matrixmatrix: kernel params", false) = defaultList.sublist("matrixmatrix: kernel params");
     MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "transpose: use implicit", bool, RAPparams);
     MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "rap: fix zero diagonals", bool, RAPparams);
-    MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "rap: triple product", bool, RAPparams);
+
+    // if "rap: triple product" has not been set and algorithm is "unsmoothed" switch triple product on
+    if (!paramList.isParameter("rap: triple product") &&
+        paramList.isType<std::string>("multigrid algorithm") &&
+        paramList.get<std::string>("multigrid algorithm") == "unsmoothed")
+      paramList.set("rap: triple product", true);
+    else
+      MUELU_TEST_AND_SET_PARAM_2LIST(paramList, defaultList, "rap: triple product", bool, RAPparams);
 
     try {
       if (paramList.isParameter("aggregation: allow empty prolongator columns")) {

--- a/packages/muelu/src/MueCentral/MueLu_Hierarchy_def.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_Hierarchy_def.hpp
@@ -873,7 +873,8 @@ namespace MueLu {
     AllocateLevelMultiVectors(X.getNumVectors());
 
     // Print residual information before iterating
-    MagnitudeType prevNorm = STS::magnitude(STS::one()), curNorm = STS::magnitude(STS::one());
+    typedef Teuchos::ScalarTraits<typename STS::magnitudeType> STM;
+    MagnitudeType prevNorm = STM::one(), curNorm = STM::one();
     rate_ = 1.0;
     if (startLevel == 0 && !isPreconditioner_ &&
         (IsPrint(Statistics1) || tol > 0)) {

--- a/packages/muelu/test/interface/complex/EasyParameterListInterpreter/reuse-tP-3_np4.xml
+++ b/packages/muelu/test/interface/complex/EasyParameterListInterpreter/reuse-tP-3_np4.xml
@@ -1,5 +1,5 @@
 <ParameterList name="MueLu">
-  <Parameter name="multigrid algorithm"             type="string"   value="unsmoothed"/>
+  <!-- <Parameter name="multigrid algorithm"             type="string"   value="unsmoothed"/> -->
   <ParameterList name="level 1">
     <Parameter name="reuse: type"                   type="string"   value="tP"/>
   </ParameterList>

--- a/packages/muelu/test/interface/complex/FactoryParameterListInterpreter/unsmoothed1.xml
+++ b/packages/muelu/test/interface/complex/FactoryParameterListInterpreter/unsmoothed1.xml
@@ -11,6 +11,11 @@
       <Parameter name="factory"                             type="string" value="TentativePFactory"/>
     </ParameterList>
 
+    <ParameterList name="myRAPFact">
+      <Parameter name="factory"                             type="string" value="RAPFactory"/>
+      <Parameter name="rap: triple product"                 type="bool"   value="true"/>
+    </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="Hierarchy">
@@ -22,6 +27,7 @@
       <Parameter name="Graph"                               type="string"   value="myCoalesceDropFact"/>
       <Parameter name="Ptent"                               type="string"   value="myProlongatorFact"/>
       <Parameter name="P"                                   type="string"   value="myProlongatorFact"/>
+      <Parameter name="A"                                   type="string"   value="myRAPFact"/>
     </ParameterList>
 
   </ParameterList>

--- a/packages/muelu/test/interface/complex/Output/default_mhd_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/default_mhd_np4_tpetra.gold
@@ -66,7 +66,7 @@ matrixmatrix: kernel params ->
 
 Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 1
-rap: triple product = 0   [default]
+rap: triple product = 1
 rap: fix zero diagonals = 0   [default]
 rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
@@ -140,7 +140,7 @@ matrixmatrix: kernel params ->
 
 Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 1
-rap: triple product = 0   [default]
+rap: triple product = 1
 rap: fix zero diagonals = 0   [default]
 rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]

--- a/packages/muelu/test/interface/complex/Output/default_mhd_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/default_mhd_tpetra.gold
@@ -66,7 +66,7 @@ matrixmatrix: kernel params ->
 
 Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 1
-rap: triple product = 0   [default]
+rap: triple product = 1
 rap: fix zero diagonals = 0   [default]
 rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
@@ -140,7 +140,7 @@ matrixmatrix: kernel params ->
 
 Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 1
-rap: triple product = 0   [default]
+rap: triple product = 1
 rap: fix zero diagonals = 0   [default]
 rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]

--- a/packages/muelu/test/interface/complex/Output/reuse-tP-3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-tP-3_np4_tpetra.gold
@@ -23,8 +23,8 @@ Level 1
 Build (MueLu::RebalanceTransferFactory)
 Build (MueLu::RepartitionFactory)
 Computing Ac (MueLu::RAPFactory)
-Build (MueLu::TentativePFactory)
-Build (MueLu::UncoupledAggregationFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
 Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
@@ -35,6 +35,13 @@ aggregation: Dirichlet threshold = 0   [default]
 aggregation: drop scheme = classical   [default]
 lightweight wrap = 1
 
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
@@ -68,6 +75,12 @@ Domain GID offsets = {0}   [default]
 
 tentative: calculate qr = 1   [default]
 tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
 matrixmatrix: kernel params -> 
  [empty list]
 
@@ -157,8 +170,8 @@ Level 2
 Build (MueLu::RebalanceTransferFactory)
 Build (MueLu::RepartitionFactory)
 Computing Ac (MueLu::RAPFactory)
-Build (MueLu::TentativePFactory)
-Build (MueLu::UncoupledAggregationFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
 Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
@@ -169,6 +182,13 @@ aggregation: Dirichlet threshold = 0   [default]
 aggregation: drop scheme = classical   [default]
 lightweight wrap = 1
 
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
@@ -202,6 +222,12 @@ Domain GID offsets = {0}   [default]
 
 tentative: calculate qr = 1   [default]
 tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
 matrixmatrix: kernel params -> 
  [empty list]
 
@@ -274,18 +300,18 @@ repartition: use subcommunicators = 1   [default]
 ---                            Multigrid Summary                             ---
 --------------------------------------------------------------------------------
 Number of levels    = 3
-Operator complexity = 1.44
+Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
   0  9999  29995  3.00                  4  
-  1  3335  10003  3.00     3.00         4  
-  2  1112  3334   3.00     3.00         1  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
-Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10003}
+Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015}
 
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
@@ -313,6 +339,30 @@ smoother ->
 
 Level 1
 Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Reusing previous AP data
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
 Using original prolongator
 repartition: rebalance P and R = 0
 repartition: rebalance Nullspace = 1   [default]
@@ -362,7 +412,7 @@ matrixmatrix: kernel params ->
 
 repartition: use subcommunicators = 1   [default]
 
-Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10003})
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015})
 keep smoother data = 1
 PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
 PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
@@ -385,8 +435,8 @@ Level 2
 Build (MueLu::RebalanceTransferFactory)
 Build (MueLu::RepartitionFactory)
 Computing Ac (MueLu::RAPFactory)
-Build (MueLu::TentativePFactory)
-Build (MueLu::UncoupledAggregationFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
 Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
@@ -397,6 +447,13 @@ aggregation: Dirichlet threshold = 0   [default]
 aggregation: drop scheme = classical   [default]
 lightweight wrap = 1
 
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
@@ -430,6 +487,12 @@ Domain GID offsets = {0}   [default]
 
 tentative: calculate qr = 1   [default]
 tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
 matrixmatrix: kernel params -> 
  [empty list]
 
@@ -502,18 +565,18 @@ repartition: use subcommunicators = 1   [default]
 ---                            Multigrid Summary                             ---
 --------------------------------------------------------------------------------
 Number of levels    = 3
-Operator complexity = 1.44
+Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
   0  9999  29995  3.00                  4  
-  1  3335  10003  3.00     3.00         4  
-  2  1112  3334   3.00     3.00         1  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
-Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10003}
+Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015}
 
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother

--- a/packages/muelu/test/interface/complex/Output/reuse-tP-3_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-tP-3_tpetra.gold
@@ -23,8 +23,8 @@ Level 1
 Build (MueLu::RebalanceTransferFactory)
 Build (MueLu::RepartitionFactory)
 Computing Ac (MueLu::RAPFactory)
-Build (MueLu::TentativePFactory)
-Build (MueLu::UncoupledAggregationFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
 Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
@@ -35,6 +35,13 @@ aggregation: Dirichlet threshold = 0   [default]
 aggregation: drop scheme = classical   [default]
 lightweight wrap = 1
 
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
@@ -68,6 +75,12 @@ Domain GID offsets = {0}   [default]
 
 tentative: calculate qr = 1   [default]
 tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
 matrixmatrix: kernel params -> 
  [empty list]
 
@@ -157,8 +170,8 @@ Level 2
 Build (MueLu::RebalanceTransferFactory)
 Build (MueLu::RepartitionFactory)
 Computing Ac (MueLu::RAPFactory)
-Build (MueLu::TentativePFactory)
-Build (MueLu::UncoupledAggregationFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
 Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
@@ -169,6 +182,13 @@ aggregation: Dirichlet threshold = 0   [default]
 aggregation: drop scheme = classical   [default]
 lightweight wrap = 1
 
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
@@ -202,6 +222,12 @@ Domain GID offsets = {0}   [default]
 
 tentative: calculate qr = 1   [default]
 tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
 matrixmatrix: kernel params -> 
  [empty list]
 
@@ -320,6 +346,30 @@ smoother ->
 
 Level 1
 Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Reusing previous AP data
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
 Using original prolongator
 repartition: rebalance P and R = 0
 repartition: rebalance Nullspace = 1   [default]
@@ -392,8 +442,8 @@ Level 2
 Build (MueLu::RebalanceTransferFactory)
 Build (MueLu::RepartitionFactory)
 Computing Ac (MueLu::RAPFactory)
-Build (MueLu::TentativePFactory)
-Build (MueLu::UncoupledAggregationFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
 Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
@@ -404,6 +454,13 @@ aggregation: Dirichlet threshold = 0   [default]
 aggregation: drop scheme = classical   [default]
 lightweight wrap = 1
 
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
@@ -437,6 +494,12 @@ Domain GID offsets = {0}   [default]
 
 tentative: calculate qr = 1   [default]
 tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
 matrixmatrix: kernel params -> 
  [empty list]
 

--- a/packages/muelu/test/interface/complex/Output/unsmoothed1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/unsmoothed1_tpetra.gold
@@ -74,7 +74,7 @@ matrixmatrix: kernel params ->
 
 Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
-rap: triple product = 0   [default]
+rap: triple product = 1
 rap: fix zero diagonals = 0   [default]
 rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
@@ -156,7 +156,7 @@ matrixmatrix: kernel params ->
 
 Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
-rap: triple product = 0   [default]
+rap: triple product = 1
 rap: fix zero diagonals = 0   [default]
 rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]

--- a/packages/muelu/test/interface/default/EasyParameterListInterpreter/reuse-tP-3_np4.xml
+++ b/packages/muelu/test/interface/default/EasyParameterListInterpreter/reuse-tP-3_np4.xml
@@ -1,5 +1,5 @@
 <ParameterList name="MueLu">
-  <Parameter name="multigrid algorithm"             type="string"   value="unsmoothed"/>
+  <!-- <Parameter name="multigrid algorithm"             type="string"   value="unsmoothed"/> -->
   <ParameterList name="level 1">
     <Parameter name="reuse: type"                   type="string"   value="tP"/>
   </ParameterList>

--- a/packages/muelu/test/interface/default/FactoryParameterListInterpreter/unsmoothed1.xml
+++ b/packages/muelu/test/interface/default/FactoryParameterListInterpreter/unsmoothed1.xml
@@ -11,6 +11,11 @@
       <Parameter name="factory"                             type="string" value="TentativePFactory"/>
     </ParameterList>
 
+    <ParameterList name="myRAPFact">
+      <Parameter name="factory"                             type="string" value="RAPFactory"/>
+      <Parameter name="rap: triple product"                 type="bool"   value="true"/>
+    </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="Hierarchy">
@@ -22,6 +27,7 @@
       <Parameter name="Graph"                               type="string"   value="myCoalesceDropFact"/>
       <Parameter name="Ptent"                               type="string"   value="myProlongatorFact"/>
       <Parameter name="P"                                   type="string"   value="myProlongatorFact"/>
+      <Parameter name="A"                                   type="string"   value="myRAPFact"/>
     </ParameterList>
 
   </ParameterList>

--- a/packages/muelu/test/interface/default/Output/default_mhd_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/default_mhd_np4_tpetra.gold
@@ -66,7 +66,7 @@ matrixmatrix: kernel params ->
 
 Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 1
-rap: triple product = 0   [default]
+rap: triple product = 1
 rap: fix zero diagonals = 0   [default]
 rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
@@ -140,7 +140,7 @@ matrixmatrix: kernel params ->
 
 Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 1
-rap: triple product = 0   [default]
+rap: triple product = 1
 rap: fix zero diagonals = 0   [default]
 rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]

--- a/packages/muelu/test/interface/default/Output/default_mhd_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/default_mhd_tpetra.gold
@@ -66,7 +66,7 @@ matrixmatrix: kernel params ->
 
 Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 1
-rap: triple product = 0   [default]
+rap: triple product = 1
 rap: fix zero diagonals = 0   [default]
 rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
@@ -140,7 +140,7 @@ matrixmatrix: kernel params ->
 
 Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 1
-rap: triple product = 0   [default]
+rap: triple product = 1
 rap: fix zero diagonals = 0   [default]
 rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]

--- a/packages/muelu/test/interface/default/Output/reuse-tP-3_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-3_epetra.gold
@@ -13,8 +13,8 @@ Level 1
 Build (MueLu::RebalanceTransferFactory)
 Build (MueLu::RepartitionFactory)
 Computing Ac (MueLu::RAPFactory)
-Build (MueLu::TentativePFactory)
-Build (MueLu::UncoupledAggregationFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
 Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
@@ -25,6 +25,13 @@ aggregation: Dirichlet threshold = 0   [default]
 aggregation: drop scheme = classical   [default]
 lightweight wrap = 1
 
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
@@ -58,6 +65,12 @@ Domain GID offsets = {0}   [default]
 
 tentative: calculate qr = 1   [default]
 tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
 matrixmatrix: kernel params -> 
  [empty list]
 
@@ -137,8 +150,8 @@ Level 2
 Build (MueLu::RebalanceTransferFactory)
 Build (MueLu::RepartitionFactory)
 Computing Ac (MueLu::RAPFactory)
-Build (MueLu::TentativePFactory)
-Build (MueLu::UncoupledAggregationFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
 Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
@@ -149,6 +162,13 @@ aggregation: Dirichlet threshold = 0   [default]
 aggregation: drop scheme = classical   [default]
 lightweight wrap = 1
 
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
@@ -182,6 +202,12 @@ Domain GID offsets = {0}   [default]
 
 tentative: calculate qr = 1   [default]
 tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
 matrixmatrix: kernel params -> 
  [empty list]
 
@@ -290,6 +316,30 @@ smoother ->
 
 Level 1
 Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Reusing previous AP data
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
 Using original prolongator
 repartition: rebalance P and R = 0
 repartition: rebalance Nullspace = 1   [default]
@@ -352,8 +402,8 @@ Level 2
 Build (MueLu::RebalanceTransferFactory)
 Build (MueLu::RepartitionFactory)
 Computing Ac (MueLu::RAPFactory)
-Build (MueLu::TentativePFactory)
-Build (MueLu::UncoupledAggregationFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
 Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
@@ -364,6 +414,13 @@ aggregation: Dirichlet threshold = 0   [default]
 aggregation: drop scheme = classical   [default]
 lightweight wrap = 1
 
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
@@ -397,6 +454,12 @@ Domain GID offsets = {0}   [default]
 
 tentative: calculate qr = 1   [default]
 tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
 matrixmatrix: kernel params -> 
  [empty list]
 

--- a/packages/muelu/test/interface/default/Output/reuse-tP-3_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-3_np4_epetra.gold
@@ -13,8 +13,8 @@ Level 1
 Build (MueLu::RebalanceTransferFactory)
 Build (MueLu::RepartitionFactory)
 Computing Ac (MueLu::RAPFactory)
-Build (MueLu::TentativePFactory)
-Build (MueLu::UncoupledAggregationFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
 Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
@@ -25,6 +25,13 @@ aggregation: Dirichlet threshold = 0   [default]
 aggregation: drop scheme = classical   [default]
 lightweight wrap = 1
 
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
@@ -58,6 +65,12 @@ Domain GID offsets = {0}   [default]
 
 tentative: calculate qr = 1   [default]
 tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
 matrixmatrix: kernel params -> 
  [empty list]
 
@@ -137,8 +150,8 @@ Level 2
 Build (MueLu::RebalanceTransferFactory)
 Build (MueLu::RepartitionFactory)
 Computing Ac (MueLu::RAPFactory)
-Build (MueLu::TentativePFactory)
-Build (MueLu::UncoupledAggregationFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
 Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
@@ -149,6 +162,13 @@ aggregation: Dirichlet threshold = 0   [default]
 aggregation: drop scheme = classical   [default]
 lightweight wrap = 1
 
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
@@ -182,6 +202,12 @@ Domain GID offsets = {0}   [default]
 
 tentative: calculate qr = 1   [default]
 tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
 matrixmatrix: kernel params -> 
  [empty list]
 
@@ -254,14 +280,14 @@ repartition: use subcommunicators = 1   [default]
 ---                            Multigrid Summary                             ---
 --------------------------------------------------------------------------------
 Number of levels    = 3
-Operator complexity = 1.44
+Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
   0  9999  29995  3.00                  4  
-  1  3335  10003  3.00     3.00         4  
-  2  1112  3334   3.00     3.00         1  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
@@ -283,6 +309,30 @@ smoother ->
 
 Level 1
 Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Reusing previous AP data
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
 Using original prolongator
 repartition: rebalance P and R = 0
 repartition: rebalance Nullspace = 1   [default]
@@ -345,8 +395,8 @@ Level 2
 Build (MueLu::RebalanceTransferFactory)
 Build (MueLu::RepartitionFactory)
 Computing Ac (MueLu::RAPFactory)
-Build (MueLu::TentativePFactory)
-Build (MueLu::UncoupledAggregationFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
 Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
@@ -357,6 +407,13 @@ aggregation: Dirichlet threshold = 0   [default]
 aggregation: drop scheme = classical   [default]
 lightweight wrap = 1
 
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
@@ -390,6 +447,12 @@ Domain GID offsets = {0}   [default]
 
 tentative: calculate qr = 1   [default]
 tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
 matrixmatrix: kernel params -> 
  [empty list]
 
@@ -462,14 +525,14 @@ repartition: use subcommunicators = 1   [default]
 ---                            Multigrid Summary                             ---
 --------------------------------------------------------------------------------
 Number of levels    = 3
-Operator complexity = 1.44
+Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
   0  9999  29995  3.00                  4  
-  1  3335  10003  3.00     3.00         4  
-  2  1112  3334   3.00     3.00         1  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/reuse-tP-3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-3_np4_tpetra.gold
@@ -23,8 +23,8 @@ Level 1
 Build (MueLu::RebalanceTransferFactory)
 Build (MueLu::RepartitionFactory)
 Computing Ac (MueLu::RAPFactory)
-Build (MueLu::TentativePFactory)
-Build (MueLu::UncoupledAggregationFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
 Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
@@ -35,6 +35,13 @@ aggregation: Dirichlet threshold = 0   [default]
 aggregation: drop scheme = classical   [default]
 lightweight wrap = 1
 
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
@@ -68,6 +75,12 @@ Domain GID offsets = {0}   [default]
 
 tentative: calculate qr = 1   [default]
 tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
 matrixmatrix: kernel params -> 
  [empty list]
 
@@ -157,8 +170,8 @@ Level 2
 Build (MueLu::RebalanceTransferFactory)
 Build (MueLu::RepartitionFactory)
 Computing Ac (MueLu::RAPFactory)
-Build (MueLu::TentativePFactory)
-Build (MueLu::UncoupledAggregationFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
 Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
@@ -169,6 +182,13 @@ aggregation: Dirichlet threshold = 0   [default]
 aggregation: drop scheme = classical   [default]
 lightweight wrap = 1
 
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
@@ -202,6 +222,12 @@ Domain GID offsets = {0}   [default]
 
 tentative: calculate qr = 1   [default]
 tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
 matrixmatrix: kernel params -> 
  [empty list]
 
@@ -274,18 +300,18 @@ repartition: use subcommunicators = 1   [default]
 ---                            Multigrid Summary                             ---
 --------------------------------------------------------------------------------
 Number of levels    = 3
-Operator complexity = 1.44
+Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
   0  9999  29995  3.00                  4  
-  1  3335  10003  3.00     3.00         4  
-  2  1112  3334   3.00     3.00         1  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
-Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10003}
+Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015}
 
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
@@ -313,6 +339,30 @@ smoother ->
 
 Level 1
 Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Reusing previous AP data
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
 Using original prolongator
 repartition: rebalance P and R = 0
 repartition: rebalance Nullspace = 1   [default]
@@ -362,7 +412,7 @@ matrixmatrix: kernel params ->
 
 repartition: use subcommunicators = 1   [default]
 
-Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10003})
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015})
 keep smoother data = 1
 PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
 PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
@@ -385,8 +435,8 @@ Level 2
 Build (MueLu::RebalanceTransferFactory)
 Build (MueLu::RepartitionFactory)
 Computing Ac (MueLu::RAPFactory)
-Build (MueLu::TentativePFactory)
-Build (MueLu::UncoupledAggregationFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
 Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
@@ -397,6 +447,13 @@ aggregation: Dirichlet threshold = 0   [default]
 aggregation: drop scheme = classical   [default]
 lightweight wrap = 1
 
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
@@ -430,6 +487,12 @@ Domain GID offsets = {0}   [default]
 
 tentative: calculate qr = 1   [default]
 tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
 matrixmatrix: kernel params -> 
  [empty list]
 
@@ -502,18 +565,18 @@ repartition: use subcommunicators = 1   [default]
 ---                            Multigrid Summary                             ---
 --------------------------------------------------------------------------------
 Number of levels    = 3
-Operator complexity = 1.44
+Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
   0  9999  29995  3.00                  4  
-  1  3335  10003  3.00     3.00         4  
-  2  1112  3334   3.00     3.00         1  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
-Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10003}
+Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015}
 
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother

--- a/packages/muelu/test/interface/default/Output/reuse-tP-3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-3_tpetra.gold
@@ -23,8 +23,8 @@ Level 1
 Build (MueLu::RebalanceTransferFactory)
 Build (MueLu::RepartitionFactory)
 Computing Ac (MueLu::RAPFactory)
-Build (MueLu::TentativePFactory)
-Build (MueLu::UncoupledAggregationFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
 Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
@@ -35,6 +35,13 @@ aggregation: Dirichlet threshold = 0   [default]
 aggregation: drop scheme = classical   [default]
 lightweight wrap = 1
 
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
@@ -68,6 +75,12 @@ Domain GID offsets = {0}   [default]
 
 tentative: calculate qr = 1   [default]
 tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
 matrixmatrix: kernel params -> 
  [empty list]
 
@@ -157,8 +170,8 @@ Level 2
 Build (MueLu::RebalanceTransferFactory)
 Build (MueLu::RepartitionFactory)
 Computing Ac (MueLu::RAPFactory)
-Build (MueLu::TentativePFactory)
-Build (MueLu::UncoupledAggregationFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
 Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
@@ -169,6 +182,13 @@ aggregation: Dirichlet threshold = 0   [default]
 aggregation: drop scheme = classical   [default]
 lightweight wrap = 1
 
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
@@ -202,6 +222,12 @@ Domain GID offsets = {0}   [default]
 
 tentative: calculate qr = 1   [default]
 tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
 matrixmatrix: kernel params -> 
  [empty list]
 
@@ -320,6 +346,30 @@ smoother ->
 
 Level 1
 Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Reusing previous AP data
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
 Using original prolongator
 repartition: rebalance P and R = 0
 repartition: rebalance Nullspace = 1   [default]
@@ -392,8 +442,8 @@ Level 2
 Build (MueLu::RebalanceTransferFactory)
 Build (MueLu::RepartitionFactory)
 Computing Ac (MueLu::RAPFactory)
-Build (MueLu::TentativePFactory)
-Build (MueLu::UncoupledAggregationFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
 Build (MueLu::CoalesceDropFactory)
 Build (MueLu::AmalgamationFactory)
 [empty list]
@@ -404,6 +454,13 @@ aggregation: Dirichlet threshold = 0   [default]
 aggregation: drop scheme = classical   [default]
 lightweight wrap = 1
 
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
@@ -437,6 +494,12 @@ Domain GID offsets = {0}   [default]
 
 tentative: calculate qr = 1   [default]
 tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
 matrixmatrix: kernel params -> 
  [empty list]
 

--- a/packages/muelu/test/interface/default/Output/unsmoothed1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/unsmoothed1_epetra.gold
@@ -64,7 +64,7 @@ matrixmatrix: kernel params ->
 
 Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
-rap: triple product = 0   [default]
+rap: triple product = 1
 rap: fix zero diagonals = 0   [default]
 rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
@@ -136,7 +136,7 @@ matrixmatrix: kernel params ->
 
 Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
-rap: triple product = 0   [default]
+rap: triple product = 1
 rap: fix zero diagonals = 0   [default]
 rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]

--- a/packages/muelu/test/interface/default/Output/unsmoothed1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/unsmoothed1_tpetra.gold
@@ -74,7 +74,7 @@ matrixmatrix: kernel params ->
 
 Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
-rap: triple product = 0   [default]
+rap: triple product = 1
 rap: fix zero diagonals = 0   [default]
 rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
@@ -156,7 +156,7 @@ matrixmatrix: kernel params ->
 
 Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
-rap: triple product = 0   [default]
+rap: triple product = 1
 rap: fix zero diagonals = 0   [default]
 rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]

--- a/packages/muelu/test/interface/kokkos-complex/EasyParameterListInterpreter/reuse-tP-3_np4.xml
+++ b/packages/muelu/test/interface/kokkos-complex/EasyParameterListInterpreter/reuse-tP-3_np4.xml
@@ -1,5 +1,5 @@
 <ParameterList name="MueLu">
-  <Parameter name="multigrid algorithm"             type="string"   value="unsmoothed"/>
+  <!-- <Parameter name="multigrid algorithm"             type="string"   value="unsmoothed"/> -->
   <ParameterList name="level 1">
     <Parameter name="reuse: type"                   type="string"   value="tP"/>
   </ParameterList>

--- a/packages/muelu/test/interface/kokkos-complex/FactoryParameterListInterpreter/unsmoothed1.xml
+++ b/packages/muelu/test/interface/kokkos-complex/FactoryParameterListInterpreter/unsmoothed1.xml
@@ -11,6 +11,11 @@
       <Parameter name="factory"                             type="string" value="TentativePFactory"/>
     </ParameterList>
 
+    <ParameterList name="myRAPFact">
+      <Parameter name="factory"                             type="string" value="RAPFactory"/>
+      <Parameter name="rap: triple product"                 type="bool"   value="true"/>
+    </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="Hierarchy">
@@ -22,6 +27,7 @@
       <Parameter name="Graph"                               type="string"   value="myCoalesceDropFact"/>
       <Parameter name="Ptent"                               type="string"   value="myProlongatorFact"/>
       <Parameter name="P"                                   type="string"   value="myProlongatorFact"/>
+      <Parameter name="A"                                   type="string"   value="myRAPFact"/>
     </ParameterList>
 
   </ParameterList>

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse1_tpetra.gold
@@ -78,6 +78,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -164,6 +165,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -250,6 +252,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse2_tpetra.gold
@@ -78,6 +78,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -164,6 +165,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -250,6 +252,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -336,6 +339,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -422,6 +426,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse3_tpetra.gold
@@ -78,6 +78,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -164,6 +165,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -250,6 +252,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -336,6 +339,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse5_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse5_tpetra.gold
@@ -78,6 +78,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -164,6 +165,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLpgamg1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLpgamg1_tpetra.gold
@@ -80,6 +80,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -168,6 +169,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -256,6 +258,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -344,6 +347,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother1_tpetra.gold
@@ -78,6 +78,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -164,6 +165,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -250,6 +252,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -336,6 +339,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother2_tpetra.gold
@@ -78,6 +78,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -164,6 +165,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -250,6 +252,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -336,6 +339,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother3_tpetra.gold
@@ -78,6 +78,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -164,6 +165,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -250,6 +252,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -336,6 +339,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother4_tpetra.gold
@@ -78,6 +78,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -164,6 +165,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -250,6 +252,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -336,6 +339,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLunsmoothed1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLunsmoothed1_tpetra.gold
@@ -71,6 +71,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -150,6 +151,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -229,6 +231,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -308,6 +311,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 

--- a/packages/muelu/test/interface/kokkos-complex/Output/default_mhd_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/default_mhd_np4_tpetra.gold
@@ -63,7 +63,7 @@ matrixmatrix: kernel params ->
 
 Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 1
-rap: triple product = 0   [default]
+rap: triple product = 1
 rap: fix zero diagonals = 0   [default]
 rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
@@ -134,7 +134,7 @@ matrixmatrix: kernel params ->
 
 Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 1
-rap: triple product = 0   [default]
+rap: triple product = 1
 rap: fix zero diagonals = 0   [default]
 rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/default_mhd_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/default_mhd_tpetra.gold
@@ -63,7 +63,7 @@ matrixmatrix: kernel params ->
 
 Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 1
-rap: triple product = 0   [default]
+rap: triple product = 1
 rap: fix zero diagonals = 0   [default]
 rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
@@ -134,7 +134,7 @@ matrixmatrix: kernel params ->
 
 Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 1
-rap: triple product = 0   [default]
+rap: triple product = 1
 rap: fix zero diagonals = 0   [default]
 rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-3_np4_tpetra.gold
@@ -23,8 +23,7 @@ Level 1
 Build (MueLu::RebalanceTransferFactory)
 Build (MueLu::RepartitionFactory)
 Computing Ac (MueLu::RAPFactory)
-Build (MueLu::TentativePFactory_kokkos)
-Build (MueLu::UncoupledAggregationFactory_kokkos)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::CoalesceDropFactory_kokkos)
 Build (MueLu::AmalgamationFactory)
 [empty list]
@@ -38,6 +37,8 @@ filtered matrix: reuse graph = 1   [default]
 filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
@@ -65,6 +66,12 @@ Build (MueLu::CoarseMapFactory_kokkos)
 
 tentative: calculate qr = 1   [default]
 tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
 matrixmatrix: kernel params -> 
  [empty list]
 
@@ -151,8 +158,7 @@ Level 2
 Build (MueLu::RebalanceTransferFactory)
 Build (MueLu::RepartitionFactory)
 Computing Ac (MueLu::RAPFactory)
-Build (MueLu::TentativePFactory_kokkos)
-Build (MueLu::UncoupledAggregationFactory_kokkos)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::CoalesceDropFactory_kokkos)
 Build (MueLu::AmalgamationFactory)
 [empty list]
@@ -166,6 +172,8 @@ filtered matrix: reuse graph = 1   [default]
 filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
@@ -193,6 +201,12 @@ Build (MueLu::CoarseMapFactory_kokkos)
 
 tentative: calculate qr = 1   [default]
 tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
 matrixmatrix: kernel params -> 
  [empty list]
 
@@ -262,18 +276,18 @@ repartition: use subcommunicators = 1   [default]
 ---                            Multigrid Summary                             ---
 --------------------------------------------------------------------------------
 Number of levels    = 3
-Operator complexity = 1.44
+Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
   0  9999  29995  3.00                  4  
-  1  3335  10003  3.00     3.00         4  
-  2  1112  3334   3.00     3.00         1  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
-Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10003}
+Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015}
 
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
@@ -301,6 +315,26 @@ smoother ->
 
 Level 1
 Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
 Using original prolongator
 repartition: rebalance P and R = 0
 repartition: rebalance Nullspace = 1   [default]
@@ -347,7 +381,7 @@ matrixmatrix: kernel params ->
 
 repartition: use subcommunicators = 1   [default]
 
-Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10003})
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015})
 keep smoother data = 1
 PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
 PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
@@ -370,8 +404,7 @@ Level 2
 Build (MueLu::RebalanceTransferFactory)
 Build (MueLu::RepartitionFactory)
 Computing Ac (MueLu::RAPFactory)
-Build (MueLu::TentativePFactory_kokkos)
-Build (MueLu::UncoupledAggregationFactory_kokkos)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::CoalesceDropFactory_kokkos)
 Build (MueLu::AmalgamationFactory)
 [empty list]
@@ -385,6 +418,8 @@ filtered matrix: reuse graph = 1   [default]
 filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
@@ -412,6 +447,12 @@ Build (MueLu::CoarseMapFactory_kokkos)
 
 tentative: calculate qr = 1   [default]
 tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
 matrixmatrix: kernel params -> 
  [empty list]
 
@@ -481,18 +522,18 @@ repartition: use subcommunicators = 1   [default]
 ---                            Multigrid Summary                             ---
 --------------------------------------------------------------------------------
 Number of levels    = 3
-Operator complexity = 1.44
+Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
   0  9999  29995  3.00                  4  
-  1  3335  10003  3.00     3.00         4  
-  2  1112  3334   3.00     3.00         1  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
-Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10003}
+Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015}
 
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-3_tpetra.gold
@@ -23,8 +23,7 @@ Level 1
 Build (MueLu::RebalanceTransferFactory)
 Build (MueLu::RepartitionFactory)
 Computing Ac (MueLu::RAPFactory)
-Build (MueLu::TentativePFactory_kokkos)
-Build (MueLu::UncoupledAggregationFactory_kokkos)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::CoalesceDropFactory_kokkos)
 Build (MueLu::AmalgamationFactory)
 [empty list]
@@ -38,6 +37,8 @@ filtered matrix: reuse graph = 1   [default]
 filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
@@ -65,6 +66,12 @@ Build (MueLu::CoarseMapFactory_kokkos)
 
 tentative: calculate qr = 1   [default]
 tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
 matrixmatrix: kernel params -> 
  [empty list]
 
@@ -151,8 +158,7 @@ Level 2
 Build (MueLu::RebalanceTransferFactory)
 Build (MueLu::RepartitionFactory)
 Computing Ac (MueLu::RAPFactory)
-Build (MueLu::TentativePFactory_kokkos)
-Build (MueLu::UncoupledAggregationFactory_kokkos)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::CoalesceDropFactory_kokkos)
 Build (MueLu::AmalgamationFactory)
 [empty list]
@@ -166,6 +172,8 @@ filtered matrix: reuse graph = 1   [default]
 filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
@@ -193,6 +201,12 @@ Build (MueLu::CoarseMapFactory_kokkos)
 
 tentative: calculate qr = 1   [default]
 tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
 matrixmatrix: kernel params -> 
  [empty list]
 
@@ -308,6 +322,26 @@ smoother ->
 
 Level 1
 Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
 Using original prolongator
 repartition: rebalance P and R = 0
 repartition: rebalance Nullspace = 1   [default]
@@ -377,8 +411,7 @@ Level 2
 Build (MueLu::RebalanceTransferFactory)
 Build (MueLu::RepartitionFactory)
 Computing Ac (MueLu::RAPFactory)
-Build (MueLu::TentativePFactory_kokkos)
-Build (MueLu::UncoupledAggregationFactory_kokkos)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::CoalesceDropFactory_kokkos)
 Build (MueLu::AmalgamationFactory)
 [empty list]
@@ -392,6 +425,8 @@ filtered matrix: reuse graph = 1   [default]
 filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
@@ -419,6 +454,12 @@ Build (MueLu::CoarseMapFactory_kokkos)
 
 tentative: calculate qr = 1   [default]
 tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
 matrixmatrix: kernel params -> 
  [empty list]
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/unsmoothed1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/unsmoothed1_tpetra.gold
@@ -71,7 +71,7 @@ matrixmatrix: kernel params ->
 
 Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
-rap: triple product = 0   [default]
+rap: triple product = 1
 rap: fix zero diagonals = 0   [default]
 rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
@@ -150,7 +150,7 @@ matrixmatrix: kernel params ->
 
 Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
-rap: triple product = 0   [default]
+rap: triple product = 1
 rap: fix zero diagonals = 0   [default]
 rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]

--- a/packages/muelu/test/interface/kokkos/EasyParameterListInterpreter/reuse-tP-3_np4.xml
+++ b/packages/muelu/test/interface/kokkos/EasyParameterListInterpreter/reuse-tP-3_np4.xml
@@ -1,5 +1,5 @@
 <ParameterList name="MueLu">
-  <Parameter name="multigrid algorithm"             type="string"   value="unsmoothed"/>
+  <!-- <Parameter name="multigrid algorithm"             type="string"   value="unsmoothed"/> -->
   <ParameterList name="level 1">
     <Parameter name="reuse: type"                   type="string"   value="tP"/>
   </ParameterList>

--- a/packages/muelu/test/interface/kokkos/FactoryParameterListInterpreter/unsmoothed1.xml
+++ b/packages/muelu/test/interface/kokkos/FactoryParameterListInterpreter/unsmoothed1.xml
@@ -11,6 +11,11 @@
       <Parameter name="factory"                             type="string" value="TentativePFactory"/>
     </ParameterList>
 
+    <ParameterList name="myRAPFact">
+      <Parameter name="factory"                             type="string" value="RAPFactory"/>
+      <Parameter name="rap: triple product"                 type="bool"   value="true"/>
+    </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="Hierarchy">
@@ -22,6 +27,7 @@
       <Parameter name="Graph"                               type="string"   value="myCoalesceDropFact"/>
       <Parameter name="Ptent"                               type="string"   value="myProlongatorFact"/>
       <Parameter name="P"                                   type="string"   value="myProlongatorFact"/>
+      <Parameter name="A"                                   type="string"   value="myRAPFact"/>
     </ParameterList>
 
   </ParameterList>

--- a/packages/muelu/test/interface/kokkos/Output/MLaux_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLaux_epetra.gold
@@ -78,7 +78,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 512
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -98,7 +97,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]

--- a/packages/muelu/test/interface/kokkos/Output/MLaux_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLaux_tpetra.gold
@@ -81,6 +81,7 @@ matrixmatrix: kernel params ->
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse1_tpetra.gold
@@ -78,6 +78,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -164,6 +165,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -250,6 +252,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse2_tpetra.gold
@@ -78,6 +78,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -164,6 +165,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -250,6 +252,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -336,6 +339,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -422,6 +426,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse3_tpetra.gold
@@ -78,6 +78,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -164,6 +165,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -250,6 +252,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -336,6 +339,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse4_tpetra.gold
@@ -78,6 +78,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -164,6 +165,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -250,6 +252,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -336,6 +339,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse5_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse5_tpetra.gold
@@ -78,6 +78,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -164,6 +165,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 

--- a/packages/muelu/test/interface/kokkos/Output/MLpgamg1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLpgamg1_tpetra.gold
@@ -80,6 +80,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -168,6 +169,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -256,6 +258,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -344,6 +347,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning1_epetra.gold
@@ -77,7 +77,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 512
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -97,7 +96,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
@@ -198,7 +196,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 512
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -218,7 +215,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
@@ -319,7 +315,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 512
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -339,7 +334,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
@@ -440,7 +434,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 512
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -460,7 +453,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
@@ -561,7 +553,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 512
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -581,7 +572,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning1_tpetra.gold
@@ -80,6 +80,7 @@ matrixmatrix: kernel params ->
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -211,6 +212,7 @@ matrixmatrix: kernel params ->
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -342,6 +344,7 @@ matrixmatrix: kernel params ->
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -473,6 +476,7 @@ matrixmatrix: kernel params ->
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -604,6 +608,7 @@ matrixmatrix: kernel params ->
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning2_epetra.gold
@@ -77,7 +77,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 1000
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -97,7 +96,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
@@ -198,7 +196,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 1000
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -218,7 +215,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
@@ -319,7 +315,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 1000
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -339,7 +334,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
@@ -440,7 +434,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 1000
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -460,7 +453,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning2_tpetra.gold
@@ -80,6 +80,7 @@ matrixmatrix: kernel params ->
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -211,6 +212,7 @@ matrixmatrix: kernel params ->
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -342,6 +344,7 @@ matrixmatrix: kernel params ->
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -473,6 +476,7 @@ matrixmatrix: kernel params ->
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning3_epetra.gold
@@ -77,7 +77,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 256
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -97,7 +96,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
@@ -198,7 +196,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 256
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -218,7 +215,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
@@ -319,7 +315,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 256
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -339,7 +334,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
@@ -440,7 +434,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 256
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -460,7 +453,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning3_tpetra.gold
@@ -80,6 +80,7 @@ matrixmatrix: kernel params ->
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -211,6 +212,7 @@ matrixmatrix: kernel params ->
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -342,6 +344,7 @@ matrixmatrix: kernel params ->
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -473,6 +476,7 @@ matrixmatrix: kernel params ->
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother1_tpetra.gold
@@ -78,6 +78,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -164,6 +165,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -250,6 +252,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -336,6 +339,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother2_tpetra.gold
@@ -78,6 +78,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -164,6 +165,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -250,6 +252,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -336,6 +339,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother3_tpetra.gold
@@ -78,6 +78,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -164,6 +165,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -250,6 +252,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -336,6 +339,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother4_tpetra.gold
@@ -72,6 +72,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -152,6 +153,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -232,6 +234,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -312,6 +315,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 

--- a/packages/muelu/test/interface/kokkos/Output/MLunsmoothed1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLunsmoothed1_tpetra.gold
@@ -71,6 +71,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -150,6 +151,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -229,6 +231,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 
@@ -308,6 +311,7 @@ Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
 rap: fix zero diagonals = 0   [default]
+rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
 RepairMainDiagonal = 0
 matrixmatrix: kernel params -> 

--- a/packages/muelu/test/interface/kokkos/Output/default_mhd_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_mhd_np4_tpetra.gold
@@ -63,7 +63,7 @@ matrixmatrix: kernel params ->
 
 Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 1
-rap: triple product = 0   [default]
+rap: triple product = 1
 rap: fix zero diagonals = 0   [default]
 rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
@@ -134,7 +134,7 @@ matrixmatrix: kernel params ->
 
 Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 1
-rap: triple product = 0   [default]
+rap: triple product = 1
 rap: fix zero diagonals = 0   [default]
 rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]

--- a/packages/muelu/test/interface/kokkos/Output/default_mhd_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_mhd_tpetra.gold
@@ -63,7 +63,7 @@ matrixmatrix: kernel params ->
 
 Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 1
-rap: triple product = 0   [default]
+rap: triple product = 1
 rap: fix zero diagonals = 0   [default]
 rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
@@ -134,7 +134,7 @@ matrixmatrix: kernel params ->
 
 Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 1
-rap: triple product = 0   [default]
+rap: triple product = 1
 rap: fix zero diagonals = 0   [default]
 rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar1_epetra.gold
@@ -76,7 +76,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -88,7 +87,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -102,7 +100,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
@@ -202,7 +199,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -214,7 +210,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -228,7 +223,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
@@ -328,7 +322,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -340,7 +333,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -354,7 +346,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar1_np4_epetra.gold
@@ -76,7 +76,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -88,7 +87,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -102,7 +100,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar2_epetra.gold
@@ -77,7 +77,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -89,7 +88,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -103,7 +101,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
@@ -204,7 +201,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -216,7 +212,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -230,7 +225,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
@@ -331,7 +325,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -343,7 +336,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -357,7 +349,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar2_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar2_np4_epetra.gold
@@ -77,7 +77,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -89,7 +88,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 1
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 2000
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -103,7 +101,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]

--- a/packages/muelu/test/interface/kokkos/Output/repartition1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition1_epetra.gold
@@ -74,7 +74,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -86,7 +85,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -100,7 +98,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
@@ -198,7 +195,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -210,7 +206,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -224,7 +219,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]

--- a/packages/muelu/test/interface/kokkos/Output/repartition1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition1_np4_epetra.gold
@@ -74,7 +74,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -86,7 +85,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -100,7 +98,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
@@ -198,7 +195,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -210,7 +206,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -224,7 +219,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]

--- a/packages/muelu/test/interface/kokkos/Output/repartition3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition3_epetra.gold
@@ -74,7 +74,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -86,7 +85,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -100,7 +98,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 0
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
@@ -198,7 +195,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -210,7 +206,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -224,7 +219,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 0
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]

--- a/packages/muelu/test/interface/kokkos/Output/repartition3_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition3_np4_epetra.gold
@@ -74,7 +74,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -86,7 +85,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -100,7 +98,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 0
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
@@ -198,7 +195,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -210,7 +206,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -224,7 +219,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 0
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]

--- a/packages/muelu/test/interface/kokkos/Output/repartition4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition4_epetra.gold
@@ -74,7 +74,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -86,7 +85,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -100,7 +98,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
@@ -198,7 +195,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -210,7 +206,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -224,7 +219,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0

--- a/packages/muelu/test/interface/kokkos/Output/repartition4_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition4_np4_epetra.gold
@@ -74,7 +74,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -86,7 +85,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -100,7 +98,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
@@ -198,7 +195,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -210,7 +206,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -224,7 +219,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_epetra.gold
@@ -74,7 +74,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -86,7 +85,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -100,7 +98,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1
@@ -198,7 +195,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -210,7 +206,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -224,7 +219,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_np4_epetra.gold
@@ -74,7 +74,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -86,7 +85,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -100,7 +98,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1
@@ -198,7 +195,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -210,7 +206,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -224,7 +219,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 repartition: rebalance P and R = 1
 repartition: rebalance Nullspace = 1   [default]

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_epetra.gold
@@ -70,7 +70,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 1
 rap: triple product = 0   [default]
@@ -82,7 +81,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -96,7 +94,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
@@ -180,7 +177,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 1
 rap: triple product = 0   [default]
@@ -192,7 +188,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -206,7 +201,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_np4_epetra.gold
@@ -70,7 +70,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 1
 rap: triple product = 0   [default]
@@ -82,7 +81,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -96,7 +94,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
@@ -180,7 +177,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 1
 rap: triple product = 0   [default]
@@ -192,7 +188,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -206,7 +201,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_epetra.gold
@@ -70,7 +70,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 1
 rap: triple product = 0   [default]
@@ -82,7 +81,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -96,7 +94,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
@@ -180,7 +177,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 1
 rap: triple product = 0   [default]
@@ -192,7 +188,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -206,7 +201,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
@@ -281,7 +275,6 @@ Transferring coordinates
 Reusing coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 1
 rap: triple product = 0   [default]
@@ -323,7 +316,6 @@ Transferring coordinates
 Reusing coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 1
 rap: triple product = 0   [default]

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_np4_epetra.gold
@@ -70,7 +70,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 1
 rap: triple product = 0   [default]
@@ -82,7 +81,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -96,7 +94,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
@@ -180,7 +177,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 1
 rap: triple product = 0   [default]
@@ -192,7 +188,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -206,7 +201,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
@@ -274,7 +268,6 @@ Transferring coordinates
 Reusing coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 1
 rap: triple product = 0   [default]
@@ -316,7 +309,6 @@ Transferring coordinates
 Reusing coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 1
 rap: triple product = 0   [default]

--- a/packages/muelu/test/interface/kokkos/Output/reuse-S-1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-S-1_epetra.gold
@@ -74,7 +74,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -86,7 +85,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -100,7 +98,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1
@@ -198,7 +195,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -210,7 +206,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -224,7 +219,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1
@@ -353,7 +347,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -365,7 +358,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -379,7 +371,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1
@@ -477,7 +468,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -489,7 +479,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -503,7 +492,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1

--- a/packages/muelu/test/interface/kokkos/Output/reuse-S-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-S-1_np4_epetra.gold
@@ -74,7 +74,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -86,7 +85,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -100,7 +98,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1
@@ -198,7 +195,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -210,7 +206,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -224,7 +219,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 repartition: rebalance P and R = 1
 repartition: rebalance Nullspace = 1   [default]
@@ -344,7 +338,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -356,7 +349,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -370,7 +362,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1
@@ -468,7 +459,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -480,7 +470,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -494,7 +483,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 repartition: rebalance P and R = 1
 repartition: rebalance Nullspace = 1   [default]

--- a/packages/muelu/test/interface/kokkos/Output/reuse-full-1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-full-1_epetra.gold
@@ -74,7 +74,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -86,7 +85,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -100,7 +98,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1
@@ -198,7 +195,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -210,7 +206,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -224,7 +219,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1

--- a/packages/muelu/test/interface/kokkos/Output/reuse-full-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-full-1_np4_epetra.gold
@@ -74,7 +74,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -86,7 +85,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -100,7 +98,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 1
@@ -198,7 +195,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -210,7 +206,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -224,7 +219,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 repartition: rebalance P and R = 1
 repartition: rebalance Nullspace = 1   [default]

--- a/packages/muelu/test/interface/kokkos/Output/reuse-none_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-none_epetra.gold
@@ -74,7 +74,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -86,7 +85,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -100,7 +98,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
@@ -198,7 +195,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -210,7 +206,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -224,7 +219,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
@@ -353,7 +347,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -365,7 +358,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -379,7 +371,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
@@ -477,7 +468,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -489,7 +479,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -503,7 +492,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]

--- a/packages/muelu/test/interface/kokkos/Output/reuse-none_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-none_np4_epetra.gold
@@ -74,7 +74,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -86,7 +85,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -100,7 +98,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
@@ -198,7 +195,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -210,7 +206,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -224,7 +219,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
@@ -346,7 +340,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -358,7 +351,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -372,7 +364,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
@@ -470,7 +461,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -482,7 +472,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -496,7 +485,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_epetra.gold
@@ -74,7 +74,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -86,7 +85,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -100,7 +98,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
@@ -198,7 +195,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -210,7 +206,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -224,7 +219,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
@@ -343,7 +337,6 @@ Transferring coordinates
 Reusing coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -419,7 +412,6 @@ Transferring coordinates
 Reusing coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_np4_epetra.gold
@@ -74,7 +74,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -86,7 +85,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -100,7 +98,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
@@ -198,7 +195,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -210,7 +206,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -224,7 +219,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
@@ -336,7 +330,6 @@ Transferring coordinates
 Reusing coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -412,7 +405,6 @@ Transferring coordinates
 Reusing coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_epetra.gold
@@ -75,7 +75,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -87,7 +86,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -101,7 +99,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
@@ -200,7 +197,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -212,7 +208,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -226,7 +221,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
@@ -344,7 +338,6 @@ Transferring coordinates
 Reusing coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -431,7 +424,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -443,7 +435,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -457,7 +448,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_np4_epetra.gold
@@ -75,7 +75,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -87,7 +86,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -101,7 +99,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
@@ -200,7 +197,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -212,7 +208,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -226,7 +221,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
@@ -337,7 +331,6 @@ Transferring coordinates
 Reusing coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -424,7 +417,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -436,7 +428,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -450,7 +441,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_epetra.gold
@@ -67,7 +67,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -79,7 +78,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -93,7 +91,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
@@ -184,7 +181,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -196,7 +192,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -210,7 +205,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
@@ -309,7 +303,6 @@ Transferring coordinates
 Reusing coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -388,7 +381,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -400,7 +392,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -414,7 +405,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_np4_epetra.gold
@@ -67,7 +67,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -79,7 +78,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -93,7 +91,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
@@ -184,7 +181,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -196,7 +192,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -210,7 +205,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
@@ -302,7 +296,6 @@ Transferring coordinates
 Reusing coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -381,7 +374,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 0   [default]
 rap: triple product = 0   [default]
@@ -393,7 +385,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -407,7 +398,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_np4_tpetra.gold
@@ -23,8 +23,7 @@ Level 1
 Build (MueLu::RebalanceTransferFactory)
 Build (MueLu::RepartitionFactory)
 Computing Ac (MueLu::RAPFactory)
-Build (MueLu::TentativePFactory_kokkos)
-Build (MueLu::UncoupledAggregationFactory_kokkos)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::CoalesceDropFactory_kokkos)
 Build (MueLu::AmalgamationFactory)
 [empty list]
@@ -38,6 +37,8 @@ filtered matrix: reuse graph = 1   [default]
 filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
@@ -65,6 +66,12 @@ Build (MueLu::CoarseMapFactory_kokkos)
 
 tentative: calculate qr = 1   [default]
 tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
 matrixmatrix: kernel params -> 
  [empty list]
 
@@ -151,8 +158,7 @@ Level 2
 Build (MueLu::RebalanceTransferFactory)
 Build (MueLu::RepartitionFactory)
 Computing Ac (MueLu::RAPFactory)
-Build (MueLu::TentativePFactory_kokkos)
-Build (MueLu::UncoupledAggregationFactory_kokkos)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::CoalesceDropFactory_kokkos)
 Build (MueLu::AmalgamationFactory)
 [empty list]
@@ -166,6 +172,8 @@ filtered matrix: reuse graph = 1   [default]
 filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
@@ -193,6 +201,12 @@ Build (MueLu::CoarseMapFactory_kokkos)
 
 tentative: calculate qr = 1   [default]
 tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
 matrixmatrix: kernel params -> 
  [empty list]
 
@@ -262,18 +276,18 @@ repartition: use subcommunicators = 1   [default]
 ---                            Multigrid Summary                             ---
 --------------------------------------------------------------------------------
 Number of levels    = 3
-Operator complexity = 1.44
+Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
   0  9999  29995  3.00                  4  
-  1  3335  10003  3.00     3.00         4  
-  2  1112  3334   3.00     3.00         1  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
-Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10003}
+Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015}
 
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
@@ -301,6 +315,26 @@ smoother ->
 
 Level 1
 Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
 Using original prolongator
 repartition: rebalance P and R = 0
 repartition: rebalance Nullspace = 1   [default]
@@ -347,7 +381,7 @@ matrixmatrix: kernel params ->
 
 repartition: use subcommunicators = 1   [default]
 
-Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10003})
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015})
 keep smoother data = 1
 PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
 PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
@@ -370,8 +404,7 @@ Level 2
 Build (MueLu::RebalanceTransferFactory)
 Build (MueLu::RepartitionFactory)
 Computing Ac (MueLu::RAPFactory)
-Build (MueLu::TentativePFactory_kokkos)
-Build (MueLu::UncoupledAggregationFactory_kokkos)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::CoalesceDropFactory_kokkos)
 Build (MueLu::AmalgamationFactory)
 [empty list]
@@ -385,6 +418,8 @@ filtered matrix: reuse graph = 1   [default]
 filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
@@ -412,6 +447,12 @@ Build (MueLu::CoarseMapFactory_kokkos)
 
 tentative: calculate qr = 1   [default]
 tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
 matrixmatrix: kernel params -> 
  [empty list]
 
@@ -481,18 +522,18 @@ repartition: use subcommunicators = 1   [default]
 ---                            Multigrid Summary                             ---
 --------------------------------------------------------------------------------
 Number of levels    = 3
-Operator complexity = 1.44
+Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
 level  rows  nnz    nnz/row  c ratio  procs
   0  9999  29995  3.00                  4  
-  1  3335  10003  3.00     3.00         4  
-  2  1112  3334   3.00     3.00         1  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
-Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10003}
+Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015}
 
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_tpetra.gold
@@ -23,8 +23,7 @@ Level 1
 Build (MueLu::RebalanceTransferFactory)
 Build (MueLu::RepartitionFactory)
 Computing Ac (MueLu::RAPFactory)
-Build (MueLu::TentativePFactory_kokkos)
-Build (MueLu::UncoupledAggregationFactory_kokkos)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::CoalesceDropFactory_kokkos)
 Build (MueLu::AmalgamationFactory)
 [empty list]
@@ -38,6 +37,8 @@ filtered matrix: reuse graph = 1   [default]
 filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
@@ -65,6 +66,12 @@ Build (MueLu::CoarseMapFactory_kokkos)
 
 tentative: calculate qr = 1   [default]
 tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
 matrixmatrix: kernel params -> 
  [empty list]
 
@@ -151,8 +158,7 @@ Level 2
 Build (MueLu::RebalanceTransferFactory)
 Build (MueLu::RepartitionFactory)
 Computing Ac (MueLu::RAPFactory)
-Build (MueLu::TentativePFactory_kokkos)
-Build (MueLu::UncoupledAggregationFactory_kokkos)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::CoalesceDropFactory_kokkos)
 Build (MueLu::AmalgamationFactory)
 [empty list]
@@ -166,6 +172,8 @@ filtered matrix: reuse graph = 1   [default]
 filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
@@ -193,6 +201,12 @@ Build (MueLu::CoarseMapFactory_kokkos)
 
 tentative: calculate qr = 1   [default]
 tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
 matrixmatrix: kernel params -> 
  [empty list]
 
@@ -308,6 +322,26 @@ smoother ->
 
 Level 1
 Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
 Using original prolongator
 repartition: rebalance P and R = 0
 repartition: rebalance Nullspace = 1   [default]
@@ -377,8 +411,7 @@ Level 2
 Build (MueLu::RebalanceTransferFactory)
 Build (MueLu::RepartitionFactory)
 Computing Ac (MueLu::RAPFactory)
-Build (MueLu::TentativePFactory_kokkos)
-Build (MueLu::UncoupledAggregationFactory_kokkos)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
 Build (MueLu::CoalesceDropFactory_kokkos)
 Build (MueLu::AmalgamationFactory)
 [empty list]
@@ -392,6 +425,8 @@ filtered matrix: reuse graph = 1   [default]
 filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
 BuildAggregates (Phase 1 (main))
 BuildAggregates (Phase 2a (secondary))
@@ -419,6 +454,12 @@ Build (MueLu::CoarseMapFactory_kokkos)
 
 tentative: calculate qr = 1   [default]
 tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
 matrixmatrix: kernel params -> 
  [empty list]
 

--- a/packages/muelu/test/interface/kokkos/Output/transpose2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose2_epetra.gold
@@ -70,7 +70,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 1
 rap: triple product = 0   [default]
@@ -82,7 +81,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -96,7 +94,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
@@ -180,7 +177,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 1
 rap: triple product = 0   [default]
@@ -192,7 +188,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -206,7 +201,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]

--- a/packages/muelu/test/interface/kokkos/Output/transpose2_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose2_np4_epetra.gold
@@ -70,7 +70,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 1
 rap: triple product = 0   [default]
@@ -82,7 +81,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -96,7 +94,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]
@@ -180,7 +177,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 1
 rap: triple product = 0   [default]
@@ -192,7 +188,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -206,7 +201,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0   [default]

--- a/packages/muelu/test/interface/kokkos/Output/transpose3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose3_epetra.gold
@@ -70,7 +70,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 1
 rap: triple product = 0   [default]
@@ -82,7 +81,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -96,7 +94,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
@@ -180,7 +177,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 1
 rap: triple product = 0   [default]
@@ -192,7 +188,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -206,7 +201,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0

--- a/packages/muelu/test/interface/kokkos/Output/transpose3_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose3_np4_epetra.gold
@@ -70,7 +70,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 1
 rap: triple product = 0   [default]
@@ -82,7 +81,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -96,7 +94,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0
@@ -180,7 +177,6 @@ Build (MueLu::CoordinatesTransferFactory_kokkos)
 Transferring coordinates
 write start = -1   [default]
 write end = -1   [default]
-structured aggregation = 0   [default]
 
 transpose: use implicit = 1
 rap: triple product = 0   [default]
@@ -192,7 +188,6 @@ matrixmatrix: kernel params ->
 
 Build (MueLu::RepartitionHeuristicFactory)
 repartition: start level = 2   [default]
-repartition: node repartition level = -1   [default]
 repartition: min rows per proc = 800   [default]
 repartition: target rows per proc = 0   [default]
 repartition: min rows per thread = 0   [default]
@@ -206,7 +201,6 @@ repartition: print partition distribution = 0   [default]
 repartition: remap parts = 1   [default]
 repartition: remap num values = 4   [default]
 repartition: remap accept partition = 1   [default]
-repartition: node repartition level = -1   [default]
 
 Using original prolongator
 repartition: rebalance P and R = 0

--- a/packages/muelu/test/interface/kokkos/Output/unsmoothed1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/unsmoothed1_tpetra.gold
@@ -71,7 +71,7 @@ matrixmatrix: kernel params ->
 
 Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
-rap: triple product = 0   [default]
+rap: triple product = 1
 rap: fix zero diagonals = 0   [default]
 rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
@@ -150,7 +150,7 @@ matrixmatrix: kernel params ->
 
 Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
-rap: triple product = 0   [default]
+rap: triple product = 1
 rap: fix zero diagonals = 0   [default]
 rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]

--- a/packages/muelu/test/interface/kokkos/Output/unsmoothed2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/unsmoothed2_tpetra.gold
@@ -71,7 +71,7 @@ matrixmatrix: kernel params ->
 
 Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
-rap: triple product = 0   [default]
+rap: triple product = 1
 rap: fix zero diagonals = 0   [default]
 rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]
@@ -150,7 +150,7 @@ matrixmatrix: kernel params ->
 
 Computing Ac (MueLu::RAPFactory)
 transpose: use implicit = 0   [default]
-rap: triple product = 0   [default]
+rap: triple product = 1
 rap: fix zero diagonals = 0   [default]
 rap: relative diagonal floor = {}   [default]
 CheckMainDiagonal = 0   [default]

--- a/packages/muelu/test/maxwell/CMakeLists.txt
+++ b/packages/muelu/test/maxwell/CMakeLists.txt
@@ -29,7 +29,7 @@ IF (${PACKAGE_NAME}_ENABLE_Belos AND ${PACKAGE_NAME}_ENABLE_Amesos2)
       NUM_MPI_PROCS 4
       )
 
-    IF (${PACKAGE_NAME}_ENABLE_ML)
+    IF (${PACKAGE_NAME}_ENABLE_ML AND ${PACKAGE_NAME}_ENABLE_EPETRA)
       TRIBITS_ADD_TEST(
         Maxwell3D
         NAME "Maxwell3D-Tpetra-ML-list"


### PR DESCRIPTION
@trilinos/muelu 

## Description
- Use triple product for unsmoothed hierarchies, since it's always faster.
- Second attempt at disabling failing test with ML style list. 
  (Why do we have builds with ML enabled and Epetra disabled?)