### PR TITLE
Tpetra: Fix #5408 (build warning in CrsGraph)

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -2353,8 +2353,8 @@ namespace Tpetra {
                    const Teuchos::ArrayView<const LocalOrdinal>& indices,
                    std::function<void(const size_t, const size_t, const size_t)> fun) const
   {
-    const char tfecfFuncName[] = "findLocalIndices: ";
 #ifdef HAVE_TPETRA_DEBUG
+    const char tfecfFuncName[] = "findLocalIndices: ";
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
       (this->getProfileType() != StaticProfile, std::runtime_error,
        "findLocalIndices requires that the graph have StaticProfile.");


### PR DESCRIPTION
@trilinos/tpetra @rrdrake 

## Description

Fix build warning in release build.

## Motivation and Context

Sierra builds with warnings as errors.

## Related Issues

* Closes #5408 

