### PR TITLE
Remove unused variable in Pliris

### DIFF
--- a/packages/pliris/test/vector_random/cxx_main.cpp
+++ b/packages/pliris/test/vector_random/cxx_main.cpp
@@ -91,8 +91,6 @@ int main(int argc, char *argv[])
 
   int mlen;   // Message length for input data
 
-  int ierror;
-
   int num_global_length;
 
   unsigned int seed= 10;
@@ -271,9 +269,9 @@ int main(int argc, char *argv[])
               std::cout << " ****   Setting Random Matrix    ****" << std::endl;
 
 
-     ierror = A.SetSeed(seed+comm.MyPID() );
+     A.SetSeed(seed+comm.MyPID() );
 
-     ierror = A.Random();
+     A.Random();
 
 
      // Now Create the RHS
@@ -413,13 +411,13 @@ int main(int argc, char *argv[])
      // Reset the matrix Random values
 
 
-     ierror = A.SetSeed(seed + comm.MyPID() );
+     A.SetSeed(seed + comm.MyPID() );
 
 
-     ierror = A.Random();
+     A.Random();
 
 
-     ierror = A.NormInf(&ainf);
+     A.NormInf(&ainf);
 
     // perform the Matrix vector product
 


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/pliris 
@trilinos/framework 

## Description
<!--- Please describe your changes in detail. -->
While [checking the progress of Werror being set globally](https://testing.sandia.gov/cdash/index.php?project=Trilinos&parentid=5203083&filtercount=1&showfilters=1&field1=buildstamp&compare1=61&value1=20190619-1725-Experimental&filtercombine=and), Pliris was found to have an unused variable, found under subproject Xpetra. There appears to be no other use for ierror and it's not used in assert statements either. So the variable has been removed.

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
This is work toward Issue #3178, eventually allowing -Werror to be set for all packages.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
