### PR TITLE
Tpetra:  changes to reduce the number of deprecated warnings issued 

### DIFF
--- a/packages/tpetra/core/src/Tpetra_ConfigDefs.hpp
+++ b/packages/tpetra/core/src/Tpetra_ConfigDefs.hpp
@@ -133,9 +133,9 @@ namespace Tpetra {
 
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE
   TPETRA_DEPRECATED const ProfileType DynamicProfile = ProfileType(StaticProfile+1);
-#define TPETRA_DEFAULT_PROFILE_TYPE DynamicProfile
+#define TPETRA_DEFAULT_PROFILE_TYPE Tpetra::ProfileType(Tpetra::StaticProfile+1)  // DynamicProfile
 #else
-#define TPETRA_DEFAULT_PROFILE_TYPE StaticProfile
+#define TPETRA_DEFAULT_PROFILE_TYPE Tpetra::StaticProfile
 #endif
 
   /*! Optimize storage option */

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -402,7 +402,7 @@ namespace Tpetra {
     TPETRA_DEPRECATED
     CrsGraph (const Teuchos::RCP<const map_type>& rowMap,
               const Teuchos::ArrayRCP<const size_t>& numEntPerRow,
-	      const ProfileType pftype = DynamicProfile,
+	      const ProfileType pftype = TPETRA_DEFAULT_PROFILE_TYPE,
               const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 #endif // TPETRA_ENABLE_DEPRECATED_CODE
 
@@ -488,7 +488,7 @@ namespace Tpetra {
     CrsGraph (const Teuchos::RCP<const map_type>& rowMap,
               const Teuchos::RCP<const map_type>& colMap,
               const Teuchos::ArrayRCP<const size_t>& numEntPerRow,
-	      const ProfileType pftype = DynamicProfile,
+	      const ProfileType pftype = TPETRA_DEFAULT_PROFILE_TYPE,
               const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 #endif // TPETRA_ENABLE_DEPRECATED_CODE
 
@@ -2876,7 +2876,7 @@ namespace Tpetra {
           fillCompleteClone = params->get ("fillComplete clone", fillCompleteClone);
           useLocalIndices = params->get ("Locally indexed clone", useLocalIndices);
           if (params->get ("Static profile clone", true) == false) {
-            pftype = DynamicProfile;
+            pftype = ProfileType(StaticProfile+1); // DynamicProfile (Tpetra_ConfigDefs.h)
           }
           debug = params->get ("Debug", debug);
         }

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -1031,7 +1031,7 @@ namespace Tpetra {
   CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
   getNode () const
   {
-    return rowMap_.is_null () ? Teuchos::null : rowMap_->getNode ();
+    return Teuchos::null;
   }
 #endif // TPETRA_ENABLE_DEPRECATED_CODE
 

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -557,7 +557,7 @@ namespace Tpetra {
     TPETRA_DEPRECATED
     CrsMatrix (const Teuchos::RCP<const map_type>& rowMap,
                const Teuchos::ArrayRCP<const size_t>& numEntPerRowToAlloc,
-               const ProfileType pftype = DynamicProfile,
+               const ProfileType pftype = TPETRA_DEFAULT_PROFILE_TYPE,
                const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 #endif // TPETRA_ENABLE_DEPRECATED_CODE
 
@@ -623,7 +623,7 @@ namespace Tpetra {
     CrsMatrix (const Teuchos::RCP<const map_type>& rowMap,
                const Teuchos::RCP<const map_type>& colMap,
                const Teuchos::ArrayRCP<const size_t>& numEntPerRowToAlloc,
-               const ProfileType pftype = DynamicProfile,
+               const ProfileType pftype = TPETRA_DEFAULT_PROFILE_TYPE,
                const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 #endif // TPETRA_ENABLE_DEPRECATED_CODE
 
@@ -867,7 +867,7 @@ namespace Tpetra {
 
         bool staticProfileClone = true;
         staticProfileClone = params->get ("Static profile clone", staticProfileClone);
-        pftype = staticProfileClone ? StaticProfile : DynamicProfile;
+        pftype = staticProfileClone ? StaticProfile : ProfileType(StaticProfile+1) /*DynamicProfile*/;
       }
 
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -807,7 +807,7 @@ namespace Tpetra {
   Teuchos::RCP<Node>
   CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   getNode () const {
-    return getCrsGraphRef ().getNode ();
+    return Teuchos::null;
   }
 #endif // TPETRA_ENABLE_DEPRECATED_CODE
 
@@ -8419,11 +8419,19 @@ namespace Tpetra {
       // Construct the result matrix C.
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE
       if (constructorSublist.is_null ()) {
-        C = rcp (new crs_matrix_type (C_rowMap, 0, DynamicProfile));
+        C = rcp (new crs_matrix_type (C_rowMap, 0, ProfileType(StaticProfile+1) /*DynamicProfile*/));
       } else {
-        C = rcp (new crs_matrix_type (C_rowMap, 0, DynamicProfile,
+        C = rcp (new crs_matrix_type (C_rowMap, 0, ProfileType(StaticProfile+1) /*DynamicProfile*/,
                                       constructorSublist));
       }
+#else
+      // true: !A_rowMap->isSameAs (*B_rowMap)
+      TEUCHOS_TEST_FOR_EXCEPTION(true,
+                                 std::invalid_argument,
+                                 "Tpetra::CrsMatrix::add: The row maps must be the same for statically "
+                                 "allocated matrices in order to be sure that there is sufficient space "
+                                 "to do the addition");
+
 #endif
     }
 

--- a/packages/tpetra/core/src/Tpetra_Experimental_BlockCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Experimental_BlockCrsMatrix_def.hpp
@@ -3728,7 +3728,7 @@ public:
   BlockCrsMatrix<Scalar, LO, GO, Node>::
   getNode() const
   {
-    return graph_.getNode();
+    return Teuchos::null;
 
   }
 #endif // TPETRA_ENABLE_DEPRECATED_CODE

--- a/packages/tpetra/core/src/Tpetra_RowMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_RowMatrix_def.hpp
@@ -217,9 +217,9 @@ namespace Tpetra {
       // Construct the result matrix C.
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE
       if (constructorSublist.is_null ()) {
-        C = rcp (new crs_matrix_type (C_rowMap, 0, DynamicProfile));
+        C = rcp (new crs_matrix_type (C_rowMap, 0, ProfileType(StaticProfile+1) /* DynamicProfile */));
       } else {
-        C = rcp (new crs_matrix_type (C_rowMap, 0, DynamicProfile,
+        C = rcp (new crs_matrix_type (C_rowMap, 0, ProfileType(StaticProfile+1) /* DynamicProfile */,
                                       constructorSublist));
       }
 #else

--- a/packages/tpetra/core/test/CrsGraph/CrsGraph_Issue601.cpp
+++ b/packages/tpetra/core/test/CrsGraph/CrsGraph_Issue601.cpp
@@ -109,7 +109,7 @@ namespace { // (anonymous)
 
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE
       out << "ProfileType: "
-          << ((profileType == Tpetra::DynamicProfile) ? "Dynamic" : "Static")
+          << ((profileType == Tpetra::StaticProfile) ? "Static" : "Dynamic")
           << "Profile" << endl;
 #endif // TPETRA_ENABLE_DEPRECATED_CODE
       Teuchos::OSTab tab2 (out);

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_NonlocalAfterResume.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_NonlocalAfterResume.cpp
@@ -160,7 +160,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( CrsMatrix, NonlocalAfterResume, LO, GO, Scala
     //----------------------------------------------------------------------
     // put in diagonal, locally
     //----------------------------------------------------------------------
-    Tpetra::ProfileType pftype = Tpetra::TPETRA_DEFAULT_PROFILE_TYPE;
+    Tpetra::ProfileType pftype = TPETRA_DEFAULT_PROFILE_TYPE;
     Tpetra::CrsMatrix<Scalar,LO,GO,Node> matrix(rmap,cmap,3,pftype);
     for (GO r=rmap->getMinGlobalIndex(); r <= rmap->getMaxGlobalIndex(); ++r) {
       matrix.insertGlobalValues(r,tuple(r),tuple(ST::one()));

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests.cpp
@@ -113,13 +113,13 @@ namespace { // (anonymous)
     {
       RCPMap map  = createContigMapWithNode<LO,GO,Node>(INVALID,numLocal,comm);
       MV mv(map,1);
-      zero = rcp( new MAT(map,0,Tpetra::TPETRA_DEFAULT_PROFILE_TYPE) );
+      zero = rcp( new MAT(map,0,TPETRA_DEFAULT_PROFILE_TYPE) );
       TEST_THROW(zero->apply(mv,mv), std::runtime_error);
 #   if defined(HAVE_TPETRA_THROW_EFFICIENCY_WARNINGS)
       // throw exception because we required increased allocation
       TEST_THROW(zero->insertGlobalValues(map->getMinGlobalIndex(),tuple<GO>(0),tuple<Scalar>(ST::one())), std::runtime_error);
 #   endif
-      TEST_ASSERT( zero->getProfileType() == Tpetra::TPETRA_DEFAULT_PROFILE_TYPE );
+      TEST_ASSERT( zero->getProfileType() == TPETRA_DEFAULT_PROFILE_TYPE );
       zero->fillComplete();
     }
     STD_TESTS((*zero));
@@ -183,11 +183,11 @@ namespace { // (anonymous)
     GO base = numLocal*myImageID;
     RCP<Tpetra::RowMatrix<Scalar,LO,GO,Node> > eye;
     {
-      RCP<MAT> eye_crs = rcp(new MAT(map,numLocal,Tpetra::TPETRA_DEFAULT_PROFILE_TYPE));
+      RCP<MAT> eye_crs = rcp(new MAT(map,numLocal,TPETRA_DEFAULT_PROFILE_TYPE));
       for (size_t i=0; i<numLocal; ++i) {
         eye_crs->insertGlobalValues(base+i,tuple<GO>(base+i),tuple<Scalar>(ST::one()));
       }
-      TEST_ASSERT( eye_crs->getProfileType() == Tpetra::TPETRA_DEFAULT_PROFILE_TYPE );
+      TEST_ASSERT( eye_crs->getProfileType() == TPETRA_DEFAULT_PROFILE_TYPE );
       eye_crs->fillComplete();
       eye = eye_crs;
     }

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests2.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests2.cpp
@@ -257,14 +257,14 @@ inline void tupleToArray(Array<T> &arr, const tuple &tup)
     RCP<const map_type> lclmap = createLocalMapWithNode<LO,GO,Node> (P, comm);
 
     // create the matrix
-    MAT A(rowmap,P,Tpetra::TPETRA_DEFAULT_PROFILE_TYPE);
+    MAT A(rowmap,P,TPETRA_DEFAULT_PROFILE_TYPE);
     for (GO i=0; i<static_cast<GO>(M); ++i) {
       for (GO j=0; j<static_cast<GO>(P); ++j) {
         A.insertGlobalValues( M*myImageID+i, tuple<GO>(j), tuple<Scalar>(M*myImageID+i + j*M*N) );
       }
     }
     // call fillComplete()
-    TEST_EQUALITY_CONST( A.getProfileType() == Tpetra::TPETRA_DEFAULT_PROFILE_TYPE, true );
+    TEST_EQUALITY_CONST( A.getProfileType() == TPETRA_DEFAULT_PROFILE_TYPE, true );
     A.fillComplete(lclmap,rowmap);
     // build the input multivector X
     MV X(lclmap,numVecs);

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests3.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests3.cpp
@@ -422,9 +422,6 @@ inline void tupleToArray(Array<T> &arr, const tuple &tup)
 
     // call fillComplete()
     out << "Call fillComplete on the matrix" << endl;
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-    TEST_EQUALITY_CONST( A.getProfileType() == Tpetra::DynamicProfile, true );
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
     A.fillComplete (lclmap, rowmap);
     A.describe (out, VERB_LOW);
 

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests4.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests4.cpp
@@ -356,7 +356,7 @@ inline void tupleToArray(Array<T> &arr, const tuple &tup)
     RCP<const Map<LO,GO,Node> > map = createContigMapWithNode<LO,GO,Node>(INVALID,1,comm);
     const Scalar SZERO = ScalarTraits<Scalar>::zero();
     {
-      Tpetra::ProfileType pftype = Tpetra::TPETRA_DEFAULT_PROFILE_TYPE;
+      Tpetra::ProfileType pftype = TPETRA_DEFAULT_PROFILE_TYPE;
       MAT matrix(map,map,1,pftype);
       TEST_EQUALITY_CONST( matrix.isFillActive(),   true );
       TEST_EQUALITY_CONST( matrix.isFillComplete(), false );
@@ -392,7 +392,7 @@ inline void tupleToArray(Array<T> &arr, const tuple &tup)
       TEST_THROW( matrix.fillComplete(),        std::runtime_error );
     }
     {
-      Tpetra::ProfileType pftype = Tpetra::TPETRA_DEFAULT_PROFILE_TYPE;
+      Tpetra::ProfileType pftype = TPETRA_DEFAULT_PROFILE_TYPE;
       MAT matrix(map,map,1,pftype);
       TEST_EQUALITY_CONST( matrix.isFillActive(),   true );
       TEST_EQUALITY_CONST( matrix.isFillComplete(), false );
@@ -602,7 +602,7 @@ inline void tupleToArray(Array<T> &arr, const tuple &tup)
     auto map = createContigMapWithNode<LO, GO, Node> (INVALID, 1, comm);
 
     // construct matrix
-    Tpetra::ProfileType pftype = Tpetra::TPETRA_DEFAULT_PROFILE_TYPE;
+    Tpetra::ProfileType pftype = TPETRA_DEFAULT_PROFILE_TYPE;
     CrsMatrix<Scalar,LO,GO,Node> A (map, map, 1, pftype);
     A.insertLocalValues (0, tuple<LO> (0), tuple<Scalar> (STS::zero ()));
     A.fillComplete (map, map);

--- a/packages/tpetra/core/test/CrsMatrix/Regression/Albany182.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/Regression/Albany182.cpp
@@ -1013,11 +1013,11 @@ namespace { // (anonymous)
     for (Tpetra::ProfileType profileType : pftypes) {
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE
       out << ">>> Target matrix is {";
-      if (profileType == Tpetra::DynamicProfile) {
-        out << "DynamicProfile";
+      if (profileType == Tpetra::StaticProfile) {
+        out << "StaticProfile";
       }
       else {
-        out << "StaticProfile";
+        out << "DynamicProfile";
       }
       out << ", locally indexed}" << endl;
 #else

--- a/packages/tpetra/core/test/TpetraUtils_MatrixGenerator.hpp
+++ b/packages/tpetra/core/test/TpetraUtils_MatrixGenerator.hpp
@@ -283,7 +283,7 @@ namespace Tpetra {
 
         // Construct the CrsMatrix, using the row map, with the
         // constructor specifying the number of nonzeros for each row.
-        Tpetra::ProfileType pftype = Tpetra::TPETRA_DEFAULT_PROFILE_TYPE;
+        Tpetra::ProfileType pftype = TPETRA_DEFAULT_PROFILE_TYPE;
         RCP<sparse_matrix_type> A =
           rcp (new sparse_matrix_type (pRowMap, myNumEntriesPerRow (), pftype));
 

--- a/packages/tpetra/core/test/inout/Bug5800.cpp
+++ b/packages/tpetra/core/test/inout/Bug5800.cpp
@@ -181,11 +181,7 @@ namespace {
       // map needs to be a nonconst RCP to const MapType, because
       // readDense would set map to a computed Map on output if if
       // were null on input.
-      return reader_type::readDense (in, map->getComm (),
-#ifdef TPETRA_ENABLE_DEPRECATED_CODE
-                                     map->getNode (),
-#endif // TPETRA_ENABLE_DEPRECATED_CODE
-                                     map);
+      return reader_type::readDense (in, map->getComm (), map);
     }
 
     // Ensure that X and Y have the same dimensions, and that the


### PR DESCRIPTION
@trilinos/tpetra 
#5117 

This PR reduces the number of uses of the enum value DynamicProfile in Tpetra source code.  It will reduce the number of warnings issued by Tpetra during compilation.  

Note that not all deprecation warnings in Tpetra and the rest of the software stack can be eliminated.  With explicit instantiation and deprecated code enabled, deprecated code gets compiled and warnings get issued, even if the code is not called anywhere.  Also, because DynamicProfile deprecation changes both a default behavior and a keyword, it is difficult to remove warnings due to the default behavior change.  Finally, since DynamicProfile is currently the Tpetra default, we need to retain its use in testing; tests exercising DynamicProfile should not be removed just to silence warnings.


## How Has This Been Tested?
ATDM scripts on linux workstation
```
source ../cmake/std/atdm/load-env.sh  gnu-7.2.0-openmp-release-debug
MPI_EXEC=`which mpiexec`


cmake \
  -GNinja \
  -DMPI_EXEC=${MPI_EXEC} \
  -DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/atdm/ATDMDevEnv.cmake \
  -DTrilinos_ENABLE_TESTS=ON -DTrilinos_ENABLE_Teuchos=ON \
  -DTrilinos_ENABLE_Tpetra=ON \
  -DTrilinos_ENABLE_Belos=ON \
  -DTrilinos_ENABLE_Tempus=ON \
.. |& tee OUTPUT.CMAKE
```


