### PR TITLE
Disable one Zoltan2 and one Piro test for Tpetra_INST_INT_INT=OFF for ATDM builds (#5411, #5412)

### DIFF
--- a/cmake/std/atdm/ATDMDevEnvSettings.cmake
+++ b/cmake/std/atdm/ATDMDevEnvSettings.cmake
@@ -433,6 +433,11 @@ IF (ATDM_USE_CUDA AND ATDM_COMPLEX)
   ATDM_SET_ENABLE(Trilinos_ENABLE_MueLu OFF)
 ENDIF()
 
+# Disable Piro_ThyraSolver exec that does not build with no global int
+# instantiation (see #5412)
+ATDM_SET_ENABLE(Piro_ThyraSolver_EXE_DISABLE ON)
+ATDM_SET_ENABLE(Piro_ThyraSolver_MPI_4_DISABLE ON)
+
 #
 # H) ATDM env config install hooks
 #

--- a/cmake/std/atdm/ATDMDevEnvSettings.cmake
+++ b/cmake/std/atdm/ATDMDevEnvSettings.cmake
@@ -433,6 +433,11 @@ IF (ATDM_USE_CUDA AND ATDM_COMPLEX)
   ATDM_SET_ENABLE(Trilinos_ENABLE_MueLu OFF)
 ENDIF()
 
+# Disable Zoltan2_XpetraEpertraMatrix exec that does not build with no global
+# int instatiation (see #5411)
+ATDM_SET_ENABLE(Zoltan2_XpetraEpetraMatrix_EXE_DISABLE ON)
+ATDM_SET_ENABLE(Zoltan2_XpetraEpetraMatrix_MPI_4_DISABLE ON)
+
 # Disable Piro_ThyraSolver exec that does not build with no global int
 # instantiation (see #5412)
 ATDM_SET_ENABLE(Piro_ThyraSolver_EXE_DISABLE ON)

--- a/packages/piro/test/CMakeLists.txt
+++ b/packages/piro/test/CMakeLists.txt
@@ -78,6 +78,7 @@ IF (Piro_ENABLE_NOX)
     NUM_MPI_PROCS 1-4
     ARGS -v
     PASS_REGULAR_EXPRESSION "TEST PASSED"
+    ADDED_EXE_TARGET_NAME_OUT ThyraSolver_NAME
   )
 
   TRIBITS_ADD_EXECUTABLE_AND_TEST(
@@ -144,6 +145,12 @@ IF (Piro_ENABLE_NOX)
     STANDARD_PASS_OUTPUT
   )
 
+  IF (ThyraSolver_NAME)
+   SET(ThyraSolver_EXENAME ThyraSolver)
+  ELSE()
+   SET(ThyraSolver_EXENAME)
+  ENDIF()
+
   IF (AnalysisDriverTpetra_NAME)
    SET(AnalysisDriverTpetra_EXENAME AnalysisDriverTpetra)
   ELSE()
@@ -176,7 +183,7 @@ IF (Piro_ENABLE_NOX)
 	  input_SGAnalysis.xml dakota_sg.in dakota_sg_target.txt
     SOURCE_DIR   ${PACKAGE_SOURCE_DIR}/test
     SOURCE_PREFIX "_"
-    EXEDEPS ThyraSolver AnalysisDriver ${AnalysisDriverTpetra_EXENAME} UnitTests NOXSolver_UnitTests
+    EXEDEPS ${ThyraSolver_EXENAME} AnalysisDriver ${AnalysisDriverTpetra_EXENAME} UnitTests NOXSolver_UnitTests
   )
 
 ENDIF()


### PR DESCRIPTION
CC: @rppawlo, @trilinos/zoltan2 

This PR contains commits to disable the building and running of the test exectuables: 

* #5411: Zoltan2_XpetraEpertraMatrix: Commit e1cc0def95c7858a80b794d4777859fc313f2358
* #5412: Piro_ThyraSolver: Commit d1277996e6a8748113c2ab6ab33b9503cbb9edfb

This avoids the build errors in the new build `Trilinos-atdm-sems-rhel6-gnu-7.2.0-openmp-release-debug-no-global-int` where the settings in the build will be used for all the ATDM Trilinos builds.

In fact, since Tpetra is deprecating instantiating multiple global ordinal types, all Trilinos builds will need to go need to do this in the future.
