### PR TITLE
Ifpack2:  revisions to support static profile 

### DIFF
--- a/packages/ifpack2/src/Ifpack2_ILUT_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_ILUT_def.hpp
@@ -464,8 +464,6 @@ void ILUT<MatrixType>::compute ()
     const scalar_type one  = STS::one ();
 
     const local_ordinal_type myNumRows = A_local_->getNodeNumRows ();
-    L_ = rcp (new crs_matrix_type (A_local_->getRowMap (), A_local_->getColMap (), 0));
-    U_ = rcp (new crs_matrix_type (A_local_->getRowMap (), A_local_->getColMap (), 0));
 
     // If this macro is defined, files containing the L and U factors
     // will be written. DON'T CHECK IN THE CODE WITH THIS MACRO ENABLED!!!
@@ -736,26 +734,26 @@ void ILUT<MatrixType>::compute ()
     }
 
     L_ = rcp (new crs_matrix_type (A_local_->getRowMap(), A_local_->getColMap(),
-                                   nnzPerRow()), Tpetra::StaticProfile);
+                                   nnzPerRow(), Tpetra::StaticProfile));
 
     for (local_ordinal_type row_i = 0 ; row_i < myNumRows ; ++row_i) {
       L_->insertLocalValues (row_i, L_tmp_idx[row_i](), L_tmpv[row_i]());
     }
 
-    L_->fillComplete(); // FIXME (mfh 03 Apr 2013) Do we need domain and range Map?
+    L_->fillComplete(); 
 
     for (local_ordinal_type row_i = 0 ; row_i < myNumRows ; ++row_i) {
       nnzPerRow[row_i] = U_tmp_idx[row_i].size();
     }
 
-    U_ = rcp (new crs_matrix_type (A_local_->getRowMap(), A_local_->getColMap(), 
-                                   nnzPerRow()), Tpetra::StaticProfile);
+    U_ = rcp (new crs_matrix_type (A_local_->getRowMap(), A_local_->getColMap(),
+                                   nnzPerRow(), Tpetra::StaticProfile));
 
     for (local_ordinal_type row_i = 0 ; row_i < myNumRows ; ++row_i) {
       U_->insertLocalValues (row_i, U_tmp_idx[row_i](), U_tmpv[row_i]());
     }
 
-    U_->fillComplete(); // FIXME (mfh 03 Apr 2013) Do we need domain and range Map?
+    U_->fillComplete();
 
     L_solver_->setMatrix(L_);
     L_solver_->initialize ();

--- a/packages/ifpack2/src/Ifpack2_SparseContainer_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_SparseContainer_decl.hpp
@@ -289,6 +289,27 @@ private:
   //! Copy constructor: Declared but not implemented, to forbid copy construction.
   SparseContainer (const SparseContainer<MatrixType,InverseType>& rhs);
 
+  /// \brief For a row of a block, identify entries to be inserted to diagBlocks_
+  //  Pulled into a separate function to allow separate counting and identification
+  ///  \param blockIndex,         [in]  block being processed
+  ///  \param rowIndex,           [in]  row being processed in this block
+  ///  \param localRows,          [in]  rows of the block
+  ///  \param Indices,            [in]  Storage for row indices of inputMatrix
+  ///  \param Values,             [in]  Storage for row values of inputMatrix
+  ///  \param Indices_insert,     [out] Indices to be inserted for this row
+  ///  \param Values_insert,      [out] Value associated with the index
+  ///  \param num_entries_found   [out] number of Indices to be inserted
+  void findRowIndicesAndCounts(
+    int blockIndex,
+    local_ordinal_type rowIndex,
+    const Teuchos::ArrayView<const local_ordinal_type> &localRows,
+    Teuchos::Array<local_ordinal_type> &Indices,
+    Teuchos::Array<scalar_type> &Values,
+    Teuchos::Array<InverseGlobalOrdinal> &Indices_insert,
+    Teuchos::Array<InverseScalar> &Values_insert,
+    size_t &num_entries_found
+  ) const;
+
   //! Extract the submatrices identified by the local indices set by the constructor.
   void extract ();
 

--- a/packages/ifpack2/src/Ifpack2_SparseContainer_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_SparseContainer_decl.hpp
@@ -303,8 +303,8 @@ private:
     int blockIndex,
     local_ordinal_type rowIndex,
     const Teuchos::ArrayView<const local_ordinal_type> &localRows,
-    Teuchos::Array<local_ordinal_type> &Indices,
-    Teuchos::Array<scalar_type> &Values,
+    const Teuchos::ArrayView<local_ordinal_type> &Indices,
+    const Teuchos::ArrayView<scalar_type> &Values,
     Teuchos::Array<InverseGlobalOrdinal> &Indices_insert,
     Teuchos::Array<InverseScalar> &Values_insert,
     size_t &num_entries_found

--- a/packages/ifpack2/src/Ifpack2_SparseContainer_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_SparseContainer_def.hpp
@@ -130,9 +130,10 @@ void SparseContainer<MatrixType,InverseType>::findRowIndicesAndCounts(
   int blockIndex,                        // block being processed
   local_ordinal_type rowIndex,           // row being processed in this block
   const Teuchos::ArrayView<const local_ordinal_type> &localRows,  
-  Teuchos::Array<local_ordinal_type> &Indices,  // Storage for row indices 
+  const Teuchos::ArrayView<local_ordinal_type> &Indices,
+                                                // Storage for row indices 
                                                 // of inputMatrix
-  Teuchos::Array<scalar_type> &Values,          // Storage for row values 
+  const Teuchos::ArrayView<scalar_type> &Values,// Storage for row values 
                                                 // of inputMatrix
   Teuchos::Array<InverseGlobalOrdinal> &Indices_insert,  // Output: Indices to 
                                                          // be inserted for
@@ -206,14 +207,10 @@ void SparseContainer<MatrixType,InverseType>::initialize ()
   Inverses_.reserve(this->numBlocks_);
 
   const size_t maxNumEntriesInRow = this->inputMatrix_->getNodeMaxNumRowEntries();
-  Teuchos::Array<scalar_type> Values;
-  Teuchos::Array<local_ordinal_type> Indices;
-  Teuchos::Array<InverseScalar> Values_insert;
-  Teuchos::Array<InverseGlobalOrdinal> Indices_insert;
-  Values.resize (maxNumEntriesInRow);
-  Indices.resize (maxNumEntriesInRow);
-  Values_insert.resize (maxNumEntriesInRow);
-  Indices_insert.resize (maxNumEntriesInRow);
+  Teuchos::Array<scalar_type> Values(maxNumEntriesInRow);
+  Teuchos::Array<local_ordinal_type> Indices(maxNumEntriesInRow);
+  Teuchos::Array<InverseScalar> Values_insert(maxNumEntriesInRow);
+  Teuchos::Array<InverseGlobalOrdinal> Indices_insert(maxNumEntriesInRow);
 
   for(int i = 0; i < this->numBlocks_; i++)
   {
@@ -231,7 +228,7 @@ void SparseContainer<MatrixType,InverseType>::initialize ()
     for (local_ordinal_type j = 0; j < numRows_; j++)
     {
       size_t num_entries_found;
-      findRowIndicesAndCounts(i, j, localRows, Indices, Values,
+      findRowIndicesAndCounts(i, j, localRows, Indices(), Values(),
                               Indices_insert, Values_insert, num_entries_found);
       nEntriesPerRow[j] = num_entries_found;
     }
@@ -654,15 +651,10 @@ extract ()
   }
 
   const size_t maxNumEntriesInRow = A.getNodeMaxNumRowEntries();
-  Array<scalar_type> Values;
-  Array<local_ordinal_type> Indices;
-  Array<InverseScalar> Values_insert;
-  Array<InverseGlobalOrdinal> Indices_insert;
-
-  Values.resize (maxNumEntriesInRow);
-  Indices.resize (maxNumEntriesInRow);
-  Values_insert.resize (maxNumEntriesInRow);
-  Indices_insert.resize (maxNumEntriesInRow);
+  Array<scalar_type> Values(maxNumEntriesInRow);
+  Array<local_ordinal_type> Indices(maxNumEntriesInRow);
+  Array<InverseScalar> Values_insert(maxNumEntriesInRow);
+  Array<InverseGlobalOrdinal> Indices_insert(maxNumEntriesInRow);
 
   for(local_ordinal_type i = 0; i < this->numBlocks_; i++)
   {
@@ -671,7 +663,7 @@ extract ()
     for (local_ordinal_type j = 0; j < numRows_; j++)
     {
       size_t num_entries_found;
-      findRowIndicesAndCounts(i, j, localRows, Indices, Values, 
+      findRowIndicesAndCounts(i, j, localRows, Indices(), Values(), 
                               Indices_insert, Values_insert, num_entries_found);
       diagBlocks_[i]->insertGlobalValues(j, Indices_insert (0, num_entries_found),
                                             Values_insert (0, num_entries_found));

--- a/packages/ifpack2/src/Ifpack2_SparseContainer_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_SparseContainer_def.hpp
@@ -179,8 +179,9 @@ void SparseContainer<MatrixType,InverseType>::findRowIndicesAndCounts(
 
     if (jj != INVALID)
     {
-      Indices[num_entries_found] = localMaps_[blockIndex].getGlobalElement(jj);
-      Values[num_entries_found] = Values[k];
+      Indices_insert[num_entries_found] = 
+                     localMaps_[blockIndex].getGlobalElement(jj);
+      Values_insert[num_entries_found] = Values[k];
       num_entries_found++;
     }
   }

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestBlockRelaxation.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestBlockRelaxation.cpp
@@ -92,6 +92,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2BlockRelaxation, Test0, Scalar, LocalOr
   const Teuchos::RCP<const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> > rowmap =
     tif_utest::create_tpetra_map<LocalOrdinal,GlobalOrdinal,Node>(num_rows_per_proc);
   Teuchos::RCP<const CRS> crsmatrix = tif_utest::create_test_matrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>(rowmap);
+
   Ifpack2::BlockRelaxation<ROW> prec(crsmatrix);
 
   Teuchos::ParameterList params;

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestDenseSolver.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestDenseSolver.cpp
@@ -121,7 +121,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(DenseSolver, LapackComparison, ScalarType, Loc
 
   // The matrix will be block diagonal, so we can use the row Map as
   // the column Map.
-  RCP<crs_matrix_type> A (new crs_matrix_type (rowMap, colMap, (size_t) 0));
+  RCP<crs_matrix_type> A (new crs_matrix_type (rowMap, colMap, (size_t) 3));
 
   Array<scalar_type> val (3);
   Array<local_ordinal_type> ind (3);

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestDenseSolver.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestDenseSolver.cpp
@@ -121,7 +121,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(DenseSolver, LapackComparison, ScalarType, Loc
 
   // The matrix will be block diagonal, so we can use the row Map as
   // the column Map.
-  RCP<crs_matrix_type> A (new crs_matrix_type (rowMap, colMap, (size_t) 3));
+  RCP<crs_matrix_type> A (new crs_matrix_type (rowMap, colMap, 3));
 
   Array<scalar_type> val (3);
   Array<local_ordinal_type> ind (3);

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestHelpers.hpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestHelpers.hpp
@@ -100,7 +100,7 @@ create_tridiag_graph (const LocalOrdinal num_rows_per_proc)
     rcp (new map_type (INVALID, num_rows_per_proc, indexBase, comm));
 
   RCP<Tpetra::CrsGraph<LocalOrdinal,GlobalOrdinal,Node> > crsgraph =
-    rcp (new Tpetra::CrsGraph<LocalOrdinal,GlobalOrdinal,Node> (rowmap, 0));
+    rcp (new Tpetra::CrsGraph<LocalOrdinal,GlobalOrdinal,Node> (rowmap, 3));
 
   Teuchos::Array<GlobalOrdinal> cols;
   const LocalOrdinal lclNumRows =

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestHelpers.hpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestHelpers.hpp
@@ -100,7 +100,7 @@ create_tridiag_graph (const LocalOrdinal num_rows_per_proc)
     rcp (new map_type (INVALID, num_rows_per_proc, indexBase, comm));
 
   RCP<Tpetra::CrsGraph<LocalOrdinal,GlobalOrdinal,Node> > crsgraph =
-    rcp (new Tpetra::CrsGraph<LocalOrdinal,GlobalOrdinal,Node> (rowmap, 3));
+    rcp (new Tpetra::CrsGraph<LocalOrdinal,GlobalOrdinal,Node> (rowmap, 3, Tpetra::StaticProfile));
 
   Teuchos::Array<GlobalOrdinal> cols;
   const LocalOrdinal lclNumRows =
@@ -142,9 +142,9 @@ create_test_graph (const LocalOrdinal num_rows_per_proc)
 
   Teuchos::RCP<const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> > rowmap = Teuchos::rcp(new Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node>(INVALID, num_rows_per_proc, indexBase, comm));
 
-  Teuchos::RCP<Tpetra::CrsGraph<LocalOrdinal,GlobalOrdinal,Node> > crsgraph = Teuchos::rcp(new Tpetra::CrsGraph<LocalOrdinal,GlobalOrdinal,Node>(rowmap, 0));
-
   size_t global_size = rowmap->getGlobalNumElements();
+  Teuchos::RCP<Tpetra::CrsGraph<LocalOrdinal,GlobalOrdinal,Node> > crsgraph = Teuchos::rcp(new Tpetra::CrsGraph<LocalOrdinal,GlobalOrdinal,Node>(rowmap, global_size, Tpetra::StaticProfile));
+
   Teuchos::Array<GlobalOrdinal> cols;
   for(LocalOrdinal l_row = 0; (size_t) l_row<rowmap->getNodeNumElements(); l_row++) {
     GlobalOrdinal g_row = rowmap->getGlobalElement(l_row);
@@ -278,7 +278,7 @@ Teuchos::RCP<Tpetra::CrsGraph<LocalOrdinal,GlobalOrdinal,Node> > create_dense_lo
 template<class Scalar,class LocalOrdinal,class GlobalOrdinal,class Node>
 Teuchos::RCP<const Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > create_test_matrix(const Teuchos::RCP<const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> >& rowmap, Scalar val=Teuchos::ScalarTraits<Scalar>::zero())
 {
-  Teuchos::RCP<Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > crsmatrix = Teuchos::rcp(new Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>(rowmap, 3/*tri-diagonal matrix*/));
+  Teuchos::RCP<Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > crsmatrix = Teuchos::rcp(new Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>(rowmap, 3/*tri-diagonal matrix*/, Tpetra::StaticProfile));
 
   Teuchos::Array<GlobalOrdinal> col(3);
   Teuchos::Array<Scalar> coef(3);
@@ -327,7 +327,7 @@ Teuchos::RCP<const Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > c
 template<class Scalar,class LocalOrdinal,class GlobalOrdinal,class Node>
 Teuchos::RCP<const Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > create_test_matrix2(const Teuchos::RCP<const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> >& rowmap)
 {
-  Teuchos::RCP<Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > crsmatrix = Teuchos::rcp(new Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>(rowmap, 3/*tri-diagonal matrix*/));
+  Teuchos::RCP<Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > crsmatrix = Teuchos::rcp(new Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>(rowmap, 3/*tri-diagonal matrix*/, Tpetra::StaticProfile));
 
   Teuchos::Array<GlobalOrdinal> col(1);
   Teuchos::Array<Scalar> coef(1);
@@ -382,7 +382,7 @@ Teuchos::RCP<const Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > c
 template<class Scalar,class LocalOrdinal,class GlobalOrdinal,class Node>
 Teuchos::RCP<const Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > create_test_matrix3(const Teuchos::RCP<const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> >& rowmap)
 {
-  Teuchos::RCP<Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > crsmatrix = Teuchos::rcp(new Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>(rowmap, 3/*tri-diagonal matrix*/));
+  Teuchos::RCP<Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > crsmatrix = Teuchos::rcp(new Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>(rowmap, 3/*tri-diagonal matrix*/, Tpetra::StaticProfile));
 
   /*
      NOTE:  this utility creates a matrix whose column map is equal to its row map.  At processor boundaries,
@@ -444,7 +444,7 @@ Teuchos::RCP<const Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > c
 template<class Scalar,class LocalOrdinal,class GlobalOrdinal,class Node>
 Teuchos::RCP<const Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > create_banded_matrix(const Teuchos::RCP<const Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node> >& rowmap, const GlobalOrdinal bw)
 {
-  Teuchos::RCP<Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > crsmatrix = Teuchos::rcp(new Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>(rowmap, 5));
+  Teuchos::RCP<Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > crsmatrix = Teuchos::rcp(new Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>(rowmap, 5, Tpetra::StaticProfile));
 
   Teuchos::Array<GlobalOrdinal> col(1);
   Teuchos::Array<Scalar> coef(1);
@@ -716,7 +716,7 @@ Teuchos::RCP<const Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > c
   //
   // Beyond this the matrix is diagonal.  We also explicitly stick in some hard zeros for the line partitioning test
 
-  Teuchos::RCP<Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > crsmatrix = Teuchos::rcp(new Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>(rowmap, 0));
+  Teuchos::RCP<Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > crsmatrix = Teuchos::rcp(new Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>(rowmap, 4, Tpetra::StaticProfile));
 
   Teuchos::Array<GlobalOrdinal> indices(4);
   Teuchos::Array<Scalar> values(4);
@@ -772,7 +772,7 @@ Teuchos::RCP<const Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > c
   //
   // Beyond this the matrix is diagonal.
 
-  Teuchos::RCP<Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > crsmatrix = Teuchos::rcp(new Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>(rowmap, 0));
+  Teuchos::RCP<Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > crsmatrix = Teuchos::rcp(new Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>(rowmap, 5, Tpetra::StaticProfile));
 
   Teuchos::Array<GlobalOrdinal> indices(5);
   Teuchos::Array<Scalar> values(5);
@@ -828,7 +828,7 @@ Teuchos::RCP<const Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > c
   //
   // Beyond this the matrix is diagonal.  We also explicitly stick in some hard zeros for the line partitioning test
 
-  Teuchos::RCP<Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > crsmatrix = Teuchos::rcp(new Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>(rowmap, 0));
+  Teuchos::RCP<Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > crsmatrix = Teuchos::rcp(new Tpetra::CrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>(rowmap, 5, Tpetra::StaticProfile));
 
   Teuchos::Array<GlobalOrdinal> indices(5);
   Teuchos::Array<Scalar> values(5);

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestRILUK.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestRILUK.cpp
@@ -99,7 +99,7 @@ static Teuchos::RCP<Ifpack2::RILUK<Tpetra::RowMatrix<Scalar,LocalOrdinal,GlobalO
   //Construct a nondiagonal matrix.  It's not tridiagonal because of processor boundaries.
   const Scalar one = Teuchos::ScalarTraits<Scalar>::one();
   const Scalar two = one + one;
-  RCP<crs_matrix_type > A = Teuchos::rcp(new crs_matrix_type(map, 1));
+  RCP<crs_matrix_type > A = Teuchos::rcp(new crs_matrix_type(map, 3));
   Teuchos::Array<GlobalOrdinal> col(3);
   Teuchos::Array<Scalar>        val(3);
   size_t numLocalElts = map->getNodeNumElements();

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestTriDiSolver.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestTriDiSolver.cpp
@@ -125,7 +125,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(TriDiSolver, LapackComparison, ScalarType, Loc
 
   // The matrix will be block diagonal, so we can use the row Map as
   // the column Map.
-  RCP<crs_matrix_type> A = rcp(new crs_matrix_type (rowMap, colMap, (size_t) 0));
+  RCP<crs_matrix_type> A = rcp(new crs_matrix_type (rowMap, colMap, (size_t) 3));
 
   Array<scalar_type> val (3);
   Array<local_ordinal_type> ind (3);

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestTriDiSolver.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestTriDiSolver.cpp
@@ -125,7 +125,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(TriDiSolver, LapackComparison, ScalarType, Loc
 
   // The matrix will be block diagonal, so we can use the row Map as
   // the column Map.
-  RCP<crs_matrix_type> A = rcp(new crs_matrix_type (rowMap, colMap, (size_t) 3));
+  RCP<crs_matrix_type> A = rcp(new crs_matrix_type (rowMap, colMap, 3));
 
   Array<scalar_type> val (3);
   Array<local_ordinal_type> ind (3);


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/ifpack2 

## Description
Tpetra is deprecating DynamicProfile.  These changes allow Ifpack2 to work with StaticProfile.
The changes update Containers and ILUT.  ILUK is not yet done and is not included in this pull request.

This code discovers the nonzeros needed in ILUT as before, but rather than insert them immediately, it stores them in Teuchos Arrays.  Once all nonzeros are discovered, it creates L and U with StaticProfile and the number of entries per row.  Then it inserts the nonzeros.

These changes also update several tests and test helpers in the Ifpack2 test directory.

#5065 


## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->

ATDM Script:  All Ifpack2 tests pass with Tpetra_ENABLE_DEPRECATED_CODE=ON
```
source ../cmake/std/atdm/load-env.sh  gnu-7.2.0-openmp-release-debug
MPI_EXEC=`which mpiexec`
cmake \
  -GNinja \
  -DMPI_EXEC=${MPI_EXEC} \
  -DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/atdm/ATDMDevEnv.cmake \
  -DTrilinos_ENABLE_TESTS=ON  \
  -DTrilinos_ENABLE_Ifpack2=ON \
.. |& tee OUTPUT.CMAKE
```

Not all tests pass yet with Tpetra_ENABLE_DEPRECATED_CODE=OFF, but more pass than before.


<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [ ] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
