### PR TITLE
zoltan:  add capability to write GIDs to files created by Zoltan_Gene…

### DIFF
--- a/packages/zoltan/src/zz/zz_gen_files.c
+++ b/packages/zoltan/src/zz/zz_gen_files.c
@@ -326,6 +326,25 @@ int gen_geom, int gen_graph, int gen_hg)
   fflush(fp);
   fclose(fp);
 
+  sprintf(full_fname, "%s.gids", fname);
+  if (zz->Proc == 0)
+    fp = fopen(full_fname, "w");
+  else
+    fp = fopen(full_fname, "a");
+  if (fp==NULL) {
+    ZOLTAN_PRINT_ERROR(zz->Proc, yo, "Could not open file for writing.\n");
+    error = ZOLTAN_FATAL;
+    goto End;
+  }
+  for (i=0; i<num_obj; i++) {
+    int j;
+    for (j = 0; j < lenGID; j++)
+      fprintf(fp, ZOLTAN_ID_SPEC" ", global_ids[i*lenGID+j]);
+    fprintf(fp, "\n");
+  }
+  fflush(fp);
+  fclose(fp);
+
   /* Write geometry to file, if applicable. */
   if (gen_geom){
     sprintf(full_fname, "%s.coords", fname);


### PR DESCRIPTION
Adding capability for Zoltan_Generate_Files to output global IDs along with coordinates, graph edges, etc.  This capability is needed by MOAB to benchmark performance using two-weight partitions generated from Zoltan.
@trilinos/zoltan 

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->

<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [ x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
