### PR TITLE
Tpetra: Fix build for buffer_memory_space = CudaHostPinnedSpace (but don't change it)

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_DefaultTypes.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DefaultTypes.hpp
@@ -61,48 +61,47 @@ namespace Details {
 namespace DefaultTypes {
   //! Default value of Scalar template parameter.
 #if defined(HAVE_TPETRA_INST_DOUBLE)
-  typedef double scalar_type;
+  using scalar_type = double;
 #elif defined(HAVE_TPETRA_INST_FLOAT)
-  typedef float scalar_type;
+  using scalar_type = float;
 #else
 #  error "Tpetra: No scalar types in the set {float, double} have been enabled."
 #endif
 
   //! Default value of LocalOrdinal template parameter.
-  typedef int local_ordinal_type;
+  using local_ordinal_type = int;
 
   /// \typedef global_ordinal_type
   /// \brief Default value of GlobalOrdinal template parameter.
 #if defined(TPETRA_ENABLE_DEPRECATED_CODE)
     #if defined(HAVE_TPETRA_INST_INT_INT)
-        typedef int global_ordinal_type;
+      using global_ordinal_type = int;
     #elif defined(HAVE_TPETRA_INST_INT_LONG_LONG)
-      typedef long long global_ordinal_type;
+      using global_ordinal_type = long long;
     #elif defined(HAVE_TPETRA_INST_INT_LONG)
-      typedef long global_ordinal_type;
+      using global_ordinal_type = long;
     #elif defined(HAVE_TPETRA_INST_INT_UNSIGNED_LONG)
-      typedef unsigned long global_ordinal_type;
+      using global_ordinal_type = unsigned long;
     #elif defined(HAVE_TPETRA_INST_INT_UNSIGNED)
-      typedef unsigned global_ordinal_type;
+      using global_ordinal_type = unsigned;
     #else
         #error "Tpetra: No global ordinal types in the set {int, long long, long, unsigned long, unsigned} have been enabled."
     #endif
 #else  // TPETRA_ENABLE_DEPRECATED_CODE IS NOT DEFINED
     #if defined(HAVE_TPETRA_INST_INT_LONG_LONG)
-        typedef long long global_ordinal_type;
+        using global_ordinal_type = long long;
     #elif defined(HAVE_TPETRA_INST_INT_INT)
-        typedef int global_ordinal_type;
+        using global_ordinal_type = int;
     #elif defined(HAVE_TPETRA_INST_INT_LONG)
-        typedef long global_ordinal_type;
+        using global_ordinal_type = long;
     #elif defined(HAVE_TPETRA_INST_INT_UNSIGNED_LONG)
-        typedef unsigned long global_ordinal_type;
+        using global_ordinal_type = unsigned long;
     #elif defined(HAVE_TPETRA_INST_INT_UNSIGNED)
-        typedef unsigned global_ordinal_type;
+        using global_ordinal_type = unsigned;
     #else
         #error "Tpetra: No global ordinal types in the set {int, long long, long, unsigned long, unsigned} have been enabled."
     #endif
 #endif
-
 
   /// \typedef execution_space
   /// \brief Default Tpetra execution space.
@@ -120,6 +119,21 @@ namespace DefaultTypes {
 
   //! Default value of Node template parameter.
   using node_type = ::Kokkos::Compat::KokkosDeviceWrapperNode<execution_space>;
+
+  /// \brief Memory space used for MPI communication buffers.
+  ///
+  /// See #1088 for why this is not just ExecutionSpace::memory_space.
+  template<class ExecutionSpace>
+  using comm_buffer_memory_space =
+#ifdef KOKKOS_ENABLE_CUDA
+    typename std::conditional<
+      std::is_same<typename ExecutionSpace::execution_space, Kokkos::Cuda>::value,
+      Kokkos::CudaHostPinnedSpace,
+      typename ExecutionSpace::memory_space>::type;
+#else
+    typename ExecutionSpace::memory_space;
+#endif // KOKKOS_ENABLE_CUDA
+
 } // namespace DefaultTypes
 
 } // namespace Details

--- a/packages/tpetra/core/src/Tpetra_Details_DefaultTypes.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DefaultTypes.hpp
@@ -128,7 +128,7 @@ namespace DefaultTypes {
 #ifdef KOKKOS_ENABLE_CUDA
     typename std::conditional<
       std::is_same<typename ExecutionSpace::execution_space, Kokkos::Cuda>::value,
-      Kokkos::CudaHostPinnedSpace,
+      Kokkos::CudaSpace,
       typename ExecutionSpace::memory_space>::type;
 #else
     typename ExecutionSpace::memory_space;

--- a/packages/tpetra/core/src/Tpetra_Details_Transfer_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Transfer_decl.hpp
@@ -77,9 +77,9 @@ private:
 
   // See #1088 for why this is not just device_type::memory_space.
 #ifdef KOKKOS_ENABLE_CUDA
-  static constexpr bool is_cuda =
-    std::is_same<execution_space, Kokkos::Cuda>::value;
-  using memory_space = typename std::conditional<is_cuda, Kokkos::CudaSpace,
+  using memory_space = typename std::conditional<
+    std::is_same<execution_space, Kokkos::Cuda>::value,
+    Kokkos::CudaHostPinnedSpace,
     typename NT::device_type::memory_space>::type;
 #else
   using memory_space = typename NT::device_type::memory_space;

--- a/packages/tpetra/core/src/Tpetra_Details_Transfer_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Transfer_decl.hpp
@@ -74,16 +74,8 @@ public:
 
 private:
   using execution_space = typename NT::device_type::execution_space;
-
-  // See #1088 for why this is not just device_type::memory_space.
-#ifdef KOKKOS_ENABLE_CUDA
-  using memory_space = typename std::conditional<
-    std::is_same<execution_space, Kokkos::Cuda>::value,
-    Kokkos::CudaHostPinnedSpace,
-    typename NT::device_type::memory_space>::type;
-#else
-  using memory_space = typename NT::device_type::memory_space;
-#endif // KOKKOS_ENABLE_CUDA
+  using memory_space =
+    ::Tpetra::Details::DefaultTypes::comm_buffer_memory_space<execution_space>;
   using device_type = Kokkos::Device<execution_space, memory_space>;
 
 public:

--- a/packages/tpetra/core/src/Tpetra_Details_crsUtils.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_crsUtils.hpp
@@ -71,8 +71,8 @@ uninitialized_view(const std::string& name, const size_t& size)
 template<class RowPtr, class Indices, class Values, class Padding>
 void
 pad_crs_arrays(
-    RowPtr& row_ptr_beg,
-    RowPtr& row_ptr_end,
+               const RowPtr& row_ptr_beg,
+               const RowPtr& row_ptr_end,
     Indices& indices,
     Values& values,
     const Padding& padding)
@@ -296,8 +296,8 @@ find_crs_indices(
 template<class RowPtr, class Indices, class Padding>
 void
 padCrsArrays(
-    RowPtr& rowPtrBeg,
-    RowPtr& rowPtrEnd,
+             const RowPtr& rowPtrBeg,
+             const RowPtr& rowPtrEnd,
     Indices& indices,
     const Padding& padding)
 {
@@ -310,8 +310,8 @@ padCrsArrays(
 template<class RowPtr, class Indices, class Values, class Padding>
 void
 padCrsArrays(
-    RowPtr& rowPtrBeg,
-    RowPtr& rowPtrEnd,
+             const RowPtr& rowPtrBeg,
+             const RowPtr& rowPtrEnd,
     Indices& indices,
     Values& values,
     const Padding& padding)

--- a/packages/tpetra/core/src/Tpetra_Details_packCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_packCrsMatrix_def.hpp
@@ -918,9 +918,8 @@ packCrsMatrix (const CrsMatrix<ST, LO, GO, NT>& sourceMatrix,
 
   // This is an output array, so we don't have to copy to device here.
   // However, we'll have to remember to copy back to host when done.
-  typename local_matrix_type::device_type outputDevice;
-  auto num_packets_per_lid_d =
-    create_mirror_view_from_raw_host_array (outputDevice,
+  Kokkos::View<size_t*, buffer_device_type> num_packets_per_lid_d =
+    create_mirror_view_from_raw_host_array (buffer_device_type (),
                                             numPacketsPerLID.getRawPtr (),
                                             numPacketsPerLID.size (), false,
                                             "num_packets_per_lid");
@@ -930,19 +929,14 @@ packCrsMatrix (const CrsMatrix<ST, LO, GO, NT>& sourceMatrix,
   //
   // This is an input array, so we have to copy to device here.
   // However, we never need to copy it back to host.
-  auto export_lids_d =
+  Kokkos::View<const LO*, buffer_device_type> export_lids_d =
     create_mirror_view_from_raw_host_array (buffer_device_type (),
                                             exportLIDs.getRawPtr (),
                                             exportLIDs.size (), true,
                                             "export_lids");
-  static_assert (std::is_same<typename decltype (export_lids_d)::device_type,
-                   buffer_device_type>::value,
-                 "export_lids_d has the wrong device_type.");
 
-  // Create an empty array of PIDs
-  Kokkos::View<int*, device_type> export_pids_d ("export_pids", 0);
-
-  Kokkos::DualView<char*, buffer_device_type> exports_dv ("exports", 0);
+  Kokkos::View<int*, device_type> export_pids_d; // output arg
+  Kokkos::DualView<char*, buffer_device_type> exports_dv; // output arg
   constexpr bool pack_pids = false;
   PackCrsMatrixImpl::packCrsMatrix<ST, LO, GO, NT, buffer_device_type> (
       sourceMatrix, exports_dv, num_packets_per_lid_d, export_lids_d,

--- a/packages/tpetra/core/src/Tpetra_Details_unpackCrsGraphAndCombine_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_unpackCrsGraphAndCombine_def.hpp
@@ -101,11 +101,11 @@ namespace UnpackAndCombineCrsGraphImpl {
 /// \tparam BufferDevice The "buffer device type."
 template<class Packet, class GO, class Device, class BufferDevice>
 KOKKOS_FUNCTION int
-unpackRow(typename Kokkos::View<GO*,Device,Kokkos::MemoryUnmanaged>& gids_out,
-          typename Kokkos::View<int*,Device,Kokkos::MemoryUnmanaged>& pids_out,
-          const Kokkos::View<const Packet*,BufferDevice>& imports,
-          const size_t offset,
-          const size_t num_ent)
+unpackRow (const Kokkos::View<GO*,Device,Kokkos::MemoryUnmanaged>& gids_out,
+           const Kokkos::View<int*,Device,Kokkos::MemoryUnmanaged>& pids_out,
+           const Kokkos::View<const Packet*,BufferDevice>& imports,
+           const size_t offset,
+           const size_t num_ent)
 {
   using size_type = typename Kokkos::View<GO*,Device>::size_type;
 
@@ -120,8 +120,9 @@ unpackRow(typename Kokkos::View<GO*,Device,Kokkos::MemoryUnmanaged>& gids_out,
 
   // Unpack PIDs
   if (pids_out.size() > 0) {
-    for (size_type k=0; k<num_ent; k++)
+    for (size_type k=0; k<num_ent; k++) {
       pids_out(k) = static_cast<int>(imports(offset+num_ent+k));
+    }
   }
 
   return 0;
@@ -137,8 +138,11 @@ unpackRow(typename Kokkos::View<GO*,Device,Kokkos::MemoryUnmanaged>& gids_out,
 /// Data (bytes) describing the row of the CRS graph are "unpacked"
 /// from a single (concatenated) (view of) Packet* directly into the
 /// row of the graph.
-template<class LocalOrdinal, class Packet, class RowView,
-         class IndicesView, class Device, class BufferDevice>
+template<class LocalOrdinal,
+         class Packet,
+         class RowView,
+         class IndicesView,
+         class BufferDevice>
 class UnpackAndCombineFunctor {
 
   using LO = LocalOrdinal;
@@ -148,13 +152,13 @@ class UnpackAndCombineFunctor {
   using indices_type = IndicesView;
   using buffer_device_type = BufferDevice;
 
-  using device_type = Device;
+  using device_type = typename IndicesView::device_type;
   using execution_space = typename device_type::execution_space;
 
   using num_packets_per_lid_type = Kokkos::View<const size_t*, buffer_device_type>;
   using offsets_type = Kokkos::View<const size_t*, device_type>;
   using input_buffer_type = Kokkos::View<const packet_type*, buffer_device_type>;
-  using import_lids_type = Kokkos::View<const LO*, device_type>;
+  using import_lids_type = Kokkos::View<const LO*, buffer_device_type>;
 
   using gids_scratch_type = Kokkos::View<GO*, device_type>;
   using pids_scratch_type = Kokkos::View<int*,device_type>;
@@ -178,8 +182,8 @@ class UnpackAndCombineFunctor {
 
   UnpackAndCombineFunctor(
       const row_ptrs_type& row_ptrs_beg_in,
-      row_ptrs_type& row_ptrs_end_in,
-      indices_type& indices_in,
+      const row_ptrs_type& row_ptrs_end_in,
+      const indices_type& indices_in,
       const input_buffer_type& imports_in,
       const num_packets_per_lid_type& num_packets_per_lid_in,
       const import_lids_type& import_lids_in,
@@ -271,9 +275,7 @@ class UnpackAndCombineFunctor {
     gids_out_type gids_out = subview(gids_scratch, slice(a, b));
     pids_out_type pids_out = subview(pids_scratch, slice(a, (unpack_pids ? b : a)));
 
-    // Unpack this row!
-    int err = unpackRow<packet_type,GO,device_type,buffer_device_type>(
-        gids_out, pids_out, imports, offset, num_ent);
+    const int err = unpackRow (gids_out, pids_out, imports, offset, num_ent);
 
     if (err != 0) {
       dst = Kokkos::make_pair(3, i);
@@ -326,25 +328,28 @@ computeCrsPadding(const NumPackets& num_packets_per_lid,
 ///
 /// This is a higher level interface to the UnpackAndCombineFunctor
 template<class LocalOrdinal, class Packet, class RowView,
-         class IndicesView, class Device, class BufferDevice>
+         class IndicesView, class BufferDevice>
 void
-unpackAndCombine(
-    RowView& row_ptrs_beg,
-    RowView& row_ptrs_end,
-    IndicesView& indices,
-    const Kokkos::View<const Packet*, BufferDevice, Kokkos::MemoryUnmanaged>& imports,
-    const Kokkos::View<const size_t*, BufferDevice, Kokkos::MemoryUnmanaged>& num_packets_per_lid,
-    const Kokkos::View<const LocalOrdinal*, Device, Kokkos::MemoryUnmanaged>& import_lids,
-    const bool unpack_pids)
+unpackAndCombine
+(const RowView& row_ptrs_beg,
+ const RowView& row_ptrs_end,
+ IndicesView& indices,
+ const Kokkos::View<const Packet*, BufferDevice, Kokkos::MemoryUnmanaged>& imports,
+ const Kokkos::View<const size_t*, BufferDevice, Kokkos::MemoryUnmanaged>& num_packets_per_lid,
+ const Kokkos::View<const LocalOrdinal*, BufferDevice, Kokkos::MemoryUnmanaged>& import_lids,
+ const bool unpack_pids)
 {
 
-  using ImportLidsView = Kokkos::View<const LocalOrdinal*, Device, Kokkos::MemoryUnmanaged>;
-  using NumPacketsView = Kokkos::View<const size_t*, BufferDevice, Kokkos::MemoryUnmanaged>;
+  using ImportLidsView =
+    Kokkos::View<const LocalOrdinal*, BufferDevice, Kokkos::MemoryUnmanaged>;
+  using NumPacketsView =
+    Kokkos::View<const size_t*, BufferDevice, Kokkos::MemoryUnmanaged>;
   using LO = LocalOrdinal;
-  using device_type = Device;
-  using execution_space = typename device_type::execution_space;
-  using range_policy = Kokkos::RangePolicy<execution_space, Kokkos::IndexType<LO>>;
-  using unpack_functor_type = UnpackAndCombineFunctor<LO,Packet,RowView,IndicesView,Device,BufferDevice>;
+  using execution_space = typename BufferDevice::execution_space;
+  using range_policy =
+    Kokkos::RangePolicy<execution_space, Kokkos::IndexType<LO>>;
+  using unpack_functor_type =
+    UnpackAndCombineFunctor<LO, Packet, RowView, IndicesView, BufferDevice>;
 
   const char prefix[] =
     "Tpetra::Details::UnpackAndCombineCrsGraphImpl::unpackAndCombine: ";
@@ -355,10 +360,13 @@ unpackAndCombine(
     return;
   }
 
+  using device_type = typename IndicesView::device_type;
+
   // Resize row pointers and indices to accommodate incoming data
-  auto padding = computeCrsPadding<NumPacketsView,ImportLidsView,Device>(
-    num_packets_per_lid, import_lids, unpack_pids);
-  padCrsArrays(row_ptrs_beg, row_ptrs_end, indices, padding);
+  auto padding =
+    computeCrsPadding<NumPacketsView, ImportLidsView, device_type>
+      (num_packets_per_lid, import_lids, unpack_pids);
+  padCrsArrays<RowView, IndicesView, decltype (padding) > (row_ptrs_beg, row_ptrs_end, indices, padding);
 
   // Get the offsets
   Kokkos::View<size_t*, device_type> offsets("offsets", num_import_lids+1);
@@ -368,19 +376,22 @@ unpackAndCombine(
   // maximum number of entries is needed to allocate unpack buffers on the
   // device.
   size_t max_num_ent;
-  Kokkos::parallel_reduce("MaxReduce",
-    range_policy(0, static_cast<LO>(num_packets_per_lid.size())),
-    KOKKOS_LAMBDA(const LO& i, size_t& running_max_num_ent) {
-      size_t num_packets_this_lid = num_packets_per_lid(i);
-      size_t num_ent = (unpack_pids) ? num_packets_this_lid/2
-                                     : num_packets_this_lid;
-      if (num_ent > running_max_num_ent) running_max_num_ent = num_ent;
-    }, Kokkos::Max<size_t>(max_num_ent));
+  Kokkos::parallel_reduce
+    ("MaxReduce",
+     range_policy (0, LO (num_packets_per_lid.size ())),
+     KOKKOS_LAMBDA (const LO i, size_t& running_max_num_ent) {
+       const size_t num_packets_this_lid = num_packets_per_lid(i);
+       const size_t num_ent = (unpack_pids) ? num_packets_this_lid/2 :
+         num_packets_this_lid;
+       if (num_ent > running_max_num_ent) {
+         running_max_num_ent = num_ent;
+       }
+     }, Kokkos::Max<size_t> (max_num_ent));
 
   // Now do the actual unpack!
-  unpack_functor_type f(row_ptrs_beg, row_ptrs_end, indices,
-      imports, num_packets_per_lid, import_lids, offsets,
-      max_num_ent, unpack_pids);
+  unpack_functor_type f (row_ptrs_beg, row_ptrs_end, indices, imports,
+                         num_packets_per_lid, import_lids, offsets,
+                         max_num_ent, unpack_pids);
 
   typename unpack_functor_type::value_type x;
   Kokkos::parallel_reduce(range_policy(0, static_cast<LO>(num_import_lids)), f, x);
@@ -388,8 +399,6 @@ unpackAndCombine(
   TEUCHOS_TEST_FOR_EXCEPTION(x_h.first != 0, std::runtime_error,
       prefix << "UnpackAndCombineFunctor reported error code "
              << x_h.first << " for the first bad row " << x_h.second);
-
-  return;
 }
 
 template<class Packet, class LocalGraph, class BufferDevice>
@@ -459,7 +468,7 @@ template<class Packet, class LO, class Device, class BufferDevice>
 void
 setupRowPointersForRemotes(
   const Kokkos::View<size_t*, Device>& tgt_rowptr,
-  const Kokkos::View<const LO*, Device>& import_lids,
+  const Kokkos::View<const LO*, BufferDevice>& import_lids,
   const Kokkos::View<const Packet*, BufferDevice>& /* imports */,
   const Kokkos::View<const size_t*, BufferDevice>& num_packets_per_lid)
 {
@@ -551,7 +560,7 @@ copyDataFromSameIDs(
   );
 }
 
-template<class LocalGraph, class LocalMap>
+template<class LocalGraph, class LocalMap, class BufferDevice>
 void
 copyDataFromPermuteIDs(
     const Kokkos::View<typename LocalMap::global_ordinal_type*,
@@ -565,9 +574,9 @@ copyDataFromPermuteIDs(
     const Kokkos::View<const int*,
                        typename LocalMap::device_type>& src_pids,
     const Kokkos::View<const typename LocalMap::local_ordinal_type*,
-                       typename LocalMap::device_type>& permute_to_lids,
+      BufferDevice, Kokkos::MemoryUnmanaged>& permute_to_lids,
     const Kokkos::View<const typename LocalMap::local_ordinal_type*,
-                       typename LocalMap::device_type>& permute_from_lids,
+      BufferDevice, Kokkos::MemoryUnmanaged>& permute_from_lids,
     const LocalGraph& local_graph,
     const LocalMap& local_col_map,
     const int my_pid)
@@ -613,7 +622,10 @@ unpackAndCombineIntoCrsArrays2(
     const Kokkos::View<int*, typename LocalMap::device_type>& tgt_pids,
     const Kokkos::View<size_t*,typename LocalMap::device_type>& new_start_row,
     const Kokkos::View<const size_t*, typename LocalMap::device_type>& offsets,
-    const Kokkos::View<const typename LocalMap::local_ordinal_type*, typename LocalMap::device_type>& import_lids,
+    const Kokkos::View<
+      const typename LocalMap::local_ordinal_type*,
+      BufferDevice,
+      Kokkos::MemoryUnmanaged>& import_lids,
     const Kokkos::View<const Packet*, BufferDevice>& imports,
     const Kokkos::View<const size_t*, BufferDevice>& num_packets_per_lid,
     const LocalGraph& /* local_graph */,
@@ -658,8 +670,7 @@ unpackAndCombineIntoCrsArrays2(
       gids_out_type gids_out = subview(tgt_colind, slice(start_row, end_row));
       pids_out_type pids_out = subview(tgt_pids, slice(start_row, end_row));
 
-      err += unpackRow<packet_type,GO,device_type,buffer_device_type>(
-          gids_out, pids_out, imports, offset, num_ent);
+      err += unpackRow (gids_out, pids_out, imports, offset, num_ent);
 
       // Correct target PIDs.
       for (size_t j = 0; j < static_cast<size_t>(num_ent); ++j) {
@@ -682,15 +693,15 @@ unpackAndCombineIntoCrsArrays(
     const LocalGraph & local_graph,
     const LocalMap & local_col_map,
     const Kokkos::View<const typename LocalMap::local_ordinal_type*,
-                       typename LocalMap::device_type,
+                       BufferDevice,
                        Kokkos::MemoryUnmanaged>& import_lids,
     const Kokkos::View<const Packet*, BufferDevice>& imports,
     const Kokkos::View<const size_t*, BufferDevice>& num_packets_per_lid,
     const Kokkos::View<const typename LocalMap::local_ordinal_type*,
-                       typename LocalMap::device_type,
+                       BufferDevice,
                        Kokkos::MemoryUnmanaged>& permute_to_lids,
     const Kokkos::View<const typename LocalMap::local_ordinal_type*,
-                       typename LocalMap::device_type,
+                       BufferDevice,
                        Kokkos::MemoryUnmanaged>& permute_from_lids,
     const Kokkos::View<size_t*,
                        typename LocalMap::device_type,
@@ -731,6 +742,11 @@ unpackAndCombineIntoCrsArrays(
   // In the case of reduced communicators, the sourceGraph won't have
   // the right "my_pid", so thus we have to supply it.
   const int my_pid = my_tgt_pid;
+
+  // FIXME (mfh 24 Jun 2019)
+  //
+  // 1. Only zero the entries of tgt_rowptr that actually need it.
+  // 2. Consider merging these three kernels into one.
 
   // Zero the rowptr
   parallel_for(
@@ -877,15 +893,13 @@ unpackCrsGraphAndCombine(
   using packet_type = typename graph_type::packet_type;
   using buffer_device_type = typename graph_type::buffer_device_type;
   using execution_space = typename device_type::execution_space;
-  typename execution_space::device_type outputDevice;
-  using buffer_execution_space = typename buffer_device_type::execution_space;
-  typename buffer_execution_space::device_type bufferOutputDevice;
   using range_policy = Kokkos::RangePolicy<execution_space, Kokkos::IndexType<LO>>;
-
   using row_ptrs_type = typename graph_type::local_graph_type::row_map_type::non_const_type;
   using indices_type = typename graph_type::t_GlobalOrdinal_1D;
 
   // Convert all Teuchos::Array to Kokkos::View.
+
+  buffer_device_type bufferOutputDevice;
 
   // numPacketsPerLID, importLIDs, and imports are input, so we have to copy
   // them to device.  Since unpacking is done directly in to the local graph
@@ -901,7 +915,7 @@ unpackCrsGraphAndCombine(
         true, "num_packets_per_lid");
 
   auto import_lids_d =
-    create_mirror_view_from_raw_host_array(outputDevice,
+    create_mirror_view_from_raw_host_array(bufferOutputDevice,
         importLIDs.getRawPtr(), importLIDs.size(),
         true, "import_lids");
 
@@ -938,9 +952,9 @@ unpackCrsGraphAndCombine(
   }
 
   // Now do the actual unpack!
-  unpackAndCombine<LO,packet_type,row_ptrs_type,indices_type,device_type,buffer_device_type>(
-        row_ptrs_beg, row_ptrs_end, indices, imports_d,
-        num_packets_per_lid_d, import_lids_d, false);
+  unpackAndCombine<LO, GO, row_ptrs_type, indices_type, buffer_device_type>
+    (row_ptrs_beg, row_ptrs_end, indices, imports_d,
+     num_packets_per_lid_d, import_lids_d, false);
 
   // mfh Later, permit graph to be locally indexed, and check whether
   // incoming column indices are in the column Map.  If not, error.
@@ -1161,18 +1175,17 @@ unpackAndCombineIntoCrsArrays(
 {
   using Kokkos::View;
   using Kokkos::deep_copy;
-  using Teuchos::ArrayView;
   using Teuchos::outArg;
   using Teuchos::REDUCE_MAX;
   using Teuchos::reduceAll;
   using LO = LocalOrdinal;
-  using packet_type = typename CrsGraph<LocalOrdinal,GlobalOrdinal,Node>::packet_type;
-  using local_graph_type = typename CrsGraph<LocalOrdinal,GlobalOrdinal,Node>::local_graph_type;
-  using buffer_device_type = typename CrsGraph<LocalOrdinal,GlobalOrdinal,Node>::buffer_device_type;
+  using GO = GlobalOrdinal;
+  using crs_graph_type = CrsGraph<LO, GO, Node>;
+  using packet_type = typename crs_graph_type::packet_type;
+  using local_graph_type = typename crs_graph_type::local_graph_type;
+  using buffer_device_type = typename crs_graph_type::buffer_device_type;
   using device_type = typename Node::device_type;
-  using execution_space = typename device_type::execution_space;
-  using buffer_execution_space = typename buffer_device_type::execution_space;
-  using size_type = typename ArrayView<const LO>::size_type;
+  using size_type = typename Teuchos::ArrayView<const LO>::size_type;
 
   const char prefix[] = "Tpetra::Details::unpackAndCombineIntoCrsArrays: ";
 
@@ -1203,42 +1216,51 @@ unpackAndCombineIntoCrsArrays(
   auto local_col_map = sourceGraph.getColMap()->getLocalMap();
 
   // Convert input arrays to Kokkos::View
-  typename execution_space::device_type outputDevice;
-  typename buffer_execution_space::device_type bufferOutputDevice;
+  device_type outputDevice;
+  buffer_device_type bufferOutputDevice;
 
-  auto import_lids_d = create_mirror_view_from_raw_host_array(outputDevice,
-        importLIDs.getRawPtr(), importLIDs.size(),
-        true, "import_lids");
+  Kokkos::View<const LO*, buffer_device_type> import_lids_d =
+    create_mirror_view_from_raw_host_array
+      (bufferOutputDevice, importLIDs.getRawPtr(),
+       importLIDs.size(), true, "import_lids");
 
-  auto imports_d = create_mirror_view_from_raw_host_array(bufferOutputDevice,
-        imports.getRawPtr(), imports.size(),
-        true, "imports");
+  Kokkos::View<const packet_type*, buffer_device_type> imports_d =
+    create_mirror_view_from_raw_host_array
+      (bufferOutputDevice, imports.getRawPtr(),
+       imports.size(), true, "imports");
 
-  auto num_packets_per_lid_d = create_mirror_view_from_raw_host_array(bufferOutputDevice,
+  Kokkos::View<const size_t*, buffer_device_type> num_packets_per_lid_d =
+    create_mirror_view_from_raw_host_array(bufferOutputDevice,
       numPacketsPerLID.getRawPtr(), numPacketsPerLID.size(),
       true, "num_packets_per_lid");
 
-  auto permute_from_lids_d = create_mirror_view_from_raw_host_array(outputDevice,
-      permuteFromLIDs.getRawPtr(), permuteFromLIDs.size(),
-      true, "permute_from_lids");
-
-  auto permute_to_lids_d = create_mirror_view_from_raw_host_array(outputDevice,
+  Kokkos::View<const LO*, buffer_device_type> permute_to_lids_d =
+    create_mirror_view_from_raw_host_array(bufferOutputDevice,
       permuteToLIDs.getRawPtr(), permuteToLIDs.size(),
       true, "permute_to_lids");
 
-  auto crs_rowptr_d = create_mirror_view_from_raw_host_array(outputDevice,
+  Kokkos::View<const LO*, buffer_device_type> permute_from_lids_d =
+    create_mirror_view_from_raw_host_array(bufferOutputDevice,
+      permuteFromLIDs.getRawPtr(), permuteFromLIDs.size(),
+      true, "permute_from_lids");
+
+  Kokkos::View<size_t*, device_type> crs_rowptr_d =
+    create_mirror_view_from_raw_host_array(outputDevice,
       CRS_rowptr.getRawPtr(), CRS_rowptr.size(),
       true, "crs_rowptr");
 
-  auto crs_colind_d = create_mirror_view_from_raw_host_array(outputDevice,
+  Kokkos::View<GO*, device_type> crs_colind_d =
+    create_mirror_view_from_raw_host_array(outputDevice,
       CRS_colind.getRawPtr(), CRS_colind.size(),
       true, "crs_colidx");
 
-  auto src_pids_d = create_mirror_view_from_raw_host_array(outputDevice,
+  Kokkos::View<const int*, device_type> src_pids_d =
+    create_mirror_view_from_raw_host_array(outputDevice,
       SourcePids.getRawPtr(), SourcePids.size(),
       true, "src_pids");
 
-  auto tgt_pids_d = create_mirror_view_from_raw_host_array(outputDevice,
+  Kokkos::View<int*, device_type> tgt_pids_d =
+    create_mirror_view_from_raw_host_array(outputDevice,
       TargetPids.getRawPtr(), TargetPids.size(),
       true, "tgt_pids");
 
@@ -1248,6 +1270,8 @@ unpackAndCombineIntoCrsArrays(
       local_graph, local_col_map, import_lids_d, imports_d, num_packets_per_lid_d,
       permute_to_lids_d, permute_from_lids_d, crs_rowptr_d, crs_colind_d, src_pids_d,
       tgt_pids_d, numSameIDs, TargetNumRows, TargetNumNonzeros, MyTargetPID);
+
+  // FIXME (mfh 25 Jun 2019) HostMirror of CudaUVMSpace is CudaUVMSpace!!!
 
   // Copy outputs back to host
   typename decltype(crs_rowptr_d)::HostMirror crs_rowptr_h(

--- a/packages/tpetra/core/src/Tpetra_DistObject_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_DistObject_decl.hpp
@@ -727,7 +727,7 @@ namespace Tpetra {
 #ifdef KOKKOS_ENABLE_CUDA
     using buffer_memory_space = typename std::conditional<
       std::is_same<typename device_type::execution_space, Kokkos::Cuda>::value,
-      Kokkos::CudaSpace,
+      Kokkos::CudaHostPinnedSpace,
       typename device_type::memory_space>::type;
 #else
     using buffer_memory_space = typename device_type::memory_space;

--- a/packages/tpetra/core/src/Tpetra_DistObject_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_DistObject_decl.hpp
@@ -722,22 +722,15 @@ namespace Tpetra {
 
     /// \typedef buffer_memory_space
     /// \brief Kokkos memory space for communication buffers.
-    ///
-    /// See #1088 for why this is not just <tt>device_type::memory_space</tt>.
-#ifdef KOKKOS_ENABLE_CUDA
-    using buffer_memory_space = typename std::conditional<
-      std::is_same<typename device_type::execution_space, Kokkos::Cuda>::value,
-      Kokkos::CudaHostPinnedSpace,
-      typename device_type::memory_space>::type;
-#else
-    using buffer_memory_space = typename device_type::memory_space;
-#endif // KOKKOS_ENABLE_CUDA
+    using buffer_memory_space =
+      ::Tpetra::Details::DefaultTypes::comm_buffer_memory_space<
+        typename device_type::execution_space>;
 
   public:
     /// \typedef buffer_device_type
     /// \brief Kokkos::Device specialization for communication buffers.
     ///
-    /// See #1088 for why this is not just <tt>device_type::device_type</tt>.
+    /// See #1088 for why this is not just \c device_type.
     ///
     /// This needs to be public so that I can declare functions like
     /// packAndPrepareWithOwningPIDs.

--- a/packages/tpetra/core/src/Tpetra_DistObject_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_DistObject_def.hpp
@@ -589,16 +589,18 @@ namespace Tpetra {
         std::cerr << os.str ();
       }
 
-      auto permToLIDs = (revOp == DoForward) ?
+      using const_lo_dv_type =
+        Kokkos::DualView<const local_ordinal_type*, buffer_device_type>;
+      const_lo_dv_type permToLIDs = (revOp == DoForward) ?
         transfer.getPermuteToLIDs_dv () :
         transfer.getPermuteFromLIDs_dv ();
-      auto permFromLIDs = (revOp == DoForward) ?
+      const_lo_dv_type permFromLIDs = (revOp == DoForward) ?
         transfer.getPermuteFromLIDs_dv () :
         transfer.getPermuteToLIDs_dv ();
-      auto remoteLIDs = (revOp == DoForward) ?
+      const_lo_dv_type remoteLIDs = (revOp == DoForward) ?
         transfer.getRemoteLIDs_dv () :
         transfer.getExportLIDs_dv ();
-      auto exportLIDs = (revOp == DoForward) ?
+      const_lo_dv_type exportLIDs = (revOp == DoForward) ?
         transfer.getExportLIDs_dv () :
         transfer.getRemoteLIDs_dv ();
       doTransferNew (src, CM, numSameIDs, permToLIDs, permFromLIDs,

--- a/packages/tpetra/core/src/Tpetra_Experimental_BlockCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Experimental_BlockCrsMatrix_def.hpp
@@ -43,7 +43,7 @@
 #define TPETRA_EXPERIMENTAL_BLOCKCRSMATRIX_DEF_HPP
 
 /// \file Tpetra_Experimental_BlockCrsMatrix_def.hpp
-/// \brief Definition of Tpetra::Experimental::BlockCrsMatrix
+/// \brief DEPRECATED header file; use Tpetra_BlockCrsMatrix_def.hpp instead
 
 #if !defined(TRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS)
 #if defined(__GNU__)
@@ -51,6 +51,6 @@
 #endif
 #endif
 
-#include <Tpetra_BlockCrsMatrix_def.hpp> 
+#include "Tpetra_BlockCrsMatrix_def.hpp"
 
 #endif // TPETRA_EXPERIMENTAL_BLOCKCRSMATRIX_DEF_HPP

--- a/packages/tpetra/core/src/Tpetra_ImportExportData_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_ImportExportData_decl.hpp
@@ -152,7 +152,7 @@ namespace Tpetra {
 #ifdef KOKKOS_ENABLE_CUDA
     using memory_space = typename std::conditional<
       std::is_same<execution_space, Kokkos::Cuda>::value,
-      Kokkos::CudaSpace,
+      Kokkos::CudaHostPinnedSpace,
       typename Node::device_type::memory_space>::type;
 #else
     using memory_space = typename Node::device_type::memory_space;

--- a/packages/tpetra/core/src/Tpetra_ImportExportData_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_ImportExportData_decl.hpp
@@ -147,16 +147,8 @@ namespace Tpetra {
     bool verbose_ = false;
 
     using execution_space = typename Node::device_type::execution_space;
-
-    // See #1088 for why this is not just device_type::memory_space.
-#ifdef KOKKOS_ENABLE_CUDA
-    using memory_space = typename std::conditional<
-      std::is_same<execution_space, Kokkos::Cuda>::value,
-      Kokkos::CudaHostPinnedSpace,
-      typename Node::device_type::memory_space>::type;
-#else
-    using memory_space = typename Node::device_type::memory_space;
-#endif // KOKKOS_ENABLE_CUDA
+    using memory_space =
+      ::Tpetra::Details::DefaultTypes::comm_buffer_memory_space<execution_space>;
     using device_type = Kokkos::Device<execution_space, memory_space>;
 
     /// \brief Index of target Map LIDs to which to permute.

--- a/packages/tpetra/core/test/ImportExport2/ImportExport2_UnitTests.cpp
+++ b/packages/tpetra/core/test/ImportExport2/ImportExport2_UnitTests.cpp
@@ -833,10 +833,12 @@ double test_with_matvec(const CrsMatrixType &A, const CrsMatrixType &B){
   return Teuchos::as<double> (norms[0]);
 }
 
-
-// ===============================================================================
-template <class CrsMatrixType, class map_type>
-double test_with_matvec_reduced_maps(const CrsMatrixType &A, const CrsMatrixType &B, const map_type & Bfullmap){
+template <class CrsMatrixType, class MapType>
+double
+test_with_matvec_reduced_maps (const CrsMatrixType& A,
+                               const CrsMatrixType& B,
+                               const MapType& Bfullmap)
+{
   typedef typename CrsMatrixType::local_ordinal_type LO;
   typedef typename CrsMatrixType::global_ordinal_type GO;
   typedef typename CrsMatrixType::scalar_type Scalar;
@@ -844,9 +846,10 @@ double test_with_matvec_reduced_maps(const CrsMatrixType &A, const CrsMatrixType
   typedef Tpetra::MultiVector<Scalar, LO, GO, NT> vector_type;
   typedef Tpetra::Import<LO, GO, NT> import_type;
 
-  RCP<const map_type>  Amap  = A.getDomainMap();
+  RCP<const MapType>  Amap  = A.getDomainMap();
   vector_type Xa(Amap,1), Ya(Amap,1), Diff(Amap,1);
-  RCP<const map_type> Bmap  = Bfullmap.getNodeNumElements() > 0 ? B.getDomainMap() : Teuchos::null;
+  RCP<const MapType> Bmap  = Bfullmap.getNodeNumElements() > 0 ?
+    B.getDomainMap() : Teuchos::null;
 
   vector_type Xb_alias(rcp(&Bfullmap,false),1);
   vector_type Yb_alias(rcp(&Bfullmap,false),1);
@@ -875,16 +878,17 @@ double test_with_matvec_reduced_maps(const CrsMatrixType &A, const CrsMatrixType
   return Teuchos::as<double>(norms[0]);
 }
 
-
-// ===============================================================================
 template<class CrsMatrixType>
-void build_test_matrix(RCP<const Teuchos::Comm<int> > & Comm, RCP<CrsMatrixType> & A){
+void
+build_test_matrix (const RCP<const Teuchos::Comm<int>>& Comm,
+                   RCP<CrsMatrixType>& A)
+{
   typedef typename CrsMatrixType::local_ordinal_type LO;
   typedef typename CrsMatrixType::global_ordinal_type GO;
   typedef typename CrsMatrixType::scalar_type Scalar;
   typedef typename CrsMatrixType::node_type NT;
 
-  typedef Tpetra::Map<LO, GO, NT> map_type;
+  using map_type = Tpetra::Map<LO, GO, NT>;
   typedef Teuchos::ScalarTraits<Scalar> STS;
 
   const Scalar ONE = STS::one ();
@@ -944,13 +948,16 @@ void build_test_matrix(RCP<const Teuchos::Comm<int> > & Comm, RCP<CrsMatrixType>
 
 // ===============================================================================
 template<class CrsMatrixType>
-void build_test_matrix_wideband(RCP<const Teuchos::Comm<int> > & Comm, RCP<CrsMatrixType> & A){
+void
+build_test_matrix_wideband (const RCP<const Teuchos::Comm<int>>& Comm,
+                            RCP<CrsMatrixType>& A)
+{
   typedef typename CrsMatrixType::local_ordinal_type LO;
   typedef typename CrsMatrixType::global_ordinal_type GO;
   typedef typename CrsMatrixType::scalar_type Scalar;
   typedef typename CrsMatrixType::node_type NT;
 
-  typedef Tpetra::Map<LO, GO, NT> map_type;
+  using map_type = Tpetra::Map<LO, GO, NT>;
   typedef Teuchos::ScalarTraits<Scalar> STS;
 
   const Scalar ONE = STS::one ();
@@ -965,7 +972,8 @@ void build_test_matrix_wideband(RCP<const Teuchos::Comm<int> > & Comm, RCP<CrsMa
   }
 
   // Construct a Map that puts approximately the same Number of equations on each processor
-  RCP<const map_type > MyMap = rcp(new map_type(NumGlobalEquations, NumMyEquations, 0, Comm));
+  RCP<const map_type> MyMap =
+    rcp (new map_type (NumGlobalEquations, NumMyEquations, 0, Comm));
 
   // Create the matrix
   A = rcp(new CrsMatrixType(MyMap,10));
@@ -1209,7 +1217,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FusedImportExport, doImport, LO, GO, Scalar )
 {
   typedef Tpetra::CrsGraph<LO, GO> Graph;
   typedef Tpetra::CrsMatrix<Scalar, LO, GO> CrsMatrixType;
-  typedef Tpetra::Map<LO, GO> MapType;
+  using map_type = Tpetra::Map<LO, GO>;
   typedef Tpetra::Import<LO, GO> ImportType;
   typedef Tpetra::Export<LO, GO> ExportType;
   typedef typename Teuchos::ScalarTraits<Scalar>::magnitudeType MagType;
@@ -1223,8 +1231,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FusedImportExport, doImport, LO, GO, Scalar )
 
   RCP<CrsMatrixType> A, B, C;
   RCP<Graph> Bg;
-  RCP<const MapType> Map1, Map2;
-  RCP<MapType> Map3;
+  RCP<const map_type> Map1, Map2;
+  RCP<map_type> Map3;
 
   RCP<ImportType> Import1;
   RCP<ExportType> Export1;
@@ -1262,8 +1270,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FusedImportExport, doImport, LO, GO, Scalar )
     GST num_global = A->getRowMap()->getGlobalNumElements();
 
     // New map with all on Proc1
-    if(MyPID==0) Map1 = rcp(new MapType(num_global,(size_t)num_global,0,Comm));
-    else Map1 = rcp(new MapType(num_global,(size_t)0,0,Comm));
+    if(MyPID==0) Map1 = rcp(new map_type(num_global,(size_t)num_global,0,Comm));
+    else Map1 = rcp(new map_type(num_global,(size_t)0,0,Comm));
 
     // Execute fused import
     Import1 = rcp(new ImportType(A->getRowMap(),Map1));
@@ -1328,7 +1336,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FusedImportExport, doImport, LO, GO, Scalar )
     for(size_t i=0; i<num_local; i++)
       MyGIDs[i] = A->getRowMap()->getGlobalElement(num_local-i-1);
 
-    Map1 = rcp(new MapType(INVALID,MyGIDs(),0,Comm));
+    Map1 = rcp(new map_type(INVALID,MyGIDs(),0,Comm));
 
     // Execute fused import
     Import1 = rcp(new ImportType(A->getRowMap(),Map1));
@@ -1405,7 +1413,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FusedImportExport, doImport, LO, GO, Scalar )
     }
 
     // New map & importer
-    Map1=rcp(new MapType(INVALID,MyGIDs.view(0,idx),0,Comm));
+    Map1=rcp(new map_type(INVALID,MyGIDs.view(0,idx),0,Comm));
     Import1 = rcp(new ImportType(A->getRowMap(),Map1));
 
     // Build unfused matrix to compare
@@ -1537,7 +1545,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FusedImportExport, doImport, LO, GO, Scalar )
     // Execute fused import constructor
     Import1 = rcp(new ImportType(A->getRowMap(),Map3));
     B = Tpetra::importAndFillCompleteCrsMatrix<CrsMatrixType>(A,*Import1,Map3,Map3,rcp(&params,false));
-    diff=test_with_matvec_reduced_maps<CrsMatrixType,MapType>(*A,*B,*Map3);
+    diff=test_with_matvec_reduced_maps<CrsMatrixType,map_type>(*A,*B,*Map3);
     if(diff > diff_tol){
       if(MyPID==0) {
         cerr << "FusedImport: Test #6 FAILED with norm diff = " << diff
@@ -1559,7 +1567,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FusedImportExport, doImport, LO, GO, Scalar )
     // Execute fused export constructor
     Export1 = rcp(new ExportType(A->getRowMap(),Map3));
     B = Tpetra::exportAndFillCompleteCrsMatrix<CrsMatrixType>(A,*Export1,Map3,Map3,rcp(&params,false));
-    diff=test_with_matvec_reduced_maps<CrsMatrixType,MapType>(*A,*B,*Map3);
+    diff=test_with_matvec_reduced_maps<CrsMatrixType,map_type>(*A,*B,*Map3);
     if(diff > diff_tol){
       if(MyPID==0) {
         cerr << "FusedExport: Test #6 FAILED with norm diff = " << diff
@@ -1598,8 +1606,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FusedImportExport, doImport, LO, GO, Scalar )
     GST num_global = A->getRowMap()->getGlobalNumElements();
 
     // New map with all on Proc1
-    if(MyPID==0) Map1 = rcp(new MapType(num_global,(size_t)num_global,0,Comm));
-    else Map1 = rcp(new MapType(num_global,(size_t)0,0,Comm));
+    if(MyPID==0) Map1 = rcp(new map_type(num_global,(size_t)num_global,0,Comm));
+    else Map1 = rcp(new map_type(num_global,(size_t)0,0,Comm));
 
     // Parameters
     Teuchos::ParameterList params;
@@ -1736,7 +1744,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( ReverseImportExport, doImport, LO, GO, Scalar
   // NOTE: This test will fail.
 
   RCP<const Comm<int> > Comm = getDefaultComm();
-  typedef Tpetra::Map<LO, GO> MapType;
+  typedef Tpetra::Map<LO, GO> map_type;
   typedef Tpetra::Import<LO, GO> ImportType;
   typedef Tpetra::Export<LO, GO> ExportType;
   typedef typename Teuchos::ScalarTraits<Scalar>::magnitudeType MagType;
@@ -1747,7 +1755,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( ReverseImportExport, doImport, LO, GO, Scalar
   RCP<CrsMatrixType> A;
 
   RCP<VectorType> SourceVector, TargetVector, TestVector;
-  RCP<const MapType> MapSource, MapTarget;
+  RCP<const map_type> MapSource, MapTarget;
   RCP<ImportType> Import1;
   RCP<ExportType> Export1;
   int MyPID = Comm->getRank();
@@ -1762,7 +1770,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( ReverseImportExport, doImport, LO, GO, Scalar
 
   // Target Map - all on one proc
   size_t num_local = MyPID==0 ? num_global : 0;
-  MapTarget = rcp(new MapType(num_global,num_local,0,Comm));
+  MapTarget = rcp(new map_type(num_global,num_local,0,Comm));
 
   // Vectors
   SourceVector = rcp(new VectorType(MapSource));
@@ -1824,7 +1832,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL( Import_Util, GetPids, LO, GO )  {
   // Unit Test the functionality in Tpetra_Import_Util
   RCP<const Comm<int> > Comm = getDefaultComm();
   typedef Tpetra::CrsMatrix<>::scalar_type Scalar;
-  typedef Tpetra::Map<LO, GO> MapType;
+  typedef Tpetra::Map<LO, GO> map_type;
   typedef Tpetra::Import<LO, GO> ImportType;
   typedef Tpetra::Export<LO, GO> ExportType;
   typedef Tpetra::Vector<int, LO, GO> IntVectorType;
@@ -1834,7 +1842,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL( Import_Util, GetPids, LO, GO )  {
   RCP<CrsMatrixType> A;
 
   RCP<IntVectorType> SourceVector, TargetVector, TestVector;
-  RCP<const MapType> MapSource, MapTarget;
+  RCP<const map_type> MapSource, MapTarget;
   RCP<ImportType> Import1;
   RCP<ExportType> Export1;
   int MyPID = Comm->getRank();
@@ -1848,7 +1856,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL( Import_Util, GetPids, LO, GO )  {
 
   // Target Map - all on one proc
   const size_t num_local = MyPID==0 ? num_global : 0;
-  MapTarget = rcp (new MapType (num_global,num_local,0,Comm));
+  MapTarget = rcp (new map_type (num_global,num_local,0,Comm));
 
   // Vectors
   SourceVector = rcp(new IntVectorType(MapSource));
@@ -2007,22 +2015,24 @@ TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL( Import_Util, PackAndPrepareWithOwningPIDs, LO
 
 
 // Unit Test the functionality in Tpetra_Import_Util
-TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( Import_Util, UnpackAndCombineWithOwningPIDs, LO, GO, Scalar)  {
+TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( Import_Util, UnpackAndCombineWithOwningPIDs, LO, GO, Scalar)
+{
   using Teuchos::av_reinterpret_cast;
-  typedef Tpetra::Map<LO, GO> MapType;
+  typedef Tpetra::Map<LO, GO> map_type;
   typedef Tpetra::Import<LO, GO> ImportType;
   typedef Tpetra::CrsMatrix<Scalar, LO, GO> CrsMatrixType;
-  typedef typename Tpetra::CrsMatrix<Scalar, LO, GO>::packet_type PacketType;
-  typedef typename MapType::device_type device_type;
-  typedef Tpetra::global_size_t GST;
-  typedef typename CrsMatrixType::impl_scalar_type IST;
+  using packet_type = typename Tpetra::CrsMatrix<Scalar, LO, GO>::packet_type;
+  using device_type = typename map_type::device_type;
+  using GST = Tpetra::global_size_t;
+  using IST = typename CrsMatrixType::impl_scalar_type;
+  using buffer_device_type = typename CrsMatrixType::buffer_device_type;
 
   RCP<const Comm<int> > Comm = getDefaultComm();
   RCP<CrsMatrixType> A,B;
   int total_err=0;
   int test_err=0;
   int MyPID = Comm->getRank();
-  RCP<const MapType> MapSource, MapTarget;
+  RCP<const map_type> MapSource, MapTarget;
 
   const bool debug = ::Tpetra::Details::Behavior::debug ();
   verbose = ::Tpetra::Details::Behavior::verbose ();
@@ -2039,19 +2049,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( Import_Util, UnpackAndCombineWithOwningPIDs, 
   }
 
   ::Tpetra::Details::Behavior::disable_verbose_behavior ();
-
-  // mfh 01 Aug 2017: Deal with fix for #1088, by not using
-  // Kokkos::CudaUVMSpace for communication buffers.
-#ifdef KOKKOS_ENABLE_CUDA
-  typedef typename std::conditional<
-  std::is_same<typename device_type::execution_space, Kokkos::Cuda>::value,
-    Kokkos::CudaSpace,
-    typename device_type::memory_space>::type buffer_memory_space;
-#else
-  typedef typename device_type::memory_space buffer_memory_space;
-#endif // KOKKOS_ENABLE_CUDA
-  typedef typename device_type::execution_space buffer_execution_space;
-  typedef Kokkos::Device<buffer_execution_space, buffer_memory_space> buffer_device_type;
 
   Kokkos::DualView<char*, buffer_device_type> exports;
   Teuchos::Array<char> imports;
@@ -2070,7 +2067,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( Import_Util, UnpackAndCombineWithOwningPIDs, 
 
   // Target Map - all on one proc
   size_t num_local = MyPID==0 ? num_global : 0;
-  MapTarget = rcp(new MapType(num_global,num_local,0,Comm));
+  MapTarget = rcp(new map_type(num_global,num_local,0,Comm));
 
   // Build Importer
   if (verbose) {
@@ -2165,7 +2162,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( Import_Util, UnpackAndCombineWithOwningPIDs, 
       os << *prefix << "Calling 4-arg doPostsAndWaits" << std::endl;
       std::cerr << os.str ();
     }
-    distor.doPostsAndWaits<PacketType>(exports_av,numExportPackets(),imports(),numImportPackets());
+    distor.doPostsAndWaits<packet_type>(exports_av,numExportPackets(),imports(),numImportPackets());
     if (verbose) {
       std::ostringstream os;
       os << *prefix << "Done with 4-arg doPostsAndWaits" << std::endl;
@@ -2257,7 +2254,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( Import_Util, UnpackAndCombineWithOwningPIDs, 
     if(!test_err) {
 
       // Reindex colind to local indices
-      const MapType & Bmap = *B->getColMap();
+      const map_type & Bmap = *B->getColMap();
       for(size_t i=0; i<as<size_t>(colind.size()); i++){
         colind[i]=Bmap.getLocalElement(colind[i]);
       }
@@ -2298,15 +2295,15 @@ TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL( Import_Util,LowCommunicationMakeColMapAndRein
   // Test the colmap...
   RCP<const Comm<int> > Comm = getDefaultComm();
   typedef Tpetra::CrsMatrix<>::scalar_type Scalar;
-  typedef Tpetra::Map<LO,GO> MapType;
+  typedef Tpetra::Map<LO,GO> map_type;
   typedef Tpetra::Import<LO,GO> ImportType;
   typedef Tpetra::CrsMatrix<Scalar,LO,GO> CrsMatrixType;
   typedef Teuchos_Ordinal rsize_t;
   using Teuchos::av_reinterpret_cast;
 
   RCP<CrsMatrixType> A;
-  RCP<const MapType> Acolmap, Adomainmap;
-  RCP<const MapType> Bcolmap;
+  RCP<const map_type> Acolmap, Adomainmap;
+  RCP<const map_type> Bcolmap;
   int total_err=0;
   int test_err=0;
 
@@ -2371,13 +2368,13 @@ TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL( Import, AdvancedConstructors, LO, GO )  {
   // Test the remotePIDs Tpetra::Import constructor
   RCP<const Comm<int> > Comm = getDefaultComm();
   typedef Tpetra::CrsMatrix<>::scalar_type Scalar;
-  typedef Tpetra::Map<LO, GO> MapType;
+  typedef Tpetra::Map<LO, GO> map_type;
   typedef Tpetra::Import<LO, GO> ImportType;
   typedef Tpetra::CrsMatrix<Scalar, LO, GO> CrsMatrixType;
   RCP<CrsMatrixType> A,B;
 
   RCP<const ImportType> Import1, Import2;
-  RCP<MapType> Map0;
+  RCP<map_type> Map0;
   int total_err=0;
   int test_err=0;
 
@@ -2473,11 +2470,11 @@ TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL( Import, AdvancedConstructors, LO, GO )  {
  TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FusedImportExport, MueLuStyle, LO, GO, Scalar )  {
   // Test a muelu-style SA build and rebalance.  Kind of like Gangnam Style, but with more cows.
   RCP<const Comm<int> > Comm = getDefaultComm();
-  typedef Tpetra::Map<LO, GO> MapType;
+  typedef Tpetra::Map<LO, GO> map_type;
   typedef Tpetra::Import<LO, GO> ImportType;
   typedef Tpetra::CrsMatrix<Scalar, LO, GO> CrsMatrixType;
   RCP<CrsMatrixType> A,Ptent,P,R,AP,RAP,rebalancedP;
-  RCP<MapType> Map0;
+  RCP<map_type> Map0;
   RCP<const ImportType> Import0,ImportTemp;
 
   const int myRank = Comm->getRank ();
@@ -2617,7 +2614,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL( RemoteOnlyImport, Basic, LO, GO )  {
 // Test the remotePIDs Tpetra::Import constructor
   RCP<const Comm<int> > Comm = getDefaultComm();
   typedef Tpetra::CrsMatrix<>::scalar_type Scalar;
-  typedef Tpetra::Map<LO, GO> MapType;
+  typedef Tpetra::Map<LO, GO> map_type;
   typedef Tpetra::Import<LO, GO> ImportType;
   typedef Tpetra::Vector<Scalar, LO, GO> VectorType;
   typedef Tpetra::CrsMatrix<Scalar, LO, GO> CrsMatrixType;
@@ -2625,7 +2622,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL( RemoteOnlyImport, Basic, LO, GO )  {
 
   RCP<const ImportType> Import1, Import2;
   RCP<VectorType> SourceVector, TargetVector, TestVector;
-  RCP<MapType> Map0;
+  RCP<map_type> Map0;
   const int myRank = Comm->getRank ();
   int total_err=0;
   int test_err=0;
@@ -2663,7 +2660,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL( RemoteOnlyImport, Basic, LO, GO )  {
 
   // Build the remote-only map
   try {
-    build_remote_only_map<ImportType,MapType>(Import1,Map0);
+    build_remote_only_map<ImportType,map_type>(Import1,Map0);
   } catch (std::exception& e) {
     err << "Proc " << myRank << ": " << e.what ();
     lclErr = 1;
@@ -2742,11 +2739,11 @@ TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL( RemoteOnlyImport, Basic, LO, GO )  {
 
 TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL( Import_Util,GetTwoTransferOwnershipVector, LO, GO )  {
   RCP<const Comm<int> > Comm = getDefaultComm();
-  typedef Tpetra::Map<LO, GO> MapType;
+  typedef Tpetra::Map<LO, GO> map_type;
   typedef Tpetra::Import<LO, GO> ImportType;
   typedef Tpetra::Vector<int, LO, GO> IntVectorType;
   RCP<const ImportType> ImportOwn, ImportXfer;
-  RCP<MapType> Map0, Map1, Map2;
+  RCP<map_type> Map0, Map1, Map2;
 
   // Get Rank
   const int NumProc = Comm->getSize ();
@@ -2763,7 +2760,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL( Import_Util,GetTwoTransferOwnershipVector, LO
 
   // Map0  - Even
   GO num_global = num_per_proc * NumProc;
-  Map0 = rcp(new MapType(num_global,0,Comm));
+  Map0 = rcp(new map_type(num_global,0,Comm));
 
 
   // Map1 - Cycled
@@ -2771,7 +2768,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL( Import_Util,GetTwoTransferOwnershipVector, LO
   for(int i=0; i<num_per_proc; i++) {
     map1_gids[i] = MyPID + i*NumProc;
   }
-  Map1 = rcp(new MapType(INVALID,map1_gids,0,Comm));
+  Map1 = rcp(new map_type(INVALID,map1_gids,0,Comm));
 
   // Map2 - Reversed
   Teuchos::Array<GO> map2_gids(num_per_proc);
@@ -2779,7 +2776,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL( Import_Util,GetTwoTransferOwnershipVector, LO
   for(int i=0; i<num_per_proc; i++) {
     map2_gids[i] = map2_base + i;
   }
-  Map2 = rcp(new MapType(INVALID,map2_gids,0,Comm));
+  Map2 = rcp(new map_type(INVALID,map2_gids,0,Comm));
 
   // Importer / Exporter
   ImportOwn = rcp(new ImportType(Map0,Map1));


### PR DESCRIPTION
@trilinos/tpetra 

## Description

Currently, Tpetra uses `CudaSpace` as the Kokkos memory space for MPI communication buffers.  We want to try using `CudaHostPinnedSpace` instead, and compare performance of the two options.  (See #4757.)  Trivially changing the space (via the `buffer_memory_space` typedef that appears in a few places) does not build.  This PR fixes the build for that case.

NOTE: This PR does NOT change `buffer_memory_space` to `CudaHostPinnedSpace`.  It just makes sure that Tpetra can build with that change.  If you want to try `buffer_memory_space=CudaSpace`, just drop the last commit.

## Motivation and Context

ATDM performance on GPU clusters.

## Related Issues

* Part of #4757 