### PR TITLE
Ifpack2: Partial fix for #4647

### DIFF
--- a/packages/ifpack2/src/CMakeLists.txt
+++ b/packages/ifpack2/src/CMakeLists.txt
@@ -369,5 +369,5 @@ TRIBITS_ADD_LIBRARY(
 #
 # Make a trivial change here if you want CMake to run, due to changes
 # you make to files in Ifpack2.  Here is another such change.
-# Behold, I make another change, and another.
+# Behold, I make another change, and another, and another.
 #

--- a/packages/ifpack2/src/Ifpack2_AdditiveSchwarz_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_AdditiveSchwarz_decl.hpp
@@ -59,6 +59,7 @@
 #include "Tpetra_Map.hpp"
 #include "Tpetra_MultiVector.hpp"
 #include "Tpetra_RowMatrix.hpp"
+#include <memory>
 #include <type_traits>
 
 namespace Trilinos {
@@ -94,8 +95,8 @@ preconditioner to a multivector.
 \section Ifpack2_AdditiveSchwarz_Alg Algorithm
 
 One-level overlapping domain decomposition preconditioners use local
-solvers of Dirichlet type. This means that the solver effectively 
-applies the inverse of the local matrix (possibly with overlap) 
+solvers of Dirichlet type. This means that the solver effectively
+applies the inverse of the local matrix (possibly with overlap)
 to the residual to be preconditioned.
 
 The preconditioner can be written as:
@@ -836,6 +837,14 @@ private:
   Teuchos::RCP<inner_solver_type> Inverse_;
   //! Local distributed map for filtering multivector with no overlap.
   Teuchos::RCP<const map_type> localMap_;
+  //! Cached local (possibly) overlapping input (multi)vector.
+  mutable std::unique_ptr<MV> overlapping_B_;
+  //! Cached local (possibly) overlapping output (multi)vector.
+  mutable std::unique_ptr<MV> overlapping_Y_;
+  //! Cached residual (multi)vector.
+  mutable std::unique_ptr<MV> R_;
+  //! Cached intermediate result (multi)vector.
+  mutable std::unique_ptr<MV> C_;
 
   /// \brief Import object used in apply().
   ///

--- a/packages/ifpack2/src/Ifpack2_AdditiveSchwarz_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_AdditiveSchwarz_decl.hpp
@@ -310,26 +310,25 @@ public:
   //@{
 
   //! The type of the entries of the input MatrixType.
-  typedef typename MatrixType::scalar_type scalar_type;
+  using scalar_type = typename MatrixType::scalar_type;
 
   //! The type of local indices in the input MatrixType.
-  typedef typename MatrixType::local_ordinal_type local_ordinal_type;
+  using local_ordinal_type = typename MatrixType::local_ordinal_type;
 
   //! The type of global indices in the input MatrixType.
-  typedef typename MatrixType::global_ordinal_type global_ordinal_type;
+  using global_ordinal_type = typename MatrixType::global_ordinal_type;
 
   //! The Node type used by the input MatrixType.
-  typedef typename MatrixType::node_type node_type;
+  using node_type = typename MatrixType::node_type;
 
   //! The type of the magnitude (absolute value) of a matrix entry.
-  typedef typename Teuchos::ScalarTraits<scalar_type>::magnitudeType magnitude_type;
+  using magnitude_type =
+    typename Teuchos::ScalarTraits<scalar_type>::magnitudeType;
 
   //! The Tpetra::RowMatrix specialization matching MatrixType.
-  typedef Tpetra::RowMatrix<scalar_type,
-                            local_ordinal_type,
-                            global_ordinal_type,
-                            node_type> row_matrix_type;
-
+  using row_matrix_type =
+    Tpetra::RowMatrix<scalar_type, local_ordinal_type,
+                      global_ordinal_type, node_type>;
   //@}
   // \name Constructors and destructor
   //@{
@@ -352,7 +351,7 @@ public:
                    const int overlapLevel);
 
   //! Destructor
-  virtual ~AdditiveSchwarz();
+  virtual ~AdditiveSchwarz () = default;
 
   //@}
   //! \name Implementation of Tpetra::Operator
@@ -780,13 +779,13 @@ private:
   Teuchos::RCP<row_matrix_type> innerMatrix_;
 
   //! If true, the preconditioner has been successfully initialized.
-  bool IsInitialized_;
+  bool IsInitialized_ = false;
   //! If true, the preconditioner has been successfully computed.
-  bool IsComputed_;
+  bool IsComputed_ = false;
   //! If true, overlapping is used
-  bool IsOverlapping_;
+  bool IsOverlapping_ = false;
   //! Level of overlap among the processors.
-  int OverlapLevel_;
+  int OverlapLevel_ = 0;
 
   /// \brief A (deep) copy of the list given to setParameters().
   ///
@@ -799,40 +798,40 @@ private:
   mutable Teuchos::RCP<const Teuchos::ParameterList> validParams_;
 
   //! Combine mode for off-process elements (only if overlap is used)
-  Tpetra::CombineMode CombineMode_;
+  Tpetra::CombineMode CombineMode_ = Tpetra::ZERO;
   //! If \c true, reorder the local matrix.
-  bool UseReordering_;
+  bool UseReordering_ = false;
   //! Record reordering for output purposes.
-  std::string ReorderingAlgorithm_;
+  std::string ReorderingAlgorithm_ = "none";
   //! Whether to filter singleton rows.
-  bool FilterSingletons_;
+  bool FilterSingletons_ = false;
   //! Matrix from which singleton rows have been filtered.
   Teuchos::RCP<row_matrix_type> SingletonMatrix_;
   //! The number of iterations to be done.
-  int NumIterations_;
+  int NumIterations_ = 1;
   //! True if and only if the initial guess is zero.
-  bool ZeroStartingSolution_;
+  bool ZeroStartingSolution_ = true;
   //! Damping for inner update, if used
-  scalar_type UpdateDamping_;
+  scalar_type UpdateDamping_ = Teuchos::ScalarTraits<scalar_type>::one ();
 
   //! The total number of successful calls to initialize().
-  int NumInitialize_;
+  int NumInitialize_ = 0;
   //! The total number of successful calls to compute().
-  int NumCompute_;
+  int NumCompute_ = 0;
   //! The total number of successful calls to apply().
-  mutable int NumApply_;
+  mutable int NumApply_ = 0;
   //! The total time in seconds of all successful calls to initialize().
-  double InitializeTime_;
+  double InitializeTime_ = 0.0;
   //! The total time in seconds of all successful calls to compute().
-  double ComputeTime_;
+  double ComputeTime_ = 0.0;
   //! The total time in seconds of all successful calls to apply().
-  mutable double ApplyTime_;
+  mutable double ApplyTime_ = 0.0;
   //! The total number of floating-point operations over all initialize() calls.
-  double InitializeFlops_;
+  double InitializeFlops_ = 0.0;
   //! The total number of floating-point operations over all compute() calls.
-  double ComputeFlops_;
+  double ComputeFlops_ = 0.0;
   //! The total number of floating-point operations over all apply() calls.
-  mutable double ApplyFlops_;
+  mutable double ApplyFlops_ = 0.0;
   //! The inner (that is, per subdomain local) solver.
   Teuchos::RCP<inner_solver_type> Inverse_;
   //! Local distributed map for filtering multivector with no overlap.

--- a/packages/ifpack2/src/Ifpack2_AdditiveSchwarz_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_AdditiveSchwarz_def.hpp
@@ -230,7 +230,6 @@ AdditiveSchwarz<MatrixType, LocalInverseType>::innerPrecParams () const
   return std::make_pair (params, match);
 }
 
-
 template<class MatrixType, class LocalInverseType>
 std::string
 AdditiveSchwarz<MatrixType, LocalInverseType>::defaultInnerPrecName ()
@@ -240,68 +239,24 @@ AdditiveSchwarz<MatrixType, LocalInverseType>::defaultInnerPrecName ()
   return "ILUT";
 }
 
-
 template<class MatrixType, class LocalInverseType>
 AdditiveSchwarz<MatrixType, LocalInverseType>::
 AdditiveSchwarz (const Teuchos::RCP<const row_matrix_type>& A) :
-  Matrix_ (A),
-  IsInitialized_ (false),
-  IsComputed_ (false),
-  IsOverlapping_ (false),
-  OverlapLevel_ (0),
-  CombineMode_ (Tpetra::ZERO),
-  UseReordering_ (false),
-  ReorderingAlgorithm_ ("none"),
-  FilterSingletons_ (false),
-  NumIterations_(1),
-  ZeroStartingSolution_(true),
-  UpdateDamping_(Teuchos::ScalarTraits<scalar_type>::one()),
-  NumInitialize_ (0),
-  NumCompute_ (0),
-  NumApply_ (0),
-  InitializeTime_ (0.0),
-  ComputeTime_ (0.0),
-  ApplyTime_ (0.0)
-{
-  Teuchos::ParameterList plist;
-  setParameters (plist); // Set parameters to default values
-}
+  Matrix_ (A)
+{}
 
 template<class MatrixType, class LocalInverseType>
 AdditiveSchwarz<MatrixType, LocalInverseType>::
 AdditiveSchwarz (const Teuchos::RCP<const row_matrix_type>& A,
                  const int overlapLevel) :
   Matrix_ (A),
-  IsInitialized_ (false),
-  IsComputed_ (false),
-  IsOverlapping_ (false),
-  OverlapLevel_ (overlapLevel),
-  CombineMode_ (Tpetra::ZERO),
-  UseReordering_ (false),
-  ReorderingAlgorithm_ ("none"),
-  FilterSingletons_ (false),
-  NumIterations_(1),
-  ZeroStartingSolution_(true),
-  UpdateDamping_(Teuchos::ScalarTraits<scalar_type>::one()),
-  NumInitialize_ (0),
-  NumCompute_ (0),
-  NumApply_ (0),
-  InitializeTime_ (0.0),
-  ComputeTime_ (0.0),
-  ApplyTime_ (0.0)
-{
-  Teuchos::ParameterList plist;
-  setParameters (plist); // Set parameters to default values
-}
-
-
-template<class MatrixType,class LocalInverseType>
-AdditiveSchwarz<MatrixType,LocalInverseType>::~AdditiveSchwarz () {}
-
+  OverlapLevel_ (overlapLevel)
+{}
 
 template<class MatrixType,class LocalInverseType>
 Teuchos::RCP<const Tpetra::Map<typename MatrixType::local_ordinal_type, typename MatrixType::global_ordinal_type, typename MatrixType::node_type > >
-AdditiveSchwarz<MatrixType,LocalInverseType>::getDomainMap() const
+AdditiveSchwarz<MatrixType,LocalInverseType>::
+getDomainMap () const
 {
   TEUCHOS_TEST_FOR_EXCEPTION(
     Matrix_.is_null (), std::runtime_error, "Ifpack2::AdditiveSchwarz::"

--- a/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
@@ -96,7 +96,7 @@
 
 // ::: Experiments :::
 // define either pinned memory or cudamemory for mpi
-// if both macros are disabled, it will use tpetra memory space which is uvm space for cuda 
+// if both macros are disabled, it will use tpetra memory space which is uvm space for cuda
 // if defined, this use pinned memory instead of device pointer
 // by default, we enable pinned memory
 #define IFPACK2_BLOCKTRIDICONTAINER_USE_PINNED_MEMORY_FOR_MPI
@@ -130,7 +130,7 @@ namespace KB = KokkosBatched::Experimental;
     using MemoryTraits = Kokkos::MemoryTraits<MemoryTraitsType::Unmanaged |
                                               MemoryTraitsType::RandomAccess |
                                               flag>;
-    
+
     template <typename ViewType>
     using Unmanaged = Kokkos::View<typename ViewType::data_type,
                                    typename ViewType::array_layout,
@@ -140,17 +140,17 @@ namespace KB = KokkosBatched::Experimental;
     using Atomic = Kokkos::View<typename ViewType::data_type,
                                 typename ViewType::array_layout,
                                 typename ViewType::device_type,
-                                MemoryTraits<typename ViewType::memory_traits,Kokkos::Atomic> >;    
+                                MemoryTraits<typename ViewType::memory_traits,Kokkos::Atomic> >;
     template <typename ViewType>
-    using Const = Kokkos::View<typename ViewType::const_data_type, 
+    using Const = Kokkos::View<typename ViewType::const_data_type,
                                typename ViewType::array_layout,
-                               typename ViewType::device_type, 
+                               typename ViewType::device_type,
                                typename ViewType::memory_traits>;
     template <typename ViewType>
-    using ConstUnmanaged = Const<Unmanaged<ViewType> >;    
+    using ConstUnmanaged = Const<Unmanaged<ViewType> >;
 
     template <typename ViewType>
-    using AtomicUnmanaged = Atomic<Unmanaged<ViewType> >;    
+    using AtomicUnmanaged = Atomic<Unmanaged<ViewType> >;
 
     template <typename ViewType>
     using Unmanaged = Kokkos::View<typename ViewType::data_type,
@@ -170,8 +170,8 @@ namespace KB = KokkosBatched::Experimental;
     ///
     template<typename T> struct BlockTridiagScalarType { typedef T type; };
 #if defined(IFPACK2_BLOCKTRIDICONTAINER_USE_SMALL_SCALAR_FOR_BLOCKTRIDIAG)
-    template<> struct BlockTridiagScalarType<double> { typedef float type; };    
-    //template<> struct SmallScalarType<Kokkos::complex<double> > { typedef Kokkos::complex<float> type; };    
+    template<> struct BlockTridiagScalarType<double> { typedef float type; };
+    //template<> struct SmallScalarType<Kokkos::complex<double> > { typedef Kokkos::complex<float> type; };
 #endif
 
     ///
@@ -200,33 +200,33 @@ namespace KB = KokkosBatched::Experimental;
     template<typename T, int N>
     struct ArrayValueType {
       T v[N];
-      KOKKOS_INLINE_FUNCTION 
+      KOKKOS_INLINE_FUNCTION
       ArrayValueType() {
         for (int i=0;i<N;++i)
           this->v[i] = 0;
       }
-      KOKKOS_INLINE_FUNCTION 
+      KOKKOS_INLINE_FUNCTION
       ArrayValueType(const ArrayValueType &b) {
-        for (int i=0;i<N;++i) 
+        for (int i=0;i<N;++i)
           this->v[i] = b.v[i];
-      }      
+      }
     };
     template<typename T, int N>
-    static 
-    KOKKOS_INLINE_FUNCTION 
+    static
+    KOKKOS_INLINE_FUNCTION
     void
-    operator+=(volatile ArrayValueType<T,N> &a, 
+    operator+=(volatile ArrayValueType<T,N> &a,
                volatile const ArrayValueType<T,N> &b) {
-      for (int i=0;i<N;++i) 
+      for (int i=0;i<N;++i)
         a.v[i] += b.v[i];
     }
     template<typename T, int N>
-    static 
+    static
     KOKKOS_INLINE_FUNCTION
     void
-    operator+=(ArrayValueType<T,N> &a, 
+    operator+=(ArrayValueType<T,N> &a,
                const ArrayValueType<T,N> &b) {
-      for (int i=0;i<N;++i) 
+      for (int i=0;i<N;++i)
         a.v[i] += b.v[i];
     }
 
@@ -240,22 +240,22 @@ namespace KB = KokkosBatched::Experimental;
       typedef Kokkos::View<value_type,ExecSpace,Kokkos::MemoryTraits<Kokkos::Unmanaged> > result_view_type;
       value_type *value;
 
-      KOKKOS_INLINE_FUNCTION 
+      KOKKOS_INLINE_FUNCTION
       SumReducer(value_type &val) : value(&val) {}
 
-      KOKKOS_INLINE_FUNCTION 
+      KOKKOS_INLINE_FUNCTION
       void join(value_type &dst, value_type &src) const {
-        for (int i=0;i<N;++i) 
+        for (int i=0;i<N;++i)
           dst.v[i] += src.v[i];
       }
-      KOKKOS_INLINE_FUNCTION 
+      KOKKOS_INLINE_FUNCTION
       void join(volatile value_type &dst, const volatile value_type &src) const {
-        for (int i=0;i<N;++i) 
+        for (int i=0;i<N;++i)
           dst.v[i] += src.v[i];
-      }          
-      KOKKOS_INLINE_FUNCTION 
+      }
+      KOKKOS_INLINE_FUNCTION
       void init(value_type &val) const {
-        for (int i=0;i<N;++i)         
+        for (int i=0;i<N;++i)
           val.v[i] = Kokkos::reduction_identity<T>::sum();
       }
       KOKKOS_INLINE_FUNCTION
@@ -270,23 +270,23 @@ namespace KB = KokkosBatched::Experimental;
 
 #if defined(HAVE_IFPACK2_BLOCKTRIDICONTAINER_TIMERS)
 #define IFPACK2_BLOCKTRIDICONTAINER_TIMER(label) TEUCHOS_FUNC_TIME_MONITOR(label);
-#else 
-#define IFPACK2_BLOCKTRIDICONTAINER_TIMER(label) 
+#else
+#define IFPACK2_BLOCKTRIDICONTAINER_TIMER(label)
 #endif
-    
+
 #if defined(KOKKOS_ENABLE_CUDA) && defined(IFPACK2_BLOCKTRIDICONTAINER_ENABLE_PROFILE)
 #define IFPACK2_BLOCKTRIDICONTAINER_PROFILER_REGION_BEGIN \
-    CUDA_SAFE_CALL(cudaProfilerStart());                     
+    CUDA_SAFE_CALL(cudaProfilerStart());
 
-#define IFPACK2_BLOCKTRIDICONTAINER_PROFILER_REGION_END	\
+#define IFPACK2_BLOCKTRIDICONTAINER_PROFILER_REGION_END \
     { CUDA_SAFE_CALL( cudaProfilerStop() ); }
-#else 
+#else
     /// later put vtune profiler region
 #define IFPACK2_BLOCKTRIDICONTAINER_PROFILER_REGION_BEGIN
-#define IFPACK2_BLOCKTRIDICONTAINER_PROFILER_REGION_END    
+#define IFPACK2_BLOCKTRIDICONTAINER_PROFILER_REGION_END
 #endif
-    
-    /// 
+
+    ///
     /// implementation typedefs
     ///
     template <typename MatrixType>
@@ -299,7 +299,7 @@ namespace KB = KokkosBatched::Experimental;
       typedef typename MatrixType::local_ordinal_type local_ordinal_type;
       typedef typename MatrixType::global_ordinal_type global_ordinal_type;
       typedef typename MatrixType::node_type node_type;
-      
+
       ///
       /// kokkos arithmetic traits of scalar_type
       ///
@@ -313,11 +313,11 @@ namespace KB = KokkosBatched::Experimental;
       /// default host execution space
       ///
       typedef Kokkos::DefaultHostExecutionSpace host_execution_space;
-      
+
       ///
       /// tpetra types
       ///
-      typedef typename node_type::device_type node_device_type;      
+      typedef typename node_type::device_type node_device_type;
       typedef typename node_device_type::execution_space node_execution_space;
       typedef typename node_device_type::memory_space node_memory_space;
 
@@ -329,9 +329,9 @@ namespace KB = KokkosBatched::Experimental;
                                         node_memory_space>::type memory_space;
       typedef Kokkos::Device<execution_space,memory_space> device_type;
 #else
-      typedef node_device_type device_type;      
+      typedef node_device_type device_type;
       typedef node_execution_space execution_space;
-      typedef node_memory_space memory_space;      
+      typedef node_memory_space memory_space;
 #endif
 
       typedef Tpetra::MultiVector<scalar_type,local_ordinal_type,global_ordinal_type,node_type> tpetra_multivector_type;
@@ -357,7 +357,7 @@ namespace KB = KokkosBatched::Experimental;
       typedef Vector<SIMD<btdm_scalar_type>,internal_vector_length> internal_vector_type;
 
       ///
-      /// commonly used view types 
+      /// commonly used view types
       ///
       typedef Kokkos::View<size_type*,device_type> size_type_1d_view;
       typedef Kokkos::View<local_ordinal_type*,device_type> local_ordinal_type_1d_view;
@@ -365,7 +365,7 @@ namespace KB = KokkosBatched::Experimental;
       typedef Kokkos::View<impl_scalar_type*,device_type> impl_scalar_type_1d_view;
       typedef Kokkos::View<impl_scalar_type*,node_device_type> impl_scalar_type_1d_view_tpetra;
 
-      // tpetra multivector values (layout left): may need to change the typename more explicitly 
+      // tpetra multivector values (layout left): may need to change the typename more explicitly
       typedef Kokkos::View<impl_scalar_type**,Kokkos::LayoutLeft,device_type> impl_scalar_type_2d_view;
       typedef Kokkos::View<impl_scalar_type**,Kokkos::LayoutLeft,node_device_type> impl_scalar_type_2d_view_tpetra;
 
@@ -377,12 +377,12 @@ namespace KB = KokkosBatched::Experimental;
       typedef Kokkos::View<btdm_scalar_type***,Kokkos::LayoutRight,device_type> btdm_scalar_type_3d_view;
       typedef Kokkos::View<btdm_scalar_type****,Kokkos::LayoutRight,device_type> btdm_scalar_type_4d_view;
     };
-    
+
     ///
     /// setup sequential importer
     ///
     template<typename MatrixType>
-    typename Teuchos::RCP<const typename ImplType<MatrixType>::tpetra_import_type> 
+    typename Teuchos::RCP<const typename ImplType<MatrixType>::tpetra_import_type>
     createBlockCrsTpetraImporter(const Teuchos::RCP<const typename ImplType<MatrixType>::tpetra_block_crs_matrix_type> &A) {
       IFPACK2_BLOCKTRIDICONTAINER_TIMER("BlockTriDi::CreateBlockCrsTpetraImporter");
       using impl_type = ImplType<MatrixType>;
@@ -398,8 +398,8 @@ namespace KB = KokkosBatched::Experimental;
       return Teuchos::rcp(new tpetra_import_type(src, tgt));
     }
 
-    // Partial replacement for forward-mode MultiVector::doImport. 
-    // Permits overlapped communication and computation, but also supports sync'ed. 
+    // Partial replacement for forward-mode MultiVector::doImport.
+    // Permits overlapped communication and computation, but also supports sync'ed.
     // I'm finding that overlapped comm/comp can give quite poor performance on some
     // platforms, so we can't just use it straightforwardly always.
 
@@ -458,12 +458,12 @@ namespace KB = KokkosBatched::Experimental;
         CallbackDataArgsForSendRecv *in = reinterpret_cast<CallbackDataArgsForSendRecv*>(data);
         in->r_val = isend(in->comm, in->buf, in->count, in->pid, in->tag, in->ireq);
       }
-      
+
       static void CUDART_CB callback_irecv(cudaStream_t this_stream, cudaError_t status, void *data) {
         CallbackDataArgsForSendRecv *in = reinterpret_cast<CallbackDataArgsForSendRecv*>(data);
         in->r_val = irecv(in->comm, in->buf, in->count, in->pid, in->tag, in->ireq);
       }
-      
+
       static void CUDART_CB callback_wait(cudaStream_t this_stream, cudaError_t status, void *data) {
 #ifdef HAVE_IFPACK2_MPI
         MPI_Request *req = reinterpret_cast<MPI_Request*>(data);
@@ -471,7 +471,7 @@ namespace KB = KokkosBatched::Experimental;
 #endif // HAVE_IFPACK2_MPI
       }
 #endif // defined(KOKKOS_ENABLE_CUDA) && defined(IFPACK2_BLOCKTRIDICONTAINER_USE_CUDA_STREAM)
-      
+
       static int waitany(int count, MPI_Request* reqs, int* index) {
 #ifdef HAVE_IFPACK2_MPI
         return MPI_Waitany(count, reqs, index, MPI_STATUS_IGNORE);
@@ -498,7 +498,7 @@ namespace KB = KokkosBatched::Experimental;
       using impl_scalar_type = typename impl_type::impl_scalar_type;
 
       using int_1d_view_host = Kokkos::View<int*,Kokkos::HostSpace>;
-      using local_ordinal_type_1d_view_host = Kokkos::View<local_ordinal_type*,Kokkos::HostSpace>; 
+      using local_ordinal_type_1d_view_host = Kokkos::View<local_ordinal_type*,Kokkos::HostSpace>;
 
       using execution_space = typename impl_type::execution_space;
       using memory_space = typename impl_type::memory_space;
@@ -506,8 +506,8 @@ namespace KB = KokkosBatched::Experimental;
       using size_type_1d_view = typename impl_type::size_type_1d_view;
       using size_type_1d_view_host = Kokkos::View<size_type*,Kokkos::HostSpace>;
 
-#if defined(KOKKOS_ENABLE_CUDA) 
-      using impl_scalar_type_1d_view = 
+#if defined(KOKKOS_ENABLE_CUDA)
+      using impl_scalar_type_1d_view =
         typename std::conditional<std::is_same<execution_space,Kokkos::Cuda>::value,
 #  if defined(IFPACK2_BLOCKTRIDICONTAINER_USE_PINNED_MEMORY_FOR_MPI)
                                   Kokkos::View<impl_scalar_type*,Kokkos::CudaHostPinnedSpace>,
@@ -529,7 +529,7 @@ namespace KB = KokkosBatched::Experimental;
 
       impl_scalar_type_2d_view_tpetra remote_multivector;
       local_ordinal_type blocksize;
-      
+
       template<typename T>
       struct SendRecvPair {
         T send, recv;
@@ -555,20 +555,20 @@ namespace KB = KokkosBatched::Experimental;
 
       // for cuda
     public:
-      void setOffsetValues(const Teuchos::ArrayView<const size_t> &lens, 
-                           const size_type_1d_view &offs) { 
+      void setOffsetValues(const Teuchos::ArrayView<const size_t> &lens,
+                           const size_type_1d_view &offs) {
         // wrap lens to kokkos view and deep copy to device
         Kokkos::View<size_t*,Kokkos::HostSpace> lens_host(const_cast<size_t*>(lens.getRawPtr()), lens.size());
         const auto lens_device = Kokkos::create_mirror_view_and_copy(memory_space(), lens_host);
-        
+
         // exclusive scan
         const Kokkos::RangePolicy<execution_space> policy(0,offs.extent(0));
         const local_ordinal_type lens_size = lens_device.extent(0);
         Kokkos::parallel_scan
-          ("AsyncableImport::RangePolicy::setOffsetValues", 
+          ("AsyncableImport::RangePolicy::setOffsetValues",
            policy, KOKKOS_LAMBDA(const local_ordinal_type &i, size_type &update, const bool &final) {
-            if (final) 
-              offs(i) = update;            
+            if (final)
+              offs(i) = update;
             update += (i < lens_size ? lens_device[i] : 0);
           });
       }
@@ -586,10 +586,10 @@ namespace KB = KokkosBatched::Experimental;
         pids.send = int_1d_view_host(do_not_initialize_tag("pids send"), pids_to.size());
         memcpy(pids.send.data(), pids_to.getRawPtr(), sizeof(int)*pids.send.extent(0));
 
-        // mpi requests 
+        // mpi requests
         reqs.recv.resize(pids.recv.extent(0)); memset(reqs.recv.data(), 0, reqs.recv.size()*sizeof(MPI_Request));
         reqs.send.resize(pids.send.extent(0)); memset(reqs.send.data(), 0, reqs.send.size()*sizeof(MPI_Request));
-        
+
         // construct offsets
         const auto lengths_to = distributor.getLengthsTo();
         offset.send = size_type_1d_view(do_not_initialize_tag("offset send"), lengths_to.size() + 1);
@@ -597,10 +597,10 @@ namespace KB = KokkosBatched::Experimental;
         const auto lengths_from = distributor.getLengthsFrom();
         offset.recv = size_type_1d_view(do_not_initialize_tag("offset recv"), lengths_from.size() + 1);
 
-        setOffsetValues(lengths_to,   offset.send); 
+        setOffsetValues(lengths_to,   offset.send);
         offset_host.send = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), offset.send);
 
-        setOffsetValues(lengths_from, offset.recv); 
+        setOffsetValues(lengths_from, offset.recv);
         offset_host.recv = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), offset.recv);
       }
 
@@ -637,17 +637,17 @@ namespace KB = KokkosBatched::Experimental;
       struct ToMultiVector {};
 
       AsyncableImport (const Teuchos::RCP<const tpetra_map_type>& src_map,
-                       const Teuchos::RCP<const tpetra_map_type>& tgt_map, 
+                       const Teuchos::RCP<const tpetra_map_type>& tgt_map,
                        const local_ordinal_type blocksize_,
                        const local_ordinal_type_1d_view dm2cm_) {
         blocksize = blocksize_;
         dm2cm = dm2cm_;
-        
+
 #ifdef HAVE_IFPACK2_MPI
         comm = Tpetra::Details::extractMpiCommFromTeuchos(*tgt_map->getComm());
 #endif
         const tpetra_import_type import(src_map, tgt_map);
-        
+
         createMpiRequests(import);
         createSendRecvIDs(import);
 
@@ -656,15 +656,15 @@ namespace KB = KokkosBatched::Experimental;
           const local_ordinal_type num_streams = pids.send.extent(0);
           stream.send.resize(num_streams);
           callback_data.send.resize(num_streams);
-          for (local_ordinal_type i=0;i<num_streams;++i) 
-            CUDA_SAFE_CALL(cudaStreamCreate(&stream.send[i])); // nonblocking flag is not really necessary here 
+          for (local_ordinal_type i=0;i<num_streams;++i)
+            CUDA_SAFE_CALL(cudaStreamCreate(&stream.send[i])); // nonblocking flag is not really necessary here
         }
         {
           const local_ordinal_type num_streams = pids.recv.extent(0);
           stream.recv.resize(num_streams);
           callback_data.recv.resize(num_streams);
-          for (local_ordinal_type i=0;i<num_streams;++i) 
-            CUDA_SAFE_CALL(cudaStreamCreate(&stream.recv[i])); // nonblocking flag is not really necessary here 
+          for (local_ordinal_type i=0;i<num_streams;++i)
+            CUDA_SAFE_CALL(cudaStreamCreate(&stream.recv[i])); // nonblocking flag is not really necessary here
         }
 #endif
       }
@@ -673,15 +673,15 @@ namespace KB = KokkosBatched::Experimental;
 #if defined(KOKKOS_ENABLE_CUDA) && defined(IFPACK2_BLOCKTRIDICONTAINER_USE_CUDA_STREAM)
         {
           const local_ordinal_type num_streams = stream.send.size();
-          for (local_ordinal_type i=0;i<num_streams;++i) 
+          for (local_ordinal_type i=0;i<num_streams;++i)
             CUDA_SAFE_CALL(cudaStreamDestroy(stream.send[i]));
         }
         {
           const local_ordinal_type num_streams = stream.recv.size();
-          for (local_ordinal_type i=0;i<num_streams;++i) 
+          for (local_ordinal_type i=0;i<num_streams;++i)
             CUDA_SAFE_CALL(cudaStreamDestroy(stream.recv[i]));
         }
-#endif        
+#endif
       }
 
       void createDataBuffer(const local_ordinal_type &num_vectors) {
@@ -691,7 +691,7 @@ namespace KB = KokkosBatched::Experimental;
             remote_multivector.extent(1) == extent_1) {
           // skip
         } else {
-          remote_multivector = 
+          remote_multivector =
             impl_scalar_type_2d_view_tpetra(do_not_initialize_tag("remote multivector"), extent_0, extent_1);
 
           const auto send_buffer_size = offset_host.send[offset_host.send.extent(0)-1]*blocksize*num_vectors;
@@ -719,7 +719,7 @@ namespace KB = KokkosBatched::Experimental;
       static
       void copyViaCudaStream(const local_ordinal_type_1d_view &lids_,
                              const impl_scalar_type_1d_view &buffer_,
-                             const local_ordinal_type ibeg_, 
+                             const local_ordinal_type ibeg_,
                              const local_ordinal_type iend_,
                              const impl_scalar_type_2d_view_tpetra &multivector_,
                              const local_ordinal_type blocksize_,
@@ -735,20 +735,20 @@ namespace KB = KokkosBatched::Experimental;
         else if (blocksize_ <=  8) vector_size =  8;
         else if (blocksize_ <= 16) vector_size = 16;
         else                       vector_size = 32;
-        
+
         const auto exec_instance = Kokkos::Cuda(stream_);
         const auto work_item_property = Kokkos::Experimental::WorkItemProperty::HintLightWeight;
         const team_policy_type policy(exec_instance, idiff, 1, vector_size);
         Kokkos::parallel_for
-          (//"AsyncableImport::TeamPolicy::copyViaCudaStream", 
+          (//"AsyncableImport::TeamPolicy::copyViaCudaStream",
            Kokkos::Experimental::require(policy, work_item_property),
-           KOKKOS_LAMBDA(const typename team_policy_type::member_type &member) {          
+           KOKKOS_LAMBDA(const typename team_policy_type::member_type &member) {
             const local_ordinal_type i = member.league_rank();
             Kokkos::parallel_for
               (Kokkos::TeamThreadRange(member,num_vectors),[&](const local_ordinal_type &j) {
                 auto aptr = abase + blocksize_*(i + idiff*j);
                 auto bptr = &multivector_(blocksize_*lids_(i + ibeg_), j);
-                if (std::is_same<PackTag,ToBuffer>::value) 
+                if (std::is_same<PackTag,ToBuffer>::value)
                   Kokkos::parallel_for
                     (Kokkos::ThreadVectorRange(member,blocksize_),[&](const local_ordinal_type &k) {
                       aptr[k] = bptr[k];
@@ -760,8 +760,8 @@ namespace KB = KokkosBatched::Experimental;
                     });
               });
           });
-      } 
-      
+      }
+
       void asyncSendRecvViaCudaStream(const impl_scalar_type_2d_view_tpetra &mv) {
         IFPACK2_BLOCKTRIDICONTAINER_TIMER("BlockTriDi::AsyncableImport::AsyncSendRecv");
 
@@ -772,7 +772,7 @@ namespace KB = KokkosBatched::Experimental;
 
         // 0. post receive async
         for (local_ordinal_type i=0,iend=pids.recv.extent(0);i<iend;++i) {
-          irecv(comm, 
+          irecv(comm,
                 reinterpret_cast<char*>(buffer.recv.data() + offset_host.recv[i]*mv_blocksize),
                 (offset_host.recv[i+1] - offset_host.recv[i])*mv_blocksize*sizeof(impl_scalar_type),
                 pids.recv[i],
@@ -783,15 +783,15 @@ namespace KB = KokkosBatched::Experimental;
         // 1. async memcpy
 #if defined (KOKKOS_ENABLE_OPENMP)
 #pragma omp parallel for
-#endif        
+#endif
         for (local_ordinal_type i=0;i<static_cast<local_ordinal_type>(pids.send.extent(0));++i) {
           auto &stream_at_i = stream.send[i];
           // 1.0. enqueue pack buffer
-          copyViaCudaStream<ToBuffer>(lids.send, buffer.send, 
-                                      offset_host.send(i), offset_host.send(i+1), 
+          copyViaCudaStream<ToBuffer>(lids.send, buffer.send,
+                                      offset_host.send(i), offset_host.send(i+1),
                                       mv, blocksize,
                                       stream_at_i);
-          
+
           // // 1.1. enqueue call back posting isend , call back does not really work; what did I do wrong.
           // auto &data_at_i = callback_data.send[i];
           // data_at_i.comm = comm;
@@ -807,18 +807,18 @@ namespace KB = KokkosBatched::Experimental;
         Kokkos::fence();
 #if defined (KOKKOS_ENABLE_OPENMP)
 #pragma omp parallel for
-#endif        
+#endif
         for (local_ordinal_type i=0;i<static_cast<local_ordinal_type>(pids.send.extent(0));++i) {
           // 1.1. sync the stream and isend
           //CUDA_SAFE_CALL(cudaStreamSynchronize(stream_at_i));
-          isend(comm, 
+          isend(comm,
                 reinterpret_cast<const char*>(buffer.send.data() + offset_host.send[i]*mv_blocksize),
                 (offset_host.send[i+1] - offset_host.send[i])*mv_blocksize*sizeof(impl_scalar_type),
-                pids.send[i], 
+                pids.send[i],
                 42,
                 &reqs.send[i]);
         }
-        
+
         // 2. poke communication
         for (local_ordinal_type i=0,iend=pids.recv.extent(0);i<iend;++i) {
           int flag;
@@ -829,7 +829,7 @@ namespace KB = KokkosBatched::Experimental;
       }
 
       void syncRecvViaCudaStream() {
-	IFPACK2_BLOCKTRIDICONTAINER_TIMER("BlockTriDi::AsyncableImport::SyncRecv");
+        IFPACK2_BLOCKTRIDICONTAINER_TIMER("BlockTriDi::AsyncableImport::SyncRecv");
 #ifdef HAVE_IFPACK2_MPI
         // 0. wait for receive async.
 #if defined (KOKKOS_ENABLE_OPENMP)
@@ -839,14 +839,14 @@ namespace KB = KokkosBatched::Experimental;
           local_ordinal_type idx = i;
           auto &stream_at_idx = stream.recv[idx];
 
-          // 0.0. wait any 
+          // 0.0. wait any
           waitany(pids.recv.extent(0), reqs.recv.data(), &idx);
-          
+
           // 0.0. add call back for waiting version (not working, what did i do wrong?)
-          //CUDA_SAFE_CALL(cudaStreamAddCallback(stream_at_idx, callback_wait, (void*)&reqs.recv[idx], 0)); 
-          
+          //CUDA_SAFE_CALL(cudaStreamAddCallback(stream_at_idx, callback_wait, (void*)&reqs.recv[idx], 0));
+
           // 0.1. unpack data after data is moved into a device
-          copyViaCudaStream<ToMultiVector>(lids.recv, buffer.recv, 
+          copyViaCudaStream<ToMultiVector>(lids.recv, buffer.recv,
                                            offset_host.recv(idx), offset_host.recv(idx+1),
                                            remote_multivector, blocksize,
                                            stream_at_idx);
@@ -863,16 +863,16 @@ namespace KB = KokkosBatched::Experimental;
 
       // ======================================================================
       // Generic version without using cuda stream
-      // - only difference between cuda and host architecture is on using team 
+      // - only difference between cuda and host architecture is on using team
       //   or range policies.
       // ======================================================================
       template<typename PackTag>
-      static 
+      static
       void copy(const local_ordinal_type_1d_view &lids_,
                 const impl_scalar_type_1d_view &buffer_,
-                const local_ordinal_type &ibeg_, 
+                const local_ordinal_type &ibeg_,
                 const local_ordinal_type &iend_,
-                const impl_scalar_type_2d_view_tpetra &multivector_, 
+                const impl_scalar_type_2d_view_tpetra &multivector_,
                 const local_ordinal_type blocksize_) {
         const local_ordinal_type num_vectors = multivector_.extent(1);
         const local_ordinal_type mv_blocksize = blocksize_*num_vectors;
@@ -888,14 +888,14 @@ namespace KB = KokkosBatched::Experimental;
           else                       vector_size = 32;
           const team_policy_type policy(idiff, 1, vector_size);
           Kokkos::parallel_for
-            ("AsyncableImport::TeamPolicy::copy", 
-             policy, KOKKOS_LAMBDA(const typename team_policy_type::member_type &member) {          
+            ("AsyncableImport::TeamPolicy::copy",
+             policy, KOKKOS_LAMBDA(const typename team_policy_type::member_type &member) {
               const local_ordinal_type i = member.league_rank();
               Kokkos::parallel_for
                 (Kokkos::TeamThreadRange(member,num_vectors),[&](const local_ordinal_type &j) {
                   auto aptr = abase + blocksize_*(i + idiff*j);
                   auto bptr = &multivector_(blocksize_*lids_(i + ibeg_), j);
-                  if (std::is_same<PackTag,ToBuffer>::value) 
+                  if (std::is_same<PackTag,ToBuffer>::value)
                     Kokkos::parallel_for
                       (Kokkos::ThreadVectorRange(member,blocksize_),[&](const local_ordinal_type &k) {
                         aptr[k] = bptr[k];
@@ -910,7 +910,7 @@ namespace KB = KokkosBatched::Experimental;
 #endif
         } else {
 #if defined(__CUDA_ARCH__)
-          TEUCHOS_TEST_FOR_EXCEPT_MSG(true, "Error: CUDA should not see this code"); 
+          TEUCHOS_TEST_FOR_EXCEPT_MSG(true, "Error: CUDA should not see this code");
 #else
           {
             const Kokkos::RangePolicy<execution_space> policy(0, idiff*num_vectors);
@@ -932,7 +932,7 @@ namespace KB = KokkosBatched::Experimental;
       }
 
       void asyncSendRecv(const impl_scalar_type_2d_view_tpetra &mv) {
-	IFPACK2_BLOCKTRIDICONTAINER_TIMER("BlockTriDi::AsyncableImport::AsyncSendRecv");
+        IFPACK2_BLOCKTRIDICONTAINER_TIMER("BlockTriDi::AsyncableImport::AsyncSendRecv");
 
 #ifdef HAVE_IFPACK2_MPI
         // constants and reallocate data buffers if necessary
@@ -941,22 +941,22 @@ namespace KB = KokkosBatched::Experimental;
 
         // receive async
         for (local_ordinal_type i=0,iend=pids.recv.extent(0);i<iend;++i) {
-          irecv(comm, 
+          irecv(comm,
                 reinterpret_cast<char*>(buffer.recv.data() + offset_host.recv[i]*mv_blocksize),
                 (offset_host.recv[i+1] - offset_host.recv[i])*mv_blocksize*sizeof(impl_scalar_type),
                 pids.recv[i],
                 42,
                 &reqs.recv[i]);
         }
-        
+
         // send async
         for (local_ordinal_type i=0,iend=pids.send.extent(0);i<iend;++i) {
-          copy<ToBuffer>(lids.send, buffer.send, offset_host.send(i), offset_host.send(i+1), 
+          copy<ToBuffer>(lids.send, buffer.send, offset_host.send(i), offset_host.send(i+1),
                          mv, blocksize);
-          isend(comm, 
+          isend(comm,
                 reinterpret_cast<const char*>(buffer.send.data() + offset_host.send[i]*mv_blocksize),
                 (offset_host.send[i+1] - offset_host.send[i])*mv_blocksize*sizeof(impl_scalar_type),
-                pids.send[i], 
+                pids.send[i],
                 42,
                 &reqs.send[i]);
         }
@@ -972,7 +972,7 @@ namespace KB = KokkosBatched::Experimental;
       }
 
       void syncRecv() {
-	IFPACK2_BLOCKTRIDICONTAINER_TIMER("BlockTriDi::AsyncableImport::SyncRecv");
+        IFPACK2_BLOCKTRIDICONTAINER_TIMER("BlockTriDi::AsyncableImport::SyncRecv");
 #ifdef HAVE_IFPACK2_MPI
         // receive async.
         for (local_ordinal_type i=0,iend=pids.recv.extent(0);i<iend;++i) {
@@ -990,7 +990,7 @@ namespace KB = KokkosBatched::Experimental;
         IFPACK2_BLOCKTRIDICONTAINER_TIMER("BlockTriDi::AsyncableImport::SyncExchange");
 #if defined(KOKKOS_ENABLE_CUDA) && defined(IFPACK2_BLOCKTRIDICONTAINER_USE_CUDA_STREAM)
         asyncSendRecvViaCudaStream(mv);
-        syncRecvViaCudaStream();        
+        syncRecvViaCudaStream();
 #else
         asyncSendRecv(mv);
         syncRecv();
@@ -1004,7 +1004,7 @@ namespace KB = KokkosBatched::Experimental;
     /// setup async importer
     ///
     template<typename MatrixType>
-    Teuchos::RCP<AsyncableImport<MatrixType> > 
+    Teuchos::RCP<AsyncableImport<MatrixType> >
     createBlockCrsAsyncImporter(const Teuchos::RCP<const typename ImplType<MatrixType>::tpetra_block_crs_matrix_type> &A) {
       using impl_type = ImplType<MatrixType>;
       using tpetra_map_type = typename impl_type::tpetra_map_type;
@@ -1016,9 +1016,9 @@ namespace KB = KokkosBatched::Experimental;
       const auto blocksize = A->getBlockSize();
       const auto domain_map = g.getDomainMap();
       const auto column_map = g.getColMap();
-      
+
       std::vector<global_ordinal_type> gids;
-      bool separate_remotes = true, found_first = false, need_owned_permutation = false;      
+      bool separate_remotes = true, found_first = false, need_owned_permutation = false;
       for (size_t i=0;i<column_map->getNodeNumElements();++i) {
         const global_ordinal_type gid = column_map->getGlobalElement(i);
         if (!domain_map->isNodeGlobalElement(gid)) {
@@ -1028,7 +1028,7 @@ namespace KB = KokkosBatched::Experimental;
           separate_remotes = false;
           break;
         }
-        if (!need_owned_permutation && 
+        if (!need_owned_permutation &&
             domain_map->getLocalElement(gid) != static_cast<local_ordinal_type>(i)) {
           // The owned part of the domain and column maps are different
           // orderings. We *could* do a super efficient impl of this case in the
@@ -1041,10 +1041,10 @@ namespace KB = KokkosBatched::Experimental;
           need_owned_permutation = true;
         }
       }
-      
+
       if (separate_remotes) {
         const auto invalid = Teuchos::OrdinalTraits<global_ordinal_type>::invalid();
-        const auto parsimonious_col_map 
+        const auto parsimonious_col_map
           = Teuchos::rcp(new tpetra_map_type(invalid, gids.data(), gids.size(), 0, domain_map->getComm()));
         if (parsimonious_col_map->getGlobalNumElements() > 0) {
           // make the importer only if needed.
@@ -1053,7 +1053,7 @@ namespace KB = KokkosBatched::Experimental;
             dm2cm = local_ordinal_type_1d_view(do_not_initialize_tag("dm2cm"), domain_map->getNodeNumElements());
             const auto dm2cm_host = Kokkos::create_mirror_view(dm2cm);
             for (size_t i=0;i<domain_map->getNodeNumElements();++i)
-              dm2cm_host(i) = domain_map->getLocalElement(column_map->getGlobalElement(i));          
+              dm2cm_host(i) = domain_map->getLocalElement(column_map->getGlobalElement(i));
             Kokkos::deep_copy(dm2cm, dm2cm_host);
           }
           return Teuchos::rcp(new AsyncableImport<MatrixType>(domain_map, parsimonious_col_map, blocksize, dm2cm));
@@ -1118,7 +1118,7 @@ namespace KB = KokkosBatched::Experimental;
     /// setup part interface using the container partitions array
     ///
     template<typename MatrixType>
-    PartInterface<MatrixType> 
+    PartInterface<MatrixType>
     createPartInterface(const Teuchos::RCP<const typename ImplType<MatrixType>::tpetra_block_crs_matrix_type> &A,
                         const Teuchos::Array<Teuchos::Array<typename ImplType<MatrixType>::local_ordinal_type> > &partitions) {
       using impl_type = ImplType<MatrixType>;
@@ -1128,45 +1128,45 @@ namespace KB = KokkosBatched::Experimental;
       constexpr int vector_length = impl_type::vector_length;
 
       const auto comm = A->getRowMap()->getComm();
-      
+
       PartInterface<MatrixType> interf;
-      
+
       const bool jacobi = partitions.size() == 0;
       const local_ordinal_type A_n_lclrows = A->getNodeNumRows();
       const local_ordinal_type nparts = jacobi ? A_n_lclrows : partitions.size();
 
-#if defined(BLOCKTRIDICONTAINER_DEBUG)              
+#if defined(BLOCKTRIDICONTAINER_DEBUG)
       local_ordinal_type nrows = 0;
-      if (jacobi)       
+      if (jacobi)
         nrows = nparts;
-      else              
+      else
         for (local_ordinal_type i=0;i<nparts;++i) nrows += partitions[i].size();
 
       TEUCHOS_TEST_FOR_EXCEPT_MSG
         (nrows != A_n_lclrows, get_msg_prefix(comm) << "The #rows implied by the local partition is not "
          << "the same as getNodeNumRows: " << nrows << " vs " << A_n_lclrows);
 #endif
-      
+
       // permutation vector
       std::vector<local_ordinal_type> p;
       if (jacobi) {
-	interf.max_partsz = 1;
+        interf.max_partsz = 1;
       } else {
         // reorder parts to maximize simd packing efficiency
         p.resize(nparts);
-        
+
         typedef std::pair<local_ordinal_type,local_ordinal_type> size_idx_pair_type;
         std::vector<size_idx_pair_type> partsz(nparts);
         for (local_ordinal_type i=0;i<nparts;++i)
           partsz[i] = size_idx_pair_type(partitions[i].size(), i);
         std::sort(partsz.begin(), partsz.end(),
-                  [] (const size_idx_pair_type& x, const size_idx_pair_type& y) { 
-                    return x.first > y.first; 
+                  [] (const size_idx_pair_type& x, const size_idx_pair_type& y) {
+                    return x.first > y.first;
                   });
         for (local_ordinal_type i=0;i<nparts;++i)
           p[i] = partsz[i].second;
 
-	interf.max_partsz = partsz[0].first;
+        interf.max_partsz = partsz[0].first;
       }
 
       // allocate parts
@@ -1182,7 +1182,7 @@ namespace KB = KokkosBatched::Experimental;
       const auto part2rowidx0 = Kokkos::create_mirror_view(interf.part2rowidx0);
       const auto part2packrowidx0 = Kokkos::create_mirror_view(interf.part2packrowidx0);
       const auto rowidx2part = Kokkos::create_mirror_view(interf.rowidx2part);
-      
+
       // Determine parts.
       interf.row_contiguous = true;
       partptr(0) = 0;
@@ -1193,8 +1193,8 @@ namespace KB = KokkosBatched::Experimental;
         const auto* part = jacobi ? NULL : &partitions[p[ip]];
         const local_ordinal_type ipnrows = jacobi ? 1 : part->size();
         TEUCHOS_ASSERT(ip == 0 || (jacobi || ipnrows <= static_cast<local_ordinal_type>(partitions[p[ip-1]].size())));
-        TEUCHOS_TEST_FOR_EXCEPT_MSG(ipnrows == 0, 
-                                    get_msg_prefix(comm) 
+        TEUCHOS_TEST_FOR_EXCEPT_MSG(ipnrows == 0,
+                                    get_msg_prefix(comm)
                                     << "partition " << p[ip]
                                     << " is empty, which is not allowed.");
         //assume No overlap.
@@ -1206,10 +1206,10 @@ namespace KB = KokkosBatched::Experimental;
         const local_ordinal_type os = partptr(ip);
         for (local_ordinal_type i=0;i<ipnrows;++i) {
           const auto lcl_row = jacobi ? ip : (*part)[i];
-          TEUCHOS_TEST_FOR_EXCEPT_MSG(lcl_row < 0 || lcl_row >= A_n_lclrows, 
-                                      get_msg_prefix(comm) 
+          TEUCHOS_TEST_FOR_EXCEPT_MSG(lcl_row < 0 || lcl_row >= A_n_lclrows,
+                                      get_msg_prefix(comm)
                                       << "partitions[" << p[ip] << "]["
-                                      << i << "] = " << lcl_row 
+                                      << i << "] = " << lcl_row
                                       << " but input matrix implies limits of [0, " << A_n_lclrows-1
                                       << "].");
           lclrow(os+i) = lcl_row;
@@ -1219,7 +1219,7 @@ namespace KB = KokkosBatched::Experimental;
         }
         partptr(ip+1) = os + ipnrows;
       }
-#if defined(BLOCKTRIDICONTAINER_DEBUG)              
+#if defined(BLOCKTRIDICONTAINER_DEBUG)
       TEUCHOS_ASSERT(partptr(nparts) == nrows);
 #endif
       if (lclrow(0) != 0) interf.row_contiguous = false;
@@ -1279,26 +1279,26 @@ namespace KB = KokkosBatched::Experimental;
       BlockTridiags(const BlockTridiags &b) = default;
 
       // Index into row-major block of a tridiag.
-      template <typename idx_type> 
+      template <typename idx_type>
       static KOKKOS_FORCEINLINE_FUNCTION
       idx_type IndexToRow (const idx_type& ind) { return (ind + 1) / 3; }
       // Given a row of a row-major tridiag, return the index of the first block
       // in that row.
-      template <typename idx_type> 
+      template <typename idx_type>
       static KOKKOS_FORCEINLINE_FUNCTION
       idx_type RowToIndex (const idx_type& row) { return row > 0 ? 3*row - 1 : 0; }
       // Number of blocks in a tridiag having a given number of rows.
-      template <typename idx_type> 
+      template <typename idx_type>
       static KOKKOS_FORCEINLINE_FUNCTION
       idx_type NumBlocks (const idx_type& nrows) { return nrows > 0 ? 3*nrows - 2 : 0; }
     };
 
-    
+
     ///
     /// block tridiags initialization from part interface
-    /// 
+    ///
     template<typename MatrixType>
-    BlockTridiags<MatrixType> 
+    BlockTridiags<MatrixType>
     createBlockTridiags(const PartInterface<MatrixType> &interf) {
       using impl_type = ImplType<MatrixType>;
       using execution_space = typename impl_type::execution_space;
@@ -1311,26 +1311,26 @@ namespace KB = KokkosBatched::Experimental;
       BlockTridiags<MatrixType> btdm;
 
       const local_ordinal_type ntridiags = interf.partptr.extent(0) - 1;
-      
+
       { // construct the flat index pointers into the tridiag values array.
         btdm.flat_td_ptr = size_type_1d_view(do_not_initialize_tag("btdm.flat_td_ptr"), ntridiags + 1);
         const Kokkos::RangePolicy<execution_space> policy(0,ntridiags + 1);
         Kokkos::parallel_scan
-          ("createBlockTridiags::RangePolicy::flat_td_ptr", 
+          ("createBlockTridiags::RangePolicy::flat_td_ptr",
            policy, KOKKOS_LAMBDA(const local_ordinal_type &i, size_type &update, const bool &final) {
-            if (final) 
-              btdm.flat_td_ptr(i) = update;       
+            if (final)
+              btdm.flat_td_ptr(i) = update;
             if (i < ntridiags) {
               const local_ordinal_type nrows = interf.partptr(i+1) - interf.partptr(i);
               update += btdm.NumBlocks(nrows);
-            } 
+            }
           });
-        
+
         const auto nblocks = Kokkos::create_mirror_view_and_copy
           (Kokkos::HostSpace(), Kokkos::subview(btdm.flat_td_ptr, ntridiags));
         btdm.is_diagonal_only = (static_cast<local_ordinal_type>(nblocks()) == ntridiags);
       }
-      
+
       // And the packed index pointers.
       if (vector_length == 1) {
         btdm.pack_td_ptr = btdm.flat_td_ptr;
@@ -1339,7 +1339,7 @@ namespace KB = KokkosBatched::Experimental;
         btdm.pack_td_ptr = size_type_1d_view(do_not_initialize_tag("btdm.pack_td_ptr"), ntridiags + 1);
         const Kokkos::RangePolicy<execution_space> policy(0,npacks);
         Kokkos::parallel_scan
-          ("createBlockTridiags::RangePolicy::pack_td_ptr", 
+          ("createBlockTridiags::RangePolicy::pack_td_ptr",
            policy, KOKKOS_LAMBDA(const local_ordinal_type &i, size_type &update, const bool &final) {
             const local_ordinal_type parti      = interf.packptr(i);
             const local_ordinal_type parti_next = interf.packptr(i+1);
@@ -1349,14 +1349,14 @@ namespace KB = KokkosBatched::Experimental;
                 btdm.pack_td_ptr(pti) = nblks;
               const local_ordinal_type nrows = interf.partptr(parti+1) - interf.partptr(parti);
               // last one
-              if (i == npacks-1) 
+              if (i == npacks-1)
                 btdm.pack_td_ptr(ntridiags) = nblks + btdm.NumBlocks(nrows);
             }
             {
               const local_ordinal_type nrows = interf.partptr(parti+1) - interf.partptr(parti);
               update += btdm.NumBlocks(nrows);
             }
-          });        
+          });
       }
 
       // values and A_colindsub are created in the symbolic phase
@@ -1391,7 +1391,7 @@ namespace KB = KokkosBatched::Experimental;
       {
         const int vector_length = impl_type::vector_length;
         const int internal_vector_length = impl_type::internal_vector_length;
-        
+
         using btdm_scalar_type = typename impl_type::btdm_scalar_type;
         using internal_vector_type = typename impl_type::internal_vector_type;
         using internal_vector_type_4d_view =
@@ -1764,17 +1764,17 @@ namespace KB = KokkosBatched::Experimental;
       }
     }
 
-    
+
     ///
     /// numeric phase, initialize the preconditioner
     ///
     template<typename ArgActiveExecutionMemorySpace>
     struct ExtractAndFactorizeTridiagsDefaultModeAndAlgo;
-    
+
     template<>
     struct ExtractAndFactorizeTridiagsDefaultModeAndAlgo<Kokkos::HostSpace> {
       typedef KB::Mode::Serial mode_type;
-#if defined(__KOKKOSBATCHED_INTEL_MKL_COMPACT_BATCHED__) 
+#if defined(__KOKKOSBATCHED_INTEL_MKL_COMPACT_BATCHED__)
       typedef KB::Algo::Level3::CompactMKL algo_type;
 #else
       typedef KB::Algo::Level3::Blocked algo_type;
@@ -1782,43 +1782,43 @@ namespace KB = KokkosBatched::Experimental;
       static int recommended_team_size(const int /* blksize */,
                                        const int /* vector_length */,
                                        const int /* internal_vector_length */) {
-	return 1;
+        return 1;
       }
 
     };
-    
-#if defined(KOKKOS_ENABLE_CUDA) 
+
+#if defined(KOKKOS_ENABLE_CUDA)
     static inline int ExtractAndFactorizeRecommendedCudaTeamSize(const int blksize,
                                                                  const int vector_length,
-                                                                 const int internal_vector_length) {      
+                                                                 const int internal_vector_length) {
       const int vector_size = vector_length/internal_vector_length;
       int total_team_size(0);
       if      (blksize <=  5) total_team_size =  32;
-      else if (blksize <=  9) total_team_size =  32; // 64 
+      else if (blksize <=  9) total_team_size =  32; // 64
       else if (blksize <= 12) total_team_size =  96;
       else if (blksize <= 16) total_team_size = 128;
       else if (blksize <= 20) total_team_size = 160;
       else                    total_team_size = 160;
-      return 2*total_team_size/vector_size; 
+      return 2*total_team_size/vector_size;
     }
     template<>
     struct ExtractAndFactorizeTridiagsDefaultModeAndAlgo<Kokkos::CudaSpace> {
       typedef KB::Mode::Team mode_type;
       typedef KB::Algo::Level3::Unblocked algo_type;
-      static int recommended_team_size(const int blksize, 
-    				       const int vector_length, 
-    				       const int internal_vector_length) { 
-	return ExtractAndFactorizeRecommendedCudaTeamSize(blksize, vector_length, internal_vector_length);
+      static int recommended_team_size(const int blksize,
+                                       const int vector_length,
+                                       const int internal_vector_length) {
+        return ExtractAndFactorizeRecommendedCudaTeamSize(blksize, vector_length, internal_vector_length);
       }
     };
     template<>
     struct ExtractAndFactorizeTridiagsDefaultModeAndAlgo<Kokkos::CudaUVMSpace> {
       typedef KB::Mode::Team mode_type;
       typedef KB::Algo::Level3::Unblocked algo_type;
-      static int recommended_team_size(const int blksize, 
-    				       const int vector_length, 
-    				       const int internal_vector_length) { 
-	return ExtractAndFactorizeRecommendedCudaTeamSize(blksize, vector_length, internal_vector_length);
+      static int recommended_team_size(const int blksize,
+                                       const int vector_length,
+                                       const int internal_vector_length) {
+        return ExtractAndFactorizeRecommendedCudaTeamSize(blksize, vector_length, internal_vector_length);
       }
     };
 #endif
@@ -1839,9 +1839,9 @@ namespace KB = KokkosBatched::Experimental;
       using block_crs_matrix_type = typename impl_type::tpetra_block_crs_matrix_type;
       /// views
       using local_ordinal_type_1d_view = typename impl_type::local_ordinal_type_1d_view;
-      using size_type_1d_view = typename impl_type::size_type_1d_view; 
-      using impl_scalar_type_1d_view_tpetra = typename impl_type::impl_scalar_type_1d_view_tpetra; 
-      /// vectorization 
+      using size_type_1d_view = typename impl_type::size_type_1d_view;
+      using impl_scalar_type_1d_view_tpetra = typename impl_type::impl_scalar_type_1d_view_tpetra;
+      /// vectorization
       using btdm_scalar_type = typename impl_type::btdm_scalar_type;
       using btdm_magnitude_type = typename impl_type::btdm_magnitude_type;
       using vector_type_3d_view = typename impl_type::vector_type_3d_view;
@@ -1856,18 +1856,18 @@ namespace KB = KokkosBatched::Experimental;
 
       /// team policy member type
       using team_policy_type = Kokkos::TeamPolicy<execution_space>;
-      using member_type = typename team_policy_type::member_type;      
-      
+      using member_type = typename team_policy_type::member_type;
+
     private:
       // part interface
       const ConstUnmanaged<local_ordinal_type_1d_view> partptr, lclrow, packptr;
       const local_ordinal_type max_partsz;
       // block crs matrix (it could be Kokkos::UVMSpace::size_type, which is int)
-      using a_rowptr_value_type = typename Kokkos::ViewTraits<local_ordinal_type*,typename impl_type::node_device_type>::size_type; 
+      using a_rowptr_value_type = typename Kokkos::ViewTraits<local_ordinal_type*,typename impl_type::node_device_type>::size_type;
       using size_type_1d_view_tpetra = Kokkos::View<a_rowptr_value_type*,typename impl_type::node_device_type>;
       const ConstUnmanaged<size_type_1d_view_tpetra> A_rowptr;
       const ConstUnmanaged<impl_scalar_type_1d_view_tpetra> A_values;
-      // block tridiags 
+      // block tridiags
       const ConstUnmanaged<size_type_1d_view> pack_td_ptr, flat_td_ptr;
       const ConstUnmanaged<local_ordinal_type_1d_view> A_colindsub;
       const Unmanaged<internal_vector_type_4d_view> internal_vector_values;
@@ -1880,21 +1880,21 @@ namespace KB = KokkosBatched::Experimental;
       const local_ordinal_type vector_length_value;
 
     public:
-      ExtractAndFactorizeTridiags(const BlockTridiags<MatrixType> &btdm_, 
+      ExtractAndFactorizeTridiags(const BlockTridiags<MatrixType> &btdm_,
                                   const PartInterface<MatrixType> &interf_,
                                   const Teuchos::RCP<const block_crs_matrix_type> &A_,
                                   const magnitude_type& tiny_) :
         // interface
-        partptr(interf_.partptr), 
-        lclrow(interf_.lclrow), 
+        partptr(interf_.partptr),
+        lclrow(interf_.lclrow),
         packptr(interf_.packptr),
-	max_partsz(interf_.max_partsz),
+        max_partsz(interf_.max_partsz),
         // block crs matrix
-        A_rowptr(A_->getCrsGraph().getLocalGraph().row_map), 
+        A_rowptr(A_->getCrsGraph().getLocalGraph().row_map),
         A_values(const_cast<block_crs_matrix_type*>(A_.get())->template getValues<memory_space>()),
-        // block tridiags 
-        pack_td_ptr(btdm_.pack_td_ptr), 
-        flat_td_ptr(btdm_.flat_td_ptr), 
+        // block tridiags
+        pack_td_ptr(btdm_.pack_td_ptr),
+        flat_td_ptr(btdm_.flat_td_ptr),
         A_colindsub(btdm_.A_colindsub),
         internal_vector_values((internal_vector_type*)btdm_.values.data(),
                                btdm_.values.extent(0),
@@ -1910,15 +1910,15 @@ namespace KB = KokkosBatched::Experimental;
         blocksize_square(blocksize*blocksize),
         // diagonal weight to avoid zero pivots
         tiny(tiny_),
-	vector_loop_size(vector_length/internal_vector_length),
-	vector_length_value(vector_length) {}
+        vector_loop_size(vector_length/internal_vector_length),
+        vector_length_value(vector_length) {}
 
     private:
 
-      KOKKOS_INLINE_FUNCTION 
-      void 
-      extract(local_ordinal_type partidx, 
-	      local_ordinal_type npacks) const {
+      KOKKOS_INLINE_FUNCTION
+      void
+      extract(local_ordinal_type partidx,
+              local_ordinal_type npacks) const {
         const size_type kps = pack_td_ptr(partidx);
         local_ordinal_type kfs[vector_length] = {};
         local_ordinal_type ri0[vector_length] = {};
@@ -1942,7 +1942,7 @@ namespace KB = KokkosBatched::Experimental;
               for (local_ordinal_type jj=0;jj<blocksize;++jj) {
                 const auto idx = ii*blocksize + jj;
                 auto& v = internal_vector_values(pi, ii, jj, 0);
-                for (local_ordinal_type vi=0;vi<npacks;++vi) 
+                for (local_ordinal_type vi=0;vi<npacks;++vi)
                   v[vi] = static_cast<btdm_scalar_type>(block[vi][idx]);
               }
             }
@@ -1959,12 +1959,12 @@ namespace KB = KokkosBatched::Experimental;
         }
       }
 
-      KOKKOS_INLINE_FUNCTION 
-      void 
-      extract(const member_type &member, 
+      KOKKOS_INLINE_FUNCTION
+      void
+      extract(const member_type &member,
               const local_ordinal_type &partidxbeg,
-	      const local_ordinal_type &npacks,
-	      const local_ordinal_type &vbeg) const {
+              const local_ordinal_type &npacks,
+              const local_ordinal_type &vbeg) const {
         local_ordinal_type kfs_vals[internal_vector_length] = {};
         local_ordinal_type ri0_vals[internal_vector_length] = {};
         local_ordinal_type nrows_vals[internal_vector_length] = {};
@@ -1976,42 +1976,42 @@ namespace KB = KokkosBatched::Experimental;
           nrows_vals[vi] = partptr(partidxbeg+vi+1) - ri0_vals[vi];
         }
 
-        local_ordinal_type j_vals[internal_vector_length] = {};	
-	for (local_ordinal_type tr=0;tr<nrows_vals[0];++tr) {          
-	  for (local_ordinal_type v=vbeg,vi=0;v<npacks && vi<internal_vector_length;++v,++vi) {	
-	    const local_ordinal_type nrows = nrows_vals[vi];
-	    if (tr < nrows) {
-	      auto &j = j_vals[vi];
-	      const local_ordinal_type kfs = kfs_vals[vi];
-	      const local_ordinal_type ri0 = ri0_vals[vi];
-	      const local_ordinal_type lbeg = (tr == 0         ? 1 : 0);
-	      const local_ordinal_type lend = (tr == nrows - 1 ? 2 : 3);
-	      for (local_ordinal_type l=lbeg;l<lend;++l,++j) {
-		const size_type Aj = A_rowptr(lclrow(ri0 + tr)) + A_colindsub(kfs + j);
-		const impl_scalar_type* block = &A_values(Aj*blocksize_square);
-		const size_type pi = kps + j;
-		Kokkos::parallel_for
-		  (Kokkos::TeamThreadRange(member,blocksize), 
-		   [&](const local_ordinal_type &ii) {
-		    for (local_ordinal_type jj=0;jj<blocksize;++jj)
-		      scalar_values(pi, ii, jj, v) = static_cast<btdm_scalar_type>(block[ii*blocksize + jj]);
-		  });
-	      }
-	    }
+        local_ordinal_type j_vals[internal_vector_length] = {};
+        for (local_ordinal_type tr=0;tr<nrows_vals[0];++tr) {
+          for (local_ordinal_type v=vbeg,vi=0;v<npacks && vi<internal_vector_length;++v,++vi) {
+            const local_ordinal_type nrows = nrows_vals[vi];
+            if (tr < nrows) {
+              auto &j = j_vals[vi];
+              const local_ordinal_type kfs = kfs_vals[vi];
+              const local_ordinal_type ri0 = ri0_vals[vi];
+              const local_ordinal_type lbeg = (tr == 0         ? 1 : 0);
+              const local_ordinal_type lend = (tr == nrows - 1 ? 2 : 3);
+              for (local_ordinal_type l=lbeg;l<lend;++l,++j) {
+                const size_type Aj = A_rowptr(lclrow(ri0 + tr)) + A_colindsub(kfs + j);
+                const impl_scalar_type* block = &A_values(Aj*blocksize_square);
+                const size_type pi = kps + j;
+                Kokkos::parallel_for
+                  (Kokkos::TeamThreadRange(member,blocksize),
+                   [&](const local_ordinal_type &ii) {
+                    for (local_ordinal_type jj=0;jj<blocksize;++jj)
+                      scalar_values(pi, ii, jj, v) = static_cast<btdm_scalar_type>(block[ii*blocksize + jj]);
+                  });
+              }
+            }
           }
         }
       }
 
       template<typename AAViewType,
-	       typename WWViewType>
-      KOKKOS_INLINE_FUNCTION 
-      void 
-      factorize(const member_type &member, 
-		const local_ordinal_type &i0,
-		const local_ordinal_type &nrows,
+               typename WWViewType>
+      KOKKOS_INLINE_FUNCTION
+      void
+      factorize(const member_type &member,
+                const local_ordinal_type &i0,
+                const local_ordinal_type &nrows,
                 const local_ordinal_type &v,
-		const AAViewType &AA,
-		const WWViewType &WW) const {
+                const AAViewType &AA,
+                const WWViewType &WW) const {
         typedef ExtractAndFactorizeTridiagsDefaultModeAndAlgo
           <Kokkos::Impl::ActiveExecutionMemorySpace> default_mode_and_algo_type;
         typedef default_mode_and_algo_type::mode_type default_mode_type;
@@ -2050,78 +2050,78 @@ namespace KB = KokkosBatched::Experimental;
               ::invoke(member, A, tiny);
           }
         } else {
-	  // for block jacobi invert a matrix here
-	  auto W = Kokkos::subview(WW, Kokkos::ALL(), Kokkos::ALL(), v);
-	  KB::Copy<member_type,KB::Trans::NoTranspose,default_mode_type>
+          // for block jacobi invert a matrix here
+          auto W = Kokkos::subview(WW, Kokkos::ALL(), Kokkos::ALL(), v);
+          KB::Copy<member_type,KB::Trans::NoTranspose,default_mode_type>
             ::invoke(member, A, W);
-	  KB::SetIdentity<member_type,default_mode_type>
+          KB::SetIdentity<member_type,default_mode_type>
             ::invoke(member, A);
           member.team_barrier();
-	  KB::Trsm<member_type,
-		   KB::Side::Left,KB::Uplo::Lower,KB::Trans::NoTranspose,KB::Diag::Unit,
-		   default_mode_type,default_algo_type>
+          KB::Trsm<member_type,
+                   KB::Side::Left,KB::Uplo::Lower,KB::Trans::NoTranspose,KB::Diag::Unit,
+                   default_mode_type,default_algo_type>
             ::invoke(member, one, W, A);
-	  KB::Trsm<member_type,
-		   KB::Side::Left,KB::Uplo::Upper,KB::Trans::NoTranspose,KB::Diag::NonUnit,
-		   default_mode_type,default_algo_type>
+          KB::Trsm<member_type,
+                   KB::Side::Left,KB::Uplo::Upper,KB::Trans::NoTranspose,KB::Diag::NonUnit,
+                   default_mode_type,default_algo_type>
             ::invoke(member, one, W, A);
-	}
+        }
       }
 
     public:
 
       struct ExtractAndFactorizeTag {};
 
-      KOKKOS_INLINE_FUNCTION 
-      void 
+      KOKKOS_INLINE_FUNCTION
+      void
       operator() (const ExtractAndFactorizeTag &, const member_type &member) const {
-	// btdm is packed and sorted from largest one 
-	const local_ordinal_type packidx = member.league_rank();
+        // btdm is packed and sorted from largest one
+        const local_ordinal_type packidx = member.league_rank();
 
-	const local_ordinal_type partidx = packptr(packidx);
-	const local_ordinal_type npacks = packptr(packidx+1) - partidx;
-	const local_ordinal_type i0 = pack_td_ptr(partidx);
-	const local_ordinal_type nrows = partptr(partidx+1) - partptr(partidx);
+        const local_ordinal_type partidx = packptr(packidx);
+        const local_ordinal_type npacks = packptr(packidx+1) - partidx;
+        const local_ordinal_type i0 = pack_td_ptr(partidx);
+        const local_ordinal_type nrows = partptr(partidx+1) - partptr(partidx);
 
-	internal_vector_scratch_type_3d_view
-	  WW(member.team_scratch(0), blocksize, blocksize, vector_loop_size);
+        internal_vector_scratch_type_3d_view
+          WW(member.team_scratch(0), blocksize, blocksize, vector_loop_size);
         if (vector_loop_size == 1) {
           extract(partidx, npacks);
           factorize(member, i0, nrows, 0, internal_vector_values, WW);
-        } else {          
+        } else {
           Kokkos::parallel_for
             (Kokkos::ThreadVectorRange(member, vector_loop_size), [&](const local_ordinal_type &v) {
               const local_ordinal_type vbeg = v*internal_vector_length;
-              if (vbeg < npacks) 
+              if (vbeg < npacks)
                 extract(member, partidx+vbeg, npacks, vbeg);
-	      factorize(member, i0, nrows, v, internal_vector_values, WW);
+              factorize(member, i0, nrows, v, internal_vector_values, WW);
             });
         }
       }
 
       void run() {
-	IFPACK2_BLOCKTRIDICONTAINER_PROFILER_REGION_BEGIN;
-	const local_ordinal_type team_size = 
-	  ExtractAndFactorizeTridiagsDefaultModeAndAlgo<typename execution_space::memory_space>::
-	  recommended_team_size(blocksize, vector_length, internal_vector_length);
-	const local_ordinal_type per_team_scratch = internal_vector_scratch_type_3d_view::
-	  shmem_size(blocksize, blocksize, vector_loop_size);
+        IFPACK2_BLOCKTRIDICONTAINER_PROFILER_REGION_BEGIN;
+        const local_ordinal_type team_size =
+          ExtractAndFactorizeTridiagsDefaultModeAndAlgo<typename execution_space::memory_space>::
+          recommended_team_size(blocksize, vector_length, internal_vector_length);
+        const local_ordinal_type per_team_scratch = internal_vector_scratch_type_3d_view::
+          shmem_size(blocksize, blocksize, vector_loop_size);
 
-	Kokkos::TeamPolicy<execution_space,ExtractAndFactorizeTag>
-	  policy(packptr.extent(0)-1, team_size, vector_loop_size); 
+        Kokkos::TeamPolicy<execution_space,ExtractAndFactorizeTag>
+          policy(packptr.extent(0)-1, team_size, vector_loop_size);
 #if defined(KOKKOS_ENABLE_DEPRECATED_CODE)
-	Kokkos::parallel_for("ExtractAndFactorize::TeamPolicy::run<ExtractAndFactorizeTag>", 
-			     policy.set_scratch_size(0,Kokkos::PerTeam(per_team_scratch)), *this);
+        Kokkos::parallel_for("ExtractAndFactorize::TeamPolicy::run<ExtractAndFactorizeTag>",
+                             policy.set_scratch_size(0,Kokkos::PerTeam(per_team_scratch)), *this);
 #else
         policy.set_scratch_size(0,Kokkos::PerTeam(per_team_scratch));
-	Kokkos::parallel_for("ExtractAndFactorize::TeamPolicy::run<ExtractAndFactorizeTag>", 
+        Kokkos::parallel_for("ExtractAndFactorize::TeamPolicy::run<ExtractAndFactorizeTag>",
                              policy, *this);
 #endif
-	IFPACK2_BLOCKTRIDICONTAINER_PROFILER_REGION_END;
+        IFPACK2_BLOCKTRIDICONTAINER_PROFILER_REGION_END;
       }
-      
-    }; 
-    
+
+    };
+
     ///
     /// top level numeric interface
     ///
@@ -2135,7 +2135,7 @@ namespace KB = KokkosBatched::Experimental;
       ExtractAndFactorizeTridiags<MatrixType> function(btdm, interf, A, tiny);
       function.run();
     }
-    
+
     ///
     /// pack multivector
     ///
@@ -2156,7 +2156,7 @@ namespace KB = KokkosBatched::Experimental;
       static constexpr int vector_length = impl_type::vector_length;
 
       using member_type = typename Kokkos::TeamPolicy<execution_space>::member_type;
-      
+
     private:
       // part interface
       const ConstUnmanaged<local_ordinal_type_1d_view> partptr;
@@ -2173,19 +2173,19 @@ namespace KB = KokkosBatched::Experimental;
 
       template<typename TagType>
       KOKKOS_INLINE_FUNCTION
-      void copy_multivectors(const local_ordinal_type &j, 
-                             const local_ordinal_type &vi, 
-                             const local_ordinal_type &pri, 
+      void copy_multivectors(const local_ordinal_type &j,
+                             const local_ordinal_type &vi,
+                             const local_ordinal_type &pri,
                              const local_ordinal_type &ri0) const {
-	for (local_ordinal_type col=0;col<num_vectors;++col) 
-	  for (local_ordinal_type i=0;i<blocksize;++i)
-	    packed_multivector(pri, i, col)[vi] = static_cast<btdm_scalar_type>(scalar_multivector(blocksize*lclrow(ri0+j)+i,col));
+        for (local_ordinal_type col=0;col<num_vectors;++col)
+          for (local_ordinal_type i=0;i<blocksize;++i)
+            packed_multivector(pri, i, col)[vi] = static_cast<btdm_scalar_type>(scalar_multivector(blocksize*lclrow(ri0+j)+i,col));
       }
 
     public:
 
-      MultiVectorConverter(const PartInterface<MatrixType> &interf,                    
-                           const vector_type_3d_view &pmv) 
+      MultiVectorConverter(const PartInterface<MatrixType> &interf,
+                           const vector_type_3d_view &pmv)
         : partptr(interf.partptr),
           packptr(interf.packptr),
           part2packrowidx0(interf.part2packrowidx0),
@@ -2197,7 +2197,7 @@ namespace KB = KokkosBatched::Experimental;
 
       // TODO:: modify this routine similar to the team level functions
       inline
-      void 
+      void
       operator() (const local_ordinal_type &packidx) const {
         local_ordinal_type partidx = packptr(packidx);
         local_ordinal_type npacks = packptr(packidx+1) - partidx;
@@ -2209,70 +2209,70 @@ namespace KB = KokkosBatched::Experimental;
           ri0[v] = part2rowidx0(partidx);
           nrows[v] = part2rowidx0(partidx+1) - ri0[v];
         }
-        for (local_ordinal_type j=0;j<nrows[0];++j) {          
+        for (local_ordinal_type j=0;j<nrows[0];++j) {
           local_ordinal_type cnt = 1;
           for (;cnt<npacks && j!= nrows[cnt];++cnt);
           npacks = cnt;
           const local_ordinal_type pri = pri0 + j;
-	  for (local_ordinal_type col=0;col<num_vectors;++col) 
-	    for (local_ordinal_type i=0;i<blocksize;++i)
-	      for (local_ordinal_type v=0;v<npacks;++v) 
-		packed_multivector(pri, i, col)[v] = static_cast<btdm_scalar_type>(scalar_multivector(blocksize*lclrow(ri0[v]+j)+i,col));
+          for (local_ordinal_type col=0;col<num_vectors;++col)
+            for (local_ordinal_type i=0;i<blocksize;++i)
+              for (local_ordinal_type v=0;v<npacks;++v)
+                packed_multivector(pri, i, col)[v] = static_cast<btdm_scalar_type>(scalar_multivector(blocksize*lclrow(ri0[v]+j)+i,col));
         }
       }
 
       KOKKOS_INLINE_FUNCTION
-      void 
+      void
       operator() (const member_type &member) const {
         const local_ordinal_type packidx = member.league_rank();
         const local_ordinal_type partidx_begin = packptr(packidx);
         const local_ordinal_type npacks = packptr(packidx+1) - partidx_begin;
         const local_ordinal_type pri0 = part2packrowidx0(partidx_begin);
-	Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, npacks), [&](const local_ordinal_type &v) {
-	    const local_ordinal_type partidx = partidx_begin + v;
-	    const local_ordinal_type ri0 = part2rowidx0(partidx);
-	    const local_ordinal_type nrows = part2rowidx0(partidx+1) - ri0;
-	    
-	    if (nrows == 1) {
-	      const local_ordinal_type pri = pri0;
-	      for (local_ordinal_type col=0;col<num_vectors;++col) {
-		Kokkos::parallel_for(Kokkos::TeamThreadRange(member, blocksize), [&](const local_ordinal_type &i) {
-		    packed_multivector(pri, i, col)[v] = static_cast<btdm_scalar_type>(scalar_multivector(blocksize*lclrow(ri0)+i,col));
-		  });
-	      }
-	    } else {
-	      Kokkos::parallel_for(Kokkos::TeamThreadRange(member, nrows), [&](const local_ordinal_type &j) {
-		  const local_ordinal_type pri = pri0 + j;
-		  for (local_ordinal_type col=0;col<num_vectors;++col) 
-		    for (local_ordinal_type i=0;i<blocksize;++i)
-		      packed_multivector(pri, i, col)[v] = static_cast<btdm_scalar_type>(scalar_multivector(blocksize*lclrow(ri0+j)+i,col));
-		});
-	    }
+        Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, npacks), [&](const local_ordinal_type &v) {
+            const local_ordinal_type partidx = partidx_begin + v;
+            const local_ordinal_type ri0 = part2rowidx0(partidx);
+            const local_ordinal_type nrows = part2rowidx0(partidx+1) - ri0;
+
+            if (nrows == 1) {
+              const local_ordinal_type pri = pri0;
+              for (local_ordinal_type col=0;col<num_vectors;++col) {
+                Kokkos::parallel_for(Kokkos::TeamThreadRange(member, blocksize), [&](const local_ordinal_type &i) {
+                    packed_multivector(pri, i, col)[v] = static_cast<btdm_scalar_type>(scalar_multivector(blocksize*lclrow(ri0)+i,col));
+                  });
+              }
+            } else {
+              Kokkos::parallel_for(Kokkos::TeamThreadRange(member, nrows), [&](const local_ordinal_type &j) {
+                  const local_ordinal_type pri = pri0 + j;
+                  for (local_ordinal_type col=0;col<num_vectors;++col)
+                    for (local_ordinal_type i=0;i<blocksize;++i)
+                      packed_multivector(pri, i, col)[v] = static_cast<btdm_scalar_type>(scalar_multivector(blocksize*lclrow(ri0+j)+i,col));
+                });
+            }
           });
       }
-      
+
       void run(const impl_scalar_type_2d_view_tpetra &scalar_multivector_) {
-	IFPACK2_BLOCKTRIDICONTAINER_PROFILER_REGION_BEGIN;
+        IFPACK2_BLOCKTRIDICONTAINER_PROFILER_REGION_BEGIN;
         IFPACK2_BLOCKTRIDICONTAINER_TIMER("BlockTriDi::MultiVectorConverter");
 
         scalar_multivector = scalar_multivector_;
         if (is_cuda<execution_space>::value) {
 #if defined(KOKKOS_ENABLE_CUDA)
-	  const local_ordinal_type vl = vector_length;
+          const local_ordinal_type vl = vector_length;
           const Kokkos::TeamPolicy<execution_space> policy(packptr.extent(0) - 1, Kokkos::AUTO(), vl);
           Kokkos::parallel_for
             ("MultiVectorConverter::TeamPolicy", policy, *this);
 #endif
         } else {
 #if defined(__CUDA_ARCH__)
-          TEUCHOS_TEST_FOR_EXCEPT_MSG(true, "Error: CUDA should not see this code"); 
+          TEUCHOS_TEST_FOR_EXCEPT_MSG(true, "Error: CUDA should not see this code");
 #else
           const Kokkos::RangePolicy<execution_space> policy(0, packptr.extent(0) - 1);
           Kokkos::parallel_for
             ("MultiVectorConverter::RangePolicy", policy, *this);
 #endif
         }
-	IFPACK2_BLOCKTRIDICONTAINER_PROFILER_REGION_END;
+        IFPACK2_BLOCKTRIDICONTAINER_PROFILER_REGION_END;
       }
     };
 
@@ -2281,12 +2281,12 @@ namespace KB = KokkosBatched::Experimental;
     ///
     template<typename ArgActiveExecutionMemorySpace>
     struct SolveTridiagsDefaultModeAndAlgo;
-    
+
     template<>
     struct SolveTridiagsDefaultModeAndAlgo<Kokkos::HostSpace> {
       typedef KB::Mode::Serial mode_type;
       typedef KB::Algo::Level2::Unblocked single_vector_algo_type;
-#if defined(__KOKKOSBATCHED_INTEL_MKL_COMPACT_BATCHED__) 
+#if defined(__KOKKOSBATCHED_INTEL_MKL_COMPACT_BATCHED__)
       typedef KB::Algo::Level3::CompactMKL multi_vector_algo_type;
 #else
       typedef KB::Algo::Level3::Blocked multi_vector_algo_type;
@@ -2294,14 +2294,14 @@ namespace KB = KokkosBatched::Experimental;
       static int recommended_team_size(const int /* blksize */,
                                        const int /* vector_length */,
                                        const int /* internal_vector_length */) {
-	return 1; 
+        return 1;
       }
     };
-    
-#if defined(KOKKOS_ENABLE_CUDA) 
+
+#if defined(KOKKOS_ENABLE_CUDA)
     static inline int SolveTridiagsRecommendedCudaTeamSize(const int blksize,
                                                            const int vector_length,
-                                                           const int internal_vector_length) {      
+                                                           const int internal_vector_length) {
       const int vector_size = vector_length/internal_vector_length;
       int total_team_size(0);
       if      (blksize <=  5) total_team_size =  32;
@@ -2310,7 +2310,7 @@ namespace KB = KokkosBatched::Experimental;
       else if (blksize <= 16) total_team_size = 128;
       else if (blksize <= 20) total_team_size = 160;
       else                    total_team_size = 160;
-      return total_team_size/vector_size; 
+      return total_team_size/vector_size;
     }
 
     template<>
@@ -2318,10 +2318,10 @@ namespace KB = KokkosBatched::Experimental;
       typedef KB::Mode::Team mode_type;
       typedef KB::Algo::Level2::Unblocked single_vector_algo_type;
       typedef KB::Algo::Level3::Unblocked multi_vector_algo_type;
-      static int recommended_team_size(const int blksize, 
-				       const int vector_length, 
-				       const int internal_vector_length) { 
-	return SolveTridiagsRecommendedCudaTeamSize(blksize, vector_length, internal_vector_length);
+      static int recommended_team_size(const int blksize,
+                                       const int vector_length,
+                                       const int internal_vector_length) {
+        return SolveTridiagsRecommendedCudaTeamSize(blksize, vector_length, internal_vector_length);
       }
     };
     template<>
@@ -2329,10 +2329,10 @@ namespace KB = KokkosBatched::Experimental;
       typedef KB::Mode::Team mode_type;
       typedef KB::Algo::Level2::Unblocked single_vector_algo_type;
       typedef KB::Algo::Level3::Unblocked multi_vector_algo_type;
-      static int recommended_team_size(const int blksize, 
-    				       const int vector_length, 
-    				       const int internal_vector_length) { 
-	return SolveTridiagsRecommendedCudaTeamSize(blksize, vector_length, internal_vector_length);
+      static int recommended_team_size(const int blksize,
+                                       const int vector_length,
+                                       const int internal_vector_length) {
+        return SolveTridiagsRecommendedCudaTeamSize(blksize, vector_length, internal_vector_length);
       }
     };
 #endif
@@ -2351,8 +2351,8 @@ namespace KB = KokkosBatched::Experimental;
       using btdm_magnitude_type = typename impl_type::btdm_magnitude_type;
       /// views
       using local_ordinal_type_1d_view = typename impl_type::local_ordinal_type_1d_view;
-      using size_type_1d_view = typename impl_type::size_type_1d_view; 
-      /// vectorization 
+      using size_type_1d_view = typename impl_type::size_type_1d_view;
+      /// vectorization
       using vector_type_3d_view = typename impl_type::vector_type_3d_view;
       using internal_vector_type_4d_view = typename impl_type::internal_vector_type_4d_view;
       //using btdm_scalar_type_4d_view = typename impl_type::btdm_scalar_type_4d_view;
@@ -2369,8 +2369,8 @@ namespace KB = KokkosBatched::Experimental;
 
       /// team policy types
       using team_policy_type = Kokkos::TeamPolicy<execution_space>;
-      using member_type = typename team_policy_type::member_type;      
- 
+      using member_type = typename team_policy_type::member_type;
+
     private:
       // part interface
       const ConstUnmanaged<local_ordinal_type_1d_view> partptr;
@@ -2378,13 +2378,13 @@ namespace KB = KokkosBatched::Experimental;
       const ConstUnmanaged<local_ordinal_type_1d_view> part2packrowidx0;
       const ConstUnmanaged<local_ordinal_type_1d_view> lclrow;
 
-      // block tridiags 
+      // block tridiags
       const ConstUnmanaged<size_type_1d_view> pack_td_ptr;
 
       // block tridiags values
       const ConstUnmanaged<internal_vector_type_4d_view> D_internal_vector_values;
       const Unmanaged<internal_vector_type_4d_view> X_internal_vector_values;
-      
+
       const local_ordinal_type vector_loop_size;
 
       // copy to multivectors : damping factor and Y_scalar_multivector
@@ -2398,34 +2398,34 @@ namespace KB = KokkosBatched::Experimental;
       const bool compute_diff;
 
     public:
-      SolveTridiags(const PartInterface<MatrixType> &interf,                    
-                    const BlockTridiags<MatrixType> &btdm, 
+      SolveTridiags(const PartInterface<MatrixType> &interf,
+                    const BlockTridiags<MatrixType> &btdm,
                     const vector_type_3d_view &pmv,
-		    const impl_scalar_type damping_factor,
-		    const bool is_norm_manager_active) 
+                    const impl_scalar_type damping_factor,
+                    const bool is_norm_manager_active)
         :
         // interface
-        partptr(interf.partptr), 
+        partptr(interf.partptr),
         packptr(interf.packptr),
         part2packrowidx0(interf.part2packrowidx0),
-	lclrow(interf.lclrow),
+        lclrow(interf.lclrow),
         // block tridiags and  multivector
-        pack_td_ptr(btdm.pack_td_ptr), 
+        pack_td_ptr(btdm.pack_td_ptr),
         D_internal_vector_values((internal_vector_type*)btdm.values.data(),
-                                 btdm.values.extent(0), 
-                                 btdm.values.extent(1), 
-                                 btdm.values.extent(2), 
+                                 btdm.values.extent(0),
+                                 btdm.values.extent(1),
+                                 btdm.values.extent(2),
                                  vector_length/internal_vector_length),
         X_internal_vector_values((internal_vector_type*)pmv.data(),
-                                 pmv.extent(0), 
-                                 pmv.extent(1), 
-                                 pmv.extent(2), 
+                                 pmv.extent(0),
+                                 pmv.extent(1),
+                                 pmv.extent(2),
                                  vector_length/internal_vector_length),
-	vector_loop_size(vector_length/internal_vector_length),
-	Y_scalar_multivector(),
-	Z_scalar_vector(),
-	df(damping_factor),
-	compute_diff(is_norm_manager_active)	
+        vector_loop_size(vector_length/internal_vector_length),
+        Y_scalar_multivector(),
+        Z_scalar_vector(),
+        df(damping_factor),
+        compute_diff(is_norm_manager_active)
       {}
 
     public:
@@ -2434,112 +2434,112 @@ namespace KB = KokkosBatched::Experimental;
       KOKKOS_INLINE_FUNCTION
       void
       copyToFlatMultiVector(const member_type &member,
-			    const local_ordinal_type partidxbeg, // partidx for v = 0
-			    const local_ordinal_type npacks,
-			    const local_ordinal_type pri0,
-			    const local_ordinal_type v, // index with a loop of vector_loop_size
-			    const local_ordinal_type blocksize,
-			    const local_ordinal_type num_vectors) const {
-	const local_ordinal_type vbeg = v*internal_vector_length;
-	if (vbeg < npacks) {
-	  local_ordinal_type ri0_vals[internal_vector_length] = {};
-	  local_ordinal_type nrows_vals[internal_vector_length] = {};
-	  for (local_ordinal_type vv=vbeg,vi=0;vv<npacks && vi<internal_vector_length;++vv,++vi) {	
-	    const local_ordinal_type partidx = partidxbeg+vv;
-	    ri0_vals[vi] = partptr(partidx);
-	    nrows_vals[vi] = partptr(partidx+1) - ri0_vals[vi];
-	  }
+                            const local_ordinal_type partidxbeg, // partidx for v = 0
+                            const local_ordinal_type npacks,
+                            const local_ordinal_type pri0,
+                            const local_ordinal_type v, // index with a loop of vector_loop_size
+                            const local_ordinal_type blocksize,
+                            const local_ordinal_type num_vectors) const {
+        const local_ordinal_type vbeg = v*internal_vector_length;
+        if (vbeg < npacks) {
+          local_ordinal_type ri0_vals[internal_vector_length] = {};
+          local_ordinal_type nrows_vals[internal_vector_length] = {};
+          for (local_ordinal_type vv=vbeg,vi=0;vv<npacks && vi<internal_vector_length;++vv,++vi) {
+            const local_ordinal_type partidx = partidxbeg+vv;
+            ri0_vals[vi] = partptr(partidx);
+            nrows_vals[vi] = partptr(partidx+1) - ri0_vals[vi];
+          }
 
           impl_scalar_type z_partial_sum(0);
-	  if (nrows_vals[0] == 1) {
-	    const local_ordinal_type j=0, pri=pri0;
-	    {
-	      for (local_ordinal_type vv=vbeg,vi=0;vv<npacks && vi<internal_vector_length;++vv,++vi) {
-		const local_ordinal_type ri0 = ri0_vals[vi];
-		const local_ordinal_type nrows = nrows_vals[vi];
-		if (j < nrows) {
-		  Kokkos::parallel_for
-		    (Kokkos::TeamThreadRange(member, blocksize), 
-		     [&](const local_ordinal_type &i) {
-		      const local_ordinal_type row = blocksize*lclrow(ri0+j)+i;
-		      for (local_ordinal_type col=0;col<num_vectors;++col) {
-			impl_scalar_type &y = Y_scalar_multivector(row,col);
-			const impl_scalar_type yd = X_internal_vector_values(pri, i, col, v)[vi] - y;
-			y  += df*yd;
-			
-			{//if (compute_diff) {
+          if (nrows_vals[0] == 1) {
+            const local_ordinal_type j=0, pri=pri0;
+            {
+              for (local_ordinal_type vv=vbeg,vi=0;vv<npacks && vi<internal_vector_length;++vv,++vi) {
+                const local_ordinal_type ri0 = ri0_vals[vi];
+                const local_ordinal_type nrows = nrows_vals[vi];
+                if (j < nrows) {
+                  Kokkos::parallel_for
+                    (Kokkos::TeamThreadRange(member, blocksize),
+                     [&](const local_ordinal_type &i) {
+                      const local_ordinal_type row = blocksize*lclrow(ri0+j)+i;
+                      for (local_ordinal_type col=0;col<num_vectors;++col) {
+                        impl_scalar_type &y = Y_scalar_multivector(row,col);
+                        const impl_scalar_type yd = X_internal_vector_values(pri, i, col, v)[vi] - y;
+                        y  += df*yd;
+
+                        {//if (compute_diff) {
                           const auto yd_abs = Kokkos::ArithTraits<impl_scalar_type>::abs(yd);
                           z_partial_sum += yd_abs*yd_abs;
                         }
                       }
-		    });
-		}
-	      }
-	    }
-	  } else {
-	    Kokkos::parallel_for
-	      (Kokkos::TeamThreadRange(member, nrows_vals[0]), 
-	       [&](const local_ordinal_type &j) {
-	  	const local_ordinal_type pri = pri0 + j;
-	  	for (local_ordinal_type vv=vbeg,vi=0;vv<npacks && vi<internal_vector_length;++vv,++vi) {
-	  	  const local_ordinal_type ri0 = ri0_vals[vi];
-	  	  const local_ordinal_type nrows = nrows_vals[vi];
-	  	  if (j < nrows) {
-	  	    for (local_ordinal_type col=0;col<num_vectors;++col) {
-	  	      for (local_ordinal_type i=0;i<blocksize;++i) {
-	  		const local_ordinal_type row = blocksize*lclrow(ri0+j)+i;
-	  		impl_scalar_type &y = Y_scalar_multivector(row,col);
-	  		const impl_scalar_type yd = X_internal_vector_values(pri, i, col, v)[vi] - y;
-	  		y += df*yd;
+                    });
+                }
+              }
+            }
+          } else {
+            Kokkos::parallel_for
+              (Kokkos::TeamThreadRange(member, nrows_vals[0]),
+               [&](const local_ordinal_type &j) {
+                const local_ordinal_type pri = pri0 + j;
+                for (local_ordinal_type vv=vbeg,vi=0;vv<npacks && vi<internal_vector_length;++vv,++vi) {
+                  const local_ordinal_type ri0 = ri0_vals[vi];
+                  const local_ordinal_type nrows = nrows_vals[vi];
+                  if (j < nrows) {
+                    for (local_ordinal_type col=0;col<num_vectors;++col) {
+                      for (local_ordinal_type i=0;i<blocksize;++i) {
+                        const local_ordinal_type row = blocksize*lclrow(ri0+j)+i;
+                        impl_scalar_type &y = Y_scalar_multivector(row,col);
+                        const impl_scalar_type yd = X_internal_vector_values(pri, i, col, v)[vi] - y;
+                        y += df*yd;
 
-			{//if (compute_diff) {
+                        {//if (compute_diff) {
                           const auto yd_abs = Kokkos::ArithTraits<impl_scalar_type>::abs(yd);
                           z_partial_sum += yd_abs*yd_abs;
                         }
-	  	      }
-	  	    }
-	  	  }
-	  	}
-	      });
-	  }
-          //if (compute_diff) 
+                      }
+                    }
+                  }
+                }
+              });
+          }
+          //if (compute_diff)
             Z_scalar_vector(member.league_rank()) += z_partial_sum;
-	}
+        }
       }
 
       ///
       /// cuda team vectorization
       ///
       template<typename WWViewType>
-      KOKKOS_INLINE_FUNCTION 
-      void 
-      solveSingleVector(const member_type &member, 
+      KOKKOS_INLINE_FUNCTION
+      void
+      solveSingleVector(const member_type &member,
                         const local_ordinal_type &blocksize,
                         const local_ordinal_type &i0,
                         const local_ordinal_type &r0,
                         const local_ordinal_type &nrows,
                         const local_ordinal_type &v,
-			const WWViewType &WW) const {
+                        const WWViewType &WW) const {
         typedef SolveTridiagsDefaultModeAndAlgo
           <Kokkos::Impl::ActiveExecutionMemorySpace> default_mode_and_algo_type;
         typedef default_mode_and_algo_type::mode_type default_mode_type;
         typedef default_mode_and_algo_type::single_vector_algo_type default_algo_type;
-        
+
         // base pointers
         auto A = D_internal_vector_values.data();
         auto X = X_internal_vector_values.data();
 
         // constant
         const auto one = Kokkos::ArithTraits<btdm_magnitude_type>::one();
-	const auto zero = Kokkos::ArithTraits<btdm_magnitude_type>::zero();
+        const auto zero = Kokkos::ArithTraits<btdm_magnitude_type>::zero();
         //const local_ordinal_type num_vectors = X_scalar_values.extent(2);
 
         // const local_ordinal_type blocksize = D_scalar_values.extent(1);
         const local_ordinal_type astep = D_internal_vector_values.stride_0();
-        const local_ordinal_type as0 = D_internal_vector_values.stride_1(); //blocksize*vector_length; 
+        const local_ordinal_type as0 = D_internal_vector_values.stride_1(); //blocksize*vector_length;
         const local_ordinal_type as1 = D_internal_vector_values.stride_2(); //vector_length;
         const local_ordinal_type xstep = X_internal_vector_values.stride_0();
-        const local_ordinal_type xs0 = X_internal_vector_values.stride_1(); //vector_length; 
+        const local_ordinal_type xs0 = X_internal_vector_values.stride_1(); //vector_length;
 
         // for multiple rhs
         //const local_ordinal_type xs0 = num_vectors*vector_length; //X_scalar_values.stride_1();
@@ -2548,16 +2548,16 @@ namespace KB = KokkosBatched::Experimental;
         // move to starting point
         A += i0*astep + v;
         X += r0*xstep + v;
-        
-        //for (local_ordinal_type col=0;col<num_vectors;++col) 
+
+        //for (local_ordinal_type col=0;col<num_vectors;++col)
         if (nrows > 1) {
           // solve Lx = x
           KOKKOSBATCHED_TRSV_LOWER_NO_TRANSPOSE_INTERNAL_INVOKE
-            (default_mode_type,default_algo_type, 
+            (default_mode_type,default_algo_type,
              member,
              KB::Diag::Unit,
              blocksize,blocksize,
-             one, 
+             one,
              A, as0, as1,
              X, xs0);
 
@@ -2577,21 +2577,21 @@ namespace KB = KokkosBatched::Experimental;
                member,
                KB::Diag::Unit,
                blocksize,blocksize,
-               one, 
+               one,
                A+3*astep, as0, as1,
                X+1*xstep, xs0);
-            
+
             A += 3*astep;
             X += 1*xstep;
           }
-          
+
           // solve Ux = x
           KOKKOSBATCHED_TRSV_UPPER_NO_TRANSPOSE_INTERNAL_INVOKE
             (default_mode_type,default_algo_type,
              member,
              KB::Diag::NonUnit,
              blocksize, blocksize,
-             one, 
+             one,
              A, as0, as1,
              X, xs0);
 
@@ -2606,23 +2606,23 @@ namespace KB = KokkosBatched::Experimental;
                X, xs0,
                one,
                X-1*xstep, xs0);
-            
+
             KOKKOSBATCHED_TRSV_UPPER_NO_TRANSPOSE_INTERNAL_INVOKE
               (default_mode_type,default_algo_type,
                member,
                KB::Diag::NonUnit,
                blocksize, blocksize,
-               one, 
+               one,
                A, as0, as1,
                X-1*xstep,xs0);
-            
+
             X -= 1*xstep;
           }
           // for multiple rhs
           //X += xs1;
-	} else {
-	  const local_ordinal_type ws0 = WW.stride_0();
-	  auto W = WW.data() + v;
+        } else {
+          const local_ordinal_type ws0 = WW.stride_0();
+          auto W = WW.data() + v;
           KOKKOSBATCHED_COPY_VECTOR_NO_TRANSPOSE_INTERNAL_INVOKE
             (default_mode_type,
              member, blocksize, X, xs0, W, ws0);
@@ -2633,29 +2633,29 @@ namespace KB = KokkosBatched::Experimental;
              one,
              A, as0, as1,
              W, xs0,
-	     zero,
+             zero,
              X, xs0);
-	}
+        }
       }
-      
+
       template<typename WWViewType>
-      KOKKOS_INLINE_FUNCTION 
-      void 
-      solveMultiVector(const member_type &member, 
+      KOKKOS_INLINE_FUNCTION
+      void
+      solveMultiVector(const member_type &member,
                        const local_ordinal_type &/* blocksize */,
                        const local_ordinal_type &i0,
                        const local_ordinal_type &r0,
                        const local_ordinal_type &nrows,
                        const local_ordinal_type &v,
-		       const WWViewType &WW) const {
+                       const WWViewType &WW) const {
         typedef SolveTridiagsDefaultModeAndAlgo
           <Kokkos::Impl::ActiveExecutionMemorySpace> default_mode_and_algo_type;
         typedef default_mode_and_algo_type::mode_type default_mode_type;
         typedef default_mode_and_algo_type::multi_vector_algo_type default_algo_type;
-        
+
         // constant
         const auto one = Kokkos::ArithTraits<btdm_magnitude_type>::one();
-	const auto zero = Kokkos::ArithTraits<btdm_magnitude_type>::zero();
+        const auto zero = Kokkos::ArithTraits<btdm_magnitude_type>::zero();
 
         // subview pattern
         auto A  = Kokkos::subview(D_internal_vector_values, i0, Kokkos::ALL(), Kokkos::ALL(), v);
@@ -2665,184 +2665,184 @@ namespace KB = KokkosBatched::Experimental;
         local_ordinal_type i = i0, r = r0;
 
 
-	if (nrows > 1) {
-	  // solve Lx = x
-	  KB::Trsm<member_type,
-		   KB::Side::Left,KB::Uplo::Lower,KB::Trans::NoTranspose,KB::Diag::Unit,
-		   default_mode_type,default_algo_type>
-	    ::invoke(member, one, A, X1);
-	  for (local_ordinal_type tr=1;tr<nrows;++tr,i+=3) {
-	    A.assign_data( &D_internal_vector_values(i+2,0,0,v) );
-	    X2.assign_data( &X_internal_vector_values(++r,0,0,v) );
-	    KB::Gemm<member_type,
-		     KB::Trans::NoTranspose,KB::Trans::NoTranspose,
-		     default_mode_type,default_algo_type>
-	      ::invoke(member, -one, A, X1, one, X2);
-	    A.assign_data( &D_internal_vector_values(i+3,0,0,v) );
-	    KB::Trsm<member_type,
-		     KB::Side::Left,KB::Uplo::Lower,KB::Trans::NoTranspose,KB::Diag::Unit,
-		     default_mode_type,default_algo_type>
-	      ::invoke(member, one, A, X2);
-	    X1.assign_data( X2.data() );
-	  }
-	  
-	  // solve Ux = x
-	  KB::Trsm<member_type,
-		   KB::Side::Left,KB::Uplo::Upper,KB::Trans::NoTranspose,KB::Diag::NonUnit,
-		   default_mode_type,default_algo_type>
-	    ::invoke(member, one, A, X1);
-	  for (local_ordinal_type tr=nrows;tr>1;--tr) {
-	    i -= 3;
-	    A.assign_data( &D_internal_vector_values(i+1,0,0,v) );
-	    X2.assign_data( &X_internal_vector_values(--r,0,0,v) );          
-	    KB::Gemm<member_type,
-		     KB::Trans::NoTranspose,KB::Trans::NoTranspose,
-		     default_mode_type,default_algo_type>                   
-	      ::invoke(member, -one, A, X1, one, X2); 
-	    A.assign_data( &D_internal_vector_values(i,0,0,v) );          
-	    KB::Trsm<member_type,
-		     KB::Side::Left,KB::Uplo::Upper,KB::Trans::NoTranspose,KB::Diag::NonUnit,
-		     default_mode_type,default_algo_type>
-	      ::invoke(member, one, A, X2);
-	    X1.assign_data( X2.data() );
-	  }
-	} else {
-	  // matrix is already inverted
-	  auto W = Kokkos::subview(WW, Kokkos::ALL(), Kokkos::ALL(), v);
-	  KB::Copy<member_type,KB::Trans::NoTranspose,default_mode_type>
+        if (nrows > 1) {
+          // solve Lx = x
+          KB::Trsm<member_type,
+                   KB::Side::Left,KB::Uplo::Lower,KB::Trans::NoTranspose,KB::Diag::Unit,
+                   default_mode_type,default_algo_type>
+            ::invoke(member, one, A, X1);
+          for (local_ordinal_type tr=1;tr<nrows;++tr,i+=3) {
+            A.assign_data( &D_internal_vector_values(i+2,0,0,v) );
+            X2.assign_data( &X_internal_vector_values(++r,0,0,v) );
+            KB::Gemm<member_type,
+                     KB::Trans::NoTranspose,KB::Trans::NoTranspose,
+                     default_mode_type,default_algo_type>
+              ::invoke(member, -one, A, X1, one, X2);
+            A.assign_data( &D_internal_vector_values(i+3,0,0,v) );
+            KB::Trsm<member_type,
+                     KB::Side::Left,KB::Uplo::Lower,KB::Trans::NoTranspose,KB::Diag::Unit,
+                     default_mode_type,default_algo_type>
+              ::invoke(member, one, A, X2);
+            X1.assign_data( X2.data() );
+          }
+
+          // solve Ux = x
+          KB::Trsm<member_type,
+                   KB::Side::Left,KB::Uplo::Upper,KB::Trans::NoTranspose,KB::Diag::NonUnit,
+                   default_mode_type,default_algo_type>
+            ::invoke(member, one, A, X1);
+          for (local_ordinal_type tr=nrows;tr>1;--tr) {
+            i -= 3;
+            A.assign_data( &D_internal_vector_values(i+1,0,0,v) );
+            X2.assign_data( &X_internal_vector_values(--r,0,0,v) );
+            KB::Gemm<member_type,
+                     KB::Trans::NoTranspose,KB::Trans::NoTranspose,
+                     default_mode_type,default_algo_type>
+              ::invoke(member, -one, A, X1, one, X2);
+            A.assign_data( &D_internal_vector_values(i,0,0,v) );
+            KB::Trsm<member_type,
+                     KB::Side::Left,KB::Uplo::Upper,KB::Trans::NoTranspose,KB::Diag::NonUnit,
+                     default_mode_type,default_algo_type>
+              ::invoke(member, one, A, X2);
+            X1.assign_data( X2.data() );
+          }
+        } else {
+          // matrix is already inverted
+          auto W = Kokkos::subview(WW, Kokkos::ALL(), Kokkos::ALL(), v);
+          KB::Copy<member_type,KB::Trans::NoTranspose,default_mode_type>
             ::invoke(member, X1, W);
-	  KB::Gemm<member_type,
-		   KB::Trans::NoTranspose,KB::Trans::NoTranspose,
-		   default_mode_type,default_algo_type>
+          KB::Gemm<member_type,
+                   KB::Trans::NoTranspose,KB::Trans::NoTranspose,
+                   default_mode_type,default_algo_type>
             ::invoke(member, one, A, W, zero, X1);
-	}
+        }
       }
 
       template<int B> struct SingleVectorTag {};
       template<int B> struct MultiVectorTag {};
-      
-      template<int B>
-      KOKKOS_INLINE_FUNCTION 
-      void 
-      operator() (const SingleVectorTag<B> &, const member_type &member) const {
-	const local_ordinal_type packidx = member.league_rank();
-	const local_ordinal_type partidx = packptr(packidx);	
-        const local_ordinal_type npacks = packptr(packidx+1) - partidx;
-        const local_ordinal_type pri0 = part2packrowidx0(partidx);
-	const local_ordinal_type i0 = pack_td_ptr(partidx);
-	const local_ordinal_type r0 = part2packrowidx0(partidx);
-        const local_ordinal_type nrows = partptr(partidx+1) - partptr(partidx);
-        const local_ordinal_type blocksize = (B == 0 ? D_internal_vector_values.extent(1) : B);      
-	const local_ordinal_type num_vectors = 1;
-	internal_vector_scratch_type_3d_view
-	  WW(member.team_scratch(0), blocksize, 1, vector_loop_size);
-        Kokkos::single(Kokkos::PerTeam(member), [&]() {
-            Z_scalar_vector(member.league_rank()) = impl_scalar_type(0);
-          }); 
-	Kokkos::parallel_for
-	  (Kokkos::ThreadVectorRange(member, vector_loop_size),[&](const int &v) {
-	    solveSingleVector(member, blocksize, i0, r0, nrows, v, WW);
-	    copyToFlatMultiVector(member, partidx, npacks, pri0, v, blocksize, num_vectors);
-	  });
-      }      
 
       template<int B>
-      KOKKOS_INLINE_FUNCTION 
-      void 
-      operator() (const MultiVectorTag<B> &, const member_type &member) const {
-	const local_ordinal_type packidx = member.league_rank();
-	const local_ordinal_type partidx = packptr(packidx);	
+      KOKKOS_INLINE_FUNCTION
+      void
+      operator() (const SingleVectorTag<B> &, const member_type &member) const {
+        const local_ordinal_type packidx = member.league_rank();
+        const local_ordinal_type partidx = packptr(packidx);
         const local_ordinal_type npacks = packptr(packidx+1) - partidx;
         const local_ordinal_type pri0 = part2packrowidx0(partidx);
-	const local_ordinal_type i0 = pack_td_ptr(partidx);
-	const local_ordinal_type r0 = part2packrowidx0(partidx);
+        const local_ordinal_type i0 = pack_td_ptr(partidx);
+        const local_ordinal_type r0 = part2packrowidx0(partidx);
         const local_ordinal_type nrows = partptr(partidx+1) - partptr(partidx);
         const local_ordinal_type blocksize = (B == 0 ? D_internal_vector_values.extent(1) : B);
-	const local_ordinal_type num_vectors = X_internal_vector_values.extent(2);
+        const local_ordinal_type num_vectors = 1;
+        internal_vector_scratch_type_3d_view
+          WW(member.team_scratch(0), blocksize, 1, vector_loop_size);
+        Kokkos::single(Kokkos::PerTeam(member), [&]() {
+            Z_scalar_vector(member.league_rank()) = impl_scalar_type(0);
+          });
+        Kokkos::parallel_for
+          (Kokkos::ThreadVectorRange(member, vector_loop_size),[&](const int &v) {
+            solveSingleVector(member, blocksize, i0, r0, nrows, v, WW);
+            copyToFlatMultiVector(member, partidx, npacks, pri0, v, blocksize, num_vectors);
+          });
+      }
 
-	internal_vector_scratch_type_3d_view
+      template<int B>
+      KOKKOS_INLINE_FUNCTION
+      void
+      operator() (const MultiVectorTag<B> &, const member_type &member) const {
+        const local_ordinal_type packidx = member.league_rank();
+        const local_ordinal_type partidx = packptr(packidx);
+        const local_ordinal_type npacks = packptr(packidx+1) - partidx;
+        const local_ordinal_type pri0 = part2packrowidx0(partidx);
+        const local_ordinal_type i0 = pack_td_ptr(partidx);
+        const local_ordinal_type r0 = part2packrowidx0(partidx);
+        const local_ordinal_type nrows = partptr(partidx+1) - partptr(partidx);
+        const local_ordinal_type blocksize = (B == 0 ? D_internal_vector_values.extent(1) : B);
+        const local_ordinal_type num_vectors = X_internal_vector_values.extent(2);
+
+        internal_vector_scratch_type_3d_view
           WW(member.team_scratch(0), blocksize, num_vectors, vector_loop_size);
         Kokkos::single(Kokkos::PerTeam(member), [&]() {
             Z_scalar_vector(member.league_rank()) = impl_scalar_type(0);
-          }); 
-	Kokkos::parallel_for
-	  (Kokkos::ThreadVectorRange(member, vector_loop_size),[&](const int &v) {
-	    solveMultiVector(member, blocksize, i0, r0, nrows, v, WW);
-	    copyToFlatMultiVector(member, partidx, npacks, pri0, v, blocksize, num_vectors);
-	  });
-      }      
+          });
+        Kokkos::parallel_for
+          (Kokkos::ThreadVectorRange(member, vector_loop_size),[&](const int &v) {
+            solveMultiVector(member, blocksize, i0, r0, nrows, v, WW);
+            copyToFlatMultiVector(member, partidx, npacks, pri0, v, blocksize, num_vectors);
+          });
+      }
 
       void run(const impl_scalar_type_2d_view_tpetra &Y,
-	       const impl_scalar_type_1d_view &Z) {
-	IFPACK2_BLOCKTRIDICONTAINER_PROFILER_REGION_BEGIN;
-	IFPACK2_BLOCKTRIDICONTAINER_TIMER("BlockTriDi::SolveTridiags");
+               const impl_scalar_type_1d_view &Z) {
+        IFPACK2_BLOCKTRIDICONTAINER_PROFILER_REGION_BEGIN;
+        IFPACK2_BLOCKTRIDICONTAINER_TIMER("BlockTriDi::SolveTridiags");
 
-	/// set vectors 
-	this->Y_scalar_multivector = Y;
-	this->Z_scalar_vector = Z;
+        /// set vectors
+        this->Y_scalar_multivector = Y;
+        this->Z_scalar_vector = Z;
 
-	const local_ordinal_type num_vectors = X_internal_vector_values.extent(2);
-	const local_ordinal_type blocksize = D_internal_vector_values.extent(1);
+        const local_ordinal_type num_vectors = X_internal_vector_values.extent(2);
+        const local_ordinal_type blocksize = D_internal_vector_values.extent(1);
 
-	const local_ordinal_type team_size = 
-	  SolveTridiagsDefaultModeAndAlgo<typename execution_space::memory_space>::
-	  recommended_team_size(blocksize, vector_length, internal_vector_length);
-	const int per_team_scratch = internal_vector_scratch_type_3d_view
-	  ::shmem_size(blocksize, num_vectors, vector_loop_size);
-	
+        const local_ordinal_type team_size =
+          SolveTridiagsDefaultModeAndAlgo<typename execution_space::memory_space>::
+          recommended_team_size(blocksize, vector_length, internal_vector_length);
+        const int per_team_scratch = internal_vector_scratch_type_3d_view
+          ::shmem_size(blocksize, num_vectors, vector_loop_size);
+
 #if defined(KOKKOS_ENABLE_DEPRECATED_CODE)
-#define BLOCKTRIDICONTAINER_DETAILS_SOLVETRIDIAGS(B)			\
-	if (num_vectors == 1) {						\
-	  const Kokkos::TeamPolicy<execution_space,SingleVectorTag<B> > \
-	    policy(packptr.extent(0) - 1, team_size, vector_loop_size); \
-	  Kokkos::parallel_for						\
-	    ("SolveTridiags::TeamPolicy::run<SingleVector>",		\
-	     policy.set_scratch_size(0,Kokkos::PerTeam(per_team_scratch)), *this); \
-	} else {							\
-	  const Kokkos::TeamPolicy<execution_space,MultiVectorTag<B> > \
-	    policy(packptr.extent(0) - 1, team_size, vector_loop_size); \
-	  Kokkos::parallel_for						\
-	    ("SolveTridiags::TeamPolicy::run<MultiVector>",		\
-	     policy.set_scratch_size(0,Kokkos::PerTeam(per_team_scratch)), *this); \
-	} break
-#else	
-#define BLOCKTRIDICONTAINER_DETAILS_SOLVETRIDIAGS(B)			\
-	if (num_vectors == 1) {						\
-	  Kokkos::TeamPolicy<execution_space,SingleVectorTag<B> >       \
-	    policy(packptr.extent(0) - 1, team_size, vector_loop_size); \
+#define BLOCKTRIDICONTAINER_DETAILS_SOLVETRIDIAGS(B)                    \
+        if (num_vectors == 1) {                                         \
+          const Kokkos::TeamPolicy<execution_space,SingleVectorTag<B> > \
+            policy(packptr.extent(0) - 1, team_size, vector_loop_size); \
+          Kokkos::parallel_for                                          \
+            ("SolveTridiags::TeamPolicy::run<SingleVector>",            \
+             policy.set_scratch_size(0,Kokkos::PerTeam(per_team_scratch)), *this); \
+        } else {                                                        \
+          const Kokkos::TeamPolicy<execution_space,MultiVectorTag<B> > \
+            policy(packptr.extent(0) - 1, team_size, vector_loop_size); \
+          Kokkos::parallel_for                                          \
+            ("SolveTridiags::TeamPolicy::run<MultiVector>",             \
+             policy.set_scratch_size(0,Kokkos::PerTeam(per_team_scratch)), *this); \
+        } break
+#else
+#define BLOCKTRIDICONTAINER_DETAILS_SOLVETRIDIAGS(B)                    \
+        if (num_vectors == 1) {                                         \
+          Kokkos::TeamPolicy<execution_space,SingleVectorTag<B> >       \
+            policy(packptr.extent(0) - 1, team_size, vector_loop_size); \
           policy.set_scratch_size(0,Kokkos::PerTeam(per_team_scratch)); \
-	  Kokkos::parallel_for						\
-	    ("SolveTridiags::TeamPolicy::run<SingleVector>",		\
+          Kokkos::parallel_for                                          \
+            ("SolveTridiags::TeamPolicy::run<SingleVector>",            \
              policy, *this);                                            \
-	} else {							\
+        } else {                                                        \
           Kokkos::TeamPolicy<execution_space,MultiVectorTag<B> >        \
             policy(packptr.extent(0) - 1, team_size, vector_loop_size); \
           policy.set_scratch_size(0,Kokkos::PerTeam(per_team_scratch)); \
-	  Kokkos::parallel_for						\
-	    ("SolveTridiags::TeamPolicy::run<MultiVector>",		\
+          Kokkos::parallel_for                                          \
+            ("SolveTridiags::TeamPolicy::run<MultiVector>",             \
              policy, *this);                                            \
-	} break
+        } break
 #endif
-	switch (blocksize) {
-	case   3: BLOCKTRIDICONTAINER_DETAILS_SOLVETRIDIAGS( 3);
-	case   5: BLOCKTRIDICONTAINER_DETAILS_SOLVETRIDIAGS( 5);
-	case   7: BLOCKTRIDICONTAINER_DETAILS_SOLVETRIDIAGS( 7);
-	case   9: BLOCKTRIDICONTAINER_DETAILS_SOLVETRIDIAGS( 9);
-	case  10: BLOCKTRIDICONTAINER_DETAILS_SOLVETRIDIAGS(10);
-	case  11: BLOCKTRIDICONTAINER_DETAILS_SOLVETRIDIAGS(11);
-	case  16: BLOCKTRIDICONTAINER_DETAILS_SOLVETRIDIAGS(16);
-	case  17: BLOCKTRIDICONTAINER_DETAILS_SOLVETRIDIAGS(17);
-	case  18: BLOCKTRIDICONTAINER_DETAILS_SOLVETRIDIAGS(18);
-	default : BLOCKTRIDICONTAINER_DETAILS_SOLVETRIDIAGS( 0);            
-	}
+        switch (blocksize) {
+        case   3: BLOCKTRIDICONTAINER_DETAILS_SOLVETRIDIAGS( 3);
+        case   5: BLOCKTRIDICONTAINER_DETAILS_SOLVETRIDIAGS( 5);
+        case   7: BLOCKTRIDICONTAINER_DETAILS_SOLVETRIDIAGS( 7);
+        case   9: BLOCKTRIDICONTAINER_DETAILS_SOLVETRIDIAGS( 9);
+        case  10: BLOCKTRIDICONTAINER_DETAILS_SOLVETRIDIAGS(10);
+        case  11: BLOCKTRIDICONTAINER_DETAILS_SOLVETRIDIAGS(11);
+        case  16: BLOCKTRIDICONTAINER_DETAILS_SOLVETRIDIAGS(16);
+        case  17: BLOCKTRIDICONTAINER_DETAILS_SOLVETRIDIAGS(17);
+        case  18: BLOCKTRIDICONTAINER_DETAILS_SOLVETRIDIAGS(18);
+        default : BLOCKTRIDICONTAINER_DETAILS_SOLVETRIDIAGS( 0);
+        }
 #undef BLOCKTRIDICONTAINER_DETAILS_SOLVETRIDIAGS
 
-        IFPACK2_BLOCKTRIDICONTAINER_PROFILER_REGION_END;  	
+        IFPACK2_BLOCKTRIDICONTAINER_PROFILER_REGION_END;
       }
-    }; 
-    
+    };
+
     ///
-    /// compute local residula vector y = b - R x 
+    /// compute local residula vector y = b - R x
     ///
     static inline int ComputeResidualVectorRecommendedCudaVectorSize(const int blksize,
                                                                      const int team_size) {
@@ -2853,7 +2853,7 @@ namespace KB = KokkosBatched::Experimental;
       else if (blksize <= 16) total_team_size = 128;
       else if (blksize <= 20) total_team_size = 160;
       else                    total_team_size = 160;
-      return total_team_size/team_size; 
+      return total_team_size/team_size;
     }
 
     template<typename MatrixType>
@@ -2872,16 +2872,16 @@ namespace KB = KokkosBatched::Experimental;
       using btdm_magnitude_type = typename impl_type::btdm_magnitude_type;
       /// views
       using local_ordinal_type_1d_view = typename impl_type::local_ordinal_type_1d_view;
-      using size_type_1d_view = typename impl_type::size_type_1d_view; 
+      using size_type_1d_view = typename impl_type::size_type_1d_view;
       using tpetra_block_access_view_type = typename impl_type::tpetra_block_access_view_type; // block crs (layout right)
-      using impl_scalar_type_1d_view = typename impl_type::impl_scalar_type_1d_view; 
+      using impl_scalar_type_1d_view = typename impl_type::impl_scalar_type_1d_view;
       using impl_scalar_type_2d_view_tpetra = typename impl_type::impl_scalar_type_2d_view_tpetra; // block multivector (layout left)
       using vector_type_3d_view = typename impl_type::vector_type_3d_view;
       using btdm_scalar_type_4d_view = typename impl_type::btdm_scalar_type_4d_view;
       static constexpr int vector_length = impl_type::vector_length;
 
       /// team policy member type (used in cuda)
-      using member_type = typename Kokkos::TeamPolicy<execution_space>::member_type;      
+      using member_type = typename Kokkos::TeamPolicy<execution_space>::member_type;
 
       // enum for max blocksize and vector length
       enum : int { max_blocksize = 32 };
@@ -2901,7 +2901,7 @@ namespace KB = KokkosBatched::Experimental;
 
       // block crs graph information
       // for cuda (kokkos crs graph uses a different size_type from size_t)
-      using a_rowptr_value_type = typename Kokkos::ViewTraits<local_ordinal_type*,node_device_type>::size_type; 
+      using a_rowptr_value_type = typename Kokkos::ViewTraits<local_ordinal_type*,node_device_type>::size_type;
       const ConstUnmanaged<Kokkos::View<a_rowptr_value_type*,node_device_type> > A_rowptr;
       const ConstUnmanaged<Kokkos::View<local_ordinal_type*,node_device_type> > A_colind;
 
@@ -2913,7 +2913,7 @@ namespace KB = KokkosBatched::Experimental;
       const ConstUnmanaged<local_ordinal_type_1d_view> part2rowidx0;
       const ConstUnmanaged<local_ordinal_type_1d_view> rowidx2part;
       const ConstUnmanaged<local_ordinal_type_1d_view> partptr;
-      const ConstUnmanaged<local_ordinal_type_1d_view> lclrow;     
+      const ConstUnmanaged<local_ordinal_type_1d_view> lclrow;
       const ConstUnmanaged<local_ordinal_type_1d_view> dm2cm;
       const bool is_dm2cm_active;
 
@@ -2923,7 +2923,7 @@ namespace KB = KokkosBatched::Experimental;
                             const LocalCrsGraphType &graph,
                             const local_ordinal_type &blocksize_requested_,
                             const PartInterface<MatrixType> &interf,
-                            const local_ordinal_type_1d_view &dm2cm_) 
+                            const local_ordinal_type_1d_view &dm2cm_)
         : rowptr(amd.rowptr), rowptr_remote(amd.rowptr_remote),
           colindsub(amd.A_colindsub), colindsub_remote(amd.A_colindsub_remote),
           tpetra_values(amd.tpetra_values),
@@ -2940,9 +2940,9 @@ namespace KB = KokkosBatched::Experimental;
       {}
 
       inline
-      void 
+      void
       SerialGemv(const local_ordinal_type &blocksize,
-                 const impl_scalar_type * const KOKKOS_RESTRICT AA, 
+                 const impl_scalar_type * const KOKKOS_RESTRICT AA,
                  const impl_scalar_type * const KOKKOS_RESTRICT xx,
                  /* */ impl_scalar_type * KOKKOS_RESTRICT yy) const {
         for (local_ordinal_type k0=0;k0<blocksize;++k0) {
@@ -2954,18 +2954,18 @@ namespace KB = KokkosBatched::Experimental;
 #if defined(KOKKOS_ENABLE_PRAGMA_UNROLL)
 #   pragma unroll
 #endif
-          for (local_ordinal_type k1=0;k1<blocksize;++k1) 
+          for (local_ordinal_type k1=0;k1<blocksize;++k1)
             val += AA[offset+k1]*xx[k1];
           yy[k0] -= val;
         }
       }
 
       template<typename bbViewType, typename yyViewType>
-      KOKKOS_INLINE_FUNCTION       
-      void 
+      KOKKOS_INLINE_FUNCTION
+      void
       VectorCopy(const member_type &member,
                  const local_ordinal_type &blocksize,
-                 const bbViewType &bb, 
+                 const bbViewType &bb,
                  const yyViewType &yy) const {
         Kokkos::parallel_for(Kokkos::ThreadVectorRange(member, blocksize), [&](const local_ordinal_type &k0)  {
             yy(k0) = static_cast<typename yyViewType::const_value_type>(bb(k0));
@@ -2973,72 +2973,72 @@ namespace KB = KokkosBatched::Experimental;
       }
 
       template<typename AAViewType, typename xxViewType, typename yyViewType>
-      KOKKOS_INLINE_FUNCTION       
-      void 
-      TeamVectorGemv(const member_type &member, 
+      KOKKOS_INLINE_FUNCTION
+      void
+      TeamVectorGemv(const member_type &member,
                const local_ordinal_type &blocksize,
-               const AAViewType &AA, 
-               const xxViewType &xx, 
-               const yyViewType &yy) const { 
+               const AAViewType &AA,
+               const xxViewType &xx,
+               const yyViewType &yy) const {
         Kokkos::parallel_for
-          (Kokkos::TeamThreadRange(member, blocksize), 
+          (Kokkos::TeamThreadRange(member, blocksize),
            [&](const local_ordinal_type &k0) {
             impl_scalar_type val = 0;
             Kokkos::parallel_for
-              (Kokkos::ThreadVectorRange(member, blocksize), 
+              (Kokkos::ThreadVectorRange(member, blocksize),
                [&](const local_ordinal_type &k1) {
                 val += AA(k0,k1)*xx(k1);
               });
-	    Kokkos::atomic_fetch_add(&yy(k0), typename yyViewType::const_value_type(-val));
+            Kokkos::atomic_fetch_add(&yy(k0), typename yyViewType::const_value_type(-val));
           });
       }
 
       template<typename AAViewType, typename xxViewType, typename yyViewType>
-      KOKKOS_INLINE_FUNCTION       
-      void 
-      VectorGemv(const member_type &member, 
-      		 const local_ordinal_type &blocksize,
-      		 const AAViewType &AA, 
-      		 const xxViewType &xx, 
-      		 const yyViewType &yy) const { 
-      	Kokkos::parallel_for
-      	  (Kokkos::ThreadVectorRange(member, blocksize), 
-      	   [&](const local_ordinal_type &k0) {
-      	    impl_scalar_type val(0);
-      	    for (local_ordinal_type k1=0;k1<blocksize;++k1) {
-      	      val += AA(k0,k1)*xx(k1);
-      	    }            
-      	    Kokkos::atomic_fetch_add(&yy(k0), typename yyViewType::const_value_type(-val));
-      	  });
+      KOKKOS_INLINE_FUNCTION
+      void
+      VectorGemv(const member_type &member,
+                 const local_ordinal_type &blocksize,
+                 const AAViewType &AA,
+                 const xxViewType &xx,
+                 const yyViewType &yy) const {
+        Kokkos::parallel_for
+          (Kokkos::ThreadVectorRange(member, blocksize),
+           [&](const local_ordinal_type &k0) {
+            impl_scalar_type val(0);
+            for (local_ordinal_type k1=0;k1<blocksize;++k1) {
+              val += AA(k0,k1)*xx(k1);
+            }
+            Kokkos::atomic_fetch_add(&yy(k0), typename yyViewType::const_value_type(-val));
+          });
       }
 
       // template<typename AAViewType, typename xxViewType, typename yyViewType>
-      // KOKKOS_INLINE_FUNCTION       
-      // void 
-      // VectorGemv(const member_type &member, 
-      // 		 const local_ordinal_type &blocksize,
-      // 		 const AAViewType &AA, 
-      // 		 const xxViewType &xx, 
-      // 		 const yyViewType &yy) const { 
-      // 	for (local_ordinal_type k0=0;k0<blocksize;++k0) {
-      // 	  impl_scalar_type val = 0;
-      // 	  Kokkos::parallel_for
-      // 	    (Kokkos::ThreadVectorRange(member, blocksize), 
-      // 	     [&](const local_ordinal_type &k1) {
-      // 	      val += AA(k0,k1)*xx(k1);
-      // 	    });
-      // 	  Kokkos::atomic_fetch_add(&yy(k0), -val);
-      // 	}
+      // KOKKOS_INLINE_FUNCTION
+      // void
+      // VectorGemv(const member_type &member,
+      //                 const local_ordinal_type &blocksize,
+      //                 const AAViewType &AA,
+      //                 const xxViewType &xx,
+      //                 const yyViewType &yy) const {
+      //        for (local_ordinal_type k0=0;k0<blocksize;++k0) {
+      //          impl_scalar_type val = 0;
+      //          Kokkos::parallel_for
+      //            (Kokkos::ThreadVectorRange(member, blocksize),
+      //             [&](const local_ordinal_type &k1) {
+      //              val += AA(k0,k1)*xx(k1);
+      //            });
+      //          Kokkos::atomic_fetch_add(&yy(k0), -val);
+      //        }
       // }
 
       struct SeqTag {};
 
       inline
-      void 
+      void
       operator() (const SeqTag &, const local_ordinal_type& i) const {
         const local_ordinal_type blocksize = blocksize_requested;
         const local_ordinal_type blocksize_square = blocksize*blocksize;
-        
+
         // constants
         const Kokkos::pair<local_ordinal_type,local_ordinal_type> block_range(0, blocksize);
         const local_ordinal_type num_vectors = y.extent(1);
@@ -3047,8 +3047,8 @@ namespace KB = KokkosBatched::Experimental;
           // y := b
           impl_scalar_type *yy = &y(row, col);
           const impl_scalar_type * const bb = &b(row, col);
-          memcpy(yy, bb, sizeof(impl_scalar_type)*blocksize);         
-        
+          memcpy(yy, bb, sizeof(impl_scalar_type)*blocksize);
+
           // y -= Rx
           const size_type A_k0 = A_rowptr[i];
           for (size_type k=rowptr[i];k<rowptr[i+1];++k) {
@@ -3060,10 +3060,10 @@ namespace KB = KokkosBatched::Experimental;
         }
       }
 
-      KOKKOS_INLINE_FUNCTION 
-      void 
+      KOKKOS_INLINE_FUNCTION
+      void
       operator() (const SeqTag &, const member_type &member) const {
-        
+
         // constants
         const local_ordinal_type blocksize = blocksize_requested;
         const local_ordinal_type blocksize_square = blocksize*blocksize;
@@ -3076,28 +3076,28 @@ namespace KB = KokkosBatched::Experimental;
         auto bb = Kokkos::subview(b, block_range, 0);
         auto xx = bb;
         auto yy = Kokkos::subview(y, block_range, 0);
-        auto A_block = ConstUnmanaged<tpetra_block_access_view_type>(NULL, blocksize, blocksize); 
-        
+        auto A_block = ConstUnmanaged<tpetra_block_access_view_type>(NULL, blocksize, blocksize);
+
         const local_ordinal_type row = lr*blocksize;
         for (local_ordinal_type col=0;col<num_vectors;++col) {
           // y := b
           yy.assign_data(&y(row, col));
           bb.assign_data(&b(row, col));
-	  if (member.team_rank() == 0) 
+          if (member.team_rank() == 0)
             VectorCopy(member, blocksize, bb, yy);
           member.team_barrier();
 
           // y -= Rx
-          const size_type A_k0 = A_rowptr[lr];              
-	  Kokkos::parallel_for
-	    (Kokkos::TeamThreadRange(member, rowptr[lr], rowptr[lr+1]), 
-	     [&](const local_ordinal_type &k) {
-	      const size_type j = A_k0 + colindsub[k];
-	      A_block.assign_data( &tpetra_values(j*blocksize_square) );
-	      xx.assign_data( &x(A_colind[j]*blocksize, col) );
-	      VectorGemv(member, blocksize, A_block, xx, yy);
-	    });
-	}
+          const size_type A_k0 = A_rowptr[lr];
+          Kokkos::parallel_for
+            (Kokkos::TeamThreadRange(member, rowptr[lr], rowptr[lr+1]),
+             [&](const local_ordinal_type &k) {
+              const size_type j = A_k0 + colindsub[k];
+              A_block.assign_data( &tpetra_values(j*blocksize_square) );
+              xx.assign_data( &x(A_colind[j]*blocksize, col) );
+              VectorGemv(member, blocksize, A_block, xx, yy);
+            });
+        }
       }
 
       template<int B>
@@ -3105,12 +3105,12 @@ namespace KB = KokkosBatched::Experimental;
 
       template<int B>
       inline
-      void 
+      void
       operator() (const AsyncTag<B> &, const local_ordinal_type &rowidx) const {
         const local_ordinal_type blocksize = (B == 0 ? blocksize_requested : B);
         const local_ordinal_type blocksize_square = blocksize*blocksize;
 
-        // constants        
+        // constants
         const local_ordinal_type partidx = rowidx2part(rowidx);
         const local_ordinal_type pri = part2packrowidx0(partidx) + (rowidx - partptr(partidx));
         const local_ordinal_type v = partidx % vector_length;
@@ -3126,7 +3126,7 @@ namespace KB = KokkosBatched::Experimental;
         for (local_ordinal_type col=0;col<num_vectors;++col) {
           // y := b
           memcpy(yy, &b(row, col), sizeof(impl_scalar_type)*blocksize);
-          
+
           // y -= Rx
           const size_type A_k0 = A_rowptr[lr];
           for (size_type k=rowptr[lr];k<rowptr[lr+1];++k) {
@@ -3140,23 +3140,23 @@ namespace KB = KokkosBatched::Experimental;
             } else {
               const auto loc = A_colind_at_j - num_local_rows;
               const impl_scalar_type * const xx_remote = &x_remote(loc*blocksize, col);
-              SerialGemv(blocksize, AA,xx_remote,yy);                
+              SerialGemv(blocksize, AA,xx_remote,yy);
             }
           }
           // move yy to y_packed
-          for (local_ordinal_type k=0;k<blocksize;++k) 
+          for (local_ordinal_type k=0;k<blocksize;++k)
             y_packed(pri, k, col)[v] = yy[k];
         }
       }
 
       template<int B>
-      KOKKOS_INLINE_FUNCTION 
-      void 
+      KOKKOS_INLINE_FUNCTION
+      void
       operator() (const AsyncTag<B> &, const member_type &member) const {
         const local_ordinal_type blocksize = (B == 0 ? blocksize_requested : B);
         const local_ordinal_type blocksize_square = blocksize*blocksize;
 
-        // constants        
+        // constants
         const local_ordinal_type rowidx = member.league_rank();
         const local_ordinal_type partidx = rowidx2part(rowidx);
         const local_ordinal_type pri = part2packrowidx0(partidx) + (rowidx - partptr(partidx));
@@ -3171,7 +3171,7 @@ namespace KB = KokkosBatched::Experimental;
         auto xx = Kokkos::subview(x, block_range, 0);
         auto xx_remote = Kokkos::subview(x_remote, block_range, 0);
         auto yy = Kokkos::subview(y_packed_scalar, 0, block_range, 0, 0);
-        auto A_block = ConstUnmanaged<tpetra_block_access_view_type>(NULL, blocksize, blocksize); 
+        auto A_block = ConstUnmanaged<tpetra_block_access_view_type>(NULL, blocksize, blocksize);
 
         const local_ordinal_type lr = lclrow(rowidx);
         const local_ordinal_type row = lr*blocksize;
@@ -3179,42 +3179,42 @@ namespace KB = KokkosBatched::Experimental;
           // y := b
           bb.assign_data(&b(row, col));
           yy.assign_data(&y_packed_scalar(pri, 0, col, v));
-          if (member.team_rank() == 0) 
+          if (member.team_rank() == 0)
             VectorCopy(member, blocksize, bb, yy);
           member.team_barrier();
 
           // y -= Rx
           const size_type A_k0 = A_rowptr[lr];
-	  Kokkos::parallel_for
-	    (Kokkos::TeamThreadRange(member, rowptr[lr], rowptr[lr+1]), 
-	     [&](const local_ordinal_type &k) {
-	      const size_type j = A_k0 + colindsub[k];
-	      A_block.assign_data( &tpetra_values(j*blocksize_square) );
-              
-	      const local_ordinal_type A_colind_at_j = A_colind[j];
-	      if (A_colind_at_j < num_local_rows) {
-		const auto loc = is_dm2cm_active ? dm2cm[A_colind_at_j] : A_colind_at_j;
-		xx.assign_data( &x(loc*blocksize, col) );
-		VectorGemv(member, blocksize, A_block, xx, yy);
-	      } else {
-		const auto loc = A_colind_at_j - num_local_rows;
-		xx_remote.assign_data( &x_remote(loc*blocksize, col) );
-		VectorGemv(member, blocksize, A_block, xx_remote, yy);
-	      }
-	    });
+          Kokkos::parallel_for
+            (Kokkos::TeamThreadRange(member, rowptr[lr], rowptr[lr+1]),
+             [&](const local_ordinal_type &k) {
+              const size_type j = A_k0 + colindsub[k];
+              A_block.assign_data( &tpetra_values(j*blocksize_square) );
+
+              const local_ordinal_type A_colind_at_j = A_colind[j];
+              if (A_colind_at_j < num_local_rows) {
+                const auto loc = is_dm2cm_active ? dm2cm[A_colind_at_j] : A_colind_at_j;
+                xx.assign_data( &x(loc*blocksize, col) );
+                VectorGemv(member, blocksize, A_block, xx, yy);
+              } else {
+                const auto loc = A_colind_at_j - num_local_rows;
+                xx_remote.assign_data( &x_remote(loc*blocksize, col) );
+                VectorGemv(member, blocksize, A_block, xx_remote, yy);
+              }
+            });
         }
       }
-      
+
       template <int P, int B> struct OverlapTag {};
 
       template<int P, int B>
       inline
-      void 
+      void
       operator() (const OverlapTag<P,B> &, const local_ordinal_type& rowidx) const {
         const local_ordinal_type blocksize = (B == 0 ? blocksize_requested : B);
         const local_ordinal_type blocksize_square = blocksize*blocksize;
 
-        // constants        
+        // constants
         const local_ordinal_type partidx = rowidx2part(rowidx);
         const local_ordinal_type pri = part2packrowidx0(partidx) + (rowidx - partptr(partidx));
         const local_ordinal_type v = partidx % vector_length;
@@ -3225,20 +3225,20 @@ namespace KB = KokkosBatched::Experimental;
         // temporary buffer for y flat
         impl_scalar_type yy[max_blocksize] = {};
 
-        auto colindsub_used = (P == 0 ? colindsub : colindsub_remote); 
+        auto colindsub_used = (P == 0 ? colindsub : colindsub_remote);
         auto rowptr_used = (P == 0 ? rowptr : rowptr_remote);
 
         const local_ordinal_type lr = lclrow(rowidx);
         const local_ordinal_type row = lr*blocksize;
         for (local_ordinal_type col=0;col<num_vectors;++col) {
-          if (P == 0) { 
+          if (P == 0) {
             // y := b
             memcpy(yy, &b(row, col), sizeof(impl_scalar_type)*blocksize);
           } else {
             // y (temporary) := 0
-            memset(yy, 0, sizeof(impl_scalar_type)*blocksize); 
+            memset(yy, 0, sizeof(impl_scalar_type)*blocksize);
           }
-          
+
           // y -= Rx
           const size_type A_k0 = A_rowptr[lr];
           for (size_type k=rowptr_used[lr];k<rowptr_used[lr+1];++k) {
@@ -3252,28 +3252,28 @@ namespace KB = KokkosBatched::Experimental;
             } else {
               const auto loc = A_colind_at_j - num_local_rows;
               const impl_scalar_type * const xx_remote = &x_remote(loc*blocksize, col);
-              SerialGemv(blocksize,AA,xx_remote,yy);                
+              SerialGemv(blocksize,AA,xx_remote,yy);
             }
           }
           // move yy to y_packed
           if (P == 0) {
-            for (local_ordinal_type k=0;k<blocksize;++k) 
+            for (local_ordinal_type k=0;k<blocksize;++k)
               y_packed(pri, k, col)[v] = yy[k];
           } else {
-            for (local_ordinal_type k=0;k<blocksize;++k) 
+            for (local_ordinal_type k=0;k<blocksize;++k)
               y_packed(pri, k, col)[v] += yy[k];
           }
         }
       }
 
       template<int P, int B>
-      KOKKOS_INLINE_FUNCTION 
-      void 
+      KOKKOS_INLINE_FUNCTION
+      void
       operator() (const OverlapTag<P,B> &, const member_type &member) const {
         const local_ordinal_type blocksize = (B == 0 ? blocksize_requested : B);
         const local_ordinal_type blocksize_square = blocksize*blocksize;
 
-        // constants        
+        // constants
         const local_ordinal_type rowidx = member.league_rank();
         const local_ordinal_type partidx = rowidx2part(rowidx);
         const local_ordinal_type pri = part2packrowidx0(partidx) + (rowidx - partptr(partidx));
@@ -3289,40 +3289,40 @@ namespace KB = KokkosBatched::Experimental;
         auto xx_remote = bb; //Kokkos::subview(x_remote, block_range, 0);
         auto yy = Kokkos::subview(y_packed_scalar, 0, block_range, 0, 0);
         auto A_block = ConstUnmanaged<tpetra_block_access_view_type>(NULL, blocksize, blocksize);
-        auto colindsub_used = (P == 0 ? colindsub : colindsub_remote); 
+        auto colindsub_used = (P == 0 ? colindsub : colindsub_remote);
         auto rowptr_used = (P == 0 ? rowptr : rowptr_remote);
 
         const local_ordinal_type lr = lclrow(rowidx);
         const local_ordinal_type row = lr*blocksize;
         for (local_ordinal_type col=0;col<num_vectors;++col) {
           yy.assign_data(&y_packed_scalar(pri, 0, col, v));
-          if (P == 0) { 
+          if (P == 0) {
             // y := b
             bb.assign_data(&b(row, col));
-            if (member.team_rank() == 0) 
+            if (member.team_rank() == 0)
               VectorCopy(member, blocksize, bb, yy);
-            member.team_barrier();            
-          } 
-          
+            member.team_barrier();
+          }
+
           // y -= Rx
           const size_type A_k0 = A_rowptr[lr];
-	  Kokkos::parallel_for
-	    (Kokkos::TeamThreadRange(member, rowptr_used[lr], rowptr_used[lr+1]), 
-	     [&](const local_ordinal_type &k) {
-	      const size_type j = A_k0 + colindsub_used[k];
-	      A_block.assign_data( &tpetra_values(j*blocksize_square) );
-	      
-	      const local_ordinal_type A_colind_at_j = A_colind[j];
-	      if (P == 0) {
-		const auto loc = is_dm2cm_active ? dm2cm[A_colind_at_j] : A_colind_at_j;
-		xx.assign_data( &x(loc*blocksize, col) );
-		VectorGemv(member, blocksize, A_block, xx, yy);
-	      } else {
-		const auto loc = A_colind_at_j - num_local_rows;
-		xx_remote.assign_data( &x_remote(loc*blocksize, col) );
-		VectorGemv(member, blocksize, A_block, xx_remote, yy);
-	      }
-	    });
+          Kokkos::parallel_for
+            (Kokkos::TeamThreadRange(member, rowptr_used[lr], rowptr_used[lr+1]),
+             [&](const local_ordinal_type &k) {
+              const size_type j = A_k0 + colindsub_used[k];
+              A_block.assign_data( &tpetra_values(j*blocksize_square) );
+
+              const local_ordinal_type A_colind_at_j = A_colind[j];
+              if (P == 0) {
+                const auto loc = is_dm2cm_active ? dm2cm[A_colind_at_j] : A_colind_at_j;
+                xx.assign_data( &x(loc*blocksize, col) );
+                VectorGemv(member, blocksize, A_block, xx, yy);
+              } else {
+                const auto loc = A_colind_at_j - num_local_rows;
+                xx_remote.assign_data( &x_remote(loc*blocksize, col) );
+                VectorGemv(member, blocksize, A_block, xx_remote, yy);
+              }
+            });
         }
       }
 
@@ -3330,43 +3330,43 @@ namespace KB = KokkosBatched::Experimental;
       template<typename MultiVectorLocalViewTypeY,
                typename MultiVectorLocalViewTypeB,
                typename MultiVectorLocalViewTypeX>
-      void run(const MultiVectorLocalViewTypeY &y_, 
-               const MultiVectorLocalViewTypeB &b_, 
+      void run(const MultiVectorLocalViewTypeY &y_,
+               const MultiVectorLocalViewTypeB &b_,
                const MultiVectorLocalViewTypeX &x_) {
-	IFPACK2_BLOCKTRIDICONTAINER_PROFILER_REGION_BEGIN;
+        IFPACK2_BLOCKTRIDICONTAINER_PROFILER_REGION_BEGIN;
         IFPACK2_BLOCKTRIDICONTAINER_TIMER("BlockTriDi::ComputeResidual::<SeqTag>");
 
-        y = y_; b = b_; x = x_; 
+        y = y_; b = b_; x = x_;
         if (is_cuda<execution_space>::value) {
 #if defined(KOKKOS_ENABLE_CUDA)
-	  const local_ordinal_type blocksize = blocksize_requested;	  
-	  const local_ordinal_type team_size = 8;
-	  const local_ordinal_type vector_size = ComputeResidualVectorRecommendedCudaVectorSize(blocksize, team_size);
+          const local_ordinal_type blocksize = blocksize_requested;
+          const local_ordinal_type team_size = 8;
+          const local_ordinal_type vector_size = ComputeResidualVectorRecommendedCudaVectorSize(blocksize, team_size);
           const Kokkos::TeamPolicy<execution_space,SeqTag> policy(rowptr.extent(0) - 1, team_size, vector_size);
           Kokkos::parallel_for
             ("ComputeResidual::TeamPolicy::run<SeqTag>", policy, *this);
 #endif
         } else {
-#if defined(__CUDA_ARCH__)        
-          TEUCHOS_TEST_FOR_EXCEPT_MSG(true, "Error: CUDA should not see this code"); 
-#else          
+#if defined(__CUDA_ARCH__)
+          TEUCHOS_TEST_FOR_EXCEPT_MSG(true, "Error: CUDA should not see this code");
+#else
           const Kokkos::RangePolicy<execution_space,SeqTag> policy(0, rowptr.extent(0) - 1);
           Kokkos::parallel_for
             ("ComputeResidual::RangePolicy::run<SeqTag>", policy, *this);
 #endif
         }
-	IFPACK2_BLOCKTRIDICONTAINER_PROFILER_REGION_END;
+        IFPACK2_BLOCKTRIDICONTAINER_PROFILER_REGION_END;
       }
 
       // y = b - R (x , x_remote)
       template<typename MultiVectorLocalViewTypeB,
                typename MultiVectorLocalViewTypeX,
                typename MultiVectorLocalViewTypeX_Remote>
-      void run(const vector_type_3d_view &y_packed_, 
-               const MultiVectorLocalViewTypeB &b_, 
+      void run(const vector_type_3d_view &y_packed_,
+               const MultiVectorLocalViewTypeB &b_,
                const MultiVectorLocalViewTypeX &x_,
                const MultiVectorLocalViewTypeX_Remote &x_remote_) {
-	IFPACK2_BLOCKTRIDICONTAINER_PROFILER_REGION_BEGIN;
+        IFPACK2_BLOCKTRIDICONTAINER_PROFILER_REGION_BEGIN;
         IFPACK2_BLOCKTRIDICONTAINER_TIMER("BlockTriDi::ComputeResidual::<AsyncTag>");
 
         b = b_; x = x_; x_remote = x_remote_;
@@ -3384,16 +3384,16 @@ namespace KB = KokkosBatched::Experimental;
 
         if (is_cuda<execution_space>::value) {
 #if defined(KOKKOS_ENABLE_CUDA)
-	  const local_ordinal_type blocksize = blocksize_requested;	  
-	  const local_ordinal_type team_size = 8;
-	  const local_ordinal_type vector_size = ComputeResidualVectorRecommendedCudaVectorSize(blocksize, team_size);
+          const local_ordinal_type blocksize = blocksize_requested;
+          const local_ordinal_type team_size = 8;
+          const local_ordinal_type vector_size = ComputeResidualVectorRecommendedCudaVectorSize(blocksize, team_size);
           // local_ordinal_type vl_power_of_two = 1;
           // for (;vl_power_of_two<=blocksize_requested;vl_power_of_two*=2);
           // vl_power_of_two *= (vl_power_of_two < blocksize_requested ? 2 : 1);
-	  // const local_ordinal_type vl = vl_power_of_two > vector_length ? vector_length : vl_power_of_two;
+          // const local_ordinal_type vl = vl_power_of_two > vector_length ? vector_length : vl_power_of_two;
 #define BLOCKTRIDICONTAINER_DETAILS_COMPUTERESIDUAL(B) {                \
-            const Kokkos::TeamPolicy<execution_space,AsyncTag<B> >	\
-	      policy(rowidx2part.extent(0), team_size, vector_size);	\
+            const Kokkos::TeamPolicy<execution_space,AsyncTag<B> >      \
+              policy(rowidx2part.extent(0), team_size, vector_size);    \
             Kokkos::parallel_for                                        \
               ("ComputeResidual::TeamPolicy::run<AsyncTag>",            \
                policy, *this); } break
@@ -3407,14 +3407,14 @@ namespace KB = KokkosBatched::Experimental;
           case  16: BLOCKTRIDICONTAINER_DETAILS_COMPUTERESIDUAL(16);
           case  17: BLOCKTRIDICONTAINER_DETAILS_COMPUTERESIDUAL(17);
           case  18: BLOCKTRIDICONTAINER_DETAILS_COMPUTERESIDUAL(18);
-          default : BLOCKTRIDICONTAINER_DETAILS_COMPUTERESIDUAL( 0);            
+          default : BLOCKTRIDICONTAINER_DETAILS_COMPUTERESIDUAL( 0);
           }
 #undef BLOCKTRIDICONTAINER_DETAILS_COMPUTERESIDUAL
 #endif
-        } else {          
-#if defined(__CUDA_ARCH__)        
-          TEUCHOS_TEST_FOR_EXCEPT_MSG(true, "Error: CUDA should not see this code"); 
-#else          
+        } else {
+#if defined(__CUDA_ARCH__)
+          TEUCHOS_TEST_FOR_EXCEPT_MSG(true, "Error: CUDA should not see this code");
+#else
 #define BLOCKTRIDICONTAINER_DETAILS_COMPUTERESIDUAL(B) {                \
             const Kokkos::RangePolicy<execution_space,AsyncTag<B> > policy(0, rowidx2part.extent(0)); \
             Kokkos::parallel_for                                        \
@@ -3430,24 +3430,24 @@ namespace KB = KokkosBatched::Experimental;
           case  16: BLOCKTRIDICONTAINER_DETAILS_COMPUTERESIDUAL(16);
           case  17: BLOCKTRIDICONTAINER_DETAILS_COMPUTERESIDUAL(17);
           case  18: BLOCKTRIDICONTAINER_DETAILS_COMPUTERESIDUAL(18);
-          default : BLOCKTRIDICONTAINER_DETAILS_COMPUTERESIDUAL( 0);            
+          default : BLOCKTRIDICONTAINER_DETAILS_COMPUTERESIDUAL( 0);
           }
 #undef BLOCKTRIDICONTAINER_DETAILS_COMPUTERESIDUAL
 #endif
         }
-	IFPACK2_BLOCKTRIDICONTAINER_PROFILER_REGION_END;
+        IFPACK2_BLOCKTRIDICONTAINER_PROFILER_REGION_END;
       }
-      
+
       // y = b - R (y , y_remote)
       template<typename MultiVectorLocalViewTypeB,
                typename MultiVectorLocalViewTypeX,
                typename MultiVectorLocalViewTypeX_Remote>
-      void run(const vector_type_3d_view &y_packed_, 
-               const MultiVectorLocalViewTypeB &b_, 
+      void run(const vector_type_3d_view &y_packed_,
+               const MultiVectorLocalViewTypeB &b_,
                const MultiVectorLocalViewTypeX &x_,
                const MultiVectorLocalViewTypeX_Remote &x_remote_,
                const bool compute_owned) {
-	IFPACK2_BLOCKTRIDICONTAINER_PROFILER_REGION_BEGIN;
+        IFPACK2_BLOCKTRIDICONTAINER_PROFILER_REGION_BEGIN;
         IFPACK2_BLOCKTRIDICONTAINER_TIMER("BlockTriDi::ComputeResidual::<OverlapTag>");
 
         b = b_; x = x_; x_remote = x_remote_;
@@ -3460,27 +3460,27 @@ namespace KB = KokkosBatched::Experimental;
                                                      vector_length);
 #endif
         } else {
-          y_packed = y_packed_; 
+          y_packed = y_packed_;
         }
 
         if (is_cuda<execution_space>::value) {
 #if defined(KOKKOS_ENABLE_CUDA)
-	  const local_ordinal_type blocksize = blocksize_requested;	  
-	  const local_ordinal_type team_size = 8;
-	  const local_ordinal_type vector_size = ComputeResidualVectorRecommendedCudaVectorSize(blocksize, team_size);
+          const local_ordinal_type blocksize = blocksize_requested;
+          const local_ordinal_type team_size = 8;
+          const local_ordinal_type vector_size = ComputeResidualVectorRecommendedCudaVectorSize(blocksize, team_size);
           // local_ordinal_type vl_power_of_two = 1;
           // for (;vl_power_of_two<=blocksize_requested;vl_power_of_two*=2);
           // vl_power_of_two *= (vl_power_of_two < blocksize_requested ? 2 : 1);
-	  // const local_ordinal_type vl = vl_power_of_two > vector_length ? vector_length : vl_power_of_two;
+          // const local_ordinal_type vl = vl_power_of_two > vector_length ? vector_length : vl_power_of_two;
 #define BLOCKTRIDICONTAINER_DETAILS_COMPUTERESIDUAL(B)  \
           if (compute_owned) {                                          \
             const Kokkos::TeamPolicy<execution_space,OverlapTag<0,B> > \
-	      policy(rowidx2part.extent(0), team_size, vector_size);	\
+              policy(rowidx2part.extent(0), team_size, vector_size);    \
             Kokkos::parallel_for                                        \
               ("ComputeResidual::TeamPolicy::run<OverlapTag<0> >", policy, *this); \
           } else {                                                      \
             const Kokkos::TeamPolicy<execution_space,OverlapTag<1,B> > \
-	      policy(rowidx2part.extent(0), team_size, vector_size);	\
+              policy(rowidx2part.extent(0), team_size, vector_size);    \
             Kokkos::parallel_for                                        \
               ("ComputeResidual::TeamPolicy::run<OverlapTag<1> >", policy, *this); \
           } break
@@ -3494,23 +3494,23 @@ namespace KB = KokkosBatched::Experimental;
           case  16: BLOCKTRIDICONTAINER_DETAILS_COMPUTERESIDUAL(16);
           case  17: BLOCKTRIDICONTAINER_DETAILS_COMPUTERESIDUAL(17);
           case  18: BLOCKTRIDICONTAINER_DETAILS_COMPUTERESIDUAL(18);
-          default : BLOCKTRIDICONTAINER_DETAILS_COMPUTERESIDUAL( 0);            
+          default : BLOCKTRIDICONTAINER_DETAILS_COMPUTERESIDUAL( 0);
           }
-#undef BLOCKTRIDICONTAINER_DETAILS_COMPUTERESIDUAL          
+#undef BLOCKTRIDICONTAINER_DETAILS_COMPUTERESIDUAL
 #endif
         } else {
-#if defined(__CUDA_ARCH__)        
-          TEUCHOS_TEST_FOR_EXCEPT_MSG(true, "Error: CUDA should not see this code"); 
-#else          
+#if defined(__CUDA_ARCH__)
+          TEUCHOS_TEST_FOR_EXCEPT_MSG(true, "Error: CUDA should not see this code");
+#else
 #define BLOCKTRIDICONTAINER_DETAILS_COMPUTERESIDUAL(B)  \
           if (compute_owned) {                                          \
             const Kokkos::RangePolicy<execution_space,OverlapTag<0,B> > \
-	      policy(0, rowidx2part.extent(0));				\
+              policy(0, rowidx2part.extent(0));                         \
             Kokkos::parallel_for                                        \
               ("ComputeResidual::RangePolicy::run<OverlapTag<0> >", policy, *this); \
           } else {                                                      \
             const Kokkos::RangePolicy<execution_space,OverlapTag<1,B> > \
-	      policy(0, rowidx2part.extent(0));				\
+              policy(0, rowidx2part.extent(0));                         \
             Kokkos::parallel_for                                        \
               ("ComputeResidual::RangePolicy::run<OverlapTag<1> >", policy, *this); \
           } break
@@ -3525,25 +3525,24 @@ namespace KB = KokkosBatched::Experimental;
           case  16: BLOCKTRIDICONTAINER_DETAILS_COMPUTERESIDUAL(16);
           case  17: BLOCKTRIDICONTAINER_DETAILS_COMPUTERESIDUAL(17);
           case  18: BLOCKTRIDICONTAINER_DETAILS_COMPUTERESIDUAL(18);
-          default : BLOCKTRIDICONTAINER_DETAILS_COMPUTERESIDUAL( 0);            
+          default : BLOCKTRIDICONTAINER_DETAILS_COMPUTERESIDUAL( 0);
           }
 #undef BLOCKTRIDICONTAINER_DETAILS_COMPUTERESIDUAL
 #endif
         }
-	IFPACK2_BLOCKTRIDICONTAINER_PROFILER_REGION_END;
+        IFPACK2_BLOCKTRIDICONTAINER_PROFILER_REGION_END;
       }
-    }; 
+    };
 
     template<typename MatrixType>
     void reduceVector(const ConstUnmanaged<typename ImplType<MatrixType>::impl_scalar_type_1d_view> zz,
                       /* */ typename ImplType<MatrixType>::magnitude_type *vals) {
       IFPACK2_BLOCKTRIDICONTAINER_PROFILER_REGION_BEGIN;
-      IFPACK2_BLOCKTRIDICONTAINER_TIMER("BlockTriDi::ReduceVector");	
+      IFPACK2_BLOCKTRIDICONTAINER_TIMER("BlockTriDi::ReduceVector");
 
       using impl_type = ImplType<MatrixType>;
       using local_ordinal_type = typename impl_type::local_ordinal_type;
       using impl_scalar_type = typename impl_type::impl_scalar_type;
-      using magnitude_type = typename impl_type::magnitude_type;
 #if 0
       const auto norm2 = KokkosBlas::nrm1(zz);
 #else
@@ -3554,18 +3553,18 @@ namespace KB = KokkosBatched::Experimental;
          KOKKOS_LAMBDA(const local_ordinal_type &i, impl_scalar_type &update) {
           update += zz(i);
         }, norm2);
-#endif	
+#endif
       vals[0] = Kokkos::ArithTraits<impl_scalar_type>::abs(norm2);
 
       IFPACK2_BLOCKTRIDICONTAINER_PROFILER_REGION_END;
     }
-    
+
     ///
     /// Manage the distributed part of the computation of residual norms.
     ///
     template<typename MatrixType>
     struct NormManager {
-    public: 
+    public:
       using impl_type = ImplType<MatrixType>;
       using host_execution_space = typename impl_type::host_execution_space;
       using magnitude_type = typename impl_type::magnitude_type;
@@ -3583,7 +3582,7 @@ namespace KB = KokkosBatched::Experimental;
       NormManager() = default;
       NormManager(const NormManager &b) = default;
       NormManager(const Teuchos::RCP<const Teuchos::Comm<int> >& comm) {
-        sweep_step_ = 1; 
+        sweep_step_ = 1;
         sweep_step_upper_bound_ = 1;
         collective_ = comm->getSize() > 1;
         if (collective_) {
@@ -3605,7 +3604,7 @@ namespace KB = KokkosBatched::Experimental;
         sweep_step_upper_bound_ = sweep_step;
         sweep_step_ = 1;
       }
-      
+
       // Get the buffer into which to store rank-local squared norms.
       magnitude_type* getBuffer() { return &work_[0]; }
 
@@ -3613,14 +3612,14 @@ namespace KB = KokkosBatched::Experimental;
       void ireduce(const int sweep, const bool force = false) {
         if ( ! force && sweep % sweep_step_) return;
 
-	IFPACK2_BLOCKTRIDICONTAINER_TIMER("BlockTriDi::NormManager::Ireduce");
+        IFPACK2_BLOCKTRIDICONTAINER_TIMER("BlockTriDi::NormManager::Ireduce");
 
         work_[1] = work_[0];
-	auto send_data = &work_[1];
-	auto recv_data = &work_[0];
+        auto send_data = &work_[1];
+        auto recv_data = &work_[0];
         if (collective_) {
 #ifdef HAVE_IFPACK2_MPI
-# if defined(IFPACK2_BLOCKTRIDICONTAINER_USE_MPI_3) 
+# if defined(IFPACK2_BLOCKTRIDICONTAINER_USE_MPI_3)
           MPI_Iallreduce(send_data, recv_data, 1,
                          Teuchos::Details::MpiTypeTraits<magnitude_type>::getType(),
                          MPI_SUM, comm_, &mpi_request_);
@@ -3632,30 +3631,30 @@ namespace KB = KokkosBatched::Experimental;
 #endif
         }
       }
-      
+
       // Check if the norm-based termination criterion is met. tol2 is the
       // tolerance squared. Sweep is the sweep index. If not every iteration is
       // being checked, this function immediately returns false. If a check must
       // be done at this iteration, it waits for the reduction triggered by
       // ireduce to complete, then checks the global norm against the tolerance.
       bool checkDone (const int sweep, const magnitude_type tol2, const bool force = false) {
-        // early return 
-        if (sweep <= 0) return false;	
-	
-	IFPACK2_BLOCKTRIDICONTAINER_TIMER("BlockTriDi::NormManager::CheckDone");
-	
+        // early return
+        if (sweep <= 0) return false;
+
+        IFPACK2_BLOCKTRIDICONTAINER_TIMER("BlockTriDi::NormManager::CheckDone");
+
         TEUCHOS_ASSERT(sweep >= 1);
         if ( ! force && (sweep - 1) % sweep_step_) return false;
         if (collective_) {
 #ifdef HAVE_IFPACK2_MPI
-# if defined(IFPACK2_BLOCKTRIDICONTAINER_USE_MPI_3) 
+# if defined(IFPACK2_BLOCKTRIDICONTAINER_USE_MPI_3)
           MPI_Wait(&mpi_request_, MPI_STATUS_IGNORE);
 # else
           // Do nothing.
 # endif
 #endif
         }
-	bool r_val = false;
+        bool r_val = false;
         if (sweep == 1) {
           work_[2] = work_[0];
         } else {
@@ -3669,28 +3668,28 @@ namespace KB = KokkosBatched::Experimental;
         } else {
           sweep_step_ = sweep_step_upper_bound_;
         }
-	return r_val;
+        return r_val;
       }
-      
+
       // After termination has occurred, finalize the norms for use in
       // get_norms{0,final}.
       void finalize () {
         work_[0] = std::sqrt(work_[0]); // after converged
-        if (work_[2] >= 0) 
+        if (work_[2] >= 0)
           work_[2] = std::sqrt(work_[2]); // first norm
         // if work_[2] is minus one, then norm is not requested.
       }
-      
+
       // Report norms to the caller.
       const magnitude_type getNorms0 () const { return work_[2]; }
       const magnitude_type getNormsFinal () const { return work_[0]; }
     };
-	
+
     ///
     /// top level apply interface
     ///
     template<typename MatrixType>
-    int 
+    int
     applyInverseJacobi(// importer
                        const Teuchos::RCP<const typename ImplType<MatrixType>::tpetra_block_crs_matrix_type> &A,
                        const Teuchos::RCP<const typename ImplType<MatrixType>::tpetra_import_type> &tpetra_importer,
@@ -3705,20 +3704,18 @@ namespace KB = KokkosBatched::Experimental;
                        const PartInterface<MatrixType> &interf, // mesh interface
                        const BlockTridiags<MatrixType> &btdm, // packed block tridiagonal matrices
                        const AmD<MatrixType> &amd, // R = A - D
-                       /* */ typename ImplType<MatrixType>::vector_type_1d_view &work, // workspace for packed multivector of right hand side 
+                       /* */ typename ImplType<MatrixType>::vector_type_1d_view &work, // workspace for packed multivector of right hand side
                        /* */ NormManager<MatrixType> &norm_manager,
                        // preconditioner parameters
-                       const typename ImplType<MatrixType>::impl_scalar_type &damping_factor, 
+                       const typename ImplType<MatrixType>::impl_scalar_type &damping_factor,
                        /* */ bool is_y_zero,
-                       const int max_num_sweeps, 
+                       const int max_num_sweeps,
                        const typename ImplType<MatrixType>::magnitude_type tol,
-                       const int check_tol_every) { 
+                       const int check_tol_every) {
       IFPACK2_BLOCKTRIDICONTAINER_TIMER("BlockTriDi::ApplyInverseJacobi");
 
       using impl_type = ImplType<MatrixType>;
       using node_memory_space = typename impl_type::node_memory_space;
-      using memory_space = typename impl_type::memory_space;
-
       using local_ordinal_type = typename impl_type::local_ordinal_type;
       using size_type = typename impl_type::size_type;
       using impl_scalar_type = typename impl_type::impl_scalar_type;
@@ -3731,10 +3728,10 @@ namespace KB = KokkosBatched::Experimental;
       using impl_scalar_type_1d_view = typename impl_type::impl_scalar_type_1d_view;
 
       // either tpetra importer or async importer must be active
-      TEUCHOS_TEST_FOR_EXCEPT_MSG(!tpetra_importer.is_null() && !async_importer.is_null(), 
+      TEUCHOS_TEST_FOR_EXCEPT_MSG(!tpetra_importer.is_null() && !async_importer.is_null(),
                                   "Neither Tpetra importer nor Async importer is null.");
       // max number of sweeps should be positive number
-      TEUCHOS_TEST_FOR_EXCEPT_MSG(max_num_sweeps <= 0, 
+      TEUCHOS_TEST_FOR_EXCEPT_MSG(max_num_sweeps <= 0,
                                   "Maximum number of sweeps must be >= 1.");
 
       // const parameters
@@ -3749,32 +3746,32 @@ namespace KB = KokkosBatched::Experimental;
       const impl_scalar_type zero(0.0);
 
       TEUCHOS_TEST_FOR_EXCEPT_MSG(is_norm_manager_active && is_seq_method_requested,
-                                  "The seq method for applyInverseJacobi, " << 
+                                  "The seq method for applyInverseJacobi, " <<
                                   "which in any case is for developer use only, " <<
                                   "does not support norm-based termination.");
 
       // if workspace is needed more, resize it
       const size_type work_span_required = num_blockrows*num_vectors*blocksize;
-      if (work.span() < work_span_required) 
+      if (work.span() < work_span_required)
         work = vector_type_1d_view("vector workspace 1d view", work_span_required);
 
       // construct W
       const local_ordinal_type W_size = interf.packptr.extent(0)-1;
-      if (local_ordinal_type(W.extent(0)) < W_size) 
-	W = impl_scalar_type_1d_view("W", W_size);
+      if (local_ordinal_type(W.extent(0)) < W_size)
+        W = impl_scalar_type_1d_view("W", W_size);
 
       typename impl_type::impl_scalar_type_2d_view_tpetra remote_multivector;
       {
-	if (is_seq_method_requested) {
-	  if (Z.getNumVectors() != Y.getNumVectors()) 
-	    Z = tpetra_multivector_type(tpetra_importer->getTargetMap(), num_vectors, false);                   
-	} else {
-	  if (is_async_importer_active) {
-	    // create comm data buffer and keep it here
-	    async_importer->createDataBuffer(num_vectors);
-	    remote_multivector = async_importer->getRemoteMultiVectorLocalView();
-	  }
-	}
+        if (is_seq_method_requested) {
+          if (Z.getNumVectors() != Y.getNumVectors())
+            Z = tpetra_multivector_type(tpetra_importer->getTargetMap(), num_vectors, false);
+        } else {
+          if (is_async_importer_active) {
+            // create comm data buffer and keep it here
+            async_importer->createDataBuffer(num_vectors);
+            remote_multivector = async_importer->getRemoteMultiVectorLocalView();
+          }
+        }
       }
 
       // wrap the workspace with 3d view
@@ -3785,17 +3782,17 @@ namespace KB = KokkosBatched::Experimental;
       if (is_y_zero) Kokkos::deep_copy(YY, zero);
 
       MultiVectorConverter<MatrixType> multivector_converter(interf, pmv);
-      SolveTridiags<MatrixType> solve_tridiags(interf, btdm, pmv, 
-					       damping_factor, is_norm_manager_active);
+      SolveTridiags<MatrixType> solve_tridiags(interf, btdm, pmv,
+                                               damping_factor, is_norm_manager_active);
 
       const local_ordinal_type_1d_view dummy_local_ordinal_type_1d_view;
-      ComputeResidualVector<MatrixType> 
-	compute_residual_vector(amd, A->getCrsGraph().getLocalGraph(), blocksize, interf, 
-				is_async_importer_active ? async_importer->dm2cm : dummy_local_ordinal_type_1d_view);
-      
+      ComputeResidualVector<MatrixType>
+        compute_residual_vector(amd, A->getCrsGraph().getLocalGraph(), blocksize, interf,
+                                is_async_importer_active ? async_importer->dm2cm : dummy_local_ordinal_type_1d_view);
+
       // norm manager workspace resize
-      if (is_norm_manager_active) 
-	norm_manager.setCheckFrequency(check_tol_every);
+      if (is_norm_manager_active)
+        norm_manager.setCheckFrequency(check_tol_every);
 
       // iterate
       int sweep = 0;
@@ -3805,17 +3802,17 @@ namespace KB = KokkosBatched::Experimental;
             // pmv := x(lclrow)
             multivector_converter.run(XX);
           } else {
-            if (is_seq_method_requested) { 
-              // SEQ METHOD IS TESTING ONLY 
+            if (is_seq_method_requested) {
+              // SEQ METHOD IS TESTING ONLY
 
               // y := x - R y
               Z.doImport(Y, *tpetra_importer, Tpetra::REPLACE);
               compute_residual_vector.run(YY, XX, ZZ);
-              
+
               // pmv := y(lclrow).
               multivector_converter.run(YY);
             } else {
-              // fused y := x - R y and pmv := y(lclrow); 
+              // fused y := x - R y and pmv := y(lclrow);
               // real use case does not use overlap comp and comm
               if (overlap_communication_and_computation || !is_async_importer_active) {
                 if (is_async_importer_active) async_importer->asyncSendRecv(YY);
@@ -3837,13 +3834,13 @@ namespace KB = KokkosBatched::Experimental;
             }
           }
         }
-        
+
         // pmv := inv(D) pmv.
         {
           solve_tridiags.run(YY, W);
-	}
+        }
         {
-          if (is_norm_manager_active) {	  
+          if (is_norm_manager_active) {
             // y(lclrow) = (b - a) y(lclrow) + a pmv, with b = 1 always.
             reduceVector<MatrixType>(W, norm_manager.getBuffer());
             if (sweep + 1 == max_num_sweeps) {
@@ -3865,32 +3862,32 @@ namespace KB = KokkosBatched::Experimental;
 
 
     template<typename MatrixType>
-    struct ImplObject { 
+    struct ImplObject {
       using impl_type = ImplType<MatrixType>;
       using part_interface_type = PartInterface<MatrixType>;
       using block_tridiags_type = BlockTridiags<MatrixType>;
       using amd_type = AmD<MatrixType>;
       using norm_manager_type = NormManager<MatrixType>;
       using async_import_type = AsyncableImport<MatrixType>;
-      
+
       // distructed objects
       Teuchos::RCP<const typename impl_type::tpetra_block_crs_matrix_type> A;
       Teuchos::RCP<const typename impl_type::tpetra_import_type> tpetra_importer;
       Teuchos::RCP<async_import_type> async_importer;
       bool overlap_communication_and_computation;
-      
+
       // copy of Y (mutable to penentrate const)
       mutable typename impl_type::tpetra_multivector_type Z;
       mutable typename impl_type::impl_scalar_type_1d_view W;
-      
+
       // local objects
       part_interface_type part_interface;
       block_tridiags_type block_tridiags; // D
       amd_type a_minus_d; // R = A - D
       mutable typename impl_type::vector_type_1d_view work; // right hand side workspace
-      mutable norm_manager_type norm_manager;      
+      mutable norm_manager_type norm_manager;
     };
-  
+
   } // namespace BlockTriDiContainerDetails
 
 } // namespace Ifpack2

--- a/packages/ifpack2/src/Ifpack2_Details_getParamTryingTypes.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_getParamTryingTypes.hpp
@@ -1,0 +1,107 @@
+/*@HEADER
+// ***********************************************************************
+//
+//       Ifpack2: Templated Object-Oriented Algebraic Preconditioner Package
+//                 Copyright (2009) Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// ***********************************************************************
+//@HEADER
+*/
+
+#ifndef IFPACK2_DETAILS_GETPARAMTRYINGTYPES_HPP
+#define IFPACK2_DETAILS_GETPARAMTRYINGTYPES_HPP
+
+#include "Ifpack2_config.h"
+#include "Teuchos_TypeNameTraits.hpp"
+#include "Teuchos_ParameterList.hpp"
+
+namespace Ifpack2 {
+namespace Details {
+
+template<class ResultType, class ... CandidateTypes>
+struct GetParamTryingTypes {};
+
+template<class ResultType>
+struct GetParamTryingTypes<ResultType> {
+  static void
+  get (ResultType& /* result */,
+       const Teuchos::ParameterEntry& /* ent */,
+       const std::string& paramName,
+       const char prefix[])
+  {
+    using Teuchos::TypeNameTraits;
+    TEUCHOS_TEST_FOR_EXCEPTION
+      (true, std::invalid_argument, prefix << "\"" << paramName
+       << "\" parameter exists in input ParameterList, but does not "
+       "have the right type.  The proper type is "
+       << TypeNameTraits<ResultType>::name () << ".");
+  }
+};
+
+  template<class ResultType, class First, class ... Rest>
+  struct GetParamTryingTypes<ResultType, First, Rest...> {
+    static void
+    get (ResultType& result,
+         const Teuchos::ParameterEntry& ent,
+         const std::string& paramName,
+         const char prefix[])
+    {
+      if (ent.template isType<First> ()) {
+        result = static_cast<ResultType> (Teuchos::getValue<First> (ent));
+      }
+      else {
+        using rest_type = GetParamTryingTypes<ResultType, Rest...>;
+        rest_type::get (result, ent, paramName, prefix);
+      }
+    }
+  };
+
+  template<class ResultType, class ... CandidateTypes>
+  void
+  getParamTryingTypes (ResultType& result,
+                       const Teuchos::ParameterList& params,
+                       const std::string& paramName,
+                       const char prefix[])
+  {
+    using Teuchos::ParameterEntry;
+    const ParameterEntry* ent = params.getEntryPtr (paramName);
+    if (ent != nullptr) {
+      using impl_type = GetParamTryingTypes<ResultType, CandidateTypes...>;
+      impl_type::get (result, *ent, paramName, prefix);
+    }
+  }
+
+} // namespace Details
+} // namespace Ifpack2
+
+#endif // IFPACK2_DETAILS_GETPARAMTRYINGTYPES_HPP

--- a/packages/ifpack2/src/Ifpack2_ILUT_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_ILUT_decl.hpp
@@ -151,7 +151,7 @@ public:
   explicit ILUT (const Teuchos::RCP<const row_matrix_type>& A);
 
   //! Destructor
-  virtual ~ILUT();
+  virtual ~ILUT () = default;
 
   //@}
   //! \name Methods for setting up and computing the incomplete factorization
@@ -307,7 +307,7 @@ public:
   double getApplyTime() const;
 
   //! Get a rough estimate of cost per iteration
-  size_t getNodeSmootherComplexity() const;  
+  size_t getNodeSmootherComplexity() const;
 
 
   /// \brief The level of fill.

--- a/packages/ifpack2/src/Ifpack2_ILUT_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_ILUT_def.hpp
@@ -151,11 +151,12 @@ void ILUT<MatrixType>::setParameters (const Teuchos::ParameterList& params)
   // strong exception guarantee (i.e., is transactional).
 
   // Fill level in ILUT is a double, not a magnitude_type, because it
-  // depends on LO and GO, not on Scalar.
+  // depends on LO and GO, not on Scalar.  Also, you can't cast
+  // arbitrary magnitude_type (e.g., Sacado::MP::Vector) to double.
   double fillLevel = LevelOfFill_;
   {
     const std::string paramName ("fact: ilut level-of-fill");
-    getParamTryingTypes<double, double, magnitude_type>
+    getParamTryingTypes<double, double, float>
       (fillLevel, params, paramName, prefix);
     TEUCHOS_TEST_FOR_EXCEPTION
       (fillLevel < 1.0, std::runtime_error,

--- a/packages/ifpack2/src/Ifpack2_ILUT_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_ILUT_def.hpp
@@ -52,6 +52,7 @@
 #include "Ifpack2_LocalFilter.hpp"
 #include "Ifpack2_LocalSparseTriangularSolver.hpp"
 #include "Ifpack2_Parameters.hpp"
+#include "Ifpack2_Details_getParamTryingTypes.hpp"
 #include "Tpetra_CrsMatrix.hpp"
 #include "Teuchos_Time.hpp"
 #include "Teuchos_TypeNameTraits.hpp"
@@ -88,7 +89,6 @@ namespace Ifpack2 {
     template<class ScalarType>
     inline typename Teuchos::ScalarTraits<ScalarType>::magnitudeType
     ilutDefaultDropTolerance () {
-      using Teuchos::as;
       typedef Teuchos::ScalarTraits<ScalarType> STS;
       typedef typename STS::magnitudeType magnitude_type;
       typedef Teuchos::ScalarTraits<magnitude_type> STM;
@@ -99,7 +99,7 @@ namespace Ifpack2 {
       // The min ensures that in case magnitude_type has very low
       // precision, we'll at least get some value strictly less than
       // one.
-      return std::min (as<magnitude_type> (1000) * STS::magnitude (STS::eps ()), oneHalf);
+      return std::min (static_cast<magnitude_type> (1000) * STS::magnitude (STS::eps ()), oneHalf);
     }
 
     // Full specialization for ScalarType = double.
@@ -133,10 +133,6 @@ ILUT<MatrixType>::ILUT (const Teuchos::RCP<const row_matrix_type>& A) :
   allocateSolvers();
 }
 
-template <class MatrixType>
-ILUT<MatrixType>::~ILUT()
-{}
-
 template<class MatrixType>
 void ILUT<MatrixType>::allocateSolvers ()
 {
@@ -144,36 +140,12 @@ void ILUT<MatrixType>::allocateSolvers ()
   U_solver_ = Teuchos::rcp (new LocalSparseTriangularSolver<row_matrix_type> ());
 }
 
-namespace { // (anonymous)
-
-  template<class MagnitudeType>
-  std::pair<MagnitudeType, bool>
-  getMagnitudeOrDoubleParameterAsMagnitude (const Teuchos::ParameterList& params,
-					    const char parameterName[],
-					    const MagnitudeType& currentValue)
-  {
-    const std::string pname (parameterName);
-
-    if (params.isType<MagnitudeType> (pname)) {
-      const MagnitudeType value = params.get<MagnitudeType> (pname);
-      return {value, true};
-    }
-    else if (! std::is_same<MagnitudeType, double>::value &&
-	     params.isType<double> (pname)) {
-      const MagnitudeType value = params.get<double> (pname);
-      return {value, true};
-    }
-    else {
-      return {currentValue, false};
-    }
-  }
-
-} // namespace (anonymous)
-
-
 template <class MatrixType>
 void ILUT<MatrixType>::setParameters (const Teuchos::ParameterList& params)
 {
+  using Details::getParamTryingTypes;
+  const char prefix[] = "Ifpack2::ILUT: ";
+
   // Don't actually change the instance variables until we've checked
   // all parameters.  This ensures that setParameters satisfies the
   // strong exception guarantee (i.e., is transactional).
@@ -181,20 +153,12 @@ void ILUT<MatrixType>::setParameters (const Teuchos::ParameterList& params)
   // Fill level in ILUT is a double, not a magnitude_type, because it
   // depends on LO and GO, not on Scalar.
   double fillLevel = LevelOfFill_;
-  bool gotFillLevel = false;
   {
-    const std::string fillLevelParamName ("fact: ilut level-of-fill");
-    if (params.isType<double> (fillLevelParamName)) {
-      fillLevel = params.get<double> (fillLevelParamName);
-      gotFillLevel = true;
-    }
-    else if (! std::is_same<magnitude_type, double>::value &&
-	     params.isType<double> (fillLevelParamName)) {
-      fillLevel = params.get<double> (fillLevelParamName);
-      gotFillLevel = true;
-    }
+    const std::string paramName ("fact: ilut level-of-fill");
+    getParamTryingTypes<double, double, magnitude_type>
+      (fillLevel, params, paramName, prefix);
     TEUCHOS_TEST_FOR_EXCEPTION
-      (gotFillLevel && fillLevel < 1.0, std::runtime_error,
+      (fillLevel < 1.0, std::runtime_error,
        "Ifpack2::ILUT: The \"fact: ilut level-of-fill\" parameter must be >= "
        "1.0, but you set it to " << fillLevel << ".  For ILUT, the fill level "
        "means something different than it does for ILU(k).  ILU(0) produces "
@@ -204,34 +168,43 @@ void ILUT<MatrixType>::setParameters (const Teuchos::ParameterList& params)
        "fill-in.");
   }
 
-  const auto absThreshResult =
-    getMagnitudeOrDoubleParameterAsMagnitude (params, "fact: absolute threshold", Athresh_);
-  const auto relThreshResult =
-    getMagnitudeOrDoubleParameterAsMagnitude (params, "fact: relative threshold", Rthresh_);
-  const auto relaxResult =
-    getMagnitudeOrDoubleParameterAsMagnitude (params, "fact: relax value", RelaxValue_);
-  const auto dropResult =
-    getMagnitudeOrDoubleParameterAsMagnitude (params, "fact: drop tolerance", DropTolerance_);
+  magnitude_type absThresh = Athresh_;
+  {
+    const std::string paramName ("fact: absolute threshold");
+    getParamTryingTypes<magnitude_type, magnitude_type, double>
+      (absThresh, params, paramName, prefix);
+  }
+
+  magnitude_type relThresh = Rthresh_;
+  {
+    const std::string paramName ("fact: relative threshold");
+    getParamTryingTypes<magnitude_type, magnitude_type, double>
+      (relThresh, params, paramName, prefix);
+  }
+
+  magnitude_type relaxValue = RelaxValue_;
+  {
+    const std::string paramName ("fact: relax value");
+    getParamTryingTypes<magnitude_type, magnitude_type, double>
+      (relaxValue, params, paramName, prefix);
+  }
+
+  magnitude_type dropTol = DropTolerance_;
+  {
+    const std::string paramName ("fact: drop tolerance");
+    getParamTryingTypes<magnitude_type, magnitude_type, double>
+      (dropTol, params, paramName, prefix);
+  }
 
   // Forward to trisolvers.
   L_solver_->setParameters(params);
   U_solver_->setParameters(params);
 
-  if (gotFillLevel) {
-    LevelOfFill_ = fillLevel;
-  }
-  if (absThreshResult.second) {
-    Athresh_ = absThreshResult.first;
-  }
-  if (relThreshResult.second) {
-    Rthresh_ = relThreshResult.first;
-  }
-  if (relaxResult.second) {
-    RelaxValue_ = relaxResult.first;
-  }
-  if (dropResult.second) {
-    DropTolerance_ = dropResult.first;
-  }
+  LevelOfFill_ = fillLevel;
+  Athresh_ = absThresh;
+  Rthresh_ = relThresh;
+  RelaxValue_ = relaxValue;
+  DropTolerance_ = dropTol;
 }
 
 

--- a/packages/ifpack2/src/Ifpack2_RILUK_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_RILUK_def.hpp
@@ -280,13 +280,14 @@ setParameters (const Teuchos::ParameterList& params)
   // "fact: iluk level-of-fill" parsing is more complicated, because
   // we want to allow as many types as make sense.  int is the native
   // type, but we also want to accept double (for backwards
-  // compatibilty with ILUT).
+  // compatibilty with ILUT).  You can't cast arbitrary magnitude_type
+  // (e.g., Sacado::MP::Vector) to int, so we use float instead, to
+  // get coverage of the most common magnitude_type cases.  Weirdly,
+  // there's an Ifpack2 test that sets the fill level as a
+  // global_ordinal_type.
   {
     const std::string paramName ("fact: iluk level-of-fill");
-    // You can't cast arbitrary magnitude_type (e.g.,
-    // Sacado::MP::Vector) to int, so we use float instead, to get
-    // coverage of the most common magnitude_type cases.
-    getParamTryingTypes<int, int, double, float>
+    getParamTryingTypes<int, int, global_ordinal_type, double, float>
       (fillLevel, params, paramName, prefix);
   }
   // For the other parameters, we prefer magnitude_type, but allow

--- a/packages/ifpack2/src/Ifpack2_RILUK_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_RILUK_def.hpp
@@ -34,8 +34,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
-//
 // ***********************************************************************
 //@HEADER
 */
@@ -46,63 +44,7 @@
 #include "Ifpack2_LocalFilter.hpp"
 #include "Tpetra_CrsMatrix.hpp"
 #include "Ifpack2_LocalSparseTriangularSolver.hpp"
-
-namespace { // (anonymous)
-
-  template<class ResultType, class ... CandidateTypes>
-  struct GetParamTryingTypes {};
-
-  template<class ResultType>
-  struct GetParamTryingTypes<ResultType> {
-    static void
-    get (ResultType& /* result */,
-         const Teuchos::ParameterEntry& /* ent */,
-         const std::string& paramName,
-         const char prefix[])
-    {
-      using Teuchos::TypeNameTraits;
-      TEUCHOS_TEST_FOR_EXCEPTION
-        (true, std::invalid_argument, prefix << "\"" << paramName
-         << "\" parameter exists in input ParameterList, but does not "
-         "have the right type.  The proper type is "
-         << TypeNameTraits<ResultType>::name () << ".");
-    }
-  };
-
-  template<class ResultType, class First, class ... Rest>
-  struct GetParamTryingTypes<ResultType, First, Rest...> {
-    static void
-    get (ResultType& result,
-         const Teuchos::ParameterEntry& ent,
-         const std::string& paramName,
-         const char prefix[])
-    {
-      if (ent.template isType<First> ()) {
-        result = static_cast<ResultType> (Teuchos::getValue<First> (ent));
-      }
-      else {
-        using rest_type = GetParamTryingTypes<ResultType, Rest...>;
-        rest_type::get (result, ent, paramName, prefix);
-      }
-    }
-  };
-
-  template<class ResultType, class ... CandidateTypes>
-  void
-  getParamTryingTypes (ResultType& result,
-                       const Teuchos::ParameterList& params,
-                       const std::string& paramName,
-                       const char prefix[])
-  {
-    using Teuchos::ParameterEntry;
-    const ParameterEntry* ent = params.getEntryPtr (paramName);
-    if (ent != nullptr) {
-      using impl_type = GetParamTryingTypes<ResultType, CandidateTypes...>;
-      impl_type::get (result, *ent, paramName, prefix);
-    }
-  }
-
-} // namespace (anonymous)
+#include "Ifpack2_Details_getParamTryingTypes.hpp"
 
 namespace Ifpack2 {
 
@@ -326,6 +268,7 @@ void
 RILUK<MatrixType>::
 setParameters (const Teuchos::ParameterList& params)
 {
+  using Details::getParamTryingTypes;
   using GO = global_ordinal_type;
   const char prefix[] = "Ifpack2::RILUK: ";
 

--- a/packages/ifpack2/src/Ifpack2_RILUK_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_RILUK_def.hpp
@@ -269,7 +269,6 @@ RILUK<MatrixType>::
 setParameters (const Teuchos::ParameterList& params)
 {
   using Details::getParamTryingTypes;
-  using GO = global_ordinal_type;
   const char prefix[] = "Ifpack2::RILUK: ";
 
   // Default values of the various parameters.
@@ -280,12 +279,14 @@ setParameters (const Teuchos::ParameterList& params)
 
   // "fact: iluk level-of-fill" parsing is more complicated, because
   // we want to allow as many types as make sense.  int is the native
-  // type, but we also want to accept magnitude_type (for
-  // compatibility with ILUT) and double (for backwards compatibilty
-  // with ILUT).
+  // type, but we also want to accept double (for backwards
+  // compatibilty with ILUT).
   {
     const std::string paramName ("fact: iluk level-of-fill");
-    getParamTryingTypes<int, magnitude_type, double, int, GO>
+    // You can't cast arbitrary magnitude_type (e.g.,
+    // Sacado::MP::Vector) to int, so we use float instead, to get
+    // coverage of the most common magnitude_type cases.
+    getParamTryingTypes<int, int, double, float>
       (fillLevel, params, paramName, prefix);
   }
   // For the other parameters, we prefer magnitude_type, but allow


### PR DESCRIPTION
@trilinos/ifpack2 @trilinos/muelu 

## Description

1. Partially fix #4647 by removing almost all use of try-catch for `Teuchos::ParameterList` control flow (an antipattern) from Ifpack2.
2. Remove some unnecessary `Tpetra::MultiVector` allocations from `Ifpack2::AdditiveSchwarz::apply`.  Thanks to Robert Knaus for pointing this out.
3. Remove duplication from `Teuchos::ParameterList` processing in Ifpack2.

## Related Issues

* Part of #4647 

