### PR TITLE
ATDM Add a cee-rhel6 no-global-int build to show additional Piro and ROL build errors

### DIFF
--- a/cmake/ctest/drivers/atdm/cee-rhel6/drivers/Trilinos-atdm-cee-rhel6_clang-5.0.1_openmpi-1.10.2_serial_static_opt_no-global-int.sh
+++ b/cmake/ctest/drivers/atdm/cee-rhel6/drivers/Trilinos-atdm-cee-rhel6_clang-5.0.1_openmpi-1.10.2_serial_static_opt_no-global-int.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ "${Trilinos_TRACK}" == "" ]; then
+  export Trilinos_TRACK=Experimental
+fi
+
+$WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cee-rhel6/local-driver.sh

--- a/cmake/std/atdm/cee-rhel6/all_supported_builds.sh
+++ b/cmake/std/atdm/cee-rhel6/all_supported_builds.sh
@@ -7,4 +7,5 @@ export ATDM_CONFIG_ALL_SUPPORTED_BUILDS=(
   cee-rhel6_gnu-7.2.0_openmpi-1.10.2_serial_shared_opt     # SPARC CI build
   cee-rhel6_intel-17.0.1_intelmpi-5.1.2_serial_static_opt  # SPARC Nightly Build
   cee-rhel6_intel-18.0.2_mpich2-3.2_openmp_static_opt      # SPARC CI build
+  cee-rhel6_clang-5.0.1_openmpi-1.10.2_serial_static_opt_no-global-int  # Temp build
   )

--- a/cmake/std/atdm/ctest-s-local-test-driver.sh
+++ b/cmake/std/atdm/ctest-s-local-test-driver.sh
@@ -63,7 +63,7 @@ fi
 
 echo
 echo "***"
-echo "*** $0 " "$@"
+echo "*** $0"
 echo "***"
 echo
 


### PR DESCRIPTION
This adds the build:

* `Trilinos-atdm-cee-rhel6_clang-5.0.1_openmpi-1.10.2_serial_static_opt_no-global-int`

which shows new build errors for Piro and ROL tests/examples that did not exist in the existing build `Trilinos-atdm-sems-rhel6-gnu-7.2.0-openmp-release-debug-no-global-int`.  This is likely because the 'cee-rhel6' builds enable extra packages and TPLs used by SPARC.

I tested this on 'ceerws1113' running:

```
$ cd /scratch/rabartl/Trilinos.base/BUILDS/ATDM/CEE-RHEL6/CTEST_S/

$ env Trilinos_PACKAGES=Piro,ROL \
  ./ctest-s-local-test-driver-cee-rhel6.sh \
  cee-rhel6_clang-5.0.1_openmpi-1.10.2_serial_static_opt_no-global-int


***
*** /scratch/rabartl/Trilinos.base/Trilinos/cmake/std/atdm/ctest-s-local-test-driver.sh
***

ATDM_TRILINOS_DIR = '/scratch/rabartl/Trilinos.base/Trilinos'

Load some env to get python, cmake, etc ...

Hostname 'ceerws1113' matches known ATDM host 'cee-rhel6' and system 'cee-rhel6'
Setting compiler and build options for build-name 'cee-rhel6-default'
Using CEE RHEL6 compiler stack CLANG-5.0.1_OPENMPI-1.10.2 to build DEBUG code with Kokkos node type SERIAL

Running builds:
    cee-rhel6_clang-5.0.1_openmpi-1.10.2_serial_static_opt_no-global-int

Running Jenkins driver Trilinos-atdm-cee-rhel6_clang-5.0.1_openmpi-1.10.2_serial_static_opt_no-global-int.sh ...

Creating directory: Trilinos-atdm-cee-rhel6_clang-5.0.1_openmpi-1.10.2_serial_static_opt_no-global-int
Creating directory: SRC_AND_BUILD

real    21m55.685s
user    273m47.158s
sys     11m59.519s
```

That posted to:

* [Trilinos-atdm-cee-rhel6_clang-5.0.1_openmpi-1.10.2_serial_static_opt_no-global-int-exp](https://testing-dev.sandia.gov/cdash/index.php?project=Trilinos&parentid=4679403)

and showed build errors [here](https://testing-dev.sandia.gov/cdash/viewBuildError.php?buildid=4679403) for:

* `packages/piro/test/Piro_AnalysisDriverTpetra.exe`
* `packages/rol/adapters/tpetra/test/vector/CMakeFiles/ROL_adapters_tpetra_test_vector_SimulatedVectorTpetraBatchManagerInterface.dir/test_02.cpp.o`

I will add new ATDM Trilinos GitHub issues for these.
