### PR TITLE
Tpetra: Fix logic used in all Reduce

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_allReduceView.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_allReduceView.hpp
@@ -182,17 +182,11 @@ allReduceView (const OutputViewType& output,
     return;
   }
 
-  // We've had some experience that some MPI implementations do not
-  // perform well with UVM allocations.
-  const bool assumeMpiCanAccessBuffers =
-    ! view_is_cuda_uvm<OutputViewType>::value &&
-    ! view_is_cuda_uvm<InputViewType>::value &&
-    ::Tpetra::Details::Behavior::assumeMpiIsCudaAware ();
-
   const bool needContiguousTemporaryBuffers =
-    ! assumeMpiCanAccessBuffers ||
     ::Tpetra::Details::isInterComm (comm) ||
-    output.span_is_contiguous () || input.span_is_contiguous ();
+    (! output.span_is_contiguous () )     ||
+    (! input.span_is_contiguous () );
+
   if (needContiguousTemporaryBuffers) {
     auto output_tmp = makeContiguousBuffer (output);
     auto input_tmp = makeContiguousBuffer (input);

--- a/packages/tpetra/core/src/Tpetra_Details_allReduceView.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_allReduceView.hpp
@@ -182,11 +182,17 @@ allReduceView (const OutputViewType& output,
     return;
   }
 
-  const bool needContiguousTemporaryBuffers =
-    ::Tpetra::Details::isInterComm (comm) ||
-    (! output.span_is_contiguous () )     ||
-    (! input.span_is_contiguous () );
+  // We've had some experience that some MPI implementations do not
+  // perform well with UVM allocations.
+  const bool assumeMpiCanAccessBuffers =
+    ! view_is_cuda_uvm<OutputViewType>::value &&
+    ! view_is_cuda_uvm<InputViewType>::value &&
+    ::Tpetra::Details::Behavior::assumeMpiIsCudaAware ();
 
+  const bool needContiguousTemporaryBuffers =
+    ! assumeMpiCanAccessBuffers ||
+    ::Tpetra::Details::isInterComm (comm) ||
+    output.span_is_contiguous () || input.span_is_contiguous ();
   if (needContiguousTemporaryBuffers) {
     auto output_tmp = makeContiguousBuffer (output);
     auto input_tmp = makeContiguousBuffer (input);


### PR DESCRIPTION
The prior logic had conditions based on whether the view was Cuda UVM or
not.  If UVM, you always end up creating 2 views and performance 2
copies. This unneeded.  Moreover, the logic for whether the input views
were contiguous was backwards (it trigged the code path for non-contig
cases when the views were actually contiguous!).

This fix enables a 2-3x speedup for small payload allreduces.

@trilinos/tpetra 

