### PR TITLE
MueLu: adding logic in region driver for structured/unstructured runs

### DIFF
--- a/packages/muelu/research/regionMG/examples/structured/CMakeLists.txt
+++ b/packages/muelu/research/regionMG/examples/structured/CMakeLists.txt
@@ -12,7 +12,7 @@ IF (${PACKAGE_NAME}_ENABLE_Tpetra AND ${PACKAGE_NAME}_ENABLE_Amesos2)
     )
 
   TRIBITS_COPY_FILES_TO_BINARY_DIR(StructuredRegion_cp
-    SOURCE_FILES structured_1dof.xml structured_linear_1dof.xml
+    SOURCE_FILES structured_1dof.xml structured_1dof-complex.xml structured_linear_1dof.xml structured_unstructured_1dof.xml
     )
 
   TRIBITS_ADD_TEST(

--- a/packages/muelu/research/regionMG/examples/structured/structured_1dof-complex.xml
+++ b/packages/muelu/research/regionMG/examples/structured/structured_1dof-complex.xml
@@ -92,7 +92,7 @@
       <ParameterList name="ParameterList">
         <Parameter name="relaxation: type"                 type="string"    value="Jacobi"/>
         <Parameter name="relaxation: sweeps"               type="int"       value="1"/>
-        <Parameter name="relaxation: damping"              type="double"    value="0.666"/>
+        <!-- <Parameter name="relaxation: damping"              type="double"    value="0.666"/> -->
       </ParameterList>
     </ParameterList>
 

--- a/packages/muelu/research/regionMG/examples/structured/structured_linear_1dof.xml
+++ b/packages/muelu/research/regionMG/examples/structured/structured_linear_1dof.xml
@@ -98,7 +98,7 @@
     <Parameter name="verbosity"                             type="string"   value="High"/>
 
     <ParameterList name="All">
-      <Parameter name="PreSmoother"                         type="string"   value="myILU"/>
+      <Parameter name="PreSmoother"                         type="string"   value="NoSmoother"/>
       <Parameter name="PostSmoother"                        type="string"   value="NoSmoother"/>
       <Parameter name="Nullspace"                           type="string"   value="myNullspaceFact"/>
       <Parameter name="Aggregates"                          type="string"   value="myAggregationFact"/>

--- a/packages/muelu/research/regionMG/examples/structured/structured_unstructured_1dof.xml
+++ b/packages/muelu/research/regionMG/examples/structured/structured_unstructured_1dof.xml
@@ -15,12 +15,12 @@
     </ParameterList>
 
     <ParameterList name="myAggregationFact">
-      <Parameter name="factory"                                   type="string" value="StructuredAggregationFactory"/>
+      <Parameter name="factory"                                   type="string" value="HybridAggregationFactory"/>
       <Parameter name="aggregation: coupling"                     type="string" value="uncoupled"/>
-      <Parameter name="aggregation: output type"                  type="string" value="CrsGraph"/>
       <Parameter name="aggregation: coarsening order"             type="int"    value="0"/>
       <Parameter name="aggregation: coarsening rate"              type="string" value="{2}"/>
       <Parameter name="Graph"                                     type="string" value="myCoalesceDropFact"/>
+      <Parameter name="DofsPerNode"                               type="string" value="myCoalesceDropFact"/>
     </ParameterList>
 
     <ParameterList name="myCoarseMapFact">
@@ -28,21 +28,17 @@
       <Parameter name="Aggregates"                          type="string" value="myAggregationFact"/>
     </ParameterList>
 
-    <!-- Note that ParameterLists must be defined prior to being used -->
     <ParameterList name="myProlongatorFact">
-      <Parameter name="factory"                             type="string" value="GeometricInterpolationPFactory"/>
-      <Parameter name="interp: build coarse coordinates"    type="bool"   value="true"/>
-      <Parameter name="interp: interpolation order"         type="int"    value="0"/>
-      <Parameter name="prolongatorGraph"                    type="string" value="myAggregationFact"/>
-      <Parameter name="coarseCoordinatesFineMap"            type="string" value="myAggregationFact"/>
-      <Parameter name="coarseCoordinatesMap"                type="string" value="myAggregationFact"/>
+      <Parameter name="factory"                             type="string" value="TentativePFactory"/>
+      <Parameter name="tentative: build coarse coordinates" type="bool"   value="true" />
     </ParameterList>
 
     <ParameterList name="myCoordTransferFact">
       <Parameter name="factory"                             type="string" value="CoordinatesTransferFactory"/>
-      <Parameter name="structured aggregation"              type="bool"   value="true"/>
+      <Parameter name="hybrid aggregation"                  type="bool"   value="true"/>
       <Parameter name="numDimensions"                       type="string" value="myAggregationFact"/>
       <Parameter name="lCoarseNodesPerDim"                  type="string" value="myAggregationFact"/>
+      <Parameter name="aggregationRegionTypeCoarse"         type="string" value="myAggregationFact"/>
     </ParameterList>
 
     <ParameterList name="myNullspaceFact">
@@ -72,37 +68,13 @@
       </ParameterList>
     </ParameterList>
 
-    <ParameterList name="myILU">
-      <Parameter name="factory" type="string" value="TrilinosSmoother"/>
-      <Parameter name="type"  type="string" value="RILUK"/>
-      <ParameterList name="ParameterList">
-        <Parameter name="schwarz: overlap level"           type="int"    value="1"/>
-        <Parameter name="schwarz: combine mode"            type="string" value="Zero"/>
-        <Parameter name="schwarz: use reordering"          type="bool"   value="false"/>
-        <Parameter name="fact: iluk level-of-fill"         type="int"    value="0"/>
-        <Parameter name="fact: absolute threshold"         type="double" value="0."/>
-        <Parameter name="fact: relative threshold"         type="double" value="1."/>
-        <Parameter name="fact: relax value"                type="double" value="0."/>
-      </ParameterList>
-    </ParameterList>
-
-    <ParameterList name="myJacobi">
-      <Parameter name="factory" type="string" value="TrilinosSmoother"/>
-      <Parameter name="type"  type="string" value="RELAXATION"/>
-      <ParameterList name="ParameterList">
-        <Parameter name="relaxation: type"                 type="string"    value="Jacobi"/>
-        <Parameter name="relaxation: sweeps"               type="int"       value="1"/>
-        <Parameter name="relaxation: damping"              type="double"    value="0.666"/>
-      </ParameterList>
-    </ParameterList>
-
   </ParameterList>
 
 
   <!-- Definition of the multigrid preconditioner -->
   <ParameterList name="Hierarchy">
 
-    <Parameter name="max levels"                            type="int"      value="6"/> <!-- Max number of levels -->
+    <Parameter name="max levels"                            type="int"      value="2"/> <!-- Max number of levels -->
     <Parameter name="cycle type"                            type="string"   value="W"/>
     <Parameter name="coarse: max size"                      type="int"      value="20"/> <!-- Min number of rows on coarsest level -->
     <Parameter name="verbosity"                             type="string"   value="High"/>
@@ -112,12 +84,11 @@
       <Parameter name="PostSmoother"                        type="string"   value="NoSmoother"/>
       <Parameter name="Nullspace"                           type="string"   value="myNullspaceFact"/>
       <Parameter name="Aggregates"                          type="string"   value="myAggregationFact"/>
-      <Parameter name="lCoarseNodesPerDim"                  type="string"   value="myAggregationFact"/>
+      <!-- <Parameter name="lCoarseNodesPerDim"                  type="string"   value="myAggregationFact"/> -->
       <Parameter name="P"                                   type="string"   value="myProlongatorFact"/>
       <Parameter name="R"                                   type="string"   value="myRestrictorFact"/>
       <Parameter name="A"                                   type="string"   value="myRAPFact"/>
       <!-- <Parameter name="CoarseSolver"                        type="string"   value="DirectSolver"/> -->
-      <Parameter name="CoarseSolver"                        type="string"   value="myILU"/>
       <Parameter name="Coordinates"                         type="string"   value="myProlongatorFact"/>
       <Parameter name="lNodesPerDim"                        type="string"   value="myCoordTransferFact"/>
       <Parameter name="numDimensions"                       type="string"   value="myCoordTransferFact"/>

--- a/packages/muelu/src/Graph/StructuredAggregation/MueLu_StructuredAggregationFactory_def.hpp
+++ b/packages/muelu/src/Graph/StructuredAggregation/MueLu_StructuredAggregationFactory_def.hpp
@@ -187,17 +187,17 @@ namespace MueLu {
     if(currentLevel.GetLevelID() == 0) {
       // On level 0, data is provided by applications and has no associated factory.
       numDimensions = currentLevel.Get<int>("numDimensions", NoFactory::get());
+      lFineNodesPerDir = currentLevel.Get<Array<LO> >("lNodesPerDim", NoFactory::get());
       if(coupled) {
         gFineNodesPerDir = currentLevel.Get<Array<GO> >("gNodesPerDim", NoFactory::get());
       }
-      lFineNodesPerDir = currentLevel.Get<Array<LO> >("lNodesPerDim", NoFactory::get());
     } else {
       // On level > 0, data is provided directly by generating factories.
       numDimensions = Get<int>(currentLevel, "numDimensions");
+      lFineNodesPerDir = Get<Array<LO> >(currentLevel, "lNodesPerDim");
       if(coupled) {
         gFineNodesPerDir = Get<Array<GO> >(currentLevel, "gNodesPerDim");
       }
-      lFineNodesPerDir = Get<Array<LO> >(currentLevel, "lNodesPerDim");
     }
 
 

--- a/packages/muelu/src/Graph/StructuredAggregation/uncoupled/MueLu_UncoupledIndexManager_def.hpp
+++ b/packages/muelu/src/Graph/StructuredAggregation/uncoupled/MueLu_UncoupledIndexManager_def.hpp
@@ -59,8 +59,9 @@ namespace MueLu {
                                  const int MyRank, const int NumRanks,
                                  const Array<GO> GFineNodesPerDir, const Array<LO> LFineNodesPerDir,
                                  const Array<LO> CoarseRate) :
-  IndexManager(comm, coupled, NumDimensions, interpolationOrder, GFineNodesPerDir, LFineNodesPerDir),
-  myRank(MyRank), numRanks(NumRanks) {
+    IndexManager(comm, coupled, NumDimensions, interpolationOrder, Array<GO>(3, -1), LFineNodesPerDir),
+    myRank(MyRank), numRanks(NumRanks)
+  {
 
     // Load coarse rate, being careful about formating
     for(int dim = 0; dim < 3; ++dim) {

--- a/packages/muelu/src/Misc/MueLu_CoordinatesTransferFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_CoordinatesTransferFactory_def.hpp
@@ -112,6 +112,7 @@ namespace MueLu {
     if(pL.get<bool>("hybrid aggregation") == true) {
       Input(fineLevel,"aggregationRegionTypeCoarse");
       Input(fineLevel, "lCoarseNodesPerDim");
+      Input(fineLevel, "numDimensions");
     }
   }
 
@@ -133,12 +134,13 @@ namespace MueLu {
 
     if(pL.get<bool>("hybrid aggregation") == true) {
       std::string regionType = Get<std::string>(fineLevel,"aggregationRegionTypeCoarse");
+      numDimensions          = Get<int>(fineLevel, "numDimensions");
       lCoarseNodesPerDir     = Get<Array<LO> >(fineLevel, "lCoarseNodesPerDim");
       Set<std::string>(coarseLevel, "aggregationRegionType", regionType);
+      Set<int>(coarseLevel, "numDimensions", numDimensions);
       Set< Array<LO> >(coarseLevel, "lNodesPerDim", lCoarseNodesPerDir);
-    }
 
-    if(pL.get<bool>("structured aggregation") == true) {
+    } else if(pL.get<bool>("structured aggregation") == true) {
       if(pL.get<bool>("aggregation coupled") == true) {
         gCoarseNodesPerDir = Get<Array<GO> >(fineLevel, "gCoarseNodesPerDim");
         Set<Array<GO> >(coarseLevel, "gNodesPerDim", gCoarseNodesPerDir);
@@ -147,6 +149,7 @@ namespace MueLu {
       Set<Array<LO> >(coarseLevel, "lNodesPerDim", lCoarseNodesPerDir);
       numDimensions = Get<int>(fineLevel, "numDimensions");
       Set<int>(coarseLevel, "numDimensions", numDimensions);
+
     } else if(pL.get<bool>("Geometric") == true) {
       coarseCoords       = Get<RCP<xdMV> >(coarseLevel, "coarseCoordinates");
       gCoarseNodesPerDir = Get<Array<GO> >(coarseLevel, "gCoarseNodesPerDim");

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_CoarseMapFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_CoarseMapFactory_def.hpp
@@ -177,13 +177,13 @@ namespace MueLu {
     GlobalOrdinal indexBase   = aggregates->GetMap()->getIndexBase();
 
     RCP<const Map> coarseMap = StridedMapFactory::Build(aggregates->GetMap()->lib(),
-        Teuchos::OrdinalTraits<Xpetra::global_size_t>::invalid(),
-        nCoarseDofs,
-        indexBase,
-        stridingInfo_,
-        comm,
-        stridedBlockId,
-        domainGidOffset);
+                                                        Teuchos::OrdinalTraits<Xpetra::global_size_t>::invalid(),
+                                                        nCoarseDofs,
+                                                        indexBase,
+                                                        stridingInfo_,
+                                                        comm,
+                                                        stridedBlockId,
+                                                        domainGidOffset);
 
     Set(currentLevel, "CoarseMap", coarseMap);
   } // Build

--- a/packages/muelu/test/unit_tests/Aggregates.cpp
+++ b/packages/muelu/test/unit_tests/Aggregates.cpp
@@ -233,18 +233,13 @@ class AggregateGenerator {
     gimmeHybridAggregates(const RCP<Matrix>&A, RCP<AmalgamationInfo> & amalgInfo,
                           const std::string regionType,
                           Array<GO> gNodesPerDir, Array<LO> lNodesPerDir,
-                          const LO numDimensions, const std::string meshLayout,
-                          const Array<GO> meshData)
+                          const LO numDimensions)
     {
       Level level;
       TestHelpers::TestFactory<SC,LO,GO,NO>::createSingleLevelHierarchy(level);
       level.Set("A", A);
       level.Set("numDimensions", numDimensions);
-      level.Set("gNodesPerDim", gNodesPerDir);
       level.Set("lNodesPerDim", lNodesPerDir);
-      level.Set("aggregation: mesh data", meshData);
-
-      const std::string coupling = "uncoupled";
 
       RCP<AmalgamationFactory> amalgFact = rcp(new AmalgamationFactory());
       amalgFact->SetDefaultVerbLevel(MueLu::None);
@@ -255,8 +250,6 @@ class AggregateGenerator {
       RCP<HybridAggregationFactory> aggFact = rcp(new HybridAggregationFactory());
       aggFact->SetFactory("Graph", dropFact);
       // Structured
-      aggFact->SetParameter("aggregation: mode",                         Teuchos::ParameterEntry(coupling));
-      aggFact->SetParameter("aggregation: mesh layout",                  Teuchos::ParameterEntry(meshLayout));
       aggFact->SetParameter("aggregation: coarsening order",             Teuchos::ParameterEntry(0));
       aggFact->SetParameter("aggregation: coarsening rate",              Teuchos::ParameterEntry(std::string("{3}")));
       // Uncoupled
@@ -838,8 +831,7 @@ class AggregateGenerator {
     RCP<Aggregates> aggregates = AggregateGenerator<SC,LO,GO,NO>::
       gimmeHybridAggregates(A, amalgInfo, regionType,
                             gNodesPerDir, lNodesPerDir,
-                            numDimensions, meshLayout,
-                            meshData);
+                            numDimensions);
 
 
     TEST_EQUALITY(aggregates != Teuchos::null, true);

--- a/packages/muelu/test/unit_tests/IndexManager.cpp
+++ b/packages/muelu/test/unit_tests/IndexManager.cpp
@@ -579,7 +579,6 @@ namespace MueLuTests {
     if(myIndexManager->getNumGlobalFineNodes()      != -1)                          {chk = -1;}
     for(int dim = 0; dim < 3; ++dim) {
       if(myIndexManager->getCoarseningRate(dim)         != coarseRate[dim])         {chk = -1;}
-      if(myIndexManager->getGlobalFineNodesInDir(dim)   != gNodesPerDir[dim])       {chk = -1;}
     }
     if(comm->getSize() == 1) {
       if(myIndexManager->getNumLocalFineNodes()         != 125)                     {chk = -1;}


### PR DESCRIPTION
Primarily added an new xml file to drive the algorithm correctly.
Also cleaned up a bunch of aggregation related things that were not kept up to date with changes in structured aggregation.
Will probably go at it again especially to clean the constructor of UncoupledIndexManager.
Fixing tests that the changes to HybridAggregation beak.

@trilinos/muelu 

## Description
Refreshing the HybridAggregationFactory to bring it up to date with the new StructuredAggregationFactory interface. Also checking that the structured region multigrid can support runs where one rank is considered unstructured.

## Motivation and Context
This will prepare the driver and the hybrid aggregation for some work on interface aggregation that needs to happen for the region multigrid method.

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of #5467
* Composed of 


## How Has This Been Tested?
The tests have been run locally and all are passing.
A new xml has been added to allow users to exert HybridAggregation with the region driver

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.