### PR TITLE
Update for new module names for spack-rhel env (CDOFA-52)

### DIFF
--- a/cmake/std/atdm/spack-rhel/custom_builds.sh
+++ b/cmake/std/atdm/spack-rhel/custom_builds.sh
@@ -1,0 +1,36 @@
+#
+# Custom builds for spack-rhel env
+#
+# NOTE: This file gets sourced in atdm/utils/set_build_options.sh before the
+# default grep logic is applied.
+#
+
+if   [[ $ATDM_CONFIG_BUILD_NAME == *"gnu-7.2.0-openmpi-1.10.2"* ]] \
+  || [[ $ATDM_CONFIG_BUILD_NAME == *"gnu-7.2.0_openmpi-1.10.2"* ]] \
+  ; then
+  export ATDM_CONFIG_COMPILER=GNU-7.2.0_OPENMPI-1.10.2
+
+elif [[ $ATDM_CONFIG_BUILD_NAME == *"gnu-7.2.0-openmpi-2.1.2"* ]] \
+  || [[ $ATDM_CONFIG_BUILD_NAME == *"gnu-7.2.0_openmpi-2.1.2"* ]] \
+  ; then
+  export ATDM_CONFIG_COMPILER=GNU-7.2.0_OPENMPI-2.1.2
+
+elif [[ $ATDM_CONFIG_BUILD_NAME == *"gnu-7.2.0"* ]] \
+  || [[ $ATDM_CONFIG_BUILD_NAME == *"gnu"* ]] \
+  || [[ $ATDM_CONFIG_BUILD_NAME == *"default" ]] \
+  ; then
+  export ATDM_CONFIG_COMPILER=GNU-7.2.0_OPENMPI-1.10.2
+
+else
+  echo
+  echo "***"
+  echo "*** ERROR: A supported compiler was not selected for 'spack-rhel' env"
+  echo "***"
+  echo "*** Supported compilers include:"
+  echo "***"
+  echo "****  gnu-7.2.0-openmpi-1.10.2 (default)"
+  echo "****  gnu-7.2.0-openmpi-2.1.2"
+  echo "***"  
+  return
+
+fi

--- a/cmake/std/atdm/spack-rhel/environment.sh
+++ b/cmake/std/atdm/spack-rhel/environment.sh
@@ -8,31 +8,33 @@
 ################################################################################
 
 #
-# Deal with compiler versions
+# Functions
 #
 
-if [ "$ATDM_CONFIG_COMPILER" == "DEFAULT" ] ; then
-  export ATDM_CONFIG_COMPILER=GNU-7.2.0
-elif [[ "$ATDM_CONFIG_COMPILER" == "GNU"* ]]; then
-  if [[ "$ATDM_CONFIG_COMPILER" == "GNU" ]] ; then
-    export ATDM_CONFIG_COMPILER=GNU-7.2.0
-  elif [[ "$ATDM_CONFIG_COMPILER" != "GNU-7.2.0" ]] ; then
-    echo
-    echo "***"
-    echo "*** ERROR: GNU COMPILER=$ATDM_CONFIG_COMPILER is not supported!"
-    echo "*** Only GNU compilers supported on this system are:"
-    echo "***   gnu (defaults to gnu-7.2.0)"
-    echo "***   gnu-7.2.0"
-    echo "***"
-    return
-  fi
-else
-  echo
-  echo "***"
-  echo "*** ERROR: COMPILER=$ATDM_CONFIG_COMPILER is not supported!"
-  echo "***"
-  return
-fi
+function load_spack_tpl_modules() {
+  compiler_dash_version=$1
+  mpi_dash_version=$2
+
+  module load spack-netlib-lapack/3.8.0-${compiler_dash_version}
+  export BLAS_ROOT=$NETLIB_LAPACK_ROOT
+  export LAPACK_ROOT=$NETLIB_LAPACK_ROOT
+
+  module load spack-binutils/2.31.1-${compiler_dash_version}
+  module load spack-gettext/0.19.8.1-${compiler_dash_version} # for binutils
+  module load spack-libiconv/1.15-${compiler_dash_version} # for gettext 
+  module load spack-boost/1.59.0-${compiler_dash_version}
+  module load spack-superlu/4.3-${compiler_dash_version}
+  module load spack-zlib/1.2.11-${compiler_dash_version}
+  module load spack-metis/5.1.0-${compiler_dash_version}
+  module load spack-hdf5/1.8.21-${compiler_dash_version}-${mpi_dash_version}
+  module load spack-netcdf/4.4.1-${compiler_dash_version}-${mpi_dash_version}
+  module load spack-parallel-netcdf/1.11.0-${compiler_dash_version}-${mpi_dash_version}
+  module load spack-parmetis/4.0.3-${compiler_dash_version}-${mpi_dash_version}
+  module load spack-cgns/snl-atdm-${compiler_dash_version}-${mpi_dash_version}
+  module load spack-superlu-dist/6.1.0-${compiler_dash_version}-${mpi_dash_version}
+
+}
+
 
 #
 # Allow KOKKOS_ARCH to be set but unset it if DEFAULT
@@ -70,7 +72,7 @@ export ATDM_CONFIG_BUILD_COUNT=$ATDM_CONFIG_MAX_NUM_CORES_TO_USE
 # NOTE: Use as many build processes and there are cores by default.
 
 module purge
-module load spack-cmake/3.13.4-gcc-7.2.0
+module load spack-cmake/3.13.4-gcc-7.2.0  # ToDo: Remove compiler from name of these!
 module load spack-git/2.20.1-gcc-7.2.0
 module load spack-ninja-fortran/1.7.2.gaad58-gcc-7.2.0
 
@@ -97,7 +99,7 @@ else
   # instead run with half that many to be safe and avoid time-outs.
 fi
 
-if [ "$ATDM_CONFIG_COMPILER" == "GNU-7.2.0" ]; then
+if [ "$ATDM_CONFIG_COMPILER" == "GNU-7.2.0_OPENMPI-1.10.2" ]; then
 
   module load spack-gcc/7.2.0
   export OMPI_CXX=`which g++`
@@ -106,23 +108,18 @@ if [ "$ATDM_CONFIG_COMPILER" == "GNU-7.2.0" ]; then
 
   module load spack-openmpi/1.10.1-gcc-7.2.0
 
-  module load spack-netlib-lapack/3.8.0-gcc-7.2.0
-  export BLAS_ROOT=$NETLIB_LAPACK_ROOT
-  export LAPACK_ROOT=$NETLIB_LAPACK_ROOT
+  load_spack_tpl_modules gcc-7.2.0 openmpi-1.10.1
 
-  module load spack-binutils/2.31.1-gcc-7.2.0
-  module load spack-gettext/0.19.8.1-gcc-7.2.0 # for binutils
-  module load spack-libiconv/1.15-gcc-7.2.0 # for gettext 
-  module load spack-boost/1.59.0-gcc-7.2.0
-  module load spack-netcdf/4.4.1-gcc-7.2.0-openmpi-1.10.1
-  module load spack-parallel-netcdf/1.11.0-gcc-7.2.0-openmpi-1.10.1
-  module load spack-superlu/4.3-gcc-7.2.0
-  module load spack-hdf5/1.8.21-gcc-7.2.0-openmpi-1.10.1
-  module load spack-zlib/1.2.11-gcc-7.2.0
-  module load spack-metis/5.1.0-gcc-7.2.0
-  module load spack-parmetis/4.0.3-gcc-7.2.0-openmpi-1.10.1
-  module load spack-cgns/snl-atdm-gcc-7.2.0-openmpi-1.10.1
-  module load spack-superlu-dist/6.1.0-gcc-7.2.0-openmpi-1.10.1
+elif [ "$ATDM_CONFIG_COMPILER" == "GNU-7.2.0_OPENMPI-2.1.2" ]; then
+
+  module load spack-gcc/7.2.0
+  export OMPI_CXX=`which g++`
+  export OMPI_CC=`which gcc`
+  export OMPI_FC=`which gfortran`
+
+  module load spack-openmpi/2.1.2-gcc-7.2.0
+
+  load_spack_tpl_modules gcc-7.2.0 openmpi-2.1.2
 
 else
   echo

--- a/cmake/std/atdm/spack-rhel/environment.sh
+++ b/cmake/std/atdm/spack-rhel/environment.sh
@@ -70,9 +70,9 @@ export ATDM_CONFIG_BUILD_COUNT=$ATDM_CONFIG_MAX_NUM_CORES_TO_USE
 # NOTE: Use as many build processes and there are cores by default.
 
 module purge
-module load gcc-7.2.0/spack-cmake/3.13.4
-module load gcc-7.2.0/spack-git/2.20.1
-module load gcc-7.2.0/spack-ninja-fortran/1.7.2.gaad58
+module load spack-cmake/3.13.4-gcc-7.2.0
+module load spack-git/2.20.1-gcc-7.2.0
+module load spack-ninja-fortran/1.7.2.gaad58-gcc-7.2.0
 
 if [[ "$ATDM_CONFIG_NODE_TYPE" == "OPENMP" ]] ; then
   export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=$(($ATDM_CONFIG_MAX_NUM_CORES_TO_USE/2))
@@ -99,30 +99,30 @@ fi
 
 if [ "$ATDM_CONFIG_COMPILER" == "GNU-7.2.0" ]; then
 
-  SPACK_GCC_COMPILER_TO_LOAD=`module avail 2>&1 | grep spack-gcc/7.2.0`
-  module load ${SPACK_GCC_COMPILER_TO_LOAD}
+  module load spack-gcc/7.2.0
   export OMPI_CXX=`which g++`
   export OMPI_CC=`which gcc`
   export OMPI_FC=`which gfortran`
 
-  module load gcc-7.2.0/spack-netlib-lapack/3.8.0
+  module load spack-openmpi/1.10.1-gcc-7.2.0
+
+  module load spack-netlib-lapack/3.8.0-gcc-7.2.0
   export BLAS_ROOT=$NETLIB_LAPACK_ROOT
   export LAPACK_ROOT=$NETLIB_LAPACK_ROOT
 
-  module load gcc-7.2.0/spack-binutils/2.31.1
-  module load gcc-7.2.0/spack-gettext/0.19.8.1 # for binutils
-  module load gcc-7.2.0/spack-libiconv/1.15 # for gettext 
-  module load gcc-7.2.0/spack-openmpi/1.10.1
-  module load gcc-7.2.0/spack-boost/1.59.0
-  module load gcc-7.2.0/spack-netcdf/4.4.1
-  module load gcc-7.2.0/spack-parallel-netcdf/1.11.0
-  module load gcc-7.2.0/spack-superlu/4.3
-  module load gcc-7.2.0/spack-hdf5/1.8.21
-  module load gcc-7.2.0/spack-zlib/1.2.11
-  module load gcc-7.2.0/spack-metis/5.1.0
-  module load gcc-7.2.0/spack-parmetis/4.0.3
-  module load gcc-7.2.0/spack-cgns/snl-atdm
-  module load gcc-7.2.0/spack-superlu-dist/6.1.0
+  module load spack-binutils/2.31.1-gcc-7.2.0
+  module load spack-gettext/0.19.8.1-gcc-7.2.0 # for binutils
+  module load spack-libiconv/1.15-gcc-7.2.0 # for gettext 
+  module load spack-boost/1.59.0-gcc-7.2.0
+  module load spack-netcdf/4.4.1-gcc-7.2.0-openmpi-1.10.1
+  module load spack-parallel-netcdf/1.11.0-gcc-7.2.0-openmpi-1.10.1
+  module load spack-superlu/4.3-gcc-7.2.0
+  module load spack-hdf5/1.8.21-gcc-7.2.0-openmpi-1.10.1
+  module load spack-zlib/1.2.11-gcc-7.2.0
+  module load spack-metis/5.1.0-gcc-7.2.0
+  module load spack-parmetis/4.0.3-gcc-7.2.0-openmpi-1.10.1
+  module load spack-cgns/snl-atdm-gcc-7.2.0-openmpi-1.10.1
+  module load spack-superlu-dist/6.1.0-gcc-7.2.0-openmpi-1.10.1
 
 else
   echo


### PR DESCRIPTION
Need to merge to this for the new module names for the updates spack modules (see [CDOFA-52](https://sems-atlassian-srn.sandia.gov/browse/CDOFA-52)).

I also added support for a gnu-7.2.0-openmpi-2.1.2 env (just for some testing).

NOTE: This is just stepping stone toward a more general setup where the user can select any Spack-supported compiler and MPI and it will adjust automatically.

I tested this locally as is documented in [CDOFA-52](https://sems-atlassian-srn.sandia.gov/browse/CDOFA-52).
