### PR TITLE
Turn down parallel build levels for waterman+cuda+rdc+debug (ATDV-182)

### DIFF
--- a/cmake/std/atdm/waterman/environment.sh
+++ b/cmake/std/atdm/waterman/environment.sh
@@ -55,10 +55,16 @@ echo "Using waterman compiler stack $ATDM_CONFIG_COMPILER to build $ATDM_CONFIG_
 export ATDM_CONFIG_ENABLE_SPARC_SETTINGS=ON
 export ATDM_CONFIG_USE_NINJA=ON
 
-if [[ "$ATDM_CONFIG_COMPILER" == "CUDA"* ]] && \
-  [[ "${ATDM_CONFIG_CUDA_RDC}" == "ON" ]] ; then
-  export ATDM_CONFIG_BUILD_COUNT=32
-  export ATDM_CONFIG_PARALLEL_LINK_JOBS_LIMIT=16
+if   [[ "$ATDM_CONFIG_COMPILER" == "CUDA"* ]] \
+  && [[ "${ATDM_CONFIG_CUDA_RDC}" == "ON" ]] \
+  ; then
+  if [[ "${ATDM_CONFIG_BUILD_TYPE}" == *"DEBUG" ]] ;then
+    export ATDM_CONFIG_BUILD_COUNT=20
+    export ATDM_CONFIG_PARALLEL_LINK_JOBS_LIMIT=10
+  else
+    export ATDM_CONFIG_BUILD_COUNT=32
+    export ATDM_CONFIG_PARALLEL_LINK_JOBS_LIMIT=16
+  fi
   # When CUDA+RDC is enabled, using all 64 cores to build and link results in
   # build errors as described in #4502.
 else


### PR DESCRIPTION
The build Trilinos-atdm-waterman-cuda-9.2-rdc-release-debug is currently
crashing due to OOM errors with the linker.  This is making it more
conservative in hopes that it will fix the errors.  See [ATDV-182](https://sems-atlassian-srn.sandia.gov/browse/ATDV-182).

I did some local testing just loading the envs and grepping for these vars.