### PR TITLE
MueLu: fix undefined vars in MatvecKernelDriver

### DIFF
--- a/packages/muelu/test/scaling/MatvecKernelDriver.cpp
+++ b/packages/muelu/test/scaling/MatvecKernelDriver.cpp
@@ -767,7 +767,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
         case Experiments::MKL:
         {
             TimeMonitor t(*TimeMonitor::getNewTimer("MV MKL: Total"));            
-            MV_MKL(AMKL,xdouble,ydouble);
+            MV_MKL(mkl_A,mkl_xdouble,mkl_ydouble);
         }
           break;
         #endif
@@ -869,7 +869,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
     }
 
 #if defined(HAVE_MUELU_MKL) 
-    mkl_sparse_destroy(AMKL);
+    mkl_sparse_destroy(mkl_A);
 #endif
 
     success = true;


### PR DESCRIPTION
Fixes the following compilation errors when MKL is enabled:

```
/dev/shm/nolta/cleanenv.NzTEvz/Trilinos/packages/muelu/test/scaling/MatvecKernelDriver.cpp(770): error: identifier "AMKL" is undefined
              MV_MKL(AMKL,xdouble,ydouble);
                     ^

/dev/shm/nolta/cleanenv.NzTEvz/Trilinos/packages/muelu/test/scaling/MatvecKernelDriver.cpp(770): error: identifier "xdouble" is undefined
              MV_MKL(AMKL,xdouble,ydouble);
                          ^

/dev/shm/nolta/cleanenv.NzTEvz/Trilinos/packages/muelu/test/scaling/MatvecKernelDriver.cpp(770): error: identifier "ydouble" is undefined
              MV_MKL(AMKL,xdouble,ydouble);
                                  ^

/dev/shm/nolta/cleanenv.NzTEvz/Trilinos/packages/muelu/test/scaling/MatvecKernelDriver.cpp(872): error: identifier "AMKL" is undefined
      mkl_sparse_destroy(AMKL);
                         ^

compilation aborted for /dev/shm/nolta/cleanenv.NzTEvz/Trilinos/packages/muelu/test/scaling/MatvecKernelDriver.cpp (code 2)
make[2]: *** [packages/muelu/test/scaling/CMakeFiles/MueLu_MatvecKernelDriver.dir/MatvecKernelDriver.cpp.o] Error 2
make[1]: *** [packages/muelu/test/scaling/CMakeFiles/MueLu_MatvecKernelDriver.dir/all] Error 2
make: *** [all] Error 2
```