### PR TITLE
galeri: fix #5490 by setting the entries in Nullspace_ equal to one

### DIFF
--- a/packages/galeri/src-xpetra/Galeri_StencilProblems.hpp
+++ b/packages/galeri/src-xpetra/Galeri_StencilProblems.hpp
@@ -69,7 +69,9 @@ namespace Galeri {
 
     template <typename Map, typename Matrix, typename MultiVector>
     Teuchos::RCP<MultiVector> ScalarProblem<Map,Matrix,MultiVector>::BuildNullspace() {
-      return this->Nullspace_ = MultiVectorTraits<Map,MultiVector>::Build(this->Map_, 1);
+      this->Nullspace_ = MultiVectorTraits<Map,MultiVector>::Build(this->Map_, 1);
+      this->Nullspace_->putScalar(Teuchos::ScalarTraits<typename MultiVector::scalar_type>::one());
+      return this->Nullspace_;
     }
 
     // =============================================  Laplace1D  =============================================


### PR DESCRIPTION
@trilinos/galeri 

## Description
The current implementation of `ScalarProblem` in Galeri constructs a MultiVector for the Nullspace_ but leaves it uninitialized.

## Motivation and Context
This is a bug that ought to be fixed to avoid bad surprises when MueLu relies on nullspace information for smoothed aggregation.

## Related Issues

* Closes #5490 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## How Has This Been Tested?
Local tests have been performed

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.