### PR TITLE
ATDM: Change from ctest -j8 to -j1 on mutrino

### DIFF
--- a/cmake/std/atdm/mutrino/environment.sh
+++ b/cmake/std/atdm/mutrino/environment.sh
@@ -39,10 +39,11 @@ export ATDM_CONFIG_MPI_EXEC="/opt/slurm/bin/srun"
 export ATDM_CONFIG_MPI_EXEC_NUMPROCS_FLAG="--ntasks"
 export ATDM_CONFIG_MPI_PRE_FLAGS="--mpi=pmi2;--ntasks-per-node;36"
 
-export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=8
-# NOTE: Using -j8 instead of -j16 for ctest is to try to avoid 'srun' "Job
-# <jobid> step creation temporarily disabled" failures on 'mutrino' (see
-# TRIL-214).
+export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=1
+# Using --hint=nomultithread seems to only allow one srun command to run at at
+# time while the others wait.  Threfore, you might as well just run with one
+# ctest process.  This should avoid the false timeouts and failures to start
+# srun we have been seeing for months on mutrino.
 
 if [ "$ATDM_CONFIG_COMPILER" == "INTEL" ] && [ "$ATDM_CONFIG_KOKKOS_ARCH" == "HSW"  ]; then
     module use /projects/EMPIRE/mutrino/tpls/hsw/modulefiles


### PR DESCRIPTION
The current settings for srun being used only allow for one srun command to
run a job at a time anyway so might as well avoid bogus timeouts and failures
due to srun timing out before it even starts a job.

The efforts to allow running in parllel on mutrino on the same node have not
worked out as of yet.  See:

    https://gitlab.kitware.com/snl/project-1/issues/91

I tested this on 'mutrino' with:

```
[rabartl@mutrino Trilinos (atdm-knl-ctest-j1)]$ . cmake/std/atdm/load-env.sh default
Hostname 'mutrino' matches known ATDM host 'mutrino' and system 'mutrino'
Setting compiler and build options for build-name 'default'
Using mutrino compiler stack INTEL to build DEBUG code with Kokkos node type SERIAL and KOKKOS_ARCH=HSW

[rabartl@mutrino Trilinos (atdm-knl-ctest-j1)]$ set | grep ATDM_CONFIG_CTEST
ATDM_CONFIG_CTEST_PARALLEL_LEVEL=1
```

