### PR TITLE
Tpetra and Ifpack2:  Minor changes to remove build warnings 

### DIFF
--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestAdditiveSchwarz.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestAdditiveSchwarz.cpp
@@ -444,7 +444,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2AdditiveSchwarz, RILUK_UserOrdering, Sc
     tif_utest::create_tpetra_map<LO,GO,Node>(num_rows_per_proc);
   RCP<const crs_matrix_type> crsmatrix =
     tif_utest::create_test_matrix<Scalar,LO,GO,Node>(rowmap);
-  size_t N = rowmap->getNodeNumElements();
 
   out << "Creating AdditiveSchwarz instance" << endl;
 
@@ -454,6 +453,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2AdditiveSchwarz, RILUK_UserOrdering, Sc
   out << "Filling in ParameterList for AdditiveSchwarz" << endl;
 
 #if defined(HAVE_IFPACK2_XPETRA) && defined(HAVE_IFPACK2_ZOLTAN2)
+  size_t N = rowmap->getNodeNumElements();
   params.set ("schwarz: use reordering", true);
 
   // Now let's do some user ordering.  Reverse ordering, because, why not?

--- a/packages/tpetra/core/src/Tpetra_Details_unpackCrsGraphAndCombine_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_unpackCrsGraphAndCombine_def.hpp
@@ -638,8 +638,6 @@ unpackAndCombineIntoCrsArrays2(
   using Kokkos::parallel_reduce;
   using Kokkos::atomic_fetch_add;
 
-  using packet_type = Packet;
-  using buffer_device_type = BufferDevice;
   using device_type = typename LocalMap::device_type;
   using LO = typename LocalMap::local_ordinal_type;
   using GO = typename LocalMap::global_ordinal_type;
@@ -890,7 +888,6 @@ unpackCrsGraphAndCombine(
   using UnpackAndCombineCrsGraphImpl::unpackAndCombine;
   using graph_type = CrsGraph<LO,GO,Node>;
   using device_type = typename Node::device_type;
-  using packet_type = typename graph_type::packet_type;
   using buffer_device_type = typename graph_type::buffer_device_type;
   using execution_space = typename device_type::execution_space;
   using range_policy = Kokkos::RangePolicy<execution_space, Kokkos::IndexType<LO>>;

--- a/packages/tpetra/core/test/ImportExport2/ImportExport2_UnitTests.cpp
+++ b/packages/tpetra/core/test/ImportExport2/ImportExport2_UnitTests.cpp
@@ -2022,7 +2022,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( Import_Util, UnpackAndCombineWithOwningPIDs, 
   typedef Tpetra::Import<LO, GO> ImportType;
   typedef Tpetra::CrsMatrix<Scalar, LO, GO> CrsMatrixType;
   using packet_type = typename Tpetra::CrsMatrix<Scalar, LO, GO>::packet_type;
-  using device_type = typename map_type::device_type;
   using GST = Tpetra::global_size_t;
   using IST = typename CrsMatrixType::impl_scalar_type;
   using buffer_device_type = typename CrsMatrixType::buffer_device_type;


### PR DESCRIPTION
@trilinos/tpetra @trilinos/ifpack2 

Very minor changes to remove build warnings.  These warnings were visible when Tpetra's deprecated code is disabled.

https://testing.sandia.gov/cdash/index.php?project=Trilinos&subproject=Tpetra&filtercount=2&showfilters=1&filtercombine=and&field1=site&compare1=63&value1=rocketman&field2=buildname&compare2=63&value2=DEPRECATED
