### PR TITLE
Belos,Ifpack2,Thyra,Tpetra: Remove use of KOKKOS_ENABLE_DEPRECATED_CODE macro

### DIFF
--- a/packages/belos/tpetra/example/WrapTpetraSolver/wrapTpetraSolver.cpp
+++ b/packages/belos/tpetra/example/WrapTpetraSolver/wrapTpetraSolver.cpp
@@ -349,13 +349,8 @@ private:
     mv_type R (B.getMap (), numVecs);
 
     computeResiduals (norms, R, *A_, X, B);
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-    norms.template sync<Kokkos::HostSpace> ();
-    auto norms_h = norms.template view<Kokkos::HostSpace> ();
-#else
     norms.sync_host ();
     auto norms_h = norms.view_host ();
-#endif
 
     SolverInput<SC, LO, GO, NT> input;
     input.tol = tol_;

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresSstep.hpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresSstep.hpp
@@ -83,15 +83,10 @@ public:
     // triangle of R.
 
     // Compute A_cur / R (Matlab notation for A_cur * R^{-1}) in place.
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-    A.template sync<Kokkos::HostSpace> ();
-    A.template modify<Kokkos::HostSpace> ();
-    auto A_lcl = A.template getLocalView<Kokkos::HostSpace> ();
-#else
     A.sync_host ();
     A.modify_host ();
     auto A_lcl = A.getLocalViewHost ();
-#endif
+
     SC* const A_lcl_raw = reinterpret_cast<SC*> (A_lcl.data ());
     const LO LDA = LO (A.getStride ());
 

--- a/packages/ifpack2/src/Ifpack2_BlockRelaxation_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockRelaxation_def.hpp
@@ -475,13 +475,9 @@ apply (const Tpetra::MultiVector<typename MatrixType::scalar_type,
   // we need to create an auxiliary vector, Xcopy
   Teuchos::RCP<const MV> X_copy;
   {
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-    auto X_lcl_host = X.template getLocalView<Kokkos::HostSpace> ();
-    auto Y_lcl_host = Y.template getLocalView<Kokkos::HostSpace> ();
-#else
     auto X_lcl_host = X.getLocalViewHost ();
     auto Y_lcl_host = Y.getLocalViewHost ();
-#endif
+
     if (X_lcl_host.data () == Y_lcl_host.data ()) {
       X_copy = rcp (new MV (X, Teuchos::Copy));
     } else {
@@ -717,30 +713,19 @@ BlockRelaxation<MatrixType,ContainerType>::
 ApplyInverseJacobi (const MV& X, MV& Y) const
 {
   const size_t NumVectors = X.getNumVectors ();
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-  typename ContainerType::HostView XView = X.template getLocalView<Kokkos::HostSpace> ();
-  typename ContainerType::HostView YView = Y.template getLocalView<Kokkos::HostSpace> ();
-#else
   auto XView = X.getLocalViewHost ();
   auto YView = Y.getLocalViewHost ();
-#endif
+
   MV AY (Y.getMap (), NumVectors);
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-  typename ContainerType::HostView AYView = AY.template getLocalView<Kokkos::HostSpace> ();
-#else
   auto AYView = AY.getLocalViewHost ();
-#endif
+
   // Initial matvec not needed
   int starting_iteration = 0;
   if (OverlapLevel_ > 0)
   {
     //Overlapping jacobi, with view of W_
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-    typename ContainerType::HostView WView = W_->template getLocalView<Kokkos::HostSpace> ();
-#else
     auto WView = W_->getLocalViewHost ();
-#endif
     if(ZeroStartingSolution_) {
       Container_->DoOverlappingJacobi(XView, YView, WView, X.getStride());
       starting_iteration = 1;
@@ -780,13 +765,8 @@ ApplyInverseGS (const MV& X, MV& Y) const
   using Teuchos::ptr;
   size_t numVecs = X.getNumVectors();
   //Get view of X (is never modified in this function)
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-  typename ContainerType::HostView XView = X.template getLocalView<Kokkos::HostSpace> ();
-  typename ContainerType::HostView YView = Y.template getLocalView<Kokkos::HostSpace> ();
-#else
   auto XView = X.getLocalViewHost ();
   auto YView = Y.getLocalViewHost ();
-#endif
   //Pre-import Y, if parallel
   Ptr<MV> Y2;
   bool deleteY2 = false;
@@ -803,21 +783,13 @@ ApplyInverseGS (const MV& X, MV& Y) const
     {
       //do import once per sweep
       Y2->doImport(Y, *Importer_, Tpetra::INSERT);
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-      typename ContainerType::HostView Y2View = Y2->template getLocalView<Kokkos::HostSpace> ();
-#else
       auto Y2View = Y2->getLocalViewHost ();
-#endif
       Container_->DoGaussSeidel(XView, YView, Y2View, X.getStride());
     }
   }
   else
   {
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-    typename ContainerType::HostView Y2View = Y2->template getLocalView<Kokkos::HostSpace> ();
-#else
     auto Y2View = Y2->getLocalViewHost ();
-#endif
     for(int j = 0; j < NumSweeps_; ++j)
     {
       Container_->DoGaussSeidel(XView, YView, Y2View, X.getStride());
@@ -835,13 +807,8 @@ ApplyInverseSGS (const MV& X, MV& Y) const
   using Teuchos::Ptr;
   using Teuchos::ptr;
   //Get view of X (is never modified in this function)
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-  typename ContainerType::HostView XView = X.template getLocalView<Kokkos::HostSpace> ();
-  typename ContainerType::HostView YView = Y.template getLocalView<Kokkos::HostSpace> ();
-#else
   auto XView = X.getLocalViewHost ();
   auto YView = Y.getLocalViewHost ();
-#endif
   //Pre-import Y, if parallel
   Ptr<MV> Y2;
   bool deleteY2 = false;
@@ -858,21 +825,13 @@ ApplyInverseSGS (const MV& X, MV& Y) const
     {
       //do import once per sweep
       Y2->doImport(Y, *Importer_, Tpetra::INSERT);
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-      typename ContainerType::HostView Y2View = Y2->template getLocalView<Kokkos::HostSpace> ();
-#else
       auto Y2View = Y2->getLocalViewHost ();
-#endif
       Container_->DoSGS(XView, YView, Y2View, X.getStride());
     }
   }
   else
   {
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-    typename ContainerType::HostView Y2View = Y2->template getLocalView<Kokkos::HostSpace> ();
-#else
     auto Y2View = Y2->getLocalViewHost ();
-#endif
     for(int j = 0; j < NumSweeps_; ++j)
     {
       Container_->DoSGS(XView, YView, Y2View, X.getStride());
@@ -947,7 +906,7 @@ description () const
     out << "Matrix: null, ";
   }
   else {
-    //    out << "Matrix: not null"    
+    //    out << "Matrix: not null"
     // << ", Global matrix dimensions: ["
     out << "Global matrix dimensions: ["
         << A_->getGlobalNumRows () << ", " << A_->getGlobalNumCols () << "], ";
@@ -975,7 +934,7 @@ description () const
   out << "block container: " << ((containerType == "Generic") ? containerType_ : containerType);
   if(List_.isParameter("partitioner: PDE equations"))
     out << ", dofs/node: "<<List_.get<int>("partitioner: PDE equations");
-     
+
 
   out << "}";
   return out.str();

--- a/packages/ifpack2/src/Ifpack2_Chebyshev_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Chebyshev_def.hpp
@@ -462,13 +462,8 @@ applyImpl (const MV& X,
   RCP<const MV> X_copy;
   bool copiedInput = false;
   {
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-    auto X_lcl_host = X.template getLocalView<Kokkos::HostSpace> ();
-    auto Y_lcl_host = Y.template getLocalView<Kokkos::HostSpace> ();
-#else
     auto X_lcl_host = X.getLocalViewHost ();
     auto Y_lcl_host = Y.getLocalViewHost ();
-#endif
     if (X_lcl_host.data () == Y_lcl_host.data ()) {
       X_copy = rcp (new MV (X, Teuchos::Copy));
       copiedInput = true;

--- a/packages/ifpack2/src/Ifpack2_Container.hpp
+++ b/packages/ifpack2/src/Ifpack2_Container.hpp
@@ -344,13 +344,9 @@ public:
   //! Wrapper for apply with MVs, used in unit tests (never called by BlockRelaxation)
   void applyMV (mv_type& X, mv_type& Y) const
   {
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-    HostView XView = X.template getLocalView<Kokkos::HostSpace>();
-    HostView YView = Y.template getLocalView<Kokkos::HostSpace>();
-#else
     HostView XView = X.getLocalViewHost();
     HostView YView = Y.getLocalViewHost();
-#endif
+
     this->apply (XView, YView, 0, X.getStride());
   }
 
@@ -389,15 +385,10 @@ public:
                         mv_type& Y,
                         vector_type& W)
   {
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-    HostView XView = X.template getLocalView<Kokkos::HostSpace>();
-    HostView YView = Y.template getLocalView<Kokkos::HostSpace>();
-    HostView WView = W.template getLocalView<Kokkos::HostSpace>();
-#else
     HostView XView = X.getLocalViewHost();
     HostView YView = Y.getLocalViewHost();
     HostView WView = W.getLocalViewHost();
-#endif
+
     weightedApply (XView, YView, WView, 0, X.getStride());
   }
 
@@ -476,11 +467,7 @@ void Container<MatrixType>::DoJacobi(HostView& X, HostView& Y, int stride) const
     {
       local_ordinal_type LRID = partitions_[partitionIndices_[i]];
       getMatDiag();
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-      HostView diagView = Diag_->template getLocalView<Kokkos::HostSpace>();
-#else
       HostView diagView = Diag_->getLocalViewHost();
-#endif
       impl_scalar_type d = (impl_scalar_type) one / diagView(LRID, 0);
       for(size_t nv = 0; nv < numVecs; nv++)
       {
@@ -588,11 +575,7 @@ void Container<MatrixType>::DoGaussSeidel(HostView& X, HostView& Y, HostView& Y2
       // a singleton calculation is exact, all residuals should be zero.
       local_ordinal_type LRID = partitionIndices_[i];  // by definition, a singleton 1 row in block.
       getMatDiag();
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-      HostView diagView = Diag_->template getLocalView<Kokkos::HostSpace>();
-#else
       HostView diagView = Diag_->getLocalViewHost();
-#endif
       impl_scalar_type d = (impl_scalar_type) one / diagView(LRID, 0);
       for(size_t m = 0; m < numVecs; m++)
       {
@@ -694,11 +677,7 @@ void Container<MatrixType>::DoSGS(HostView& X, HostView& Y, HostView& Y2, int st
     {
       local_ordinal_type LRID  = partitions_[partitionIndices_[i]];
       getMatDiag();
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-      HostView diagView = Diag_->template getLocalView<Kokkos::HostSpace>();
-#else
       HostView diagView = Diag_->getLocalViewHost();
-#endif
       impl_scalar_type d = (impl_scalar_type) one / diagView(LRID, 0);
       for(size_t m = 0; m < numVecs; m++)
       {

--- a/packages/ifpack2/src/Ifpack2_Details_Amesos2Wrapper_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Amesos2Wrapper_def.hpp
@@ -461,13 +461,9 @@ apply (const Tpetra::MultiVector<scalar_type, local_ordinal_type, global_ordinal
     // when computing the output.  Otherwise, alias X_temp to X.
     RCP<const MV> X_temp;
     {
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-      auto X_lcl_host = X.template getLocalView<Kokkos::HostSpace> ();
-      auto Y_lcl_host = Y.template getLocalView<Kokkos::HostSpace> ();
-#else
       auto X_lcl_host = X.getLocalViewHost ();
       auto Y_lcl_host = Y.getLocalViewHost ();
-#endif
+
       if (X_lcl_host.data () == Y_lcl_host.data ()) {
         X_temp = rcp (new MV (X, Teuchos::Copy));
       } else {

--- a/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
@@ -1043,13 +1043,8 @@ makeInverseDiagonal (const row_matrix_type& A, const bool useDiagOffsets) const
     // In debug mode, make sure that all diagonal entries are
     // positive, on all processes.  Note that *out_ only prints on
     // Process 0 of the matrix's communicator.
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-    D_rangeMap->template sync<Kokkos::HostSpace> ();
-    auto D_lcl = D_rangeMap->template getLocalView<Kokkos::HostSpace> ();
-#else
     D_rangeMap->sync_host ();
     auto D_lcl = D_rangeMap->getLocalViewHost ();
-#endif
     auto D_lcl_1d = Kokkos::subview (D_lcl, Kokkos::ALL (), 0);
 
     typedef typename MV::impl_scalar_type IST;

--- a/packages/ifpack2/src/Ifpack2_Experimental_RBILUK_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Experimental_RBILUK_def.hpp
@@ -320,16 +320,7 @@ initAllValues (const block_crs_matrix_type& A)
   // NOTE (mfh 27 May 2016) The factorization below occurs entirely on
   // host, so sync to host first.  The const_cast is unfortunate but
   // is our only option to make this correct.
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-  const_cast<block_crs_matrix_type&> (A).template sync<Kokkos::HostSpace> ();
-  L_block_->template sync<Kokkos::HostSpace> ();
-  U_block_->template sync<Kokkos::HostSpace> ();
-  D_block_->template sync<Kokkos::HostSpace> ();
-  // NOTE (mfh 27 May 2016) We're modifying L, U, and D on host.
-  L_block_->template modify<Kokkos::HostSpace> ();
-  U_block_->template modify<Kokkos::HostSpace> ();
-  D_block_->template modify<Kokkos::HostSpace> ();
-#else
+
   const_cast<block_crs_matrix_type&> (A).sync_host ();
   L_block_->sync_host ();
   U_block_->sync_host ();
@@ -338,7 +329,6 @@ initAllValues (const block_crs_matrix_type& A)
   L_block_->modify_host ();
   U_block_->modify_host ();
   D_block_->modify_host ();
-#endif
 
   RCP<const map_type> rowMap = L_block_->getRowMap ();
 
@@ -484,21 +474,8 @@ void RBILUK<MatrixType>::compute ()
   if (! A_block_.is_null ()) {
     Teuchos::RCP<block_crs_matrix_type> A_nc =
       Teuchos::rcp_const_cast<block_crs_matrix_type> (A_block_);
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-    A_nc->template sync<Kokkos::HostSpace> ();
-#else
     A_nc->sync_host ();
-#endif
   }
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-  L_block_->template sync<Kokkos::HostSpace> ();
-  U_block_->template sync<Kokkos::HostSpace> ();
-  D_block_->template sync<Kokkos::HostSpace> ();
-  // NOTE (mfh 27 May 2016) We're modifying L, U, and D on host.
-  L_block_->template modify<Kokkos::HostSpace> ();
-  U_block_->template modify<Kokkos::HostSpace> ();
-  D_block_->template modify<Kokkos::HostSpace> ();
-#else
   L_block_->sync_host ();
   U_block_->sync_host ();
   D_block_->sync_host ();
@@ -506,7 +483,6 @@ void RBILUK<MatrixType>::compute ()
   L_block_->modify_host ();
   U_block_->modify_host ();
   D_block_->modify_host ();
-#endif
 
   Teuchos::Time timer ("RBILUK::compute");
   { // Start timing

--- a/packages/ifpack2/src/Ifpack2_Hiptmair_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Hiptmair_def.hpp
@@ -315,13 +315,9 @@ apply (const Tpetra::MultiVector<typename MatrixType::scalar_type,
     // we need to create an auxiliary vector, Xcopy
     RCP<const MV> Xcopy;
     {
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-      auto X_lcl_host = X.template getLocalView<Kokkos::HostSpace> ();
-      auto Y_lcl_host = Y.template getLocalView<Kokkos::HostSpace> ();
-#else
       auto X_lcl_host = X.getLocalViewHost ();
       auto Y_lcl_host = Y.getLocalViewHost ();
-#endif
+
       if (X_lcl_host.data () == Y_lcl_host.data ()) {
         Xcopy = rcp (new MV (X, Teuchos::Copy));
       } else {

--- a/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
@@ -189,13 +189,9 @@ public:
     (void)alpha;
     (void)beta;
 #ifdef HAVE_IFPACK2_SHYLU_NODEHTS
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-    const auto& X_view = X.template getLocalView<Kokkos::HostSpace> ();
-    const auto& Y_view = Y.template getLocalView<Kokkos::HostSpace> ();
-#else
     const auto& X_view = X.getLocalViewHost ();
     const auto& Y_view = Y.getLocalViewHost ();
-#endif
+
     // Only does something if #rhs > current capacity.
     HTST::reset_max_nrhs(Timpl_.get(), X_view.extent(1));
     // Switch alpha and beta because of HTS's opposite convention.

--- a/packages/ifpack2/src/Ifpack2_Relaxation_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Relaxation_def.hpp
@@ -561,13 +561,9 @@ apply (const Tpetra::MultiVector<scalar_type, local_ordinal_type, global_ordinal
       RCP<const MV> Xcopy;
       // FIXME (mfh 12 Sep 2014) This test for aliasing is incomplete.
       {
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-        auto X_lcl_host = X.template getLocalView<Kokkos::HostSpace> ();
-        auto Y_lcl_host = Y.template getLocalView<Kokkos::HostSpace> ();
-#else
         auto X_lcl_host = X.getLocalViewHost ();
         auto Y_lcl_host = Y.getLocalViewHost ();
-#endif
+
         if (X_lcl_host.data () == Y_lcl_host.data ()) {
           Xcopy = rcp (new MV (X, Teuchos::Copy));
         } else {

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestBlockCrsUtil.hpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestBlockCrsUtil.hpp
@@ -246,11 +246,8 @@ struct BlockCrsMatrixMaker {
     const auto& g = a.getCrsGraph();
     const auto& rowptr = g.getLocalGraph().row_map;
     const auto& colidx = g.getLocalGraph().entries;
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-    const auto& values = a.template getValues<Kokkos::HostSpace>();
-#else
     const auto& values = a.getValuesHost();
-#endif
+
     const auto row_map = g.getRowMap();
     const auto col_map = g.getColMap();
     const LO bs = a.getBlockSize(), bs2 = bs*bs;
@@ -262,11 +259,7 @@ struct BlockCrsMatrixMaker {
       new Tpetra_Map(Tpetra_BlockMultiVector::makePointMap(*col_map, bs)));
     Tpetra_MultiVector_Magnitude colsum_mv(cpm, 1);
     colsum_mv.putScalar(0);
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-    auto colsum = colsum_mv.template getLocalView<Kokkos::HostSpace>();
-#else
     auto colsum = colsum_mv.getLocalViewHost();
-#endif
 
     // Get off-diag 1-norms.
     for (LO r = 0; r < nrows; ++r) {
@@ -296,7 +289,7 @@ struct BlockCrsMatrixMaker {
       Tpetra_Import importer(a.getDomainMap(), cpm);
       colsum_mv.doImport(d, importer, Tpetra::REPLACE);
     }
-  
+
     // Modify diag entries.
     for (LO r = 0; r < nrows; ++r) {
       const auto rgid = row_map->getGlobalElement(r);
@@ -431,7 +424,7 @@ struct BlockCrsMatrixMaker {
             }
       }
       TEUCHOS_ASSERT(static_cast<GO>(rowptr(nr)) == nnz);
-    
+
       // Sort columns in each row.
       for (Int r = 0; r < nr; ++r)
         std::sort(colidx.data() + rowptr(r), colidx.data() + rowptr(r+1));
@@ -506,7 +499,7 @@ struct BlockCrsMatrixMaker {
         }
     }
     if (K > 0) TEUCHOS_ASSERT(offdiag_idxs[0] != -1);
-    if (K+1 < sb.nk) TEUCHOS_ASSERT(offdiag_idxs[1] != -1);  
+    if (K+1 < sb.nk) TEUCHOS_ASSERT(offdiag_idxs[1] != -1);
   }
 
   template <typename View> static void

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestBlockRelaxation.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestBlockRelaxation.cpp
@@ -217,17 +217,12 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2BlockRelaxation, Test2, Scalar, LO, GO)
   MV x = *xrcp;
 
   TEST_INEQUALITY(&x, &y);                                               // vector x and y are different
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-  x.template sync<Kokkos::HostSpace> ();
-  y.template sync<Kokkos::HostSpace> ();
-  auto x_lcl_host = x.template getLocalView<Kokkos::HostSpace> ();
-  auto y_lcl_host = x.template getLocalView<Kokkos::HostSpace> ();
-#else
+
   x.sync_host ();
   y.sync_host ();
   auto x_lcl_host = x.getLocalViewHost ();
   auto y_lcl_host = x.getLocalViewHost ();
-#endif
+
   TEST_EQUALITY( x_lcl_host.data (), y_lcl_host.data () ); // vector x and y are pointing to the same memory location (such test only works if num of local elements != 0)
 
   prec.apply(x, y);

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestLocalSparseTriangularSolver.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestLocalSparseTriangularSolver.cpp
@@ -1059,15 +1059,9 @@ void testArrowMatrix (bool& success, Teuchos::FancyOStream& out)
   // Set up the right-hand side b.
   vec_type b (ranMap);
   {
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-    b.template sync<Kokkos::HostSpace> ();
-    b.template modify<Kokkos::HostSpace> ();
-    auto b_lcl_2d = b.template getLocalView<Kokkos::HostSpace> ();
-#else
     b.sync_host ();
     b.modify_host ();
     auto b_lcl_2d = b.getLocalViewHost ();
-#endif
     auto b_lcl_1d = Kokkos::subview (b_lcl_2d, Kokkos::ALL (), 0);
 
     for (LO i = 0; i < lclNumRows; ++i) {
@@ -1137,13 +1131,8 @@ void testArrowMatrix (bool& success, Teuchos::FancyOStream& out)
   {
     Teuchos::OSTab tab2 (out);
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-    c.template sync<Kokkos::HostSpace> ();
-    auto c_lcl_2d = c.template getLocalView<Kokkos::HostSpace> ();
-#else
     c.sync_host ();
     auto c_lcl_2d = c.getLocalViewHost ();
-#endif
     auto c_lcl_1d = Kokkos::subview (c_lcl_2d, Kokkos::ALL (), 0);
 
     for (LO i = 0; i + 1 < lclNumRows; ++i) {
@@ -1187,13 +1176,8 @@ void testArrowMatrix (bool& success, Teuchos::FancyOStream& out)
   {
     Teuchos::OSTab tab2 (out);
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-    x.template sync<Kokkos::HostSpace> ();
-    auto x_lcl_2d = x.template getLocalView<Kokkos::HostSpace> ();
-#else
     x.sync_host ();
     auto x_lcl_2d = x.getLocalViewHost ();
-#endif
     auto x_lcl_1d = Kokkos::subview (x_lcl_2d, Kokkos::ALL (), 0);
 
     for (LO i = 0; i + 1 < lclNumRows; ++i) {
@@ -1220,13 +1204,8 @@ void testArrowMatrix (bool& success, Teuchos::FancyOStream& out)
   {
     Teuchos::OSTab tab2 (out);
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-    c.template sync<Kokkos::HostSpace> ();
-    auto c_lcl_2d = c.template getLocalView<Kokkos::HostSpace> ();
-#else
     c.sync_host ();
     auto c_lcl_2d = c.getLocalViewHost ();
-#endif
     auto c_lcl_1d = Kokkos::subview (c_lcl_2d, Kokkos::ALL (), 0);
 
     for (LO i = 0; i + 1 < lclNumRows; ++i) {
@@ -1245,13 +1224,8 @@ void testArrowMatrix (bool& success, Teuchos::FancyOStream& out)
   {
     Teuchos::OSTab tab2 (out);
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-    x.template sync<Kokkos::HostSpace> ();
-    auto x_lcl_2d = x.template getLocalView<Kokkos::HostSpace> ();
-#else
     x.sync_host ();
     auto x_lcl_2d = x.getLocalViewHost ();
-#endif
     auto x_lcl_1d = Kokkos::subview (x_lcl_2d, Kokkos::ALL (), 0);
 
     for (LO i = 0; i + 1 < lclNumRows; ++i) {

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestRelaxation.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestRelaxation.cpp
@@ -194,13 +194,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2Relaxation, Test2, Scalar, LocalOrdinal
 
   TEST_INEQUALITY(&x, &y); // vector x and y are different
   // Vectors x and y point to the same data.
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-  TEST_EQUALITY(x.template getLocalView<Kokkos::HostSpace> ().data (),
-                y.template getLocalView<Kokkos::HostSpace> ().data ());
-#else
   TEST_EQUALITY(x.getLocalViewHost ().data (),
                 y.getLocalViewHost ().data ());
-#endif
 
   prec.apply(x, y);
 

--- a/packages/thyra/adapters/tpetra/src/Thyra_TpetraEuclideanScalarProd_def.hpp
+++ b/packages/thyra/adapters/tpetra/src/Thyra_TpetraEuclideanScalarProd_def.hpp
@@ -1,12 +1,12 @@
 // @HEADER
 // ***********************************************************************
-// 
+//
 //    Thyra: Interfaces and Support for Abstract Numerical Algorithms
 //                 Copyright (2004) Sandia Corporation
-// 
+//
 // Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
 // license for use of this work by or on behalf of the U.S. Government.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -34,8 +34,8 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Roscoe A. Bartlett (bartlettra@ornl.gov) 
-// 
+// Questions? Contact Roscoe A. Bartlett (bartlettra@ornl.gov)
+//
 // ***********************************************************************
 // @HEADER
 
@@ -71,17 +71,10 @@ void TpetraEuclideanScalarProd<Scalar,LocalOrdinal,GlobalOrdinal,Node>::scalarPr
     X_tpetra->dot(*Y_tpetra, scalarProds_out);
   } else {
     // If one of the casts succeeded, sync that MV to host space
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-    if (nonnull(X_tpetra))
-      Teuchos::rcp_const_cast<TMV>(X_tpetra)->template sync<Kokkos::HostSpace>();
-    if (nonnull(Y_tpetra))
-      Teuchos::rcp_const_cast<TMV>(Y_tpetra)->template sync<Kokkos::HostSpace>();
-#else
     if (nonnull(X_tpetra))
       Teuchos::rcp_const_cast<TMV>(X_tpetra)->sync_host ();
     if (nonnull(Y_tpetra))
       Teuchos::rcp_const_cast<TMV>(Y_tpetra)->sync_host ();
-#endif
 
     EuclideanScalarProd<Scalar>::scalarProdsImpl(X, Y, scalarProds_out);
   }

--- a/packages/thyra/adapters/tpetra/src/Thyra_TpetraMultiVector_def.hpp
+++ b/packages/thyra/adapters/tpetra/src/Thyra_TpetraMultiVector_def.hpp
@@ -131,13 +131,8 @@ assignMultiVecImpl(const MultiVectorBase<Scalar>& mv)
     tpetraMultiVector_.getNonconstObj()->assign(*tmv);
   } else {
     // This version will require/modify the host view of this vector.
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-    tpetraMultiVector_.getNonconstObj()->template sync<Kokkos::HostSpace>();
-    tpetraMultiVector_.getNonconstObj()->template modify<Kokkos::HostSpace>();
-#else
     tpetraMultiVector_.getNonconstObj()->sync_host ();
     tpetraMultiVector_.getNonconstObj()->modify_host ();
-#endif
     MultiVectorDefaultBase<Scalar>::assignMultiVecImpl(mv);
   }
 }
@@ -158,7 +153,7 @@ void TpetraMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>::updateImpl(
   )
 {
   auto tmv = this->getConstTpetraMultiVector(Teuchos::rcpFromRef(mv));
- 
+
   // If the cast succeeded, call Tpetra directly.
   // Otherwise, fall back to the RTOp implementation.
   if (nonnull(tmv)) {
@@ -166,13 +161,8 @@ void TpetraMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>::updateImpl(
     tpetraMultiVector_.getNonconstObj()->update(alpha, *tmv, ST::one());
   } else {
     // This version will require/modify the host view of this vector.
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-    tpetraMultiVector_.getNonconstObj()->template sync<Kokkos::HostSpace>();
-    tpetraMultiVector_.getNonconstObj()->template modify<Kokkos::HostSpace>();
-#else
     tpetraMultiVector_.getNonconstObj()->sync_host ();
     tpetraMultiVector_.getNonconstObj()->modify_host ();
-#endif
     MultiVectorDefaultBase<Scalar>::updateImpl(alpha, mv);
   }
 }
@@ -250,13 +240,8 @@ void TpetraMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>::linearCombinatio
     }
   } else {
     // This version will require/modify the host view of this vector.
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-    tpetraMultiVector_.getNonconstObj()->template sync<Kokkos::HostSpace>();
-    tpetraMultiVector_.getNonconstObj()->template modify<Kokkos::HostSpace>();
-#else
     tpetraMultiVector_.getNonconstObj()->sync_host ();
     tpetraMultiVector_.getNonconstObj()->modify_host ();
-#endif
     MultiVectorDefaultBase<Scalar>::linearCombinationImpl(alpha, mv, beta);
   }
 }
@@ -276,13 +261,8 @@ void TpetraMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>::dotsImpl(
     tpetraMultiVector_.getConstObj()->dot(*tmv, prods);
   } else {
     // This version will require/modify the host view of this vector.
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-    tpetraMultiVector_.getNonconstObj()->template sync<Kokkos::HostSpace>();
-    tpetraMultiVector_.getNonconstObj()->template modify<Kokkos::HostSpace>();
-#else
     tpetraMultiVector_.getNonconstObj()->sync_host ();
     tpetraMultiVector_.getNonconstObj()->modify_host ();
-#endif
     MultiVectorDefaultBase<Scalar>::dotsImpl(mv, prods);
   }
 }
@@ -485,13 +465,8 @@ mvMultiReductApplyOpImpl(
   for (auto itr = multi_vecs.begin(); itr != multi_vecs.end(); ++itr) {
     Ptr<const TMV> tmv = Teuchos::ptr_dynamic_cast<const TMV>(*itr);
     if (nonnull(tmv)) {
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-      Teuchos::rcp_const_cast<Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> >(
-      tmv->getConstTpetraMultiVector())-> template sync<Kokkos::HostSpace>();
-#else
       Teuchos::rcp_const_cast<Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> >(
       tmv->getConstTpetraMultiVector())-> sync_host ();
-#endif
     }
   }
 
@@ -499,13 +474,8 @@ mvMultiReductApplyOpImpl(
   for (auto itr = targ_multi_vecs.begin(); itr != targ_multi_vecs.end(); ++itr) {
     Ptr<TMV> tmv = Teuchos::ptr_dynamic_cast<TMV>(*itr);
     if (nonnull(tmv)) {
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-      tmv->getTpetraMultiVector()->template sync<Kokkos::HostSpace>();
-      tmv->getTpetraMultiVector()->template modify<Kokkos::HostSpace>();
-#else
       tmv->getTpetraMultiVector()->sync_host ();
       tmv->getTpetraMultiVector()->modify_host ();
-#endif
     }
   }
 
@@ -524,13 +494,8 @@ acquireDetachedMultiVectorViewImpl(
 {
   // Only viewing data, so just sync dual view to host space
   typedef typename Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> TMV;
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-  Teuchos::rcp_const_cast<TMV>(
-    tpetraMultiVector_.getConstObj())->template sync<Kokkos::HostSpace>();
-#else
   Teuchos::rcp_const_cast<TMV>(
     tpetraMultiVector_.getConstObj())->sync_host ();
-#endif
 
   SpmdMultiVectorDefaultBase<Scalar>::
     acquireDetachedMultiVectorViewImpl(rowRng, colRng, sub_mv);
@@ -546,13 +511,8 @@ acquireNonconstDetachedMultiVectorViewImpl(
   )
 {
   // Sync to host and mark as modified
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-  tpetraMultiVector_.getNonconstObj()->template sync<Kokkos::HostSpace>();
-  tpetraMultiVector_.getNonconstObj()->template modify<Kokkos::HostSpace>();
-#else
   tpetraMultiVector_.getNonconstObj()->sync_host ();
   tpetraMultiVector_.getNonconstObj()->modify_host ();
-#endif
 
   SpmdMultiVectorDefaultBase<Scalar>::
     acquireNonconstDetachedMultiVectorViewImpl(rowRng, colRng, sub_mv);
@@ -698,13 +658,8 @@ void TpetraMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>::euclideanApply(
     Y_tpetra->template modify<execution_space>();
     Y_tpetra->multiply(trans, Teuchos::NO_TRANS, alpha, *tpetraMultiVector_.getConstObj(), *X_tpetra, beta);
   } else {
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-    Teuchos::rcp_const_cast<TMV>(
-      tpetraMultiVector_.getConstObj())->template sync<Kokkos::HostSpace>();
-#else
     Teuchos::rcp_const_cast<TMV>(
       tpetraMultiVector_.getConstObj())->sync_host ();
-#endif
     SpmdMultiVectorDefaultBase<Scalar>::euclideanApply(M_trans, X, Y, alpha, beta);
   }
 

--- a/packages/thyra/adapters/tpetra/src/Thyra_TpetraVector_def.hpp
+++ b/packages/thyra/adapters/tpetra/src/Thyra_TpetraVector_def.hpp
@@ -1,12 +1,12 @@
 // @HEADER
 // ***********************************************************************
-// 
+//
 //    Thyra: Interfaces and Support for Abstract Numerical Algorithms
 //                 Copyright (2004) Sandia Corporation
-// 
+//
 // Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
 // license for use of this work by or on behalf of the U.S. Government.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
@@ -34,8 +34,8 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Roscoe A. Bartlett (bartlettra@ornl.gov) 
-// 
+// Questions? Contact Roscoe A. Bartlett (bartlettra@ornl.gov)
+//
 // ***********************************************************************
 // @HEADER
 
@@ -177,13 +177,8 @@ void TpetraVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>::absImpl(
     tpetraVector_.getNonconstObj()->abs(*tx);
   } else {
     // This version will require/modify the host view of this vector.
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-    tpetraVector_.getNonconstObj()->template sync<Kokkos::HostSpace>();
-    tpetraVector_.getNonconstObj()->template modify<Kokkos::HostSpace>();
-#else
     tpetraVector_.getNonconstObj()->sync_host ();
     tpetraVector_.getNonconstObj()->modify_host ();
-#endif
     VectorDefaultBase<Scalar>::absImpl(x);
   }
 }
@@ -202,13 +197,8 @@ void TpetraVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>::reciprocalImpl(
     tpetraVector_.getNonconstObj()->reciprocal(*tx);
   } else {
     // This version will require/modify the host view of this vector.
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-    tpetraVector_.getNonconstObj()->template sync<Kokkos::HostSpace>();
-    tpetraVector_.getNonconstObj()->template modify<Kokkos::HostSpace>();
-#else
     tpetraVector_.getNonconstObj()->sync_host ();
     tpetraVector_.getNonconstObj()->modify_host ();
-#endif
     VectorDefaultBase<Scalar>::reciprocalImpl(x);
   }
 }
@@ -229,13 +219,8 @@ void TpetraVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>::eleWiseScaleImpl(
       ST::one(), *tx, *tpetraVector_.getConstObj(), ST::zero());
   } else {
     // This version will require/modify the host view of this vector.
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-    tpetraVector_.getNonconstObj()->template sync<Kokkos::HostSpace>();
-    tpetraVector_.getNonconstObj()->template modify<Kokkos::HostSpace>();
-#else
     tpetraVector_.getNonconstObj()->sync_host ();
     tpetraVector_.getNonconstObj()->modify_host ();
-#endif
     VectorDefaultBase<Scalar>::eleWiseScaleImpl(x);
   }
 }
@@ -261,11 +246,7 @@ TpetraVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>::norm2WeightedImpl(
     return ST::magnitude(ST::squareroot(tpetraVector_.getConstObj()->dot(*temp)));
   } else {
     // This version will require the host view of this vector.
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-    tpetraVector_.getNonconstObj()->template sync<Kokkos::HostSpace>();
-#else
     tpetraVector_.getNonconstObj()->sync_host ();
-#endif
     return VectorDefaultBase<Scalar>::norm2WeightedImpl(x);
   }
 }
@@ -285,11 +266,7 @@ void TpetraVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>::applyOpImpl(
     auto tv = this->getConstTpetraVector(Teuchos::rcpFromPtr(*itr));
     if (nonnull(tv)) {
       typedef Tpetra::Vector<Scalar,LocalOrdinal,GlobalOrdinal,Node> TV;
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-      Teuchos::rcp_const_cast<TV>(tv)->template sync<Kokkos::HostSpace>();
-#else
       Teuchos::rcp_const_cast<TV>(tv)->sync_host ();
-#endif
     }
   }
 
@@ -297,13 +274,8 @@ void TpetraVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>::applyOpImpl(
   for (auto itr = targ_vecs.begin(); itr != targ_vecs.end(); ++itr) {
     auto tv = this->getTpetraVector(Teuchos::rcpFromPtr(*itr));
     if (nonnull(tv)) {
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-      tv->template sync<Kokkos::HostSpace>();
-      tv->template modify<Kokkos::HostSpace>();
-#else
       tv->sync_host ();
       tv->modify_host ();
-#endif
     }
   }
 
@@ -320,13 +292,8 @@ acquireDetachedVectorViewImpl(
 {
   // Only viewing data, so just sync dual view to host space
   typedef typename Tpetra::Vector<Scalar,LocalOrdinal,GlobalOrdinal,Node> TV;
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-  Teuchos::rcp_const_cast<TV>(
-    tpetraVector_.getConstObj())->template sync<Kokkos::HostSpace>();
-#else
   Teuchos::rcp_const_cast<TV>(
     tpetraVector_.getConstObj())->sync_host ();
-#endif
 
   SpmdVectorDefaultBase<Scalar>::acquireDetachedVectorViewImpl(rng, sub_vec);
 }
@@ -336,17 +303,12 @@ template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void TpetraVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>::
 acquireNonconstDetachedVectorViewImpl(
   const Range1D& rng,
-  RTOpPack::SubVectorView<Scalar>* sub_vec 
+  RTOpPack::SubVectorView<Scalar>* sub_vec
   )
 {
   // Sync to host and mark as modified
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-  tpetraVector_.getNonconstObj()->template sync<Kokkos::HostSpace>();
-  tpetraVector_.getNonconstObj()->template modify<Kokkos::HostSpace>();
-#else
   tpetraVector_.getNonconstObj()->sync_host ();
   tpetraVector_.getNonconstObj()->modify_host ();
-#endif
 
   SpmdVectorDefaultBase<Scalar>::acquireNonconstDetachedVectorViewImpl(rng, sub_vec);
 }
@@ -389,13 +351,8 @@ assignMultiVecImpl(const MultiVectorBase<Scalar>& mv)
     tpetraVector_.getNonconstObj()->assign(*tmv);
   } else {
     // This version will require/modify the host view of this vector.
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-    tpetraVector_.getNonconstObj()->template sync<Kokkos::HostSpace>();
-    tpetraVector_.getNonconstObj()->template modify<Kokkos::HostSpace>();
-#else
     tpetraVector_.getNonconstObj()->sync_host ();
     tpetraVector_.getNonconstObj()->modify_host ();
-#endif
     MultiVectorDefaultBase<Scalar>::assignMultiVecImpl(mv);
   }
 }
@@ -423,13 +380,8 @@ void TpetraVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>::updateImpl(
     tpetraVector_.getNonconstObj()->update(alpha, *tmv, ST::one());
   } else {
     // This version will require/modify the host view of this vector.
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-    tpetraVector_.getNonconstObj()->template sync<Kokkos::HostSpace>();
-    tpetraVector_.getNonconstObj()->template modify<Kokkos::HostSpace>();
-#else
     tpetraVector_.getNonconstObj()->sync_host();
     tpetraVector_.getNonconstObj()->modify_host();
-#endif
     MultiVectorDefaultBase<Scalar>::updateImpl(alpha, mv);
   }
 }
@@ -507,13 +459,8 @@ void TpetraVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>::linearCombinationImpl
     }
   } else {
     // This version will require/modify the host view of this vector.
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-    tpetraVector_.getNonconstObj()->template sync<Kokkos::HostSpace>();
-    tpetraVector_.getNonconstObj()->template modify<Kokkos::HostSpace>();
-#else
     tpetraVector_.getNonconstObj()->sync_host ();
     tpetraVector_.getNonconstObj()->modify_host ();
-#endif
     MultiVectorDefaultBase<Scalar>::linearCombinationImpl(alpha, mv, beta);
   }
 }
@@ -533,13 +480,8 @@ void TpetraVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>::dotsImpl(
     tpetraVector_.getConstObj()->dot(*tmv, prods);
   } else {
     // This version will require/modify the host view of this vector.
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-    tpetraVector_.getNonconstObj()->template sync<Kokkos::HostSpace>();
-    tpetraVector_.getNonconstObj()->template modify<Kokkos::HostSpace>();
-#else
     tpetraVector_.getNonconstObj()->sync_host ();
     tpetraVector_.getNonconstObj()->modify_host ();
-#endif
     MultiVectorDefaultBase<Scalar>::dotsImpl(mv, prods);
   }
 }
@@ -620,11 +562,7 @@ void TpetraVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>::applyImpl(
     Y_tpetra->template modify<execution_space>();
     Y_tpetra->multiply(trans, Teuchos::NO_TRANS, alpha, *tpetraVector_.getConstObj(), *X_tpetra, beta);
   } else {
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-    Teuchos::rcp_const_cast<TV>(tpetraVector_.getConstObj())->template sync<Kokkos::HostSpace>();
-#else
     Teuchos::rcp_const_cast<TV>(tpetraVector_.getConstObj())->sync_host ();
-#endif
     VectorDefaultBase<Scalar>::applyImpl(M_trans, X, Y, alpha, beta);
   }
 

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -6040,17 +6040,8 @@ namespace Tpetra {
       X_domainMap = X_colMap->offsetViewNonConst (domainMap, 0);
 
 #ifdef HAVE_TPETRA_DEBUG
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-      auto X_colMap_host_view =
-        X_colMap->template getLocalView<Kokkos::HostSpace> ();
-      auto X_domainMap_host_view =
-        X_domainMap->template getLocalView<Kokkos::HostSpace> ();
-#else
-      auto X_colMap_host_view =
-        X_colMap->getLocalViewHost ();
-      auto X_domainMap_host_view =
-        X_domainMap->getLocalViewHost ();
-#endif
+      auto X_colMap_host_view = X_colMap->getLocalViewHost ();
+      auto X_domainMap_host_view = X_domainMap->getLocalViewHost ();
 
       if (X_colMap->getLocalLength () != 0 && X_domainMap->getLocalLength ()) {
         TEUCHOS_TEST_FOR_EXCEPTION


### PR DESCRIPTION
@trilinos/belos @trilinos/ifpack2 @trilinos/thyra @trilinos/tpetra @kddevin 

## Description

Remove use of `KOKKOS_ENABLE_DEPRECATED_CODE` macro.

## Motivation and Context

In all cases I saw, both code paths (with or without the macro defined) now build fine.