### PR TITLE
MueLu: use AMG as coarse solver for regionMG

### DIFF
--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
@@ -1263,13 +1263,14 @@ void createRegionHierarchy(const int maxRegPerProc,
                            RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& coarseCompOp,
                            const int maxRegPerGID,
                            ArrayView<LocalOrdinal> compositeToRegionLIDs,
-                           RCP<Amesos2::Solver<Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>, Tpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& coarseSolver
+                           ParameterList& coarseSolverData
                            )
 {
 #include "Xpetra_UseShortNames.hpp"
 
-  typedef MueLu::Hierarchy<SC, LO, GO, NO> Hierarchy;
-  typedef MueLu::Utilities<SC, LO, GO, NO> Utilities;
+  using Hierarchy = MueLu::Hierarchy<SC, LO, GO, NO>;
+  using Utilities = MueLu::Utilities<SC, LO, GO, NO>;
+  using DirectCoarseSolver = Amesos2::Solver<Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>, Tpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> >;
 
   std::cout << mapComp->getComm()->getRank() << " | Setting up MueLu hierarchies ..." << std::endl;
   int numLevels = 0;
@@ -1409,9 +1410,14 @@ void createRegionHierarchy(const int maxRegPerProc,
                               regMatrices,
                               coarseCompOp);
 
-  std::cout << mapComp->getComm()->getRank() << " | MakeCoarseCompositeDirectSolver ..." << std::endl;
+  std::cout << mapComp->getComm()->getRank() << " | MakeCoarseCompositeSolver ..." << std::endl;
 
-  coarseSolver = MakeCompositeDirectSolver(coarseCompOp);
+  const bool useDirectSolver = coarseSolverData.get<bool>("use direct solver");
+  if (useDirectSolver)
+  {
+    RCP<DirectCoarseSolver> coarseDirectSolver = MakeCompositeDirectSolver(coarseCompOp);
+    coarseSolverData.set<RCP<DirectCoarseSolver>>("direct solver object", coarseDirectSolver);
+  }
 
   std::cout << mapComp->getComm()->getRank() << " | MakeInterfaceScalingFactors ..." << std::endl;
 
@@ -1457,15 +1463,15 @@ void createRegionHierarchy(const int maxRegPerProc,
   // Define dummy values
   const int maxRegPerGID = 0;
   ArrayView<LocalOrdinal> compositeToRegionLIDs = {};
-  RCP<Amesos2::Solver<Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>,
-      Tpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > coarseSolver = Teuchos::null;
+  RCP<ParameterList> coarseSolverParams = rcp(new ParameterList("Coarse solver parameters"));
+  coarseSolverParams->set<bool>("use coarse solver", true);
 
   // Call the actual routine
   createRegionHierarchy(maxRegPerProc, numDimensions, lNodesPerDim,
       aggregationRegionType, xmlFileName, nullspace, coordinates,
       regionGrpMats, mapComp, rowMapPerGrp, colMapPerGrp, revisedRowMapPerGrp, revisedColMapPerGrp, rowImportPerGrp,
       compRowMaps, compColMaps, regRowMaps, regColMaps, quasiRegRowMaps, quasiRegColMaps, regMatrices, regProlong,
-      regRowImporters, regInterfaceScalings, coarseCompOp, maxRegPerGID, compositeToRegionLIDs, coarseSolver);
+      regRowImporters, regInterfaceScalings, coarseCompOp, maxRegPerGID, compositeToRegionLIDs, *coarseSolverParams);
 }
 
 
@@ -1647,7 +1653,7 @@ void vCycle(const int l, ///< ID of current level
             Array<std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > > regRowImporters, ///< regional row importers
             Array<std::vector<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > > regInterfaceScalings, ///< regional interface scaling factors
             RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > coarseCompMat, ///< Coarsest level composite operator
-            RCP<Amesos2::Solver<Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>, Tpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > coarseSolver = Teuchos::null ///< Coarsest level composite direct solver
+            RCP<ParameterList> coarseSolverData = Teuchos::null
             )
 {
 #include "Xpetra_UseShortNames.hpp"
@@ -1687,7 +1693,7 @@ void vCycle(const int l, ///< ID of current level
     // Call V-cycle recursively
     vCycle(l+1, numLevels, maxFineIter, maxCoarseIter, omega, maxRegPerProc,
            coarseRegX, coarseRegB, regMatrices, regProlong, compRowMaps,
-           quasiRegRowMaps, regRowMaps, regRowImporters, regInterfaceScalings, coarseCompMat, coarseSolver);
+           quasiRegRowMaps, regRowMaps, regRowImporters, regInterfaceScalings, coarseCompMat, coarseSolverData);
 
     // Transfer coarse level correction to fine level
     std::vector<RCP<Vector> > regCorrection(maxRegPerProc);
@@ -1716,69 +1722,82 @@ void vCycle(const int l, ///< ID of current level
     RCP<Teuchos::FancyOStream> fos = Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
     fos->setOutputToRootOnly(0);
 
-
+    const bool useDirectSolver = coarseSolverData->get<bool>("use direct solver");
+    if (useDirectSolver)
+    {
 #if defined(HAVE_MUELU_TPETRA) && defined(HAVE_MUELU_AMESOS2)
 
-  TEUCHOS_TEST_FOR_EXCEPT_MSG(coarseCompMat->getRowMap()->lib()!=Xpetra::UseTpetra,
-      "Coarse solver requires Tpetra/Amesos2 stack.");
-  TEUCHOS_ASSERT(!coarseSolver.is_null());
+      using DirectCoarseSolver = Amesos2::Solver<Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>, Tpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> >;
+      RCP<DirectCoarseSolver> coarseSolver = coarseSolverData->get<RCP<DirectCoarseSolver>>("direct solver object");
 
-  using Utilities = MueLu::Utilities<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
+      TEUCHOS_TEST_FOR_EXCEPT_MSG(coarseCompMat->getRowMap()->lib()!=Xpetra::UseTpetra,
+          "Coarse solver requires Tpetra/Amesos2 stack.");
+      TEUCHOS_ASSERT(!coarseSolver.is_null());
 
-  // First get the Xpetra vectors from region to composite format
-  // (the coarseCompMat should already exist)
-  RCP<Vector> compX = VectorFactory::Build(coarseCompMat->getRowMap(), true);
-  RCP<Vector> compRhs = VectorFactory::Build(coarseCompMat->getRowMap(), true);
-  {
-    for (int j = 0; j < maxRegPerProc; j++) {
-      RCP<Vector> inverseInterfaceScaling = VectorFactory::Build(regInterfaceScalings[l][j]->getMap());
-      inverseInterfaceScaling->reciprocal(*regInterfaceScalings[l][j]);
-      fineRegB[j]->elementWiseMultiply(SC_ONE, *fineRegB[j], *inverseInterfaceScaling, SC_ZERO);
-    }
+      using Utilities = MueLu::Utilities<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
 
-    regionalToComposite(fineRegB, compRhs, maxRegPerProc, quasiRegRowMaps[l],
-                        regRowImporters[l], Xpetra::ADD);
-  }
+      // First get the Xpetra vectors from region to composite format
+      // (the coarseCompMat should already exist)
+      RCP<Vector> compX = VectorFactory::Build(coarseCompMat->getRowMap(), true);
+      RCP<Vector> compRhs = VectorFactory::Build(coarseCompMat->getRowMap(), true);
+      {
+        for (int j = 0; j < maxRegPerProc; j++) {
+          RCP<Vector> inverseInterfaceScaling = VectorFactory::Build(regInterfaceScalings[l][j]->getMap());
+          inverseInterfaceScaling->reciprocal(*regInterfaceScalings[l][j]);
+          fineRegB[j]->elementWiseMultiply(SC_ONE, *fineRegB[j], *inverseInterfaceScaling, SC_ZERO);
+        }
 
-  // From here on we switch to Tpetra for simplicity
-  // we could also implement a similar Epetra branch
-  using Tpetra_MultiVector = Tpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
+        regionalToComposite(fineRegB, compRhs, maxRegPerProc, quasiRegRowMaps[l],
+                            regRowImporters[l], Xpetra::ADD);
+      }
 
-//    *fos << "Attempting to use Amesos2 to solve the coarse grid problem" << std::endl;
-  RCP<Tpetra_MultiVector> tX = Utilities::MV2NonConstTpetraMV2(*compX);
-  RCP<const Tpetra_MultiVector> tB = Utilities::MV2TpetraMV(compRhs);
+      // From here on we switch to Tpetra for simplicity
+      // we could also implement a similar Epetra branch
+      using Tpetra_MultiVector = Tpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
 
-  /* Solve!
-   *
-   * Calling solve() on the coarseSolver sould just do a triangular solve, since symbolic
-   * and numeric factorization are supposed to have happened during hierarchy setup.
-   * Here, we just check if they're done and print message if not.
-   *
-   * We don't have to change the map of tX and tB since we have configured the Amesos2 solver
-   * during its construction to work with non-continous maps.
-   */
-  if (not coarseSolver->getStatus().symbolicFactorizationDone())
-    *fos << "Symbolic factorization should have been done during hierarchy setup, "
-        "but actually is missing. Anyway ... just do it right now." << std::endl;
-  if (not coarseSolver->getStatus().numericFactorizationDone())
-    *fos << "Numeric factorization should have been done during hierarchy setup, "
-        "but actually is missing. Anyway ... just do it right now." << std::endl;
-  coarseSolver->solve(tX.ptr(), tB.ptr());
+    //    *fos << "Attempting to use Amesos2 to solve the coarse grid problem" << std::endl;
+      RCP<Tpetra_MultiVector> tX = Utilities::MV2NonConstTpetraMV2(*compX);
+      RCP<const Tpetra_MultiVector> tB = Utilities::MV2TpetraMV(compRhs);
 
-  // Transform back to region format
-  std::vector<RCP<Vector> > quasiRegX(maxRegPerProc);
-  compositeToRegional(compX, quasiRegX, fineRegX,
-                      maxRegPerProc,
-                      quasiRegRowMaps[l],
-                      regRowMaps[l],
-                      regRowImporters[l]);
+      /* Solve!
+       *
+       * Calling solve() on the coarseSolver sould just do a triangular solve, since symbolic
+       * and numeric factorization are supposed to have happened during hierarchy setup.
+       * Here, we just check if they're done and print message if not.
+       *
+       * We don't have to change the map of tX and tB since we have configured the Amesos2 solver
+       * during its construction to work with non-continous maps.
+       */
+      if (not coarseSolver->getStatus().symbolicFactorizationDone())
+        *fos << "Symbolic factorization should have been done during hierarchy setup, "
+            "but actually is missing. Anyway ... just do it right now." << std::endl;
+      if (not coarseSolver->getStatus().numericFactorizationDone())
+        *fos << "Numeric factorization should have been done during hierarchy setup, "
+            "but actually is missing. Anyway ... just do it right now." << std::endl;
+      coarseSolver->solve(tX.ptr(), tB.ptr());
+
+      // Transform back to region format
+      std::vector<RCP<Vector> > quasiRegX(maxRegPerProc);
+      compositeToRegional(compX, quasiRegX, fineRegX,
+                          maxRegPerProc,
+                          quasiRegRowMaps[l],
+                          regRowMaps[l],
+                          regRowImporters[l]);
 #else
-    *fos << "+++++++++++++++++++++++++++ WARNING +++++++++++++++++++++++++\n"
-         << "+ Coarse level solver requires Tpetra and Amesos2.          +\n"
-         << "+ Skipping the coarse level solve.                          +\n"
-         << "+++++++++++++++++++++++++++ WARNING +++++++++++++++++++++++++"
-         << std::endl;
+      *fos << "+++++++++++++++++++++++++++ WARNING +++++++++++++++++++++++++\n"
+           << "+ Coarse level solver requires Tpetra and Amesos2.          +\n"
+           << "+ Skipping the coarse level solve.                          +\n"
+           << "+++++++++++++++++++++++++++ WARNING +++++++++++++++++++++++++"
+           << std::endl;
 #endif
+    }
+    else // use AMG as coarse level solver
+    {
+      *fos << "+++++++++++++++++++++++++++ WARNING +++++++++++++++++++++++++\n"
+           << "+ AMG as coarse level solver is not implemented, yet.       +\n"
+           << "+++++++++++++++++++++++++++ WARNING +++++++++++++++++++++++++"
+           << std::endl;
+    }
   }
 
   return;

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
@@ -1809,12 +1809,12 @@ void vCycle(const int l, ///< ID of current level
 
       /* Solve!
        *
-       * Calling solve() on the coarseSolver sould just do a triangular solve, since symbolic
+       * Calling solve() on the coarseSolver should just do a triangular solve, since symbolic
        * and numeric factorization are supposed to have happened during hierarchy setup.
        * Here, we just check if they're done and print message if not.
        *
        * We don't have to change the map of tX and tB since we have configured the Amesos2 solver
-       * during its construction to work with non-continous maps.
+       * during its construction to work with non-continuous maps.
        */
       if (not coarseSolver->getStatus().symbolicFactorizationDone())
         *fos << "Symbolic factorization should have been done during hierarchy setup, "

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
@@ -1205,7 +1205,6 @@ RCP<MueLu::Hierarchy<Scalar, LocalOrdinal, GlobalOrdinal, Node> >
 MakeCompositeAMGHierarchy(RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& compOp, const std::string& xmlFileName)
 {
 #include "MueLu_UseShortNames.hpp"
-#include "Xpetra_UseShortNames.hpp"
 
   const Scalar one = Teuchos::ScalarTraits<Scalar>::one();
 
@@ -1216,6 +1215,10 @@ MakeCompositeAMGHierarchy(RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal
   // Get parameter list for AMG hierarchy
   RCP<ParameterList> mueluParams = Teuchos::getParametersFromXmlFile(xmlFileName);
 
+  // Get the user data sublist
+  const std::string userName = "user data";
+  Teuchos::ParameterList& userParamList = mueluParams->sublist(userName);
+
   // Add nullspace information
   {
     // Compute nullspace
@@ -1223,9 +1226,12 @@ MakeCompositeAMGHierarchy(RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal
     nullspace->putScalar(one);
 
     // Insert into parameter list
-    const std::string userName = "user data";
-    Teuchos::ParameterList& userParamList = mueluParams->sublist(userName);
     userParamList.set("Nullspace", nullspace);
+  }
+
+  // Add coordinate information for rebalancing
+  {
+    //ToDo Add coordinate information
   }
 
   // Create an AMG hierarchy based on the composite coarse level operator from the region MG scheme

--- a/packages/muelu/research/regionMG/examples/structured/CMakeLists.txt
+++ b/packages/muelu/research/regionMG/examples/structured/CMakeLists.txt
@@ -12,7 +12,12 @@ IF (${PACKAGE_NAME}_ENABLE_Tpetra AND ${PACKAGE_NAME}_ENABLE_Amesos2)
     )
 
   TRIBITS_COPY_FILES_TO_BINARY_DIR(StructuredRegion_cp
-    SOURCE_FILES structured_1dof.xml structured_1dof-complex.xml structured_linear_1dof.xml structured_unstructured_1dof.xml
+    SOURCE_FILES amg_1dof.xml
+      structured_1dof.xml
+      structured_1dof_3level.xml
+      structured_1dof-complex.xml
+      structured_linear_1dof.xml
+      structured_unstructured_1dof.xml
     )
 
   TRIBITS_ADD_TEST(
@@ -27,6 +32,14 @@ IF (${PACKAGE_NAME}_ENABLE_Tpetra AND ${PACKAGE_NAME}_ENABLE_Amesos2)
     StructuredRegionDriver
     NAME "Structured_Region_Star2D_Tpetra"
     ARGS "--linAlgebra=Tpetra --xml=structured_1dof.xml --matrixType=Star2D --nx=10 --ny=10 --smootherIts=2"
+    COMM serial mpi
+    NUM_MPI_PROCS 4
+    )
+
+  TRIBITS_ADD_TEST(
+    StructuredRegionDriver
+    NAME "Structured_Region_Star2D_AMG_CoarseSolver_Tpetra"
+    ARGS "--linAlgebra=Tpetra --xml=structured_1dof_3level.xml --matrixType=Star2D --nx=50 --ny=50 --smootherIts=2 --amg-coarse-solver --coarseAmgXml=amg_1dof.xml"
     COMM serial mpi
     NUM_MPI_PROCS 4
     )

--- a/packages/muelu/research/regionMG/examples/structured/amg_1dof.xml
+++ b/packages/muelu/research/regionMG/examples/structured/amg_1dof.xml
@@ -1,0 +1,67 @@
+<ParameterList name="MueLu">
+  <!-- Factory collection -->
+  <ParameterList name="Factories">
+  
+    <ParameterList name="UncoupledAggregationFact">
+      <Parameter name="factory"                             type="string" value="UncoupledAggregationFactory"/>
+      <Parameter name="aggregation: ordering"               type="string" value="natural"/>
+      <Parameter name="aggregation: max selected neighbors" type="int"    value="0"/>
+      <Parameter name="aggregation: min agg size"           type="int"    value="2"/>
+    </ParameterList>
+  
+    <ParameterList name="myTentativePFact">
+      <Parameter name="factory"                             type="string" value="TentativePFactory"/>
+    </ParameterList>
+
+    <ParameterList name="myProlongatorFact">
+      <Parameter name="factory"                             type="string" value="SaPFactory"/>
+      <Parameter name="P"                                   type="string" value="myTentativePFact"/>
+      <Parameter name="sa: damping factor"                  type="double" value="1.33333333"/>
+    </ParameterList>
+    
+    <ParameterList name="myRestrictorFact">
+      <Parameter name="factory"                             type="string" value="TransPFactory"/>
+      <Parameter name="P"                                   type="string" value="myProlongatorFact"/>
+    </ParameterList>
+    
+    <ParameterList name="myRAPFact">
+      <Parameter name="factory"                             type="string" value="RAPFactory"/>
+      <Parameter name="P"                                   type="string" value="myProlongatorFact"/>
+      <Parameter name="R"                                   type="string" value="myRestrictorFact"/>
+    </ParameterList>
+    
+    <ParameterList name="Chebyshev">
+      <Parameter name="factory"                             type="string" value="TrilinosSmoother"/>
+      <Parameter name="type"                                type="string" value="CHEBYSHEV"/>
+
+      <ParameterList name="ParameterList">
+        <Parameter name="chebyshev: degree"                 type="int"     value="3"/>>
+        <!-- 7 in 2D, 20 in 3D -->
+        <Parameter name="chebyshev: ratio eigenvalue"       type="double"  value="20"/>
+        <Parameter name="chebyshev: min eigenvalue"         type="double"  value="1.0"/>
+        <Parameter name="chebyshev: zero starting solution" type="bool"    value="true"/>
+      </ParameterList>
+    </ParameterList>
+  
+  </ParameterList>
+  
+  <!-- Definition of the multigrid preconditioner -->
+  <ParameterList name="Hierarchy">
+
+    <Parameter name="max levels"                            type="int"      value="3"/>
+    <Parameter name="coarse: max size"                      type="int"      value="10"/>
+    <Parameter name="cycle type"                            type="string"   value="V"/>
+    <Parameter name="verbosity"                             type="string"   value="High"/>
+
+    <ParameterList name="All">
+      <Parameter name="Smoother"                            type="string"   value="Chebyshev"/>
+      <Parameter name="Aggregates"                          type="string"   value="UncoupledAggregationFact"/>
+      <Parameter name="Nullspace"                           type="string"   value="myTentativePFact"/>
+      <Parameter name="P"                                   type="string"   value="myProlongatorFact"/>
+      <Parameter name="R"                                   type="string"   value="myRestrictorFact"/>
+      <Parameter name="CoarseSolver"                        type="string"   value="DirectSolver"/>
+    </ParameterList>
+
+  </ParameterList>
+  
+</ParameterList>

--- a/packages/muelu/research/regionMG/examples/structured/structured_1dof_3level.xml
+++ b/packages/muelu/research/regionMG/examples/structured/structured_1dof_3level.xml
@@ -1,0 +1,127 @@
+<ParameterList name="MueLu">
+
+  <!-- Configuration of the Xpetra operator (fine level) -->
+  <ParameterList name="Matrix">
+    <Parameter name="PDE equations"                   type="int" value="1"/> <!-- Number of PDE equations at each grid node.-->
+  </ParameterList>
+
+  <!-- Factory collection -->
+  <ParameterList name="Factories">
+
+    <ParameterList name="myCoalesceDropFact">
+      <Parameter name="factory"                             type="string" value="CoalesceDropFactory"/>
+      <Parameter name="lightweight wrap"                    type="bool"   value="true"/>
+      <Parameter name="aggregation: drop tol"               type="double" value="0.00"/>
+    </ParameterList>
+
+    <ParameterList name="myAggregationFact">
+      <Parameter name="factory"                                   type="string" value="StructuredAggregationFactory"/>
+      <Parameter name="aggregation: coupling"                     type="string" value="uncoupled"/>
+      <Parameter name="aggregation: output type"                  type="string" value="CrsGraph"/>
+      <Parameter name="aggregation: coarsening order"             type="int"    value="0"/>
+      <Parameter name="aggregation: coarsening rate"              type="string" value="{2}"/>
+      <Parameter name="Graph"                                     type="string" value="myCoalesceDropFact"/>
+    </ParameterList>
+
+    <ParameterList name="myCoarseMapFact">
+      <Parameter name="factory"                             type="string" value="CoarseMapFactory"/>
+      <Parameter name="Aggregates"                          type="string" value="myAggregationFact"/>
+    </ParameterList>
+
+    <!-- Note that ParameterLists must be defined prior to being used -->
+    <ParameterList name="myProlongatorFact">
+      <Parameter name="factory"                             type="string" value="GeometricInterpolationPFactory"/>
+      <Parameter name="interp: build coarse coordinates"    type="bool"   value="true"/>
+      <Parameter name="interp: interpolation order"         type="int"    value="0"/>
+      <Parameter name="prolongatorGraph"                    type="string" value="myAggregationFact"/>
+      <Parameter name="coarseCoordinatesFineMap"            type="string" value="myAggregationFact"/>
+      <Parameter name="coarseCoordinatesMap"                type="string" value="myAggregationFact"/>
+    </ParameterList>
+
+    <ParameterList name="myCoordTransferFact">
+      <Parameter name="factory"                             type="string" value="CoordinatesTransferFactory"/>
+      <Parameter name="structured aggregation"              type="bool"   value="true"/>
+      <Parameter name="numDimensions"                       type="string" value="myAggregationFact"/>
+      <Parameter name="lCoarseNodesPerDim"                  type="string" value="myAggregationFact"/>
+    </ParameterList>
+
+    <ParameterList name="myNullspaceFact">
+      <Parameter name="factory"                             type="string" value="NullspaceFactory"/>
+      <Parameter name="Nullspace"                           type="string" value="myProlongatorFact"/>
+    </ParameterList>
+
+    <ParameterList name="myRestrictorFact">
+      <Parameter name="factory"                             type="string" value="TransPFactory"/>
+    </ParameterList>
+
+    <!-- <ParameterList name="myAggExport"> -->
+    <!--   <Parameter name="factory"                             type="string" value="AggregationExportFactory"/> -->
+    <!--   <Parameter name="Aggregates"                          type="string" value="myAggregationFact"/> -->
+    <!--   <Parameter name="aggregation: output filename"        type="string" value="structured_aggs"/> -->
+    <!--   <Parameter name="aggregation: output file: agg style" type="string" value="Jacks"/> -->
+    <!--   <Parameter name="aggregation: output file: agg style" type="string" value="Convex Hulls"/> -->
+    <!-- </ParameterList> -->
+
+    <ParameterList name="myRAPFact">
+      <Parameter name="factory"                             type="string" value="RAPFactory"/>
+      <Parameter name="P"                                   type="string" value="myProlongatorFact"/>
+      <Parameter name="R"                                   type="string" value="myRestrictorFact"/>
+      <ParameterList name="TransferFactories">
+        <Parameter name="CoordinateTransfer"                type="string" value="myCoordTransferFact"/>
+        <!-- <Parameter name="AggregationExportFactory"                type="string" value="myAggExport"/> -->
+      </ParameterList>
+    </ParameterList>
+
+    <ParameterList name="myILU">
+      <Parameter name="factory" type="string" value="TrilinosSmoother"/>
+      <Parameter name="type"  type="string" value="RILUK"/>
+      <ParameterList name="ParameterList">
+        <Parameter name="schwarz: overlap level"           type="int"    value="1"/>
+        <Parameter name="schwarz: combine mode"            type="string" value="Zero"/>
+        <Parameter name="schwarz: use reordering"          type="bool"   value="false"/>
+        <Parameter name="fact: iluk level-of-fill"         type="int"    value="0"/>
+        <Parameter name="fact: absolute threshold"         type="double" value="0."/>
+        <Parameter name="fact: relative threshold"         type="double" value="1."/>
+        <Parameter name="fact: relax value"                type="double" value="0."/>
+      </ParameterList>
+    </ParameterList>
+
+    <ParameterList name="myJacobi">
+      <Parameter name="factory" type="string" value="TrilinosSmoother"/>
+      <Parameter name="type"  type="string" value="RELAXATION"/>
+      <ParameterList name="ParameterList">
+        <Parameter name="relaxation: type"                 type="string"    value="Jacobi"/>
+        <Parameter name="relaxation: sweeps"               type="int"       value="1"/>
+        <Parameter name="relaxation: damping"              type="double"    value="0.666"/>
+      </ParameterList>
+    </ParameterList>
+
+  </ParameterList>
+
+
+  <!-- Definition of the multigrid preconditioner -->
+  <ParameterList name="Hierarchy">
+
+    <Parameter name="max levels"                            type="int"      value="3"/> <!-- Max number of levels -->
+    <Parameter name="cycle type"                            type="string"   value="W"/>
+    <Parameter name="coarse: max size"                      type="int"      value="20"/> <!-- Min number of rows on coarsest level -->
+    <Parameter name="verbosity"                             type="string"   value="High"/>
+
+    <ParameterList name="All">
+      <Parameter name="PreSmoother"                         type="string"   value="NoSmoother"/>
+      <Parameter name="PostSmoother"                        type="string"   value="NoSmoother"/>
+      <Parameter name="Nullspace"                           type="string"   value="myNullspaceFact"/>
+      <Parameter name="Aggregates"                          type="string"   value="myAggregationFact"/>
+      <Parameter name="lCoarseNodesPerDim"                  type="string"   value="myAggregationFact"/>
+      <Parameter name="P"                                   type="string"   value="myProlongatorFact"/>
+      <Parameter name="R"                                   type="string"   value="myRestrictorFact"/>
+      <Parameter name="A"                                   type="string"   value="myRAPFact"/>
+      <!-- <Parameter name="CoarseSolver"                        type="string"   value="DirectSolver"/> -->
+      <Parameter name="CoarseSolver"                        type="string"   value="myILU"/>
+      <Parameter name="Coordinates"                         type="string"   value="myProlongatorFact"/>
+      <Parameter name="lNodesPerDim"                        type="string"   value="myCoordTransferFact"/>
+      <Parameter name="numDimensions"                       type="string"   value="myCoordTransferFact"/>
+    </ParameterList>
+  </ParameterList>
+
+</ParameterList>


### PR DESCRIPTION
@trilinos/muelu 
@lucbv @rstumin @pohm01 

## Description

- Allow to replace the direct solver on the coarsest regionML level by 1 sweep through an AMG hierarchy.
- Add a test.

## Motivation and Context

This is a step towards "true HHG", where we use regionMG to coarsen partially structured meshes until they appear to be fully unstructured. Then, we use AMG for further coarsening.

## Related Issues

* Part of #5503

## How Has This Been Tested?

A test with 3 levels of regionMG and then 3 levels of AMG on top has been added. Thorough testing of actual results has still to be done.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [x] These changes break backwards compatibility.