### PR TITLE
Disable on Piro and ROL test that does not build with no global int instantiation (#5446, #5447, ATDV-714)

### DIFF
--- a/cmake/std/atdm/ATDMDevEnvSettings.cmake
+++ b/cmake/std/atdm/ATDMDevEnvSettings.cmake
@@ -443,6 +443,11 @@ ATDM_SET_ENABLE(Zoltan2_XpetraEpetraMatrix_MPI_4_DISABLE ON)
 ATDM_SET_ENABLE(Piro_ThyraSolver_EXE_DISABLE ON)
 ATDM_SET_ENABLE(Piro_ThyraSolver_MPI_4_DISABLE ON)
 
+# Disable Piro_AnalysisDriverTpetra exec that will not build with no global
+# int instantiation (see #5446)
+ATDM_SET_ENABLE(Piro_AnalysisDriverTpetra_EXE_DISABLE ON)
+ATDM_SET_ENABLE(Piro_AnalysisDriverTpetra_MPI_4_DISABLE ON)
+
 #
 # H) ATDM env config install hooks
 #

--- a/cmake/std/atdm/ATDMDevEnvSettings.cmake
+++ b/cmake/std/atdm/ATDMDevEnvSettings.cmake
@@ -448,6 +448,11 @@ ATDM_SET_ENABLE(Piro_ThyraSolver_MPI_4_DISABLE ON)
 ATDM_SET_ENABLE(Piro_AnalysisDriverTpetra_EXE_DISABLE ON)
 ATDM_SET_ENABLE(Piro_AnalysisDriverTpetra_MPI_4_DISABLE ON)
 
+# Disable ROL test exec that will not buld with no global int instantiation
+# (see #5447)
+ATDM_SET_ENABLE(ROL_adapters_tpetra_test_vector_SimulatedVectorTpetraBatchManagerInterface_EXE_DISABLE ON)
+ATDM_SET_ENABLE(ROL_adapters_tpetra_test_vector_SimulatedVectorTpetraBatchManagerInterface_MPI_4_DISABLE ON)
+
 #
 # H) ATDM env config install hooks
 #


### PR DESCRIPTION
This disables the building of two test exectuables, one in Piro (#5446) and one in ROL (#5447) that don't build when Tpetra global int instantiations are disabled (see [ATDV-174](https://sems-atlassian-srn.sandia.gov/browse/ATDV-174)).  Merging this will allow us to set `Tpetra_INST_INT_INT=OFF` in all of the ATDM Trilinos builds and in all of the ATDM APPs.

I tested this using the (still in-development but useful) 'spack-rhel' env on my COE RHEL6 machine 'crf450' with:

```
./checkin-test-atdm-spack-rhel6.sh \
  spack-rhel-gnu-7.2.0-openmpi-1.10.1-opt-dbg-no-global-int \
  --enable-packages=Piro,ROL --local-do-all
```

Before the disables in the PR, this produced two build errors:

```
FAILED: packages/rol/adapters/tpetra/test/vector/CMakeFiles/ROL_adapters_tpetra_test_vector_SimulatedVectorTpetraBatchManagerInterface.dir/test_02.cpp.o 
FAILED: packages/piro/test/Piro_AnalysisDriverTpetra.exe
```

and two test failures:

```
$ ctest -j16
...

99% tests passed, 2 tests failed out of 157

Subproject Time Summary:
Piro    =   7.40 sec*proc (12 tests)
ROL     = 265.00 sec*proc (145 tests)

Total Test time (real) =  55.80 sec

The following tests FAILED:
         15 - ROL_adapters_tpetra_test_vector_SimulatedVectorTpetraBatchManagerInterface_MPI_4 (Not Run)
        151 - Piro_AnalysisDriverTpetra_MPI_4 (Not Run)
Errors while running CTest
```

After these disables, this produced:

```
1) spack-rhel-gnu-7.2.0-openmpi-1.10.1-opt-dbg-no-global-int Results:
---------------------------------------------------------------------

  passed: Trilinos/spack-rhel-gnu-7.2.0-openmpi-1.10.1-opt-dbg-no-global-int: passed=155,notpassed=0
  
  Wed Jul 10 06:54:57 MDT 2019
  
  Enabled Packages: Piro, ROL
  Hostname: crf450.srn.sandia.gov
  Source Dir: /home/rabartl/Trilinos.base/Trilinos/cmake/tribits/ci_support/../../..
  Build Dir: /home/rabartl/Trilinos.base/BUILDS/ATDM/SPACK-RHEL/CHECKIN/spack-rhel-gnu-7.2.0-openmpi-1.10.1-opt-dbg-no-global-int
  
  CMake Cache Varibles: -GNinja -DTrilinos_TRIBITS_DIR:PATH=/home/rabartl/Trilinos.base/Trilinos/cmake/tribits -DTrilinos_ENABLE_TESTS:BOOL=ON -DTrilinos_TEST_CATEGORIES:STRING=NIGHTLY -DTrilinos_ALLOW_NO_PACKAGES:BOOL=OFF -DDART_TESTING_TIMEOUT:STRING=600.0 -GNinja -DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/atdm/ATDMDevEnv.cmake -DTrilinos_TRACE_ADD_TEST=ON -DTrilinos_ENABLE_Piro:BOOL=ON -DTrilinos_ENABLE_ROL:BOOL=ON -DTrilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=ON -DTrilinos_ENABLE_ALL_FORWARD_DEP_PACKAGES:BOOL=OFF
  Make Options: -j 20
  CTest Options: -j 10
  
  Pull: Not Performed
  Configure: Passed (1.01 min)
  Build: Passed (0.00 min)
  Test: Passed (0.85 min)
  
  100% tests passed, 0 tests failed out of 155
  
  Subproject Time Summary:
  Piro    =   5.77 sec*proc (11 tests)
  ROL     = 255.17 sec*proc (144 tests)
  
  Total Test time (real) =  50.74 sec
  
  Total time for spack-rhel-gnu-7.2.0-openmpi-1.10.1-opt-dbg-no-global-int = 1.86 min
```





