### PR TITLE
Ifpack2: Heuristic to set upper size of graphs in RILUK.

### DIFF
--- a/packages/ifpack2/src/Ifpack2_IlukGraph.hpp
+++ b/packages/ifpack2/src/Ifpack2_IlukGraph.hpp
@@ -260,22 +260,27 @@ void IlukGraph<GraphType>::initialize()
 
   constructOverlapGraph();
 
-  L_Graph_ = rcp (new crs_graph_type (OverlapGraph_->getRowMap (),
-                                      OverlapGraph_->getRowMap (), 0));
-  U_Graph_ = rcp (new crs_graph_type (OverlapGraph_->getRowMap (),
-                                      OverlapGraph_->getRowMap (), 0));
-
   // Get Maximum Row length
   const int MaxNumIndices = OverlapGraph_->getNodeMaxNumRowEntries ();
+
+  // FIXME (mfh 23 Dec 2013) Use size_t or whatever
+  // getNodeNumElements() returns, instead of ptrdiff_t.
+  const int NumMyRows = OverlapGraph_->getRowMap ()->getNodeNumElements ();
+
+  // Heuristic to get the maximum number of entries per row.
+  const int MaxNumEntriesPerRow = (LevelFill_ == 0)
+                                ? MaxNumIndices
+                                : MaxNumIndices + 5*LevelFill_;
+  L_Graph_ = rcp (new crs_graph_type (OverlapGraph_->getRowMap (),
+                                      OverlapGraph_->getRowMap (), MaxNumEntriesPerRow));
+  U_Graph_ = rcp (new crs_graph_type (OverlapGraph_->getRowMap (),
+                                      OverlapGraph_->getRowMap (), MaxNumEntriesPerRow));
 
   Array<local_ordinal_type> L (MaxNumIndices);
   Array<local_ordinal_type> U (MaxNumIndices);
 
   // First we copy the user's graph into L and U, regardless of fill level
 
-  // FIXME (mfh 23 Dec 2013) Use size_t or whatever
-  // getNodeNumElements() returns, instead of ptrdiff_t.
-  const int NumMyRows = OverlapGraph_->getRowMap ()->getNodeNumElements ();
   NumMyDiagonals_ = 0;
 
   for (int i = 0; i< NumMyRows; ++i) {


### PR DESCRIPTION
Needed to run with `Tpetra::StaticProfile` which will become default
after `Tpetra::DynamicProfile` is removed.

Closes: #5510

@trilinos/ifpack2 @trilinos/tpetra 

The heuristic is probably very bad.  Saad's "Iterative Methods for Sparse Linear Systems" says

> the amount of fill-in and computational work for obtaining the ILU(p) factorization is not predictable for p > 0. 

This statement is in relation to Algorithm 10.5 of the same text.  I'm not sure that is true of this algorithm.  I figured the heuristic would be faster/easier than counting.

All tests now pass