### PR TITLE
Tpetra: Fix #4607 (sort rows in explicit transpose by default)

### DIFF
--- a/packages/muelu/src/Utils/MueLu_Utilities_decl.hpp
+++ b/packages/muelu/src/Utils/MueLu_Utilities_decl.hpp
@@ -753,7 +753,17 @@ namespace MueLu {
               // Compute the transpose A of the Tpetra matrix tpetraOp.
               RCP<Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > A;
               Tpetra::RowMatrixTransposer<Scalar, LocalOrdinal, GlobalOrdinal, Node> transposer(rcpFromRef(tpetraOp),label);
-              A = transposer.createTranspose(params);
+
+              {
+                using Teuchos::ParameterList;
+                using Teuchos::rcp;
+                RCP<ParameterList> transposeParams = params.is_null () ?
+                  rcp (new ParameterList) :
+                  rcp (new ParameterList (*params));
+                transposeParams.set ("sort", false);
+                A = transposer.createTranspose(transposeParams);
+              }
+
               RCP<Xpetra::TpetraCrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > AA   = rcp(new Xpetra::TpetraCrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>(A));
               RCP<CrsMatrix>                                                           AAA  = rcp_implicit_cast<CrsMatrix>(AA);
               RCP<Matrix>                                                              AAAA = rcp( new CrsMatrixWrap(AAA));

--- a/packages/muelu/src/Utils/MueLu_Utilities_decl.hpp
+++ b/packages/muelu/src/Utils/MueLu_Utilities_decl.hpp
@@ -760,7 +760,7 @@ namespace MueLu {
                 RCP<ParameterList> transposeParams = params.is_null () ?
                   rcp (new ParameterList) :
                   rcp (new ParameterList (*params));
-                transposeParams.set ("sort", false);
+                transposeParams->set ("sort", false);
                 A = transposer.createTranspose(transposeParams);
               }
 

--- a/packages/muelu/src/Utils/MueLu_Utilities_def.hpp
+++ b/packages/muelu/src/Utils/MueLu_Utilities_def.hpp
@@ -490,7 +490,16 @@ namespace MueLu {
 
         RCP<Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > A;
         Tpetra::RowMatrixTransposer<Scalar, LocalOrdinal, GlobalOrdinal, Node> transposer(rcpFromRef(tpetraOp),label); //more than meets the eye
-        A = transposer.createTranspose(params);
+
+        {
+          using Teuchos::ParameterList;
+          using Teuchos::rcp;
+          RCP<ParameterList> transposeParams = params.is_null () ?
+            rcp (new ParameterList) :
+            rcp (new ParameterList (*params));
+          transposeParams.set ("sort", false);
+          A = transposer.createTranspose (transposeParams);
+        }
 
         RCP<Xpetra::TpetraCrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > AA   = rcp(new Xpetra::TpetraCrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>(A) );
         RCP<Xpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> >       AAA  = rcp_implicit_cast<Xpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> >(AA);
@@ -540,7 +549,7 @@ namespace MueLu {
         Xscalar = rcp_dynamic_cast<Xpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> >(X);
       return Xscalar;
   }
-  
+
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   RCP<Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::magnitudeType,LocalOrdinal,GlobalOrdinal,Node> >

--- a/packages/muelu/src/Utils/MueLu_Utilities_def.hpp
+++ b/packages/muelu/src/Utils/MueLu_Utilities_def.hpp
@@ -497,7 +497,7 @@ namespace MueLu {
           RCP<ParameterList> transposeParams = params.is_null () ?
             rcp (new ParameterList) :
             rcp (new ParameterList (*params));
-          transposeParams.set ("sort", false);
+          transposeParams->set ("sort", false);
           A = transposer.createTranspose (transposeParams);
         }
 

--- a/packages/muelu/src/Utils/MueLu_Utilities_kokkos_decl.hpp
+++ b/packages/muelu/src/Utils/MueLu_Utilities_kokkos_decl.hpp
@@ -580,7 +580,7 @@ namespace MueLu {
             RCP<ParameterList> transposeParams = params.is_null () ?
               rcp (new ParameterList) :
               rcp (new ParameterList (*params));
-            transposeParams.set ("sort", false);
+            transposeParams->set ("sort", false);
             A = transposer.createTranspose(transposeParams);
           }
 

--- a/packages/muelu/src/Utils/MueLu_Utilities_kokkos_decl.hpp
+++ b/packages/muelu/src/Utils/MueLu_Utilities_kokkos_decl.hpp
@@ -574,7 +574,16 @@ namespace MueLu {
           // Compute the transpose A of the Tpetra matrix tpetraOp.
           RCP<Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > A;
           Tpetra::RowMatrixTransposer<SC,LO,GO,NO> transposer(rcpFromRef(tpetraOp),label);
-          A = transposer.createTranspose(params);
+          {
+            using Teuchos::ParameterList;
+            using Teuchos::rcp;
+            RCP<ParameterList> transposeParams = params.is_null () ?
+              rcp (new ParameterList) :
+              rcp (new ParameterList (*params));
+            transposeParams.set ("sort", false);
+            A = transposer.createTranspose(transposeParams);
+          }
+
           RCP<Xpetra::TpetraCrsMatrix<SC,LO,GO,NO> > AA   = rcp(new Xpetra::TpetraCrsMatrix<SC,LO,GO,NO>(A));
           RCP<CrsMatrix>                             AAA  = rcp_implicit_cast<CrsMatrix>(AA);
           RCP<CrsMatrixWrap>                         AAAA = rcp(new CrsMatrixWrap(AAA));

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_OpenMP.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_OpenMP.hpp
@@ -116,7 +116,7 @@ struct KernelWrappers2<Scalar,LocalOrdinal,GlobalOrdinal,Kokkos::Compat::KokkosO
 template<class Scalar,
          class LocalOrdinal,
          class GlobalOrdinal, class LocalOrdinalViewType>
-struct KernelWrappers3<Scalar,LocalOrdinal,GlobalOrdinal,Kokkos::Compat::KokkosOpenMPWrapperNode,LocalOrdinalViewType> {  
+struct KernelWrappers3<Scalar,LocalOrdinal,GlobalOrdinal,Kokkos::Compat::KokkosOpenMPWrapperNode,LocalOrdinalViewType> {
   static inline void mult_R_A_P_newmatrix_kernel_wrapper(CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Kokkos::Compat::KokkosOpenMPWrapperNode>& Rview,
                                                          CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Kokkos::Compat::KokkosOpenMPWrapperNode>& Aview,
                                                          CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Kokkos::Compat::KokkosOpenMPWrapperNode>& Pview,
@@ -141,7 +141,7 @@ static inline void mult_R_A_P_reuse_kernel_wrapper(CrsMatrixStruct<Scalar, Local
                                                          const std::string& label = std::string(),
                                                          const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
-  static inline void mult_PT_A_P_newmatrix_kernel_wrapper(CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Kokkos::Compat::KokkosOpenMPWrapperNode>& Aview,                                                        
+  static inline void mult_PT_A_P_newmatrix_kernel_wrapper(CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Kokkos::Compat::KokkosOpenMPWrapperNode>& Aview,
                                                          CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Kokkos::Compat::KokkosOpenMPWrapperNode>& Pview,
                                                          const LocalOrdinalViewType & Acol2Prow,
                                                          const LocalOrdinalViewType & Acol2PIrow,
@@ -152,7 +152,7 @@ static inline void mult_R_A_P_reuse_kernel_wrapper(CrsMatrixStruct<Scalar, Local
                                                          const std::string& label = std::string(),
                                                          const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
-  static inline void mult_PT_A_P_reuse_kernel_wrapper(CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Kokkos::Compat::KokkosOpenMPWrapperNode>& Aview,                                                        
+  static inline void mult_PT_A_P_reuse_kernel_wrapper(CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Kokkos::Compat::KokkosOpenMPWrapperNode>& Aview,
                                                          CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Kokkos::Compat::KokkosOpenMPWrapperNode>& Pview,
                                                          const LocalOrdinalViewType & Acol2Prow,
                                                          const LocalOrdinalViewType & Acol2PIrow,
@@ -538,7 +538,7 @@ void KernelWrappers3<Scalar,LocalOrdinal,GlobalOrdinal,Kokkos::Compat::KokkosOpe
                                                                                                                                                       CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Kokkos::Compat::KokkosOpenMPWrapperNode>& Rview,
                                                                                                                                                       CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Kokkos::Compat::KokkosOpenMPWrapperNode>& Aview,
                                                                                                                                                       CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Kokkos::Compat::KokkosOpenMPWrapperNode>& Pview,
-                                                                                                                                                      
+
                                                                                                const LocalOrdinalViewType & Acol2Prow,
                                                                                                const LocalOrdinalViewType & Acol2Irow,
                                                                                                const LocalOrdinalViewType & Pcol2Ccol,
@@ -587,7 +587,7 @@ template<class Scalar,
          class GlobalOrdinal,
          class LocalOrdinalViewType>
 void KernelWrappers3<Scalar,LocalOrdinal,GlobalOrdinal,Kokkos::Compat::KokkosOpenMPWrapperNode,LocalOrdinalViewType>::mult_PT_A_P_newmatrix_kernel_wrapper(CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Kokkos::Compat::KokkosOpenMPWrapperNode>& Aview,
-                                                                                                                                                         
+
                                                                                                                                                          CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Kokkos::Compat::KokkosOpenMPWrapperNode>& Pview,
                                                                                                                                                          const LocalOrdinalViewType & Acol2Prow,
                                                                                                                                                          const LocalOrdinalViewType & Acol2PIrow,
@@ -603,7 +603,7 @@ void KernelWrappers3<Scalar,LocalOrdinal,GlobalOrdinal,Kokkos::Compat::KokkosOpe
     std::string prefix_mmm = std::string("TpetraExt ") + label + std::string(": ");
     using Teuchos::TimeMonitor;
     Teuchos::RCP<TimeMonitor> MM;
-#endif    
+#endif
 
   // Node-specific code
   std::string nodename("OpenMP");
@@ -617,21 +617,36 @@ void KernelWrappers3<Scalar,LocalOrdinal,GlobalOrdinal,Kokkos::Compat::KokkosOpe
   }
 
   if(myalg == "LTG") {
- #ifdef HAVE_TPETRA_MMM_TIMINGS
-        MM = rcp(new TimeMonitor (*TimeMonitor::getNewTimer(prefix_mmm + std::string("PTAP local transpose"))));
-  #endif
-        // We don't need a kernel-level PTAP, we just transpose here
-        typedef RowMatrixTransposer<Scalar,LocalOrdinal,GlobalOrdinal, Kokkos::Compat::KokkosOpenMPWrapperNode>  transposer_type;
-        transposer_type transposer (Pview.origMatrix,label+std::string("XP: "));
-        Teuchos::RCP<Teuchos::ParameterList> transposeParams = Teuchos::rcp(new Teuchos::ParameterList);
-        if (!params.is_null())
-          transposeParams->set("compute global constants",
-                               params->get("compute global constants: temporaries",
-                                           false));
-        Teuchos::RCP<CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Kokkos::Compat::KokkosOpenMPWrapperNode> > Ptrans = transposer.createTransposeLocal(transposeParams);
-        CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Kokkos::Compat::KokkosOpenMPWrapperNode> Rview;
-        Rview.origMatrix = Ptrans;       
-        ::Tpetra::MatrixMatrix::ExtraKernels::mult_R_A_P_newmatrix_LowThreadGustavsonKernel(Rview,Aview,Pview,Acol2Prow,Acol2PIrow,Pcol2Accol,PIcol2Accol,Ac,Acimport,label,params);
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+    MM = rcp(new TimeMonitor (*TimeMonitor::getNewTimer(prefix_mmm + std::string("PTAP local transpose"))));
+#endif
+
+    using Teuchos::ParameterList;
+    using Teuchos::RCP;
+    using LO = LocalOrdinal;
+    using GO = GlobalOrdinal;
+    using SC = Scalar;
+
+    // We don't need a kernel-level PTAP, we just transpose here
+    using transposer_type =
+      RowMatrixTransposer<SC, LO, GO, Kokkos::Compat::KokkosOpenMPWrapperNode>;
+    transposer_type transposer (Pview.origMatrix, label + "XP: ");
+    RCP<ParameterList> transposeParams (new ParameterList);
+    if (! params.is_null ()) {
+      transposeParams->set ("compute global constants",
+                            params->get ("compute global constants: temporaries",
+                                         false));
+    }
+    transposeParams->set ("sort", false);
+    RCP<CrsMatrix<SC, LO, GO, Kokkos::Compat::KokkosOpenMPWrapperNode> > Ptrans =
+      transposer.createTransposeLocal (transposeParams);
+    CrsMatrixStruct<SC, LO, GO, Kokkos::Compat::KokkosOpenMPWrapperNode> Rview;
+    Rview.origMatrix = Ptrans;
+
+    using ::Tpetra::MatrixMatrix::ExtraKernels::mult_R_A_P_newmatrix_LowThreadGustavsonKernel;
+    mult_R_A_P_newmatrix_LowThreadGustavsonKernel
+      (Rview, Aview, Pview, Acol2Prow, Acol2PIrow, Pcol2Accol,
+       PIcol2Accol, Ac, Acimport, label, params);
   }
   else {
     throw std::runtime_error("Tpetra::MatrixMatrix::PT_A_P newmatrix unknown kernel");
@@ -644,7 +659,7 @@ template<class Scalar,
          class GlobalOrdinal,
          class LocalOrdinalViewType>
 void KernelWrappers3<Scalar,LocalOrdinal,GlobalOrdinal,Kokkos::Compat::KokkosOpenMPWrapperNode,LocalOrdinalViewType>::mult_PT_A_P_reuse_kernel_wrapper(CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Kokkos::Compat::KokkosOpenMPWrapperNode>& Aview,
-                                                                                                                                                         
+
                                                                                                                                                          CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Kokkos::Compat::KokkosOpenMPWrapperNode>& Pview,
                                                                                                                                                          const LocalOrdinalViewType & Acol2Prow,
                                                                                                                                                          const LocalOrdinalViewType & Acol2PIrow,
@@ -660,7 +675,7 @@ void KernelWrappers3<Scalar,LocalOrdinal,GlobalOrdinal,Kokkos::Compat::KokkosOpe
     std::string prefix_mmm = std::string("TpetraExt ") + label + std::string(": ");
     using Teuchos::TimeMonitor;
     Teuchos::RCP<TimeMonitor> MM;
-#endif    
+#endif
 
   // Node-specific code
   std::string nodename("OpenMP");
@@ -674,21 +689,36 @@ void KernelWrappers3<Scalar,LocalOrdinal,GlobalOrdinal,Kokkos::Compat::KokkosOpe
   }
 
   if(myalg == "LTG") {
- #ifdef HAVE_TPETRA_MMM_TIMINGS
-        MM = rcp(new TimeMonitor (*TimeMonitor::getNewTimer(prefix_mmm + std::string("PTAP local transpose"))));
-  #endif
-        // We don't need a kernel-level PTAP, we just transpose here
-        typedef RowMatrixTransposer<Scalar,LocalOrdinal,GlobalOrdinal, Kokkos::Compat::KokkosOpenMPWrapperNode>  transposer_type;
-        transposer_type transposer (Pview.origMatrix,label+std::string("XP: "));
-        Teuchos::RCP<Teuchos::ParameterList> transposeParams = Teuchos::rcp(new Teuchos::ParameterList);
-        if (!params.is_null())
-          transposeParams->set("compute global constants",
-                               params->get("compute global constants: temporaries",
-                                           false));
-        Teuchos::RCP<CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Kokkos::Compat::KokkosOpenMPWrapperNode> > Ptrans = transposer.createTransposeLocal(transposeParams);
-        CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Kokkos::Compat::KokkosOpenMPWrapperNode> Rview;
-        Rview.origMatrix = Ptrans;       
-        ::Tpetra::MatrixMatrix::ExtraKernels::mult_R_A_P_reuse_LowThreadGustavsonKernel(Rview,Aview,Pview,Acol2Prow,Acol2PIrow,Pcol2Accol,PIcol2Accol,Ac,Acimport,label,params);
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+    MM = rcp(new TimeMonitor (*TimeMonitor::getNewTimer(prefix_mmm + std::string("PTAP local transpose"))));
+#endif
+
+    using Teuchos::ParameterList;
+    using Teuchos::RCP;
+    using LO = LocalOrdinal;
+    using GO = GlobalOrdinal;
+    using SC = Scalar;
+
+    // We don't need a kernel-level PTAP, we just transpose here
+    using transposer_type =
+      RowMatrixTransposer<SC, LO, GO, Kokkos::Compat::KokkosOpenMPWrapperNode>;
+    transposer_type transposer (Pview.origMatrix, label + "XP: ");
+    RCP<ParameterList> transposeParams (new ParameterList);
+    if (! params.is_null ()) {
+      transposeParams->set ("compute global constants",
+                            params->get ("compute global constants: temporaries",
+                                         false));
+    }
+    transposeParams->set ("sort", false);
+    RCP<CrsMatrix<SC, LO, GO, Kokkos::Compat::KokkosOpenMPWrapperNode> > Ptrans =
+      transposer.createTransposeLocal (transposeParams);
+    CrsMatrixStruct<SC, LO, GO, Kokkos::Compat::KokkosOpenMPWrapperNode> Rview;
+    Rview.origMatrix = Ptrans;
+
+    using ::Tpetra::MatrixMatrix::ExtraKernels::mult_R_A_P_reuse_LowThreadGustavsonKernel;
+    mult_R_A_P_reuse_LowThreadGustavsonKernel
+      (Rview, Aview, Pview, Acol2Prow, Acol2PIrow, Pcol2Accol,
+       PIcol2Accol, Ac, Acimport, label, params);
   }
   else {
     throw std::runtime_error("Tpetra::MatrixMatrix::PT_A_P reuse unknown kernel");

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
@@ -159,19 +159,23 @@ void Multiply(
   use_optimized_ATB = false;
 #endif
 
-  if (!use_optimized_ATB && transposeA) {
-    transposer_type transposer(rcpFromRef (A));
-    Aprime = transposer.createTranspose();
+  using Teuchos::ParameterList;
+  RCP<ParameterList> transposeParams (new ParameterList);
+  transposeParams->set ("sort", false);
 
-  } else {
+  if (!use_optimized_ATB && transposeA) {
+    transposer_type transposer (rcpFromRef (A));
+    Aprime = transposer.createTranspose (transposeParams);
+  }
+  else {
     Aprime = rcpFromRef(A);
   }
 
   if (transposeB) {
-    transposer_type transposer(rcpFromRef (B));
-    Bprime = transposer.createTranspose();
-
-  } else {
+    transposer_type transposer (rcpFromRef (B));
+    Bprime = transposer.createTranspose (transposeParams);
+  }
+  else {
     Bprime = rcpFromRef(B);
   }
 
@@ -488,11 +492,16 @@ void Add(
   TEUCHOS_TEST_FOR_EXCEPTION(B.isLocallyIndexed() , std::runtime_error,
     prefix << "ERROR, input matrix B must not be locally indexed!");
 
+  using Teuchos::ParameterList;
+  RCP<ParameterList> transposeParams (new ParameterList);
+  transposeParams->set ("sort", false);
+
   RCP<const crs_matrix_type> Aprime = null;
   if (transposeA) {
-    transposer_type transposer(rcpFromRef (A));
-    Aprime = transposer.createTranspose();
-  } else {
+    transposer_type transposer (rcpFromRef (A));
+    Aprime = transposer.createTranspose (transposeParams);
+  }
+  else {
     Aprime = rcpFromRef(A);
   }
 
@@ -666,37 +675,53 @@ add (const Scalar& alpha,
     std::cerr << os.str ();
   }
 
-  TEUCHOS_TEST_FOR_EXCEPTION(!A.isFillComplete () || !B.isFillComplete (), std::invalid_argument,
-    prefix_mmm << "A and B must both be fill complete.");
+  TEUCHOS_TEST_FOR_EXCEPTION
+    (! A.isFillComplete () || ! B.isFillComplete (), std::invalid_argument,
+     prefix_mmm << "A and B must both be fill complete.");
 #ifdef HAVE_TPETRA_DEBUG
   // The matrices don't have domain or range Maps unless they are fill complete.
   if (A.isFillComplete () && B.isFillComplete ()) {
     const bool domainMapsSame =
-      (!transposeA && !transposeB && !A.getDomainMap()->locallySameAs (*B.getDomainMap ())) ||
-      (!transposeA &&  transposeB && !A.getDomainMap()->isSameAs (*B.getRangeMap  ())) ||
-      ( transposeA && !transposeB && !A.getRangeMap ()->isSameAs (*B.getDomainMap ()));
+      (! transposeA && ! transposeB &&
+       ! A.getDomainMap()->locallySameAs (*B.getDomainMap ())) ||
+      (! transposeA &&   transposeB &&
+       ! A.getDomainMap()->isSameAs (*B.getRangeMap  ())) ||
+      (  transposeA && ! transposeB &&
+       ! A.getRangeMap ()->isSameAs (*B.getDomainMap ()));
     TEUCHOS_TEST_FOR_EXCEPTION(domainMapsSame, std::invalid_argument,
       prefix_mmm << "The domain Maps of Op(A) and Op(B) are not the same.");
 
     const bool rangeMapsSame =
-      (!transposeA && !transposeB && !A.getRangeMap ()->isSameAs (*B.getRangeMap ())) ||
-      (!transposeA &&  transposeB && !A.getRangeMap ()->isSameAs (*B.getDomainMap())) ||
-      ( transposeA && !transposeB && !A.getDomainMap()->isSameAs (*B.getRangeMap ()));
+      (! transposeA && ! transposeB &&
+       ! A.getRangeMap ()->isSameAs (*B.getRangeMap ())) ||
+      (! transposeA &&   transposeB &&
+       ! A.getRangeMap ()->isSameAs (*B.getDomainMap())) ||
+      (  transposeA && ! transposeB &&
+       ! A.getDomainMap()->isSameAs (*B.getRangeMap ()));
     TEUCHOS_TEST_FOR_EXCEPTION(rangeMapsSame, std::invalid_argument,
       prefix_mmm << "The range Maps of Op(A) and Op(B) are not the same.");
   }
 #endif // HAVE_TPETRA_DEBUG
+
+  using Teuchos::ParameterList;
+  RCP<ParameterList> transposeParams (new ParameterList);
+  transposeParams->set ("sort", false);
+
   auto comm = A.getComm();
   // Form the explicit transpose of A if necessary.
   RCP<const crs_matrix_type> Aprime = rcpFromRef(A);
   if (transposeA) {
-    transposer_type transposer(Aprime);
-    Aprime = transposer.createTranspose ();
+    transposer_type transposer (Aprime);
+    Aprime = transposer.createTranspose (transposeParams);
   }
+
 #ifdef HAVE_TPETRA_DEBUG
-  TEUCHOS_TEST_FOR_EXCEPTION(Aprime.is_null (), std::logic_error,
-    prefix_mmm << "Failed to compute Op(A). Please report this bug to the Tpetra developers.");
+  TEUCHOS_TEST_FOR_EXCEPTION
+    (Aprime.is_null (), std::logic_error,
+     prefix_mmm << "Failed to compute Op(A). "
+     "Please report this bug to the Tpetra developers.");
 #endif // HAVE_TPETRA_DEBUG
+
   // Form the explicit transpose of B if necessary.
   RCP<const crs_matrix_type> Bprime = rcpFromRef(B);
   if (transposeB) {
@@ -706,8 +731,8 @@ add (const Scalar& alpha,
          << "Form explicit xpose of B" << std::endl;
       std::cerr << os.str ();
     }
-    transposer_type transposer(Bprime);
-    Bprime = transposer.createTranspose ();
+    transposer_type transposer (Bprime);
+    Bprime = transposer.createTranspose (transposeParams);
   }
 #ifdef HAVE_TPETRA_DEBUG
   TEUCHOS_TEST_FOR_EXCEPTION(Bprime.is_null (), std::logic_error,
@@ -747,9 +772,9 @@ add (const Scalar& alpha,
   {
     //import Aprime into Bprime's row map so the local matrices have same # of rows
     auto import = rcp(new import_type(Aprime->getRowMap(), Bprime->getRowMap()));
-    // cbl do not set 
+    // cbl do not set
     // parameterlist "isMatrixMatrix_TransferAndFillComplete" true here as
-    // this import _may_ take the form of a transfer. In practice it would be unlikely, 
+    // this import _may_ take the form of a transfer. In practice it would be unlikely,
     // but the general case is not so forgiving.
 
     Aprime = importAndFillCompleteCrsMatrix<crs_matrix_type>(Aprime, *import, Bprime->getDomainMap(), Bprime->getRangeMap());
@@ -960,12 +985,17 @@ void Add(
   }
 #endif // HAVE_TPETRA_DEBUG
 
+  using Teuchos::ParameterList;
+  RCP<ParameterList> transposeParams (new ParameterList);
+  transposeParams->set ("sort", false);
+
   // Form the explicit transpose of A if necessary.
   RCP<const crs_matrix_type> Aprime;
   if (transposeA) {
     transposer_type theTransposer (rcpFromRef (A));
-    Aprime = theTransposer.createTranspose ();
-  } else {
+    Aprime = theTransposer.createTranspose (transposeParams);
+  }
+  else {
     Aprime = rcpFromRef (A);
   }
 
@@ -978,8 +1008,9 @@ void Add(
   RCP<const crs_matrix_type> Bprime;
   if (transposeB) {
     transposer_type theTransposer (rcpFromRef (B));
-    Bprime = theTransposer.createTranspose ();
-  } else {
+    Bprime = theTransposer.createTranspose (transposeParams);
+  }
+  else {
     Bprime = rcpFromRef (B);
   }
 
@@ -1450,8 +1481,6 @@ void printMultiplicationStatistics(Teuchos::RCP<TransferType > Transfer, const s
   }
 }
 
-
-/*********************************************************************************************************/
 // Kernel method for computing the local portion of C = A*B
 template<class Scalar,
          class LocalOrdinal,
@@ -1464,7 +1493,6 @@ void mult_AT_B_newmatrix(
   const std::string & label,
   const Teuchos::RCP<Teuchos::ParameterList>& params)
 {
-  // Using &  Typedefs
   using Teuchos::RCP;
   using Teuchos::rcp;
   typedef Scalar                            SC;
@@ -1477,63 +1505,91 @@ void mult_AT_B_newmatrix(
 #ifdef HAVE_TPETRA_MMM_TIMINGS
   std::string prefix_mmm = std::string("TpetraExt ") + label + std::string(": ");
   using Teuchos::TimeMonitor;
-  RCP<Teuchos::TimeMonitor> MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer(prefix_mmm + std::string("MMM-T Transpose"))));
+  RCP<TimeMonitor> MM = rcp (new TimeMonitor
+    (*TimeMonitor::getNewTimer (prefix_mmm + "MMM-T Transpose")));
 #endif
 
   /*************************************************************/
   /* 1) Local Transpose of A                                   */
   /*************************************************************/
-  transposer_type transposer (rcpFromRef (A),label+std::string("XP: "));
-  RCP<Teuchos::ParameterList> transposeParams = Teuchos::rcp(new Teuchos::ParameterList);
-  if(!params.is_null()) transposeParams->set("compute global constants",params->get("compute global constants: temporaries",false));
-  RCP<CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > Atrans = transposer.createTransposeLocal(transposeParams);
+  transposer_type transposer (rcpFromRef (A), label + std::string("XP: "));
+
+  using Teuchos::ParameterList;
+  RCP<ParameterList> transposeParams (new ParameterList);
+  transposeParams->set ("sort", false);
+  if(! params.is_null ()) {
+    transposeParams->set ("compute global constants",
+                          params->get ("compute global constants: temporaries",
+                                       false));
+  }
+  RCP<Tpetra::CrsMatrix<SC, LO, GO, NO>> Atrans =
+    transposer.createTransposeLocal (transposeParams);
 
   /*************************************************************/
   /* 2/3) Call mult_A_B_newmatrix w/ fillComplete              */
   /*************************************************************/
 #ifdef HAVE_TPETRA_MMM_TIMINGS
   MM = Teuchos::null;
-  MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer(prefix_mmm + std::string("MMM-T I&X"))));
+  MM = rcp (new TimeMonitor
+    (*TimeMonitor::getNewTimer (prefix_mmm + std::string ("MMM-T I&X"))));
 #endif
 
   // Get views, asserting that no import is required to speed up computation
   crs_matrix_struct_type Aview;
   crs_matrix_struct_type Bview;
-  RCP<const Import<LocalOrdinal,GlobalOrdinal, Node> > dummyImporter;
+  RCP<const Import<LO, GO, NO> > dummyImporter;
 
   // NOTE: the I&X routine sticks an importer on the paramlist as output, so we have to use a unique guy here
-  RCP<Teuchos::ParameterList> importParams1 = Teuchos::rcp(new Teuchos::ParameterList);
-  if(!params.is_null()) {
-      importParams1->set("compute global constants",params->get("compute global constants: temporaries",false));
-      auto slist = params->sublist("matrixmatrix: kernel params",false);
-      bool isMM = slist.get("isMatrixMatrix_TransferAndFillComplete",false);
-      bool overrideAllreduce = slist.get("MM_TAFC_OverrideAllreduceCheck",false);
-      int mm_optimization_core_count=::Tpetra::Details::Behavior::TAFC_OptimizationCoreCount();
-      mm_optimization_core_count = slist.get("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count);
-      int mm_optimization_core_count2 = params->get("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count);
-      if(mm_optimization_core_count2<mm_optimization_core_count) mm_optimization_core_count=mm_optimization_core_count2;
-      auto & sip1 = importParams1->sublist("matrixmatrix: kernel params",false);
-      sip1.set("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count);
-      sip1.set("isMatrixMatrix_TransferAndFillComplete",isMM);
-      sip1.set("MM_TAFC_OverrideAllreduceCheck",overrideAllreduce);
+  RCP<Teuchos::ParameterList> importParams1 (new ParameterList);
+  if (! params.is_null ()) {
+    importParams1->set ("compute global constants",
+                        params->get ("compute global constants: temporaries",
+                                     false));
+    auto slist = params->sublist ("matrixmatrix: kernel params", false);
+    bool isMM = slist.get ("isMatrixMatrix_TransferAndFillComplete", false);
+    bool overrideAllreduce = slist.get("MM_TAFC_OverrideAllreduceCheck", false);
+    int mm_optimization_core_count =
+      ::Tpetra::Details::Behavior::TAFC_OptimizationCoreCount();
+    mm_optimization_core_count =
+      slist.get ("MM_TAFC_OptimizationCoreCount", mm_optimization_core_count);
+    int mm_optimization_core_count2 =
+      params->get ("MM_TAFC_OptimizationCoreCount", mm_optimization_core_count);
+    if (mm_optimization_core_count2 < mm_optimization_core_count) {
+      mm_optimization_core_count = mm_optimization_core_count2;
+    }
+    auto & sip1 = importParams1->sublist ("matrixmatrix: kernel params", false);
+    sip1.set ("MM_TAFC_OptimizationCoreCount", mm_optimization_core_count);
+    sip1.set ("isMatrixMatrix_TransferAndFillComplete", isMM);
+    sip1.set ("MM_TAFC_OverrideAllreduceCheck", overrideAllreduce);
   }
 
-  MMdetails::import_and_extract_views(*Atrans, Atrans->getRowMap(), Aview, dummyImporter,true, label,importParams1);
+  MMdetails::import_and_extract_views (*Atrans, Atrans->getRowMap (),
+                                       Aview, dummyImporter, true,
+                                       label, importParams1);
 
-  RCP<Teuchos::ParameterList> importParams2 = Teuchos::rcp(new Teuchos::ParameterList);
-  if(!params.is_null()){
-      importParams2->set("compute global constants",params->get("compute global constants: temporaries",false));
-      auto slist = params->sublist("matrixmatrix: kernel params",false);
-      bool isMM = slist.get("isMatrixMatrix_TransferAndFillComplete",false);
-      bool overrideAllreduce = slist.get("MM_TAFC_OverrideAllreduceCheck",false);
-      int mm_optimization_core_count=::Tpetra::Details::Behavior::TAFC_OptimizationCoreCount();
-      mm_optimization_core_count = slist.get("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count);
-      int mm_optimization_core_count2 = params->get("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count);
-      if(mm_optimization_core_count2<mm_optimization_core_count) mm_optimization_core_count=mm_optimization_core_count2;
-      auto & sip2 = importParams2->sublist("matrixmatrix: kernel params",false);
-      sip2.set("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count);
-      sip2.set("isMatrixMatrix_TransferAndFillComplete",isMM);
-      sip2.set("MM_TAFC_OverrideAllreduceCheck",overrideAllreduce);
+  RCP<ParameterList> importParams2 (new ParameterList);
+  if (! params.is_null ()) {
+    importParams2->set ("compute global constants",
+                        params->get ("compute global constants: temporaries",
+                                     false));
+    auto slist = params->sublist ("matrixmatrix: kernel params", false);
+    bool isMM = slist.get ("isMatrixMatrix_TransferAndFillComplete", false);
+    bool overrideAllreduce = slist.get ("MM_TAFC_OverrideAllreduceCheck", false);
+    int mm_optimization_core_count =
+      ::Tpetra::Details::Behavior::TAFC_OptimizationCoreCount();
+    mm_optimization_core_count =
+      slist.get ("MM_TAFC_OptimizationCoreCount",
+                 mm_optimization_core_count);
+    int mm_optimization_core_count2 =
+      params->get ("MM_TAFC_OptimizationCoreCount",
+                   mm_optimization_core_count);
+    if (mm_optimization_core_count2 < mm_optimization_core_count) {
+      mm_optimization_core_count = mm_optimization_core_count2;
+    }
+    auto & sip2 = importParams2->sublist ("matrixmatrix: kernel params", false);
+    sip2.set ("MM_TAFC_OptimizationCoreCount", mm_optimization_core_count);
+    sip2.set ("isMatrixMatrix_TransferAndFillComplete", isMM);
+    sip2.set ("MM_TAFC_OverrideAllreduceCheck", overrideAllreduce);
   }
 
   if(B.getRowMap()->isSameAs(*Atrans->getColMap())){
@@ -1548,16 +1604,17 @@ void mult_AT_B_newmatrix(
   MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer(prefix_mmm + std::string("MMM-T AB-core"))));
 #endif
 
-  RCP<Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> >Ctemp;
+  RCP<Tpetra::CrsMatrix<SC, LO, GO, NO>> Ctemp;
 
   // If Atrans has no Exporter, we can use C instead of having to create a temp matrix
-  bool needs_final_export = !Atrans->getGraph()->getExporter().is_null();
-  if (needs_final_export)
-    Ctemp = rcp(new Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>(Atrans->getRowMap(),0));
-  else
-    Ctemp = rcp(&C,false);// don't allow deallocation
+  bool needs_final_export = ! Atrans->getGraph ()->getExporter ().is_null();
+  if (needs_final_export) {
+    Ctemp = rcp (new Tpetra::CrsMatrix<SC, LO, GO, NO> (Atrans->getRowMap (), 0));
+  }
+  else {
+    Ctemp = rcp (&C, false);
+  }
 
-  // Multiply
   mult_A_B_newmatrix(Aview, Bview, *Ctemp, label,params);
 
   /*************************************************************/
@@ -1568,29 +1625,32 @@ void mult_AT_B_newmatrix(
   MM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer(prefix_mmm + std::string("MMM-T exportAndFillComplete"))));
 #endif
 
-  Teuchos::RCP<Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > Crcp(&C,false);
+  RCP<Tpetra::CrsMatrix<SC, LO, GO, NO>> Crcp (&C, false);
 
   if (needs_final_export) {
-    Teuchos::ParameterList labelList;
+    ParameterList labelList;
     labelList.set("Timer Label", label);
     if(!params.is_null()) {
-        Teuchos::ParameterList& params_sublist = params->sublist("matrixmatrix: kernel params",false);
-        Teuchos::ParameterList& labelList_subList = labelList.sublist("matrixmatrix: kernel params",false);
-        int mm_optimization_core_count = ::Tpetra::Details::Behavior::TAFC_OptimizationCoreCount();
-        mm_optimization_core_count = params_sublist.get("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count);
-        int mm_optimization_core_count2 = params->get("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count);
-        if(mm_optimization_core_count2<mm_optimization_core_count) mm_optimization_core_count=mm_optimization_core_count2;
-        labelList_subList.set("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count,"Core Count above which the optimized neighbor discovery is used");
-        bool isMM = params_sublist.get("isMatrixMatrix_TransferAndFillComplete",false);
-        bool overrideAllreduce = params_sublist.get("MM_TAFC_OverrideAllreduceCheck",false);
+      ParameterList& params_sublist = params->sublist("matrixmatrix: kernel params",false);
+      ParameterList& labelList_subList = labelList.sublist("matrixmatrix: kernel params",false);
+      int mm_optimization_core_count = ::Tpetra::Details::Behavior::TAFC_OptimizationCoreCount();
+      mm_optimization_core_count = params_sublist.get("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count);
+      int mm_optimization_core_count2 = params->get("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count);
+      if(mm_optimization_core_count2<mm_optimization_core_count) mm_optimization_core_count=mm_optimization_core_count2;
+      labelList_subList.set("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count,"Core Count above which the optimized neighbor discovery is used");
+      bool isMM = params_sublist.get("isMatrixMatrix_TransferAndFillComplete",false);
+      bool overrideAllreduce = params_sublist.get("MM_TAFC_OverrideAllreduceCheck",false);
 
-        labelList_subList.set("isMatrixMatrix_TransferAndFillComplete",isMM,
-                      "This parameter should be set to true only for MatrixMatrix operations: the optimization in Epetra that was ported to Tpetra does _not_ take into account the possibility that for any given source PID, a particular GID may not exist on the target PID: i.e. a transfer operation. A fix for this general case is in development.");
-        labelList.set("compute global constants",params->get("compute global constants",true));
-        labelList.set("MM_TAFC_OverrideAllreduceCheck",overrideAllreduce);
+      labelList_subList.set ("isMatrixMatrix_TransferAndFillComplete", isMM,
+                             "This parameter should be set to true only for MatrixMatrix operations: the optimization in Epetra that was ported to Tpetra does _not_ take into account the possibility that for any given source PID, a particular GID may not exist on the target PID: i.e. a transfer operation. A fix for this general case is in development.");
+      labelList.set("compute global constants",params->get("compute global constants",true));
+      labelList.set("MM_TAFC_OverrideAllreduceCheck",overrideAllreduce);
     }
-    Ctemp->exportAndFillComplete(Crcp,*Ctemp->getGraph()->getExporter(),
-                                 B.getDomainMap(),A.getDomainMap(),rcp(&labelList,false));
+    Ctemp->exportAndFillComplete (Crcp,
+                                  *Ctemp->getGraph ()->getExporter (),
+                                  B.getDomainMap (),
+                                  A.getDomainMap (),
+                                  rcp (&labelList, false));
   }
 #ifdef HAVE_TPETRA_MMM_STATISTICS
   printMultiplicationStatistics(Ctemp->getGraph()->getExporter(), label+std::string(" AT_B MMM"));
@@ -2871,7 +2931,7 @@ void KernelWrappers2<Scalar,LocalOrdinal,GlobalOrdinal,Node,LocalOrdinalViewType
       if(!params.is_null()) labelList->set("compute global constants",params->get("compute global constants",true));
       RCP<const Export<LO,GO,NO> > dummyExport;
       C.expertStaticFillComplete(Bview.origMatrix->getDomainMap(), Aview.origMatrix->getRangeMap(), Cimport,dummyExport,labelList);
-  
+
   }
 }
 
@@ -3317,7 +3377,7 @@ void import_and_extract_views(
     labelList_subList.set("isMatrixMatrix_TransferAndFillComplete",isMM);
     labelList_subList.set("MM_TAFC_OptimizationCoreCount",mm_optimization_core_count);
     labelList_subList.set("MM_TAFC_OverrideAllreduceCheck",overrideAllreduce);
-    
+
     Aview.importMatrix = Tpetra::importAndFillCompleteCrsMatrix<crs_matrix_type>(rcpFromRef(A), *importer,
                                     A.getDomainMap(), importer->getTargetMap(), rcpFromRef(labelList));
 

--- a/packages/tpetra/core/ext/TpetraExt_TripleMatrixMultiply_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_TripleMatrixMultiply_def.hpp
@@ -151,23 +151,27 @@ namespace Tpetra {
       // whether the matrix is empty.
       const bool newFlag = !Ac.getGraph()->isLocallyIndexed() && !Ac.getGraph()->isGloballyIndexed();
 
+      using Teuchos::ParameterList;
+      RCP<ParameterList> transposeParams (new ParameterList);
+      transposeParams->set ("sort", false);
+
       if (transposeR && &R != &P) {
         transposer_type transposer(rcpFromRef (R));
-        Rprime = transposer.createTranspose();
+        Rprime = transposer.createTranspose (transposeParams);
       } else {
         Rprime = rcpFromRef(R);
       }
 
       if (transposeA) {
         transposer_type transposer(rcpFromRef (A));
-        Aprime = transposer.createTranspose();
+        Aprime = transposer.createTranspose (transposeParams);
       } else {
         Aprime = rcpFromRef(A);
       }
 
       if (transposeP) {
         transposer_type transposer(rcpFromRef (P));
-        Pprime = transposer.createTranspose();
+        Pprime = transposer.createTranspose (transposeParams);
       } else {
         Pprime = rcpFromRef(P);
       }
@@ -398,7 +402,7 @@ namespace Tpetra {
       local_map_type Irowmap_local;  if(!Pview.importMatrix.is_null()) Irowmap_local = Pview.importMatrix->getRowMap()->getLocalMap();
       local_map_type Pcolmap_local = Pview.origMatrix->getColMap()->getLocalMap();
       local_map_type Icolmap_local;  if(!Pview.importMatrix.is_null()) Icolmap_local = Pview.importMatrix->getColMap()->getLocalMap();
-      
+
 
       // mfh 27 Sep 2016: Pcol2Ccol is a table that maps from local column
       // indices of B, to local column indices of Ac.  (B and Ac have the
@@ -426,7 +430,7 @@ namespace Tpetra {
         // column Maps of (the local part of) P, and the "remote" part of
         // P.  Ditto for the Import.  We have optimized this "setUnion"
         // operation on Import objects and Maps.
-        
+
         // Choose the right variant of setUnion
         if (!Pimport.is_null() && !Iimport.is_null()) {
           Cimport = Pimport->setUnion(*Iimport);
@@ -447,7 +451,7 @@ namespace Tpetra {
         // communication costs of sparse matrix-matrix multiply.
         TEUCHOS_TEST_FOR_EXCEPTION(!Cimport->getSourceMap()->isSameAs(*Pview.origMatrix->getDomainMap()),
                                    std::runtime_error, "Tpetra::RAP: Import setUnion messed with the DomainMap in an unfortunate way");
-        
+
         // NOTE: This is not efficient and should be folded into setUnion
         //
         // mfh 27 Sep 2016: What the above comment means, is that the
@@ -461,9 +465,9 @@ namespace Tpetra {
         Kokkos::parallel_for("Tpetra::mult_R_A_P_newmatrix::Icol2Ccol_getGlobalElement",range_type(0,Pview.importMatrix->getColMap()->getNodeNumElements()),KOKKOS_LAMBDA(const LO i) {
             Icol2Ccol(i) = Ccolmap_local.getLocalElement(Icolmap_local.getGlobalElement(i));
           });
-        
+
       }
-      
+
       // Replace the column map
       //
       // mfh 27 Sep 2016: We do this because C was originally created
@@ -484,7 +488,7 @@ namespace Tpetra {
       // B_remote), then targetMapToImportRow[Aik] is the local index of
       // that row of B.  Otherwise, targetMapToOrigRow[Aik] is "invalid"
       // (a flag value).
-      
+
       // Run through all the hash table lookups once and for all
       lo_view_t targetMapToOrigRow(Kokkos::ViewAllocateWithoutInitializing("targetMapToOrigRow"),Aview.colMap->getNodeNumElements());
       lo_view_t targetMapToImportRow(Kokkos::ViewAllocateWithoutInitializing("targetMapToImportRow"),Aview.colMap->getNodeNumElements());
@@ -501,7 +505,7 @@ namespace Tpetra {
             targetMapToImportRow(i) = I_LID;
           }
         });
-            
+
       // Call the actual kernel.  We'll rely on partial template specialization to call the correct one ---
       // Either the straight-up Tpetra code (SerialNode) or the KokkosKernels one (other NGP node types)
       KernelWrappers3<Scalar,LocalOrdinal,GlobalOrdinal,Node,lo_view_t>::
@@ -565,7 +569,7 @@ namespace Tpetra {
       local_map_type Pcolmap_local = Pview.origMatrix->getColMap()->getLocalMap();
       local_map_type Icolmap_local;  if(!Pview.importMatrix.is_null()) Icolmap_local = Pview.importMatrix->getColMap()->getLocalMap();
       local_map_type Ccolmap_local = Ccolmap->getLocalMap();
-      
+
       // Build the final importer / column map, hash table lookups for C
       lo_view_t Bcol2Ccol(Kokkos::ViewAllocateWithoutInitializing("Bcol2Ccol"),Pview.colMap->getNodeNumElements()), Icol2Ccol;
       {
@@ -574,7 +578,7 @@ namespace Tpetra {
         Kokkos::parallel_for(range_type(0,Pview.origMatrix->getColMap()->getNodeNumElements()),KOKKOS_LAMBDA(const LO i) {
             Bcol2Ccol(i) = Ccolmap_local.getLocalElement(Pcolmap_local.getGlobalElement(i));
           });
-        
+
         if (!Pview.importMatrix.is_null()) {
           TEUCHOS_TEST_FOR_EXCEPTION(!Cimport->getSourceMap()->isSameAs(*Pview.origMatrix->getDomainMap()),
                                      std::runtime_error, "Tpetra::MMM: Import setUnion messed with the DomainMap in an unfortunate way");
@@ -585,7 +589,7 @@ namespace Tpetra {
             });
         }
       }
-      
+
       // Run through all the hash table lookups once and for all
       lo_view_t targetMapToOrigRow(Kokkos::ViewAllocateWithoutInitializing("targetMapToOrigRow"),Aview.colMap->getNodeNumElements());
       lo_view_t targetMapToImportRow(Kokkos::ViewAllocateWithoutInitializing("targetMapToImportRow"),Aview.colMap->getNodeNumElements());
@@ -599,10 +603,10 @@ namespace Tpetra {
             LO I_LID = Irowmap_local.getLocalElement(aidx);
             targetMapToOrigRow(i)   = LO_INVALID;
             targetMapToImportRow(i) = I_LID;
-            
+
           }
-        });   
-      
+        });
+
       // Call the actual kernel.  We'll rely on partial template specialization to call the correct one ---
       // Either the straight-up Tpetra code (SerialNode) or the KokkosKernels one (other NGP node types)
       KernelWrappers3<Scalar,LocalOrdinal,GlobalOrdinal,Node,lo_view_t>::
@@ -664,7 +668,7 @@ namespace Tpetra {
       local_map_type Irowmap_local;  if(!Pview.importMatrix.is_null()) Irowmap_local = Pview.importMatrix->getRowMap()->getLocalMap();
       local_map_type Pcolmap_local = Pview.origMatrix->getColMap()->getLocalMap();
       local_map_type Icolmap_local;  if(!Pview.importMatrix.is_null()) Icolmap_local = Pview.importMatrix->getColMap()->getLocalMap();
-      
+
 
       // mfh 27 Sep 2016: Pcol2Ccol is a table that maps from local column
       // indices of B, to local column indices of Ac.  (B and Ac have the
@@ -692,7 +696,7 @@ namespace Tpetra {
         // column Maps of (the local part of) P, and the "remote" part of
         // P.  Ditto for the Import.  We have optimized this "setUnion"
         // operation on Import objects and Maps.
-        
+
         // Choose the right variant of setUnion
         if (!Pimport.is_null() && !Iimport.is_null()) {
           Cimport = Pimport->setUnion(*Iimport);
@@ -713,7 +717,7 @@ namespace Tpetra {
         // communication costs of sparse matrix-matrix multiply.
         TEUCHOS_TEST_FOR_EXCEPTION(!Cimport->getSourceMap()->isSameAs(*Pview.origMatrix->getDomainMap()),
                                    std::runtime_error, "Tpetra::RAP: Import setUnion messed with the DomainMap in an unfortunate way");
-        
+
         // NOTE: This is not efficient and should be folded into setUnion
         //
         // mfh 27 Sep 2016: What the above comment means, is that the
@@ -727,9 +731,9 @@ namespace Tpetra {
         Kokkos::parallel_for("Tpetra::mult_R_A_P_newmatrix::Icol2Ccol_getGlobalElement",range_type(0,Pview.importMatrix->getColMap()->getNodeNumElements()),KOKKOS_LAMBDA(const LO i) {
             Icol2Ccol(i) = Ccolmap_local.getLocalElement(Icolmap_local.getGlobalElement(i));
           });
-        
+
       }
-      
+
       // Replace the column map
       //
       // mfh 27 Sep 2016: We do this because C was originally created
@@ -750,7 +754,7 @@ namespace Tpetra {
       // B_remote), then targetMapToImportRow[Aik] is the local index of
       // that row of B.  Otherwise, targetMapToOrigRow[Aik] is "invalid"
       // (a flag value).
-      
+
       // Run through all the hash table lookups once and for all
       lo_view_t targetMapToOrigRow(Kokkos::ViewAllocateWithoutInitializing("targetMapToOrigRow"),Aview.colMap->getNodeNumElements());
       lo_view_t targetMapToImportRow(Kokkos::ViewAllocateWithoutInitializing("targetMapToImportRow"),Aview.colMap->getNodeNumElements());
@@ -767,7 +771,7 @@ namespace Tpetra {
             targetMapToImportRow(i) = I_LID;
           }
         });
-            
+
       // Call the actual kernel.  We'll rely on partial template specialization to call the correct one ---
       // Either the straight-up Tpetra code (SerialNode) or the KokkosKernels one (other NGP node types)
       KernelWrappers3<Scalar,LocalOrdinal,GlobalOrdinal,Node,lo_view_t>::
@@ -829,7 +833,7 @@ namespace Tpetra {
       local_map_type Pcolmap_local = Pview.origMatrix->getColMap()->getLocalMap();
       local_map_type Icolmap_local;  if(!Pview.importMatrix.is_null()) Icolmap_local = Pview.importMatrix->getColMap()->getLocalMap();
       local_map_type Ccolmap_local = Ccolmap->getLocalMap();
-      
+
       // Build the final importer / column map, hash table lookups for C
       lo_view_t Bcol2Ccol(Kokkos::ViewAllocateWithoutInitializing("Bcol2Ccol"),Pview.colMap->getNodeNumElements()), Icol2Ccol;
       {
@@ -838,7 +842,7 @@ namespace Tpetra {
         Kokkos::parallel_for(range_type(0,Pview.origMatrix->getColMap()->getNodeNumElements()),KOKKOS_LAMBDA(const LO i) {
             Bcol2Ccol(i) = Ccolmap_local.getLocalElement(Pcolmap_local.getGlobalElement(i));
           });
-        
+
         if (!Pview.importMatrix.is_null()) {
           TEUCHOS_TEST_FOR_EXCEPTION(!Cimport->getSourceMap()->isSameAs(*Pview.origMatrix->getDomainMap()),
                                      std::runtime_error, "Tpetra::MMM: Import setUnion messed with the DomainMap in an unfortunate way");
@@ -849,7 +853,7 @@ namespace Tpetra {
             });
         }
       }
-      
+
       // Run through all the hash table lookups once and for all
       lo_view_t targetMapToOrigRow(Kokkos::ViewAllocateWithoutInitializing("targetMapToOrigRow"),Aview.colMap->getNodeNumElements());
       lo_view_t targetMapToImportRow(Kokkos::ViewAllocateWithoutInitializing("targetMapToImportRow"),Aview.colMap->getNodeNumElements());
@@ -863,10 +867,10 @@ namespace Tpetra {
             LO I_LID = Irowmap_local.getLocalElement(aidx);
             targetMapToOrigRow(i)   = LO_INVALID;
             targetMapToImportRow(i) = I_LID;
-            
+
           }
-        });   
-      
+        });
+
       // Call the actual kernel.  We'll rely on partial template specialization to call the correct one ---
       // Either the straight-up Tpetra code (SerialNode) or the KokkosKernels one (other NGP node types)
       KernelWrappers3<Scalar,LocalOrdinal,GlobalOrdinal,Node,lo_view_t>::
@@ -934,11 +938,11 @@ namespace Tpetra {
       const KCRS & Amat = Aview.origMatrix->getLocalMatrix();
       const KCRS & Pmat = Pview.origMatrix->getLocalMatrix();
       const KCRS & Rmat = Rview.origMatrix->getLocalMatrix();
-      
+
       c_lno_view_t Arowptr = Amat.graph.row_map, Prowptr = Pmat.graph.row_map,  Rrowptr = Rmat.graph.row_map;
       const lno_nnz_view_t Acolind = Amat.graph.entries, Pcolind = Pmat.graph.entries , Rcolind = Rmat.graph.entries;
       const scalar_view_t Avals = Amat.values, Pvals = Pmat.values, Rvals = Rmat.values;
-      
+
       c_lno_view_t  Irowptr;
       lno_nnz_view_t  Icolind;
       scalar_view_t  Ivals;
@@ -948,7 +952,7 @@ namespace Tpetra {
         Ivals   = Pview.importMatrix->getLocalMatrix().values;
         p_max_nnz_per_row = std::max(p_max_nnz_per_row,Pview.importMatrix->getNodeMaxNumRowEntries());
       }
-      
+
 #ifdef HAVE_TPETRA_MMM_TIMINGS
       RCP<TimeMonitor> MM2 = rcp(new TimeMonitor(*TimeMonitor::getNewTimer(prefix_mmm + std::string("RAP Newmatrix SerialCore - Compare"))));
 #endif
@@ -1173,7 +1177,7 @@ namespace Tpetra {
       const KCRS & Pmat = Pview.origMatrix->getLocalMatrix();
       const KCRS & Rmat = Rview.origMatrix->getLocalMatrix();
       const KCRS & Cmat = Ac.getLocalMatrix();
-      
+
       c_lno_view_t Arowptr = Amat.graph.row_map, Prowptr = Pmat.graph.row_map,  Rrowptr = Rmat.graph.row_map, Crowptr =  Cmat.graph.row_map;
       const lno_nnz_view_t Acolind = Amat.graph.entries, Pcolind = Pmat.graph.entries , Rcolind = Rmat.graph.entries, Ccolind = Cmat.graph.entries;
       const scalar_view_t Avals = Amat.values, Pvals = Pmat.values, Rvals = Rmat.values;
@@ -1188,7 +1192,7 @@ namespace Tpetra {
         Ivals   = Pview.importMatrix->getLocalMatrix().values;
         p_max_nnz_per_row = std::max(p_max_nnz_per_row,Pview.importMatrix->getNodeMaxNumRowEntries());
       }
-      
+
 #ifdef HAVE_TPETRA_MMM_TIMINGS
       RCP<TimeMonitor> MM2 = rcp(new TimeMonitor(*TimeMonitor::getNewTimer(prefix_mmm + std::string("RAP Reuse SerialCore - Compare"))));
 #endif
@@ -1219,11 +1223,11 @@ namespace Tpetra {
         CSR_ip = Crowptr[i+1];
         for (size_t k = OLD_ip; k < CSR_ip; k++) {
           ac_status[Ccolind[k]] = k;
-          
+
           // Reset values in the row of C
           Cvals[k] = SC_ZERO;
         }
-        
+
         // mfh 27 Sep 2016: For each entry of R in the current row of R
         for (size_t kk = Rrowptr[i]; kk < Rrowptr[i+1]; kk++) {
           LO k  = Rcolind[kk]; // local column index of current entry of R
@@ -1256,7 +1260,7 @@ namespace Tpetra {
                 TEUCHOS_TEST_FOR_EXCEPTION(ac_status[Cij] < OLD_ip || ac_status[Cij] >= CSR_ip,
                                            std::runtime_error, "Trying to insert a new entry (" << i << "," << Cij << ") into a static graph " <<
                                            "(c_status = " << ac_status[Cij] << " of [" << OLD_ip << "," << CSR_ip << "))");
-                
+
                 Cvals[ac_status[Cij]] += Rik*Akl*Plj;
               }
             } else {
@@ -1275,7 +1279,7 @@ namespace Tpetra {
                 TEUCHOS_TEST_FOR_EXCEPTION(ac_status[Cij] < OLD_ip || ac_status[Cij] >= CSR_ip,
                                            std::runtime_error, "Trying to insert a new entry (" << i << "," << Cij << ") into a static graph " <<
                                            "(c_status = " << ac_status[Cij] << " of [" << OLD_ip << "," << CSR_ip << "))");
-                
+
                 Cvals[ac_status[Cij]] += Rik*Akl*Plj;
               }
             }
@@ -1286,7 +1290,7 @@ namespace Tpetra {
 #ifdef HAVE_TPETRA_MMM_TIMINGS
   auto MM3 = rcp(new TimeMonitor (*TimeMonitor::getNewTimer(prefix_mmm + std::string("RAP Reuse ESFC"))));
 #endif
-  
+
   Ac.fillComplete(Ac.getDomainMap(), Ac.getRangeMap());
 
 }
@@ -1319,15 +1323,22 @@ namespace Tpetra {
       // We don't need a kernel-level PTAP, we just transpose here
       typedef RowMatrixTransposer<Scalar,LocalOrdinal,GlobalOrdinal, Node>  transposer_type;
       transposer_type transposer (Pview.origMatrix,label+std::string("XP: "));
-      Teuchos::RCP<Teuchos::ParameterList> transposeParams = Teuchos::rcp(new Teuchos::ParameterList);
-      if (!params.is_null())
-        transposeParams->set("compute global constants",
-                             params->get("compute global constants: temporaries",
+
+      using Teuchos::ParameterList;
+      using Teuchos::RCP;
+      RCP<ParameterList> transposeParams (new ParameterList);
+      transposeParams->set ("sort", false);
+
+      if (! params.is_null ()) {
+        transposeParams->set ("compute global constants",
+                              params->get ("compute global constants: temporaries",
                                            false));
-      Teuchos::RCP<CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > Ptrans = transposer.createTransposeLocal(transposeParams);
+      }
+      RCP<CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > Ptrans =
+        transposer.createTransposeLocal (transposeParams);
       CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Node> Rview;
-      Rview.origMatrix = Ptrans;       
-      
+      Rview.origMatrix = Ptrans;
+
       mult_R_A_P_newmatrix_kernel_wrapper(Rview,Aview,Pview,Acol2Prow,Acol2PIrow,Pcol2Accol,PIcol2Accol,Ac,Acimport,label,params);
     }
 
@@ -1358,15 +1369,22 @@ namespace Tpetra {
       // We don't need a kernel-level PTAP, we just transpose here
       typedef RowMatrixTransposer<Scalar,LocalOrdinal,GlobalOrdinal, Node>  transposer_type;
       transposer_type transposer (Pview.origMatrix,label+std::string("XP: "));
-      Teuchos::RCP<Teuchos::ParameterList> transposeParams = Teuchos::rcp(new Teuchos::ParameterList);
-      if (!params.is_null())
-        transposeParams->set("compute global constants",
-                             params->get("compute global constants: temporaries",
+
+      using Teuchos::ParameterList;
+      using Teuchos::RCP;
+      RCP<ParameterList> transposeParams (new ParameterList);
+      transposeParams->set ("sort", false);
+
+      if (! params.is_null ()) {
+        transposeParams->set ("compute global constants",
+                              params->get ("compute global constants: temporaries",
                                            false));
-      Teuchos::RCP<CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > Ptrans = transposer.createTransposeLocal(transposeParams);
+      }
+      RCP<CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > Ptrans =
+        transposer.createTransposeLocal (transposeParams);
       CrsMatrixStruct<Scalar, LocalOrdinal, GlobalOrdinal, Node> Rview;
-      Rview.origMatrix = Ptrans;       
-      
+      Rview.origMatrix = Ptrans;
+
       mult_R_A_P_reuse_kernel_wrapper(Rview,Aview,Pview,Acol2Prow,Acol2PIrow,Pcol2Accol,PIcol2Accol,Ac,Acimport,label,params);
     }
 
@@ -1476,12 +1494,17 @@ namespace Tpetra {
       ArrayView<const SC>     Rvals;
 
       transposer_type transposer (Pview.origMatrix,label+std::string("XP: "));
-      RCP<Teuchos::ParameterList> transposeParams = Teuchos::rcp(new Teuchos::ParameterList);
-      if (!params.is_null())
-        transposeParams->set("compute global constants",
-                             params->get("compute global constants: temporaries",
-                                         false));
-      RCP<CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > Ptrans = transposer.createTransposeLocal(transposeParams);
+
+      using Teuchos::ParameterList;
+      RCP<ParameterList> transposeParams (new ParameterList);
+      transposeParams->set ("sort", false);  
+      if (! params.is_null ()) {
+        transposeParams->set ("compute global constants",
+                              params->get ("compute global constants: temporaries",
+                                           false));
+      }
+      RCP<CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > Ptrans =
+        transposer.createTransposeLocal (transposeParams);
 
       Ptrans->getAllValues(Rrowptr_RCP, Rcolind_RCP, Rvals_RCP);
       Rrowptr = Rrowptr_RCP();

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -34,8 +34,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
-//
 // ************************************************************************
 // @HEADER
 
@@ -597,6 +595,17 @@ namespace Tpetra {
               const Teuchos::RCP<const map_type>& domainMap = Teuchos::null,
               const Teuchos::RCP<const map_type>& rangeMap = Teuchos::null,
               const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
+
+    //! Create a fill-complete CrsGraph from all the things it needs.
+    CrsGraph (const local_graph_type& lclGraph,
+              const Teuchos::RCP<const map_type>& rowMap,
+              const Teuchos::RCP<const map_type>& colMap,
+              const Teuchos::RCP<const map_type>& domainMap,
+              const Teuchos::RCP<const map_type>& rangeMap,
+              const Teuchos::RCP<const import_type>& importer,
+              const Teuchos::RCP<const export_type>& exporter,
+              const Teuchos::RCP<Teuchos::ParameterList>& params =
+                Teuchos::null);
 
     //! Copy constructor (default).
     CrsGraph (const CrsGraph<local_ordinal_type, global_ordinal_type, node_type>&) = default;

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -34,8 +34,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
-//
 // ************************************************************************
 // @HEADER
 
@@ -888,6 +886,67 @@ namespace Tpetra {
     }
     this->fillComplete_ = true;
     this->checkInternalState ();
+  }
+
+  template <class LocalOrdinal, class GlobalOrdinal, class Node>
+  CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
+  CrsGraph (const local_graph_type& lclGraph,
+            const Teuchos::RCP<const map_type>& rowMap,
+            const Teuchos::RCP<const map_type>& colMap,
+            const Teuchos::RCP<const map_type>& domainMap,
+            const Teuchos::RCP<const map_type>& rangeMap,
+            const Teuchos::RCP<const import_type>& importer,
+            const Teuchos::RCP<const export_type>& exporter,
+            const Teuchos::RCP<Teuchos::ParameterList>& params) :
+    DistObject<GlobalOrdinal, LocalOrdinal, GlobalOrdinal, node_type> (rowMap),
+    rowMap_ (rowMap),
+    colMap_ (colMap),
+    rangeMap_ (rangeMap.is_null () ? rowMap : rangeMap),
+    domainMap_ (domainMap.is_null () ? rowMap : domainMap),
+    importer_ (importer),
+    exporter_ (exporter),
+    lclGraph_ (lclGraph),
+    nodeNumDiags_ (Teuchos::OrdinalTraits<size_t>::invalid ()),
+    nodeMaxNumRowEntries_ (Teuchos::OrdinalTraits<size_t>::invalid ()),
+    globalNumEntries_ (Teuchos::OrdinalTraits<global_size_t>::invalid ()),
+    globalNumDiags_ (Teuchos::OrdinalTraits<global_size_t>::invalid ()),
+    globalMaxNumRowEntries_ (Teuchos::OrdinalTraits<global_size_t>::invalid ()),
+    pftype_ (StaticProfile),
+    numAllocForAllRows_ (0),
+    storageStatus_ (::Tpetra::Details::STORAGE_1D_PACKED),
+    indicesAreAllocated_ (true),
+    indicesAreLocal_ (true),
+    indicesAreGlobal_ (false),
+    fillComplete_ (false), // not yet, but see below
+    lowerTriangular_ (false),
+    upperTriangular_ (false),
+    indicesAreSorted_ (true),
+    noRedundancies_ (true),
+    haveLocalConstants_ (false),
+    haveGlobalConstants_ (false),
+    sortGhostsAssociatedWithEachProcessor_ (true)
+  {
+    staticAssertions();
+    const char tfecfFuncName[] = "Tpetra::CrsGraph(local_graph_type,"
+      "Map,Map,Map,Map,Import,Export,params): ";
+
+    TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+      (colMap.is_null (), std::runtime_error,
+       "The input column Map must be nonnull.");
+
+    k_lclInds1D_ = lclGraph_.entries;
+    k_rowPtrs_ = lclGraph_.row_map;
+    const bool callComputeGlobalConstants =
+      params.get () == nullptr ||
+      params->get ("compute global constants", true);
+    const bool computeLocalTriangularConstants =
+      params.get () == nullptr ||
+      params->get ("compute local triangular constants", true);
+    if (callComputeGlobalConstants) {
+      this->computeGlobalConstants (computeLocalTriangularConstants);
+    }
+    fillComplete_ = true;
+    checkInternalState ();
   }
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -34,8 +34,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
-//
 // ************************************************************************
 // @HEADER
 
@@ -804,6 +802,16 @@ namespace Tpetra {
                const Teuchos::RCP<const map_type>& rangeMap = Teuchos::null,
                const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
+    //! Create a fill-complete CrsMatrix from all the things it needs.
+    CrsMatrix (const local_matrix_type& lclMatrix,
+               const Teuchos::RCP<const map_type>& rowMap,
+               const Teuchos::RCP<const map_type>& colMap,
+               const Teuchos::RCP<const map_type>& domainMap,
+               const Teuchos::RCP<const map_type>& rangeMap,
+               const Teuchos::RCP<const import_type>& importer,
+               const Teuchos::RCP<const export_type>& exporter,
+               const Teuchos::RCP<Teuchos::ParameterList>& params =
+                 Teuchos::null);
 
     /// \brief Copy constructor, with option to do deep or shallow copy.
     // This function in 'Copy' mode is only guaranteed to work correctly for matrices

--- a/packages/tpetra/core/src/Tpetra_RowMatrixTransposer_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_RowMatrixTransposer_def.hpp
@@ -147,7 +147,7 @@ createTransposeLocal (const Teuchos::RCP<Teuchos::ParameterList>& params)
 #endif
 
   const bool sort = [&] () {
-    constexpr bool sortDefault = false; // see #4607 discussion
+    constexpr bool sortDefault = true; // see #4607 discussion
     const char sortParamName[] = "sort";
     return params.get () == nullptr ? sortDefault :
       params->get (sortParamName, sortDefault);

--- a/packages/tpetra/core/src/Tpetra_RowMatrixTransposer_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_RowMatrixTransposer_def.hpp
@@ -137,7 +137,7 @@ createTransposeLocal (const Teuchos::RCP<Teuchos::ParameterList>& params)
   TimeMonitor MM (*TimeMonitor::getNewTimer (prefix + "Transpose Local"));
 #endif
 
-  constexpr bool sortColIndsDefault = false; // see #4607 discussion
+  // constexpr bool sortColIndsDefault = false; // see #4607 discussion
   // NOTE (mfh 10 Jul 2019) Don't actually implement this yet, since
   // we need to test it first.
   // const bool sortColInds = params.get () == nullptr ?

--- a/packages/tpetra/core/src/Tpetra_RowMatrixTransposer_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_RowMatrixTransposer_def.hpp
@@ -140,9 +140,9 @@ createTransposeLocal (const Teuchos::RCP<Teuchos::ParameterList>& params)
   // constexpr bool sortColIndsDefault = false; // see #4607 discussion
   // NOTE (mfh 10 Jul 2019) Don't actually implement this yet, since
   // we need to test it first.
+  // const char sortParamName[] = "sort and merge";
   // const bool sortColInds = params.get () == nullptr ?
-  //   sortColIndsDefault :
-  //   params->get ("sort column indices", sortColIndsDefault);
+  //   sortColIndsDefault : params->get (sortParamName, sortColIndsDefault);
   const bool sortColInds = false;
 
   // Prebuild the importers and exporters the no-communication way,

--- a/packages/tpetra/core/src/Tpetra_Util.hpp
+++ b/packages/tpetra/core/src/Tpetra_Util.hpp
@@ -629,7 +629,7 @@ namespace Tpetra {
   ///         val.begin (), val.end ());
   /// \endcode
   template<class IT1, class IT2>
-  void
+  KOKKOS_INLINE_FUNCTION void
   merge2 (IT1& indResultOut, IT2& valResultOut,
           IT1 indBeg, IT1 indEnd,
           IT2 valBeg, IT2 /* valEnd */)

--- a/packages/tpetra/core/test/RowMatrixTransposer/CMakeLists.txt
+++ b/packages/tpetra/core/test/RowMatrixTransposer/CMakeLists.txt
@@ -14,6 +14,13 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   STANDARD_PASS_OUTPUT
   )
 
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  CrsMatrix_transpose_sortedRows
+  SOURCES sorted.cpp
+  COMM serial mpi
+  STANDARD_PASS_OUTPUT
+  )
+
 TRIBITS_COPY_FILES_TO_BINARY_DIR(TransposeFileCopies
   SOURCE_FILES a.mtx atrans.mtx
   EXEDEPS RowMatrixTransposer_UnitTests

--- a/packages/tpetra/core/test/RowMatrixTransposer/main.cpp
+++ b/packages/tpetra/core/test/RowMatrixTransposer/main.cpp
@@ -35,8 +35,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
-//
 // ************************************************************************
 // @HEADER
 */
@@ -48,7 +46,7 @@
 #include <Teuchos_FancyOStream.hpp>
 #include <cmath>
 
-template<class CrsMatrix_t> 
+template<class CrsMatrix_t>
 typename CrsMatrix_t::scalar_type getNorm(CrsMatrix_t& matrix){
   typedef typename CrsMatrix_t::local_ordinal_type LO;
   typedef typename CrsMatrix_t::scalar_type Scalar;

--- a/packages/tpetra/core/test/RowMatrixTransposer/sorted.cpp
+++ b/packages/tpetra/core/test/RowMatrixTransposer/sorted.cpp
@@ -205,7 +205,7 @@ testTranspose (bool& success,
 
   RCP<crs_matrix_type> A = createTestMatrix (comm, lclNumRows);
   {
-    out << "Test with default \"sort and merge\"" << std::endl;
+    out << "Test with default \"sort\"" << std::endl;
     Teuchos::OSTab tab1 (out);
 
     RCP<crs_matrix_type> AT_unsorted = [&] () {
@@ -226,12 +226,12 @@ testTranspose (bool& success,
   }
 
   {
-    out << "Test with \"sort and merge\" = true" << std::endl;
+    out << "Test with \"sort\" = true" << std::endl;
     Teuchos::OSTab tab1 (out);
 
     RCP<crs_matrix_type> AT_sorted = [&] () {
       auto params = Teuchos::parameterList ("Tpetra::RowMatrixTransposer");
-      params->set ("sort and merge", true);
+      params->set ("sort", true);
       Tpetra::RowMatrixTransposer<> transposer (A);
       return transposer.createTranspose (params);
     } ();

--- a/packages/tpetra/core/test/RowMatrixTransposer/sorted.cpp
+++ b/packages/tpetra/core/test/RowMatrixTransposer/sorted.cpp
@@ -1,0 +1,262 @@
+/*
+// @HEADER
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services Package
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// ************************************************************************
+// @HEADER
+*/
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Tpetra_Core.hpp"
+#include "Tpetra_CrsMatrix.hpp"
+#include "Tpetra_Map.hpp"
+#include "Tpetra_RowMatrixTransposer.hpp"
+#include <array>
+
+namespace { // (anonymous)
+
+using Teuchos::Comm;
+using Teuchos::outArg;
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::REDUCE_MIN;
+using Teuchos::reduceAll;
+using crs_matrix_type = Tpetra::CrsMatrix<>;
+using map_type = Tpetra::Map<>;
+using ST = crs_matrix_type::scalar_type;
+using LO = map_type::local_ordinal_type;
+using GO = map_type::global_ordinal_type;
+
+RCP<const map_type>
+makeRowMap (RCP<const Comm<int>> comm, const LO lclNumRows)
+{
+  const GO indexBase = 0;
+  const GO gblNumRows = GO (comm->getSize ()) * GO (lclNumRows);
+  return rcp (new map_type (gblNumRows, lclNumRows, indexBase, comm));
+}
+
+RCP<const map_type>
+makeColumnMap (RCP<const Comm<int>> comm)
+{
+  const GO indexBase = 0;
+  const std::array<GO, 1> myGblInds {{indexBase}};
+  const GO gblNumCols (comm->getSize ());
+  return rcp (new map_type (gblNumCols, myGblInds.data (),
+                            LO (myGblInds.size ()), indexBase, comm));
+}
+
+RCP<const map_type>
+makeDomainMap (RCP<const Comm<int>> comm)
+{
+  const LO lclNumInds = (comm->getRank () == 0) ? 1 : 0;
+  const GO gblNumInds = 1;
+  const GO indexBase = 0;
+  return rcp (new map_type (gblNumInds, lclNumInds, indexBase, comm));
+}
+
+RCP<const map_type>
+makeRangeMap (RCP<const Comm<int>> comm, const LO lclNumRows)
+{
+  const GO indexBase = 0;
+  const GO gblNumRows = GO (comm->getSize ()) * GO (lclNumRows);
+  return rcp (new map_type (gblNumRows, lclNumRows, indexBase, comm));
+}
+
+RCP<crs_matrix_type>
+createTestMatrix (RCP<const Comm<int>> comm, const LO lclNumRows)
+{
+  RCP<crs_matrix_type> A;
+#ifdef TPETRA_ENABLE_DEPRECATED_CODE
+  A = rcp (new crs_matrix_type (makeRowMap (comm, lclNumRows),
+                                makeColumnMap (comm), size_t (1),
+                                Tpetra::StaticProfile));
+#else
+  A = rcp (new crs_matrix_type (makeRowMap (comm, lclNumRows),
+                                makeColumnMap (comm), size_t (1)));
+#endif // TPETRA_ENABLE_DEPRECATED_CODE
+
+  constexpr LO numEnt = 1;
+  std::array<LO, 1> lclCols {{ 0 }};
+  std::array<ST, 1> vals {{ 1.0 }};
+  for (LO lclRow = 0; lclRow < lclNumRows; ++lclRow) {
+    A->insertLocalValues (lclRow, numEnt, vals.data (), lclCols.data ());
+  }
+  A->fillComplete (makeDomainMap (comm),
+                   makeRangeMap (comm, lclNumRows));
+  return A;
+}
+
+void
+standardTransposeTests (bool& success,
+                        Teuchos::FancyOStream& out,
+                        const crs_matrix_type& A,
+                        const crs_matrix_type& AT,
+                        const Comm<int>& comm)
+{
+  int lclSuccess = 1;
+  int gblSuccess = 0;
+
+  auto G = A.getCrsGraph ();
+  TEST_ASSERT( ! G.is_null () );
+  auto GT = AT.getCrsGraph ();
+  TEST_ASSERT( ! GT.is_null () );
+
+  lclSuccess = success ? 1 : 0;
+  gblSuccess = 0;
+  reduceAll (comm, REDUCE_MIN, lclSuccess, outArg (gblSuccess));
+  TEST_ASSERT( gblSuccess == 1 );
+  if (! success) {
+    return;
+  }
+
+  auto colMap = A.getColMap ();
+  TEST_ASSERT( ! colMap.is_null () );
+  auto domMap = A.getDomainMap ();
+  TEST_ASSERT( ! domMap.is_null () );
+  auto ranMap = A.getRangeMap ();
+  TEST_ASSERT( ! ranMap.is_null () );
+  auto rowMap = A.getRowMap ();
+  TEST_ASSERT( ! rowMap.is_null () );
+
+  auto colMap_at = AT.getColMap ();
+  TEST_ASSERT( ! colMap_at.is_null () );
+  auto domMap_at = AT.getDomainMap ();
+  TEST_ASSERT( ! domMap_at.is_null () );
+  auto ranMap_at = AT.getRangeMap ();
+  TEST_ASSERT( ! ranMap_at.is_null () );
+  auto rowMap_at = AT.getRowMap ();
+  TEST_ASSERT( ! rowMap_at.is_null () );
+
+  lclSuccess = success ? 1 : 0;
+  gblSuccess = 0;
+  reduceAll (comm, REDUCE_MIN, lclSuccess, outArg (gblSuccess));
+  TEST_ASSERT( gblSuccess == 1 );
+  if (! success) {
+    return;
+  }
+
+  // It's normal for column and row Maps to differ, since
+  // createTranspose prefers to redistribute the result to have a
+  // nonshared row Map.
+
+  TEST_ASSERT( domMap_at->isSameAs (*ranMap) );
+  TEST_ASSERT( ranMap_at->isSameAs (*domMap) );
+
+  auto G_imp = G->getImporter ();
+  TEST_ASSERT( colMap->isSameAs (*domMap) || ! G_imp.is_null () );
+  auto GT_imp = GT->getImporter ();
+  TEST_ASSERT( colMap_at->isSameAs (*domMap_at) || ! GT_imp.is_null () );
+
+  auto G_exp = G->getExporter ();
+  TEST_ASSERT( rowMap->isSameAs (*ranMap) || ! G_exp.is_null () );
+  auto GT_exp = GT->getExporter ();
+  TEST_ASSERT( rowMap_at->isSameAs (*ranMap_at) || ! GT_exp.is_null () );
+
+  lclSuccess = success ? 1 : 0;
+  gblSuccess = 0;
+  reduceAll (comm, REDUCE_MIN, lclSuccess, outArg (gblSuccess));
+  TEST_ASSERT( gblSuccess == 1 );
+  if (! success) {
+    return;
+  }
+}
+
+void
+testTranspose (bool& success,
+               Teuchos::FancyOStream& out,
+               RCP<const Comm<int>> comm,
+               const LO lclNumRows)
+{
+  int lclSuccess = 1;
+  int gblSuccess = 0;
+
+  RCP<crs_matrix_type> A = createTestMatrix (comm, lclNumRows);
+  Tpetra::RowMatrixTransposer<> transposer (A);
+  RCP<crs_matrix_type> AT_unsorted = transposer.createTranspose ();
+  TEST_ASSERT( ! AT_unsorted.is_null () );
+  standardTransposeTests (success, out, *A, *AT_unsorted, *comm);
+
+  lclSuccess = success ? 1 : 0;
+  gblSuccess = 0;
+  reduceAll (*comm, REDUCE_MIN, lclSuccess, outArg (gblSuccess));
+  TEST_ASSERT( gblSuccess == 1 );
+  if (! success) {
+    return;
+  }
+
+#if 0
+  RCP<crs_matrix_type> AT_sorted = [&] () {
+    auto params = Teuchos::parameterList ("Tpetra::RowMatrixTransposer");
+    params->set ("sort and merge", true);
+    return transposer.createTranspose (params);
+  } ();
+
+  TEST_ASSERT( ! AT_sorted.is_null () );
+  standardTransposeTests (success, out, *A, *AT_sorted, *comm);
+
+  lclSuccess = success ? 1 : 0;
+  gblSuccess = 0;
+  reduceAll (*comm, REDUCE_MIN, lclSuccess, outArg (gblSuccess));
+  TEST_ASSERT( gblSuccess == 1 );
+  if (! success) {
+    return;
+  }
+#endif // 0
+}
+
+TEUCHOS_UNIT_TEST( CrsMatrixTranspose, SortRows )
+{
+  const LO lclNumRows = 1000;
+  RCP<const Comm<int>> comm = Tpetra::getDefaultComm ();
+  testTranspose (success, out, comm, lclNumRows );
+}
+
+} // namespace (anonymous)
+
+int
+main (int argc, char* argv[])
+{
+  int errCode = 0;
+  {
+    Tpetra::ScopeGuard tpetraScope (&argc, &argv);
+    errCode = Teuchos::UnitTestRepository::runUnitTestsFromMain (argc, argv);
+  }
+  return errCode;
+}
+
+
+
+


### PR DESCRIPTION
@trilinos/tpetra @trilinos/muelu 

## Description

1. `Tpetra::RowMatrixTransposer::createTranspose*` methods now sort rows (by local column indices) of the result by default.  This fixes #4607.
2. As discussed [here](https://github.com/trilinos/Trilinos/issues/4607#issuecomment-472869688), the sparse matrix-matrix multiply routines do their own sorting.  Thus, we have changed those routines to tell RowMatrixTransposer not to sort rows.
3. Optimized local transpose: Fewer parallel kernel launches; don't initialize allocations unless needed.
4. Removed an unused code path in local transpose, where the input matrix is a RowMatrix but not a CrsMatrix.  In that case, createTransposeLocal now first converts the input to CrsMatrix.

## Related Issues

* Closes #4607 