### PR TITLE
Fixes for Belos "Native" Tpetra Gmres

### DIFF
--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_Gmres.hpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_Gmres.hpp
@@ -326,15 +326,12 @@ private:
       // Belos::OrthoManagerFactory here.
       Belos::OrthoManagerFactory<SC, MV, OP> factory;
       Teuchos::RCP<Belos::OutputManager<SC>> outMan; // can be null
+      Teuchos::RCP<Teuchos::ParameterList> params;   // can be null
       if (this->input_.maxOrthoSteps > 0) {
-        Teuchos::RCP<Teuchos::ParameterList> params = Teuchos::rcp (new Teuchos::ParameterList());
+        params = Teuchos::rcp (new Teuchos::ParameterList());
         params->set ("maxNumOrthogPasses", this->input_.maxOrthoSteps);
-        ortho_ = factory.makeMatOrthoManager (ortho, Teuchos::null, outMan, "Belos", params);
       }
-      else {
-        Teuchos::RCP<Teuchos::ParameterList> params; // can be null
-        ortho_ = factory.makeMatOrthoManager (ortho, Teuchos::null, outMan, "Belos", params);
-      }
+      ortho_ = factory.makeMatOrthoManager (ortho, Teuchos::null, outMan, "Belos", params);
       TEUCHOS_TEST_FOR_EXCEPTION
         (ortho_.get () == nullptr, std::runtime_error, "Gmres: Failed to "
          "create (Mat)OrthoManager of type \"" << ortho << "\".");
@@ -488,7 +485,8 @@ protected:
 
     mag_type b_norm;  // initial residual norm
     mag_type b0_norm; // initial residual norm, not left preconditioned
-    mag_type r_norm, r_norm_imp;
+    mag_type r_norm;
+    mag_type r_norm_imp;
     vec_type R (B.getMap ());
     vec_type Y (B.getMap ());
     vec_type MP (B.getMap ());

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_Gmres.hpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_Gmres.hpp
@@ -486,8 +486,9 @@ protected:
 
     mag_type b_norm;  // initial residual norm
     mag_type b0_norm; // initial residual norm, not left preconditioned
-    mag_type r_norm;
+    mag_type r_norm, r_norm_imp;
     vec_type R (B.getMap ());
+    vec_type Y (B.getMap ());
     vec_type MP (B.getMap ());
     MV Q (B.getMap (), restart+1);
     vec_type P = * (Q.getVectorNonConst (0));
@@ -534,6 +535,7 @@ protected:
     y[0] = SC {b_norm};
 
     // main loop
+    int iter = 0;
     while (output.numIters < input.maxNumIters && ! output.converged) {
       if (outPtr != nullptr) {
         *outPtr << "Restart cycle " << output.numRests << ":" << endl;
@@ -543,19 +545,18 @@ protected:
         *outPtr << output;
       }
 
-      int iter = 0;
       if (input.maxNumIters < output.numIters+restart) {
         restart = input.maxNumIters-output.numIters;
       }
 
       // restart cycle
-      for (iter = 0; iter < restart && metric > input.tol; ++iter) {
+      for (; iter < restart && metric > input.tol; ++iter) {
         if (outPtr != nullptr) {
           *outPtr << "Current iteration: iter=" << iter
                   << ", restart=" << restart
                   << ", metric=" << metric << endl;
+          Indent indent3 (outPtr);
         }
-        Indent indent3 (outPtr);
 
         // AP = A*P
         vec_type P  = * (Q.getVectorNonConst (iter));
@@ -594,6 +595,12 @@ protected:
         }
       } // end of restart cycle
 
+      if (iter < restart) {
+        // save the old solution, just in case explicit residual norm failed the convergence test
+        Tpetra::deep_copy (Y, X);
+        blas.COPY (1+iter, y.values(), 1, h.values(), 1);
+      }
+      r_norm_imp = STS::magnitude (y (iter)); // save implicit residual norm
       if (iter > 0) {
         // Compute Ritz values, if requested
         if (input.computeRitzValues && output.numRests == 0) {
@@ -607,7 +614,6 @@ protected:
                    H.values(), H.stride(), y.values(), y.stride());
         Teuchos::Range1D cols(0, iter-1);
         Teuchos::RCP<const MV> Qj = Q.subView(cols);
-        //y.resize (iter);
         dense_vector_type y_iter (Teuchos::View, y.values (), iter);
         if (input.precoSide == "right") {
           //MVT::MvTimesMatAddMv (one, *Qj, y, zero, R);
@@ -622,35 +628,51 @@ protected:
         //y.resize (restart+1);
       }
       // Compute explicit unpreconditioned residual
-      P = * (Q.getVectorNonConst (0));
-      A.apply (X, P);
-      P.update (one, B, -one);
-      r_norm = P.norm2 (); // residual norm
+      A.apply (X, R);
+      R.update (one, B, -one);
+      r_norm = R.norm2 (); // residual norm
       output.absResid = r_norm;
       output.relResid = r_norm / b0_norm;
+      if (outPtr != nullptr) {
+        *outPtr << "Implicit and explicit residual norms at restart: " << r_norm_imp << ", " << r_norm << endl;
+      }
 
       metric = this->getConvergenceMetric (r_norm, b0_norm, input);
       if (metric <= input.tol) {
         output.converged = true;
       }
       else if (output.numIters < input.maxNumIters) {
-        // Initialize starting vector for restart
-        if (input.precoSide == "left") {
-          Tpetra::deep_copy (R, P);
-          M.apply (R, P);
-          r_norm = P.norm2 (); // norm
+        // Restart, only if max inner-iteration was reached.
+        // Otherwise continue the inner-iteration.
+        if (iter >= restart) {
+          // Restart: Initialize starting vector for restart
+          iter = 0;
+          P = * (Q.getVectorNonConst (0));
+          if (input.precoSide == "left") {
+            M.apply (R, P);
+            r_norm = P.norm2 (); // norm
+          }
+          else {
+            // set the starting vector
+            Tpetra::deep_copy (P, R);
+          }
+          P.scale (one / r_norm);
+          y[0] = SC {r_norm};
+          for (int i=1; i < restart+1; i++) {
+            y[i] = STS::zero ();
+          }
+          output.numRests++;
         }
-        P.scale (one / r_norm);
-        y[0] = SC {r_norm};
-        for (int i=1; i < restart+1; i++) {
-          y[i] = STS::zero ();
+        else {
+          // reset to the old solution
+          Tpetra::deep_copy (X, Y);
+          blas.COPY (1+iter, h.values(), 1, y.values(), 1);
         }
-        output.numRests++;
       }
     }
 
     // return residual norm as B
-    Tpetra::deep_copy (B, P);
+    Tpetra::deep_copy (B, R);
 
     if (outPtr != nullptr) {
       *outPtr << "At end of solve:" << endl;

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_Gmres.hpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_Gmres.hpp
@@ -606,6 +606,12 @@ protected:
         if (input.computeRitzValues && output.numRests == 0) {
           computeRitzValues (iter, G, output.ritzValues);
           sortRitzValues <LO, SC> (iter, output.ritzValues);
+          if (outPtr != nullptr) {
+            *outPtr << " > ComputeRitzValues: " << endl;
+            for (int i = 0; i < iter; i++) {
+              *outPtr << " > ritzValues[ " << i << " ] = " << output.ritzValues[i] << endl;
+            }
+          }
         }
         // Update solution
         blas.TRSM (Teuchos::LEFT_SIDE, Teuchos::UPPER_TRI,

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresPipeline.hpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresPipeline.hpp
@@ -71,7 +71,7 @@ private:
     mag_type b_norm; // initial residual norm
     mag_type b0_norm; // initial residual norm, not left-preconditioned
     mag_type r_norm;
-    mag_type r_norm_imp = -1.0;
+    mag_type r_norm_imp = -STM::one ();
     dense_matrix_type  G (restart+1, restart+1, true);
     dense_matrix_type  H (restart+1, restart, true);
     dense_vector_type  y (restart+1, true);

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresPipeline.hpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresPipeline.hpp
@@ -71,7 +71,7 @@ private:
     mag_type b_norm; // initial residual norm
     mag_type b0_norm; // initial residual norm, not left-preconditioned
     mag_type r_norm;
-    mag_type r_norm_imp = -one;
+    mag_type r_norm_imp = -1.0;
     dense_matrix_type  G (restart+1, restart+1, true);
     dense_matrix_type  H (restart+1, restart, true);
     dense_vector_type  y (restart+1, true);

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresPipeline.hpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresPipeline.hpp
@@ -70,7 +70,8 @@ private:
 
     mag_type b_norm; // initial residual norm
     mag_type b0_norm; // initial residual norm, not left-preconditioned
-    mag_type r_norm, r_norm_imp;
+    mag_type r_norm;
+    mag_type r_norm_imp;
     dense_matrix_type  G (restart+1, restart+1, true);
     dense_matrix_type  H (restart+1, restart, true);
     dense_vector_type  y (restart+1, true);

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresPipeline.hpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresPipeline.hpp
@@ -70,16 +70,18 @@ private:
 
     mag_type b_norm; // initial residual norm
     mag_type b0_norm; // initial residual norm, not left-preconditioned
-    mag_type r_norm;
+    mag_type r_norm, r_norm_imp;
     dense_matrix_type  G (restart+1, restart+1, true);
     dense_matrix_type  H (restart+1, restart, true);
     dense_vector_type  y (restart+1, true);
+    dense_vector_type  h (restart+1, true);
     std::vector<mag_type> cs (restart);
     std::vector<SC> sn (restart);
     MV  Q (B.getMap (), restart+1);
     MV  V (B.getMap (), restart+1);
     vec_type Z = * (V.getVectorNonConst (0));
     vec_type R (B.getMap ());
+    vec_type Y (B.getMap ());
     vec_type MZ (B.getMap ());
 
     // initial residual (making sure R = B - Ax)
@@ -135,22 +137,24 @@ private:
     y[0] = r_norm;
 
     // Main loop
+    int iter = 0;
     mag_type metric = 2*input.tol; // to make sure to hit the first synch
     while (output.numIters < input.maxNumIters && ! output.converged) {
-      int iter = 0;
-      if (input.maxNumIters < output.numIters+restart) {
-        restart = input.maxNumIters-output.numIters;
+      if (iter == 0) {
+        if (input.maxNumIters < output.numIters+restart) {
+          restart = input.maxNumIters-output.numIters;
+        }
+
+        // Normalize initial vector
+        MVT::MvScale (Z, one/std::sqrt(G(0, 0)));
+
+        // Copy initial vector
+        vec_type AP = * (Q.getVectorNonConst (0));
+        Tpetra::deep_copy (AP, Z);
       }
 
-      // Normalize initial vector
-      MVT::MvScale (Z, one/std::sqrt(G(0, 0)));
-
-      // Copy initial vector
-      vec_type AP = * (Q.getVectorNonConst (0));
-      Tpetra::deep_copy (AP, Z);
-
       // Restart cycle
-      for (iter = 0; iter < restart+ell && metric > input.tol; ++iter) {
+      for (; iter < restart+ell && metric > input.tol; ++iter) {
         if (iter < restart) {
           // W = A*Z
           vec_type Z = * (V.getVectorNonConst (iter));
@@ -176,6 +180,12 @@ private:
           output.numIters ++;
         }
         int k = iter+1 - ell; // we synch idot from k-th iteration
+        if (outPtr != nullptr && k > 0) {
+          *outPtr << "Current iteration: iter=" << iter
+                  << ", restart=" << restart
+                  << ", metric=" << metric << endl;
+          Indent indent3 (outPtr);
+        }
 
         // Compute G and H
         if (k >= 0) {
@@ -269,6 +279,13 @@ private:
           req = Tpetra::idot (vals, Qprev, W);
         }
       } // End of restart cycle
+
+      if (iter < restart+ell) {
+        // save the old solution, just in case explicit residual norm failed the convergence test
+        Tpetra::deep_copy (Y, X);
+        blas.COPY (1+iter, y.values(), 1, h.values(), 1);
+      }
+      r_norm_imp = STS::magnitude (y (iter)); // save implicit residual norm
       if (iter > 0) {
         // Update solution
         blas.TRSM (Teuchos::LEFT_SIDE, Teuchos::UPPER_TRI,
@@ -293,34 +310,64 @@ private:
         y.resize (restart+1);
       }
       // Compute real residual
-      Z = * (V.getVectorNonConst (0));
-      A.apply (X, Z);
-      Z.update (one, B, -one);
-      r_norm = Z.norm2 (); // residual norm
+      A.apply (X, R);
+      R.update (one, B, -one);
+      // TODO: compute residual norm with all-reduce, should be idot?
+      r_norm = R.norm2 ();
       output.absResid = r_norm;
       output.relResid = r_norm / b_norm;
+      if (outPtr != nullptr) {
+        *outPtr << "Implicit and explicit residual norms at restart: " << r_norm_imp << ", " << r_norm << endl;
+      }
+
       // Convergence check (with explicitly computed residual norm)
       metric = this->getConvergenceMetric (r_norm, b_norm, input);
       if (metric <= input.tol) {
         output.converged = true;
       }
       else if (output.numIters < input.maxNumIters) {
-        // Initialize starting vector for restart
-        if (input.precoSide == "left") {
-          Tpetra::deep_copy (R, Z);
-          M.apply (R, Z);
+        // Restart, only if max inner-iteration was reached.
+        // Otherwise continue the inner-iteration.
+        if (iter >= restart+ell) {
+          // Restart: Initialize starting vector for restart
+          iter = 0;
+          Z = * (V.getVectorNonConst (0));
+          if (input.precoSide == "left") {
+            M.apply (R, Z);
+            r_norm = STS::real (Z.dot (Z)); //norm2 (); // residual norm
+          }
+          else {
+            // set the starting vector
+            Tpetra::deep_copy (Z, R);
+          }
+          G(0, 0) = r_norm;
+          r_norm = STM::squareroot (r_norm);
+          //Z.scale (one / r_norm);
+          y[0] = r_norm;
+          for (int i=1; i < restart+1; ++i) {
+            y[i] = zero;
+          }
+          // Restart
+          output.numRests ++;
         }
-        // TODO: recomputing all-reduce, should be idot?
-        r_norm = STS::real (Z.dot (Z)); //norm2 (); // residual norm
-        G(0, 0) = r_norm;
-        r_norm = STM::squareroot (r_norm);
-        //Z.scale (one / r_norm);
-        y[0] = r_norm;
-        for (int i=1; i < restart+1; ++i) {
-          y[i] = zero;
+        else {
+          // reset to the old solution
+          Tpetra::deep_copy (X, Y);
+          blas.COPY (1+iter, h.values(), 1, y.values(), 1);
+          {
+            // Copy the new vector
+            vec_type AP = * (Q.getVectorNonConst (iter));
+            Tpetra::deep_copy (AP, * (V.getVectorNonConst (iter)));
+
+            // Start all-reduce to compute G(:, iter)
+            // [Q(:,1:k-1), V(:,k:iter)]'*W
+            Teuchos::Range1D index_prev(0, iter);
+            const MV Qprev  = * (Q.subView(index_prev));
+
+            vec_type W = * (V.getVectorNonConst (iter));
+            req = Tpetra::idot (vals, Qprev, W);
+          }
         }
-        // Restart
-        output.numRests ++;
       }
     }
 

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresPipeline.hpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresPipeline.hpp
@@ -285,7 +285,7 @@ private:
         Tpetra::deep_copy (Y, X);
         blas.COPY (1+iter, y.values(), 1, h.values(), 1);
       }
-      r_norm_imp = STS::magnitude (y (iter)); // save implicit residual norm
+      r_norm_imp = STS::magnitude (y (iter - ell)); // save implicit residual norm
       if (iter > 0) {
         // Update solution
         blas.TRSM (Teuchos::LEFT_SIDE, Teuchos::UPPER_TRI,

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresSingleReduce.hpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresSingleReduce.hpp
@@ -152,7 +152,8 @@ private:
 
     mag_type b_norm;  // initial residual norm
     mag_type b0_norm; // initial residual norm, not left-preconditioned
-    mag_type r_norm, r_norm_imp;
+    mag_type r_norm;
+    mag_type r_norm_imp;
     MV Q (B.getMap (), restart+1);
     vec_type P = * (Q.getVectorNonConst (0));
     vec_type R (B.getMap ());
@@ -345,7 +346,9 @@ private:
         }
         else {
           // reset to the old solution
-          if (outPtr != nullptr) *outPtr << " > not-restart with iter=" << iter << endl;
+          if (outPtr != nullptr) {
+            *outPtr << " > not-restart with iter=" << iter << endl;
+          }
           Tpetra::deep_copy (X, Y);
           blas.COPY (1+iter, h.values(), 1, y.values(), 1);
         }

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresSingleReduce.hpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresSingleReduce.hpp
@@ -44,10 +44,7 @@ public:
   setParameters (Teuchos::ParameterList& params) {
     Gmres<SC, MV, OP>::setParameters (params);
 
-    int stepSize = stepSize_;
-    if (params.isParameter ("Step Size")) {
-      stepSize = params.get<int> ("Step Size");
-    }
+    int stepSize = params.get<int> ("Step Size", stepSize_);
     stepSize_ = stepSize;
   }
 

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresSingleReduce.hpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresSingleReduce.hpp
@@ -8,8 +8,8 @@ namespace BelosTpetra {
 namespace Impl {
 
 template<class SC = Tpetra::Operator<>::scalar_type,
-	 class MV = Tpetra::MultiVector<SC>,
-	 class OP = Tpetra::Operator<SC>>
+         class MV = Tpetra::MultiVector<SC>,
+         class OP = Tpetra::Operator<SC>>
 class GmresSingleReduce : public Gmres<SC, MV, OP> {
 private:
   using base_type = Gmres<SC, MV, OP>;
@@ -65,10 +65,10 @@ private:
   //! Apply the orthogonalization using a single all-reduce
   int
   projectAndNormalizeSingleReduce (int n,
-				   const SolverInput<SC>& input, 
-				   MV& Q,
-				   dense_matrix_type& H,
-				   dense_matrix_type& WORK) const
+                                   const SolverInput<SC>& input, 
+                                   MV& Q,
+                                   dense_matrix_type& H,
+                                   dense_matrix_type& WORK) const
   {
     Teuchos::BLAS<LO, SC> blas;
     const SC one = STS::one ();
@@ -155,10 +155,11 @@ private:
 
     mag_type b_norm;  // initial residual norm
     mag_type b0_norm; // initial residual norm, not left-preconditioned
-    mag_type r_norm;
+    mag_type r_norm, r_norm_imp;
     MV Q (B.getMap (), restart+1);
     vec_type P = * (Q.getVectorNonConst (0));
     vec_type R (B.getMap ());
+    vec_type Y (B.getMap ());
     vec_type MP (B.getMap ());
 
     Teuchos::BLAS<LO ,SC> blas;
@@ -201,7 +202,7 @@ private:
 
       Tpetra::deep_copy (R, B);
       output = Gmres<SC, MV, OP>::solveOneVec (outPtr, X, R, A, M,
-					       input_gmres);
+                                               input_gmres);
       if (output.converged) {
         return output; // standard GMRES converged
       }
@@ -224,31 +225,38 @@ private:
     y[0] = SC {r_norm};
     const int s = getStepSize ();
     // main loop
+    int iter = 0;
     while (output.numIters < input.maxNumIters && ! output.converged) {
-      int iter = 0;
       if (input.maxNumIters < output.numIters+restart) {
         restart = input.maxNumIters-output.numIters;
       }
       // restart cycle
-      for (iter = 0; iter < restart && metric > input.tol; ++iter) {
+      for (; iter < restart && metric > input.tol; ++iter) {
+        if (outPtr != nullptr) {
+          *outPtr << "Current iteration: iter=" << iter
+                  << ", restart=" << restart
+                  << ", metric=" << metric << endl;
+          Indent indent3 (outPtr);
+        }
+
         // AP = A*P
         vec_type P  = * (Q.getVectorNonConst (iter));
         vec_type AP = * (Q.getVectorNonConst (iter+1));
         if (input.precoSide == "none") { // no preconditioner
           A.apply (P, AP);
         }
-	else if (input.precoSide == "right") {
+        else if (input.precoSide == "right") {
           M.apply (P, MP);
           A.apply (MP, AP);
         }
-	else {
+        else {
           A.apply (P, MP);
           M.apply (MP, AP);
         }
         // Shift for Newton basis
         if (computeRitzValues) {
           //AP.update (-output.ritzValues[iter],  P, one);
-	  const complex_type theta = output.ritzValues[iter % s];
+          const complex_type theta = output.ritzValues[iter % s];
           UpdateNewton<SC, MV>::updateNewtonV (iter, Q, theta);
         }
         output.numIters++; 
@@ -258,9 +266,9 @@ private:
         // Shift back for Newton basis
         if (computeRitzValues) {
           // H(iter, iter) += output.ritzValues[iter];
-	  const complex_type theta = output.ritzValues[iter % s];
+          const complex_type theta = output.ritzValues[iter % s];
           UpdateNewton<SC, MV>::updateNewtonH (iter, H, theta);
-	}
+        }
 
         // Convergence check
         if (H(iter+1, iter) != zero) {
@@ -268,18 +276,24 @@ private:
           this->reduceHessenburgToTriangular (iter, H, cs, sn, y.values ());
           // Convergence check
           metric = this->getConvergenceMetric (STS::magnitude (y[iter+1]),
-					       b_norm, input);
+                                               b_norm, input);
         }
-	else {
+        else {
           H(iter+1, iter) = zero;
           metric = STM::zero ();
         }
       } // end of restart cycle 
+      if (iter < restart) {
+        // save the old solution, just in case explicit residual norm failed the convergence test
+        Tpetra::deep_copy (Y, X);
+        blas.COPY (1+iter, y.values(), 1, h.values(), 1);
+      }
+      r_norm_imp = STS::magnitude (y (iter)); // save implicit residual norm
       if (iter > 0) {
         // Update solution
         blas.TRSM (Teuchos::LEFT_SIDE, Teuchos::UPPER_TRI, Teuchos::NO_TRANS,
-		   Teuchos::NON_UNIT_DIAG, iter, 1, one,
-		   H.values(), H.stride(), y.values (), y.stride ());
+                   Teuchos::NON_UNIT_DIAG, iter, 1, one,
+                   H.values(), H.stride(), y.values (), y.stride ());
         Teuchos::Range1D cols(0, iter-1);
         Teuchos::RCP<const MV> Qj = Q.subView(cols);
         y.resize (iter);
@@ -288,39 +302,56 @@ private:
           M.apply (R, MP);
           X.update (one, MP, one);
         }
-	else {
+        else {
           MVT::MvTimesMatAddMv (one, *Qj, y, one, X);
         }
         y.resize (restart+1);
       }
 
       // Compute explicit residual vector in preparation for restart.
-      P = * (Q.getVectorNonConst (0));
-      A.apply (X, P);
-      P.update (one, B, -one);
-      r_norm = P.norm2 (); // residual norm
+      A.apply (X, R);
+      R.update (one, B, -one);
+      r_norm = R.norm2 (); // residual norm
       output.absResid = r_norm;
       output.relResid = r_norm / b0_norm;
+      if (outPtr != nullptr) {
+        *outPtr << "Implicit and explicit residual norms at restart: " << r_norm_imp << ", " << r_norm << endl;
+      }
 
       metric = this->getConvergenceMetric (r_norm, b0_norm, input);
       if (metric <= input.tol) {
         output.converged = true;
-	return output;
+        return output;
       }
       else if (output.numIters < input.maxNumIters) {
-        // Initialize starting vector for restart
-        if (input.precoSide == "left") {
-          Tpetra::deep_copy (R, P);
-          M.apply (R, P);
-	  // FIXME (mfh 14 Aug 2018) Didn't we already compute this above?
-          r_norm = P.norm2 ();
+        // Restart, only if max inner-iteration was reached.
+        // Otherwise continue the inner-iteration.
+        if (iter >= restart) {
+          // Initialize starting vector for restart
+          iter = 0;
+          P = * (Q.getVectorNonConst (0));
+          if (input.precoSide == "left") {
+            M.apply (R, P);
+            // FIXME (mfh 14 Aug 2018) Didn't we already compute this above?
+            r_norm = P.norm2 ();
+          }
+          else {
+            // set the starting vector
+            Tpetra::deep_copy (P, R);
+          }
+          P.scale (one / r_norm);
+          y[0] = SC {r_norm};
+          for (int i=1; i < restart+1; i++) {
+            y[i] = zero;
+          }
+          output.numRests++; // restart
         }
-        P.scale (one / r_norm);
-        y[0] = SC {r_norm};
-        for (int i=1; i < restart+1; i++) {
-	  y[i] = zero;
-	}
-        output.numRests++; // restart
+        else {
+          // reset to the old solution
+          if (outPtr != nullptr) *outPtr << " > not-restart with iter=" << iter << endl;
+          Tpetra::deep_copy (X, Y);
+          blas.COPY (1+iter, h.values(), 1, y.values(), 1);
+        }
       }
     }
 
@@ -331,7 +362,7 @@ private:
 };
 
 template<class SC, class MV, class OP,
-	 template<class, class, class> class KrylovSubclassType>
+         template<class, class, class> class KrylovSubclassType>
 class SolverManager;
 
 // This is the Belos::SolverManager subclass that gets registered with

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresSstep.hpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresSstep.hpp
@@ -217,7 +217,8 @@ private:
 
     mag_type b_norm;  // initial residual norm
     mag_type b0_norm; // initial residual norm, not left preconditioned
-    mag_type r_norm, r_norm_imp;
+    mag_type r_norm;
+    mag_type r_norm_imp;
     mag_type metric;
     vec_type R (B.getMap ());
     vec_type Y (B.getMap ());
@@ -357,8 +358,8 @@ private:
             }
             this->reduceHessenburgToTriangular(iter+iiter, T, cs, sn, y);
             if (outPtr != nullptr) {
-              *outPtr << " > implicit residual norm=(" << iter+iiter+1 << ")=" << STS::magnitude (y(iter+iiter+1))
-                      << endl;
+              *outPtr << " > implicit residual norm=(" << iter+iiter+1 << ")="
+                      << STS::magnitude (y(iter+iiter+1)) << endl;
             }
           }
           metric = this->getConvergenceMetric (STS::magnitude (y(iter+step)), b_norm, input);

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresSstep.hpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresSstep.hpp
@@ -129,8 +129,8 @@ public:
     stepSize_ (5),
     tsqr_ (Teuchos::null)
   {
-    this->input_.computeRitzValues = false;
-    this->input_.computeRitzValuesOnFly = true;
+    this->input_.computeRitzValues = true;
+    this->input_.computeRitzValuesOnFly = false;
   }
 
   GmresSstep (const Teuchos::RCP<const OP>& A) :
@@ -138,8 +138,8 @@ public:
     stepSize_ (5),
     tsqr_ (Teuchos::null)
   {
-    this->input_.computeRitzValues = false;
-    this->input_.computeRitzValuesOnFly = true;
+    this->input_.computeRitzValues = true;
+    this->input_.computeRitzValuesOnFly = false;
   }
 
   virtual ~GmresSstep () = default;

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresSstep.hpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresSstep.hpp
@@ -126,7 +126,7 @@ private:
 public:
   GmresSstep () :
     base_type::Gmres (),
-    stepSize_ (1),
+    stepSize_ (5),
     tsqr_ (Teuchos::null)
   {
     this->input_.computeRitzValues = false;
@@ -135,7 +135,7 @@ public:
 
   GmresSstep (const Teuchos::RCP<const OP>& A) :
     base_type::Gmres (A),
-    stepSize_ (1),
+    stepSize_ (5),
     tsqr_ (Teuchos::null)
   {
     this->input_.computeRitzValues = false;

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_Krylov_parameters.hpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_Krylov_parameters.hpp
@@ -57,6 +57,7 @@ public:
   std::string precoType {"none"};
   std::string precoSide {"none"};
   bool computeRitzValues = false;
+  bool computeRitzValuesOnFly = true;
 };
 
 // The default constructor creates output corresponding to "solving

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_Krylov_parameters.hpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_Krylov_parameters.hpp
@@ -53,6 +53,7 @@ public:
   int stepSize = 5;
   bool needToScale = true;
   bool needToReortho = false;
+  int maxOrthoSteps = 0;
   std::string orthoType {"ICGS"};
   std::string precoType {"none"};
   std::string precoSide {"none"};

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_Krylov_parameters.hpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_Krylov_parameters.hpp
@@ -50,7 +50,7 @@ public:
   mag_type tol = STM::squareroot (STS::eps ());
   int maxNumIters = 1000;
   int resCycle = 30;
-  int stepSize = 1;
+  int stepSize = 5;
   bool needToScale = true;
   bool needToReortho = false;
   std::string orthoType {"ICGS"};


### PR DESCRIPTION
This pull-request makes a couple of updates to Gmres solvers in belos/tpetra
- check explicit residual norm before restart
- an option to compute Ritz values without restart (for generating Newton basis)
- increase the default step size of s-step Gmres to five

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [ ] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

