### PR TITLE
Intrepid2: add getFunctionSpace(), etc. to Basis

### DIFF
--- a/packages/intrepid2/perf-test/DynRankView/test_02.hpp
+++ b/packages/intrepid2/perf-test/DynRankView/test_02.hpp
@@ -60,11 +60,11 @@ namespace Intrepid2 {
     namespace Serial {
       
       // compute determinant for rank 2 array
-      template<typename outputViewType,
+      template<typename OutputViewType,
                typename inputViewType>
       KOKKOS_FORCEINLINE_FUNCTION
       void
-      clone( /**/  outputViewType output,
+      clone( /**/  OutputViewType output,
              const inputViewType  input ) {
         const ordinal_type iend = output.extent(0);
         const ordinal_type jend = output.extent(1);

--- a/packages/intrepid2/src/Cell/Intrepid2_CellTools.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellTools.hpp
@@ -1509,11 +1509,11 @@ namespace Intrepid2 {
       \param  cellTopo          [in]  - cell topology with a reference cell required
   */
   template<typename jacobianViewType,
-           typename pointViewType,
+           typename PointViewType,
            typename worksetCellViewType>
   static void
   CellTools_setJacobianArgs( const jacobianViewType     jacobian,
-                             const pointViewType        points,
+                             const PointViewType        points,
                              const worksetCellViewType  worksetCell,
                              const shards::CellTopology cellTopo );
 

--- a/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefValidateArguments.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefValidateArguments.hpp
@@ -63,11 +63,11 @@ namespace Intrepid2 {
   //============================================================================================//
 
   template<typename jacobianViewType, 
-           typename pointViewType,
+           typename PointViewType,
            typename worksetCellViewType>
   void 
   CellTools_setJacobianArgs( const jacobianViewType     jacobian,
-                             const pointViewType        points,
+                             const PointViewType        points,
                              const worksetCellViewType  worksetCell,
                              const shards::CellTopology cellTopo ) {
     // Validate worksetCell array

--- a/packages/intrepid2/src/Cell/Intrepid2_CellTools_Serial.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellTools_Serial.hpp
@@ -458,12 +458,12 @@ namespace Intrepid2 {
         // input: 
         //   vals  (N)   - hgrad basis values evaluated at a single point (C1/C2 element only)
         //   nodes (N,D) - cell element-to-node connectivity
-        template<typename pointViewType,
+        template<typename PointViewType,
                  typename basisValViewType,
                  typename nodeViewType>
         KOKKOS_INLINE_FUNCTION
         static void
-        mapToPhysicalFrame(const pointViewType    &point,    // D  
+        mapToPhysicalFrame(const PointViewType    &point,    // D  
                            const basisValViewType &vals,     // N  
                            const nodeViewType     &nodes) {  // N,D 
           const auto N = vals.extent(0);

--- a/packages/intrepid2/src/Cell/Intrepid2_CellTopologyTags.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellTopologyTags.hpp
@@ -97,10 +97,10 @@ namespace Intrepid2 {
       static constexpr double coords[2][3]{ {-1.0, 0.0, 0.0}, { 1.0, 0.0, 0.0} };
 
       // base topology has this check method
-      template<typename pointViewType>
+      template<typename PointViewType>
       KOKKOS_INLINE_FUNCTION
       static bool
-      checkPointInclusion(const pointViewType &point, 
+      checkPointInclusion(const PointViewType &point, 
                           const double threshold) {
         const double minus_one = -1.0 - threshold, plus_one = 1.0 + threshold;
         return (minus_one <= point(0) && point(0) <= plus_one);
@@ -121,10 +121,10 @@ namespace Intrepid2 {
                    numIntr = 1 };
       static constexpr double coords[3][3]{ {-1.0, 0.0, 0.0}, { 1.0, 0.0, 0.0}, { 0.0, 0.0, 0.0} };
 
-      template<typename pointViewType>
+      template<typename PointViewType>
       KOKKOS_INLINE_FUNCTION
       static bool
-      checkPointInclusion(const pointViewType &point, 
+      checkPointInclusion(const PointViewType &point, 
                           const double threshold) {
         return base_cell_topology_type::checkPointInclusion(point, threshold);
       }
@@ -149,10 +149,10 @@ namespace Intrepid2 {
                    numIntr = 1 };
       static constexpr double coords[3][3]{ { 0.0, 0.0, 0.0}, { 1.0, 0.0, 0.0}, { 0.0, 1.0, 0.0} };
 
-      template<typename pointViewType>
+      template<typename PointViewType>
       KOKKOS_INLINE_FUNCTION
       static bool
-      checkPointInclusion(const pointViewType &point, 
+      checkPointInclusion(const PointViewType &point, 
                           const double threshold) {
         const double distance = max( max( -point(0), -point(1) ), point(0) + point(1) - 1.0 );
         return distance < threshold;
@@ -173,10 +173,10 @@ namespace Intrepid2 {
                    numIntr = 1 };
       static constexpr double coords[4][3]{ { 0.0, 0.0, 0.0}, { 1.0, 0.0, 0.0}, { 0.0, 1.0, 0.0}, { 1.0/3.0, 1.0/3.0, 0.0} };
 
-      template<typename pointViewType>
+      template<typename PointViewType>
       KOKKOS_INLINE_FUNCTION
       static bool
-      checkPointInclusion(const pointViewType &point, 
+      checkPointInclusion(const PointViewType &point, 
                           const double threshold) {
         return base_cell_topology_type::checkPointInclusion(point, threshold);
       }
@@ -197,10 +197,10 @@ namespace Intrepid2 {
       static constexpr double coords[6][3]{ { 0.0, 0.0, 0.0}, { 1.0, 0.0, 0.0}, { 0.0, 1.0, 0.0},
                                 { 0.5, 0.0, 0.0}, { 0.5, 0.5, 0.0}, { 0.0, 0.5, 0.0} };
 
-      template<typename pointViewType>
+      template<typename PointViewType>
       KOKKOS_INLINE_FUNCTION
       static bool
-      checkPointInclusion(const pointViewType &point, 
+      checkPointInclusion(const PointViewType &point, 
                           const double threshold) {
         return base_cell_topology_type::checkPointInclusion(point, threshold);
       }
@@ -225,10 +225,10 @@ namespace Intrepid2 {
                    numIntr = 1 };
       static constexpr double coords[4][3]{ {-1.0,-1.0, 0.0}, { 1.0,-1.0, 0.0}, { 1.0, 1.0, 0.0}, {-1.0, 1.0, 0.0} };
 
-      template<typename pointViewType>
+      template<typename PointViewType>
       KOKKOS_INLINE_FUNCTION
       static bool
-      checkPointInclusion(const pointViewType &point, 
+      checkPointInclusion(const PointViewType &point, 
                           const double threshold) {
         const double minus_one = -1.0 - threshold, plus_one = 1.0 + threshold;
         return ((minus_one <= point(0) && point(0) <= plus_one) &&
@@ -251,10 +251,10 @@ namespace Intrepid2 {
       static constexpr double coords[8][3]{ {-1.0,-1.0, 0.0}, { 1.0,-1.0, 0.0}, { 1.0, 1.0, 0.0}, {-1.0, 1.0, 0.0},
                                 { 0.0,-1.0, 0.0}, { 1.0, 0.0, 0.0}, { 0.0, 1.0, 0.0}, {-1.0, 0.0, 0.0} };
 
-      template<typename pointViewType>
+      template<typename PointViewType>
       KOKKOS_INLINE_FUNCTION
       static bool
-      checkPointInclusion(const pointViewType &point, 
+      checkPointInclusion(const PointViewType &point, 
                           const double threshold) {
         return base_cell_topology_type::checkPointInclusion(point, threshold);
       }
@@ -275,10 +275,10 @@ namespace Intrepid2 {
       static constexpr double coords[9][3]{ {-1.0,-1.0, 0.0}, { 1.0,-1.0, 0.0}, { 1.0, 1.0, 0.0}, {-1.0, 1.0, 0.0},
                                             { 0.0,-1.0, 0.0}, { 1.0, 0.0, 0.0}, { 0.0, 1.0, 0.0}, {-1.0, 0.0, 0.0}, { 0.0, 0.0, 0.0} };
 
-      template<typename pointViewType>
+      template<typename PointViewType>
       KOKKOS_INLINE_FUNCTION
       static bool
-      checkPointInclusion(const pointViewType &point, 
+      checkPointInclusion(const PointViewType &point, 
                           const double threshold) {
         return base_cell_topology_type::checkPointInclusion(point, threshold);
       }
@@ -303,10 +303,10 @@ namespace Intrepid2 {
                    numIntr = 1 };
       static constexpr double coords[4][3]{ { 0.0, 0.0, 0.0}, { 1.0, 0.0, 0.0}, { 0.0, 1.0, 0.0}, { 0.0, 0.0, 1.0} };
 
-      template<typename pointViewType>
+      template<typename PointViewType>
       KOKKOS_INLINE_FUNCTION
       static bool
-      checkPointInclusion(const pointViewType &point,
+      checkPointInclusion(const PointViewType &point,
                           const double threshold) {
         const double distance = max( max(-point(0),-point(1)),
                                      max(-point(2), point(0) + point(1) + point(2) - 1) );
@@ -330,10 +330,10 @@ namespace Intrepid2 {
       static constexpr double coords[8][3]{ { 0.0, 0.0, 0.0}, { 1.0, 0.0, 0.0}, { 0.0, 1.0, 0.0}, { 0.0, 0.0, 1.0},
                                 { 1/3, 0.0, 1/3}, { 1/3, 1/3, 1/3}, { 1/3, 1/3, 0.0}, { 0.0, 1/3, 1/3} };
 
-      template<typename pointViewType>
+      template<typename PointViewType>
       KOKKOS_INLINE_FUNCTION
       static bool
-      checkPointInclusion(const pointViewType &point, 
+      checkPointInclusion(const PointViewType &point, 
                           const double threshold) {
         return base_cell_topology_type::checkPointInclusion(point, threshold);
       }
@@ -354,10 +354,10 @@ namespace Intrepid2 {
       static constexpr double coords[10][3]{ { 0.0, 0.0, 0.0}, { 1.0, 0.0, 0.0}, { 0.0, 1.0, 0.0}, { 0.0, 0.0, 1.0},
                                  { 0.5, 0.0, 0.0}, { 0.5, 0.5, 0.0}, { 0.0, 0.5, 0.0}, { 0.0, 0.0, 0.5}, { 0.5, 0.0, 0.5}, { 0.0, 0.5, 0.5} };
 
-      template<typename pointViewType>
+      template<typename PointViewType>
       KOKKOS_INLINE_FUNCTION
       static bool
-      checkPointInclusion(const pointViewType &point, 
+      checkPointInclusion(const PointViewType &point, 
                           const double threshold) {
         return base_cell_topology_type::checkPointInclusion(point, threshold);
       }
@@ -378,10 +378,10 @@ namespace Intrepid2 {
       static constexpr double coords[11][3]{ { 0.0, 0.0, 0.0}, { 1.0, 0.0, 0.0}, { 0.0, 1.0, 0.0}, { 0.0, 0.0, 1.0},
                                  { 0.5, 0.0, 0.0}, { 0.5, 0.5, 0.0}, { 0.0, 0.5, 0.0}, { 0.0, 0.0, 0.5}, { 0.5, 0.0, 0.5}, { 0.0, 0.5, 0.5} };
       
-      template<typename pointViewType>
+      template<typename PointViewType>
       KOKKOS_INLINE_FUNCTION
       static bool
-      checkPointInclusion(const pointViewType &point, 
+      checkPointInclusion(const PointViewType &point, 
                           const double threshold) {
         return base_cell_topology_type::checkPointInclusion(point, threshold);
       }
@@ -407,10 +407,10 @@ namespace Intrepid2 {
       static constexpr double coords[8][3]{ {-1.0,-1.0,-1.0}, { 1.0,-1.0,-1.0}, { 1.0, 1.0,-1.0}, {-1.0, 1.0,-1.0},
                                 {-1.0,-1.0, 1.0}, { 1.0,-1.0, 1.0}, { 1.0, 1.0, 1.0}, {-1.0, 1.0, 1.0} };
 
-      template<typename pointViewType>
+      template<typename PointViewType>
       KOKKOS_INLINE_FUNCTION
       static bool
-      checkPointInclusion(const pointViewType &point, 
+      checkPointInclusion(const PointViewType &point, 
                           const double threshold) {
         const double minus_one = -1.0 - threshold, plus_one = 1.0 + threshold;
         return ((minus_one <= point(0) && point(0) <= plus_one) &&
@@ -437,10 +437,10 @@ namespace Intrepid2 {
                                  {-1.0,-1.0, 0.0}, { 1.0,-1.0, 0.0}, { 1.0, 1.0, 0.0}, {-1.0, 1.0, 0.0},
                                  { 0.0,-1.0, 1.0}, { 1.0, 0.0, 1.0}, { 0.0, 1.0, 1.0}, {-1.0, 0.0, 1.0} };
 
-      template<typename pointViewType>
+      template<typename PointViewType>
       KOKKOS_INLINE_FUNCTION
       static bool
-      checkPointInclusion(const pointViewType &point, 
+      checkPointInclusion(const PointViewType &point, 
                           const double threshold) {
         return base_cell_topology_type::checkPointInclusion(point, threshold);
       }
@@ -467,10 +467,10 @@ namespace Intrepid2 {
                                  { 0.0, 0.0, 0.0},
                                  { 0.0, 0.0,-1.0}, { 0.0, 0.0, 1.0}, {-1.0, 0.0, 0.0}, { 1.0, 0.0, 0.0}, {0.0,-1.0, 0.0}, {0.0, 1.0, 0.0} };
 
-      template<typename pointViewType>
+      template<typename PointViewType>
       KOKKOS_INLINE_FUNCTION
       static bool
-      checkPointInclusion(const pointViewType &point, 
+      checkPointInclusion(const PointViewType &point, 
                           const double threshold) {
         return base_cell_topology_type::checkPointInclusion(point, threshold);
       }
@@ -495,10 +495,10 @@ namespace Intrepid2 {
                    numIntr = 1 };
       static constexpr double coords[5][3]{ {-1.0,-1.0, 0.0}, { 1.0,-1.0, 0.0}, { 1.0, 1.0, 0.0}, {-1.0, 1.0, 0.0}, { 0.0, 0.0, 1.0} };
 
-      template<typename pointViewType>
+      template<typename PointViewType>
       KOKKOS_INLINE_FUNCTION
       static bool
-      checkPointInclusion(const pointViewType &point, 
+      checkPointInclusion(const PointViewType &point, 
                           const double threshold) {
         const double minus_one = -1.0 - threshold, plus_one = 1.0 + threshold, minus_zero = -threshold;
         const double left  = minus_one + point(2);
@@ -525,10 +525,10 @@ namespace Intrepid2 {
                                  { 0.0,-1.0, 0.0}, { 1.0, 0.0, 0.0}, { 0.0, 1.0, 0.0}, {-1.0, 0.0, 0.0},
                                  {-0.5,-0.5, 0.5}, { 0.5,-0.5, 0.5}, { 0.5, 0.5, 0.5}, {-0.5, 0.5, 0.5} };
 
-      template<typename pointViewType>
+      template<typename PointViewType>
       KOKKOS_INLINE_FUNCTION
       static bool
-      checkPointInclusion(const pointViewType &point, 
+      checkPointInclusion(const PointViewType &point, 
                           const double threshold) {
         return base_cell_topology_type::checkPointInclusion(point, threshold);
       }
@@ -550,10 +550,10 @@ namespace Intrepid2 {
                                  { 0.0,-1.0, 0.0}, { 1.0, 0.0, 0.0}, { 0.0, 1.0, 0.0}, {-1.0, 0.0, 0.0},
                                  {-0.5,-0.5, 0.5}, { 0.5,-0.5, 0.5}, { 0.5, 0.5, 0.5}, {-0.5, 0.5, 0.5}, { 0.0, 0.0, 0.0} };
 
-      template<typename pointViewType>
+      template<typename PointViewType>
       KOKKOS_INLINE_FUNCTION
       static bool
-      checkPointInclusion(const pointViewType &point, 
+      checkPointInclusion(const PointViewType &point, 
                           const double threshold) {
         return base_cell_topology_type::checkPointInclusion(point, threshold);
       }
@@ -578,10 +578,10 @@ namespace Intrepid2 {
                    numIntr = 1 };
       static constexpr double coords[6][3]{ { 0.0, 0.0,-1.0}, { 1.0, 0.0,-1.0}, { 0.0, 1.0,-1.0}, { 0.0, 0.0, 1.0}, { 1.0, 0.0, 1.0}, { 0.0, 1.0, 1.0} };
 
-      template<typename pointViewType>
+      template<typename PointViewType>
       KOKKOS_INLINE_FUNCTION
       static bool
-      checkPointInclusion(const pointViewType &point, 
+      checkPointInclusion(const PointViewType &point, 
                           const double threshold) {
         const double minus_one = -1.0 - threshold, plus_one = 1.0 + threshold;
         const double distance = max( max( -point(0), -point(1) ), point(0) + point(1) - 1 );
@@ -605,10 +605,10 @@ namespace Intrepid2 {
                                  { 0.5, 0.0,-1.0}, { 0.5, 0.5,-1.0}, { 0.0, 0.5,-1.0}, { 0.0, 0.0, 0.0}, { 1.0, 0.0, 0.0}, { 0.0, 1.0, 0.0},
                                  { 0.5, 0.0, 1.0}, { 0.5, 0.5, 1.0}, { 0.0, 0.5, 1.0} };
 
-      template<typename pointViewType>
+      template<typename PointViewType>
       KOKKOS_INLINE_FUNCTION
       static bool
-      checkPointInclusion(const pointViewType &point, 
+      checkPointInclusion(const PointViewType &point, 
                           const double threshold) {
         return base_cell_topology_type::checkPointInclusion(point, threshold);
       }
@@ -632,10 +632,10 @@ namespace Intrepid2 {
                                  { 0.5, 0.0, 0.0}, { 0.5, 0.5, 0.0}, { 0.0, 0.5, 0.0} };
 
       
-      template<typename pointViewType>
+      template<typename PointViewType>
       KOKKOS_INLINE_FUNCTION
       static bool
-      checkPointInclusion(const pointViewType &point, 
+      checkPointInclusion(const PointViewType &point, 
                           const double threshold) {
         return base_cell_topology_type::checkPointInclusion(point, threshold);
       }

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_Basis.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_Basis.hpp
@@ -109,93 +109,60 @@ namespace Intrepid2 {
     /**  \brief View type for ordinal
     */
     using OrdinalViewType = Kokkos::View<ordinal_type,ExecSpaceType>;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalViewType instead")
-    using ordinal_view_type
-    INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalViewType instead","OrdinalViewType")
-    = Kokkos::View<ordinal_type,ExecSpaceType>;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalViewType instead") using ordinal_view_type INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalViewType instead","OrdinalViewType") = OrdinalViewType;
 
     /**  \brief View for basis type
     */
     using EBasisViewType = Kokkos::View<EBasis,ExecSpaceType>;
-    INTREPID2_DEPRECATED_MESSAGE("use EBasisViewType instead")
-    using ebasis_view_type
-    INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use EBasisViewType instead","EBasisViewType")
-    = Kokkos::View<EBasis,ExecSpaceType>;
+    INTREPID2_DEPRECATED_MESSAGE("use EBasisViewType instead") using ebasis_view_type INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use EBasisViewType instead","EBasisViewType") = EBasisViewType;
 
     /**  \brief View for coordinate system type
     */
     using ECoordinatesViewType = Kokkos::View<ECoordinates,ExecSpaceType>;
-    INTREPID2_DEPRECATED_MESSAGE("use ECoordinatesViewType instead")
-    using ecoordinates_view_type
-    INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ECoordinatesViewType instead","ECoordinatesViewType")
-    = Kokkos::View<ECoordinates,ExecSpaceType>;
+    INTREPID2_DEPRECATED_MESSAGE("use ECoordinatesViewType instead") using ecoordinates_view_type INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ECoordinatesViewType instead","ECoordinatesViewType") = ECoordinatesViewType;
 
     // ** tag interface
     //  - tag interface is not decorated with Kokkos inline so it should be allocated on hostspace
 
     /**  \brief View type for 1d host array
     */
-    using OrdinalTypeArray1DHost = Kokkos::View<ordinal_type*  ,typename ExecSpaceType::array_layout,Kokkos::HostSpace>;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead")
-    using ordinal_type_array_1d_host
-    INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost")
-    = Kokkos::View<ordinal_type*  ,typename ExecSpaceType::array_layout,Kokkos::HostSpace>;
+    using OrdinalTypeArray1DHost = Kokkos::View<ordinal_type*,typename ExecSpaceType::array_layout,Kokkos::HostSpace>;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
 
     /**  \brief View type for 2d host array
     */
-    using OrdinalTypeArray2DHost = Kokkos::View<ordinal_type** ,typename ExecSpaceType::array_layout,Kokkos::HostSpace>;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead")
-    using ordinal_type_array_2d_host
-    INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost")
-    = Kokkos::View<ordinal_type** ,typename ExecSpaceType::array_layout,Kokkos::HostSpace>;
+    using OrdinalTypeArray2DHost = Kokkos::View<ordinal_type**,typename ExecSpaceType::array_layout,Kokkos::HostSpace>;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
 
     /**  \brief View type for 3d host array
     */
     using OrdinalTypeArray3DHost = Kokkos::View<ordinal_type***,typename ExecSpaceType::array_layout,Kokkos::HostSpace>;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead")
-    using ordinal_type_array_3d_host
-    INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost")
-    = Kokkos::View<ordinal_type***,typename ExecSpaceType::array_layout,Kokkos::HostSpace>;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
     /**  \brief View type for 1d host array
     */
-    using OrdinalTypeArrayStride1DHost = Kokkos::View<ordinal_type*  , Kokkos::LayoutStride, Kokkos::HostSpace>;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArrayStride1DHost instead")
-    using ordinal_type_array_stride_1d_host
-    INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArrayStride1DHost instead","OrdinalTypeArrayStride1DHost")
-    = Kokkos::View<ordinal_type*  , Kokkos::LayoutStride, Kokkos::HostSpace>;
+    using OrdinalTypeArrayStride1DHost = Kokkos::View<ordinal_type*, Kokkos::LayoutStride, Kokkos::HostSpace>;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArrayStride1DHost instead") using ordinal_type_array_stride_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArrayStride1DHost instead","OrdinalTypeArrayStride1DHost") = OrdinalTypeArrayStride1DHost;
 
     /**  \brief View type for 1d device array
     */
-    using OrdinalTypeArray1D = Kokkos::View<ordinal_type*  ,ExecSpaceType>;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1D instead")
-    using ordinal_type_array_1d
-    INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1D instead","OrdinalTypeArray1D")
-    = Kokkos::View<ordinal_type*  ,ExecSpaceType>;
+    using OrdinalTypeArray1D = Kokkos::View<ordinal_type*,ExecSpaceType>;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1D instead") using ordinal_type_array_1d INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1D instead","OrdinalTypeArray1D") = OrdinalTypeArray1D;
 
     /**  \brief View type for 2d device array
     */
-    using OrdinalTypeArray2D = Kokkos::View<ordinal_type** ,ExecSpaceType>;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2D instead")
-    using ordinal_type_array_2d
-    INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2D instead","OrdinalTypeArray2D")
-    = Kokkos::View<ordinal_type** ,ExecSpaceType>;
+    using OrdinalTypeArray2D = Kokkos::View<ordinal_type**,ExecSpaceType>;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2D instead") using ordinal_type_array_2d INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2D instead","OrdinalTypeArray2D") = OrdinalTypeArray2D;
 
     /**  \brief View type for 3d device array
     */
     using OrdinalTypeArray3D = Kokkos::View<ordinal_type***,ExecSpaceType>;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3D instead")
-    using ordinal_type_array_3d
-    INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3D instead","OrdinalTypeArray3D")
-    = Kokkos::View<ordinal_type***,ExecSpaceType>;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3D instead") using ordinal_type_array_3d INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3D instead","OrdinalTypeArray3D") = OrdinalTypeArray3D;
 
     /**  \brief View type for 1d device array 
     */
     using OrdinalTypeArrayStride1D = Kokkos::View<ordinal_type*, Kokkos::LayoutStride, ExecSpaceType>;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArrayStride1D instead")
-    using ordinal_type_array_stride_1d
-    INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArrayStride1D instead","OrdinalTypeArrayStride1D")
-    = Kokkos::View<ordinal_type*  , Kokkos::LayoutStride, ExecSpaceType>;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArrayStride1D instead") using ordinal_type_array_stride_1d INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArrayStride1D instead","OrdinalTypeArrayStride1D") = OrdinalTypeArrayStride1D;
 
     /**  \brief Scalar type for point values
     */
@@ -243,7 +210,7 @@ namespace Intrepid2 {
         \li     ordinalToTag_[DodOrd][2] = ordinal of the specified DoF relative to the subcell
         \li     ordinalToTag_[DofOrd][3] = total number of DoFs associated with the subcell
     */
-    ordinal_type_array_2d_host ordinalToTag_;
+    OrdinalTypeArray2DHost ordinalToTag_;
 
     /** \brief  DoF tag to ordinal lookup table.
 
@@ -256,7 +223,7 @@ namespace Intrepid2 {
 
         \li     tagToOrdinal_[subcDim][subcOrd][subcDofOrd] = Degree-of-freedom ordinal
     */
-    ordinal_type_array_3d_host tagToOrdinal_;
+    OrdinalTypeArray3DHost tagToOrdinal_;
 
     /** \brief  Fills <var>ordinalToTag_</var> and <var>tagToOrdinal_</var> by basis-specific tag data
 
@@ -688,7 +655,7 @@ namespace Intrepid2 {
     }
 
     /** \brief DoF tag to ordinal data structure */
-    const ordinal_type_array_3d_host
+    const OrdinalTypeArray3DHost
     getAllDofOrdinal() const {
       return tagToOrdinal_;
     }
@@ -722,7 +689,7 @@ namespace Intrepid2 {
         \li     element [DofOrd][2] = tag field 2 for the DoF with the specified ordinal
         \li     element [DofOrd][3] = tag field 3 for the DoF with the specified ordinal
     */
-    const ordinal_type_array_2d_host
+    const OrdinalTypeArray2DHost
     getAllDofTags() const {
       return ordinalToTag_;
     }

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_Basis.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_Basis.hpp
@@ -34,8 +34,9 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Kyungjoo Kim  (kyukim@sandia.gov), or
-//                    Mauro Perego  (mperego@sandia.gov)
+// Questions? Contact Kyungjoo Kim  (kyukim@sandia.gov),
+//                    Mauro Perego  (mperego@sandia.gov), or
+//                    Nate Roberts  (nvrober@sandia.gov)
 //
 // ************************************************************************
 // @HEADER
@@ -54,6 +55,7 @@
 #include "Intrepid2_Utils.hpp"
 
 #include "Intrepid2_CellTopologyTags.hpp"
+#include "Kokkos_Vector.hpp"
 #include "Shards_CellTopology.hpp"
 
 namespace Intrepid2 {
@@ -92,58 +94,112 @@ namespace Intrepid2 {
            typename pointValueType = double>
   class Basis {
   public:
-
+    /**  \brief (Kokkos) Execution space for basis.
+     */
+    using ExecutionSpace  = ExecSpaceType;
+    
+    /**  \brief Output value type for basis; default is double.
+     */
+    using OutputValueType = outputValueType;
+    
+    /**  \brief Point value type for basis; default is double.
+     */
+    using PointValueType  = pointValueType;
+    
     /**  \brief View type for ordinal
     */
-    typedef Kokkos::View<ordinal_type,ExecSpaceType> ordinal_view_type;
+    using OrdinalViewType = Kokkos::View<ordinal_type,ExecSpaceType>;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalViewType instead")
+    using ordinal_view_type
+    INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalViewType instead","OrdinalViewType")
+    = Kokkos::View<ordinal_type,ExecSpaceType>;
 
     /**  \brief View for basis type
     */
-    typedef Kokkos::View<EBasis,ExecSpaceType> ebasis_view_type;
+    using EBasisViewType = Kokkos::View<EBasis,ExecSpaceType>;
+    INTREPID2_DEPRECATED_MESSAGE("use EBasisViewType instead")
+    using ebasis_view_type
+    INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use EBasisViewType instead","EBasisViewType")
+    = Kokkos::View<EBasis,ExecSpaceType>;
 
     /**  \brief View for coordinate system type
     */
-    typedef Kokkos::View<ECoordinates,ExecSpaceType> ecoordinates_view_type;
+    using ECoordinatesViewType = Kokkos::View<ECoordinates,ExecSpaceType>;
+    INTREPID2_DEPRECATED_MESSAGE("use ECoordinatesViewType instead")
+    using ecoordinates_view_type
+    INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ECoordinatesViewType instead","ECoordinatesViewType")
+    = Kokkos::View<ECoordinates,ExecSpaceType>;
 
     // ** tag interface
     //  - tag interface is not decorated with Kokkos inline so it should be allocated on hostspace
 
     /**  \brief View type for 1d host array
     */
-    typedef Kokkos::View<ordinal_type*  ,typename ExecSpaceType::array_layout,Kokkos::HostSpace> ordinal_type_array_1d_host;
+    using OrdinalTypeArray1DHost = Kokkos::View<ordinal_type*  ,typename ExecSpaceType::array_layout,Kokkos::HostSpace>;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead")
+    using ordinal_type_array_1d_host
+    INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost")
+    = Kokkos::View<ordinal_type*  ,typename ExecSpaceType::array_layout,Kokkos::HostSpace>;
 
     /**  \brief View type for 2d host array
     */
-    typedef Kokkos::View<ordinal_type** ,typename ExecSpaceType::array_layout,Kokkos::HostSpace> ordinal_type_array_2d_host;
+    using OrdinalTypeArray2DHost = Kokkos::View<ordinal_type** ,typename ExecSpaceType::array_layout,Kokkos::HostSpace>;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead")
+    using ordinal_type_array_2d_host
+    INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost")
+    = Kokkos::View<ordinal_type** ,typename ExecSpaceType::array_layout,Kokkos::HostSpace>;
 
     /**  \brief View type for 3d host array
     */
-    typedef Kokkos::View<ordinal_type***,typename ExecSpaceType::array_layout,Kokkos::HostSpace> ordinal_type_array_3d_host;
+    using OrdinalTypeArray3DHost = Kokkos::View<ordinal_type***,typename ExecSpaceType::array_layout,Kokkos::HostSpace>;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead")
+    using ordinal_type_array_3d_host
+    INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost")
+    = Kokkos::View<ordinal_type***,typename ExecSpaceType::array_layout,Kokkos::HostSpace>;
 
     /**  \brief View type for 1d host array
     */
-    typedef Kokkos::View<ordinal_type*  , Kokkos::LayoutStride, Kokkos::HostSpace> ordinal_type_array_stride_1d_host;
+    using OrdinalTypeArrayStride1DHost = Kokkos::View<ordinal_type*  , Kokkos::LayoutStride, Kokkos::HostSpace>;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArrayStride1DHost instead")
+    using ordinal_type_array_stride_1d_host
+    INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArrayStride1DHost instead","OrdinalTypeArrayStride1DHost")
+    = Kokkos::View<ordinal_type*  , Kokkos::LayoutStride, Kokkos::HostSpace>;
 
     /**  \brief View type for 1d device array
     */
-    typedef Kokkos::View<ordinal_type*  ,ExecSpaceType> ordinal_type_array_1d;
+    using OrdinalTypeArray1D = Kokkos::View<ordinal_type*  ,ExecSpaceType>;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1D instead")
+    using ordinal_type_array_1d
+    INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1D instead","OrdinalTypeArray1D")
+    = Kokkos::View<ordinal_type*  ,ExecSpaceType>;
 
     /**  \brief View type for 2d device array
     */
-    typedef Kokkos::View<ordinal_type** ,ExecSpaceType> ordinal_type_array_2d;
+    using OrdinalTypeArray2D = Kokkos::View<ordinal_type** ,ExecSpaceType>;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2D instead")
+    using ordinal_type_array_2d
+    INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2D instead","OrdinalTypeArray2D")
+    = Kokkos::View<ordinal_type** ,ExecSpaceType>;
 
     /**  \brief View type for 3d device array
     */
-    typedef Kokkos::View<ordinal_type***,ExecSpaceType> ordinal_type_array_3d;
+    using OrdinalTypeArray3D = Kokkos::View<ordinal_type***,ExecSpaceType>;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3D instead")
+    using ordinal_type_array_3d
+    INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3D instead","OrdinalTypeArray3D")
+    = Kokkos::View<ordinal_type***,ExecSpaceType>;
 
     /**  \brief View type for 1d device array 
     */
-    typedef Kokkos::View<ordinal_type*  , Kokkos::LayoutStride, ExecSpaceType> ordinal_type_array_stride_1d;
+    using OrdinalTypeArrayStride1D = Kokkos::View<ordinal_type*, Kokkos::LayoutStride, ExecSpaceType>;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArrayStride1D instead")
+    using ordinal_type_array_stride_1d
+    INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArrayStride1D instead","OrdinalTypeArrayStride1D")
+    = Kokkos::View<ordinal_type*  , Kokkos::LayoutStride, ExecSpaceType>;
 
     /**  \brief Scalar type for point values
     */
     typedef typename ScalarTraits<pointValueType>::scalar_type scalarType;
-
   protected:
 
     /** \brief  Cardinality of the basis, i.e., the number of basis functions/degrees-of-freedom
@@ -167,7 +223,11 @@ namespace Intrepid2 {
     /** \brief  The coordinate system for which the basis is defined
      */
     ECoordinates basisCoordinates_;
-
+    
+    /** \brief  The function space in which the basis is defined
+     */
+    EFunctionSpace functionSpace_ = FUNCTION_SPACE_MAX;
+    
     /** \brief  "true" if <var>tagToOrdinal_</var> and <var>ordinalToTag_</var> have been initialized
      */
     //Kokkos::View<bool,ExecSpaceType> basisTagsAreSet_;
@@ -275,7 +335,15 @@ namespace Intrepid2 {
         Rank-2 array for vector basis with dimensions (cardinality, cell dimension)
      */
     Kokkos::DynRankView<scalarType,ExecSpaceType> dofCoeffs_;
-
+    
+    /** \brief Polynomial degree for each degree of freedom.  Only defined for hierarchical bases right now.
+     The number of entries per degree of freedom in this table depends on the basis type.  For hypercubes,
+     this will be the spatial dimension.  We have not yet determined what this will be for simplices beyond 1D;
+     there are not yet hierarchical simplicial bases beyond 1D in Intrepid2.
+     
+     Rank-2 array with dimensions (cardinality, cell dimension)
+     */
+    OrdinalTypeArray2DHost fieldOrdinalPolynomialDegree_;
   public:
 
     Basis() = default;
@@ -301,7 +369,12 @@ namespace Intrepid2 {
     /** \brief View type for scalars 
     */
     typedef Kokkos::DynRankView<scalarType,Kokkos::LayoutStride,ExecSpaceType>      scalarViewType;
-
+    
+    // Upper-case versions of the types defined above (these are more consistent with modern C++ conventions)
+    using OutputViewType = outputViewType;
+    using PointViewType  = pointViewType;
+    using ScalarViewType = scalarViewType;
+    
     /** \brief  Evaluation of a FEM basis on a <strong>reference cell</strong>.
 
         Returns values of <var>operatorType</var> acting on FEM basis functions for a set of
@@ -384,7 +457,102 @@ namespace Intrepid2 {
                                     ">>> ERROR (Basis::getDofCoeffs): this method is not supported or should be over-riden accordingly by derived classes.");
     }
 
-
+    /** \brief For hierarchical bases, returns the field ordinals that have at most the specified degree in each dimension.
+     Assuming that these are less than or equal to the polynomial orders provided at Basis construction, the corresponding polynomials will form a superset of the Basis of the same type constructed with polynomial orders corresponding to the specified degrees.
+     
+     \param  degrees      [in] - 1D host ordinal array of length specified by getPolynomialDegreeLength(), indicating what the maximum degree in each dimension should be
+     
+     \return a 1D host ordinal array containing the ordinals of matching basis functions
+     */
+    OrdinalTypeArray1DHost getFieldOrdinalsForDegree(OrdinalTypeArray1DHost &degrees) const
+    {
+      int degreeEntryLength     = fieldOrdinalPolynomialDegree_.extent_int(1);
+      int requestedDegreeLength = degrees.extent_int(0);
+      INTREPID2_TEST_FOR_EXCEPTION(degreeEntryLength != requestedDegreeLength, std::invalid_argument, "length of degrees does not match the entries in fieldOrdinalPolynomialDegree_");
+      Kokkos::vector<int> fieldOrdinalsVector;
+      for (int basisOrdinal=0; basisOrdinal<fieldOrdinalPolynomialDegree_.extent_int(0); basisOrdinal++)
+      {
+        bool matches = true;
+        for (int d=0; d<degreeEntryLength; d++)
+        {
+          if (fieldOrdinalPolynomialDegree_(basisOrdinal,d) > degrees(d)) matches = false;
+        }
+        if (matches) fieldOrdinalsVector.push_back(basisOrdinal);
+      }
+      OrdinalTypeArray1DHost fieldOrdinals("fieldOrdinalsForDegree",fieldOrdinalsVector.size());
+      for (int i=0; i<fieldOrdinalsVector.size(); i++)
+      {
+        fieldOrdinals(i) = fieldOrdinalsVector[i];
+      }
+      return fieldOrdinals;
+    }
+    
+    /** \brief For hierarchical bases, returns the field ordinals that have at most the specified degree in each dimension.
+     Assuming that these are less than or equal to the polynomial orders provided at Basis construction, the corresponding polynomials will form a superset of the Basis of the same type constructed with polynomial orders corresponding to the specified degrees.
+     
+     This variant takes a Kokkos::vector of polynomial degrees and returns a Kokkos::vector of field ordinals.  It calls the other variant, which uses Kokkos Views on the host.
+     
+     \param  degrees      [in] - Kokkos::vector<int> of length specified by getPolynomialDegreeLength(), indicating what the maximum degree in each dimension should be
+     
+     \return a Kokkos::vector<int> containing the ordinals of matching basis functions
+     
+     */
+    Kokkos::vector<int> getFieldOrdinalsForDegree(Kokkos::vector<int> &degrees) const
+    {
+      OrdinalTypeArray1DHost degreesView("degrees",degrees.size());
+      for (int d=0; d<degrees.size(); d++)
+      {
+        degreesView(d) = degrees[d];
+      }
+      auto fieldOrdinalsView = getFieldOrdinalsForDegree(degreesView);
+      Kokkos::vector<int> fieldOrdinalsVector(fieldOrdinalsView.extent_int(0));
+      for (int i=0; i<fieldOrdinalsView.extent_int(0); i++)
+      {
+        fieldOrdinalsVector[i] = fieldOrdinalsView(i);
+      }
+      return fieldOrdinalsVector;
+    }
+    
+    /** \brief For hierarchical bases, returns the polynomial degree (which may have multiple values in higher spatial dimensions) for the specified basis ordinal as a host array.
+     
+        \param fieldOrdinal     [in] - ordinal of the basis function whose polynomial degree is requested.
+     
+        \return a 1D host array of length matching getPolynomialDegreeLength(), with the polynomial degree of the basis function in each dimension.
+     */
+    OrdinalTypeArray1DHost getPolynomialDegreeOfField(int fieldOrdinal) const
+    {
+      INTREPID2_TEST_FOR_EXCEPTION(fieldOrdinal < 0, std::invalid_argument, "field ordinal must be non-negative");
+      INTREPID2_TEST_FOR_EXCEPTION(fieldOrdinal >= fieldOrdinalPolynomialDegree_.extent_int(0), std::invalid_argument, "field ordinal out of bounds");
+      
+      return Kokkos::subview(fieldOrdinalPolynomialDegree_,fieldOrdinal,Kokkos::ALL);
+    }
+    
+    /**
+     \brief For hierarchical bases, returns the polynomial degree (which may have multiple values in higher spatial dimensions) for the specified basis ordinal as a host array.
+     
+     \param fieldOrdinal     [in] - ordinal of the basis function whose polynomial degree is requested.
+     
+     \return a Kokkos::vector<int> of length matching getPolynomialDegreeLength(), with the polynomial degree of the basis function in each dimension.
+     */
+    Kokkos::vector<int> getPolynomialDegreeOfFieldAsVector(int fieldOrdinal) const
+    {
+      auto polynomialDegreeView = getPolynomialDegreeOfField(fieldOrdinal);
+      Kokkos::vector<int> polynomialDegree(polynomialDegreeView.extent_int(0));
+      
+      for (int d=0; d<polynomialDegree.size(); d++)
+      {
+        polynomialDegree[d] = polynomialDegreeView(d);
+      }
+      return polynomialDegree;
+    }
+    
+    /** \brief For hierarchical bases, returns the number of entries required to specify the polynomial degree of a basis function.
+     */
+    int getPolynomialDegreeLength() const
+    {
+      return fieldOrdinalPolynomialDegree_.extent_int(1);
+    }
+    
     /** \brief  Returns basis name
 
         \return the name of the basis
@@ -421,8 +589,16 @@ namespace Intrepid2 {
     getDegree() const {
       return basisDegree_;
     }
-
-
+    
+    /** \brief  Returns the function space for the basis.
+     
+        \return the function space.
+     */
+    EFunctionSpace
+    getFunctionSpace() const {
+      return functionSpace_;
+    }
+    
     /** \brief  Returns the base cell topology for which the basis is defined. See Shards documentation
         https://trilinos.org/packages/shards for definition of base cell topology.
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_Basis.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_Basis.hpp
@@ -671,7 +671,7 @@ namespace Intrepid2 {
         \li     element [2] = tag field 2  ->  ordinal of the specified DoF relative to the subcell
         \li     element [3] = tag field 3  ->  total number of DoFs associated with the subcell
     */
-    const ordinal_type_array_stride_1d_host
+    const OrdinalTypeArrayStride1DHost
     getDofTag( const ordinal_type dofOrd ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       INTREPID2_TEST_FOR_EXCEPTION( dofOrd < 0 || dofOrd >= static_cast<ordinal_type>(ordinalToTag_.extent(0)), std::out_of_range,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_Basis.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_Basis.hpp
@@ -109,17 +109,18 @@ namespace Intrepid2 {
     /**  \brief View type for ordinal
     */
     using OrdinalViewType = Kokkos::View<ordinal_type,ExecSpaceType>;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalViewType instead") using ordinal_view_type INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalViewType instead","OrdinalViewType") = OrdinalViewType;
+    using ordinal_view_type __attribute__((deprecated("use OrdinalViewType instead","OrdinalViewType"))) = OrdinalViewType;
+//    using ordinal_view_type INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalViewType instead","OrdinalViewType") = OrdinalViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalViewType instead");
 
     /**  \brief View for basis type
     */
     using EBasisViewType = Kokkos::View<EBasis,ExecSpaceType>;
-    INTREPID2_DEPRECATED_MESSAGE("use EBasisViewType instead") using ebasis_view_type INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use EBasisViewType instead","EBasisViewType") = EBasisViewType;
+    using ebasis_view_type INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use EBasisViewType instead","EBasisViewType") = EBasisViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use EBasisViewType instead");
 
     /**  \brief View for coordinate system type
     */
     using ECoordinatesViewType = Kokkos::View<ECoordinates,ExecSpaceType>;
-    INTREPID2_DEPRECATED_MESSAGE("use ECoordinatesViewType instead") using ecoordinates_view_type INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ECoordinatesViewType instead","ECoordinatesViewType") = ECoordinatesViewType;
+    using ecoordinates_view_type INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ECoordinatesViewType instead","ECoordinatesViewType") = ECoordinatesViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ECoordinatesViewType instead");
 
     // ** tag interface
     //  - tag interface is not decorated with Kokkos inline so it should be allocated on hostspace
@@ -127,42 +128,42 @@ namespace Intrepid2 {
     /**  \brief View type for 1d host array
     */
     using OrdinalTypeArray1DHost = Kokkos::View<ordinal_type*,typename ExecSpaceType::array_layout,Kokkos::HostSpace>;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
+    using ordinal_type_array_1d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead");
 
     /**  \brief View type for 2d host array
     */
     using OrdinalTypeArray2DHost = Kokkos::View<ordinal_type**,typename ExecSpaceType::array_layout,Kokkos::HostSpace>;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
+    using ordinal_type_array_2d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead");
 
     /**  \brief View type for 3d host array
     */
     using OrdinalTypeArray3DHost = Kokkos::View<ordinal_type***,typename ExecSpaceType::array_layout,Kokkos::HostSpace>;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
+    using ordinal_type_array_3d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead");
 
     /**  \brief View type for 1d host array
     */
     using OrdinalTypeArrayStride1DHost = Kokkos::View<ordinal_type*, Kokkos::LayoutStride, Kokkos::HostSpace>;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArrayStride1DHost instead") using ordinal_type_array_stride_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArrayStride1DHost instead","OrdinalTypeArrayStride1DHost") = OrdinalTypeArrayStride1DHost;
+    using ordinal_type_array_stride_1d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArrayStride1DHost instead","OrdinalTypeArrayStride1DHost") = OrdinalTypeArrayStride1DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArrayStride1DHost instead");
 
     /**  \brief View type for 1d device array
     */
     using OrdinalTypeArray1D = Kokkos::View<ordinal_type*,ExecSpaceType>;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1D instead") using ordinal_type_array_1d INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1D instead","OrdinalTypeArray1D") = OrdinalTypeArray1D;
+    using ordinal_type_array_1d INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray1D instead","OrdinalTypeArray1D") = OrdinalTypeArray1D INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray1D instead");
 
     /**  \brief View type for 2d device array
     */
     using OrdinalTypeArray2D = Kokkos::View<ordinal_type**,ExecSpaceType>;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2D instead") using ordinal_type_array_2d INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2D instead","OrdinalTypeArray2D") = OrdinalTypeArray2D;
+    using ordinal_type_array_2d INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray2D instead","OrdinalTypeArray2D") = OrdinalTypeArray2D INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray2D instead");
 
     /**  \brief View type for 3d device array
     */
     using OrdinalTypeArray3D = Kokkos::View<ordinal_type***,ExecSpaceType>;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3D instead") using ordinal_type_array_3d INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3D instead","OrdinalTypeArray3D") = OrdinalTypeArray3D;
+    using ordinal_type_array_3d INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray3D instead","OrdinalTypeArray3D") = OrdinalTypeArray3D INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray3D instead");
 
     /**  \brief View type for 1d device array 
     */
     using OrdinalTypeArrayStride1D = Kokkos::View<ordinal_type*, Kokkos::LayoutStride, ExecSpaceType>;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArrayStride1D instead") using ordinal_type_array_stride_1d INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArrayStride1D instead","OrdinalTypeArrayStride1D") = OrdinalTypeArrayStride1D;
+    using ordinal_type_array_stride_1d INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArrayStride1D instead","OrdinalTypeArrayStride1D") = OrdinalTypeArrayStride1D INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArrayStride1D instead");
 
     /**  \brief Scalar type for point values
     */
@@ -328,17 +329,17 @@ namespace Intrepid2 {
     /** \brief View type for basis value output
     */
     using OutputViewType = Kokkos::DynRankView<OutputValueType,Kokkos::LayoutStride,ExecSpaceType>;
-    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+    using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
 
     /** \brief View type for input points
     */
     using PointViewType = Kokkos::DynRankView<PointValueType,Kokkos::LayoutStride,ExecSpaceType>;
-    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+    using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
 
     /** \brief View type for scalars 
     */
     using ScalarViewType = Kokkos::DynRankView<scalarType,Kokkos::LayoutStride,ExecSpaceType>;
-    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+    using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
     
     /** \brief  Evaluation of a FEM basis on a <strong>reference cell</strong>.
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_Basis.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_Basis.hpp
@@ -319,28 +319,26 @@ namespace Intrepid2 {
     // receives input arguments
     /** \brief Dummy array to receive input arguments
     */
-    outputValueType getDummyOutputValue() { return outputValueType(); }
+    OutputValueType getDummyOutputValue() { return outputValueType(); }
 
     /** \brief Dummy array to receive input arguments
     */
-    pointValueType getDummyPointValue() { return pointValueType(); }
+    PointValueType getDummyPointValue() { return pointValueType(); }
 
     /** \brief View type for basis value output
     */
-    typedef Kokkos::DynRankView<outputValueType,Kokkos::LayoutStride,ExecSpaceType> outputViewType;
+    using OutputViewType = Kokkos::DynRankView<OutputValueType,Kokkos::LayoutStride,ExecSpaceType>;
+    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
 
     /** \brief View type for input points
     */
-    typedef Kokkos::DynRankView<pointValueType,Kokkos::LayoutStride,ExecSpaceType>  pointViewType;
+    using PointViewType = Kokkos::DynRankView<PointValueType,Kokkos::LayoutStride,ExecSpaceType>;
+    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
 
     /** \brief View type for scalars 
     */
-    typedef Kokkos::DynRankView<scalarType,Kokkos::LayoutStride,ExecSpaceType>      scalarViewType;
-    
-    // Upper-case versions of the types defined above (these are more consistent with modern C++ conventions)
-    using OutputViewType = outputViewType;
-    using PointViewType  = pointViewType;
-    using ScalarViewType = scalarViewType;
+    using ScalarViewType = Kokkos::DynRankView<scalarType,Kokkos::LayoutStride,ExecSpaceType>;
+    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
     
     /** \brief  Evaluation of a FEM basis on a <strong>reference cell</strong>.
 
@@ -362,8 +360,8 @@ namespace Intrepid2 {
     */
     virtual
     void
-    getValues(       outputViewType /* outputValues */,
-               const pointViewType  /* inputPoints */,
+    getValues(       OutputViewType /* outputValues */,
+               const PointViewType  /* inputPoints */,
                const EOperator /* operatorType */ = OPERATOR_VALUE ) const {
       INTREPID2_TEST_FOR_EXCEPTION( true, std::logic_error,
                                     ">>> ERROR (Basis::getValues): this method (FEM) is not supported or should be over-riden accordingly by derived classes.");
@@ -390,9 +388,9 @@ namespace Intrepid2 {
     */
     virtual
     void
-    getValues(        outputViewType /* outputValues */,
-                const pointViewType  /* inputPoints */,
-                const pointViewType  /* cellVertices */,
+    getValues(        OutputViewType /* outputValues */,
+                const PointViewType  /* inputPoints */,
+                const PointViewType  /* cellVertices */,
                 const EOperator /* operatorType */ = OPERATOR_VALUE ) const {
       INTREPID2_TEST_FOR_EXCEPTION( true, std::logic_error,
                                     ">>> ERROR (Basis::getValues): this method (FVM) is not supported or should be over-riden accordingly by derived classes.");
@@ -404,7 +402,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoords( scalarViewType /* dofCoords */ ) const {
+    getDofCoords( ScalarViewType /* dofCoords */ ) const {
       INTREPID2_TEST_FOR_EXCEPTION( true, std::logic_error,
                                     ">>> ERROR (Basis::getDofCoords): this method is not supported or should be over-riden accordingly by derived classes.");
     }
@@ -419,7 +417,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoeffs( scalarViewType /* dofCoeffs */ ) const {
+    getDofCoeffs( ScalarViewType /* dofCoeffs */ ) const {
       INTREPID2_TEST_FOR_EXCEPTION( true, std::logic_error,
                                     ">>> ERROR (Basis::getDofCoeffs): this method is not supported or should be over-riden accordingly by derived classes.");
     }
@@ -433,6 +431,8 @@ namespace Intrepid2 {
      */
     OrdinalTypeArray1DHost getFieldOrdinalsForDegree(OrdinalTypeArray1DHost &degrees) const
     {
+      INTREPID2_TEST_FOR_EXCEPTION( basisType_ != BASIS_FEM_HIERARCHICAL, std::logic_error,
+                                   ">>> ERROR (Basis::getFieldOrdinalsForDegree): this method is not supported for non-hierarchical bases.");
       int degreeEntryLength     = fieldOrdinalPolynomialDegree_.extent_int(1);
       int requestedDegreeLength = degrees.extent_int(0);
       INTREPID2_TEST_FOR_EXCEPTION(degreeEntryLength != requestedDegreeLength, std::invalid_argument, "length of degrees does not match the entries in fieldOrdinalPolynomialDegree_");
@@ -466,6 +466,8 @@ namespace Intrepid2 {
      */
     Kokkos::vector<int> getFieldOrdinalsForDegree(Kokkos::vector<int> &degrees) const
     {
+      INTREPID2_TEST_FOR_EXCEPTION( basisType_ != BASIS_FEM_HIERARCHICAL, std::logic_error,
+                                   ">>> ERROR (Basis::getFieldOrdinalsForDegree): this method is not supported for non-hierarchical bases.");
       OrdinalTypeArray1DHost degreesView("degrees",degrees.size());
       for (int d=0; d<degrees.size(); d++)
       {
@@ -488,6 +490,8 @@ namespace Intrepid2 {
      */
     OrdinalTypeArray1DHost getPolynomialDegreeOfField(int fieldOrdinal) const
     {
+      INTREPID2_TEST_FOR_EXCEPTION( basisType_ != BASIS_FEM_HIERARCHICAL, std::logic_error,
+                                   ">>> ERROR (Basis::getPolynomialDegreeOfField): this method is not supported for non-hierarchical bases.");
       INTREPID2_TEST_FOR_EXCEPTION(fieldOrdinal < 0, std::invalid_argument, "field ordinal must be non-negative");
       INTREPID2_TEST_FOR_EXCEPTION(fieldOrdinal >= fieldOrdinalPolynomialDegree_.extent_int(0), std::invalid_argument, "field ordinal out of bounds");
       
@@ -503,6 +507,8 @@ namespace Intrepid2 {
      */
     Kokkos::vector<int> getPolynomialDegreeOfFieldAsVector(int fieldOrdinal) const
     {
+      INTREPID2_TEST_FOR_EXCEPTION( basisType_ != BASIS_FEM_HIERARCHICAL, std::logic_error,
+                                   ">>> ERROR (Basis::getPolynomialDegreeOfFieldAsVector): this method is not supported for non-hierarchical bases.");
       auto polynomialDegreeView = getPolynomialDegreeOfField(fieldOrdinal);
       Kokkos::vector<int> polynomialDegree(polynomialDegreeView.extent_int(0));
       
@@ -517,6 +523,8 @@ namespace Intrepid2 {
      */
     int getPolynomialDegreeLength() const
     {
+      INTREPID2_TEST_FOR_EXCEPTION( basisType_ != BASIS_FEM_HIERARCHICAL, std::logic_error,
+                                   ">>> ERROR (Basis::getPolynomialDegreeLength): this method is not supported for non-hierarchical bases.");
       return fieldOrdinalPolynomialDegree_.extent_int(1);
     }
     

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_Basis.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_Basis.hpp
@@ -109,8 +109,7 @@ namespace Intrepid2 {
     /**  \brief View type for ordinal
     */
     using OrdinalViewType = Kokkos::View<ordinal_type,ExecSpaceType>;
-    using ordinal_view_type __attribute__((deprecated("use OrdinalViewType instead","OrdinalViewType"))) = OrdinalViewType;
-//    using ordinal_view_type INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalViewType instead","OrdinalViewType") = OrdinalViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalViewType instead");
+    using ordinal_view_type INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalViewType instead","OrdinalViewType") = OrdinalViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalViewType instead");
 
     /**  \brief View for basis type
     */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_HEX_I1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_HEX_I1_FEM.hpp
@@ -189,9 +189,9 @@ namespace Intrepid2 {
     using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
     using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
     
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
+    using ordinal_type_array_1d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead");
+    using ordinal_type_array_2d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead");
+    using ordinal_type_array_3d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead");
 
     /** \brief  Constructor.
      */
@@ -201,9 +201,9 @@ namespace Intrepid2 {
     using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
     using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
     
-    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+    using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+    using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
+    using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
     
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_HEX_I1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_HEX_I1_FEM.hpp
@@ -185,9 +185,13 @@ namespace Intrepid2 {
            typename pointValueType = double>
   class Basis_HCURL_HEX_I1_FEM : public Basis<ExecSpaceType,outputValueType,pointValueType> {
   public:
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+    
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
     /** \brief  Constructor.
      */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_HEX_I1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_HEX_I1_FEM.hpp
@@ -127,11 +127,11 @@ namespace Intrepid2 {
       */
       template<EOperator opType>
       struct Serial {
-        template<typename outputViewType,
+        template<typename OutputViewType,
                  typename inputViewType>
         KOKKOS_INLINE_FUNCTION
         static void
-        getValues(       outputViewType output,
+        getValues(       OutputViewType output,
                    const inputViewType  input );
       };
 
@@ -197,16 +197,20 @@ namespace Intrepid2 {
      */
     Basis_HCURL_HEX_I1_FEM();
 
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarViewType  scalarViewType;
-
+    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    
+    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+    
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
-    getValues(       outputViewType outputValues,
-               const pointViewType  inputPoints,
+    getValues(       OutputViewType outputValues,
+               const PointViewType  inputPoints,
                const EOperator operatorType = OPERATOR_VALUE ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       Intrepid2::getValues_HCURL_Args(outputValues,
@@ -223,7 +227,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoords( scalarViewType dofCoords ) const {
+    getDofCoords( ScalarViewType dofCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,
@@ -241,7 +245,7 @@ namespace Intrepid2 {
       
   virtual
   void
-  getDofCoeffs( scalarViewType dofCoeffs ) const {
+  getDofCoeffs( ScalarViewType dofCoeffs ) const {
 #ifdef HAVE_INTREPID2_DEBUG
     // Verify rank of output array.
     INTREPID2_TEST_FOR_EXCEPTION( dofCoeffs.rank() != 2, std::invalid_argument,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_HEX_I1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_HEX_I1_FEMDef.hpp
@@ -305,7 +305,7 @@ namespace Intrepid2 {
                                  1, 11, 0, 1 };
 
       // when exec space is device, this wrapping relies on uvm.
-      ordinal_type_array_1d_host tagView(&tags[0], 48);
+      OrdinalTypeArray1DHost tagView(&tags[0], 48);
 
       // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
       this->setOrdinalTagData(this->tagToOrdinal_,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_HEX_I1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_HEX_I1_FEMDef.hpp
@@ -56,12 +56,12 @@ namespace Intrepid2 {
   namespace Impl {
 
     template<EOperator opType>
-    template<typename outputViewType,
+    template<typename OutputViewType,
              typename inputViewType>
     KOKKOS_INLINE_FUNCTION
     void
     Basis_HCURL_HEX_I1_FEM::Serial<opType>::
-    getValues(       outputViewType output,
+    getValues(       OutputViewType output,
                const inputViewType input ) {
 
       switch (opType) {
@@ -319,7 +319,7 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoords("dofCoordsHost", this->basisCardinality_,this->basisCellTopology_.getDimension());
 
     dofCoords(0,0)  =  0.0;   dofCoords(0,1)  = -1.0;   dofCoords(0,2)  = -1.0;
@@ -340,7 +340,7 @@ namespace Intrepid2 {
 
 
     // dofCoeffs on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoeffs("dofCoeffsHost", this->basisCardinality_,this->basisCellTopology_.getDimension());
 
     // for HCURL_HEX_I1 dofCoeffs are the tangents on the hexahedron edges (with tangents magnitude equal to edges' lengths)

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_HEX_I1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_HEX_I1_FEMDef.hpp
@@ -280,6 +280,7 @@ namespace Intrepid2 {
     this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Hexahedron<8> >() );
     this->basisType_         = BASIS_FEM_DEFAULT;
     this->basisCoordinates_  = COORDINATES_CARTESIAN;
+    this->functionSpace_     = FUNCTION_SPACE_HCURL;
 
     // initialize tags
     {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_HEX_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_HEX_In_FEM.hpp
@@ -194,16 +194,20 @@ namespace Intrepid2 {
     Basis_HCURL_HEX_In_FEM(const ordinal_type order,
                             const EPointType   pointType = POINTTYPE_EQUISPACED);
 
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarViewType scalarViewType;
+    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    
+    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
-    getValues(       outputViewType outputValues,
-               const pointViewType  inputPoints,
+    getValues(       OutputViewType outputValues,
+               const PointViewType  inputPoints,
                const EOperator operatorType = OPERATOR_VALUE ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       Intrepid2::getValues_HCURL_Args(outputValues,
@@ -223,7 +227,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoords( scalarViewType dofCoords ) const {
+    getDofCoords( ScalarViewType dofCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,
@@ -240,7 +244,7 @@ namespace Intrepid2 {
       
   virtual
   void
-  getDofCoeffs( scalarViewType dofCoeffs ) const {
+  getDofCoeffs( ScalarViewType dofCoeffs ) const {
 #ifdef HAVE_INTREPID2_DEBUG
     // Verify rank of output array.
     INTREPID2_TEST_FOR_EXCEPTION( dofCoeffs.rank() != 2, std::invalid_argument,
@@ -270,7 +274,7 @@ namespace Intrepid2 {
   private:
 
     /** \brief inverse of Generalized Vandermonde matrix (isotropic order) */
-    Kokkos::DynRankView<typename scalarViewType::value_type,ExecSpaceType> vinvLine_, vinvBubble_;
+    Kokkos::DynRankView<typename ScalarViewType::value_type,ExecSpaceType> vinvLine_, vinvBubble_;
   };
 
 }// namespace Intrepid2

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_HEX_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_HEX_In_FEM.hpp
@@ -181,9 +181,13 @@ namespace Intrepid2 {
   class Basis_HCURL_HEX_In_FEM
     : public Basis<ExecSpaceType,outputValueType,pointValueType> {
   public:
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
     /** \brief  Constructor.
      */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_HEX_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_HEX_In_FEM.hpp
@@ -185,9 +185,9 @@ namespace Intrepid2 {
     using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
     using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
 
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
+    using ordinal_type_array_1d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead");
+    using ordinal_type_array_2d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead");
+    using ordinal_type_array_3d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead");
 
     /** \brief  Constructor.
      */
@@ -198,9 +198,9 @@ namespace Intrepid2 {
     using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
     using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
     
-    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+    using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+    using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
+    using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_HEX_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_HEX_In_FEMDef.hpp
@@ -535,7 +535,7 @@ namespace Intrepid2 {
                                       "counted tag index is not same as cardinality." );
       }
 
-      ordinal_type_array_1d_host tagView(&tags[0][0], this->basisCardinality_*4);
+      OrdinalTypeArray1DHost tagView(&tags[0][0], this->basisCardinality_*4);
 
       // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
       // tags are constructed on host

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_HEX_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_HEX_In_FEMDef.hpp
@@ -381,6 +381,7 @@ namespace Intrepid2 {
     this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Hexahedron<8> >() );
     this->basisType_         = BASIS_FEM_FIAT;
     this->basisCoordinates_  = COORDINATES_CARTESIAN;
+    this->functionSpace_     = FUNCTION_SPACE_HCURL;
 
     // initialize tags
     {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_HEX_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_HEX_In_FEMDef.hpp
@@ -55,14 +55,14 @@ namespace Intrepid2 {
   namespace Impl {
 
     template<EOperator opType>
-    template<typename outputViewType,
+    template<typename OutputViewType,
              typename inputViewType,
              typename workViewType,
              typename vinvViewType>
     KOKKOS_INLINE_FUNCTION
     void
     Basis_HCURL_HEX_In_FEM::Serial<opType>::
-    getValues(       outputViewType output,
+    getValues(       OutputViewType output,
                const inputViewType  input,
                      workViewType   work,
                const vinvViewType   vinvLine,
@@ -370,8 +370,8 @@ namespace Intrepid2 {
       cardLine = lineBasis.getCardinality(),
       cardBubble = bubbleBasis.getCardinality();
 
-    this->vinvLine_   = Kokkos::DynRankView<typename scalarViewType::value_type,SpT>("Hcurl::Hex::In::vinvLine", cardLine, cardLine);
-    this->vinvBubble_ = Kokkos::DynRankView<typename scalarViewType::value_type,SpT>("Hcurl::Hex::In::vinvBubble", cardBubble, cardBubble);
+    this->vinvLine_   = Kokkos::DynRankView<typename ScalarViewType::value_type,SpT>("Hcurl::Hex::In::vinvLine", cardLine, cardLine);
+    this->vinvBubble_ = Kokkos::DynRankView<typename ScalarViewType::value_type,SpT>("Hcurl::Hex::In::vinvBubble", cardBubble, cardBubble);
 
     lineBasis.getVandermondeInverse(this->vinvLine_);
     bubbleBasis.getVandermondeInverse(this->vinvBubble_);
@@ -550,14 +550,14 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoordsHost("dofCoordsHost", this->basisCardinality_, this->basisCellTopology_.getDimension());
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoeffsHost("dofCoeffsHost", this->basisCardinality_, this->basisCellTopology_.getDimension());
 
-    Kokkos::DynRankView<typename scalarViewType::value_type,SpT>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,SpT>
       dofCoordsLine("dofCoordsLine", cardLine, 1),
       dofCoordsBubble("dofCoordsBubble", cardBubble, 1);
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_QUAD_I1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_QUAD_I1_FEM.hpp
@@ -176,9 +176,13 @@ namespace Intrepid2 {
            typename pointValueType = double>
   class Basis_HCURL_QUAD_I1_FEM : public Basis<ExecSpaceType,outputValueType, pointValueType> {
   public:
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
 
     /** \brief  Constructor.

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_QUAD_I1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_QUAD_I1_FEM.hpp
@@ -180,9 +180,9 @@ namespace Intrepid2 {
     using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
     using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
 
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
+    using ordinal_type_array_1d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead");
+    using ordinal_type_array_2d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead");
+    using ordinal_type_array_3d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead");
 
 
     /** \brief  Constructor.
@@ -193,9 +193,9 @@ namespace Intrepid2 {
     using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
     using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
     
-    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+    using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+    using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
+    using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_QUAD_I1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_QUAD_I1_FEM.hpp
@@ -110,11 +110,11 @@ namespace Intrepid2 {
       */
       template<EOperator opType>
       struct Serial {
-        template<typename outputViewType,
+        template<typename OutputViewType,
                  typename inputViewType>
         KOKKOS_INLINE_FUNCTION
         static void
-        getValues(       outputViewType output,
+        getValues(       OutputViewType output,
                    const inputViewType input );
 
       };
@@ -189,16 +189,20 @@ namespace Intrepid2 {
      */
     Basis_HCURL_QUAD_I1_FEM();
 
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarViewType  scalarViewType;
+    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    
+    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
-    getValues(       outputViewType outputValues,
-               const pointViewType  inputPoints,
+    getValues(       OutputViewType outputValues,
+               const PointViewType  inputPoints,
                const EOperator operatorType = OPERATOR_VALUE ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify arguments
@@ -216,7 +220,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoords( scalarViewType dofCoords ) const {
+    getDofCoords( ScalarViewType dofCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,
@@ -233,7 +237,7 @@ namespace Intrepid2 {
     
   virtual
   void
-  getDofCoeffs( scalarViewType dofCoeffs ) const {
+  getDofCoeffs( ScalarViewType dofCoeffs ) const {
 #ifdef HAVE_INTREPID2_DEBUG
     // Verify rank of output array.
     INTREPID2_TEST_FOR_EXCEPTION( dofCoeffs.rank() != 2, std::invalid_argument,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_QUAD_I1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_QUAD_I1_FEMDef.hpp
@@ -192,6 +192,7 @@ namespace Intrepid2 {
     this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Quadrilateral<4> >() );
     this->basisType_         = BASIS_FEM_DEFAULT;
     this->basisCoordinates_  = COORDINATES_CARTESIAN;
+    this->functionSpace_     = FUNCTION_SPACE_HCURL;
 
     // initialize tags
     {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_QUAD_I1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_QUAD_I1_FEMDef.hpp
@@ -56,12 +56,12 @@ namespace Intrepid2 {
   namespace Impl {
 
     template<EOperator opType>
-    template<typename outputViewType,
+    template<typename OutputViewType,
              typename inputViewType>
     KOKKOS_INLINE_FUNCTION
     void
     Basis_HCURL_QUAD_I1_FEM::Serial<opType>::
-    getValues(       outputViewType output,
+    getValues(       OutputViewType output,
                const inputViewType input ) {
       switch (opType) {
       case OPERATOR_VALUE: {
@@ -224,7 +224,7 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoords("dofCoordsHost", this->basisCardinality_,this->basisCellTopology_.getDimension());
 
     dofCoords(0,0) =  0.0;   dofCoords(0,1) = -1.0;
@@ -237,7 +237,7 @@ namespace Intrepid2 {
 
 
     // dofCoeffs on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoeffs("dofCoeffsHost", this->basisCardinality_,this->basisCellTopology_.getDimension());
 
     // for HCURL_QUAD_I1 dofCoeffs are the tangents on the quadrilateral edges (with tangents magnitude equal to edges' lengths)

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_QUAD_I1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_QUAD_I1_FEMDef.hpp
@@ -210,7 +210,7 @@ namespace Intrepid2 {
 
       // when exec space is device, this wrapping relies on uvm.
       //Kokkos::View<ordinal_type[16], SpT> tagView(tags);
-      ordinal_type_array_1d_host tagView(&tags[0], 16);
+      OrdinalTypeArray1DHost tagView(&tags[0], 16);
 
       // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
       this->setOrdinalTagData(this->tagToOrdinal_,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_QUAD_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_QUAD_In_FEM.hpp
@@ -168,9 +168,13 @@ namespace Intrepid2 {
   class Basis_HCURL_QUAD_In_FEM
     : public Basis<ExecSpaceType,outputValueType,pointValueType> {
   public:
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
     /** \brief  Constructor.
      */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_QUAD_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_QUAD_In_FEM.hpp
@@ -172,9 +172,9 @@ namespace Intrepid2 {
     using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
     using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
 
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
+    using ordinal_type_array_1d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead");
+    using ordinal_type_array_2d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead");
+    using ordinal_type_array_3d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead");
 
     /** \brief  Constructor.
      */
@@ -185,9 +185,9 @@ namespace Intrepid2 {
     using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
     using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
     
-    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+    using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+    using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
+    using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_QUAD_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_QUAD_In_FEM.hpp
@@ -181,16 +181,20 @@ namespace Intrepid2 {
     Basis_HCURL_QUAD_In_FEM(const ordinal_type order,
                             const EPointType   pointType = POINTTYPE_EQUISPACED);
 
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarViewType  scalarViewType;
+    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    
+    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
-    getValues(       outputViewType outputValues,
-               const pointViewType  inputPoints,
+    getValues(       OutputViewType outputValues,
+               const PointViewType  inputPoints,
                const EOperator operatorType = OPERATOR_VALUE ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       Intrepid2::getValues_HCURL_Args(outputValues,
@@ -210,7 +214,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoords( scalarViewType dofCoords ) const {
+    getDofCoords( ScalarViewType dofCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,
@@ -227,7 +231,7 @@ namespace Intrepid2 {
     
   virtual
   void
-  getDofCoeffs( scalarViewType dofCoeffs ) const {
+  getDofCoeffs( ScalarViewType dofCoeffs ) const {
 #ifdef HAVE_INTREPID2_DEBUG
     // Verify rank of output array.
     INTREPID2_TEST_FOR_EXCEPTION( dofCoeffs.rank() != 2, std::invalid_argument,
@@ -257,7 +261,7 @@ namespace Intrepid2 {
   private:
 
     /** \brief inverse of Generalized Vandermonde matrix (isotropic order) */
-    Kokkos::DynRankView<typename scalarViewType::value_type,ExecSpaceType> vinvLine_, vinvBubble_;
+    Kokkos::DynRankView<typename ScalarViewType::value_type,ExecSpaceType> vinvLine_, vinvBubble_;
   };
   
 }// namespace Intrepid2

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_QUAD_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_QUAD_In_FEMDef.hpp
@@ -271,6 +271,7 @@ namespace Intrepid2 {
     this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Quadrilateral<4> >() );
     this->basisType_         = BASIS_FEM_FIAT;
     this->basisCoordinates_  = COORDINATES_CARTESIAN;
+    this->functionSpace_     = FUNCTION_SPACE_HCURL;
 
     // initialize tags
     {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_QUAD_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_QUAD_In_FEMDef.hpp
@@ -350,7 +350,7 @@ namespace Intrepid2 {
                                       "counted tag index is not same as cardinality." );
       }
 
-      ordinal_type_array_1d_host tagView(&tags[0][0], this->basisCardinality_*4);
+      OrdinalTypeArray1DHost tagView(&tags[0][0], this->basisCardinality_*4);
 
       // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
       // tags are constructed on host

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_QUAD_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_QUAD_In_FEMDef.hpp
@@ -55,14 +55,14 @@ namespace Intrepid2 {
   namespace Impl {
 
     template<EOperator opType>
-    template<typename outputViewType,
+    template<typename OutputViewType,
              typename inputViewType,
              typename workViewType,
              typename vinvViewType>
     KOKKOS_INLINE_FUNCTION
     void
     Basis_HCURL_QUAD_In_FEM::Serial<opType>::
-    getValues(       outputViewType output,
+    getValues(       OutputViewType output,
                const inputViewType  input,
                      workViewType   work,
                const vinvViewType   vinvLine,
@@ -260,8 +260,8 @@ namespace Intrepid2 {
       cardLine = lineBasis.getCardinality(),
       cardBubble = bubbleBasis.getCardinality();
 
-    this->vinvLine_   = Kokkos::DynRankView<typename scalarViewType::value_type,SpT>("Hcurl::Quad::In::vinvLine", cardLine, cardLine);
-    this->vinvBubble_ = Kokkos::DynRankView<typename scalarViewType::value_type,SpT>("Hcurl::Quad::In::vinvBubble", cardBubble, cardBubble);
+    this->vinvLine_   = Kokkos::DynRankView<typename ScalarViewType::value_type,SpT>("Hcurl::Quad::In::vinvLine", cardLine, cardLine);
+    this->vinvBubble_ = Kokkos::DynRankView<typename ScalarViewType::value_type,SpT>("Hcurl::Quad::In::vinvBubble", cardBubble, cardBubble);
 
     lineBasis.getVandermondeInverse(this->vinvLine_);
     bubbleBasis.getVandermondeInverse(this->vinvBubble_);
@@ -365,14 +365,14 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoordsHost("dofCoordsHost", this->basisCardinality_, this->basisCellTopology_.getDimension());
 
     // dofCoeffs on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoeffsHost("dofCoeffsHost", this->basisCardinality_, this->basisCellTopology_.getDimension());
 
-    Kokkos::DynRankView<typename scalarViewType::value_type,SpT>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,SpT>
       dofCoordsLine("dofCoordsLine", cardLine, 1),
       dofCoordsBubble("dofCoordsBubble", cardBubble, 1);
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TET_I1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TET_I1_FEM.hpp
@@ -177,9 +177,13 @@ namespace Intrepid2 {
            typename pointValueType = double>
   class Basis_HCURL_TET_I1_FEM : public Basis<ExecSpaceType,outputValueType,pointValueType> {
   public:
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
     /** \brief  Constructor.
      */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TET_I1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TET_I1_FEM.hpp
@@ -181,9 +181,9 @@ namespace Intrepid2 {
     using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
     using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
 
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
+    using ordinal_type_array_1d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead");
+    using ordinal_type_array_2d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead");
+    using ordinal_type_array_3d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead");
 
     /** \brief  Constructor.
      */
@@ -193,9 +193,9 @@ namespace Intrepid2 {
     using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
     using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
     
-    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+    using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+    using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
+    using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TET_I1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TET_I1_FEM.hpp
@@ -114,11 +114,11 @@ namespace Intrepid2 {
       */
       template<EOperator opType>
       struct Serial {
-        template<typename outputViewType,
+        template<typename OutputViewType,
                  typename inputViewType>
         KOKKOS_INLINE_FUNCTION
         static void
-        getValues(       outputViewType output,
+        getValues(       OutputViewType output,
                    const inputViewType input );
 
       };
@@ -189,16 +189,20 @@ namespace Intrepid2 {
      */
     Basis_HCURL_TET_I1_FEM();
 
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarViewType  scalarViewType;
+    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    
+    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
-    getValues(       outputViewType outputValues,
-               const pointViewType  inputPoints,
+    getValues(       OutputViewType outputValues,
+               const PointViewType  inputPoints,
                const EOperator operatorType = OPERATOR_VALUE ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify arguments
@@ -216,7 +220,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoords( scalarViewType dofCoords ) const {
+    getDofCoords( ScalarViewType dofCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,
@@ -234,7 +238,7 @@ namespace Intrepid2 {
       
   virtual
   void
-  getDofCoeffs( scalarViewType dofCoeffs ) const {
+  getDofCoeffs( ScalarViewType dofCoeffs ) const {
 #ifdef HAVE_INTREPID2_DEBUG
     // Verify rank of output array.
     INTREPID2_TEST_FOR_EXCEPTION( dofCoeffs.rank() != 2, std::invalid_argument,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TET_I1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TET_I1_FEMDef.hpp
@@ -244,7 +244,7 @@ namespace Intrepid2 {
         1, 5, 0, 1 };
   
       //host tags
-      ordinal_type_array_1d_host tagView(&tags[0], 24);
+      OrdinalTypeArray1DHost tagView(&tags[0], 24);
     
       // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
       this->setOrdinalTagData(this->tagToOrdinal_,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TET_I1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TET_I1_FEMDef.hpp
@@ -224,6 +224,7 @@ namespace Intrepid2 {
     this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Tetrahedron<4> >() );
     this->basisType_         = BASIS_FEM_DEFAULT;
     this->basisCoordinates_  = COORDINATES_CARTESIAN;
+    this->functionSpace_     = FUNCTION_SPACE_HCURL;
   
     // initialize tags
     {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TET_I1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TET_I1_FEMDef.hpp
@@ -55,12 +55,12 @@ namespace Intrepid2 {
   namespace Impl {
     
     template<EOperator opType>
-    template<typename outputViewType,                                                                                 
+    template<typename OutputViewType,                                                                                 
              typename inputViewType>  
     KOKKOS_INLINE_FUNCTION
     void
     Basis_HCURL_TET_I1_FEM::Serial<opType>::
-    getValues(       outputViewType output,                                                                           
+    getValues(       OutputViewType output,                                                                           
                const inputViewType input ) {  
       switch (opType) {
       case OPERATOR_VALUE: {
@@ -257,7 +257,7 @@ namespace Intrepid2 {
                               posDfOrd);
     }
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoords("dofCoordsHost", this->basisCardinality_,this->basisCellTopology_.getDimension());
 
     dofCoords(0,0) = 0.5;   dofCoords(0,1) = 0.0; dofCoords(0,2) = 0.0;
@@ -271,7 +271,7 @@ namespace Intrepid2 {
     Kokkos::deep_copy(this->dofCoords_, dofCoords);
 
     // dofCoeffs on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoeffs("dofCoeffsHost", this->basisCardinality_,this->basisCellTopology_.getDimension());
 
     dofCoeffs(0,0) =  1.0;   dofCoeffs(0,1) =  0.0; dofCoeffs(0,2) =  0.0;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TET_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TET_In_FEM.hpp
@@ -214,17 +214,22 @@ class Basis_HCURL_TET_In_FEM
       const EPointType   pointType = POINTTYPE_EQUISPACED);
 
 
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarViewType  scalarViewType;
+  using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+  using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+  using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+  
+  INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+  INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+  INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+
   typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarType  scalarType;
 
   using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
   virtual
   void
-  getValues(       outputViewType outputValues,
-      const pointViewType  inputPoints,
+  getValues(       OutputViewType outputValues,
+      const PointViewType  inputPoints,
       const EOperator operatorType = OPERATOR_VALUE) const {
 #ifdef HAVE_INTREPID2_DEBUG
     Intrepid2::getValues_HCURL_Args(outputValues,
@@ -243,7 +248,7 @@ class Basis_HCURL_TET_In_FEM
 
   virtual
   void
-  getDofCoords( scalarViewType dofCoords ) const {
+  getDofCoords( ScalarViewType dofCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
     // Verify rank of output array.
     INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,
@@ -260,7 +265,7 @@ class Basis_HCURL_TET_In_FEM
   
   virtual
   void
-  getDofCoeffs( scalarViewType dofCoeffs ) const {
+  getDofCoeffs( ScalarViewType dofCoeffs ) const {
 #ifdef HAVE_INTREPID2_DEBUG
     // Verify rank of output array.
     INTREPID2_TEST_FOR_EXCEPTION( dofCoeffs.rank() != 2, std::invalid_argument,
@@ -276,7 +281,7 @@ class Basis_HCURL_TET_In_FEM
   }
 
   void
-  getExpansionCoeffs( scalarViewType coeffs ) const {
+  getExpansionCoeffs( ScalarViewType coeffs ) const {
     // has to be same rank and dimensions
     Kokkos::deep_copy(coeffs, this->coeffs_);
   }

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TET_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TET_In_FEM.hpp
@@ -218,9 +218,9 @@ class Basis_HCURL_TET_In_FEM
   using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
   using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
   
-  INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-  INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
-  INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+  using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+  using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
+  using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
 
   typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarType  scalarType;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TET_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TET_In_FEM.hpp
@@ -204,9 +204,9 @@ template<typename ExecSpaceType = void,
 class Basis_HCURL_TET_In_FEM
     : public Basis<ExecSpaceType,outputValueType,pointValueType> {
     public:
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost OrdinalTypeArray1DHost;
+  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost OrdinalTypeArray2DHost;
+  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost OrdinalTypeArray3DHost;
 
   /** \brief  Constructor.
    */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TET_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TET_In_FEMDef.hpp
@@ -564,7 +564,7 @@ Basis_HCURL_TET_In_FEM( const ordinal_type order,
     const ordinal_type posScOrd = 1;        // position in the tag, counting from 0, of the subcell ordinal
     const ordinal_type posDfOrd = 2;        // position in the tag, counting from 0, of DoF ordinal relative to the subcell
 
-    ordinal_type_array_1d_host tagView(&tags[0][0], card*tagSize);
+    OrdinalTypeArray1DHost tagView(&tags[0][0], card*tagSize);
 
     // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
     // tags are constructed on host

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TET_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TET_In_FEMDef.hpp
@@ -60,14 +60,14 @@ namespace Intrepid2 {
 namespace Impl {
 
 template<EOperator opType>
-template<typename outputViewType,
+template<typename OutputViewType,
 typename inputViewType,
 typename workViewType,
 typename vinvViewType>
 KOKKOS_INLINE_FUNCTION
 void
 Basis_HCURL_TET_In_FEM::Serial<opType>::
-getValues(       outputViewType output,
+getValues(       OutputViewType output,
     const inputViewType  input,
           workViewType   work,
     const vinvViewType   coeffs ) {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TET_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TET_In_FEMDef.hpp
@@ -200,6 +200,7 @@ Basis_HCURL_TET_In_FEM( const ordinal_type order,
   this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Tetrahedron<4> >() );
   this->basisType_         = BASIS_FEM_FIAT;
   this->basisCoordinates_  = COORDINATES_CARTESIAN;
+  this->functionSpace_     = FUNCTION_SPACE_HCURL;
 
   const ordinal_type card = this->basisCardinality_;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_I1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_I1_FEM.hpp
@@ -184,9 +184,9 @@ namespace Intrepid2 {
     using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
     using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
 
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
+    using ordinal_type_array_1d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead");
+    using ordinal_type_array_2d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead");
+    using ordinal_type_array_3d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead");
 
     /** \brief  Constructor.
      */
@@ -196,9 +196,9 @@ namespace Intrepid2 {
     using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
     using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
     
-    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+    using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+    using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
+    using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_I1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_I1_FEM.hpp
@@ -180,9 +180,13 @@ namespace Intrepid2 {
             typename pointValueType = double >
   class Basis_HCURL_TRI_I1_FEM : public Basis<ExecSpaceType, outputValueType, pointValueType> {
   public:
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
     /** \brief  Constructor.
      */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_I1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_I1_FEM.hpp
@@ -106,11 +106,11 @@ namespace Intrepid2 {
       */
       template<EOperator opType>
       struct Serial {
-        template<typename outputViewType,
+        template<typename OutputViewType,
                  typename inputViewType>
         KOKKOS_INLINE_FUNCTION
         static void
-        getValues(       outputViewType output,
+        getValues(       OutputViewType output,
                    const inputViewType input );
 
       };
@@ -192,16 +192,20 @@ namespace Intrepid2 {
      */
     Basis_HCURL_TRI_I1_FEM();
 
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarViewType  scalarViewType;
+    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    
+    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
-    getValues(       outputViewType outputValues,
-               const pointViewType  inputPoints,
+    getValues(       OutputViewType outputValues,
+               const PointViewType  inputPoints,
                const EOperator operatorType = OPERATOR_VALUE ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify arguments
@@ -219,7 +223,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoords( scalarViewType dofCoords ) const {
+    getDofCoords( ScalarViewType dofCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,
@@ -236,7 +240,7 @@ namespace Intrepid2 {
     
   virtual
   void
-  getDofCoeffs( scalarViewType dofCoeffs ) const {
+  getDofCoeffs( ScalarViewType dofCoeffs ) const {
 #ifdef HAVE_INTREPID2_DEBUG
     // Verify rank of output array.
     INTREPID2_TEST_FOR_EXCEPTION( dofCoeffs.rank() != 2, std::invalid_argument,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_I1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_I1_FEMDef.hpp
@@ -55,12 +55,12 @@ namespace Intrepid2 {
   namespace Impl {                                                                                                    
                                                                                                                       
     template<EOperator opType>                                                                                        
-    template<typename outputViewType,                                                                                 
+    template<typename OutputViewType,                                                                                 
              typename inputViewType>                                                                                  
     KOKKOS_INLINE_FUNCTION                                                                                            
     void     
     Basis_HCURL_TRI_I1_FEM::Serial<opType>::
-    getValues(       outputViewType output,                                                                           
+    getValues(       OutputViewType output,                                                                           
                const inputViewType input ) {
       switch (opType) {
       case OPERATOR_VALUE: {
@@ -216,7 +216,7 @@ namespace Intrepid2 {
   
     }
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoords("dofCoordsHost", this->basisCardinality_,this->basisCellTopology_.getDimension());
 
     dofCoords(0,0) =  0.5;   dofCoords(0,1) =  0.0;
@@ -227,7 +227,7 @@ namespace Intrepid2 {
     Kokkos::deep_copy(this->dofCoords_, dofCoords);
 
     // dofCoeffs on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoeffs("dofCoeffsHost", this->basisCardinality_,this->basisCellTopology_.getDimension());
 
     dofCoeffs(0,0) =  1.0;   dofCoeffs(0,1) =  0.0;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_I1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_I1_FEMDef.hpp
@@ -202,7 +202,7 @@ namespace Intrepid2 {
         1, 2, 0, 1 };
 
       // host tags
-      ordinal_type_array_1d_host tagView(&tags[0], 12);
+      OrdinalTypeArray1DHost tagView(&tags[0], 12);
     
       // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
       this->setOrdinalTagData(this->tagToOrdinal_,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_I1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_I1_FEMDef.hpp
@@ -185,6 +185,7 @@ namespace Intrepid2 {
     this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Triangle<3> >() );
     this->basisType_         = BASIS_FEM_DEFAULT;
     this->basisCoordinates_  = COORDINATES_CARTESIAN;
+    this->functionSpace_     = FUNCTION_SPACE_HCURL;
 
     // initialize tags
     {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_In_FEM.hpp
@@ -204,17 +204,22 @@ class Basis_HCURL_TRI_In_FEM
       const EPointType   pointType = POINTTYPE_EQUISPACED);
 
 
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarViewType  scalarViewType;
+  using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+  using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+  using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+  
+  INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+  INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+  INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+
   typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarType  scalarType;
 
   using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
   virtual
   void
-  getValues(       outputViewType outputValues,
-      const pointViewType  inputPoints,
+  getValues(       OutputViewType outputValues,
+      const PointViewType  inputPoints,
       const EOperator operatorType = OPERATOR_VALUE) const {
 #ifdef HAVE_INTREPID2_DEBUG
     Intrepid2::getValues_HCURL_Args(outputValues,
@@ -233,7 +238,7 @@ class Basis_HCURL_TRI_In_FEM
 
   virtual
   void
-  getDofCoords( scalarViewType dofCoords ) const {
+  getDofCoords( ScalarViewType dofCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
     // Verify rank of output array.
     INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,
@@ -250,7 +255,7 @@ class Basis_HCURL_TRI_In_FEM
 
   virtual
   void
-  getDofCoeffs( scalarViewType dofCoeffs ) const {
+  getDofCoeffs( ScalarViewType dofCoeffs ) const {
 #ifdef HAVE_INTREPID2_DEBUG
     // Verify rank of output array.
     INTREPID2_TEST_FOR_EXCEPTION( dofCoeffs.rank() != 2, std::invalid_argument,
@@ -266,7 +271,7 @@ class Basis_HCURL_TRI_In_FEM
   }
 
   void
-  getExpansionCoeffs( scalarViewType coeffs ) const {
+  getExpansionCoeffs( ScalarViewType coeffs ) const {
     // has to be same rank and dimensions
     Kokkos::deep_copy(coeffs, this->coeffs_);
   }

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_In_FEM.hpp
@@ -194,9 +194,9 @@ template<typename ExecSpaceType = void,
 class Basis_HCURL_TRI_In_FEM
     : public Basis<ExecSpaceType,outputValueType,pointValueType> {
     public:
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost OrdinalTypeArray1DHost;
+  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost OrdinalTypeArray2DHost;
+  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost OrdinalTypeArray3DHost;
 
   /** \brief  Constructor.
    */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_In_FEM.hpp
@@ -208,9 +208,9 @@ class Basis_HCURL_TRI_In_FEM
   using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
   using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
   
-  INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-  INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
-  INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+  using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+  using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
+  using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
 
   typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarType  scalarType;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_In_FEMDef.hpp
@@ -59,14 +59,14 @@ namespace Intrepid2 {
   namespace Impl {
 
     template<EOperator opType>
-    template<typename outputViewType,
+    template<typename OutputViewType,
              typename inputViewType,
              typename workViewType,
              typename vinvViewType>
     KOKKOS_INLINE_FUNCTION
     void
     Basis_HCURL_TRI_In_FEM::Serial<opType>::
-    getValues(       outputViewType output,
+    getValues(       OutputViewType output,
                const inputViewType  input,
                      workViewType   work,
                const vinvViewType   coeffs ) {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_In_FEMDef.hpp
@@ -195,6 +195,7 @@ namespace Intrepid2 {
     this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Triangle<3> >() );
     this->basisType_         = BASIS_FEM_FIAT;
     this->basisCoordinates_  = COORDINATES_CARTESIAN;
+    this->functionSpace_     = FUNCTION_SPACE_HCURL;
 
     const ordinal_type card = this->basisCardinality_;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_TRI_In_FEMDef.hpp
@@ -457,7 +457,7 @@ namespace Intrepid2 {
       const ordinal_type posScOrd = 1;        // position in the tag, counting from 0, of the subcell ordinal
       const ordinal_type posDfOrd = 2;        // position in the tag, counting from 0, of DoF ordinal relative to the subcell
 
-      ordinal_type_array_1d_host tagView(&tags[0][0], card*tagSize);
+      OrdinalTypeArray1DHost tagView(&tags[0][0], card*tagSize);
 
       // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
       // tags are constructed on host

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_WEDGE_I1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_WEDGE_I1_FEM.hpp
@@ -183,9 +183,13 @@ namespace Intrepid2 {
            typename pointValueType = double>
   class Basis_HCURL_WEDGE_I1_FEM : public Basis<ExecSpaceType, outputValueType, pointValueType> {
   public:
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
     /** \brief  Constructor.
      */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_WEDGE_I1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_WEDGE_I1_FEM.hpp
@@ -120,11 +120,11 @@ namespace Intrepid2 {
       */
       template<EOperator opType>
       struct Serial {
-        template<typename outputViewType,
+        template<typename OutputViewType,
                  typename inputViewType>
         KOKKOS_INLINE_FUNCTION
         static void
-        getValues(       outputViewType output,
+        getValues(       OutputViewType output,
                    const inputViewType input );
 
       };
@@ -195,16 +195,20 @@ namespace Intrepid2 {
      */
     Basis_HCURL_WEDGE_I1_FEM();
 
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarViewType  scalarViewType;
+    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    
+    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
-    getValues(       outputViewType outputValues,
-               const pointViewType  inputPoints,
+    getValues(       OutputViewType outputValues,
+               const PointViewType  inputPoints,
                const EOperator operatorType = OPERATOR_VALUE ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify arguments
@@ -222,7 +226,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoords( scalarViewType dofCoords ) const {
+    getDofCoords( ScalarViewType dofCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_WEDGE_I1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_WEDGE_I1_FEM.hpp
@@ -187,9 +187,9 @@ namespace Intrepid2 {
     using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
     using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
 
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
+    using ordinal_type_array_1d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead");
+    using ordinal_type_array_2d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead");
+    using ordinal_type_array_3d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead");
 
     /** \brief  Constructor.
      */
@@ -199,9 +199,9 @@ namespace Intrepid2 {
     using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
     using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
     
-    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+    using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+    using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
+    using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_WEDGE_I1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_WEDGE_I1_FEMDef.hpp
@@ -235,6 +235,7 @@ namespace Intrepid2 {
     this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Wedge<6> >() );
     this->basisType_         = BASIS_FEM_DEFAULT;
     this->basisCoordinates_  = COORDINATES_CARTESIAN;
+    this->functionSpace_     = FUNCTION_SPACE_HCURL;
 
 
     // initialize tags

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_WEDGE_I1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_WEDGE_I1_FEMDef.hpp
@@ -55,12 +55,12 @@ namespace Intrepid2 {
   namespace Impl {
 
     template<EOperator opType>
-    template<typename outputViewType,
+    template<typename OutputViewType,
              typename inputViewType>
     KOKKOS_INLINE_FUNCTION
     void
     Basis_HCURL_WEDGE_I1_FEM::Serial<opType>::
-    getValues(       outputViewType output,
+    getValues(       OutputViewType output,
                const inputViewType input ) {
       switch (opType) {
       case OPERATOR_VALUE: {
@@ -272,7 +272,7 @@ namespace Intrepid2 {
                               posDfOrd);
     }
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoords("dofCoordsHost", this->basisCardinality_,this->basisCellTopology_.getDimension());
 
     dofCoords(0,0) =  0.5;  dofCoords(0,1) =  0.0;  dofCoords(0,2) = -1.0;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_WEDGE_I1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_WEDGE_I1_FEMDef.hpp
@@ -259,7 +259,7 @@ namespace Intrepid2 {
         1, 8, 0, 1 };
 
       //host tags
-      ordinal_type_array_1d_host tagView(&tags[0],36);
+      OrdinalTypeArray1DHost tagView(&tags[0],36);
 
       // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
       this->setOrdinalTagData(this->tagToOrdinal_,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_HEX_I1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_HEX_I1_FEM.hpp
@@ -178,9 +178,13 @@ namespace Intrepid2 {
            typename pointValueType = double>
   class Basis_HDIV_HEX_I1_FEM : public Basis<ExecSpaceType,outputValueType,pointValueType> {
   public:
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
     template<EOperator opType>
     struct Serial {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_HEX_I1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_HEX_I1_FEM.hpp
@@ -182,9 +182,9 @@ namespace Intrepid2 {
     using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
     using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
 
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
+    using ordinal_type_array_1d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead");
+    using ordinal_type_array_2d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead");
+    using ordinal_type_array_3d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead");
 
     template<EOperator opType>
     struct Serial {
@@ -206,9 +206,9 @@ namespace Intrepid2 {
     using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
     using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
     
-    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+    using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+    using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
+    using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_HEX_I1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_HEX_I1_FEM.hpp
@@ -115,11 +115,11 @@ namespace Intrepid2 {
       */
       template<EOperator opType>
       struct Serial {
-        template<typename outputViewType,
+        template<typename OutputViewType,
                  typename inputViewType>
         KOKKOS_INLINE_FUNCTION
         static void
-        getValues(       outputViewType output,
+        getValues(       OutputViewType output,
                    const inputViewType  input );
       };
 
@@ -202,16 +202,20 @@ namespace Intrepid2 {
      */
     Basis_HDIV_HEX_I1_FEM();
 
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarViewType  scalarViewType;
+    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    
+    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
-    getValues(       outputViewType outputValues,
-               const pointViewType  inputPoints,
+    getValues(       OutputViewType outputValues,
+               const PointViewType  inputPoints,
                const EOperator operatorType = OPERATOR_VALUE ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       Intrepid2::getValues_HDIV_Args(outputValues,
@@ -228,7 +232,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoords( scalarViewType dofCoords ) const {
+    getDofCoords( ScalarViewType dofCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,
@@ -245,7 +249,7 @@ namespace Intrepid2 {
 
   virtual
   void
-  getDofCoeffs( scalarViewType dofCoeffs ) const {
+  getDofCoeffs( ScalarViewType dofCoeffs ) const {
 #ifdef HAVE_INTREPID2_DEBUG
     // Verify rank of output array.
     INTREPID2_TEST_FOR_EXCEPTION( dofCoeffs.rank() != 2, std::invalid_argument,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_HEX_I1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_HEX_I1_FEMDef.hpp
@@ -225,7 +225,7 @@ namespace Intrepid2 {
                                  2, 5, 0, 1 };
 
       // when exec space is device, this wrapping relies on uvm.
-      ordinal_type_array_1d_host tagView(&tags[0], 24);
+      OrdinalTypeArray1DHost tagView(&tags[0], 24);
 
       // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
       this->setOrdinalTagData(this->tagToOrdinal_,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_HEX_I1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_HEX_I1_FEMDef.hpp
@@ -206,6 +206,7 @@ namespace Intrepid2 {
     this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Hexahedron<8> >() );
     this->basisType_         = BASIS_FEM_DEFAULT;
     this->basisCoordinates_  = COORDINATES_CARTESIAN;
+    this->functionSpace_     = FUNCTION_SPACE_HDIV;
 
     // initialize tags
     {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_HEX_I1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_HEX_I1_FEMDef.hpp
@@ -55,12 +55,12 @@ namespace Intrepid2 {
   namespace Impl {
 
     template<EOperator opType>
-    template<typename outputViewType,
+    template<typename OutputViewType,
              typename inputViewType>
     KOKKOS_INLINE_FUNCTION
     void
     Basis_HDIV_HEX_I1_FEM::Serial<opType>::
-    getValues(       outputViewType output,
+    getValues(       OutputViewType output,
                const inputViewType input ) {
       switch (opType) {
       case OPERATOR_VALUE : {
@@ -238,7 +238,7 @@ namespace Intrepid2 {
                               posDfOrd);
     }
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoords("dofCoordsHost", this->basisCardinality_,this->basisCellTopology_.getDimension());
 
     dofCoords(0,0)  =  0.0;   dofCoords(0,1)  = -1.0;   dofCoords(0,2)  =  0.0;
@@ -252,7 +252,7 @@ namespace Intrepid2 {
     Kokkos::deep_copy(this->dofCoords_, dofCoords);
 
     // dofCoeffs on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoeffs("dofCoeffsHost", this->basisCardinality_,this->basisCellTopology_.getDimension());
 
     // for HDIV_HEX_I1 dofCoeffs are the normals on the hexahedron faces (with normals magnitude equal to faces' areas)

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_HEX_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_HEX_In_FEM.hpp
@@ -183,16 +183,20 @@ namespace Intrepid2 {
     Basis_HDIV_HEX_In_FEM(const ordinal_type order,
                           const EPointType   pointType = POINTTYPE_EQUISPACED);
 
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarViewType scalarViewType;
+    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    
+    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
-    getValues(       outputViewType outputValues,
-               const pointViewType  inputPoints,
+    getValues(       OutputViewType outputValues,
+               const PointViewType  inputPoints,
                const EOperator operatorType = OPERATOR_VALUE ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       Intrepid2::getValues_HDIV_Args(outputValues,
@@ -212,7 +216,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoords( scalarViewType dofCoords ) const {
+    getDofCoords( ScalarViewType dofCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,
@@ -230,7 +234,7 @@ namespace Intrepid2 {
       
   virtual
   void
-  getDofCoeffs( scalarViewType dofCoeffs ) const {
+  getDofCoeffs( ScalarViewType dofCoeffs ) const {
 #ifdef HAVE_INTREPID2_DEBUG
     // Verify rank of output array.
     INTREPID2_TEST_FOR_EXCEPTION( dofCoeffs.rank() != 2, std::invalid_argument,
@@ -260,7 +264,7 @@ namespace Intrepid2 {
   private:
 
     /** \brief inverse of Generalized Vandermonde matrix (isotropic order) */
-    Kokkos::DynRankView<typename scalarViewType::value_type,ExecSpaceType> vinvLine_, vinvBubble_;
+    Kokkos::DynRankView<typename ScalarViewType::value_type,ExecSpaceType> vinvLine_, vinvBubble_;
   };
 
 }// namespace Intrepid2

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_HEX_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_HEX_In_FEM.hpp
@@ -170,9 +170,13 @@ namespace Intrepid2 {
   class Basis_HDIV_HEX_In_FEM
     : public Basis<ExecSpaceType,outputValueType,pointValueType> {
   public:
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
     /** \brief  Constructor.
      */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_HEX_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_HEX_In_FEM.hpp
@@ -174,9 +174,9 @@ namespace Intrepid2 {
     using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
     using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
 
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
+    using ordinal_type_array_1d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead");
+    using ordinal_type_array_2d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead");
+    using ordinal_type_array_3d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead");
 
     /** \brief  Constructor.
      */
@@ -187,9 +187,9 @@ namespace Intrepid2 {
     using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
     using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
     
-    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+    using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+    using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
+    using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_HEX_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_HEX_In_FEMDef.hpp
@@ -459,7 +459,7 @@ namespace Intrepid2 {
                                       "counted tag index is not same as cardinality." );
       }
 
-      ordinal_type_array_1d_host tagView(&tags[0][0], this->basisCardinality_*4);
+      OrdinalTypeArray1DHost tagView(&tags[0][0], this->basisCardinality_*4);
 
       // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
       // tags are constructed on host

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_HEX_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_HEX_In_FEMDef.hpp
@@ -55,14 +55,14 @@ namespace Intrepid2 {
   namespace Impl {
 
     template<EOperator opType>
-    template<typename outputViewType,
+    template<typename OutputViewType,
              typename inputViewType,
              typename workViewType,
              typename vinvViewType>
     KOKKOS_INLINE_FUNCTION
     void
     Basis_HDIV_HEX_In_FEM::Serial<opType>::
-    getValues(       outputViewType output,
+    getValues(       OutputViewType output,
                const inputViewType  input,
                      workViewType   work,
                const vinvViewType   vinvLine,
@@ -336,8 +336,8 @@ namespace Intrepid2 {
       cardLine = lineBasis.getCardinality(),
       cardBubble = bubbleBasis.getCardinality();
 
-    this->vinvLine_   = Kokkos::DynRankView<typename scalarViewType::value_type,SpT>("Hcurl::Hex::In::vinvLine", cardLine, cardLine);
-    this->vinvBubble_ = Kokkos::DynRankView<typename scalarViewType::value_type,SpT>("Hcurl::Hex::In::vinvBubble", cardBubble, cardBubble);
+    this->vinvLine_   = Kokkos::DynRankView<typename ScalarViewType::value_type,SpT>("Hcurl::Hex::In::vinvLine", cardLine, cardLine);
+    this->vinvBubble_ = Kokkos::DynRankView<typename ScalarViewType::value_type,SpT>("Hcurl::Hex::In::vinvBubble", cardBubble, cardBubble);
 
     lineBasis.getVandermondeInverse(this->vinvLine_);
     bubbleBasis.getVandermondeInverse(this->vinvBubble_);
@@ -474,14 +474,14 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoordsHost("dofCoordsHost", this->basisCardinality_, this->basisCellTopology_.getDimension());
 
     // dofCoeffs on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoeffsHost("dofCoeffsHost", this->basisCardinality_, this->basisCellTopology_.getDimension());
 
-    Kokkos::DynRankView<typename scalarViewType::value_type,SpT>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,SpT>
       dofCoordsLine("dofCoordsLine", cardLine, 1),
       dofCoordsBubble("dofCoordsBubble", cardBubble, 1);
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_HEX_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_HEX_In_FEMDef.hpp
@@ -347,6 +347,7 @@ namespace Intrepid2 {
     this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Hexahedron<8> >() );
     this->basisType_         = BASIS_FEM_FIAT;
     this->basisCoordinates_  = COORDINATES_CARTESIAN;
+    this->functionSpace_     = FUNCTION_SPACE_HDIV;
 
     // initialize tags
     {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_QUAD_I1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_QUAD_I1_FEM.hpp
@@ -177,9 +177,13 @@ namespace Intrepid2 {
            typename pointValueType = double>
   class Basis_HDIV_QUAD_I1_FEM : public Basis<ExecSpaceType,outputValueType,pointValueType> {
   public:
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
 
     /** \brief  Constructor.

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_QUAD_I1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_QUAD_I1_FEM.hpp
@@ -181,9 +181,9 @@ namespace Intrepid2 {
     using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
     using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
 
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
+    using ordinal_type_array_1d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead");
+    using ordinal_type_array_2d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead");
+    using ordinal_type_array_3d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead");
 
 
     /** \brief  Constructor.
@@ -194,9 +194,9 @@ namespace Intrepid2 {
     using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
     using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
     
-    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+    using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+    using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
+    using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_QUAD_I1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_QUAD_I1_FEM.hpp
@@ -114,11 +114,11 @@ namespace Intrepid2 {
       */
       template<EOperator opType>
       struct Serial {
-        template<typename outputViewType,
+        template<typename OutputViewType,
                  typename inputViewType>
         KOKKOS_INLINE_FUNCTION
         static void
-        getValues(       outputViewType output,
+        getValues(       OutputViewType output,
                    const inputViewType input );
 
       };
@@ -190,16 +190,20 @@ namespace Intrepid2 {
      */
     Basis_HDIV_QUAD_I1_FEM();
 
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarViewType  scalarViewType;
+    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    
+    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
-    getValues(       outputViewType outputValues,
-               const pointViewType  inputPoints,
+    getValues(       OutputViewType outputValues,
+               const PointViewType  inputPoints,
                const EOperator operatorType = OPERATOR_VALUE ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify arguments
@@ -217,7 +221,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoords( scalarViewType dofCoords ) const {
+    getDofCoords( ScalarViewType dofCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,
@@ -234,7 +238,7 @@ namespace Intrepid2 {
     
   virtual
   void
-  getDofCoeffs( scalarViewType dofCoeffs ) const {
+  getDofCoeffs( ScalarViewType dofCoeffs ) const {
 #ifdef HAVE_INTREPID2_DEBUG
     // Verify rank of output array.
     INTREPID2_TEST_FOR_EXCEPTION( dofCoeffs.rank() != 2, std::invalid_argument,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_QUAD_I1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_QUAD_I1_FEMDef.hpp
@@ -56,12 +56,12 @@ namespace Intrepid2 {
   namespace Impl {
 
     template<EOperator opType>
-    template<typename outputViewType,
+    template<typename OutputViewType,
              typename inputViewType>
     KOKKOS_INLINE_FUNCTION
     void
     Basis_HDIV_QUAD_I1_FEM::Serial<opType>::
-    getValues(       outputViewType output,
+    getValues(       OutputViewType output,
                const inputViewType input ) {
       switch (opType) {
       case OPERATOR_VALUE : {          // outputValues is a rank-3 array with dimensions (basisCardinality_, dim0, spaceDim)
@@ -222,7 +222,7 @@ namespace Intrepid2 {
                               posDfOrd);
     }
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoords("dofCoordsHost", this->basisCardinality_,this->basisCellTopology_.getDimension());
 
     dofCoords(0,0)  =  0.0;   dofCoords(0,1)  = -1.0;
@@ -234,7 +234,7 @@ namespace Intrepid2 {
     Kokkos::deep_copy(this->dofCoords_, dofCoords);
 
     // dofCoeffs on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoeffs("dofCoeffsHost", this->basisCardinality_,this->basisCellTopology_.getDimension());
 
     // for HDIV_QUAD_I1 dofCoeffs are the normals on the quadrilateral edges (with normals magnitude equal to edges' lengths)

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_QUAD_I1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_QUAD_I1_FEMDef.hpp
@@ -209,7 +209,7 @@ namespace Intrepid2 {
 
 
       // when exec space is device, this wrapping relies on uvm.
-      ordinal_type_array_1d_host tagView(&tags[0], 16);
+      OrdinalTypeArray1DHost tagView(&tags[0], 16);
 
       // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
       this->setOrdinalTagData(this->tagToOrdinal_,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_QUAD_I1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_QUAD_I1_FEMDef.hpp
@@ -191,6 +191,7 @@ namespace Intrepid2 {
     this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Quadrilateral<4> >() );
     this->basisType_         = BASIS_FEM_DEFAULT;
     this->basisCoordinates_  = COORDINATES_CARTESIAN;
+    this->functionSpace_     = FUNCTION_SPACE_HDIV;
 
     // initialize tags
     {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_QUAD_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_QUAD_In_FEM.hpp
@@ -180,16 +180,20 @@ namespace Intrepid2 {
     Basis_HDIV_QUAD_In_FEM(const ordinal_type order,
                             const EPointType   pointType = POINTTYPE_EQUISPACED);
 
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarViewType  scalarViewType;
+    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    
+    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
-    getValues(       outputViewType outputValues,
-               const pointViewType  inputPoints,
+    getValues(       OutputViewType outputValues,
+               const PointViewType  inputPoints,
                const EOperator operatorType = OPERATOR_VALUE ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       Intrepid2::getValues_HDIV_Args(outputValues,
@@ -208,7 +212,7 @@ namespace Intrepid2 {
     }
     virtual
     void
-    getDofCoords( scalarViewType dofCoords ) const {
+    getDofCoords( ScalarViewType dofCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,
@@ -225,7 +229,7 @@ namespace Intrepid2 {
     
   virtual
   void
-  getDofCoeffs( scalarViewType dofCoeffs ) const {
+  getDofCoeffs( ScalarViewType dofCoeffs ) const {
 #ifdef HAVE_INTREPID2_DEBUG
     // Verify rank of output array.
     INTREPID2_TEST_FOR_EXCEPTION( dofCoeffs.rank() != 2, std::invalid_argument,
@@ -255,7 +259,7 @@ namespace Intrepid2 {
   private:
 
     /** \brief inverse of Generalized Vandermonde matrix (isotropic order) */
-    Kokkos::DynRankView<typename scalarViewType::value_type,ExecSpaceType> vinvLine_, vinvBubble_;
+    Kokkos::DynRankView<typename ScalarViewType::value_type,ExecSpaceType> vinvLine_, vinvBubble_;
   };
 
 }// namespace Intrepid2

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_QUAD_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_QUAD_In_FEM.hpp
@@ -171,9 +171,9 @@ namespace Intrepid2 {
     using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
     using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
 
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
+    using ordinal_type_array_1d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead");
+    using ordinal_type_array_2d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead");
+    using ordinal_type_array_3d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead");
 
     /** \brief  Constructor.
      */
@@ -184,9 +184,9 @@ namespace Intrepid2 {
     using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
     using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
     
-    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+    using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+    using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
+    using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_QUAD_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_QUAD_In_FEM.hpp
@@ -167,9 +167,13 @@ namespace Intrepid2 {
   class Basis_HDIV_QUAD_In_FEM
     : public Basis<ExecSpaceType,outputValueType,pointValueType> {
   public:
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
     /** \brief  Constructor.
      */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_QUAD_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_QUAD_In_FEMDef.hpp
@@ -349,7 +349,7 @@ namespace Intrepid2 {
                                       "counted tag index is not same as cardinality." );
       }
 
-      ordinal_type_array_1d_host tagView(&tags[0][0], this->basisCardinality_*4);
+      OrdinalTypeArray1DHost tagView(&tags[0][0], this->basisCardinality_*4);
 
       // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
       // tags are constructed on host

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_QUAD_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_QUAD_In_FEMDef.hpp
@@ -270,6 +270,7 @@ namespace Intrepid2 {
     this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Quadrilateral<4> >() );
     this->basisType_         = BASIS_FEM_FIAT;
     this->basisCoordinates_  = COORDINATES_CARTESIAN;
+    this->functionSpace_     = FUNCTION_SPACE_HDIV;
 
     // initialize tags
     {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_QUAD_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_QUAD_In_FEMDef.hpp
@@ -55,14 +55,14 @@ namespace Intrepid2 {
   namespace Impl {
 
     template<EOperator opType>
-    template<typename outputViewType,
+    template<typename OutputViewType,
              typename inputViewType,
              typename workViewType,
              typename vinvViewType>
     KOKKOS_INLINE_FUNCTION
     void
     Basis_HDIV_QUAD_In_FEM::Serial<opType>::
-    getValues(       outputViewType output,
+    getValues(       OutputViewType output,
                const inputViewType  input,
                      workViewType   work,
                const vinvViewType   vinvLine,
@@ -259,8 +259,8 @@ namespace Intrepid2 {
       cardLine = lineBasis.getCardinality(),
       cardBubble = bubbleBasis.getCardinality();
 
-    this->vinvLine_   = Kokkos::DynRankView<typename scalarViewType::value_type,SpT>("Hdiv::Quad::In::vinvLine", cardLine, cardLine);
-    this->vinvBubble_ = Kokkos::DynRankView<typename scalarViewType::value_type,SpT>("Hdiv::Quad::In::vinvBubble", cardBubble, cardBubble);
+    this->vinvLine_   = Kokkos::DynRankView<typename ScalarViewType::value_type,SpT>("Hdiv::Quad::In::vinvLine", cardLine, cardLine);
+    this->vinvBubble_ = Kokkos::DynRankView<typename ScalarViewType::value_type,SpT>("Hdiv::Quad::In::vinvBubble", cardBubble, cardBubble);
 
     lineBasis.getVandermondeInverse(this->vinvLine_);
     bubbleBasis.getVandermondeInverse(this->vinvBubble_);
@@ -364,14 +364,14 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoordsHost("dofCoordsHost", this->basisCardinality_, this->basisCellTopology_.getDimension());
 
     // dofCoeffs on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoeffsHost("dofCoeffsHost", this->basisCardinality_, this->basisCellTopology_.getDimension());
 
-    Kokkos::DynRankView<typename scalarViewType::value_type,SpT>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,SpT>
       dofCoordsLine("dofCoordsLine", cardLine, 1),
       dofCoordsBubble("dofCoordsBubble", cardBubble, 1);
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_I1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_I1_FEM.hpp
@@ -176,9 +176,13 @@ namespace Intrepid2 {
            typename pointValueType = double>
   class Basis_HDIV_TET_I1_FEM: public Basis<ExecSpaceType,outputValueType,pointValueType> {
   public:
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
     /** \brief  Constructor.
      */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_I1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_I1_FEM.hpp
@@ -112,11 +112,11 @@ namespace Intrepid2 {
       */
       template<EOperator opType>
       struct Serial {
-        template<typename outputViewType,
+        template<typename OutputViewType,
                  typename inputViewType>
         KOKKOS_INLINE_FUNCTION
         static void
-        getValues(       outputViewType output,
+        getValues(       OutputViewType output,
                    const inputViewType input );
 
       };
@@ -188,16 +188,20 @@ namespace Intrepid2 {
      */
     Basis_HDIV_TET_I1_FEM();
 
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarViewType  scalarViewType;
+    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    
+    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
-    getValues(       outputViewType outputValues,
-               const pointViewType  inputPoints,
+    getValues(       OutputViewType outputValues,
+               const PointViewType  inputPoints,
                const EOperator operatorType = OPERATOR_VALUE ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify arguments
@@ -215,7 +219,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoords( scalarViewType dofCoords ) const {
+    getDofCoords( ScalarViewType dofCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,
@@ -232,7 +236,7 @@ namespace Intrepid2 {
 
   virtual
   void
-  getDofCoeffs( scalarViewType dofCoeffs ) const {
+  getDofCoeffs( ScalarViewType dofCoeffs ) const {
 #ifdef HAVE_INTREPID2_DEBUG
     // Verify rank of output array.
     INTREPID2_TEST_FOR_EXCEPTION( dofCoeffs.rank() != 2, std::invalid_argument,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_I1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_I1_FEM.hpp
@@ -180,9 +180,9 @@ namespace Intrepid2 {
     using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
     using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
 
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
+    using ordinal_type_array_1d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead");
+    using ordinal_type_array_2d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead");
+    using ordinal_type_array_3d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead");
 
     /** \brief  Constructor.
      */
@@ -192,9 +192,9 @@ namespace Intrepid2 {
     using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
     using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
     
-    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+    using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+    using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
+    using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_I1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_I1_FEMDef.hpp
@@ -198,6 +198,7 @@ namespace Intrepid2 {
     this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Tetrahedron<4> >() );
     this->basisType_         = BASIS_FEM_DEFAULT;
     this->basisCoordinates_  = COORDINATES_CARTESIAN;
+    this->functionSpace_     = FUNCTION_SPACE_HDIV;
 
     // initialize tags
     {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_I1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_I1_FEMDef.hpp
@@ -55,12 +55,12 @@ namespace Intrepid2 {
   namespace Impl {
 
     template<EOperator opType>
-    template<typename outputViewType,
+    template<typename OutputViewType,
              typename inputViewType>
     KOKKOS_INLINE_FUNCTION
     void
     Basis_HDIV_TET_I1_FEM::Serial<opType>::
-    getValues(       outputViewType output,
+    getValues(       OutputViewType output,
                const inputViewType input ) {
       switch (opType) {
       case OPERATOR_VALUE: {
@@ -237,7 +237,7 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoords("dofCoordsHost", this->basisCardinality_,this->basisCellTopology_.getDimension());
 
     dofCoords(0,0) =  1.0/3.0;   dofCoords(0,1) =  0.0;       dofCoords(0,2) = 1.0/3.0;
@@ -249,7 +249,7 @@ namespace Intrepid2 {
     Kokkos::deep_copy(this->dofCoords_, dofCoords);
 
     // dofCoeffs on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoeffs("dofCoeffsHost", this->basisCardinality_,this->basisCellTopology_.getDimension());
 
     // dofCoeffs are normals to faces, having magnitude equal to faces' measures

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_I1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_I1_FEMDef.hpp
@@ -215,11 +215,11 @@ namespace Intrepid2 {
                                  2, 3, 0, 1};
 
       // host tags
-      ordinal_type_array_1d_host tagView(&tags[0], 16);
+      OrdinalTypeArray1DHost tagView(&tags[0], 16);
 
       // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
-      //ordinal_type_array_2d_host ordinalToTag;
-      //ordinal_type_array_3d_host tagToOrdinal;
+      //OrdinalTypeArray2DHost ordinalToTag;
+      //OrdinalTypeArray3DHost tagToOrdinal;
       this->setOrdinalTagData(this->tagToOrdinal_,
                               this->ordinalToTag_,
                               tagView,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_In_FEM.hpp
@@ -198,9 +198,9 @@ template<typename ExecSpaceType = void,
 class Basis_HDIV_TET_In_FEM
     : public Basis<ExecSpaceType,outputValueType,pointValueType> {
     public:
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost OrdinalTypeArray1DHost;
+  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost OrdinalTypeArray2DHost;
+  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost OrdinalTypeArray3DHost;
 
   /** \brief  Constructor.
    */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_In_FEM.hpp
@@ -208,17 +208,22 @@ class Basis_HDIV_TET_In_FEM
       const EPointType   pointType = POINTTYPE_EQUISPACED);
 
 
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarViewType  scalarViewType;
+  using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+  using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+  using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+  
+  INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+  INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+  INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+
   typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarType  scalarType;
 
   using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
   virtual
   void
-  getValues( /* */ outputViewType outputValues,
-      const pointViewType  inputPoints,
+  getValues( /* */ OutputViewType outputValues,
+      const PointViewType  inputPoints,
       const EOperator operatorType = OPERATOR_VALUE) const {
 #ifdef HAVE_INTREPID2_DEBUG
     Intrepid2::getValues_HDIV_Args(outputValues,
@@ -237,7 +242,7 @@ getValues<ExecSpaceType,numPtsPerEval>( outputValues,
 
   virtual
   void
-  getDofCoords( scalarViewType dofCoords ) const {
+  getDofCoords( ScalarViewType dofCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
     // Verify rank of output array.
     INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,
@@ -254,7 +259,7 @@ getValues<ExecSpaceType,numPtsPerEval>( outputValues,
 
   virtual
   void
-  getDofCoeffs( scalarViewType dofCoeffs ) const {
+  getDofCoeffs( ScalarViewType dofCoeffs ) const {
 #ifdef HAVE_INTREPID2_DEBUG
     // Verify rank of output array.
     INTREPID2_TEST_FOR_EXCEPTION( dofCoeffs.rank() != 2, std::invalid_argument,
@@ -270,7 +275,7 @@ getValues<ExecSpaceType,numPtsPerEval>( outputValues,
   }
 
   void
-  getExpansionCoeffs( scalarViewType coeffs ) const {
+  getExpansionCoeffs( ScalarViewType coeffs ) const {
     // has to be same rank and dimensions
     Kokkos::deep_copy(coeffs, this->coeffs_);
   }

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_In_FEM.hpp
@@ -212,9 +212,9 @@ class Basis_HDIV_TET_In_FEM
   using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
   using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
   
-  INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-  INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
-  INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+  using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+  using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
+  using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
 
   typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarType  scalarType;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_In_FEMDef.hpp
@@ -195,6 +195,7 @@ Basis_HDIV_TET_In_FEM( const ordinal_type order,
   this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Tetrahedron<4> >() );
   this->basisType_         = BASIS_FEM_FIAT;
   this->basisCoordinates_  = COORDINATES_CARTESIAN;
+  this->functionSpace_     = FUNCTION_SPACE_HDIV;
 
   const ordinal_type card = this->basisCardinality_;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_In_FEMDef.hpp
@@ -59,14 +59,14 @@ namespace Intrepid2 {
 namespace Impl {
 
 template<EOperator opType>
-template<typename outputViewType,
+template<typename OutputViewType,
 typename inputViewType,
 typename workViewType,
 typename vinvViewType>
 KOKKOS_INLINE_FUNCTION
 void
 Basis_HDIV_TET_In_FEM::Serial<opType>::
-getValues(       outputViewType output,
+getValues(       OutputViewType output,
     const inputViewType  input,
           workViewType   work,
     const vinvViewType   coeffs ) {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_In_FEMDef.hpp
@@ -458,7 +458,7 @@ Basis_HDIV_TET_In_FEM( const ordinal_type order,
     const ordinal_type posScOrd = 1;        // position in the tag, counting from 0, of the subcell ordinal
     const ordinal_type posDfOrd = 2;        // position in the tag, counting from 0, of DoF ordinal relative to the subcell
 
-    ordinal_type_array_1d_host tagView(&tags[0][0], card*tagSize);
+    OrdinalTypeArray1DHost tagView(&tags[0][0], card*tagSize);
 
     // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
     // tags are constructed on host

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TRI_I1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TRI_I1_FEM.hpp
@@ -111,11 +111,11 @@ namespace Intrepid2 {
       */
       template<EOperator opType>
       struct Serial {
-        template<typename outputViewType,
+        template<typename OutputViewType,
                  typename inputViewType>
         KOKKOS_INLINE_FUNCTION
         static void
-        getValues(       outputViewType output,
+        getValues(       OutputViewType output,
                    const inputViewType input );
 
       };
@@ -186,16 +186,20 @@ namespace Intrepid2 {
      */
     Basis_HDIV_TRI_I1_FEM();
 
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarViewType  scalarViewType;
+    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    
+    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
-    getValues(       outputViewType outputValues,
-               const pointViewType  inputPoints,
+    getValues(       OutputViewType outputValues,
+               const PointViewType  inputPoints,
                const EOperator operatorType = OPERATOR_VALUE ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify arguments
@@ -213,7 +217,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoords( scalarViewType dofCoords ) const {
+    getDofCoords( ScalarViewType dofCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,
@@ -230,7 +234,7 @@ namespace Intrepid2 {
 
   virtual
   void
-  getDofCoeffs( scalarViewType dofCoeffs ) const {
+  getDofCoeffs( ScalarViewType dofCoeffs ) const {
 #ifdef HAVE_INTREPID2_DEBUG
     // Verify rank of output array.
     INTREPID2_TEST_FOR_EXCEPTION( dofCoeffs.rank() != 2, std::invalid_argument,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TRI_I1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TRI_I1_FEM.hpp
@@ -178,9 +178,9 @@ namespace Intrepid2 {
     using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
     using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
 
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
+    using ordinal_type_array_1d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead");
+    using ordinal_type_array_2d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead");
+    using ordinal_type_array_3d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead");
 
     /** \brief  Constructor.
      */
@@ -190,9 +190,9 @@ namespace Intrepid2 {
     using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
     using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
     
-    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+    using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+    using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
+    using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TRI_I1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TRI_I1_FEM.hpp
@@ -174,9 +174,13 @@ namespace Intrepid2 {
            typename pointValueType = double>
   class Basis_HDIV_TRI_I1_FEM: public Basis<ExecSpaceType,outputValueType,pointValueType> {
   public:
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
     /** \brief  Constructor.
      */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TRI_I1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TRI_I1_FEMDef.hpp
@@ -202,11 +202,11 @@ namespace Intrepid2 {
                                  1, 2, 0, 1 };
 
       // host tags
-      ordinal_type_array_1d_host tagView(&tags[0], 12);
+      OrdinalTypeArray1DHost tagView(&tags[0], 12);
 
       // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
-      //ordinal_type_array_2d_host ordinalToTag;
-      //ordinal_type_array_3d_host tagToOrdinal;
+      //OrdinalTypeArray2DHost ordinalToTag;
+      //OrdinalTypeArray3DHost tagToOrdinal;
       this->setOrdinalTagData(this->tagToOrdinal_,
                               this->ordinalToTag_,
                               tagView,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TRI_I1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TRI_I1_FEMDef.hpp
@@ -186,6 +186,7 @@ namespace Intrepid2 {
     this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Triangle<3> >() );
     this->basisType_         = BASIS_FEM_DEFAULT;
     this->basisCoordinates_  = COORDINATES_CARTESIAN;
+    this->functionSpace_     = FUNCTION_SPACE_HDIV;
 
     // initialize tags
     {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TRI_I1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TRI_I1_FEMDef.hpp
@@ -54,12 +54,12 @@ namespace Intrepid2 {
   namespace Impl {
 
     template<EOperator opType>
-    template<typename outputViewType,
+    template<typename OutputViewType,
              typename inputViewType>
     KOKKOS_INLINE_FUNCTION
     void
     Basis_HDIV_TRI_I1_FEM::Serial<opType>::
-    getValues(       outputViewType output,
+    getValues(       OutputViewType output,
                const inputViewType input ) {
       switch (opType) {
       case OPERATOR_VALUE: {
@@ -224,7 +224,7 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoords("dofCoordsHost", this->basisCardinality_,this->basisCellTopology_.getDimension());
 
     dofCoords(0,0) =  0.5;   dofCoords(0,1) =  0.0;
@@ -235,7 +235,7 @@ namespace Intrepid2 {
     Kokkos::deep_copy(this->dofCoords_, dofCoords);
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoeffs("dofCoeffsHost", this->basisCardinality_,this->basisCellTopology_.getDimension());
 
     // dofCoeffs are normals to edges, having magnitude equal to edges' measures

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TRI_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TRI_In_FEM.hpp
@@ -215,9 +215,9 @@ class Basis_HDIV_TRI_In_FEM
   using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
   using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
   
-  INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-  INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
-  INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+  using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+  using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
+  using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
 
   typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarType  scalarType;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TRI_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TRI_In_FEM.hpp
@@ -211,18 +211,22 @@ class Basis_HDIV_TRI_In_FEM
   Basis_HDIV_TRI_In_FEM(const ordinal_type order,
       const EPointType   pointType = POINTTYPE_EQUISPACED);
 
+  using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+  using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+  using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+  
+  INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+  INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+  INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
 
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarViewType  scalarViewType;
   typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarType  scalarType;
 
   using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
   virtual
   void
-  getValues( /* */ outputViewType outputValues,
-      const pointViewType  inputPoints,
+  getValues( /* */ OutputViewType outputValues,
+      const PointViewType  inputPoints,
       const EOperator operatorType = OPERATOR_VALUE) const {
 #ifdef HAVE_INTREPID2_DEBUG
     Intrepid2::getValues_HDIV_Args(outputValues,
@@ -241,7 +245,7 @@ class Basis_HDIV_TRI_In_FEM
 
   virtual
   void
-  getDofCoords( scalarViewType dofCoords ) const {
+  getDofCoords( ScalarViewType dofCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
     // Verify rank of output array.
     INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,
@@ -258,7 +262,7 @@ class Basis_HDIV_TRI_In_FEM
 
   virtual
   void
-  getDofCoeffs( scalarViewType dofCoeffs ) const {
+  getDofCoeffs( ScalarViewType dofCoeffs ) const {
 #ifdef HAVE_INTREPID2_DEBUG
     // Verify rank of output array.
     INTREPID2_TEST_FOR_EXCEPTION( dofCoeffs.rank() != 2, std::invalid_argument,
@@ -274,7 +278,7 @@ class Basis_HDIV_TRI_In_FEM
   }
 
   void
-  getExpansionCoeffs( scalarViewType coeffs ) const {
+  getExpansionCoeffs( ScalarViewType coeffs ) const {
     // has to be same rank and dimensions
     Kokkos::deep_copy(coeffs, this->coeffs_);
   }

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TRI_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TRI_In_FEM.hpp
@@ -202,9 +202,9 @@ template<typename ExecSpaceType = void,
 class Basis_HDIV_TRI_In_FEM
     : public Basis<ExecSpaceType,outputValueType,pointValueType> {
     public:
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost OrdinalTypeArray1DHost;
+  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost OrdinalTypeArray2DHost;
+  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost OrdinalTypeArray3DHost;
 
   /** \brief  Constructor.
    */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TRI_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TRI_In_FEMDef.hpp
@@ -194,6 +194,7 @@ Basis_HDIV_TRI_In_FEM( const ordinal_type order,
   this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Triangle<3> >() );
   this->basisType_         = BASIS_FEM_FIAT;
   this->basisCoordinates_  = COORDINATES_CARTESIAN;
+  this->functionSpace_     = FUNCTION_SPACE_HDIV;
 
   const ordinal_type card = this->basisCardinality_;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TRI_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TRI_In_FEMDef.hpp
@@ -58,14 +58,14 @@ namespace Intrepid2 {
 namespace Impl {
 
 template<EOperator opType>
-template<typename outputViewType,
+template<typename OutputViewType,
 typename inputViewType,
 typename workViewType,
 typename vinvViewType>
 KOKKOS_INLINE_FUNCTION
 void
 Basis_HDIV_TRI_In_FEM::Serial<opType>::
-getValues( /* */ outputViewType output,
+getValues( /* */ OutputViewType output,
     const inputViewType  input,
     /* */ workViewType   work,
     const vinvViewType   coeffs ) {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TRI_In_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TRI_In_FEMDef.hpp
@@ -456,7 +456,7 @@ Basis_HDIV_TRI_In_FEM( const ordinal_type order,
     const ordinal_type posScOrd = 1;        // position in the tag, counting from 0, of the subcell ordinal
     const ordinal_type posDfOrd = 2;        // position in the tag, counting from 0, of DoF ordinal relative to the subcell
 
-    ordinal_type_array_1d_host tagView(&tags[0][0], card*tagSize);
+    OrdinalTypeArray1DHost tagView(&tags[0][0], card*tagSize);
 
     // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
     // tags are constructed on host

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_WEDGE_I1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_WEDGE_I1_FEM.hpp
@@ -95,11 +95,11 @@ namespace Intrepid2 {
       */
       template<EOperator opType>
       struct Serial {
-        template<typename outputViewType,
+        template<typename OutputViewType,
                  typename inputViewType>
         KOKKOS_INLINE_FUNCTION
         static void
-        getValues(       outputViewType output,
+        getValues(       OutputViewType output,
                    const inputViewType input );
 
       };
@@ -170,16 +170,20 @@ namespace Intrepid2 {
      */
     Basis_HDIV_WEDGE_I1_FEM();
 
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarViewType  scalarViewType;
+    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    
+    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
-    getValues(       outputViewType outputValues,
-               const pointViewType  inputPoints,
+    getValues(       OutputViewType outputValues,
+               const PointViewType  inputPoints,
                const EOperator operatorType = OPERATOR_VALUE ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify arguments
@@ -197,7 +201,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoords( scalarViewType dofCoords ) const {
+    getDofCoords( ScalarViewType dofCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_WEDGE_I1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_WEDGE_I1_FEM.hpp
@@ -158,9 +158,13 @@ namespace Intrepid2 {
            typename pointValueType = double>
   class Basis_HDIV_WEDGE_I1_FEM : public Basis<ExecSpaceType,outputValueType,pointValueType> {
   public:
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
     /** \brief  Constructor.
      */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_WEDGE_I1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_WEDGE_I1_FEM.hpp
@@ -162,9 +162,9 @@ namespace Intrepid2 {
     using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
     using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
 
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
+    using ordinal_type_array_1d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead");
+    using ordinal_type_array_2d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead");
+    using ordinal_type_array_3d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead");
 
     /** \brief  Constructor.
      */
@@ -174,9 +174,9 @@ namespace Intrepid2 {
     using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
     using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
     
-    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+    using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+    using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
+    using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_WEDGE_I1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_WEDGE_I1_FEMDef.hpp
@@ -55,12 +55,12 @@ namespace Intrepid2 {
   namespace Impl {
 
     template<EOperator opType>
-    template<typename outputViewType,
+    template<typename OutputViewType,
              typename inputViewType>
     KOKKOS_INLINE_FUNCTION
     void
     Basis_HDIV_WEDGE_I1_FEM::Serial<opType>::
-    getValues(       outputViewType output,
+    getValues(       OutputViewType output,
                const inputViewType input ) {
       switch (opType) {
       case OPERATOR_VALUE: {
@@ -190,7 +190,7 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoords("dofCoordsHost", this->basisCardinality_,this->basisCellTopology_.getDimension());
 
     dofCoords(0,0) =  0.5;      dofCoords(0,1) =  0.0;      dofCoords(0,2) =  0.0;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_WEDGE_I1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_WEDGE_I1_FEMDef.hpp
@@ -156,6 +156,7 @@ namespace Intrepid2 {
     this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Wedge<6> >() );
     this->basisType_         = BASIS_FEM_DEFAULT;
     this->basisCoordinates_  = COORDINATES_CARTESIAN;
+    this->functionSpace_     = FUNCTION_SPACE_HDIV;
 
     // initialize tags
     {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_WEDGE_I1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_WEDGE_I1_FEMDef.hpp
@@ -174,11 +174,11 @@ namespace Intrepid2 {
                                  2, 4, 0, 1 };
 
       // host tags
-      ordinal_type_array_1d_host tagView(&tags[0], 20);
+      OrdinalTypeArray1DHost tagView(&tags[0], 20);
 
       // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
-      //ordinal_type_array_2d_host ordinalToTag;
-      //ordinal_type_array_3d_host tagToOrdinal;
+      //OrdinalTypeArray2DHost ordinalToTag;
+      //OrdinalTypeArray3DHost tagToOrdinal;
       this->setOrdinalTagData(this->tagToOrdinal_,
                               this->ordinalToTag_,
                               tagView,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C1_FEM.hpp
@@ -101,11 +101,11 @@ namespace Intrepid2 {
       */
       template<EOperator opType>
       struct Serial {
-        template<typename outputViewType,
+        template<typename OutputViewType,
                  typename inputViewType>
         KOKKOS_INLINE_FUNCTION
         static void
-        getValues(       outputViewType output,
+        getValues(       OutputViewType output,
                    const inputViewType input );
         
       };
@@ -180,16 +180,20 @@ namespace Intrepid2 {
      */
     Basis_HGRAD_HEX_C1_FEM();
 
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarViewType  scalarViewType;
+    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    
+    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
-    getValues(       outputViewType outputValues,
-               const pointViewType  inputPoints,
+    getValues(       OutputViewType outputValues,
+               const PointViewType  inputPoints,
                const EOperator operatorType = OPERATOR_VALUE ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify arguments
@@ -207,7 +211,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoords( scalarViewType dofCoords ) const {
+    getDofCoords( ScalarViewType dofCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,
@@ -224,7 +228,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoeffs( scalarViewType dofCoeffs ) const {
+    getDofCoeffs( ScalarViewType dofCoeffs ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoeffs.rank() != 1, std::invalid_argument,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C1_FEM.hpp
@@ -172,9 +172,9 @@ namespace Intrepid2 {
     using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
     using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
 
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
+    using ordinal_type_array_1d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead");
+    using ordinal_type_array_2d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead");
+    using ordinal_type_array_3d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead");
 
     /** \brief  Constructor.
      */
@@ -184,9 +184,9 @@ namespace Intrepid2 {
     using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
     using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
     
-    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+    using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+    using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
+    using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C1_FEM.hpp
@@ -168,9 +168,13 @@ namespace Intrepid2 {
            typename pointValueType = double>
   class Basis_HGRAD_HEX_C1_FEM : public Basis<ExecSpaceType,outputValueType,pointValueType> {
   public:
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
     /** \brief  Constructor.
      */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C1_FEMDef.hpp
@@ -301,11 +301,11 @@ namespace Intrepid2 {
                                  0, 7, 0, 1 };
 
       // host tags
-      ordinal_type_array_1d_host tagView(&tags[0], 32);
+      OrdinalTypeArray1DHost tagView(&tags[0], 32);
 
       // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
-      //ordinal_type_array_2d_host ordinalToTag;
-      //ordinal_type_array_3d_host tagToOrdinal;
+      //OrdinalTypeArray2DHost ordinalToTag;
+      //OrdinalTypeArray3DHost tagToOrdinal;
       this->setOrdinalTagData(this->tagToOrdinal_,
                               this->ordinalToTag_,
                               tagView,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C1_FEMDef.hpp
@@ -55,12 +55,12 @@ namespace Intrepid2 {
   namespace Impl {
 
     template<EOperator opType>
-    template<typename outputViewType,
+    template<typename OutputViewType,
              typename inputViewType>
     KOKKOS_INLINE_FUNCTION
     void
     Basis_HGRAD_HEX_C1_FEM::Serial<opType>::
-    getValues(       outputViewType output,
+    getValues(       OutputViewType output,
                const inputViewType input ) {
       switch (opType) {
       case OPERATOR_VALUE : {
@@ -323,7 +323,7 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoords("dofCoordsHost", this->basisCardinality_,this->basisCellTopology_.getDimension());
     
     dofCoords(0,0) = -1.0;   dofCoords(0,1) = -1.0; dofCoords(0,2) = -1.0;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C1_FEMDef.hpp
@@ -280,6 +280,7 @@ namespace Intrepid2 {
     this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Hexahedron<8> >() );
     this->basisType_         = BASIS_FEM_DEFAULT;
     this->basisCoordinates_  = COORDINATES_CARTESIAN;
+    this->functionSpace_     = FUNCTION_SPACE_HGRAD;
 
     // initialize tags
     {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C2_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C2_FEM.hpp
@@ -225,9 +225,9 @@ namespace Intrepid2 {
     using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
     using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
 
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
+    using ordinal_type_array_1d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead");
+    using ordinal_type_array_2d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead");
+    using ordinal_type_array_3d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead");
 
     /** \brief  Constructor.
      */
@@ -237,9 +237,9 @@ namespace Intrepid2 {
     using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
     using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
     
-    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+    using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+    using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
+    using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C2_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C2_FEM.hpp
@@ -221,9 +221,13 @@ namespace Intrepid2 {
            typename pointValueType = double>
   class Basis_HGRAD_HEX_C2_FEM : public Basis<ExecSpaceType,outputValueType,pointValueType> {
   public:
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
     /** \brief  Constructor.
      */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C2_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C2_FEM.hpp
@@ -148,11 +148,11 @@ namespace Intrepid2 {
       */
       template<EOperator opType>
       struct Serial {
-        template<typename outputViewType,
+        template<typename OutputViewType,
                  typename inputViewType>
         KOKKOS_INLINE_FUNCTION
         static void
-        getValues(       outputViewType output,
+        getValues(       OutputViewType output,
                    const inputViewType input );
         
       };
@@ -233,16 +233,20 @@ namespace Intrepid2 {
      */
     Basis_HGRAD_HEX_C2_FEM();
 
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarViewType  scalarViewType;
+    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    
+    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
-    getValues(       outputViewType outputValues,
-               const pointViewType  inputPoints,
+    getValues(       OutputViewType outputValues,
+               const PointViewType  inputPoints,
                const EOperator operatorType = OPERATOR_VALUE ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify arguments
@@ -260,7 +264,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoords( scalarViewType dofCoords ) const {
+    getDofCoords( ScalarViewType dofCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,
@@ -277,7 +281,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoeffs( scalarViewType dofCoeffs ) const {
+    getDofCoeffs( ScalarViewType dofCoeffs ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoeffs.rank() != 1, std::invalid_argument,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C2_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C2_FEMDef.hpp
@@ -1069,7 +1069,7 @@ namespace Intrepid2 {
       };
 
       // host tags
-      ordinal_type_array_1d_host tagView(&tags[0], 108);
+      OrdinalTypeArray1DHost tagView(&tags[0], 108);
 
       // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
       this->setOrdinalTagData(this -> tagToOrdinal_,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C2_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C2_FEMDef.hpp
@@ -1028,6 +1028,7 @@ namespace Intrepid2 {
     this -> basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Hexahedron<8> >() );
     this -> basisType_         = BASIS_FEM_DEFAULT;
     this -> basisCoordinates_  = COORDINATES_CARTESIAN;
+    this->functionSpace_     = FUNCTION_SPACE_HGRAD;
 
     // initialize tags
     {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C2_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_C2_FEMDef.hpp
@@ -55,12 +55,12 @@ namespace Intrepid2 {
   namespace Impl {
     
     template<EOperator opType>
-    template<typename outputViewType,
+    template<typename OutputViewType,
              typename inputViewType>
     KOKKOS_INLINE_FUNCTION
     void
     Basis_HGRAD_HEX_C2_FEM::Serial<opType>::
-    getValues(       outputViewType output,
+    getValues(       OutputViewType output,
                const inputViewType input ) {
       switch (opType) {
       case OPERATOR_VALUE : {
@@ -1082,7 +1082,7 @@ namespace Intrepid2 {
                               posDfOrd);
     }
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoords("dofCoordsHost", this->basisCardinality_,this->basisCellTopology_.getDimension());
 
     dofCoords(0,0) = -1.0;   dofCoords(0,1) = -1.0; dofCoords(0,2) = -1.0;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_Cn_FEM.hpp
@@ -171,17 +171,17 @@ namespace Intrepid2 {
     using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
     using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
 
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
+    using ordinal_type_array_1d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead");
+    using ordinal_type_array_2d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead");
+    using ordinal_type_array_3d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead");
 
     using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
     using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
     using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
     
-    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+    using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+    using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
+    using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
 
   private:
     /** \brief inverse of Generalized Vandermonde matrix (isotropic order) */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_Cn_FEM.hpp
@@ -175,13 +175,17 @@ namespace Intrepid2 {
     INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
     INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarViewType  scalarViewType;
+    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    
+    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
 
   private:
     /** \brief inverse of Generalized Vandermonde matrix (isotropic order) */
-    Kokkos::DynRankView<typename scalarViewType::value_type,ExecSpaceType> vinv_;
+    Kokkos::DynRankView<typename ScalarViewType::value_type,ExecSpaceType> vinv_;
 
   public:
 
@@ -194,8 +198,8 @@ namespace Intrepid2 {
 
     virtual
     void
-    getValues(       outputViewType outputValues,
-               const pointViewType  inputPoints,
+    getValues(       OutputViewType outputValues,
+               const PointViewType  inputPoints,
                const EOperator operatorType = OPERATOR_VALUE ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       Intrepid2::getValues_HGRAD_Args(outputValues,
@@ -215,7 +219,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoords( scalarViewType dofCoords ) const {
+    getDofCoords( ScalarViewType dofCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,
@@ -232,7 +236,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoeffs( scalarViewType dofCoeffs ) const {
+    getDofCoeffs( ScalarViewType dofCoeffs ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoeffs.rank() != 1, std::invalid_argument,
@@ -256,7 +260,7 @@ namespace Intrepid2 {
       return (this->basisDegree_ > 2);
     }
 
-    Kokkos::DynRankView<typename scalarViewType::const_value_type,ExecSpaceType>
+    Kokkos::DynRankView<typename ScalarViewType::const_value_type,ExecSpaceType>
     getVandermondeInverse() {
       return vinv_;
     }

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_Cn_FEM.hpp
@@ -167,9 +167,13 @@ namespace Intrepid2 {
   class Basis_HGRAD_HEX_Cn_FEM
     : public Basis<ExecSpaceType,outputValueType,pointValueType> {
   public:
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
     typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
     typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_Cn_FEMDef.hpp
@@ -55,14 +55,14 @@ namespace Intrepid2 {
   namespace Impl {
     
     template<EOperator opType>
-    template<typename outputViewType,
+    template<typename OutputViewType,
              typename inputViewType,
              typename workViewType,
              typename vinvViewType>
     KOKKOS_INLINE_FUNCTION
     void
     Basis_HGRAD_HEX_Cn_FEM::Serial<opType>::
-    getValues(       outputViewType output,
+    getValues(       OutputViewType output,
                const inputViewType  input,
                      workViewType   work,
                const vinvViewType   vinv,
@@ -272,7 +272,7 @@ namespace Intrepid2 {
     Basis_HGRAD_LINE_Cn_FEM<SpT,OT,PT> lineBasis( order, pointType );
     const auto cardLine = lineBasis.getCardinality();
 
-    this->vinv_ = Kokkos::DynRankView<typename scalarViewType::value_type,SpT>("Hgrad::HEX::Cn::vinv", cardLine, cardLine);
+    this->vinv_ = Kokkos::DynRankView<typename ScalarViewType::value_type,SpT>("Hgrad::HEX::Cn::vinv", cardLine, cardLine);
     lineBasis.getVandermondeInverse(this->vinv_);
     
     this->basisCardinality_  = cardLine*cardLine*cardLine;
@@ -383,10 +383,10 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoordsHost("dofCoordsHost", this->basisCardinality_, this->basisCellTopology_.getDimension());
 
-    Kokkos::DynRankView<typename scalarViewType::value_type,SpT>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,SpT>
       dofCoordsLine("dofCoordsLine", cardLine, 1);
 
     lineBasis.getDofCoords(dofCoordsLine);

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_Cn_FEMDef.hpp
@@ -368,7 +368,7 @@ namespace Intrepid2 {
         }
       }
 
-      ordinal_type_array_1d_host tagView(&tags[0][0], this->basisCardinality_*4);
+      OrdinalTypeArray1DHost tagView(&tags[0][0], this->basisCardinality_*4);
 
       // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
       // tags are constructed on host

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_HEX_Cn_FEMDef.hpp
@@ -280,6 +280,7 @@ namespace Intrepid2 {
     this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Hexahedron<8> >() );
     this->basisType_         = BASIS_FEM_FIAT;
     this->basisCoordinates_  = COORDINATES_CARTESIAN;
+    this->functionSpace_     = FUNCTION_SPACE_HGRAD;
 
     // initialize tags
     {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_C1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_C1_FEM.hpp
@@ -88,11 +88,11 @@ namespace Intrepid2 {
       */
       template<EOperator opType>
       struct Serial {
-        template<typename outputViewType,
+        template<typename OutputViewType,
                  typename inputViewType>
         KOKKOS_INLINE_FUNCTION
         static void
-        getValues(       outputViewType output,
+        getValues(       OutputViewType output,
                    const inputViewType input );
 
       };
@@ -167,16 +167,20 @@ namespace Intrepid2 {
      */
     Basis_HGRAD_LINE_C1_FEM();
 
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarViewType  scalarViewType;
+    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    
+    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
-    getValues(       outputViewType outputValues,
-               const pointViewType  inputPoints,
+    getValues(       OutputViewType outputValues,
+               const PointViewType  inputPoints,
                const EOperator operatorType = OPERATOR_VALUE ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify arguments
@@ -194,7 +198,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoords( scalarViewType dofCoords ) const {
+    getDofCoords( ScalarViewType dofCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,
@@ -211,7 +215,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoeffs( scalarViewType dofCoeffs ) const {
+    getDofCoeffs( ScalarViewType dofCoeffs ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoeffs.rank() != 1, std::invalid_argument,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_C1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_C1_FEM.hpp
@@ -155,9 +155,13 @@ namespace Intrepid2 {
   class Basis_HGRAD_LINE_C1_FEM
     : public Basis<ExecSpaceType,outputValueType,pointValueType> {
   public:
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
     /** \brief  Constructor.
      */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_C1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_C1_FEM.hpp
@@ -159,9 +159,9 @@ namespace Intrepid2 {
     using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
     using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
 
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
+    using ordinal_type_array_1d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead");
+    using ordinal_type_array_2d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead");
+    using ordinal_type_array_3d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead");
 
     /** \brief  Constructor.
      */
@@ -171,9 +171,9 @@ namespace Intrepid2 {
     using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
     using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
     
-    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+    using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+    using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
+    using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_C1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_C1_FEMDef.hpp
@@ -56,12 +56,12 @@ namespace Intrepid2 {
   namespace Impl {
 
     template<EOperator opType>
-    template<typename outputViewType,
+    template<typename OutputViewType,
              typename inputViewType>
     KOKKOS_INLINE_FUNCTION
     void
     Basis_HGRAD_LINE_C1_FEM::Serial<opType>::
-    getValues(       outputViewType output,
+    getValues(       OutputViewType output,
                const inputViewType input ) {
       switch (opType) {
       case OPERATOR_VALUE : {
@@ -198,7 +198,7 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoords("dofCoordsHost", this->basisCardinality_,this->basisCellTopology_.getDimension());
 
     dofCoords(0,0) = -1.0;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_C1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_C1_FEMDef.hpp
@@ -175,12 +175,12 @@ namespace Intrepid2 {
                                 0, 1, 0, 1 };
 
       // host tags
-      ordinal_type_array_1d_host tagView(&tags[0], 8);
+      OrdinalTypeArray1DHost tagView(&tags[0], 8);
 
       // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
       // tags are constructed on host and sent to devices
-      //ordinal_type_array_2d_host ordinalToTag;
-      //ordinal_type_array_3d_host tagToOrdinal;
+      //OrdinalTypeArray2DHost ordinalToTag;
+      //OrdinalTypeArray3DHost tagToOrdinal;
       this->setOrdinalTagData(this->tagToOrdinal_,
                               this->ordinalToTag_,
                               tagView,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_C1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_C1_FEMDef.hpp
@@ -160,6 +160,7 @@ namespace Intrepid2 {
     this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Line<2> >() );
     this->basisType_         = BASIS_FEM_DEFAULT;
     this->basisCoordinates_  = COORDINATES_CARTESIAN;
+    this->functionSpace_     = FUNCTION_SPACE_HGRAD;
 
     // initialize tags
     {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEM.hpp
@@ -183,15 +183,19 @@ namespace Intrepid2 {
     INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
     INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarViewType  scalarViewType;
+    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    
+    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
 
   private:
 
     /** \brief inverse of Generalized Vandermonde matrix, whose columns store the expansion
         coefficients of the nodal basis in terms of phis_ */
-    Kokkos::DynRankView<typename scalarViewType::value_type,ExecSpaceType> vinv_;
+    Kokkos::DynRankView<typename ScalarViewType::value_type,ExecSpaceType> vinv_;
 
   public:
     /** \brief  Constructor.
@@ -203,8 +207,8 @@ namespace Intrepid2 {
 
     virtual
     void
-    getValues(       outputViewType outputValues,
-                     const pointViewType  inputPoints,
+    getValues(       OutputViewType outputValues,
+                     const PointViewType  inputPoints,
                      const EOperator operatorType = OPERATOR_VALUE ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       Intrepid2::getValues_HGRAD_Args(outputValues,
@@ -223,7 +227,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoords( scalarViewType dofCoords ) const {
+    getDofCoords( ScalarViewType dofCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,
@@ -240,7 +244,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoeffs( scalarViewType dofCoeffs ) const {
+    getDofCoeffs( ScalarViewType dofCoeffs ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoeffs.rank() != 1, std::invalid_argument,
@@ -259,12 +263,12 @@ namespace Intrepid2 {
     }
 
     void
-    getVandermondeInverse( scalarViewType vinv ) const {
+    getVandermondeInverse( ScalarViewType vinv ) const {
       // has to be same rank and dimensions
       Kokkos::deep_copy(vinv, this->vinv_);      
     }
 
-    Kokkos::DynRankView<typename scalarViewType::const_value_type,ExecSpaceType>
+    Kokkos::DynRankView<typename ScalarViewType::const_value_type,ExecSpaceType>
     getVandermondeInverse() const {
       return vinv_;
     }

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEM.hpp
@@ -179,17 +179,17 @@ namespace Intrepid2 {
     using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
     using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
 
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
+    using ordinal_type_array_1d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead");
+    using ordinal_type_array_2d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead");
+    using ordinal_type_array_3d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead");
 
     using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
     using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
     using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
     
-    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+    using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+    using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
+    using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
 
   private:
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEM.hpp
@@ -175,9 +175,13 @@ namespace Intrepid2 {
   class Basis_HGRAD_LINE_Cn_FEM
     : public Basis<ExecSpaceType,outputValueType,pointValueType> {
   public:
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
     typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
     typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEMDef.hpp
@@ -55,14 +55,14 @@ namespace Intrepid2 {
   namespace Impl {
     
     template<EOperator opType>
-    template<typename outputViewType,
+    template<typename OutputViewType,
              typename inputViewType,
              typename workViewType,
              typename vinvViewType>
     KOKKOS_INLINE_FUNCTION
     void
     Basis_HGRAD_LINE_Cn_FEM::Serial<opType>::
-    getValues(       outputViewType output,
+    getValues(       OutputViewType output,
                const inputViewType  input,
                      workViewType   work,
                const vinvViewType   vinv,
@@ -206,7 +206,7 @@ namespace Intrepid2 {
     const ordinal_type card = this->basisCardinality_;
     
     // points are computed in the host and will be copied 
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoords("Hgrad::Line::Cn::dofCoords", card, 1);
 
 
@@ -259,7 +259,7 @@ namespace Intrepid2 {
     // form Vandermonde matrix; actually, this is the transpose of the VDM,
     // this matrix is used in LAPACK so it should be column major and left layout
     const ordinal_type lwork = card*card;
-    Kokkos::DynRankView<typename scalarViewType::value_type,Kokkos::LayoutLeft,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,Kokkos::LayoutLeft,Kokkos::HostSpace>
       vmat("Hgrad::Line::Cn::vmat", card, card), 
       work("Hgrad::Line::Cn::work", lwork),
       ipiv("Hgrad::Line::Cn::ipiv", card);
@@ -270,7 +270,7 @@ namespace Intrepid2 {
       (vmat, dofCoords, order, alpha, beta, OPERATOR_VALUE);
 
     ordinal_type info = 0;
-    Teuchos::LAPACK<ordinal_type,typename scalarViewType::value_type> lapack;
+    Teuchos::LAPACK<ordinal_type,typename ScalarViewType::value_type> lapack;
 
     lapack.GETRF(card, card, 
                  vmat.data(), vmat.stride_1(),
@@ -292,7 +292,7 @@ namespace Intrepid2 {
                                   ">>> ERROR: (Intrepid2::Basis_HGRAD_LINE_Cn_FEM) lapack.GETRI returns nonzero info." );
     
     // create host mirror 
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       vinv("Hgrad::Line::Cn::vinv", card, card);
 
     for (ordinal_type i=0;i<card;++i) 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEMDef.hpp
@@ -371,7 +371,7 @@ namespace Intrepid2 {
         }
       }
 
-      ordinal_type_array_1d_host tagView(&tags[0][0], card*4);
+      OrdinalTypeArray1DHost tagView(&tags[0][0], card*4);
 
       // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
       // tags are constructed on host

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEMDef.hpp
@@ -201,6 +201,7 @@ namespace Intrepid2 {
     this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Line<2> >() );
     this->basisType_         = BASIS_FEM_FIAT;
     this->basisCoordinates_  = COORDINATES_CARTESIAN;
+    this->functionSpace_     = FUNCTION_SPACE_HGRAD;
 
     const ordinal_type card = this->basisCardinality_;
     

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEM_JACOBI.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEM_JACOBI.hpp
@@ -232,9 +232,13 @@ namespace Intrepid2 {
     : public Basis<ExecSpaceType,outputValueType,pointValueType> {
   public:
     typedef double value_type;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
     
     /** \brief  Constructor.
      */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEM_JACOBI.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEM_JACOBI.hpp
@@ -236,9 +236,9 @@ namespace Intrepid2 {
     using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
     using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
 
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
+    using ordinal_type_array_1d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead");
+    using ordinal_type_array_2d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead");
+    using ordinal_type_array_3d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead");
     
     /** \brief  Constructor.
      */
@@ -250,8 +250,8 @@ namespace Intrepid2 {
     using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
     using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
     
-    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+    using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+    using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
    
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
  

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEM_JACOBI.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEM_JACOBI.hpp
@@ -141,11 +141,11 @@ namespace Intrepid2 {
       */
       template<EOperator opType>
       struct Serial {
-        template<typename outputViewType,
+        template<typename OutputViewType,
                  typename inputViewType>
         KOKKOS_INLINE_FUNCTION
         static void
-        getValues(       outputViewType output,
+        getValues(       OutputViewType output,
                    const inputViewType  input,
                    const ordinal_type   order,
                    const double         alpha,
@@ -246,15 +246,19 @@ namespace Intrepid2 {
                                     const double alpha = 0, 
                                     const double beta = 0 );  
 
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
+    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    
+    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
    
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
  
     virtual
     void
-    getValues(       outputViewType outputValues,
-               const pointViewType  inputPoints,
+    getValues(       OutputViewType outputValues,
+               const PointViewType  inputPoints,
                const EOperator operatorType = OPERATOR_VALUE ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       Intrepid2::getValues_HGRAD_Args(outputValues,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEM_JACOBIDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEM_JACOBIDef.hpp
@@ -218,6 +218,7 @@ namespace Intrepid2 {
     this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Line<> >() );
     this->basisType_         = BASIS_FEM_HIERARCHICAL;
     this->basisCoordinates_  = COORDINATES_CARTESIAN;
+    this->functionSpace_     = FUNCTION_SPACE_HGRAD;
 
     // jacobi 
     this->alpha_ = alpha;    

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEM_JACOBIDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEM_JACOBIDef.hpp
@@ -58,12 +58,12 @@ namespace Intrepid2 {
     // output (N,P,D)
     // input  (P,D) - assumes that it has a set of points to amortize the function call cost for jacobi polynomial.
     template<EOperator opType>
-    template<typename outputViewType,
+    template<typename OutputViewType,
              typename inputViewType>
     KOKKOS_INLINE_FUNCTION
     void
     Basis_HGRAD_LINE_Cn_FEM_JACOBI::Serial<opType>::
-    getValues(       outputViewType output,
+    getValues(       OutputViewType output,
                const inputViewType  input,
                const ordinal_type   order,
                const double         alpha,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEM_JACOBIDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_LINE_Cn_FEM_JACOBIDef.hpp
@@ -241,7 +241,7 @@ namespace Intrepid2 {
         tags[i][3] = card;  // total number of DoFs 
       }
      
-      ordinal_type_array_1d_host tagView(&tags[0][0], card*4);
+      OrdinalTypeArray1DHost tagView(&tags[0][0], card*4);
  
       // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
       // tags are constructed on host 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_PYR_C1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_PYR_C1_FEM.hpp
@@ -163,9 +163,13 @@ namespace Intrepid2 {
            typename pointValueType = double>
   class Basis_HGRAD_PYR_C1_FEM : public Basis<ExecSpaceType,outputValueType,pointValueType> {
   public:
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
 
     /** \brief  Constructor.

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_PYR_C1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_PYR_C1_FEM.hpp
@@ -167,9 +167,9 @@ namespace Intrepid2 {
     using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
     using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
 
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
+    using ordinal_type_array_1d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead");
+    using ordinal_type_array_2d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead");
+    using ordinal_type_array_3d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead");
 
 
     /** \brief  Constructor.
@@ -180,9 +180,9 @@ namespace Intrepid2 {
     using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
     using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
     
-    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+    using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+    using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
+    using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_PYR_C1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_PYR_C1_FEM.hpp
@@ -94,11 +94,11 @@ namespace Intrepid2 {
       */
       template<EOperator opType>
       struct Serial {
-        template<typename outputViewType,
+        template<typename OutputViewType,
                  typename inputViewType>
         KOKKOS_INLINE_FUNCTION
         static void
-        getValues(       outputViewType output,
+        getValues(       OutputViewType output,
                    const inputViewType input );
 
       };
@@ -176,16 +176,20 @@ namespace Intrepid2 {
      */
     Basis_HGRAD_PYR_C1_FEM();
 
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarViewType  scalarViewType;
+    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    
+    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
-    getValues(       outputViewType outputValues,
-               const pointViewType  inputPoints,
+    getValues(       OutputViewType outputValues,
+               const PointViewType  inputPoints,
                const EOperator operatorType = OPERATOR_VALUE ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify arguments
@@ -203,7 +207,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoords( scalarViewType dofCoords ) const {
+    getDofCoords( ScalarViewType dofCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,
@@ -220,7 +224,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoeffs( scalarViewType dofCoeffs ) const {
+    getDofCoeffs( ScalarViewType dofCoeffs ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoeffs.rank() != 1, std::invalid_argument,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_PYR_C1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_PYR_C1_FEMDef.hpp
@@ -252,6 +252,7 @@ namespace Intrepid2 {
     this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Pyramid<5> >() );
     this->basisType_         = BASIS_FEM_DEFAULT;
     this->basisCoordinates_  = COORDINATES_CARTESIAN;
+    this->functionSpace_     = FUNCTION_SPACE_HGRAD;
 
     // initialize tags
     {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_PYR_C1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_PYR_C1_FEMDef.hpp
@@ -56,20 +56,20 @@ namespace Intrepid2 {
   namespace Impl {
 
     template<EOperator opType>
-    template<typename outputViewType,
+    template<typename OutputViewType,
              typename inputViewType>
     KOKKOS_INLINE_FUNCTION
     void
     Basis_HGRAD_PYR_C1_FEM::Serial<opType>::
-    getValues(       outputViewType output,
+    getValues(       OutputViewType output,
                const inputViewType input ) {
       const auto eps = epsilon();
 
       static_assert(std::is_same<
-                    typename outputViewType::value_type,
+                    typename OutputViewType::value_type,
                     typename inputViewType::value_type>::value,"Input/output view has different value types");
 
-      typedef typename outputViewType::value_type value_type;
+      typedef typename OutputViewType::value_type value_type;
 
       const value_type x = input(0);
       const value_type y = input(1);
@@ -293,7 +293,7 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoords("dofCoordsHost", this->basisCardinality_,this->basisCellTopology_.getDimension());
 
     dofCoords(0,0) = -1.0;  dofCoords(0,1) = -1.0;  dofCoords(0,2) =  0.0;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_PYR_C1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_PYR_C1_FEMDef.hpp
@@ -271,11 +271,11 @@ namespace Intrepid2 {
 
 
       // host tags
-      ordinal_type_array_1d_host tagView(&tags[0], 20);
+      OrdinalTypeArray1DHost tagView(&tags[0], 20);
 
       // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
-      //ordinal_type_array_2d_host ordinalToTag;
-      //ordinal_type_array_3d_host tagToOrdinal;
+      //OrdinalTypeArray2DHost ordinalToTag;
+      //OrdinalTypeArray3DHost tagToOrdinal;
       this->setOrdinalTagData(this->tagToOrdinal_,
                               this->ordinalToTag_,
                               tagView,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C1_FEM.hpp
@@ -165,9 +165,9 @@ namespace Intrepid2 {
     using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
     using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
 
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
+    using ordinal_type_array_1d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead");
+    using ordinal_type_array_2d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead");
+    using ordinal_type_array_3d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead");
 
     /** \brief Constructor.
      */
@@ -177,9 +177,9 @@ namespace Intrepid2 {
     using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
     using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
     
-    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+    using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+    using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
+    using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C1_FEM.hpp
@@ -161,9 +161,13 @@ namespace Intrepid2 {
            typename pointValueType = double>
   class Basis_HGRAD_QUAD_C1_FEM : public Basis<ExecSpaceType,outputValueType,pointValueType> {
   public:
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
     /** \brief Constructor.
      */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C1_FEM.hpp
@@ -92,11 +92,11 @@ namespace Intrepid2 {
       */
       template<EOperator opType>
       struct Serial {
-        template<typename outputViewType,
+        template<typename OutputViewType,
                  typename inputViewType>
         KOKKOS_INLINE_FUNCTION
         static void
-        getValues(       outputViewType output,
+        getValues(       OutputViewType output,
                    const inputViewType input );
 
       };
@@ -173,16 +173,20 @@ namespace Intrepid2 {
      */
     Basis_HGRAD_QUAD_C1_FEM();
 
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarViewType  scalarViewType;
+    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    
+    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
-    getValues(       outputViewType outputValues,
-               const pointViewType  inputPoints,
+    getValues(       OutputViewType outputValues,
+               const PointViewType  inputPoints,
                const EOperator operatorType = OPERATOR_VALUE ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify arguments
@@ -200,7 +204,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoords( scalarViewType dofCoords ) const {
+    getDofCoords( ScalarViewType dofCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,
@@ -217,7 +221,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoeffs( scalarViewType dofCoeffs ) const {
+    getDofCoeffs( ScalarViewType dofCoeffs ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoeffs.rank() != 1, std::invalid_argument,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C1_FEMDef.hpp
@@ -242,11 +242,11 @@ namespace Intrepid2 {
                                  0, 3, 0, 1 };
 
       // host tags
-      ordinal_type_array_1d_host tagView(&tags[0], 16);
+      OrdinalTypeArray1DHost tagView(&tags[0], 16);
 
       // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
-      //ordinal_type_array_2d_host ordinalToTag;
-      //ordinal_type_array_3d_host tagToOrdinal;
+      //OrdinalTypeArray2DHost ordinalToTag;
+      //OrdinalTypeArray3DHost tagToOrdinal;
       this->setOrdinalTagData(this->tagToOrdinal_,
                               this->ordinalToTag_,
                               tagView,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C1_FEMDef.hpp
@@ -56,12 +56,12 @@ namespace Intrepid2 {
   namespace Impl {
 
     template<EOperator opType>
-    template<typename outputViewType,
+    template<typename OutputViewType,
              typename inputViewType>
     KOKKOS_INLINE_FUNCTION
     void
     Basis_HGRAD_QUAD_C1_FEM::Serial<opType>::
-    getValues(       outputViewType output,
+    getValues(       OutputViewType output,
                const inputViewType input ) {
       switch (opType) {
       case OPERATOR_VALUE : {
@@ -264,7 +264,7 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoords("dofCoordsHost", this->basisCardinality_,this->basisCellTopology_.getDimension());
 
     dofCoords(0,0) = -1.0;   dofCoords(0,1) = -1.0;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C1_FEMDef.hpp
@@ -225,6 +225,7 @@ namespace Intrepid2 {
     this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Quadrilateral<4> >() );
     this->basisType_         = BASIS_FEM_DEFAULT;
     this->basisCoordinates_  = COORDINATES_CARTESIAN;
+    this->functionSpace_     = FUNCTION_SPACE_HGRAD;
 
     // initialize tags
     {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C2_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C2_FEM.hpp
@@ -178,9 +178,13 @@ namespace Intrepid2 {
            typename pointValueType = double>
   class Basis_HGRAD_QUAD_C2_FEM : public Basis<ExecSpaceType,outputValueType,pointValueType> {
   public:
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
     /** \brief Constructor.
      */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C2_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C2_FEM.hpp
@@ -103,11 +103,11 @@ namespace Intrepid2 {
       */
       template<EOperator opType>
       struct Serial {
-        template<typename outputViewType,
+        template<typename OutputViewType,
                  typename inputViewType>
         KOKKOS_INLINE_FUNCTION
         static void
-        getValues(       outputViewType output,
+        getValues(       OutputViewType output,
                    const inputViewType input );
 
       };
@@ -190,16 +190,20 @@ namespace Intrepid2 {
      */
     Basis_HGRAD_QUAD_C2_FEM();
 
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarViewType  scalarViewType;
+    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    
+    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
-    getValues(       outputViewType outputValues,
-               const pointViewType  inputPoints,
+    getValues(       OutputViewType outputValues,
+               const PointViewType  inputPoints,
                const EOperator operatorType = OPERATOR_VALUE ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify arguments
@@ -217,7 +221,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoords( scalarViewType dofCoords ) const {
+    getDofCoords( ScalarViewType dofCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,
@@ -234,7 +238,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoeffs( scalarViewType dofCoeffs ) const {
+    getDofCoeffs( ScalarViewType dofCoeffs ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoeffs.rank() != 1, std::invalid_argument,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C2_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C2_FEM.hpp
@@ -182,9 +182,9 @@ namespace Intrepid2 {
     using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
     using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
 
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
+    using ordinal_type_array_1d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead");
+    using ordinal_type_array_2d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead");
+    using ordinal_type_array_3d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead");
 
     /** \brief Constructor.
      */
@@ -194,9 +194,9 @@ namespace Intrepid2 {
     using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
     using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
     
-    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+    using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+    using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
+    using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C2_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C2_FEMDef.hpp
@@ -431,7 +431,7 @@ namespace Intrepid2 {
                                  2, 0, 0, 1};
   
       //host view
-      ordinal_type_array_1d_host tagView(&tags[0],36);
+      OrdinalTypeArray1DHost tagView(&tags[0],36);
     
       // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
       this->setOrdinalTagData(this->tagToOrdinal_,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C2_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C2_FEMDef.hpp
@@ -56,12 +56,12 @@ namespace Intrepid2 {
   namespace Impl {                                                                                                                                                       
                                                                                                                                                                          
     template<EOperator opType>                                                                                                                                           
-    template<typename outputViewType,                                                                                                                                    
+    template<typename OutputViewType,                                                                                                                                    
              typename inputViewType>                                                                                                                                     
     KOKKOS_INLINE_FUNCTION                                                                                                                                               
     void                                                                                                                                                                 
     Basis_HGRAD_QUAD_C2_FEM::Serial<opType>::                                                                                                                             
-    getValues(       outputViewType output,                                                                                                                              
+    getValues(       OutputViewType output,                                                                                                                              
                const inputViewType input ) {   
     switch (opType) {
     case OPERATOR_VALUE : {
@@ -445,7 +445,7 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoords("dofCoordsHost", this->basisCardinality_,this->basisCellTopology_.getDimension());
     
     dofCoords(0,0) = -1.0;   dofCoords(0,1) = -1.0;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C2_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_C2_FEMDef.hpp
@@ -408,6 +408,7 @@ namespace Intrepid2 {
     this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Quadrilateral<4> >() );
     this->basisType_         = BASIS_FEM_DEFAULT;
     this->basisCoordinates_  = COORDINATES_CARTESIAN;
+    this->functionSpace_     = FUNCTION_SPACE_HGRAD;
 
     {
       // Basis-dependent intializations

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_Cn_FEM.hpp
@@ -170,17 +170,17 @@ namespace Intrepid2 {
     using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
     using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
 
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
+    using ordinal_type_array_1d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead");
+    using ordinal_type_array_2d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead");
+    using ordinal_type_array_3d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead");
 
     using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
     using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
     using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
     
-    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+    using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+    using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
+    using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
 
   private:
     /** \brief inverse of Generalized Vandermonde matrix (isotropic order) */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_Cn_FEM.hpp
@@ -166,9 +166,13 @@ namespace Intrepid2 {
   class Basis_HGRAD_QUAD_Cn_FEM
     : public Basis<ExecSpaceType,outputValueType,pointValueType> {
   public:
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
     typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
     typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_Cn_FEM.hpp
@@ -174,13 +174,17 @@ namespace Intrepid2 {
     INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
     INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarViewType  scalarViewType;
+    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    
+    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
 
   private:
     /** \brief inverse of Generalized Vandermonde matrix (isotropic order) */
-    Kokkos::DynRankView<typename scalarViewType::value_type,ExecSpaceType> vinv_;
+    Kokkos::DynRankView<typename ScalarViewType::value_type,ExecSpaceType> vinv_;
 
   public:
     /** \brief  Constructor.
@@ -192,8 +196,8 @@ namespace Intrepid2 {
 
     virtual
     void
-    getValues(       outputViewType outputValues,
-               const pointViewType  inputPoints,
+    getValues(       OutputViewType outputValues,
+               const PointViewType  inputPoints,
                const EOperator operatorType = OPERATOR_VALUE ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       Intrepid2::getValues_HGRAD_Args(outputValues,
@@ -212,7 +216,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoords( scalarViewType dofCoords ) const {
+    getDofCoords( ScalarViewType dofCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,
@@ -229,7 +233,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoeffs( scalarViewType dofCoeffs ) const {
+    getDofCoeffs( ScalarViewType dofCoeffs ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoeffs.rank() != 1, std::invalid_argument,
@@ -253,7 +257,7 @@ namespace Intrepid2 {
       return (this->basisDegree_ > 2);
     }
 
-    Kokkos::DynRankView<typename scalarViewType::const_value_type,ExecSpaceType>
+    Kokkos::DynRankView<typename ScalarViewType::const_value_type,ExecSpaceType>
     getVandermondeInverse() const {
       return vinv_;
     }

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_Cn_FEMDef.hpp
@@ -55,14 +55,14 @@ namespace Intrepid2 {
   namespace Impl {
 
     template<EOperator opType>
-    template<typename outputViewType,
+    template<typename OutputViewType,
              typename inputViewType,
              typename workViewType,
              typename vinvViewType>
     KOKKOS_INLINE_FUNCTION
     void
     Basis_HGRAD_QUAD_Cn_FEM::Serial<opType>::
-    getValues(       outputViewType output,
+    getValues(       OutputViewType output,
                const inputViewType  input,
                      workViewType   work,
                const vinvViewType   vinv,
@@ -285,7 +285,7 @@ namespace Intrepid2 {
     Basis_HGRAD_LINE_Cn_FEM<SpT,OT,PT> lineBasis( order, pointType );
     const auto cardLine = lineBasis.getCardinality();
     
-    this->vinv_ = Kokkos::DynRankView<typename scalarViewType::value_type,SpT>("Hgrad::Quad::Cn::vinv", cardLine, cardLine);         
+    this->vinv_ = Kokkos::DynRankView<typename ScalarViewType::value_type,SpT>("Hgrad::Quad::Cn::vinv", cardLine, cardLine);         
     lineBasis.getVandermondeInverse(this->vinv_);
 
     this->basisCardinality_  = cardLine*cardLine;
@@ -362,10 +362,10 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoordsHost("dofCoordsHost", this->basisCardinality_, this->basisCellTopology_.getDimension());
 
-    Kokkos::DynRankView<typename scalarViewType::value_type,SpT>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,SpT>
       dofCoordsLine("dofCoordsLine", cardLine, 1);
 
     lineBasis.getDofCoords(dofCoordsLine);

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_Cn_FEMDef.hpp
@@ -293,6 +293,7 @@ namespace Intrepid2 {
     this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Quadrilateral<4> >() );
     this->basisType_         = BASIS_FEM_FIAT;
     this->basisCoordinates_  = COORDINATES_CARTESIAN;
+    this->functionSpace_     = FUNCTION_SPACE_HGRAD;
 
     // initialize tags
     {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_QUAD_Cn_FEMDef.hpp
@@ -347,7 +347,7 @@ namespace Intrepid2 {
         }
       }
       
-      ordinal_type_array_1d_host tagView(&tags[0][0], this->basisCardinality_*4);
+      OrdinalTypeArray1DHost tagView(&tags[0][0], this->basisCardinality_*4);
 
       // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
       // tags are constructed on host

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_C1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_C1_FEM.hpp
@@ -158,9 +158,13 @@ namespace Intrepid2 {
            typename pointValueType = double>
   class Basis_HGRAD_TET_C1_FEM : public Basis<ExecSpaceType,outputValueType,pointValueType> {
   public:
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
     /** \brief  Constructor.
      */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_C1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_C1_FEM.hpp
@@ -91,11 +91,11 @@ namespace Intrepid2 {
       */
       template<EOperator opType>
       struct Serial {
-        template<typename outputViewType,
+        template<typename OutputViewType,
                  typename inputViewType>
         KOKKOS_INLINE_FUNCTION
         static void
-        getValues(       outputViewType output,
+        getValues(       OutputViewType output,
                    const inputViewType input );
 
       };
@@ -170,16 +170,20 @@ namespace Intrepid2 {
      */
     Basis_HGRAD_TET_C1_FEM();
 
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarViewType  scalarViewType;
+    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    
+    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
-    getValues(       outputViewType outputValues,
-               const pointViewType  inputPoints,
+    getValues(       OutputViewType outputValues,
+               const PointViewType  inputPoints,
                const EOperator operatorType = OPERATOR_VALUE ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify arguments
@@ -197,7 +201,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoords( scalarViewType dofCoords ) const {
+    getDofCoords( ScalarViewType dofCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,
@@ -214,7 +218,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoeffs( scalarViewType dofCoeffs ) const {
+    getDofCoeffs( ScalarViewType dofCoeffs ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoeffs.rank() != 1, std::invalid_argument,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_C1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_C1_FEM.hpp
@@ -162,9 +162,9 @@ namespace Intrepid2 {
     using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
     using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
 
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
+    using ordinal_type_array_1d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead");
+    using ordinal_type_array_2d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead");
+    using ordinal_type_array_3d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead");
 
     /** \brief  Constructor.
      */
@@ -174,9 +174,9 @@ namespace Intrepid2 {
     using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
     using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
     
-    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+    using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+    using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
+    using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_C1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_C1_FEMDef.hpp
@@ -182,6 +182,7 @@ namespace Intrepid2 {
     this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Tetrahedron<4> >() );
     this->basisType_         = BASIS_FEM_DEFAULT;
     this->basisCoordinates_  = COORDINATES_CARTESIAN;
+    this->functionSpace_     = FUNCTION_SPACE_HGRAD;
 
     // initialize tags
     {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_C1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_C1_FEMDef.hpp
@@ -199,11 +199,11 @@ namespace Intrepid2 {
                                  0, 3, 0, 1 };
 
       // host tags
-      ordinal_type_array_1d_host tagView(&tags[0], 16);
+      OrdinalTypeArray1DHost tagView(&tags[0], 16);
 
       // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
-      //ordinal_type_array_2d_host ordinalToTag;
-      //ordinal_type_array_3d_host tagToOrdinal;
+      //OrdinalTypeArray2DHost ordinalToTag;
+      //OrdinalTypeArray3DHost tagToOrdinal;
       this->setOrdinalTagData(this->tagToOrdinal_,
                               this->ordinalToTag_,
                               tagView,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_C1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_C1_FEMDef.hpp
@@ -56,12 +56,12 @@ namespace Intrepid2 {
   namespace Impl {
 
     template<EOperator opType>
-    template<typename outputViewType,
+    template<typename OutputViewType,
              typename inputViewType>
     KOKKOS_INLINE_FUNCTION
     void
     Basis_HGRAD_TET_C1_FEM::Serial<opType>::
-    getValues(       outputViewType output,
+    getValues(       OutputViewType output,
                const inputViewType input ) {
       switch (opType) {
       case OPERATOR_VALUE: {
@@ -221,7 +221,7 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoords("dofCoordsHost", this->basisCardinality_,this->basisCellTopology_.getDimension());
 
     dofCoords(0,0) = 0.0;   dofCoords(0,1) = 0.0; dofCoords(0,2) = 0.0;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_C2_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_C2_FEM.hpp
@@ -181,9 +181,9 @@ namespace Intrepid2 {
     using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
     using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
 
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
+    using ordinal_type_array_1d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead");
+    using ordinal_type_array_2d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead");
+    using ordinal_type_array_3d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead");
 
     /** \brief  Constructor.
      */
@@ -193,9 +193,9 @@ namespace Intrepid2 {
     using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
     using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
     
-    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+    using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+    using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
+    using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_C2_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_C2_FEM.hpp
@@ -177,9 +177,13 @@ namespace Intrepid2 {
            typename pointValueType = double>
   class Basis_HGRAD_TET_C2_FEM : public Basis<ExecSpaceType,outputValueType,pointValueType> {
   public:
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
     /** \brief  Constructor.
      */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_C2_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_C2_FEM.hpp
@@ -110,11 +110,11 @@ namespace Intrepid2 {
       */
       template<EOperator opType>
       struct Serial {
-        template<typename outputViewType,
+        template<typename OutputViewType,
                  typename inputViewType>
         KOKKOS_INLINE_FUNCTION
         static void
-        getValues(       outputViewType output,
+        getValues(       OutputViewType output,
                    const inputViewType input );
 
       };
@@ -189,16 +189,20 @@ namespace Intrepid2 {
      */
     Basis_HGRAD_TET_C2_FEM();
 
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarViewType  scalarViewType;
+    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    
+    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
-    getValues(       outputViewType outputValues,
-               const pointViewType  inputPoints,
+    getValues(       OutputViewType outputValues,
+               const PointViewType  inputPoints,
                const EOperator operatorType = OPERATOR_VALUE ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify arguments
@@ -216,7 +220,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoords( scalarViewType dofCoords ) const {
+    getDofCoords( ScalarViewType dofCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,
@@ -234,7 +238,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoeffs( scalarViewType dofCoeffs ) const {
+    getDofCoeffs( ScalarViewType dofCoeffs ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoeffs.rank() != 1, std::invalid_argument,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_C2_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_C2_FEMDef.hpp
@@ -297,6 +297,7 @@ namespace Intrepid2 {
     this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Tetrahedron<4> >() );
     this->basisType_         = BASIS_FEM_DEFAULT;
     this->basisCoordinates_  = COORDINATES_CARTESIAN;
+    this->functionSpace_     = FUNCTION_SPACE_HGRAD;
 
     // intialize tags
     {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_C2_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_C2_FEMDef.hpp
@@ -321,7 +321,7 @@ namespace Intrepid2 {
       };
 
       // host tags
-      ordinal_type_array_1d_host tagView(&tags[0], 40);
+      OrdinalTypeArray1DHost tagView(&tags[0], 40);
     
       // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
       this->setOrdinalTagData(this->tagToOrdinal_,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_C2_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_C2_FEMDef.hpp
@@ -56,12 +56,12 @@ namespace Intrepid2 {
   namespace Impl {                                                                                                                                                       
                                                                                                                                                                          
     template<EOperator opType>                                                                                                                                           
-    template<typename outputViewType,                                                                                                                                    
+    template<typename OutputViewType,                                                                                                                                    
              typename inputViewType>                                                                                                                                     
     KOKKOS_INLINE_FUNCTION                                                                                                                                               
     void                                                                                                                                                                 
     Basis_HGRAD_TET_C2_FEM::Serial<opType>::                                                                                                                             
-    getValues(       outputViewType output,                                                                                                                              
+    getValues(       OutputViewType output,                                                                                                                              
                const inputViewType input ) {   
       switch (opType) {
       case OPERATOR_VALUE: {
@@ -335,7 +335,7 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoords("dofCoordsHost", this->basisCardinality_,this->basisCellTopology_.getDimension());
 
     dofCoords(0,0) = 0.0;   dofCoords(0,1) = 0.0; dofCoords(0,2) = 0.0;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_COMP12_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_COMP12_FEM.hpp
@@ -190,9 +190,9 @@ namespace Intrepid2 {
     using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
     using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
 
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
+    using ordinal_type_array_1d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead");
+    using ordinal_type_array_2d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead");
+    using ordinal_type_array_3d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead");
 
     /** \brief  Constructor.
      */
@@ -202,9 +202,9 @@ namespace Intrepid2 {
     using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
     using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
     
-    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+    using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+    using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
+    using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_COMP12_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_COMP12_FEM.hpp
@@ -198,9 +198,13 @@ namespace Intrepid2 {
      */
     Basis_HGRAD_TET_COMP12_FEM();
     
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarViewType  scalarViewType;
+    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    
+    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
@@ -218,8 +222,8 @@ namespace Intrepid2 {
     */
     virtual
     void
-    getValues(       outputViewType outputValues,
-               const pointViewType  inputPoints,
+    getValues(       OutputViewType outputValues,
+               const PointViewType  inputPoints,
                const EOperator operatorType = OPERATOR_VALUE ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       Intrepid2::getValues_HGRAD_Args(outputValues,
@@ -242,7 +246,7 @@ namespace Intrepid2 {
     */
     virtual
     void
-    getDofCoords( scalarViewType dofCoords ) const {
+    getDofCoords( ScalarViewType dofCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_COMP12_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_COMP12_FEM.hpp
@@ -186,9 +186,13 @@ namespace Intrepid2 {
            typename pointValueType = double>
   class Basis_HGRAD_TET_COMP12_FEM : public Basis<ExecSpaceType,outputValueType,pointValueType> {
   public:
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
     /** \brief  Constructor.
      */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_COMP12_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_COMP12_FEMDef.hpp
@@ -386,6 +386,7 @@ namespace Intrepid2 {
     this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Tetrahedron<11> >() );
     this->basisType_         = BASIS_FEM_DEFAULT;
     this->basisCoordinates_  = COORDINATES_CARTESIAN;
+    this->functionSpace_     = FUNCTION_SPACE_HGRAD;
 
     {
       // Basis-dependent intializations

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_COMP12_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_COMP12_FEMDef.hpp
@@ -408,7 +408,7 @@ namespace Intrepid2 {
                                1, 5, 0, 1 };
       
       // host view
-      ordinal_type_array_1d_host tagView(&tags[0],40);
+      OrdinalTypeArray1DHost tagView(&tags[0],40);
 
       // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
       this->setOrdinalTagData(this->tagToOrdinal_,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_COMP12_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_COMP12_FEMDef.hpp
@@ -422,7 +422,7 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoords("dofCoordsHost", this->basisCardinality_, this->basisCellTopology_.getDimension());
 
     dofCoords(0,0) = 0.0;   dofCoords(0,1) = 0.0; dofCoords(0,2) = 0.0;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEM.hpp
@@ -190,17 +190,17 @@ namespace Intrepid2 {
     using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
     using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
 
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
+    using ordinal_type_array_1d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead");
+    using ordinal_type_array_2d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead");
+    using ordinal_type_array_3d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead");
 
     using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
     using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
     using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
     
-    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+    using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+    using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
+    using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
 
     typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarType  scalarType;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEM.hpp
@@ -186,9 +186,13 @@ namespace Intrepid2 {
   class Basis_HGRAD_TET_Cn_FEM
     : public Basis<ExecSpaceType,outputValueType,pointValueType> {
   public:
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
     typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
     typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEM.hpp
@@ -194,9 +194,14 @@ namespace Intrepid2 {
     INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
     INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarViewType  scalarViewType;
+    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    
+    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+
     typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarType  scalarType;
 
   private:
@@ -218,8 +223,8 @@ namespace Intrepid2 {
 
     virtual
     void
-    getValues(       outputViewType outputValues,
-                     const pointViewType  inputPoints,
+    getValues(       OutputViewType outputValues,
+                     const PointViewType  inputPoints,
                      const EOperator operatorType = OPERATOR_VALUE) const {
 #ifdef HAVE_INTREPID2_DEBUG
       Intrepid2::getValues_HGRAD_Args(outputValues,
@@ -238,7 +243,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoords( scalarViewType dofCoords ) const {
+    getDofCoords( ScalarViewType dofCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,
@@ -255,7 +260,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoeffs( scalarViewType dofCoeffs ) const {
+    getDofCoeffs( ScalarViewType dofCoeffs ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoeffs.rank() != 1, std::invalid_argument,
@@ -269,7 +274,7 @@ namespace Intrepid2 {
 
 
     void
-    getVandermondeInverse( scalarViewType vinv ) const {
+    getVandermondeInverse( ScalarViewType vinv ) const {
       // has to be same rank and dimensions
       Kokkos::deep_copy(vinv, this->vinv_);
     }
@@ -286,7 +291,7 @@ namespace Intrepid2 {
       return (this->basisDegree_ > 2);
     }
 
-    Kokkos::DynRankView<typename scalarViewType::const_value_type,ExecSpaceType>
+    Kokkos::DynRankView<typename ScalarViewType::const_value_type,ExecSpaceType>
     getVandermondeInverse() const {
       return vinv_;
     }

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEMDef.hpp
@@ -58,14 +58,14 @@ namespace Intrepid2 {
 namespace Impl {
 
 template<EOperator opType>
-template<typename outputViewType,
+template<typename OutputViewType,
 typename inputViewType,
 typename workViewType,
 typename vinvViewType>
 KOKKOS_INLINE_FUNCTION
 void
 Basis_HGRAD_TET_Cn_FEM::Serial<opType>::
-getValues(       outputViewType output,
+getValues(       OutputViewType output,
     const inputViewType  input,
     workViewType   work,
     const vinvViewType   vinv ) {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEMDef.hpp
@@ -438,7 +438,7 @@ Basis_HGRAD_TET_Cn_FEM( const ordinal_type order,
     const ordinal_type posScOrd = 1;        // position in the tag, counting from 0, of the subcell ordinal
     const ordinal_type posDfOrd = 2;        // position in the tag, counting from 0, of DoF ordinal relative to the subcell
 
-    ordinal_type_array_1d_host tagView(&tags[0][0], card*tagSize);
+    OrdinalTypeArray1DHost tagView(&tags[0][0], card*tagSize);
 
     // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
     // tags are constructed on host

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEMDef.hpp
@@ -232,6 +232,7 @@ Basis_HGRAD_TET_Cn_FEM( const ordinal_type order,
   this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Tetrahedron<4> >() );
   this->basisType_         = BASIS_FEM_FIAT;
   this->basisCoordinates_  = COORDINATES_CARTESIAN;
+  this->functionSpace_     = FUNCTION_SPACE_HGRAD;
 
   const ordinal_type card = this->basisCardinality_;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEM_ORTH.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEM_ORTH.hpp
@@ -229,8 +229,8 @@ class Basis_HGRAD_TET_Cn_FEM_ORTH
   using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
   using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
   
-  INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-  INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+  using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+  using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
   
   using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEM_ORTH.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEM_ORTH.hpp
@@ -217,9 +217,9 @@ class Basis_HGRAD_TET_Cn_FEM_ORTH
     : public Basis<ExecSpaceType,outputValueType,pointValueType> {
     public:
   typedef double value_type;
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost OrdinalTypeArray1DHost;
+  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost OrdinalTypeArray2DHost;
+  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost OrdinalTypeArray3DHost;
 
   /** \brief  Constructor.
    */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEM_ORTH.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEM_ORTH.hpp
@@ -66,14 +66,14 @@ namespace Impl {
 
 /** \brief See Intrepid2::Basis_HGRAD_TET_Cn_FEM_ORTH
  */
-template<typename outputViewType,
+template<typename OutputViewType,
 typename inputViewType, 
 typename workViewType,
 bool hasDeriv, ordinal_type n>
 struct OrthPolynomialTet {
   KOKKOS_INLINE_FUNCTION
   static void
-  generate(       outputViewType output,
+  generate(       OutputViewType output,
             const inputViewType input,
                   workViewType work,
             const ordinal_type p );
@@ -81,14 +81,14 @@ struct OrthPolynomialTet {
 
 /** \brief See Intrepid2::Basis_HGRAD_TET_Cn_FEM_ORTH
  */
-template<typename outputViewType,
+template<typename OutputViewType,
 typename inputViewType,
 typename workViewType,
 bool hasDeriv>
-struct OrthPolynomialTet<outputViewType,inputViewType,workViewType,hasDeriv,0> {
+struct OrthPolynomialTet<OutputViewType,inputViewType,workViewType,hasDeriv,0> {
   KOKKOS_INLINE_FUNCTION
   static void
-  generate(       outputViewType output,
+  generate(       OutputViewType output,
             const inputViewType input,
                   workViewType work,
             const ordinal_type p );
@@ -96,14 +96,14 @@ struct OrthPolynomialTet<outputViewType,inputViewType,workViewType,hasDeriv,0> {
 
 /** \brief See Intrepid2::Basis_HGRAD_TET_Cn_FEM_ORTH
  */
-template<typename outputViewType,
+template<typename OutputViewType,
 typename inputViewType,
 typename workViewType,
 bool hasDeriv>
-struct OrthPolynomialTet<outputViewType,inputViewType,workViewType,hasDeriv,1> {
+struct OrthPolynomialTet<OutputViewType,inputViewType,workViewType,hasDeriv,1> {
   KOKKOS_INLINE_FUNCTION
   static void
-  generate(   outputViewType output,
+  generate(   OutputViewType output,
       const inputViewType input,
             workViewType work,
       const ordinal_type p );
@@ -120,12 +120,12 @@ public:
   */
   template<EOperator opType>
   struct Serial {
-    template<typename outputViewType,
+    template<typename OutputViewType,
     typename inputViewType,
     typename workViewType>
     KOKKOS_INLINE_FUNCTION
     static void
-    getValues(       outputViewType output,
+    getValues(       OutputViewType output,
                const inputViewType  input,
                      workViewType work,
                const ordinal_type   order);
@@ -225,15 +225,19 @@ class Basis_HGRAD_TET_Cn_FEM_ORTH
    */
   Basis_HGRAD_TET_Cn_FEM_ORTH( const ordinal_type order );
 
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
+  using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+  using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+  using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+  
+  INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+  INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
   
   using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
   virtual
   void
-  getValues(       outputViewType outputValues,
-             const pointViewType  inputPoints,
+  getValues(       OutputViewType outputValues,
+             const PointViewType  inputPoints,
              const EOperator operatorType = OPERATOR_VALUE ) const {
     #ifdef HAVE_INTREPID2_DEBUG
           Intrepid2::getValues_HGRAD_Args(outputValues,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEM_ORTHDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEM_ORTHDef.hpp
@@ -476,6 +476,7 @@ Basis_HGRAD_TET_Cn_FEM_ORTH( const ordinal_type order ) {
   this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Tetrahedron<4> >() );
   this->basisType_         = BASIS_FEM_HIERARCHICAL;
   this->basisCoordinates_  = COORDINATES_CARTESIAN;
+  this->functionSpace_     = FUNCTION_SPACE_HGRAD;
 
   // initialize tags
   {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEM_ORTHDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEM_ORTHDef.hpp
@@ -54,13 +54,13 @@ namespace Intrepid2 {
 
 namespace Impl {
 
-template<typename outputViewType,
+template<typename OutputViewType,
 typename inputViewType,
 typename workViewType,
 bool hasDeriv>
 KOKKOS_INLINE_FUNCTION
-void OrthPolynomialTet<outputViewType,inputViewType,workViewType,hasDeriv,0>::generate(
-    outputViewType output,
+void OrthPolynomialTet<OutputViewType,inputViewType,workViewType,hasDeriv,0>::generate(
+    OutputViewType output,
     const inputViewType input,
     workViewType  /*work*/,
     const ordinal_type order ) {
@@ -68,7 +68,7 @@ void OrthPolynomialTet<outputViewType,inputViewType,workViewType,hasDeriv,0>::ge
   constexpr ordinal_type spaceDim = 3;
   constexpr ordinal_type maxNumPts = Parameters::MaxNumPtsPerBasisEval;
 
-  typedef typename outputViewType::value_type value_type;
+  typedef typename OutputViewType::value_type value_type;
 
   auto output0 = (hasDeriv) ? Kokkos::subview(output,  Kokkos::ALL(), Kokkos::ALL(),0) : Kokkos::subview(output,  Kokkos::ALL(), Kokkos::ALL());
 
@@ -266,13 +266,13 @@ void OrthPolynomialTet<outputViewType,inputViewType,workViewType,hasDeriv,0>::ge
       }
 }
 
-template<typename outputViewType,
+template<typename OutputViewType,
 typename inputViewType,
 typename workViewType,
 bool hasDeriv>
 KOKKOS_INLINE_FUNCTION
-void OrthPolynomialTet<outputViewType,inputViewType,workViewType,hasDeriv,1>::generate(
-    outputViewType output,
+void OrthPolynomialTet<OutputViewType,inputViewType,workViewType,hasDeriv,1>::generate(
+    OutputViewType output,
     const inputViewType  input,
     workViewType   work,
     const ordinal_type   order ) {
@@ -291,14 +291,14 @@ void OrthPolynomialTet<outputViewType,inputViewType,workViewType,hasDeriv,1>::ge
 
 
 // when n >= 2, use recursion
-template<typename outputViewType,
+template<typename OutputViewType,
 typename inputViewType,
 typename workViewType,
 bool hasDeriv,
 ordinal_type n>
 KOKKOS_INLINE_FUNCTION
-void OrthPolynomialTet<outputViewType,inputViewType,workViewType,hasDeriv,n>::generate(
-    outputViewType /* output */,
+void OrthPolynomialTet<OutputViewType,inputViewType,workViewType,hasDeriv,n>::generate(
+    OutputViewType /* output */,
     const inputViewType  /* input */,
     workViewType   /* work */,
     const ordinal_type   /* order */ ) {
@@ -307,7 +307,7 @@ void OrthPolynomialTet<outputViewType,inputViewType,workViewType,hasDeriv,n>::ge
 constexpr ordinal_type spaceDim = 3;
 constexpr ordinal_type maxCard = Intrepid2::getPnCardinality<spaceDim, Parameters::MaxOrder>();
 
-typedef typename outputViewType::value_type value_type;
+typedef typename OutputViewType::value_type value_type;
 typedef Sacado::Fad::SFad<value_type,spaceDim> fad_type;
 
 const ordinal_type
@@ -377,28 +377,28 @@ INTREPID2_TEST_FOR_ABORT( true,
 
 
 template<EOperator opType>
-template<typename outputViewType,
+template<typename OutputViewType,
 typename inputViewType,
 typename workViewType>
 KOKKOS_INLINE_FUNCTION
 void
 Basis_HGRAD_TET_Cn_FEM_ORTH::Serial<opType>::
-getValues( outputViewType output,
+getValues( OutputViewType output,
     const inputViewType  input,
     workViewType   work,
     const ordinal_type   order) {
   switch (opType) {
   case OPERATOR_VALUE: {
-    OrthPolynomialTet<outputViewType,inputViewType,workViewType,false,0>::generate( output, input, work, order );
+    OrthPolynomialTet<OutputViewType,inputViewType,workViewType,false,0>::generate( output, input, work, order );
     break;
   }
   case OPERATOR_GRAD:
   case OPERATOR_D1: {
-    OrthPolynomialTet<outputViewType,inputViewType,workViewType,true,1>::generate( output, input, work, order );
+    OrthPolynomialTet<OutputViewType,inputViewType,workViewType,true,1>::generate( output, input, work, order );
     break;
   }
   case OPERATOR_D2: {
-    OrthPolynomialTet<outputViewType,inputViewType,workViewType,true,2>::generate( output, input, work, order );
+    OrthPolynomialTet<OutputViewType,inputViewType,workViewType,true,2>::generate( output, input, work, order );
     break;
   }
   default: {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEM_ORTHDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TET_Cn_FEM_ORTHDef.hpp
@@ -496,7 +496,7 @@ Basis_HGRAD_TET_Cn_FEM_ORTH( const ordinal_type order ) {
       tags[i][3] = card;  // total number of DoFs
     }
 
-    ordinal_type_array_1d_host tagView(&tags[0][0], card*tagSize);
+    OrdinalTypeArray1DHost tagView(&tags[0][0], card*tagSize);
 
     // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
     // tags are constructed on host

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_C1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_C1_FEM.hpp
@@ -160,9 +160,9 @@ namespace Intrepid2 {
     using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
     using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
 
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
+    using ordinal_type_array_1d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead");
+    using ordinal_type_array_2d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead");
+    using ordinal_type_array_3d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead");
 
     /** \brief  Constructor.
      */
@@ -172,9 +172,9 @@ namespace Intrepid2 {
     using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
     using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
     
-    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+    using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+    using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
+    using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_C1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_C1_FEM.hpp
@@ -156,9 +156,13 @@ namespace Intrepid2 {
            typename pointValueType = double>
   class Basis_HGRAD_TRI_C1_FEM: public Basis<ExecSpaceType,outputValueType,pointValueType> {
   public:
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
     /** \brief  Constructor.
      */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_C1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_C1_FEM.hpp
@@ -89,11 +89,11 @@ namespace Intrepid2 {
       */
       template<EOperator opType>
       struct Serial {
-        template<typename outputViewType,
+        template<typename OutputViewType,
                  typename inputViewType>
         KOKKOS_INLINE_FUNCTION
         static void
-        getValues(       outputViewType output,
+        getValues(       OutputViewType output,
                    const inputViewType input );
 
       };
@@ -168,16 +168,20 @@ namespace Intrepid2 {
      */
     Basis_HGRAD_TRI_C1_FEM();
 
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarViewType  scalarViewType;
+    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    
+    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
-    getValues(       outputViewType outputValues,
-               const pointViewType  inputPoints,
+    getValues(       OutputViewType outputValues,
+               const PointViewType  inputPoints,
                const EOperator operatorType = OPERATOR_VALUE ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify arguments
@@ -195,7 +199,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoords( scalarViewType dofCoords ) const {
+    getDofCoords( ScalarViewType dofCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,
@@ -212,7 +216,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoeffs( scalarViewType dofCoeffs ) const {
+    getDofCoeffs( ScalarViewType dofCoeffs ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoeffs.rank() != 1, std::invalid_argument,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_C1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_C1_FEMDef.hpp
@@ -202,11 +202,11 @@ namespace Intrepid2 {
                                  0, 2, 0, 1 };
 
       // host tags
-      ordinal_type_array_1d_host tagView(&tags[0], 12);
+      OrdinalTypeArray1DHost tagView(&tags[0], 12);
 
       // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
-      //ordinal_type_array_2d_host ordinalToTag;
-      //ordinal_type_array_3d_host tagToOrdinal;
+      //OrdinalTypeArray2DHost ordinalToTag;
+      //OrdinalTypeArray3DHost tagToOrdinal;
       this->setOrdinalTagData(this->tagToOrdinal_,
                               this->ordinalToTag_,
                               tagView,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_C1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_C1_FEMDef.hpp
@@ -57,12 +57,12 @@ namespace Intrepid2 {
   namespace Impl {
 
     template<EOperator opType>
-    template<typename outputViewType,
+    template<typename OutputViewType,
              typename inputViewType>
     KOKKOS_INLINE_FUNCTION
     void
     Basis_HGRAD_TRI_C1_FEM::Serial<opType>::
-    getValues(       outputViewType output,
+    getValues(       OutputViewType output,
                const inputViewType input ) {
       switch (opType) {
       case OPERATOR_VALUE: {
@@ -224,7 +224,7 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoords("dofCoordsHost", this->basisCardinality_,this->basisCellTopology_.getDimension());
 
     dofCoords(0,0) =  0.0;   dofCoords(0,1) =  0.0;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_C1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_C1_FEMDef.hpp
@@ -186,6 +186,7 @@ namespace Intrepid2 {
     this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Triangle<3> >() );
     this->basisType_         = BASIS_FEM_DEFAULT;
     this->basisCoordinates_  = COORDINATES_CARTESIAN;
+    this->functionSpace_     = FUNCTION_SPACE_HGRAD;
 
     // initialize tags
     {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_C2_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_C2_FEM.hpp
@@ -96,11 +96,11 @@ namespace Intrepid2 {
       */
       template<EOperator opType>
       struct Serial {
-        template<typename outputViewType,
+        template<typename OutputViewType,
                  typename inputViewType>
         KOKKOS_INLINE_FUNCTION
         static void
-        getValues(       outputViewType output,
+        getValues(       OutputViewType output,
                    const inputViewType input );
 
       };
@@ -179,16 +179,20 @@ namespace Intrepid2 {
      */
     Basis_HGRAD_TRI_C2_FEM();
 
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarViewType  scalarViewType;
+    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    
+    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
-    getValues(       outputViewType outputValues,
-               const pointViewType  inputPoints,
+    getValues(       OutputViewType outputValues,
+               const PointViewType  inputPoints,
                const EOperator operatorType = OPERATOR_VALUE ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify arguments
@@ -206,7 +210,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoords( scalarViewType dofCoords ) const {
+    getDofCoords( ScalarViewType dofCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,
@@ -223,7 +227,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoeffs( scalarViewType dofCoeffs ) const {
+    getDofCoeffs( ScalarViewType dofCoeffs ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoeffs.rank() != 1, std::invalid_argument,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_C2_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_C2_FEM.hpp
@@ -171,9 +171,9 @@ namespace Intrepid2 {
     using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
     using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
 
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
+    using ordinal_type_array_1d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead");
+    using ordinal_type_array_2d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead");
+    using ordinal_type_array_3d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead");
 
     /** \brief  Constructor.
      */
@@ -183,9 +183,9 @@ namespace Intrepid2 {
     using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
     using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
     
-    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+    using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+    using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
+    using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_C2_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_C2_FEM.hpp
@@ -167,9 +167,13 @@ namespace Intrepid2 {
            typename pointValueType = double>
   class Basis_HGRAD_TRI_C2_FEM: public Basis<ExecSpaceType,outputValueType,pointValueType> {
   public:
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
     /** \brief  Constructor.
      */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_C2_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_C2_FEMDef.hpp
@@ -56,12 +56,12 @@ namespace Intrepid2 {
   namespace Impl {
 
     template<EOperator opType>
-    template<typename outputViewType,
+    template<typename OutputViewType,
              typename inputViewType>
     KOKKOS_INLINE_FUNCTION
     void
     Basis_HGRAD_TRI_C2_FEM::Serial<opType>::
-    getValues(       outputViewType output,
+    getValues(       OutputViewType output,
                const inputViewType input ) {
       switch (opType) {
       case OPERATOR_VALUE: {
@@ -280,7 +280,7 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoords("dofCoordsHost", this->basisCardinality_,this->basisCellTopology_.getDimension());
 
     dofCoords(0,0) =  0.0;   dofCoords(0,1) =  0.0;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_C2_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_C2_FEMDef.hpp
@@ -247,6 +247,7 @@ namespace Intrepid2 {
     this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Triangle<3> >() );
     this->basisType_         = BASIS_FEM_DEFAULT;
     this->basisCoordinates_  = COORDINATES_CARTESIAN;
+    this->functionSpace_     = FUNCTION_SPACE_HGRAD;
 
     // initialize tags
     {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_C2_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_C2_FEMDef.hpp
@@ -266,7 +266,7 @@ namespace Intrepid2 {
                                  1, 2, 0, 1};
 
       //host tags
-      ordinal_type_array_1d_host tagView(&tags[0], 24);
+      OrdinalTypeArray1DHost tagView(&tags[0], 24);
 
       // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
       this->setOrdinalTagData(this->tagToOrdinal_,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEM.hpp
@@ -185,17 +185,17 @@ namespace Intrepid2 {
     using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
     using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
 
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
+    using ordinal_type_array_1d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead");
+    using ordinal_type_array_2d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead");
+    using ordinal_type_array_3d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead");
 
     using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
     using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
     using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
     
-    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+    using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+    using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
+    using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
 
     typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarType  scalarType;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEM.hpp
@@ -189,9 +189,14 @@ namespace Intrepid2 {
     INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
     INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarViewType  scalarViewType;
+    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    
+    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+
     typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarType  scalarType;
 
   private:
@@ -210,8 +215,8 @@ namespace Intrepid2 {
 
     virtual
     void
-    getValues(       outputViewType outputValues,
-                     const pointViewType  inputPoints,
+    getValues(       OutputViewType outputValues,
+                     const PointViewType  inputPoints,
                      const EOperator operatorType = OPERATOR_VALUE) const {
 #ifdef HAVE_INTREPID2_DEBUG
       Intrepid2::getValues_HGRAD_Args(outputValues,
@@ -230,7 +235,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoords( scalarViewType dofCoords ) const {
+    getDofCoords( ScalarViewType dofCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,
@@ -247,7 +252,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoeffs( scalarViewType dofCoeffs ) const {
+    getDofCoeffs( ScalarViewType dofCoeffs ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoeffs.rank() != 1, std::invalid_argument,
@@ -273,12 +278,12 @@ namespace Intrepid2 {
     }
 
     void
-    getVandermondeInverse( scalarViewType vinv ) const {
+    getVandermondeInverse( ScalarViewType vinv ) const {
       // has to be same rank and dimensions
       Kokkos::deep_copy(vinv, this->vinv_);
     }
 
-    Kokkos::DynRankView<typename scalarViewType::const_value_type,ExecSpaceType>
+    Kokkos::DynRankView<typename ScalarViewType::const_value_type,ExecSpaceType>
     getVandermondeInverse() const {
       return vinv_;
     }

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEM.hpp
@@ -181,9 +181,13 @@ namespace Intrepid2 {
   class Basis_HGRAD_TRI_Cn_FEM
     : public Basis<ExecSpaceType,outputValueType,pointValueType> {
   public:
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
     typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
     typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEMDef.hpp
@@ -392,7 +392,7 @@ Basis_HGRAD_TRI_Cn_FEM( const ordinal_type order,
       }
     }
 
-    ordinal_type_array_1d_host tagView(&tags[0][0], card*tagSize);
+    OrdinalTypeArray1DHost tagView(&tags[0][0], card*tagSize);
 
     // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
     // tags are constructed on host

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEMDef.hpp
@@ -258,6 +258,7 @@ Basis_HGRAD_TRI_Cn_FEM( const ordinal_type order,
   this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Triangle<3> >() );
   this->basisType_         = BASIS_FEM_FIAT;
   this->basisCoordinates_  = COORDINATES_CARTESIAN;
+  this->functionSpace_     = FUNCTION_SPACE_HGRAD;
 
   const ordinal_type card = this->basisCardinality_;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEMDef.hpp
@@ -57,14 +57,14 @@ namespace Intrepid2 {
 namespace Impl {
 
 template<EOperator opType>
-template<typename outputViewType,
+template<typename OutputViewType,
 typename inputViewType,
 typename workViewType,
 typename vinvViewType>
 KOKKOS_INLINE_FUNCTION
 void
 Basis_HGRAD_TRI_Cn_FEM::Serial<opType>::
-getValues(       outputViewType output,
+getValues(       OutputViewType output,
     const inputViewType  input,
     workViewType   work,
     const vinvViewType   vinv ) {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEM_ORTH.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEM_ORTH.hpp
@@ -220,9 +220,9 @@ class Basis_HGRAD_TRI_Cn_FEM_ORTH
     : public Basis<ExecSpaceType,outputValueType,pointValueType> {
     public:
   typedef double value_type;
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost OrdinalTypeArray1DHost;
+  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost OrdinalTypeArray2DHost;
+  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost OrdinalTypeArray3DHost;
 
   /** \brief  Constructor.
    */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEM_ORTH.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEM_ORTH.hpp
@@ -232,8 +232,8 @@ class Basis_HGRAD_TRI_Cn_FEM_ORTH
     using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
     using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
     
-    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+    using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+    using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
 
   using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEM_ORTH.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEM_ORTH.hpp
@@ -67,14 +67,14 @@ namespace Impl {
 /**
    \brief See Intrepid2::Basis_HGRAD_TRI_Cn_FEM_ORTH
 */
-template<typename outputViewType,
+template<typename OutputViewType,
 typename inputViewType,
 typename workViewType,
 bool hasDeriv, ordinal_type n>
 struct OrthPolynomialTri {
   KOKKOS_INLINE_FUNCTION
   static void
-  generate(       outputViewType output,
+  generate(       OutputViewType output,
             const inputViewType input,
                   workViewType work,
             const ordinal_type p );
@@ -83,14 +83,14 @@ struct OrthPolynomialTri {
 /**
    \brief See Intrepid2::Basis_HGRAD_TRI_Cn_FEM_ORTH
 */
-template<typename outputViewType,
+template<typename OutputViewType,
 typename inputViewType,
 typename workViewType,
 bool hasDeriv>
-struct OrthPolynomialTri<outputViewType,inputViewType,workViewType,hasDeriv,0> {
+struct OrthPolynomialTri<OutputViewType,inputViewType,workViewType,hasDeriv,0> {
   KOKKOS_INLINE_FUNCTION
   static void
-  generate(       outputViewType output,
+  generate(       OutputViewType output,
             const inputViewType input,
                   workViewType work,
             const ordinal_type p );
@@ -99,14 +99,14 @@ struct OrthPolynomialTri<outputViewType,inputViewType,workViewType,hasDeriv,0> {
 /**
    \brief See Intrepid2::Basis_HGRAD_TRI_Cn_FEM_ORTH
 */
-template<typename outputViewType,
+template<typename OutputViewType,
 typename inputViewType,
 typename workViewType,
 bool hasDeriv>
-struct OrthPolynomialTri<outputViewType,inputViewType,workViewType,hasDeriv,1> {
+struct OrthPolynomialTri<OutputViewType,inputViewType,workViewType,hasDeriv,1> {
   KOKKOS_INLINE_FUNCTION
   static void
-  generate(   outputViewType output,
+  generate(   OutputViewType output,
       const inputViewType input,
             workViewType work,
       const ordinal_type p );
@@ -123,12 +123,12 @@ public:
   */
   template<EOperator opType>
   struct Serial {
-    template<typename outputViewType,
+    template<typename OutputViewType,
     typename inputViewType,
     typename workViewType>
     KOKKOS_INLINE_FUNCTION
     static void
-    getValues(       outputViewType output,
+    getValues(       OutputViewType output,
                const inputViewType  input,
                      workViewType work,
                const ordinal_type   order);
@@ -228,15 +228,19 @@ class Basis_HGRAD_TRI_Cn_FEM_ORTH
    */
   Basis_HGRAD_TRI_Cn_FEM_ORTH( const ordinal_type order );
 
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-  typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
+    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    
+    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
 
   using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
   virtual
   void
-  getValues(       outputViewType outputValues,
-             const pointViewType  inputPoints,
+  getValues(       OutputViewType outputValues,
+             const PointViewType  inputPoints,
              const EOperator operatorType = OPERATOR_VALUE ) const {
     #ifdef HAVE_INTREPID2_DEBUG
           Intrepid2::getValues_HGRAD_Args(outputValues,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEM_ORTHDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEM_ORTHDef.hpp
@@ -417,7 +417,7 @@ Basis_HGRAD_TRI_Cn_FEM_ORTH( const ordinal_type order ) {
       tags[i][3] = card;  // total number of DoFs
     }
 
-    ordinal_type_array_1d_host tagView(&tags[0][0], card*tagSize);
+    OrdinalTypeArray1DHost tagView(&tags[0][0], card*tagSize);
 
     // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
     // tags are constructed on host

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEM_ORTHDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEM_ORTHDef.hpp
@@ -397,6 +397,7 @@ Basis_HGRAD_TRI_Cn_FEM_ORTH( const ordinal_type order ) {
   this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Triangle<3> >() );
   this->basisType_         = BASIS_FEM_HIERARCHICAL;
   this->basisCoordinates_  = COORDINATES_CARTESIAN;
+  this->functionSpace_     = FUNCTION_SPACE_HGRAD;
 
   // initialize tags
   {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEM_ORTHDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_TRI_Cn_FEM_ORTHDef.hpp
@@ -55,13 +55,13 @@ namespace Intrepid2 {
 
 namespace Impl {
 
-template<typename outputViewType,
+template<typename OutputViewType,
 typename inputViewType,
 typename workViewType,
 bool hasDeriv>
 KOKKOS_INLINE_FUNCTION
-void OrthPolynomialTri<outputViewType,inputViewType,workViewType,hasDeriv,0>::generate(
-    outputViewType output,
+void OrthPolynomialTri<OutputViewType,inputViewType,workViewType,hasDeriv,0>::generate(
+    OutputViewType output,
     const inputViewType input,
     workViewType  /*work*/,
     const ordinal_type order ) {
@@ -69,7 +69,7 @@ void OrthPolynomialTri<outputViewType,inputViewType,workViewType,hasDeriv,0>::ge
   constexpr ordinal_type spaceDim = 2;
   constexpr ordinal_type maxNumPts = Parameters::MaxNumPtsPerBasisEval;
 
-  typedef typename outputViewType::value_type value_type;
+  typedef typename OutputViewType::value_type value_type;
 
   auto output0 = (hasDeriv) ? Kokkos::subview(output,  Kokkos::ALL(), Kokkos::ALL(),0) : Kokkos::subview(output,  Kokkos::ALL(), Kokkos::ALL());
 
@@ -195,13 +195,13 @@ void OrthPolynomialTri<outputViewType,inputViewType,workViewType,hasDeriv,0>::ge
       }
 }
 
-template<typename outputViewType,
+template<typename OutputViewType,
 typename inputViewType,
 typename workViewType,
 bool hasDeriv>
 KOKKOS_INLINE_FUNCTION
-void OrthPolynomialTri<outputViewType,inputViewType,workViewType,hasDeriv,1>::generate(
-    outputViewType output,
+void OrthPolynomialTri<OutputViewType,inputViewType,workViewType,hasDeriv,1>::generate(
+    OutputViewType output,
     const inputViewType  input,
     workViewType   work,
     const ordinal_type   order ) {
@@ -220,14 +220,14 @@ void OrthPolynomialTri<outputViewType,inputViewType,workViewType,hasDeriv,1>::ge
 
 
 // when n >= 2, use recursion
-template<typename outputViewType,
+template<typename OutputViewType,
 typename inputViewType,
 typename workViewType,
 bool hasDeriv,
 ordinal_type n>
 KOKKOS_INLINE_FUNCTION
-void OrthPolynomialTri<outputViewType,inputViewType,workViewType,hasDeriv,n>::generate(
-    outputViewType /* output */,
+void OrthPolynomialTri<OutputViewType,inputViewType,workViewType,hasDeriv,n>::generate(
+    OutputViewType /* output */,
     const inputViewType  /* input */,
     workViewType   /* work */,
     const ordinal_type   /* order */ ) {
@@ -236,7 +236,7 @@ void OrthPolynomialTri<outputViewType,inputViewType,workViewType,hasDeriv,n>::ge
 constexpr ordinal_type spaceDim = 2;
 constexpr ordinal_type maxCard = Intrepid2::getPnCardinality<spaceDim, Parameters::MaxOrder>();
 
-typedef typename outputViewType::value_type value_type;
+typedef typename OutputViewType::value_type value_type;
 typedef Sacado::Fad::SFad<value_type,spaceDim> fad_type;
 
 const ordinal_type
@@ -299,28 +299,28 @@ INTREPID2_TEST_FOR_ABORT( true,
 
 
 template<EOperator opType>
-template<typename outputViewType,
+template<typename OutputViewType,
 typename inputViewType,
 typename workViewType>
 KOKKOS_INLINE_FUNCTION
 void
 Basis_HGRAD_TRI_Cn_FEM_ORTH::Serial<opType>::
-getValues( outputViewType output,
+getValues( OutputViewType output,
     const inputViewType  input,
     workViewType   work,
     const ordinal_type   order) {
   switch (opType) {
   case OPERATOR_VALUE: {
-    OrthPolynomialTri<outputViewType,inputViewType,workViewType,false,0>::generate( output, input, work, order );
+    OrthPolynomialTri<OutputViewType,inputViewType,workViewType,false,0>::generate( output, input, work, order );
     break;
   }
   case OPERATOR_GRAD:
   case OPERATOR_D1: {
-    OrthPolynomialTri<outputViewType,inputViewType,workViewType,true,1>::generate( output, input, work, order );
+    OrthPolynomialTri<OutputViewType,inputViewType,workViewType,true,1>::generate( output, input, work, order );
     break;
   }
   case OPERATOR_D2: {
-    OrthPolynomialTri<outputViewType,inputViewType,workViewType,true,2>::generate( output, input, work, order );
+    OrthPolynomialTri<OutputViewType,inputViewType,workViewType,true,2>::generate( output, input, work, order );
     break;
   }
   default: {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_WEDGE_C1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_WEDGE_C1_FEM.hpp
@@ -96,11 +96,11 @@ namespace Intrepid2 {
       */
       template<EOperator opType>
       struct Serial {
-        template<typename outputViewType,
+        template<typename OutputViewType,
                  typename inputViewType>
         KOKKOS_INLINE_FUNCTION
         static void
-        getValues(       outputViewType output,
+        getValues(       OutputViewType output,
                    const inputViewType input );
 
       };
@@ -176,16 +176,20 @@ namespace Intrepid2 {
      */
     Basis_HGRAD_WEDGE_C1_FEM();
 
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarViewType  scalarViewType;
+    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    
+    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
-    getValues(       outputViewType outputValues,
-               const pointViewType  inputPoints,
+    getValues(       OutputViewType outputValues,
+               const PointViewType  inputPoints,
                const EOperator operatorType = OPERATOR_VALUE ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify arguments
@@ -203,7 +207,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoords( scalarViewType dofCoords ) const {
+    getDofCoords( ScalarViewType dofCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,
@@ -220,7 +224,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoeffs( scalarViewType dofCoeffs ) const {
+    getDofCoeffs( ScalarViewType dofCoeffs ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoeffs.rank() != 1, std::invalid_argument,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_WEDGE_C1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_WEDGE_C1_FEM.hpp
@@ -164,9 +164,13 @@ namespace Intrepid2 {
            typename pointValueType = double>
   class Basis_HGRAD_WEDGE_C1_FEM : public Basis<ExecSpaceType,outputValueType,pointValueType> {
   public:
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
     /** \brief  Constructor.
      */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_WEDGE_C1_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_WEDGE_C1_FEM.hpp
@@ -168,9 +168,9 @@ namespace Intrepid2 {
     using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
     using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
 
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
+    using ordinal_type_array_1d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead");
+    using ordinal_type_array_2d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead");
+    using ordinal_type_array_3d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead");
 
     /** \brief  Constructor.
      */
@@ -180,9 +180,9 @@ namespace Intrepid2 {
     using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
     using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
     
-    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+    using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+    using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
+    using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_WEDGE_C1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_WEDGE_C1_FEMDef.hpp
@@ -247,11 +247,11 @@ namespace Intrepid2 {
                                  0, 5, 0, 1 };
 
       // host tags
-      ordinal_type_array_1d_host tagView(&tags[0], 24);
+      OrdinalTypeArray1DHost tagView(&tags[0], 24);
 
       // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
-      //ordinal_type_array_2d_host ordinalToTag;
-      //ordinal_type_array_3d_host tagToOrdinal;
+      //OrdinalTypeArray2DHost ordinalToTag;
+      //OrdinalTypeArray3DHost tagToOrdinal;
       this->setOrdinalTagData(this->tagToOrdinal_,
                               this->ordinalToTag_,
                               tagView,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_WEDGE_C1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_WEDGE_C1_FEMDef.hpp
@@ -228,6 +228,7 @@ namespace Intrepid2 {
     this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Wedge<6> >() );
     this->basisType_         = BASIS_FEM_DEFAULT;
     this->basisCoordinates_  = COORDINATES_CARTESIAN;
+    this->functionSpace_     = FUNCTION_SPACE_HGRAD;
 
     // initialize tags
     {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_WEDGE_C1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_WEDGE_C1_FEMDef.hpp
@@ -56,12 +56,12 @@ namespace Intrepid2 {
   namespace Impl {
 
     template<EOperator opType>
-    template<typename outputViewType,
+    template<typename OutputViewType,
              typename inputViewType>
     KOKKOS_INLINE_FUNCTION
     void
     Basis_HGRAD_WEDGE_C1_FEM::Serial<opType>::
-    getValues(       outputViewType output,
+    getValues(       OutputViewType output,
                const inputViewType input ) {
       switch (opType) {
       case OPERATOR_VALUE: {
@@ -263,7 +263,7 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoords("dofCoordsHost", this->basisCardinality_,this->basisCellTopology_.getDimension());
 
     dofCoords(0,0) =  0.0;  dofCoords(0,1) =  0.0;  dofCoords(0,2) = -1.0;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_WEDGE_C2_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_WEDGE_C2_FEM.hpp
@@ -198,9 +198,13 @@ namespace Intrepid2 {
            typename pointValueType = double>
   class Basis_HGRAD_WEDGE_C2_FEM : public Basis<ExecSpaceType,outputValueType,pointValueType> {
   public:
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
     /** \brief  Constructor.
      */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_WEDGE_C2_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_WEDGE_C2_FEM.hpp
@@ -202,9 +202,9 @@ namespace Intrepid2 {
     using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
     using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
 
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
+    using ordinal_type_array_1d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead");
+    using ordinal_type_array_2d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead");
+    using ordinal_type_array_3d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead");
 
     /** \brief  Constructor.
      */
@@ -214,9 +214,9 @@ namespace Intrepid2 {
     using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
     using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
     
-    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+    using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+    using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
+    using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_WEDGE_C2_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_WEDGE_C2_FEM.hpp
@@ -130,11 +130,11 @@ namespace Intrepid2 {
       */
       template<EOperator opType>
       struct Serial {
-        template<typename outputViewType,
+        template<typename OutputViewType,
                  typename inputViewType>
         KOKKOS_INLINE_FUNCTION
         static void
-        getValues(       outputViewType output,
+        getValues(       OutputViewType output,
                    const inputViewType input );
 
       };
@@ -210,16 +210,20 @@ namespace Intrepid2 {
      */
     Basis_HGRAD_WEDGE_C2_FEM();
 
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarViewType  scalarViewType;
+    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    
+    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
-    getValues(       outputViewType outputValues,
-               const pointViewType  inputPoints,
+    getValues(       OutputViewType outputValues,
+               const PointViewType  inputPoints,
                const EOperator operatorType = OPERATOR_VALUE ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify arguments
@@ -237,7 +241,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoords( scalarViewType dofCoords ) const {
+    getDofCoords( ScalarViewType dofCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,
@@ -254,7 +258,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoeffs( scalarViewType dofCoeffs ) const {
+    getDofCoeffs( ScalarViewType dofCoeffs ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoeffs.rank() != 1, std::invalid_argument,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_WEDGE_C2_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_WEDGE_C2_FEMDef.hpp
@@ -668,6 +668,7 @@ namespace Intrepid2 {
     this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Wedge<6> >() );
     this->basisType_         = BASIS_FEM_DEFAULT;
     this->basisCoordinates_  = COORDINATES_CARTESIAN;
+    this->functionSpace_     = FUNCTION_SPACE_HGRAD;
 
     // initialize tags
     {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_WEDGE_C2_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_WEDGE_C2_FEMDef.hpp
@@ -700,11 +700,11 @@ namespace Intrepid2 {
       };
 
       // host tags
-      ordinal_type_array_1d_host tagView(&tags[0], 72);
+      OrdinalTypeArray1DHost tagView(&tags[0], 72);
 
       // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
-      //ordinal_type_array_2d_host ordinalToTag;
-      //ordinal_type_array_3d_host tagToOrdinal;
+      //OrdinalTypeArray2DHost ordinalToTag;
+      //OrdinalTypeArray3DHost tagToOrdinal;
       this->setOrdinalTagData(this->tagToOrdinal_,
                               this->ordinalToTag_,
                               tagView,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_WEDGE_C2_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_WEDGE_C2_FEMDef.hpp
@@ -55,12 +55,12 @@ namespace Intrepid2 {
   namespace Impl {
 
     template<EOperator opType>
-    template<typename outputViewType,
+    template<typename OutputViewType,
              typename inputViewType>
     KOKKOS_INLINE_FUNCTION
     void
     Basis_HGRAD_WEDGE_C2_FEM::Serial<opType>::
-    getValues(       outputViewType output,
+    getValues(       OutputViewType output,
                const inputViewType input ) {
       switch (opType) {
       case OPERATOR_VALUE: {
@@ -716,7 +716,7 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoords("dofCoordsHost", this->basisCardinality_,this->basisCellTopology_.getDimension());
 
     dofCoords(0,0) =  0.0;  dofCoords(0,1) =  0.0;  dofCoords(0,2) = -1.0;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_C0_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_C0_FEM.hpp
@@ -65,11 +65,11 @@ namespace Intrepid2 {
       */
       template<EOperator opType>
       struct Serial {
-        template<typename outputViewType,
+        template<typename OutputViewType,
                  typename inputViewType>
         KOKKOS_INLINE_FUNCTION
         static void
-        getValues(       outputViewType output,
+        getValues(       OutputViewType output,
                    const inputViewType input );
 
       };
@@ -147,16 +147,20 @@ namespace Intrepid2 {
      */
     Basis_HVOL_C0_FEM(const shards::CellTopology cellTopo);
 
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarViewType scalarViewType;
+    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    
+    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
-    getValues(       outputViewType outputValues,
-               const pointViewType  inputPoints,
+    getValues(       OutputViewType outputValues,
+               const PointViewType  inputPoints,
                const EOperator operatorType = OPERATOR_VALUE ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify arguments
@@ -174,7 +178,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoords( scalarViewType dofCoords ) const {
+    getDofCoords( ScalarViewType dofCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,
@@ -191,7 +195,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoeffs( scalarViewType dofCoeffs ) const {
+    getDofCoeffs( ScalarViewType dofCoeffs ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoeffs.rank() != 1, std::invalid_argument,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_C0_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_C0_FEM.hpp
@@ -131,9 +131,13 @@ namespace Intrepid2 {
            typename pointValueType = double>
   class Basis_HVOL_C0_FEM : public Basis<ExecSpaceType,outputValueType,pointValueType> {
   public:
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
     /** \brief Constructor.
      */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_C0_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_C0_FEM.hpp
@@ -135,9 +135,9 @@ namespace Intrepid2 {
     using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
     using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
 
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
+    using ordinal_type_array_1d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead");
+    using ordinal_type_array_2d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead");
+    using ordinal_type_array_3d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead");
 
     /** \brief Constructor.
      */
@@ -151,9 +151,9 @@ namespace Intrepid2 {
     using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
     using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
     
-    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+    using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+    using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
+    using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_C0_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_C0_FEMDef.hpp
@@ -139,6 +139,7 @@ namespace Intrepid2 {
     this->basisCellTopology_ = cellTopo;
     this->basisType_         = Intrepid2::BASIS_FEM_DEFAULT;
     this->basisCoordinates_  = Intrepid2::COORDINATES_CARTESIAN;
+    this->functionSpace_     = FUNCTION_SPACE_HVOL;
 
     // initialize tags
     {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_C0_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_C0_FEMDef.hpp
@@ -53,12 +53,12 @@ namespace Intrepid2 {
   namespace Impl {
 
     template<EOperator opType>
-    template<typename outputViewType,
+    template<typename OutputViewType,
              typename inputViewType>
     KOKKOS_INLINE_FUNCTION
     void
     Basis_HVOL_C0_FEM::Serial<opType>::
-    getValues(       outputViewType output,
+    getValues(       OutputViewType output,
                const inputViewType /* input */ ) {
       switch (opType) {
       case OPERATOR_VALUE : {
@@ -165,7 +165,7 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoords("dofCoordsHost", this->basisCardinality_, spaceDim), cellVerts("cellVerts", spaceDim);
 
     CellTools<SpT>::getReferenceCellCenter(Kokkos::subview(dofCoords, 0, Kokkos::ALL()),

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_C0_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_C0_FEMDef.hpp
@@ -152,7 +152,7 @@ namespace Intrepid2 {
       // An array with local DoF tags assigned to the basis functions, in the order of their local enumeration
       ordinal_type tags[4] = { spaceDim, 0, 0, 1 };
 
-      ordinal_type_array_1d_host tagView(&tags[0], 4);
+      OrdinalTypeArray1DHost tagView(&tags[0], 4);
 
       this->setOrdinalTagData(this->tagToOrdinal_,
                               this->ordinalToTag_,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_HEX_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_HEX_Cn_FEM.hpp
@@ -170,9 +170,13 @@ namespace Intrepid2 {
   class Basis_HVOL_HEX_Cn_FEM
     : public Basis<ExecSpaceType,outputValueType,pointValueType> {
   public:
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
     /** \brief  Constructor.
      */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_HEX_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_HEX_Cn_FEM.hpp
@@ -174,9 +174,9 @@ namespace Intrepid2 {
     using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
     using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
 
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
+    using ordinal_type_array_1d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead");
+    using ordinal_type_array_2d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead");
+    using ordinal_type_array_3d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead");
 
     /** \brief  Constructor.
      */
@@ -187,9 +187,9 @@ namespace Intrepid2 {
     using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
     using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
     
-    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+    using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+    using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
+    using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_HEX_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_HEX_Cn_FEM.hpp
@@ -183,16 +183,20 @@ namespace Intrepid2 {
     Basis_HVOL_HEX_Cn_FEM(const ordinal_type order,
                             const EPointType   pointType = POINTTYPE_EQUISPACED);
 
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarViewType  scalarViewType;
+    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    
+    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
-    getValues(       outputViewType outputValues,
-               const pointViewType  inputPoints,
+    getValues(       OutputViewType outputValues,
+               const PointViewType  inputPoints,
                const EOperator operatorType = OPERATOR_VALUE ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       Intrepid2::getValues_HVOL_Args(outputValues,
@@ -212,7 +216,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoords( scalarViewType dofCoords ) const {
+    getDofCoords( ScalarViewType dofCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,
@@ -229,7 +233,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoeffs( scalarViewType dofCoeffs ) const {
+    getDofCoeffs( ScalarViewType dofCoeffs ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoeffs.rank() != 1, std::invalid_argument,
@@ -256,7 +260,7 @@ namespace Intrepid2 {
   private:
 
     /** \brief inverse of Generalized Vandermonde matrix (isotropic order) */
-    Kokkos::DynRankView<typename scalarViewType::value_type,ExecSpaceType> vinv_;
+    Kokkos::DynRankView<typename ScalarViewType::value_type,ExecSpaceType> vinv_;
   };
 
 }// namespace Intrepid2

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_HEX_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_HEX_Cn_FEMDef.hpp
@@ -54,14 +54,14 @@ namespace Intrepid2 {
   namespace Impl {
     
     template<EOperator opType>
-    template<typename outputViewType,
+    template<typename OutputViewType,
              typename inputViewType,
              typename workViewType,
              typename vinvViewType>
     KOKKOS_INLINE_FUNCTION
     void
     Basis_HVOL_HEX_Cn_FEM::Serial<opType>::
-    getValues(       outputViewType output,
+    getValues(       OutputViewType output,
                const inputViewType  input,
                      workViewType   work,
                const vinvViewType   vinv,
@@ -265,7 +265,7 @@ namespace Intrepid2 {
     Basis_HVOL_LINE_Cn_FEM<SpT,OT,PT> lineBasis( order, pointType );
     const auto cardLine = lineBasis.getCardinality();
 
-    this->vinv_ = Kokkos::DynRankView<typename scalarViewType::value_type,SpT>("HVOL::HEX::Cn::vinv", cardLine, cardLine);
+    this->vinv_ = Kokkos::DynRankView<typename ScalarViewType::value_type,SpT>("HVOL::HEX::Cn::vinv", cardLine, cardLine);
     lineBasis.getVandermondeInverse(this->vinv_);
     
     this->basisCardinality_  = cardLine*cardLine*cardLine;
@@ -321,10 +321,10 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoordsHost("dofCoordsHost", this->basisCardinality_, this->basisCellTopology_.getDimension());
 
-    Kokkos::DynRankView<typename scalarViewType::value_type,SpT>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,SpT>
       dofCoordsLine("dofCoordsLine", cardLine, 1);
 
     lineBasis.getDofCoords(dofCoordsLine);

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_HEX_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_HEX_Cn_FEMDef.hpp
@@ -273,6 +273,7 @@ namespace Intrepid2 {
     this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Hexahedron<8> >() );
     this->basisType_         = BASIS_FEM_FIAT;
     this->basisCoordinates_  = COORDINATES_CARTESIAN;
+    this->functionSpace_     = FUNCTION_SPACE_HVOL;
 
     // initialize tags
     {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_HEX_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_HEX_Cn_FEMDef.hpp
@@ -306,7 +306,7 @@ namespace Intrepid2 {
         }
       }
 
-      ordinal_type_array_1d_host tagView(&tags[0][0], this->basisCardinality_*4);
+      OrdinalTypeArray1DHost tagView(&tags[0][0], this->basisCardinality_*4);
 
       // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
       // tags are constructed on host

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_LINE_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_LINE_Cn_FEM.hpp
@@ -190,16 +190,20 @@ namespace Intrepid2 {
     Basis_HVOL_LINE_Cn_FEM(const ordinal_type order,
                             const EPointType   pointType = POINTTYPE_EQUISPACED);  
 
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarViewType  scalarViewType;
+    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    
+    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
-    getValues(       outputViewType outputValues,
-               const pointViewType  inputPoints,
+    getValues(       OutputViewType outputValues,
+               const PointViewType  inputPoints,
                const EOperator operatorType = OPERATOR_VALUE ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       Intrepid2::getValues_HVOL_Args(outputValues,
@@ -218,7 +222,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoords( scalarViewType dofCoords ) const {
+    getDofCoords( ScalarViewType dofCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,
@@ -235,7 +239,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoeffs( scalarViewType dofCoeffs ) const {
+    getDofCoeffs( ScalarViewType dofCoeffs ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoeffs.rank() != 1, std::invalid_argument,
@@ -248,7 +252,7 @@ namespace Intrepid2 {
     }
 
     void
-    getVandermondeInverse( scalarViewType vinv ) const {
+    getVandermondeInverse( ScalarViewType vinv ) const {
       // has to be same rank and dimensions
       Kokkos::deep_copy(vinv, this->vinv_);      
     }
@@ -263,7 +267,7 @@ namespace Intrepid2 {
 
     /** \brief inverse of Generalized Vandermonde matrix, whose columns store the expansion
                coefficients of the nodal basis in terms of phis_ */
-    Kokkos::DynRankView<typename scalarViewType::value_type,ExecSpaceType> vinv_;
+    Kokkos::DynRankView<typename ScalarViewType::value_type,ExecSpaceType> vinv_;
   };
 
 }// namespace Intrepid2

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_LINE_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_LINE_Cn_FEM.hpp
@@ -177,9 +177,13 @@ namespace Intrepid2 {
   class Basis_HVOL_LINE_Cn_FEM
     : public Basis<ExecSpaceType,outputValueType,pointValueType> {
   public:
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
     /** \brief  Constructor.
      */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_LINE_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_LINE_Cn_FEM.hpp
@@ -181,9 +181,9 @@ namespace Intrepid2 {
     using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
     using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
 
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
+    using ordinal_type_array_1d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead");
+    using ordinal_type_array_2d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead");
+    using ordinal_type_array_3d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead");
 
     /** \brief  Constructor.
      */
@@ -194,9 +194,9 @@ namespace Intrepid2 {
     using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
     using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
     
-    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+    using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+    using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
+    using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_LINE_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_LINE_Cn_FEMDef.hpp
@@ -317,7 +317,7 @@ namespace Intrepid2 {
         tags[i][3] = card; // total number of dofs in this edge
       }
 
-      ordinal_type_array_1d_host tagView(&tags[0][0], card*4);
+      OrdinalTypeArray1DHost tagView(&tags[0][0], card*4);
 
       // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
       // tags are constructed on host

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_LINE_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_LINE_Cn_FEMDef.hpp
@@ -201,6 +201,7 @@ namespace Intrepid2 {
     this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Line<2> >() );
     this->basisType_         = BASIS_FEM_FIAT;
     this->basisCoordinates_  = COORDINATES_CARTESIAN;
+    this->functionSpace_     = FUNCTION_SPACE_HVOL;
 
     const ordinal_type card = this->basisCardinality_;
     

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_LINE_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_LINE_Cn_FEMDef.hpp
@@ -54,14 +54,14 @@ namespace Intrepid2 {
   namespace Impl {
     
     template<EOperator opType>
-    template<typename outputViewType,
+    template<typename OutputViewType,
              typename inputViewType,
              typename workViewType,
              typename vinvViewType>
     KOKKOS_INLINE_FUNCTION
     void
     Basis_HVOL_LINE_Cn_FEM::Serial<opType>::
-    getValues(       outputViewType output,
+    getValues(       OutputViewType output,
                const inputViewType  input,
                      workViewType   work,
                const vinvViewType   vinv,
@@ -206,7 +206,7 @@ namespace Intrepid2 {
     const ordinal_type card = this->basisCardinality_;
     
     // points are computed in the host and will be copied 
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoords("HVOL::Line::Cn::dofCoords", card, 1);
 
 
@@ -256,7 +256,7 @@ namespace Intrepid2 {
     // form Vandermonde matrix; actually, this is the transpose of the VDM,
     // this matrix is used in LAPACK so it should be column major and left layout
     const ordinal_type lwork = card*card;
-    Kokkos::DynRankView<typename scalarViewType::value_type,Kokkos::LayoutLeft,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,Kokkos::LayoutLeft,Kokkos::HostSpace>
       vmat("HVOL::Line::Cn::vmat", card, card),
       work("HVOL::Line::Cn::work", lwork),
       ipiv("HVOL::Line::Cn::ipiv", card);
@@ -267,7 +267,7 @@ namespace Intrepid2 {
       (vmat, dofCoords, order, alpha, beta, OPERATOR_VALUE);
 
     ordinal_type info = 0;
-    Teuchos::LAPACK<ordinal_type,typename scalarViewType::value_type> lapack;
+    Teuchos::LAPACK<ordinal_type,typename ScalarViewType::value_type> lapack;
 
     lapack.GETRF(card, card, 
                  vmat.data(), vmat.stride_1(),
@@ -289,7 +289,7 @@ namespace Intrepid2 {
                                   ">>> ERROR: (Intrepid2::Basis_HVOL_LINE_Cn_FEM) lapack.GETRI returns nonzero info." );
     
     // create host mirror 
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       vinv("HVOL::Line::Cn::vinv", card, card);
 
     for (ordinal_type i=0;i<card;++i) 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_QUAD_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_QUAD_Cn_FEM.hpp
@@ -178,16 +178,20 @@ namespace Intrepid2 {
     Basis_HVOL_QUAD_Cn_FEM(const ordinal_type order,
                             const EPointType   pointType = POINTTYPE_EQUISPACED);
 
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarViewType  scalarViewType;
+    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    
+    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
-    getValues(       outputViewType outputValues,
-               const pointViewType  inputPoints,
+    getValues(       OutputViewType outputValues,
+               const PointViewType  inputPoints,
                const EOperator operatorType = OPERATOR_VALUE ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       Intrepid2::getValues_HVOL_Args(outputValues,
@@ -206,7 +210,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoords( scalarViewType dofCoords ) const {
+    getDofCoords( ScalarViewType dofCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,
@@ -223,7 +227,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoeffs( scalarViewType dofCoeffs ) const {
+    getDofCoeffs( ScalarViewType dofCoeffs ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoeffs.rank() != 1, std::invalid_argument,
@@ -250,7 +254,7 @@ namespace Intrepid2 {
   private:
 
     /** \brief inverse of Generalized Vandermonde matrix (isotropic order) */
-    Kokkos::DynRankView<typename scalarViewType::value_type,ExecSpaceType> vinv_;
+    Kokkos::DynRankView<typename ScalarViewType::value_type,ExecSpaceType> vinv_;
   };
 
 }// namespace Intrepid2

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_QUAD_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_QUAD_Cn_FEM.hpp
@@ -169,9 +169,9 @@ namespace Intrepid2 {
     using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
     using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
 
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
+    using ordinal_type_array_1d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead");
+    using ordinal_type_array_2d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead");
+    using ordinal_type_array_3d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead");
 
     /** \brief  Constructor.
      */
@@ -182,9 +182,9 @@ namespace Intrepid2 {
     using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
     using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
     
-    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+    using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+    using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
+    using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_QUAD_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_QUAD_Cn_FEM.hpp
@@ -165,9 +165,13 @@ namespace Intrepid2 {
   class Basis_HVOL_QUAD_Cn_FEM
     : public Basis<ExecSpaceType,outputValueType,pointValueType> {
   public:
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
     /** \brief  Constructor.
      */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_QUAD_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_QUAD_Cn_FEMDef.hpp
@@ -246,6 +246,7 @@ namespace Intrepid2 {
     this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Quadrilateral<4> >() );
     this->basisType_         = BASIS_FEM_FIAT;
     this->basisCoordinates_  = COORDINATES_CARTESIAN;
+    this->functionSpace_     = FUNCTION_SPACE_HVOL;
 
     // initialize tags
     {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_QUAD_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_QUAD_Cn_FEMDef.hpp
@@ -276,7 +276,7 @@ namespace Intrepid2 {
         }
       }
       
-      ordinal_type_array_1d_host tagView(&tags[0][0], this->basisCardinality_*4);
+      OrdinalTypeArray1DHost tagView(&tags[0][0], this->basisCardinality_*4);
 
       // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
       // tags are constructed on host

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_QUAD_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_QUAD_Cn_FEMDef.hpp
@@ -54,14 +54,14 @@ namespace Intrepid2 {
   namespace Impl {
 
     template<EOperator opType>
-    template<typename outputViewType,
+    template<typename OutputViewType,
              typename inputViewType,
              typename workViewType,
              typename vinvViewType>
     KOKKOS_INLINE_FUNCTION
     void
     Basis_HVOL_QUAD_Cn_FEM::Serial<opType>::
-    getValues(       outputViewType output,
+    getValues(       OutputViewType output,
                const inputViewType  input,
                      workViewType   work,
                const vinvViewType   vinv,
@@ -238,7 +238,7 @@ namespace Intrepid2 {
     Basis_HVOL_LINE_Cn_FEM<SpT,OT,PT> lineBasis( order, pointType );
     const auto cardLine = lineBasis.getCardinality();
     
-    this->vinv_ = Kokkos::DynRankView<typename scalarViewType::value_type,SpT>("HVOL::Quad::Cn::vinv", cardLine, cardLine);
+    this->vinv_ = Kokkos::DynRankView<typename ScalarViewType::value_type,SpT>("HVOL::Quad::Cn::vinv", cardLine, cardLine);
     lineBasis.getVandermondeInverse(this->vinv_);
 
     this->basisCardinality_  = cardLine*cardLine;
@@ -291,10 +291,10 @@ namespace Intrepid2 {
     }
 
     // dofCoords on host and create its mirror view to device
-    Kokkos::DynRankView<typename scalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename SpT::array_layout,Kokkos::HostSpace>
       dofCoordsHost("dofCoordsHost", this->basisCardinality_, this->basisCellTopology_.getDimension());
 
-    Kokkos::DynRankView<typename scalarViewType::value_type,SpT>
+    Kokkos::DynRankView<typename ScalarViewType::value_type,SpT>
       dofCoordsLine("dofCoordsLine", cardLine, 1);
 
     lineBasis.getDofCoords(dofCoordsLine);

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TET_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TET_Cn_FEM.hpp
@@ -189,9 +189,13 @@ namespace Intrepid2 {
   class Basis_HVOL_TET_Cn_FEM
     : public Basis<ExecSpaceType,outputValueType,pointValueType> {
   public:
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
     /** \brief  Constructor.
      */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TET_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TET_Cn_FEM.hpp
@@ -193,9 +193,9 @@ namespace Intrepid2 {
     using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
     using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
 
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
+    using ordinal_type_array_1d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead");
+    using ordinal_type_array_2d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead");
+    using ordinal_type_array_3d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead");
 
     /** \brief  Constructor.
      */
@@ -207,9 +207,9 @@ namespace Intrepid2 {
     using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
     using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
     
-    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+    using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+    using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
+    using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
 
     typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarType  scalarType;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TET_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TET_Cn_FEM.hpp
@@ -203,17 +203,22 @@ namespace Intrepid2 {
                            const EPointType   pointType = POINTTYPE_EQUISPACED);
 
 
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarViewType  scalarViewType;
+    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    
+    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+
     typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarType  scalarType;
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
-    getValues(       outputViewType outputValues,
-               const pointViewType  inputPoints,
+    getValues(       OutputViewType outputValues,
+               const PointViewType  inputPoints,
                const EOperator operatorType = OPERATOR_VALUE) const {
 #ifdef HAVE_INTREPID2_DEBUG
       Intrepid2::getValues_HVOL_Args(outputValues,
@@ -232,7 +237,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoords( scalarViewType dofCoords ) const {
+    getDofCoords( ScalarViewType dofCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,
@@ -249,7 +254,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoeffs( scalarViewType dofCoeffs ) const {
+    getDofCoeffs( ScalarViewType dofCoeffs ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoeffs.rank() != 1, std::invalid_argument,
@@ -262,7 +267,7 @@ namespace Intrepid2 {
     }
 
     void
-    getVandermondeInverse( scalarViewType vinv ) const {
+    getVandermondeInverse( ScalarViewType vinv ) const {
       // has to be same rank and dimensions
       Kokkos::deep_copy(vinv, this->vinv_);
     }

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TET_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TET_Cn_FEMDef.hpp
@@ -322,7 +322,7 @@ namespace Intrepid2 {
         tags[i][3] = numElemDof; // total vert dof
       }
 
-      ordinal_type_array_1d_host tagView(&tags[0][0], card*tagSize);
+      OrdinalTypeArray1DHost tagView(&tags[0][0], card*tagSize);
       
       // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
       // tags are constructed on host

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TET_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TET_Cn_FEMDef.hpp
@@ -237,6 +237,7 @@ namespace Intrepid2 {
     this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Tetrahedron<4> >() );
     this->basisType_         = BASIS_FEM_FIAT;
     this->basisCoordinates_  = COORDINATES_CARTESIAN;
+    this->functionSpace_     = FUNCTION_SPACE_HVOL;
 
     const ordinal_type card = this->basisCardinality_;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TET_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TET_Cn_FEMDef.hpp
@@ -57,14 +57,14 @@ namespace Intrepid2 {
   namespace Impl {
 
     template<EOperator opType>
-    template<typename outputViewType,
+    template<typename OutputViewType,
              typename inputViewType,
              typename workViewType,
              typename vinvViewType>
     KOKKOS_INLINE_FUNCTION
     void
     Basis_HVOL_TET_Cn_FEM::Serial<opType>::
-    getValues(       outputViewType output,
+    getValues(       OutputViewType output,
                const inputViewType  input,
                      workViewType   work,
                const vinvViewType   vinv ) {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TRI_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TRI_Cn_FEM.hpp
@@ -188,9 +188,9 @@ namespace Intrepid2 {
     using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
     using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
 
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
-    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
+    using ordinal_type_array_1d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead");
+    using ordinal_type_array_2d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead");
+    using ordinal_type_array_3d_host INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead");
 
     /** \brief  Constructor.
      */
@@ -202,9 +202,9 @@ namespace Intrepid2 {
     using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
     using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
     
-    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
-    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+    using outputViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use OutputViewType instead","OutputViewType") = OutputViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use OutputViewType instead");
+    using pointViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use PointViewType instead","PointViewType") = PointViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use PointViewType instead");
+    using scalarViewType INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT("use ScalarViewType instead","ScalarViewType") = ScalarViewType INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE("use ScalarViewType instead");
 
     typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarType  scalarType;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TRI_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TRI_Cn_FEM.hpp
@@ -184,9 +184,13 @@ namespace Intrepid2 {
   class Basis_HVOL_TRI_Cn_FEM
     : public Basis<ExecSpaceType,outputValueType,pointValueType> {
   public:
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_1d_host ordinal_type_array_1d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_2d_host ordinal_type_array_2d_host;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::ordinal_type_array_3d_host ordinal_type_array_3d_host;
+    using OrdinalTypeArray1DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OrdinalTypeArray3DHost;
+
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray1DHost instead") using ordinal_type_array_1d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray1DHost instead","OrdinalTypeArray1DHost") = OrdinalTypeArray1DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray2DHost instead") using ordinal_type_array_2d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray2DHost instead","OrdinalTypeArray2DHost") = OrdinalTypeArray2DHost;
+    INTREPID2_DEPRECATED_MESSAGE("use OrdinalTypeArray3DHost instead") using ordinal_type_array_3d_host INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OrdinalTypeArray3DHost instead","OrdinalTypeArray3DHost") = OrdinalTypeArray3DHost;
 
     /** \brief  Constructor.
      */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TRI_Cn_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TRI_Cn_FEM.hpp
@@ -198,17 +198,22 @@ namespace Intrepid2 {
                            const EPointType   pointType = POINTTYPE_EQUISPACED);
 
 
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::outputViewType outputViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::pointViewType  pointViewType;
-    typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarViewType  scalarViewType;
+    using OutputViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::OutputViewType;
+    using PointViewType  = typename Basis<ExecSpaceType,outputValueType,pointValueType>::PointViewType;
+    using ScalarViewType = typename Basis<ExecSpaceType,outputValueType,pointValueType>::ScalarViewType;
+    
+    INTREPID2_DEPRECATED_MESSAGE("use OutputViewType instead") using outputViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use OutputViewType instead","OutputViewType") = OutputViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use PointViewType instead") using pointViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use PointViewType instead","PointViewType") = PointViewType;
+    INTREPID2_DEPRECATED_MESSAGE("use ScalarViewType instead") using scalarViewType INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE("use ScalarViewType instead","ScalarViewType") = ScalarViewType;
+
     typedef typename Basis<ExecSpaceType,outputValueType,pointValueType>::scalarType  scalarType;
 
     using Basis<ExecSpaceType,outputValueType,pointValueType>::getValues;
 
     virtual
     void
-    getValues(       outputViewType outputValues,
-               const pointViewType  inputPoints,
+    getValues(       OutputViewType outputValues,
+               const PointViewType  inputPoints,
                const EOperator operatorType = OPERATOR_VALUE) const {
 #ifdef HAVE_INTREPID2_DEBUG
       Intrepid2::getValues_HVOL_Args(outputValues,
@@ -227,7 +232,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoords( scalarViewType dofCoords ) const {
+    getDofCoords( ScalarViewType dofCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,
@@ -244,7 +249,7 @@ namespace Intrepid2 {
 
     virtual
     void
-    getDofCoeffs( scalarViewType dofCoeffs ) const {
+    getDofCoeffs( ScalarViewType dofCoeffs ) const {
 #ifdef HAVE_INTREPID2_DEBUG
       // Verify rank of output array.
       INTREPID2_TEST_FOR_EXCEPTION( dofCoeffs.rank() != 1, std::invalid_argument,
@@ -257,7 +262,7 @@ namespace Intrepid2 {
     }
 
     void
-    getVandermondeInverse( scalarViewType vinv ) const {
+    getVandermondeInverse( ScalarViewType vinv ) const {
       // has to be same rank and dimensions
       Kokkos::deep_copy(vinv, this->vinv_);
     }

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TRI_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TRI_Cn_FEMDef.hpp
@@ -315,7 +315,7 @@ Basis_HVOL_TRI_Cn_FEM( const ordinal_type order,
       tags[i][3] = numElemDof; // total vert dof
     }
 
-    ordinal_type_array_1d_host tagView(&tags[0][0], card*tagSize);
+    OrdinalTypeArray1DHost tagView(&tags[0][0], card*tagSize);
 
     // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
     // tags are constructed on host

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TRI_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TRI_Cn_FEMDef.hpp
@@ -231,6 +231,7 @@ Basis_HVOL_TRI_Cn_FEM( const ordinal_type order,
   this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Triangle<3> >() );
   this->basisType_         = BASIS_FEM_FIAT;
   this->basisCoordinates_  = COORDINATES_CARTESIAN;
+  this->functionSpace_     = FUNCTION_SPACE_HVOL;
 
   const ordinal_type card = this->basisCardinality_;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TRI_Cn_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_TRI_Cn_FEMDef.hpp
@@ -56,14 +56,14 @@ namespace Intrepid2 {
 namespace Impl {
 
 template<EOperator opType>
-template<typename outputViewType,
+template<typename OutputViewType,
 typename inputViewType,
 typename workViewType,
 typename vinvViewType>
 KOKKOS_INLINE_FUNCTION
 void
 Basis_HVOL_TRI_Cn_FEM::Serial<opType>::
-getValues(       outputViewType output,
+getValues(       OutputViewType output,
     const inputViewType  input,
     workViewType   work,
     const vinvViewType   vinv ) {

--- a/packages/intrepid2/src/Discretization/FunctionSpaceTools/Intrepid2_FunctionSpaceToolsDef.hpp
+++ b/packages/intrepid2/src/Discretization/FunctionSpaceTools/Intrepid2_FunctionSpaceToolsDef.hpp
@@ -80,18 +80,18 @@ namespace Intrepid2 {
    /**
        \brief Functor for calculation HGRADtransformGRAD, see Intrepid2::FunctionSpaceTools for more
    */
-    template <typename outputViewType,
+    template <typename OutputViewType,
               typename jacInverseViewType,
               typename inputViewType,
               ordinal_type spaceDim>
     struct F_HGRADtransformGRAD {
-            outputViewType     _output;
+            OutputViewType     _output;
       const jacInverseViewType  _jacInverse;
       const inputViewType _input;
 
       // output CPDD, left CPDD or PDD, right FPD
       KOKKOS_INLINE_FUNCTION
-      F_HGRADtransformGRAD(outputViewType     output_,
+      F_HGRADtransformGRAD(OutputViewType     output_,
                            jacInverseViewType  jacInverse_,
                            inputViewType input_)
         : _output(output_), 
@@ -129,7 +129,7 @@ namespace Intrepid2 {
     // this modification is for 2d and 3d (not 1d)
     // this is an attempt to measure the overhead of subview of dynrankview. 
 
-    // typedef       Kokkos::DynRankView<outputValValueType,outputValProperties...> outputViewType;
+    // typedef       Kokkos::DynRankView<outputValValueType,outputValProperties...> OutputViewType;
     // typedef const Kokkos::DynRankView<jacobianInverseValueType,jacobianInverseProperties...> jacInverseViewType;
     // typedef const Kokkos::DynRankView<inputValValueType,inputValProperties...>  inputViewType;
 
@@ -146,12 +146,12 @@ namespace Intrepid2 {
     // const ordinal_type spaceDim = inputVals.extent(2);
     // switch (spaceDim) {
     // case 2: {
-    //   typedef FunctorFunctionSpaceTools::F_HGRADtransformGRAD<outputViewType, jacInverseViewType, inputViewType, 2> FunctorType;
+    //   typedef FunctorFunctionSpaceTools::F_HGRADtransformGRAD<OutputViewType, jacInverseViewType, inputViewType, 2> FunctorType;
     //   Kokkos::parallel_for( policy, FunctorType(outputVals, jacobianInverse, inputVals) );
     //   break;
     // }
     // case 3: {
-    //   typedef FunctorFunctionSpaceTools::F_HGRADtransformGRAD<outputViewType, jacInverseViewType, inputViewType, 3> FunctorType;
+    //   typedef FunctorFunctionSpaceTools::F_HGRADtransformGRAD<OutputViewType, jacInverseViewType, inputViewType, 3> FunctorType;
     //   Kokkos::parallel_for( policy, FunctorType(outputVals, jacobianInverse, inputVals) );
     //   break;
     // }

--- a/packages/intrepid2/src/Discretization/Integration/Intrepid2_Cubature.hpp
+++ b/packages/intrepid2/src/Discretization/Integration/Intrepid2_Cubature.hpp
@@ -122,7 +122,7 @@ namespace Intrepid2 {
   class Cubature {
   public:
 
-    typedef Kokkos::DynRankView<pointValueType,Kokkos::LayoutStride,ExecSpaceType>   pointViewType;
+    typedef Kokkos::DynRankView<pointValueType,Kokkos::LayoutStride,ExecSpaceType>   PointViewType;
     typedef Kokkos::DynRankView<weightValueType,Kokkos::LayoutStride,ExecSpaceType>  weightViewType;
 
     /** \brief Returns cubature points and weights
@@ -133,7 +133,7 @@ namespace Intrepid2 {
     */
     virtual
     void
-    getCubature( pointViewType  /* cubPoints */,
+    getCubature( PointViewType  /* cubPoints */,
                  weightViewType /* cubWeights */ ) const {
       INTREPID2_TEST_FOR_EXCEPTION( true, std::logic_error,
                                     ">>> ERROR (Cubature::getCubature): this method should be over-riden by derived classes.");
@@ -148,9 +148,9 @@ namespace Intrepid2 {
     */
     virtual
     void
-    getCubature( pointViewType  /* cubPoints */,
+    getCubature( PointViewType  /* cubPoints */,
                  weightViewType /* cubWeights */,
-                 pointViewType  /* cellVertices */) const {
+                 PointViewType  /* cellVertices */) const {
       INTREPID2_TEST_FOR_EXCEPTION( true, std::logic_error,
                                     ">>> ERROR (Cubature::getCubature): this method should be over-riden by derived classes.");
     }

--- a/packages/intrepid2/src/Discretization/Integration/Intrepid2_CubatureControlVolume.hpp
+++ b/packages/intrepid2/src/Discretization/Integration/Intrepid2_CubatureControlVolume.hpp
@@ -139,7 +139,7 @@ namespace Intrepid2{
     Kokkos::DynRankView<weightValueType,ExecSpaceType> subcvCubatureWeights_;
 
   public:
-    typedef typename Cubature<ExecSpaceType,pointValueType,weightValueType>::pointViewType  pointViewType;
+    typedef typename Cubature<ExecSpaceType,pointValueType,weightValueType>::PointViewType  PointViewType;
     typedef typename Cubature<ExecSpaceType,pointValueType,weightValueType>::weightViewType weightViewType;
 
     using Cubature<ExecSpaceType,pointValueType,weightValueType>::getCubature;
@@ -153,9 +153,9 @@ namespace Intrepid2{
     */
     virtual
     void
-    getCubature( pointViewType  cubPoints,
+    getCubature( PointViewType  cubPoints,
                  weightViewType cubWeights,
-                 pointViewType  cellCoords) const;
+                 PointViewType  cellCoords) const;
 
     /** \brief Returns the number of cubature points.
      */

--- a/packages/intrepid2/src/Discretization/Integration/Intrepid2_CubatureControlVolumeBoundary.hpp
+++ b/packages/intrepid2/src/Discretization/Integration/Intrepid2_CubatureControlVolumeBoundary.hpp
@@ -129,7 +129,7 @@ namespace Intrepid2{
     Kokkos::DynRankView<pointValueType, ExecSpaceType> sidePoints_;
     
   public:
-    typedef typename Cubature<ExecSpaceType,pointValueType,weightValueType>::pointViewType  pointViewType;
+    typedef typename Cubature<ExecSpaceType,pointValueType,weightValueType>::PointViewType  PointViewType;
     typedef typename Cubature<ExecSpaceType,pointValueType,weightValueType>::weightViewType weightViewType;
 
     using Cubature<ExecSpaceType,pointValueType,weightValueType>::getCubature;
@@ -143,9 +143,9 @@ namespace Intrepid2{
     */
     virtual
     void
-    getCubature( pointViewType  cubPoints,
+    getCubature( PointViewType  cubPoints,
                  weightViewType cubWeights,
-                 pointViewType  cellCoords) const;
+                 PointViewType  cellCoords) const;
     
     /** \brief Returns the number of cubature points.
      */

--- a/packages/intrepid2/src/Discretization/Integration/Intrepid2_CubatureControlVolumeBoundaryDef.hpp
+++ b/packages/intrepid2/src/Discretization/Integration/Intrepid2_CubatureControlVolumeBoundaryDef.hpp
@@ -176,9 +176,9 @@ namespace Intrepid2{
   template <typename SpT, typename PT, typename WT>
   void
   CubatureControlVolumeBoundary<SpT,PT,WT>::
-  getCubature( pointViewType  cubPoints,
+  getCubature( PointViewType  cubPoints,
                weightViewType cubWeights,
-               pointViewType  cellCoords ) const {
+               PointViewType  cellCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
     INTREPID2_TEST_FOR_EXCEPTION( cubPoints.rank() != 3, std::invalid_argument,
                                   ">>> ERROR (CubatureControlVolumeBoundary): cubPoints must have rank 3 (C,P,D).");
@@ -258,13 +258,13 @@ namespace Intrepid2{
       typedef Kokkos::View<ordinal_type*,SpT> mapViewType;
       const auto sideNodeMap = Kokkos::subview(sideNodeMap_, node, Kokkos::ALL());
       
-      typedef typename ExecSpace<typename pointViewType::execution_space,SpT>::ExecSpaceType ExecSpaceType;
+      typedef typename ExecSpace<typename PointViewType::execution_space,SpT>::ExecSpaceType ExecSpaceType;
       
       const auto loopSize = numCells;
       Kokkos::RangePolicy<ExecSpaceType,Kokkos::Schedule<Kokkos::Static> > policy(0, loopSize);
       
       // compute centers
-      typedef Functor<pointViewType,tempPointStrideViewType,mapViewType> FunctorType;
+      typedef Functor<PointViewType,tempPointStrideViewType,mapViewType> FunctorType;
       Kokkos::parallel_for( policy, FunctorType(cubPointsNode,
                                                 subcvCoordsNode,
                                                 sideNodeMap) );

--- a/packages/intrepid2/src/Discretization/Integration/Intrepid2_CubatureControlVolumeDef.hpp
+++ b/packages/intrepid2/src/Discretization/Integration/Intrepid2_CubatureControlVolumeDef.hpp
@@ -90,9 +90,9 @@ namespace Intrepid2 {
   template <typename SpT, typename PT, typename WT>
   void
   CubatureControlVolume<SpT,PT,WT>::
-  getCubature( pointViewType  cubPoints,
+  getCubature( PointViewType  cubPoints,
                weightViewType cubWeights,
-               pointViewType  cellCoords ) const {
+               PointViewType  cellCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
     INTREPID2_TEST_FOR_EXCEPTION( cubPoints.rank() != 3, std::invalid_argument,
                                   ">>> ERROR (CubatureControlVolume): cubPoints must have rank 3 (C,P,D).");
@@ -149,12 +149,12 @@ namespace Intrepid2 {
                                      subcvJacobianNode);    // C, P, D, D
     }
     
-    typedef typename ExecSpace<typename pointViewType::execution_space,SpT>::ExecSpaceType ExecSpaceType;
+    typedef typename ExecSpace<typename PointViewType::execution_space,SpT>::ExecSpaceType ExecSpaceType;
     
     const auto loopSize = numCells;
     Kokkos::RangePolicy<ExecSpaceType,Kokkos::Schedule<Kokkos::Static> > policy(0, loopSize);
     
-    typedef Functor<pointViewType,weightViewType,tempPointViewType,tempPointViewType,tempPointViewType> FunctorType;
+    typedef Functor<PointViewType,weightViewType,tempPointViewType,tempPointViewType,tempPointViewType> FunctorType;
     Kokkos::parallel_for( policy, FunctorType(cubPoints, 
                                               cubWeights, 
                                               subcvCoords, 

--- a/packages/intrepid2/src/Discretization/Integration/Intrepid2_CubatureControlVolumeSide.hpp
+++ b/packages/intrepid2/src/Discretization/Integration/Intrepid2_CubatureControlVolumeSide.hpp
@@ -140,7 +140,7 @@ namespace Intrepid2{
     Kokkos::DynRankView<pointValueType, ExecSpaceType> sidePoints_;
 
   public:
-    typedef typename Cubature<ExecSpaceType,pointValueType,weightValueType>::pointViewType  pointViewType;
+    typedef typename Cubature<ExecSpaceType,pointValueType,weightValueType>::PointViewType  PointViewType;
     typedef typename Cubature<ExecSpaceType,pointValueType,weightValueType>::weightViewType weightViewType;
 
     using Cubature<ExecSpaceType,pointValueType,weightValueType>::getCubature;
@@ -154,9 +154,9 @@ namespace Intrepid2{
     */
     virtual
     void
-    getCubature( pointViewType  cubPoints,
+    getCubature( PointViewType  cubPoints,
                  weightViewType cubWeights,
-                 pointViewType  cellCoords) const;
+                 PointViewType  cellCoords) const;
 
     /** \brief Returns the number of cubature points.
      */

--- a/packages/intrepid2/src/Discretization/Integration/Intrepid2_CubatureControlVolumeSideDef.hpp
+++ b/packages/intrepid2/src/Discretization/Integration/Intrepid2_CubatureControlVolumeSideDef.hpp
@@ -109,9 +109,9 @@ namespace Intrepid2 {
   template <typename SpT, typename PT, typename WT>
   void
   CubatureControlVolumeSide<SpT,PT,WT>::
-  getCubature( pointViewType  cubPoints,
+  getCubature( PointViewType  cubPoints,
                weightViewType cubWeights,
-               pointViewType  cellCoords ) const {
+               PointViewType  cellCoords ) const {
 #ifdef HAVE_INTREPID2_DEBUG
     INTREPID2_TEST_FOR_EXCEPTION( cubPoints.rank() != 3, std::invalid_argument,
                                   ">>> ERROR (CubatureControlVolumeSide): cubPoints must have rank 3 (C,P,D).");
@@ -201,12 +201,12 @@ namespace Intrepid2 {
       typedef Kokkos::View<ordinal_type*,SpT> mapViewType;
       const auto sideNodeMap = Kokkos::subview(sideNodeMap_, i, Kokkos::ALL());
       
-      typedef typename ExecSpace<typename pointViewType::execution_space,SpT>::ExecSpaceType ExecSpaceType;
+      typedef typename ExecSpace<typename PointViewType::execution_space,SpT>::ExecSpaceType ExecSpaceType;
     
       const auto loopSize = numCells;
       Kokkos::RangePolicy<ExecSpaceType,Kokkos::Schedule<Kokkos::Static> > policy(0, loopSize);
       
-      typedef Functor<pointViewType,weightViewType,tempPointViewType,tempPointViewType,mapViewType> FunctorType;
+      typedef Functor<PointViewType,weightViewType,tempPointViewType,tempPointViewType,mapViewType> FunctorType;
 
       auto cubPointsThisSide  = Kokkos::subdynrankview(cubPoints,  Kokkos::ALL(), nodeRangePerSide[i], Kokkos::ALL());
       auto cubWeightsThisSide = Kokkos::subdynrankview(cubWeights, Kokkos::ALL(), nodeRangePerSide[i], Kokkos::ALL());

--- a/packages/intrepid2/src/Discretization/Integration/Intrepid2_CubatureDirect.hpp
+++ b/packages/intrepid2/src/Discretization/Integration/Intrepid2_CubatureDirect.hpp
@@ -177,14 +177,14 @@ namespace Intrepid2 {
     //
     // Cubature public functions
     //
-    typedef typename Cubature<ExecSpaceType,pointValueType,weightValueType>::pointViewType  pointViewType;
+    typedef typename Cubature<ExecSpaceType,pointValueType,weightValueType>::PointViewType  PointViewType;
     typedef typename Cubature<ExecSpaceType,pointValueType,weightValueType>::weightViewType weightViewType;
 
     using Cubature<ExecSpaceType,pointValueType,weightValueType>::getCubature;
 
     virtual
     void
-    getCubature( pointViewType  cubPoints,
+    getCubature( PointViewType  cubPoints,
                  weightViewType cubWeights ) const {
       this->getCubatureFromData(cubPoints, cubWeights, this->cubatureData_);
     }

--- a/packages/intrepid2/src/Discretization/Integration/Intrepid2_CubatureDirectLineGauss.hpp
+++ b/packages/intrepid2/src/Discretization/Integration/Intrepid2_CubatureDirectLineGauss.hpp
@@ -66,7 +66,7 @@ namespace Intrepid2 {
     typedef typename CubatureDirect<ExecSpaceType,pointValueType,weightValueType>::CubatureDataStatic CubatureDataStatic;
     typedef typename CubatureDirect<ExecSpaceType,pointValueType,weightValueType>::CubatureData       CubatureData;
 
-    typedef typename CubatureDirect<ExecSpaceType,pointValueType,weightValueType>::pointViewType  pointViewType;
+    typedef typename CubatureDirect<ExecSpaceType,pointValueType,weightValueType>::PointViewType  PointViewType;
     typedef typename CubatureDirect<ExecSpaceType,pointValueType,weightValueType>::weightViewType weightViewType;
 
   private:

--- a/packages/intrepid2/src/Discretization/Integration/Intrepid2_CubatureDirectLineGaussJacobi20.hpp
+++ b/packages/intrepid2/src/Discretization/Integration/Intrepid2_CubatureDirectLineGaussJacobi20.hpp
@@ -66,7 +66,7 @@ namespace Intrepid2 {
     typedef typename CubatureDirect<ExecSpaceType,pointValueType,weightValueType>::CubatureDataStatic CubatureDataStatic;
     typedef typename CubatureDirect<ExecSpaceType,pointValueType,weightValueType>::CubatureData       CubatureData;
 
-    typedef typename CubatureDirect<ExecSpaceType,pointValueType,weightValueType>::pointViewType  pointViewType;
+    typedef typename CubatureDirect<ExecSpaceType,pointValueType,weightValueType>::PointViewType  PointViewType;
     typedef typename CubatureDirect<ExecSpaceType,pointValueType,weightValueType>::weightViewType weightViewType;
 
   private:

--- a/packages/intrepid2/src/Discretization/Integration/Intrepid2_CubatureDirectTetDefault.hpp
+++ b/packages/intrepid2/src/Discretization/Integration/Intrepid2_CubatureDirectTetDefault.hpp
@@ -66,7 +66,7 @@ namespace Intrepid2 {
     typedef typename CubatureDirect<ExecSpaceType,pointValueType,weightValueType>::CubatureDataStatic CubatureDataStatic;
     typedef typename CubatureDirect<ExecSpaceType,pointValueType,weightValueType>::CubatureData       CubatureData;
 
-    typedef typename CubatureDirect<ExecSpaceType,pointValueType,weightValueType>::pointViewType  pointViewType;
+    typedef typename CubatureDirect<ExecSpaceType,pointValueType,weightValueType>::PointViewType  PointViewType;
     typedef typename CubatureDirect<ExecSpaceType,pointValueType,weightValueType>::weightViewType weightViewType;
 
   private:

--- a/packages/intrepid2/src/Discretization/Integration/Intrepid2_CubatureDirectTriDefault.hpp
+++ b/packages/intrepid2/src/Discretization/Integration/Intrepid2_CubatureDirectTriDefault.hpp
@@ -66,7 +66,7 @@ namespace Intrepid2 {
     typedef typename CubatureDirect<ExecSpaceType,pointValueType,weightValueType>::CubatureDataStatic CubatureDataStatic;
     typedef typename CubatureDirect<ExecSpaceType,pointValueType,weightValueType>::CubatureData       CubatureData;
 
-    typedef typename CubatureDirect<ExecSpaceType,pointValueType,weightValueType>::pointViewType  pointViewType;
+    typedef typename CubatureDirect<ExecSpaceType,pointValueType,weightValueType>::PointViewType  PointViewType;
     typedef typename CubatureDirect<ExecSpaceType,pointValueType,weightValueType>::weightViewType weightViewType;
 
   private:

--- a/packages/intrepid2/src/Discretization/Integration/Intrepid2_CubaturePolylib.hpp
+++ b/packages/intrepid2/src/Discretization/Integration/Intrepid2_CubaturePolylib.hpp
@@ -76,7 +76,7 @@ namespace Intrepid2 {
   class CubaturePolylib
     : public CubatureDirect<ExecSpaceType,pointValueType,weightValueType> {
   public:
-    typedef typename CubatureDirect<ExecSpaceType,pointValueType,weightValueType>::pointViewType  pointViewType; 
+    typedef typename CubatureDirect<ExecSpaceType,pointValueType,weightValueType>::PointViewType  PointViewType; 
     typedef typename CubatureDirect<ExecSpaceType,pointValueType,weightValueType>::weightViewType weightViewType;
 
     CubaturePolylib( const ordinal_type degree,

--- a/packages/intrepid2/src/Discretization/Integration/Intrepid2_CubatureTensor.hpp
+++ b/packages/intrepid2/src/Discretization/Integration/Intrepid2_CubatureTensor.hpp
@@ -83,14 +83,14 @@ namespace Intrepid2 {
     getCubatureImpl( Kokkos::DynRankView<cubPointValueType, cubPointProperties...>  cubPoints,
                      Kokkos::DynRankView<cubWeightValueType,cubWeightProperties...> cubWeights ) const;
 
-    typedef typename Cubature<ExecSpaceType,pointValueType,weightValueType>::pointViewType  pointViewType;
+    typedef typename Cubature<ExecSpaceType,pointValueType,weightValueType>::PointViewType  PointViewType;
     typedef typename Cubature<ExecSpaceType,pointValueType,weightValueType>::weightViewType weightViewType;
 
     using Cubature<ExecSpaceType,pointValueType,weightValueType>::getCubature;
 
     virtual
     void
-    getCubature( pointViewType  cubPoints,
+    getCubature( PointViewType  cubPoints,
                  weightViewType cubWeights ) const {
       getCubatureImpl( cubPoints,
                        cubWeights );

--- a/packages/intrepid2/src/Discretization/Integration/Intrepid2_CubatureTensorPyr.hpp
+++ b/packages/intrepid2/src/Discretization/Integration/Intrepid2_CubatureTensorPyr.hpp
@@ -92,14 +92,14 @@ namespace Intrepid2 {
     getCubatureImpl( Kokkos::DynRankView<cubPointValueType, cubPointProperties...>  cubPoints,
                      Kokkos::DynRankView<cubWeightValueType,cubWeightProperties...> cubWeights ) const;
 
-    typedef typename Cubature<ExecSpaceType,pointValueType,weightValueType>::pointViewType  pointViewType;
+    typedef typename Cubature<ExecSpaceType,pointValueType,weightValueType>::PointViewType  PointViewType;
     typedef typename Cubature<ExecSpaceType,pointValueType,weightValueType>::weightViewType weightViewType;
 
     using CubatureTensor<ExecSpaceType,pointValueType,weightValueType>::getCubature;
 
     virtual
     void
-    getCubature( pointViewType  cubPoints,
+    getCubature( PointViewType  cubPoints,
                  weightViewType cubWeights ) const {
       getCubatureImpl( cubPoints,
                        cubWeights );

--- a/packages/intrepid2/src/Orientation/Intrepid2_OrientationTools.hpp
+++ b/packages/intrepid2/src/Orientation/Intrepid2_OrientationTools.hpp
@@ -267,12 +267,12 @@ namespace Intrepid2 {
           \param  subcellOrt   [in]  - orientation number between 0 and 1
 
       */
-      template<typename outputViewType,
+      template<typename OutputViewType,
                typename subcellBasisType,
                typename cellBasisType>
       inline
       static void
-      getCoeffMatrix_HGRAD(outputViewType &output,
+      getCoeffMatrix_HGRAD(OutputViewType &output,
                            const subcellBasisType subcellBasis,
                            const cellBasisType cellBasis,
                            const ordinal_type subcellId,
@@ -287,12 +287,12 @@ namespace Intrepid2 {
           \param  subcellOrt   [in]  - orientation number between 0 and 1
 
       */
-      template<typename outputViewType,
+      template<typename OutputViewType,
                typename subcellBasisType,
                typename cellBasisType>
       inline
       static void
-      getCoeffMatrix_HCURL(outputViewType &output,
+      getCoeffMatrix_HCURL(OutputViewType &output,
                            const subcellBasisType subcellBasis,
                            const cellBasisType cellBasis,
                            const ordinal_type subcellId,
@@ -307,12 +307,12 @@ namespace Intrepid2 {
           \param  subcellOrt   [in]  - orientation number between 0 and 1
 
       */
-      template<typename outputViewType,
+      template<typename OutputViewType,
                typename subcellBasisType,
                typename cellBasisType>
       inline
       static void
-      getCoeffMatrix_HDIV(outputViewType &output,
+      getCoeffMatrix_HDIV(OutputViewType &output,
                           const subcellBasisType subcellBasis,
                           const cellBasisType cellBasis,
                           const ordinal_type subcellId,

--- a/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefCoeffMatrix_HCURL.hpp
+++ b/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefCoeffMatrix_HCURL.hpp
@@ -68,19 +68,19 @@ namespace Intrepid2 {
 
   namespace Impl {
 
-    template<typename outputViewType,
+    template<typename OutputViewType,
              typename subcellBasisType,
              typename cellBasisType>
     inline
     void
     OrientationTools::
-    getCoeffMatrix_HCURL(outputViewType &output,
+    getCoeffMatrix_HCURL(OutputViewType &output,
                          const subcellBasisType subcellBasis,
                          const cellBasisType cellBasis,
                          const ordinal_type subcellId,
                          const ordinal_type subcellOrt) {
-      typedef typename outputViewType::execution_space space_type;
-      typedef typename outputViewType::value_type value_type;
+      typedef typename OutputViewType::execution_space space_type;
+      typedef typename OutputViewType::value_type value_type;
       
       // with shards, everything should be computed on host space
       typedef typename

--- a/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefCoeffMatrix_HDIV.hpp
+++ b/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefCoeffMatrix_HDIV.hpp
@@ -72,19 +72,19 @@ namespace Intrepid2 {
   
   namespace Impl {
 
-    template<typename outputViewType,
+    template<typename OutputViewType,
              typename subcellBasisType,
              typename cellBasisType>
     inline
     void
     OrientationTools::
-    getCoeffMatrix_HDIV(outputViewType &output,
+    getCoeffMatrix_HDIV(OutputViewType &output,
                         const subcellBasisType subcellBasis,
                         const cellBasisType cellBasis,
                         const ordinal_type subcellId,
                         const ordinal_type subcellOrt) {
-      typedef typename outputViewType::execution_space space_type;
-      typedef typename outputViewType::value_type value_type;
+      typedef typename OutputViewType::execution_space space_type;
+      typedef typename OutputViewType::value_type value_type;
 
       // with shards, everything should be computed on host space
       typedef typename

--- a/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefCoeffMatrix_HGRAD.hpp
+++ b/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefCoeffMatrix_HGRAD.hpp
@@ -64,19 +64,19 @@ namespace Intrepid2 {
 
   namespace Impl {
 
-    template<typename outputViewType,
+    template<typename OutputViewType,
              typename subcellBasisType,
              typename cellBasisType>
     inline
     void
     OrientationTools::
-    getCoeffMatrix_HGRAD(outputViewType &output,
+    getCoeffMatrix_HGRAD(OutputViewType &output,
                          const subcellBasisType subcellBasis,
                          const cellBasisType cellBasis,
                          const ordinal_type subcellId,
                          const ordinal_type subcellOrt) {
-      typedef typename outputViewType::execution_space space_type;
-      typedef typename outputViewType::value_type value_type;
+      typedef typename OutputViewType::execution_space space_type;
+      typedef typename OutputViewType::value_type value_type;
 
       // with shards, everything should be computed on host space
       typedef typename

--- a/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefModifyBasis.hpp
+++ b/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefModifyBasis.hpp
@@ -124,14 +124,14 @@ namespace Intrepid2 {
   }
 
   template<typename ortViewType,
-           typename outputViewType,
+           typename OutputViewType,
            typename inputViewType,
            typename o2tViewType,
            typename t2oViewType,
            typename dataViewType>
   struct F_modifyBasisByOrientation {
     ortViewType orts;
-    outputViewType output;
+    OutputViewType output;
     inputViewType input;
     o2tViewType ordinalToTag;
     t2oViewType tagToOrdinal;
@@ -140,7 +140,7 @@ namespace Intrepid2 {
     const ordinal_type cellDim, numVerts, numEdges, numFaces, numPoints, dimBasis;
 
     F_modifyBasisByOrientation(ortViewType orts_,
-                               outputViewType output_,
+                               OutputViewType output_,
                                inputViewType input_,
                                o2tViewType ordinalToTag_,
                                t2oViewType tagToOrdinal_,

--- a/packages/intrepid2/src/Projection/Intrepid2_LagrangianInterpolationDef.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_LagrangianInterpolationDef.hpp
@@ -58,44 +58,44 @@ namespace Experimental {
 
 
 
-template<typename scalarViewType,
+template<typename ScalarViewType,
 typename ortViewType,
 typename t2oViewType,
 typename subcellParamViewType,
 typename intViewType>
 struct computeDofCoordsAndCoeffs {
-  typedef typename scalarViewType::value_type value_type;
+  typedef typename ScalarViewType::value_type value_type;
 
-  scalarViewType dofCoords_, dofCoeffs_;
+  ScalarViewType dofCoords_, dofCoeffs_;
   const ortViewType orts_;
   const t2oViewType tagToOrdinal_;
   const subcellParamViewType edgeParam_, faceParam_;
   const intViewType edgeInternalDofOrdinals_, facesInternalDofOrdinals_;
-  const scalarViewType edgeInternalDofCoords_, edgeDofCoeffs_, ortJacobianEdge_, refEdgesTan_, refEdgesNormal_;
-  const scalarViewType facesInternalDofCoords_, faceDofCoeffs_, ortJacobianFace_, refFaceTangents_, refFacesNormal_;
-  scalarViewType edgeWorkView_, faceWorkView_;
+  const ScalarViewType edgeInternalDofCoords_, edgeDofCoeffs_, ortJacobianEdge_, refEdgesTan_, refEdgesNormal_;
+  const ScalarViewType facesInternalDofCoords_, faceDofCoeffs_, ortJacobianFace_, refFaceTangents_, refFacesNormal_;
+  ScalarViewType edgeWorkView_, faceWorkView_;
   const ordinal_type cellDim_, numEdges_, numFaces_;
   const ordinal_type edgeTopoKey_, numEdgeInternalDofs_;
   const intViewType faceTopoKey_, numFacesInternalDofs_;
   const value_type edgeScale_, faceScale_;
   const bool isBasisHCURL_, isBasisHDIV_;
 
-  computeDofCoordsAndCoeffs( scalarViewType dofCoords,
-      scalarViewType dofCoeffs,
+  computeDofCoordsAndCoeffs( ScalarViewType dofCoords,
+      ScalarViewType dofCoeffs,
       const ortViewType orts,
       const t2oViewType tagToOrdinal,
       const subcellParamViewType edgeParam,
       const subcellParamViewType faceParam,
       const intViewType edgeInternalDofOrdinals,
       const intViewType facesInternalDofOrdinals,
-      const scalarViewType edgeInternalDofCoords,
-      const scalarViewType edgeDofCoeffs,
-      const scalarViewType refEdgesTan,
-      const scalarViewType refEdgesNormal,
-      const scalarViewType facesInternalDofCoords,
-      const scalarViewType faceDofCoeffs,
-      const scalarViewType refFaceTangents,
-      const scalarViewType refFacesNormal,
+      const ScalarViewType edgeInternalDofCoords,
+      const ScalarViewType edgeDofCoeffs,
+      const ScalarViewType refEdgesTan,
+      const ScalarViewType refEdgesNormal,
+      const ScalarViewType facesInternalDofCoords,
+      const ScalarViewType faceDofCoeffs,
+      const ScalarViewType refFaceTangents,
+      const ScalarViewType refFacesNormal,
       const ordinal_type cellDim,
       const ordinal_type numEdges,
       const ordinal_type numFaces,
@@ -137,9 +137,9 @@ struct computeDofCoordsAndCoeffs {
     isBasisHDIV_(isBasisHDIV)
   {
     if(numEdges > 0)
-      edgeWorkView_ = scalarViewType("edgeWorkView", dofCoords.extent(0), numEdgeInternalDofs, 1);
+      edgeWorkView_ = ScalarViewType("edgeWorkView", dofCoords.extent(0), numEdgeInternalDofs, 1);
     if(numFaces > 0)
-      faceWorkView_ = scalarViewType("faceWorkView", dofCoords.extent(0), facesInternalDofCoords.extent(1), 2);
+      faceWorkView_ = ScalarViewType("faceWorkView", dofCoords.extent(0), facesInternalDofCoords.extent(1), 2);
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -151,7 +151,7 @@ struct computeDofCoordsAndCoeffs {
       //compute coordinates associated to edge DoFs
       ordinal_type eOrt[12];
       value_type ortJac;
-      scalarViewType ortJacobianEdge(&ortJac, 1, 1);
+      ScalarViewType ortJacobianEdge(&ortJac, 1, 1);
       orts_(cell).getEdgeOrientation(eOrt, numEdges_);
       auto edgeInternalDofCoordsOriented = Kokkos::subview(edgeWorkView_,cell, Kokkos::ALL(), Kokkos::ALL());
       //map edge DoFs coords into parent element coords
@@ -208,7 +208,7 @@ struct computeDofCoordsAndCoeffs {
       //compute coordinates associated to face DoFs
       ordinal_type fOrt[12];
       value_type ortJac[4];
-      scalarViewType ortJacobianFace(ortJac, 2, 2);
+      ScalarViewType ortJacobianFace(ortJac, 2, 2);
       orts_(cell).getFaceOrientation(fOrt, numFaces_);
       //map face dofs coords into parent element coords
       for (ordinal_type iface=0; iface < numFaces_; ++iface) {
@@ -280,7 +280,7 @@ LagrangianInterpolation<SpT>::getDofCoordsAndCoeffs(
     const Kokkos::DynRankView<ortValueType,   ortProperties...>  orts) {
 
   typedef typename BasisType::scalarType scalarType;
-  typedef  Kokkos::DynRankView<scalarType, SpT> scalarViewType;
+  typedef  Kokkos::DynRankView<scalarType, SpT> ScalarViewType;
   typedef  Kokkos::DynRankView<ordinal_type, SpT> intViewType;
   typedef Kokkos::pair<ordinal_type,ordinal_type> range_type;
 
@@ -352,14 +352,14 @@ LagrangianInterpolation<SpT>::getDofCoordsAndCoeffs(
 
   const ordinal_type numCells = dofCoeffs.extent(0);
 
-  scalarViewType refDofCoords("refDofCoords", dofCoords.extent(1), dofCoords.extent(2)), refDofCoeffs;
+  ScalarViewType refDofCoords("refDofCoords", dofCoords.extent(1), dofCoords.extent(2)), refDofCoeffs;
   basis->getDofCoords(refDofCoords);
   RealSpaceTools<SpT>::clone(dofCoords,refDofCoords);
 
   if(dofCoeffs.rank() == 3) //vector basis
-    refDofCoeffs = scalarViewType("refDofCoeffs", dofCoeffs.extent(1), dofCoeffs.extent(2));
+    refDofCoeffs = ScalarViewType("refDofCoeffs", dofCoeffs.extent(1), dofCoeffs.extent(2));
   else //scalar basis
-    refDofCoeffs = scalarViewType("refDofCoeffs",dofCoeffs.extent(1));
+    refDofCoeffs = ScalarViewType("refDofCoeffs",dofCoeffs.extent(1));
   basis->getDofCoeffs(refDofCoeffs);
   RealSpaceTools<SpT>::clone(dofCoeffs,refDofCoeffs);
 
@@ -367,14 +367,14 @@ LagrangianInterpolation<SpT>::getDofCoordsAndCoeffs(
 
   ordinal_type edgeTopoKey = Teuchos::nonnull(edgeBasis) ? edgeBasis->getBaseCellTopology().getBaseKey() : 0;
   intViewType eOrt("eOrt", numEdges);
-  scalarViewType refEdgesTan("refEdgesTan",  numEdges, dim);
-  scalarViewType refEdgesNormal("refEdgesNormal",  numEdges, dim);
-  scalarViewType edgeParam;
+  ScalarViewType refEdgesTan("refEdgesTan",  numEdges, dim);
+  ScalarViewType refEdgesNormal("refEdgesNormal",  numEdges, dim);
+  ScalarViewType edgeParam;
   ordinal_type edgeBasisCardinality = Teuchos::nonnull(edgeBasis) ? edgeBasis->getCardinality() : ordinal_type(0);
   ordinal_type numEdgeInternalDofs = Teuchos::nonnull(edgeBasis) ? edgeBasis->getDofCount(1,0) : ordinal_type(0);
-  scalarViewType edgeDofCoords("edgeDofCoords", edgeBasisCardinality, 1);
-  scalarViewType edgeDofCoeffs("edgeDofCoeffs", edgeBasisCardinality);
-  scalarViewType edgeInternalDofCoords("edgeInternalDofCoords", numEdgeInternalDofs, 1);
+  ScalarViewType edgeDofCoords("edgeDofCoords", edgeBasisCardinality, 1);
+  ScalarViewType edgeDofCoeffs("edgeDofCoeffs", edgeBasisCardinality);
+  ScalarViewType edgeInternalDofCoords("edgeInternalDofCoords", numEdgeInternalDofs, 1);
   intViewType edgeInternalDofOrdinals("edgeInternalDofOrdinals", numEdgeInternalDofs);
   //depending on how the reference basis is defined, the edges are scaled differently
   auto edgeScale = (isBasisTriOrTet||isBasisI1) ? 2.0 :1.0;
@@ -411,13 +411,13 @@ LagrangianInterpolation<SpT>::getDofCoordsAndCoeffs(
 
   intViewType faceTopoKey("faceTopoKey",numFaces);
   intViewType fOrt("fOrt", numFaces);
-  scalarViewType refFaceTangents("refFaceTangents", numFaces, dim, 2);
-  scalarViewType refFacesNormal("refFacesNormal",  numFaces, dim);
-  scalarViewType faceParam;
+  ScalarViewType refFaceTangents("refFaceTangents", numFaces, dim, 2);
+  ScalarViewType refFacesNormal("refFacesNormal",  numFaces, dim);
+  ScalarViewType faceParam;
   intViewType numFacesInternalDofs("numFacesInternalDofs", numFaces);
-  scalarViewType  facesInternalDofCoords;
+  ScalarViewType  facesInternalDofCoords;
   intViewType  facesInternalDofOrdinals;
-  scalarViewType  faceDofCoeffs;
+  ScalarViewType  faceDofCoeffs;
   //depending on how the reference basis is defined, the faces are scaled differently
   auto faceScale = (isBasisHEXI1) ? 4.0 :
       (isBasisTETI1) ? 0.5 : 1.0;
@@ -434,19 +434,19 @@ LagrangianInterpolation<SpT>::getDofCoordsAndCoeffs(
     faceBasisMaxCardinality = std::max(faceBasisMaxCardinality, faceBasisCardinality);
   }
 
-  facesInternalDofCoords = scalarViewType("faceInternalDofCoords", numFaces, maxNumFacesInternalDofs, 2);
+  facesInternalDofCoords = ScalarViewType("faceInternalDofCoords", numFaces, maxNumFacesInternalDofs, 2);
   facesInternalDofOrdinals = intViewType("faceInternalDofCoords", numFaces, maxNumFacesInternalDofs);
 
   if(isBasisHCURL)
-    faceDofCoeffs = scalarViewType("faceDofCoeffs", numFaces, faceBasisMaxCardinality,2);
+    faceDofCoeffs = ScalarViewType("faceDofCoeffs", numFaces, faceBasisMaxCardinality,2);
   else
-    faceDofCoeffs = scalarViewType("faceDofCoeffs", numFaces, faceBasisMaxCardinality);
+    faceDofCoeffs = ScalarViewType("faceDofCoeffs", numFaces, faceBasisMaxCardinality);
 
   for (ordinal_type iface=0; iface < numFaces; ++iface) {
     auto faceBasis = faceBases[iface];
     faceTopoKey(iface) = faceBasis->getBaseCellTopology().getBaseKey();
     ordinal_type faceBasisCardinality = faceBasis->getCardinality();
-    scalarViewType  faceDofCoords("faceDofCoords", faceBasisCardinality, 2);
+    ScalarViewType  faceDofCoords("faceDofCoords", faceBasisCardinality, 2);
     faceBasis->getDofCoords(faceDofCoords);
     for(ordinal_type i=0; i<numFacesInternalDofs(iface); ++i) {
       facesInternalDofOrdinals(iface, i) = faceBasis->getDofOrdinal(2, 0, i);
@@ -481,7 +481,7 @@ LagrangianInterpolation<SpT>::getDofCoordsAndCoeffs(
 
   const Kokkos::RangePolicy<SpT> policy(0, numCells);
   typedef computeDofCoordsAndCoeffs
-      <scalarViewType,
+      <ScalarViewType,
       decltype(orts),
       decltype(tagToOrdinal),
       decltype(edgeParam),

--- a/packages/intrepid2/src/Projection/Intrepid2_ProjectionStruct.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_ProjectionStruct.hpp
@@ -50,6 +50,8 @@
 #include "Intrepid2_ConfigDefs.hpp"
 #include "Intrepid2_Types.hpp"
 
+#include <array>
+
 namespace Intrepid2 {
 
 namespace Experimental {

--- a/packages/intrepid2/src/Projection/Intrepid2_ProjectionTools.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_ProjectionTools.hpp
@@ -191,7 +191,7 @@ public:
   template<typename BasisType,
   typename ortValueType,       class ...ortProperties>
   static void
-  getL2EvaluationPoints(typename BasisType::scalarViewType evaluationPoints,
+  getL2EvaluationPoints(typename BasisType::ScalarViewType evaluationPoints,
       const Kokkos::DynRankView<ortValueType,   ortProperties...>  cellOrientations,
       const BasisType* cellBasis,
       ProjectionStruct<ExecSpaceType, typename BasisType::scalarType> * projStruct,
@@ -224,7 +224,7 @@ public:
   static void
   getL2BasisCoeffs(Kokkos::DynRankView<basisCoeffsValueType,basisCoeffsProperties...> basisCoeffs,
       const Kokkos::DynRankView<funValsValueType,funValsProperties...> targetAtEvalPoints,
-      const typename BasisType::scalarViewType evaluationPoints,
+      const typename BasisType::ScalarViewType evaluationPoints,
       const Kokkos::DynRankView<ortValueType,   ortProperties...>  cellOrientations,
       const BasisType* cellBasis,
       ProjectionStruct<ExecSpaceType, typename BasisType::scalarType> * projStruct);
@@ -252,8 +252,8 @@ public:
   template<typename BasisType,
   typename ortValueType,       class ...ortProperties>
   static void
-  getHGradEvaluationPoints(typename BasisType::scalarViewType evaluationPoints,
-      typename BasisType::scalarViewType gradEvalPoints,
+  getHGradEvaluationPoints(typename BasisType::ScalarViewType evaluationPoints,
+      typename BasisType::ScalarViewType gradEvalPoints,
       const Kokkos::DynRankView<ortValueType,   ortProperties...>  cellOrientations,
       const BasisType* cellBasis,
       ProjectionStruct<ExecSpaceType, typename BasisType::scalarType> * projStruct,
@@ -291,8 +291,8 @@ public:
   getHGradBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueType,basisCoeffsProperties...> basisCoeffs,
       const Kokkos::DynRankView<funValsValueType,funValsProperties...> targetAtEvalPoints,
       const Kokkos::DynRankView<funValsValueType,funValsProperties...> targetGradAtGradEvalPoints,
-      const typename BasisType::scalarViewType evaluationPoints,
-      const typename BasisType::scalarViewType gradEvalPoints,
+      const typename BasisType::ScalarViewType evaluationPoints,
+      const typename BasisType::ScalarViewType gradEvalPoints,
       const Kokkos::DynRankView<ortValueType,   ortProperties...>  cellOrientations,
       const BasisType* cellBasis,
       ProjectionStruct<ExecSpaceType, typename BasisType::scalarType> * projStruct);
@@ -320,8 +320,8 @@ public:
   template<typename BasisType,
   typename ortValueType,       class ...ortProperties>
   static void
-  getHCurlEvaluationPoints(typename BasisType::scalarViewType evaluationPoints,
-      typename BasisType::scalarViewType curlEvalPoints,
+  getHCurlEvaluationPoints(typename BasisType::ScalarViewType evaluationPoints,
+      typename BasisType::ScalarViewType curlEvalPoints,
       const Kokkos::DynRankView<ortValueType,   ortProperties...>  cellOrientations,
       const BasisType* cellBasis,
       ProjectionStruct<ExecSpaceType, typename BasisType::scalarType> * projStruct,
@@ -361,8 +361,8 @@ public:
   getHCurlBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueType,basisCoeffsProperties...> basisCoeffs,
       const Kokkos::DynRankView<funValsValueType,funValsProperties...> targetAtEvalPoints,
       const Kokkos::DynRankView<funValsValueType,funValsProperties...> targetCurlAtCurlEvalPoints,
-      const typename BasisType::scalarViewType evaluationPoints,
-      const typename BasisType::scalarViewType curlEvalPoints,
+      const typename BasisType::ScalarViewType evaluationPoints,
+      const typename BasisType::ScalarViewType curlEvalPoints,
       const Kokkos::DynRankView<ortValueType,   ortProperties...>  cellOrientations,
       const BasisType* cellBasis,
       ProjectionStruct<ExecSpaceType, typename BasisType::scalarType> * projStruct);
@@ -390,8 +390,8 @@ public:
   template<typename BasisType,
   typename ortValueType,       class ...ortProperties>
   static void
-  getHDivEvaluationPoints(typename BasisType::scalarViewType evaluationPoints,
-      typename BasisType::scalarViewType divEvalPoints,
+  getHDivEvaluationPoints(typename BasisType::ScalarViewType evaluationPoints,
+      typename BasisType::ScalarViewType divEvalPoints,
       const Kokkos::DynRankView<ortValueType,   ortProperties...>  cellOrientations,
       const BasisType* cellBasis,
       ProjectionStruct<ExecSpaceType, typename BasisType::scalarType> * projStruct,
@@ -429,8 +429,8 @@ public:
   getHDivBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueType,basisCoeffsProperties...> basisCoeffs,
       const Kokkos::DynRankView<funValsValueType,funValsProperties...> targetAtEvalPoints,
       const Kokkos::DynRankView<funValsValueType,funValsProperties...> targetDivAtDivEvalPoints,
-      const typename BasisType::scalarViewType evaluationPoints,
-      const typename BasisType::scalarViewType divEvalPoints,
+      const typename BasisType::ScalarViewType evaluationPoints,
+      const typename BasisType::ScalarViewType divEvalPoints,
       const Kokkos::DynRankView<ortValueType,   ortProperties...>  cellOrientations,
       const BasisType* cellBasis,
       ProjectionStruct<ExecSpaceType, typename BasisType::scalarType> * projStruct);
@@ -454,7 +454,7 @@ public:
   template<typename BasisType,
   typename ortValueType,       class ...ortProperties>
   static void
-  getHVolEvaluationPoints(typename BasisType::scalarViewType evaluationPoints,
+  getHVolEvaluationPoints(typename BasisType::ScalarViewType evaluationPoints,
       const Kokkos::DynRankView<ortValueType, ortProperties...>  cellOrientations,
       const BasisType* cellBasis,
       ProjectionStruct<ExecSpaceType, typename BasisType::scalarType> * projStruct,
@@ -486,7 +486,7 @@ public:
   static void
   getHVolBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueType,basisCoeffsProperties...> basisCoeffs,
       const Kokkos::DynRankView<funValsValueType,funValsProperties...> targetAtEvalPoints,
-      const typename BasisType::scalarViewType evaluationPoints,
+      const typename BasisType::ScalarViewType evaluationPoints,
       const Kokkos::DynRankView<ortValueType,   ortProperties...>  cellOrientations,
       const BasisType* cellBasis,
       ProjectionStruct<ExecSpaceType, typename BasisType::scalarType> * projStruct);

--- a/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefHCURL.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefHCURL.hpp
@@ -61,14 +61,14 @@ template<typename SpT>
 template<typename BasisType,
 typename ortValueType,       class ...ortProperties>
 void
-ProjectionTools<SpT>::getHCurlEvaluationPoints(typename BasisType::scalarViewType evaluationPoints,
-    typename BasisType::scalarViewType extDerivEvaluationPoints,
+ProjectionTools<SpT>::getHCurlEvaluationPoints(typename BasisType::ScalarViewType evaluationPoints,
+    typename BasisType::ScalarViewType extDerivEvaluationPoints,
     const Kokkos::DynRankView<ortValueType,   ortProperties...>  orts,
     const BasisType* cellBasis,
     ProjectionStruct<SpT, typename BasisType::scalarType> * projStruct,
     const EvalPointsType evalPointType) {
   typedef typename BasisType::scalarType scalarType;
-  typedef Kokkos::DynRankView<scalarType,SpT> scalarViewType;
+  typedef Kokkos::DynRankView<scalarType,SpT> ScalarViewType;
   typedef Kokkos::pair<ordinal_type,ordinal_type> range_type;
   const auto cellTopo = cellBasis->getBaseCellTopology();
   ordinal_type dim = cellTopo.getDimension();
@@ -83,7 +83,7 @@ ProjectionTools<SpT>::getHCurlEvaluationPoints(typename BasisType::scalarViewTyp
 
   for(ordinal_type ie=0; ie<numEdges; ++ie) {
     range_type edgePointsRange;
-    scalarViewType cubPoints;
+    ScalarViewType cubPoints;
     if(evalPointType == TARGET) {
       edgePointsRange = projStruct->getTargetPointsRange(edgeDim, ie);
       cubPoints = projStruct->getTargetEvalPoints(edgeDim, ie);
@@ -93,7 +93,7 @@ ProjectionTools<SpT>::getHCurlEvaluationPoints(typename BasisType::scalarViewTyp
       cubPoints = projStruct->getBasisEvalPoints(edgeDim, ie);
     }
 
-    scalarViewType orientedTargetCubPoints("orientedTargetCubPoints", cubPoints.extent(0),edgeDim);
+    ScalarViewType orientedTargetCubPoints("orientedTargetCubPoints", cubPoints.extent(0),edgeDim);
 
     const auto topoKey = projStruct->getTopologyKey(edgeDim,ie);
 
@@ -108,7 +108,7 @@ ProjectionTools<SpT>::getHCurlEvaluationPoints(typename BasisType::scalarViewTyp
 
   for(ordinal_type iface=0; iface<numFaces; ++iface) {
 
-    scalarViewType cubPoints;//("cubPoints", numTargetCubPoints, faceDim);
+    ScalarViewType cubPoints;//("cubPoints", numTargetCubPoints, faceDim);
     range_type facePointsRange;
     if(evalPointType == TARGET) {
       cubPoints = projStruct->getTargetEvalPoints(faceDim, iface);
@@ -118,7 +118,7 @@ ProjectionTools<SpT>::getHCurlEvaluationPoints(typename BasisType::scalarViewTyp
       facePointsRange = projStruct->getBasisPointsRange(faceDim, iface);
     }
 
-    scalarViewType curlCubPoints;//("curlCubPoints", numTargetCurlCubPoints, faceDim);
+    ScalarViewType curlCubPoints;//("curlCubPoints", numTargetCurlCubPoints, faceDim);
     range_type faceCurlPointsRange;
     if(evalPointType == TARGET) {
       curlCubPoints = projStruct->getTargetDerivEvalPoints(faceDim, iface);
@@ -128,8 +128,8 @@ ProjectionTools<SpT>::getHCurlEvaluationPoints(typename BasisType::scalarViewTyp
       faceCurlPointsRange = projStruct->getBasisDerivPointsRange(faceDim, iface);
     }
 
-    scalarViewType faceCubPoints("faceCubPoints", cubPoints.extent(0), faceDim);
-    scalarViewType faceCurlCubPoints("faceCurlCubPoints", curlCubPoints.extent(0), faceDim);
+    ScalarViewType faceCubPoints("faceCubPoints", cubPoints.extent(0), faceDim);
+    ScalarViewType faceCurlCubPoints("faceCurlCubPoints", curlCubPoints.extent(0), faceDim);
 
     const auto topoKey = projStruct->getTopologyKey(faceDim,iface);
     for(ordinal_type ic=0; ic<numCells; ++ic) {
@@ -148,7 +148,7 @@ ProjectionTools<SpT>::getHCurlEvaluationPoints(typename BasisType::scalarViewTyp
 
   if(cellBasis->getDofCount(dim,0)>0) {
     range_type cellPointsRange;
-    scalarViewType cubPoints;
+    ScalarViewType cubPoints;
     if(evalPointType == TARGET) {
       cubPoints = projStruct->getTargetEvalPoints(dim, 0);
       cellPointsRange = projStruct->getTargetPointsRange(dim, 0);
@@ -159,7 +159,7 @@ ProjectionTools<SpT>::getHCurlEvaluationPoints(typename BasisType::scalarViewTyp
     RealSpaceTools<SpT>::clone(Kokkos::subview(evaluationPoints, Kokkos::ALL(), cellPointsRange, Kokkos::ALL()), cubPoints);
 
     range_type cellCurlPointsRange;
-    scalarViewType curlCubPoints;
+    ScalarViewType curlCubPoints;
     if(evalPointType == TARGET) {
       curlCubPoints = projStruct->getTargetDerivEvalPoints(dim, 0);
       cellCurlPointsRange = projStruct->getTargetDerivPointsRange(dim, 0);
@@ -181,15 +181,15 @@ void
 ProjectionTools<SpT>::getHCurlBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueType,basisCoeffsProperties...> basisCoeffs,
     const Kokkos::DynRankView<funValsValueType,funValsProperties...> targetAtEvalPoints,
     const Kokkos::DynRankView<funValsValueType,funValsProperties...> targetCurlAtCurlEvalPoints,
-    const typename BasisType::scalarViewType evaluationPoints,
-    const typename BasisType::scalarViewType extDerivEvaluationPoints,
+    const typename BasisType::ScalarViewType evaluationPoints,
+    const typename BasisType::ScalarViewType extDerivEvaluationPoints,
     const Kokkos::DynRankView<ortValueType,   ortProperties...>  orts,
     const BasisType* cellBasis,
     ProjectionStruct<SpT, typename BasisType::scalarType> * projStruct){
 
   typedef typename Kokkos::Impl::is_space<SpT>::host_mirror_space::execution_space host_space_type;
   typedef typename BasisType::scalarType scalarType;
-  typedef Kokkos::DynRankView<scalarType,SpT> scalarViewType;
+  typedef Kokkos::DynRankView<scalarType,SpT> ScalarViewType;
   typedef Kokkos::pair<ordinal_type,ordinal_type> range_type;
   const auto cellTopo = cellBasis->getBaseCellTopology();
   ordinal_type dim = cellTopo.getDimension();
@@ -208,9 +208,9 @@ ProjectionTools<SpT>::getHCurlBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueTy
 
   Kokkos::View<ordinal_type*> eOrt("eOrt", numEdges);
   Kokkos::View<ordinal_type*> fOrt("fOrt", numFaces);
-  scalarViewType refEdgeTan("refEdgeTan",  dim);
-  scalarViewType refFaceTangents("refFaceTangents", dim, 2);
-  scalarViewType refFaceNormal("refFaceNormal", dim);
+  ScalarViewType refEdgeTan("refEdgeTan",  dim);
+  ScalarViewType refFaceTangents("refFaceTangents", dim, 2);
+  ScalarViewType refFaceNormal("refFaceNormal", dim);
   auto refFaceTanU = Kokkos::subview(refFaceTangents, Kokkos::ALL, 0);
   auto refFaceTanV = Kokkos::subview(refFaceTangents, Kokkos::ALL, 1);
 
@@ -227,15 +227,15 @@ ProjectionTools<SpT>::getHCurlBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueTy
   ordinal_type computedDofsCount = 0;
 
   ordinal_type numTotalCubPoints = projStruct->getNumBasisEvalPoints(), numTotalCurlCubPoints = projStruct->getNumBasisDerivEvalPoints();
-  scalarViewType cubPoints("cubPoints",numCells,numTotalCubPoints, dim);
-  scalarViewType curlCubPoints("curlCubPoints",numCells,numTotalCurlCubPoints, dim);
+  ScalarViewType cubPoints("cubPoints",numCells,numTotalCubPoints, dim);
+  ScalarViewType curlCubPoints("curlCubPoints",numCells,numTotalCurlCubPoints, dim);
   getHCurlEvaluationPoints(cubPoints, curlCubPoints, orts, cellBasis, projStruct, BASIS);
 
-  scalarViewType basisAtCubPoints("basisAtCubPoints",numCells,basisCardinality, numTotalCubPoints, dim);
-  scalarViewType basisAtTargetCubPoints("basisAtTargetCubPoints",numCells,basisCardinality, numTotalEvaluationPoints, dim);
+  ScalarViewType basisAtCubPoints("basisAtCubPoints",numCells,basisCardinality, numTotalCubPoints, dim);
+  ScalarViewType basisAtTargetCubPoints("basisAtTargetCubPoints",numCells,basisCardinality, numTotalEvaluationPoints, dim);
   {
-    scalarViewType nonOrientedBasisAtCubPoints("nonOrientedBasisAtCubPoints",numCells,basisCardinality, numTotalCubPoints, dim);
-    scalarViewType nonOrientedBasisAtTargetCubPoints("nonOrientedBasisAtTargetCubPoints",numCells,basisCardinality, numTotalEvaluationPoints, dim);
+    ScalarViewType nonOrientedBasisAtCubPoints("nonOrientedBasisAtCubPoints",numCells,basisCardinality, numTotalCubPoints, dim);
+    ScalarViewType nonOrientedBasisAtTargetCubPoints("nonOrientedBasisAtTargetCubPoints",numCells,basisCardinality, numTotalEvaluationPoints, dim);
     for(ordinal_type ic=0; ic<numCells; ++ic) {
       cellBasis->getValues(Kokkos::subview(nonOrientedBasisAtTargetCubPoints,ic,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()));
       cellBasis->getValues(Kokkos::subview(nonOrientedBasisAtCubPoints,ic,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL()), Kokkos::subview(cubPoints, ic, Kokkos::ALL(), Kokkos::ALL()));
@@ -245,20 +245,20 @@ ProjectionTools<SpT>::getHCurlBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueTy
     OrientationTools<SpT>::modifyBasisByOrientation(basisAtTargetCubPoints, nonOrientedBasisAtTargetCubPoints, orts, cellBasis);
   }
 
-  scalarViewType basisCurlAtCurlCubPoints;
-  scalarViewType basisCurlAtTargetCurlCubPoints;
+  ScalarViewType basisCurlAtCurlCubPoints;
+  ScalarViewType basisCurlAtTargetCurlCubPoints;
   if(numTotalCurlEvaluationPoints>0) {
-    scalarViewType nonOrientedBasisCurlAtTargetCurlCubPoints, nonOrientedBasisCurlAtCurlCubPoints;
+    ScalarViewType nonOrientedBasisCurlAtTargetCurlCubPoints, nonOrientedBasisCurlAtCurlCubPoints;
     if (dim == 3) {
-      basisCurlAtCurlCubPoints = scalarViewType ("basisCurlAtCurlCubPoints",numCells,basisCardinality, numTotalCurlCubPoints, dim);
-      nonOrientedBasisCurlAtCurlCubPoints = scalarViewType ("nonOrientedBasisCurlAtCurlCubPoints",numCells,basisCardinality, numTotalCurlCubPoints, dim);
-      basisCurlAtTargetCurlCubPoints = scalarViewType("basisCurlAtTargetCurlCubPoints",numCells,basisCardinality, numTotalCurlEvaluationPoints, dim);
-      nonOrientedBasisCurlAtTargetCurlCubPoints = scalarViewType("nonOrientedBasisCurlAtTargetCurlCubPoints",numCells,basisCardinality, numTotalCurlEvaluationPoints, dim);
+      basisCurlAtCurlCubPoints = ScalarViewType ("basisCurlAtCurlCubPoints",numCells,basisCardinality, numTotalCurlCubPoints, dim);
+      nonOrientedBasisCurlAtCurlCubPoints = ScalarViewType ("nonOrientedBasisCurlAtCurlCubPoints",numCells,basisCardinality, numTotalCurlCubPoints, dim);
+      basisCurlAtTargetCurlCubPoints = ScalarViewType("basisCurlAtTargetCurlCubPoints",numCells,basisCardinality, numTotalCurlEvaluationPoints, dim);
+      nonOrientedBasisCurlAtTargetCurlCubPoints = ScalarViewType("nonOrientedBasisCurlAtTargetCurlCubPoints",numCells,basisCardinality, numTotalCurlEvaluationPoints, dim);
     } else {
-      basisCurlAtCurlCubPoints = scalarViewType ("basisCurlAtCurlCubPoints",numCells,basisCardinality, numTotalCurlCubPoints);
-      nonOrientedBasisCurlAtCurlCubPoints = scalarViewType ("nonOrientedBasisCurlAtCurlCubPoints",numCells,basisCardinality, numTotalCurlCubPoints);
-      basisCurlAtTargetCurlCubPoints = scalarViewType("basisCurlAtTargetCurlCubPoints",numCells,basisCardinality, numTotalCurlEvaluationPoints);
-      nonOrientedBasisCurlAtTargetCurlCubPoints = scalarViewType("nonOrientedBasisCurlAtTargetCurlCubPoints",numCells,basisCardinality, numTotalCurlEvaluationPoints);
+      basisCurlAtCurlCubPoints = ScalarViewType ("basisCurlAtCurlCubPoints",numCells,basisCardinality, numTotalCurlCubPoints);
+      nonOrientedBasisCurlAtCurlCubPoints = ScalarViewType ("nonOrientedBasisCurlAtCurlCubPoints",numCells,basisCardinality, numTotalCurlCubPoints);
+      basisCurlAtTargetCurlCubPoints = ScalarViewType("basisCurlAtTargetCurlCubPoints",numCells,basisCardinality, numTotalCurlEvaluationPoints);
+      nonOrientedBasisCurlAtTargetCurlCubPoints = ScalarViewType("nonOrientedBasisCurlAtTargetCurlCubPoints",numCells,basisCardinality, numTotalCurlEvaluationPoints);
     }
     for(ordinal_type ic=0; ic<numCells; ++ic) {
       cellBasis->getValues(Kokkos::subview(nonOrientedBasisCurlAtCurlCubPoints,ic,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL()), Kokkos::subview(curlCubPoints, ic, Kokkos::ALL(), Kokkos::ALL()),OPERATOR_CURL);
@@ -276,14 +276,14 @@ ProjectionTools<SpT>::getHCurlBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueTy
 
     CellTools<SpT>::getReferenceEdgeTangent(refEdgeTan, ie, cellBasis->getBaseCellTopology());
 
-    scalarViewType tanBasisAtElemCubPoints("tanBasisAtElemCubPoints",numCells,edgeCardinality, numCubPoints);
-    scalarViewType tanBasisAtTargetCubPoints("tanBasisAtTargetCubPoints",numCells,edgeCardinality, numTargetCubPoints);
-    scalarViewType weightedTanBasisAtElemCubPoints("weightedTanBasisAtElemCubPoints",numCells,edgeCardinality, numCubPoints);
-    scalarViewType weightedTanBasisAtTargetCubPoints("weightedTanBasisAtTargetCubPoints",numCells,edgeCardinality, numTargetCubPoints);
-    scalarViewType tanTargetAtTargetCubPoints("normalTargetAtTargetCubPoints",numCells, numTargetCubPoints);
+    ScalarViewType tanBasisAtElemCubPoints("tanBasisAtElemCubPoints",numCells,edgeCardinality, numCubPoints);
+    ScalarViewType tanBasisAtTargetCubPoints("tanBasisAtTargetCubPoints",numCells,edgeCardinality, numTargetCubPoints);
+    ScalarViewType weightedTanBasisAtElemCubPoints("weightedTanBasisAtElemCubPoints",numCells,edgeCardinality, numCubPoints);
+    ScalarViewType weightedTanBasisAtTargetCubPoints("weightedTanBasisAtTargetCubPoints",numCells,edgeCardinality, numTargetCubPoints);
+    ScalarViewType tanTargetAtTargetCubPoints("normalTargetAtTargetCubPoints",numCells, numTargetCubPoints);
 
-    scalarViewType targetEvalWeights = projStruct->getTargetEvalWeights(edgeDim, ie);
-    scalarViewType basisEvalWeights = projStruct->getBasisEvalWeights(edgeDim, ie);
+    ScalarViewType targetEvalWeights = projStruct->getTargetEvalWeights(edgeDim, ie);
+    ScalarViewType basisEvalWeights = projStruct->getBasisEvalWeights(edgeDim, ie);
 
     //Note: we are not considering the jacobian of the orientation map since it is simply a scalar term for the integrals and it does not affect the projection
     ordinal_type offsetBasis = projStruct->getBasisPointsRange(edgeDim, ie).first;
@@ -306,10 +306,10 @@ ProjectionTools<SpT>::getHCurlBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueTy
         for(ordinal_type d=0; d <dim; ++d)
           tanTargetAtTargetCubPoints(ic,iq) += refEdgeTan(d)*targetAtEvalPoints(ic,offsetTarget+iq,d);
     }
-    scalarViewType edgeMassMat_("edgeMassMat_", numCells, edgeCardinality+1, edgeCardinality+1),
+    ScalarViewType edgeMassMat_("edgeMassMat_", numCells, edgeCardinality+1, edgeCardinality+1),
         edgeRhsMat_("rhsMat_", numCells, edgeCardinality+1);
 
-    scalarViewType cubWeights_("cubWeights_", numCells, 1, basisEvalWeights.extent(0)), targetEvalWeights_("targetEvalWeights", numCells, 1, targetEvalWeights.extent(0));
+    ScalarViewType cubWeights_("cubWeights_", numCells, 1, basisEvalWeights.extent(0)), targetEvalWeights_("targetEvalWeights", numCells, 1, targetEvalWeights.extent(0));
     RealSpaceTools<SpT>::clone(cubWeights_, basisEvalWeights);
     RealSpaceTools<SpT>::clone(targetEvalWeights_, targetEvalWeights);
 
@@ -362,7 +362,7 @@ ProjectionTools<SpT>::getHCurlBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueTy
 
   }
 
-  scalarViewType ortJacobian("ortJacobian", faceDim, faceDim);
+  ScalarViewType ortJacobian("ortJacobian", faceDim, faceDim);
 
   Basis<host_space_type,scalarType,scalarType> *hgradBasis = NULL;
   for(ordinal_type iface=0; iface<numFaces; ++iface) {
@@ -386,12 +386,12 @@ ProjectionTools<SpT>::getHCurlBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueTy
     ordinal_type numTargetCurlCubPoints = projStruct->getNumTargetDerivEvalPoints(faceDim, iface);
     ordinal_type numCubPoints = projStruct->getNumBasisEvalPoints(faceDim, iface);
 
-    scalarViewType hgradBasisGradAtCubPoints("hgradBasisGradAtCubPoints",hgradBasis->getCardinality(), numCubPoints, faceDim);
-    scalarViewType hgradBasisGradAtTargetCubPoints("hgradBasisGradAtTargetCubPoints",hgradBasis->getCardinality(), numTargetCubPoints, faceDim);
+    ScalarViewType hgradBasisGradAtCubPoints("hgradBasisGradAtCubPoints",hgradBasis->getCardinality(), numCubPoints, faceDim);
+    ScalarViewType hgradBasisGradAtTargetCubPoints("hgradBasisGradAtTargetCubPoints",hgradBasis->getCardinality(), numTargetCubPoints, faceDim);
 
     ordinal_type internalHgradCardinality = hgradBasis->getDofCount(faceDim,0);
-    scalarViewType internalHgradBasisGradAtCubPoints("internalHgradBasisGradAtCubPoints",1, internalHgradCardinality, numCubPoints, faceDim);
-    scalarViewType internalHgradBasisGradAtTargetCubPoints("internalHgradBasisGradAtTargetCubPoints",1, internalHgradCardinality, numTargetCubPoints, faceDim);
+    ScalarViewType internalHgradBasisGradAtCubPoints("internalHgradBasisGradAtCubPoints",1, internalHgradCardinality, numCubPoints, faceDim);
+    ScalarViewType internalHgradBasisGradAtTargetCubPoints("internalHgradBasisGradAtTargetCubPoints",1, internalHgradCardinality, numTargetCubPoints, faceDim);
 
 
     CellTools<SpT>::getReferenceFaceNormal(refFaceNormal, iface, cellTopo);
@@ -410,25 +410,25 @@ ProjectionTools<SpT>::getHCurlBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueTy
       }
     }
 
-    scalarViewType tanBasisAtElemCubPoints("tanBasisAtElemCubPoints",numCells,numFaceDofs, numCubPoints,dim-1);
-    scalarViewType tanBasisAtTargetCubPoints("tanBasisAtTargetCubPoints",numCells,numFaceDofs, numTargetCubPoints,dim-1);
-    scalarViewType normalBasisCurlAtElemCubPoints("normaBasisCurlAtElemCubPoints",numCells,numFaceDofs, numCubPoints);
-    scalarViewType wNormalBasisCurlAtElemCubPoints("weightedNormalBasisCurlAtElemCubPoints",numCells,numFaceDofs, numCubPoints);
+    ScalarViewType tanBasisAtElemCubPoints("tanBasisAtElemCubPoints",numCells,numFaceDofs, numCubPoints,dim-1);
+    ScalarViewType tanBasisAtTargetCubPoints("tanBasisAtTargetCubPoints",numCells,numFaceDofs, numTargetCubPoints,dim-1);
+    ScalarViewType normalBasisCurlAtElemCubPoints("normaBasisCurlAtElemCubPoints",numCells,numFaceDofs, numCubPoints);
+    ScalarViewType wNormalBasisCurlAtElemCubPoints("weightedNormalBasisCurlAtElemCubPoints",numCells,numFaceDofs, numCubPoints);
 
-    scalarViewType tanTargetAtTargetCubPoints("tanTargetAtTargetCubPoints",numCells, numTargetCubPoints, dim-1);
-    scalarViewType normalTargetCurlAtTargetCubPoints("normalTargetCurlAtTargetCubPoints",numCells, numTargetCurlCubPoints);
-    scalarViewType normalBasisCurlAtTargetCurlCubPoints("normalBasisCurlAtTargetCurlCubPoints",numCells,numFaceDofs, numTargetCurlCubPoints);
-    scalarViewType wNormalBasisCurlBasisAtTargetCurlCubPoints("weightedNormalBasisCurlAtTargetCurlCubPoints",numCells,numFaceDofs, numTargetCurlCubPoints);
+    ScalarViewType tanTargetAtTargetCubPoints("tanTargetAtTargetCubPoints",numCells, numTargetCubPoints, dim-1);
+    ScalarViewType normalTargetCurlAtTargetCubPoints("normalTargetCurlAtTargetCubPoints",numCells, numTargetCurlCubPoints);
+    ScalarViewType normalBasisCurlAtTargetCurlCubPoints("normalBasisCurlAtTargetCurlCubPoints",numCells,numFaceDofs, numTargetCurlCubPoints);
+    ScalarViewType wNormalBasisCurlBasisAtTargetCurlCubPoints("weightedNormalBasisCurlAtTargetCurlCubPoints",numCells,numFaceDofs, numTargetCurlCubPoints);
 
-    scalarViewType wHgradBasisGradAtCubPoints("wHgradBasisGradAtCubPoints",1, internalHgradCardinality, numCubPoints, faceDim);
-    scalarViewType wHgradBasisGradAtCubPoints_("wHgradBasisGradAtCubPoints_",numCells, internalHgradCardinality, numCubPoints, faceDim);
-    scalarViewType wHgradBasisGradAtTargetCubPoints("wHgradBasisGradAtTargetCubPoints",1, internalHgradCardinality, numTargetCubPoints, faceDim);
-    scalarViewType wHgradBasisGradAtTargetCubPoints_("wHgradBasisGradAtTargetCubPoints_",numCells, internalHgradCardinality, numTargetCubPoints, faceDim);
+    ScalarViewType wHgradBasisGradAtCubPoints("wHgradBasisGradAtCubPoints",1, internalHgradCardinality, numCubPoints, faceDim);
+    ScalarViewType wHgradBasisGradAtCubPoints_("wHgradBasisGradAtCubPoints_",numCells, internalHgradCardinality, numCubPoints, faceDim);
+    ScalarViewType wHgradBasisGradAtTargetCubPoints("wHgradBasisGradAtTargetCubPoints",1, internalHgradCardinality, numTargetCubPoints, faceDim);
+    ScalarViewType wHgradBasisGradAtTargetCubPoints_("wHgradBasisGradAtTargetCubPoints_",numCells, internalHgradCardinality, numTargetCubPoints, faceDim);
 
-    scalarViewType mNormalComputedProjectionCurl("mNormalComputedProjection", numCells,numCubPoints);
-    scalarViewType mTanComputedProjection("mTanComputedProjection", numCells,numCubPoints,dim-1);
+    ScalarViewType mNormalComputedProjectionCurl("mNormalComputedProjection", numCells,numCubPoints);
+    ScalarViewType mTanComputedProjection("mTanComputedProjection", numCells,numCubPoints,dim-1);
 
-    scalarViewType targetDerivEvalWeights = projStruct->getTargetDerivEvalWeights(faceDim, iface);
+    ScalarViewType targetDerivEvalWeights = projStruct->getTargetDerivEvalWeights(faceDim, iface);
     ordinal_type offsetBasis = projStruct->getBasisPointsRange(faceDim, iface).first;
     ordinal_type offsetBasisCurl = projStruct->getBasisDerivPointsRange(faceDim, iface).first;
     ordinal_type offsetTarget = projStruct->getTargetPointsRange(faceDim, iface).first;
@@ -479,12 +479,12 @@ ProjectionTools<SpT>::getHCurlBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueTy
           normalTargetCurlAtTargetCubPoints(ic,iq) += refFaceNormal(d)*targetCurlAtCurlEvalPoints(ic,offsetTargetCurl+iq,d);
     }
 
-    scalarViewType faceMassMat_("faceMassMat_", numCells, numFaceDofs+internalHgradCardinality, numFaceDofs+internalHgradCardinality),
+    ScalarViewType faceMassMat_("faceMassMat_", numCells, numFaceDofs+internalHgradCardinality, numFaceDofs+internalHgradCardinality),
         faceRhsMat_("rhsMat_", numCells, numFaceDofs+internalHgradCardinality);
 
-    scalarViewType targetCubWeights_("targetCubWeights_", 1, projStruct->getNumTargetEvalPoints(faceDim, iface));
+    ScalarViewType targetCubWeights_("targetCubWeights_", 1, projStruct->getNumTargetEvalPoints(faceDim, iface));
     RealSpaceTools<SpT>::clone(targetCubWeights_, projStruct->getTargetEvalWeights(faceDim, iface));
-    scalarViewType cubWeights_("cubWeights_", numCells, 1, numCubPoints);
+    ScalarViewType cubWeights_("cubWeights_", numCells, 1, numCubPoints);
     RealSpaceTools<SpT>::clone(cubWeights_, projStruct->getBasisEvalWeights(faceDim, iface));
     ArrayTools<SpT>::scalarMultiplyDataField( wNormalBasisCurlAtElemCubPoints, Kokkos::subview(cubWeights_, Kokkos::ALL(),0, Kokkos::ALL()),normalBasisCurlAtElemCubPoints, false);
     ArrayTools<SpT>::scalarMultiplyDataField( wHgradBasisGradAtCubPoints, Kokkos::subview(cubWeights_, 0, Kokkos::ALL(), Kokkos::ALL()),internalHgradBasisGradAtCubPoints, false);
@@ -576,17 +576,17 @@ ProjectionTools<SpT>::getHCurlBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueTy
     ordinal_type numCubPoints = projStruct->getNumBasisEvalPoints(dim,0);
     ordinal_type numTargetCubPoints = projStruct->getNumTargetEvalPoints(dim,0);
 
-    scalarViewType hgradBasisGradAtCubPoints("hgradBasisGradAtCubPoints",hgradBasis->getCardinality(), numCubPoints, dim);
-    scalarViewType hgradBasisGradAtTargetCubPoints("hgradBasisGradAtTargetCubPoints",hgradBasis->getCardinality(), numTargetCubPoints, dim);
+    ScalarViewType hgradBasisGradAtCubPoints("hgradBasisGradAtCubPoints",hgradBasis->getCardinality(), numCubPoints, dim);
+    ScalarViewType hgradBasisGradAtTargetCubPoints("hgradBasisGradAtTargetCubPoints",hgradBasis->getCardinality(), numTargetCubPoints, dim);
 
     ordinal_type internalHgradCardinality = hgradBasis->getDofCount(dim,0);
-    scalarViewType internalHgradBasisGradAtCubPoints("internalHgradBasisGradAtCubPoints",1, internalHgradCardinality, numCubPoints, dim);
-    scalarViewType internalHgradBasisGradAtTargetCubPoints("internalHgradBasisGradAtTargetCubPoints",numCells, internalHgradCardinality, numTargetCubPoints, dim);
-    scalarViewType wHgradBasisGradAtTargetCubPoints("wHgradBasisGradAtTargetCubPoints",numCells, internalHgradCardinality, numTargetCubPoints, dim);
-    scalarViewType wHgradBasisGradAtCubPoints("wHgradBasisGradAtCubPoints",numCells, internalHgradCardinality, numCubPoints, dim);
+    ScalarViewType internalHgradBasisGradAtCubPoints("internalHgradBasisGradAtCubPoints",1, internalHgradCardinality, numCubPoints, dim);
+    ScalarViewType internalHgradBasisGradAtTargetCubPoints("internalHgradBasisGradAtTargetCubPoints",numCells, internalHgradCardinality, numTargetCubPoints, dim);
+    ScalarViewType wHgradBasisGradAtTargetCubPoints("wHgradBasisGradAtTargetCubPoints",numCells, internalHgradCardinality, numTargetCubPoints, dim);
+    ScalarViewType wHgradBasisGradAtCubPoints("wHgradBasisGradAtCubPoints",numCells, internalHgradCardinality, numCubPoints, dim);
 
-    scalarViewType targetEvalWeights = projStruct->getTargetEvalWeights(dim, 0);
-    scalarViewType basisEvalWeights = projStruct->getBasisEvalWeights(dim, 0);
+    ScalarViewType targetEvalWeights = projStruct->getTargetEvalWeights(dim, 0);
+    ScalarViewType basisEvalWeights = projStruct->getBasisEvalWeights(dim, 0);
 
     hgradBasis->getValues(hgradBasisGradAtCubPoints,projStruct->getBasisEvalPoints(dim, 0), OPERATOR_GRAD);
     hgradBasis->getValues(hgradBasisGradAtTargetCubPoints,projStruct->getTargetEvalPoints(dim, 0),OPERATOR_GRAD);
@@ -607,14 +607,14 @@ ProjectionTools<SpT>::getHCurlBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueTy
       }
     }
 
-    scalarViewType internalBasisAtElemcubPoints("basisElemAtcubPoints",numCells,numElemDofs, numCubPoints, dim);
-    scalarViewType internalBasisCurlAtElemcubPoints("internalBasisCurlAtElemcubPoints",numCells,numElemDofs, numCubPoints, derDim);
-    scalarViewType internalBasisCurlAtTargetCurlCubPoints("weightedBasisCurlAtElemCubPoints",numCells,numElemDofs, numTargetCurlCubPoints,derDim);
-    scalarViewType mComputedProjectionCurl("mComputedProjectionCurl", numCells, numCubPoints, derDim);
-    scalarViewType mComputedProjection("mComputedProjection", numCells, numCubPoints, dim);
-    scalarViewType wBasisCurlAtElemCubPoints("weightedBasisCurlAtElemCubPoints",numCells,numElemDofs, numCubPoints,derDim);
-    scalarViewType wBasisCurlBasisAtTargetCurlCubPoints("weightedBasisCurlAtTargetCurlCubPoints",numCells,numElemDofs, numTargetCurlCubPoints,derDim);
-    scalarViewType targetDerivEvalWeights = projStruct->getTargetDerivEvalWeights(dim, 0);
+    ScalarViewType internalBasisAtElemcubPoints("basisElemAtcubPoints",numCells,numElemDofs, numCubPoints, dim);
+    ScalarViewType internalBasisCurlAtElemcubPoints("internalBasisCurlAtElemcubPoints",numCells,numElemDofs, numCubPoints, derDim);
+    ScalarViewType internalBasisCurlAtTargetCurlCubPoints("weightedBasisCurlAtElemCubPoints",numCells,numElemDofs, numTargetCurlCubPoints,derDim);
+    ScalarViewType mComputedProjectionCurl("mComputedProjectionCurl", numCells, numCubPoints, derDim);
+    ScalarViewType mComputedProjection("mComputedProjection", numCells, numCubPoints, dim);
+    ScalarViewType wBasisCurlAtElemCubPoints("weightedBasisCurlAtElemCubPoints",numCells,numElemDofs, numCubPoints,derDim);
+    ScalarViewType wBasisCurlBasisAtTargetCurlCubPoints("weightedBasisCurlAtTargetCurlCubPoints",numCells,numElemDofs, numTargetCurlCubPoints,derDim);
+    ScalarViewType targetDerivEvalWeights = projStruct->getTargetDerivEvalWeights(dim, 0);
     ordinal_type offsetBasis = projStruct->getBasisPointsRange(dim, 0).first;
     ordinal_type offsetBasisCurl = projStruct->getBasisDerivPointsRange(dim, 0).first;
     ordinal_type offsetTargetCurl = projStruct->getTargetDerivPointsRange(dim, 0).first;
@@ -650,7 +650,7 @@ ProjectionTools<SpT>::getHCurlBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueTy
         }
     }
 
-    scalarViewType cellMassMat_("cellMassMat_", numCells, numElemDofs+internalHgradCardinality, numElemDofs+internalHgradCardinality),
+    ScalarViewType cellMassMat_("cellMassMat_", numCells, numElemDofs+internalHgradCardinality, numElemDofs+internalHgradCardinality),
         cellRhsMat_("rhsMat_", numCells, numElemDofs+internalHgradCardinality);
 
     range_type range_H(0, numElemDofs);

--- a/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefHDIV.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefHDIV.hpp
@@ -62,14 +62,14 @@ template<typename SpT>
 template<typename BasisType,
 typename ortValueType,       class ...ortProperties>
 void
-ProjectionTools<SpT>::getHDivEvaluationPoints(typename BasisType::scalarViewType evaluationPoints,
-    typename BasisType::scalarViewType extDerivEvaluationPoints,
+ProjectionTools<SpT>::getHDivEvaluationPoints(typename BasisType::ScalarViewType evaluationPoints,
+    typename BasisType::ScalarViewType extDerivEvaluationPoints,
     const Kokkos::DynRankView<ortValueType,   ortProperties...>  orts,
     const BasisType* cellBasis,
     ProjectionStruct<SpT, typename BasisType::scalarType> * projStruct,
     const EvalPointsType evalPointType){
   typedef typename BasisType::scalarType scalarType;
-  typedef Kokkos::DynRankView<scalarType,SpT> scalarViewType;
+  typedef Kokkos::DynRankView<scalarType,SpT> ScalarViewType;
   typedef Kokkos::pair<ordinal_type,ordinal_type> range_type;
   ordinal_type dim = cellBasis->getBaseCellTopology().getDimension();
   ordinal_type sideDim = dim-1;
@@ -81,7 +81,7 @@ ProjectionTools<SpT>::getHDivEvaluationPoints(typename BasisType::scalarViewType
 
   for(ordinal_type is=0; is<numSides; ++is)  {
     range_type sidePointsRange;
-    scalarViewType sideCubPoints;
+    ScalarViewType sideCubPoints;
     if(evalPointType == TARGET) {
       sidePointsRange = projStruct->getTargetPointsRange(sideDim, is);
       sideCubPoints = projStruct->getTargetEvalPoints(sideDim, is);
@@ -91,7 +91,7 @@ ProjectionTools<SpT>::getHDivEvaluationPoints(typename BasisType::scalarViewType
       sideCubPoints = projStruct->getBasisEvalPoints(sideDim, is);
     }
 
-    scalarViewType orientedTargetCubPoints("orientedTargetCubPoints", sideCubPoints.extent(0),sideDim);
+    ScalarViewType orientedTargetCubPoints("orientedTargetCubPoints", sideCubPoints.extent(0),sideDim);
 
     const auto topoKey = projStruct->getTopologyKey(sideDim,is);
 
@@ -110,7 +110,7 @@ ProjectionTools<SpT>::getHDivEvaluationPoints(typename BasisType::scalarViewType
     return;
 
   range_type cellDivPointsRange;
-  scalarViewType divCubPoints;
+  ScalarViewType divCubPoints;
   if(evalPointType == TARGET) {
     divCubPoints = projStruct->getTargetDerivEvalPoints(dim, 0);
     cellDivPointsRange = projStruct->getTargetDerivPointsRange(dim, 0);
@@ -123,7 +123,7 @@ ProjectionTools<SpT>::getHDivEvaluationPoints(typename BasisType::scalarViewType
   if(projStruct->getTargetEvalPoints(dim, 0).data() != NULL)
   {
     range_type cellPointsRange;
-    scalarViewType cubPoints;
+    ScalarViewType cubPoints;
     if(evalPointType == TARGET) {
       cubPoints = projStruct->getTargetEvalPoints(dim, 0);
       cellPointsRange = projStruct->getTargetPointsRange(dim, 0);
@@ -145,14 +145,14 @@ void
 ProjectionTools<SpT>::getHDivBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueType,basisCoeffsProperties...> basisCoeffs,
     const Kokkos::DynRankView<funValsValueType,funValsProperties...> targetAtEvalPoints,
     const Kokkos::DynRankView<funValsValueType,funValsProperties...> targetDivAtDivEvalPoints,
-    const typename BasisType::scalarViewType evaluationPoints,
-    const typename BasisType::scalarViewType extDerivEvaluationPoints,
+    const typename BasisType::ScalarViewType evaluationPoints,
+    const typename BasisType::ScalarViewType extDerivEvaluationPoints,
     const Kokkos::DynRankView<ortValueType,   ortProperties...>  orts,
     const BasisType* cellBasis,
     ProjectionStruct<SpT, typename BasisType::scalarType> * projStruct){
   typedef typename Kokkos::Impl::is_space<SpT>::host_mirror_space::execution_space host_space_type;
   typedef typename BasisType::scalarType scalarType;
-  typedef Kokkos::DynRankView<scalarType,SpT> scalarViewType;
+  typedef Kokkos::DynRankView<scalarType,SpT> ScalarViewType;
   typedef Kokkos::pair<ordinal_type,ordinal_type> range_type;
   const auto cellTopo = cellBasis->getBaseCellTopology();
   ordinal_type dim = cellTopo.getDimension();
@@ -165,7 +165,7 @@ ProjectionTools<SpT>::getHDivBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueTyp
   const std::string& name = cellBasis->getName();
 
   ordinal_type numSides = cellBasis->getBaseCellTopology().getSideCount();
-  scalarViewType refSideNormal("refSideNormal", dim);
+  ScalarViewType refSideNormal("refSideNormal", dim);
 
   ordinal_type numSideDofs(0);
   for(ordinal_type is=0; is<numSides; ++is)
@@ -176,15 +176,15 @@ ProjectionTools<SpT>::getHDivBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueTyp
   ordinal_type computedDofsCount = 0;
 
   ordinal_type numTotalCubPoints = projStruct->getNumBasisEvalPoints(), numTotalDivCubPoints = projStruct->getNumBasisDerivEvalPoints();
-  scalarViewType cubPoints_("cubPoints",numCells,numTotalCubPoints, dim);
-  scalarViewType divCubPoints("divCubPoints",numCells,numTotalDivCubPoints, dim);
+  ScalarViewType cubPoints_("cubPoints",numCells,numTotalCubPoints, dim);
+  ScalarViewType divCubPoints("divCubPoints",numCells,numTotalDivCubPoints, dim);
   getHDivEvaluationPoints(cubPoints_, divCubPoints, orts, cellBasis, projStruct, BASIS);
 
-  scalarViewType basisAtCubPoints("basisAtCubPoints",numCells,basisCardinality, numTotalCubPoints, dim);
-  scalarViewType basisAtTargetCubPoints("basisAtTargetCubPoints",numCells,basisCardinality, numTotalEvaluationPoints, dim);
+  ScalarViewType basisAtCubPoints("basisAtCubPoints",numCells,basisCardinality, numTotalCubPoints, dim);
+  ScalarViewType basisAtTargetCubPoints("basisAtTargetCubPoints",numCells,basisCardinality, numTotalEvaluationPoints, dim);
   {
-    scalarViewType nonOrientedBasisAtCubPoints("nonOrientedBasisAtCubPoints",numCells,basisCardinality, numTotalCubPoints, dim);
-    scalarViewType nonOrientedBasisAtTargetCubPoints("nonOrientedBasisAtTargetCubPoints",numCells,basisCardinality, numTotalEvaluationPoints, dim);
+    ScalarViewType nonOrientedBasisAtCubPoints("nonOrientedBasisAtCubPoints",numCells,basisCardinality, numTotalCubPoints, dim);
+    ScalarViewType nonOrientedBasisAtTargetCubPoints("nonOrientedBasisAtTargetCubPoints",numCells,basisCardinality, numTotalEvaluationPoints, dim);
     for(ordinal_type ic=0; ic<numCells; ++ic) {
       cellBasis->getValues(Kokkos::subview(nonOrientedBasisAtTargetCubPoints,ic,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()));
       cellBasis->getValues(Kokkos::subview(nonOrientedBasisAtCubPoints,ic,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL()), Kokkos::subview(cubPoints_, ic, Kokkos::ALL(), Kokkos::ALL()));
@@ -194,14 +194,14 @@ ProjectionTools<SpT>::getHDivBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueTyp
     OrientationTools<SpT>::modifyBasisByOrientation(basisAtTargetCubPoints, nonOrientedBasisAtTargetCubPoints, orts, cellBasis);
   }
 
-  scalarViewType basisDivAtDivCubPoints;
-  scalarViewType basisDivAtTargetDivCubPoints;
+  ScalarViewType basisDivAtDivCubPoints;
+  ScalarViewType basisDivAtTargetDivCubPoints;
   if(numTotalDivEvaluationPoints>0) {
-    scalarViewType nonOrientedBasisDivAtTargetDivCubPoints, nonOrientedBasisDivAtDivCubPoints;
-    basisDivAtDivCubPoints = scalarViewType ("basisDivAtDivCubPoints",numCells,basisCardinality, numTotalDivCubPoints);
-    nonOrientedBasisDivAtDivCubPoints = scalarViewType ("nonOrientedBasisDivAtDivCubPoints",numCells,basisCardinality, numTotalDivCubPoints);
-    basisDivAtTargetDivCubPoints = scalarViewType("basisDivAtTargetDivCubPoints",numCells,basisCardinality, numTotalDivEvaluationPoints);
-    nonOrientedBasisDivAtTargetDivCubPoints = scalarViewType("nonOrientedBasisDivAtTargetDivCubPoints",numCells,basisCardinality, numTotalDivEvaluationPoints);
+    ScalarViewType nonOrientedBasisDivAtTargetDivCubPoints, nonOrientedBasisDivAtDivCubPoints;
+    basisDivAtDivCubPoints = ScalarViewType ("basisDivAtDivCubPoints",numCells,basisCardinality, numTotalDivCubPoints);
+    nonOrientedBasisDivAtDivCubPoints = ScalarViewType ("nonOrientedBasisDivAtDivCubPoints",numCells,basisCardinality, numTotalDivCubPoints);
+    basisDivAtTargetDivCubPoints = ScalarViewType("basisDivAtTargetDivCubPoints",numCells,basisCardinality, numTotalDivEvaluationPoints);
+    nonOrientedBasisDivAtTargetDivCubPoints = ScalarViewType("nonOrientedBasisDivAtTargetDivCubPoints",numCells,basisCardinality, numTotalDivEvaluationPoints);
 
     for(ordinal_type ic=0; ic<numCells; ++ic) {
       cellBasis->getValues(Kokkos::subview(nonOrientedBasisDivAtDivCubPoints,ic,Kokkos::ALL(),Kokkos::ALL()), Kokkos::subview(divCubPoints, ic, Kokkos::ALL(), Kokkos::ALL()),OPERATOR_DIV);
@@ -223,14 +223,14 @@ ProjectionTools<SpT>::getHDivBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueTyp
 
     CellTools<SpT>::getReferenceSideNormal(refSideNormal, is, cellBasis->getBaseCellTopology());
 
-    scalarViewType normalBasisAtElemcubPoints("normalBasisAtElemcubPoints",numCells,sideCardinality, numCubPoints);
-    scalarViewType normalBasisAtTargetcubPoints("normalBasisAtTargetcubPoints",numCells,sideCardinality, numTargetCubPoints);
-    scalarViewType weightedNormalBasisAtElemcubPoints("weightedNormalBasisAtElemcubPoints",numCells,sideCardinality, numCubPoints);
-    scalarViewType weightedNormalBasisAtTargetcubPoints("weightedNormalBasisAtTargetcubPoints",numCells,sideCardinality, numTargetCubPoints);
-    scalarViewType normalTargetAtTargetcubPoints("normalTargetAtTargetcubPoints",numCells, numTargetCubPoints);
+    ScalarViewType normalBasisAtElemcubPoints("normalBasisAtElemcubPoints",numCells,sideCardinality, numCubPoints);
+    ScalarViewType normalBasisAtTargetcubPoints("normalBasisAtTargetcubPoints",numCells,sideCardinality, numTargetCubPoints);
+    ScalarViewType weightedNormalBasisAtElemcubPoints("weightedNormalBasisAtElemcubPoints",numCells,sideCardinality, numCubPoints);
+    ScalarViewType weightedNormalBasisAtTargetcubPoints("weightedNormalBasisAtTargetcubPoints",numCells,sideCardinality, numTargetCubPoints);
+    ScalarViewType normalTargetAtTargetcubPoints("normalTargetAtTargetcubPoints",numCells, numTargetCubPoints);
 
-    scalarViewType targetEvalWeights = projStruct->getTargetEvalWeights(sideDim, is);
-    scalarViewType basisEvalWeights = projStruct->getBasisEvalWeights(sideDim, is);
+    ScalarViewType targetEvalWeights = projStruct->getTargetEvalWeights(sideDim, is);
+    ScalarViewType basisEvalWeights = projStruct->getBasisEvalWeights(sideDim, is);
 
     //Note: we are not considering the jacobian of the orientation map since it is simply a scalar term for the integrals and it does not affect the projection
     ordinal_type offsetBasis = projStruct->getBasisPointsRange(sideDim, is).first;
@@ -255,15 +255,15 @@ ProjectionTools<SpT>::getHDivBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueTyp
     }
 
 
-    scalarViewType sideMassMat_("sideMassMat_", numCells, sideCardinality+1, sideCardinality+1),
+    ScalarViewType sideMassMat_("sideMassMat_", numCells, sideCardinality+1, sideCardinality+1),
         sideRhsMat_("rhsMat_", numCells, sideCardinality+1);
 
-    scalarViewType targetEvalWeights_("targetEvalWeights", numCells, 1, targetEvalWeights.extent(0));
+    ScalarViewType targetEvalWeights_("targetEvalWeights", numCells, 1, targetEvalWeights.extent(0));
     RealSpaceTools<SpT>::clone(targetEvalWeights_, targetEvalWeights);
 
     range_type range_H(0, sideCardinality);
     range_type range_B(sideCardinality, sideCardinality+1);
-    scalarViewType ones("ones",numCells,1,numCubPoints);
+    ScalarViewType ones("ones",numCells,1,numCubPoints);
     Kokkos::deep_copy(ones,1);
 
     FunctionSpaceTools<SpT >::integrate(Kokkos::subview(sideMassMat_, Kokkos::ALL(), range_H, range_H), normalBasisAtElemcubPoints, weightedNormalBasisAtElemcubPoints);
@@ -342,13 +342,13 @@ ProjectionTools<SpT>::getHDivBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueTyp
   ordinal_type numTargetDivCubPoints = projStruct->getNumTargetDerivEvalPoints(dim,0);
   ordinal_type numDivCubPoints = projStruct->getNumBasisDerivEvalPoints(dim,0);
 
-  scalarViewType weightedBasisDivAtcubPoints("weightedBasisDivAtcubPoints",numCells,numElemDofs, numDivCubPoints);
-  scalarViewType weightedBasisDivAtcubTargetPoints("weightedBasisDivAtcubTargetPoints",numCells, numElemDofs, numTargetDivCubPoints);
+  ScalarViewType weightedBasisDivAtcubPoints("weightedBasisDivAtcubPoints",numCells,numElemDofs, numDivCubPoints);
+  ScalarViewType weightedBasisDivAtcubTargetPoints("weightedBasisDivAtcubTargetPoints",numCells, numElemDofs, numTargetDivCubPoints);
 
-  scalarViewType internalBasisDivAtcubPoints("basisDivAtcubPoints",numCells,numElemDofs, numDivCubPoints);
+  ScalarViewType internalBasisDivAtcubPoints("basisDivAtcubPoints",numCells,numElemDofs, numDivCubPoints);
 
-  scalarViewType targetDivEvalWeights = projStruct->getTargetDerivEvalWeights(dim, 0);
-  scalarViewType divEvalWeights = projStruct->getBasisDerivEvalWeights(dim, 0);
+  ScalarViewType targetDivEvalWeights = projStruct->getTargetDerivEvalWeights(dim, 0);
+  ScalarViewType divEvalWeights = projStruct->getBasisDerivEvalWeights(dim, 0);
   ordinal_type offsetBasisDiv = projStruct->getBasisDerivPointsRange(dim, 0).first;
   ordinal_type offsetTargetDiv = projStruct->getTargetDerivPointsRange(dim, 0).first;
 
@@ -376,7 +376,7 @@ ProjectionTools<SpT>::getHDivBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueTyp
   Kokkos::DynRankView<funValsValueType,Kokkos::LayoutLeft,host_space_type> massMat_("massMat_",numCells,numElemDofs+numCurlInteriorDOFs,numElemDofs+numCurlInteriorDOFs);
   Kokkos::DynRankView<funValsValueType,Kokkos::LayoutLeft,host_space_type> rhsMatTrans("rhsMatTrans",numCells,numElemDofs+numCurlInteriorDOFs);
 
-  scalarViewType targetSideDivAtcubPoints("targetSideDivAtcubPoints",numCells, numDivCubPoints);
+  ScalarViewType targetSideDivAtcubPoints("targetSideDivAtcubPoints",numCells, numDivCubPoints);
   for(ordinal_type i=0; i<numSideDofs; ++i) {
     ordinal_type idof = computedDofs(i);
     for(ordinal_type ic=0; ic<numCells; ++ic)
@@ -390,26 +390,26 @@ ProjectionTools<SpT>::getHDivBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueTyp
   FunctionSpaceTools<SpT >::integrate(Kokkos::subview(rhsMatTrans, Kokkos::ALL(), range_H), targetSideDivAtcubPoints, weightedBasisDivAtcubPoints,true);
 
   if(numCurlInteriorDOFs>0){
-    scalarViewType cubPoints = projStruct->getBasisEvalPoints(dim,0);
+    ScalarViewType cubPoints = projStruct->getBasisEvalPoints(dim,0);
     ordinal_type numCubPoints = projStruct->getNumBasisEvalPoints(dim,0);
     ordinal_type numTargetCubPoints = projStruct->getNumTargetEvalPoints(dim,0);
 
-    scalarViewType targetSideApproxAtcubPoints("targetSideAtcubPoints",numCells, numCubPoints, dim);
-    scalarViewType internalBasisAtcubPoints("basisAtcubPoints",numCells,numElemDofs, numCubPoints, dim);
-    scalarViewType hcurlBasisCurlAtcubPoints("hcurlBasisCurlAtcubPoints",hcurlBasisCardinality, numCubPoints,dim);
-    scalarViewType internalHcurlBasisCurlAtcubPoints("internalHcurlBasisCurlAtcubPoints",numCells,numCurlInteriorDOFs, numCubPoints,dim);
-    scalarViewType hcurlBasisCurlAtcubTargetPoints("hcurlBasisCurlAtcubTargetPoints", hcurlBasisCardinality,numTargetCubPoints, dim);
-    scalarViewType internalHcurlBasisCurlAtcubTargetPoints("internalHcurlBasisCurlAtcubTargetPoints",numCells, numCurlInteriorDOFs, numTargetCubPoints, dim);
-    scalarViewType weightedHcurlBasisCurlAtcubPoints("weightedHcurlBasisHcurlAtcubPoints", numCells, numCurlInteriorDOFs, numCubPoints,dim);
-    scalarViewType weightedHcurlBasisCurlAtcubTargetPoints("weightedHcurlBasisHcurlAtcubTargetPoints",numCells, numCurlInteriorDOFs, numTargetCubPoints,dim);
+    ScalarViewType targetSideApproxAtcubPoints("targetSideAtcubPoints",numCells, numCubPoints, dim);
+    ScalarViewType internalBasisAtcubPoints("basisAtcubPoints",numCells,numElemDofs, numCubPoints, dim);
+    ScalarViewType hcurlBasisCurlAtcubPoints("hcurlBasisCurlAtcubPoints",hcurlBasisCardinality, numCubPoints,dim);
+    ScalarViewType internalHcurlBasisCurlAtcubPoints("internalHcurlBasisCurlAtcubPoints",numCells,numCurlInteriorDOFs, numCubPoints,dim);
+    ScalarViewType hcurlBasisCurlAtcubTargetPoints("hcurlBasisCurlAtcubTargetPoints", hcurlBasisCardinality,numTargetCubPoints, dim);
+    ScalarViewType internalHcurlBasisCurlAtcubTargetPoints("internalHcurlBasisCurlAtcubTargetPoints",numCells, numCurlInteriorDOFs, numTargetCubPoints, dim);
+    ScalarViewType weightedHcurlBasisCurlAtcubPoints("weightedHcurlBasisHcurlAtcubPoints", numCells, numCurlInteriorDOFs, numCubPoints,dim);
+    ScalarViewType weightedHcurlBasisCurlAtcubTargetPoints("weightedHcurlBasisHcurlAtcubTargetPoints",numCells, numCurlInteriorDOFs, numTargetCubPoints,dim);
 
     hcurlBasis->getValues(hcurlBasisCurlAtcubPoints, cubPoints, OPERATOR_CURL);
 
     ordinal_type offsetBasis = projStruct->getBasisPointsRange(dim, 0).first;
     range_type targetPointsRange = projStruct->getTargetPointsRange(dim, 0);
 
-    scalarViewType targetEvalWeights = projStruct->getTargetEvalWeights(dim, 0);
-    scalarViewType basisEvalWeights = projStruct->getBasisEvalWeights(dim, 0);
+    ScalarViewType targetEvalWeights = projStruct->getTargetEvalWeights(dim, 0);
+    ScalarViewType basisEvalWeights = projStruct->getBasisEvalWeights(dim, 0);
 
 
     for(ordinal_type ic=0; ic<numCells; ++ic) {

--- a/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefHGRAD.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefHGRAD.hpp
@@ -61,14 +61,14 @@ template<typename SpT>
 template<typename BasisType,
 typename ortValueType,       class ...ortProperties>
 void
-ProjectionTools<SpT>::getHGradEvaluationPoints(typename BasisType::scalarViewType evaluationPoints,
-    typename BasisType::scalarViewType extDerivEvaluationPoints,
+ProjectionTools<SpT>::getHGradEvaluationPoints(typename BasisType::ScalarViewType evaluationPoints,
+    typename BasisType::ScalarViewType extDerivEvaluationPoints,
     const Kokkos::DynRankView<ortValueType,   ortProperties...>  orts,
     const BasisType* cellBasis,
     ProjectionStruct<SpT, typename BasisType::scalarType> * projStruct,
     const EvalPointsType evalPointType) {
   typedef typename BasisType::scalarType scalarType;
-  typedef Kokkos::DynRankView<scalarType,SpT> scalarViewType;
+  typedef Kokkos::DynRankView<scalarType,SpT> ScalarViewType;
   typedef Kokkos::pair<ordinal_type,ordinal_type> range_type;
   const auto cellTopo = cellBasis->getBaseCellTopology();
   ordinal_type dim = cellTopo.getDimension();
@@ -84,7 +84,7 @@ ProjectionTools<SpT>::getHGradEvaluationPoints(typename BasisType::scalarViewTyp
 
   if(numVertices>0) {
     //TODO: use lattice to retrieve vertex coordinates.
-    scalarViewType dofCoords("dofCoords", cellBasis->getCardinality(), dim);
+    ScalarViewType dofCoords("dofCoords", cellBasis->getCardinality(), dim);
     cellBasis->getDofCoords(dofCoords);
     for(ordinal_type iv=0; iv<numVertices; ++iv) {
       ordinal_type idof = cellBasis->getDofOrdinal(0, iv, 0);
@@ -96,7 +96,7 @@ ProjectionTools<SpT>::getHGradEvaluationPoints(typename BasisType::scalarViewTyp
 
   for(ordinal_type ie=0; ie<numEdges; ++ie) {
     range_type edgeGradPointsRange;
-    scalarViewType cubPoints;
+    ScalarViewType cubPoints;
     if(evalPointType == TARGET) {
       edgeGradPointsRange = projStruct->getTargetDerivPointsRange(edgeDim, ie);
       cubPoints = projStruct->getTargetDerivEvalPoints(edgeDim, ie);
@@ -106,7 +106,7 @@ ProjectionTools<SpT>::getHGradEvaluationPoints(typename BasisType::scalarViewTyp
       cubPoints = projStruct->getBasisDerivEvalPoints(edgeDim, ie);
     }
 
-    scalarViewType orientedTargetCubPoints("orientedTargetCubPoints", cubPoints.extent(0),edgeDim);
+    ScalarViewType orientedTargetCubPoints("orientedTargetCubPoints", cubPoints.extent(0),edgeDim);
 
     const auto topoKey = projStruct->getTopologyKey(edgeDim,ie);
 
@@ -121,7 +121,7 @@ ProjectionTools<SpT>::getHGradEvaluationPoints(typename BasisType::scalarViewTyp
 
   for(ordinal_type iface=0; iface<numFaces; ++iface) {
 
-    scalarViewType gradCubPoints;
+    ScalarViewType gradCubPoints;
     range_type faceGradPointsRange;
     if(evalPointType == TARGET) {
       gradCubPoints = projStruct->getTargetDerivEvalPoints(faceDim, iface);
@@ -131,7 +131,7 @@ ProjectionTools<SpT>::getHGradEvaluationPoints(typename BasisType::scalarViewTyp
       faceGradPointsRange = projStruct->getBasisDerivPointsRange(faceDim, iface);
     }
 
-    scalarViewType faceGradCubPoints("faceGradCubPoints", gradCubPoints.extent(0), faceDim);
+    ScalarViewType faceGradCubPoints("faceGradCubPoints", gradCubPoints.extent(0), faceDim);
 
     const auto topoKey = projStruct->getTopologyKey(faceDim,iface);
     for(ordinal_type ic=0; ic<numCells; ++ic) {
@@ -146,7 +146,7 @@ ProjectionTools<SpT>::getHGradEvaluationPoints(typename BasisType::scalarViewTyp
 
   if(cellBasis->getDofCount(dim,0)>0) {
     range_type cellGradPointsRange;
-    scalarViewType gradCubPoints;
+    ScalarViewType gradCubPoints;
     if(evalPointType == TARGET) {
       gradCubPoints = projStruct->getTargetDerivEvalPoints(dim, 0);
       cellGradPointsRange = projStruct->getTargetDerivPointsRange(dim, 0);
@@ -168,15 +168,15 @@ void
 ProjectionTools<SpT>::getHGradBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueType,basisCoeffsProperties...> basisCoeffs,
     const Kokkos::DynRankView<funValsValueType,funValsProperties...> targetAtEvalPoints,
     const Kokkos::DynRankView<funValsValueType,funValsProperties...> targetGradAtGradEvalPoints,
-    const typename BasisType::scalarViewType evaluationPoints,
-    const typename BasisType::scalarViewType extDerivEvaluationPoints,
+    const typename BasisType::ScalarViewType evaluationPoints,
+    const typename BasisType::ScalarViewType extDerivEvaluationPoints,
     const Kokkos::DynRankView<ortValueType,   ortProperties...>  orts,
     const BasisType* cellBasis,
     ProjectionStruct<SpT, typename BasisType::scalarType> * projStruct){
 
   typedef typename Kokkos::Impl::is_space<SpT>::host_mirror_space::execution_space host_space_type;
   typedef typename BasisType::scalarType scalarType;
-  typedef Kokkos::DynRankView<scalarType,SpT> scalarViewType;
+  typedef Kokkos::DynRankView<scalarType,SpT> ScalarViewType;
   typedef Kokkos::pair<ordinal_type,ordinal_type> range_type;
   const auto cellTopo = cellBasis->getBaseCellTopology();
   ordinal_type dim = cellTopo.getDimension();
@@ -193,8 +193,8 @@ ProjectionTools<SpT>::getHGradBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueTy
 
   Kokkos::View<ordinal_type*> eOrt("eOrt", numEdges);
   Kokkos::View<ordinal_type*> fOrt("fOrt", numFaces);
-  scalarViewType refEdgeTan("refEdgeTan",  dim);
-  scalarViewType refFaceTangents("refFaceTangents", dim, 2);
+  ScalarViewType refEdgeTan("refEdgeTan",  dim);
+  ScalarViewType refFaceTangents("refFaceTangents", dim, 2);
   auto refFaceTanU = Kokkos::subview(refFaceTangents, Kokkos::ALL, 0);
   auto refFaceTanV = Kokkos::subview(refFaceTangents, Kokkos::ALL, 1);
 
@@ -214,15 +214,15 @@ ProjectionTools<SpT>::getHGradBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueTy
 
   ordinal_type numTotalCubPoints = projStruct->getNumBasisEvalPoints(),
       numTotalGradCubPoints = projStruct->getNumBasisDerivEvalPoints();
-  scalarViewType cubPoints("cubPoints",numCells,numTotalCubPoints, dim);
-  scalarViewType gradCubPoints("gradCubPoints",numCells,numTotalGradCubPoints, dim);
+  ScalarViewType cubPoints("cubPoints",numCells,numTotalCubPoints, dim);
+  ScalarViewType gradCubPoints("gradCubPoints",numCells,numTotalGradCubPoints, dim);
   getHGradEvaluationPoints(cubPoints, gradCubPoints, orts, cellBasis, projStruct, BASIS);
 
-  scalarViewType basisAtCubPoints("basisAtCubPoints",numCells,basisCardinality, numTotalCubPoints);
-  scalarViewType basisAtTargetCubPoints("basisAtTargetCubPoints",numCells,basisCardinality, numTotalEvaluationPoints);
+  ScalarViewType basisAtCubPoints("basisAtCubPoints",numCells,basisCardinality, numTotalCubPoints);
+  ScalarViewType basisAtTargetCubPoints("basisAtTargetCubPoints",numCells,basisCardinality, numTotalEvaluationPoints);
   {
-    scalarViewType nonOrientedBasisAtCubPoints("nonOrientedBasisAtCubPoints",numCells,basisCardinality, numTotalCubPoints);
-    scalarViewType nonOrientedBasisAtTargetCubPoints("nonOrientedBasisAtTargetCubPoints",numCells,basisCardinality, numTotalEvaluationPoints);
+    ScalarViewType nonOrientedBasisAtCubPoints("nonOrientedBasisAtCubPoints",numCells,basisCardinality, numTotalCubPoints);
+    ScalarViewType nonOrientedBasisAtTargetCubPoints("nonOrientedBasisAtTargetCubPoints",numCells,basisCardinality, numTotalEvaluationPoints);
 
     for(ordinal_type ic=0; ic<numCells; ++ic) {
       cellBasis->getValues(Kokkos::subview(nonOrientedBasisAtTargetCubPoints,ic,Kokkos::ALL(),Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()));
@@ -233,15 +233,15 @@ ProjectionTools<SpT>::getHGradBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueTy
     OrientationTools<SpT>::modifyBasisByOrientation(basisAtTargetCubPoints, nonOrientedBasisAtTargetCubPoints, orts, cellBasis);
   }
 
-  scalarViewType basisGradAtGradCubPoints;
-  scalarViewType basisGradAtTargetGradCubPoints;
+  ScalarViewType basisGradAtGradCubPoints;
+  ScalarViewType basisGradAtTargetGradCubPoints;
   if(numTotalGradEvaluationPoints>0) {
-    scalarViewType nonOrientedBasisGradAtTargetGradCubPoints, nonOrientedBasisGradAtGradCubPoints;
+    ScalarViewType nonOrientedBasisGradAtTargetGradCubPoints, nonOrientedBasisGradAtGradCubPoints;
 
-    basisGradAtGradCubPoints = scalarViewType ("basisGradAtGradCubPoints",numCells,basisCardinality, numTotalGradCubPoints, dim);
-    nonOrientedBasisGradAtGradCubPoints = scalarViewType ("nonOrientedBasisGradAtGradCubPoints",numCells,basisCardinality, numTotalGradCubPoints, dim);
-    basisGradAtTargetGradCubPoints = scalarViewType("basisGradAtTargetGradCubPoints",numCells,basisCardinality, numTotalGradEvaluationPoints, dim);
-    nonOrientedBasisGradAtTargetGradCubPoints = scalarViewType("nonOrientedBasisGradAtTargetGradCubPoints",numCells,basisCardinality, numTotalGradEvaluationPoints, dim);
+    basisGradAtGradCubPoints = ScalarViewType ("basisGradAtGradCubPoints",numCells,basisCardinality, numTotalGradCubPoints, dim);
+    nonOrientedBasisGradAtGradCubPoints = ScalarViewType ("nonOrientedBasisGradAtGradCubPoints",numCells,basisCardinality, numTotalGradCubPoints, dim);
+    basisGradAtTargetGradCubPoints = ScalarViewType("basisGradAtTargetGradCubPoints",numCells,basisCardinality, numTotalGradEvaluationPoints, dim);
+    nonOrientedBasisGradAtTargetGradCubPoints = ScalarViewType("nonOrientedBasisGradAtTargetGradCubPoints",numCells,basisCardinality, numTotalGradEvaluationPoints, dim);
 
     for(ordinal_type ic=0; ic<numCells; ++ic) {
       cellBasis->getValues(Kokkos::subview(nonOrientedBasisGradAtGradCubPoints,ic,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL()), Kokkos::subview(gradCubPoints, ic, Kokkos::ALL(), Kokkos::ALL()),OPERATOR_GRAD);
@@ -267,14 +267,14 @@ ProjectionTools<SpT>::getHGradBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueTy
 
     CellTools<SpT>::getReferenceEdgeTangent(refEdgeTan, ie, cellBasis->getBaseCellTopology());
 
-    scalarViewType edgeBasisAtCubPoints("tanBasisAtElemCubPoints",numCells,edgeCardinality, numCubPoints);
-    scalarViewType edgeTargetAtTargetCubPoints("tanBasisAtTargetCubPoints",numCells, numTargetCubPoints);
-    scalarViewType weightedBasisAtElemCubPoints("weightedTanBasisAtElemCubPoints",numCells,edgeCardinality, numCubPoints);
-    scalarViewType weightedBasisAtTargetCubPoints("weightedTanBasisAtTargetCubPoints",numCells,edgeCardinality, numTargetCubPoints);
-    scalarViewType mComputedProjection("mComputedProjection", numCells, numCubPoints);
+    ScalarViewType edgeBasisAtCubPoints("tanBasisAtElemCubPoints",numCells,edgeCardinality, numCubPoints);
+    ScalarViewType edgeTargetAtTargetCubPoints("tanBasisAtTargetCubPoints",numCells, numTargetCubPoints);
+    ScalarViewType weightedBasisAtElemCubPoints("weightedTanBasisAtElemCubPoints",numCells,edgeCardinality, numCubPoints);
+    ScalarViewType weightedBasisAtTargetCubPoints("weightedTanBasisAtTargetCubPoints",numCells,edgeCardinality, numTargetCubPoints);
+    ScalarViewType mComputedProjection("mComputedProjection", numCells, numCubPoints);
 
-    scalarViewType targetEvalWeights = projStruct->getTargetDerivEvalWeights(edgeDim, ie);
-    scalarViewType basisEvalWeights = projStruct->getBasisDerivEvalWeights(edgeDim, ie);
+    ScalarViewType targetEvalWeights = projStruct->getTargetDerivEvalWeights(edgeDim, ie);
+    ScalarViewType basisEvalWeights = projStruct->getBasisDerivEvalWeights(edgeDim, ie);
 
     //Note: we are not considering the jacobian of the orientation map since it is simply a scalar term for the integrals and it does not affect the projection
     ordinal_type offsetBasis = projStruct->getBasisDerivPointsRange(edgeDim, ie).first;
@@ -308,10 +308,10 @@ ProjectionTools<SpT>::getHGradBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueTy
     }
 
 
-    scalarViewType edgeMassMat_("edgeMassMat_", numCells, edgeCardinality, edgeCardinality),
+    ScalarViewType edgeMassMat_("edgeMassMat_", numCells, edgeCardinality, edgeCardinality),
         edgeRhsMat_("rhsMat_", numCells, edgeCardinality);
 
-    scalarViewType cubWeights_("cubWeights_", numCells, 1, basisEvalWeights.extent(0)), targetEvalWeights_("targetEvalWeights", numCells, 1, targetEvalWeights.extent(0));
+    ScalarViewType cubWeights_("cubWeights_", numCells, 1, basisEvalWeights.extent(0)), targetEvalWeights_("targetEvalWeights", numCells, 1, targetEvalWeights.extent(0));
     RealSpaceTools<SpT>::clone(cubWeights_, basisEvalWeights);
     RealSpaceTools<SpT>::clone(targetEvalWeights_, targetEvalWeights);
 
@@ -356,7 +356,7 @@ ProjectionTools<SpT>::getHGradBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueTy
       computedDofs(computedDofsCount++) = cellBasis->getDofOrdinal(edgeDim, ie, i);
   }
 
-  scalarViewType ortJacobian("ortJacobian", faceDim, faceDim);
+  ScalarViewType ortJacobian("ortJacobian", faceDim, faceDim);
 
   for(ordinal_type iface=0; iface<numFaces; ++iface) {
 
@@ -371,19 +371,19 @@ ProjectionTools<SpT>::getHGradBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueTy
 
     CellTools<SpT>::getReferenceFaceTangents(refFaceTanU, refFaceTanV,iface, cellTopo);
 
-    scalarViewType faceBasisGradAtGradCubPoints("normaBasisGradAtGradCubPoints",numCells,faceCardinality, numGradCubPoints,faceDim);
-    scalarViewType wBasisGradAtGradCubPoints("weightedNormalBasisGradAtGradCubPoints",numCells,faceCardinality, numGradCubPoints,faceDim);
+    ScalarViewType faceBasisGradAtGradCubPoints("normaBasisGradAtGradCubPoints",numCells,faceCardinality, numGradCubPoints,faceDim);
+    ScalarViewType wBasisGradAtGradCubPoints("weightedNormalBasisGradAtGradCubPoints",numCells,faceCardinality, numGradCubPoints,faceDim);
 
-    scalarViewType faceBasisGradAtTargetGradCubPoints("normalBasisGradAtTargetGradCubPoints",numCells,faceCardinality, numTargetGradCubPoints,faceDim);
-    scalarViewType wBasisGradBasisAtTargetGradCubPoints("weightedNormalBasisGradAtTargetGradCubPoints",numCells,faceCardinality, numTargetGradCubPoints,faceDim);
+    ScalarViewType faceBasisGradAtTargetGradCubPoints("normalBasisGradAtTargetGradCubPoints",numCells,faceCardinality, numTargetGradCubPoints,faceDim);
+    ScalarViewType wBasisGradBasisAtTargetGradCubPoints("weightedNormalBasisGradAtTargetGradCubPoints",numCells,faceCardinality, numTargetGradCubPoints,faceDim);
 
-    scalarViewType targetGradAtTargetGradCubPoints("targetGradAtTargetGradCubPoints",numCells, numTargetGradCubPoints,faceDim);
-    scalarViewType mComputedProjectionGrad("mNormalComputedProjection", numCells,numGradCubPoints,faceDim);
+    ScalarViewType targetGradAtTargetGradCubPoints("targetGradAtTargetGradCubPoints",numCells, numTargetGradCubPoints,faceDim);
+    ScalarViewType mComputedProjectionGrad("mNormalComputedProjection", numCells,numGradCubPoints,faceDim);
 
     ordinal_type offsetBasisGrad = projStruct->getBasisDerivPointsRange(faceDim, iface).first;
     ordinal_type offsetTargetGrad = projStruct->getTargetDerivPointsRange(faceDim, iface).first;
-    scalarViewType targetGradCubWeights = projStruct->getTargetDerivEvalWeights(faceDim, iface);
-    scalarViewType gradCubWeights = projStruct->getBasisDerivEvalWeights(faceDim, iface);
+    ScalarViewType targetGradCubWeights = projStruct->getTargetDerivEvalWeights(faceDim, iface);
+    ScalarViewType gradCubWeights = projStruct->getBasisDerivEvalWeights(faceDim, iface);
 
     //Note: we are not considering the jacobian of the orientation map since it is simply a scalar term for the integrals and it does not affect the projection
     for(ordinal_type ic=0; ic<numCells; ++ic)  {
@@ -426,7 +426,7 @@ ProjectionTools<SpT>::getHGradBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueTy
       }
     }
 
-    scalarViewType faceMassMat_("faceMassMat_", numCells, faceCardinality, faceCardinality),
+    ScalarViewType faceMassMat_("faceMassMat_", numCells, faceCardinality, faceCardinality),
         faceRhsMat_("rhsMat_", numCells, faceCardinality);
 
     FunctionSpaceTools<SpT >::integrate(faceMassMat_, faceBasisGradAtGradCubPoints, wBasisGradAtGradCubPoints);
@@ -480,18 +480,18 @@ ProjectionTools<SpT>::getHGradBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueTy
     ordinal_type numTargetGradCubPoints = projStruct->getNumTargetDerivEvalPoints(dim,0);
     ordinal_type numGradCubPoints = projStruct->getNumBasisDerivEvalPoints(dim,0);
 
-    scalarViewType internalBasisGradAtGradCubPoints("internalBasisGradAtCubPoints",numCells,numElemDofs, numGradCubPoints, dim);
-    scalarViewType internalBasisGradAtTargetGradCubPoints("weightedBasisGradAtGradCubPoints",numCells,numElemDofs, numTargetGradCubPoints,dim);
-    scalarViewType mComputedProjectionGrad("mComputedProjectionGrad", numCells, numGradCubPoints, dim);
+    ScalarViewType internalBasisGradAtGradCubPoints("internalBasisGradAtCubPoints",numCells,numElemDofs, numGradCubPoints, dim);
+    ScalarViewType internalBasisGradAtTargetGradCubPoints("weightedBasisGradAtGradCubPoints",numCells,numElemDofs, numTargetGradCubPoints,dim);
+    ScalarViewType mComputedProjectionGrad("mComputedProjectionGrad", numCells, numGradCubPoints, dim);
 
-    scalarViewType targetGradCubWeights = projStruct->getTargetDerivEvalWeights(dim, 0);
-    scalarViewType cubGradWeights = projStruct->getBasisDerivEvalWeights(dim, 0);
+    ScalarViewType targetGradCubWeights = projStruct->getTargetDerivEvalWeights(dim, 0);
+    ScalarViewType cubGradWeights = projStruct->getBasisDerivEvalWeights(dim, 0);
     ordinal_type offsetBasisGrad = projStruct->getBasisDerivPointsRange(dim, 0).first;
     ordinal_type offsetTargetGrad = projStruct->getTargetDerivPointsRange(dim, 0).first;
 
 
-    scalarViewType wBasisGradAtGradCubPoints("weightedBasisGradAtGradCubPoints",numCells,numElemDofs, numGradCubPoints,dim);
-    scalarViewType wBasisGradBasisAtTargetGradCubPoints("weightedBasisGradAtTargetGradCubPoints",numCells,numElemDofs, numTargetGradCubPoints,dim);
+    ScalarViewType wBasisGradAtGradCubPoints("weightedBasisGradAtGradCubPoints",numCells,numElemDofs, numGradCubPoints,dim);
+    ScalarViewType wBasisGradBasisAtTargetGradCubPoints("weightedBasisGradAtTargetGradCubPoints",numCells,numElemDofs, numTargetGradCubPoints,dim);
     for(ordinal_type j=0; j <numElemDofs; ++j) {
       ordinal_type idof = cellBasis->getDofOrdinal(dim, 0, j);
       for(ordinal_type ic=0; ic<numCells; ++ic) {
@@ -519,7 +519,7 @@ ProjectionTools<SpT>::getHGradBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueTy
     }
 
 
-    scalarViewType cellMassMat_("cellMassMat_", numCells, numElemDofs, numElemDofs),
+    ScalarViewType cellMassMat_("cellMassMat_", numCells, numElemDofs, numElemDofs),
         cellRhsMat_("rhsMat_", numCells, numElemDofs);
 
     FunctionSpaceTools<SpT >::integrate(cellMassMat_, internalBasisGradAtGradCubPoints, wBasisGradAtGradCubPoints);

--- a/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefHVOL.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefHVOL.hpp
@@ -61,16 +61,16 @@ template<typename SpT>
 template<typename BasisType,
 typename ortValueType,       class ...ortProperties>
 void
-ProjectionTools<SpT>::getHVolEvaluationPoints(typename BasisType::scalarViewType evaluationPoints,
+ProjectionTools<SpT>::getHVolEvaluationPoints(typename BasisType::ScalarViewType evaluationPoints,
     const Kokkos::DynRankView<ortValueType,   ortProperties...>  /*orts*/,
     const BasisType* cellBasis,
     ProjectionStruct<SpT, typename BasisType::scalarType> * projStruct,
     const EvalPointsType evalPointType) {
   typedef typename BasisType::scalarType scalarType;
-  typedef Kokkos::DynRankView<scalarType,SpT> scalarViewType;
+  typedef Kokkos::DynRankView<scalarType,SpT> ScalarViewType;
   ordinal_type dim = cellBasis->getBaseCellTopology().getDimension();
 
-  scalarViewType cubPoints;
+  ScalarViewType cubPoints;
   if(evalPointType == TARGET) {
     cubPoints = projStruct->getTargetEvalPoints(dim, 0);
   } else {
@@ -88,28 +88,28 @@ typename ortValueType,class ...ortProperties>
 void
 ProjectionTools<SpT>::getHVolBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueType,basisCoeffsProperties...> basisCoeffs,
     const Kokkos::DynRankView<funValsValueType,funValsProperties...> targetAtEvalPoints,
-    const typename BasisType::scalarViewType evaluationPoints,
+    const typename BasisType::ScalarViewType evaluationPoints,
     const Kokkos::DynRankView<ortValueType,   ortProperties...>  orts,
     const BasisType* cellBasis,
     ProjectionStruct<SpT, typename BasisType::scalarType> * projStruct){
 
   typedef typename Kokkos::Impl::is_space<SpT>::host_mirror_space::execution_space host_space_type;
   typedef typename BasisType::scalarType scalarType;
-  typedef Kokkos::DynRankView<scalarType,SpT> scalarViewType;
+  typedef Kokkos::DynRankView<scalarType,SpT> ScalarViewType;
   ordinal_type dim = cellBasis->getBaseCellTopology().getDimension();
 
   ordinal_type basisCardinality = cellBasis->getCardinality();
 
   ordinal_type numCubPoints = projStruct->getNumBasisEvalPoints(dim, 0);
   ordinal_type numTargetCubPoints = projStruct->getNumTargetEvalPoints(dim, 0);
-  scalarViewType cubPoints = projStruct->getBasisEvalPoints(dim, 0);
-  scalarViewType cubWeights = projStruct->getBasisEvalWeights(dim, 0);
-  scalarViewType cubTargetWeights = projStruct->getTargetEvalWeights(dim, 0);
+  ScalarViewType cubPoints = projStruct->getBasisEvalPoints(dim, 0);
+  ScalarViewType cubWeights = projStruct->getBasisEvalWeights(dim, 0);
+  ScalarViewType cubTargetWeights = projStruct->getTargetEvalWeights(dim, 0);
 
   ordinal_type numCells = targetAtEvalPoints.extent(0);
 
-  scalarViewType basisAtCubPoints("basisAtcubPoints", basisCardinality, numCubPoints);
-  scalarViewType basisAtcubTargetPoints("basisAtcubTargetPoints", basisCardinality, numTargetCubPoints);
+  ScalarViewType basisAtCubPoints("basisAtcubPoints", basisCardinality, numCubPoints);
+  ScalarViewType basisAtcubTargetPoints("basisAtcubTargetPoints", basisCardinality, numTargetCubPoints);
 
   cellBasis->getValues(basisAtCubPoints, cubPoints);
   if(evaluationPoints.rank()==3)
@@ -118,13 +118,13 @@ ProjectionTools<SpT>::getHVolBasisCoeffs(Kokkos::DynRankView<basisCoeffsValueTyp
     cellBasis->getValues(basisAtcubTargetPoints, evaluationPoints);
 
 
-  scalarViewType weightedBasisAtcubTargetPoints_("weightedBasisAtcubTargetPoints_",numCells, basisCardinality, numTargetCubPoints);
-  scalarViewType cubWeights_(cubWeights.data(),1,numCubPoints);
-  scalarViewType evaluationWeights_(cubTargetWeights.data(),1,numTargetCubPoints);
-  scalarViewType basisAtcubTargetPoints_(basisAtcubTargetPoints.data(),1, basisCardinality, numTargetCubPoints);
-  scalarViewType basisAtCubPoints_(basisAtCubPoints.data(),1, basisCardinality, numCubPoints);
-  scalarViewType weightedBasisAtCubPoints("weightedBasisAtCubPoints",1,basisCardinality, numCubPoints);
-  scalarViewType weightedBasisAtcubTargetPoints("weightedBasisAtcubTargetPoints",1, basisCardinality, numTargetCubPoints);
+  ScalarViewType weightedBasisAtcubTargetPoints_("weightedBasisAtcubTargetPoints_",numCells, basisCardinality, numTargetCubPoints);
+  ScalarViewType cubWeights_(cubWeights.data(),1,numCubPoints);
+  ScalarViewType evaluationWeights_(cubTargetWeights.data(),1,numTargetCubPoints);
+  ScalarViewType basisAtcubTargetPoints_(basisAtcubTargetPoints.data(),1, basisCardinality, numTargetCubPoints);
+  ScalarViewType basisAtCubPoints_(basisAtCubPoints.data(),1, basisCardinality, numCubPoints);
+  ScalarViewType weightedBasisAtCubPoints("weightedBasisAtCubPoints",1,basisCardinality, numCubPoints);
+  ScalarViewType weightedBasisAtcubTargetPoints("weightedBasisAtcubTargetPoints",1, basisCardinality, numTargetCubPoints);
   ArrayTools<SpT>::scalarMultiplyDataField( weightedBasisAtCubPoints, cubWeights_, basisAtCubPoints_, false);
   ArrayTools<SpT>::scalarMultiplyDataField( weightedBasisAtcubTargetPoints, evaluationWeights_, basisAtcubTargetPoints, false);
   RealSpaceTools<SpT>::clone(weightedBasisAtcubTargetPoints_,Kokkos::subview(weightedBasisAtcubTargetPoints,0,Kokkos::ALL(), Kokkos::ALL()));

--- a/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefL2.hpp
+++ b/packages/intrepid2/src/Projection/Intrepid2_ProjectionToolsDefL2.hpp
@@ -61,13 +61,13 @@ template<typename SpT>
 template<typename BasisType,
 typename ortValueType,       class ...ortProperties>
 void
-ProjectionTools<SpT>::getL2EvaluationPoints(typename BasisType::scalarViewType evaluationPoints,
+ProjectionTools<SpT>::getL2EvaluationPoints(typename BasisType::ScalarViewType evaluationPoints,
     const Kokkos::DynRankView<ortValueType,   ortProperties...>  orts,
     const BasisType* cellBasis,
     ProjectionStruct<SpT, typename BasisType::scalarType> * projStruct,
     const EvalPointsType evalPointType) {
   typedef typename BasisType::scalarType scalarType;
-  typedef Kokkos::DynRankView<scalarType,SpT> scalarViewType;
+  typedef Kokkos::DynRankView<scalarType,SpT> ScalarViewType;
   typedef Kokkos::pair<ordinal_type,ordinal_type> range_type;
   const auto cellTopo = cellBasis->getBaseCellTopology();
   ordinal_type dim = cellTopo.getDimension();
@@ -83,7 +83,7 @@ ProjectionTools<SpT>::getL2EvaluationPoints(typename BasisType::scalarViewType e
 
   if(numVertices>0) {
     //TODO: use lattice to retrieve vertex coordinates.
-    scalarViewType dofCoords("dofCoords", cellBasis->getCardinality(), dim);
+    ScalarViewType dofCoords("dofCoords", cellBasis->getCardinality(), dim);
     cellBasis->getDofCoords(dofCoords);
     for(ordinal_type iv=0; iv<numVertices; ++iv) {
       ordinal_type idof = cellBasis->getDofOrdinal(0, iv, 0);
@@ -95,7 +95,7 @@ ProjectionTools<SpT>::getL2EvaluationPoints(typename BasisType::scalarViewType e
 
   for(ordinal_type ie=0; ie<numEdges; ++ie) {
     range_type edgePointsRange;
-    scalarViewType cubPoints;
+    ScalarViewType cubPoints;
     if(evalPointType == TARGET) {
       edgePointsRange = projStruct->getTargetPointsRange(edgeDim, ie);
       cubPoints = projStruct->getTargetEvalPoints(edgeDim, ie);
@@ -105,7 +105,7 @@ ProjectionTools<SpT>::getL2EvaluationPoints(typename BasisType::scalarViewType e
       cubPoints = projStruct->getBasisEvalPoints(edgeDim, ie);
     }
 
-    scalarViewType orientedTargetCubPoints("orientedTargetCubPoints", cubPoints.extent(0),edgeDim);
+    ScalarViewType orientedTargetCubPoints("orientedTargetCubPoints", cubPoints.extent(0),edgeDim);
 
     const auto topoKey = projStruct->getTopologyKey(edgeDim,ie);
 
@@ -120,7 +120,7 @@ ProjectionTools<SpT>::getL2EvaluationPoints(typename BasisType::scalarViewType e
 
   for(ordinal_type iface=0; iface<numFaces; ++iface) {
 
-    scalarViewType cubPoints;
+    ScalarViewType cubPoints;
     range_type facePointsRange;
     if(evalPointType == TARGET) {
       cubPoints = projStruct->getTargetEvalPoints(faceDim, iface);
@@ -130,7 +130,7 @@ ProjectionTools<SpT>::getL2EvaluationPoints(typename BasisType::scalarViewType e
       facePointsRange = projStruct->getBasisPointsRange(faceDim, iface);
     }
 
-    scalarViewType faceCubPoints("faceCubPoints", cubPoints.extent(0), faceDim);
+    ScalarViewType faceCubPoints("faceCubPoints", cubPoints.extent(0), faceDim);
 
     const auto topoKey = projStruct->getTopologyKey(faceDim,iface);
     for(ordinal_type ic=0; ic<numCells; ++ic) {
@@ -145,7 +145,7 @@ ProjectionTools<SpT>::getL2EvaluationPoints(typename BasisType::scalarViewType e
 
   if(cellBasis->getDofCount(dim,0)>0) {
     range_type cellPointsRange;
-    scalarViewType cubPoints;
+    ScalarViewType cubPoints;
     if(evalPointType == TARGET) {
       cubPoints = projStruct->getTargetEvalPoints(dim, 0);
       cellPointsRange = projStruct->getTargetPointsRange(dim, 0);
@@ -166,14 +166,14 @@ typename ortValueType,class ...ortProperties>
 void
 ProjectionTools<SpT>::getL2BasisCoeffs(Kokkos::DynRankView<basisCoeffsValueType,basisCoeffsProperties...> basisCoeffs,
     const Kokkos::DynRankView<funValsValueType,funValsProperties...> targetAtEvalPoints,
-    const typename BasisType::scalarViewType evaluationPoints,
+    const typename BasisType::ScalarViewType evaluationPoints,
     const Kokkos::DynRankView<ortValueType,   ortProperties...>  orts,
     const BasisType* cellBasis,
     ProjectionStruct<SpT, typename BasisType::scalarType> * projStruct){
 
   typedef typename Kokkos::Impl::is_space<SpT>::host_mirror_space::execution_space host_space_type;
   typedef typename BasisType::scalarType scalarType;
-  typedef Kokkos::DynRankView<scalarType,SpT> scalarViewType;
+  typedef Kokkos::DynRankView<scalarType,SpT> ScalarViewType;
   typedef Kokkos::pair<ordinal_type,ordinal_type> range_type;
   const auto cellTopo = cellBasis->getBaseCellTopology();
   ordinal_type dim = cellTopo.getDimension();
@@ -192,10 +192,10 @@ ProjectionTools<SpT>::getL2BasisCoeffs(Kokkos::DynRankView<basisCoeffsValueType,
 
   Kokkos::View<ordinal_type*> eOrt("eOrt", numEdges);
   Kokkos::View<ordinal_type*> fOrt("fOrt", numFaces);
-  scalarViewType refEdgeTan("refEdgeTan",  dim);
-  scalarViewType refEdgeNormal("refEdgeNormal",  dim);
-  scalarViewType refFaceTangents("refFaceTangents", dim, 2);
-  scalarViewType refFaceNormal("refFaceNormal", dim);
+  ScalarViewType refEdgeTan("refEdgeTan",  dim);
+  ScalarViewType refEdgeNormal("refEdgeNormal",  dim);
+  ScalarViewType refFaceTangents("refFaceTangents", dim, 2);
+  ScalarViewType refFaceNormal("refFaceNormal", dim);
   auto refFaceTanU = Kokkos::subview(refFaceTangents, Kokkos::ALL, 0);
   auto refFaceTanV = Kokkos::subview(refFaceTangents, Kokkos::ALL, 1);
 
@@ -214,15 +214,15 @@ ProjectionTools<SpT>::getL2BasisCoeffs(Kokkos::DynRankView<basisCoeffsValueType,
   ordinal_type computedDofsCount = 0;
 
   ordinal_type numTotalCubPoints = projStruct->getNumBasisEvalPoints();
-  scalarViewType cubPoints("cubPoints",numCells,numTotalCubPoints, dim);
+  ScalarViewType cubPoints("cubPoints",numCells,numTotalCubPoints, dim);
   getL2EvaluationPoints(cubPoints, orts, cellBasis, projStruct, BASIS);
 
-  scalarViewType basisAtCubPoints("basisAtCubPoints",numCells,basisCardinality, numTotalCubPoints, fieldDim);
-  scalarViewType basisAtTargetCubPoints("basisAtTargetCubPoints",numCells,basisCardinality, numTotalEvaluationPoints, fieldDim);
+  ScalarViewType basisAtCubPoints("basisAtCubPoints",numCells,basisCardinality, numTotalCubPoints, fieldDim);
+  ScalarViewType basisAtTargetCubPoints("basisAtTargetCubPoints",numCells,basisCardinality, numTotalEvaluationPoints, fieldDim);
   {
     if(fieldDim == 1) {
-      scalarViewType nonOrientedBasisAtCubPoints("nonOrientedBasisAtCubPoints",numCells,basisCardinality, numTotalCubPoints);
-      scalarViewType nonOrientedBasisAtTargetCubPoints("nonOrientedBasisAtTargetCubPoints",numCells,basisCardinality, numTotalEvaluationPoints);
+      ScalarViewType nonOrientedBasisAtCubPoints("nonOrientedBasisAtCubPoints",numCells,basisCardinality, numTotalCubPoints);
+      ScalarViewType nonOrientedBasisAtTargetCubPoints("nonOrientedBasisAtTargetCubPoints",numCells,basisCardinality, numTotalEvaluationPoints);
       for(ordinal_type ic=0; ic<numCells; ++ic) {
         cellBasis->getValues(Kokkos::subview(nonOrientedBasisAtTargetCubPoints,ic,Kokkos::ALL(),Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()));
         cellBasis->getValues(Kokkos::subview(nonOrientedBasisAtCubPoints,ic,Kokkos::ALL(),Kokkos::ALL()), Kokkos::subview(cubPoints, ic, Kokkos::ALL(), Kokkos::ALL()));
@@ -234,8 +234,8 @@ ProjectionTools<SpT>::getL2BasisCoeffs(Kokkos::DynRankView<basisCoeffsValueType,
 
     }
     else {
-      scalarViewType nonOrientedBasisAtCubPoints("nonOrientedBasisAtCubPoints",numCells,basisCardinality, numTotalCubPoints,fieldDim);
-      scalarViewType nonOrientedBasisAtTargetCubPoints("nonOrientedBasisAtTargetCubPoints",numCells,basisCardinality, numTotalEvaluationPoints,fieldDim);
+      ScalarViewType nonOrientedBasisAtCubPoints("nonOrientedBasisAtCubPoints",numCells,basisCardinality, numTotalCubPoints,fieldDim);
+      ScalarViewType nonOrientedBasisAtTargetCubPoints("nonOrientedBasisAtTargetCubPoints",numCells,basisCardinality, numTotalEvaluationPoints,fieldDim);
       for(ordinal_type ic=0; ic<numCells; ++ic) {
         cellBasis->getValues(Kokkos::subview(nonOrientedBasisAtTargetCubPoints,ic,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()));
         cellBasis->getValues(Kokkos::subview(nonOrientedBasisAtCubPoints,ic,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL()), Kokkos::subview(cubPoints, ic, Kokkos::ALL(), Kokkos::ALL()));
@@ -256,7 +256,7 @@ ProjectionTools<SpT>::getL2BasisCoeffs(Kokkos::DynRankView<basisCoeffsValueType,
 
   ordinal_type faceDofDim = isHCurlBAsis ? 2 : 1;
 
-  scalarViewType edgeCoeff("edgeCoeff", fieldDim);
+  ScalarViewType edgeCoeff("edgeCoeff", fieldDim);
   for(ordinal_type ie=0; ie<numEdges; ++ie)  {
 
     if(fieldDim == 1)
@@ -273,14 +273,14 @@ ProjectionTools<SpT>::getL2BasisCoeffs(Kokkos::DynRankView<basisCoeffsValueType,
     ordinal_type numCubPoints = projStruct->getNumBasisEvalPoints(edgeDim, ie);
     ordinal_type numTargetCubPoints = projStruct->getNumTargetEvalPoints(edgeDim, ie);
 
-    scalarViewType edgeBasisAtCubPoints("tanBasisAtElemCubPoints",numCells,edgeCardinality, numCubPoints);
-    scalarViewType edgeTargetAtTargetCubPoints("tanBasisAtTargetCubPoints",numCells, numTargetCubPoints);
-    scalarViewType weightedBasisAtElemCubPoints("weightedTanBasisAtElemCubPoints",numCells,edgeCardinality, numCubPoints);
-    scalarViewType weightedBasisAtTargetCubPoints("weightedTanBasisAtTargetCubPoints",numCells,edgeCardinality, numTargetCubPoints);
-    scalarViewType mComputedProjection("mComputedProjection", numCells, numCubPoints);
+    ScalarViewType edgeBasisAtCubPoints("tanBasisAtElemCubPoints",numCells,edgeCardinality, numCubPoints);
+    ScalarViewType edgeTargetAtTargetCubPoints("tanBasisAtTargetCubPoints",numCells, numTargetCubPoints);
+    ScalarViewType weightedBasisAtElemCubPoints("weightedTanBasisAtElemCubPoints",numCells,edgeCardinality, numCubPoints);
+    ScalarViewType weightedBasisAtTargetCubPoints("weightedTanBasisAtTargetCubPoints",numCells,edgeCardinality, numTargetCubPoints);
+    ScalarViewType mComputedProjection("mComputedProjection", numCells, numCubPoints);
 
-    scalarViewType targetEvalWeights = projStruct->getTargetEvalWeights(edgeDim, ie);
-    scalarViewType basisEvalWeights = projStruct->getBasisEvalWeights(edgeDim, ie);
+    ScalarViewType targetEvalWeights = projStruct->getTargetEvalWeights(edgeDim, ie);
+    ScalarViewType basisEvalWeights = projStruct->getBasisEvalWeights(edgeDim, ie);
 
     //Note: we are not considering the jacobian of the orientation map since it is simply a scalar term for the integrals and it does not affect the projection
     ordinal_type offsetBasis = projStruct->getBasisPointsRange(edgeDim, ie).first;
@@ -314,10 +314,10 @@ ProjectionTools<SpT>::getL2BasisCoeffs(Kokkos::DynRankView<basisCoeffsValueType,
     }
 
 
-    scalarViewType edgeMassMat_("edgeMassMat_", numCells, edgeCardinality, edgeCardinality),
+    ScalarViewType edgeMassMat_("edgeMassMat_", numCells, edgeCardinality, edgeCardinality),
         edgeRhsMat_("rhsMat_", numCells, edgeCardinality);
 
-    scalarViewType cubWeights_("cubWeights_", numCells, 1, basisEvalWeights.extent(0)), targetEvalWeights_("targetEvalWeights", numCells, 1, targetEvalWeights.extent(0));
+    ScalarViewType cubWeights_("cubWeights_", numCells, 1, basisEvalWeights.extent(0)), targetEvalWeights_("targetEvalWeights", numCells, 1, targetEvalWeights.extent(0));
     RealSpaceTools<SpT>::clone(cubWeights_, basisEvalWeights);
     RealSpaceTools<SpT>::clone(targetEvalWeights_, targetEvalWeights);
 
@@ -362,9 +362,9 @@ ProjectionTools<SpT>::getL2BasisCoeffs(Kokkos::DynRankView<basisCoeffsValueType,
       computedDofs(computedDofsCount++) = cellBasis->getDofOrdinal(edgeDim, ie, i);
   }
 
-  scalarViewType ortJacobian("ortJacobian", faceDim, faceDim);
+  ScalarViewType ortJacobian("ortJacobian", faceDim, faceDim);
 
-  scalarViewType faceCoeff("faceCoeff", fieldDim, faceDofDim);
+  ScalarViewType faceCoeff("faceCoeff", fieldDim, faceDofDim);
   for(ordinal_type iface=0; iface<numFaces; ++iface) {
 
 
@@ -386,19 +386,19 @@ ProjectionTools<SpT>::getL2BasisCoeffs(Kokkos::DynRankView<basisCoeffsValueType,
         faceCoeff(d,0) = refFaceNormal(d);
     }
 
-    scalarViewType faceBasisDofAtCubPoints("normaBasisAtCubPoints",numCells,faceCardinality, numCubPoints,faceDofDim);
-    scalarViewType wBasisDofAtCubPoints("weightedNormalBasisAtCubPoints",numCells,faceCardinality, numCubPoints,faceDofDim);
+    ScalarViewType faceBasisDofAtCubPoints("normaBasisAtCubPoints",numCells,faceCardinality, numCubPoints,faceDofDim);
+    ScalarViewType wBasisDofAtCubPoints("weightedNormalBasisAtCubPoints",numCells,faceCardinality, numCubPoints,faceDofDim);
 
-    scalarViewType faceBasisAtTargetCubPoints("normalBasisAtTargetCubPoints",numCells,faceCardinality, numTargetCubPoints,faceDofDim);
-    scalarViewType wBasisBasisAtTargetCubPoints("weightedNormalBasisAtTargetCubPoints",numCells,faceCardinality, numTargetCubPoints,faceDofDim);
+    ScalarViewType faceBasisAtTargetCubPoints("normalBasisAtTargetCubPoints",numCells,faceCardinality, numTargetCubPoints,faceDofDim);
+    ScalarViewType wBasisBasisAtTargetCubPoints("weightedNormalBasisAtTargetCubPoints",numCells,faceCardinality, numTargetCubPoints,faceDofDim);
 
-    scalarViewType targetAtTargetCubPoints("targetAtTargetCubPoints",numCells, numTargetCubPoints,faceDofDim);
-    scalarViewType mComputedProjection("mNormalComputedProjection", numCells,numCubPoints,faceDofDim);
+    ScalarViewType targetAtTargetCubPoints("targetAtTargetCubPoints",numCells, numTargetCubPoints,faceDofDim);
+    ScalarViewType mComputedProjection("mNormalComputedProjection", numCells,numCubPoints,faceDofDim);
 
     ordinal_type offsetBasis = projStruct->getBasisPointsRange(faceDim, iface).first;
     ordinal_type offsetTarget = projStruct->getTargetPointsRange(faceDim, iface).first;
-    scalarViewType targetCubWeights = projStruct->getTargetEvalWeights(faceDim, iface);
-    scalarViewType CubWeights = projStruct->getBasisEvalWeights(faceDim, iface);
+    ScalarViewType targetCubWeights = projStruct->getTargetEvalWeights(faceDim, iface);
+    ScalarViewType CubWeights = projStruct->getBasisEvalWeights(faceDim, iface);
 
     //Note: we are not considering the jacobian of the orientation map since it is simply a scalar term for the integrals and it does not affect the projection
     for(ordinal_type ic=0; ic<numCells; ++ic)  {
@@ -444,7 +444,7 @@ ProjectionTools<SpT>::getL2BasisCoeffs(Kokkos::DynRankView<basisCoeffsValueType,
       }
     }
 
-    scalarViewType faceMassMat_("faceMassMat_", numCells, faceCardinality, faceCardinality),
+    ScalarViewType faceMassMat_("faceMassMat_", numCells, faceCardinality, faceCardinality),
         faceRhsMat_("rhsMat_", numCells, faceCardinality);
 
     FunctionSpaceTools<SpT >::integrate(faceMassMat_, faceBasisDofAtCubPoints, wBasisDofAtCubPoints);
@@ -499,17 +499,17 @@ ProjectionTools<SpT>::getL2BasisCoeffs(Kokkos::DynRankView<basisCoeffsValueType,
     ordinal_type numTargetCubPoints = projStruct->getNumTargetEvalPoints(dim,0);
     ordinal_type numCubPoints = projStruct->getNumBasisEvalPoints(dim,0);
 
-    scalarViewType internalBasisAtCubPoints("internalBasisAtCubPoints",numCells,numElemDofs, numCubPoints, fieldDim);
-    scalarViewType mComputedProjection("mComputedProjection", numCells, numCubPoints, fieldDim);
+    ScalarViewType internalBasisAtCubPoints("internalBasisAtCubPoints",numCells,numElemDofs, numCubPoints, fieldDim);
+    ScalarViewType mComputedProjection("mComputedProjection", numCells, numCubPoints, fieldDim);
 
-    scalarViewType targetCubWeights = projStruct->getTargetEvalWeights(dim, 0);
-    scalarViewType cubWeights = projStruct->getBasisEvalWeights(dim, 0);
+    ScalarViewType targetCubWeights = projStruct->getTargetEvalWeights(dim, 0);
+    ScalarViewType cubWeights = projStruct->getBasisEvalWeights(dim, 0);
     ordinal_type offsetBasis = projStruct->getBasisPointsRange(dim, 0).first;
     ordinal_type offsetTarget = projStruct->getTargetPointsRange(dim, 0).first;
 
 
-    scalarViewType wBasisAtCubPoints("weightedBasisAtCubPoints",numCells,numElemDofs, numCubPoints,fieldDim);
-    scalarViewType wBasisBasisAtTargetCubPoints("weightedBasisAtTargetCubPoints",numCells,numElemDofs, numTargetCubPoints,fieldDim);
+    ScalarViewType wBasisAtCubPoints("weightedBasisAtCubPoints",numCells,numElemDofs, numCubPoints,fieldDim);
+    ScalarViewType wBasisBasisAtTargetCubPoints("weightedBasisAtTargetCubPoints",numCells,numElemDofs, numTargetCubPoints,fieldDim);
     for(ordinal_type j=0; j <numElemDofs; ++j) {
       ordinal_type idof = cellBasis->getDofOrdinal(dim, 0, j);
       for(ordinal_type ic=0; ic<numCells; ++ic) {
@@ -536,7 +536,7 @@ ProjectionTools<SpT>::getL2BasisCoeffs(Kokkos::DynRankView<basisCoeffsValueType,
     }
 
 
-    scalarViewType cellMassMat_("cellMassMat_", numCells, numElemDofs, numElemDofs),
+    ScalarViewType cellMassMat_("cellMassMat_", numCells, numElemDofs, numElemDofs),
         cellRhsMat_("rhsMat_", numCells, numElemDofs);
 
     FunctionSpaceTools<SpT >::integrate(cellMassMat_, internalBasisAtCubPoints, wBasisAtCubPoints);

--- a/packages/intrepid2/src/Shared/Intrepid2_ArrayToolsDefCloneScale.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_ArrayToolsDefCloneScale.hpp
@@ -56,15 +56,15 @@ namespace Intrepid2 {
     /**
       \brief Functor for clone see Intrepid2::ArrayTools for more
     */ 
-    template<typename outputViewType,
+    template<typename OutputViewType,
              typename inputViewType,
              ordinal_type valRank>
     struct F_clone {
-            outputViewType _output;
+            OutputViewType _output;
       const inputViewType _input;
 
       KOKKOS_INLINE_FUNCTION
-      F_clone(outputViewType output_,
+      F_clone(OutputViewType output_,
               inputViewType input_)
         : _output(output_),
           _input(input_) {}
@@ -147,7 +147,7 @@ namespace Intrepid2 {
     }
 #endif
 
-    typedef Kokkos::DynRankView<outputValueType,outputProperties...> outputViewType;
+    typedef Kokkos::DynRankView<outputValueType,outputProperties...> OutputViewType;
     typedef Kokkos::DynRankView<inputValueType, inputProperties...>  inputViewType; 
     typedef typename ExecSpace< typename inputViewType::execution_space , SpT >::ExecSpaceType ExecSpaceType;
     
@@ -159,17 +159,17 @@ namespace Intrepid2 {
     const ordinal_type valRank = output.rank() - 3;
     switch (valRank) {
     case 0: {
-      typedef FunctorArrayTools::F_clone<outputViewType,inputViewType,0> FunctorType;
+      typedef FunctorArrayTools::F_clone<OutputViewType,inputViewType,0> FunctorType;
       Kokkos::parallel_for( policy, FunctorType(output, input) );
       break;
     }
     case 1: {
-      typedef FunctorArrayTools::F_clone<outputViewType,inputViewType,1> FunctorType;
+      typedef FunctorArrayTools::F_clone<OutputViewType,inputViewType,1> FunctorType;
       Kokkos::parallel_for( policy, FunctorType(output, input) );
       break;
     }
     case 2: {
-      typedef FunctorArrayTools::F_clone<outputViewType,inputViewType,2> FunctorType;
+      typedef FunctorArrayTools::F_clone<OutputViewType,inputViewType,2> FunctorType;
       Kokkos::parallel_for( policy, FunctorType(output, input) );
       break;
     }
@@ -195,7 +195,7 @@ namespace Intrepid2 {
     }
 #endif
 
-    typedef Kokkos::DynRankView<outputValueType,outputProperties...> outputViewType;
+    typedef Kokkos::DynRankView<outputValueType,outputProperties...> OutputViewType;
     typedef Kokkos::DynRankView<inputValueType, inputProperties...>  inputViewType; 
     typedef typename ExecSpace< typename inputViewType::execution_space , SpT >::ExecSpaceType ExecSpaceType;
     
@@ -207,17 +207,17 @@ namespace Intrepid2 {
     const ordinal_type valRank = output.rank() - 2;
     switch (valRank) {
     case 0: {
-      typedef FunctorArrayTools::F_clone<outputViewType,inputViewType,0> FunctorType;
+      typedef FunctorArrayTools::F_clone<OutputViewType,inputViewType,0> FunctorType;
       Kokkos::parallel_for( policy, FunctorType(output, input) );
       break;
     }
     case 1: {
-      typedef FunctorArrayTools::F_clone<outputViewType,inputViewType,1> FunctorType;
+      typedef FunctorArrayTools::F_clone<OutputViewType,inputViewType,1> FunctorType;
       Kokkos::parallel_for( policy, FunctorType(output, input) );
       break;
     }
     case 2: {
-      typedef FunctorArrayTools::F_clone<outputViewType,inputViewType,2> FunctorType;
+      typedef FunctorArrayTools::F_clone<OutputViewType,inputViewType,2> FunctorType;
       Kokkos::parallel_for( policy, FunctorType(output, input) );
       break;
     }

--- a/packages/intrepid2/src/Shared/Intrepid2_ArrayToolsDefDot.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_ArrayToolsDefDot.hpp
@@ -55,16 +55,16 @@ namespace Intrepid2 {
     /**
        \brief Functor for dotMultiply see Intrepid2::ArrayTools for more
     */
-    template < typename outputViewType, typename leftInputViewType, typename rightInputViewType >
+    template < typename OutputViewType, typename leftInputViewType, typename rightInputViewType >
     struct F_dotMultiply {
-      outputViewType _output;
+      OutputViewType _output;
       leftInputViewType _leftInput;
       rightInputViewType _rightInput;
       const bool _hasField;
-      typedef typename outputViewType::value_type value_type;
+      typedef typename OutputViewType::value_type value_type;
 
       KOKKOS_INLINE_FUNCTION
-      F_dotMultiply(outputViewType output_,
+      F_dotMultiply(OutputViewType output_,
               leftInputViewType leftInput_,
               rightInputViewType rightInput_,
               const bool hasField_)
@@ -124,10 +124,10 @@ namespace Intrepid2 {
                const Kokkos::DynRankView<rightInputValueType,rightInputProperties...>  rightInput, 
                const bool hasField ) {
 
-    typedef Kokkos::DynRankView<outputValueType,    outputProperties...>      outputViewType;
+    typedef Kokkos::DynRankView<outputValueType,    outputProperties...>      OutputViewType;
     typedef Kokkos::DynRankView<leftInputValueType, leftInputProperties...>   leftInputViewType;
     typedef Kokkos::DynRankView<rightInputValueType,rightInputProperties...>  rightInputViewType;
-    typedef FunctorArrayTools::F_dotMultiply<outputViewType, leftInputViewType, rightInputViewType> FunctorType;
+    typedef FunctorArrayTools::F_dotMultiply<OutputViewType, leftInputViewType, rightInputViewType> FunctorType;
     typedef typename ExecSpace< typename leftInputViewType::execution_space , SpT >::ExecSpaceType ExecSpaceType;
 
     const size_type loopSize = ( hasField ? output.extent(0)*output.extent(1)*output.extent(2) :

--- a/packages/intrepid2/src/Shared/Intrepid2_ArrayToolsDefScalar.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_ArrayToolsDefScalar.hpp
@@ -55,18 +55,18 @@ namespace Intrepid2 {
     /**
        \brief Functor for scalarMultiply see Intrepid2::ArrayTools for more
     */
-    template<typename outputViewType,
+    template<typename OutputViewType,
              typename inputLeftViewType,
              typename inputRightViewType,
              bool equalRank,
              bool reciprocal>
     struct F_scalarMultiply {
-            outputViewType _output;
+            OutputViewType _output;
       const inputLeftViewType _inputLeft;
       const inputRightViewType _inputRight;
 
       KOKKOS_INLINE_FUNCTION
-      F_scalarMultiply(outputViewType output_,
+      F_scalarMultiply(OutputViewType output_,
                        inputLeftViewType inputLeft_,
                        inputRightViewType inputRight_)
         : _output(output_),
@@ -80,7 +80,7 @@ namespace Intrepid2 {
         const auto val = _inputLeft(cl , pt%_inputLeft.extent(1));
         
         //const ordinal_type cp[2] = { cl, pt };
-        //ViewAdapter<2,outputViewType> out(cp, _output);
+        //ViewAdapter<2,OutputViewType> out(cp, _output);
         auto out = Kokkos::subview(_output, cl, pt, Kokkos::ALL(), Kokkos::ALL());
         if (equalRank) {
           //const ViewAdapter<2,inputRightViewType> right(cp, _inputRight);
@@ -104,7 +104,7 @@ namespace Intrepid2 {
         const auto val = _inputLeft(cl , pt%_inputLeft.extent(1));
 
         //const ordinal_type cfp[3] = { cl, bf, pt };
-        //ViewAdapter<3,outputViewType> out(cfp, _output);
+        //ViewAdapter<3,OutputViewType> out(cfp, _output);
         auto out = Kokkos::subview(_output, cl, bf, pt, Kokkos::ALL(), Kokkos::ALL());
         if (equalRank) {
           //const ViewAdapter<3,inputRightViewType> right(cfp, _inputRight);          

--- a/packages/intrepid2/src/Shared/Intrepid2_ArrayToolsDefTensor.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_ArrayToolsDefTensor.hpp
@@ -55,15 +55,15 @@ namespace Intrepid2 {
     /**
        \brief Functor for crossProduct see Intrepid2::ArrayTools for more
     */
-    template < typename outputViewType, typename leftInputViewType, typename rightInputViewType >
+    template < typename OutputViewType, typename leftInputViewType, typename rightInputViewType >
     struct F_crossProduct{
-      outputViewType _output;
+      OutputViewType _output;
       const leftInputViewType _leftInput;
       const rightInputViewType _rightInput;
       const bool _hasField, _isCrossProd3D;
 
       KOKKOS_INLINE_FUNCTION
-      F_crossProduct(outputViewType output_,
+      F_crossProduct(OutputViewType output_,
               leftInputViewType leftInput_,
               rightInputViewType rightInput_,
               const bool hasField_,
@@ -122,10 +122,10 @@ namespace Intrepid2 {
                 const Kokkos::DynRankView<rightInputValueType,rightInputProperties...>  rightInput,
                 const bool hasField ) {
 
-    typedef Kokkos::DynRankView<outputValueType,    outputProperties...>      outputViewType;
+    typedef Kokkos::DynRankView<outputValueType,    outputProperties...>      OutputViewType;
     typedef const Kokkos::DynRankView<leftInputValueType, leftInputProperties...>   leftInputViewType;
     typedef const Kokkos::DynRankView<rightInputValueType,rightInputProperties...>  rightInputViewType;
-    typedef FunctorArrayTools::F_crossProduct<outputViewType, leftInputViewType, rightInputViewType> FunctorType;
+    typedef FunctorArrayTools::F_crossProduct<OutputViewType, leftInputViewType, rightInputViewType> FunctorType;
     typedef typename ExecSpace< typename rightInputViewType::execution_space , SpT >::ExecSpaceType ExecSpaceType;
 
     const size_type loopSize = ( hasField ? output.extent(0)*output.extent(1)*output.extent(2) :
@@ -382,15 +382,15 @@ namespace Intrepid2 {
     /**
        \brief Functor for outerProduct see Intrepid2::ArrayTools for more
     */
-    template < typename outputViewType, typename leftInputViewType, typename rightInputViewType >
+    template < typename OutputViewType, typename leftInputViewType, typename rightInputViewType >
     struct F_outerProduct {
-      outputViewType _output;
+      OutputViewType _output;
       const leftInputViewType _leftInput;
       const rightInputViewType _rightInput;
       const bool _hasField;
 
       KOKKOS_INLINE_FUNCTION
-      F_outerProduct(outputViewType output_,
+      F_outerProduct(OutputViewType output_,
               leftInputViewType leftInput_,
               rightInputViewType rightInput_,
               const bool hasField_)
@@ -445,10 +445,10 @@ namespace Intrepid2 {
                 const Kokkos::DynRankView<rightInputValueType,rightInputProperties...>  rightInput,
                 const bool hasField ) {
 
-    typedef Kokkos::DynRankView<outputValueType,    outputProperties...>      outputViewType;
+    typedef Kokkos::DynRankView<outputValueType,    outputProperties...>      OutputViewType;
     typedef const Kokkos::DynRankView<leftInputValueType, leftInputProperties...>   leftInputViewType;
     typedef const Kokkos::DynRankView<rightInputValueType,rightInputProperties...>  rightInputViewType;
-    typedef FunctorArrayTools::F_outerProduct<outputViewType, leftInputViewType, rightInputViewType> FunctorType;
+    typedef FunctorArrayTools::F_outerProduct<OutputViewType, leftInputViewType, rightInputViewType> FunctorType;
     typedef typename ExecSpace< typename leftInputViewType::execution_space , SpT >::ExecSpaceType ExecSpaceType;
 
     const size_type loopSize = ( hasField ? output.extent(0)*output.extent(1)*output.extent(2) :
@@ -673,18 +673,18 @@ namespace Intrepid2 {
     /**
        \brief Functor for matvecProduct see Intrepid2::ArrayTools for more
     */
-    template < typename outputViewType, 
+    template < typename OutputViewType, 
                typename leftInputViewType, 
                typename rightInputViewType>
     struct F_matvecProduct {
-      /**/  outputViewType     _output;
+      /**/  OutputViewType     _output;
       const leftInputViewType  _leftInput;
       const rightInputViewType _rightInput;
 
       const bool _isTranspose;
       
       KOKKOS_INLINE_FUNCTION
-      F_matvecProduct(outputViewType     output_,
+      F_matvecProduct(OutputViewType     output_,
                       leftInputViewType  leftInput_,
                       rightInputViewType rightInput_,
                       const bool isTranspose_)
@@ -789,10 +789,10 @@ namespace Intrepid2 {
                  const bool hasField,
                  const bool isTranspose ) {
 
-    typedef       Kokkos::DynRankView<outputValueType,    outputProperties...>      outputViewType;
+    typedef       Kokkos::DynRankView<outputValueType,    outputProperties...>      OutputViewType;
     typedef const Kokkos::DynRankView<leftInputValueType, leftInputProperties...>   leftInputViewType;
     typedef const Kokkos::DynRankView<rightInputValueType,rightInputProperties...>  rightInputViewType;
-    typedef FunctorArrayTools::F_matvecProduct<outputViewType, leftInputViewType, rightInputViewType> FunctorType;
+    typedef FunctorArrayTools::F_matvecProduct<OutputViewType, leftInputViewType, rightInputViewType> FunctorType;
     typedef typename ExecSpace< typename leftInputViewType::execution_space , SpT >::ExecSpaceType ExecSpaceType;
 
     if (hasField) {
@@ -1122,16 +1122,16 @@ namespace Intrepid2 {
     /**
        \brief Functor for matmatProduct see Intrepid2::ArrayTools for more
     */
-    template < typename outputViewType, typename leftInputViewType, typename rightInputViewType >
+    template < typename OutputViewType, typename leftInputViewType, typename rightInputViewType >
     struct F_matmatProduct{
-      outputViewType _output;
+      OutputViewType _output;
       leftInputViewType _leftInput;
       rightInputViewType _rightInput;
       const bool _hasField, _isTranspose;
       typedef typename leftInputViewType::value_type value_type; 
 
       KOKKOS_INLINE_FUNCTION
-      F_matmatProduct(outputViewType output_,
+      F_matmatProduct(OutputViewType output_,
               leftInputViewType leftInput_,
               rightInputViewType rightInput_,
               const bool hasField_,
@@ -1225,10 +1225,10 @@ namespace Intrepid2 {
                  const bool hasField,
                  const bool isTranspose ) {
 
-    typedef Kokkos::DynRankView<outputValueType,    outputProperties...>      outputViewType;
+    typedef Kokkos::DynRankView<outputValueType,    outputProperties...>      OutputViewType;
     typedef const Kokkos::DynRankView<leftInputValueType, leftInputProperties...>   leftInputViewType;
     typedef const Kokkos::DynRankView<rightInputValueType,rightInputProperties...>  rightInputViewType;
-    typedef FunctorArrayTools::F_matmatProduct<outputViewType, leftInputViewType, rightInputViewType> FunctorType;
+    typedef FunctorArrayTools::F_matmatProduct<OutputViewType, leftInputViewType, rightInputViewType> FunctorType;
     typedef typename ExecSpace< typename leftInputViewType::execution_space , SpT >::ExecSpaceType ExecSpaceType;
 
     const size_type loopSize = ( hasField ? output.extent(0)*output.extent(1)*output.extent(2) :

--- a/packages/intrepid2/src/Shared/Intrepid2_RealSpaceToolsDef.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_RealSpaceToolsDef.hpp
@@ -221,14 +221,14 @@ namespace Intrepid2 {
     /**
       \brief Functor for extractScalarValues see Intrepid2::RealSpaceTools for more
     */ 
-    template<typename outputViewType,
+    template<typename OutputViewType,
              typename inputViewType>
     struct F_extractScalarValues {
-      outputViewType _output;
+      OutputViewType _output;
       inputViewType  _input;
 
       KOKKOS_INLINE_FUNCTION
-      F_extractScalarValues( outputViewType output_,
+      F_extractScalarValues( OutputViewType output_,
                        inputViewType  input_ )
         : _output(output_), _input(input_) {}
 
@@ -255,9 +255,9 @@ namespace Intrepid2 {
   RealSpaceTools<SpT>::
   extractScalarValues(       Kokkos::DynRankView<outputValueType,outputProperties...>  output,
                        const Kokkos::DynRankView<inputValueType, inputProperties...>   input ) {
-    typedef          Kokkos::DynRankView<outputValueType,outputProperties...> outputViewType;
+    typedef          Kokkos::DynRankView<outputValueType,outputProperties...> OutputViewType;
     typedef          Kokkos::DynRankView<inputValueType,inputProperties...> inputViewType;
-    typedef          FunctorRealSpaceTools::F_extractScalarValues<outputViewType,inputViewType> FunctorType;
+    typedef          FunctorRealSpaceTools::F_extractScalarValues<OutputViewType,inputViewType> FunctorType;
     typedef typename ExecSpace<typename inputViewType::execution_space,SpT>::ExecSpaceType ExecSpaceType;
     
     const auto loopSize = input.extent(0);
@@ -269,14 +269,14 @@ namespace Intrepid2 {
     /**
       \brief Functor for clone see Intrepid2::RealSpaceTools for more
     */ 
-    template<typename outputViewType,
+    template<typename OutputViewType,
              typename inputViewType>
     struct F_clone {
-      outputViewType _output;
+      OutputViewType _output;
       inputViewType  _input;
 
       KOKKOS_INLINE_FUNCTION
-      F_clone( outputViewType output_,
+      F_clone( OutputViewType output_,
                inputViewType  input_ )
         : _output(output_), _input(input_) {}
 
@@ -348,9 +348,9 @@ namespace Intrepid2 {
       }
     }
 #endif
-    typedef          Kokkos::DynRankView<outputValueType,outputProperties...>     outputViewType;
+    typedef          Kokkos::DynRankView<outputValueType,outputProperties...>     OutputViewType;
     typedef          Kokkos::DynRankView<inputValueType,inputProperties...>       inputViewType;
-    typedef          FunctorRealSpaceTools::F_clone<outputViewType,inputViewType> FunctorType;
+    typedef          FunctorRealSpaceTools::F_clone<OutputViewType,inputViewType> FunctorType;
     typedef typename ExecSpace<typename inputViewType::execution_space,SpT>::ExecSpaceType ExecSpaceType;
 
     size_type loopSize = 1;

--- a/packages/intrepid2/src/Shared/Intrepid2_Utils.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_Utils.hpp
@@ -109,14 +109,22 @@ namespace Intrepid2 {
 #endif
   
 // adapted from Kokkos_Macros.hpp
+// adapted from Kokkos_Macros.hpp
 #if defined(KOKKOS_COMPILER_GNU) || defined(KOKKOS_COMPILER_CLANG)
   #if defined(KOKKOS_COMPILER_CLANG)
     #define INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT(msg,fixit) __attribute__((deprecated(msg,fixit)))
     #define INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE(msg)
   #else // GNU
-    #define INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT(msg,fixit)
-    #define INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE(msg) __attribute__((deprecated(msg)))
-    // see https://gcc.gnu.org/onlinedocs/gcc-4.9.0/gcc/Function-Attributes.html
+    #if not defined(KOKKOS_ENABLE_CUDA)
+      #define INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT(msg,fixit)
+      #define INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE(msg) __attribute__((deprecated(msg)))
+      // see https://gcc.gnu.org/onlinedocs/gcc-4.9.0/gcc/Function-Attributes.html
+    #else
+      // for unknown reasons, the CUDA compilers seem to have trouble with this gcc feature
+      // we therefore disable typedef deprecation warnings on CUDA
+      #define INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT(msg,fixit)
+      #define INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE(msg) __attribute__((deprecated(msg)))
+    #endif
   #endif
 #else
   #define INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT(msg,fixit)

--- a/packages/intrepid2/src/Shared/Intrepid2_Utils.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_Utils.hpp
@@ -109,33 +109,18 @@ namespace Intrepid2 {
 #endif
   
 // adapted from Kokkos_Macros.hpp
-#if (defined(KOKKOS_ENABLE_CXX14) || defined(KOKKOS_ENABLE_CXX17) || defined(KOKKOS_ENABLE_CXX20))
-  #define INTREPID2_DEPRECATED [[deprecated]]
-  #define INTREPID2_DEPRECATED_MESSAGE(msg) [[deprecated(msg)]]
-  #define INTREPID2_DEPRECATED_TRAILING_ATTRIBUTE
-  #define INTREPID2_DEPRECATED_MESSAGE_TRAILING_ATTRIBUTE(msg)
-  #define INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE(msg,fixit)
-#else
-  #if defined(KOKKOS_COMPILER_GNU) || defined(KOKKOS_COMPILER_CLANG)
-    #define INTREPID2_DEPRECATED
-    #define INTREPID2_DEPRECATED_MESSAGE(msg)
-    #define INTREPID2_DEPRECATED_TRAILING_ATTRIBUTE              __attribute__((deprecated))
-    #define INTREPID2_DEPRECATED_MESSAGE_TRAILING_ATTRIBUTE(msg) __attribute__((deprecated(msg)))
-    #if defined(KOKKOS_COMPILER_CLANG)
-      #define INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE(msg,fixit) __attribute__((deprecated(msg,fixit)))
-      // see https://clang.llvm.org/docs/AttributeReference.html#deprecated
-    #else // GNU
-      // GNU doesn't support the replacement argument, so we drop that
-      #define INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE(msg,fixit) __attribute__((deprecated(msg)))
-      // see https://gcc.gnu.org/onlinedocs/gcc-4.9.0/gcc/Function-Attributes.html
-    #endif
-  #else
-    #define INTREPID2_DEPRECATED
-    #define INTREPID2_DEPRECATED_MESSAGE(msg)
-    #define INTREPID2_DEPRECATED_TRAILING_ATTRIBUTE
-    #define INTREPID2_DEPRECATED_MESSAGE_TRAILING_ATTRIBUTE(msg)
-    #define INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE(msg,fixit)
+#if defined(KOKKOS_COMPILER_GNU) || defined(KOKKOS_COMPILER_CLANG)
+  #if defined(KOKKOS_COMPILER_CLANG)
+    #define INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT(msg,fixit) __attribute__((deprecated(msg,fixit)))
+    #define INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE(msg)
+  #else // GNU
+    #define INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT(msg,fixit)
+    #define INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE(msg) __attribute__((deprecated(msg)))
+    // see https://gcc.gnu.org/onlinedocs/gcc-4.9.0/gcc/Function-Attributes.html
   #endif
+#else
+  #define INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT(msg,fixit)
+  #define INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE(msg) __attribute__((deprecated(msg)))
 #endif
   /**
    \brief scalar type traits

--- a/packages/intrepid2/src/Shared/Intrepid2_Utils.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_Utils.hpp
@@ -53,7 +53,7 @@
 #include "Intrepid2_Types.hpp"
 
 #include "Kokkos_Core.hpp"
-
+#include "Kokkos_Macros.hpp" // provides some preprocessor values used in definitions of INTREPID2_DEPRECATED, etc.
 
 namespace Intrepid2 {
 
@@ -107,7 +107,36 @@ namespace Intrepid2 {
     Kokkos::abort(  "[Intrepid2] Abort\n");                             \
   }
 #endif
-
+  
+// adapted from Kokkos_Macros.hpp
+#if (defined(KOKKOS_ENABLE_CXX14) || defined(KOKKOS_ENABLE_CXX17) || defined(KOKKOS_ENABLE_CXX20))
+  #define INTREPID2_DEPRECATED [[deprecated]]
+  #define INTREPID2_DEPRECATED_MESSAGE(msg) [[deprecated(msg)]]
+  #define INTREPID2_DEPRECATED_TRAILING_ATTRIBUTE
+  #define INTREPID2_DEPRECATED_MESSAGE_TRAILING_ATTRIBUTE(msg)
+  #define INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE(msg,fixit)
+#else
+  #if defined(KOKKOS_COMPILER_GNU) || defined(KOKKOS_COMPILER_CLANG)
+    #define INTREPID2_DEPRECATED
+    #define INTREPID2_DEPRECATED_MESSAGE(msg)
+    #define INTREPID2_DEPRECATED_TRAILING_ATTRIBUTE              __attribute__((deprecated))
+    #define INTREPID2_DEPRECATED_MESSAGE_TRAILING_ATTRIBUTE(msg) __attribute__((deprecated(msg)))
+    #if defined(KOKKOS_COMPILER_CLANG)
+      #define INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE(msg,fixit) __attribute__((deprecated(msg,fixit)))
+      // see https://clang.llvm.org/docs/AttributeReference.html#deprecated
+    #else // GNU
+      // GNU doesn't support the replacement argument, so we drop that
+      #define INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE(msg,fixit) __attribute__((deprecated(msg)))
+      // see https://gcc.gnu.org/onlinedocs/gcc-4.9.0/gcc/Function-Attributes.html
+    #endif
+  #else
+    #define INTREPID2_DEPRECATED
+    #define INTREPID2_DEPRECATED_MESSAGE(msg)
+    #define INTREPID2_DEPRECATED_TRAILING_ATTRIBUTE
+    #define INTREPID2_DEPRECATED_MESSAGE_TRAILING_ATTRIBUTE(msg)
+    #define INTREPID2_DEPRECATED_MESSAGE_REPLACEMENT_TRAILING_ATTRIBUTE(msg,fixit)
+  #endif
+#endif
   /**
    \brief scalar type traits
   */ 

--- a/packages/intrepid2/src/Shared/Intrepid2_Utils.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_Utils.hpp
@@ -114,9 +114,16 @@ namespace Intrepid2 {
     #define INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT(msg,fixit) __attribute__((deprecated(msg,fixit)))
     #define INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE(msg)
   #else // GNU
-    #define INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT(msg,fixit) __attribute__ ((deprecated(msg)))
-    #define INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE(msg)
-    // see https://gcc.gnu.org/onlinedocs/gcc-4.9.0/gcc/Function-Attributes.html
+    #if not defined(KOKKOS_ENABLE_CUDA)
+      #define INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT(msg,fixit) __attribute__ ((deprecated(msg)))
+      #define INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE(msg)
+      // see https://gcc.gnu.org/onlinedocs/gcc-4.9.0/gcc/Function-Attributes.html
+    #else // GNU + CUDA
+      // for unknown reasons, the CUDA compilers seem to have trouble with this gcc feature
+      // we therefore disable typedef deprecation warnings on CUDA
+      #define INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT(msg,fixit)
+      #define INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE(msg)
+    #endif
   #endif
 #else
   // don't issue deprecation warnings on compilers other than gcc and clang (this is not part of the C++11 standard; it is compiler-specific)

--- a/packages/intrepid2/src/Shared/Intrepid2_Utils.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_Utils.hpp
@@ -109,26 +109,19 @@ namespace Intrepid2 {
 #endif
   
 // adapted from Kokkos_Macros.hpp
-// adapted from Kokkos_Macros.hpp
 #if defined(KOKKOS_COMPILER_GNU) || defined(KOKKOS_COMPILER_CLANG)
   #if defined(KOKKOS_COMPILER_CLANG)
     #define INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT(msg,fixit) __attribute__((deprecated(msg,fixit)))
     #define INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE(msg)
   #else // GNU
-    #if not defined(KOKKOS_ENABLE_CUDA)
-      #define INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT(msg,fixit)
-      #define INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE(msg) __attribute__((deprecated(msg)))
-      // see https://gcc.gnu.org/onlinedocs/gcc-4.9.0/gcc/Function-Attributes.html
-    #else
-      // for unknown reasons, the CUDA compilers seem to have trouble with this gcc feature
-      // we therefore disable typedef deprecation warnings on CUDA
-      #define INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT(msg,fixit)
-      #define INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE(msg)
-    #endif
+    #define INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT(msg,fixit) __attribute__ ((deprecated(msg)))
+    #define INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE(msg)
+    // see https://gcc.gnu.org/onlinedocs/gcc-4.9.0/gcc/Function-Attributes.html
   #endif
 #else
+  // don't issue deprecation warnings on compilers other than gcc and clang (this is not part of the C++11 standard; it is compiler-specific)
   #define INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT(msg,fixit)
-  #define INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE(msg) __attribute__((deprecated(msg)))
+  #define INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE(msg) 
 #endif
   /**
    \brief scalar type traits

--- a/packages/intrepid2/src/Shared/Intrepid2_Utils.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_Utils.hpp
@@ -123,7 +123,7 @@ namespace Intrepid2 {
       // for unknown reasons, the CUDA compilers seem to have trouble with this gcc feature
       // we therefore disable typedef deprecation warnings on CUDA
       #define INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT(msg,fixit)
-      #define INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE(msg) __attribute__((deprecated(msg)))
+      #define INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE(msg)
     #endif
   #endif
 #else

--- a/packages/intrepid2/unit-test/Cell/test_06.hpp
+++ b/packages/intrepid2/unit-test/Cell/test_06.hpp
@@ -68,16 +68,16 @@ namespace Intrepid2 {
       *outStream << "-------------------------------------------------------------------------------" << "\n\n"; \
     };                                                                  
 
-    template<typename outputViewType,
+    template<typename OutputViewType,
              typename inputViewType,
              typename worksetViewType>
     struct F_mapToPhysicalFrame {
-      outputViewType _output;
+      OutputViewType _output;
       inputViewType _input;
       worksetViewType _workset;
 
       KOKKOS_INLINE_FUNCTION
-      F_mapToPhysicalFrame(outputViewType output_,
+      F_mapToPhysicalFrame(OutputViewType output_,
                            inputViewType input_,
                            worksetViewType workset_) 
         : _output(output_), 
@@ -102,17 +102,17 @@ namespace Intrepid2 {
       }
     };
 
-    template<typename outputViewType,
+    template<typename OutputViewType,
              typename inputViewType,
              typename worksetViewType>      
     struct F_mapToReferenceFrame {
-      outputViewType _output;
+      OutputViewType _output;
       inputViewType _input;
       worksetViewType _workset;
 
 
       KOKKOS_INLINE_FUNCTION
-      F_mapToReferenceFrame(outputViewType output_,
+      F_mapToReferenceFrame(OutputViewType output_,
                             inputViewType input_,
                             worksetViewType workset_) 
         : _output(output_), 

--- a/packages/intrepid2/unit-test/Cell/test_07.hpp
+++ b/packages/intrepid2/unit-test/Cell/test_07.hpp
@@ -105,16 +105,16 @@ namespace Intrepid2 {
     }                                                                   \
       
     template<typename cellTopologyTagType,
-             typename outputViewType,
+             typename OutputViewType,
              typename inputViewType>
     struct F_checkPointInclusion {
       double _offset;
-      outputViewType _output;
+      OutputViewType _output;
       inputViewType _input;
 
       KOKKOS_INLINE_FUNCTION
       F_checkPointInclusion(const double offset_, 
-                            outputViewType output_,
+                            OutputViewType output_,
                             inputViewType input_)
         : _offset(offset_), 
           _output(output_), 

--- a/packages/intrepid2/unit-test/Discretization/Basis/HCURL_HEX_I1_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HCURL_HEX_I1_FEM/test_01.hpp
@@ -551,6 +551,35 @@ namespace Intrepid2 {
         errorFlag = -1000;
       };
       
+      *outStream
+      << "\n"
+      << "===============================================================================\n"
+      << "| TEST 5: Function Space is Correct                                           |\n"
+      << "===============================================================================\n";
+      
+      try {
+        const EFunctionSpace fs = hexBasis.getFunctionSpace();
+        
+        if (fs != FUNCTION_SPACE_HCURL)
+        {
+          *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+          
+          // Output the multi-index of the value where the error is:
+          *outStream << " Expected a function space of FUNCTION_SPACE_HCURL (enum value " << FUNCTION_SPACE_HCURL << "),";
+          *outStream << " but got " << fs << "\n";
+          if (fs == FUNCTION_SPACE_MAX)
+          {
+            *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+          }
+          errorFlag++;
+        }
+      } catch (std::logic_error err){
+        *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+        *outStream << err.what() << '\n';
+        *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+        errorFlag = -1000;
+      }
+      
       if (errorFlag != 0)
         std::cout << "End Result: TEST FAILED\n";
       else

--- a/packages/intrepid2/unit-test/Discretization/Basis/HCURL_HEX_In_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HCURL_HEX_In_FEM/test_01.hpp
@@ -523,6 +523,38 @@ int HCURL_HEX_In_FEM_Test01(const bool verbose) {
     errorFlag = -1000;
   };
 
+  *outStream
+  << "\n"
+  << "===============================================================================\n"
+  << "| TEST 5: Function Space is Correct                                           |\n"
+  << "===============================================================================\n";
+  
+  try {
+    const ordinal_type order = std::min(3, maxOrder);
+    HexBasisType hexBasis(order);
+    
+    const EFunctionSpace fs = hexBasis.getFunctionSpace();
+    
+    if (fs != FUNCTION_SPACE_HCURL)
+    {
+      *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+      
+      // Output the multi-index of the value where the error is:
+      *outStream << " Expected a function space of FUNCTION_SPACE_HCURL (enum value " << FUNCTION_SPACE_HCURL << "),";
+      *outStream << " but got " << fs << "\n";
+      if (fs == FUNCTION_SPACE_MAX)
+      {
+        *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+      }
+      errorFlag++;
+    }
+  } catch (std::logic_error err){
+    *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+    *outStream << err.what() << '\n';
+    *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+    errorFlag = -1000;
+  }
+
   if (errorFlag != 0)
     std::cout << "End Result: TEST FAILED\n";
   else

--- a/packages/intrepid2/unit-test/Discretization/Basis/HCURL_QUAD_I1_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HCURL_QUAD_I1_FEM/test_01.hpp
@@ -448,6 +448,35 @@ namespace Intrepid2 {
         errorFlag = -1000;
       }
   
+      *outStream
+      << "\n"
+      << "===============================================================================\n"
+      << "| TEST 5: Function Space is Correct                                           |\n"
+      << "===============================================================================\n";
+      
+      try {
+        const EFunctionSpace fs = quadBasis.getFunctionSpace();
+        
+        if (fs != FUNCTION_SPACE_HCURL)
+        {
+          *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+          
+          // Output the multi-index of the value where the error is:
+          *outStream << " Expected a function space of FUNCTION_SPACE_HCURL (enum value " << FUNCTION_SPACE_HCURL << "),";
+          *outStream << " but got " << fs << "\n";
+          if (fs == FUNCTION_SPACE_MAX)
+          {
+            *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+          }
+          errorFlag++;
+        }
+      } catch (std::logic_error err){
+        *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+        *outStream << err.what() << '\n';
+        *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+        errorFlag = -1000;
+      }
+      
       if (errorFlag != 0)
         std::cout << "End Result: TEST FAILED\n";
       else

--- a/packages/intrepid2/unit-test/Discretization/Basis/HCURL_QUAD_In_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HCURL_QUAD_In_FEM/test_01.hpp
@@ -525,6 +525,38 @@ int HCURL_QUAD_In_FEM_Test01(const bool verbose) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   }
+  
+  *outStream
+  << "\n"
+  << "===============================================================================\n"
+  << "| TEST 5: Function Space is Correct                                           |\n"
+  << "===============================================================================\n";
+  
+  try {
+    const ordinal_type order = std::min(3, maxOrder);
+    QuadBasisType quadBasis(order);
+    
+    const EFunctionSpace fs = quadBasis.getFunctionSpace();
+    
+    if (fs != FUNCTION_SPACE_HCURL)
+    {
+      *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+      
+      // Output the multi-index of the value where the error is:
+      *outStream << " Expected a function space of FUNCTION_SPACE_HCURL (enum value " << FUNCTION_SPACE_HCURL << "),";
+      *outStream << " but got " << fs << "\n";
+      if (fs == FUNCTION_SPACE_MAX)
+      {
+        *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+      }
+      errorFlag++;
+    }
+  } catch (std::logic_error err){
+    *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+    *outStream << err.what() << '\n';
+    *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+    errorFlag = -1000;
+  }
 
   if (errorFlag != 0)
     std::cout << "End Result: TEST FAILED\n";
@@ -537,31 +569,3 @@ int HCURL_QUAD_In_FEM_Test01(const bool verbose) {
 }
 }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/packages/intrepid2/unit-test/Discretization/Basis/HCURL_TET_I1_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HCURL_TET_I1_FEM/test_01.hpp
@@ -511,6 +511,35 @@ namespace Intrepid2 {
     errorFlag = -1000;
   };
 
+  *outStream
+  << "\n"
+  << "===============================================================================\n"
+  << "| TEST 5: Function Space is Correct                                           |\n"
+  << "===============================================================================\n";
+  
+  try {
+    const EFunctionSpace fs = tetBasis.getFunctionSpace();
+    
+    if (fs != FUNCTION_SPACE_HCURL)
+    {
+      *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+      
+      // Output the multi-index of the value where the error is:
+      *outStream << " Expected a function space of FUNCTION_SPACE_HCURL (enum value " << FUNCTION_SPACE_HCURL << "),";
+      *outStream << " but got " << fs << "\n";
+      if (fs == FUNCTION_SPACE_MAX)
+      {
+        *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+      }
+      errorFlag++;
+    }
+  } catch (std::logic_error err){
+    *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+    *outStream << err.what() << '\n';
+    *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+    errorFlag = -1000;
+  }
+      
   if (errorFlag != 0)
     std::cout << "End Result: TEST FAILED\n";
   else

--- a/packages/intrepid2/unit-test/Discretization/Basis/HCURL_TET_In_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HCURL_TET_In_FEM/test_01.hpp
@@ -455,6 +455,38 @@ int HCURL_TET_In_FEM_Test01(const bool verbose) {
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
     errorFlag = -1000;
   };
+  
+  *outStream
+  << "\n"
+  << "===============================================================================\n"
+  << "| TEST 5: Function Space is Correct                                           |\n"
+  << "===============================================================================\n";
+  
+  try {
+    const ordinal_type order = std::min(3, maxOrder);
+    TetBasisType tetBasis(order, POINTTYPE_WARPBLEND);
+    
+    const EFunctionSpace fs = tetBasis.getFunctionSpace();
+    
+    if (fs != FUNCTION_SPACE_HCURL)
+    {
+      *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+      
+      // Output the multi-index of the value where the error is:
+      *outStream << " Expected a function space of FUNCTION_SPACE_HCURL (enum value " << FUNCTION_SPACE_HCURL << "),";
+      *outStream << " but got " << fs << "\n";
+      if (fs == FUNCTION_SPACE_MAX)
+      {
+        *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+      }
+      errorFlag++;
+    }
+  } catch (std::logic_error err){
+    *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+    *outStream << err.what() << '\n';
+    *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+    errorFlag = -1000;
+  }
 
   if (errorFlag != 0)
     std::cout << "End Result: TEST FAILED\n";

--- a/packages/intrepid2/unit-test/Discretization/Basis/HCURL_TRI_I1_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HCURL_TRI_I1_FEM/test_01.hpp
@@ -460,6 +460,35 @@ namespace Intrepid2 {
     errorFlag = -1000;
   };
 
+  *outStream
+  << "\n"
+  << "===============================================================================\n"
+  << "| TEST 5: Function Space is Correct                                           |\n"
+  << "===============================================================================\n";
+  
+  try {
+    const EFunctionSpace fs = triBasis.getFunctionSpace();
+    
+    if (fs != FUNCTION_SPACE_HCURL)
+    {
+      *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+      
+      // Output the multi-index of the value where the error is:
+      *outStream << " Expected a function space of FUNCTION_SPACE_HCURL (enum value " << FUNCTION_SPACE_HCURL << "),";
+      *outStream << " but got " << fs << "\n";
+      if (fs == FUNCTION_SPACE_MAX)
+      {
+        *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+      }
+      errorFlag++;
+    }
+  } catch (std::logic_error err){
+    *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+    *outStream << err.what() << '\n';
+    *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+    errorFlag = -1000;
+  }
+      
   if (errorFlag != 0)
     std::cout << "End Result: TEST FAILED\n";
   else

--- a/packages/intrepid2/unit-test/Discretization/Basis/HCURL_TRI_In_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HCURL_TRI_In_FEM/test_01.hpp
@@ -551,6 +551,38 @@ int HCURL_TRI_In_FEM_Test01(const bool verbose) {
     errorFlag = -1000;
   };
 
+  *outStream
+  << "\n"
+  << "===============================================================================\n"
+  << "| TEST 6: Function Space is Correct                                           |\n"
+  << "===============================================================================\n";
+  
+  try {
+    const ordinal_type order = std::min(4, maxOrder);
+    TriBasisType triBasis(order, POINTTYPE_WARPBLEND);
+    
+    const EFunctionSpace fs = triBasis.getFunctionSpace();
+    
+    if (fs != FUNCTION_SPACE_HCURL)
+    {
+      *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+      
+      // Output the multi-index of the value where the error is:
+      *outStream << " Expected a function space of FUNCTION_SPACE_HCURL (enum value " << FUNCTION_SPACE_HCURL << "),";
+      *outStream << " but got " << fs << "\n";
+      if (fs == FUNCTION_SPACE_MAX)
+      {
+        *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+      }
+      errorFlag++;
+    }
+  } catch (std::logic_error err){
+    *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+    *outStream << err.what() << '\n';
+    *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+    errorFlag = -1000;
+  }
+  
   if (errorFlag != 0)
     std::cout << "End Result: TEST FAILED\n";
   else

--- a/packages/intrepid2/unit-test/Discretization/Basis/HCURL_WEDGE_I1_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HCURL_WEDGE_I1_FEM/test_01.hpp
@@ -439,6 +439,35 @@ namespace Test {
     errorFlag = -1000;
   };
 
+  *outStream
+  << "\n"
+  << "===============================================================================\n"
+  << "| TEST 4: Function Space is Correct                                           |\n"
+  << "===============================================================================\n";
+  
+  try {
+    const EFunctionSpace fs = wedgeBasis.getFunctionSpace();
+    
+    if (fs != FUNCTION_SPACE_HCURL)
+    {
+      *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+      
+      // Output the multi-index of the value where the error is:
+      *outStream << " Expected a function space of FUNCTION_SPACE_HCURL (enum value " << FUNCTION_SPACE_HCURL << "),";
+      *outStream << " but got " << fs << "\n";
+      if (fs == FUNCTION_SPACE_MAX)
+      {
+        *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+      }
+      errorFlag++;
+    }
+  } catch (std::logic_error err){
+    *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+    *outStream << err.what() << '\n';
+    *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+    errorFlag = -1000;
+  }
+    
   if (errorFlag != 0)
     std::cout << "End Result: TEST FAILED\n";
   else

--- a/packages/intrepid2/unit-test/Discretization/Basis/HDIV_HEX_I1_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HDIV_HEX_I1_FEM/test_01.hpp
@@ -497,6 +497,34 @@ namespace Intrepid2 {
         errorFlag = -1000;
       };
 
+      *outStream
+      << "\n"
+      << "===============================================================================\n"
+      << "| TEST 5: Function Space is Correct                                           |\n"
+      << "===============================================================================\n";
+      
+      try {
+        const EFunctionSpace fs = hexBasis.getFunctionSpace();
+        
+        if (fs != FUNCTION_SPACE_HDIV)
+        {
+          *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+          
+          // Output the multi-index of the value where the error is:
+          *outStream << " Expected a function space of FUNCTION_SPACE_HDIV (enum value " << FUNCTION_SPACE_HDIV << "),";
+          *outStream << " but got " << fs << "\n";
+          if (fs == FUNCTION_SPACE_MAX)
+          {
+            *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+          }
+          errorFlag++;
+        }
+      } catch (std::logic_error err){
+        *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+        *outStream << err.what() << '\n';
+        *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+        errorFlag = -1000;
+      }
       if (errorFlag != 0)
         std::cout << "End Result: TEST FAILED\n";
       else

--- a/packages/intrepid2/unit-test/Discretization/Basis/HDIV_HEX_In_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HDIV_HEX_In_FEM/test_01.hpp
@@ -518,6 +518,38 @@ int HDIV_HEX_In_FEM_Test01(const bool verbose) {
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
     errorFlag = -1000;
   };
+  
+  *outStream
+  << "\n"
+  << "===============================================================================\n"
+  << "| TEST 4: Function Space is Correct                                           |\n"
+  << "===============================================================================\n";
+  
+  try {
+    const ordinal_type order = 1;
+    HexBasisType hexBasis(order);
+    
+    const EFunctionSpace fs = hexBasis.getFunctionSpace();
+    
+    if (fs != FUNCTION_SPACE_HDIV)
+    {
+      *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+      
+      // Output the multi-index of the value where the error is:
+      *outStream << " Expected a function space of FUNCTION_SPACE_HDIV (enum value " << FUNCTION_SPACE_HDIV << "),";
+      *outStream << " but got " << fs << "\n";
+      if (fs == FUNCTION_SPACE_MAX)
+      {
+        *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+      }
+      errorFlag++;
+    }
+  } catch (std::logic_error err){
+    *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+    *outStream << err.what() << '\n';
+    *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+    errorFlag = -1000;
+  }
 
   if (errorFlag != 0)
     std::cout << "End Result: TEST FAILED\n";

--- a/packages/intrepid2/unit-test/Discretization/Basis/HDIV_QUAD_I1_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HDIV_QUAD_I1_FEM/test_01.hpp
@@ -454,6 +454,35 @@ namespace Intrepid2 {
         *outStream << err.what() << "\n\n";
         errorFlag = -1000;
       };
+      
+      *outStream
+      << "\n"
+      << "===============================================================================\n"
+      << "| TEST 4: Function Space is Correct                                           |\n"
+      << "===============================================================================\n";
+      
+      try {
+        const EFunctionSpace fs = quadBasis.getFunctionSpace();
+        
+        if (fs != FUNCTION_SPACE_HDIV)
+        {
+          *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+          
+          // Output the multi-index of the value where the error is:
+          *outStream << " Expected a function space of FUNCTION_SPACE_HDIV (enum value " << FUNCTION_SPACE_HDIV << "),";
+          *outStream << " but got " << fs << "\n";
+          if (fs == FUNCTION_SPACE_MAX)
+          {
+            *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+          }
+          errorFlag++;
+        }
+      } catch (std::logic_error err){
+        *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+        *outStream << err.what() << '\n';
+        *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+        errorFlag = -1000;
+      }
 
       if (errorFlag != 0)
         std::cout << "End Result: TEST FAILED\n";

--- a/packages/intrepid2/unit-test/Discretization/Basis/HDIV_QUAD_In_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HDIV_QUAD_In_FEM/test_01.hpp
@@ -414,7 +414,7 @@ int HDIV_QUAD_In_FEM_Test01(const bool verbose) {
   *outStream
   << "\n"
   << "===============================================================================\n"
-  << "| TEST 5: correctness of basis function values                                |\n"
+  << "| TEST 6: correctness of basis function values                                |\n"
   << "===============================================================================\n";
 
   outStream->precision(20);
@@ -518,6 +518,37 @@ int HDIV_QUAD_In_FEM_Test01(const bool verbose) {
     }
   } catch (std::logic_error err) {
     *outStream << err.what() << "\n\n";
+    errorFlag = -1000;
+  }
+  
+  *outStream
+  << "\n"
+  << "===============================================================================\n"
+  << "| TEST 7: Function Space is Correct                                           |\n"
+  << "===============================================================================\n";
+  
+  try {
+    const int order = 2;
+    QuadBasisType quadBasis(order);
+    const EFunctionSpace fs = quadBasis.getFunctionSpace();
+    
+    if (fs != FUNCTION_SPACE_HDIV)
+    {
+      *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+      
+      // Output the multi-index of the value where the error is:
+      *outStream << " Expected a function space of FUNCTION_SPACE_HDIV (enum value " << FUNCTION_SPACE_HDIV << "),";
+      *outStream << " but got " << fs << "\n";
+      if (fs == FUNCTION_SPACE_MAX)
+      {
+        *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+      }
+      errorFlag++;
+    }
+  } catch (std::logic_error err){
+    *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+    *outStream << err.what() << '\n';
+    *outStream << "-------------------------------------------------------------------------------" << "\n\n";
     errorFlag = -1000;
   }
 

--- a/packages/intrepid2/unit-test/Discretization/Basis/HDIV_TET_I1_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HDIV_TET_I1_FEM/test_01.hpp
@@ -448,6 +448,35 @@ namespace Intrepid2 {
         *outStream << err.what() << "\n\n";
         errorFlag = -1000;
       };
+      
+      *outStream
+      << "\n"
+      << "===============================================================================\n"
+      << "| TEST 5: Function Space is Correct                                           |\n"
+      << "===============================================================================\n";
+      
+      try {
+        const EFunctionSpace fs = tetBasis.getFunctionSpace();
+        
+        if (fs != FUNCTION_SPACE_HDIV)
+        {
+          *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+          
+          // Output the multi-index of the value where the error is:
+          *outStream << " Expected a function space of FUNCTION_SPACE_HDIV (enum value " << FUNCTION_SPACE_HDIV << "),";
+          *outStream << " but got " << fs << "\n";
+          if (fs == FUNCTION_SPACE_MAX)
+          {
+            *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+          }
+          errorFlag++;
+        }
+      } catch (std::logic_error err){
+        *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+        *outStream << err.what() << '\n';
+        *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+        errorFlag = -1000;
+      }
   
      if (errorFlag != 0)
        std::cout << "End Result: TEST FAILED\n";

--- a/packages/intrepid2/unit-test/Discretization/Basis/HDIV_TET_In_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HDIV_TET_In_FEM/test_01.hpp
@@ -673,6 +673,38 @@ int HDIV_TET_In_FEM_Test01(const bool verbose) {
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
     errorFlag = -1000;
   };
+  
+  *outStream
+  << "\n"
+  << "===============================================================================\n"
+  << "| TEST 5: Function Space is Correct                                           |\n"
+  << "===============================================================================\n";
+  
+  try {
+    const ordinal_type order = std::min(4, maxOrder);
+    TetBasisType tetBasis(order, POINTTYPE_EQUISPACED);
+    
+    const EFunctionSpace fs = tetBasis.getFunctionSpace();
+    
+    if (fs != FUNCTION_SPACE_HDIV)
+    {
+      *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+      
+      // Output the multi-index of the value where the error is:
+      *outStream << " Expected a function space of FUNCTION_SPACE_HDIV (enum value " << FUNCTION_SPACE_HDIV << "),";
+      *outStream << " but got " << fs << "\n";
+      if (fs == FUNCTION_SPACE_MAX)
+      {
+        *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+      }
+      errorFlag++;
+    }
+  } catch (std::logic_error err){
+    *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+    *outStream << err.what() << '\n';
+    *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+    errorFlag = -1000;
+  }
 
   if (errorFlag != 0)
     std::cout << "End Result: TEST FAILED\n";

--- a/packages/intrepid2/unit-test/Discretization/Basis/HDIV_TRI_I1_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HDIV_TRI_I1_FEM/test_01.hpp
@@ -460,6 +460,35 @@ namespace Intrepid2 {
          *outStream << err.what() << "\n\n";
          errorFlag = -1000;
        };
+      
+      *outStream
+      << "\n"
+      << "===============================================================================\n"
+      << "| TEST 5: Function Space is Correct                                           |\n"
+      << "===============================================================================\n";
+      
+      try {
+        const EFunctionSpace fs = triBasis.getFunctionSpace();
+        
+        if (fs != FUNCTION_SPACE_HDIV)
+        {
+          *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+          
+          // Output the multi-index of the value where the error is:
+          *outStream << " Expected a function space of FUNCTION_SPACE_HDIV (enum value " << FUNCTION_SPACE_HDIV << "),";
+          *outStream << " but got " << fs << "\n";
+          if (fs == FUNCTION_SPACE_MAX)
+          {
+            *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+          }
+          errorFlag++;
+        }
+      } catch (std::logic_error err){
+        *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+        *outStream << err.what() << '\n';
+        *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+        errorFlag = -1000;
+      }
 
       if (errorFlag != 0)
         std::cout << "End Result: TEST FAILED\n";

--- a/packages/intrepid2/unit-test/Discretization/Basis/HDIV_TRI_I1_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HDIV_TRI_I1_FEM/test_01.hpp
@@ -120,8 +120,8 @@ namespace Intrepid2 {
       typedef ValueType outputValueType;
       typedef ValueType pointValueType;
       Basis_HDIV_TRI_I1_FEM<DeviceSpaceType,outputValueType,pointValueType> triBasis;
-      //typedef typename decltype(triBasis)::outputViewType outputViewType;
-      //typedef typename decltype(triBasis)::pointViewType  pointViewType;
+      //typedef typename decltype(triBasis)::OutputViewType OutputViewType;
+      //typedef typename decltype(triBasis)::PointViewType  PointViewType;
 
       *outStream
         << "\n"

--- a/packages/intrepid2/unit-test/Discretization/Basis/HDIV_TRI_In_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HDIV_TRI_In_FEM/test_01.hpp
@@ -467,6 +467,38 @@ int HDIV_TRI_In_FEM_Test01(const bool verbose) {
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
     errorFlag = -1000;
   };
+  
+  *outStream
+  << "\n"
+  << "===============================================================================\n"
+  << "| TEST 5: Function Space is Correct                                           |\n"
+  << "===============================================================================\n";
+  
+  try {
+    const ordinal_type order = std::min(4, maxOrder);
+    TriBasisType triBasis(order, POINTTYPE_EQUISPACED);
+    
+    const EFunctionSpace fs = triBasis.getFunctionSpace();
+    
+    if (fs != FUNCTION_SPACE_HDIV)
+    {
+      *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+      
+      // Output the multi-index of the value where the error is:
+      *outStream << " Expected a function space of FUNCTION_SPACE_HDIV (enum value " << FUNCTION_SPACE_HDIV << "),";
+      *outStream << " but got " << fs << "\n";
+      if (fs == FUNCTION_SPACE_MAX)
+      {
+        *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+      }
+      errorFlag++;
+    }
+  } catch (std::logic_error err){
+    *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+    *outStream << err.what() << '\n';
+    *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+    errorFlag = -1000;
+  }
 
   if (errorFlag != 0)
     std::cout << "End Result: TEST FAILED\n";

--- a/packages/intrepid2/unit-test/Discretization/Basis/HDIV_WEDGE_I1_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HDIV_WEDGE_I1_FEM/test_01.hpp
@@ -461,6 +461,35 @@ int HDIV_WEDGE_I1_FEM_Test01(const bool verbose) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   }
+  
+  *outStream
+  << "\n"
+  << "===============================================================================\n"
+  << "| TEST 5: Function Space is Correct                                           |\n"
+  << "===============================================================================\n";
+  
+  try {
+    const EFunctionSpace fs = wedgeBasis.getFunctionSpace();
+    
+    if (fs != FUNCTION_SPACE_HDIV)
+    {
+      *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+      
+      // Output the multi-index of the value where the error is:
+      *outStream << " Expected a function space of FUNCTION_SPACE_HDIV (enum value " << FUNCTION_SPACE_HDIV << "),";
+      *outStream << " but got " << fs << "\n";
+      if (fs == FUNCTION_SPACE_MAX)
+      {
+        *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+      }
+      errorFlag++;
+    }
+  } catch (std::logic_error err){
+    *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+    *outStream << err.what() << '\n';
+    *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+    errorFlag = -1000;
+  }
 
   if (errorFlag != 0)
     std::cout << "End Result: TEST FAILED\n";

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_HEX_C1_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_HEX_C1_FEM/test_01.hpp
@@ -731,6 +731,35 @@ namespace Intrepid2 {
         errorFlag = -1000;
       };
 
+      *outStream
+      << "\n"
+      << "===============================================================================\n"
+      << "| TEST 5: Function Space is Correct                                           |\n"
+      << "===============================================================================\n";
+      
+      try {
+        const EFunctionSpace fs = hexBasis.getFunctionSpace();
+        
+        if (fs != FUNCTION_SPACE_HGRAD)
+        {
+          *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+          
+          // Output the multi-index of the value where the error is:
+          *outStream << " Expected a function space of FUNCTION_SPACE_HGRAD (enum value " << FUNCTION_SPACE_HGRAD << "),";
+          *outStream << " but got " << fs << "\n";
+          if (fs == FUNCTION_SPACE_MAX)
+          {
+            *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+          }
+          errorFlag++;
+        }
+      } catch (std::logic_error err){
+        *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+        *outStream << err.what() << '\n';
+        *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+        errorFlag = -1000;
+      }
+      
       if (errorFlag != 0)
         std::cout << "End Result: TEST FAILED\n";
       else

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_HEX_C1_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_HEX_C1_FEM/test_01.hpp
@@ -119,8 +119,8 @@ namespace Intrepid2 {
       typedef ValueType outputValueType;
       typedef ValueType pointValueType;
       Basis_HGRAD_HEX_C1_FEM<DeviceSpaceType,outputValueType,pointValueType> hexBasis;
-      //typedef typename decltype(hexBasis)::outputViewType outputViewType;
-      //typedef typename decltype(hexBasis)::pointViewType  pointViewType;
+      //typedef typename decltype(hexBasis)::OutputViewType OutputViewType;
+      //typedef typename decltype(hexBasis)::PointViewType  PointViewType;
 
       *outStream
         << "\n"

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_HEX_C2_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_HEX_C2_FEM/test_01.hpp
@@ -739,6 +739,35 @@ namespace Intrepid2 {
         errorFlag = -1000;
       };
 
+      *outStream
+      << "\n"
+      << "===============================================================================\n"
+      << "| TEST 5: Function Space is Correct                                           |\n"
+      << "===============================================================================\n";
+      
+      try {
+        const EFunctionSpace fs = hexBasis.getFunctionSpace();
+        
+        if (fs != FUNCTION_SPACE_HGRAD)
+        {
+          *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+          
+          // Output the multi-index of the value where the error is:
+          *outStream << " Expected a function space of FUNCTION_SPACE_HGRAD (enum value " << FUNCTION_SPACE_HGRAD << "),";
+          *outStream << " but got " << fs << "\n";
+          if (fs == FUNCTION_SPACE_MAX)
+          {
+            *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+          }
+          errorFlag++;
+        }
+      } catch (std::logic_error err){
+        *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+        *outStream << err.what() << '\n';
+        *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+        errorFlag = -1000;
+      }
+      
       if (errorFlag != 0)
         std::cout << "End Result: TEST FAILED\n";
       else

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_HEX_C2_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_HEX_C2_FEM/test_01.hpp
@@ -122,8 +122,8 @@ namespace Intrepid2 {
       typedef ValueType outputValueType;
       typedef ValueType pointValueType;
       Basis_HGRAD_HEX_C2_FEM<DeviceSpaceType,outputValueType,pointValueType> hexBasis;
-      //typedef typename decltype(hexBasis)::outputViewType outputViewType;
-      //typedef typename decltype(hexBasis)::pointViewType  pointViewType;
+      //typedef typename decltype(hexBasis)::OutputViewType OutputViewType;
+      //typedef typename decltype(hexBasis)::PointViewType  PointViewType;
 
       *outStream
         << "\n"

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_HEX_Cn_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_HEX_Cn_FEM/test_01.hpp
@@ -758,6 +758,38 @@ int HGRAD_HEX_Cn_FEM_Test01(const bool verbose) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
+  
+  *outStream
+  << "\n"
+  << "===============================================================================\n"
+  << "| TEST 5: Function Space is Correct                                           |\n"
+  << "===============================================================================\n";
+  
+  try {
+    constexpr ordinal_type order = 2;
+    HexBasisType hexBasis(order);
+    
+    const EFunctionSpace fs = hexBasis.getFunctionSpace();
+    
+    if (fs != FUNCTION_SPACE_HGRAD)
+    {
+      *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+      
+      // Output the multi-index of the value where the error is:
+      *outStream << " Expected a function space of FUNCTION_SPACE_HGRAD (enum value " << FUNCTION_SPACE_HGRAD << "),";
+      *outStream << " but got " << fs << "\n";
+      if (fs == FUNCTION_SPACE_MAX)
+      {
+        *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+      }
+      errorFlag++;
+    }
+  } catch (std::logic_error err){
+    *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+    *outStream << err.what() << '\n';
+    *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+    errorFlag = -1000;
+  }
 
   if (errorFlag != 0)
     std::cout << "End Result: TEST FAILED\n";

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_LINE_C1_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_LINE_C1_FEM/test_01.hpp
@@ -419,6 +419,35 @@ namespace Intrepid2 {
         *outStream << "-------------------------------------------------------------------------------" << "\n\n";
         errorFlag = -1000;
       };
+      
+      *outStream
+      << "\n"
+      << "===============================================================================\n"
+      << "| TEST 4: Function Space is Correct                                           |\n"
+      << "===============================================================================\n";
+      
+      try {
+        const EFunctionSpace fs = lineBasis.getFunctionSpace();
+        
+        if (fs != FUNCTION_SPACE_HGRAD)
+        {
+          *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+          
+          // Output the multi-index of the value where the error is:
+          *outStream << " Expected a function space of FUNCTION_SPACE_HGRAD (enum value " << FUNCTION_SPACE_HGRAD << "),";
+          *outStream << " but got " << fs << "\n";
+          if (fs == FUNCTION_SPACE_MAX)
+          {
+            *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+          }
+          errorFlag++;
+        }
+      } catch (std::logic_error err){
+        *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+        *outStream << err.what() << '\n';
+        *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+        errorFlag = -1000;
+      }
 
       if (errorFlag != 0)
         std::cout << "End Result: TEST FAILED\n";

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_LINE_C1_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_LINE_C1_FEM/test_01.hpp
@@ -121,8 +121,8 @@ namespace Intrepid2 {
       typedef ValueType outputValueType;
       typedef ValueType pointValueType;
       Basis_HGRAD_LINE_C1_FEM<DeviceSpaceType,outputValueType,pointValueType> lineBasis;
-      //typedef typename decltype(lineBasis)::outputViewType outputViewType;
-      //typedef typename decltype(lineBasis)::pointViewType  pointViewType;
+      //typedef typename decltype(lineBasis)::OutputViewType OutputViewType;
+      //typedef typename decltype(lineBasis)::PointViewType  PointViewType;
 
       *outStream
         << "\n"

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_LINE_Cn_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_LINE_Cn_FEM/test_01.hpp
@@ -283,6 +283,38 @@ namespace Test {
         *outStream << err.what() << "\n\n";
         errorFlag = -1000;
       };
+      
+      *outStream
+      << "\n"
+      << "===============================================================================\n"
+      << "| TEST 3: Function Space is Correct                                           |\n"
+      << "===============================================================================\n";
+      
+      try {
+        int order = 2;
+        LineBasisType lineBasis(order);
+        
+        const EFunctionSpace fs = lineBasis.getFunctionSpace();
+        
+        if (fs != FUNCTION_SPACE_HGRAD)
+        {
+          *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+          
+          // Output the multi-index of the value where the error is:
+          *outStream << " Expected a function space of FUNCTION_SPACE_HGRAD (enum value " << FUNCTION_SPACE_HGRAD << "),";
+          *outStream << " but got " << fs << "\n";
+          if (fs == FUNCTION_SPACE_MAX)
+          {
+            *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+          }
+          errorFlag++;
+        }
+      } catch (std::logic_error err){
+        *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+        *outStream << err.what() << '\n';
+        *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+        errorFlag = -1000;
+      }
 
       if (errorFlag != 0)
         std::cout << "End Result: TEST FAILED\n";

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_LINE_Cn_FEM_JACOBI/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_LINE_Cn_FEM_JACOBI/test_01.hpp
@@ -486,6 +486,38 @@ namespace Intrepid2 {
         errorFlag = -1000;
       };
 
+      *outStream
+      << "\n"
+      << "===============================================================================\n"
+      << "| TEST 5: Function Space is Correct                                           |\n"
+      << "===============================================================================\n";
+      
+      try {
+        int order = 2;
+        const double alpha = 0.0, beta = 0.0;
+        LineBasisType lineBasis(order, alpha, beta);
+        
+        const EFunctionSpace fs = lineBasis.getFunctionSpace();
+        
+        if (fs != FUNCTION_SPACE_HGRAD)
+        {
+          *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+          
+          // Output the multi-index of the value where the error is:
+          *outStream << " Expected a function space of FUNCTION_SPACE_HGRAD (enum value " << FUNCTION_SPACE_HGRAD << "),";
+          *outStream << " but got " << fs << "\n";
+          if (fs == FUNCTION_SPACE_MAX)
+          {
+            *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+          }
+          errorFlag++;
+        }
+      } catch (std::logic_error err){
+        *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+        *outStream << err.what() << '\n';
+        *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+        errorFlag = -1000;
+      }
 
       if (errorFlag != 0)
         std::cout << "End Result: TEST FAILED\n";

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_PYR_C1_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_PYR_C1_FEM/test_01.hpp
@@ -500,6 +500,35 @@ namespace Intrepid2 {
        errorFlag = -1000;
      }
 
+     *outStream
+     << "\n"
+     << "===============================================================================\n"
+     << "| TEST 4: Function Space is Correct                                           |\n"
+     << "===============================================================================\n";
+     
+     try {
+       const EFunctionSpace fs = pyrBasis.getFunctionSpace();
+       
+       if (fs != FUNCTION_SPACE_HGRAD)
+       {
+         *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+         
+         // Output the multi-index of the value where the error is:
+         *outStream << " Expected a function space of FUNCTION_SPACE_HGRAD (enum value " << FUNCTION_SPACE_HGRAD << "),";
+         *outStream << " but got " << fs << "\n";
+         if (fs == FUNCTION_SPACE_MAX)
+         {
+           *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+         }
+         errorFlag++;
+       }
+     } catch (std::logic_error err){
+       *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+       *outStream << err.what() << '\n';
+       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+       errorFlag = -1000;
+     }
+      
      if (errorFlag != 0)
        std::cout << "End Result: TEST FAILED\n";
      else

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_QUAD_C1_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_QUAD_C1_FEM/test_01.hpp
@@ -554,6 +554,35 @@ namespace Intrepid2 {
         errorFlag = -1000;
       }
 
+      *outStream
+      << "\n"
+      << "===============================================================================\n"
+      << "| TEST 5: Function Space is Correct                                           |\n"
+      << "===============================================================================\n";
+      
+      try {
+        const EFunctionSpace fs = quadBasis.getFunctionSpace();
+        
+        if (fs != FUNCTION_SPACE_HGRAD)
+        {
+          *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+          
+          // Output the multi-index of the value where the error is:
+          *outStream << " Expected a function space of FUNCTION_SPACE_HGRAD (enum value " << FUNCTION_SPACE_HGRAD << "),";
+          *outStream << " but got " << fs << "\n";
+          if (fs == FUNCTION_SPACE_MAX)
+          {
+            *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+          }
+          errorFlag++;
+        }
+      } catch (std::logic_error err){
+        *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+        *outStream << err.what() << '\n';
+        *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+        errorFlag = -1000;
+      }
+      
       if (errorFlag != 0)
         std::cout << "End Result: TEST FAILED\n";
       else

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_QUAD_C1_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_QUAD_C1_FEM/test_01.hpp
@@ -120,8 +120,8 @@ namespace Intrepid2 {
       typedef ValueType outputValueType;
       typedef ValueType pointValueType;
       Basis_HGRAD_QUAD_C1_FEM<DeviceSpaceType,outputValueType,pointValueType> quadBasis;
-      //typedef typename decltype(quadBasis)::outputViewType outputViewType;
-      //typedef typename decltype(quadBasis)::pointViewType  pointViewType;
+      //typedef typename decltype(quadBasis)::OutputViewType OutputViewType;
+      //typedef typename decltype(quadBasis)::PointViewType  PointViewType;
 
       *outStream
         << "\n"

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_QUAD_C2_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_QUAD_C2_FEM/test_01.hpp
@@ -823,6 +823,35 @@ namespace Intrepid2 {
         errorFlag = -1000;
       };
 
+      *outStream
+      << "\n"
+      << "===============================================================================\n"
+      << "| TEST 5: Function Space is Correct                                           |\n"
+      << "===============================================================================\n";
+      
+      try {
+        const EFunctionSpace fs = quadBasis.getFunctionSpace();
+        
+        if (fs != FUNCTION_SPACE_HGRAD)
+        {
+          *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+          
+          // Output the multi-index of the value where the error is:
+          *outStream << " Expected a function space of FUNCTION_SPACE_HGRAD (enum value " << FUNCTION_SPACE_HGRAD << "),";
+          *outStream << " but got " << fs << "\n";
+          if (fs == FUNCTION_SPACE_MAX)
+          {
+            *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+          }
+          errorFlag++;
+        }
+      } catch (std::logic_error err){
+        *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+        *outStream << err.what() << '\n';
+        *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+        errorFlag = -1000;
+      }
+      
       if (errorFlag != 0)
         std::cout << "End Result: TEST FAILED\n";
       else

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_QUAD_C2_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_QUAD_C2_FEM/test_01.hpp
@@ -120,8 +120,8 @@ namespace Intrepid2 {
       typedef ValueType outputValueType;
       typedef ValueType pointValueType;
       Basis_HGRAD_QUAD_C2_FEM<DeviceSpaceType,outputValueType,pointValueType> quadBasis;
-      //typedef typename decltype(quadBasis)::outputViewType outputViewType;
-      //typedef typename decltype(quadBasis)::pointViewType  pointViewType;
+      //typedef typename decltype(quadBasis)::OutputViewType OutputViewType;
+      //typedef typename decltype(quadBasis)::PointViewType  PointViewType;
 
       *outStream
         << "\n"

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_QUAD_Cn_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_QUAD_Cn_FEM/test_01.hpp
@@ -850,7 +850,38 @@ int HGRAD_QUAD_Cn_FEM_Test01(const bool verbose) {
     errorFlag = -1000;
   };
 
-
+  *outStream
+  << "\n"
+  << "===============================================================================\n"
+  << "| TEST 4: Function Space is Correct                                           |\n"
+  << "===============================================================================\n";
+  
+  try {
+    const auto order = std::min(5, maxOrder);
+    QuadBasisType quadBasis(order);
+    
+    const EFunctionSpace fs = quadBasis.getFunctionSpace();
+    
+    if (fs != FUNCTION_SPACE_HGRAD)
+    {
+      *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+      
+      // Output the multi-index of the value where the error is:
+      *outStream << " Expected a function space of FUNCTION_SPACE_HGRAD (enum value " << FUNCTION_SPACE_HGRAD << "),";
+      *outStream << " but got " << fs << "\n";
+      if (fs == FUNCTION_SPACE_MAX)
+      {
+        *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+      }
+      errorFlag++;
+    }
+  } catch (std::logic_error err){
+    *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+    *outStream << err.what() << '\n';
+    *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+    errorFlag = -1000;
+  }
+  
   if (errorFlag != 0)
     std::cout << "End Result: TEST FAILED\n";
   else

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TET_C1_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TET_C1_FEM/test_01.hpp
@@ -508,6 +508,35 @@ namespace Intrepid2 {
        *outStream << err.what() << "\n\n";
        errorFlag = -1000;
      }
+      
+     *outStream
+     << "\n"
+     << "===============================================================================\n"
+     << "| TEST 5: Function Space is Correct                                           |\n"
+     << "===============================================================================\n";
+     
+     try {
+       const EFunctionSpace fs = tetBasis.getFunctionSpace();
+       
+       if (fs != FUNCTION_SPACE_HGRAD)
+       {
+         *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+         
+         // Output the multi-index of the value where the error is:
+         *outStream << " Expected a function space of FUNCTION_SPACE_HGRAD (enum value " << FUNCTION_SPACE_HGRAD << "),";
+         *outStream << " but got " << fs << "\n";
+         if (fs == FUNCTION_SPACE_MAX)
+         {
+           *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+         }
+         errorFlag++;
+       }
+     } catch (std::logic_error err){
+       *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+       *outStream << err.what() << '\n';
+       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+       errorFlag = -1000;
+     }
   
      if (errorFlag != 0)
        std::cout << "End Result: TEST FAILED\n";

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TET_C2_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TET_C2_FEM/test_01.hpp
@@ -551,6 +551,35 @@ namespace Test {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
+    
+  *outStream
+  << "\n"
+  << "===============================================================================\n"
+  << "| TEST 4: Function Space is Correct                                           |\n"
+  << "===============================================================================\n";
+  
+  try {
+    const EFunctionSpace fs = tetBasis.getFunctionSpace();
+    
+    if (fs != FUNCTION_SPACE_HGRAD)
+    {
+      *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+      
+      // Output the multi-index of the value where the error is:
+      *outStream << " Expected a function space of FUNCTION_SPACE_HGRAD (enum value " << FUNCTION_SPACE_HGRAD << "),";
+      *outStream << " but got " << fs << "\n";
+      if (fs == FUNCTION_SPACE_MAX)
+      {
+        *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+      }
+      errorFlag++;
+    }
+  } catch (std::logic_error err){
+    *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+    *outStream << err.what() << '\n';
+    *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+    errorFlag = -1000;
+  }
 
   if (errorFlag != 0)
     std::cout << "End Result: TEST FAILED\n";

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TET_COMP12_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TET_COMP12_FEM/test_01.hpp
@@ -465,6 +465,35 @@ namespace Intrepid2 {
         errorFlag = -1000;
       }
 
+      *outStream
+      << "\n"
+      << "===============================================================================\n"
+      << "| TEST 2: Function Space is Correct                                           |\n"
+      << "===============================================================================\n";
+      
+      try {
+        const EFunctionSpace fs = tetBasis.getFunctionSpace();
+        
+        if (fs != FUNCTION_SPACE_HGRAD)
+        {
+          *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+          
+          // Output the multi-index of the value where the error is:
+          *outStream << " Expected a function space of FUNCTION_SPACE_HGRAD (enum value " << FUNCTION_SPACE_HGRAD << "),";
+          *outStream << " but got " << fs << "\n";
+          if (fs == FUNCTION_SPACE_MAX)
+          {
+            *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+          }
+          errorFlag++;
+        }
+      } catch (std::logic_error err){
+        *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+        *outStream << err.what() << '\n';
+        *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+        errorFlag = -1000;
+      }
+      
       if (errorFlag != 0)
         std::cout << "End Result: TEST FAILED\n";
       else

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TET_Cn_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TET_Cn_FEM/test_01.hpp
@@ -311,6 +311,37 @@ int HGRAD_TET_Cn_FEM_Test01(const bool verbose) {
   };
 #endif
 
+  *outStream
+  << "\n"
+  << "===============================================================================\n"
+  << "| TEST 5: Function Space is Correct                                           |\n"
+  << "===============================================================================\n";
+  
+  try {
+    const ordinal_type order = std::min(2,maxOrder);
+    TetBasisType tetBasis(order, POINTTYPE_WARPBLEND);
+    
+    const EFunctionSpace fs = tetBasis.getFunctionSpace();
+    
+    if (fs != FUNCTION_SPACE_HGRAD)
+    {
+      *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+      
+      // Output the multi-index of the value where the error is:
+      *outStream << " Expected a function space of FUNCTION_SPACE_HGRAD (enum value " << FUNCTION_SPACE_HGRAD << "),";
+      *outStream << " but got " << fs << "\n";
+      if (fs == FUNCTION_SPACE_MAX)
+      {
+        *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+      }
+      errorFlag++;
+    }
+  } catch (std::logic_error err){
+    *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+    *outStream << err.what() << '\n';
+    *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+    errorFlag = -1000;
+  }
 
   if (errorFlag != 0)
     std::cout << "End Result: TEST FAILED\n";

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TET_Cn_FEM_ORTH/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TET_Cn_FEM_ORTH/test_01.hpp
@@ -630,9 +630,40 @@ int HGRAD_TET_Cn_FEM_ORTH_Test01(const bool verbose) {
     errorFlag = -1000;
   }
 
-  // second order derivatives test missing!!
- 
+  *outStream
+  << "\n"
+  << "===============================================================================\n"
+  << "| TEST 2: Function Space is Correct                                           |\n"
+  << "===============================================================================\n";
+  
+  try {
+    const ordinal_type order = std::min(3, maxOrder);
+    tetBasisType tetBasis(order);
+    
+    const EFunctionSpace fs = tetBasis.getFunctionSpace();
+    
+    if (fs != FUNCTION_SPACE_HGRAD)
+    {
+      *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+      
+      // Output the multi-index of the value where the error is:
+      *outStream << " Expected a function space of FUNCTION_SPACE_HGRAD (enum value " << FUNCTION_SPACE_HGRAD << "),";
+      *outStream << " but got " << fs << "\n";
+      if (fs == FUNCTION_SPACE_MAX)
+      {
+        *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+      }
+      errorFlag++;
+    }
+  } catch (std::logic_error err){
+    *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+    *outStream << err.what() << '\n';
+    *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+    errorFlag = -1000;
+  }
 
+  // second order derivatives test missing!!
+  
   if (errorFlag != 0)
     std::cout << "End Result: TEST FAILED\n";
   else

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TRI_C1_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TRI_C1_FEM/test_01.hpp
@@ -534,6 +534,36 @@ namespace Intrepid2 {
         errorFlag = -1000;
       };
 
+      *outStream
+      << "\n"
+      << "===============================================================================\n"
+      << "| TEST 5: Function Space is Correct                                           |\n"
+      << "===============================================================================\n";
+      
+      try {
+        const EFunctionSpace fs = triBasis.getFunctionSpace();
+        
+        if (fs != FUNCTION_SPACE_HGRAD)
+        {
+          *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+          
+          // Output the multi-index of the value where the error is:
+          *outStream << " Expected a function space of FUNCTION_SPACE_HGRAD (enum value " << FUNCTION_SPACE_HGRAD << "),";
+          *outStream << " but got " << fs << "\n";
+          if (fs == FUNCTION_SPACE_MAX)
+          {
+            *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+          }
+          errorFlag++;
+        }
+      } catch (std::logic_error err){
+        *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+        *outStream << err.what() << '\n';
+        *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+        errorFlag = -1000;
+      }
+      
+      
       if (errorFlag != 0)
         std::cout << "End Result: TEST FAILED\n";
       else

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TRI_C1_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TRI_C1_FEM/test_01.hpp
@@ -121,8 +121,8 @@ namespace Intrepid2 {
       typedef ValueType outputValueType;
       typedef ValueType pointValueType;
       Basis_HGRAD_TRI_C1_FEM<DeviceSpaceType,outputValueType,pointValueType> triBasis;
-      //typedef typename decltype(triBasis)::outputViewType outputViewType;
-      //typedef typename decltype(triBasis)::pointViewType  pointViewType;
+      //typedef typename decltype(triBasis)::OutputViewType OutputViewType;
+      //typedef typename decltype(triBasis)::PointViewType  PointViewType;
 
       *outStream
         << "\n"

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TRI_C2_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TRI_C2_FEM/test_01.hpp
@@ -524,6 +524,35 @@ namespace Intrepid2 {
         errorFlag = -1000;
       };
 
+      *outStream
+      << "\n"
+      << "===============================================================================\n"
+      << "| TEST 4: Function Space is Correct                                           |\n"
+      << "===============================================================================\n";
+      
+      try {
+        const EFunctionSpace fs = triBasis.getFunctionSpace();
+        
+        if (fs != FUNCTION_SPACE_HGRAD)
+        {
+          *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+          
+          // Output the multi-index of the value where the error is:
+          *outStream << " Expected a function space of FUNCTION_SPACE_HGRAD (enum value " << FUNCTION_SPACE_HGRAD << "),";
+          *outStream << " but got " << fs << "\n";
+          if (fs == FUNCTION_SPACE_MAX)
+          {
+            *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+          }
+          errorFlag++;
+        }
+      } catch (std::logic_error err){
+        *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+        *outStream << err.what() << '\n';
+        *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+        errorFlag = -1000;
+      }
+      
       if (errorFlag != 0)
         std::cout << "End Result: TEST FAILED\n";
       else

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TRI_C2_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TRI_C2_FEM/test_01.hpp
@@ -123,8 +123,8 @@ namespace Intrepid2 {
       typedef ValueType outputValueType;
       typedef ValueType pointValueType;
       Basis_HGRAD_TRI_C2_FEM<DeviceSpaceType,outputValueType,pointValueType> triBasis;
-      //typedef typename decltype(triBasis)::outputViewType outputViewType;
-      //typedef typename decltype(triBasis)::pointViewType  pointViewType;
+      //typedef typename decltype(triBasis)::OutputViewType OutputViewType;
+      //typedef typename decltype(triBasis)::PointViewType  PointViewType;
 
       *outStream
         << "\n"

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TRI_Cn_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TRI_Cn_FEM/test_01.hpp
@@ -267,6 +267,39 @@ namespace Intrepid2 {
         *outStream << "-------------------------------------------------------------------------------" << "\n\n";
         errorFlag = -1000;
       };
+      
+      *outStream
+      << "\n"
+      << "===============================================================================\n"
+      << "| TEST 4: Function Space is Correct                                           |\n"
+      << "===============================================================================\n";
+      
+      try {
+        for (auto order=1;order<std::min(3, maxOrder);++order) {
+          TriBasisType triBasis(order);
+          
+          const EFunctionSpace fs = triBasis.getFunctionSpace();
+          
+          if (fs != FUNCTION_SPACE_HGRAD)
+          {
+            *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+            
+            // Output the multi-index of the value where the error is:
+            *outStream << " Expected a function space of FUNCTION_SPACE_HGRAD (enum value " << FUNCTION_SPACE_HGRAD << "),";
+            *outStream << " but got " << fs << "\n";
+            if (fs == FUNCTION_SPACE_MAX)
+            {
+              *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+            }
+            errorFlag++;
+          }
+        }
+      } catch (std::logic_error err){
+        *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+        *outStream << err.what() << '\n';
+        *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+        errorFlag = -1000;
+      }
 
       if (errorFlag != 0)
         std::cout << "End Result: TEST FAILED\n";

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TRI_Cn_FEM_ORTH/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_TRI_Cn_FEM_ORTH/test_01.hpp
@@ -485,6 +485,40 @@ int HGRAD_TRI_Cn_FEM_ORTH_Test01(const bool verbose) {
     errorFlag = -1000;
   }
 #endif
+  
+  *outStream
+  << "\n"
+  << "===============================================================================\n"
+  << "| TEST 4: Function Space is Correct                                           |\n"
+  << "===============================================================================\n";
+  
+  try {
+    for (auto order=0;order<std::min(3, maxOrder);++order) {
+      triBasisType triBasis(order);
+      
+      const EFunctionSpace fs = triBasis.getFunctionSpace();
+      
+      if (fs != FUNCTION_SPACE_HGRAD)
+      {
+        *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+        
+        // Output the multi-index of the value where the error is:
+        *outStream << " Expected a function space of FUNCTION_SPACE_HGRAD (enum value " << FUNCTION_SPACE_HGRAD << "),";
+        *outStream << " but got " << fs << "\n";
+        if (fs == FUNCTION_SPACE_MAX)
+        {
+          *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+        }
+        errorFlag++;
+      }
+    }
+  } catch (std::logic_error err){
+    *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+    *outStream << err.what() << '\n';
+    *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+    errorFlag = -1000;
+  }
+  
   if (errorFlag != 0)
     std::cout << "End Result: TEST FAILED\n";
   else

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_WEDGE_C1_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_WEDGE_C1_FEM/test_01.hpp
@@ -578,6 +578,35 @@ namespace Intrepid2 {
         *outStream << err.what() << "\n\n";
         errorFlag = -1000;
       }
+      
+      *outStream
+      << "\n"
+      << "===============================================================================\n"
+      << "| TEST 5: Function Space is Correct                                           |\n"
+      << "===============================================================================\n";
+      
+      try {
+        const EFunctionSpace fs = wedgeBasis.getFunctionSpace();
+        
+        if (fs != FUNCTION_SPACE_HGRAD)
+        {
+          *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+          
+          // Output the multi-index of the value where the error is:
+          *outStream << " Expected a function space of FUNCTION_SPACE_HGRAD (enum value " << FUNCTION_SPACE_HGRAD << "),";
+          *outStream << " but got " << fs << "\n";
+          if (fs == FUNCTION_SPACE_MAX)
+          {
+            *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+          }
+          errorFlag++;
+        }
+      } catch (std::logic_error err){
+        *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+        *outStream << err.what() << '\n';
+        *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+        errorFlag = -1000;
+      }
   
       if (errorFlag != 0)
         std::cout << "End Result: TEST FAILED\n";

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_WEDGE_C2_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_WEDGE_C2_FEM/test_01.hpp
@@ -613,6 +613,35 @@ namespace Intrepid2 {
         errorFlag = -1000;
       }
 
+      *outStream
+      << "\n"
+      << "===============================================================================\n"
+      << "| TEST 4: Function Space is Correct                                           |\n"
+      << "===============================================================================\n";
+      
+      try {
+        const EFunctionSpace fs = wedgeBasis.getFunctionSpace();
+          
+        if (fs != FUNCTION_SPACE_HGRAD)
+        {
+          *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+          
+          // Output the multi-index of the value where the error is:
+          *outStream << " Expected a function space of FUNCTION_SPACE_HGRAD (enum value " << FUNCTION_SPACE_HGRAD << "),";
+          *outStream << " but got " << fs << "\n";
+          if (fs == FUNCTION_SPACE_MAX)
+          {
+            *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+          }
+          errorFlag++;
+        }
+      } catch (std::logic_error err){
+        *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+        *outStream << err.what() << '\n';
+        *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+        errorFlag = -1000;
+      }
+      
       if (errorFlag != 0)
         std::cout << "End Result: TEST FAILED\n";
       else

--- a/packages/intrepid2/unit-test/Discretization/Basis/HVOL_C0_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HVOL_C0_FEM/test_01.hpp
@@ -249,6 +249,39 @@ namespace Intrepid2 {
         errorFlag = -1000;
       };
 
+      *outStream
+      << "\n"
+      << "===============================================================================\n"
+      << "| TEST 4: Function Space is Correct                                           |\n"
+      << "===============================================================================\n";
+      
+      try {
+        for (ordinal_type id=0;id<6;++id) {
+          Basis_HVOL_C0_FEM<DeviceSpaceType,outputValueType,pointValueType> basis(cells[id]);
+          
+          const EFunctionSpace fs      = basis.getFunctionSpace();
+          
+          if (fs != FUNCTION_SPACE_HVOL)
+          {
+            *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+            
+            // Output the multi-index of the value where the error is:
+            *outStream << " Expected a function space of FUNCTION_SPACE_HVOL (enum value " << FUNCTION_SPACE_HVOL << "),";
+            *outStream << " but got " << fs << "\n";
+            if (fs == FUNCTION_SPACE_MAX)
+            {
+              *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+            }
+            errorFlag++;
+          }
+        }
+      } catch (std::logic_error err){
+        *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+        *outStream << err.what() << '\n';
+        *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+        errorFlag = -1000;
+      }
+      
       if (errorFlag != 0)
         std::cout << "End Result: TEST FAILED\n";
       else

--- a/packages/intrepid2/unit-test/Discretization/Basis/HVOL_HEX_Cn_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HVOL_HEX_Cn_FEM/test_01.hpp
@@ -355,6 +355,38 @@ int HVOL_HEX_Cn_FEM_Test01(const bool verbose) {
     errorFlag = -1000;
   };
 
+  *outStream
+  << "\n"
+  << "===============================================================================\n"
+  << "| TEST 4: Function Space is Correct                                           |\n"
+  << "===============================================================================\n";
+  
+  try {
+    for (auto ip=0;ip<std::min(5, maxOrder);++ip) {
+      HexBasisType hexBasis(ip);
+      
+      const EFunctionSpace fs = hexBasis.getFunctionSpace();
+      
+      if (fs != FUNCTION_SPACE_HVOL)
+      {
+        *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+        
+        // Output the multi-index of the value where the error is:
+        *outStream << " Expected a function space of FUNCTION_SPACE_HVOL (enum value " << FUNCTION_SPACE_HVOL << "),";
+        *outStream << " but got " << fs << "\n";
+        if (fs == FUNCTION_SPACE_MAX)
+        {
+          *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+        }
+        errorFlag++;
+      }
+    }
+  } catch (std::logic_error err){
+    *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+    *outStream << err.what() << '\n';
+    *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+    errorFlag = -1000;
+  }
 
 
   if (errorFlag != 0)

--- a/packages/intrepid2/unit-test/Discretization/Basis/HVOL_LINE_Cn_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HVOL_LINE_Cn_FEM/test_01.hpp
@@ -273,6 +273,39 @@ namespace Intrepid2 {
         *outStream << err.what() << "\n\n";
         errorFlag = -1000;
       };
+      
+      *outStream
+      << "\n"
+      << "===============================================================================\n"
+      << "| TEST 3: Function Space is Correct                                           |\n"
+      << "===============================================================================\n";
+      
+      try {
+        for (auto ip=0;ip<std::min(5, maxOrder);++ip) {
+          LineBasisType lineBasis(ip);
+          
+          const EFunctionSpace fs = lineBasis.getFunctionSpace();
+          
+          if (fs != FUNCTION_SPACE_HVOL)
+          {
+            *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+            
+            // Output the multi-index of the value where the error is:
+            *outStream << " Expected a function space of FUNCTION_SPACE_HVOL (enum value " << FUNCTION_SPACE_HVOL << "),";
+            *outStream << " but got " << fs << "\n";
+            if (fs == FUNCTION_SPACE_MAX)
+            {
+              *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+            }
+            errorFlag++;
+          }
+        }
+      } catch (std::logic_error err){
+        *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+        *outStream << err.what() << '\n';
+        *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+        errorFlag = -1000;
+      }
 
       if (errorFlag != 0)
         std::cout << "End Result: TEST FAILED\n";

--- a/packages/intrepid2/unit-test/Discretization/Basis/HVOL_QUAD_Cn_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HVOL_QUAD_Cn_FEM/test_01.hpp
@@ -349,7 +349,38 @@ namespace Intrepid2 {
         errorFlag = -1000;
       };
 
-
+      *outStream
+      << "\n"
+      << "===============================================================================\n"
+      << "| TEST 4: Function Space is Correct                                           |\n"
+      << "===============================================================================\n";
+      
+      try {
+        for (auto ip=0;ip<std::min(5, maxOrder);++ip) {
+          QuadBasisType quadBasis(ip);
+          
+          const EFunctionSpace fs = quadBasis.getFunctionSpace();
+          
+          if (fs != FUNCTION_SPACE_HVOL)
+          {
+            *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+            
+            // Output the multi-index of the value where the error is:
+            *outStream << " Expected a function space of FUNCTION_SPACE_HVOL (enum value " << FUNCTION_SPACE_HVOL << "),";
+            *outStream << " but got " << fs << "\n";
+            if (fs == FUNCTION_SPACE_MAX)
+            {
+              *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+            }
+            errorFlag++;
+          }
+        }
+      } catch (std::logic_error err){
+        *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+        *outStream << err.what() << '\n';
+        *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+        errorFlag = -1000;
+      }
 
       if (errorFlag != 0)
         std::cout << "End Result: TEST FAILED\n";

--- a/packages/intrepid2/unit-test/Discretization/Basis/HVOL_TET_Cn_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HVOL_TET_Cn_FEM/test_01.hpp
@@ -260,7 +260,39 @@ namespace Intrepid2 {
       };
 #endif
 
-
+      *outStream
+      << "\n"
+      << "===============================================================================\n"
+      << "| TEST 4: Function Space is Correct                                           |\n"
+      << "===============================================================================\n";
+      
+      try {
+        for (auto order=0;order<std::min(2, maxOrder);++order) {
+          TetBasisType tetBasis(order, POINTTYPE_WARPBLEND);
+          
+          const EFunctionSpace fs = tetBasis.getFunctionSpace();
+          
+          if (fs != FUNCTION_SPACE_HVOL)
+          {
+            *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+            
+            // Output the multi-index of the value where the error is:
+            *outStream << " Expected a function space of FUNCTION_SPACE_HVOL (enum value " << FUNCTION_SPACE_HVOL << "),";
+            *outStream << " but got " << fs << "\n";
+            if (fs == FUNCTION_SPACE_MAX)
+            {
+              *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+            }
+            errorFlag++;
+          }
+        }
+      } catch (std::logic_error err){
+        *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+        *outStream << err.what() << '\n';
+        *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+        errorFlag = -1000;
+      }
+      
 
       if (errorFlag != 0)
         std::cout << "End Result: TEST FAILED\n";

--- a/packages/intrepid2/unit-test/Discretization/Basis/HVOL_TRI_Cn_FEM/test_01.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HVOL_TRI_Cn_FEM/test_01.hpp
@@ -213,6 +213,39 @@ namespace Intrepid2 {
       };
 
 
+      *outStream
+      << "\n"
+      << "===============================================================================\n"
+      << "| TEST 3: Function Space is Correct                                           |\n"
+      << "===============================================================================\n";
+      
+      try {
+        for (auto order=0;order<std::min(3, maxOrder);++order) {
+          TriBasisType triBasis(order, POINTTYPE_WARPBLEND);
+          
+          const EFunctionSpace fs = triBasis.getFunctionSpace();
+          
+          if (fs != FUNCTION_SPACE_HVOL)
+          {
+            *outStream << std::setw(70) << "------------- TEST FAILURE! -------------" << "\n";
+            
+            // Output the multi-index of the value where the error is:
+            *outStream << " Expected a function space of FUNCTION_SPACE_HVOL (enum value " << FUNCTION_SPACE_HVOL << "),";
+            *outStream << " but got " << fs << "\n";
+            if (fs == FUNCTION_SPACE_MAX)
+            {
+              *outStream << "Note that this matches the default value defined by superclass, FUNCTION_SPACE_MAX.  Likely the subclass has failed to set the superclass functionSpace_ field.\n";
+            }
+            errorFlag++;
+          }
+        }
+      } catch (std::logic_error err){
+        *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
+        *outStream << err.what() << '\n';
+        *outStream << "-------------------------------------------------------------------------------" << "\n\n";
+        errorFlag = -1000;
+      }
+      
       if (errorFlag != 0)
         std::cout << "End Result: TEST FAILED\n";
       else

--- a/packages/muelu/test/unit_tests/IntrepidPCoarsenFactory.cpp
+++ b/packages/muelu/test/unit_tests/IntrepidPCoarsenFactory.cpp
@@ -674,8 +674,6 @@ namespace MueLuTests {
     typedef typename Teuchos::ScalarTraits<Scalar>::magnitudeType MT;
     typedef typename Teuchos::ScalarTraits<LocalOrdinal>::magnitudeType OT; // ordinal type
 
-    using namespace Kokkos;
-
     using namespace Kokkos::Experimental;
     typedef Kokkos::DynRankView<MT,typename Node::device_type> FC;
     typedef Kokkos::DynRankView<OT,typename Node::device_type> FCO; // FC of ordinals
@@ -742,8 +740,6 @@ namespace MueLuTests {
     typedef typename Node::device_type::execution_space ES;
     typedef typename Teuchos::ScalarTraits<Scalar>::magnitudeType MT;
     typedef typename Teuchos::ScalarTraits<LocalOrdinal>::magnitudeType OT; // ordinal type
-
-    using namespace Kokkos;
 
     using namespace Kokkos::Experimental;
     typedef Kokkos::DynRankView<MT,typename Node::device_type> FC;


### PR DESCRIPTION
@trilinos/intrepid2 

## Description
This PR:
1. adds an `EFunctionSpace` field to Basis, along with a getter, `getFunctionSpace()`.  It also:
2. adds typedefs for the ExecutionSpace and output/point value types,
3. adds typedef aliases that follow C++ camel-case class naming conventions (e.g. the existing `ebasis_view_type` gets an alias `EBasisViewType`),
4. defines a container `fieldOrdinalPolynomialDegree_` in the base class that will be useful for hierarchical bases that will be defined in a future PR, as well as the following related methods:
     - `getFieldOrdinalsForDegree()`
     - `getPolynomialDegreeOfField()`
     - `getPolynomialDegreeOfFieldAsVector()`
     - `getPolynomialDegreeLength()`

## Motivation and Context
1. The `getFunctionSpace()` addition essentially addresses an oversight in the prior implementation.  The new field is initialized in all existing Basis subclasses, and a test for correctness of the value has been added to existing Basis tests.
2. The typedef for ExecutionSpace and output/point value types enables template logic in derived classes without requiring the user to redundantly specify those fields; this will be used in the forthcoming PR with hierarchical basis support.
3. The typedef aliases are mainly a matter of taste and/or style; they allow me to style the code in the forthcoming PR the way that I would like.
4. One use case for hierarchical basis functions involves eliminating higher-order modes in the basis representation (in the context of limiters); another involves using the embedding feature to map from a higher-order basis to a lower-order basis.  For both of these use cases, being able to reason in code about the basis members of a specified degree is crucial.

## Checklist
- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.