### PR TITLE
CGNS: Move CGNS patch detection compile-time error to runtime warning

### DIFF
--- a/packages/seacas/libraries/ioss/src/cgns/Iocgns_ParallelDatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/cgns/Iocgns_ParallelDatabaseIO.C
@@ -184,11 +184,13 @@ namespace Iocgns {
 #if !defined(CGNS_SANDIA_PARALLEL_MODS)
     fmt::print("WARNING: The CGNS library being used in this executable does *NOT* have the "
                "CGNS-sandia.patch applied.\n"
-               "         This can result in very slow execution at large processor counts and can "
-               "possibly create\n"
+               "         This can result in hangs in parallel exeuctions or, with older versions,\n"
+	       "         very slow execution at large processor counts and can possibly create\n"
                "         CGNS files which are not readable by applications linked with older HDF5 "
                "libraries.\n"
-               "         contact gdsjaar@sandia.gov for additional info.\n");
+	       "         Note that in some cases, an older version of the patch has been applied\n"
+	       "         which does not define the symbol currently being used to detect the patch.\n"
+               "         Contact gdsjaar@sandia.gov for additional info.\n");
 #endif
 
 #if IOSS_DEBUG_OUTPUT

--- a/packages/seacas/libraries/ioss/src/cgns/Iocgns_ParallelDatabaseIO.C
+++ b/packages/seacas/libraries/ioss/src/cgns/Iocgns_ParallelDatabaseIO.C
@@ -56,9 +56,12 @@
 #include <cgnsconfig.h>
 #include <pcgnslib.h>
 
+#if 0
+// GDS: Temporarily disabled so SPARC can build inside Trilinos...
 #if !defined(CGNS_SANDIA_PARALLEL_MODS)
 #error                                                                                             \
     "At this time, CGNS must be patched using CGNS-sandia.patch; contact gdsjaar@sandia.gov for info"
+#endif
 #endif
 
 #if !defined(CGNSLIB_H)
@@ -177,6 +180,16 @@ namespace Iocgns {
   {
     usingParallelIO = true;
     dbState         = Ioss::STATE_UNKNOWN;
+
+#if !defined(CGNS_SANDIA_PARALLEL_MODS)
+    fmt::print("WARNING: The CGNS library being used in this executable does *NOT* have the "
+               "CGNS-sandia.patch applied.\n"
+               "         This can result in very slow execution at large processor counts and can "
+               "possibly create\n"
+               "         CGNS files which are not readable by applications linked with older HDF5 "
+               "libraries.\n"
+               "         contact gdsjaar@sandia.gov for additional info.\n");
+#endif
 
 #if IOSS_DEBUG_OUTPUT
     if (myProcessor == 0) {


### PR DESCRIPTION
The CGNS library is addressing parallel scalability issues and has started using
a compact storage method available in HDF5. This can speed up parallel execution
by around two orders of magnitude.  

Prior to this fix, the SEACAS/IOSS/CGNS implementation had its own workaround which
sped up parallel execution by two orders of magnitude at low to medium processor counts
and an order of magnitude at "larger" processor counts.  This workaround has been removed since the CGNS compact storage usage is a much better and maintainable solution.  This was comitted to CGNS in https://github.com/CGNS/CGNS/commit/6199af200f0692d8da8ab5f7f0825d4100d54cee

There is also another issue in that CGNS had mistakenly applied another optimization which provided a little more speedup, but made the resulting files incompatible with downstream clients using an older version of the HDF5 library.  By default, the CGNS library creates files which are readable by HDF5-1.8.X clients even though the CGNS-writing application may be using HDF5-1.10.X libraries.  This issue was fixed in https://github.com/CGNS/CGNS/commit/dfdd91da824798332b539cf74e513a70aa6ed76b

But, even with both of these fixes applied to the current CGNS/develop, it is still required that clients that use the IOSS library to read/write CGNS files be patched using the "CGNS-sandia.patch"  file at https://github.com/gsjaardema/seacas/blob/master/TPL/cgns/CGNS-sandia.patch.  This patch makes it possible to do both parallel and serial reading and writing of CGNS files during the same application execution.  This can be the reading of a file-per-processor combined with the writing of an N->1.  The changes provided in the patch are part of a PR for CGNS (https://github.com/CGNS/CGNS/pull/61), but have not yet been accepted and applied.

This patch was recently changed to add the definition of the symbol `CGNS_SANDIA_PARALLEL_MODS` in order to make it easier to determine whether the application is using a version of the library with the patch applied or not.  Note that if the patch is not applied, then the application may experience hangs. 

The issue we are potentially seeing in Trilinos and SPARC is that an older version of the patch
did not define the symbol, so it was not possible to determine whether the patch had been
applied. It is possible that the CGNS library being used has been patched so there won't be
hangs (but probably still slower execution at scale) but we cannot detect it.  This commit removes the compile-time error check for the symbol and replaces it with a run-time warning.

This is related to https://sems-atlassian-srn.sandia.gov/browse/SPAR-589, #5413 

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/seacas

## Description
<!--- Please describe your changes in detail. -->

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->

<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [ ] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
