### PR TITLE
Galeri: fix for issue #5593, protecting Epetra only examples in CMakeLists.txt

### DIFF
--- a/packages/galeri/example-fem/CMakeLists.txt
+++ b/packages/galeri/example-fem/CMakeLists.txt
@@ -1,20 +1,21 @@
 
-TRIBITS_ADD_EXECUTABLE(
-  Grid
-  SOURCES Grid.cpp
-  COMM serial mpi
-  )
+IF(${PACKAGE_NAME}_ENABLE_Epetra)
+  TRIBITS_ADD_EXECUTABLE(
+    Grid
+    SOURCES Grid.cpp
+    COMM serial mpi
+    )
 
-TRIBITS_ADD_EXECUTABLE(
-  Laplacian3D
-  SOURCES Laplacian3D.cpp
-  COMM serial mpi
-  )
+  TRIBITS_ADD_EXECUTABLE(
+    Laplacian3D
+    SOURCES Laplacian3D.cpp
+    COMM serial mpi
+    )
 
-TRIBITS_ADD_EXECUTABLE(
-  AdvDiff2D
-  SOURCES AdvDiff2D.cpp
-  COMM serial mpi
-  )
-
+  TRIBITS_ADD_EXECUTABLE(
+    AdvDiff2D
+    SOURCES AdvDiff2D.cpp
+    COMM serial mpi
+    )
+ENDIF()
 

--- a/packages/galeri/example/CMakeLists.txt
+++ b/packages/galeri/example/CMakeLists.txt
@@ -1,60 +1,62 @@
 
-IF (NOT Trilinos_NO_32BIT_GLOBAL_INDICES)
+IF(${PACKAGE_NAME}_ENABLE_Epetra)
+  IF (NOT Trilinos_NO_32BIT_GLOBAL_INDICES)
 
-  TRIBITS_ADD_EXECUTABLE_AND_TEST(
-    Map
-    SOURCES Map.cpp
-    NUM_MPI_PROCS 1
-    COMM serial mpi
-    )
+    TRIBITS_ADD_EXECUTABLE_AND_TEST(
+      Map
+      SOURCES Map.cpp
+      NUM_MPI_PROCS 1
+      COMM serial mpi
+      )
 
-  TRIBITS_ADD_EXECUTABLE_AND_TEST(
-    CrsMatrix
-    SOURCES CrsMatrix.cpp
-    NUM_MPI_PROCS 1
-    COMM serial mpi
-    )
+    TRIBITS_ADD_EXECUTABLE_AND_TEST(
+      CrsMatrix
+      SOURCES CrsMatrix.cpp
+      NUM_MPI_PROCS 1
+      COMM serial mpi
+      )
 
-  TRIBITS_ADD_EXECUTABLE_AND_TEST(
-    VbrMatrix
-    SOURCES VbrMatrix.cpp
-    NUM_MPI_PROCS 1
-    COMM serial mpi
-    )
+   TRIBITS_ADD_EXECUTABLE_AND_TEST(
+      VbrMatrix
+      SOURCES VbrMatrix.cpp
+      NUM_MPI_PROCS 1
+      COMM serial mpi
+      )
 
-  TRIBITS_ADD_EXECUTABLE_AND_TEST(
-    LinearProblem
-    SOURCES LinearProblem.cpp
-    NUM_MPI_PROCS 1
-    COMM serial mpi
-    )
+    TRIBITS_ADD_EXECUTABLE_AND_TEST(
+      LinearProblem
+      SOURCES LinearProblem.cpp
+      NUM_MPI_PROCS 1
+      COMM serial mpi
+      )
 
-ENDIF()
+  ENDIF()
 
-IF (NOT Trilinos_NO_64BIT_GLOBAL_INDICES)
+  IF (NOT Trilinos_NO_64BIT_GLOBAL_INDICES)
 
-  TRIBITS_ADD_EXECUTABLE_AND_TEST(
-    Map_LL
-    SOURCES Map.cpp
-    NUM_MPI_PROCS 1
-    COMM serial mpi
-	TARGET_DEFINES -DGALERI_TEST_USE_LONGLONG_GO
-    )
+    TRIBITS_ADD_EXECUTABLE_AND_TEST(
+      Map_LL
+      SOURCES Map.cpp
+      NUM_MPI_PROCS 1
+      COMM serial mpi
+      TARGET_DEFINES -DGALERI_TEST_USE_LONGLONG_GO
+      )
 
-  TRIBITS_ADD_EXECUTABLE_AND_TEST(
-    CrsMatrix_LL
-    SOURCES CrsMatrix.cpp
-    NUM_MPI_PROCS 1
-    COMM serial mpi
-	TARGET_DEFINES -DGALERI_TEST_USE_LONGLONG_GO
-    )
+    TRIBITS_ADD_EXECUTABLE_AND_TEST(
+      CrsMatrix_LL
+      SOURCES CrsMatrix.cpp
+      NUM_MPI_PROCS 1
+      COMM serial mpi
+      TARGET_DEFINES -DGALERI_TEST_USE_LONGLONG_GO
+      )
 
-  TRIBITS_ADD_EXECUTABLE_AND_TEST(
-    LinearProblem_LL
-    SOURCES LinearProblem.cpp
-    NUM_MPI_PROCS 1
-    COMM serial mpi
-	TARGET_DEFINES -DGALERI_TEST_USE_LONGLONG_GO
-    )
+    TRIBITS_ADD_EXECUTABLE_AND_TEST(
+      LinearProblem_LL
+      SOURCES LinearProblem.cpp
+      NUM_MPI_PROCS 1
+      COMM serial mpi
+      TARGET_DEFINES -DGALERI_TEST_USE_LONGLONG_GO
+      )
 
+  ENDIF()
 ENDIF()


### PR DESCRIPTION
I am adding appropriate checks in CMakeLists.txt to ensure that builds of galeri do not fail if Epetra is OFF but examples of galeri are ON.

@trilinos/galeri 

## Description
Galeri fails to compile its examples if Epetra is OFF

## Motivation and Context
This is part of on-going work to remove deprecated code in Tpetra

## Related Issues

* Closes #5593 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to #1033
* Part of #5602
* Composed of 

## How Has This Been Tested?
I performed a local build with Galeri and its examples ON while Epetra is OFF

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.