### PR TITLE
MueLu: fixing the Zoltan unit-test for static allocation of Tpetra::CrsGraph see issue #5614

### DIFF
--- a/packages/muelu/test/unit_tests/PgPFactory.cpp
+++ b/packages/muelu/test/unit_tests/PgPFactory.cpp
@@ -831,10 +831,9 @@ namespace MueLuTests {
     out << "version: " << MueLu::Version() << std::endl;
     out << "Test PgPFactory (reuse row based omegas for restriction operator)" << std::endl;
 
-    typedef typename Teuchos::ScalarTraits<SC>::magnitudeType real_type;
-    typedef typename Xpetra::MultiVector<real_type,LO,GO,NO> RealValuedMultiVector;
-
-    typedef typename Teuchos::ScalarTraits<SC>::magnitudeType magnitude_type;
+    using magnitude_type        = typename Teuchos::ScalarTraits<SC>::magnitudeType;
+    using real_type             = typename Teuchos::ScalarTraits<SC>::coordinateType;
+    using RealValuedMultiVector = typename Xpetra::MultiVector<real_type,LO,GO,NO>;
 
     RCP<const Teuchos::Comm<int> > comm = Teuchos::DefaultComm<int>::getComm();
 
@@ -884,7 +883,7 @@ namespace MueLuTests {
 
     RCP<TentativePFactory> Ptentfact = rcp(new TentativePFactory());
     RCP<PgPFactory>        Pfact = rcp( new PgPFactory());
-    RCP<Factory>          Rfact = rcp( new TransPFactory() );
+    RCP<Factory>           Rfact = rcp( new TransPFactory() );
     RCP<RAPFactory>        Acfact = rcp( new RAPFactory() );
     H->SetMaxCoarseSize(1);
 


### PR DESCRIPTION
@trilinos/muelu 

## Description
The matrix in unit-test Zoltan_Build is now properly estimating the number of non-zeros per row which allows to be built without crashing with the new static allocation of the Tpetra::CrsGraph

## Motivation and Context
This work will make the test pass after Tpetra removes its deprecated code.

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of #5614 
* Composed of 


## How Has This Been Tested?
I performed a local build and the test is now passing correctly.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.