### PR TITLE
Tpetra: #5525 fix (AddProfilingUnitTest on MPI+CUDA)

### DIFF
--- a/packages/tpetra/core/test/MatrixMatrix/AddProfilingTest.cpp
+++ b/packages/tpetra/core/test/MatrixMatrix/AddProfilingTest.cpp
@@ -70,34 +70,36 @@ using Teuchos::RCP;
 using Teuchos::rcp;
 using Teuchos::Comm;
 
-#define NUM_ROWS 1000
-#define NNZ_PER_ROW 100
-#define TRIALS 5
+static const int numRows = 1000;
 
 //Produce a random matrix with given nnz per global row
 template<typename SC, typename LO, typename GO, typename NT>
-RCP<Tpetra::CrsMatrix<SC, LO, GO, NT>> getTestMatrix(RCP<Tpetra::Map<LO, GO, NT>>& rowMap,
+RCP<Tpetra::CrsMatrix<SC, LO, GO, NT>> getTestMatrix(RCP<Tpetra::Map<LO, GO, NT>>& domainRangeMap,
     RCP<Tpetra::Map<LO, GO, NT>>& colMap, int seed, RCP<const Comm<int>>& comm)
 {
-  //create a non-overlapping distributed row map
-  size_t maxNnzPerRow = std::min(comm->getSize() * NNZ_PER_ROW, NUM_ROWS); 
-        //since square matrix and each proc inserting NNZ_PER_ROW in each global row
-  auto mat = rcp(new Tpetra::CrsMatrix<SC, LO, GO, NT>(rowMap, colMap, maxNnzPerRow));
+  using Teuchos::Array;
+  using Teuchos::ArrayView;
+  const LO maxNnzPerRow = 100;
+  //use the range map as row map (non-overlapping distribution)
+  auto mat = rcp(new Tpetra::CrsMatrix<SC, LO, GO, NT>(domainRangeMap, colMap, maxNnzPerRow));
   //get consistent results between trials
   srand(comm->getRank() * 7 + 42 + seed);
-  auto myCols = colMap->getNodeElementList();
-  for(GO i = 0; i < NUM_ROWS; i++)
+  ArrayView<const GO> ownedRows = domainRangeMap->getNodeElementList();
+  ArrayView<const GO> ownedCols = colMap->getNodeElementList();
+  for(GO row : ownedRows)
   {
-    Teuchos::Array<SC> vals(NNZ_PER_ROW);
-    Teuchos::Array<GO> inds(NNZ_PER_ROW);
-    for(int j = 0; j < NNZ_PER_ROW; j++)
+    Teuchos::Array<SC> vals(maxNnzPerRow);
+    Teuchos::Array<GO> inds(maxNnzPerRow);
+    for(int j = 0; j < maxNnzPerRow; j++)
     {
-      vals[j] = ((double) (rand() % RAND_MAX));
-      inds[j] = myCols[rand() % myCols.size()];
+      //get random between 0.0 and 10.0
+      vals[j] = 10.0 * rand() / RAND_MAX;
+      inds[j] = ownedCols[rand() % ownedCols.size()];
     }
-    mat->insertGlobalValues(i, inds(), vals());
+    //No guarantee that the indices are unique, so use sumInto
+    mat->sumIntoGlobalValues(row, inds(), vals());
   }
-  mat->fillComplete(rowMap, rowMap);
+  mat->fillComplete(domainRangeMap, domainRangeMap);
   return mat;
 }
 
@@ -108,16 +110,15 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Tpetra_AddProfiling, sorted, SC, LO, GO, NT)
   RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
   if(comm->getRank() == 0)
     std::cout << "Running sorted add test on " << comm->getSize() << " MPI ranks.\n";
-  RCP<map_type> rowMap = rcp(new map_type(NUM_ROWS, 0, comm));
-  RCP<map_type> colMap = rcp(new map_type(NUM_ROWS, 0, comm));
+  RCP<map_type> rowMap = rcp(new map_type(numRows, 0, comm));
+  RCP<map_type> colMap = rcp(new map_type(numRows, 0, comm));
   RCP<crs_matrix_type> A = getTestMatrix<SC, LO, GO, NT>(rowMap, colMap, 1, comm);
   RCP<crs_matrix_type> B = getTestMatrix<SC, LO, GO, NT>(rowMap, colMap, 2, comm);
   Kokkos::Impl::Timer addTimer;
   auto one = Teuchos::ScalarTraits<SC>::one();
-  for(int i = 0; i < TRIALS; i++)
-    RCP<crs_matrix_type> C = MatrixMatrix::add(one, false, *A, one, false, *B);
+  RCP<crs_matrix_type> C = MatrixMatrix::add(one, false, *A, one, false, *B);
   double tkernel = addTimer.seconds();
-  std::cout << "sorted (kernel): addition took on avg " << (tkernel / TRIALS) << "s.\n";
+  std::cout << "sorted (kernel): addition took " << tkernel << "s.\n";
 }
 
 TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Tpetra_AddProfiling, different_col_maps, SC, LO, GO, NT)
@@ -127,9 +128,9 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Tpetra_AddProfiling, different_col_maps, SC, L
   RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
   if(comm->getRank() == 0)
     std::cout << "Running \"different col maps\" add test on " << comm->getSize() << " MPI ranks.\n";
-  RCP<map_type> rowMap = rcp(new map_type(NUM_ROWS, 0, comm));
+  RCP<map_type> rowMap = rcp(new map_type(numRows, 0, comm));
   //Number of random global columns to include in column map
-  GO colMapSize = NUM_ROWS / comm->getSize();
+  GO colMapSize = numRows / comm->getSize();
   auto getRandColMap = [&] (int seed) -> Teuchos::Array<GO>
   {
     srand(seed);
@@ -139,7 +140,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Tpetra_AddProfiling, different_col_maps, SC, L
       GO col;
       do
       {
-        col = rand() % NUM_ROWS;
+        col = rand() % numRows;
       }
       while(cols.find(col) != cols.end());
       cols.insert(col);
@@ -148,24 +149,21 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Tpetra_AddProfiling, different_col_maps, SC, L
     {
       int i = 0;
       for(auto c : cols)
-      {
         colList[i++] = c;
-      }
     }
     return colList;
   };
   Teuchos::Array<GO> colMapARaw = getRandColMap(comm->getRank() + 12342);
   Teuchos::Array<GO> colMapBRaw = getRandColMap(comm->getRank() + 87345);
-  RCP<map_type> colMapA = rcp(new map_type(NUM_ROWS, colMapARaw(), 0, comm));
-  RCP<map_type> colMapB = rcp(new map_type(NUM_ROWS, colMapBRaw(), 0, comm));
+  RCP<map_type> colMapA = rcp(new map_type(numRows, colMapARaw(), 0, comm));
+  RCP<map_type> colMapB = rcp(new map_type(numRows, colMapBRaw(), 0, comm));
   RCP<crs_matrix_type> A = getTestMatrix<SC, LO, GO, NT>(rowMap, colMapA, 1, comm);
   RCP<crs_matrix_type> B = getTestMatrix<SC, LO, GO, NT>(rowMap, colMapB, 2, comm);
   Kokkos::Impl::Timer addTimer;
   auto one = Teuchos::ScalarTraits<SC>::one();
-  for(int i = 0; i < TRIALS; i++)
-    RCP<crs_matrix_type> C = MatrixMatrix::add(one, false, *A, one, false, *B);
+  RCP<crs_matrix_type> C = MatrixMatrix::add(one, false, *A, one, false, *B);
   double tkernel = addTimer.seconds();
-  std::cout << "mismatched col maps (kernel): addition took on avg " << (tkernel / TRIALS) << "s.\n";
+  std::cout << "mismatched col maps (kernel): addition took " << tkernel << "s.\n";
 }
 
 #define UNIT_TEST_GROUP_SC_LO_GO_NO( SC, LO, GO, NT )			\


### PR DESCRIPTION
Fix AddProfilingTest failure on MPI+CUDA.
Changed the way the input matrices are constructed.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Description
<!--- Please describe your changes in detail. -->
AddProfilingUnitTests.cpp was failing because the row/range map had 1000 global elements,
but every process was trying to global insert into all 1000 rows. Now each process
only adds entries to owned rows as intended.

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
This was failing on waterman in the nightly tests.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to #5525
* Part of 
* Composed of 
-->

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->
This test now passes on my machine with CUDA 9.2 (same as waterman) and CUDA-aware OpenMPI 4.0.1.
<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
