### PR TITLE
MueLu: fixing isorropia test before removal of Tpetra deprecated code issue #5614

### DIFF
--- a/packages/muelu/test/scaling/circ_nsp_dependency.xml
+++ b/packages/muelu/test/scaling/circ_nsp_dependency.xml
@@ -13,7 +13,7 @@
     <!-- -->
     <!-- Non-permuted factories -->
     <!-- -->
-    
+
     <ParameterList name="myNspFact">
       <Parameter name="factory"                             type="string" value="NullspaceFactory"/>
       <!--<Paramter name="Nullspace" type="string" value="myRebalanceProlongatorFact"/>-->
@@ -22,9 +22,8 @@
     <ParameterList name="myCoalesceDropFact">
       <Parameter name="factory"                             type="string" value="CoalesceDropFactory"/>
       <Parameter name="lightweight wrap"                    type="bool"   value="true"/>
-      <!--
-      <Parameter name="aggregation: drop tol"               type="double" value="0.1"/>
-      -->
+      <!-- for aggregation dropping -->
+      <!-- <Parameter name="aggregation: drop tol"               type="double" value="0.1"/> -->
     </ParameterList>
 
     <ParameterList name="CoupledAggregationFact">
@@ -55,7 +54,7 @@
       <Parameter name="Aggregates"                          type="string" value="UncoupledAggregationFact"/>
       <Parameter name="Nullspace"                           type="string" value="myNspFact"/>
     </ParameterList>
-    
+
     <ParameterList name="myTentativePFact">
       <Parameter name="factory"                             type="string" value="TentativePFactory"/>
       <Parameter name="Aggregates"                          type="string" value="UncoupledAggregationFact"/>
@@ -74,16 +73,16 @@
       <Parameter name="P"                                   type="string" value="myProlongatorFact"/>
     </ParameterList>
 
-    <!-- <ParameterList name="myTransferCoordinatesFact">
+    <ParameterList name="myTransferCoordinatesFact">
       <Parameter name="factory"                             type="string" value="CoordinatesTransferFactory"/>
-    </ParameterList> -->
+    </ParameterList>
 
     <ParameterList name="myRAPFact">
       <Parameter name="factory"                             type="string" value="RAPFactory"/>
       <Parameter name="P"                                   type="string" value="myProlongatorFact"/>
       <Parameter name="R"                                   type="string" value="myRestrictorFact"/>
       <ParameterList name="TransferFactories">
-	<!-- <Parameter name="For Coordinates"                   type="string" value="myTransferCoordinatesFact"/> -->
+	<Parameter name="For Coordinates"                   type="string" value="myTransferCoordinatesFact"/>
         <!-- <Parameter name="Visualization"                     type="string" value="myAggExportFact"/> -->
       </ParameterList>
     </ParameterList>
@@ -141,7 +140,7 @@
       <Parameter name="Nullspace" type="string" value="myRebalanceProlongatorFact"/>
     </ParameterList>
 
-    
+
     <ParameterList name="myRebalanceRestrictionFact">
       <Parameter name="factory"                             type="string" value="RebalanceTransferFactory"/>
       <Parameter name="type"                                type="string" value="Restriction"/>
@@ -226,6 +225,8 @@
       <Parameter name="A"                                   type="string"   value="myRebalanceAFact"/>
       <Parameter name="P"                                   type="string"   value="myRebalanceProlongatorFact"/>
       <Parameter name="R"                                   type="string"   value="myRebalanceRestrictionFact"/>
+      <Parameter name="Aggregates"                          type="string"   value="UncoupledAggregationFact"/>
+      <Parameter name="Nullspace"                           type="string"   value="myRebalanceProlongatorFact"/>
       <Parameter name="Coordinates"                         type="string"   value="myRebalanceProlongatorFact"/>
       <Parameter name="Importer"                            type="string"   value="myRepartitionFact"/>
       <Parameter name="Graph"                               type="string"   value="myCoalesceDropFact"/>

--- a/packages/muelu/test/scaling/iso_poisson.xml
+++ b/packages/muelu/test/scaling/iso_poisson.xml
@@ -88,7 +88,7 @@
       <Parameter name="repartition: max imbalance"          type="double" value="1.1"/>
       <Parameter name="repartition: start level"            type="int"    value="2"/>
     </ParameterList>
-    
+
     <ParameterList name="myZoltanInterface">
       <Parameter name="factory"                             type="string" value="ZoltanInterface"/>
       <Parameter name="A"                                   type="string" value="myRAPFact"/>

--- a/packages/muelu/test/scaling/isorropia.xml
+++ b/packages/muelu/test/scaling/isorropia.xml
@@ -17,9 +17,8 @@
     <ParameterList name="myCoalesceDropFact">
       <Parameter name="factory"                             type="string" value="CoalesceDropFactory"/>
       <Parameter name="lightweight wrap"                    type="bool"   value="true"/>
-      <!--
-      <Parameter name="aggregation: drop tol"               type="double" value="0.1"/>
-      -->
+      <!-- for aggregation dropping -->
+      <!-- <Parameter name="aggregation: drop tol"               type="double" value="0.1"/> -->
     </ParameterList>
 
     <ParameterList name="CoupledAggregationFact">
@@ -55,21 +54,26 @@
       <!-- <Parameter name="sa: damping factor"                  type="double" value="1.333"/> -->
     </ParameterList>
 
+    <ParameterList name="myTentativeRFact"> <!-- for projecting coordinates -->
+      <Parameter name="factory"                             type="string" value="TransPFactory"/>
+      <Parameter name="P"                                   type="string" value="myTentativePFact"/>
+    </ParameterList>
+
     <ParameterList name="myRestrictorFact">
       <Parameter name="factory"                             type="string" value="TransPFactory"/>
       <Parameter name="P"                                   type="string" value="myProlongatorFact"/>
     </ParameterList>
 
-    <!-- <ParameterList name="myTransferCoordinatesFact">
+    <ParameterList name="myTransferCoordinatesFact">
       <Parameter name="factory"                             type="string" value="CoordinatesTransferFactory"/>
-    </ParameterList> -->
+    </ParameterList>
 
     <ParameterList name="myRAPFact">
       <Parameter name="factory"                             type="string" value="RAPFactory"/>
       <Parameter name="P"                                   type="string" value="myProlongatorFact"/>
       <Parameter name="R"                                   type="string" value="myRestrictorFact"/>
       <ParameterList name="TransferFactories">
-	<!-- <Parameter name="For Coordinates"                   type="string" value="myTransferCoordinatesFact"/> -->
+	<Parameter name="For Coordinates"                   type="string" value="myTransferCoordinatesFact"/>
         <!-- <Parameter name="Visualization"                     type="string" value="myAggExportFact"/> -->
       </ParameterList>
     </ParameterList>
@@ -78,7 +82,7 @@
 <!-- Repartitioning -->
 <!-- -->
 
-	<!-- amalgamation of coarse level matrix -->
+    <!-- amalgamation of coarse level matrix -->
     <ParameterList name="myRebAmalgFact">
       <Parameter name="factory"                             type="string" value="AmalgamationFactory"/>
       <Parameter name="A"                                   type="string" value="myRAPFact"/>
@@ -119,6 +123,7 @@
       <Parameter name="factory"                             type="string" value="RebalanceTransferFactory"/>
       <Parameter name="type"                                type="string" value="Interpolation"/>
       <Parameter name="P"                                   type="string" value="myProlongatorFact"/>
+      <Parameter name="Coordinates"                         type="string" value="myTransferCoordinatesFact"/>
       <Parameter name="Nullspace"                           type="string" value="myTentativePFact"/>
     </ParameterList>
 


### PR DESCRIPTION
@trilinos/muelu 

## Description
Mainly tweaking a bit the xml file to have coordinate flow through MueLu.
No idea why this pops up now?

## Motivation and Context
This test showed up as broken during the testing of Trilinos with `Tpetra_Deprecated_Code=OFF`


## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to #5602 
* Part of #5614 
* Composed of 

## How Has This Been Tested?
Local build and tests have been performed and the offending test now passes


## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.