### PR TITLE
Fix Amesos2 unit tests KLU2 and GappedMtxGIDs

### DIFF
--- a/packages/amesos2/example/GappedMtxGIDs-1proc.cpp
+++ b/packages/amesos2/example/GappedMtxGIDs-1proc.cpp
@@ -395,6 +395,7 @@ readCrsMatrixFromFile (const std::string& matrixFilename,
      "Failed to open file \"" << matrixFilename << "\" on Process 0.");
 
   using Teuchos::RCP;
+  //maxNumElementsPerRow as defined by the .mm files that go with this example
   RCP<MAT> A (new MAT (rowMap, 2));
 
   if (myRank == 0) 

--- a/packages/amesos2/example/GappedMtxGIDs-1proc.cpp
+++ b/packages/amesos2/example/GappedMtxGIDs-1proc.cpp
@@ -395,7 +395,7 @@ readCrsMatrixFromFile (const std::string& matrixFilename,
      "Failed to open file \"" << matrixFilename << "\" on Process 0.");
 
   using Teuchos::RCP;
-  RCP<MAT> A (new MAT (rowMap, 0));
+  RCP<MAT> A (new MAT (rowMap, 2));
 
   if (myRank == 0) 
   {

--- a/packages/amesos2/test/solvers/KLU2_UnitTests.cpp
+++ b/packages/amesos2/test/solvers/KLU2_UnitTests.cpp
@@ -417,7 +417,7 @@ namespace {
           "KLU2 NonContigGID Test: The non-contiguous map claims to be contiguous.");
 
       //RCP<MAT> A = rcp( new MAT(map,3) ); // max of three entries in a row
-      RCP<MAT> A = rcp( new MAT(map,0) );
+      RCP<MAT> A = rcp( new MAT(map,3) );
       A->setObjectLabel("A");
 
       /*


### PR DESCRIPTION
@trilinos/tpetra 

## Description
Changes the unit tests in Amesos2 to work with GO=int and GO=<default>

## Motivation and Context
To further the removal of deprecated code

## Related Issues
* Part of #5602 

## How Has This Been Tested?
Built unit tests against GO = int and GO = <default>, checked unit tests run

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [ x ] My code follows the code style of the affected package(s).
- [ na ] My change requires a change to the documentation.
- [ x ] I have updated the documentation accordingly.
- [ x ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ na ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.
- [ x ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.
