### PR TITLE
Ifpack2: Fixing an error that affects clang

### DIFF
--- a/packages/ifpack2/src/Ifpack2_BandedContainer_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_BandedContainer_decl.hpp
@@ -128,8 +128,8 @@ private:
   using typename Container<MatrixType>::ISC;
   using typename ContainerImpl<MatrixType, LSC>::LISC;
 
-  using Container<MatrixType>::mv_type;
-  using Container<MatrixType>::map_type;
+  using typename Container<MatrixType>::mv_type;
+  using typename Container<MatrixType>::map_type;
   using local_mv_type = Tpetra::MultiVector<LSC, LO, GO, NO>;
   using typename Container<MatrixType>::vector_type;
   using typename Container<MatrixType>::import_type;


### PR DESCRIPTION
@trilinos/ifpack2 

Fixing an error in `Ifpack2_BandedContainer_Serial.cpp`:
```
packages/ifpack2/src/Ifpack2_BandedContainer_decl.hpp:131:32: error: dependent using declaration re
solved to type without 'typename'
  using Container<MatrixType>::mv_type;
                               ^
```

This affected me on clang compilers, but judging by the other `using Container<MatrixType>:: ...` lines nearby were using `typename`:

https://github.com/trilinos/Trilinos/blob/1bfa7b16c0eb5de6980ce552e7511caf34973a48/packages/ifpack2/src/Ifpack2_BandedContainer_decl.hpp#L128-L138

it seemed reasonable to make lines 131 and 132 consistent.  This removed my compiler error on my environment. 

