### PR TITLE
zoltan2:  allow deprecation of dynamicProfile #5602

### DIFF
--- a/packages/zoltan2/src/models/Zoltan2_HyperGraphModel.hpp
+++ b/packages/zoltan2/src/models/Zoltan2_HyperGraphModel.hpp
@@ -550,7 +550,14 @@ HyperGraphModel<Adapter>::HyperGraphModel(
         // TODO KDD 1/17 It would be better to use minimum GID rather than
         // TODO zero in the above Tpetra::Map constructor.  Github #1024
       }
-      secondAdj = rcp(new sparse_matrix_type(oneToOneMap,0));
+      Teuchos::Array<size_t> nPerRow(numLocalVertices_);
+      size_t rowcnt = 0;
+      for (size_t i=0; i<numLocalVertices_;i++) {
+        if (!isOwner_[i])
+          continue;
+        nPerRow[rowcnt++] = offsets[i+1]-offsets[i];
+      }
+      secondAdj = rcp(new sparse_matrix_type(oneToOneMap,nPerRow(0,rowcnt)));
       for (size_t i=0; i<numLocalVertices_;i++) {
         if (!isOwner_[i])
           continue;

--- a/packages/zoltan2/src/models/Zoltan2_ModelHelpers.hpp
+++ b/packages/zoltan2/src/models/Zoltan2_ModelHelpers.hpp
@@ -162,8 +162,11 @@ get2ndAdjsMatFromAdjs(const Teuchos::RCP<const MeshAdapter<User> > &ia,
     RCP<sparse_matrix_type> adjsMatrix;
 
     // Construct Tpetra::CrsGraph objects.
+    Array<size_t> rowlens(LocalNumIDs);
+    for (size_t localElement = 0; localElement < LocalNumIDs; localElement++)
+      rowlens[localElement] = offsets[localElement+1] - offsets[localElement];
     adjsMatrix = rcp (new sparse_matrix_type (sourcetargetMapG,//oneToOneSTMap,
-                                              0));
+                                              rowlens()));
 
     Array<nonzero_t> justOneA(maxcols, 1);
     ArrayView<const gno_t> adjacencyIdsAV(adjacencyIds, offsets[LocalNumIDs]);

--- a/packages/zoltan2/test/partition/TaskMappingProblemTest.cpp
+++ b/packages/zoltan2/test/partition/TaskMappingProblemTest.cpp
@@ -106,7 +106,12 @@ RCP<mytest_tcrsGraph_t> create_tpetra_input_matrix(
   using namespace Teuchos;
   RCP<const mytest_map_t> map = rcp (new mytest_map_t (numGlobalTasks, myTasks, 0, tcomm));
 
-  RCP<mytest_tcrsGraph_t> TpetraCrsGraph(new mytest_tcrsGraph_t (map, 0));
+  Teuchos::Array<size_t> adjPerTask(myTasks);
+  for (zgno_t lclRow = 0; lclRow < myTasks; ++lclRow)
+    adjPerTask[lclRow] = task_communication_xadj_[lclRow+1] 
+                       - task_communication_xadj_[lclRow];
+  RCP<mytest_tcrsGraph_t> TpetraCrsGraph(new mytest_tcrsGraph_t(map,
+                                                                adjPerTask()));
 
   env->timerStart(Zoltan2::MACRO_TIMERS, "TpetraGraphCreate");
 

--- a/packages/zoltan2/test/partition/TaskMappingTest.cpp
+++ b/packages/zoltan2/test/partition/TaskMappingTest.cpp
@@ -115,7 +115,11 @@ int main(int narg, char *arg[]){
     typedef Tpetra::Map<zlno_t, zgno_t, mytest_znode_t> map_t;
     RCP<const map_t> map = rcp (new map_t (numGlobalTasks, myTasks, 0, tcomm));
 
-    RCP<tcrsGraph_t> TpetraCrsGraph(new tcrsGraph_t (map, 0));
+    Teuchos::Array<size_t> adjPerTask(myTasks);
+    for (zlno_t lclRow = 0; lclRow < myTasks; lclRow++)
+      adjPerTask[lclRow] = task_communication_xadj_[lclRow+1] 
+                         - task_communication_xadj_[lclRow];
+    RCP<tcrsGraph_t> TpetraCrsGraph(new tcrsGraph_t (map, adjPerTask()));
 
 
     for (zlno_t lclRow = 0; lclRow < myTasks; ++lclRow) {

--- a/packages/zoltan2/test/unit/util/Metric.cpp
+++ b/packages/zoltan2/test/unit/util/Metric.cpp
@@ -308,7 +308,7 @@ graph_idInput_t * create_adapter<graph_idInput_t>(RCP<const Comm<int> > comm,
   Teuchos::RCP<const map_t> map = rcp(new map_t(gNvtx, indexList, 0, comm));
 
   // Make some stuff in the graph
-  size_t maxRowLen = 1;
+  size_t maxRowLen = 2;
   Teuchos::RCP<matrix_t> matrix = rcp(new matrix_t(map, maxRowLen));
 
   // I picked this graph as a simple test case.

--- a/packages/zoltan2/test/unit/util/componentMetrics.cpp
+++ b/packages/zoltan2/test/unit/util/componentMetrics.cpp
@@ -129,7 +129,7 @@ int test_every_third(Teuchos::RCP<const Teuchos::Comm<int> > &comm)
   size_t nVtx = map->getNodeNumElements();
 
   // Create a Tpetra::Matrix with every third local row in the same component
-  size_t maxRowLen = 1;
+  size_t maxRowLen = 3;
   Teuchos::RCP<zmatrix_t> matrix = rcp(new zmatrix_t(map, maxRowLen));
 
   Teuchos::Array<zgno_t> col(3);
@@ -184,7 +184,7 @@ int test_dist_component(Teuchos::RCP<const Teuchos::Comm<int> > &comm)
   size_t nVtx = map->getNodeNumElements();
 
   // Create a Tpetra::Matrix with a single component
-  size_t maxRowLen = 1;
+  size_t maxRowLen = 3;
   Teuchos::RCP<zmatrix_t> matrix = rcp(new zmatrix_t(map, maxRowLen));
 
   Teuchos::Array<zgno_t> col(3);
@@ -246,7 +246,7 @@ int test_one_proc(Teuchos::RCP<const Teuchos::Comm<int> > &comm)
   Teuchos::RCP<const zmap_t> map = rcp(new zmap_t(gNvtx, nVtx, 0, comm));
 
   // Create a Tpetra::Matrix with one component
-  size_t maxRowLen = 1;
+  size_t maxRowLen = 2;
   Teuchos::RCP<zmatrix_t> matrix = rcp(new zmatrix_t(map, maxRowLen));
   if (allOnThisProc) {
     Teuchos::Array<zgno_t> col(2);


### PR DESCRIPTION
@trilinos/zoltan2 

#5615 #5609 

## Description
Tpetra is deprecating use of DynamicProfile construction for graphs and matrices.
This PR changes several uses of DynamicProfile to StaticProfile, by providing the number of entries for rows of the matrix.  
I do not use StaticProfile in the function call, as the default profile type will become StaticProfile.


## How Has This Been Tested?

Tested in linux with Tpetra_ENABLE_DEPRECATED_CODE=OFF and Tpetra_INST_INT_INT=ON.


## Checklist

- [ x] My commit messages mention the appropriate GitHub issue numbers.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
- [x ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
