### PR TITLE
ShyLU: Fixed test link errors #5618

### DIFF
--- a/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_OverlappingOperator_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/SchwarzOperators/FROSch_OverlappingOperator_def.hpp
@@ -96,6 +96,7 @@ namespace FROSch {
         MultiVectorPtr yOverlap = Xpetra::MultiVectorFactory<SC,LO,GO,NO>::Build(OverlappingMatrix_->getDomainMap(),x.getNumVectors());
         
         // AH 11/28/2018: replaceMap does not update the GlobalNumRows. Therefore, we have to create a new MultiVector on the serial Communicator. In Epetra, we can prevent to copy the MultiVector.
+        #ifdef HAVE_XPETRA_EPETRA
         if (xTmp->getMap()->lib() == Xpetra::UseEpetra) {
             xOverlapTmp = Xpetra::MultiVectorFactory<SC,LO,GO,NO>::Build(OverlappingMap_,x.getNumVectors());
             
@@ -113,7 +114,9 @@ namespace FROSch {
             
             Teuchos::RCP<Epetra_MultiVector> epetraMultiVectorXOverlap(new Epetra_MultiVector(View,epetraMap,A,MyLDA,x.getNumVectors()));
             xOverlap = Teuchos::RCP<Xpetra::EpetraMultiVectorT<GO,NO> >(new Xpetra::EpetraMultiVectorT<GO,NO>(epetraMultiVectorXOverlap));
-        } else {
+        } else
+        #endif
+        {
             xOverlap = Xpetra::MultiVectorFactory<SC,LO,GO,NO>::Build(OverlappingMap_,x.getNumVectors());
             
             xOverlap->doImport(*xTmp,*Scatter_,Xpetra::INSERT);

--- a/packages/shylu/shylu_dd/frosch/test/Import_Tpetra/main.cpp
+++ b/packages/shylu/shylu_dd/frosch/test/Import_Tpetra/main.cpp
@@ -52,10 +52,13 @@
 
 #include <Xpetra_CrsMatrixWrap.hpp>
 #include <Xpetra_DefaultPlatform.hpp>
-#include <Xpetra_EpetraCrsMatrix.hpp>
 #include <Xpetra_MapFactory.hpp>
 #include <Xpetra_MatrixFactory.hpp>
 #include <Xpetra_UseDefaultTypes.hpp>
+
+#ifdef HAVE_XPETRA_EPETRA
+#include <Xpetra_EpetraCrsMatrix.hpp>
+#endif
 
 #include "FROSch_Tools_def.hpp"
 

--- a/packages/shylu/shylu_dd/frosch/test/InterfacePartitionOfUnity/main.cpp
+++ b/packages/shylu/shylu_dd/frosch/test/InterfacePartitionOfUnity/main.cpp
@@ -70,7 +70,7 @@ typedef KokkosClassic::DefaultNode::DefaultNodeType NO;
 
 int main(int argc, char *argv[])
 {
-	using namespace std;
+    using namespace std;
     using namespace Teuchos;
     using namespace Xpetra;
     using namespace FROSch;
@@ -128,12 +128,12 @@ int main(int argc, char *argv[])
         Comm->barrier(); if (Comm->getRank()==0) cout << "#############\n# Assembly #\n#############\n" << endl;
 
         ParameterList GaleriList;
-        GaleriList.set("nx", int(N*M));
-        GaleriList.set("ny", int(N*M));
-        GaleriList.set("nz", int(N*M));
-        GaleriList.set("mx", int(N));
-        GaleriList.set("my", int(N));
-        GaleriList.set("mz", int(N));
+        GaleriList.set("nx", GlobalOrdinal(N*M));
+        GaleriList.set("ny", GlobalOrdinal(N*M));
+        GaleriList.set("nz", GlobalOrdinal(N*M));
+        GaleriList.set("mx", GlobalOrdinal(N));
+        GaleriList.set("my", GlobalOrdinal(N));
+        GaleriList.set("mz", GlobalOrdinal(N));
 
         RCP<const Map<LO,GO,NO> > UniqueMap;
         RCP<MultiVector<SC,LO,GO,NO> > Coordinates;

--- a/packages/shylu/shylu_dd/frosch/test/InterfaceSets/main.cpp
+++ b/packages/shylu/shylu_dd/frosch/test/InterfaceSets/main.cpp
@@ -101,7 +101,7 @@ int main(int argc, char *argv[])
         return(EXIT_SUCCESS);
     }
 
-    int N;
+    int N = 0;
     int color=1;
     if (Dimension == 2) {
         N = (int) (pow(CommWorld->getSize(),1/2.) + 100*numeric_limits<double>::epsilon()); // 1/H
@@ -131,12 +131,12 @@ int main(int argc, char *argv[])
         Comm->barrier(); if (Comm->getRank()==0) cout << "#############\n# Assembly #\n#############\n" << endl;
 
         ParameterList GaleriList;
-        GaleriList.set("nx", int(N*M));
-        GaleriList.set("ny", int(N*M));
-        GaleriList.set("nz", int(N*M));
-        GaleriList.set("mx", int(N));
-        GaleriList.set("my", int(N));
-        GaleriList.set("mz", int(N));
+        GaleriList.set("nx", GlobalOrdinal(N*M));
+        GaleriList.set("ny", GlobalOrdinal(N*M));
+        GaleriList.set("nz", GlobalOrdinal(N*M));
+        GaleriList.set("mx", GlobalOrdinal(N));
+        GaleriList.set("my", GlobalOrdinal(N));
+        GaleriList.set("mz", GlobalOrdinal(N));
 
         RCP<const Map<LO,GO,NO> > UniqueMap;
         RCP<MultiVector<SC,LO,GO,NO> > Coordinates;

--- a/packages/shylu/shylu_dd/frosch/test/Thyra_Xpetra_Laplace/main.cpp
+++ b/packages/shylu/shylu_dd/frosch/test/Thyra_Xpetra_Laplace/main.cpp
@@ -138,7 +138,7 @@ int main(int argc, char *argv[])
         return(EXIT_SUCCESS);
     }
     
-    int N;
+    int N = 0;
     int color=1;
     if (Dimension == 2) {
         N = (int) (pow(CommWorld->getSize(),1/2.) + 100*numeric_limits<double>::epsilon()); // 1/H
@@ -178,12 +178,12 @@ int main(int argc, char *argv[])
             dofsPerNodeVector[block] = (UN) max(int(DofsPerNode-block),1);
             
             ParameterList GaleriList;
-            GaleriList.set("nx", int(N*(M+block)));
-            GaleriList.set("ny", int(N*(M+block)));
-            GaleriList.set("nz", int(N*(M+block)));
-            GaleriList.set("mx", int(N));
-            GaleriList.set("my", int(N));
-            GaleriList.set("mz", int(N));
+            GaleriList.set("nx", GlobalOrdinal(N*(M+block)));
+            GaleriList.set("ny", GlobalOrdinal(N*(M+block)));
+            GaleriList.set("nz", GlobalOrdinal(N*(M+block)));
+            GaleriList.set("mx", GlobalOrdinal(N));
+            GaleriList.set("my", GlobalOrdinal(N));
+            GaleriList.set("mz", GlobalOrdinal(N));
             
             RCP<const Map<LO,GO,NO> > UniqueMapTmp;
             RCP<MultiVector<SC,LO,GO,NO> > CoordinatesTmp;

--- a/packages/xpetra/src/Headers/Xpetra_UseDefaultTypes.hpp
+++ b/packages/xpetra/src/Headers/Xpetra_UseDefaultTypes.hpp
@@ -54,7 +54,19 @@
 // Define default data types
 typedef double Scalar;
 typedef int LocalOrdinal;
+
+// Choose global ordinal based on enabled underlying libraries
+#ifdef HAVE_XPETRA_TPETRA
+typedef typename Tpetra::Map<>::global_ordinal_type GlobalOrdinal;
+//Have Epetra only; use Epetra's default GlobalOrdinal
+#else
+#ifdef EPETRA_NO_32BIT_GLOBAL_INDICES
+typedef long long GlobalOrdinal;
+#else
 typedef int GlobalOrdinal;
+#endif
+#endif
+
 typedef KokkosClassic::DefaultNode::DefaultNodeType Node;
 
 #endif // DOXYGEN_SHOULD_SKIP_THIS

--- a/packages/xpetra/src/Map/Xpetra_Map.hpp
+++ b/packages/xpetra/src/Map/Xpetra_Map.hpp
@@ -75,6 +75,21 @@ namespace Xpetra {
 # endif
 #endif
 
+  namespace Details
+  {
+    //Check for the default Tpetra GlobalOrdinal (long long)
+    #ifdef HAVE_XPETRA_TPETRA
+    typedef typename Tpetra::Map<>::global_ordinal_type DefaultGlobalOrdinal;
+    //Have Epetra only; use Epetra's default GlobalOrdinal
+    #else
+    #ifdef EPETRA_NO_32BIT_GLOBAL_INDICES
+    typedef long long DefaultGlobalOrdinal;
+    #else
+    typedef int DefaultGlobalOrdinal;
+    #endif
+    #endif
+  }
+
   enum UnderlyingLib {
     UseEpetra,
     UseTpetra,
@@ -82,7 +97,7 @@ namespace Xpetra {
   };
 
   template <class LocalOrdinal = int,
-            class GlobalOrdinal = LocalOrdinal,
+            class GlobalOrdinal = Details::DefaultGlobalOrdinal,
             class Node = KokkosClassic::DefaultNode::DefaultNodeType>
   class Map
     : public Teuchos::Describable


### PR DESCRIPTION
Fixed link errors in several ShyLU_DDFROSch tests, where the global ordinal was
unknowingly hardcoded as int. Made Xpetra pick a reasonable default GlobalOrdinal.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/xpetra 
@trilinos/shylu 

## Description
<!--- Please describe your changes in detail. -->
Building with Tpetra GO=long long (but not GO=int) caused the failure, because Xpetra structrues were not instantiated with *_int_int_node. The reason why GO was hardcoded to int in ShyLU is because ShyLU used the Xpetra "default types" to define Scalar, LO, GO and NO. In Xpetra_DefaultTypes.hpp, GO was hardcoded to int, regardless of what was enabled in CMake. So this commit adds logic in Xpetra to choose a reasonable default GlobalOrdinal based on what is enabled: if Tpetra is enabled, the default GO of Tpetra is chosen. Then if Epetra 64-bit GO is enabled, long long is used. Otherwise, int is used.

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
This fixes a ShyLU build failure as part of the Tpetra deprecated code removal (#5602).
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes #5618 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to #5602
* Part of 
* Composed of 
-->

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->
This was built with Tpetra GO=long long enabled, GO=int disabled, Epetra disabled, and deprecated code disabled. Most tests in FROSch failed to build before, but now build and run successfully (except for the two in #5617, which were fixed separately).
<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
I didn't say that all existing tests passed, because some other fixes (see #5602) for tests in this configuration have not made it to develop branch yet. The tests affected by these changes do pass.