### PR TITLE
teko:  fixes to support staticProfile matrix construction in Tpetra #5602

### DIFF
--- a/packages/teko/tests/src/tGraphLaplacian_tpetra.cpp
+++ b/packages/teko/tests/src/tGraphLaplacian_tpetra.cpp
@@ -77,7 +77,13 @@ void tGraphLaplacian_tpetra::initializeTest()
 Teuchos::RCP<Tpetra::CrsMatrix<ST,LO,GO,NT> > stencil(const Teuchos::Comm<int> & comm)
 {
    Teuchos::RCP<Tpetra::Map<LO,GO,NT> > map = rcp(new Tpetra::Map<LO,GO,NT>(5,0,rcpFromRef(comm)));
-   Teuchos::RCP<Tpetra::CrsMatrix<ST,LO,GO,NT> > mat = rcp(new Tpetra::CrsMatrix<ST,LO,GO,NT>(map,0));
+   Teuchos::RCP<Tpetra::CrsMatrix<ST,LO,GO,NT> > mat = rcp(new Tpetra::CrsMatrix<ST,LO,GO,NT>(map,6));
+   // KDD 8/2019:  The value 6 above is needed because this test inserts 
+   // three indices twice into row 4 of the matrix.
+   // Tpetra is robust enough to correctly handle the double insertion. 
+   // But if this double insertion is, in fact, an error, the 6 can probably
+   // be changed to 3.  Note that this test doesn't insert any nonzeros into
+   // row 0 of the matrix.
 
    // arrays for indicies and values
    GO indicies[3];


### PR DESCRIPTION
#5602 
@trilinos/teko 


## Description
Changes to enable only static profile construction of Tpetra CrsMatrices.
Enables builds with Tpetra_ENABLE_DEPRECATED_CODE=OFF to succeed.

Changed one test to provide a maximum number of entries per row.  (Note that this test is rather odd in that it inserts into one matrix row twice, while not inserting at all into another matrix row.  But I digress.)

Changed the subblock constructor to count the number of nonzeros per row, then create the matrix, and then insert the nonzeros.

## Motivation and Context
DynamicProfile construction of Tpetra CrsGraph and CrsMAtrix is deprecated and will disappear soon.

Tested on linux with
Tpetra_ENABLE_DEPRECATED_CODE=OFF
Xpetra_ENABLE_DEPRECATED_CODE=OFF
Tpetra_INST_INT_INT=ON
