### PR TITLE
MueLu: pass nullspace/coordinates to AMG as region MG coarse solver

### DIFF
--- a/packages/muelu/research/mmayr/composite_to_regions/src/HHG_Utils_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/HHG_Utils_def.hpp
@@ -51,6 +51,7 @@
 #include <Xpetra_Map.hpp>
 #include <Xpetra_MultiVector.hpp>
 
+#include <Teuchos_Array.hpp>
 #include <Teuchos_FancyOStream.hpp>
 #include <Teuchos_RCP.hpp>
 
@@ -100,6 +101,20 @@ struct widget {
 template <class T>
 void printRegionalObject(const std::string objName, ///< string to be used for screen output
     const std::vector<Teuchos::RCP<T> > regObj, ///< regional object to be printed to screen
+    const int myRank, ///< rank of calling proc
+    Teuchos::FancyOStream& outstream ///< output stream
+    )
+{
+  for (int j = 0; j < (int) regObj.size(); j++) {
+    outstream << myRank << ": " << objName << " " << j << std::endl;
+    regObj[j]->describe(outstream, Teuchos::VERB_EXTREME);
+  }
+}
+
+//! Print an object in regional layout to screen
+template <class T>
+void printRegionalObject(const std::string objName, ///< string to be used for screen output
+    const Teuchos::Array<Teuchos::RCP<T> > regObj, ///< regional object to be printed to screen
     const int myRank, ///< rank of calling proc
     Teuchos::FancyOStream& outstream ///< output stream
     )

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
@@ -1317,10 +1317,8 @@ void createRegionHierarchy(const int maxRegPerProc,
                            Array<RCP<Teuchos::ParameterList> >& smootherParams
                            )
 {
-#include "Xpetra_UseShortNames.hpp"
+#include "MueLu_UseShortNames.hpp"
 
-  using Hierarchy = MueLu::Hierarchy<SC, LO, GO, NO>;
-  using Utilities = MueLu::Utilities<SC, LO, GO, NO>;
   using DirectCoarseSolver = Amesos2::Solver<Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>, Tpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> >;
 
   std::cout << mapComp->getComm()->getRank() << " | Setting up MueLu hierarchies ..." << std::endl;

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionMatrix_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionMatrix_def.hpp
@@ -163,7 +163,7 @@ void compositeToRegional(RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal,
 
 /*! \brief Transform regional vector to composite layout
  *
- *  Starting from a \c Epetra_Vector in regional layout, we
+ *  Starting from a \c Xpetra::Vector in regional layout, we
  *  1. replace the regional map with the quasiRegional map
  *  2. export it into a vector with composite layout using the \c CombineMode \c Add.
  *     Note: on-process values also have to be added to account for region interfaces inside a process.
@@ -201,12 +201,14 @@ void regionalToComposite(const std::vector<RCP<Xpetra::Vector<Scalar, LocalOrdin
       RCP<Vector> partialCompVec = VectorFactory::Build(rowImportPerGrp[0]->getSourceMap(), true);
       TEUCHOS_ASSERT(Teuchos::nonnull(partialCompVec));
       TEUCHOS_ASSERT(partialCompVec->getLocalLength() == compVecLocalLength);
-      // ToDo (mayr.mt) Use input variable 'combineMode'
-      partialCompVec->doExport(*quasiRegVec, *(rowImportPerGrp[grpIdx]), Xpetra::ADD);
+      partialCompVec->doExport(*quasiRegVec, *(rowImportPerGrp[grpIdx]), combineMode);
 
-      Teuchos::ArrayRCP<const SC> partialCompVecData = partialCompVec->getData(0);
-      for(size_t entryIdx = 0; entryIdx < compVecLocalLength; ++entryIdx) {
-        compVec->sumIntoLocalValue(static_cast<LO>(entryIdx), partialCompVecData[entryIdx]);
+      if (combineMode == Xpetra::ADD)
+      {
+        Teuchos::ArrayRCP<const SC> partialCompVecData = partialCompVec->getData(0);
+        for(size_t entryIdx = 0; entryIdx < compVecLocalLength; ++entryIdx) {
+          compVec->sumIntoLocalValue(static_cast<LO>(entryIdx), partialCompVecData[entryIdx]);
+        }
       }
     }
   }

--- a/packages/muelu/research/regionMG/examples/structured/structured_1dof_3level.xml
+++ b/packages/muelu/research/regionMG/examples/structured/structured_1dof_3level.xml
@@ -36,6 +36,8 @@
       <Parameter name="prolongatorGraph"                    type="string" value="myAggregationFact"/>
       <Parameter name="coarseCoordinatesFineMap"            type="string" value="myAggregationFact"/>
       <Parameter name="coarseCoordinatesMap"                type="string" value="myAggregationFact"/>
+      <Parameter name="Keep nullspace"                      type="bool"	  value="true"/>
+      <Parameter name="Keep coordinates"                    type="bool"	  value="true"/>
     </ParameterList>
 
     <ParameterList name="myCoordTransferFact">

--- a/packages/muelu/src/Transfers/GeneralGeometric/MueLu_GeometricInterpolationPFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/GeneralGeometric/MueLu_GeometricInterpolationPFactory_decl.hpp
@@ -110,6 +110,17 @@ namespace MueLu{
                                    const Teuchos::SerialDenseVector<LO,real_type> parametricCoordinates,
                                    real_type functions[4][8]) const;
 
+    //! @name Control keep mechanism
+    //! @{
+
+    //! Flag to enforce keeping nullspace as user data
+    mutable bool bKeepNullspaceAsUserData_ = false;
+
+    //! Flag to enforce keeping cooordinates as user data
+    mutable bool bKeepCoordinatesAsUserData_ = false;
+
+    //! @}
+
   }; // class GeometricInterpolationPFactory
 
 } // namespace MueLu

--- a/packages/muelu/src/Transfers/GeneralGeometric/MueLu_GeometricInterpolationPFactory_def.hpp
+++ b/packages/muelu/src/Transfers/GeneralGeometric/MueLu_GeometricInterpolationPFactory_def.hpp
@@ -89,6 +89,9 @@ namespace MueLu {
     validParamList->set<RCP<const FactoryBase> >("lCoarseNodesPerDim",           Teuchos::null,
                                                  "Number of nodes per spatial dimension on the coarse grid.");
 
+    validParamList->set<bool>("Keep nullspace", false, "Force to keep the nullspace vectors.");
+    validParamList->set<bool>("Keep coordinates", false, "Force to keep the coordinates vectors.");
+
     return validParamList;
   }
 
@@ -109,6 +112,11 @@ namespace MueLu {
       Input(fineLevel, "coarseCoordinatesFineMap");
       Input(fineLevel, "coarseCoordinatesMap");
     }
+
+    if (pL.get<bool>("Keep nullspace"))
+      bKeepNullspaceAsUserData_ = true;
+    if (pL.get<bool>("Keep coordinates"))
+      bKeepCoordinatesAsUserData_ = true;
 
   }
 
@@ -161,6 +169,9 @@ namespace MueLu {
       coarseCoordinates->replaceMap(coarseCoordsMap);
 
       Set(coarseLevel, "Coordinates", coarseCoordinates);
+
+      if (bKeepCoordinatesAsUserData_)
+        coarseLevel.AddKeepFlag("Coordinates", NoFactory::get(), MueLu::UserData);
     }
 
     *out << "Fine and coarse coordinates have been loaded from the fine level and set on the coarse level." << std::endl;
@@ -194,6 +205,9 @@ namespace MueLu {
       P->apply(*fineNullspace, *coarseNullspace, Teuchos::TRANS, Teuchos::ScalarTraits<SC>::one(),
                Teuchos::ScalarTraits<SC>::zero());
       Set(coarseLevel, "Nullspace", coarseNullspace);
+
+      if (bKeepNullspaceAsUserData_)
+        coarseLevel.AddKeepFlag("Nullspace", NoFactory::get(), MueLu::UserData);
     }
 
     *out << "The coarse nullspace is constructed and set on the coarse level." << std::endl;

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_decl.hpp
@@ -159,7 +159,19 @@ namespace MueLu {
                          RCP<const Map> coarseMap, RCP<Matrix>& Ptentative, RCP<MultiVector>& coarseNullspace) const;
     bool isGoodMap(const Map& rowMap, const Map& colMap) const;
 
+    //! Flag to enable transfer of coordinates to coarse level
     mutable bool bTransferCoordinates_ = false;
+
+    //! @name Control keep mechanism
+    //! @{
+
+    //! Flag to enforce keeping nullspace as user data
+    mutable bool bKeepNullspaceAsUserData_ = false;
+
+    //! Flag to enforce keeping cooordinates as user data
+    mutable bool bKeepCoordinatesAsUserData_ = false;
+
+    //! @}
 
   }; //class TentativePFactory
 

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_def.hpp
@@ -90,6 +90,9 @@ namespace MueLu {
     validParamList->set< RCP<const FactoryBase> >("Coordinates",        Teuchos::null, "Generating factory of the coordinates");
     validParamList->set< RCP<const FactoryBase> >("Node Comm",          Teuchos::null, "Generating factory of the node level communicator");
 
+    validParamList->set<bool>("Keep nullspace", false, "Force to keep the nullspace vectors.");
+    validParamList->set<bool>("Keep coordinates", false, "Force to keep the coordinates vectors.");
+
     // Make sure we don't recursively validate options for the matrixmatrix kernels
     ParameterList norecurse;
     norecurse.disableRecursiveValidation();
@@ -116,6 +119,11 @@ namespace MueLu {
     } else if (bTransferCoordinates_) {
       Input(fineLevel, "Coordinates");
     }
+
+    if (pL.get<bool>("tentative: keep nullspace"))
+      bKeepNullspaceAsUserData_ = true;
+    if (pL.get<bool>("tentative: keep coordinates"))
+      bKeepCoordinatesAsUserData_ = true;
   }
 
   template <class Scalar,class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -237,6 +245,11 @@ namespace MueLu {
     }
     Set(coarseLevel, "Nullspace",   coarseNullspace);
     Set(coarseLevel, "P",           Ptentative);
+
+    if (bKeepNullspaceAsUserData_)
+      coarseLevel.AddKeepFlag("Nullspace", NoFactory::get(), MueLu::UserData);
+    if (bKeepCoordinatesAsUserData_ && bTransferCoordinates_)
+      coarseLevel.AddKeepFlag("Coordinates", NoFactory::get(), MueLu::UserData);
 
     if (IsPrint(Statistics2)) {
       RCP<ParameterList> params = rcp(new ParameterList());


### PR DESCRIPTION
@trilinos/muelu 
@lucbv @rstumin @pohm01 

## Description

- Add "Keep" flags to `TentativePFacotry` and to `GeometricInterpolationPFactory` to force those factories to keep the "Nullspace" and the "Coordinates".
- Extract nullspace and coordinates from the region hierarchy, move them to the composite format, and pass them to the "AMG as coarse solver" setup.
- Add some utilities to the HHG headers.

## Motivation and Context

- The nullspace for problems other than Poisson be created manually and has to be extracted from the coarse level of the region hierarchy. 
- Coordinates are required for load balancing. They always have to be extracted from the region hierarchy,

## Related Issues

* Part of #5503 

## How Has This Been Tested?

I ran some local tests. The keep mechanism doesn't work properly so far. Here's the output:
```
0 | MakeCoarseCompositeSolver ...
MueLu::NoFactory::Build(): this method cannot be called.

Maybe, the required variable has been generated by another factory?
Here is a list of all available data on the current level:
LevelID = 2
  data name             gen. factory addr.  req    keep   type             data            req'd by            
  --------------------  ------------------  -----  -----  ---------------  --------------  --------------------
  A                     NoFactory           0      Final  Matrix           available                           
  Coordinates           NoFactory           0      User   unknown          not available                       
  Nullspace             NoFactory           0      User   unknown          not available                       
  P                     NoFactory           0      Final  Matrix           available                           
  PreSmoother           NoFactory           0      Final  SmootherBase     available                           
  R                     NoFactory           0      Final  Matrix           available                           

p=3: *** Caught standard std::exception of type 'MueLu::Exceptions::RuntimeError' :

 MueLu::NoFactory::Build(): this method cannot be called.

p=1: *** Caught standard std::exception of type 'MueLu::Exceptions::RuntimeError' :

 MueLu::NoFactory::Build(): this method cannot be called.

p=0: *** Caught standard std::exception of type 'MueLu::Exceptions::RuntimeError' :

 MueLu::NoFactory::Build(): this method cannot be called.

p=2: *** Caught standard std::exception of type 'MueLu::Exceptions::RuntimeError' :

 MueLu::NoFactory::Build(): this method cannot be called.
-------------------------------------------------------
Primary job  terminated normally, but 1 process returned
a non-zero exit code.. Per user-direction, the job has been aborted.
-------------------------------------------------------
--------------------------------------------------------------------------
mpirun detected that one or more processes exited with non-zero status, thus causing
the job to be terminated. The first process to do so was:

  Process name: [[17570,1],0]
  Exit code:    1
--------------------------------------------------------------------------
```

I don't know what to set as generating factory. @lucbv, any ideas?

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [x] These changes break backwards compatibility.

## Additional Information

This adds class members and input options to `TentativePFacotry` and to `GeometricInterpolationPFactory`. Before merging, let's get it to work and then figure out how to do this in a clean way.
