### PR TITLE
Adding option to tempus DIRK stepper for resetting initial guess.

### DIFF
--- a/packages/tempus/src/Tempus_StepperDIRK_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperDIRK_decl.hpp
@@ -132,6 +132,12 @@ public:
     virtual void setInitialConditions (
       const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory);
 
+    /// Set parameter so that the initial guess is reset at the beginning of each timestep.
+    virtual void setResetInitialGuess(bool reset_guess)
+      { this->stepperPL_->template set<bool>("Reset Initial Guess", reset_guess); }
+    virtual bool getResetInitialGuess() const
+      { return this->stepperPL_->template get<bool>("Reset Initial Guess", true); }
+
     /// Take the specified timestep, dt, and return true if successful.
     virtual void takeStep(
       const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory);

--- a/packages/tempus/src/Tempus_StepperDIRK_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperDIRK_impl.hpp
@@ -237,6 +237,10 @@ void StepperDIRK<Scalar>::takeStep(
     Teuchos::SerialDenseVector<int,Scalar> b = DIRK_ButcherTableau_->b();
     Teuchos::SerialDenseVector<int,Scalar> c = DIRK_ButcherTableau_->c();
 
+    // Reset non-zero initial guess.
+    if ( this->getResetInitialGuess() && (!this->getZeroInitialGuess()) )
+      Thyra::assign(stageX_.ptr(), *(currentState->getX()));
+
     // Compute stage solutions
     bool pass = true;
     Thyra::SolveStatus<Scalar> sStatus;
@@ -436,6 +440,7 @@ StepperDIRK<Scalar>::getValidParameters() const
   this->getValidParametersBasic(pl);
   pl->set<bool>("Initial Condition Consistency Check", false);
   pl->set<bool>("Zero Initial Guess", false);
+  pl->set<bool>("Reset Initial Guess", true);
   return pl;
 }
 

--- a/packages/tempus/test/DIRK/Tempus_DIRKTest.cpp
+++ b/packages/tempus/test/DIRK/Tempus_DIRKTest.cpp
@@ -90,6 +90,8 @@ TEUCHOS_UNIT_TEST(DIRK, ParameterList)
            .set<double>("theta", 0.5);
       tempusPL->sublist("Default Stepper").remove("Zero Initial Guess");
       tempusPL->sublist("Default Stepper").set<bool>("Zero Initial Guess", 0);
+      tempusPL->sublist("Default Stepper").remove("Reset Initial Guess");
+      tempusPL->sublist("Default Stepper").set<bool>("Reset Initial Guess", 1);
       tempusPL->sublist("Default Stepper").set("Default Solver", *solverPL);
     } else if (RKMethods[m] == "SDIRK 2 Stage 2nd order") {
       // Construct in the same order as default.
@@ -101,6 +103,8 @@ TEUCHOS_UNIT_TEST(DIRK, ParameterList)
            .set<double>("gamma", 0.2928932188134524);
       tempusPL->sublist("Default Stepper").remove("Zero Initial Guess");
       tempusPL->sublist("Default Stepper").set<bool>("Zero Initial Guess", 0);
+      tempusPL->sublist("Default Stepper").remove("Reset Initial Guess");
+      tempusPL->sublist("Default Stepper").set<bool>("Reset Initial Guess", 1);
       tempusPL->sublist("Default Stepper").set("Default Solver", *solverPL);
     } else if (RKMethods[m] == "SDIRK 2 Stage 3rd order") {
       // Construct in the same order as default.
@@ -114,6 +118,8 @@ TEUCHOS_UNIT_TEST(DIRK, ParameterList)
            .set<double>("gamma", 0.7886751345948128);
       tempusPL->sublist("Default Stepper").remove("Zero Initial Guess");
       tempusPL->sublist("Default Stepper").set<bool>("Zero Initial Guess", 0);
+      tempusPL->sublist("Default Stepper").remove("Reset Initial Guess");
+      tempusPL->sublist("Default Stepper").set<bool>("Reset Initial Guess", 1);
       tempusPL->sublist("Default Stepper").set("Default Solver", *solverPL);
     }
 

--- a/packages/tempus/test/DIRK/Tempus_DIRK_SinCos.xml
+++ b/packages/tempus/test/DIRK/Tempus_DIRK_SinCos.xml
@@ -53,6 +53,7 @@
       <Parameter name="Initial Condition Consistency Check" type="bool" value="false"/>
       <Parameter name="Solver Name"    type="string" value="Default Solver"/>
       <Parameter name="Zero Initial Guess" type="bool" value="0"/>
+      <Parameter name="Reset Initial Guess" type="bool" value="1"/>
 
       <ParameterList name="Default Solver">
         <ParameterList name="NOX">

--- a/packages/tempus/test/DIRK/Tempus_DIRK_SteadyQuadratic.xml
+++ b/packages/tempus/test/DIRK/Tempus_DIRK_SteadyQuadratic.xml
@@ -43,6 +43,7 @@
       <Parameter name="Initial Condition Consistency" type="string" value="None"/>
       <Parameter name="Initial Condition Consistency Check" type="bool" value="false"/>
       <Parameter name="Zero Initial Guess" type="bool" value="0"/>
+      <Parameter name="Reset Initial Guess" type="bool" value="1"/>
       <Parameter name="Solver Name"    type="string" value="Default Solver"/>
 
       <ParameterList name="Default Solver">

--- a/packages/tempus/test/DIRK/Tempus_DIRK_VanDerPol.xml
+++ b/packages/tempus/test/DIRK/Tempus_DIRK_VanDerPol.xml
@@ -114,6 +114,7 @@
       <Parameter name="Initial Condition Consistency" type="string" value="None"/>
       <Parameter name="Initial Condition Consistency Check" type="bool" value="false"/>
       <Parameter name="Zero Initial Guess" type="bool" value="0"/>
+      <Parameter name="Reset Initial Guess" type="bool" value="1"/>
       <Parameter name="Solver Name"    type="string" value="Default Solver"/>
 
       <ParameterList name="Default Solver">


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tempus
Tagging drekar team for visibility: @sconde @johnshadid @rppawlo 

## Motivation and Context

The changes in this pull request are motivated by solver difficulties observed in Drekar. In certain situations, the nonlinear solve for a stage may become severely divergent. The resulting diverged solution is nevertheless returned and stored in the internal stage vector of the StepperDIRK class, and becomes the initial guess for the next nonlinear solve. When the timestep is cut and the step is attempted again, this diverged solution persists. Because this diverged solution is a very poor initial guess, subsequent solves will fail regardless of how far the timestep is reduced. The purpose of this pull request is to implement a mechanism to ensure that a reasonable initial guess is used for nonlinear solves after a timestep has failed.

## Description

Implemented option in StepperDIRK to reset the initial stage vector at the beginning of each timestep. If this option is enabled, the stage vector is set to the current solution (the initial condition for the timestep). If this option is set to false, the current behavior of the stepper class is recovered.

## How Has This Been Tested?

A test has been implemented in Drekar to verify that this change has the desired effect on solver robustness.

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [X] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.
