### PR TITLE
MueLu: adding time monitors in region MG

### DIFF
--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
@@ -47,6 +47,7 @@
 
 #include <vector>
 #include <iostream>
+#include <chrono>
 #include <numeric>
 
 #ifdef HAVE_MPI
@@ -92,10 +93,10 @@ using Teuchos::ParameterList;
  * This can be achieved by setting \c inverseScaling to \c true.
  */
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-void scaleInterfaceDOFs(std::vector<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regVec, ///< Vector to be scaled
-    const std::vector<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& scalingFactors, ///< Vector with scaling factors
-    bool inverseScaling ///< Divide by scaling factors (yes/no?)
-    )
+void scaleInterfaceDOFs(Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regVec, ///< Vector to be scaled
+                        const Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& scalingFactors, ///< Vector with scaling factors
+                        bool inverseScaling ///< Divide by scaling factors (yes/no?)
+                        )
 {
   using Vector = Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
   using VectorFactory = Xpetra::VectorFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
@@ -103,7 +104,7 @@ void scaleInterfaceDOFs(std::vector<RCP<Xpetra::Vector<Scalar, LocalOrdinal, Glo
   const Scalar zero = Teuchos::ScalarTraits<Scalar>::zero();
   const Scalar one = Teuchos::ScalarTraits<Scalar>::one();
 
-  for (std::size_t j = 0; j < regVec.size(); j++)
+  for (int j = 0; j < regVec.size(); j++)
   {
     if (inverseScaling)
     {
@@ -1017,6 +1018,9 @@ void MakeCoarseLevelMaps2(const int maxRegPerGID,
   Teuchos::ArrayView<LO> compositeToRegionLIDs = compositeToRegionLIDsFinest;
   for(int currentLevel = 1; currentLevel < numLevels; ++currentLevel) {
 
+    // RCP<Teuchos::FancyOStream> out = Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
+    // regProlong[currentLevel][0]->describe(*out, Teuchos::VERB_EXTREME);
+
     // Extracting some basic information about local mesh in composite/region format
     const size_t numFineRegionNodes    = regProlong[currentLevel][0]->getNodeNumRows();
     const size_t numFineCompositeNodes = compositeToRegionLIDs.size();
@@ -1057,7 +1061,7 @@ void MakeCoarseLevelMaps2(const int maxRegPerGID,
 
     // We communicate the above GIDs to their duplicate so that we can replace GIDs of the region
     // column map and form the quasiregion column map.
-    std::vector<RCP<Xpetra::Vector<MT, LO, GO, NO> > > coarseQuasiregionGIDs(1), coarseRegionGIDs(1);
+    Array<RCP<Xpetra::Vector<MT, LO, GO, NO> > > coarseQuasiregionGIDs(1), coarseRegionGIDs(1);
     compositeToRegional(coarseCompositeGIDs,
                         coarseQuasiregionGIDs,
                         coarseRegionGIDs,
@@ -1250,7 +1254,7 @@ template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void MakeInterfaceScalingFactors(const int maxRegPerProc,
                                  const int numLevels,
                                  Array<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& compRowMaps,
-                                 Array<std::vector<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > >& regInterfaceScalings,
+                                 Array<Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > >& regInterfaceScalings,
                                  Array<std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > >& regRowMaps,
                                  Array<std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > >& regRowImporters,
                                  Array<std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > >& quasiRegRowMaps)
@@ -1276,7 +1280,7 @@ void MakeInterfaceScalingFactors(const int maxRegPerProc,
     /* transform composite layout back to regional layout. Now, GIDs associated
      * with region interface should carry a scaling factor (!= 1).
      */
-    std::vector<RCP<Vector> > quasiRegInterfaceScaling(maxRegPerProc); // Is that vector really needed?
+    Array<RCP<Vector> > quasiRegInterfaceScaling(maxRegPerProc); // Is that vector really needed?
     compositeToRegional(compInterfaceScalingSum, quasiRegInterfaceScaling,
                         regInterfaceScalings[l], maxRegPerProc, quasiRegRowMaps[l],
                         regRowMaps[l], regRowImporters[l]);
@@ -1309,13 +1313,13 @@ void createRegionHierarchy(const int maxRegPerProc,
                            Array<std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > >& regMatrices,
                            Array<std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > >& regProlong,
                            Array<std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > >& regRowImporters,
-                           Array<std::vector<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > >& regInterfaceScalings,
+                           Array<Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > >& regInterfaceScalings,
                            RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& coarseCompOp,
                            const int maxRegPerGID,
                            ArrayView<LocalOrdinal> compositeToRegionLIDs,
                            RCP<Teuchos::ParameterList>& coarseSolverData,
-                           Array<RCP<Teuchos::ParameterList> >& smootherParams
-                           )
+                           Array<RCP<Teuchos::ParameterList> >& smootherParams,
+                           RCP<Teuchos::ParameterList> hierarchyData)
 {
 #include "Xpetra_UseShortNames.hpp"
 
@@ -1432,6 +1436,16 @@ void createRegionHierarchy(const int maxRegPerProc,
       regRowMaps[l][j] = Teuchos::rcp_const_cast<Xpetra::Map<LO,GO,NO> >(regMatrices[l][j]->getRowMap()); // ToDo (mayr.mt) Should we rather copy?
       regColMaps[l][j] = Teuchos::rcp_const_cast<Xpetra::Map<LO,GO,NO> >(regMatrices[l][j]->getColMap()); // ToDo (mayr.mt) Should we rather copy?
     }
+
+    // Create residual and solution vectors and cache them for vCycle apply
+    std::string levelName("level");
+    levelName += std::to_string(l);
+    ParameterList& levelList = hierarchyData->sublist(levelName, false, "list of data on current level");
+    Teuchos::Array<RCP<Vector> > regRes(maxRegPerProc), regSol(maxRegPerProc);
+    createRegionalVector(regRes, maxRegPerProc, revisedRowMapPerGrp);
+    createRegionalVector(regSol, maxRegPerProc, revisedRowMapPerGrp);
+    levelList.set<Teuchos::Array<RCP<Vector> > >("residual", regRes, "Cached residual vector");
+    levelList.set<Teuchos::Array<RCP<Vector> > >("solution", regSol, "Cached solution vector");
   }
 
   MakeCoarseLevelMaps2(maxRegPerGID,
@@ -1526,7 +1540,7 @@ void createRegionHierarchy(const int maxRegPerProc,
                            Array<std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > >& regMatrices,
                            Array<std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > >& regProlong,
                            Array<std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > >& regRowImporters,
-                           Array<std::vector<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > >& regInterfaceScalings,
+                           Array<Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > >& regInterfaceScalings,
                            RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& coarseCompOp,
                            Array<RCP<Teuchos::ParameterList> >& smootherParams
                            )
@@ -1545,7 +1559,7 @@ void createRegionHierarchy(const int maxRegPerProc,
                         revisedColMapPerGrp, rowImportPerGrp, compRowMaps, compColMaps, regRowMaps,
                         regColMaps, quasiRegRowMaps, quasiRegColMaps, regMatrices, regProlong,
                         regRowImporters, regInterfaceScalings, coarseCompOp, maxRegPerGID,
-                        compositeToRegionLIDs, coarseSolverParams, smootherParams);
+                        compositeToRegionLIDs, coarseSolverParams, smootherParams, dummy);
 }
 
 
@@ -1557,10 +1571,10 @@ void createRegionHierarchy(const int maxRegPerProc,
  *  3. Compute r = b - y
  */
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-std::vector<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >
-computeResidual(std::vector<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regRes, ///< residual (to be evaluated)
-                const std::vector<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regX, ///< left-hand side (solution)
-                const std::vector<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regB, ///< right-hand side (forcing term)
+Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >
+computeResidual(Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regRes, ///< residual (to be evaluated)
+                const Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regX, ///< left-hand side (solution)
+                const Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regB, ///< right-hand side (forcing term)
                 const std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regionGrpMats,
                 const RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > mapComp, ///< composite map, computed by removing GIDs > numDofs in revisedRowMapPerGrp
                 const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > rowMapPerGrp, ///< row maps in region layout [in] requires the mapping of GIDs on fine mesh to "filter GIDs"
@@ -1569,7 +1583,10 @@ computeResidual(std::vector<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdin
     )
 {
 #include "Xpetra_UseShortNames.hpp"
+  using Teuchos::TimeMonitor;
   const int maxRegPerProc = regX.size();
+
+  RCP<TimeMonitor> tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("computeResidual: 1 - Rreg = Areg*Xreg")));
 
   /* Update the residual vector
    * 1. Compute tmp = A * regX in each region
@@ -1582,13 +1599,21 @@ computeResidual(std::vector<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdin
     //    TEUCHOS_ASSERT(regionGrpMats[j]->getRangeMap()->isSameAs(*regRes[j]->getMap()));
   }
 
+  tm = Teuchos::null;
+  tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("computeResidual: 2 - sumInterfaceValues")));
+
   sumInterfaceValues(regRes, mapComp, maxRegPerProc, rowMapPerGrp,
                      revisedRowMapPerGrp, rowImportPerGrp);
+
+  tm = Teuchos::null;
+  tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("computeResidual: 3 - Rreg = Breg - Rreg")));
 
   for (int j = 0; j < maxRegPerProc; j++) { // step 3
     regRes[j]->update(1.0, *regB[j], -1.0);
     //    TEUCHOS_ASSERT(regRes[j]->getMap()->isSameAs(*regB[j]->getMap()));
   }
+
+  tm = Teuchos::null;
 
   return regRes;
 } // computeResidual
@@ -1600,21 +1625,22 @@ void vCycle(const int l, ///< ID of current level
             const int numLevels, ///< Total number of levels
             const int maxCoarseIter, ///< max. sweeps on coarse level
             const int maxRegPerProc, ///< Max number of regions per process
-            std::vector<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& fineRegX, ///< solution
-            std::vector<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > fineRegB, ///< right hand side
+            Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& fineRegX, ///< solution
+            Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > fineRegB, ///< right hand side
             Array<std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > > regMatrices, ///< Matrices in region layout
             Array<std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > > regProlong, ///< Prolongators in region layout
             Array<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > compRowMaps, ///< composite maps
             Array<std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > > quasiRegRowMaps, ///< quasiRegional row maps
             Array<std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > > regRowMaps, ///< regional row maps
             Array<std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > > regRowImporters, ///< regional row importers
-            Array<std::vector<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > > regInterfaceScalings, ///< regional interface scaling factors
+            Array<Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > > regInterfaceScalings, ///< regional interface scaling factors
             Array<RCP<Teuchos::ParameterList> > smootherParams, ///< region smoother parameter list
             RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > coarseCompMat, ///< Coarsest level composite operator
-            RCP<ParameterList> coarseSolverData = Teuchos::null
-            )
+            RCP<ParameterList> coarseSolverData = Teuchos::null,
+            RCP<ParameterList> hierarchyData = Teuchos::null)
 {
 #include "MueLu_UseShortNames.hpp"
+  using Teuchos::TimeMonitor;
   const Scalar SC_ZERO = Teuchos::ScalarTraits<Scalar>::zero();
   const Scalar SC_ONE = Teuchos::ScalarTraits<Scalar>::one();
 
@@ -1622,21 +1648,47 @@ void vCycle(const int l, ///< ID of current level
 
 //    std::cout << "level: " << l << std::endl;
 
+    // extract data from hierarchy parameterlist
+    std::string levelName("level" + std::to_string(l));
+    ParameterList levelList;
+    bool useCachedVectors = false;
+    // if(Teuchos::nonnull(hierarchyData) &&  hierarchyData->isSublist(levelName)) {
+    //   levelList = hierarchyData->sublist(levelName);
+    //   if(levelList.isParameter("residual") && levelList.isParameter("solution")) {
+    //     useCachedVectors = true;
+    //   }
+    // }
+
+    RCP<TimeMonitor> tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("vCycle: 1 - pre-smoother")));
+
     // pre-smoothing
     smootherApply(smootherParams[l], maxRegPerProc, fineRegX, fineRegB, regMatrices[l],
                   regInterfaceScalings[l], compRowMaps[l],
                   quasiRegRowMaps[l], regRowMaps[l], regRowImporters[l]);
 
-    std::vector<RCP<Vector> > regRes(maxRegPerProc);
-    createRegionalVector(regRes, maxRegPerProc, regRowMaps[l]);
+    tm = Teuchos::null;
+    tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("vCycle: 2 - compute residual")));
+
+    Array<RCP<Vector> > regRes(maxRegPerProc);
+    if(useCachedVectors) {
+      regRes = levelList.get<Teuchos::Array<RCP<Vector> > >("residual");
+    } else {
+      createRegionalVector(regRes, maxRegPerProc, regRowMaps[l]);
+    }
     computeResidual(regRes, fineRegX, fineRegB, regMatrices[l], compRowMaps[l],
                     quasiRegRowMaps[l], regRowMaps[l], regRowImporters[l]);
 
+    tm = Teuchos::null;
+    tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("vCycle: 3 - scale interface")));
+
     scaleInterfaceDOFs(regRes, regInterfaceScalings[l], true);
 
+    tm = Teuchos::null;
+    tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("vCycle: 4 - create coarse vectors")));
+
     // Transfer to coarse level
-    std::vector<RCP<Vector> > coarseRegX(maxRegPerProc);
-    std::vector<RCP<Vector> > coarseRegB(maxRegPerProc);
+    Array<RCP<Vector> > coarseRegX(maxRegPerProc);
+    Array<RCP<Vector> > coarseRegB(maxRegPerProc);
     for (int j = 0; j < maxRegPerProc; j++) {
       coarseRegX[j] = VectorFactory::Build(regRowMaps[l+1][j], true);
       coarseRegB[j] = VectorFactory::Build(regRowMaps[l+1][j], true);
@@ -1645,23 +1697,34 @@ void vCycle(const int l, ///< ID of current level
       TEUCHOS_ASSERT(regProlong[l+1][j]->getRangeMap()->isSameAs(*regRes[j]->getMap()));
       TEUCHOS_ASSERT(regProlong[l+1][j]->getDomainMap()->isSameAs(*coarseRegB[j]->getMap()));
     }
+
+    tm = Teuchos::null;
+    tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("vCycle: 5 - sum interface values")));
+
     sumInterfaceValues(coarseRegB, compRowMaps[l+1], maxRegPerProc,
                        quasiRegRowMaps[l+1], regRowMaps[l+1], regRowImporters[l+1]);
+
+    tm = Teuchos::null;
 
     // Call V-cycle recursively
     vCycle(l+1, numLevels, maxCoarseIter, maxRegPerProc,
            coarseRegX, coarseRegB, regMatrices, regProlong, compRowMaps,
            quasiRegRowMaps, regRowMaps, regRowImporters, regInterfaceScalings,
-           smootherParams, coarseCompMat, coarseSolverData);
+           smootherParams, coarseCompMat, coarseSolverData, hierarchyData);
+
+    tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("vCycle: 6 - transfer coarse to fine")));
 
     // Transfer coarse level correction to fine level
-    std::vector<RCP<Vector> > regCorrection(maxRegPerProc);
+    Array<RCP<Vector> > regCorrection(maxRegPerProc);
     for (int j = 0; j < maxRegPerProc; j++) {
       regCorrection[j] = VectorFactory::Build(regRowMaps[l][j], true);
       regProlong[l+1][j]->apply(*coarseRegX[j], *regCorrection[j]);
       TEUCHOS_ASSERT(regProlong[l+1][j]->getDomainMap()->isSameAs(*coarseRegX[j]->getMap()));
       TEUCHOS_ASSERT(regProlong[l+1][j]->getRangeMap()->isSameAs(*regCorrection[j]->getMap()));
     }
+
+    tm = Teuchos::null;
+    tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("vCycle: 7 - add coarse grid correction")));
 
     // apply coarse grid correction
     for (int j = 0; j < maxRegPerProc; j++) {
@@ -1670,16 +1733,24 @@ void vCycle(const int l, ///< ID of current level
 
 //    std::cout << "level: " << l << std::endl;
 
+    tm = Teuchos::null;
+    tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("vCycle: 8 - post-smoother")));
+
     // post-smoothing
     smootherApply(smootherParams[l], maxRegPerProc, fineRegX, fineRegB, regMatrices[l],
                   regInterfaceScalings[l], compRowMaps[l],
                   quasiRegRowMaps[l], regRowMaps[l], regRowImporters[l]);
+
+    tm = Teuchos::null;
+
   } else {
 
     // Coarsest grid solve
 
     RCP<Teuchos::FancyOStream> fos = Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
     fos->setOutputToRootOnly(0);
+
+    RCP<TimeMonitor> tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("vCycle: * - coarsest grid solve")));
 
     // First get the Xpetra vectors from region to composite format
     // (the coarseCompMat should already exist)
@@ -1702,7 +1773,7 @@ void vCycle(const int l, ///< ID of current level
 #if defined(HAVE_MUELU_TPETRA) && defined(HAVE_MUELU_AMESOS2)
 
       using DirectCoarseSolver = Amesos2::Solver<Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>, Tpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> >;
-      RCP<DirectCoarseSolver> coarseSolver = coarseSolverData->get<RCP<DirectCoarseSolver>>("direct solver object");
+      RCP<DirectCoarseSolver> coarseSolver = coarseSolverData->get<RCP<DirectCoarseSolver> >("direct solver object");
 
       TEUCHOS_TEST_FOR_EXCEPT_MSG(coarseCompMat->getRowMap()->lib()!=Xpetra::UseTpetra,
           "Coarse solver requires Tpetra/Amesos2 stack.");
@@ -1753,12 +1824,14 @@ void vCycle(const int l, ///< ID of current level
     }
 
     // Transform back to region format
-    std::vector<RCP<Vector> > quasiRegX(maxRegPerProc);
+    Array<RCP<Vector> > quasiRegX(maxRegPerProc);
     compositeToRegional(compX, quasiRegX, fineRegX,
                         maxRegPerProc,
                         quasiRegRowMaps[l],
                         regRowMaps[l],
                         regRowImporters[l]);
+
+    tm = Teuchos::null;
   }
 
   return;

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionSmoothers_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionSmoothers_def.hpp
@@ -91,149 +91,35 @@ void jacobiSetup(RCP<Teuchos::ParameterList> params,
                  const int maxRegPerProc,
                  const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > revisedRowMapPerGrp,
                  const std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regionGrpMats,
-                 const std::vector<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regionInterfaceScaling,
+                 const Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regionInterfaceScaling,
                  const RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > mapComp, ///< composite map
                  const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > rowMapPerGrp, ///< row maps in region layout [in] requires the mapping of GIDs on fine mesh to "filter GIDs"
                  const std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > rowImportPerGrp) ///< row importer in region layout [in]
 {
 #include "Xpetra_UseShortNames.hpp"
-  std::vector<RCP<Vector> > regRes(maxRegPerProc);
+  Array<RCP<Vector> > regRes(maxRegPerProc);
   createRegionalVector(regRes, maxRegPerProc, revisedRowMapPerGrp);
 
   // extract diagonal from region matrices, recover true diagonal values, invert diagonal
-  
-  std::vector<RCP<Vector> > diagReg(maxRegPerProc);
+
+  Array<RCP<Vector> > diagReg(maxRegPerProc);
   createRegionalVector(diagReg, maxRegPerProc, revisedRowMapPerGrp);
 
   for (int j = 0; j < maxRegPerProc; j++) {
     // extract inverse of diagonal from matrix
     diagReg[j] = VectorFactory::Build(regionGrpMats[j]->getRowMap(), true);
     regionGrpMats[j]->getLocalDiagCopy(*diagReg[j]);
-
-    // RCP<Teuchos::FancyOStream> out = Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
-    // regionInterfaceScaling[j]->describe(*out, Teuchos::VERB_EXTREME);
-    // diag[j]->describe(*out, Teuchos::VERB_EXTREME);
-  }
-
-  params->set<Teuchos::Array<RCP<Vector> > >("jacobi: inverse diagonal", diag);
-}
-
-/*! \brief performs Jacobi setup
- *
- * Computes the inverse of the diagonal in region format and with interface scaling
- */
-template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-void jacobiSetup(RCP<Teuchos::ParameterList> params,
-                 const int maxRegPerProc,
-                 const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > revisedRowMapPerGrp,
-                 const std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regionGrpMats,
-                 const Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regionInterfaceScaling) {
-#include "Xpetra_UseShortNames.hpp"
-  const Scalar SC_ZERO = Teuchos::ScalarTraits<Scalar>::zero();
-  const Scalar SC_ONE = Teuchos::ScalarTraits<Scalar>::one();
-
-  Array<RCP<Vector> > regRes(maxRegPerProc);
-  createRegionalVector(regRes, maxRegPerProc, revisedRowMapPerGrp);
-
-  // extract diagonal from region matrices, recover true diagonal values, invert diagonal
-  Teuchos::Array<RCP<Vector> > diag(maxRegPerProc);
-  for (int j = 0; j < maxRegPerProc; j++) {
-    // extract inverse of diagonal from matrix
-    diag[j] = VectorFactory::Build(regionGrpMats[j]->getRowMap(), true);
-    regionGrpMats[j]->getLocalDiagCopy(*diag[j]);
-    diag[j]->elementWiseMultiply(SC_ONE, *regionInterfaceScaling[j], *diag[j], SC_ZERO); // ToDo Does it work to pass in diag[j], but also return into the same variable?
-    diag[j]->reciprocal(*diag[j]);
-
-    // RCP<Teuchos::FancyOStream> out = Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
-    // regionInterfaceScaling[j]->describe(*out, Teuchos::VERB_EXTREME);
-    // diag[j]->describe(*out, Teuchos::VERB_EXTREME);
   }
 
   sumInterfaceValues(diagReg, mapComp, maxRegPerProc, rowMapPerGrp,
-        revisedRowMapPerGrp, rowImportPerGrp);
+                     revisedRowMapPerGrp, rowImportPerGrp);
 
   for (int j = 0; j < maxRegPerProc; j++) {
     diagReg[j]->reciprocal(*diagReg[j]);
   }
-  Teuchos::Array<RCP<Vector> > diag(maxRegPerProc);
-  for (int j = 0; j < maxRegPerProc; j++) diag[j] = diagReg[j];
-  params->set<Teuchos::Array<RCP<Vector> > >("jacobi: inverse diagonal", diag);
+
+  params->set<Teuchos::Array<RCP<Vector> > >("jacobi: inverse diagonal", diagReg);
 }
-
-/*! \brief Do Jacobi smoothing
- *
- *  Perform Jacobi smoothing in the region layout using the true diagonal value
- *  recovered from the splitted matrix.
- */
-template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-void jacobiIterate(RCP<Teuchos::ParameterList> smootherParams,
-                   std::vector<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regX, // left-hand side (or solution)
-                   const std::vector<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regB, // right-hand side (or residual)
-                   const std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regionGrpMats, // matrices in true region layout
-                   const std::vector<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regionInterfaceScaling, // recreate on coarse grid by import Add on region vector of ones
-                   const int maxRegPerProc, ///< max number of regions per proc [in]
-                   const RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > mapComp, ///< composite map
-                   const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > rowMapPerGrp, ///< row maps in region layout [in] requires the mapping of GIDs on fine mesh to "filter GIDs"
-                   const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > revisedRowMapPerGrp, ///< revised row maps in region layout [in] (actually extracted from regionGrpMats)
-                   const std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > rowImportPerGrp ///< row importer in region layout [in]
-    )
-{
-#include "Xpetra_UseShortNames.hpp"
-  // const Scalar SC_ZERO = Teuchos::ScalarTraits<Scalar>::zero();
-  const Scalar SC_ONE = Teuchos::ScalarTraits<Scalar>::one();
-
-  const int maxIter    = smootherParams->get<int>   ("smoother: sweeps");
-  const double damping = smootherParams->get<double>("smoother: damping");
-  Array<RCP<Vector> > diag_inv = smootherParams->get<Array<RCP<Vector> > >("jacobi: inverse diagonal");
-
-  Array<RCP<Vector> > regRes(maxRegPerProc);
-  createRegionalVector(regRes, maxRegPerProc, revisedRowMapPerGrp);
-
-
-  for (int iter = 0; iter < maxIter; ++iter) {
-
-    /* Update the residual vector
-     * 1. Compute tmp = A * regX in each region
-     * 2. Sum interface values in tmp due to duplication (We fake this by scaling to reverse the basic splitting)
-     * 3. Compute r = B - tmp
-     */
-    for (int j = 0; j < maxRegPerProc; j++) { // step 1
-
-//      Teuchos::RCP<Teuchos::FancyOStream> fos = Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
-//      regRes[j]->getMap()->describe(*fos, Teuchos::VERB_EXTREME);
-//      regionGrpMats[j]->getRangeMap()->describe(*fos, Teuchos::VERB_EXTREME);
-
-//      TEUCHOS_ASSERT(regionGrpMats[j]->getDomainMap()->isSameAs(*regX[j]->getMap()));
-//      TEUCHOS_ASSERT(regionGrpMats[j]->getRangeMap()->isSameAs(*regRes[j]->getMap()));
-
-      regionGrpMats[j]->apply(*regX[j], *regRes[j]);
-    }
-
-    sumInterfaceValues(regRes, mapComp, maxRegPerProc, rowMapPerGrp,
-                       revisedRowMapPerGrp, rowImportPerGrp); // step 2
-
-    for (int j = 0; j < maxRegPerProc; j++) { // step 3
-      regRes[j]->update(SC_ONE, *regB[j], -SC_ONE);
-    }
-
-    // check for convergence
-    {
-      RCP<Vector> compRes = VectorFactory::Build(mapComp, true);
-      regionalToComposite(regRes, compRes, maxRegPerProc, rowMapPerGrp,
-                          rowImportPerGrp, Xpetra::ADD);
-      typename Teuchos::ScalarTraits<Scalar>::magnitudeType normRes = compRes->norm2();
-
-      if (normRes < 1.0e-12) {return;}
-    }
-
-    for (int j = 0; j < maxRegPerProc; j++) {
-      // update solution according to Jacobi's method
-      regX[j]->elementWiseMultiply(damping, *diag_inv[j], *regRes[j], SC_ONE);
-    }
-  }
-
-  return;
-} // jacobiIterate
 
 /*! \brief Do Jacobi smoothing
  *
@@ -273,14 +159,6 @@ void jacobiIterate(RCP<Teuchos::ParameterList> smootherParams,
      * 3. Compute r = B - tmp
      */
     for (int j = 0; j < maxRegPerProc; j++) { // step 1
-
-//      Teuchos::RCP<Teuchos::FancyOStream> fos = Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
-//      regRes[j]->getMap()->describe(*fos, Teuchos::VERB_EXTREME);
-//      regionGrpMats[j]->getRangeMap()->describe(*fos, Teuchos::VERB_EXTREME);
-
-//      TEUCHOS_ASSERT(regionGrpMats[j]->getDomainMap()->isSameAs(*regX[j]->getMap()));
-//      TEUCHOS_ASSERT(regionGrpMats[j]->getRangeMap()->isSameAs(*regRes[j]->getMap()));
-
       regionGrpMats[j]->apply(*regX[j], *regRes[j]);
     }
 
@@ -291,8 +169,8 @@ void jacobiIterate(RCP<Teuchos::ParameterList> smootherParams,
       regRes[j]->update(SC_ONE, *regB[j], -SC_ONE);
     }
 
+    // update solution according to Jacobi's method
     for (int j = 0; j < maxRegPerProc; j++) {
-      // update solution according to Jacobi's method
       regX[j]->elementWiseMultiply(damping, *diag_inv[j], *regRes[j], SC_ONE);
     }
   }
@@ -379,7 +257,7 @@ void smootherSetup(RCP<Teuchos::ParameterList> params,
                    const int maxRegPerProc,
                    const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > revisedRowMapPerGrp,
                    const std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regionGrpMats,
-                   const Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regionInterfaceScaling) {
+                   const Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regionInterfaceScaling,
                    const RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > mapComp, ///< composite map
                    const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > rowMapPerGrp, ///< row maps in region layout [in] requires the mapping of GIDs on fine mesh to "filter GIDs"
                    const std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > rowImportPerGrp) ///< row importer in region layout [in]
@@ -397,11 +275,11 @@ void smootherSetup(RCP<Teuchos::ParameterList> params,
     break;
   case 1:
     jacobiSetup(params, maxRegPerProc, revisedRowMapPerGrp, regionGrpMats, regionInterfaceScaling,
-                mapComp, rowMapPerGrp,  rowImportPerGrp);
+                mapComp, rowMapPerGrp, rowImportPerGrp);
     break;
   case 2:
     jacobiSetup(params, maxRegPerProc, revisedRowMapPerGrp, regionGrpMats, regionInterfaceScaling,
-                mapComp, rowMapPerGrp,  rowImportPerGrp);
+                mapComp, rowMapPerGrp, rowImportPerGrp);
     break;
   case 3:
     std::cout << "Chebyshev smoother not implemented yet no smoother is applied" << std::endl;

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionSmoothers_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionSmoothers_def.hpp
@@ -109,6 +109,44 @@ void jacobiSetup(RCP<Teuchos::ParameterList> params,
     // extract inverse of diagonal from matrix
     diagReg[j] = VectorFactory::Build(regionGrpMats[j]->getRowMap(), true);
     regionGrpMats[j]->getLocalDiagCopy(*diagReg[j]);
+
+    // RCP<Teuchos::FancyOStream> out = Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
+    // regionInterfaceScaling[j]->describe(*out, Teuchos::VERB_EXTREME);
+    // diag[j]->describe(*out, Teuchos::VERB_EXTREME);
+  }
+
+  params->set<Teuchos::Array<RCP<Vector> > >("jacobi: inverse diagonal", diag);
+}
+
+/*! \brief performs Jacobi setup
+ *
+ * Computes the inverse of the diagonal in region format and with interface scaling
+ */
+template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+void jacobiSetup(RCP<Teuchos::ParameterList> params,
+                 const int maxRegPerProc,
+                 const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > revisedRowMapPerGrp,
+                 const std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regionGrpMats,
+                 const Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regionInterfaceScaling) {
+#include "Xpetra_UseShortNames.hpp"
+  const Scalar SC_ZERO = Teuchos::ScalarTraits<Scalar>::zero();
+  const Scalar SC_ONE = Teuchos::ScalarTraits<Scalar>::one();
+
+  Array<RCP<Vector> > regRes(maxRegPerProc);
+  createRegionalVector(regRes, maxRegPerProc, revisedRowMapPerGrp);
+
+  // extract diagonal from region matrices, recover true diagonal values, invert diagonal
+  Teuchos::Array<RCP<Vector> > diag(maxRegPerProc);
+  for (int j = 0; j < maxRegPerProc; j++) {
+    // extract inverse of diagonal from matrix
+    diag[j] = VectorFactory::Build(regionGrpMats[j]->getRowMap(), true);
+    regionGrpMats[j]->getLocalDiagCopy(*diag[j]);
+    diag[j]->elementWiseMultiply(SC_ONE, *regionInterfaceScaling[j], *diag[j], SC_ZERO); // ToDo Does it work to pass in diag[j], but also return into the same variable?
+    diag[j]->reciprocal(*diag[j]);
+
+    // RCP<Teuchos::FancyOStream> out = Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
+    // regionInterfaceScaling[j]->describe(*out, Teuchos::VERB_EXTREME);
+    // diag[j]->describe(*out, Teuchos::VERB_EXTREME);
   }
 
   sumInterfaceValues(diagReg, mapComp, maxRegPerProc, rowMapPerGrp,
@@ -146,10 +184,9 @@ void jacobiIterate(RCP<Teuchos::ParameterList> smootherParams,
 
   const int maxIter    = smootherParams->get<int>   ("smoother: sweeps");
   const double damping = smootherParams->get<double>("smoother: damping");
-  Teuchos::Array<RCP<Vector> > diag_inv = smootherParams->get<Teuchos::Array<RCP<Vector> > >("jacobi: inverse diagonal");
+  Array<RCP<Vector> > diag_inv = smootherParams->get<Array<RCP<Vector> > >("jacobi: inverse diagonal");
 
-
-  std::vector<RCP<Vector> > regRes(maxRegPerProc);
+  Array<RCP<Vector> > regRes(maxRegPerProc);
   createRegionalVector(regRes, maxRegPerProc, revisedRowMapPerGrp);
 
 
@@ -176,7 +213,82 @@ void jacobiIterate(RCP<Teuchos::ParameterList> smootherParams,
                        revisedRowMapPerGrp, rowImportPerGrp); // step 2
 
     for (int j = 0; j < maxRegPerProc; j++) { // step 3
-      regRes[j]->update(1.0, *regB[j], -1.0);
+      regRes[j]->update(SC_ONE, *regB[j], -SC_ONE);
+    }
+
+    // check for convergence
+    {
+      RCP<Vector> compRes = VectorFactory::Build(mapComp, true);
+      regionalToComposite(regRes, compRes, maxRegPerProc, rowMapPerGrp,
+                          rowImportPerGrp, Xpetra::ADD);
+      typename Teuchos::ScalarTraits<Scalar>::magnitudeType normRes = compRes->norm2();
+
+      if (normRes < 1.0e-12) {return;}
+    }
+
+    for (int j = 0; j < maxRegPerProc; j++) {
+      // update solution according to Jacobi's method
+      regX[j]->elementWiseMultiply(damping, *diag_inv[j], *regRes[j], SC_ONE);
+    }
+  }
+
+  return;
+} // jacobiIterate
+
+/*! \brief Do Jacobi smoothing
+ *
+ *  Perform Jacobi smoothing in the region layout using the true diagonal value
+ *  recovered from the splitted matrix.
+ */
+template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+void jacobiIterate(RCP<Teuchos::ParameterList> smootherParams,
+                   Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regX, // left-hand side (or solution)
+                   const Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regB, // right-hand side (or residual)
+                   const std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regionGrpMats, // matrices in true region layout
+                   const Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regionInterfaceScaling, // recreate on coarse grid by import Add on region vector of ones
+                   const int maxRegPerProc, ///< max number of regions per proc [in]
+                   const RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > mapComp, ///< composite map
+                   const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > rowMapPerGrp, ///< row maps in region layout [in] requires the mapping of GIDs on fine mesh to "filter GIDs"
+                   const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > revisedRowMapPerGrp, ///< revised row maps in region layout [in] (actually extracted from regionGrpMats)
+                   const std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > rowImportPerGrp ///< row importer in region layout [in]
+    )
+{
+#include "Xpetra_UseShortNames.hpp"
+  // const Scalar SC_ZERO = Teuchos::ScalarTraits<Scalar>::zero();
+  const Scalar SC_ONE = Teuchos::ScalarTraits<Scalar>::one();
+
+  const int maxIter    = smootherParams->get<int>   ("smoother: sweeps");
+  const double damping = smootherParams->get<double>("smoother: damping");
+  Array<RCP<Vector> > diag_inv = smootherParams->get<Array<RCP<Vector> > >("jacobi: inverse diagonal");
+
+  Array<RCP<Vector> > regRes(maxRegPerProc);
+  createRegionalVector(regRes, maxRegPerProc, revisedRowMapPerGrp);
+
+
+  for (int iter = 0; iter < maxIter; ++iter) {
+
+    /* Update the residual vector
+     * 1. Compute tmp = A * regX in each region
+     * 2. Sum interface values in tmp due to duplication (We fake this by scaling to reverse the basic splitting)
+     * 3. Compute r = B - tmp
+     */
+    for (int j = 0; j < maxRegPerProc; j++) { // step 1
+
+//      Teuchos::RCP<Teuchos::FancyOStream> fos = Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
+//      regRes[j]->getMap()->describe(*fos, Teuchos::VERB_EXTREME);
+//      regionGrpMats[j]->getRangeMap()->describe(*fos, Teuchos::VERB_EXTREME);
+
+//      TEUCHOS_ASSERT(regionGrpMats[j]->getDomainMap()->isSameAs(*regX[j]->getMap()));
+//      TEUCHOS_ASSERT(regionGrpMats[j]->getRangeMap()->isSameAs(*regRes[j]->getMap()));
+
+      regionGrpMats[j]->apply(*regX[j], *regRes[j]);
+    }
+
+    sumInterfaceValues(regRes, mapComp, maxRegPerProc, rowMapPerGrp,
+                       revisedRowMapPerGrp, rowImportPerGrp); // step 2
+
+    for (int j = 0; j < maxRegPerProc; j++) { // step 3
+      regRes[j]->update(SC_ONE, *regB[j], -SC_ONE);
     }
 
     for (int j = 0; j < maxRegPerProc; j++) {
@@ -195,16 +307,16 @@ void jacobiIterate(RCP<Teuchos::ParameterList> smootherParams,
  */
 template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void GSIterate(RCP<Teuchos::ParameterList> smootherParams,
-                   std::vector<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regX, // left-hand side (or solution)
-                   const std::vector<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regB, // right-hand side (or residual)
-                   const std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regionGrpMats, // matrices in true region layout
-                   const std::vector<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regionInterfaceScaling, // recreate on coarse grid by import Add on region vector of ones
-                   const int maxRegPerProc, ///< max number of regions per proc [in]
-                   const RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > mapComp, ///< composite map
-                   const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > rowMapPerGrp, ///< row maps in region layout [in] requires the mapping of GIDs on fine mesh to "filter GIDs"
-                   const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > revisedRowMapPerGrp, ///< revised row maps in region layout [in] (actually extracted from regionGrpMats)
-                   const std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > rowImportPerGrp ///< row importer in region layout [in]
-    )
+               Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regX, // left-hand side (or solution)
+               const Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regB, // right-hand side (or residual)
+               const std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regionGrpMats, // matrices in true region layout
+               const Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regionInterfaceScaling, // recreate on coarse grid by import Add on region vector of ones
+               const int maxRegPerProc, ///< max number of regions per proc [in]
+               const RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > mapComp, ///< composite map
+               const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > rowMapPerGrp, ///< row maps in region layout [in] requires the mapping of GIDs on fine mesh to "filter GIDs"
+               const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > revisedRowMapPerGrp, ///< revised row maps in region layout [in] (actually extracted from regionGrpMats)
+               const std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > rowImportPerGrp ///< row importer in region layout [in]
+               )
 {
 #include "Xpetra_UseShortNames.hpp"
   const int maxIter    = smootherParams->get<int>   ("smoother: sweeps");
@@ -212,7 +324,7 @@ void GSIterate(RCP<Teuchos::ParameterList> smootherParams,
   Teuchos::Array<RCP<Vector> > diag_inv = smootherParams->get<Teuchos::Array<RCP<Vector> > >("jacobi: inverse diagonal");
 
 
-  std::vector<RCP<Vector> > regRes(maxRegPerProc);
+  Array<RCP<Vector> > regRes(maxRegPerProc);
   createRegionalVector(regRes, maxRegPerProc, revisedRowMapPerGrp);
 
   for (int iter = 0; iter < maxIter; ++iter) {
@@ -233,18 +345,18 @@ void GSIterate(RCP<Teuchos::ParameterList> smootherParams,
       regRes[j]->update(1.0, *regB[j], -1.0);
     }
 
-    // update the solution and the residual 
-    
+    // update the solution and the residual
+
     using MT = typename Teuchos::ScalarTraits<SC>::magnitudeType;
     RCP<Vector>  delta;
     delta = VectorFactory::Build(regionGrpMats[0]->getRowMap(), true);
-    Teuchos::ArrayRCP<SC> ldelta= delta->getDataNonConst(0);
-    Teuchos::ArrayRCP<SC> OneregX= regX[0]->getDataNonConst(0);
-    Teuchos::ArrayRCP<SC> OneregRes= regRes[0]->getDataNonConst(0);
+    ArrayRCP<SC> ldelta= delta->getDataNonConst(0);
+    ArrayRCP<SC> OneregX= regX[0]->getDataNonConst(0);
+    ArrayRCP<SC> OneregRes= regRes[0]->getDataNonConst(0);
     Teuchos::ArrayRCP<SC> Onediag = diag_inv[0]->getDataNonConst(0);
 
     for (size_t k = 0; k < regionGrpMats[0]->getNodeNumRows(); k++) ldelta[k] = 0.;
-    for (size_t k = 0; k < regionGrpMats[0]->getNodeNumRows(); k++) { 
+    for (size_t k = 0; k < regionGrpMats[0]->getNodeNumRows(); k++) {
       ArrayView<const LO> AAcols;
       ArrayView<const SC> AAvals;
       regionGrpMats[0]->getLocalRowView(k, AAcols, AAvals);
@@ -267,7 +379,7 @@ void smootherSetup(RCP<Teuchos::ParameterList> params,
                    const int maxRegPerProc,
                    const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > revisedRowMapPerGrp,
                    const std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regionGrpMats,
-                   const std::vector<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regionInterfaceScaling,
+                   const Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regionInterfaceScaling) {
                    const RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > mapComp, ///< composite map
                    const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > rowMapPerGrp, ///< row maps in region layout [in] requires the mapping of GIDs on fine mesh to "filter GIDs"
                    const std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > rowImportPerGrp) ///< row importer in region layout [in]
@@ -303,10 +415,10 @@ void smootherSetup(RCP<Teuchos::ParameterList> params,
 template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void smootherApply(RCP<Teuchos::ParameterList> params,
                    const int maxRegPerProc,
-                   std::vector<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regX,
-                   const std::vector<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regB,
+                   Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regX,
+                   const Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regB,
                    const std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regionGrpMats,
-                   const std::vector<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regionInterfaceScaling,
+                   const Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regionInterfaceScaling,
                    const RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > mapComp,
                    const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > rowMapPerGrp,
                    const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > revisedRowMapPerGrp,
@@ -316,7 +428,7 @@ void smootherApply(RCP<Teuchos::ParameterList> params,
   std::map<std::string, int> smootherTypes;
   smootherTypes.insert(std::pair<std::string, int>("None",         0));
   smootherTypes.insert(std::pair<std::string, int>("Jacobi",       1));
-  smootherTypes.insert(std::pair<std::string, int>("Gauss", 2));
+  smootherTypes.insert(std::pair<std::string, int>("Gauss-Seidel", 2));
   smootherTypes.insert(std::pair<std::string, int>("Chebyshev",    3));
 
   switch(smootherTypes[type]) {
@@ -325,10 +437,7 @@ void smootherApply(RCP<Teuchos::ParameterList> params,
   case 1:
     jacobiIterate(params, regX, regB, regionGrpMats, regionInterfaceScaling, maxRegPerProc,
                   mapComp, rowMapPerGrp, revisedRowMapPerGrp, rowImportPerGrp);
-    break;
   case 2:
-    GSIterate(params, regX, regB, regionGrpMats, regionInterfaceScaling, maxRegPerProc,
-                  mapComp, rowMapPerGrp, revisedRowMapPerGrp, rowImportPerGrp);
     break;
   case 3:
     break;

--- a/packages/muelu/research/mmayr/composite_to_regions/src/main.cpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/main.cpp
@@ -435,10 +435,10 @@ int main_(int argc, char *argv[]) {
   Teuchos::RCP<Vector> compY = Teuchos::null; // result vector for truly composite calculations
   Teuchos::RCP<Vector> regYComp = Teuchos::null; // result vector in composite layout, but computed via regional operations
 
-  std::vector<Teuchos::RCP<Vector> > quasiRegX(maxRegPerProc); // initial guess associated with myRank's ith region in quasiRegional layout
-  std::vector<Teuchos::RCP<Vector> > quasiRegY(maxRegPerProc); // result vector associated with myRank's ith region in quasiRegional layout
-  std::vector<Teuchos::RCP<Vector> > regX(maxRegPerProc); // initial guess associated with myRank's ith region in regional layout
-  std::vector<Teuchos::RCP<Vector> > regY(maxRegPerProc); // result vector associated with myRank's ith region in regional layout
+  Array<Teuchos::RCP<Vector> > quasiRegX(maxRegPerProc); // initial guess associated with myRank's ith region in quasiRegional layout
+  Array<Teuchos::RCP<Vector> > quasiRegY(maxRegPerProc); // result vector associated with myRank's ith region in quasiRegional layout
+  Array<Teuchos::RCP<Vector> > regX(maxRegPerProc); // initial guess associated with myRank's ith region in regional layout
+  Array<Teuchos::RCP<Vector> > regY(maxRegPerProc); // result vector associated with myRank's ith region in regional layout
 
   std::vector<LocalOrdinal> intIDs; // LIDs of interface DOFs
   std::vector<std::vector<LocalOrdinal> > regIntIDs(maxRegPerProc); // LIDs of interface DOFs
@@ -462,7 +462,7 @@ int main_(int argc, char *argv[]) {
   Array<std::vector<RCP<Matrix> > > regMatrices; // regional matrices on each level
   Array<std::vector<RCP<Matrix> > > regProlong; // regional prolongators on each level
   Array<std::vector<RCP<Import> > > regRowImporters; // regional row importers on each level
-  Array<std::vector<RCP<Vector> > > regInterfaceScalings; // regional interface scaling factors on each level
+  Array<Array<RCP<Vector> > > regInterfaceScalings; // regional interface scaling factors on each level
 
   Teuchos::RCP<Matrix> coarseCompOp = Teuchos::null;
 
@@ -870,14 +870,14 @@ int main_(int argc, char *argv[]) {
     compositeToRegional(compX, quasiRegX, regX, maxRegPerProc, rowMapPerGrp,
         revisedRowMapPerGrp, rowImportPerGrp);
 
-    std::vector<RCP<Vector> > quasiRegB(maxRegPerProc);
-    std::vector<RCP<Vector> > regB(maxRegPerProc);
+    Array<RCP<Vector> > quasiRegB(maxRegPerProc);
+    Array<RCP<Vector> > regB(maxRegPerProc);
     compositeToRegional(compB, quasiRegB, regB, maxRegPerProc, rowMapPerGrp,
         revisedRowMapPerGrp, rowImportPerGrp);
 
 //    printRegionalObject<Vector>("regB 0", regB, myRank, *fos);
 
-    std::vector<RCP<Vector> > regRes(maxRegPerProc);
+    Array<RCP<Vector> > regRes(maxRegPerProc);
     for (int j = 0; j < maxRegPerProc; j++) { // step 1
       regRes[j] = VectorFactory::Build(revisedRowMapPerGrp[j], true);
     }

--- a/packages/muelu/research/mmayr/hhg/Xpetra_RegionMatrix_decl.hpp
+++ b/packages/muelu/research/mmayr/hhg/Xpetra_RegionMatrix_decl.hpp
@@ -30,10 +30,10 @@ enum ESplittingMethodHHG {
  *
  *  \author mayr.mt \date 09/2017
  */
-template <class SC = Operator<>::scalar_type,
-          class LO = Operator<>::local_ordinal_type,
-          class GO = typename Operator<LO>::global_ordinal_type,
-          class NO = typename Operator<LO, GO>::node_type,
+template <class SC = MueLu::DefaultScalar,
+          class LO = MueLu::DefaultLocalOrdinal,
+          class GO = MueLu::DefaultGlobalOrdinal,
+          class NO = MueLu::DefaultNode,
           Xpetra::UnderlyingLib lib = Xpetra::UseEpetra,
           Xpetra::ESplittingMethodHHG splitMethod = region_split> // lbv: what should be the default value here?
 class RegionMatrix //: public Matrix<SC, LO, GO, NO> {

--- a/packages/muelu/research/q2q1/MueLu_Q2Q1PFactory.hpp
+++ b/packages/muelu/research/q2q1/MueLu_Q2Q1PFactory.hpp
@@ -60,10 +60,10 @@
 
 namespace MueLu {
 
-  template <class Scalar = Xpetra::Matrix<>::scalar_type,
-            class LocalOrdinal = typename Xpetra::Matrix<Scalar>::local_ordinal_type,
-            class GlobalOrdinal = typename Xpetra::Matrix<Scalar, LocalOrdinal>::global_ordinal_type,
-            class Node = typename Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal>::node_type>
+  template <class Scalar = MueLu::DefaultScalar,
+            class LocalOrdinal = MueLu::DefaultLocalOrdinal,
+            class GlobalOrdinal = MueLu::DefaultGlobalOrdinal,
+            class Node = MueLu::DefaultNode>
   class Q2Q1PFactory : public PFactory {
 #include "MueLu_UseShortNames.hpp"
 

--- a/packages/muelu/research/q2q1/MueLu_Q2Q1uPFactory.hpp
+++ b/packages/muelu/research/q2q1/MueLu_Q2Q1uPFactory.hpp
@@ -104,10 +104,10 @@ namespace MueLu {
   };
 
 
-  template <class Scalar        = Xpetra::Matrix<>::scalar_type,
-            class LocalOrdinal  = typename Xpetra::Matrix<Scalar>::local_ordinal_type,
-            class GlobalOrdinal = typename Xpetra::Matrix<Scalar, LocalOrdinal>::global_ordinal_type,
-            class Node          = typename Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal>::node_type>
+  template <class Scalar        = MueLu::DefaultScalar,
+            class LocalOrdinal  = MueLu::DefaultLocalOrdinal,
+            class GlobalOrdinal = MueLu::DefaultGlobalOrdinal,
+            class Node          = MueLu::DefaultNode>
   class Q2Q1uPFactory : public PFactory {
 #include "MueLu_UseShortNames.hpp"
     typedef MyCptList_<LocalOrdinal> MyCptList;

--- a/packages/muelu/test/structured/Driver_Structured.cpp
+++ b/packages/muelu/test/structured/Driver_Structured.cpp
@@ -152,7 +152,8 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
   double      tol               = 1e-12;             clp.setOption("tol",                   &tol,               "solver convergence tolerance");
   bool        scaleResidualHist = true;              clp.setOption("scale", "noscale",      &scaleResidualHist, "scaled Krylov residual history");
   bool        solvePreconditioned = true;            clp.setOption("solve-preconditioned","no-solve-preconditioned", &solvePreconditioned, "use MueLu preconditioner in solve");
-  std::string operation         = "solve";           clp.setOption("op",                    &operation,         "operation to perform: (matvec | setup | solver)");  std::string belosType         = "cg";              clp.setOption("belosType",             &belosType,         "belos solver type: (Pseudoblock CG | Block CG | Pseudoblock GMRES | Block GMRES | ...) see BelosSolverFactory.hpp for exhaustive list of solvers");
+  std::string operation         = "solve";           clp.setOption("op",                    &operation,         "operation to perform: (matvec | setup | solver)");
+  std::string belosType         = "cg";              clp.setOption("belosType",             &belosType,         "belos solver type: (Pseudoblock CG | Block CG | Pseudoblock GMRES | Block GMRES | ...) see BelosSolverFactory.hpp for exhaustive list of solvers");
 #ifdef HAVE_MUELU_TPETRA
   std::string equilibrate = "no" ;                   clp.setOption("equilibrate",           &equilibrate,       "equilibrate the system (no | diag | 1-norm)");
 #endif


### PR DESCRIPTION
@trilinos/muelu 

## Description
Adding a whole lot of monitors to find were time can be shaved off?
Also fixing a couple of issues in the experimental side of MueLu after default types in Xpetra have been removed.
Finally switching some of the data from `std::vector` to `Teuchos::Array`.

## Motivation and Context
The main goal is to add time monitor for performance diagnostic, it already allowed to identify a target for refactor.
Using `Teuchos::Array` allows us to use parameter list more easily since std::vector cannot be stored natively on parameter list.

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to #5656
* Part of 
* Composed of 

## How Has This Been Tested?
Local build and test is successful, the monitors are reporting time appropriately


## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.