### PR TITLE
Fix #5711

### DIFF
--- a/TPLsList.cmake
+++ b/TPLsList.cmake
@@ -57,8 +57,8 @@ TRIBITS_REPOSITORY_DEFINE_TPLS(
   MKL             "cmake/TPLs/"    EX
   yaml-cpp        "cmake/TPLs/"    EX
   Peano           "cmake/TPLs/"    EX
-  CUDA            "${${PROJECT_NAME}_TRIBITS_DIR}/core/std_tpls/"    ST
-  CUSPARSE        "cmake/TPLs/"    ST
+  CUDA            "${${PROJECT_NAME}_TRIBITS_DIR}/core/std_tpls/"    PT
+  CUSPARSE        "cmake/TPLs/"    PT
   Thrust          "cmake/TPLs/"    ST
   Cusp            "cmake/TPLs/"    ST
   TBB             "cmake/TPLs/"    EX


### PR DESCRIPTION
@trilinos/framework 

## Description

Make CUDA and CUSPARSE (sic) PT instead of ST.

## Motivation and Context

1. We have a CUDA PR test build, so CUDA should be considered just as important as MPI, the BLAS, and LAPACK (which are all PT).
2. CUSPARSE comes with CUDA automatically, but since it's ST, we're almost certainly not enabling it by default in our CUDA PR test build. This is bad because NVIDIA has done a lot of work to implement kernels that we're likely not testing.

## Related Issues

* Closes #5711 
