### PR TITLE
Panzer: add sideset data to pamgen generated exodus output

### DIFF
--- a/packages/panzer/adapters-stk/cmake/Dependencies.cmake
+++ b/packages/panzer/adapters-stk/cmake/Dependencies.cmake
@@ -1,7 +1,13 @@
+# NOTE: Pamgen is an indirect dependency brought in through
+# SEACASIOSS. We do NOT need to declare it as a direct library
+# dependency. The pamgen stk_interface factory unit test does need
+# Pamgen enabled to run, so Pamgen is only declared an optional test
+# dependency.
+
 SET(LIB_REQUIRED_DEP_PACKAGES STKUtil STKTopology STKMesh STKIO Zoltan Stratimikos Piro NOX Rythmos PanzerCore PanzerDiscFE)
 SET(LIB_OPTIONAL_DEP_PACKAGES SEACASIoss SEACASExodus Teko MueLu Ifpack2)
 SET(TEST_REQUIRED_DEP_PACKAGES SEACASIoss SEACASExodus Teko MueLu Ifpack2)
-SET(TEST_OPTIONAL_DEP_PACKAGES)
+SET(TEST_OPTIONAL_DEP_PACKAGES Pamgen)
 SET(LIB_REQUIRED_DEP_TPLS)
 SET(LIB_OPTIONAL_DEP_TPLS)
 SET(TEST_REQUIRED_DEP_TPLS)

--- a/packages/panzer/adapters-stk/src/Panzer_STK_ModelEvaluatorFactory_impl.hpp
+++ b/packages/panzer/adapters-stk/src/Panzer_STK_ModelEvaluatorFactory_impl.hpp
@@ -77,7 +77,6 @@
 
 #include "Panzer_STK_Interface.hpp"
 #include "Panzer_STK_ExodusReaderFactory.hpp"
-#include "Panzer_STK_PamgenReaderFactory.hpp"
 #include "Panzer_STK_LineMeshFactory.hpp"
 #include "Panzer_STK_SquareQuadMeshFactory.hpp"
 #include "Panzer_STK_SquareTriMeshFactory.hpp"
@@ -960,8 +959,10 @@ namespace panzer_stk {
       mesh_factory->setParameterList(Teuchos::rcp(new Teuchos::ParameterList(mesh_params.sublist("Exodus File"))));
     }
     else if (mesh_params.get<std::string>("Source") ==  "Pamgen Mesh") {
-      mesh_factory = Teuchos::rcp(new panzer_stk::STK_PamgenReaderFactory());
-      mesh_factory->setParameterList(Teuchos::rcp(new Teuchos::ParameterList(mesh_params.sublist("Pamgen Mesh"))));
+      mesh_factory = Teuchos::rcp(new panzer_stk::STK_ExodusReaderFactory());
+      Teuchos::RCP<Teuchos::ParameterList> pamgenList = Teuchos::rcp(new Teuchos::ParameterList(mesh_params.sublist("Pamgen Mesh")));
+      pamgenList->set("File Type","Pamgen"); // For backwards compatibility when pamgen had separate factory from exodus
+      mesh_factory->setParameterList(pamgenList);
     }
     else if (mesh_params.get<std::string>("Source") ==  "Inline Mesh") {
 

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_ExodusReaderFactory.cpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_ExodusReaderFactory.cpp
@@ -61,6 +61,20 @@
 
 namespace panzer_stk {
 
+int getMeshDimension(const std::string & meshStr,
+                     stk::ParallelMachine parallelMach,
+                     const bool isExodus)
+{
+  stk::io::StkMeshIoBroker meshData(parallelMach);
+  meshData.property_add(Ioss::Property("LOWER_CASE_VARIABLE_NAMES", false));
+  if (isExodus)
+    meshData.add_mesh_database(meshStr, "exodus", stk::io::READ_MESH);
+  else
+    meshData.add_mesh_database(meshStr, "pamgen", stk::io::READ_MESH);
+  meshData.create_input_mesh();
+  return Teuchos::as<int>(meshData.meta_data_rcp()->spatial_dimension());
+}
+
 STK_ExodusReaderFactory::STK_ExodusReaderFactory()
   : fileName_(""), restartIndex_(0), isExodus_(true), userMeshScaling_(false), meshScaleFactor_(0.0)
 { }

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_ExodusReaderFactory.hpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_ExodusReaderFactory.hpp
@@ -56,6 +56,23 @@ namespace panzer_stk {
 
 class STK_Interface;
 
+/** External function to return the dimension of an Exodus or Pamgen
+ * mesh. This uses a quick temporary read of the meta data from input
+ * file/mesh and is intended if you need the mesh dimension before the
+ * MeshFactory is used to build the uncommitted mesh. Once
+ * buildUncommittedMesh() is called, you can query the dimension from
+ * the MetaData in the STK_Interface object (will be faster than
+ * creating mesh metadata done in this function).
+ *
+ * \param[in] meshStr Filename containing the mesh string, or the mesh string itself.
+ * \param[in] parallelMach Descriptor for machine to build this mesh on.
+ * \param[in] isExodus Set to true for Exodus mesh, set to false for Pamgen mesh.
+ *
+ * \returns Integer indicating the spatial dimension of the mesh.
+ */
+  int getMeshDimension(const std::string & meshStr,stk::ParallelMachine parallelMach,
+                       const bool isExodus = true);
+
 /** Concrete mesh factory instantiation. This reads
   * a mesh from an exodus file and builds a STK_Interface object.
   *
@@ -100,7 +117,7 @@ public:
      */
    virtual void completeMeshConstruction(STK_Interface & mesh,stk::ParallelMachine parallelMach) const;
 
-   //! From ParameterListAcceptor
+   //! From ParameterListAcceptor. Must be called if the empty ctor is used to construct this object.
    void setParameterList(const Teuchos::RCP<Teuchos::ParameterList> & paramList);
 
    //! From ParameterListAcceptor

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_ExodusReaderFactory.hpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_ExodusReaderFactory.hpp
@@ -71,7 +71,14 @@ public:
 
    STK_ExodusReaderFactory();
 
-   STK_ExodusReaderFactory(const std::string & fileName,int restartIndex=0);
+
+  /** \brief Ctor
+   *
+   * \param[in] fileName Name of the input file.
+   * \param[in] restartIndex Index used for restarts.
+   * \param[in] isExodus If true, the input file is in exodus format. If false, it assumes Pamgen format.
+   */
+  STK_ExodusReaderFactory(const std::string & fileName, const int restartIndex=0, const bool isExodus = true);
 
    /** Construct a STK_Inteface object described
      * by this factory.
@@ -111,6 +118,7 @@ protected:
 
    std::string fileName_;
    int restartIndex_;
+   bool isExodus_;
 
 private:
 

--- a/packages/panzer/adapters-stk/test/stk_interface_test/CMakeLists.txt
+++ b/packages/panzer/adapters-stk/test/stk_interface_test/CMakeLists.txt
@@ -139,15 +139,19 @@ TRIBITS_COPY_FILES_TO_BINARY_DIR(stk_interface_copy
   EXEDEPS tExodusReaderFactory
   )
 
-TRIBITS_COPY_FILES_TO_BINARY_DIR(stk_interface_copy_pamgen
-  SOURCE_FILES pamgen_test.gen
-  DEST_DIR "${CMAKE_CURRENT_BINARY_DIR}"
-  EXEDEPS tExodusReaderFactory
-  )
+IF(${PACKAGE_NAME}_ENABLE_Pamgen)
 
-#TRIBITS_ADD_EXECUTABLE_AND_TEST(
-#  tPamgenMeshFactory
-#  SOURCES tPamgenMeshFactory.cpp ${UNIT_TEST_DRIVER}
-#  NUM_MPI_PROCS 1
-#  COMM serial mpi
-#  )
+  TRIBITS_ADD_EXECUTABLE_AND_TEST(
+    tPamgenMeshFactory
+    SOURCES tPamgenMeshFactory.cpp ${UNIT_TEST_DRIVER}
+    NUM_MPI_PROCS 1
+    COMM serial mpi
+    )
+
+  TRIBITS_COPY_FILES_TO_BINARY_DIR(stk_interface_copy_pamgen
+    SOURCE_FILES pamgen_test.gen
+    DEST_DIR "${CMAKE_CURRENT_BINARY_DIR}"
+    EXEDEPS tPamgenMeshFactory
+    )
+
+ENDIF()

--- a/packages/panzer/adapters-stk/test/stk_interface_test/pamgen_test.gen
+++ b/packages/panzer/adapters-stk/test/stk_interface_test/pamgen_test.gen
@@ -1,23 +1,21 @@
 mesh
-               radial trisection
-                trisection blocks, 4
-                transition radius, 0.02
-                numz 1
-                  zblock 1 1.0 interval 20
-                numr 3 
-                  rblock 1 0.04 first size 0.004  last size 0.006
-                  rblock 2 0.06 first size 0.006  last size 0.0075
-                  rblock 3 0.04 first size 0.0075 last size 0.01
-                numa 1
-                  ablock 1 360.0  interval 24
-              end
-              set assign
-                 block sideset, ihi, 1, 3
-                 block sideset, klo, 10, 1 
-                 block sideset, khi, 11, 1
-                 block sideset, klo, 20, 2 
-                 block sideset, khi, 21, 2
-                 block sideset, klo, 30, 3 
-                 block sideset, khi, 31, 3
-              end
-            end
+  rectilinear
+    nx 1
+    ny 2
+    nz 3
+    bx 1
+    by 1
+    bz 1
+    gmin = 0.0 0.0 0.0
+    gmax = 1.0 1.0 1.0
+  end
+  set assign
+    sideset,ilo,1
+    sideset,jhi,2
+    sideset,klo,3
+    sideset,ihi,4
+    sideset,jlo,5
+    sideset,khi,6
+    nodeset,ilo,1
+  end
+end

--- a/packages/panzer/adapters-stk/test/stk_interface_test/tExodusReaderFactory.cpp
+++ b/packages/panzer/adapters-stk/test/stk_interface_test/tExodusReaderFactory.cpp
@@ -172,6 +172,11 @@ TEUCHOS_UNIT_TEST(tExodusReaderFactory, basic_test)
    }
 }
 
+TEUCHOS_UNIT_TEST(tExodusReaderFactory, getMeshDimension)
+{
+   TEST_EQUALITY(panzer_stk::getMeshDimension("meshes/basic.gen",MPI_COMM_WORLD,true),2);
+}
+
 TEUCHOS_UNIT_TEST(tExodusReaderFactory, exo_scaling)
 {
   {

--- a/packages/panzer/adapters-stk/test/stk_interface_test/tPamgenMeshFactory.cpp
+++ b/packages/panzer/adapters-stk/test/stk_interface_test/tPamgenMeshFactory.cpp
@@ -316,4 +316,9 @@ TEUCHOS_UNIT_TEST(tPamgenFactory, basic)
 
 }
 
+TEUCHOS_UNIT_TEST(tPamgenFactory, getMeshDimension)
+{
+  TEST_EQUALITY(panzer_stk::getMeshDimension("pamgen_test.gen",MPI_COMM_WORLD,false),3);
 }
+
+} // namespace panzer_stk

--- a/packages/panzer/adapters-stk/test/stk_interface_test/tPamgenMeshFactory.cpp
+++ b/packages/panzer/adapters-stk/test/stk_interface_test/tPamgenMeshFactory.cpp
@@ -49,7 +49,7 @@
 #include "Panzer_STK_Version.hpp"
 #include "PanzerAdaptersSTK_config.hpp"
 #include "Panzer_STK_Interface.hpp"
-#include "Panzer_STK_PamgenReaderFactory.hpp"
+#include "Panzer_STK_ExodusReaderFactory.hpp"
 #include "Panzer_STK_SetupUtilities.hpp"
 
 #include "Shards_BasicTopologies.hpp"
@@ -62,26 +62,258 @@
 
 #include "stk_mesh/base/GetEntities.hpp"
 #include "stk_mesh/base/Selector.hpp"
+#include "stk_mesh/base/CreateAdjacentEntities.hpp"
 
 namespace panzer_stk {
 
-TEUCHOS_UNIT_TEST(tSquareQuadMeshFactory, periodic_input)
+// Acceptance test that deomstrates panzer's use of pamgen/stk
+TEUCHOS_UNIT_TEST(tPamgenFactory, acceptance)
 {
-   using Teuchos::RCP;
-   using Teuchos::rcp;
-   using Teuchos::rcpFromRef;
+  using namespace Teuchos;
+  using Teuchos::RCP;
+  using Teuchos::rcp;
 
-   RCP<Teuchos::ParameterList> pl = rcp(new Teuchos::ParameterList);
-   pl->set("X Blocks",2);
-   pl->set("Y Blocks",1);
-   pl->set("X Elements",2);
-   pl->set("Y Elements",3);
-   Teuchos::ParameterList & pbcs = pl->sublist("Periodic BCs");
-   pbcs.set<int>("Count",1);
-   pbcs.set("Periodic Condition 1","x-coord left;right");
+  // IMPORTANT: This test must be run on one processor. Multiple
+  // processors split the surface counts.
+  TEST_EQUALITY(Teuchos::DefaultComm<int>::getComm()->getSize(),1);
 
-   STK_PamgenReaderFactory pamgenFactory("pamgen_test.gen");
-   pamgenFactory.buildMesh(MPI_COMM_WORLD);
+  const bool verbose = false;
+
+  RCP<stk::mesh::MetaData> metaData;
+  RCP<stk::mesh::BulkData> bulkData;
+  const std::string output_exodus_file_name = "pamgen_acceptance_output.exo";
+  std::vector<std::size_t> gold_ss_values{6,3,2,6,3,2,6,3,2,6,3,2};
+
+  // Create a stk::mesh from a pamgen using io broker, then delete the broker
+  {
+    out << "\nCreating pamgen mesh." << std::endl;
+    RCP<stk::io::StkMeshIoBroker> broker = rcp(new stk::io::StkMeshIoBroker(MPI_COMM_WORLD));
+    broker->add_mesh_database("pamgen_test.gen", "pamgen", stk::io::READ_MESH);
+    broker->create_input_mesh();
+    metaData = broker->meta_data_rcp();
+    bulkData = Teuchos::rcp(new stk::mesh::BulkData(*metaData,MPI_COMM_WORLD));
+    broker->set_bulk_data(bulkData);
+    broker->add_all_mesh_fields_as_input_fields();
+    broker->populate_bulk_data();
+
+    if (verbose) {
+      metaData->dump_all_meta_info(out);
+      bulkData->dump_all_mesh_info(out);
+    }
+  }
+
+  // Setup extra mesh information for edges and faces. This is the
+
+  // **************************************************
+  // * create_adjacent_entities wipes out sideset ids
+  // being written to exodus! Sidesets do seem to still
+  // be valid for the stk::mesh object though.
+  // **************************************************
+  if (true) {
+    stk::mesh::PartVector emptyPartVector;
+    stk::mesh::create_adjacent_entities(*bulkData,emptyPartVector);
+  }
+
+  // Verify the sidesets exist and are not empty in the mesh
+  {
+    out << "\nChecking sidesets before writing:" << std::endl;
+    auto surfaces = metaData->get_surfaces_in_surface_to_block_map();
+    std::size_t surface_index = 0;
+    for (auto s : surfaces) {
+      // out << s->name() << std::endl;
+      stk::mesh::Selector side_selector = *s;
+      // stk::mesh::Selector sel = side_selector & lo_selector;
+      const stk::mesh::BucketVector& bv = bulkData->get_buckets(stk::topology::FACE_RANK,side_selector);
+      std::size_t num_faces_in_sideset = 0;
+      for (std::size_t b=0; b < bv.size(); ++b) {
+        num_faces_in_sideset += bv[b]->size();
+      }
+      TEST_EQUALITY(gold_ss_values[surface_index],num_faces_in_sideset);
+      ++surface_index;
+    }
+  }
+
+  // Output mesh to exodus file
+  {
+    out << "\nWriting output file." << std::endl;
+    RCP<stk::io::StkMeshIoBroker> broker = rcp(new stk::io::StkMeshIoBroker(MPI_COMM_WORLD));
+    broker->set_bulk_data(bulkData);
+    auto meshIndex_ = broker->create_output_mesh(output_exodus_file_name,stk::io::PURPOSE_UNKNOWN);
+
+    const stk::mesh::FieldVector& fields = metaData->get_fields();
+    for (size_t i(0); i < fields.size(); ++i) {
+      // Do NOT add MESH type stk fields to exodus io, but do add everything
+      // else. This allows us to avoid having to catch a throw for
+      // re-registering coordinates, sidesets, etc... Note that some
+      // fields like LOAD_BAL don't always have a role assigned, so for
+      // roles that point to null, we need to register them as well.
+      auto role = stk::io::get_field_role(*fields[i]);
+      if (role != nullptr) {
+        if (*role != Ioss::Field::MESH)
+          broker->add_field(meshIndex_, *fields[i]);
+      } else {
+        broker->add_field(meshIndex_, *fields[i]);
+      }
+    }
+
+    double currentStateTime = 10.0;
+    broker->begin_output_step(meshIndex_, currentStateTime);
+    broker->write_defined_output_fields(meshIndex_);
+    broker->end_output_step(meshIndex_);
+  }
+
+  // Delete mesh
+  bulkData = Teuchos::null;
+  metaData = Teuchos::null;
+
+  // Read in mesh from exodus
+  {
+    out << "\nReading Exodus file." << std::endl;
+    RCP<stk::io::StkMeshIoBroker> broker = rcp(new stk::io::StkMeshIoBroker(MPI_COMM_WORLD));
+    broker->add_mesh_database(output_exodus_file_name, "exodus", stk::io::READ_MESH);
+    broker->create_input_mesh();
+    metaData = broker->meta_data_rcp();
+    bulkData = Teuchos::rcp(new stk::mesh::BulkData(*metaData,MPI_COMM_WORLD));
+    broker->set_bulk_data(bulkData);
+    broker->add_all_mesh_fields_as_input_fields();
+    broker->populate_bulk_data();
+
+    if (verbose) {
+      metaData->dump_all_meta_info(out);
+      bulkData->dump_all_mesh_info(out);
+    }
+  }
+
+  // Verify the sidesets exist and are not empty in the mesh
+  {
+    out << "\nVerifying sidesets from exodus file:" << std::endl;
+    auto surfaces = metaData->get_surfaces_in_surface_to_block_map();
+    TEST_COMPARE(surfaces.size(),>,0);
+    std::size_t surface_index = 0;
+    for (auto s : surfaces) {
+      stk::mesh::Selector side_selector = *s;
+      const stk::mesh::BucketVector& bv = bulkData->get_buckets(stk::topology::FACE_RANK,side_selector);
+      std::size_t num_faces_in_sideset = 0;
+      for (std::size_t b=0; b < bv.size(); ++b) {
+        num_faces_in_sideset += bv[b]->size();
+      }
+      TEST_EQUALITY(gold_ss_values[surface_index],num_faces_in_sideset);
+      ++surface_index;
+    }
+  }
+
+}
+
+TEUCHOS_UNIT_TEST(tPamgenFactory, basic)
+{
+  using namespace Teuchos;
+  using Teuchos::RCP;
+  using Teuchos::rcp;
+
+  std::string output_file_name = "pamgen_basic_test_outputcheck.gen";
+
+  // IMPORTANT: This test must be run on one processor. Multiple
+  // processors split the surface counts.
+  TEST_EQUALITY(Teuchos::DefaultComm<int>::getComm()->getSize(),1);
+
+  std::vector<std::size_t> gold_ss_values{6,3,2,6,3,2,6,3,2,6,3,2};
+
+  // *******************************************
+  // Create and write out a stk mesh from pamgen
+  // *******************************************
+  {
+    out << "\nCreating pamgen mesh." << std::endl;
+    RCP<ParameterList> p = parameterList();
+    const std::string input_file_name = "pamgen_test.gen";
+    p->set("File Name",input_file_name);
+    p->set("File Type","Pamgen");
+
+    STK_ExodusReaderFactory pamgenFactory;
+    pamgenFactory.setParameterList(p);
+
+    auto mesh = pamgenFactory.buildMesh(MPI_COMM_WORLD);
+    auto metaData = mesh->getMetaData();
+    auto bulkData = mesh->getBulkData();
+
+    // Write sideset names
+    std::vector<std::string> sideset_names;
+    mesh->getSidesetNames(sideset_names);
+    TEST_COMPARE(sideset_names.size(),>,0)
+    out << "\nsideset names:\n";
+    for (auto s : sideset_names)
+      out << s << std::endl;
+    out << "\n";
+
+    // Get locally owned sidesets
+    const stk::mesh::Part& lo_part = metaData->locally_owned_part();
+    stk::mesh::Selector lo_selector = lo_part;
+
+    auto surfaces = metaData->get_surfaces_in_surface_to_block_map();
+    std::size_t surface_index = 0;
+    for (auto s : surfaces) {
+      stk::mesh::Selector side_selector = *s;
+      stk::mesh::Selector sel = side_selector & lo_selector;
+      const stk::mesh::BucketVector& bv = bulkData->get_buckets(stk::topology::FACE_RANK,sel);
+      std::size_t num_faces_in_sideset = 0;
+      for (std::size_t b=0; b < bv.size(); ++b) {
+        num_faces_in_sideset += bv[b]->size();
+      }
+      TEST_EQUALITY(gold_ss_values[surface_index],num_faces_in_sideset);
+      ++surface_index;
+    }
+    mesh->writeToExodus(output_file_name);
+
+    if (false) {
+      metaData->dump_all_meta_info(out);
+      bulkData->dump_all_mesh_info(out);
+    }
+  }
+
+  // *******************************************
+  // Read back in pamgen mesh from exodus and check sideset exist
+  // (i.e. repeat the above code using an exodus reader)
+  // *******************************************
+  {
+    RCP<ParameterList> p = parameterList();
+    p->set("File Name",output_file_name);
+    p->set("File Type","Exodus");
+
+    STK_ExodusReaderFactory factory;
+    factory.setParameterList(p);
+
+    auto mesh = factory.buildMesh(MPI_COMM_WORLD);
+    auto metaData = mesh->getMetaData();
+    auto bulkData = mesh->getBulkData();
+
+    // Write sideset names
+    std::vector<std::string> sideset_names;
+    mesh->getSidesetNames(sideset_names);
+    TEST_COMPARE(sideset_names.size(),>,0)
+    out << "\nsideset names:\n";
+    for (auto s : sideset_names)
+      out << s << std::endl;
+    out << "\n";
+
+    // Get locally owned sidesets
+    const stk::mesh::Part& lo_part = metaData->locally_owned_part();
+    stk::mesh::Selector lo_selector = lo_part;
+
+    auto surfaces = metaData->get_surfaces_in_surface_to_block_map();
+    std::size_t surface_index = 0;
+    for (auto s : surfaces) {
+      stk::mesh::Selector side_selector = *s;
+      stk::mesh::Selector sel = side_selector & lo_selector;
+      const stk::mesh::BucketVector& bv = bulkData->get_buckets(stk::topology::FACE_RANK,sel);
+      std::size_t num_faces_in_sideset = 0;
+      for (std::size_t b=0; b < bv.size(); ++b) {
+        num_faces_in_sideset += bv[b]->size();
+      }
+      TEST_EQUALITY(gold_ss_values[surface_index],num_faces_in_sideset);
+      ++surface_index;
+    }
+    mesh->writeToExodus(output_file_name);
+  }
+
 }
 
 }


### PR DESCRIPTION
* deprecated explicit pamgen reader (combined with exodus reader now)
* added unit tests for pamgen meshes
* verification of sideset data in output meshes

note: I have not removed the old pamgen exodus reader until the apps switch their code over to the new factory. This way we can prevent CI issues in app/trilinos integration.