### PR TITLE
Tempus: Fix for the null vector bug in TimeStepControl_decl.hpp

### DIFF
--- a/packages/tempus/src/Tempus_TimeStepControl_decl.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControl_decl.hpp
@@ -175,9 +175,11 @@ public:
     virtual void setOutputTimes(std::vector<Scalar> OutputTimes)
       { outputTimes_ = OutputTimes;
         std::ostringstream ss;
-        std::copy(OutputTimes.begin(), OutputTimes.end()-1,
+        if (!outputTimes_.empty())
+          { std::copy(OutputTimes.begin(), OutputTimes.end()-1,
                   std::ostream_iterator<Scalar>(ss, ","));
-        ss << OutputTimes.back();
+            ss << OutputTimes.back();
+	  }
         tscPL_->set<std::string>("Output Time List", ss.str());
       }
     virtual void setMaxFailures(int MaxFailures)


### PR DESCRIPTION
<!---

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tempus 

## Description
Bug fix for a null vector error in TimeStepControl_decl.hpp

## Motivation and Context
This bug created issues when trying to setup a Tempus integrator from defaults.

<!---


## Related Issues

## How Has This Been Tested?
All the Tempus tests still pass with this bug fix.  The changes shouldn't affect any package besides Tempus.


## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
