### PR TITLE
Zoltan2 test exercising multiple weights for MJ partitioner

### DIFF
--- a/packages/zoltan2/test/driver/CMakeLists.txt
+++ b/packages/zoltan2/test/driver/CMakeLists.txt
@@ -128,6 +128,17 @@ TRIBITS_ADD_TEST(
 )
 
 # MultiJagged Tests
+TRIBITS_ADD_TEST(
+    test_driver
+    NAME multijaggedVwgt2Test
+    NUM_MPI_PROCS 4
+    COMM serial mpi
+    ARGS
+    "./driverinputs/multijaggedVwgt2Test.xml"
+    PASS_REGULAR_EXPRESSION "PASS"
+    FAIL_REGULAR_EXPRESSION "FAIL"
+)
+
 IF (${PROJECT_NAME}_ENABLE_Galeri)
   TRIBITS_ADD_TEST(
     test_driver

--- a/packages/zoltan2/test/driver/driverinputs/CMakeLists.txt
+++ b/packages/zoltan2/test/driver/driverinputs/CMakeLists.txt
@@ -12,6 +12,7 @@ TRIBITS_COPY_FILES_TO_BINARY_DIR(copy_input_files_for_driver
         input_template.xml
         rcbTest.xml
         multiJaggedTest.xml
+        multijaggedVwgt2Test.xml
         GeomGenWeight.txt
         chacoGraphMetricsTest.xml
         chacoGraphMetricsTestNoDistribute.xml

--- a/packages/zoltan2/test/driver/driverinputs/multijaggedVwgt2Test.xml
+++ b/packages/zoltan2/test/driver/driverinputs/multijaggedVwgt2Test.xml
@@ -1,0 +1,69 @@
+<!--////////////////////////////////////////////////////////////////////////////
+ ////////////////////////////////////////////////////////////////////////////////
+ 
+ REQUIRED BLOCKS:
+ 1. Input parameters
+ 2. Problem parameters
+ 
+ OPTIONAL Blocks:
+ 3. Comparison
+ 
+ SUPPORTED INPUT FILE TYPES:
+ 1. Geometric Generator
+ 2. Pamgen
+ 3. Chaco
+ 4. Matrix Market
+ 
+ SUPPORTED PROBLEM TYPES:
+ 1. partitioning
+ 
+ SUPPORTED INPUT DATA TYPES:
+ 1. coordinates
+ 2. (x,t,e)petra_crs_matrix
+ 3. (x,t,e)petra_crs_graph
+ 4. (x,t,e)petra_vector
+ 5. (x,t,e)petra_multivector
+ 
+ SUPPORTED INPUT ADAPTERS:
+ 1. BasicIdentifier
+ 2. XpetraMultiVector
+ 3. XpetraCrsGraph
+ 4. XpetraCrsMatrix
+ 5. BasicVector
+ 5. PamgenMesh
+ 
+ ** REFER TO THE README FOR A MORE DETAILED EXPLANATION
+ 
+ ////////////////////////////////////////////////////////////////////////////////
+ /////////////////////////////////////////////////////////////////////////////-->
+
+<ParameterList name="multijaggedVwgt2Test">
+  
+  <ParameterList name="InputParameters">
+    <Parameter name="input file" type="string" value="vwgt2"/>
+    <Parameter name="file type" type="string" value="Chaco"/>
+  </ParameterList>
+  
+  <ParameterList name="mj">
+    <Parameter name="kind" type="string" value="partitioning"/>
+    <ParameterList name="InputAdapterParameters">
+      <Parameter name="data type" type="string" value="coordinates"/>
+      <Parameter name="input adapter" type="string" value="XpetraMultiVector"/>
+    </ParameterList>
+    
+    <ParameterList name="Zoltan2Parameters">
+      <Parameter name="algorithm" type="string" value="multijagged"/>
+      <Parameter name="compute_metrics" type="bool" value="true"/>
+    </ParameterList>
+    
+    <ParameterList name="Metrics">
+      <ParameterList name="metriccheck1">
+        <Parameter name="check" type="string" value="imbalance"/>
+        <Parameter name="weight" type="int" value="0"/>
+        <Parameter name="lower" type="double" value="0.99"/>
+        <Parameter name="upper" type="double" value="1.18"/>
+      </ParameterList>
+    </ParameterList> 
+  </ParameterList>
+
+</ParameterList>

--- a/packages/zoltan2/test/driver/driverinputs/multijaggedVwgt2Test.xml
+++ b/packages/zoltan2/test/driver/driverinputs/multijaggedVwgt2Test.xml
@@ -61,7 +61,7 @@
         <Parameter name="check" type="string" value="imbalance"/>
         <Parameter name="weight" type="int" value="0"/>
         <Parameter name="lower" type="double" value="0.99"/>
-        <Parameter name="upper" type="double" value="1.18"/>
+        <Parameter name="upper" type="double" value="1.4"/>
       </ParameterList>
     </ParameterList> 
   </ParameterList>


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/zoltan2

## Description
Sanity test for MJ with multiple weights

## Motivation and Context
Zoltan2 accepts multiple weights per ID to be partitioned.
MJ accesses and migrates all weights, but uses only the first weight for partitioning.
This test exercises MJ with multiple weights

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->

<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [ ] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
