### PR TITLE
Zoltan2:  Changed behavior of driver when file of initial processor assignments is provided

### DIFF
--- a/packages/zoltan2/test/driver/driverinputs/sacer4320/CMakeLists.txt
+++ b/packages/zoltan2/test/driver/driverinputs/sacer4320/CMakeLists.txt
@@ -15,6 +15,7 @@ TRIBITS_COPY_FILES_TO_BINARY_DIR(copy_sacer4320
     SOURCE_FILES
         sacer.xml
         sacer.graph
+        sacer.assign
         sacer.coords
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}
     DEST_DIR ${CMAKE_CURRENT_BINARY_DIR}

--- a/packages/zoltan2/test/helpers/UserInputForTests.hpp
+++ b/packages/zoltan2/test/helpers/UserInputForTests.hpp
@@ -2589,8 +2589,9 @@ int UserInputForTests::chaco_input_assign(
     }
 
     flag = 0;
-    if (assignment[0] > nvtxs)
-        flag = assignment[1];
+    int np = this->tcomm_->getSize();
+    if (assignment[0] >= np) flag = assignment[0];
+    srand(this->tcomm_->getRank());
     for (i = 1; i < nvtxs; i++) {
         j = fscanf(finassign, "%hd", &(assignment[i]));
         if (j != 1) {
@@ -2604,15 +2605,21 @@ int UserInputForTests::chaco_input_assign(
             fclose(finassign);
             return (1);
         }
-        if (assignment[i] > nvtxs) {    /* warn since probably an error */
+        if (assignment[i] >= np) {    // warn since perhaps an error -- initial part 
+                                      // assignment is greater than number of processors
             if (assignment[i] > flag)
                 flag = assignment[i];
+            assignment[i] = rand() % np;  // randomly assign vtx to a proc in this case
         }
     }
+    srand(rand());
 
     if (flag) {
-        printf("WARNING: Possible error in assignment file `%s'\n", inassignname);
-        printf("         More assignment sets (%d) than vertices (%d)\n", flag, nvtxs);
+        printf("WARNING: Possible error in assignment file `%s'\n",
+                         inassignname);
+        printf("         Max assignment set (%d) greater than "
+                         "max processor rank (%d)\n", flag, np-1);
+        printf("         Some vertices given random initial assignments\n");
     }
 
     /* Check for spurious extra stuff in file. */


### PR DESCRIPTION
@trilinos/zoltan2 
## Description
Changed behavior of test_driver program when file of vertices' processor assignments is provided for initial distribution.
Old behavior:  if comm->getSize() < number of processors in assignment
files, vtx assigned (by the file) to processors that are not in comm
were ignored (so a smaller problem was partitioned).
New behavior:  vtx assigned (by the file) to processors that are not in comm
are now randomly reassigned to processors in comm (so that all vtx are
partitioned).  A warning is issued that the file's max processor is
greater than the comm's max processor.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->


<!--- Please describe your changes in detail. -->

## Motivation and Context
It was not intuitive or obvious that some vertices would be ignored when running a test with a smaller communicator than was used to generate an assignment file.  
Assignment files are usually provided for debugging; ignoring vertices in some cases could lead to misinterpretation of results.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->

<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [ ] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
