### PR TITLE
tpetra:  a more effective workaround for #5179

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_def.hpp
@@ -76,14 +76,7 @@ namespace FHT {
 // we would need experiments to find out.
 template<class ExecSpace>
 bool worthBuildingFixedHashTableInParallel () {
-//  KDD 8/19:  A temporary fix for #5179.  It appears some errors come from
-//  KDD 8/19:  computeOffsetsFromCounts; this temporary patch avoids the most
-//  KDD 8/19:  reproducible of the errors.  We'll reverse this as we debug
-//  KDD 8/19:  the problem, but this temporary fix may allow users to make 
-//  KDD 8/19:  progress toward their milestones.
-//  return ExecSpace::concurrency() > 1;
-    return false;
-//  KDD 8/19
+  return ExecSpace::concurrency() > 1;
 }
 
 // If the input kokkos::View<const KeyType*, ArrayLayout,

--- a/packages/tpetra/core/src/Tpetra_Details_computeOffsets.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_computeOffsets.hpp
@@ -323,8 +323,15 @@ computeOffsetsFromCounts (const OffsetsViewType& ptr,
       // execution space.  If we can't, we need to make a temporary
       // "device" copy of counts in offsets' memory space.
 
+// Workaround to issue #5179, discovered by jhu.
+// Workaround allows application progress while root cause of issue is 
+// investigated.  KDD 8/17/19
+#define Tpetra_Workaround5179
+#ifndef Tpetra_Workaround5179
+
       using memory_space = typename device_type::memory_space;
       // The first template parameter needs to be a memory space.
+      
       constexpr bool countsAccessibleFromOffsetsExecSpace =
         Kokkos::Impl::VerifyExecutionCanAccessMemorySpace<memory_space,
         typename CVT::memory_space>::value;
@@ -344,6 +351,7 @@ computeOffsetsFromCounts (const OffsetsViewType& ptr,
         Kokkos::parallel_scan (range, functor, total, funcName);
       }
       else { // make tmp copy of counts accessible from offsets' space
+#endif // Tpetra_Workaround5179
         using dev_counts_type = Kokkos::View<count_type*,
           typename CVT::array_layout, device_type>;
         dev_counts_type counts_d ("counts_d", numCounts);
@@ -353,7 +361,9 @@ computeOffsetsFromCounts (const OffsetsViewType& ptr,
           ComputeOffsetsFromCounts<OVT, dev_counts_type, SizeType>;
         functor_type functor (ptr, counts_d);
         Kokkos::parallel_scan (range, functor, total, funcName);
+#ifndef Tpetra_Workaround5179
       }
+#endif // Tpetra_Workaround5179
     }
     catch (std::exception& e) {
       TEUCHOS_TEST_FOR_EXCEPTION


### PR DESCRIPTION
@trilinos/tpetra 
The previous workaround #5715 for #5179 was not completely effective.  This workaround is better.

This workaround forces a deep_copy of counts before the parallel_scan in the computeOffsetsFromCounts function.
See #define Tpetra_Workaround5179 in Tpetra_Details_computeOffsets.hpp
This workaround reverses the workaround in #5715, which now is not needed.

Some questions remain, as we saw unusual behavior when debugging this issue.  For example, this workaround removes compilation of an if-test and the if-branch from the function.  In experiments that only forced the if-test to be false but allowed the if-branch to compile, we saw the same failures as in the original code.  It is not clear why removing the if-test and if-branch allows correct execution.  We will continue to investigate.

This workaround is intended to allow applications to meet their milestones.

Tested on waterman with ATDM scripts:
```
#!/bin/bash

source ../cmake/std/atdm/load-env.sh cuda-debug

args=(
  -GNinja
  -DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/atdm/ATDMDevEnv.cmake
  -DTrilinos_ENABLE_TESTS=OFF
  -DTrilinos_ENABLE_MueLu=ON
  -DMueLu_ENABLE_TESTS=ON
  -DMueLu_ENABLE_EXAMPLES=ON
  -DTrilinos_ENABLE_Tpetra=ON
  -DTpetra_ENABLE_TESTS=ON
  -DTpetra_ENABLE_EXAMPLES=ON
)

cmake "${args[@]}" .. |& tee OUTPUT.CMAKE

make NP=16 |& tee OUTPUT.MAKE

 bsub -x -Is -n 20 ctest -j20
```
