### PR TITLE
MueLu: unify setup of region smoothers

### DIFF
--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionSmoothers_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionSmoothers_def.hpp
@@ -82,6 +82,24 @@ using Teuchos::Array;
 using Teuchos::ArrayView;
 using Teuchos::ParameterList;
 
+/*! \brief Create list of valid smoother types
+ *
+ * Create this list here in a routine, such that everyone can use exactly the same list.
+ * This avoids copy-and-paste errors.
+ *
+ * ToDo: replace this list by an enum when we migrate to actual code.
+ */
+std::map<std::string, int> getListOfValidSmootherTypes()
+{
+  std::map<std::string, int> smootherTypes;
+  smootherTypes.insert(std::pair<std::string, int>("None",      0));
+  smootherTypes.insert(std::pair<std::string, int>("Jacobi",    1));
+  smootherTypes.insert(std::pair<std::string, int>("Gauss",     2));
+  smootherTypes.insert(std::pair<std::string, int>("Chebyshev", 3));
+
+  return smootherTypes;
+}
+
 /*! \brief Perform setup for point-relaxation smoothers
  *
  * Computes the inverse of the diagonal in region format and with interface scaling
@@ -265,11 +283,7 @@ void smootherSetup(RCP<Teuchos::ParameterList> params,
 {
   const std::string type = params->get<std::string>("smoother: type");
 
-  std::map<std::string, int> smootherTypes;
-  smootherTypes.insert(std::pair<std::string, int>("None",      0));
-  smootherTypes.insert(std::pair<std::string, int>("Jacobi",    1));
-  smootherTypes.insert(std::pair<std::string, int>("Gauss",     2));
-  smootherTypes.insert(std::pair<std::string, int>("Chebyshev", 3));
+  std::map<std::string, int> smootherTypes = getListOfValidSmootherTypes();
 
   switch(smootherTypes[type]) {
   case 0:
@@ -307,11 +321,7 @@ void smootherApply(RCP<Teuchos::ParameterList> params,
                    const std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > rowImportPerGrp) {
   const std::string type = params->get<std::string>("smoother: type");
 
-  std::map<std::string, int> smootherTypes;
-  smootherTypes.insert(std::pair<std::string, int>("None",      0));
-  smootherTypes.insert(std::pair<std::string, int>("Jacobi",    1));
-  smootherTypes.insert(std::pair<std::string, int>("Gauss",     2));
-  smootherTypes.insert(std::pair<std::string, int>("Chebyshev", 3));
+  std::map<std::string, int> smootherTypes = getListOfValidSmootherTypes();
 
   switch(smootherTypes[type]) {
   case 0:

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionSmoothers_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionSmoothers_def.hpp
@@ -303,8 +303,10 @@ void smootherSetup(RCP<Teuchos::ParameterList> params,
     break;
   }
   default:
-    std::cout << "Unknow smoother: " << type << "!" << std::endl;
+  {
+    std::cout << "Unknown smoother: " << type << "!" << std::endl;
     throw;
+  }
   }
 }
 
@@ -325,17 +327,30 @@ void smootherApply(RCP<Teuchos::ParameterList> params,
 
   switch(smootherTypes[type]) {
   case 0:
+  {
     break;
+  }
   case 1:
+  {
     jacobiIterate(params, regX, regB, regionGrpMats, regionInterfaceScaling, maxRegPerProc,
                   mapComp, rowMapPerGrp, revisedRowMapPerGrp, rowImportPerGrp);
     break;
+  }
   case 2:
-      GSIterate(params, regX, regB, regionGrpMats, regionInterfaceScaling, maxRegPerProc,
+  {
+    GSIterate(params, regX, regB, regionGrpMats, regionInterfaceScaling, maxRegPerProc,
                 mapComp, rowMapPerGrp, revisedRowMapPerGrp, rowImportPerGrp);
     break;
+  }
   case 3:
+  {
     break;
+  }
+  default:
+  {
+    std::cout << "Unknown smoother: " << type << "!" << std::endl;
+    throw;
+  }
   }
 
 } // smootherApply


### PR DESCRIPTION
@trilinos/muelu 
@lucbv @rstumin @pohm01 

## Description

- rename setup routine of relaxation based smoothers, such that it reflects the fact to be used for both Jacobi and Gauss-Seidel
- move definition of list of valid region smoother types to a central routine

## Motivation and Context

- use descriptive names
- remove code redundancy, avoid danger of copy-and-paste mistakes

## Related Issues

* Follows #5701, in particular [this comment](https://github.com/trilinos/Trilinos/pull/5701#discussion_r313705754)

## How Has This Been Tested?

I ran all `MueLu_Structured_Region` tests locally.

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [x] These changes break backwards compatibility.