### PR TITLE
Panzer: require Epetra to build

### DIFF
--- a/packages/panzer/core/cmake/Dependencies.cmake
+++ b/packages/panzer/core/cmake/Dependencies.cmake
@@ -1,4 +1,4 @@
-SET(LIB_REQUIRED_DEP_PACKAGES TeuchosCore TeuchosComm TeuchosParameterList TpetraCore)
+SET(LIB_REQUIRED_DEP_PACKAGES TeuchosCore TeuchosComm TeuchosParameterList TpetraCore Epetra)
 SET(LIB_OPTIONAL_DEP_PACKAGES )
 SET(TEST_REQUIRED_DEP_PACKAGES )
 SET(TEST_OPTIONAL_DEP_PACKAGES )


### PR DESCRIPTION
Per the discussion in #5592, Panzer requires Epetra.

Closes: #5592
Part of: #5602