### PR TITLE
KokkosKernels: CUDA SPGEMM symbolic workaround

### DIFF
--- a/packages/kokkos-kernels/src/sparse/impl/KokkosSparse_spgemm_impl_def.hpp
+++ b/packages/kokkos-kernels/src/sparse/impl/KokkosSparse_spgemm_impl_def.hpp
@@ -158,7 +158,14 @@ void KokkosSPGEMM
     //first get the max flops for a row, which will be used for max row size.
     //If we did compression in single step, row_mapB[i] points the begining of row i,
     //and new_row_mapB[i] points to the end of row i.
-    if (compression_applied){
+
+#ifdef KOKKOS_ENABLE_CUDA
+    //BMK 8-19-19: emergency bug workaround on CUDA (#402): disable compression
+    if (compression_applied && !std::is_same<MyExecSpace, Kokkos::Cuda>::value) {
+#else
+    if (compression_applied) {
+#endif
+    
 		nnz_lno_t maxNumRoughZeros = this->handle->get_spgemm_handle()->compressed_max_row_flops;
 
     	if (compress_in_single_step){


### PR DESCRIPTION
In the default SPGEMM algorithm (SPGEMM_KK) on CUDA,
the symbolic phase produces an incorrect row map for some inputs
(see KokkosKernels issue 402). This bug has been tracked to
entry compression. So as a temporary workaround, compression has been
disabled on CUDA.

This bug affects EMPIRE.
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/kokkos-kernels 

## Description
<!--- Please describe your changes in detail. -->

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to https://github.com/kokkos/kokkos-kernels/issues/402
* Part of
* Composed of 
-->

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->

<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [ ] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
