### PR TITLE
Fix smart-jenkins-driver.sh (#4933)

### DIFF
--- a/cmake/ctest/drivers/atdm/smart-jenkins-driver.sh
+++ b/cmake/ctest/drivers/atdm/smart-jenkins-driver.sh
@@ -21,7 +21,8 @@ if [ "${WORKSPACE}" == ""  ] ; then
 fi
 
 export ATDM_CONFIG_BUILD_NAME=$JOB_NAME
-source $WORKSPACE/Trilinos/cmake/std/atdm/utils/get_system_info.sh
+export ATDM_CONFIG_SCRIPT_DIR=$WORKSPACE/Trilinos/cmake/std/atdm
+source ${ATDM_CONFIG_SCRIPT_DIR}/utils/get_system_info.sh
 
 echo
 echo "Running: $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/$ATDM_CONFIG_SYSTEM_NAME/drivers/$JOB_NAME.sh ..."


### PR DESCRIPTION
In the previous refactoring to create get_system_info.sh for #4933, the
variable ATDM_CONFIG_SCRIPT_DIR was newly required to be set but was not set
from a fresh env.

I had tested this smart-jenkins-driver.sh locally but the env var
ATDM_CONFIG_SCRIPT_DIR must have been set in my local env which allowed it to
pass.

This should fix all of the ATDM Trilinos builds. (There have been no builds submitting to CDash since Saturday).

