### PR TITLE
Tpetra: Fix #5762

### DIFF
--- a/packages/tpetra/core/src/CMakeLists.txt
+++ b/packages/tpetra/core/src/CMakeLists.txt
@@ -758,5 +758,5 @@ SET_PROPERTY(
 # / from this directory, or to / from the 'impl' subdirectory.  That ensures
 # that running "make" will also rerun CMake in order to regenerate Makefiles.
 #
-# Another change!  Another!
+# Here's another change.
 #

--- a/packages/tpetra/core/src/Tpetra_CrsMatrixMultiplyOp.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrixMultiplyOp.hpp
@@ -47,6 +47,7 @@
 /// Declaration and definition of Tpetra::CrsMatrixMultiplyOp and its
 /// nonmember constructor Tpetra::createCrsMatrixMultiplyOp.
 
+#include "Tpetra_CrsMatrixMultiplyOp_fwd.hpp"
 #include "Tpetra_CrsMatrix.hpp"
 #include "Tpetra_Util.hpp"
 #include "Tpetra_Details_Behavior.hpp"
@@ -87,11 +88,15 @@ namespace Tpetra {
   ///
   /// \tparam Node The fourth template parameter of CrsMatrix and
   ///   Operator.
+  ///
+  /// If you encounter link errors when Scalar != MatScalar, try
+  /// including <tt>Tpetra_LocalCrsMatrixOperator_def.hpp</tt> after
+  /// including this header file.
   template <class Scalar,
-            class MatScalar = Scalar,
-            class LocalOrdinal = ::Tpetra::Details::DefaultTypes::local_ordinal_type,
-            class GlobalOrdinal = ::Tpetra::Details::DefaultTypes::global_ordinal_type,
-            class Node = ::Tpetra::Details::DefaultTypes::node_type>
+            class MatScalar,
+            class LocalOrdinal,
+            class GlobalOrdinal,
+            class Node>
   class CrsMatrixMultiplyOp :
     public Operator<Scalar, LocalOrdinal, GlobalOrdinal, Node>
   {

--- a/packages/tpetra/core/src/Tpetra_CrsMatrixMultiplyOp_fwd.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrixMultiplyOp_fwd.hpp
@@ -1,0 +1,59 @@
+// @HEADER
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services Package
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// ************************************************************************
+// @HEADER
+
+#ifndef TPETRA_CRSMATRIXMULTIPLYOP_FWD_HPP
+#define TPETRA_CRSMATRIXMULTIPLYOP_FWD_HPP
+
+#include "Tpetra_Details_DefaultTypes.hpp"
+
+/// \file Tpetra_CrsMatrixMultiplyOp_fwd.hpp
+/// \brief Forward declaration of Tpetra::CrsMatrixMultiplyOp
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+namespace Tpetra {
+template<class Scalar,
+         class MatScalar = Scalar,
+         class LocalOrdinal = ::Tpetra::Details::DefaultTypes::local_ordinal_type,
+         class GlobalOrdinal = ::Tpetra::Details::DefaultTypes::global_ordinal_type,
+         class Node = ::Tpetra::Details::DefaultTypes::node_type>
+class CrsMatrixMultiplyOp;
+} // namespace Tpetra
+#endif // DOXYGEN_SHOULD_SKIP_THIS
+
+#endif // TPETRA_CRSMATRIXMULTIPLYOP_FWD_HPP


### PR DESCRIPTION
@trilinos/tpetra @vbrunini 

## Description

Add forward declaration header file for `Tpetra::CrsMatrixMultiplyOp`.

## Motivation and Context

Sierra (specifically Chaparral) wants this in order to isolate the implementation and thereby keep build times low.

## Related Issues

* Closes #5762 