### PR TITLE
Teuchos: Add Teuchos_string.hpp to CMakeLists.txt

### DIFF
--- a/packages/teuchos/parser/src/CMakeLists.txt
+++ b/packages/teuchos/parser/src/CMakeLists.txt
@@ -15,6 +15,7 @@ SET(HEADERS
   "${DIR}/Teuchos_Reader.hpp"
   "${DIR}/Teuchos_ReaderTables.hpp"
   "${DIR}/Teuchos_regex.hpp"
+  "${DIR}/Teuchos_string.hpp"
   "${DIR}/Teuchos_TableDecl.hpp"
   "${DIR}/Teuchos_XML.hpp"
   "${DIR}/Teuchos_YAML.hpp"


### PR DESCRIPTION
@trilinos/teuchos 
@trilinos/framework 

This PR is to fix an issue with Teuchos that came up developing an installation test for Trilinos.

Teuchos fails to compile tests against an installed Trilinos because `Teuchos_string.hpp` isn't installed via `make install` when `CMAKE_INSTALL_PREFIX` is set. 

This update adds the file to the CMakeLists.txt file so that `make install` will transfer the file to the installation directory.

FYI @jwillenbring