### PR TITLE
Thyra+Belos: Fix issue

### DIFF
--- a/packages/stratimikos/adapters/belos/src/BelosThyraAdapter.hpp
+++ b/packages/stratimikos/adapters/belos/src/BelosThyraAdapter.hpp
@@ -280,10 +280,10 @@ namespace Belos {
 
       const int m = B.numRows();
       const int n = B.numCols();
+      auto vs = A.domain();
       // Create a view of the B object!
       Teuchos::RCP< const TMVB >
-        B_thyra = Thyra::createMembersView(
-          A.domain(),
+        B_thyra = vs->createCachedMembersView(
           RTOpPack::ConstSubMultiVectorView<ScalarType>(
             0, m, 0, n,
             arcpFromArrayView(arrayView(&B(0,0), B.stride()*B.numCols())), B.stride()
@@ -339,10 +339,10 @@ namespace Belos {
       // Create a multivector to hold the result (m by n)
       int m = A.domain()->dim();
       int n = mv.domain()->dim();
+      auto vs = A.domain();
       // Create a view of the B object!
       Teuchos::RCP< TMVB >
-        B_thyra = Thyra::createMembersView(
-          A.domain(),
+        B_thyra = vs->createCachedMembersView(
           RTOpPack::SubMultiVectorView<ScalarType>(
             0, m, 0, n,
             arcpFromArrayView(arrayView(&B(0,0), B.stride()*B.numCols())), B.stride()

--- a/packages/thyra/adapters/tpetra/src/Thyra_TpetraVectorSpace_decl.hpp
+++ b/packages/thyra/adapters/tpetra/src/Thyra_TpetraVectorSpace_decl.hpp
@@ -106,11 +106,13 @@ protected:
   RCP<MultiVectorBase<Scalar> >
   createMembers(int numMembers) const;
 
+public:
+
   RCP<MultiVectorBase<Scalar> >
-  createMembersView( const RTOpPack::SubMultiVectorView<Scalar> &raw_mv ) const;
+  createCachedMembersView( const RTOpPack::SubMultiVectorView<Scalar> &raw_mv ) const;
 
   RCP<const MultiVectorBase<Scalar> >
-  createMembersView( const RTOpPack::ConstSubMultiVectorView<Scalar> &raw_mv ) const;
+  createCachedMembersView( const RTOpPack::ConstSubMultiVectorView<Scalar> &raw_mv ) const;
 
   //@}
 

--- a/packages/thyra/adapters/tpetra/src/Thyra_TpetraVectorSpace_def.hpp
+++ b/packages/thyra/adapters/tpetra/src/Thyra_TpetraVectorSpace_def.hpp
@@ -146,7 +146,7 @@ private:
 
 template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 RCP< MultiVectorBase<Scalar> >
-TpetraVectorSpace<Scalar,LocalOrdinal,GlobalOrdinal,Node>::createMembersView(
+TpetraVectorSpace<Scalar,LocalOrdinal,GlobalOrdinal,Node>::createCachedMembersView(
   const RTOpPack::SubMultiVectorView<Scalar> &raw_mv ) const
 {
 #ifdef TEUCHOS_DEBUG
@@ -203,7 +203,7 @@ TpetraVectorSpace<Scalar,LocalOrdinal,GlobalOrdinal,Node>::createMembersView(
 
 template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 RCP<const MultiVectorBase<Scalar> >
-TpetraVectorSpace<Scalar,LocalOrdinal,GlobalOrdinal,Node>::createMembersView(
+TpetraVectorSpace<Scalar,LocalOrdinal,GlobalOrdinal,Node>::createCachedMembersView(
   const RTOpPack::ConstSubMultiVectorView<Scalar> &raw_mv ) const
 {
 #ifdef TEUCHOS_DEBUG

--- a/packages/thyra/core/src/interfaces/operator_vector/fundamental/Thyra_VectorSpaceBase_decl.hpp
+++ b/packages/thyra/core/src/interfaces/operator_vector/fundamental/Thyra_VectorSpaceBase_decl.hpp
@@ -709,6 +709,75 @@ protected:
   createMembersView(
     const RTOpPack::ConstSubMultiVectorView<Scalar> &raw_mv ) const = 0;
 
+
+ public:
+
+  /** \brief Create a (possibly) cached multi-vector member that is a non-<tt>const</tt> view of
+   * raw multi-vector data. The caching mechanism must be implemented by child classes, by default
+   * this just calls the regular <tt>createMembersView</tt>.
+   *
+   * @param raw_mv [in] On input contains pointer
+   * (i.e. <tt>raw_mv.values()</tt>) to array that the returned
+   * <tt>MultiVectorBase</tt> will be a view of.
+   *
+   * <b>Preconditions:</b><ul>
+   *
+   * <li><tt>raw_mv</tt> has been initialized to memory (i.e.
+   * <tt>raw_mv.subDim()!=0 && raw_mv.values()!=NULL</tt>).
+   *
+   * <li><tt>raw_mv</tt> is <em>consistent</em> with the local storage of this
+   * spaces vector data.  This precondition is purposefully vague since this
+   * function can be used an variety of specialized use-cases.
+   *
+   * </ul>
+   *
+   * <b>Postconditions:</b><ul>
+   *
+   * <li>See <tt>this->createMembers()</tt> where
+   * <tt>numMembers==raw_mv.numSubCols()</tt>
+   *
+   * </ul>
+   *
+   * It is stated here that the client can not expect that the values pointed
+   * to by <tt>raw_mv.values()</tt> to be changed until the smart pointer
+   * <tt>returnVal</tt> goes out of scope.  This is to allow for an
+   * implementation that temporarily copies data into and out of a
+   * <tt>MultiVectorBase</tt> object using explicit vector access.
+   */
+  virtual RCP<MultiVectorBase<Scalar> >
+  createCachedMembersView( const RTOpPack::SubMultiVectorView<Scalar> &raw_mv ) const { return this->createMembersView(raw_mv); };
+
+  /** \brief Create a (possibly) cached multi-vector member that is a <tt>const</tt> view of raw
+   * multi-vector data. The caching mechanism must be implemented by child classes, by default
+   * this just calls the regular <tt>createMembersView</tt>.
+   *
+   * @param raw_mv [in] On input contains pointer
+   * (i.e. <tt>raw_mv.values()</tt>) to array that the returned
+   * <tt>MultiVectorBase</tt> will be a view of.  The data pointed to by
+   * <tt>raw_mv.values()</tt> must remain valid until the returned
+   * <tt>MultiVectorBase</tt> object is destroyed.
+   *
+   * This function works exactly the same as the previous version that takes a
+   * <tt>RTOpPack::SubMultiVectorView</tt> object except that this version
+   * takes a <tt>RTOpPack::ConstSubMultiVectorView</tt> object and returns a smart
+   * pointer to a <tt>const</tt> <tt>MultiVectorBase</tt> object.
+   *
+   * <b>Preconditions:</b><ul>
+   *
+   * <li>See the previous <tt>RTOpPack::SubMultiVectorView</tt> version of
+   * this function.
+   *
+   * </ul>
+   *
+   * <b>Postconditions:</b><ul>
+   *
+   * <li>See <tt>this->createMember()</tt>
+   *
+   * </ul>
+   */
+  virtual RCP<const MultiVectorBase<Scalar> >
+  createCachedMembersView( const RTOpPack::ConstSubMultiVectorView<Scalar> &raw_mv ) const { return this->createMembersView(raw_mv); };
+
   //@}
 
 protected:


### PR DESCRIPTION
@trilinos/thyra @trilinos/belos 

## Description
Caching the multivector used by `Thyra::createMembersView` did not always work correctly (https://github.com/SNLComputation/Albany/issues/503), probably because multiple MVs from`createMembersView` were active. I added a new member function to Thyra's vector space that does caching when the Tpetra backend is used, and use that function in the Belos Thyra adapter.