### PR TITLE
ShyLU/FROSch: include missing Tpetra header

### DIFF
--- a/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_Tools_def.hpp
+++ b/packages/shylu/shylu_dd/frosch/src/Tools/FROSch_Tools_def.hpp
@@ -44,6 +44,7 @@
 
 #include <FROSch_Tools_decl.hpp>
 
+#include <Tpetra_Distributor.hpp>
 
 namespace FROSch {
     


### PR DESCRIPTION
@trilinos/shylu 
@searhein 

## Description
Add `#include <Tpetra_Distributor.hpp>` to `packages/shylu/shylu_dd/frosch/src/Tools/FROSch_Tools_def.hpp`

## Motivation and Context

The `Tpetra::Distributor` class is used in this file, so its declaration should be included. This fixes a compilation error on my machine. 

## How Has This Been Tested?
Build and `ctest` pass locally.

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.