### PR TITLE
Add call to get-changed-trilinos-packages.sh

### DIFF
--- a/cmake/std/PullRequestLinuxDriverTest.py
+++ b/cmake/std/PullRequestLinuxDriverTest.py
@@ -420,15 +420,29 @@ config_map = {'Trilinos_pullrequest_gcc_4.8.4': 'PullRequestLinuxGCC4.8.4Testing
 
 
 def createPackageEnables(arguments):
+    enable_map = {'Trilinos_pullrequest_python_2': 'TrilinosFrameworkTests',
+                  'Trilinos_pullrequest_python_3': 'TrilinosFrameworkTests'}
+
     try:
-        subprocess.check_call([os.path.join(arguments.workspaceDir,
-                                            'Trilinos',
-                                            'commonTools',
-                                            'framework',
-                                            'get-changed-trilinos-packages.sh'),
-                               os.path.join('origin', arguments.targetBranch),
-                               'HEAD',
-                               'packageEnables.cmake'])
+        if arguments.job_base_name not in enable_map:
+            subprocess.check_call([os.path.join(arguments.workspaceDir,
+                                                'Trilinos',
+                                                'commonTools',
+                                                'framework',
+                                                'get-changed-trilinos-packages.sh'),
+                                   os.path.join('origin', arguments.targetBranch),
+                                   'HEAD',
+                                   'packageEnables.cmake'])
+        else:
+            with open('packageEnables.cmake',  'w') as f_out:
+                f_out.write('''
+MACRO(PR_ENABLE_BOOL  VAR_NAME  VAR_VAL)
+  MESSAGE("-- Setting ${VAR_NAME} = ${VAR_VAL}")
+  SET(${VAR_NAME} ${VAR_VAL} CACHE BOOL "Set in $CMAKE_PACKAGE_ENABLES_OUT")
+ENDMACRO()
+
+PR_ENABLE_BOOL(Trilinos_ENABLE_''' + enable_map[arguments.job_base_name] + ''' ON)
+''')
         print('Enabled packages:')
         cmake_rstring = subprocess.check_output(['cmake',
                                                  '-P',

--- a/cmake/std/unittests/TestPullRequestLinuxDriverTest.py
+++ b/cmake/std/unittests/TestPullRequestLinuxDriverTest.py
@@ -307,7 +307,8 @@ ENDMACRO()
 '''
         with mock.patch('subprocess.check_call',
                         side_effect=self.success_side_effect()) as m_out, \
-            mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
+                mock.patch('sys.stdout',
+                           new_callable=StringIO) as m_stdout:
             PullRequestLinuxDriverTest.createPackageEnables(self.arguments)
         m_out.assert_called_once_with([os.path.join(self.jenkins_workspace,
                                                     'Trilinos',
@@ -317,6 +318,22 @@ ENDMACRO()
                                        os.path.join('origin',
                                                     self.target_branch),
                                        'HEAD', 'packageEnables.cmake'])
+        self.assertEqual(expected_output, m_stdout.getvalue())
+        os.unlink('packageEnables.cmake')
+
+    def test_call_python2(self):
+        expected_output = '''Enabled packages:
+-- Setting Trilinos_ENABLE_TrilinosFrameworkTests = ON
+
+'''
+
+        l_arguments = self.arguments
+        l_arguments.job_base_name = 'Trilinos_pullrequest_python_2'
+        with mock.patch('subprocess.check_call',
+                        side_effect=self.success_side_effect()) as m_out, \
+            mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
+            PullRequestLinuxDriverTest.createPackageEnables(l_arguments)
+        m_out.assert_not_called()
         self.assertEqual(expected_output, m_stdout.getvalue())
         os.unlink('packageEnables.cmake')
 


### PR DESCRIPTION
I missed this during the transition to python
and jhux found the issue in #5789

@trilinos/framework 
@william76 
@ZUUL42 

## Description

## Motivation and Context
This is a bug fix to run the correct set of packages - this was missed during migration
from bash to python

## How Has This Been Tested?
Unittests are included for the python and tests have been added for this
capability

## Checklist

- [ x ] My commit messages mention the appropriate GitHub issue numbers.
- [ x ] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ x ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.
