### PR TITLE
ROL - change dimension to extent for kokkos deprecation

### DIFF
--- a/packages/rol/adapters/tpetra/src/mpi/ROL_PinTVectorCommunication_Tpetra.hpp
+++ b/packages/rol/adapters/tpetra/src/mpi/ROL_PinTVectorCommunication_Tpetra.hpp
@@ -73,7 +73,7 @@ public:
     // int myRank = -1;
     // MPI_Comm_rank(comm, &myRank);
 
-    MPI_Send(const_cast<Real*>(&view(0,0)),int(view.dimension(0)*view.dimension(1)),MPI_DOUBLE,rank,tag,comm);
+    MPI_Send(const_cast<Real*>(&view(0,0)),int(view.extent(0)*view.extent(1)),MPI_DOUBLE,rank,tag,comm);
   }
 
   /**
@@ -87,7 +87,7 @@ public:
     // int myRank = -1;
     // MPI_Comm_rank(comm, &myRank);
 
-    MPI_Recv(&view(0,0),int(view.dimension(0)*view.dimension(1)),MPI_DOUBLE,rank,tag,comm,MPI_STATUS_IGNORE);
+    MPI_Recv(&view(0,0),int(view.extent(0)*view.extent(1)),MPI_DOUBLE,rank,tag,comm,MPI_STATUS_IGNORE);
 
     // tp_source.template sync<Kokkos::DeviceSpace>();
   }
@@ -103,9 +103,9 @@ public:
     int myRank = -1;
     MPI_Comm_rank(comm, &myRank);
 
-    assert(view.dimension(1)==1);
+    assert(view.extent(1)==1);
 
-    std::vector<Real> buffer(view.dimension(0)*view.dimension(1),0.0);
+    std::vector<Real> buffer(view.extent(0)*view.extent(1),0.0);
     MPI_Recv(&buffer[0],int(buffer.size()),MPI_DOUBLE,rank,tag,comm,MPI_STATUS_IGNORE);
 
     for(size_t i=0;i<buffer.size();i++)


### PR DESCRIPTION
@trilinos/rol , @trilinos/tpetra


## Description
With deprecation of tpetra and kokkos for downstream packages, ROL does not compile because it uses dimension. This PR changes it with extent.

## Motivation and Context
We are testing Tpetra downstream deprecation. The code does not compile.
