### PR TITLE
Amesos2 Klu2: Remove superfluous MPI_Bcast

### DIFF
--- a/packages/amesos2/src/Amesos2_KLU2_def.hpp
+++ b/packages/amesos2/src/Amesos2_KLU2_def.hpp
@@ -345,7 +345,7 @@ KLU2<Matrix,Vector>::solve_impl(
     }
 
     /* All processes should have the same error code */
-    Teuchos::broadcast(*(this->getComm()), 0, &ierr);
+    // Teuchos::broadcast(*(this->getComm()), 0, &ierr);
 
   } // end single_process_optim_check && nrhs == 1
   else  // single proc optimizations but nrhs > 1,
@@ -423,7 +423,7 @@ KLU2<Matrix,Vector>::solve_impl(
     } // end root_
 
     /* All processes should have the same error code */
-    Teuchos::broadcast(*(this->getComm()), 0, &ierr);
+    // Teuchos::broadcast(*(this->getComm()), 0, &ierr);
 
     // global_size_type ierr_st = as<global_size_type>(ierr); // unused
     // TODO


### PR DESCRIPTION
@trilinos/amesos2

## Description
Remove a superfluous MPI_Bcast. The communicated error code is always zero, as far as I can tell.