### PR TITLE
Tpetra: More permanent fixes for FixedHashTable issue in #5179

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_def.hpp
@@ -76,7 +76,14 @@ namespace FHT {
 // we would need experiments to find out.
 template<class ExecSpace>
 bool worthBuildingFixedHashTableInParallel () {
+//  KDD 8/19:  A temporary fix for #5179.  It appears some errors come from
+//  KDD 8/19:  computeOffsetsFromCounts; this temporary patch avoids the most
+//  KDD 8/19:  reproducible of the errors.  We'll reverse this as we debug
+//  KDD 8/19:  the problem, but this temporary fix may allow users to make
+//  KDD 8/19:  progress toward their milestones.
   return ExecSpace::concurrency() > 1;
+//    return false;
+//  KDD 8/19
 }
 
 // If the input kokkos::View<const KeyType*, ArrayLayout,

--- a/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_def.hpp
@@ -82,7 +82,7 @@ bool worthBuildingFixedHashTableInParallel () {
 //  KDD 8/19:  reproducible of the errors.  We'll reverse this as we debug
 //  KDD 8/19:  the problem, but this temporary fix may allow users to make
 //  KDD 8/19:  progress toward their milestones.
-std::cout << "KDDKDD WorthIt " << (ExecSpace::concurrency() > 1) << std::endl;
+//std::cout << "KDDKDD WorthIt " << (ExecSpace::concurrency() > 1) << std::endl;
     return ExecSpace::concurrency() > 1;
 //  return false;
 //  KDD 8/19
@@ -1231,12 +1231,11 @@ init (const keys_type& keys,
   // with actual parallel execution spaces, it does require multiple
   // passes over the data.  Thus, it still makes sense to have a
   // sequential fall-back.
-#define KDDHACK
+  //#define KDDHACK
 #ifndef KDDHACK
   if (buildInParallel) {
 #endif
     ::Tpetra::Details::computeOffsetsFromCounts (ptr, counts);
-
 #ifndef KDDHACK
   }
   else {

--- a/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_def.hpp
@@ -1246,6 +1246,23 @@ init (const keys_type& keys,
     Kokkos::deep_copy (ptr, ptrHost);
   }
 
+  if (debug) {
+    Kokkos::HostSpace space;
+    auto counts_h = Kokkos::create_mirror_view (space, counts);
+    auto ptr_h = Kokkos::create_mirror_view (space, ptr);
+
+    bool bad = false;
+    for (offset_type i = 0; i < size; ++i) {
+      if (ptr_h[i+1] != ptr_h[i] + counts_h[i]) {
+        bad = true;
+      }
+    }
+    TEUCHOS_TEST_FOR_EXCEPTION
+      (bad, std::logic_error, "Tpetra::Details::FixedHashTable "
+       "constructor: computeOffsetsFromCounts gave an incorrect "
+       "result.");
+  }
+
   // FIXME (mfh 28 Mar 2016) Need a fence here, otherwise SIGSEGV w/
   // CUDA when val is filled.
   execution_space().fence ();

--- a/packages/tpetra/core/src/Tpetra_Details_computeOffsets.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_computeOffsets.hpp
@@ -321,7 +321,6 @@ computeOffsetsFromCounts (const ExecutionSpace& execSpace,
       counts_a = counts_copy;
     }
 
-    typename offsets_device_type::execution_space execSpace;
     using functor_type =
       ComputeOffsetsFromCounts<offset_type, count_type, SizeType>;
     total = functor_type::run (execSpace, ptr_a, counts_a);

--- a/packages/tpetra/core/src/Tpetra_Details_computeOffsets.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_computeOffsets.hpp
@@ -332,12 +332,18 @@ computeOffsetsFromCounts (const OffsetsViewType& ptr,
       using memory_space = typename device_type::memory_space;
       // The first template parameter needs to be a memory space.
 
+//#define KDDHACK2
+#ifdef KDDHACK2
+      constexpr bool countsAccessibleFromOffsetsExecSpace = false;
+#else
       constexpr bool countsAccessibleFromOffsetsExecSpace =
         Kokkos::Impl::VerifyExecutionCanAccessMemorySpace<memory_space,
         typename CVT::memory_space>::value;
+#endif
 //#define JHUHACK
 #ifndef JHUHACK
       if (countsAccessibleFromOffsetsExecSpace) {
+std::cout << "KDD If branch" << std::endl;
 #ifdef KOKKOS_ENABLE_CUDA
         // If 'counts' is a UVM allocation, then conservatively fence
         // first, in case it was last accessed on host.  We're about
@@ -345,6 +351,7 @@ computeOffsetsFromCounts (const OffsetsViewType& ptr,
         using CMS = typename CVT::memory_space;
         if (std::is_same<CMS, Kokkos::CudaUVMSpace>::value) {
           using counts_exec_space = typename CMS::execution_space;
+std::cout << "KDD Yo fence" << std::endl;
           counts_exec_space ().fence (); // for UVM's sake.
         }
 #endif // KOKKOS_ENABLE_CUDA
@@ -354,6 +361,7 @@ computeOffsetsFromCounts (const OffsetsViewType& ptr,
       }
       else { // make tmp copy of counts accessible from offsets' space
 #endif //JHUHACK
+std::cout << "KDD Else branch" << std::endl;
         using dev_counts_type = Kokkos::View<count_type*,
           typename CVT::array_layout, device_type>;
         dev_counts_type counts_d ("counts_d", numCounts);

--- a/packages/tpetra/core/src/Tpetra_createDeepCopy_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_createDeepCopy_CrsMatrix_def.hpp
@@ -96,7 +96,6 @@ createDeepCopy (const RowMatrix<SC, LO, GO, NT>& A)
       crs_matrix_type (A.getRowMap (), entPerRow_av);
 #endif // TPETRA_ENABLE_DEPRECATED_CODE
 
-    using IST = typename crs_matrix_type::impl_scalar_type;
     const bool hasViews = A.supportsRowViews ();
 
     Teuchos::Array<GO> inputIndsBuf;


### PR DESCRIPTION
@trilinos/tpetra 

## Description

Please don't merge this quite just yet, per request by @kddevin .

Per request by @kddevin , here are the changes I made to FixedHashTable and computeOffsetsFromCounts, that prevent the crash observed in the MueLu driver, per discussion in #5179.   The fix makes the code cleaner and simpler.

## Related Issues

* Related to #5179 

## How Has This Been Tested?

On waterman, with the MueLu driver, and with Tpetra's tests.