### PR TITLE
Reduce stk_simd tests until the team can resolve intel issue

### DIFF
--- a/packages/stk/stk_unit_tests/stk_simd/CMakeLists.txt
+++ b/packages/stk/stk_unit_tests/stk_simd/CMakeLists.txt
@@ -22,7 +22,7 @@ TRIBITS_ADD_EXECUTABLE(
 TRIBITS_ADD_TEST(
    simd_unit_tests
    NAME STKSimd_Simd
-   ARGS "--gtest_filter=StkSimd.Simd*"
+   ARGS "--gtest_filter=StkSimd.Simd_fmadd"
    COMM serial mpi
    PASS_REGULAR_EXPRESSION "PASS"
    FAIL_REGULAR_EXPRESSION "FAIL"


### PR DESCRIPTION
During the recent PR testing snafu a problem
was introduced in a stk_simd test. This just
turns that off until we can get it resolved.


@trilinos/stk 

