### PR TITLE
Xpetra: Fix Issue #5813

### DIFF
--- a/packages/xpetra/src/Headers/Xpetra_ConfigDefs.hpp
+++ b/packages/xpetra/src/Headers/Xpetra_ConfigDefs.hpp
@@ -86,6 +86,10 @@
 #include <Teuchos_ConfigDefs.hpp>
 #include <Kokkos_ConfigDefs.hpp>
 
+#if defined(HAVE_XPETRA_TPETRA)
+    #include <Tpetra_ConfigDefs.hpp>
+#endif
+
 //! %Xpetra namespace
 namespace Xpetra {
   // Used in all Xpetra code that explicitly must a type (like a loop index)

--- a/packages/xpetra/src/Map/Xpetra_Map.hpp
+++ b/packages/xpetra/src/Map/Xpetra_Map.hpp
@@ -53,13 +53,13 @@
 #include <Teuchos_Describable.hpp>
 
 #ifdef HAVE_XPETRA_EPETRA
-#include "Epetra_config.h"
+    #include "Epetra_config.h"
 #endif
 
 #ifdef HAVE_XPETRA_KOKKOS_REFACTOR
-#ifdef HAVE_XPETRA_TPETRA
-#include <Tpetra_Map.hpp>
-#endif
+    #ifdef HAVE_XPETRA_TPETRA
+        #include <Tpetra_Map.hpp>
+    #endif
 #endif
 
 namespace Xpetra {

--- a/packages/xpetra/src/Map/Xpetra_MapFactory_decl.hpp
+++ b/packages/xpetra/src/Map/Xpetra_MapFactory_decl.hpp
@@ -47,15 +47,8 @@
 #define XPETRA_MAPFACTORY_DECL_HPP
 
 #include "Xpetra_ConfigDefs.hpp"
+
 #include "Xpetra_Map.hpp"
-
-//#ifdef HAVE_XPETRA_TPETRA
-//#    include "Xpetra_TpetraMap.hpp"
-//#endif
-//#ifdef HAVE_XPETRA_EPETRA
-//#    include "Xpetra_EpetraMap.hpp"
-//#endif
-
 #include "Xpetra_Exceptions.hpp"
 
 namespace Xpetra {
@@ -91,7 +84,7 @@ class MapFactory
           GlobalOrdinal                                 indexBase,
           const Teuchos::RCP<const Teuchos::Comm<int>>& comm,
           LocalGlobal                                   lg,
-          const Teuchos::RCP<Node>& /* node */);
+          const Teuchos::RCP<Node>&                     /* node */);
 #endif      // TPETRA_ENABLE_DEPRECATED_CODE
 
 
@@ -112,7 +105,7 @@ class MapFactory
           size_t                                        numLocalElements,
           GlobalOrdinal                                 indexBase,
           const Teuchos::RCP<const Teuchos::Comm<int>>& comm,
-          const Teuchos::RCP<Node>& /* node */);
+          const Teuchos::RCP<Node>&                     /* node */);
 #endif      // TPETRA_ENABLE_DEPRECATED_CODE
 
 
@@ -133,7 +126,7 @@ class MapFactory
           const Teuchos::ArrayView<const GlobalOrdinal>& elementList,
           GlobalOrdinal                                  indexBase,
           const Teuchos::RCP<const Teuchos::Comm<int>>&  comm,
-          const Teuchos::RCP<Node>& /* node */);
+          const Teuchos::RCP<Node>&                      /* node */);
 #endif      // TPETRA_ENABLE_DEPRECATED_CODE
 
 

--- a/packages/xpetra/src/Map/Xpetra_MapFactory_def.hpp
+++ b/packages/xpetra/src/Map/Xpetra_MapFactory_def.hpp
@@ -79,7 +79,7 @@ Build(UnderlyingLib                                 lib,
       GlobalOrdinal                                 indexBase,
       const Teuchos::RCP<const Teuchos::Comm<int>>& comm,
       LocalGlobal                                   lg,
-      const Teuchos::RCP<Node>& /* node */)
+      const Teuchos::RCP<Node>&                     /* node */)
 {
     return Build(lib, numGlobalElements, indexBase, comm, lg);
 }
@@ -119,7 +119,7 @@ Build(UnderlyingLib                                 lib,
       size_t                                        numLocalElements,
       GlobalOrdinal                                 indexBase,
       const Teuchos::RCP<const Teuchos::Comm<int>>& comm,
-      const Teuchos::RCP<Node>& /* node */)
+      const Teuchos::RCP<Node>&                     /* node */)
 {
     return Build(lib, numGlobalElements, numLocalElements, indexBase, comm);
 }
@@ -159,7 +159,7 @@ Build(UnderlyingLib                                  lib,
       const Teuchos::ArrayView<const GlobalOrdinal>& elementList,
       GlobalOrdinal                                  indexBase,
       const Teuchos::RCP<const Teuchos::Comm<int>>&  comm,
-      const Teuchos::RCP<Node>& /* node */)
+      const Teuchos::RCP<Node>&                      /* node */)
 {
     return Build(lib, numGlobalElements, elementList, indexBase, comm);
 }


### PR DESCRIPTION
@trilinos/xpetra 
@mayrmt @jhux2 

Addresses Issue #5813 

Xpetra headers weren't picking up the `TPETRA_ENABLE_DEPRECATED_CODE` preprocessor macro because `Tpetra_ConfigDefs.hpp` was not getting pulled in.

This commit adds a couple of cosmetic fixes but primarily addresses Issue #5813 by adding `Tpetra_ConfigDefs.hpp` into the `Xpetra_ConfigDefs.hpp` file so that Xpetra headers get the Tpetra information they need if they're building Tpetra.

FYI @trilinos/tpetra 