### PR TITLE
Epetra: allow users to disable OpenMP support in Epetra.

### DIFF
--- a/packages/epetra/src/CMakeLists.txt
+++ b/packages/epetra/src/CMakeLists.txt
@@ -8,9 +8,11 @@ SET(EPETRA_MPI ${TPL_ENABLE_MPI})
 IF(CMAKE_SIZEOF_VOID_P GREATER 4)
   SET(EPETRA_ADDRESS64BIT ON)
 ENDIF()
-SET(Epetra_HAVE_OMP ${${PROJECT_NAME}_ENABLE_OpenMP})
-# This is the preferred macro to key on, but am keeping the old one for backward compatibility
-SET(EPETRA_HAVE_OMP ${${PROJECT_NAME}_ENABLE_OpenMP})
+
+TRIBITS_ADD_OPTION_AND_DEFINE(${PACKAGE_NAME}_ENABLE_OpenMP
+  EPETRA_HAVE_OMP
+  "Enable OpenMP support in Epetra."
+  ${${PROJECT_NAME}_ENABLE_OpenMP})
 
 SET(HAVE_BLAS ON)
 SET(HAVE_LAPACK ON)


### PR DESCRIPTION
The epetra use of OpenMP is broken for gcc 9 (see #5390 ). If we want to build trilinos with OpenMP support enabled (for kokkos and tpetra), we currently need to disable epetra. The work around to allow for epetra without openmp enabled would be to set:
```
-D EPETRA_HAVE_OMP:BOOL=OFF \
-D Epetra_HAVE_OMP:BOOL=OFF \
```
However these variables are ignored because the variables are set as normal instead of cached variables in epetra's CMakeLists.txt file. This PR changes the variables to cached so that users can override the default, allowing us to build trilinos with openmp support enabled and with epetra enabled.

NOTE: I think only the first variable listed above is used, but the second was kept around for backwards compatibility according to a comment in code.