### PR TITLE
MueLu: don't use numpy in region MG regression testing python script

### DIFF
--- a/packages/muelu/research/regionMG/examples/structured/compare_residual_history.py
+++ b/packages/muelu/research/regionMG/examples/structured/compare_residual_history.py
@@ -1,4 +1,3 @@
-import numpy as np
 import os
 import sys
 from __builtin__ import True, False


### PR DESCRIPTION
@trilinos/muelu 
@lucbv @rstumin @pohm01 

## Description

`numpy` is not available on all systems. Hence, using it can lead to test failures. Since `numpy` is not used anyway, let's not import it.

## Motivation and Context

The testing script should work on all systems. (Since it requires python, systems without python are excluded anyways.)

## Related Issues

* Follows #5760

## How Has This Been Tested?

Tests pass on a system, that has not have `numpy` installed.

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [x] These changes break backwards compatibility.

## Additional Information
These tests are for experimental code, so they are only executed, if experimental code is enabled in MueLu. That's not the case for the autotester (and many other systems).