### PR TITLE
Tempus: Missing Args in explicit Steppers InArgs.

### DIFF
--- a/packages/tempus/src/Tempus_StepperBDF2_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperBDF2_impl.hpp
@@ -241,9 +241,11 @@ void StepperBDF2<Scalar>::takeStep(
     const Scalar alpha = getAlpha(dt, dtOld);
     const Scalar beta  = getBeta (dt);
 
-    Teuchos::RCP<ImplicitODEParameters<Scalar> > p =
-      Teuchos::rcp(new ImplicitODEParameters<Scalar>(timeDer,dt,alpha,beta,
-                                                     SOLVE_FOR_X));
+    auto p = Teuchos::rcp(new ImplicitODEParameters<Scalar>(
+      timeDer, dt, alpha, beta));
+
+    if (!Teuchos::is_null(stepperBDF2Observer_))
+      stepperBDF2Observer_->observeBeforeSolve(solutionHistory, *this);
 
     const Thyra::SolveStatus<Scalar> sStatus =
       this->solveImplicitODE(x, xDot, time, p);

--- a/packages/tempus/src/Tempus_StepperBackwardEuler_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperBackwardEuler_impl.hpp
@@ -207,9 +207,8 @@ void StepperBackwardEuler<Scalar>::takeStep(
 
     const Scalar alpha = Scalar(1.0)/dt;
     const Scalar beta  = Scalar(1.0);
-    Teuchos::RCP<ImplicitODEParameters<Scalar> > p =
-      Teuchos::rcp(new ImplicitODEParameters<Scalar>(timeDer,dt,alpha,beta,
-                                                     SOLVE_FOR_X));
+    auto p = Teuchos::rcp(new ImplicitODEParameters<Scalar>(
+      timeDer, dt, alpha, beta));
 
     if (!Teuchos::is_null(stepperBEObserver_))
       stepperBEObserver_->observeBeforeSolve(solutionHistory, *this);

--- a/packages/tempus/src/Tempus_StepperDIRK_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperDIRK_impl.hpp
@@ -282,10 +282,8 @@ void StepperDIRK<Scalar>::takeStep(
             Teuchos::rcp(new StepperDIRKTimeDerivative<Scalar>(
               alpha,xTilde_.getConst()));
 
-          Teuchos::RCP<ImplicitODEParameters<Scalar> > p =
-            Teuchos::rcp(new ImplicitODEParameters<Scalar>(
-              timeDer, dt, alpha, beta));
-          p->stageNumber_ = i;
+          auto p = Teuchos::rcp(new ImplicitODEParameters<Scalar>(
+            timeDer, dt, alpha, beta, SOLVE_FOR_X, i));
 
           if (!Teuchos::is_null(stepperDIRKObserver_))
             stepperDIRKObserver_->observeBeforeSolve(solutionHistory, *this);

--- a/packages/tempus/src/Tempus_StepperExplicitRK_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperExplicitRK_impl.hpp
@@ -344,8 +344,11 @@ void StepperExplicitRK<Scalar>::takeStep(
         if (!Teuchos::is_null(stepperExplicitRKObserver_))
           stepperExplicitRKObserver_->observeBeforeExplicit(solutionHistory,
                                                             *this);
+
+        auto p = Teuchos::rcp(new ExplicitODEParameters<Scalar>(dt));
+
         // Evaluate xDot = f(x,t).
-        this->evaluateExplicitODE(stageXDot_[i], stageX_, ts);
+        this->evaluateExplicitODE(stageXDot_[i], stageX_, ts, p);
       }
 
       if (!Teuchos::is_null(stepperExplicitRKObserver_))

--- a/packages/tempus/src/Tempus_StepperExplicit_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperExplicit_decl.hpp
@@ -13,6 +13,24 @@
 #include "Tempus_Stepper.hpp"
 
 
+template<class Scalar>
+class ExplicitODEParameters
+{
+  public:
+    /// Constructor
+    ExplicitODEParameters()
+      : timeStepSize_(Scalar(0.0)), stageNumber_(0)
+    {}
+    /// Constructor
+    ExplicitODEParameters(Scalar timeStepSize, int stageNumber = 0)
+      : timeStepSize_(timeStepSize), stageNumber_(stageNumber)
+    {}
+
+    Scalar                                timeStepSize_;
+    int                                   stageNumber_;
+};
+
+
 namespace Tempus {
 
 
@@ -122,14 +140,16 @@ public:
     virtual void evaluateExplicitODE(
       Teuchos::RCP<      Thyra::VectorBase<Scalar> > xDot,
       Teuchos::RCP<const Thyra::VectorBase<Scalar> > x,
-      const Scalar time);
+      const Scalar time,
+      const Teuchos::RCP<ExplicitODEParameters<Scalar> > & p );
 
     /// Evaluate xDotDot = f(x, xDot, t).
     virtual void evaluateExplicitODE(
       Teuchos::RCP<      Thyra::VectorBase<Scalar> > xDotDot,
       Teuchos::RCP<const Thyra::VectorBase<Scalar> > x,
       Teuchos::RCP<const Thyra::VectorBase<Scalar> > xDot,
-      const Scalar time);
+      const Scalar time,
+      const Teuchos::RCP<ExplicitODEParameters<Scalar> > & p );
   //@}
 
 

--- a/packages/tempus/src/Tempus_StepperExplicit_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperExplicit_impl.hpp
@@ -108,8 +108,9 @@ void StepperExplicit<Scalar>::setInitialConditions(
         *out << "Warning -- Requested IC consistency of 'None' but\n"
              << "           initialState does not have an xDot.\n"
              << "           Setting a 'Consistent' xDot!\n" << std::endl;
+        auto p = Teuchos::rcp(new ExplicitODEParameters<Scalar>(0.0));
         evaluateExplicitODE(getStepperXDot(initialState), x,
-                            initialState->getTime());
+                            initialState->getTime(), p);
         initialState->setIsSynced(true);
       }
     }
@@ -120,9 +121,10 @@ void StepperExplicit<Scalar>::setInitialConditions(
         *out << "Warning -- Requested IC consistency of 'None' but\n"
              << "           initialState does not have an xDotDot.\n"
              << "           Setting a 'Consistent' xDotDot!\n" << std::endl;
+        auto p = Teuchos::rcp(new ExplicitODEParameters<Scalar>(0.0));
         this->evaluateExplicitODE(getStepperXDotDot(initialState), x,
                                   initialState->getXDot(),
-                                  initialState->getTime());
+                                  initialState->getTime(), p);
         initialState->setIsSynced(true);
       }
     }
@@ -154,14 +156,16 @@ void StepperExplicit<Scalar>::setInitialConditions(
   else if (icConsistency == "Consistent") {
     if (this->getOrderODE() == FIRST_ORDER_ODE) {
       // Evaluate xDot = f(x,t).
+      auto p = Teuchos::rcp(new ExplicitODEParameters<Scalar>(0.0));
       evaluateExplicitODE(getStepperXDot(initialState), x,
-                          initialState->getTime());
+                          initialState->getTime(), p);
     }
     else if (this->getOrderODE() == SECOND_ORDER_ODE) {
       // Evaluate xDotDot = f(x,xDot,t).
+      auto p = Teuchos::rcp(new ExplicitODEParameters<Scalar>(0.0));
       this->evaluateExplicitODE(initialState->getXDotDot(), x,
                                 initialState->getXDot(),
-                                initialState->getTime());
+                                initialState->getTime(), p);
     }
   }
   else {
@@ -179,7 +183,8 @@ void StepperExplicit<Scalar>::setInitialConditions(
     if (this->getOrderODE() == FIRST_ORDER_ODE) {
       auto xDot = getStepperXDot(initialState);
       auto f    = initialState->getX()->clone_v();
-      evaluateExplicitODE(f, x, initialState->getTime());
+      auto p    = Teuchos::rcp(new ExplicitODEParameters<Scalar>(0.0));
+      evaluateExplicitODE(f, x, initialState->getTime(), p);
       Thyra::Vp_StV(f.ptr(), Scalar(-1.0), *(xDot));
       Scalar normX = Thyra::norm(*x);
       Scalar reldiff = Scalar(0.0);
@@ -201,8 +206,9 @@ void StepperExplicit<Scalar>::setInitialConditions(
     else if (this->getOrderODE() == SECOND_ORDER_ODE) {
       auto xDotDot = initialState->getXDotDot();
       auto f       = initialState->getX()->clone_v();
+      auto p       = Teuchos::rcp(new ExplicitODEParameters<Scalar>(0.0));
       this->evaluateExplicitODE(f, x, initialState->getXDot(),
-                                initialState->getTime());
+                                initialState->getTime(), p);
       Thyra::Vp_StV(f.ptr(), Scalar(-1.0), *(xDotDot));
       Scalar normX = Thyra::norm(*x);
       Scalar reldiff = Scalar(0.0);
@@ -311,12 +317,17 @@ void
 StepperExplicit<Scalar>::
 evaluateExplicitODE(Teuchos::RCP<      Thyra::VectorBase<Scalar> > xDot,
                     Teuchos::RCP<const Thyra::VectorBase<Scalar> > x,
-                    const Scalar time)
+                    const Scalar time,
+                    const Teuchos::RCP<ExplicitODEParameters<Scalar> > & p )
 {
   typedef Thyra::ModelEvaluatorBase MEB;
 
   inArgs_.set_x(x);
   if (inArgs_.supports(MEB::IN_ARG_t)) inArgs_.set_t(time);
+  if (inArgs_.supports(MEB::IN_ARG_step_size))
+    inArgs_.set_step_size(p->timeStepSize_);
+  if (inArgs_.supports(MEB::IN_ARG_stage_number))
+    inArgs_.set_stage_number(p->stageNumber_);
 
   // For model evaluators whose state function f(x, xDot, t) describes
   // an implicit ODE, and which accept an optional xDot input argument,
@@ -336,13 +347,18 @@ StepperExplicit<Scalar>::
 evaluateExplicitODE(Teuchos::RCP<      Thyra::VectorBase<Scalar> > xDotDot,
                     Teuchos::RCP<const Thyra::VectorBase<Scalar> > x,
                     Teuchos::RCP<const Thyra::VectorBase<Scalar> > xDot,
-                    const Scalar time)
+                    const Scalar time,
+                    const Teuchos::RCP<ExplicitODEParameters<Scalar> > & p )
 {
   typedef Thyra::ModelEvaluatorBase MEB;
 
   inArgs_.set_x(x);
   if (inArgs_.supports(MEB::IN_ARG_x_dot)) inArgs_.set_x_dot(xDot);
   if (inArgs_.supports(MEB::IN_ARG_t)) inArgs_.set_t(time);
+  if (inArgs_.supports(MEB::IN_ARG_step_size))
+    inArgs_.set_step_size(p->timeStepSize_);
+  if (inArgs_.supports(MEB::IN_ARG_stage_number))
+    inArgs_.set_stage_number(p->stageNumber_);
 
   // For model evaluators whose state function f(x, xDot, xDotDot, t) describes
   // an implicit ODE, and which accept an optional xDotDot input argument,

--- a/packages/tempus/src/Tempus_StepperForwardEuler_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperForwardEuler_impl.hpp
@@ -106,15 +106,18 @@ void StepperForwardEuler<Scalar>::takeStep(
     RCP<SolutionState<Scalar> > workingState=solutionHistory->getWorkingState();
 
     RCP<Thyra::VectorBase<Scalar> > xDot = this->getStepperXDot(currentState);
+    const Scalar dt = workingState->getTimeStep();
 
     if ( !(this->getUseFSAL()) ) {
       // Need to compute XDotOld.
       if (!Teuchos::is_null(stepperFEObserver_))
         stepperFEObserver_->observeBeforeExplicit(solutionHistory, *this);
 
+      auto p = Teuchos::rcp(new ExplicitODEParameters<Scalar>(dt));
+
       // Evaluate xDot = f(x,t).
       this->evaluateExplicitODE(xDot, currentState->getX(),
-                                currentState->getTime());
+                                currentState->getTime(), p);
 
       // For UseFSAL=false, x and xDot are now sync'ed or consistent
       // at the same time level for the currentState.
@@ -123,7 +126,6 @@ void StepperForwardEuler<Scalar>::takeStep(
 
 
     // Forward Euler update, x^n = x^{n-1} + dt^n * xDot^{n-1}
-    const Scalar dt = workingState->getTimeStep();
     Thyra::V_VpStV(Teuchos::outArg(*(workingState->getX())),
       *(currentState->getX()),dt,*(xDot));
 
@@ -135,9 +137,11 @@ void StepperForwardEuler<Scalar>::takeStep(
       if (!Teuchos::is_null(stepperFEObserver_))
         stepperFEObserver_->observeBeforeExplicit(solutionHistory, *this);
 
+      auto p = Teuchos::rcp(new ExplicitODEParameters<Scalar>(dt));
+
       // Evaluate xDot = f(x,t).
       this->evaluateExplicitODE(xDot, workingState->getX(),
-                                workingState->getTime());
+                                workingState->getTime(), p);
 
       // For UseFSAL=true, x and xDot are now sync'ed or consistent
       // for the workingState.

--- a/packages/tempus/src/Tempus_StepperIMEX_RK_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RK_impl.hpp
@@ -601,9 +601,8 @@ void StepperIMEX_RK<Scalar>::takeStep(
           Teuchos::rcp(new StepperIMEX_RKTimeDerivative<Scalar>(
             alpha, xTilde_.getConst()));
 
-        Teuchos::RCP<ImplicitODEParameters<Scalar> > p =
-         Teuchos::rcp(new ImplicitODEParameters<Scalar>(timeDer,dt,alpha,beta));
-        p->stageNumber_ = i;
+        auto p = Teuchos::rcp(new ImplicitODEParameters<Scalar>(
+          timeDer, dt, alpha, beta, SOLVE_FOR_X, i));
 
         if (!Teuchos::is_null(stepperIMEX_RKObserver_))
           stepperIMEX_RKObserver_->observeBeforeSolve(solutionHistory, *this);

--- a/packages/tempus/src/Tempus_StepperImplicit_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperImplicit_decl.hpp
@@ -23,23 +23,26 @@ class ImplicitODEParameters
   public:
     /// Constructor
     ImplicitODEParameters()
-      : timeDer_(Teuchos::null), timeStepSize_(Scalar(0.0)), stageNumber_(0),
-        alpha_(Scalar(0.0)), beta_(Scalar(0.0)), evaluationType_(SOLVE_FOR_X)
+      : timeDer_(Teuchos::null), timeStepSize_(Scalar(0.0)),
+        alpha_(Scalar(0.0)), beta_(Scalar(0.0)), evaluationType_(SOLVE_FOR_X),
+        stageNumber_(0)
     {}
     /// Constructor
     ImplicitODEParameters(Teuchos::RCP<TimeDerivative<Scalar> > timeDer,
                           Scalar timeStepSize, Scalar alpha, Scalar beta,
-                          EVALUATION_TYPE evaluationType = SOLVE_FOR_X)
-      : timeDer_(timeDer), timeStepSize_(timeStepSize), stageNumber_(0),
-        alpha_(alpha), beta_(beta), evaluationType_(evaluationType)
+                          EVALUATION_TYPE evaluationType = SOLVE_FOR_X,
+                          int stageNumber = 0)
+      : timeDer_(timeDer), timeStepSize_(timeStepSize),
+        alpha_(alpha), beta_(beta), evaluationType_(evaluationType),
+        stageNumber_(stageNumber)
     {}
 
     Teuchos::RCP<TimeDerivative<Scalar> > timeDer_;
     Scalar                                timeStepSize_;
-    int                                   stageNumber_;
     Scalar                                alpha_;
     Scalar                                beta_;
     EVALUATION_TYPE                       evaluationType_;
+    int                                   stageNumber_;
 };
 
 /** \brief Thyra Base interface for implicit time steppers.
@@ -95,7 +98,7 @@ public:
       const Scalar time,
       const Teuchos::RCP<ImplicitODEParameters<Scalar> > & p );
 
-    /// Evaluate implicit ODE, f(x, xDot, t, p), residual.
+    /// Evaluate implicit ODE residual, f(x, xDot, t, p).
     void evaluateImplicitODE(
             Teuchos::RCP<Thyra::VectorBase<Scalar> > & f,
       const Teuchos::RCP<Thyra::VectorBase<Scalar> > & x,

--- a/packages/tempus/src/Tempus_StepperImplicit_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperImplicit_impl.hpp
@@ -166,9 +166,8 @@ void StepperImplicit<Scalar>::setInitialConditions(
       RCP<TimeDerivative<Scalar> > timeDer = Teuchos::null;
       const Scalar alpha = Scalar(1.0);    // d(xDot)/d(xDot)
       const Scalar beta  = Scalar(0.0);    // d(x   )/d(xDot)
-      RCP<ImplicitODEParameters<Scalar> > p =
-        Teuchos::rcp(new ImplicitODEParameters<Scalar>(timeDer,dt,alpha,beta,
-                                                       SOLVE_FOR_XDOT_CONST_X));
+      auto p = Teuchos::rcp(new ImplicitODEParameters<Scalar>(
+        timeDer, dt, alpha, beta, SOLVE_FOR_XDOT_CONST_X));
 
       auto xDot = this->getStepperXDot(initialState);
       const Thyra::SolveStatus<Scalar> sStatus =
@@ -206,9 +205,8 @@ void StepperImplicit<Scalar>::setInitialConditions(
     RCP<TimeDerivative<Scalar> > timeDer = Teuchos::null;
     const Scalar alpha = Scalar(0.0);
     const Scalar beta  = Scalar(0.0);
-    RCP<ImplicitODEParameters<Scalar> > p =
-      Teuchos::rcp(new ImplicitODEParameters<Scalar>(timeDer,dt,alpha,beta,
-                                                     EVALUATE_RESIDUAL));
+    auto p = Teuchos::rcp(new ImplicitODEParameters<Scalar>(
+      timeDer, dt, alpha, beta, EVALUATE_RESIDUAL));
 
     this->evaluateImplicitODE(f, x, xDot, time, p);
 

--- a/packages/tempus/src/Tempus_StepperLeapfrog_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperLeapfrog_impl.hpp
@@ -137,10 +137,12 @@ void StepperLeapfrog<Scalar>::takeStep(
     if (!Teuchos::is_null(stepperLFObserver_))
       stepperLFObserver_->observeBeforeExplicit(solutionHistory, *this);
 
+    auto p = Teuchos::rcp(new ExplicitODEParameters<Scalar>(dt));
+
     // Evaluate xDotDot = f(x,t).
     this->evaluateExplicitODE(workingState->getXDotDot(),
                               workingState->getX(),
-                              Teuchos::null, time+dt);
+                              Teuchos::null, time+dt, p);
 
     if (!Teuchos::is_null(stepperLFObserver_))
       stepperLFObserver_->observeBeforeXDotUpdate(solutionHistory, *this);

--- a/packages/tempus/src/Tempus_StepperTrapezoidal_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperTrapezoidal_impl.hpp
@@ -140,28 +140,18 @@ void StepperTrapezoidal<Scalar>::takeStep(
     const Scalar alpha = getAlpha(dt);
     const Scalar beta  = getBeta (dt);
 
-
     // Setup TimeDerivative
     Teuchos::RCP<TimeDerivative<Scalar> > timeDer =
       Teuchos::rcp(new StepperTrapezoidalTimeDerivative<Scalar>(
         alpha, xOld, xDotOld));
 
-    // Setup InArgs and OutArgs
-    typedef Thyra::ModelEvaluatorBase MEB;
-    MEB::InArgs<Scalar>  inArgs  = this->wrapperModel_->getInArgs();
-    MEB::OutArgs<Scalar> outArgs = this->wrapperModel_->getOutArgs();
-    inArgs.set_x(x);
-    if (inArgs.supports(MEB::IN_ARG_x_dot    )) inArgs.set_x_dot    (xDot);
-    if (inArgs.supports(MEB::IN_ARG_t        )) inArgs.set_t        (time);
-    if (inArgs.supports(MEB::IN_ARG_step_size)) inArgs.set_step_size(dt);
-    if (inArgs.supports(MEB::IN_ARG_alpha    )) inArgs.set_alpha    (alpha);
-    if (inArgs.supports(MEB::IN_ARG_beta     )) inArgs.set_beta     (beta);
-
-    this->wrapperModel_->setForSolve(timeDer, inArgs, outArgs);
+    auto p = Teuchos::rcp(new ImplicitODEParameters<Scalar>(
+      timeDer, dt, alpha, beta));
 
     stepperTrapObserver_->observeBeforeSolve(solutionHistory, *this);
 
-    const Thyra::SolveStatus<Scalar> sStatus = this->solveImplicitODE(x);
+    const Thyra::SolveStatus<Scalar> sStatus =
+      this->solveImplicitODE(x, xDot, time, p);
 
     stepperTrapObserver_->observeAfterSolve(solutionHistory, *this);
 


### PR DESCRIPTION
 * Added new parameters for explicit evaluation, xDot = f(x,t,p).
   Parameters for explicit steppers, p, are currently dt and stage number.

 * Cleaned up implicit parameters (e.g., included stage number in
   argument list).

 * StepperTrapezoidal was missing the new solveImplicitODE().

Passes all tests on my Mac.

@trilinos/tempus