### PR TITLE
TrilinosCouplings/FENL:  Change order of includes to fix overload error

### DIFF
--- a/packages/trilinoscouplings/examples/fenl/main_pce.cpp
+++ b/packages/trilinoscouplings/examples/fenl/main_pce.cpp
@@ -1,5 +1,5 @@
-#include "Stokhos_Sacado_Kokkos_MP_Vector.hpp"
 #include "Stokhos_Sacado_Kokkos_UQ_PCE.hpp"
+#include "Stokhos_Sacado_Kokkos_MP_Vector.hpp"
 #include "Stokhos.hpp"
 
 //----------------------------------------------------------------------------


### PR DESCRIPTION
Fixes the build error reported here:

https://testing.sandia.gov/cdash/viewBuildError.php?buildid=5530425

I have no idea why this build is the only one that has ever come across
this error, nor why changing the include order fixes it.  The compiler
complains about a missing overload of Kokkos::create_mirror() with a
Sacado::UQ::PCE view, and the file that calls it is below where the file
that defines it is included.  Who knows.
