### PR TITLE
MueLu: add Chebyshev for region MG

### DIFF
--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
@@ -717,62 +717,6 @@ void createRegionHierarchy(const int maxRegPerProc,
 }
 
 
-/*! \brief Compute the residual \f$r = b - Ax\f$
- *
- *  The residual is computed based on matrices and vectors in a regional layout.
- *  1. Compute y = A*x in regional layout.
- *  2. Sum interface values of y to account for duplication of interface DOFs.
- *  3. Compute r = b - y
- */
-template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >
-computeResidual(Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regRes, ///< residual (to be evaluated)
-                const Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regX, ///< left-hand side (solution)
-                const Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regB, ///< right-hand side (forcing term)
-                const std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regionGrpMats,
-                const RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > mapComp, ///< composite map, computed by removing GIDs > numDofs in revisedRowMapPerGrp
-                const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > rowMapPerGrp, ///< row maps in region layout [in] requires the mapping of GIDs on fine mesh to "filter GIDs"
-                const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > revisedRowMapPerGrp, ///< revised row maps in region layout [in] (actually extracted from regionGrpMats)
-                const std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > rowImportPerGrp ///< row importer in region layout [in]
-    )
-{
-#include "Xpetra_UseShortNames.hpp"
-  using Teuchos::TimeMonitor;
-  const int maxRegPerProc = regX.size();
-
-  RCP<TimeMonitor> tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("computeResidual: 1 - Rreg = Areg*Xreg")));
-
-  /* Update the residual vector
-   * 1. Compute tmp = A * regX in each region
-   * 2. Sum interface values in tmp due to duplication (We fake this by scaling to reverse the basic splitting)
-   * 3. Compute r = B - tmp
-   */
-  for (int j = 0; j < maxRegPerProc; j++) { // step 1
-    regionGrpMats[j]->apply(*regX[j], *regRes[j]);
-    //    TEUCHOS_ASSERT(regionGrpMats[j]->getDomainMap()->isSameAs(*regX[j]->getMap()));
-    //    TEUCHOS_ASSERT(regionGrpMats[j]->getRangeMap()->isSameAs(*regRes[j]->getMap()));
-  }
-
-  tm = Teuchos::null;
-  tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("computeResidual: 2 - sumInterfaceValues")));
-
-  sumInterfaceValues(regRes, mapComp, maxRegPerProc, rowMapPerGrp,
-                     revisedRowMapPerGrp, rowImportPerGrp);
-
-  tm = Teuchos::null;
-  tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("computeResidual: 3 - Rreg = Breg - Rreg")));
-
-  for (int j = 0; j < maxRegPerProc; j++) { // step 3
-    regRes[j]->update(1.0, *regB[j], -1.0);
-    //    TEUCHOS_ASSERT(regRes[j]->getMap()->isSameAs(*regB[j]->getMap()));
-  }
-
-  tm = Teuchos::null;
-
-  return regRes;
-} // computeResidual
-
-
 //! Recursive V-cycle in region fashion
 template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void vCycle(const int l, ///< ID of current level

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionMatrix_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionMatrix_def.hpp
@@ -712,4 +712,59 @@ void regionalToComposite(const std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdin
   return;
 } // regionalToComposite
 
+/*! \brief Compute the residual \f$r = b - Ax\f$
+ *
+ *  The residual is computed based on matrices and vectors in a regional layout.
+ *  1. Compute y = A*x in regional layout.
+ *  2. Sum interface values of y to account for duplication of interface DOFs.
+ *  3. Compute r = b - y
+ */
+template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >
+computeResidual(Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regRes, ///< residual (to be evaluated)
+                const Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regX, ///< left-hand side (solution)
+                const Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regB, ///< right-hand side (forcing term)
+                const std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regionGrpMats,
+                const RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > mapComp, ///< composite map, computed by removing GIDs > numDofs in revisedRowMapPerGrp
+                const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > rowMapPerGrp, ///< row maps in region layout [in] requires the mapping of GIDs on fine mesh to "filter GIDs"
+                const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > revisedRowMapPerGrp, ///< revised row maps in region layout [in] (actually extracted from regionGrpMats)
+                const std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > rowImportPerGrp ///< row importer in region layout [in]
+    )
+{
+#include "Xpetra_UseShortNames.hpp"
+  using Teuchos::TimeMonitor;
+  const int maxRegPerProc = regX.size();
+
+  RCP<TimeMonitor> tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("computeResidual: 1 - Rreg = Areg*Xreg")));
+
+  /* Update the residual vector
+   * 1. Compute tmp = A * regX in each region
+   * 2. Sum interface values in tmp due to duplication (We fake this by scaling to reverse the basic splitting)
+   * 3. Compute r = B - tmp
+   */
+  for (int j = 0; j < maxRegPerProc; j++) { // step 1
+    regionGrpMats[j]->apply(*regX[j], *regRes[j]);
+    //    TEUCHOS_ASSERT(regionGrpMats[j]->getDomainMap()->isSameAs(*regX[j]->getMap()));
+    //    TEUCHOS_ASSERT(regionGrpMats[j]->getRangeMap()->isSameAs(*regRes[j]->getMap()));
+  }
+
+  tm = Teuchos::null;
+  tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("computeResidual: 2 - sumInterfaceValues")));
+
+  sumInterfaceValues(regRes, mapComp, maxRegPerProc, rowMapPerGrp,
+                     revisedRowMapPerGrp, rowImportPerGrp);
+
+  tm = Teuchos::null;
+  tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("computeResidual: 3 - Rreg = Breg - Rreg")));
+
+  for (int j = 0; j < maxRegPerProc; j++) { // step 3
+    regRes[j]->update(1.0, *regB[j], -1.0);
+    //    TEUCHOS_ASSERT(regRes[j]->getMap()->isSameAs(*regB[j]->getMap()));
+  }
+
+  tm = Teuchos::null;
+
+  return regRes;
+} // computeResidual
+
 #endif // MUELU_SETUPREGIONMATRIX_DEF_HPP

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionSmoothers_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionSmoothers_def.hpp
@@ -405,7 +405,6 @@ void chebyshevIterate ( RCP<Teuchos::ParameterList> params,
   const Scalar eigRatio  = params->get<double>("smoother: eigRatio");
   const Scalar lambdaMax = params->get<Scalar>("chebyshev: lambda max");
   const Scalar lambdaMin = lambdaMax / eigRatio;
-  std::cout<<lambdaMax<<std::endl;
   
   Teuchos::Array<RCP<Vector> > diag_inv = params->get<Teuchos::Array<RCP<Vector> > >("chebyshev: inverse diagonal");
 

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionSmoothers_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionSmoothers_def.hpp
@@ -258,6 +258,230 @@ void GSIterate(RCP<Teuchos::ParameterList> smootherParams,
   return;
 } // GS
 
+
+template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+typename Teuchos::ScalarTraits<Scalar>::magnitudeType
+calcNorm2(Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regVec,
+                        const RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > mapComp,
+                        const int maxRegPerProc,
+                        const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > rowMapPerGrp,
+                        const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > revisedRowMapPerGrp,
+                        const std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > rowImportPerGrp)
+{
+#include "Xpetra_UseShortNames.hpp"
+  RCP<Vector> compVec = VectorFactory::Build(mapComp, true);
+  regionalToComposite(regVec, compVec, maxRegPerProc, rowMapPerGrp, rowImportPerGrp, Xpetra::ADD);
+  typename Teuchos::ScalarTraits<Scalar>::magnitudeType norm = compVec->norm2();
+
+  return norm;
+} // calcNorm2
+
+template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+Scalar
+dotProd(Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regX,
+        Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regY,
+        const RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > mapComp,
+        const int maxRegPerProc,
+        const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > rowMapPerGrp,
+        const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > revisedRowMapPerGrp,
+        const std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > rowImportPerGrp)
+{
+#include "Xpetra_UseShortNames.hpp"
+  RCP<Vector> compX = VectorFactory::Build(mapComp, true);
+  RCP<Vector> compY = VectorFactory::Build(mapComp, true);
+  regionalToComposite(regX, compX, maxRegPerProc, rowMapPerGrp, rowImportPerGrp, Xpetra::ADD);
+  regionalToComposite(regY, compY, maxRegPerProc, rowMapPerGrp, rowImportPerGrp, Xpetra::ADD);
+  SC dotVal = compX->dot(*compY);
+
+  return dotVal;
+} // dotProd
+
+template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+Scalar
+powerMethod(RCP<Teuchos::ParameterList> params,
+                    const int maxRegPerProc,
+                    const std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regionGrpMats,
+                    const Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regionInterfaceScaling,
+                 //   const std::vector<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regionInterfaceScaling,
+                    const RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > mapComp,
+                    const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > rowMapPerGrp,
+                    const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > revisedRowMapPerGrp,
+                    const std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > rowImportPerGrp,
+                    const int numIters)
+{
+#include "Xpetra_UseShortNames.hpp"
+
+  Teuchos::Array<RCP<Vector> > diagInv = params->get<Teuchos::Array<RCP<Vector> > >("chebyshev: inverse diagonal");
+  const SC SC_ZERO = Teuchos::ScalarTraits<Scalar>::zero();
+  const SC SC_ONE  = Teuchos::ScalarTraits<Scalar>::one();
+  SC lambdaMax = SC_ZERO;
+  SC RQ_top, RQ_bottom, norm;
+
+  Array<RCP<Vector> > regX(maxRegPerProc);
+  createRegionalVector(regX, maxRegPerProc, revisedRowMapPerGrp);
+  Array<RCP<Vector> > regY(maxRegPerProc);
+  createRegionalVector(regY, maxRegPerProc, revisedRowMapPerGrp);
+
+  for( int j = 0; j < maxRegPerProc; j++){
+    regX[j]->randomize();
+  }
+  norm = calcNorm2(regX, mapComp, maxRegPerProc, rowMapPerGrp, revisedRowMapPerGrp, rowImportPerGrp);
+  for (int j = 0; j < maxRegPerProc; j++) {
+    regX[j]->scale( SC_ONE / norm );
+  }
+
+  for (int iter = 0; iter < numIters; ++iter) {
+
+    for (int j = 0; j < maxRegPerProc; j++) { // step 1
+      regionGrpMats[j]->apply(*regX[j], *regY[j]); // A.apply (x, y);
+    }
+    sumInterfaceValues( regY, mapComp, maxRegPerProc, rowMapPerGrp, revisedRowMapPerGrp, rowImportPerGrp); // step 2
+
+    // Scale by inverse of diagonal
+    for (int j = 0; j < maxRegPerProc; j++){
+      regY[j]->elementWiseMultiply(SC_ONE, *diagInv[j], *regY[j], SC_ZERO);
+    }
+
+    RQ_top = dotProd( regY, regX, mapComp, maxRegPerProc, rowMapPerGrp, revisedRowMapPerGrp, rowImportPerGrp);
+    RQ_bottom = dotProd( regX, regX, mapComp, maxRegPerProc, rowMapPerGrp, revisedRowMapPerGrp, rowImportPerGrp);
+    lambdaMax = RQ_top / RQ_bottom;
+
+    norm = calcNorm2(regY, mapComp, maxRegPerProc, rowMapPerGrp, revisedRowMapPerGrp, rowImportPerGrp);
+
+    if (norm == SC_ZERO) { // Return something reasonable.
+      return SC_ZERO;
+    }
+    for (int j = 0; j < maxRegPerProc; j++) {
+      regX[j]->update( SC_ONE / norm, *regY[j], SC_ZERO);
+    }
+
+  }
+
+  return lambdaMax;
+} // powerMethod
+
+/*! \brief performs Chebyshev setup
+ */
+template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+void chebyshevSetup(RCP<Teuchos::ParameterList> params,
+                   const int maxRegPerProc,
+                   const std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regionGrpMats,
+                   const Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regionInterfaceScaling,
+                 //  const std::vector<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regionInterfaceScaling,
+                   const RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > mapComp,
+                   const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > rowMapPerGrp,
+                   const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > revisedRowMapPerGrp,
+                   const std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > rowImportPerGrp) {
+#include "Xpetra_UseShortNames.hpp"
+  const Scalar SC_ZERO = Teuchos::ScalarTraits<Scalar>::zero();
+  const Scalar SC_ONE  = Teuchos::ScalarTraits<Scalar>::one();
+
+  Array<RCP<Vector> > regRes(maxRegPerProc);
+  createRegionalVector(regRes, maxRegPerProc, revisedRowMapPerGrp);
+
+  // extract diagonal from region matrices, recover true diagonal values, invert diagonal
+  Teuchos::Array<RCP<Vector> > diag(maxRegPerProc);
+  for (int j = 0; j < maxRegPerProc; j++) {
+    // extract inverse of diagonal from matrix
+    diag[j] = VectorFactory::Build(regionGrpMats[j]->getRowMap(), true);
+    regionGrpMats[j]->getLocalDiagCopy(*diag[j]);
+    diag[j]->elementWiseMultiply(SC_ONE, *diag[j], *regionInterfaceScaling[j], SC_ZERO); // ToDo Does it work to pass in diag[j], but also return into the same variable?
+    diag[j]->reciprocal(*diag[j]);
+  }
+
+  params->set<Teuchos::Array<RCP<Vector> > >("chebyshev: inverse diagonal", diag);
+
+  // Calculate lambdaMax
+  Scalar lambdaMax = 1;
+  lambdaMax = powerMethod( params,
+                           maxRegPerProc,
+                           regionGrpMats,
+                           regionInterfaceScaling,
+                           mapComp,
+                           rowMapPerGrp,
+                           revisedRowMapPerGrp,
+                           rowImportPerGrp,
+                           1000);
+  params->set< Scalar >("chebyshev: lambda max", lambdaMax );
+
+} // chebyshevSetup
+
+template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+void chebyshevIterate ( RCP<Teuchos::ParameterList> params,
+                   Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regX, // left-hand side (or solution)
+                   const Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regB, // right-hand side (or residual)
+                   const std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regionGrpMats, // matrices in true region layout
+                   const Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regionInterfaceScaling, // recreate on coarse grid by import Add on region vector of ones
+                   const int maxRegPerProc, ///< max number of regions per proc [in]
+                   const RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > mapComp, ///< composite map
+                   const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > rowMapPerGrp, ///< row maps in region layout [in] requires the mapping of GIDs on fine mesh to "filter GIDs"
+                   const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > revisedRowMapPerGrp, ///< revised row maps in region layout [in] (actually extracted from regionGrpMats)
+                   const std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > rowImportPerGrp ///< row importer in region layout [in]
+                   )
+{
+#include "Xpetra_UseShortNames.hpp"
+  const int maxIter    = params->get<int>   ("smoother: sweeps");
+  Scalar lambdaMax     = params->get<Scalar>("chebyshev: lambda max");
+  
+  Teuchos::Array<RCP<Vector> > diag_inv = params->get<Teuchos::Array<RCP<Vector> > >("chebyshev: inverse diagonal");
+
+  const Scalar eigRatio = 4; // 30 is Ifpack2 default
+  const Scalar lambdaMin = lambdaMax / eigRatio;
+
+  const Scalar SC_ZERO = Teuchos::ScalarTraits<Scalar>::zero();
+  const Scalar SC_ONE  = Teuchos::ScalarTraits<Scalar>::one();
+  const Scalar SC_TWO  = Teuchos::as<Scalar> (2);
+
+  const Scalar d = (lambdaMax + lambdaMin) / SC_TWO;// Ifpack2 calls this theta
+  const Scalar c = (lambdaMax - lambdaMin) / SC_TWO;// Ifpack2 calls this 1/delta
+
+  Array<RCP<Vector> > regRes(maxRegPerProc);
+  createRegionalVector(regRes, maxRegPerProc, revisedRowMapPerGrp);
+
+  Array<RCP<Vector> > regP(maxRegPerProc);
+  createRegionalVector(regP, maxRegPerProc, revisedRowMapPerGrp);
+  Array<RCP<Vector> > regZ(maxRegPerProc);
+  createRegionalVector(regZ, maxRegPerProc, revisedRowMapPerGrp);
+
+  Scalar alpha, beta;
+
+  for (int i = 0; i < maxIter; ++i) {
+    // Compute residual vector
+    for (int j = 0; j < maxRegPerProc; j++) { // step 1
+      regionGrpMats[j]->apply(*regX[j], *regRes[j]);
+    }
+    sumInterfaceValues(regRes, mapComp, maxRegPerProc, rowMapPerGrp, revisedRowMapPerGrp, rowImportPerGrp); // step 2
+    for (int j = 0; j < maxRegPerProc; j++) { // step 3
+      regRes[j]->update(1.0, *regB[j], -1.0);
+    }
+
+    //solve (Z, D_inv, R); // z = D_inv * R, that is, D \ R.
+    for(int j = 0; j < maxRegPerProc; j++) {
+      regZ[j]->elementWiseMultiply(SC_ONE, *diag_inv[j], *regRes[j], SC_ZERO);
+    }
+    if (i == 0) {
+      for (int j=0; j < maxRegPerProc; j++) {
+      regP[j]->update( SC_ONE, *regZ[j], SC_ZERO); // P = Z
+      }
+      alpha = SC_TWO / d;//if2
+    } else {
+      beta  = alpha * ( c / SC_TWO ) * ( c / SC_TWO ); //if2
+      alpha = SC_ONE / ( d - beta ); //if2
+      for (int j=0; j < maxRegPerProc; j++) {
+        regP[j]->update( SC_ONE, *regZ[j], beta);// P = Z + beta*P
+      }
+    }
+    for (int j=0; j < maxRegPerProc; j++) {
+      regX[j]->update( alpha, *regP[j], SC_ONE);// X = X + alpha*P
+    }
+
+    // If we compute the residual here, we could either do R = B -
+    // A*X, or R = R - alpha*A*P.  Since we choose the former, we
+    // can move the computeResidual call to the top of the loop.
+  }
+} // chebyshevIterate
+
+
 template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void smootherSetup(RCP<Teuchos::ParameterList> params,
                    const int maxRegPerProc,
@@ -286,7 +510,7 @@ void smootherSetup(RCP<Teuchos::ParameterList> params,
   }
   case 3:
   {
-    std::cout << "Chebyshev smoother not implemented yet. No smoother is applied" << std::endl;
+    chebyshevSetup(params, maxRegPerProc, regionGrpMats, regionInterfaceScaling, mapComp, rowMapPerGrp, revisedRowMapPerGrp, rowImportPerGrp);
     break;
   }
   default:
@@ -330,6 +554,8 @@ void smootherApply(RCP<Teuchos::ParameterList> params,
     break;
   }
   case 3:
+    chebyshevIterate(params, regX, regB, regionGrpMats, regionInterfaceScaling, maxRegPerProc,
+                  mapComp, rowMapPerGrp, revisedRowMapPerGrp, rowImportPerGrp);
   {
     break;
   }

--- a/packages/muelu/research/regionMG/examples/structured/CMakeLists.txt
+++ b/packages/muelu/research/regionMG/examples/structured/CMakeLists.txt
@@ -76,6 +76,22 @@ IF (${PACKAGE_NAME}_ENABLE_Tpetra AND ${PACKAGE_NAME}_ENABLE_Amesos2)
 
   TRIBITS_ADD_TEST(
     StructuredRegionDriver
+    NAME "Structured_Region_Star2D_Tpetra_Chebyshev"
+    ARGS "--linAlgebra=Tpetra --xml=structured_1dof.xml --matrixType=Star2D --nx=10 --ny=10 --smootherIts=2 --convergence-log=Star2D_Chebyshev_1.log --smootherType=Chebyshev"
+    COMM serial mpi
+    NUM_MPI_PROCS 1
+    )
+
+  TRIBITS_ADD_TEST(
+    StructuredRegionDriver
+    NAME "Structured_Region_Star2D_Tpetra_Chebyshev"
+    ARGS "--linAlgebra=Tpetra --xml=structured_1dof.xml --matrixType=Star2D --nx=10 --ny=10 --smootherIts=2 --convergence-log=Star2D_Chebyshev_4.log --smootherType=Chebyshev"
+    COMM serial mpi
+    NUM_MPI_PROCS 4
+    )
+
+  TRIBITS_ADD_TEST(
+    StructuredRegionDriver
     NAME "Structured_Region_Star2D_AMG_CoarseSolver_Tpetra"
     ARGS "--linAlgebra=Tpetra --xml=structured_1dof_3level.xml --matrixType=Star2D --nx=50 --ny=50 --smootherIts=2 --coarseSolverType=amg --coarseAmgXml=amg_1dof.xml"
     COMM serial mpi

--- a/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
+++ b/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
@@ -169,6 +169,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
   std::string smootherType       = "Jacobi";            clp.setOption("smootherType",          &smootherType,      "smoother to be used: (None | Jacobi | Gauss | Chebyshev)");
   int         smootherIts        = 2;                   clp.setOption("smootherIts",           &smootherIts,       "number of smoother iterations");
   double      smootherDamp       = 0.67;                clp.setOption("smootherDamp",          &smootherDamp,      "damping parameter for the level smoother");
+  double      smootherEigRatio   = 2.0;                   clp.setOption("smootherEigRatio",      &smootherEigRatio,  "eigenvalue ratio max/min used to approximate the smallest eigenvalue for Chebyshev relaxation");
   double      tol                = 1e-12;               clp.setOption("tol",                   &tol,               "solver convergence tolerance");
   bool        scaleResidualHist  = true;                clp.setOption("scale", "noscale",      &scaleResidualHist, "scaled Krylov residual history");
   bool        serialRandom       = false;               clp.setOption("use-serial-random", "no-use-serial-random", &serialRandom, "generate the random vector serially and then broadcast it");
@@ -218,6 +219,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
   smootherParams[0]->set("smoother: type",    smootherType);
   smootherParams[0]->set("smoother: sweeps",  smootherIts);
   smootherParams[0]->set("smoother: damping", smootherDamp);
+  smootherParams[0]->set("smoother: eigRatio", smootherEigRatio);
 
   bool useUnstructured = false;
   Array<LO> unstructuredRanks = Teuchos::fromStringToArray<LO>(unstructured);


### PR DESCRIPTION
@trilinos/muelu 

## Description

- Add a text-book Chebyshev implementation for region MG.
- Move `computeResidual()` utility from `SetupRegionHierarchy_def.hpp` to `SetupRegionMatrix_def.hpp`
- Cover Chebyshev smoother by two region MG completion tests in 2D.

## Motivation and Context

## Related Issues

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->

<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [x] These changes break backwards compatibility.

## Additional Information

Let's start as WIP-PR, so that we can discuss things.