### PR TITLE
MueLu: distance2 coloring, Aggregates_kokkos and Phase 1 aggregation

### DIFF
--- a/packages/muelu/src/Graph/Containers/MueLu_Aggregates_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/Containers/MueLu_Aggregates_kokkos_decl.hpp
@@ -61,7 +61,7 @@
 
 #include "MueLu_BaseClass.hpp"
 
-#include "MueLu_LWGraph_kokkos_fwd.hpp"
+#include "MueLu_LWGraph_kokkos.hpp"
 #include "MueLu_IndexManager_kokkos.hpp"
 
 #define MUELU_UNAGGREGATED  -1   /* indicates that a node is unassigned to  */
@@ -106,15 +106,18 @@ namespace MueLu {
   template <class LocalOrdinal, class GlobalOrdinal, class DeviceType>
   class Aggregates_kokkos<LocalOrdinal, GlobalOrdinal, Kokkos::Compat::KokkosDeviceWrapperNode<DeviceType> > : public BaseClass {
   public:
-    typedef LocalOrdinal                                             local_ordinal_type;
-    typedef GlobalOrdinal                                            global_ordinal_type;
-    typedef typename DeviceType::execution_space                     execution_space;
-    typedef Kokkos::RangePolicy<local_ordinal_type, execution_space> range_type;
-    typedef Kokkos::Compat::KokkosDeviceWrapperNode<DeviceType>      node_type;
-    typedef DeviceType                                               device_type;
+    // For some reason we seem intent on having these declared before pulling the short names in
+    // I am not sure why but I will keep things as it is for now
+    // If you need to define a type that depend on a short name please do it further down after
+    // the header has been included!
+    using local_ordinal_type  = LocalOrdinal;
+    using global_ordinal_type = GlobalOrdinal;
+    using execution_space     = typename DeviceType::execution_space;
+    using node_type           = Kokkos::Compat::KokkosDeviceWrapperNode<DeviceType>;
+    using device_type         = DeviceType;
+    using range_type          = Kokkos::RangePolicy<local_ordinal_type, execution_space>;
 
-    typedef Kokkos::View<LocalOrdinal*, DeviceType>                  aggregates_sizes_type;
-    typedef Kokkos::StaticCrsGraph<LocalOrdinal, Kokkos::LayoutLeft, execution_space> local_graph_type;
+    using aggregates_sizes_type = Kokkos::View<LocalOrdinal*, DeviceType>;
 
   private:
     // For compatibility
@@ -124,7 +127,10 @@ namespace MueLu {
 
   public:
 
-  public:
+    // Defining types that require the short names included above
+    using local_graph_type = typename LWGraph_kokkos::local_graph_type;
+    using colors_view_type = Kokkos::View<typename local_graph_type::entries_type::data_type,
+                                          typename local_graph_type::device_type::memory_space>;
 
     /*! @brief Standard constructor for Aggregates structure
      *
@@ -147,10 +153,30 @@ namespace MueLu {
      */
     virtual ~Aggregates_kokkos() { }
 
-    ///< returns the number of aggregates of the current processor. Note: could/should be renamed to GetNumLocalAggregates?
-    KOKKOS_INLINE_FUNCTION LO GetNumAggregates() const {
-      return numAggregates_;
-    }
+    //! @name Set/Get Methods for specific aggregation data
+    //@{
+
+    /*! @brief Get the index manager used by structured aggregation algorithms.
+        This has to be done by the aggregation factory.
+    */
+    RCP<IndexManager_kokkos>& GetIndexManager() { return geoData_; }
+
+    /*! @brief Set the index manager used by structured aggregation algorithms.
+        This has to be done by the aggregation factory.
+    */
+    void SetIndexManager(RCP<IndexManager_kokkos> & geoData) { geoData_ = geoData; }
+
+    /*! @brief Get a distance 2 coloring of the underlying graph.
+        The coloring is computed and set during Phase1 of aggregation.
+    */
+    colors_view_type& GetGraphColors() { return graphColors_; }
+
+    /*! @brief Set a distance 2 coloring of the underlying graph.
+        The coloring is computed and set during Phase1 of aggregation.
+    */
+    void SetGraphColors(colors_view_type graphColors) { graphColors_ = graphColors; }
+
+    //@}
 
     /*! @brief Set number of local aggregates on current processor.
 
@@ -158,17 +184,10 @@ namespace MueLu {
     */
     void SetNumAggregates(LO nAggregates) { numAggregates_ = nAggregates; }
 
-    /*! @brief Get the index manager used by structured aggregation algorithms.
-
-        This has to be done by the aggregation factory.
-    */
-    RCP<IndexManager_kokkos>& GetIndexManager() { return geoData_; }
-
-    /*! @brief Get the index manager used by structured aggregation algorithms.
-
-        This has to be done by the aggregation factory.
-    */
-    void SetIndexManager(RCP<IndexManager_kokkos> & geoData) { geoData_ = geoData; }
+    ///< returns the number of aggregates of the current processor. Note: could/should be renamed to GetNumLocalAggregates?
+    KOKKOS_INLINE_FUNCTION LO GetNumAggregates() const {
+      return numAggregates_;
+    }
 
     //! @brief Record whether aggregates include DOFs from other processes.
     KOKKOS_INLINE_FUNCTION void AggregatesCrossProcessors(const bool& flag) {
@@ -261,6 +280,11 @@ namespace MueLu {
      *  on a problem.
      */
     RCP<IndexManager_kokkos> geoData_;
+
+    /*! graphColors_ stores a view that assigns a color to each node in the graph
+     *  These colors are used to parallelize the aggregation process in UncoupledAggregation
+     */
+    colors_view_type graphColors_;
 
     Kokkos::View<bool*, DeviceType> isRoot_;
 

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase1Algorithm_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase1Algorithm_kokkos_def.hpp
@@ -70,7 +70,8 @@ namespace MueLu {
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   void AggregationPhase1Algorithm_kokkos<LocalOrdinal, GlobalOrdinal, Node>::
-  BuildAggregates(const ParameterList& params, const LWGraph_kokkos& graph, Aggregates_kokkos& aggregates, std::vector<unsigned>& aggStat,
+  BuildAggregates(const ParameterList& params, const LWGraph_kokkos& graph,
+                  Aggregates_kokkos& aggregates, std::vector<unsigned>& aggStat,
                   LO& numNonAggregatedNodes) const {
     Monitor m(*this, "BuildAggregates");
 
@@ -86,7 +87,8 @@ namespace MueLu {
       algorithm = algorithmFromName(params.get<std::string>("aggregation: phase 1 algorithm"));
     }
 
-    TEUCHOS_TEST_FOR_EXCEPTION(maxNodesPerAggregate < minNodesPerAggregate, Exceptions::RuntimeError,
+    TEUCHOS_TEST_FOR_EXCEPTION(maxNodesPerAggregate < minNodesPerAggregate,
+                               Exceptions::RuntimeError,
                                "MueLu::UncoupledAggregationAlgorithm::BuildAggregates: minNodesPerAggregate must be smaller or equal to MaxNodePerAggregate!");
 
     //Distance-2 gives less control than serial uncoupled phase 1
@@ -94,12 +96,13 @@ namespace MueLu {
     //can only enforce max aggregate size
     if(algorithm == Algorithm::Distance2)
     {
-      BuildAggregatesDistance2(graph, aggregates, aggStat, numNonAggregatedNodes, maxNodesPerAggregate);
+      BuildAggregatesDistance2(graph, aggregates, aggStat,
+                               numNonAggregatedNodes, maxNodesPerAggregate);
     }
     else
     {
-      BuildAggregatesSerial(graph, aggregates, aggStat, numNonAggregatedNodes,
-          minNodesPerAggregate, maxNodesPerAggregate, maxNeighAlreadySelected, orderingStr);
+      BuildAggregatesSerial(graph, aggregates, aggStat, numNonAggregatedNodes, minNodesPerAggregate,
+                            maxNodesPerAggregate, maxNeighAlreadySelected, orderingStr);
     }
   }
 
@@ -107,9 +110,9 @@ namespace MueLu {
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   void AggregationPhase1Algorithm_kokkos<LocalOrdinal, GlobalOrdinal, Node>::
   BuildAggregatesSerial(const LWGraph_kokkos& graph, Aggregates_kokkos& aggregates,
-      std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes,
-      LO minNodesPerAggregate, LO maxNodesPerAggregate,
-      LO maxNeighAlreadySelected, std::string& orderingStr) const
+                        std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes,
+                        LO minNodesPerAggregate, LO maxNodesPerAggregate,
+                        LO maxNeighAlreadySelected, std::string& orderingStr) const
   {
     enum {
       O_NATURAL,
@@ -267,7 +270,8 @@ namespace MueLu {
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   void AggregationPhase1Algorithm_kokkos<LocalOrdinal, GlobalOrdinal, Node>::
   BuildAggregatesDistance2(const LWGraph_kokkos& graph, Aggregates_kokkos& aggregates,
-      std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes, LO maxAggSize) const
+                           std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes,
+                           LO maxAggSize) const
   {
     const LO  numRows = graph.GetNodeNumVertices();
     const int myRank  = graph.GetComm()->getRank();
@@ -277,137 +281,114 @@ namespace MueLu {
 
     LO numLocalAggregates = aggregates.GetNumAggregates();
 
-    //get the sparse local graph in CRS
-    std::vector<LocalOrdinal> rowptrs;
-    rowptrs.reserve(numRows + 1);
-    std::vector<LocalOrdinal> colinds;
-    colinds.reserve(graph.GetNodeNumEdges());
-
-    rowptrs.push_back(0);
-    for(LocalOrdinal row = 0; row < numRows; row++)
-    {
-      auto entries = graph.getNeighborVertices(row);
-      for(LocalOrdinal i = 0; i < entries.length; i++)
-      {
-        colinds.push_back(entries.colidx(i));
-      }
-      rowptrs.push_back(colinds.size());
-    }
-
     //the local CRS graph to Kokkos device views, then compute graph squared
-    typedef typename Tpetra::CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::local_graph_type graph_t;
-    typedef typename graph_t::device_type device_t;
-    typedef typename device_t::memory_space memory_space;
-    typedef typename device_t::execution_space execution_space;
-    typedef typename graph_t::row_map_type::non_const_type rowptrs_view;
-    typedef typename rowptrs_view::HostMirror host_rowptrs_view;
-    typedef typename graph_t::entries_type::non_const_type colinds_view;
-    typedef typename colinds_view::HostMirror host_colinds_view;
+    using graph_t         = typename LWGraph_kokkos::local_graph_type;
+    using device_t        = typename graph_t::device_type;
+    using memory_space    = typename device_t::memory_space;
+    using execution_space = typename device_t::execution_space;
+    using rowptrs_view    = typename graph_t::row_map_type;
+    using colinds_view    = typename graph_t::entries_type;
     //note: just using colinds_view in place of scalar_view_t type (it won't be used at all by symbolic SPGEMM)
-    typedef KokkosKernels::Experimental::KokkosKernelsHandle<
-      typename rowptrs_view::const_value_type, typename colinds_view::const_value_type, typename colinds_view::const_value_type, 
-      execution_space, memory_space, memory_space> KernelHandle;
+    using KernelHandle = KokkosKernels::Experimental::
+      KokkosKernelsHandle<typename rowptrs_view::value_type, typename colinds_view::value_type,
+                          typename colinds_view::value_type, execution_space, memory_space,
+                          memory_space>;
 
-    KernelHandle kh;
-    //leave gc algorithm choice as the default
-    kh.create_distance2_graph_coloring_handle();
+    typename Aggregates_kokkos::colors_view_type::HostMirror colors;
 
-    // get the distance-2 graph coloring handle
-    auto coloringHandle = kh.get_distance2_graph_coloring_handle();
-
-    // Set the distance-2 graph coloring algorithm to use.
-    // Options:
-    //     COLORING_D2_DEFAULT        - Let the kernel handle pick the variation
-    //     COLORING_D2_SERIAL         - Use the legacy serial-only implementation
-    //     COLORING_D2_MATRIX_SQUARED - Use the SPGEMM + D1GC method
-    //     COLORING_D2_SPGEMM         - Same as MATRIX_SQUARED
-    //     COLORING_D2_VB             - Use the parallel vertex based direct method
-    //     COLORING_D2_VB_BIT         - Same as VB but using the bitvector forbidden array
-    //     COLORING_D2_VB_BIT_EF      - Add experimental edge-filtering to VB_BIT
-    coloringHandle->set_algorithm( KokkosGraph::COLORING_D2_SERIAL );   
-
-    //Create device views for graph rowptrs/colinds
-    rowptrs_view aRowptrs("A device rowptrs", rowptrs.size());
-    colinds_view aColinds("A device colinds", colinds.size());
-    // Populate A in temporary host views, then copy to device
     {
-      host_rowptrs_view aHostRowptrs = Kokkos::create_mirror_view(aRowptrs);
-      for(size_t i = 0; i < rowptrs.size(); i++)
-      {
-        aHostRowptrs(i) = rowptrs[i];
-      }
-      Kokkos::deep_copy(aRowptrs, aHostRowptrs);
-      host_colinds_view aHostColinds = Kokkos::create_mirror_view(aColinds);
-      for(size_t i = 0; i < colinds.size(); i++)
-      {
-        aHostColinds(i) = colinds[i];
-      }
-      Kokkos::deep_copy(aColinds, aHostColinds);
+      Monitor m(*this, "Graph Coloring");
+      KernelHandle kh;
+      //leave gc algorithm choice as the default
+      kh.create_distance2_graph_coloring_handle();
+
+      // get the distance-2 graph coloring handle
+      auto coloringHandle = kh.get_distance2_graph_coloring_handle();
+
+      // Set the distance-2 graph coloring algorithm to use.
+      // Options:
+      //     COLORING_D2_DEFAULT        - Let the kernel handle pick the variation
+      //     COLORING_D2_SERIAL         - Use the legacy serial-only implementation
+      //     COLORING_D2_MATRIX_SQUARED - Use the SPGEMM + D1GC method
+      //     COLORING_D2_SPGEMM         - Same as MATRIX_SQUARED
+      //     COLORING_D2_VB             - Use the parallel vertex based direct method
+      //     COLORING_D2_VB_BIT         - Same as VB but using the bitvector forbidden array
+      //     COLORING_D2_VB_BIT_EF      - Add experimental edge-filtering to VB_BIT
+      coloringHandle->set_algorithm( KokkosGraph::COLORING_D2_SERIAL );
+
+      //Create device views for graph rowptrs/colinds
+      rowptrs_view aRowptrs = graph.getRowPtrs();
+      colinds_view aColinds = graph.getEntries();
+
+      //run d2 graph coloring
+      //graph is symmetric so row map/entries and col map/entries are the same
+      KokkosGraph::Experimental::graph_compute_distance2_color(&kh, numRows, numRows, aRowptrs, aColinds, aRowptrs, aColinds);
+
+      // extract the colors and store them in the aggregates
+      aggregates.SetGraphColors(coloringHandle->get_vertex_colors());
+      typename Aggregates_kokkos::colors_view_type colorsDevice = aggregates.GetGraphColors();
+
+      colors = Kokkos::create_mirror_view(colorsDevice);
+      Kokkos::deep_copy(colors, colorsDevice);
+
+      //clean up coloring handle
+      kh.destroy_distance2_graph_coloring_handle();
     }
-    //run d2 graph coloring
-    //graph is symmetric so row map/entries and col map/entries are the same
-    KokkosGraph::Experimental::graph_compute_distance2_color(&kh, numRows, numRows, aRowptrs, aColinds, aRowptrs, aColinds);
 
-    // extract the colors
-    auto colorsDevice = coloringHandle->get_vertex_colors();
-
-    auto colors = Kokkos::create_mirror_view(colorsDevice);
-    Kokkos::deep_copy(colors, colorsDevice);
-
-    //clean up coloring handle
-    kh.destroy_distance2_graph_coloring_handle();
-
-    //have color 1 (first color) be the aggregate roots (add those to mapping first)
-    LocalOrdinal aggCount = 0;
-    for(LocalOrdinal i = 0; i < numRows; i++)
     {
-      if(colors(i) == 1 && aggStat[i] == READY)
-      {
-        vertex2AggId[i] = aggCount++;
-        aggStat[i] = AGGREGATED;
-        numLocalAggregates++;
-        procWinner[i] = myRank;
-      }
-    }
-    numNonAggregatedNodes = 0;
-    std::vector<LocalOrdinal> aggSizes(numLocalAggregates, 0);
-    for(int i = 0; i < numRows; i++)
-    {
-      if(vertex2AggId[i] >= 0)
-        aggSizes[vertex2AggId[i]]++;
-    }
-    //now assign every READY vertex to a directly connected root
-    for(LocalOrdinal i = 0; i < numRows; i++)
-    {
-      if(colors(i) != 1 && (aggStat[i] == READY || aggStat[i] == NOTSEL))
-      {
-        //get neighbors of vertex i and
-        //look for local, aggregated, color 1 neighbor (valid root)
-        auto neighbors = graph.getNeighborVertices(i);
-        for(LocalOrdinal j = 0; j < neighbors.length; j++)
+      Monitor m(*this, "Building Initial Aggregates");
+      //have color 1 (first color) be the aggregate roots (add those to mapping first)
+      LocalOrdinal aggCount = 0;
+      for(LocalOrdinal i = 0; i < numRows; i++)
         {
-          auto nei = neighbors.colidx(j);
-          LocalOrdinal agg = vertex2AggId[nei];
-          if(graph.isLocalNeighborVertex(nei) && colors(nei) == 1 && aggStat[nei] == AGGREGATED && aggSizes[agg] < maxAggSize)
-          {
-            //assign vertex i to aggregate with root j
-            vertex2AggId[i] = agg;
-            aggSizes[agg]++;
-            aggStat[i] = AGGREGATED;
-            procWinner[i] = myRank;
-            break;
-          }
+          if(colors(i) == 1 && aggStat[i] == READY)
+            {
+              vertex2AggId[i] = aggCount++;
+              aggStat[i] = AGGREGATED;
+              numLocalAggregates++;
+              procWinner[i] = myRank;
+            }
         }
-      }
-      if(aggStat[i] != AGGREGATED)
-      {
-        numNonAggregatedNodes++;
-        if(aggStat[i] == NOTSEL)
-          aggStat[i] = READY;
-      }
+      numNonAggregatedNodes = 0;
+      std::vector<LocalOrdinal> aggSizes(numLocalAggregates, 0);
+      for(int i = 0; i < numRows; i++)
+        {
+          if(vertex2AggId[i] >= 0)
+            aggSizes[vertex2AggId[i]]++;
+        }
+      //now assign every READY vertex to a directly connected root
+      for(LocalOrdinal i = 0; i < numRows; i++)
+        {
+          if(colors(i) != 1 && (aggStat[i] == READY || aggStat[i] == NOTSEL))
+            {
+              //get neighbors of vertex i and
+              //look for local, aggregated, color 1 neighbor (valid root)
+              auto neighbors = graph.getNeighborVertices(i);
+              for(LocalOrdinal j = 0; j < neighbors.length; j++)
+                {
+                  auto nei = neighbors.colidx(j);
+                  LocalOrdinal agg = vertex2AggId[nei];
+                  if(graph.isLocalNeighborVertex(nei) && colors(nei) == 1 && aggStat[nei] == AGGREGATED && aggSizes[agg] < maxAggSize)
+                    {
+                      //assign vertex i to aggregate with root j
+                      vertex2AggId[i] = agg;
+                      aggSizes[agg]++;
+                      aggStat[i] = AGGREGATED;
+                      procWinner[i] = myRank;
+                      break;
+                    }
+                }
+            }
+          if(aggStat[i] != AGGREGATED)
+            {
+              numNonAggregatedNodes++;
+              if(aggStat[i] == NOTSEL)
+                aggStat[i] = READY;
+            }
+        }
+      // update aggregate object
+      aggregates.SetNumAggregates(numLocalAggregates);
     }
-    // update aggregate object
-    aggregates.SetNumAggregates(numLocalAggregates);
   }
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -427,4 +408,3 @@ namespace MueLu {
 
 #endif // HAVE_MUELU_KOKKOS_REFACTOR
 #endif // MUELU_AGGREGATIONPHASE1ALGORITHM_KOKKOS_DEF_HPP
-

--- a/packages/muelu/test/scaling/CMakeLists.txt
+++ b/packages/muelu/test/scaling/CMakeLists.txt
@@ -39,7 +39,7 @@ IF (${PACKAGE_NAME}_HAVE_TPETRA_SOLVER_STACK OR ${PACKAGE_NAME}_HAVE_EPETRA_SOLV
     )
 
   TRIBITS_COPY_FILES_TO_BINARY_DIR(Driver_cp
-    SOURCE_FILES scaling.xml scaling.yaml scaling-complex.xml scaling-withglobalconstants.xml scaling-complex-withglobalconstants.xml circ_nsp_dependency.xml isorropia.xml iso_poisson.xml conchas_milestone_zoltan.xml conchas_milestone_zoltan2.xml conchas_milestone_zoltan2_complex.xml sa_with_ilu.xml sa_with_Ifpack2_line_detection.xml rap.xml smoother.xml smoother_complex.xml tripleMatrixProduct.xml scaling-ml.xml elasticity3D.xml amgx.json amgx.xml scaling-with-rerun.xml
+    SOURCE_FILES scaling.xml scaling.yaml scaling-complex.xml scaling-withglobalconstants.xml scaling-complex-withglobalconstants.xml circ_nsp_dependency.xml isorropia.xml iso_poisson.xml conchas_milestone_zoltan.xml conchas_milestone_zoltan2.xml conchas_milestone_zoltan2_complex.xml sa_with_ilu.xml sa_with_Ifpack2_line_detection.xml rap.xml smoother.xml smoother_complex.xml tripleMatrixProduct.xml scaling-ml.xml elasticity3D.xml amgx.json amgx.xml scaling-with-rerun.xml scaling_distance2_agg.xml
    )
 
  TRIBITS_ADD_EXECUTABLE(
@@ -280,6 +280,16 @@ IF (${PACKAGE_NAME}_HAVE_TPETRA_SOLVER_STACK)
         NUM_MPI_PROCS 4
         COMM mpi # HAVE_MPI required
         )
+
+      IF(${PACKAGE_NAME}_ENABLE_Kokkos_Refactor)
+        TRIBITS_ADD_TEST(
+          Driver
+          NAME "DriverTpetra_Distance2Coloring"
+          ARGS "--linAlgebra=Tpetra --xml=scaling_distance2_agg.xml"
+          NUM_MPI_PROCS 4
+          COMM mpi # HAVE_MPI required
+          )
+      ENDIF()
 
     ENDIF()
 

--- a/packages/muelu/test/scaling/scaling_distance2_agg.xml
+++ b/packages/muelu/test/scaling/scaling_distance2_agg.xml
@@ -1,0 +1,55 @@
+<ParameterList name="MueLu">
+
+  <!--
+    For a generic symmetric scalar problem, these are the recommended settings for MueLu.
+  -->
+
+  <!-- ===========  GENERAL ================ -->
+    <Parameter        name="verbosity"                            type="string"   value="high"/>
+
+    <Parameter        name="coarse: max size"                     type="int"      value="1000"/>
+
+    <Parameter        name="multigrid algorithm"                  type="string"   value="sa"/>
+
+    <!-- reduces setup cost for symmetric problems -->
+    <Parameter        name="transpose: use implicit"              type="bool"     value="true"/>
+
+    <!-- start of default values for general options (can be omitted) -->
+    <Parameter        name="max levels"                	          type="int"      value="10"/>
+    <Parameter        name="number of equations"                  type="int"      value="1"/>
+    <Parameter        name="sa: use filtered matrix"              type="bool"     value="true"/>
+    <!-- end of default values -->
+
+  <!-- ===========  AGGREGATION  =========== -->
+    <Parameter        name="aggregation: type"                    type="string"   value="uncoupled"/>
+    <Parameter        name="aggregation: drop scheme"             type="string"   value="classical"/>
+    <Parameter        name="aggregation: phase 1 algorithm"       type="string"   value="Distance2"/>
+    <!-- Uncomment the next line to enable dropping of weak connections, which can help AMG convergence
+         for anisotropic problems.  The exact value is problem dependent. -->
+    <!-- <Parameter        name="aggregation: drop tol"                type="double"   value="0.02"/> -->
+
+  <!-- ===========  SMOOTHING  =========== -->
+    <Parameter        name="smoother: type"                       type="string"   value="CHEBYSHEV"/>
+    <ParameterList    name="smoother: params">
+      <Parameter      name="chebyshev: degree"                    type="int"      value="2"/>>
+      <Parameter      name="chebyshev: ratio eigenvalue"          type="double"   value="7"/>
+      <Parameter      name="chebyshev: min eigenvalue"            type="double"   value="1.0"/>
+      <Parameter      name="chebyshev: zero starting solution"    type="bool"     value="true"/>
+    </ParameterList>
+
+  <!-- ===========  REPARTITIONING  =========== -->
+    <Parameter        name="repartition: enable"                  type="bool"     value="true"/>
+    <Parameter        name="repartition: partitioner"             type="string"   value="zoltan2"/>
+    <Parameter        name="repartition: start level"             type="int"      value="2"/>
+    <Parameter        name="repartition: min rows per proc"       type="int"      value="800"/>
+    <Parameter        name="repartition: max imbalance"           type="double"   value="1.1"/>
+    <Parameter        name="repartition: remap parts"             type="bool"     value="false"/>
+    <!-- start of default values for repartitioning (can be omitted) -->
+    <Parameter name="repartition: remap parts"                type="bool"     value="true"/>
+    <Parameter name="repartition: rebalance P and R"          type="bool"     value="false"/>
+    <ParameterList name="repartition: params">
+       <Parameter name="algorithm" type="string" value="multijagged"/>
+    </ParameterList>
+    <!-- end of default values -->
+
+</ParameterList>

--- a/packages/muelu/test/unit_tests_kokkos/Aggregates_kokkos.cpp
+++ b/packages/muelu/test/unit_tests_kokkos/Aggregates_kokkos.cpp
@@ -144,15 +144,15 @@ namespace MueLuTests {
     // Setup aggregation factory (use default factory for graph)
     RCP<UncoupledAggregationFactory_kokkos> aggFact = rcp(new UncoupledAggregationFactory_kokkos());
     aggFact->SetFactory("Graph", dropFact);
-    aggFact->SetParameter("aggregation: max agg size",Teuchos::ParameterEntry(3));
-    aggFact->SetParameter("aggregation: min agg size",Teuchos::ParameterEntry(3));
-    aggFact->SetParameter("aggregation: max selected neighbors",Teuchos::ParameterEntry(0));
-    aggFact->SetParameter("aggregation: ordering",Teuchos::ParameterEntry(std::string("natural")));
-    aggFact->SetParameter("aggregation: enable phase 1",  Teuchos::ParameterEntry(true));
-    aggFact->SetParameter("aggregation: phase 1 algorithm",Teuchos::ParameterEntry(std::string("Distance2")));
-    aggFact->SetParameter("aggregation: enable phase 2a", Teuchos::ParameterEntry(true));
-    aggFact->SetParameter("aggregation: enable phase 2b", Teuchos::ParameterEntry(true));
-    aggFact->SetParameter("aggregation: enable phase 3",  Teuchos::ParameterEntry(true));
+    aggFact->SetParameter("aggregation: max agg size",           Teuchos::ParameterEntry(3));
+    aggFact->SetParameter("aggregation: min agg size",           Teuchos::ParameterEntry(3));
+    aggFact->SetParameter("aggregation: max selected neighbors", Teuchos::ParameterEntry(0));
+    aggFact->SetParameter("aggregation: ordering",               Teuchos::ParameterEntry(std::string("natural")));
+    aggFact->SetParameter("aggregation: enable phase 1",         Teuchos::ParameterEntry(true));
+    aggFact->SetParameter("aggregation: phase 1 algorithm",      Teuchos::ParameterEntry(std::string("Distance2")));
+    aggFact->SetParameter("aggregation: enable phase 2a",        Teuchos::ParameterEntry(true));
+    aggFact->SetParameter("aggregation: enable phase 2b",        Teuchos::ParameterEntry(true));
+    aggFact->SetParameter("aggregation: enable phase 3",         Teuchos::ParameterEntry(true));
 
     level.Request("Aggregates", aggFact.get());
     level.Request("UnAmalgamationInfo", amalgFact.get());


### PR DESCRIPTION
@trilinos/muelu

## Description
Adding a set and get methods to Aggregates_kokkos in order to store the coloring of the LWGraph used for aggregates creation.
This will allow to pass the colors to all phases of aggregation without reworking interfaces too much.
Using the new methods in LWGraph_kokkos avoids copying on host the data needed by
the coloring algorithm. This saves 2 communication: 1 DtoH and 1 HtoD.
Extra time monitors are added in AggregationPhase1 to account for coloring and
aggregation separately.
Adding a test that exercises the Distance2 algorithmic path in test/scaling

## Motivation and Context
This work is part of a refactor to have MueLu SA-AMG setup performed on device

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of #5838
* Composed of 


## How Has This Been Tested?
I did a local build with OpenMP, all the test pass including the new test for Distance2 with the `scaling/Driver`

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.