### PR TITLE
MueLu: modifying BuildAggregates signature in AggregationAlgorithmBase_kokkos

### DIFF
--- a/packages/muelu/src/Graph/Containers/MueLu_LWGraph_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/Containers/MueLu_LWGraph_kokkos_decl.hpp
@@ -75,17 +75,20 @@ namespace MueLu {
   template<class LocalOrdinal, class GlobalOrdinal, class DeviceType>
   class LWGraph_kokkos<LocalOrdinal, GlobalOrdinal, Kokkos::Compat::KokkosDeviceWrapperNode<DeviceType>> {
   public:
-    typedef LocalOrdinal                                             local_ordinal_type;
-    typedef GlobalOrdinal                                            global_ordinal_type;
-    typedef typename DeviceType::execution_space                     execution_space;
-    typedef Kokkos::RangePolicy<local_ordinal_type, execution_space> range_type;
-    typedef Kokkos::Compat::KokkosDeviceWrapperNode<DeviceType>      node_type;
-    typedef size_t                                                   size_type;
+    using local_ordinal_type  = LocalOrdinal;
+    using global_ordinal_type = GlobalOrdinal;
+    using execution_space     = typename DeviceType::execution_space;
+    using memory_space        = typename DeviceType::memory_space;
+    using range_type          = Kokkos::RangePolicy<local_ordinal_type, execution_space>;
+    using node_type           = Kokkos::Compat::KokkosDeviceWrapperNode<DeviceType>;
+    using size_type           = size_t;
 
-    typedef Xpetra::Map<LocalOrdinal, GlobalOrdinal, node_type> map_type;
-    typedef Kokkos::StaticCrsGraph<LocalOrdinal, Kokkos::LayoutLeft, execution_space> local_graph_type;
-    typedef Kokkos::View<const bool*, DeviceType>               boundary_nodes_type;
-    typedef Kokkos::View<const LocalOrdinal*, DeviceType>       row_type;
+    using map_type            = Xpetra::Map<LocalOrdinal, GlobalOrdinal, node_type>;
+    using local_graph_type    = Kokkos::StaticCrsGraph<LocalOrdinal,
+                                                       Kokkos::LayoutLeft,
+                                                       execution_space>;
+    using boundary_nodes_type = Kokkos::View<const bool*, memory_space>;
+    using row_type            = Kokkos::View<const LocalOrdinal*, memory_space>;
 
   private:
     // For compatibility

--- a/packages/muelu/src/Graph/MueLu_AggregationAlgorithmBase_kokkos.hpp
+++ b/packages/muelu/src/Graph/MueLu_AggregationAlgorithmBase_kokkos.hpp
@@ -74,8 +74,8 @@ namespace MueLu {
 #include "MueLu_UseShortNamesOrdinal.hpp"
     public:
 
-    typedef typename LWGraph_kokkos::local_graph_type::device_type::execution_space execution_space;
-    typedef typename LWGraph_kokkos::local_graph_type::device_type::memory_space memory_space;
+    using execution_space = typename LWGraph_kokkos::execution_space;
+    using memory_space    = typename LWGraph_kokkos::memory_space;
 
     //! @name Constructors/Destructors
     //@{
@@ -92,7 +92,7 @@ namespace MueLu {
     virtual void BuildAggregates(const Teuchos::ParameterList& params,
                                  const LWGraph_kokkos& graph,
                                  Aggregates_kokkos& aggregates,
-                                 std::vector<unsigned>& aggStat,
+                                 Kokkos::View<unsigned*, memory_space>& aggStat,
                                  LO& numNonAggregatedNodes) const = 0;
     //@}
   };

--- a/packages/muelu/src/Graph/StructuredAggregation/MueLu_AggregationStructuredAlgorithm_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/StructuredAggregation/MueLu_AggregationStructuredAlgorithm_kokkos_decl.hpp
@@ -106,22 +106,20 @@ namespace MueLu {
     //! @name Aggregation methods.
     //@{
 
-    /*! @brief Local aggregation. */
+    /*! @brief Build aggregates object. */
 
-    void BuildAggregates(const Teuchos::ParameterList& /* params */, const LWGraph_kokkos& /* graph */,
-                         Aggregates_kokkos& /* aggregates */,
-                         std::vector<unsigned>& /* aggStat */,
-                         LO& /* numNonAggregatedNodes */) const {};
-
-    void BuildAggregates(const Teuchos::ParameterList& params, const LWGraph_kokkos& graph,
+    void BuildAggregates(const Teuchos::ParameterList& params,
+                         const LWGraph_kokkos& graph,
                          Aggregates_kokkos& aggregates,
                          Kokkos::View<unsigned*, memory_space>& aggStat,
                          LO& numNonAggregatedNodes) const;
 
-    /*! @brief Local aggregation. */
+    /*! @brief Build a CrsGraph instead of aggregates. */
 
-    void BuildGraph(const LWGraph_kokkos& graph, RCP<IndexManager_kokkos>& geoData,
-                    const LO dofsPerNode, RCP<CrsGraph>& myGraph) const;
+    void BuildGraph(const LWGraph_kokkos& graph,
+                    RCP<IndexManager_kokkos>& geoData,
+                    const LO dofsPerNode,
+                    RCP<CrsGraph>& myGraph) const;
     //@}
 
     std::string description() const { return "Aggretation: structured algorithm"; }

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase1Algorithm_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase1Algorithm_kokkos_decl.hpp
@@ -109,15 +109,20 @@ namespace MueLu {
 
     /*! @brief Local aggregation. */
 
-    void BuildAggregates(const ParameterList& params, const LWGraph_kokkos& graph, Aggregates_kokkos& aggregates, std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes) const;
+    void BuildAggregates(const Teuchos::ParameterList& params,
+                         const LWGraph_kokkos& graph,
+                         Aggregates_kokkos& aggregates,
+                         Kokkos::View<unsigned*, typename LWGraph_kokkos::memory_space>& aggStat,
+                         LO& numNonAggregatedNodes) const;
 
     void BuildAggregatesSerial(const LWGraph_kokkos& graph, Aggregates_kokkos& aggregates,
-      std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes,
-      LO minNodesPerAggregate, LO maxNodesPerAggregate,
-      LO maxNeighAlreadySelected, std::string& orderingStr) const;
+                               std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes,
+                               LO minNodesPerAggregate, LO maxNodesPerAggregate,
+                               LO maxNeighAlreadySelected, std::string& orderingStr) const;
 
     void BuildAggregatesDistance2(const LWGraph_kokkos& graph, Aggregates_kokkos& aggregates,
-        std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes, LO maxAggSize) const;
+                                  std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes,
+                                  LO maxAggSize) const;
     //@}
 
     std::string description() const { return "Phase 1 (main)"; }
@@ -125,7 +130,7 @@ namespace MueLu {
     enum struct Algorithm
     {
       Serial,
-      Distance2 
+      Distance2
     };
 
     static Algorithm algorithmFromName(const std::string& name)

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase1Algorithm_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase1Algorithm_kokkos_def.hpp
@@ -70,10 +70,23 @@ namespace MueLu {
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   void AggregationPhase1Algorithm_kokkos<LocalOrdinal, GlobalOrdinal, Node>::
-  BuildAggregates(const ParameterList& params, const LWGraph_kokkos& graph,
-                  Aggregates_kokkos& aggregates, std::vector<unsigned>& aggStat,
+  BuildAggregates(const Teuchos::ParameterList& params,
+                  const LWGraph_kokkos& graph,
+                  Aggregates_kokkos& aggregates,
+                  Kokkos::View<unsigned*, typename LWGraph_kokkos::memory_space>& aggstat,
                   LO& numNonAggregatedNodes) const {
     Monitor m(*this, "BuildAggregates");
+
+    using memory_space = typename LWGraph_kokkos::memory_space;
+
+    typename Kokkos::View<unsigned*, memory_space>::HostMirror aggstatHost
+      = Kokkos::create_mirror(aggstat);
+    Kokkos::deep_copy(aggstatHost, aggstat);
+    std::vector<unsigned> aggStat;
+    aggStat.resize(aggstatHost.extent(0));
+    for(size_t idx = 0; idx < aggstatHost.extent(0); ++idx) {
+      aggStat[idx] = aggstatHost(idx);
+    }
 
     std::string orderingStr     = params.get<std::string>("aggregation: ordering");
     int maxNeighAlreadySelected = params.get<int>        ("aggregation: max selected neighbors");
@@ -104,6 +117,11 @@ namespace MueLu {
       BuildAggregatesSerial(graph, aggregates, aggStat, numNonAggregatedNodes, minNodesPerAggregate,
                             maxNodesPerAggregate, maxNeighAlreadySelected, orderingStr);
     }
+
+    for(size_t idx = 0; idx < aggstatHost.extent(0); ++idx) {
+      aggstatHost(idx) = aggStat[idx];
+    }
+    Kokkos::deep_copy(aggstat, aggstatHost);
   }
 
 

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2aAlgorithm_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2aAlgorithm_kokkos_decl.hpp
@@ -90,6 +90,8 @@ namespace MueLu {
 #include "MueLu_UseShortNamesOrdinal.hpp"
 
   public:
+    using memory_space = typename LWGraph_kokkos::memory_space;
+
     //! @name Constructors/Destructors.
     //@{
 
@@ -107,7 +109,11 @@ namespace MueLu {
 
     /*! @brief Local aggregation. */
 
-    void BuildAggregates(const ParameterList& params, const LWGraph_kokkos& graph, Aggregates_kokkos& aggregates, std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes) const;
+    void BuildAggregates(const Teuchos::ParameterList& params,
+                         const LWGraph_kokkos& graph,
+                         Aggregates_kokkos& aggregates,
+                         Kokkos::View<unsigned*, memory_space>& aggStat,
+                         LO& numNonAggregatedNodes) const;
     //@}
 
     std::string description() const { return "Phase 2a (secondary)"; }

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2bAlgorithm_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2bAlgorithm_kokkos_decl.hpp
@@ -106,7 +106,11 @@ namespace MueLu {
 
     /*! @brief Local aggregation. */
 
-    void BuildAggregates(const ParameterList& params, const LWGraph_kokkos& graph, Aggregates_kokkos& aggregates, std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes) const;
+    void BuildAggregates(const ParameterList& params,
+                         const LWGraph_kokkos& graph,
+                         Aggregates_kokkos& aggregates,
+                         Kokkos::View<unsigned*, typename LWGraph_kokkos::memory_space>& aggStat,
+                         LO& numNonAggregatedNodes) const;
     //@}
 
     std::string description() const { return "Phase 2b (expansion)"; }

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2bAlgorithm_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2bAlgorithm_kokkos_def.hpp
@@ -65,8 +65,24 @@ namespace MueLu {
   // Try to stick unaggregated nodes into a neighboring aggregate if they are
   // not already too big
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
-  void AggregationPhase2bAlgorithm_kokkos<LocalOrdinal, GlobalOrdinal, Node>::BuildAggregates(const ParameterList& /* params */, const LWGraph_kokkos& graph, Aggregates_kokkos& aggregates, std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes) const {
+  void AggregationPhase2bAlgorithm_kokkos<LocalOrdinal, GlobalOrdinal, Node>::
+  BuildAggregates(const ParameterList& /* params */,
+                  const LWGraph_kokkos& graph,
+                  Aggregates_kokkos& aggregates,
+                  Kokkos::View<unsigned*, typename LWGraph_kokkos::memory_space>& aggstat,
+                  LO& numNonAggregatedNodes) const {
     Monitor m(*this, "BuildAggregates");
+
+    using memory_space = typename LWGraph_kokkos::memory_space;
+
+    typename Kokkos::View<unsigned*, memory_space>::HostMirror aggstatHost
+      = Kokkos::create_mirror(aggstat);
+    Kokkos::deep_copy(aggstatHost, aggstat);
+    std::vector<unsigned> aggStat;
+    aggStat.resize(aggstatHost.extent(0));
+    for(size_t idx = 0; idx < aggstatHost.extent(0); ++idx) {
+      aggStat[idx] = aggstatHost(idx);
+    }
 
     const LO  numRows = graph.GetNodeNumVertices();
     const int myRank  = graph.GetComm()->getRank();
@@ -141,6 +157,11 @@ namespace MueLu {
         }
       }
     }
+
+    for(size_t idx = 0; idx < aggstatHost.extent(0); ++idx) {
+      aggstatHost(idx) = aggStat[idx];
+    }
+    Kokkos::deep_copy(aggstat, aggstatHost);
   }
 
 } // end namespace

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase3Algorithm_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase3Algorithm_kokkos_decl.hpp
@@ -102,7 +102,11 @@ namespace MueLu {
 
     /*! @brief Local aggregation. */
 
-    void BuildAggregates(const ParameterList& params, const LWGraph_kokkos& graph, Aggregates_kokkos& aggregates, std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes) const;
+    void BuildAggregates(const ParameterList& params,
+                         const LWGraph_kokkos& graph,
+                         Aggregates_kokkos& aggregates,
+                         Kokkos::View<unsigned*, typename LWGraph_kokkos::memory_space>& aggStat,
+                         LO& numNonAggregatedNodes) const;
     //@}
 
     std::string description() const { return "Phase 3 (cleanup)"; }

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_IsolatedNodeAggregationAlgorithm_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_IsolatedNodeAggregationAlgorithm_kokkos_decl.hpp
@@ -104,7 +104,11 @@ namespace MueLu {
 
     /*! @brief Local aggregation. */
 
-    void BuildAggregates(const ParameterList& params, const LWGraph_kokkos& graph, Aggregates_kokkos& aggregates, std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes) const;
+    void BuildAggregates(const ParameterList& params,
+                         const LWGraph_kokkos& graph,
+                         Aggregates_kokkos& aggregates,
+                         Kokkos::View<unsigned*, typename LWGraph_kokkos::memory_space>& aggStat,
+                         LO& numNonAggregatedNodes) const;
     //@}
 
     std::string description() const { return "Phase - (isolated)"; }

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_OnePtAggregationAlgorithm_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_OnePtAggregationAlgorithm_kokkos_decl.hpp
@@ -103,7 +103,11 @@ namespace MueLu {
 
     /*! @brief Local aggregation. */
 
-    void BuildAggregates(Teuchos::ParameterList const & params, LWGraph_kokkos const & graph, Aggregates_kokkos & aggregates, std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes) const;
+    void BuildAggregates(Teuchos::ParameterList const & params,
+                         LWGraph_kokkos const & graph,
+                         Aggregates_kokkos & aggregates,
+                         Kokkos::View<unsigned*, typename LWGraph_kokkos::memory_space>& aggStat,
+                         LO& numNonAggregatedNodes) const;
     //@}
 
 

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_OnePtAggregationAlgorithm_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_OnePtAggregationAlgorithm_kokkos_def.hpp
@@ -68,8 +68,24 @@ namespace MueLu {
   }
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
-  void OnePtAggregationAlgorithm_kokkos<LocalOrdinal, GlobalOrdinal, Node>::BuildAggregates(Teuchos::ParameterList const & /* params */, LWGraph_kokkos const & graph, Aggregates_kokkos & aggregates, std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes) const {
+  void OnePtAggregationAlgorithm_kokkos<LocalOrdinal, GlobalOrdinal, Node>::
+  BuildAggregates(Teuchos::ParameterList const & /* params */,
+                  LWGraph_kokkos const & graph,
+                  Aggregates_kokkos & aggregates,
+                  Kokkos::View<unsigned*, typename LWGraph_kokkos::memory_space>& aggstat,
+                  LO& numNonAggregatedNodes) const {
     Monitor m(*this, "BuildAggregates");
+
+    using memory_space = typename LWGraph_kokkos::memory_space;
+
+    typename Kokkos::View<unsigned*, memory_space>::HostMirror aggstatHost
+      = Kokkos::create_mirror(aggstat);
+    Kokkos::deep_copy(aggstatHost, aggstat);
+    std::vector<unsigned> aggStat;
+    aggStat.resize(aggstatHost.extent(0));
+    for(size_t idx = 0; idx < aggstatHost.extent(0); ++idx) {
+      aggStat[idx] = aggstatHost(idx);
+    }
 
     const LocalOrdinal nRows = graph.GetNodeNumVertices();
     const int myRank = graph.GetComm()->getRank();
@@ -103,6 +119,11 @@ namespace MueLu {
 
       iNode1++;
     } // end while
+
+    for(size_t idx = 0; idx < aggstatHost.extent(0); ++idx) {
+      aggstatHost(idx) = aggStat[idx];
+    }
+    Kokkos::deep_copy(aggstat, aggstatHost);
 
     // update aggregate object
     aggregates.SetNumAggregates(nLocalAggregates);

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_PreserveDirichletAggregationAlgorithm_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_PreserveDirichletAggregationAlgorithm_kokkos_decl.hpp
@@ -92,6 +92,9 @@ namespace MueLu {
 #include "MueLu_UseShortNamesOrdinal.hpp"
 
   public:
+
+    using memory_space = typename LWGraph_kokkos::memory_space;
+
     //! @name Constructors/Destructors.
     //@{
 
@@ -109,7 +112,11 @@ namespace MueLu {
 
     /*! @brief Local aggregation. */
 
-    void BuildAggregates(const Teuchos::ParameterList& params, const LWGraph_kokkos& graph, Aggregates_kokkos& aggregates, std::vector<unsigned>& aggStat, LO& numNonAggregatedNodes) const;
+    void BuildAggregates(const Teuchos::ParameterList& params,
+                         const LWGraph_kokkos& graph,
+                         Aggregates_kokkos& aggregates,
+                         Kokkos::View<unsigned*, memory_space>& aggStat,
+                         LO& numNonAggregatedNodes) const;
     //@}
 
     std::string description() const { return "Phase - (Dirichlet)"; }

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_UncoupledAggregationFactory_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_UncoupledAggregationFactory_kokkos_def.hpp
@@ -180,7 +180,9 @@ namespace MueLu {
     const LO numRows = graph->GetNodeNumVertices();
 
     // construct aggStat information
-    std::vector<unsigned> aggStat(numRows, READY);
+    Kokkos::View<unsigned*, typename LWGraph_kokkos::memory_space> aggStat("aggregation status",
+                                                                           numRows);
+    Kokkos::deep_copy(aggStat, READY);
 
     // TODO
     //ArrayRCP<const bool> dirichletBoundaryMap = graph->GetBoundaryNodeMap();


### PR DESCRIPTION
@trilinos/muelu

## Description
The goal is to remove instances of `std::vector<>` from the interface in favor
of `Kokkos::View<>` even if the underlying implementation still uses a `std::vector<>`
This will facilitate pushing new algorithms through the stack.

## Motivation and Context
This work is part of a refactor of the MueLu setup see issue #5838

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of #5838
* Composed of 

## How Has This Been Tested?
I used a local build with OpenMP enabled, all tests are passing.

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.