### PR TITLE
MueLu RefMaxwell: Apply nullspace fix when no BCs are detected

### DIFF
--- a/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_decl.hpp
+++ b/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_decl.hpp
@@ -389,6 +389,7 @@ namespace MueLu {
     Kokkos::View<const bool*, typename Node::device_type> BCrowsKokkos_;
     Kokkos::View<const bool*, typename Node::device_type> BCcolsKokkos_;
 #endif
+    int BCrowcount_, BCcolcount_;
     Teuchos::ArrayRCP<const bool> BCrows_;
     Teuchos::ArrayRCP<const bool> BCcols_;
     //! Nullspace

--- a/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_def.hpp
+++ b/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_def.hpp
@@ -264,32 +264,33 @@ namespace MueLu {
       if (useKokkos_) {
         BCrowsKokkos_ = Utilities_kokkos::DetectDirichletRows(*SM_Matrix_,Teuchos::ScalarTraits<magnitudeType>::eps(),/*count_twos_as_dirichlet=*/true);
         BCcolsKokkos_ = Utilities_kokkos::DetectDirichletCols(*D0_Matrix_,BCrowsKokkos_);
+
+        BCrowcount_ = 0;
+        for (size_t i = 0; i<BCrowsKokkos_.size(); i++)
+          if (BCrowsKokkos_(i))
+            BCrowcount_ += 1;
+        BCcolcount_ = 0;
+        for (size_t i = 0; i<BCcolsKokkos_.size(); i++)
+          if (BCcolsKokkos_(i))
+            BCcolcount_ += 1;
         if (IsPrint(Statistics2)) {
-          int BCrowcount = 0;
-          for (size_t i = 0; i<BCrowsKokkos_.size(); i++)
-            if (BCrowsKokkos_(i))
-              BCrowcount += 1;
-          int BCcolcount = 0;
-          for (size_t i = 0; i<BCcolsKokkos_.size(); i++)
-            if (BCcolsKokkos_(i))
-              BCcolcount += 1;
-          GetOStream(Statistics2) << "MueLu::RefMaxwell::compute(): Detected " << BCrowcount << " BC rows and " << BCcolcount << " BC columns." << std::endl;
+          GetOStream(Statistics2) << "MueLu::RefMaxwell::compute(): Detected " << BCrowcount_ << " BC rows and " << BCcolcount_ << " BC columns." << std::endl;
         }
       } else
 #endif
         {
           BCrows_ = Utilities::DetectDirichletRows(*SM_Matrix_,Teuchos::ScalarTraits<magnitudeType>::eps(),/*count_twos_as_dirichlet=*/true);
           BCcols_ = Utilities::DetectDirichletCols(*D0_Matrix_,BCrows_);
+          BCrowcount_ = 0;
+          for (auto it = BCrows_.begin(); it != BCrows_.end(); ++it)
+            if (*it)
+              BCrowcount_ += 1;
+          BCcolcount_ = 0;
+          for (auto it = BCcols_.begin(); it != BCcols_.end(); ++it)
+            if (*it)
+              BCcolcount_ += 1;
           if (IsPrint(Statistics2)) {
-            int BCrowcount = 0;
-            for (auto it = BCrows_.begin(); it != BCrows_.end(); ++it)
-              if (*it)
-                BCrowcount += 1;
-            int BCcolcount = 0;
-            for (auto it = BCcols_.begin(); it != BCcols_.end(); ++it)
-              if (*it)
-                BCcolcount += 1;
-            GetOStream(Statistics2) << "MueLu::RefMaxwell::compute(): Detected " << BCrowcount << " BC rows and " << BCcolcount << " BC columns." << std::endl;
+            GetOStream(Statistics2) << "MueLu::RefMaxwell::compute(): Detected " << BCrowcount_ << " BC rows and " << BCcolcount_ << " BC columns." << std::endl;
           }
         }
     }
@@ -786,6 +787,11 @@ namespace MueLu {
         if (!reuse) {
           ParameterList& userParamList = precList22_.sublist("user data");
           userParamList.set<RCP<RealValuedMultiVector> >("Coordinates", Coords_);
+          // If we detected no boundary conditions, the (2,2) problem is singular
+          if (BCrowcount_ == 0 &&
+              (!precList22_.isSublist("coarse: params") ||
+               !precList22_.sublist("coarse: params").isParameter("fix nullspace")))
+            precList22_.sublist("coarse: params").set("fix nullspace",true);
           Hierarchy22_ = MueLu::CreateXpetraPreconditioner(A22_, precList22_);
         } else {
           RCP<MueLu::Level> level0 = Hierarchy22_->GetLevel(0);

--- a/packages/muelu/test/maxwell/Maxwell.xml
+++ b/packages/muelu/test/maxwell/Maxwell.xml
@@ -35,9 +35,7 @@
     <Parameter name="aggregation: drop tol" type="double" value="0.01"/>
     <Parameter name="coarse: max size" type="int" value="128"/>
     <Parameter name="coarse: type" type="string" value="Klu"/>
-    <ParameterList name="coarse: params">
-      <Parameter name="fix nullspace" type="bool" value="true"/>
-    </ParameterList>
+
     <Parameter name="smoother: type" type="string" value="RELAXATION"/>
     <ParameterList name="smoother: params">
       <Parameter name="relaxation: type" type="string" value="Symmetric Gauss-Seidel"/>

--- a/packages/muelu/test/maxwell/Maxwell_complex.xml
+++ b/packages/muelu/test/maxwell/Maxwell_complex.xml
@@ -36,6 +36,17 @@
       <Parameter name="relaxation: type" type="string" value="Symmetric Gauss-Seidel"/>
       <Parameter name="relaxation: sweeps" type="int" value="2"/>
     </ParameterList>
+
+    <Parameter name="repartition: enable" type="bool" value="true"/>
+    <Parameter name="repartition: partitioner" type="string" value="zoltan2"/>
+    <Parameter name="repartition: start level" type="int" value="1"/>
+    <Parameter name="repartition: min rows per proc" type="int" value="200"/>
+    <Parameter name="repartition: max imbalance" type="double" value="1.1"/>
+    <Parameter name="repartition: remap parts" type="bool" value="true"/>
+    <Parameter name="repartition: rebalance P and R" type="bool" value="false"/>
+    <ParameterList name="repartition: params">
+      <Parameter name="algorithm" type="string" value="multijagged"/>
+    </ParameterList>
   </ParameterList>
 
 </ParameterList>

--- a/packages/panzer/mini-em/example/BlockPrec/maxwell.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/maxwell.xml
@@ -20,9 +20,9 @@
         <Parameter name="X Blocks" type="int" value="1" />
         <Parameter name="Y Blocks" type="int" value="1" />
         <Parameter name="Z Blocks" type="int" value="1" />
-        <Parameter name="X Elements" type="int" value="10" />
-        <Parameter name="Y Elements" type="int" value="10" />
-        <Parameter name="Z Elements" type="int" value="10" />
+        <Parameter name="X Elements" type="int" value="15" />
+        <Parameter name="Y Elements" type="int" value="15" />
+        <Parameter name="Z Elements" type="int" value="15" />
         <!-- <ParameterList name="Periodic BCs"> -->
         <!--   <Parameter name="Count" type="int" value="3"/> -->
         <!--   <Parameter name="Periodic Condition 1" type="string" value="xz-all 1e-8: top;bottom"/> -->

--- a/packages/panzer/mini-em/example/BlockPrec/maxwell2D.xml
+++ b/packages/panzer/mini-em/example/BlockPrec/maxwell2D.xml
@@ -11,8 +11,8 @@
       <ParameterList name="Mesh Factory Parameter List">
         <Parameter name="X Blocks" type="int" value="1" />
         <Parameter name="Y Blocks" type="int" value="1" />
-        <Parameter name="X Elements" type="int" value="10" />
-        <Parameter name="Y Elements" type="int" value="10" />
+        <Parameter name="X Elements" type="int" value="100" />
+        <Parameter name="Y Elements" type="int" value="100" />
         <!-- <ParameterList name="Periodic BCs"> -->
         <!--   <Parameter name="Count" type="int" value="2"/> -->
         <!--   <Parameter name="Periodic Condition 1" type="string" value="x-all 1e-8: top;bottom"/> -->


### PR DESCRIPTION
@trilinos/muelu

## Description
Automatically apply nullspace fix to avoid singular matrix in RefMaxwell when no boundary conditions were detected.