### PR TITLE
Tpetra: allow custom memory space (fix #5864)

### DIFF
--- a/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_def.hpp
@@ -2945,7 +2945,12 @@ public:
     // We use a "struct of arrays" approach to packing each row's
     // entries.  All the column indices (as global indices) go first,
     // then all their owning process ranks, and then the values.
-    exports.resize (totalNumBytes);
+    if(exports.extent(0) != totalNumBytes)
+    {
+      const std::string oldLabel = exports.d_view.label ();
+      const std::string newLabel = (oldLabel == "") ? "exports" : oldLabel;
+      exports = Kokkos::DualView<packet_type*, buffer_device_type>(newLabel, totalNumBytes);
+    }
     if (totalNumEntries > 0) {
       // Current position (in bytes) in the 'exports' output array.
       Kokkos::View<size_t*, host_exec> offset("offset", numExportLIDs+1);


### PR DESCRIPTION
Allow a custom Kokkos memory space to be set as the Tpetra
comm_buffer_memory_space in Tpetra_Details_DefaultTypes.hpp (e.g. CudaHostPinnedSpace instead of
CudaSpace). The only thing preventing this was the use of
Kokkos::DualView::resize() in BlockCrsMatrix::packAndPrepare();
currently resize() doesn't allow using a different device memory space
than the device's default (this may change in the future).

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra @trilinos/kokkos 

## Description
<!--- Please describe your changes in detail. -->
in Tpetra::BlockCrsMatrix::packAndPrepare(), replace Kokkos::DualView::resize() with just constructing a new DualView and doing copy assignment.
## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
This change expands the set of memory spaces that may be used as the Tpetra-wide space for communication buffers in Tpetra_Details_DefaultTypes.hpp. Previously, BlockCrsMatrix::packAndPrepare() called DualView::resize(), which does not support the device view's memory space being anything other than ``typename device::execution_space::memory_space``, so Tpetra only had one option for the default memory space (CudaSpace if Cuda was enabled, or CudaUVMSpace if UVM was enabled in Kokkos). This commit expands the set of choices to include CudaHostPinnedSpace and even HostSpace (accessed via UVM on device).
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes #5864 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->
Built and tested Tpetra and MueLu with the comm_buffer_memory_space defined as CudaHostPinnedSpace.
<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
