### PR TITLE
Xpetra: Fix default node for Epetra types

### DIFF
--- a/packages/xpetra/src/Headers/Xpetra_UseShortNamesScalar.hpp
+++ b/packages/xpetra/src/Headers/Xpetra_UseShortNamesScalar.hpp
@@ -150,9 +150,9 @@ typedef Xpetra::TpetraCrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> Tpetr
 // TODO remove this
 #ifdef XPETRA_EPETRACRSMATRIX_SHORT
 #ifndef XPETRA_EPETRA_NO_32BIT_GLOBAL_INDICES
-typedef Xpetra::EpetraCrsMatrixT<long long, Node> EpetraCrsMatrix64;
+typedef Xpetra::EpetraCrsMatrixT<long long, Xpetra::EpetraNode> EpetraCrsMatrix64;
 #endif
-typedef Xpetra::EpetraCrsMatrixT<int, Node> EpetraCrsMatrix; // do we need this???
+typedef Xpetra::EpetraCrsMatrixT<int, Xpetra::EpetraNode> EpetraCrsMatrix; // do we need this???
 #endif
 // TODO remove above entries
 

--- a/packages/xpetra/src/Utils/ForwardDeclaration/Xpetra_EpetraCrsGraph_fwd.hpp
+++ b/packages/xpetra/src/Utils/ForwardDeclaration/Xpetra_EpetraCrsGraph_fwd.hpp
@@ -48,7 +48,7 @@
 
 namespace Xpetra {
   template<class GO, class NO> class EpetraCrsGraphT;
-  typedef EpetraCrsGraphT<int, typename Xpetra::Map<int, int>::node_type> EpetraCrsGraph;
+  typedef EpetraCrsGraphT<int, EpetraNode> EpetraCrsGraph;
 }
 
 #ifndef XPETRA_EPETRACRSGRAPH_SHORT

--- a/packages/xpetra/src/Utils/ForwardDeclaration/Xpetra_EpetraCrsMatrix_fwd.hpp
+++ b/packages/xpetra/src/Utils/ForwardDeclaration/Xpetra_EpetraCrsMatrix_fwd.hpp
@@ -51,7 +51,7 @@
 namespace Xpetra {
   template<class GO, class NO> class EpetraCrsMatrixT;
 #ifndef XPETRA_EPETRA_NO_32BIT_GLOBAL_INDICES
-  typedef EpetraCrsMatrixT<int, KokkosClassic::DefaultNode::DefaultNodeType> EpetraCrsMatrix;
+  typedef EpetraCrsMatrixT<int, EpetraNode> EpetraCrsMatrix;
 #endif
 }
 

--- a/packages/xpetra/src/Utils/ForwardDeclaration/Xpetra_EpetraExport_fwd.hpp
+++ b/packages/xpetra/src/Utils/ForwardDeclaration/Xpetra_EpetraExport_fwd.hpp
@@ -48,7 +48,7 @@
 
 namespace Xpetra {
   template<class GO, class NO> class EpetraExportT;
-  typedef EpetraExportT<int, typename Xpetra::Map<int, int>::node_type> EpetraExport;
+  typedef EpetraExportT<int, EpetraNode> EpetraExport;
 }
 
 #ifndef XPETRA_EPETRAEXPORT_SHORT

--- a/packages/xpetra/src/Utils/ForwardDeclaration/Xpetra_EpetraImport_fwd.hpp
+++ b/packages/xpetra/src/Utils/ForwardDeclaration/Xpetra_EpetraImport_fwd.hpp
@@ -48,7 +48,7 @@
 
 namespace Xpetra {
   template<class GO, class NO> class EpetraImportT;
-  typedef EpetraImportT<int, typename Xpetra::Map<int, int>::node_type> EpetraImport;
+  typedef EpetraImportT<int, EpetraNode> EpetraImport;
 }
 
 #ifndef XPETRA_EPETRAIMPORT_SHORT

--- a/packages/xpetra/src/Utils/ForwardDeclaration/Xpetra_EpetraIntVector_fwd.hpp
+++ b/packages/xpetra/src/Utils/ForwardDeclaration/Xpetra_EpetraIntVector_fwd.hpp
@@ -48,7 +48,7 @@
 
 namespace Xpetra {
   template<class GO, class NO> class EpetraIntVectorT;
-  typedef EpetraIntVectorT<int, typename Xpetra::Map<int, int>::node_type> EpetraIntVector;
+  typedef EpetraIntVectorT<int, EpetraNode> EpetraIntVector;
 }
 
 #ifndef XPETRA_EPETRAINTVECTOR_SHORT

--- a/packages/xpetra/src/Utils/ForwardDeclaration/Xpetra_EpetraMap_fwd.hpp
+++ b/packages/xpetra/src/Utils/ForwardDeclaration/Xpetra_EpetraMap_fwd.hpp
@@ -48,7 +48,7 @@
 
 namespace Xpetra {
   template<class GO, class NO> class EpetraMapT;
-  typedef EpetraMapT<int, typename Xpetra::Map<int, int>::node_type> EpetraMap;
+  typedef EpetraMapT<int, EpetraNode> EpetraMap;
 }
 
 #ifndef XPETRA_EPETRAMAP_SHORT

--- a/packages/xpetra/src/Utils/ForwardDeclaration/Xpetra_EpetraMultiVector_fwd.hpp
+++ b/packages/xpetra/src/Utils/ForwardDeclaration/Xpetra_EpetraMultiVector_fwd.hpp
@@ -48,7 +48,7 @@
 
 namespace Xpetra {
   template<class GO, class NO> class EpetraMultiVectorT;
-  typedef EpetraMultiVectorT<int, typename Xpetra::Map<int, int>::node_type> EpetraMultiVector;
+  typedef EpetraMultiVectorT<int, EpetraNode> EpetraMultiVector;
 }
 
 #ifndef XPETRA_EPETRAMULTIVECTOR_SHORT

--- a/packages/xpetra/src/Utils/ForwardDeclaration/Xpetra_EpetraVector_fwd.hpp
+++ b/packages/xpetra/src/Utils/ForwardDeclaration/Xpetra_EpetraVector_fwd.hpp
@@ -48,7 +48,7 @@
 
 namespace Xpetra {
   template<class GO, class NO> class EpetraVectorT;
-  typedef EpetraVectorT<int, typename Xpetra::Map<int, int>::node_type> EpetraVector;
+  typedef EpetraVectorT<int, EpetraNode> EpetraVector;
 }
 
 #ifndef XPETRA_EPETRAVECTOR_SHORT


### PR DESCRIPTION
Use "EpetraNode" as the default node template parameter for Xpetra::Epetra... types,
instead of KokkosClassic::DefaultNode::DefaultNodeType. Usually
these are identical, but in the case that Kokkos OpenMP is enabled but Epetra
OpenMP is disabled (a legal configuration), this fixes bad cast
exceptions in MueLu.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/xpetra 

## Description
<!--- Please describe your changes in detail. -->
## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
This fixes runtime errors in the MueLu MLParameterList examples, when Kokkos OpenMP is enabled but Epetra OpenMP is disabled. In this case, Epetra uses serial node, while the rest of Xpetra defaults to OpenMP node.

With this change, EpetraNode (which is always defined as the single valid node type for Epetra, either Serial or OpenMP) is the default for all Xpetra Epetra types.

This issue was discovered by @mhoemmen while testing PR #5871, which disabled Epetra OpenMP entirely.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to #5871 #5390 
* Part of 
* Composed of 
-->

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->
Built and tested Xpetra, Epetra, ML, Tpetra, and MueLu, with Kokkos OpenMP but without Epetra OpenMP.
<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- N/A My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
