### PR TITLE
Tpetra: Add verbose output to Directory & createOneToOne

### DIFF
--- a/packages/tpetra/core/src/Tpetra_DirectoryImpl_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_DirectoryImpl_decl.hpp
@@ -45,7 +45,6 @@
 /// \file Tpetra_DirectoryImpl_decl.hpp
 /// \brief Declaration of implementation details of Tpetra::Directory.
 
-#include <Tpetra_ConfigDefs.hpp>
 #include "Tpetra_TieBreak.hpp"
 #include "Tpetra_Map_fwd.hpp"
 
@@ -65,7 +64,7 @@
 #  define HAVE_TPETRA_DIRECTORY_SPARSE_MAP_FIX 1
 #endif // HAVE_TPETRA_DIRECTORY_SPARSE_MAP_FIX
 
-#include <Tpetra_Details_FixedHashTable_decl.hpp>
+#include "Tpetra_Details_FixedHashTable_decl.hpp"
 
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
 // Forward declaration of Teuchos::Comm
@@ -99,7 +98,9 @@ namespace Tpetra {
       /// may <i>not</i> keep a reference to the Map.  This prevents
       /// circular references, since the Map itself owns the
       /// Directory.
-      Directory ();
+      Directory () = default;
+
+      virtual ~Directory () = default;
 
       /// Find process IDs and (optionally) local IDs for the given global IDs.
       ///
@@ -167,13 +168,15 @@ namespace Tpetra {
       typedef Directory<LocalOrdinal, GlobalOrdinal, NodeType> base_type;
       typedef typename base_type::map_type map_type;
 
+      //! Constructor (that takes no arguments).
+      ReplicatedDirectory () = default;
+
       //! Constructor (that takes a Map).
       ReplicatedDirectory (const map_type& map);
 
-      //! Constructor (that takes no arguments).
-      ReplicatedDirectory ();
+      ~ReplicatedDirectory () override = default;
 
-      virtual bool isOneToOne (const Teuchos::Comm<int>& comm) const;
+      bool isOneToOne (const Teuchos::Comm<int>& comm) const override;
 
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE
       template <class Node2>
@@ -198,11 +201,11 @@ namespace Tpetra {
                       const Teuchos::ArrayView<const GlobalOrdinal> &globalIDs,
                       const Teuchos::ArrayView<int> &nodeIDs,
                       const Teuchos::ArrayView<LocalOrdinal> &localIDs,
-                      const bool computeLIDs) const;
+                      const bool computeLIDs) const override;
 
     private:
       //! The number of process(es) in the input Map's communicator.
-      const int numProcs_;
+      const int numProcs_ = 0;
     };
 
 
@@ -221,17 +224,15 @@ namespace Tpetra {
       // This friend declaration lets us implement clone().
       template <class LO, class GO, class N> friend class ContiguousUniformDirectory;
 
-      //! Empty constructor for use by clone()
-      ContiguousUniformDirectory () {}
-
     public:
       typedef Directory<LocalOrdinal, GlobalOrdinal, NodeType> base_type;
       typedef typename base_type::map_type map_type;
 
-      //! Constructor.
+      ContiguousUniformDirectory () = default;
       ContiguousUniformDirectory (const map_type& map);
+      ~ContiguousUniformDirectory () override = default;
 
-      virtual bool isOneToOne (const Teuchos::Comm<int>&) const {
+      bool isOneToOne (const Teuchos::Comm<int>&) const override {
         return true;
       }
 
@@ -259,7 +260,7 @@ namespace Tpetra {
                       const Teuchos::ArrayView<const GlobalOrdinal> &globalIDs,
                       const Teuchos::ArrayView<int> &nodeIDs,
                       const Teuchos::ArrayView<LocalOrdinal> &localIDs,
-                      const bool computeLIDs) const;
+                      const bool computeLIDs) const override;
     };
 
 
@@ -271,17 +272,15 @@ namespace Tpetra {
     private:
       template <class LO, class GO, class N> friend class DistributedContiguousDirectory;
 
-      //! Empty constructor for use by clone()
-      DistributedContiguousDirectory () {}
-
     public:
       typedef Directory<LocalOrdinal, GlobalOrdinal, NodeType> base_type;
       typedef typename base_type::map_type map_type;
 
-      //! Constructor.
+      DistributedContiguousDirectory () = default;
       DistributedContiguousDirectory (const map_type& map);
+      ~DistributedContiguousDirectory () override = default;
 
-      virtual bool isOneToOne (const Teuchos::Comm<int>&) const {
+      bool isOneToOne (const Teuchos::Comm<int>&) const override {
         return true;
       }
 
@@ -316,7 +315,7 @@ namespace Tpetra {
                       const Teuchos::ArrayView<const GlobalOrdinal> &globalIDs,
                       const Teuchos::ArrayView<int> &nodeIDs,
                       const Teuchos::ArrayView<LocalOrdinal> &localIDs,
-                      const bool computeLIDs) const;
+                      const bool computeLIDs) const override;
 
     private:
       /// \brief Minimum global ID for each process in the communicator.
@@ -351,23 +350,21 @@ namespace Tpetra {
     class DistributedNoncontiguousDirectory :
       public Directory<LocalOrdinal, GlobalOrdinal, NodeType> {
     private:
-      template <class LO, class GO, class N> friend class DistributedNoncontiguousDirectory;
-      //! Private constructor for post-contruction initialization in clone()
-      DistributedNoncontiguousDirectory () {}
+      template <class LO, class GO, class N>
+      friend class DistributedNoncontiguousDirectory;
 
     public:
       typedef Tpetra::Details::TieBreak<LocalOrdinal, GlobalOrdinal> tie_break_type;
-      typedef Directory<LocalOrdinal, GlobalOrdinal, NodeType> base_type;
-      typedef typename base_type::map_type map_type;
+      using base_type = Directory<LocalOrdinal, GlobalOrdinal, NodeType>;
+      using map_type = typename base_type::map_type;
 
-      //! Constructor.
+      DistributedNoncontiguousDirectory () = default;
       DistributedNoncontiguousDirectory (const map_type& map);
-
-      //! Constructor.
       DistributedNoncontiguousDirectory (const map_type& map,
                                          const tie_break_type& tie_break);
+      ~DistributedNoncontiguousDirectory () override = default;
 
-      virtual bool isOneToOne (const Teuchos::Comm<int>& comm) const;
+      bool isOneToOne (const Teuchos::Comm<int>& comm) const override;
 
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE
       template <class Node2>
@@ -414,7 +411,7 @@ namespace Tpetra {
                       const Teuchos::ArrayView<const GlobalOrdinal> &globalIDs,
                       const Teuchos::ArrayView<int> &nodeIDs,
                       const Teuchos::ArrayView<LocalOrdinal> &localIDs,
-                      const bool computeLIDs) const;
+                      const bool computeLIDs) const override;
     private:
       /// \brief Initialization routine that unifies the implementation of
       ///        the two constructors

--- a/packages/tpetra/core/src/Tpetra_DirectoryImpl_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_DirectoryImpl_def.hpp
@@ -48,9 +48,10 @@
 #include "Tpetra_Distributor.hpp"
 #include "Tpetra_Map.hpp"
 #include "Tpetra_TieBreak.hpp"
-
 #include "Tpetra_Details_FixedHashTable.hpp"
 #include "Teuchos_Comm.hpp"
+#include <memory>
+#include <sstream>
 
 // FIXME (mfh 16 Apr 2013) GIANT HACK BELOW
 #ifdef HAVE_TPETRACORE_MPI
@@ -942,13 +943,15 @@ namespace Tpetra {
       using Teuchos::as;
       using Teuchos::RCP;
       using Teuchos::toString;
+      using ::Tpetra::Details::Behavior;
       using std::cerr;
       using std::endl;
-      typedef typename Array<GO>::size_type size_type;
+      using size_type = typename Array<GO>::size_type;
       const char funcPrefix[] = "Tpetra::"
         "DistributedNoncontiguousDirectory::getEntriesImpl: ";
       const char errSuffix[] =
         "  Please report this bug to the Tpetra developers.";
+
       RCP<const Teuchos::Comm<int> > comm = map.getComm ();
       const bool verbose = Behavior::verbose ("Directory") ||
         Behavior::verbose ("Tpetra::Directory");

--- a/packages/tpetra/core/src/Tpetra_DirectoryImpl_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_DirectoryImpl_def.hpp
@@ -45,13 +45,11 @@
 /// \file Tpetra_DirectoryImpl_def.hpp
 /// \brief Definition of implementation details of Tpetra::Directory.
 
-#include <Tpetra_DirectoryImpl_decl.hpp>
-#include <Tpetra_Distributor.hpp>
-#include <Tpetra_Map.hpp>
-#include <Tpetra_TieBreak.hpp>
+#include "Tpetra_Distributor.hpp"
+#include "Tpetra_Map.hpp"
+#include "Tpetra_TieBreak.hpp"
 
-#include <Tpetra_Details_FixedHashTable.hpp>
-#include <Tpetra_HashTable.hpp>
+#include "Tpetra_Details_FixedHashTable.hpp"
 #include "Teuchos_Comm.hpp"
 
 // FIXME (mfh 16 Apr 2013) GIANT HACK BELOW
@@ -62,10 +60,6 @@
 
 namespace Tpetra {
   namespace Details {
-    template<class LO, class GO, class NT>
-    Directory<LO, GO, NT>::
-    Directory () {}
-
     template<class LO, class GO, class NT>
     LookupStatus
     Directory<LO, GO, NT>::
@@ -108,13 +102,6 @@ namespace Tpetra {
     ReplicatedDirectory<LO, GO, NT>::
     ReplicatedDirectory (const map_type& map) :
       numProcs_ (map.getComm ()->getSize ())
-    {}
-
-
-    template<class LO, class GO, class NT>
-    ReplicatedDirectory<LO, GO, NT>::
-    ReplicatedDirectory () :
-      numProcs_ (0) // to be set later
     {}
 
 
@@ -954,11 +941,37 @@ namespace Tpetra {
       using Teuchos::ArrayView;
       using Teuchos::as;
       using Teuchos::RCP;
+      using Teuchos::toString;
       using std::cerr;
       using std::endl;
       typedef typename Array<GO>::size_type size_type;
-
+      const char funcPrefix[] = "Tpetra::"
+        "DistributedNoncontiguousDirectory::getEntriesImpl: ";
+      const char errSuffix[] =
+        "  Please report this bug to the Tpetra developers.";
       RCP<const Teuchos::Comm<int> > comm = map.getComm ();
+      const bool verbose = Behavior::verbose ("Directory") ||
+        Behavior::verbose ("Tpetra::Directory");
+      std::unique_ptr<std::string> procPrefix;
+      if (verbose) {
+        std::ostringstream os;
+        os << "Proc ";
+        if (map.getComm ().is_null ()) {
+          os << "?";
+        }
+        else {
+          os << map.getComm ()->getRank ();
+        }
+        os << ": ";
+        procPrefix = std::unique_ptr<std::string> (new std::string (os.str ()));
+        os << funcPrefix << "{GIDs: " << toString (globalIDs)
+           << ", PIDs: " << toString (nodeIDs)
+           << ", LIDs: " << toString (localIDs)
+           << ", computeLIDs: " << (computeLIDs ? "true" : "false")
+           << "}" << endl;
+        cerr << os.str ();
+      }
+
       const size_t numEntries = globalIDs.size ();
       const LO LINVALID = Teuchos::OrdinalTraits<LO>::invalid();
       LookupStatus res = AllIDsPresent;
@@ -976,7 +989,20 @@ namespace Tpetra {
 
       // Get directory locations for the requested list of entries.
       Array<int> dirImages (numEntries);
+      if (verbose) {
+        std::ostringstream os;
+        os << *procPrefix << "Call directoryMap_->getRemoteIndexList"
+           << endl;
+        cerr << os.str ();
+      }
       res = directoryMap_->getRemoteIndexList (globalIDs, dirImages ());
+      if (verbose) {
+        std::ostringstream os;
+        os << *procPrefix << "directoryMap_->getRemoteIndexList "
+          "PIDs result: " << toString (dirImages) << endl;
+        cerr << os.str ();
+      }
+
       // Check for unfound globalIDs and set corresponding nodeIDs to -1
       size_t numMissing = 0;
       if (res == IDNotPresent) {
@@ -993,7 +1019,21 @@ namespace Tpetra {
 
       Array<GO> sendGIDs;
       Array<int> sendImages;
+      if (verbose) {
+        std::ostringstream os;
+        os << *procPrefix << "Call Distributor::createFromRecvs"
+           << endl;
+        cerr << os.str ();
+      }
       distor.createFromRecvs (globalIDs, dirImages (), sendGIDs, sendImages);
+      if (verbose) {
+        std::ostringstream os;
+        os << *procPrefix << "Distributor::createFromRecvs result: "
+           << "{sendGIDs: " << toString (sendGIDs)
+           << ", sendPIDs: " << toString (sendImages)
+           << "}" << endl;
+        cerr << os.str ();
+      }
       const size_type numSends = sendGIDs.size ();
 
       //
@@ -1043,55 +1083,70 @@ namespace Tpetra {
         size_type exportsIndex = 0;
 
         if (useHashTables_) {
+          if (verbose) {
+            std::ostringstream os;
+            os << *procPrefix << "Pack exports (useHashTables_ true)"
+               << endl;
+            cerr << os.str ();
+          }
           for (size_type gidIndex = 0; gidIndex < numSends; ++gidIndex) {
             const GO curGID = sendGIDs[gidIndex];
             // Don't use as() here (see above note).
             exports[exportsIndex++] = static_cast<global_size_t> (curGID);
             const LO curLID = directoryMap_->getLocalElement (curGID);
-            TEUCHOS_TEST_FOR_EXCEPTION(curLID == LINVALID, std::logic_error,
-              Teuchos::typeName (*this) << "::getEntriesImpl(): The Directory "
-              "Map's global index " << curGID << " does not have a corresponding "
-              "local index.  Please report this bug to the Tpetra developers.");
+            TEUCHOS_TEST_FOR_EXCEPTION
+              (curLID == LINVALID, std::logic_error, funcPrefix <<
+               "Directory Map's global index " << curGID << " lacks "
+               "a corresponding local index." << errSuffix);
             // Don't use as() here (see above note).
-            exports[exportsIndex++] = static_cast<global_size_t> (lidToPidTable_->get (curLID));
+            exports[exportsIndex++] =
+              static_cast<global_size_t> (lidToPidTable_->get (curLID));
             if (computeLIDs) {
               // Don't use as() here (see above note).
-              exports[exportsIndex++] = static_cast<global_size_t> (lidToLidTable_->get (curLID));
+              exports[exportsIndex++] =
+                static_cast<global_size_t> (lidToLidTable_->get (curLID));
             }
           }
-        } else {
+        }
+        else {
+          if (verbose) {
+            std::ostringstream os;
+            os << *procPrefix << "Pack exports (useHashTables_ false)"
+               << endl;
+            cerr << os.str ();
+          }
           for (size_type gidIndex = 0; gidIndex < numSends; ++gidIndex) {
             const GO curGID = sendGIDs[gidIndex];
             // Don't use as() here (see above note).
             exports[exportsIndex++] = static_cast<global_size_t> (curGID);
             const LO curLID = directoryMap_->getLocalElement (curGID);
-            TEUCHOS_TEST_FOR_EXCEPTION(curLID == LINVALID, std::logic_error,
-              Teuchos::typeName (*this) << "::getEntriesImpl(): The Directory "
-              "Map's global index " << curGID << " does not have a corresponding "
-              "local index.  Please report this bug to the Tpetra developers.");
+            TEUCHOS_TEST_FOR_EXCEPTION
+              (curLID == LINVALID, std::logic_error, funcPrefix <<
+               "Directory Map's global index " << curGID << " lacks "
+               "a corresponding local index." << errSuffix);
             // Don't use as() here (see above note).
-            exports[exportsIndex++] = static_cast<global_size_t> (PIDs_[curLID]);
+            exports[exportsIndex++] =
+              static_cast<global_size_t> (PIDs_[curLID]);
             if (computeLIDs) {
               // Don't use as() here (see above note).
-              exports[exportsIndex++] = static_cast<global_size_t> (LIDs_[curLID]);
+              exports[exportsIndex++] =
+                static_cast<global_size_t> (LIDs_[curLID]);
             }
           }
         }
 
-        TEUCHOS_TEST_FOR_EXCEPTION(
-          exportsIndex > exports.size (), std::logic_error,
-          Teuchos::typeName (*this) << "::getEntriesImpl(): On Process " <<
-          comm->getRank () << ", exportsIndex = " << exportsIndex <<
-          " > exports.size() = " << exports.size () <<
-          ".  Please report this bug to the Tpetra developers.");
+        TEUCHOS_TEST_FOR_EXCEPTION
+          (exportsIndex > exports.size (), std::logic_error,
+           funcPrefix << "On Process " << comm->getRank () << ", "
+           "exportsIndex = " << exportsIndex << " > exports.size() = "
+           << exports.size () << "." << errSuffix);
       }
 
-      TEUCHOS_TEST_FOR_EXCEPTION(
-        numEntries < numMissing, std::logic_error,
-        Teuchos::typeName (*this) << "::getEntriesImpl(): On Process "
-        << comm->getRank () << ", numEntries = " << numEntries
-        << " < numMissing = " << numMissing
-        << ".  Please report this bug to the Tpetra developers.");
+      TEUCHOS_TEST_FOR_EXCEPTION
+        (numEntries < numMissing, std::logic_error, funcPrefix <<
+         "On Process " << comm->getRank () << ", numEntries = " <<
+         numEntries << " < numMissing = " << numMissing << "." <<
+         errSuffix);
 
       //
       // mfh 13 Nov 2012: See note above on conversions between
@@ -1121,7 +1176,20 @@ namespace Tpetra {
       // FIXME (mfh 20 Mar 2014) One could overlap the sort2() below
       // with communication, by splitting this call into doPosts and
       // doWaits.  The code is still correct in this form, however.
+      if (verbose) {
+        std::ostringstream os;
+        os << *procPrefix << "Call doPostsAndWaits: {packetSize: "
+           << packetSize << ", exports: " << toString (exports) << "}"
+           << endl;
+        cerr << os.str ();
+      }
       distor.doPostsAndWaits (exports ().getConst (), packetSize, imports ());
+      if (verbose) {
+        std::ostringstream os;
+        os << *procPrefix << "doPostsAndWaits result: "
+           << toString (imports) << endl;
+        cerr << os.str ();
+      }
 
       Array<GO> sortedIDs (globalIDs); // deep copy (for later sorting)
       Array<GO> offset (numEntries); // permutation array (sort2 output)
@@ -1129,23 +1197,29 @@ namespace Tpetra {
         offset[ii] = ii;
       }
       sort2 (sortedIDs.begin(), sortedIDs.begin() + numEntries, offset.begin());
+      if (verbose) {
+        std::ostringstream os;
+        os << *procPrefix << "sortedIDs: " << toString (sortedIDs)
+           << ", offset: " << toString (offset) << endl;
+        cerr << os.str ();
+      }
 
       size_t importsIndex = 0;
-      //typename Array<global_size_t>::iterator ptr = imports.begin();
-      typedef typename Array<GO>::iterator IT;
 
       // we know these conversions are in range, because we loaded this data
+      //
+      // Don't use as() for conversions here; we know they are in range.
       for (size_t i = 0; i < numRecv; ++i) {
-        // Don't use as() here (see above note).
         const GO curGID = static_cast<GO> (imports[importsIndex++]);
-        std::pair<IT, IT> p1 = std::equal_range (sortedIDs.begin(), sortedIDs.end(), curGID);
+        auto p1 = std::equal_range (sortedIDs.begin(),
+                                    sortedIDs.end(), curGID);
         if (p1.first != p1.second) {
           const size_t j = p1.first - sortedIDs.begin();
-          // Don't use as() here (see above note).
-          nodeIDs[offset[j]] = static_cast<int> (imports[importsIndex++]);
+          nodeIDs[offset[j]] =
+            static_cast<int> (imports[importsIndex++]);
           if (computeLIDs) {
-            // Don't use as() here (see above note).
-            localIDs[offset[j]] = static_cast<LO> (imports[importsIndex++]);
+            localIDs[offset[j]] =
+              static_cast<LO> (imports[importsIndex++]);
           }
           if (nodeIDs[offset[j]] == -1) {
             res = IDNotPresent;
@@ -1153,18 +1227,22 @@ namespace Tpetra {
         }
       }
 
-      TEUCHOS_TEST_FOR_EXCEPTION(
-        static_cast<size_t> (importsIndex) > static_cast<size_t> (imports.size ()),
-        std::logic_error,
-        "Tpetra::Details::DistributedNoncontiguousDirectory::getEntriesImpl: "
-        "On Process " << comm->getRank () << ": importsIndex = " <<
-        importsIndex << " > imports.size() = " << imports.size () << ".  "
-        "numRecv: " << numRecv << ", packetSize: " << packetSize << ", "
-        "numEntries (# GIDs): " << numEntries << ", numMissing: " << numMissing
-        << ": distor.getTotalReceiveLength(): "
-        << distor.getTotalReceiveLength () << ".  Please report this bug to "
-        "the Tpetra developers.");
-
+      TEUCHOS_TEST_FOR_EXCEPTION
+        (size_t (importsIndex) > size_t (imports.size ()),
+         std::logic_error, funcPrefix << "On Process " <<
+         comm->getRank () << ": importsIndex = " << importsIndex
+         << " > imports.size() = " << imports.size () << ".  "
+         "numRecv: " << numRecv
+         << ", packetSize: " << packetSize << ", "
+         "numEntries (# GIDs): " << numEntries
+         << ", numMissing: " << numMissing
+         << ": distor.getTotalReceiveLength(): "
+         << distor.getTotalReceiveLength () << "." << errSuffix);
+      if (verbose) {
+        std::ostringstream os;
+        os << *procPrefix << funcPrefix << "Done!" << endl;
+        cerr << os.str ();
+      }
       return res;
     }
 

--- a/packages/tpetra/core/src/Tpetra_Map_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Map_decl.hpp
@@ -396,7 +396,7 @@ namespace Tpetra {
          const Teuchos::RCP<const Teuchos::Comm<int> > &comm);
 
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE
-    TPETRA_DEPRECATED 
+    TPETRA_DEPRECATED
     Map (const global_size_t numGlobalElements,
          const size_t numLocalElements,
          const global_ordinal_type indexBase,
@@ -1290,7 +1290,9 @@ namespace Tpetra {
     /// requires a host View) if necessary (only noncontiguous Maps
     /// need this).
 #ifndef SWIG
-    mutable typename decltype (lgMap_)::HostMirror lgMapHost_;
+    mutable Kokkos::View<const GlobalOrdinal*,
+                         Kokkos::LayoutLeft,
+                         Kokkos::HostSpace> lgMapHost_;
 #endif
 
     //! Type of a mapping from global IDs to local IDs.
@@ -1598,13 +1600,9 @@ namespace Tpetra {
         // What we _can_ do here, though, is avoid a deep_copy in case
         // we're not using CUDA, by exploiting host mirrors.
 
-        static_assert (std::is_same<typename decltype (mapOut.lgMapHost_)::array_layout,
-                         typename decltype (mapIn.lgMapHost_)::array_layout>::value,
-          "mapOut.lgMapHost_ and MapIn.lgMapHost_ do not have the same "
-          "array_layout.  Please report this bug to the Tpetra developers.");
-
         // lgMapOut is nonconst, so use it here instead of mapOut.lgMap_.
-        auto lgMapHostOut = Kokkos::create_mirror_view (lgMapOut);
+        auto lgMapHostOut =
+          Kokkos::create_mirror_view (Kokkos::HostSpace (), lgMapOut);
         Kokkos::deep_copy (lgMapHostOut, lgMapOut);
         mapOut.lgMapHost_ = lgMapHostOut;
       }

--- a/packages/tpetra/core/src/Tpetra_TieBreak.hpp
+++ b/packages/tpetra/core/src/Tpetra_TieBreak.hpp
@@ -34,8 +34,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
-//
 // ************************************************************************
 // @HEADER
 
@@ -47,6 +45,8 @@
 
 #include "Tpetra_TieBreak_fwd.hpp"
 #include "Teuchos_RCP.hpp"
+#include <utility>
+#include <vector>
 
 namespace Tpetra {
 namespace Details {
@@ -100,7 +100,7 @@ namespace Details {
     }
 
     //! Virtual destructor (for memory safety of derived classes).
-    virtual ~TieBreak () {}
+    virtual ~TieBreak () = default;
 
     /// \brief Break any ties in ownership of the given global index GID.
     ///


### PR DESCRIPTION
@trilinos/tpetra 

## Description

1. Add verbose output to Directory and createOneToOne.
2. Make `Tpetra::Map::lgMapHost_` a HostSpace View, not a HostMirror View.

## Motivation and Context

Help with #5179 debugging.

## Related Issues

* Related to #5179 
