### PR TITLE
ShyLU BDDC: fixed KLU2 build errors

### DIFF
--- a/packages/shylu/shylu_dd/bddc/src/shylu_SolverKLU2.hpp
+++ b/packages/shylu/shylu_dd/bddc/src/shylu_SolverKLU2.hpp
@@ -53,15 +53,6 @@
 #include "Amesos2_KLU2.hpp"
 #include "shylu_SolverBaseBDDC.hpp"
 
-/*
-#include "klu2_defaults.hpp"
-#include "klu2_analyze.hpp"
-#include "klu2_factor.hpp"
-#include "klu2_solve.hpp"
-#include "klu2_free_symbolic.hpp"
-#include "klu2_free_numeric.hpp"
-*/
-
 namespace bddc {
   
   template <class SX> 


### PR DESCRIPTION
Fix build errors in ShyLU_DD BDDC tests, when Amesos2 ETI is off. The issue was that shylu_SolverKLU2.hpp was including the
same klu2 headers as Amesos2_KLU2_TypeMap.hpp and Amesos2_KLU2_FunctionMap.hpp.
The klu2 include guards silently prevented Amesos2 from actually getting
the required klu2 declarations.

Now, shylu_SolverKLU.hpp does not include klu2_* (in global namespace),
and instead uses the declarations that Amesos2 has already included
(in the ::KLU2 namespace). This is safe because KLU2 support in shylu
requires Amesos2 to be enabled.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/shylu 

## Description
<!--- Please describe your changes in detail. -->

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
Fixes build errors in the [Tpetra deprecated code OFF build on rocketman](https://testing.sandia.gov/cdash/viewBuildError.php?buildid=5621989). This issue has nothing to do with Tpetra, but this build (which has Amesos2 ETI off) happens to expose the problem: include guards were preventing Amesos2 from including the required klu2 source files, since ShyLU was including the same files. Normally that's what include guards are supposed to do, but Amesos2 includes them in the KLU2 namespace and ShyLU was including them in global namespace. So now ShyLU gets its klu2 declarations through Amesos2.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->
Built successfully with a configuration matching the rocketman nightly build "1.10.1_RELEASE_TPETRA_DEPRECATED_CODE_OFF_ENABLE_DOWNSTREAM" (linked above).
<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- N/A My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
