### PR TITLE
Belos: Fix #5904

### DIFF
--- a/packages/belos/tpetra/src/Belos_Details_Tpetra_registerSolverFactory.cpp
+++ b/packages/belos/tpetra/src/Belos_Details_Tpetra_registerSolverFactory.cpp
@@ -34,8 +34,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
-//
 // ************************************************************************
 //@HEADER
 
@@ -45,31 +43,29 @@
 
 #include "BelosSolverFactory_Tpetra.hpp"
 
-#include "BelosBiCGStabSolMgr.hpp"
-#include "BelosBlockCGSolMgr.hpp"
-#include "BelosBlockGmresSolMgr.hpp"
-#include "BelosFixedPointSolMgr.hpp"
-#include "BelosGCRODRSolMgr.hpp"
-#include "BelosGmresPolySolMgr.hpp"
-#include "BelosLSQRSolMgr.hpp"
-#include "BelosMinresSolMgr.hpp"
-#include "BelosPCPGSolMgr.hpp"
-#include "BelosPseudoBlockCGSolMgr.hpp"
-#include "BelosPseudoBlockGmresSolMgr.hpp"
-#include "BelosPseudoBlockTFQMRSolMgr.hpp"
-#include "BelosRCGSolMgr.hpp"
-#include "BelosTFQMRSolMgr.hpp"
-
 namespace BelosTpetra {
 namespace Impl {
 
+extern void register_BiCGStab (const bool verbose);
+extern void register_BlockCG (const bool verbose);
+extern void register_BlockGmres (const bool verbose);
 extern void register_CgPipeline (const bool verbose);
 extern void register_CgSingleReduce (const bool verbose);
+extern void register_FixedPoint (const bool verbose);
+extern void register_GCRODR (const bool verbose);
 extern void register_GmresPipeline (const bool verbose);
+extern void register_GmresPoly (const bool verbose);
 extern void register_GmresSingleReduce (const bool verbose);
-  
+extern void register_LSQR (const bool verbose);
+extern void register_Minres (const bool verbose);
+extern void register_PCPG (const bool verbose);
+extern void register_PseudoBlockCG (const bool verbose);
+extern void register_PseudoBlockGmres (const bool verbose);
+extern void register_PseudoBlockTFQMR (const bool verbose);
+extern void register_TFQMR (const bool verbose);
+
 } // namespace Impl
-} // namespace BelosTpetra  
+} // namespace BelosTpetra
 
 #include "TpetraCore_ETIHelperMacros.h"
 TPETRA_ETI_MANGLING_TYPEDEFS()
@@ -79,72 +75,23 @@ namespace Details {
 namespace Tpetra {
 
 void registerSolverFactory() {
+  ::BelosTpetra::Impl::register_BiCGStab (false);
+  ::BelosTpetra::Impl::register_BlockCG (false);
+  ::BelosTpetra::Impl::register_BlockGmres (false);
   ::BelosTpetra::Impl::register_CgPipeline (false);
   ::BelosTpetra::Impl::register_CgSingleReduce (false);
+  ::BelosTpetra::Impl::register_FixedPoint (false);
+  ::BelosTpetra::Impl::register_GCRODR (false);
   ::BelosTpetra::Impl::register_GmresPipeline (false);
+  ::BelosTpetra::Impl::register_GmresPoly (false);
   ::BelosTpetra::Impl::register_GmresSingleReduce (false);
-  
-  #define BELOS_LCL_CALL_FOR_MANAGER(manager,name,SC, LO, GO, NT)   \
-    Impl::registerSolverSubclassForTypes<                           \
-      manager<SC,::Tpetra::MultiVector<SC, LO, GO, NT>,             \
-      ::Tpetra::Operator<SC, LO, GO, NT>>, SC,                      \
-      ::Tpetra::MultiVector<SC, LO, GO, NT>,                        \
-      ::Tpetra::Operator<SC, LO, GO, NT>> (name);
-
-  #define LCL_CALL( SC, LO, GO, NT ) BELOS_LCL_CALL_FOR_MANAGER(BiCGStabSolMgr, "BICGSTAB", SC, LO, GO, NT)
-  TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR( LCL_CALL )
-
-  #undef LCL_CALL
-  #define LCL_CALL( SC, LO, GO, NT ) BELOS_LCL_CALL_FOR_MANAGER(BlockCGSolMgr, "BLOCK CG", SC, LO, GO, NT)
-  TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR( LCL_CALL )
-
-  #undef LCL_CALL
-  #define LCL_CALL( SC, LO, GO, NT ) BELOS_LCL_CALL_FOR_MANAGER(BlockGmresSolMgr, "BLOCK GMRES", SC, LO, GO, NT)
-  TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR( LCL_CALL )
-
-  #undef LCL_CALL
-  #define LCL_CALL( SC, LO, GO, NT ) BELOS_LCL_CALL_FOR_MANAGER(FixedPointSolMgr, "FIXED POINT", SC, LO, GO, NT)
-  TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR( LCL_CALL )
-
-  #undef LCL_CALL
-  #define LCL_CALL( SC, LO, GO, NT ) BELOS_LCL_CALL_FOR_MANAGER(GCRODRSolMgr, "GCRODR", SC, LO, GO, NT)
-  TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR( LCL_CALL )
-
-  #undef LCL_CALL
-  #define LCL_CALL( SC, LO, GO, NT ) BELOS_LCL_CALL_FOR_MANAGER(GmresPolySolMgr, "HYBRID BLOCK GMRES", SC, LO, GO, NT)
-  TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR( LCL_CALL )
-
-  #undef LCL_CALL
-  #define LCL_CALL( SC, LO, GO, NT ) BELOS_LCL_CALL_FOR_MANAGER(LSQRSolMgr, "LSQR", SC, LO, GO, NT)
-  TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR( LCL_CALL )
-
-  #undef LCL_CALL
-  #define LCL_CALL( SC, LO, GO, NT ) BELOS_LCL_CALL_FOR_MANAGER(MinresSolMgr, "MINRES", SC, LO, GO, NT)
-  TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR( LCL_CALL )
-
-  #undef LCL_CALL
-  #define LCL_CALL( SC, LO, GO, NT ) BELOS_LCL_CALL_FOR_MANAGER(PCPGSolMgr, "PCPG", SC, LO, GO, NT)
-  TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR( LCL_CALL )
-
-  #undef LCL_CALL
-  #define LCL_CALL( SC, LO, GO, NT ) BELOS_LCL_CALL_FOR_MANAGER(PseudoBlockCGSolMgr, "PSEUDOBLOCK CG", SC, LO, GO, NT)
-  TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR( LCL_CALL )
-
-  #undef LCL_CALL
-  #define LCL_CALL( SC, LO, GO, NT ) BELOS_LCL_CALL_FOR_MANAGER(PseudoBlockGmresSolMgr, "PSEUDOBLOCK GMRES", SC, LO, GO, NT)
-  TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR( LCL_CALL )
-
-  #undef LCL_CALL
-  #define LCL_CALL( SC, LO, GO, NT ) BELOS_LCL_CALL_FOR_MANAGER(PseudoBlockTFQMRSolMgr, "PSEUDOBLOCK TFQMR", SC, LO, GO, NT)
-  TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR( LCL_CALL )
-
-  #undef LCL_CALL
-  #define LCL_CALL( SC, LO, GO, NT ) BELOS_LCL_CALL_FOR_MANAGER(RCGSolMgr, "RCG", SC, LO, GO, NT)
-  TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR( LCL_CALL )
-
-  #undef LCL_CALL
-  #define LCL_CALL( SC, LO, GO, NT ) BELOS_LCL_CALL_FOR_MANAGER(TFQMRSolMgr, "TFQMR", SC, LO, GO, NT)
-  TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR( LCL_CALL )
+  ::BelosTpetra::Impl::register_LSQR (false);
+  ::BelosTpetra::Impl::register_Minres (false);
+  ::BelosTpetra::Impl::register_PCPG (false);
+  ::BelosTpetra::Impl::register_PseudoBlockCG (false);
+  ::BelosTpetra::Impl::register_PseudoBlockGmres (false);
+  ::BelosTpetra::Impl::register_PseudoBlockTFQMR (false);
+  ::BelosTpetra::Impl::register_TFQMR (false);
 }
 
 } // namespace Tpetra

--- a/packages/belos/tpetra/src/CMakeLists.txt
+++ b/packages/belos/tpetra/src/CMakeLists.txt
@@ -45,8 +45,8 @@ APPEND_SET(HEADERS
   ${CMAKE_CURRENT_SOURCE_DIR}/solvers/Belos_Tpetra_Gmres.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/solvers/Belos_Tpetra_GmresS.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/solvers/Belos_Tpetra_GmresSstep.hpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/solvers/Belos_Tpetra_GmresPipeline.hpp  
-  ${CMAKE_CURRENT_SOURCE_DIR}/solvers/Belos_Tpetra_GmresSingleReduce.hpp  
+  ${CMAKE_CURRENT_SOURCE_DIR}/solvers/Belos_Tpetra_GmresPipeline.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/solvers/Belos_Tpetra_GmresSingleReduce.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/solvers/Belos_Tpetra_Krylov.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/solvers/Belos_Tpetra_Krylov_parameters.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/solvers/Belos_Tpetra_SolverManager.hpp
@@ -54,14 +54,28 @@ APPEND_SET(HEADERS
   ${CMAKE_CURRENT_SOURCE_DIR}/solvers/Belos_Tpetra_UpdateNewton.hpp
   )
 APPEND_SET(SOURCES
+  ${CMAKE_CURRENT_SOURCE_DIR}/solvers/Belos_Tpetra_BiCGStab.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/solvers/Belos_Tpetra_BlockCG.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/solvers/Belos_Tpetra_BlockGmres.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/solvers/Belos_Tpetra_Cg.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/solvers/Belos_Tpetra_CgPipeline.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/solvers/Belos_Tpetra_CgSingleReduce.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/solvers/Belos_Tpetra_Gmres.cpp  
-  ${CMAKE_CURRENT_SOURCE_DIR}/solvers/Belos_Tpetra_GmresS.cpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/solvers/Belos_Tpetra_GmresSstep.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/solvers/Belos_Tpetra_FixedPoint.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/solvers/Belos_Tpetra_GCRODR.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/solvers/Belos_Tpetra_Gmres.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/solvers/Belos_Tpetra_GmresPipeline.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/solvers/Belos_Tpetra_GmresPoly.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/solvers/Belos_Tpetra_GmresS.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/solvers/Belos_Tpetra_GmresSingleReduce.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/solvers/Belos_Tpetra_GmresSstep.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/solvers/Belos_Tpetra_LSQR.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/solvers/Belos_Tpetra_Minres.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/solvers/Belos_Tpetra_PCPG.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/solvers/Belos_Tpetra_PseudoBlockCG.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/solvers/Belos_Tpetra_PseudoBlockGmres.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/solvers/Belos_Tpetra_PseudoBlockTFQMR.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/solvers/Belos_Tpetra_TFQMR.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/solvers/Belos_Tpetra_RCG.cpp
   )
 
 #

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_BiCGStab.cpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_BiCGStab.cpp
@@ -1,0 +1,85 @@
+//@HEADER
+// ************************************************************************
+//
+//                 Belos: Block Linear Solvers Package
+//                  Copyright 2004 Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// ************************************************************************
+//@HEADER
+
+#include "BelosSolverFactory.hpp"
+#include "BelosSolverFactory_Tpetra.hpp"
+#include "BelosBiCGStabSolMgr.hpp"
+#include "TpetraCore_ETIHelperMacros.h"
+#include "Teuchos_TypeNameTraits.hpp"
+#include <iostream>
+
+namespace BelosTpetra {
+namespace Impl {
+
+template<class SC, class LO, class GO, class NT>
+void register_BiCGStab_tmpl (const bool verbose)
+{
+  using ::Belos::Impl::registerSolverSubclassForTypes;
+  using MV = ::Tpetra::MultiVector<SC, LO, GO, NT>;
+  using OP = ::Tpetra::Operator<SC, LO, GO, NT>;
+  using solver_type = ::Belos::BiCGStabSolMgr<SC, MV, OP>;
+
+  if (verbose) {
+    using Teuchos::TypeNameTraits;
+    std::cout << "Registering BelosTpetra BiCGStabSolMgr<"
+              << TypeNameTraits<SC>::name () << ", "
+              << TypeNameTraits<LO>::name () << ", "
+              << TypeNameTraits<GO>::name () << ", "
+              << TypeNameTraits<NT>::name () << ">" << std::endl;
+  }
+  const char solverName[] = "BICGSTAB";
+  registerSolverSubclassForTypes<solver_type, SC, MV, OP> (solverName);
+}
+
+void register_BiCGStab (const bool verbose)
+{
+  TPETRA_ETI_MANGLING_TYPEDEFS()
+
+#ifdef BELOS_TPETRA_REGISTER_BICGSTAB
+#  undef BELOS_TPETRA_REGISTER_BICGSTAB
+#endif // BELOS_TPETRA_REGISTER_BICGSTAB
+#define BELOS_TPETRA_REGISTER_BICGSTAB( SC, LO, GO, NT ) register_BiCGStab_tmpl<SC, LO, GO, NT> (verbose);
+
+  TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR( BELOS_TPETRA_REGISTER_BICGSTAB )
+
+#undef BELOS_TPETRA_REGISTER_BICGSTAB
+}
+
+} // namespace Impl
+} // namespace BelosTpetra

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_BlockCG.cpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_BlockCG.cpp
@@ -1,0 +1,85 @@
+//@HEADER
+// ************************************************************************
+//
+//                 Belos: Block Linear Solvers Package
+//                  Copyright 2004 Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// ************************************************************************
+//@HEADER
+
+#include "BelosSolverFactory.hpp"
+#include "BelosSolverFactory_Tpetra.hpp"
+#include "BelosBlockCGSolMgr.hpp"
+#include "TpetraCore_ETIHelperMacros.h"
+#include "Teuchos_TypeNameTraits.hpp"
+#include <iostream>
+
+namespace BelosTpetra {
+namespace Impl {
+
+template<class SC, class LO, class GO, class NT>
+void register_BlockCG_tmpl (const bool verbose)
+{
+  using ::Belos::Impl::registerSolverSubclassForTypes;
+  using MV = ::Tpetra::MultiVector<SC, LO, GO, NT>;
+  using OP = ::Tpetra::Operator<SC, LO, GO, NT>;
+  using solver_type = ::Belos::BlockCGSolMgr<SC, MV, OP>;
+
+  if (verbose) {
+    using Teuchos::TypeNameTraits;
+    std::cout << "Registering BelosTpetra BlockCGSolMgr<"
+              << TypeNameTraits<SC>::name () << ", "
+              << TypeNameTraits<LO>::name () << ", "
+              << TypeNameTraits<GO>::name () << ", "
+              << TypeNameTraits<NT>::name () << ">" << std::endl;
+  }
+  const char solverName[] = "BLOCK CG";
+  registerSolverSubclassForTypes<solver_type, SC, MV, OP> (solverName);
+}
+
+void register_BlockCG (const bool verbose)
+{
+  TPETRA_ETI_MANGLING_TYPEDEFS()
+
+#ifdef BELOS_TPETRA_REGISTER_BLOCKCG
+#  undef BELOS_TPETRA_REGISTER_BLOCKCG
+#endif // BELOS_TPETRA_REGISTER_BLOCKCG
+#define BELOS_TPETRA_REGISTER_BLOCKCG( SC, LO, GO, NT ) register_BlockCG_tmpl<SC, LO, GO, NT> (verbose);
+
+  TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR( BELOS_TPETRA_REGISTER_BLOCKCG )
+
+#undef BELOS_TPETRA_REGISTER_BLOCKCG
+}
+
+} // namespace Impl
+} // namespace BelosTpetra

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_BlockGmres.cpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_BlockGmres.cpp
@@ -1,0 +1,85 @@
+//@HEADER
+// ************************************************************************
+//
+//                 Belos: Block Linear Solvers Package
+//                  Copyright 2004 Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// ************************************************************************
+//@HEADER
+
+#include "BelosSolverFactory.hpp"
+#include "BelosSolverFactory_Tpetra.hpp"
+#include "BelosBlockGmresSolMgr.hpp"
+#include "TpetraCore_ETIHelperMacros.h"
+#include "Teuchos_TypeNameTraits.hpp"
+#include <iostream>
+
+namespace BelosTpetra {
+namespace Impl {
+
+template<class SC, class LO, class GO, class NT>
+void register_BlockGmres_tmpl (const bool verbose)
+{
+  using ::Belos::Impl::registerSolverSubclassForTypes;
+  using MV = ::Tpetra::MultiVector<SC, LO, GO, NT>;
+  using OP = ::Tpetra::Operator<SC, LO, GO, NT>;
+  using solver_type = ::Belos::BlockGmresSolMgr<SC, MV, OP>;
+
+  if (verbose) {
+    using Teuchos::TypeNameTraits;
+    std::cout << "Registering BelosTpetra BlockGmresSolMgr<"
+              << TypeNameTraits<SC>::name () << ", "
+              << TypeNameTraits<LO>::name () << ", "
+              << TypeNameTraits<GO>::name () << ", "
+              << TypeNameTraits<NT>::name () << ">" << std::endl;
+  }
+  const char solverName[] = "BLOCK GMRES";
+  registerSolverSubclassForTypes<solver_type, SC, MV, OP> (solverName);
+}
+
+void register_BlockGmres (const bool verbose)
+{
+  TPETRA_ETI_MANGLING_TYPEDEFS()
+
+#ifdef BELOS_TPETRA_REGISTER_BLOCKGMRES
+#  undef BELOS_TPETRA_REGISTER_BLOCKGMRES
+#endif // BELOS_TPETRA_REGISTER_BLOCKGMRES
+#define BELOS_TPETRA_REGISTER_BLOCKGMRES( SC, LO, GO, NT ) register_BlockGmres_tmpl<SC, LO, GO, NT> (verbose);
+
+  TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR( BELOS_TPETRA_REGISTER_BLOCKGMRES )
+
+#undef BELOS_TPETRA_REGISTER_BLOCKGMRES
+}
+
+} // namespace Impl
+} // namespace BelosTpetra

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_FixedPoint.cpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_FixedPoint.cpp
@@ -1,0 +1,85 @@
+//@HEADER
+// ************************************************************************
+//
+//                 Belos: Block Linear Solvers Package
+//                  Copyright 2004 Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// ************************************************************************
+//@HEADER
+
+#include "BelosSolverFactory.hpp"
+#include "BelosSolverFactory_Tpetra.hpp"
+#include "BelosFixedPointSolMgr.hpp"
+#include "TpetraCore_ETIHelperMacros.h"
+#include "Teuchos_TypeNameTraits.hpp"
+#include <iostream>
+
+namespace BelosTpetra {
+namespace Impl {
+
+template<class SC, class LO, class GO, class NT>
+void register_FixedPoint_tmpl (const bool verbose)
+{
+  using ::Belos::Impl::registerSolverSubclassForTypes;
+  using MV = ::Tpetra::MultiVector<SC, LO, GO, NT>;
+  using OP = ::Tpetra::Operator<SC, LO, GO, NT>;
+  using solver_type = ::Belos::FixedPointSolMgr<SC, MV, OP>;
+
+  if (verbose) {
+    using Teuchos::TypeNameTraits;
+    std::cout << "Registering BelosTpetra FixedPointSolMgr<"
+              << TypeNameTraits<SC>::name () << ", "
+              << TypeNameTraits<LO>::name () << ", "
+              << TypeNameTraits<GO>::name () << ", "
+              << TypeNameTraits<NT>::name () << ">" << std::endl;
+  }
+  const char solverName[] = "FIXED POINT";
+  registerSolverSubclassForTypes<solver_type, SC, MV, OP> (solverName);
+}
+
+void register_FixedPoint (const bool verbose)
+{
+  TPETRA_ETI_MANGLING_TYPEDEFS()
+
+#ifdef BELOS_TPETRA_REGISTER_FIXEDPOINT
+#  undef BELOS_TPETRA_REGISTER_FIXEDPOINT
+#endif // BELOS_TPETRA_REGISTER_FIXEDPOINT
+#define BELOS_TPETRA_REGISTER_FIXEDPOINT( SC, LO, GO, NT ) register_FixedPoint_tmpl<SC, LO, GO, NT> (verbose);
+
+  TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR( BELOS_TPETRA_REGISTER_FIXEDPOINT )
+
+#undef BELOS_TPETRA_REGISTER_FIXEDPOINT
+}
+
+} // namespace Impl
+} // namespace BelosTpetra

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_GCRODR.cpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_GCRODR.cpp
@@ -1,0 +1,85 @@
+//@HEADER
+// ************************************************************************
+//
+//                 Belos: Block Linear Solvers Package
+//                  Copyright 2004 Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// ************************************************************************
+//@HEADER
+
+#include "BelosSolverFactory.hpp"
+#include "BelosSolverFactory_Tpetra.hpp"
+#include "BelosGCRODRSolMgr.hpp"
+#include "TpetraCore_ETIHelperMacros.h"
+#include "Teuchos_TypeNameTraits.hpp"
+#include <iostream>
+
+namespace BelosTpetra {
+namespace Impl {
+
+template<class SC, class LO, class GO, class NT>
+void register_GCRODR_tmpl (const bool verbose)
+{
+  using ::Belos::Impl::registerSolverSubclassForTypes;
+  using MV = ::Tpetra::MultiVector<SC, LO, GO, NT>;
+  using OP = ::Tpetra::Operator<SC, LO, GO, NT>;
+  using solver_type = ::Belos::GCRODRSolMgr<SC, MV, OP>;
+
+  if (verbose) {
+    using Teuchos::TypeNameTraits;
+    std::cout << "Registering BelosTpetra GCRODRSolMgr<"
+              << TypeNameTraits<SC>::name () << ", "
+              << TypeNameTraits<LO>::name () << ", "
+              << TypeNameTraits<GO>::name () << ", "
+              << TypeNameTraits<NT>::name () << ">" << std::endl;
+  }
+  const char solverName[] = "GCRODR";
+  registerSolverSubclassForTypes<solver_type, SC, MV, OP> (solverName);
+}
+
+void register_GCRODR (const bool verbose)
+{
+  TPETRA_ETI_MANGLING_TYPEDEFS()
+
+#ifdef BELOS_TPETRA_REGISTER_GCRODR
+#  undef BELOS_TPETRA_REGISTER_GCRODR
+#endif // BELOS_TPETRA_REGISTER_GCRODR
+#define BELOS_TPETRA_REGISTER_GCRODR( SC, LO, GO, NT ) register_GCRODR_tmpl<SC, LO, GO, NT> (verbose);
+
+  TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR( BELOS_TPETRA_REGISTER_GCRODR )
+
+#undef BELOS_TPETRA_REGISTER_GCRODR
+}
+
+} // namespace Impl
+} // namespace BelosTpetra

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresPoly.cpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_GmresPoly.cpp
@@ -1,0 +1,85 @@
+//@HEADER
+// ************************************************************************
+//
+//                 Belos: Block Linear Solvers Package
+//                  Copyright 2004 Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// ************************************************************************
+//@HEADER
+
+#include "BelosSolverFactory.hpp"
+#include "BelosSolverFactory_Tpetra.hpp"
+#include "BelosGmresPolySolMgr.hpp"
+#include "TpetraCore_ETIHelperMacros.h"
+#include "Teuchos_TypeNameTraits.hpp"
+#include <iostream>
+
+namespace BelosTpetra {
+namespace Impl {
+
+template<class SC, class LO, class GO, class NT>
+void register_GmresPoly_tmpl (const bool verbose)
+{
+  using ::Belos::Impl::registerSolverSubclassForTypes;
+  using MV = ::Tpetra::MultiVector<SC, LO, GO, NT>;
+  using OP = ::Tpetra::Operator<SC, LO, GO, NT>;
+  using solver_type = ::Belos::GmresPolySolMgr<SC, MV, OP>;
+
+  if (verbose) {
+    using Teuchos::TypeNameTraits;
+    std::cout << "Registering BelosTpetra GmresPolySolMgr<"
+              << TypeNameTraits<SC>::name () << ", "
+              << TypeNameTraits<LO>::name () << ", "
+              << TypeNameTraits<GO>::name () << ", "
+              << TypeNameTraits<NT>::name () << ">" << std::endl;
+  }
+  const char solverName[] = "HYBRID BLOCK GMRES";
+  registerSolverSubclassForTypes<solver_type, SC, MV, OP> (solverName);
+}
+
+void register_GmresPoly (const bool verbose)
+{
+  TPETRA_ETI_MANGLING_TYPEDEFS()
+
+#ifdef BELOS_TPETRA_REGISTER_GMRESPOLY
+#  undef BELOS_TPETRA_REGISTER_GMRESPOLY
+#endif // BELOS_TPETRA_REGISTER_GMRESPOLY
+#define BELOS_TPETRA_REGISTER_GMRESPOLY( SC, LO, GO, NT ) register_GmresPoly_tmpl<SC, LO, GO, NT> (verbose);
+
+  TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR( BELOS_TPETRA_REGISTER_GMRESPOLY )
+
+#undef BELOS_TPETRA_REGISTER_GMRESPOLY
+}
+
+} // namespace Impl
+} // namespace BelosTpetra

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_LSQR.cpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_LSQR.cpp
@@ -1,0 +1,85 @@
+//@HEADER
+// ************************************************************************
+//
+//                 Belos: Block Linear Solvers Package
+//                  Copyright 2004 Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// ************************************************************************
+//@HEADER
+
+#include "BelosSolverFactory.hpp"
+#include "BelosSolverFactory_Tpetra.hpp"
+#include "BelosLSQRSolMgr.hpp"
+#include "TpetraCore_ETIHelperMacros.h"
+#include "Teuchos_TypeNameTraits.hpp"
+#include <iostream>
+
+namespace BelosTpetra {
+namespace Impl {
+
+template<class SC, class LO, class GO, class NT>
+void register_LSQR_tmpl (const bool verbose)
+{
+  using ::Belos::Impl::registerSolverSubclassForTypes;
+  using MV = ::Tpetra::MultiVector<SC, LO, GO, NT>;
+  using OP = ::Tpetra::Operator<SC, LO, GO, NT>;
+  using solver_type = ::Belos::LSQRSolMgr<SC, MV, OP>;
+
+  if (verbose) {
+    using Teuchos::TypeNameTraits;
+    std::cout << "Registering BelosTpetra LSQRSolMgr<"
+              << TypeNameTraits<SC>::name () << ", "
+              << TypeNameTraits<LO>::name () << ", "
+              << TypeNameTraits<GO>::name () << ", "
+              << TypeNameTraits<NT>::name () << ">" << std::endl;
+  }
+  const char solverName[] = "LSQR";
+  registerSolverSubclassForTypes<solver_type, SC, MV, OP> (solverName);
+}
+
+void register_LSQR (const bool verbose)
+{
+  TPETRA_ETI_MANGLING_TYPEDEFS()
+
+#ifdef BELOS_TPETRA_REGISTER_LSQR
+#  undef BELOS_TPETRA_REGISTER_LSQR
+#endif // BELOS_TPETRA_REGISTER_LSQR
+#define BELOS_TPETRA_REGISTER_LSQR( SC, LO, GO, NT ) register_LSQR_tmpl<SC, LO, GO, NT> (verbose);
+
+  TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR( BELOS_TPETRA_REGISTER_LSQR )
+
+#undef BELOS_TPETRA_REGISTER_LSQR
+}
+
+} // namespace Impl
+} // namespace BelosTpetra

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_Minres.cpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_Minres.cpp
@@ -1,0 +1,85 @@
+//@HEADER
+// ************************************************************************
+//
+//                 Belos: Block Linear Solvers Package
+//                  Copyright 2004 Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// ************************************************************************
+//@HEADER
+
+#include "BelosSolverFactory.hpp"
+#include "BelosSolverFactory_Tpetra.hpp"
+#include "BelosMinresSolMgr.hpp"
+#include "TpetraCore_ETIHelperMacros.h"
+#include "Teuchos_TypeNameTraits.hpp"
+#include <iostream>
+
+namespace BelosTpetra {
+namespace Impl {
+
+template<class SC, class LO, class GO, class NT>
+void register_Minres_tmpl (const bool verbose)
+{
+  using ::Belos::Impl::registerSolverSubclassForTypes;
+  using MV = ::Tpetra::MultiVector<SC, LO, GO, NT>;
+  using OP = ::Tpetra::Operator<SC, LO, GO, NT>;
+  using solver_type = ::Belos::MinresSolMgr<SC, MV, OP>;
+
+  if (verbose) {
+    using Teuchos::TypeNameTraits;
+    std::cout << "Registering BelosTpetra MinresSolMgr<"
+              << TypeNameTraits<SC>::name () << ", "
+              << TypeNameTraits<LO>::name () << ", "
+              << TypeNameTraits<GO>::name () << ", "
+              << TypeNameTraits<NT>::name () << ">" << std::endl;
+  }
+  const char solverName[] = "MINRES";
+  registerSolverSubclassForTypes<solver_type, SC, MV, OP> (solverName);
+}
+
+void register_Minres (const bool verbose)
+{
+  TPETRA_ETI_MANGLING_TYPEDEFS()
+
+#ifdef BELOS_TPETRA_REGISTER_MINRES
+#  undef BELOS_TPETRA_REGISTER_MINRES
+#endif // BELOS_TPETRA_REGISTER_MINRES
+#define BELOS_TPETRA_REGISTER_MINRES( SC, LO, GO, NT ) register_Minres_tmpl<SC, LO, GO, NT> (verbose);
+
+  TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR( BELOS_TPETRA_REGISTER_MINRES )
+
+#undef BELOS_TPETRA_REGISTER_MINRES
+}
+
+} // namespace Impl
+} // namespace BelosTpetra

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_PCPG.cpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_PCPG.cpp
@@ -1,0 +1,85 @@
+//@HEADER
+// ************************************************************************
+//
+//                 Belos: Block Linear Solvers Package
+//                  Copyright 2004 Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// ************************************************************************
+//@HEADER
+
+#include "BelosSolverFactory.hpp"
+#include "BelosSolverFactory_Tpetra.hpp"
+#include "BelosPCPGSolMgr.hpp"
+#include "TpetraCore_ETIHelperMacros.h"
+#include "Teuchos_TypeNameTraits.hpp"
+#include <iostream>
+
+namespace BelosTpetra {
+namespace Impl {
+
+template<class SC, class LO, class GO, class NT>
+void register_PCPG_tmpl (const bool verbose)
+{
+  using ::Belos::Impl::registerSolverSubclassForTypes;
+  using MV = ::Tpetra::MultiVector<SC, LO, GO, NT>;
+  using OP = ::Tpetra::Operator<SC, LO, GO, NT>;
+  using solver_type = ::Belos::PCPGSolMgr<SC, MV, OP>;
+
+  if (verbose) {
+    using Teuchos::TypeNameTraits;
+    std::cout << "Registering BelosTpetra PCPGSolMgr<"
+              << TypeNameTraits<SC>::name () << ", "
+              << TypeNameTraits<LO>::name () << ", "
+              << TypeNameTraits<GO>::name () << ", "
+              << TypeNameTraits<NT>::name () << ">" << std::endl;
+  }
+  const char solverName[] = "PCPG";
+  registerSolverSubclassForTypes<solver_type, SC, MV, OP> (solverName);
+}
+
+void register_PCPG (const bool verbose)
+{
+  TPETRA_ETI_MANGLING_TYPEDEFS()
+
+#ifdef BELOS_TPETRA_REGISTER_PCPG
+#  undef BELOS_TPETRA_REGISTER_PCPG
+#endif // BELOS_TPETRA_REGISTER_PCPG
+#define BELOS_TPETRA_REGISTER_PCPG( SC, LO, GO, NT ) register_PCPG_tmpl<SC, LO, GO, NT> (verbose);
+
+  TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR( BELOS_TPETRA_REGISTER_PCPG )
+
+#undef BELOS_TPETRA_REGISTER_PCPG
+}
+
+} // namespace Impl
+} // namespace BelosTpetra

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_PseudoBlockCG.cpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_PseudoBlockCG.cpp
@@ -1,0 +1,85 @@
+//@HEADER
+// ************************************************************************
+//
+//                 Belos: Block Linear Solvers Package
+//                  Copyright 2004 Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// ************************************************************************
+//@HEADER
+
+#include "BelosSolverFactory.hpp"
+#include "BelosSolverFactory_Tpetra.hpp"
+#include "BelosPseudoBlockCGSolMgr.hpp"
+#include "TpetraCore_ETIHelperMacros.h"
+#include "Teuchos_TypeNameTraits.hpp"
+#include <iostream>
+
+namespace BelosTpetra {
+namespace Impl {
+
+template<class SC, class LO, class GO, class NT>
+void register_PseudoBlockCG_tmpl (const bool verbose)
+{
+  using ::Belos::Impl::registerSolverSubclassForTypes;
+  using MV = ::Tpetra::MultiVector<SC, LO, GO, NT>;
+  using OP = ::Tpetra::Operator<SC, LO, GO, NT>;
+  using solver_type = ::Belos::PseudoBlockCGSolMgr<SC, MV, OP>;
+
+  if (verbose) {
+    using Teuchos::TypeNameTraits;
+    std::cout << "Registering BelosTpetra PseudoBlockCGSolMgr<"
+              << TypeNameTraits<SC>::name () << ", "
+              << TypeNameTraits<LO>::name () << ", "
+              << TypeNameTraits<GO>::name () << ", "
+              << TypeNameTraits<NT>::name () << ">" << std::endl;
+  }
+  const char solverName[] = "PSEUDOBLOCK CG";
+  registerSolverSubclassForTypes<solver_type, SC, MV, OP> (solverName);
+}
+
+void register_PseudoBlockCG (const bool verbose)
+{
+  TPETRA_ETI_MANGLING_TYPEDEFS()
+
+#ifdef BELOS_TPETRA_REGISTER_PSEUDOBLOCKCG
+#  undef BELOS_TPETRA_REGISTER_PSEUDOBLOCKCG
+#endif // BELOS_TPETRA_REGISTER_PSEUDOBLOCKCG
+#define BELOS_TPETRA_REGISTER_PSEUDOBLOCKCG( SC, LO, GO, NT ) register_PseudoBlockCG_tmpl<SC, LO, GO, NT> (verbose);
+
+  TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR( BELOS_TPETRA_REGISTER_PSEUDOBLOCKCG )
+
+#undef BELOS_TPETRA_REGISTER_PSEUDOBLOCKCG
+}
+
+} // namespace Impl
+} // namespace BelosTpetra

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_PseudoBlockGmres.cpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_PseudoBlockGmres.cpp
@@ -1,0 +1,85 @@
+//@HEADER
+// ************************************************************************
+//
+//                 Belos: Block Linear Solvers Package
+//                  Copyright 2004 Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// ************************************************************************
+//@HEADER
+
+#include "BelosSolverFactory.hpp"
+#include "BelosSolverFactory_Tpetra.hpp"
+#include "BelosPseudoBlockGmresSolMgr.hpp"
+#include "TpetraCore_ETIHelperMacros.h"
+#include "Teuchos_TypeNameTraits.hpp"
+#include <iostream>
+
+namespace BelosTpetra {
+namespace Impl {
+
+template<class SC, class LO, class GO, class NT>
+void register_PseudoBlockGmres_tmpl (const bool verbose)
+{
+  using ::Belos::Impl::registerSolverSubclassForTypes;
+  using MV = ::Tpetra::MultiVector<SC, LO, GO, NT>;
+  using OP = ::Tpetra::Operator<SC, LO, GO, NT>;
+  using solver_type = ::Belos::PseudoBlockGmresSolMgr<SC, MV, OP>;
+
+  if (verbose) {
+    using Teuchos::TypeNameTraits;
+    std::cout << "Registering BelosTpetra PseudoBlockGmresSolMgr<"
+              << TypeNameTraits<SC>::name () << ", "
+              << TypeNameTraits<LO>::name () << ", "
+              << TypeNameTraits<GO>::name () << ", "
+              << TypeNameTraits<NT>::name () << ">" << std::endl;
+  }
+  const char solverName[] = "PSEUDOBLOCK GMRES";
+  registerSolverSubclassForTypes<solver_type, SC, MV, OP> (solverName);
+}
+
+void register_PseudoBlockGmres (const bool verbose)
+{
+  TPETRA_ETI_MANGLING_TYPEDEFS()
+
+#ifdef BELOS_TPETRA_REGISTER_PSEUDOBLOCKGMRES
+#  undef BELOS_TPETRA_REGISTER_PSEUDOBLOCKGMRES
+#endif // BELOS_TPETRA_REGISTER_PSEUDOBLOCKGMRES
+#define BELOS_TPETRA_REGISTER_PSEUDOBLOCKGMRES( SC, LO, GO, NT ) register_PseudoBlockGmres_tmpl<SC, LO, GO, NT> (verbose);
+
+  TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR( BELOS_TPETRA_REGISTER_PSEUDOBLOCKGMRES )
+
+#undef BELOS_TPETRA_REGISTER_PSEUDOBLOCKGMRES
+}
+
+} // namespace Impl
+} // namespace BelosTpetra

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_PseudoBlockTFQMR.cpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_PseudoBlockTFQMR.cpp
@@ -1,0 +1,85 @@
+//@HEADER
+// ************************************************************************
+//
+//                 Belos: Block Linear Solvers Package
+//                  Copyright 2004 Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// ************************************************************************
+//@HEADER
+
+#include "BelosSolverFactory.hpp"
+#include "BelosSolverFactory_Tpetra.hpp"
+#include "BelosPseudoBlockTFQMRSolMgr.hpp"
+#include "TpetraCore_ETIHelperMacros.h"
+#include "Teuchos_TypeNameTraits.hpp"
+#include <iostream>
+
+namespace BelosTpetra {
+namespace Impl {
+
+template<class SC, class LO, class GO, class NT>
+void register_PseudoBlockTFQMR_tmpl (const bool verbose)
+{
+  using ::Belos::Impl::registerSolverSubclassForTypes;
+  using MV = ::Tpetra::MultiVector<SC, LO, GO, NT>;
+  using OP = ::Tpetra::Operator<SC, LO, GO, NT>;
+  using solver_type = ::Belos::PseudoBlockTFQMRSolMgr<SC, MV, OP>;
+
+  if (verbose) {
+    using Teuchos::TypeNameTraits;
+    std::cout << "Registering BelosTpetra PseudoBlockTFQMRSolMgr<"
+              << TypeNameTraits<SC>::name () << ", "
+              << TypeNameTraits<LO>::name () << ", "
+              << TypeNameTraits<GO>::name () << ", "
+              << TypeNameTraits<NT>::name () << ">" << std::endl;
+  }
+  const char solverName[] = "PSEUDOBLOCK TFQMR";
+  registerSolverSubclassForTypes<solver_type, SC, MV, OP> (solverName);
+}
+
+void register_PseudoBlockTFQMR (const bool verbose)
+{
+  TPETRA_ETI_MANGLING_TYPEDEFS()
+
+#ifdef BELOS_TPETRA_REGISTER_PSEUDOBLOCKTFQMR
+#  undef BELOS_TPETRA_REGISTER_PSEUDOBLOCKTFQMR
+#endif // BELOS_TPETRA_REGISTER_PSEUDOBLOCKTFQMR
+#define BELOS_TPETRA_REGISTER_PSEUDOBLOCKTFQMR( SC, LO, GO, NT ) register_PseudoBlockTFQMR_tmpl<SC, LO, GO, NT> (verbose);
+
+  TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR( BELOS_TPETRA_REGISTER_PSEUDOBLOCKTFQMR )
+
+#undef BELOS_TPETRA_REGISTER_PSEUDOBLOCKTFQMR
+}
+
+} // namespace Impl
+} // namespace BelosTpetra

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_RCG.cpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_RCG.cpp
@@ -1,0 +1,85 @@
+//@HEADER
+// ************************************************************************
+//
+//                 Belos: Block Linear Solvers Package
+//                  Copyright 2004 Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// ************************************************************************
+//@HEADER
+
+#include "BelosSolverFactory.hpp"
+#include "BelosSolverFactory_Tpetra.hpp"
+#include "BelosRCGSolMgr.hpp"
+#include "TpetraCore_ETIHelperMacros.h"
+#include "Teuchos_TypeNameTraits.hpp"
+#include <iostream>
+
+namespace BelosTpetra {
+namespace Impl {
+
+template<class SC, class LO, class GO, class NT>
+void register_RCG_tmpl (const bool verbose)
+{
+  using ::Belos::Impl::registerSolverSubclassForTypes;
+  using MV = ::Tpetra::MultiVector<SC, LO, GO, NT>;
+  using OP = ::Tpetra::Operator<SC, LO, GO, NT>;
+  using solver_type = ::Belos::RCGSolMgr<SC, MV, OP>;
+
+  if (verbose) {
+    using Teuchos::TypeNameTraits;
+    std::cout << "Registering BelosTpetra RCGSolMgr<"
+              << TypeNameTraits<SC>::name () << ", "
+              << TypeNameTraits<LO>::name () << ", "
+              << TypeNameTraits<GO>::name () << ", "
+              << TypeNameTraits<NT>::name () << ">" << std::endl;
+  }
+  const char solverName[] = "RCG";
+  registerSolverSubclassForTypes<solver_type, SC, MV, OP> (solverName);
+}
+
+void register_RCG (const bool verbose)
+{
+  TPETRA_ETI_MANGLING_TYPEDEFS()
+
+#ifdef BELOS_TPETRA_REGISTER_RCG
+#  undef BELOS_TPETRA_REGISTER_RCG
+#endif // BELOS_TPETRA_REGISTER_RCG
+#define BELOS_TPETRA_REGISTER_RCG( SC, LO, GO, NT ) register_RCG_tmpl<SC, LO, GO, NT> (verbose);
+
+  TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR( BELOS_TPETRA_REGISTER_RCG )
+
+#undef BELOS_TPETRA_REGISTER_RCG
+}
+
+} // namespace Impl
+} // namespace BelosTpetra

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_TFQMR.cpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_TFQMR.cpp
@@ -1,0 +1,85 @@
+//@HEADER
+// ************************************************************************
+//
+//                 Belos: Block Linear Solvers Package
+//                  Copyright 2004 Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// ************************************************************************
+//@HEADER
+
+#include "BelosSolverFactory.hpp"
+#include "BelosSolverFactory_Tpetra.hpp"
+#include "BelosTFQMRSolMgr.hpp"
+#include "TpetraCore_ETIHelperMacros.h"
+#include "Teuchos_TypeNameTraits.hpp"
+#include <iostream>
+
+namespace BelosTpetra {
+namespace Impl {
+
+template<class SC, class LO, class GO, class NT>
+void register_TFQMR_tmpl (const bool verbose)
+{
+  using ::Belos::Impl::registerSolverSubclassForTypes;
+  using MV = ::Tpetra::MultiVector<SC, LO, GO, NT>;
+  using OP = ::Tpetra::Operator<SC, LO, GO, NT>;
+  using solver_type = ::Belos::TFQMRSolMgr<SC, MV, OP>;
+
+  if (verbose) {
+    using Teuchos::TypeNameTraits;
+    std::cout << "Registering BelosTpetra TFQMRSolMgr<"
+              << TypeNameTraits<SC>::name () << ", "
+              << TypeNameTraits<LO>::name () << ", "
+              << TypeNameTraits<GO>::name () << ", "
+              << TypeNameTraits<NT>::name () << ">" << std::endl;
+  }
+  const char solverName[] = "TFQMR";
+  registerSolverSubclassForTypes<solver_type, SC, MV, OP> (solverName);
+}
+
+void register_TFQMR (const bool verbose)
+{
+  TPETRA_ETI_MANGLING_TYPEDEFS()
+
+#ifdef BELOS_TPETRA_REGISTER_TFQMR
+#  undef BELOS_TPETRA_REGISTER_TFQMR
+#endif // BELOS_TPETRA_REGISTER_TFQMR
+#define BELOS_TPETRA_REGISTER_TFQMR( SC, LO, GO, NT ) register_TFQMR_tmpl<SC, LO, GO, NT> (verbose);
+
+  TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR( BELOS_TPETRA_REGISTER_TFQMR )
+
+#undef BELOS_TPETRA_REGISTER_TFQMR
+}
+
+} // namespace Impl
+} // namespace BelosTpetra


### PR DESCRIPTION
@trilinos/belos 

## Description

Break out Belos::SolverFactory Tpetra solver registration into separate files, to improve build time for Sierra building Trilinos.

## Related Issues

* Closes #5904 