### PR TITLE
MueLu: refactor phase2 aggregation

### DIFF
--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase1Algorithm_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase1Algorithm_kokkos_def.hpp
@@ -75,7 +75,6 @@ namespace MueLu {
                   Aggregates_kokkos& aggregates,
                   Kokkos::View<unsigned*, typename LWGraph_kokkos::memory_space>& aggStat,
                   LO& numNonAggregatedNodes) const {
-    Monitor m(*this, "BuildAggregates");
 
     using memory_space = typename LWGraph_kokkos::memory_space;
 
@@ -102,15 +101,18 @@ namespace MueLu {
     {
       if(params.get<bool>("aggregation: deterministic"))
       {
+        Monitor m(*this, "BuildAggregatesDeterministic");
         BuildAggregatesDeterministic(maxNodesPerAggregate, graph,
                                      aggregates, aggStat, numNonAggregatedNodes);
       } else {
+        Monitor m(*this, "BuildAggregatesRandom");
         BuildAggregatesDistance2(maxNodesPerAggregate, graph,
                                  aggregates, aggStat, numNonAggregatedNodes);
       }
     }
     else
     {
+      Monitor m(*this, "BuildAggregatesSerial");
       typename Kokkos::View<unsigned*, memory_space>::HostMirror aggStatHost
         = Kokkos::create_mirror(aggStat);
       Kokkos::deep_copy(aggStatHost, aggStat);

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2aAlgorithm_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2aAlgorithm_kokkos_decl.hpp
@@ -114,6 +114,18 @@ namespace MueLu {
                          Aggregates_kokkos& aggregates,
                          Kokkos::View<unsigned*, memory_space>& aggStat,
                          LO& numNonAggregatedNodes) const;
+
+    void BuildAggregatesRandom(const Teuchos::ParameterList& params,
+                               const LWGraph_kokkos& graph,
+                               Aggregates_kokkos& aggregates,
+                               Kokkos::View<unsigned*, memory_space>& aggStat,
+                               LO& numNonAggregatedNodes) const;
+
+    void BuildAggregatesDeterministic(const Teuchos::ParameterList& params,
+                                      const LWGraph_kokkos& graph,
+                                      Aggregates_kokkos& aggregates,
+                                      Kokkos::View<unsigned*, memory_space>& aggStat,
+                                      LO& numNonAggregatedNodes) const;
     //@}
 
     std::string description() const { return "Phase 2a (secondary)"; }

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2aAlgorithm_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2aAlgorithm_kokkos_def.hpp
@@ -60,6 +60,8 @@
 #include "MueLu_LWGraph_kokkos.hpp"
 #include "MueLu_Monitor.hpp"
 
+#include "Kokkos_Sort.hpp"
+
 namespace MueLu {
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -71,25 +73,138 @@ namespace MueLu {
                   LO& numNonAggregatedNodes) const {
     Monitor m(*this, "BuildAggregates");
 
-    typename Kokkos::View<unsigned*, memory_space>::HostMirror aggstatHost
-      = Kokkos::create_mirror(aggstat);
-    Kokkos::deep_copy(aggstatHost, aggstat);
-    std::vector<unsigned> aggStat;
-    aggStat.resize(aggstatHost.extent(0));
-    for(size_t idx = 0; idx < aggstatHost.extent(0); ++idx) {
-      aggStat[idx] = aggstatHost(idx);
+    if(params.get<bool>("aggregation: deterministic")) {
+      std::cout << "Using deterministic Phase2a aggregation" << std::endl;
+      BuildAggregatesDeterministic(params, graph, aggregates, aggstat, numNonAggregatedNodes);
+    } else {
+      std::cout << "Using random Phase2a aggregation" << std::endl;
+      BuildAggregatesRandom(params, graph, aggregates, aggstat, numNonAggregatedNodes);
     }
 
-    int minNodesPerAggregate = params.get<int>("aggregation: min agg size");
-    int maxNodesPerAggregate = params.get<int>("aggregation: max agg size");
+  } // BuildAggregates
+
+  template <class LO, class GO, class Node>
+  void AggregationPhase2aAlgorithm_kokkos<LO, GO, Node>::
+  BuildAggregatesRandom(const ParameterList& params,
+                        const LWGraph_kokkos& graph,
+                        Aggregates_kokkos& aggregates,
+                        Kokkos::View<unsigned*, typename LWGraph_kokkos::memory_space>& aggStat,
+                        LO& numNonAggregatedNodes) const
+  {
+    using memory_space    = typename LWGraph_kokkos::memory_space;
+    using execution_space = typename LWGraph_kokkos::execution_space;
+
+    const int minNodesPerAggregate = params.get<int>("aggregation: min agg size");
+    const int maxNodesPerAggregate = params.get<int>("aggregation: max agg size");
 
     const LO  numRows = graph.GetNodeNumVertices();
     const int myRank  = graph.GetComm()->getRank();
 
-    ArrayRCP<LO> vertex2AggId = aggregates.GetVertex2AggId()->getDataNonConst(0);
-    ArrayRCP<LO> procWinner   = aggregates.GetProcWinner()  ->getDataNonConst(0);
+    auto vertex2AggId  = aggregates.GetVertex2AggId()->template getLocalView<memory_space>();
+    auto procWinner    = aggregates.GetProcWinner()  ->template getLocalView<memory_space>();
+    auto colors        = aggregates.GetGraphColors();
+    const LO numColors = aggregates.GetGraphNumColors();
 
-    LO numLocalAggregates = aggregates.GetNumAggregates();
+    LO numLocalNodes      = numRows;
+    LO numLocalAggregated = numLocalNodes - numNonAggregatedNodes;
+
+    const double aggFactor = 0.5;
+    double       factor    = static_cast<double>(numLocalAggregated)/(numLocalNodes+1);
+    factor = pow(factor, aggFactor);
+
+    // LBV on Sept 12, 2019: this looks a little heavy handed,
+    // I'm not sure a view is needed to perform atomic updates.
+    // If we can avoid this and use a simple LO that would be
+    // simpler for later maintenance.
+    Kokkos::View<LO, memory_space> numLocalAggregates("numLocalAggregates");
+    typename Kokkos::View<LO, memory_space>::HostMirror h_numLocalAggregates =
+      Kokkos::create_mirror_view(numLocalAggregates);
+    h_numLocalAggregates() = aggregates.GetNumAggregates();
+    Kokkos::deep_copy(numLocalAggregates, h_numLocalAggregates);
+
+    // Now we create new aggregates using root nodes in all colors other than the first color,
+    // as the first color was already exhausted in Phase 1.
+    for(int color = 2; color < numColors + 1; ++color) {
+      LO tmpNumNonAggregatedNodes = 0;
+      Kokkos::parallel_reduce("Aggregation Phase 2a: loop over each individual color",
+                              Kokkos::RangePolicy<execution_space>(0, numRows),
+                              KOKKOS_LAMBDA (const LO rootCandidate, LO& lNumNonAggregatedNodes) {
+                                if(aggStat(rootCandidate) == READY &&
+                                   colors(rootCandidate) == color) {
+
+                                  LO aggSize = 0;
+                                  auto neighbors = graph.getNeighborVertices(rootCandidate);
+
+                                  // Loop over neighbors to count how many nodes could join
+                                  // the new aggregate
+                                  LO numNeighbors = 0;
+                                  for(int j = 0; j < neighbors.length; ++j) {
+                                    LO neigh = neighbors(j);
+                                    if(neigh != rootCandidate) {
+                                      if(graph.isLocalNeighborVertex(neigh) &&
+                                         aggStat(neigh) == READY &&
+                                         aggSize < maxNodesPerAggregate) {
+                                        // aggList(aggSize) = neigh;
+                                        ++aggSize;
+                                      }
+                                      ++numNeighbors;
+                                    }
+                                  }
+
+                                  // If a sufficient number of nodes can join the new aggregate
+                                  // then we actually create the aggregate.
+                                  if(aggSize > minNodesPerAggregate &&
+                                     aggSize > factor*numNeighbors) {
+
+                                    // aggregates.SetIsRoot(rootCandidate);
+                                    LO aggIndex = Kokkos::
+                                      atomic_fetch_add(&numLocalAggregates(), 1);
+
+                                    for(int j = 0; j < neighbors.length; ++j) {
+                                      LO neigh = neighbors(j);
+                                      if(neigh != rootCandidate) {
+                                        if(graph.isLocalNeighborVertex(neigh) &&
+                                           aggStat(neigh) == READY &&
+                                           aggSize < maxNodesPerAggregate) {
+                                          aggStat(neigh)   = AGGREGATED;
+                                          vertex2AggId(neigh, 0) = aggIndex;
+                                          procWinner(neigh, 0)   = myRank;
+                                        }
+                                      }
+                                    }
+                                    lNumNonAggregatedNodes -= aggSize;
+                                  }
+                                }
+                              }, tmpNumNonAggregatedNodes);
+      numNonAggregatedNodes += tmpNumNonAggregatedNodes;
+    }
+
+    // update aggregate object
+    Kokkos::deep_copy(h_numLocalAggregates, numLocalAggregates);
+    aggregates.SetNumAggregates(h_numLocalAggregates());
+  } // BuildAggregatesRandom
+
+  template <class LO, class GO, class Node>
+  void AggregationPhase2aAlgorithm_kokkos<LO, GO, Node>::
+  BuildAggregatesDeterministic(const ParameterList& params,
+                               const LWGraph_kokkos& graph,
+                               Aggregates_kokkos& aggregates,
+                               Kokkos::View<unsigned*, typename LWGraph_kokkos::memory_space>& aggStat,
+                               LO& numNonAggregatedNodes) const
+  {
+    using memory_space    = typename LWGraph_kokkos::memory_space;
+    using execution_space = typename LWGraph_kokkos::execution_space;
+
+    const int minNodesPerAggregate = params.get<int>("aggregation: min agg size");
+    const int maxNodesPerAggregate = params.get<int>("aggregation: max agg size");
+
+    const LO  numRows = graph.GetNodeNumVertices();
+    const int myRank  = graph.GetComm()->getRank();
+
+    auto vertex2AggId  = aggregates.GetVertex2AggId()->template getLocalView<memory_space>();
+    auto procWinner    = aggregates.GetProcWinner()  ->template getLocalView<memory_space>();
+    auto colors        = aggregates.GetGraphColors();
+    const LO numColors = aggregates.GetGraphNumColors();
 
     LO numLocalNodes      = procWinner.size();
     LO numLocalAggregated = numLocalNodes - numNonAggregatedNodes;
@@ -98,62 +213,101 @@ namespace MueLu {
     double       factor    = as<double>(numLocalAggregated)/(numLocalNodes+1);
     factor = pow(factor, aggFactor);
 
-    int              aggIndex = -1;
-    size_t           aggSize  =  0;
-    std::vector<int> aggList(graph.getNodeMaxNumRowEntries());
+    Kokkos::View<LO, memory_space> numLocalAggregates("numLocalAggregates");
+    typename Kokkos::View<LO, memory_space>::HostMirror h_numLocalAggregates =
+      Kokkos::create_mirror_view(numLocalAggregates);
+    h_numLocalAggregates() = aggregates.GetNumAggregates();
+    Kokkos::deep_copy(numLocalAggregates, h_numLocalAggregates);
 
-    for (LO rootCandidate = 0; rootCandidate < numRows; rootCandidate++) {
-      if (aggStat[rootCandidate] != READY)
-        continue;
+    // Now we create new aggregates using root nodes in all colors other than the first color,
+    // as the first color was already exhausted in Phase 1.
+    //
+    // In the deterministic version, exactly the same set of aggregates will be created
+    // (as the nondeterministic version)
+    // because no vertex V can be a neighbor of two vertices of the same color, so two root
+    // candidates can't fight over V
+    //
+    // But, the precise values in vertex2AggId need to match exactly, so just sort the new
+    // roots of each color before assigning aggregate IDs
 
-      aggSize = 0;
+    //numNonAggregatedNodes is the best available upper bound for the number of aggregates
+    //which may be created in this phase, so use it for the size of newRoots
+    Kokkos::View<LO*, memory_space> newRoots("New root LIDs", numNonAggregatedNodes);
+    Kokkos::View<LO, memory_space> numNewRoots("Number of new aggregates of current color");
+    auto h_numNewRoots = Kokkos::create_mirror_view(numNewRoots);
+    for(int color = 1; color < numColors + 1; ++color) {
+      h_numNewRoots() = 0;
+      Kokkos::deep_copy(numNewRoots, h_numNewRoots);
+      Kokkos::parallel_for("Aggregation Phase 2a: determining new roots of current color",
+                           Kokkos::RangePolicy<execution_space>(0, numRows),
+                           KOKKOS_LAMBDA(const LO rootCandidate) {
+                             if(aggStat(rootCandidate) == READY &&
+                                colors(rootCandidate) == color) {
+                               LO aggSize = 0;
+                               auto neighbors = graph.getNeighborVertices(rootCandidate);
+                               // Loop over neighbors to count how many nodes could join
+                               // the new aggregate
+                               LO numNeighbors = 0;
+                               for(int j = 0; j < neighbors.length; ++j) {
+                                 LO neigh = neighbors(j);
+                                 if(neigh != rootCandidate)
+                                   {
+                                     if(graph.isLocalNeighborVertex(neigh) &&
+                                        aggStat(neigh) == READY &&
+                                        aggSize < maxNodesPerAggregate)
+                                       {
+                                         ++aggSize;
+                                       }
+                                     ++numNeighbors;
+                                   }
+                               }
+                               // If a sufficient number of nodes can join the new aggregate
+                               // then we mark rootCandidate as a future root.
+                               if(aggSize > minNodesPerAggregate && aggSize > factor*numNeighbors) {
+                                 LO newRootIndex = Kokkos::atomic_fetch_add(&numNewRoots(), 1);
+                                 newRoots(newRootIndex) = rootCandidate;
+                               }
+                             }
+                           });
+      Kokkos::deep_copy(h_numNewRoots, numNewRoots);
 
-      auto neighOfINode = graph.getNeighborVertices(rootCandidate);
-
-      LO numNeighbors = 0;
-      for (int j = 0; j < as<int>(neighOfINode.length); j++) {
-        LO neigh = neighOfINode(j);
-
-        if (neigh != rootCandidate) {
-          if (graph.isLocalNeighborVertex(neigh) && aggStat[neigh] == READY) {
-            // If aggregate size does not exceed max size, add node to the tentative aggregate
-            // NOTE: We do not exit the loop over all neighbours since we have still
-            //       to count all aggregated neighbour nodes for the aggregation criteria
-            // NOTE: We check here for the maximum aggregation size. If we would do it below
-            //       with all the other check too big aggregates would not be accepted at all.
-            if (aggSize < as<size_t>(maxNodesPerAggregate))
-              aggList[aggSize++] = neigh;
-          }
-
-          numNeighbors++;
-        }
-      }
-
-      // NOTE: ML uses a hardcoded value 3 instead of MinNodesPerAggregate
-      if (aggSize > as<size_t>(minNodesPerAggregate) &&
-          aggSize > factor*numNeighbors) {
-        // Accept new aggregate
-        // rootCandidate becomes the root of the newly formed aggregate
-        aggregates.SetIsRoot(rootCandidate);
-        aggIndex = numLocalAggregates++;
-
-        for (size_t k = 0; k < aggSize; k++) {
-          aggStat     [aggList[k]] = AGGREGATED;
-          vertex2AggId[aggList[k]] = aggIndex;
-          procWinner  [aggList[k]] = myRank;
-        }
-
-        numNonAggregatedNodes -= aggSize;
+      if(h_numNewRoots() > 0) {
+        //sort the new root indices
+        Kokkos::sort(newRoots, 0, h_numNewRoots());
+        //now, loop over all new roots again and actually create the aggregates
+        LO tmpNumNonAggregatedNodes = 0;
+        //First, just find the set of color vertices which will become aggregate roots
+        Kokkos::parallel_reduce("Aggregation Phase 2a: create new aggregates",
+                                Kokkos::RangePolicy<execution_space>(0, h_numNewRoots()),
+                                KOKKOS_LAMBDA (const LO newRootIndex, LO& lNumNonAggregatedNodes) {
+                                  LO root = newRoots(newRootIndex);
+                                  LO newAggID = numLocalAggregates() + newRootIndex;
+                                  auto neighbors = graph.getNeighborVertices(root);
+                                  // Loop over neighbors and add them to new aggregate
+                                  aggStat(root)      = AGGREGATED;
+                                  vertex2AggId(root, 0) = newAggID;
+                                  LO aggSize = 1;
+                                  for(int j = 0; j < neighbors.length; ++j) {
+                                    LO neigh = neighbors(j);
+                                    if(neigh != root) {
+                                      if(graph.isLocalNeighborVertex(neigh) &&
+                                         aggStat(neigh) == READY &&
+                                         aggSize < maxNodesPerAggregate) {
+                                        aggStat(neigh)      = AGGREGATED;
+                                        vertex2AggId(neigh, 0) = newAggID;
+                                        procWinner(neigh, 0)   = myRank;
+                                        aggSize++;
+                                      }
+                                    }
+                                  }
+                                  lNumNonAggregatedNodes -= aggSize;
+                                }, tmpNumNonAggregatedNodes);
+        numNonAggregatedNodes += tmpNumNonAggregatedNodes;
+        h_numLocalAggregates() += h_numNewRoots();
+        Kokkos::deep_copy(numLocalAggregates, h_numLocalAggregates);
       }
     }
-
-    for(size_t idx = 0; idx < aggstatHost.extent(0); ++idx) {
-      aggstatHost(idx) = aggStat[idx];
-    }
-    Kokkos::deep_copy(aggstat, aggstatHost);
-
-    // update aggregate object
-    aggregates.SetNumAggregates(numLocalAggregates);
+    aggregates.SetNumAggregates(h_numLocalAggregates());
   }
 
 } // end namespace

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2aAlgorithm_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2aAlgorithm_kokkos_def.hpp
@@ -69,16 +69,15 @@ namespace MueLu {
   BuildAggregates(const ParameterList& params,
                   const LWGraph_kokkos& graph,
                   Aggregates_kokkos& aggregates,
-                  Kokkos::View<unsigned*, typename LWGraph_kokkos::memory_space>& aggstat,
+                  Kokkos::View<unsigned*, typename LWGraph_kokkos::memory_space>& aggStat,
                   LO& numNonAggregatedNodes) const {
-    Monitor m(*this, "BuildAggregates");
 
     if(params.get<bool>("aggregation: deterministic")) {
-      std::cout << "Using deterministic Phase2a aggregation" << std::endl;
-      BuildAggregatesDeterministic(params, graph, aggregates, aggstat, numNonAggregatedNodes);
+      Monitor m(*this, "BuildAggregatesDeterministic");
+      BuildAggregatesDeterministic(params, graph, aggregates, aggStat, numNonAggregatedNodes);
     } else {
-      std::cout << "Using random Phase2a aggregation" << std::endl;
-      BuildAggregatesRandom(params, graph, aggregates, aggstat, numNonAggregatedNodes);
+      Monitor m(*this, "BuildAggregatesRandom");
+      BuildAggregatesRandom(params, graph, aggregates, aggStat, numNonAggregatedNodes);
     }
 
   } // BuildAggregates

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2bAlgorithm_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2bAlgorithm_kokkos_decl.hpp
@@ -111,6 +111,18 @@ namespace MueLu {
                          Aggregates_kokkos& aggregates,
                          Kokkos::View<unsigned*, typename LWGraph_kokkos::memory_space>& aggStat,
                          LO& numNonAggregatedNodes) const;
+
+    void BuildAggregatesRandom(const ParameterList& params,
+                               const LWGraph_kokkos& graph,
+                               Aggregates_kokkos& aggregates,
+                               Kokkos::View<unsigned*, typename LWGraph_kokkos::memory_space>& aggStat,
+                               LO& numNonAggregatedNodes) const;
+
+    void BuildAggregatesDeterministic(const ParameterList& params,
+                                      const LWGraph_kokkos& graph,
+                                      Aggregates_kokkos& aggregates,
+                                      Kokkos::View<unsigned*, typename LWGraph_kokkos::memory_space>& aggStat,
+                                      LO& numNonAggregatedNodes) const;
     //@}
 
     std::string description() const { return "Phase 2b (expansion)"; }

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2bAlgorithm_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2bAlgorithm_kokkos_def.hpp
@@ -66,38 +66,154 @@ namespace MueLu {
   // not already too big
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   void AggregationPhase2bAlgorithm_kokkos<LocalOrdinal, GlobalOrdinal, Node>::
-  BuildAggregates(const ParameterList& /* params */,
+  BuildAggregates(const ParameterList& params,
                   const LWGraph_kokkos& graph,
                   Aggregates_kokkos& aggregates,
-                  Kokkos::View<unsigned*, typename LWGraph_kokkos::memory_space>& aggstat,
+                  Kokkos::View<unsigned*, typename LWGraph_kokkos::memory_space>& aggStat,
                   LO& numNonAggregatedNodes) const {
-    Monitor m(*this, "BuildAggregates");
 
-    using memory_space = typename LWGraph_kokkos::memory_space;
-
-    typename Kokkos::View<unsigned*, memory_space>::HostMirror aggstatHost
-      = Kokkos::create_mirror(aggstat);
-    Kokkos::deep_copy(aggstatHost, aggstat);
-    std::vector<unsigned> aggStat;
-    aggStat.resize(aggstatHost.extent(0));
-    for(size_t idx = 0; idx < aggstatHost.extent(0); ++idx) {
-      aggStat[idx] = aggstatHost(idx);
+    if(params.get<bool>("aggregation: deterministic")) {
+      Monitor m(*this, "BuildAggregatesDeterministic");
+      BuildAggregatesDeterministic(params, graph, aggregates, aggStat, numNonAggregatedNodes);
+    } else {
+      Monitor m(*this, "BuildAggregatesRandom");
+      BuildAggregatesRandom(params, graph, aggregates, aggStat, numNonAggregatedNodes);
     }
+
+  } // BuildAggregates
+
+  template <class LO, class GO, class Node>
+  void AggregationPhase2bAlgorithm_kokkos<LO, GO, Node>::
+  BuildAggregatesRandom(const ParameterList& params,
+                        const LWGraph_kokkos& graph,
+                        Aggregates_kokkos& aggregates,
+                        Kokkos::View<unsigned*, typename LWGraph_kokkos::memory_space>& aggStat,
+                        LO& numNonAggregatedNodes) const {
+    using memory_space    = typename LWGraph_kokkos::memory_space;
+    using execution_space = typename LWGraph_kokkos::execution_space;
 
     const LO  numRows = graph.GetNodeNumVertices();
     const int myRank  = graph.GetComm()->getRank();
 
-    ArrayRCP<LO> vertex2AggId = aggregates.GetVertex2AggId()->getDataNonConst(0);
-    ArrayRCP<LO> procWinner   = aggregates.GetProcWinner()  ->getDataNonConst(0);
+    auto vertex2AggId           = aggregates.GetVertex2AggId()->template getLocalView<memory_space>();
+    auto procWinner             = aggregates.GetProcWinner()  ->template getLocalView<memory_space>();
+    auto colors                 = aggregates.GetGraphColors();
+    const LO numColors          = aggregates.GetGraphNumColors();
+    const LO numLocalAggregates = aggregates.GetNumAggregates();
 
+    const LO defaultConnectWeight = 100;
+    const LO penaltyConnectWeight = 10;
+
+    Kokkos::View<LO*, memory_space> aggWeight    ("aggWeight",     numLocalAggregates);
+    Kokkos::View<LO*, memory_space> connectWeight("connectWeight", numRows);
+    Kokkos::View<LO*, memory_space> aggPenalties ("aggPenalties",  numLocalAggregates);
+
+    Kokkos::deep_copy(connectWeight, defaultConnectWeight);
+
+    // taw: by running the aggregation routine more than once there is a chance that also
+    // non-aggregated nodes with a node distance of two are added to existing aggregates.
+    // Assuming that the aggregate size is 3 in each direction running the algorithm only twice
+    // should be sufficient.
+    // lbv: If the prior phase of aggregation where run without specifying an aggregate size,
+    // the distance 2 coloring and phase 1 aggregation actually guarantee that only one iteration
+    // is needed to reach distance 2 neighbors.
+    int maxIters = 2;
+    int maxNodesPerAggregate = params.get<int>("aggregation: max agg size");
+    if(maxNodesPerAggregate == std::numeric_limits<int>::max()) {maxIters = 1;}
+    for (int iter = 0; iter < maxIters; ++iter) {
+      for(LO color = 1; color <= numColors; ++color) {
+        Kokkos::deep_copy(aggWeight, 0);
+
+        //the reduce counts how many nodes are aggregated by this phase,
+        //which will then be subtracted from numNonAggregatedNodes
+        LO numAggregated = 0;
+        Kokkos::parallel_reduce("Aggregation Phase 2b: aggregates expansion",
+                                Kokkos::RangePolicy<execution_space>(0, numRows),
+                                KOKKOS_LAMBDA (const LO i, LO& tmpNumAggregated) {
+                                  if (aggStat(i) != READY || colors(i) != color)
+                                    return;
+
+                                  auto neighOfINode = graph.getNeighborVertices(i);
+                                  for (int j = 0; j < neighOfINode.length; j++) {
+                                    LO neigh = neighOfINode(j);
+
+                                    // We don't check (neigh != i), as it is covered by checking
+                                    // (aggStat[neigh] == AGGREGATED)
+                                    if (graph.isLocalNeighborVertex(neigh) &&
+                                        aggStat(neigh) == AGGREGATED)
+                                      Kokkos::atomic_add(&aggWeight(vertex2AggId(neigh, 0), 0),
+                                                         connectWeight(neigh));
+                                  }
+
+                                  int bestScore   = -100000;
+                                  int bestAggId   = -1;
+                                  int bestConnect = -1;
+
+                                  for (int j = 0; j < neighOfINode.length; j++) {
+                                    LO neigh = neighOfINode(j);
+
+                                    if (graph.isLocalNeighborVertex(neigh) &&
+                                        aggStat(neigh) == AGGREGATED) {
+                                      auto aggId = vertex2AggId(neigh, 0);
+                                      int score = aggWeight(aggId) - aggPenalties(aggId);
+
+                                      if (score > bestScore) {
+                                        bestAggId   = aggId;
+                                        bestScore   = score;
+                                        bestConnect = connectWeight(neigh);
+
+                                      } else if (aggId == bestAggId &&
+                                                 connectWeight(neigh) > bestConnect) {
+                                        bestConnect = connectWeight(neigh);
+                                      }
+                                    }
+                                  }
+                                  if (bestScore >= 0) {
+                                    aggStat(i, 0)      = AGGREGATED;
+                                    vertex2AggId(i, 0) = bestAggId;
+                                    procWinner(i, 0)   = myRank;
+
+                                    Kokkos::atomic_add(&aggPenalties(bestAggId), 1);
+                                    connectWeight(i) = bestConnect - penaltyConnectWeight;
+                                    tmpNumAggregated++;
+                                  }
+                                }, numAggregated); //parallel_for
+        numNonAggregatedNodes -= numAggregated;
+      }
+    } // loop over maxIters
+
+  } // BuildAggregatesRandom
+
+
+
+  template <class LO, class GO, class Node>
+  void AggregationPhase2bAlgorithm_kokkos<LO, GO, Node>::
+  BuildAggregatesDeterministic(const ParameterList& params,
+                               const LWGraph_kokkos& graph,
+                               Aggregates_kokkos& aggregates,
+                               Kokkos::View<unsigned*, typename LWGraph_kokkos::memory_space>& aggStat,
+                               LO& numNonAggregatedNodes) const {
+    using memory_space    = typename LWGraph_kokkos::memory_space;
+    using execution_space = typename LWGraph_kokkos::execution_space;
+
+    const LO  numRows = graph.GetNodeNumVertices();
+    const int myRank  = graph.GetComm()->getRank();
+
+    auto vertex2AggId     = aggregates.GetVertex2AggId()->template getLocalView<memory_space>();
+    auto procWinner       = aggregates.GetProcWinner()  ->template getLocalView<memory_space>();
+    auto colors           = aggregates.GetGraphColors();
+    const LO numColors    = aggregates.GetGraphNumColors();
     LO numLocalAggregates = aggregates.GetNumAggregates();
 
     const int defaultConnectWeight = 100;
     const int penaltyConnectWeight = 10;
 
-    std::vector<int> aggWeight    (numLocalAggregates, 0);
-    std::vector<int> connectWeight(numRows, defaultConnectWeight);
-    std::vector<int> aggPenalties (numRows, 0);
+    Kokkos::View<int*, memory_space> connectWeight    ("connectWeight",     numRows);
+    Kokkos::View<int*, memory_space> aggWeight        ("aggWeight",         numLocalAggregates);
+    Kokkos::View<int*, memory_space> aggPenaltyUpdates("aggPenaltyUpdates", numLocalAggregates);
+    Kokkos::View<int*, memory_space> aggPenalties     ("aggPenalties",      numLocalAggregates);
+
+    Kokkos::deep_copy(connectWeight, defaultConnectWeight);
 
     // We do this cycle twice.
     // I don't know why, but ML does it too
@@ -105,65 +221,86 @@ namespace MueLu {
     // non-aggregated nodes with a node distance of two are added to existing aggregates.
     // Assuming that the aggregate size is 3 in each direction running the algorithm only twice
     // should be sufficient.
-    for (int k = 0; k < 2; k++) {
-      for (LO i = 0; i < numRows; i++) {
-        if (aggStat[i] != READY)
-          continue;
+    int maxIters = 2;
+    int maxNodesPerAggregate = params.get<int>("aggregation: max agg size");
+    if(maxNodesPerAggregate == std::numeric_limits<int>::max()) {maxIters = 1;}
+    for (int iter = 0; iter < maxIters; ++iter) {
+      for(LO color = 1; color <= numColors; color++) {
+        Kokkos::deep_copy(aggWeight, 0);
 
-        auto neighOfINode = graph.getNeighborVertices(i);
-
-        for (int j = 0; j < as<int>(neighOfINode.length); j++) {
-          LO neigh = neighOfINode(j);
-
-          // We don't check (neigh != i), as it is covered by checking (aggStat[neigh] == AGGREGATED)
-          if (graph.isLocalNeighborVertex(neigh) && aggStat[neigh] == AGGREGATED)
-            aggWeight[vertex2AggId[neigh]] += connectWeight[neigh];
-        }
-
-        int bestScore   = -100000;
-        int bestAggId   = -1;
-        int bestConnect = -1;
-
-        for (int j = 0; j < as<int>(neighOfINode.length); j++) {
-          LO neigh = neighOfINode(j);
-
-          if (graph.isLocalNeighborVertex(neigh) && aggStat[neigh] == AGGREGATED) {
-            int aggId = vertex2AggId[neigh];
-            int score = aggWeight[aggId] - aggPenalties[aggId];
-
-            if (score > bestScore) {
-              bestAggId   = aggId;
-              bestScore   = score;
-              bestConnect = connectWeight[neigh];
-
-            } else if (aggId == bestAggId && connectWeight[neigh] > bestConnect) {
-              bestConnect = connectWeight[neigh];
+        //the reduce counts how many nodes are aggregated by this phase,
+        //which will then be subtracted from numNonAggregatedNodes
+        LO numAggregated = 0;
+        Kokkos::parallel_for("Aggregation Phase 2b: updating agg weights",
+          Kokkos::RangePolicy<execution_space>(0, numRows),
+          KOKKOS_LAMBDA (const LO i)
+          {
+            if (aggStat(i) != READY || colors(i) != color)
+              return;
+            auto neighOfINode = graph.getNeighborVertices(i);
+            for (int j = 0; j < neighOfINode.length; j++) {
+              LO neigh = neighOfINode(j);
+              // We don't check (neigh != i), as it is covered by checking
+              // (aggStat[neigh] == AGGREGATED)
+              if (graph.isLocalNeighborVertex(neigh) &&
+                  aggStat(neigh) == AGGREGATED)
+              Kokkos::atomic_add(&aggWeight(vertex2AggId(neigh, 0), 0),
+                  connectWeight(neigh));
             }
+          });
+        execution_space().fence();
+        Kokkos::parallel_reduce("Aggregation Phase 2b: aggregates expansion",
+          Kokkos::RangePolicy<execution_space>(0, numRows),
+          KOKKOS_LAMBDA (const LO i, LO& tmpNumAggregated)
+          {
+            if (aggStat(i) != READY || colors(i) != color)
+              return;
+            int bestScore   = -100000;
+            int bestAggId   = -1;
+            int bestConnect = -1;
 
-            // Reset the weights for the next loop
-            aggWeight[aggId] = 0;
-          }
-        }
+            auto neighOfINode = graph.getNeighborVertices(i);
+            for (int j = 0; j < neighOfINode.length; j++) {
+              LO neigh = neighOfINode(j);
 
-        if (bestScore >= 0) {
-          aggStat     [i] = AGGREGATED;
-          vertex2AggId[i] = bestAggId;
-          procWinner  [i] = myRank;
+              if (graph.isLocalNeighborVertex(neigh) &&
+                  aggStat(neigh) == AGGREGATED) {
+                auto aggId = vertex2AggId(neigh, 0);
+                int score = aggWeight(aggId) - aggPenalties(aggId);
 
-          numNonAggregatedNodes--;
+                if (score > bestScore) {
+                  bestAggId   = aggId;
+                  bestScore   = score;
+                  bestConnect = connectWeight(neigh);
 
-          aggPenalties[bestAggId]++;
-          connectWeight[i] = bestConnect - penaltyConnectWeight;
-        }
+                } else if (aggId == bestAggId &&
+                    connectWeight(neigh) > bestConnect) {
+                  bestConnect = connectWeight(neigh);
+                }
+              }
+            }
+            if (bestScore >= 0) {
+              aggStat(i)         = AGGREGATED;
+              vertex2AggId(i, 0) = bestAggId;
+              procWinner(i, 0)   = myRank;
+
+              Kokkos::atomic_add(&aggPenaltyUpdates(bestAggId), 1);
+              connectWeight(i) = bestConnect - penaltyConnectWeight;
+              tmpNumAggregated++;
+            }
+          }, numAggregated); //parallel_reduce
+        execution_space().fence();
+        Kokkos::parallel_for("Aggregation Phase 2b: updating agg penalties",
+          Kokkos::RangePolicy<execution_space>(0, numLocalAggregates),
+          KOKKOS_LAMBDA (const LO agg)
+          {
+            aggPenalties(agg) += aggPenaltyUpdates(agg);
+            aggPenaltyUpdates(agg) = 0;
+          });
+        numNonAggregatedNodes -= numAggregated;
       }
-    }
-
-    for(size_t idx = 0; idx < aggstatHost.extent(0); ++idx) {
-      aggstatHost(idx) = aggStat[idx];
-    }
-    Kokkos::deep_copy(aggstat, aggstatHost);
-  }
-
+    } // loop over k
+  } // BuildAggregatesDeterministic
 } // end namespace
 
 #endif // HAVE_MUELU_KOKKOS_REFACTOR

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_UncoupledAggregationFactory_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_UncoupledAggregationFactory_kokkos_def.hpp
@@ -230,8 +230,7 @@ namespace MueLu {
     if (IsPrint(Statistics1))
       MueLu_sumAll(comm, as<GO>(numRows), numGlobalRows);
 
-    std::string algoParamName = "aggregation: phase 1 algorithm";
-    if(pL.isParameter(algoParamName) && pL.get<std::string>(algoParamName) == "Distance2") {
+    {
       SubFactoryMonitor sfm(*this, "Algo \"Graph Coloring\"", currentLevel);
 
       // LBV on Sept 06 2019: the note below is a little worrisome,

--- a/packages/muelu/test/interface/CreateOperator.cpp
+++ b/packages/muelu/test/interface/CreateOperator.cpp
@@ -364,6 +364,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib lib, int arg
       mueluList.set("verbosity",                           "test");
       mueluList.set("coarse: max size",                    100);
       mueluList.set("use kokkos refactor",                 useKokkos);
+      mueluList.set("aggregation: deterministic",          useKokkos);
 
       ParameterListInterpreter mueLuFactory(mueluList);
       RCP<Hierarchy> H = mueLuFactory.CreateHierarchy();
@@ -408,6 +409,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib lib, int arg
       mueluList.set("verbosity",          "test");
       mueluList.set("coarse: max size",   100);
       mueluList.set("use kokkos refactor", useKokkos);
+      mueluList.set("aggregation: deterministic", useKokkos);
       ParameterList& level0 = mueluList.sublist("level 0");
       level0.set("Coordinates", coordinates0);
       ParameterList& level1 = mueluList.sublist("level 1");
@@ -439,6 +441,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib lib, int arg
       mueluList.set("max levels",                 4);
       mueluList.set("coarse: max size",           100);
       mueluList.set("use kokkos refactor", useKokkos);
+      mueluList.set("aggregation: deterministic", useKokkos);
       ParameterList& level0 = mueluList.sublist("level 0");
       level0.set("Coordinates", coordinates0);
       ParameterList& level1 = mueluList.sublist("level 1");
@@ -469,6 +472,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib lib, int arg
       mueluList.set("transpose: use implicit",    true);
       mueluList.set("max levels",                 2);
       mueluList.set("use kokkos refactor", useKokkos);
+      mueluList.set("aggregation: deterministic", useKokkos);
       ParameterList& level0 = mueluList.sublist("level 0");
       level0.set("Coordinates", coordinates0);
       ParameterList& level1 = mueluList.sublist("level 1");

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse1_tpetra.gold
@@ -38,9 +38,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -123,9 +123,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -211,9 +211,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse2_tpetra.gold
@@ -38,9 +38,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -123,9 +123,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -211,9 +211,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -299,9 +299,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -387,9 +387,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse3_tpetra.gold
@@ -38,9 +38,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -123,9 +123,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -211,9 +211,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -299,9 +299,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse5_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse5_tpetra.gold
@@ -38,9 +38,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -123,9 +123,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLpgamg1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLpgamg1_tpetra.gold
@@ -38,9 +38,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -125,9 +125,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -215,9 +215,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -305,9 +305,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother1_tpetra.gold
@@ -38,9 +38,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -123,9 +123,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -211,9 +211,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -299,9 +299,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother2_tpetra.gold
@@ -38,9 +38,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -123,9 +123,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -211,9 +211,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -299,9 +299,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother3_tpetra.gold
@@ -38,9 +38,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -123,9 +123,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -211,9 +211,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -299,9 +299,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother4_tpetra.gold
@@ -38,9 +38,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -123,9 +123,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -211,9 +211,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -299,9 +299,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLunsmoothed1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLunsmoothed1_tpetra.gold
@@ -37,9 +37,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -115,9 +115,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -196,9 +196,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -277,9 +277,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]

--- a/packages/muelu/test/interface/kokkos-complex/Output/aggregation1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/aggregation1_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -124,9 +124,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/aggregation3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/aggregation3_tpetra.gold
@@ -38,9 +38,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -126,9 +126,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/aggregation4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/aggregation4_tpetra.gold
@@ -38,9 +38,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -133,9 +133,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/coarse1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/coarse1_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -124,9 +124,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -211,9 +211,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/coarse2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/coarse2_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -124,9 +124,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -211,9 +211,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -298,9 +298,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -385,9 +385,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/coarse3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/coarse3_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -124,9 +124,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/default_e3d_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/default_e3d_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -124,9 +124,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/default_mhd_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/default_mhd_np4_tpetra.gold
@@ -32,9 +32,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -104,9 +104,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/default_mhd_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/default_mhd_tpetra.gold
@@ -32,9 +32,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -104,9 +104,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/default_p2d_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/default_p2d_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -124,9 +124,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/default_p3d_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/default_p3d_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -124,9 +124,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/default_pg_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/default_pg_np4_tpetra.gold
@@ -37,9 +37,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -126,9 +126,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/default_pg_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/default_pg_tpetra.gold
@@ -37,9 +37,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -126,9 +126,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/driver_drekar1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/driver_drekar1_np4_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/driver_drekar1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/driver_drekar1_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -176,9 +176,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -312,9 +312,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/driver_drekar2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/driver_drekar2_np4_tpetra.gold
@@ -41,9 +41,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/driver_drekar2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/driver_drekar2_tpetra.gold
@@ -41,9 +41,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -178,9 +178,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -315,9 +315,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/emin1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/emin1_tpetra.gold
@@ -37,9 +37,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -134,9 +134,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/emin2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/emin2_tpetra.gold
@@ -37,9 +37,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -134,9 +134,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/emin3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/emin3_tpetra.gold
@@ -37,9 +37,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -134,9 +134,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/empty_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/empty_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -124,9 +124,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_1_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_1_np1_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesDeterministic (Phase 2a (secondary))
+BuildAggregatesDeterministic (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -47,7 +47,7 @@ aggregation: max selected neighbors = 0   [default]
 aggregation: ordering = natural   [default]
 aggregation: enable phase 1 = 1   [default]
 aggregation: phase 1 algorithm = Serial   [default]
-aggregation: deterministic = 0   [default]
+aggregation: deterministic = 1   [unused]
 aggregation: enable phase 2a = 1   [default]
 aggregation: enable phase 2b = 1   [default]
 aggregation: enable phase 3 = 1   [default]
@@ -124,9 +124,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesDeterministic (Phase 2a (secondary))
+BuildAggregatesDeterministic (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -134,7 +134,7 @@ aggregation: max selected neighbors = 0   [default]
 aggregation: ordering = natural   [default]
 aggregation: enable phase 1 = 1   [default]
 aggregation: phase 1 algorithm = Serial   [default]
-aggregation: deterministic = 0   [default]
+aggregation: deterministic = 1   [unused]
 aggregation: enable phase 2a = 1   [default]
 aggregation: enable phase 2b = 1   [default]
 aggregation: enable phase 3 = 1   [default]
@@ -211,9 +211,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesDeterministic (Phase 2a (secondary))
+BuildAggregatesDeterministic (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -221,7 +221,7 @@ aggregation: max selected neighbors = 0   [default]
 aggregation: ordering = natural   [default]
 aggregation: enable phase 1 = 1   [default]
 aggregation: phase 1 algorithm = Serial   [default]
-aggregation: deterministic = 0   [default]
+aggregation: deterministic = 1   [unused]
 aggregation: enable phase 2a = 1   [default]
 aggregation: enable phase 2b = 1   [default]
 aggregation: enable phase 3 = 1   [default]
@@ -283,14 +283,14 @@ Cycle type          = V
 level  rows   nnz    nnz/row  c ratio  procs
   0  10000  49600  4.96                  1  
   1  1700   14928  8.78     5.88         1  
-  2  192    1674   8.72     8.85         1  
-  3  24     190    7.92     8.00         1  
+  2  192    1682   8.76     8.85         1  
+  3  24     200    8.33     8.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 
 Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [1700, 1700], Global nnz: 14928}
 
-Smoother (level 2) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [192, 192], Global nnz: 1674}
+Smoother (level 2) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [192, 192], Global nnz: 1682}
 
 Smoother (level 3) pre  : <Direct> solver interface
 Smoother (level 3) post : no smoother

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_1_np4_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesDeterministic (Phase 2a (secondary))
+BuildAggregatesDeterministic (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -47,7 +47,7 @@ aggregation: max selected neighbors = 0   [default]
 aggregation: ordering = natural   [default]
 aggregation: enable phase 1 = 1   [default]
 aggregation: phase 1 algorithm = Serial   [default]
-aggregation: deterministic = 0   [default]
+aggregation: deterministic = 1   [unused]
 aggregation: enable phase 2a = 1   [default]
 aggregation: enable phase 2b = 1   [default]
 aggregation: enable phase 3 = 1   [default]
@@ -124,9 +124,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesDeterministic (Phase 2a (secondary))
+BuildAggregatesDeterministic (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -134,7 +134,7 @@ aggregation: max selected neighbors = 0   [default]
 aggregation: ordering = natural   [default]
 aggregation: enable phase 1 = 1   [default]
 aggregation: phase 1 algorithm = Serial   [default]
-aggregation: deterministic = 0   [default]
+aggregation: deterministic = 1   [unused]
 aggregation: enable phase 2a = 1   [default]
 aggregation: enable phase 2b = 1   [default]
 aggregation: enable phase 3 = 1   [default]
@@ -211,9 +211,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesDeterministic (Phase 2a (secondary))
+BuildAggregatesDeterministic (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -221,7 +221,7 @@ aggregation: max selected neighbors = 0   [default]
 aggregation: ordering = natural   [default]
 aggregation: enable phase 1 = 1   [default]
 aggregation: phase 1 algorithm = Serial   [default]
-aggregation: deterministic = 0   [default]
+aggregation: deterministic = 1   [unused]
 aggregation: enable phase 2a = 1   [default]
 aggregation: enable phase 2b = 1   [default]
 aggregation: enable phase 3 = 1   [default]
@@ -283,14 +283,14 @@ Cycle type          = V
 level  rows   nnz    nnz/row  c ratio  procs
   0  10000  49600  4.96                  4  
   1  1700   15318  9.01     5.88         4  
-  2  216    2150   9.95     7.87         4  
-  3  32     434    13.56    6.75         4  
+  2  216    2158   9.99     7.87         4  
+  3  32     446    13.94    6.75         4  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 
 Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [1700, 1700], Global nnz: 15318}
 
-Smoother (level 2) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [216, 216], Global nnz: 2150}
+Smoother (level 2) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [216, 216], Global nnz: 2158}
 
 Smoother (level 3) pre  : <Direct> solver interface
 Smoother (level 3) post : no smoother

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_5_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_5_np1_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesDeterministic (Phase 2a (secondary))
+BuildAggregatesDeterministic (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -47,7 +47,7 @@ aggregation: max selected neighbors = 0   [default]
 aggregation: ordering = natural   [default]
 aggregation: enable phase 1 = 1   [default]
 aggregation: phase 1 algorithm = Serial   [default]
-aggregation: deterministic = 0   [default]
+aggregation: deterministic = 1   [unused]
 aggregation: enable phase 2a = 1   [default]
 aggregation: enable phase 2b = 1   [default]
 aggregation: enable phase 3 = 1   [default]
@@ -124,9 +124,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesDeterministic (Phase 2a (secondary))
+BuildAggregatesDeterministic (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -134,7 +134,7 @@ aggregation: max selected neighbors = 0   [default]
 aggregation: ordering = natural   [default]
 aggregation: enable phase 1 = 1   [default]
 aggregation: phase 1 algorithm = Serial   [default]
-aggregation: deterministic = 0   [default]
+aggregation: deterministic = 1   [unused]
 aggregation: enable phase 2a = 1   [default]
 aggregation: enable phase 2b = 1   [default]
 aggregation: enable phase 3 = 1   [default]
@@ -208,9 +208,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesDeterministic (Phase 2a (secondary))
+BuildAggregatesDeterministic (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -218,7 +218,7 @@ aggregation: max selected neighbors = 0   [default]
 aggregation: ordering = natural   [default]
 aggregation: enable phase 1 = 1   [default]
 aggregation: phase 1 algorithm = Serial   [default]
-aggregation: deterministic = 0   [default]
+aggregation: deterministic = 1   [unused]
 aggregation: enable phase 2a = 1   [default]
 aggregation: enable phase 2b = 1   [default]
 aggregation: enable phase 3 = 1   [default]
@@ -280,14 +280,14 @@ Cycle type          = V
 level  rows   nnz    nnz/row  c ratio  procs
   0  10000  49600  4.96                  1  
   1  1700   14928  8.78     5.88         1  
-  2  192    1674   8.72     8.85         1  
-  3  24     190    7.92     8.00         1  
+  2  192    1682   8.76     8.85         1  
+  3  24     200    8.33     8.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 
 Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [1700, 1700], Global nnz: 14928}
 
-Smoother (level 2) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [192, 192], Global nnz: 1674}
+Smoother (level 2) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [192, 192], Global nnz: 1682}
 
 Smoother (level 3) pre  : <Direct> solver interface
 Smoother (level 3) post : no smoother

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_5_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_5_np4_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesDeterministic (Phase 2a (secondary))
+BuildAggregatesDeterministic (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -47,7 +47,7 @@ aggregation: max selected neighbors = 0   [default]
 aggregation: ordering = natural   [default]
 aggregation: enable phase 1 = 1   [default]
 aggregation: phase 1 algorithm = Serial   [default]
-aggregation: deterministic = 0   [default]
+aggregation: deterministic = 1   [unused]
 aggregation: enable phase 2a = 1   [default]
 aggregation: enable phase 2b = 1   [default]
 aggregation: enable phase 3 = 1   [default]
@@ -124,9 +124,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesDeterministic (Phase 2a (secondary))
+BuildAggregatesDeterministic (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -134,7 +134,7 @@ aggregation: max selected neighbors = 0   [default]
 aggregation: ordering = natural   [default]
 aggregation: enable phase 1 = 1   [default]
 aggregation: phase 1 algorithm = Serial   [default]
-aggregation: deterministic = 0   [default]
+aggregation: deterministic = 1   [unused]
 aggregation: enable phase 2a = 1   [default]
 aggregation: enable phase 2b = 1   [default]
 aggregation: enable phase 3 = 1   [default]
@@ -208,9 +208,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesDeterministic (Phase 2a (secondary))
+BuildAggregatesDeterministic (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -218,7 +218,7 @@ aggregation: max selected neighbors = 0   [default]
 aggregation: ordering = natural   [default]
 aggregation: enable phase 1 = 1   [default]
 aggregation: phase 1 algorithm = Serial   [default]
-aggregation: deterministic = 0   [default]
+aggregation: deterministic = 1   [unused]
 aggregation: enable phase 2a = 1   [default]
 aggregation: enable phase 2b = 1   [default]
 aggregation: enable phase 3 = 1   [default]
@@ -280,14 +280,14 @@ Cycle type          = V
 level  rows   nnz    nnz/row  c ratio  procs
   0  10000  49600  4.96                  4  
   1  1700   15318  9.01     5.88         4  
-  2  216    2150   9.95     7.87         4  
-  3  32     434    13.56    6.75         4  
+  2  216    2158   9.99     7.87         4  
+  3  32     446    13.94    6.75         4  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 
 Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [1700, 1700], Global nnz: 15318}
 
-Smoother (level 2) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [216, 216], Global nnz: 2150}
+Smoother (level 2) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [216, 216], Global nnz: 2158}
 
 Smoother (level 3) pre  : <Direct> solver interface
 Smoother (level 3) post : no smoother

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_6_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_6_np1_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesDeterministic (Phase 2a (secondary))
+BuildAggregatesDeterministic (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -47,7 +47,7 @@ aggregation: max selected neighbors = 0   [default]
 aggregation: ordering = natural   [default]
 aggregation: enable phase 1 = 1   [default]
 aggregation: phase 1 algorithm = Serial   [default]
-aggregation: deterministic = 0   [default]
+aggregation: deterministic = 1   [unused]
 aggregation: enable phase 2a = 1   [default]
 aggregation: enable phase 2b = 1   [default]
 aggregation: enable phase 3 = 1   [default]
@@ -124,9 +124,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesDeterministic (Phase 2a (secondary))
+BuildAggregatesDeterministic (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -134,7 +134,7 @@ aggregation: max selected neighbors = 0   [default]
 aggregation: ordering = natural   [default]
 aggregation: enable phase 1 = 1   [default]
 aggregation: phase 1 algorithm = Serial   [default]
-aggregation: deterministic = 0   [default]
+aggregation: deterministic = 1   [unused]
 aggregation: enable phase 2a = 1   [default]
 aggregation: enable phase 2b = 1   [default]
 aggregation: enable phase 3 = 1   [default]
@@ -208,9 +208,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesDeterministic (Phase 2a (secondary))
+BuildAggregatesDeterministic (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -218,7 +218,7 @@ aggregation: max selected neighbors = 0   [default]
 aggregation: ordering = natural   [default]
 aggregation: enable phase 1 = 1   [default]
 aggregation: phase 1 algorithm = Serial   [default]
-aggregation: deterministic = 0   [default]
+aggregation: deterministic = 1   [unused]
 aggregation: enable phase 2a = 1   [default]
 aggregation: enable phase 2b = 1   [default]
 aggregation: enable phase 3 = 1   [default]
@@ -279,14 +279,14 @@ Cycle type          = V
 level  rows   nnz    nnz/row  c ratio  procs
   0  10000  49600  4.96                  1  
   1  1700   14928  8.78     5.88         1  
-  2  192    1674   8.72     8.85         1  
-  3  24     190    7.92     8.00         1  
+  2  192    1682   8.76     8.85         1  
+  3  24     200    8.33     8.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 
 Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [1700, 1700], Global nnz: 14928}
 
-Smoother (level 2) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [192, 192], Global nnz: 1674}
+Smoother (level 2) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [192, 192], Global nnz: 1682}
 
 Smoother (level 3) pre  : <Direct> solver interface
 Smoother (level 3) post : no smoother

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_6_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_6_np4_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesDeterministic (Phase 2a (secondary))
+BuildAggregatesDeterministic (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -47,7 +47,7 @@ aggregation: max selected neighbors = 0   [default]
 aggregation: ordering = natural   [default]
 aggregation: enable phase 1 = 1   [default]
 aggregation: phase 1 algorithm = Serial   [default]
-aggregation: deterministic = 0   [default]
+aggregation: deterministic = 1   [unused]
 aggregation: enable phase 2a = 1   [default]
 aggregation: enable phase 2b = 1   [default]
 aggregation: enable phase 3 = 1   [default]
@@ -124,9 +124,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesDeterministic (Phase 2a (secondary))
+BuildAggregatesDeterministic (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -134,7 +134,7 @@ aggregation: max selected neighbors = 0   [default]
 aggregation: ordering = natural   [default]
 aggregation: enable phase 1 = 1   [default]
 aggregation: phase 1 algorithm = Serial   [default]
-aggregation: deterministic = 0   [default]
+aggregation: deterministic = 1   [unused]
 aggregation: enable phase 2a = 1   [default]
 aggregation: enable phase 2b = 1   [default]
 aggregation: enable phase 3 = 1   [default]
@@ -208,9 +208,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesDeterministic (Phase 2a (secondary))
+BuildAggregatesDeterministic (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -218,7 +218,7 @@ aggregation: max selected neighbors = 0   [default]
 aggregation: ordering = natural   [default]
 aggregation: enable phase 1 = 1   [default]
 aggregation: phase 1 algorithm = Serial   [default]
-aggregation: deterministic = 0   [default]
+aggregation: deterministic = 1   [unused]
 aggregation: enable phase 2a = 1   [default]
 aggregation: enable phase 2b = 1   [default]
 aggregation: enable phase 3 = 1   [default]
@@ -279,14 +279,14 @@ Cycle type          = V
 level  rows   nnz    nnz/row  c ratio  procs
   0  10000  49600  4.96                  4  
   1  1700   15318  9.01     5.88         4  
-  2  216    2150   9.95     7.87         4  
-  3  32     434    13.56    6.75         4  
+  2  216    2158   9.99     7.87         4  
+  3  32     446    13.94    6.75         4  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 
 Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [1700, 1700], Global nnz: 15318}
 
-Smoother (level 2) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [216, 216], Global nnz: 2150}
+Smoother (level 2) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [216, 216], Global nnz: 2158}
 
 Smoother (level 3) pre  : <Direct> solver interface
 Smoother (level 3) post : no smoother

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_7_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_7_np1_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesDeterministic (Phase 2a (secondary))
+BuildAggregatesDeterministic (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -47,7 +47,7 @@ aggregation: max selected neighbors = 0   [default]
 aggregation: ordering = natural   [default]
 aggregation: enable phase 1 = 1   [default]
 aggregation: phase 1 algorithm = Serial   [default]
-aggregation: deterministic = 0   [default]
+aggregation: deterministic = 1   [unused]
 aggregation: enable phase 2a = 1   [default]
 aggregation: enable phase 2b = 1   [default]
 aggregation: enable phase 3 = 1   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_7_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_7_np4_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesDeterministic (Phase 2a (secondary))
+BuildAggregatesDeterministic (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -47,7 +47,7 @@ aggregation: max selected neighbors = 0   [default]
 aggregation: ordering = natural   [default]
 aggregation: enable phase 1 = 1   [default]
 aggregation: phase 1 algorithm = Serial   [default]
-aggregation: deterministic = 0   [default]
+aggregation: deterministic = 1   [unused]
 aggregation: enable phase 2a = 1   [default]
 aggregation: enable phase 2b = 1   [default]
 aggregation: enable phase 3 = 1   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/pg1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/pg1_tpetra.gold
@@ -37,9 +37,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -126,9 +126,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/pg2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/pg2_tpetra.gold
@@ -37,9 +37,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -126,9 +126,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/repartition1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/repartition1_np4_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -176,9 +176,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/repartition1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/repartition1_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -176,9 +176,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/repartition3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/repartition3_np4_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -176,9 +176,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/repartition3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/repartition3_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -176,9 +176,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/repartition4_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/repartition4_np4_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -176,9 +176,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/repartition4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/repartition4_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -176,9 +176,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-RAP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-RAP-1_np4_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -176,9 +176,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-RAP-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-RAP-1_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -176,9 +176,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-RAP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-RAP-2_np4_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -162,9 +162,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-RAP-2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-RAP-2_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -162,9 +162,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-RP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-RP-2_np4_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -162,9 +162,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-RP-2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-RP-2_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -162,9 +162,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-S-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-S-1_np4_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -176,9 +176,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -334,9 +334,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -470,9 +470,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-S-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-S-1_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -176,9 +176,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -345,9 +345,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -481,9 +481,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-full-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-full-1_np4_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -176,9 +176,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-full-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-full-1_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -176,9 +176,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-none_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-none_np4_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -176,9 +176,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -336,9 +336,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -472,9 +472,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-none_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-none_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -176,9 +176,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -345,9 +345,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -481,9 +481,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-1_np4_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -176,9 +176,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-1_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -176,9 +176,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-2_np4_tpetra.gold
@@ -41,9 +41,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -178,9 +178,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -425,9 +425,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-2_tpetra.gold
@@ -41,9 +41,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -178,9 +178,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -434,9 +434,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-3_np4_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -176,9 +176,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -423,9 +423,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-3_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -176,9 +176,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -432,9 +432,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother10_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother10_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -124,9 +124,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother11_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother11_tpetra.gold
@@ -56,9 +56,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -162,9 +162,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother12_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother12_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -124,9 +124,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -211,9 +211,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -298,9 +298,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -385,9 +385,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother13_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother13_tpetra.gold
@@ -44,9 +44,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -138,9 +138,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother1_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -124,9 +124,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother2_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -124,9 +124,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother3_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -124,9 +124,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother4_tpetra.gold
@@ -18,9 +18,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -86,9 +86,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother5_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother5_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -124,9 +124,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother6_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother6_tpetra.gold
@@ -25,9 +25,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -100,9 +100,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother9_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother9_tpetra.gold
@@ -44,9 +44,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -138,9 +138,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/sync1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/sync1_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -124,9 +124,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/transpose1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/transpose1_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -120,9 +120,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/transpose2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/transpose2_np4_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -162,9 +162,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/transpose2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/transpose2_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -162,9 +162,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/transpose3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/transpose3_np4_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -162,9 +162,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/transpose3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/transpose3_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -162,9 +162,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos-complex/Output/unsmoothed1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/unsmoothed1_tpetra.gold
@@ -36,9 +36,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -116,9 +116,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/MLaux_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLaux_tpetra.gold
@@ -42,9 +42,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse1_tpetra.gold
@@ -38,9 +38,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -123,9 +123,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -211,9 +211,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse2_tpetra.gold
@@ -38,9 +38,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -123,9 +123,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -211,9 +211,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -299,9 +299,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -387,9 +387,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse3_tpetra.gold
@@ -38,9 +38,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -123,9 +123,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -211,9 +211,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -299,9 +299,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse4_tpetra.gold
@@ -38,9 +38,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -123,9 +123,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -211,9 +211,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -299,9 +299,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse5_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse5_tpetra.gold
@@ -38,9 +38,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -123,9 +123,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]

--- a/packages/muelu/test/interface/kokkos/Output/MLpgamg1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLpgamg1_tpetra.gold
@@ -38,9 +38,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -125,9 +125,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -215,9 +215,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -305,9 +305,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning1_tpetra.gold
@@ -41,9 +41,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -174,9 +174,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -307,9 +307,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -440,9 +440,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -573,9 +573,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning2_tpetra.gold
@@ -41,9 +41,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -174,9 +174,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -307,9 +307,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -440,9 +440,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning3_tpetra.gold
@@ -41,9 +41,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -174,9 +174,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -307,9 +307,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -440,9 +440,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother1_tpetra.gold
@@ -38,9 +38,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -123,9 +123,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -211,9 +211,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -299,9 +299,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother2_tpetra.gold
@@ -38,9 +38,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -123,9 +123,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -211,9 +211,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -299,9 +299,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother3_tpetra.gold
@@ -38,9 +38,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -123,9 +123,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -211,9 +211,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -299,9 +299,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother4_tpetra.gold
@@ -32,9 +32,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -111,9 +111,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -193,9 +193,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -275,9 +275,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]

--- a/packages/muelu/test/interface/kokkos/Output/MLunsmoothed1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLunsmoothed1_tpetra.gold
@@ -37,9 +37,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -115,9 +115,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -196,9 +196,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]
@@ -277,9 +277,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1   [default]
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 1   [unused]

--- a/packages/muelu/test/interface/kokkos/Output/aggregation1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/aggregation1_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -124,9 +124,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/aggregation3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/aggregation3_tpetra.gold
@@ -38,9 +38,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -126,9 +126,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/aggregation4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/aggregation4_tpetra.gold
@@ -38,9 +38,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -133,9 +133,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/coarse1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/coarse1_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -124,9 +124,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -211,9 +211,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/coarse2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/coarse2_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -124,9 +124,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -211,9 +211,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -298,9 +298,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -385,9 +385,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/coarse3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/coarse3_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -124,9 +124,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/default_e3d_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_e3d_tpetra.gold
@@ -31,9 +31,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -112,9 +112,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/default_mhd_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_mhd_np4_tpetra.gold
@@ -32,9 +32,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -104,9 +104,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/default_mhd_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_mhd_tpetra.gold
@@ -32,9 +32,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -104,9 +104,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/default_p2d_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_p2d_tpetra.gold
@@ -31,9 +31,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -112,9 +112,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/default_p3d_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_p3d_tpetra.gold
@@ -31,9 +31,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -112,9 +112,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/default_pg_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_pg_np4_tpetra.gold
@@ -37,9 +37,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -126,9 +126,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/default_pg_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_pg_tpetra.gold
@@ -37,9 +37,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -126,9 +126,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar1_np4_tpetra.gold
@@ -35,9 +35,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar1_tpetra.gold
@@ -35,9 +35,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -166,9 +166,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -297,9 +297,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar2_np4_tpetra.gold
@@ -36,9 +36,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar2_tpetra.gold
@@ -36,9 +36,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -168,9 +168,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -300,9 +300,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/emin1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/emin1_tpetra.gold
@@ -37,9 +37,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -134,9 +134,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/emin2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/emin2_tpetra.gold
@@ -37,9 +37,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -134,9 +134,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/emin3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/emin3_tpetra.gold
@@ -37,9 +37,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -134,9 +134,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/empty_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/empty_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -124,9 +124,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_1_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_1_np1_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesDeterministic (Phase 2a (secondary))
+BuildAggregatesDeterministic (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -47,7 +47,7 @@ aggregation: max selected neighbors = 0   [default]
 aggregation: ordering = natural   [default]
 aggregation: enable phase 1 = 1   [default]
 aggregation: phase 1 algorithm = Serial   [default]
-aggregation: deterministic = 0   [default]
+aggregation: deterministic = 1   [unused]
 aggregation: enable phase 2a = 1   [default]
 aggregation: enable phase 2b = 1   [default]
 aggregation: enable phase 3 = 1   [default]
@@ -124,9 +124,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesDeterministic (Phase 2a (secondary))
+BuildAggregatesDeterministic (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -134,7 +134,7 @@ aggregation: max selected neighbors = 0   [default]
 aggregation: ordering = natural   [default]
 aggregation: enable phase 1 = 1   [default]
 aggregation: phase 1 algorithm = Serial   [default]
-aggregation: deterministic = 0   [default]
+aggregation: deterministic = 1   [unused]
 aggregation: enable phase 2a = 1   [default]
 aggregation: enable phase 2b = 1   [default]
 aggregation: enable phase 3 = 1   [default]
@@ -211,9 +211,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesDeterministic (Phase 2a (secondary))
+BuildAggregatesDeterministic (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -221,7 +221,7 @@ aggregation: max selected neighbors = 0   [default]
 aggregation: ordering = natural   [default]
 aggregation: enable phase 1 = 1   [default]
 aggregation: phase 1 algorithm = Serial   [default]
-aggregation: deterministic = 0   [default]
+aggregation: deterministic = 1   [unused]
 aggregation: enable phase 2a = 1   [default]
 aggregation: enable phase 2b = 1   [default]
 aggregation: enable phase 3 = 1   [default]
@@ -283,14 +283,14 @@ Cycle type          = V
 level  rows   nnz    nnz/row  c ratio  procs
   0  10000  49600  4.96                  1  
   1  1700   14928  8.78     5.88         1  
-  2  192    1674   8.72     8.85         1  
-  3  24     190    7.92     8.00         1  
+  2  192    1682   8.76     8.85         1  
+  3  24     200    8.33     8.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 
 Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [1700, 1700], Global nnz: 14928}
 
-Smoother (level 2) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [192, 192], Global nnz: 1674}
+Smoother (level 2) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [192, 192], Global nnz: 1682}
 
 Smoother (level 3) pre  : <Direct> solver interface
 Smoother (level 3) post : no smoother

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_1_np4_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesDeterministic (Phase 2a (secondary))
+BuildAggregatesDeterministic (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -47,7 +47,7 @@ aggregation: max selected neighbors = 0   [default]
 aggregation: ordering = natural   [default]
 aggregation: enable phase 1 = 1   [default]
 aggregation: phase 1 algorithm = Serial   [default]
-aggregation: deterministic = 0   [default]
+aggregation: deterministic = 1   [unused]
 aggregation: enable phase 2a = 1   [default]
 aggregation: enable phase 2b = 1   [default]
 aggregation: enable phase 3 = 1   [default]
@@ -124,9 +124,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesDeterministic (Phase 2a (secondary))
+BuildAggregatesDeterministic (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -134,7 +134,7 @@ aggregation: max selected neighbors = 0   [default]
 aggregation: ordering = natural   [default]
 aggregation: enable phase 1 = 1   [default]
 aggregation: phase 1 algorithm = Serial   [default]
-aggregation: deterministic = 0   [default]
+aggregation: deterministic = 1   [unused]
 aggregation: enable phase 2a = 1   [default]
 aggregation: enable phase 2b = 1   [default]
 aggregation: enable phase 3 = 1   [default]
@@ -211,9 +211,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesDeterministic (Phase 2a (secondary))
+BuildAggregatesDeterministic (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -221,7 +221,7 @@ aggregation: max selected neighbors = 0   [default]
 aggregation: ordering = natural   [default]
 aggregation: enable phase 1 = 1   [default]
 aggregation: phase 1 algorithm = Serial   [default]
-aggregation: deterministic = 0   [default]
+aggregation: deterministic = 1   [unused]
 aggregation: enable phase 2a = 1   [default]
 aggregation: enable phase 2b = 1   [default]
 aggregation: enable phase 3 = 1   [default]
@@ -283,14 +283,14 @@ Cycle type          = V
 level  rows   nnz    nnz/row  c ratio  procs
   0  10000  49600  4.96                  4  
   1  1700   15318  9.01     5.88         4  
-  2  216    2150   9.95     7.87         4  
-  3  32     434    13.56    6.75         4  
+  2  216    2158   9.99     7.87         4  
+  3  32     446    13.94    6.75         4  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 
 Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [1700, 1700], Global nnz: 15318}
 
-Smoother (level 2) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [216, 216], Global nnz: 2150}
+Smoother (level 2) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [216, 216], Global nnz: 2158}
 
 Smoother (level 3) pre  : <Direct> solver interface
 Smoother (level 3) post : no smoother

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np1_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesDeterministic (Phase 2a (secondary))
+BuildAggregatesDeterministic (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -47,7 +47,7 @@ aggregation: max selected neighbors = 0   [default]
 aggregation: ordering = natural   [default]
 aggregation: enable phase 1 = 1   [default]
 aggregation: phase 1 algorithm = Serial   [default]
-aggregation: deterministic = 0   [default]
+aggregation: deterministic = 1   [unused]
 aggregation: enable phase 2a = 1   [default]
 aggregation: enable phase 2b = 1   [default]
 aggregation: enable phase 3 = 1   [default]
@@ -124,9 +124,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesDeterministic (Phase 2a (secondary))
+BuildAggregatesDeterministic (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -134,7 +134,7 @@ aggregation: max selected neighbors = 0   [default]
 aggregation: ordering = natural   [default]
 aggregation: enable phase 1 = 1   [default]
 aggregation: phase 1 algorithm = Serial   [default]
-aggregation: deterministic = 0   [default]
+aggregation: deterministic = 1   [unused]
 aggregation: enable phase 2a = 1   [default]
 aggregation: enable phase 2b = 1   [default]
 aggregation: enable phase 3 = 1   [default]
@@ -208,9 +208,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesDeterministic (Phase 2a (secondary))
+BuildAggregatesDeterministic (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -218,7 +218,7 @@ aggregation: max selected neighbors = 0   [default]
 aggregation: ordering = natural   [default]
 aggregation: enable phase 1 = 1   [default]
 aggregation: phase 1 algorithm = Serial   [default]
-aggregation: deterministic = 0   [default]
+aggregation: deterministic = 1   [unused]
 aggregation: enable phase 2a = 1   [default]
 aggregation: enable phase 2b = 1   [default]
 aggregation: enable phase 3 = 1   [default]
@@ -280,14 +280,14 @@ Cycle type          = V
 level  rows   nnz    nnz/row  c ratio  procs
   0  10000  49600  4.96                  1  
   1  1700   14928  8.78     5.88         1  
-  2  192    1674   8.72     8.85         1  
-  3  24     190    7.92     8.00         1  
+  2  192    1682   8.76     8.85         1  
+  3  24     200    8.33     8.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 
 Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [1700, 1700], Global nnz: 14928}
 
-Smoother (level 2) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [192, 192], Global nnz: 1674}
+Smoother (level 2) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [192, 192], Global nnz: 1682}
 
 Smoother (level 3) pre  : <Direct> solver interface
 Smoother (level 3) post : no smoother

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np4_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesDeterministic (Phase 2a (secondary))
+BuildAggregatesDeterministic (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -47,7 +47,7 @@ aggregation: max selected neighbors = 0   [default]
 aggregation: ordering = natural   [default]
 aggregation: enable phase 1 = 1   [default]
 aggregation: phase 1 algorithm = Serial   [default]
-aggregation: deterministic = 0   [default]
+aggregation: deterministic = 1   [unused]
 aggregation: enable phase 2a = 1   [default]
 aggregation: enable phase 2b = 1   [default]
 aggregation: enable phase 3 = 1   [default]
@@ -124,9 +124,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesDeterministic (Phase 2a (secondary))
+BuildAggregatesDeterministic (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -134,7 +134,7 @@ aggregation: max selected neighbors = 0   [default]
 aggregation: ordering = natural   [default]
 aggregation: enable phase 1 = 1   [default]
 aggregation: phase 1 algorithm = Serial   [default]
-aggregation: deterministic = 0   [default]
+aggregation: deterministic = 1   [unused]
 aggregation: enable phase 2a = 1   [default]
 aggregation: enable phase 2b = 1   [default]
 aggregation: enable phase 3 = 1   [default]
@@ -208,9 +208,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesDeterministic (Phase 2a (secondary))
+BuildAggregatesDeterministic (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -218,7 +218,7 @@ aggregation: max selected neighbors = 0   [default]
 aggregation: ordering = natural   [default]
 aggregation: enable phase 1 = 1   [default]
 aggregation: phase 1 algorithm = Serial   [default]
-aggregation: deterministic = 0   [default]
+aggregation: deterministic = 1   [unused]
 aggregation: enable phase 2a = 1   [default]
 aggregation: enable phase 2b = 1   [default]
 aggregation: enable phase 3 = 1   [default]
@@ -280,14 +280,14 @@ Cycle type          = V
 level  rows   nnz    nnz/row  c ratio  procs
   0  10000  49600  4.96                  4  
   1  1700   15318  9.01     5.88         4  
-  2  216    2150   9.95     7.87         4  
-  3  32     434    13.56    6.75         4  
+  2  216    2158   9.99     7.87         4  
+  3  32     446    13.94    6.75         4  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 
 Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [1700, 1700], Global nnz: 15318}
 
-Smoother (level 2) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [216, 216], Global nnz: 2150}
+Smoother (level 2) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [216, 216], Global nnz: 2158}
 
 Smoother (level 3) pre  : <Direct> solver interface
 Smoother (level 3) post : no smoother

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np1_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesDeterministic (Phase 2a (secondary))
+BuildAggregatesDeterministic (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -47,7 +47,7 @@ aggregation: max selected neighbors = 0   [default]
 aggregation: ordering = natural   [default]
 aggregation: enable phase 1 = 1   [default]
 aggregation: phase 1 algorithm = Serial   [default]
-aggregation: deterministic = 0   [default]
+aggregation: deterministic = 1   [unused]
 aggregation: enable phase 2a = 1   [default]
 aggregation: enable phase 2b = 1   [default]
 aggregation: enable phase 3 = 1   [default]
@@ -124,9 +124,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesDeterministic (Phase 2a (secondary))
+BuildAggregatesDeterministic (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -134,7 +134,7 @@ aggregation: max selected neighbors = 0   [default]
 aggregation: ordering = natural   [default]
 aggregation: enable phase 1 = 1   [default]
 aggregation: phase 1 algorithm = Serial   [default]
-aggregation: deterministic = 0   [default]
+aggregation: deterministic = 1   [unused]
 aggregation: enable phase 2a = 1   [default]
 aggregation: enable phase 2b = 1   [default]
 aggregation: enable phase 3 = 1   [default]
@@ -208,9 +208,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesDeterministic (Phase 2a (secondary))
+BuildAggregatesDeterministic (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -218,7 +218,7 @@ aggregation: max selected neighbors = 0   [default]
 aggregation: ordering = natural   [default]
 aggregation: enable phase 1 = 1   [default]
 aggregation: phase 1 algorithm = Serial   [default]
-aggregation: deterministic = 0   [default]
+aggregation: deterministic = 1   [unused]
 aggregation: enable phase 2a = 1   [default]
 aggregation: enable phase 2b = 1   [default]
 aggregation: enable phase 3 = 1   [default]
@@ -279,14 +279,14 @@ Cycle type          = V
 level  rows   nnz    nnz/row  c ratio  procs
   0  10000  49600  4.96                  1  
   1  1700   14928  8.78     5.88         1  
-  2  192    1674   8.72     8.85         1  
-  3  24     190    7.92     8.00         1  
+  2  192    1682   8.76     8.85         1  
+  3  24     200    8.33     8.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 
 Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [1700, 1700], Global nnz: 14928}
 
-Smoother (level 2) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [192, 192], Global nnz: 1674}
+Smoother (level 2) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [192, 192], Global nnz: 1682}
 
 Smoother (level 3) pre  : <Direct> solver interface
 Smoother (level 3) post : no smoother

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np4_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesDeterministic (Phase 2a (secondary))
+BuildAggregatesDeterministic (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -47,7 +47,7 @@ aggregation: max selected neighbors = 0   [default]
 aggregation: ordering = natural   [default]
 aggregation: enable phase 1 = 1   [default]
 aggregation: phase 1 algorithm = Serial   [default]
-aggregation: deterministic = 0   [default]
+aggregation: deterministic = 1   [unused]
 aggregation: enable phase 2a = 1   [default]
 aggregation: enable phase 2b = 1   [default]
 aggregation: enable phase 3 = 1   [default]
@@ -124,9 +124,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesDeterministic (Phase 2a (secondary))
+BuildAggregatesDeterministic (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -134,7 +134,7 @@ aggregation: max selected neighbors = 0   [default]
 aggregation: ordering = natural   [default]
 aggregation: enable phase 1 = 1   [default]
 aggregation: phase 1 algorithm = Serial   [default]
-aggregation: deterministic = 0   [default]
+aggregation: deterministic = 1   [unused]
 aggregation: enable phase 2a = 1   [default]
 aggregation: enable phase 2b = 1   [default]
 aggregation: enable phase 3 = 1   [default]
@@ -208,9 +208,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesDeterministic (Phase 2a (secondary))
+BuildAggregatesDeterministic (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -218,7 +218,7 @@ aggregation: max selected neighbors = 0   [default]
 aggregation: ordering = natural   [default]
 aggregation: enable phase 1 = 1   [default]
 aggregation: phase 1 algorithm = Serial   [default]
-aggregation: deterministic = 0   [default]
+aggregation: deterministic = 1   [unused]
 aggregation: enable phase 2a = 1   [default]
 aggregation: enable phase 2b = 1   [default]
 aggregation: enable phase 3 = 1   [default]
@@ -279,14 +279,14 @@ Cycle type          = V
 level  rows   nnz    nnz/row  c ratio  procs
   0  10000  49600  4.96                  4  
   1  1700   15318  9.01     5.88         4  
-  2  216    2150   9.95     7.87         4  
-  3  32     434    13.56    6.75         4  
+  2  216    2158   9.99     7.87         4  
+  3  32     446    13.94    6.75         4  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 
 Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [1700, 1700], Global nnz: 15318}
 
-Smoother (level 2) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [216, 216], Global nnz: 2150}
+Smoother (level 2) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [216, 216], Global nnz: 2158}
 
 Smoother (level 3) pre  : <Direct> solver interface
 Smoother (level 3) post : no smoother

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np1_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesDeterministic (Phase 2a (secondary))
+BuildAggregatesDeterministic (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -47,7 +47,7 @@ aggregation: max selected neighbors = 0   [default]
 aggregation: ordering = natural   [default]
 aggregation: enable phase 1 = 1   [default]
 aggregation: phase 1 algorithm = Serial   [default]
-aggregation: deterministic = 0   [default]
+aggregation: deterministic = 1   [unused]
 aggregation: enable phase 2a = 1   [default]
 aggregation: enable phase 2b = 1   [default]
 aggregation: enable phase 3 = 1   [default]

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np4_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesDeterministic (Phase 2a (secondary))
+BuildAggregatesDeterministic (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -47,7 +47,7 @@ aggregation: max selected neighbors = 0   [default]
 aggregation: ordering = natural   [default]
 aggregation: enable phase 1 = 1   [default]
 aggregation: phase 1 algorithm = Serial   [default]
-aggregation: deterministic = 0   [default]
+aggregation: deterministic = 1   [unused]
 aggregation: enable phase 2a = 1   [default]
 aggregation: enable phase 2b = 1   [default]
 aggregation: enable phase 3 = 1   [default]

--- a/packages/muelu/test/interface/kokkos/Output/pg1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/pg1_tpetra.gold
@@ -37,9 +37,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -126,9 +126,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/pg2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/pg2_tpetra.gold
@@ -37,9 +37,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -126,9 +126,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/repartition1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition1_np4_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -176,9 +176,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/repartition1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition1_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -176,9 +176,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/repartition3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition3_np4_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -176,9 +176,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/repartition3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition3_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -176,9 +176,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/repartition4_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition4_np4_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -176,9 +176,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/repartition4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition4_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -176,9 +176,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_np4_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -176,9 +176,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -176,9 +176,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_np4_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -162,9 +162,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -162,9 +162,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_np4_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -162,9 +162,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -162,9 +162,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/reuse-S-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-S-1_np4_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -176,9 +176,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -334,9 +334,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -470,9 +470,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/reuse-S-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-S-1_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -176,9 +176,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -345,9 +345,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -481,9 +481,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/reuse-full-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-full-1_np4_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -176,9 +176,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/reuse-full-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-full-1_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -176,9 +176,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/reuse-none_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-none_np4_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -176,9 +176,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -336,9 +336,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -472,9 +472,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/reuse-none_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-none_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -176,9 +176,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -345,9 +345,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -481,9 +481,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_np4_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -176,9 +176,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -176,9 +176,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_np4_tpetra.gold
@@ -41,9 +41,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -178,9 +178,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -425,9 +425,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_tpetra.gold
@@ -41,9 +41,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -178,9 +178,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -434,9 +434,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_np4_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -176,9 +176,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -423,9 +423,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -176,9 +176,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -432,9 +432,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/smoother10_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother10_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -124,9 +124,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/smoother11_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother11_tpetra.gold
@@ -56,9 +56,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -162,9 +162,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/smoother12_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother12_tpetra.gold
@@ -31,9 +31,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -112,9 +112,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -193,9 +193,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -274,9 +274,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -355,9 +355,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/smoother13_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother13_tpetra.gold
@@ -38,9 +38,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -126,9 +126,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/smoother1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother1_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -124,9 +124,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/smoother2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother2_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -124,9 +124,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/smoother3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother3_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -124,9 +124,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/smoother4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother4_tpetra.gold
@@ -18,9 +18,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -86,9 +86,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/smoother5_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother5_tpetra.gold
@@ -31,9 +31,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -112,9 +112,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/smoother6_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother6_tpetra.gold
@@ -25,9 +25,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -100,9 +100,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/smoother9_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother9_tpetra.gold
@@ -38,9 +38,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -126,9 +126,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/sync1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/sync1_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -124,9 +124,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/transpose1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose1_tpetra.gold
@@ -37,9 +37,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -120,9 +120,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/transpose2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose2_np4_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -162,9 +162,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/transpose2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose2_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -162,9 +162,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/transpose3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose3_np4_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -162,9 +162,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/transpose3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose3_tpetra.gold
@@ -40,9 +40,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -162,9 +162,9 @@ lightweight wrap = 1
 Build (MueLu::TentativePFactory_kokkos)
 Build (MueLu::UncoupledAggregationFactory_kokkos)
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/unsmoothed1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/unsmoothed1_tpetra.gold
@@ -36,9 +36,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -116,9 +116,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]

--- a/packages/muelu/test/interface/kokkos/Output/unsmoothed2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/unsmoothed2_tpetra.gold
@@ -36,9 +36,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]
@@ -116,9 +116,9 @@ filtered matrix: reuse eigenvalue = 1   [default]
 lightweight wrap = 1
 
 BuildAggregates (Phase - (Dirichlet))
-BuildAggregates (Phase 1 (main))
-BuildAggregates (Phase 2a (secondary))
-BuildAggregates (Phase 2b (expansion))
+BuildAggregatesSerial (Phase 1 (main))
+BuildAggregatesRandom (Phase 2a (secondary))
+BuildAggregatesRandom (Phase 2b (expansion))
 BuildAggregates (Phase 3 (cleanup))
 aggregation: max agg size = -1   [default]
 aggregation: min agg size = 2   [default]


### PR DESCRIPTION
@trilinos/muelu 

## Description
Adding refactor of phase 2a and 2b of aggregation using the distance 2 coloring.

## Motivation and Context
This work is part of issue #5838 and aims at having the setup of MueLu SA-AMG performed on GPU.

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of #5838 
* Composed of 

## How Has This Been Tested?
The unit-tests for kokkos are testing the new algorithms and are passing correctly

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.