### PR TITLE
MueLu: print total number of fixed-point iterations in region MG driver

### DIFF
--- a/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
+++ b/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
@@ -1554,7 +1554,8 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
     typename Teuchos::ScalarTraits<Scalar>::magnitudeType normResIni;
     const int old_precision = std::cout.precision();
     std::cout << std::setprecision(8) << std::scientific;
-    for (int cycle = 0; cycle < maxIts; ++cycle)
+    int cycle = 0;
+    for (cycle = 0; cycle < maxIts; ++cycle)
     {
       // check for convergence
       {
@@ -1599,6 +1600,9 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
                regProlong, compRowMaps, quasiRegRowMaps, regRowMaps, regRowImporters,
                regInterfaceScalings, smootherParams, coarseCompOp, coarseSolverData, hierarchyData);
     }
+    if (myRank == 0)
+      std::cout << "Number of iterations performed for this solve: " << cycle << std::endl;
+
     std::cout << std::setprecision(old_precision);
     std::cout.unsetf(std::ios::fixed | std::ios::scientific);
   }


### PR DESCRIPTION
@trilinos/muelu 
@lucbv @rstumin @pohm01 

## Description

Print the number of fixed point iterations to screen using the line
```
Number of iterations performed for this solve: <numberOfIterations>
```

## Motivation and Context

This is the same line as for the structured MG driver. Having the same screen output simplifies scripted post processing of log files.

## How Has This Been Tested?

I verified screen output manually and also with some postprocessing scripts applied to the screen output log file.

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.
