### PR TITLE
MueLu: fixing the construction of region coordinates in region driver

### DIFF
--- a/packages/muelu/research/regionMG/examples/structured/CMakeLists.txt
+++ b/packages/muelu/research/regionMG/examples/structured/CMakeLists.txt
@@ -18,6 +18,7 @@ IF (${PACKAGE_NAME}_ENABLE_Tpetra AND ${PACKAGE_NAME}_ENABLE_Amesos2)
       structured_1dof_3level.xml
       structured_1dof-complex.xml
       structured_linear_1dof.xml
+      structured_linear_3dof.xml
       structured_unstructured_1dof.xml
       compare_residual_history.py
       gold_files/Star2D_GS_4.log.gold

--- a/packages/muelu/research/regionMG/examples/structured/structured_linear_3dof.xml
+++ b/packages/muelu/research/regionMG/examples/structured/structured_linear_3dof.xml
@@ -15,13 +15,12 @@
     </ParameterList>
 
     <ParameterList name="myAggregationFact">
-      <Parameter name="factory"                             type="string" value="StructuredAggregationFactory"/>
-      <Parameter name="aggregation: coupling"               type="string" value="uncoupled"/>
-      <Parameter name="aggregation: output type"            type="string" value="CrsGraph"/>
-      <Parameter name="aggregation: coarsening order"       type="int"    value="1"/>
-      <Parameter name="aggregation: coarsening rate"        type="string" value="{2}"/>
-      <Parameter name="Graph"                               type="string" value="myCoalesceDropFact"/>
-      <Parameter name="DofsPerNode"                         type="string" value="myCoalesceDropFact"/>
+      <Parameter name="factory"                                   type="string" value="StructuredAggregationFactory"/>
+      <Parameter name="aggregation: coupling"                     type="string" value="uncoupled"/>
+      <Parameter name="aggregation: output type"                  type="string" value="CrsGraph"/>
+      <Parameter name="aggregation: coarsening order"             type="int"    value="1"/>
+      <Parameter name="aggregation: coarsening rate"              type="string" value="{2}"/>
+      <Parameter name="Graph"                                     type="string" value="myCoalesceDropFact"/>
     </ParameterList>
 
     <ParameterList name="myCoarseMapFact">
@@ -44,6 +43,8 @@
       <Parameter name="structured aggregation"              type="bool"   value="true"/>
       <Parameter name="numDimensions"                       type="string" value="myAggregationFact"/>
       <Parameter name="lCoarseNodesPerDim"                  type="string" value="myAggregationFact"/>
+      <!-- <Parameter name="write start"                         type="int"    value="0"/> -->
+      <!-- <Parameter name="write end"                           type="int"    value="3"/> -->
     </ParameterList>
 
     <ParameterList name="myNullspaceFact">
@@ -73,7 +74,6 @@
       </ParameterList>
     </ParameterList>
 
-    <!-- ===========  SMOOTHING  =========== -->
     <ParameterList name="myILU">
       <Parameter name="factory" type="string" value="TrilinosSmoother"/>
       <Parameter name="type"  type="string" value="RILUK"/>
@@ -88,36 +88,15 @@
       </ParameterList>
     </ParameterList>
 
-    <ParameterList name="myChebyshev">
-      <Parameter name="factory" type="string" value="TrilinosSmoother"/>
-      <Parameter name="type"  type="string" value="CHEBYSHEV"/>
-      <ParameterList name="ParameterList">
-        <Parameter      name="chebyshev: degree"                    type="int"      value="2"/>
-        <Parameter      name="chebyshev: ratio eigenvalue"          type="double"   value="7"/>
-        <Parameter      name="chebyshev: min eigenvalue"            type="double"   value="1.0"/>
-        <Parameter      name="chebyshev: zero starting solution"    type="bool"     value="true"/>
-      </ParameterList>
-    </ParameterList>
-
-    <ParameterList name="mySGS">
-      <Parameter name="factory" type="string" value="TrilinosSmoother"/>
-      <Parameter name="type" type="string" value="RELAXATION"/>
-      <ParameterList name="ParameterList">
-        <Parameter name="relaxation: type"             type="string" value="Symmetric Gauss-Seidel"/>
-        <Parameter name="relaxation: sweeps"           type="int"    value="1"/>
-        <Parameter name="relaxation: damping factor"   type="double" value="0.8"/>
-      </ParameterList>
-    </ParameterList>
-
   </ParameterList>
 
 
   <!-- Definition of the multigrid preconditioner -->
   <ParameterList name="Hierarchy">
 
-    <Parameter name="max levels"                            type="int"      value="6"/> <!-- Max number of levels -->
-    <Parameter name="cycle type"                            type="string"   value="V"/>
-    <Parameter name="coarse: max size"                      type="int"      value="100"/> <!-- Min number of rows on coarsest level -->
+    <Parameter name="max levels"                            type="int"      value="3"/> <!-- Max number of levels -->
+    <Parameter name="cycle type"                            type="string"   value="W"/>
+    <Parameter name="coarse: max size"                      type="int"      value="20"/> <!-- Min number of rows on coarsest level -->
     <Parameter name="verbosity"                             type="string"   value="High"/>
 
     <ParameterList name="DataToWrite">
@@ -127,16 +106,16 @@
     </ParameterList>
 
     <ParameterList name="All">
-      <Parameter name="PreSmoother"                         type="string"   value="mySGS"/>
-      <Parameter name="PostSmoother"                        type="string"   value="mySGS"/>
+      <Parameter name="PreSmoother"                         type="string"   value="NoSmoother"/>
+      <Parameter name="PostSmoother"                        type="string"   value="NoSmoother"/>
       <Parameter name="Nullspace"                           type="string"   value="myNullspaceFact"/>
       <Parameter name="Aggregates"                          type="string"   value="myAggregationFact"/>
       <Parameter name="lCoarseNodesPerDim"                  type="string"   value="myAggregationFact"/>
       <Parameter name="P"                                   type="string"   value="myProlongatorFact"/>
       <Parameter name="R"                                   type="string"   value="myRestrictorFact"/>
       <Parameter name="A"                                   type="string"   value="myRAPFact"/>
-      <Parameter name="CoarseSolver"                        type="string"   value="DirectSolver"/>
-      <!-- <Parameter name="CoarseSolver"                        type="string"   value="myILU"/> -->
+      <!-- <Parameter name="CoarseSolver"                        type="string"   value="DirectSolver"/> -->
+      <Parameter name="CoarseSolver"                        type="string"   value="myILU"/>
       <Parameter name="Coordinates"                         type="string"   value="myProlongatorFact"/>
       <Parameter name="lNodesPerDim"                        type="string"   value="myCoordTransferFact"/>
       <Parameter name="numDimensions"                       type="string"   value="myCoordTransferFact"/>

--- a/packages/muelu/src/Transfers/GeneralGeometric/MueLu_GeometricInterpolationPFactory_def.hpp
+++ b/packages/muelu/src/Transfers/GeneralGeometric/MueLu_GeometricInterpolationPFactory_def.hpp
@@ -49,8 +49,6 @@
 #include "Xpetra_CrsGraph.hpp"
 #include "Xpetra_CrsMatrixUtils.hpp"
 
-#include "Xpetra_IO.hpp"
-
 #include "MueLu_MasterList.hpp"
 #include "MueLu_Monitor.hpp"
 #include "MueLu_Aggregates.hpp"
@@ -172,11 +170,35 @@ namespace MueLu {
     } else if(interpolationOrder == 1) {
       // Compute the prolongator using piece-wise linear interpolation
       // First get all the required coordinates to compute the local part of P
+      RCP<const Map> prolongatorColMap = prolongatorGraph->getColMap();
+
+      const size_t dofsPerNode = static_cast<size_t>(A->GetFixedBlockSize());
+      const size_t numColIndices = prolongatorColMap->getNodeNumElements();
+      TEUCHOS_TEST_FOR_EXCEPTION((numColIndices % dofsPerNode) != 0,
+                                 Exceptions::RuntimeError,
+                                 "Something went wrong, the number of columns in the prolongator is not a multiple of dofsPerNode!");
+      const size_t numGhostCoords = numColIndices / dofsPerNode;
+      const GO indexBase = prolongatorColMap->getIndexBase();
+      const GO coordIndexBase = fineCoordinates->getMap()->getIndexBase();
+
+      ArrayView<const GO> prolongatorColIndices = prolongatorColMap->getNodeElementList();
+      Array<GO> ghostCoordIndices(numGhostCoords);
+      for(size_t ghostCoordIdx = 0; ghostCoordIdx < numGhostCoords; ++ghostCoordIdx) {
+        ghostCoordIndices[ghostCoordIdx]
+          = (prolongatorColIndices[ghostCoordIdx*dofsPerNode] - indexBase) / dofsPerNode
+          + coordIndexBase;
+      }
+      RCP<Map> ghostCoordMap = MapFactory::Build(fineCoordinates->getMap()->lib(),
+                                                 prolongatorColMap->getGlobalNumElements() / dofsPerNode,
+                                                 ghostCoordIndices(),
+                                                 coordIndexBase,
+                                                 fineCoordinates->getMap()->getComm());
+
       RCP<realvaluedmultivector_type> ghostCoordinates
-        = Xpetra::MultiVectorFactory<real_type,LO,GO,NO>::Build(prolongatorGraph->getColMap(),
+        = Xpetra::MultiVectorFactory<real_type,LO,GO,NO>::Build(ghostCoordMap,
                                                                 fineCoordinates->getNumVectors());
       RCP<const Import> ghostImporter = ImportFactory::Build(coarseCoordinates->getMap(),
-                                                             prolongatorGraph->getColMap());
+                                                             ghostCoordMap);
       ghostCoordinates->doImport(*coarseCoordinates, *ghostImporter, Xpetra::INSERT);
 
       SubFactoryMonitor sfm(*this, "BuildLinearP", coarseLevel);

--- a/packages/muelu/test/structured/structured_2dof.xml
+++ b/packages/muelu/test/structured/structured_2dof.xml
@@ -87,6 +87,37 @@
       </ParameterList>
     </ParameterList>
 
+    <ParameterList name="myChebyshev">
+      <Parameter name="factory" type="string" value="TrilinosSmoother"/>
+      <Parameter name="type"  type="string" value="CHEBYSHEV"/>
+      <ParameterList name="ParameterList">
+        <Parameter      name="chebyshev: degree"                    type="int"      value="2"/>
+        <Parameter      name="chebyshev: ratio eigenvalue"          type="double"   value="7"/>
+        <Parameter      name="chebyshev: min eigenvalue"            type="double"   value="1.0"/>
+        <Parameter      name="chebyshev: zero starting solution"    type="bool"     value="true"/>
+      </ParameterList>
+    </ParameterList>
+
+    <ParameterList name="mySGS">
+      <Parameter name="factory" type="string" value="TrilinosSmoother"/>
+      <Parameter name="type" type="string" value="RELAXATION"/>
+      <ParameterList name="ParameterList">
+        <Parameter name="relaxation: type"             type="string" value="Symmetric Gauss-Seidel"/>
+        <Parameter name="relaxation: sweeps"           type="int"    value="1"/>
+        <Parameter name="relaxation: damping factor"   type="double" value="0.8"/>
+      </ParameterList>
+    </ParameterList>
+
+    <ParameterList name="myJacobi">
+      <Parameter name="factory" type="string" value="TrilinosSmoother"/>
+      <Parameter name="type" type="string" value="RELAXATION"/>
+      <ParameterList name="ParameterList">
+        <Parameter name="relaxation: type"             type="string" value="Jacobi"/>
+        <Parameter name="relaxation: sweeps"           type="int"    value="1"/>
+        <Parameter name="relaxation: damping factor"   type="double" value="0.6666"/>
+      </ParameterList>
+    </ParameterList>
+
   </ParameterList>
 
 
@@ -98,17 +129,23 @@
     <Parameter name="coarse: max size"                      type="int"      value="10"/> <!-- Min number of rows on coarsest level -->
     <Parameter name="verbosity"                             type="string"   value="High"/>
 
+    <ParameterList name="DataToWrite">
+       <!-- <Parameter name="Matrices"          type="string"   value="{0,1}"/> -->
+       <Parameter name="Prolongators"      type="string"   value="{1,2}"/>
+       <!-- <Parameter name="Restrictors"       type="string"   value="{1,2}"/> -->
+    </ParameterList>
+
     <ParameterList name="All">
-      <Parameter name="PreSmoother"                         type="string"   value="myILU"/>
-      <Parameter name="PostSmoother"                        type="string"   value="NoSmoother"/>
+      <Parameter name="PreSmoother"                         type="string"   value="myJacobi"/>
+      <Parameter name="PostSmoother"                        type="string"   value="myJacobi"/>
       <Parameter name="Nullspace"                           type="string"   value="myNullspaceFact"/>
       <Parameter name="Aggregates"                          type="string"   value="myAggregationFact"/>
       <Parameter name="lCoarseNodesPerDim"                  type="string"   value="myAggregationFact"/>
       <Parameter name="P"                                   type="string"   value="myProlongatorFact"/>
       <Parameter name="R"                                   type="string"   value="myRestrictorFact"/>
       <Parameter name="A"                                   type="string"   value="myRAPFact"/>
-      <!-- <Parameter name="CoarseSolver"                        type="string"   value="DirectSolver"/> -->
-      <Parameter name="CoarseSolver"                        type="string"   value="myILU"/>
+      <Parameter name="CoarseSolver"                        type="string"   value="DirectSolver"/>
+      <!-- <Parameter name="CoarseSolver"                        type="string"   value="myILU"/> -->
       <Parameter name="Coordinates"                         type="string"   value="myProlongatorFact"/>
       <Parameter name="lNodesPerDim"                        type="string"   value="myCoordTransferFact"/>
       <Parameter name="numDimensions"                       type="string"   value="myCoordTransferFact"/>


### PR DESCRIPTION
@trilinos/muelu 

## Description
Properly constructing maps and importers for coordinates that take into account the number of degrees of freedom per node in the linear system being solved.
I think that to prevent this type of unexpected behavior I might remove the
coupled path in structured aggregation...

## Motivation and Context
This fixes a couple of bugs related to the handling of coordinates in region MG and in GeometricInterpolationPFactory.

## Related Issues

* Closes issue #5921
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 

## How Has This Been Tested?
A local build and test has been performed and no failures has been observed

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.