### PR TITLE
MueLu: Fix CMake/preprocessor logic for default GO (#5932)

### DIFF
--- a/packages/muelu/CMakeLists.txt
+++ b/packages/muelu/CMakeLists.txt
@@ -265,8 +265,10 @@ GLOBAL_SET(HAVE_${PACKAGE_NAME_UC}_TEKO ${${PACKAGE_NAME}_ENABLE_Teko})
 # - MueLu_ENABLE_EXPLICIT_INSTANTIATION
 # - Enabling/disabling of scalar/ordinal types is controlled by Tpetra
 
-IF(${PACKAGE_NAME}_ENABLE_EXPLICIT_INSTANTIATION)
+GLOBAL_SET(HAVE_${PACKAGE_NAME_UC}_DEFAULT_GO_LONG OFF)
+GLOBAL_SET(HAVE_${PACKAGE_NAME_UC}_DEFAULT_GO_LONGLONG OFF)
 
+IF(${PACKAGE_NAME}_ENABLE_EXPLICIT_INSTANTIATION)
   # <double, int, int>
   # Examples and tests need at least this one, also if Epetra is enabled
   IF(Tpetra_INST_DOUBLE AND Tpetra_INST_INT_INT)
@@ -343,10 +345,16 @@ IF(${PACKAGE_NAME}_ENABLE_EXPLICIT_INSTANTIATION)
   MESSAGE(STATUS "<complex, int, int>       : ${${PACKAGE_NAME}_INST_COMPLEX_INT_INT}")
 
   # GO preference: int > long long > long
-  GLOBAL_SET(HAVE_${PACKAGE_NAME_UC}_DEFAULT_GO_LONG
-    (NOT ${${PACKAGE_NAME}_INST_DOUBLE_INT_INT} AND NOT ${${PACKAGE_NAME}_INST_DOUBLE_INT_LONG_LONG}))
-  GLOBAL_SET(HAVE_${PACKAGE_NAME_UC}_DEFAULT_GO_LONGLONG NOT ${${PACKAGE_NAME}_INST_DOUBLE_INT_INT})
-
+  IF(NOT ${${PACKAGE_NAME}_INST_DOUBLE_INT_INT})
+    # No GO=int (first choice for default)
+    IF(NOT ${${PACKAGE_NAME}_INST_DOUBLE_INT_LONGLONGINT})
+      #No GO=long long (second choice), must use long
+      GLOBAL_SET(HAVE_${PACKAGE_NAME_UC}_DEFAULT_GO_LONG ON)
+    ELSE()
+      GLOBAL_SET(HAVE_${PACKAGE_NAME_UC}_DEFAULT_GO_LONGLONG ON)
+    ENDIF()
+  ENDIF()
+    
   # If Tpetra is enabled, determine which Nodes are used
   IF (${PACKAGE_NAME}_ENABLE_Tpetra)
     GLOBAL_SET (HAVE_${PACKAGE_NAME_UC}_SERIAL  ${Tpetra_INST_SERIAL})
@@ -373,15 +381,7 @@ ELSE()
     GLOBAL_SET (HAVE_${PACKAGE_NAME_UC}_SERIAL  ON)
   ENDIF()
 
-  # With ETI off, can just use int as the default GO
-  GLOBAL_SET(HAVE_${PACKAGE_NAME_UC}_DEFAULT_GO_LONGLONG OFF)
-  GLOBAL_SET(HAVE_${PACKAGE_NAME_UC}_DEFAULT_GO_LONG OFF)
-ENDIF()
-
-IF(${${PACKAGE_NAME}_ENABLE_DEFAULT_GO_LONGLONG})
-  MESSAGE(STATUS "Using long long as the default GlobalOrdinal in MueLu.")
-ELSE()
-  MESSAGE(STATUS "Using int as the default GlobalOrdinal in MueLu.")
+  # With ETI off, free to leave int as the default GO
 ENDIF()
 
 # HAVE_MUELU_COMPLEX=ON iff:

--- a/packages/muelu/cmake/MueLu_config.hpp.in
+++ b/packages/muelu/cmake/MueLu_config.hpp.in
@@ -112,6 +112,9 @@
 #cmakedefine HAVE_MUELU_OPENMP
 #cmakedefine HAVE_MUELU_CUDA
 
+#cmakedefine HAVE_MUELU_DEFAULT_GO_LONGLONG
+#cmakedefine HAVE_MUELU_DEFAULT_GO_LONG
+
 /*
  If deprecated warnings are on, and the compiler supports them, then
  define MUELU_DEPRECATED to emit deprecated warnings.  Otherwise,

--- a/packages/muelu/src/Headers/MueLu_Details_DefaultTypes.hpp
+++ b/packages/muelu/src/Headers/MueLu_Details_DefaultTypes.hpp
@@ -48,15 +48,16 @@
 #define MUELU_USEDEFAULTTYPES_HPP
 
 #include <Kokkos_DefaultNode.hpp>
+#include "MueLu_config.hpp"
 
 namespace MueLu
 {
   typedef double DefaultScalar;
   typedef int DefaultLocalOrdinal;
 
-  #ifdef HAVE_MUELU_DEFAULT_GO_LONG
+  #if defined HAVE_MUELU_DEFAULT_GO_LONG
   typedef long DefaultGlobalOrdinal;
-  #elif HAVE_MUELU_DEFAULT_GO_LONGLONG
+  #elif defined HAVE_MUELU_DEFAULT_GO_LONGLONG
   typedef long long DefaultGlobalOrdinal;
   #else
   typedef int DefaultGlobalOrdinal;


### PR DESCRIPTION
-Fixes what was supposed to be included in #5697
-setting global CMake variables about which
  integer type should be the default GO in MueLu
-this enables/disables #defines in MueLu_config.h
-#defines from MueLu_config.h are used to set the
  default GO typedef in MueLu_Details_DefaultTypes.hpp

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/muelu 

## Description
<!--- Please describe your changes in detail. -->
The changes that fixed the default GO selection were:

- fix misspelling of the MueLu ETI option in cmake: changed ``${${PACKAGE_NAME}_INST_DOUBLE_INT_LONG_LONG}`` to ``${${PACKAGE_NAME}_INST_DOUBLE_INT_LONGLONGINT}``
- include MueLu_config.hpp into MueLu_Details_DefaultTypes.hpp; without this, the preprocessor definitions were never seen by it
- use nested cmake "IF(...)" to set the boolean variables instead of trying to use boolean expressions as the right-hand side of GLOBAL_SET(). Added benefit of the IF()s making the intention clearer.
- add ``#cmakedefine HAVE_MUELU_DEFAULT_GO_LONGLONG`` and ``#cmakedefine HAVE_MUELU_DEFAULT_GO_LONG`` (thanks @csiefer2)

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
Fixes linker errors caused by MueLu's default GO type disagreeing with what's enabled in MueLu ETI [see issue](https://github.com/trilinos/Trilinos/issues/5932)
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes #5923
* Blocks 
* Is blocked by 
* Follows #5697
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->
Went through MueLu configuration with the following settings, and then checked that MueLu_config.hpp had #defined the right things:
``HAVE_MUELU_DEFAULT_GO_LONGLONG`` (use GO=long long), ``HAVE_MUELU_DEFAULT_GO_LONG`` (use GO=long), or neither (GO=int).

- all default: Tpetra_INST_INT_INT and Tpetra_INST_INT_LONG_LONG (default GO=int)
- Tpetra_INST_INT_INT (default GO=int)
- Tpetra_INST_INT_LONG (default GO=long)
- what will be default after Tpetra deprecated code removal: Tpetra_INST_INT_LONG_LONG (default GO=long long)
- Tpetra_INST_INT_LONG and Tpetra_INST_INT_LONG_LONG (default GO=long long)
- ETI off (default GO=int)

<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
