### PR TITLE
Tpetra, MueLu: deprecated code fixes

### DIFF
--- a/packages/muelu/src/Transfers/Energy-Minimization/Solvers/MueLu_SteepestDescentSolver_def.hpp
+++ b/packages/muelu/src/Transfers/Energy-Minimization/Solvers/MueLu_SteepestDescentSolver_def.hpp
@@ -84,7 +84,7 @@ namespace MueLu {
     P = rcp_const_cast<Matrix>(rcpFromRef(P0));
 
     for (size_t k = 0; k < nIts_; k++) {
-      AP = Xpetra::MatrixMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Multiply(*A, false, *P, false, mmfancy, true, false);
+      AP = Xpetra::MatrixMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Multiply(*A, false, *P, false, mmfancy, true, true);
 #if 0
       // gradient = -2 A^T * A * P
       SC stepLength = 2*stepLength_;
@@ -93,7 +93,7 @@ namespace MueLu {
 #else
       // gradient = - A * P
       SC stepLength = stepLength_;
-      Utilities::MyOldScaleMatrix(*AP, D, true, false, false);
+      Utilities::MyOldScaleMatrix(*AP, D, true, true, false);
       C.Apply(*AP, *Ptmp);
 #endif
 

--- a/packages/muelu/src/Transfers/Petrov-Galerkin-SA/MueLu_PgPFactory_def.hpp
+++ b/packages/muelu/src/Transfers/Petrov-Galerkin-SA/MueLu_PgPFactory_def.hpp
@@ -303,7 +303,7 @@ namespace MueLu {
 
         // compute D^{-1} * A * D^{-1} * A * P0
         bool doFillComplete=true;
-        bool optimizeStorage=false;
+        bool optimizeStorage=true;
         Teuchos::ArrayRCP<Scalar> diagA = Utilities::GetMatrixDiagonal(*A);
         RCP<Matrix> DinvADinvAP0 = Xpetra::MatrixMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Multiply(*A, false, *DinvAP0, false, GetOStream(Statistics2), doFillComplete, optimizeStorage);
         Utilities::MyOldScaleMatrix(*DinvADinvAP0, diagA, true, doFillComplete, optimizeStorage); //scale matrix with reciprocal of diag

--- a/packages/muelu/test/scaling/MMKernelDriver.cpp
+++ b/packages/muelu/test/scaling/MMKernelDriver.cpp
@@ -695,7 +695,7 @@ void Multiply_KokkosKernels(const Xpetra::Matrix<Scalar,LocalOrdinal,GlobalOrdin
                                                      Browptr,Bcolind,Bvals,false,
                                                      Crowptr,Ccolind,Cvals);
       kh.destroy_spgemm_handle();
-      KCRS::execution_space::fence();
+      typename KCRS::execution_space().fence();
   
       #ifdef USE_DESCRIPTIVE_STATS
       switch (alg_enum) {


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/muelu 
@trilinos/tpetra 

## Description
<!--- Please describe your changes in detail. -->
    MueLu: fix PgP, emin test failures when Tpetra deprecated is off.
    
    Tpetra: fix MatrixMatrix::Multiply timer scope issue.
    
    Also in MueLu, replaced one instance of deprecated Kokkos fence:
    exec_space::fence() ==> exec_space().fence().
    
    TpetraExt::MatrixMatrix::Multiply has two main code paths:
    a fast one that does fillComplete() and one that doesn't. The
    fast code path (mult_A_B_newmatrix()) for computing C=A*B also
    allocates C to exactly the right size, avoiding the guesswork of
    constructing C with enough entries per row.
    
    However, Xpetra's wrapper for Multiply doesn't request
    fillComplete unless optimizeStorage is also requested. So this commit
    passes "optimizeStorage = true" to Xpetra::Multiply in the
    PG and EMin transfers. This now uses the faster code path in Tpetra
    multiply, and if Tpetra deprecated is off, avoids MueLu test failures
    related to not enough entries being allocated per row.


## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
This change fixes these MueLu test failures (the last remaining failures when Tpetra/Kokkos deprecated off, and GO=long long - see #5614 ):
```
	198 - MueLu_UnitTestsTpetra_MPI_1 (Failed)
	199 - MueLu_UnitTestsTpetra_MPI_4 (Failed)
	226 - MueLu_ParameterListInterpreterTpetraHeavy_MPI_1 (Failed)
	227 - MueLu_ParameterListInterpreterTpetraHeavy_MPI_4 (Failed)
	228 - MueLu_BlockedTransfer_Tpetra_MPI_4 (Failed)
```
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes
* Blocks 
* Is blocked by 
* Follows
* Precedes 
* Related to #5602
* Part of #5614 
* Composed of 
-->

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->
Built and ran tests for Tpetra and downstream with Serial, Cuda and OpenMP; with and without Tpetra/Kokkos deprecated code enabled. There are still some failures in Cuda with deprecated off, but I checked that these were not caused by my changes. To the best of my knowledge no new build errors or test failures were introduced.
<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
