### PR TITLE
Fixes for trilinoscopuling build errors, and some TimeMonitor destruc…

### DIFF
--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_ExtraKernels_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_ExtraKernels_def.hpp
@@ -289,7 +289,7 @@ void mult_A_B_newmatrix_LowThreadGustavsonKernel(CrsMatrixStruct<Scalar, LocalOr
   copy_out_from_thread_memory(thread_total_nnz,tl_colind,tl_values,m,thread_chunk,row_mapC,entriesC,valuesC);
 
 #ifdef HAVE_TPETRA_MMM_TIMINGS
-  MM.~(); // destruct the 'Core'
+  MM.~TimeMonitor(); // destruct the 'Core'
   Teuchos::TimeMonitor MMsort (*TimeMonitor::getNewTimer(prefix_mmm + std::string("MMM Newmatrix OpenMPSort")));
 #endif
     // Sort & set values
@@ -683,7 +683,7 @@ void jacobi_A_B_newmatrix_LowThreadGustavsonKernel(Scalar omega,
 
 
 #ifdef HAVE_TPETRA_MMM_TIMINGS
-  MM.~();
+  MM.~TimeMonitor();
   Teuchos::TimeMonitor MMsort (*TimeMonitor::getNewTimer(prefix_mmm + std::string("Jacobi Newmatrix OpenMPSort")));
 #endif
     // Sort & set values
@@ -990,7 +990,7 @@ void jacobi_A_B_newmatrix_MultiplyScaleAddKernel(Scalar omega,
   Tpetra::MMdetails::mult_A_B_newmatrix(Aview,Bview,*AB,label+std::string(" MSAK"),params);
 
 #ifdef HAVE_TPETRA_MMM_TIMINGS
-  MMmult.~();
+  MMmult.~TimeMonitor();
   Teuchos::TimeMonitor MMscale (*TimeMonitor::getNewTimer(prefix_mmm + std::string("Jacobi Newmatrix MSAK Scale")));
 #endif
 
@@ -998,7 +998,7 @@ void jacobi_A_B_newmatrix_MultiplyScaleAddKernel(Scalar omega,
   AB->leftScale(Dinv);
 
 #ifdef HAVE_TPETRA_MMM_TIMINGS
-  MMscale.~();
+  MMscale.~TimeMonitor();
   Teuchos::TimeMonitor MMadd (*TimeMonitor::getNewTimer(prefix_mmm + std::string("Jacobi Newmatrix MSAK Add")));
 #endif
 
@@ -1238,14 +1238,14 @@ static inline void mult_R_A_P_newmatrix_LowThreadGustavsonKernel(CrsMatrixStruct
           tl_values(tid) = Acvals;
         });
   #ifdef HAVE_TPETRA_MMM_TIMINGS
-        MM.~();
+        MM.~TimeMonitor();
         Teuchos::TimeMonitor MMcopy (*TimeMonitor::getNewTimer(prefix_mmm + std::string("RAP Newmatrix copy from thread local")));
   #endif
 
         copy_out_from_thread_memory(thread_total_nnz,tl_colind, tl_values, m, thread_chunk, rowmapAc, entriesAc, valuesAc);
 
   #ifdef HAVE_TPETRA_MMM_TIMINGS
-        MMcopy.~();
+        MMcopy.~TimeMonitor();
         Teuchos::TimeMonitor MMsort (*TimeMonitor::getNewTimer(prefix_mmm + std::string("RAP Newmatrix Final Sort")));
   #endif
 
@@ -1255,7 +1255,7 @@ static inline void mult_R_A_P_newmatrix_LowThreadGustavsonKernel(CrsMatrixStruct
         Ac.setAllValues(rowmapAc, entriesAc, valuesAc);
 
   #ifdef HAVE_TPETRA_MMM_TIMINGS
-        MMsort.~();
+        MMsort.~TimeMonitor();
         Teuchos::TimeMonitor MMfill (*TimeMonitor::getNewTimer(prefix_mmm + std::string("RAP Newmatrix ESFC")));
   #endif
 

--- a/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_def.hpp
@@ -771,11 +771,11 @@ public:
       " <= 0.  The block size must be positive.");
     {
       // These are rcp
-      const auto domainPointMap = getDomainMap();
+      const auto rcpDomainPointMap = getDomainMap();
       const auto colPointMap = Teuchos::rcp 
         (new typename BMV::map_type (BMV::makePointMap (*graph_.getColMap(), blockSize_)));
       *pointImporter_ = Teuchos::rcp 
-        (new typename crs_graph_type::import_type (domainPointMap, colPointMap));
+        (new typename crs_graph_type::import_type (rcpDomainPointMap, colPointMap));
     }
     {
       typedef typename crs_graph_type::local_graph_type::row_map_type row_map_type;

--- a/packages/trilinoscouplings/examples/scaling/HybridIntrepidPoisson2D_Pamgen_Tpetra_main.cpp
+++ b/packages/trilinoscouplings/examples/scaling/HybridIntrepidPoisson2D_Pamgen_Tpetra_main.cpp
@@ -104,6 +104,9 @@ main (int argc, char *argv[])
 #ifdef HAVE_TRILINOSCOUPLINGS_MUELU
   typedef TpetraIntrepidPoissonExample::LO LO;
   typedef TpetraIntrepidPoissonExample::GO GO;
+#else
+  typedef TpetraIntrepidPoissonExample::sparse_matrix_type::local_ordinal_type LO;
+  typedef TpetraIntrepidPoissonExample::sparse_matrix_type::global_ordinal_type GO;
 #endif // HAVE_TRILINOSCOUPLINGS_MUELU
   typedef TpetraIntrepidPoissonExample::Node Node;
   typedef Teuchos::ScalarTraits<ST> STS;


### PR DESCRIPTION

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Description
Fixes for build errors uncovered by Tpetra deprecation  work. Also fix for code inside #ifdef HAVE_TPETRA_MMM_TIMINGS that apparently has not ever been compiled.

## How Has This Been Tested?
Built on Rhel6 ceerws1412


## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [ x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
