### PR TITLE
Framwork: Strip off whitespace from arguments

### DIFF
--- a/cmake/std/PullRequestLinuxDriverMerge.py
+++ b/cmake/std/PullRequestLinuxDriverMerge.py
@@ -80,6 +80,12 @@ def parseArgs():
 
 
 def merge_branch(source_url, source_branch, target_branch, sourceSHA):
+
+    source_url    = source_url.strip()
+    source_branch = source_branch.strip()
+    target_branch = target_branch.strip()
+    sourceSHA     = sourceSHA.strip()
+
     remote_list = subprocess.check_output(['git', 'remote', '-v'])
     if 'source_remote' in remote_list:
         print('git remote exists, removing it', file=sys.stdout)
@@ -110,6 +116,9 @@ def merge_branch(source_url, source_branch, target_branch, sourceSHA):
 
     actual_source_SHA = subprocess.check_output(['git', 'rev-parse',
                                                  'source_remote/' + source_branch])
+
+    actual_source_SHA = actual_source_SHA.strip()
+
     if actual_source_SHA != sourceSHA:
         print('The SHA ({source_sha}) for the last commit on branch {source_branch}'.format(source_sha=actual_source_SHA,
                                                                                             source_branch=source_branch),


### PR DESCRIPTION
@trilinos/framework 

@prwolfe I was hitting problems trying to test out my sandboxed Jenkins job for installation testing and the error in the console log looks something like this:
```
18:13:54 The SHA (0a17f129cb98cbd8241fa0d351a97df0aa6998d2
18:13:54 ) for the last commit on branch fmwk-installation-testing
18:13:54   in repo https://github.com/william76/Trilinos is different than the expected SHA,
18:13:54   which is: 0a17f129cb98cbd8241fa0d351a97df0aa6998d2.
18:13:54 Build step 'Execute shell' marked build as failure
```

The print message in `PullRequestLinuxDriverMerge.py` that generates this is the following:
```python
    if actual_source_SHA != sourceSHA:
        print('The SHA ({source_sha}) for the last commit on branch {source_branch}'.format(source_sha=actual_source_SHA,
                                                                                            source_branch=source_branch),
              file=sys.stdout)
        print('  in repo {source_repo} is different than the expected SHA,'.format(source_repo=source_url),
              file=sys.stdout)
        print('  which is: {source_sha}.'.format(source_sha=sourceSHA),
              file=sys.stdout)
        raise SystemExit(-1)
```
Looking closely at that first `print()` I can see that the newline after the SHA1 for `{source_sha}` shouldn't be there.  This makes me think there's a newline is picked up from that string from somewhere... but the SHA1 is going in via a Jenkins parameter. Maybe my cut and paste from my console window is picking it up and Jenkins doesn't show that because it's a single line window.

In any case, this PR is just adding some defensive coding to the `merge_branch()` function to strip trailing and leading white space from the strings.

