### PR TITLE
Ifpack2 vector length adjustment for ARM

### DIFF
--- a/packages/kokkos-kernels/src/batched/KokkosBatched_Vector.hpp
+++ b/packages/kokkos-kernels/src/batched/KokkosBatched_Vector.hpp
@@ -26,8 +26,10 @@ namespace KokkosBatched {
     enum : int { value = 16 };
 #elif defined(__AVX__) || defined(__AVX2__)
     enum : int { value = 8 };
+#elif defined(__ARM_ARCH)
+    enum : int { value = 8 };    
 #else
-    enum : int { value = 16 };      
+    enum : int { value = 8 };      
 #endif
   };
   template<>
@@ -36,8 +38,10 @@ namespace KokkosBatched {
     enum : int { value = 8 };
 #elif defined(__AVX__) || defined(__AVX2__)
     enum : int { value = 4 };
+#elif defined(__ARM_ARCH)
+    enum : int { value = 4 };    
 #else
-    enum : int { value = 8 };      
+    enum : int { value = 4 };      
 #endif
   };
   template<>    
@@ -46,8 +50,10 @@ namespace KokkosBatched {
     enum : int { value = 8 };
 #elif defined(__AVX__) || defined(__AVX2__)
     enum : int { value = 4 };
+#elif defined(__ARM_ARCH)
+    enum : int { value = 4 };    
 #else
-    enum : int { value = 8 };      
+    enum : int { value = 4 };      
 #endif
   };
   template<>
@@ -56,8 +62,10 @@ namespace KokkosBatched {
     enum : int { value = 4 };
 #elif defined(__AVX__) || defined(__AVX2__)
     enum : int { value = 2 };
+#elif defined(__ARM_ARCH)
+    enum : int { value = 2 };    
 #else 
-    enum : int { value = 4 };      
+    enum : int { value = 2 };      
 #endif
   };
 


### PR DESCRIPTION
## Description
For ARM vectorizations, we may want to use 256bit vector length (4 doubles) even if the hardware supports 128bit (2 doubles). Using 128bit length, it does not seem to hide latency well. This is a very rough estimation with experiments. We do this so that we can set up a baseline performance of the Ifpack2 block tridiagonal solver (SPARC). I will submit a separate PR for KK.

FYI: As we do not have have a PR test with ARM, the PR test would (should) not complain in this PR. 
