### PR TITLE
Tempus: Add Initialization to Steppers 5908

### DIFF
--- a/packages/piro/src/Piro_TempusSolver_Def.hpp
+++ b/packages/piro/src/Piro_TempusSolver_Def.hpp
@@ -380,7 +380,7 @@ Piro::TempusSolver<Scalar>::TempusSolver(
   *out << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
 #endif
   if (fwdStateStepper->getModel() != underlyingModel) {
-    fwdStateStepper->setNonConstModel(underlyingModel);
+    fwdStateStepper->setModel(underlyingModel);
   }
 }
 
@@ -425,7 +425,7 @@ Piro::TempusSolver<Scalar>::TempusSolver(
   }
 
   if (fwdStateStepper->getModel() != underlyingModel) {
-    fwdStateStepper->setNonConstModel(underlyingModel);
+    fwdStateStepper->setModel(underlyingModel);
   }
 }
 
@@ -988,6 +988,7 @@ setObserver()
     //Set observer in integrator
     fwdStateIntegrator->getObserver()->clearObservers();
     fwdStateIntegrator->setObserver(observer);
+    fwdStateStepper->initialize();
     //Reinitialize everything in integrator class, since we have changed the observer.
     fwdStateIntegrator->initialize();
   }
@@ -1022,6 +1023,7 @@ void Piro::TempusSolver<Scalar>::
 setInitialGuess(Teuchos::RCP< const Thyra::VectorBase<Scalar> > initial_guess) 
 {
    fwdStateStepper->setInitialGuess(initial_guess); 
+   fwdStateStepper->initialize();
 }
 
 #ifdef ALBANY_BUILD

--- a/packages/tempus/src/Tempus_IntegratorBasic_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorBasic_impl.hpp
@@ -103,7 +103,7 @@ void IntegratorBasic<Scalar>::setStepper(
     std::string stepperName = integratorPL_->get<std::string>("Stepper Name");
 
     RCP<ParameterList> stepperPL = Teuchos::sublist(tempusPL_,stepperName,true);
-    stepper_ = sf->createStepper(stepperPL, models);
+    stepper_ = sf->createMultiSteppers(stepperPL, models);
   } else {
     stepper_->createSubSteppers(models);
   }

--- a/packages/tempus/src/Tempus_StepperBDF2_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperBDF2_decl.hpp
@@ -80,7 +80,7 @@ public:
   /** \brief Default constructor.
    *
    *  - Requires the following calls before takeStep():
-   *    setModel(), setSolver(), setStartUpStepper() and initialize().
+   *    setModel() and initialize().
   */
   StepperBDF2();
 
@@ -100,6 +100,9 @@ public:
 
   /// \name Basic stepper methods
   //@{
+    virtual void setModel(
+      const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel);
+
     virtual void setObserver(
       Teuchos::RCP<StepperObserver<Scalar> > obs = Teuchos::null);
 
@@ -107,8 +110,7 @@ public:
     { return this->stepperObserver_; }
 
     /// Set the stepper to use in first step
-    void setStartUpStepper(std::string startupStepperType =
-                           "DIRK 1 Stage Theta Method");
+    void setStartUpStepper(std::string startupStepperType);
     void setStartUpStepper(Teuchos::RCP<Stepper<Scalar> > startupStepper);
 
     /// Initialize during construction and after changing input parameters.
@@ -158,12 +160,14 @@ public:
                           const Teuchos::EVerbosityLevel verbLevel) const;
   //@}
 
+  virtual bool isValidSetup(Teuchos::FancyOStream & out) const;
+
 private:
 
-  Teuchos::RCP<Stepper<Scalar> >                     startUpStepper_;
-  Teuchos::RCP<StepperObserverComposite<Scalar> >    stepperObserver_;
-  Teuchos::RCP<StepperBDF2Observer<Scalar> >         stepperBDF2Observer_;
-  Scalar                                             order_;
+  Teuchos::RCP<Stepper<Scalar> >             startUpStepper_;
+  Teuchos::RCP<StepperObserverComposite<Scalar> >     stepperObserver_;
+  Teuchos::RCP<StepperBDF2Observer<Scalar> > stepperBDF2Observer_;
+  Scalar                                     order_ = Scalar(2.0);
 };
 
 /** \brief Time-derivative interface for BDF2.

--- a/packages/tempus/src/Tempus_StepperBackwardEuler_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperBackwardEuler_decl.hpp
@@ -62,7 +62,7 @@ public:
 
   /** \brief Default constructor.
    *
-   *  Requires subsequent setModel(), setSolver() and initialize()
+   *  Requires subsequent setModel() and initialize()
    *  calls before calling takeStep().
   */
   StepperBackwardEuler();
@@ -72,6 +72,7 @@ public:
     const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
     const Teuchos::RCP<StepperObserver<Scalar> >& obs,
     const Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> >& solver,
+    const Teuchos::RCP<Stepper<Scalar> >& predictorStepper,
     bool useFSAL,
     std::string ICConsistency,
     bool ICConsistencyCheck,
@@ -79,18 +80,19 @@ public:
 
   /// \name Basic stepper methods
   //@{
+    virtual void setModel(
+      const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel);
+
     virtual void setObserver(
       Teuchos::RCP<StepperObserver<Scalar> > obs = Teuchos::null);
 
     virtual Teuchos::RCP<StepperObserver<Scalar> > getObserver() const
-    { return this->stepperBEObserver_; }
+    { return stepperBEObserver_; }
 
     /// Set the predictor
-    void setPredictor(std::string predictorType = "None");
-    void setPredictor(Teuchos::RCP<Stepper<Scalar> > predictorStepper);
-
-    /// Initialize during construction and after changing input parameters.
-    virtual void initialize();
+    void setPredictor(std::string predictorType);
+    void setPredictor(Teuchos::RCP<Stepper<Scalar> > predictorStepper =
+      Teuchos::null);
 
     /// Set the initial conditions and make them consistent.
     virtual void setInitialConditions (
@@ -132,6 +134,8 @@ public:
     virtual void describe(Teuchos::FancyOStream        & out,
                           const Teuchos::EVerbosityLevel verbLevel) const;
   //@}
+
+  virtual bool isValidSetup(Teuchos::FancyOStream & out) const;
 
   /// \name Implementation of StepperOptimizationInterface
   //@{

--- a/packages/tempus/src/Tempus_StepperDIRK_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperDIRK_decl.hpp
@@ -157,7 +157,7 @@ public:
     virtual Teuchos::RCP<StepperObserver<Scalar> > getObserver() const
     { return this->stepperObserver_; }
 
-    /// Initialize during construction and after changing input parameters.
+    /// Initialize after construction and changing input parameters.
     virtual void initialize();
 
     /// Set the initial conditions and make them consistent.
@@ -223,6 +223,8 @@ public:
                           const Teuchos::EVerbosityLevel verbLevel) const;
   //@}
 
+  virtual bool isValidSetup(Teuchos::FancyOStream & out) const;
+
   /// \name Accessors methods
   //@{
     /** \brief Use embedded if avialable. */
@@ -257,6 +259,7 @@ protected:
   Teuchos::RCP<Thyra::VectorBase<Scalar> >               xTilde_;
 
   Teuchos::RCP<StepperRKObserverComposite<Scalar> >        stepperObserver_;
+
 
   // For Embedded RK
   bool useEmbedded_;

--- a/packages/tempus/src/Tempus_StepperExplicitRK_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperExplicitRK_decl.hpp
@@ -146,6 +146,8 @@ public:
                           const Teuchos::EVerbosityLevel verbLevel) const;
   //@}
 
+  virtual bool isValidSetup(Teuchos::FancyOStream & out) const;
+
   /// \name Accessors methods
   //@{
     /** \brief Use embedded if avialable. */
@@ -174,8 +176,8 @@ protected:
 
   Teuchos::RCP<RKButcherTableau<Scalar> >                tableau_;
 
-  std::vector<Teuchos::RCP<Thyra::VectorBase<Scalar> > >     stageXDot_;
-  Teuchos::RCP<Thyra::VectorBase<Scalar> >                   stageX_;
+  std::vector<Teuchos::RCP<Thyra::VectorBase<Scalar> > > stageXDot_;
+  Teuchos::RCP<Thyra::VectorBase<Scalar> >               stageX_;
 
   Teuchos::RCP<StepperRKObserverComposite<Scalar> >          stepperObserver_;
 

--- a/packages/tempus/src/Tempus_StepperExplicit_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperExplicit_decl.hpp
@@ -46,8 +46,6 @@ public:
   //@{
     virtual void setModel(
       const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel);
-    virtual void setNonConstModel(
-      const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& appModel);
     virtual Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >
       getModel(){return appModel_;}
 
@@ -60,7 +58,7 @@ public:
       const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory);
 
     virtual void setSolver(
-      Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > solver = Teuchos::null);
+      Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > solver);
 
     virtual Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > getSolver() const
       { return Teuchos::null; }
@@ -112,6 +110,14 @@ public:
       const Scalar time,
       const Teuchos::RCP<ExplicitODEParameters<Scalar> > & p );
   //@}
+
+  /// \name Overridden from Teuchos::Describable
+  //@{
+    virtual void describe(Teuchos::FancyOStream        & out,
+                          const Teuchos::EVerbosityLevel verbLevel) const;
+  //@}
+
+  virtual bool isValidSetup(Teuchos::FancyOStream & out) const;
 
 protected:
 

--- a/packages/tempus/src/Tempus_StepperExplicit_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperExplicit_impl.hpp
@@ -26,13 +26,6 @@ void StepperExplicit<Scalar>::setModel(
 
 
 template<class Scalar>
-void StepperExplicit<Scalar>::setNonConstModel(
-  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& appModel)
-{
-  setModel(appModel);
-}
-
-template<class Scalar>
 void StepperExplicit<Scalar>::setInitialConditions(
   const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory)
 {
@@ -350,6 +343,35 @@ evaluateExplicitODE(Teuchos::RCP<      Thyra::VectorBase<Scalar> > xDotDot,
   outArgs_.set_f(xDotDot);
 
   appModel_->evalModel(inArgs_, outArgs_);
+}
+
+
+
+template<class Scalar>
+void StepperExplicit<Scalar>::describe(Teuchos::FancyOStream        & out,
+                               const Teuchos::EVerbosityLevel verbLevel) const
+{
+  out << "--- StepperExplicit ---\n";
+  out << "  appModel_         = " << appModel_ << std::endl;
+  out << "  inArgs_           = " << inArgs_ << std::endl;
+  out << "  outArgs_          = " << outArgs_ << std::endl;
+  out << "  stepperX_         = " << stepperX_ << std::endl;
+  out << "  stepperXDot_      = " << stepperXDot_ << std::endl;
+  out << "  stepperXDotDot_   = " << stepperXDotDot_ << std::endl;
+}
+
+
+template<class Scalar>
+bool StepperExplicit<Scalar>::isValidSetup(Teuchos::FancyOStream & out) const
+{
+  bool isValidSetup = true;
+
+  if (appModel_ == Teuchos::null) {
+    isValidSetup = false;
+    out << "The application ModelEvaluator is not set!\n";
+  }
+
+  return isValidSetup;
 }
 
 

--- a/packages/tempus/src/Tempus_StepperFactory.hpp
+++ b/packages/tempus/src/Tempus_StepperFactory.hpp
@@ -68,10 +68,9 @@ public:
   }
 
   /// Create stepper from ParameterList with its details.
-  Teuchos::RCP<Stepper<Scalar> > createStepper(
+  Teuchos::RCP<Stepper<Scalar> > createMultiSteppers(
     Teuchos::RCP<Teuchos::ParameterList> stepperPL,
-    std::vector<Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > >
-      models = Teuchos::null)
+    std::vector<Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > > models)
   {
     std::string stepperType = stepperPL->get<std::string>("Stepper Type");
     return this->createStepper(models, stepperType, stepperPL);

--- a/packages/tempus/src/Tempus_StepperForwardEulerObserver.hpp
+++ b/packages/tempus/src/Tempus_StepperForwardEulerObserver.hpp
@@ -9,6 +9,7 @@
 #ifndef Tempus_StepperForwardEulerObserver_hpp
 #define Tempus_StepperForwardEulerObserver_hpp
 
+#include "Tempus_StepperObserver.hpp"
 #include "Tempus_SolutionHistory.hpp"
 
 

--- a/packages/tempus/src/Tempus_StepperForwardEuler_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperForwardEuler_decl.hpp
@@ -77,9 +77,6 @@ public:
     virtual Teuchos::RCP<StepperObserver<Scalar> > getObserver() const
     { return this->stepperFEObserver_; }
 
-    /// Initialize during construction and after changing input parameters.
-    virtual void initialize();
-
     /// Set the initial conditions, make them consistent, and set needed memory.
     virtual void setInitialConditions (
       const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory);
@@ -104,6 +101,8 @@ public:
     virtual void describe(Teuchos::FancyOStream        & out,
                           const Teuchos::EVerbosityLevel verbLevel) const;
   //@}
+
+  virtual bool isValidSetup(Teuchos::FancyOStream & out) const;
 
 protected:
 

--- a/packages/tempus/src/Tempus_StepperHHTAlpha_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperHHTAlpha_decl.hpp
@@ -78,9 +78,6 @@ public:
     virtual Teuchos::RCP<StepperObserver<Scalar> > getObserver() const
     { return Teuchos::null; }
 
-    /// Initialize during construction and after changing input parameters.
-    virtual void initialize();
-
     /// Set the initial conditions and make them consistent.
     virtual void setInitialConditions (
       const Teuchos::RCP<SolutionHistory<Scalar> >& /* solutionHistory */){}
@@ -124,41 +121,43 @@ public:
                           const Teuchos::EVerbosityLevel verbLevel) const;
   //@}
 
-    void predictVelocity(Thyra::VectorBase<Scalar>& vPred,
+  virtual bool isValidSetup(Teuchos::FancyOStream & out) const;
+
+  void predictVelocity(Thyra::VectorBase<Scalar>& vPred,
+                           const Thyra::VectorBase<Scalar>& v,
+                           const Thyra::VectorBase<Scalar>& a,
+                           const Scalar dt) const;
+
+  void predictDisplacement(Thyra::VectorBase<Scalar>& dPred,
+                             const Thyra::VectorBase<Scalar>& d,
                              const Thyra::VectorBase<Scalar>& v,
                              const Thyra::VectorBase<Scalar>& a,
                              const Scalar dt) const;
 
-    void predictDisplacement(Thyra::VectorBase<Scalar>& dPred,
-                               const Thyra::VectorBase<Scalar>& d,
-                               const Thyra::VectorBase<Scalar>& v,
-                               const Thyra::VectorBase<Scalar>& a,
-                               const Scalar dt) const;
+  void predictVelocity_alpha_f(Thyra::VectorBase<Scalar>& vPred,
+                               const Thyra::VectorBase<Scalar>& v) const;
 
-    void predictVelocity_alpha_f(Thyra::VectorBase<Scalar>& vPred,
-                                 const Thyra::VectorBase<Scalar>& v) const;
+  void predictDisplacement_alpha_f(Thyra::VectorBase<Scalar>& dPred,
+                                   const Thyra::VectorBase<Scalar>& d) const;
 
-    void predictDisplacement_alpha_f(Thyra::VectorBase<Scalar>& dPred,
-                                     const Thyra::VectorBase<Scalar>& d) const;
+  void correctAcceleration(Thyra::VectorBase<Scalar>& a_n_plus1,
+                            const Thyra::VectorBase<Scalar>& a_n) const;
 
-    void correctAcceleration(Thyra::VectorBase<Scalar>& a_n_plus1,
-                              const Thyra::VectorBase<Scalar>& a_n) const;
+  void correctVelocity(Thyra::VectorBase<Scalar>& v,
+                           const Thyra::VectorBase<Scalar>& vPred,
+                           const Thyra::VectorBase<Scalar>& a,
+                           const Scalar dt) const;
 
-    void correctVelocity(Thyra::VectorBase<Scalar>& v,
-                             const Thyra::VectorBase<Scalar>& vPred,
+  void correctDisplacement(Thyra::VectorBase<Scalar>& d,
+                             const Thyra::VectorBase<Scalar>& dPred,
                              const Thyra::VectorBase<Scalar>& a,
                              const Scalar dt) const;
 
-    void correctDisplacement(Thyra::VectorBase<Scalar>& d,
-                               const Thyra::VectorBase<Scalar>& dPred,
-                               const Thyra::VectorBase<Scalar>& a,
-                               const Scalar dt) const;
-
-    void setSchemeName(std::string schemeName);
-    void setBeta(Scalar beta);
-    void setGamma(Scalar gamma);
-    void setAlphaF(Scalar alpha_f);
-    void setAlphaM(Scalar alpha_m);
+  void setSchemeName(std::string schemeName);
+  void setBeta(Scalar beta);
+  void setGamma(Scalar gamma);
+  void setAlphaF(Scalar alpha_f);
+  void setAlphaM(Scalar alpha_m);
 
 private:
 

--- a/packages/tempus/src/Tempus_StepperIMEX_RK_Partition_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RK_Partition_decl.hpp
@@ -353,6 +353,8 @@ public:
                           const Teuchos::EVerbosityLevel verbLevel) const;
   //@}
 
+  virtual bool isValidSetup(Teuchos::FancyOStream & out) const;
+
   void evalImplicitModelExplicitly(
     const Teuchos::RCP<const Thyra::VectorBase<Scalar> > & X,
     const Teuchos::RCP<const Thyra::VectorBase<Scalar> > & Y,

--- a/packages/tempus/src/Tempus_StepperIMEX_RK_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RK_decl.hpp
@@ -330,6 +330,8 @@ public:
                           const Teuchos::EVerbosityLevel verbLevel) const;
   //@}
 
+  virtual bool isValidSetup(Teuchos::FancyOStream & out) const;
+
   void evalImplicitModelExplicitly(
     const Teuchos::RCP<const Thyra::VectorBase<Scalar> > & X,
     Scalar time, Scalar stepSize, Scalar stageNumber,

--- a/packages/tempus/src/Tempus_StepperImplicit_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperImplicit_decl.hpp
@@ -232,16 +232,19 @@ public:
   //@{
     virtual void setModel(
       const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel);
-    virtual void setNonConstModel(
-      const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& appModel);
-    virtual Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >
-      getModel(){return wrapperModel_->getAppModel();}
+    virtual Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > getModel()
+    {
+      Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > model;
+      if (wrapperModel_ != Teuchos::null) model = wrapperModel_->getAppModel();
+      return model;
+    }
     virtual Teuchos::RCP<const WrapperModelEvaluator<Scalar> >
       getWrapperModel(){return wrapperModel_;}
 
+    virtual void setDefaultSolver();
     /// Set solver.
     virtual void setSolver(
-      Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > solver = Teuchos::null);
+      Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > solver);
     virtual Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > getSolver() const
       { return solver_; }
 
@@ -275,11 +278,17 @@ public:
 
     /// Pass initial guess to Newton solver (only relevant for implicit solvers)
     virtual void setInitialGuess(
-      Teuchos::RCP<const Thyra::VectorBase<Scalar> > initial_guess)
-      {initial_guess_ = initial_guess;}
+      Teuchos::RCP<const Thyra::VectorBase<Scalar> > initialGuess)
+    {
+      initialGuess_ = initialGuess;
+      this->isInitialized_ = false;
+    }
 
     /// Set parameter so that the initial guess is set to zero (=True) or use last timestep (=False).
-    virtual void setZeroInitialGuess(bool zIG) { zeroInitialGuess_ = zIG; }
+    virtual void setZeroInitialGuess(bool zIG) {
+      zeroInitialGuess_ = zIG;
+      this->isInitialized_ = false;
+    }
     virtual bool getZeroInitialGuess() const { return zeroInitialGuess_; }
 
     virtual Scalar getInitTimeStep(
@@ -299,11 +308,19 @@ public:
       Teuchos::RCP<SolutionState<Scalar> > state);
   //@}
 
+  /// \name Overridden from Teuchos::Describable
+  //@{
+    virtual void describe(Teuchos::FancyOStream        & out,
+                          const Teuchos::EVerbosityLevel verbLevel) const;
+  //@}
+
+  virtual bool isValidSetup(Teuchos::FancyOStream & out) const;
+
 protected:
 
   Teuchos::RCP<WrapperModelEvaluator<Scalar> >        wrapperModel_;
   Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> >   solver_;
-  Teuchos::RCP<const Thyra::VectorBase<Scalar> >      initial_guess_;
+  Teuchos::RCP<const Thyra::VectorBase<Scalar> >      initialGuess_;
   bool zeroInitialGuess_;
 
   Teuchos::RCP<StepperObserver<Scalar> >              stepperObserver_;

--- a/packages/tempus/src/Tempus_StepperLeapfrog_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperLeapfrog_decl.hpp
@@ -101,9 +101,6 @@ public:
     virtual Teuchos::RCP<StepperObserver<Scalar> > getObserver() const
     { return this->stepperObserver_; }
 
-    /// Initialize during construction and after changing input parameters.
-    virtual void initialize();
-
     /// Set the initial conditions and make them consistent.
     virtual void setInitialConditions (
       const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory);
@@ -140,6 +137,8 @@ public:
     virtual void describe(Teuchos::FancyOStream        & out,
                           const Teuchos::EVerbosityLevel verbLevel) const;
   //@}
+
+  virtual bool isValidSetup(Teuchos::FancyOStream & out) const;
 
 protected:
 

--- a/packages/tempus/src/Tempus_StepperNewmarkExplicitAForm_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkExplicitAForm_decl.hpp
@@ -84,9 +84,6 @@ public:
     virtual Teuchos::RCP<StepperObserver<Scalar> > getObserver() const
     { return Teuchos::null; }
 
-    /// Initialize during construction and after changing input parameters.
-    virtual void initialize();
-
     /// Set the initial conditions and make them consistent.
     virtual void setInitialConditions (
       const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory);
@@ -125,6 +122,8 @@ public:
                           const Teuchos::EVerbosityLevel verbLevel) const;
   //@}
 
+  virtual bool isValidSetup(Teuchos::FancyOStream & out) const;
+
   void predictVelocity(Thyra::VectorBase<Scalar>& vPred,
                            const Thyra::VectorBase<Scalar>& v,
                            const Thyra::VectorBase<Scalar>& a,
@@ -149,6 +148,8 @@ public:
       std::logic_error,
       "Error in 'Newmark Explicit a-Form' stepper: invalid value of Gamma = "
        << gamma_ << ".  Please select 0 <= Gamma <= 1. \n");
+
+    this->isInitialized_ = false;
   }
 
   bool getUseFSALDefault() const { return true; }

--- a/packages/tempus/src/Tempus_StepperNewmarkExplicitAForm_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkExplicitAForm_impl.hpp
@@ -98,15 +98,6 @@ StepperNewmarkExplicitAForm<Scalar>::StepperNewmarkExplicitAForm(
 
 
 template<class Scalar>
-void StepperNewmarkExplicitAForm<Scalar>::initialize()
-{
-  TEUCHOS_TEST_FOR_EXCEPTION(
-    this->appModel_ == Teuchos::null, std::logic_error,
-    "Error - Need to set the model, setModel(), before calling "
-    "StepperNewmarkExplicitAForm::initialize()\n");
-}
-
-template<class Scalar>
 void StepperNewmarkExplicitAForm<Scalar>::setInitialConditions(
   const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory)
 {
@@ -238,6 +229,8 @@ template<class Scalar>
 void StepperNewmarkExplicitAForm<Scalar>::takeStep(
   const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory)
 {
+  this->checkInitialized();
+
   using Teuchos::RCP;
 
   TEMPUS_FUNC_TIME_MONITOR("Tempus::StepperNewmarkExplicitAForm::takeStep()");
@@ -327,10 +320,27 @@ getDefaultStepperState()
 template<class Scalar>
 void StepperNewmarkExplicitAForm<Scalar>::describe(
    Teuchos::FancyOStream               &out,
-   const Teuchos::EVerbosityLevel      /* verbLevel */) const
+   const Teuchos::EVerbosityLevel      verbLevel) const
 {
-  out << this->getStepperType() << "::describe:" << std::endl
-      << "appModel_ = " << this->appModel_->description() << std::endl;
+  out << std::endl;
+  Stepper<Scalar>::describe(out, verbLevel);
+  StepperExplicit<Scalar>::describe(out, verbLevel);
+
+  out << "--- StepperNewmarkExplicitAForm ---\n";
+  out << "  gamma_ = " << gamma_ << std::endl;
+  out << "-----------------------------------" << std::endl;
+}
+
+
+template<class Scalar>
+bool StepperNewmarkExplicitAForm<Scalar>::isValidSetup(Teuchos::FancyOStream & out) const
+{
+  bool isValidSetup = true;
+
+  if ( !Stepper<Scalar>::isValidSetup(out) ) isValidSetup = false;
+  if ( !StepperExplicit<Scalar>::isValidSetup(out) ) isValidSetup = false;
+
+  return isValidSetup;
 }
 
 

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_decl.hpp
@@ -106,9 +106,6 @@ public:
     virtual Teuchos::RCP<StepperObserver<Scalar> > getObserver() const
     { return Teuchos::null; }
 
-    /// Initialize during construction and after changing input parameters.
-    virtual void initialize();
-
     /// Set the initial conditions and make them consistent.
     virtual void setInitialConditions (
       const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory);
@@ -152,33 +149,35 @@ public:
                           const Teuchos::EVerbosityLevel verbLevel) const;
   //@}
 
-    void predictVelocity(Thyra::VectorBase<Scalar>& vPred,
+  virtual bool isValidSetup(Teuchos::FancyOStream & out) const;
+
+  void predictVelocity(Thyra::VectorBase<Scalar>& vPred,
+                           const Thyra::VectorBase<Scalar>& v,
+                           const Thyra::VectorBase<Scalar>& a,
+                           const Scalar dt) const;
+
+  void predictDisplacement(Thyra::VectorBase<Scalar>& dPred,
+                             const Thyra::VectorBase<Scalar>& d,
                              const Thyra::VectorBase<Scalar>& v,
                              const Thyra::VectorBase<Scalar>& a,
                              const Scalar dt) const;
 
-    void predictDisplacement(Thyra::VectorBase<Scalar>& dPred,
-                               const Thyra::VectorBase<Scalar>& d,
-                               const Thyra::VectorBase<Scalar>& v,
-                               const Thyra::VectorBase<Scalar>& a,
-                               const Scalar dt) const;
+  void correctVelocity(Thyra::VectorBase<Scalar>& v,
+                           const Thyra::VectorBase<Scalar>& vPred,
+                           const Thyra::VectorBase<Scalar>& a,
+                           const Scalar dt) const;
 
-    void correctVelocity(Thyra::VectorBase<Scalar>& v,
-                             const Thyra::VectorBase<Scalar>& vPred,
+  void correctDisplacement(Thyra::VectorBase<Scalar>& d,
+                             const Thyra::VectorBase<Scalar>& dPred,
                              const Thyra::VectorBase<Scalar>& a,
                              const Scalar dt) const;
 
-    void correctDisplacement(Thyra::VectorBase<Scalar>& d,
-                               const Thyra::VectorBase<Scalar>& dPred,
-                               const Thyra::VectorBase<Scalar>& a,
-                               const Scalar dt) const;
+  void setSchemeName(std::string schemeName);
+  void setBeta(Scalar beta);
+  void setGamma(Scalar gamma);
 
-    void setSchemeName(std::string schemeName);
-    void setBeta(Scalar beta);
-    void setGamma(Scalar gamma);
-
-    virtual bool getUseFSALDefault() const { return true; }
-    virtual std::string getICConsistencyDefault() const { return "Consistent"; }
+  virtual bool getUseFSALDefault() const { return true; }
+  virtual std::string getICConsistencyDefault() const { return "Consistent"; }
 
 private:
 

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitDForm_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitDForm_decl.hpp
@@ -9,8 +9,8 @@
 #ifndef Tempus_StepperNewmarkImplicitDForm_decl_hpp
 #define Tempus_StepperNewmarkImplicitDForm_decl_hpp
 
-#include "Tempus_WrapperModelEvaluatorSecondOrder.hpp"
 #include "Tempus_StepperImplicit.hpp"
+#include "Tempus_WrapperModelEvaluatorSecondOrder.hpp"
 
 namespace Tempus {
 
@@ -62,53 +62,49 @@ class StepperNewmarkImplicitDForm : virtual public Tempus::StepperImplicit<Scala
 
   /// \name Basic stepper methods
   //@{
-  virtual void
-  setModel(const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar>>& appModel);
+    virtual void
+    setModel(const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar>>& appModel);
 
   virtual void setObserver(
     Teuchos::RCP<StepperObserver<Scalar> > /* obs */ = Teuchos::null){}
 
-  virtual Teuchos::RCP<StepperObserver<Scalar> > getObserver() const
-  { return Teuchos::null; }
+    virtual Teuchos::RCP<StepperObserver<Scalar> > getObserver() const
+    { return Teuchos::null; }
 
-  /// Initialize during construction and after changing input parameters.
-  virtual void
-  initialize();
+    /// Set the initial conditions and make them consistent.
+    virtual void setInitialConditions (
+      const Teuchos::RCP<SolutionHistory<Scalar> >& /* solutionHistory */){}
 
-  /// Set the initial conditions and make them consistent.
-  virtual void setInitialConditions (
-    const Teuchos::RCP<SolutionHistory<Scalar> >& /* solutionHistory */){}
+    /// Take the specified timestep, dt, and return true if successful.
+    virtual void
+    takeStep(const Teuchos::RCP<SolutionHistory<Scalar>>& solutionHistory);
 
-  /// Take the specified timestep, dt, and return true if successful.
-  virtual void
-  takeStep(const Teuchos::RCP<SolutionHistory<Scalar>>& solutionHistory);
-
-  /// Get a default (initial) StepperState
-  virtual Teuchos::RCP<Tempus::StepperState<Scalar>>
-  getDefaultStepperState();
-  virtual Scalar
-  getOrder() const {
-    if (gamma_ == 0.5)
-      return 2.0;
-    else
+    /// Get a default (initial) StepperState
+    virtual Teuchos::RCP<Tempus::StepperState<Scalar>>
+    getDefaultStepperState();
+    virtual Scalar
+    getOrder() const {
+      if (gamma_ == 0.5)
+        return 2.0;
+      else
+        return 1.0;
+    }
+    virtual Scalar
+    getOrderMin() const {
       return 1.0;
-  }
-  virtual Scalar
-  getOrderMin() const {
-    return 1.0;
-  }
-  virtual Scalar
-  getOrderMax() const {
-    return 2.0;
-  }
-  virtual bool isExplicit()         const {return false;}
-  virtual bool isImplicit()         const {return true;}
-  virtual bool isExplicitImplicit() const
-    {return isExplicit() and isImplicit();}
-  virtual bool isOneStepMethod()   const {return true;}
-  virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
+    }
+    virtual Scalar
+    getOrderMax() const {
+      return 2.0;
+    }
+    virtual bool isExplicit()         const {return false;}
+    virtual bool isImplicit()         const {return true;}
+    virtual bool isExplicitImplicit() const
+      {return isExplicit() and isImplicit();}
+    virtual bool isOneStepMethod()   const {return true;}
+    virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
 
-  virtual OrderODE getOrderODE()   const {return SECOND_ORDER_ODE;}
+    virtual OrderODE getOrderODE()   const {return SECOND_ORDER_ODE;}
   //@}
 
   /// Return W_xDotxDot_coeff = d(xDotDot)/d(x).
@@ -126,6 +122,8 @@ class StepperNewmarkImplicitDForm : virtual public Tempus::StepperImplicit<Scala
     virtual void describe(Teuchos::FancyOStream& out,
                           const Teuchos::EVerbosityLevel verbLevel) const;
   //@}
+
+  virtual bool isValidSetup(Teuchos::FancyOStream & out) const;
 
   void
   predictVelocity(
@@ -159,9 +157,6 @@ class StepperNewmarkImplicitDForm : virtual public Tempus::StepperImplicit<Scala
   void setGamma(Scalar gamma);
 
  protected:
-
-  Thyra::ModelEvaluatorBase::InArgs<Scalar> inArgs_;
-  Thyra::ModelEvaluatorBase::OutArgs<Scalar> outArgs_;
 
   std::string schemeName_;
   Scalar beta_;

--- a/packages/tempus/src/Tempus_StepperOperatorSplit_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperOperatorSplit_decl.hpp
@@ -64,9 +64,6 @@ public:
     virtual void setModel(
       const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel);
 
-    virtual void setNonConstModel(
-      const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& appModel);
-
     virtual Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >
       getModel();
 
@@ -158,21 +155,20 @@ public:
                           const Teuchos::EVerbosityLevel verbLevel) const;
   //@}
 
+  virtual bool isValidSetup(Teuchos::FancyOStream & out) const;
+
   virtual std::vector<Teuchos::RCP<Stepper<Scalar> > > getStepperList() const
     { return subStepperList_; }
   virtual void setStepperList(std::vector<Teuchos::RCP<Stepper<Scalar> > > sl)
     { subStepperList_ = sl; }
+
   /** \brief Add Stepper to subStepper list.
    *  In most cases, subSteppers cannot use xDotOld (thus the default),
    *  but in some cases, the xDotOld can be used and save compute cycles.
    *  The user can set this when adding to the subStepper list.
    */
   virtual void addStepper(Teuchos::RCP<Stepper<Scalar> > stepper,
-                          bool useFSAL = false)
-  {
-    stepper->setUseFSAL(useFSAL);
-    subStepperList_.push_back(stepper);
-  }
+                          bool useFSAL = false);
 
   virtual void setSubStepperList(
     std::vector<Teuchos::RCP<Stepper<Scalar> > > subStepperList);

--- a/packages/tempus/src/Tempus_StepperRKButcherTableau.hpp
+++ b/packages/tempus/src/Tempus_StepperRKButcherTableau.hpp
@@ -40,7 +40,12 @@ template<class Scalar>
 class StepperERK_ForwardEuler :
   virtual public StepperExplicitRK<Scalar>
 {
-  public:
+public:
+  /** \brief Default constructor.
+   *
+   * Requires subsequent setModel() and initialize()
+   * calls before calling takestep().
+  */
   StepperERK_ForwardEuler()
   {
     this->setStepperType("RK Forward Euler");
@@ -112,7 +117,12 @@ template<class Scalar>
 class StepperERK_4Stage4thOrder :
   virtual public StepperExplicitRK<Scalar>
 {
-  public:
+public:
+  /** \brief Default constructor.
+   *
+   * Requires subsequent setModel() and initialize()
+   * calls before calling takestep().
+  */
   StepperERK_4Stage4thOrder()
   {
     this->setStepperType("RK Explicit 4 Stage");
@@ -212,7 +222,12 @@ template<class Scalar>
 class StepperERK_BogackiShampine32 :
   virtual public StepperExplicitRK<Scalar>
 {
-  public:
+public:
+  /** \brief Default constructor.
+   *
+   * Requires subsequent setModel() and initialize()
+   * calls before calling takestep().
+  */
   StepperERK_BogackiShampine32()
   {
     this->setStepperType("Bogacki-Shampine 3(2) Pair");
@@ -325,7 +340,12 @@ template<class Scalar>
 class StepperERK_Merson45 :
   virtual public StepperExplicitRK<Scalar>
 {
-  public:
+public:
+  /** \brief Default constructor.
+   *
+   * Requires subsequent setModel() and initialize()
+   * calls before calling takestep().
+  */
   StepperERK_Merson45()
   {
     this->setStepperType("Merson 4(5) Pair");
@@ -549,7 +569,12 @@ template<class Scalar>
 class StepperERK_4Stage3rdOrderRunge :
   virtual public StepperExplicitRK<Scalar>
 {
-  public:
+public:
+  /** \brief Default constructor.
+   *
+   * Requires subsequent setModel() and initialize()
+   * calls before calling takestep().
+  */
   StepperERK_4Stage3rdOrderRunge()
   {
     this->setStepperType("RK Explicit 4 Stage 3rd order by Runge");
@@ -647,7 +672,12 @@ template<class Scalar>
 class StepperERK_5Stage3rdOrderKandG :
   virtual public StepperExplicitRK<Scalar>
 {
-  public:
+public:
+  /** \brief Default constructor.
+   *
+   * Requires subsequent setModel() and initialize()
+   * calls before calling takestep().
+  */
   StepperERK_5Stage3rdOrderKandG()
   {
     this->setStepperType("RK Explicit 5 Stage 3rd order by Kinnmark and Gray");
@@ -745,7 +775,12 @@ template<class Scalar>
 class StepperERK_3Stage3rdOrder :
   virtual public StepperExplicitRK<Scalar>
 {
-  public:
+public:
+  /** \brief Default constructor.
+   *
+   * Requires subsequent setModel() and initialize()
+   * calls before calling takestep().
+  */
   StepperERK_3Stage3rdOrder()
   {
     this->setStepperType("RK Explicit 3 Stage 3rd order");
@@ -846,7 +881,12 @@ template<class Scalar>
 class StepperERK_3Stage3rdOrderTVD :
   virtual public StepperExplicitRK<Scalar>
 {
-  public:
+public:
+  /** \brief Default constructor.
+   *
+   * Requires subsequent setModel() and initialize()
+   * calls before calling takestep().
+  */
   StepperERK_3Stage3rdOrderTVD()
   {
     this->setStepperType("RK Explicit 3 Stage 3rd order TVD");
@@ -949,7 +989,12 @@ template<class Scalar>
 class StepperERK_3Stage3rdOrderHeun :
   virtual public StepperExplicitRK<Scalar>
 {
-  public:
+public:
+  /** \brief Default constructor.
+   *
+   * Requires subsequent setModel() and initialize()
+   * calls before calling takestep().
+  */
   StepperERK_3Stage3rdOrderHeun()
   {
     this->setStepperType("RK Explicit 3 Stage 3rd order by Heun");
@@ -1046,7 +1091,12 @@ template<class Scalar>
 class StepperERK_Midpoint :
   virtual public StepperExplicitRK<Scalar>
 {
-  public:
+public:
+  /** \brief Default constructor.
+   *
+   * Requires subsequent setModel() and initialize()
+   * calls before calling takestep().
+  */
   StepperERK_Midpoint()
   {
     this->setStepperType("RK Explicit Midpoint");
@@ -1134,7 +1184,12 @@ template<class Scalar>
 class StepperERK_Trapezoidal :
   virtual public StepperExplicitRK<Scalar>
 {
-  public:
+public:
+  /** \brief Default constructor.
+   *
+   * Requires subsequent setModel() and initialize()
+   * calls before calling takestep().
+  */
   StepperERK_Trapezoidal()
   {
     this->setStepperType("RK Explicit Trapezoidal");
@@ -1215,7 +1270,7 @@ protected:
  *  Reference:  Gottlieb, S., Ketcheson, D.I., Shu, C.-W.
  *              Strong Stability Preserving Runge–Kutta and Multistep Time Discretizations.
  *              World Scientific Press, London (2011)
- *               
+ *
  *
  */
 template<class Scalar>
@@ -1422,6 +1477,7 @@ public:
   {
     this->tableau_ = Teuchos::rcp(new RKButcherTableau<Scalar>(
       this->getStepperType(),A,b,c,order,orderMin,orderMax,bstar));
+    this->isInitialized_ = false;
   }
 
   virtual std::string getDefaultICConsistency() const { return "Consistent"; }
@@ -1468,7 +1524,12 @@ template<class Scalar>
 class StepperDIRK_BackwardEuler :
   virtual public StepperDIRK<Scalar>
 {
-  public:
+public:
+  /** \brief Default constructor.
+   *
+   *  Requires subsequent setModel() and initialize()
+   *  calls before calling takeStep().
+  */
   StepperDIRK_BackwardEuler()
   {
     this->setStepperType("RK Backward Euler");
@@ -1568,7 +1629,12 @@ template<class Scalar>
 class StepperSDIRK_2Stage2ndOrder :
   virtual public StepperDIRK<Scalar>
 {
-  public:
+public:
+  /** \brief Default constructor.
+   *
+   * Requires subsequent setModel() and initialize()
+   * calls before calling takestep().
+  */
   StepperSDIRK_2Stage2ndOrder()
   {
     typedef Teuchos::ScalarTraits<Scalar> ST;
@@ -1603,7 +1669,12 @@ class StepperSDIRK_2Stage2ndOrder :
                 ICConsistencyCheck, useEmbedded, zeroInitialGuess);
   }
 
-  void setGamma(Scalar gamma) { gamma_ = gamma; this->setupTableau(); }
+  void setGamma(Scalar gamma)
+  {
+    gamma_ = gamma;
+    this->isInitialized_ = false;
+    this->setupTableau();
+  }
 
   std::string getDescription() const
   {
@@ -1705,7 +1776,12 @@ template<class Scalar>
 class StepperSDIRK_2Stage3rdOrder :
   virtual public StepperDIRK<Scalar>
 {
-  public:
+public:
+  /** \brief Default constructor.
+   *
+   * Requires subsequent setModel() and initialize()
+   * calls before calling takestep().
+  */
   StepperSDIRK_2Stage3rdOrder()
   {
     typedef Teuchos::ScalarTraits<Scalar> ST;
@@ -1756,8 +1832,9 @@ class StepperSDIRK_2Stage3rdOrder :
       "gammaType needs to be '3rd Order A-stable', '2nd Order L-stable' "
       "or 'gamma'.");
 
-     gammaType_ = gammaType;
-     this->setupTableau();
+    gammaType_ = gammaType;
+    this->isInitialized_ = false;
+    this->setupTableau();
   }
   void setGamma(Scalar gamma)
   {
@@ -1765,6 +1842,7 @@ class StepperSDIRK_2Stage3rdOrder :
       gamma_ = gamma;
       this->setupTableau();
     }
+    this->isInitialized_ = false;
   }
 
   std::string getDescription() const
@@ -1874,7 +1952,12 @@ template<class Scalar>
 class StepperEDIRK_2Stage3rdOrder :
   virtual public StepperDIRK<Scalar>
 {
-  public:
+public:
+  /** \brief Default constructor.
+   *
+   * Requires subsequent setModel() and initialize()
+   * calls before calling takestep().
+  */
   StepperEDIRK_2Stage3rdOrder()
   {
     this->setStepperType("EDIRK 2 Stage 3rd order");
@@ -1986,7 +2069,12 @@ template<class Scalar>
 class StepperDIRK_1StageTheta :
   virtual public StepperDIRK<Scalar>
 {
-  public:
+public:
+  /** \brief Default constructor.
+   *
+   * Requires subsequent setModel() and initialize()
+   * calls before calling takestep().
+  */
   StepperDIRK_1StageTheta()
   {
     typedef Teuchos::ScalarTraits<Scalar> ST;
@@ -2027,6 +2115,7 @@ class StepperDIRK_1StageTheta :
       "Try using the 'RK Forward Euler' stepper.\n");
     theta_ = theta;
     this->setupTableau();
+    this->isInitialized_ = false;
   }
 
   std::string getDescription() const
@@ -2119,7 +2208,12 @@ template<class Scalar>
 class StepperEDIRK_2StageTheta :
   virtual public StepperDIRK<Scalar>
 {
-  public:
+public:
+  /** \brief Default constructor.
+   *
+   * Requires subsequent setModel() and initialize()
+   * calls before calling takestep().
+  */
   StepperEDIRK_2StageTheta()
   {
     typedef Teuchos::ScalarTraits<Scalar> ST;
@@ -2159,6 +2253,7 @@ class StepperEDIRK_2StageTheta :
       "'theta' can not be zero, as it makes this stepper explicit. \n"
       "Try using the 'RK Forward Euler' stepper.\n");
     theta_ = theta;
+    this->isInitialized_ = false;
     this->setupTableau();
   }
 
@@ -2257,7 +2352,12 @@ template<class Scalar>
 class StepperEDIRK_TrapezoidalRule :
   virtual public StepperDIRK<Scalar>
 {
-  public:
+public:
+  /** \brief Default constructor.
+   *
+   * Requires subsequent setModel() and initialize()
+   * calls before calling takestep().
+  */
   StepperEDIRK_TrapezoidalRule()
   {
     this->setStepperType("RK Trapezoidal Rule");
@@ -2368,7 +2468,12 @@ template<class Scalar>
 class StepperSDIRK_ImplicitMidpoint :
   virtual public StepperDIRK<Scalar>
 {
-  public:
+public:
+  /** \brief Default constructor.
+   *
+   * Requires subsequent setModel() and initialize()
+   * calls before calling takestep().
+  */
   StepperSDIRK_ImplicitMidpoint()
   {
     this->setStepperType("RK Implicit Midpoint");
@@ -2471,8 +2576,6 @@ protected:
  *  Reference:  Gottlieb, S., Ketcheson, D.I., Shu, C.-W.
  *              Strong Stability Preserving Runge–Kutta and Multistep Time Discretizations.
  *              World Scientific Press, London (2011)
- *               
- *
  */
 template<class Scalar>
 class StepperSDIRK_SSPDIRK22 :
@@ -2581,8 +2684,6 @@ protected:
  *  Reference:  Gottlieb, S., Ketcheson, D.I., Shu, C.-W.
  *              Strong Stability Preserving Runge–Kutta and Multistep Time Discretizations.
  *              World Scientific Press, London (2011)
- *               
- *
  */
 template<class Scalar>
 class StepperSDIRK_SSPDIRK32 :
@@ -2693,8 +2794,6 @@ protected:
  *  Reference:  Gottlieb, S., Ketcheson, D.I., Shu, C.-W.
  *              Strong Stability Preserving Runge–Kutta and Multistep Time Discretizations.
  *              World Scientific Press, London (2011)
- *               
- *
  */
 template<class Scalar>
 class StepperSDIRK_SSPDIRK23 :
@@ -2804,8 +2903,6 @@ protected:
  *  Reference:  Gottlieb, S., Ketcheson, D.I., Shu, C.-W.
  *              Strong Stability Preserving Runge–Kutta and Multistep Time Discretizations.
  *              World Scientific Press, London (2011)
- *               
- *
  */
 template<class Scalar>
 class StepperSDIRK_SSPDIRK33 :
@@ -2846,7 +2943,7 @@ class StepperSDIRK_SSPDIRK33 :
       << "        [ 1/(2 sqrt(2)       1/( 4 + 2 sqrt(2)                    ] \n"
       << "        [ 1/(2 sqrt(2)        1/(2 sqrt(2)      1/( 4 + 2 sqrt(2) ] \n"
       << "b     = [ 1/3                    1/3                1/3           ] \n"
-      << std::endl;    
+      << std::endl;
     return Description.str();
   }
 
@@ -2922,7 +3019,12 @@ template<class Scalar>
 class StepperDIRK_1Stage1stOrderRadauIA :
   virtual public StepperDIRK<Scalar>
 {
-  public:
+public:
+  /** \brief Default constructor.
+   *
+   * Requires subsequent setModel() and initialize()
+   * calls before calling takestep().
+  */
   StepperDIRK_1Stage1stOrderRadauIA()
   {
     this->setStepperType("RK Implicit 1 Stage 1st order Radau IA");
@@ -3022,7 +3124,12 @@ template<class Scalar>
 class StepperDIRK_2Stage2ndOrderLobattoIIIB :
   virtual public StepperDIRK<Scalar>
 {
-  public:
+public:
+  /** \brief Default constructor.
+   *
+   * Requires subsequent setModel() and initialize()
+   * calls before calling takestep().
+  */
   StepperDIRK_2Stage2ndOrderLobattoIIIB()
   {
     this->setStepperType("RK Implicit 2 Stage 2nd order Lobatto IIIB");
@@ -3139,7 +3246,12 @@ template<class Scalar>
 class StepperSDIRK_5Stage4thOrder :
   virtual public StepperDIRK<Scalar>
 {
-  public:
+public:
+  /** \brief Default constructor.
+   *
+   * Requires subsequent setModel() and initialize()
+   * calls before calling takestep().
+  */
   StepperSDIRK_5Stage4thOrder()
   {
     this->setStepperType("SDIRK 5 Stage 4th order");
@@ -3299,7 +3411,12 @@ template<class Scalar>
 class StepperSDIRK_3Stage4thOrder :
   virtual public StepperDIRK<Scalar>
 {
-  public:
+public:
+  /** \brief Default constructor.
+   *
+   * Requires subsequent setModel() and initialize()
+   * calls before calling takestep().
+  */
   StepperSDIRK_3Stage4thOrder()
   {
     this->setStepperType("SDIRK 3 Stage 4th order");
@@ -3430,7 +3547,12 @@ template<class Scalar>
 class StepperSDIRK_5Stage5thOrder :
   virtual public StepperDIRK<Scalar>
 {
-  public:
+public:
+  /** \brief Default constructor.
+   *
+   * Requires subsequent setModel() and initialize()
+   * calls before calling takestep().
+  */
   StepperSDIRK_5Stage5thOrder()
   {
     this->setStepperType("SDIRK 5 Stage 5th order");
@@ -3603,7 +3725,12 @@ template<class Scalar>
 class StepperSDIRK_21Pair :
   virtual public StepperDIRK<Scalar>
 {
-  public:
+public:
+  /** \brief Default constructor.
+   *
+   * Requires subsequent setModel() and initialize()
+   * calls before calling takestep().
+  */
   StepperSDIRK_21Pair()
   {
     this->setStepperType("SDIRK 2(1) Pair");
@@ -3724,7 +3851,12 @@ template<class Scalar>
 class StepperDIRK_General :
   virtual public StepperDIRK<Scalar>
 {
-  public:
+public:
+  /** \brief Default constructor.
+   *
+   * Requires subsequent setModel() and initialize()
+   * calls before calling takestep().
+  */
   StepperDIRK_General()
   {
     this->setStepperType("General DIRK");
@@ -3756,7 +3888,7 @@ class StepperDIRK_General :
       this->tableau_->isImplicit() != true, std::logic_error,
       "Error - General DIRK did not receive a DIRK Butcher Tableau!\n");
 
-    this->setup(appModel, obs, useFSAL, ICConsistency,
+    this->setup(appModel, obs, solver, useFSAL, ICConsistency,
                 ICConsistencyCheck, useEmbedded, zeroInitialGuess);
   }
 
@@ -3798,6 +3930,7 @@ class StepperDIRK_General :
                                  t->A(),t->b(),t->c(),
                                  t->order(),t->orderMin(),t->orderMax(),
                                  t->bstar()));
+      this->isInitialized_ = false;
     }
   }
 
@@ -3812,6 +3945,7 @@ class StepperDIRK_General :
   {
     this->tableau_ = Teuchos::rcp(new RKButcherTableau<Scalar>(
       this->getStepperType(),A,b,c,order,orderMin,orderMax,bstar));
+    this->isInitialized_ = false;
   }
 
   Teuchos::RCP<const Teuchos::ParameterList>

--- a/packages/tempus/src/Tempus_StepperStaggeredForwardSensitivity_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperStaggeredForwardSensitivity_decl.hpp
@@ -80,8 +80,6 @@ public:
   //@{
     virtual void setModel(
       const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel);
-    virtual void setNonConstModel(
-      const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& appModel);
     virtual Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > getModel();
 
     virtual void setSolver(
@@ -95,9 +93,6 @@ public:
 
     virtual Teuchos::RCP<StepperObserver<Scalar> > getObserver() const
     { return Teuchos::null; }
-
-    /// Initialize during construction and after changing input parameters.
-    virtual void initialize();
 
     /// Set the initial conditions and make them consistent.
     virtual void setInitialConditions (
@@ -168,6 +163,8 @@ public:
     virtual void describe(Teuchos::FancyOStream        & out,
                           const Teuchos::EVerbosityLevel verbLevel) const;
   //@}
+
+  virtual bool isValidSetup(Teuchos::FancyOStream & out) const;
 
   Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> > get_x_space() const;
 

--- a/packages/tempus/src/Tempus_StepperSubcycling_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperSubcycling_decl.hpp
@@ -153,9 +153,6 @@ public:
     virtual bool getSubcyclingPrintDtChanges() const;
   //@}
 
-  // Temporary until 5908 branch is committed.
-  bool isInitialized_ = false;
-
 protected:
 
   Teuchos::RCP<StepperSubcyclingObserver<Scalar> >  stepperSCObserver_;

--- a/packages/tempus/src/Tempus_StepperTrapezoidal_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperTrapezoidal_decl.hpp
@@ -88,9 +88,6 @@ public:
     virtual Teuchos::RCP<StepperObserver<Scalar> > getObserver() const
     { return this->stepperTrapObserver_; }
 
-    /// Initialize during construction and after changing input parameters.
-    virtual void initialize();
-
     /// Set the initial conditions and make them consistent.
     virtual void setInitialConditions (
       const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory);
@@ -126,6 +123,8 @@ public:
     virtual void describe(Teuchos::FancyOStream        & out,
                           const Teuchos::EVerbosityLevel verbLevel) const;
   //@}
+
+  virtual bool isValidSetup(Teuchos::FancyOStream & out) const;
 
   virtual bool getUseFSALDefault() const { return true; }
   virtual std::string getICConsistencyDefault() const { return "Consistent"; }

--- a/packages/tempus/src/Tempus_Stepper_impl.hpp
+++ b/packages/tempus/src/Tempus_Stepper_impl.hpp
@@ -146,5 +146,64 @@ Teuchos::RCP<Teuchos::ParameterList> defaultSolverParameters()
   return solverPL;
 }
 
+
+template<class Scalar>
+void Stepper<Scalar>::initialize()
+{
+  Teuchos::RCP<Teuchos::FancyOStream> out = this->getOStream();
+
+  bool isValidSetup = this->isValidSetup(*out);
+
+  if (isValidSetup)
+    this->isInitialized_ = true;   // Only place it is set to true.
+  else
+    this->describe(*out, Teuchos::VERB_MEDIUM);
+}
+
+
+template<class Scalar>
+void Stepper<Scalar>::checkInitialized()
+{
+#ifdef TEMPUS_HIDE_DEPRECATED_CODE
+  if ( !this->isInitialized() ) {
+    this->describe( *(this->getOStream()), Teuchos::VERB_MEDIUM);
+    TEUCHOS_TEST_FOR_EXCEPTION( !this->isInitialized(), std::logic_error,
+      "Error - " << this->description() << " is not initialized!");
+  }
+#endif // TEMPUS_HIDE_DEPRECATED_CODE
+}
+
+
+template<class Scalar>
+void Stepper<Scalar>::describe(Teuchos::FancyOStream        & out,
+                               const Teuchos::EVerbosityLevel verbLevel) const
+{
+  out << "--- Stepper ---\n"
+      << "  isInitialized_      = " << Teuchos::toString(isInitialized_) << std::endl
+      << "  stepperType_        = " << stepperType_ << std::endl
+      << "  useFSAL_            = " << Teuchos::toString(useFSAL_) << std::endl
+      << "  ICConsistency_      = " << ICConsistency_ << std::endl
+      << "  ICConsistencyCheck_ = " << Teuchos::toString(ICConsistencyCheck_) << std::endl;
+}
+
+
+template<class Scalar>
+bool Stepper<Scalar>::isValidSetup(
+  Teuchos::FancyOStream & out) const
+{
+  bool isValidSetup = true;
+
+  if ( !(ICConsistency_ == "None" || ICConsistency_ == "Zero" ||
+         ICConsistency_ == "App"  || ICConsistency_ == "Consistent") ) {
+    isValidSetup = false;
+    out << "The IC consistency does not have a valid value!\n"
+        << "('None', 'Zero', 'App' or 'Consistent')\n"
+        << "  ICConsistency  = " << ICConsistency_ << "\n";
+  }
+
+  return isValidSetup;
+}
+
+
 } // namespace Tempus
 #endif // Tempus_Stepper_impl_hpp

--- a/packages/tempus/test/BDF2/Tempus_BDF2Test.cpp
+++ b/packages/tempus/test/BDF2/Tempus_BDF2Test.cpp
@@ -129,8 +129,6 @@ TEUCHOS_UNIT_TEST(BDF2, ConstructingFromDefaults)
   // Setup Stepper for field solve ----------------------------
   auto stepper = rcp(new Tempus::StepperBDF2<double>());
   stepper->setModel(model);
-  stepper->setSolver();
-  stepper->setStartUpStepper();
   stepper->initialize();
 
   // Setup TimeStepControl ------------------------------------

--- a/packages/tempus/test/BackwardEuler/Tempus_BackwardEulerTest.cpp
+++ b/packages/tempus/test/BackwardEuler/Tempus_BackwardEulerTest.cpp
@@ -132,7 +132,6 @@ TEUCHOS_UNIT_TEST(BackwardEuler, ConstructingFromDefaults)
   // Setup Stepper for field solve ----------------------------
   auto stepper = rcp(new Tempus::StepperBackwardEuler<double>());
   stepper->setModel(model);
-  stepper->setSolver();
   stepper->initialize();
 
   // Setup TimeStepControl ------------------------------------

--- a/packages/tempus/test/DIRK/Tempus_DIRKTest.cpp
+++ b/packages/tempus/test/DIRK/Tempus_DIRKTest.cpp
@@ -207,7 +207,6 @@ TEUCHOS_UNIT_TEST(DIRK, ConstructingFromDefaults)
   RCP<Tempus::Stepper<double> > stepper =
     sf->createStepper("SDIRK 2 Stage 2nd order");
   stepper->setModel(model);
-  stepper->setSolver();
   stepper->initialize();
 
   // Setup TimeStepControl ------------------------------------

--- a/packages/tempus/test/HHTAlpha/Tempus_HHTAlphaTest.cpp
+++ b/packages/tempus/test/HHTAlpha/Tempus_HHTAlphaTest.cpp
@@ -21,6 +21,7 @@
 #include "Thyra_LinearOpWithSolveFactoryHelpers.hpp"
 #include "Thyra_DetachedVectorView.hpp"
 #include "Thyra_DetachedMultiVectorView.hpp"
+#include "NOX_Thyra.H"
 
 
 #ifdef Tempus_ENABLE_MPI
@@ -141,7 +142,6 @@ TEUCHOS_UNIT_TEST(HHTAlpha, ConstructingFromDefaults)
   // Setup Stepper for field solve ----------------------------
   auto stepper = rcp(new Tempus::StepperHHTAlpha<double>());
   stepper->setModel(model);
-  stepper->setSolver();
   stepper->initialize();
 
   // Setup TimeStepControl ------------------------------------

--- a/packages/tempus/test/IMEX_RK/Tempus_IMEX_RKTest.cpp
+++ b/packages/tempus/test/IMEX_RK/Tempus_IMEX_RKTest.cpp
@@ -68,7 +68,6 @@ TEUCHOS_UNIT_TEST(IMEX_RK, ConstructingFromDefaults)
   // Setup Stepper for field solve ----------------------------
   auto stepper = rcp(new Tempus::StepperIMEX_RK<double>());
   stepper->setModel(model);
-  stepper->setSolver();
   stepper->initialize();
 
   // Setup TimeStepControl ------------------------------------

--- a/packages/tempus/test/IMEX_RK_Partitioned/Tempus_IMEX_RK_PartitionedTest.cpp
+++ b/packages/tempus/test/IMEX_RK_Partitioned/Tempus_IMEX_RK_PartitionedTest.cpp
@@ -73,7 +73,6 @@ TEUCHOS_UNIT_TEST(IMEX_RK_Partitioned, ConstructingFromDefaults)
   // Setup Stepper for field solve ----------------------------
   auto stepper = rcp(new Tempus::StepperIMEX_RK_Partition<double>());
   stepper->setModel(model);
-  stepper->setSolver();
   stepper->initialize();
 
   // Setup TimeStepControl ------------------------------------

--- a/packages/tempus/test/Observer/Tempus_ObserverTest.cpp
+++ b/packages/tempus/test/Observer/Tempus_ObserverTest.cpp
@@ -16,6 +16,8 @@
 #include "Tempus_IntegratorObserverLogging.hpp"
 #include "Tempus_IntegratorObserverComposite.hpp"
 
+#include "Tempus_StepperExplicitRK.hpp"
+
 #include "Tempus_StepperRKObserverLogging.hpp"
 #include "Tempus_StepperRKObserverComposite.hpp"
 
@@ -161,7 +163,7 @@ TEUCHOS_UNIT_TEST(Observer, IntegratorObserverLogging)
 #endif // TEST_INTEGRATOROBSERVERLOGGING
 
 #ifdef TEST_INTEGRATOROBSERVERCOMPOSITE
-TEUCHOS_UNIT_TEST( Observer, IntegratorObserverComposite) 
+TEUCHOS_UNIT_TEST( Observer, IntegratorObserverComposite)
 {
 
   // Read params from .xml file
@@ -270,11 +272,15 @@ TEUCHOS_UNIT_TEST(Observer, StepperRKObserverLogging)
     Teuchos::rcp(new Tempus::StepperRKObserverLogging<double>);
 
   const auto stepper_observer =
-      Teuchos::rcp_dynamic_cast<Tempus::StepperRKObserverComposite<double> >
-      (integrator->getStepper()->getObserver(), true);
-
+      Teuchos::rcp(new Tempus::StepperRKObserverComposite<double>());
   stepper_observer->clearObservers();
   stepper_observer->addObserver(loggingObs);
+
+  auto stepper =
+      Teuchos::rcp_dynamic_cast<Tempus::StepperExplicitRK<double> >
+      (integrator->getStepper(), true);
+  stepper->setObserver(stepper_observer);
+  stepper->initialize();
 
   // Integrate to timeMax
   bool integratorStatus = integrator->advanceTime();

--- a/packages/tempus/test/Subcycling/Tempus_SubcyclingTest.cpp
+++ b/packages/tempus/test/Subcycling/Tempus_SubcyclingTest.cpp
@@ -409,6 +409,7 @@ TEUCHOS_UNIT_TEST(Subcycling, VanDerPolOperatorSplit)
     auto stepperSC = rcp(new Tempus::StepperSubcycling<double>());
     auto stepperFE = sf->createStepperForwardEuler(explicitModel,Teuchos::null);
     stepperFE->setUseFSAL(false);
+    stepperFE->initialize();
     stepperSC->setSubcyclingStepper(stepperFE);
 
     stepperSC->setSubcyclingMinTimeStep      (0.00001);

--- a/packages/tempus/test/Trapezoidal/Tempus_TrapezoidalTest.cpp
+++ b/packages/tempus/test/Trapezoidal/Tempus_TrapezoidalTest.cpp
@@ -140,7 +140,6 @@ TEUCHOS_UNIT_TEST(Trapezoidal, ConstructingFromDefaults)
   //  stepper->setSolver(solverPL);
   //}
   stepper->setModel(model);
-  stepper->setSolver();
   stepper->initialize();
 
   // Setup TimeStepControl ------------------------------------

--- a/packages/tempus/unit_test/CMakeLists.txt
+++ b/packages/tempus/unit_test/CMakeLists.txt
@@ -9,8 +9,281 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   )
 
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
-  ERK_ForwardEuler
+  UnitTest_BDF2 
+  SOURCES Tempus_UnitTest_BDF2.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_BackwardEuler
+  SOURCES Tempus_UnitTest_BackwardEuler.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_DIRK_BackwardEuler
+  SOURCES Tempus_UnitTest_DIRK_BackwardEuler.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_DIRK_1Stage1stOrderRadauIA
+  SOURCES Tempus_UnitTest_DIRK_1Stage1stOrderRadauIA.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_DIRK_1StageTheta
+  SOURCES Tempus_UnitTest_DIRK_1StageTheta.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_DIRK_2Stage2ndOrderLobattoIIIB
+  SOURCES Tempus_UnitTest_DIRK_2Stage2ndOrderLobattoIIIB.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_DIRK_General
+  SOURCES Tempus_UnitTest_DIRK_General.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_EDIRK_2Stage3rdOrder
+  SOURCES Tempus_UnitTest_EDIRK_2Stage3rdOrder.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_EDIRK_2StageTheta
+  SOURCES Tempus_UnitTest_EDIRK_2StageTheta.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_EDIRK_TrapezoidalRule
+  SOURCES Tempus_UnitTest_EDIRK_TrapezoidalRule.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_SDIRK_21Pair
+  SOURCES Tempus_UnitTest_SDIRK_21Pair.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_SDIRK_2Stage2ndOrder
+  SOURCES Tempus_UnitTest_SDIRK_2Stage2ndOrder.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_SDIRK_2Stage3rdOrder
+  SOURCES Tempus_UnitTest_SDIRK_2Stage3rdOrder.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_SDIRK_3Stage4thOrder
+  SOURCES Tempus_UnitTest_SDIRK_3Stage4thOrder.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_SDIRK_5Stage4thOrder
+  SOURCES Tempus_UnitTest_SDIRK_5Stage4thOrder.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_SDIRK_5Stage5thOrder
+  SOURCES Tempus_UnitTest_SDIRK_5Stage5thOrder.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_SDIRK_ImplicitMidpoint
+  SOURCES Tempus_UnitTest_SDIRK_ImplicitMidpoint.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_ERK_3_8Rule
+  SOURCES Tempus_UnitTest_ERK_3_8Rule.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_ERK_3Stage3rdOrder
+  SOURCES Tempus_UnitTest_ERK_3Stage3rdOrder.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_ERK_3Stage3rdOrderHeun
+  SOURCES Tempus_UnitTest_ERK_3Stage3rdOrderHeun.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_ERK_3Stage3rdOrderTVD
+  SOURCES Tempus_UnitTest_ERK_3Stage3rdOrderTVD.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_ERK_4Stage3rdOrderRunge
+  SOURCES Tempus_UnitTest_ERK_4Stage3rdOrderRunge.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_ERK_4Stage4thOrder
+  SOURCES Tempus_UnitTest_ERK_4Stage4thOrder.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_ERK_5Stage3rdOrderKandG
+  SOURCES Tempus_UnitTest_ERK_5Stage3rdOrderKandG.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_ERK_BogackiShampine32
+  SOURCES Tempus_UnitTest_ERK_BogackiShampine32.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_ERK_ForwardEuler
   SOURCES Tempus_UnitTest_ERK_ForwardEuler.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_ERK_General
+  SOURCES Tempus_UnitTest_ERK_General.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_ERK_Merson45
+  SOURCES Tempus_UnitTest_ERK_Merson45.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_ERK_Midpoint
+  SOURCES Tempus_UnitTest_ERK_Midpoint.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_ERK_Trapezoidal
+  SOURCES Tempus_UnitTest_ERK_Trapezoidal.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_ForwardEuler
+  SOURCES Tempus_UnitTest_ForwardEuler.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_HHTAlpha
+  SOURCES Tempus_UnitTest_HHTAlpha.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_IMEX_RK
+  SOURCES Tempus_UnitTest_IMEX_RK.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_IMEX_RK_Partition
+  SOURCES Tempus_UnitTest_IMEX_RK_Partition.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_Leapfrog
+  SOURCES Tempus_UnitTest_Leapfrog.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_NewmarkExplicitAForm
+  SOURCES Tempus_UnitTest_NewmarkExplicitAForm.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_NewmarkImplicitAForm
+  SOURCES Tempus_UnitTest_NewmarkImplicitAForm.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_NewmarkImplicitDForm
+  SOURCES Tempus_UnitTest_NewmarkImplicitDForm.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_OperatorSplit
+  SOURCES Tempus_UnitTest_OperatorSplit.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_Trapezoidal
+  SOURCES Tempus_UnitTest_Trapezoidal.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
   TESTONLYLIBS tempus_test_models
   NUM_MPI_PROCS 1
   )
@@ -21,3 +294,4 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   TESTONLYLIBS tempus_test_models
   NUM_MPI_PROCS 1
   )
+

--- a/packages/tempus/unit_test/Tempus_UnitTest_BDF2.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_BDF2.cpp
@@ -1,0 +1,103 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_UnitTest_Utils.hpp"
+
+#include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/VanDerPolModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+using Tempus::StepperFactory;
+
+// Comment out any of the following tests to exclude from build/run.
+#define CONSTRUCTION
+#define STEPPERFACTORY_CONSTRUCTION
+
+
+#ifdef CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(BDF2, Construction)
+{
+  auto model = rcp(new Tempus_Test::SinCosModel<double>());
+
+  // Default construction.
+  auto stepper = rcp(new Tempus::StepperBDF2<double>());
+  stepper->setModel(model);
+  stepper->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Default values for construction.
+  auto obs    = rcp(new Tempus::StepperBDF2Observer<double>());
+  auto solver = rcp(new Thyra::NOXNonlinearSolver());
+  solver->setParameterList(Tempus::defaultSolverParameters());
+
+  auto startUpStepper = rcp(new Tempus::StepperDIRK_1StageTheta<double>());
+  startUpStepper->setModel(model);  // Can use the same model since both steppers are implicit ODEs.
+  startUpStepper->initialize();
+
+  auto defaultStepper = rcp(new Tempus::StepperBDF2<double>());
+  bool useFSAL              = defaultStepper->getUseFSALDefault();
+  std::string ICConsistency = defaultStepper->getICConsistencyDefault();
+  bool ICConsistencyCheck   = defaultStepper->getICConsistencyCheckDefault();
+  bool zeroInitialGuess     = defaultStepper->getZeroInitialGuess();
+
+  // Test the set functions.
+  stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setSolver(solver);                          stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setStartUpStepper(startUpStepper);          stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setZeroInitialGuess(zeroInitialGuess);      stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Full argument list construction.
+  stepper = rcp(new Tempus::StepperBDF2<double>(
+    model, obs, solver, startUpStepper, useFSAL,
+    ICConsistency, ICConsistencyCheck, zeroInitialGuess));
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+}
+#endif // CONSTRUCTION
+
+
+#ifdef STEPPERFACTORY_CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(BDF2, StepperFactory_Construction)
+{
+  auto model = rcp(new Tempus_Test::SinCosModel<double>());
+  testFactoryConstruction("BDF2", model);
+}
+#endif // STEPPERFACTORY_CONSTRUCTION
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_BackwardEuler.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_BackwardEuler.cpp
@@ -1,0 +1,103 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_UnitTest_Utils.hpp"
+
+#include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/VanDerPolModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+using Tempus::StepperFactory;
+
+// Comment out any of the following tests to exclude from build/run.
+#define CONSTRUCTION
+#define STEPPERFACTORY_CONSTRUCTION
+
+
+#ifdef CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(BackwardEuler, Construction)
+{
+  auto model   = rcp(new Tempus_Test::SinCosModel<double>());
+
+  // Default construction.
+  auto stepper = rcp(new Tempus::StepperBackwardEuler<double>());
+  stepper->setModel(model);
+  stepper->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Default values for construction.
+  auto obs    = rcp(new Tempus::StepperBackwardEulerObserver<double>());
+  auto solver = rcp(new Thyra::NOXNonlinearSolver());
+  solver->setParameterList(Tempus::defaultSolverParameters());
+
+  auto predictorStepper = rcp(new Tempus::StepperForwardEuler<double>());
+  predictorStepper->setModel(model);  // Can use the same model since both steppers are implicit ODEs.
+  predictorStepper->initialize();
+
+  auto defaultStepper = rcp(new Tempus::StepperBackwardEuler<double>());
+  bool useFSAL              = defaultStepper->getUseFSALDefault();
+  std::string ICConsistency = defaultStepper->getICConsistencyDefault();
+  bool ICConsistencyCheck   = defaultStepper->getICConsistencyCheckDefault();
+  bool zeroInitialGuess     = defaultStepper->getZeroInitialGuess();
+
+  // Test the set functions.
+  stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setSolver(solver);                          stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setPredictor(predictorStepper);             stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setZeroInitialGuess(zeroInitialGuess);      stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Full argument list construction.
+  stepper = rcp(new Tempus::StepperBackwardEuler<double>(
+    model, obs, solver, predictorStepper, useFSAL,
+    ICConsistency, ICConsistencyCheck, zeroInitialGuess));
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+}
+#endif // CONSTRUCTION
+
+
+#ifdef STEPPERFACTORY_CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(BackwardEuler, StepperFactory_Construction)
+{
+  auto model = rcp(new Tempus_Test::SinCosModel<double>());
+  testFactoryConstruction("Backward Euler", model);
+}
+#endif // STEPPERFACTORY_CONSTRUCTION
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_DIRK_1Stage1stOrderRadauIA.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_DIRK_1Stage1stOrderRadauIA.cpp
@@ -1,0 +1,99 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_UnitTest_Utils.hpp"
+
+#include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/VanDerPolModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+using Tempus::StepperFactory;
+
+// Comment out any of the following tests to exclude from build/run.
+#define CONSTRUCTION
+#define STEPPERFACTORY_CONSTRUCTION
+
+
+#ifdef CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(DIRK_1Stage1stOrderRadauIA, Construction)
+{
+  auto model   = rcp(new Tempus_Test::SinCosModel<double>());
+
+  // Default construction.
+  auto stepper = rcp(new Tempus::StepperDIRK_1Stage1stOrderRadauIA<double>());
+  stepper->setModel(model);
+  stepper->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Default values for construction.
+  auto obs    = rcp(new Tempus::StepperRKObserverComposite<double>());
+  auto solver = rcp(new Thyra::NOXNonlinearSolver());
+  solver->setParameterList(Tempus::defaultSolverParameters());
+
+  bool useFSAL              = stepper->getUseFSALDefault();
+  std::string ICConsistency = stepper->getICConsistencyDefault();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool useEmbedded          = stepper->getUseEmbeddedDefault();
+  bool zeroInitialGuess     = stepper->getZeroInitialGuess();
+
+  // Test the set functions.
+  stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setSolver(solver);                          stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseEmbedded(useEmbedded);                stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setZeroInitialGuess(zeroInitialGuess);      stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Full argument list construction.
+  stepper = rcp(new Tempus::StepperDIRK_1Stage1stOrderRadauIA<double>(
+    model, obs, solver, useFSAL,
+    ICConsistency, ICConsistencyCheck, useEmbedded, zeroInitialGuess));
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+}
+#endif // CONSTRUCTION
+
+
+#ifdef STEPPERFACTORY_CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(DIRK_1Stage1stOrderRadauIA, StepperFactory_Construction)
+{
+  auto model = rcp(new Tempus_Test::SinCosModel<double>());
+  testFactoryConstruction("RK Implicit 1 Stage 1st order Radau IA", model);
+}
+#endif // STEPPERFACTORY_CONSTRUCTION
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_DIRK_1StageTheta.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_DIRK_1StageTheta.cpp
@@ -1,0 +1,102 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_UnitTest_Utils.hpp"
+
+#include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/VanDerPolModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+using Tempus::StepperFactory;
+
+// Comment out any of the following tests to exclude from build/run.
+#define CONSTRUCTION
+#define STEPPERFACTORY_CONSTRUCTION
+
+
+#ifdef CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(DIRK_1StageTheta, Construction)
+{
+  auto model   = rcp(new Tempus_Test::SinCosModel<double>());
+
+  // Default construction.
+  auto stepper = rcp(new Tempus::StepperDIRK_1StageTheta<double>());
+  stepper->setModel(model);
+  stepper->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Default values for construction.
+  auto obs    = rcp(new Tempus::StepperRKObserverComposite<double>());
+  auto solver = rcp(new Thyra::NOXNonlinearSolver());
+  solver->setParameterList(Tempus::defaultSolverParameters());
+
+  bool useFSAL              = stepper->getUseFSALDefault();
+  std::string ICConsistency = stepper->getICConsistencyDefault();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool useEmbedded          = stepper->getUseEmbeddedDefault();
+  bool zeroInitialGuess     = stepper->getZeroInitialGuess();
+  double theta              = 0.5;
+
+  // Test the set functions.
+  stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setSolver(solver);                          stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseEmbedded(useEmbedded);                stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setZeroInitialGuess(zeroInitialGuess);      stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+  stepper->setTheta(theta);                            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Full argument list construction.
+  stepper = rcp(new Tempus::StepperDIRK_1StageTheta<double>(
+    model, obs, solver, useFSAL, ICConsistency, ICConsistencyCheck,
+    useEmbedded, zeroInitialGuess, theta));
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+}
+#endif // CONSTRUCTION
+
+
+#ifdef STEPPERFACTORY_CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(DIRK_1StageTheta, StepperFactory_Construction)
+{
+  auto model = rcp(new Tempus_Test::SinCosModel<double>());
+  testFactoryConstruction("DIRK 1 Stage Theta Method", model);
+}
+#endif // STEPPERFACTORY_CONSTRUCTION
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_DIRK_2Stage2ndOrderLobattoIIIB.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_DIRK_2Stage2ndOrderLobattoIIIB.cpp
@@ -1,0 +1,99 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_UnitTest_Utils.hpp"
+
+#include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/VanDerPolModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+using Tempus::StepperFactory;
+
+// Comment out any of the following tests to exclude from build/run.
+#define CONSTRUCTION
+#define STEPPERFACTORY_CONSTRUCTION
+
+
+#ifdef CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(DIRK_2Stage2ndOrderLobattoIIIB, Construction)
+{
+  auto model   = rcp(new Tempus_Test::SinCosModel<double>());
+
+  // Default construction.
+  auto stepper = rcp(new Tempus::StepperDIRK_2Stage2ndOrderLobattoIIIB<double>());
+  stepper->setModel(model);
+  stepper->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Default values for construction.
+  auto obs    = rcp(new Tempus::StepperRKObserverComposite<double>());
+  auto solver = rcp(new Thyra::NOXNonlinearSolver());
+  solver->setParameterList(Tempus::defaultSolverParameters());
+
+  bool useFSAL              = stepper->getUseFSALDefault();
+  std::string ICConsistency = stepper->getICConsistencyDefault();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool useEmbedded          = stepper->getUseEmbeddedDefault();
+  bool zeroInitialGuess     = stepper->getZeroInitialGuess();
+
+  // Test the set functions.
+  stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setSolver(solver);                          stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseEmbedded(useEmbedded);                stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setZeroInitialGuess(zeroInitialGuess);      stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Full argument list construction.
+  stepper = rcp(new Tempus::StepperDIRK_2Stage2ndOrderLobattoIIIB<double>(
+    model, obs, solver, useFSAL,
+    ICConsistency, ICConsistencyCheck, useEmbedded, zeroInitialGuess));
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+}
+#endif // CONSTRUCTION
+
+
+#ifdef STEPPERFACTORY_CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(DIRK_2Stage2ndOrderLobattoIIIB, StepperFactory_Construction)
+{
+  auto model = rcp(new Tempus_Test::SinCosModel<double>());
+  testFactoryConstruction("RK Implicit 2 Stage 2nd order Lobatto IIIB", model);
+}
+#endif // STEPPERFACTORY_CONSTRUCTION
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_DIRK_BackwardEuler.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_DIRK_BackwardEuler.cpp
@@ -1,0 +1,99 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_UnitTest_Utils.hpp"
+
+#include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/VanDerPolModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+using Tempus::StepperFactory;
+
+// Comment out any of the following tests to exclude from build/run.
+#define CONSTRUCTION
+#define STEPPERFACTORY_CONSTRUCTION
+
+
+#ifdef CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(DIRK_BackwardEuler, Construction)
+{
+  auto model = rcp(new Tempus_Test::SinCosModel<double>());
+
+  // Default construction.
+  auto stepper = rcp(new Tempus::StepperDIRK_BackwardEuler<double>());
+  stepper->setModel(model);
+  stepper->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Default values for construction.
+  auto obs    = rcp(new Tempus::StepperRKObserverComposite<double>());
+  auto solver = rcp(new Thyra::NOXNonlinearSolver());
+  solver->setParameterList(Tempus::defaultSolverParameters());
+
+  bool useFSAL              = stepper->getUseFSALDefault();
+  std::string ICConsistency = stepper->getICConsistencyDefault();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool useEmbedded          = stepper->getUseEmbeddedDefault();
+  bool zeroInitialGuess     = stepper->getZeroInitialGuess();
+
+  // Test the set functions.
+  stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setSolver(solver);                          stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseEmbedded(useEmbedded);                stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setZeroInitialGuess(zeroInitialGuess);      stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Full argument list construction.
+  stepper = rcp(new Tempus::StepperDIRK_BackwardEuler<double>(
+    model, obs, solver, useFSAL,
+    ICConsistency, ICConsistencyCheck, useEmbedded, zeroInitialGuess));
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+}
+#endif // CONSTRUCTION
+
+
+#ifdef STEPPERFACTORY_CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(DIRK_BackwardEuler, StepperFactory_Construction)
+{
+  auto model = rcp(new Tempus_Test::SinCosModel<double>());
+  testFactoryConstruction("RK Backward Euler", model);
+}
+#endif // STEPPERFACTORY_CONSTRUCTION
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_DIRK_General.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_DIRK_General.cpp
@@ -1,0 +1,123 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_UnitTest_Utils.hpp"
+
+#include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/VanDerPolModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+using Tempus::StepperFactory;
+
+// Comment out any of the following tests to exclude from build/run.
+#define CONSTRUCTION
+#define STEPPERFACTORY_CONSTRUCTION
+
+
+#ifdef CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(DIRK_General, Construction)
+{
+  auto model   = rcp(new Tempus_Test::SinCosModel<double>());
+
+  // Default construction.
+  auto stepper = rcp(new Tempus::StepperDIRK_General<double>());
+  stepper->setModel(model);
+  stepper->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Default values for construction.
+  auto obs    = rcp(new Tempus::StepperRKObserverComposite<double>());
+  auto solver = rcp(new Thyra::NOXNonlinearSolver());
+  solver->setParameterList(Tempus::defaultSolverParameters());
+
+  bool useFSAL              = stepper->getUseFSALDefault();
+  std::string ICConsistency = stepper->getICConsistencyDefault();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool useEmbedded          = stepper->getUseEmbeddedDefault();
+  bool zeroInitialGuess     = stepper->getZeroInitialGuess();
+
+  using Teuchos::as;
+  int NumStages = 2;
+  Teuchos::SerialDenseMatrix<int,double> A(NumStages,NumStages);
+  Teuchos::SerialDenseVector<int,double> b(NumStages);
+  Teuchos::SerialDenseVector<int,double> c(NumStages);
+  Teuchos::SerialDenseVector<int,double> bstar(0);
+
+  // Fill A:
+  A(0,0) = 0.2928932188134524; A(0,1) = 0.0;
+  A(1,0) = 0.7071067811865476; A(1,1) = 0.2928932188134524;
+
+  // Fill b:
+  b(0) = 0.7071067811865476;
+  b(1) = 0.2928932188134524;
+
+  // Fill c:
+  c(0) = 0.2928932188134524;
+  c(1) = 1.0;
+
+  int order = 2;
+
+  // Test the set functions.
+  stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setSolver(solver);                          stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseEmbedded(useEmbedded);                stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setZeroInitialGuess(zeroInitialGuess);      stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+  stepper->setTableau(A, b, c, order, order, order);   stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Full argument list construction.
+  stepper = rcp(new Tempus::StepperDIRK_General<double>(
+    model, obs, solver, useFSAL,
+    ICConsistency, ICConsistencyCheck, useEmbedded, zeroInitialGuess,
+    A, b, c, order, order, order, bstar));
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+}
+#endif // CONSTRUCTION
+
+
+#ifdef STEPPERFACTORY_CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(DIRK_General, StepperFactory_Construction)
+{
+  auto model = rcp(new Tempus_Test::SinCosModel<double>());
+  testFactoryConstruction("General DIRK", model);
+}
+#endif // STEPPERFACTORY_CONSTRUCTION
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_EDIRK_2Stage3rdOrder.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_EDIRK_2Stage3rdOrder.cpp
@@ -1,0 +1,99 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_UnitTest_Utils.hpp"
+
+#include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/VanDerPolModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+using Tempus::StepperFactory;
+
+// Comment out any of the following tests to exclude from build/run.
+#define CONSTRUCTION
+#define STEPPERFACTORY_CONSTRUCTION
+
+
+#ifdef CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(EDIRK_2Stage3rdOrder, Construction)
+{
+  auto model   = rcp(new Tempus_Test::SinCosModel<double>());
+
+  // Default construction.
+  auto stepper = rcp(new Tempus::StepperEDIRK_2Stage3rdOrder<double>());
+  stepper->setModel(model);
+  stepper->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Default values for construction.
+  auto obs    = rcp(new Tempus::StepperRKObserverComposite<double>());
+  auto solver = rcp(new Thyra::NOXNonlinearSolver());
+  solver->setParameterList(Tempus::defaultSolverParameters());
+
+  bool useFSAL              = stepper->getUseFSALDefault();
+  std::string ICConsistency = stepper->getICConsistencyDefault();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool useEmbedded          = stepper->getUseEmbeddedDefault();
+  bool zeroInitialGuess     = stepper->getZeroInitialGuess();
+
+  // Test the set functions.
+  stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setSolver(solver);                          stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseEmbedded(useEmbedded);                stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setZeroInitialGuess(zeroInitialGuess);      stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Full argument list construction.
+  stepper = rcp(new Tempus::StepperEDIRK_2Stage3rdOrder<double>(
+    model, obs, solver, useFSAL,
+    ICConsistency, ICConsistencyCheck, useEmbedded, zeroInitialGuess));
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+}
+#endif // CONSTRUCTION
+
+
+#ifdef STEPPERFACTORY_CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(EDIRK_2Stage3rdOrder, StepperFactory_Construction)
+{
+  auto model = rcp(new Tempus_Test::SinCosModel<double>());
+  testFactoryConstruction("EDIRK 2 Stage 3rd order", model);
+}
+#endif // STEPPERFACTORY_CONSTRUCTION
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_EDIRK_2StageTheta.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_EDIRK_2StageTheta.cpp
@@ -1,0 +1,102 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_UnitTest_Utils.hpp"
+
+#include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/VanDerPolModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+using Tempus::StepperFactory;
+
+// Comment out any of the following tests to exclude from build/run.
+#define CONSTRUCTION
+#define STEPPERFACTORY_CONSTRUCTION
+
+
+#ifdef CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(EDIRK_2StageTheta, Construction)
+{
+  auto model   = rcp(new Tempus_Test::SinCosModel<double>());
+
+  // Default construction.
+  auto stepper = rcp(new Tempus::StepperEDIRK_2StageTheta<double>());
+  stepper->setModel(model);
+  stepper->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Default values for construction.
+  auto obs    = rcp(new Tempus::StepperRKObserverComposite<double>());
+  auto solver = rcp(new Thyra::NOXNonlinearSolver());
+  solver->setParameterList(Tempus::defaultSolverParameters());
+
+  bool useFSAL              = stepper->getUseFSALDefault();
+  std::string ICConsistency = stepper->getICConsistencyDefault();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool useEmbedded          = stepper->getUseEmbeddedDefault();
+  bool zeroInitialGuess     = stepper->getZeroInitialGuess();
+  double theta              = 0.5;
+
+  // Test the set functions.
+  stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setSolver(solver);                          stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseEmbedded(useEmbedded);                stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setZeroInitialGuess(zeroInitialGuess);      stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+  stepper->setTheta(theta);                            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Full argument list construction.
+  stepper = rcp(new Tempus::StepperEDIRK_2StageTheta<double>(
+    model, obs, solver, useFSAL, ICConsistency, ICConsistencyCheck,
+    useEmbedded, zeroInitialGuess, theta));
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+}
+#endif // CONSTRUCTION
+
+
+#ifdef STEPPERFACTORY_CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(EDIRK_2StageTheta, StepperFactory_Construction)
+{
+  auto model = rcp(new Tempus_Test::SinCosModel<double>());
+  testFactoryConstruction("EDIRK 2 Stage Theta Method", model);
+}
+#endif // STEPPERFACTORY_CONSTRUCTION
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_EDIRK_TrapezoidalRule.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_EDIRK_TrapezoidalRule.cpp
@@ -1,0 +1,99 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_UnitTest_Utils.hpp"
+
+#include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/VanDerPolModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+using Tempus::StepperFactory;
+
+// Comment out any of the following tests to exclude from build/run.
+#define CONSTRUCTION
+#define STEPPERFACTORY_CONSTRUCTION
+
+
+#ifdef CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(EDIRK_TrapezoidalRule, Construction)
+{
+  auto model   = rcp(new Tempus_Test::SinCosModel<double>());
+
+  // Default construction.
+  auto stepper = rcp(new Tempus::StepperEDIRK_TrapezoidalRule<double>());
+  stepper->setModel(model);
+  stepper->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Default values for construction.
+  auto obs    = rcp(new Tempus::StepperRKObserverComposite<double>());
+  auto solver = rcp(new Thyra::NOXNonlinearSolver());
+  solver->setParameterList(Tempus::defaultSolverParameters());
+
+  bool useFSAL              = stepper->getUseFSALDefault();
+  std::string ICConsistency = stepper->getICConsistencyDefault();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool useEmbedded          = stepper->getUseEmbeddedDefault();
+  bool zeroInitialGuess     = stepper->getZeroInitialGuess();
+
+  // Test the set functions.
+  stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setSolver(solver);                          stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseEmbedded(useEmbedded);                stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setZeroInitialGuess(zeroInitialGuess);      stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Full argument list construction.
+  stepper = rcp(new Tempus::StepperEDIRK_TrapezoidalRule<double>(
+    model, obs, solver, useFSAL,
+    ICConsistency, ICConsistencyCheck, useEmbedded, zeroInitialGuess));
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+}
+#endif // CONSTRUCTION
+
+
+#ifdef STEPPERFACTORY_CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(EDIRK_TrapezoidalRule, StepperFactory_Construction)
+{
+  auto model = rcp(new Tempus_Test::SinCosModel<double>());
+  testFactoryConstruction("RK Trapezoidal Rule", model);
+}
+#endif // STEPPERFACTORY_CONSTRUCTION
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_ERK_3Stage3rdOrder.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_ERK_3Stage3rdOrder.cpp
@@ -1,0 +1,94 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_UnitTest_Utils.hpp"
+#include "Tempus_StepperRKButcherTableau.hpp"
+
+#include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/VanDerPolModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+using Tempus::StepperFactory;
+using Tempus::StepperExplicitRK;
+
+// Comment out any of the following tests to exclude from build/run.
+#define CONSTRUCTION
+#define STEPPERFACTORY_CONSTRUCTION
+
+
+#ifdef CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(ERK_3Stage3rdOrder, Default_Construction)
+{
+  auto model   = rcp(new Tempus_Test::SinCosModel<double>());
+
+  // Default construction.
+  auto stepper = rcp(new Tempus::StepperERK_3Stage3rdOrder<double>());
+  stepper->setModel(model);
+  stepper->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+  // Default values for construction.
+  auto obs    = rcp(new Tempus::StepperRKObserverComposite<double>());
+
+  bool useFSAL              = stepper->getUseFSALDefault();
+  std::string ICConsistency = stepper->getICConsistencyDefault();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool useEmbedded          = stepper->getUseEmbeddedDefault();
+
+  // Test the set functions.
+  stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseEmbedded(useEmbedded);                stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Full argument list construction.
+  stepper = rcp(new Tempus::StepperERK_3Stage3rdOrder<double>(
+    model, obs, useFSAL, ICConsistency, ICConsistencyCheck, useEmbedded));
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+}
+#endif // CONSTRUCTION
+
+
+#ifdef STEPPERFACTORY_CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(ERK_3Stage3rdOrder, StepperFactory_Construction)
+{
+  auto model = rcp(new Tempus_Test::SinCosModel<double>());
+  testFactoryConstruction("RK Explicit 3 Stage 3rd order", model);
+}
+#endif // STEPPERFACTORY_CONSTRUCTION
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_ERK_3Stage3rdOrderHeun.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_ERK_3Stage3rdOrderHeun.cpp
@@ -1,0 +1,94 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_UnitTest_Utils.hpp"
+#include "Tempus_StepperRKButcherTableau.hpp"
+
+#include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/VanDerPolModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+using Tempus::StepperFactory;
+using Tempus::StepperExplicitRK;
+
+// Comment out any of the following tests to exclude from build/run.
+#define CONSTRUCTION
+#define STEPPERFACTORY_CONSTRUCTION
+
+
+#ifdef CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(ERK_3Stage3rdOrderHeun, Default_Construction)
+{
+  auto model   = rcp(new Tempus_Test::SinCosModel<double>());
+
+  // Default construction.
+  auto stepper = rcp(new Tempus::StepperERK_3Stage3rdOrderHeun<double>());
+  stepper->setModel(model);
+  stepper->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+  // Default values for construction.
+  auto obs    = rcp(new Tempus::StepperRKObserverComposite<double>());
+
+  bool useFSAL              = stepper->getUseFSALDefault();
+  std::string ICConsistency = stepper->getICConsistencyDefault();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool useEmbedded          = stepper->getUseEmbeddedDefault();
+
+  // Test the set functions.
+  stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseEmbedded(useEmbedded);                stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Full argument list construction.
+  stepper = rcp(new Tempus::StepperERK_3Stage3rdOrderHeun<double>(
+    model, obs, useFSAL, ICConsistency, ICConsistencyCheck, useEmbedded));
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+}
+#endif // CONSTRUCTION
+
+
+#ifdef STEPPERFACTORY_CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(ERK_3Stage3rdOrderHeun, StepperFactory_Construction)
+{
+  auto model = rcp(new Tempus_Test::SinCosModel<double>());
+  testFactoryConstruction("RK Explicit 3 Stage 3rd order by Heun", model);
+}
+#endif // STEPPERFACTORY_CONSTRUCTION
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_ERK_3Stage3rdOrderTVD.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_ERK_3Stage3rdOrderTVD.cpp
@@ -1,0 +1,94 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_UnitTest_Utils.hpp"
+#include "Tempus_StepperRKButcherTableau.hpp"
+
+#include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/VanDerPolModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+using Tempus::StepperFactory;
+using Tempus::StepperExplicitRK;
+
+// Comment out any of the following tests to exclude from build/run.
+#define CONSTRUCTION
+#define STEPPERFACTORY_CONSTRUCTION
+
+
+#ifdef CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(ERK_3Stage3rdOrderTVD, Default_Construction)
+{
+  auto model   = rcp(new Tempus_Test::SinCosModel<double>());
+
+  // Default construction.
+  auto stepper = rcp(new Tempus::StepperERK_3Stage3rdOrderTVD<double>());
+  stepper->setModel(model);
+  stepper->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+  // Default values for construction.
+  auto obs    = rcp(new Tempus::StepperRKObserverComposite<double>());
+
+  bool useFSAL              = stepper->getUseFSALDefault();
+  std::string ICConsistency = stepper->getICConsistencyDefault();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool useEmbedded          = stepper->getUseEmbeddedDefault();
+
+  // Test the set functions.
+  stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseEmbedded(useEmbedded);                stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Full argument list construction.
+  stepper = rcp(new Tempus::StepperERK_3Stage3rdOrderTVD<double>(
+    model, obs, useFSAL, ICConsistency, ICConsistencyCheck, useEmbedded));
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+}
+#endif // CONSTRUCTION
+
+
+#ifdef STEPPERFACTORY_CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(ERK_3Stage3rdOrderTVD, StepperFactory_Construction)
+{
+  auto model = rcp(new Tempus_Test::SinCosModel<double>());
+  testFactoryConstruction("RK Explicit 3 Stage 3rd order TVD", model);
+}
+#endif // STEPPERFACTORY_CONSTRUCTION
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_ERK_3_8Rule.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_ERK_3_8Rule.cpp
@@ -1,0 +1,94 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_UnitTest_Utils.hpp"
+#include "Tempus_StepperRKButcherTableau.hpp"
+
+#include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/VanDerPolModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+using Tempus::StepperFactory;
+using Tempus::StepperExplicitRK;
+
+// Comment out any of the following tests to exclude from build/run.
+#define CONSTRUCTION
+#define STEPPERFACTORY_CONSTRUCTION
+
+
+#ifdef CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(ERK_3_8Rule, Default_Construction)
+{
+  auto model   = rcp(new Tempus_Test::SinCosModel<double>());
+
+  // Default construction.
+  auto stepper = rcp(new Tempus::StepperERK_3_8Rule<double>());
+  stepper->setModel(model);
+  stepper->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+  // Default values for construction.
+  auto obs    = rcp(new Tempus::StepperRKObserverComposite<double>());
+
+  bool useFSAL              = stepper->getUseFSALDefault();
+  std::string ICConsistency = stepper->getICConsistencyDefault();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool useEmbedded          = stepper->getUseEmbeddedDefault();
+
+  // Test the set functions.
+  stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseEmbedded(useEmbedded);                stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Full argument list construction.
+  stepper = rcp(new Tempus::StepperERK_3_8Rule<double>(
+    model, obs, useFSAL, ICConsistency, ICConsistencyCheck, useEmbedded));
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+}
+#endif // CONSTRUCTION
+
+
+#ifdef STEPPERFACTORY_CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(ERK_3_8Rule, StepperFactory_Construction)
+{
+  auto model = rcp(new Tempus_Test::SinCosModel<double>());
+  testFactoryConstruction("RK Explicit 3/8 Rule", model);
+}
+#endif // STEPPERFACTORY_CONSTRUCTION
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_ERK_4Stage3rdOrderRunge.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_ERK_4Stage3rdOrderRunge.cpp
@@ -1,0 +1,94 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_UnitTest_Utils.hpp"
+#include "Tempus_StepperRKButcherTableau.hpp"
+
+#include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/VanDerPolModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+using Tempus::StepperFactory;
+using Tempus::StepperExplicitRK;
+
+// Comment out any of the following tests to exclude from build/run.
+#define CONSTRUCTION
+#define STEPPERFACTORY_CONSTRUCTION
+
+
+#ifdef CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(ERK_4Stage3rdOrderRunge, Default_Construction)
+{
+  auto model   = rcp(new Tempus_Test::SinCosModel<double>());
+
+  // Default construction.
+  auto stepper = rcp(new Tempus::StepperERK_4Stage3rdOrderRunge<double>());
+  stepper->setModel(model);
+  stepper->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+  // Default values for construction.
+  auto obs    = rcp(new Tempus::StepperRKObserverComposite<double>());
+
+  bool useFSAL              = stepper->getUseFSALDefault();
+  std::string ICConsistency = stepper->getICConsistencyDefault();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool useEmbedded          = stepper->getUseEmbeddedDefault();
+
+  // Test the set functions.
+  stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseEmbedded(useEmbedded);                stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Full argument list construction.
+  stepper = rcp(new Tempus::StepperERK_4Stage3rdOrderRunge<double>(
+    model, obs, useFSAL, ICConsistency, ICConsistencyCheck, useEmbedded));
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+}
+#endif // CONSTRUCTION
+
+
+#ifdef STEPPERFACTORY_CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(ERK_4Stage3rdOrderRunge, StepperFactory_Construction)
+{
+  auto model = rcp(new Tempus_Test::SinCosModel<double>());
+  testFactoryConstruction("RK Explicit 4 Stage 3rd order by Runge", model);
+}
+#endif // STEPPERFACTORY_CONSTRUCTION
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_ERK_4Stage4thOrder.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_ERK_4Stage4thOrder.cpp
@@ -1,0 +1,94 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_UnitTest_Utils.hpp"
+#include "Tempus_StepperRKButcherTableau.hpp"
+
+#include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/VanDerPolModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+using Tempus::StepperFactory;
+using Tempus::StepperExplicitRK;
+
+// Comment out any of the following tests to exclude from build/run.
+#define CONSTRUCTION
+#define STEPPERFACTORY_CONSTRUCTION
+
+
+#ifdef CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(ERK_4Stage4thOrder, Default_Construction)
+{
+  auto model   = rcp(new Tempus_Test::SinCosModel<double>());
+
+  // Default construction.
+  auto stepper = rcp(new Tempus::StepperERK_4Stage4thOrder<double>());
+  stepper->setModel(model);
+  stepper->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+  // Default values for construction.
+  auto obs    = rcp(new Tempus::StepperRKObserverComposite<double>());
+
+  bool useFSAL              = stepper->getUseFSALDefault();
+  std::string ICConsistency = stepper->getICConsistencyDefault();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool useEmbedded          = stepper->getUseEmbeddedDefault();
+
+  // Test the set functions.
+  stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseEmbedded(useEmbedded);                stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Full argument list construction.
+  stepper = rcp(new Tempus::StepperERK_4Stage4thOrder<double>(
+    model, obs, useFSAL, ICConsistency, ICConsistencyCheck, useEmbedded));
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+}
+#endif // CONSTRUCTION
+
+
+#ifdef STEPPERFACTORY_CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(ERK_4Stage4thOrder, StepperFactory_Construction)
+{
+  auto model = rcp(new Tempus_Test::SinCosModel<double>());
+  testFactoryConstruction("RK Explicit 4 Stage", model);
+}
+#endif // STEPPERFACTORY_CONSTRUCTION
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_ERK_5Stage3rdOrderKandG.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_ERK_5Stage3rdOrderKandG.cpp
@@ -1,0 +1,94 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_UnitTest_Utils.hpp"
+#include "Tempus_StepperRKButcherTableau.hpp"
+
+#include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/VanDerPolModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+using Tempus::StepperFactory;
+using Tempus::StepperExplicitRK;
+
+// Comment out any of the following tests to exclude from build/run.
+#define CONSTRUCTION
+#define STEPPERFACTORY_CONSTRUCTION
+
+
+#ifdef CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(ERK_5Stage3rdOrderKandG, Default_Construction)
+{
+  auto model   = rcp(new Tempus_Test::SinCosModel<double>());
+
+  // Default construction.
+  auto stepper = rcp(new Tempus::StepperERK_5Stage3rdOrderKandG<double>());
+  stepper->setModel(model);
+  stepper->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+  // Default values for construction.
+  auto obs    = rcp(new Tempus::StepperRKObserverComposite<double>());
+
+  bool useFSAL              = stepper->getUseFSALDefault();
+  std::string ICConsistency = stepper->getICConsistencyDefault();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool useEmbedded          = stepper->getUseEmbeddedDefault();
+
+  // Test the set functions.
+  stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseEmbedded(useEmbedded);                stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Full argument list construction.
+  stepper = rcp(new Tempus::StepperERK_5Stage3rdOrderKandG<double>(
+    model, obs, useFSAL, ICConsistency, ICConsistencyCheck, useEmbedded));
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+}
+#endif // CONSTRUCTION
+
+
+#ifdef STEPPERFACTORY_CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(ERK_5Stage3rdOrderKandG, StepperFactory_Construction)
+{
+  auto model = rcp(new Tempus_Test::SinCosModel<double>());
+  testFactoryConstruction("RK Explicit 5 Stage 3rd order by Kinnmark and Gray", model);
+}
+#endif // STEPPERFACTORY_CONSTRUCTION
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_ERK_BogackiShampine32.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_ERK_BogackiShampine32.cpp
@@ -1,0 +1,94 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_UnitTest_Utils.hpp"
+#include "Tempus_StepperRKButcherTableau.hpp"
+
+#include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/VanDerPolModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+using Tempus::StepperFactory;
+using Tempus::StepperExplicitRK;
+
+// Comment out any of the following tests to exclude from build/run.
+#define CONSTRUCTION
+#define STEPPERFACTORY_CONSTRUCTION
+
+
+#ifdef CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(ERK_BogackiShampine32, Default_Construction)
+{
+  auto model   = rcp(new Tempus_Test::SinCosModel<double>());
+
+  // Default construction.
+  auto stepper = rcp(new Tempus::StepperERK_BogackiShampine32<double>());
+  stepper->setModel(model);
+  stepper->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+  // Default values for construction.
+  auto obs    = rcp(new Tempus::StepperRKObserverComposite<double>());
+
+  bool useFSAL              = stepper->getUseFSALDefault();
+  std::string ICConsistency = stepper->getICConsistencyDefault();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool useEmbedded          = stepper->getUseEmbeddedDefault();
+
+  // Test the set functions.
+  stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseEmbedded(useEmbedded);                stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Full argument list construction.
+  stepper = rcp(new Tempus::StepperERK_BogackiShampine32<double>(
+    model, obs, useFSAL, ICConsistency, ICConsistencyCheck, useEmbedded));
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+}
+#endif // CONSTRUCTION
+
+
+#ifdef STEPPERFACTORY_CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(ERK_BogackiShampine32, StepperFactory_Construction)
+{
+  auto model = rcp(new Tempus_Test::SinCosModel<double>());
+  testFactoryConstruction("Bogacki-Shampine 3(2) Pair", model);
+}
+#endif // STEPPERFACTORY_CONSTRUCTION
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_ERK_General.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_ERK_General.cpp
@@ -1,0 +1,118 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_UnitTest_Utils.hpp"
+#include "Tempus_StepperRKButcherTableau.hpp"
+
+#include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/VanDerPolModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+using Tempus::StepperFactory;
+using Tempus::StepperExplicitRK;
+
+// Comment out any of the following tests to exclude from build/run.
+#define CONSTRUCTION
+#define STEPPERFACTORY_CONSTRUCTION
+
+
+#ifdef CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(ERK_General, Default_Construction)
+{
+  auto model   = rcp(new Tempus_Test::SinCosModel<double>());
+
+  // Default construction.
+  auto stepper = rcp(new Tempus::StepperERK_General<double>());
+  stepper->setModel(model);
+  stepper->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+  // Default values for construction.
+  auto obs    = rcp(new Tempus::StepperRKObserverComposite<double>());
+
+  bool useFSAL              = stepper->getUseFSALDefault();
+  std::string ICConsistency = stepper->getICConsistencyDefault();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool useEmbedded          = stepper->getUseEmbeddedDefault();
+
+  int NumStages = 4;
+  Teuchos::SerialDenseMatrix<int,double> A(NumStages,NumStages);
+  Teuchos::SerialDenseVector<int,double> b(NumStages);
+  Teuchos::SerialDenseVector<int,double> c(NumStages);
+  Teuchos::SerialDenseVector<int,double> bstar(0);
+
+  // Fill A:
+  A(0,0) = 0.0;  A(0,1) = 0.0;  A(0,2) = 0.0;  A(0,3) = 0.0;
+  A(1,0) = 0.5;  A(1,1) = 0.0;  A(1,2) = 0.0;  A(1,3) = 0.0;
+  A(2,0) = 0.0;  A(2,1) = 0.5;  A(2,2) = 0.0;  A(2,3) = 0.0;
+  A(3,0) = 0.0;  A(3,1) = 0.0;  A(3,2) = 1.0;  A(3,3) = 0.0;
+
+  // Fill b:
+  b(0) = 1.0/6.0;  b(1) = 1.0/3.0;  b(2) = 1.0/3.0;  b(3) = 1.0/6.0;
+
+  // fill c:
+  c(0) = 0.0;  c(1) = 0.5;  c(2) = 0.5;  c(3) = 1.0;
+
+  int order = 4;
+
+
+  // Test the set functions.
+  stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseEmbedded(useEmbedded);                stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+  stepper->setTableau(A, b, c, order, order, order);   stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Full argument list construction.
+  stepper = rcp(new Tempus::StepperERK_General<double>(
+    model, obs, useFSAL, ICConsistency, ICConsistencyCheck, useEmbedded,
+    A, b, c, order, order, order, bstar));
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+}
+#endif // CONSTRUCTION
+
+
+#ifdef STEPPERFACTORY_CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(ERK_General, StepperFactory_Construction)
+{
+  auto model = rcp(new Tempus_Test::SinCosModel<double>());
+  testFactoryConstruction("General ERK", model);
+}
+#endif // STEPPERFACTORY_CONSTRUCTION
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_ERK_Merson45.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_ERK_Merson45.cpp
@@ -1,0 +1,94 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_UnitTest_Utils.hpp"
+#include "Tempus_StepperRKButcherTableau.hpp"
+
+#include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/VanDerPolModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+using Tempus::StepperFactory;
+using Tempus::StepperExplicitRK;
+
+// Comment out any of the following tests to exclude from build/run.
+#define CONSTRUCTION
+#define STEPPERFACTORY_CONSTRUCTION
+
+
+#ifdef CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(ERK_Merson45, Default_Construction)
+{
+  auto model   = rcp(new Tempus_Test::SinCosModel<double>());
+
+  // Default construction.
+  auto stepper = rcp(new Tempus::StepperERK_Merson45<double>());
+  stepper->setModel(model);
+  stepper->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+  // Default values for construction.
+  auto obs    = rcp(new Tempus::StepperRKObserverComposite<double>());
+
+  bool useFSAL              = stepper->getUseFSALDefault();
+  std::string ICConsistency = stepper->getICConsistencyDefault();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool useEmbedded          = stepper->getUseEmbeddedDefault();
+
+  // Test the set functions.
+  stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseEmbedded(useEmbedded);                stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Full argument list construction.
+  stepper = rcp(new Tempus::StepperERK_Merson45<double>(
+    model, obs, useFSAL, ICConsistency, ICConsistencyCheck, useEmbedded));
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+}
+#endif // CONSTRUCTION
+
+
+#ifdef STEPPERFACTORY_CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(ERK_Merson45, StepperFactory_Construction)
+{
+  auto model = rcp(new Tempus_Test::SinCosModel<double>());
+  testFactoryConstruction("Merson 4(5) Pair", model);
+}
+#endif // STEPPERFACTORY_CONSTRUCTION
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_ERK_Midpoint.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_ERK_Midpoint.cpp
@@ -1,0 +1,94 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_UnitTest_Utils.hpp"
+#include "Tempus_StepperRKButcherTableau.hpp"
+
+#include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/VanDerPolModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+using Tempus::StepperFactory;
+using Tempus::StepperExplicitRK;
+
+// Comment out any of the following tests to exclude from build/run.
+#define CONSTRUCTION
+#define STEPPERFACTORY_CONSTRUCTION
+
+
+#ifdef CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(ERK_Midpoint, Default_Construction)
+{
+  auto model   = rcp(new Tempus_Test::SinCosModel<double>());
+
+  // Default construction.
+  auto stepper = rcp(new Tempus::StepperERK_Midpoint<double>());
+  stepper->setModel(model);
+  stepper->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+  // Default values for construction.
+  auto obs    = rcp(new Tempus::StepperRKObserverComposite<double>());
+
+  bool useFSAL              = stepper->getUseFSALDefault();
+  std::string ICConsistency = stepper->getICConsistencyDefault();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool useEmbedded          = stepper->getUseEmbeddedDefault();
+
+  // Test the set functions.
+  stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseEmbedded(useEmbedded);                stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Full argument list construction.
+  stepper = rcp(new Tempus::StepperERK_Midpoint<double>(
+    model, obs, useFSAL, ICConsistency, ICConsistencyCheck, useEmbedded));
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+}
+#endif // CONSTRUCTION
+
+
+#ifdef STEPPERFACTORY_CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(ERK_Midpoint, StepperFactory_Construction)
+{
+  auto model = rcp(new Tempus_Test::SinCosModel<double>());
+  testFactoryConstruction("RK Explicit Midpoint", model);
+}
+#endif // STEPPERFACTORY_CONSTRUCTION
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_ERK_Trapezoidal.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_ERK_Trapezoidal.cpp
@@ -1,0 +1,94 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_UnitTest_Utils.hpp"
+#include "Tempus_StepperRKButcherTableau.hpp"
+
+#include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/VanDerPolModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+using Tempus::StepperFactory;
+using Tempus::StepperExplicitRK;
+
+// Comment out any of the following tests to exclude from build/run.
+#define CONSTRUCTION
+#define STEPPERFACTORY_CONSTRUCTION
+
+
+#ifdef CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(ERK_Trapezoidal, Default_Construction)
+{
+  auto model   = rcp(new Tempus_Test::SinCosModel<double>());
+
+  // Default construction.
+  auto stepper = rcp(new Tempus::StepperERK_Trapezoidal<double>());
+  stepper->setModel(model);
+  stepper->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+  // Default values for construction.
+  auto obs    = rcp(new Tempus::StepperRKObserverComposite<double>());
+
+  bool useFSAL              = stepper->getUseFSALDefault();
+  std::string ICConsistency = stepper->getICConsistencyDefault();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool useEmbedded          = stepper->getUseEmbeddedDefault();
+
+  // Test the set functions.
+  stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseEmbedded(useEmbedded);                stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Full argument list construction.
+  stepper = rcp(new Tempus::StepperERK_Trapezoidal<double>(
+    model, obs, useFSAL, ICConsistency, ICConsistencyCheck, useEmbedded));
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+}
+#endif // CONSTRUCTION
+
+
+#ifdef STEPPERFACTORY_CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(ERK_Trapezoidal, StepperFactory_Construction)
+{
+  auto model = rcp(new Tempus_Test::SinCosModel<double>());
+  testFactoryConstruction("RK Explicit Trapezoidal", model);
+}
+#endif // STEPPERFACTORY_CONSTRUCTION
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_ForwardEuler.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_ForwardEuler.cpp
@@ -1,0 +1,92 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_UnitTest_Utils.hpp"
+#include "Tempus_StepperRKButcherTableau.hpp"
+
+#include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/VanDerPolModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+using Tempus::StepperFactory;
+using Tempus::StepperExplicitRK;
+
+// Comment out any of the following tests to exclude from build/run.
+#define CONSTRUCTION
+#define STEPPERFACTORY_CONSTRUCTION
+
+
+#ifdef CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(ForwardEuler, Default_Construction)
+{
+  auto model   = rcp(new Tempus_Test::SinCosModel<double>());
+
+  // Default construction.
+  auto stepper = rcp(new Tempus::StepperForwardEuler<double>());
+  stepper->setModel(model);
+  stepper->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+  // Default values for construction.
+  auto obs    = rcp(new Tempus::StepperForwardEulerObserver<double>());
+
+  bool useFSAL              = stepper->getUseFSALDefault();
+  std::string ICConsistency = stepper->getICConsistencyDefault();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+
+  // Test the set functions.
+  stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Full argument list construction.
+  stepper = rcp(new Tempus::StepperForwardEuler<double>(
+    model, obs, useFSAL, ICConsistency, ICConsistencyCheck));
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+}
+#endif // CONSTRUCTION
+
+
+#ifdef STEPPERFACTORY_CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(ForwardEuler, StepperFactory_Construction)
+{
+  auto model = rcp(new Tempus_Test::SinCosModel<double>());
+  testFactoryConstruction("Forward Euler", model);
+}
+#endif // STEPPERFACTORY_CONSTRUCTION
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_HHTAlpha.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_HHTAlpha.cpp
@@ -1,0 +1,109 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_UnitTest_Utils.hpp"
+
+#include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/VanDerPolModel.hpp"
+#include "../TestModels/HarmonicOscillatorModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+using Tempus::StepperFactory;
+
+// Comment out any of the following tests to exclude from build/run.
+#define CONSTRUCTION
+#define STEPPERFACTORY_CONSTRUCTION
+
+
+#ifdef CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(HHTAlpha, Construction)
+{
+  auto model = rcp(new Tempus_Test::HarmonicOscillatorModel<double>());
+
+  // Default construction.
+  auto stepper = rcp(new Tempus::StepperHHTAlpha<double>());
+  stepper->setModel(model);
+  stepper->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Default values for construction.
+  auto solver = rcp(new Thyra::NOXNonlinearSolver());
+  solver->setParameterList(Tempus::defaultSolverParameters());
+
+  bool useFSAL              = stepper->getUseFSALDefault();
+  std::string ICConsistency = stepper->getICConsistencyDefault();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool zeroInitialGuess     = stepper->getZeroInitialGuess();
+  std::string schemeName    = "Newmark Beta User Defined";
+  double beta               = 0.25;
+  double gamma              = 0.5;
+  double alpha_f            = 0.0;
+  double alpha_m            = 0.0;
+
+
+  // Test the set functions.
+  stepper->setSolver(solver);                          stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setZeroInitialGuess(zeroInitialGuess);      stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+  stepper->setSchemeName(schemeName);                  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setBeta(beta);                              stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setGamma(gamma);                            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setAlphaF(alpha_f);                         stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setAlphaM(alpha_m);                         stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Full argument list construction.
+  stepper = rcp(new Tempus::StepperHHTAlpha<double>(
+    model, Teuchos::null, solver, useFSAL,
+    ICConsistency, ICConsistencyCheck, zeroInitialGuess,
+    schemeName, beta, gamma, alpha_f, alpha_m));
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+}
+#endif // CONSTRUCTION
+
+
+#ifdef STEPPERFACTORY_CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(HHTAlpha, StepperFactory_Construction)
+{
+  auto model = rcp(new Tempus_Test::HarmonicOscillatorModel<double>());
+  testFactoryConstruction("HHT-Alpha", model);
+}
+#endif // STEPPERFACTORY_CONSTRUCTION
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_IMEX_RK.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_IMEX_RK.cpp
@@ -1,0 +1,120 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_UnitTest_Utils.hpp"
+#include "Tempus_StepperRKButcherTableau.hpp"
+
+#include "../TestModels/VanDerPol_IMEX_ExplicitModel.hpp"
+#include "../TestModels/VanDerPol_IMEX_ImplicitModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+using Tempus::StepperFactory;
+using Tempus::StepperExplicitRK;
+
+// Comment out any of the following tests to exclude from build/run.
+#define CONSTRUCTION
+#define STEPPERFACTORY_CONSTRUCTION
+
+
+#ifdef CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(IMEX_RK, Default_Construction)
+{
+  // Setup the IMEX Pair ModelEvaluator
+  auto explicitModel = rcp(new Tempus_Test::VanDerPol_IMEX_ExplicitModel<double>());
+  auto implicitModel = rcp(new Tempus_Test::VanDerPol_IMEX_ImplicitModel<double>());
+  auto model = rcp(new Tempus::WrapperModelEvaluatorPairIMEX_Basic<double>(
+                                             explicitModel, implicitModel));
+
+  // Default construction.
+  auto stepper = rcp(new Tempus::StepperIMEX_RK<double>());
+  stepper->setModel(model);
+  stepper->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+  // Default values for construction.
+  auto obs    = rcp(new Tempus::StepperRKObserverComposite<double>());
+  auto solver = rcp(new Thyra::NOXNonlinearSolver());
+  solver->setParameterList(Tempus::defaultSolverParameters());
+
+  bool useFSAL              = stepper->getUseFSALDefault();
+  std::string ICConsistency = stepper->getICConsistencyDefault();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool zeroInitialGuess     = stepper->getZeroInitialGuess();
+  std::string stepperType   = "IMEX RK SSP2";
+  auto stepperERK = Teuchos::rcp(new Tempus::StepperERK_Trapezoidal<double>());
+  auto explicitTableau      = stepperERK->getTableau();
+  auto stepperSDIRK = Teuchos::rcp(new Tempus::StepperSDIRK_2Stage3rdOrder<double>());
+  auto implicitTableau      = stepperSDIRK->getTableau();
+  int order                 = 2;
+
+
+  // Test the set functions.
+  stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setSolver(solver);                          stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setZeroInitialGuess(zeroInitialGuess);      stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+  stepper->setStepperType(stepperType);                stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setExplicitTableau(explicitTableau);        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setImplicitTableau(implicitTableau);        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setOrder(order);                            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Full argument list construction.
+  stepper = rcp(new Tempus::StepperIMEX_RK<double>(
+    model, obs, solver, useFSAL,
+    ICConsistency, ICConsistencyCheck, zeroInitialGuess,
+    stepperType, explicitTableau, implicitTableau, order));
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+}
+#endif // CONSTRUCTION
+
+
+#ifdef STEPPERFACTORY_CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(IMEX_RK, StepperFactory_Construction)
+{
+  // Setup the IMEX Pair ModelEvaluator
+  auto explicitModel = rcp(new Tempus_Test::VanDerPol_IMEX_ExplicitModel<double>());
+  auto implicitModel = rcp(new Tempus_Test::VanDerPol_IMEX_ImplicitModel<double>());
+  auto model = rcp(new Tempus::WrapperModelEvaluatorPairIMEX_Basic<double>(
+                                             explicitModel, implicitModel));
+
+  testFactoryConstruction("IMEX RK SSP2", model);
+}
+#endif // STEPPERFACTORY_CONSTRUCTION
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_IMEX_RK_Partition.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_IMEX_RK_Partition.cpp
@@ -1,0 +1,133 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_UnitTest_Utils.hpp"
+#include "Tempus_StepperRKButcherTableau.hpp"
+
+#include "../TestModels/VanDerPol_IMEX_ExplicitModel.hpp"
+#include "../TestModels/VanDerPol_IMEXPart_ImplicitModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+using Tempus::StepperFactory;
+using Tempus::StepperExplicitRK;
+
+// Comment out any of the following tests to exclude from build/run.
+#define CONSTRUCTION
+#define STEPPERFACTORY_CONSTRUCTION
+
+
+#ifdef CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(IMEX_RK_Partition, Default_Construction)
+{
+  // Setup the explicit VanDerPol ModelEvaluator
+  const bool useProductVector = true;
+  auto explicitModel = rcp(new Tempus_Test::VanDerPol_IMEX_ExplicitModel<double>(Teuchos::null, useProductVector));
+  auto implicitModel = rcp(new Tempus_Test::VanDerPol_IMEXPart_ImplicitModel<double>());
+
+  // Setup the IMEX Pair ModelEvaluator
+  const int numExplicitBlocks = 1;
+  const int parameterIndex = 4;
+  auto model = rcp(new Tempus::WrapperModelEvaluatorPairPartIMEX_Basic<double>(
+                         explicitModel, implicitModel,
+                         numExplicitBlocks, parameterIndex));
+
+
+  // Default construction.
+  auto stepper = rcp(new Tempus::StepperIMEX_RK_Partition<double>());
+  stepper->setModel(model);
+  stepper->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+  // Default values for construction.
+  auto obs    = rcp(new Tempus::StepperRKObserverComposite<double>());
+  auto solver = rcp(new Thyra::NOXNonlinearSolver());
+  solver->setParameterList(Tempus::defaultSolverParameters());
+
+  bool useFSAL              = stepper->getUseFSALDefault();
+  std::string ICConsistency = stepper->getICConsistencyDefault();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool zeroInitialGuess     = stepper->getZeroInitialGuess();
+  std::string stepperType   = "IMEX RK SSP2";
+  auto stepperERK = Teuchos::rcp(new Tempus::StepperERK_Trapezoidal<double>());
+  auto explicitTableau      = stepperERK->getTableau();
+  auto stepperSDIRK = Teuchos::rcp(new Tempus::StepperSDIRK_2Stage3rdOrder<double>());
+  auto implicitTableau      = stepperSDIRK->getTableau();
+  int order                 = 2;
+
+
+  // Test the set functions.
+  stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setSolver(solver);                          stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setZeroInitialGuess(zeroInitialGuess);      stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+  stepper->setStepperType(stepperType);                stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setExplicitTableau(explicitTableau);        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setImplicitTableau(implicitTableau);        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setOrder(order);                            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Full argument list construction.
+  stepper = rcp(new Tempus::StepperIMEX_RK_Partition<double>(
+    model, obs, solver, useFSAL,
+    ICConsistency, ICConsistencyCheck, zeroInitialGuess,
+    stepperType, explicitTableau, implicitTableau, order));
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+}
+#endif // CONSTRUCTION
+
+
+#ifdef STEPPERFACTORY_CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(IMEX_RK_Partition, StepperFactory_Construction)
+{
+  // Setup the explicit VanDerPol ModelEvaluator
+  const bool useProductVector = true;
+  auto explicitModel = rcp(new Tempus_Test::VanDerPol_IMEX_ExplicitModel<double>(Teuchos::null, useProductVector));
+  auto implicitModel = rcp(new Tempus_Test::VanDerPol_IMEXPart_ImplicitModel<double>());
+
+  // Setup the IMEX Pair ModelEvaluator
+  const int numExplicitBlocks = 1;
+  const int parameterIndex = 4;
+  auto model = rcp(new Tempus::WrapperModelEvaluatorPairPartIMEX_Basic<double>(
+                         explicitModel, implicitModel,
+                         numExplicitBlocks, parameterIndex));
+
+  testFactoryConstruction("Partitioned IMEX RK SSP2", model);
+}
+#endif // STEPPERFACTORY_CONSTRUCTION
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_Leapfrog.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_Leapfrog.cpp
@@ -1,0 +1,93 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_UnitTest_Utils.hpp"
+
+#include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/VanDerPolModel.hpp"
+#include "../TestModels/HarmonicOscillatorModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+using Tempus::StepperFactory;
+
+// Comment out any of the following tests to exclude from build/run.
+#define CONSTRUCTION
+#define STEPPERFACTORY_CONSTRUCTION
+
+
+#ifdef CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(Leapfrog, Construction)
+{
+  auto model = rcp(new Tempus_Test::HarmonicOscillatorModel<double>());
+
+  // Default construction.
+  auto stepper = rcp(new Tempus::StepperLeapfrog<double>());
+  stepper->setModel(model);
+  stepper->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Default values for construction.
+  auto obs    = rcp(new Tempus::StepperLeapfrogObserver<double>());
+
+  bool useFSAL              = stepper->getUseFSALDefault();
+  std::string ICConsistency = stepper->getICConsistencyDefault();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+
+
+  // Test the set functions.
+  stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Full argument list construction.
+  stepper = rcp(new Tempus::StepperLeapfrog<double>(
+    model, obs, useFSAL, ICConsistency, ICConsistencyCheck));
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+}
+#endif // CONSTRUCTION
+
+
+#ifdef STEPPERFACTORY_CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(Leapfrog, StepperFactory_Construction)
+{
+  auto model = rcp(new Tempus_Test::HarmonicOscillatorModel<double>());
+  testFactoryConstruction("Leapfrog", model);
+}
+#endif // STEPPERFACTORY_CONSTRUCTION
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_NewmarkExplicitAForm.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_NewmarkExplicitAForm.cpp
@@ -1,0 +1,93 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_UnitTest_Utils.hpp"
+
+#include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/VanDerPolModel.hpp"
+#include "../TestModels/HarmonicOscillatorModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+using Tempus::StepperFactory;
+
+// Comment out any of the following tests to exclude from build/run.
+#define CONSTRUCTION
+#define STEPPERFACTORY_CONSTRUCTION
+
+
+#ifdef CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(NewmarkExplicitAForm, Construction)
+{
+  auto model = rcp(new Tempus_Test::HarmonicOscillatorModel<double>());
+
+  // Default construction.
+  auto stepper = rcp(new Tempus::StepperNewmarkExplicitAForm<double>());
+  stepper->setModel(model);
+  stepper->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Default values for construction.
+  bool useFSAL              = stepper->getUseFSALDefault();
+  std::string ICConsistency = stepper->getICConsistencyDefault();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  double gamma              = 0.5;
+
+
+  // Test the set functions.
+  stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+  stepper->setGamma(gamma);                            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Full argument list construction.
+  stepper = rcp(new Tempus::StepperNewmarkExplicitAForm<double>(
+    model, Teuchos::null, useFSAL, ICConsistency, ICConsistencyCheck, gamma));
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+}
+#endif // CONSTRUCTION
+
+
+#ifdef STEPPERFACTORY_CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(NewmarkExplicitAForm, StepperFactory_Construction)
+{
+  auto model = rcp(new Tempus_Test::HarmonicOscillatorModel<double>());
+  testFactoryConstruction("Newmark Explicit a-Form", model);
+}
+#endif // STEPPERFACTORY_CONSTRUCTION
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_NewmarkImplicitAForm.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_NewmarkImplicitAForm.cpp
@@ -1,0 +1,105 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_UnitTest_Utils.hpp"
+
+#include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/VanDerPolModel.hpp"
+#include "../TestModels/HarmonicOscillatorModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+using Tempus::StepperFactory;
+
+// Comment out any of the following tests to exclude from build/run.
+#define CONSTRUCTION
+#define STEPPERFACTORY_CONSTRUCTION
+
+
+#ifdef CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(NewmarkImplicitAForm, Construction)
+{
+  auto model = rcp(new Tempus_Test::HarmonicOscillatorModel<double>());
+
+  // Default construction.
+  auto stepper = rcp(new Tempus::StepperNewmarkImplicitAForm<double>());
+  stepper->setModel(model);
+  stepper->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Default values for construction.
+  auto solver = rcp(new Thyra::NOXNonlinearSolver());
+  solver->setParameterList(Tempus::defaultSolverParameters());
+
+  bool useFSAL              = stepper->getUseFSALDefault();
+  std::string ICConsistency = stepper->getICConsistencyDefault();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool zeroInitialGuess     = stepper->getZeroInitialGuess();
+  std::string schemeName    = "Average Acceleration";
+  double beta               = 0.25;
+  double gamma              = 0.5;
+
+
+  // Test the set functions.
+  stepper->setSolver(solver);                          stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setZeroInitialGuess(zeroInitialGuess);      stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+  stepper->setSchemeName(schemeName);                  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setBeta(beta);                              stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setGamma(gamma);                            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Full argument list construction.
+  stepper = rcp(new Tempus::StepperNewmarkImplicitAForm<double>(
+    model, Teuchos::null, solver, useFSAL,
+    ICConsistency, ICConsistencyCheck, zeroInitialGuess,
+    schemeName, beta, gamma));
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+}
+#endif // CONSTRUCTION
+
+
+#ifdef STEPPERFACTORY_CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(NewmarkImplicitAForm, StepperFactory_Construction)
+{
+  auto model = rcp(new Tempus_Test::HarmonicOscillatorModel<double>());
+  testFactoryConstruction("Newmark Implicit a-Form", model);
+}
+#endif // STEPPERFACTORY_CONSTRUCTION
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_NewmarkImplicitDForm.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_NewmarkImplicitDForm.cpp
@@ -1,0 +1,105 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_UnitTest_Utils.hpp"
+
+#include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/VanDerPolModel.hpp"
+#include "../TestModels/HarmonicOscillatorModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+using Tempus::StepperFactory;
+
+// Comment out any of the following tests to exclude from build/run.
+#define CONSTRUCTION
+#define STEPPERFACTORY_CONSTRUCTION
+
+
+#ifdef CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(NewmarkImplicitDForm, Construction)
+{
+  auto model = rcp(new Tempus_Test::HarmonicOscillatorModel<double>());
+
+  // Default construction.
+  auto stepper = rcp(new Tempus::StepperNewmarkImplicitDForm<double>());
+  stepper->setModel(model);
+  stepper->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Default values for construction.
+  auto solver = rcp(new Thyra::NOXNonlinearSolver());
+  solver->setParameterList(Tempus::defaultSolverParameters());
+
+  bool useFSAL              = stepper->getUseFSALDefault();
+  std::string ICConsistency = stepper->getICConsistencyDefault();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool zeroInitialGuess     = stepper->getZeroInitialGuess();
+  std::string schemeName    = "Average Acceleration";
+  double beta               = 0.25;
+  double gamma              = 0.5;
+
+
+  // Test the set functions.
+  stepper->setSolver(solver);                          stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setZeroInitialGuess(zeroInitialGuess);      stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+  stepper->setSchemeName(schemeName);                  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setBeta(beta);                              stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setGamma(gamma);                            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Full argument list construction.
+  stepper = rcp(new Tempus::StepperNewmarkImplicitDForm<double>(
+    model, Teuchos::null, solver, useFSAL,
+    ICConsistency, ICConsistencyCheck, zeroInitialGuess,
+    schemeName, beta, gamma));
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+}
+#endif // CONSTRUCTION
+
+
+#ifdef STEPPERFACTORY_CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(NewmarkImplicitDForm, StepperFactory_Construction)
+{
+  auto model = rcp(new Tempus_Test::HarmonicOscillatorModel<double>());
+  testFactoryConstruction("Newmark Implicit d-Form", model);
+}
+#endif // STEPPERFACTORY_CONSTRUCTION
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_OperatorSplit.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_OperatorSplit.cpp
@@ -1,0 +1,130 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_UnitTest_Utils.hpp"
+#include "Tempus_StepperRKButcherTableau.hpp"
+
+#include "../TestModels/VanDerPol_IMEX_ExplicitModel.hpp"
+#include "../TestModels/VanDerPol_IMEX_ImplicitModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+using Tempus::StepperFactory;
+using Tempus::StepperExplicitRK;
+
+// Comment out any of the following tests to exclude from build/run.
+#define CONSTRUCTION
+#define STEPPERFACTORY_CONSTRUCTION
+
+
+#ifdef CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(OperatorSplit, Default_Construction)
+{
+  auto explicitModel = rcp(new Tempus_Test::VanDerPol_IMEX_ExplicitModel<double>());
+  auto implicitModel = rcp(new Tempus_Test::VanDerPol_IMEX_ImplicitModel<double>());
+
+  // Default construction.
+  auto stepper = rcp(new Tempus::StepperOperatorSplit<double>());
+  auto sf = Teuchos::rcp(new Tempus::StepperFactory<double>());
+  auto subStepper1 =
+    sf->createStepperForwardEuler(explicitModel, Teuchos::null);
+  auto subStepper2 =
+    sf->createStepperBackwardEuler(implicitModel, Teuchos::null);
+  stepper->addStepper(subStepper1);
+  stepper->addStepper(subStepper2);
+  stepper->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+  // Default values for construction.
+  auto obs    = rcp(new Tempus::StepperOperatorSplitObserver<double>());
+
+  bool useFSAL              = stepper->getUseFSALDefault();
+  std::string ICConsistency = stepper->getICConsistencyDefault();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  int order = 2;
+
+  // Test the set functions.
+  stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setOrder(order);                            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setOrderMin(order);                         stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setOrderMax(order);                         stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Full argument list construction.
+  std::vector<RCP<const Thyra::ModelEvaluator<double> > > models;
+  models.push_back(explicitModel);
+  models.push_back(implicitModel);
+
+  std::vector<Teuchos::RCP<Tempus::Stepper<double> > > subStepperList;
+  subStepperList.push_back(subStepper1);
+  subStepperList.push_back(subStepper2);
+
+  stepper = rcp(new Tempus::StepperOperatorSplit<double>(
+    models, subStepperList, obs, useFSAL, ICConsistency, ICConsistencyCheck,
+    order, order, order));
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+}
+#endif // CONSTRUCTION
+
+
+#ifdef STEPPERFACTORY_CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(OperatorSplit, StepperFactory_Construction)
+{
+  // Read params from .xml file
+  auto pList = getParametersFromXmlFile(
+                 "../test/OperatorSplit/Tempus_OperatorSplit_VanDerPol.xml");
+  auto tempusPL  = sublist(pList, "Tempus", true);
+  auto stepperPL = sublist(tempusPL, "Demo Stepper", true);
+
+  auto explicitModel = rcp(new Tempus_Test::VanDerPol_IMEX_ExplicitModel<double>());
+  auto implicitModel = rcp(new Tempus_Test::VanDerPol_IMEX_ImplicitModel<double>());
+  std::vector<RCP<const Thyra::ModelEvaluator<double> > > models;
+  models.push_back(explicitModel);
+  models.push_back(implicitModel);
+
+
+  auto sf = Teuchos::rcp(new StepperFactory<double>());
+
+  // Test using ParameterList.
+  // Passing in model.
+  auto stepper = sf->createMultiSteppers(stepperPL, models);
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+}
+#endif // STEPPERFACTORY_CONSTRUCTION
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_SDIRK_21Pair.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_SDIRK_21Pair.cpp
@@ -1,0 +1,99 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_UnitTest_Utils.hpp"
+
+#include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/VanDerPolModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+using Tempus::StepperFactory;
+
+// Comment out any of the following tests to exclude from build/run.
+#define CONSTRUCTION
+#define STEPPERFACTORY_CONSTRUCTION
+
+
+#ifdef CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(SDIRK_21Pair, Construction)
+{
+  auto model   = rcp(new Tempus_Test::SinCosModel<double>());
+
+  // Default construction.
+  auto stepper = rcp(new Tempus::StepperSDIRK_21Pair<double>());
+  stepper->setModel(model);
+  stepper->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Default values for construction.
+  auto obs    = rcp(new Tempus::StepperRKObserverComposite<double>());
+  auto solver = rcp(new Thyra::NOXNonlinearSolver());
+  solver->setParameterList(Tempus::defaultSolverParameters());
+
+  bool useFSAL              = stepper->getUseFSALDefault();
+  std::string ICConsistency = stepper->getICConsistencyDefault();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool useEmbedded          = stepper->getUseEmbeddedDefault();
+  bool zeroInitialGuess     = stepper->getZeroInitialGuess();
+
+  // Test the set functions.
+  stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setSolver(solver);                          stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseEmbedded(useEmbedded);                stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setZeroInitialGuess(zeroInitialGuess);      stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Full argument list construction.
+  stepper = rcp(new Tempus::StepperSDIRK_21Pair<double>(
+    model, obs, solver, useFSAL,
+    ICConsistency, ICConsistencyCheck, useEmbedded, zeroInitialGuess));
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+}
+#endif // CONSTRUCTION
+
+
+#ifdef STEPPERFACTORY_CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(SDIRK_21Pair, StepperFactory_Construction)
+{
+  auto model = rcp(new Tempus_Test::SinCosModel<double>());
+  testFactoryConstruction("SDIRK 2(1) Pair", model);
+}
+#endif // STEPPERFACTORY_CONSTRUCTION
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_SDIRK_2Stage2ndOrder.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_SDIRK_2Stage2ndOrder.cpp
@@ -1,0 +1,102 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_UnitTest_Utils.hpp"
+
+#include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/VanDerPolModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+using Tempus::StepperFactory;
+
+// Comment out any of the following tests to exclude from build/run.
+#define CONSTRUCTION
+#define STEPPERFACTORY_CONSTRUCTION
+
+
+#ifdef CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(SDIRK_2Stage2ndOrder, Construction)
+{
+  auto model   = rcp(new Tempus_Test::SinCosModel<double>());
+
+  // Default construction.
+  auto stepper = rcp(new Tempus::StepperSDIRK_2Stage2ndOrder<double>());
+  stepper->setModel(model);
+  stepper->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Default values for construction.
+  auto obs    = rcp(new Tempus::StepperRKObserverComposite<double>());
+  auto solver = rcp(new Thyra::NOXNonlinearSolver());
+  solver->setParameterList(Tempus::defaultSolverParameters());
+
+  bool useFSAL              = stepper->getUseFSALDefault();
+  std::string ICConsistency = stepper->getICConsistencyDefault();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool useEmbedded          = stepper->getUseEmbeddedDefault();
+  bool zeroInitialGuess     = stepper->getZeroInitialGuess();
+  double gamma              = 0.2928932188134524;
+
+  // Test the set functions.
+  stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setSolver(solver);                          stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseEmbedded(useEmbedded);                stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setZeroInitialGuess(zeroInitialGuess);      stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+  stepper->setGamma(gamma);                            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Full argument list construction.
+  stepper = rcp(new Tempus::StepperSDIRK_2Stage2ndOrder<double>(
+    model, obs, solver, useFSAL, ICConsistency, ICConsistencyCheck,
+    useEmbedded, zeroInitialGuess, gamma));
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+}
+#endif // CONSTRUCTION
+
+
+#ifdef STEPPERFACTORY_CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(SDIRK_2Stage2ndOrder, StepperFactory_Construction)
+{
+  auto model = rcp(new Tempus_Test::SinCosModel<double>());
+  testFactoryConstruction("SDIRK 2 Stage 2nd order", model);
+}
+#endif // STEPPERFACTORY_CONSTRUCTION
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_SDIRK_2Stage3rdOrder.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_SDIRK_2Stage3rdOrder.cpp
@@ -1,0 +1,104 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_UnitTest_Utils.hpp"
+
+#include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/VanDerPolModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+using Tempus::StepperFactory;
+
+// Comment out any of the following tests to exclude from build/run.
+#define CONSTRUCTION
+#define STEPPERFACTORY_CONSTRUCTION
+
+
+#ifdef CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(SDIRK_2Stage3rdOrder, Construction)
+{
+  auto model   = rcp(new Tempus_Test::SinCosModel<double>());
+
+  // Default construction.
+  auto stepper = rcp(new Tempus::StepperSDIRK_2Stage3rdOrder<double>());
+  stepper->setModel(model);
+  stepper->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Default values for construction.
+  auto obs    = rcp(new Tempus::StepperRKObserverComposite<double>());
+  auto solver = rcp(new Thyra::NOXNonlinearSolver());
+  solver->setParameterList(Tempus::defaultSolverParameters());
+
+  bool useFSAL              = stepper->getUseFSALDefault();
+  std::string ICConsistency = stepper->getICConsistencyDefault();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool useEmbedded          = stepper->getUseEmbeddedDefault();
+  bool zeroInitialGuess     = stepper->getZeroInitialGuess();
+  std::string gammaType     = "3rd Order A-stable";
+  double gamma              = 0.7886751345948128;
+
+  // Test the set functions.
+  stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setSolver(solver);                          stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseEmbedded(useEmbedded);                stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setZeroInitialGuess(zeroInitialGuess);      stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+  stepper->setGammaType(gammaType);                    stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setGamma(gamma);                            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Full argument list construction.
+  stepper = rcp(new Tempus::StepperSDIRK_2Stage3rdOrder<double>(
+    model, obs, solver, useFSAL, ICConsistency, ICConsistencyCheck,
+    useEmbedded, zeroInitialGuess, gammaType, gamma));
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+}
+#endif // CONSTRUCTION
+
+
+#ifdef STEPPERFACTORY_CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(SDIRK_2Stage3rdOrder, StepperFactory_Construction)
+{
+  auto model = rcp(new Tempus_Test::SinCosModel<double>());
+  testFactoryConstruction("SDIRK 2 Stage 3rd order", model);
+}
+#endif // STEPPERFACTORY_CONSTRUCTION
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_SDIRK_3Stage4thOrder.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_SDIRK_3Stage4thOrder.cpp
@@ -1,0 +1,99 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_UnitTest_Utils.hpp"
+
+#include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/VanDerPolModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+using Tempus::StepperFactory;
+
+// Comment out any of the following tests to exclude from build/run.
+#define CONSTRUCTION
+#define STEPPERFACTORY_CONSTRUCTION
+
+
+#ifdef CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(SDIRK_3Stage4thOrder, Construction)
+{
+  auto model   = rcp(new Tempus_Test::SinCosModel<double>());
+
+  // Default construction.
+  auto stepper = rcp(new Tempus::StepperSDIRK_3Stage4thOrder<double>());
+  stepper->setModel(model);
+  stepper->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Default values for construction.
+  auto obs    = rcp(new Tempus::StepperRKObserverComposite<double>());
+  auto solver = rcp(new Thyra::NOXNonlinearSolver());
+  solver->setParameterList(Tempus::defaultSolverParameters());
+
+  bool useFSAL              = stepper->getUseFSALDefault();
+  std::string ICConsistency = stepper->getICConsistencyDefault();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool useEmbedded          = stepper->getUseEmbeddedDefault();
+  bool zeroInitialGuess     = stepper->getZeroInitialGuess();
+
+  // Test the set functions.
+  stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setSolver(solver);                          stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseEmbedded(useEmbedded);                stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setZeroInitialGuess(zeroInitialGuess);      stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Full argument list construction.
+  stepper = rcp(new Tempus::StepperSDIRK_3Stage4thOrder<double>(
+    model, obs, solver, useFSAL,
+    ICConsistency, ICConsistencyCheck, useEmbedded, zeroInitialGuess));
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+}
+#endif // CONSTRUCTION
+
+
+#ifdef STEPPERFACTORY_CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(SDIRK_3Stage4thOrder, StepperFactory_Construction)
+{
+  auto model = rcp(new Tempus_Test::SinCosModel<double>());
+  testFactoryConstruction("SDIRK 3 Stage 4th order", model);
+}
+#endif // STEPPERFACTORY_CONSTRUCTION
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_SDIRK_5Stage4thOrder.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_SDIRK_5Stage4thOrder.cpp
@@ -1,0 +1,99 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_UnitTest_Utils.hpp"
+
+#include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/VanDerPolModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+using Tempus::StepperFactory;
+
+// Comment out any of the following tests to exclude from build/run.
+#define CONSTRUCTION
+#define STEPPERFACTORY_CONSTRUCTION
+
+
+#ifdef CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(SDIRK_5Stage4thOrder, Construction)
+{
+  auto model   = rcp(new Tempus_Test::SinCosModel<double>());
+
+  // Default construction.
+  auto stepper = rcp(new Tempus::StepperSDIRK_5Stage4thOrder<double>());
+  stepper->setModel(model);
+  stepper->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Default values for construction.
+  auto obs    = rcp(new Tempus::StepperRKObserverComposite<double>());
+  auto solver = rcp(new Thyra::NOXNonlinearSolver());
+  solver->setParameterList(Tempus::defaultSolverParameters());
+
+  bool useFSAL              = stepper->getUseFSALDefault();
+  std::string ICConsistency = stepper->getICConsistencyDefault();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool useEmbedded          = stepper->getUseEmbeddedDefault();
+  bool zeroInitialGuess     = stepper->getZeroInitialGuess();
+
+  // Test the set functions.
+  stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setSolver(solver);                          stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseEmbedded(useEmbedded);                stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setZeroInitialGuess(zeroInitialGuess);      stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Full argument list construction.
+  stepper = rcp(new Tempus::StepperSDIRK_5Stage4thOrder<double>(
+    model, obs, solver, useFSAL,
+    ICConsistency, ICConsistencyCheck, useEmbedded, zeroInitialGuess));
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+}
+#endif // CONSTRUCTION
+
+
+#ifdef STEPPERFACTORY_CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(SDIRK_5Stage4thOrder, StepperFactory_Construction)
+{
+  auto model = rcp(new Tempus_Test::SinCosModel<double>());
+  testFactoryConstruction("SDIRK 5 Stage 4th order", model);
+}
+#endif // STEPPERFACTORY_CONSTRUCTION
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_SDIRK_5Stage5thOrder.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_SDIRK_5Stage5thOrder.cpp
@@ -1,0 +1,99 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_UnitTest_Utils.hpp"
+
+#include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/VanDerPolModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+using Tempus::StepperFactory;
+
+// Comment out any of the following tests to exclude from build/run.
+#define CONSTRUCTION
+#define STEPPERFACTORY_CONSTRUCTION
+
+
+#ifdef CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(SDIRK_5Stage5thOrder, Construction)
+{
+  auto model   = rcp(new Tempus_Test::SinCosModel<double>());
+
+  // Default construction.
+  auto stepper = rcp(new Tempus::StepperSDIRK_5Stage5thOrder<double>());
+  stepper->setModel(model);
+  stepper->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Default values for construction.
+  auto obs    = rcp(new Tempus::StepperRKObserverComposite<double>());
+  auto solver = rcp(new Thyra::NOXNonlinearSolver());
+  solver->setParameterList(Tempus::defaultSolverParameters());
+
+  bool useFSAL              = stepper->getUseFSALDefault();
+  std::string ICConsistency = stepper->getICConsistencyDefault();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool useEmbedded          = stepper->getUseEmbeddedDefault();
+  bool zeroInitialGuess     = stepper->getZeroInitialGuess();
+
+  // Test the set functions.
+  stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setSolver(solver);                          stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseEmbedded(useEmbedded);                stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setZeroInitialGuess(zeroInitialGuess);      stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Full argument list construction.
+  stepper = rcp(new Tempus::StepperSDIRK_5Stage5thOrder<double>(
+    model, obs, solver, useFSAL,
+    ICConsistency, ICConsistencyCheck, useEmbedded, zeroInitialGuess));
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+}
+#endif // CONSTRUCTION
+
+
+#ifdef STEPPERFACTORY_CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(SDIRK_5Stage5thOrder, StepperFactory_Construction)
+{
+  auto model = rcp(new Tempus_Test::SinCosModel<double>());
+  testFactoryConstruction("SDIRK 5 Stage 5th order", model);
+}
+#endif // STEPPERFACTORY_CONSTRUCTION
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_SDIRK_ImplicitMidpoint.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_SDIRK_ImplicitMidpoint.cpp
@@ -1,0 +1,99 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_UnitTest_Utils.hpp"
+
+#include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/VanDerPolModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+using Tempus::StepperFactory;
+
+// Comment out any of the following tests to exclude from build/run.
+#define CONSTRUCTION
+#define STEPPERFACTORY_CONSTRUCTION
+
+
+#ifdef CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(SDIRK_ImplicitMidpoint, Construction)
+{
+  auto model   = rcp(new Tempus_Test::SinCosModel<double>());
+
+  // Default construction.
+  auto stepper = rcp(new Tempus::StepperSDIRK_ImplicitMidpoint<double>());
+  stepper->setModel(model);
+  stepper->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Default values for construction.
+  auto obs    = rcp(new Tempus::StepperRKObserverComposite<double>());
+  auto solver = rcp(new Thyra::NOXNonlinearSolver());
+  solver->setParameterList(Tempus::defaultSolverParameters());
+
+  bool useFSAL              = stepper->getUseFSALDefault();
+  std::string ICConsistency = stepper->getICConsistencyDefault();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool useEmbedded          = stepper->getUseEmbeddedDefault();
+  bool zeroInitialGuess     = stepper->getZeroInitialGuess();
+
+  // Test the set functions.
+  stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setSolver(solver);                          stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseEmbedded(useEmbedded);                stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setZeroInitialGuess(zeroInitialGuess);      stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Full argument list construction.
+  stepper = rcp(new Tempus::StepperSDIRK_ImplicitMidpoint<double>(
+    model, obs, solver, useFSAL,
+    ICConsistency, ICConsistencyCheck, useEmbedded, zeroInitialGuess));
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+}
+#endif // CONSTRUCTION
+
+
+#ifdef STEPPERFACTORY_CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(SDIRK_ImplicitMidpoint, StepperFactory_Construction)
+{
+  auto model = rcp(new Tempus_Test::SinCosModel<double>());
+  testFactoryConstruction("RK Implicit Midpoint", model);
+}
+#endif // STEPPERFACTORY_CONSTRUCTION
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_Subcycling.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_Subcycling.cpp
@@ -53,7 +53,7 @@ TEUCHOS_UNIT_TEST(Subcycling, Default_Construction)
   auto stepperBE = sf->createStepperBackwardEuler(model, Teuchos::null);
   stepper->setSubcyclingStepper(stepperBE);
   stepper->initialize();
-  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized_);
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
 
   // Default values for construction.
   auto obs    = rcp(new Tempus::StepperSubcyclingObserver<double>());
@@ -65,11 +65,11 @@ TEUCHOS_UNIT_TEST(Subcycling, Default_Construction)
   bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
 
   // Test the set functions
-  stepper->setSolver(solver);                          stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized_);
-  stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized_);
-  stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized_);
-  stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized_);
-  stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized_);
+  stepper->setSolver(solver);                          stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
 
 
   // Full argument list construction.
@@ -80,7 +80,7 @@ TEUCHOS_UNIT_TEST(Subcycling, Default_Construction)
 
   stepper = rcp(new Tempus::StepperSubcycling<double>(
     model, obs, scIntegrator, useFSAL, ICConsistency, ICConsistencyCheck));
-  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized_);
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
 
 }
 #endif // CONSTRUCTION

--- a/packages/tempus/unit_test/Tempus_UnitTest_Trapezoidal.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_Trapezoidal.cpp
@@ -1,0 +1,97 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Thyra_VectorStdOps.hpp"
+
+#include "Tempus_StepperFactory.hpp"
+#include "Tempus_UnitTest_Utils.hpp"
+
+#include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/VanDerPolModel.hpp"
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <fstream>
+#include <vector>
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+using Teuchos::sublist;
+using Teuchos::getParametersFromXmlFile;
+
+using Tempus::StepperFactory;
+
+// Comment out any of the following tests to exclude from build/run.
+#define CONSTRUCTION
+#define STEPPERFACTORY_CONSTRUCTION
+
+
+#ifdef CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(Trapezoidal, Construction)
+{
+  auto model   = rcp(new Tempus_Test::SinCosModel<double>());
+
+  // Default construction.
+  auto stepper = rcp(new Tempus::StepperTrapezoidal<double>());
+  stepper->setModel(model);
+  stepper->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Default values for construction.
+  auto obs    = rcp(new Tempus::StepperTrapezoidalObserver<double>());
+  auto solver = rcp(new Thyra::NOXNonlinearSolver());
+  solver->setParameterList(Tempus::defaultSolverParameters());
+
+  bool useFSAL              = stepper->getUseFSALDefault();
+  std::string ICConsistency = stepper->getICConsistencyDefault();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool zeroInitialGuess     = stepper->getZeroInitialGuess();
+
+  // Test the set functions.
+  stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setSolver(solver);                          stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setZeroInitialGuess(zeroInitialGuess);      stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+
+  // Full argument list construction.
+  stepper = rcp(new Tempus::StepperTrapezoidal<double>(
+    model, obs, solver, useFSAL,
+    ICConsistency, ICConsistencyCheck, zeroInitialGuess));
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+}
+#endif // CONSTRUCTION
+
+
+#ifdef STEPPERFACTORY_CONSTRUCTION
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(Trapezoidal, StepperFactory_Construction)
+{
+  auto model = rcp(new Tempus_Test::SinCosModel<double>());
+  testFactoryConstruction("Trapezoidal Method", model);
+}
+#endif // STEPPERFACTORY_CONSTRUCTION
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_Utils.hpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_Utils.hpp
@@ -1,0 +1,57 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#ifndef Tempus_UnitTest_Utils_hpp
+#define Tempus_UnitTest_Utils_hpp
+
+#include "Tempus_StepperFactory.hpp"
+
+#include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/VanDerPolModel.hpp"
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+using Teuchos::ParameterList;
+
+using Tempus::StepperFactory;
+
+
+void testFactoryConstruction(std::string stepperType,
+  const Teuchos::RCP<const Thyra::ModelEvaluator<double> >& model)
+{
+  RCP<StepperFactory<double> > sf = Teuchos::rcp(new StepperFactory<double>());
+
+  // Test using stepperType
+  // Passing in model.
+  auto stepper = sf->createStepper(stepperType, model);
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  // With setting model.
+  stepper = sf->createStepper(stepperType);
+  stepper->setModel(model);
+  stepper->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+
+  // Test using ParameterList.
+  // Passing in model.
+  auto stepperPL = rcp_const_cast<ParameterList>(stepper->getValidParameters());
+  stepper = sf->createStepper(stepperPL, model);
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  // With setting model.
+  stepper = sf->createStepper(stepperPL);
+  stepper->setModel(model);
+  stepper->initialize();
+  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+}
+
+
+} // namespace Tempus_Test
+#endif // Tempus_UnitTest_Utils_hpp


### PR DESCRIPTION
 * All Steppers now check if they are initialized, checkInitialized(),
   at the start of takeStep() to ensure they are properly setup.
 * Added isValidSetup() to steppers to check if the stepper is a
   valid setup.  Used by initialize() to set the isInitialized_
   flag.  Can be used by applications to self check their steppers.
 * Changed the Stepper's describe() to output the stepper's member
   data.  Used by initialize() if isValidSetup() returns as false.
 * All set functions on the Stepper set isInitialized_ to false
   and require a subsequent initialize() call.
 * Added unit tests for all ~40 steppers that test their constructors.

Passes all tests on my Mac and no new warnings.

@trilinos/tempus 

Closes #5908 

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [ ] My code follows the code style of the affected package(s).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.