### PR TITLE
MueLu: fixing bug with kokkos refactor in FactoryManager, see issue #5961

### DIFF
--- a/packages/muelu/src/Interface/MueLu_HierarchyManager.hpp
+++ b/packages/muelu/src/Interface/MueLu_HierarchyManager.hpp
@@ -353,7 +353,7 @@ namespace MueLu {
             if (!M.is_null()) {
               Xpetra::IO<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Write(fileName,* M);
             }
-          }	  
+          }
 	  else if (L->IsAvailable(name)) {
 	    // Try nofactory
             RCP<T> M = L->template Get< RCP<T> >(name);

--- a/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
+++ b/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
@@ -421,6 +421,7 @@ namespace MueLu {
     // FIXME: should it be here, or higher up
     RCP<FactoryManager> defaultManager = rcp(new FactoryManager());
     defaultManager->SetVerbLevel(this->verbosity_);
+    defaultManager->SetKokkosRefactor(useKokkos_);
 
     // We will ignore keeps0
     std::vector<keep_pair> keeps0;

--- a/packages/muelu/src/MueCentral/MueLu_FactoryManager_decl.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_FactoryManager_decl.hpp
@@ -176,6 +176,8 @@ namespace MueLu {
       useKokkos_ = useKokkos;
     }
 
+    bool GetKokkosRefactor() const { return useKokkos_; }
+
     //@}
 
     void Clean() const { defaultFactoryTable_.clear(); }

--- a/packages/muelu/test/interface/ParameterListInterpreter.cpp
+++ b/packages/muelu/test/interface/ParameterListInterpreter.cpp
@@ -78,8 +78,8 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
   using Teuchos::rcp;
   using Teuchos::TimeMonitor;
 
-  typedef typename Teuchos::ScalarTraits<SC>::magnitudeType real_type;
-  typedef Xpetra::MultiVector<real_type,LO,GO,NO> RealValuedMultiVector;
+  using real_type             = typename Teuchos::ScalarTraits<SC>::coordinateType;
+  using RealValuedMultiVector = Xpetra::MultiVector<real_type,LO,GO,NO>;
 
   // =========================================================================
   // MPI initialization using Teuchos
@@ -119,7 +119,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
   matrixParameters.set("nx",         Teuchos::as<GO>(9999));
   matrixParameters.set("matrixType", "Laplace1D");
   RCP<Matrix>      A           = MueLuTests::TestHelpers::TestFactory<SC, LO, GO, NO>::Build1DPoisson(matrixParameters.get<GO>("nx"), lib);
-  RCP<RealValuedMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<double,LO,GO,Map,RealValuedMultiVector>("1D", A->getRowMap(), matrixParameters);
+  RCP<RealValuedMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<real_type,LO,GO,Map,RealValuedMultiVector>("1D", A->getRowMap(), matrixParameters);
 
   std::string prefix;
   if (useKokkos) {

--- a/packages/muelu/test/unit_tests_kokkos/CMakeLists.txt
+++ b/packages/muelu/test/unit_tests_kokkos/CMakeLists.txt
@@ -26,6 +26,7 @@ APPEND_SET(SOURCES
   StructuredAggregation_kokkos.cpp
   #SaPFactory_kokkos.cpp
   TentativePFactory_kokkos.cpp
+  UseKokkos_kokkos.cpp
 )
 
 ### Tests that require other Trilinos packages

--- a/packages/muelu/test/unit_tests_kokkos/UseKokkos_kokkos.cpp
+++ b/packages/muelu/test/unit_tests_kokkos/UseKokkos_kokkos.cpp
@@ -1,0 +1,105 @@
+// @HEADER
+//
+// ***********************************************************************
+//
+//        MueLu: A package for multigrid based preconditioning
+//                  Copyright 2012 Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact
+//                    Jonathan Hu       (jhu@sandia.gov)
+//                    Andrey Prokopenko (aprokop@sandia.gov)
+//                    Ray Tuminaro      (rstumin@sandia.gov)
+//
+// ***********************************************************************
+//
+// @HEADER
+#include <Teuchos_UnitTestHarness.hpp>
+#include <Teuchos_DefaultComm.hpp>
+
+#include <Xpetra_Matrix.hpp>
+#include <Xpetra_MultiVectorFactory.hpp>
+
+#include "MueLu_UseDefaultTypes.hpp"
+
+#include "MueLu_TestHelpers_kokkos.hpp"
+#include "MueLu_Version.hpp"
+
+#include "MueLu_ParameterListInterpreter.hpp"
+#include "MueLu_FactoryManager.hpp"
+#include "MueLu_HierarchyManager.hpp"
+#include "MueLu_Hierarchy.hpp"
+
+namespace MueLuTests {
+
+
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(UseKokkos_kokkos, FactoryManager, Scalar, LocalOrdinal, GlobalOrdinal, Node)
+  {
+#   include "MueLu_UseShortNames.hpp"
+    MUELU_TESTING_SET_OSTREAM;
+    MUELU_TESTING_LIMIT_SCOPE(Scalar,GlobalOrdinal,Node);
+    out << "version: " << MueLu::Version() << std::endl;
+
+    using Teuchos::RCP;
+    using Teuchos::rcp;
+    using real_type = typename Teuchos::ScalarTraits<SC>::coordinateType;
+    using RealValuedMultiVector = Xpetra::MultiVector<real_type,LO,GO,NO>;
+
+    const bool useKokkos = false;
+
+    // Build the problem
+    RCP<Matrix> A = MueLuTests::TestHelpers_kokkos::TestFactory<SC, LO, GO, NO>::Build1DPoisson(2001);
+    RCP<const Map> map = A->getMap();
+    RCP<RealValuedMultiVector> coordinates = Xpetra::MultiVectorFactory<real_type, LO, GO, NO>::Build(map, 1);
+    RCP<MultiVector> nullspace = MultiVectorFactory::Build(map, 1);
+    nullspace->putScalar(Teuchos::ScalarTraits<SC>::one());
+
+    // Setting paramters for the hierarchy
+    Teuchos::ParameterList paramList;
+    paramList.set("verbosity", "test");
+    paramList.set("use kokkos refactor", useKokkos);
+    RCP<HierarchyManager> mueluFactory = rcp(new ParameterListInterpreter(paramList));
+    mueluFactory->CheckConfig();
+    const RCP<const FactoryManagerBase> manager = mueluFactory->GetFactoryManager(0);
+    RCP<const FactoryManager> factoryManager = Teuchos::rcp_dynamic_cast<const FactoryManager>(manager, true);
+
+    TEST_EQUALITY(factoryManager->GetKokkosRefactor() == useKokkos, true);
+  }
+
+
+#define MUELU_ETI_GROUP(SC,LO,GO,NO) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(UseKokkos_kokkos, FactoryManager, SC, LO, GO, NO)
+
+#include <MueLu_ETI_4arg.hpp>
+
+
+} //namespace MueLuTests


### PR DESCRIPTION
@trilinos/muelu 

## Description
The `useKokkos_` attribute of FactoryManager is not set appropriately set when using an easy xml.
For instance it is set to true in `muelu/example/basic/Simple.cpp` when `simple.xml` clearly sets:
```
<Parameter        name="use kokkos refactor"                  type="bool"     value="false"/>
```

## Motivation and Context
This is a bug and as such should be fixed but it also blocks PR #5956 


## Related Issues

* Closes #5961
* Blocks #5956 and #5838
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 

## How Has This Been Tested?
A new unit-test is added to MueLu to make sure this parameter is consistently set between the parameter list interpreter and the factory manager.

## Checklist

- [x] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.