### PR TITLE
MueLu: clean-up region MG coarse solver options

### DIFF
--- a/packages/muelu/research/CMakeLists.txt
+++ b/packages/muelu/research/CMakeLists.txt
@@ -1,6 +1,6 @@
 # based on experimental code
 IF (${PACKAGE_NAME}_ENABLE_Experimental)
-    ADD_SUBDIRECTORY(q2q1)
+  ADD_SUBDIRECTORY(q2q1)
   IF(${PACKAGE_NAME}_ENABLE_ADDITIVE_VARIANT)
     MESSAGE(STATUS "MG Additive Variant enabled")
     ADD_SUBDIRECTORY(max/AdditiveMG)

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
@@ -778,17 +778,21 @@ void createRegionHierarchy(const int maxRegPerProc,
 
   std::cout << mapComp->getComm()->getRank() << " | MakeCoarseCompositeSolver ..." << std::endl;
 
-  const bool useDirectSolver = coarseSolverData->get<bool>("use direct solver");
-  if (useDirectSolver)
+  const std::string coarseSolverType = coarseSolverData->get<std::string>("coarse solver type");
+  if (coarseSolverType == "direct")
   {
     RCP<DirectCoarseSolver> coarseDirectSolver = MakeCompositeDirectSolver(coarseCompOp);
     coarseSolverData->set<RCP<DirectCoarseSolver>>("direct solver object", coarseDirectSolver);
   }
-  else
+  else if (coarseSolverType == "amg")
   {
     std::string amgXmlFileName = coarseSolverData->get<std::string>("amg xml file");
     RCP<Hierarchy> coarseAMGHierarchy = MakeCompositeAMGHierarchy(coarseCompOp, amgXmlFileName);
     coarseSolverData->set<RCP<Hierarchy>>("amg hierarchy object", coarseAMGHierarchy);
+  }
+  else
+  {
+    TEUCHOS_TEST_FOR_EXCEPT_MSG(false, "Unknown coarse solver type.");
   }
 
   std::cout << mapComp->getComm()->getRank() << " | MakeInterfaceScalingFactors ..." << std::endl;
@@ -1047,8 +1051,8 @@ void vCycle(const int l, ///< ID of current level
 
     RCP<TimeMonitor> tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("vCycle: * - coarsest grid solve")));
 
-    const bool useCoarseSmoother = false;
-    if (useCoarseSmoother) {
+    const std::string coarseSolverType = coarseSolverData->get<std::string>("coarse solver type");
+    if (coarseSolverType == "smoother") {
       smootherApply(smootherParams[l], maxRegPerProc, fineRegX, fineRegB, regMatrices[l],
                   regInterfaceScalings[l], compRowMaps[l],
                   quasiRegRowMaps[l], regRowMaps[l], regRowImporters[l]);
@@ -1069,8 +1073,7 @@ void vCycle(const int l, ///< ID of current level
                             regRowImporters[l], Xpetra::ADD);
       }
 
-      const bool useDirectSolver = coarseSolverData->get<bool>("use direct solver");
-      if (useDirectSolver)
+      if (coarseSolverType == "direct")
       {
 #if defined(HAVE_MUELU_TPETRA) && defined(HAVE_MUELU_AMESOS2)
   
@@ -1115,7 +1118,7 @@ void vCycle(const int l, ///< ID of current level
              << std::endl;
 #endif
       }
-      else // use AMG as coarse level solver
+      else if (coarseSolverType == "amg") // use AMG as coarse level solver
       {
   
         // Extract the hierarchy from the coarseSolverData
@@ -1123,6 +1126,10 @@ void vCycle(const int l, ///< ID of current level
   
         // Run a single V-cycle
         amgHierarchy->Iterate(*compRhs, *compX, 1);
+      }
+      else
+      {
+        TEUCHOS_TEST_FOR_EXCEPT_MSG(false, "Unknown coarse solver type.");
       }
   
       // Transform back to region format

--- a/packages/muelu/research/regionMG/examples/structured/CMakeLists.txt
+++ b/packages/muelu/research/regionMG/examples/structured/CMakeLists.txt
@@ -2,7 +2,7 @@ INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
 INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}/../../../../test/unit_tests)
 INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}/../../../mmayr/composite_to_regions/src)
 
-# This test requires Tpetra, so it's only included if Tpetra is enabled
+# This test requires Tpetra and Amesos2, so it's only included if Tpetra is enabled
 IF (${PACKAGE_NAME}_ENABLE_Tpetra AND ${PACKAGE_NAME}_ENABLE_Amesos2)
 
   TRIBITS_ADD_EXECUTABLE(

--- a/packages/muelu/research/regionMG/examples/structured/CMakeLists.txt
+++ b/packages/muelu/research/regionMG/examples/structured/CMakeLists.txt
@@ -57,11 +57,27 @@ IF (${PACKAGE_NAME}_ENABLE_Tpetra AND ${PACKAGE_NAME}_ENABLE_Amesos2)
     COMM serial mpi
     NUM_MPI_PROCS 4
     )
+    
+  TRIBITS_ADD_TEST(
+    StructuredRegionDriver
+    NAME "Structured_Region_Star2D_CoarseSmoother_Tpetra"
+    ARGS "--linAlgebra=Tpetra --xml=structured_1dof.xml --matrixType=Star2D --nx=10 --ny=10 --smootherIts=2 --coarseSolverType=smoother"
+    COMM serial mpi
+    NUM_MPI_PROCS 1
+    )
+
+  TRIBITS_ADD_TEST(
+    StructuredRegionDriver
+    NAME "Structured_Region_Star2D_CoarseSmoother_Tpetra"
+    ARGS "--linAlgebra=Tpetra --xml=structured_1dof.xml --matrixType=Star2D --nx=10 --ny=10 --smootherIts=2 --coarseSolverType=smoother"
+    COMM serial mpi
+    NUM_MPI_PROCS 4
+    )
 
   TRIBITS_ADD_TEST(
     StructuredRegionDriver
     NAME "Structured_Region_Star2D_AMG_CoarseSolver_Tpetra"
-    ARGS "--linAlgebra=Tpetra --xml=structured_1dof_3level.xml --matrixType=Star2D --nx=50 --ny=50 --smootherIts=2 --amg-coarse-solver --coarseAmgXml=amg_1dof.xml"
+    ARGS "--linAlgebra=Tpetra --xml=structured_1dof_3level.xml --matrixType=Star2D --nx=50 --ny=50 --smootherIts=2 --coarseSolverType=amg --coarseAmgXml=amg_1dof.xml"
     COMM serial mpi
     NUM_MPI_PROCS 4
     )

--- a/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
+++ b/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
@@ -170,7 +170,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
   double      tol                = 1e-12;               clp.setOption("tol",                   &tol,               "solver convergence tolerance");
   bool        scaleResidualHist  = true;                clp.setOption("scale", "noscale",      &scaleResidualHist, "scaled Krylov residual history");
   bool        serialRandom       = false;               clp.setOption("use-serial-random", "no-use-serial-random", &serialRandom, "generate the random vector serially and then broadcast it");
-  bool        directCoarseSolver = true;                clp.setOption("direct-coarse-solver", "amg-coarse-solver", &directCoarseSolver, "Type of solver for composite coarse level operator");
+  std::string coarseSolverType   = "";                  clp.setOption("coarseSolverType",      &coarseSolverType,  "Type of solver for (composite) coarse level operator (smoother | direct | amg)");
   std::string unstructured       = "{}";                clp.setOption("unstructured",          &unstructured,   "List of ranks to be treated as unstructured, e.g. {0, 2, 5}");
   std::string coarseAmgXmlFile   = "";                  clp.setOption("coarseAmgXml",          &coarseAmgXmlFile,  "Read parameters for AMG as coarse level solve from this xml file.");
 #ifdef HAVE_MUELU_TPETRA
@@ -1455,7 +1455,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
   Array<Array<RCP<Vector> > > regInterfaceScalings; // regional interface scaling factors on each level
   Teuchos::RCP<Matrix> coarseCompOp = Teuchos::null;
   RCP<ParameterList> coarseSolverData = rcp(new ParameterList());
-  coarseSolverData->set<bool>("use direct solver", directCoarseSolver);
+  coarseSolverData->set<std::string>("coarse solver type", coarseSolverType);
   coarseSolverData->set<std::string>("amg xml file", coarseAmgXmlFile);
   RCP<ParameterList> hierarchyData = rcp(new ParameterList());
 

--- a/packages/muelu/research/regionMG/examples/structured/compare_residual_history.py
+++ b/packages/muelu/research/regionMG/examples/structured/compare_residual_history.py
@@ -1,6 +1,5 @@
 import os
 import sys
-from __builtin__ import True, False
 
 numIterPassed = False
 goldConvergenceHistoryPassed = True


### PR DESCRIPTION
@trilinos/muelu 
@lucbv @rstumin @pohm01 

## Description

Change command line options for regionMG coarse solver to allow for "direct", "amg", or "smoother".

The purely boolean option `--use-direct-solver` is now replaced by `--coarseSolverType={amg,direct,smoother}`.

## Motivation and Context

This is triggered by [this discussion in PR 5968](https://github.com/trilinos/Trilinos/pull/5968#discussion_r327364780).

## Related Issues

* Related to discussion in #5968

## How Has This Been Tested?

Build and tests pass locally.

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.