### PR TITLE
MueLu: add elasticity tests to region MG

### DIFF
--- a/packages/muelu/research/regionMG/examples/structured/CMakeLists.txt
+++ b/packages/muelu/research/regionMG/examples/structured/CMakeLists.txt
@@ -138,6 +138,22 @@ IF (${PACKAGE_NAME}_ENABLE_Tpetra AND ${PACKAGE_NAME}_ENABLE_Amesos2)
     NUM_MPI_PROCS 4
     )
 
+  TRIBITS_ADD_TEST(
+    StructuredRegionDriver
+    NAME "Structured_Region_Linear_Elasticity3D_Tpetra"
+    ARGS "--linAlgebra=Tpetra --xml=structured_linear_3dof.xml --matrixType=Elasticity3D --nx=7 --ny=7 --nz=7 --smootherIts=2 --tol=1.0e-8 --convergence-log=Elasticity3D_linear_1.log"
+    COMM serial mpi
+    NUM_MPI_PROCS 1
+    )
+
+TRIBITS_ADD_TEST(
+    StructuredRegionDriver
+    NAME "Structured_Region_Linear_Elasticity3D_Tpetra"
+    ARGS "--linAlgebra=Tpetra --xml=structured_linear_3dof.xml --matrixType=Elasticity3D --nx=7 --ny=7 --nz=7 --smootherIts=2 --tol=1.0e-8 --convergence-log=Elasticity3D_linear_1.log"
+    COMM serial mpi
+    NUM_MPI_PROCS 4
+    )
+
   ## These are very few regression tests, that also compare residual convergence history
   ASSERT_DEFINED(PYTHONINTERP_FOUND)
   IF (PYTHONINTERP_FOUND)

--- a/packages/muelu/research/regionMG/examples/structured/CMakeLists.txt
+++ b/packages/muelu/research/regionMG/examples/structured/CMakeLists.txt
@@ -149,7 +149,7 @@ IF (${PACKAGE_NAME}_ENABLE_Tpetra AND ${PACKAGE_NAME}_ENABLE_Amesos2)
 TRIBITS_ADD_TEST(
     StructuredRegionDriver
     NAME "Structured_Region_Linear_Elasticity3D_Tpetra"
-    ARGS "--linAlgebra=Tpetra --xml=structured_linear_3dof.xml --matrixType=Elasticity3D --nx=7 --ny=7 --nz=7 --smootherIts=2 --tol=1.0e-8 --convergence-log=Elasticity3D_linear_1.log"
+    ARGS "--linAlgebra=Tpetra --xml=structured_linear_3dof.xml --matrixType=Elasticity3D --nx=7 --ny=7 --nz=7 --smootherIts=2 --tol=1.0e-8 --convergence-log=Elasticity3D_linear_4.log"
     COMM serial mpi
     NUM_MPI_PROCS 4
     )

--- a/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
+++ b/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
@@ -172,7 +172,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
   double      tol                = 1e-12;               clp.setOption("tol",                   &tol,               "solver convergence tolerance");
   bool        scaleResidualHist  = true;                clp.setOption("scale", "noscale",      &scaleResidualHist, "scaled Krylov residual history");
   bool        serialRandom       = false;               clp.setOption("use-serial-random", "no-use-serial-random", &serialRandom, "generate the random vector serially and then broadcast it");
-  std::string coarseSolverType   = "";                  clp.setOption("coarseSolverType",      &coarseSolverType,  "Type of solver for (composite) coarse level operator (smoother | direct | amg)");
+  std::string coarseSolverType   = "direct";            clp.setOption("coarseSolverType",      &coarseSolverType,  "Type of solver for (composite) coarse level operator (smoother | direct | amg)");
   std::string unstructured       = "{}";                clp.setOption("unstructured",          &unstructured,   "List of ranks to be treated as unstructured, e.g. {0, 2, 5}");
   std::string coarseAmgXmlFile   = "";                  clp.setOption("coarseAmgXml",          &coarseAmgXmlFile,  "Read parameters for AMG as coarse level solve from this xml file.");
 #ifdef HAVE_MUELU_TPETRA

--- a/packages/muelu/research/regionMG/examples/structured/structured_linear_3dof.xml
+++ b/packages/muelu/research/regionMG/examples/structured/structured_linear_3dof.xml
@@ -19,7 +19,7 @@
       <Parameter name="aggregation: coupling"                     type="string" value="uncoupled"/>
       <Parameter name="aggregation: output type"                  type="string" value="CrsGraph"/>
       <Parameter name="aggregation: coarsening order"             type="int"    value="1"/>
-      <Parameter name="aggregation: coarsening rate"              type="string" value="{2}"/>
+      <Parameter name="aggregation: coarsening rate"              type="string" value="{3}"/>
       <Parameter name="Graph"                                     type="string" value="myCoalesceDropFact"/>
     </ParameterList>
 


### PR DESCRIPTION
@trilinos/muelu 

## Description

- set default coarse level solver in region MG driver to be a direct solver
- add serial and parallel 3D elasticity tests for region MG
- change coarsening rate to 3 in `structured_linear_3dof.xml`


## Motivation and Context
We fixed some issues with multipler DOFs per node in the region MG framework. Let's protect the current state by adding elasticity tests.

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [x] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.