### PR TITLE
Zoltan2:  fix MJ parameter setting and add premigration test

### DIFF
--- a/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
+++ b/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
@@ -7289,7 +7289,7 @@ void Zoltan2_AlgMJ<Adapter>::set_input_parameters(const Teuchos::ParameterList &
 
         pe = pl.getEntryPtr("mj_premigration_coordinate_count");
         if (pe){
-        	min_coord_per_rank_for_premigration = pe->getValue(&mj_premigration_option);
+        	min_coord_per_rank_for_premigration = pe->getValue(&min_coord_per_rank_for_premigration);
         }else {
                 min_coord_per_rank_for_premigration = 32000;
         }

--- a/packages/zoltan2/test/driver/CMakeLists.txt
+++ b/packages/zoltan2/test/driver/CMakeLists.txt
@@ -176,6 +176,17 @@ TRIBITS_ADD_TEST(
 
 TRIBITS_ADD_TEST(
     test_driver
+    NAME mjTestPremigrate
+    NUM_MPI_PROCS 3
+    COMM serial mpi
+    ARGS
+    "./driverinputs/multiJaggedPremigrateTest.xml"
+    PASS_REGULAR_EXPRESSION "PASS"
+    FAIL_REGULAR_EXPRESSION "FAIL"
+)
+
+TRIBITS_ADD_TEST(
+    test_driver
     NAME zoltanWithGraphAdapter
     COMM serial mpi
     ARGS

--- a/packages/zoltan2/test/driver/CMakeLists.txt
+++ b/packages/zoltan2/test/driver/CMakeLists.txt
@@ -177,7 +177,7 @@ TRIBITS_ADD_TEST(
 TRIBITS_ADD_TEST(
     test_driver
     NAME mjTestPremigrate
-    NUM_MPI_PROCS 3
+    NUM_MPI_PROCS 4
     COMM serial mpi
     ARGS
     "./driverinputs/multiJaggedPremigrateTest.xml"

--- a/packages/zoltan2/test/driver/driverinputs/CMakeLists.txt
+++ b/packages/zoltan2/test/driver/driverinputs/CMakeLists.txt
@@ -12,6 +12,7 @@ TRIBITS_COPY_FILES_TO_BINARY_DIR(copy_input_files_for_driver
         input_template.xml
         rcbTest.xml
         multiJaggedTest.xml
+        multiJaggedPremigrateTest.xml
         multijaggedVwgt2Test.xml
         GeomGenWeight.txt
         chacoGraphMetricsTest.xml

--- a/packages/zoltan2/test/driver/driverinputs/multiJaggedPremigrateTest.xml
+++ b/packages/zoltan2/test/driver/driverinputs/multiJaggedPremigrateTest.xml
@@ -1,0 +1,75 @@
+<!--////////////////////////////////////////////////////////////////////////////
+ ////////////////////////////////////////////////////////////////////////////////
+ 
+ REQUIRED BLOCKS:
+ 1. Input parameters
+ 2. Problem parameters
+ 
+ OPTIONAL Blocks:
+ 3. Comparison
+ 
+ SUPPORTED INPUT FILE TYPES:
+ 1. Geometric Generator
+ 2. Pamgen
+ 3. Chaco
+ 4. Matrix Market
+ 
+ SUPPORTED PROBLEM TYPES:
+ 1. partitioning
+ 
+ SUPPORTED INPUT DATA TYPES:
+ 1. coordinates
+ 2. (x,t,e)petra_crs_matrix
+ 3. (x,t,e)petra_crs_graph
+ 4. (x,t,e)petra_vector
+ 5. (x,t,e)petra_multivector
+ 
+ SUPPORTED INPUT ADAPTERS:
+ 1. BasicIdentifier
+ 2. XpetraMultiVector
+ 3. XpetraCrsGraph
+ 4. XpetraCrsMatrix
+ 5. BasicVector
+ 5. PamgenMesh
+ 
+ ** REFER TO THE README FOR A MORE DETAILED EXPLANATION
+ 
+ ////////////////////////////////////////////////////////////////////////////////
+ /////////////////////////////////////////////////////////////////////////////-->
+
+<ParameterList name="mjTestPremigrate">
+  
+  <ParameterList name="InputParameters">
+    <Parameter name="input path" type="string" value="./"/>
+    <Parameter name="input file" type="string" value="simple"/>
+    <Parameter name="file type" type="string" value="Chaco"/>
+  </ParameterList>
+  
+  <ParameterList name="test1">
+    <Parameter name="kind" type="string" value="partitioning"/>
+    <ParameterList name="InputAdapterParameters">
+      <Parameter name="data type" type="string" value="coordinates"/>
+      <Parameter name="input adapter" type="string" value="XpetraMultiVector"/>
+    </ParameterList>
+    
+    <ParameterList name="Zoltan2Parameters">
+      <Parameter name="timer_output_stream" type="string" value="std::cout"/>
+      <Parameter name="algorithm" type="string" value="multijagged"/>
+      <Parameter name="num_global_parts" type="int" value="2"/>
+      <Parameter name="mj_premigration_option" type="int" value="1"/>
+      <Parameter name="mj_premigration_coordinate_count" type="int" value="100"/>
+      <Parameter name="compute_metrics" type="bool" value="true"/>
+    </ParameterList>
+    
+    <ParameterList name="Metrics">
+      <ParameterList name="metriccheck1">
+        <Parameter name="check" type="string" value="imbalance"/>
+        <Parameter name="lower" type="double" value="0.99"/>
+        <Parameter name="upper" type="double" value="1.4"/>
+      </ParameterList>
+    </ParameterList>
+    
+    
+  </ParameterList>
+
+</ParameterList>


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/zoltan2 

## Description
Zoltan2 did not have a test explicitly exercising MJ's premigration.  This PR adds such a test:  a small problem with small target number of parts that forces premigration.

This PR also corrects a Teuchos parameter getValue call to use the same argument and result value.  The old code was correct but subject to future errors if data types were changed.


## Motivation and Context

All code should be exercised.  Other work in premigration code requires that we have a test.

## How Has This Been Tested?
built and run on cee-lan linux workstation; all tests (including the new one) pass