### PR TITLE
ATDM: Add cee-rhel6 intel-19 build

### DIFF
--- a/cmake/ctest/drivers/atdm/cee-rhel6/drivers/Trilinos-atdm-cee-rhel6_gnu-4.9.3_openmpi-1.10.2_serial_shared_opt.sh
+++ b/cmake/ctest/drivers/atdm/cee-rhel6/drivers/Trilinos-atdm-cee-rhel6_gnu-4.9.3_openmpi-1.10.2_serial_shared_opt.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-export Trilinos_TRACK=ATDM
-$WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cee-rhel6/local-driver.sh

--- a/cmake/ctest/drivers/atdm/cee-rhel6/drivers/Trilinos-atdm-cee-rhel6_intel-17.0.1_intelmpi-5.1.2_serial_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/cee-rhel6/drivers/Trilinos-atdm-cee-rhel6_intel-17.0.1_intelmpi-5.1.2_serial_static_opt.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-export Trilinos_TRACK=ATDM
-$WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cee-rhel6/local-driver.sh

--- a/cmake/ctest/drivers/atdm/cee-rhel6/drivers/Trilinos-atdm-cee-rhel6_intel-19.0.3_intelmpi-2018.4_serial_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/cee-rhel6/drivers/Trilinos-atdm-cee-rhel6_intel-19.0.3_intelmpi-2018.4_serial_static_opt.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-export Trilinos_TRACK=Experimental
+export Trilinos_TRACK=ATDM
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cee-rhel6/local-driver.sh

--- a/cmake/ctest/drivers/atdm/cee-rhel6/drivers/Trilinos-atdm-cee-rhel6_intel-19.0.3_intelmpi-2018.4_serial_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/cee-rhel6/drivers/Trilinos-atdm-cee-rhel6_intel-19.0.3_intelmpi-2018.4_serial_static_opt.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export Trilinos_TRACK=Experimental
+$WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cee-rhel6/local-driver.sh

--- a/cmake/std/atdm/cee-rhel6/all_supported_builds.sh
+++ b/cmake/std/atdm/cee-rhel6/all_supported_builds.sh
@@ -5,6 +5,6 @@ export ATDM_CONFIG_CTEST_S_BUILD_NAME_PREFIX=Trilinos-atdm-
 export ATDM_CONFIG_ALL_SUPPORTED_BUILDS=(
   cee-rhel6_clang-5.0.1_openmpi-1.10.2_serial_static_opt   # SPARC CI build
   cee-rhel6_gnu-7.2.0_openmpi-1.10.2_serial_shared_opt     # SPARC CI build
-  cee-rhel6_intel-17.0.1_intelmpi-5.1.2_serial_static_opt  # SPARC Nightly Build
   cee-rhel6_intel-18.0.2_mpich2-3.2_openmp_static_opt      # SPARC CI build
+  cee-rhel6_intel-19.0.3_intelmpi-2018.4_serial_static_opt # SPARC Nightly bulid
   )

--- a/cmake/std/atdm/cee-rhel6/custom_builds.sh
+++ b/cmake/std/atdm/cee-rhel6/custom_builds.sh
@@ -17,15 +17,9 @@ if   [[ $ATDM_CONFIG_BUILD_NAME == *"clang-5.0.1-openmpi-1.10.2"* ]] \
 elif [[ $ATDM_CONFIG_BUILD_NAME == *"gnu-7.2.0-openmpi-1.10.2"* ]] \
   || [[ $ATDM_CONFIG_BUILD_NAME == *"gnu-7.2.0_openmpi-1.10.2"* ]] \
   || [[ $ATDM_CONFIG_BUILD_NAME == *"gnu-7.2.0"* ]] \
-  ; then
-  export ATDM_CONFIG_COMPILER=GNU-7.2.0_OPENMPI-1.10.2
-
-elif [[ $ATDM_CONFIG_BUILD_NAME == *"gnu-4.9.3-openmpi-1.10.2"* ]] \
-  || [[ $ATDM_CONFIG_BUILD_NAME == *"gnu-4.9.3_openmpi-1.10.2"* ]] \
-  || [[ $ATDM_CONFIG_BUILD_NAME == *"gnu-4.9.3"* ]] \
   || [[ $ATDM_CONFIG_BUILD_NAME == *"gnu"* ]] \
   ; then
-  export ATDM_CONFIG_COMPILER=GNU-4.9.3_OPENMPI-1.10.2
+  export ATDM_CONFIG_COMPILER=GNU-7.2.0_OPENMPI-1.10.2
   # List default "gnu"* build last for correct matching!
 
 elif [[ $ATDM_CONFIG_BUILD_NAME == *"intel-18.0.2-mpich2-3.2"* ]] \
@@ -52,8 +46,7 @@ else
   echo "*** Supported compilers include:"
   echo "***"
   echo "****  clang-5.0.1-openmpi-1.10.2   (default)"
-  echo "****  gnu-4.9.3-openmpi-1.10.2     (default gnu)"
-  echo "****  gnu-7.2.0-openmpi-1.10.2"
+  echo "****  gnu-7.2.0-openmpi-1.10.2     (default gnu)"
   echo "****  intel-18.0.2-mpich2-3.2"
   echo "****  intel-19.0.3-intelmpi-2018.4 (default intel)"
   echo "***"  

--- a/cmake/std/atdm/cee-rhel6/custom_builds.sh
+++ b/cmake/std/atdm/cee-rhel6/custom_builds.sh
@@ -27,6 +27,14 @@ elif [[ $ATDM_CONFIG_BUILD_NAME == *"gnu-4.9.3-openmpi-1.10.2"* ]] \
   ; then
   export ATDM_CONFIG_COMPILER=GNU-4.9.3_OPENMPI-1.10.2
 
+elif [[ $ATDM_CONFIG_BUILD_NAME == *"intel-19.0.3-intelmpi-2018.4"* ]] \
+  || [[ $ATDM_CONFIG_BUILD_NAME == *"intel-19.0.3_intelmpi-2018.4"* ]] \
+  || [[ $ATDM_CONFIG_BUILD_NAME == *"intel-19.0.3"* ]] \
+  || [[ $ATDM_CONFIG_BUILD_NAME == *"intel-19"* ]] \
+  || [[ $ATDM_CONFIG_BUILD_NAME == *"intel"* ]] \
+  ; then
+  export ATDM_CONFIG_COMPILER=INTEL-19.0.3_INTELMPI-2018.4
+
 elif [[ $ATDM_CONFIG_BUILD_NAME == *"intel-18.0.2-mpich2-3.2"* ]] \
   || [[ $ATDM_CONFIG_BUILD_NAME == *"intel-18.0.2_mpich2-3.2"* ]] \
   || [[ $ATDM_CONFIG_BUILD_NAME == *"intel-18.0.2"* ]] \
@@ -38,7 +46,6 @@ elif [[ $ATDM_CONFIG_BUILD_NAME == *"intel-17.0.1-intelmpi-5.1.2"* ]] \
   || [[ $ATDM_CONFIG_BUILD_NAME == *"intel-17.0.1_intelmpi-5.1.2"* ]] \
   || [[ $ATDM_CONFIG_BUILD_NAME == *"intel-17.0.1"* ]] \
   || [[ $ATDM_CONFIG_BUILD_NAME == *"intel-17"* ]] \
-  || [[ $ATDM_CONFIG_BUILD_NAME == *"intel"* ]] \
   ; then
   export ATDM_CONFIG_COMPILER=INTEL-17.0.1_INTELMPI-5.1.2
 
@@ -52,8 +59,9 @@ else
   echo "****  clang-5.0.1-openmpi-1.10.2   (default)"
   echo "****  gnu-4.9.3-openmpi-1.10.2     (default gnu)"
   echo "****  gnu-7.2.0-openmpi-1.10.2"
-  echo "****  intel-17.0.1-intelmpi-5.1.2  (default intel)"
+  echo "****  intel-17.0.1-intelmpi-5.1.2"
   echo "****  intel-18.0.2-mpich2-3.2"
+  echo "****  intel-19.0.3-intelmpi-2018.4  (default intel)"
   echo "***"  
   return
 fi

--- a/cmake/std/atdm/cee-rhel6/custom_builds.sh
+++ b/cmake/std/atdm/cee-rhel6/custom_builds.sh
@@ -26,14 +26,7 @@ elif [[ $ATDM_CONFIG_BUILD_NAME == *"gnu-4.9.3-openmpi-1.10.2"* ]] \
   || [[ $ATDM_CONFIG_BUILD_NAME == *"gnu"* ]] \
   ; then
   export ATDM_CONFIG_COMPILER=GNU-4.9.3_OPENMPI-1.10.2
-
-elif [[ $ATDM_CONFIG_BUILD_NAME == *"intel-19.0.3-intelmpi-2018.4"* ]] \
-  || [[ $ATDM_CONFIG_BUILD_NAME == *"intel-19.0.3_intelmpi-2018.4"* ]] \
-  || [[ $ATDM_CONFIG_BUILD_NAME == *"intel-19.0.3"* ]] \
-  || [[ $ATDM_CONFIG_BUILD_NAME == *"intel-19"* ]] \
-  || [[ $ATDM_CONFIG_BUILD_NAME == *"intel"* ]] \
-  ; then
-  export ATDM_CONFIG_COMPILER=INTEL-19.0.3_INTELMPI-2018.4
+  # List default "gnu"* build last for correct matching!
 
 elif [[ $ATDM_CONFIG_BUILD_NAME == *"intel-18.0.2-mpich2-3.2"* ]] \
   || [[ $ATDM_CONFIG_BUILD_NAME == *"intel-18.0.2_mpich2-3.2"* ]] \
@@ -42,12 +35,14 @@ elif [[ $ATDM_CONFIG_BUILD_NAME == *"intel-18.0.2-mpich2-3.2"* ]] \
   ; then
   export ATDM_CONFIG_COMPILER=INTEL-18.0.2_MPICH2-3.2
 
-elif [[ $ATDM_CONFIG_BUILD_NAME == *"intel-17.0.1-intelmpi-5.1.2"* ]] \
-  || [[ $ATDM_CONFIG_BUILD_NAME == *"intel-17.0.1_intelmpi-5.1.2"* ]] \
-  || [[ $ATDM_CONFIG_BUILD_NAME == *"intel-17.0.1"* ]] \
-  || [[ $ATDM_CONFIG_BUILD_NAME == *"intel-17"* ]] \
+elif [[ $ATDM_CONFIG_BUILD_NAME == *"intel-19.0.3-intelmpi-2018.4"* ]] \
+  || [[ $ATDM_CONFIG_BUILD_NAME == *"intel-19.0.3_intelmpi-2018.4"* ]] \
+  || [[ $ATDM_CONFIG_BUILD_NAME == *"intel-19.0.3"* ]] \
+  || [[ $ATDM_CONFIG_BUILD_NAME == *"intel-19"* ]] \
+  || [[ $ATDM_CONFIG_BUILD_NAME == *"intel"* ]] \
   ; then
-  export ATDM_CONFIG_COMPILER=INTEL-17.0.1_INTELMPI-5.1.2
+  export ATDM_CONFIG_COMPILER=INTEL-19.0.3_INTELMPI-2018.4
+  # List default "intel"* build last for correct matching!
 
 else
   echo
@@ -59,10 +54,10 @@ else
   echo "****  clang-5.0.1-openmpi-1.10.2   (default)"
   echo "****  gnu-4.9.3-openmpi-1.10.2     (default gnu)"
   echo "****  gnu-7.2.0-openmpi-1.10.2"
-  echo "****  intel-17.0.1-intelmpi-5.1.2"
   echo "****  intel-18.0.2-mpich2-3.2"
-  echo "****  intel-19.0.3-intelmpi-2018.4  (default intel)"
+  echo "****  intel-19.0.3-intelmpi-2018.4 (default intel)"
   echo "***"  
   return
+
 fi
 # ToDo: Add support for CUDA compilers above

--- a/cmake/std/atdm/cee-rhel6/environment.sh
+++ b/cmake/std/atdm/cee-rhel6/environment.sh
@@ -163,24 +163,6 @@ elif [ "$ATDM_CONFIG_COMPILER" == "INTEL-18.0.2_MPICH2-3.2" ]; then
   export ATDM_CONFIG_OPENMP_FORTRAN_LIB_NAMES=gomp
   export ATDM_CONFIG_OPENMP_GOMP_LIBRARY=-lgomp
 
-elif [ "$ATDM_CONFIG_COMPILER" == "INTEL-17.0.1_INTELMPI-5.1.2" ]; then
-  module load sparc-dev/intel-17.0.1_intelmpi-5.1.2
-  export OMPI_CXX=`which icpc`
-  export OMPI_CC=`which icc`
-  export OMPI_FC=`which ifort`
-  export MPICC=`which mpicc`
-  export MPICXX=`which mpicxx`
-  export MPIF90=`which mpif90`
-  if [[ "$ATDM_CONFIG_ENABLE_STRONG_WARNINGS" == "1" ]]; then
-    export ATDM_CONFIG_CXX_FLAGS="${ATDM_CONFIG_INTEL_CXX_WARNINGS}"
-  fi
-  export ATDM_CONFIG_MKL_ROOT=${CBLAS_ROOT}
-  export ATDM_CONFIG_MPI_EXEC=mpirun
-  export ATDM_CONFIG_MPI_EXEC_NUMPROCS_FLAG=-np
-  export ATDM_CONFIG_OPENMP_FORTRAN_FLAGS=-fopenmp
-  export ATDM_CONFIG_OPENMP_FORTRAN_LIB_NAMES=gomp
-  export ATDM_CONFIG_OPENMP_GOMP_LIBRARY=-lgomp
-
 else
   echo
   echo "***"

--- a/cmake/std/atdm/cee-rhel6/environment.sh
+++ b/cmake/std/atdm/cee-rhel6/environment.sh
@@ -94,23 +94,6 @@ elif [[ "$ATDM_CONFIG_COMPILER" == "GNU-7.2.0_OPENMPI-1.10.2" ]] ; then
   export ATDM_CONFIG_MPI_EXEC_NUMPROCS_FLAG=-np
   export ATDM_CONFIG_MPI_PRE_FLAGS="--bind-to;none"
 
-elif [[ "$ATDM_CONFIG_COMPILER" == "GNU-4.9.3_OPENMPI-1.10.2" ]] ; then
-  module load sparc-dev/gcc-4.9.3_openmpi-1.10.2
-  export OMPI_CXX=`which g++`
-  export OMPI_CC=`which gcc`
-  export OMPI_FC=`which gfortran`
-  export MPICC=`which mpicc`
-  export MPICXX=`which mpicxx`
-  export MPIF90=`which mpif90`
-  if [[ "$ATDM_CONFIG_ENABLE_STRONG_WARNINGS" == "1" ]]; then
-    export ATDM_CONFIG_CXX_FLAGS="${ATDM_CONFIG_GNU_CXX_WARNINGS}"
-  fi
-  export ATDM_CONFIG_MKL_ROOT=${CBLAS_ROOT}
-  export ATDM_CONFIG_MPI_PRE_FLAGS="--bind-to;none"
-  # Still uses old 
-  export ATDM_CONFIG_SUPERLUDIST_INCLUDE_DIRS=${SUPERLUDIST_ROOT}/SRC
-  export ATDM_CONFIG_SUPERLUDIST_LIBS=${SUPERLUDIST_ROOT}/lib/libsuperlu_dist_4.2.a
-
 elif [ "$ATDM_CONFIG_COMPILER" == "INTEL-19.0.3_INTELMPI-2018.4" ]; then
   module load sparc-dev/intel-19.0.3_intelmpi-2018.4
   export OMPI_CXX=`which icpc`

--- a/cmake/std/atdm/cee-rhel6/environment.sh
+++ b/cmake/std/atdm/cee-rhel6/environment.sh
@@ -74,6 +74,7 @@ if [[ "$ATDM_CONFIG_COMPILER" == "CLANG-5.0.1_OPENMPI-1.10.2" ]]; then
     export ATDM_CONFIG_CXX_FLAGS="${ATDM_CONFIG_GNU_CXX_WARNINGS}"
   fi
   export ATDM_CONFIG_MKL_ROOT=${CBLAS_ROOT}
+
 elif [[ "$ATDM_CONFIG_COMPILER" == "GNU-7.2.0_OPENMPI-1.10.2" ]] ; then
   module load sparc-dev/gcc-7.2.0_openmpi-1.10.2
   unset OMP_NUM_THREADS  # SPARC module sets these and we must unset!
@@ -92,6 +93,7 @@ elif [[ "$ATDM_CONFIG_COMPILER" == "GNU-7.2.0_OPENMPI-1.10.2" ]] ; then
   export ATDM_CONFIG_MPI_EXEC=mpirun
   export ATDM_CONFIG_MPI_EXEC_NUMPROCS_FLAG=-np
   export ATDM_CONFIG_MPI_PRE_FLAGS="--bind-to;none"
+
 elif [[ "$ATDM_CONFIG_COMPILER" == "GNU-4.9.3_OPENMPI-1.10.2" ]] ; then
   module load sparc-dev/gcc-4.9.3_openmpi-1.10.2
   export OMPI_CXX=`which g++`
@@ -108,6 +110,25 @@ elif [[ "$ATDM_CONFIG_COMPILER" == "GNU-4.9.3_OPENMPI-1.10.2" ]] ; then
   # Still uses old 
   export ATDM_CONFIG_SUPERLUDIST_INCLUDE_DIRS=${SUPERLUDIST_ROOT}/SRC
   export ATDM_CONFIG_SUPERLUDIST_LIBS=${SUPERLUDIST_ROOT}/lib/libsuperlu_dist_4.2.a
+
+elif [ "$ATDM_CONFIG_COMPILER" == "INTEL-19.0.3_INTELMPI-2018.4" ]; then
+  module load sparc-dev/intel-19.0.3_intelmpi-2018.4
+  export OMPI_CXX=`which icpc`
+  export OMPI_CC=`which icc`
+  export OMPI_FC=`which ifort`
+  export MPICC=`which mpicc`
+  export MPICXX=`which mpicxx`
+  export MPIF90=`which mpif90`
+  if [[ "$ATDM_CONFIG_ENABLE_STRONG_WARNINGS" == "1" ]]; then
+    export ATDM_CONFIG_CXX_FLAGS="${ATDM_CONFIG_INTEL_CXX_WARNINGS}"
+  fi
+  export ATDM_CONFIG_MKL_ROOT=${CBLAS_ROOT}
+  export ATDM_CONFIG_MPI_EXEC=mpirun
+  export ATDM_CONFIG_MPI_EXEC_NUMPROCS_FLAG=-np
+  export ATDM_CONFIG_OPENMP_FORTRAN_FLAGS=-fopenmp
+  export ATDM_CONFIG_OPENMP_FORTRAN_LIB_NAMES=gomp
+  export ATDM_CONFIG_OPENMP_GOMP_LIBRARY=-lgomp
+
 elif [ "$ATDM_CONFIG_COMPILER" == "INTEL-18.0.2_MPICH2-3.2" ]; then
   module load sparc-dev/intel-18.0.2_mpich2-3.2
   export OMP_NUM_THREADS=3 # Because Si H. requested this
@@ -141,6 +162,7 @@ elif [ "$ATDM_CONFIG_COMPILER" == "INTEL-18.0.2_MPICH2-3.2" ]; then
   export ATDM_CONFIG_OPENMP_FORTRAN_FLAGS=-fopenmp
   export ATDM_CONFIG_OPENMP_FORTRAN_LIB_NAMES=gomp
   export ATDM_CONFIG_OPENMP_GOMP_LIBRARY=-lgomp
+
 elif [ "$ATDM_CONFIG_COMPILER" == "INTEL-17.0.1_INTELMPI-5.1.2" ]; then
   module load sparc-dev/intel-17.0.1_intelmpi-5.1.2
   export OMPI_CXX=`which icpc`
@@ -158,12 +180,14 @@ elif [ "$ATDM_CONFIG_COMPILER" == "INTEL-17.0.1_INTELMPI-5.1.2" ]; then
   export ATDM_CONFIG_OPENMP_FORTRAN_FLAGS=-fopenmp
   export ATDM_CONFIG_OPENMP_FORTRAN_LIB_NAMES=gomp
   export ATDM_CONFIG_OPENMP_GOMP_LIBRARY=-lgomp
+
 else
   echo
   echo "***"
   echo "*** ERROR: COMPILER=$ATDM_CONFIG_COMPILER is not supported on this system!"
   echo "***"
   return
+
 fi
 
 # ToDo: Update above to only load the compiler and MPI moudles and then


### PR DESCRIPTION
* Added new intel-19 build that SPARC is now using (replacing their intel-17 build)
* Removed intel-17 build SPARC was using
* Removed obsolete gnu-4.9.3 (which has not been run in months)

FYI: This will be the first and only Intel 19 build of Trilinos submitting to the CDash site.

## How was this tested?

I ran a full build of all the ATDM Trilinos packages from 'ceerws1113' with:

```
$ cd /scratch/rabartl/Trilinos.base/BUILDS/ATDM/CEE-RHEL6/CTEST_S/
$ ./ctest-s-local-test-driver-cee-rhel6.sh \
  cee-rhel6_intel-19.0.3_intelmpi-2018.4_serial_static_opt
```

and submitted to CDash shown at:

* [Trilinos-atdm-cee-rhel6_intel-19.0.3_intelmpi-2018.4_serial_static_opt-exp](https://testing.sandia.gov/cdash/index.php?project=Trilinos&parentid=5692657) (passed=2098)

I then ran the testing of Kokkos and Teuchos for all of the supported builds with:

```
$ cd /scratch/rabartl/Trilinos.base/BUILDS/ATDM/CEE-RHEL6/CTEST_S/

$ env Trilinos_PACKAGES=Kokkos,Teuchos \
  ./ctest-s-local-test-driver-cee-rhel6.sh all
```

and it submitted to CDash at:

* [Trilinos-atdm-cee-rhel6_clang-5.0.1_openmpi-1.10.2_serial_static_opt-exp](https://testing-dev.sandia.gov/cdash/index.php?project=Trilinos&parentid=4886130) (compiler = Clang 5.0.1, passed=162)
* [Trilinos-atdm-cee-rhel6_gnu-7.2.0_openmpi-1.10.2_serial_shared_opt-exp](https://testing-dev.sandia.gov/cdash/index.php?project=Trilinos&parentid=4886137) (compiler = GNU 7.2.0, passed=165)
* [Trilinos-atdm-cee-rhel6_intel-18.0.2_mpich2-3.2_openmp_static_opt-exp](https://testing-dev.sandia.gov/cdash/index.php?project=Trilinos&parentid=4886141) (compiler = Intel 18.0.2.20180210, passed=164)
* [Trilinos-atdm-cee-rhel6_intel-19.0.3_intelmpi-2018.4_serial_static_opt-exp](https://testing-dev.sandia.gov/cdash/index.php?project=Trilinos&parentid=4886180) (compiler = Intel 19.0.0.20190206, passed=162)

I did not test this against SPARC yet.






