### PR TITLE
Zoltan2:  total UVM hack for empire

### DIFF
--- a/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
+++ b/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
@@ -6787,7 +6787,6 @@ bool Zoltan2_AlgMJ<Adapter>::mj_premigrate_to_subset( int used_num_ranks,
     // This is the correct implementation, using initial_mj_gnos_ as the 
     // data to be sent.
     ArrayView<const mj_gno_t> sent_gnos(initial_mj_gnos_, num_local_coords_);
-std::cout << " KDDKDD USING THE OLD WAY " << std::endl;
 #else
     // Unfortunately, this HACK is needed to workaround BUGs in SpectrumMPI.
     // Apparently, SpectrumMPI does not communicate UVM memory correctly 
@@ -6813,7 +6812,6 @@ std::cout << " KDDKDD USING THE OLD WAY " << std::endl;
     for (mj_lno_t i = 0; i < num_local_coords_; i++) 
       uvmHackIds[i] = initial_mj_gnos_[i];
     ArrayView<const mj_gno_t> sent_gnos = uvmHackIds();
-std::cout << " KDDKDD USING THE HACKED WAY " << std::endl;
 #endif
 
     distributor.doPostsAndWaits<mj_gno_t>(sent_gnos, 1, received_gnos());

--- a/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
+++ b/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
@@ -6810,8 +6810,8 @@ std::cout << " KDDKDD USING THE OLD WAY " << std::endl;
     // the correct implementation above when vortex's problems are fixed.
     //
     // KDD 9/25/19 Addressing Empire debugging of UVM+MPI and parallel_scan
-    ArrayRCP<gno_t> uvmHackIds = ArrayRCP(num_local_coords_);
-    for (size_t i = 0; i < num_local_coords_; i++) 
+    ArrayRCP<mj_gno_t> uvmHackIds(num_local_coords_);
+    for (mj_lno_t i = 0; i < num_local_coords_; i++) 
       uvmHackIds[i] = initial_mj_gnos_[i];
     ArrayView<const mj_gno_t> sent_gnos = uvmHackIds();
 std::cout << " KDDKDD USING THE HACKED WAY " << std::endl;

--- a/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
+++ b/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
@@ -6783,10 +6783,9 @@ bool Zoltan2_AlgMJ<Adapter>::mj_premigrate_to_subset( int used_num_ranks,
   {
     ArrayRCP<mj_gno_t> received_gnos(num_incoming_gnos);
 
-#define ZOLTAN2_UVM_HACK
-#ifndef ZOLTAN2_UVM_HACK
+#if !defined(HAVE_TPETRACORE_CUDA)  // KDD UVM HACK FOR CUDA IS BELOW
     // This is the correct implementation, using initial_mj_gnos_ as the 
-    // data to be sent.  i
+    // data to be sent.
     ArrayView<const mj_gno_t> sent_gnos(initial_mj_gnos_, num_local_coords_);
 std::cout << " KDDKDD USING THE OLD WAY " << std::endl;
 #else

--- a/packages/zoltan2/test/driver/CMakeLists.txt
+++ b/packages/zoltan2/test/driver/CMakeLists.txt
@@ -177,7 +177,7 @@ TRIBITS_ADD_TEST(
 TRIBITS_ADD_TEST(
     test_driver
     NAME mjTestPremigrate
-    NUM_MPI_PROCS 3
+    NUM_MPI_PROCS 4
     COMM serial mpi
     ARGS
     "./driverinputs/multiJaggedPremigrateTest.xml"


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/zoltan2 @srajama1 @jjellio @bathmatt 

## Description
Added a HACK that copies data returned by Tpetra::Map::getNodeElementList() from the UVM memory returned by Tpetra to host memory before sending the memory to Tpetra::Distributor.



## Motivation and Context
SpectrumMPI is reported to behave badly with UVM unless certain runtime flags are used, but using the flags slows down all MPI communication.  So this HACK avoids passing UVM to MPI for the one use case reported by Empire debuggers.
See
https://gitlab-ex.sandia.gov/jhu/TrilinosSolverPerformance/issues/43

I am not excited about merging this HACK.  The best solution is to obtain a working MPI.  The next best solution may be for Tpetra to identify UVM memory in Distributor and do the copy there for all users.  I hope to see whether this change benefits the debugging effort before actually merging it.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->
Built/tested on cee-lan and on white testbed with and without CUDA.
New test multiJaggedPremigrateTest.xml explicitly invokes pre-migration, including function mj_premigrate_to_subset which was called out by Empire debuggers.
@jjellio said he could test these changes in the application from a branch.
<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [ ] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
