### PR TITLE
Xpetra: cmake logic to solve GlobalOrdinal conflict

### DIFF
--- a/packages/xpetra/CMakeLists.txt
+++ b/packages/xpetra/CMakeLists.txt
@@ -139,11 +139,19 @@ IF (${PACKAGE_NAME}_ENABLE_Epetra)
   IF(NOT ${${PACKAGE_NAME}_Epetra_NO_32BIT_GLOBAL_INDICES})
     MESSAGE("-- Xpetra support for 32 bit Epetra enabled.")
     MESSAGE("--    ${PACKAGE_NAME}_Epetra_NO_32BIT_GLOBAL_INDICES=" ${${PACKAGE_NAME}_Epetra_NO_32BIT_GLOBAL_INDICES})
-    
+
     # Tpetra and Epetra need to match GO types
     IF(${PACKAGE_NAME}_ENABLE_Tpetra)
       IF(NOT Tpetra_INST_INT_INT)
-        MESSAGE(FATAL_ERROR "If Xpetra Epetra support is enabled and Epetra 32-bit global indices are enabled, Xpetra requires that you enable Tpetra_INST_INT_INT")
+        SET(EXPLICIT_PACKAGE_LIST ${${PROJECT_NAME}_ENABLED_PACKAGES_LIST})
+        IF(Epetra IN_LIST EXPLICIT_PACKAGE_LIST)
+          # Epetra was explicitly enabled by the user, so error out
+          MESSAGE(FATAL_ERROR "If Xpetra Epetra support is enabled and Epetra 32-bit global indices are enabled, Xpetra requires that you enable Tpetra_INST_INT_INT")
+        ELSE()
+          # Epetra was enabled but only implicitly; give a warning but turn off Xpetra's Epetra support
+          MESSAGE(WARNING "32-bit global indices are enabled in Epetra but not Tpetra. Since Epetra was not enabled explicitly by user, disabling Epetra support in Xpetra.")
+          SET(${PACKAGE_NAME}_ENABLE_Epetra OFF)
+        ENDIF()
       ENDIF()
     ENDIF()
 

--- a/packages/xpetra/src/Vector/Xpetra_TpetraVector_def.hpp
+++ b/packages/xpetra/src/Vector/Xpetra_TpetraVector_def.hpp
@@ -415,7 +415,7 @@ class TpetraVector<Scalar, int, int, EpetraNode>
 
 #ifdef HAVE_XPETRA_KOKKOS_REFACTOR
 
-    using dual_view_type = typename Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::dual_view_type dual_view_type;
+    using dual_view_type = typename Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::dual_view_type;
 
     typename dual_view_type::t_host_um getHostLocalView() const
     {


### PR DESCRIPTION
When Tpetra deprecated code is removed, its default GO will be long
long. Epetra is enabled by default but with 32-bit GO. Previously if
Epetra32 was enabled and Tpetra GO=int was off, Xpetra would error out
at configure time.

This means that without deprecated code, a Trilinos build with
MueLu/Xpetra enabled and every option default would fail to configure.
This change catches the situation above. If Epetra is explicitly
enabled by the user, it errors out like before. But if Epetra is
only implicitly enabled and GO=long long, Xpetra will just warn
and disable its Epetra support, so configuration will succeed
and Xpetra+downstream will just use Tpetra and GO=long long.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/xpetra 

## Description
<!--- Please describe your changes in detail. -->

## Motivation and Context
<!--- Why is this change required?  What problem does it solve? -->
This will fix configure when deprecated code is disabled or removed, as shown in this
nightly on rocketman: https://testing-dev.sandia.gov/cdash/viewConfigure.php?buildid=4900214
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to >

* Part of 
* Composed of 
-->

## How Has This Been Tested?
<!---
Please describe in detail how you tested your changes.  Include details of your
testing environment and the tests you ran to see how your change affects other
areas of the code.  Consider including configure, build, and test log files.
-->

<!--- 
## Screenshots
Not obligatory, but is there anything pertinent that we should see?
 -->

<!---
Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, please ask&mdash;we are here to help.
-->

## Checklist

- [ ] My commit messages mention the appropriate GitHub issue numbers.
- [ ] My code follows the code style of the affected package(s).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [code contribution guidelines](../blob/master/CONTRIBUTING.md) for this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] No new compiler warnings were introduced.
- [ ] These changes break backwards compatibility.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
