### PR TITLE
Sacado:  Add some SFINAE to restrict instantiation of ConditionalReturnType

### DIFF
--- a/packages/sacado/src/CMakeLists.txt
+++ b/packages/sacado/src/CMakeLists.txt
@@ -290,6 +290,8 @@ SET(HEADERS ${HEADERS}
   mpl/Sacado_mpl_type_wrap.hpp
   mpl/Sacado_mpl_is_placeholder.hpp
   mpl/Sacado_mpl_integral_nonzero_constant.hpp
+  mpl/Sacado_mpl_void.hpp
+  mpl/Sacado_mpl_has_equal_to.hpp
   )
 
 # Scalar flop counters

--- a/packages/sacado/src/mpl/Sacado_mpl_has_equal_to.hpp
+++ b/packages/sacado/src/mpl/Sacado_mpl_has_equal_to.hpp
@@ -1,0 +1,53 @@
+// @HEADER
+// ***********************************************************************
+//
+//                           Sacado Package
+//                 Copyright (2006) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// This library is free software; you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as
+// published by the Free Software Foundation; either version 2.1 of the
+// License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+// USA
+// Questions? Contact David M. Gay (dmgay@sandia.gov) or Eric T. Phipps
+// (etphipp@sandia.gov).
+//
+// ***********************************************************************
+// @HEADER
+
+#ifndef SACADO_MPL_HAS_EQUAL_TO_HPP
+#define SACADO_MPL_HAS_EQUAL_TO_HPP
+
+#include <type_traits>
+
+#include "Sacado_mpl_void.hpp"
+
+namespace Sacado {
+
+  namespace mpl {
+
+    template <typename T1, typename T2 = T1, typename = void_t<> >
+    struct has_equal_to : std::false_type {};
+
+    template <typename T1, typename T2>
+    struct has_equal_to<T1, T2, void_t<decltype(std::declval<T1>() ==
+                                                std::declval<T2>())> >
+    : std::true_type {};
+
+  }
+
+}
+
+#endif // SACADO_MPL_HAS_EQUAL_TO_HPP

--- a/packages/sacado/src/mpl/Sacado_mpl_void.hpp
+++ b/packages/sacado/src/mpl/Sacado_mpl_void.hpp
@@ -1,0 +1,45 @@
+// @HEADER
+// ***********************************************************************
+//
+//                           Sacado Package
+//                 Copyright (2006) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// This library is free software; you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as
+// published by the Free Software Foundation; either version 2.1 of the
+// License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+// USA
+// Questions? Contact David M. Gay (dmgay@sandia.gov) or Eric T. Phipps
+// (etphipp@sandia.gov).
+//
+// ***********************************************************************
+// @HEADER
+
+#ifndef SACADO_MPL_VOID_HPP
+#define SACADO_MPL_VOID_HPP
+
+namespace Sacado {
+
+  namespace mpl {
+
+    template<typename... Ts> struct make_void { typedef void type; };
+
+    template<typename... Ts> using void_t = typename make_void<Ts...>::type;
+
+  }
+
+}
+
+#endif // SACADO_MPL_VOID_HPP

--- a/packages/sacado/test/UnitTests/CMakeLists.txt
+++ b/packages/sacado/test/UnitTests/CMakeLists.txt
@@ -298,6 +298,15 @@ IF (Sacado_ENABLE_TeuchosCore)
       NUM_MPI_PROCS 1
       STANDARD_PASS_OUTPUT
       )
+
+    TRIBITS_ADD_EXECUTABLE_AND_TEST(
+      ConditionalReturnTypeTest
+      SOURCES ConditionalReturnTypeTest.cpp
+      ARGS
+      COMM serial mpi
+      NUM_MPI_PROCS 1
+      STANDARD_PASS_OUTPUT
+      )
   ENDIF()
 
   TRIBITS_ADD_EXECUTABLE_AND_TEST(

--- a/packages/sacado/test/UnitTests/ConditionalReturnTypeTest.cpp
+++ b/packages/sacado/test/UnitTests/ConditionalReturnTypeTest.cpp
@@ -1,0 +1,67 @@
+// @HEADER
+// ***********************************************************************
+//
+//                           Sacado Package
+//                 Copyright (2006) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// This library is free software; you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as
+// published by the Free Software Foundation; either version 2.1 of the
+// License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+// USA
+// Questions? Contact David M. Gay (dmgay@sandia.gov) or Eric T. Phipps
+// (etphipp@sandia.gov).
+//
+// ***********************************************************************
+// @HEADER
+#include <vector>
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_UnitTestRepository.hpp"
+#include "Teuchos_GlobalMPISession.hpp"
+#include "Teuchos_TestingHelpers.hpp"
+
+#include "Sacado.hpp"
+
+template <typename T>
+struct container {
+  T x;
+};
+
+// Test that checks ConditionalReturnType used in the return type deduction for
+// conditional operations uses SFINAE correctly to remove the Fad overloads
+// when the compiler searches for unrelated overloads of !=
+TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( ConditionalReturnType, Fad, FAD )
+{
+  std::vector< container<FAD> > x(1);
+  std::vector< container<FAD> > y(x);
+
+  // Test is really to check whether the code compiles, so if it compiles,
+  // it passes
+  success = true;
+}
+
+const int global_fad_size = 10;
+typedef Sacado::Fad::Exp::DFad<double> Fad_DFadType;
+typedef Sacado::Fad::Exp::SFad<double,global_fad_size> Fad_SFadType;
+typedef Sacado::Fad::Exp::SLFad<double,global_fad_size> Fad_SLFadType;
+TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT(ConditionalReturnType, Fad, Fad_DFadType)
+TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT(ConditionalReturnType, Fad, Fad_SFadType)
+TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT(ConditionalReturnType, Fad, Fad_SLFadType)
+
+int main( int argc, char* argv[] ) {
+  Teuchos::GlobalMPISession mpiSession(&argc, &argv);
+  return Teuchos::UnitTestRepository::runUnitTestsFromMain(argc, argv);
+}


### PR DESCRIPTION
Because of the way the conditional overloads (==, !=, ...) are written
using ConditionalReturnType, this trait can be instantiated with invalid
arguments when the compiler is going through its overload resolution
process for completely unrelated types.  This was observed in SPARC when
using the new Fad design.  This adds some SFINAE metaprogramming to
prevent those instantiations.  It also adds an essentially compile-time
test to make sure the overloads are dropped correctly using SFINAE.