### PR TITLE
ROL: fixing PDE-Opt examples with deprecated code off

### DIFF
--- a/packages/rol/example/PDE-OPT/0ld/TOOLS/dofmanager.hpp
+++ b/packages/rol/example/PDE-OPT/0ld/TOOLS/dofmanager.hpp
@@ -59,15 +59,17 @@ template <class Real>
 class DofManager {
 
 private:
+  using GO = typename Tpetra::Map<>::global_ordinal_type;
+
   ROL::Ptr<MeshManager<Real> > meshManager_;
   std::vector<ROL::Ptr<Intrepid::Basis<Real, Intrepid::FieldContainer<Real> > > > intrepidBasis_;
 
-  int numCells_;         // number of mesh cells
-  int numNodes_;         // number of mesh nodes
-  int numEdges_;         // number of mesh edges
+  GO numCells_;         // number of mesh cells
+  GO numNodes_;         // number of mesh nodes
+  GO numEdges_;         // number of mesh edges
 
-  ROL::Ptr<Intrepid::FieldContainer<int> > meshCellToNodeMap_;
-  ROL::Ptr<Intrepid::FieldContainer<int> > meshCellToEdgeMap_;
+  ROL::Ptr<Intrepid::FieldContainer<GO> > meshCellToNodeMap_;
+  ROL::Ptr<Intrepid::FieldContainer<GO> > meshCellToEdgeMap_;
 
   // Local dof information.
   int numBases_;                                  // number of bases (fields)
@@ -85,18 +87,18 @@ private:
                                                   // contains [number of bases] index vectors, where each index vector
                                                   // is of size [basis cardinality]
   // Global dof information. 
-  int numNodeDofs_;  // number of global node dofs
-  int numEdgeDofs_;  // number of global edge dofs
-  int numFaceDofs_;  // number of global face dofs
-  int numDofs_;      // total number of global dofs
+  GO numNodeDofs_;  // number of global node dofs
+  GO numEdgeDofs_;  // number of global edge dofs
+  GO numFaceDofs_;  // number of global face dofs
+  GO numDofs_;      // total number of global dofs
 
-  ROL::Ptr<Intrepid::FieldContainer<int> > nodeDofs_;  // global node dofs, of size [numNodes_ x numLocalNodeDofs_]
-  ROL::Ptr<Intrepid::FieldContainer<int> > edgeDofs_;  // global edge dofs, of size [numEdges_ x numLocalEdgeDofs_]
-  ROL::Ptr<Intrepid::FieldContainer<int> > faceDofs_;  // global face dofs, of size [numFaces_ x numLocalFaceDofs_]
-  ROL::Ptr<Intrepid::FieldContainer<int> > cellDofs_;  // global cell dofs, of size [numCells_ x numLocalDofs_];
+  ROL::Ptr<Intrepid::FieldContainer<GO> > nodeDofs_;  // global node dofs, of size [numNodes_ x numLocalNodeDofs_]
+  ROL::Ptr<Intrepid::FieldContainer<GO> > edgeDofs_;  // global edge dofs, of size [numEdges_ x numLocalEdgeDofs_]
+  ROL::Ptr<Intrepid::FieldContainer<GO> > faceDofs_;  // global face dofs, of size [numFaces_ x numLocalFaceDofs_]
+  ROL::Ptr<Intrepid::FieldContainer<GO> > cellDofs_;  // global cell dofs, of size [numCells_ x numLocalDofs_];
                                                            // ordered by subcell (node, then edge, then face) and basis index
 
-  std::vector<ROL::Ptr<Intrepid::FieldContainer<int> > > fieldDofs_;  // global cell dofs, indexed by field/basis, of size [numCells_ x basis cardinality];
+  std::vector<ROL::Ptr<Intrepid::FieldContainer<GO> > > fieldDofs_;  // global cell dofs, indexed by field/basis, of size [numCells_ x basis cardinality];
                                                                           // ordered by subcell (node, then edge, then face)
 
 public:
@@ -155,52 +157,52 @@ public:
   }
 
 
-  ROL::Ptr<Intrepid::FieldContainer<int> > getNodeDofs() const {
+  ROL::Ptr<Intrepid::FieldContainer<GO> > getNodeDofs() const {
     return nodeDofs_;
   }
 
 
-  ROL::Ptr<Intrepid::FieldContainer<int> > getEdgeDofs() const {
+  ROL::Ptr<Intrepid::FieldContainer<GO> > getEdgeDofs() const {
     return edgeDofs_;
   }
 
 
-  ROL::Ptr<Intrepid::FieldContainer<int> > getFaceDofs() const {
+  ROL::Ptr<Intrepid::FieldContainer<GO> > getFaceDofs() const {
     return faceDofs_;
   }
 
 
-  ROL::Ptr<Intrepid::FieldContainer<int> > getCellDofs() const {
+  ROL::Ptr<Intrepid::FieldContainer<GO> > getCellDofs() const {
     return cellDofs_;
   }
 
 
-  std::vector<ROL::Ptr<Intrepid::FieldContainer<int> > > getFieldDofs() const {
+  std::vector<ROL::Ptr<Intrepid::FieldContainer<GO> > > getFieldDofs() const {
     return fieldDofs_;
   }
 
 
-  ROL::Ptr<Intrepid::FieldContainer<int> > getFieldDofs(const int & fieldNumber) const {
+  ROL::Ptr<Intrepid::FieldContainer<GO> > getFieldDofs(const int & fieldNumber) const {
     return fieldDofs_[fieldNumber];
   }
 
 
-  int getNumNodeDofs() const {
+  GO getNumNodeDofs() const {
     return numNodeDofs_;
   }
 
 
-  int getNumEdgeDofs() const {
+  GO getNumEdgeDofs() const {
     return numEdgeDofs_;
   }
 
 
-  int getNumFaceDofs() const {
+  GO getNumFaceDofs() const {
     return numFaceDofs_;
   }
 
 
-  int getNumDofs() const {
+  GO getNumDofs() const {
     return numDofs_;
   }
 
@@ -234,13 +236,13 @@ private:
 
   void computeDofArrays() {
 
-    nodeDofs_ = ROL::makePtr<Intrepid::FieldContainer<int>>(numNodes_, numLocalNodeDofs_);
-    edgeDofs_ = ROL::makePtr<Intrepid::FieldContainer<int>>(numEdges_, numLocalEdgeDofs_);
-    faceDofs_ = ROL::makePtr<Intrepid::FieldContainer<int>>(numCells_, numLocalFaceDofs_);
+    nodeDofs_ = ROL::makePtr<Intrepid::FieldContainer<GO>>(numNodes_, numLocalNodeDofs_);
+    edgeDofs_ = ROL::makePtr<Intrepid::FieldContainer<GO>>(numEdges_, numLocalEdgeDofs_);
+    faceDofs_ = ROL::makePtr<Intrepid::FieldContainer<GO>>(numCells_, numLocalFaceDofs_);
 
-    Intrepid::FieldContainer<int> &nodeDofs = *nodeDofs_;
-    Intrepid::FieldContainer<int> &edgeDofs = *edgeDofs_;
-    Intrepid::FieldContainer<int> &faceDofs = *faceDofs_;
+    Intrepid::FieldContainer<GO> &nodeDofs = *nodeDofs_;
+    Intrepid::FieldContainer<GO> &edgeDofs = *edgeDofs_;
+    Intrepid::FieldContainer<GO> &faceDofs = *faceDofs_;
 
     int dofCt = -1;
 
@@ -262,7 +264,7 @@ private:
     //
 
     // count node dofs
-    for (int i=0; i<numNodes_; ++i) {
+    for (GO i=0; i<numNodes_; ++i) {
       int locNodeCt = -1;
       for (int j=0; j<numBases_; ++j) {
         for (int k=0; k<numDofsPerNode_[j]; ++k) {
@@ -273,7 +275,7 @@ private:
     numNodeDofs_ = dofCt+1;
 
     // count edge dofs
-    for (int i=0; i<numEdges_; ++i) {
+    for (GO i=0; i<numEdges_; ++i) {
       int locEdgeCt = -1;
       for (int j=0; j<numBases_; ++j) {
         for (int k=0; k<numDofsPerEdge_[j]; ++k) {
@@ -284,7 +286,7 @@ private:
     numEdgeDofs_ = dofCt+1-numNodeDofs_;
 
     // count face dofs
-    for (int i=0; i<numCells_; ++i) {
+    for (GO i=0; i<numCells_; ++i) {
       int locFaceCt = -1;
       for (int j=0; j<numBases_; ++j) {
         for (int k=0; k<numDofsPerFace_[j]; ++k) {
@@ -301,17 +303,17 @@ private:
 
   void computeCellDofs() {
 
-    cellDofs_ = ROL::makePtr<Intrepid::FieldContainer<int>>(numCells_, numLocalDofs_);
+    cellDofs_ = ROL::makePtr<Intrepid::FieldContainer<GO>>(numCells_, numLocalDofs_);
 
     // Grab object references, for easier indexing.
-    Intrepid::FieldContainer<int> &cdofs = *cellDofs_;
-    Intrepid::FieldContainer<int> &nodeDofs = *nodeDofs_;
-    Intrepid::FieldContainer<int> &edgeDofs = *edgeDofs_;
-    Intrepid::FieldContainer<int> &faceDofs = *faceDofs_;
-    Intrepid::FieldContainer<int> &ctn = *meshCellToNodeMap_;
-    Intrepid::FieldContainer<int> &cte = *meshCellToEdgeMap_;
+    Intrepid::FieldContainer<GO> &cdofs = *cellDofs_;
+    Intrepid::FieldContainer<GO> &nodeDofs = *nodeDofs_;
+    Intrepid::FieldContainer<GO> &edgeDofs = *edgeDofs_;
+    Intrepid::FieldContainer<GO> &faceDofs = *faceDofs_;
+    Intrepid::FieldContainer<GO> &ctn = *meshCellToNodeMap_;
+    Intrepid::FieldContainer<GO> &cte = *meshCellToEdgeMap_;
 
-    for (int i=0; i<numCells_; ++i) {
+    for (GO i=0; i<numCells_; ++i) {
       int ct = -1;
       for (int j=0; j<numLocalNodes_; ++j) {
         for (int k=0; k<numLocalNodeDofs_; ++k) {
@@ -372,13 +374,13 @@ private:
 
     fieldDofs_.resize(numBases_);
 
-    Intrepid::FieldContainer<int> &cdofs = *cellDofs_;
+    Intrepid::FieldContainer<GO> &cdofs = *cellDofs_;
 
     for (int fieldNum=0; fieldNum<numBases_; ++fieldNum) { 
       int basisCard = intrepidBasis_[fieldNum]->getCardinality();
-      fieldDofs_[fieldNum] = ROL::makePtr<Intrepid::FieldContainer<int>>(numCells_, basisCard);
-      Intrepid::FieldContainer<int> &fdofs = *(fieldDofs_[fieldNum]);
-      for (int i=0; i<numCells_; ++i) {
+      fieldDofs_[fieldNum] = ROL::makePtr<Intrepid::FieldContainer<GO>>(numCells_, basisCard);
+      Intrepid::FieldContainer<GO> &fdofs = *(fieldDofs_[fieldNum]);
+      for (GO i=0; i<numCells_; ++i) {
         for (int j=0; j<basisCard; ++j) {
           fdofs(i,j) = cdofs(i, fieldPattern_[fieldNum][j]);
         }

--- a/packages/rol/example/PDE-OPT/0ld/TOOLS/elasticity.hpp
+++ b/packages/rol/example/PDE-OPT/0ld/TOOLS/elasticity.hpp
@@ -54,6 +54,9 @@
 
 template<class Real>
 class Elasticity : public PDE_FEM <Real> {
+private:
+  using GO = typename Tpetra::Map<>::global_ordinal_type;
+
 protected:
 
   Real E_;
@@ -772,7 +775,7 @@ public:
                               const std::vector<int> &localNodeNum,
                               const std::vector<Real> &coord1,
                               const std::vector<Real> &coord2) { 
-    ROL::Ptr<Intrepid::FieldContainer<int> > nodeDofs = this->dofMgr_->getNodeDofs();
+    ROL::Ptr<Intrepid::FieldContainer<GO> > nodeDofs = this->dofMgr_->getNodeDofs();
     bool isLoadPosContainedInCurrentSegment = false;
     int whichNodeIsCloser = -1;
     // if update F, provides parametrized computation of F[0] and F[1]

--- a/packages/rol/example/PDE-OPT/0ld/elasticity/data.hpp
+++ b/packages/rol/example/PDE-OPT/0ld/elasticity/data.hpp
@@ -52,6 +52,7 @@ template<class Real>
 class ElasticityData : public Elasticity <Real> {
 
 private:
+  using GO = typename Tpetra::Map<>::global_ordinal_type;
 
 public:
 
@@ -66,7 +67,7 @@ ElasticityData(const ROL::Ptr<const Teuchos::Comm<int> > &comm,
 	this->AssembleSystemGraph();
 	this->AssembleSystemMats();
 	//Setup DBC information, do not specify any bc sides, use coordinates to determine the BC instead
-	std::vector<int> dbc_side {};
+	std::vector<GO> dbc_side {};
 	this->SetUpMyDBCInfo(true, dbc_side);
 	//Setup all loads 
     	this->process_loading_information(parlist);

--- a/packages/rol/example/PDE-OPT/0ld/elasticity/dataSIMP.hpp
+++ b/packages/rol/example/PDE-OPT/0ld/elasticity/dataSIMP.hpp
@@ -52,6 +52,7 @@ template<class Real>
 class ElasticitySIMPData : public ElasticitySIMP <Real> {
 
 private:
+  using GO = typename Tpetra::Map<>::global_ordinal_type;
 
 public:
 
@@ -70,7 +71,7 @@ ElasticitySIMPData(const ROL::Ptr<const Teuchos::Comm<int> > &comm,
 	this->AssembleSystemGraph();
 	this->AssembleSystemMats();
 	//Setup DBC information, do not specify any bc sides, use coordinates to determine the BC instead
-	std::vector<int> dbc_side {};
+	std::vector<GO> dbc_side {};
 	this->SetUpMyDBCInfo(true, dbc_side);
 	//Setup all loads 
     	this->process_loading_information(parlist);

--- a/packages/rol/example/PDE-OPT/0ld/elasticitySIMP_topologyOptimization/data.hpp
+++ b/packages/rol/example/PDE-OPT/0ld/elasticitySIMP_topologyOptimization/data.hpp
@@ -52,6 +52,7 @@
 template<class Real>
 class ElasticitySIMPOperators : public ElasticitySIMP <Real> {
 private:
+  using GO = typename Tpetra::Map<>::global_ordinal_type;
 
   Real volFrac_;
 
@@ -65,7 +66,7 @@ public:
     this->SetUpLocalIntrepidArrays();
     this->ComputeLocalSystemMats(true);
 //Setup DBC information, do not specify any bc sides, use coordinates to determine the BC instead
-    std::vector<int> dbc_side {};
+    std::vector<GO> dbc_side {};
     this->SetUpMyDBCInfo(true, dbc_side);
     this->process_loading_information(parlist);
 //With new modification on boundary traction, ComputeLocalForceVec should go after SetUpMyBCInfo and process_loading_information

--- a/packages/rol/example/tempus/example_parabolic_modeleval_forward-adjoint.cpp
+++ b/packages/rol/example/tempus/example_parabolic_modeleval_forward-adjoint.cpp
@@ -198,7 +198,7 @@ int main(int argc, char *argv[]) {
                << " seconds." << std::endl << std::endl;
 
   }
-  catch (std::logic_error err) {
+  catch (std::logic_error& err) {
     *outStream << err.what() << "\n";
     errorFlag = -1000;
   }; // end try


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/rol 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
This fixes all the PDE-OPT 0ld examples (compile and runtime errors) with Tpetra deprecated code is off. The vast majority of the changes are just replacing any use of "int" with the default Tpetra global ordinal, when the value describes a global quantity (global number of cells, global dofs, etc.). Every ``FieldContainer<int>`` has been replaced by ``FieldContainer<GO>``. GO has been added as a private typedef in each "data" class of the various PDEs.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to #5602 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
N/A; this is just part of the preparations for deprecated code removal by Tpetra.
## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
This change fixes the following examples/tests (when Tpetra deprecated code is OFF):

- ROL_example_PDE-OPT_0ld_elasticity_example_01_MPI_1
- ROL_example_PDE-OPT_0ld_elasticity_example_02_MPI_1
- ROL_example_PDE-OPT_0ld_poisson_example_01_MPI_4
- ROL_example_PDE-OPT_0ld_stoch-adv-diff_example_01_MPI_4
- ROL_example_PDE-OPT_0ld_stefan-boltzmann_example_03_MPI_4
- ROL_example_PDE-OPT_0ld_adv-diff-react_example_01_MPI_4
- ROL_example_PDE-OPT_0ld_adv-diff-react_example_02_MPI_4

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->