### PR TITLE
Add move functions to Teuchos::RCP (#6031)

### DIFF
--- a/packages/teuchos/core/src/Teuchos_RCP.hpp
+++ b/packages/teuchos/core/src/Teuchos_RCP.hpp
@@ -282,6 +282,15 @@ RCP<T>::RCP(const RCP<T>& r_ptr)
 
 
 template<class T>
+inline
+RCP<T>::RCP(RCP<T>&& r_ptr)
+  : ptr_(r_ptr.ptr_), node_(std::move(r_ptr.node_))
+{
+  r_ptr.ptr_ = 0;
+}
+
+
+template<class T>
 template<class T2>
 inline
 RCP<T>::RCP(const RCP<T2>& r_ptr)
@@ -306,6 +315,22 @@ RCP<T>& RCP<T>::operator=(const RCP<T>& r_ptr)
   reset(); // Force delete first in debug mode!
 #endif
   RCP<T>(r_ptr).swap(*this);
+  return *this;
+}
+
+
+template<class T>
+inline
+RCP<T>& RCP<T>::operator=(RCP<T>&& r_ptr)
+{
+#ifdef TEUCHOS_DEBUG
+  if (this == &r_ptr)
+    return *this;
+  reset(); // Force delete first in debug mode!
+#endif
+  ptr_ = r_ptr.ptr_;
+  node_ = std::move(r_ptr.node_);
+  r_ptr.ptr_ = 0;
   return *this;
 }
 

--- a/packages/teuchos/core/src/Teuchos_RCPDecl.hpp
+++ b/packages/teuchos/core/src/Teuchos_RCPDecl.hpp
@@ -521,6 +521,15 @@ public:
    */
   inline RCP(const RCP<T>& r_ptr);
 
+  /** \brief Move constructor.
+   *
+   * <b>Postconditons:</b><ul>
+   * <li> <tt>*this</tt> is an exact copy of <tt>r_ptr</tt> before the call.
+   * <li> <tt>r_ptr</tt> is uninitialized
+   * </ul>
+   */
+  inline RCP(RCP<T>&& r_ptr);
+
   /** \brief Initialize from another <tt>RCP<T2></tt> object (implicit conversion only).
    *
    * This function allows the implicit conversion of smart pointer objects just
@@ -570,6 +579,17 @@ public:
    * Provides the "strong guarantee" in a debug build!
    */
   inline RCP<T>& operator=(const RCP<T>& r_ptr);
+
+  /** \brief Move assign.
+   *
+   * <b>Postconditons:</b><ul>
+   * <li> <tt>*this</tt> is an exact copy of <tt>r_ptr</tt> before the call.
+   * <li> <tt>r_ptr</tt> is uninitialized
+   * </ul>
+   *
+   * Provides the "strong guarantee" in a debug build!
+   */
+  inline RCP<T>& operator=(RCP<T>&& r_ptr);
 
   /** \brief Assign to null.
    *

--- a/packages/teuchos/core/src/Teuchos_RCPDecl.hpp
+++ b/packages/teuchos/core/src/Teuchos_RCPDecl.hpp
@@ -439,7 +439,7 @@ public:
    *
    * <b>Postconditons:</b> <ul>
    * <li> <tt>this->get() == 0</tt>
-   * <li> <tt>this->strength() == RCP_STRENGTH_INVALID</tt>
+   * <li> <tt>this->strength() == RCP_STRONG</tt>
    * <li> <tt>this->is_vali_ptr() == true</tt>
    * <li> <tt>this->strong_count() == 0</tt>
    * <li> <tt>this->weak_count() == 0</tt>
@@ -645,8 +645,6 @@ public:
    *     when <tt>*this</tt> is destroyed if <tt>strong_count()==1</tt>.
    * <li><tt>RCP_WEAK</tt>: Underlying reference-counted object will not be deleted
    *     when <tt>*this</tt> is destroyed if <tt>strong_count() > 0</tt>.
-   * <li><tt>RCP_STRENGTH_INVALID</tt>: <tt>*this</tt> is not strong or weak but
-   *     is null.
    * </ul>
    */
   inline ERCPStrength strength() const;

--- a/packages/teuchos/core/src/Teuchos_RCPNode.hpp
+++ b/packages/teuchos/core/src/Teuchos_RCPNode.hpp
@@ -810,28 +810,62 @@ public:
     bind();
   }
 
+  //! Move constructor
+  RCPNodeHandle (RCPNodeHandle&& node_ref)
+    : node_ (node_ref.node_), strength_ (node_ref.strength_)
+  {
+    node_ref.node_ = 0;
+    node_ref.strength_ = RCP_STRONG;
+  }
+
   //! Swap the contents of \c node_ref with \c *this.
   void swap (RCPNodeHandle& node_ref) {
     std::swap (node_ref.node_, node_);
     std::swap (node_ref.strength_, strength_);
   }
 
-  /// \brief Assignment operator.
+
+
+  /// \brief Null assignment.
+  ///
+  /// This method satisfies the strong exception guarantee: It either
+  /// returns successfully, or throws an exception without modifying
+  /// any user-visible state.
+  RCPNodeHandle& operator= (ENull) {
+    unbind(); // May throw in some cases
+    node_ = 0;
+    strength_ = RCP_STRONG;
+    return *this;
+  }
+
+  /// \brief Copy assignment operator.
   ///
   /// This method satisfies the strong exception guarantee: It either
   /// returns successfully, or throws an exception without modifying
   /// any user-visible state.
   RCPNodeHandle& operator= (const RCPNodeHandle& node_ref) {
-    // Assignment to self check: Note, We don't need to do an assigment to
-    // self check here because such a check is already done in the RCP and
-    // ArrayRCP classes.
-    // Take care of this's existing node and object
+    // NOTE: Don't need to check assignment to self since user-facing classes
+    // do that!
     unbind(); // May throw in some cases
-    // Assign the new node
     node_ = node_ref.node_;
     strength_ = node_ref.strength_;
     bind();
-    // Return
+    return *this;
+  }
+
+  /// \brief Move assignment operator.
+  ///
+  /// This method satisfies the strong exception guarantee: It either
+  /// returns successfully, or throws an exception without modifying
+  /// any user-visible state.
+  RCPNodeHandle& operator= (RCPNodeHandle&& node_ref) {
+    // NOTE: Don't need to check assignment to self since user-facing classes
+    // do that!
+    unbind(); // May throw in some cases
+    node_ = node_ref.node_;
+    strength_ = node_ref.strength_;
+    node_ref.node_ = 0;
+    node_ref.strength_ = RCP_STRONG;
     return *this;
   }
 
@@ -1045,7 +1079,6 @@ private:
         }
       }
     }
-
   void unbindOneStrong();
   void unbindOneTotal();
 };

--- a/packages/teuchos/core/test/MemoryManagement/RCPNodeHandle_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/RCPNodeHandle_UnitTests.cpp
@@ -544,6 +544,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( RCPNodeHandle, copyConstruct, T )
 {
   RCPNodeHandle nodeRef1(basicRCPNodeHandle<T>(true));
   RCPNodeHandle nodeRef2(nodeRef1);
+  TEST_EQUALITY( nodeRef1.node_ptr(), nodeRef2.node_ptr() );
+  TEST_EQUALITY_CONST( nodeRef1.same_node(nodeRef2), true );
   TEST_EQUALITY_CONST( nodeRef1.count(), 2 );
   TEST_EQUALITY_CONST( nodeRef2.count(), 2 );
   TEST_EQUALITY_CONST( nodeRef1.has_ownership(), true );
@@ -551,7 +553,21 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( RCPNodeHandle, copyConstruct, T )
 }
 
 
-TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( RCPNodeHandle, assignmentOperator, T )
+TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( RCPNodeHandle, moveConstruct, T )
+{
+  RCPNodeHandle nodeRef1(basicRCPNodeHandle<T>(true));
+  RCPNodeHandle nodeRef2(std::move(nodeRef1));
+  TEST_EQUALITY_CONST( nodeRef1.node_ptr(), 0 );
+  TEST_INEQUALITY_CONST( nodeRef2.node_ptr(), 0 );
+  TEST_EQUALITY_CONST( nodeRef1.same_node(nodeRef2), false );
+  TEST_EQUALITY_CONST( nodeRef1.count(), 0 );
+  TEST_EQUALITY_CONST( nodeRef2.count(), 1 );
+  TEST_EQUALITY_CONST( nodeRef1.has_ownership(), false );
+  TEST_EQUALITY_CONST( nodeRef2.has_ownership(), true );
+}
+
+
+TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( RCPNodeHandle, copyAssignmentOperator, T )
 {
   RCPNodeHandle nodeRef1(basicRCPNodeHandle<T>(true));
   RCPNodeHandle nodeRef2;
@@ -559,6 +575,21 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( RCPNodeHandle, assignmentOperator, T )
   TEST_EQUALITY_CONST( nodeRef1.count(), 2 );
   TEST_EQUALITY_CONST( nodeRef2.count(), 2 );
   TEST_EQUALITY_CONST( nodeRef1.has_ownership(), true );
+  TEST_EQUALITY_CONST( nodeRef2.has_ownership(), true );
+}
+
+
+TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( RCPNodeHandle, moveAssignmentOperator, T )
+{
+  RCPNodeHandle nodeRef1(basicRCPNodeHandle<T>(true));
+  RCPNodeHandle nodeRef2;
+  nodeRef2 = std::move(nodeRef1);
+  TEST_EQUALITY_CONST( nodeRef1.node_ptr(), 0 );
+  TEST_INEQUALITY_CONST( nodeRef2.node_ptr(), 0 );
+  TEST_EQUALITY_CONST( nodeRef1.same_node(nodeRef2), false );
+  TEST_EQUALITY_CONST( nodeRef1.count(), 0 );
+  TEST_EQUALITY_CONST( nodeRef2.count(), 1 );
+  TEST_EQUALITY_CONST( nodeRef1.has_ownership(), false );
   TEST_EQUALITY_CONST( nodeRef2.has_ownership(), true );
 }
 
@@ -701,7 +732,9 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( RCPNodeHandle, extraData_failed_const, T )
   TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( RCPNodeHandle, weakPtr_basic_1, T ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( RCPNodeHandle, weakPtr_basic_2, T ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( RCPNodeHandle, copyConstruct, T ) \
-  TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( RCPNodeHandle, assignmentOperator, T ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( RCPNodeHandle, moveConstruct, T ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( RCPNodeHandle, copyAssignmentOperator, T ) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( RCPNodeHandle, moveAssignmentOperator, T ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( RCPNodeHandle, extraData_basic, T ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( RCPNodeHandle, extraData_basic_const, T ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( RCPNodeHandle, extraData_failed, T ) \

--- a/packages/teuchos/core/test/MemoryManagement/RCP_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/RCP_UnitTests.cpp
@@ -150,6 +150,27 @@ TEUCHOS_UNIT_TEST( RCP, copy_construct_nonnull )
 }
 
 
+/*
+TEUCHOS_UNIT_TEST( RCP, move_construct_nonnull )
+{
+  RCP<A> a_rcp(new A);
+  RCP<A> b_rcp(std::move(a_rcp));
+  TEST_EQUALITY_CONST(a_rcp.get(), 0);
+  TEST_EQUALITY_CONST(a_rcp.getRawPtr(), 0);
+  TEST_EQUALITY_CONST(a_rcp.strength(), RCP_STRONG);
+  TEST_EQUALITY_CONST(a_rcp.strong_count(), 0);
+  TEST_EQUALITY_CONST(a_rcp.weak_count(), 0);
+  TEST_EQUALITY_CONST(a_rcp.has_ownership(), false);
+  TEST_INEQUALITY_CONST(b_rcp.get(), 0);
+  TEST_INEQUALITY_CONST(b_rcp.getRawPtr(), 0);
+  TEST_EQUALITY_CONST(b_rcp.strength(), RCP_STRONG);
+  TEST_EQUALITY_CONST(b_rcp.strong_count(), 1);
+  TEST_EQUALITY_CONST(b_rcp.weak_count(), 0);
+  TEST_EQUALITY_CONST(b_rcp.has_ownership(), true);
+}
+*/
+
+
 TEUCHOS_UNIT_TEST( RCP, assign_self_null )
 {
   RCP<A> a_rcp;

--- a/packages/teuchos/core/test/MemoryManagement/RCP_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/RCP_UnitTests.cpp
@@ -150,7 +150,6 @@ TEUCHOS_UNIT_TEST( RCP, copy_construct_nonnull )
 }
 
 
-/*
 TEUCHOS_UNIT_TEST( RCP, move_construct_nonnull )
 {
   RCP<A> a_rcp(new A);
@@ -168,7 +167,6 @@ TEUCHOS_UNIT_TEST( RCP, move_construct_nonnull )
   TEST_EQUALITY_CONST(b_rcp.weak_count(), 0);
   TEST_EQUALITY_CONST(b_rcp.has_ownership(), true);
 }
-*/
 
 
 TEUCHOS_UNIT_TEST( RCP, assign_self_null )
@@ -179,7 +177,7 @@ TEUCHOS_UNIT_TEST( RCP, assign_self_null )
 }
 
 
-TEUCHOS_UNIT_TEST( RCP, assign_self_nonnull )
+TEUCHOS_UNIT_TEST( RCP, copy_assign_self_nonnull )
 {
   RCP<A> a_rcp(new A);
   A *a_raw_ptr = a_rcp.getRawPtr();
@@ -189,7 +187,7 @@ TEUCHOS_UNIT_TEST( RCP, assign_self_nonnull )
 }
 
 
-TEUCHOS_UNIT_TEST( RCP, assign_nonnull )
+TEUCHOS_UNIT_TEST( RCP, copy_assign_nonnull )
 {
   RCP<A> a_rcp(new A);
   RCP<A> b_rcp;
@@ -203,6 +201,26 @@ TEUCHOS_UNIT_TEST( RCP, assign_nonnull )
   TEST_EQUALITY_CONST(a_rcp.weak_count(), 0);
   TEST_EQUALITY_CONST(b_rcp.weak_count(), 0);
   TEST_EQUALITY_CONST(a_rcp.has_ownership(), true);
+  TEST_EQUALITY_CONST(b_rcp.has_ownership(), true);
+}
+
+
+TEUCHOS_UNIT_TEST( RCP, move_assign_nonnull )
+{
+  RCP<A> a_rcp(new A);
+  RCP<A> b_rcp;
+  b_rcp = std::move(a_rcp);
+  TEST_EQUALITY_CONST(a_rcp.get(), 0);
+  TEST_EQUALITY_CONST(a_rcp.getRawPtr(), 0);
+  TEST_EQUALITY_CONST(a_rcp.strength(), RCP_STRONG);
+  TEST_EQUALITY_CONST(a_rcp.strong_count(), 0);
+  TEST_EQUALITY_CONST(a_rcp.weak_count(), 0);
+  TEST_EQUALITY_CONST(a_rcp.has_ownership(), false);
+  TEST_INEQUALITY_CONST(b_rcp.get(), 0);
+  TEST_INEQUALITY_CONST(b_rcp.getRawPtr(), 0);
+  TEST_EQUALITY_CONST(b_rcp.strength(), RCP_STRONG);
+  TEST_EQUALITY_CONST(b_rcp.strong_count(), 1);
+  TEST_EQUALITY_CONST(b_rcp.weak_count(), 0);
   TEST_EQUALITY_CONST(b_rcp.has_ownership(), true);
 }
 

--- a/packages/teuchos/core/test/MemoryManagement/RCP_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/RCP_UnitTests.cpp
@@ -90,7 +90,67 @@ TEUCHOS_UNIT_TEST( DeallocNull, free )
 }
 
 
-TEUCHOS_UNIT_TEST( RCP, assignSelf_null )
+TEUCHOS_UNIT_TEST( RCP, construct_default )
+{
+  RCP<A> a_rcp;
+  TEST_EQUALITY_CONST(a_rcp.get(), 0);
+  TEST_EQUALITY_CONST(a_rcp.getRawPtr(), 0);
+  TEST_EQUALITY_CONST(a_rcp.strength(), RCP_STRONG);
+  TEST_EQUALITY_CONST(a_rcp.strong_count(), 0);
+  TEST_EQUALITY_CONST(a_rcp.weak_count(), 0);
+  TEST_EQUALITY_CONST(a_rcp.has_ownership(), false);
+}
+
+
+TEUCHOS_UNIT_TEST( RCP, construct_nonull )
+{
+  RCP<A> a_rcp(new A);
+  TEST_INEQUALITY_CONST(a_rcp.get(), 0);
+  TEST_INEQUALITY_CONST(a_rcp.getRawPtr(), 0);
+  TEST_EQUALITY_CONST(a_rcp.strength(), RCP_STRONG);
+  TEST_EQUALITY_CONST(a_rcp.strong_count(), 1);
+  TEST_EQUALITY_CONST(a_rcp.weak_count(), 0);
+  TEST_EQUALITY_CONST(a_rcp.has_ownership(), true);
+}
+
+
+TEUCHOS_UNIT_TEST( RCP, copy_construct_null )
+{
+  RCP<A> a_rcp;
+  RCP<A> b_rcp(a_rcp);
+  TEST_EQUALITY_CONST(a_rcp.get(), 0);
+  TEST_EQUALITY_CONST(a_rcp.getRawPtr(), 0);
+  TEST_EQUALITY_CONST(a_rcp.strength(), RCP_STRONG);
+  TEST_EQUALITY_CONST(a_rcp.strong_count(), 0);
+  TEST_EQUALITY_CONST(a_rcp.weak_count(), 0);
+  TEST_EQUALITY_CONST(a_rcp.has_ownership(), false);
+  TEST_EQUALITY_CONST(b_rcp.get(), 0);
+  TEST_EQUALITY_CONST(b_rcp.getRawPtr(), 0);
+  TEST_EQUALITY_CONST(b_rcp.strength(), RCP_STRONG);
+  TEST_EQUALITY_CONST(b_rcp.strong_count(), 0);
+  TEST_EQUALITY_CONST(b_rcp.weak_count(), 0);
+  TEST_EQUALITY_CONST(b_rcp.has_ownership(), false);
+}
+
+
+TEUCHOS_UNIT_TEST( RCP, copy_construct_nonnull )
+{
+  RCP<A> a_rcp(new A);
+  RCP<A> b_rcp(a_rcp);
+  TEST_EQUALITY(b_rcp.get(), a_rcp.get());
+  TEST_EQUALITY(b_rcp.getRawPtr(), a_rcp.getRawPtr());
+  TEST_EQUALITY_CONST(a_rcp.strength(), RCP_STRONG);
+  TEST_EQUALITY_CONST(b_rcp.strength(), RCP_STRONG);
+  TEST_EQUALITY_CONST(a_rcp.strong_count(), 2);
+  TEST_EQUALITY_CONST(b_rcp.strong_count(), 2);
+  TEST_EQUALITY_CONST(a_rcp.weak_count(), 0);
+  TEST_EQUALITY_CONST(b_rcp.weak_count(), 0);
+  TEST_EQUALITY_CONST(a_rcp.has_ownership(), true);
+  TEST_EQUALITY_CONST(b_rcp.has_ownership(), true);
+}
+
+
+TEUCHOS_UNIT_TEST( RCP, assign_self_null )
 {
   RCP<A> a_rcp;
   a_rcp = a_rcp;
@@ -98,13 +158,31 @@ TEUCHOS_UNIT_TEST( RCP, assignSelf_null )
 }
 
 
-TEUCHOS_UNIT_TEST( RCP, assignSelf_nonnull )
+TEUCHOS_UNIT_TEST( RCP, assign_self_nonnull )
 {
   RCP<A> a_rcp(new A);
   A *a_raw_ptr = a_rcp.getRawPtr();
   a_rcp = a_rcp;
   TEST_ASSERT(nonnull(a_rcp));
   TEST_EQUALITY(a_rcp.getRawPtr(), a_raw_ptr);
+}
+
+
+TEUCHOS_UNIT_TEST( RCP, assign_nonnull )
+{
+  RCP<A> a_rcp(new A);
+  RCP<A> b_rcp;
+  b_rcp = a_rcp;
+  TEST_EQUALITY(b_rcp.get(), a_rcp.get());
+  TEST_EQUALITY(b_rcp.getRawPtr(), a_rcp.getRawPtr());
+  TEST_EQUALITY_CONST(a_rcp.strength(), RCP_STRONG);
+  TEST_EQUALITY_CONST(b_rcp.strength(), RCP_STRONG);
+  TEST_EQUALITY_CONST(a_rcp.strong_count(), 2);
+  TEST_EQUALITY_CONST(b_rcp.strong_count(), 2);
+  TEST_EQUALITY_CONST(a_rcp.weak_count(), 0);
+  TEST_EQUALITY_CONST(b_rcp.weak_count(), 0);
+  TEST_EQUALITY_CONST(a_rcp.has_ownership(), true);
+  TEST_EQUALITY_CONST(b_rcp.has_ownership(), true);
 }
 
 


### PR DESCRIPTION
This is a WIP PR to develop C++11 move functions for Teuchos Memory Management classes (see #6031).

This branch can be merged at any time if needed, even if all of the move operations have not been added yet since they are finished for Teuchos::RCP.