### PR TITLE
Fix build error for ATDM 'cee-rhel6' builds starting 2019-10-04

### DIFF
--- a/cmake/std/atdm/README.md
+++ b/cmake/std/atdm/README.md
@@ -494,9 +494,10 @@ the `checkin-test-atdm.sh` script is run and will set these as the defaults
 ## ctest-s-local-test-driver.sh
 
 When one wants to run local builds to test a branch and submit results to
-CDash so that they are archived and for others to see, then a simple way to
-that is to use the provided `ctest-s-local-test-driver.sh` script.  This
-script uses the CTest -S Jenkins driver system in the directory
+CDash (so that they are archived and for others to see), then a simple way to
+that is to use the provided
+[`ctest-s-local-test-driver.sh`](https://github.com/trilinos/Trilinos/blob/develop/cmake/std/atdm/ctest-s-local-test-driver.sh)
+script.  This script uses the CTest -S Jenkins driver system in the directory
 `Trilinos/cmake/ctest/drivers/atdm/` and the specific Jenkins driver files in
 the directory
 
@@ -513,22 +514,40 @@ $ cd <some_base_build_dir>/
 $ ln -s <some_base_dir>/Trilinos/cmake/std/atdm/ctest-s-local-test-driver.sh .
 ````
 
-Then run any of the build names (e.g. `gnu-opt-debug`) listed in the variable
-`ATDM_CONFIG_ALL_SUPPORTED_BUILDS` in the file
-`cmake/std/atdm/<system_name>/all_supported_builds.sh` (or `all` for all of
-the defined builds) for the system as:
+Then one can run any of the builds with defined driver files listed under:
+
+```
+    Trilinos/cmake/ctest/drivers/atdm/<system_name>/drivers/
+      <full-build-name-1>.sh
+      <full-build-name-2>.sh
+      ...
+```
+
+using:
 
 ```
 $ env \
     Trilinos_PACKAGES=<pkg0>,<pkg1>,... \
+    ATDM_CTEST_S_USE_FULL_BUILD_NAME=1 \
   ./ctest-s-local-test-driver.sh <build-base-name-0> <build-base-name-1> ...
 ```
 
-That will submit results to the Trilinos CDash project to the "Experimental"
-CDash Group (the CDash group can not be changed).  This will automatically
-allocate nodes and run just like it was running as a Jenkins job so the
-details of how this is done are completely taken care of by the existing setup
-for the current system.
+(Or leave out `Trilinos_PACKAGES` to test all of the ATDM packages.)  That
+will submit results to the Trilinos CDash project to the "Experimental" Group
+(the CDash group cannot be changed).  This will automatically allocate nodes
+and run just like it was running as a Jenkins job so the details of how this
+is done are completely taken care of by the existing setup for the current
+system.
+
+To run all of the supported builds listed in the variable
+`ATDM_CONFIG_ALL_SUPPORTED_BUILDS` in the file
+`cmake/std/atdm/<system_name>/all_supported_builds.sh`, use:
+
+```
+$ env \
+    Trilinos_PACKAGES=<pkg0>,<pkg1>,... \
+  ./ctest-s-local-test-driver.sh all
+```
 
 One can examine the progress of the builds and tests locally by looking at the
 generated files:
@@ -537,9 +556,8 @@ generated files:
   <some_base_build_dir>/<full_build_name>/smart-jenkins-driver.out
 ```
 
-(e.g. `<full_build_name>` = `Trilinos-atdm-<system_name>-gnu-opt-debug`) and
-also examine the generated `*.xml` configure, build, and test files created
-under:
+and also examine the generated `*.xml` configure, build, and test files
+created under:
 
 ```
   <some_base_build_dir>/<full_build_name>/SRC_AND_BUILD/BUILD/Testing/
@@ -556,10 +574,28 @@ $ env \
   ./ctest-s-local-test-driver.sh <build-base-name-0> <build-base-name-1> ...
 ```
 
-See
+One can also do run local installs using:
+
+```
+$ env \
+    Trilinos_PACKAGES=<pkg0>,<pkg1>,... \
+    ATDM_CONFIG_TRIL_CMAKE_INSTALL_PREFIX=install \
+    CTEST_DO_INSTALL=ON \
+  ./ctest-s-local-test-driver.sh <build-base-name-0> <build-base-name-1> ...
+```
+
+That will install the enabled Trilinos packages under:
+
+```
+  <full-build-name>/SRC_AND_BUILD/BUILD/install/
+```
+
+For more details, see the help documentation in the scirpt itself
+[`ctest-s-local-test-driver.sh`](https://github.com/trilinos/Trilinos/blob/develop/cmake/std/atdm/ctest-s-local-test-driver.sh). Also,
+see
 [TRIBITS_CTEST_DRIVER()](https://tribits.org/doc/TribitsDevelopersGuide.html#determining-what-testing-related-actions-are-performed-tribits-ctest-driver)
 for a description of all of the options that can be set as env vars to, for
-example, skip configure, skip the build, skip running tests, etc.
+example, skip the configure, skip the build, skip running tests, etc.
 
 
 ## Specific instructions for each system

--- a/cmake/std/atdm/cee-rhel6/environment.sh
+++ b/cmake/std/atdm/cee-rhel6/environment.sh
@@ -223,7 +223,7 @@ export ATDM_CONFIG_NETCDF_LIBS="-L${BOOST_ROOT}/lib;-L${NETCDF_ROOT}/lib;-L${NET
 if [[ "${ATDM_CONFIG_SUPERLUDIST_INCLUDE_DIRS}" == "" ]] ; then
   # Set the default which is correct for all of the new TPL builds
   export ATDM_CONFIG_SUPERLUDIST_INCLUDE_DIRS=${SUPERLUDIST_ROOT}/include
-  export ATDM_CONFIG_SUPERLUDIST_LIBS=${SUPERLUDIST_ROOT}/lib/libsuperlu_dist.a
+  export ATDM_CONFIG_SUPERLUDIST_LIBS=${SUPERLUDIST_ROOT}/lib64/libsuperlu_dist.a
 fi
 
 # Finished!

--- a/cmake/std/atdm/ctest-s-local-test-driver.sh
+++ b/cmake/std/atdm/ctest-s-local-test-driver.sh
@@ -59,11 +59,11 @@ Trilinos-atdm-<system_name>-gnu-openmp-opt).
 
 To select the default env to load instead of 'default', use:
 
-  env ATDM_CHT_DEFAULT_ENV=<system_name>-default \\
+  env ATDM_CTEST_S_DEFAULT_ENV=<system_name>-default \\
   ./ctest-s-local-test-driver.sh <build-name-1> >build-name-2> ...
 
 (For example, this is needed for the 'cee-rhel6' system to set
-ATDM_CHT_DEFAULT_ENV=cee-rhel6-default, otherwise the 'sems-rhel6' env will be
+ATDM_CTEST_S_DEFAULT_ENV=cee-rhel6-default, otherwise the 'sems-rhel6' env will be
 selected.)
 
 To control the list of packages tests, not rebuild from scratch, and not
@@ -127,15 +127,15 @@ fi
 # Load a default env for the system
 #
 
-if [ "$ATDM_CHT_DEFAULT_ENV" == "" ] ; then
-  ATDM_CHT_DEFAULT_ENV=default
+if [ "$ATDM_CTEST_S_DEFAULT_ENV" == "" ] ; then
+  ATDM_CTEST_S_DEFAULT_ENV=default
 fi
-#echo "ATDM_CHT_DEFAULT_ENV = ${ATDM_CHT_DEFAULT_ENV}"
+#echo "ATDM_CTEST_S_DEFAULT_ENV = ${ATDM_CTEST_S_DEFAULT_ENV}"
 
 echo
 echo "Load some env to get python, cmake, etc ..."
 echo
-source $STD_ATDM_DIR/load-env.sh ${ATDM_CHT_DEFAULT_ENV}
+source $STD_ATDM_DIR/load-env.sh ${ATDM_CTEST_S_DEFAULT_ENV}
 # NOTE: Above, it does not matter which env you load.  Any of them will
 # provide the right python, cmake, etc.
 

--- a/cmake/std/atdm/ctest-s-local-test-driver.sh
+++ b/cmake/std/atdm/ctest-s-local-test-driver.sh
@@ -16,13 +16,17 @@ To use, symlink into some scratch directory and then run as:
 
   ./ctest-s-local-test-driver.sh <build-name-1> <build-name-2> ...
 
-If no build names are not given, then the help message is printed.  If 'all'
-is given, then all of the builds supported for the current sytem are run as
-specified in the Trilinos/cmake/std/atdm/<system_name>/all_supported_builds.sh
-file.
+To run all of the supported builds, run with 'all':
 
-The buld names <build-name-keysi> by default must match the the name of the
-builds listed under:
+  ./ctest-s-local-test-driver.sh all
+
+which runs all of the supported builds listed in the file
+Trilinos/cmake/std/atdm/<system_name>/all_supported_builds.sh.
+
+If no commandline arguments are given, then this help message is printed.
+
+If specifying the individual names <build-name-keysi> then the much match the
+names of the driver scripts listed under:
 
   Trilinos/cmake/ctest/drivers/atdm/<system_name>/drivers/
 
@@ -54,26 +58,35 @@ full script name:
     <build-name-keysi>.sh
 
 Tail -f the generated files <full_build_name>/smart-jenkins-driver.out to see
-details of each run (e.g. <full_build_name> =
-Trilinos-atdm-<system_name>-gnu-openmp-opt).
+details of each run.
 
 To select the default env to load instead of 'default', use:
 
   env ATDM_CTEST_S_DEFAULT_ENV=<system_name>-default \\
   ./ctest-s-local-test-driver.sh <build-name-1> >build-name-2> ...
 
-(For example, this is needed for the 'cee-rhel6' system to set
-ATDM_CTEST_S_DEFAULT_ENV=cee-rhel6-default, otherwise the 'sems-rhel6' env will be
-selected.)
+(For example, one must set ATDM_CTEST_S_DEFAULT_ENV=cee-rhel6-default to run
+the 'cee-rhel6' builds on CEE RHEL6 and RHE6 machines. Otherwise the
+'sems-rhel6' env will be selected which is the default env on those machines.)
 
-To control the list of packages tests, not rebuild from scratch, and not
-submit, use (for example):
+To control the list of packages tested, not rebuild from scratch, and not
+submit, use, for example:
 
   env \\
     Trilinos_PACKAGES=<pkg0>,<pkg1>,... \\
     CTEST_START_WITH_EMPTY_BINARY_DIRECTORY=FALSE \\
     CTEST_DO_SUBMIT=OFF \\
-  ./ctest-s-local-test-driver.sh <build-name-1> >build-name-2> ...
+  ./ctest-s-local-test-driver.sh <build-name-1> <build-name-2> ...
+
+To test local installs, one can also set env vars:
+
+  ATDM_CONFIG_TRIL_CMAKE_INSTALL_PREFIX=install
+  CTEST_DO_INSTALL=ON
+
+That will cause Trilinos to be installed into a new install/ directory under
+the build directory:
+
+  <full-build-name>/SRC_AND_BUILD/BUILD/install/
 
 Other options that are good to set sometimes include:
 
@@ -83,6 +96,8 @@ Other options that are good to set sometimes include:
   CTEST_DO_TEST=OFF
   CTEST_PARALLEL_LEVEL=<N>
   CTEST_DO_SUBMIT=OFF
+
+See the documentation for TRIBITS_CTEST_DRIVER() for more details.
 "
 
 if [[ "$@" == "" ]] || [[ "$@" == "-h" ]] ||  [[ "$@" == "--help" ]]; then


### PR DESCRIPTION
This fixes the build error reported in #6040.  This also updates some documentation.

## How was this tested?

On 'ceerws1113' I ran:

```
$ cd /scratch/rabartl/Trilinos.base/BUILDS/ATDM/CEE-RHEL6/CTEST_S/

$ env \
    ATDM_TRILINOS_INSTALL_PREFIX=install \
    CTEST_DO_INSTALL=ON \
  ./ctest-s-local-test-driver-cee-rhel6.sh \
    all
```

which posted to:

* https://testing.sandia.gov/cdash/index.php?project=Trilinos&filtercount=2&showfilters=1&filtercombine=and&field1=groupname&compare1=61&value1=Experimental&field2=buildname&compare2=65&value2=Trilinos-atdm-cee-rhel6

(see the more recent builds that passed.)

