### PR TITLE
Testing: Tpetra: speed up nightly testing

### DIFF
--- a/cmake/ctest/drivers/rocketman/mpi_release_tpetra_deprecated_code_off_downstream_enabled.cmake
+++ b/cmake/ctest/drivers/rocketman/mpi_release_tpetra_deprecated_code_off_downstream_enabled.cmake
@@ -79,7 +79,7 @@ SET(Trilinos_EXCLUDE_PACKAGES Epetra GlobiPack OptiPack Domi PyTrilinos Moertel)
 SET(Trilinos_ENABLE_ALL_FORWARD_DEP_PACKAGES ON)
 
 # If true, this option yields faster builds. In that case, however, it won't disable any upstream package that fails to compile.
-SET(Trilinos_CTEST_DO_ALL_AT_ONCE FALSE)
+SET(Trilinos_CTEST_DO_ALL_AT_ONCE TRUE)
 
 # Because Trilinos_CTEST_DO_ALL_AT_ONCE is set to OFF above,
 # the packages in Trilinos_EXCLUDE_PACKAGES above must also be disabled explicitly in EXTRA_CONFIGURE_OPTIONS


### PR DESCRIPTION
Set testing variable Trilinos_CTEST_DO_ALL_AT_ONCE to true.  I've
confirmed that this speeds up the builds (~3x), at the price of
not disabling any upstream package that might fail.  But since there
are no build failures at the time of this commit, this should be ok.

This is a change to the nightly testing infrastructure, not a change to Tpetra itself.

No testing is required.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trilinos/trilinos/6062)
<!-- Reviewable:end -->
