### PR TITLE
panzer:  change dynamic profile Tpetra::CrsGraph construction to static profile for #5602

### DIFF
--- a/packages/panzer/adapters-stk/src/Panzer_STK_LocalMeshUtilities.cpp
+++ b/packages/panzer/adapters-stk/src/Panzer_STK_LocalMeshUtilities.cpp
@@ -256,12 +256,15 @@ buildNodeToCellMatrix(const Teuchos::RCP<const Teuchos::Comm<int> > & comm,
   RCP<crs_type> cell_to_node;
   {
     PANZER_FUNC_TIME_MONITOR_DIFF("Build matrix",BuildMatrix);
-    // The matrix is indexed by (global cell, global node) = local node
-    cell_to_node = rcp(new crs_type(cell_map,0));
 
     // fill in the cell to node matrix
     const unsigned int num_local_cells = owned_cells_to_nodes.extent(0);
     const unsigned int num_nodes_per_cell = owned_cells_to_nodes.extent(1);
+
+    // The matrix is indexed by (global cell, global node) = local node
+    cell_to_node = rcp(new crs_type(cell_map,num_nodes_per_cell,
+                                    Tpetra::StaticProfile));
+
     std::vector<panzer::LocalOrdinal> local_node_indexes(num_nodes_per_cell);
     std::vector<panzer::GlobalOrdinal> global_node_indexes(num_nodes_per_cell);
     for(unsigned int i=0;i<num_local_cells;i++) {


### PR DESCRIPTION


<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/panzer @trilinos/tpetra 

## Description
Changed dynamic profile Tpetra::CrsGraph construction to static profile.
Static profile requires an upper bound on the number of entries per matrix row to be inserted.
In these changes, I counted the number of entries per row using the same loop structure as the original code to insert the entries.  The count was provided to the constructor and the graph was constructed with StaticProfile before entries are inserted.

## Motivation
Tpetra::DynamicProfile is deprecated.  See https://github.com/trilinos/Trilinos/wiki/Deprecation2

<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
-->

## Related Issues
#5602 



## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

Tested on cee-lan linux workstation with ATDM script 
Tested with and without Tpetra_ENABLE_DEPRECATED_CODE=OFF.
For example:

```
source ../cmake/std/atdm/load-env.sh  gnu-7.2.0-openmp-release-debug
MPI_EXEC=`which mpiexec`

cmake \
  -GNinja \
 -DMPI_EXEC=${MPI_EXEC} \
 -DTpetra_ENABLE_DEPRECATED_CODE=OFF \
 -DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/atdm/ATDMDevEnv.cmake \
 -DTrilinos_ENABLE_TESTS=ON \
 -DTrilinos_ENABLE_GlobiPack:BOOL=OFF \
 -DTrilinos_ENABLE_OptiPack:BOOL=OFF \
 -DTrilinos_ENABLE_Domi:BOOL=OFF \
 -DTrilinos_ENABLE_PyTrilinos:BOOL=OFF \
 -DTrilinos_ENABLE_Moertel:BOOL=OFF \
 -DTrilinos_ENABLE_COMPLEX:BOOL=OFF \
 -DTrilinos_ENABLE_TriKota:BOOL=OFF \
 -DTrilinos_ENABLE_Optika:BOOL=OFF \
 -DTrilinos_ENABLE_Panzer:BOOL=ON \
 -DTrilinos_ENABLE_Piro:BOOL=ON \
 -DTrilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=ON \
 -DTrilinos_ENABLE_SECONDARY_TESTED_CODE:BOOL=ON \
 -DTPL_ENABLE_Matio=OFF \
 -DTPL_ENABLE_X11=OFF \
..
```

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->