### PR TITLE
Reduce ctest -j8 to -j4 for all CUDA builds (#6052)

### DIFF
--- a/cmake/std/atdm/ride/environment.sh
+++ b/cmake/std/atdm/ride/environment.sh
@@ -191,7 +191,7 @@ elif [[ "$ATDM_CONFIG_COMPILER" == "CUDA-9.2_GNU-7.2.0" ]] ; then
   export CUDA_LAUNCH_BLOCKING=1
   export CUDA_MANAGED_FORCE_DEVICE_ALLOC=1
   export KOKKOS_NUM_DEVICES=2
-  export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=8
+  export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=4
   # ABove avoids timeouts due to not running on separate GPUs (see #2446)
 
 elif [[ "$ATDM_CONFIG_COMPILER" == "CUDA-10.1_GNU-7.2.0" ]] ; then
@@ -210,7 +210,7 @@ elif [[ "$ATDM_CONFIG_COMPILER" == "CUDA-10.1_GNU-7.2.0" ]] ; then
   export CUDA_LAUNCH_BLOCKING=1
   export CUDA_MANAGED_FORCE_DEVICE_ALLOC=1
   export KOKKOS_NUM_DEVICES=2
-  export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=8
+  export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=4
   # ABove avoids timeouts due to not running on separate GPUs (see #2446)
 
 fi

--- a/cmake/std/atdm/waterman/environment.sh
+++ b/cmake/std/atdm/waterman/environment.sh
@@ -119,7 +119,7 @@ elif [[ "$ATDM_CONFIG_COMPILER" == "CUDA"* ]] ; then
   export CUDA_LAUNCH_BLOCKING=1
   export CUDA_MANAGED_FORCE_DEVICE_ALLOC=1
   export KOKKOS_NUM_DEVICES=2
-  export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=8
+  export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=4
   # Avoids timeouts due to not running on separate GPUs (see #2446)
 else
   echo


### PR DESCRIPTION
As described in #6052, it is possible that running with ctest -j8 could cause
out-of-memory errors on the GPU and when using UVM the errors are delayed and
hard to diagnose.  Therefore, to be safe, we need to drop to ctest -j4.  That
will cause all of the 4-proc MPI tests to run by themselves and will allow
four 1-proc MPI tests to run.  Hopefully this will eliminate any possibility
of running out of mememory on the GPU.

Hopefully Kitware can help us create a system where we can more effectively
use the GPUs as part of #2422.

## How was this tested

I did not test this.  But I think we can see they are correct by inspection.
