### PR TITLE
Tempus: Add Output Control to TimeStepControl.

### DIFF
--- a/packages/tempus/src/Tempus_IntegratorBasic_decl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorBasic_decl.hpp
@@ -163,6 +163,9 @@ public:
 
     virtual void setScreenOutputIndexInterval(int i)
     { integratorPL_->set("Screen Output Index Interval", i); }
+
+    virtual void setScreenOutputIndexList(std::string s)
+    { integratorPL_->set("Screen Output Index List", s); }
   //@}
 
   /// Parse when screen output should be executed

--- a/packages/tempus/src/Tempus_IntegratorObserverNoOp.cpp
+++ b/packages/tempus/src/Tempus_IntegratorObserverNoOp.cpp
@@ -1,0 +1,19 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Tempus_ExplicitTemplateInstantiation.hpp"
+
+#ifdef HAVE_TEMPUS_EXPLICIT_INSTANTIATION
+#include "Tempus_IntegratorObserverNoOp.hpp"
+#include "Tempus_IntegratorObserverNoOp_impl.hpp"
+
+namespace Tempus {
+  TEMPUS_INSTANTIATE_TEMPLATE_CLASS(IntegratorObserverNoOp)
+}
+
+#endif

--- a/packages/tempus/src/Tempus_IntegratorObserverNoOp_decl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorObserverNoOp_decl.hpp
@@ -1,0 +1,63 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#ifndef Tempus_IntegratorObserverNoOp_decl_hpp
+#define Tempus_IntegratorObserverNoOp_decl_hpp
+
+#include "Tempus_IntegratorObserver.hpp"
+#include "Tempus_Integrator.hpp"
+#include "Teuchos_Time.hpp"
+
+namespace Tempus {
+
+/** \brief IntegratorObserverNoOp class for time integrators.
+ *  This basic class has simple no-op functions, as all basic
+ *  functionality should be handled through other methods.
+ */
+template<class Scalar>
+class IntegratorObserverNoOp
+  : virtual public Tempus::IntegratorObserver<Scalar>
+{
+public:
+
+  /// Constructor
+  IntegratorObserverNoOp();
+
+  /// Destructor
+  virtual ~IntegratorObserverNoOp();
+
+  /// \name Basic IntegratorObserver methods
+  //@{
+    /// Observe the beginning of the time integrator.
+    virtual void observeStartIntegrator(const Integrator<Scalar>& integrator) override;
+
+    /// Observe the beginning of the time step loop.
+    virtual void observeStartTimeStep(const Integrator<Scalar>& integrator) override;
+
+    /// Observe after the next time step size is selected.
+    virtual void observeNextTimeStep(const Integrator<Scalar>& integrator) override;
+
+    /// Observe before Stepper takes step.
+    virtual void observeBeforeTakeStep(const Integrator<Scalar>& integrator) override;
+
+    /// Observe after Stepper takes step.
+    virtual void observeAfterTakeStep(const Integrator<Scalar>& integrator) override;
+
+    /// Observe after checking time step.  Observer can still fail the time step here.
+    virtual void observeAfterCheckTimeStep(const Integrator<Scalar>& integrator) override;
+
+    /// Observe the end of the time step loop.
+    virtual void observeEndTimeStep(const Integrator<Scalar>& integrator) override;
+
+    /// Observe the end of the time integrator.
+    virtual void observeEndIntegrator(const Integrator<Scalar>& integrator) override;
+  //@}
+
+};
+} // namespace Tempus
+#endif // Tempus_IntegratorObserverNoOp_decl_hpp

--- a/packages/tempus/src/Tempus_IntegratorObserverNoOp_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorObserverNoOp_impl.hpp
@@ -1,0 +1,55 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#ifndef Tempus_IntegratorObserverNoOp_impl_hpp
+#define Tempus_IntegratorObserverNoOp_impl_hpp
+
+#include "Tempus_Stepper.hpp"
+
+namespace Tempus {
+
+template<class Scalar>
+IntegratorObserverNoOp<Scalar>::IntegratorObserverNoOp(){}
+
+template<class Scalar>
+IntegratorObserverNoOp<Scalar>::~IntegratorObserverNoOp(){}
+
+template<class Scalar>
+void IntegratorObserverNoOp<Scalar>::
+observeStartIntegrator(const Integrator<Scalar>& /* integrator */){}
+
+template<class Scalar>
+void IntegratorObserverNoOp<Scalar>::
+observeStartTimeStep(const Integrator<Scalar>& /* integrator */){}
+
+template<class Scalar>
+void IntegratorObserverNoOp<Scalar>::
+observeNextTimeStep(const Integrator<Scalar>& /* integrator */){}
+
+template<class Scalar>
+void IntegratorObserverNoOp<Scalar>::
+observeBeforeTakeStep(const Integrator<Scalar>& /* integrator */){}
+
+template<class Scalar>
+void IntegratorObserverNoOp<Scalar>::
+observeAfterTakeStep(const Integrator<Scalar>& /* integrator */){}
+
+template<class Scalar>
+void IntegratorObserverNoOp<Scalar>::
+observeAfterCheckTimeStep(const Integrator<Scalar>& /* integrator */){}
+
+template<class Scalar>
+void IntegratorObserverNoOp<Scalar>::
+observeEndTimeStep(const Integrator<Scalar>& /* integrator */){}
+
+template<class Scalar>
+void IntegratorObserverNoOp<Scalar>::
+observeEndIntegrator(const Integrator<Scalar>& /* integrator */){}
+
+} // namespace Tempus
+#endif // Tempus_IntegratorObserverNoOp_impl_hpp

--- a/packages/tempus/src/Tempus_StepperSubcycling_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperSubcycling_decl.hpp
@@ -127,8 +127,12 @@ public:
     virtual void setSubcyclingMaxFailures(int MaxFailures);
     virtual void setSubcyclingMaxConsecFailures(int MaxConsecFailures);
     virtual void setSubcyclingScreenOutputIndexInterval(int i);
+    virtual void setSubcyclingScreenOutputIndexList(std::string s);
     virtual void setSubcyclingTimeStepControlStrategy(
       Teuchos::RCP<TimeStepControlStrategy<Scalar> > tscs);
+    virtual void setSubcyclingIntegratorObserver(
+      Teuchos::RCP<IntegratorObserver<Scalar> > obs);
+    virtual void setSubcyclingPrintDtChanges(bool printDtChanges);
   //@}
 
   // Temporary until 5908 branch is committed.

--- a/packages/tempus/src/Tempus_TimeStepControlStrategyBasicVS.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategyBasicVS.hpp
@@ -131,8 +131,7 @@ public:
     const int iStep = metaData->getIStep();
     int order = metaData->getOrder();
     Scalar dt = metaData->getDt();
-    bool printChanges = solutionHistory->getVerbLevel() !=
-                        Teuchos::as<int>(Teuchos::VERB_NONE);
+    bool printDtChanges = tsc.getPrintDtChanges();
 
     RCP<Teuchos::FancyOStream> out = tsc.getOStream();
     Teuchos::OSTab ostab(out,0,"getNextTimeStep");
@@ -156,48 +155,48 @@ public:
 
     // General rule: only increase/decrease dt once for any given reason.
     if (workingState->getSolutionStatus() == Status::FAILED) {
-      if (printChanges) *out << changeDT(iStep, dt, dt*sigma,
+      if (printDtChanges) *out << changeDT(iStep, dt, dt*sigma,
         "Stepper failure - Decreasing dt.");
       dt *= sigma;
     }
     else { //Stepper passed
       if (eta < getMinEta()) { // increase dt
-        if (printChanges) *out << changeDT(iStep, dt, dt*rho,
+        if (printDtChanges) *out << changeDT(iStep, dt, dt*rho,
           "Monitoring Value (eta) is too small ("
           + std::to_string(eta) + " < " + std::to_string(getMinEta())
           + ").  Increasing dt.");
         dt *= rho;
       }
       else if (eta > getMaxEta()) { // reduce dt
-        if (printChanges) *out << changeDT(iStep, dt, dt*sigma,
+        if (printDtChanges) *out << changeDT(iStep, dt, dt*sigma,
           "Monitoring Value (eta) is too large ("
           + std::to_string(eta) + " > " + std::to_string(getMaxEta())
           + ").  Decreasing dt.");
         dt *= sigma;
       }
       else if (errorAbs > tsc.getMaxAbsError()) { // reduce dt
-        if (printChanges) *out << changeDT(iStep, dt, dt*sigma,
+        if (printDtChanges) *out << changeDT(iStep, dt, dt*sigma,
           "Absolute error is too large ("
           + std::to_string(errorAbs)+" > "+std::to_string(tsc.getMaxAbsError())
           + ").  Decreasing dt.");
         dt *= sigma;
       }
       else if (errorRel > tsc.getMaxRelError()) { // reduce dt
-        if (printChanges) *out << changeDT(iStep, dt, dt*sigma,
+        if (printDtChanges) *out << changeDT(iStep, dt, dt*sigma,
           "Relative error is too large ("
           + std::to_string(errorRel)+" > "+std::to_string(tsc.getMaxRelError())
           + ").  Decreasing dt.");
         dt *= sigma;
       }
       else if (order < tsc.getMinOrder()) { // order too low, increase dt
-        if (printChanges) *out << changeDT(iStep, dt, dt*rho,
+        if (printDtChanges) *out << changeDT(iStep, dt, dt*rho,
           "Order is too small ("
           + std::to_string(order) + " < " + std::to_string(tsc.getMinOrder())
           + ").  Increasing dt.");
         dt *= rho;
       }
       else if (order > tsc.getMaxOrder()) { // order too high, reduce dt
-        if (printChanges) *out << changeDT(iStep, dt, dt*sigma,
+        if (printDtChanges) *out << changeDT(iStep, dt, dt*sigma,
           "Order is too large ("
           + std::to_string(order) + " > " + std::to_string(tsc.getMaxOrder())
           + ").  Decreasing dt.");
@@ -206,12 +205,12 @@ public:
     }
 
     if (dt < tsc.getMinTimeStep()) { // decreased below minimum dt
-      if (printChanges) *out << changeDT(iStep, dt, tsc.getMinTimeStep(),
+      if (printDtChanges) *out << changeDT(iStep, dt, tsc.getMinTimeStep(),
         "dt is too small.  Resetting to minimum dt.");
       dt = tsc.getMinTimeStep();
     }
     if (dt > tsc.getMaxTimeStep()) { // increased above maximum dt
-      if (printChanges) *out << changeDT(iStep, dt, tsc.getMaxTimeStep(),
+      if (printDtChanges) *out << changeDT(iStep, dt, tsc.getMaxTimeStep(),
         "dt is too large.  Resetting to maximum dt.");
       dt = tsc.getMaxTimeStep();
     }

--- a/packages/tempus/src/Tempus_TimeStepControlStrategyConstant.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategyConstant.hpp
@@ -46,8 +46,7 @@ public:
      const Scalar errorRel = metaData->getErrorRel();
      int order = metaData->getOrder();
      Scalar dt = metaData->getDt();
-     bool printChanges = solutionHistory->getVerbLevel() !=
-        Teuchos::as<int>(Teuchos::VERB_NONE);
+     bool printDtChanges = tsc.getPrintDtChanges();
 
      dt = tsc.getInitTimeStep();
 
@@ -65,7 +64,7 @@ public:
      // Stepper failure
      if (workingState->getSolutionStatus() == Status::FAILED) {
         if (order+1 <= tsc.getMaxOrder()) {
-           if (printChanges) *out << changeOrder(order, order+1,
+           if (printDtChanges) *out << changeOrder(order, order+1,
                  "Stepper failure, increasing order.");
            order++;
         } else {
@@ -81,7 +80,7 @@ public:
      // Absolute error failure
      if (errorAbs > tsc.getMaxAbsError()) {
         if (order+1 <= tsc.getMaxOrder()) {
-           if (printChanges) *out << changeOrder(order, order+1,
+           if (printDtChanges) *out << changeOrder(order, order+1,
                  "Absolute error is too large.  Increasing order.");
            order++;
         } else {
@@ -101,7 +100,7 @@ public:
      // Relative error failure
      if (errorRel > tsc.getMaxRelError()) {
         if (order+1 <= tsc.getMaxOrder()) {
-           if (printChanges) *out << changeOrder(order, order+1,
+           if (printDtChanges) *out << changeOrder(order, order+1,
                  "Relative error is too large.  Increasing order.");
            order++;
         } else {

--- a/packages/tempus/src/Tempus_TimeStepControlStrategyIntegralController.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategyIntegralController.hpp
@@ -84,8 +84,7 @@ public:
      // assumes the embedded solution is the low order solution
      int order = metaData->getOrder() - 1;
      Scalar dt = metaData->getDt();
-     //bool printChanges = solutionHistory->getVerbLevel() !=
-        //Teuchos::as<int>(Teuchos::VERB_NONE);
+     //bool printDtChanges = tsc.getPrintDtChanges();
 
      Teuchos::RCP<Teuchos::FancyOStream> out = tsc.getOStream();
      Teuchos::OSTab ostab(out,1,"getNextTimeStep");

--- a/packages/tempus/src/Tempus_TimeStepControlStrategyPID.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategyPID.hpp
@@ -55,8 +55,7 @@ public:
      volatile const Scalar errorRel = metaData->getErrorRel();
      int order = metaData->getOrder();
      Scalar dt = metaData->getDt();
-     bool printChanges = solutionHistory->getVerbLevel() !=
-        Teuchos::as<int>(Teuchos::VERB_NONE);
+     //bool printDtChanges = tsc.getPrintDtChanges();
 
      Teuchos::RCP<Teuchos::FancyOStream> out = tsc.getOStream();
      Teuchos::OSTab ostab(out,1,"getNextTimeStep");

--- a/packages/tempus/src/Tempus_TimeStepControl_decl.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControl_decl.hpp
@@ -50,9 +50,6 @@ public:
   /// Constructor
   TimeStepControl(Teuchos::RCP<Teuchos::ParameterList> pList = Teuchos::null);
 
-  /// This is a copy constructor
-  TimeStepControl(const TimeStepControl<Scalar>& tsc);
-
   /// Destructor
   virtual ~TimeStepControl() {}
 
@@ -192,6 +189,9 @@ public:
       { tscPL_->set<int>("Output Index Interval",OutputIndexInterval); }
     virtual void setOutputTimeInterval(double OutputTimeInterval)
       { tscPL_->set<double>("Output Time Interval",OutputTimeInterval); }
+    virtual void setPrintDtChanges(bool printDtChanges)
+      { printDtChanges_ = printDtChanges; }
+    virtual bool getPrintDtChanges() const { return printDtChanges_; }
   //@}
 
 protected:
@@ -205,6 +205,8 @@ protected:
   Scalar dtAfterOutput_;  ///< dt to reinstate after output step.
 
   Teuchos::RCP<TimeStepControlStrategyComposite<Scalar>> stepControlStrategy_;
+
+  bool printDtChanges_;
 
 };
 } // namespace Tempus

--- a/packages/tempus/src/Tempus_TimeStepControl_impl.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControl_impl.hpp
@@ -29,20 +29,14 @@ namespace Tempus {
 template<class Scalar>
 TimeStepControl<Scalar>::TimeStepControl(
   Teuchos::RCP<Teuchos::ParameterList> pList)
-  : outputAdjustedDt_(false), dtAfterOutput_(0.0)
+  : tscPL_(pList),
+    outputAdjustedDt_(false),
+    dtAfterOutput_(0.0),
+    stepControlStrategy_(Teuchos::null),
+    printDtChanges_(true)
 {
   this->initialize(pList);
 }
-
-template<class Scalar>
-TimeStepControl<Scalar>::TimeStepControl(const TimeStepControl<Scalar>& tsc_)
-  : tscPL_              (tsc_.tscPL_              ),
-    outputIndices_      (tsc_.outputIndices_      ),
-    outputTimes_        (tsc_.outputTimes_        ),
-    outputAdjustedDt_   (tsc_.outputAdjustedDt_   ),
-    dtAfterOutput_      (tsc_.dtAfterOutput_      ),
-    stepControlStrategy_(tsc_.stepControlStrategy_ )
-{}
 
 
 template<class Scalar>
@@ -56,8 +50,6 @@ void TimeStepControl<Scalar>::getNextTimeStep(
   {
     RCP<Teuchos::FancyOStream> out = this->getOStream();
     Teuchos::OSTab ostab(out,0,"getNextTimeStep");
-    bool printChanges = solutionHistory->getVerbLevel() !=
-                        Teuchos::as<int>(Teuchos::VERB_NONE);
 
     auto changeDT = [] (int istep, Scalar dt_old, Scalar dt_new,
                         std::string reason)
@@ -84,7 +76,7 @@ void TimeStepControl<Scalar>::getNextTimeStep(
     if (getStepType() == "Variable") {
       // If last time step was adjusted for output, reinstate previous dt.
       if (outputAdjustedDt_ == true) {
-        if (printChanges) *out << changeDT(iStep, dt, dtAfterOutput_,
+        if (printDtChanges_) *out << changeDT(iStep, dt, dtAfterOutput_,
           "Reset dt after output.");
         dt = dtAfterOutput_;
         outputAdjustedDt_ = false;
@@ -92,13 +84,13 @@ void TimeStepControl<Scalar>::getNextTimeStep(
       }
 
       if (dt <= 0.0) {
-        if (printChanges) *out << changeDT(iStep, dt, getInitTimeStep(),
+        if (printDtChanges_) *out << changeDT(iStep, dt, getInitTimeStep(),
           "Reset dt to initial dt.");
         dt = getInitTimeStep();
       }
 
       if (dt < getMinTimeStep()) {
-        if (printChanges) *out << changeDT(iStep, dt, getMinTimeStep(),
+        if (printDtChanges_) *out << changeDT(iStep, dt, getMinTimeStep(),
           "Reset dt to minimum dt.");
         dt = getMinTimeStep();
       }
@@ -117,12 +109,12 @@ void TimeStepControl<Scalar>::getNextTimeStep(
 
     if (getStepType() == "Variable") {
       if (dt < getMinTimeStep()) { // decreased below minimum dt
-        if (printChanges) *out << changeDT(iStep, dt, getMinTimeStep(),
+        if (printDtChanges_) *out << changeDT(iStep, dt, getMinTimeStep(),
           "dt is too small.  Resetting to minimum dt.");
         dt = getMinTimeStep();
       }
       if (dt > getMaxTimeStep()) { // increased above maximum dt
-        if (printChanges) *out << changeDT(iStep, dt, getMaxTimeStep(),
+        if (printDtChanges_) *out << changeDT(iStep, dt, getMaxTimeStep(),
           "dt is too large.  Resetting to maximum dt.");
         dt = getMaxTimeStep();
       }
@@ -169,7 +161,7 @@ void TimeStepControl<Scalar>::getNextTimeStep(
         // Adjust time step to hit output times.
         if (std::abs((lastTime+dt-oTime)/(lastTime+dt)) < reltol) {
           output = true;
-          if (printChanges) *out << changeDT(iStep, dt, oTime - lastTime,
+          if (printDtChanges_) *out << changeDT(iStep, dt, oTime - lastTime,
             "Adjusting dt for numerical roundoff to hit the next output time.");
           // Next output time IS VERY near next time (<reltol away from it),
           // e.g., adjust for numerical roundoff.
@@ -179,7 +171,7 @@ void TimeStepControl<Scalar>::getNextTimeStep(
         } else if (lastTime*(1.0+reltol) < oTime &&
                    oTime < (lastTime+dt-getMinTimeStep())*(1.0+reltol)) {
           output = true;
-          if (printChanges) *out << changeDT(iStep, dt, oTime - lastTime,
+          if (printDtChanges_) *out << changeDT(iStep, dt, oTime - lastTime,
             "Adjusting dt to hit the next output time.");
           // Next output time is not near next time
           // (>getMinTimeStep() away from it).
@@ -188,7 +180,7 @@ void TimeStepControl<Scalar>::getNextTimeStep(
           dtAfterOutput_ = dt;
           dt = oTime - lastTime;
         } else {
-          if (printChanges) *out << changeDT(iStep, dt, (oTime - lastTime)/2.0,
+          if (printDtChanges_) *out << changeDT(iStep, dt, (oTime - lastTime)/2.0,
             "The next output time is within the minimum dt of the next time. "
             "Adjusting dt to take two steps.");
           // Next output time IS near next time
@@ -208,7 +200,7 @@ void TimeStepControl<Scalar>::getNextTimeStep(
     // numerical differences.
     if ((lastTime + dt > getFinalTime() ) ||
         (std::abs((lastTime+dt-getFinalTime())/(lastTime+dt)) < reltol)) {
-      if (printChanges) *out << changeDT(iStep, dt, getFinalTime() - lastTime,
+      if (printDtChanges_) *out << changeDT(iStep, dt, getFinalTime() - lastTime,
         "Adjusting dt to hit final time.");
       dt = getFinalTime() - lastTime;
     }

--- a/packages/tempus/test/Subcycling/Tempus_SubcyclingTest.cpp
+++ b/packages/tempus/test/Subcycling/Tempus_SubcyclingTest.cpp
@@ -13,6 +13,7 @@
 #include "Thyra_VectorStdOps.hpp"
 
 #include "Tempus_IntegratorBasic.hpp"
+#include "Tempus_IntegratorObserverSubcycling.hpp"
 
 #include "Tempus_StepperFactory.hpp"
 #include "Tempus_StepperSubcycling.hpp"
@@ -128,6 +129,9 @@ TEUCHOS_UNIT_TEST(Subcycling, ConstructingFromDefaults)
   stepper->setSubcyclingMaxFailures      (10);
   stepper->setSubcyclingMaxConsecFailures(5);
   stepper->setSubcyclingScreenOutputIndexInterval(1);
+  stepper->setSubcyclingIntegratorObserver(
+    Teuchos::rcp(new Tempus::IntegratorObserverSubcycling<double>()));
+  stepper->setSubcyclingPrintDtChanges   (true);
 
   stepper->initialize();
 
@@ -163,7 +167,7 @@ TEUCHOS_UNIT_TEST(Subcycling, ConstructingFromDefaults)
   integrator->setStepperWStepper(stepper);
   integrator->setTimeStepControl(timeStepControl);
   integrator->setSolutionHistory(solutionHistory);
-  integrator->setScreenOutputIndexInterval(1);
+  integrator->setScreenOutputIndexInterval(10);
   //integrator->setObserver(...);
   integrator->initialize();
 
@@ -241,6 +245,9 @@ TEUCHOS_UNIT_TEST(Subcycling, SinCosAdapt)
     stepper->setSubcyclingMaxFailures      (10);
     stepper->setSubcyclingMaxConsecFailures(5);
     stepper->setSubcyclingScreenOutputIndexInterval(1);
+    //stepper->setSubcyclingIntegratorObserver(
+    //  Teuchos::rcp(new Tempus::IntegratorObserverSubcycling<double>()));
+    //stepper->setSubcyclingPrintDtChanges   (true);
 
     // Set variable strategy.
     auto strategy = rcp(new Tempus::TimeStepControlStrategyBasicVS<double>());
@@ -283,7 +290,7 @@ TEUCHOS_UNIT_TEST(Subcycling, SinCosAdapt)
     integrator->setStepperWStepper(stepper);
     integrator->setTimeStepControl(timeStepControl);
     integrator->setSolutionHistory(solutionHistory);
-    integrator->setScreenOutputIndexInterval(1);
+    integrator->setScreenOutputIndexInterval(10);
     //integrator->setObserver(...);
     integrator->initialize();
 
@@ -410,6 +417,10 @@ TEUCHOS_UNIT_TEST(Subcycling, VanDerPolOperatorSplit)
     stepperSC->setSubcyclingMaxFailures      (10);
     stepperSC->setSubcyclingMaxConsecFailures(5);
     stepperSC->setSubcyclingScreenOutputIndexInterval(1);
+    //stepper->setSubcyclingIntegratorObserver(
+    //  Teuchos::rcp(new Tempus::IntegratorObserverSubcycling<double>()));
+    //stepperSC->setSubcyclingPrintDtChanges   (true);
+
     //stepperSC->setSubcyclingStepType         ("Constant");
     stepperSC->setSubcyclingStepType         ("Variable");
     auto strategySC = rcp(new Tempus::TimeStepControlStrategyBasicVS<double>());
@@ -475,7 +486,7 @@ TEUCHOS_UNIT_TEST(Subcycling, VanDerPolOperatorSplit)
     integrator->setStepperWStepper(stepper);
     integrator->setTimeStepControl(timeStepControl);
     integrator->setSolutionHistory(solutionHistory);
-    integrator->setScreenOutputIndexInterval(1);
+    integrator->setScreenOutputIndexInterval(10);
     //integrator->setObserver(...);
     integrator->initialize();
 

--- a/packages/tempus/unit_test/Tempus_UnitTest_Subcycling.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_Subcycling.cpp
@@ -74,15 +74,9 @@ TEUCHOS_UNIT_TEST(Subcycling, Default_Construction)
 
   // Full argument list construction.
   auto scIntegrator = Teuchos::rcp(new Tempus::IntegratorBasic<double>());
-  { // Set default subcycling Stepper to Forward Euler.
-    RCP<ParameterList> tempusPL = scIntegrator->getTempusParameterList();
-    tempusPL->sublist("Default Integrator")
-                 .set("Stepper Name", "Default Subcycling Stepper");
-    RCP<ParameterList> stepperPL = Teuchos::parameterList();
-    stepperPL->set("Stepper Type", "Forward Euler");
-    tempusPL->set("Default Subcycling Stepper", *stepperPL);
-  }
-  scIntegrator->setParameterList(Teuchos::null);
+  auto stepperFE = sf->createStepperForwardEuler(model, Teuchos::null);
+  scIntegrator->setStepperWStepper(stepperFE);
+  scIntegrator->initialize();
 
   stepper = rcp(new Tempus::StepperSubcycling<double>(
     model, obs, scIntegrator, useFSAL, ICConsistency, ICConsistencyCheck));


### PR DESCRIPTION
 * Added ability to control printing of timestep changes.
 * Added set function for "Output Index List" in TimeStepControl.
 * Added ability to set the observer on the Subcycling Integrator.
 * Added a no-op IntegratorObserver that does nothing, including
   printing headers and timestep during integrator->advanceTime().
   Primarily used for Subcycling integrator without printing, which
   is the default.
 * Added testing for setting the output on/off.

All tests pass on my Mac.

@trilinos/tempus 