### PR TITLE
Change Spack module from SuperLUDist 6.2.0 to 5.4.0 (CDOFA-66)

### DIFF
--- a/cmake/std/atdm/spack-rhel/environment.sh
+++ b/cmake/std/atdm/spack-rhel/environment.sh
@@ -29,7 +29,7 @@ function load_spack_tpl_modules() {
   module load spack-parallel-netcdf/1.11.0-${compiler_dash_version}-${mpi_dash_version}
   module load spack-parmetis/4.0.3-${compiler_dash_version}-${mpi_dash_version}
   module load spack-cgns/snl-atdm-${compiler_dash_version}-${mpi_dash_version}
-  module load spack-superlu-dist/6.1.0-${compiler_dash_version}-${mpi_dash_version}
+  module load spack-superlu-dist/5.4.0-${compiler_dash_version}-${mpi_dash_version}
 
 }
 


### PR DESCRIPTION
This matches the change to the atdm-spack/install-trilinos-env.sh script in the [atdm-spack](https://gitlab.sandia.gov/atdm/atdm-spack) gitlab repo.

The testing of this is documented in [CDOFA-66](https://sems-atlassian-srn.sandia.gov/browse/CDOFA-66) and included testing with the ATDM Trilinos configuration (Amesos2 tests only) and SPARC.
