### PR TITLE
STK:  fix for #5541  Detect insufficient global ordinal type at configure rather than build time

### DIFF
--- a/cmake/RepositoryDependenciesSetup.cmake
+++ b/cmake/RepositoryDependenciesSetup.cmake
@@ -14,12 +14,13 @@ endif()
 
 #########################################################################
 # STKBalance does not work with GO=INT or GO=UNSIGNED
-# Warn and disable it if it was set as a dependence of STK
+# Note and disable it if it was set as a dependence of STK
 # Error out if it was explicitly requested by user
 
-IF ("${Tpetra_ENABLE_DEPRECATED_CODE}" STREQUAL "OFF")  # Remove this test when
-                                                        # Tpetra DEPRECATED
-                                                        # code is removed
+IF ((NOT ("${Tpetra_ENABLE_DEPRECATED_CODE}" STREQUAL "")) # Remove this test
+    AND                                                    # when removing
+    (NOT Tpetra_ENABLE_DEPRECATED_CODE))                   # Tpetra DEPRECATED
+                                                           # code 
   SET(KDD_ENABLE_DEPRECATED OFF)  # Remove this line when DEPRECATED is removed
   SET(KDD_INT_INT OFF)     # Current default
 ELSE() # Remove this "else" section when Tpetra DEPRECATED code is removed
@@ -65,16 +66,16 @@ ENDIF()
 IF ((NOT ${KDD_INT_LONG}) AND (NOT ${KDD_INT_LONG_LONG}))
   IF ("${${PROJECT_NAME}_ENABLE_STKBalance}" STREQUAL "")
     # STKBalance may be enabled but only implicitly (as a dependence of STK);
-    # give a warning but turn off STKBalance support
-    MESSAGE(WARNING "int global indices are enabled in Trilinos. "
-                    "Because STKBalance requires long or long long "
-                    "global indices, STKBalance will be disabled.  "
-                    "To make this warning go away, do not request "
-                    "int global indices in Trilinos (that is,  do not "
-                    "set Tpetra_INST_INT_INT=ON or "
-                    "Tpetra_INST_INT_UNSIGNED=ON)." )
+    # give a message but turn off STKBalance support
+    MESSAGE("NOTE:  int global indices are enabled in Trilinos. "
+            "Because STKBalance requires long or long long "
+            "global indices, STKBalance will be disabled.  "
+            "To make this warning go away, do not request "
+            "int global indices in Trilinos (that is,  do not "
+            "set Tpetra_INST_INT_INT=ON or "
+            "Tpetra_INST_INT_UNSIGNED=ON)." )
     SET(${PROJECT_NAME}_ENABLE_STKBalance OFF)
-  ELSEIF (${${PROJECT_NAME}_ENABLE_STKBalance})
+  ELSEIF (${PROJECT_NAME}_ENABLE_STKBalance)
     # STKBalance was explicitly enabled by the user, so error out
     MESSAGE(FATAL_ERROR 
             "STKBalance requires long or long long global indices, "

--- a/cmake/RepositoryDependenciesSetup.cmake
+++ b/cmake/RepositoryDependenciesSetup.cmake
@@ -64,7 +64,7 @@ ENDIF()
 
 IF ((NOT ${KDD_INT_LONG}) AND (NOT ${KDD_INT_LONG_LONG}))
   IF ("${${PROJECT_NAME}_ENABLE_STKBalance}" STREQUAL "")
-    # STKBalance was enabled but only implicitly (as a dependence of STK);
+    # STKBalance may be enabled but only implicitly (as a dependence of STK);
     # give a warning but turn off STKBalance support
     MESSAGE(WARNING "int global indices are enabled in Trilinos. "
                     "Because STKBalance requires long or long long "
@@ -74,7 +74,7 @@ IF ((NOT ${KDD_INT_LONG}) AND (NOT ${KDD_INT_LONG_LONG}))
                     "set Tpetra_INST_INT_INT=ON or "
                     "Tpetra_INST_INT_UNSIGNED=ON)." )
     SET(${PROJECT_NAME}_ENABLE_STKBalance OFF)
-  ELSE()
+  ELSEIF (${${PROJECT_NAME}_ENABLE_STKBalance})
     # STKBalance was explicitly enabled by the user, so error out
     MESSAGE(FATAL_ERROR 
             "STKBalance requires long or long long global indices, "

--- a/cmake/RepositoryDependenciesSetup.cmake
+++ b/cmake/RepositoryDependenciesSetup.cmake
@@ -11,3 +11,76 @@ if (TPL_ENABLE_CUDA AND NOT Kokkos_ENABLE_Cuda_Relocatable_Device_Code)
     message(FATAL_ERROR "ERROR: ${PROJECT_NAME}_ENABLE_ShyLU_NodeTacho=ON but TPL_ENABLE_CUDA='${TPL_ENABLE_CUDA}' AND Kokkos_ENABLE_Cuda_Relocatable_Device_Code='${Kokkos_ENABLE_Cuda_Relocatable_Device_Code}' which is not allowed!")
   endif()
 endif() 
+
+#########################################################################
+# STKBalance does not work with GO=INT or GO=UNSIGNED
+# Warn and disable it if it was set as a dependence of STK
+# Error out if it was explicitly requested by user
+
+IF ("${Tpetra_ENABLE_DEPRECATED_CODE}" STREQUAL "OFF")  # Remove this test when
+                                                        # Tpetra DEPRECATED
+                                                        # code is removed
+  SET(KDD_ENABLE_DEPRECATED OFF)  # Remove this line when DEPRECATED is removed
+  SET(KDD_INT_INT OFF)     # Current default
+ELSE() # Remove this "else" section when Tpetra DEPRECATED code is removed
+  SET(KDD_ENABLE_DEPRECATED ON)   # Remove this line when DEPRECATED is removed
+  SET(KDD_INT_INT ON)      # Deprecated default
+ENDIF()
+
+SET(KDD_INT_UNSIGNED OFF)  # Current default
+SET(KDD_INT_LONG OFF)      # Current default
+SET(KDD_INT_LONG_LONG ON)  # Current default
+
+IF (NOT ("${Tpetra_INST_INT_INT}" STREQUAL ""))
+  SET(KDD_INT_INT ${Tpetra_INST_INT_INT})
+  if (${KDD_INT_INT}                      # Keep this test but
+      AND (NOT ${KDD_ENABLE_DEPRECATED})) # remove this test when DEPRECATED
+                                          # is removed
+    SET(KDD_INT_LONG_LONG OFF)
+  ENDIF()
+ENDIF()
+
+IF(NOT ("${Tpetra_INST_INT_UNSIGNED}" STREQUAL ""))
+  SET(KDD_INT_UNSIGNED ${Tpetra_INST_INT_UNSIGNED})
+  if (${KDD_INT_UNSIGNED}                 # Keep this test but
+      AND (NOT ${KDD_ENABLE_DEPRECATED})) # remove this test when DEPRECATED
+                                          # is removed
+    SET(KDD_INT_LONG_LONG OFF)
+  ENDIF()
+ENDIF()
+
+IF(NOT ("${Tpetra_INST_INT_LONG}" STREQUAL ""))
+  SET(KDD_INT_LONG ${Tpetra_INST_INT_LONG})
+  if (${KDD_INT_LONG}                     # Keep this test but
+      AND (NOT ${KDD_ENABLE_DEPRECATED})) # remove this test when DEPRECATED
+                                          # is removed
+    SET(KDD_INT_LONG_LONG OFF)
+  ENDIF()
+ENDIF()
+
+IF(NOT ("${Tpetra_INST_INT_LONG_LONG}" STREQUAL ""))
+  SET(KDD_INT_LONG_LONG ${Tpetra_INST_INT_LONG_LONG})
+ENDIF()
+
+IF ((NOT ${KDD_INT_LONG}) AND (NOT ${KDD_INT_LONG_LONG}))
+  IF ("${${PROJECT_NAME}_ENABLE_STKBalance}" STREQUAL "")
+    # STKBalance was enabled but only implicitly (as a dependence of STK);
+    # give a warning but turn off STKBalance support
+    MESSAGE(WARNING "int global indices are enabled in Trilinos. "
+                    "Because STKBalance requires long or long long "
+                    "global indices, STKBalance will be disabled.  "
+                    "To make this warning go away, do not request "
+                    "int global indices in Trilinos (that is,  do not "
+                    "set Tpetra_INST_INT_INT=ON or "
+                    "Tpetra_INST_INT_UNSIGNED=ON)." )
+    SET(${PROJECT_NAME}_ENABLE_STKBalance OFF)
+  ELSE()
+    # STKBalance was explicitly enabled by the user, so error out
+    MESSAGE(FATAL_ERROR 
+            "STKBalance requires long or long long global indices, "
+            "but Trilinos is using int indices "
+            "(likely via Tpetra_INST_INT_INT or Tpetra_INST_INT_UNSIGNED).  "
+            "Disable STKBalance or specify Tpetra_INST_INT_LONG_LONG.")
+  ENDIF()
+ENDIF()
+  


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/stk @alanw0 @bartlettroscoe 

## Description
Some Cmake voodoo to detect STKBalance's insufficient global ordinal types (int, unsigned) at configure time rather than at build time.
If the user specifies Trilinos_ENABLE_STKBalance=ON with insufficient data types, a CMake error is issued.
If STKBalance is enabled only indirectly via enabling STK and the GOs are insufficient, a CMake warning is issued and STKBalance is disabled.

Thanks to @bartlettroscoe for instructions on making these changes and pointing me to the right file.

## Motivation

STKBalance requires global ordinal types long or long long.  It checks for these types at compile time.  But by then, users may have wasted a lot of time building with a global ordinal type that is no good.  It is better to check for sufficient GO types when configuring.
This change allows Trilinos to build with GO=INT only.

<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
#5541 #5602 
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback

@alanw0 Please let me know if you see a problem with this change.

## Testing

On CEE-LAN, 
with and without Trilinos_ENABLE_STKBalance, 
with Trilinos_ENABLE_STKBalance=ON and OFF,
with Tpetra_INST_INT_INT=ON and OFF and unspecified,
with Tpetra_INST_INT_UNSIGNED=ON and unspecified,
with Tpetra_INST_INT_LONG=ON and unspecified,
with Tpetra_INST_INT_LONG_LONG=ON and OFF and unspecified

<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->