### PR TITLE
Allow enable of Intrepid and therefore Percept in ATDM Trilinos builds (#6017)

### DIFF
--- a/cmake/std/atdm/ATDMDisables.cmake
+++ b/cmake/std/atdm/ATDMDisables.cmake
@@ -24,7 +24,6 @@ SET(ATDM_SE_PACKAGE_DISABLES
   Trios
   FEI
   TriKota
-  Intrepid
   STKClassic
   STKSearchUtil
   STKUnit_tests
@@ -77,6 +76,7 @@ SET(ATDM_SE_PACKAGE_TEST_DISABLES
   Pamgen
   Ifpack
   ML
+  Intrepid
   )
 
 #


### PR DESCRIPTION
Addresses #6017

However, we don't want to be enabling any Intrepid tests since Intrepid is
legacy code and we want Percept to change over to use Intrepid2 at some point
soon.  The usage of Intrepid by Percept will be tested through Panzer and that
is all.  Therefore, we disable the implicit enable of the Intrepid tests.

Testing details are given below.

<details>

<summary><b>Testing Details:</b> (click to expand)</summary>

.

Testing out enable of Percept implicitly through Panzer on 'ceerws1113':

```
$ cd /scratch/rabartl/Trilinos.base/BUILDS/ATDM/CEE-RHEL6/CHECKIN/

$ ./checkin-test-atdm-cee-rhel6.sh \
  gcc-7.2.0-openmpi-opt-dbg \
  --enable-packages=Panzer --local-do-all

PASSED (NOT READY TO PUSH): Trilinos: ceerws1113

Tue Oct 15 17:01:24 MDT 2019

Enabled Packages: Panzer

Build test results:
-------------------
1) gcc-7.2.0-openmpi-opt-dbg => passed: passed=169,notpassed=0 (33.52 min)
```

The configure output showed:

* `Final set of enabled packages:  Gtest Kokkos Teuchos KokkosKernels RTOp Sacado Epetra Zoltan Shards Triutils EpetraExt Tpetra TrilinosSS Thyra Xpetra AztecOO Galeri Amesos Pamgen Zoltan2 Ifpack ML Belos Amesos2 SEACAS Anasazi Ifpack2 Stratimikos Teko Intrepid Intrepid2 STK Percept Phalanx NOX MueLu Rythmos Tempus Piro Panzer 40`

There we see the enable of `Intrepid` and `Percept`.

Also note that the only impact of allowing the enable of Intrepid should be to impact Panzer as shown by:

```
$ grep "\(Intrepid\|Percept\)" gcc-7.2.0-openmpi-opt-dbg/configure.out | grep -v Intrepid2

Allow enable of Intrepid and therefore Percept in ATDM Trilinos builds (#6017)
-- Setting Trilinos_ENABLE_Percept=ON because PanzerAdaptersSTK has an optional dependence on Percept
-- Setting Trilinos_ENABLE_STKExprEval=ON because Percept has a required dependence on STKExprEval
-- Setting Trilinos_ENABLE_STKSearch=ON because Percept has a required dependence on STKSearch
-- Setting Trilinos_ENABLE_STKTransfer=ON because Percept has a required dependence on STKTransfer
-- Setting Trilinos_ENABLE_Intrepid=ON because Percept has a required dependence on Intrepid
-- Setting Trilinos_ENABLE_Gtest=ON because Percept has an optional dependence on Gtest
-- Setting Intrepid_ENABLE_Epetra=ON since Trilinos_ENABLE_Intrepid=ON AND Trilinos_ENABLE_Epetra=ON
-- Setting Intrepid_ENABLE_EpetraExt=ON since Trilinos_ENABLE_Intrepid=ON AND Trilinos_ENABLE_EpetraExt=ON
-- Setting Intrepid_ENABLE_Amesos=ON since Trilinos_ENABLE_Intrepid=ON AND Trilinos_ENABLE_Amesos=ON
-- Setting Intrepid_ENABLE_Pamgen=ON since Trilinos_ENABLE_Intrepid=ON AND Trilinos_ENABLE_Pamgen=ON
-- Setting Percept_ENABLE_Gtest=ON since Trilinos_ENABLE_Percept=ON AND Trilinos_ENABLE_Gtest=ON
-- Setting PanzerAdaptersSTK_ENABLE_Percept=ON since Trilinos_ENABLE_PanzerAdaptersSTK=ON AND Trilinos_ENABLE_Percept=ON
Processing enabled package: Intrepid (Libs)
Processing enabled package: Percept (Libs)
-- PanzerDofMgr_tIntrepidFieldPattern_MPI_4: Added test (BASIC, NUM_MPI_PROCS=4, PROCESSORS=4)!
```

As shown in the CDash build [here](https://testing.sandia.gov/cdash/viewConfigure.php?buildid=5779928), these packages other than Intrepid and Percept are already all enabled in the ATDM Trilinos builds:

* `Final set of enabled SE packages:  ... Gtest ... STKSearch STKTransfer ... STKExprEval ...` 


The test results showed:

```

100% tests passed, 0 tests failed out of 169

Subproject Time Summary:
Panzer    = 2328.68 sec*proc (169 tests)

Total Test time (real) = 300.27 sec
```

And as per https://github.com/trilinos/Trilinos/issues/6017#issuecomment-542453455, we see the Percept-related test running:

```
$ grep tExodusReaderFactory_percept gcc-7.2.0-openmpi-opt-dbg/Testing/Temporary/LastTest.log 
5. tExodusReaderFactory_percept_UnitTest ... [Passed] (0.0522 sec)
```

Now to verify that no Intrepid tests will get enabled I run:

```
$ cd /scratch/rabartl/Trilinos.base/BUILDS/ATDM/CEE-RHEL6/CHECKIN/

$ ./checkin-test-atdm-cee-rhel6.sh \
  gcc-7.2.0-openmpi-opt-dbg \
  --enable-all-packages=on --configure
```

That showed:

```
$ grep "\(Intrepid\|Percept\|Panzer\)" gcc-7.2.0-openmpi-opt-dbg/configure.out | grep "Processing enabled package"

Processing enabled package: Intrepid (Libs)
Processing enabled package: Intrepid2 (Libs, Tests, Examples)
Processing enabled package: Percept (Libs, Tests, Examples)
Processing enabled package: Panzer (Core, DofMgr, DiscFE, AdaptersSTK, MiniEM, Tests, Examples)
```

So this shows that indeed Intrepid tests will not be enabled and Intrepid will not be explicitly processed by the ctest -S driver but Percept will.  (That means that a row on CDash will appear for Intrepid2, Percept, and Panzer but not for Intrepid.)

Now to test Panzer on waterman:

```
$ cd ~/Trilinos.base/BUILDS/WATERMAN/CTEST_S/

$ env \
    Trilinos_PACKAGES=Panzer \
    ATDM_CTEST_S_USE_FULL_BUILD_NAME=1 \
  ./ctest-s-local-test-driver.sh \
    Trilinos-atdm-waterman_cuda-9.2_fpic_static_opt \
    Trilinos-atdm-waterman-cuda-9.2-release-debug

***
*** ./ctest-s-local-test-driver.sh
***

ATDM_TRILINOS_DIR = '/home/rabartl/Trilinos.base/Trilinos'

Load some env to get python, cmake, etc ...

Hostname 'waterman11' matches known ATDM host 'waterman' and system 'waterman'
Setting compiler and build options for build-name 'default'
Using waterman compiler stack GNU to build DEBUG code with Kokkos node type SERIAL and KOKKOS_ARCH=Power9

Running builds:
    Trilinos-atdm-waterman_cuda-9.2_fpic_static_opt
    Trilinos-atdm-waterman-cuda-9.2-release-debug

Running Jenkins driver Trilinos-atdm-waterman_cuda-9.2_fpic_static_opt.sh ...

    Creating directory: Trilinos-atdm-waterman_cuda-9.2_fpic_static_opt

    Creating directory: SRC_AND_BUILD

    See log file Trilinos-atdm-waterman_cuda-9.2_fpic_static_opt/smart-jenkins-driver.out

real    57m28.699s
user    0m0.901s
sys     0m0.677s

Running Jenkins driver Trilinos-atdm-waterman-cuda-9.2-release-debug.sh ...

    See log file Trilinos-atdm-waterman-cuda-9.2-release-debug/smart-jenkins-driver.out

real    74m44.905s
user    0m1.041s
sys     0m0.604s
```

That sent results to:

* https://testing.sandia.gov/cdash/index.php?project=Trilinos&date=2019-10-15&filtercount=2&showfilters=1&filtercombine=and&field1=groupname&compare1=61&value1=Experimental&field2=block&field2count=2&field2field1=buildname&field2compare1=61&field2value1=Trilinos-atdm-waterman-cuda-9.2-release-debug-exp&field2field2=buildname&field2compare2=61&field2value2=Trilinos-atdm-waterman_cuda-9.2_fpic_static_opt-exp

and shows all passing tests.

But it looks like the test `PanzerAdaptersSTK_tExodusReaderFactory_MPI_2` is not even running in the waterman builds:

* https://testing.sandia.gov/cdash/queryTests.php?project=Trilinos&date=2019-10-15&filtercount=3&showfilters=1&filtercombine=and&field1=groupname&compare1=61&value1=Experimental&field2=block&field2count=2&field2field1=buildname&field2compare1=61&field2value1=Trilinos-atdm-waterman-cuda-9.2-release-debug-exp&field2field2=buildname&field2compare2=61&field2value2=Trilinos-atdm-waterman_cuda-9.2_fpic_static_opt-exp&field3=testname&compare3=61&value3=PanzerAdaptersSTK_tExodusReaderFactory_MPI_2

But it does show up the next testing day `date=2019-10-16`:

* https://testing.sandia.gov/cdash/queryTests.php?project=Trilinos&date=2019-10-16&filtercount=3&showfilters=1&filtercombine=and&field1=groupname&compare1=61&value1=Experimental&field2=block&field2count=2&field2field1=buildname&field2compare1=61&field2value1=Trilinos-atdm-waterman-cuda-9.2-release-debug-exp&field2field2=buildname&field2compare2=61&field2value2=Trilinos-atdm-waterman_cuda-9.2_fpic_static_opt-exp&field3=testname&compare3=61&value3=PanzerAdaptersSTK_tExodusReaderFactory_MPI_2

Therefore, there seems to be a defect in CDash :-(  I reported this in:

* https://gitlab.kitware.com/snl/project-1/issues/113

The query:

* https://testing.sandia.gov/cdash/queryTests.php?project=Trilinos&date=2019-10-16&filtercount=4&showfilters=1&filtercombine=and&field1=groupname&compare1=61&value1=Experimental&field2=block&field2count=2&field2field1=buildname&field2compare1=61&field2value1=Trilinos-atdm-waterman-cuda-9.2-release-debug-exp&field2field2=buildname&field2compare2=61&field2value2=Trilinos-atdm-waterman_cuda-9.2_fpic_static_opt-exp&field3=testname&compare3=61&value3=PanzerAdaptersSTK_tExodusReaderFactory_MPI_2&field4=testoutput&compare4=95&value4=tExodusReaderFactory_percept

shows the unit test `tExodusReaderFactory_percept_UnitTest` running and passing.



</details>

