### PR TITLE
rythmos:  fixed printing of Teuchos::SerialDense* to remove deprecated behavior

### DIFF
--- a/packages/rythmos/src/Rythmos_ExplicitRKStepper_def.hpp
+++ b/packages/rythmos/src/Rythmos_ExplicitRKStepper_def.hpp
@@ -433,9 +433,9 @@ void ExplicitRKStepper<Scalar>::describe(
     }
     out << "ktemp_vector = " << std::endl;
     out << Teuchos::describe(*ktemp_vector_,verbLevel);
-    out << "ERK Butcher Tableau A matrix: " << erkButcherTableau_->A() << std::endl;
-    out << "ERK Butcher Tableau b vector: " << erkButcherTableau_->b() << std::endl;
-    out << "ERK Butcher Tableau c vector: " << erkButcherTableau_->c() << std::endl;
+    out << "ERK Butcher Tableau A matrix: " << printMat(erkButcherTableau_->A()) << std::endl;
+    out << "ERK Butcher Tableau b vector: " << printMat(erkButcherTableau_->b()) << std::endl;
+    out << "ERK Butcher Tableau c vector: " << printMat(erkButcherTableau_->c()) << std::endl;
     out << "t = " << t_ << std::endl;
   }
 }

--- a/packages/rythmos/src/Rythmos_RKButcherTableau.hpp
+++ b/packages/rythmos/src/Rythmos_RKButcherTableau.hpp
@@ -200,9 +200,9 @@ class RKButcherTableauDefaultBase :
         out << this->description() << std::endl;
         out << this->getMyDescription() << std::endl;
         out << "number of Stages = " << this->numStages() << std::endl;
-        out << "A = " << this->A() << std::endl;
-        out << "b = " << this->b() << std::endl;
-        out << "c = " << this->c() << std::endl;
+        out << "A = " << printMat(this->A()) << std::endl;
+        out << "b = " << printMat(this->b()) << std::endl;
+        out << "c = " << printMat(this->c()) << std::endl;
         out << "order = " << this->order() << std::endl;
       }
     }


### PR DESCRIPTION
## Description

PR #5374 changed the way Teuchos::SerialDense* objects are printed.  
These cases were missed in PR #5374.  They will be needed when Teuchos' deprecated code is removed.


<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tempus @trilinos/teuchos 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Removing deprecated code is good.  Having the remaining code compile correctly is even better.
See #5374 and related issues for discussion.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing

Giant build with almost every bit of deprecated code in Trilinos disabled.
On cee-lan linux workstation, using ATDM scripts.
```
source /home/tmp/code/Trilinos/cmake/std/atdm/load-env.sh  gnu-7.2.0-openmp-release-debug
module load sems-metis/5.1.0/base

cmake \
  -GNinja \
 -DMPI_EXEC=${MPI_EXEC} \
 -DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/atdm/ATDMDevEnv.cmake \
 -DTrilinos_ENABLE_TESTS=ON \
 -DTrilinos_ENABLE_Domi:BOOL=OFF \
 -DTrilinos_ENABLE_PyTrilinos:BOOL=OFF \
 -DTrilinos_ENABLE_Moertel:BOOL=OFF \
 -DTrilinos_ENABLE_COMPLEX:BOOL=OFF \
 -DTrilinos_ENABLE_TriKota:BOOL=OFF \
 -DTrilinos_ENABLE_Optika:BOOL=OFF \
 -DTrilinos_ENABLE_Tpetra:BOOL=ON \
 -DTrilinos_ENABLE_Belos:BOOL=ON \
 -DTrilinos_ENABLE_Epetra:BOOL=ON \
 -DTrilinos_ENABLE_Ifpack2:BOOL=ON \
 -DTrilinos_ENABLE_MueLu:BOOL=ON \
 -DTrilinos_ENABLE_Panzer:BOOL=ON \
 -DTrilinos_ENABLE_Phalanx:BOOL=ON \
 -DTrilinos_ENABLE_Piro:BOOL=ON \
 -DTrilinos_ENABLE_RTop:BOOL=ON \
 -DTrilinos_ENABLE_STK:BOOL=ON \
 -DTrilinos_ENABLE_Thyra:BOOL=ON \
 -DTrilinos_ENABLE_GlobiPack:BOOL=ON \
 -DTrilinos_ENABLE_OptiPack:BOOL=ON \
 -DTrilinos_ENABLE_Claps:BOOL=ON \
 -D Kokkos_ENABLE_DEPRECATED_CODE=OFF \
 -D Tpetra_ENABLE_DEPRECATED_CODE=OFF  \
 -D Belos_HIDE_DEPRECATED_CODE=ON  \
 -D Epetra_HIDE_DEPRECATED_CODE=ON  \
 -D Ifpack2_HIDE_DEPRECATED_CODE=ON \
 -D Ifpack2_ENABLE_DEPRECATED_CODE=OFF \
 -D MueLu_ENABLE_DEPRECATED_CODE=OFF \
 -D Panzer_HIDE_DEPRECATED_CODE=ON  \
 -D Phalanx_HIDE_DEPRECATED_CODE=ON \
 -D RTop_HIDE_DEPRECATED_CODE=ON \
 -D STK_HIDE_DEPRECATED_CODE=ON \
 -D Teuchos_HIDE_DEPRECATED_CODE=ON\
 -D Thyra_HIDE_DEPRECATED_CODE=ON \
 -D Claps_HIDE_DEPRECATED_CODE=ON \
 -D GlobiPack_HIDE_DEPRECATED_CODE=ON \
 -D OptiPack_HIDE_DEPRECATED_CODE=ON \
 -D Trios_HIDE_DEPRECATED_CODE=ON \
 -DTrilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=ON \
 -DTrilinos_ENABLE_SECONDARY_TESTED_CODE:BOOL=ON \
 -DTPL_ENABLE_METIS=ON \
 -DMETIS_LIBRARY_DIRS=${SEMS_METIS_LIBRARY_PATH} \
 -DMETIS_INCLUDE_DIRS=${SEMS_METIS_INCLUDE_PATH} \
 -DTPL_ENABLE_Matio=OFF \
 -DTPL_ENABLE_X11=OFF \
/home/tmp/code/Trilinos |& tee OUTPUT.CMAKE
```
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->