### PR TITLE
Tempus: Cleanup some warnings.

### DIFF
--- a/packages/tempus/src/Tempus_StepperIMEX_RK_Partition_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RK_Partition_impl.hpp
@@ -101,11 +101,11 @@ void StepperIMEX_RK_Partition<Scalar>::setTableaus(
 
       int order = 1;
 
-      auto explicitTableau = Teuchos::rcp(new RKButcherTableau<Scalar>(
+      auto expTableau = Teuchos::rcp(new RKButcherTableau<Scalar>(
         "Explicit Tableau - Partitioned IMEX RK 1st order",
         A,b,c,order,order,order));
 
-      this->setExplicitTableau(explicitTableau);
+      this->setExplicitTableau(expTableau);
     }
     {
       // Implicit Tableau
@@ -129,11 +129,11 @@ void StepperIMEX_RK_Partition<Scalar>::setTableaus(
 
       int order = 1;
 
-      auto implicitTableau = Teuchos::rcp(new RKButcherTableau<Scalar>(
+      auto impTableau = Teuchos::rcp(new RKButcherTableau<Scalar>(
         "Implicit Tableau - Partitioned IMEX RK 1st order",
         A,b,c,order,order,order));
 
-      this->setImplicitTableau(implicitTableau);
+      this->setImplicitTableau(impTableau);
     }
     this->setStepperType("Partitioned IMEX RK 1st order");
     this->setOrder(1);
@@ -176,11 +176,11 @@ void StepperIMEX_RK_Partition<Scalar>::setTableaus(
 
       int order = 2;
 
-      auto explicitTableau = Teuchos::rcp(new RKButcherTableau<Scalar>(
+      auto expTableau = Teuchos::rcp(new RKButcherTableau<Scalar>(
         "Explicit Tableau - Partitioned IMEX RK ARS 233",
         A,b,c,order,order,order));
 
-      this->setExplicitTableau(explicitTableau);
+      this->setExplicitTableau(expTableau);
     }
     {
       // Implicit Tableau
@@ -197,11 +197,11 @@ void StepperIMEX_RK_Partition<Scalar>::setTableaus(
 
       int order = 3;
 
-      auto implicitTableau = Teuchos::rcp(new RKButcherTableau<Scalar>(
+      auto impTableau = Teuchos::rcp(new RKButcherTableau<Scalar>(
         "Implicit Tableau - Partitioned IMEX RK ARS 233",
         A,b,c,order,order,order));
 
-      this->setImplicitTableau(implicitTableau);
+      this->setImplicitTableau(impTableau);
     }
     this->setStepperType("Partitioned IMEX RK ARS 233");
     this->setOrder(3);

--- a/packages/tempus/src/Tempus_StepperIMEX_RK_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RK_impl.hpp
@@ -101,11 +101,11 @@ void StepperIMEX_RK<Scalar>::setTableaus(std::string stepperType,
 
       int order = 1;
 
-      auto explicitTableau = Teuchos::rcp(new RKButcherTableau<Scalar>(
+      auto expTableau = Teuchos::rcp(new RKButcherTableau<Scalar>(
         "Explicit Tableau - IMEX RK 1st order",
         A,b,c,order,order,order));
 
-      this->setExplicitTableau(explicitTableau);
+      this->setExplicitTableau(expTableau);
     }
     {
       // Implicit Tableau
@@ -129,11 +129,11 @@ void StepperIMEX_RK<Scalar>::setTableaus(std::string stepperType,
 
       int order = 1;
 
-      auto implicitTableau = Teuchos::rcp(new RKButcherTableau<Scalar>(
+      auto impTableau = Teuchos::rcp(new RKButcherTableau<Scalar>(
         "Implicit Tableau - IMEX RK 1st order",
         A,b,c,order,order,order));
 
-      this->setImplicitTableau(implicitTableau);
+      this->setImplicitTableau(impTableau);
     }
     this->setStepperType("IMEX RK 1st order");
     this->setOrder(1);
@@ -175,10 +175,10 @@ void StepperIMEX_RK<Scalar>::setTableaus(std::string stepperType,
 
       int order = 2;
 
-      auto explicitTableau = Teuchos::rcp(new RKButcherTableau<Scalar>(
+      auto expTableau = Teuchos::rcp(new RKButcherTableau<Scalar>(
         "Partition IMEX-RK Explicit Stepper",A,b,c,order,order,order));
 
-      this->setExplicitTableau(explicitTableau);
+      this->setExplicitTableau(expTableau);
     }
     {
       // Implicit Tableau
@@ -195,10 +195,10 @@ void StepperIMEX_RK<Scalar>::setTableaus(std::string stepperType,
 
       int order = 3;
 
-      auto implicitTableau = Teuchos::rcp(new RKButcherTableau<Scalar>(
+      auto impTableau = Teuchos::rcp(new RKButcherTableau<Scalar>(
         "Partition IMEX-RK Implicit Stepper",A,b,c,order,order,order));
 
-      this->setImplicitTableau(implicitTableau);
+      this->setImplicitTableau(impTableau);
     }
     this->setStepperType("IMEX RK ARS 233");
     this->setOrder(3);

--- a/packages/tempus/src/Tempus_StepperSubcycling_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperSubcycling_impl.hpp
@@ -50,7 +50,7 @@ StepperSubcycling<Scalar>::StepperSubcycling()
     stepperPL->set("Stepper Type", "Forward Euler");
     tempusPL->set("Default Subcycling Stepper", *stepperPL);
 
-    auto sf = Teuchos::rcp(new Tempus::StepperFactory<double>());
+    auto sf = Teuchos::rcp(new Tempus::StepperFactory<Scalar>());
     auto stepperFE = sf->createStepperForwardEuler(Teuchos::null,Teuchos::null);
     setSubcyclingStepper(stepperFE);
   }
@@ -266,7 +266,6 @@ void StepperSubcycling<Scalar>::initialize()
          this->getICConsistency() == "App"  ||
          this->getICConsistency() == "Consistent") ) {
     isValidSetup = false;
-    Teuchos::RCP<Teuchos::FancyOStream> out = this->getOStream();
     *out << "The IC consistency does not have a valid value!\n"
          << "('None', 'Zero', 'App' or 'Consistent')\n"
          << "  ICConsistency  = " << this->getICConsistency() << "\n";
@@ -417,7 +416,7 @@ void StepperSubcycling<Scalar>::takeStep(
                                            currentState->getStepperState(),
                                            currentState->getPhysicsState()));
 
-    auto scSH = rcp(new Tempus::SolutionHistory<double>());
+    auto scSH = rcp(new Tempus::SolutionHistory<Scalar>());
     scSH->setName("Subcycling States");
     scSH->setStorageType(Tempus::STORAGE_TYPE_STATIC);
     scSH->setStorageLimit(3);

--- a/packages/tempus/src/Tempus_WrapperModelEvaluatorBasic_impl.hpp
+++ b/packages/tempus/src/Tempus_WrapperModelEvaluatorBasic_impl.hpp
@@ -22,7 +22,7 @@ createInArgs() const
   MEB::InArgsSetup<Scalar> inArgs(appModel_->getNominalValues());
 
   inArgs.setModelEvalDescription(this->description());
-  return inArgs;
+  return std::move(inArgs);
 }
 
 
@@ -34,7 +34,7 @@ createOutArgsImpl() const
   typedef Thyra::ModelEvaluatorBase MEB;
   MEB::OutArgsSetup<Scalar> outArgs(appModel_->createOutArgs());
   outArgs.setModelEvalDescription(this->description());
-  return outArgs;
+  return std::move(outArgs);
 }
 
 

--- a/packages/tempus/src/Tempus_WrapperModelEvaluatorPairIMEX_Basic_impl.hpp
+++ b/packages/tempus/src/Tempus_WrapperModelEvaluatorPairIMEX_Basic_impl.hpp
@@ -99,7 +99,7 @@ getNominalValues() const
 {
   typedef Thyra::ModelEvaluatorBase MEB;
   MEB::InArgsSetup<Scalar> inArgs = this->createInArgs();
-  return inArgs;
+  return std::move(inArgs);
 }
 
 template <typename Scalar>
@@ -111,7 +111,7 @@ createInArgs() const
   //MEB::InArgsSetup<Scalar> inArgs(implicitModel_->createInArgs());
   MEB::InArgsSetup<Scalar> inArgs(implicitModel_->getNominalValues());
   inArgs.setModelEvalDescription(this->description());
-  return inArgs;
+  return std::move(inArgs);
 }
 
 template <typename Scalar>
@@ -122,7 +122,7 @@ createOutArgsImpl() const
   typedef Thyra::ModelEvaluatorBase MEB;
   MEB::OutArgsSetup<Scalar> outArgs(implicitModel_->createOutArgs());
   outArgs.setModelEvalDescription(this->description());
-  return outArgs;
+  return std::move(outArgs);
 }
 
 template <typename Scalar>

--- a/packages/tempus/src/Tempus_WrapperModelEvaluatorPairPartIMEX_Basic_impl.hpp
+++ b/packages/tempus/src/Tempus_WrapperModelEvaluatorPairPartIMEX_Basic_impl.hpp
@@ -370,7 +370,7 @@ getNominalValues() const
   typedef Thyra::ModelEvaluatorBase MEB;
   MEB::InArgsSetup<Scalar> inArgs = this->createInArgs();
   inArgs.set_Np(1);
-  return inArgs;
+  return std::move(inArgs);
 }
 
 template <typename Scalar>
@@ -386,13 +386,13 @@ createInArgs() const
     MEB::InArgsSetup<Scalar> inArgs(implicitInArgs);
     inArgs.setModelEvalDescription(this->description());
     inArgs.set_Np(np);
-    return inArgs;
+    return std::move(inArgs);
   }
 
   MEB::InArgsSetup<Scalar> inArgs(explicitInArgs);
   inArgs.setModelEvalDescription(this->description());
   inArgs.set_Np(np);
-  return inArgs;
+  return std::move(inArgs);
 }
 
 template <typename Scalar>
@@ -408,13 +408,13 @@ createOutArgsImpl() const
     MEB::OutArgsSetup<Scalar> outArgs(implicitOutArgs);
     outArgs.setModelEvalDescription(this->description());
     outArgs.set_Np_Ng(np,implicitOutArgs.Ng());
-    return outArgs;
+    return std::move(outArgs);
   }
 
   MEB::OutArgsSetup<Scalar> outArgs(explicitOutArgs);
   outArgs.setModelEvalDescription(this->description());
   outArgs.set_Np_Ng(np,explicitOutArgs.Ng());
-  return outArgs;
+  return std::move(outArgs);
 }
 
 template <typename Scalar>

--- a/packages/tempus/src/Tempus_WrapperModelEvaluatorSecondOrder_impl.hpp
+++ b/packages/tempus/src/Tempus_WrapperModelEvaluatorSecondOrder_impl.hpp
@@ -27,7 +27,7 @@ createInArgs() const
   inArgs.set_Np(appModel_->Np());
   inArgs.setSupports(MEB::IN_ARG_x);
 
-  return inArgs;
+  return std::move(inArgs);
 }
 
 
@@ -47,7 +47,7 @@ createOutArgsImpl() const
   outArgs.setSupports(MEB::OUT_ARG_f);
   outArgs.setSupports(MEB::OUT_ARG_W_op);
 
-  return outArgs;
+  return std::move(outArgs);
 }
 
 

--- a/packages/tempus/test/Subcycling/Tempus_SubcyclingTest.cpp
+++ b/packages/tempus/test/Subcycling/Tempus_SubcyclingTest.cpp
@@ -515,9 +515,7 @@ TEUCHOS_UNIT_TEST(Subcycling, VanDerPolOperatorSplit)
     if ((n == 0) or (n == nTimeStepSizes-1)) {
       std::string fname = "Tempus_Subcycling_VanDerPol-Ref.dat";
       if (n == 0) fname = "Tempus_Subcycling_VanDerPol.dat";
-      RCP<const SolutionHistory<double> > solutionHistory =
-        integrator->getSolutionHistory();
-      writeSolution(fname, solutionHistory);
+      writeSolution(fname, integrator->getSolutionHistory());
       //solutionHistory->printHistory("medium");
     }
   }


### PR DESCRIPTION
 * Removed some shadow warnings.
 * Replaced some double declaration types that should be Scalar.
 * Fixed some "local variable will be copied despite being
   returned by name [-Wreturn-std-move]" warnings using std::move().

All tests pass on my Mac.

@trilinos/tempus 

Closes #6119 