### PR TITLE
Piro: remove deprecated tests with OptiPack and GlobiPack

### DIFF
--- a/packages/piro/cmake/Piro_config.hpp.in
+++ b/packages/piro/cmake/Piro_config.hpp.in
@@ -33,11 +33,9 @@
 #cmakedefine HAVE_PIRO_STOKHOS
 /* DEPRECATED */
 #cmakedefine Piro_ENABLE_Stokhos
-#ifndef OPTIPACK_HIDE_DEPRECATED_CODE
 #cmakedefine HAVE_PIRO_OPTIPACK
 /* DEPRECATED */
 #cmakedefine Piro_ENABLE_OptiPack
-#endif // !OPTIPACK_HIDE_DEPRECATED_CODE
 #cmakedefine HAVE_PIRO_TRIKOTA
 /* DEPRECATED */
 #cmakedefine Piro_ENABLE_TriKota

--- a/packages/piro/src/Piro_PerformAnalysis.hpp
+++ b/packages/piro/src/Piro_PerformAnalysis.hpp
@@ -49,11 +49,9 @@
 #include "Thyra_ModelEvaluatorDefaultBase.hpp"
 #include "Thyra_VectorStdOps.hpp"
 
-#ifndef OPTIPACK_HIDE_DEPRECATED_CODE
 #ifdef HAVE_PIRO_OPTIPACK
 #include "OptiPack_Config.h"
 #endif
-#endif 
 
 namespace Piro {
 

--- a/packages/piro/test/Main_AnalysisDriver.cpp
+++ b/packages/piro/test/Main_AnalysisDriver.cpp
@@ -57,6 +57,10 @@
 #include "Teuchos_StandardCatchMacros.hpp"
 
 #include "Piro_ConfigDefs.hpp"
+#ifdef HAVE_PIRO_OPTIPACK
+#include "OptiPack_Config.h"
+#endif
+
 
 int main(int argc, char *argv[]) {
 

--- a/packages/piro/test/_input_Analysis_Dakota.xml
+++ b/packages/piro/test/_input_Analysis_Dakota.xml
@@ -156,15 +156,5 @@
     </ParameterList>
     <ParameterList name="MOOCHO">
     </ParameterList>
-    <ParameterList name="OptiPack">
-      <Parameter name="Max Num Iterations" type="int" value="20"/>
-      <Parameter name="Objective Gradient Tol" type="double" value="1.0e-6"/>
-      <Parameter name="Solver Type" type="string" value="FR"/>
-    </ParameterList>
-    <ParameterList name="GlobiPack">
-      <ParameterList name="Minimize">
-        <Parameter name="Max Iterations" type="int" value="8"/>
-      </ParameterList>
-    </ParameterList>
   </ParameterList>
 </ParameterList>

--- a/packages/piro/test/_input_Analysis_MOOCHO.xml
+++ b/packages/piro/test/_input_Analysis_MOOCHO.xml
@@ -163,15 +163,5 @@
         <Parameter name="Explicit Array" type="string" value="{0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="OptiPack">
-      <Parameter name="Max Num Iterations" type="int" value="20"/>
-      <Parameter name="Objective Gradient Tol" type="double" value="1.0e-6"/>
-      <Parameter name="Solver Type" type="string" value="FR"/>
-    </ParameterList>
-    <ParameterList name="GlobiPack">
-      <ParameterList name="Minimize">
-        <Parameter name="Max Iterations" type="int" value="8"/>
-      </ParameterList>
-    </ParameterList>
   </ParameterList>
 </ParameterList>

--- a/packages/piro/test/_input_Analysis_ROL.xml
+++ b/packages/piro/test/_input_Analysis_ROL.xml
@@ -303,15 +303,5 @@
         <Parameter name="Explicit Array" type="string" value="{0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="OptiPack">
-      <Parameter name="Max Num Iterations" type="int" value="20"/>
-      <Parameter name="Objective Gradient Tol" type="double" value="1.0e-6"/>
-      <Parameter name="Solver Type" type="string" value="FR"/>
-    </ParameterList>
-    <ParameterList name="GlobiPack">
-      <ParameterList name="Minimize">
-        <Parameter name="Max Iterations" type="int" value="8"/>
-      </ParameterList>
-    </ParameterList>
   </ParameterList>
 </ParameterList>

--- a/packages/piro/test/_input_Analysis_ROL_AdjointSensitivities.xml
+++ b/packages/piro/test/_input_Analysis_ROL_AdjointSensitivities.xml
@@ -304,15 +304,5 @@
         <Parameter name="Explicit Array" type="string" value="{0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="OptiPack">
-      <Parameter name="Max Num Iterations" type="int" value="20"/>
-      <Parameter name="Objective Gradient Tol" type="double" value="1.0e-6"/>
-      <Parameter name="Solver Type" type="string" value="FR"/>
-    </ParameterList>
-    <ParameterList name="GlobiPack">
-      <ParameterList name="Minimize">
-        <Parameter name="Max Iterations" type="int" value="8"/>
-      </ParameterList>
-    </ParameterList>
   </ParameterList>
 </ParameterList>

--- a/packages/piro/test/_input_Analysis_ROL_AdjointSensitivities_Tpetra.xml
+++ b/packages/piro/test/_input_Analysis_ROL_AdjointSensitivities_Tpetra.xml
@@ -304,15 +304,5 @@
         <Parameter name="Explicit Array" type="string" value="{0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="OptiPack">
-      <Parameter name="Max Num Iterations" type="int" value="20"/>
-      <Parameter name="Objective Gradient Tol" type="double" value="1.0e-6"/>
-      <Parameter name="Solver Type" type="string" value="FR"/>
-    </ParameterList>
-    <ParameterList name="GlobiPack">
-      <ParameterList name="Minimize">
-        <Parameter name="Max Iterations" type="int" value="8"/>
-      </ParameterList>
-    </ParameterList>
   </ParameterList>
 </ParameterList>

--- a/packages/piro/test/_input_Analysis_ROL_Tpetra.xml
+++ b/packages/piro/test/_input_Analysis_ROL_Tpetra.xml
@@ -303,15 +303,5 @@
         <Parameter name="Explicit Array" type="string" value="{0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="OptiPack">
-      <Parameter name="Max Num Iterations" type="int" value="20"/>
-      <Parameter name="Objective Gradient Tol" type="double" value="1.0e-6"/>
-      <Parameter name="Solver Type" type="string" value="FR"/>
-    </ParameterList>
-    <ParameterList name="GlobiPack">
-      <ParameterList name="Minimize">
-        <Parameter name="Max Iterations" type="int" value="8"/>
-      </ParameterList>
-    </ParameterList>
   </ParameterList>
 </ParameterList>

--- a/packages/rythmos/src/Rythmos_ExplicitRKStepper_def.hpp
+++ b/packages/rythmos/src/Rythmos_ExplicitRKStepper_def.hpp
@@ -433,9 +433,9 @@ void ExplicitRKStepper<Scalar>::describe(
     }
     out << "ktemp_vector = " << std::endl;
     out << Teuchos::describe(*ktemp_vector_,verbLevel);
-    out << "ERK Butcher Tableau A matrix: " << erkButcherTableau_->A() << std::endl;
-    out << "ERK Butcher Tableau b vector: " << erkButcherTableau_->b() << std::endl;
-    out << "ERK Butcher Tableau c vector: " << erkButcherTableau_->c() << std::endl;
+    out << "ERK Butcher Tableau A matrix: " << printMat(erkButcherTableau_->A()) << std::endl;
+    out << "ERK Butcher Tableau b vector: " << printMat(erkButcherTableau_->b()) << std::endl;
+    out << "ERK Butcher Tableau c vector: " << printMat(erkButcherTableau_->c()) << std::endl;
     out << "t = " << t_ << std::endl;
   }
 }

--- a/packages/rythmos/src/Rythmos_RKButcherTableau.hpp
+++ b/packages/rythmos/src/Rythmos_RKButcherTableau.hpp
@@ -200,9 +200,9 @@ class RKButcherTableauDefaultBase :
         out << this->description() << std::endl;
         out << this->getMyDescription() << std::endl;
         out << "number of Stages = " << this->numStages() << std::endl;
-        out << "A = " << this->A() << std::endl;
-        out << "b = " << this->b() << std::endl;
-        out << "c = " << this->c() << std::endl;
+        out << "A = " << printMat(this->A()) << std::endl;
+        out << "b = " << printMat(this->b()) << std::endl;
+        out << "c = " << printMat(this->c()) << std::endl;
         out << "order = " << this->order() << std::endl;
       }
     }


### PR DESCRIPTION

@trilinos/piro 

Corrected the ifdef guards for testing whether OptiPack deprecated code should be included or hidden.  The old version did not really exclude the OptiPack calls, because include files were not handled correctly.  Now the Optipack calls and tests are excluded correctly (verified during testing with C++-preprocessor warning directives).

This branch also pulls in branch #6117 (rythmos) in order to compile correctly with all deprecated code hidden.

## Motivation

Optipack and GlobiPack are deprecated packages, slated to be removed from Trilinos. #4957

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

Confirmed removal of tests with @mperego 

## Testing
cee-lan linux workstation with OptiPack_HIDE_DEPRECATED_CODE=ON
```
cmake \
  -GNinja \
 -DMPI_EXEC=${MPI_EXEC} \
 -DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/atdm/ATDMDevEnv.cmake \
 -DTrilinos_ENABLE_TESTS=ON \
 -DTrilinos_ENABLE_Domi:BOOL=OFF \
 -DTrilinos_ENABLE_PyTrilinos:BOOL=OFF \
 -DTrilinos_ENABLE_Moertel:BOOL=OFF \
 -DTrilinos_ENABLE_COMPLEX:BOOL=OFF \
 -DTrilinos_ENABLE_TriKota:BOOL=OFF \
 -DTrilinos_ENABLE_Optika:BOOL=OFF \
 -DTrilinos_ENABLE_Tpetra:BOOL=ON \
 -DTrilinos_ENABLE_Belos:BOOL=ON \
 -DTrilinos_ENABLE_Epetra:BOOL=ON \
 -DTrilinos_ENABLE_Ifpack2:BOOL=ON \
 -DTrilinos_ENABLE_MueLu:BOOL=ON \
 -DTrilinos_ENABLE_Panzer:BOOL=ON \
 -DTrilinos_ENABLE_Phalanx:BOOL=ON \
 -DTrilinos_ENABLE_Piro:BOOL=ON \
 -DTrilinos_ENABLE_RTop:BOOL=ON \
 -DTrilinos_ENABLE_STK:BOOL=ON \
 -DTrilinos_ENABLE_Thyra:BOOL=ON \
 -DTrilinos_ENABLE_GlobiPack:BOOL=ON \
 -DTrilinos_ENABLE_OptiPack:BOOL=ON \
 -DTrilinos_ENABLE_Claps:BOOL=ON \
 -D Kokkos_ENABLE_DEPRECATED_CODE=OFF \
 -D Tpetra_ENABLE_DEPRECATED_CODE=OFF  \
 -D Belos_HIDE_DEPRECATED_CODE=ON  \
 -D Epetra_HIDE_DEPRECATED_CODE=ON  \
 -D Ifpack2_HIDE_DEPRECATED_CODE=ON \
 -D Ifpack2_ENABLE_DEPRECATED_CODE=OFF \
 -D MueLu_ENABLE_DEPRECATED_CODE=OFF \
 -D Panzer_HIDE_DEPRECATED_CODE=ON  \
 -D Phalanx_HIDE_DEPRECATED_CODE=ON \
 -D RTop_HIDE_DEPRECATED_CODE=ON \
 -D STK_HIDE_DEPRECATED_CODE=ON \
 -D Teuchos_HIDE_DEPRECATED_CODE=ON\
 -D Thyra_HIDE_DEPRECATED_CODE=ON \
 -D Claps_HIDE_DEPRECATED_CODE=ON \
 -D GlobiPack_HIDE_DEPRECATED_CODE=ON \
 -D OptiPack_HIDE_DEPRECATED_CODE=ON \
 -D Trios_HIDE_DEPRECATED_CODE=ON \
 -DTrilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=ON \
 -DTrilinos_ENABLE_SECONDARY_TESTED_CODE:BOOL=ON \
 -DTPL_ENABLE_METIS=ON \
 -DMETIS_LIBRARY_DIRS=${SEMS_METIS_LIBRARY_PATH} \
 -DMETIS_INCLUDE_DIRS=${SEMS_METIS_INCLUDE_PATH} \
 -DTPL_ENABLE_Matio=OFF \
 -DTPL_ENABLE_X11=OFF \
/home/tmp/code/Trilinos |& tee OUTPUT.CMAKE
```
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->