### PR TITLE
PullRequestLinuxDriver.sh: remove ".sandia.gov" from the no_proxy env…

### DIFF
--- a/cmake/std/PullRequestLinuxDriver.sh
+++ b/cmake/std/PullRequestLinuxDriver.sh
@@ -34,7 +34,7 @@ echo -e "REPO_ROOT : ${REPO_ROOT}"
 # proxies so set them here.
 export https_proxy=http://wwwproxy.sandia.gov:80
 export http_proxy=http://wwwproxy.sandia.gov:80
-export no_proxy='localhost,localnets,.sandia.gov,127.0.0.1,169.254.0.0/16,forge.sandia.gov'
+export no_proxy='localhost,localnets,127.0.0.1,169.254.0.0/16,forge.sandia.gov'
 
 
 # Call the script to handle merging the incoming branch into


### PR DESCRIPTION
…ironemt variable

Testing shows this works on the ascic machines as well
as the cloud nodes for both testing (although it is
currently showing "500 error" and for testing-dev. Lets
hope that it holds up for a while.

Why our networks are not more stable is beyond me...

This will have to be force pushed of course as no PR's are currently functional.