### PR TITLE
Tpetra/Ifpack2/MueLu/Xpetra: Residual function implementation DO NOT MERGE

### DIFF
--- a/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
@@ -56,6 +56,7 @@
 #include "Kokkos_ArithTraits.hpp"
 #include "Teuchos_FancyOStream.hpp"
 #include "Teuchos_oblackholestream.hpp"
+#include "Tpetra_Details_residual.hpp"
 #include <cmath>
 #include <iostream>
 
@@ -983,11 +984,10 @@ Chebyshev<ScalarType, MV>::
 computeResidual (MV& R, const MV& B, const op_type& A, const MV& X,
                  const Teuchos::ETransp mode)
 {
-  Tpetra::deep_copy(R, B);
-  A.apply (X, R, mode, -STS::one(), STS::one());
+  Tpetra::Details::residual(A,X,B,R);
 }
 
-template<class ScalarType, class MV>
+template <class ScalarType, class MV>
 void
 Chebyshev<ScalarType, MV>::
 solve (MV& Z, const V& D_inv, const MV& R) {

--- a/packages/ifpack2/src/Ifpack2_Relaxation_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Relaxation_def.hpp
@@ -52,6 +52,7 @@
 #include "MatrixMarket_Tpetra.hpp"
 #include "Tpetra_transform_MultiVector.hpp"
 #include "Tpetra_withLocalAccess_MultiVector.hpp"
+#include "Tpetra_Details_residual.hpp"
 #include <cstdlib>
 #include <memory>
 #include <sstream>
@@ -1385,8 +1386,7 @@ ApplyInverseRichardson (const Tpetra::MultiVector<scalar_type,local_ordinal_type
 
   for (int j = startSweep; j < NumSweeps_; ++j) {
     // Each iteration: Y = Y + \omega D^{-1} (X - A*Y)
-    applyMat (Y, *cachedMV_);
-    cachedMV_->update (STS::one (), X, -STS::one ());
+    Tpetra::Details::residual(*A_,Y,X,*cachedMV_);
     Y.update(DampingFactor_,*cachedMV_,STS::one());
   }
 
@@ -1456,8 +1456,7 @@ ApplyInverseJacobi (const Tpetra::MultiVector<scalar_type,local_ordinal_type,glo
 
   for (int j = startSweep; j < NumSweeps_; ++j) {
     // Each iteration: Y = Y + \omega D^{-1} (X - A*Y)
-    applyMat (Y, *cachedMV_);
-    cachedMV_->update (STS::one (), X, -STS::one ());
+    Tpetra::Details::residual(*A_,Y,X,*cachedMV_);
     Y.elementWiseMultiply (DampingFactor_, *Diagonal_, *cachedMV_, STS::one ());
   }
 

--- a/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_decl.hpp
+++ b/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_decl.hpp
@@ -339,6 +339,16 @@ namespace MueLu {
 
     void describe(Teuchos::FancyOStream &out, const Teuchos::EVerbosityLevel verbLevel = Teuchos::VERB_HIGH) const;
 
+    //! Compute a residual R = B - (*this) * X
+    void residual(const MultiVector & X,
+                  const MultiVector & B,
+                  MultiVector & R) const {
+      using STS = Teuchos::ScalarTraits<Scalar>;
+      R.update(STS::one(),X,STS::zero());
+      this->apply (X, R, Teuchos::NO_TRANS, -STS::one(), STS::one());   
+    }      
+    
+
   private:
 
     /** Initialize with matrices except the Jacobian (don't compute the preconditioner)

--- a/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_decl.hpp
+++ b/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_decl.hpp
@@ -344,7 +344,7 @@ namespace MueLu {
                   const MultiVector & B,
                   MultiVector & R) const {
       using STS = Teuchos::ScalarTraits<Scalar>;
-      R.update(STS::one(),X,STS::zero());
+      R.update(STS::one(),B,STS::zero());
       this->apply (X, R, Teuchos::NO_TRANS, -STS::one(), STS::one());   
     }      
     

--- a/packages/muelu/adapters/xpetra/MueLu_XpetraOperator_decl.hpp
+++ b/packages/muelu/adapters/xpetra/MueLu_XpetraOperator_decl.hpp
@@ -140,6 +140,18 @@ namespace MueLu {
     }
 #endif
 
+    //! Compute a residual R = B - (*this) * X
+    void residual(const Xpetra::MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & X,
+                  const Xpetra::MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & B,
+                  Xpetra::MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & R) const {
+      using STS = Teuchos::ScalarTraits<Scalar>;
+      R.update(STS::one(),X,STS::zero());
+      this->apply (X, R, Teuchos::NO_TRANS, -STS::one(), STS::one());   
+    }      
+    
+
+
+
     //! @name MueLu specific
     //@{
 

--- a/packages/muelu/adapters/xpetra/MueLu_XpetraOperator_decl.hpp
+++ b/packages/muelu/adapters/xpetra/MueLu_XpetraOperator_decl.hpp
@@ -145,7 +145,7 @@ namespace MueLu {
                   const Xpetra::MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & B,
                   Xpetra::MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & R) const {
       using STS = Teuchos::ScalarTraits<Scalar>;
-      R.update(STS::one(),X,STS::zero());
+      R.update(STS::one(),B,STS::zero());
       this->apply (X, R, Teuchos::NO_TRANS, -STS::one(), STS::one());   
     }      
     

--- a/packages/muelu/src/Utils/MueLu_UtilitiesBase_decl.hpp
+++ b/packages/muelu/src/Utils/MueLu_UtilitiesBase_decl.hpp
@@ -358,11 +358,9 @@ namespace MueLu {
     static RCP<MultiVector> Residual(const Xpetra::Operator<Scalar,LocalOrdinal,GlobalOrdinal,Node>& Op, const MultiVector& X, const MultiVector& RHS) {
       TEUCHOS_TEST_FOR_EXCEPTION(X.getNumVectors() != RHS.getNumVectors(), Exceptions::RuntimeError, "Number of solution vectors != number of right-hand sides")
         const size_t numVecs = X.getNumVectors();
-        Scalar one = Teuchos::ScalarTraits<Scalar>::one(), negone = -one, zero = Teuchos::ScalarTraits<Scalar>::zero();
         // TODO Op.getRangeMap should return a BlockedMap if it is a BlockedCrsOperator
         RCP<MultiVector> RES = Xpetra::MultiVectorFactory<Scalar,LocalOrdinal,GlobalOrdinal,Node>::Build(RHS.getMap(), numVecs, false); // no need to initialize to zero
-        Op.apply(X, *RES, Teuchos::NO_TRANS, one, zero);
-        RES->update(one, RHS, negone);
+        Op.residual(X,RHS,*RES);
         return RES;
     }
     
@@ -370,10 +368,7 @@ namespace MueLu {
     static void Residual(const Xpetra::Operator<Scalar,LocalOrdinal,GlobalOrdinal,Node>& Op, const MultiVector& X, const MultiVector& RHS, MultiVector & Resid) {
       TEUCHOS_TEST_FOR_EXCEPTION(X.getNumVectors() != RHS.getNumVectors(), Exceptions::RuntimeError, "Number of solution vectors != number of right-hand sides");
       TEUCHOS_TEST_FOR_EXCEPTION(Resid.getNumVectors() != RHS.getNumVectors(), Exceptions::RuntimeError, "Number of residual vectors != number of right-hand sides");
-      Scalar one = Teuchos::ScalarTraits<Scalar>::one(), negone = -one, zero = Teuchos::ScalarTraits<Scalar>::zero();
-      // TODO Op.getRangeMap should return a BlockedMap if it is a BlockedCrsOperator
-      Op.apply(X, Resid, Teuchos::NO_TRANS, one, zero);
-      Resid.update(one, RHS, negone);
+      Op.residual(X,RHS,Resid);
     }
 
 

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -307,7 +307,7 @@ namespace Tpetra {
   /// Computes R = B - A * X 
   namespace Details {
     template<class SC, class LO, class GO, class NO>
-    void residual(const CrsMatrix<SC,LO,GO,NO> &   A,
+    void residual(const Operator<SC,LO,GO,NO> &   A,
                   const MultiVector<SC,LO,GO,NO> & X,
                   const MultiVector<SC,LO,GO,NO> & B,
                   MultiVector<SC,LO,GO,NO> & R);
@@ -864,9 +864,9 @@ namespace Tpetra {
 
     // This friend declaration allows for fused residual calculation
     template <class S2, class LO2, class GO2, class N2>
-    friend void Details::residual(const CrsMatrix<S2,LO2,GO2,N2> &   A,
-              const MultiVector<S2,LO2,GO2,N2> & X,
-              const MultiVector<S2,LO2,GO2,N2> & B,
+    friend void Details::residual(const Operator<S2,LO2,GO2,N2> &   A,
+                                  const MultiVector<S2,LO2,GO2,N2> & X,
+                                  const MultiVector<S2,LO2,GO2,N2> & B,
                                   MultiVector<S2,LO2,GO2,N2> & R);
 
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -303,6 +303,16 @@ namespace Tpetra {
                                                                typename CrsMatrixType::node_type> >& rangeMap,
                                   const Teuchos::RCP<Teuchos::ParameterList>& params);
 
+  /// \brief Nonmember function that computes a residual
+  /// Computes R = B - A * X 
+  namespace Details {
+    template<class SC, class LO, class GO, class NO>
+    void residual(const CrsMatrix<SC,LO,GO,NO> &   A,
+                  const MultiVector<SC,LO,GO,NO> & X,
+                  const MultiVector<SC,LO,GO,NO> & B,
+                  MultiVector<SC,LO,GO,NO> & R);
+  }
+
   /// \class CrsMatrix
   /// \brief Sparse matrix that presents a row-oriented interface that
   ///   lets users read or modify entries.
@@ -851,6 +861,13 @@ namespace Tpetra {
     // This friend declaration makes the clone() method work.
     template <class S2, class LO2, class GO2, class N2>
     friend class CrsMatrix;
+
+    // This friend declaration allows for fused residual calculation
+    template <class S2, class LO2, class GO2, class N2>
+    friend void Details::residual(const CrsMatrix<S2,LO2,GO2,N2> &   A,
+              const MultiVector<S2,LO2,GO2,N2> & X,
+              const MultiVector<S2,LO2,GO2,N2> & B,
+                                  MultiVector<S2,LO2,GO2,N2> & R);
 
 #ifdef TPETRA_ENABLE_DEPRECATED_CODE
     /// \brief Create a deep copy of this CrsMatrix, where the copy

--- a/packages/tpetra/core/src/Tpetra_Details_residual.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_residual.hpp
@@ -1,0 +1,266 @@
+// @HEADER
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services Package
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//
+// ************************************************************************
+// @HEADER
+
+#ifndef TPETRA_DETAILS_RESIDUAL_HPP
+#define TPETRA_DETAILS_RESIDUAL_HPP
+
+#include "TpetraCore_config.h"
+#include "Tpetra_CrsMatrix.hpp"
+#include "Tpetra_MultiVector.hpp"
+#include "Teuchos_RCP.hpp"
+#include "Tpetra_Details_Behavior.hpp"
+
+/// \file Tpetra_Details_residual.hpp
+/// \brief Functions that allow for fused residual calculation.
+/// \warning This file, and its contents, are implementation details
+///   of Tpetra.  The file itself or its contents may disappear or
+///   change at any time.
+
+namespace Tpetra {
+  namespace Details {
+
+template<class SC, class LO, class GO, class NO>
+void localResidual(const CrsMatrix<SC,LO,GO,NO> &   A,
+              const MultiVector<SC,LO,GO,NO> & X_in,
+              const MultiVector<SC,LO,GO,NO> & B,
+              MultiVector<SC,LO,GO,NO> & R_in) {
+   using Tpetra::Details::ProfilingRegion;
+    using Teuchos::NO_TRANS;
+    ProfilingRegion regionLocalApply ("Tpetra::CrsMatrix::localResidual");
+
+    auto X_lcl = X.getLocalViewDevice ();
+    auto Y_lcl = Y.getLocalViewDevice ();
+    // TODO (24 Jul 2019) uncomment later; this line of code wasn't
+    // here before, so we need to test it separately before pushing.
+    //
+    // Y.modify_device ();
+
+    const bool debug = ::Tpetra::Details::Behavior::debug ();
+    if (debug) {
+      const char tfecfFuncName[] = "localResidual: ";
+      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+        (A.lclMatrix_.get () == nullptr, std::logic_error,
+         "lclMatrix_ not created yet.");
+      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+        (X.getNumVectors () != Y.getNumVectors (), std::runtime_error,
+         "X.getNumVectors() = " << X.getNumVectors () << " != "
+         "Y.getNumVectors() = " << Y.getNumVectors () << ".");
+      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+        (X.getNumVectors () != R.getNumVectors (), std::runtime_error,
+         "X.getNumVectors() = " << X.getNumVectors () << " != "
+         "R.getNumVectors() = " << R.getNumVectors () << ".");
+
+      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+        (X.getLocalLength () !=
+         A.getColMap ()->getNodeNumElements (), std::runtime_error,
+         "X has the wrong number of local rows.  "
+         "X.getLocalLength() = " << X.getLocalLength () << " != "
+         "A.getColMap()->getNodeNumElements() = " <<
+         A.getColMap ()->getNodeNumElements () << ".");
+      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+        (R.getLocalLength () !=
+         A.getRowMap ()->getNodeNumElements (), std::runtime_error,
+         "R has the wrong number of local rows.  "
+         "R.getLocalLength() = " << R.getLocalLength () << " != "
+         "A.getRangeMap()->getNodeNumElements() = " <<
+         A.getRangeMap ()->getNodeNumElements () << ".");
+      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+        (B.getLocalLength () !=
+         A.getRowMap ()->getNodeNumElements (), std::runtime_error,
+         "B has the wrong number of local rows.  "
+         "B.getLocalLength() = " << B.getLocalLength () << " != "
+         "A.getRangeMap()->getNodeNumElements() = " <<
+         A.getRangeMap ()->getNodeNumElements () << ".");
+
+      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+        (! A.isFillComplete (), std::runtime_error, "The matrix A is not "
+         "fill complete.  You must call fillComplete() (possibly with "
+         "domain and range Map arguments) without an intervening "
+         "resumeFill() call before you may call this method.");
+
+      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+        (! X.isConstantStride () || ! R.isConstantStride () || ! B.isConstantStride () )
+         std::runtime_error, "X, Y and B must be constant stride.");
+      // If the two pointers are NULL, then they don't alias one
+      // another, even though they are equal.
+      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+        (X_lcl.data () == R_lcl.data () && X_lcl.data () != nullptr ||
+         X_lcl.data () == B_lcl.data () && X_lcl.data () != nullptr,
+         std::runtime_error, "X, Y and R may not alias one another.");
+    }
+
+    // This is currently a "reference implementation" waiting until Kokkos Kernels provides
+    // a residual kernel.
+    //    lclMatrix_->apply (X_lcl, Y_lcl, mode, alpha, beta);
+  }
+}
+
+//! Computes R = B - A * X 
+template<class SC, class LO, class GO, class NO>
+void residual(const CrsMatrix<SC,LO,GO,NO> &   A,
+              const MultiVector<SC,LO,GO,NO> & X_in,
+              const MultiVector<SC,LO,GO,NO> & B_in,
+              MultiVector<SC,LO,GO,NO> & R_in) {
+  using Tpetra::Details::ProfilingRegion;
+  using Teuchos::RCP;
+  using Teuchos::rcp;
+  using Teuchos::rcp_const_cast;
+  using Teuchos::rcpFromRef;
+  
+  // We treat the case of a replicated MV output specially.
+  const bool R_is_replicated =
+    (! R_in.isDistributed () && A.getComm ()->getSize () != 1);
+
+  // It's possible that R is a view of X or B.  
+  // We don't try to to detect the more subtle cases (e.g., one is a
+  // subview of the other, but their initial pointers differ).  We
+  // only need to do this if this matrix's Import is trivial;
+  // otherwise, we don't actually apply the operator from X into Y.
+  
+  RCP<const import_type> importer = A.getGraph ()->getImporter ();
+  RCP<const export_type> exporter = A.getGraph ()->getExporter ();
+
+  // Temporary MV for Import operation.  After the block of code
+  // below, this will be an (Imported if necessary) column Map MV
+  // ready to give to localApply(...).
+  RCP<const MV> X_colMap;
+  if (importer.is_null ()) {
+    if (! X_in.isConstantStride ()) {
+      // Not all sparse mat-vec kernels can handle an input MV with
+      // nonconstant stride correctly, so we have to copy it in that
+      // case into a constant stride MV.  To make a constant stride
+      // copy of X_in, we force creation of the column (== domain)
+      // Map MV (if it hasn't already been created, else fetch the
+      // cached copy).  This avoids creating a new MV each time.
+      RCP<MV> X_colMapNonConst = getColumnMapMultiVector (X_in, true);
+      Tpetra::deep_copy (*X_colMapNonConst, X_in);
+      X_colMap = rcp_const_cast<const MV> (X_colMapNonConst);
+    }
+    else {
+      // The domain and column Maps are the same, so do the local
+      // multiply using the domain Map input MV X_in.
+      X_colMap = rcpFromRef (X_in);
+    }
+  }
+  else { // need to Import source (multi)vector
+    ProfilingRegion regionImport ("Tpetra::CrsMatrix::residual: Import");
+    // We're doing an Import anyway, which will copy the relevant
+    // elements of the domain Map MV X_in into a separate column Map
+    // MV.  Thus, we don't have to worry whether X_in is constant
+    // stride.
+    RCP<MV> X_colMapNonConst = getColumnMapMultiVector (X_in);
+    
+    // Import from the domain Map MV to the column Map MV.
+    X_colMapNonConst->doImport (X_in, *importer, INSERT);
+    X_colMap = rcp_const_cast<const MV> (X_colMapNonConst);
+  }
+
+  // Temporary MV for doExport (if needed), or for copying a
+  // nonconstant stride output MV into a constant stride MV.  This
+  // is null if we don't need the temporary MV, that is, if the
+  // Export is trivial (null).
+  RCP<MV> R_rowMap = getRowMapMultiVector (R_in);
+
+  // FIXME: Need to get a potential cached buffer for B
+  RCP<MV> B_rowMap = getRowMapMultiVector2 (B_in);
+
+
+  // If we have a nontrivial Export object, we must perform an
+  // Export.  In that case, the local multiply result will go into
+  // the row Map multivector.  We don't have to make a
+  // constant-stride version of R_in in this case, because we had to
+  // make a constant stride R_rowMap MV and do an Export anyway.
+  if (! exporter.is_null ()) {
+    {
+      ProfilingRegion regionExport ("Tpetra::CrsMatrix::residual: B Import");
+      B_rowMap.doImport(*B_in, *exporter, ADD);
+    }
+
+    localResidual (A, *X_colMap, *B_rowMap, *R_rowMap);
+    
+    {
+      ProfilingRegion regionExport ("Tpetra::CrsMatrix::residual: R Export");
+      
+      // Do the Export operation.
+      R_in.doExport (*R_rowMap, *exporter, ADD);
+    }
+  }
+  else { // Don't do an Export: row Map and range Map are the same.
+    //
+    // If R_in does not have constant stride, or if the column Map
+    // MV aliases R_in, then we can't let the kernel write directly
+    // to R_in.  Instead, we have to use the cached row (== range)
+    // Map MV as temporary storage.
+    //
+    // FIXME (mfh 05 Jun 2014) This test for aliasing only tests if
+    // the user passed in the same MultiVector for both X and R.  It
+    // won't detect whether one MultiVector views the other.  We
+    // should also check the MultiVectors' raw data pointers.
+    if (! R_in.isConstantStride () || X_colMap.getRawPtr () == &R_in) {
+      // Force creating the MV if it hasn't been created already.
+      // This will reuse a previously created cached MV.
+      R_rowMap = getRowMapMultiVector (R_in, true);
+      // FIXME: Muck with this
+
+      Tpetra::deep_copy (*R_rowMap, R_in);
+      localResidual (A, *X_colMap, *B_rowMap, *R_rowMap);
+      Tpetra::deep_copy (R_in, *R_rowMap);
+    }
+    else {
+      localResidual (A, *X_colMap, *B_rowMap, *R_rowMap);
+    }
+  }
+
+  // If the range Map is a locally replicated Map, sum up
+  // contributions from each process. 
+  if (R_is_replicated) {
+    ProfilingRegion regionReduce ("Tpetra::CrsMatrix::residual: Reduce Y");
+    R_in.reduce ();
+  }
+}
+
+
+
+
+
+  } // namespace Details
+} // namespace Tpetra
+
+#endif // TPETRA_DETAILS_RESIDUAL_HPP

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_gaussSeidel.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_gaussSeidel.cpp
@@ -49,6 +49,7 @@
 #include <Tpetra_CrsMatrix.hpp>
 #include <Tpetra_Map.hpp>
 #include <Tpetra_Core.hpp>
+#include <Tpetra_Details_residual.hpp>
 #include <MatrixMarket_Tpetra.hpp>
 
 #include <Teuchos_Array.hpp>
@@ -426,8 +427,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( CrsMatrix, gaussSeidelSerial, LocalOrdinalTyp
   }
 
   // Compute initial residual R = B - A * X and ||R||_2.
-  matrix->apply (*X, *R); // R = A * X
-  R->update (STS::one(), *B, -STS::one()); // R = 1*B - 1*R
+  Tpetra::Details::residual(*matrix,*X,*B,*R);
   residNorms[0] = norm2 (*R);
 
   if (debug) {
@@ -499,8 +499,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( CrsMatrix, gaussSeidelSerial, LocalOrdinalTyp
 
     // Compute the new residual R = B - A * X.  This is not part of
     // Gauss-Seidel itself, but we use it to measure convergence.
-    matrix->apply (*X, *R); // R = A * X
-    R->update (STS::one(), *B, -STS::one()); // R = 1*B - 1*R
+    Tpetra::Details::residual(*matrix,*X,*B,*R);
     residNorms[iter+1] = norm2 (*R);
 
     X_norm = norm2 (*X);
@@ -832,8 +831,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( CrsMatrix, reorderedGaussSeidelSerial, LocalO
 
 
   // Compute initial residual R = B - A * X and ||R||_2.
-  matrix->apply (*X, *R); // R = A * X
-  R->update (STS::one(), *B, -STS::one()); // R = 1*B - 1*R
+  Tpetra::Details::residual(*matrix,*X,*B,*R);
   residNorms[0] = norm2 (*R);
 
   // Compute norms of X, D, and B.
@@ -892,8 +890,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( CrsMatrix, reorderedGaussSeidelSerial, LocalO
 
     // Compute the new residual R = B - A * X.  This is not part of
     // Gauss-Seidel itself, but we use it to measure convergence.
-    matrix->apply (*X, *R); // R = A * X
-    R->update (STS::one(), *B, -STS::one()); // R = 1*B - 1*R
+    Tpetra::Details::residual(*matrix,*X,*B,*R);
     residNorms[iter+1] = norm2 (*R);
 
     X_norm = norm2 (*X);

--- a/packages/xpetra/src/BlockedCrsMatrix/Xpetra_BlockedCrsMatrix.hpp
+++ b/packages/xpetra/src/BlockedCrsMatrix/Xpetra_BlockedCrsMatrix.hpp
@@ -1499,6 +1499,15 @@ namespace Xpetra {
     }
 #endif
 
+    //! Compute a residual R = B - (*this) * X
+    void residual(const MultiVector & X,
+                  const MultiVector & B,
+                  MultiVector & R) const {
+      using STS = Teuchos::ScalarTraits<Scalar>;
+      R.update(STS::one(),X,STS::zero());
+      this->apply (X, R, Teuchos::NO_TRANS, -STS::one(), STS::one());      
+    }
+    
   private:
 
     /** \name helper functions */
@@ -1572,7 +1581,6 @@ namespace Xpetra {
       // Set current view
       this->currentViewLabel_ = this->GetDefaultViewLabel();
     }
-
 
   private:
     bool is_diagonal_;   // If we're diagonal a bunch of the extraction stuff should work

--- a/packages/xpetra/src/BlockedCrsMatrix/Xpetra_BlockedCrsMatrix.hpp
+++ b/packages/xpetra/src/BlockedCrsMatrix/Xpetra_BlockedCrsMatrix.hpp
@@ -781,7 +781,6 @@ namespace Xpetra {
         return;
       }
       else if(is_diagonal_) {
-	//CMS
 	GlobalOrdinal gid = this->getRowMap()->getGlobalElement(LocalRow);
 	size_t row = getBlockedRangeMap()->getMapIndexForGID(gid);
 	getMatrix(row,row)->getLocalRowView(getMatrix(row,row)->getRowMap()->getLocalElement(gid),indices,values);

--- a/packages/xpetra/src/BlockedCrsMatrix/Xpetra_BlockedCrsMatrix.hpp
+++ b/packages/xpetra/src/BlockedCrsMatrix/Xpetra_BlockedCrsMatrix.hpp
@@ -1504,7 +1504,7 @@ namespace Xpetra {
                   const MultiVector & B,
                   MultiVector & R) const {
       using STS = Teuchos::ScalarTraits<Scalar>;
-      R.update(STS::one(),X,STS::zero());
+      R.update(STS::one(),B,STS::zero());
       this->apply (X, R, Teuchos::NO_TRANS, -STS::one(), STS::one());      
     }
     

--- a/packages/xpetra/src/CrsMatrix/Xpetra_CrsMatrix.hpp
+++ b/packages/xpetra/src/CrsMatrix/Xpetra_CrsMatrix.hpp
@@ -327,6 +327,11 @@ namespace Xpetra {
     //! Does this have an underlying matrix
     virtual bool hasMatrix() const = 0;
 
+    //! Compute a residual R = B - (*this) * X
+    virtual void residual(const MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & X,
+                          const MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & B,
+                          MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & R) const = 0;
+
 
   }; // CrsMatrix class
 

--- a/packages/xpetra/src/CrsMatrix/Xpetra_EpetraCrsMatrix.hpp
+++ b/packages/xpetra/src/CrsMatrix/Xpetra_EpetraCrsMatrix.hpp
@@ -259,7 +259,11 @@ public:
 
   void residual(const MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & X,
                 const MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & B,
-                MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & R) const;
+                MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & R) const{ 
+    Scalar one = Teuchos::ScalarTraits<Scalar>::one(), negone = -one;
+    apply(X,R);
+    R.update(one,B,negone);
+  }
 
 }; // EpetraCrsMatrixT class (specialization on GO=long, empty stub implementation)
 

--- a/packages/xpetra/src/CrsMatrix/Xpetra_EpetraCrsMatrix.hpp
+++ b/packages/xpetra/src/CrsMatrix/Xpetra_EpetraCrsMatrix.hpp
@@ -1242,8 +1242,9 @@ public:
                 const MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & B,
                 MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & R) const {
     Scalar one = Teuchos::ScalarTraits<Scalar>::one(), negone = -one;
+
     apply(X,R);
-    R.update(one,X,negone);
+    R.update(one,B,negone);
   }
 
 private:
@@ -2247,7 +2248,7 @@ public:
                 MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & R) const {
     Scalar one = Teuchos::ScalarTraits<Scalar>::one(), negone = -one;
     apply(X,R);
-    R.update(one,X,negone);
+    R.update(one,B,negone);
   }
 
 

--- a/packages/xpetra/src/CrsMatrix/Xpetra_EpetraCrsMatrix.hpp
+++ b/packages/xpetra/src/CrsMatrix/Xpetra_EpetraCrsMatrix.hpp
@@ -257,6 +257,10 @@ public:
 #endif
 #endif
 
+  void residual(const MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & X,
+                const MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & B,
+                MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & R) const;
+
 }; // EpetraCrsMatrixT class (specialization on GO=long, empty stub implementation)
 
 #ifndef XPETRA_EPETRA_NO_32BIT_GLOBAL_INDICES
@@ -1232,6 +1236,14 @@ public:
   {
     TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::RuntimeError,
                                "Xpetra::EpetraCrsMatrix::setAllValues is not implemented");
+  }
+
+  void residual(const MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & X,
+                const MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & B,
+                MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & R) const {
+    Scalar one = Teuchos::ScalarTraits<Scalar>::one(), negone = -one;
+    apply(X,R);
+    R.update(one,X,negone);
   }
 
 private:
@@ -2229,6 +2241,15 @@ public:
     TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::RuntimeError,
                                "Xpetra::EpetraCrsMatrix::setAllValues is not implemented");
   }
+
+  void residual(const MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & X,
+                const MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & B,
+                MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & R) const {
+    Scalar one = Teuchos::ScalarTraits<Scalar>::one(), negone = -one;
+    apply(X,R);
+    R.update(one,X,negone);
+  }
+
 
 private:
   mutable local_matrix_type localMatrix_;

--- a/packages/xpetra/src/CrsMatrix/Xpetra_TpetraBlockCrsMatrix_decl.hpp
+++ b/packages/xpetra/src/CrsMatrix/Xpetra_TpetraBlockCrsMatrix_decl.hpp
@@ -431,7 +431,7 @@ namespace Xpetra {
                   const MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & B,
                   MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & R) const {
       using STS = Teuchos::ScalarTraits<Scalar>;
-      R.update(STS::one(),X,STS::zero());
+      R.update(STS::one(),B,STS::zero());
       this->apply (X, R, Teuchos::NO_TRANS, -STS::one(), STS::one());   
     }      
     

--- a/packages/xpetra/src/CrsMatrix/Xpetra_TpetraBlockCrsMatrix_decl.hpp
+++ b/packages/xpetra/src/CrsMatrix/Xpetra_TpetraBlockCrsMatrix_decl.hpp
@@ -426,6 +426,18 @@ namespace Xpetra {
 #endif  // HAVE_XPETRA_TPETRA
 #endif  // HAVE_XPETRA_KOKKOS_REFACTOR
 
+    //! Compute a residual R = B - (*this) * X
+    void residual(const MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & X,
+                  const MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & B,
+                  MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & R) const {
+      using STS = Teuchos::ScalarTraits<Scalar>;
+      R.update(STS::one(),X,STS::zero());
+      this->apply (X, R, Teuchos::NO_TRANS, -STS::one(), STS::one());   
+    }      
+    
+
+
+
   private:
 
     RCP< Tpetra::BlockCrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > mtx_;

--- a/packages/xpetra/src/CrsMatrix/Xpetra_TpetraCrsMatrix_decl.hpp
+++ b/packages/xpetra/src/CrsMatrix/Xpetra_TpetraCrsMatrix_decl.hpp
@@ -438,6 +438,11 @@ namespace Xpetra {
 #endif
 #endif
 
+    //! Compute a residual R = B - (*this) * X
+    void residual(const MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & X,
+                  const MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & B,
+                  MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & R) const;
+    
    //@}
 
   private:
@@ -839,6 +844,11 @@ namespace Xpetra {
 #endif
 #endif
 
+    //! Compute a residual R = B - (*this) * X
+    void residual(const MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & X,
+                  const MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & B,
+                  MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & R) const { }
+    
    //@}
   }; // TpetraCrsMatrix class (specialization for GO=int, NO=EpetraNode)
 #endif
@@ -1234,6 +1244,11 @@ namespace Xpetra {
                        const typename local_matrix_type::values_type& val) {    }
 #endif
 #endif
+
+    //! Compute a residual R = B - (*this) * X
+    void residual(const MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & X,
+                  const MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & B,
+                  MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & R) const { }
 
    //@}
   }; // TpetraCrsMatrix class (specialization for GO=long long, NO=EpetraNode)

--- a/packages/xpetra/src/CrsMatrix/Xpetra_TpetraCrsMatrix_def.hpp
+++ b/packages/xpetra/src/CrsMatrix/Xpetra_TpetraCrsMatrix_def.hpp
@@ -47,6 +47,7 @@
 #define XPETRA_TPETRACRSMATRIX_DEF_HPP
 
 #include "Xpetra_TpetraCrsMatrix_decl.hpp"
+#include "Tpetra_Details_residual.hpp"
 
 namespace Xpetra {
 
@@ -464,6 +465,15 @@ namespace Xpetra {
     //! Get the underlying Tpetra matrix
     template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
     RCP<Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > TpetraCrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>::getTpetra_CrsMatrixNonConst() const { return mtx_; } //TODO: remove
+
+ //! Compute a residual R = B - (*this) * X
+  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  void TpetraCrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node>::residual(const MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & X,
+                                                                         const MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & B,
+                                                                         MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & R) const { 
+    Tpetra::Details::residual(*mtx_,toTpetra(X),toTpetra(B),toTpetra(R));
+  }
+
 
 ////////////////////////////////////////////
 ////////////////////////////////////////////

--- a/packages/xpetra/src/Operator/Xpetra_EpetraOperator.hpp
+++ b/packages/xpetra/src/Operator/Xpetra_EpetraOperator.hpp
@@ -161,7 +161,7 @@ namespace Xpetra {
                   const MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & B,
                   MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & R) const {
       using STS = Teuchos::ScalarTraits<Scalar>;
-      R.update(STS::one(),X,STS::zero());
+      R.update(STS::one(),B,STS::zero());
       this->apply (X, R, Teuchos::NO_TRANS, -STS::one(), STS::one());   
     }
     

--- a/packages/xpetra/src/Operator/Xpetra_EpetraOperator.hpp
+++ b/packages/xpetra/src/Operator/Xpetra_EpetraOperator.hpp
@@ -156,6 +156,15 @@ namespace Xpetra {
     //! EpetraOperator constructor to wrap a Epetra_Operator object
     EpetraOperator(const Teuchos::RCP<Epetra_Operator> &op) : op_(op) { } //TODO removed const
 
+    //! Compute a residual R = B - (*this) * X
+    void residual(const MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & X,
+                  const MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & B,
+                  MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & R) const {
+      using STS = Teuchos::ScalarTraits<Scalar>;
+      R.update(STS::one(),X,STS::zero());
+      this->apply (X, R, Teuchos::NO_TRANS, -STS::one(), STS::one());   
+    }
+    
     //@}
 
   private:

--- a/packages/xpetra/src/Operator/Xpetra_Operator.hpp
+++ b/packages/xpetra/src/Operator/Xpetra_Operator.hpp
@@ -114,6 +114,12 @@ namespace Xpetra {
     //@}
 
     virtual void removeEmptyProcessesInPlace(const RCP<const Map>& /* newMap */) { }
+
+    //! Compute a residual R = B - (*this) * X
+    virtual void residual(const MultiVector & X,
+                          const MultiVector & B,
+                          MultiVector& R) const = 0;
+
   };
 
 } // Xpetra namespace

--- a/packages/xpetra/src/Operator/Xpetra_TpetraOperator.hpp
+++ b/packages/xpetra/src/Operator/Xpetra_TpetraOperator.hpp
@@ -129,7 +129,7 @@ namespace Xpetra {
     void residual(const MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & X,
                   const MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & B,
                   MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & R) const {
-      Tpetra::Details::residual(*op,X,B,R);
+      Tpetra::Details::residual(*op_,X,B,R);
     }
 
 

--- a/packages/xpetra/src/Operator/Xpetra_TpetraOperator.hpp
+++ b/packages/xpetra/src/Operator/Xpetra_TpetraOperator.hpp
@@ -49,6 +49,7 @@
 #include "Xpetra_TpetraConfigDefs.hpp"
 
 #include <Tpetra_Operator.hpp>
+#include <Tpetra_Details_residual.hpp>
 
 #include "Xpetra_Map.hpp"
 #include "Xpetra_TpetraMap.hpp"
@@ -124,6 +125,14 @@ namespace Xpetra {
     //! Gets the operator out
     RCP<Tpetra::Operator< Scalar, LocalOrdinal, GlobalOrdinal, Node> > getOperator(){return op_;}
 
+    //! Compute a residual R = B - (*this) * X
+    void residual(const MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & X,
+                  const MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & B,
+                  MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & R) const {
+      Tpetra::Details::residual(*op,X,B,R);
+    }
+
+
     //@}
 
   private:
@@ -195,6 +204,10 @@ namespace Xpetra {
     //! Gets the operator out
     RCP<Tpetra::Operator< Scalar, LocalOrdinal, GlobalOrdinal, Node> > getOperator(){return Teuchos::null;}
 
+    void residual(const MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & X,
+                  const MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & B,
+                  MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & R) const {
+    }
 
   //@}
 
@@ -262,6 +275,11 @@ namespace Xpetra {
 
     //! Gets the operator out
     RCP<Tpetra::Operator< Scalar, LocalOrdinal, GlobalOrdinal, Node> > getOperator(){return Teuchos::null;}
+
+    void residual(const MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & X,
+                  const MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & B,
+                  MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & R) const {
+    }
     //@}
 
   }; // TpetraOperator class

--- a/packages/xpetra/sup/Matrix/Xpetra_CrsMatrixWrap_decl.hpp
+++ b/packages/xpetra/sup/Matrix/Xpetra_CrsMatrixWrap_decl.hpp
@@ -468,6 +468,13 @@ public:
 
   RCP<CrsMatrix> getCrsMatrix() const;
 
+
+  //! Compute a residual R = B - (*this) * X
+  void residual(const MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & X,
+                const MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & B,
+                MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & R) const;
+  
+
   //@}
 #ifdef XPETRA_ENABLE_DEPRECATED_CODE
   template<class Node2>

--- a/packages/xpetra/sup/Matrix/Xpetra_CrsMatrixWrap_def.hpp
+++ b/packages/xpetra/sup/Matrix/Xpetra_CrsMatrixWrap_def.hpp
@@ -491,6 +491,16 @@ namespace Xpetra {
     }
   }
 
+
+  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  void CrsMatrixWrap<Scalar,LocalOrdinal,GlobalOrdinal,Node>::residual(
+            const MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & X, 
+            const MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & B,
+            MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & R) const {
+    matrixData_->residual(X,B,R);
+  }
+
+
 } //namespace Xpetra
 
 #endif //ifndef XPETRA_CRSMATRIXWRAP_DEF_HPP

--- a/packages/xpetra/sup/Matrix/Xpetra_Matrix.hpp
+++ b/packages/xpetra/sup/Matrix/Xpetra_Matrix.hpp
@@ -599,6 +599,11 @@ namespace Xpetra {
 #endif
     // ----------------------------------------------------------------------------------
 
+    //! Compute a residual R = B - (*this) * X
+    virtual void residual(const MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & X,
+                          const MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & B,
+                          MultiVector< Scalar, LocalOrdinal, GlobalOrdinal, Node > & R) const = 0;
+
     protected:
       Teuchos::Hashtable<viewLabel_t, RCP<MatrixView> > operatorViewTable_; // hashtable storing the operator views (keys = view names, values = views).
 


### PR DESCRIPTION
Creates a Tpetra-level residual function with a placeholder implementation.  Percolates this through MueLu's Residual function as well as Ifpack2's Jacobi, Richardson and Chebyshev.

This function makes no change in existing code behavior, but is merely a code refactor allowing the next PR to implement at Tpetra-level fused residual kernel.

Testing(Tpetra): CrsMatrix_gaussSeidel.
Testing(MueLu): As this changes the innards of the Residual function, all of the Hierarchy & ParameterList tests exercise this guy.