### PR TITLE
ATDM: Do rebuilds by default for all ATDM Trilinos builds

### DIFF
--- a/cmake/ctest/drivers/atdm/TrilinosCTestDriverCore.atdm.cmake
+++ b/cmake/ctest/drivers/atdm/TrilinosCTestDriverCore.atdm.cmake
@@ -52,7 +52,7 @@ MACRO(TRILINOS_SYSTEM_SPECIFIC_CTEST_DRIVER)
     IF ("$ENV{ATDM_CONFIG_BUILD_COUNT}" GREATER "0")
       SET(CTEST_BUILD_FLAGS "-j$ENV{ATDM_CONFIG_BUILD_COUNT} ")
     ELSE()
-      SET(CTEST_BUILD_FLAGS "")
+      SET(CTEST_BUILD_FLAGS "")  # Use all cores!
     ENDIF()
     SET(CTEST_BUILD_FLAGS "${CTEST_BUILD_FLAGS}-k 999999")
   ELSE()
@@ -154,6 +154,9 @@ MACRO(TRILINOS_SYSTEM_SPECIFIC_CTEST_DRIVER)
     # for the number of new warnings, errors, tests, etc.
     SET(CTEST_SITE "$ENV{ATDM_CONFIG_CDASH_HOSTNAME}")
   ENDIF()
+
+  # Let's be brave and do all rebuilds (massively speed up build times)
+  SET(CTEST_START_WITH_EMPTY_BINARY_DIRECTORY FALSE)
 
   # Don't process any extra repos
   SET(Trilinos_EXTRAREPOS_FILE NONE)


### PR DESCRIPTION
This will massively speed up the build times and will also test to see how robust the Trilinos CMake build system is to rebuilds.

## How was this tested?

```
$ ssh ceerws1113

$ cd /scratch/rabartl/Trilinos.base/BUILDS/ATDM/SEMS-RHEL6/CTEST_S

$  env Trilinos_PACKAGES=Kokkos
    ./ctest-s-local-test-driver.sh sems-rhel6-gnu-7.2.0-openmp-release-debug
```

The log file showed:

````
-- CTEST_START_WITH_EMPTY_BINARY_DIRECTORY='FALSE'
````
