### PR TITLE
Sacado:  Add move semantics and fix GPU bug with new Fad design

### DIFF
--- a/packages/sacado/src/new_design/Sacado_Fad_Exp_DynamicStorage.hpp
+++ b/packages/sacado/src/new_design/Sacado_Fad_Exp_DynamicStorage.hpp
@@ -31,6 +31,7 @@
 #define SACADO_FAD_EXP_DYNAMICSTORAGE_HPP
 
 #include <type_traits>
+#include <utility>
 
 #include "Sacado_ConfigDefs.h"
 #include "Sacado_DynamicArrayTraits.hpp"
@@ -65,12 +66,12 @@ namespace Sacado {
       //! Default constructor
       KOKKOS_INLINE_FUNCTION
       DynamicStorage() :
-        val_(), sz_(0), len_(0), dx_(NULL) {}
+        val_(), sz_(0), len_(0), dx_(nullptr) {}
 
       //! Constructor with value
       KOKKOS_INLINE_FUNCTION
       DynamicStorage(const T & x) :
-        val_(x), sz_(0), len_(0), dx_(NULL) {}
+        val_(x), sz_(0), len_(0), dx_(nullptr) {}
 
       //! Constructor with size \c sz
       /*!
@@ -90,6 +91,15 @@ namespace Sacado {
       DynamicStorage(const DynamicStorage& x) :
         val_(x.val_), sz_(x.sz_), len_(x.sz_) {
         dx_ = ds_array<U>::get_and_fill(x.dx_, sz_);
+      }
+
+      //! Move constructor
+      KOKKOS_INLINE_FUNCTION
+      DynamicStorage(DynamicStorage&& x) :
+        val_(std::move(x.val_)), sz_(x.sz_), len_(x.len_), dx_(x.dx_) {
+        x.sz_ = 0;
+        x.len_ = 0;
+        x.dx_ = nullptr;
       }
 
       //! Destructor
@@ -117,6 +127,20 @@ namespace Sacado {
           }
           else
             ds_array<U>::copy(x.dx_, dx_, sz_);
+        }
+        return *this;
+      }
+
+      //! Move assignment
+      KOKKOS_INLINE_FUNCTION
+      DynamicStorage& operator=(DynamicStorage&& x) {
+        if (this != &x) {
+          if (len_ != 0)
+            ds_array<U>::destroy_and_release(dx_, len_);
+          val_ = std::move(x.val_);
+          sz_ = x.sz_; x.sz_ = 0;
+          len_ = x.len_; x.len_ = 0;
+          dx_ = x.dx_; x.dx_ = nullptr;
         }
         return *this;
       }

--- a/packages/sacado/src/new_design/Sacado_Fad_Exp_GeneralFad.hpp
+++ b/packages/sacado/src/new_design/Sacado_Fad_Exp_GeneralFad.hpp
@@ -126,6 +126,9 @@ namespace Sacado {
       //! Copy constructor
       GeneralFad(const GeneralFad& x) = default;
 
+      //! Move constructor
+      GeneralFad(GeneralFad&& x) = default;
+
       //! Copy constructor from any Expression object
       template <typename S>
       KOKKOS_INLINE_FUNCTION
@@ -218,6 +221,10 @@ namespace Sacado {
       //! Assignment with GeneralFad right-hand-side
       GeneralFad&
       operator=(const GeneralFad& x) = default;
+
+      //! Move assignment with GeneralFad right-hand-side
+      GeneralFad&
+      operator=(GeneralFad&& x) = default;
 
       //! Assignment operator with any expression right-hand-side
       template <typename S>

--- a/packages/sacado/src/new_design/Sacado_Fad_Exp_StaticFixedStorage.hpp
+++ b/packages/sacado/src/new_design/Sacado_Fad_Exp_StaticFixedStorage.hpp
@@ -31,6 +31,7 @@
 #define SACADO_FAD_EXP_STATICFIXEDSTORAGE_HPP
 
 #include <type_traits>
+#include <utility>
 
 #include "Sacado_ConfigDefs.h"
 #include "Sacado_StaticArrayTraits.hpp"
@@ -104,6 +105,14 @@ namespace Sacado {
            dx_[i] = x.dx_[i];
       }
 
+      //! Move constructor
+      KOKKOS_INLINE_FUNCTION
+      StaticFixedStorage(StaticFixedStorage&& x) :
+        val_(std::move(x.val_)) {
+         for (int i=0; i<Num; i++)
+           dx_[i] = std::move(x.dx_[i]);
+      }
+
       //! Destructor
       ~StaticFixedStorage() = default;
 
@@ -119,6 +128,17 @@ namespace Sacado {
           val_ = x.val_;
           for (int i=0; i<Num; i++)
             dx_[i] = x.dx_[i];
+        }
+        return *this;
+      }
+
+      //! Move assignment
+      KOKKOS_INLINE_FUNCTION
+      StaticFixedStorage& operator=(StaticFixedStorage&& x) {
+        if (this != &x) {
+          val_ = std::move(x.val_);
+          for (int i=0; i<Num; i++)
+            dx_[i] = std::move(x.dx_[i]);
         }
         return *this;
       }

--- a/packages/sacado/src/new_design/Sacado_Fad_Exp_StaticStorage.hpp
+++ b/packages/sacado/src/new_design/Sacado_Fad_Exp_StaticStorage.hpp
@@ -31,6 +31,7 @@
 #define SACADO_FAD_EXP_STATICSTORAGE_HPP
 
 #include <type_traits>
+#include <utility>
 
 #include "Sacado_ConfigDefs.h"
 #include "Sacado_StaticArrayTraits.hpp"
@@ -100,6 +101,14 @@ namespace Sacado {
           dx_[i] = x.dx_[i];
       }
 
+      //! Move constructor
+      KOKKOS_INLINE_FUNCTION
+      StaticStorage(StaticStorage&& x) :
+        val_(std::move(x.val_)), sz_(x.sz_) {
+        for (int i=0; i<sz_; i++)
+          dx_[i] = std::move(x.dx_[i]);
+      }
+
       //! Destructor
       KOKKOS_INLINE_FUNCTION
       ~StaticStorage() {}
@@ -113,6 +122,18 @@ namespace Sacado {
           //ss_array<T>::copy(x.dx_, dx_, sz_);
           for (int i=0; i<sz_; i++)
             dx_[i] = x.dx_[i];
+        }
+        return *this;
+      }
+
+      //! Move assignment
+      KOKKOS_INLINE_FUNCTION
+      StaticStorage& operator=(StaticStorage&& x) {
+        if (this != &x) {
+          val_ = std::move(x.val_);
+          sz_ = x.sz_;
+          for (int i=0; i<sz_; i++)
+            dx_[i] = std::move(x.dx_[i]);
         }
         return *this;
       }

--- a/packages/sacado/src/new_design/Sacado_Fad_Exp_VectorDynamicStorage.hpp
+++ b/packages/sacado/src/new_design/Sacado_Fad_Exp_VectorDynamicStorage.hpp
@@ -31,6 +31,7 @@
 #define SACADO_FAD_EXP_VECTORDYNAMICSTORAGE_HPP
 
 #include <type_traits>
+#include <utility>
 
 #include "Sacado_Traits.hpp"
 #include "Sacado_DynamicArrayTraits.hpp"
@@ -65,13 +66,15 @@ namespace Sacado {
       //! Default constructor
       KOKKOS_INLINE_FUNCTION
       VectorDynamicStorage() :
-        v_(), owns_mem(true), sz_(0), len_(0), stride_(1), val_(&v_), dx_(NULL)
+        v_(), owns_mem(true), sz_(0), len_(0), stride_(1), val_(&v_),
+        dx_(nullptr)
       {}
 
       //! Constructor with value
       KOKKOS_INLINE_FUNCTION
       VectorDynamicStorage(const T & x) :
-        v_(x), owns_mem(true), sz_(0), len_(0), stride_(1), val_(&v_), dx_(NULL)
+        v_(x), owns_mem(true), sz_(0), len_(0), stride_(1), val_(&v_),
+        dx_(nullptr)
       {}
 
       //! Constructor with size \c sz
@@ -104,6 +107,10 @@ namespace Sacado {
         stride_(1), val_(&v_)  {
         dx_ = ds_array<U>::strided_get_and_fill(x.dx_, x.stride_, sz_);
       }
+
+      // Move does not make sense for this storage since it is always tied to
+      // some preallocated data.  Don't define move constructor so compiler will
+      // always fall-back to copy
 
       //! Destructor
       KOKKOS_INLINE_FUNCTION
@@ -139,6 +146,10 @@ namespace Sacado {
         }
         return *this;
       }
+
+      // Move does not make sense for this storage since it is always tied to
+      // some preallocated data.  Don't define move assignment so compiler will
+      // always fall-back to copy
 
       //! Returns number of derivative components
       KOKKOS_INLINE_FUNCTION

--- a/packages/sacado/src/new_design/Sacado_Fad_Exp_ViewStorage.hpp
+++ b/packages/sacado/src/new_design/Sacado_Fad_Exp_ViewStorage.hpp
@@ -120,7 +120,11 @@ namespace Sacado {
       //! Assignment
       KOKKOS_INLINE_FUNCTION
       ViewStorage& operator=(const ViewStorage& x) {
-        if (this != std::addressof(x)) {
+        // Can't use std::addressof() on the GPU, so this is equivalent
+        // according to cppreference.com
+        if (this != reinterpret_cast<ViewStorage*>(
+              &const_cast<char&>(
+                reinterpret_cast<const volatile char&>(x)))) {
           *val_ = *x.val_;
           if (stride_one)
             for (int i=0; i<sz_.value; ++i)

--- a/packages/sacado/src/new_design/Sacado_Fad_Exp_ViewStorage.hpp
+++ b/packages/sacado/src/new_design/Sacado_Fad_Exp_ViewStorage.hpp
@@ -31,6 +31,7 @@
 #define SACADO_FAD_EXP_VIEWSTORAGE_HPP
 
 #include <type_traits>
+#include <utility>
 #include <memory>
 
 #include "Sacado_DynamicArrayTraits.hpp"
@@ -108,6 +109,10 @@ namespace Sacado {
       ViewStorage(const ViewStorage& x) :
         sz_(x.sz_), stride_(x.stride_), val_(x.val_), dx_(x.dx_) {}
 
+      // Move does not make sense for this storage since it is always tied to
+      // some preallocated data.  Don't define move constructor so compiler will
+      // always fall-back to copy
+
       //! Destructor
       KOKKOS_INLINE_FUNCTION
       ~ViewStorage() {}
@@ -126,6 +131,10 @@ namespace Sacado {
         }
         return *this;
       }
+
+      // Move does not make sense for this storage since it is always tied to
+      // some preallocated data.  Don't define move assignment so compiler will
+      // always fall-back to copy
 
       //! Returns number of derivative components
       KOKKOS_INLINE_FUNCTION

--- a/packages/sacado/test/UnitTests/CMakeLists.txt
+++ b/packages/sacado/test/UnitTests/CMakeLists.txt
@@ -317,4 +317,13 @@ IF (Sacado_ENABLE_TeuchosCore)
     NUM_MPI_PROCS 1
     STANDARD_PASS_OUTPUT
     )
+
+  TRIBITS_ADD_EXECUTABLE_AND_TEST(
+    MoveTests
+    SOURCES MoveTests.cpp
+    ARGS
+    COMM serial mpi
+    NUM_MPI_PROCS 1
+    STANDARD_PASS_OUTPUT
+    )
 ENDIF()

--- a/packages/sacado/test/UnitTests/MoveTests.cpp
+++ b/packages/sacado/test/UnitTests/MoveTests.cpp
@@ -1,0 +1,506 @@
+// @HEADER
+// ***********************************************************************
+//
+//                           Sacado Package
+//                 Copyright (2006) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// This library is free software; you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as
+// published by the Free Software Foundation; either version 2.1 of the
+// License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+// USA
+// Questions? Contact David M. Gay (dmgay@sandia.gov) or Eric T. Phipps
+// (etphipp@sandia.gov).
+//
+// ***********************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_UnitTestRepository.hpp"
+#include "Teuchos_GlobalMPISession.hpp"
+#include "Teuchos_TestingHelpers.hpp"
+
+#include "Sacado_No_Kokkos.hpp"
+
+#if SACADO_ENABLE_NEW_DESIGN
+#include "Sacado_Fad_Exp_DMFad.hpp"
+#include "Sacado_Fad_Exp_DVFad.hpp"
+#include "Sacado_Fad_Exp_ViewFad.hpp"
+
+// Size used for all Fad types
+const int global_fad_size = 10;
+
+//
+// Move constructor tests
+//
+
+TEUCHOS_UNIT_TEST( MoveConstructorTests, SFad )
+{
+  typedef double value_type;
+  typedef Sacado::Fad::Exp::SFad<value_type,global_fad_size> ad_type;
+  success = true;
+
+  // Initialize AD type
+  ad_type x(global_fad_size, value_type(1.5));
+  for (int i=0; i<global_fad_size; ++i)
+    x.fastAccessDx(i) = value_type(2.0+i);
+
+  // Move x into y
+  ad_type y = std::move(x);
+
+  // Check y is correct
+  TEST_EQUALITY_CONST( y.size(), global_fad_size );
+  TEST_EQUALITY_CONST( y.val(), value_type(1.5) );
+  for (int i=0; i<global_fad_size; ++i) {
+    TEST_EQUALITY_CONST( y.dx(i), value_type(2.0+i) );
+  }
+
+  // Check x is correct
+  TEST_EQUALITY_CONST( x.size(), global_fad_size );
+  TEST_EQUALITY_CONST( x.val(), value_type(1.5) );
+  TEST_INEQUALITY( x.dx(), y.dx() );
+  for (int i=0; i<global_fad_size; ++i) {
+    TEST_EQUALITY_CONST( x.dx(i), value_type(2.0+i) );
+  }
+}
+
+TEUCHOS_UNIT_TEST( MoveConstructorTests, SLFad )
+{
+  typedef double value_type;
+  typedef Sacado::Fad::Exp::SLFad<value_type,global_fad_size> ad_type;
+  success = true;
+
+  // Initialize AD type
+  ad_type x(global_fad_size, value_type(1.5));
+  for (int i=0; i<global_fad_size; ++i)
+    x.fastAccessDx(i) = value_type(2.0+i);
+
+  // Move x into y
+  ad_type y = std::move(x);
+
+  // Check y is correct
+  TEST_EQUALITY_CONST( y.size(), global_fad_size );
+  TEST_EQUALITY_CONST( y.val(), value_type(1.5) );
+  for (int i=0; i<global_fad_size; ++i) {
+    TEST_EQUALITY_CONST( y.dx(i), value_type(2.0+i) );
+  }
+
+  // Check x is correct
+  TEST_EQUALITY_CONST( x.size(), global_fad_size );
+  TEST_EQUALITY_CONST( x.val(), value_type(1.5) );
+  TEST_INEQUALITY( x.dx(), y.dx() );
+  for (int i=0; i<global_fad_size; ++i) {
+    TEST_EQUALITY_CONST( x.dx(i), value_type(2.0+i) );
+  }
+}
+
+TEUCHOS_UNIT_TEST( MoveConstructorTests, DFad )
+{
+  typedef double value_type;
+  typedef Sacado::Fad::Exp::DFad<value_type> ad_type;
+  success = true;
+
+  // Initialize AD type
+  ad_type x(global_fad_size, value_type(1.5));
+  for (int i=0; i<global_fad_size; ++i)
+    x.fastAccessDx(i) = value_type(2.0+i);
+
+  // Move x into y
+  ad_type y = std::move(x);
+
+  // Check y is correct
+  TEST_EQUALITY_CONST( y.size(), global_fad_size );
+  TEST_EQUALITY_CONST( y.val(), value_type(1.5) );
+  for (int i=0; i<global_fad_size; ++i) {
+    TEST_EQUALITY_CONST( y.dx(i), value_type(2.0+i) );
+  }
+
+  // Check x is correct
+  value_type *null_ptr = nullptr;
+  TEST_EQUALITY_CONST( x.size(), 0 );
+  TEST_EQUALITY_CONST( x.val(), value_type(1.5) );
+  TEST_EQUALITY( x.dx(), null_ptr );
+}
+
+TEUCHOS_UNIT_TEST( MoveConstructorTests, DMFad )
+{
+  typedef double value_type;
+  typedef Sacado::Fad::Exp::DMFad<value_type> ad_type;
+  success = true;
+
+  // Setup memory pool
+  Sacado::Fad::MemPoolManager<value_type> poolManager(100);
+  Sacado::Fad::MemPool *pool = poolManager.getMemoryPool(global_fad_size);
+  ad_type::setDefaultPool(pool);
+
+  // Initialize AD type
+  ad_type x(global_fad_size, value_type(1.5));
+  for (int i=0; i<global_fad_size; ++i)
+    x.fastAccessDx(i) = value_type(2.0+i);
+
+  // Move x into y
+  ad_type y = std::move(x);
+
+  // Check y is correct
+  TEST_EQUALITY_CONST( y.size(), global_fad_size );
+  TEST_EQUALITY_CONST( y.val(), value_type(1.5) );
+  for (int i=0; i<global_fad_size; ++i) {
+    TEST_EQUALITY_CONST( y.dx(i), value_type(2.0+i) );
+  }
+
+  // Check x is correct
+  value_type *null_ptr = nullptr;
+  TEST_EQUALITY_CONST( x.size(), 0 );
+  TEST_EQUALITY_CONST( x.val(), value_type(1.5) );
+  TEST_EQUALITY_CONST( x.dx(), null_ptr );
+}
+
+TEUCHOS_UNIT_TEST( MoveConstructorTests, DVFad_Owned )
+{
+  typedef double value_type;
+  typedef Sacado::Fad::Exp::DVFad<value_type> ad_type;
+  success = true;
+
+  // Initialize AD type
+  ad_type x(global_fad_size, value_type(1.5));
+  for (int i=0; i<global_fad_size; ++i)
+    x.fastAccessDx(i) = value_type(2.0+i);
+
+  // Move x into y
+  ad_type y = std::move(x);
+
+  // Check y is correct
+  TEST_EQUALITY_CONST( y.size(), global_fad_size );
+  TEST_EQUALITY_CONST( y.val(), value_type(1.5) );
+  for (int i=0; i<global_fad_size; ++i) {
+    TEST_EQUALITY_CONST( y.dx(i), value_type(2.0+i) );
+  }
+
+  // Check x is correct
+  TEST_EQUALITY_CONST( x.size(), global_fad_size );
+  TEST_EQUALITY_CONST( x.val(), value_type(1.5) );
+  TEST_INEQUALITY( x.dx(), y.dx() );
+  for (int i=0; i<global_fad_size; ++i) {
+    TEST_EQUALITY_CONST( x.dx(i), value_type(2.0+i) );
+  }
+}
+
+TEUCHOS_UNIT_TEST( MoveConstructorTests, DVFad_Unowned )
+{
+  typedef double value_type;
+  typedef Sacado::Fad::Exp::DVFad<value_type> ad_type;
+  success = true;
+
+  // Initialize AD type
+  value_type x_val = value_type(1.5);
+  std::vector<value_type> x_dx(global_fad_size);
+  for (int i=0; i<global_fad_size; ++i)
+    x_dx[i] = value_type(2.0+i);
+  ad_type x(global_fad_size, &x_val, x_dx.data(), 1, false);
+
+  // Move x into y
+  ad_type y = std::move(x);
+
+  // Check y is correct
+  TEST_EQUALITY_CONST( y.size(), global_fad_size );
+  TEST_EQUALITY_CONST( y.val(), value_type(1.5) );
+  for (int i=0; i<global_fad_size; ++i) {
+    TEST_EQUALITY_CONST( y.dx(i), value_type(2.0+i) );
+  }
+
+  // Check x is correct
+  TEST_EQUALITY_CONST( x.size(), global_fad_size );
+  TEST_EQUALITY_CONST( x.val(), value_type(1.5) );
+  TEST_INEQUALITY( x.dx(), y.dx() );
+  for (int i=0; i<global_fad_size; ++i) {
+    TEST_EQUALITY_CONST( x.dx(i), value_type(2.0+i) );
+  }
+}
+
+TEUCHOS_UNIT_TEST( MoveConstructorTests, ViewFad )
+{
+  typedef double value_type;
+  typedef Sacado::Fad::Exp::DFad<value_type> dfad_type;
+  typedef Sacado::Fad::Exp::ViewFad<value_type,0,1,dfad_type> ad_type;
+  success = true;
+
+  // Initialize AD type
+  value_type x_val = value_type(1.5);
+  std::vector<value_type> x_dx(global_fad_size);
+  for (int i=0; i<global_fad_size; ++i)
+    x_dx[i] = value_type(2.0+i);
+  ad_type x(x_dx.data(), &x_val, global_fad_size, 1);
+
+  // Move x into y
+  ad_type y = std::move(x);
+
+  // Check y is correct
+  TEST_EQUALITY_CONST( y.size(), global_fad_size );
+  TEST_EQUALITY_CONST( y.val(), value_type(1.5) );
+  TEST_EQUALITY( y.dx(), x_dx.data() );
+  for (int i=0; i<global_fad_size; ++i) {
+    TEST_EQUALITY_CONST( y.dx(i), value_type(2.0+i) );
+  }
+
+  // Check x is correct
+  TEST_EQUALITY_CONST( x.size(), global_fad_size );
+  TEST_EQUALITY_CONST( x.val(), value_type(1.5) );
+  TEST_EQUALITY( x.dx(), x_dx.data() );
+  for (int i=0; i<global_fad_size; ++i) {
+    TEST_EQUALITY_CONST( x.dx(i), value_type(2.0+i) );
+  }
+}
+
+//
+// Move assignment tests
+//
+
+TEUCHOS_UNIT_TEST( MoveAssignmentTests, SFad )
+{
+  typedef double value_type;
+  typedef Sacado::Fad::Exp::SFad<value_type,global_fad_size> ad_type;
+  success = true;
+
+  // Initialize AD type
+  ad_type x(global_fad_size, value_type(1.5));
+  for (int i=0; i<global_fad_size; ++i)
+    x.fastAccessDx(i) = value_type(2.0+i);
+
+  // Move x into y
+  ad_type y(0.5);
+  y = std::move(x);
+
+  // Check y is correct
+  TEST_EQUALITY_CONST( y.size(), global_fad_size );
+  TEST_EQUALITY_CONST( y.val(), value_type(1.5) );
+  for (int i=0; i<global_fad_size; ++i) {
+    TEST_EQUALITY_CONST( y.dx(i), value_type(2.0+i) );
+  }
+
+  // Check x is correct
+  TEST_EQUALITY_CONST( x.size(), global_fad_size );
+  TEST_EQUALITY_CONST( x.val(), value_type(1.5) );
+  TEST_INEQUALITY( x.dx(), y.dx() );
+  for (int i=0; i<global_fad_size; ++i) {
+    TEST_EQUALITY_CONST( x.dx(i), value_type(2.0+i) );
+  }
+}
+
+TEUCHOS_UNIT_TEST( MoveAssignmentTests, SLFad )
+{
+  typedef double value_type;
+  typedef Sacado::Fad::Exp::SLFad<value_type,global_fad_size> ad_type;
+  success = true;
+
+  // Initialize AD type
+  ad_type x(global_fad_size, value_type(1.5));
+  for (int i=0; i<global_fad_size; ++i)
+    x.fastAccessDx(i) = value_type(2.0+i);
+
+  // Move x into y
+  ad_type y(0.5);
+  y = std::move(x);
+
+  // Check y is correct
+  TEST_EQUALITY_CONST( y.size(), global_fad_size );
+  TEST_EQUALITY_CONST( y.val(), value_type(1.5) );
+  for (int i=0; i<global_fad_size; ++i) {
+    TEST_EQUALITY_CONST( y.dx(i), value_type(2.0+i) );
+  }
+
+  // Check x is correct
+  TEST_EQUALITY_CONST( x.size(), global_fad_size );
+  TEST_EQUALITY_CONST( x.val(), value_type(1.5) );
+  TEST_INEQUALITY( x.dx(), y.dx() );
+  for (int i=0; i<global_fad_size; ++i) {
+    TEST_EQUALITY_CONST( x.dx(i), value_type(2.0+i) );
+  }
+}
+
+TEUCHOS_UNIT_TEST( MoveAssignmentTests, DFad )
+{
+  typedef double value_type;
+  typedef Sacado::Fad::Exp::DFad<value_type> ad_type;
+  success = true;
+
+  // Initialize AD type
+  ad_type x(global_fad_size, value_type(1.5));
+  for (int i=0; i<global_fad_size; ++i)
+    x.fastAccessDx(i) = value_type(2.0+i);
+
+  // Move x into y
+  ad_type y(0.5);
+  y = std::move(x);
+
+  // Check y is correct
+  TEST_EQUALITY_CONST( y.size(), global_fad_size );
+  TEST_EQUALITY_CONST( y.val(), value_type(1.5) );
+  for (int i=0; i<global_fad_size; ++i) {
+    TEST_EQUALITY_CONST( y.dx(i), value_type(2.0+i) );
+  }
+
+  // Check x is correct
+  value_type *null_ptr = nullptr;
+  TEST_EQUALITY_CONST( x.size(), 0 );
+  TEST_EQUALITY_CONST( x.val(), value_type(1.5) );
+  TEST_EQUALITY( x.dx(), null_ptr );
+}
+
+TEUCHOS_UNIT_TEST( MoveAssignmentTests, DMFad )
+{
+  typedef double value_type;
+  typedef Sacado::Fad::Exp::DMFad<value_type> ad_type;
+  success = true;
+
+  // Setup memory pool
+  Sacado::Fad::MemPoolManager<value_type> poolManager(100);
+  Sacado::Fad::MemPool *pool = poolManager.getMemoryPool(global_fad_size);
+  ad_type::setDefaultPool(pool);
+
+  // Initialize AD type
+  ad_type x(global_fad_size, value_type(1.5));
+  for (int i=0; i<global_fad_size; ++i)
+    x.fastAccessDx(i) = value_type(2.0+i);
+
+  // Move x into y
+  ad_type y(0.5);
+  y = std::move(x);
+
+  // Check y is correct
+  TEST_EQUALITY_CONST( y.size(), global_fad_size );
+  TEST_EQUALITY_CONST( y.val(), value_type(1.5) );
+  for (int i=0; i<global_fad_size; ++i) {
+    TEST_EQUALITY_CONST( y.dx(i), value_type(2.0+i) );
+  }
+
+  // Check x is correct
+  value_type *null_ptr = nullptr;
+  TEST_EQUALITY_CONST( x.size(), 0 );
+  TEST_EQUALITY_CONST( x.val(), value_type(1.5) );
+  TEST_EQUALITY_CONST( x.dx(), null_ptr );
+}
+
+TEUCHOS_UNIT_TEST( MoveAssignmentTests, DVFad_Owned )
+{
+  typedef double value_type;
+  typedef Sacado::Fad::Exp::DVFad<value_type> ad_type;
+  success = true;
+
+  // Initialize AD type
+  ad_type x(global_fad_size, value_type(1.5));
+  for (int i=0; i<global_fad_size; ++i)
+    x.fastAccessDx(i) = value_type(2.0+i);
+
+  // Move x into y
+  ad_type y(0.5);
+  y = std::move(x);
+
+  // Check y is correct
+  TEST_EQUALITY_CONST( y.size(), global_fad_size );
+  TEST_EQUALITY_CONST( y.val(), value_type(1.5) );
+  for (int i=0; i<global_fad_size; ++i) {
+    TEST_EQUALITY_CONST( y.dx(i), value_type(2.0+i) );
+  }
+
+  // Check x is correct
+  TEST_EQUALITY_CONST( x.size(), global_fad_size );
+  TEST_EQUALITY_CONST( x.val(), value_type(1.5) );
+  TEST_INEQUALITY( x.dx(), y.dx() );
+  for (int i=0; i<global_fad_size; ++i) {
+    TEST_EQUALITY_CONST( x.dx(i), value_type(2.0+i) );
+  }
+}
+
+TEUCHOS_UNIT_TEST( MoveAssignmentTests, DVFad_Unowned )
+{
+  typedef double value_type;
+  typedef Sacado::Fad::Exp::DVFad<value_type> ad_type;
+  success = true;
+
+  // Initialize AD type
+  value_type x_val = value_type(1.5);
+  std::vector<value_type> x_dx(global_fad_size);
+  for (int i=0; i<global_fad_size; ++i)
+    x_dx[i] = value_type(2.0+i);
+  ad_type x(global_fad_size, &x_val, x_dx.data(), 1, false);
+
+  // Move x into y
+  ad_type y(0.5);
+  y = std::move(x);
+
+  // Check y is correct
+  TEST_EQUALITY_CONST( y.size(), global_fad_size );
+  TEST_EQUALITY_CONST( y.val(), value_type(1.5) );
+  for (int i=0; i<global_fad_size; ++i) {
+    TEST_EQUALITY_CONST( y.dx(i), value_type(2.0+i) );
+  }
+
+  // Check x is correct
+  TEST_EQUALITY_CONST( x.size(), global_fad_size );
+  TEST_EQUALITY_CONST( x.val(), value_type(1.5) );
+  TEST_INEQUALITY( x.dx(), y.dx() );
+  for (int i=0; i<global_fad_size; ++i) {
+    TEST_EQUALITY_CONST( x.dx(i), value_type(2.0+i) );
+  }
+}
+
+TEUCHOS_UNIT_TEST( MoveAssignmentTests, ViewFad )
+{
+  typedef double value_type;
+  typedef Sacado::Fad::Exp::DFad<value_type> dfad_type;
+  typedef Sacado::Fad::Exp::ViewFad<value_type,0,1,dfad_type> ad_type;
+  success = true;
+
+  // Initialize AD type
+  value_type x_val = value_type(1.5);
+  std::vector<value_type> x_dx(global_fad_size);
+  for (int i=0; i<global_fad_size; ++i)
+    x_dx[i] = value_type(2.0+i);
+  ad_type x(x_dx.data(), &x_val, global_fad_size, 1);
+
+  // Move x into y
+  value_type y_val = value_type(0.5);
+  std::vector<value_type> y_dx(global_fad_size);
+  for (int i=0; i<global_fad_size; ++i)
+    y_dx[i] = value_type(20.0+i);
+  ad_type y(y_dx.data(), &y_val, global_fad_size, 1);
+  y = std::move(x);
+
+  // Check y is correct
+  TEST_EQUALITY_CONST( y.size(), global_fad_size );
+  TEST_EQUALITY_CONST( y.val(), value_type(1.5) );
+  TEST_EQUALITY( y.dx(), y_dx.data() );
+  for (int i=0; i<global_fad_size; ++i) {
+    TEST_EQUALITY_CONST( y.dx(i), value_type(2.0+i) );
+  }
+
+  // Check x is correct
+  TEST_EQUALITY_CONST( x.size(), global_fad_size );
+  TEST_EQUALITY_CONST( x.val(), value_type(1.5) );
+  TEST_EQUALITY( x.dx(), x_dx.data() );
+  for (int i=0; i<global_fad_size; ++i) {
+    TEST_EQUALITY_CONST( x.dx(i), value_type(2.0+i) );
+  }
+}
+
+template <>
+Sacado::Fad::MemPool* Sacado::Fad::Exp::MemPoolStorage<double>::defaultPool_ = nullptr;
+
+#endif
+
+int main( int argc, char* argv[] ) {
+  Teuchos::GlobalMPISession mpiSession(&argc, &argv);
+  return Teuchos::UnitTestRepository::runUnitTestsFromMain(argc, argv);
+}


### PR DESCRIPTION
Adds move constructors/assignment operators to new Fad design, and associated tests.  Also removes use of std::addressof() in the new Fad design which is problematic on the GPU.