### PR TITLE
Tpetra/MueLu: switched performance tests to StackedTimer

### DIFF
--- a/packages/muelu/test/scaling/MatrixMatrixMultiply.cpp
+++ b/packages/muelu/test/scaling/MatrixMatrixMultiply.cpp
@@ -98,6 +98,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib &lib, int ar
   using Teuchos::rcp;
   using Teuchos::Time;
   using Teuchos::TimeMonitor;
+  using Teuchos::StackedTimer;
   using namespace MueLuTests;
 
   RCP< const Teuchos::Comm<int> > comm = Teuchos::DefaultComm<int>::getComm();

--- a/packages/tpetra/core/example/Finite-Element-Assembly/CMakeLists.txt
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/CMakeLists.txt
@@ -98,7 +98,7 @@ ENDIF()
 TRIBITS_ADD_TEST(
   FEMAssembly
   NAME Performance_StrongScaling_FEMAssembly_InsertGlobalIndicesFESPKokkos
-  ARGS "--with-insert-global-indices-fe --with-StaticProfile --num-elements-x=480 --num-elements-y=480 --kokkos"
+  ARGS "--with-insert-global-indices-fe --with-StaticProfile --num-elements-x=8192 --num-elements-y=8192 --kokkos"
   COMM mpi
   NUM_MPI_PROCS 1
   STANDARD_PASS_OUTPUT
@@ -109,7 +109,7 @@ TRIBITS_ADD_TEST(
 TRIBITS_ADD_TEST(
   FEMAssembly
   NAME Performance_StrongScaling_FEMAssembly_InsertGlobalIndicesFESPKokkos
-  ARGS "--with-insert-global-indices-fe --with-StaticProfile --num-elements-x=480 --num-elements-y=480 --kokkos"
+  ARGS "--with-insert-global-indices-fe --with-StaticProfile --num-elements-x=8192 --num-elements-y=8192 --kokkos"
   COMM mpi
   NUM_MPI_PROCS 4
   STANDARD_PASS_OUTPUT
@@ -120,7 +120,7 @@ TRIBITS_ADD_TEST(
 TRIBITS_ADD_TEST(
   FEMAssembly
   NAME Performance_StrongScaling_FEMAssembly_InsertGlobalIndicesFESPKokkos
-  ARGS "--with-insert-global-indices-fe --with-StaticProfile --num-elements-x=480 --num-elements-y=480 --kokkos"
+  ARGS "--with-insert-global-indices-fe --with-StaticProfile --num-elements-x=8192 --num-elements-y=8192 --kokkos"
   COMM mpi
   NUM_MPI_PROCS 9
   STANDARD_PASS_OUTPUT
@@ -131,7 +131,7 @@ TRIBITS_ADD_TEST(
 TRIBITS_ADD_TEST(
   FEMAssembly
   NAME Performance_StrongScaling_FEMAssembly_InsertGlobalIndicesFESPKokkos
-  ARGS "--with-insert-global-indices-fe --with-StaticProfile --num-elements-x=480 --num-elements-y=480 --kokkos"
+  ARGS "--with-insert-global-indices-fe --with-StaticProfile --num-elements-x=8192 --num-elements-y=8192 --kokkos"
   COMM mpi
   NUM_MPI_PROCS 16
   STANDARD_PASS_OUTPUT
@@ -142,7 +142,7 @@ TRIBITS_ADD_TEST(
 TRIBITS_ADD_TEST(
   FEMAssembly
   NAME Performance_StrongScaling_FEMAssembly_InsertGlobalIndicesFESPKokkos
-  ARGS "--with-insert-global-indices-fe --with-StaticProfile --num-elements-x=480 --num-elements-y=480 --kokkos"
+  ARGS "--with-insert-global-indices-fe --with-StaticProfile --num-elements-x=8192 --num-elements-y=8192 --kokkos"
   COMM mpi
   NUM_MPI_PROCS 25
   STANDARD_PASS_OUTPUT

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_InsertGlobalIndices_DP.hpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_InsertGlobalIndices_DP.hpp
@@ -144,7 +144,7 @@ int executeInsertGlobalIndicesDP_(const Teuchos::RCP<const Teuchos::Comm<int> >&
 
   auto owned_element_to_node_ids = mesh.getOwnedElementToNode();
 
-  RCP<TimeMonitor> timerGlobal = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("X) Global")));
+  Teuchos::TimeMonitor::getStackedTimer()->startBaseTimer();
   RCP<TimeMonitor> timerElementLoopGraph = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("1) ElementLoop  (Graph)")));
 
   RCP<crs_graph_type> crs_graph = rcp(new crs_graph_type(row_map, 0));
@@ -279,7 +279,7 @@ int executeInsertGlobalIndicesDP_(const Teuchos::RCP<const Teuchos::Comm<int> >&
   }
 
 
-  timerGlobal = Teuchos::null;
+  Teuchos::TimeMonitor::getStackedTimer()->stopBaseTimer();
 
   // Print out crs_matrix details.
   if(opts.verbose) crs_matrix->describe(out, Teuchos::VERB_EXTREME);

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_InsertGlobalIndices_FE_SP.hpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_InsertGlobalIndices_FE_SP.hpp
@@ -158,7 +158,7 @@ int executeInsertGlobalIndicesFESP_(const Teuchos::RCP<const Teuchos::Comm<int> 
 
   auto owned_element_to_node_ids = mesh.getOwnedElementToNode();
 
-  RCP<TimeMonitor> timerGlobal = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("X) Global")));
+  Teuchos::TimeMonitor::getStackedTimer()->startBaseTimer();
   RCP<TimeMonitor> timerElementLoopGraph = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("1) ElementLoop  (Graph)")));
 
   RCP<fe_graph_type> fe_graph = rcp(new fe_graph_type(row_map, owned_plus_shared_map, 16));
@@ -301,8 +301,7 @@ int executeInsertGlobalIndicesFESP_(const Teuchos::RCP<const Teuchos::Comm<int> 
     Tpetra::endFill(*rhs);
   }
 
-
-  timerGlobal = Teuchos::null;
+  Teuchos::TimeMonitor::getStackedTimer()->stopBaseTimer();
 
   // Print out fe_matrix details.
   if(opts.verbose) fe_matrix->describe(out, Teuchos::VERB_EXTREME);
@@ -379,7 +378,7 @@ int executeInsertGlobalIndicesFESPKokkos_(const Teuchos::RCP<const Teuchos::Comm
 
   auto owned_element_to_node_ids = mesh.getOwnedElementToNode();
 
-  RCP<TimeMonitor> timerGlobal = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("X) Global")));
+  Teuchos::TimeMonitor::getStackedTimer()->startBaseTimer();
 
   RCP<fe_graph_type> fe_graph =
     rcp (new fe_graph_type (row_map, owned_plus_shared_map, 16));
@@ -544,8 +543,7 @@ int executeInsertGlobalIndicesFESPKokkos_(const Teuchos::RCP<const Teuchos::Comm
     Tpetra::endFill(*rhs);
   }
 
-
-  timerGlobal = Teuchos::null;
+  Teuchos::TimeMonitor::getStackedTimer()->stopBaseTimer();
 
   // Print out fe_matrix details.
   if(opts.verbose) fe_matrix->describe(out, Teuchos::VERB_EXTREME);

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_LocalElementLoop_DP.hpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_LocalElementLoop_DP.hpp
@@ -148,7 +148,7 @@ int executeLocalElementLoopDP_(const Teuchos::RCP<const Teuchos::Comm<int> >& co
 
   auto owned_element_to_node_ids = mesh.getOwnedElementToNode();
 
-  RCP<TimeMonitor> timerGlobal = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("X) Global")));
+  Teuchos::TimeMonitor::getStackedTimer()->startBaseTimer();
   RCP<TimeMonitor> timerElementLoopGraph = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("1) ElementLoop  (All Graph)")));
 
   // Type-2 Assembly distinguishes owned and overlapping nodes.
@@ -335,7 +335,7 @@ int executeLocalElementLoopDP_(const Teuchos::RCP<const Teuchos::Comm<int> >& co
     crs_matrix_owned->fillComplete();
   }
 
-  timerGlobal = Teuchos::null;
+  Teuchos::TimeMonitor::getStackedTimer()->stopBaseTimer();
 
   // Print out crs_matrix_owned and crs_matrix_overlapping details.
   if(opts.verbose)
@@ -414,7 +414,7 @@ int executeLocalElementLoopDPKokkos_(const Teuchos::RCP<const Teuchos::Comm<int>
 
   auto owned_element_to_node_ids = mesh.getOwnedElementToNode();
 
-  RCP<TimeMonitor> timerGlobal = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("X) Global")));
+  Teuchos::TimeMonitor::getStackedTimer()->startBaseTimer();
   RCP<TimeMonitor> timerElementLoopGraph = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("1) ElementLoop  (All Graph)")));
 
   // Type-2 Assembly distinguishes owned and overlapping nodes.
@@ -622,7 +622,7 @@ int executeLocalElementLoopDPKokkos_(const Teuchos::RCP<const Teuchos::Comm<int>
     crs_matrix_owned->fillComplete();
   }
 
-  timerGlobal = Teuchos::null;
+  Teuchos::TimeMonitor::getStackedTimer()->stopBaseTimer();
 
   // Print out crs_matrix_owned and crs_matrix_overlapping details.
   if(opts.verbose)

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_TotalElementLoop_DP.hpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_TotalElementLoop_DP.hpp
@@ -144,7 +144,7 @@ int executeTotalElementLoopDP_(const Teuchos::RCP<const Teuchos::Comm<int> >& co
   auto owned_element_to_node_ids = mesh.getOwnedElementToNode();
   auto ghost_element_to_node_ids = mesh.getGhostElementToNode();
 
-  RCP<TimeMonitor> timerGlobal = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("X) Global")));
+  Teuchos::TimeMonitor::getStackedTimer()->startBaseTimer();
   RCP<TimeMonitor> timerElementLoopGraph = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("1) ElementLoop  (Graph)")));
 
   RCP<crs_graph_type> crs_graph = rcp(new crs_graph_type(row_map, 0));
@@ -333,7 +333,7 @@ int executeTotalElementLoopDP_(const Teuchos::RCP<const Teuchos::Comm<int> >& co
     crs_matrix->fillComplete();
   }
 
-  timerGlobal = Teuchos::null;
+  Teuchos::TimeMonitor::getStackedTimer()->stopBaseTimer();
 
   // Print out crs_matrix details.
   if(opts.verbose) crs_matrix->describe(out, Teuchos::VERB_EXTREME);

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_TotalElementLoop_SP.hpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_TotalElementLoop_SP.hpp
@@ -152,7 +152,7 @@ int executeTotalElementLoopSP_(const Teuchos::RCP<const Teuchos::Comm<int> >& co
   auto owned_element_to_node_ids = mesh.getOwnedElementToNode();
   auto ghost_element_to_node_ids = mesh.getGhostElementToNode();
 
-  RCP<TimeMonitor> timerGlobal = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("X) Global")));
+  Teuchos::TimeMonitor::getStackedTimer()->startBaseTimer();
   RCP<TimeMonitor> timerElementLoopGraph = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("1) ElementLoop  (Graph)")));
 
   RCP<crs_graph_type> crs_graph = rcp(new crs_graph_type(row_map, maxEntriesPerRow, Tpetra::StaticProfile));
@@ -353,7 +353,7 @@ int executeTotalElementLoopSP_(const Teuchos::RCP<const Teuchos::Comm<int> >& co
     crs_matrix.describe (out, Teuchos::VERB_EXTREME);
   }
 
-  timerGlobal = Teuchos::null;
+  Teuchos::TimeMonitor::getStackedTimer()->stopBaseTimer();
 
   // Save crs_matrix as a MatrixMarket file.
   if (opts.saveMM) {
@@ -431,7 +431,7 @@ executeTotalElementLoopSPKokkos_
   auto owned_element_to_node_ids = mesh.getOwnedElementToNode();
   auto ghost_element_to_node_ids = mesh.getGhostElementToNode();
 
-  RCP<TimeMonitor> timerGlobal = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("X) Global")));
+  Teuchos::TimeMonitor::getStackedTimer()->startBaseTimer();
   RCP<TimeMonitor> timerElementLoopGraph = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("1) ElementLoop  (Graph)")));
 
   RCP<crs_graph_type> crs_graph = rcp(new crs_graph_type(row_map, maxEntriesPerRow, Tpetra::StaticProfile));
@@ -644,7 +644,7 @@ executeTotalElementLoopSPKokkos_
   // Print out crs_matrix details.
   if(opts.verbose) crs_matrix->describe(out, Teuchos::VERB_EXTREME);
 
-  timerGlobal = Teuchos::null;
+  Teuchos::TimeMonitor::getStackedTimer()->stopBaseTimer();
 
   // Save crs_matrix as a MatrixMarket file.
   if(opts.saveMM)


### PR DESCRIPTION
Also increased the problem size for CGSolve and FE Assembly
strong scaling tests so that the 1-rank run takes roughly 30 seconds
(up from ~1 second)

@trilinos/tpetra 
@trilinos/muelu 

## Motivation

This lets the automatic CDash output scraper parse the timings. StackedTimer was natural for these performance tests (MatrixMatrixMultiply, CGSolve, and FEAssembly) anyway, since they had all had "global" timers and then sub-timers for each phase of the test. StackedTimer naturally displays this hierarchy and computes the remainder (time not inside a sub-timer) which is useful.


## Stakeholder Feedback

Part of Tpetra stack performance testing effort.

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
These were just changes to tests.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->