### PR TITLE
Add back TeuchosNumerics_DISABLE_STEQR_TEST=ON (#2410, #6166)

### DIFF
--- a/cmake/std/atdm/waterman/tweaks/Tweaks.cmake
+++ b/cmake/std/atdm/waterman/tweaks/Tweaks.cmake
@@ -8,6 +8,9 @@ ATDM_SET_ENABLE(PanzerAdaptersIOSS_tIOSSConnManager3_MPI_3_DISABLE ON)
 
 IF (Trilinos_ENABLE_DEBUG)
 
+  # STEQR() test fails on IBM Power systems with current TPL setup (#2410, #6166)
+  ATDM_SET_ENABLE(TeuchosNumerics_DISABLE_STEQR_TEST ON)
+
   # Disable Tempus tests that started timing out in debug builds when
   # Trilinos_ENABLE_DEBUG=ON was set PR #5970 (#6009)
   ATDM_SET_ENABLE(Tempus_BackwardEuler_MPI_1_DISABLE ON)


### PR DESCRIPTION
This got removed by accident as part of an earlier refactoring to a single Tweaks.cmake file.  This should allow this test to pass now (without this single unit test).

This should resolve #6166.  Also, see #2410.

## How was this tested?

On 'waterman' I did:

```
$ cd ~/Trilinos.base/BUILDS/WATERMAN/CHECKIN/

$ ./checkin-test-atdm.sh cuda-9.2-dbg --enable-packages=Teuchos --configure

$ grep TeuchosNumerics_DISABLE_STEQR_TEST cuda-9.2-dbg/configure.out 
-- Setting default TeuchosNumerics_DISABLE_STEQR_TEST=ON
```

**[PASSED]**


