### PR TITLE
6141no getter functions for output interval and output indices in time step control

### DIFF
--- a/packages/tempus/src/Tempus_TimeStepControl_decl.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControl_decl.hpp
@@ -129,6 +129,10 @@ public:
       { return tscPL_->get<int>("Number of Time Steps"); }
     virtual Teuchos::RCP<TimeStepControlStrategyComposite<Scalar>>
        getTimeStepControlStrategy() const { return stepControlStrategy_;}
+    virtual int getOutputIndexInterval()
+      { return outputIndexInterval_;}
+    virtual double getOutputTimeInterval()
+      { return outputTimeInterval_;}
   //@}
 
   /// \name Set ParameterList values
@@ -188,9 +192,11 @@ public:
         ("Maximum Number of Consecutive Stepper Failures", MaxConsecFailures); }
     virtual void setNumTimeSteps(int numTimeSteps);
     virtual void setOutputIndexInterval(int OutputIndexInterval)
-      { tscPL_->set<int>("Output Index Interval",OutputIndexInterval); }
+      { tscPL_->set<int>("Output Index Interval",OutputIndexInterval);
+        outputIndexInterval_ = OutputIndexInterval; }
     virtual void setOutputTimeInterval(double OutputTimeInterval)
-      { tscPL_->set<double>("Output Time Interval",OutputTimeInterval); }
+      { tscPL_->set<double>("Output Time Interval",OutputTimeInterval);
+        outputTimeInterval_ = OutputTimeInterval; }
     virtual void setPrintDtChanges(bool printDtChanges)
       { printDtChanges_ = printDtChanges; }
     virtual bool getPrintDtChanges() const { return printDtChanges_; }
@@ -202,6 +208,8 @@ protected:
 
   std::vector<int>    outputIndices_;  ///< Vector of output indices.
   std::vector<Scalar> outputTimes_;    ///< Vector of output times.
+  int outputIndexInterval_;
+  double outputTimeInterval_;
 
   bool outputAdjustedDt_; ///< Flag indicating that dt was adjusted for output.
   Scalar dtAfterOutput_;  ///< dt to reinstate after output step.

--- a/packages/tempus/unit_test/Tempus_UnitTest_TimeStepControl.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_TimeStepControl.cpp
@@ -32,6 +32,7 @@ using Teuchos::getParametersFromXmlFile;
 
 // Comment out any of the following tests to exclude from build/run.
 #define SETOUTPUTTIMES
+#define SETANDGETOUTPUTINDICESANDINTERVALS
 
 
 #ifdef SETOUTPUTTIMES
@@ -109,6 +110,25 @@ TEUCHOS_UNIT_TEST(TimeStepControl, setOutputTimes)
   //std::cout << "tscPL = \n" << *tscPL << std::endl;
 }
 #endif // SETOUTPUTTIMES
+
+
+#ifdef SETANDGETOUTPUTINDICESANDINTERVALS
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeStepControl, getOutputIndicesandIntervals){
+  auto tsc = rcp(new Tempus::TimeStepControl<double>());
+  int setOutputTimeIndex = 17;
+  double setOutputTimeInterval = 1.101001000100001e-7;
+
+  tsc->setOutputIndexInterval(setOutputTimeIndex);
+  tsc->setOutputTimeInterval(setOutputTimeInterval);
+
+  int getOutputTimeIndex = tsc->getOutputIndexInterval();
+  double getOutputTimeInterval = tsc->getOutputTimeInterval();
+  TEST_COMPARE(getOutputTimeInterval, ==, setOutputTimeInterval);
+  TEST_COMPARE(getOutputTimeIndex, ==, setOutputTimeIndex);
+}
+#endif // SETANDGETOUTPUTINDICESANDINTERVALS
 
 
 } // namespace Tempus_Test


### PR DESCRIPTION
Tempus:  This closes issue 6141, no getter functions for output interval and output indices in time step control.  Adds getter functions for output interval and output indices and a unit test demonstrating their correctness.

