### PR TITLE
Phalanx: add access() method to fields

### DIFF
--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.hpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.hpp
@@ -1213,7 +1213,7 @@ void STK_Interface::setCellFieldData(const std::string & fieldName,const std::st
 
       double * solnData = stk::mesh::field_data(*field,element);
       TEUCHOS_ASSERT(solnData!=0); // only needed if blockId is not specified
-      solnData[0] = scaleValue*solutionValues(cell,0);
+      solnData[0] = scaleValue*solutionValues.access(cell,0);
    }
 }
 

--- a/packages/phalanx/src/Phalanx_Field.hpp
+++ b/packages/phalanx/src/Phalanx_Field.hpp
@@ -133,6 +133,11 @@ namespace PHX {
     typename PHX::FieldReturnType<array_type>::return_type
     operator()(const index_pack&...) const;
 
+    template<typename... index_pack>
+    KOKKOS_INLINE_FUNCTION
+    typename PHX::FieldReturnType<array_type>::return_type
+    access(const index_pack&...) const;
+
     KOKKOS_INLINE_FUNCTION
     size_type rank() const;
 

--- a/packages/phalanx/src/Phalanx_Field_Def.hpp
+++ b/packages/phalanx/src/Phalanx_Field_Def.hpp
@@ -175,6 +175,21 @@ PHX::Field<DataT,Rank,Layout>::operator()(const index_pack&... indices) const
 
 // **********************************************************************
 template<typename DataT,int Rank,typename Layout>
+template<typename... index_pack>
+KOKKOS_INLINE_FUNCTION
+typename PHX::FieldReturnType<typename PHX::Field<DataT,Rank,Layout>::array_type>::return_type
+PHX::Field<DataT,Rank,Layout>::access(const index_pack&... indices) const
+{
+#if defined( PHX_DEBUG) && !defined (__CUDA_ARCH__ )
+  static_assert(Rank == sizeof...(indices), "PHX::Field::operator(const index_pack&... indices) : must have number of indices equal to rank!");
+  TEUCHOS_TEST_FOR_EXCEPTION(!m_data_set, std::logic_error, m_field_data_error_msg);
+#endif
+
+  return m_field_data.access(indices...);
+}
+
+// **********************************************************************
+template<typename DataT,int Rank,typename Layout>
 KOKKOS_INLINE_FUNCTION
 typename PHX::Field<DataT,Rank,Layout>::size_type
 PHX::Field<DataT,Rank,Layout>::rank() const

--- a/packages/phalanx/src/Phalanx_MDField.hpp
+++ b/packages/phalanx/src/Phalanx_MDField.hpp
@@ -349,6 +349,17 @@ namespace PHX {
       return m_view(indices...);
     }
 
+    template<typename... index_pack>
+    KOKKOS_FORCEINLINE_FUNCTION
+    typename PHX::MDFieldReturnType<array_type>::return_type
+    access(const index_pack&... indices) const
+    {
+#if defined( PHX_DEBUG) && !defined (__CUDA_ARCH__ )
+      TEUCHOS_TEST_FOR_EXCEPTION(!m_data_set, std::logic_error, fieldDataErrorMsg());
+#endif
+      return m_view.access(indices...);
+    }
+
     template<typename iType0>
     KOKKOS_FORCEINLINE_FUNCTION
     typename PHX::MDFieldReturnType<array_type>::return_type

--- a/packages/phalanx/test/Field/Field.cpp
+++ b/packages/phalanx/test/Field/Field.cpp
@@ -296,6 +296,30 @@ TEUCHOS_UNIT_TEST(field, all)
     cout << "passed!" << endl;
 
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // Check the access() function
+    for (size_type i=0; i < f7.extent(0); ++i) {
+      f1(i) = cf1.access(i);
+      for (size_type j=0; j < f7.extent(1); ++j) {
+	f2(i,j) = cf2.access(i,j);
+	for (size_type k=0; k < f7.extent(2); ++k) {
+	  f3(i,j,k) = cf3.access(i,j,k);
+	  for (size_type l=0; l < f7.extent(3); ++l) {
+	    f4(i,j,k,l) = cf4.access(i,j,k,l);
+	    for (size_type m=0; m < f7.extent(4); ++m) {
+	      f5(i,j,k,l,m) = cf5.access(i,j,k,l,m);
+	      for (size_type n=0; n < f7.extent(5); ++n) {
+		f6(i,j,k,l,m,n) = cf6.access(i,j,k,l,m,n);
+		for (size_type o=0; o < f7.extent(6); ++o) {
+		  f7(i,j,k,l,m,n,o) = cf7.access(i,j,k,l,m,n,o);
+		}
+	      }
+	    }
+	  }
+	}
+      }
+    }
+ 
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     // check for const mdfield assignment from non-const factory
     // PHX::any.  the field manager always stores the non-const
     // version.

--- a/packages/phalanx/test/Field/MDField_Compiletime.cpp
+++ b/packages/phalanx/test/Field/MDField_Compiletime.cpp
@@ -376,6 +376,30 @@ TEUCHOS_UNIT_TEST(mdfield, CompileTimeChecked)
     cout << "passed!" << endl;
 
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // Check the access() function
+    for (size_type i=0; i < f7.dimension(0); ++i) {
+      f1(i) = cf1.access(i);
+      for (size_type j=0; j < f7.dimension(1); ++j) {
+	f2(i,j) = cf2.access(i,j);
+	for (size_type k=0; k < f7.dimension(2); ++k) {
+	  f3(i,j,k) = cf3.access(i,j,k);
+	  for (size_type l=0; l < f7.dimension(3); ++l) {
+	    f4(i,j,k,l) = cf4.access(i,j,k,l);
+	    for (size_type m=0; m < f7.dimension(4); ++m) {
+	      f5(i,j,k,l,m) = cf5.access(i,j,k,l,m);
+	      for (size_type n=0; n < f7.dimension(5); ++n) {
+		f6(i,j,k,l,m,n) = cf6.access(i,j,k,l,m,n);
+		for (size_type o=0; o < f7.dimension(6); ++o) {
+		  f7(i,j,k,l,m,n,o) = cf7.access(i,j,k,l,m,n,o);
+		}
+	      }
+	    }
+	  }
+	}
+      }
+    }
+
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     // check for const mdfield assignment from non-const factory
     // PHX::any.  the field manager always stores the non-const
     // version.

--- a/packages/phalanx/test/Field/MDField_Runtime.cpp
+++ b/packages/phalanx/test/Field/MDField_Runtime.cpp
@@ -399,6 +399,30 @@ TEUCHOS_UNIT_TEST(mdfield, RuntimeTimeChecked)
     }
 
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // Check the access() function
+    for (size_type i=0; i < f7.dimension(0); ++i) {
+      f1(i) = cf1.access(i);
+      for (size_type j=0; j < f7.dimension(1); ++j) {
+	f2(i,j) = cf2.access(i,j);
+	for (size_type k=0; k < f7.dimension(2); ++k) {
+	  f3(i,j,k) = cf3.access(i,j,k);
+	  for (size_type l=0; l < f7.dimension(3); ++l) {
+	    f4(i,j,k,l) = cf4.access(i,j,k,l);
+	    for (size_type m=0; m < f7.dimension(4); ++m) {
+	      f5(i,j,k,l,m) = cf5.access(i,j,k,l,m);
+	      for (size_type n=0; n < f7.dimension(5); ++n) {
+		f6(i,j,k,l,m,n) = cf6.access(i,j,k,l,m,n);
+		for (size_type o=0; o < f7.dimension(6); ++o) {
+		  f7(i,j,k,l,m,n,o) = cf7.access(i,j,k,l,m,n,o);
+		}
+	      }
+	    }
+	  }
+	}
+      }
+    }
+
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     // check for const mdfield assignment from non-const factory
     // PHX::any.  the field manager always sotres the non-const
     // version.


### PR DESCRIPTION
required for empire use case due to kokkos deprecations.

882 in empire