### PR TITLE
ATDM: Disable randomly hanging ROL_example_PDE-OPT_ginzburg-landau_example_0[1|2]_MPI_4tets (#6124)

### DIFF
--- a/cmake/std/atdm/waterman/tweaks/CUDA-9.2-GNU-7.2.0-OPENMPI-2.1.2_RELEASE_CUDA_POWER9_VOLTA70.cmake
+++ b/cmake/std/atdm/waterman/tweaks/CUDA-9.2-GNU-7.2.0-OPENMPI-2.1.2_RELEASE_CUDA_POWER9_VOLTA70.cmake
@@ -1,0 +1,3 @@
+# Disable randomly hanging ROL tets (#6124)
+ATDM_SET_ENABLE(ROL_example_PDE-OPT_ginzburg-landau_example_01_MPI_4_DISABLE ON)
+ATDM_SET_ENABLE(ROL_example_PDE-OPT_ginzburg-landau_example_02_MPI_4_DISABLE ON)


### PR DESCRIPTION
Disables what should be the last failing ROL tests after allowing the enable of Intrepid (see #6017 and #6124).

These two tests are disabled only for the build `Trilinos-atdm-waterman_cuda-9.2_shared_opt`.

## How was this tested?

On `waterman` I did:

```
$ ssh waterman

$ cd ~/Trilinos.base/BUILDS/WATERMAN/CHECKIN/

$ ./checkin-test-atdm.sh cuda-dbg cuda-opt --enable-packages=ROL --configure

...

PASSED (NOT READY TO PUSH): Trilinos: waterman11

Sat Nov  2 09:50:23 MDT 2019

Enabled Packages: ROL

Build test results:
-------------------
1) cuda-dbg => passed: configure-only passed => Not ready to push! (2.91 min)
2) cuda-opt => passed: configure-only passed => Not ready to push! (2.81 min)
```

I verified the tests should only be disabled in 'cuda-opt' builds with:

```
$ find . -maxdepth 2 -name configure.out -exec grep -nH "ROL_example_PDE-OPT_ginzburg-landau_example_0[12]_MPI_4" {} \; | grep "[Aa]dded" | sort
./cuda-dbg/configure.out:1136:-- ROL_example_PDE-OPT_ginzburg-landau_example_01_MPI_4: Added test (BASIC, NUM_MPI_PROCS=4, PROCESSORS=4)!
./cuda-dbg/configure.out:1137:-- ROL_example_PDE-OPT_ginzburg-landau_example_02_MPI_4: Added test (BASIC, NUM_MPI_PROCS=4, PROCESSORS=4)!
./cuda-opt/configure.out:1142:-- ROL_example_PDE-OPT_ginzburg-landau_example_01_MPI_4: NOT added test because ROL_example_PDE-OPT_ginzburg-landau_example_01_MPI_4_DISABLE='ON'!
./cuda-opt/configure.out:1143:-- ROL_example_PDE-OPT_ginzburg-landau_example_02_MPI_4: NOT added test because ROL_example_PDE-OPT_ginzburg-landau_example_02_MPI_4_DISABLE='ON'!
```

See, the tests are added for the `gnu-dbg` build but not added for the `gnu-opt` build.

**[PASSED]**



