### PR TITLE
KokkosKernels: Optimized GEMM for A^TB with tall and skinny matrices on CUDA.

### DIFF
--- a/packages/kokkos-kernels/src/impl/tpls/KokkosBlas3_gemm_tpl_spec_decl.hpp
+++ b/packages/kokkos-kernels/src/impl/tpls/KokkosBlas3_gemm_tpl_spec_decl.hpp
@@ -335,6 +335,127 @@ KOKKOSBLAS3_CGEMM_BLAS( Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::Layout
 namespace KokkosBlas {
 namespace Impl {
 
+
+// DotBasedGEMM implements the optimization for C = beta*C + alpha*A^TB 
+// with A and B matrices both being tall and skinny. C matrix is assumably 
+// small, so, each entry of C is computed by performing the dot product of 
+// respective columns of A and B matrices. Note that the dot products are
+// performed on very long vectors, so, each dot product is distributed among
+// numDivPerDot teams.     
+
+struct TagInit{};   // The tag for the initialization parallel_for 
+struct TagMult{};   // The tag for the multiplication parallel_for 
+template<class ExecSpace, class AV, class BV, class CV>
+struct DotBasedGEMM{
+
+  const AV A;
+  const BV B;
+  CV C;
+
+  using scalar_A = typename AV::non_const_value_type;
+  using size_A = typename AV::size_type;
+  using scalar_C = typename CV::non_const_value_type;
+  using size_C = typename CV::size_type;
+
+  const scalar_A alpha;
+  const scalar_C beta;
+
+  // The following types (especially dotSize) could have simply been int,
+  // e.g., see lines 488-490.
+  const size_C numCrows;           
+  const size_C numCcols;
+
+  size_C numDivPerDot;   // number of teams collectively performing a dot product
+  size_C numTeams;       // total number of teams
+  
+  const size_A dotSize;        // the length of the vectors in the dot products
+  size_A chunkSize;      // the local length of each team's share on the dot product  
+  
+
+  DotBasedGEMM(const scalar_A& alpha_, const AV& A_, const BV& B_, const scalar_C& beta_, const CV& C_):A(A_),B(B_),C(C_),alpha(alpha_),beta(beta_),numCrows(C.extent(0)),numCcols(C.extent(1)),dotSize(A.extent(0))
+  { }
+
+  void run() {
+
+    constexpr size_C workPerTeam = 4096;                   // Amount of work per team
+    const size_C ndots = numCrows * numCcols;              // Number of dot products
+    size_C appxNumTeams = (dotSize * ndots) / workPerTeam; // Estimation for appxNumTeams
+
+    // Adjust appxNumTeams in case it is too small or too large
+    if(appxNumTeams < 32)
+      appxNumTeams = 32;
+    if(appxNumTeams > 1024)
+      appxNumTeams = 1024;
+
+    // If there are more dot products than the number of teams,
+    // then set the number of teams to be number of dot products
+    // and each team will perform only one dot product.
+    // We don't want a team to perform more than one dot product.
+    if(ndots >= appxNumTeams) {
+      numTeams = ndots;
+      numDivPerDot = 1;
+    }
+    // If there are more teams than dot products, each dot product can
+    // potentially be performed by multiple teams. First, compute 
+    // numDivPerDot as an integer (take the floor, not ceiling), then,
+    // compute actual number of teams by using this factor.
+    else{
+      numDivPerDot = appxNumTeams / ndots;
+      numTeams = ndots * numDivPerDot;
+    }
+
+    // Determine the local length for the dot product
+    chunkSize = dotSize / numDivPerDot;
+    if(numDivPerDot > 1)
+      chunkSize++;
+
+    // Initialize C matrix as beta*C
+    // This is not required for the Belos MvTransMv use case which
+    // already initializes C to zero, however, absolutely needed for 
+    // other cases, e.g., when beta is nonzero or when C was not 
+    // initialized for the case beta being zero.  
+    Kokkos::RangePolicy<TagInit, ExecSpace> policy1(0, ndots);
+    Kokkos::parallel_for("Initialize C for Dot Product Based GEMM", policy1, *this);
+
+    // Multiply alpha*A^TB and add it to beta*C
+    Kokkos::TeamPolicy<TagMult, ExecSpace> policy2(numTeams, Kokkos::AUTO);
+    Kokkos::parallel_for("Perform Dot Product Based GEMM", policy2, *this);
+
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  void operator() (const TagInit&, const size_C &i) const {
+    const size_C rowId = i / numCcols;
+    const size_C colId = i % numCcols;
+    C(rowId, colId) = beta * C(rowId, colId);
+  }
+
+
+  KOKKOS_INLINE_FUNCTION
+  void operator() (const TagMult&, const typename Kokkos::TeamPolicy<>::member_type& teamMember) const {
+
+    const size_C globalRank = teamMember.league_rank();
+    const size_C localRank = globalRank % numDivPerDot;
+    const size_C i = globalRank / numDivPerDot;
+    const size_C rowId = i / numCcols;
+    const size_C colId = i % numCcols;
+    
+
+    scalar_C result = 0;
+    const size_A baseInd = chunkSize*localRank; 
+    Kokkos::parallel_reduce( Kokkos::TeamThreadRange(teamMember, chunkSize), [&]( const size_A k, scalar_C &update ) {
+	if(baseInd + k < dotSize)
+	  update += alpha * A(baseInd+k, rowId) * B(baseInd+k, colId);
+      }, result );
+
+    
+    if(teamMember.team_rank() == 0)
+      Kokkos::atomic_add(&C(rowId, colId), result);
+  }
+
+};
+
+  
 #define KOKKOSBLAS3_DGEMM_CUBLAS( LAYOUTA, LAYOUTB, LAYOUTC, MEM_SPACE, ETI_SPEC_AVAIL ) \
 template<class ExecSpace> \
 struct GEMM< \
@@ -389,11 +510,25 @@ struct GEMM< \
       transb = CUBLAS_OP_T; \
     else \
       transb = CUBLAS_OP_C; \
-    KokkosBlas::Impl::CudaBlasSingleton & s = KokkosBlas::Impl::CudaBlasSingleton::singleton(); \
-    if(!A_is_lr && !B_is_lr && !C_is_lr ) \
-      cublasDgemm(s.handle, transa, transb, M, N, K, &alpha, A.data(), LDA, B.data(), LDB, &beta, C.data(), LDC); \
-    if(A_is_lr && B_is_lr && C_is_lr ) \
-      cublasDgemm(s.handle, transb, transa, N, M, K, &alpha, B.data(), LDB, A.data(), LDA, &beta, C.data(), LDC); \
+    \
+    bool useDotBasedGemm = false; \
+    constexpr int numDotsLayoutLeftThreshold = 1600; \
+    constexpr int numDotsLayoutRightThreshold = 100; \
+    if(   (!A_is_lr && A_t & transb == CUBLAS_OP_N && M*N < numDotsLayoutLeftThreshold) \
+       || ( A_is_lr && A_t & transb == CUBLAS_OP_N && M*N < numDotsLayoutRightThreshold)) \
+      useDotBasedGemm = true; \
+    \
+    if(useDotBasedGemm) { \
+      DotBasedGEMM<ExecSpace,AViewType,BViewType,CViewType> gemm(alpha,A,B,beta,C); \
+      gemm.run(); \
+    } \
+    else { \
+      KokkosBlas::Impl::CudaBlasSingleton & s = KokkosBlas::Impl::CudaBlasSingleton::singleton(); \
+      if(!A_is_lr && !B_is_lr && !C_is_lr )				\
+	cublasDgemm(s.handle, transa, transb, M, N, K, &alpha, A.data(), LDA, B.data(), LDB, &beta, C.data(), LDC); \
+      if(A_is_lr && B_is_lr && C_is_lr )				\
+	cublasDgemm(s.handle, transb, transa, N, M, K, &alpha, B.data(), LDB, A.data(), LDA, &beta, C.data(), LDC); \
+    } \
     Kokkos::Profiling::popRegion(); \
   } \
 };
@@ -452,11 +587,25 @@ struct GEMM< \
       transb = CUBLAS_OP_T; \
     else \
       transb = CUBLAS_OP_C; \
-    KokkosBlas::Impl::CudaBlasSingleton & s = KokkosBlas::Impl::CudaBlasSingleton::singleton(); \
-    if(!A_is_lr && !B_is_lr && !C_is_lr ) \
-      cublasSgemm(s.handle, transa, transb, M, N, K, &alpha, A.data(), LDA, B.data(), LDB, &beta, C.data(), LDC); \
-    if(A_is_lr && B_is_lr && C_is_lr ) \
-      cublasSgemm(s.handle, transb, transa, N, M, K, &alpha, B.data(), LDB, A.data(), LDA, &beta, C.data(), LDC); \
+    \
+    bool useDotBasedGemm = false; \
+    constexpr int numDotsLayoutLeftThreshold = 1600; \
+    constexpr int numDotsLayoutRightThreshold = 100; \
+    if(   (!A_is_lr && A_t & transb == CUBLAS_OP_N && M*N < numDotsLayoutLeftThreshold) \
+       || ( A_is_lr && A_t & transb == CUBLAS_OP_N && M*N < numDotsLayoutRightThreshold)) \
+      useDotBasedGemm = true; \
+    \
+    if(useDotBasedGemm) { \
+      DotBasedGEMM<ExecSpace,AViewType,BViewType,CViewType> gemm(alpha,A,B,beta,C); \
+      gemm.run(); \
+    } \
+    else { \
+      KokkosBlas::Impl::CudaBlasSingleton & s = KokkosBlas::Impl::CudaBlasSingleton::singleton(); \
+      if(!A_is_lr && !B_is_lr && !C_is_lr ) \
+        cublasSgemm(s.handle, transa, transb, M, N, K, &alpha, A.data(), LDA, B.data(), LDB, &beta, C.data(), LDC); \
+      if(A_is_lr && B_is_lr && C_is_lr ) \
+        cublasSgemm(s.handle, transb, transa, N, M, K, &alpha, B.data(), LDB, A.data(), LDA, &beta, C.data(), LDC); \
+    } \
     Kokkos::Profiling::popRegion(); \
   } \
 };
@@ -515,11 +664,25 @@ struct GEMM< \
       transb = CUBLAS_OP_T; \
     else \
       transb = CUBLAS_OP_C; \
-    KokkosBlas::Impl::CudaBlasSingleton & s = KokkosBlas::Impl::CudaBlasSingleton::singleton(); \
-    if(!A_is_lr && !B_is_lr && !C_is_lr ) \
-      cublasZgemm(s.handle, transa, transb, M, N, K, reinterpret_cast<const cuDoubleComplex*>(&alpha), reinterpret_cast<const cuDoubleComplex*>(A.data()), LDA, reinterpret_cast<const cuDoubleComplex*>(B.data()), LDB, reinterpret_cast<const cuDoubleComplex*>(&beta), reinterpret_cast<cuDoubleComplex*>(C.data()), LDC); \
-    if(A_is_lr && B_is_lr && C_is_lr ) \
-      cublasZgemm(s.handle, transb, transa, N, M, K, reinterpret_cast<const cuDoubleComplex*>(&alpha), reinterpret_cast<const cuDoubleComplex*>(B.data()), LDB, reinterpret_cast<const cuDoubleComplex*>(A.data()), LDA, reinterpret_cast<const cuDoubleComplex*>(&beta), reinterpret_cast<cuDoubleComplex*>(C.data()), LDC); \
+    \
+    bool useDotBasedGemm = false; \
+    constexpr int numDotsLayoutLeftThreshold = 1600; \
+    constexpr int numDotsLayoutRightThreshold = 100; \
+    if(   (!A_is_lr && A_t & transb == CUBLAS_OP_N && M*N < numDotsLayoutLeftThreshold) \
+       || ( A_is_lr && A_t & transb == CUBLAS_OP_N && M*N < numDotsLayoutRightThreshold)) \
+      useDotBasedGemm = true; \
+    \
+    if(useDotBasedGemm) { \
+      DotBasedGEMM<ExecSpace,AViewType,BViewType,CViewType> gemm(alpha,A,B,beta,C); \
+      gemm.run(); \
+    } \
+    else { \
+      KokkosBlas::Impl::CudaBlasSingleton & s = KokkosBlas::Impl::CudaBlasSingleton::singleton(); \
+      if(!A_is_lr && !B_is_lr && !C_is_lr ) \
+	cublasZgemm(s.handle, transa, transb, M, N, K, reinterpret_cast<const cuDoubleComplex*>(&alpha), reinterpret_cast<const cuDoubleComplex*>(A.data()), LDA, reinterpret_cast<const cuDoubleComplex*>(B.data()), LDB, reinterpret_cast<const cuDoubleComplex*>(&beta), reinterpret_cast<cuDoubleComplex*>(C.data()), LDC); \
+      if(A_is_lr && B_is_lr && C_is_lr ) \
+	cublasZgemm(s.handle, transb, transa, N, M, K, reinterpret_cast<const cuDoubleComplex*>(&alpha), reinterpret_cast<const cuDoubleComplex*>(B.data()), LDB, reinterpret_cast<const cuDoubleComplex*>(A.data()), LDA, reinterpret_cast<const cuDoubleComplex*>(&beta), reinterpret_cast<cuDoubleComplex*>(C.data()), LDC); \
+    } \
     Kokkos::Profiling::popRegion(); \
   } \
 }; \
@@ -578,11 +741,25 @@ struct GEMM< \
       transb = CUBLAS_OP_T; \
     else \
       transb = CUBLAS_OP_C; \
-    KokkosBlas::Impl::CudaBlasSingleton & s = KokkosBlas::Impl::CudaBlasSingleton::singleton(); \
-    if(!A_is_lr && !B_is_lr && !C_is_lr ) \
-      cublasCgemm(s.handle, transa, transb, M, N, K, reinterpret_cast<const cuComplex*>(&alpha), reinterpret_cast<const cuComplex*>(A.data()), LDA, reinterpret_cast<const cuComplex*>(B.data()), LDB, reinterpret_cast<const cuComplex*>(&beta), reinterpret_cast<cuComplex*>(C.data()), LDC); \
-    if(A_is_lr && B_is_lr && C_is_lr ) \
-      cublasCgemm(s.handle, transb, transa, N, M, K, reinterpret_cast<const cuComplex*>(&alpha), reinterpret_cast<const cuComplex*>(B.data()), LDB, reinterpret_cast<const cuComplex*>(A.data()), LDA, reinterpret_cast<const cuComplex*>(&beta), reinterpret_cast<cuComplex*>(C.data()), LDC); \
+    \
+    bool useDotBasedGemm = false; \
+    constexpr int numDotsLayoutLeftThreshold = 1600; \
+    constexpr int numDotsLayoutRightThreshold = 100; \
+    if(   (!A_is_lr && A_t & transb == CUBLAS_OP_N && M*N < numDotsLayoutLeftThreshold) \
+       || ( A_is_lr && A_t & transb == CUBLAS_OP_N && M*N < numDotsLayoutRightThreshold)) \
+      useDotBasedGemm = true; \
+    \
+    if(useDotBasedGemm) { \
+      DotBasedGEMM<ExecSpace,AViewType,BViewType,CViewType> gemm(alpha,A,B,beta,C); \
+      gemm.run(); \
+    } \
+    else { \
+      KokkosBlas::Impl::CudaBlasSingleton & s = KokkosBlas::Impl::CudaBlasSingleton::singleton(); \
+      if(!A_is_lr && !B_is_lr && !C_is_lr ) \
+	cublasCgemm(s.handle, transa, transb, M, N, K, reinterpret_cast<const cuComplex*>(&alpha), reinterpret_cast<const cuComplex*>(A.data()), LDA, reinterpret_cast<const cuComplex*>(B.data()), LDB, reinterpret_cast<const cuComplex*>(&beta), reinterpret_cast<cuComplex*>(C.data()), LDC); \
+      if(A_is_lr && B_is_lr && C_is_lr ) \
+	cublasCgemm(s.handle, transb, transa, N, M, K, reinterpret_cast<const cuComplex*>(&alpha), reinterpret_cast<const cuComplex*>(B.data()), LDB, reinterpret_cast<const cuComplex*>(A.data()), LDA, reinterpret_cast<const cuComplex*>(&beta), reinterpret_cast<cuComplex*>(C.data()), LDC); \
+    } \
     Kokkos::Profiling::popRegion(); \
   } \
 };


### PR DESCRIPTION

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/kokkos-kernels 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

This PR contains an improved version of KokkosBlas::gemm for CUDA: DotBasedGEMM. DotBasedGEMM implements the optimization for C = betaC + alphaA^TB with A and B matrices both being tall and skinny. C matrix is assumably small, so each entry of C is computed by performing the dot product of respective columns of A and B matrices. Note that the dot products are performed on very long vectors, so each dot product is distributed among multiple teams.

When the conditions of having tall and skinny matrices in the form alpha*A^TB hold, instead of calling CUBLAS' gemm, DotBasedGEMM is called. This is considered as an improvement over CUBLAS' gemm, so DotBasedGEMM never takes place if CUBLAS is not enabled.

Respective PR for Kokkos-Kernels is [here](https://github.com/kokkos/kokkos-kernels/pull/490).

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->

**Output of test_all_sandia on white (without and with cublas):**

`../scripts/test_all_sandia --spot-check --arch=Power8,Pascal60`

```
Running on machine: white
Going to test compilers:  gcc/6.4.0 gcc/7.2.0 ibm/16.1.0 cuda/9.2.88 cuda/10.0.130
Testing compiler gcc/6.4.0
Testing compiler gcc/7.2.0
  Starting job gcc-7.2.0-OpenMP-release
  Starting job gcc-6.4.0-OpenMP_Serial-release
  PASSED gcc-7.2.0-OpenMP-release
  Starting job gcc-7.2.0-Serial-release
  PASSED gcc-6.4.0-OpenMP_Serial-release
Testing compiler ibm/16.1.0
  Starting job gcc-7.2.0-OpenMP_Serial-release
  PASSED gcc-7.2.0-Serial-release
Testing compiler cuda/9.2.88
  Starting job ibm-16.1.0-Serial-release
  PASSED gcc-7.2.0-OpenMP_Serial-release
  PASSED ibm-16.1.0-Serial-release
Testing compiler cuda/10.0.130
  Starting job cuda-9.2.88-Cuda_OpenMP-release
  PASSED cuda-9.2.88-Cuda_OpenMP-release
  Starting job cuda-10.0.130-Cuda_Serial-release
  PASSED cuda-10.0.130-Cuda_Serial-release
#######################################################
PASSED TESTS
#######################################################
cuda-10.0.130-Cuda_Serial-release build_time=1124 run_time=283
cuda-9.2.88-Cuda_OpenMP-release build_time=1034 run_time=222
gcc-6.4.0-OpenMP_Serial-release build_time=555 run_time=290
gcc-7.2.0-OpenMP-release build_time=390 run_time=107
gcc-7.2.0-OpenMP_Serial-release build_time=623 run_time=368
gcc-7.2.0-Serial-release build_time=233 run_time=182
ibm-16.1.0-Serial-release build_time=1336 run_time=262
#######################################################
FAILED TESTS
#######################################################
```

`../scripts/test_all_sandia cuda --spot-check --with-cuda-options=enable_lambda --with-tpls=cublas --arch=Power8,Pascal60`

```
Running on machine: white
Going to test compilers:  cuda/9.2.88 cuda/10.0.130
Testing compiler cuda/9.2.88
Testing compiler cuda/10.0.130
  Starting job cuda-9.2.88-Cuda_OpenMP-release
  PASSED cuda-9.2.88-Cuda_OpenMP-release
  Starting job cuda-10.0.130-Cuda_Serial-release
  PASSED cuda-10.0.130-Cuda_Serial-release
#######################################################
PASSED TESTS
#######################################################
cuda-10.0.130-Cuda_Serial-release build_time=1177 run_time=287
cuda-9.2.88-Cuda_OpenMP-release build_time=1206 run_time=223
#######################################################
FAILED TESTS
#######################################################


```
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->