### PR TITLE
Add new cts1 machine attaway to known ATDM systems

### DIFF
--- a/cmake/std/atdm/utils/get_known_system_info.sh
+++ b/cmake/std/atdm/utils/get_known_system_info.sh
@@ -66,6 +66,10 @@ elif [[ $ATDM_CONFIG_REAL_HOSTNAME == "ghost"* ]] \
   || [[ $ATDM_CONFIG_REAL_HOSTNAME =~ gho[0-9]+ ]] ; then
   ATDM_HOSTNAME=ghost
   ATDM_SYSTEM_NAME=serrano
+elif [[ $ATDM_CONFIG_REAL_HOSTNAME == "attaway"* ]] \
+  || [[ $ATDM_CONFIG_REAL_HOSTNAME =~ swa[0-9]+ ]] ; then
+  ATDM_HOSTNAME=attaway
+  ATDM_SYSTEM_NAME=serrano
 
 # tlcc2 systems
 elif [[ $SNLSYSTEM == "tlcc2"* ]] ; then


### PR DESCRIPTION
@bartlettroscoe 

## Motivation
A new system is being stood up and it matches systems we already support (cst1) 

## Testing
On an attaway login node:
```console
jfrye@attaway-login5:[~]: source Trilinos/cmake/std/atdm/load-env.sh Trilinos-atdm-serrano-intel-debug-openmp
Hostname 'attaway-login5' matches known ATDM host 'attaway' and system 'serrano'
Setting compiler and build options for build-name 'Trilinos-atdm-serrano-intel-debug-openmp'
Using toss3 compiler stack INTEL to build DEBUG code with Kokkos node type OPENMP

The following have been reloaded with a version change:
  1) mkl/18.0.0.128 => mkl/18.0.5.274
```

on a compute node:
```console
jfrye@swa1:[~]: source Trilinos/cmake/std/atdm/load-env.sh Trilinos-atdm-serrano-intel-debug-openmp
Hostname 'swa1' matches known ATDM host 'attaway' and system 'serrano'
Setting compiler and build options for build-name 'Trilinos-atdm-serrano-intel-debug-openmp'
Using toss3 compiler stack INTEL to build DEBUG code with Kokkos node type OPENMP

The following have been reloaded with a version change:
  1) mkl/18.0.0.128 => mkl/18.0.5.274

```