### PR TITLE
 Refactor to more flexible/maintainable system matching and add cee-rhel6 for CEE RHEL7 (ATDV-228)

### DIFF
--- a/cmake/ctest/drivers/atdm/README.md
+++ b/cmake/ctest/drivers/atdm/README.md
@@ -441,13 +441,13 @@ The following `<system_name>` sub-directories exist (in alphabetical order):
 
 ## How to add a new system
 
-To add a new system, first the new system to the file:
+To add a new system, first update the file:
 
 ```
   Trilinos/cmake/std/atdm/utils/get_known_system_info.sh
 ```
 
-First, add the new system name to the variable:
+First, add the new system name to the list variable:
 
 ```
 ATDM_KNOWN_SYSTEM_NAMES_LIST=(
@@ -455,10 +455,10 @@ ATDM_KNOWN_SYSTEM_NAMES_LIST=(
   )
 ```
 
-Second, if the system mathching is done by matching to the `hostname`, then
+Second, if the system selection is done by matching to the `hostname`, then
 add a new `elif` statement for that set of machines.  Note that more than one
 `hostname` machine may map to the same `<new_system_name>` (e.g. both `white`
-and `ride` machines map to the system `ride`).
+and `ride` machines map to the system env `ride`).
 
 However, if adding a new system type that will run on many machines and not
 looking at the `hostname` on the machine, then add a new `if` block to the

--- a/cmake/ctest/drivers/atdm/README.md
+++ b/cmake/ctest/drivers/atdm/README.md
@@ -441,16 +441,29 @@ The following `<system_name>` sub-directories exist (in alphabetical order):
 
 ## How to add a new system
 
-To add a new system, first add a new `elseif` statement for the new system in
-the file:
+To add a new system, first the new system to the file:
 
 ```
   Trilinos/cmake/std/atdm/utils/get_known_system_info.sh
 ```
 
-Note that more than one `hostname` machine may map to the same
-`<new_system_name>` (e.g. both `white` and `ride` machines map to the system
-`ride`).
+First, add the new system name to the variable:
+
+```
+ATDM_KNOWN_SYSTEM_NAMES_LIST=(
+  ...
+  )
+```
+
+Second, if the system mathching is done by matching to the `hostname`, then
+add a new `elif` statement for that set of machines.  Note that more than one
+`hostname` machine may map to the same `<new_system_name>` (e.g. both `white`
+and `ride` machines map to the system `ride`).
+
+However, if adding a new system type that will run on many machines and not
+looking at the `hostname` on the machine, then add a new `if` block to the
+section for the logic.  For an example, see how the system types `tlcc2`,
+`sems-rhel6`, and `cee-rhel6` are handled.
 
 The variable `ATDM_HOSTNAME` (set to exported variable
 `ATDM_CONFIG_CDASH_HOSTNAME`) is used for the CDash site name.  This makes it

--- a/cmake/std/atdm/README.md
+++ b/cmake/std/atdm/README.md
@@ -94,16 +94,21 @@ Each of these keywords [`<system_name>`](#system_name),
 <a name="system_name"/>
 
 **`<system_name>`**: Typically, the system name is determined automatically by
-examining the `hostname` or other files on the system and matching to known
-hosts.  Therefore, it is typically not necessary to specify `<system_name>` in
-the `<build-name>` keys string.  But there are some cases where more then one
-`<system_name>` env are supported on the same machine.  For example, on CEE
-LAN RHEL6 machines, both the <a href="#sems-rhel6-environment">SEMS RHEL6
-env</a> and <a href="#cee-rhel6-environment">CEE RHEL6 env</a> are supported.
-On these CEE LAN RHEL6 machines, when `cee-rhel6` is included in
-`<build-name>`, then the `cee-rhel6` env will be selected.  But if
-`sems-rhel6` is included in the build name or no system name is given, then
-the `sems-rhel6` env will be selected by default on such machines.
+examining the `hostname`, standard system env vars, or other files on the
+machine and matching to a known supported system.  Therefore, it is typically
+not necessary to specify `<system_name>` in the `<build-name>` keys string.
+But there are some cases where more then one `<system_name>` env are supported
+on the same machine.  For example, on CEE LAN RHEL6 machines, both the <a
+href="#sems-rhel6-environment">sems-rhel6</a> and <a
+href="#cee-rhel6-environment">cee-rhel6</a> environments are supported.  On
+these CEE LAN RHEL6 machines, when `cee-rhel6` is included in `<build-name>`,
+then the `cee-rhel6` env will be selected.  But if `sems-rhel6` is included in
+the build name or no system name is given, then the `sems-rhel6` env will be
+selected by default on such machines.  Likewise for CEE LAN RHEL7 machines
+with the <a href="#sems-rhel6-environment">sems-rhel7</a> and <a
+href="#cee-rhel6-environment">cee-rhel6</a> environments.  And if `spack-rhel`
+is included in `<build-name>`, then the <a
+href="#spack-rhel-environment">spack-rhel</a> will attempted to be loaded.
 
 <a name="kokkos_arch"/>
 
@@ -608,7 +613,7 @@ example, skip the configure, skip the build, skip running tests, etc.
 * <a href="#sems-rhel6-environment">SEMS RHEL6 Environment</a>
 * <a href="#sems-rhel7-environment">SEMS RHEL7 Environment</a>
 * <a href="#spack-rhel-environment">Spack RHEL Environment</a>
-* <a href="#cee-rhel6-environment">CEE RHEL6 Environment</a>
+* <a href="#cee-rhel6-environment">CEE RHEL6 and RHEL7 Environment</a>
 * <a href="#waterman">waterman</a>
 
 
@@ -934,11 +939,11 @@ builds for the `spack-rhel` env and also to load the correct env to find
 Python, etc.
 
 
-### CEE RHEL6 Environment
+### CEE RHEL6 and RHEL7 Environment
 
-Once logged into any CEE LAN RHEL6 SRN machine, one can configure, build, and
-run tests for any ATDM Trilinos package using the `cee-rhel6` env.  For
-example, to configure, build and run the tests for the
+Once logged into any CEE LAN RHEL6 or RHEL7 SRN machine, one can configure,
+build, and run tests for any ATDM Trilinos package using the `cee-rhel6` env.
+For example, to configure, build and run the tests for the
 `cee-rhel6-clang-opt-openmp` build for say `MueLu` on a CEE LAN machine,
 (after cloning Trilinos on the `develop` branch) one would do:
 

--- a/cmake/std/atdm/cee-rhel6/environment.sh
+++ b/cmake/std/atdm/cee-rhel6/environment.sh
@@ -171,9 +171,9 @@ fi
 # modules change them!
 
 # Use updated Ninja and CMake
-module load atdm-env
-module load atdm-cmake/3.11.1
-module load atdm-ninja_fortran/1.7.2
+module load sems-env
+module load sems-cmake/3.12.2
+module load sems-ninja_fortran/1.8.2
 
 export ATDM_CONFIG_USE_HWLOC=OFF
 

--- a/cmake/std/atdm/ctest-s-local-test-driver.sh
+++ b/cmake/std/atdm/ctest-s-local-test-driver.sh
@@ -23,7 +23,8 @@ To run all of the supported builds, run with 'all':
 which runs all of the supported builds listed in the file
 Trilinos/cmake/std/atdm/<system_name>/all_supported_builds.sh.
 
-If no commandline arguments are given, then this help message is printed.
+If no commandline arguments are given, then then the list of supported builds
+that can be selected from is printed.
 
 If specifying the individual names <build-name-keysi> then the much match the
 names of the driver scripts listed under:
@@ -35,9 +36,9 @@ prefix to form the full build name:
 
   ${ATDM_CONFIG_CTEST_S_BUILD_NAME_PREFIX}<build-name-keysi>
 
-(where ATDM_CONFIG_CTEST_S_BUILD_NAME_PREFIX is defined in the
-Trilinos/cmake/std/atdm/<system_name>/all_supported_builds.sh file) and the
-full driver script name:
+(where ATDM_CONFIG_CTEST_S_BUILD_NAME_PREFIX is defined in the file
+Trilinos/cmake/std/atdm/<system_name>/all_supported_builds.sh) and the full
+driver script name is:
 
   Trilinos/cmake/ctest/drivers/atdm/<system_name>/drivers/
     ${ATDM_CONFIG_CTEST_S_BUILD_NAME_PREFIX}<build-name-keysi>.sh
@@ -66,15 +67,15 @@ To select the default env to load instead of 'default', use:
   ./ctest-s-local-test-driver.sh <build-name-1> >build-name-2> ...
 
 (For example, one must set ATDM_CTEST_S_DEFAULT_ENV=cee-rhel6-default to run
-the 'cee-rhel6' builds on CEE RHEL6 and RHE6 machines. Otherwise the
+the 'cee-rhel6' builds on CEE RHEL6 and RHE7 machines. Otherwise the
 'sems-rhel6' env will be selected which is the default env on those machines.)
 
-To control the list of packages tested, not rebuild from scratch, and not
-submit, use, for example:
+To control the list of packages tested, to build from scratch (default is to
+rebuild), and not submit to CDash, use, for example:
 
   env \\
     Trilinos_PACKAGES=<pkg0>,<pkg1>,... \\
-    CTEST_START_WITH_EMPTY_BINARY_DIRECTORY=FALSE \\
+    CTEST_START_WITH_EMPTY_BINARY_DIRECTORY=TRUE \\
     CTEST_DO_SUBMIT=OFF \\
   ./ctest-s-local-test-driver.sh <build-name-1> <build-name-2> ...
 
@@ -98,9 +99,13 @@ Other options that are good to set sometimes include:
   CTEST_DO_SUBMIT=OFF
 
 See the documentation for TRIBITS_CTEST_DRIVER() for more details.
+
+Options:
+
+  -h | --help  Print this help string
 "
 
-if [[ "$@" == "" ]] || [[ "$@" == "-h" ]] ||  [[ "$@" == "--help" ]]; then
+if [[ "$@" == "-h" ]] ||  [[ "$@" == "--help" ]]; then
   echo "$CTEST_S_LOCAL_DRIVER_HELP_STR"
   exit 0
 fi
@@ -162,6 +167,23 @@ source $STD_ATDM_DIR/load-env.sh ${ATDM_CTEST_S_DEFAULT_ENV}
 source $STD_ATDM_DIR/$ATDM_CONFIG_SYSTEM_NAME/all_supported_builds.sh
 #echo "ATDM_CONFIG_ALL_SUPPORTED_BUILDS = '${ATDM_CONFIG_ALL_SUPPORTED_BUILDS[@]}'"
 
+if [[ "$@" == "" ]] ; then
+  echo
+  echo "Error, must provide 'all' or a list of supported build names which include:"
+  echo
+  for build_name_body in ${ATDM_CONFIG_ALL_SUPPORTED_BUILDS[@]} ; do
+    if [[ "${ATDM_CTEST_S_USE_FULL_BUILD_NAME}" == "1" ]] ; then
+      build_name="${ATDM_CONFIG_CTEST_S_BUILD_NAME_PREFIX}${build_name_body}"
+    else
+      build_name="${build_name_body}"
+    fi
+    echo "    ${build_name}"
+  done
+  echo
+  echo "See --help for more details!"
+  exit 1
+fi
+
 ATDM_ARRAY_OF_BUILDS=$@
 if [ "${ATDM_ARRAY_OF_BUILDS}" == "all" ] ; then
   ATDM_ARRAY_OF_BUILDS=${ATDM_CONFIG_ALL_SUPPORTED_BUILDS[@]}
@@ -183,7 +205,7 @@ ln -sf ${ATDM_TRILINOS_DIR} .
 
 for build_name_body in ${ATDM_ARRAY_OF_BUILDS[@]} ; do
 
-  if [ "${ATDM_CTEST_S_USE_FULL_BUILD_NAME}" == "1" ] ; then
+  if [[ "${ATDM_CTEST_S_USE_FULL_BUILD_NAME}" == "1" ]] ; then
     build_name="${build_name_body}"
   else
     build_name="${ATDM_CONFIG_CTEST_S_BUILD_NAME_PREFIX}${build_name_body}"

--- a/cmake/std/atdm/utils/get_known_system_info.sh
+++ b/cmake/std/atdm/utils/get_known_system_info.sh
@@ -11,7 +11,6 @@ unset ATDM_CONFIG_CDASH_HOSTNAME
 unset ATDM_CONFIG_SYSTEM_NAME
 unset ATDM_CONFIG_SYSTEM_DIR
 
-# Assert this script is sourced, not run!
 called=$_
 if [ "$called" == "$0" ] ; then
   echo "This script '$0' is being called.  Instead, it must be sourced!"
@@ -19,123 +18,190 @@ if [ "$called" == "$0" ] ; then
 fi
 unset called
 
-# Assert that ATDM_CONFIG_BUILD_NAME is set!
 if [ -z "$ATDM_CONFIG_BUILD_NAME" ] ; then
   echo "Error, must set ATDM_CONFIG_BUILD_NAME in env!"
   return
 fi
 
-export ATDM_CONFIG_REAL_HOSTNAME=`hostname`
-#echo "Hostname = '$ATDM_CONFIG_REAL_HOSTNAME'"
+if [ -z "$ATDM_CONFIG_SCRIPT_DIR" ] ; then
+  echo "Error, must set ATDM_CONFIG_SCRIPT_DIR in env!"
+  return
+fi
+
+source ${ATDM_CONFIG_SCRIPT_DIR}/utils/get_system_info_utils.sh
+
+realHostname=`hostname`
+#echo "Hostname = '$realHostname'"
+
+#
+# List out all of the known system envs
+#
+# These are listed in order of presidence where if the current machine matches
+# more than one of these, the first match will be selected if the system name
+# is not given in the build name.
+#
+
+ATDM_KNOWN_SYSTEM_NAMES_LIST=(
+  shiller
+  ride
+  mutrino   # Will be repalced by 'cts1'
+  waterman
+  serrano   # Will be replaced by 'cts1'
+  tlcc2
+  sems-rhel7
+  sems-rhel6
+  cee-rhel6  # Used for CEE RHEL7 machines as well!
+  spack-rhel
+  )
+
+#
+# A) Look for matches of known system names that appear in the buildname
+#
+
+knownSystemNameInBuildName=`get_knownSystemNameInBuildName`
+#echo "knownSystemNameInBuildName = '${knownSystemNameInBuildName}'"
+
+#
+# B) See if the current system matches a known hostname
+#
+# This will be just a single match (if any)
+#
+
+hostnameMatch=
+hostnameMatchSystemName=
+
+# Specifically named test-bed machines
+if [[ $realHostname == "hansen"* ]] ; then
+  hostnameMatch=hansen
+  hostnameMatchSystemName=shiller
+elif [[ $realHostname == "shiller"* ]] ; then
+  hostnameMatch=shiller
+  hostnameMatchSystemName=shiller
+elif [[ $realHostname == "white"* ]] ; then
+  hostnameMatch=white
+  hostnameMatchSystemName=ride
+elif [[ $realHostname == "ride"* ]] ; then
+  hostnameMatch=ride
+  hostnameMatchSystemName=ride
+elif [[ $realHostname == "mutrino"* ]] ; then
+  hostnameMatch=mutrino
+  hostnameMatchSystemName=mutrino
+elif [[ $realHostname == "waterman"* ]] ; then
+  hostnameMatch=waterman
+  hostnameMatchSystemName=waterman
+
+# Specifically named cts1 systems
+elif [[ $realHostname == "serrano"* ]] || [[ $realHostname =~ ser[0-9]+ ]] ; then
+  hostnameMatch=serrano
+  hostnameMatchSystemName=
+elif [[ $realHostname == "eclipse"* ]] || [[ $realHostname =~ ec[0-9]+ ]] ; then
+  hostnameMatch=eclipse
+  hostnameMatchSystemName=serrano
+elif [[ $realHostname == "ghost"* ]] || [[ $realHostname =~ gho[0-9]+ ]] ; then
+  hostnameMatch=ghost
+  hostnameMatchSystemName=serrano
+elif [[ $realHostname == "attaway"* ]] || [[ $realHostname =~ swa[0-9]+ ]] ; then
+  hostnameMatch=attaway
+  hostnameMatchSystemName=serrano
+ 
+# End specifically named systems
+fi
+
+#echo "hostnameMatch ='${hostnameMatch}'"
+
+#
+# C) Look for known system types that matches this machine
+#
+# A given machine may match more than one known system type so this can be an
+# array of matches.  Also, the list of known systems will be in the prefered
+# match order so, if no other match criteria is in play, then the first
+# matching system type will be selected.
+#
+
+systemNameTypeMatchedList=()  # In order of match preference
+unset systemNameTypeMatchedListHostNames
+declare -A systemNameTypeMatchedListHostNames
+
+# TLCC2 systems
+if [[ $SNLSYSTEM == "tlcc2"* ]] ; then
+  systemNameTypeMatchedList+=(tlcc2)
+  systemNameTypeMatchedListHostNames[tlcc2]=$SNLCLUSTER
+fi
+
+# SEMS RHEL6 and RHEL7 systems
+if [[ "${SEMS_PLATFORM}" == "rhel6-x86_64" ]] ; then
+  systemNameTypeMatchedList+=(sems-rhel6)
+  systemNameTypeMatchedListHostNames[sems-rhel6]=sems-rhel6
+elif [[ "${SEMS_PLATFORM}" == "rhel7-x86_64" ]] ; then
+  systemNameTypeMatchedList+=(sems-rhel7)
+  systemNameTypeMatchedListHostNames[sems-rhel7]=sems-rhel7
+fi
+
+# CEE RHEL6 (and RHEL7) systems
+if [[ "${SNLSYSTEM}" == "cee" ]] ; then
+  if [[ "${SNLCLUSTER}" == "linux_rh6" ]] || [[ "${SNLCLUSTER}" == "linux_rh7" ]] ; then
+    systemNameTypeMatchedList+=(cee-rhel6)
+    systemNameTypeMatchedListHostNames[cee-rhel6]=cee-rhel6
+  fi
+fi
+
+# If the user puts 'spack-rhel' in the build name, assume that the modules are
+# there (since one can build this stack on almost any machine).
+if [[ "${knownSystemNameInBuildName}" == "spack-rhel" ]] ; then
+  systemNameTypeMatchedList+=(spack-rhel)
+  systemNameTypeMatchedListHostNames[spack-rhel]=spack-rhel
+fi
+# NOTE: Above, I was using:
+#
+#  spackCMakeModule=`module avail 2>&1 | grep spack-cmake | head -1`
+#
+# to determine if a spack-rhel env was setup but that check actually takes a
+# long time (5 sec) on some systems so I went with the easier logic above.
+
+#echo "systemNameTypeMatchedList = '(${systemNameTypeMatchedList[@]})'"
+
+#################################################################################
+### NOTE: No modifications below this line should be needed when adding a new
+### system base on hostname or system type!
+#################################################################################
+
+#
+# D) Select a known system given the above info
+#
 
 ATDM_HOSTNAME=
 ATDM_SYSTEM_NAME=
 
-ATDM_IS_CEE_RHEL6_MACHINE=
-
-# Specifically named systems
-if [[ $ATDM_CONFIG_REAL_HOSTNAME == "hansen"* ]] ; then
-  ATDM_HOSTNAME=hansen
-  ATDM_SYSTEM_NAME=shiller
-elif [[ $ATDM_CONFIG_REAL_HOSTNAME == "shiller"* ]] ; then
-  ATDM_HOSTNAME=shiller
-  ATDM_SYSTEM_NAME=shiller
-elif [[ $ATDM_CONFIG_REAL_HOSTNAME == "white"* ]] ; then
-  ATDM_HOSTNAME=white
-  ATDM_SYSTEM_NAME=ride
-elif [[ $ATDM_CONFIG_REAL_HOSTNAME == "ride"* ]] ; then
-  ATDM_HOSTNAME=ride
-  ATDM_SYSTEM_NAME=ride
-elif [[ $ATDM_CONFIG_REAL_HOSTNAME == "mutrino"* ]] ; then
-  ATDM_HOSTNAME=mutrino
-  ATDM_SYSTEM_NAME=mutrino
-elif [[ $ATDM_CONFIG_REAL_HOSTNAME == "waterman"* ]] ; then
-  ATDM_HOSTNAME=waterman
-  ATDM_SYSTEM_NAME=waterman
-
-# cts1 systems
-elif [[ $ATDM_CONFIG_REAL_HOSTNAME == "serrano"* ]] \
-  || [[ $ATDM_CONFIG_REAL_HOSTNAME =~ ser[0-9]+ ]] ; then
-  ATDM_HOSTNAME=serrano
-  ATDM_SYSTEM_NAME=serrano
-elif [[ $ATDM_CONFIG_REAL_HOSTNAME == "eclipse"* ]] \
-  || [[ $ATDM_CONFIG_REAL_HOSTNAME =~ ec[0-9]+ ]] ; then
-  ATDM_HOSTNAME=eclipse
-  ATDM_SYSTEM_NAME=serrano
-elif [[ $ATDM_CONFIG_REAL_HOSTNAME == "ghost"* ]] \
-  || [[ $ATDM_CONFIG_REAL_HOSTNAME =~ gho[0-9]+ ]] ; then
-  ATDM_HOSTNAME=ghost
-  ATDM_SYSTEM_NAME=serrano
-elif [[ $ATDM_CONFIG_REAL_HOSTNAME == "attaway"* ]] \
-  || [[ $ATDM_CONFIG_REAL_HOSTNAME =~ swa[0-9]+ ]] ; then
-  ATDM_HOSTNAME=attaway
-  ATDM_SYSTEM_NAME=serrano
-
-# tlcc2 systems
-elif [[ $SNLSYSTEM == "tlcc2"* ]] ; then
-  ATDM_SYSTEM_NAME=tlcc2
-  if [[ $SNLCLUSTER == "" ]] ; then
-    ATDM_HOSTNAME=$ATDM_CONFIG_REAL_HOSTNAME
-  else
-    ATDM_HOSTNAME=$SNLCLUSTER
-  fi
-
-# environments available on rhel systems
-elif [[ $ATDM_CONFIG_BUILD_NAME == *"spack-rhel"* ]] ; then
-  ATDM_HOSTNAME=spack-rhel
-  ATDM_SYSTEM_NAME=spack-rhel
-elif [[ -f /projects/sems/modulefiles/utils/get-platform ]] ; then
-  # This machine has the SEMS modules!
-  ATDM_SYSTEM_NAME=`source /projects/sems/modulefiles/utils/get-platform`
-  if [[ $ATDM_SYSTEM_NAME == "rhel7-x86_64" ]] ; then
-    # This is a RHEL7 platform that has the SEMS modules.
-    ATDM_HOSTNAME=sems-rhel7
-    ATDM_SYSTEM_NAME=sems-rhel7
-  elif [[ $ATDM_SYSTEM_NAME == "rhel6-x86_64" ]] ; then
-    # This is a RHEL6 platform that has the SEMS modules.  But is this also a
-    # CEE LAN mahcine?
-    if [[ -f /projects/sparc/modules/cee-rhel6/sparc/master ]] ; then
-      ATDM_IS_CEE_RHEL6_MACHINE=1
-    fi
-    # Now select the env based on the above logic
-    if [[ $ATDM_CONFIG_BUILD_NAME == *"sems-rhel6"* ]] ; then
-      ATDM_HOSTNAME=sems-rhel6
-      ATDM_SYSTEM_NAME=sems-rhel6
-    elif [[ $ATDM_CONFIG_BUILD_NAME == *"cee-rhel6"* ]] ; then
-      if [[ $ATDM_IS_CEE_RHEL6_MACHINE == "1" ]] ; then
-        # This is a CEE RHEL6 machine and 'cee-rhel6' was given in build name,
-        # so select the system name 'sem-rhel6'
-        ATDM_SYSTEM_NAME=cee-rhel6
-        ATDM_HOSTNAME=cee-rhel6
-      else
-        echo
-        echo "***"
-        echo "*** Error, hostname='$ATDM_CONFIG_REAL_HOSTNAME' is a 'sems-rhel6' machine but is"
-        echo "*** is *not* a 'cee-rhel6' machine but 'cee-rhel6' was given in the"
-        echo "*** build name string '$ATDM_CONFIG_BUILD_NAME'!  Please remove 'cee-rhel6'"
-	echo "*** from the build name or provide 'sems-rhel6' and then the 'sems-rhel6'"
-	echo "*** env will be used."
-        echo "***"
-        return
-      fi
-    else
-      # 'cee-rhel6' nor 'sems-rhel6' was set in the build name, so the default
-      # is to sue the 'sems-rhel6' env!
-      ATDM_HOSTNAME=sems-rhel6
-      ATDM_SYSTEM_NAME=sems-rhel6
-    fi
-  else
-    echo
-    echo "***"
-    echo "*** Error, hostname='$ATDM_CONFIG_REAL_HOSTNAME' has the SEMS env"
-    echo "*** mounted but the SEMS system '${ATDM_SYSTEM_NAME}' is not yet supported!"
-    echo "***"
-    return
-  fi
+# D.1) First, go with the system name in the build name.
+if [[ "${ATDM_SYSTEM_NAME}" == "" ]] && [[ "${knownSystemNameInBuildName}" != "" ]] ; then
+  ATDM_SYSTEM_NAME=${knownSystemNameInBuildName}
+  ATDM_HOSTNAME=${systemNameTypeMatchedListHostNames[${ATDM_SYSTEM_NAME}]}
+  assert_selected_system_matches_known_host_in_build_name || return
+  assert_selected_system_matches_known_system_type_mathces || return
 fi
 
+# D.2) Second, go with matches based on hostname
+if [[ "${ATDM_SYSTEM_NAME}" == "" ]] && [[ "${hostnameMatch}" != "" ]] ; then
+  ATDM_SYSTEM_NAME=${hostnameMatchSystemName}
+  ATDM_HOSTNAME=${hostnameMatch}
+fi
+
+# D.3) Last, go with a matching system type
+if [[ "${ATDM_SYSTEM_NAME}" == "" ]] && [[ "${systemNameTypeMatchedList}" != "" ]] ; then
+  ATDM_SYSTEM_NAME=${systemNameTypeMatchedList[0]}  # First matching system type is preferred!
+  ATDM_HOSTNAME=${systemNameTypeMatchedListHostNames[${ATDM_SYSTEM_NAME}]}
+fi
+
+#echo "ATDM_HOSTNAME = '${ATDM_HOSTNAME}'"
+#echo "ATDM_SYSTEM_NAME = '${ATDM_SYSTEM_NAME}'"
+
+#
+# E) We have selected a known system set the env vars for that!
+#
+
 if [[ $ATDM_SYSTEM_NAME != "" ]] ; then
-  echo "Hostname '$ATDM_CONFIG_REAL_HOSTNAME' matches known ATDM host '$ATDM_HOSTNAME' and system '$ATDM_SYSTEM_NAME'"
+  echo "Hostname '$realHostname' matches known ATDM host '$ATDM_HOSTNAME' and system '$ATDM_SYSTEM_NAME'"
+  export ATDM_CONFIG_REAL_HOSTNAME=$realHostname
   export ATDM_CONFIG_CDASH_HOSTNAME=$ATDM_HOSTNAME
   export ATDM_CONFIG_SYSTEM_NAME=$ATDM_SYSTEM_NAME
   export ATDM_CONFIG_SYSTEM_DIR=${ATDM_CONFIG_SCRIPT_DIR}/${ATDM_CONFIG_SYSTEM_NAME}

--- a/cmake/std/atdm/utils/get_known_system_info.sh
+++ b/cmake/std/atdm/utils/get_known_system_info.sh
@@ -93,7 +93,7 @@ elif [[ $realHostname == "waterman"* ]] ; then
 # Specifically named cts1 systems
 elif [[ $realHostname == "serrano"* ]] || [[ $realHostname =~ ser[0-9]+ ]] ; then
   hostnameMatch=serrano
-  hostnameMatchSystemName=
+  hostnameMatchSystemName=serrano
 elif [[ $realHostname == "eclipse"* ]] || [[ $realHostname =~ ec[0-9]+ ]] ; then
   hostnameMatch=eclipse
   hostnameMatchSystemName=serrano

--- a/cmake/std/atdm/utils/get_system_info.sh
+++ b/cmake/std/atdm/utils/get_system_info.sh
@@ -26,6 +26,11 @@ if [ "$called" == "$0" ] ; then
   exit 1
 fi
 
+if [ -z "$ATDM_CONFIG_SCRIPT_DIR" ] ; then
+  echo "Error, must set ATDM_CONFIG_SCRIPT_DIR in env!"
+  return
+fi
+
 source ${ATDM_CONFIG_SCRIPT_DIR}/utils/unset_atdm_config_vars_system_info.sh
 
 # First, look for a custom system configuration

--- a/cmake/std/atdm/utils/get_system_info_utils.sh
+++ b/cmake/std/atdm/utils/get_system_info_utils.sh
@@ -1,12 +1,14 @@
 # Utilities for system matching
 
 function get_knownSystemNameInBuildName() {
+  knownSystemNameInBuildName=
   for known_build_name in ${ATDM_KNOWN_SYSTEM_NAMES_LIST[@]} ; do
     if [[ $ATDM_CONFIG_BUILD_NAME == *"${known_build_name}"* ]] ; then
       knownSystemNameInBuildName=${known_build_name}
       break
     fi
   done
+  echo ${knownSystemNameInBuildName}
 }
 
 

--- a/cmake/std/atdm/utils/get_system_info_utils.sh
+++ b/cmake/std/atdm/utils/get_system_info_utils.sh
@@ -1,0 +1,95 @@
+# Utilities for system matching
+
+function get_knownSystemNameInBuildName() {
+  for known_build_name in ${ATDM_KNOWN_SYSTEM_NAMES_LIST[@]} ; do
+    if [[ $ATDM_CONFIG_BUILD_NAME == *"${known_build_name}"* ]] ; then
+      knownSystemNameInBuildName=${known_build_name}
+      break
+    fi
+  done
+}
+
+
+function list_contains() {
+  list_name=$1  # Name of bash array of items is being searched
+  item=$2   # Item we are looking for in that array
+  list=$(eval echo \${${list_name}[@]})  # Get the array elements
+  for list_item in ${list}; do
+    if [[ "${list_item}" == "${item}" ]] ; then
+      #echo "List contains '${item}'"
+      return 0
+    fi
+  done
+  return 1
+}
+
+
+function assert_selected_system_matches_known_host_in_build_name() {
+
+  if [[ "${hostnameMatch}" == "" ]] ; then
+    return 0
+  fi
+
+  if [[ "${ATDM_SYSTEM_NAME}" != "${hostnameMatchSystemName}" ]] ; then
+    echo
+    echo "***"
+    echo "*** Error, the system name '${knownSystemNameInBuildName}' given in the build name:"
+    echo "***"
+    echo "***   ${ATDM_CONFIG_BUILD_NAME}"
+    echo "***"
+    echo "*** does not match the system type based on the hostname:"
+    echo "***"
+    echo "***   $realHostname"
+    echo "***"
+    echo "*** where this machine matches the known host system:"
+    echo "***"
+    echo "***  $hostnameMatch"
+    echo "***"
+    echo "*** with the associated system name:"
+    echo "***"
+    echo "***  $hostnameMatchSystemName"
+    echo "***"
+    echo "*** To address this, either remove '${knownSystemNameInBuildName}' from the build name"
+    echo "*** or change it to '${hostnameMatchSystemName}'."
+    echo "***"
+    echo
+    return 1
+  fi
+  return 0
+}
+
+
+function assert_selected_system_matches_known_system_type_mathces() {
+
+  if [[ "${systemNameTypeMatchedList}" == "" ]] ; then
+    return 0
+  fi
+  
+  local selectedSystemNameMatchesSystemTypeMatches=false
+  list_contains systemNameTypeMatchedList ${ATDM_SYSTEM_NAME} \
+    && selectedSystemNameMatchesSystemTypeMatches=true
+
+  if [[ "${selectedSystemNameMatchesSystemTypeMatches}" == "false" ]]; then
+    echo
+    echo "***"
+    echo "*** Error, the system name '${knownSystemNameInBuildName}' given in the build name:"
+    echo "***"
+    echo "***   ${ATDM_CONFIG_BUILD_NAME}"
+    echo "***"
+    echo "*** does not match the current host:"
+    echo "***"
+    echo "***   $realHostname"
+    echo "***"
+    echo "**** and does not match a supported system type on this machine which includes:"
+    echo "***"
+    echo "***   (${systemNameTypeMatchedList[@]})"
+    echo "***"
+    echo "*** To address this, either remove '${knownSystemNameInBuildName}' from the build name"
+    echo "*** or change it to one of the above suppported system types."
+    echo "***"
+    echo
+    return 1
+  fi
+  return 0
+
+}


### PR DESCRIPTION
See the commits for what this does.  After merging this, the 'cee-rhel6' env will work on CEE LAN RHEL7 machines.

## How was this tested?

<details>

<summary><b>DETAILED TESTS:</b> (click to expand)</summary>

**On 'crf450' (SNL COE RHEL6 wtih SEMS NFS synced):**

```
$ . cmake/std/atdm/load-env.sh default

Hostname 'crf450.srn.sandia.gov' matches known ATDM host 'sems-rhel6' and system 'sems-rhel6'
Setting compiler and build options for build-name 'default'
Using SEMS RHEL6 compiler stack GNU-7.2.0 to build DEBUG code with Kokkos node type SERIAL

$ . cmake/std/atdm/load-env.sh sems-rhel6-default

Hostname 'crf450.srn.sandia.gov' matches known ATDM host 'sems-rhel6' and system 'sems-rhel6'
Setting compiler and build options for build-name 'sems-rhel6-default'
Using SEMS RHEL6 compiler stack GNU-7.2.0 to build DEBUG code with Kokkos node type SERIAL

$ . cmake/std/atdm/load-env.sh sems-rhel7-default

***
*** Error, the system name 'sems-rhel7' given in the build name:
***
***   sems-rhel7-default
***
*** does not match the current host:
***
***   crf450.srn.sandia.gov
***
**** and does not match a supported system type on this machine which includes:
***
***   (sems-rhel6)
***
*** To address this, either remove 'sems-rhel7' from the build name
*** or change it to one of the above suppported system types.
***

Error, could not determine a system confiuration, aborting env loading script!
```

==> **[PASSED]**

**On 'ceerws1113' (CEE RHEL6):**

```
$ . cmake/std/atdm/load-env.sh default

Hostname 'ceerws1113' matches known ATDM host 'sems-rhel6' and system 'sems-rhel6'
Setting compiler and build options for build-name 'default'
Using SEMS RHEL6 compiler stack GNU-7.2.0 to build DEBUG code with Kokkos node type SERIAL

$ . cmake/std/atdm/load-env.sh sems-rhel6-default

Hostname 'ceerws1113' matches known ATDM host 'sems-rhel6' and system 'sems-rhel6'
Setting compiler and build options for build-name 'sems-rhel6-default'
Using SEMS RHEL6 compiler stack GNU-7.2.0 to build DEBUG code with Kokkos node type SERIAL

$ . cmake/std/atdm/load-env.sh cee-rhel6-default

Hostname 'ceerws1113' matches known ATDM host 'cee-rhel6' and system 'cee-rhel6'
Setting compiler and build options for build-name 'cee-rhel6-default'
Using CEE RHEL6 compiler stack CLANG-5.0.1_OPENMPI-1.10.2 to build DEBUG code with Kokkos node type SERIAL

$ . cmake/std/atdm/load-env.sh sems-rhel7-default


***
*** Error, the system name 'sems-rhel7' given in the build name:
***
***   sems-rhel7-default
***
*** does not match the current host:
***
***   ceerws1113
***
**** and does not match a supported system type on this machine which includes:
***
***   (sems-rhel6 cee-rhel6)
***
*** To address this, either remove 'sems-rhel7' from the build name
*** or change it to one of the above suppported system types.
***

Error, could not determine a system confiuration, aborting env loading script!
```
==> **[PASSED]**

**On 'ews00232' (CEE RHEL7 machine):**

```
$ . cmake/std/atdm/load-env.sh default

Hostname 'ews00232' matches known ATDM host 'sems-rhel7' and system 'sems-rhel7'
Setting compiler and build options for build-name 'default'
Using SEMS RHEL7 compiler stack GNU-7.2.0 to build DEBUG code with Kokkos node type SERIAL

$ . cmake/std/atdm/load-env.sh sems-rhel7-default

Hostname 'ews00232' matches known ATDM host 'sems-rhel7' and system 'sems-rhel7'
Setting compiler and build options for build-name 'sems-rhel7-default'
Using SEMS RHEL7 compiler stack GNU-7.2.0 to build DEBUG code with Kokkos node type SERIAL

$ . cmake/std/atdm/load-env.sh cee-rhel6-default

Hostname 'ews00232' matches known ATDM host 'cee-rhel6' and system 'cee-rhel6'
Setting compiler and build options for build-name 'cee-rhel6-default'
Using CEE RHEL6 compiler stack CLANG-5.0.1_OPENMPI-1.10.2 to build DEBUG code with Kokkos node type SERIAL

$ . cmake/std/atdm/load-env.sh spack-rhel-default

Hostname 'ews00232' matches known ATDM host 'spack-rhel' and system 'spack-rhel'
Setting compiler and build options for build-name 'spack-rhel-default'
Using SPACK RHEL compiler stack GNU-7.2.0_OPENMPI-1.10.1 to build DEBUG code with Kokkos node type SERIAL

$ . cmake/std/atdm/load-env.sh ride-default


***
*** Error, the system name 'ride' given in the build name:
***
***   ride-default
***
*** does not match the current host:
***
***   ews00232
***
**** and does not match a supported system type on this machine which includes:
***
***   (sems-rhel7 cee-rhel6)
***
*** To address this, either remove 'ride' from the build name
*** or change it to one of the above suppported system types.
***

Error, could not determine a system confiuration, aborting env loading script!
```

==> **[PASSED]**

**On 'chama' (TLCC2 machine):**

```
$ . cmake/std/atdm/load-env.sh default

Hostname 'chama-login6' matches known ATDM host 'chama' and system 'tlcc2'
Setting compiler and build options for build-name 'default'
Using toss3 compiler stack INTEL to build DEBUG code with Kokkos node type SERIAL

The following have been reloaded with a version change:
  1) mkl/18.0.0.128 => mkl/18.0.5.274


$ . cmake/std/atdm/load-env.sh tlcc2-default

Hostname 'chama-login6' matches known ATDM host 'chama' and system 'tlcc2'
Setting compiler and build options for build-name 'tlcc2-default'
Using toss3 compiler stack INTEL to build DEBUG code with Kokkos node type SERIAL

The following have been reloaded with a version change:
  1) mkl/18.0.0.128 => mkl/18.0.5.274


$ . cmake/std/atdm/load-env.sh sems-rhel6-default


***
*** Error, the system name 'sems-rhel6' given in the build name:
***
***   sems-rhel6-default
***
*** does not match the current host:
***
***   chama-login6
***
**** and does not match a supported system type on this machine which includes:
***
***   (tlcc2)
***
*** To address this, either remove 'sems-rhel6' from the build name
*** or change it to one of the above suppported system types.
***

Error, could not determine a system confiuration, aborting env loading script!
```

==> **[PASSSED]**

**On 'ride' (Test bed machine selected based on `hostname`):**

```
$ . cmake/std/atdm/load-env.sh default

Hostname 'ride6' matches known ATDM host 'ride' and system 'ride'
Setting compiler and build options for build-name 'default'
Using white/ride compiler stack GNU-7.2.0 to build DEBUG code with Kokkos node type SERIAL and KOKKOS_ARCH=Power8

$ . cmake/std/atdm/load-env.sh ride-default

Hostname 'ride6' matches known ATDM host '' and system 'ride'
Setting compiler and build options for build-name 'ride-default'
Using white/ride compiler stack GNU-7.2.0 to build DEBUG code with Kokkos node type SERIAL and KOKKOS_ARCH=Power8

$ . cmake/std/atdm/load-env.sh waterman-default


***
*** Error, the system name 'waterman' given in the build name:
***
***   waterman-default
***
*** does not match the system type based on the hostname:
***
***   ride6
***
*** where this machine matches the known host system:
***
***  ride
***
*** with the associated system name:
***
***  ride
***
*** To address this, either remove 'waterman' from the build name
*** or change it to 'ride'.
***

Error, could not determine a system confiuration, aborting env loading script!
```

==> **[PASSED]**

**On 'serrano' (A CTS-1 machine, currently matched based on `hostname`):**

```
$ . cmake/std/atdm/load-env.sh default

Hostname 'serrano-login2' matches known ATDM host 'serrano' and system 'serrano'
Setting compiler and build options for build-name 'default'
Using toss3 compiler stack INTEL to build DEBUG code with Kokkos node type SERIAL

The following have been reloaded with a version change:
  1) mkl/18.0.0.128 => mkl/18.0.5.274


$ . cmake/std/atdm/load-env.sh serrano-default

Hostname 'serrano-login2' matches known ATDM host '' and system 'serrano'
Setting compiler and build options for build-name 'serrano-default'
Using toss3 compiler stack INTEL to build DEBUG code with Kokkos node type SERIAL

The following have been reloaded with a version change:
  1) mkl/18.0.0.128 => mkl/18.0.5.274


$ . cmake/std/atdm/load-env.sh tlcc2-default


***
*** Error, the system name 'tlcc2' given in the build name:
***
***   tlcc2-default
***
*** does not match the system type based on the hostname:
***
***   serrano-login2
***
*** where this machine matches the known host system:
***
***  serrano
***
*** with the associated system name:
***
***  serrano
***
*** To address this, either remove 'tlcc2' from the build name
*** or change it to 'serrano'.
***

Error, could not determine a system confiuration, aborting env loading script!
```

==> **[PASSED]**

</details>




