### PR TITLE
Intrepid2: fix a gcc error related to our typedef deprecation warnings.

### DIFF
--- a/packages/intrepid2/src/Shared/Intrepid2_Utils.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_Utils.hpp
@@ -115,7 +115,7 @@ namespace Intrepid2 {
     #define INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE(msg)
   #else // GNU
     #if not defined(KOKKOS_ENABLE_CUDA)
-      #define INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT(msg,fixit) __attribute__ ((deprecated(msg)))
+      #define INTREPID2_DEPRECATED_TYPENAME_REPLACEMENT(msg,fixit) [[deprecated(msg)]]
       #define INTREPID2_DEPRECATED_TYPENAME_TRAILING_ATTRIBUTE(msg)
       // see https://gcc.gnu.org/onlinedocs/gcc-4.9.0/gcc/Function-Attributes.html
     #else // GNU + CUDA


### PR DESCRIPTION
@trilinos/intrepid2

## Motivation
Under certain circumstances (not entirely understood, but with a reproducing configuration provided by @stanmoore1), gcc gives errors for our existing typedef deprecation warnings.  

## Related Issues
* Closes #6233

