### PR TITLE
Fix 6246

### DIFF
--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HGRAD_HEX.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HGRAD_HEX.hpp
@@ -100,6 +100,8 @@ namespace Intrepid2
      */
     Basis_Derived_HGRAD_HEX(int polyOrder) : Basis_Derived_HGRAD_HEX(polyOrder, polyOrder, polyOrder) {}
     
+    using Basis<ExecutionSpace,OutputValueType,PointValueType>::getValues;
+    
     /** \brief  multi-component getValues() method (required/called by TensorBasis)
         \param [out] outputValues - the view into which to place the output values
         \param [in] operatorType - the operator on the basis

--- a/packages/intrepid2/src/Shared/Intrepid2_TestUtils.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_TestUtils.hpp
@@ -69,7 +69,7 @@ using ViewType = Kokkos::DynRankView<ScalarType,Kokkos::DefaultExecutionSpace>;
 template<typename ScalarType>
 inline bool valuesAreSmall(ScalarType a, ScalarType b, double epsilon)
 {
-  using namespace std;
+  using std::abs;
   return (abs(a) < epsilon) && (abs(b) < epsilon);
 }
 

--- a/packages/intrepid2/src/Shared/Intrepid2_TestUtils.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_TestUtils.hpp
@@ -66,9 +66,11 @@ static const double TEST_TOLERANCE_TIGHT = 1.e2 * std::numeric_limits<double>::e
 template<typename ScalarType>
 using ViewType = Kokkos::DynRankView<ScalarType,Kokkos::DefaultExecutionSpace>;
 
-inline bool valuesAreSmall(double a, double b, double epsilon)
+template<typename ScalarType>
+inline bool valuesAreSmall(ScalarType a, ScalarType b, double epsilon)
 {
-  return (std::abs(a) < epsilon) && (std::abs(b) < epsilon);
+  using namespace std;
+  return (abs(a) < epsilon) && (abs(b) < epsilon);
 }
 
 inline bool approximatelyEqual(double a, double b, double epsilon)

--- a/packages/intrepid2/unit-test/Discretization/Basis/HierarchicalBases/AnalyticPolynomialsMatchTests.cpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HierarchicalBases/AnalyticPolynomialsMatchTests.cpp
@@ -157,7 +157,11 @@ namespace
         OutputScalar expected  = expectedValuesViewHost(fieldOrdinal);
         
         bool valuesMatch = true;
-        TEUCHOS_TEST_FLOATING_EQUALITY(actual, expected, tol, out, valuesMatch);
+        bool valuesAreBothSmall = valuesAreSmall(actual, expected, tol);
+        if (!valuesAreBothSmall)
+        {
+          TEUCHOS_TEST_FLOATING_EQUALITY(actual, expected, tol, out, valuesMatch);
+        }
         
         if (!valuesMatch)
         {
@@ -290,7 +294,11 @@ namespace
         double expected  = expectedValues[fieldOrdinal];
         
         bool valuesMatch = true;
-        TEUCHOS_TEST_FLOATING_EQUALITY(actual, expected, tol, out, valuesMatch);
+        bool valuesAreBothSmall = valuesAreSmall(actual, expected, tol);
+        if (!valuesAreBothSmall)
+        {
+          TEUCHOS_TEST_FLOATING_EQUALITY(actual, expected, tol, out, valuesMatch);
+        }
         
         if (!valuesMatch)
         {
@@ -372,8 +380,16 @@ namespace
         OutputScalar hgradValue = hgradOutputViewHost(fieldOrdinal,  pointOrdinal,0);
         OutputScalar hvolValue  =  hvolOutputViewHost(fieldOrdinal-1,pointOrdinal,0);
         
+        OutputScalar actual = hgradValue;
+        OutputScalar expected = OutputScalar(0.5 * hvolValue);
+        
         bool valuesMatch = true;
-        TEUCHOS_TEST_FLOATING_EQUALITY(hgradValue, OutputScalar(0.5 * hvolValue), tol, out, valuesMatch);
+        
+        bool valuesAreBothSmall = valuesAreSmall(actual, expected, tol);
+        if (!valuesAreBothSmall)
+        {
+          TEUCHOS_TEST_FLOATING_EQUALITY(actual, expected, tol, out, valuesMatch);
+        }
         
         if (!valuesMatch)
         {

--- a/packages/intrepid2/unit-test/Shared/Polylib/LegendreJacobiPolynomials/IntegratedLegendreTests.cpp
+++ b/packages/intrepid2/unit-test/Shared/Polylib/LegendreJacobiPolynomials/IntegratedLegendreTests.cpp
@@ -182,8 +182,15 @@ namespace
             double P_i_minus_2 = shifted_scaled_legendre_values_host(i-2);
             L_i_expected = (P_i - t * t * P_i_minus_2) / i_factor;
           }
+          
+          bool valuesMatch = true;
+          bool valuesAreBothSmall = valuesAreSmall(L_i_actual, L_i_expected, tol);
+          if (!valuesAreBothSmall)
+          {
+            TEUCHOS_TEST_FLOATING_EQUALITY(L_i_actual, L_i_expected, tol, out, valuesMatch);
+          }
       
-          if (! approximatelyEqual(L_i_actual, L_i_expected, tol) )
+          if ( !valuesMatch )
           {
             out << "for polyOrder " << i << ", x = " << x << ", t = " << t << ": ";
             out << L_i_actual << " != " << L_i_expected;


### PR DESCRIPTION
@trilinos/intrepid2 

## Motivation
These changes reduce sensitivity to platform differences in floating point comparisons employed in recently-introduced tests in Intrepid2.  I have reproduced reported test failures on serrano and waterman, and confirmed that these changes eliminate those failures.

## Related Issues
* Closes #6246