### PR TITLE
Update mapping of git users to remove duplicate and put in sandia.gov addresses

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -5,9 +5,13 @@ Christopher G. Baker <bakercg@ornl.gov>
 Christopher G. Baker <bakercg@ornl.gov> Chris Baker <bakercg@ornl.gov>
 Christopher G. Baker <bakercg@ornl.gov> Baker Christopher G <ogb@billmp1.ornl.gov> 
 Christopher G. Baker <bakercg@ornl.gov> Christopher G. Baker <ogb@orthanc.ornl.gov> 
+Kris Beckwith <kbeckwi@sandia.gov>
+Kris Beckwith <kbeckwi@sandia.gov> Kris Beckwith <krcb@users.noreply.github.com>
 Erik G. Boman <egboman@sandia.gov> 
 Erik G. Boman <egboman@sandia.gov> Erik Boman <egboman@sandia.gov>
 Erik G. Boman <egboman@sandia.gov> Erik Boman <ejboman@sandia.gov> 
+Sidafa Conde <sconde@sandia.gov>
+Sidafa Conde <sconde@sandia.gov> Sidafa Conde <sconde@umassd.edu>
 Eric C. Cyr <eccyr@sandia.gov>
 Eric C. Cyr <eccyr@sandia.gov> Eric Cyr <eccyr@sandia.gov>
 Karen D. Devine <kddevin@sandia.gov> 
@@ -17,22 +21,45 @@ Karen D. Devine <kddevin@sandia.gov> Karen Devine <kddevin@sandia.gov>
 Karen D. Devine <kddevin@sandia.gov> K Devine <kddevin@users.noreply.github.com>
 H. Carter Edwards <hcedwar@sandia.gov> 
 H. Carter Edwards <hcedwar@sandia.gov> Carter Edwards <hcedwar@sandia.gov>  
+H. Carter Edwards <hMichael A. Heroux <maherou@sandia.gov>
 Jeremie Gaidamour <jngaida@sandia.gov> 
 Jeremie Gaidamour <jngaida@host56.snlca-visitor.net> Jeremie Gaidamour <jngaida@sandia.gov>
-H. Carter Edwards <hMichael A. Heroux <maherou@sandia.gov>
 Michael A. Heroux <maherou@sandia.gov> Mike Heroux <maherou@sandia.gov> 
 Michael A. Heroux <maherou@sandia.gov> Mike Heroux <maherou@gmail.com>
 Michael A. Heroux <maherou@sandia.gov> Michael Heroux <maherou@Mikes-Mac-17-inch.local> 
-Stephen Kennon <srkenno@sandia.gov> 
+Michel de Messieres <michel@demessieres.com>
+Michel de Messieres <michel@demessieres.com> micheldemessieres <michel@demessieres.com>
+Alexander Heinlein <alexander.heinlein@uni-köln.de>
+Alexander Heinlein <alexander.heinlein@uni-köln.de> Alexander Heinlein <alexander.heinlein@uni-koeln.de>
+Simon David Hammond <sdhammo@sandia.gov>
+Simon David Hammond <sdhammo@sandia.gov> Simon David Hammond <Si Hammond>
+Mark Hoemmen <mhoemme@sandia.gov>
+Mark Hoemmen <mhoemme@sandia.gov> Mark Hoemmen <mhoemmen@users.noreply.github.com>
+Dan Ibanez <daibane@sandia.gov>
+Dan Ibanez <daibane@sandia.gov> Dan Ibanez <ibaned@users.noreply.github.com>
+Dan Ibanez <daibane@sandia.gov> Daniel Alejandro Ibanez <daibane@sandia.gov>
+Stephen Kennon <srkenno@sandia.gov>
 Stephen Kennon <srkenno@sandia.gov> Steve Kennon <srkenno@sandia.gov> 
 Jason A. Kraftcheck <kraftche@cae.wisc.edu> 
 Jason A. Kraftcheck <kraftche@cae.wisc.edu> Jason Kraftcheck <kraftche@cae.wisc.edu>
-Jason A. Kraftcheck <kraftche@cae.wisc.edu> Jason Kraftcheck <jason@hex.ep.wisc.edu> 
+Jason A. Kraftcheck <kraftche@cae.wisc.edu> Jason Kraftcheck <jason@hex.ep.wisc.edu>
+Brian Micheal Kelly <bmkelle@sandia.gov> 
+Brian Micheal Kelly <bmkelle@sandia.gov> brian-kelley <brian.honda11@gmail.com>
+Christian Glusa <caglusa@sandia.gov>
+Christian Glusa <caglusa@sandia.gov> Christian Glusa <cgcgcg@users.noreply.github.com>
+Kim Liegeois <kimliegeois@ymail.com>
+Kim Liegeois <kimliegeois@ymail.com> kliegeois <kimliegeois@ymail.com>
 Kevin R. Long <kevin.long@ttu.edu> 
 Kevin R. Long <kevin.long@ttu.edu> Kevin Long <kevin.long@ttu.edu>
 Kevin R. Long <kevin.long@ttu.edu> Kevin Long <kevin@feynman.math.ttu.edu>
 Kevin R. Long <kevin.long@ttu.edu> Kevin Long <kevin@feynman.site>
 Kevin R. Long <kevin.long@ttu.edu> Kevin Long <kevin@landau.math.ttu.edu> 
+Matthias Mayr <mmayr@sandia.gov>
+Matthias Mayr <mmayr@sandia.gov> mayr.mt <matthias.mayr@unibw.de>
+Matthias Mayr <mmayr@sandia.gov> Matthias Mayr <matthias.mayr@unibw.de>
+Matthias Mayr <mmayr@sandia.gov> Matthias Mayr <mayrmt@users.noreply.github.com>
+William McLendon <wcmclen@sandia.gov>
+William McLendon <wcmclen@sandia.gov> William <william76@users.noreply.github.com>
 Kurts L. Nusbaum <klnusbaum@gmail.com> 
 Kurts L. Nusbaum <klnusbaum@gmail.com> Kurtis L. Nusbaum <klnusbaum@csbsju.edu> 
 Kurts L. Nusbaum <klnusbaum@gmail.com> Kurtis Nusbaum <klnusbaum@gmail.com> 
@@ -42,19 +69,28 @@ Roger P. Pawlowski <rppawlo@sandia.gov>
 Roger P. Pawlowski <rppawlo@sandia.gov> Roger Pawlowski <rppawlo@sandia.gov> 
 Roger P. Pawlowski <rppawlo@sandia.gov> Roger P Pawlowski <rppawlo@sandia.gov>
 Roger P. Pawlowski <rppawlo@sandia.gov> Roger P. Pawlowski <p8d@u233.ornl.gov> 
+RogerP.  Pawlowski <rppawlo@sandia.gov> Roger Pawlowski <rppawlo@users.noreply.github.com>
 Brent M. Perschbacher <bmpersc@sandia.gov> 
 Brent M. Perschbacher <bmpersc@sandia.gov> Brent Perschbacher <bmpersc@sandia.gov> 
 Michael N. Phenow <mnphenow> 
 Michael N. Phenow <mnphenow> Michael N. Phenow <mnpheno> 
 Eric T. Phipps <etphipp@sandia.gov> 
 Eric T. Phipps <etphipp@sandia.gov> Eric Phipps <etphipp@sandia.gov>  
+Andrey Prokopenko <prokopenkoav@ornl.gov>
+Andrey Prokopenko <prokopenkoav@ornl.gov> Andrey Prokopenko <aprokop@sandia.gov>
 Andrew G. Salinger <agsalin@sandia.gov> 
 Andrew G. Salinger <agsalin@sandia.gov> Andy Salinger <agsalin@sandia.gov>
+Henry Swantner <HRSwant@sandia.gov>
+Henry Swantner <HRSwant@sandia.gov> Henry <31079596+ZUUL42@users.noreply.github.com>
 Lee Ann Riesen <lriesen@sandia.gov>
 Lee Ann Riesen <lriesen@sandia.gov> Lee Ann Riesen <lafisk@sandia.gov>
 Christopher Siefert <csiefer@sandia.gov> 
 Christopher Siefert <csiefer@sandia.gov> Chris Siefert <csiefer@sandia.gov>
 Christopher Siefert <csiefer@sandia.gov> Chris 'Stuck in New York' Siefert <csiefer@sandia.gov> 
+Christopher Siefert <csiefer@sandia.gov> Chris Siefert <csiefer2@users.noreply.github.com>
+Greg Sjaardema <gdsjaar@sandia.gov>
+Greg Sjaardema <gdsjaar@sandia.gov> gsjaardema <gsjaardema@gmail.com>
+Greg Sjaardema <gdsjaar@sandia.gov> Greg Sjaardema <gsjaardema@gmail.com>
 William F. Spotz <wfspotz@sandia.gov> 
 William F. Spotz <wfspotz@sandia.gov> Bill Spotz <wfspotz@sandia.gov>
 Heidi K. Thornquist <hkthorn@sandia.gov>
@@ -65,9 +101,14 @@ Tobias Wiesner <wiesner>
 Tobias Wiesner <wiesner> Tobias Wiesner <wiesner@lnm.mw.tum.de>
 Tobias Wiesner <wiesner> Tobias Wiesner <wiesner@poincare.lnm.mw.tum.de> 
 Tobias Wiesner <wiesner> Tobias Wiesner <wiesner@descartes.lnm.mw.tum.de> 
+Greg von Winckel <gvonwin@sandia.gov>
+Greg von Winckel <gvonwin@sandia.gov> Greg von Winckel <gregvw@gmail.com>
 James M. Willenbring <jmwille@sandia.gov>
 James M. Willenbring <jmwille@sandia.gov> James Willenbring <jmwille@sandia.gov>
+James M. Willenbring <jmwille@sandia.gov> James Willenbring <jim.mn21@yahoo.com>
 Alan B. Williams <william@sandia.gov> 
 Alan B. Williams <william@sandia.gov> Alan Williams <william@sandia.gov>
-Andrey Prokopenko <prokopenkoav@ornl.gov>
-Andrey Prokopenko <prokopenkoav@ornl.gov> Andrey Prokopenko <aprokop@sandia.gov>
+Paul Wolfenbarger <prwolfe@sandia.gov>
+Paul Wolfenbarger <prwolfe@sandia.gov> Paul Wolfenbarger <prwolfe@users.noreply.github.com>
+Ichitaro Yamazaki <iyamaza@sandia.gov>
+Ichitaro Yamazaki <iyamaza@sandia.gov> iyamazaki <ic.yamazaki@gmail.com>


### PR DESCRIPTION
This gives a more accurate count of the number of commits being made by Sandia and non-Sandia developers.
