### PR TITLE
Fix setting of ATDM_CONFIG_BUILD_NAME when hostname match system is in build name (ATDV-228)

### DIFF
--- a/cmake/std/atdm/utils/get_known_system_info.sh
+++ b/cmake/std/atdm/utils/get_known_system_info.sh
@@ -61,6 +61,11 @@ ATDM_KNOWN_SYSTEM_NAMES_LIST=(
 knownSystemNameInBuildName=`get_knownSystemNameInBuildName`
 #echo "knownSystemNameInBuildName = '${knownSystemNameInBuildName}'"
 
+# System name and hostname matching
+systemNameTypeMatchedList=()  # In order of match preference
+unset systemNameTypeMatchedListHostNames
+declare -A systemNameTypeMatchedListHostNames
+
 #
 # B) See if the current system matches a known hostname
 #
@@ -109,6 +114,9 @@ fi
 
 #echo "hostnameMatch ='${hostnameMatch}'"
 
+systemNameTypeMatchedList+=(${hostnameMatchSystemName})
+systemNameTypeMatchedListHostNames[${hostnameMatchSystemName}]=${hostnameMatch}
+
 #
 # C) Look for known system types that matches this machine
 #
@@ -118,9 +126,6 @@ fi
 # matching system type will be selected.
 #
 
-systemNameTypeMatchedList=()  # In order of match preference
-unset systemNameTypeMatchedListHostNames
-declare -A systemNameTypeMatchedListHostNames
 
 # TLCC2 systems
 if [[ $SNLSYSTEM == "tlcc2"* ]] ; then


### PR DESCRIPTION
This was a varaible that I did not test in my manual testing.  Very bad.

This killed the testing on a bunch of machines.
