### PR TITLE
MueLu ParameterListInterpreter: fuse prolongation and update

### DIFF
--- a/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
+++ b/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
@@ -414,6 +414,9 @@ namespace MueLu {
     // Detect if we use implicit transpose
     changedImplicitTranspose_ = MUELU_TEST_AND_SET_VAR(paramList, "transpose: use implicit", bool, this->implicitTranspose_);
 
+    // Detect if we use fuse prolongation and update
+    MUELU_TEST_AND_SET_VAR(paramList, "fuse prolongation and update", bool, this->fuseProlongationAndUpdate_);
+
     if (paramList.isSublist("matvec params"))
       this->matvecParams_ = Teuchos::parameterList(paramList.sublist("matvec params"));
 
@@ -1876,6 +1879,11 @@ namespace MueLu {
       if (hieraList.isParameter("transpose: use implicit")) {
         this->implicitTranspose_ = hieraList.get<bool>("transpose: use implicit");
         hieraList.remove("transpose: use implicit");
+      }
+
+      if (hieraList.isParameter("fuse prolongation and update")) {
+        this->fuseProlongationAndUpdate_ = hieraList.get<bool>("fuse prolongation and update");
+        hieraList.remove("fuse prolongation and update");
       }
 
       if (hieraList.isSublist("matvec params"))


### PR DESCRIPTION
@trilinos/muelu 

## Motivation
Fusing of prolongation and update was implemented in the hierarchy, but not exposed in the ParameterListInterpreter.