### PR TITLE
ATDM: Fix detection of sems-rhel6 and sems-rhel7 when SEMS_SYSTEM is not set (ATDV-228)

### DIFF
--- a/cmake/std/atdm/utils/get_known_system_info.sh
+++ b/cmake/std/atdm/utils/get_known_system_info.sh
@@ -140,6 +140,15 @@ if [[ "${SEMS_PLATFORM}" == "rhel6-x86_64" ]] ; then
 elif [[ "${SEMS_PLATFORM}" == "rhel7-x86_64" ]] ; then
   systemNameTypeMatchedList+=(sems-rhel7)
   systemNameTypeMatchedListHostNames[sems-rhel7]=sems-rhel7
+elif [[ -f /projects/sems/modulefiles/utils/get-platform ]] ; then
+  ATDM_SYSTEM_NAME=`source /projects/sems/modulefiles/utils/get-platform`
+  if [[ $ATDM_SYSTEM_NAME == "rhel6-x86_64" ]] ; then
+    systemNameTypeMatchedList+=(sems-rhel6)
+    systemNameTypeMatchedListHostNames[sems-rhel6]=sems-rhel6
+  elif [[ $ATDM_SYSTEM_NAME == "rhel7-x86_64" ]] ; then
+    systemNameTypeMatchedList+=(sems-rhel7)
+    systemNameTypeMatchedListHostNames[sems-rhel7]=sems-rhel7
+  fi
 fi
 
 # CEE RHEL6 (and RHEL7) systems


### PR DESCRIPTION
Turns out that you have to actually define the SEMS modules in order to hvae
SEMS_SYSTEM set.  Therefore, this adds back logic to look for the file:

  /projects/sems/modulefiles/utils/get-platform

This should fix the 'sems-rhel7' builds on ascicgpu14 and other such machines.

## How was this tested

I disabled the sourcing of:

```
. /projects/sems/modulefiles/utils/sems-modules-init.sh
```

in my `.bashrc` file and I was able to reproduce the problem where it did not recognize support for the system 'sems-rhel7' on ascicgpu14.  After this patch, it did.
