### PR TITLE
Change EMPIRE Trilinos Configuration

### DIFF
--- a/cmake/std/atdm/apps/empire/EMPIRETrilinosEnables.cmake
+++ b/cmake/std/atdm/apps/empire/EMPIRETrilinosEnables.cmake
@@ -10,6 +10,9 @@ ATDM_SET_CACHE(Gtest_SKIP_INSTALL TRUE CACHE BOOL)
 # #5341.  (Once we can get SPARC to have its own gtest, then we can move this
 # setting to ATDMDevEnvSettings.cmake. See SPAR-614.)
 
+ATDM_SET_CACHE(Trilinos_ENABLE_Gtest FALSE CACHE BOOL)
+ATDM_SET_CACHE(Kokkos_ENABLE_Profiling TRUE CACHE BOOL)
+
 INCLUDE("${CMAKE_CURRENT_LIST_DIR}/EMPIRETrilinosPackagesList.cmake")
 FOREACH(TRIBITS_PACKAGE ${EMPIRE_Trilinos_Packages})
   SET(${PROJECT_NAME}_ENABLE_${TRIBITS_PACKAGE} ON)


### PR DESCRIPTION
Migrate two Trilinos configuration flags from EMPIRE's build scripts to those in Trilinos itself.  These flags have been included in EMPIRE's build scripts for some time, but if Trilinos developers are going to exactly replicate an EMPIRE build of Trilinos, these need to be in Trilinos instead.