### PR TITLE
MueLu: removing some std::cout statments from region functions

### DIFF
--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
@@ -422,7 +422,7 @@ void MakeInterfaceScalingFactors(const int maxRegPerProc,
                                  Array<std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > >& quasiRegRowMaps)
 {
 #include "Xpetra_UseShortNames.hpp"
-  std::cout << compRowMaps[0]->getComm()->getRank() << " | Computing interface scaling factors ..." << std::endl;
+  // std::cout << compRowMaps[0]->getComm()->getRank() << " | Computing interface scaling factors ..." << std::endl;
 
   const SC SC_ONE = Teuchos::ScalarTraits<SC>::one();
 
@@ -489,7 +489,7 @@ void createRegionHierarchy(const int maxRegPerProc,
   using Utilities = MueLu::Utilities<SC, LO, GO, NO>;
   using DirectCoarseSolver = Amesos2::Solver<Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>, Tpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> >;
 
-  std::cout << mapComp->getComm()->getRank() << " | Setting up MueLu hierarchies ..." << std::endl;
+  // std::cout << mapComp->getComm()->getRank() << " | Setting up MueLu hierarchies ..." << std::endl;
   int numLevels = 0;
 
   // A hierarchy for each group
@@ -527,7 +527,7 @@ void createRegionHierarchy(const int maxRegPerProc,
     regGrpHierarchy[j] = MueLu::CreateXpetraPreconditioner(regionGrpMats[j], *mueluParams);
   }
 
-  std::cout << mapComp->getComm()->getRank() << " | Resize containers..." << std::endl;
+  // std::cout << mapComp->getComm()->getRank() << " | Resize containers..." << std::endl;
 
   // resize Arrays and vectors
   {
@@ -561,7 +561,7 @@ void createRegionHierarchy(const int maxRegPerProc,
     }
   }
 
-  std::cout << mapComp->getComm()->getRank() << " | Fill fine level containers..." << std::endl;
+  // std::cout << mapComp->getComm()->getRank() << " | Fill fine level containers..." << std::endl;
 
   // Fill fine level with our data
   {
@@ -583,7 +583,7 @@ void createRegionHierarchy(const int maxRegPerProc,
     regProlong[0] = fineLevelProlong;
   }
 
-  std::cout << mapComp->getComm()->getRank() << " | Fill coarser level containers..." << std::endl;
+  // std::cout << mapComp->getComm()->getRank() << " | Fill coarser level containers..." << std::endl;
 
   /* Get coarse level matrices and prolongators from MueLu hierarchy
    * Note: fine level has been dealt with previously, so we start at level 1 here.
@@ -620,7 +620,7 @@ void createRegionHierarchy(const int maxRegPerProc,
                        compRowMaps,
                        regRowImporters);
 
-  std::cout << mapComp->getComm()->getRank() << " | MakeCoarseCompositeOperator ..." << std::endl;
+  // std::cout << mapComp->getComm()->getRank() << " | MakeCoarseCompositeOperator ..." << std::endl;
 
   MakeCoarseCompositeOperator(maxRegPerProc,
                               numLevels,
@@ -631,7 +631,7 @@ void createRegionHierarchy(const int maxRegPerProc,
                               regMatrices,
                               coarseCompOp);
 
-  std::cout << mapComp->getComm()->getRank() << " | MakeCoarseCompositeSolver ..." << std::endl;
+  // std::cout << mapComp->getComm()->getRank() << " | MakeCoarseCompositeSolver ..." << std::endl;
 
   const std::string coarseSolverType = coarseSolverData->get<std::string>("coarse solver type");
   if (coarseSolverType == "direct")
@@ -650,7 +650,7 @@ void createRegionHierarchy(const int maxRegPerProc,
     TEUCHOS_TEST_FOR_EXCEPT_MSG(false, "Unknown coarse solver type.");
   }
 
-  std::cout << mapComp->getComm()->getRank() << " | MakeInterfaceScalingFactors ..." << std::endl;
+  // std::cout << mapComp->getComm()->getRank() << " | MakeInterfaceScalingFactors ..." << std::endl;
 
   MakeInterfaceScalingFactors(maxRegPerProc,
                               numLevels,


### PR DESCRIPTION
@trilinos/muelu 

## Motivation
Now that the code is getting closer to being run at large scale output statement from all ranks should be used more cautiously.
Also adding a bit more profiling.

## Testing
Testing was performed locally, the extra output is gone.
