### PR TITLE
Xpetra: Re-enabled fast TwoMatrixAdd path

### DIFF
--- a/packages/xpetra/sup/Utils/Xpetra_MatrixMatrix.hpp
+++ b/packages/xpetra/sup/Utils/Xpetra_MatrixMatrix.hpp
@@ -110,7 +110,6 @@ namespace Xpetra {
       if(transposeA)
         Aprime = transposer_type(Aprime).createTranspose();
       //Decide whether the fast code path can be taken.
-      /*
       if(A.isFillComplete() && B.isFillComplete())
       {
         RCP<tcrs_matrix_type> C = rcp(new tcrs_matrix_type(Aprime->getRowMap(), 0));
@@ -122,7 +121,6 @@ namespace Xpetra {
       }
       else
       {
-      */
         //Slow case - one or both operands are non-fill complete.
         //TODO: deprecate this.
         //Need to compute the explicit transpose before add if transposeA and/or transposeB.
@@ -152,7 +150,7 @@ namespace Xpetra {
             *Bprime, false, beta,
             C);
         return rcp(new CrsWrap(rcp_implicit_cast<CrsType>(rcp(new XTCrsType(C)))));
-      //}
+      }
     }
 #endif
   }


### PR DESCRIPTION
DO NOT MERGE until we know that this doesn't break EMPIRE.
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/xpetra 
@trilinos/tpetra

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

This change re-enables the fast codepath in ``Xpetra::MatrixMatrix::TwoMatrixAdd()`` that was originally merged in #6190, but which was reverted in #6266 because it appeared to break EMPIRE (see #6264). But now it seems that #6190 just exposed an existing bug in MueLu kokkos refactor uncoupled aggregation. So @rppawlo when it is confirmed that this patch (reverting the revert) doesn't break EMPIRE, we can put it back in develop.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
-->
## Related Issues
* Closes 
* Blocks 
* Is blocked by 
* Follows #6190 (which had this enabled originally), #6266 (which reverted this code path) 
* Precedes 
* Related to #6264
* Part of 
* Composed of 



## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
See comments on #6264 for the discussion about the new EMPIRE failures from 11-12-19.
## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->