### PR TITLE
Fix bug in atdm/utils/get_know_system_info.sh (#6276)

### DIFF
--- a/cmake/std/atdm/utils/get_known_system_info.sh
+++ b/cmake/std/atdm/utils/get_known_system_info.sh
@@ -115,6 +115,8 @@ fi
 #echo "hostnameMatch ='${hostnameMatch}'"
 
 if [[ "${hostnameMatch}" != "" ]] ; then
+  # A matching system by hostname becomes the first preferred match (but not
+  # the only possible match)
   systemNameTypeMatchedList+=(${hostnameMatchSystemName})
   systemNameTypeMatchedListHostNames[${hostnameMatchSystemName}]=${hostnameMatch}
 fi
@@ -195,13 +197,7 @@ if [[ "${ATDM_SYSTEM_NAME}" == "" ]] && [[ "${knownSystemNameInBuildName}" != ""
   assert_selected_system_matches_known_system_type_mathces || return
 fi
 
-# D.2) Second, go with matches based on hostname
-if [[ "${ATDM_SYSTEM_NAME}" == "" ]] && [[ "${hostnameMatch}" != "" ]] ; then
-  ATDM_SYSTEM_NAME=${hostnameMatchSystemName}
-  ATDM_HOSTNAME=${hostnameMatch}
-fi
-
-# D.3) Last, go with a matching system type
+# D.2) Last, go with the hostname match or matching system type
 if [[ "${ATDM_SYSTEM_NAME}" == "" ]] && [[ "${systemNameTypeMatchedList}" != "" ]] ; then
   ATDM_SYSTEM_NAME=${systemNameTypeMatchedList[0]}  # First matching system type is preferred!
   ATDM_HOSTNAME=${systemNameTypeMatchedListHostNames[${ATDM_SYSTEM_NAME}]}

--- a/cmake/std/atdm/utils/get_known_system_info.sh
+++ b/cmake/std/atdm/utils/get_known_system_info.sh
@@ -44,7 +44,7 @@ realHostname=`hostname`
 ATDM_KNOWN_SYSTEM_NAMES_LIST=(
   shiller
   ride
-  mutrino   # Will be repalced by 'cts1'
+  mutrino   # Will be repalced by 'ats1'
   waterman
   serrano   # Will be replaced by 'cts1'
   tlcc2
@@ -125,7 +125,6 @@ systemNameTypeMatchedListHostNames[${hostnameMatchSystemName}]=${hostnameMatch}
 # match order so, if no other match criteria is in play, then the first
 # matching system type will be selected.
 #
-
 
 # TLCC2 systems
 if [[ $SNLSYSTEM == "tlcc2"* ]] ; then

--- a/cmake/std/atdm/utils/get_known_system_info.sh
+++ b/cmake/std/atdm/utils/get_known_system_info.sh
@@ -114,8 +114,10 @@ fi
 
 #echo "hostnameMatch ='${hostnameMatch}'"
 
-systemNameTypeMatchedList+=(${hostnameMatchSystemName})
-systemNameTypeMatchedListHostNames[${hostnameMatchSystemName}]=${hostnameMatch}
+if [[ "${hostnameMatch}" != "" ]] ; then
+  systemNameTypeMatchedList+=(${hostnameMatchSystemName})
+  systemNameTypeMatchedListHostNames[${hostnameMatchSystemName}]=${hostnameMatch}
+fi
 
 #
 # C) Look for known system types that matches this machine


### PR DESCRIPTION
This should fix the bug reported in #6276 for systems where the ATDM system is not selected from the hostname (e.g. 'sems-rhel7').  It was just a bug on my part.

I also got rid of some unnecessary code so the should should be more uniform now and easier to maintain.
