### PR TITLE
Tpetra: Fix #6282 (in CrsMatrix unpack functor, assume matrix rows sorted)

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_unpackCrsMatrixAndCombine_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_unpackCrsMatrixAndCombine_def.hpp
@@ -375,15 +375,17 @@ struct UnpackCrsMatrixAndCombineFunctor {
     const LO* const lids_raw = const_cast<const LO*> (lids_out.data ());
     const ST* const vals_raw = const_cast<const ST*> (vals_out.data ());
     LO num_modified = 0;
+
+    constexpr bool matrix_has_sorted_rows = true; // see #6282
     if (combine_mode == ADD) {
       num_modified +=
         local_matrix.sumIntoValues (import_lid, lids_raw, num_ent,
-                                    vals_raw, false, atomic);
+                                    vals_raw, matrix_has_sorted_rows, atomic);
     }
     else if (combine_mode == REPLACE) {
       num_modified +=
         local_matrix.replaceValues (import_lid, lids_raw, num_ent,
-                                    vals_raw, false, atomic);
+                                    vals_raw, matrix_has_sorted_rows, atomic);
     }
     else {
       dst = Kokkos::make_pair (4, i); // invalid combine mode


### PR DESCRIPTION
@trilinos/tpetra @vbrunini 

In the Tpetra::CrsMatrix unpack functor, assume that the local matrix's rows are sorted, when calling sumIntoValues and replaceValues.

## Related Issues

* Closes #6282 

## Stakeholder Feedback

See Sierra Thermal Fluids issue TF-1264.

## Testing

This should be exercised by existing Tpetra::CrsMatrix unpack / doExport / doImport tests.