### PR TITLE
Tpetra: Fix #6300; add benchmark for CrsMatrix unpack

### DIFF
--- a/packages/tpetra/core/example/advanced/Benchmarks/CMakeLists.txt
+++ b/packages/tpetra/core/example/advanced/Benchmarks/CMakeLists.txt
@@ -33,8 +33,11 @@ TRIBITS_ADD_EXECUTABLE(
   COMM serial mpi
 )
 
+# This benchmark needs at least 2 MPI processes.
+# It builds fine without MPI, but there's no point
+# in building it for that case.
 TRIBITS_ADD_EXECUTABLE(
   CrsMatrixDenseRowUnpack
   SOURCES CrsMatrixDenseRowUnpack.cpp
-  COMM serial mpi
+  COMM mpi
 )

--- a/packages/tpetra/core/example/advanced/Benchmarks/CMakeLists.txt
+++ b/packages/tpetra/core/example/advanced/Benchmarks/CMakeLists.txt
@@ -32,3 +32,9 @@ TRIBITS_ADD_EXECUTABLE(
   SOURCES CrsMatrix_sumIntoLocalValues.cpp
   COMM serial mpi
 )
+
+TRIBITS_ADD_EXECUTABLE(
+  CrsMatrixDenseRowUnpack
+  SOURCES CrsMatrixDenseRowUnpack.cpp
+  COMM serial mpi
+)

--- a/packages/tpetra/core/example/advanced/Benchmarks/CrsMatrixDenseRowUnpack.cpp
+++ b/packages/tpetra/core/example/advanced/Benchmarks/CrsMatrixDenseRowUnpack.cpp
@@ -635,6 +635,8 @@ void printCmdLineArgs(std::ostream& out,
       << "  lclNumRows: " << args.lclNumRows << endl
       << "  lclNumCols: " << args.lclNumCols << endl
       << "  numTrials: " << args.numTrials << endl
+      << "  numOverlapRows: " << args.numOverlapRows << endl
+      << "  contiguousMaps: " << args.contiguousMaps << endl
       << endl;
 }
 

--- a/packages/tpetra/core/example/advanced/Benchmarks/CrsMatrixDenseRowUnpack.cpp
+++ b/packages/tpetra/core/example/advanced/Benchmarks/CrsMatrixDenseRowUnpack.cpp
@@ -645,6 +645,13 @@ int main(int argc, char* argv[])
   Tpetra::ScopeGuard tpetraScope(&argc, &argv);
   {
     auto tpetraComm = Tpetra::getDefaultComm();
+    const int minNumProcs = 2;
+    if(tpetraComm->getSize() < minNumProcs) {
+      std::cerr << "This benchmark must be run with at least "
+                << minNumProcs << " MPI processes." << std::endl;
+      return EXIT_FAILURE;
+    }
+
     CommandLineProcessor cmdp;
     CmdLineArgs args;
     setCmdLineArgs(args, cmdp);

--- a/packages/tpetra/core/example/advanced/Benchmarks/CrsMatrixDenseRowUnpack.cpp
+++ b/packages/tpetra/core/example/advanced/Benchmarks/CrsMatrixDenseRowUnpack.cpp
@@ -1,0 +1,494 @@
+// @HEADER
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services Package
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// ************************************************************************
+// @HEADER
+
+#include "Tpetra_Core.hpp"
+#include "Tpetra_CrsGraph.hpp"
+#include "Tpetra_CrsMatrix.hpp"
+#include "Tpetra_Export.hpp"
+#include "Tpetra_Map.hpp"
+#include "Tpetra_Details_Behavior.hpp"
+#include "Teuchos_CommandLineProcessor.hpp"
+#include "Teuchos_FancyOStream.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include <numeric>
+#include <cmath>
+
+using Tpetra::global_size_t;
+using Teuchos::Array;
+using Teuchos::ArrayView;
+using Teuchos::as;
+using Teuchos::CommandLineProcessor;
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::Time;
+using Teuchos::TimeMonitor;
+
+using GST = Tpetra::global_size_t;
+using map_type = Tpetra::Map<>;
+using LO = map_type::local_ordinal_type;
+using GO = map_type::global_ordinal_type;
+using crs_graph_type = Tpetra::CrsGraph<>;
+using crs_matrix_type = Tpetra::CrsMatrix<double>;
+using export_type = Tpetra::Export<>;
+
+struct CmdLineArgs {
+  double densityFraction = 1.0;
+  int lclNumRows = 10;
+  int lclNumCols = -1;
+  int numTrials = 100;
+  int numOverlapRows = 3;
+  bool contiguousMaps = true;
+};
+
+std::unique_ptr<GO[]>
+getTargetRowMapIndices(const LO lclNumRows,
+                       const int myRank,
+                       const int numProcs)
+{
+  const GO gblNumRows = GO(lclNumRows) * GO(numProcs);
+  const GO indexBase = 0;
+  const GO gidBase = indexBase + GO(lclNumRows) * GO(myRank);
+
+  // LIDs [0, N-1] -> GIDs gidBase + [N-1, 1, N-2, 2, ...].
+  std::unique_ptr<GO[]> tgtGids(new GO[lclNumRows]);
+  for (LO lid = 0; lid < lclNumRows; ++lid) {
+    const LO offset = (lid % LO(2) == 0) ?
+      lclNumRows - LO(1) - lid : lid;
+    const GO gblRow = gidBase + GO(offset);
+    TEUCHOS_ASSERT(gblRow >= indexBase);
+    TEUCHOS_ASSERT(gblRow < indexBase + gblNumRows);
+    tgtGids[lid] = gblRow;
+  }
+  return std::move(tgtGids);
+}
+
+RCP<const map_type>
+getTargetRowMap(const RCP<const Teuchos::Comm<int>>& comm,
+                const CmdLineArgs& args)
+{
+  const int myRank = comm->getRank();
+  const int numProcs = comm->getSize();
+  const LO lclNumRows = args.lclNumRows;
+  const GO gblNumRows = GO(lclNumRows) * GO(numProcs);
+  const GO indexBase = 0;
+
+  if(args.contiguousMaps) {
+    return rcp(new map_type(gblNumRows, indexBase, comm));
+  }
+  else {
+    std::unique_ptr<GO[]> tgtGids =
+      getTargetRowMapIndices(lclNumRows, myRank, numProcs);
+    return rcp(new map_type(gblNumRows, tgtGids.get(),
+                            lclNumRows, indexBase, comm));
+  }
+}
+
+RCP<const map_type>
+getSourceRowMap(const RCP<const map_type>& tgtMap,
+                const CmdLineArgs& args)
+{
+  const auto comm = tgtMap->getComm();
+  const int myRank = comm->getRank();
+  const int numProcs = comm->getSize();
+  const LO tgtLclNumRows = LO(args.lclNumRows);
+  const GO tgtGblNumRows = GO(tgtLclNumRows) * GO(numProcs);
+  const GO indexBase = tgtMap->getIndexBase();
+  const GO tgtGidBase = indexBase + GO(tgtLclNumRows) * GO(myRank);
+  const GO srcGidBase = indexBase +
+    ((tgtGidBase + GO(tgtLclNumRows)) % tgtGblNumRows);
+  const LO srcLclNumRows = LO(args.numOverlapRows);
+
+  TEUCHOS_ASSERT(srcGidBase >= indexBase);
+  TEUCHOS_ASSERT(srcGidBase < indexBase + tgtGblNumRows);
+
+  // Construct Source Map so that copyAndPermute has nothing to do.
+  // This should help focus the benchmark on pack and unpack.
+  std::unique_ptr<GO[]> srcGids(new GO[srcLclNumRows]);
+  for(LO lid = 0; lid < srcLclNumRows; ++lid) {
+    const GO gblRow = srcGidBase + GO(lid);
+    TEUCHOS_ASSERT(gblRow >= indexBase);
+    TEUCHOS_ASSERT(gblRow < indexBase + tgtGblNumRows);
+    srcGids[lid] = gblRow;
+  }
+  using Teuchos::OrdinalTraits;
+  return rcp(new map_type(OrdinalTraits<GST>::invalid(), srcGids.get(),
+                          srcLclNumRows, tgtMap->getIndexBase(), comm));
+}
+
+RCP<const map_type>
+getDomainMap(const RCP<const Teuchos::Comm<int>>& comm,
+             const CmdLineArgs& args)
+{
+  const int numProcs = comm->getSize();
+  const GO gblNumCols = GO(args.lclNumCols) * GO(numProcs);
+  const GO indexBase = 0;
+
+  return rcp(new map_type(gblNumCols, indexBase, comm));
+}
+
+// Create a new timer with the given name if it hasn't already been
+// created, else get the previously created timer with that name.
+RCP<Time> getTimer(const std::string& timerName) {
+  RCP<Time> timer = TimeMonitor::lookupCounter(timerName);
+  if (timer.is_null()) {
+    timer = TimeMonitor::getNewCounter(timerName);
+  }
+  return timer;
+}
+
+class FillSourceMatrixValues {
+public:
+  FillSourceMatrixValues(const crs_matrix_type::local_matrix_type& A)
+    : A_(A)
+  {}
+  KOKKOS_INLINE_FUNCTION void operator() (const LO lclRow) const {
+    auto A_row = A_.row(lclRow);
+    const double multiplier = (double(A_.numRows()) + 1.0) * double(lclRow);
+    for(LO lclCol = 0; lclCol < A_row.length; ++lclCol) {
+      A_row.value(lclCol) = multiplier + (1.0 + double(lclCol));
+    }
+  }
+private:
+  crs_matrix_type::local_matrix_type A_;
+};
+
+void
+fillSourceMatrixValues(const crs_matrix_type& A)
+{
+  TEUCHOS_ASSERT(! A.isFillComplete() );
+  auto A_lcl = A.getLocalMatrix();
+  using execution_space =
+    crs_matrix_type::device_type::execution_space;
+  using range_type = Kokkos::RangePolicy<execution_space, LO>;
+  Kokkos::parallel_for("Fill source's values",
+                       range_type(0, A_lcl.numRows()),
+                       FillSourceMatrixValues(A_lcl));
+}
+
+// FIXME (mfh 17 Nov 2019) We actually should have the source matrix
+// have fewer entries per row than the target matrix, so that we don't
+// hit any potential "all the column indices are the same"
+// optimizations.
+
+class TestTargetMatrixValues {
+public:
+  TestTargetMatrixValues(const crs_matrix_type::local_matrix_type& A,
+                         const bool replaceCombineMode)
+    : A_(A), replaceCombineMode_(replaceCombineMode)
+  {}
+  KOKKOS_INLINE_FUNCTION void
+  operator() (const LO lclRow, int& success) const {
+    auto A_row = A_.row(lclRow);
+    const double multiplier = (double(A_.numRows()) + 1.0) * double(lclRow);
+    for(LO lclCol = 0; lclCol < A_row.length; ++lclCol) {
+      const double value = multiplier + (1.0 + double(lclCol));
+      const bool mySuccess = replaceCombineMode_ ?
+        value == A_row.value(lclCol) :
+        value - 1.0 == A_row.value(lclCol);
+      success = mySuccess ? success : 0;
+    }
+  }
+private:
+  crs_matrix_type::local_matrix_type A_;
+  bool replaceCombineMode_;
+};
+
+int
+testTargetLocalMatrixValues(const crs_matrix_type::local_matrix_type& A,
+                            const Tpetra::CombineMode combineMode)
+{
+  const bool replaceCombineMode = combineMode == Tpetra::REPLACE;
+  using execution_space =
+    crs_matrix_type::device_type::execution_space;
+  int lclSuccess = 0;
+  Kokkos::parallel_reduce("Test target's values",
+    Kokkos::RangePolicy<execution_space, LO>(0, A.numRows()),
+    TestTargetMatrixValues(A, combineMode),
+    Kokkos::Min<int, Kokkos::AnonymousSpace>(lclSuccess));
+  return lclSuccess;
+}
+
+void
+testTargetMatrixValues(const crs_matrix_type& A,
+                       const Tpetra::CombineMode combineMode)
+{
+  const int lclSuccess =
+    testTargetLocalMatrixValues(A.getLocalMatrix(), combineMode);
+  int gblSuccess = 1;
+  auto comm = A.getMap()->getComm();
+  Teuchos::reduceAll(*comm, Teuchos::REDUCE_MIN, lclSuccess,
+                     Teuchos::outArg(gblSuccess));
+  TEUCHOS_TEST_FOR_EXCEPTION
+    (gblSuccess != 1, std::logic_error, "Test failed: "
+     << Tpetra::combineModeToString(combineMode) << " CombineMode");
+}
+
+void benchmark(const RCP<const Teuchos::Comm<int>>& comm,
+               const CmdLineArgs& args)
+{
+  using std::cerr;
+  using std::endl;
+
+  const int numProcs = comm->getSize();
+  const int myRank = comm->getRank();
+  const bool verbose = Tpetra::Details::Behavior::verbose();
+  std::unique_ptr<std::string> prefix;
+  if(verbose) {
+    std::ostringstream os;
+    os << "Proc " << myRank << ": ";
+    prefix = std::unique_ptr<std::string>(new std::string(os.str()));
+    os << "benchmark: Make Maps" << endl;
+    cerr << os.str();
+  }
+
+  auto tgtRowMap = getTargetRowMap(comm, args);
+  auto domainMap = getDomainMap(comm, args);
+  auto rangeMap  = tgtRowMap;
+  auto srcRowMap = getSourceRowMap(tgtRowMap, args);
+
+  RCP<Teuchos::FancyOStream> fancyOutPtr;
+  if(verbose) {
+    fancyOutPtr = Teuchos::getFancyOStream(Teuchos::rcpFromRef(cerr));
+    cerr << "Target row Map:" << endl;
+    tgtRowMap->describe(*fancyOutPtr, Teuchos::VERB_EXTREME);
+    cerr << "Source row Map:" << endl;
+    srcRowMap->describe(*fancyOutPtr, Teuchos::VERB_EXTREME);
+  }
+
+  const LO lclNumCols = LO(args.lclNumCols);
+  const GO gblNumCols = GO(lclNumCols) * GO(numProcs);
+  const LO maxNumColsToFill =
+    std::ceil(args.densityFraction * double(gblNumCols));
+  const LO numColsToFill = maxNumColsToFill > gblNumCols ?
+    gblNumCols : maxNumColsToFill;
+
+  if(verbose) {
+    std::ostringstream os;
+    os << *prefix << "Make Graphs: {lclNumCols: " << lclNumCols
+       << ", numColsToFill: " << numColsToFill << "}" << endl;
+    cerr << os.str();
+  }
+
+  std::unique_ptr<GO[]> colGids(new GO[numColsToFill]);
+  std::iota(colGids.get(), colGids.get()+numColsToFill,
+            domainMap->getIndexBase());
+  auto tgtGraph = rcp(new crs_graph_type(tgtRowMap, numColsToFill));
+  auto srcGraph = rcp(new crs_graph_type(srcRowMap, numColsToFill));
+
+  Kokkos::fence(); // let device allocations & fills finish
+  for(LO lclRow = 0; lclRow < LO(tgtRowMap->getNodeNumElements()); ++lclRow) {
+    const GO gblRow = tgtRowMap->getGlobalElement(lclRow);
+    tgtGraph->insertGlobalIndices(gblRow, numColsToFill, colGids.get());
+  }
+  for(LO lclRow = 0; lclRow < LO(srcRowMap->getNodeNumElements()); ++lclRow) {
+    const GO gblRow = srcRowMap->getGlobalElement(lclRow);
+    srcGraph->insertGlobalIndices(gblRow, numColsToFill, colGids.get());
+  }
+  tgtGraph->fillComplete(domainMap, rangeMap);
+  srcGraph->fillComplete(domainMap, rangeMap);
+
+  crs_matrix_type tgtMatrix(tgtGraph);
+  tgtMatrix.setAllToScalar(-1.0); // flag value
+  tgtMatrix.fillComplete(domainMap, rangeMap);
+  crs_matrix_type srcMatrix(srcGraph);
+
+  fillSourceMatrixValues(srcMatrix);
+  srcMatrix.fillComplete(domainMap, rangeMap);
+
+  export_type exporter(srcRowMap, tgtRowMap);
+
+  // Before benchmarking, actually test the two cases: CombineModes
+  // REPLACE and ADD.
+
+  tgtMatrix.resumeFill();
+  {
+    const Tpetra::CombineMode combineMode = Tpetra::REPLACE;
+    tgtMatrix.doExport(srcMatrix, exporter, combineMode);
+    testTargetMatrixValues(tgtMatrix, combineMode);
+  }
+  tgtMatrix.setAllToScalar(-1.0); // flag value
+  {
+    const Tpetra::CombineMode combineMode = Tpetra::ADD;
+    tgtMatrix.doExport(srcMatrix, exporter, combineMode);
+    testTargetMatrixValues(tgtMatrix, combineMode);
+  }
+  tgtMatrix.setAllToScalar(-1.0); // flag value
+
+  for (auto combineMode : {Tpetra::ADD, Tpetra::REPLACE}) {
+    auto timer = [&] {
+      std::ostringstream os;
+      os << "Tpetra::CrsMatrix::doExport: " << args.numTrials
+         << " trial" << (args.numTrials != 1 ? "s" : "") << ", "
+         << Tpetra::combineModeToString(combineMode) << " CombineMode";
+      return getTimer(os.str());
+    }();
+    {
+      TimeMonitor timeMon(*timer);
+      for(int trial = 0; trial < args.numTrials; ++trial) {
+        tgtMatrix.doExport(srcMatrix, exporter, Tpetra::ADD);
+      }
+    }
+    tgtMatrix.setAllToScalar(-1.0); // flag value
+  }
+}
+
+void setCmdLineArgs(CmdLineArgs& args,
+                    Teuchos::CommandLineProcessor& cmdp)
+{
+  cmdp.setOption ("densityFraction", &args.densityFraction,
+                  "Fraction: Number of entries in each \"dense\" "
+                  "row, divided by number of columns");
+  cmdp.setOption ("lclNumRows", &args.lclNumRows,
+                  "Number of row (and range) Map rows per process");
+  cmdp.setOption ("lclNumCols", &args.lclNumCols,
+                  "Number of domain Map indices per process; "
+                  "-1 means \"same as lclNumRows\"");
+  cmdp.setOption ("numTrials", &args.numTrials,
+                  "Number of times to repeat each "
+                  "operation in a timing loop");
+  cmdp.setOption ("numOverlapRows", &args.numOverlapRows,
+                  "Number of overlapping rows (that is, rows that "
+                  "the target matrix needs to receive from a remote "
+                  "process) per process.");
+  cmdp.setOption ("contiguousMaps", "noncontiguousMaps",
+                  &args.contiguousMaps,
+                  "Whether the row, domain, and range Maps "
+                  "of the target CrsMatrix are contiguous.");
+}
+
+enum class CmdLineArgsValidation {
+  VALID,
+  PRINTED_HELP,
+  INVALID
+};
+
+CmdLineArgsValidation
+getAndValidateCmdLineArgs(CmdLineArgs& args,
+                          Teuchos::CommandLineProcessor& cmdp,
+                          std::ostream& err,
+                          int argc,
+                          char* argv[])
+{
+  const CommandLineProcessor::EParseCommandLineReturn parseResult =
+    cmdp.parse(argc, argv);
+  if(parseResult == CommandLineProcessor::PARSE_HELP_PRINTED) {
+    // The user specified --help at the command line to print help
+    // with command-line arguments.
+    return CmdLineArgsValidation::PRINTED_HELP;
+  }
+  else {
+    using std::endl;
+    bool valid = true;
+    if(parseResult != CommandLineProcessor::PARSE_SUCCESSFUL) {
+      err << "Failed to parse command-line arguments." << endl;
+      valid = false;
+    }
+    if(args.numTrials < 0) {
+      err << "numTrials must be nonnegative." << endl;
+      valid = false;
+    }
+    if(args.lclNumRows < 0) {
+      err << "lclNumRows must be nonnegative." << endl;
+      valid = false;
+    }
+
+    if(args.lclNumCols == -1) {
+      args.lclNumCols = args.lclNumRows;
+    }
+    else if(args.lclNumCols < 0) {
+      err << "lclNumCols must be nonnegative." << endl;
+      valid = false;
+    }
+
+    if(args.numOverlapRows < 0) {
+      err << "numOverlapRows must be nonnegative." << endl;
+      valid = false;
+    }
+    if(args.numOverlapRows > args.lclNumRows) {
+      err << "numOverlapRows must be <= lclNumRows." << endl;
+      valid = false;
+    }
+    if(args.densityFraction < 0.0 || args.densityFraction > 1.0) {
+      err << "densityFraction must be in [0,1]." << endl;
+      valid = false;
+    }
+    return valid ? CmdLineArgsValidation::VALID :
+      CmdLineArgsValidation::INVALID;
+  }
+}
+
+void printCmdLineArgs(std::ostream& out,
+                      const CmdLineArgs& args)
+{
+  using std::endl;
+  out << endl << "---" << endl
+      << "Command-line options:" << endl
+      << "  densityFraction: " << args.densityFraction << endl
+      << "  lclNumRows: " << args.lclNumRows << endl
+      << "  lclNumCols: " << args.lclNumCols << endl
+      << "  numTrials: " << args.numTrials << endl
+      << endl;
+}
+
+int main(int argc, char* argv[])
+{
+  Tpetra::ScopeGuard tpetraScope(&argc, &argv);
+  {
+    auto tpetraComm = Tpetra::getDefaultComm();
+    CommandLineProcessor cmdp;
+    CmdLineArgs args;
+    setCmdLineArgs(args, cmdp);
+    const auto validation =
+      getAndValidateCmdLineArgs(args, cmdp, std::cerr, argc, argv);
+    if(validation == CmdLineArgsValidation::PRINTED_HELP) {
+      return EXIT_SUCCESS;
+    }
+    else if(validation == CmdLineArgsValidation::INVALID) {
+      return EXIT_FAILURE;
+    }
+    else {
+      if(tpetraComm->getRank() == 0) {
+        printCmdLineArgs(std::cout, args);
+      }
+      benchmark(tpetraComm, args);
+      TimeMonitor::report(tpetraComm.ptr(), std::cout);
+    }
+  }
+  return EXIT_SUCCESS;
+}

--- a/packages/tpetra/core/src/CMakeLists.txt
+++ b/packages/tpetra/core/src/CMakeLists.txt
@@ -768,5 +768,5 @@ SET_PROPERTY(
 # / from this directory, or to / from the 'impl' subdirectory.  That ensures
 # that running "make" will also rerun CMake in order to regenerate Makefiles.
 #
-# Here's another change.
+# Here's another change, and another.
 #

--- a/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_def.hpp
@@ -34,8 +34,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
-//
 // ************************************************************************
 // @HEADER
 
@@ -2582,7 +2580,7 @@ public:
     /// its constructor), then the second argument is the result of
     /// <tt>PackTraits<Scalar>::packValueCount</tt>, called on a
     /// <tt>Scalar</tt> value with the correct run-time size.
-    template<class LO, class GO, class D>
+    template<class LO, class GO>
     size_t
     packRowCount (const size_t numEnt,
                   const size_t numBytesPerValue,
@@ -2597,9 +2595,9 @@ public:
       else {
         // We store the number of entries as a local index (LO).
         LO numEntLO = 0; // packValueCount wants this.
-        GO gid;
-        const size_t numEntLen = PackTraits<LO, D>::packValueCount (numEntLO);
-        const size_t gidsLen = numEnt * PackTraits<GO, D>::packValueCount (gid);
+        GO gid {};
+        const size_t numEntLen = PackTraits<LO>::packValueCount (numEntLO);
+        const size_t gidsLen = numEnt * PackTraits<GO>::packValueCount (gid);
         const size_t valsLen = numEnt * numBytesPerValue * blkSize * blkSize;
         return numEntLen + gidsLen + valsLen;
       }
@@ -2615,9 +2613,9 @@ public:
     ///   scalar (not block!) entry (value) of the row.
     ///
     /// \return Number of (block) entries in the packed row.
-    template<class ST, class LO, class GO, class D>
+    template<class ST, class LO, class GO>
     size_t
-    unpackRowCount (const typename ::Tpetra::Details::PackTraits<LO, D>::input_buffer_type& imports,
+    unpackRowCount (const typename ::Tpetra::Details::PackTraits<LO>::input_buffer_type& imports,
                     const size_t offset,
                     const size_t numBytes,
                     const size_t /* numBytesPerValue */)
@@ -2631,13 +2629,13 @@ public:
       }
       else {
         LO numEntLO = 0;
-        const size_t theNumBytes = PackTraits<LO, D>::packValueCount (numEntLO);
+        const size_t theNumBytes = PackTraits<LO>::packValueCount (numEntLO);
         TEUCHOS_TEST_FOR_EXCEPTION
           (theNumBytes > numBytes, std::logic_error, "unpackRowCount: "
            "theNumBytes = " << theNumBytes << " < numBytes = " << numBytes
            << ".");
         const char* const inBuf = imports.data () + offset;
-        const size_t actualNumBytes = PackTraits<LO, D>::unpackValue (numEntLO, inBuf);
+        const size_t actualNumBytes = PackTraits<LO>::unpackValue (numEntLO, inBuf);
         TEUCHOS_TEST_FOR_EXCEPTION
           (actualNumBytes > numBytes, std::logic_error, "unpackRowCount: "
            "actualNumBytes = " << actualNumBytes << " < numBytes = " << numBytes
@@ -2649,13 +2647,13 @@ public:
     /// \brief Pack the block row (stored in the input arrays).
     ///
     /// \return The number of bytes packed.
-    template<class ST, class LO, class GO, class D>
+    template<class ST, class LO, class GO>
     size_t
-    packRowForBlockCrs (const typename ::Tpetra::Details::PackTraits<LO, D>::output_buffer_type exports,
+    packRowForBlockCrs (const typename ::Tpetra::Details::PackTraits<LO>::output_buffer_type exports,
                         const size_t offset,
                         const size_t numEnt,
-                        const typename ::Tpetra::Details::PackTraits<GO, D>::input_array_type& gidsIn,
-                        const typename ::Tpetra::Details::PackTraits<ST, D>::input_array_type& valsIn,
+                        const typename ::Tpetra::Details::PackTraits<GO>::input_array_type& gidsIn,
+                        const typename ::Tpetra::Details::PackTraits<ST>::input_array_type& valsIn,
                         const size_t numBytesPerValue,
                         const size_t blockSize)
     {
@@ -2672,9 +2670,9 @@ public:
       const LO numEntLO = static_cast<size_t> (numEnt);
 
       const size_t numEntBeg = offset;
-      const size_t numEntLen = PackTraits<LO, D>::packValueCount (numEntLO);
+      const size_t numEntLen = PackTraits<LO>::packValueCount (numEntLO);
       const size_t gidsBeg = numEntBeg + numEntLen;
-      const size_t gidsLen = numEnt * PackTraits<GO, D>::packValueCount (gid);
+      const size_t gidsLen = numEnt * PackTraits<GO>::packValueCount (gid);
       const size_t valsBeg = gidsBeg + gidsLen;
       const size_t valsLen = numScalarEnt * numBytesPerValue;
 
@@ -2684,15 +2682,15 @@ public:
 
       size_t numBytesOut = 0;
       int errorCode = 0;
-      numBytesOut += PackTraits<LO, D>::packValue (numEntOut, numEntLO);
+      numBytesOut += PackTraits<LO>::packValue (numEntOut, numEntLO);
 
       {
         Kokkos::pair<int, size_t> p;
-        p = PackTraits<GO, D>::packArray (gidsOut, gidsIn.data (), numEnt);
+        p = PackTraits<GO>::packArray (gidsOut, gidsIn.data (), numEnt);
         errorCode += p.first;
         numBytesOut += p.second;
 
-        p = PackTraits<ST, D>::packArray (valsOut, valsIn.data (), numScalarEnt);
+        p = PackTraits<ST>::packArray (valsOut, valsIn.data (), numScalarEnt);
         errorCode += p.first;
         numBytesOut += p.second;
       }
@@ -2711,11 +2709,11 @@ public:
     }
 
     // Return the number of bytes actually read / used.
-    template<class ST, class LO, class GO, class D>
+    template<class ST, class LO, class GO>
     size_t
-    unpackRowForBlockCrs (const typename ::Tpetra::Details::PackTraits<GO, D>::output_array_type& gidsOut,
-                          const typename ::Tpetra::Details::PackTraits<ST, D>::output_array_type& valsOut,
-                          const typename ::Tpetra::Details::PackTraits<int, D>::input_buffer_type& imports,
+    unpackRowForBlockCrs (const typename ::Tpetra::Details::PackTraits<GO>::output_array_type& gidsOut,
+                          const typename ::Tpetra::Details::PackTraits<ST>::output_array_type& valsOut,
+                          const typename ::Tpetra::Details::PackTraits<int>::input_buffer_type& imports,
                           const size_t offset,
                           const size_t numBytes,
                           const size_t numEnt,
@@ -2743,9 +2741,9 @@ public:
       const LO lid = 0; // packValueCount wants this
 
       const size_t numEntBeg = offset;
-      const size_t numEntLen = PackTraits<LO, D>::packValueCount (lid);
+      const size_t numEntLen = PackTraits<LO>::packValueCount (lid);
       const size_t gidsBeg = numEntBeg + numEntLen;
-      const size_t gidsLen = numEnt * PackTraits<GO, D>::packValueCount (gid);
+      const size_t gidsLen = numEnt * PackTraits<GO>::packValueCount (gid);
       const size_t valsBeg = gidsBeg + gidsLen;
       const size_t valsLen = numScalarEnt * numBytesPerValue;
 
@@ -2756,7 +2754,7 @@ public:
       size_t numBytesOut = 0;
       int errorCode = 0;
       LO numEntOut;
-      numBytesOut += PackTraits<LO, D>::unpackValue (numEntOut, numEntIn);
+      numBytesOut += PackTraits<LO>::unpackValue (numEntOut, numEntIn);
       TEUCHOS_TEST_FOR_EXCEPTION
         (static_cast<size_t> (numEntOut) != numEnt, std::logic_error,
          "unpackRowForBlockCrs: Expected number of entries " << numEnt
@@ -2764,11 +2762,11 @@ public:
 
       {
         Kokkos::pair<int, size_t> p;
-        p = PackTraits<GO, D>::unpackArray (gidsOut.data (), gidsIn, numEnt);
+        p = PackTraits<GO>::unpackArray (gidsOut.data (), gidsIn, numEnt);
         errorCode += p.first;
         numBytesOut += p.second;
 
-        p = PackTraits<ST, D>::unpackArray (valsOut.data (), valsIn, numScalarEnt);
+        p = PackTraits<ST>::unpackArray (valsOut.data (), valsIn, numScalarEnt);
         errorCode += p.first;
         numBytesOut += p.second;
       }
@@ -2897,7 +2895,7 @@ public:
     const size_t blockSize = static_cast<size_t> (src->getBlockSize ());
     const size_t numExportLIDs = exportLIDs.extent (0);
     const size_t numBytesPerValue =
-      PackTraits<impl_scalar_type, host_exec>
+      PackTraits<impl_scalar_type>
       ::packValueCount(this->val_.extent(0) ? this->val_.view_host()(0) : impl_scalar_type());
 
     // Compute the number of bytes ("packets") per row to pack.  While
@@ -2921,7 +2919,7 @@ public:
           numEnt = (numEnt == Teuchos::OrdinalTraits<size_t>::invalid () ? 0 : numEnt);
 
           const size_t numBytes =
-            packRowCount<LO, GO, host_exec> (numEnt, numBytesPerValue, blockSize);
+            packRowCount<LO, GO> (numEnt, numBytesPerValue, blockSize);
           numPacketsPerLIDHost(i) = numBytes;
           update += typename reducer_type::value_type(numEnt, numBytes, numEnt);
         }, rowReducerStruct);
@@ -3016,12 +3014,13 @@ public:
             //   the following function interface need the same execution space
             //   host scratch space somehow is not considered same as the host_exec
             // Copy the row's data into the current spot in the exports array.
-            const size_t numBytes = packRowForBlockCrs<impl_scalar_type,LO,GO,host_exec>
+            const size_t numBytes =
+              packRowForBlockCrs<impl_scalar_type, LO, GO>
               (exports.view_host(),
                offset(i),
                numEnt,
-               Kokkos::View<const GO*,host_exec>(gblColInds.data(), maxRowLength),
-               Kokkos::View<const impl_scalar_type*,host_exec>(reinterpret_cast<const impl_scalar_type*>(valsRaw), numEnt*blockSize*blockSize),
+               Kokkos::View<const GO*, host_exec>(gblColInds.data(), maxRowLength),
+               Kokkos::View<const impl_scalar_type*, host_exec>(reinterpret_cast<const impl_scalar_type*>(valsRaw), numEnt*blockSize*blockSize),
                numBytesPerValue,
                blockSize);
 
@@ -3164,7 +3163,7 @@ public:
     // could be bad if the calling process has no entries, but other
     // processes have entries that they want to send to us.
     const size_t numBytesPerValue =
-      PackTraits<impl_scalar_type, host_exec>::packValueCount
+      PackTraits<impl_scalar_type>::packValueCount
         (this->val_.extent (0) ? this->val_.view_host () (0) : impl_scalar_type ());
     const size_t maxRowNumEnt = graph_.getNodeMaxNumRowEntries ();
     const size_t maxRowNumScalarEnt = maxRowNumEnt * blockSize * blockSize;
@@ -3273,7 +3272,7 @@ public:
           const LO lclRow = importLIDsHost(i);
           const size_t numBytes = numPacketsPerLIDHost(i);
           const size_t numEnt =
-            unpackRowCount<impl_scalar_type, LO, GO, host_exec>
+            unpackRowCount<impl_scalar_type, LO, GO>
             (imports.view_host (), offval, numBytes, numBytesPerValue);
 
           if (numBytes > 0) {
@@ -3301,7 +3300,7 @@ public:
           size_t numBytesOut = 0;
           try {
             numBytesOut =
-              unpackRowForBlockCrs<impl_scalar_type, LO, GO, host_exec>
+              unpackRowForBlockCrs<impl_scalar_type, LO, GO>
               (Kokkos::View<GO*,host_exec>(gidsOut.data(), numEnt),
                Kokkos::View<impl_scalar_type*,host_exec>(valsOut.data(), numScalarEnt),
                imports.view_host(),

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -55,7 +55,7 @@
 #include "Tpetra_DistObject.hpp"
 #include "Tpetra_CrsGraph.hpp"
 #include "Tpetra_Vector.hpp"
-#include "Tpetra_Details_PackTraits.hpp"
+#include "Tpetra_Details_PackTraits.hpp" // unused here, could delete
 #include "KokkosSparse_CrsMatrix.hpp"
 
 // localGaussSeidel and reorderedLocalGaussSeidel are templated on
@@ -304,7 +304,7 @@ namespace Tpetra {
                                   const Teuchos::RCP<Teuchos::ParameterList>& params);
 
   /// \brief Nonmember function that computes a residual
-  /// Computes R = B - A * X 
+  /// Computes R = B - A * X
   namespace Details {
     template<class SC, class LO, class GO, class NO>
     void residual(const Operator<SC,LO,GO,NO> &   A,

--- a/packages/tpetra/core/src/Tpetra_Details_ScalarViewTraits.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_ScalarViewTraits.hpp
@@ -1,0 +1,121 @@
+// @HEADER
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services Package
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// ************************************************************************
+// @HEADER
+
+#ifndef TPETRA_DETAILS_SCALARVIEWTRAITS_HPP
+#define TPETRA_DETAILS_SCALARVIEWTRAITS_HPP
+
+///
+/// \file Tpetra_Details_ScalarViewTraits.hpp
+/// \brief Declaration and generic definition of traits class that
+///   tells Tpetra::CrsMatrix how to pack and unpack data.
+///
+
+#include "Tpetra_Details_PackTraits.hpp"
+
+namespace Tpetra {
+namespace Details {
+
+/// \brief Traits class for allocating a Kokkos::View<T*, D>.
+///
+/// \tparam T The type of the data to pack / unpack.
+/// \tparam D The Kokkos "device" type; where the data live.
+template<class T, class D>
+struct ScalarViewTraits {
+  using value_type = T;
+  using device_type = D;
+
+  /// \brief Given an instance of \c value_type allocated with the
+  ///   right size, allocate and return a one-dimensional array of
+  ///   \c value_type.
+  ///
+  /// This function lets the pack and unpack code that uses
+  /// ScalarViewTraits correctly handle types that have a size
+  /// specified at run time.  In particular, it's helpful if that code
+  /// needs to allocate temporary buffers of \c value_type.
+  /// ScalarViewTraits still assumes that all instances of \c
+  /// value_type in an input or output array have the same run-time
+  /// size.
+  ///
+  /// \param x [in] Instance of \c value_type with the correct
+  ///  (run-time) size.
+  ///
+  /// \param numEnt [in] Number of entries in the returned
+  ///   Kokkos::View.
+  ///
+  /// \param label [in] Optional string label of the returned
+  ///   Kokkos::View.  (Kokkos::View's constructor takes a string
+  ///   label, which Kokkos uses for debugging output.)
+  ///
+  /// \return One-dimensional array of \c value_type, all instances of
+  ///   which have the same (run-time) size as \c x.
+  ///
+  /// \note To implementers of specializations: If the number of bytes
+  ///   to pack or unpack your type may be determined at run time, you
+  ///   might be able just to use this implementation as-is, and just
+  ///   reimplement numValuesPerScalar().
+  static Kokkos::View<value_type*, device_type>
+  allocateArray (const value_type& x,
+                 const size_t numEnt,
+                 const std::string& label = "")
+  {
+    using view_type = Kokkos::View<value_type*, device_type>;
+    using size_type = typename view_type::size_type;
+
+    // When the traits::specialize type is non-void this exploits
+    // the fact that Kokkos::View's constructor ignores
+    // size arguments beyond what the View's type specifies.  For
+    // value_type = Stokhos::UQ::PCE<S>, numValuesPerScalar returns
+    // something other than 1, and the constructor will actually use
+    // that value.
+    // Otherwise, the number of arguments must match the dynamic rank
+    // (i.e. number *'s with the value_type of the View)
+    const size_t numVals = PackTraits<value_type>::numValuesPerScalar (x);
+    if (std::is_same<typename view_type::traits::specialize, void>::value ) {
+      return view_type (label, numEnt);
+    }
+    else {
+      return view_type (label, numEnt, numVals);
+    }
+  }
+}; // struct ScalarViewTraits
+
+} // namespace Details
+} // namespace Tpetra
+
+#endif // TPETRA_DETAILS_SCALARVIEWTRAITS_HPP

--- a/packages/tpetra/core/src/Tpetra_Details_ScalarViewTraits.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_ScalarViewTraits.hpp
@@ -95,7 +95,6 @@ struct ScalarViewTraits {
                  const std::string& label = "")
   {
     using view_type = Kokkos::View<value_type*, device_type>;
-    using size_type = typename view_type::size_type;
 
     // When the traits::specialize type is non-void this exploits
     // the fact that Kokkos::View's constructor ignores

--- a/packages/tpetra/core/src/Tpetra_Details_packCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_packCrsMatrix_def.hpp
@@ -34,8 +34,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
-//
 // ************************************************************************
 // @HEADER
 
@@ -407,9 +405,9 @@ KOKKOS_FUNCTION
 Kokkos::pair<int, size_t>
 packCrsMatrixRow (const ColumnMap& col_map,
                   const Kokkos::View<char*, BufferDeviceType>& exports,
-                  const typename PackTraits<typename ColumnMap::local_ordinal_type, typename ColumnMap::device_type>::input_array_type& lids_in,
-                  const typename PackTraits<int, typename ColumnMap::device_type>::input_array_type& pids_in,
-                  const typename PackTraits<ST, typename ColumnMap::device_type>::input_array_type& vals_in,
+                  const typename PackTraits<typename ColumnMap::local_ordinal_type>::input_array_type& lids_in,
+                  const typename PackTraits<int>::input_array_type& pids_in,
+                  const typename PackTraits<ST>::input_array_type& vals_in,
                   const size_t offset,
                   const size_t num_ent,
                   const size_t num_bytes_per_value,
@@ -428,14 +426,14 @@ packCrsMatrixRow (const ColumnMap& col_map,
 
   const LO num_ent_LO = static_cast<LO> (num_ent); // packValueCount wants this
   const size_t num_ent_beg = offset;
-  const size_t num_ent_len = PackTraits<LO, BDT>::packValueCount (num_ent_LO);
+  const size_t num_ent_len = PackTraits<LO>::packValueCount (num_ent_LO);
 
   const size_t gids_beg = num_ent_beg + num_ent_len;
-  const size_t gids_len = num_ent * PackTraits<GO, BDT>::packValueCount (GO (0));
+  const size_t gids_len = num_ent * PackTraits<GO>::packValueCount (GO (0));
 
   const size_t pids_beg = gids_beg + gids_len;
   const size_t pids_len = pack_pids ?
-    num_ent * PackTraits<int, BDT>::packValueCount (int (0)) :
+    num_ent * PackTraits<int>::packValueCount (int (0)) :
     static_cast<size_t> (0);
 
   const size_t vals_beg = gids_beg + gids_len + pids_len;
@@ -448,7 +446,7 @@ packCrsMatrixRow (const ColumnMap& col_map,
 
   size_t num_bytes_out = 0;
   int error_code = 0;
-  num_bytes_out += PackTraits<LO, BDT>::packValue (num_ent_out, num_ent_LO);
+  num_bytes_out += PackTraits<LO>::packValue (num_ent_out, num_ent_LO);
 
   {
     // Copy column indices one at a time, so that we don't need
@@ -456,18 +454,18 @@ packCrsMatrixRow (const ColumnMap& col_map,
     for (size_t k = 0; k < num_ent; ++k) {
       const LO lid = lids_in[k];
       const GO gid = col_map.getGlobalElement (lid);
-      num_bytes_out += PackTraits<GO, BDT>::packValue (gids_out, k, gid);
+      num_bytes_out += PackTraits<GO>::packValue (gids_out, k, gid);
     }
     // Copy PIDs one at a time, so that we don't need temporary storage.
     if (pack_pids) {
       for (size_t k = 0; k < num_ent; ++k) {
         const LO lid = lids_in[k];
         const int pid = pids_in[lid];
-        num_bytes_out += PackTraits<int, BDT>::packValue (pids_out, k, pid);
+        num_bytes_out += PackTraits<int>::packValue (pids_out, k, pid);
       }
     }
     const auto p =
-      PackTraits<ST, BDT>::packArray (vals_out, vals_in.data (), num_ent);
+      PackTraits<ST>::packArray (vals_out, vals_in.data (), num_ent);
     error_code += p.first;
     num_bytes_out += p.second;
   }
@@ -497,10 +495,8 @@ struct PackCrsMatrixFunctor {
     num_packets_per_lid_view_type;
   typedef Kokkos::View<const size_t*, BufferDeviceType> offsets_view_type;
   typedef Kokkos::View<char*, BufferDeviceType> exports_view_type;
-  typedef typename PackTraits<LO, BufferDeviceType>::input_array_type
-    export_lids_view_type;
-  typedef typename PackTraits<int, DT>::input_array_type
-    source_pids_view_type;
+  using export_lids_view_type = typename PackTraits<LO>::input_array_type;
+  using source_pids_view_type = typename PackTraits<int>::input_array_type;
 
   typedef typename num_packets_per_lid_view_type::non_const_value_type
     count_type;
@@ -642,25 +638,16 @@ void
 do_pack (const LocalMatrix& local_matrix,
          const LocalMap& local_map,
          const Kokkos::View<char*, BufferDeviceType>& exports,
-         const typename PackTraits<
-             size_t,
-             BufferDeviceType
-           >::input_array_type& num_packets_per_lid,
-         const typename PackTraits<
-             typename LocalMap::local_ordinal_type,
-             BufferDeviceType
-           >::input_array_type& export_lids,
-         const typename PackTraits<
-             int,
-             typename LocalMatrix::device_type
-           >::input_array_type& source_pids,
+         const typename PackTraits<size_t>::input_array_type& num_packets_per_lid,
+         const typename PackTraits<typename LocalMap::local_ordinal_type>::input_array_type& export_lids,
+         const typename PackTraits<int>::input_array_type& source_pids,
          const Kokkos::View<const size_t*, BufferDeviceType>& offsets,
          const size_t num_bytes_per_value,
          const bool pack_pids)
 {
-  typedef typename LocalMap::local_ordinal_type LO;
-  typedef typename LocalMatrix::device_type DT;
-  typedef Kokkos::RangePolicy<typename DT::execution_space, LO> range_type;
+  using LO = typename LocalMap::local_ordinal_type;
+  using DT = typename LocalMatrix::device_type;
+  using range_type = Kokkos::RangePolicy<typename DT::execution_space, LO>;
   const char prefix[] = "Tpetra::Details::do_pack: ";
 
   if (export_lids.extent (0) != 0) {
@@ -686,8 +673,8 @@ do_pack (const LocalMatrix& local_matrix,
        "least one matrix entry, but source_pids.extent(0) = 0.");
   }
 
-  typedef PackCrsMatrixFunctor<LocalMatrix, LocalMap,
-    BufferDeviceType> pack_functor_type;
+  using pack_functor_type =
+    PackCrsMatrixFunctor<LocalMatrix, LocalMap, BufferDeviceType>;
   pack_functor_type f (local_matrix, local_map, exports,
                        num_packets_per_lid, export_lids,
                        source_pids, offsets, num_bytes_per_value,
@@ -698,33 +685,12 @@ do_pack (const LocalMatrix& local_matrix,
   Kokkos::parallel_reduce (range, f, result);
 
   if (result.first != 0) {
-    std::ostringstream os;
-
-    if (result.first == 1) { // invalid local row index
-      auto export_lids_h = Kokkos::create_mirror_view (export_lids);
-      Kokkos::deep_copy (export_lids_h, export_lids);
-      const auto firstBadLid = export_lids_h(result.second);
-      os << "First bad export LID: export_lids(i=" << result.second << ") = "
-         << firstBadLid;
-    }
-    else if (result.first == 2) { // invalid offset
-      auto offsets_h = Kokkos::create_mirror_view (offsets);
-      Kokkos::deep_copy (offsets_h, offsets);
-      const auto firstBadOffset = offsets_h(result.second);
-
-      auto num_packets_per_lid_h =
-        Kokkos::create_mirror_view (num_packets_per_lid);
-      Kokkos::deep_copy (num_packets_per_lid_h, num_packets_per_lid);
-      os << "First bad offset: offsets(i=" << result.second << ") = "
-         << firstBadOffset << ", num_packets_per_lid(i) = "
-         << num_packets_per_lid_h(result.second) << ", buf_size = "
-         << exports.size ();
-    }
-
+    // We can't deep_copy from AnonymousSpace Views, so we can't print
+    // out any information from them in case of error.
     TEUCHOS_TEST_FOR_EXCEPTION
-      (true, std::runtime_error, prefix << "PackCrsMatrixFunctor reported "
-       "error code " << result.first << " for the first bad row "
-       << result.second << ".  " << os.str ());
+      (true, std::runtime_error, prefix << "PackCrsMatrixFunctor "
+       "reported error code " << result.first << " for the first "
+       "bad row " << result.second << ".");
   }
 }
 
@@ -799,14 +765,14 @@ packCrsMatrix (const CrsMatrix<ST, LO, GO, NT>& sourceMatrix,
        << num_packets_per_lid.data () << " == NULL.");
   }
 
-  const size_t num_bytes_per_lid = PackTraits<LO, DT>::packValueCount (LO (0));
-  const size_t num_bytes_per_gid = PackTraits<GO, DT>::packValueCount (GO (0));
-  const size_t num_bytes_per_pid = PackTraits<int, DT>::packValueCount (int (0));
+  const size_t num_bytes_per_lid = PackTraits<LO>::packValueCount (LO (0));
+  const size_t num_bytes_per_gid = PackTraits<GO>::packValueCount (GO (0));
+  const size_t num_bytes_per_pid = PackTraits<int>::packValueCount (int (0));
 
   size_t num_bytes_per_value = 0;
-  if (PackTraits<ST, DT>::compileTimeSize) {
+  if (PackTraits<ST>::compileTimeSize) {
     // Assume ST is default constructible; packValueCount wants an instance.
-    num_bytes_per_value = PackTraits<ST,DT>::packValueCount (ST ());
+    num_bytes_per_value = PackTraits<ST>::packValueCount (ST ());
   }
   else {
     // Since the packed data come from the source matrix, we can use
@@ -821,7 +787,7 @@ packCrsMatrix (const CrsMatrix<ST, LO, GO, NT>& sourceMatrix,
     size_t num_bytes_per_value_l = 0;
     if (local_matrix.values.extent(0) > 0) {
       const ST& val = local_matrix.values(0);
-      num_bytes_per_value_l = PackTraits<ST, DT>::packValueCount (val);
+      num_bytes_per_value_l = PackTraits<ST>::packValueCount (val);
     }
     using Teuchos::reduceAll;
     reduceAll<int, size_t> (* (sourceMatrix.getComm ()),

--- a/packages/tpetra/core/src/Tpetra_Details_unpackCrsMatrixAndCombine_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_unpackCrsMatrixAndCombine_def.hpp
@@ -289,9 +289,8 @@ struct UnpackCrsMatrixAndCombineFunctor {
     using Kokkos::View;
     using Kokkos::subview;
     using Kokkos::MemoryUnmanaged;
-    typedef typename XS::size_type size_type;
-    typedef typename Kokkos::pair<size_type, size_type> slice;
-    typedef BufferDeviceType BDT;
+    using size_type = typename XS::size_type;
+    using slice = Kokkos::pair<size_type, size_type>;
 
     typedef View<LO*, DT, MemoryUnmanaged> lids_out_type;
     typedef View<int*,DT, MemoryUnmanaged> pids_out_type;
@@ -874,7 +873,6 @@ unpackAndCombineIntoCrsArrays2(
   typedef typename Kokkos::View<LO*, DT>::size_type size_type;
   typedef typename Kokkos::pair<size_type, size_type> slice;
   typedef Kokkos::RangePolicy<XS, Kokkos::IndexType<size_type> > range_policy;
-  typedef BufferDeviceType BDT;
 
   typedef View<int*,DT, MemoryUnmanaged> pids_out_type;
   typedef View<GO*, DT, MemoryUnmanaged> gids_out_type;
@@ -959,7 +957,6 @@ unpackAndCombineIntoCrsArrays(
   const char prefix[] = "unpackAndCombineIntoCrsArrays: ";
 
   const size_t N = tgt_num_rows;
-  const size_t mynnz = tgt_num_nonzeros;
 
   // In the case of reduced communicators, the sourceMatrix won't have
   // the right "my_pid", so thus we have to supply it.

--- a/packages/tpetra/core/src/Tpetra_DirectoryImpl_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_DirectoryImpl_decl.hpp
@@ -34,8 +34,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
-//
 // ************************************************************************
 // @HEADER
 
@@ -192,7 +190,7 @@ namespace Tpetra {
       //@{
 
       //! A one-line human-readable description of this object.
-      std::string description () const;
+      std::string description () const override;
       //@}
     protected:
       //! Find process IDs and (optionally) local IDs for the given global IDs.
@@ -250,7 +248,7 @@ namespace Tpetra {
       //@{
 
       //! A one-line human-readable description of this object.
-      std::string description () const;
+      std::string description () const override;
       //@}
 
     protected:
@@ -305,7 +303,7 @@ namespace Tpetra {
       //@{
 
       //! A one-line human-readable description of this object.
-      std::string description () const;
+      std::string description () const override;
       //@}
 
     protected:
@@ -402,7 +400,7 @@ namespace Tpetra {
       //@{
 
       //! A one-line human-readable description of this object.
-      std::string description () const;
+      std::string description () const override;
       //@}
     protected:
       //! Find process IDs and (optionally) local IDs for the given global IDs.

--- a/packages/tpetra/core/src/Tpetra_Map_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Map_decl.hpp
@@ -1014,7 +1014,7 @@ namespace Tpetra {
     /// like tab levels.  If you just want to wrap std::cout, try
     /// this:
     /// \code
-    /// auto out = Teuchos::getFancyOStream (Teuchos::rcpFromRef (std::out));
+    /// auto out = Teuchos::getFancyOStream(Teuchos::rcpFromRef(std::cout));
     /// \endcode
     void
     describe (Teuchos::FancyOStream &out,

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -34,8 +34,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
-//
 // ************************************************************************
 // @HEADER
 
@@ -4621,8 +4619,8 @@ namespace Tpetra {
 
     auto v1 = this->getLocalViewHost ();
     auto v2 = vec.getLocalViewHost ();
-    if (PackTraits<ST, HES>::packValueCount (v1(0,0)) !=
-        PackTraits<ST, HES>::packValueCount (v2(0,0))) {
+    if (PackTraits<ST>::packValueCount (v1(0,0)) !=
+        PackTraits<ST>::packValueCount (v2(0,0))) {
       return false;
     }
 


### PR DESCRIPTION
@trilinos/tpetra @trilinos/stokhos 

1. Fix #6300 (build warnings).
2. Add benchmark for `Tpetra::CrsMatrix::unpackAndCombine`, for the special case of dense rows (see #6282).
3. Reorganize `Tpetra::Details::PackTraits` to simplify code and reduce need for templating on Device type.  This touches Stokhos a bit.

## Motivation

Sierra (specifically Aria) discovered the performance issue that led to #6282. 

## Related Issues

* Closes #6300 
* Related to #6282. 

## Stakeholder Feedback

See TF-1264 (in Aria's internal issue tracking system).

## Testing

The new benchmark includes a test; the test always runs.