### PR TITLE
Fix suggested vector size when nr == 0

### DIFF
--- a/packages/kokkos-kernels/src/common/KokkosKernels_ExecSpaceUtils.hpp
+++ b/packages/kokkos-kernels/src/common/KokkosKernels_ExecSpaceUtils.hpp
@@ -103,7 +103,8 @@ inline int kk_get_suggested_vector_size(
     break;
   case Exec_CUDA:
 
-    suggested_vector_size_ = nnz / double (nr) + 0.5;
+    if (nr > 0)
+      suggested_vector_size_ = nnz / double (nr) + 0.5;
     if (suggested_vector_size_ < 3){
       suggested_vector_size_ = 2;
     }


### PR DESCRIPTION
@trilinos/kokkos-kernels 

## Motivation
Matches PR https://github.com/kokkos/kokkos-kernels/pull/499

Should fix https://github.com/trilinos/Trilinos/issues/6264