### PR TITLE
Intrepid2: Fix 6307

### DIFF
--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_TensorBasis.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_TensorBasis.hpp
@@ -686,9 +686,8 @@ namespace Intrepid2
             const int outputVectorSize = getVectorSizeForHierarchicalParallelism<OutputValueType>();
             const int pointVectorSize  = getVectorSizeForHierarchicalParallelism<PointValueType>();
             const int vectorSize = std::max(outputVectorSize,pointVectorSize);
-            const int teamSize = basisCardinality2;
             
-            auto policy = Kokkos::TeamPolicy<ExecutionSpace>(basisCardinality1,teamSize,vectorSize);
+            auto policy = Kokkos::TeamPolicy<ExecutionSpace>(basisCardinality1,Kokkos::AUTO(),vectorSize);
             
             double weight = 1.0;
             using FunctorType = TensorViewFunctor<ExecutionSpace, OutputValueType, OutputViewType>;
@@ -840,9 +839,8 @@ namespace Intrepid2
       const int outputVectorSize = getVectorSizeForHierarchicalParallelism<OutputValueType>();
       const int pointVectorSize  = getVectorSizeForHierarchicalParallelism<PointValueType>();
       const int vectorSize = std::max(outputVectorSize,pointVectorSize);
-      const int teamSize = basisCardinality2;
       
-      auto policy = Kokkos::TeamPolicy<ExecutionSpace>(basisCardinality1,teamSize,vectorSize);
+      auto policy = Kokkos::TeamPolicy<ExecutionSpace>(basisCardinality1,Kokkos::AUTO(),vectorSize);
       
       using FunctorType = TensorViewFunctor<ExecutionSpace, OutputValueType, OutputViewType>;
       
@@ -1342,9 +1340,8 @@ namespace Intrepid2
       const int outputVectorSize = getVectorSizeForHierarchicalParallelism<OutputScalar>();
       const int pointVectorSize  = getVectorSizeForHierarchicalParallelism<PointScalar>();
       const int vectorSize = std::max(outputVectorSize,pointVectorSize);
-      const int teamSize = basisCardinality2;
       
-      auto policy = Kokkos::TeamPolicy<ExecutionSpace>(basisCardinality1,teamSize,vectorSize);
+      auto policy = Kokkos::TeamPolicy<ExecutionSpace>(basisCardinality1,Kokkos::AUTO(),vectorSize);
       
       using FunctorType = TensorBasis3_Functor<ExecutionSpace, OutputScalar, OutputViewType>;
       FunctorType functor(outputValues, outputValues1, outputValues2, outputValues3, tensorPoints, weight);

--- a/packages/intrepid2/unit-test/Discretization/Basis/HierarchicalBases/TensorViewFunctorTests.cpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HierarchicalBases/TensorViewFunctorTests.cpp
@@ -71,9 +71,8 @@ namespace
     
     const bool hasADType = false;
     const int vectorSize = hasADType ? FAD_VECTOR_SIZE : VECTOR_SIZE;
-    const int teamSize = view2.extent_int(0);
     
-    auto policy = Kokkos::TeamPolicy<ExecutionSpace>(view1.extent_int(0),teamSize,vectorSize);
+    auto policy = Kokkos::TeamPolicy<ExecutionSpace>(view1.extent_int(0),Kokkos::AUTO(),vectorSize);
     
     using FunctorType = TensorViewFunctor<ExecutionSpace, Scalar, ScalarViewType>;
     


### PR DESCRIPTION
@trilinos/intrepid2 

## Related Issues
Closes #6307 (test failures when built with `KOKKOS_ENABLE_DEPRECATED_CODE=OFF`).