### PR TITLE
Intrepid2: tweaks to OrientationTools::modifyBasisByOrientation() to allow reference-space inputs.

### DIFF
--- a/packages/intrepid2/unit-test/Orientation/test_orientation_HEX.hpp
+++ b/packages/intrepid2/unit-test/Orientation/test_orientation_HEX.hpp
@@ -42,7 +42,7 @@
 
 
 /** \file
-    \brief  Test for checking orientation tools for Hexaedral elements
+    \brief  Test for checking orientation tools for Hexahedral elements
  
     The test considers two hexahedra in the physical space sharing a common face. 
     In order to test significant configurations, we consider 6 mappings of the reference hexahedron
@@ -456,25 +456,26 @@ int OrientationHex(const bool verbose) {
 
        //Testing Kronecker property of basis functions
        {
+         DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality);
+         DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
+         DynRankView ConstructWithLabel(transformedBasisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
          for(ordinal_type i=0; i<numCells; ++i) {
-           DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality);
-           DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
-           DynRankView ConstructWithLabel(transformedBasisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
            auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
            auto outView =Kokkos::subview( basisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL());
            basis.getValues(outView, inView);
+         }
 
-           // modify basis values to account for orientations
-           ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
-               basisValuesAtDofCoords,
-               elemOrts,
-               &basis);
+         // modify basis values to account for orientations
+         ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
+                                       basisValuesAtDofCoords,
+                                       elemOrts,
+                                       &basis);
 
-           // transform basis values
-           deep_copy(transformedBasisValuesAtDofCoordsOriented,
-               basisValuesAtDofCoordsOriented);
+         // transform basis values
+         deep_copy(transformedBasisValuesAtDofCoordsOriented,
+                   basisValuesAtDofCoordsOriented);
 
-
+         for(ordinal_type i=0; i<numCells; ++i) {
            for(ordinal_type k=0; k<basisCardinality; ++k) {
              for(ordinal_type j=0; j<basisCardinality; ++j){
                ValueType dofValue = transformedBasisValuesAtDofCoordsOriented(i,k,j) * dofCoeffsPhys(i,j);
@@ -493,7 +494,7 @@ int OrientationHex(const bool verbose) {
          }
        }
 
-       //check function reproducbility
+       //check function reproducibility
        Fun fun;
        DynRankView ConstructWithLabel(funDofs, numCells, basisCardinality);
        DynRankView ConstructWithLabel(funAtPhysRefCoords, numCells, numRefCoords);
@@ -555,17 +556,15 @@ int OrientationHex(const bool verbose) {
        //check that fun values at reference points coincide with those computed using basis functions
        DynRankView ConstructWithLabel(basisValuesAtRefCoordsOriented, numCells, basisCardinality, numRefCoords);
        DynRankView ConstructWithLabel(transformedBasisValuesAtRefCoordsOriented, numCells, basisCardinality, numRefCoords);
-       DynRankView basisValuesAtRefCoordsCells("inValues", numCells, basisCardinality, numRefCoords);
 
        DynRankView ConstructWithLabel(basisValuesAtRefCoords, basisCardinality, numRefCoords);
        basis.getValues(basisValuesAtRefCoords, refPoints);
-       rst::clone(basisValuesAtRefCoordsCells,basisValuesAtRefCoords);
 
        // modify basis values to account for orientations
        ots::modifyBasisByOrientation(basisValuesAtRefCoordsOriented,
-           basisValuesAtRefCoordsCells,
-           elemOrts,
-           &basis);
+                                     basisValuesAtRefCoords,
+                                     elemOrts,
+                                     &basis);
 
        // transform basis values
        deep_copy(transformedBasisValuesAtRefCoordsOriented,

--- a/packages/intrepid2/unit-test/Orientation/test_orientation_QUAD.hpp
+++ b/packages/intrepid2/unit-test/Orientation/test_orientation_QUAD.hpp
@@ -362,25 +362,27 @@ int OrientationQuad(const bool verbose) {
 
        //Testing Kronecker property of basis functions
        {
+         DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality);
+         DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
+         DynRankView ConstructWithLabel(transformedBasisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
+         
          for(ordinal_type i=0; i<numCells; ++i) {
-           DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality);
-           DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
-           DynRankView ConstructWithLabel(transformedBasisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
            auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
            auto outView =Kokkos::subview( basisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL());
            basis.getValues(outView, inView);
+         }
 
-           // modify basis values to account for orientations
-           ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
-               basisValuesAtDofCoords,
-               elemOrts,
-               &basis);
+         // modify basis values to account for orientations
+         ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
+                                       basisValuesAtDofCoords,
+                                       elemOrts,
+                                       &basis);
 
-           // transform basis values
-           deep_copy(transformedBasisValuesAtDofCoordsOriented,
-               basisValuesAtDofCoordsOriented);
+         // transform basis values
+         deep_copy(transformedBasisValuesAtDofCoordsOriented,
+                   basisValuesAtDofCoordsOriented);
 
-
+         for(ordinal_type i=0; i<numCells; ++i) {
            for(ordinal_type k=0; k<basisCardinality; ++k) {
              for(ordinal_type j=0; j<basisCardinality; ++j){
                ValueType dofValue = transformedBasisValuesAtDofCoordsOriented(i,k,j) * dofCoeffsPhys(i,j);
@@ -437,17 +439,15 @@ int OrientationQuad(const bool verbose) {
        //check that fun values at reference points coincide with those computed using basis functions
        DynRankView ConstructWithLabel(basisValuesAtRefCoordsOriented, numCells, basisCardinality, numRefCoords);
        DynRankView ConstructWithLabel(transformedBasisValuesAtRefCoordsOriented, numCells, basisCardinality, numRefCoords);
-       DynRankView basisValuesAtRefCoordsCells("inValues", numCells, basisCardinality, numRefCoords);
 
        DynRankView ConstructWithLabel(basisValuesAtRefCoords, basisCardinality, numRefCoords);
        basis.getValues(basisValuesAtRefCoords, refPoints);
-       rst::clone(basisValuesAtRefCoordsCells,basisValuesAtRefCoords);
 
        // modify basis values to account for orientations
        ots::modifyBasisByOrientation(basisValuesAtRefCoordsOriented,
-           basisValuesAtRefCoordsCells,
-           elemOrts,
-           &basis);
+                                     basisValuesAtRefCoords,
+                                     elemOrts,
+                                     &basis);
 
        // transform basis values
        deep_copy(transformedBasisValuesAtRefCoordsOriented,

--- a/packages/intrepid2/unit-test/Orientation/test_orientation_TET.hpp
+++ b/packages/intrepid2/unit-test/Orientation/test_orientation_TET.hpp
@@ -423,25 +423,27 @@ int OrientationTet(const bool verbose) {
 
        //Testing Kronecker property of basis functions
        {
+         DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality);
+         DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
+         DynRankView ConstructWithLabel(transformedBasisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
+         
          for(ordinal_type i=0; i<numCells; ++i) {
-           DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality);
-           DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
-           DynRankView ConstructWithLabel(transformedBasisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
            auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
            auto outView =Kokkos::subview( basisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL());
            basis.getValues(outView, inView);
+         }
 
-           // modify basis values to account for orientations
-           ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
-               basisValuesAtDofCoords,
-               elemOrts,
-               &basis);
+         // modify basis values to account for orientations
+         ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
+                                       basisValuesAtDofCoords,
+                                       elemOrts,
+                                       &basis);
 
-           // transform basis values
-           deep_copy(transformedBasisValuesAtDofCoordsOriented,
-               basisValuesAtDofCoordsOriented);
+         // transform basis values
+         deep_copy(transformedBasisValuesAtDofCoordsOriented,
+                   basisValuesAtDofCoordsOriented);
 
-
+         for(ordinal_type i=0; i<numCells; ++i) {
            for(ordinal_type k=0; k<basisCardinality; ++k) {
              for(ordinal_type j=0; j<basisCardinality; ++j){
                ValueType dofValue = transformedBasisValuesAtDofCoordsOriented(i,k,j) * dofCoeffsPhys(i,j);
@@ -522,17 +524,15 @@ int OrientationTet(const bool verbose) {
        //check that fun values at reference points coincide with those computed using basis functions
        DynRankView ConstructWithLabel(basisValuesAtRefCoordsOriented, numCells, basisCardinality, numRefCoords);
        DynRankView ConstructWithLabel(transformedBasisValuesAtRefCoordsOriented, numCells, basisCardinality, numRefCoords);
-       DynRankView basisValuesAtRefCoordsCells("inValues", numCells, basisCardinality, numRefCoords);
 
        DynRankView ConstructWithLabel(basisValuesAtRefCoords, basisCardinality, numRefCoords);
        basis.getValues(basisValuesAtRefCoords, refPoints);
-       rst::clone(basisValuesAtRefCoordsCells,basisValuesAtRefCoords);
 
        // modify basis values to account for orientations
        ots::modifyBasisByOrientation(basisValuesAtRefCoordsOriented,
-           basisValuesAtRefCoordsCells,
-           elemOrts,
-           &basis);
+                                     basisValuesAtRefCoords,
+                                     elemOrts,
+                                     &basis);
 
        // transform basis values
        deep_copy(transformedBasisValuesAtRefCoordsOriented,

--- a/packages/intrepid2/unit-test/Orientation/test_orientation_TRI.hpp
+++ b/packages/intrepid2/unit-test/Orientation/test_orientation_TRI.hpp
@@ -362,25 +362,27 @@ int OrientationTri(const bool verbose) {
 
        //Testing Kronecker property of basis functions
        {
+         DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality);
+         DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
+         DynRankView ConstructWithLabel(transformedBasisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
+         
          for(ordinal_type i=0; i<numCells; ++i) {
-           DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality);
-           DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
-           DynRankView ConstructWithLabel(transformedBasisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
            auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
            auto outView =Kokkos::subview( basisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL());
            basis.getValues(outView, inView);
+         }
 
-           // modify basis values to account for orientations
-           ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
-               basisValuesAtDofCoords,
-               elemOrts,
-               &basis);
+         // modify basis values to account for orientations
+         ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
+                                       basisValuesAtDofCoords,
+                                       elemOrts,
+                                       &basis);
 
-           // transform basis values
-           deep_copy(transformedBasisValuesAtDofCoordsOriented,
-               basisValuesAtDofCoordsOriented);
+         // transform basis values
+         deep_copy(transformedBasisValuesAtDofCoordsOriented,
+                   basisValuesAtDofCoordsOriented);
 
-
+         for(ordinal_type i=0; i<numCells; ++i) {
            for(ordinal_type k=0; k<basisCardinality; ++k) {
              for(ordinal_type j=0; j<basisCardinality; ++j){
                ValueType dofValue = transformedBasisValuesAtDofCoordsOriented(i,k,j) * dofCoeffsPhys(i,j);
@@ -437,21 +439,19 @@ int OrientationTri(const bool verbose) {
        //check that fun values at reference points coincide with those computed using basis functions
        DynRankView ConstructWithLabel(basisValuesAtRefCoordsOriented, numCells, basisCardinality, numRefCoords);
        DynRankView ConstructWithLabel(transformedBasisValuesAtRefCoordsOriented, numCells, basisCardinality, numRefCoords);
-       DynRankView basisValuesAtRefCoordsCells("inValues", numCells, basisCardinality, numRefCoords);
 
        DynRankView ConstructWithLabel(basisValuesAtRefCoords, basisCardinality, numRefCoords);
        basis.getValues(basisValuesAtRefCoords, refPoints);
-       rst::clone(basisValuesAtRefCoordsCells,basisValuesAtRefCoords);
 
        // modify basis values to account for orientations
        ots::modifyBasisByOrientation(basisValuesAtRefCoordsOriented,
-           basisValuesAtRefCoordsCells,
-           elemOrts,
-           &basis);
+                                     basisValuesAtRefCoords,
+                                     elemOrts,
+                                     &basis);
 
        // transform basis values
        deep_copy(transformedBasisValuesAtRefCoordsOriented,
-           basisValuesAtRefCoordsOriented);
+                 basisValuesAtRefCoordsOriented);
 
        DynRankView ConstructWithLabel(funAtRefCoordsOriented, numCells, numRefCoords);
        for(ordinal_type i=0; i<numCells; ++i) {


### PR DESCRIPTION
Also, modified tests for hexahedron, quadrilateral, tetrahedron, and triangle so that these now exercise the new code path as well as the old.  Also tweaked those tests slightly to fix an issue where some code that was in a cell loop should not have been in a cell loop (the code was not wrong, but slightly less precise than it might have been).

@trilinos/intrepid2

## Motivation
See #6317.

## Related Issues
Closes #6317.

## Testing
The new code path is exercised by the Test_Orientation_{HEX,QUAD,TET,TRI} tests.