### PR TITLE
MueLu: fixing the count of aggregated nodes in refactored Phase2a of aggregation, see #6325

### DIFF
--- a/packages/muelu/test/interface/ParameterListInterpreter.cpp
+++ b/packages/muelu/test/interface/ParameterListInterpreter.cpp
@@ -407,6 +407,16 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
           stringToReplace = "Smoother complexity = " + floatRegex;
           replacementString = "Smoother complexity = <ignored>";
           run_sed("'s/" + stringToReplace + "/" + replacementString + "/'", baseFile);
+
+          // Finally ignore the Chebyshev eigen value ratio which varies with aggregation
+          stringToReplace = "chebyshev: ratio eigenvalue = " + floatRegex;
+          replacementString = "chebyshev: ratio eigenvalue = <ignored>";
+          run_sed("'s/" + stringToReplace + "/" + replacementString + "/'", baseFile);
+
+          // as well as the alpha paramter it sets
+          stringToReplace = "lambdaMax = <ignored>, alpha: " + floatRegex + ", lambdaMin = <ignored>,";
+          replacementString = "lambdaMax = <ignored>, alpha: <ignored>, lambdaMin = <ignored>,";
+          run_sed("'s/" + stringToReplace + "/" + replacementString + "/'", baseFile);
         }
 
         // Run comparison (ignoring whitespaces)


### PR DESCRIPTION

A piece of logic is wrong in the algorithms that counts
how many nodes have been aggregated in Phase2a of aggregation.
This commit fixes that by individually counting every node
that is being aggregated instead of counting all the nodes in
a newly formed aggregate, at once.

@trilinos/muelu 

## Motivation
All bugs shall be fixed, but this is also generating a failing test in Empire and blocking the adoption of the latest refactored setup of MueLu.

## Related Issues

* Closes #6325
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 


## Stakeholder Feedback
Empire: @cgcgcg will check that the failing test is fixed after this modification is applied.
ExaWind: @lucbv checked that ExaWind is not negatively affected by these changes.

## Testing
Local tests have been performed and @cgcgcg will apply locally these changes to test these with Empire