### PR TITLE
Tpetra:  conversions to allow compilation of tests when scalar=std::complex<float>

### DIFF
--- a/packages/tpetra/core/test/Block/BlockCrsMatrix.cpp
+++ b/packages/tpetra/core/test/Block/BlockCrsMatrix.cpp
@@ -2463,7 +2463,7 @@ namespace {
     else {
       out << normStr.str() << std::endl;
     }
-    TEUCHOS_TEST_FOR_EXCEPTION(relativeError[0]>1e-8, std::runtime_error, "BlockCrsMatrix matvec does not produce same result as CrsMatrix matvec.");
+    TEUCHOS_TEST_FOR_EXCEPTION(relativeError[0]>5e-8, std::runtime_error, "BlockCrsMatrix matvec does not produce same result as CrsMatrix matvec.");
   }
 
 

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_PackUnpack.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_PackUnpack.cpp
@@ -353,9 +353,9 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CrsMatrix, PackThenUnpackAndCombine, SC, LO, G
       int curNumErrors = 0;
       LO num_indices = static_cast<LO>(A_indices.size());
       for (LO i=0; i<num_indices; i++) {
-        if (! essentially_equal<SC>(2.0 * A_values[i], B_values[i])) {
+        if (! essentially_equal<SC>(SC(2.0) * A_values[i], B_values[i])) {
           errStrm << "ERROR: Proc " << world_rank << ", row " << loc_row
-                  << ", 2*A[" << i << "]=" << 2.0 * A_values[i] << ", but "
+                  << ", 2*A[" << i << "]=" << SC(2.0) * A_values[i] << ", but "
                   <<     "B[" << i << "]=" <<   B_values[i] << "!\n";
           ++curNumErrors;
         }

--- a/packages/tpetra/core/test/ImportExport2/ImportExport2_CrsSortingUtils.cpp
+++ b/packages/tpetra/core/test/ImportExport2/ImportExport2_CrsSortingUtils.cpp
@@ -286,7 +286,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( Import_Util, SortCrsEntries, Scalar, LO, GO)
     // merge/shrink
     vals2.resize(new_num_entries);
     vals_rand.resize(new_num_entries);
-    for (size_type i=0; i<new_num_entries; i++) vals2[i] = 2.*vals[i];
+    for (size_type i=0; i<new_num_entries; i++) 
+      vals2[i] = scalar_type(2.)*vals[i];
     TEST_COMPARE_FLOATING_ARRAYS(vals2, vals_rand, 1.e-12);
 
     //


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
In #6314, @william76 noted that Tpetra tests failed to compile when he built with Trilinos_ENABLE_FLOAT and Trilinos_ENABLE_COMPLEX.  The problem was a multiplication of a double constant (2.) with a std::complex<float>.  These changes convert the double constant to scalar_type to allow successful compilation and execution.

At the same time, I loosened a tolerance in one test that failed with scalar_type=float.  

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
@william76 : please let me know whether this PR solves your compilation issue.  I do **not** expect these changes to fix the Xpetra issue in #6314, but they should allow you to make progress with compilation for your debugging of #6314 

<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

Built and tested on linux workstation with Trilinos_ENABLE_FLOAT and Trilinos_ENABLE_COMPLEX, as well as the usual instantiated scalar types (double, int, long long, std::complex<double>).  
module purge
module load sems-env
module load sems-cmake
module load sems-gcc/4.9.3
module load sems-openmpi/1.10.1
All tests compiled and passed.


<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->