### PR TITLE
Sacado:  Fix ViewFad conversions for new design.

### DIFF
--- a/packages/sacado/src/Sacado_SFINAE_Macros.hpp
+++ b/packages/sacado/src/Sacado_SFINAE_Macros.hpp
@@ -48,7 +48,13 @@
 
 #define SACADO_EXP_ENABLE_EXPR_FUNC(RETURN_TYPE) \
   SACADO_ENABLE_IF_SAME(typename Expr<S>::derived_type::value_type, value_type, RETURN_TYPE)
-#define SACADO_EXP_ENABLE_EXPR_CTOR_DEF SACADO_EXP_ENABLE_EXPR_FUNC(void*)
+#define SACADO_EXP_ENABLE_EXPR_CTOR_DEF \
+  typename mpl::enable_if_c<                                            \
+    mpl::is_convertible< typename Expr<S>::derived_type::value_type ,   \
+                         value_type >::value &&                         \
+    (ExprLevel< typename Expr<S>::derived_type::value_type >::value ==  \
+     ExprLevel< value_type >::value) &&                                 \
+    !is_view, void* >::type
 #define SACADO_EXP_ENABLE_EXPR_CTOR_DECL SACADO_EXP_ENABLE_EXPR_CTOR_DEF = 0
 #define SACADO_FAD_EXP_ENABLE_EXPR_FUNC \
   SACADO_ENABLE_IF_SAME(typename Expr<S>::derived_type::value_type, typename FAD::value_type, FAD&)
@@ -59,6 +65,12 @@
   SACADO_ENABLE_IF_CONVERTIBLE(S, value_type, RETURN_TYPE)
 #define SACADO_ENABLE_VALUE_CTOR_DEF SACADO_ENABLE_VALUE_FUNC(void*)
 #define SACADO_ENABLE_VALUE_CTOR_DECL SACADO_ENABLE_VALUE_CTOR_DEF = 0
+
+#define SACADO_EXP_ENABLE_VALUE_CTOR_DEF \
+  typename mpl::enable_if_c<                                            \
+    Sacado::mpl::is_convertible< S , value_type >::value &&             \
+    !is_view, void* >::type
+#define SACADO_EXP_ENABLE_VALUE_CTOR_DECL SACADO_EXP_ENABLE_VALUE_CTOR_DEF = 0
 
 #define SACADO_FAD_OP_ENABLE_EXPR_EXPR(OP)                              \
   typename mpl::enable_if_c< IsFadExpr<T1>::value && IsFadExpr<T2>::value && \

--- a/packages/sacado/src/new_design/Sacado_Fad_Exp_DynamicStorage.hpp
+++ b/packages/sacado/src/new_design/Sacado_Fad_Exp_DynamicStorage.hpp
@@ -50,6 +50,7 @@ namespace Sacado {
       typedef typename std::remove_cv<T>::type value_type;
       static constexpr bool is_statically_sized = false;
       static constexpr int static_size = 0;
+      static constexpr bool is_view = false;
 
       //! Turn DynamicStorage into a meta-function class usable with mpl::apply
       template <typename TT, typename UU = TT>
@@ -78,12 +79,25 @@ namespace Sacado {
        * Initializes derivative array 0 of length \c sz
        */
       KOKKOS_INLINE_FUNCTION
-      DynamicStorage(const int sz, const T & x, const DerivInit zero_out) :
+      DynamicStorage(const int sz, const T & x,
+                     const DerivInit zero_out = InitDerivArray) :
         val_(x), sz_(sz), len_(sz) {
         if (zero_out == InitDerivArray)
           dx_ = ds_array<U>::get_and_fill(sz_);
         else
           dx_ = ds_array<U>::get(sz_);
+      }
+
+      //! Constructor with size \c sz, index \c i, and value \c x
+      /*!
+       * Initializes value to \c x and derivative array of length \c sz
+       * as row \c i of the identity matrix, i.e., sets derivative component
+       * \c i to 1 and all other's to zero.
+       */
+      KOKKOS_INLINE_FUNCTION
+      DynamicStorage(const int sz, const int i, const value_type & x) :
+        DynamicStorage(sz, x, InitDerivArray) {
+        dx_[i]=1.;
       }
 
       //! Copy constructor

--- a/packages/sacado/src/new_design/Sacado_Fad_Exp_MemPoolStorage.hpp
+++ b/packages/sacado/src/new_design/Sacado_Fad_Exp_MemPoolStorage.hpp
@@ -182,6 +182,7 @@ namespace Sacado {
       typedef typename std::remove_cv<T>::type value_type;
       static constexpr bool is_statically_sized = false;
       static constexpr int static_size = 0;
+      static constexpr bool is_view = false;
 
       //! Turn MemPoolStorage into a meta-function class usable with mpl::apply
       template <typename TT>
@@ -208,12 +209,25 @@ namespace Sacado {
       /*!
        * Initializes derivative array 0 of length \c sz
        */
-      MemPoolStorage(const int sz, const T & x, const DerivInit zero_out) :
+      MemPoolStorage(const int sz, const T & x,
+                     const DerivInit zero_out = InitDerivArray) :
         val_(x), sz_(sz), len_(sz), myPool_(defaultPool_) {
         if (zero_out == InitDerivArray)
           dx_ = mp_array<T>::get_and_fill(sz_, myPool_);
         else
           dx_ = mp_array<T>::get(sz_, myPool_);
+      }
+
+      //! Constructor with size \c sz, index \c i, and value \c x
+      /*!
+       * Initializes value to \c x and derivative array of length \c sz
+       * as row \c i of the identity matrix, i.e., sets derivative component
+       * \c i to 1 and all other's to zero.
+       */
+      KOKKOS_INLINE_FUNCTION
+      MemPoolStorage(const int sz, const int i, const value_type & x) :
+        MemPoolStorage(sz, x, InitDerivArray) {
+        dx_[i]=1.;
       }
 
       //! Copy constructor

--- a/packages/sacado/src/new_design/Sacado_Fad_Exp_StaticFixedStorage.hpp
+++ b/packages/sacado/src/new_design/Sacado_Fad_Exp_StaticFixedStorage.hpp
@@ -54,6 +54,7 @@ namespace Sacado {
       typedef typename std::remove_cv<T>::type value_type;
       static constexpr bool is_statically_sized = true;
       static constexpr int static_size = Num;
+      static constexpr bool is_view = false;
 
       //! Turn StaticFixedStorage into a meta-function class usable with mpl::apply
       template <typename TT>
@@ -82,7 +83,8 @@ namespace Sacado {
        * Initializes derivative array 0 of length \c sz
        */
       KOKKOS_INLINE_FUNCTION
-      StaticFixedStorage(const int sz, const T & x, const DerivInit zero_out) :
+      StaticFixedStorage(const int sz, const T & x,
+                         const DerivInit zero_out = InitDerivArray) :
         val_(x) {
 #if defined(SACADO_DEBUG) && !defined(__CUDA_ARCH__ )
         if (sz != Num)
@@ -90,6 +92,18 @@ namespace Sacado {
 #endif
         if (zero_out == InitDerivArray)
           ss_array<T>::zero(dx_, Num);
+      }
+
+      //! Constructor with size \c sz, index \c i, and value \c x
+      /*!
+       * Initializes value to \c x and derivative array of length \c sz
+       * as row \c i of the identity matrix, i.e., sets derivative component
+       * \c i to 1 and all other's to zero.
+       */
+      KOKKOS_INLINE_FUNCTION
+      StaticFixedStorage(const int sz, const int i, const value_type & x) :
+        StaticFixedStorage(sz, x, InitDerivArray) {
+        dx_[i]=1.;
       }
 
       //! Copy constructor

--- a/packages/sacado/src/new_design/Sacado_Fad_Exp_StaticStorage.hpp
+++ b/packages/sacado/src/new_design/Sacado_Fad_Exp_StaticStorage.hpp
@@ -54,6 +54,7 @@ namespace Sacado {
       typedef typename std::remove_cv<T>::type value_type;
       static constexpr bool is_statically_sized = false;
       static constexpr int static_size = 0;
+      static constexpr bool is_view = false;
 
       //! Turn StaticStorage into a meta-function class usable with mpl::apply
       template <typename TT>
@@ -82,7 +83,8 @@ namespace Sacado {
        * Initializes derivative array 0 of length \c sz
        */
       KOKKOS_INLINE_FUNCTION
-      StaticStorage(const int sz, const T & x, const DerivInit zero_out) :
+      StaticStorage(const int sz, const T & x,
+                    const DerivInit zero_out = InitDerivArray) :
         val_(x), sz_(sz) {
 #if defined(SACADO_DEBUG) && !defined(__CUDA_ARCH__ )
         if (sz > Num)
@@ -90,6 +92,18 @@ namespace Sacado {
 #endif
         if (zero_out == InitDerivArray)
           ss_array<T>::zero(dx_, sz_);
+      }
+
+      //! Constructor with size \c sz, index \c i, and value \c x
+      /*!
+       * Initializes value to \c x and derivative array of length \c sz
+       * as row \c i of the identity matrix, i.e., sets derivative component
+       * \c i to 1 and all other's to zero.
+       */
+      KOKKOS_INLINE_FUNCTION
+      StaticStorage(const int sz, const int i, const value_type & x) :
+        StaticStorage(sz, x, InitDerivArray) {
+        dx_[i]=1.;
       }
 
       //! Copy constructor

--- a/packages/sacado/src/new_design/Sacado_Fad_Exp_VectorDynamicStorage.hpp
+++ b/packages/sacado/src/new_design/Sacado_Fad_Exp_VectorDynamicStorage.hpp
@@ -50,6 +50,7 @@ namespace Sacado {
       typedef typename std::remove_cv<T>::type value_type;
       static constexpr bool is_statically_sized = false;
       static constexpr int static_size = 0;
+      static constexpr bool is_view = false;
 
       //! Turn DynamicStorage into a meta-function class usable with mpl::apply
       template <typename TT, typename UU = TT>
@@ -82,12 +83,25 @@ namespace Sacado {
        * Initializes derivative array 0 of length \c sz
        */
       KOKKOS_INLINE_FUNCTION
-      VectorDynamicStorage(const int sz, const T & x, const DerivInit zero_out) :
+      VectorDynamicStorage(const int sz, const T & x,
+                           const DerivInit zero_out = InitDerivArray) :
         v_(x), owns_mem(true), sz_(sz), len_(sz), stride_(1), val_(&v_) {
         if (zero_out == InitDerivArray)
           dx_ = ds_array<U>::get_and_fill(sz_);
         else
           dx_ = ds_array<U>::get(sz_);
+      }
+
+      //! Constructor with size \c sz, index \c i, and value \c x
+      /*!
+       * Initializes value to \c x and derivative array of length \c sz
+       * as row \c i of the identity matrix, i.e., sets derivative component
+       * \c i to 1 and all other's to zero.
+       */
+      KOKKOS_INLINE_FUNCTION
+      VectorDynamicStorage(const int sz, const int i, const value_type & x) :
+        VectorDynamicStorage(sz, x, InitDerivArray) {
+        dx_[i]=1.;
       }
 
       //! Constructor with supplied memory

--- a/packages/sacado/src/new_design/Sacado_Fad_Exp_ViewStorage.hpp
+++ b/packages/sacado/src/new_design/Sacado_Fad_Exp_ViewStorage.hpp
@@ -64,6 +64,7 @@ namespace Sacado {
       typedef typename std::remove_cv<T>::type value_type;
       static constexpr bool is_statically_sized = (static_length > 0);
       static constexpr int static_size = static_length;
+      static constexpr bool is_view = true;
       typedef U base_fad_type;
 
       //! Turn ViewStorage into a meta-function class usable with mpl::apply
@@ -81,16 +82,6 @@ namespace Sacado {
       //! Default constructor (needed to satisfy interface)
       KOKKOS_INLINE_FUNCTION
       ViewStorage() :
-        sz_(0), stride_(0), val_(0), dx_(0) {}
-
-      //! Constructor with value (needed to satisfy interface)
-      KOKKOS_INLINE_FUNCTION
-      ViewStorage(const T & x) :
-        sz_(0), stride_(0), val_(0), dx_(0) {}
-
-      //! Constructor with size \c sz (needed to satisfy interface)
-      KOKKOS_INLINE_FUNCTION
-      ViewStorage(const int sz, const T & x, const DerivInit zero_out) :
         sz_(0), stride_(0), val_(0), dx_(0) {}
 
       //! Constructor


### PR DESCRIPTION
The new design implementation was allowing conversions from other AD
types to ViewFad, which is not correct.  In addition to being generally
unsafe, this was causing compiler errors in Panzer when the two return
types of the ternary operator differ, with one being ViewFad.

It tooks some time to figure out a way to do this that NVCC accepted.
It seems to not handle inherited constructors disabled through SFINAE
correctly.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/<teamName>

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->