### PR TITLE
MueLu: fixing regionalToComposite() for region vectors

### DIFF
--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
@@ -798,7 +798,7 @@ void vCycle(const int l, ///< ID of current level
     tm = Teuchos::null;
     tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("vCycle: 5 - sum interface values")));
 
-    sumInterfaceValues(coarseRegB, compRowMaps[l+1], maxRegPerProc,
+    sumInterfaceValues(coarseRegB, compRowMaps[l+1],
                        quasiRegRowMaps[l+1], regRowMaps[l+1], regRowImporters[l+1]);
 
     tm = Teuchos::null;

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
@@ -217,12 +217,12 @@ void MakeCoarseLevelMaps2(const int maxRegPerGID,
     }
 
     // We communicate the above GIDs to their duplicate so that we can replace GIDs of the region
-    // column map and form the quasiregion column map.
-    Array<RCP<Xpetra::Vector<MT, LO, GO, NO> > > coarseQuasiregionGIDs(1), coarseRegionGIDs(1);
+    // column map and form the quasiRegion column map.
+    Array<RCP<Xpetra::Vector<MT, LO, GO, NO> > > coarseQuasiregionGIDs(1);
+    Array<RCP<Xpetra::Vector<MT, LO, GO, NO> > > coarseRegionGIDs(1);
     compositeToRegional(coarseCompositeGIDs,
                         coarseQuasiregionGIDs,
                         coarseRegionGIDs,
-                        1,
                         quasiRegRowMaps[currentLevel - 1],
                         regRowMaps[currentLevel - 1],
                         regRowImporters[currentLevel - 1]);
@@ -444,7 +444,7 @@ void MakeInterfaceScalingFactors(const int maxRegPerProc,
      */
     Array<RCP<Vector> > quasiRegInterfaceScaling(maxRegPerProc); // Is that vector really needed?
     compositeToRegional(compInterfaceScalingSum, quasiRegInterfaceScaling,
-                        regInterfaceScalings[l], maxRegPerProc, quasiRegRowMaps[l],
+                        regInterfaceScalings[l], quasiRegRowMaps[l],
                         regRowMaps[l], regRowImporters[l]);
   }
 } // MakeInterfaceScalingFactors
@@ -934,7 +934,6 @@ void vCycle(const int l, ///< ID of current level
       // Transform back to region format
       Array<RCP<Vector> > quasiRegX(maxRegPerProc);
       compositeToRegional(compX, quasiRegX, fineRegX,
-                          maxRegPerProc,
                           quasiRegRowMaps[l],
                           regRowMaps[l],
                           regRowImporters[l]);

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
@@ -437,7 +437,7 @@ void MakeInterfaceScalingFactors(const int maxRegPerProc,
 
     // transform to composite layout while adding interface values via the Export() combine mode
     RCP<Vector> compInterfaceScalingSum = VectorFactory::Build(compRowMaps[l], true);
-    regionalToComposite(regInterfaceScalings[l], compInterfaceScalingSum, maxRegPerProc, quasiRegRowMaps[l], regRowImporters[l], Xpetra::ADD);
+    regionalToComposite(regInterfaceScalings[l], compInterfaceScalingSum, maxRegPerProc, regRowImporters[l], Xpetra::ADD);
 
     /* transform composite layout back to regional layout. Now, GIDs associated
      * with region interface should carry a scaling factor (!= 1).
@@ -868,7 +868,7 @@ void vCycle(const int l, ///< ID of current level
           fineRegB[j]->elementWiseMultiply(SC_ONE, *fineRegB[j], *inverseInterfaceScaling, SC_ZERO);
         }
 
-        regionalToComposite(fineRegB, compRhs, maxRegPerProc, quasiRegRowMaps[l],
+        regionalToComposite(fineRegB, compRhs, maxRegPerProc,
                             regRowImporters[l], Xpetra::ADD);
       }
 

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
@@ -303,7 +303,7 @@ void MakeCoarseCompositeOperator(const int maxRegPerProc, const int numLevels,
   //      coarseCompOp->setAllToScalar(SC_ZERO);
   //      coarseCompOp->describe(*fos, Teuchos::VERB_EXTREME);
 
-  regionalToComposite(regMatrices[maxLevel], maxRegPerProc,
+  regionalToComposite(regMatrices[maxLevel],
                       quasiRegRowMaps[maxLevel], quasiRegColMaps[maxLevel],
                       regRowImporters[maxLevel], Xpetra::ADD,
                       coarseCompOp);
@@ -436,7 +436,7 @@ void MakeInterfaceScalingFactors(const int maxRegPerProc,
 
     // transform to composite layout while adding interface values via the Export() combine mode
     RCP<Vector> compInterfaceScalingSum = VectorFactory::Build(compRowMaps[l], true);
-    regionalToComposite(regInterfaceScalings[l], compInterfaceScalingSum, maxRegPerProc, regRowImporters[l], Xpetra::ADD);
+    regionalToComposite(regInterfaceScalings[l], compInterfaceScalingSum, regRowImporters[l], Xpetra::ADD);
 
     /* transform composite layout back to regional layout. Now, GIDs associated
      * with region interface should carry a scaling factor (!= 1).
@@ -867,7 +867,7 @@ void vCycle(const int l, ///< ID of current level
           fineRegB[j]->elementWiseMultiply(SC_ONE, *fineRegB[j], *inverseInterfaceScaling, SC_ZERO);
         }
 
-        regionalToComposite(fineRegB, compRhs, maxRegPerProc,
+        regionalToComposite(fineRegB, compRhs,
                             regRowImporters[l], Xpetra::ADD);
       }
 

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
@@ -223,7 +223,6 @@ void MakeCoarseLevelMaps2(const int maxRegPerGID,
     compositeToRegional(coarseCompositeGIDs,
                         coarseQuasiregionGIDs,
                         coarseRegionGIDs,
-                        quasiRegRowMaps[currentLevel - 1],
                         regRowMaps[currentLevel - 1],
                         regRowImporters[currentLevel - 1]);
 
@@ -444,7 +443,7 @@ void MakeInterfaceScalingFactors(const int maxRegPerProc,
      */
     Array<RCP<Vector> > quasiRegInterfaceScaling(maxRegPerProc); // Is that vector really needed?
     compositeToRegional(compInterfaceScalingSum, quasiRegInterfaceScaling,
-                        regInterfaceScalings[l], quasiRegRowMaps[l],
+                        regInterfaceScalings[l],
                         regRowMaps[l], regRowImporters[l]);
   }
 } // MakeInterfaceScalingFactors
@@ -934,7 +933,6 @@ void vCycle(const int l, ///< ID of current level
       // Transform back to region format
       Array<RCP<Vector> > quasiRegX(maxRegPerProc);
       compositeToRegional(compX, quasiRegX, fineRegX,
-                          quasiRegRowMaps[l],
                           regRowMaps[l],
                           regRowImporters[l]);
 

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionMatrix_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionMatrix_def.hpp
@@ -572,7 +572,7 @@ void MakeRegionMatrices(const RCP<Xpetra::CrsMatrixWrap<Scalar, LocalOrdinal, Gl
       // transform to composite layout while adding interface values via the Export() combine mode
       RCP<Vector> compInterfaceScalingSum = VectorFactory::Build(mapComp, true);
       regionalToComposite(interfaceScaling, compInterfaceScalingSum,
-                          maxRegPerProc, rowImportPerGrp, Xpetra::ADD);
+                          rowImportPerGrp, Xpetra::ADD);
 
       /* transform composite layout back to regional layout. Now, GIDs associated
        * with region interface should carry a scaling factor (!= 1).
@@ -633,7 +633,6 @@ void MakeRegionMatrices(const RCP<Xpetra::CrsMatrixWrap<Scalar, LocalOrdinal, Gl
  */
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void regionalToComposite(const std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regMat, ///< Matrix in region layout [in]
-                         const int maxRegPerProc, ///< max number of regions per proc
                          const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > rowMapPerGrp, ///< row maps in quasiRegion layout [in]
                          const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > colMapPerGrp, ///< col maps in quasiRegion layout [in]
                          const std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > rowImportPerGrp, ///< row importer in region layout [in]
@@ -645,6 +644,9 @@ void regionalToComposite(const std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdin
   using Teuchos::TimeMonitor;
   using Teuchos::rcp;
   using std::size_t;
+
+  // Get max number of regions per proc
+  const int maxRegPerProc = regMat.size();
 
   RCP<TimeMonitor> tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("regionalToComposite: Matrix")));
 

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionMatrix_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionMatrix_def.hpp
@@ -762,7 +762,7 @@ computeResidual(Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, No
   tm = Teuchos::null;
   tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("computeResidual: 2 - sumInterfaceValues")));
 
-  sumInterfaceValues(regRes, mapComp, maxRegPerProc, rowMapPerGrp,
+  sumInterfaceValues(regRes, mapComp, rowMapPerGrp,
                      revisedRowMapPerGrp, rowImportPerGrp);
 
   tm = Teuchos::null;

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionMatrix_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionMatrix_def.hpp
@@ -551,7 +551,7 @@ void MakeRegionMatrices(const RCP<Xpetra::CrsMatrixWrap<Scalar, LocalOrdinal, Gl
     createRegionalVector(quasiRegNspViolation, maxRegPerProc, rowMapPerGrp);
     createRegionalVector(regNspViolation, maxRegPerProc, revisedRowMapPerGrp);
     compositeToRegional(nspViolation, quasiRegNspViolation, regNspViolation,
-                        maxRegPerProc, rowMapPerGrp, revisedRowMapPerGrp, rowImportPerGrp);
+                        rowMapPerGrp, revisedRowMapPerGrp, rowImportPerGrp);
 
     /* The nullspace violation computed in the composite layout needs to be
      * transfered to the regional layout. Since we use this to compute
@@ -579,7 +579,7 @@ void MakeRegionMatrices(const RCP<Xpetra::CrsMatrixWrap<Scalar, LocalOrdinal, Gl
        */
       Array<RCP<Vector> > quasiRegInterfaceScaling(maxRegPerProc);
       compositeToRegional(compInterfaceScalingSum, quasiRegInterfaceScaling,
-                          interfaceScaling, maxRegPerProc, rowMapPerGrp,
+                          interfaceScaling, rowMapPerGrp,
                           revisedRowMapPerGrp, rowImportPerGrp);
 
       // modify its interface entries

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionMatrix_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionMatrix_def.hpp
@@ -551,7 +551,7 @@ void MakeRegionMatrices(const RCP<Xpetra::CrsMatrixWrap<Scalar, LocalOrdinal, Gl
     createRegionalVector(quasiRegNspViolation, maxRegPerProc, rowMapPerGrp);
     createRegionalVector(regNspViolation, maxRegPerProc, revisedRowMapPerGrp);
     compositeToRegional(nspViolation, quasiRegNspViolation, regNspViolation,
-                        rowMapPerGrp, revisedRowMapPerGrp, rowImportPerGrp);
+                        revisedRowMapPerGrp, rowImportPerGrp);
 
     /* The nullspace violation computed in the composite layout needs to be
      * transfered to the regional layout. Since we use this to compute
@@ -579,7 +579,7 @@ void MakeRegionMatrices(const RCP<Xpetra::CrsMatrixWrap<Scalar, LocalOrdinal, Gl
        */
       Array<RCP<Vector> > quasiRegInterfaceScaling(maxRegPerProc);
       compositeToRegional(compInterfaceScalingSum, quasiRegInterfaceScaling,
-                          interfaceScaling, rowMapPerGrp,
+                          interfaceScaling,
                           revisedRowMapPerGrp, rowImportPerGrp);
 
       // modify its interface entries

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionMatrix_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionMatrix_def.hpp
@@ -572,7 +572,7 @@ void MakeRegionMatrices(const RCP<Xpetra::CrsMatrixWrap<Scalar, LocalOrdinal, Gl
       // transform to composite layout while adding interface values via the Export() combine mode
       RCP<Vector> compInterfaceScalingSum = VectorFactory::Build(mapComp, true);
       regionalToComposite(interfaceScaling, compInterfaceScalingSum,
-                          maxRegPerProc, rowMapPerGrp, rowImportPerGrp, Xpetra::ADD);
+                          maxRegPerProc, rowImportPerGrp, Xpetra::ADD);
 
       /* transform composite layout back to regional layout. Now, GIDs associated
        * with region interface should carry a scaling factor (!= 1).

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionSmoothers_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionSmoothers_def.hpp
@@ -116,7 +116,7 @@ void relaxationSmootherSetup(RCP<Teuchos::ParameterList> params,
     regionGrpMats[j]->getLocalDiagCopy(*diagReg[j]);
   }
 
-  sumInterfaceValues(diagReg, mapComp, maxRegPerProc, rowMapPerGrp,
+  sumInterfaceValues(diagReg, mapComp, rowMapPerGrp,
                      revisedRowMapPerGrp, rowImportPerGrp);
 
   for (int j = 0; j < maxRegPerProc; j++) {
@@ -315,7 +315,7 @@ powerMethod(RCP<Teuchos::ParameterList> params,
     for (int j = 0; j < maxRegPerProc; j++) { // step 1
       regionGrpMats[j]->apply(*regX[j], *regY[j]); // A.apply (x, y);
     }
-    sumInterfaceValues( regY, mapComp, maxRegPerProc, rowMapPerGrp, revisedRowMapPerGrp, rowImportPerGrp); // step 2
+    sumInterfaceValues( regY, mapComp, rowMapPerGrp, revisedRowMapPerGrp, rowImportPerGrp); // step 2
 
     // Scale by inverse of diagonal
     for (int j = 0; j < maxRegPerProc; j++){

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionSmoothers_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionSmoothers_def.hpp
@@ -251,7 +251,7 @@ calcNorm2(Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > 
 {
 #include "Xpetra_UseShortNames.hpp"
   RCP<Vector> compVec = VectorFactory::Build(mapComp, true);
-  regionalToComposite(regVec, compVec, maxRegPerProc, rowMapPerGrp, rowImportPerGrp, Xpetra::ADD);
+  regionalToComposite(regVec, compVec, maxRegPerProc, rowImportPerGrp, Xpetra::ADD);
   typename Teuchos::ScalarTraits<Scalar>::magnitudeType norm = compVec->norm2();
 
   return norm;
@@ -270,8 +270,8 @@ dotProd(Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >&
 #include "Xpetra_UseShortNames.hpp"
   RCP<Vector> compX = VectorFactory::Build(mapComp, true);
   RCP<Vector> compY = VectorFactory::Build(mapComp, true);
-  regionalToComposite(regX, compX, maxRegPerProc, rowMapPerGrp, rowImportPerGrp, Xpetra::ADD);
-  regionalToComposite(regY, compY, maxRegPerProc, rowMapPerGrp, rowImportPerGrp, Xpetra::ADD);
+  regionalToComposite(regX, compX, maxRegPerProc, rowImportPerGrp, Xpetra::ADD);
+  regionalToComposite(regY, compY, maxRegPerProc, rowImportPerGrp, Xpetra::ADD);
   SC dotVal = compX->dot(*compY);
 
   return dotVal;

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionSmoothers_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionSmoothers_def.hpp
@@ -251,7 +251,7 @@ calcNorm2(Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > 
 {
 #include "Xpetra_UseShortNames.hpp"
   RCP<Vector> compVec = VectorFactory::Build(mapComp, true);
-  regionalToComposite(regVec, compVec, maxRegPerProc, rowImportPerGrp, Xpetra::ADD);
+  regionalToComposite(regVec, compVec, rowImportPerGrp, Xpetra::ADD);
   typename Teuchos::ScalarTraits<Scalar>::magnitudeType norm = compVec->norm2();
 
   return norm;
@@ -270,8 +270,8 @@ dotProd(Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >&
 #include "Xpetra_UseShortNames.hpp"
   RCP<Vector> compX = VectorFactory::Build(mapComp, true);
   RCP<Vector> compY = VectorFactory::Build(mapComp, true);
-  regionalToComposite(regX, compX, maxRegPerProc, rowImportPerGrp, Xpetra::ADD);
-  regionalToComposite(regY, compY, maxRegPerProc, rowImportPerGrp, Xpetra::ADD);
+  regionalToComposite(regX, compX, rowImportPerGrp, Xpetra::ADD);
+  regionalToComposite(regY, compY, rowImportPerGrp, Xpetra::ADD);
   SC dotVal = compX->dot(*compY);
 
   return dotVal;

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionVector_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionVector_def.hpp
@@ -91,13 +91,16 @@ template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void compositeToRegional(RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > compVec, ///< Vector in composite layout [in]
                          Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& quasiRegVecs, ///< Vector in quasiRegional layout [in/out]
                          Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regVecs, ///< Vector in regional layout [in/out]
-                         const int maxRegPerProc, ///< max number of regions per proc [in]
                          const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > rowMapPerGrp, ///< row maps in region layout [in]
                          const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > revisedRowMapPerGrp, ///< revised row maps in region layout [in]
                          const std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > rowImportPerGrp ///< row importer in region layout [in]
                          )
 {
 #include "Xpetra_UseShortNames.hpp"
+
+  // Get max number of regions per proc
+  const int maxRegPerProc = regVecs.size();
+
   // quasiRegional layout
   for (int grpIdx = 0; grpIdx < maxRegPerProc; ++grpIdx) {
     // create empty vectors and fill it by extracting data from composite vector
@@ -206,8 +209,6 @@ void sumInterfaceValues(Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrd
   RCP<Vector> compVec = VectorFactory::Build(compMap, true);
   TEUCHOS_ASSERT(!compVec.is_null());
 
-  Array<Teuchos::RCP<Vector> > quasiRegVec(maxRegPerProc);
-
   RCP<TimeMonitor> tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("sumInterfaceValues: 1 - regionalToComposite")));
   regionalToComposite(regVec, compVec, maxRegPerProc,
                       rowImportPerGrp, Xpetra::ADD);
@@ -215,7 +216,8 @@ void sumInterfaceValues(Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrd
   tm = Teuchos::null;
   tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("sumInterfaceValues: 2 - compositeToRegional")));
 
-  compositeToRegional(compVec, quasiRegVec, regVec, maxRegPerProc,
+  Array<Teuchos::RCP<Vector> > quasiRegVec(maxRegPerProc);
+  compositeToRegional(compVec, quasiRegVec, regVec,
                       rowMapPerGrp, revisedRowMapPerGrp, rowImportPerGrp);
 
   tm = Teuchos::null;

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionVector_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionVector_def.hpp
@@ -196,7 +196,6 @@ void regionalToComposite(const Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, Gl
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void sumInterfaceValues(Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regVec,
                         const RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > compMap,
-                        const int maxRegPerProc, ///< max number of regions per proc [in]
                         const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > rowMapPerGrp,///< row maps in region layout [in]
                         const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > revisedRowMapPerGrp,///< revised row maps in region layout [in]
                         const std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > rowImportPerGrp ///< row importer in region layout [in])
@@ -204,6 +203,9 @@ void sumInterfaceValues(Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrd
 {
 #include "Xpetra_UseShortNames.hpp"
   using Teuchos::TimeMonitor;
+
+  // Get max number of regions per proc
+  const int maxRegPerProc = regVec.size();
 
   RCP<Vector> compVec = VectorFactory::Build(compMap, true);
   TEUCHOS_ASSERT(!compVec.is_null());

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionVector_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionVector_def.hpp
@@ -132,7 +132,6 @@ void compositeToRegional(RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal,
 template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void regionalToComposite(const Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regVec, ///< Vector in region layout [in]
                          RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > compVec, ///< Vector in composite layout [in/out]
-                         const int maxRegPerProc, ///< max number of regions per proc
                          const std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > rowImportPerGrp, ///< row importer in region layout [in]
                          const Xpetra::CombineMode combineMode ///< Combine mode for import/export [in]
                          )
@@ -143,6 +142,9 @@ void regionalToComposite(const Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, Gl
    */
 #include "Xpetra_UseShortNames.hpp"
   using Teuchos::TimeMonitor;
+
+  // Get max number of regions per proc
+  const int maxRegPerProc = regVec.size();
 
   RCP<TimeMonitor> tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("regionalToComposite: 1 - compVec setup")));
 
@@ -211,7 +213,7 @@ void sumInterfaceValues(Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrd
   TEUCHOS_ASSERT(!compVec.is_null());
 
   RCP<TimeMonitor> tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("sumInterfaceValues: 1 - regionalToComposite")));
-  regionalToComposite(regVec, compVec, maxRegPerProc,
+  regionalToComposite(regVec, compVec,
                       rowImportPerGrp, Xpetra::ADD);
 
   tm = Teuchos::null;

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionVector_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionVector_def.hpp
@@ -99,11 +99,11 @@ void compositeToRegional(RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal,
 {
 #include "Xpetra_UseShortNames.hpp"
   // quasiRegional layout
-  for (int j = 0; j < maxRegPerProc; j++) {
+  for (int grpIdx = 0; grpIdx < maxRegPerProc; ++grpIdx) {
     // create empty vectors and fill it by extracting data from composite vector
-    quasiRegVecs[j] = VectorFactory::Build(rowMapPerGrp[j], true);
-    TEUCHOS_ASSERT(!quasiRegVecs[j].is_null());
-    quasiRegVecs[j]->doImport(*compVec, *(rowImportPerGrp[j]), Xpetra::INSERT);
+    quasiRegVecs[grpIdx] = VectorFactory::Build(rowImportPerGrp[grpIdx]->getTargetMap(), true);
+    TEUCHOS_ASSERT(!quasiRegVecs[grpIdx].is_null());
+    quasiRegVecs[grpIdx]->doImport(*compVec, *(rowImportPerGrp[grpIdx]), Xpetra::INSERT);
   }
 
   // regional layout
@@ -131,7 +131,6 @@ template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void regionalToComposite(const Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regVec, ///< Vector in region layout [in]
                          RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > compVec, ///< Vector in composite layout [in/out]
                          const int maxRegPerProc, ///< max number of regions per proc
-                         const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > rowMapPerGrp, ///< row maps in quasiRegion layout [in]
                          const std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > rowImportPerGrp, ///< row importer in region layout [in]
                          const Xpetra::CombineMode combineMode ///< Combine mode for import/export [in]
                          )
@@ -210,7 +209,7 @@ void sumInterfaceValues(Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrd
   Array<Teuchos::RCP<Vector> > quasiRegVec(maxRegPerProc);
 
   RCP<TimeMonitor> tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("sumInterfaceValues: 1 - regionalToComposite")));
-  regionalToComposite(regVec, compVec, maxRegPerProc, rowMapPerGrp,
+  regionalToComposite(regVec, compVec, maxRegPerProc,
                       rowImportPerGrp, Xpetra::ADD);
 
   tm = Teuchos::null;

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionVector_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionVector_def.hpp
@@ -91,7 +91,6 @@ template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void compositeToRegional(RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > compVec, ///< Vector in composite layout [in]
                          Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& quasiRegVecs, ///< Vector in quasiRegional layout [in/out]
                          Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regVecs, ///< Vector in regional layout [in/out]
-                         const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > rowMapPerGrp, ///< row maps in region layout [in]
                          const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > revisedRowMapPerGrp, ///< revised row maps in region layout [in]
                          const std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > rowImportPerGrp ///< row importer in region layout [in]
                          )
@@ -218,7 +217,7 @@ void sumInterfaceValues(Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrd
 
   Array<Teuchos::RCP<Vector> > quasiRegVec(maxRegPerProc);
   compositeToRegional(compVec, quasiRegVec, regVec,
-                      rowMapPerGrp, revisedRowMapPerGrp, rowImportPerGrp);
+                      revisedRowMapPerGrp, rowImportPerGrp);
 
   tm = Teuchos::null;
 

--- a/packages/muelu/research/mmayr/composite_to_regions/src/main.cpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/main.cpp
@@ -867,12 +867,12 @@ int main_(int argc, char *argv[]) {
     }
 
     // transform composite vectors to regional layout
-    compositeToRegional(compX, quasiRegX, regX, maxRegPerProc, rowMapPerGrp,
+    compositeToRegional(compX, quasiRegX, regX, rowMapPerGrp,
         revisedRowMapPerGrp, rowImportPerGrp);
 
     Array<RCP<Vector> > quasiRegB(maxRegPerProc);
     Array<RCP<Vector> > regB(maxRegPerProc);
-    compositeToRegional(compB, quasiRegB, regB, maxRegPerProc, rowMapPerGrp,
+    compositeToRegional(compB, quasiRegB, regB, rowMapPerGrp,
         revisedRowMapPerGrp, rowImportPerGrp);
 
 //    printRegionalObject<Vector>("regB 0", regB, myRank, *fos);

--- a/packages/muelu/research/mmayr/composite_to_regions/src/main.cpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/main.cpp
@@ -867,12 +867,12 @@ int main_(int argc, char *argv[]) {
     }
 
     // transform composite vectors to regional layout
-    compositeToRegional(compX, quasiRegX, regX, rowMapPerGrp,
+    compositeToRegional(compX, quasiRegX, regX,
         revisedRowMapPerGrp, rowImportPerGrp);
 
     Array<RCP<Vector> > quasiRegB(maxRegPerProc);
     Array<RCP<Vector> > regB(maxRegPerProc);
-    compositeToRegional(compB, quasiRegB, regB, rowMapPerGrp,
+    compositeToRegional(compB, quasiRegB, regB,
         revisedRowMapPerGrp, rowImportPerGrp);
 
 //    printRegionalObject<Vector>("regB 0", regB, myRank, *fos);

--- a/packages/muelu/research/mmayr/composite_to_regions/src/main.cpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/main.cpp
@@ -915,7 +915,7 @@ int main_(int argc, char *argv[]) {
 //        printRegionalObject<Vector>("regB 1", regB, myRank, *fos);
 
         compRes = VectorFactory::Build(mapComp, true);
-        regionalToComposite(regRes, compRes, maxRegPerProc,
+        regionalToComposite(regRes, compRes,
                             rowImportPerGrp, Xpetra::ADD);
         typename Teuchos::ScalarTraits<Scalar>::magnitudeType normRes = compRes->norm2();
 
@@ -953,7 +953,7 @@ int main_(int argc, char *argv[]) {
     sleep(1);
 
     // ToDo (mayr.mt) Is this the right CombineMode?
-    regionalToComposite(regX, compX, maxRegPerProc, rowMapPerGrp, rowImportPerGrp, Xpetra::INSERT);
+    regionalToComposite(regX, compX, rowMapPerGrp, rowImportPerGrp, Xpetra::INSERT);
 
     std::cout << myRank << " | compX after V-cycle" << std::endl;
     sleep(1);

--- a/packages/muelu/research/mmayr/composite_to_regions/src/main.cpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/main.cpp
@@ -915,7 +915,7 @@ int main_(int argc, char *argv[]) {
 //        printRegionalObject<Vector>("regB 1", regB, myRank, *fos);
 
         compRes = VectorFactory::Build(mapComp, true);
-        regionalToComposite(regRes, compRes, maxRegPerProc, rowMapPerGrp,
+        regionalToComposite(regRes, compRes, maxRegPerProc,
                             rowImportPerGrp, Xpetra::ADD);
         typename Teuchos::ScalarTraits<Scalar>::magnitudeType normRes = compRes->norm2();
 

--- a/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
+++ b/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
@@ -814,7 +814,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
         }
 
         compRes = VectorFactory::Build(dofMap, true);
-        regionalToComposite(regRes, compRes, maxRegPerProc,
+        regionalToComposite(regRes, compRes,
                             rowImportPerGrp, Xpetra::ADD);
 
         typename Teuchos::ScalarTraits<Scalar>::magnitudeType normRes = compRes->norm2();

--- a/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
+++ b/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
@@ -717,12 +717,12 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
     // transform composite vectors to regional layout
     Array<Teuchos::RCP<Vector> > quasiRegX(maxRegPerProc);
     Array<Teuchos::RCP<Vector> > regX(maxRegPerProc);
-    compositeToRegional(X, quasiRegX, regX, rowMapPerGrp,
+    compositeToRegional(X, quasiRegX, regX,
                         revisedRowMapPerGrp, rowImportPerGrp);
 
     Array<RCP<Vector> > quasiRegB(maxRegPerProc);
     Array<RCP<Vector> > regB(maxRegPerProc);
-    compositeToRegional(B, quasiRegB, regB, rowMapPerGrp,
+    compositeToRegional(B, quasiRegB, regB,
                         revisedRowMapPerGrp, rowImportPerGrp);
 #ifdef DUMP_LOCALX_AND_A
     FILE *fp;

--- a/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
+++ b/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
@@ -717,12 +717,12 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
     // transform composite vectors to regional layout
     Array<Teuchos::RCP<Vector> > quasiRegX(maxRegPerProc);
     Array<Teuchos::RCP<Vector> > regX(maxRegPerProc);
-    compositeToRegional(X, quasiRegX, regX, maxRegPerProc, rowMapPerGrp,
+    compositeToRegional(X, quasiRegX, regX, rowMapPerGrp,
                         revisedRowMapPerGrp, rowImportPerGrp);
 
     Array<RCP<Vector> > quasiRegB(maxRegPerProc);
     Array<RCP<Vector> > regB(maxRegPerProc);
-    compositeToRegional(B, quasiRegB, regB, maxRegPerProc, rowMapPerGrp,
+    compositeToRegional(B, quasiRegB, regB, rowMapPerGrp,
                         revisedRowMapPerGrp, rowImportPerGrp);
 #ifdef DUMP_LOCALX_AND_A
     FILE *fp;

--- a/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
+++ b/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
@@ -814,7 +814,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
         }
 
         compRes = VectorFactory::Build(dofMap, true);
-        regionalToComposite(regRes, compRes, maxRegPerProc, rowMapPerGrp,
+        regionalToComposite(regRes, compRes, maxRegPerProc,
                             rowImportPerGrp, Xpetra::ADD);
 
         typename Teuchos::ScalarTraits<Scalar>::magnitudeType normRes = compRes->norm2();

--- a/packages/muelu/test/unit_tests/RegionMatrix.cpp
+++ b/packages/muelu/test/unit_tests/RegionMatrix.cpp
@@ -238,7 +238,6 @@ void test_matrix(const int maxRegPerProc,
   // with the original composite B vector.
   RCP<Vector> compB = VectorFactory::Build(A->getRowMap());
   regionalToComposite(regB, compB, maxRegPerProc,
-                      rowMapPerGrp,
                       rowImportPerGrp,
                       Xpetra::ADD);
 
@@ -663,7 +662,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, MatVec, Scalar, LocalOrdinal, Gl
   // composite B with the original B
   RCP<Vector> compB = VectorFactory::Build(dofMap);
   regionalToComposite(regB, compB, maxRegPerProc,
-                      rowMapPerGrp,
                       rowImportPerGrp,
                       Xpetra::ADD);
 

--- a/packages/muelu/test/unit_tests/RegionMatrix.cpp
+++ b/packages/muelu/test/unit_tests/RegionMatrix.cpp
@@ -237,7 +237,7 @@ void test_matrix(const int maxRegPerProc,
   // to composite format so it can be compared
   // with the original composite B vector.
   RCP<Vector> compB = VectorFactory::Build(A->getRowMap());
-  regionalToComposite(regB, compB, maxRegPerProc,
+  regionalToComposite(regB, compB,
                       rowImportPerGrp,
                       Xpetra::ADD);
 
@@ -259,7 +259,7 @@ void test_matrix(const int maxRegPerProc,
   /************************************/
   RCP<Matrix> compositeMatrix = MatrixFactory::Build(A->getRowMap(), 10, Xpetra::StaticProfile);
   // Transform region A into composite A.
-  regionalToComposite(regionGrpMats, maxRegPerProc,
+  regionalToComposite(regionGrpMats,
                       rowMapPerGrp, colMapPerGrp,
                       rowImportPerGrp, Xpetra::INSERT,
                       compositeMatrix);
@@ -537,7 +537,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, RegionToCompositeMatrix, Scalar,
 
   // Finally do the revert operation: start with regionGrpMats and bring it to composite format
   RCP<Matrix> compositeMatrix = MatrixFactory::Build(dofMap, 10, Xpetra::StaticProfile);
-  regionalToComposite(regionGrpMats, maxRegPerProc,
+  regionalToComposite(regionGrpMats,
                       rowMapPerGrp, colMapPerGrp,
                       rowImportPerGrp, Xpetra::INSERT,
                       compositeMatrix);
@@ -663,7 +663,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, MatVec, Scalar, LocalOrdinal, Gl
   // Now create composite B using region B so we can compare
   // composite B with the original B
   RCP<Vector> compB = VectorFactory::Build(dofMap);
-  regionalToComposite(regB, compB, maxRegPerProc,
+  regionalToComposite(regB, compB,
                       rowImportPerGrp,
                       Xpetra::ADD);
 

--- a/packages/muelu/test/unit_tests/RegionMatrix.cpp
+++ b/packages/muelu/test/unit_tests/RegionMatrix.cpp
@@ -226,7 +226,7 @@ void test_matrix(const int maxRegPerProc,
   // Now build the region X vector
   Array<RCP<Vector> > quasiRegX(maxRegPerProc), quasiRegB(maxRegPerProc);
   Array<RCP<Vector> > regX(maxRegPerProc), regB(maxRegPerProc);
-  compositeToRegional(X, quasiRegX, regX, rowMapPerGrp,
+  compositeToRegional(X, quasiRegX, regX,
                       revisedRowMapPerGrp, rowImportPerGrp);
   regB[0] = VectorFactory::Build(revisedRowMapPerGrp[0], true);
 
@@ -651,9 +651,11 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, MatVec, Scalar, LocalOrdinal, Gl
   A->apply(*X, *B, Teuchos::NO_TRANS, TST::one(), TST::zero());
 
   // Create the region vectors and apply region A
-  Array<RCP<Vector> > quasiRegX(maxRegPerProc), quasiRegB(maxRegPerProc);
-  Array<RCP<Vector> > regX(maxRegPerProc), regB(maxRegPerProc);
-  compositeToRegional(X, quasiRegX, regX, rowMapPerGrp,
+  Array<RCP<Vector> > quasiRegX(maxRegPerProc);
+  Array<RCP<Vector> > quasiRegB(maxRegPerProc);
+  Array<RCP<Vector> > regX(maxRegPerProc);
+  Array<RCP<Vector> > regB(maxRegPerProc);
+  compositeToRegional(X, quasiRegX, regX,
                       revisedRowMapPerGrp, rowImportPerGrp);
   regB[0] = VectorFactory::Build(revisedRowMapPerGrp[0], true);
   regionMat->apply(*regX[0], *regB[0], Teuchos::NO_TRANS, TST::one(), TST::zero());

--- a/packages/muelu/test/unit_tests/RegionMatrix.cpp
+++ b/packages/muelu/test/unit_tests/RegionMatrix.cpp
@@ -226,7 +226,7 @@ void test_matrix(const int maxRegPerProc,
   // Now build the region X vector
   Array<RCP<Vector> > quasiRegX(maxRegPerProc), quasiRegB(maxRegPerProc);
   Array<RCP<Vector> > regX(maxRegPerProc), regB(maxRegPerProc);
-  compositeToRegional(X, quasiRegX, regX, maxRegPerProc, rowMapPerGrp,
+  compositeToRegional(X, quasiRegX, regX, rowMapPerGrp,
                       revisedRowMapPerGrp, rowImportPerGrp);
   regB[0] = VectorFactory::Build(revisedRowMapPerGrp[0], true);
 
@@ -653,7 +653,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, MatVec, Scalar, LocalOrdinal, Gl
   // Create the region vectors and apply region A
   Array<RCP<Vector> > quasiRegX(maxRegPerProc), quasiRegB(maxRegPerProc);
   Array<RCP<Vector> > regX(maxRegPerProc), regB(maxRegPerProc);
-  compositeToRegional(X, quasiRegX, regX, maxRegPerProc, rowMapPerGrp,
+  compositeToRegional(X, quasiRegX, regX, rowMapPerGrp,
                       revisedRowMapPerGrp, rowImportPerGrp);
   regB[0] = VectorFactory::Build(revisedRowMapPerGrp[0], true);
   regionMat->apply(*regX[0], *regB[0], Teuchos::NO_TRANS, TST::one(), TST::zero());

--- a/packages/muelu/test/unit_tests/RegionVector.cpp
+++ b/packages/muelu/test/unit_tests/RegionVector.cpp
@@ -180,11 +180,11 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionVector, RegionCompositeVector, Scalar, L
                                               20, 21, 22, 23, 24}));
       for (int j = 0; j < maxRegPerProc; j++) {
         myValues = regVec[j]->getData(0);
-        for(int idx = 0; idx < regVec[j]->getLocalLength(); ++idx) {
+        for(size_t idx = 0; idx < regVec[j]->getLocalLength(); ++idx) {
           TEST_FLOATING_EQUALITY(myValues[idx], refValues[idx], 100*TMT::eps());
         }
         myValues = quasiRegVec[j]->getData(0);
-        for(int idx = 0; idx < quasiRegVec[j]->getLocalLength(); ++idx) {
+        for(size_t idx = 0; idx < quasiRegVec[j]->getLocalLength(); ++idx) {
           TEST_FLOATING_EQUALITY(myValues[idx], refValues[idx], 100*TMT::eps());
         }
 
@@ -214,11 +214,11 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionVector, RegionCompositeVector, Scalar, L
       // Loop over region matrix data and compare it to ref data
       for (int j = 0; j < maxRegPerProc; j++){
         myValues = regVec[j]->getData(0);
-        for(int idx = 0; idx < regVec[j]->getLocalLength(); ++idx) {
+        for(size_t idx = 0; idx < regVec[j]->getLocalLength(); ++idx) {
           TEST_FLOATING_EQUALITY(myValues[idx], refValues[idx], 100*TMT::eps());
         }
         myValues = quasiRegVec[j]->getData(0);
-        for(int idx = 0; idx < quasiRegVec[j]->getLocalLength(); ++idx) {
+        for(size_t idx = 0; idx < quasiRegVec[j]->getLocalLength(); ++idx) {
           TEST_FLOATING_EQUALITY(myValues[idx], refValues[idx], 100*TMT::eps());
         }
       }
@@ -240,7 +240,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionVector, RegionCompositeVector, Scalar, L
     // Create a composite vector
     RCP<Vector> compVec = VectorFactory::Build(dofMap, true);
 
-    regionalToComposite(regVec, compVec, maxRegPerProc, rowMapPerGrp, rowImportPerGrp, Xpetra::ADD);
+    regionalToComposite(regVec, compVec, maxRegPerProc, rowImportPerGrp, Xpetra::ADD);
 
     if(numRanks == 1) {
       TEST_EQUALITY(compVec->getLocalLength(),  25);
@@ -254,7 +254,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionVector, RegionCompositeVector, Scalar, L
                                               15.0, 16.0, 17.0, 18.0, 19.0,
                                               20.0, 21.0, 22.0, 23.0, 24.0}));
       myValues = compVec->getData(0);
-      for(int idx = 0; idx < compVec->getLocalLength(); ++idx) {
+      for(size_t idx = 0; idx < compVec->getLocalLength(); ++idx) {
         TEST_FLOATING_EQUALITY(myValues[idx], refValues[idx], 100*TMT::eps());
       }
 
@@ -292,7 +292,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionVector, RegionCompositeVector, Scalar, L
       }
       // Loop over region vector data and compare it to reference data
       myValues = compVec->getData(0);
-      for(int idx = 0; idx < compVec->getLocalLength(); ++idx) {
+      for(size_t idx = 0; idx < compVec->getLocalLength(); ++idx) {
         TEST_FLOATING_EQUALITY(myValues[idx], refValues[idx], 100*TMT::eps());
       }
     }
@@ -309,7 +309,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionVector, RegionCompositeVector, Scalar, L
     // transform to composite layout while adding interface values via the Export() combine mode
     RCP<Vector> compInterfaceScalingSum = VectorFactory::Build(dofMap, true);
     regionalToComposite(interfaceScaling, compInterfaceScalingSum,
-                        maxRegPerProc, rowMapPerGrp, rowImportPerGrp, Xpetra::ADD);
+                        maxRegPerProc, rowImportPerGrp, Xpetra::ADD);
 
     /* transform composite layout back to regional layout. Now, GIDs associated
      * with region interface should carry a scaling factor (!= 1).
@@ -328,7 +328,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionVector, RegionCompositeVector, Scalar, L
       Teuchos::ArrayRCP<const SC> myScaling;
       for (int j = 0; j < maxRegPerProc; j++){
         myScaling = interfaceScaling[j]->getData(0);
-        for(int idx = 0; idx < interfaceScaling[j]->getLocalLength(); ++idx) {
+        for(size_t idx = 0; idx < interfaceScaling[j]->getLocalLength(); ++idx) {
           TEST_FLOATING_EQUALITY(myScaling[idx], 1.0, 100*TMT::eps());
         }
       }
@@ -355,7 +355,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionVector, RegionCompositeVector, Scalar, L
       // Loop over region vector data and compare it to reference data
       for (int j = 0; j < maxRegPerProc; j++){
         myScaling = interfaceScaling[j]->getData(0);
-        for(int idx = 0; idx < interfaceScaling[j]->getLocalLength(); ++idx) {
+        for(size_t idx = 0; idx < interfaceScaling[j]->getLocalLength(); ++idx) {
           TEST_FLOATING_EQUALITY(myScaling[idx], refValues[idx], 100*TMT::eps());
         }
       }

--- a/packages/muelu/test/unit_tests/RegionVector.cpp
+++ b/packages/muelu/test/unit_tests/RegionVector.cpp
@@ -164,7 +164,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionVector, RegionCompositeVector, Scalar, L
     Array<RCP<Vector> > regVec(maxRegPerProc);
     Array<Teuchos::RCP<Vector> > quasiRegVec(maxRegPerProc);
 
-    compositeToRegional(compVec, quasiRegVec, regVec, maxRegPerProc, rowMapPerGrp, revisedRowMapPerGrp, rowImportPerGrp);
+    compositeToRegional(compVec, quasiRegVec, regVec, rowMapPerGrp, revisedRowMapPerGrp, rowImportPerGrp);
 
     if(numRanks == 1){
       TEST_EQUALITY(regVec[0]->getLocalLength(),  25);
@@ -317,7 +317,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionVector, RegionCompositeVector, Scalar, L
     Array<RCP<Vector> > regVec(maxRegPerProc);
     Array<RCP<Vector> > quasiRegInterfaceScaling(maxRegPerProc);
     compositeToRegional(compInterfaceScalingSum, quasiRegInterfaceScaling,
-                        interfaceScaling, maxRegPerProc, rowMapPerGrp,
+                        interfaceScaling, rowMapPerGrp,
                         revisedRowMapPerGrp, rowImportPerGrp);
 
     if(numRanks == 1) {

--- a/packages/muelu/test/unit_tests/RegionVector.cpp
+++ b/packages/muelu/test/unit_tests/RegionVector.cpp
@@ -240,7 +240,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionVector, RegionCompositeVector, Scalar, L
     // Create a composite vector
     RCP<Vector> compVec = VectorFactory::Build(dofMap, true);
 
-    regionalToComposite(regVec, compVec, maxRegPerProc, rowImportPerGrp, Xpetra::ADD);
+    regionalToComposite(regVec, compVec, rowImportPerGrp, Xpetra::ADD);
 
     if(numRanks == 1) {
       TEST_EQUALITY(compVec->getLocalLength(),  25);
@@ -309,7 +309,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionVector, RegionCompositeVector, Scalar, L
     // transform to composite layout while adding interface values via the Export() combine mode
     RCP<Vector> compInterfaceScalingSum = VectorFactory::Build(dofMap, true);
     regionalToComposite(interfaceScaling, compInterfaceScalingSum,
-                        maxRegPerProc, rowImportPerGrp, Xpetra::ADD);
+                        rowImportPerGrp, Xpetra::ADD);
 
     /* transform composite layout back to regional layout. Now, GIDs associated
      * with region interface should carry a scaling factor (!= 1).

--- a/packages/muelu/test/unit_tests/RegionVector.cpp
+++ b/packages/muelu/test/unit_tests/RegionVector.cpp
@@ -164,7 +164,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionVector, RegionCompositeVector, Scalar, L
     Array<RCP<Vector> > regVec(maxRegPerProc);
     Array<Teuchos::RCP<Vector> > quasiRegVec(maxRegPerProc);
 
-    compositeToRegional(compVec, quasiRegVec, regVec, rowMapPerGrp, revisedRowMapPerGrp, rowImportPerGrp);
+    compositeToRegional(compVec, quasiRegVec, regVec, revisedRowMapPerGrp, rowImportPerGrp);
 
     if(numRanks == 1){
       TEST_EQUALITY(regVec[0]->getLocalLength(),  25);
@@ -317,8 +317,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionVector, RegionCompositeVector, Scalar, L
     Array<RCP<Vector> > regVec(maxRegPerProc);
     Array<RCP<Vector> > quasiRegInterfaceScaling(maxRegPerProc);
     compositeToRegional(compInterfaceScalingSum, quasiRegInterfaceScaling,
-                        interfaceScaling, rowMapPerGrp,
-                        revisedRowMapPerGrp, rowImportPerGrp);
+                        interfaceScaling, revisedRowMapPerGrp, rowImportPerGrp);
 
     if(numRanks == 1) {
       TEST_EQUALITY(interfaceScaling[0]->getLocalLength(),    25);


### PR DESCRIPTION
@trilinos/muelu 

## Motivation
A debug build of trilinos reveals that a potentially wrong map is used when importing into a composite vector inside function: regionalToComposite(). This is fixed by using the maps stored in the import object instead of input arguments to regionalToComposite(). Further interface simplifications could be done in regionalToComposite() and compositeToRegional().
I am adding the gdb stack trace that I get when running the tests: [debug_build_gdb_trace.txt](https://github.com/trilinos/Trilinos/files/3889006/debug_build_gdb_trace.txt)


## Related Issues

* Closes #6349
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 

## Testing
Performed a local debug build and ran `ctest -R` on it, all tests are now passing.