### PR TITLE
MueLu: ignoring OperatorComplexity in ParameterListInterpreter for kokkos, see issue #6361

### DIFF
--- a/packages/muelu/test/interface/ParameterListInterpreter.cpp
+++ b/packages/muelu/test/interface/ParameterListInterpreter.cpp
@@ -403,7 +403,10 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
           replacementString = "Global matrix dimensions: <ignored>, Global nnz: <ignored>";
           run_sed("'s/" + stringToReplace + "/" + replacementString + "/'", baseFile);
 
-          // Catch smoother complexity output from MueLu
+          // Catch operator/smoother complexity output from MueLu
+          stringToReplace = "Operator complexity = " + floatRegex;
+          replacementString = "Operator complexity = <ignored>";
+          run_sed("'s/" + stringToReplace + "/" + replacementString + "/'", baseFile);
           stringToReplace = "Smoother complexity = " + floatRegex;
           replacementString = "Smoother complexity = <ignored>";
           run_sed("'s/" + stringToReplace + "/" + replacementString + "/'", baseFile);


### PR DESCRIPTION
After kokkos refactor of aggregation, non deterministic aggregates are formed.
This means that checking operator complexity against a gold file is wrong.
This commits implements logic to ignore OperatorComplexity for kokkos runs of
ParameterListInterpreter.


@trilinos/<teamName>

## Motivation
This PR fixes an issue in the ParameterListInerpreter that arose after the implementation of the refactored aggregation. It should fix the ATDM tests on GPU machines.

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 

## Stakeholder Feedback
@bartlettroscoe please let us know if this change fixes test failures of the ATDM track observed in #6361 

## Testing
Local build and tests have been performed.