### PR TITLE
Framework: Some cleanup and tweaks on PR testing script

### DIFF
--- a/cmake/std/PullRequestLinuxDriverTest.py
+++ b/cmake/std/PullRequestLinuxDriverTest.py
@@ -396,7 +396,7 @@ def get_memory_info():
         import psutil
         mem_total = psutil.virtual_memory().total
         mem_kb = mem_total/1024
-    except ModuleNotFoundError:
+    except:
         # If we can't load psutil then just look for /proc/meminfo
         # - Note: /proc/meminfo assumes a unix/linux system and will fail on
         #         windows or OSX systems that don't have that file.

--- a/cmake/std/PullRequestLinuxDriverTest.py
+++ b/cmake/std/PullRequestLinuxDriverTest.py
@@ -116,17 +116,21 @@ def print_input_variables(arguments):
 
 
 def confirmGitVersion():
+    """
+    """
     git_version_string = subprocess.check_output(['git', '--version'])
     git_version_number_string = git_version_string[git_version_string.rfind(' '):]
     major_git_version = int(git_version_number_string[:git_version_number_string.find('.')])
     minor_git_version = int(git_version_number_string[git_version_number_string.find('.')+1:
                                                       git_version_number_string.rfind('.')])
 
-    if major_git_version  <  2 or (major_git_version == 2 and
-                                   minor_git_version < 10):
+    if major_git_version  <  2 or (major_git_version == 2 and minor_git_version < 10):
         raise SystemExit("Git version  should be 2.10 or better - Exiting!")
     else:
         print(git_version_string)
+
+    return None
+
 
 
 def setBuildEnviron(arguments):
@@ -337,6 +341,7 @@ def setBuildEnviron(arguments):
 
     if 'sems-env' == moduleList[0]:
         module('use', '/projects/sems/modulefiles/projects')
+
     for mod in moduleList:
         if isinstance(mod, str):
             module('load', mod)
@@ -349,6 +354,7 @@ def setBuildEnviron(arguments):
 
     if 'OMPI_CC' in l_environMap:
         l_environMap['OMPI_CC'] = os.environ.get('CC', '')
+
     if 'OMPI_FC' in l_environMap:
         l_environMap['OMPI_FC'] = os.environ.get('FC', '')
 
@@ -358,6 +364,7 @@ def setBuildEnviron(arguments):
             os.environ[key] = value + os.pathsep + os.environ[key]
         else:
             os.environ[key] = value
+
     confirmGitVersion()
 
     print ("Environment:\n", file=sys.stdout)
@@ -372,6 +379,7 @@ def setBuildEnviron(arguments):
     print(module('list'))
 
 
+
 def getCDashTrack():
     returnValue = 'Pull Request'
     if 'PULLREQUEST_CDASH_TRACK' in os.environ:
@@ -383,6 +391,7 @@ def getCDashTrack():
         print('PULLREQUEST_CDASH_TRACK isn\'t set, using default value')
 
     return returnValue
+
 
 
 def get_memory_info():
@@ -413,9 +422,12 @@ def get_memory_info():
     return output
 
 
+
 def compute_n():
-    '''given the default and the hardware environment determine the
-     number of processors  to use'''
+    '''
+    Given the default and the hardware environment determine the
+    number of processors  to use
+    '''
     try:
         environment_weight = int(os.environ['JENKINS_JOB_WEIGHT'])
     except KeyError:
@@ -437,14 +449,6 @@ def compute_n():
 
     return parallel_level
 
-
-config_map = {'Trilinos_pullrequest_gcc_4.8.4': 'PullRequestLinuxGCC4.8.4TestingSettings.cmake',
-              'Trilinos_pullrequest_intel_17.0.1': 'PullRequestLinuxIntelTestingSettings.cmake',
-              'Trilinos_pullrequest_gcc_4.9.3_SERIAL': 'PullRequestLinuxGCC4.9.3TestingSettingsSERIAL.cmake',
-              'Trilinos_pullrequest_gcc_7.2.0': 'PullRequestLinuxGCC7.2.0TestingSettings.cmake',
-              'Trilinos_pullrequest_cuda_9.2': 'PullRequestLinuxCuda9.2TestingSettings.cmake',
-              'Trilinos_pullrequest_python_2': 'PullRequestLinuxPython2.cmake',
-              'Trilinos_pullrequest_python_3': 'PullRequestLinuxPython3.cmake'}
 
 
 def createPackageEnables(arguments):
@@ -484,7 +488,22 @@ PR_ENABLE_BOOL(Trilinos_ENABLE_''' + enable_map[arguments.job_base_name] + ''' O
         print('There was an issue generating packageEnables.cmake.  '
               'The error code was: {}'.format(cpe.returncode))
 
+    return None
+
+
+
+config_map = {'Trilinos_pullrequest_gcc_4.8.4': 'PullRequestLinuxGCC4.8.4TestingSettings.cmake',
+              'Trilinos_pullrequest_intel_17.0.1': 'PullRequestLinuxIntelTestingSettings.cmake',
+              'Trilinos_pullrequest_gcc_4.9.3_SERIAL': 'PullRequestLinuxGCC4.9.3TestingSettingsSERIAL.cmake',
+              'Trilinos_pullrequest_gcc_7.2.0': 'PullRequestLinuxGCC7.2.0TestingSettings.cmake',
+              'Trilinos_pullrequest_cuda_9.2': 'PullRequestLinuxCuda9.2TestingSettings.cmake',
+              'Trilinos_pullrequest_python_2': 'PullRequestLinuxPython2.cmake',
+              'Trilinos_pullrequest_python_3': 'PullRequestLinuxPython3.cmake'}
+
+
 def run():
+    """
+    """
     return_value = True
     arguments = parse_args()
 

--- a/cmake/std/README.md
+++ b/cmake/std/README.md
@@ -3,3 +3,5 @@ README
 
 - 2018-11-08 - `PullRequestLinuxDriver-old.sh` will be deprecated away once the updates to the new 'split' version of this 
   file are up and running properly.  (@william76)
+
+

--- a/cmake/std/unittests/TestPullRequestLinuxDriverTest.py
+++ b/cmake/std/unittests/TestPullRequestLinuxDriverTest.py
@@ -715,8 +715,7 @@ class testCompute_n(unittest.TestCase):
         we should still  run at least one job'''
         m_open =  mock.mock_open(read_data='''MemTotal 32965846 kB''')
         with self.m_environ, \
-            mock.patch('PullRequestLinuxDriverTest.open',
-                       m_open, create=True), \
+            mock.patch('PullRequestLinuxDriverTest.open', m_open, create=True), \
             mock.patch('PullRequestLinuxDriverTest.cpu_count', return_value=18):
             parallel_level = PullRequestLinuxDriverTest.compute_n()
         self.assertEqual(10, parallel_level)
@@ -725,8 +724,7 @@ class testCompute_n(unittest.TestCase):
         '''check we match whats on 113-115 and the cloud'''
         m_open =  mock.mock_open(read_data='''MemTotal 65805212 kB''')
         with self.m_environ, \
-            mock.patch('PullRequestLinuxDriverTest.open',
-                       m_open, create=True), \
+            mock.patch('PullRequestLinuxDriverTest.open', m_open, create=True), \
             mock.patch('PullRequestLinuxDriverTest.cpu_count', return_value=32):
             parallel_level = PullRequestLinuxDriverTest.compute_n()
         self.assertEqual(20, parallel_level)
@@ -736,8 +734,7 @@ class testCompute_n(unittest.TestCase):
         '''match whats on the 14x series'''
         m_open =  mock.mock_open(read_data='''MemTotal 65805212 kB''')
         with self.m_environ, \
-            mock.patch('PullRequestLinuxDriverTest.open',
-                       m_open, create=True), \
+            mock.patch('PullRequestLinuxDriverTest.open', m_open, create=True), \
             mock.patch('PullRequestLinuxDriverTest.cpu_count', return_value=72):
             parallel_level = PullRequestLinuxDriverTest.compute_n()
         self.assertEqual(10, parallel_level)
@@ -747,8 +744,7 @@ class testCompute_n(unittest.TestCase):
         '''match ascic158'''
         m_open = mock.mock_open(read_data='''MemTotal 131610424 kB''')
         with self.m_environ, \
-             mock.patch('PullRequestLinuxDriverTest.open',
-                        m_open, create=True), \
+             mock.patch('PullRequestLinuxDriverTest.open', m_open, create=True), \
              mock.patch('PullRequestLinuxDriverTest.cpu_count', return_value=88):
             parallel_level = PullRequestLinuxDriverTest.compute_n()
         self.assertEqual(13, parallel_level)
@@ -758,8 +754,7 @@ class testCompute_n(unittest.TestCase):
         '''this matches ascic166'''
         m_open = mock.mock_open(read_data='''MemTotal 131610424 kB''')
         with self.m_environ, \
-             mock.patch('PullRequestLinuxDriverTest.open',
-                        m_open, create=True), \
+             mock.patch('PullRequestLinuxDriverTest.open', m_open, create=True), \
              mock.patch('PullRequestLinuxDriverTest.cpu_count', return_value=80):
             parallel_level = PullRequestLinuxDriverTest.compute_n()
         self.assertEqual(20, parallel_level)
@@ -767,3 +762,5 @@ class testCompute_n(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()  # pragma nocover
+
+

--- a/cmake/std/unittests/TestPullRequestLinuxDriverTest.py
+++ b/cmake/std/unittests/TestPullRequestLinuxDriverTest.py
@@ -73,7 +73,7 @@ class Test_run(unittest.TestCase):
             m_check_out.return_value='git version 1.10.1'
 
             bad_git_string = 'Git version  should be 2.10 or better - Exiting!'
-            if sys.version_info.major is not 3:
+            if(sys.version_info.major != 3):
                 with self.assertRaisesRegexp(SystemExit, bad_git_string):
                     PullRequestLinuxDriverTest.confirmGitVersion()
             else:
@@ -136,7 +136,7 @@ ERROR : Source branch is NOT trilinos/Trilinos::master_merge_YYYYMMDD_HHMMSS
       : This violates Trilinos policy, pull requests into the master branch are restricted.
       : Perhaps you forgot to specify the develop branch as the target in your PR?
 *"""
-            if sys.version_info.major is not 3:
+            if(sys.version_info.major != 3):
                 with self.assertRaisesRegexp(SystemExit, bad_branch_string):
                     PullRequestLinuxDriverTest.run()
             else:
@@ -397,7 +397,7 @@ class Test_setEnviron(unittest.TestCase):
                 self.m_chdir, \
                 self.m_check_out, \
                 self.m_environ:
-            if sys.version_info.major is not 3:
+            if(sys.version_info.major != 3):
                 with self.assertRaisesRegexp(SystemExit, expected_output):
                     PullRequestLinuxDriverTest.setBuildEnviron(self.arguments)
             else:


### PR DESCRIPTION
@trilinos/framework 

This is WIP - I want to see what the Python PR testing shows since I haven't been able to replicate it locally.

Mostly just some style and formatting cleanup to make some things more readable, but I also made a more generic memory information option that tries to use psutil, and if it's not available then we try to load `/proc/meminfo` which would only work on Linux machines.

