### PR TITLE
MueLu: region vector test fix

### DIFF
--- a/packages/muelu/test/unit_tests/RegionVector.cpp
+++ b/packages/muelu/test/unit_tests/RegionVector.cpp
@@ -328,7 +328,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionVector, RegionCompositeVector, Scalar, L
       for (int j = 0; j < maxRegPerProc; j++){
         myScaling = interfaceScaling[j]->getData(0);
         for(size_t idx = 0; idx < interfaceScaling[j]->getLocalLength(); ++idx) {
-          TEST_FLOATING_EQUALITY(myScaling[idx], 1.0, 100*TMT::eps());
+          TEST_FLOATING_EQUALITY(myScaling[idx], TST::one(), 100*TMT::eps());
         }
       }
 


### PR DESCRIPTION
Using 1.0 in TEUCHOS_FLOATING_EQUALITY fails in a std::complex<> build because of template type deduction.


@trilinos/muelu 

## Motivation
MueLu does not compile when both `Experimental` and `Complex` are turned on.
This should fix that specific build.

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 