### PR TITLE
MueLu: cleanup function interfaces in regionMG

### DIFF
--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
@@ -798,8 +798,7 @@ void vCycle(const int l, ///< ID of current level
     tm = Teuchos::null;
     tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("vCycle: 5 - sum interface values")));
 
-    sumInterfaceValues(coarseRegB, compRowMaps[l+1],
-                       quasiRegRowMaps[l+1], regRowMaps[l+1], regRowImporters[l+1]);
+    sumInterfaceValues(coarseRegB, regRowMaps[l+1], regRowImporters[l+1]);
 
     tm = Teuchos::null;
 

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
@@ -720,8 +720,6 @@ void createRegionHierarchy(const int maxRegPerProc,
 template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void vCycle(const int l, ///< ID of current level
             const int numLevels, ///< Total number of levels
-            const int maxCoarseIter, ///< max. sweeps on coarse level
-            const int maxRegPerProc, ///< Max number of regions per process
             Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& fineRegX, ///< solution
             Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > fineRegB, ///< right hand side
             Array<std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > > regMatrices, ///< Matrices in region layout
@@ -740,6 +738,9 @@ void vCycle(const int l, ///< ID of current level
   using Teuchos::TimeMonitor;
   const Scalar SC_ZERO = Teuchos::ScalarTraits<Scalar>::zero();
   const Scalar SC_ONE = Teuchos::ScalarTraits<Scalar>::one();
+
+  // Get max number of regions per process
+  const int maxRegPerProc = fineRegX.size();
 
   if (l < numLevels - 1) { // fine or intermediate levels
 
@@ -803,7 +804,7 @@ void vCycle(const int l, ///< ID of current level
     tm = Teuchos::null;
 
     // Call V-cycle recursively
-    vCycle(l+1, numLevels, maxCoarseIter, maxRegPerProc,
+    vCycle(l+1, numLevels,
            coarseRegX, coarseRegB, regMatrices, regProlong, compRowMaps,
            quasiRegRowMaps, regRowMaps, regRowImporters, regInterfaceScalings,
            smootherParams, coarseCompMat, coarseSolverData, hierarchyData);

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
@@ -660,9 +660,9 @@ void createRegionHierarchy(const int maxRegPerProc,
                               quasiRegRowMaps);
 
   for(int levelIdx = 0; levelIdx < numLevels; ++levelIdx) {
-    smootherSetup(smootherParams[levelIdx], maxRegPerProc, regRowMaps[levelIdx],
+    smootherSetup(smootherParams[levelIdx], regRowMaps[levelIdx],
                   regMatrices[levelIdx], regInterfaceScalings[levelIdx],
-                  compRowMaps[levelIdx], regRowMaps[levelIdx], regRowImporters[levelIdx]);
+                  regRowImporters[levelIdx]);
   }
 
 } // createRegionHierarchy
@@ -760,9 +760,8 @@ void vCycle(const int l, ///< ID of current level
     RCP<TimeMonitor> tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("vCycle: 1 - pre-smoother")));
 
     // pre-smoothing
-    smootherApply(smootherParams[l], maxRegPerProc, fineRegX, fineRegB, regMatrices[l],
-                  regInterfaceScalings[l], compRowMaps[l],
-                  quasiRegRowMaps[l], regRowMaps[l], regRowImporters[l]);
+    smootherApply(smootherParams[l], fineRegX, fineRegB, regMatrices[l],
+                  regRowMaps[l], regRowImporters[l]);
 
     tm = Teuchos::null;
     tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("vCycle: 2 - compute residual")));
@@ -834,9 +833,8 @@ void vCycle(const int l, ///< ID of current level
     tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("vCycle: 8 - post-smoother")));
 
     // post-smoothing
-    smootherApply(smootherParams[l], maxRegPerProc, fineRegX, fineRegB, regMatrices[l],
-                  regInterfaceScalings[l], compRowMaps[l],
-                  quasiRegRowMaps[l], regRowMaps[l], regRowImporters[l]);
+    smootherApply(smootherParams[l], fineRegX, fineRegB, regMatrices[l],
+                  regRowMaps[l], regRowImporters[l]);
 
     tm = Teuchos::null;
 
@@ -851,9 +849,8 @@ void vCycle(const int l, ///< ID of current level
 
     const std::string coarseSolverType = coarseSolverData->get<std::string>("coarse solver type");
     if (coarseSolverType == "smoother") {
-      smootherApply(smootherParams[l], maxRegPerProc, fineRegX, fineRegB, regMatrices[l],
-                  regInterfaceScalings[l], compRowMaps[l],
-                  quasiRegRowMaps[l], regRowMaps[l], regRowImporters[l]);
+      smootherApply(smootherParams[l], fineRegX, fineRegB, regMatrices[l],
+                  regRowMaps[l], regRowImporters[l]);
     }
     else {
       // First get the Xpetra vectors from region to composite format

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
@@ -436,7 +436,7 @@ void MakeInterfaceScalingFactors(const int maxRegPerProc,
 
     // transform to composite layout while adding interface values via the Export() combine mode
     RCP<Vector> compInterfaceScalingSum = VectorFactory::Build(compRowMaps[l], true);
-    regionalToComposite(regInterfaceScalings[l], compInterfaceScalingSum, regRowImporters[l], Xpetra::ADD);
+    regionalToComposite(regInterfaceScalings[l], compInterfaceScalingSum, regRowImporters[l]);
 
     /* transform composite layout back to regional layout. Now, GIDs associated
      * with region interface should carry a scaling factor (!= 1).
@@ -866,8 +866,7 @@ void vCycle(const int l, ///< ID of current level
           fineRegB[j]->elementWiseMultiply(SC_ONE, *fineRegB[j], *inverseInterfaceScaling, SC_ZERO);
         }
 
-        regionalToComposite(fineRegB, compRhs,
-                            regRowImporters[l], Xpetra::ADD);
+        regionalToComposite(fineRegB, compRhs, regRowImporters[l]);
       }
 
       if (coarseSolverType == "direct")

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
@@ -603,8 +603,8 @@ void createRegionHierarchy(const int maxRegPerProc,
     levelName += std::to_string(l);
     ParameterList& levelList = hierarchyData->sublist(levelName, false, "list of data on current level");
     Teuchos::Array<RCP<Vector> > regRes(maxRegPerProc), regSol(maxRegPerProc);
-    createRegionalVector(regRes, maxRegPerProc, revisedRowMapPerGrp);
-    createRegionalVector(regSol, maxRegPerProc, revisedRowMapPerGrp);
+    createRegionalVector(regRes, revisedRowMapPerGrp);
+    createRegionalVector(regSol, revisedRowMapPerGrp);
     levelList.set<Teuchos::Array<RCP<Vector> > >("residual", regRes, "Cached residual vector");
     levelList.set<Teuchos::Array<RCP<Vector> > >("solution", regSol, "Cached solution vector");
   }
@@ -771,7 +771,7 @@ void vCycle(const int l, ///< ID of current level
     if(useCachedVectors) {
       regRes = levelList.get<Teuchos::Array<RCP<Vector> > >("residual");
     } else {
-      createRegionalVector(regRes, maxRegPerProc, regRowMaps[l]);
+      createRegionalVector(regRes, regRowMaps[l]);
     }
     computeResidual(regRes, fineRegX, fineRegB, regMatrices[l], compRowMaps[l],
                     quasiRegRowMaps[l], regRowMaps[l], regRowImporters[l]);

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
@@ -773,8 +773,8 @@ void vCycle(const int l, ///< ID of current level
     } else {
       createRegionalVector(regRes, regRowMaps[l]);
     }
-    computeResidual(regRes, fineRegX, fineRegB, regMatrices[l], compRowMaps[l],
-                    quasiRegRowMaps[l], regRowMaps[l], regRowImporters[l]);
+    computeResidual(regRes, fineRegX, fineRegB, regMatrices[l],
+                    regRowMaps[l], regRowImporters[l]);
 
     tm = Teuchos::null;
     tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("vCycle: 3 - scale interface")));

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionMatrix_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionMatrix_def.hpp
@@ -737,8 +737,6 @@ computeResidual(Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, No
                 const Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regX, ///< left-hand side (solution)
                 const Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regB, ///< right-hand side (forcing term)
                 const std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regionGrpMats,
-                const RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > mapComp, ///< composite map, computed by removing GIDs > numDofs in revisedRowMapPerGrp
-                const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > rowMapPerGrp, ///< row maps in region layout [in] requires the mapping of GIDs on fine mesh to "filter GIDs"
                 const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > revisedRowMapPerGrp, ///< revised row maps in region layout [in] (actually extracted from regionGrpMats)
                 const std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > rowImportPerGrp ///< row importer in region layout [in]
     )

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionMatrix_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionMatrix_def.hpp
@@ -548,8 +548,8 @@ void MakeRegionMatrices(const RCP<Xpetra::CrsMatrixWrap<Scalar, LocalOrdinal, Gl
 
     // move to regional layout
     Array<RCP<Vector> > quasiRegNspViolation(maxRegPerProc);
-    createRegionalVector(quasiRegNspViolation, maxRegPerProc, rowMapPerGrp);
-    createRegionalVector(regNspViolation, maxRegPerProc, revisedRowMapPerGrp);
+    createRegionalVector(quasiRegNspViolation, rowMapPerGrp);
+    createRegionalVector(regNspViolation, revisedRowMapPerGrp);
     compositeToRegional(nspViolation, quasiRegNspViolation, regNspViolation,
                         revisedRowMapPerGrp, rowImportPerGrp);
 

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionMatrix_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionMatrix_def.hpp
@@ -764,8 +764,7 @@ computeResidual(Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, No
   tm = Teuchos::null;
   tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("computeResidual: 2 - sumInterfaceValues")));
 
-  sumInterfaceValues(regRes, mapComp, rowMapPerGrp,
-                     revisedRowMapPerGrp, rowImportPerGrp);
+  sumInterfaceValues(regRes, revisedRowMapPerGrp, rowImportPerGrp);
 
   tm = Teuchos::null;
   tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("computeResidual: 3 - Rreg = Breg - Rreg")));

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionMatrix_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionMatrix_def.hpp
@@ -571,8 +571,7 @@ void MakeRegionMatrices(const RCP<Xpetra::CrsMatrixWrap<Scalar, LocalOrdinal, Gl
 
       // transform to composite layout while adding interface values via the Export() combine mode
       RCP<Vector> compInterfaceScalingSum = VectorFactory::Build(mapComp, true);
-      regionalToComposite(interfaceScaling, compInterfaceScalingSum,
-                          rowImportPerGrp, Xpetra::ADD);
+      regionalToComposite(interfaceScaling, compInterfaceScalingSum, rowImportPerGrp);
 
       /* transform composite layout back to regional layout. Now, GIDs associated
        * with region interface should carry a scaling factor (!= 1).

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionSmoothers_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionSmoothers_def.hpp
@@ -103,12 +103,12 @@ void relaxationSmootherSetup(RCP<Teuchos::ParameterList> params,
 {
 #include "Xpetra_UseShortNames.hpp"
   Array<RCP<Vector> > regRes(maxRegPerProc);
-  createRegionalVector(regRes, maxRegPerProc, revisedRowMapPerGrp);
+  createRegionalVector(regRes, revisedRowMapPerGrp);
 
   // extract diagonal from region matrices, recover true diagonal values, invert diagonal
 
   Array<RCP<Vector> > diagReg(maxRegPerProc);
-  createRegionalVector(diagReg, maxRegPerProc, revisedRowMapPerGrp);
+  createRegionalVector(diagReg, revisedRowMapPerGrp);
 
   for (int j = 0; j < maxRegPerProc; j++) {
     // extract inverse of diagonal from matrix
@@ -152,7 +152,7 @@ void jacobiIterate(RCP<Teuchos::ParameterList> smootherParams,
   Array<RCP<Vector> > diag_inv = smootherParams->get<Array<RCP<Vector> > >("relaxation smoothers: inverse diagonal");
 
   Array<RCP<Vector> > regRes(maxRegPerProc);
-  createRegionalVector(regRes, maxRegPerProc, revisedRowMapPerGrp);
+  createRegionalVector(regRes, revisedRowMapPerGrp);
 
 
   for (int iter = 0; iter < maxIter; ++iter) {
@@ -198,7 +198,7 @@ void GSIterate(RCP<Teuchos::ParameterList> smootherParams,
 
 
   Array<RCP<Vector> > regRes(maxRegPerProc);
-  createRegionalVector(regRes, maxRegPerProc, revisedRowMapPerGrp);
+  createRegionalVector(regRes, revisedRowMapPerGrp);
 
   for (int iter = 0; iter < maxIter; ++iter) {
 
@@ -297,9 +297,9 @@ powerMethod(RCP<Teuchos::ParameterList> params,
   SC RQ_top, RQ_bottom, norm;
 
   Array<RCP<Vector> > regX(maxRegPerProc);
-  createRegionalVector(regX, maxRegPerProc, revisedRowMapPerGrp);
+  createRegionalVector(regX, revisedRowMapPerGrp);
   Array<RCP<Vector> > regY(maxRegPerProc);
-  createRegionalVector(regY, maxRegPerProc, revisedRowMapPerGrp);
+  createRegionalVector(regY, revisedRowMapPerGrp);
 
   for( int j = 0; j < maxRegPerProc; j++){
     regX[j]->randomize();
@@ -355,7 +355,7 @@ void chebyshevSetup(RCP<Teuchos::ParameterList> params,
   const Scalar SC_ONE  = Teuchos::ScalarTraits<Scalar>::one();
 
   Array<RCP<Vector> > regRes(maxRegPerProc);
-  createRegionalVector(regRes, maxRegPerProc, revisedRowMapPerGrp);
+  createRegionalVector(regRes, revisedRowMapPerGrp);
 
   // extract diagonal from region matrices, recover true diagonal values, invert diagonal
   Teuchos::Array<RCP<Vector> > diag(maxRegPerProc);
@@ -415,12 +415,12 @@ void chebyshevIterate ( RCP<Teuchos::ParameterList> params,
   const Scalar c = (lambdaMax - lambdaMin) / SC_TWO;// Ifpack2 calls this 1/delta
 
   Array<RCP<Vector> > regRes(maxRegPerProc);
-  createRegionalVector(regRes, maxRegPerProc, revisedRowMapPerGrp);
+  createRegionalVector(regRes, revisedRowMapPerGrp);
 
   Array<RCP<Vector> > regP(maxRegPerProc);
-  createRegionalVector(regP, maxRegPerProc, revisedRowMapPerGrp);
+  createRegionalVector(regP, revisedRowMapPerGrp);
   Array<RCP<Vector> > regZ(maxRegPerProc);
-  createRegionalVector(regZ, maxRegPerProc, revisedRowMapPerGrp);
+  createRegionalVector(regZ, revisedRowMapPerGrp);
 
   Scalar alpha, beta;
 

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionSmoothers_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionSmoothers_def.hpp
@@ -250,7 +250,7 @@ calcNorm2(Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > 
 {
 #include "Xpetra_UseShortNames.hpp"
   RCP<Vector> compVec = VectorFactory::Build(mapComp, true);
-  regionalToComposite(regVec, compVec, rowImportPerGrp, Xpetra::ADD);
+  regionalToComposite(regVec, compVec, rowImportPerGrp);
   typename Teuchos::ScalarTraits<Scalar>::magnitudeType norm = compVec->norm2();
 
   return norm;
@@ -269,8 +269,8 @@ dotProd(Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >&
 #include "Xpetra_UseShortNames.hpp"
   RCP<Vector> compX = VectorFactory::Build(mapComp, true);
   RCP<Vector> compY = VectorFactory::Build(mapComp, true);
-  regionalToComposite(regX, compX, rowImportPerGrp, Xpetra::ADD);
-  regionalToComposite(regY, compY, rowImportPerGrp, Xpetra::ADD);
+  regionalToComposite(regX, compX, rowImportPerGrp);
+  regionalToComposite(regY, compY, rowImportPerGrp);
   SC dotVal = compX->dot(*compY);
 
   return dotVal;

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionSmoothers_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionSmoothers_def.hpp
@@ -116,8 +116,7 @@ void relaxationSmootherSetup(RCP<Teuchos::ParameterList> params,
     regionGrpMats[j]->getLocalDiagCopy(*diagReg[j]);
   }
 
-  sumInterfaceValues(diagReg, mapComp, rowMapPerGrp,
-                     revisedRowMapPerGrp, rowImportPerGrp);
+  sumInterfaceValues(diagReg, revisedRowMapPerGrp, rowImportPerGrp);
 
   for (int j = 0; j < maxRegPerProc; j++) {
     diagReg[j]->reciprocal(*diagReg[j]);
@@ -315,7 +314,7 @@ powerMethod(RCP<Teuchos::ParameterList> params,
     for (int j = 0; j < maxRegPerProc; j++) { // step 1
       regionGrpMats[j]->apply(*regX[j], *regY[j]); // A.apply (x, y);
     }
-    sumInterfaceValues( regY, mapComp, rowMapPerGrp, revisedRowMapPerGrp, rowImportPerGrp); // step 2
+    sumInterfaceValues(regY, revisedRowMapPerGrp, rowImportPerGrp); // step 2
 
     // Scale by inverse of diagonal
     for (int j = 0; j < maxRegPerProc; j++){

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionSmoothers_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionSmoothers_def.hpp
@@ -162,7 +162,7 @@ void jacobiIterate(RCP<Teuchos::ParameterList> smootherParams,
      * 2. Sum interface values in tmp due to duplication (We fake this by scaling to reverse the basic splitting)
      * 3. Compute r = B - tmp
      */
-    computeResidual( regRes, regX, regB, regionGrpMats, mapComp, rowMapPerGrp, revisedRowMapPerGrp, rowImportPerGrp );
+    computeResidual(regRes, regX, regB, regionGrpMats, revisedRowMapPerGrp, rowImportPerGrp );
 
     // update solution according to Jacobi's method
     for (int j = 0; j < maxRegPerProc; j++) {
@@ -207,7 +207,7 @@ void GSIterate(RCP<Teuchos::ParameterList> smootherParams,
      * 2. Sum interface values in tmp due to duplication (We fake this by scaling to reverse the basic splitting)
      * 3. Compute r = B - tmp
      */
-    computeResidual( regRes, regX, regB, regionGrpMats, mapComp, rowMapPerGrp, revisedRowMapPerGrp, rowImportPerGrp );
+    computeResidual(regRes, regX, regB, regionGrpMats, revisedRowMapPerGrp, rowImportPerGrp );
 
     // update the solution and the residual
 
@@ -426,7 +426,7 @@ void chebyshevIterate ( RCP<Teuchos::ParameterList> params,
 
   for (int i = 0; i < maxIter; ++i) {
     // Compute residual vector
-    computeResidual( regRes, regX, regB, regionGrpMats, mapComp, rowMapPerGrp, revisedRowMapPerGrp, rowImportPerGrp );
+    computeResidual(regRes, regX, regB, regionGrpMats, revisedRowMapPerGrp, rowImportPerGrp );
 
     //solve (Z, D_inv, R); // z = D_inv * R, that is, D \ R.
     for(int j = 0; j < maxRegPerProc; j++) {

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionVector_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionVector_def.hpp
@@ -69,11 +69,14 @@ using Teuchos::Array;
 //! Create an empty vector in the regional layout
 template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void createRegionalVector(Teuchos::Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regVecs, ///< regional vector to be filled
-                          const int maxRegPerProc, ///< max number of regions per process
                           const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > revisedRowMapPerGrp ///< regional map
                           )
 {
 #include "Xpetra_UseShortNames.hpp"
+
+  // Get max number of regions per process
+  const int maxRegPerProc = revisedRowMapPerGrp.size();
+
   regVecs.resize(maxRegPerProc);
   for (int j = 0; j < maxRegPerProc; j++)
     regVecs[j] = VectorFactory::Build(revisedRowMapPerGrp[j], true);

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionVector_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionVector_def.hpp
@@ -197,8 +197,6 @@ void regionalToComposite(const Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, Gl
  */
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void sumInterfaceValues(Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regVec,
-                        const RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > compMap,
-                        const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > rowMapPerGrp,///< row maps in region layout [in]
                         const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > revisedRowMapPerGrp,///< revised row maps in region layout [in]
                         const std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > rowImportPerGrp ///< row importer in region layout [in])
                         )
@@ -208,6 +206,9 @@ void sumInterfaceValues(Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrd
 
   // Get max number of regions per proc
   const int maxRegPerProc = regVec.size();
+
+  // Composite map is the same in every group, so just take the first one.
+  const RCP<const Map> compMap = rowImportPerGrp[0]->getSourceMap();
 
   RCP<Vector> compVec = VectorFactory::Build(compMap, true);
   TEUCHOS_ASSERT(!compVec.is_null());

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionVector_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionVector_def.hpp
@@ -123,7 +123,7 @@ void compositeToRegional(RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal,
  *
  *  Starting from a \c Epetra_Vector in regional layout, we
  *  1. replace the regional map with the quasiRegional map
- *  2. export it into a vector with composite layout using the \c CombineMode \c Add.
+ *  2. export it into a vector with composite layout using the \c CombineMode \c Xpetra::ADD.
  *     Note: on-process values also have to be added to account for region interfaces inside a process.
  *
  *  \note We also need the capability to add processor-local values. This is not supported by
@@ -132,8 +132,7 @@ void compositeToRegional(RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal,
 template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void regionalToComposite(const Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regVec, ///< Vector in region layout [in]
                          RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > compVec, ///< Vector in composite layout [in/out]
-                         const std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > rowImportPerGrp, ///< row importer in region layout [in]
-                         const Xpetra::CombineMode combineMode ///< Combine mode for import/export [in]
+                         const std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > rowImportPerGrp ///< row importer in region layout [in]
                          )
 {
   /* Let's fake an ADD combine mode that also adds local values by
@@ -169,7 +168,6 @@ void regionalToComposite(const Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, Gl
       RCP<Vector> partialCompVec = VectorFactory::Build(rowImportPerGrp[0]->getSourceMap(), true);
       TEUCHOS_ASSERT(Teuchos::nonnull(partialCompVec));
       TEUCHOS_ASSERT(partialCompVec->getLocalLength() == compVecLocalLength);
-      // ToDo (mayr.mt) Use input variable 'combineMode'
       partialCompVec->doExport(*quasiRegVec, *(rowImportPerGrp[grpIdx]), Xpetra::ADD);
 
       tm = Teuchos::null;
@@ -214,8 +212,7 @@ void sumInterfaceValues(Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrd
   TEUCHOS_ASSERT(!compVec.is_null());
 
   RCP<TimeMonitor> tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("sumInterfaceValues: 1 - regionalToComposite")));
-  regionalToComposite(regVec, compVec,
-                      rowImportPerGrp, Xpetra::ADD);
+  regionalToComposite(regVec, compVec, rowImportPerGrp);
 
   tm = Teuchos::null;
   tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("sumInterfaceValues: 2 - compositeToRegional")));

--- a/packages/muelu/research/mmayr/composite_to_regions/src/main.cpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/main.cpp
@@ -915,8 +915,7 @@ int main_(int argc, char *argv[]) {
 //        printRegionalObject<Vector>("regB 1", regB, myRank, *fos);
 
         compRes = VectorFactory::Build(mapComp, true);
-        regionalToComposite(regRes, compRes,
-                            rowImportPerGrp, Xpetra::ADD);
+        regionalToComposite(regRes, compRes, rowImportPerGrp);
         typename Teuchos::ScalarTraits<Scalar>::magnitudeType normRes = compRes->norm2();
 
         // Output current residual norm to screen (on proc 0 only)
@@ -953,7 +952,7 @@ int main_(int argc, char *argv[]) {
     sleep(1);
 
     // ToDo (mayr.mt) Is this the right CombineMode?
-    regionalToComposite(regX, compX, rowMapPerGrp, rowImportPerGrp, Xpetra::INSERT);
+    regionalToComposite(regX, compX, rowImportPerGrp);
 
     std::cout << myRank << " | compX after V-cycle" << std::endl;
     sleep(1);

--- a/packages/muelu/research/mmayr/composite_to_regions/src/main.cpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/main.cpp
@@ -934,7 +934,7 @@ int main_(int argc, char *argv[]) {
       /////////////////////////////////////////////////////////////////////////
 
 //      printRegionalObject<Vector>("regB 2", regB, myRank, *fos);
-      vCycle(0, numLevels, maxCoarseIter, maxRegPerProc,
+      vCycle(0, numLevels,
              regX, regB, regMatrices,
              regProlong, compRowMaps, quasiRegRowMaps, regRowMaps, regRowImporters,
              regInterfaceScalings, smootherParams, coarseCompOp);

--- a/packages/muelu/research/mmayr/composite_to_regions/src/main.cpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/main.cpp
@@ -909,8 +909,8 @@ int main_(int argc, char *argv[]) {
         // SWITCH BACK TO NON-LEVEL VARIABLES
         ////////////////////////////////////////////////////////////////////////
 
-        computeResidual(regRes, regX, regB, regionGrpMats, mapComp,
-                        rowMapPerGrp, revisedRowMapPerGrp, rowImportPerGrp);
+        computeResidual(regRes, regX, regB, regionGrpMats,
+            revisedRowMapPerGrp, rowImportPerGrp);
 
 //        printRegionalObject<Vector>("regB 1", regB, myRank, *fos);
 

--- a/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
+++ b/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
@@ -814,8 +814,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
         }
 
         compRes = VectorFactory::Build(dofMap, true);
-        regionalToComposite(regRes, compRes,
-                            rowImportPerGrp, Xpetra::ADD);
+        regionalToComposite(regRes, compRes, rowImportPerGrp);
 
         typename Teuchos::ScalarTraits<Scalar>::magnitudeType normRes = compRes->norm2();
         if(cycle == 0) { normResIni = normRes; }

--- a/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
+++ b/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
@@ -838,7 +838,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
         /////////////////////////////////////////////////////////////////////////
 
         //      printRegionalObject<Vector>("regB 2", regB, myRank, *fos);
-        vCycle(0, numLevels, maxCoarseIter, maxRegPerProc,
+        vCycle(0, numLevels,
                regX, regB, regMatrices,
                regProlong, compRowMaps, quasiRegRowMaps, regRowMaps, regRowImporters,
                regInterfaceScalings, smootherParams, coarseCompOp, coarseSolverData, hierarchyData);

--- a/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
+++ b/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
@@ -807,8 +807,8 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
         // SWITCH BACK TO NON-LEVEL VARIABLES
         ////////////////////////////////////////////////////////////////////////
         {
-          computeResidual(regRes, regX, regB, regionGrpMats, dofMap,
-              rowMapPerGrp, revisedRowMapPerGrp, rowImportPerGrp);
+          computeResidual(regRes, regX, regB, regionGrpMats,
+              revisedRowMapPerGrp, rowImportPerGrp);
 
           scaleInterfaceDOFs(regRes, regInterfaceScalings[0], true);
         }

--- a/packages/muelu/test/unit_tests/RegionMatrix.cpp
+++ b/packages/muelu/test/unit_tests/RegionMatrix.cpp
@@ -237,9 +237,7 @@ void test_matrix(const int maxRegPerProc,
   // to composite format so it can be compared
   // with the original composite B vector.
   RCP<Vector> compB = VectorFactory::Build(A->getRowMap());
-  regionalToComposite(regB, compB,
-                      rowImportPerGrp,
-                      Xpetra::ADD);
+  regionalToComposite(regB, compB, rowImportPerGrp);
 
   // Extract the data from B and compB to compare it
   ArrayRCP<const SC> dataB     = B->getData(0);
@@ -663,9 +661,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, MatVec, Scalar, LocalOrdinal, Gl
   // Now create composite B using region B so we can compare
   // composite B with the original B
   RCP<Vector> compB = VectorFactory::Build(dofMap);
-  regionalToComposite(regB, compB,
-                      rowImportPerGrp,
-                      Xpetra::ADD);
+  regionalToComposite(regB, compB, rowImportPerGrp);
 
   // Extract the data from B and compB to compare it
   ArrayRCP<const SC> dataB     = B->getData(0);

--- a/packages/muelu/test/unit_tests/RegionVector.cpp
+++ b/packages/muelu/test/unit_tests/RegionVector.cpp
@@ -240,7 +240,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionVector, RegionCompositeVector, Scalar, L
     // Create a composite vector
     RCP<Vector> compVec = VectorFactory::Build(dofMap, true);
 
-    regionalToComposite(regVec, compVec, rowImportPerGrp, Xpetra::ADD);
+    regionalToComposite(regVec, compVec, rowImportPerGrp);
 
     if(numRanks == 1) {
       TEST_EQUALITY(compVec->getLocalLength(),  25);
@@ -308,8 +308,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionVector, RegionCompositeVector, Scalar, L
 
     // transform to composite layout while adding interface values via the Export() combine mode
     RCP<Vector> compInterfaceScalingSum = VectorFactory::Build(dofMap, true);
-    regionalToComposite(interfaceScaling, compInterfaceScalingSum,
-                        rowImportPerGrp, Xpetra::ADD);
+    regionalToComposite(interfaceScaling, compInterfaceScalingSum, rowImportPerGrp);
 
     /* transform composite layout back to regional layout. Now, GIDs associated
      * with region interface should carry a scaling factor (!= 1).


### PR DESCRIPTION
@trilinos/muelu 
@lucbv 

## Motivation

First cut at cleaning up function interfaces. In particular, this PR removes function arguments
- that haven't been used anyway.
- that are kind of redundant, because their content can be easily extracted from other arguments.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback

This is experimental code. No applications use it right now.

## Testing

The set of regionMG tests runs and passes.

## Additional Information

For sure, there's more to do. In particular, we could/should think about getting rid of the concept of "groups"...
