### PR TITLE
Update cdash_analyze_and_report.py and gitdist-setup.sh

### DIFF
--- a/cmake/tribits/ci_support/CDashQueryAnalyzeReport.py
+++ b/cmake/tribits/ci_support/CDashQueryAnalyzeReport.py
@@ -57,6 +57,24 @@ from GeneralScriptSupport import *
 
 import cdash_build_testing_date as CBTD
 
+
+# Accept the --date input option with values 'today', 'yesterday', or some
+# 'YYYY-MM-DD' value.
+#
+def convertInputDateArgToYYYYMMDD(cdashProjectTestingDayStartTime, dateText,
+  currentDateTimeStr=None,  # Used for unit testing only
+  ):
+  if dateText == "yesterday" or dateText == "today":
+    if dateText == "yesterday": dayIncr = -1
+    else: dayIncr = 0
+    dateTime = CBTD.getRelativeCDashBuildStartTimeFromCmndLineArgs(
+      currentDateTimeStr, cdashProjectTestingDayStartTime, dayIncr)
+    rtnDate = CBTD.getDateOnlyFromDateTime(dateTime)
+  else:
+    rtnDate = validateAndConvertYYYYMMDD(dateText)
+  return rtnDate
+
+
 # Validate a date YYYY-MM-DD string and return a date object for the
 # 'datetime' module.
 # 

--- a/cmake/tribits/ci_support/cdash_build_testing_date.py
+++ b/cmake/tribits/ci_support/cdash_build_testing_date.py
@@ -74,8 +74,8 @@ def injectCmndLineOptionsInParser(clp, gitoliteRootDefault=""):
   
   clp.add_option(
     "--cdash-project-start-time", dest="cdashProjectStartTimeUtcStr", type="string", default="",
-    help="Starting time for the CDash testing day in 'HH:MM' in UTC."\
-      + " Check the CDash project settings for the testing date." )
+    help="Starting time for the CDash testing day in 'hh:mmm' in UTC."\
+      + " Check the CDash project settings for the testing day start time." )
   
   clp.add_option(
     "--day-incr", dest="dayIncrInt", type="int", default="0",
@@ -175,6 +175,12 @@ def getDateStrFromDateTime(dateTime):
   return dateTime.strftime("%Y-%m-%d")
 
 
+# Return the datetime object for just <YYYY>-<MM>-<DD> for an input datetime
+# object.
+def getDateOnlyFromDateTime(dateTime):
+  return datetime.datetime(year=dateTime.year, month=dateTime.month, day=dateTime.day)
+
+
 # Compute the CDash testing day for a given build using its 'buildstarttime'
 # field and the testing day start time and return it as a datetime object.
 #
@@ -253,8 +259,11 @@ def getTestingDayDateFromBuildStartTimeStr(
 # then the relative CDash build date time would be 2018-01-22:00:10 UTC and
 # the testing day would be 2018-01-22.
 #
-# To extract the "<YYYY>-<MM>-<DD>" string, use the function
-# getDateStrFromDateTime().
+# To extract just the year, month and day from the returned datetime object as
+# a datetime object, use the function getDateOnlyFromDateTime().
+#
+# To extract the "<YYYY>-<MM>-<DD>" string from teh returned datetime object,
+# use the function getDateStrFromDateTime().
 # 
 def getRelativeCDashBuildStartTime(
   cdashBuildStartTimeUtc,   # CDash build start time in UTC (datetime objet)
@@ -272,8 +281,24 @@ def getRelativeCDashBuildStartTime(
 # This function just converts the input command-line args and then calls
 # getRelativeCDashBuildStartTime().
 #
+# Arguments:
+#
+# cdashBuildStartTimeStr [in] Reference build start time in
+# "YYY-MM-DDThh:mm:ss TZ".  If 'None', then is taken from
+# getCurrentDateTimeUtc().
+#
+# cdashProjectStartTimeUtcStr [in] CDash project build start time in
+# UTC in the format "hh:mm".
+#
+# dayIncrInt [in] Integer for the day to return relative to
+# cdashProjectStartTimeUtcStr.  The current testing day would be 0.  Yesterday
+# would be -1 and so on.
+#
+# debugLevel [in] If 0, then no debugging.  If > 0, then debug output will be
+# printed.
+#
 def getRelativeCDashBuildStartTimeFromCmndLineArgs(
-  cdashBuildStartTimeStr,  # If 'None', then is taken from getCurrentDateTimeUtc()
+  cdashBuildStartTimeStr,
   cdashProjectStartTimeUtcStr,
   dayIncrInt,
   debugLevel=0,

--- a/cmake/tribits/python_utils/gitdist-setup.sh
+++ b/cmake/tribits/python_utils/gitdist-setup.sh
@@ -1,3 +1,20 @@
+# Assert this script is sourced, not run!
+called=$_
+if [ "$called" == "$0" ] ; then
+  echo "This script '$0' is being called.  Instead, it must be sourced!"
+  exit 1
+fi
+
+# Get the base dir for the sourced script
+SCRIPT_DIR=`echo $BASH_SOURCE | sed "s/\(.*\)\/.*\.sh/\1/g"`
+#echo "SCRIPT_DIR = '$SCRIPT_DIR'"
+
+existing_gitdist=`which gitdist 2> /dev/null`
+if [[ "${existing_gitdist}" == "" ]] ; then
+  echo "Setting alias gitdist=${SCRIPT_DIR}/gitdist"
+  alias gitdist=${SCRIPT_DIR}/gitdist
+fi
+
 # Source this with bash to load useful env for using gitdist
 alias gitdist-status="gitdist dist-repo-status"
 alias gitdist-mod="gitdist --dist-mod-only"

--- a/cmake/tribits/python_utils/gitdist.py
+++ b/cmake/tribits/python_utils/gitdist.py
@@ -189,8 +189,27 @@ repoSelectionAndSetupHelp = r"""
 REPO SELECTION AND SETUP:
 
 Before using the gitdist tool, one must first add the gitdist script to one's
-default path.  This can be done, for example, by copying the gitdist script to
-one's ~/bin/ directory:
+default path.  On bash, the simplest way to do this is to source the
+gitdist-setup.py script:
+
+  $ source <some-base-dir>/TriBITS/tribits/python_utils/gitdist-setup.sh
+
+This will set an alias to the gitdist script in that same directory by
+default, will set up useful alias 'gitdist-status', 'gitdist-mod', and
+'gitdist-mod-status', and 'gitdist-repo-versions', and will set up
+command-line completion just like for raw git (assuming that
+git-completion.bash has been sourced first).  The files 'gitdist' and
+'gitdist-setup.sh' can also be copied to another directory (e.g. ~/bin) and
+then 'gitdist-setup.sh' can be sourced from there (as a simple "install"):
+
+  $ cp <some-base-dir>/TriBITS/tribits/python_utils/gitdist \
+       <some-base-dir>/TriBITS/tribits/python_utils/gitdist-setup.sh \
+      ~/bin/
+  $ source ~/bin/gitdist-setup.sh
+  $ export PATH=$HOME/bin:$PATH
+
+This script can also be set up manually, for example, by copying the gitdist
+script to one's ~/bin/ directory:
 
   $ cp <some-base-dir>/TriBITS/tribits/python_utils/gitdist ~/bin/
   $ chmod a+x ~/bin/gitdist
@@ -201,7 +220,7 @@ and then adding $HOME/bin to one's 'PATH' env var with:
 
 (i.e. in one's ~/.bash_profile file).  Then, one will want to set up some
 useful shell aliases like 'gitdist-status', 'gitdist-mod', and
-'gitdist-mod-status' (see --dist-help=aliases).
+'gitdist-mod-status' and 'gitdist-repo-versions' (see --dist-help=aliases).
 
 The set of git repos processed by gitdist is determined by the argument:
 
@@ -380,13 +399,11 @@ example):
   $ gitdist --dist-no-color log -1 --pretty=format:"%h [%ad] <%ae>%n%s" \
     | grep -v "^$" &> RepoVersion.txt
 
-or two lines per repo using (for example):
+(which is defined as the alias 'gitdist-repo-versions' in the file
+'gitdist-setup.sh') or two lines per repo using (for example):
 
   $ gitdist --dist-no-color log -1 --pretty=format:"%h [%ad] <%ae>" \
     | grep -v "^$" &> RepoVersion.txt
-
-(See the alias 'gitdist-repo-versions' defined in the file
-'gitdist-setup.sh'.)
 
 This allows checking out consistent versions of the set git repos, diffing two
 consistent versions of the set of git repos, etc.


### PR DESCRIPTION
The main update from this snapshot is the updated gitdist-setup.sh script that automatically sets and alias to the gitdist file in the same directory.  Makes it super easy to get setup to use gitidst (just a single  source command).  This brings this into Trilinos.

The update to cdash_analyze_and_report.py is to support `--date=today` and `--date=yesterday` which are the most common use cases.


