### PR TITLE
MueLu: fix some compiler warnings in experimental code

### DIFF
--- a/packages/muelu/research/mmayr/composite_to_regions/src/main.cpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/main.cpp
@@ -888,7 +888,6 @@ int main_(int argc, char *argv[]) {
 
     // define max iteration counts
     const int maxVCycle = 200;
-    const int maxCoarseIter = 100;
 
     // Prepare output of residual norm to file
     RCP<std::ofstream> log;

--- a/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
+++ b/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
@@ -771,9 +771,6 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
     // SWITCH TO RECURSIVE STYLE --> USE LEVEL CONTAINER VARIABLES
     /////////////////////////////////////////////////////////////////////////
 
-    // define max iteration counts
-    const int maxCoarseIter = 100;
-
     // Prepare output of residual norm to file
     RCP<std::ofstream> log;
     if (myRank == 0)
@@ -795,7 +792,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
     }
 
     // Richardson iterations
-    typename Teuchos::ScalarTraits<Scalar>::magnitudeType normResIni;
+    typename Teuchos::ScalarTraits<Scalar>::magnitudeType normResIni = Teuchos::ScalarTraits<Scalar>::zero();
     const int old_precision = std::cout.precision();
     std::cout << std::setprecision(8) << std::scientific;
     int cycle = 0;


### PR DESCRIPTION
@trilinos/muelu 

## Motivation

Review of #6376 brought up some possible compiler warnings in experimental code. So far, they don't cause trouble in PR testing, as they are guarded by `EXPERIMENTAL` flags. Still, let's fix this just to be safe.

## Related Issues

* Follows comments in PR #6376


## Stakeholder Feedback

This is experimental code, so there's no external app.

## Testing

Unit tests pass.