### PR TITLE
Stokhos,Belos,Tpetra: Fix #6354 (part 2)

### DIFF
--- a/packages/belos/tpetra/src/BelosMultiVecTraits_Tpetra.hpp
+++ b/packages/belos/tpetra/src/BelosMultiVecTraits_Tpetra.hpp
@@ -34,8 +34,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
-//
 // ************************************************************************
 //@HEADER
 

--- a/packages/stokhos/src/sacado/kokkos/pce/tpetra/Tpetra_TsqrAdaptor_UQ_PCE.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/tpetra/Tpetra_TsqrAdaptor_UQ_PCE.hpp
@@ -294,16 +294,16 @@ namespace Tpetra {
       }
     }
 
-    /// \brief Finish intranode TSQR initialization.
+    /// \brief Finish intraprocess TSQR initialization.
     ///
     /// \note It's OK to call this method more than once; it is idempotent.
     void
     prepareNodeTsqr (const MV& mv)
     {
-      node_tsqr_factory_type::prepareNodeTsqr (nodeTsqr_, mv.getMap()->getNode());
+      node_tsqr_factory_type::prepareNodeTsqr (nodeTsqr_);
     }
 
-    /// \brief Finish internode TSQR initialization.
+    /// \brief Finish interprocess TSQR initialization.
     ///
     /// \param mv [in] A valid Tpetra::MultiVector instance whose
     ///   communicator wrapper we will use to prepare TSQR.

--- a/packages/stokhos/src/sacado/kokkos/vector/tpetra/Tpetra_TsqrAdaptor_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/tpetra/Tpetra_TsqrAdaptor_MP_Vector.hpp
@@ -294,16 +294,16 @@ namespace Tpetra {
       }
     }
 
-    /// \brief Finish intranode TSQR initialization.
+    /// \brief Finish intraprocess TSQR initialization.
     ///
     /// \note It's OK to call this method more than once; it is idempotent.
     void
     prepareNodeTsqr (const MV& mv)
     {
-      node_tsqr_factory_type::prepareNodeTsqr (nodeTsqr_, mv.getMap()->getNode());
+      node_tsqr_factory_type::prepareNodeTsqr (nodeTsqr_);
     }
 
-    /// \brief Finish internode TSQR initialization.
+    /// \brief Finish interprocess TSQR initialization.
     ///
     /// \param mv [in] A valid Tpetra::MultiVector instance whose
     ///   communicator wrapper we will use to prepare TSQR.

--- a/packages/stratimikos/adapters/belos/src/Thyra_TsqrAdaptor.hpp
+++ b/packages/stratimikos/adapters/belos/src/Thyra_TsqrAdaptor.hpp
@@ -265,16 +265,13 @@ namespace Thyra {
 #endif // HAVE_MPI
     }
 
-    /// \brief Finish intranode TSQR initialization.
+    /// \brief Finish intraprocess TSQR initialization.
     ///
     /// \note It's OK to call this method more than once; it is idempotent.
     void
-    prepareNodeTsqr (const MV& /* X */)
-    {
-      throw std::logic_error ("Thyra adaptor for TSQR not implemented");
-    }
+    prepareNodeTsqr (const MV& /* X */) {}
 
-    /// \brief Finish internode TSQR initialization.
+    /// \brief Finish interprocess TSQR initialization.
     ///
     /// Input X is a valid Thyra::MultiVectorBase instance whose
     /// communicator wrapper we will use to prepare TSQR.  It is not
@@ -287,10 +284,7 @@ namespace Thyra {
     /// we don't know how to extract a communicator from it.  If it
     /// fails in this way, it will throw std::runtime_error.
     void
-    prepareDistTsqr (const MV& /* X */)
-    {
-      throw std::logic_error ("Thyra adaptor for TSQR not implemented");
-    }
+    prepareDistTsqr (const MV& /* X */) {}
 
     /// \brief Finish TSQR initialization.
     ///

--- a/packages/tpetra/core/src/Epetra_TsqrAdaptor.hpp
+++ b/packages/tpetra/core/src/Epetra_TsqrAdaptor.hpp
@@ -34,13 +34,11 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
-//
 // ************************************************************************
 // @HEADER
 
-#ifndef __Epetra_TsqrAdaptor_hpp
-#define __Epetra_TsqrAdaptor_hpp
+#ifndef EPETRA_TSQRADAPTOR_HPP
+#define EPETRA_TSQRADAPTOR_HPP
 
 ///
 /// \file Epetra_TsqrAdaptor.hpp
@@ -346,21 +344,16 @@ namespace Epetra {
       }
     }
 
-    /// \brief Finish intranode TSQR initialization.
+    /// \brief Finish intraprocess TSQR initialization.
     ///
     /// \note It's OK to call this method more than once; it is idempotent.
     void
-    prepareNodeTsqr (const MV& mv)
+    prepareNodeTsqr (const MV& /* mv */)
     {
-      (void) mv; // Epetra objects don't have a Kokkos Node.
-
-      // Create Node with empty ParameterList.
-      Teuchos::ParameterList plist;
-      Teuchos::RCP<node_type> node (new node_type (plist));
-      node_tsqr_factory_type::prepareNodeTsqr (nodeTsqr_, node);
+      node_tsqr_factory_type::prepareNodeTsqr (nodeTsqr_);
     }
 
-    /// \brief Finish internode TSQR initialization.
+    /// \brief Finish interprocess TSQR initialization.
     ///
     /// \param mv [in] A multivector, from which to extract the
     ///   Epetra_Comm communicator wrapper to use to initialize TSQR.
@@ -387,5 +380,5 @@ namespace Epetra {
 
 #endif // defined(HAVE_TPETRA_EPETRA) && defined(HAVE_TPETRA_TSQR)
 
-#endif // __Epetra_TsqrAdaptor_hpp
+#endif // EPETRA_TSQRADAPTOR_HPP
 

--- a/packages/tpetra/core/test/CMakeLists.txt
+++ b/packages/tpetra/core/test/CMakeLists.txt
@@ -31,6 +31,7 @@ ADD_SUBDIRECTORIES(
   Sort
   Utils
   RowMatrixTransposer
+  Tsqr
   TypeStack
   )
 

--- a/packages/tpetra/core/test/Node/Issue510.cpp
+++ b/packages/tpetra/core/test/Node/Issue510.cpp
@@ -35,8 +35,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
-//
 // ************************************************************************
 // @HEADER
 */

--- a/packages/tpetra/core/test/Tsqr/CMakeLists.txt
+++ b/packages/tpetra/core/test/Tsqr/CMakeLists.txt
@@ -1,0 +1,10 @@
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  TsqrAdaptor
+  SOURCES
+    TsqrAdaptor
+    ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  COMM serial mpi
+  NUM_MPI_PROCS 1
+  ARGS ""
+  STANDARD_PASS_OUTPUT
+  )

--- a/packages/tpetra/core/test/Tsqr/TsqrAdaptor.cpp
+++ b/packages/tpetra/core/test/Tsqr/TsqrAdaptor.cpp
@@ -1,0 +1,73 @@
+#include "Tpetra_Map.hpp"
+#include "Tpetra_MultiVector.hpp"
+#include "Tpetra_TsqrAdaptor.hpp"
+#include "Teuchos_Assert.hpp"
+#include "Teuchos_TypeNameTraits.hpp"
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Tpetra_Core.hpp"
+#include <limits>
+
+namespace { // (anonymous)
+
+  Teuchos::RCP<const Tpetra::Map<>>
+  makeMap(const Teuchos::RCP<const Teuchos::Comm<int>>& comm)
+  {
+    using map_type = Tpetra::Map<>;
+
+    TEUCHOS_ASSERT( ! comm.is_null() );
+
+    const map_type::local_ordinal_type lclNumInds (5);
+    const int numProcs = comm->getSize();
+    const Tpetra::global_size_t gblNumInds (numProcs * lclNumInds);
+    const map_type::global_ordinal_type indexBase (0);
+    return Teuchos::rcp(new map_type(gblNumInds, indexBase, comm));
+  }
+
+  TEUCHOS_UNIT_TEST( TsqrAdaptor, WhetherItCompiles )
+  {
+    using MV = Tpetra::MultiVector<>;
+    using tsqr_adaptor_type = Tpetra::TsqrAdaptor<MV>;
+
+    out << "TsqrAdaptor type name: "
+        << Teuchos::TypeNameTraits<tsqr_adaptor_type>::name()
+        << std::endl;
+    auto map = makeMap(Tpetra::getDefaultComm());
+
+    const size_t numVecs = 3;
+    const bool zeroOut = false;
+    MV A(map, numVecs, zeroOut);
+    MV Q(map, numVecs);
+    A.randomize();
+
+    tsqr_adaptor_type thingie;
+
+    // FIXME (mfh 02 Dec 2019) It's not clear that setParameterList
+    // works for an empty but nonnull ParameterList.
+    using Teuchos::ParameterList;
+    using Teuchos::RCP;
+    RCP<ParameterList> tsqrParams;
+    thingie.setParameterList(tsqrParams);
+
+    RCP<const ParameterList> validTsqrParams =
+      thingie.getValidParameters();
+    tsqrParams = rcp(new ParameterList(*validTsqrParams));
+    thingie.setParameterList(tsqrParams);
+
+    using LO = MV::local_ordinal_type;
+    using SC = MV::scalar_type;
+    using dense_matrix_type = Teuchos::SerialDenseMatrix<LO, SC>;
+    dense_matrix_type R(numVecs, numVecs, zeroOut);
+
+    for (bool forceNonnegativeDiagonal : {false, true}) {
+      thingie.factorExplicit (A, Q, R, forceNonnegativeDiagonal);
+      // Random matrices need not necessarily have full rank.
+      // Just print the rank so we don't emit a build warning.
+      using mag_type = MV::mag_type;
+      const mag_type tol = std::numeric_limits<mag_type>::epsilon();
+      const int rank = thingie.revealRank(Q, R, tol);
+      out << "Current rank: " << rank << std::endl;
+    }
+  }
+
+} // namespace (anonymous)
+

--- a/packages/tpetra/tsqr/src/Tsqr_NodeTsqrFactory.hpp
+++ b/packages/tpetra/tsqr/src/Tsqr_NodeTsqrFactory.hpp
@@ -131,24 +131,13 @@ namespace TSQR {
       return rcp (new node_tsqr_type (plist));
     }
 
-    /// \brief Prepare the NodeTsqr instance for use by setting its
-    ///   Kokkos \c Node instance.
+    /// \brief Prepare the NodeTsqr instance for use.
     ///
-    /// Some NodeTsqr subclasses can't compute anything until they
-    /// have a pointer to a Kokkos Node instance.  Call this method
-    /// before invoking any computational methods of the NodeTsqr
-    /// subclass instance.
-    ///
-    /// \pre <tt> ! nodeTsqr.is_null() && ! node.is_null() </tt>
+    /// \pre <tt> ! nodeTsqr.is_null() </tt>
     /// \post <tt> nodeTsqr->ready() </tt>
     static void
-    prepareNodeTsqr (const Teuchos::RCP<node_tsqr_type>& nodeTsqr,
-                     const Teuchos::RCP<node_type>& node)
-    {
-      // SequentialTsqr doesn't need the Kokkos Node instance.
-      (void) nodeTsqr;
-      (void) node;
-    }
+    prepareNodeTsqr (const Teuchos::RCP<node_tsqr_type>& /* nodeTsqr */)
+    {}
   };
 } // namespace TSQR
 


### PR DESCRIPTION
@trilinos/tpetra @trilinos/belos @trilinos/stokhos

1. TsqrAdaptor no longer calls the deprecated method
   `Tpetra::Map::getNode`.  This includes the two partial
   specializations of TsqrAdaptor in Stokhos.

2. Tpetra now has a test that builds and calls methods in TsqrAdaptor.
   Before, the only tests for TsqrAdaptor were in Belos.

## Motivation

Albany reported build errors in its Tpetra develop build with deprecated code off.

## Related Issues

* Closes #6354 

## Stakeholder Feedback

Reported by Albany in #6354.

## Testing

Tested locally.