### PR TITLE
Tpetra: Fix #6393

### DIFF
--- a/packages/tpetra/core/src/CMakeLists.txt
+++ b/packages/tpetra/core/src/CMakeLists.txt
@@ -768,5 +768,5 @@ SET_PROPERTY(
 # / from this directory, or to / from the 'impl' subdirectory.  That ensures
 # that running "make" will also rerun CMake in order to regenerate Makefiles.
 #
-# Here's another change, and another.
+# Here's another change, and another, and yet another.
 #

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -61,6 +61,7 @@
 #include "Tpetra_Details_gathervPrint.hpp"
 #include "Tpetra_Details_getDiagCopyWithoutOffsets.hpp"
 #include "Tpetra_Details_leftScaleLocalCrsMatrix.hpp"
+#include "Tpetra_Details_local_deep_copy.hpp"
 #include "Tpetra_Details_Profiling.hpp"
 #include "Tpetra_Details_rightScaleLocalCrsMatrix.hpp"
 #include "Tpetra_Details_ScalarViewTraits.hpp"
@@ -2072,9 +2073,7 @@ namespace Tpetra {
         (tgt_IST, numInserted);
       View<const IST*, HostSpace, MemoryTraits<Unmanaged>> src
         (src_IST, numInserted);
-      // NOTE (mfh 04 Dec 2019) Use local_deep_copy, not deep_copy,
-      // since this copy may be too small to justify parallelization.
-      using Kokkos::Experimental::local_deep_copy;
+      using Tpetra::Details::local_deep_copy;
       local_deep_copy (tgt, src);
     }
   }

--- a/packages/tpetra/core/src/Tpetra_Details_PackTraits.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_PackTraits.hpp
@@ -151,7 +151,11 @@ struct PackTraits {
 
       // As of CUDA 6, it's totally fine to use memcpy in a CUDA device
       // function.  It does what one would expect.
-      memcpy (outBuf, inBuf, numBytes);
+      //
+      // mfh (04 Dec 2019) We can't use Kokkos::local_deep_copy here,
+      // because outBuf is an array of char, not an array of
+      // value_type.  The only way to pack safely is to memcpy.
+      memcpy (outBuf, reinterpret_cast<const char*> (inBuf), numBytes);
       return pair_type (errorCode, numBytes);
     }
   }
@@ -201,7 +205,11 @@ struct PackTraits {
 
       // As of CUDA 6, it's totally fine to use memcpy in a CUDA device
       // function.  It does what one would expect.
-      memcpy (outBuf, inBuf, numBytes);
+      //
+      // mfh (04 Dec 2019) We can't use Kokkos::local_deep_copy here,
+      // because inBuf is an array of char, not an array of
+      // value_type.  The only way to pack safely is to memcpy.
+      memcpy (reinterpret_cast<char*> (outBuf), inBuf, numBytes);
       return pair_type (errorCode, numBytes);
     }
   }
@@ -257,7 +265,11 @@ struct PackTraits {
 
     // As of CUDA 6, it's totally fine to use memcpy in a CUDA device
     // function.  It does what one would expect.
-    memcpy (outBuf, &inVal, numBytes);
+    //
+    // mfh (04 Dec 2019) We can't use Kokkos::local_deep_copy here,
+    // because outBuf is an array of char, not an array of value_type.
+    // The only way to pack safely is to memcpy.
+    memcpy (outBuf, reinterpret_cast<const char*> (&inVal), numBytes);
     return numBytes;
   }
 
@@ -286,7 +298,13 @@ struct PackTraits {
 
     // As of CUDA 6, it's totally fine to use memcpy in a CUDA device
     // function.  It does what one would expect.
-    memcpy (outBuf + offset, &inVal, numBytes);
+    //
+    // mfh (04 Dec 2019) We can't use Kokkos::local_deep_copy here,
+    // because outBuf is an array of char, not an array of value_type.
+    // The only way to pack safely is to memcpy.
+    memcpy (outBuf + offset,
+            reinterpret_cast<const char*> (&inVal),
+            numBytes);
     return numBytes;
   }
 
@@ -313,7 +331,13 @@ struct PackTraits {
 
     // As of CUDA 6, it's totally fine to use memcpy in a CUDA device
     // function.  It does what one would expect.
-    memcpy (&outVal, inBuf, numBytes);
+    //
+    // mfh (04 Dec 2019) We can't use Kokkos::local_deep_copy here,
+    // because inBuf is an array of char, not an array of value_type.
+    // The only way to unpack safely is to memcpy.
+    memcpy (reinterpret_cast<char*> (&outVal),
+            inBuf,
+            numBytes);
     return numBytes;
   }
 }; // struct PackTraits

--- a/packages/tpetra/core/src/Tpetra_Details_crsUtils.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_crsUtils.hpp
@@ -34,25 +34,24 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
-//
 // ************************************************************************
 // @HEADER
-
-#ifndef TPETRA_DETAILS_CRSUTILS_HPP
-#define TPETRA_DETAILS_CRSUTILS_HPP
-#include <numeric>
-#include <type_traits>
-
-#include "TpetraCore_config.h"
-#include "Kokkos_Core.hpp"
-#include "Kokkos_UnorderedMap.hpp"
 
 /// \file Tpetra_Details_crsUtils.hpp
 /// \brief Functions for manipulating CRS arrays
 /// \warning This file, and its contents, are implementation details
 ///   of Tpetra.  The file itself or its contents may disappear or
 ///   change at any time.
+
+#ifndef TPETRA_DETAILS_CRSUTILS_HPP
+#define TPETRA_DETAILS_CRSUTILS_HPP
+
+#include "TpetraCore_config.h"
+#include "Kokkos_Core.hpp"
+#include "Kokkos_UnorderedMap.hpp"
+#include "Tpetra_Details_local_deep_copy.hpp"
+#include <numeric>
+#include <type_traits>
 
 namespace Tpetra {
 namespace Details {
@@ -136,7 +135,7 @@ pad_crs_arrays(
         range(this_row_beg, this_row_beg+used_this_row));
       auto indices_new_subview = subview(indices_new,
         range(row_ptr_beg(i), row_ptr_beg(i)+used_this_row));
-      using Kokkos::Experimental::local_deep_copy;
+      using Tpetra::Details::local_deep_copy;
       local_deep_copy (indices_new_subview, indices_old_subview);
     }
 
@@ -146,7 +145,7 @@ pad_crs_arrays(
         range(this_row_beg, this_row_beg+used_this_row));
       auto values_new_subview = subview(values_new,
         range(row_ptr_beg(i), row_ptr_beg(i)+used_this_row));
-      using Kokkos::Experimental::local_deep_copy;
+      using Tpetra::Details::local_deep_copy;
       local_deep_copy (values_new_subview, values_old_subview);
     }
 
@@ -171,7 +170,7 @@ pad_crs_arrays(
         range(this_row_beg, this_row_beg+used_this_row));
       auto indices_new_subview = subview(indices_new,
         range(row_ptr_beg(n), row_ptr_beg(n)+used_this_row));
-      using Kokkos::Experimental::local_deep_copy;
+      using Tpetra::Details::local_deep_copy;
       local_deep_copy (indices_new_subview, indices_old_subview);
     }
 
@@ -180,7 +179,7 @@ pad_crs_arrays(
         range(this_row_beg, this_row_beg+used_this_row));
       auto values_new_subview = subview(values_new,
         range(row_ptr_beg(n), row_ptr_beg(n)+used_this_row));
-      using Kokkos::Experimental::local_deep_copy;
+      using Tpetra::Details::local_deep_copy;
       local_deep_copy (values_new_subview, values_old_subview);
     }
   }

--- a/packages/tpetra/core/src/Tpetra_Details_crsUtils.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_crsUtils.hpp
@@ -112,7 +112,6 @@ pad_crs_arrays(
     return;
 
   using ptrs_value_type = typename RowPtr::non_const_value_type;
-  using inds_value_type = typename Indices::non_const_value_type;
   using vals_value_type = typename Values::non_const_value_type;
 
   // The indices array must be resized and the row_ptr arrays shuffled
@@ -133,20 +132,26 @@ pad_crs_arrays(
 
     // Copy over indices
     {
-      auto indices_old_subview = subview(indices, range(this_row_beg, this_row_beg+used_this_row));
-      auto indices_new_subview = subview(indices_new, range(row_ptr_beg(i), row_ptr_beg(i)+used_this_row));
-      // just call memcpy; it works fine on device if this becomes a kernel
-      memcpy(indices_new_subview.data(), indices_old_subview.data(), used_this_row * sizeof(inds_value_type));
+      auto indices_old_subview = subview(indices,
+        range(this_row_beg, this_row_beg+used_this_row));
+      auto indices_new_subview = subview(indices_new,
+        range(row_ptr_beg(i), row_ptr_beg(i)+used_this_row));
+      using Kokkos::Experimental::local_deep_copy;
+      local_deep_copy (indices_new_subview, indices_old_subview);
     }
 
     // And then the values
     if (pad_values) {
-      auto values_old_subview = subview(values, range(this_row_beg, this_row_beg+used_this_row));
-      auto values_new_subview = subview(values_new, range(row_ptr_beg(i), row_ptr_beg(i)+used_this_row));
-      memcpy(values_new_subview.data(), values_old_subview.data(), used_this_row * sizeof(vals_value_type));
+      auto values_old_subview = subview(values,
+        range(this_row_beg, this_row_beg+used_this_row));
+      auto values_new_subview = subview(values_new,
+        range(row_ptr_beg(i), row_ptr_beg(i)+used_this_row));
+      using Kokkos::Experimental::local_deep_copy;
+      local_deep_copy (values_new_subview, values_old_subview);
     }
 
-    // Before modifying the row_ptr arrays, save current beg, end for next iteration
+    // Before modifying the row_ptr arrays, save current beg, end for
+    // next iteration
     this_row_beg = row_ptr_beg(i+1);
     this_row_end = row_ptr_end(i+1);
 
@@ -162,15 +167,21 @@ pad_crs_arrays(
     auto used_this_row = row_ptr_end(n) - row_ptr_beg(n);
 
     {
-      auto indices_old_subview = subview(indices, range(this_row_beg, this_row_beg+used_this_row));
-      auto indices_new_subview = subview(indices_new, range(row_ptr_beg(n), row_ptr_beg(n)+used_this_row));
-      memcpy(indices_new_subview.data(), indices_old_subview.data(), used_this_row * sizeof(inds_value_type));
+      auto indices_old_subview = subview(indices,
+        range(this_row_beg, this_row_beg+used_this_row));
+      auto indices_new_subview = subview(indices_new,
+        range(row_ptr_beg(n), row_ptr_beg(n)+used_this_row));
+      using Kokkos::Experimental::local_deep_copy;
+      local_deep_copy (indices_new_subview, indices_old_subview);
     }
 
     if (pad_values) {
-      auto values_old_subview = subview(values, range(this_row_beg, this_row_beg+used_this_row));
-      auto values_new_subview = subview(values_new, range(row_ptr_beg(n), row_ptr_beg(n)+used_this_row));
-      memcpy(values_new_subview.data(), values_old_subview.data(), used_this_row * sizeof(vals_value_type));
+      auto values_old_subview = subview(values,
+        range(this_row_beg, this_row_beg+used_this_row));
+      auto values_new_subview = subview(values_new,
+        range(row_ptr_beg(n), row_ptr_beg(n)+used_this_row));
+      using Kokkos::Experimental::local_deep_copy;
+      local_deep_copy (values_new_subview, values_old_subview);
     }
   }
 

--- a/packages/tpetra/core/src/Tpetra_Details_local_deep_copy.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_local_deep_copy.hpp
@@ -1,0 +1,117 @@
+// @HEADER
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services Package
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// ************************************************************************
+// @HEADER
+
+#ifndef TPETRA_DETAILS_LOCAL_DEEP_COPY_HPP
+#define TPETRA_DETAILS_LOCAL_DEEP_COPY_HPP
+
+#include "TpetraCore_config.h"
+#include "Kokkos_Core.hpp"
+#include <type_traits>
+#include <cstring> // memcpy
+
+namespace Tpetra {
+namespace Details {
+
+  template<class DT, class ... DP , class ST, class ... SP>
+  KOKKOS_INLINE_FUNCTION void
+  local_deep_copy_contiguous (const Kokkos::View<DT, DP...>& dst,
+                              const Kokkos::View<ST, SP...>& src)
+  {
+    auto dst_raw = dst.data ();
+    auto src_raw = src.data ();
+
+    using dst_type = Kokkos::View<DT, DP...>;
+    using src_type = Kokkos::View<ST, SP...>;
+    using dst_value_type = typename dst_type::non_const_value_type;
+    using src_value_type = typename src_type::non_const_value_type;
+    constexpr bool same_value =
+      std::is_same<dst_value_type, src_value_type>::value;
+    constexpr bool trivially_copyable =
+      std::is_trivially_copyable<dst_value_type>::value;
+    constexpr bool both_rank_one =
+      static_cast<int> (dst_type::Rank) == 1 &&
+      static_cast<int> (src_type::Rank) == 1;
+    // All contiguous rank-1 Views have the "same layout."
+    constexpr bool same_layout = both_rank_one ||
+      std::is_same<typename dst_type::array_layout,
+                   typename dst_type::array_layout>::value;
+    if (same_value && trivially_copyable && same_layout) {
+      // See Trilinos #6393; the casts avoid compiler warnings for the
+      // "else" case.  Once we have "if constexpr" we can get rid of
+      // the casts.
+      std::memcpy (reinterpret_cast<char*> (dst_raw),
+                   reinterpret_cast<const char*> (src_raw),
+                   sizeof (dst_type));
+    }
+    else {
+      for (size_t k = 0; k < dst.span (); ++k) {
+        dst_raw[k] = src_raw[k];
+      }
+    }
+  }
+
+  template<class DT, class ... DP , class ST, class ... SP>
+  KOKKOS_INLINE_FUNCTION void
+  local_deep_copy (const Kokkos::View<DT, DP...>& dst,
+                   const Kokkos::View<ST, SP...>& src,
+                   typename std::enable_if<
+                     static_cast<int> (Kokkos::View<DT, DP...>::Rank) == 1 &&
+                     static_cast<int> (Kokkos::View<ST, SP...>::Rank) == 1
+                   >::type* = 0)
+  {
+    // FIXME (mfh 08 Dec 2019) Use Kokkos::local_deep_copy, once
+    // that function leaves the Kokkos::Experimental namespace.
+    // using Kokkos::Experimental::local_deep_copy;
+    // local_deep_copy (dst, src);
+
+    if (dst.span_is_contiguous () && src.span_is_contiguous ()) {
+      local_deep_copy_contiguous (dst, src);
+    }
+    else {
+      using size_type = decltype (dst.extent (0));
+      for (size_type k = 0; k < dst.extent (0); ++k) {
+        dst(k) = src(k);
+      }
+    }
+  }
+
+} // namespace Details
+} // namespace Tpetra
+
+#endif // TPETRA_DETAILS_LOCAL_DEEP_COPY_HPP


### PR DESCRIPTION
@trilinos/tpetra

Using `memcpy` with `Kokkos::complex<T>` pointers causes GCC 8.3 to issue warnings, since `Kokkos::complex<T>` is not `TriviallyCopyable`.  This commit removes use of `memcpy` with `Kokkos::complex<T>` pointers from Tpetra.

## Related Issues

* Closes https://github.com/trilinos/Trilinos/issues/6393
* Related to https://github.com/kokkos/kokkos/issues/2577
* Part of https://github.com/trilinos/Trilinos/issues/6295

## Testing info

Tested with GCC 4.8.4 + OpenMP on Linux.