### PR TITLE
Zoltan2 and Galeri:  remove warnings reported by gcc8.3 

### DIFF
--- a/packages/galeri/src-xpetra/Galeri_Elasticity2DProblem.hpp
+++ b/packages/galeri/src-xpetra/Galeri_Elasticity2DProblem.hpp
@@ -316,7 +316,6 @@ namespace Galeri {
     template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Map, typename Matrix, typename MultiVector>
     RCP<typename Problem<Map,Matrix,MultiVector>::RealValuedMultiVector>
     Elasticity2DProblem<Scalar,LocalOrdinal,GlobalOrdinal,Map,Matrix,MultiVector>::BuildCoords() {
-      using RealValuedMultiVector = typename Problem<Map,Matrix,MultiVector>::RealValuedMultiVector;
       // FIXME: map here is an extended map, with multiple DOF per node
       // as we cannot construct a single DOF map in Problem, we repeat the coords
       this->Coords_ = MultiVectorTraits<Map,RealValuedMultiVector>::Build(this->Map_, nDim_);

--- a/packages/galeri/src-xpetra/Galeri_Elasticity3DProblem.hpp
+++ b/packages/galeri/src-xpetra/Galeri_Elasticity3DProblem.hpp
@@ -335,7 +335,6 @@ namespace Galeri {
     template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Map, typename Matrix, typename MultiVector>
     RCP<typename Problem<Map,Matrix,MultiVector>::RealValuedMultiVector>
     Elasticity3DProblem<Scalar,LocalOrdinal,GlobalOrdinal,Map,Matrix,MultiVector>::BuildCoords() {
-      using RealValuedMultiVector = typename Problem<Map,Matrix,MultiVector>::RealValuedMultiVector;
       // FIXME: map here is an extended map, with multiple DOF per node
       // as we cannot construct a single DOF map in Problem, we repeat the coords
       this->Coords_ = MultiVectorTraits<Map,RealValuedMultiVector>::Build(this->Map_, nDim_);
@@ -370,7 +369,6 @@ namespace Galeri {
     template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Map, typename Matrix, typename MultiVector>
     RCP<MultiVector> Elasticity3DProblem<Scalar,LocalOrdinal,GlobalOrdinal,Map,Matrix,MultiVector>::BuildNullspace() {
 
-      using RealValuedMultiVector = typename Problem<Map,Matrix,MultiVector>::RealValuedMultiVector;
       typedef Teuchos::ScalarTraits<Scalar> TST;
       typedef typename RealValuedMultiVector::scalar_type real_type;
 

--- a/packages/galeri/src-xpetra/Galeri_StencilProblems.hpp
+++ b/packages/galeri/src-xpetra/Galeri_StencilProblems.hpp
@@ -99,7 +99,6 @@ namespace Galeri {
 
     template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Map, typename Matrix, typename MultiVector>
     Teuchos::RCP<typename Problem<Map,Matrix,MultiVector>::RealValuedMultiVector> Laplace1DProblem<Scalar,LocalOrdinal,GlobalOrdinal,Map,Matrix,MultiVector>::BuildCoords() {
-      using RealValuedMultiVector = typename Problem<Map,Matrix,MultiVector>::RealValuedMultiVector;
 
       GlobalOrdinal nx = this->list_.get("nx", (GlobalOrdinal) -1);
 

--- a/packages/zoltan2/src/algorithms/order/Zoltan2_AlgND.hpp
+++ b/packages/zoltan2/src/algorithms/order/Zoltan2_AlgND.hpp
@@ -201,8 +201,6 @@ int AlgND<Adapter>::globalOrder(
 template <typename Adapter>
 int AlgND<Adapter>::localOrder(const RCP<LocalOrderingSolution<lno_t> > &solution_)
 {
-    typedef typename Adapter::lno_t lno_t;     // local ids
-
     mEnv->debug(DETAILED_STATUS, std::string("Entering AlgND"));
 
     //////////////////////////////////////////////////////////////////////
@@ -534,10 +532,8 @@ void AlgND<Adapter>::getBoundLayer(part_t levelIndx, const std::vector<part_t> &
 				   std::vector<lno_t> &bigraphCRSRowPtr, std::vector<lno_t> &bigraphCRSCols,
 				   std::vector<lno_t> &bigraphVMapS, std::vector<lno_t> &bigraphVMapT)
 {
-  typedef typename Adapter::lno_t lno_t;         // local ids
   typedef typename Adapter::offset_t offset_t;   // offset_t
-  typedef typename Adapter::scalar_t scalar_t;   // scalars
-  typedef StridedData<lno_t, scalar_t> input_t;
+  typedef StridedData<lno_t, typename Adapter::scalar_t> input_t;
 
   lno_t numVerts = mGraphModel->getLocalNumVertices();
 

--- a/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
+++ b/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
@@ -6861,8 +6861,6 @@ void AlgMJ<mj_scalar_t, mj_lno_t, mj_gno_t, mj_part_t, mj_node_t>::
     auto local_new_part_xadj = this->new_part_xadj;
     auto local_new_coordinate_permutations = this->new_coordinate_permutations;
 
-    typedef typename mj_node_t::device_type device_t;
-
     // part shift holds the which part number an old part number corresponds to.
     Kokkos::View<mj_part_t*, device_t> part_shifts("part_shifts", num_parts);
 

--- a/packages/zoltan2/test/directory/directoryTest_KokkosSimple.cpp
+++ b/packages/zoltan2/test/directory/directoryTest_KokkosSimple.cpp
@@ -150,7 +150,7 @@ int test_simple_replace(Teuchos::RCP<const Teuchos::Comm<int> > comm) {
       ++err;
     }
   }
-  catch(std::logic_error) {
+  catch(std::logic_error &e) {
     if(comm->getSize() != 1) {
       err = 1;
     }

--- a/packages/zoltan2/test/helpers/UserInputForTests.hpp
+++ b/packages/zoltan2/test/helpers/UserInputForTests.hpp
@@ -2756,7 +2756,6 @@ void UserInputForTests::setPamgenCoordinateMV()
   }
 
   // make a Tpetra map
-  typedef  Tpetra::Map<zlno_t, zgno_t, znode_t> map_t;
   RCP<Tpetra::Map<zlno_t, zgno_t, znode_t> > mp;
   //   mp = rcp(new map_t(numGlobalElements, numelements, 0, this->tcomm_)); // constructo 1
 
@@ -2796,7 +2795,6 @@ void UserInputForTests::setPamgenAdjacencyGraph()
   // Define Types
 //  typedef zlno_t lno_t;
 //  typedef zgno_t gno_t;
-  typedef  Tpetra::Map<zlno_t, zgno_t, znode_t> map_t;
 
   // get info for setting up map
   size_t local_nodes = (size_t)this->pamgen_mesh->num_nodes;


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/zoltan2 @trilinos/galeri 

## Motivation
In #6295, @ZUUL42 is trying to stand up PR build with gcc 8.3 and warnings-as-errors.
These changes eliminate warnings reported in Zoltan2 tests.




## Related Issues
#6295 

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
@ZUUL42 please let me know whether or not Zoltan2 comes back clean in your re-testing

## Testing
Built and ran with gcc 8.3 and openmpi 1.10 on cee-lan.
```
module load sems-env
module load sems-cmake/3.10.3
module load sierra-devel/gcc-8.3.0-openmpi-1.10.2
```
Used Tpetra_ENABLE_DEPRECATED_CODE=OFF and KOKKOS_ENABLE_DEPRECATED_CODE=OFF



<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->