### PR TITLE
Tpetra: explicitly sort entries of add() result, make setAllIndices() expect sorted.

### DIFF
--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
@@ -824,15 +824,7 @@ add (const Scalar& alpha,
     //TODO: use KokkosKernels batched sort on device as soon as it's available
     //But now, have to sort on host (using UVM)
     exec_space().fence();
-    for(LO row = 0; row < numLocalRows; row++)
-    {
-      size_type rowBegin = rowptrs(row);
-      size_type rowEnd = rowptrs(row + 1);
-      lno_t* entriesBegin = &localColinds(rowBegin);
-      lno_t* entriesEnd = &localColinds(rowEnd);
-      typename AddKern::impl_scalar_type* valuesBegin = &vals(rowBegin);
-      Tpetra::sort2(entriesBegin, entriesEnd, valuesBegin);
-    }
+    Tpetra::Import_Util::sortCrsEntries(rowptrs, localColinds, vals);
     C.setAllValues(rowptrs, localColinds, vals);
     C.fillComplete(CDomainMap, CRangeMap, params);
     if(!doFillComplete)

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -1492,6 +1492,7 @@ namespace Tpetra {
 
     /// \brief Set the graph's data directly, using 1-D storage.
     ///
+    /// \pre columnIndices are sorted within rows
     /// \pre <tt>hasColMap() == true</tt>
     /// \pre <tt>rowPointers.size() != getNodeNumRows()+1</tt>
     /// \pre No insert routines have been called.
@@ -1504,6 +1505,7 @@ namespace Tpetra {
 
     /// \brief Set the graph's data directly, using 1-D storage.
     ///
+    /// \pre columnIndices are sorted within rows
     /// \pre <tt>hasColMap() == true</tt>
     /// \pre <tt>rowPointers.size() != getNodeNumRows()+1</tt>
     /// \pre No insert routines have been called.

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -3493,6 +3493,8 @@ namespace Tpetra {
 
     indicesAreAllocated_ = true;
     indicesAreLocal_     = true;
+    indicesAreSorted_    = true;
+    noRedundancies_      = true;
     pftype_              = StaticProfile; // if the profile wasn't static before, it sure is now.
     k_lclInds1D_         = columnIndices;
     k_rowPtrs_           = rowPointers;

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -2146,6 +2146,7 @@ namespace Tpetra {
 
     /// \brief Set the local matrix using three (compressed sparse row) arrays.
     ///
+    /// \pre ind is sorted within each row
     /// \pre <tt>hasColMap() == true</tt>
     /// \pre <tt>getGraph() != Teuchos::null</tt>
     /// \pre No insert/sum routines have been called
@@ -2174,6 +2175,7 @@ namespace Tpetra {
 
     /// \brief Set the local matrix using three (compressed sparse row) arrays.
     ///
+    /// \pre ind is sorted within each row
     /// \pre <tt>hasColMap() == true</tt>
     /// \pre <tt>getGraph() != Teuchos::null</tt>
     /// \pre No insert/sum routines have been called


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 
@cgcgcg 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
TpetraExt::MatrixMatrix::add() was producing a fill-complete result matrix with unsorted local entries (invalid). It was doing setAllValues() followed by fillComplete(), but the fillComplete was not sorting indices because the graph's isSorted_ flag was still true.

- Fixed the actual problem in add() by sorting indices before calling setAllValues()
- Updated the documentation for CrsGraph::setAllIndices() and CrsMatrix::setAllValues() to say that the indices must be sorted on input, because they do not check for sorted
- setAllIndices() now sets isSorted_ and noRedundancies_ to true, since neither sorting nor merging will be done during fillComplete(). This was already happening in all the CrsGraph constructors that call setAllIndices().
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
Fixes a bug exposed by EMPIRE.
## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
add() is tested in Tpetra and Xpetra, and used in many MueLu tests.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->