### PR TITLE
Zoltan2: Fix valgrind warning for Multijagged (#6399)

### DIFF
--- a/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
+++ b/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
@@ -3603,8 +3603,8 @@ struct ArrayCombinationReducer {
       dst.ptr[n] = 0;
     }
 
-    for(int n = value_count_weights + 2;
-      n < value_count_weights + value_count_rightleft - 2; n += 2) {
+    for(int n = value_count_weights;
+      n < value_count_weights + value_count_rightleft; n += 2) {
       dst.ptr[n]   = -max_scalar;
       dst.ptr[n+1] =  max_scalar;
     }
@@ -3752,8 +3752,8 @@ struct ReduceWeightsFunctor {
       for(int n = 0; n < value_count_weights; ++n) {
         shared_ptr[n] = 0;
       }
-      for(int n = value_count_weights + 2;
-        n < value_count_weights + value_count_rightleft - 2; n += 2) {
+      for(int n = value_count_weights;
+        n < value_count_weights + value_count_rightleft; n += 2) {
         shared_ptr[n]   = -max_scalar;
         shared_ptr[n+1] =  max_scalar;
       }


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/zoltan2

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Resolve #6399.  Removes valgrind warnings due to uninitialized data in the array buffer. The buffer is used to eliminate some branching in the kernel so those elements are not actually used. But initializing the element will be negligible cost and removes the valgrind warning. This fix is not expected to have any side effects on the calculation.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->