### PR TITLE
Tpetra: document the requirements of column maps

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -1548,16 +1548,12 @@ namespace Tpetra {
     /// \param newColMap [in] New column Map.  Must be nonnull.
     ///   Within Tpetra, there are no particular restrictions on the column map.
     ///   However, if this graph will be used in Xpetra, Ifpack2, or MueLu,
-    ///   the column map's list of global indices on each process must be in a certain order:
-    ///   locally owned GIDs (sorted), followed by remote GIDs (in order of
-    ///   owning proc, and sorted within each proc).
+    ///   the column map's list of global indices must follow "Aztec ordering":
+    ///   locally owned GIDs (same order as in domain map), followed by remote GIDs
+    ///   (in order of owning proc, and sorted within each proc).
     ///
-    ///   If in doubt, it is strongly recommended to use Tpetra::Details::makeColMap()
-    ///   to create the column map. makeColMap() takes a domain map
-    ///   that determines which columns are locally owned,
-    ///   and the RowGraph whose globally indexed entries
-    ///   must be mapped to local indices. Alternately, it can take
-    ///   a domain map and a raw Kokkos::View of global indices to be mapped.
+    ///   It is strongly recommended to use \c Tpetra::Details::makeColMap()
+    ///   to create the column map. makeColMap() follows Aztec ordering by default.
     void replaceColMap (const Teuchos::RCP<const map_type>& newColMap);
 
     /// \brief Reindex the column indices in place, and replace the

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -1546,11 +1546,13 @@ namespace Tpetra {
     /// does their order change, as a result of calling this method.
     ///
     /// \param newColMap [in] New column Map.  Must be nonnull.
-    ///   The column map's list of global indices on each process must be in a certain order:
+    ///   Within Tpetra, there are no particular restrictions on the column map.
+    ///   However, if this graph will be used in Xpetra, Ifpack2, or MueLu,
+    ///   the column map's list of global indices on each process must be in a certain order:
     ///   locally owned GIDs (sorted), followed by remote GIDs (in order of
     ///   owning proc, and sorted within each proc).
     ///
-    ///   It is strongly recommended to use Tpetra::Details::makeColMap()
+    ///   If in doubt, it is strongly recommended to use Tpetra::Details::makeColMap()
     ///   to create the column map. makeColMap() takes a domain map
     ///   that determines which columns are locally owned,
     ///   and the RowGraph whose globally indexed entries

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -411,6 +411,7 @@ namespace Tpetra {
     /// \param rowMap [in] Distribution of rows of the graph.
     ///
     /// \param colMap [in] Distribution of columns of the graph.
+    ///   See replaceColMap() for the requirements.
     ///
     /// \param maxNumEntriesPerRow [in] Maximum number of graph
     ///   entries per row.  If pftype==DynamicProfile, this is only a
@@ -436,6 +437,7 @@ namespace Tpetra {
     /// \param rowMap [in] Distribution of rows of the graph.
     ///
     /// \param colMap [in] Distribution of columns of the graph.
+    ///   See replaceColMap() for the requirements.
     ///
     /// \param numEntPerRow [in] Maximum number of graph entries to
     ///   allocate for each row.  If pftype==DynamicProfile, this is
@@ -461,6 +463,7 @@ namespace Tpetra {
     /// \param rowMap [in] Distribution of rows of the graph.
     ///
     /// \param colMap [in] Distribution of columns of the graph.
+    ///   See replaceColMap() for the requirements.
     ///
     /// \param numEntPerRow [in] Maximum number of graph entries to
     ///   allocate for each row.  If pftype==DynamicProfile, this is
@@ -496,6 +499,7 @@ namespace Tpetra {
     /// \param rowMap [in] Distribution of rows of the graph.
     ///
     /// \param colMap [in] Distribution of columns of the graph.
+    ///   See replaceColMap() for the requirements.
     ///
     /// \param rowPointers [in] The beginning of each row in the graph,
     ///   as in a CSR "rowptr" array.  The length of this vector should be
@@ -522,6 +526,7 @@ namespace Tpetra {
     /// \param rowMap [in] Distribution of rows of the graph.
     ///
     /// \param colMap [in] Distribution of columns of the graph.
+    ///   See replaceColMap() for the requirements.
     ///
     /// \param rowPointers [in] The beginning of each row in the graph,
     ///   as in a CSR "rowptr" array.  The length of this vector should be
@@ -551,6 +556,7 @@ namespace Tpetra {
     /// \param rowMap [in] Distribution of rows of the graph.
     ///
     /// \param colMap [in] Distribution of columns of the graph.
+    ///   See replaceColMap() for the requirements.
     ///
     /// \param lclGraph [in] A locally indexed Kokkos::StaticCrsGraph
     ///   whose local row indices come from the specified row Map, and
@@ -1540,6 +1546,16 @@ namespace Tpetra {
     /// does their order change, as a result of calling this method.
     ///
     /// \param newColMap [in] New column Map.  Must be nonnull.
+    ///   The column map's list of global indices on each process must be in a certain order:
+    ///   locally owned GIDs (sorted), followed by remote GIDs (in order of
+    ///   owning proc, and sorted within each proc).
+    ///
+    ///   It is strongly recommended to use Tpetra::Details::makeColMap()
+    ///   to create the column map. makeColMap() takes a domain map
+    ///   that determines which columns are locally owned,
+    ///   and the RowGraph whose globally indexed entries
+    ///   must be mapped to local indices. Alternately, it can take
+    ///   a domain map and a raw Kokkos::View of global indices to be mapped.
     void replaceColMap (const Teuchos::RCP<const map_type>& newColMap);
 
     /// \brief Reindex the column indices in place, and replace the

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -2390,17 +2390,13 @@ namespace Tpetra {
     ///
     /// \param newColMap [in] New column Map.  Must be nonnull.
     ///   Within Tpetra, there are no particular restrictions on the column map.
-    ///   However, if this matrix will be used in Xpetra, Ifpack2, or MueLu,
-    ///   the column map's list of global indices on each process must be in a certain order:
-    ///   locally owned GIDs (sorted), followed by remote GIDs (in order of
-    ///   owning proc, and sorted within each proc).
+    ///   However, if this graph will be used in Xpetra, Ifpack2, or MueLu,
+    ///   the column map's list of global indices must follow "Aztec ordering":
+    ///   locally owned GIDs (same order as in domain map), followed by remote GIDs
+    ///   (in order of owning proc, and sorted within each proc).
     ///
-    ///   If in doubt, it is strongly recommended to use Tpetra::Details::makeColMap()
-    ///   to create the column map. makeColMap() takes a domain map
-    ///   that determines which columns are locally owned,
-    ///   and the RowGraph whose globally indexed entries
-    ///   must be mapped to local indices. Alternately, it can take
-    ///   a domain map and a raw Kokkos::View of global indices to be mapped.
+    ///   It is strongly recommended to use \c Tpetra::Details::makeColMap()
+    ///   to create the column map. makeColMap() follows Aztec ordering by default.
     ///
     /// \pre The matrix must have no entries inserted yet, on any
     ///   process in the row Map's communicator.

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -595,6 +595,7 @@ namespace Tpetra {
     /// \param rowMap [in] Distribution of rows of the matrix.
     ///
     /// \param colMap [in] Distribution of columns of the matrix.
+    ///   See replaceColMap() for the requirements.
     ///
     /// \param maxNumEntPerRow [in] Maximum number of matrix
     ///   entries per row.  If pftype==DynamicProfile, this is only a
@@ -623,6 +624,7 @@ namespace Tpetra {
     /// \param rowMap [in] Distribution of rows of the matrix.
     ///
     /// \param colMap [in] Distribution of columns of the matrix.
+    ///   See replaceColMap() for the requirements.
     ///
     /// \param numEntPerRowToAlloc [in] Maximum number of matrix
     ///   entries to allocate for each row.  If
@@ -718,6 +720,7 @@ namespace Tpetra {
     /// \param rowMap [in] Distribution of rows of the matrix.
     ///
     /// \param colMap [in] Distribution of columns of the matrix.
+    ///   See replaceColMap() for the requirements.
     ///
     /// \param rowPointers [in] The beginning of each row in the matrix,
     ///   as in a CSR "rowptr" array.  The length of this vector should be
@@ -748,6 +751,7 @@ namespace Tpetra {
     /// \param rowMap [in] Distribution of rows of the matrix.
     ///
     /// \param colMap [in] Distribution of columns of the matrix.
+    ///   See replaceColMap() for the requirements.
     ///
     /// \param rowPointers [in] The beginning of each row in the matrix,
     ///   as in a CSR "rowptr" array.  The length of this vector should be
@@ -782,6 +786,7 @@ namespace Tpetra {
     /// \param rowMap [in] Distribution of rows of the matrix.
     ///
     /// \param colMap [in] Distribution of columns of the matrix.
+    ///   See replaceColMap() for the requirements.
     ///
     /// \param lclMatrix [in] A local CrsMatrix containing all local
     ///    matrix values as well as a local graph.  The graph's local
@@ -807,6 +812,7 @@ namespace Tpetra {
     /// \param rowMap [in] Distribution of rows of the matrix.
     ///
     /// \param colMap [in] Distribution of columns of the matrix.
+    ///   See replaceColMap() for the requirements.
     ///
     /// \param domainMap [in] The matrix's domain Map.  MUST be one to
     ///   one!
@@ -2383,6 +2389,16 @@ namespace Tpetra {
     /// \brief Replace the matrix's column Map with the given Map.
     ///
     /// \param newColMap [in] New column Map.  Must be nonnull.
+    ///   The column map's list of global indices on each process must be in a certain order:
+    ///   locally owned GIDs (sorted), followed by remote GIDs (in order of
+    ///   owning proc, and sorted within each proc).
+    ///
+    ///   It is strongly recommended to use Tpetra::Details::makeColMap()
+    ///   to create the column map. makeColMap() takes a domain map
+    ///   that determines which columns are locally owned,
+    ///   and the RowGraph whose globally indexed entries
+    ///   must be mapped to local indices. Alternately, it can take
+    ///   a domain map and a raw Kokkos::View of global indices to be mapped.
     ///
     /// \pre The matrix must have no entries inserted yet, on any
     ///   process in the row Map's communicator.

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -2389,11 +2389,13 @@ namespace Tpetra {
     /// \brief Replace the matrix's column Map with the given Map.
     ///
     /// \param newColMap [in] New column Map.  Must be nonnull.
-    ///   The column map's list of global indices on each process must be in a certain order:
+    ///   Within Tpetra, there are no particular restrictions on the column map.
+    ///   However, if this matrix will be used in Xpetra, Ifpack2, or MueLu,
+    ///   the column map's list of global indices on each process must be in a certain order:
     ///   locally owned GIDs (sorted), followed by remote GIDs (in order of
     ///   owning proc, and sorted within each proc).
     ///
-    ///   It is strongly recommended to use Tpetra::Details::makeColMap()
+    ///   If in doubt, it is strongly recommended to use Tpetra::Details::makeColMap()
     ///   to create the column map. makeColMap() takes a domain map
     ///   that determines which columns are locally owned,
     ///   and the RowGraph whose globally indexed entries

--- a/packages/tpetra/core/src/Tpetra_Details_makeColMap_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_makeColMap_decl.hpp
@@ -109,7 +109,7 @@ namespace Details {
 ///   are responsible for propagating that error state to all
 ///   processes.
 ///
-/// This function <i>always</i> makes a column Map, even if the Map
+/// This function <i>always</i> makes a column Map, even if the graph
 /// already has one.  This makes it possible to change the graph's
 /// structure, and have its column Map and corresponding Import update
 /// in the same way.


### PR DESCRIPTION
At CrsMatrix/CrsGraph constructors and replaceColMap(),
document the GID ordering requirements of column maps:
-locals before remotes (determined by domain map)
-locals sorted
-remotes sorted first by proc and then by GID

Strongly recommending that Details::makeColMap() be
used instead of constructing it manually from raw GIDs.

Also, fix a typo in a makeColMap comment.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The requirements of column maps need to be codified, especially as more matrix/graph construction stuff gets rewritten using Kokkos. Having these comments here would have made #6190 a lot easier, for example.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
-->
## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows #6190  
* Precedes 
* Related to 
* Part of 
* Composed of 



## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Just documentation (doxygen/comment) changes.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->