### PR TITLE
Sacado/Stokhos:  Make unary expression constructors explicit.

### DIFF
--- a/packages/minitensor/src/MiniTensor_Utilities.i.h
+++ b/packages/minitensor/src/MiniTensor_Utilities.i.h
@@ -110,7 +110,7 @@ KOKKOS_INLINE_FUNCTION
 T
 copysign(T const & a, T const & b)
 {
-  return b >= 0 ? std::abs(a) : -std::abs(a);
+  return b >= 0 ? T(std::abs(a)) : T(-std::abs(a));
 }
 
 //

--- a/packages/sacado/src/Sacado_CacheFad_Ops.hpp
+++ b/packages/sacado/src/Sacado_CacheFad_Ops.hpp
@@ -76,7 +76,7 @@ namespace Sacado {
       typedef typename ExprT::base_expr_type base_expr_type;
 
       KOKKOS_INLINE_FUNCTION
-      Expr(const ExprT& expr_) : expr(expr_)  {}
+      explicit Expr(const ExprT& expr_) : expr(expr_)  {}
 
       KOKKOS_INLINE_FUNCTION
       int size() const { return expr.size(); }
@@ -144,7 +144,7 @@ namespace Sacado {
       typedef typename ExprT::base_expr_type base_expr_type;
 
       KOKKOS_INLINE_FUNCTION
-      Expr(const ExprT& expr_) : expr(expr_)  {}
+      explicit Expr(const ExprT& expr_) : expr(expr_)  {}
 
       KOKKOS_INLINE_FUNCTION
       int size() const { return expr.size(); }
@@ -213,7 +213,7 @@ namespace Sacado {
       typedef typename ExprT::base_expr_type base_expr_type;
 
       KOKKOS_INLINE_FUNCTION
-      Expr(const ExprT& expr_) : expr(expr_)  {}
+      explicit Expr(const ExprT& expr_) : expr(expr_)  {}
 
       KOKKOS_INLINE_FUNCTION
       int size() const { return expr.size(); }
@@ -286,7 +286,7 @@ namespace Sacado {
       typedef typename ExprT::base_expr_type base_expr_type;
 
       KOKKOS_INLINE_FUNCTION
-      Expr(const ExprT& expr_) : expr(expr_)  {}
+      explicit Expr(const ExprT& expr_) : expr(expr_)  {}
 
       KOKKOS_INLINE_FUNCTION
       int size() const { return expr.size(); }
@@ -362,7 +362,7 @@ namespace Sacado {                                                      \
       typedef typename ExprT::base_expr_type base_expr_type;            \
                                                                         \
       KOKKOS_INLINE_FUNCTION                                            \
-      Expr(const ExprT& expr_) : expr(expr_)  {}                        \
+      explicit Expr(const ExprT& expr_) : expr(expr_)  {}               \
                                                                         \
       KOKKOS_INLINE_FUNCTION                                            \
       int size() const { return expr.size(); }                          \

--- a/packages/sacado/src/Sacado_ELRCacheFad_Ops.hpp
+++ b/packages/sacado/src/Sacado_ELRCacheFad_Ops.hpp
@@ -82,7 +82,7 @@ namespace Sacado {
       static const bool is_linear = true;
 
       KOKKOS_INLINE_FUNCTION
-      Expr(const ExprT& expr_) : expr(expr_)  {}
+      explicit Expr(const ExprT& expr_) : expr(expr_)  {}
 
       KOKKOS_INLINE_FUNCTION
       int size() const { return expr.size(); }
@@ -179,7 +179,7 @@ namespace Sacado {
       static const bool is_linear = true;
 
       KOKKOS_INLINE_FUNCTION
-      Expr(const ExprT& expr_) : expr(expr_)  {}
+      explicit Expr(const ExprT& expr_) : expr(expr_)  {}
 
       KOKKOS_INLINE_FUNCTION
       int size() const { return expr.size(); }
@@ -278,7 +278,7 @@ namespace Sacado {
       static const bool is_linear = false;
 
       KOKKOS_INLINE_FUNCTION
-      Expr(const ExprT& expr_) : expr(expr_)  {}
+      explicit Expr(const ExprT& expr_) : expr(expr_)  {}
 
       KOKKOS_INLINE_FUNCTION
       int size() const { return expr.size(); }
@@ -386,7 +386,7 @@ namespace Sacado {
       static const bool is_linear = false;
 
       KOKKOS_INLINE_FUNCTION
-      Expr(const ExprT& expr_) : expr(expr_)  {}
+      explicit Expr(const ExprT& expr_) : expr(expr_)  {}
 
       KOKKOS_INLINE_FUNCTION
       int size() const { return expr.size(); }
@@ -497,7 +497,7 @@ namespace Sacado {                                                      \
       static const bool is_linear = false;                              \
                                                                         \
       KOKKOS_INLINE_FUNCTION                                            \
-      Expr(const ExprT& expr_) : expr(expr_)  {}                        \
+      explicit Expr(const ExprT& expr_) : expr(expr_)  {}               \
                                                                         \
       KOKKOS_INLINE_FUNCTION                                            \
       int size() const { return expr.size(); }                          \

--- a/packages/sacado/src/Sacado_ELRFad_Ops.hpp
+++ b/packages/sacado/src/Sacado_ELRFad_Ops.hpp
@@ -77,7 +77,7 @@ namespace Sacado {                                                      \
       static const bool is_linear = LINEAR;                             \
                                                                         \
       KOKKOS_INLINE_FUNCTION                                            \
-      Expr(const ExprT& expr_) : expr(expr_)  {}                        \
+      explicit Expr(const ExprT& expr_) : expr(expr_)  {}               \
                                                                         \
       KOKKOS_INLINE_FUNCTION                                            \
       int size() const { return expr.size(); }                          \

--- a/packages/sacado/src/Sacado_Fad_Ops.hpp
+++ b/packages/sacado/src/Sacado_Fad_Ops.hpp
@@ -78,7 +78,7 @@ namespace Sacado {                                                      \
       typedef typename ExprT::base_expr_type base_expr_type;            \
                                                                         \
       KOKKOS_INLINE_FUNCTION                                            \
-      Expr(const ExprT& expr_) : expr(expr_)  {}                        \
+      explicit Expr(const ExprT& expr_) : expr(expr_)  {}               \
                                                                         \
       KOKKOS_INLINE_FUNCTION                                            \
       int size() const { return expr.size(); }                          \

--- a/packages/sacado/src/new_design/Sacado_Fad_Exp_Ops.hpp
+++ b/packages/sacado/src/new_design/Sacado_Fad_Exp_Ops.hpp
@@ -66,7 +66,7 @@ namespace Sacado {                                                      \
       typedef ExprSpecDefault expr_spec_type;                           \
                                                                         \
       KOKKOS_INLINE_FUNCTION                                            \
-      OP(const T& expr_) : expr(expr_)  {}                              \
+      explicit OP(const T& expr_) : expr(expr_)  {}                     \
                                                                         \
       KOKKOS_INLINE_FUNCTION                                            \
       int size() const { return expr.size(); }                          \

--- a/packages/sacado/test/UnitTests/CMakeLists.txt
+++ b/packages/sacado/test/UnitTests/CMakeLists.txt
@@ -326,4 +326,13 @@ IF (Sacado_ENABLE_TeuchosCore)
     NUM_MPI_PROCS 1
     STANDARD_PASS_OUTPUT
     )
+
+  TRIBITS_ADD_EXECUTABLE_AND_TEST(
+    TernaryExprTests
+    SOURCES TernaryExprTests.cpp
+    ARGS
+    COMM serial mpi
+    NUM_MPI_PROCS 1
+    STANDARD_PASS_OUTPUT
+    )
 ENDIF()

--- a/packages/sacado/test/UnitTests/TernaryExprTests.cpp
+++ b/packages/sacado/test/UnitTests/TernaryExprTests.cpp
@@ -1,0 +1,99 @@
+// @HEADER
+// ***********************************************************************
+//
+//                           Sacado Package
+//                 Copyright (2006) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// This library is free software; you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as
+// published by the Free Software Foundation; either version 2.1 of the
+// License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful, but
+// WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301
+// USA
+// Questions? Contact David M. Gay (dmgay@sandia.gov) or Eric T. Phipps
+// (etphipp@sandia.gov).
+//
+// ***********************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_UnitTestRepository.hpp"
+#include "Teuchos_GlobalMPISession.hpp"
+#include "Teuchos_TestingHelpers.hpp"
+
+#include "Sacado.hpp"
+
+// Size used for all Fad types
+const int global_fad_size = 10;
+
+// Check whether the ternary operator works as expected
+TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( Ternary, Ternary, AD )
+{
+  typedef AD ad_type;
+  typedef typename ad_type::value_type value_type;
+
+  success = true;
+
+  ad_type x(global_fad_size, value_type(1.5));
+  for (int i=0; i<global_fad_size; ++i)
+    x.fastAccessDx(i) = 2.0;
+
+  ad_type y = x > 0 ? -x : x;
+
+  TEST_EQUALITY_CONST( y.val(), -1.5 );
+  for (int i=0; i<global_fad_size; ++i)
+    TEST_EQUALITY_CONST( y.dx(i), -2.0 );
+}
+
+typedef Sacado::Fad::DFad<double> Fad_DFadType;
+typedef Sacado::Fad::SLFad<double,global_fad_size> Fad_SLFadType;
+typedef Sacado::Fad::SFad<double,global_fad_size> Fad_SFadType;
+TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( Ternary, Ternary, Fad_DFadType )
+TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( Ternary, Ternary, Fad_SLFadType )
+TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( Ternary, Ternary, Fad_SFadType )
+
+typedef Sacado::ELRFad::DFad<double> ELRFad_DFadType;
+typedef Sacado::ELRFad::SLFad<double,global_fad_size> ELRFad_SLFadType;
+typedef Sacado::ELRFad::SFad<double,global_fad_size> ELRFad_SFadType;
+TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( Ternary, Ternary, ELRFad_DFadType )
+TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( Ternary, Ternary, ELRFad_SLFadType )
+TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( Ternary, Ternary, ELRFad_SFadType )
+
+typedef Sacado::CacheFad::DFad<double> CacheFad_DFadType;
+typedef Sacado::CacheFad::SLFad<double,global_fad_size> CacheFad_SLFadType;
+typedef Sacado::CacheFad::SFad<double,global_fad_size> CacheFad_SFadType;
+TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( Ternary, Ternary, CacheFad_DFadType )
+TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( Ternary, Ternary, CacheFad_SLFadType )
+TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( Ternary, Ternary, CacheFad_SFadType )
+
+typedef Sacado::ELRCacheFad::DFad<double> ELRCacheFad_DFadType;
+typedef Sacado::ELRCacheFad::SLFad<double,global_fad_size> ELRCacheFad_SLFadType;
+typedef Sacado::ELRCacheFad::SFad<double,global_fad_size> ELRCacheFad_SFadType;
+TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( Ternary, Ternary, ELRCacheFad_DFadType )
+TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( Ternary, Ternary, ELRCacheFad_SLFadType )
+TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( Ternary, Ternary, ELRCacheFad_SFadType )
+
+#if defined(SACADO_ENABLE_NEW_DESIGN) && !defined(SACADO_NEW_FAD_DESIGN_IS_DEFAULT)
+typedef Sacado::Fad::Exp::DFad<double> ExpFad_DFadType;
+typedef Sacado::Fad::Exp::SLFad<double,global_fad_size> ExpFad_SLFadType;
+typedef Sacado::Fad::Exp::SFad<double,global_fad_size> ExpFad_SFadType;
+TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( Ternary, Ternary, ExpFad_DFadType )
+TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( Ternary, Ternary, ExpFad_SLFadType )
+TEUCHOS_UNIT_TEST_TEMPLATE_1_INSTANT( Ternary, Ternary, ExpFad_SFadType )
+#endif
+
+int main( int argc, char* argv[] ) {
+  Teuchos::GlobalMPISession mpiSession(&argc, &argv);
+  return Teuchos::UnitTestRepository::runUnitTestsFromMain(argc, argv);
+}

--- a/packages/stokhos/src/sacado/kokkos/vector/Sacado_MP_Vector_ops.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/Sacado_MP_Vector_ops.hpp
@@ -126,7 +126,7 @@ namespace Sacado {                                                      \
       typedef typename Tnv::base_expr_type base_expr_type;              \
                                                                         \
       KOKKOS_INLINE_FUNCTION                                            \
-      OP(const T& expr_) : expr(expr_)  {}                              \
+      explicit OP(const T& expr_) : expr(expr_)  {}                     \
                                                                         \
       KOKKOS_INLINE_FUNCTION                                            \
       std::string name() const {                                        \

--- a/packages/stokhos/test/UnitTest/Stokhos_SacadoMPVectorUnitTest.cpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_SacadoMPVectorUnitTest.cpp
@@ -397,6 +397,16 @@ struct UnitTestSetup {
                           setup.rtol, setup.atol, out);                 \
   }
 
+#define TERNARY_UNIT_TEST(VEC)                                          \
+  TEUCHOS_UNIT_TEST( VEC, ternay) {                                     \
+    UTS setup;                                                          \
+    UTS::vec_type u = std::sin(setup.x);                                \
+    UTS::vec_type v = -std::sin(setup.x);                               \
+    u = u >= 0 ? -u : u;                                                 \
+    success = compareVecs(u, "u", v, "v",                               \
+                          setup.rtol, setup.atol, out);                 \
+  }
+
 #define VECTOR_UNIT_TESTS(VEC)                                  \
   UNARY_UNIT_TEST(VEC, +, UnaryPlus)                            \
   UNARY_UNIT_TEST(VEC, -, UnaryMinus)                           \
@@ -434,6 +444,7 @@ struct UnitTestSetup {
   OPASSIGN_UNIT_TEST(VEC, /=, DivideEqual)                      \
                                                                 \
   SAXPY_UNIT_TEST(VEC)                                          \
+  TERNARY_UNIT_TEST(VEC)                                        \
                                                                 \
   TEUCHOS_UNIT_TEST( VEC, initializer_list_copy ) {                     \
     UTS setup;                                                          \


### PR DESCRIPTION
This marks all unary operation constructors for
expression-template-based Sacado/Stokhos scalar types explicit,
preventing implicit conversions to these types.  An implicit conversion
to an expression template class should never happen, so this should have
been added a long time ago.  It also fixes compiler errors when using
the ternary operator with scalars and unary expressions, such as

conditional ? scalar : unary-expression ;

by preventing a possible implicit conversion of scalar to
unary-expression, and without having to put an explicit conversion to
scalar in the code.  Note that ternary involving two expressions
e.g., "conditional ? expression1 : expression2 ;" still
won't work because of limitations in the standard.

Related to Kokkos PR [512](https://github.com/kokkos/kokkos-kernels/pull/512)