### PR TITLE
ATDM: Disable all Ansazi and Piro tests, troublesome Belos tests related to ATDM (ATDV-261)

### DIFF
--- a/cmake/std/atdm/ATDMDisables.cmake
+++ b/cmake/std/atdm/ATDMDisables.cmake
@@ -68,11 +68,13 @@ IF (NOT ATDM_ENABLE_SPARC_SETTINGS)
   # at a time in an orderly fashion.
 ENDIF()
 
-# Disable MueLu for all cuda+complex builds for now since there are build
-# errors in the MueLu library that takes out everything downstream that
-# depends on MueLu (see #4599).
 IF (ATDM_USE_CUDA AND ATDM_COMPLEX)
+
+  # Disable MueLu for all cuda+complex builds for now since there are build
+  # errors in the MueLu library that takes out everything downstream that
+  # depends on MueLu (see #4599).
   ATDM_SET_ENABLE(Trilinos_ENABLE_MueLu OFF)
+
 ENDIF()
 
 
@@ -102,7 +104,9 @@ SET(ATDM_SE_PACKAGE_TEST_DISABLES
   Pamgen
   Ifpack
   ML
+  Anasazi
   Intrepid
+  Piro
   )
 
 #
@@ -196,6 +200,15 @@ ATDM_SET_ENABLE(Teko_ModALPreconditioner_MPI_1_DISABLE ON)
 # int instatiation (see #5411)
 ATDM_SET_ENABLE(Zoltan2_XpetraEpetraMatrix_EXE_DISABLE ON)
 ATDM_SET_ENABLE(Zoltan2_XpetraEpetraMatrix_MPI_4_DISABLE ON)
+
+# Diable experimental Belos HybridGMES tests in all ATDM Trilinos builds as
+# none of the ATDM customer codes are using this solver (see #4159)
+ATDM_SET_ENABLE(Belos_Tpetra_HybridGMRES_hb_test_1_MPI_4_DISABLE ON)
+ATDM_SET_ENABLE(Belos_Tpetra_HybridGMRES_hb_test_0_MPI_4_DISABLE ON)
+
+# Disable test for Belos recycling CG solver that is not used by ATDM APPs
+# (see #2919)
+ATDM_SET_ENABLE(Belos_rcg_hb_MPI_4_DISABLE ON)
 
 # Disable Piro_ThyraSolver exec that does not build with no global int
 # instantiation (see #5412)

--- a/cmake/std/atdm/shiller/tweaks/CUDA_COMMON_TWEAKS.cmake
+++ b/cmake/std/atdm/shiller/tweaks/CUDA_COMMON_TWEAKS.cmake
@@ -3,12 +3,3 @@ ATDM_SET_ENABLE(PanzerAdaptersSTK_MixedPoissonExample-ConvTest-Hex-Order-3_DISAB
 
 # Disable test that consistantly times out at 10 minutes (#3579)
 ATDM_SET_ENABLE(PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-4_DISABLE ON)
-
-# Disable test that times out after 10 minutes (#2455)
-ATDM_SET_ENABLE(Anasazi_Epetra_BlockDavidson_auxtest_MPI_4_DISABLE ON)
-
-# Disable test takes a long time to complete for some reason (#2455)
-ATDM_SET_ENABLE(Anasazi_Epetra_LOBPCG_auxtest_MPI_4_DISABLE ON)
-
-# Disable expensive test that started timing out (#2919)
-ATDM_SET_ENABLE(Belos_rcg_hb_MPI_4_DISABLE ON)

--- a/cmake/std/atdm/shiller/tweaks/GNU_DEBUG_SERIAL_HSW.cmake
+++ b/cmake/std/atdm/shiller/tweaks/GNU_DEBUG_SERIAL_HSW.cmake
@@ -1,14 +1,5 @@
-# Disable test that times out after 10 minutes (#2455)
-ATDM_SET_ENABLE(Anasazi_Epetra_BlockDavidson_auxtest_MPI_4_DISABLE ON)
-
-# Disable test takes a long time to complete for some reason (#2455)
-ATDM_SET_ENABLE(Anasazi_Epetra_LOBPCG_auxtest_MPI_4_DISABLE ON)
-
 # Disable test that times out for some unkown reason (#2925)
 ATDM_SET_ENABLE(Stratimikos_test_aztecoo_thyra_driver_MPI_1_DISABLE ON)
-
-# Disable expensive test that started timing out (#2919)
-ATDM_SET_ENABLE(Belos_rcg_hb_MPI_4_DISABLE ON)
 
 # Disable some unit tests that run too slow in this DEBUG build (#2827)
 ATDM_SET_CACHE(KokkosKernels_sparse_serial_MPI_1_EXTRA_ARGS

--- a/cmake/std/atdm/shiller/tweaks/GNU_RELEASE_SERIAL_HSW.cmake
+++ b/cmake/std/atdm/shiller/tweaks/GNU_RELEASE_SERIAL_HSW.cmake
@@ -1,11 +1,2 @@
-# Disable test that times out after 10 minutes (#2455)
-ATDM_SET_ENABLE(Anasazi_Epetra_BlockDavidson_auxtest_MPI_4_DISABLE ON)
-
-# Disable test takes a long time to complete for some reason (#2455)
-ATDM_SET_ENABLE(Anasazi_Epetra_LOBPCG_auxtest_MPI_4_DISABLE ON)
-
 # Disable test that times out randomly for some unkown reason (#2925)
 ATDM_SET_ENABLE(Stratimikos_test_aztecoo_thyra_driver_MPI_1_DISABLE ON)
-
-# Disable expensive test that started timing out (#2919)
-ATDM_SET_ENABLE(Belos_rcg_hb_MPI_4_DISABLE ON)


### PR DESCRIPTION
This is an attempt to reduce the cost of maintaining the ATDM Trillinos builds
by not taking time to triage failing tests that don't protect functionality
used by the ATDM APPs.  In the past, we were asked to test more functionality
than is used by ATDM but we have to cut down on the cost of maintaining these
builds and disabling these tests is an easy way to do that that will not
negatively impact ATDM.

For more details, see [ATDV-261|https://sems-atlassian-srn.sandia.gov/browse/ATDV-261].

## How was this tested?

On my RHEL 6 machine I tested the disables with:

```
$ cd /home/rabartl/Trilinos.base/BUILDS/ATDM/SEMS-RHEL6/CHECKIN/

$ ./checkin-test-atdm.sh gnu-openmp-opt --enable-all-packages=on --configure
```

The configure output showed:

```
$ grep "Final set of enabled packages" gnu-openmp-opt/configure.out 
Final set of enabled packages:  TrilinosFrameworkTests Gtest Kokkos Teuchos KokkosKernels RTOp Sacado Epetra Zoltan Shards Triutils EpetraExt Tpetra TrilinosSS Thyra Xpetra AztecOO Galeri Amesos Pamgen Zoltan2 Ifpack ML Belos Amesos2 SEACAS Anasazi Ifpack2 Stratimikos Teko Intrepid Intrepid2 STK Percept Phalanx NOX MueLu Rythmos Tempus Piro Panzer 41

$ grep "Processing enabled package: Anasazi" gnu-openmp-opt/configure.out 
Processing enabled package: Anasazi (Libs)

$ grep "Processing enabled package: Piro" gnu-openmp-opt/configure.out 
Processing enabled package: Piro (Libs)

$ grep "Belos_Tpetra_HybridGMRES_hb_test_" gnu-openmp-opt/configure.out 
-- Setting default Belos_Tpetra_HybridGMRES_hb_test_1_MPI_4_DISABLE=ON
-- Setting default Belos_Tpetra_HybridGMRES_hb_test_0_MPI_4_DISABLE=ON
-- Belos_Tpetra_HybridGMRES_hb_test_0_MPI_4: NOT added test because Belos_Tpetra_HybridGMRES_hb_test_0_MPI_4_DISABLE='ON'!
-- Belos_Tpetra_HybridGMRES_hb_test_1_MPI_4: NOT added test because Belos_Tpetra_HybridGMRES_hb_test_1_MPI_4_DISABLE='ON'!
-- Belos_Tpetra_HybridGMRES_hb_test_2_MPI_4: Added test (BASIC, NUM_MPI_PROCS=4, PROCESSORS=4)!

$ grep "Belos_rcg_hb_MPI_4" gnu-openmp-opt/configure.out 
-- Setting default Belos_rcg_hb_MPI_4_DISABLE=ON
-- Belos_rcg_hb_MPI_4: NOT added test because Belos_rcg_hb_MPI_4_DISABLE='ON'!
```

That looks correct :-)

Now to ensure that a lot of tests have still been enabled:

```
$ cd gnu-openmp-opt/

$ . load-env.sh 
Hostname 'crf450.srn.sandia.gov' matches known ATDM host 'sems-rhel6' and system 'sems-rhel6'
Setting compiler and build options for build-name 'gnu-openmp-opt'
Using SEMS RHEL6 compiler stack GNU-7.2.0 to build RELEASE code with Kokkos node type OPENMP

$ ctest -N | grep "Total Tests"

...

Total Tests: 1949
```

The set of enabled tests looks about right.
