### PR TITLE
MueLu: removing shadow type declaration for gcc/8.3 build see issue #6295

### DIFF
--- a/packages/belos/src/BelosStatusTestGenResSubNorm.hpp
+++ b/packages/belos/src/BelosStatusTestGenResSubNorm.hpp
@@ -794,7 +794,6 @@ class StatusTestGenResSubNorm<ScalarType,Thyra::MultiVectorBase<ScalarType>,Thyr
 
     Teuchos::RCP<const MV> thySubVec = thyProdVec->getMultiVectorBlock(block);
 
-    typedef MultiVecTraits<ScalarType, MV> MVT;
     MVT::MvNorm(*thySubVec,normVec,type);
   }
 

--- a/packages/muelu/adapters/belos/BelosXpetraStatusTestGenResSubNorm.hpp
+++ b/packages/muelu/adapters/belos/BelosXpetraStatusTestGenResSubNorm.hpp
@@ -612,7 +612,6 @@ class StatusTestGenResSubNorm<Scalar,Xpetra::MultiVector<Scalar,LocalOrdinal,Glo
     Teuchos::RCP<const MV> input = Teuchos::rcpFromRef(mv);
 
     Teuchos::RCP<const MV> SubVec = mapExtractor_->ExtractVector(input, block);
-    typedef MultiVecTraits<Scalar, MV> MVT;
     MVT::MvNorm(*SubVec,normVec,type);
   }
 

--- a/packages/muelu/src/Graph/MueLu_AggregationAlgorithmBase_kokkos.hpp
+++ b/packages/muelu/src/Graph/MueLu_AggregationAlgorithmBase_kokkos.hpp
@@ -73,9 +73,7 @@ namespace MueLu {
 #undef MUELU_AGGREGATIONALGORITHMBASE_KOKKOS_SHORT
 #include "MueLu_UseShortNamesOrdinal.hpp"
     public:
-
-    using execution_space = typename LWGraph_kokkos::execution_space;
-    using memory_space    = typename LWGraph_kokkos::memory_space;
+    using memory_space = typename LWGraph_kokkos::memory_space;
 
     //! @name Constructors/Destructors
     //@{

--- a/packages/muelu/src/Graph/StructuredAggregation/MueLu_AggregationStructuredAlgorithm_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/StructuredAggregation/MueLu_AggregationStructuredAlgorithm_kokkos_decl.hpp
@@ -80,16 +80,16 @@ namespace MueLu {
 
   public:
 
-    typedef typename LWGraph_kokkos::local_graph_type local_graph_type;
-    typedef typename local_graph_type::row_map_type::non_const_type non_const_row_map_type;
-    typedef typename local_graph_type::size_type size_type;
-    typedef typename local_graph_type::entries_type entries_type;
-    typedef typename local_graph_type::device_type::execution_space execution_space;
-    typedef typename local_graph_type::device_type::memory_space memory_space;
+    using local_graph_type       = typename LWGraph_kokkos::local_graph_type;
+    using non_const_row_map_type = typename local_graph_type::row_map_type::non_const_type;
+    using size_type              = typename local_graph_type::size_type;
+    using entries_type           = typename local_graph_type::entries_type;
+    using execution_space        = typename local_graph_type::device_type::execution_space;
+    using memory_space           = typename local_graph_type::device_type::memory_space;
 
-    typedef decltype(std::declval<LOVector>().template getLocalView<memory_space>()) LOVectorView;
-    typedef typename Kokkos::View<const int[3], memory_space> constIntTupleView;
-    typedef typename Kokkos::View<const LO[3],  memory_space> constLOTupleView;
+    using LOVectorView      = decltype(std::declval<LOVector>().template getLocalView<memory_space>());
+    using constIntTupleView = typename Kokkos::View<const int[3], memory_space>;
+    using constLOTupleView  = typename Kokkos::View<const LO[3],  memory_space>;
 
     //! @name Constructors/Destructors.
     //@{

--- a/packages/muelu/src/Graph/StructuredAggregation/MueLu_AggregationStructuredAlgorithm_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/StructuredAggregation/MueLu_AggregationStructuredAlgorithm_kokkos_def.hpp
@@ -120,8 +120,6 @@ namespace MueLu {
       out = Teuchos::getFancyOStream(rcp(new Teuchos::oblackholestream()));
     }
 
-    typedef typename CrsGraph::local_graph_type local_graph_type;
-
     // Compute the number of coarse points needed to interpolate quantities to a fine point
     int numInterpolationPoints = 0;
     if(geoData->getInterpolationOrder() == 0) {

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase1Algorithm_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase1Algorithm_kokkos_decl.hpp
@@ -92,7 +92,8 @@ namespace MueLu {
 #include "MueLu_UseShortNamesOrdinal.hpp"
 
   public:
-    using memory_space = typename LWGraph_kokkos::memory_space;
+    using execution_space = typename LWGraph_kokkos::execution_space;
+    using memory_space    = typename LWGraph_kokkos::memory_space;
 
     //! @name Constructors/Destructors.
     //@{

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase1Algorithm_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase1Algorithm_kokkos_def.hpp
@@ -76,8 +76,6 @@ namespace MueLu {
                   Kokkos::View<unsigned*, typename LWGraph_kokkos::memory_space>& aggStat,
                   LO& numNonAggregatedNodes) const {
 
-    using memory_space = typename LWGraph_kokkos::memory_space;
-
     int minNodesPerAggregate    = params.get<int>        ("aggregation: min agg size");
     int maxNodesPerAggregate    = params.get<int>        ("aggregation: max agg size");
 
@@ -111,9 +109,6 @@ namespace MueLu {
                         Kokkos::View<unsigned*, typename LWGraph_kokkos::memory_space>& aggStat,
                         LO& numNonAggregatedNodes) const
   {
-    using memory_space    = typename LWGraph_kokkos::memory_space;
-    using execution_space = typename LWGraph_kokkos::execution_space;
-
     const LO  numRows = graph.GetNodeNumVertices();
     const int myRank  = graph.GetComm()->getRank();
 
@@ -215,10 +210,6 @@ namespace MueLu {
                                Kokkos::View<unsigned*, typename LWGraph_kokkos::memory_space>& aggStat,
                                LO& numNonAggregatedNodes) const
   {
-    using graph_t         = typename LWGraph_kokkos::local_graph_type;
-    using memory_space    = typename graph_t::device_type::memory_space;
-    using execution_space = typename graph_t::device_type::execution_space;
-
     const LO  numRows = graph.GetNodeNumVertices();
     const int myRank  = graph.GetComm()->getRank();
 

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2aAlgorithm_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2aAlgorithm_kokkos_decl.hpp
@@ -90,7 +90,8 @@ namespace MueLu {
 #include "MueLu_UseShortNamesOrdinal.hpp"
 
   public:
-    using memory_space = typename LWGraph_kokkos::memory_space;
+    using execution_space = typename LWGraph_kokkos::execution_space;
+    using memory_space    = typename LWGraph_kokkos::memory_space;
 
     //! @name Constructors/Destructors.
     //@{

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2aAlgorithm_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2aAlgorithm_kokkos_def.hpp
@@ -90,9 +90,6 @@ namespace MueLu {
                         Kokkos::View<unsigned*, typename LWGraph_kokkos::memory_space>& aggStat,
                         LO& numNonAggregatedNodes) const
   {
-    using memory_space    = typename LWGraph_kokkos::memory_space;
-    using execution_space = typename LWGraph_kokkos::execution_space;
-
     const int minNodesPerAggregate = params.get<int>("aggregation: min agg size");
     const int maxNodesPerAggregate = params.get<int>("aggregation: max agg size");
 
@@ -202,9 +199,6 @@ namespace MueLu {
                                Kokkos::View<unsigned*, typename LWGraph_kokkos::memory_space>& aggStat,
                                LO& numNonAggregatedNodes) const
   {
-    using memory_space    = typename LWGraph_kokkos::memory_space;
-    using execution_space = typename LWGraph_kokkos::execution_space;
-
     const int minNodesPerAggregate = params.get<int>("aggregation: min agg size");
     const int maxNodesPerAggregate = params.get<int>("aggregation: max agg size");
 

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2bAlgorithm_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2bAlgorithm_kokkos_decl.hpp
@@ -89,6 +89,9 @@ namespace MueLu {
 #include "MueLu_UseShortNamesOrdinal.hpp"
 
   public:
+    using execution_space = typename LWGraph_kokkos::execution_space;
+    using memory_space    = typename LWGraph_kokkos::memory_space;
+
     //! @name Constructors/Destructors.
     //@{
 

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2bAlgorithm_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase2bAlgorithm_kokkos_def.hpp
@@ -89,8 +89,6 @@ namespace MueLu {
                         Aggregates_kokkos& aggregates,
                         Kokkos::View<unsigned*, typename LWGraph_kokkos::memory_space>& aggStat,
                         LO& numNonAggregatedNodes) const {
-    using memory_space    = typename LWGraph_kokkos::memory_space;
-    using execution_space = typename LWGraph_kokkos::execution_space;
 
     const LO  numRows = graph.GetNodeNumVertices();
     const int myRank  = graph.GetComm()->getRank();
@@ -193,8 +191,6 @@ namespace MueLu {
                                Aggregates_kokkos& aggregates,
                                Kokkos::View<unsigned*, typename LWGraph_kokkos::memory_space>& aggStat,
                                LO& numNonAggregatedNodes) const {
-    using memory_space    = typename LWGraph_kokkos::memory_space;
-    using execution_space = typename LWGraph_kokkos::execution_space;
 
     const LO  numRows = graph.GetNodeNumVertices();
     const int myRank  = graph.GetComm()->getRank();

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase3Algorithm_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase3Algorithm_kokkos_decl.hpp
@@ -85,7 +85,9 @@ namespace MueLu {
 #include "MueLu_UseShortNamesOrdinal.hpp"
 
   public:
+    using execution_space = typename LWGraph_kokkos::execution_space;
     using memory_space    = typename LWGraph_kokkos::memory_space;
+
     //! @name Constructors/Destructors.
     //@{
 

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase3Algorithm_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_AggregationPhase3Algorithm_kokkos_def.hpp
@@ -94,8 +94,6 @@ namespace MueLu {
                         Aggregates_kokkos& aggregates,
                         Kokkos::View<unsigned*, typename LWGraph_kokkos::memory_space>& aggStat,
                         LO& numNonAggregatedNodes) const {
-    using memory_space    = typename LWGraph_kokkos::memory_space;
-    using execution_space = typename LWGraph_kokkos::execution_space;
 
     bool makeNonAdjAggs = false;
     bool error_on_isolated = false;

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_IsolatedNodeAggregationAlgorithm_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_IsolatedNodeAggregationAlgorithm_kokkos_decl.hpp
@@ -87,6 +87,7 @@ namespace MueLu {
 #include "MueLu_UseShortNamesOrdinal.hpp"
 
   public:
+    using memory_space = typename LWGraph_kokkos::memory_space;
     //! @name Constructors/Destructors.
     //@{
 

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_IsolatedNodeAggregationAlgorithm_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_IsolatedNodeAggregationAlgorithm_kokkos_def.hpp
@@ -71,8 +71,6 @@ namespace MueLu {
                   LO& numNonAggregatedNodes) const {
     Monitor m(*this, "BuildAggregates");
 
-    using memory_space = typename LWGraph_kokkos::memory_space;
-
     typename Kokkos::View<unsigned*, memory_space>::HostMirror aggstatHost
       = Kokkos::create_mirror(aggstat);
     Kokkos::deep_copy(aggstatHost, aggstat);

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_OnePtAggregationAlgorithm_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_OnePtAggregationAlgorithm_kokkos_decl.hpp
@@ -86,6 +86,7 @@ namespace MueLu {
 #include "MueLu_UseShortNamesOrdinal.hpp"
 
   public:
+    using memory_space = typename LWGraph_kokkos::memory_space;
     //! @name Constructors/Destructors.
     //@{
 

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_OnePtAggregationAlgorithm_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_OnePtAggregationAlgorithm_kokkos_def.hpp
@@ -76,8 +76,6 @@ namespace MueLu {
                   LO& numNonAggregatedNodes) const {
     Monitor m(*this, "BuildAggregates");
 
-    using memory_space = typename LWGraph_kokkos::memory_space;
-
     typename Kokkos::View<unsigned*, memory_space>::HostMirror aggstatHost
       = Kokkos::create_mirror(aggstat);
     Kokkos::deep_copy(aggstatHost, aggstat);

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_PreserveDirichletAggregationAlgorithm_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_PreserveDirichletAggregationAlgorithm_kokkos_decl.hpp
@@ -92,8 +92,8 @@ namespace MueLu {
 #include "MueLu_UseShortNamesOrdinal.hpp"
 
   public:
-
-    using memory_space = typename LWGraph_kokkos::memory_space;
+    using execution_space = typename LWGraph_kokkos::execution_space;
+    using memory_space    = typename LWGraph_kokkos::memory_space;
 
     //! @name Constructors/Destructors.
     //@{

--- a/packages/muelu/src/Graph/UncoupledAggregation/MueLu_PreserveDirichletAggregationAlgorithm_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/UncoupledAggregation/MueLu_PreserveDirichletAggregationAlgorithm_kokkos_def.hpp
@@ -70,8 +70,6 @@ namespace MueLu {
                   Kokkos::View<unsigned*, typename LWGraph_kokkos::memory_space>& aggStat,
                   LO& numNonAggregatedNodes) const {
     Monitor m(*this, "BuildAggregates");
-    using memory_space       = typename LWGraph_kokkos::memory_space;
-    using execution_space    = typename LWGraph_kokkos::execution_space;
     using local_ordinal_type = typename LWGraph_kokkos::local_ordinal_type;
 
     // Extract parameters and data from:

--- a/packages/muelu/src/Interface/MueLu_HierarchyManager.hpp
+++ b/packages/muelu/src/Interface/MueLu_HierarchyManager.hpp
@@ -394,10 +394,6 @@ namespace MueLu {
     // For dumping an IntrepidPCoarsening element-to-node map to disk
     template<class T>
     void WriteFieldContainer(const std::string& fileName, T & fcont,const Map &colMap) const {
-      typedef LocalOrdinal LO;
-      typedef GlobalOrdinal GO;
-      typedef Node NO;
-      typedef Xpetra::MultiVector<GO,LO,GO,NO> GOMultiVector;
 
       size_t num_els = (size_t) fcont.extent(0);
       size_t num_vecs =(size_t) fcont.extent(1);

--- a/packages/muelu/src/Misc/MueLu_BlockedCoordinatesTransferFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_BlockedCoordinatesTransferFactory_def.hpp
@@ -89,9 +89,8 @@ namespace MueLu {
   void BlockedCoordinatesTransferFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Build(Level & /* fineLevel */, Level &coarseLevel) const {
     FactoryMonitor m(*this, "Build", coarseLevel);
 
-    typedef Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::magnitudeType,LO,GO,NO> dMV;
-    typedef Xpetra::BlockedMultiVector<typename Teuchos::ScalarTraits<Scalar>::magnitudeType,LO,GO,NO> dBV;
-    typedef Xpetra::BlockedMap<LO,GO,NO> BlockedMap;
+    typedef Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::coordinateType,LO,GO,NO> dMV;
+    typedef Xpetra::BlockedMultiVector<typename Teuchos::ScalarTraits<Scalar>::coordinateType,LO,GO,NO> dBV;
 
     GetOStream(Runtime0) << "Transferring (blocked) coordinates" << std::endl;
 
@@ -110,9 +109,9 @@ namespace MueLu {
       const RCP<const FactoryBase>& myFactory = subFactories_[i];
       myFactory->CallBuild(coarseLevel);
       subBlockCoords[i] = coarseLevel.Get<RCP<dMV> >("Coordinates", myFactory.get());
-      //      subBlockMaps[i]   = subBlockCoords[i]->getMap();      
+      //      subBlockMaps[i]   = subBlockCoords[i]->getMap();
     }
-    
+
     // Blocked Map
     RCP<const BlockedMap> coarseMap = Get< RCP<const BlockedMap> >(coarseLevel, "CoarseMap");
 
@@ -120,7 +119,7 @@ namespace MueLu {
     RCP<dBV> bcoarseCoords = rcp(new dBV(coarseMap,subBlockCoords));
 
     // Turn the blocked coordinates vector into an unblocked one
-    RCP<dMV> coarseCoords = bcoarseCoords->Merge();   
+    RCP<dMV> coarseCoords = bcoarseCoords->Merge();
     Set<RCP<dMV> >(coarseLevel, "Coordinates", coarseCoords);
   }
 

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_kokkos_decl.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_kokkos_decl.hpp
@@ -114,7 +114,7 @@ namespace MueLu {
     typedef typename DeviceType::execution_space                     execution_space;
     typedef Kokkos::RangePolicy<local_ordinal_type, execution_space> range_type;
     typedef Kokkos::Compat::KokkosDeviceWrapperNode<DeviceType>      node_type;
-    typedef typename Teuchos::ScalarTraits<Scalar>::magnitudeType    real_type;
+    typedef typename Teuchos::ScalarTraits<Scalar>::coordinateType   real_type;
     typedef Xpetra::MultiVector<real_type, LocalOrdinal, GlobalOrdinal, node_type> RealValuedMultiVector;
 
   private:

--- a/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_kokkos_def.hpp
+++ b/packages/muelu/src/Transfers/Smoothed-Aggregation/MueLu_TentativePFactory_kokkos_def.hpp
@@ -436,7 +436,6 @@ namespace MueLu {
     FactoryMonitor m(*this, "Build", coarseLevel);
 
     typedef typename Teuchos::ScalarTraits<Scalar>::coordinateType coordinate_type;
-    typedef Xpetra::MultiVector<coordinate_type,LO,GO,NO> RealValuedMultiVector;
     typedef Xpetra::MultiVectorFactory<coordinate_type,LO,GO,NO> RealValuedMultiVectorFactory;
     const ParameterList& pL = GetParameterList();
     std::string nspName = "Nullspace";

--- a/packages/muelu/test/unit_tests/MueLu_TestHelpers.hpp
+++ b/packages/muelu/test/unit_tests/MueLu_TestHelpers.hpp
@@ -589,13 +589,6 @@ namespace MueLuTests {
       }
 
       static Teuchos::RCP<Xpetra::BlockedCrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > CreateBlockDiagonalExampleMatrix(Xpetra::UnderlyingLib lib, int noBlocks, Teuchos::RCP<const Teuchos::Comm<int> > comm) {
-        typedef Xpetra::Map<LocalOrdinal,GlobalOrdinal,Node> Map;
-        typedef Xpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> CrsMatrix;
-        typedef Xpetra::CrsMatrixFactory<Scalar,LocalOrdinal,GlobalOrdinal,Node> CrsMatrixFactory;
-        typedef Xpetra::MapExtractor<Scalar,LocalOrdinal,GlobalOrdinal,Node> MapExtractor;
-        typedef Xpetra::BlockedCrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> BlockedCrsMatrix;
-        typedef Xpetra::CrsMatrixWrap<Scalar,LocalOrdinal,GlobalOrdinal,Node> CrsMatrixWrap;
-
         GlobalOrdinal nOverallDOFGidsPerProc = Teuchos::as<GlobalOrdinal>(Teuchos::ScalarTraits<GlobalOrdinal>::pow(2,noBlocks-2)) * 10;
 
         GlobalOrdinal procOffset = comm->getRank() * nOverallDOFGidsPerProc;
@@ -660,13 +653,6 @@ namespace MueLuTests {
       }
 
       static Teuchos::RCP<Xpetra::BlockedCrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > CreateBlockDiagonalExampleMatrixThyra(Xpetra::UnderlyingLib lib, int noBlocks, Teuchos::RCP<const Teuchos::Comm<int> > comm) {
-        typedef Xpetra::Map<LocalOrdinal,GlobalOrdinal,Node> Map;
-        typedef Xpetra::MapFactory<LocalOrdinal,GlobalOrdinal,Node> MapFactory;
-        typedef Xpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> CrsMatrix;
-        typedef Xpetra::CrsMatrixFactory<Scalar,LocalOrdinal,GlobalOrdinal,Node> CrsMatrixFactory;
-        typedef Xpetra::MapExtractor<Scalar,LocalOrdinal,GlobalOrdinal,Node> MapExtractor;
-        typedef Xpetra::BlockedCrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> BlockedCrsMatrix;
-        typedef Xpetra::CrsMatrixWrap<Scalar,LocalOrdinal,GlobalOrdinal,Node> CrsMatrixWrap;
 
         std::vector<Teuchos::RCP<const Map> > maps(noBlocks, Teuchos::null);
 
@@ -711,10 +697,6 @@ namespace MueLuTests {
       }
 
       static Teuchos::RCP<Xpetra::BlockedCrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> > CreateBlocked3x3MatrixThyra(const Teuchos::Comm<int>& comm, Xpetra::UnderlyingLib lib) {
-        typedef Xpetra::Map<LocalOrdinal,GlobalOrdinal,Node> Map;
-        typedef Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> Matrix;
-        typedef Xpetra::MapExtractor<Scalar,LocalOrdinal,GlobalOrdinal,Node> MapExtractor;
-        typedef Xpetra::BlockedCrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> BlockedCrsMatrix;
 
         std::vector<RCP<const Map> > maps = std::vector<RCP<const Map> >(3, Teuchos::null);
         maps[0] = TestHelpers::TestFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::BuildMap(100);

--- a/packages/xpetra/src/BlockedCrsMatrix/Xpetra_MapExtractor_def.hpp
+++ b/packages/xpetra/src/BlockedCrsMatrix/Xpetra_MapExtractor_def.hpp
@@ -187,9 +187,6 @@ namespace Xpetra {
     MapExtractor<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     ExtractVector(RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& full, size_t block, bool bThyraMode) const
     {
-        using Vector        = Xpetra::Vector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
-        using VectorFactory = Xpetra::VectorFactory<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
-
         XPETRA_TEST_FOR_EXCEPTION(block >= map_->getNumMaps(),
                                   std::out_of_range,
                                   "ExtractVector: Error, block = " << block << " is too big. The MapExtractor only contains " << map_->getNumMaps()
@@ -215,9 +212,6 @@ namespace Xpetra {
     MapExtractor<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     ExtractVector(RCP<const Xpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> >& full, size_t block, bool bThyraMode) const
     {
-        using BlockedMultiVector = Xpetra::BlockedMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
-        using MultiVectorFactory = Xpetra::MultiVectorFactory<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
-
         XPETRA_TEST_FOR_EXCEPTION(block >= map_->getNumMaps(),
                                   std::out_of_range,
                                   "ExtractVector: Error, block = " << block << " is too big. The MapExtractor only contains " << map_->getNumMaps()
@@ -266,10 +260,6 @@ namespace Xpetra {
     MapExtractor<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     ExtractVector(RCP<Xpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> >& full, size_t block, bool bThyraMode) const
     {
-        using MultiVector        = Xpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
-        using BlockedMultiVector = Xpetra::BlockedMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
-        using MultiVectorFactory = Xpetra::MultiVectorFactory<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
-
         XPETRA_TEST_FOR_EXCEPTION(block >= map_->getNumMaps(),
                                   std::out_of_range,
                                   "ExtractVector: Error, block = " << block << " is too big. The MapExtractor only contains " << map_->getNumMaps()
@@ -317,8 +307,6 @@ namespace Xpetra {
     MapExtractor<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     ExtractVector(RCP<const Xpetra::BlockedMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node> >& full, size_t block, bool bThyraMode) const
     {
-        using MultiVector        = Xpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
-
         XPETRA_TEST_FOR_EXCEPTION(block >= map_->getNumMaps(),
                                   std::out_of_range,
                                   "ExtractVector: Error, block = " << block << " is too big. The MapExtractor only contains " << map_->getNumMaps()
@@ -340,8 +328,6 @@ namespace Xpetra {
     MapExtractor<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     ExtractVector(RCP<Xpetra::BlockedMultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>>& full, size_t block, bool bThyraMode) const
     {
-        using MultiVector        = Xpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
-
         XPETRA_TEST_FOR_EXCEPTION(block >= map_->getNumMaps(),
                                   std::out_of_range,
                                   "ExtractVector: Error, block = " << block << " is too big. The MapExtractor only contains " << map_->getNumMaps()
@@ -363,9 +349,6 @@ namespace Xpetra {
     MapExtractor<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     InsertVector(const Xpetra::Vector<Scalar,LocalOrdinal,GlobalOrdinal,Node>& partial, size_t block, Vector& full, bool bThyraMode) const
     {
-        using Map                = Xpetra::Map<LocalOrdinal,GlobalOrdinal,Node>;
-        using MultiVector        = Xpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
-
         XPETRA_TEST_FOR_EXCEPTION(block >= map_->getNumMaps(),
                                   std::out_of_range,
                                   "ExtractVector: Error, block = " << block << " is too big. The MapExtractor only contains " << map_->getNumMaps()
@@ -424,9 +407,6 @@ namespace Xpetra {
     MapExtractor<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     InsertVector(const Xpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>& partial, size_t block, MultiVector& full, bool bThyraMode) const
     {
-        using Map                = Xpetra::Map<LocalOrdinal,GlobalOrdinal,Node>;
-        using MultiVector        = Xpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
-
         XPETRA_TEST_FOR_EXCEPTION(block >= map_->getNumMaps(),
                                   std::out_of_range,
                                   "ExtractVector: Error, block = " << block << " is too big. The MapExtractor only contains " << map_->getNumMaps()
@@ -507,8 +487,6 @@ namespace Xpetra {
                  RCP<Xpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>> full,
                  bool bThyraMode) const
     {
-        using BlockedMultiVector = Xpetra::BlockedMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
-
         RCP<BlockedMultiVector> bfull = Teuchos::rcp_dynamic_cast<BlockedMultiVector>(full);
         if(bfull.is_null() == true)
             InsertVector(*partial, block, *full, bThyraMode);
@@ -536,8 +514,6 @@ namespace Xpetra {
                  RCP<Xpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>> full,
                  bool bThyraMode) const
     {
-        using BlockedMultiVector = Xpetra::BlockedMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
-
         RCP<BlockedMultiVector> bfull = Teuchos::rcp_dynamic_cast<BlockedMultiVector>(full);
         if(bfull.is_null() == true)
             InsertVector(*partial, block, *full, bThyraMode);
@@ -585,7 +561,6 @@ namespace Xpetra {
     MapExtractor<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     getVector(size_t i, bool bThyraMode, bool bZero) const
     {
-        using VectorFactory = Xpetra::VectorFactory<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
         XPETRA_TEST_FOR_EXCEPTION(map_->getThyraMode() == false && bThyraMode == true,
                                   Xpetra::Exceptions::RuntimeError,
                                   "MapExtractor::getVector: getVector in Thyra-style numbering only possible if MapExtractor has been created using "
@@ -600,8 +575,6 @@ namespace Xpetra {
     MapExtractor<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     getVector(size_t i, size_t numvec, bool bThyraMode, bool bZero) const
     {
-        using MultiVectorFactory = Xpetra::MultiVectorFactory<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
-
         XPETRA_TEST_FOR_EXCEPTION(map_->getThyraMode() == false && bThyraMode == true,
                                   Xpetra::Exceptions::RuntimeError,
                                   "MapExtractor::getVector: getVector in Thyra-style numbering only possible if MapExtractor has been created using "

--- a/packages/xpetra/src/BlockedCrsMatrix/Xpetra_ReorderedBlockedCrsMatrix.hpp
+++ b/packages/xpetra/src/BlockedCrsMatrix/Xpetra_ReorderedBlockedCrsMatrix.hpp
@@ -271,7 +271,6 @@ namespace Xpetra {
 
     /** \brief Print the object with some verbosity level to an FancyOStream object. */
     void describe(Teuchos::FancyOStream& out, const Teuchos::EVerbosityLevel verbLevel = Teuchos::Describable::verbLevel_default) const {
-      typedef Xpetra::BlockedCrsMatrix<Scalar,LocalOrdinal,GlobalOrdinal,Node> BlockedCrsMatrix;
 
       out << "Xpetra::ReorderedBlockedCrsMatrix: " << BlockedCrsMatrix::Rows() << " x " << BlockedCrsMatrix::Cols() << std::endl;
 

--- a/packages/xpetra/src/BlockedVector/Xpetra_BlockedVector_decl.hpp
+++ b/packages/xpetra/src/BlockedVector/Xpetra_BlockedVector_decl.hpp
@@ -71,10 +71,10 @@ class BlockedVector
     , public virtual Xpetra::BlockedMultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>
 {
   public:
-    typedef Scalar        scalar_type;
-    typedef LocalOrdinal  local_ordinal_type;
-    typedef GlobalOrdinal global_ordinal_type;
-    typedef Node          node_type;
+    using scalar_type         = Scalar;
+    using local_ordinal_type  = LocalOrdinal;
+    using global_ordinal_type = GlobalOrdinal;
+    using node_type           = Node;
 
     using Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::dot;                     // overloading, not hiding
     using Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::norm1;                   // overloading, not hiding

--- a/packages/xpetra/src/BlockedVector/Xpetra_BlockedVector_def.hpp
+++ b/packages/xpetra/src/BlockedVector/Xpetra_BlockedVector_def.hpp
@@ -102,7 +102,6 @@ void
 BlockedVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 replaceGlobalValue(GlobalOrdinal globalRow, size_t vectorIndex, const Scalar& value)
 {
-    using BlockedMultiVector = Xpetra::BlockedMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
     BlockedMultiVector::replaceGlobalValue(globalRow, vectorIndex, value);
 }
 
@@ -112,7 +111,6 @@ void
 BlockedVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 sumIntoGlobalValue(GlobalOrdinal globalRow, size_t vectorIndex, const Scalar& value)
 {
-    using BlockedMultiVector = Xpetra::BlockedMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
     BlockedMultiVector::sumIntoGlobalValue(globalRow, vectorIndex, value);
 }
 
@@ -122,7 +120,6 @@ void
 BlockedVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 replaceLocalValue(LocalOrdinal  myRow, size_t vectorIndex, const Scalar& value)
 {
-    using BlockedMultiVector = Xpetra::BlockedMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
     BlockedMultiVector::replaceLocalValue(myRow, vectorIndex, value);
 }
 
@@ -132,7 +129,6 @@ void
 BlockedVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 sumIntoLocalValue(LocalOrdinal  myRow, size_t vectorIndex, const Scalar& value)
 {
-    using BlockedMultiVector = Xpetra::BlockedMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
     BlockedMultiVector::sumIntoLocalValue(myRow, vectorIndex, value);
 }
 
@@ -142,7 +138,6 @@ void
 BlockedVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 replaceGlobalValue(GlobalOrdinal globalRow, const Scalar& value)
 {
-    using BlockedMultiVector = Xpetra::BlockedMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
     BlockedMultiVector::replaceGlobalValue(globalRow, 0, value);
 }
 
@@ -152,7 +147,6 @@ void
 BlockedVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 sumIntoGlobalValue(GlobalOrdinal globalRow, const Scalar& value)
 {
-    using BlockedMultiVector = Xpetra::BlockedMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
     BlockedMultiVector::sumIntoGlobalValue(globalRow, 0, value);
 }
 
@@ -161,7 +155,6 @@ void
 BlockedVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 replaceLocalValue(LocalOrdinal myRow, const Scalar& value)
 {
-    using BlockedMultiVector = Xpetra::BlockedMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
     BlockedMultiVector::replaceLocalValue(myRow, 0, value);
 }
 
@@ -170,7 +163,6 @@ void
 BlockedVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 sumIntoLocalValue(LocalOrdinal myRow, const Scalar& value)
 {
-    using BlockedMultiVector = Xpetra::BlockedMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
     BlockedMultiVector::sumIntoLocalValue(myRow, 0, value);
 }
 
@@ -179,7 +171,6 @@ void
 BlockedVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 putScalar(const Scalar& value)
 {
-    using BlockedMultiVector = Xpetra::BlockedMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
     BlockedMultiVector::putScalar(value);
 }
 
@@ -188,7 +179,6 @@ Teuchos::RCP<const Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>>
 BlockedVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 getVector(size_t j) const
 {
-    using BlockedMultiVector = Xpetra::BlockedMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
     return BlockedMultiVector::getVector(j);
 }
 
@@ -197,7 +187,6 @@ Teuchos::RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>>
 BlockedVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 getVectorNonConst(size_t j)
 {
-    using BlockedMultiVector = Xpetra::BlockedMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
     return BlockedMultiVector::getVectorNonConst(j);
 }
 
@@ -206,7 +195,6 @@ Teuchos::ArrayRCP<const Scalar>
 BlockedVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 getData(size_t j) const
 {
-    using BlockedMultiVector = Xpetra::BlockedMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
     return BlockedMultiVector::getData(j);
 }
 
@@ -215,7 +203,6 @@ Teuchos::ArrayRCP<Scalar>
 BlockedVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 getDataNonConst(size_t j)
 {
-    using BlockedMultiVector = Xpetra::BlockedMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
     return BlockedMultiVector::getDataNonConst(j);
 }
 
@@ -224,7 +211,6 @@ void
 BlockedVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 dot(const MultiVector& A, const Teuchos::ArrayView<Scalar>& dots) const
 {
-    using BlockedMultiVector = Xpetra::BlockedMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
     BlockedMultiVector::dot(A, dots);
     return;
 }
@@ -234,7 +220,6 @@ Scalar
 BlockedVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 dot(const Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& A) const
 {
-    using BlockedMultiVector = Xpetra::BlockedMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
     Teuchos::Array<Scalar> dots = Teuchos::Array<Scalar>(1);
     BlockedMultiVector::dot(A, dots);
     return dots[ 0 ];
@@ -245,7 +230,6 @@ void
 BlockedVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 abs(const Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& A)
 {
-    using BlockedMultiVector = Xpetra::BlockedMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
     BlockedMultiVector::abs(A);
     return;
 }
@@ -255,7 +239,6 @@ void
 BlockedVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 reciprocal(const Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& A)
 {
-    using BlockedMultiVector = Xpetra::BlockedMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
     BlockedMultiVector::reciprocal(A);
     return;
 }
@@ -265,7 +248,6 @@ void
 BlockedVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 scale(const Scalar& alpha)
 {
-    using BlockedMultiVector = Xpetra::BlockedMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
     BlockedMultiVector::scale(alpha);
     return;
 }
@@ -275,7 +257,6 @@ void
 BlockedVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 scale(Teuchos::ArrayView<const Scalar> alpha)
 {
-    using BlockedMultiVector = Xpetra::BlockedMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
     BlockedMultiVector::scale(alpha);
     return;
 }
@@ -287,7 +268,6 @@ update(const Scalar& alpha,
        const Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& A,
        const Scalar& beta)
 {
-    using BlockedMultiVector = Xpetra::BlockedMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
     BlockedMultiVector::update(alpha, A, beta);
     return;
 }
@@ -301,7 +281,6 @@ update(const Scalar&                                                         alp
        const Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& B,
        const Scalar&                                                         gamma)
 {
-    using BlockedMultiVector = Xpetra::BlockedMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
     BlockedMultiVector::update(alpha, A, beta, B, gamma);
     return;
 }
@@ -346,7 +325,6 @@ void
 BlockedVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 norm1(const Teuchos::ArrayView<typename Teuchos::ScalarTraits<Scalar>::magnitudeType>& norms) const
 {
-    using BlockedMultiVector = Xpetra::BlockedMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
     BlockedMultiVector::norm1(norms);
 }
 
@@ -356,7 +334,6 @@ void
 BlockedVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 norm2(const Teuchos::ArrayView<typename Teuchos::ScalarTraits<Scalar>::magnitudeType>& norms) const
 {
-    using BlockedMultiVector = Xpetra::BlockedMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
     BlockedMultiVector::norm2(norms);
 }
 
@@ -366,7 +343,6 @@ void
 BlockedVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 normInf(const Teuchos::ArrayView<typename Teuchos::ScalarTraits<Scalar>::magnitudeType>& norms) const
 {
-    using BlockedMultiVector = Xpetra::BlockedMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
     BlockedMultiVector::normInf(norms);
 }
 
@@ -540,7 +516,6 @@ void
 BlockedVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
 replaceMap(const RCP<const Map>& map)
 {
-    using BlockedMultiVector = Xpetra::BlockedMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
     BlockedMultiVector::replaceMap(map);
 }
 
@@ -671,7 +646,6 @@ Xpetra_randomize()
     BlockedVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     getMultiVector(size_t r) const
     {
-        using BlockedMultiVector = Xpetra::BlockedMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
         return BlockedMultiVector::getMultiVector(r);
     }
 
@@ -681,7 +655,6 @@ Xpetra_randomize()
     BlockedVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     getMultiVector(size_t r, bool bThyraMode) const
     {
-        using BlockedMultiVector = Xpetra::BlockedMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
         return BlockedMultiVector::getMultiVector(r, bThyraMode);
     }
 
@@ -693,7 +666,6 @@ Xpetra_randomize()
                    Teuchos::RCP<const Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > v,
                    bool bThyraMode)
     {
-        using BlockedMultiVector = Xpetra::BlockedMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
         BlockedMultiVector::setMultiVector(r, v, bThyraMode);
         return;
     }
@@ -704,7 +676,6 @@ Xpetra_randomize()
     BlockedVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     Merge() const
     {
-        using BlockedMultiVector = Xpetra::BlockedMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
         return BlockedMultiVector::Merge();
     }
 
@@ -714,7 +685,6 @@ Xpetra_randomize()
     BlockedVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
     assign(const Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& rhs)
     {
-        using BlockedMultiVector = Xpetra::BlockedMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
         BlockedMultiVector::assign(rhs);
     }
 

--- a/packages/xpetra/src/Vector/Xpetra_EpetraVectorFactory.cpp
+++ b/packages/xpetra/src/Vector/Xpetra_EpetraVectorFactory.cpp
@@ -61,11 +61,6 @@ Build(const Teuchos::RCP<const Xpetra::Map<int, int, EpetraNode>>& map, bool zer
 {
     XPETRA_MONITOR("VectorFactory::Build");
 
-    using Scalar        = double;
-    using LocalOrdinal  = int;
-    using GlobalOrdinal = int;
-    using Node          = EpetraNode;
-
     RCP<const Xpetra::BlockedMap<LocalOrdinal, GlobalOrdinal, Node>> 
       bmap = Teuchos::rcp_dynamic_cast<const Xpetra::BlockedMap<LocalOrdinal, GlobalOrdinal, Node>>(map);
 
@@ -102,11 +97,6 @@ Build(const Teuchos::RCP<const Xpetra::Map<int, long long, EpetraNode>>& map, bo
 {
     XPETRA_MONITOR("VectorFactory::Build");
 
-    using Scalar        = double;
-    using LocalOrdinal  = int;
-    using GlobalOrdinal = long long;
-    using Node          = EpetraNode;
-
     RCP<const Xpetra::BlockedMap<LocalOrdinal, GlobalOrdinal, Node>> bmap =
       Teuchos::rcp_dynamic_cast<const Xpetra::BlockedMap<LocalOrdinal, GlobalOrdinal, Node>>(map);
     if(!bmap.is_null())
@@ -142,11 +132,6 @@ Build(const Teuchos::RCP<const Xpetra::Map<int, int, EpetraNode>>& map, bool zer
 {
     XPETRA_MONITOR("VectorFactory::Build");
 
-    using Scalar        = int;
-    using LocalOrdinal  = int;
-    using GlobalOrdinal = int;
-    using Node          = EpetraNode;
-
     RCP<const Xpetra::BlockedMap<LocalOrdinal, GlobalOrdinal, Node>> bmap =
       Teuchos::rcp_dynamic_cast<const Xpetra::BlockedMap<LocalOrdinal, GlobalOrdinal, Node>>(map);
     if(!bmap.is_null())
@@ -180,11 +165,6 @@ VectorFactory<int, int, long long, EpetraNode>::
 Build(const Teuchos::RCP<const Xpetra::Map<int, long long, EpetraNode>>& map, bool zeroOut)
 {
     XPETRA_MONITOR("VectorFactory::Build");
-
-    using Scalar        = int;
-    using LocalOrdinal  = int;
-    using GlobalOrdinal = long long;
-    using Node          = EpetraNode;
 
     RCP<const Xpetra::BlockedMap<LocalOrdinal, GlobalOrdinal, Node>> bmap =
       Teuchos::rcp_dynamic_cast<const Xpetra::BlockedMap<LocalOrdinal, GlobalOrdinal, Node>>(map);

--- a/packages/xpetra/sup/Utils/Xpetra_MatrixUtils.hpp
+++ b/packages/xpetra/sup/Utils/Xpetra_MatrixUtils.hpp
@@ -93,9 +93,6 @@ public:
 
   static Teuchos::RCP<Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > xpetraGidNumbering2ThyraGidNumbering(
       const Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>& input) {
-    typedef Xpetra::MapUtils<LocalOrdinal, GlobalOrdinal, Node>  MapUtils;
-    typedef Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>  MultiVector;
-    typedef Xpetra::MultiVectorFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>  MultiVectorFactory;
     RCP<const Map> map = MapUtils::shrinkMapGIDs(*(input.getMap()),*(input.getMap()));
     RCP<MultiVector> ret = MultiVectorFactory::Build(map, input.getNumVectors(), true);
     for (size_t c = 0; c < input.getNumVectors(); c++) {
@@ -202,10 +199,6 @@ public:
                        Teuchos::RCP<const Xpetra::MapExtractor<Scalar, LocalOrdinal, GlobalOrdinal, Node> > domainMapExtractor,
                        Teuchos::RCP<const Xpetra::MapExtractor<Scalar, LocalOrdinal, GlobalOrdinal, Node> > columnMapExtractor = Teuchos::null,
                        bool bThyraMode = false) {
-    typedef Xpetra::MapUtils<LocalOrdinal, GlobalOrdinal, Node>  MapUtils;
-    typedef Xpetra::MapExtractor<Scalar, LocalOrdinal, GlobalOrdinal, Node> MapExtractor;
-    typedef Xpetra::MapExtractorFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node> MapExtractorFactory;
-    typedef Xpetra::MatrixUtils<Scalar, LocalOrdinal, GlobalOrdinal, Node>  MatrixUtils;
 
     size_t numRows  = rangeMapExtractor->NumMaps();
     size_t numCols  = domainMapExtractor->NumMaps();

--- a/packages/xpetra/sup/Utils/Xpetra_ThyraUtils.hpp
+++ b/packages/xpetra/sup/Utils/Xpetra_ThyraUtils.hpp
@@ -141,11 +141,9 @@ public:
     using Teuchos::RCP;
     using Teuchos::rcp_dynamic_cast;
     using Teuchos::as;
-    typedef Thyra::VectorSpaceBase<Scalar> ThyVecSpaceBase;
-    typedef Thyra::ProductVectorSpaceBase<Scalar> ThyProdVecSpaceBase;
-
-    using Map      = Xpetra::Map<LocalOrdinal,GlobalOrdinal,Node>;
-    using ThyUtils = Xpetra::ThyraUtils<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
+    using ThyVecSpaceBase     = Thyra::VectorSpaceBase<Scalar>;
+    using ThyProdVecSpaceBase = Thyra::ProductVectorSpaceBase<Scalar>;
+    using ThyUtils            = Xpetra::ThyraUtils<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
 
 
     RCP<Map> resultMap = Teuchos::null;
@@ -211,12 +209,7 @@ public:
 
     using ThyMultVecBase     = Thyra::MultiVectorBase<Scalar>;
     using ThyProdMultVecBase = Thyra::ProductMultiVectorBase<Scalar>;
-
-    using Map                = Xpetra::Map<LocalOrdinal,GlobalOrdinal,Node>;
-    using MultiVector        = Xpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
-    using MultiVectorFactory = Xpetra::MultiVectorFactory<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
     using ThyUtils           = Xpetra::ThyraUtils<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
-    using BlockedMultiVector = Xpetra::BlockedMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
 
     // return value
     RCP<MultiVector> xpMultVec = Teuchos::null;
@@ -521,9 +514,6 @@ public:
     //typedef Thyra::ProductVectorSpaceBase<Scalar> ThyProdVecSpaceBase;
     typedef Thyra::ProductMultiVectorBase<Scalar> ThyProdMultVecBase;
 
-    using MultiVector        = Xpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
-    using BlockedMultiVector = Xpetra::BlockedMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
-
 
     // copy data from tY_inout to Y_inout
     RCP<ThyProdMultVecBase> prodTarget = rcp_dynamic_cast<ThyProdMultVecBase>(target);
@@ -793,8 +783,6 @@ public:
     using Teuchos::as;
     typedef Thyra::VectorSpaceBase<Scalar> ThyVecSpaceBase;
     typedef Thyra::ProductVectorSpaceBase<Scalar> ThyProdVecSpaceBase;
-    typedef Xpetra::Map<LocalOrdinal,GlobalOrdinal,Node> Map;
-    typedef Xpetra::MapUtils<LocalOrdinal,GlobalOrdinal,Node> MapUtils;
     typedef Xpetra::ThyraUtils<Scalar,LocalOrdinal,GlobalOrdinal,Node> ThyUtils;
 
     RCP<Map> resultMap = Teuchos::null;
@@ -892,11 +880,7 @@ public:
 
     using ThyProdMultVecBase = Thyra::ProductMultiVectorBase<Scalar>;
     using ThyMultVecBase     = Thyra::MultiVectorBase<Scalar>;
-    using Map                = Xpetra::Map<LocalOrdinal,GlobalOrdinal,Node>;
-    using MultiVector        = Xpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
-    using MultiVectorFactory = Xpetra::MultiVectorFactory<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
     using ThyUtils           = Xpetra::ThyraUtils<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
-    using BlockedMultiVector = Xpetra::BlockedMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
 
     // return value
     RCP<MultiVector> xpMultVec = Teuchos::null;
@@ -1300,7 +1284,6 @@ public:
     //typedef Thyra::SpmdMultiVectorBase<Scalar> ThySpmdMultVecBase;
     //typedef Thyra::ProductVectorSpaceBase<Scalar> ThyProdVecSpaceBase;
     typedef Thyra::ProductMultiVectorBase<Scalar> ThyProdMultVecBase;
-    typedef Xpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node > MultiVector;
 
     // copy data from tY_inout to Y_inout
     RCP<ThyProdMultVecBase> prodTarget = rcp_dynamic_cast<ThyProdMultVecBase>(target);
@@ -1511,7 +1494,6 @@ public:
     using Teuchos::as;
     typedef Thyra::VectorSpaceBase<Scalar> ThyVecSpaceBase;
     typedef Thyra::ProductVectorSpaceBase<Scalar> ThyProdVecSpaceBase;
-    typedef Xpetra::Map<LocalOrdinal,GlobalOrdinal,Node> Map;
     typedef Xpetra::ThyraUtils<Scalar,LocalOrdinal,GlobalOrdinal,Node> ThyUtils;
 
     RCP<const ThyProdVecSpaceBase > prodVectorSpace = rcp_dynamic_cast<const ThyProdVecSpaceBase >(vectorSpace);
@@ -1611,9 +1593,6 @@ public:
     using Teuchos::as;
     typedef Thyra::ProductMultiVectorBase<Scalar> ThyProdMultVecBase;
     typedef Thyra::MultiVectorBase<Scalar> ThyMultVecBase;
-    typedef Xpetra::Map<LocalOrdinal,GlobalOrdinal,Node> Map;
-    typedef Xpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node > MultiVector;
-    typedef Xpetra::MultiVectorFactory<Scalar,LocalOrdinal,GlobalOrdinal,Node> MultiVectorFactory;
     typedef Xpetra::ThyraUtils<Scalar,LocalOrdinal,GlobalOrdinal,Node> ThyUtils;
 
     // return value
@@ -2021,7 +2000,6 @@ public:
     //typedef Thyra::SpmdMultiVectorBase<Scalar> ThySpmdMultVecBase;
     //typedef Thyra::ProductVectorSpaceBase<Scalar> ThyProdVecSpaceBase;
     typedef Thyra::ProductMultiVectorBase<Scalar> ThyProdMultVecBase;
-    typedef Xpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node > MultiVector;
 
     // copy data from tY_inout to Y_inout
     RCP<ThyProdMultVecBase> prodTarget = rcp_dynamic_cast<ThyProdMultVecBase>(target);


### PR DESCRIPTION
@trilinos/muelu @trilinos/xpetra 

## Motivation
There is a push in Trilinos to remove warnings caught by gcc/8.3.0 to align with the tests performed by Sierra. Thus this PR attempts to remove the `[-Werror=shadow]` seen in MueLu builds.

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of #6295 
* Composed of 


## Stakeholder Feedback
@ZUUL42 let me know when you have a new build after this PR merges, it should look cleaner on the xpetra/muelu side.

## Testing
Local build and tests have been performed using sems-gcc/8.3.0