### PR TITLE
ATDM: Disable packages GEMMA does not use in all cuda+complex builds (ATDV-265)

### DIFF
--- a/cmake/std/atdm/ATDMDisables.cmake
+++ b/cmake/std/atdm/ATDMDisables.cmake
@@ -69,10 +69,36 @@ ENDIF()
 
 IF (ATDM_USE_CUDA AND ATDM_COMPLEX)
 
-  # Disable MueLu for all cuda+complex builds for now since there are build
-  # errors in the MueLu library that takes out everything downstream that
-  # depends on MueLu (see #4599).
-  ATDM_SET_ENABLE(Trilinos_ENABLE_MueLu OFF)
+  # Disable extra packages not being used by GEMMA in cuda+complex builds (see
+  # ATDV-263, ATDV-265)
+  SET(ATDM_SE_PACKAGE_DISABLES
+    ${ATDM_SE_PACKAGE_DISABLES}
+    ShyLU_Node
+    Amesos2
+    SEACAS
+    Anasazi
+    Ifpack2
+    Stratimikos
+    Teko
+    Intrepid
+    Intrepid2
+    STK
+    Percept
+    NOX
+    Moertel
+    MueLu
+    Rythmos
+    Tempus
+    ROL
+    Piro
+    Panzer
+    )
+  # Note, above:
+  # * We are allowing the enable of Zoltan2 for now even though GEMMA is not
+  #   currently using it because Zoltan2 developers want to maintain it (see
+  #   discussion in ATDV-263).
+  # * The package MueLu does not currently build for cuda+complex builds so
+  #   therefore must be disabled (see #4599)
 
 ENDIF()
 

--- a/cmake/std/atdm/ATDMDisables.cmake
+++ b/cmake/std/atdm/ATDMDisables.cmake
@@ -30,7 +30,6 @@ SET(ATDM_SE_PACKAGE_DISABLES
   OptiPack
   Isorropia
   KokkosExample
-  MiniTensor
   Domi
   Pliris
   Komplex

--- a/cmake/std/atdm/ATDMDisables.cmake
+++ b/cmake/std/atdm/ATDMDisables.cmake
@@ -25,6 +25,7 @@ ATDM_SET_CACHE(TPL_ENABLE_yaml-cpp OFF CACHE BOOL)
 
 # Packages and sub-packages disables common to both SPARC and EMPIRE
 SET(ATDM_SE_PACKAGE_DISABLES
+  TrilinosFrameworkTests
   MiniTensor
   GlobiPack
   OptiPack


### PR DESCRIPTION
We don't have the human resources to continue to keep testing and trying to maintain builds and tests that ATDM does not use.  If ATDM APPs are not directly impacted, Trilinos developers mostly just ignore the GitHub issues we create so it is a waste of computer resources and human time maintaining them. 

For more details, see [ATDV-261](https://sems-atlassian-srn.sandia.gov/browse/ATDV-261), [ATDV-262](https://sems-atlassian-srn.sandia.gov/browse/ATDV-262), and [ATDV-265](https://sems-atlassian-srn.sandia.gov/browse/ATDV-265).

## How was this tested?

Doing configure of Trilinos with GEMMA packages:

```
$ ssh ascicgpu15

$ cd /scratch/rabartl/Trilinos.base/BUILDS/ATDM/SEMS-RHEL7/CHECKIN/

$ ./checkin-test-atdm.sh \
  sems-rhel7-cuda-9.2-Volta70-complex-shared-release-debug \
  --enable-packages=Phalanx,KokkosCore,KokkosAlgorithms,Teuchos,Tpetra,Belos,Triutils,Pliris,Gtest \
  --configure
```

The set of packages enabled and *not* enabled is:

* `Final set of enabled packages:  Gtest Kokkos Teuchos KokkosKernels RTOp Sacado Epetra Zoltan Shards Triutils EpetraExt Tpetra TrilinosSS Thyra Xpetra Pliris AztecOO Galeri Amesos Ifpack ML Belos Phalanx 23`

* `Final set of non-enabled packages:  TrilinosFrameworkTests MiniTensor GlobiPack Domi OptiPack Isorropia Claps Pamgen Zoltan2 ShyLU_Node Amesos2 SEACAS Trios Komplex Anasazi Ifpack2 Stratimikos FEI Teko TriKota Intrepid Intrepid2 STK Percept NOX Moertel MueLu ShyLU_DD ShyLU Rythmos Tempus Stokhos ROL Piro Panzer PyTrilinos NewPackage TrilinosCouplings Pike 39`

Therefore, we can add the extra disables for the extra packages not already disabled in ATDM Trilinos builds. ... Done.

Now to test with all enabled packages and verify the same set of enabled packages:

```
$ ssh ascicgpu15

$ cd /scratch/rabartl/Trilinos.base/BUILDS/ATDM/SEMS-RHEL7/CHECKIN/

$ ./checkin-test-atdm.sh \
  sems-rhel7-cuda-9.2-Volta70-complex-shared-release-debug \
  --enable-all-packages=on --configure
```

After that, there is the set of enabled packages:

* `Final set of enabled packages:  Gtest Kokkos Teuchos KokkosKernels RTOp Sacado Epetra Zoltan Shards Triutils EpetraExt Tpetra TrilinosSS Thyra Xpetra AztecOO Galeri Amesos Pamgen Zoltan2 Ifpack ML Belos Phalanx 24`

That is exactly the same set of packages except for Zoltan2, which we are allowing for testing purposes.

Now to test this updated configuration, just to be safe:

```
$ ssh ascicgpu15

$ cd /scratch/rabartl/Trilinos.base/BUILDS/ATDM/SEMS-RHEL7/CTEST_S/

$ ./ctest-s-local-test-driver.sh \
  sems-rhel7-cuda-9.2-Volta70-complex-shared-release-debug

***
*** ./ctest-s-local-test-driver.sh
***

ATDM_TRILINOS_DIR = '/scratch/rabartl/Trilinos.base/Trilinos'

Load some env to get python, cmake, etc ...

Hostname 'ascicgpu15' matches known ATDM host 'sems-rhel7' and system 'sems-rhel7'
Setting compiler and build options for build-name 'default'
Using SEMS RHEL7 compiler stack GNU-7.2.0 to build DEBUG code with Kokkos node type SERIAL

Running builds:
    sems-rhel7-cuda-9.2-Volta70-complex-shared-release-debug

Running Jenkins driver Trilinos-atdm-sems-rhel7-cuda-9.2-Volta70-complex-shared-release-debug.sh ...

    See log file Trilinos-atdm-sems-rhel7-cuda-9.2-Volta70-complex-shared-release-debug/smart-jenkins-driver.out

real    144m20.654s
user    1215m23.769s
sys     171m38.605s
```

That posted results to:

* [Trilinos-atdm-sems-rhel7-cuda-9.2-Volta70-complex-shared-release-debug-exp](https://testing-dev.sandia.gov/cdash/index.php?project=Trilinos&parentid=5078129)

That shows 11 failing tests for TpetraCore and Zoltan2 which are already failing and are already tracking in:

* https://github.com/trilinos/Trilinos/issues/6333
* https://github.com/trilinos/Trilinos/issues/6333
* https://github.com/trilinos/Trilinos/issues/6418
* https://github.com/trilinos/Trilinos/issues/6412
