### PR TITLE
KokkosKernels: Fix #6418 

### DIFF
--- a/packages/kokkos-kernels/unit_test/blas/Test_Blas3_gemm.hpp
+++ b/packages/kokkos-kernels/unit_test/blas/Test_Blas3_gemm.hpp
@@ -105,9 +105,10 @@ namespace Test {
     uint64_t seed = Kokkos::Impl::clock_tic();
     Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(seed);
 
-    Kokkos::fill_random(A,rand_pool,ScalarA(10));
-    Kokkos::fill_random(B,rand_pool,ScalarB(10));
-    Kokkos::fill_random(C,rand_pool,ScalarC(10));
+    // (SA 11 Dec 2019) Max (previously: 10) increased to detect the bug in Trilinos issue #6418 
+    Kokkos::fill_random(A,rand_pool, Kokkos::rand<typename Kokkos::Random_XorShift64_Pool<execution_space>::generator_type,ScalarA>::max());
+    Kokkos::fill_random(B,rand_pool, Kokkos::rand<typename Kokkos::Random_XorShift64_Pool<execution_space>::generator_type,ScalarB>::max());
+    Kokkos::fill_random(C,rand_pool, Kokkos::rand<typename Kokkos::Random_XorShift64_Pool<execution_space>::generator_type,ScalarC>::max());
     
     Kokkos::deep_copy(C2,C);
 


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/kokkos-kernels 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

This PR 
1) fixes the issue https://github.com/trilinos/Trilinos/issues/6418, which was caused by DotBasedGEMM in KokkosKernels, by excluding the conjugate transpose case for A from the optimized case and    
2) upgrades the initialization kernels in DotBasedGEMM to use MDRangePolicy.
 
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Related Issues
https://github.com/trilinos/Trilinos/issues/6418
https://github.com/kokkos/kokkos-kernels/pull/510#discussion_r354566671

## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

These tests (which were failing in https://github.com/trilinos/Trilinos/issues/6418) are passing now:

    TpetraCore_gemm_m_eq_1_MPI_1
    TpetraCore_gemm_m_eq_2_MPI_1
    TpetraCore_gemm_m_eq_5_MPI_1
    TpetraCore_gemm_m_eq_13_MPI_1
    TpetraCore_MultiVector_UnitTests_MPI_4


<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->