### PR TITLE
Teuchos: Change default of maxArrayIterRatio from 100 to 200 (#6429)

### DIFF
--- a/packages/teuchos/core/test/MemoryManagement/Array_Performance_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/Array_Performance_UnitTests.cpp
@@ -60,7 +60,7 @@ using Teuchos::Ordinal;
 double relCpuSpeed = 1e-2;
 int maxArraySize = 10000;
 double maxArrayBracketRatio =100.0;
-double maxArrayIterRatio = 100.0;
+double maxArrayIterRatio = 200.0;
 double maxArrayRCPSelfIterRatio =200.0;
 
 const int minArraySize = 100;


### PR DESCRIPTION
For the CUDA debug builds on 'white' and 'ride', this ratio has gotten as high
as 123 (see #6429).  Not sure what changes on 'white' and 'ride' to trigger these timing
failures, but this particular test is not designed to be performance test per
say in an arbitrary (ebug) build.  It is hard to believe the ratio of
non-optimized Teuchos Array iterator operations is more than 100x slower than
raw pointer operations on this machine but I guess anything is possible.

NOTE: This just changes the default.  It does not change the proper
PERFORMANCE test.
