### PR TITLE
Tempus: Get Basic Variable Stepping Working with Two States.

### DIFF
--- a/packages/tempus/src/Tempus_IntegratorAdjointSensitivity_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorAdjointSensitivity_impl.hpp
@@ -519,11 +519,11 @@ buildSolutionHistory(
     }
     RCP<VectorBase<Scalar> > x_dot_dot_b = x_dot_dot;
 
-    RCP<SolutionState<Scalar> > prod_state =
-      rcp(new SolutionState<Scalar>(forward_state->getMetaData()->clone(),
-                                    x_b, x_dot_b, x_dot_dot_b,
-                                    forward_state->getStepperState()->clone(),
-                                    Teuchos::null));
+    RCP<SolutionState<Scalar> > prod_state = forward_state->clone();
+    prod_state->setX(x_b);
+    prod_state->setXDot(x_dot_b);
+    prod_state->setXDotDot(x_dot_dot_b);
+    prod_state->setPhysicsState(Teuchos::null);
     solutionHistory_->addState(prod_state);
   }
 }

--- a/packages/tempus/src/Tempus_IntegratorObserverBasic_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorObserverBasic_impl.hpp
@@ -63,12 +63,11 @@ void IntegratorObserverBasic<Scalar>::
 observeEndTimeStep(const Integrator<Scalar>& integrator){
 
   using Teuchos::RCP;
-  RCP<SolutionStateMetaData<Scalar> > csmd =
-    integrator.getSolutionHistory()->getCurrentState()->getMetaData();
+  auto cs = integrator.getSolutionHistory()->getCurrentState();
 
-  if ((csmd->getOutputScreen() == true) or
-      (csmd->getOutput() == true) or
-      (csmd->getTime() == integrator.getTimeStepControl()->getFinalTime())) {
+  if ((cs->getOutputScreen() == true) or
+      (cs->getOutput() == true) or
+      (cs->getTime() == integrator.getTimeStepControl()->getFinalTime())) {
 
      const Scalar steppertime = integrator.getStepperTimer()->totalElapsedTime();
      // reset the stepper timer
@@ -77,13 +76,13 @@ observeEndTimeStep(const Integrator<Scalar>& integrator){
      const Teuchos::RCP<Teuchos::FancyOStream> out = integrator.getOStream();
      Teuchos::OSTab ostab(out,0,"ScreenOutput");
      *out<<std::scientific
-        <<std::setw( 6)<<std::setprecision(3)<<csmd->getIStep()
-        <<std::setw(11)<<std::setprecision(3)<<csmd->getTime()
-        <<std::setw(11)<<std::setprecision(3)<<csmd->getDt()
-        <<std::setw(11)<<std::setprecision(3)<<csmd->getErrorAbs()
-        <<std::setw(11)<<std::setprecision(3)<<csmd->getErrorRel()
-        <<std::fixed     <<std::setw( 7)<<std::setprecision(1)<<csmd->getOrder()
-        <<std::scientific<<std::setw( 7)<<std::setprecision(3)<<csmd->getNFailures()
+        <<std::setw( 6)<<std::setprecision(3)<<cs->getIndex()
+        <<std::setw(11)<<std::setprecision(3)<<cs->getTime()
+        <<std::setw(11)<<std::setprecision(3)<<cs->getTimeStep()
+        <<std::setw(11)<<std::setprecision(3)<<cs->getErrorAbs()
+        <<std::setw(11)<<std::setprecision(3)<<cs->getErrorRel()
+        <<std::fixed     <<std::setw( 7)<<std::setprecision(1)<<cs->getOrder()
+        <<std::scientific<<std::setw( 7)<<std::setprecision(3)<<cs->getNFailures()
         <<std::setw(11)<<std::setprecision(3)<<steppertime
         <<std::endl;
   }

--- a/packages/tempus/src/Tempus_IntegratorObserverSubcycling_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorObserverSubcycling_impl.hpp
@@ -55,12 +55,11 @@ void IntegratorObserverSubcycling<Scalar>::
 observeEndTimeStep(const Integrator<Scalar>& integrator){
 
   using Teuchos::RCP;
-  RCP<SolutionStateMetaData<Scalar> > csmd =
-    integrator.getSolutionHistory()->getCurrentState()->getMetaData();
+  auto cs = integrator.getSolutionHistory()->getCurrentState();
 
-  if ((csmd->getOutputScreen() == true) or
-      (csmd->getOutput() == true) or
-      (csmd->getTime() == integrator.getTimeStepControl()->getFinalTime())) {
+  if ((cs->getOutputScreen() == true) or
+      (cs->getOutput() == true) or
+      (cs->getTime() == integrator.getTimeStepControl()->getFinalTime())) {
 
      const Scalar steppertime = integrator.getStepperTimer()->totalElapsedTime();
      // reset the stepper timer
@@ -69,13 +68,13 @@ observeEndTimeStep(const Integrator<Scalar>& integrator){
      const Teuchos::RCP<Teuchos::FancyOStream> out = integrator.getOStream();
      Teuchos::OSTab ostab(out,0,"ScreenOutput");
      *out<<std::scientific
-        <<std::setw( 6)<<std::setprecision(3)<<csmd->getIStep()
-        <<std::setw(11)<<std::setprecision(3)<<csmd->getTime()
-        <<std::setw(11)<<std::setprecision(3)<<csmd->getDt()
-        <<std::setw(11)<<std::setprecision(3)<<csmd->getErrorAbs()
-        <<std::setw(11)<<std::setprecision(3)<<csmd->getErrorRel()
-        <<std::fixed     <<std::setw( 7)<<std::setprecision(1)<<csmd->getOrder()
-        <<std::scientific<<std::setw( 7)<<std::setprecision(3)<<csmd->getNFailures()
+        <<std::setw( 6)<<std::setprecision(3)<<cs->getIndex()
+        <<std::setw(11)<<std::setprecision(3)<<cs->getTime()
+        <<std::setw(11)<<std::setprecision(3)<<cs->getTimeStep()
+        <<std::setw(11)<<std::setprecision(3)<<cs->getErrorAbs()
+        <<std::setw(11)<<std::setprecision(3)<<cs->getErrorRel()
+        <<std::fixed     <<std::setw( 7)<<std::setprecision(1)<<cs->getOrder()
+        <<std::scientific<<std::setw( 7)<<std::setprecision(3)<<cs->getNFailures()
         <<std::setw(11)<<std::setprecision(3)<<steppertime
         <<std::endl;
   }

--- a/packages/tempus/src/Tempus_IntegratorPseudoTransientAdjointSensitivity_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorPseudoTransientAdjointSensitivity_impl.hpp
@@ -404,10 +404,10 @@ buildSolutionHistory()
       x_dot_dot_b = x_dot_dot;
     }
 
-    RCP<SolutionState<Scalar> > prod_state =
-      rcp(new SolutionState<Scalar>(state->getMetaData()->clone(),
-                                    x_b, x_dot_b, x_dot_dot_b,
-                                    state->getStepperState()->clone()));
+    RCP<SolutionState<Scalar> > prod_state = state->clone();
+    prod_state->setX(x_b);
+    prod_state->setXDot(x_dot_b);
+    prod_state->setXDotDot(x_dot_dot_b);
     solutionHistory_->addState(prod_state);
   }
 
@@ -447,10 +447,10 @@ buildSolutionHistory()
       x_dot_dot_b = x_dot_dot;
     }
 
-    RCP<SolutionState<Scalar> > prod_state =
-      rcp(new SolutionState<Scalar>(state->getMetaData()->clone(),
-                                    x_b, x_dot_b, x_dot_dot_b,
-                                    state->getStepperState()->clone()));
+    RCP<SolutionState<Scalar> > prod_state = state->clone();
+    prod_state->setX(x_b);
+    prod_state->setXDot(x_dot_b);
+    prod_state->setXDotDot(x_dot_dot_b);
     solutionHistory_->addState(prod_state);
   }
 }

--- a/packages/tempus/src/Tempus_IntegratorPseudoTransientForwardSensitivity_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorPseudoTransientForwardSensitivity_impl.hpp
@@ -484,10 +484,10 @@ buildSolutionHistory()
       x_dot_dot = multiVectorProductVector(prod_space, x_dot_dot_mv);
     }
 
-    RCP<SolutionState<Scalar> > prod_state =
-      rcp(new SolutionState<Scalar>(state->getMetaData()->clone(),
-                                    x, x_dot, x_dot_dot,
-                                    state->getStepperState()->clone()));
+    RCP<SolutionState<Scalar> > prod_state = state->clone();
+    prod_state->setX(x);
+    prod_state->setXDot(x_dot);
+    prod_state->setXDotDot(x_dot_dot);
     solutionHistory_->addState(prod_state);
   }
 
@@ -536,10 +536,10 @@ buildSolutionHistory()
       x_dot_dot = multiVectorProductVector(prod_space, x_dot_dot_mv);
     }
 
-    RCP<SolutionState<Scalar> > prod_state =
-      rcp(new SolutionState<Scalar>(state->getMetaData()->clone(),
-                                    x, x_dot, x_dot_dot,
-                                    state->getStepperState()->clone()));
+    RCP<SolutionState<Scalar> > prod_state = state->clone();
+    prod_state->setX(x);
+    prod_state->setXDot(x_dot);
+    prod_state->setXDotDot(x_dot_dot);
     solutionHistory_->addState(prod_state);
   }
 }

--- a/packages/tempus/src/Tempus_SolutionHistory_decl.hpp
+++ b/packages/tempus/src/Tempus_SolutionHistory_decl.hpp
@@ -299,7 +299,7 @@ public:
       *out << "  ";
       if (state == getWorkingState()) *out << "w - ";
       else if (state == getCurrentState()) *out << "c - ";
-      else if (state->getMetaData()->getIsInterpolated() == true) *out<<"i - ";
+      else if (state->getIsInterpolated() == true) *out<<"i - ";
       else *out << "    ";
       *out << "[" << i << "] = " << state << std::endl;
       if (verb == "medium" or verb == "high") {

--- a/packages/tempus/src/Tempus_SolutionHistory_impl.hpp
+++ b/packages/tempus/src/Tempus_SolutionHistory_impl.hpp
@@ -15,7 +15,6 @@
 #include "Teuchos_TimeMonitor.hpp"
 
 // Tempus
-#include "Tempus_SolutionStateMetaData.hpp"
 #include "Tempus_InterpolatorFactory.hpp"
 
 //#include "Thyra_VectorStdOps.hpp"
@@ -136,13 +135,13 @@ void SolutionHistory<Scalar>::addWorkingState(
 
   addState(state);
   workingState_ = (*history_)[getNumStates()-1];
-  RCP<SolutionStateMetaData<Scalar> > csmd = getCurrentState()->getMetaData();
-  RCP<SolutionStateMetaData<Scalar> > wsmd = workingState_    ->getMetaData();
-  wsmd->setSolutionStatus(Status::WORKING);
-  wsmd->setIStep(csmd->getIStep()+1);
+  auto cs = getCurrentState();
+  auto ws = getWorkingState();
+  ws->setSolutionStatus(Status::WORKING);
+  ws->setIndex(cs->getIndex()+1);
   if (updateTime) {
-    wsmd->setTime(csmd->getTime() + csmd->getDt());
-    wsmd->setDt(csmd->getDt());
+    ws->setTime(cs->getTime() + cs->getTimeStep());
+    ws->setTimeStep(cs->getTimeStep());
   }
 }
 
@@ -261,15 +260,14 @@ void SolutionHistory<Scalar>::initWorkingState()
 template<class Scalar>
 void SolutionHistory<Scalar>::promoteWorkingState()
 {
-  Teuchos::RCP<SolutionStateMetaData<Scalar> > md =
-    getWorkingState()->getMetaData();
+  auto ws = getWorkingState();
 
-  if ( md->getSolutionStatus() == Status::PASSED ) {
-    md->setNFailures(std::max(0,md->getNFailures()-1));
-    md->setNConsecutiveFailures(0);
-    md->setSolutionStatus(Status::PASSED);
-    //md->setIsSynced(true);
-    md->setIsInterpolated(false);
+  if ( ws->getSolutionStatus() == Status::PASSED ) {
+    ws->setNFailures(std::max(0,ws->getNFailures()-1));
+    ws->setNConsecutiveFailures(0);
+    ws->setSolutionStatus(Status::PASSED);
+    //ws->setIsSynced(true);
+    ws->setIsInterpolated(false);
     workingState_ = Teuchos::null;
   } else {
     Teuchos::RCP<Teuchos::FancyOStream> out = this->getOStream();

--- a/packages/tempus/src/Tempus_SolutionStateMetaData_decl.hpp
+++ b/packages/tempus/src/Tempus_SolutionStateMetaData_decl.hpp
@@ -30,6 +30,29 @@ public:
   /// Default constructor.
   SolutionStateMetaData();
 
+#ifndef TEMPUS_HIDE_DEPRECATED_CODE
+  /// Constructor - Deprecated!
+  TEMPUS_DEPRECATED_MSG("Please use constructor with 21 arguments.")
+  SolutionStateMetaData(
+    const Scalar time,
+    const int    iStep,
+    const Scalar dt,
+    const Scalar errorAbs,
+    const Scalar errorRel,
+    const int    order,
+    const int    nFailures,
+    const int    nRunningFailures,
+    const int    nConsecutiveFailures,
+    const Scalar tolRel,
+    const Scalar tolAbs,
+    const Status solutionStatus,
+    const bool   output,
+    const bool   outputScreen,
+    const bool   isSynced,
+    const bool   isInterpolated,
+    const Scalar accuracy);
+#endif
+
   /// Constructor
   SolutionStateMetaData(
     const Scalar time,
@@ -43,6 +66,10 @@ public:
     const int    nConsecutiveFailures,
     const Scalar tolRel,
     const Scalar tolAbs,
+    const Scalar xNormL2,
+    const Scalar dxNormL2Rel,
+    const Scalar dxNormL2Abs,
+    const bool   computeNorms,
     const Status solutionStatus,
     const bool   output,
     const bool   outputScreen,
@@ -75,6 +102,10 @@ public:
     int    getNConsecutiveFailures() const {return nConsecutiveFailures_;}
     Scalar getTolAbs()               const {return tolAbs_;}
     Scalar getTolRel()               const {return tolRel_;}
+    Scalar getXNormL2()              const {return xNormL2_;}
+    Scalar getDxNormL2Abs()          const {return dxNormL2Abs_;}
+    Scalar getDxNormL2Rel()          const {return dxNormL2Rel_;}
+    bool   getComputeNorms()         const {return computeNorms_;}
     Status getSolutionStatus()       const {return solutionStatus_;}
     bool   getOutput()               const {return output_;}
     bool   getOutputScreen()         const {return outputScreen_;}
@@ -82,27 +113,30 @@ public:
     bool   getIsInterpolated()       const {return isInterpolated_;}
     Scalar getAccuracy()             const {return accuracy_;}
 
-    void setTime(Scalar time) {time_ = time;}
-    void setIStep(int iStep) {iStep_ = iStep;}
-    void setDt(Scalar dt) {dt_ = dt;}
-    void setErrorAbs (Scalar errorAbs){errorAbs_ = errorAbs;}
-    void setErrorRel (Scalar errorRel){errorRel_ = errorRel;}
-    void setOrder(Scalar order) {order_ = order;}
-    void setNFailures(int nFailures) {nFailures_ = nFailures;}
-    void setNRunningFailures(int nFailures) {nRunningFailures_ = nFailures;}
+    void setTime(Scalar time)                  {time_ = time;}
+    void setIStep(int iStep)                   {iStep_ = iStep;}
+    void setDt(Scalar dt)                      {dt_ = dt;}
+    void setErrorAbs (Scalar errorAbs)         {errorAbs_ = errorAbs;}
+    void setErrorRel (Scalar errorRel)         {errorRel_ = errorRel;}
+    void setOrder(Scalar order)                {order_ = order;}
+    void setNFailures(int nFailures)           {nFailures_ = nFailures;}
+    void setNRunningFailures(int nFailures)    {nRunningFailures_ = nFailures;}
     void setNConsecutiveFailures(int nConsecutiveFailures)
       {nConsecutiveFailures_ = nConsecutiveFailures;}
-    void setTolRel (Scalar tolRel){tolRel_ = tolRel;}
-    void setTolAbs (Scalar tolAbs){tolAbs_ = tolAbs;}
+    void setTolRel (Scalar tolRel)             {tolRel_ = tolRel;}
+    void setTolAbs (Scalar tolAbs)             {tolAbs_ = tolAbs;}
+    void setXNormL2 (Scalar xNormL2)           {xNormL2_ = xNormL2;}
+    void setDxNormL2Rel (Scalar dxNormL2Rel)   {dxNormL2Rel_ = dxNormL2Rel;}
+    void setDxNormL2Abs (Scalar dxNormL2Abs)   {dxNormL2Abs_ = dxNormL2Abs;}
+    void setComputeNorms (bool computeNorms)   {computeNorms_ = computeNorms;}
     void setSolutionStatus(Status solutionStatus)
       {solutionStatus_ = solutionStatus;}
-    void setOutput(bool output) {output_ = output;}
-    void setOutputScreen(bool outputScreen) {outputScreen_ = outputScreen;}
-    void setIsSynced(bool isSynced) {isSynced_=isSynced;}
+    void setOutput(bool output)                {output_ = output;}
+    void setOutputScreen(bool outputScreen)    {outputScreen_ = outputScreen;}
+    void setIsSynced(bool isSynced)            {isSynced_=isSynced;}
     void setIsInterpolated(bool isInterpolated)
       {isInterpolated_ = isInterpolated;}
-    void setAccuracy(Scalar accuracy) {accuracy_ = accuracy;}
-
+    void setAccuracy(Scalar accuracy)          {accuracy_ = accuracy;}
   //@}
 
   /// \name Overridden from Teuchos::Describable
@@ -122,8 +156,12 @@ protected:
   int nFailures_;            ///< Total number of stepper failures
   int nRunningFailures_;     ///< Total number of running stepper failures
   int nConsecutiveFailures_; ///< Consecutive number of stepper failures
-  Scalar tolRel_;            ///< Absolute tolerance
-  Scalar tolAbs_;            ///< Relative tolerance
+  Scalar tolRel_;            ///< Relative tolerance
+  Scalar tolAbs_;            ///< Absolute tolerance
+  Scalar xNormL2_;           ///< L2-Norm of the solution
+  Scalar dxNormL2Rel_;       ///< Relative L2-Norm of the change in solution, ||x_i-x_{i-1}||/||x_{i-1}||
+  Scalar dxNormL2Abs_;       ///< Absolute L2-Norm of the change in solution, ||x_i-x_{i-1}||
+  bool   computeNorms_;      ///< flag to compute norms of solution
 
   /** \brief The solutionStatus is used to indicate
       - if the solution is still being worked on; WORKING

--- a/packages/tempus/src/Tempus_SolutionStateMetaData_impl.hpp
+++ b/packages/tempus/src/Tempus_SolutionStateMetaData_impl.hpp
@@ -13,7 +13,7 @@
 
 namespace Tempus {
 
-// SolutionStateMetaData definitions:
+
 template<class Scalar>
 SolutionStateMetaData<Scalar>::SolutionStateMetaData()
   :time_          (0.0),
@@ -27,6 +27,10 @@ SolutionStateMetaData<Scalar>::SolutionStateMetaData()
    nConsecutiveFailures_(0),
    tolRel_        (1.0e-02),
    tolAbs_        (0.0),
+   xNormL2_       (0.0),
+   dxNormL2Rel_   (0.0),
+   dxNormL2Abs_   (0.0),
+   computeNorms_  (false),
    solutionStatus_(WORKING),
    output_        (false),
    outputScreen_  (false),
@@ -35,6 +39,7 @@ SolutionStateMetaData<Scalar>::SolutionStateMetaData()
    accuracy_      (0.0)
 {}
 
+#ifndef TEMPUS_HIDE_DEPRECATED_CODE
 template<class Scalar>
 SolutionStateMetaData<Scalar>::SolutionStateMetaData(
   const Scalar time,
@@ -65,6 +70,57 @@ SolutionStateMetaData<Scalar>::SolutionStateMetaData(
    nConsecutiveFailures_(nConsecutiveFailures),
    tolRel_        (tolRel),
    tolAbs_        (tolAbs),
+   xNormL2_       (0.0),
+   dxNormL2Rel_   (0.0),
+   dxNormL2Abs_   (0.0),
+   computeNorms_  (false),
+   solutionStatus_(solutionStatus),
+   output_        (output),
+   outputScreen_  (outputScreen),
+   isSynced_      (isSynced),
+   isInterpolated_(isInterpolated),
+   accuracy_      (accuracy)
+{}
+#endif
+
+template<class Scalar>
+SolutionStateMetaData<Scalar>::SolutionStateMetaData(
+  const Scalar time,
+  const int    iStep,
+  const Scalar dt,
+  const Scalar errorAbs,
+  const Scalar errorRel,
+  const int    order,
+  const int    nFailures,
+  const int    nRunningFailures,
+  const int    nConsecutiveFailures,
+  const Scalar tolRel,
+  const Scalar tolAbs,
+  const Scalar xNormL2,
+  const Scalar dxNormL2Rel,
+  const Scalar dxNormL2Abs,
+  const bool   computeNorms,
+  const Status solutionStatus,
+  const bool   output,
+  const bool   outputScreen,
+  const bool   isSynced,
+  const bool   isInterpolated,
+  const Scalar accuracy)
+  :time_          (time),
+   iStep_         (iStep),
+   dt_            (dt),
+   errorAbs_      (errorAbs),
+   errorRel_      (errorRel),
+   order_         (order),
+   nFailures_     (nFailures),
+   nRunningFailures_(nRunningFailures),
+   nConsecutiveFailures_(nConsecutiveFailures),
+   tolRel_        (tolRel),
+   tolAbs_        (tolAbs),
+   xNormL2_       (xNormL2),
+   dxNormL2Rel_   (dxNormL2Rel),
+   dxNormL2Abs_   (dxNormL2Abs),
+   computeNorms_  (computeNorms),
    solutionStatus_(solutionStatus),
    output_        (output),
    outputScreen_  (outputScreen),
@@ -86,6 +142,9 @@ SolutionStateMetaData<Scalar>::SolutionStateMetaData(const SolutionStateMetaData
    nConsecutiveFailures_(ssmd.nConsecutiveFailures_),
    tolRel_        (ssmd.tolRel_),
    tolAbs_        (ssmd.tolAbs_),
+   dxNormL2Rel_   (ssmd.dxNormL2Rel_),
+   dxNormL2Abs_   (ssmd.dxNormL2Abs_),
+   computeNorms_  (ssmd.computeNorms_),
    solutionStatus_(ssmd.solutionStatus_),
    output_        (ssmd.output_),
    outputScreen_  (ssmd.outputScreen_),
@@ -111,6 +170,10 @@ Teuchos::RCP<SolutionStateMetaData<Scalar> > SolutionStateMetaData<Scalar>::clon
       nConsecutiveFailures_,
       tolRel_,
       tolAbs_,
+      xNormL2_,
+      dxNormL2Rel_,
+      dxNormL2Abs_,
+      computeNorms_,
       solutionStatus_,
       output_,
       outputScreen_,
@@ -137,6 +200,10 @@ copy(const Teuchos::RCP<const SolutionStateMetaData<Scalar> >& ssmd)
   nConsecutiveFailures_ = ssmd->nConsecutiveFailures_;
   tolRel_         = ssmd->tolRel_,
   tolAbs_         = ssmd->tolAbs_,
+  xNormL2_        = ssmd->xNormL2_,
+  dxNormL2Rel_    = ssmd->dxNormL2Rel_,
+  dxNormL2Abs_    = ssmd->dxNormL2Abs_,
+  computeNorms_   = ssmd->computeNorms_,
   solutionStatus_ = ssmd->solutionStatus_;
   output_         = ssmd->output_;
   outputScreen_   = ssmd->outputScreen_;
@@ -168,10 +235,14 @@ void SolutionStateMetaData<Scalar>::describe(
         << "errorRel       = " << errorRel_ << std::endl
         << "order          = " << order_ << std::endl
         << "nFailures      = " << nFailures_ << std::endl
-        << "nRunningFailures= " << nRunningFailures_<< std::endl
+        << "nRunningFailures = " << nRunningFailures_<< std::endl
         << "nConsecutiveFailures = " << nConsecutiveFailures_ << std::endl
         << "tolRel         = " << tolRel_ << std::endl
         << "tolAbs         = " << tolAbs_ << std::endl
+        << "xNormL2        = " << xNormL2_ << std::endl
+        << "dxNormL2Rel    = " << dxNormL2Rel_ << std::endl
+        << "dxNormL2Abs    = " << dxNormL2Abs_ << std::endl
+        << "computeNorms   = " << computeNorms_ << std::endl
         << "solutionStatus = " << toString(solutionStatus_) << std::endl
         << "output         = " << output_ << std::endl
         << "outputScreen   = " << outputScreen_ << std::endl

--- a/packages/tempus/src/Tempus_SolutionState_decl.hpp
+++ b/packages/tempus/src/Tempus_SolutionState_decl.hpp
@@ -136,12 +136,16 @@ public:
     virtual int    getNConsecutiveFailures() const {return metaData_->getNConsecutiveFailures();}
     virtual Scalar getTolAbs()           const {return metaData_->getTolAbs();}
     virtual Scalar getTolRel()           const {return metaData_->getTolRel();}
+    virtual Scalar getXNormL2()          const {return metaData_->getXNormL2();}
+    virtual Scalar getDxNormL2Abs()      const {return metaData_->getDxNormL2Abs();}
+    virtual Scalar getDxNormL2Rel()      const {return metaData_->getDxNormL2Rel();}
+    virtual bool   getComputeNorms()     const {return metaData_->getComputeNorms();}
     virtual Status getSolutionStatus()   const {return metaData_->getSolutionStatus();}
-    virtual bool getOutput()             const {return metaData_->getOutput();}
-    virtual bool getOutputScreen()       const {return metaData_->getOutputScreen();}
-    virtual bool getIsSynced()           const {return metaData_->getIsSynced();}
-    virtual bool getIsInterpolated()     const {return metaData_->getIsInterpolated();}
-    virtual bool getAccuracy()           const {return metaData_->getAccuracy();}
+    virtual bool   getOutput()           const {return metaData_->getOutput();}
+    virtual bool   getOutputScreen()     const {return metaData_->getOutputScreen();}
+    virtual bool   getIsSynced()         const {return metaData_->getIsSynced();}
+    virtual bool   getIsInterpolated()   const {return metaData_->getIsInterpolated();}
+    virtual bool   getAccuracy()         const {return metaData_->getAccuracy();}
   //@}
 
   /// \name Set MetaData values
@@ -170,12 +174,21 @@ public:
     virtual void setNRunningFailures(int nFailures) { TEUCHOS_ASSERT(metaData_nc_ != Teuchos::null);
                                           metaData_nc_->setNRunningFailures(nFailures); }
     virtual void setNConsecutiveFailures(int nConsecutiveFailures)
-      { TEUCHOS_ASSERT(metaData_nc_ != Teuchos::null);
+                                        { TEUCHOS_ASSERT(metaData_nc_ != Teuchos::null);
                                           metaData_nc_->setNConsecutiveFailures(nConsecutiveFailures); }
     virtual void setTolRel (Scalar tolRel){ TEUCHOS_ASSERT(metaData_nc_ != Teuchos::null);
                                           metaData_nc_->setTolRel(tolRel); }
     virtual void setTolAbs (Scalar tolAbs){ TEUCHOS_ASSERT(metaData_nc_ != Teuchos::null);
                                           metaData_nc_->setTolAbs(tolAbs); }
+
+    virtual void setXNormL2 (Scalar xNormL2){ TEUCHOS_ASSERT(metaData_nc_ != Teuchos::null);
+                                          metaData_nc_->setXNormL2(xNormL2); }
+    virtual void setDxNormL2Rel (Scalar dxNormL2Rel){ TEUCHOS_ASSERT(metaData_nc_ != Teuchos::null);
+                                          metaData_nc_->setDxNormL2Rel(dxNormL2Rel); }
+    virtual void setDxNormL2Abs (Scalar dxNormL2Abs){ TEUCHOS_ASSERT(metaData_nc_ != Teuchos::null);
+                                          metaData_nc_->setDxNormL2Abs(dxNormL2Abs); }
+    virtual void setComputeNorms(bool computeNorms) { TEUCHOS_ASSERT(metaData_nc_ != Teuchos::null);
+                                          metaData_nc_->setComputeNorms(computeNorms); }
 
     virtual void setSolutionStatus(Status s) { TEUCHOS_ASSERT(metaData_nc_ != Teuchos::null);
                                                metaData_nc_->setSolutionStatus(s); }
@@ -242,8 +255,15 @@ public:
     virtual void setXDotDot(Teuchos::RCP<const Thyra::VectorBase<Scalar> > xdotdot)
       { xdotdot_nc_ = Teuchos::null; xdotdot_ = xdotdot; }
 
+    virtual void setStepperState(Teuchos::RCP<StepperState<Scalar> >& ss)
+      { stepperState_nc_ = ss; stepperState_ = ss; }
+    virtual void setStepperState(const Teuchos::RCP<StepperState<Scalar> >& ss)
+      { stepperState_nc_ = Teuchos::null; stepperState_ = ss; }
+
+    virtual void setPhysicsState(Teuchos::RCP<PhysicsState<Scalar> >& ps)
+      { physicsState_nc_ = ps; physicsState_ = ps; }
     virtual void setPhysicsState(const Teuchos::RCP<PhysicsState<Scalar> >& ps)
-      { physicsState_nc_ = ps; physicsState_ = physicsState_nc_; }
+      { physicsState_nc_ = Teuchos::null; physicsState_ = ps; }
   //@}
 
 
@@ -287,6 +307,10 @@ public:
                           const Teuchos::EVerbosityLevel verbLevel) const;
   //@}
 
+  /// Compute the solution norms, and solution change from ssIn, if provided.
+  virtual void computeNorms(
+    const Teuchos::RCP<const SolutionState<Scalar> >& ssIn = Teuchos::null);
+
 private:
   // Member Data
 
@@ -307,12 +331,12 @@ private:
   Teuchos::RCP<Thyra::VectorBase<Scalar> > xdotdot_nc_;
 
   /// StepperState for this SolutionState
-  Teuchos::RCP<const Tempus::StepperState<Scalar> > stepperState_;
-  Teuchos::RCP<Tempus::StepperState<Scalar> > stepperState_nc_;
+  Teuchos::RCP<const StepperState<Scalar> > stepperState_;
+  Teuchos::RCP<StepperState<Scalar> > stepperState_nc_;
 
   /// PhysicsState for this SolutionState
-  Teuchos::RCP<const Tempus::PhysicsState<Scalar> > physicsState_;
-  Teuchos::RCP<Tempus::PhysicsState<Scalar> > physicsState_nc_;
+  Teuchos::RCP<const PhysicsState<Scalar> > physicsState_;
+  Teuchos::RCP<PhysicsState<Scalar> > physicsState_nc_;
 
 };
 } // namespace Tempus

--- a/packages/tempus/src/Tempus_StepperBDF2_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperBDF2_impl.hpp
@@ -222,6 +222,7 @@ void StepperBDF2<Scalar>::takeStep(
 
     workingState->setSolutionStatus(sStatus);  // Converged --> pass.
     workingState->setOrder(getOrder());
+    workingState->computeNorms(currentState);
     //this->stepperObserver_->observeEndTakeStep(solutionHistory, *this);
   }
   return;

--- a/packages/tempus/src/Tempus_StepperBackwardEuler_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperBackwardEuler_impl.hpp
@@ -212,6 +212,7 @@ void StepperBackwardEuler<Scalar>::takeStep(
 
     workingState->setSolutionStatus(sStatus);  // Converged --> pass.
     workingState->setOrder(this->getOrder());
+    workingState->computeNorms(currentState);
     this->stepperObserver_->observeEndTakeStep(solutionHistory, *this);
   }
   return;

--- a/packages/tempus/src/Tempus_StepperDIRK_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperDIRK_impl.hpp
@@ -287,9 +287,8 @@ void StepperDIRK<Scalar>::takeStep(
     }
 
     if (tableau_->isEmbedded() and this->getUseEmbedded()) {
-      RCP<SolutionStateMetaData<Scalar> > metaData=workingState->getMetaData();
-      const Scalar tolAbs = metaData->getTolRel();
-      const Scalar tolRel = metaData->getTolAbs();
+      const Scalar tolRel = workingState->getTolRel();
+      const Scalar tolAbs = workingState->getTolAbs();
 
       // just compute the error weight vector
       // (all that is needed is the error, and not the embedded solution)
@@ -315,7 +314,7 @@ void StepperDIRK<Scalar>::takeStep(
       assign(sc.ptr(), Teuchos::ScalarTraits<Scalar>::zero());
       Thyra::ele_wise_divide(Teuchos::as<Scalar>(1.0), *ee_, *abs_u, sc.ptr());
       Scalar err = std::abs(Thyra::norm_inf(*sc));
-      metaData->setErrorRel(err);
+      workingState->setErrorRel(err);
 
       // test if step should be rejected
       if (std::isinf(err) || std::isnan(err) || err > Teuchos::as<Scalar>(1.0))
@@ -326,6 +325,7 @@ void StepperDIRK<Scalar>::takeStep(
     else      workingState->setSolutionStatus(Status::FAILED);
 
     workingState->setOrder(this->getOrder());
+    workingState->computeNorms(currentState);
     this->stepperObserver_->observeEndTakeStep(solutionHistory, *this);
   }
   return;

--- a/packages/tempus/src/Tempus_StepperForwardEuler_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperForwardEuler_impl.hpp
@@ -162,6 +162,7 @@ void StepperForwardEuler<Scalar>::takeStep(
 
     workingState->setSolutionStatus(Status::PASSED);
     workingState->setOrder(this->getOrder());
+    workingState->computeNorms(currentState);
     this->stepperObserver_->observeEndTakeStep(solutionHistory, *this);
   }
   return;

--- a/packages/tempus/src/Tempus_StepperHHTAlpha_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperHHTAlpha_impl.hpp
@@ -426,6 +426,7 @@ void StepperHHTAlpha<Scalar>::takeStep(
 
     workingState->setSolutionStatus(sStatus);  // Converged --> pass.
     workingState->setOrder(this->getOrder());
+    workingState->computeNorms(currentState);
   }
   return;
 }

--- a/packages/tempus/src/Tempus_StepperIMEX_RK_Partition_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RK_Partition_impl.hpp
@@ -654,6 +654,7 @@ void StepperIMEX_RK_Partition<Scalar>::takeStep(
     if (pass == true) workingState->setSolutionStatus(Status::PASSED);
     else              workingState->setSolutionStatus(Status::FAILED);
     workingState->setOrder(this->getOrder());
+    workingState->computeNorms(currentState);
     this->stepperObserver_->observeEndTakeStep(solutionHistory, *this);
   }
   return;

--- a/packages/tempus/src/Tempus_StepperIMEX_RK_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RK_impl.hpp
@@ -608,6 +608,7 @@ void StepperIMEX_RK<Scalar>::takeStep(
     if (pass == true) workingState->setSolutionStatus(Status::PASSED);
     else              workingState->setSolutionStatus(Status::FAILED);
     workingState->setOrder(this->getOrder());
+    workingState->computeNorms(currentState);
     this->stepperObserver_->observeEndTakeStep(solutionHistory, *this);
   }
   return;

--- a/packages/tempus/src/Tempus_StepperLeapfrog_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperLeapfrog_impl.hpp
@@ -169,6 +169,7 @@ void StepperLeapfrog<Scalar>::takeStep(
 
     workingState->setSolutionStatus(Status::PASSED);
     workingState->setOrder(this->getOrder());
+    workingState->computeNorms(currentState);
     //this->stepperObserver_->observeEndTakeStep(solutionHistory, *this);
   }
   return;

--- a/packages/tempus/src/Tempus_StepperNewmarkExplicitAForm_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkExplicitAForm_impl.hpp
@@ -302,6 +302,7 @@ void StepperNewmarkExplicitAForm<Scalar>::takeStep(
 
     workingState->setSolutionStatus(Status::PASSED);
     workingState->setOrder(this->getOrder());
+    workingState->computeNorms(currentState);
   }
   return;
 }

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_impl.hpp
@@ -480,6 +480,7 @@ void StepperNewmarkImplicitAForm<Scalar>::takeStep(
 
     workingState->setSolutionStatus(sStatus);  // Converged --> pass.
     workingState->setOrder(this->getOrder());
+    workingState->computeNorms(currentState);
   }
   return;
 }

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitDForm_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitDForm_impl.hpp
@@ -399,6 +399,7 @@ StepperNewmarkImplicitDForm<Scalar>::takeStep(
 #endif
 
     workingState->setOrder(this->getOrder());
+    workingState->computeNorms(currentState);
   }
   return;
 }

--- a/packages/tempus/src/Tempus_StepperOperatorSplit_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperOperatorSplit_impl.hpp
@@ -300,6 +300,7 @@ void StepperOperatorSplit<Scalar>::takeStep(
     if (pass == true) workingState->setSolutionStatus(Status::PASSED);
     else              workingState->setSolutionStatus(Status::FAILED);
     workingState->setOrder(this->getOrder());
+    workingState->computeNorms(solutionHistory->getCurrentState());
     OpSpSolnHistory_->clear();
     stepperOSObserver_->observeEndTakeStep(solutionHistory, *this);
   }

--- a/packages/tempus/src/Tempus_StepperStaggeredForwardSensitivity_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperStaggeredForwardSensitivity_impl.hpp
@@ -159,10 +159,10 @@ takeStep(
       xdotdot = XDotDot->getNonconstMultiVector()->col(0);
 
     // Create state solution history
-    RCP<SolutionState<Scalar> > state_state =
-      rcp(new SolutionState<Scalar>(state->getMetaData()->clone(),
-                                    x, xdot, xdotdot,
-                                    state->getStepperState()->clone()));
+    RCP<SolutionState<Scalar> > state_state = state->clone();
+    state_state->setX(x);
+    state_state->setXDot(xdot);
+    state_state->setXDotDot(xdotdot);
     stateSolutionHistory_ = rcp(new SolutionHistory<Scalar>(shPL));
     stateSolutionHistory_->addState(state_state);
 
@@ -187,10 +187,10 @@ takeStep(
       dxdotdotdp_vec = multiVectorProductVector(prod_space, dxdotdotdp);
 
     // Create sensitivity solution history
-    RCP<SolutionState<Scalar> > sens_state =
-      rcp(new SolutionState<Scalar>(state->getMetaData()->clone(),
-                                    dxdp_vec, dxdotdp_vec, dxdotdotdp_vec,
-                                    state->getStepperState()->clone()));
+    RCP<SolutionState<Scalar> > sens_state = state->clone();
+    sens_state->setX(dxdp_vec);
+    sens_state->setXDot(dxdotdp_vec);
+    sens_state->setXDotDot(dxdotdotdp_vec);
     sensSolutionHistory_ = rcp(new SolutionHistory<Scalar>(shPL));
     sensSolutionHistory_->addState(sens_state);
   }

--- a/packages/tempus/src/Tempus_StepperSubcycling_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperSubcycling_impl.hpp
@@ -392,29 +392,20 @@ void StepperSubcycling<Scalar>::takeStep(
     scTSC->setFinalTime  (workingState->getTime());
     scTSC->setMaxTimeStep(workingState->getTimeStep());
 
-    Teuchos::RCP<SolutionStateMetaData<Scalar> > scMD =
-      rcp(new SolutionStateMetaData<Scalar>());
-    scMD->copy(currentState->getMetaData());
-    scMD->setDt(scTSC->getInitTimeStep());
-    scMD->setOrder(scIntegrator_->getStepper()->getOrder());
-    scMD->setIStep(0);
-    scMD->setNFailures(0);
-    scMD->setNRunningFailures(0);
-    scMD->setNConsecutiveFailures(0);
-    scMD->setOutput(false);
-    scMD->setOutputScreen(false);
+    auto subcyclingState = currentState->clone();
+    subcyclingState->setTimeStep(scTSC->getInitTimeStep());
+    subcyclingState->setOrder(scIntegrator_->getStepper()->getOrder());
+    subcyclingState->setIndex(0);
+    subcyclingState->setNFailures(0);
+    subcyclingState->setNRunningFailures(0);
+    subcyclingState->setNConsecutiveFailures(0);
+    subcyclingState->setOutput(false);
+    subcyclingState->setOutputScreen(false);
 
-    TEUCHOS_TEST_FOR_EXCEPTION(!scMD->getIsSynced(), std::logic_error,
+    TEUCHOS_TEST_FOR_EXCEPTION(!subcyclingState->getIsSynced(),std::logic_error,
       "Error - StepperSubcycling<Scalar>::takeStep(...)\n"
       "        Subcycling requires the the solution is synced!\n"
       "        (i.e., x, xDot, and xDotDot at the same time level.\n");
-
-    auto subcyclingState = rcp(new SolutionState<Scalar>( scMD,
-                                           currentState->getX(),
-                                           currentState->getXDot(),
-                                           currentState->getXDotDot(),
-                                           currentState->getStepperState(),
-                                           currentState->getPhysicsState()));
 
     auto scSH = rcp(new Tempus::SolutionHistory<Scalar>());
     scSH->setName("Subcycling States");
@@ -447,6 +438,7 @@ void StepperSubcycling<Scalar>::takeStep(
     if (pass == true) workingState->setSolutionStatus(Status::PASSED);
     else              workingState->setSolutionStatus(Status::FAILED);
     workingState->setOrder(scCS->getOrder());
+    workingState->computeNorms(currentState);
     scSH->clear();
     stepperSCObserver_->observeEndTakeStep(solutionHistory, *this);
   }

--- a/packages/tempus/src/Tempus_StepperTrapezoidal_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperTrapezoidal_impl.hpp
@@ -171,6 +171,7 @@ void StepperTrapezoidal<Scalar>::takeStep(
 
     workingState->setSolutionStatus(sStatus);  // Converged --> pass.
     workingState->setOrder(this->getOrder());
+    workingState->computeNorms(currentState);
     this->stepperObserver_->observeEndTakeStep(solutionHistory, *this);
   }
   return;

--- a/packages/tempus/src/Tempus_TimeStepControlStrategyConstant.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategyConstant.hpp
@@ -12,7 +12,6 @@
 #include "Tempus_TimeStepControl.hpp"
 #include "Tempus_TimeStepControlStrategy.hpp"
 #include "Tempus_SolutionState.hpp"
-#include "Tempus_SolutionStateMetaData.hpp"
 #include "Tempus_SolutionHistory.hpp"
 #include "Tempus_StepperState.hpp"
 
@@ -41,11 +40,10 @@ public:
   {
      using Teuchos::RCP;
      RCP<SolutionState<Scalar> >workingState=solutionHistory->getWorkingState();
-     RCP<SolutionStateMetaData<Scalar> > metaData = workingState->getMetaData();
-     const Scalar errorAbs = metaData->getErrorAbs();
-     const Scalar errorRel = metaData->getErrorRel();
-     int order = metaData->getOrder();
-     Scalar dt = metaData->getDt();
+     const Scalar errorAbs = workingState->getErrorAbs();
+     const Scalar errorRel = workingState->getErrorRel();
+     int order = workingState->getOrder();
+     Scalar dt = workingState->getTimeStep();
      bool printDtChanges = tsc.getPrintDtChanges();
 
      dt = tsc.getInitTimeStep();
@@ -129,8 +127,8 @@ public:
        "    order = " << order << "\n");
 
      // update order and dt
-     metaData->setOrder(order);
-     metaData->setDt(dt);
+     workingState->setOrder(order);
+     workingState->setTimeStep(dt);
   }
 
 };

--- a/packages/tempus/src/Tempus_TimeStepControlStrategyIntegralController.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategyIntegralController.hpp
@@ -12,7 +12,6 @@
 #include "Tempus_TimeStepControl.hpp"
 #include "Tempus_TimeStepControlStrategy.hpp"
 #include "Tempus_SolutionState.hpp"
-#include "Tempus_SolutionStateMetaData.hpp"
 #include "Tempus_SolutionHistory.hpp"
 #include "Tempus_StepperState.hpp"
 
@@ -77,13 +76,12 @@ public:
      }
 
      Teuchos::RCP<SolutionState<Scalar> > workingState=solutionHistory->getWorkingState();
-     Teuchos::RCP<SolutionStateMetaData<Scalar> > metaData = workingState->getMetaData();
-     const Scalar errorRel = metaData->getErrorRel();
+     const Scalar errorRel = workingState->getErrorRel();
      Scalar beta = 1.0;
 
      // assumes the embedded solution is the low order solution
-     int order = metaData->getOrder() - 1;
-     Scalar dt = metaData->getDt();
+     int order = workingState->getOrder() - 1;
+     Scalar dt = workingState->getTimeStep();
      //bool printDtChanges = tsc.getPrintDtChanges();
 
      Teuchos::RCP<Teuchos::FancyOStream> out = tsc.getOStream();
@@ -129,7 +127,7 @@ public:
      if (workingState->getSolutionStatus() == Status::PASSED or
          workingState->getSolutionStatus() == Status::WORKING) {
         if(lastStepRejected_){
-           dt = std::min(dt, metaData->getDt());
+           dt = std::min(dt, workingState->getTimeStep());
         } else {
            facMax_ = tscsPL_->get<Scalar>("Maximum Safety Factor");
         }
@@ -140,7 +138,7 @@ public:
      }
 
      // update dt
-     metaData->setDt(dt);
+     workingState->setTimeStep(dt);
   }
 
   /// \name Overridden from Teuchos::ParameterListAcceptor

--- a/packages/tempus/src/Tempus_TimeStepControlStrategyPID.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControlStrategyPID.hpp
@@ -12,7 +12,6 @@
 #include "Tempus_TimeStepControl.hpp"
 #include "Tempus_TimeStepControlStrategy.hpp"
 #include "Tempus_SolutionState.hpp"
-#include "Tempus_SolutionStateMetaData.hpp"
 #include "Tempus_SolutionHistory.hpp"
 #include "Tempus_StepperState.hpp"
 
@@ -49,12 +48,11 @@ public:
      }
 
      Teuchos::RCP<SolutionState<Scalar> > workingState=solutionHistory->getWorkingState();
-     Teuchos::RCP<SolutionStateMetaData<Scalar> > metaData = workingState->getMetaData();
-     const Scalar errorAbs = metaData->getErrorAbs();
-     volatile const int iStep = metaData->getIStep();
-     volatile const Scalar errorRel = metaData->getErrorRel();
-     int order = metaData->getOrder();
-     Scalar dt = metaData->getDt();
+     const Scalar errorAbs = workingState->getErrorAbs();
+     volatile const int iStep = workingState->getIndex();
+     volatile const Scalar errorRel = workingState->getErrorRel();
+     int order = workingState->getOrder();
+     Scalar dt = workingState->getTimeStep();
      //bool printDtChanges = tsc.getPrintDtChanges();
 
      Teuchos::RCP<Teuchos::FancyOStream> out = tsc.getOStream();
@@ -93,7 +91,7 @@ public:
      if (workingState->getSolutionStatus() == Status::PASSED or
          workingState->getSolutionStatus() == Status::WORKING) {
         if(lastStepRejected_){
-           dt = std::min(dt, metaData->getDt());
+           dt = std::min(dt, workingState->getTimestep());
         } else {
            facMax_ = tscsPL_->get<Scalar>("Maximum Safety Factor");
         }
@@ -104,7 +102,7 @@ public:
      }
 
      // update dt
-     metaData->setDt(dt);
+     workingState->setTimeStep(dt);
   }
 
   /// \name Overridden from Teuchos::ParameterListAcceptor

--- a/packages/tempus/src/Tempus_TimeStepControl_impl.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControl_impl.hpp
@@ -64,11 +64,10 @@ void TimeStepControl<Scalar>::getNextTimeStep(
     };
 
     RCP<SolutionState<Scalar> > workingState=solutionHistory->getWorkingState();
-    RCP<SolutionStateMetaData<Scalar> > metaData = workingState->getMetaData();
     const Scalar lastTime = solutionHistory->getCurrentState()->getTime();
-    const int iStep = metaData->getIStep();
-    int order = metaData->getOrder();
-    Scalar dt = metaData->getDt();
+    const int iStep = workingState->getIndex();
+    int order = workingState->getOrder();
+    Scalar dt = workingState->getTimeStep();
     bool output = false;
 
     RCP<StepperState<Scalar> > stepperState = workingState->getStepperState();
@@ -96,16 +95,16 @@ void TimeStepControl<Scalar>::getNextTimeStep(
       }
     }
 
-    // update dt in metaData for the step control strategy to be informed
-    metaData->setDt(dt);
+    // update dt for the step control strategy to be informed
+    workingState->setTimeStep(dt);
 
     // call the step control strategy (to update order/dt if needed)
     stepControlStrategy_->getNextTimeStep(*this, solutionHistory,
                                          integratorStatus);
 
     // get the order and dt (probably have changed by stepControlStrategy_)
-    order = metaData->getOrder();
-    dt = metaData->getDt();
+    order = workingState->getOrder();
+    dt = workingState->getTimeStep();
 
     if (getStepType() == "Variable") {
       if (dt < getMinTimeStep()) { // decreased below minimum dt
@@ -224,10 +223,10 @@ void TimeStepControl<Scalar>::getNextTimeStep(
       << getFinalTime() << "]\n"
       "    T + dt = " << lastTime <<" + "<< dt <<" = " << lastTime + dt <<"\n");
 
-    metaData->setOrder(order);
-    metaData->setDt(dt);
-    metaData->setTime(lastTime + dt);
-    metaData->setOutput(output);
+    workingState->setOrder(order);
+    workingState->setTimeStep(dt);
+    workingState->setTime(lastTime + dt);
+    workingState->setOutput(output);
   }
   return;
 }

--- a/packages/tempus/test/IMEX_RK/Tempus_IMEX_RK_FSA.hpp
+++ b/packages/tempus/test/IMEX_RK/Tempus_IMEX_RK_FSA.hpp
@@ -155,6 +155,10 @@ void test_vdp_fsa(const bool use_combined_method,
       // Setup the Integrator and reset initial time step
       pl->sublist("Default Integrator")
          .sublist("Time Step Control").set("Initial Time Step", dt);
+      pl->sublist("Default Integrator")
+         .sublist("Time Step Control").set("Integrator Step Type", "Constant");
+      pl->sublist("Default Integrator")
+         .sublist("Time Step Control").remove("Time Step Control Strategy");
       RCP<Tempus::IntegratorForwardSensitivity<double> > integrator =
         Tempus::integratorForwardSensitivity<double>(pl, model);
       order = integrator->getStepper()->getOrder();

--- a/packages/tempus/test/IMEX_RK_Partitioned/Tempus_IMEX_RK_Partitioned_FSA.hpp
+++ b/packages/tempus/test/IMEX_RK_Partitioned/Tempus_IMEX_RK_Partitioned_FSA.hpp
@@ -199,6 +199,10 @@ void test_vdp_fsa(const std::string& method_name,
       // Setup the Integrator and reset initial time step
       pl->sublist("Default Integrator")
          .sublist("Time Step Control").set("Initial Time Step", dt);
+      pl->sublist("Default Integrator")
+         .sublist("Time Step Control").set("Integrator Step Type", "Constant");
+      pl->sublist("Default Integrator")
+         .sublist("Time Step Control").remove("Time Step Control Strategy");
       RCP<Tempus::IntegratorForwardSensitivity<double> > integrator =
         Tempus::integratorForwardSensitivity<double>(pl, model);
       order = integrator->getStepper()->getOrder();


### PR DESCRIPTION
Needed to change how the norms were calculated so that they
would work with just two states.  The norms are now calculated
at the end of the stepper where we have both the currentState
and the workingState available to calculate the relative change
in the solution.

  * Added to SolutionStateMetaData
    - xNormL2 - L2 Norm of the solution, ||x_i||
    - dxNormL2Rel - relative change, ||x_i-x_{i-1}||/||x_{i-1}||
    - dxNormL2Abs - absolute change, ||x_i-x_{i-1}||
    - computeNorms - flag to compute norms
  * Moved norms calculations from
    TimeStepControlStrategyBasicVS::computeEta() to
    SolutionState::computeNorms()
  * Added new test that is sensitive to TimeStepControlStrategyBasicVS.
  * Fixed a few tests that depended on having two SolutionStates to get
    constant timestepping.
  * Reduced the usage of SolutionStateMetaData interface in favor of
    the SolutionState interface.  There are a few places where the
    MetaData interface is useful.
  * Deprecated a constructor for SolutionStateMetaData.  Marked with
    TEMPUS_DEPRECATED and TEMPUS_DEPRECATED_CODE.
  * Fix bug where tolRel and tolAbs were swapped in ExplicitRK and DIRK.

Tempus and Piro tests pass on the CEE LAN.

@trilinos/tempus 

Closes #6438 