### PR TITLE
Xpetra: fixing a -Wshadow warning for issue #6295

### DIFF
--- a/packages/xpetra/src/Map/Xpetra_EpetraMapFactory.cpp
+++ b/packages/xpetra/src/Map/Xpetra_EpetraMapFactory.cpp
@@ -91,10 +91,6 @@ namespace Xpetra {
     {
       XPETRA_MONITOR("MapFactory::Build");
 
-      using LocalOrdinal  = int;
-      using GlobalOrdinal = int;
-      using Node          = EpetraNode;
-
 #ifdef HAVE_XPETRA_TPETRA
       if (lib == UseTpetra)
         return rcp( new Xpetra::TpetraMap<LocalOrdinal,GlobalOrdinal, Node> (numGlobalElements, indexBase, comm, lg) );
@@ -133,10 +129,6 @@ namespace Xpetra {
     {
       XPETRA_MONITOR("MapFactory::Build");
 
-      using LocalOrdinal  = int;
-      using GlobalOrdinal = int;
-      using Node          = EpetraNode;
-
 #ifdef HAVE_XPETRA_TPETRA
       if (lib == UseTpetra)
         return rcp( new TpetraMap<LocalOrdinal,GlobalOrdinal, Node> (numGlobalElements, numLocalElements, indexBase, comm) );
@@ -173,9 +165,6 @@ namespace Xpetra {
           int indexBase,
           const Teuchos::RCP<const Teuchos::Comm<int> > &comm)
     {
-      using LocalOrdinal  = int;
-      using GlobalOrdinal = int;
-      using Node          = EpetraNode;
 
       XPETRA_MONITOR("MapFactory::Build");
 #ifdef HAVE_XPETRA_TPETRA
@@ -198,10 +187,6 @@ namespace Xpetra {
           int                                                   numDofPerNode)
     {
       XPETRA_MONITOR("MapFactory::Build");
-
-      using LocalOrdinal  = int;
-      using GlobalOrdinal = int;
-      using Node          = EpetraNode;
 
       RCP<const BlockedMap<LocalOrdinal, GlobalOrdinal, Node> > bmap = Teuchos::rcp_dynamic_cast<const BlockedMap<LocalOrdinal, GlobalOrdinal, Node> >(map);
       if(!bmap.is_null())
@@ -245,10 +230,6 @@ namespace Xpetra {
                    const Teuchos::RCP< const Teuchos::Comm< int > > &comm)
     {
        XPETRA_MONITOR("MapFactory::Build");
-
-      using LocalOrdinal  = int;
-      using GlobalOrdinal = int;
-      using Node          = EpetraNode;
 
 #ifdef HAVE_XPETRA_TPETRA
        if (lib == UseTpetra)
@@ -298,10 +279,6 @@ namespace Xpetra {
     {
        XPETRA_MONITOR("MapFactory::Build");
 
-      using LocalOrdinal  = int;
-      using GlobalOrdinal = int;
-      using Node          = EpetraNode;
-
 #ifdef HAVE_XPETRA_TPETRA
        if (lib == UseTpetra)
 #if ((defined(EPETRA_HAVE_OMP) && (defined(HAVE_TPETRA_INST_OPENMP) && defined(HAVE_TPETRA_INST_INT_INT))) || \
@@ -350,10 +327,6 @@ namespace Xpetra {
     {
        XPETRA_MONITOR("MapFactory::Build");
 
-      using LocalOrdinal  = int;
-      using GlobalOrdinal = int;
-      using Node          = EpetraNode;
-
 #ifdef HAVE_XPETRA_TPETRA
        if (lib == UseTpetra)
 #if ((defined(EPETRA_HAVE_OMP) && (defined(HAVE_TPETRA_INST_OPENMP) && defined(HAVE_TPETRA_INST_INT_INT))) || \
@@ -384,10 +357,6 @@ namespace Xpetra {
                            const Teuchos::RCP< const Teuchos::Comm< int > > &comm)
     {
        XPETRA_MONITOR("MapFactory::Build");
-
-      using LocalOrdinal  = int;
-      using GlobalOrdinal = int;
-      using Node          = EpetraNode;
 
 #ifdef HAVE_XPETRA_TPETRA
        if (lib == UseTpetra)
@@ -420,10 +389,6 @@ namespace Xpetra {
                     const Teuchos::RCP< const Teuchos::Comm< int > > &comm)
     {
        XPETRA_MONITOR("MapFactory::Build");
-
-      using LocalOrdinal  = int;
-      using GlobalOrdinal = int;
-      using Node          = EpetraNode;
 
        #ifdef HAVE_XPETRA_TPETRA
        if (lib == UseTpetra)
@@ -468,10 +433,6 @@ namespace Xpetra {
                             const Teuchos::RCP< const Teuchos::Comm< int > > &comm)
     {
        XPETRA_MONITOR("MapFactory::Build");
-
-      using LocalOrdinal  = int;
-      using GlobalOrdinal = int;
-      using Node          = EpetraNode;
 
 #ifdef HAVE_XPETRA_TPETRA
        if (lib == UseTpetra)
@@ -544,10 +505,6 @@ namespace Xpetra {
     {
       XPETRA_MONITOR("MapFactory::Build");
 
-      using LocalOrdinal  = int;
-      using GlobalOrdinal = long long;
-      using Node          = EpetraNode;
-
 #ifdef HAVE_XPETRA_TPETRA
       if (lib == UseTpetra)
         return rcp( new TpetraMap<LocalOrdinal,GlobalOrdinal, Node> (numGlobalElements, indexBase, comm, lg) );
@@ -585,10 +542,6 @@ namespace Xpetra {
            const Teuchos::RCP<const Teuchos::Comm<int> > &comm)
     {
       XPETRA_MONITOR("MapFactory::Build");
-
-      using LocalOrdinal  = int;
-      using GlobalOrdinal = long long;
-      using Node          = EpetraNode;
 
 #ifdef HAVE_XPETRA_TPETRA
       if (lib == UseTpetra)
@@ -628,10 +581,6 @@ namespace Xpetra {
     {
       XPETRA_MONITOR("MapFactory::Build");
 
-      using LocalOrdinal  = int;
-      using GlobalOrdinal = long long;
-      using Node          = EpetraNode;
-
 #ifdef HAVE_XPETRA_TPETRA
       if (lib == UseTpetra)
         return rcp( new TpetraMap<LocalOrdinal,GlobalOrdinal, Node> (numGlobalElements, elementList, indexBase, comm) );
@@ -651,10 +600,6 @@ namespace Xpetra {
            int numDofPerNode)
     {
       XPETRA_MONITOR("MapFactory::Build");
-
-      using LocalOrdinal  = int;
-      using GlobalOrdinal = long long;
-      using Node          = EpetraNode;
 
       RCP<const BlockedMap<LocalOrdinal, GlobalOrdinal, Node> > bmap = Teuchos::rcp_dynamic_cast<const BlockedMap<LocalOrdinal, GlobalOrdinal, Node> >(map);
       if(!bmap.is_null()) {
@@ -689,10 +634,6 @@ namespace Xpetra {
                    const Teuchos::RCP< const Teuchos::Comm< int > > &comm)
     {
        XPETRA_MONITOR("MapFactory::Build");
-
-      using LocalOrdinal  = int;
-      using GlobalOrdinal = long long;
-      using Node          = EpetraNode;
 
 #ifdef HAVE_XPETRA_TPETRA
        if (lib == UseTpetra)
@@ -733,10 +674,6 @@ namespace Xpetra {
                            const Teuchos::RCP< const Teuchos::Comm< int > > &comm)
     {
        XPETRA_MONITOR("MapFactory::Build");
-
-      using LocalOrdinal  = int;
-      using GlobalOrdinal = long long;
-      using Node          = EpetraNode;
 
 #ifdef HAVE_XPETRA_TPETRA
        if (lib == UseTpetra)
@@ -783,10 +720,6 @@ namespace Xpetra {
     {
        XPETRA_MONITOR("MapFactory::Build");
 
-      using LocalOrdinal  = int;
-      using GlobalOrdinal = long long;
-      using Node          = EpetraNode;
-
 #ifdef HAVE_XPETRA_TPETRA
        if (lib == UseTpetra)
 #if ((defined(EPETRA_HAVE_OMP) && (defined(HAVE_TPETRA_INST_OPENMP) && defined(HAVE_TPETRA_INST_INT_LONG_LONG))) || \
@@ -818,10 +751,6 @@ namespace Xpetra {
     {
        XPETRA_MONITOR("MapFactory::Build");
 
-      using LocalOrdinal  = int;
-      using GlobalOrdinal = long long;
-      using Node          = EpetraNode;
-
 #ifdef HAVE_XPETRA_TPETRA
        if (lib == UseTpetra)
 #if ((defined(EPETRA_HAVE_OMP) && (defined(HAVE_TPETRA_INST_OPENMP) && defined(HAVE_TPETRA_INST_INT_LONG_LONG))) || \
@@ -847,10 +776,6 @@ namespace Xpetra {
                                                             const Teuchos::RCP<const Teuchos::Comm<int>>& comm)
     {
         XPETRA_MONITOR("MapFactory::Build");
-
-        using LocalOrdinal  = int;
-        using GlobalOrdinal = long long;
-        using Node          = EpetraNode;
 
 #ifdef HAVE_XPETRA_TPETRA
         if(lib == UseTpetra)
@@ -896,10 +821,6 @@ namespace Xpetra {
                             const Teuchos::RCP<const Teuchos::Comm<int>>& comm)
     {
         XPETRA_MONITOR("MapFactory::Build");
-
-        using LocalOrdinal  = int;
-        using GlobalOrdinal = long long;
-        using Node          = EpetraNode;
 
 #ifdef HAVE_XPETRA_TPETRA
         if(lib == UseTpetra)


### PR DESCRIPTION
@trilinos/xpetra 

## Motivation
Just removing un-necessary type definition since the definitions are already available through the class templates.
This is should remove the current error in Xpetra from [this build](https://testing.sandia.gov/cdash/index.php?project=Trilinos&display=project&filtercount=3&showfilters=1&filtercombine=and&field1=site&compare1=61&value1=ascic166&field2=buildname&compare2=61&value2=PR-gcc_8.3-test-Trilinos_pullrequest_gcc_8.3.0-15&field3=buildstamp&compare3=61&value3=20191211-0033-Experimental)

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of #6295 
* Composed of 



## Testing
Local build and tests have been performed using gcc/8.3.0