### PR TITLE
rol: updates to fix compile errors with kokkos deprecated code off

### DIFF
--- a/packages/rol/adapters/tpetra/src/mpi/ROL_PinTVectorCommunication_Tpetra.hpp
+++ b/packages/rol/adapters/tpetra/src/mpi/ROL_PinTVectorCommunication_Tpetra.hpp
@@ -66,9 +66,9 @@ public:
   void send(MPI_Comm comm,int rank,Vector<Real> & source,int tag=0) const override
   {
     auto & tp_source = *dynamic_cast<TpetraMultiVector<Real>&>(source).getVector();
-    tp_source.template sync<Kokkos::HostSpace>();
+    tp_source.sync_host();
 
-    auto view = tp_source.template getLocalView<Kokkos::HostSpace>();
+    auto view = tp_source.getLocalViewHost();
 
     // int myRank = -1;
     // MPI_Comm_rank(comm, &myRank);
@@ -82,7 +82,7 @@ public:
   void recv(MPI_Comm comm,int rank,Vector<Real> & dest,int tag=0) const override
   {
     auto & tp_dest = *dynamic_cast<TpetraMultiVector<Real>&>(dest).getVector();
-    auto view = tp_dest.template getLocalView<Kokkos::HostSpace>();
+    auto view = tp_dest.getLocalViewHost();
 
     // int myRank = -1;
     // MPI_Comm_rank(comm, &myRank);
@@ -98,7 +98,7 @@ public:
   void recvSumInto(MPI_Comm comm,int rank,Vector<Real> & dest,int tag=0) const override
   {
     auto & tp_dest = *dynamic_cast<TpetraMultiVector<Real>&>(dest).getVector();
-    auto view = tp_dest.template getLocalView<Kokkos::HostSpace>();
+    auto view = tp_dest.getLocalViewHost();
 
     int myRank = -1;
     MPI_Comm_rank(comm, &myRank);


### PR DESCRIPTION
Convert templated calls getLocalView<Kokkos::HostSpace> to getLocalViewHost
 Changes to be committed:
	modified:   packages/rol/adapters/tpetra/src/mpi/ROL_PinTVectorCommunication_Tpetra.hpp

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/rol 

## Motivation
These changes are necessary to successfully compile when disabling Kokkos' deprecated code.

Detected during Kokkos+KokkosKernels Trilinos Integration testing on Waterman with a configuration like the following:

```
module purge
source ${TRILINOS_DIR}/cmake/std/atdm/load-env.sh cuda-9.2-opt

cmake \
 -GNinja \
 -DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/atdm/ATDMDevEnv.cmake \
 -DTrilinos_ENABLE_TESTS=ON \
 -DTrilinos_ENABLE_ALL_PACKAGES=ON \
  -DKOKKOS_ENABLE_DEPRECATED_CODE=OFF \
$TRILINOS_DIR
```


## Testing
Compilation now successfully continuing with the changes in the PR