### PR TITLE
kokkos-kernels: update distance1 handle, gemm unit test

### DIFF
--- a/packages/kokkos-kernels/src/graph/KokkosGraph_Distance1ColorHandle.hpp
+++ b/packages/kokkos-kernels/src/graph/KokkosGraph_Distance1ColorHandle.hpp
@@ -521,13 +521,7 @@ private:
             vector_size,
             nv, ne);
 
-        team_policy_t tmp_policy(nv, Kokkos::AUTO, vector_size);
-        int max_allowed_team_size = tmp_policy.team_size_max( clt, Kokkos::ParallelForTag() );
-
-        KokkosKernels::Impl::get_suggested_team_size<HandleExecSpace>(
-            max_allowed_team_size,
-            vector_size,
-            teamSizeMax);
+        teamSizeMax = KokkosKernels::Impl::get_suggested_team_size<team_policy_t>(clt, vector_size);
 #endif
 
         Kokkos::parallel_for("KokkosGraph::CountLowerTriangleTeam",

--- a/packages/kokkos-kernels/unit_test/blas/Test_Blas3_gemm.hpp
+++ b/packages/kokkos-kernels/unit_test/blas/Test_Blas3_gemm.hpp
@@ -106,9 +106,21 @@ namespace Test {
     Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(seed);
 
     // (SA 11 Dec 2019) Max (previously: 10) increased to detect the bug in Trilinos issue #6418 
-    Kokkos::fill_random(A,rand_pool, Kokkos::rand<typename Kokkos::Random_XorShift64_Pool<execution_space>::generator_type,ScalarA>::max());
-    Kokkos::fill_random(B,rand_pool, Kokkos::rand<typename Kokkos::Random_XorShift64_Pool<execution_space>::generator_type,ScalarB>::max());
-    Kokkos::fill_random(C,rand_pool, Kokkos::rand<typename Kokkos::Random_XorShift64_Pool<execution_space>::generator_type,ScalarC>::max());
+#ifdef KOKKOS_ENABLE_CUDA
+    if (std::is_same<execution_space,Kokkos::Cuda>::value) 
+    {
+      Kokkos::fill_random(A,rand_pool, Kokkos::rand<typename Kokkos::Random_XorShift64_Pool<execution_space>::generator_type,ScalarA>::max());
+      Kokkos::fill_random(B,rand_pool, Kokkos::rand<typename Kokkos::Random_XorShift64_Pool<execution_space>::generator_type,ScalarB>::max());
+      Kokkos::fill_random(C,rand_pool, Kokkos::rand<typename Kokkos::Random_XorShift64_Pool<execution_space>::generator_type,ScalarC>::max());
+    }
+    else
+#else
+    {
+      Kokkos::fill_random(A,rand_pool,ScalarA(10));
+      Kokkos::fill_random(B,rand_pool,ScalarB(10));
+      Kokkos::fill_random(C,rand_pool,ScalarC(10));
+    }
+#endif
     
     Kokkos::deep_copy(C2,C);
 

--- a/packages/kokkos-kernels/unit_test/blas/Test_Blas3_gemm.hpp
+++ b/packages/kokkos-kernels/unit_test/blas/Test_Blas3_gemm.hpp
@@ -106,21 +106,23 @@ namespace Test {
     Kokkos::Random_XorShift64_Pool<execution_space> rand_pool(seed);
 
     // (SA 11 Dec 2019) Max (previously: 10) increased to detect the bug in Trilinos issue #6418 
+    // Revisit this to address issues with complex types
+/*
 #ifdef KOKKOS_ENABLE_CUDA
-    if (std::is_same<execution_space,Kokkos::Cuda>::value) 
+    if (std::is_same<execution_space,Kokkos::Cuda>::value)
     {
       Kokkos::fill_random(A,rand_pool, Kokkos::rand<typename Kokkos::Random_XorShift64_Pool<execution_space>::generator_type,ScalarA>::max());
       Kokkos::fill_random(B,rand_pool, Kokkos::rand<typename Kokkos::Random_XorShift64_Pool<execution_space>::generator_type,ScalarB>::max());
       Kokkos::fill_random(C,rand_pool, Kokkos::rand<typename Kokkos::Random_XorShift64_Pool<execution_space>::generator_type,ScalarC>::max());
     }
     else
-#else
+#endif
+*/
     {
       Kokkos::fill_random(A,rand_pool,ScalarA(10));
       Kokkos::fill_random(B,rand_pool,ScalarB(10));
       Kokkos::fill_random(C,rand_pool,ScalarC(10));
     }
-#endif
     
     Kokkos::deep_copy(C2,C);
 


### PR DESCRIPTION
Addresses issue #6450

update handle to call get_suggested_team_size with proper API, missed
during cherry pick as part of PR #6439

preemptively update Blas3_gemm unit test as done in PR
kokkos/kokkos-kernels#529

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/kokkos-kernels 

## Motivation

Fix bug reported in #6450
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
Confirmation from @ikalash that this resolve Albany issues reported in #6450 
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing

a la PR tester
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->