### PR TITLE
Xpetra, MueLu: Fix no-tpetra, no-ETI build

### DIFF
--- a/packages/muelu/test/scaling/ImportPerformance.cpp
+++ b/packages/muelu/test/scaling/ImportPerformance.cpp
@@ -772,7 +772,9 @@ int main_(Teuchos::CommandLineProcessor &clp,  Xpetra::UnderlyingLib &lib, int a
 #include "MueLu_Test_ETI.hpp"
 
 int main(int argc, char *argv[]) {
+#ifdef HAVE_MUELU_KOKKOSCORE
     Kokkos::ScopeGuard KokkosScope(argc,argv);
+#endif
     auto val =  Automatic_Test_ETI(argc,argv);
     return val;
 }

--- a/packages/xpetra/CMakeLists.txt
+++ b/packages/xpetra/CMakeLists.txt
@@ -22,7 +22,7 @@ IF( DEFINED ${PROJECT_NAME}_ENABLE_Tpetra AND ${${PACKAGE_NAME}_ENABLE_Tpetra} )
   TRIBITS_ADD_EXPLICIT_INSTANTIATION_OPTION()
 ELSE()
   MESSAGE( STATUS "Xpetra: Skipping ETI check because Tpetra is not enabled." )
-  SET( HAVE_${PACKAGE_NAME_UC}_EXPLICIT_INSTANTIATION OFF BOOL "Set to OFF by CMake because Tpetra isn't enabled" )
+  SET( HAVE_${PACKAGE_NAME_UC}_EXPLICIT_INSTANTIATION OFF )
 ENDIF()
 
 # Deprecation stuff

--- a/packages/xpetra/src/BlockedCrsMatrix/Xpetra_MapExtractor_decl.hpp
+++ b/packages/xpetra/src/BlockedCrsMatrix/Xpetra_MapExtractor_decl.hpp
@@ -60,6 +60,8 @@
 #include <Xpetra_MapUtils.hpp>
 #include <Xpetra_MultiVector_decl.hpp>
 #include <Xpetra_Vector.hpp>
+#include <Xpetra_BlockedMultiVector_decl.hpp>
+#include <Xpetra_MultiVectorFactory_decl.hpp>
 
 namespace Xpetra {
 

--- a/packages/xpetra/src/BlockedCrsMatrix/Xpetra_MapExtractor_def.hpp
+++ b/packages/xpetra/src/BlockedCrsMatrix/Xpetra_MapExtractor_def.hpp
@@ -48,6 +48,7 @@
 
 #include <Xpetra_MultiVectorFactory.hpp>
 #include <Xpetra_VectorFactory.hpp>
+#include <Xpetra_BlockedMultiVector.hpp>
 
 #include <Xpetra_MapExtractor_decl.hpp>
 

--- a/packages/xpetra/src/BlockedMap/Xpetra_BlockedMap_def.hpp
+++ b/packages/xpetra/src/BlockedMap/Xpetra_BlockedMap_def.hpp
@@ -51,7 +51,7 @@
 
 #include "Xpetra_Exceptions.hpp"
 #include "Xpetra_ImportFactory.hpp"
-#include "Xpetra_MapFactory_decl.hpp"
+#include "Xpetra_MapFactory.hpp"
 
 
 

--- a/packages/xpetra/src/BlockedVector/Xpetra_BlockedVector_def.hpp
+++ b/packages/xpetra/src/BlockedVector/Xpetra_BlockedVector_def.hpp
@@ -49,7 +49,7 @@
 
 #include "Xpetra_BlockedVector_decl.hpp"
 
-#include "Xpetra_BlockedMultiVector_decl.hpp"
+#include "Xpetra_BlockedMultiVector.hpp"
 #include "Xpetra_Exceptions.hpp"
 
 

--- a/packages/xpetra/src/Vector/Xpetra_EpetraVectorFactory.cpp
+++ b/packages/xpetra/src/Vector/Xpetra_EpetraVectorFactory.cpp
@@ -44,7 +44,8 @@
 //
 // @HEADER
 #include "Xpetra_VectorFactory.hpp"
-
+#include "Xpetra_Vector.hpp"
+#include "Xpetra_BlockedVector.hpp"
 
 namespace Xpetra {
 

--- a/packages/xpetra/sup/StridedMap/Xpetra_StridedMap_def.hpp
+++ b/packages/xpetra/sup/StridedMap/Xpetra_StridedMap_def.hpp
@@ -49,7 +49,7 @@
 #ifndef XPETRA_STRIDEDMAP_DEF_HPP
 #define XPETRA_STRIDEDMAP_DEF_HPP
 
-#include "Xpetra_StridedMap_decl.hpp"
+#include "Xpetra_StridedMap.hpp"
 
 #include <Teuchos_OrdinalTraits.hpp>
 

--- a/packages/xpetra/test/BlockedMultiVector/ThyraBlockedMultiVector_UnitTests.cpp
+++ b/packages/xpetra/test/BlockedMultiVector/ThyraBlockedMultiVector_UnitTests.cpp
@@ -66,7 +66,7 @@
 #include <Xpetra_ThyraUtils.hpp>
 
 #ifdef HAVE_XPETRA_THYRA
-#include <Thyra_DefaultProductVectorSpace_decl.hpp>
+#include <Thyra_DefaultProductVectorSpace.hpp>
 #endif
 
 #include <set>

--- a/packages/xpetra/test/Map/StridedMapFactory_UnitTests.cpp
+++ b/packages/xpetra/test/Map/StridedMapFactory_UnitTests.cpp
@@ -60,6 +60,7 @@
 #endif
 
 #include "Xpetra_StridedMapFactory.hpp"
+#include "Xpetra_StridedMap.hpp"
 
 namespace {
   using Teuchos::Array;

--- a/packages/xpetra/test/Matrix/Matrix_UnitTests.cpp
+++ b/packages/xpetra/test/Matrix/Matrix_UnitTests.cpp
@@ -241,7 +241,6 @@ namespace {
     Teuchos::RCP<const Teuchos::Comm<int> > comm = getDefaultComm();
     const size_t numLocal = 10;
     const size_t INVALID = Teuchos::OrdinalTraits<size_t>::invalid(); // TODO: global_size_t instead of size_t
-    using MV  = Xpetra::MultiVector<Scalar,LO,GO,Node>;
     using Teuchos::ArrayRCP;
     using Teuchos::RCP;
     using Teuchos::rcp;
@@ -250,6 +249,7 @@ namespace {
 
 
 #ifdef HAVE_XPETRA_TPETRA
+    using MV  = Xpetra::MultiVector<Scalar,LO,GO,Node>;
     typedef Xpetra::CrsMatrixWrap<Scalar, LO, GO, Node> CrsMatrixWrap;
     RCP<const Xpetra::Map<LO,GO,Node> > map =
       Xpetra::MapFactory<LO,GO,Node>::createContigMapWithNode (Xpetra::UseTpetra,INVALID,numLocal,comm);   


### PR DESCRIPTION
- Xpetra cmake tried to pass type and docstring to set(), but that
 isn't allowed (so HAVE_XPETRA_EXPLICIT_INSTANTIATION was really
 being set to "OFF BOOL ..." which is truthy).
- Fixed some places where Y_decl.hpp was included in X_def.hpp.
 Instead, including Y.hpp.
- Fixed some missing decl includes that caused missing short names
 definitions.
- In MueLu ImportPerformance test, guard usage of Kokkos with macros

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/xpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The [nightly geminga build that does this configuration](https://testing-dev.sandia.gov/cdash/viewBuildError.php?buildid=5097866) has been failing.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Only file includes were changed, not semantics.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->