### PR TITLE
Intrepid2: add support for hierarchical H(grad) bases on triangle and tetrahedron.

### DIFF
--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_Basis.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_Basis.hpp
@@ -359,7 +359,7 @@ namespace Intrepid2 {
                const PointViewType  /* inputPoints */,
                const EOperator /* operatorType */ = OPERATOR_VALUE ) const {
       INTREPID2_TEST_FOR_EXCEPTION( true, std::logic_error,
-                                    ">>> ERROR (Basis::getValues): this method (FEM) is not supported or should be over-riden accordingly by derived classes.");
+                                    ">>> ERROR (Basis::getValues): this method (FEM) is not supported or should be overridden accordingly by derived classes.");
     }
 
     /** \brief  Evaluation of an FVD basis evaluation on a <strong>physical cell</strong>.
@@ -388,7 +388,7 @@ namespace Intrepid2 {
                 const PointViewType  /* cellVertices */,
                 const EOperator /* operatorType */ = OPERATOR_VALUE ) const {
       INTREPID2_TEST_FOR_EXCEPTION( true, std::logic_error,
-                                    ">>> ERROR (Basis::getValues): this method (FVM) is not supported or should be over-riden accordingly by derived classes.");
+                                    ">>> ERROR (Basis::getValues): this method (FVM) is not supported or should be overridden accordingly by derived classes.");
     }
 
 
@@ -399,7 +399,7 @@ namespace Intrepid2 {
     void
     getDofCoords( ScalarViewType /* dofCoords */ ) const {
       INTREPID2_TEST_FOR_EXCEPTION( true, std::logic_error,
-                                    ">>> ERROR (Basis::getDofCoords): this method is not supported or should be over-riden accordingly by derived classes.");
+                                    ">>> ERROR (Basis::getDofCoords): this method is not supported or should be overridden accordingly by derived classes.");
     }
 
     /** \brief Coefficients for computing degrees of freedom for Lagrangian basis
@@ -414,7 +414,7 @@ namespace Intrepid2 {
     void
     getDofCoeffs( ScalarViewType /* dofCoeffs */ ) const {
       INTREPID2_TEST_FOR_EXCEPTION( true, std::logic_error,
-                                    ">>> ERROR (Basis::getDofCoeffs): this method is not supported or should be over-riden accordingly by derived classes.");
+                                    ">>> ERROR (Basis::getDofCoeffs): this method is not supported or should be overridden accordingly by derived classes.");
     }
 
     /** \brief For hierarchical bases, returns the field ordinals that have at most the specified degree in each dimension.

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HGRAD_HEX.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HGRAD_HEX.hpp
@@ -106,13 +106,13 @@ namespace Intrepid2
     */
     virtual
     const char*
-    getName() const {
+    getName() const override {
       return "Intrepid2_DerivedBasis_HGRAD_HEX";
     }
 
     /** \brief True if orientation is required
     */
-    virtual bool requireOrientation() const {
+    virtual bool requireOrientation() const override {
       return (this->getDegree() > 2);
     }
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HGRAD_QUAD.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HGRAD_QUAD.hpp
@@ -94,13 +94,13 @@ namespace Intrepid2
     */
     virtual
     const char*
-    getName() const {
+    getName() const override {
       return "Intrepid2_DerivedBasis_HGRAD_QUAD";
     }
 
     /** \brief True if orientation is required
     */
-    virtual bool requireOrientation() const {
+    virtual bool requireOrientation() const override {
       return (this->getDegree() > 2);
     }
     

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_HEX_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HCURL_HEX_In_FEM.hpp
@@ -169,9 +169,9 @@ namespace Intrepid2 {
   }
 
   /** \class  Intrepid2::Basis_HCURL_HEX_In_FEM
-      \brief  Implementation of the default H(curl)-compatible FEM basis on Hexahedral cell
+      \brief  Implementation of the default H(curl)-compatible FEM basis on Hexahedron cell
 
-              Implements Nedelec basis of degree n on the reference Hexahedral cell. The basis has
+              Implements Nedelec basis of degree n on the reference Hexahedron cell. The basis has
               cardinality 3n (n+1)^2 and spans a INCOMPLETE polynomial space.
 
   */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_HEX_In_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_HEX_In_FEM.hpp
@@ -158,9 +158,9 @@ namespace Intrepid2 {
   }
 
   /** \class  Intrepid2::Basis_HDIV_HEX_In_FEM
-      \brief  Implementation of the default H(div)-compatible FEM basis on Hexahedral cell
+      \brief  Implementation of the default H(div)-compatible FEM basis on Hexahedron cell
 
-              Implements Raviart-Thomas basis of degree n on the reference Hexahedral cell. The basis has
+              Implements Raviart-Thomas basis of degree n on the reference Hexahedron cell. The basis has
               cardinality 3(n+1)n^2 and spans a INCOMPLETE polynomial space.
 
   */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_I1_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HDIV_TET_I1_FEMDef.hpp
@@ -241,7 +241,7 @@ namespace Intrepid2 {
       dofCoords("dofCoordsHost", this->basisCardinality_,this->basisCellTopology_.getDimension());
 
     dofCoords(0,0) =  1.0/3.0;   dofCoords(0,1) =  0.0;       dofCoords(0,2) = 1.0/3.0;
-    dofCoords(1,0) =  1.0/3.0;   dofCoords(1,1) =  1.0/3.0;   dofCoords(1,2) = 1.0/3.0;;
+    dofCoords(1,0) =  1.0/3.0;   dofCoords(1,1) =  1.0/3.0;   dofCoords(1,2) = 1.0/3.0;
     dofCoords(2,0) =  0.0;       dofCoords(2,1) =  1.0/3.0;   dofCoords(2,2) = 1.0/3.0;
     dofCoords(3,0) =  1.0/3.0;   dofCoords(3,1) =  1.0/3.0;   dofCoords(3,2) = 0.0;
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_WEDGE_C2_FEMDef.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HGRAD_WEDGE_C2_FEMDef.hpp
@@ -204,7 +204,7 @@ namespace Intrepid2 {
 
         output.access(4, 0) =  2.*z*(1. + z);
         output.access(4, 1) =  0.;
-        output.access(4, 2) =  ((-1. + 4.*x)*(1. + 2.*z))/2.;;
+        output.access(4, 2) =  ((-1. + 4.*x)*(1. + 2.*z))/2.;
         output.access(4, 3) =  0.;
         output.access(4, 4) =  0.;
         output.access(4, 5) =  x*(-1. + 2.*x);

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_C0_FEM.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HVOL_C0_FEM.hpp
@@ -124,7 +124,7 @@ namespace Intrepid2 {
   }
 
    /** \class  Intrepid2::Basis_HVOL_C0_FEM
-       \brief  Implementation of the default HVOL-compatible FEM contstant basis on triangle, quadrilateral, hexahedral and tetrahedral cells.
+       \brief  Implementation of the default HVOL-compatible FEM contstant basis on triangle, quadrilateral, hexahedron and tetrahedron cells.
   */
   template<typename ExecSpaceType = void,
            typename outputValueType = double,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HierarchicalBasisFamily.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HierarchicalBasisFamily.hpp
@@ -52,11 +52,41 @@
 #include "Intrepid2_DerivedBasisFamily.hpp"
 
 #include "Intrepid2_IntegratedLegendreBasis_HGRAD_LINE.hpp"
+#include "Intrepid2_IntegratedLegendreBasis_HGRAD_TRI.hpp"
+#include "Intrepid2_IntegratedLegendreBasis_HGRAD_TET.hpp"
 #include "Intrepid2_LegendreBasis_HVOL_LINE.hpp"
 
 namespace Intrepid2 {
   // the following defines a family of hierarchical basis functions that matches the unpermuted ESEAS basis functions
   // each basis member is associated with appropriate subcell topologies, making this suitable for continuous Galerkin finite elements.
+  
+  template<typename ExecutionSpace=Kokkos::DefaultExecutionSpace,
+           typename OutputScalar = double,
+           typename PointScalar  = double,
+           bool defineVertexFunctions = true>
+  class HierarchicalTriangleBasisFamily
+  {
+  public:
+    // we will fill these in as we implement them
+    using HGRAD = IntegratedLegendreBasis_HGRAD_TRI<ExecutionSpace,OutputScalar,PointScalar,defineVertexFunctions>;
+    using HCURL = void;
+    using HDIV  = void;
+    using HVOL  = void;
+  };
+  
+  template<typename ExecutionSpace=Kokkos::DefaultExecutionSpace,
+  typename OutputScalar = double,
+  typename PointScalar  = double,
+  bool defineVertexFunctions = true>
+  class HierarchicalTetrahedronBasisFamily
+  {
+  public:
+    // we will fill these in as we implement them
+    using HGRAD = IntegratedLegendreBasis_HGRAD_TET<ExecutionSpace,OutputScalar,PointScalar,defineVertexFunctions>;
+    using HCURL = void;
+    using HDIV  = void;
+    using HVOL  = void;
+  };
   
   /** \class Intrepid2::HierarchicalBasisFamily
       \brief A family of hierarchical basis functions, constructed in a way that follows work by Fuentes et al.
@@ -82,7 +112,10 @@ namespace Intrepid2 {
            typename OutputScalar = double,
            typename PointScalar  = double>
   using HierarchicalBasisFamily = DerivedBasisFamily< IntegratedLegendreBasis_HGRAD_LINE<ExecutionSpace,OutputScalar,PointScalar,true>,
-                                                      LegendreBasis_HVOL_LINE<ExecutionSpace,OutputScalar,PointScalar> >;
+                                                      LegendreBasis_HVOL_LINE<ExecutionSpace,OutputScalar,PointScalar>,
+                                                      HierarchicalTriangleBasisFamily<ExecutionSpace,OutputScalar,PointScalar>,
+                                                      HierarchicalTetrahedronBasisFamily<ExecutionSpace,OutputScalar,PointScalar>
+                                                      >;
   
   /** \class Intrepid2::HierarchicalBasisFamily
       \brief A family of hierarchical basis functions, constructed in a way that follows work by Fuentes et al., suitable for use in DG contexts.
@@ -96,7 +129,10 @@ namespace Intrepid2 {
            typename OutputScalar = double,
            typename PointScalar  = double>
   using DGHierarchicalBasisFamily = DerivedBasisFamily< IntegratedLegendreBasis_HGRAD_LINE<ExecutionSpace,OutputScalar,PointScalar,false>,
-                                                        LegendreBasis_HVOL_LINE<ExecutionSpace,OutputScalar,PointScalar> >;
+                                                        LegendreBasis_HVOL_LINE<ExecutionSpace,OutputScalar,PointScalar>,
+                                                        HierarchicalTriangleBasisFamily<ExecutionSpace,OutputScalar,PointScalar,false>,
+                                                        HierarchicalTetrahedronBasisFamily<ExecutionSpace,OutputScalar,PointScalar,false>
+                                                      >;
   
 }
 

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_IntegratedLegendreBasis_HGRAD_TET.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_IntegratedLegendreBasis_HGRAD_TET.hpp
@@ -1,0 +1,856 @@
+// @HEADER
+// ************************************************************************
+//
+//                           Intrepid2 Package
+//                 Copyright (2007) Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Kyungjoo Kim  (kyukim@sandia.gov),
+//                    Mauro Perego  (mperego@sandia.gov), or
+//                    Nate Roberts  (nvrober@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+
+/** \file   Intrepid2_IntegratedLegendreBasis_HGRAD_TET.hpp
+    \brief  H(grad) basis on the tetrahedon based on integrated Legendre polynomials.
+    \author Created by N.V. Roberts.
+ */
+
+#ifndef Intrepid2_IntegratedLegendreBasis_HGRAD_TET_h
+#define Intrepid2_IntegratedLegendreBasis_HGRAD_TET_h
+
+#include <Kokkos_View.hpp>
+#include <Kokkos_DynRankView.hpp>
+
+#include <Intrepid2_config.h>
+
+#include "Intrepid2_Polynomials.hpp"
+#include "Intrepid2_Utils.hpp"
+
+namespace Intrepid2
+{
+  /** \class  Intrepid2::Hierarchical_HGRAD_TET_Functor
+      \brief  Functor for computing values for the IntegratedLegendreBasis_HGRAD_TET class.
+   
+   This functor is not intended for use outside of IntegratedLegendreBasis_HGRAD_TET.
+  */
+  template<class ExecutionSpace, class OutputScalar, class PointScalar,
+           class OutputFieldType, class InputPointsType>
+  struct Hierarchical_HGRAD_TET_Functor
+  {
+    using ScratchSpace        = Kokkos::DefaultExecutionSpace::scratch_memory_space;
+    using OutputScratchView   = Kokkos::View<OutputScalar*,ScratchSpace,Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+    using OutputScratchView2D = Kokkos::View<OutputScalar**,ScratchSpace,Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+    using PointScratchView    = Kokkos::View<PointScalar*, ScratchSpace,Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+    
+    using TeamPolicy = Kokkos::TeamPolicy<>;
+    using TeamMember = TeamPolicy::member_type;
+    
+    EOperator opType_;
+    
+    OutputFieldType  output_;      // F,P
+    InputPointsType  inputPoints_; // P,D
+    
+    int polyOrder_;
+    bool defineVertexFunctions_;
+    int numFields_, numPoints_;
+    
+    size_t fad_size_output_;
+    
+    static const int numVertices = 4;
+    static const int numEdges    = 6;
+    // the following ordering of the edges matches that used by ESEAS
+    const int edge_start_[numEdges] = {0,1,0,0,1,2}; // edge i is from edge_start_[i] to edge_end_[i]
+    const int edge_end_[numEdges]   = {1,2,2,3,3,3}; // edge i is from edge_start_[i] to edge_end_[i]
+    
+    static const int numFaces    = 4;
+    const int face_vertex_0[numFaces] = {0,0,1,0}; // faces are abc where 0 ≤ a < b < c ≤ 3
+    const int face_vertex_1[numFaces] = {1,1,2,2};
+    const int face_vertex_2[numFaces] = {2,3,3,3};
+    
+    // this allows us to look up the edge ordinal of the first edge of a face
+    // this is useful because face functions are defined using edge basis functions of the first edge of the face
+    const int face_ordinal_of_first_edge[numFaces] = {0,0,1,2};
+    
+    Hierarchical_HGRAD_TET_Functor(EOperator opType, OutputFieldType output, InputPointsType inputPoints,
+                                    int polyOrder, bool defineVertexFunctions)
+    : opType_(opType), output_(output), inputPoints_(inputPoints),
+      polyOrder_(polyOrder), defineVertexFunctions_(defineVertexFunctions),
+      fad_size_output_(getScalarDimensionForView(output))
+    {
+      numFields_ = output.extent_int(0);
+      numPoints_ = output.extent_int(1);
+      INTREPID2_TEST_FOR_EXCEPTION(numPoints_ != inputPoints.extent_int(0), std::invalid_argument, "point counts need to match!");
+      INTREPID2_TEST_FOR_EXCEPTION(numFields_ != (polyOrder_+1)*(polyOrder_+2)*(polyOrder_+3)/6, std::invalid_argument, "output field size does not match basis cardinality");
+    }
+    
+    KOKKOS_INLINE_FUNCTION
+    void operator()( const TeamMember & teamMember ) const
+    {
+      const int numFaceBasisFunctionsPerFace = (polyOrder_-2) * (polyOrder_-1) / 2;
+      const int numInteriorBasisFunctions = (polyOrder_-3) * (polyOrder_-2) * (polyOrder_-1) / 6;
+      
+      auto pointOrdinal = teamMember.league_rank();
+      OutputScratchView legendre_values1_at_point, legendre_values2_at_point;
+      OutputScratchView2D jacobi_values1_at_point, jacobi_values2_at_point, jacobi_values3_at_point;
+      const int numAlphaValues = (polyOrder_-1 > 1) ? (polyOrder_-1) : 1; // make numAlphaValues at least 1 so we can avoid zero-extent allocations…
+      if (fad_size_output_ > 0) {
+        legendre_values1_at_point = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1, fad_size_output_);
+        legendre_values2_at_point = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1, fad_size_output_);
+        jacobi_values1_at_point   = OutputScratchView2D(teamMember.team_shmem(), numAlphaValues, polyOrder_ + 1, fad_size_output_);
+        jacobi_values2_at_point   = OutputScratchView2D(teamMember.team_shmem(), numAlphaValues, polyOrder_ + 1, fad_size_output_);
+        jacobi_values3_at_point   = OutputScratchView2D(teamMember.team_shmem(), numAlphaValues, polyOrder_ + 1, fad_size_output_);
+      }
+      else {
+        legendre_values1_at_point = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1);
+        legendre_values2_at_point = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1);
+        jacobi_values1_at_point   = OutputScratchView2D(teamMember.team_shmem(), numAlphaValues, polyOrder_ + 1);
+        jacobi_values2_at_point   = OutputScratchView2D(teamMember.team_shmem(), numAlphaValues, polyOrder_ + 1);
+        jacobi_values3_at_point   = OutputScratchView2D(teamMember.team_shmem(), numAlphaValues, polyOrder_ + 1);
+      }
+      
+      const auto & x = inputPoints_(pointOrdinal,0);
+      const auto & y = inputPoints_(pointOrdinal,1);
+      const auto & z = inputPoints_(pointOrdinal,2);
+      
+      // write as barycentric coordinates:
+      const PointScalar lambda[numVertices] = {1. - x - y - z, x, y, z};
+      const PointScalar lambda_dx[numVertices] = {-1., 1., 0., 0.};
+      const PointScalar lambda_dy[numVertices] = {-1., 0., 1., 0.};
+      const PointScalar lambda_dz[numVertices] = {-1., 0., 0., 1.};
+      
+      const int num1DEdgeFunctions = polyOrder_ - 1;
+      
+      switch (opType_)
+      {
+        case OPERATOR_VALUE:
+        {
+          // vertex functions come first, according to vertex ordering: (0,0,0), (1,0,0), (0,1,0), (0,0,1)
+          for (int vertexOrdinal=0; vertexOrdinal<numVertices; vertexOrdinal++)
+          {
+            output_(vertexOrdinal,pointOrdinal) = lambda[vertexOrdinal];
+          }
+          if (!defineVertexFunctions_)
+          {
+            // "DG" basis case
+            // here, we overwrite the first vertex function with 1:
+            output_(0,pointOrdinal) = 1.0;
+          }
+          
+          // edge functions
+          int fieldOrdinalOffset = numVertices;
+          for (int edgeOrdinal=0; edgeOrdinal<numEdges; edgeOrdinal++)
+          {
+            const auto & s0 = lambda[edge_start_[edgeOrdinal]];
+            const auto & s1 = lambda[  edge_end_[edgeOrdinal]];
+
+            Polynomials::shiftedScaledIntegratedLegendreValues(legendre_values1_at_point, polyOrder_, PointScalar(s1), PointScalar(s0+s1));
+            for (int edgeFunctionOrdinal=0; edgeFunctionOrdinal<num1DEdgeFunctions; edgeFunctionOrdinal++)
+            {
+              // the first two integrated legendre functions are essentially the vertex functions; hence the +2 on on the RHS here:
+              output_(edgeFunctionOrdinal+fieldOrdinalOffset,pointOrdinal) = legendre_values1_at_point(edgeFunctionOrdinal+2);
+            }
+            fieldOrdinalOffset += num1DEdgeFunctions;
+          }
+          /*
+           Face functions for face abc are the product of edge functions on their ab edge
+           and a Jacobi polynomial [L^2i_j](s0+s1,s2) = L^2i_j(s2;s0+s1+s2)
+           */
+          for (int faceOrdinal=0; faceOrdinal<numFaces; faceOrdinal++)
+          {
+            const auto & s0 = lambda[face_vertex_0[faceOrdinal]];
+            const auto & s1 = lambda[face_vertex_1[faceOrdinal]];
+            const auto & s2 = lambda[face_vertex_2[faceOrdinal]];
+            const PointScalar jacobiScaling = s0 + s1 + s2;
+            
+            // compute integrated Jacobi values for each desired value of alpha
+            for (int n=2; n<=polyOrder_; n++)
+            {
+              const double alpha = n*2;
+              const int alphaOrdinal = n-2;
+              using Kokkos::subview;
+              using Kokkos::ALL;
+              auto jacobi_alpha = subview(jacobi_values1_at_point, alphaOrdinal, ALL);
+              Polynomials::integratedJacobiValues(jacobi_alpha, alpha, polyOrder_-2, s2, jacobiScaling);
+            }
+            
+            const int edgeOrdinal = face_ordinal_of_first_edge[faceOrdinal];
+            int localFaceBasisOrdinal = 0;
+            for (int totalPolyOrder=3; totalPolyOrder<=polyOrder_; totalPolyOrder++)
+            {
+              for (int i=2; i<totalPolyOrder; i++)
+              {
+                const int edgeBasisOrdinal = edgeOrdinal*num1DEdgeFunctions + i-2 + numVertices;
+                const auto & edgeValue = output_(edgeBasisOrdinal,pointOrdinal);
+                const int alphaOrdinal = i-2;
+                
+                const int j = totalPolyOrder - i;
+                const auto & jacobiValue = jacobi_values1_at_point(alphaOrdinal,j);
+                const int fieldOrdinal = fieldOrdinalOffset + localFaceBasisOrdinal;
+                output_(fieldOrdinal,pointOrdinal) = edgeValue * jacobiValue;
+                
+                localFaceBasisOrdinal++;
+              }
+            }
+            fieldOrdinalOffset += numFaceBasisFunctionsPerFace;
+          }
+          // interior functions
+          // compute integrated Jacobi values for each desired value of alpha
+          for (int n=3; n<=polyOrder_; n++)
+          {
+            const double alpha = n*2;
+            const double jacobiScaling = 1.0;
+            const int alphaOrdinal = n-3;
+            using Kokkos::subview;
+            using Kokkos::ALL;
+            auto jacobi_alpha = subview(jacobi_values1_at_point, alphaOrdinal, ALL);
+            Polynomials::integratedJacobiValues(jacobi_alpha, alpha, polyOrder_-3, lambda[3], jacobiScaling);
+          }
+          const int min_i  = 2;
+          const int min_j  = 1;
+          const int min_k  = 1;
+          const int min_ij = min_i + min_j;
+          const int min_ijk = min_ij + min_k;
+          int localInteriorBasisOrdinal = 0;
+          for (int totalPolyOrder_ijk=min_ijk; totalPolyOrder_ijk <= polyOrder_; totalPolyOrder_ijk++)
+          {
+            int localFaceBasisOrdinal = 0;
+            for (int totalPolyOrder_ij=min_ij; totalPolyOrder_ij <= totalPolyOrder_ijk-min_j; totalPolyOrder_ij++)
+            {
+              for (int i=2; i <= totalPolyOrder_ij-min_j; i++)
+              {
+                const int j = totalPolyOrder_ij - i;
+                const int k = totalPolyOrder_ijk - totalPolyOrder_ij;
+                const int faceBasisOrdinal = numEdges*num1DEdgeFunctions + numVertices + localFaceBasisOrdinal;
+                const auto & faceValue = output_(faceBasisOrdinal,pointOrdinal);
+                const int alphaOrdinal = (i+j)-3;
+                localFaceBasisOrdinal++;
+              
+                const int fieldOrdinal = fieldOrdinalOffset + localInteriorBasisOrdinal;
+                const auto & jacobiValue = jacobi_values1_at_point(alphaOrdinal,k);
+                output_(fieldOrdinal,pointOrdinal) = faceValue * jacobiValue;
+                localInteriorBasisOrdinal++;
+              } // end i loop
+            } // end totalPolyOrder_ij loop
+          } // end totalPolyOrder_ijk loop
+          fieldOrdinalOffset += numInteriorBasisFunctions;
+        } // end OPERATOR_VALUE
+          break;
+        case OPERATOR_GRAD:
+        case OPERATOR_D1:
+        {
+          // vertex functions
+          if (defineVertexFunctions_)
+          {
+            // standard, "CG" basis case
+            // first vertex function is 1-x-y-z
+            output_(0,pointOrdinal,0) = -1.0;
+            output_(0,pointOrdinal,1) = -1.0;
+            output_(0,pointOrdinal,2) = -1.0;
+          }
+          else
+          {
+            // "DG" basis case
+            // here, the first "vertex" function is 1, so the derivative is 0:
+            output_(0,pointOrdinal,0) = 0.0;
+            output_(0,pointOrdinal,1) = 0.0;
+            output_(0,pointOrdinal,2) = 0.0;
+          }
+          // second vertex function is x
+          output_(1,pointOrdinal,0) = 1.0;
+          output_(1,pointOrdinal,1) = 0.0;
+          output_(1,pointOrdinal,2) = 0.0;
+          // third vertex function is y
+          output_(2,pointOrdinal,0) = 0.0;
+          output_(2,pointOrdinal,1) = 1.0;
+          output_(2,pointOrdinal,2) = 0.0;
+          // fourth vertex function is z
+          output_(3,pointOrdinal,0) = 0.0;
+          output_(3,pointOrdinal,1) = 0.0;
+          output_(3,pointOrdinal,2) = 1.0;
+
+          // edge functions
+          int fieldOrdinalOffset = numVertices;
+          /*
+           Per Fuentes et al. (see Appendix E.1, E.2), the edge functions, defined for i ≥ 2, are
+             [L_i](s0,s1) = L_i(s1; s0+s1)
+           and have gradients:
+             grad [L_i](s0,s1) = [P_{i-1}](s0,s1) grad s1 + [R_{i-1}](s0,s1) grad (s0 + s1)
+           where
+             [R_{i-1}](s0,s1) = R_{i-1}(s1; s0+s1) = d/dt L_{i}(s0; s0+s1)
+           The P_i we have implemented in shiftedScaledLegendreValues, while d/dt L_{i+1} is
+           implemented in shiftedScaledIntegratedLegendreValues_dt.
+           */
+          // rename the scratch memory to match our usage here:
+          auto & P_i_minus_1 = legendre_values1_at_point;
+          auto & L_i_dt      = legendre_values2_at_point;
+          for (int edgeOrdinal=0; edgeOrdinal<numEdges; edgeOrdinal++)
+          {
+            const auto & s0 = lambda[edge_start_[edgeOrdinal]];
+            const auto & s1 = lambda[  edge_end_[edgeOrdinal]];
+            
+            const auto & s0_dx = lambda_dx[edge_start_[edgeOrdinal]];
+            const auto & s0_dy = lambda_dy[edge_start_[edgeOrdinal]];
+            const auto & s0_dz = lambda_dz[edge_start_[edgeOrdinal]];
+            const auto & s1_dx = lambda_dx[  edge_end_[edgeOrdinal]];
+            const auto & s1_dy = lambda_dy[  edge_end_[edgeOrdinal]];
+            const auto & s1_dz = lambda_dz[  edge_end_[edgeOrdinal]];
+            
+            Polynomials::shiftedScaledLegendreValues             (P_i_minus_1, polyOrder_-1, PointScalar(s1), PointScalar(s0+s1));
+            Polynomials::shiftedScaledIntegratedLegendreValues_dt(L_i_dt,      polyOrder_,   PointScalar(s1), PointScalar(s0+s1));
+            for (int edgeFunctionOrdinal=0; edgeFunctionOrdinal<num1DEdgeFunctions; edgeFunctionOrdinal++)
+            {
+              // the first two (integrated) Legendre functions are essentially the vertex functions; hence the +2 here:
+              const int i = edgeFunctionOrdinal+2;
+              output_(edgeFunctionOrdinal+fieldOrdinalOffset,pointOrdinal,0) = P_i_minus_1(i-1) * s1_dx + L_i_dt(i) * (s1_dx + s0_dx);
+              output_(edgeFunctionOrdinal+fieldOrdinalOffset,pointOrdinal,1) = P_i_minus_1(i-1) * s1_dy + L_i_dt(i) * (s1_dy + s0_dy);
+              output_(edgeFunctionOrdinal+fieldOrdinalOffset,pointOrdinal,2) = P_i_minus_1(i-1) * s1_dz + L_i_dt(i) * (s1_dz + s0_dz);
+            }
+            fieldOrdinalOffset += num1DEdgeFunctions;
+          }
+          
+          /*
+           Fuentes et al give the face functions as phi_{ij}, with gradient:
+             grad phi_{ij}(s0,s1,s2) = [L^{2i}_j](s0+s1,s2) grad [L_i](s0,s1) + [L_i](s0,s1) grad [L^{2i}_j](s0+s1,s2)
+           where:
+           - grad [L_i](s0,s1) is the edge function gradient we computed above
+           - [L_i](s0,s1) is the edge function which we have implemented above (in OPERATOR_VALUE)
+           - L^{2i}_j is a Jacobi polynomial with:
+               [L^{2i}_j](s0,s1) = L^{2i}_j(s1;s0+s1)
+             and the gradient for j ≥ 1 is
+               grad [L^{2i}_j](s0,s1) = [P^{2i}_{j-1}](s0,s1) grad s1 + [R^{2i}_{j-1}(s0,s1)] grad (s0 + s1)
+           Here,
+             [P^{2i}_{j-1}](s0,s1) = P^{2i}_{j-1}(s1,s0+s1)
+           and
+             [R^{2i}_{j-1}(s0,s1)] = d/dt L^{2i}_j(s1,s0+s1)
+           We have implemented P^{alpha}_{j} as shiftedScaledJacobiValues,
+           and d/dt L^{alpha}_{j} as integratedJacobiValues_dt.
+           */
+          // rename the scratch memory to match our usage here:
+          auto & L_i            = legendre_values2_at_point;
+          auto & L_2i_j_dt      = jacobi_values1_at_point;
+          auto & L_2i_j         = jacobi_values2_at_point;
+          auto & P_2i_j_minus_1 = jacobi_values3_at_point;
+          
+          for (int faceOrdinal=0; faceOrdinal<numFaces; faceOrdinal++)
+          {
+            const auto & s0 = lambda[face_vertex_0[faceOrdinal]];
+            const auto & s1 = lambda[face_vertex_1[faceOrdinal]];
+            const auto & s2 = lambda[face_vertex_2[faceOrdinal]];
+            Polynomials::shiftedScaledIntegratedLegendreValues(L_i, polyOrder_, s1, s0+s1);
+            
+            const PointScalar jacobiScaling = s0 + s1 + s2;
+            
+            // compute integrated Jacobi values for each desired value of alpha
+            for (int n=2; n<=polyOrder_; n++)
+            {
+              const double alpha = n*2;
+              const int alphaOrdinal = n-2;
+              using Kokkos::subview;
+              using Kokkos::ALL;
+              auto L_2i_j_dt_alpha      = subview(L_2i_j_dt,      alphaOrdinal, ALL);
+              auto L_2i_j_alpha         = subview(L_2i_j,         alphaOrdinal, ALL);
+              auto P_2i_j_minus_1_alpha = subview(P_2i_j_minus_1, alphaOrdinal, ALL);
+              Polynomials::integratedJacobiValues_dt(L_2i_j_dt_alpha,      alpha, polyOrder_-2, s2, jacobiScaling);
+              Polynomials::integratedJacobiValues   (L_2i_j_alpha,         alpha, polyOrder_-2, s2, jacobiScaling);
+              Polynomials::shiftedScaledJacobiValues(P_2i_j_minus_1_alpha, alpha, polyOrder_-1, s2, jacobiScaling);
+            }
+            
+            const int edgeOrdinal = face_ordinal_of_first_edge[faceOrdinal];
+            int localFaceOrdinal = 0;
+            for (int totalPolyOrder=3; totalPolyOrder<=polyOrder_; totalPolyOrder++)
+            {
+              for (int i=2; i<totalPolyOrder; i++)
+              {
+                const int edgeBasisOrdinal = edgeOrdinal*num1DEdgeFunctions + i-2 + numVertices;
+                const auto & grad_L_i_dx = output_(edgeBasisOrdinal,pointOrdinal,0);
+                const auto & grad_L_i_dy = output_(edgeBasisOrdinal,pointOrdinal,1);
+                const auto & grad_L_i_dz = output_(edgeBasisOrdinal,pointOrdinal,2);
+                
+                const int alphaOrdinal = i-2;
+                
+                const auto & s0_dx = lambda_dx[face_vertex_0[faceOrdinal]];
+                const auto & s0_dy = lambda_dy[face_vertex_0[faceOrdinal]];
+                const auto & s0_dz = lambda_dz[face_vertex_0[faceOrdinal]];
+                const auto & s1_dx = lambda_dx[face_vertex_1[faceOrdinal]];
+                const auto & s1_dy = lambda_dy[face_vertex_1[faceOrdinal]];
+                const auto & s1_dz = lambda_dz[face_vertex_1[faceOrdinal]];
+                const auto & s2_dx = lambda_dx[face_vertex_2[faceOrdinal]];
+                const auto & s2_dy = lambda_dy[face_vertex_2[faceOrdinal]];
+                const auto & s2_dz = lambda_dz[face_vertex_2[faceOrdinal]];
+                
+                int j = totalPolyOrder - i;
+ 
+                // put references to the entries of interest in like-named variables with lowercase first letters
+                auto & l_2i_j         = L_2i_j(alphaOrdinal,j);
+                auto & l_i            = L_i(i);
+                auto & l_2i_j_dt      = L_2i_j_dt(alphaOrdinal,j);
+                auto & p_2i_j_minus_1 = P_2i_j_minus_1(alphaOrdinal,j-1);
+                
+                const OutputScalar basisValue_dx = l_2i_j * grad_L_i_dx + l_i * (p_2i_j_minus_1 * s2_dx + l_2i_j_dt * (s0_dx + s1_dx + s2_dx));
+                const OutputScalar basisValue_dy = l_2i_j * grad_L_i_dy + l_i * (p_2i_j_minus_1 * s2_dy + l_2i_j_dt * (s0_dy + s1_dy + s2_dy));
+                const OutputScalar basisValue_dz = l_2i_j * grad_L_i_dz + l_i * (p_2i_j_minus_1 * s2_dz + l_2i_j_dt * (s0_dz + s1_dz + s2_dz));
+                
+                const int fieldOrdinal = fieldOrdinalOffset + localFaceOrdinal;
+                
+                output_(fieldOrdinal,pointOrdinal,0) = basisValue_dx;
+                output_(fieldOrdinal,pointOrdinal,1) = basisValue_dy;
+                output_(fieldOrdinal,pointOrdinal,2) = basisValue_dz;
+                
+                localFaceOrdinal++;
+              }
+            }
+            fieldOrdinalOffset += numFaceBasisFunctionsPerFace;
+          }
+          // interior functions
+          /*
+           Per Fuentes et al. (see Appendix E.1, E.2), the interior functions, defined for i ≥ 2, are
+             phi_ij(lambda_012) [L^{2(i+j)}_k](1-lambda_3,lambda_3) = phi_ij(lambda_012) L^{2(i+j)}_k (lambda_3; 1)
+           and have gradients:
+             L^{2(i+j)}_k (lambda_3; 1) grad (phi_ij(lambda_012)) + phi_ij(lambda_012) grad (L^{2(i+j)}_k (lambda_3; 1))
+           where:
+             - phi_ij(lambda_012) is the (i,j) basis function on face 012,
+             - L^{alpha}_j(t0; t1) is the jth integrated Jacobi polynomial
+           and the gradient of the integrated Jacobi polynomial can be computed:
+           - grad L^{alpha}_j(t0; t1) = P^{alpha}_{j-1} (t0;t1) grad t0 + R^{alpha}_{j-1}(t0,t1) grad t1
+           Here, t1=1, so this simplifies to:
+           - grad L^{alpha}_j(t0; t1) = P^{alpha}_{j-1} (t0;t1) grad t0
+           
+           The P_i we have implemented in shiftedScaledJacobiValues.
+           */
+          // rename the scratch memory to match our usage here:
+          auto & L_alpha = jacobi_values1_at_point;
+          auto & P_alpha = jacobi_values2_at_point;
+          
+          // precompute values used in face ordinal 0:
+          {
+            const auto & s0 = lambda[0];
+            const auto & s1 = lambda[1];
+            const auto & s2 = lambda[2];
+            // Legendre:
+            Polynomials::shiftedScaledIntegratedLegendreValues(legendre_values1_at_point, polyOrder_, PointScalar(s1), PointScalar(s0+s1));
+            
+            // Jacobi for each desired alpha value:
+            const PointScalar jacobiScaling = s0 + s1 + s2;
+            for (int n=2; n<=polyOrder_; n++)
+            {
+              const double alpha = n*2;
+              const int alphaOrdinal = n-2;
+              using Kokkos::subview;
+              using Kokkos::ALL;
+              auto jacobi_alpha = subview(jacobi_values3_at_point, alphaOrdinal, ALL);
+              Polynomials::integratedJacobiValues(jacobi_alpha, alpha, polyOrder_-2, s2, jacobiScaling);
+            }
+          }
+          
+          // interior
+          for (int n=3; n<=polyOrder_; n++)
+          {
+            const double alpha = n*2;
+            const double jacobiScaling = 1.0;
+            const int alphaOrdinal = n-3;
+            using Kokkos::subview;
+            using Kokkos::ALL;
+            
+            // values for interior functions:
+            auto L = subview(L_alpha, alphaOrdinal, ALL);
+            auto P = subview(P_alpha, alphaOrdinal, ALL);
+            Polynomials::integratedJacobiValues   (L, alpha, polyOrder_-3, lambda[3], jacobiScaling);
+            Polynomials::shiftedScaledJacobiValues(P, alpha, polyOrder_-3, lambda[3], jacobiScaling);
+          }
+          
+          const int min_i  = 2;
+          const int min_j  = 1;
+          const int min_k  = 1;
+          const int min_ij = min_i + min_j;
+          const int min_ijk = min_ij + min_k;
+          int localInteriorBasisOrdinal = 0;
+          for (int totalPolyOrder_ijk=min_ijk; totalPolyOrder_ijk <= polyOrder_; totalPolyOrder_ijk++)
+          {
+            int localFaceBasisOrdinal = 0;
+            for (int totalPolyOrder_ij=min_ij; totalPolyOrder_ij <= totalPolyOrder_ijk-min_j; totalPolyOrder_ij++)
+            {
+              for (int i=2; i <= totalPolyOrder_ij-min_j; i++)
+              {
+                const int j = totalPolyOrder_ij - i;
+                const int k = totalPolyOrder_ijk - totalPolyOrder_ij;
+                // interior functions use basis values belonging to the first face, 012
+                const int faceBasisOrdinal = numEdges*num1DEdgeFunctions + numVertices + localFaceBasisOrdinal;
+                
+                const auto & faceValue_dx = output_(faceBasisOrdinal,pointOrdinal,0);
+                const auto & faceValue_dy = output_(faceBasisOrdinal,pointOrdinal,1);
+                const auto & faceValue_dz = output_(faceBasisOrdinal,pointOrdinal,2);
+                
+                // determine faceValue (on face 0)
+                OutputScalar faceValue;
+                {
+                  const auto & edgeValue = legendre_values1_at_point(i);
+                  const int alphaOrdinal = i-2;
+                  const auto & jacobiValue = jacobi_values3_at_point(alphaOrdinal,j);
+                  faceValue = edgeValue * jacobiValue;
+                }
+                localFaceBasisOrdinal++;
+              
+                const int alphaOrdinal = (i+j)-3;
+              
+                const int fieldOrdinal = fieldOrdinalOffset + localInteriorBasisOrdinal;
+                const auto & integratedJacobiValue = L_alpha(alphaOrdinal,k);
+                const auto & jacobiValue = P_alpha(alphaOrdinal,k-1);
+                output_(fieldOrdinal,pointOrdinal,0) = integratedJacobiValue * faceValue_dx + faceValue * jacobiValue * lambda_dx[3];
+                output_(fieldOrdinal,pointOrdinal,1) = integratedJacobiValue * faceValue_dy + faceValue * jacobiValue * lambda_dy[3];
+                output_(fieldOrdinal,pointOrdinal,2) = integratedJacobiValue * faceValue_dz + faceValue * jacobiValue * lambda_dz[3];
+                
+                localInteriorBasisOrdinal++;
+              } // end i loop
+            } // end totalPolyOrder_ij loop
+          } // end totalPolyOrder_ijk loop
+          fieldOrdinalOffset += numInteriorBasisFunctions;
+        }
+          break;
+        case OPERATOR_D2:
+        case OPERATOR_D3:
+        case OPERATOR_D4:
+        case OPERATOR_D5:
+        case OPERATOR_D6:
+        case OPERATOR_D7:
+        case OPERATOR_D8:
+        case OPERATOR_D9:
+        case OPERATOR_D10:
+          INTREPID2_TEST_FOR_ABORT( true,
+                                   ">>> ERROR: (Intrepid2::Basis_HGRAD_TET_Cn_FEM_ORTH::OrthPolynomialTri) Computing of second and higher-order derivatives is not currently supported");
+        default:
+          // unsupported operator type
+          device_assert(false);
+      }
+    }
+    
+    // Provide the shared memory capacity.
+    // This function takes the team_size as an argument,
+    // which allows team_size-dependent allocations.
+    size_t team_shmem_size (int team_size) const
+    {
+      // we will use shared memory to create a fast buffer for basis computations
+      // for the (integrated) Legendre computations, we just need p+1 values stored
+      // for the (integrated) Jacobi computations, though, we want (p+1)*(# alpha values)
+      // alpha is either 2i or 2(i+j), where i=2,…,p or i+j=3,…,p.  So there are at most (p-1) alpha values needed.
+      // We can have up to 3 of the (integrated) Jacobi values needed at once.
+      const int numAlphaValues = std::max(polyOrder_-1, 1); // make it at least 1 so we can avoid zero-extent ranks…
+      size_t shmem_size = 0;
+      if (fad_size_output_ > 0)
+      {
+        // Legendre:
+        shmem_size += 2 * OutputScratchView::shmem_size(polyOrder_ + 1, fad_size_output_);
+        // Jacobi:
+        shmem_size += 3 * OutputScratchView2D::shmem_size(numAlphaValues, polyOrder_ + 1, fad_size_output_);
+      }
+      else
+      {
+        // Legendre:
+        shmem_size += 2 * OutputScratchView::shmem_size(polyOrder_ + 1);
+        // Jacobi:
+        shmem_size += 3 * OutputScratchView2D::shmem_size(numAlphaValues, polyOrder_ + 1);
+      }
+      
+      return shmem_size;
+    }
+  };
+  
+  /** \class  Intrepid2::IntegratedLegendreBasis_HGRAD_TET
+      \brief  Basis defining integrated Legendre basis on the line, a polynomial subspace of H(grad) on the line.
+
+              This is used in the construction of hierarchical bases on higher-dimensional topologies.  For
+              mathematical details of the construction, see:
+   
+               Federico Fuentes, Brendan Keith, Leszek Demkowicz, Sriram Nagaraj.
+               "Orientation embedded high order shape functions for the exact sequence elements of all shapes."
+               Computers & Mathematics with Applications, Volume 70, Issue 4, 2015, Pages 353-458, ISSN 0898-1221.
+               https://doi.org/10.1016/j.camwa.2015.04.027.
+   
+               Note that the template argument defineVertexFunctions controls whether this basis is defined in a
+               strictly hierarchical way.  If defineVertexFunctions is false, then the first basis function is the
+               constant 1.0, and this basis will be suitable for discontinuous discretizations.  If defineVertexFunctions
+               is true, then the first basis function will instead be 1.0-x-y, and the basis will be suitable for
+               continuous discretizations.
+  */
+  template<typename ExecutionSpace=Kokkos::DefaultExecutionSpace,
+           typename OutputScalar = double,
+           typename PointScalar  = double,
+           bool defineVertexFunctions = true>  // if defineVertexFunctions is true, first four basis functions are 1-x-y-z, x, y, and z.  Otherwise, they are 1, x, y, and z.
+  class IntegratedLegendreBasis_HGRAD_TET
+  : public Basis<ExecutionSpace,OutputScalar,PointScalar>
+  {
+  public:
+    using OrdinalTypeArray1DHost = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::OrdinalTypeArray2DHost;
+    
+    using OutputViewType = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::OutputViewType;
+    using PointViewType  = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::PointViewType;
+    using ScalarViewType = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::ScalarViewType;
+  protected:
+    int polyOrder_; // the maximum order of the polynomial
+    bool defineVertexFunctions_;  // if true, first four basis functions are 1-x-y-z, x, y, and z.  Otherwise, they are 1, x, y, and z.
+  public:
+    /** \brief  Constructor.
+        \param [in] polyOrder - the polynomial order of the basis.
+     
+     The basis will have polyOrder + 1 members.
+     
+     If defineVertexFunctions is false, then all basis functions are identified with the interior of the line element, and the first four basis functions are 1, x, y, and z.
+     
+     If defineVertexFunctions is true, then the first two basis functions are 1-x-y-z, x, y, and z, and these are identified with the left and right vertices of the cell.
+     
+     */
+    IntegratedLegendreBasis_HGRAD_TET(int polyOrder)
+    :
+    polyOrder_(polyOrder)
+    {
+      this->basisCardinality_  = ((polyOrder+1) * (polyOrder+2) * (polyOrder+3)) / 6;
+      this->basisDegree_       = polyOrder;
+      this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Tetrahedron<> >() );
+      this->basisType_         = BASIS_FEM_HIERARCHICAL;
+      this->basisCoordinates_  = COORDINATES_CARTESIAN;
+      this->functionSpace_     = FUNCTION_SPACE_HGRAD;
+      
+      const int degreeLength = 1;
+      this->fieldOrdinalPolynomialDegree_ = OrdinalTypeArray2DHost("Integrated Legendre H(grad) tetrahedron polynomial degree lookup", this->basisCardinality_, degreeLength);
+      
+      int fieldOrdinalOffset = 0;
+      // **** vertex functions **** //
+      const int numVertices = this->basisCellTopology_.getVertexCount();
+      const int numFunctionsPerVertex = 1;
+      const int numVertexFunctions = numVertices * numFunctionsPerVertex;
+      for (int i=0; i<numVertexFunctions; i++)
+      {
+        // for H(grad) on tetrahedron, if defineVertexFunctions is false, first four basis members are linear
+        // if not, then the only difference is that the first member is constant
+        this->fieldOrdinalPolynomialDegree_(i,0) = 1;
+      }
+      if (!defineVertexFunctions)
+      {
+        this->fieldOrdinalPolynomialDegree_(0,0) = 0;
+      }
+      fieldOrdinalOffset += numVertexFunctions;
+      
+      // **** edge functions **** //
+      const int numFunctionsPerEdge = polyOrder - 1; // bubble functions: all but the vertices
+      const int numEdges            = this->basisCellTopology_.getEdgeCount();
+      for (int edgeOrdinal=0; edgeOrdinal<numEdges; edgeOrdinal++)
+      {
+        for (int i=0; i<numFunctionsPerEdge; i++)
+        {
+          this->fieldOrdinalPolynomialDegree_(i+fieldOrdinalOffset,0) = i+2; // vertex functions are 1st order; edge functions start at order 2
+        }
+        fieldOrdinalOffset += numFunctionsPerEdge;
+      }
+      
+      // **** face functions **** //
+      const int numFunctionsPerFace   = ((polyOrder-1)*(polyOrder-2))/2;
+      const int numFaces = 4;
+      for (int faceOrdinal=0; faceOrdinal<numFaces; faceOrdinal++)
+      {
+        for (int totalPolyOrder=3; totalPolyOrder<=polyOrder_; totalPolyOrder++)
+        {
+          const int totalFaceDofs         = (totalPolyOrder-2)*(totalPolyOrder-1)/2;
+          const int totalFaceDofsPrevious = (totalPolyOrder-3)*(totalPolyOrder-2)/2;
+          const int faceDofsForPolyOrder  = totalFaceDofs - totalFaceDofsPrevious;
+          for (int i=0; i<faceDofsForPolyOrder; i++)
+          {
+            this->fieldOrdinalPolynomialDegree_(fieldOrdinalOffset,0) = totalPolyOrder;
+            fieldOrdinalOffset++;
+          }
+        }
+      }
+
+      // **** interior functions **** //
+      const int numFunctionsPerVolume = ((polyOrder-1)*(polyOrder-2)*(polyOrder-3))/6;
+      const int numVolumes = 1; // interior
+      for (int volumeOrdinal=0; volumeOrdinal<numVolumes; volumeOrdinal++)
+      {
+        for (int totalPolyOrder=4; totalPolyOrder<=polyOrder_; totalPolyOrder++)
+        {
+          const int totalInteriorDofs         = (totalPolyOrder-3)*(totalPolyOrder-2)*(totalPolyOrder-1)/6;
+          const int totalInteriorDofsPrevious = (totalPolyOrder-4)*(totalPolyOrder-3)*(totalPolyOrder-2)/6;
+          const int interiorDofsForPolyOrder  = totalInteriorDofs - totalInteriorDofsPrevious;
+          
+          for (int i=0; i<interiorDofsForPolyOrder; i++)
+          {
+            this->fieldOrdinalPolynomialDegree_(fieldOrdinalOffset,0) = totalPolyOrder;
+            fieldOrdinalOffset++;
+          }
+        }
+      }
+      
+      INTREPID2_TEST_FOR_EXCEPTION(fieldOrdinalOffset != this->basisCardinality_, std::invalid_argument, "Internal error: basis enumeration is incorrect");
+      
+      // initialize tags
+      {
+        // ESEAS numbers tetrahedron faces differently from Intrepid2
+        // ESEAS:     012, 013, 123, 023
+        // Intrepid2: 013, 123, 032, 021
+        const int intrepid2FaceOrdinals[4] {3,0,1,2}; // index is the ESEAS face ordinal; value is the intrepid2 ordinal
+        
+        const auto & cardinality = this->basisCardinality_;
+        
+        // Basis-dependent initializations
+        const ordinal_type tagSize  = 4;        // size of DoF tag, i.e., number of fields in the tag
+        const ordinal_type posScDim = 0;        // position in the tag, counting from 0, of the subcell dim
+        const ordinal_type posScOrd = 1;        // position in the tag, counting from 0, of the subcell ordinal
+        const ordinal_type posDfOrd = 2;        // position in the tag, counting from 0, of DoF ordinal relative to the subcell
+        
+        OrdinalTypeArray1DHost tagView("tag view", cardinality*tagSize);
+        const int vertexDim = 0, edgeDim = 1, faceDim = 2, volumeDim = 3;
+
+        if (defineVertexFunctions) {
+          {
+            int tagNumber = 0;
+            for (int vertexOrdinal=0; vertexOrdinal<numVertices; vertexOrdinal++)
+            {
+              for (int functionOrdinal=0; functionOrdinal<numFunctionsPerVertex; functionOrdinal++)
+              {
+                tagView(tagNumber*tagSize+0) = vertexDim;             // vertex dimension
+                tagView(tagNumber*tagSize+1) = vertexOrdinal;         // vertex id
+                tagView(tagNumber*tagSize+2) = functionOrdinal;       // local dof id
+                tagView(tagNumber*tagSize+3) = numFunctionsPerVertex; // total number of dofs in this vertex
+                tagNumber++;
+              }
+            }
+            for (int edgeOrdinal=0; edgeOrdinal<numEdges; edgeOrdinal++)
+            {
+              for (int functionOrdinal=0; functionOrdinal<numFunctionsPerEdge; functionOrdinal++)
+              {
+                tagView(tagNumber*tagSize+0) = edgeDim;               // edge dimension
+                tagView(tagNumber*tagSize+1) = edgeOrdinal;           // edge id
+                tagView(tagNumber*tagSize+2) = functionOrdinal;       // local dof id
+                tagView(tagNumber*tagSize+3) = numFunctionsPerEdge;   // total number of dofs on this edge
+                tagNumber++;
+              }
+            }
+            for (int faceOrdinalESEAS=0; faceOrdinalESEAS<numFaces; faceOrdinalESEAS++)
+            {
+              int faceOrdinalIntrepid2 = intrepid2FaceOrdinals[faceOrdinalESEAS];
+              for (int functionOrdinal=0; functionOrdinal<numFunctionsPerFace; functionOrdinal++)
+              {
+                tagView(tagNumber*tagSize+0) = faceDim;               // face dimension
+                tagView(tagNumber*tagSize+1) = faceOrdinalIntrepid2;  // face id
+                tagView(tagNumber*tagSize+2) = functionOrdinal;       // local dof id
+                tagView(tagNumber*tagSize+3) = numFunctionsPerFace;   // total number of dofs on this face
+                tagNumber++;
+              }
+            }
+            for (int volumeOrdinal=0; volumeOrdinal<numVolumes; volumeOrdinal++)
+            {
+              for (int functionOrdinal=0; functionOrdinal<numFunctionsPerVolume; functionOrdinal++)
+              {
+                tagView(tagNumber*tagSize+0) = volumeDim;               // volume dimension
+                tagView(tagNumber*tagSize+1) = volumeOrdinal;           // volume id
+                tagView(tagNumber*tagSize+2) = functionOrdinal;         // local dof id
+                tagView(tagNumber*tagSize+3) = numFunctionsPerVolume;   // total number of dofs in this volume
+                tagNumber++;
+              }
+            }
+            INTREPID2_TEST_FOR_EXCEPTION(tagNumber != this->basisCardinality_, std::invalid_argument, "Internal error: basis tag enumeration is incorrect");
+          }
+        } else {
+          for (ordinal_type i=0;i<cardinality;++i) {
+            tagView(i*tagSize+0) = volumeDim;   // volume dimension
+            tagView(i*tagSize+1) = 0;           // volume ordinal
+            tagView(i*tagSize+2) = i;           // local dof id
+            tagView(i*tagSize+3) = cardinality; // total number of dofs on this face
+          }
+        }
+        
+        // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
+        // tags are constructed on host
+        this->setOrdinalTagData(this->tagToOrdinal_,
+                                this->ordinalToTag_,
+                                tagView,
+                                this->basisCardinality_,
+                                tagSize,
+                                posScDim,
+                                posScOrd,
+                                posDfOrd);
+      }
+    }
+    
+    /** \brief  Returns basis name
+     
+     \return the name of the basis
+     */
+    const char* getName() const override {
+      return "Intrepid2_IntegratedLegendreBasis_HGRAD_TET";
+    }
+    
+    // since the getValues() below only overrides the FEM variant, we specify that
+    // we use the base class's getValues(), which implements the FVD variant by throwing an exception.
+    // (It's an error to use the FVD variant on this basis.)
+    using Basis<ExecutionSpace,OutputScalar,PointScalar>::getValues;
+    
+    /** \brief  Evaluation of a FEM basis on a <strong>reference cell</strong>.
+
+        Returns values of <var>operatorType</var> acting on FEM basis functions for a set of
+        points in the <strong>reference cell</strong> for which the basis is defined.
+
+        \param  outputValues      [out] - variable rank array with the basis values
+        \param  inputPoints       [in]  - rank-2 array (P,D) with the evaluation points
+        \param  operatorType      [in]  - the operator acting on the basis functions
+
+        \remark For rank and dimension specifications of the output array see Section
+        \ref basis_md_array_sec.  Dimensions of <var>ArrayScalar</var> arguments are checked
+        at runtime if HAVE_INTREPID2_DEBUG is defined.
+
+        \remark A FEM basis spans a COMPLETE or INCOMPLETE polynomial space on the reference cell
+        which is a smooth function space. Thus, all operator types that are meaningful for the
+        approximated function space are admissible. When the order of the operator exceeds the
+        degree of the basis, the output array is filled with the appropriate number of zeros.
+    */
+    virtual void getValues( OutputViewType outputValues, const PointViewType  inputPoints,
+                           const EOperator operatorType = OPERATOR_VALUE ) const override
+    {
+      auto numPoints = inputPoints.extent_int(0);
+      
+      using FunctorType = Hierarchical_HGRAD_TET_Functor<ExecutionSpace, OutputScalar, PointScalar, OutputViewType, PointViewType>;
+      
+      FunctorType functor(operatorType, outputValues, inputPoints, polyOrder_, defineVertexFunctions);
+      
+      const int outputVectorSize = getVectorSizeForHierarchicalParallelism<OutputScalar>();
+      const int pointVectorSize  = getVectorSizeForHierarchicalParallelism<PointScalar>();
+      const int vectorSize = std::max(outputVectorSize,pointVectorSize);
+      const int teamSize = 1; // because of the way the basis functions are computed, we don't have a second level of parallelism...
+      
+      auto policy = Kokkos::TeamPolicy<ExecutionSpace>(numPoints,teamSize,vectorSize);
+      Kokkos::parallel_for( policy , functor, "Hierarchical_HGRAD_TET_Functor");
+    }
+  };
+} // end namespace Intrepid2
+
+#endif /* Intrepid2_IntegratedLegendreBasis_HGRAD_TET_h */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_IntegratedLegendreBasis_HGRAD_TRI.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_IntegratedLegendreBasis_HGRAD_TRI.hpp
@@ -1,0 +1,568 @@
+// @HEADER
+// ************************************************************************
+//
+//                           Intrepid2 Package
+//                 Copyright (2007) Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Kyungjoo Kim  (kyukim@sandia.gov),
+//                    Mauro Perego  (mperego@sandia.gov), or
+//                    Nate Roberts  (nvrober@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+
+/** \file   Intrepid2_IntegratedLegendreBasis_HGRAD_TRI.hpp
+    \brief  H(grad) basis on the triangle based on integrated Legendre polynomials.
+    \author Created by N.V. Roberts.
+ */
+
+#ifndef Intrepid2_IntegratedLegendreBasis_HGRAD_TRI_h
+#define Intrepid2_IntegratedLegendreBasis_HGRAD_TRI_h
+
+#include <Kokkos_View.hpp>
+#include <Kokkos_DynRankView.hpp>
+
+#include <Intrepid2_config.h>
+
+#include "Intrepid2_Polynomials.hpp"
+#include "Intrepid2_Utils.hpp"
+
+namespace Intrepid2
+{
+  /** \class  Intrepid2::Hierarchical_HGRAD_TRI_Functor
+      \brief  Functor for computing values for the IntegratedLegendreBasis_HGRAD_TRI class.
+   
+   This functor is not intended for use outside of IntegratedLegendreBasis_HGRAD_TRI.
+  */
+  template<class ExecutionSpace, class OutputScalar, class PointScalar,
+           class OutputFieldType, class InputPointsType>
+  struct Hierarchical_HGRAD_TRI_Functor
+  {
+    using ScratchSpace       = Kokkos::DefaultExecutionSpace::scratch_memory_space;
+    using OutputScratchView  = Kokkos::View<OutputScalar*,ScratchSpace,Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+    using PointScratchView   = Kokkos::View<PointScalar*, ScratchSpace,Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+    
+    using TeamPolicy = Kokkos::TeamPolicy<>;
+    using TeamMember = TeamPolicy::member_type;
+    
+    EOperator opType_;
+    
+    OutputFieldType  output_;      // F,P
+    InputPointsType  inputPoints_; // P,D
+    
+    int polyOrder_;
+    bool defineVertexFunctions_;
+    int numFields_, numPoints_;
+    
+    size_t fad_size_output_;
+    
+    static const int numVertices = 3;
+    static const int numEdges    = 3;
+    const int edge_start_[numEdges] = {0,1,0}; // edge i is from edge_start_[i] to edge_end_[i]
+    const int edge_end_[numEdges]   = {1,2,2}; // edge i is from edge_start_[i] to edge_end_[i]
+    
+    Hierarchical_HGRAD_TRI_Functor(EOperator opType, OutputFieldType output, InputPointsType inputPoints,
+                                    int polyOrder, bool defineVertexFunctions)
+    : opType_(opType), output_(output), inputPoints_(inputPoints),
+      polyOrder_(polyOrder), defineVertexFunctions_(defineVertexFunctions),
+      fad_size_output_(getScalarDimensionForView(output))
+    {
+      numFields_ = output.extent_int(0);
+      numPoints_ = output.extent_int(1);
+      INTREPID2_TEST_FOR_EXCEPTION(numPoints_ != inputPoints.extent_int(0), std::invalid_argument, "point counts need to match!");
+      INTREPID2_TEST_FOR_EXCEPTION(numFields_ != (polyOrder_+1)*(polyOrder_+2)/2, std::invalid_argument, "output field size does not match basis cardinality");
+    }
+    
+    KOKKOS_INLINE_FUNCTION
+    void operator()( const TeamMember & teamMember ) const
+    {
+      auto pointOrdinal = teamMember.league_rank();
+      OutputScratchView edge_field_values_at_point, jacobi_values_at_point, other_values_at_point, other_values2_at_point;
+      if (fad_size_output_ > 0) {
+        edge_field_values_at_point = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1, fad_size_output_);
+        jacobi_values_at_point     = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1, fad_size_output_);
+        other_values_at_point      = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1, fad_size_output_);
+        other_values2_at_point     = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1, fad_size_output_);
+      }
+      else {
+        edge_field_values_at_point = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1);
+        jacobi_values_at_point     = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1);
+        other_values_at_point      = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1);
+        other_values2_at_point     = OutputScratchView(teamMember.team_shmem(), polyOrder_ + 1);
+      }
+      
+      const auto & x = inputPoints_(pointOrdinal,0);
+      const auto & y = inputPoints_(pointOrdinal,1);
+      
+      // write as barycentric coordinates:
+      const PointScalar lambda[3]    = {1. - x - y, x, y};
+      const PointScalar lambda_dx[3] = {-1., 1., 0.};
+      const PointScalar lambda_dy[3] = {-1., 0., 1.};
+      
+      const int num1DEdgeFunctions = polyOrder_ - 1;
+      
+      switch (opType_)
+      {
+        case OPERATOR_VALUE:
+        {
+          // vertex functions come first, according to vertex ordering: (0,0), (1,0), (0,1)
+          for (int vertexOrdinal=0; vertexOrdinal<numVertices; vertexOrdinal++)
+          {
+            output_(vertexOrdinal,pointOrdinal) = lambda[vertexOrdinal];
+          }
+          if (!defineVertexFunctions_)
+          {
+            // "DG" basis case
+            // here, we overwrite the first vertex function with 1:
+            output_(0,pointOrdinal) = 1.0;
+          }
+          
+          // edge functions
+          int fieldOrdinalOffset = 3;
+          for (int edgeOrdinal=0; edgeOrdinal<numEdges; edgeOrdinal++)
+          {
+            const auto & s0 = lambda[edge_start_[edgeOrdinal]];
+            const auto & s1 = lambda[  edge_end_[edgeOrdinal]];
+            
+            Polynomials::shiftedScaledIntegratedLegendreValues(edge_field_values_at_point, polyOrder_, PointScalar(s1), PointScalar(s0+s1));
+            for (int edgeFunctionOrdinal=0; edgeFunctionOrdinal<num1DEdgeFunctions; edgeFunctionOrdinal++)
+            {
+              // the first two integrated legendre functions are essentially the vertex functions; hence the +2 on on the RHS here:
+              output_(edgeFunctionOrdinal+fieldOrdinalOffset,pointOrdinal) = edge_field_values_at_point(edgeFunctionOrdinal+2);
+            }
+            fieldOrdinalOffset += num1DEdgeFunctions;
+          }
+          
+          // face functions
+          {
+            // these functions multiply the edge functions from the 01 edge by integrated Jacobi functions, appropriately scaled
+            const double jacobiScaling = 1.0; // s0 + s1 + s2
+            
+            for (int i=2; i<polyOrder_; i++)
+            {
+              const int edgeBasisOrdinal = i+numVertices-2; // i+1: where the value of the edge function is stored in output_
+              const auto & edgeValue = output_(edgeBasisOrdinal,pointOrdinal);
+              const double alpha = i*2.0;
+              
+              Polynomials::integratedJacobiValues(jacobi_values_at_point, alpha, polyOrder_-2, lambda[2], jacobiScaling);
+              for (int j=1; i+j <= polyOrder_; j++)
+              {
+                const auto & jacobiValue = jacobi_values_at_point(j);
+                output_(fieldOrdinalOffset,pointOrdinal) = edgeValue * jacobiValue;
+                fieldOrdinalOffset++;
+              }
+            }
+          }
+        } // end OPERATOR_VALUE
+          break;
+        case OPERATOR_GRAD:
+        case OPERATOR_D1:
+        {
+          // vertex functions
+          if (defineVertexFunctions_)
+          {
+            // standard, "CG" basis case
+            // first vertex function is 1-x-y
+            output_(0,pointOrdinal,0) = -1.0;
+            output_(0,pointOrdinal,1) = -1.0;
+          }
+          else
+          {
+            // "DG" basis case
+            // here, the first "vertex" function is 1, so the derivative is 0:
+            output_(0,pointOrdinal,0) = 0.0;
+            output_(0,pointOrdinal,1) = 0.0;
+          }
+          // second vertex function is x
+          output_(1,pointOrdinal,0) = 1.0;
+          output_(1,pointOrdinal,1) = 0.0;
+          // third vertex function is y
+          output_(2,pointOrdinal,0) = 0.0;
+          output_(2,pointOrdinal,1) = 1.0;
+          
+          // edge functions
+          int fieldOrdinalOffset = 3;
+          /*
+           Per Fuentes et al. (see Appendix E.1, E.2), the edge functions, defined for i ≥ 2, are
+             [L_i](s0,s1) = L_i(s1; s0+s1)
+           and have gradients:
+             grad [L_i](s0,s1) = [P_{i-1}](s0,s1) grad s1 + [R_{i-1}](s0,s1) grad (s0 + s1)
+           where
+             [R_{i-1}](s0,s1) = R_{i-1}(s1; s0+s1) = d/dt L_{i}(s0; s0+s1)
+           The P_i we have implemented in shiftedScaledLegendreValues, while d/dt L_{i+1} is
+           implemented in shiftedScaledIntegratedLegendreValues_dt.
+           */
+          // rename the scratch memory to match our usage here:
+          auto & P_i_minus_1 = edge_field_values_at_point;
+          auto & L_i_dt      = jacobi_values_at_point;
+          for (int edgeOrdinal=0; edgeOrdinal<numEdges; edgeOrdinal++)
+          {
+            const auto & s0 = lambda[edge_start_[edgeOrdinal]];
+            const auto & s1 = lambda[  edge_end_[edgeOrdinal]];
+            
+            const auto & s0_dx = lambda_dx[edge_start_[edgeOrdinal]];
+            const auto & s0_dy = lambda_dy[edge_start_[edgeOrdinal]];
+            const auto & s1_dx = lambda_dx[  edge_end_[edgeOrdinal]];
+            const auto & s1_dy = lambda_dy[  edge_end_[edgeOrdinal]];
+            
+            Polynomials::shiftedScaledLegendreValues             (P_i_minus_1, polyOrder_-1, PointScalar(s1), PointScalar(s0+s1));
+            Polynomials::shiftedScaledIntegratedLegendreValues_dt(L_i_dt,      polyOrder_,   PointScalar(s1), PointScalar(s0+s1));
+            for (int edgeFunctionOrdinal=0; edgeFunctionOrdinal<num1DEdgeFunctions; edgeFunctionOrdinal++)
+            {
+              // the first two (integrated) Legendre functions are essentially the vertex functions; hence the +2 here:
+              const int i = edgeFunctionOrdinal+2;
+              output_(edgeFunctionOrdinal+fieldOrdinalOffset,pointOrdinal,0) = P_i_minus_1(i-1) * s1_dx + L_i_dt(i) * (s1_dx + s0_dx);
+              output_(edgeFunctionOrdinal+fieldOrdinalOffset,pointOrdinal,1) = P_i_minus_1(i-1) * s1_dy + L_i_dt(i) * (s1_dy + s0_dy);
+            }
+            fieldOrdinalOffset += num1DEdgeFunctions;
+          }
+          
+          /*
+           Fuentes et al give the face functions as phi_{ij}, with gradient:
+             grad phi_{ij}(s0,s1,s2) = [L^{2i}_j](s0+s1,s2) grad [L_i](s0,s1) + [L_i](s0,s1) grad [L^{2i}_j](s0+s1,s2)
+           where:
+           - grad [L_i](s0,s1) is the edge function gradient we computed above
+           - [L_i](s0,s1) is the edge function which we have implemented above (in OPERATOR_VALUE)
+           - L^{2i}_j is a Jacobi polynomial with:
+               [L^{2i}_j](s0,s1) = L^{2i}_j(s1;s0+s1)
+             and the gradient for j ≥ 1 is
+               grad [L^{2i}_j](s0,s1) = [P^{2i}_{j-1}](s0,s1) grad s1 + [R^{2i}_{j-1}(s0,s1)] grad (s0 + s1)
+           Here,
+             [P^{2i}_{j-1}](s0,s1) = P^{2i}_{j-1}(s1,s0+s1)
+           and
+             [R^{2i}_{j-1}(s0,s1)] = d/dt L^{2i}_j(s1,s0+s1)
+           We have implemented P^{alpha}_{j} as shiftedScaledJacobiValues,
+           and d/dt L^{alpha}_{j} as integratedJacobiValues_dt.
+           */
+          // rename the scratch memory to match our usage here:
+          auto & P_2i_j_minus_1 = edge_field_values_at_point;
+          auto & L_2i_j_dt      = jacobi_values_at_point;
+          auto & L_i            = other_values_at_point;
+          auto & L_2i_j         = other_values2_at_point;
+          {
+            // face functions multiply the edge functions from the 01 edge by integrated Jacobi functions, appropriately scaled
+            const double jacobiScaling = 1.0; // s0 + s1 + s2
+
+            for (int i=2; i<polyOrder_; i++)
+            {
+              // the edge function here is for edge 01, in the first set of edge functions.
+              const int edgeBasisOrdinal = i+numVertices-2; // i+1: where the value of the edge function is stored in output_
+              const auto & grad_L_i_dx = output_(edgeBasisOrdinal,pointOrdinal,0);
+              const auto & grad_L_i_dy = output_(edgeBasisOrdinal,pointOrdinal,1);
+              
+              const double alpha = i*2.0;
+
+              Polynomials::shiftedScaledIntegratedLegendreValues(L_i, polyOrder_, lambda[1], lambda[0]+lambda[1]);
+              Polynomials::integratedJacobiValues_dt(     L_2i_j_dt, alpha, polyOrder_,   lambda[2], jacobiScaling);
+              Polynomials::integratedJacobiValues   (        L_2i_j, alpha, polyOrder_,   lambda[2], jacobiScaling);
+              Polynomials::shiftedScaledJacobiValues(P_2i_j_minus_1, alpha, polyOrder_-1, lambda[2], jacobiScaling);
+              
+              const auto & s0_dx = lambda_dx[0];
+              const auto & s0_dy = lambda_dy[0];
+              const auto & s1_dx = lambda_dx[1];
+              const auto & s1_dy = lambda_dy[1];
+              const auto & s2_dx = lambda_dx[2];
+              const auto & s2_dy = lambda_dy[2];
+              
+              for (int j=1; i+j <= polyOrder_; j++)
+              {
+                const OutputScalar basisValue_dx = L_2i_j(j) * grad_L_i_dx + L_i(i) * (P_2i_j_minus_1(j-1) * s2_dx + L_2i_j_dt(j) * (s0_dx + s1_dx + s2_dx));
+                const OutputScalar basisValue_dy = L_2i_j(j) * grad_L_i_dy + L_i(i) * (P_2i_j_minus_1(j-1) * s2_dy + L_2i_j_dt(j) * (s0_dy + s1_dy + s2_dy));
+                
+                output_(fieldOrdinalOffset,pointOrdinal,0) = basisValue_dx;
+                output_(fieldOrdinalOffset,pointOrdinal,1) = basisValue_dy;
+                fieldOrdinalOffset++;
+              }
+            }
+          }
+        }
+          break;
+        case OPERATOR_D2:
+        case OPERATOR_D3:
+        case OPERATOR_D4:
+        case OPERATOR_D5:
+        case OPERATOR_D6:
+        case OPERATOR_D7:
+        case OPERATOR_D8:
+        case OPERATOR_D9:
+        case OPERATOR_D10:
+          INTREPID2_TEST_FOR_ABORT( true,
+                                   ">>> ERROR: (Intrepid2::Basis_HGRAD_TRI_Cn_FEM_ORTH::OrthPolynomialTri) Computing of second and higher-order derivatives is not currently supported");
+        default:
+          // unsupported operator type
+          device_assert(false);
+      }
+    }
+    
+    // Provide the shared memory capacity.
+    // This function takes the team_size as an argument,
+    // which allows team_size-dependent allocations.
+    size_t team_shmem_size (int team_size) const
+    {
+      // we will use shared memory to create a fast buffer for basis computations
+      size_t shmem_size = 0;
+      if (fad_size_output_ > 0)
+        shmem_size += 4 * OutputScratchView::shmem_size(polyOrder_ + 1, fad_size_output_);
+      else
+        shmem_size += 4 * OutputScratchView::shmem_size(polyOrder_ + 1);
+      
+      return shmem_size;
+    }
+  };
+  
+  /** \class  Intrepid2::IntegratedLegendreBasis_HGRAD_TRI
+      \brief  Basis defining integrated Legendre basis on the line, a polynomial subspace of H(grad) on the line.
+
+              This is used in the construction of hierarchical bases on higher-dimensional topologies.  For
+              mathematical details of the construction, see:
+   
+               Federico Fuentes, Brendan Keith, Leszek Demkowicz, Sriram Nagaraj.
+               "Orientation embedded high order shape functions for the exact sequence elements of all shapes."
+               Computers & Mathematics with Applications, Volume 70, Issue 4, 2015, Pages 353-458, ISSN 0898-1221.
+               https://doi.org/10.1016/j.camwa.2015.04.027.
+   
+               Note that the template argument defineVertexFunctions controls whether this basis is defined in a
+               strictly hierarchical way.  If defineVertexFunctions is false, then the first basis function is the
+               constant 1.0, and this basis will be suitable for discontinuous discretizations.  If defineVertexFunctions
+               is true, then the first basis function will instead be 1.0-x-y, and the basis will be suitable for
+               continuous discretizations.
+  */
+  template<typename ExecutionSpace=Kokkos::DefaultExecutionSpace,
+           typename OutputScalar = double,
+           typename PointScalar  = double,
+           bool defineVertexFunctions = true>            // if defineVertexFunctions is true, first three basis functions are 1-x-y, x, and y.  Otherwise, they are 1, x, and y.
+  class IntegratedLegendreBasis_HGRAD_TRI
+  : public Basis<ExecutionSpace,OutputScalar,PointScalar>
+  {
+  public:
+    using OrdinalTypeArray1DHost = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::OrdinalTypeArray2DHost;
+    
+    using OutputViewType = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::OutputViewType;
+    using PointViewType  = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::PointViewType;
+    using ScalarViewType = typename Basis<ExecutionSpace,OutputScalar,PointScalar>::ScalarViewType;
+  protected:
+    int polyOrder_; // the maximum order of the polynomial
+    bool defineVertexFunctions_; // if true, first and second basis functions are x and 1-x.  Otherwise, they are 1 and x.
+  public:
+    /** \brief  Constructor.
+        \param [in] polyOrder - the polynomial order of the basis.
+     
+     The basis will have polyOrder + 1 members.
+     
+     If defineVertexFunctions is false, then all basis functions are identified with the interior of the line element, and the first two basis functions are 1 and x.
+     
+     If defineVertexFunctions is true, then the first two basis functions are 1-x and x, and these are identified with the left and right vertices of the cell.
+     
+     */
+    IntegratedLegendreBasis_HGRAD_TRI(int polyOrder)
+    :
+    polyOrder_(polyOrder)
+    {
+      this->basisCardinality_  = ((polyOrder+2) * (polyOrder+1)) / 2;
+      this->basisDegree_       = polyOrder;
+      this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Triangle<> >() );
+      this->basisType_         = BASIS_FEM_HIERARCHICAL;
+      this->basisCoordinates_  = COORDINATES_CARTESIAN;
+      this->functionSpace_     = FUNCTION_SPACE_HGRAD;
+      
+      const int degreeLength = 1;
+      this->fieldOrdinalPolynomialDegree_ = OrdinalTypeArray2DHost("Integrated Legendre H(grad) triangle polynomial degree lookup", this->basisCardinality_, degreeLength);
+      
+      int fieldOrdinalOffset = 0;
+      // **** vertex functions **** //
+      const int numVertices = this->basisCellTopology_.getVertexCount();
+      const int numFunctionsPerVertex = 1;
+      const int numVertexFunctions = numVertices * numFunctionsPerVertex;
+      for (int i=0; i<numVertexFunctions; i++)
+      {
+        // for H(grad) on triangle, if defineVertexFunctions is false, first three basis members are linear
+        // if not, then the only difference is that the first member is constant
+        this->fieldOrdinalPolynomialDegree_(i,0) = 1;
+      }
+      if (!defineVertexFunctions)
+      {
+        this->fieldOrdinalPolynomialDegree_(0,0) = 0;
+      }
+      fieldOrdinalOffset += numVertexFunctions;
+      
+      // **** edge functions **** //
+      const int numFunctionsPerEdge = polyOrder - 1; // bubble functions: all but the vertices
+      const int numEdges            = this->basisCellTopology_.getEdgeCount();
+      for (int edgeOrdinal=0; edgeOrdinal<numEdges; edgeOrdinal++)
+      {
+        for (int i=0; i<numFunctionsPerEdge; i++)
+        {
+          this->fieldOrdinalPolynomialDegree_(i+fieldOrdinalOffset,0) = i+2; // vertex functions are 1st order; edge functions start at order 2
+        }
+        fieldOrdinalOffset += numFunctionsPerEdge;
+      }
+      
+      // **** face functions **** //
+      const int max_ij_sum = polyOrder;
+      for (int i=2; i<max_ij_sum; i++)
+      {
+        for (int j=1; i+j<=max_ij_sum; j++)
+        {
+          this->fieldOrdinalPolynomialDegree_(fieldOrdinalOffset,0) = i+j;
+          fieldOrdinalOffset++;
+        }
+      }
+      const int numFaces = 1;
+      const int numFunctionsPerFace = ((polyOrder-1)*(polyOrder-2))/2;
+      INTREPID2_TEST_FOR_EXCEPTION(fieldOrdinalOffset != this->basisCardinality_, std::invalid_argument, "Internal error: basis enumeration is incorrect");
+      
+      // initialize tags
+      {
+        const auto & cardinality = this->basisCardinality_;
+        
+        // Basis-dependent initializations
+        const ordinal_type tagSize  = 4;        // size of DoF tag, i.e., number of fields in the tag
+        const ordinal_type posScDim = 0;        // position in the tag, counting from 0, of the subcell dim
+        const ordinal_type posScOrd = 1;        // position in the tag, counting from 0, of the subcell ordinal
+        const ordinal_type posDfOrd = 2;        // position in the tag, counting from 0, of DoF ordinal relative to the subcell
+        
+        OrdinalTypeArray1DHost tagView("tag view", cardinality*tagSize);
+        const int vertexDim = 0, edgeDim = 1, faceDim = 2;
+
+        if (defineVertexFunctions) {
+          {
+            int tagNumber = 0;
+            for (int vertexOrdinal=0; vertexOrdinal<numVertices; vertexOrdinal++)
+            {
+              for (int functionOrdinal=0; functionOrdinal<numFunctionsPerVertex; functionOrdinal++)
+              {
+                tagView(tagNumber*tagSize+0) = vertexDim;             // vertex dimension
+                tagView(tagNumber*tagSize+1) = vertexOrdinal;         // vertex id
+                tagView(tagNumber*tagSize+2) = functionOrdinal;       // local dof id
+                tagView(tagNumber*tagSize+3) = numFunctionsPerVertex; // total number of dofs in this vertex
+                tagNumber++;
+              }
+            }
+            for (int edgeOrdinal=0; edgeOrdinal<numEdges; edgeOrdinal++)
+            {
+              for (int functionOrdinal=0; functionOrdinal<numFunctionsPerEdge; functionOrdinal++)
+              {
+                tagView(tagNumber*tagSize+0) = edgeDim;               // edge dimension
+                tagView(tagNumber*tagSize+1) = edgeOrdinal;           // edge id
+                tagView(tagNumber*tagSize+2) = functionOrdinal;       // local dof id
+                tagView(tagNumber*tagSize+3) = numFunctionsPerEdge;   // total number of dofs on this edge
+                tagNumber++;
+              }
+            }
+            for (int faceOrdinal=0; faceOrdinal<numFaces; faceOrdinal++)
+            {
+              for (int functionOrdinal=0; functionOrdinal<numFunctionsPerFace; functionOrdinal++)
+              {
+                tagView(tagNumber*tagSize+0) = faceDim;               // face dimension
+                tagView(tagNumber*tagSize+1) = faceOrdinal;           // face id
+                tagView(tagNumber*tagSize+2) = functionOrdinal;       // local dof id
+                tagView(tagNumber*tagSize+3) = numFunctionsPerFace;   // total number of dofs on this face
+                tagNumber++;
+              }
+            }
+          }
+        } else {
+          for (ordinal_type i=0;i<cardinality;++i) {
+            tagView(i*tagSize+0) = faceDim;     // face dimension
+            tagView(i*tagSize+1) = 0;           // face id
+            tagView(i*tagSize+2) = i;           // local dof id
+            tagView(i*tagSize+3) = cardinality; // total number of dofs on this face
+          }
+        }
+        
+        // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
+        // tags are constructed on host
+        this->setOrdinalTagData(this->tagToOrdinal_,
+                                this->ordinalToTag_,
+                                tagView,
+                                this->basisCardinality_,
+                                tagSize,
+                                posScDim,
+                                posScOrd,
+                                posDfOrd);
+      }
+    }
+    
+    /** \brief  Returns basis name
+     
+     \return the name of the basis
+     */
+    const char* getName() const override {
+      return "Intrepid2_IntegratedLegendreBasis_HGRAD_TRI";
+    }
+    
+    // since the getValues() below only overrides the FEM variant, we specify that
+    // we use the base class's getValues(), which implements the FVD variant by throwing an exception.
+    // (It's an error to use the FVD variant on this basis.)
+    using Basis<ExecutionSpace,OutputScalar,PointScalar>::getValues;
+    
+    /** \brief  Evaluation of a FEM basis on a <strong>reference cell</strong>.
+
+        Returns values of <var>operatorType</var> acting on FEM basis functions for a set of
+        points in the <strong>reference cell</strong> for which the basis is defined.
+
+        \param  outputValues      [out] - variable rank array with the basis values
+        \param  inputPoints       [in]  - rank-2 array (P,D) with the evaluation points
+        \param  operatorType      [in]  - the operator acting on the basis functions
+
+        \remark For rank and dimension specifications of the output array see Section
+        \ref basis_md_array_sec.  Dimensions of <var>ArrayScalar</var> arguments are checked
+        at runtime if HAVE_INTREPID2_DEBUG is defined.
+
+        \remark A FEM basis spans a COMPLETE or INCOMPLETE polynomial space on the reference cell
+        which is a smooth function space. Thus, all operator types that are meaningful for the
+        approximated function space are admissible. When the order of the operator exceeds the
+        degree of the basis, the output array is filled with the appropriate number of zeros.
+    */
+    virtual void getValues( OutputViewType outputValues, const PointViewType inputPoints,
+                           const EOperator operatorType = OPERATOR_VALUE ) const override
+    {
+      auto numPoints = inputPoints.extent_int(0);
+      
+      using FunctorType = Hierarchical_HGRAD_TRI_Functor<ExecutionSpace, OutputScalar, PointScalar, OutputViewType, PointViewType>;
+      
+      FunctorType functor(operatorType, outputValues, inputPoints, polyOrder_, defineVertexFunctions);
+      
+      const int outputVectorSize = getVectorSizeForHierarchicalParallelism<OutputScalar>();
+      const int pointVectorSize  = getVectorSizeForHierarchicalParallelism<PointScalar>();
+      const int vectorSize = std::max(outputVectorSize,pointVectorSize);
+      const int teamSize = 1; // because of the way the basis functions are computed, we don't have a second level of parallelism...
+      
+      auto policy = Kokkos::TeamPolicy<ExecutionSpace>(numPoints,teamSize,vectorSize);
+      Kokkos::parallel_for( policy , functor, "Hierarchical_HGRAD_TRI_Functor");
+    }
+  };
+} // end namespace Intrepid2
+
+#endif /* Intrepid2_IntegratedLegendreBasis_HGRAD_TRI_h */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_NodalBasisFamily.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_NodalBasisFamily.hpp
@@ -59,10 +59,20 @@
 #include <Intrepid2_HDIV_QUAD_In_FEM.hpp>
 #include <Intrepid2_HVOL_QUAD_Cn_FEM.hpp>
 
+#include <Intrepid2_HGRAD_TRI_Cn_FEM.hpp>
+#include <Intrepid2_HCURL_TRI_In_FEM.hpp>
+#include <Intrepid2_HDIV_TRI_In_FEM.hpp>
+#include <Intrepid2_HVOL_TRI_Cn_FEM.hpp>
+
 #include <Intrepid2_HGRAD_HEX_Cn_FEM.hpp>
 #include <Intrepid2_HCURL_HEX_In_FEM.hpp>
 #include <Intrepid2_HDIV_HEX_In_FEM.hpp>
 #include <Intrepid2_HVOL_HEX_Cn_FEM.hpp>
+
+#include <Intrepid2_HGRAD_TET_Cn_FEM.hpp>
+#include <Intrepid2_HCURL_TET_In_FEM.hpp>
+#include <Intrepid2_HDIV_TET_In_FEM.hpp>
+#include <Intrepid2_HVOL_TET_Cn_FEM.hpp>
 
 namespace Intrepid2 {
   // the following defines a family of nodal basis functions, derived from a the standard high-order Intrepid2 bases on the line
@@ -112,11 +122,24 @@ namespace Intrepid2 {
     using HDIV_QUAD  = Basis_HDIV_QUAD_In_FEM<ExecutionSpace,OutputValueType,PointValueType>;
     using HVOL_QUAD  = Basis_HVOL_QUAD_Cn_FEM<ExecutionSpace,OutputValueType,PointValueType>;
     
-    // hexahedral bases
+    // triangle bases
+    using HGRAD_TRI = Basis_HGRAD_TRI_Cn_FEM<ExecutionSpace,OutputValueType,PointValueType>;
+    using HCURL_TRI = Basis_HCURL_TRI_In_FEM<ExecutionSpace,OutputValueType,PointValueType>;
+    using HDIV_TRI  = Basis_HDIV_TRI_In_FEM<ExecutionSpace,OutputValueType,PointValueType>;
+    using HVOL_TRI  = Basis_HVOL_TRI_Cn_FEM<ExecutionSpace,OutputValueType,PointValueType>;
+    
+    // hexahedron bases
     using HGRAD_HEX = Basis_HGRAD_HEX_Cn_FEM<ExecutionSpace,OutputValueType,PointValueType>;
     using HCURL_HEX = Basis_HCURL_HEX_In_FEM<ExecutionSpace,OutputValueType,PointValueType>;
     using HDIV_HEX  = Basis_HDIV_HEX_In_FEM<ExecutionSpace,OutputValueType,PointValueType>;
     using HVOL_HEX  = Basis_HVOL_HEX_Cn_FEM<ExecutionSpace,OutputValueType,PointValueType>;
+    
+    // tetrahedron bases
+    using HGRAD_TET = Basis_HGRAD_TET_Cn_FEM<ExecutionSpace,OutputValueType,PointValueType>;
+    using HCURL_TET = Basis_HCURL_TET_In_FEM<ExecutionSpace,OutputValueType,PointValueType>;
+    using HDIV_TET  = Basis_HDIV_TET_In_FEM<ExecutionSpace,OutputValueType,PointValueType>;
+    using HVOL_TET  = Basis_HVOL_TET_Cn_FEM<ExecutionSpace,OutputValueType,PointValueType>;
+    
   };
   
   /** \class Intrepid2::DerivedBasisFamilyModified
@@ -149,7 +172,7 @@ namespace Intrepid2 {
     using HDIV_QUAD  = Basis_Derived_HDIV_QUAD <HGRAD_LINE, HVOL_LINE>;
     using HVOL_QUAD  = Basis_Derived_HVOL_QUAD <HVOL_LINE>;
     
-    // hexahedral bases
+    // hexahedron bases
     using HGRAD_HEX = Basis_Derived_HGRAD_HEX<HGRAD_LINE>;
     using HCURL_HEX = Basis_Derived_HCURL_HEX<HGRAD_LINE, HVOL_LINE>;
     using HDIV_HEX  = Basis_Derived_HDIV_HEX <HGRAD_LINE, HVOL_LINE>;

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_TensorBasis.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_TensorBasis.hpp
@@ -752,7 +752,7 @@ namespace Intrepid2
       INTREPID2_TEST_FOR_EXCEPTION(true, std::invalid_argument, "one-operator, two-inputPoints getValues should be overridden by TensorBasis subclasses");
     }
     
-    /** \brief  Evaluation of a tensor FEM basis on a <strong>reference cell</strong>; subclasses should override this.
+    /** \brief  Evaluation of a tensor FEM basis on a <strong>reference cell</strong>.
 
         Returns values of <var>operatorType</var> acting on FEM basis functions for a set of
         points in the <strong>reference cell</strong> for which the basis is defined.

--- a/packages/intrepid2/src/Shared/Intrepid2_TestUtils.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_TestUtils.hpp
@@ -126,18 +126,28 @@ inline Teuchos::RCP< Intrepid2::Basis<Kokkos::DefaultExecutionSpace,double,doubl
   BasisPtr basis;
   using namespace Intrepid2;
   
-  if (cellTopo.getBaseKey() == shards::Line<2>::key)
+  if (cellTopo.getBaseKey() == shards::Line<>::key)
   {
     basis = getLineBasis<BasisFamily>(fs,polyOrder_x);
   }
-  else if (cellTopo.getBaseKey() == shards::Quadrilateral<4>::key)
+  else if (cellTopo.getBaseKey() == shards::Quadrilateral<>::key)
   {
+    INTREPID2_TEST_FOR_EXCEPTION(polyOrder_y < 0, std::invalid_argument, "polyOrder_y must be specified");
     basis = getQuadrilateralBasis<BasisFamily>(fs,polyOrder_x,polyOrder_y);
+  }
+  else if (cellTopo.getBaseKey() == shards::Triangle<>::key)
+  {
+    basis = getTriangleBasis<BasisFamily>(fs,polyOrder_x);
   }
   else if (cellTopo.getBaseKey() == shards::Hexahedron<>::key)
   {
+    INTREPID2_TEST_FOR_EXCEPTION(polyOrder_y < 0, std::invalid_argument, "polyOrder_y must be specified");
     INTREPID2_TEST_FOR_EXCEPTION(polyOrder_z < 0, std::invalid_argument, "polyOrder_z must be specified");
-    basis = getHexahedralBasis<BasisFamily>(fs,polyOrder_x,polyOrder_y,polyOrder_z);
+    basis = getHexahedronBasis<BasisFamily>(fs,polyOrder_x,polyOrder_y,polyOrder_z);
+  }
+  else if (cellTopo.getBaseKey() == shards::Tetrahedron<>::key)
+  {
+    basis = getTetrahedronBasis<BasisFamily>(fs, polyOrder_x);
   }
   else
   {
@@ -156,8 +166,10 @@ inline Teuchos::RCP< Intrepid2::Basis<Kokkos::DefaultExecutionSpace,double,doubl
   
   using LineBasisGrad = Intrepid2::IntegratedLegendreBasis_HGRAD_LINE<ExecSpace, Scalar, Scalar, defineVertexFunctions, true>;
   using LineBasisVol  = Intrepid2::LegendreBasis_HVOL_LINE< ExecSpace, Scalar, Scalar>;
+  using TriangleBasisFamily = Intrepid2::HierarchicalTriangleBasisFamily<ExecSpace, Scalar, Scalar, defineVertexFunctions>;
+  using TetrahedronBasisFamily = Intrepid2::HierarchicalTetrahedronBasisFamily<ExecSpace, Scalar, Scalar, defineVertexFunctions>;
   
-  using BasisFamily = DerivedBasisFamily<LineBasisGrad, LineBasisVol>;
+  using BasisFamily = DerivedBasisFamily<LineBasisGrad, LineBasisVol, TriangleBasisFamily, TetrahedronBasisFamily>;
   
   return getBasisUsingFamily<BasisFamily>(cellTopo, fs, polyOrder_x, polyOrder_y, polyOrder_z);
 }
@@ -177,6 +189,9 @@ inline ViewType<ValueType> getView(const std::string &label, DimArgs... dims)
   }
 }
 
+/** \brief Returns a View containing equispaced points on the line.
+ \param [in] numPointsBase - the number of points that will be defined along each edge.
+ */
 template <typename PointValueType>
 inline ViewType<PointValueType> lineInputPointsView(int numPoints)
 {
@@ -184,11 +199,16 @@ inline ViewType<PointValueType> lineInputPointsView(int numPoints)
   Kokkos::parallel_for(numPoints, KOKKOS_LAMBDA(const int i)
   {
     double x_zero_one = i * 1.0 / (numPoints-1); // the x value on [0,1]
-    inputPoints(i,0) = fromZeroOne(x_zero_one);   // standard Intrepid2 element
+    inputPoints(i,0) = PointValueType(fromZeroOne(x_zero_one));   // standard Intrepid2 element
   });
   return inputPoints;
 }
 
+/** \brief Returns a View containing equispaced points on the hexahedron.
+ \param [in] numPointsBase - the number of points that will be defined along each edge.
+ 
+ The total number of points defined will be a cubic number; if n=numPointsBase, then the point count is n^3.
+ */
 template <typename PointValueType>
 inline ViewType<PointValueType> hexInputPointsView(int numPoints_1D)
 {
@@ -203,15 +223,20 @@ inline ViewType<PointValueType> hexInputPointsView(int numPoints_1D)
       {
         double z_zero_one = k * 1.0 / (numPoints_1D-1); // the z value on [0,1]
         int pointOrdinal = (i*numPoints_1D+j)*numPoints_1D+k;
-        inputPoints(pointOrdinal,0) = fromZeroOne(x_zero_one);   // standard Intrepid2 element
-        inputPoints(pointOrdinal,1) = fromZeroOne(y_zero_one);   // standard Intrepid2 element
-        inputPoints(pointOrdinal,2) = fromZeroOne(z_zero_one);   // standard Intrepid2 element
+        inputPoints(pointOrdinal,0) = PointValueType(fromZeroOne(x_zero_one));   // standard Intrepid2 element
+        inputPoints(pointOrdinal,1) = PointValueType(fromZeroOne(y_zero_one));   // standard Intrepid2 element
+        inputPoints(pointOrdinal,2) = PointValueType(fromZeroOne(z_zero_one));   // standard Intrepid2 element
       }
     }
   });
   return inputPoints;
 }
 
+/** \brief Returns a View containing equispaced points on the quadrilateral.
+ \param [in] numPointsBase - the number of points that will be defined along each edge.
+ 
+ The total number of points defined will be a square number; if n=numPointsBase, then the point count is n^2.
+ */
 template <typename PointValueType>
 inline ViewType<PointValueType> quadInputPointsView(int numPoints_1D)
 {
@@ -224,8 +249,82 @@ inline ViewType<PointValueType> quadInputPointsView(int numPoints_1D)
     {
       double y_zero_one = j * 1.0 / (numPoints_1D-1); // the y value on [0,1]
       int pointOrdinal = i*numPoints_1D+j;
-      inputPoints(pointOrdinal,0) = fromZeroOne(x_zero_one);   // standard Intrepid2 element
-      inputPoints(pointOrdinal,1) = fromZeroOne(y_zero_one);   // standard Intrepid2 element
+      inputPoints(pointOrdinal,0) = PointValueType(fromZeroOne(x_zero_one));   // standard Intrepid2 element
+      inputPoints(pointOrdinal,1) = PointValueType(fromZeroOne(y_zero_one));   // standard Intrepid2 element
+    }
+  });
+  return inputPoints;
+}
+
+/** \brief Returns a View containing regularly-spaced points on the tetrahedron.
+ \param [in] numPointsBase - the number of points that will be defined along each edge.
+ 
+ The total number of points defined will be a tetrahedral number; if n=numPointsBase, then the point count is the nth tetrahedral number, given by n*(n+1)*(n+2)/6.
+ */
+template <typename PointValueType>
+inline ViewType<PointValueType> tetInputPointsView(int numPointsBase)
+{
+  const int numPoints = numPointsBase*(numPointsBase+1)*(numPointsBase+2)/6;
+  ViewType<PointValueType> inputPoints = getView<PointValueType>("tetrahedron input points",numPoints,3);
+  Kokkos::parallel_for(numPointsBase, KOKKOS_LAMBDA(const int d0) // d0 generalizes row
+  {
+    // the following might be the formula for the nested for loop below, but we need to check this
+    // for now, we comment this out and do the clearer thing that requires more computation
+//    const int n = numPointsBase-d0;
+//    const int pointOrdinalOffset = n*(n+1)*(n+2)/6;
+    int pointOrdinalOffset = 0;
+    for (int i=0; i<d0; i++)
+    {
+      for (int j=0; j<numPointsBase-i; j++)
+      {
+        pointOrdinalOffset += (numPointsBase - i - j);
+      }
+    }
+    
+    double z_zero_one = d0 * 1.0 / (numPointsBase-1); // z value on [0,1]
+    int pointOrdinal = pointOrdinalOffset;
+    for (int d1=0; d1<numPointsBase-d0; d1++) // d1 generalizes column
+    {
+      double y_zero_one = d1 * 1.0 / (numPointsBase-1); // the y value on [0,1]
+      for (int d2=0; d2<numPointsBase-d0-d1; d2++)
+      {
+        double x_zero_one = d2 * 1.0 / (numPointsBase-1); // the x value on [0,1]
+        
+        inputPoints(pointOrdinal,0) = PointValueType(x_zero_one);
+        inputPoints(pointOrdinal,1) = PointValueType(y_zero_one);
+        inputPoints(pointOrdinal,2) = PointValueType(z_zero_one);
+        
+        pointOrdinal++;
+      }
+    }
+  });
+  return inputPoints;
+}
+
+/** \brief Returns a View containing regularly-spaced points on the triangle.
+ \param [in] numPointsBase - the number of points that will be defined along each edge.
+ 
+ The total number of points defined will be a triangular number; if n=numPointsBase, then the point count is the nth triangular number, given by n*(n+1)/2.
+ */
+template <typename PointValueType>
+inline ViewType<PointValueType> triInputPointsView(int numPointsBase)
+{
+  const int numPoints = numPointsBase*(numPointsBase+1)/2;
+  ViewType<PointValueType> inputPoints = getView<PointValueType>("triangle input points",numPoints,2);
+  Kokkos::parallel_for(numPointsBase, KOKKOS_LAMBDA(const int row)
+  {
+    int rowPointOrdinalOffset = 0;
+    for (int i=0; i<row; i++)
+    {
+      rowPointOrdinalOffset += (numPointsBase - i);
+    }
+    double y_zero_one = row * 1.0 / (numPointsBase-1); // y value on [0,1]
+    for (int col=0; col<numPointsBase-row; col++)
+    {
+      const int pointOrdinal = rowPointOrdinalOffset + col;
+      double x_zero_one = col * 1.0 / (numPointsBase-1); // the x value on [0,1]
+      inputPoints(pointOrdinal,0) = PointValueType(x_zero_one);
+      inputPoints(pointOrdinal,1) = PointValueType(y_zero_one);
     }
   });
   return inputPoints;
@@ -234,17 +333,25 @@ inline ViewType<PointValueType> quadInputPointsView(int numPoints_1D)
 template <typename PointValueType>
 inline ViewType<PointValueType> getInputPointsView(shards::CellTopology &cellTopo, int numPoints_1D)
 {
-  if (cellTopo.getBaseKey() == shards::Line<2>::key)
+  if (cellTopo.getBaseKey() == shards::Line<>::key)
   {
     return lineInputPointsView<PointValueType>(numPoints_1D);
   }
-  else if (cellTopo.getBaseKey() == shards::Quadrilateral<4>::key)
+  else if (cellTopo.getBaseKey() == shards::Quadrilateral<>::key)
   {
     return quadInputPointsView<PointValueType>(numPoints_1D);
   }
-  else if (cellTopo.getBaseKey() == shards::Hexahedron<8>::key)
+  else if (cellTopo.getBaseKey() == shards::Hexahedron<>::key)
   {
     return hexInputPointsView<PointValueType>(numPoints_1D);
+  }
+  else if (cellTopo.getBaseKey() == shards::Triangle<>::key)
+  {
+    return triInputPointsView<PointValueType>(numPoints_1D);
+  }
+  else if (cellTopo.getBaseKey() == shards::Tetrahedron<>::key)
+  {
+    return tetInputPointsView<PointValueType>(numPoints_1D);
   }
   else
   {

--- a/packages/intrepid2/unit-test/Discretization/Basis/BasisEquivalenceTests.cpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/BasisEquivalenceTests.cpp
@@ -227,7 +227,7 @@ namespace
                             const double relTol, const double absTol, Teuchos::FancyOStream &out, bool &success)
   {
     // first, check that the bases agree on cardinality
-    TEST_ASSERT(basis1.getCardinality() == basis2.getCardinality());
+    TEST_EQUALITY(basis1.getCardinality(), basis2.getCardinality());
     
     const int basisCardinality = basis1.getCardinality();
     
@@ -245,6 +245,18 @@ namespace
     ViewType<PointScalar> points = ViewType<PointScalar>("quadrature points 1D ref cell", numRefPoints, spaceDim);
     ViewType<WeightScalar> weights = ViewType<WeightScalar>("quadrature weights 1D ref cell", numRefPoints);
     quadrature->getCubature(points, weights);
+    
+    out << "Points being tested:\n";
+    for (int pointOrdinal=0; pointOrdinal<numRefPoints; pointOrdinal++)
+    {
+      out << pointOrdinal << ": " << "(";
+      for (int d=0; d<spaceDim; d++)
+      {
+        out << points(pointOrdinal,d);
+        if (d < spaceDim-1) out << ",";
+      }
+      out << ")\n";
+    }
     
     auto functionSpace = basis1.getFunctionSpace();
     
@@ -282,6 +294,111 @@ namespace
     ViewType<Scalar> basis1Coefficients("basis 1 coefficients to represent basis 2", basisCardinality, basisCardinality);
     Kokkos::deep_copy(basis1Coefficients, basis1_vs_basis2);
     solveSystemUsingHostLapack(basis1_vs_basis1, basis1Coefficients);
+    
+    // for non-"DG" bases, check that the topological associations match up
+    // to check for DG-ness of basis, examine how many dofs are associated with the interior
+    shards::CellTopology cellTopo = basis1.getBaseCellTopology();
+    const int interiorDim = cellTopo.getDimension();
+    const int interiorSubcellOrdinal = 0;
+    const int firstDofOrdinalForSubcell = 0;
+    
+    int basis1InteriorCardinality = 0, basis2InteriorCardinality = 0;
+    int basis1FirstInterior = -1, basis2FirstInterior = -1;
+    if (basis1.getAllDofOrdinal().extent_int(0) > interiorDim)
+    {
+      basis1FirstInterior = basis1.getAllDofOrdinal()(interiorDim, interiorSubcellOrdinal, firstDofOrdinalForSubcell);
+    }
+    if (basis2.getAllDofOrdinal().extent_int(0) > interiorDim)
+    {
+      basis2FirstInterior = basis2.getAllDofOrdinal()(interiorDim, interiorSubcellOrdinal, firstDofOrdinalForSubcell);
+    }
+    
+    // if there are no interior dofs, we'll get a -1 value
+    if (basis1FirstInterior != -1)
+    {
+      // at index 3, dof tag stores the total dof count associated with the subcell (here, the interior)
+      basis1InteriorCardinality = basis1.getDofTag(basis1FirstInterior)(3);
+    }
+    if (basis2FirstInterior != -1)
+    {
+      // at index 3, dof tag stores the total dof count associated with the subcell (here, the interior)
+      basis2InteriorCardinality = basis2.getDofTag(basis2FirstInterior)(3);
+    }
+    const bool basis1IsDG = (basis1InteriorCardinality == basisCardinality);
+    const bool basis2IsDG = (basis2InteriorCardinality == basisCardinality);
+    const bool neitherBasisIsDG = !basis1IsDG && !basis2IsDG;
+    if (neitherBasisIsDG)
+    {
+      auto basis1CoefficientsHost = getHostCopy(basis1Coefficients);
+      // if neither basis is DG, then we can expect them to have matching counts on basis members
+      // associated with a given subcell.  We can also expect the representation of of members of basis1
+      // on a given subcell in terms of basis2 to involve at least some members of basis2 associated with the same
+      // subcell.  (We can check this by examining the weights in basis1Coefficients.)
+      for (int subcellDim=0; subcellDim<=interiorDim; subcellDim++)
+      {
+        out << "checking subcells of dimension " << subcellDim << std::endl;
+        // if there are no dofs for this subcell dimension and greater, then getAllDofOrdinal() won't have
+        // an entry for subcellDim.  The following guards against that:
+        if (basis1.getAllDofOrdinal().extent_int(0) <= subcellDim)
+        {
+          // basis1 has no dofs for this subcell dim.  Check that basis2 also does not:
+          TEST_ASSERT(basis2.getAllDofOrdinal().extent_int(0) <= subcellDim);
+          break; // we've already checked all subcell dimensions that have any dofs associated with them
+        }
+        
+        const int subcellCount = cellTopo.getSubcellCount(subcellDim);
+        for (int subcellOrdinal=0; subcellOrdinal<subcellCount; subcellOrdinal++)
+        {
+          // need to find the first dof ordinal for the subcell to get the basis cardinality on the subcell
+          const int basis1FirstDofOrdinal = basis1.getAllDofOrdinal()(subcellDim, subcellOrdinal, firstDofOrdinalForSubcell);
+          const int basis2FirstDofOrdinal = basis2.getAllDofOrdinal()(subcellDim, subcellOrdinal, firstDofOrdinalForSubcell);
+          // if there are no dofs on the subcell, we'll get a -1 value
+          if ((basis1FirstDofOrdinal == -1) || (basis2FirstDofOrdinal == -1))
+          {
+            // if one of the bases has no dofs on the subcell, then both should:
+            TEST_ASSERT((basis1FirstDofOrdinal == -1) && (basis2FirstDofOrdinal == -1));
+            // if either of the bases has no dofs on the subcell, we should continue with the next subcell
+            continue;
+          }
+          // at index 3, dof tag stores the total dof count associated with the subcell
+          const int basis1SubcellCardinality = basis1.getDofTag(basis1FirstDofOrdinal)(3);
+          const int basis2SubcellCardinality = basis2.getDofTag(basis2FirstDofOrdinal)(3);
+          TEST_EQUALITY(basis1SubcellCardinality, basis2SubcellCardinality);
+          // if we fail the cardinality check, not much point in checking the coefficients
+          if (basis1SubcellCardinality != basis2SubcellCardinality) continue;
+          
+          out << "subcell " << subcellOrdinal << " has " << basis1SubcellCardinality << " dofs.\n";
+          
+          std::vector<ordinal_type> basis1SubcellDofOrdinals(basis1SubcellCardinality);
+          std::vector<ordinal_type> basis2SubcellDofOrdinals(basis2SubcellCardinality);
+          for (int subcellDofOrdinal=0; subcellDofOrdinal<basis1SubcellCardinality; subcellDofOrdinal++)
+          {
+            basis1SubcellDofOrdinals[subcellDofOrdinal] = basis1.getAllDofOrdinal()(subcellDim, subcellOrdinal, subcellDofOrdinal);
+            basis2SubcellDofOrdinals[subcellDofOrdinal] = basis2.getAllDofOrdinal()(subcellDim, subcellOrdinal, subcellDofOrdinal);
+          }
+          for (int subcellDofOrdinal=0; subcellDofOrdinal<basis1SubcellCardinality; subcellDofOrdinal++)
+          {
+            // each column in basis1Coefficients represents the corresponding member of basis 2 in terms of members of basis 1
+            const int basis2DofOrdinal = basis2SubcellDofOrdinals[subcellDofOrdinal];
+            out << "checking representation of basis2 dof ordinal " << basis2DofOrdinal << std::endl;
+            
+            // look for at least one member of basis1's representation on the subcell
+            bool hasNonzeroCoefficient = false;
+            for (const int basis1DofOrdinal : basis1SubcellDofOrdinals)
+            {
+              Scalar basisCoefficient = basis1CoefficientsHost(basis1DofOrdinal,basis2DofOrdinal);
+              bool nonzeroCoefficient = (std::abs(basisCoefficient) > absTol);
+              if (nonzeroCoefficient)
+              {
+                out << "basis coefficient " << basisCoefficient << " is nonzero (absTol = " << absTol << ").\n";
+                hasNonzeroCoefficient = true;
+              }
+            }
+            TEST_ASSERT(hasNonzeroCoefficient);
+          }
+        }
+      }
+    }
     
     // compute the values for basis2 using basis1Coefficients, basis1Values, and confirm that these agree with basisValues2
     ViewType<Scalar> basis2ValuesFromBasis1 = getOutputView<Scalar>(functionSpace, OPERATOR_VALUE, basisCardinality, numRefPoints, spaceDim);
@@ -475,6 +592,117 @@ namespace
     CnBasis cnBasis(polyOrder);
     C2Basis c2Basis;
     testBasisEquivalence(cnBasis, c2Basis, opsToTest, relTol, absTol, out, success);
+  }
+  
+  TEUCHOS_UNIT_TEST( BasisEquivalence, TetrahedronNodalCnVersusNodalC2_HGRAD )
+  {
+    using CnBasis = Intrepid2::Basis_HGRAD_TET_Cn_FEM<Kokkos::DefaultExecutionSpace>;
+    using C2Basis = Intrepid2::Basis_HGRAD_TET_C2_FEM<Kokkos::DefaultExecutionSpace>;
+    
+    // OPERATOR_D2 and above are not supported by either the nodal or the hierarchical basis at present...
+    std::vector<EOperator> opsToTest {OPERATOR_GRAD, OPERATOR_D1};
+    
+    // these tolerances are selected such that we have a little leeway for architectural differences
+    // (It is true, though, that we incur a fair amount of floating point error for higher order bases in higher dimensions)
+    const double relTol=1e-12; // 2e-14 is sharp on development setup; relaxing for potential architectural differences
+    const double absTol=1e-13; // 3e-15 is sharp on development setup; relaxing for potential architectural differences
+    
+    CnBasis cnBasis(2);
+    C2Basis c2Basis;
+    testBasisEquivalence(cnBasis, c2Basis, opsToTest, relTol, absTol, out, success);
+  }
+  
+  TEUCHOS_UNIT_TEST( BasisEquivalence, TetrahedronHierarchicalDGVersusHierarchicalCG_HGRAD )
+  {
+    using CGBasis = HierarchicalBasisFamily<>::HGRAD_TET;
+    using DGBasis = DGHierarchicalBasisFamily<>::HGRAD_TET;
+    
+    // these tolerances are selected such that we have a little leeway for architectural differences
+    // (It is true, though, that we incur a fair amount of floating point error for higher order bases in higher dimensions)
+    const double relTol=1e-6; // 3e-8 is sharp on development setup for polyOrder=2; relaxing for potential architectural differences
+    const double absTol=1e-9; // 5e-11 is sharp on development setup for polyOrder=2; relaxing for potential architectural differences
+    
+    std::vector<EOperator> opsToTest {OPERATOR_GRAD, OPERATOR_D1};
+    for (int polyOrder=1; polyOrder<7; polyOrder++)
+    {
+      CGBasis cgBasis(polyOrder);
+      DGBasis dgBasis(polyOrder);
+      testBasisEquivalence(cgBasis, dgBasis, opsToTest, relTol, absTol, out, success);
+    }
+  }
+  
+  TEUCHOS_UNIT_TEST( BasisEquivalence, TetrahedronNodalVersusHierarchicalCG_HGRAD )
+  {
+    using HierarchicalBasis = HierarchicalBasisFamily<>::HGRAD_TET;
+    using NodalBasis        = NodalBasisFamily<>::HGRAD_TET;
+    
+    // OPERATOR_D2 and above are not supported by either the nodal or the hierarchical basis at present...
+    std::vector<EOperator> opsToTest {OPERATOR_GRAD, OPERATOR_D1};
+    
+    // these tolerances are selected such that we have a little leeway for architectural differences
+    // (It is true, though, that we incur a fair amount of floating point error for higher order bases in higher dimensions)
+    const double relTol=1e-6;  // 3e-08 is sharp on development setup for polyOrder=6; relaxing for potential architectural differences
+    const double absTol=1e-10; // 3e-12 is sharp on development setup for polyOrder=6; relaxing for potential architectural differences
+    
+    for (int polyOrder=1; polyOrder<7; polyOrder++)
+    {
+      HierarchicalBasis hierarchicalBasis(polyOrder);
+      NodalBasis        nodalBasis(polyOrder);
+      
+//      auto cellTopo = nodalBasis.getBaseCellTopology();
+//      const int faceDim = 2;
+//      for (int intrepid2FaceOrdinal=0; intrepid2FaceOrdinal<4; intrepid2FaceOrdinal++)
+//      {
+//        int vertex0 = cellTopo.getNodeMap(faceDim, intrepid2FaceOrdinal, 0);
+//        int vertex1 = cellTopo.getNodeMap(faceDim, intrepid2FaceOrdinal, 1);
+//        int vertex2 = cellTopo.getNodeMap(faceDim, intrepid2FaceOrdinal, 2);
+//        std::cout << "face " << intrepid2FaceOrdinal << ": " << vertex0 << vertex1 << vertex2 << std::endl;
+//      }
+      
+      testBasisEquivalence(nodalBasis, hierarchicalBasis, opsToTest, relTol, absTol, out, success);
+    }
+  }
+  
+  TEUCHOS_UNIT_TEST( BasisEquivalence, TriangleNodalVersusHierarchicalCG_HGRAD )
+  {
+    using HierarchicalBasis = HierarchicalBasisFamily<>::HGRAD_TRI;
+    using NodalBasis        = NodalBasisFamily<>::HGRAD_TRI;
+    
+    // OPERATOR_D2 and above are not supported by either the nodal or the hierarchical basis at present...
+    std::vector<EOperator> opsToTest {OPERATOR_GRAD, OPERATOR_D1};
+    
+    // these tolerances are selected such that we have a little leeway for architectural differences
+    // (It is true, though, that we incur a fair amount of floating point error for higher order bases in higher dimensions)
+    const double relTol=1e-11; // 7e-13 is sharp on development setup for polyOrder=4; relaxing for potential architectural differences
+    const double absTol=1e-12; // 2e-14 is sharp on development setup for polyOrder=4; relaxing for potential architectural differences
+    
+    for (int polyOrder=1; polyOrder<5; polyOrder++)
+    {
+      HierarchicalBasis hierarchicalBasis(polyOrder);
+      NodalBasis        nodalBasis(polyOrder);
+      testBasisEquivalence(nodalBasis, hierarchicalBasis, opsToTest, relTol, absTol, out, success);
+    }
+  }
+  
+  TEUCHOS_UNIT_TEST( BasisEquivalence, TriangleHierarchicalCGVersusHierarchicalDG_HGRAD )
+  {
+    using CGBasis =   HierarchicalBasisFamily<>::HGRAD_TRI;
+    using DGBasis = DGHierarchicalBasisFamily<>::HGRAD_TRI;
+    
+    // OPERATOR_D2 and above are not supported by either the nodal or the hierarchical basis at present...
+    std::vector<EOperator> opsToTest {OPERATOR_GRAD, OPERATOR_D1};
+    
+    // these tolerances are selected such that we have a little leeway for architectural differences
+    // (It is true, though, that we incur a fair amount of floating point error for higher order bases in higher dimensions)
+    const double relTol=1e-11; // 7e-13 is sharp on development setup for polyOrder=4; relaxing for potential architectural differences
+    const double absTol=1e-12; // 2e-14 is sharp on development setup for polyOrder=4; relaxing for potential architectural differences
+    
+    for (int polyOrder=1; polyOrder<5; polyOrder++)
+    {
+      CGBasis cgBasis(polyOrder);
+      DGBasis dgBasis(polyOrder);
+      testBasisEquivalence(cgBasis, dgBasis, opsToTest, relTol, absTol, out, success);
+    }
   }
   
 } // namespace

--- a/packages/intrepid2/unit-test/Discretization/Basis/HierarchicalBases/AnalyticPolynomialsMatchTests.cpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HierarchicalBases/AnalyticPolynomialsMatchTests.cpp
@@ -52,6 +52,7 @@
 
 #include "Intrepid2_HierarchicalBasisFamily.hpp"
 #include "Intrepid2_NodalBasisFamily.hpp"
+#include "Intrepid2_Polynomials.hpp"
 #include "Intrepid2_Types.hpp"
 
 #include "Intrepid2_TestUtils.hpp"
@@ -61,6 +62,174 @@
 namespace
 {
   using namespace Intrepid2;
+  
+  template<typename Scalar>
+  Scalar integratedJacobi(Scalar x, Scalar t, double alpha, const int n, const int derivativeOrder = 0)
+  {
+    // ideally, we would have closed-form expressions somewhere in here, as we do for integrated Legendre below
+    // for now, though, this is just a thin wrapper around the call to Intrepid2::Polynomials::integratedJacobiValues()
+    auto values = getView<Scalar>("integrated Jacobi values", n+1);
+    Polynomials::integratedJacobiValues(values, alpha, n, x, t);
+    return values(n);
+  }
+  
+  template<typename Scalar>
+  Scalar integratedLegendreAnalytic(Scalar x, const int n, bool useMinusOneToOne, const int derivativeOrder = 0)
+  {
+    // formulas below are for x in [-1,1]; if we are using [0,1], need to remap appropriately:
+    const double derivativeScaling = useMinusOneToOne ? 1.0 : pow(2.0, derivativeOrder);
+    if (!useMinusOneToOne)
+    {
+      x = 2.0 * x - 1.0;
+    }
+    Scalar value;
+    switch (derivativeOrder)
+    {
+      case 0:
+        switch (n)
+      {
+        case 0:
+          value = (1.0-x)/2.0;                   // left vertex function (node at -1)
+          break;
+        case 1:
+          value = (1.0+x)/2.0;                   // right vertex function (node at 1)
+          break;
+        case 2:
+          value = (x*x-1.0)/4.0;                 // L_2 : (x^2 - 1) / 4
+          break;
+        case 3:
+          value = (x*x*x-x)/4.0;                 // L_3 : (x^3 - x) / 4
+          break;
+        case 4:
+          value = (5.*x*x*x*x - 6.*x*x+1.)/16.0; // L_4 : (5x^4-6x^2+1) / 16
+          break;
+        default:
+          TEUCHOS_TEST_FOR_EXCEPTION(true, std::invalid_argument, "unsupported n");
+      }
+        break;
+      case 1:
+        switch (n)
+      {
+        case 0:
+          value = -1.0/2.0;              // left vertex function (node at -1)
+          break;
+        case 1:
+          value = 1.0/2.0;               // right vertex function (node at 1)
+          break;
+        case 2:
+          value = x/2.0;                 // L_2 : (x^2 - 1) / 4
+          break;
+        case 3:
+          value = (3.0*x*x-1.0)/4.0;     // L_3 : (x^3 - x) / 4
+          break;
+        case 4:
+          value = (5.*x*x*x - 3.*x)/4.0; // L_4 : (5x^4-6x^2+1) / 16
+          break;
+        default:
+          TEUCHOS_TEST_FOR_EXCEPTION(true, std::invalid_argument, "unsupported n");
+      }
+        break;
+      case 2:
+        switch (n)
+      {
+        case 0:
+          value = 0.0;               // left vertex function (node at -1)
+          break;
+        case 1:
+          value = 0.0;               // right vertex function (node at 1)
+          break;
+        case 2:
+          value = 1.0/2.0;           // L_2 : (x^2 - 1) / 4
+          break;
+        case 3:
+          value = 3.0*x/2.0;         // L_3 : (x^3 - x) / 4
+          break;
+        case 4:
+          value = (15.*x*x - 3.)/4.; // L_4 : (5x^4-6x^2+1) / 16
+          break;
+        default:
+          TEUCHOS_TEST_FOR_EXCEPTION(true, std::invalid_argument, "unsupported n");
+      }
+        break;
+      case 3:
+        switch (n)
+      {
+        case 0:
+          value = 0.0;               // left vertex function (node at -1)
+          break;
+        case 1:
+          value = 0.0;               // right vertex function (node at 1)
+          break;
+        case 2:
+          value = 0.0;               // L_2 : (x^2 - 1) / 4
+          break;
+        case 3:
+          value = 3.0/2.0;           // L_3 : (x^3 - x) / 4
+          break;
+        case 4:
+          value = (15.*x)/2.;        // L_4 : (5x^4-6x^2+1) / 16
+          break;
+        default:
+          TEUCHOS_TEST_FOR_EXCEPTION(true, std::invalid_argument, "unsupported n");
+      }
+        break;
+      case 4:
+        switch (n)
+      {
+        case 0:
+          value = 0.0;           // left vertex function (node at -1)
+          break;
+        case 1:
+          value = 0.0;           // right vertex function (node at 1)
+          break;
+        case 2:
+          value = 0.0;           // L_2 : (x^2 - 1) / 4
+          break;
+        case 3:
+          value = 0.0;           // L_3 : (x^3 - x) / 4
+          break;
+        case 4:
+          value = 15./2.;        // L_4 : (5x^4-6x^2+1) / 16
+          break;
+        default:
+          TEUCHOS_TEST_FOR_EXCEPTION(true, std::invalid_argument, "unsupported n");
+      }
+        break;
+      default:
+        value = 0.0;
+    }
+    return value * derivativeScaling;
+  }
+  
+  template<typename Scalar>
+  Scalar shiftedScaledIntegratedLegendreAnalytic(Scalar x, Scalar t, const int n)
+  {
+    bool useMinusOneToOne = false; // our domain is [0,1]
+    const int derivativeOrder = 0;
+    double tol = 1e-15;
+    using std::abs;
+    if ((n == 0) || (n == 1))
+    {
+      // linear in x: scaling by t cancels
+      return integratedLegendreAnalytic(x, n, useMinusOneToOne, derivativeOrder);
+    }
+    else if (abs(t) < tol)
+    {
+      // define a scaling by 0 to be 0 (does this match what Fuentes et al do??)
+      // even if this isn't perfectly general, it works for our tests (at least for OPERATOR_VALUE):
+      // we only ever will end up with t=0 for edge functions on the triangle, evaluated at a vertex.  These vanish.
+      return 0.0;
+    }
+    else
+    {
+      Scalar tPower = 1.0;
+      for (int i=0; i<n; i++)
+      {
+        tPower *= t;
+      }
+      return tPower * integratedLegendreAnalytic(Scalar(x/t), n, useMinusOneToOne);
+    }
+  }
   
   template<typename ExecutionSpace=Kokkos::DefaultExecutionSpace,
            typename OutputScalar = double,
@@ -92,63 +261,35 @@ namespace
       int pointPassed = true;
       PointScalar x = inputPointsViewHost(pointOrdinal,0);
       
+      const bool useMinusOneToOne = true; // Intrepid2's reference element
+      int derivativeOrder;
+      
       switch (op)
       {
         case Intrepid2::OPERATOR_VALUE:
-          expectedValuesViewHost(0) = (1.0-x)/2.0;                   // left vertex function (node at -1)
-          expectedValuesViewHost(1) = (1.0+x)/2.0;                   // right vertex function (node at 1)
-          expectedValuesViewHost(2) = (x*x-1.0)/4.0;                 // L_2 : (x^2 - 1) / 4
-          expectedValuesViewHost(3) = (x*x*x-x)/4.0;                 // L_3 : (x^3 - x) / 4
-          expectedValuesViewHost(4) = (5.*x*x*x*x - 6.*x*x+1.)/16.0; // L_4 : (5x^4-6x^2+1) / 16
+          derivativeOrder = 0;
           break;
         case Intrepid2::OPERATOR_GRAD:
+          derivativeOrder = 1;
+          break;
         case Intrepid2::OPERATOR_D1:
-          // first derivatives of the above:
-          expectedValuesViewHost(0) = -1.0/2.0;              // left vertex function (node at -1)
-          expectedValuesViewHost(1) = 1.0/2.0;               // right vertex function (node at 1)
-          expectedValuesViewHost(2) = x/2.0;                 // L_2 : (x^2 - 1) / 4
-          expectedValuesViewHost(3) = (3.0*x*x-1.0)/4.0;     // L_3 : (x^3 - x) / 4
-          expectedValuesViewHost(4) = (5.*x*x*x - 3.*x)/4.0; // L_4 : (5x^4-6x^2+1) / 16
-          break;
         case Intrepid2::OPERATOR_D2:
-          // second derivatives:
-          expectedValuesViewHost(0) = 0.0;               // left vertex function (node at -1)
-          expectedValuesViewHost(1) = 0.0;               // right vertex function (node at 1)
-          expectedValuesViewHost(2) = 1.0/2.0;           // L_2 : (x^2 - 1) / 4
-          expectedValuesViewHost(3) = 3.0*x/2.0;         // L_3 : (x^3 - x) / 4
-          expectedValuesViewHost(4) = (15.*x*x - 3.)/4.; // L_4 : (5x^4-6x^2+1) / 16
-          break;
         case Intrepid2::OPERATOR_D3:
-          // third derivatives:
-          expectedValuesViewHost(0) = 0.0;               // left vertex function (node at -1)
-          expectedValuesViewHost(1) = 0.0;               // right vertex function (node at 1)
-          expectedValuesViewHost(2) = 0.0;               // L_2 : (x^2 - 1) / 4
-          expectedValuesViewHost(3) = 3.0/2.0;           // L_3 : (x^3 - x) / 4
-          expectedValuesViewHost(4) = (15.*x)/2.;        // L_4 : (5x^4-6x^2+1) / 16
-          break;
         case Intrepid2::OPERATOR_D4:
-          // fourth derivatives:
-          expectedValuesViewHost(0) = 0.0;           // left vertex function (node at -1)
-          expectedValuesViewHost(1) = 0.0;           // right vertex function (node at 1)
-          expectedValuesViewHost(2) = 0.0;           // L_2 : (x^2 - 1) / 4
-          expectedValuesViewHost(3) = 0.0;           // L_3 : (x^3 - x) / 4
-          expectedValuesViewHost(4) = 15./2.;        // L_4 : (5x^4-6x^2+1) / 16
-          break;
         case Intrepid2::OPERATOR_D5:
         case Intrepid2::OPERATOR_D6:
         case Intrepid2::OPERATOR_D7:
         case Intrepid2::OPERATOR_D8:
         case Intrepid2::OPERATOR_D9:
         case Intrepid2::OPERATOR_D10:
-          // fourth derivatives:
-          expectedValuesViewHost(0) = 0.0;           // left vertex function (node at -1)
-          expectedValuesViewHost(1) = 0.0;           // right vertex function (node at 1)
-          expectedValuesViewHost(2) = 0.0;           // L_2 : (x^2 - 1) / 4
-          expectedValuesViewHost(3) = 0.0;           // L_3 : (x^3 - x) / 4
-          expectedValuesViewHost(4) = 0.0;           // L_4 : (5x^4-6x^2+1) / 16
+          derivativeOrder = op - OPERATOR_D1 + 1;
           break;
         default:
           INTREPID2_TEST_FOR_EXCEPTION(true, std::invalid_argument, "Unsupported operator");
+      }
+      for (int n=0; n<polyOrder+1; n++)
+      {
+        expectedValuesViewHost(n) = integratedLegendreAnalytic(x, n, useMinusOneToOne, derivativeOrder);
       }
       
       for (int fieldOrdinal=0; fieldOrdinal<hgradBasis->getCardinality(); fieldOrdinal++)
@@ -339,6 +480,208 @@ namespace
     }
   }
   
+  template<typename ExecutionSpace=Kokkos::DefaultExecutionSpace,
+           typename OutputScalar = double,
+           typename PointScalar  = double>
+  void testHierarchicalHGRAD_TRIANGLE_MatchesAnalyticValues(Intrepid2::EOperator op, const double tol, Teuchos::FancyOStream &out, bool &success)
+  {
+    using namespace Intrepid2;
+    using BasisFamily = HierarchicalBasisFamily<ExecutionSpace,OutputScalar,PointScalar>;
+    
+    const int spaceDim  = 2;
+    const int polyOrder = 4;
+    auto hgradBasis = getTriangleBasis<BasisFamily>(FUNCTION_SPACE_HGRAD, polyOrder);
+    
+    const int numVertices                  = 3;
+    const int numFunctionsPerVertex        = 1;
+    const int numVertexFunctionsExpected   = numVertices * numFunctionsPerVertex;
+    const int numEdges                     = 3;
+    const int num1DEdgeFunctions           = (polyOrder + 1) - 2; // line basis cardinality, minus two vertex functions
+    const int numEdgeFunctionsExpected     = num1DEdgeFunctions * numEdges;
+    const int numInteriorFunctionsExpected = (num1DEdgeFunctions-1)*num1DEdgeFunctions/2; // triangular sum
+    const int expectedCardinality = numVertexFunctionsExpected + numEdgeFunctionsExpected + numInteriorFunctionsExpected;
+    
+    TEST_EQUALITY(expectedCardinality, hgradBasis->getCardinality());
+    // could also test vertex/edge/face function count individually (worth doing, I think)
+    
+    int numPoints_1D = 5;
+    shards::CellTopology triangleTopo = shards::CellTopology(shards::getCellTopologyData<shards::Triangle<> >() );
+    auto inputPointsView = getInputPointsView<PointScalar>(triangleTopo, numPoints_1D);
+    
+    const int numPoints = inputPointsView.extent_int(0);
+        
+    auto hgradOutputView = getOutputView<OutputScalar>(FUNCTION_SPACE_HGRAD, op, hgradBasis->getCardinality(), numPoints, spaceDim);
+    hgradBasis->getValues(hgradOutputView, inputPointsView, op);
+    
+    auto hgradOutputViewHost  = getHostCopy(hgradOutputView);
+    auto inputPointsViewHost = getHostCopy(inputPointsView);
+    
+    ViewType<OutputScalar> expectedValuesView = getOutputView<OutputScalar>(FUNCTION_SPACE_HGRAD, op, hgradBasis->getCardinality(), numPoints, spaceDim);
+    auto expectedValuesViewHost = getHostCopy(expectedValuesView);
+    
+    auto legendreValuesAtPoint = getView<OutputScalar>("Legendre values temporary storage", polyOrder+1);
+    auto legendreValuesAtPointHost = getHostCopy(legendreValuesAtPoint);
+    
+    for (int pointOrdinal=0; pointOrdinal<numPoints; pointOrdinal++)
+    {
+      int pointPassed = true;
+      PointScalar x = inputPointsViewHost(pointOrdinal,0);
+      PointScalar y = inputPointsViewHost(pointOrdinal,1);
+      
+      out << "Checking point (" << x << "," << y << ")\n";
+      
+      // write as barycentric coordinates:
+      const PointScalar lambda[3] = {1. - x - y, x, y};
+      const int edge_start[3] = {0,1,0};
+      const int edge_end[3]   = {1,2,2};
+      
+      switch (op)
+      {
+        case Intrepid2::OPERATOR_VALUE:
+        {
+          // vertex polynomials come first, according to vertex ordering: (0,0), (1,0), (0,1)
+          for (int vertexOrdinal=0; vertexOrdinal<numVertexFunctionsExpected; vertexOrdinal++)
+          {
+            expectedValuesViewHost(vertexOrdinal,pointOrdinal) = lambda[vertexOrdinal];
+          }
+          
+          int fieldOrdinalOffset = 3;
+          for (int edgeOrdinal=0; edgeOrdinal<numEdges; edgeOrdinal++)
+          {
+            const auto & s0 = lambda[edge_start[edgeOrdinal]];
+            const auto & s1 = lambda[edge_end[edgeOrdinal]];
+            const PointScalar t = s0 + s1;
+            
+            for (int edgeFunctionOrdinal=0; edgeFunctionOrdinal<num1DEdgeFunctions; edgeFunctionOrdinal++)
+            {
+              expectedValuesViewHost(edgeFunctionOrdinal+fieldOrdinalOffset,pointOrdinal) = shiftedScaledIntegratedLegendreAnalytic(s1, t, edgeFunctionOrdinal+2);
+            }
+            fieldOrdinalOffset += num1DEdgeFunctions;
+          }
+          // face functions
+          for (int i=2; i<polyOrder; i++)
+          {
+            // we use edge function values from the 01 edge and blend with integrated Jacobi
+            // the 01 edge function values start just after the vertex functions; since i starts at 2, our offset is therefore 1:
+            const int offset = numVertexFunctionsExpected - 2;
+            const OutputScalar & edgeFunctionValue = expectedValuesViewHost(i+offset,pointOrdinal);
+            double alpha = i * 2.0;
+            for (int j=1; i+j<=polyOrder; j++)
+            {
+              const PointScalar  &x = lambda[2];
+              const PointScalar   t = 1.0;
+              const OutputScalar jacobiValue = integratedJacobi(x, t, alpha, j);
+              expectedValuesViewHost(fieldOrdinalOffset,pointOrdinal) = edgeFunctionValue * jacobiValue;
+              fieldOrdinalOffset++;
+            }
+          }
+        }
+          break;
+//        case Intrepid2::OPERATOR_GRAD:
+//        case Intrepid2::OPERATOR_D1:
+//          // first derivatives of the above:
+//          expectedValues[0] = 0.0;                      // P_0 : 1
+//          expectedValues[1] = 1.0;                      // P_1 : x
+//          expectedValues[2] = 3.*x;                     // P_2 : (3x^2 - 1) / 2
+//          expectedValues[3] = (15.0*x*x-3.0)/2.0;       // P_3 : (5x^3 - 3x) / 2
+//          expectedValues[4] = (35.*x*x*x - 15.*x)/2.0;  // P_4 : (35x^4-30x^2+3) / 8
+//          break;
+//        case Intrepid2::OPERATOR_D2:
+//          // second derivatives:
+//          expectedValues[0] = 0.0;                 // P_0 : 1
+//          expectedValues[1] = 0.0;                 // P_1 : x
+//          expectedValues[2] = 3.0;                 // P_2 : (3x^2 - 1) / 2
+//          expectedValues[3] = 15.0*x;              // P_3 : (5x^3 - 3x) / 2
+//          expectedValues[4] = (105.*x*x - 15.)/2.; // P_4 : (35x^4-30x^2+3) / 8
+//          break;
+//        case Intrepid2::OPERATOR_D3:
+//          // third derivatives:
+//          expectedValues[0] = 0.0;           // P_0 : 1
+//          expectedValues[1] = 0.0;           // P_1 : x
+//          expectedValues[2] = 0.0;           // P_2 : (3x^2 - 1) / 2
+//          expectedValues[3] = 15.0;          // P_3 : (5x^3 - 3x) / 2
+//          expectedValues[4] = 105.*x;        // P_4 : (35x^4-30x^2+3) / 8
+//          break;
+//        case Intrepid2::OPERATOR_D4:
+//          // fourth derivatives:
+//          expectedValues[0] = 0.0;           // P_0 : 1
+//          expectedValues[1] = 0.0;           // P_1 : x
+//          expectedValues[2] = 0.0;           // P_2 : (3x^2 - 1) / 2
+//          expectedValues[3] = 0.0;           // P_3 : (5x^3 - 3x) / 2
+//          expectedValues[4] = 105.;          // P_4 : (35x^4-30x^2+3) / 8
+//          break;
+//        case Intrepid2::OPERATOR_D5:
+//        case Intrepid2::OPERATOR_D6:
+//        case Intrepid2::OPERATOR_D7:
+//        case Intrepid2::OPERATOR_D8:
+//        case Intrepid2::OPERATOR_D9:
+//        case Intrepid2::OPERATOR_D10:
+//          // nth (n≥5) derivatives are all 0:
+//          expectedValues[0] = 0.0;           // P_0 : 1
+//          expectedValues[1] = 0.0;           // P_1 : x
+//          expectedValues[2] = 0.0;           // P_2 : (3x^2 - 1) / 2
+//          expectedValues[3] = 0.0;           // P_3 : (5x^3 - 3x) / 2
+//          expectedValues[4] = 0.0;           // P_4 : (35x^4-30x^2+3) / 8
+//          break;
+        default:
+          INTREPID2_TEST_FOR_EXCEPTION(true, std::invalid_argument, "Unsupported operator");
+      }
+      
+      for (int fieldOrdinal=0; fieldOrdinal<hgradBasis->getCardinality(); fieldOrdinal++)
+      {
+        for (int d=0; d<hgradOutputViewHost.extent_int(2); d++)
+        {
+          OutputScalar actual    = hgradOutputViewHost.access(fieldOrdinal,pointOrdinal,d);
+          OutputScalar expected  = expectedValuesViewHost.access(fieldOrdinal,pointOrdinal,d);
+        
+          bool valuesMatch = true;
+          bool valuesAreBothSmall = valuesAreSmall(actual, expected, tol);
+          if (!valuesAreBothSmall)
+          {
+            TEUCHOS_TEST_FLOATING_EQUALITY(actual, expected, tol, out, valuesMatch);
+          }
+        
+          if (!valuesMatch)
+          {
+            pointPassed = false;
+            PointScalar x = inputPointsViewHost(pointOrdinal,0);
+            PointScalar y = inputPointsViewHost(pointOrdinal,1);
+            if (op == OPERATOR_VALUE) out << "values";
+            else
+            {
+              int derivativeOrder = getOperatorOrder(op);
+              if (derivativeOrder == 1)
+              {
+                out << "first ";
+              }
+              else if (derivativeOrder == 2)
+              {
+                out << "second ";
+              }
+              else if (derivativeOrder == 3)
+              {
+                out << "third ";
+              }
+              else
+              {
+                out << derivativeOrder << "th ";
+              }
+              out << "derivatives";
+            }
+            out << " for ("  << x << "," << y << ") differ for field ordinal " << fieldOrdinal;
+            out << ": expected " << expected << "; actual " << actual;
+            out << " (diff: " << expected-actual << ")" << std::endl;
+            success = false;
+          }
+        }
+      }
+      if (!pointPassed)
+      {
+        out << "point " << pointOrdinal << " failed.\n";
+      }
+    }
+  }
+  
   // compare derivatives of order derivativeOrder in H(grad) with derivatives of order (derivativeOrder-1) in H(vol)
   template<class LineBasisFamily>
   void testDerivativesMatch(int polyOrder, int derivativeOrder, const double tol, Teuchos::FancyOStream &out, bool &success)
@@ -460,8 +803,8 @@ namespace
     }
     else if (cellTopo.getKey() == shards::Hexahedron<>::key)
     {
-      derivedBasis  = getHexahedralBasis<DerivedNodalBasisFamily> (fs, polyOrder); // derived basis supports both isotropic and anisotropic polyOrder
-      standardBasis = getHexahedralBasis<StandardNodalBasisFamily>(fs, polyOrder); // isotropic
+      derivedBasis  = getHexahedronBasis<DerivedNodalBasisFamily> (fs, polyOrder); // derived basis supports both isotropic and anisotropic polyOrder
+      standardBasis = getHexahedronBasis<StandardNodalBasisFamily>(fs, polyOrder); // isotropic
     }
     
     int standardCardinality = standardBasis->getCardinality();
@@ -694,6 +1037,19 @@ namespace
     }
   }
   
+  TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL( AnalyticPolynomialsMatch, Hierarchical_HGRAD_TRI, OutputScalar, PointScalar )
+  {
+    const double tol = TEST_TOLERANCE_TIGHT;
+    using ExecSpace = Kokkos::DefaultExecutionSpace;
+    
+//    std::vector<Intrepid2::EOperator> operators = {{OPERATOR_VALUE, OPERATOR_GRAD, OPERATOR_D1, OPERATOR_D2, OPERATOR_D3, OPERATOR_D4, OPERATOR_D5, OPERATOR_D6, OPERATOR_D7, OPERATOR_D8, OPERATOR_D9, OPERATOR_D10}};
+    std::vector<Intrepid2::EOperator> operators = {OPERATOR_VALUE};
+    for (auto op : operators)
+    {
+      testHierarchicalHGRAD_TRIANGLE_MatchesAnalyticValues<ExecSpace,OutputScalar,PointScalar>(op, tol, out, success);
+    }
+  }
+  
   TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL( AnalyticPolynomialsMatch, Hierarchical_LineBasisDerivativesAgree, OutputScalar, PointScalar )
   {
     const int maxPolyOrder = 10;
@@ -741,7 +1097,7 @@ namespace
     runNodalBasisComparisonTests<DerivedNodalBasisFamily, StandardNodalBasisFamily>(polyOrder_2D, quadTopo, {FUNCTION_SPACE_HGRAD}, {OPERATOR_VALUE,OPERATOR_GRAD}, tol, out, success);
     runNodalBasisComparisonTests<DerivedNodalBasisFamily, StandardNodalBasisFamily>(polyOrder_2D, quadTopo, {FUNCTION_SPACE_HGRAD}, operators_dk, tol, out, success);
     
-    out << "Running 3D nodal hexahedral basis comparison tests…\n";
+    out << "Running 3D nodal hexahedron basis comparison tests…\n";
     runNodalBasisComparisonTests<DerivedNodalBasisFamily, StandardNodalBasisFamily>(polyOrder_3D, hexTopo, {FUNCTION_SPACE_HVOL}, {OPERATOR_VALUE}, tol, out, success);
     runNodalBasisComparisonTests<DerivedNodalBasisFamily, StandardNodalBasisFamily>(polyOrder_3D, hexTopo, {FUNCTION_SPACE_HGRAD}, {OPERATOR_VALUE,OPERATOR_GRAD}, tol, out, success);
     runNodalBasisComparisonTests<DerivedNodalBasisFamily, StandardNodalBasisFamily>(polyOrder_3D, hexTopo, {FUNCTION_SPACE_HGRAD}, operators_dk, tol, out, success);
@@ -749,5 +1105,6 @@ namespace
                                                         
   INTREPID2_OUTPUTSCALAR_POINTSCALAR_TEST_INSTANT( AnalyticPolynomialsMatch, Hierarchical_HGRAD_LINE )
   INTREPID2_OUTPUTSCALAR_POINTSCALAR_TEST_INSTANT( AnalyticPolynomialsMatch, Hierarchical_LineBasisDerivativesAgree )
+  INTREPID2_OUTPUTSCALAR_POINTSCALAR_TEST_INSTANT( AnalyticPolynomialsMatch, Hierarchical_HGRAD_TRI )
   INTREPID2_OUTPUTSCALAR_POINTSCALAR_TEST_INSTANT( AnalyticPolynomialsMatch, HierarchicalNodalComparisons )
 } // namespace


### PR DESCRIPTION
@trilinos/intrepid2 
Continuing the work implementing hierarchical bases, this PR adds support for H(grad) bases on triangles and tetrahedra. (These are the bases that EMPIRE expects to use for limiters soon.)

There are two types of tests included here:
1. Basis equivalence tests: these confirm that both the DG and CG variants of the bases are consistent with the existing nodal bases in Intrepid2.
2. Sub-basis inclusion tests: these confirm that the hierarchical bases do in fact nest.

In addition to those tests, an offline verification has been performed to confirm that this implementation agrees with the equivalent bases in ESEAS.

Addresses (but does not close) #6481.