### PR TITLE
Update TriBITS for updated gitdist-setup.sh script mostly

### DIFF
--- a/cmake/tribits/ci_support/cdash_build_testing_date.py
+++ b/cmake/tribits/ci_support/cdash_build_testing_date.py
@@ -46,7 +46,7 @@ import datetime
 #
 
 
-usageHelp = r"""cdash_testing_date.py --cdash-project-start-time="HH:MM" [other options]
+usageHelp = r"""cdash_testing_date.py --cdash-project-start-time="hh:mm" [other options]
 
 Returns to STDOUT the date string YYYY-MM-DD that corresponds the the matching
 CDash test day.  Is should be compatible with the 'date=YYYY-MM-DD' argument
@@ -74,7 +74,7 @@ def injectCmndLineOptionsInParser(clp, gitoliteRootDefault=""):
   
   clp.add_option(
     "--cdash-project-start-time", dest="cdashProjectStartTimeUtcStr", type="string", default="",
-    help="Starting time for the CDash testing day in 'hh:mmm' in UTC."\
+    help="Starting time for the CDash testing day in 'hh:mm' in UTC."\
       + " Check the CDash project settings for the testing day start time." )
   
   clp.add_option(
@@ -98,7 +98,7 @@ def getCmndLineOptions():
   (options, args) = clp.parse_args()
   if options.cdashProjectStartTimeUtcStr == "":
     raise Exception("Error, input argument --cdash-project-start-time must be non"\
-      +"-empty and must be of the format HH:MM UTC")
+      +"-empty and must be of the format hh:mm UTC")
   return options
 
 

--- a/cmake/tribits/python_utils/GeneralScriptSupport.py
+++ b/cmake/tribits/python_utils/GeneralScriptSupport.py
@@ -439,13 +439,14 @@ def runSysCmndInterface(cmnd, outFile=None, rtnOutput=False, extraEnv=None, \
 
 
 def runSysCmnd(cmnd, throwExcept=True, outFile=None, workingDir="",
-  extraEnv=None \
+  extraEnv=None, echoCmndForDebugging=False \
   ):
   """Run system command and optionally throw on failure"""
   sys.stdout.flush()
   sys.stderr.flush()
   try:
     outFileHandle = None
+    if echoCmndForDebugging: print("Running: "+cmnd)
     rtnCode = runSysCmndInterface(cmnd, outFile=outFile, extraEnv=extraEnv,
       workingDir=workingDir)
   except OSError as e:

--- a/cmake/tribits/python_utils/GenerateDocUtilsOutput.py
+++ b/cmake/tribits/python_utils/GenerateDocUtilsOutput.py
@@ -25,11 +25,15 @@ def setGeneratedFilePermissions(filePath):
   os.chmod(filePath, stat.S_IREAD | stat.S_IRGRP | stat.S_IROTH)
 
 
-def generateFile(filePath, generateCmnd, outFile=None, workingDir="", runTwice=False):
+def generateFile(filePath, generateCmnd, outFile=None, workingDir="",
+  runTwice=False, echoCmnds=False \
+  ):
   openWriteFilePermissions(filePath)
-  runSysCmnd(generateCmnd, outFile=outFile, workingDir=workingDir)
+  runSysCmnd(generateCmnd, outFile=outFile, workingDir=workingDir,
+    echoCmndForDebugging=echoCmnds)
   if runTwice:
-    runSysCmnd(generateCmnd, outFile=outFile, workingDir=workingDir)
+    runSysCmnd(generateCmnd, outFile=outFile, workingDir=workingDir,
+       echoCmndForDebugging=echoCmnds)
   setGeneratedFilePermissions(filePath)
 
 
@@ -82,6 +86,14 @@ def addCmndLineOptions(clp):
     help="Do not delete temporary files.",
     default=True )
 
+  clp.add_option(
+    "--echo-cmnds", dest="echoCmnds", action="store_true",
+    help="Echo the commands being run to STDOUT." )
+  clp.add_option(
+    "--no-echo-cmnds", dest="echoCmnds", action="store_false",
+    help="Do not echo the commands being run.",
+    default=False )
+
 
 def generateDocutilsOuputFiles(options):
 
@@ -98,21 +110,21 @@ def generateDocutilsOuputFiles(options):
     print("Generating " + outputFileBaseName + ".html ...")
     outputHtmlFile = outputFileBase+".html"
     generateFile(outputHtmlFile,
-      options.generateHtml+" "+rstFile+" "+outputHtmlFile)
+      options.generateHtml+" "+rstFile+" "+outputHtmlFile, echoCmnds=options.echoCmnds)
   
   if options.generateLatex:
     print("Generating " + outputFileBaseName + ".tex ...")
     outputLatexFile = outputFileBase+".tex"
     runSysCmnd(options.generateLatex+" "+options.generateLatexOptions+ \
-       " "+rstFile+" "+outputLatexFile)
+       " "+rstFile+" "+outputLatexFile, echoCmndForDebugging=options.echoCmnds)
     if options.generatePDF:
       print("Generating " + outputFileBaseName + ".pdf ...")
       outputPdfFile = outputFileBase+".pdf"
       outputPdfFileLog = outputLatexFile+".log"
       generateFile(outputPdfFile,
-        options.generatePDF+" "+outputLatexFile,
+        options.generatePDF+" -halt-on-error "+outputLatexFile,
         outFile=outputPdfFileLog,
-        runTwice=True)
+        runTwice=True, echoCmnds=options.echoCmnds)
       filesToClean.append(outputPdfFileLog)
   
   #

--- a/cmake/tribits/python_utils/gitdist-setup.sh
+++ b/cmake/tribits/python_utils/gitdist-setup.sh
@@ -19,10 +19,32 @@ fi
 alias gitdist-status="gitdist dist-repo-status"
 alias gitdist-mod="gitdist --dist-mod-only"
 alias gitdist-mod-status="gitdist --dist-mod-only dist-repo-status"
+
 function gitdist-repo-versions {
   gitdist "$@" --dist-no-color log -1 --pretty=format:"%h [%ad] <%ae>%n%s" | grep -v "^$"
 }
+export -f gitdist-repo-versions
 
-# Setup for completions for git command and gitdist options commands!
-complete -o default -o nospace -F _git -W "dist-repo-status --dist-help --dist-use-git --dist-repos --dist-not-repos --dist-version-file --dist-version-file2 --dist-no-color --dist-debug --dist-no-opt --dist-mod-only --dist-legend" gitdist gitdist-mod
-complete -o default -o nospace -W "--dist-use-git --dist-repos --dist-not-repos --dist-no-color --dist-debug --dist-no-opt --dist-mod-only" gitdist-repo-versions
+function gitdist-show-full-repo-state {
+  echo
+  echo "Repo versions:"
+  echo
+  gitdist-repo-versions "$@"
+  echo
+  echo "Repo branch status:"
+  echo
+  gitdist-status "$@" | grep -v "^$" | grep -v "(tip: to see a legend"
+  echo
+  echo "Repo remotes:"
+  echo
+  gitdist --dist-no-color "$@" remote -v | grep "\(Git Repo\|push\)"
+}
+export -f gitdist-show-full-repo-state
+
+# Setup for completions for git command and gitdist options commands
+complete -o default -o nospace -F _git \
+   -W "dist-repo-status --dist-help --dist-use-git --dist-repos --dist-not-repos --dist-version-file --dist-version-file2 --dist-no-color --dist-debug --dist-no-opt --dist-mod-only --dist-legend" \
+   gitdist gitdist-mod
+complete -o default -o nospace \
+   -W "--dist-use-git --dist-repos --dist-not-repos --dist-no-color --dist-debug --dist-no-opt --dist-mod-only" \
+   gitdist-repo-versions gitdist-show-full-repo-state


### PR DESCRIPTION
Mostly updating to provide a nice gitdist-show-full-repo-state function that can be used to give the status of a set of git repos in one shot.

This will be useful in testing Trilinos against SPARC and EMPIRE as part of the epic [ATDV-240](https://sems-atlassian-srn.sandia.gov/browse/ATDV-240).

