### PR TITLE
Zoltan2: Fixes for #6440

### DIFF
--- a/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
+++ b/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
@@ -59,6 +59,7 @@
 #include <Tpetra_Distributor.hpp>
 #include <Teuchos_StandardParameterEntryValidators.hpp>
 #include <Teuchos_ParameterList.hpp>
+#include <Kokkos_Sort.hpp>
 
 #include <algorithm>    // std::sort
 #include <vector>
@@ -4828,6 +4829,12 @@ mj_create_new_partitions(
   }
   delete [] reduce_array;
 #endif
+
+  // the last member is utility used for atomically inserting the values.
+  // Sorting here avoids potential indeterminancy in the partitioning results
+  auto track_on_cuts_sort = Kokkos::subview(track_on_cuts,
+    std::pair<mj_lno_t, mj_lno_t>(0, track_on_cuts.size() - 1));
+  Kokkos::sort(track_on_cuts_sort);
 
   bool uniform_weights0 = this->mj_uniform_weights(0);
   Kokkos::parallel_for(

--- a/packages/zoltan2/test/helpers/GeometricGenerator.hpp
+++ b/packages/zoltan2/test/helpers/GeometricGenerator.hpp
@@ -693,25 +693,15 @@ public:
   virtual ~CoordinateNormalDistribution(){};
 private:
   T normalDist(T center_, T sd, unsigned int &state) {
-    static bool derived=false;
-    static T storedDerivation;
     T polarsqrt, normalsquared, normal1, normal2;
-    if (!derived) {
-      do {
-        normal1=2.0*( T(rand_r(&state))/T(RAND_MAX) ) - 1.0;
-        normal2=2.0*( T(rand_r(&state))/T(RAND_MAX) ) - 1.0;
-        normalsquared=normal1*normal1+normal2*normal2;
-      } while ( normalsquared>=1.0 || normalsquared == 0.0);
+    do {
+      normal1=2.0*( T(rand_r(&state))/T(RAND_MAX) ) - 1.0;
+      normal2=2.0*( T(rand_r(&state))/T(RAND_MAX) ) - 1.0;
+      normalsquared=normal1*normal1+normal2*normal2;
+    } while ( normalsquared>=1.0 || normalsquared == 0.0);
 
-      polarsqrt=sqrt(-2.0*log(normalsquared)/normalsquared);
-      storedDerivation=normal1*polarsqrt;
-      derived=true;
-      return normal2*polarsqrt*sd + center_;
-    }
-    else {
-      derived=false;
-      return storedDerivation*sd + center_;
-    }
+    polarsqrt=sqrt(-2.0*log(normalsquared)/normalsquared);
+    return normal2*polarsqrt*sd + center_;
   }
 };
 


### PR DESCRIPTION
This will resolve indeterminate behavior in the Multijagged calculation.
This is expected to resolve most of the cases where 6440 failed. However in one case, cdash showed a segfault and it's not clear yet why that would occur or if it would be impacted by this fix. This will at least get the test running in a consistent manner.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/zoltan2

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Eliminates indeterminate behavior. Will fix most but perhaps not all intermittent failures reported in #6440.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->