### PR TITLE
ATDM: Add cee-rhel6 openmpi-4.0.1 builds (ATDV-237)

### DIFF
--- a/cmake/ctest/drivers/atdm/cee-rhel6/drivers/Trilinos-atdm-cee-rhel6_clang-5.0.1_openmpi-4.0.1_serial_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/cee-rhel6/drivers/Trilinos-atdm-cee-rhel6_clang-5.0.1_openmpi-4.0.1_serial_static_opt.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+if [ "${Trilinos_TRACK}" == "" ]; then
+  export Trilinos_TRACK=Specialized
+fi
+$WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cee-rhel6/local-driver.sh

--- a/cmake/ctest/drivers/atdm/cee-rhel6/drivers/Trilinos-atdm-cee-rhel6_gnu-7.2.0_openmpi-4.0.1_serial_shared_opt.sh
+++ b/cmake/ctest/drivers/atdm/cee-rhel6/drivers/Trilinos-atdm-cee-rhel6_gnu-7.2.0_openmpi-4.0.1_serial_shared_opt.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+if [ "${Trilinos_TRACK}" == "" ]; then
+  export Trilinos_TRACK=Specialized
+fi
+$WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cee-rhel6/local-driver.sh

--- a/cmake/std/atdm/cee-rhel6/all_supported_builds.sh
+++ b/cmake/std/atdm/cee-rhel6/all_supported_builds.sh
@@ -3,8 +3,10 @@
 export ATDM_CONFIG_CTEST_S_BUILD_NAME_PREFIX=Trilinos-atdm-
 
 export ATDM_CONFIG_ALL_SUPPORTED_BUILDS=(
-  cee-rhel6_clang-5.0.1_openmpi-1.10.2_serial_static_opt   # SPARC CI build
+  cee-rhel6_clang-5.0.1_openmpi-1.10.2_serial_static_opt
+  cee-rhel6_clang-5.0.1_openmpi-4.0.1_serial_static_opt    # SPARC CI build
   cee-rhel6_gnu-7.2.0_openmpi-1.10.2_serial_shared_opt     # SPARC CI build
+  cee-rhel6_gnu-7.2.0_openmpi-4.0.1_serial_shared_opt      # SPARC CI build
   cee-rhel6_intel-18.0.2_mpich2-3.2_openmp_static_opt      # SPARC CI build
   cee-rhel6_intel-19.0.3_intelmpi-2018.4_serial_static_opt # SPARC Nightly bulid
   )

--- a/cmake/std/atdm/cee-rhel6/custom_builds.sh
+++ b/cmake/std/atdm/cee-rhel6/custom_builds.sh
@@ -6,13 +6,25 @@
 #
 
 # Custom compiler selection logic
-if   [[ $ATDM_CONFIG_BUILD_NAME == *"clang-5.0.1-openmpi-1.10.2"* ]] \
+
+if [[ $ATDM_CONFIG_BUILD_NAME == *"clang-5.0.1-openmpi-4.0.1"* ]] \
+  || [[ $ATDM_CONFIG_BUILD_NAME == *"clang-5.0.1_openmpi-4.0.1"* ]] \
+  ; then
+  export ATDM_CONFIG_COMPILER=CLANG-5.0.1_OPENMPI-4.0.1
+
+elif [[ $ATDM_CONFIG_BUILD_NAME == *"clang-5.0.1-openmpi-1.10.2"* ]] \
   || [[ $ATDM_CONFIG_BUILD_NAME == *"clang-5.0.1_openmpi-1.10.2"* ]] \
   || [[ $ATDM_CONFIG_BUILD_NAME == *"clang-5.0.1"* ]] \
   || [[ $ATDM_CONFIG_BUILD_NAME == *"clang"* ]] \
   || [[ $ATDM_CONFIG_BUILD_NAME == *"default" ]] \
   ; then
   export ATDM_CONFIG_COMPILER=CLANG-5.0.1_OPENMPI-1.10.2
+  # Must list the default clang build last for correct matching of of defaults
+
+elif [[ $ATDM_CONFIG_BUILD_NAME == *"gnu-7.2.0-openmpi-4.0.1"* ]] \
+  || [[ $ATDM_CONFIG_BUILD_NAME == *"gnu-7.2.0_openmpi-4.0.1"* ]] \
+  ; then
+  export ATDM_CONFIG_COMPILER=GNU-7.2.0_OPENMPI-4.0.1
 
 elif [[ $ATDM_CONFIG_BUILD_NAME == *"gnu-7.2.0-openmpi-1.10.2"* ]] \
   || [[ $ATDM_CONFIG_BUILD_NAME == *"gnu-7.2.0_openmpi-1.10.2"* ]] \
@@ -20,7 +32,7 @@ elif [[ $ATDM_CONFIG_BUILD_NAME == *"gnu-7.2.0-openmpi-1.10.2"* ]] \
   || [[ $ATDM_CONFIG_BUILD_NAME == *"gnu"* ]] \
   ; then
   export ATDM_CONFIG_COMPILER=GNU-7.2.0_OPENMPI-1.10.2
-  # List default "gnu"* build last for correct matching!
+  # List default "gnu"* build last for correct matching of defaults
 
 elif [[ $ATDM_CONFIG_BUILD_NAME == *"intel-18.0.2-mpich2-3.2"* ]] \
   || [[ $ATDM_CONFIG_BUILD_NAME == *"intel-18.0.2_mpich2-3.2"* ]] \
@@ -46,7 +58,9 @@ else
   echo "*** Supported compilers include:"
   echo "***"
   echo "****  clang-5.0.1-openmpi-1.10.2   (default)"
+  echo "****  clang-5.0.1-openmpi-4.0.1"
   echo "****  gnu-7.2.0-openmpi-1.10.2     (default gnu)"
+  echo "****  gnu-7.2.0-openmpi-4.0.1"
   echo "****  intel-18.0.2-mpich2-3.2"
   echo "****  intel-19.0.3-intelmpi-2018.4 (default intel)"
   echo "***"  

--- a/cmake/std/atdm/cee-rhel6/environment.sh
+++ b/cmake/std/atdm/cee-rhel6/environment.sh
@@ -75,8 +75,40 @@ if [[ "$ATDM_CONFIG_COMPILER" == "CLANG-5.0.1_OPENMPI-1.10.2" ]]; then
   fi
   export ATDM_CONFIG_MKL_ROOT=${CBLAS_ROOT}
 
+elif [[ "$ATDM_CONFIG_COMPILER" == "CLANG-5.0.1_OPENMPI-4.0.1" ]]; then
+  module load sparc-dev/clang-5.0.1_openmpi-4.0.1
+  export OMPI_CXX=`which clang++`
+  export OMPI_CC=`which clang`
+  export OMPI_FC=`which gfortran`
+  export MPICC=`which mpicc`
+  export MPICXX=`which mpicxx`
+  export MPIF90=`which mpif90`
+  if [[ "$ATDM_CONFIG_ENABLE_STRONG_WARNINGS" == "1" ]]; then
+    export ATDM_CONFIG_CXX_FLAGS="${ATDM_CONFIG_GNU_CXX_WARNINGS}"
+  fi
+  export ATDM_CONFIG_MKL_ROOT=${CBLAS_ROOT}
+
 elif [[ "$ATDM_CONFIG_COMPILER" == "GNU-7.2.0_OPENMPI-1.10.2" ]] ; then
   module load sparc-dev/gcc-7.2.0_openmpi-1.10.2
+  unset OMP_NUM_THREADS  # SPARC module sets these and we must unset!
+  unset OMP_PROC_BIND
+  unset OMP_PLACES
+  export OMPI_CXX=`which g++`
+  export OMPI_CC=`which gcc`
+  export OMPI_FC=`which gfortran`
+  export MPICC=`which mpicc`
+  export MPICXX=`which mpicxx`
+  export MPIF90=`which mpif90`
+  if [[ "$ATDM_CONFIG_ENABLE_STRONG_WARNINGS" == "1" ]]; then
+    export ATDM_CONFIG_CXX_FLAGS="${ATDM_CONFIG_GNU_CXX_WARNINGS}"
+  fi
+  export ATDM_CONFIG_MKL_ROOT=${CBLAS_ROOT}
+  export ATDM_CONFIG_MPI_EXEC=mpirun
+  export ATDM_CONFIG_MPI_EXEC_NUMPROCS_FLAG=-np
+  export ATDM_CONFIG_MPI_PRE_FLAGS="--bind-to;none"
+
+elif [[ "$ATDM_CONFIG_COMPILER" == "GNU-7.2.0_OPENMPI-4.0.1" ]] ; then
+  module load sparc-dev/gcc-7.2.0_openmpi-4.0.1
   unset OMP_NUM_THREADS  # SPARC module sets these and we must unset!
   unset OMP_PROC_BIND
   unset OMP_PLACES

--- a/cmake/std/atdm/ctest-s-local-test-driver.sh
+++ b/cmake/std/atdm/ctest-s-local-test-driver.sh
@@ -110,6 +110,59 @@ if [[ "$@" == "-h" ]] ||  [[ "$@" == "--help" ]]; then
   exit 0
 fi
 
+
+#
+# Functions
+#
+
+function atdm_ctest_s_get_build_name {
+  build_name_body=$1
+  if [[ "${ATDM_CTEST_S_USE_FULL_BUILD_NAME}" == "1" ]] ; then
+    build_name="${build_name_body}"
+  else
+    build_name="${ATDM_CONFIG_CTEST_S_BUILD_NAME_PREFIX}${build_name_body}"
+  fi
+  echo ${build_name}
+}
+
+
+function atdm_ctest_s_assert_driver_script_exists {
+  build_name_body=$1
+  build_name=$(atdm_ctest_s_get_build_name ${build_name_body})
+  driver_script="${ATDM_TRILINOS_DIR}/cmake/ctest/drivers/atdm/${ATDM_CONFIG_SYSTEM_NAME}/drivers/${build_name}.sh"
+  if [[ ! -e "${driver_script}" ]]; then
+    echo
+    echo "***"
+    echo "*** ERROR: The driver script:"
+    echo "***"
+    echo "***   ${driver_script}"
+    echo "***"
+    echo "*** for the specified build:"
+    echo "***"
+    echo "***   ${build_name_body}"
+    echo "***"
+    echo "*** does not exist!"
+    echo "***"
+    return 1
+  fi
+  return 0
+}
+
+
+function atdm_ctest_s_assert_driver_scripts_exist {
+  all_driver_scripts_exist=1
+  for build_name in ${ATDM_ARRAY_OF_BUILDS[@]} ; do
+    atdm_ctest_s_assert_driver_script_exists ${build_name} \
+      || all_driver_scripts_exist=0
+  done
+  if [[ "${all_driver_scripts_exist}" != "1" ]]; then
+    echo
+    echo "Aborting the script and not running any builds!"
+    exit 1
+  fi
+}
+
+
 #
 # Sound off
 #
@@ -161,7 +214,7 @@ source $STD_ATDM_DIR/load-env.sh ${ATDM_CTEST_S_DEFAULT_ENV}
 
 #
 # Get the list of builds to run
-# 
+#
 
 # Must get ATDM_CONFIG_CTEST_S_BUILD_NAME_PREFIX
 source $STD_ATDM_DIR/$ATDM_CONFIG_SYSTEM_NAME/all_supported_builds.sh
@@ -172,11 +225,7 @@ if [[ "$@" == "" ]] ; then
   echo "Error, must provide 'all' or a list of supported build names which include:"
   echo
   for build_name_body in ${ATDM_CONFIG_ALL_SUPPORTED_BUILDS[@]} ; do
-    if [[ "${ATDM_CTEST_S_USE_FULL_BUILD_NAME}" == "1" ]] ; then
-      build_name="${ATDM_CONFIG_CTEST_S_BUILD_NAME_PREFIX}${build_name_body}"
-    else
-      build_name="${build_name_body}"
-    fi
+    build_name=$(atdm_ctest_s_get_build_name ${build_name_body})
     echo "    ${build_name}"
   done
   echo
@@ -195,6 +244,8 @@ for build_name in ${ATDM_ARRAY_OF_BUILDS[@]} ; do
   echo "    ${build_name}"
 done
 
+atdm_ctest_s_assert_driver_scripts_exist
+
 #
 # Run the builds using the ctest -S driver script
 #
@@ -205,11 +256,7 @@ ln -sf ${ATDM_TRILINOS_DIR} .
 
 for build_name_body in ${ATDM_ARRAY_OF_BUILDS[@]} ; do
 
-  if [[ "${ATDM_CTEST_S_USE_FULL_BUILD_NAME}" == "1" ]] ; then
-    build_name="${build_name_body}"
-  else
-    build_name="${ATDM_CONFIG_CTEST_S_BUILD_NAME_PREFIX}${build_name_body}"
-  fi
+  build_name=$(atdm_ctest_s_get_build_name ${build_name_body})
 
   echo
   echo "Running Jenkins driver ${build_name}.sh ..."

--- a/cmake/std/atdm/ctest-s-local-test-driver.sh
+++ b/cmake/std/atdm/ctest-s-local-test-driver.sh
@@ -259,6 +259,8 @@ for build_name_body in ${ATDM_ARRAY_OF_BUILDS[@]} ; do
   build_name=$(atdm_ctest_s_get_build_name ${build_name_body})
 
   echo
+  date
+  echo
   echo "Running Jenkins driver ${build_name}.sh ..."
 
   # Set up the directory for this build case
@@ -298,6 +300,14 @@ for build_name_body in ${ATDM_ARRAY_OF_BUILDS[@]} ; do
   ${ATDM_TRILINOS_DIR}/cmake/ctest/drivers/atdm/smart-jenkins-driver.sh \
     &> smart-jenkins-driver.out
 
+  echo
+  grep "failed out of" smart-jenkins-driver.out
+
   cd ${BASEDIR}
 
 done
+
+echo
+date
+echo
+echo "Done running all of the builds!"


### PR DESCRIPTION
This adds the ATDM Trilinos builds:

*   cee-rhel6_clang-5.0.1_openmpi-4.0.1_serial_static_opt
*  cee-rhel6_gnu-7.2.0_openmpi-4.0.1_serial_shared_opt

See [ATDV-237](https://sems-atlassian-srn.sandia.gov/browse/ATDV-237).

SPARC switched these builds form openmpi-1.10.2 to openmpi-4.0.1 many weeks ago and this change is needed to support SPARC, obviously.

## How was this tested?

On the machine 'ceerws1113' I ran:

```
$ env Trilinos_PACKAGES=Kokkos,Teuchos,Tpetra,Amesos2,SEACAS,Panzer \
  ./ctest-s-local-test-driver-cee-rhel6.sh \
    cee-rhel6_clang-5.0.1_openmpi-4.0.1_serial_static_opt \
    cee-rhel6_gnu-7.2.0_openmpi-4.0.1_serial_shared_opt

***
*** /scratch/rabartl/Trilinos.base/Trilinos/cmake/std/atdm/ctest-s-local-test-driver.sh
***

ATDM_TRILINOS_DIR = '/scratch/rabartl/Trilinos.base/Trilinos'

Load some env to get python, cmake, etc ...

Hostname 'ceerws1113' matches known ATDM host 'cee-rhel6' and system 'cee-rhel6'
Setting compiler and build options for build-name 'cee-rhel6-default'
Using CEE RHEL6 compiler stack CLANG-5.0.1_OPENMPI-1.10.2 to build DEBUG code with Kokkos node type SERIAL

Running builds:
    cee-rhel6_clang-5.0.1_openmpi-4.0.1_serial_static_opt
    cee-rhel6_gnu-7.2.0_openmpi-4.0.1_serial_shared_opt

Sat Jan  4 15:28:24 MST 2020

Running Jenkins driver Trilinos-atdm-cee-rhel6_clang-5.0.1_openmpi-4.0.1_serial_static_opt.sh ...

    See log file Trilinos-atdm-cee-rhel6_clang-5.0.1_openmpi-4.0.1_serial_static_opt/smart-jenkins-driver.out

real    39m23.820s
user    355m34.824s
sys     21m44.964s

99% tests passed, 2 tests failed out of 613

Sat Jan  4 16:07:47 MST 2020

Running Jenkins driver Trilinos-atdm-cee-rhel6_gnu-7.2.0_openmpi-4.0.1_serial_shared_opt.sh ...

    See log file Trilinos-atdm-cee-rhel6_gnu-7.2.0_openmpi-4.0.1_serial_shared_opt/smart-jenkins-driver.out

real    28m56.523s
user    329m9.626s
sys     35m52.631s

100% tests passed, 0 tests failed out of 615

Sat Jan  4 16:36:44 MST 2020

Done running all of the builds!
```

That posted to:

* [Trilinos-atdm-cee-rhel6_clang-5.0.1_openmpi-4.0.1_serial_static_opt-exp](https://testing-dev.sandia.gov/cdash/index.php?project=Trilinos&parentid=5135604) (passed=611, failed=2)
* [Trilinos-atdm-cee-rhel6_gnu-7.2.0_openmpi-4.0.1_serial_shared_opt-exp](https://testing-dev.sandia.gov/cdash/index.php?project=Trilinos&parentid=5135611) (passed=615)

The failing tests in the build cee-rhel6_clang-5.0.1_openmpi-4.0.1_serial_static_opt were:

```
99% tests passed, 2 tests failed out of 613

Subproject Time Summary:
Amesos2    =   7.35 sec*proc (8 tests)
Kokkos     = 150.16 sec*proc (24 tests)
Panzer     = 1805.34 sec*proc (171 tests)
SEACAS     = 177.87 sec*proc (51 tests)
Teuchos    = 4920.20 sec*proc (138 tests)
Tpetra     = 200.81 sec*proc (221 tests)

Total Test time (real) = 918.06 sec

The following tests FAILED:
	 49 - TeuchosCore_testTeuchosTestForTermination_2_MPI_4 (Timeout)
	 50 - TeuchosCore_testTeuchosTestForTermination_3_MPI_4 (Timeout)
```

These are starting out as Specialized builds so I think this is good enough testing for that.
