### PR TITLE
ATDM: cts1: Eliminate usage of 'sparc' and old 'atdv' modules (ATDV-212)

### DIFF
--- a/cmake/std/atdm/common/toss3/environment_new.sh
+++ b/cmake/std/atdm/common/toss3/environment_new.sh
@@ -21,9 +21,8 @@ module purge &> /dev/null
 module purge
 . /projects/sems/modulefiles/utils/sems-modules-init.sh
 module load sems-env
-module load atdm-env
-module load atdm-ninja_fortran/1.7.2
-module load sparc-git/2.19.1
+module load sems-ninja_fortran/1.8.2
+module load sems-git/2.10.1
 
 if [ "$ATDM_CONFIG_NODE_TYPE" == "OPENMP" ] ; then
   export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=8


### PR DESCRIPTION
EMPIRE developers can't load 'sparc' modules.  Therefore, we replace
'sparc-git/2.19.1' with 'sems-git/2.10.1' which should be good enough.

Also, I replaced atdm-ninja_fortran/1.7.2 with sems-ninja_fortran/1.8.2 which
is newer and eliminates usage of the old 'atdv-env' modules (which will be
replaced by Spack modules when I get a chance).

## How was this tested?

On eclipse I did:

```
$ /nscratch/rabartl/Trilinos.base/BUILDS/CTS1/CTEST_S/

$  env Trilinos_PACKAGES=Kokkos,Teuchos \
    ./ctest-s-local-test-driver-cts1.sh \
       cts1-intel-19.0.5_openmpi-4.0.1_openmp_static_opt

***
*** /home/rabartl/Trilinos.base/Trilinos/cmake/std/atdm/ctest-s-local-test-driver.sh
***

ATDM_TRILINOS_DIR = '/home/rabartl/Trilinos.base/Trilinos'

Load some env to get python, cmake, etc ...

Hostname 'eclipse-login8' matches known ATDM host 'eclipse' and system 'cts1'
Setting compiler and build options for build-name 'cts1-default'
Using cts1 toss3 compiler stack INTEL-18.0.2_OPENMPI-2.0.3 to build DEBUG code with Kokkos node type SERIAL

Running builds:
    cts1-intel-19.0.5_openmpi-4.0.1_openmp_static_opt

Mon Jan  6 11:28:57 MST 2020

Running Jenkins driver Trilinos-atdm-cts1-intel-19.0.5_openmpi-4.0.1_openmp_static_opt.sh ...

    See log file Trilinos-atdm-cts1-intel-19.0.5_openmpi-4.0.1_openmp_static_opt/smart-jenkins-driver.out

real    18m9.391s
user    65m40.057s
sys     6m30.702s

100% tests passed, 0 tests failed out of 165

Mon Jan  6 11:47:06 MST 2020

Done running all of the builds!
```

That posted to:

* [Trilinos-atdm-cts1-intel-19.0.5_openmpi-4.0.1_openmp_static_opt-exp](https://testing-dev.sandia.gov/cdash/index.php?project=Trilinos&parentid=5140712)

and [configure output](https://testing-dev.sandia.gov/cdash/viewConfigure.php?buildid=5140714) showed:

```
...
-- CMAKE_VERSION='3.12.2'
...
-- Found Git: /projects/sems/install/toss3/sems/utility/git/2.10.1/bin/git (found version "2.10.1") 
```

and the [CMakeCache.clean.txt](https://testing-dev.sandia.gov/cdash/viewNotes.php?buildid=5140712#!#note0) file showed:

```
...
GITCOMMAND:FILEPATH=/projects/sems/install/toss3/sems/utility/git/2.10.1/bin/git
GIT_EXECUTABLE:FILEPATH=/projects/sems/install/toss3/sems/utility/git/2.10.1/bin/git
...
CMAKE_MAKE_PROGRAM:FILEPATH=/projects/sems/install/toss3/sems/utility/ninja_fortran/1.8.2/bin/ninja
...
Trilinos_GENERATE_VERSION_DATE_FILES:BOOL=ON
...
```

So that should still be generating and installing the correct Trilinos_version_date.h file.




