### PR TITLE
Promote new cee-rhel6 openmpi-4.0.1 builds to ATDM group (ATDV-237)

### DIFF
--- a/cmake/ctest/drivers/atdm/cee-rhel6/drivers/Trilinos-atdm-cee-rhel6_clang-5.0.1_openmpi-4.0.1_serial_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/cee-rhel6/drivers/Trilinos-atdm-cee-rhel6_clang-5.0.1_openmpi-4.0.1_serial_static_opt.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 if [ "${Trilinos_TRACK}" == "" ]; then
-  export Trilinos_TRACK=Specialized
+  export Trilinos_TRACK=ATDM
 fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cee-rhel6/local-driver.sh

--- a/cmake/ctest/drivers/atdm/cee-rhel6/drivers/Trilinos-atdm-cee-rhel6_gnu-7.2.0_openmpi-4.0.1_serial_shared_opt.sh
+++ b/cmake/ctest/drivers/atdm/cee-rhel6/drivers/Trilinos-atdm-cee-rhel6_gnu-7.2.0_openmpi-4.0.1_serial_shared_opt.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 if [ "${Trilinos_TRACK}" == "" ]; then
-  export Trilinos_TRACK=Specialized
+  export Trilinos_TRACK=ATDM
 fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cee-rhel6/local-driver.sh


### PR DESCRIPTION
I triaged the one randomly failing test in #6532.  I think it is appropriate to promote these builds given the other builds in the ATDM group are not 100% clean (and no one seems to care that much).

SPARC is using these builds in production so they need to be promoted.
