### PR TITLE
Intrepid2: Allow using Kokkos with deprecated code

### DIFF
--- a/packages/intrepid2/src/Shared/Intrepid2_Kernels.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_Kernels.hpp
@@ -310,7 +310,7 @@ namespace Intrepid2 {
           const ordinal_type m = dst.extent(0), n = dst.extent(1);
           for (ordinal_type i=0;i<m;++i) 
             for (ordinal_type j=0;j<n;++j) 
-              dst(i,j) = src(i,j);
+              dst.access(i,j) = src.access(i,j);
         }
       }
 


### PR DESCRIPTION
@trilinos/intrepid2

## Motivation
Using `Intrepid2::Impl::CellTools::Serial::mapToReferenceFrame()` when `Kokkos` has deprecated code disabled fails. That functions calls `Intrepid2::Kernels::Serial::copy()` with a rank-1 `Kokkos::View` object which assumes a rank-2 `Kokkos::View` object. However, accessing entries in `Kokkos::View` objects via the call operator is only allowed for matching ranks. It seems that this function is only used in  `Intrepid2::Impl::CellTools::Serial::mapToReferenceFrame()`. Hence, it seems like modifying the copy function to take a rank-1 `Kokkos::View` looks like another possible solution.

## Testing
The change relaxes the constraints on using `Intrepid2::Kernels::Serial::copy()`. Hence, there should be no noticeable change.