### PR TITLE
Panzer: Adding domain EXTERNAL to DomainEvaluator 

### DIFF
--- a/packages/panzer/adapters-stk/test/evaluator_tests/domain_interface.cpp
+++ b/packages/panzer/adapters-stk/test/evaluator_tests/domain_interface.cpp
@@ -152,6 +152,10 @@ TEUCHOS_UNIT_TEST(domain_interface, base)
     e.setExpectedIndices(12,20);
     e.evaluateFields(workset);
 
+    e.setDomain(DomainEvaluator::EXTERNAL);
+    e.setExpectedIndices(8,20);
+    e.evaluateFields(workset);
+
     e.setDomain(DomainEvaluator::ALL);
     e.setExpectedIndices(0,20);
     e.evaluateFields(workset);
@@ -172,6 +176,10 @@ TEUCHOS_UNIT_TEST(domain_interface, base)
 
     e.setDomain(DomainEvaluator::VIRTUAL);
     e.setExpectedIndices(8,14);
+    e.evaluateFields(workset);
+
+    e.setDomain(DomainEvaluator::EXTERNAL);
+    e.setExpectedIndices(4,14);
     e.evaluateFields(workset);
 
     e.setDomain(DomainEvaluator::ALL);

--- a/packages/panzer/disc-fe/src/Panzer_Evaluator_DomainInterface.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_Evaluator_DomainInterface.cpp
@@ -24,6 +24,8 @@ namespace panzer {
       return 0;
     else if (domain_ == VIRTUAL)
       return workset.numOwnedCells() + workset.numGhostCells();
+    else if (domain_ == EXTERNAL)
+      return workset.numOwnedCells();
     else {
       TEUCHOS_ASSERT(false);
     }
@@ -40,6 +42,8 @@ namespace panzer {
     else if (domain_ == REAL)
       return workset.numOwnedCells() + workset.numGhostCells();
     else if (domain_ == VIRTUAL)
+      return workset.num_cells;
+    else if(domain_ == EXTERNAL)
       return workset.num_cells;
     else {
       TEUCHOS_ASSERT(false);

--- a/packages/panzer/disc-fe/src/Panzer_Evaluator_DomainInterface.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_Evaluator_DomainInterface.hpp
@@ -19,7 +19,8 @@ namespace panzer {
         GHOST=1,    /// All Ghosted cells for the workset on the MPI process
         REAL=2,     /// All Owned and Ghosted cells for the workset on the MPI process
         VIRTUAL=3,  /// All virtual cells for the workset on the MPI process
-        ALL=4       /// All OWNED, GHOSTED and VIRTUAL cells for the workset on the MPI process
+        EXTERNAL=4, /// All ghost and virtual cells for the workset on the MPI process
+        ALL=5       /// All OWNED, GHOSTED and VIRTUAL cells for the workset on the MPI process
         };
 
     /**


### PR DESCRIPTION

@trilinos/panzer 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

We need this to simplify the handling of interior sideset boundary conditions in EMPIRE.

## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing

Added test to ensure the proper indexes were selected with EXTERNAL domain selected

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->