### PR TITLE
Amesos2: fixing gcc 8.3.0 warnings for #6295

### DIFF
--- a/packages/amesos2/example/quick_solve.cpp
+++ b/packages/amesos2/example/quick_solve.cpp
@@ -155,7 +155,7 @@ int main(int argc, char *argv[]) {
   RCP<Amesos2::Solver<MAT,MV> > solver;
   try{
     solver = Amesos2::create<MAT,MV>(solver_name, A, Xhat, B);
-  } catch (std::invalid_argument e){
+  } catch (const std::invalid_argument & e){
     *fos << e.what() << std::endl;
     return 0;
   }

--- a/packages/amesos2/example/quick_solve_epetra.cpp
+++ b/packages/amesos2/example/quick_solve_epetra.cpp
@@ -151,7 +151,7 @@ int main(int argc, char *argv[]) {
   RCP<Amesos2::Solver<MAT,MV> > solver;
   try{
     solver = Amesos2::create<MAT,MV>(solver_name, rcp(A), X, B);
-  } catch (std::invalid_argument e){
+  } catch (const std::invalid_argument& e){
     *fos << e.what() << std::endl;
     return 0;
   }

--- a/packages/amesos2/test/solvers/Solver_Test.cpp
+++ b/packages/amesos2/test/solvers/Solver_Test.cpp
@@ -222,7 +222,7 @@ int main(int argc, char*argv[])
   cmdp.setOption("refactor","no-refactor", &refactor, "Recompute L and U using a numerically different matrix at some point");
   try{
     cmdp.parse(argc,argv);
-  } catch (Teuchos::CommandLineProcessor::HelpPrinted hp) {
+  } catch (const Teuchos::CommandLineProcessor::HelpPrinted& hp) {
     return EXIT_SUCCESS;        // help was printed, exit gracefully.
   }
 


### PR DESCRIPTION
@trilinos/amesos2 

## Motivation
Simply catching errors as `const reference` instead of `by value`, this removes the warnings coming out of Amesos2 in [this build](https://testing.sandia.gov/cdash/index.php?project=Trilinos&display=project&filtercount=2&showfilters=1&filtercombine=and&field1=buildname&compare1=63&value1=gcc_8.3.0&field2=buildstamp&compare2=63&value2=Experimental)

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of #6295 
* Composed of 



## Stakeholder Feedback
@ZUUL42 let us know if this fixes the warnings from Amesos2 or if there is more that needs to be done?

## Testing
Locally compiler and tested without problems