### PR TITLE
Ifpack: fixing gcc 8.3.0 warnings for #6295

### DIFF
--- a/packages/ifpack/src/Ifpack_Utils.cpp
+++ b/packages/ifpack/src/Ifpack_Utils.cpp
@@ -64,7 +64,7 @@ void Ifpack_BreakForDebugger(Epetra_Comm& Comm)
   using std::endl;
 
   char hostname[80];
-  char buf[80];
+  char buf[160];
   if (Comm.MyPID()  == 0) cout << "Host and Process Ids for tasks" << endl;
   for (int i = 0; i <Comm.NumProc() ; i++) {
     if (i == Comm.MyPID() ) {
@@ -995,7 +995,7 @@ int Ifpack_PrintSparsity(const Epetra_RowMatrix& A, const char* InputFileName,
   int MyPID;
   int NumProc;
   char FileName[1024];
-  char title[1024];
+  char title[1020];
 
   const Epetra_Comm& Comm = A.Comm();
 


### PR DESCRIPTION
@trilinos/ifpack 

## Motivation
resizing buffer and filename to avoid overflow warning, this will allow us to setup a gcc 8.3.0 build with warnings as error aligned with what Sierra currently does.

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of #6295 
* Composed of 


## Stakeholder Feedback
@ZUUL42 let me know if this removes ifpack from the list of offending packages, if not I'll look into it further

## Testing
Locally tested using sems-gcc/8.3.0 compiler and appropriate warnings