### PR TITLE
ATDM: Update cmake version to 3.12.2 in tlcc2 env

### DIFF
--- a/cmake/std/atdm/common/toss3/environment_tlcc2.sh
+++ b/cmake/std/atdm/common/toss3/environment_tlcc2.sh
@@ -25,7 +25,7 @@ module purge
 . /projects/sems/modulefiles/utils/sems-modules-init.sh
 module load sems-env
 module load atdm-env
-module load atdm-cmake/3.10.1
+module load cmake/3.12.2
 module load atdm-ninja_fortran/1.7.2
 
 if [ "$ATDM_CONFIG_NODE_TYPE" == "OPENMP" ] ; then
@@ -142,14 +142,14 @@ function atdm_run_script_on_compute_node {
   else
     account=${account_input}
   fi
-  
+
   if [ -e $output_file ] ; then
     echo "Remove existing file $output_file"
     rm $output_file
   fi
   echo "Create empty file $output_file"
   touch $output_file
-  
+
   echo
   echo "Running '$script_to_run' using sbatch in the background ..."
   set -x
@@ -157,22 +157,22 @@ function atdm_run_script_on_compute_node {
     -J $ATDM_CONFIG_BUILD_NAME --account=${account} ${script_to_run} &
   SBATCH_PID=$!
   set +x
-  
+
   echo
   echo "Tailing output file $output_file in the background ..."
   set -x
   tail -f $output_file &
   TAIL_BID=$!
   set +x
-  
+
   echo
   echo "Waiting for SBATCH_PID=$SBATCH_PID ..."
   wait $SBATCH_PID
-  
+
   echo
   echo "Kill TAIL_BID=$TAIL_BID"
   kill -s 9 $TAIL_BID
-  
+
   echo
   echo "Finished running ${script_to_run}!"
   echo
@@ -190,5 +190,3 @@ export -f atdm_run_script_on_compute_node
 # with --wait but is backgrouned to allow this to happen.  Then we wait for
 # the 'sbatch' command to complete and then we kill the 'tail -f' command.
 # That might seem overly complex but that gets the job done.
-
-

--- a/cmake/std/atdm/common/toss3/environment_tlcc2.sh
+++ b/cmake/std/atdm/common/toss3/environment_tlcc2.sh
@@ -24,9 +24,8 @@ module purge &> /dev/null
 module purge
 . /projects/sems/modulefiles/utils/sems-modules-init.sh
 module load sems-env
-module load atdm-env
 module load cmake/3.12.2
-module load atdm-ninja_fortran/1.7.2
+module load sems-ninja_fortran/1.8.2
 
 if [ "$ATDM_CONFIG_NODE_TYPE" == "OPENMP" ] ; then
   export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=8

--- a/cmake/std/atdm/tlcc2/environment.sh
+++ b/cmake/std/atdm/tlcc2/environment.sh
@@ -11,7 +11,7 @@
 # machines. please be mindful of this when making changes
 
 if [ "$ATDM_CONFIG_KOKKOS_ARCH" == "DEFAULT" ] ; then
-  export ATDM_CONFIG_KOKKOS_ARCH=SNB  
+  export ATDM_CONFIG_KOKKOS_ARCH=SNB
 fi
 
 if [ "$ATDM_CONFIG_KOKKOS_ARCH" != "SNB" ] ; then
@@ -24,4 +24,4 @@ if [ "$ATDM_CONFIG_KOKKOS_ARCH" != "SNB" ] ; then
   return
 fi
 
-source $ATDM_SCRIPT_DIR/common/toss3/environment.sh
+source $ATDM_SCRIPT_DIR/common/toss3/environment_tlcc2.sh


### PR DESCRIPTION
It looks like my editor cleaned up the whitespace in these files.
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Developers desired newer cmake version.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
None.

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
### Chama
```
source cmake/std/atdm/load-env.sh default
Hostname 'chama-login5' matches known ATDM host 'chama' and system 'tlcc2'
Setting compiler and build options for build-name 'default'
Using toss3 compiler stack INTEL to build DEBUG code with Kokkos node type SERIAL

The following have been reloaded with a version change:
  1) mkl/18.0.0.128 => mkl/18.0.5.274
```

### Skybridge
```
source cmake/std/atdm/load-env.sh default
Hostname 'skybridge-login3' matches known ATDM host 'skybridge' and system 'tlcc2'
Setting compiler and build options for build-name 'default'
Using toss3 compiler stack INTEL to build DEBUG code with Kokkos node type SERIAL

The following have been reloaded with a version change:
  1) mkl/18.0.0.128 => mkl/18.0.5.274
```
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
