### PR TITLE
Intrepid: fixing gcc 8.3.0 warnings for #6295

### DIFF
--- a/packages/intrepid/example/FieldContainer/example_02.cpp
+++ b/packages/intrepid/example/FieldContainer/example_02.cpp
@@ -106,7 +106,7 @@ int main(int argc, char *argv[]) {
     multiIndex[4] = 6;
     myContainer.getEnumeration(multiIndex);
   }
-  catch(std::logic_error err){
+  catch (const std::logic_error & err) {
     cout << err.what() << "\n"; 
   }
   
@@ -122,7 +122,7 @@ int main(int argc, char *argv[]) {
     multiIndex[3] = 2;
     myContainer.getEnumeration(multiIndex);
   }
-  catch(std::logic_error err){
+  catch (const std::logic_error & err) {
     cout << err.what() << "\n\n"; 
   }
   
@@ -154,7 +154,7 @@ int main(int argc, char *argv[]) {
   try{
     myContainer.setValues(dataTeuchosArray);
   }
-  catch(std::logic_error err){
+  catch (const std::logic_error & err) {
     cout << err.what() << "\n";
   }
   
@@ -187,7 +187,7 @@ int main(int argc, char *argv[]) {
   try{
     myContainer.setValues(dataTeuchosArray);
   }
-  catch(std::logic_error err){
+  catch (const std::logic_error & err) {
     cout << err.what() << "\n";
   }
   
@@ -199,7 +199,7 @@ int main(int argc, char *argv[]) {
   try{
     myContainer[1000];
   }
-  catch(std::logic_error err){
+  catch (const std::logic_error & err) {
     cout << err.what() << "\n\n"; 
   }
   
@@ -219,7 +219,7 @@ int main(int argc, char *argv[]) {
     
     FieldContainer<double> myOtherContainer(dimensions, dataTeuchosArray);
   }
-  catch(std::logic_error err){
+  catch (const std::logic_error & err) {
     cout << err.what() << endl;
   }
   

--- a/packages/intrepid/test/Cell/test_01.cpp
+++ b/packages/intrepid/test/Cell/test_01.cpp
@@ -573,7 +573,7 @@ int main(int argc, char *argv[]) {
   //============================================================================================//
   // Wrap up test: check if the test broke down unexpectedly due to an exception                //
   //============================================================================================//
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Cell/test_01_kokkos.cpp
+++ b/packages/intrepid/test/Cell/test_01_kokkos.cpp
@@ -576,7 +576,7 @@ Kokkos::initialize();
   //============================================================================================//
   // Wrap up test: check if the test broke down unexpectedly due to an exception                //
   //============================================================================================//
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Cell/test_02.cpp
+++ b/packages/intrepid/test/Cell/test_02.cpp
@@ -66,7 +66,7 @@ using namespace shards;
     try {                                                                                                                    \
       S ;                                                                                                                    \
     }                                                                                                                        \
-    catch (std::logic_error err) {                                                                                           \
+    catch (const std::logic_error & err) {                                                                                           \
       ++throwCounter;                                                                                                      \
         *outStream << "Expected Error " << nException << " -------------------------------------------------------------\n"; \
           *outStream << err.what() << '\n';                                                                                    \
@@ -336,7 +336,7 @@ int main(int argc, char *argv[]) {
     *         Wrap up test: check if the test broke down unexpectedly due to an exception          *
     ************************************************************************************************/
 
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1000;
   };
@@ -540,7 +540,7 @@ int main(int argc, char *argv[]) {
     *         Wrap up test: check if the test broke down unexpectedly due to an exception          *
     ************************************************************************************************/
   
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1000;
   };
@@ -1216,7 +1216,7 @@ int main(int argc, char *argv[]) {
     *         Wrap up test: check if the test broke down unexpectedly due to an exception          *
     ************************************************************************************************/
 
-  catch(std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1000;
   }

--- a/packages/intrepid/test/Cell/test_02_kokkos.cpp
+++ b/packages/intrepid/test/Cell/test_02_kokkos.cpp
@@ -67,7 +67,7 @@ using namespace shards;
     try {                                                                                                                    \
       S ;                                                                                                                    \
     }                                                                                                                        \
-    catch (std::logic_error err) {                                                                                           \
+    catch (const std::logic_error & err) {                                                                                           \
       ++throwCounter;                                                                                                      \
         *outStream << "Expected Error " << nException << " -------------------------------------------------------------\n"; \
           *outStream << err.what() << '\n';                                                                                    \
@@ -320,7 +320,7 @@ Kokkos::initialize();
     *         Wrap up test: check if the test broke down unexpectedly due to an exception          *
     ************************************************************************************************/
 
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1000;
   };
@@ -517,7 +517,7 @@ Kokkos::initialize();
     *         Wrap up test: check if the test broke down unexpectedly due to an exception          *
     ************************************************************************************************/
  
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1000;
   };
@@ -1193,7 +1193,7 @@ Kokkos::initialize();
     *         Wrap up test: check if the test broke down unexpectedly due to an exception          *
     ************************************************************************************************/
 
-  catch(std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1000;
   }

--- a/packages/intrepid/test/Cell/test_03.cpp
+++ b/packages/intrepid/test/Cell/test_03.cpp
@@ -673,7 +673,7 @@ int main(int argc, char *argv[]) {
   //============================================================================================//
   // Wrap up test: check if the test broke down unexpectedly due to an exception                //
   //============================================================================================//
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Cell/test_03_kokkos.cpp
+++ b/packages/intrepid/test/Cell/test_03_kokkos.cpp
@@ -678,7 +678,7 @@ Kokkos::initialize();
   //============================================================================================//
   // Wrap up test: check if the test broke down unexpectedly due to an exception                //
   //============================================================================================//
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HCURL_HEX_I1_FEM/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HCURL_HEX_I1_FEM/test_01.cpp
@@ -60,7 +60,7 @@ using namespace Intrepid;
   try {                                                                                                                    \
     S ;                                                                                                                    \
   }                                                                                                                        \
-  catch (std::logic_error err) {                                                                                           \
+  catch (const std::logic_error & err) {                                                                                           \
       ++throwCounter;                                                                                                      \
       *outStream << "Expected Error " << nException << " -------------------------------------------------------------\n"; \
       *outStream << err.what() << '\n';                                                                                    \
@@ -206,7 +206,7 @@ int main(int argc, char *argv[]) {
 #endif
     
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -273,7 +273,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::logic_error err){
+  catch (const std::logic_error & err){
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -454,7 +454,7 @@ int main(int argc, char *argv[]) {
    }    
   
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -530,7 +530,7 @@ int main(int argc, char *argv[]) {
     }
 
   }
-  catch (std::logic_error err){
+  catch (const std::logic_error & err){
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HCURL_HEX_In_FEM/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HCURL_HEX_In_FEM/test_01.cpp
@@ -61,7 +61,7 @@ using namespace Intrepid;
   try {                                                                                                                    \
     S ;                                                                                                                    \
   }                                                                                                                        \
-  catch (std::logic_error err) {                                                                                           \
+  catch (const std::logic_error & err) {                                                                                           \
       ++throwCounter;                                                                                                      \
       *outStream << "Expected Error " << nException << " -------------------------------------------------------------\n"; \
       *outStream << err.what() << '\n';                                                                                    \
@@ -203,7 +203,7 @@ int main(int argc, char *argv[]) {
 #endif
     
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -272,7 +272,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::logic_error err){
+  catch (const std::logic_error & err){
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -394,7 +394,7 @@ int main(int argc, char *argv[]) {
    }    
   
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HCURL_HEX_In_FEM/test_02.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HCURL_HEX_In_FEM/test_02.cpp
@@ -316,7 +316,7 @@ int main(int argc, char *argv[]) {
     
   }
   
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HCURL_QUAD_I1_FEM/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HCURL_QUAD_I1_FEM/test_01.cpp
@@ -60,7 +60,7 @@ using namespace Intrepid;
   try {                                                                                                                    \
     S ;                                                                                                                    \
   }                                                                                                                        \
-  catch (std::logic_error err) {                                                                                           \
+  catch (const std::logic_error & err) {                                                                                           \
       ++throwCounter;                                                                                                      \
       *outStream << "Expected Error " << nException << " -------------------------------------------------------------\n"; \
       *outStream << err.what() << '\n';                                                                                    \
@@ -192,7 +192,7 @@ int main(int argc, char *argv[]) {
 #endif
     
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -259,7 +259,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::logic_error err){
+  catch (const std::logic_error & err){
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -351,7 +351,7 @@ int main(int argc, char *argv[]) {
    }    
   
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -419,7 +419,7 @@ int main(int argc, char *argv[]) {
     }
 
   }
-  catch (std::logic_error err){
+  catch (const std::logic_error & err){
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HCURL_QUAD_In_FEM/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HCURL_QUAD_In_FEM/test_01.cpp
@@ -61,7 +61,7 @@ using namespace Intrepid;
   try {                                                                                                                    \
     S ;                                                                                                                    \
   }                                                                                                                        \
-  catch (std::logic_error err) {                                                                                           \
+  catch (const std::logic_error & err) {                                                                                           \
       ++throwCounter;                                                                                                      \
       *outStream << "Expected Error " << nException << " -------------------------------------------------------------\n"; \
       *outStream << err.what() << '\n';                                                                                    \
@@ -196,7 +196,7 @@ int main(int argc, char *argv[]) {
 #endif
     
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -263,7 +263,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::logic_error err){
+  catch (const std::logic_error & err){
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -367,7 +367,7 @@ int main(int argc, char *argv[]) {
    }    
   
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HCURL_TET_I1_FEM/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HCURL_TET_I1_FEM/test_01.cpp
@@ -60,7 +60,7 @@ using namespace Intrepid;
   try {                                                                                                                    \
     S ;                                                                                                                    \
   }                                                                                                                        \
-  catch (std::logic_error err) {                                                                                           \
+  catch (const std::logic_error & err) {                                                                                           \
       ++throwCounter;                                                                                                      \
       *outStream << "Expected Error " << nException << " -------------------------------------------------------------\n"; \
       *outStream << err.what() << '\n';                                                                                    \
@@ -188,7 +188,7 @@ int main(int argc, char *argv[]) {
 #endif
     
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -254,7 +254,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::logic_error err){
+  catch (const std::logic_error & err){
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -396,7 +396,7 @@ int main(int argc, char *argv[]) {
    }    
   
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -466,7 +466,7 @@ int main(int argc, char *argv[]) {
     }
 
   }
-  catch (std::logic_error err){
+  catch (const std::logic_error & err){
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HCURL_TET_In_FEM/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HCURL_TET_In_FEM/test_01.cpp
@@ -162,7 +162,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::exception err) {
+  catch (const std::exception & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   }
@@ -229,7 +229,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::exception err) {
+  catch (const std::exception & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   }  

--- a/packages/intrepid/test/Discretization/Basis/HCURL_TET_In_FEM/test_02.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HCURL_TET_In_FEM/test_02.cpp
@@ -310,7 +310,7 @@ int main(int argc, char *argv[]) {
     
   }
   
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HCURL_TET_In_FEM/test_03.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HCURL_TET_In_FEM/test_03.cpp
@@ -537,7 +537,7 @@ int main(int argc, char *argv[]) {
     
   }
   
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HCURL_TRI_I1_FEM/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HCURL_TRI_I1_FEM/test_01.cpp
@@ -60,7 +60,7 @@ using namespace Intrepid;
   try {                                                                                                                    \
     S ;                                                                                                                    \
   }                                                                                                                        \
-  catch (std::logic_error err) {                                                                                           \
+  catch (const std::logic_error & err) {                                                                                           \
       ++throwCounter;                                                                                                      \
       *outStream << "Expected Error " << nException << " -------------------------------------------------------------\n"; \
       *outStream << err.what() << '\n';                                                                                    \
@@ -192,7 +192,7 @@ int main(int argc, char *argv[]) {
 #endif
     
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -258,7 +258,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::logic_error err){
+  catch (const std::logic_error & err){
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -344,7 +344,7 @@ int main(int argc, char *argv[]) {
   }    
    
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -412,7 +412,7 @@ int main(int argc, char *argv[]) {
     }
 
   }
-  catch (std::logic_error err){
+  catch (const std::logic_error & err){
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HCURL_TRI_In_FEM/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HCURL_TRI_In_FEM/test_01.cpp
@@ -147,7 +147,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::exception err) {
+  catch (const std::exception & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   }
@@ -239,7 +239,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::exception err) {
+  catch (const std::exception & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   }
@@ -328,7 +328,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::exception err) {
+  catch (const std::exception & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   }  

--- a/packages/intrepid/test/Discretization/Basis/HCURL_WEDGE_I1_FEM/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HCURL_WEDGE_I1_FEM/test_01.cpp
@@ -60,7 +60,7 @@ using namespace Intrepid;
   try {                                                                                                                    \
     S ;                                                                                                                    \
   }                                                                                                                        \
-  catch (std::logic_error err) {                                                                                           \
+  catch (const std::logic_error & err) {                                                                                           \
       ++throwCounter;                                                                                                      \
       *outStream << "Expected Error " << nException << " -------------------------------------------------------------\n"; \
       *outStream << err.what() << '\n';                                                                                    \
@@ -192,7 +192,7 @@ int main(int argc, char *argv[]) {
 #endif
     
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -258,7 +258,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::logic_error err){
+  catch (const std::logic_error & err){
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -398,7 +398,7 @@ int main(int argc, char *argv[]) {
    }    
   
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HDIV_HEX_I1_FEM/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HDIV_HEX_I1_FEM/test_01.cpp
@@ -60,7 +60,7 @@ using namespace Intrepid;
   try {                                                                                                                    \
     S ;                                                                                                                    \
   }                                                                                                                        \
-  catch (std::logic_error err) {                                                                                           \
+  catch (const std::logic_error & err) {                                                                                           \
       ++throwCounter;                                                                                                      \
       *outStream << "Expected Error " << nException << " -------------------------------------------------------------\n"; \
       *outStream << err.what() << '\n';                                                                                    \
@@ -202,7 +202,7 @@ int main(int argc, char *argv[]) {
 #endif
     
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -267,7 +267,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::logic_error err){
+  catch (const std::logic_error & err){
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -385,7 +385,7 @@ int main(int argc, char *argv[]) {
    }    
   
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -455,7 +455,7 @@ int main(int argc, char *argv[]) {
     }
 
   }
-  catch (std::logic_error err){
+  catch (const std::logic_error & err){
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HDIV_HEX_In_FEM/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HDIV_HEX_In_FEM/test_01.cpp
@@ -61,7 +61,7 @@ using namespace Intrepid;
   try {                                                                                                                    \
     S ;                                                                                                                    \
   }                                                                                                                        \
-  catch (std::logic_error err) {                                                                                           \
+  catch (const std::logic_error & err) {                                                                                           \
       ++throwCounter;                                                                                                      \
       *outStream << "Expected Error " << nException << " -------------------------------------------------------------\n"; \
       *outStream << err.what() << '\n';                                                                                    \
@@ -200,7 +200,7 @@ int main(int argc, char *argv[]) {
 #endif
     
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -265,7 +265,7 @@ int main(int argc, char *argv[]) {
        }
      }
    }
-   catch (std::logic_error err){
+   catch (const std::logic_error & err){
      *outStream << err.what() << "\n\n";
      errorFlag = -1000;
    };
@@ -363,7 +363,7 @@ int main(int argc, char *argv[]) {
    }    
   
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HDIV_HEX_In_FEM/test_02.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HDIV_HEX_In_FEM/test_02.cpp
@@ -445,7 +445,7 @@ int main(int argc, char *argv[]) {
     
   }
   
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HDIV_QUAD_I1_FEM/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HDIV_QUAD_I1_FEM/test_01.cpp
@@ -60,7 +60,7 @@ using namespace Intrepid;
   try {                                                                                                                    \
     S ;                                                                                                                    \
   }                                                                                                                        \
-  catch (std::logic_error err) {                                                                                           \
+  catch (const std::logic_error & err) {                                                                                           \
       ++throwCounter;                                                                                                      \
       *outStream << "Expected Error " << nException << " -------------------------------------------------------------\n"; \
       *outStream << err.what() << '\n';                                                                                    \
@@ -194,7 +194,7 @@ int main(int argc, char *argv[]) {
 #endif
     
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -259,7 +259,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::logic_error err){
+  catch (const std::logic_error & err){
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -350,7 +350,7 @@ int main(int argc, char *argv[]) {
    }    
   
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HDIV_QUAD_In_FEM/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HDIV_QUAD_In_FEM/test_01.cpp
@@ -61,7 +61,7 @@ using namespace Intrepid;
   try {                                                                                                                    \
     S ;                                                                                                                    \
   }                                                                                                                        \
-  catch (std::logic_error err) {                                                                                           \
+  catch (const std::logic_error & err) {                                                                                           \
       ++throwCounter;                                                                                                      \
       *outStream << "Expected Error " << nException << " -------------------------------------------------------------\n"; \
       *outStream << err.what() << '\n';                                                                                    \
@@ -202,7 +202,7 @@ int main(int argc, char *argv[]) {
 #endif
     
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -267,7 +267,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::logic_error err){
+  catch (const std::logic_error & err){
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -374,7 +374,7 @@ int main(int argc, char *argv[]) {
    }    
   
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HDIV_QUAD_In_FEM/test_02.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HDIV_QUAD_In_FEM/test_02.cpp
@@ -429,7 +429,7 @@ int main(int argc, char *argv[]) {
     }
 
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HDIV_TET_I1_FEM/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HDIV_TET_I1_FEM/test_01.cpp
@@ -60,7 +60,7 @@ using namespace Intrepid;
   try {                                                                                                                    \
     S ;                                                                                                                    \
   }                                                                                                                        \
-  catch (std::logic_error err) {                                                                                           \
+  catch (const std::logic_error & err) {                                                                                           \
       ++throwCounter;                                                                                                      \
       *outStream << "Expected Error " << nException << " -------------------------------------------------------------\n"; \
       *outStream << err.what() << '\n';                                                                                    \
@@ -192,7 +192,7 @@ int main(int argc, char *argv[]) {
 #endif
     
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -257,7 +257,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::logic_error err){
+  catch (const std::logic_error & err){
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -359,7 +359,7 @@ int main(int argc, char *argv[]) {
    }    
   
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -427,7 +427,7 @@ int main(int argc, char *argv[]) {
     }
 
   }
-  catch (std::logic_error err){
+  catch (const std::logic_error & err){
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HDIV_TET_In_FEM/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HDIV_TET_In_FEM/test_01.cpp
@@ -291,7 +291,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::exception err) {
+  catch (const std::exception & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   }
@@ -483,7 +483,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::exception err) {
+  catch (const std::exception & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   }

--- a/packages/intrepid/test/Discretization/Basis/HDIV_TET_In_FEM/test_02.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HDIV_TET_In_FEM/test_02.cpp
@@ -446,7 +446,7 @@ int main(int argc, char *argv[]) {
     
   }
   
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HDIV_TRI_I1_FEM/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HDIV_TRI_I1_FEM/test_01.cpp
@@ -60,7 +60,7 @@ using namespace Intrepid;
   try {                                                                                                                    \
     S ;                                                                                                                    \
   }                                                                                                                        \
-  catch (std::logic_error err) {                                                                                           \
+  catch (const std::logic_error & err) {                                                                                           \
       ++throwCounter;                                                                                                      \
       *outStream << "Expected Error " << nException << " -------------------------------------------------------------\n"; \
       *outStream << err.what() << '\n';                                                                                    \
@@ -192,7 +192,7 @@ int main(int argc, char *argv[]) {
 #endif
     
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -257,7 +257,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::logic_error err){
+  catch (const std::logic_error & err){
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -353,7 +353,7 @@ int main(int argc, char *argv[]) {
    }    
   
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HDIV_TRI_In_FEM/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HDIV_TRI_In_FEM/test_01.cpp
@@ -187,7 +187,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::exception err) {
+  catch (const std::exception & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   }
@@ -277,7 +277,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::exception err) {
+  catch (const std::exception & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   }

--- a/packages/intrepid/test/Discretization/Basis/HDIV_TRI_In_FEM/test_02.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HDIV_TRI_In_FEM/test_02.cpp
@@ -429,7 +429,7 @@ int main(int argc, char *argv[]) {
     }
 
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HDIV_WEDGE_I1_FEM/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HDIV_WEDGE_I1_FEM/test_01.cpp
@@ -60,7 +60,7 @@ using namespace Intrepid;
   try {                                                                                                                    \
     S ;                                                                                                                    \
   }                                                                                                                        \
-  catch (std::logic_error err) {                                                                                           \
+  catch (const std::logic_error & err) {                                                                                           \
       ++throwCounter;                                                                                                      \
       *outStream << "Expected Error " << nException << " -------------------------------------------------------------\n"; \
       *outStream << err.what() << '\n';                                                                                    \
@@ -194,7 +194,7 @@ int main(int argc, char *argv[]) {
 #endif
     
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -259,7 +259,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::logic_error err){
+  catch (const std::logic_error & err){
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -362,7 +362,7 @@ int main(int argc, char *argv[]) {
    }    
   
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_HEX_C1_FEM/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_HEX_C1_FEM/test_01.cpp
@@ -60,7 +60,7 @@ using namespace Intrepid;
   try {                                                                                                                    \
     S ;                                                                                                                    \
   }                                                                                                                        \
-  catch (std::logic_error err) {                                                                                           \
+  catch (const std::logic_error & err) {                                                                                           \
       ++throwCounter;                                                                                                      \
       *outStream << "Expected Error " << nException << " -------------------------------------------------------------\n"; \
       *outStream << err.what() << '\n';                                                                                    \
@@ -210,7 +210,7 @@ int main(int argc, char *argv[]) {
 #endif
 
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -276,7 +276,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::logic_error err){
+  catch (const std::logic_error & err){
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -543,7 +543,7 @@ int main(int argc, char *argv[]) {
   }
   
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -599,7 +599,7 @@ int main(int argc, char *argv[]) {
     }
 
   }
-  catch (std::logic_error err){
+  catch (const std::logic_error & err){
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_HEX_C1_FEM/test_02.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_HEX_C1_FEM/test_02.cpp
@@ -565,7 +565,7 @@ int main(int argc, char *argv[]) {
 
   }
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_HEX_C2_FEM/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_HEX_C2_FEM/test_01.cpp
@@ -60,7 +60,7 @@ using namespace Intrepid;
   try {                                                                                                                    \
     S ;                                                                                                                    \
   }                                                                                                                        \
-  catch (std::logic_error err) {                                                                                           \
+  catch (const std::logic_error & err) {                                                                                           \
       ++throwCounter;                                                                                                      \
       *outStream << "Expected Error " << nException << " -------------------------------------------------------------\n"; \
       *outStream << err.what() << '\n';                                                                                    \
@@ -224,7 +224,7 @@ int main(int argc, char *argv[]) {
 #endif
 
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -290,7 +290,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::logic_error err){
+  catch (const std::logic_error & err){
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -611,7 +611,7 @@ int main(int argc, char *argv[]) {
   }
   
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -667,7 +667,7 @@ int main(int argc, char *argv[]) {
     }
 
   }
-  catch (std::logic_error err){
+  catch (const std::logic_error & err){
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_HEX_C2_FEM/test_02.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_HEX_C2_FEM/test_02.cpp
@@ -565,7 +565,7 @@ int main(int argc, char *argv[]) {
 
   }
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_HEX_Cn_FEM/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_HEX_Cn_FEM/test_01.cpp
@@ -61,7 +61,7 @@ using namespace Intrepid;
   try {                                                                                                                    \
     S ;                                                                                                                    \
   }                                                                                                                        \
-  catch (std::logic_error err) {                                                                                           \
+  catch (const std::logic_error & err) {                                                                                           \
       ++throwCounter;                                                                                                      \
       *outStream << "Expected Error " << nException << " -------------------------------------------------------------\n"; \
       *outStream << err.what() << '\n';                                                                                    \
@@ -227,7 +227,7 @@ int main(int argc, char *argv[]) {
 #endif
 
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -295,7 +295,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::logic_error err){
+  catch (const std::logic_error & err){
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -608,7 +608,7 @@ int main(int argc, char *argv[]) {
     }    
   }
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_HEX_Cn_FEM/test_02.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_HEX_Cn_FEM/test_02.cpp
@@ -570,7 +570,7 @@ int main(int argc, char *argv[]) {
 
   }
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_HEX_I2_FEM/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_HEX_I2_FEM/test_01.cpp
@@ -60,7 +60,7 @@ using namespace Intrepid;
   try {                                                                                                                    \
     S ;                                                                                                                    \
   }                                                                                                                        \
-  catch (std::logic_error err) {                                                                                           \
+  catch (const std::logic_error & err) {                                                                                           \
       ++throwCounter;                                                                                                      \
       *outStream << "Expected Error " << nException << " -------------------------------------------------------------\n"; \
       *outStream << err.what() << '\n';                                                                                    \
@@ -213,7 +213,7 @@ int main(int argc, char *argv[]) {
 #endif
 
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -279,7 +279,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::logic_error err){
+  catch (const std::logic_error & err){
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -518,7 +518,7 @@ int main(int argc, char *argv[]) {
   }
   
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -574,7 +574,7 @@ int main(int argc, char *argv[]) {
     }
 
   }
-  catch (std::logic_error err){
+  catch (const std::logic_error & err){
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_HEX_I2_FEM/test_02.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_HEX_I2_FEM/test_02.cpp
@@ -543,7 +543,7 @@ int main(int argc, char *argv[]) {
 
   }
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_LINE_C1_FEM/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_LINE_C1_FEM/test_01.cpp
@@ -61,7 +61,7 @@ using namespace Intrepid;
   try {                                                                                                                    \
     S ;                                                                                                                    \
   }                                                                                                                        \
-  catch (std::logic_error err) {                                                                                           \
+  catch (const std::logic_error & err) {                                                                                           \
       ++throwCounter;                                                                                                      \
       *outStream << "Expected Error " << nException << " -------------------------------------------------------------\n"; \
       *outStream << err.what() << '\n';                                                                                    \
@@ -191,7 +191,7 @@ int main(int argc, char *argv[]) {
 #endif
     
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -256,7 +256,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::logic_error err){
+  catch (const std::logic_error & err){
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -428,7 +428,7 @@ int main(int argc, char *argv[]) {
   }
 
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_LINE_C1_FEM/test_02.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_LINE_C1_FEM/test_02.cpp
@@ -356,7 +356,7 @@ int main(int argc, char *argv[]) {
 
   }
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_LINE_Cn_FEM/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_LINE_Cn_FEM/test_01.cpp
@@ -65,7 +65,7 @@ using namespace Intrepid;
   try {                                                                                                                    \
     S ;                                                                                                                    \
   }                                                                                                                        \
-  catch (std::logic_error err) {                                                                                           \
+  catch (const std::logic_error & err) {                                                                                           \
       ++throwCounter;                                                                                                      \
       *outStream << "Expected Error " << nException << " -------------------------------------------------------------\n"; \
       *outStream << err.what() << '\n';                                                                                    \
@@ -198,7 +198,7 @@ int main(int argc, char *argv[]) {
 #endif
 
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -246,7 +246,7 @@ int main(int argc, char *argv[]) {
      }
    }
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_LINE_Cn_FEM/test_02.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_LINE_Cn_FEM/test_02.cpp
@@ -362,7 +362,7 @@ int main(int argc, char *argv[]) {
 
   }
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_LINE_Cn_FEM_JACOBI/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_LINE_Cn_FEM_JACOBI/test_01.cpp
@@ -64,7 +64,7 @@ using namespace Intrepid;
   try {                                                                                                                    \
     S ;                                                                                                                    \
   }                                                                                                                        \
-  catch (std::logic_error err) {                                                                                           \
+  catch (const std::logic_error & err) {                                                                                           \
       ++throwCounter;                                                                                                      \
       *outStream << "Expected Error " << nException << " -------------------------------------------------------------\n"; \
       *outStream << err.what() << '\n';                                                                                    \
@@ -192,7 +192,7 @@ int main(int argc, char *argv[]) {
 #endif
 
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -286,7 +286,7 @@ int main(int argc, char *argv[]) {
 
   }
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -419,7 +419,7 @@ int main(int argc, char *argv[]) {
     }
   }
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_LINE_Cn_FEM_JACOBI/test_02.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_LINE_Cn_FEM_JACOBI/test_02.cpp
@@ -359,7 +359,7 @@ int main(int argc, char *argv[]) {
 
   }
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_LINE_Hermite_FEM/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_LINE_Hermite_FEM/test_01.cpp
@@ -67,7 +67,7 @@ using namespace Intrepid;
   try {                                                                                                                    \
     S ;                                                                                                                    \
   }                                                                                                                        \
-  catch (std::logic_error err) {                                                                                           \
+  catch (const std::logic_error & err) {                                                                                           \
       ++throwCounter;                                                                                                      \
       *outStream << "Expected Error " << nException << " -------------------------------------------------------------\n"; \
       *outStream << err.what() << '\n';                                                                                    \
@@ -227,7 +227,7 @@ int main(int argc, char *argv[]) {
   }
 
   
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -362,7 +362,7 @@ int main(int argc, char *argv[]) {
   } // end try
 
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -478,7 +478,7 @@ int main(int argc, char *argv[]) {
   }
 
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_LINE_Hermite_FEM/test_02.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_LINE_Hermite_FEM/test_02.cpp
@@ -436,7 +436,7 @@ int main(int argc, char *argv[]) {
   }
 
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_PYR_C1_FEM/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_PYR_C1_FEM/test_01.cpp
@@ -60,7 +60,7 @@ using namespace Intrepid;
   try {                                                                                                                    \
     S ;                                                                                                                    \
   }                                                                                                                        \
-  catch (std::logic_error err) {                                                                                           \
+  catch (const std::logic_error & err) {                                                                                           \
       ++throwCounter;                                                                                                      \
       *outStream << "Expected Error " << nException << " -------------------------------------------------------------\n"; \
       *outStream << err.what() << '\n';                                                                                    \
@@ -200,7 +200,7 @@ int main(int argc, char *argv[]) {
 #endif
 
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -265,7 +265,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::logic_error err){
+  catch (const std::logic_error & err){
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -418,7 +418,7 @@ int main(int argc, char *argv[]) {
   
 
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_PYR_C1_FEM/test_02.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_PYR_C1_FEM/test_02.cpp
@@ -602,7 +602,7 @@ int main(int argc, char *argv[]) {
 
   }
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_PYR_I2_FEM/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_PYR_I2_FEM/test_01.cpp
@@ -60,7 +60,7 @@ using namespace Intrepid;
   try {                                                                                                                    \
     S ;                                                                                                                    \
   }                                                                                                                        \
-  catch (std::logic_error err) {                                                                                           \
+  catch (const std::logic_error & err) {                                                                                           \
       ++throwCounter;                                                                                                      \
       *outStream << "Expected Error " << nException << " -------------------------------------------------------------\n"; \
       *outStream << err.what() << '\n';                                                                                    \
@@ -208,7 +208,7 @@ int main(int argc, char *argv[]) {
 #endif
 
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -273,7 +273,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::logic_error err){
+  catch (const std::logic_error & err){
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -470,7 +470,7 @@ int main(int argc, char *argv[]) {
   
 
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_PYR_I2_FEM/test_02.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_PYR_I2_FEM/test_02.cpp
@@ -608,7 +608,7 @@ int main(int argc, char *argv[]) {
 
   }
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_QUAD_C1_FEM/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_QUAD_C1_FEM/test_01.cpp
@@ -60,7 +60,7 @@ using namespace Intrepid;
   try {                                                                                                                    \
     S ;                                                                                                                    \
   }                                                                                                                        \
-  catch (std::logic_error err) {                                                                                           \
+  catch (const std::logic_error & err) {                                                                                           \
       ++throwCounter;                                                                                                      \
       *outStream << "Expected Error " << nException << " -------------------------------------------------------------\n"; \
       *outStream << err.what() << '\n';                                                                                    \
@@ -188,7 +188,7 @@ int main(int argc, char *argv[]) {
 #endif
 
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -253,7 +253,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::logic_error err){
+  catch (const std::logic_error & err){
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -446,7 +446,7 @@ int main(int argc, char *argv[]) {
     }    
   }
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -503,7 +503,7 @@ int main(int argc, char *argv[]) {
     }
 
   }
-  catch (std::logic_error err){
+  catch (const std::logic_error & err){
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_QUAD_C1_FEM/test_02.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_QUAD_C1_FEM/test_02.cpp
@@ -496,7 +496,7 @@ int main(int argc, char *argv[]) {
 
   }
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_QUAD_C2_FEM/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_QUAD_C2_FEM/test_01.cpp
@@ -60,7 +60,7 @@ using namespace Intrepid;
   try {                                                                                                                    \
     S ;                                                                                                                    \
   }                                                                                                                        \
-  catch (std::logic_error err) {                                                                                           \
+  catch (const std::logic_error & err) {                                                                                           \
       ++throwCounter;                                                                                                      \
       *outStream << "Expected Error " << nException << " -------------------------------------------------------------\n"; \
       *outStream << err.what() << '\n';                                                                                    \
@@ -196,7 +196,7 @@ int main(int argc, char *argv[]) {
 #endif
 
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -261,7 +261,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::logic_error err){
+  catch (const std::logic_error & err){
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -693,7 +693,7 @@ int main(int argc, char *argv[]) {
     }    
   }
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -750,7 +750,7 @@ int main(int argc, char *argv[]) {
     }
 
   }
-  catch (std::logic_error err){
+  catch (const std::logic_error & err){
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_QUAD_C2_FEM/test_02.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_QUAD_C2_FEM/test_02.cpp
@@ -496,7 +496,7 @@ int main(int argc, char *argv[]) {
 
   }
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_QUAD_Cn_FEM/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_QUAD_Cn_FEM/test_01.cpp
@@ -61,7 +61,7 @@ using namespace Intrepid;
   try {                                                                                                                    \
     S ;                                                                                                                    \
   }                                                                                                                        \
-  catch (std::logic_error err) {                                                                                           \
+  catch (const std::logic_error & err) {                                                                                           \
       ++throwCounter;                                                                                                      \
       *outStream << "Expected Error " << nException << " -------------------------------------------------------------\n"; \
       *outStream << err.what() << '\n';                                                                                    \
@@ -203,7 +203,7 @@ int main(int argc, char *argv[]) {
 #endif
 
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -268,7 +268,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::logic_error err){
+  catch (const std::logic_error & err){
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -688,7 +688,7 @@ int main(int argc, char *argv[]) {
   }
   
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_QUAD_Cn_FEM/test_02.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_QUAD_Cn_FEM/test_02.cpp
@@ -497,7 +497,7 @@ int main(int argc, char *argv[]) {
 
   }
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_TET_C1_FEM/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_TET_C1_FEM/test_01.cpp
@@ -60,7 +60,7 @@ using namespace Intrepid;
   try {                                                                                                                    \
     S ;                                                                                                                    \
   }                                                                                                                        \
-  catch (std::logic_error err) {                                                                                           \
+  catch (const std::logic_error & err) {                                                                                           \
       ++throwCounter;                                                                                                      \
       *outStream << "Expected Error " << nException << " -------------------------------------------------------------\n"; \
       *outStream << err.what() << '\n';                                                                                    \
@@ -197,7 +197,7 @@ int main(int argc, char *argv[]) {
 #endif
     
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -262,7 +262,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::logic_error err){
+  catch (const std::logic_error & err){
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -398,7 +398,7 @@ int main(int argc, char *argv[]) {
   }
   
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_TET_C1_FEM/test_02.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_TET_C1_FEM/test_02.cpp
@@ -531,7 +531,7 @@ int main(int argc, char *argv[]) {
 
   }
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_TET_C2_FEM/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_TET_C2_FEM/test_01.cpp
@@ -60,7 +60,7 @@ using namespace Intrepid;
   try {                                                                                                                    \
     S ;                                                                                                                    \
   }                                                                                                                        \
-  catch (std::logic_error err) {                                                                                           \
+  catch (const std::logic_error & err) {                                                                                           \
       ++throwCounter;                                                                                                      \
       *outStream << "Expected Error " << nException << " -------------------------------------------------------------\n"; \
       *outStream << err.what() << '\n';                                                                                    \
@@ -200,7 +200,7 @@ int main(int argc, char *argv[]) {
 #endif
     
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -265,7 +265,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::logic_error err){
+  catch (const std::logic_error & err){
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -498,7 +498,7 @@ int main(int argc, char *argv[]) {
   }
   
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_TET_C2_FEM/test_02.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_TET_C2_FEM/test_02.cpp
@@ -531,7 +531,7 @@ int main(int argc, char *argv[]) {
 
   }
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_TET_COMP12_FEM/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_TET_COMP12_FEM/test_01.cpp
@@ -62,7 +62,7 @@ using namespace Intrepid;
   try {                                                                                                                    \
     S ;                                                                                                                    \
   }                                                                                                                        \
-  catch (std::logic_error err) {                                                                                           \
+  catch (const std::logic_error & err) {                                                                                           \
       ++throwCounter;                                                                                                      \
       *outStream << "Expected Error " << nException << " -------------------------------------------------------------\n"; \
       *outStream << err.what() << '\n';                                                                                    \
@@ -426,7 +426,7 @@ int main(int argc, char *argv[]) {
      }
   }
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_TET_Cn_FEM/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_TET_Cn_FEM/test_01.cpp
@@ -136,7 +136,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::exception err) {
+  catch (const std::exception & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   }
@@ -158,7 +158,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::exception err) {
+  catch (const std::exception & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   }
@@ -181,7 +181,7 @@ int main(int argc, char *argv[]) {
     myBasis.getValues( vals , lattice , OPERATOR_GRAD );
 
   }
-  catch (std::exception err) {
+  catch (const std::exception & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   }

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_TET_Cn_FEM/test_02.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_TET_Cn_FEM/test_02.cpp
@@ -541,7 +541,7 @@ int main(int argc, char *argv[]) {
 
   }
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_TET_Cn_FEM_ORTH/test_02.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_TET_Cn_FEM_ORTH/test_02.cpp
@@ -535,7 +535,7 @@ int main(int argc, char *argv[]) {
   }
 
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_TRI_C1_FEM/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_TRI_C1_FEM/test_01.cpp
@@ -61,7 +61,7 @@ using namespace Intrepid;
   try {                                                                                                                    \
     S ;                                                                                                                    \
   }                                                                                                                        \
-  catch (std::logic_error err) {                                                                                           \
+  catch (const std::logic_error & err) {                                                                                           \
       ++throwCounter;                                                                                                      \
       *outStream << "Expected Error " << nException << " -------------------------------------------------------------\n"; \
       *outStream << err.what() << '\n';                                                                                    \
@@ -189,7 +189,7 @@ int main(int argc, char *argv[]) {
 #endif
     
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -254,7 +254,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::logic_error err){
+  catch (const std::logic_error & err){
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -415,7 +415,7 @@ int main(int argc, char *argv[]) {
   }
 
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -471,7 +471,7 @@ int main(int argc, char *argv[]) {
     }
 
   }
-  catch (std::logic_error err){
+  catch (const std::logic_error & err){
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_TRI_C1_FEM/test_02.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_TRI_C1_FEM/test_02.cpp
@@ -475,7 +475,7 @@ int main(int argc, char *argv[]) {
 
   }
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_TRI_C2_FEM/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_TRI_C2_FEM/test_01.cpp
@@ -61,7 +61,7 @@ using namespace Intrepid;
   try {                                                                                                                    \
     S ;                                                                                                                    \
   }                                                                                                                        \
-  catch (std::logic_error err) {                                                                                           \
+  catch (const std::logic_error & err) {                                                                                           \
       ++throwCounter;                                                                                                      \
       *outStream << "Expected Error " << nException << " -------------------------------------------------------------\n"; \
       *outStream << err.what() << '\n';                                                                                    \
@@ -194,7 +194,7 @@ int main(int argc, char *argv[]) {
 #endif
     
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -259,7 +259,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::logic_error err){
+  catch (const std::logic_error & err){
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -464,7 +464,7 @@ int main(int argc, char *argv[]) {
   }
 
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_TRI_C2_FEM/test_02.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_TRI_C2_FEM/test_02.cpp
@@ -475,7 +475,7 @@ int main(int argc, char *argv[]) {
 
   }
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_TRI_Cn_FEM/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_TRI_Cn_FEM/test_01.cpp
@@ -137,7 +137,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::exception err) {
+  catch (const std::exception & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   }
@@ -158,7 +158,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::exception err) {
+  catch (const std::exception & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   }
@@ -187,7 +187,7 @@ int main(int argc, char *argv[]) {
 
     std::cout << vals << std::endl;
   }
-  catch (std::exception err) {
+  catch (const std::exception & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   }

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_TRI_Cn_FEM/test_02.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_TRI_Cn_FEM/test_02.cpp
@@ -485,7 +485,7 @@ int main(int argc, char *argv[]) {
 
   }
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_TRI_Cn_FEM_ORTH/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_TRI_Cn_FEM_ORTH/test_01.cpp
@@ -134,7 +134,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch ( std::exception err) {
+  catch (const std::exception & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   }
@@ -279,7 +279,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch ( std::exception err) {
+  catch (const std::exception & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   }
@@ -425,7 +425,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch ( std::exception err) {
+  catch (const std::exception & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   }

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_TRI_Cn_FEM_ORTH/test_02.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_TRI_Cn_FEM_ORTH/test_02.cpp
@@ -478,7 +478,7 @@ int main(int argc, char *argv[]) {
 
   }
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_WEDGE_C1_FEM/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_WEDGE_C1_FEM/test_01.cpp
@@ -60,7 +60,7 @@ using namespace Intrepid;
   try {                                                                                                                    \
     S ;                                                                                                                    \
   }                                                                                                                        \
-  catch (std::logic_error err) {                                                                                           \
+  catch (const std::logic_error & err) {                                                                                           \
       ++throwCounter;                                                                                                      \
       *outStream << "Expected Error " << nException << " -------------------------------------------------------------\n"; \
       *outStream << err.what() << '\n';                                                                                    \
@@ -202,7 +202,7 @@ int main(int argc, char *argv[]) {
 #endif
 
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -267,7 +267,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::logic_error err){
+  catch (const std::logic_error & err){
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -462,7 +462,7 @@ int main(int argc, char *argv[]) {
   }
   
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_WEDGE_C1_FEM/test_02.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_WEDGE_C1_FEM/test_02.cpp
@@ -611,7 +611,7 @@ int main(int argc, char *argv[]) {
 
   }
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_WEDGE_C2_FEM/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_WEDGE_C2_FEM/test_01.cpp
@@ -60,7 +60,7 @@ using namespace Intrepid;
   try {                                                                                                                    \
     S ;                                                                                                                    \
   }                                                                                                                        \
-  catch (std::logic_error err) {                                                                                           \
+  catch (const std::logic_error & err) {                                                                                           \
       ++throwCounter;                                                                                                      \
       *outStream << "Expected Error " << nException << " -------------------------------------------------------------\n"; \
       *outStream << err.what() << '\n';                                                                                    \
@@ -209,7 +209,7 @@ int main(int argc, char *argv[]) {
 #endif
 
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -274,7 +274,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::logic_error err){
+  catch (const std::logic_error & err){
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -577,7 +577,7 @@ int main(int argc, char *argv[]) {
   }
   
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_WEDGE_I2_FEM/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_WEDGE_I2_FEM/test_01.cpp
@@ -60,7 +60,7 @@ using namespace Intrepid;
   try {                                                                                                                    \
     S ;                                                                                                                    \
   }                                                                                                                        \
-  catch (std::logic_error err) {                                                                                           \
+  catch (const std::logic_error & err) {                                                                                           \
       ++throwCounter;                                                                                                      \
       *outStream << "Expected Error " << nException << " -------------------------------------------------------------\n"; \
       *outStream << err.what() << '\n';                                                                                    \
@@ -205,7 +205,7 @@ int main(int argc, char *argv[]) {
 #endif
 
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -270,7 +270,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::logic_error err){
+  catch (const std::logic_error & err){
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };
@@ -526,7 +526,7 @@ int main(int argc, char *argv[]) {
   }
   
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/Basis/HGRAD_WEDGE_I2_FEM/test_02.cpp
+++ b/packages/intrepid/test/Discretization/Basis/HGRAD_WEDGE_I2_FEM/test_02.cpp
@@ -611,7 +611,7 @@ int main(int argc, char *argv[]) {
 
   }
   // Catch unexpected errors
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;
   };

--- a/packages/intrepid/test/Discretization/FunctionSpaceTools/test_01.cpp
+++ b/packages/intrepid/test/Discretization/FunctionSpaceTools/test_01.cpp
@@ -64,7 +64,7 @@ using namespace Intrepid;
   try {                                                                                                             \
     S ;                                                                                                             \
   }                                                                                                                 \
-  catch (std::logic_error err) {                                                                                    \
+  catch (const std::logic_error & err) {                                                                                    \
       *outStream << "Expected Error ----------------------------------------------------------------\n";            \
       *outStream << err.what() << '\n';                                                                             \
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";    \
@@ -213,7 +213,7 @@ int main(int argc, char *argv[]) {
     INTREPID_TEST_COMMAND( fst::evaluate<double>(a_2_2_2_2, a_2_2, a_2_2_2_2_2) );
 #endif
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -396,7 +396,7 @@ int main(int argc, char *argv[]) {
 
       *outStream << "\n";
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";

--- a/packages/intrepid/test/Discretization/FunctionSpaceTools/test_02.cpp
+++ b/packages/intrepid/test/Discretization/FunctionSpaceTools/test_02.cpp
@@ -337,7 +337,7 @@ int main(int argc, char *argv[]) {
 
       *outStream << "\n";
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";

--- a/packages/intrepid/test/Discretization/FunctionSpaceTools/test_03.cpp
+++ b/packages/intrepid/test/Discretization/FunctionSpaceTools/test_03.cpp
@@ -343,7 +343,7 @@ int main(int argc, char *argv[]) {
 
       *outStream << "\n";
   }// try Basis_HDIV_HEX_I1
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";

--- a/packages/intrepid/test/Discretization/FunctionSpaceTools/test_04.cpp
+++ b/packages/intrepid/test/Discretization/FunctionSpaceTools/test_04.cpp
@@ -64,7 +64,7 @@ using namespace Intrepid;
   try {                                                                                                             \
     S ;                                                                                                             \
   }                                                                                                                 \
-  catch (std::logic_error err) {                                                                                    \
+  catch (const std::logic_error & err) {                                                                                    \
       *outStream << "Expected Error ----------------------------------------------------------------\n";            \
       *outStream << err.what() << '\n';                                                                             \
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";    \
@@ -207,7 +207,7 @@ int main(int argc, char *argv[]) {
 
       *outStream << "\n";
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";

--- a/packages/intrepid/test/Discretization/FunctionSpaceTools/test_05.cpp
+++ b/packages/intrepid/test/Discretization/FunctionSpaceTools/test_05.cpp
@@ -415,7 +415,7 @@ int main(int argc, char *argv[]) {
 
       *outStream << "\n";
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";

--- a/packages/intrepid/test/Discretization/FunctionSpaceTools/test_06.cpp
+++ b/packages/intrepid/test/Discretization/FunctionSpaceTools/test_06.cpp
@@ -65,7 +65,7 @@ using namespace Intrepid;
   try {                                                                                                             \
     S ;                                                                                                             \
   }                                                                                                                 \
-  catch (std::logic_error err) {                                                                                    \
+  catch (const std::logic_error & err) {                                                                                    \
       *outStream << "Expected Error ----------------------------------------------------------------\n";            \
       *outStream << err.what() << '\n';                                                                             \
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";    \
@@ -214,7 +214,7 @@ int main(int argc, char *argv[]) {
     INTREPID_TEST_COMMAND( fst::evaluate<double>(a_2_2_2_2, a_2_2, a_2_2_2_2_2) );
 #endif
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -405,7 +405,7 @@ int main(int argc, char *argv[]) {
 
       *outStream << "\n";
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";

--- a/packages/intrepid/test/Discretization/Integration/test_01.cpp
+++ b/packages/intrepid/test/Discretization/Integration/test_01.cpp
@@ -66,7 +66,7 @@ using namespace Intrepid;
   try {                                                                                                             \
     S ;                                                                                                             \
   }                                                                                                                 \
-  catch (std::logic_error err) {                                                                                    \
+  catch (const std::logic_error & err) {                                                                                    \
       *outStream << "Expected Error ----------------------------------------------------------------\n";            \
       *outStream << err.what() << '\n';                                                                             \
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";    \
@@ -313,7 +313,7 @@ int main(int argc, char *argv[]) {
       errorFlag = -1000;
     }
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1000;
   };
@@ -430,7 +430,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1;
   };

--- a/packages/intrepid/test/Discretization/Integration/test_02.cpp
+++ b/packages/intrepid/test/Discretization/Integration/test_02.cpp
@@ -191,7 +191,7 @@ int main(int argc, char *argv[]) {
       *outStream << "\n";
     } // end for cubDeg
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1;
   };

--- a/packages/intrepid/test/Discretization/Integration/test_03.cpp
+++ b/packages/intrepid/test/Discretization/Integration/test_03.cpp
@@ -214,7 +214,7 @@ int main(int argc, char *argv[]) {
       *outStream << "\n";
     }  // end for cellCt
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1;
   };

--- a/packages/intrepid/test/Discretization/Integration/test_04.cpp
+++ b/packages/intrepid/test/Discretization/Integration/test_04.cpp
@@ -249,7 +249,7 @@ int main(int argc, char *argv[]) {
       *outStream << "\n";
     }  // end for cellCt
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1;
   };

--- a/packages/intrepid/test/Discretization/Integration/test_05.cpp
+++ b/packages/intrepid/test/Discretization/Integration/test_05.cpp
@@ -258,7 +258,7 @@ int main(int argc, char *argv[]) {
       *outStream << "\n";
     }  // end for cellCt
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1;
   };

--- a/packages/intrepid/test/Discretization/Integration/test_06.cpp
+++ b/packages/intrepid/test/Discretization/Integration/test_06.cpp
@@ -260,7 +260,7 @@ int main(int argc, char *argv[]) {
       *outStream << "\n";
     }  // end for cellCt
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1;
   };

--- a/packages/intrepid/test/Discretization/Integration/test_07.cpp
+++ b/packages/intrepid/test/Discretization/Integration/test_07.cpp
@@ -208,7 +208,7 @@ int main(int argc, char *argv[]) {
       }
       *outStream << "\n";
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1;
   };

--- a/packages/intrepid/test/Discretization/Integration/test_08.cpp
+++ b/packages/intrepid/test/Discretization/Integration/test_08.cpp
@@ -230,7 +230,7 @@ int main(int argc, char *argv[]) {
       }
       *outStream << "\n";
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1;
   };

--- a/packages/intrepid/test/Discretization/Integration/test_09.cpp
+++ b/packages/intrepid/test/Discretization/Integration/test_09.cpp
@@ -230,7 +230,7 @@ int main(int argc, char *argv[]) {
       }
       *outStream << "\n";
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1;
   };

--- a/packages/intrepid/test/Discretization/Integration/test_10.cpp
+++ b/packages/intrepid/test/Discretization/Integration/test_10.cpp
@@ -193,7 +193,7 @@ int main(int argc, char *argv[]) {
       } // end for cubDeg
     } // end for poly_type
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1;
   };

--- a/packages/intrepid/test/Discretization/Integration/test_11.cpp
+++ b/packages/intrepid/test/Discretization/Integration/test_11.cpp
@@ -298,7 +298,7 @@ int main(int argc, char *argv[]) {
       }
     } // end for rule
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1;
   };

--- a/packages/intrepid/test/Discretization/Integration/test_12.cpp
+++ b/packages/intrepid/test/Discretization/Integration/test_12.cpp
@@ -341,7 +341,7 @@ int main(int argc, char *argv[]) {
 	}
     } // end for rule
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1;
   };

--- a/packages/intrepid/test/Discretization/Integration/test_13.cpp
+++ b/packages/intrepid/test/Discretization/Integration/test_13.cpp
@@ -389,7 +389,7 @@ int main(int argc, char *argv[]) {
 	}
     } // end for rule
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1;
   };

--- a/packages/intrepid/test/Discretization/Integration/test_14.cpp
+++ b/packages/intrepid/test/Discretization/Integration/test_14.cpp
@@ -382,7 +382,7 @@ int main(int argc, char *argv[]) {
 	}
     } // end for rule
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1;
   };

--- a/packages/intrepid/test/Discretization/Integration/test_15.cpp
+++ b/packages/intrepid/test/Discretization/Integration/test_15.cpp
@@ -159,7 +159,7 @@ int main(int argc, char *argv[]) {
       *outStream << "\n";
     } // end for i
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1;
   };

--- a/packages/intrepid/test/Discretization/Integration/test_16.cpp
+++ b/packages/intrepid/test/Discretization/Integration/test_16.cpp
@@ -243,7 +243,7 @@ int main(int argc, char *argv[]) {
       *outStream << "\n";
     } // end for i
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1;
   };

--- a/packages/intrepid/test/Discretization/Integration/test_17.cpp
+++ b/packages/intrepid/test/Discretization/Integration/test_17.cpp
@@ -262,7 +262,7 @@ int main(int argc, char *argv[]) {
       *outStream << std::right << std::setw(104) << "^^^^---FAILURE!\n";
     }
   }
-  catch (std::logic_error err) {    
+  catch (const std::logic_error & err) {    
     *outStream << err.what() << "\n";
     errorFlag = -1;
   };  

--- a/packages/intrepid/test/Discretization/Integration/test_18.cpp
+++ b/packages/intrepid/test/Discretization/Integration/test_18.cpp
@@ -268,7 +268,7 @@ int main(int argc, char *argv[]) {
       *outStream << std::right << std::setw(104) << "^^^^---FAILURE!\n";
     }
   }
-  catch (std::logic_error err) {    
+  catch (const std::logic_error & err) {    
     *outStream << err.what() << "\n";
     errorFlag = -1;
   };  

--- a/packages/intrepid/test/Discretization/Integration/test_19.cpp
+++ b/packages/intrepid/test/Discretization/Integration/test_19.cpp
@@ -299,7 +299,7 @@ int main(int argc, char *argv[]) {
       *outStream << std::right << std::setw(104) << "^^^^---FAILURE!\n";
     }
   }
-  catch (std::logic_error err) {    
+  catch (const std::logic_error & err) {    
     *outStream << err.what() << "\n";
     errorFlag = -1;
   };  

--- a/packages/intrepid/test/Discretization/Integration/test_20.cpp
+++ b/packages/intrepid/test/Discretization/Integration/test_20.cpp
@@ -232,7 +232,7 @@ int main(int argc, char *argv[]) {
       *outStream << std::right << std::setw(104) << "^^^^---FAILURE!\n";
     }
   }
-  catch (std::logic_error err) {    
+  catch (const std::logic_error & err) {    
     *outStream << err.what() << "\n";
     errorFlag = -1;
   };  

--- a/packages/intrepid/test/Discretization/Integration/test_21.cpp
+++ b/packages/intrepid/test/Discretization/Integration/test_21.cpp
@@ -258,7 +258,7 @@ int main(int argc, char *argv[]) {
       } 
     }
   }
-  catch (std::logic_error err) {    
+  catch (const std::logic_error & err) {    
     *outStream << err.what() << "\n";
     errorFlag = -1;
   };  

--- a/packages/intrepid/test/Discretization/Integration/test_22.cpp
+++ b/packages/intrepid/test/Discretization/Integration/test_22.cpp
@@ -244,7 +244,7 @@ int main(int argc, char *argv[]) {
       *outStream << "\n";
     } // end for i
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1;
   };

--- a/packages/intrepid/test/Discretization/Integration/test_23.cpp
+++ b/packages/intrepid/test/Discretization/Integration/test_23.cpp
@@ -299,7 +299,7 @@ int main(int argc, char *argv[]) {
       }
     }
   }
-  catch (std::logic_error err) {    
+  catch (const std::logic_error & err) {    
     *outStream << err.what() << "\n";
     errorFlag = -1;
   };  

--- a/packages/intrepid/test/Discretization/Integration/test_24.cpp
+++ b/packages/intrepid/test/Discretization/Integration/test_24.cpp
@@ -299,7 +299,7 @@ int main(int argc, char *argv[]) {
       }
     } // end for rule
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1;
   };

--- a/packages/intrepid/test/Discretization/Integration/test_25.cpp
+++ b/packages/intrepid/test/Discretization/Integration/test_25.cpp
@@ -296,7 +296,7 @@ int main(int argc, char *argv[]) {
        }
     }
   }
-  catch (std::exception err) {
+  catch (const std::exception & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1;
   }  
@@ -495,7 +495,7 @@ int main(int argc, char *argv[]) {
     }
 
   }
-  catch (std::exception err) {
+  catch (const std::exception & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1;
   }  
@@ -704,7 +704,7 @@ int main(int argc, char *argv[]) {
 
 
   }
-  catch (std::exception err) {
+  catch (const std::exception & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1;
   }  
@@ -909,7 +909,7 @@ int main(int argc, char *argv[]) {
     }
 
   }
-  catch (std::exception err) {
+  catch (const std::exception & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1;
   }  
@@ -958,7 +958,7 @@ int main(int argc, char *argv[]) {
     }
 
   }
-  catch (std::exception err) {
+  catch (const std::exception & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1;
   }  
@@ -1001,7 +1001,7 @@ int main(int argc, char *argv[]) {
     }
 
   }
-  catch (std::exception err) {
+  catch (const std::exception & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1;
   }  
@@ -1049,7 +1049,7 @@ int main(int argc, char *argv[]) {
     }
 
   }
-  catch (std::exception err) {
+  catch (const std::exception & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1;
   }  
@@ -1093,7 +1093,7 @@ int main(int argc, char *argv[]) {
     }
 
   }
-  catch (std::exception err) {
+  catch (const std::exception & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1;
   }  
@@ -1202,7 +1202,7 @@ int main(int argc, char *argv[]) {
     }
 
   }
-  catch (std::exception err) {
+  catch (const std::exception & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1;
   }  
@@ -1302,7 +1302,7 @@ int main(int argc, char *argv[]) {
     }
 
   }
-  catch (std::exception err) {
+  catch (const std::exception & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1;
   }  

--- a/packages/intrepid/test/Discretization/TensorProductSpaceTools/test_01.cpp
+++ b/packages/intrepid/test/Discretization/TensorProductSpaceTools/test_01.cpp
@@ -20,7 +20,7 @@ using Intrepid::TensorBasis;
   try {                                                                                                             \
     S ;                                                                                                             \
   }                                                                                                                 \
-  catch (std::logic_error err) {                                                                                    \
+  catch (const std::logic_error & err) {                                                                                    \
       *outStream << "Expected Error ----------------------------------------------------------------\n";            \
       *outStream << err.what() << '\n';                                                                             \
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";    \

--- a/packages/intrepid/test/Discretization/TensorProductSpaceTools/test_02.cpp
+++ b/packages/intrepid/test/Discretization/TensorProductSpaceTools/test_02.cpp
@@ -64,7 +64,7 @@ using namespace Intrepid;
   try {                                                                                                             \
     S ;                                                                                                             \
   }                                                                                                                 \
-  catch (std::logic_error err) {                                                                                    \
+  catch (const std::logic_error & err) {                                                                                    \
       *outStream << "Expected Error ----------------------------------------------------------------\n";            \
       *outStream << err.what() << '\n';                                                                             \
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";    \
@@ -112,8 +112,6 @@ int main(int argc, char *argv[]) {
   int endThrowNumber = beginThrowNumber + numTotalExceptions;
 #endif
 
-  typedef TensorProductSpaceTools tpst; 
-
   *outStream \
   << "\n"
   << "===============================================================================\n"\
@@ -122,6 +120,8 @@ int main(int argc, char *argv[]) {
 
   try{
 #ifdef HAVE_INTREPID_DEBUG
+    typedef TensorProductSpaceTools tpst;
+
     FieldContainer<double> a_2_2(2,2);
     FieldContainer<double> a_2(2);
     FieldContainer<double> a_4(4);
@@ -158,7 +158,7 @@ int main(int argc, char *argv[]) {
 
 #endif
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";

--- a/packages/intrepid/test/Shared/ArrayTools/test_01.cpp
+++ b/packages/intrepid/test/Shared/ArrayTools/test_01.cpp
@@ -62,7 +62,7 @@ using namespace Intrepid;
   try {                                                                                                             \
     S ;                                                                                                             \
   }                                                                                                                 \
-  catch (std::logic_error err) {                                                                                    \
+  catch (const std::logic_error & err) {                                                                                    \
       *outStream << "Expected Error ----------------------------------------------------------------\n";            \
       *outStream << err.what() << '\n';                                                                             \
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";    \
@@ -281,7 +281,7 @@ int main(int argc, char *argv[]) {
 #endif
 
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -714,7 +714,7 @@ int main(int argc, char *argv[]) {
       /******************************************/
       *outStream << "\n";
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";

--- a/packages/intrepid/test/Shared/ArrayTools/test_01_kokkos.cpp
+++ b/packages/intrepid/test/Shared/ArrayTools/test_01_kokkos.cpp
@@ -63,7 +63,7 @@ using namespace Intrepid;
   try {                                                                                                             \
     S ;                                                                                                             \
   }                                                                                                                 \
-  catch (std::logic_error err) {                                                                                    \
+  catch (const std::logic_error & err) {                                                                                    \
       *outStream << "Expected Error ----------------------------------------------------------------\n";            \
       *outStream << err.what() << '\n';                                                                             \
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";    \
@@ -281,7 +281,7 @@ int main(int argc, char *argv[]) {
 #endif
 
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -775,7 +775,7 @@ int main(int argc, char *argv[]) {
       /******************************************/
       *outStream << "\n";
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";

--- a/packages/intrepid/test/Shared/ArrayTools/test_02.cpp
+++ b/packages/intrepid/test/Shared/ArrayTools/test_02.cpp
@@ -62,7 +62,7 @@ using namespace Intrepid;
   try {                                                                                                             \
     S ;                                                                                                             \
   }                                                                                                                 \
-  catch (std::logic_error err) {                                                                                    \
+  catch (const std::logic_error & err) {                                                                                    \
       *outStream << "Expected Error ----------------------------------------------------------------\n";            \
       *outStream << err.what() << '\n';                                                                             \
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";    \
@@ -214,7 +214,7 @@ int main(int argc, char *argv[]) {
 #endif
 
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -1037,7 +1037,7 @@ int main(int argc, char *argv[]) {
       /******************************************/
       *outStream << "\n";
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";

--- a/packages/intrepid/test/Shared/ArrayTools/test_02_kokkos.cpp
+++ b/packages/intrepid/test/Shared/ArrayTools/test_02_kokkos.cpp
@@ -62,7 +62,7 @@ using namespace Intrepid;
   try {                                                                                                             \
     S ;                                                                                                             \
   }                                                                                                                 \
-  catch (std::logic_error err) {                                                                                    \
+  catch (const std::logic_error & err) {                                                                                    \
       *outStream << "Expected Error ----------------------------------------------------------------\n";            \
       *outStream << err.what() << '\n';                                                                             \
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";    \
@@ -212,7 +212,7 @@ int main(int argc, char *argv[]) {
 #endif
 
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -1183,7 +1183,7 @@ int main(int argc, char *argv[]) {
       /******************************************/
       *outStream << "\n";
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";

--- a/packages/intrepid/test/Shared/ArrayTools/test_03.cpp
+++ b/packages/intrepid/test/Shared/ArrayTools/test_03.cpp
@@ -62,7 +62,7 @@ using namespace Intrepid;
   try {                                                                                                             \
     S ;                                                                                                             \
   }                                                                                                                 \
-  catch (std::logic_error err) {                                                                                    \
+  catch (const std::logic_error & err) {                                                                                    \
       *outStream << "Expected Error ----------------------------------------------------------------\n";            \
       *outStream << err.what() << '\n';                                                                             \
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";    \
@@ -203,7 +203,7 @@ int main(int argc, char *argv[]) {
 #endif
 
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -600,7 +600,7 @@ int main(int argc, char *argv[]) {
       /******************************************/
       *outStream << "\n";
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";

--- a/packages/intrepid/test/Shared/ArrayTools/test_03_kokkos.cpp
+++ b/packages/intrepid/test/Shared/ArrayTools/test_03_kokkos.cpp
@@ -63,7 +63,7 @@ using namespace Intrepid;
   try {                                                                                                             \
     S ;                                                                                                             \
   }                                                                                                                 \
-  catch (std::logic_error err) {                                                                                    \
+  catch (const std::logic_error & err) {                                                                                    \
       *outStream << "Expected Error ----------------------------------------------------------------\n";            \
       *outStream << err.what() << '\n';                                                                             \
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";    \
@@ -202,7 +202,7 @@ int main(int argc, char *argv[]) {
 #endif
 
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -704,7 +704,7 @@ int main(int argc, char *argv[]) {
       /******************************************/
       *outStream << "\n";
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";

--- a/packages/intrepid/test/Shared/ArrayTools/test_04.cpp
+++ b/packages/intrepid/test/Shared/ArrayTools/test_04.cpp
@@ -61,7 +61,7 @@ using namespace Intrepid;
   try {                                                                                                             \
     S ;                                                                                                             \
   }                                                                                                                 \
-  catch (std::logic_error err) {                                                                                    \
+  catch (const std::logic_error & err) {                                                                                    \
       *outStream << "Expected Error ----------------------------------------------------------------\n";            \
       *outStream << err.what() << '\n';                                                                             \
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";    \
@@ -649,7 +649,7 @@ int main(int argc, char *argv[]) {
    INTREPID_TEST_COMMAND(atools.matmatProductDataData<double>(fc_C_P_D3_D3, fc_C_P_D3_D3,  fc_P1_D3_D3) );
   }  
 
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -3200,7 +3200,7 @@ int main(int argc, char *argv[]) {
     *                                      Finish test                                             *
     ************************************************************************************************/
   
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";

--- a/packages/intrepid/test/Shared/ArrayTools/test_04_kokkos.cpp
+++ b/packages/intrepid/test/Shared/ArrayTools/test_04_kokkos.cpp
@@ -62,7 +62,7 @@ using namespace Intrepid;
   try {                                                                                                             \
     S ;                                                                                                             \
   }                                                                                                                 \
-  catch (std::logic_error err) {                                                                                    \
+  catch (const std::logic_error & err) {                                                                                    \
       *outStream << "Expected Error ----------------------------------------------------------------\n";            \
       *outStream << err.what() << '\n';                                                                             \
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";    \
@@ -647,7 +647,7 @@ int main(int argc, char *argv[]) {
    INTREPID_TEST_COMMAND(atools.matmatProductDataData<double>(fc_C_P_D3_D3, fc_C_P_D3_D3,  fc_P1_D3_D3) );
   }  
 
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -3472,7 +3472,7 @@ RealSpaceTools<double>::transpose(datainvtrn_c_p_d_d, datainv_c_p_d_d);
     *                                      Finish test                                             *
     ************************************************************************************************/
   
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";

--- a/packages/intrepid/test/Shared/ArrayTools/test_05.cpp
+++ b/packages/intrepid/test/Shared/ArrayTools/test_05.cpp
@@ -62,7 +62,7 @@ using namespace Intrepid;
   try {                                                                                                             \
     S ;                                                                                                             \
   }                                                                                                                 \
-  catch (std::logic_error err) {                                                                                    \
+  catch (const std::logic_error & err) {                                                                                    \
       *outStream << "Expected Error ----------------------------------------------------------------\n";            \
       *outStream << err.what() << '\n';                                                                             \
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";    \
@@ -176,7 +176,7 @@ int main(int argc, char *argv[]) {
 #endif
 
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -390,7 +390,7 @@ int main(int argc, char *argv[]) {
       /******************************************/
       *outStream << "\n";
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";

--- a/packages/intrepid/test/Shared/ArrayTools/test_05_kokkos.cpp
+++ b/packages/intrepid/test/Shared/ArrayTools/test_05_kokkos.cpp
@@ -62,7 +62,7 @@ using namespace Intrepid;
   try {                                                                                                             \
     S ;                                                                                                             \
   }                                                                                                                 \
-  catch (std::logic_error err) {                                                                                    \
+  catch (const std::logic_error & err) {                                                                                    \
       *outStream << "Expected Error ----------------------------------------------------------------\n";            \
       *outStream << err.what() << '\n';                                                                             \
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";    \
@@ -177,7 +177,7 @@ Kokkos::initialize();
 #endif
 
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -477,7 +477,7 @@ Kokkos::initialize();
       /******************************************/
       *outStream << "\n";
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";

--- a/packages/intrepid/test/Shared/FieldContainer/test_01.cpp
+++ b/packages/intrepid/test/Shared/FieldContainer/test_01.cpp
@@ -286,7 +286,7 @@ int main(int argc, char *argv[]) {
     }
   } //try 
   
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1000;
   };
@@ -479,7 +479,7 @@ int main(int argc, char *argv[]) {
     }
   } //try 
   
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1000;
   };
@@ -681,7 +681,7 @@ int main(int argc, char *argv[]) {
     }
   } //try 
   
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1000;
   };
@@ -891,7 +891,7 @@ int main(int argc, char *argv[]) {
     }
   } //try 
   
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1000;
   };
@@ -1108,7 +1108,7 @@ int main(int argc, char *argv[]) {
     }
   } //try 
   
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1000;
   };
@@ -1141,7 +1141,7 @@ int main(int argc, char *argv[]) {
     }
   }// try
     
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << err.what() << "\n";
       errorFlag = -1000;
     };

--- a/packages/intrepid/test/Shared/FieldContainer/test_02.cpp
+++ b/packages/intrepid/test/Shared/FieldContainer/test_02.cpp
@@ -138,7 +138,7 @@ int main(int argc, char *argv[]) {
       multiIndex[4] = 6;
       myContainer.getEnumeration(multiIndex);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream  << err.what() << "\n";
     };
     
@@ -157,7 +157,7 @@ int main(int argc, char *argv[]) {
       multiIndex[3] = 2;
       myContainer.getEnumeration(multiIndex);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream  << err.what() << "\n";
     };
     
@@ -192,7 +192,7 @@ int main(int argc, char *argv[]) {
       // Now try to stuff this data into FieldContainer
       myContainer.setValues(dataTeuchosArray);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream  << err.what() << "\n";
     };
     
@@ -229,7 +229,7 @@ int main(int argc, char *argv[]) {
       // Now try to stuff this data into FieldContainer
       myContainer.setValues(dataTeuchosArray());
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream  << err.what() << "\n";
     };
     
@@ -243,7 +243,7 @@ int main(int argc, char *argv[]) {
       << " Trying to use [] with enumeration that is out of range: \n";
       myContainer[1000];
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream  << err.what() << "\n";
     }
     
@@ -257,7 +257,7 @@ int main(int argc, char *argv[]) {
       << " Trying to get multi-index from enumeration that is out of bounds: \n";
       myContainer.getMultiIndex(multiIndex,10000);
     }
-    catch(std::logic_error err) {
+    catch (const std::logic_error & err) {
      *outStream << err.what() << "\n";
     }
     
@@ -271,7 +271,7 @@ int main(int argc, char *argv[]) {
       << " Trying to self-assign FieldContainer \n";
       myContainer = myContainer;
     }
-    catch(std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << err.what() << "\n"; 
     }
 
@@ -286,7 +286,7 @@ int main(int argc, char *argv[]) {
       << " using a method for rank-2 container \n";
       rank1Container.getEnumeration(1,1); 
     }
-    catch(std::logic_error err){
+    catch (const std::logic_error & err){
       *outStream << err.what() << "\n";
     }
     
@@ -297,7 +297,7 @@ int main(int argc, char *argv[]) {
       << " using a method for rank-3 container \n";
       rank1Container.getEnumeration(1,1,1); 
     }
-    catch(std::logic_error err){
+    catch (const std::logic_error & err){
       *outStream << err.what() << "\n";
     }
     
@@ -308,7 +308,7 @@ int main(int argc, char *argv[]) {
       << " using a method for rank-4 container \n";
       rank1Container.getEnumeration(1,1,1,1); 
     }
-    catch(std::logic_error err){
+    catch (const std::logic_error & err){
       *outStream << err.what() << "\n";
     }
     
@@ -319,7 +319,7 @@ int main(int argc, char *argv[]) {
       << " using a method for rank-5 container \n";
       rank1Container.getEnumeration(1,1,1,1,1); 
     }
-    catch(std::logic_error err){
+    catch (const std::logic_error & err){
       *outStream << err.what() << "\n";
     }
     
@@ -331,7 +331,7 @@ int main(int argc, char *argv[]) {
       int i0;
       rank1Container.getMultiIndex(i0,4); 
     }
-    catch(std::logic_error err){
+    catch (const std::logic_error & err){
       *outStream << err.what() << "\n";
     }
     
@@ -343,7 +343,7 @@ int main(int argc, char *argv[]) {
       int i0,i1;
       rank1Container.getMultiIndex(i0,i1,2); 
     }
-    catch(std::logic_error err){
+    catch (const std::logic_error & err){
       *outStream << err.what() << "\n";
     }
     
@@ -355,7 +355,7 @@ int main(int argc, char *argv[]) {
       int i0,i1,i2;
       rank1Container.getMultiIndex(i0,i1,i2,2); 
     }
-    catch(std::logic_error err){
+    catch (const std::logic_error & err){
       *outStream << err.what() << "\n";
     }
     
@@ -368,7 +368,7 @@ int main(int argc, char *argv[]) {
       int i0,i1,i2,i3;
       rank1Container.getMultiIndex(i0,i1,i2,i3,2); 
     }
-    catch(std::logic_error err){
+    catch (const std::logic_error & err){
       *outStream << err.what() << "\n";
     }
     
@@ -381,7 +381,7 @@ int main(int argc, char *argv[]) {
       int i0,i1,i2,i3,i4;
       rank1Container.getMultiIndex(i0,i1,i2,i3,i4,2); 
     }
-    catch(std::logic_error err){
+    catch (const std::logic_error & err){
       *outStream << err.what() << "\n";
     }
     
@@ -392,7 +392,7 @@ int main(int argc, char *argv[]) {
       
     }
   } // outer try block
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream  << err.what() << "\n";
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";

--- a/packages/intrepid/test/Shared/FieldContainer/test_03.cpp
+++ b/packages/intrepid/test/Shared/FieldContainer/test_03.cpp
@@ -74,7 +74,7 @@ SHARDS_ARRAY_DIM_TAG_SIMPLE_IMPLEMENTATION( Dim )
   try {                                                                                                             \
     S ;                                                                                                             \
   }                                                                                                                 \
-  catch (std::logic_error err) {                                                                                    \
+  catch (const std::logic_error & err) {                                                                                    \
       *outStream << "Expected Error ----------------------------------------------------------------\n";            \
       *outStream << err.what() << '\n';                                                                             \
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";    \
@@ -375,7 +375,7 @@ int main(int argc, char *argv[]) {
 
 
   } // outer try block
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream  << err.what() << "\n";
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";

--- a/packages/intrepid/test/Shared/IntrepidBurkardtRules/test_01.cpp
+++ b/packages/intrepid/test/Shared/IntrepidBurkardtRules/test_01.cpp
@@ -68,7 +68,7 @@ using namespace Intrepid;
   try {                                                                                                             \
     S ;                                                                                                             \
   }                                                                                                                 \
-  catch (std::logic_error err) {                                                                                    \
+  catch (const std::logic_error & err) {                                                                                    \
       *outStream << "Expected Error ----------------------------------------------------------------\n";            \
       *outStream << err.what() << '\n';                                                                             \
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";    \
@@ -432,7 +432,7 @@ int main(int argc, char *argv[]) {
     }
     *outStream << "\n";
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << err.what() << "\n";
     errorFlag = -1;
   };

--- a/packages/intrepid/test/Shared/IntrepidPolylib/test_01.cpp
+++ b/packages/intrepid/test/Shared/IntrepidPolylib/test_01.cpp
@@ -81,7 +81,7 @@ using namespace Intrepid;
   try {                                                                                                             \
     S ;                                                                                                             \
   }                                                                                                                 \
-  catch (std::logic_error err) {                                                                                    \
+  catch (const std::logic_error & err) {                                                                                    \
       *outStream << "Expected Error ----------------------------------------------------------------\n";            \
       *outStream << err.what() << '\n';                                                                             \
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";    \
@@ -240,7 +240,7 @@ int main(int argc, char *argv[]) {
   try{
     INTREPID_TEST_COMMAND( iplib.gammaF((double)0.33) );
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -656,7 +656,7 @@ int main(int argc, char *argv[]) {
       /******************************************/
       *outStream << "\n";
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";

--- a/packages/intrepid/test/Shared/PointTools/test_01.cpp
+++ b/packages/intrepid/test/Shared/PointTools/test_01.cpp
@@ -62,7 +62,7 @@ using namespace Intrepid;
   try {                                                                                                                    \
     S ;                                                                                                                    \
   }                                                                                                                        \
-  catch (std::logic_error err) {                                                                                           \
+  catch (const std::logic_error & err) {                                                                                           \
       ++throwCounter;                                                                                                      \
       *outStream << "Expected Error " << nException << " -------------------------------------------------------------\n"; \
       *outStream << err.what() << '\n';                                                                                    \
@@ -188,14 +188,14 @@ int main(int argc, char *argv[]) {
     try {
       PointTools::getLatticeSize( shards::getCellTopologyData< shards::Quadrilateral<4> >() , 3 , 0 );
     }
-    catch (std::invalid_argument err) {
+    catch (const std::invalid_argument & err) {
       *outStream << err.what() << "\n";
     }
 
     try {
       PointTools::getLatticeSize( shards::getCellTopologyData< shards::Hexahedron<8> >() , 3 , 0 );
     }
-    catch (std::invalid_argument err) {
+    catch (const std::invalid_argument & err) {
       *outStream << err.what() << "\n";
     }
   }
@@ -220,7 +220,7 @@ int main(int argc, char *argv[]) {
       FieldContainer<double> pts(3,1);
       PointTools::getLatticeSize( shards::getCellTopologyData< shards::Line<2> >() , 5 , 0 );
     }
-    catch (std::invalid_argument err) {
+    catch (const std::invalid_argument & err) {
       *outStream << err.what() << "\n";
     }
     // line: wrong dimension for points
@@ -228,7 +228,7 @@ int main(int argc, char *argv[]) {
       FieldContainer<double> pts(6,2);
       PointTools::getLatticeSize( shards::getCellTopologyData< shards::Line<2> >() , 5 , 0 );
     }
-    catch (std::invalid_argument err) {
+    catch (const std::invalid_argument & err) {
       *outStream << err.what() << "\n";
     }
     // triangle: too many points allocated
@@ -236,7 +236,7 @@ int main(int argc, char *argv[]) {
       FieldContainer<double> pts(4,2);
       PointTools::getLatticeSize( shards::getCellTopologyData< shards::Triangle<3> >() , 3 , 1 );
     }
-    catch (std::invalid_argument err) {
+    catch (const std::invalid_argument & err) {
       *outStream << err.what() << "\n";
     }
     // triangle: wrong dimension for points
@@ -244,7 +244,7 @@ int main(int argc, char *argv[]) {
       FieldContainer<double> pts(6,1);
       PointTools::getLatticeSize( shards::getCellTopologyData< shards::Triangle<3> >() , 3 , 0 );
     }
-    catch (std::invalid_argument err) {
+    catch (const std::invalid_argument & err) {
       *outStream << err.what() << "\n";
     }
     // tetrahedron: not enough points allocated
@@ -252,7 +252,7 @@ int main(int argc, char *argv[]) {
       FieldContainer<double> pts(4,2);
       PointTools::getLatticeSize( shards::getCellTopologyData< shards::Tetrahedron<4> >() , 2 , 0 );
     }
-    catch (std::invalid_argument err) {
+    catch (const std::invalid_argument & err) {
       *outStream << err.what() << "\n";
     }
     // tetrahedron: wrong dimension for points
@@ -260,7 +260,7 @@ int main(int argc, char *argv[]) {
       FieldContainer<double> pts(4,2);
       PointTools::getLatticeSize( shards::getCellTopologyData< shards::Tetrahedron<4> >() , 1 , 0 );
     }
-    catch (std::invalid_argument err) {
+    catch (const std::invalid_argument & err) {
       *outStream << err.what() << "\n";
     }
 

--- a/packages/intrepid/test/Shared/RealSpaceTools/test_01.cpp
+++ b/packages/intrepid/test/Shared/RealSpaceTools/test_01.cpp
@@ -127,7 +127,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::vectorNorm(a_2_2, NORM_TWO);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -135,7 +135,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::vectorNorm(a_10_2_2, a_10_2_2, NORM_TWO);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -143,7 +143,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::vectorNorm(a_10_2_2, a_10_2_2_3, NORM_TWO);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -151,7 +151,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::vectorNorm(a_10_3, a_10_2_2, NORM_TWO);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -162,7 +162,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::add(a_10_2_2, a_10_2, a_2_2);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -170,7 +170,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::add(a_10_2_3, a_10_2_2, a_10_2_2);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -178,7 +178,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::add(a_10_2_2, a_10_2_2_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -186,7 +186,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::add(a_10_2_3, a_10_2_2);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -197,7 +197,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::subtract(a_10_2_2, a_10_2, a_2_2);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -205,7 +205,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::subtract(a_10_2_3, a_10_2_2, a_10_2_2);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -213,7 +213,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::subtract(a_10_2_2, a_10_2_2_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -221,7 +221,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::subtract(a_10_2_3, a_10_2_2);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -232,7 +232,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::dot(a_10_2, a_10_2_2_3, a_10_2_2_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -240,7 +240,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::dot(a_10_2, a_10_2_2, a_10_2_2_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -248,7 +248,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::dot(a_10_2_2, a_10_2_2_3, a_10_2_2_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -256,7 +256,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::dot(a_10_2, a_10_2_2, a_10_2_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -264,7 +264,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::dot(a_10_3, a_10_2_3, a_10_2_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -275,7 +275,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::absval(a_10_3, a_10_2_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -283,7 +283,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::absval(a_10_2_2, a_10_2_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -291,7 +291,7 @@ int main(int argc, char *argv[]) {
 #endif
 
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -348,7 +348,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::inverse(a_2_2, a_10_2_2);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -356,7 +356,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::inverse(b_10_1_2_3_4, a_10_1_2_3_4);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -364,7 +364,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::inverse(b_10, a_10);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -372,7 +372,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::inverse(a_10_2_2, a_10_2_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -380,7 +380,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::inverse(b_10_2_3, a_10_2_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -388,7 +388,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::inverse(b_10_15_4_4, a_10_15_4_4);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -396,7 +396,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::inverse(b_1_1, a_1_1);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -404,7 +404,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::inverse(b_2_2, a_2_2);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -412,7 +412,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::inverse(b_3_3, a_3_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -422,7 +422,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::inverse(b_2_2, a_2_2);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -430,7 +430,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::inverse(b_3_3, a_3_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -441,7 +441,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::transpose(a_2_2, a_10_2_2);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -449,7 +449,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::transpose(b_10_1_2_3_4, a_10_1_2_3_4);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -457,7 +457,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::transpose(b_10, a_10);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -465,7 +465,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::transpose(a_10_2_2, a_10_2_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -473,7 +473,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::transpose(b_10_2_3, a_10_2_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -484,7 +484,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::det(a_2_2, a_10_2_2);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -492,7 +492,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::det(a_10_2_2, a_10_1_2_3_4);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -500,7 +500,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::det(b_10_14, a_10_15_3_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -508,7 +508,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::det(a_9, a_10_2_2);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -516,7 +516,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::det(b_10, a_10_2_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -524,7 +524,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::det(b_10_15, a_10_15_4_4);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -532,7 +532,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::det(a_10_15_4_4);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -540,7 +540,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::det(a_2_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -548,7 +548,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::det(a_4_4);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -559,7 +559,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::matvec(a_10_2_2, a_10_2_3, b_10_2_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -567,7 +567,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::matvec(a_2_2, a_2_2, a_10);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -575,7 +575,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::matvec(a_9, a_10_2_2, a_2_2);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -583,7 +583,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::matvec(b_10_15_3, a_10_15_3_3, b_10_14_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -591,7 +591,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::matvec(b_10_14_3, a_10_15_3_3, b_10_15_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -599,7 +599,7 @@ int main(int argc, char *argv[]) {
     try {
       rst::matvec(b_10_15_3, a_10_15_3_2, b_10_15_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -608,7 +608,7 @@ int main(int argc, char *argv[]) {
 #endif
 
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -985,7 +985,7 @@ int main(int argc, char *argv[]) {
       *outStream << "\n";
     }
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";

--- a/packages/intrepid/test/Shared/RealSpaceTools/test_01_kokkos.cpp
+++ b/packages/intrepid/test/Shared/RealSpaceTools/test_01_kokkos.cpp
@@ -128,7 +128,7 @@ Kokkos::initialize();
     try {
       rst::vectorNorm(a_2_2, NORM_TWO);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -136,7 +136,7 @@ Kokkos::initialize();
     try {
       rst::vectorNorm(a_10_2_2, a_10_2_2, NORM_TWO);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -144,7 +144,7 @@ Kokkos::initialize();
     try {
       rst::vectorNorm(a_10_2_2, a_10_2_2_3, NORM_TWO);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -152,7 +152,7 @@ Kokkos::initialize();
     try {
       rst::vectorNorm(a_10_3, a_10_2_2, NORM_TWO);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -163,7 +163,7 @@ Kokkos::initialize();
     try {
       rst::add(a_10_2_2, a_10_2, a_2_2);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -171,7 +171,7 @@ Kokkos::initialize();
     try {
       rst::add(a_10_2_3, a_10_2_2, a_10_2_2);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -179,7 +179,7 @@ Kokkos::initialize();
     try {
       rst::add(a_10_2_2, a_10_2_2_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -187,7 +187,7 @@ Kokkos::initialize();
     try {
       rst::add(a_10_2_3, a_10_2_2);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -198,7 +198,7 @@ Kokkos::initialize();
     try {
       rst::subtract(a_10_2_2, a_10_2, a_2_2);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -206,7 +206,7 @@ Kokkos::initialize();
     try {
       rst::subtract(a_10_2_3, a_10_2_2, a_10_2_2);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -214,7 +214,7 @@ Kokkos::initialize();
     try {
       rst::subtract(a_10_2_2, a_10_2_2_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -222,7 +222,7 @@ Kokkos::initialize();
     try {
       rst::subtract(a_10_2_3, a_10_2_2);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -233,7 +233,7 @@ Kokkos::initialize();
     try {
       rst::dot(a_10_2, a_10_2_2_3, a_10_2_2_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -241,7 +241,7 @@ Kokkos::initialize();
     try {
       rst::dot(a_10_2, a_10_2_2, a_10_2_2_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -249,7 +249,7 @@ Kokkos::initialize();
     try {
       rst::dot(a_10_2_2, a_10_2_2_3, a_10_2_2_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -257,7 +257,7 @@ Kokkos::initialize();
     try {
       rst::dot(a_10_2, a_10_2_2, a_10_2_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -265,7 +265,7 @@ Kokkos::initialize();
     try {
       rst::dot(a_10_3, a_10_2_3, a_10_2_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -276,7 +276,7 @@ Kokkos::initialize();
     try {
       rst::absval(a_10_3, a_10_2_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -284,7 +284,7 @@ Kokkos::initialize();
     try {
       rst::absval(a_10_2_2, a_10_2_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -292,7 +292,7 @@ Kokkos::initialize();
 #endif
 
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -348,7 +348,7 @@ Kokkos::initialize();
     try {
       rst::inverse(a_2_2, a_10_2_2);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -356,7 +356,7 @@ Kokkos::initialize();
     try {
       rst::inverse(b_10_1_2_3_4, a_10_1_2_3_4);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -364,7 +364,7 @@ Kokkos::initialize();
     try {
       rst::inverse(b_10, a_10);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -372,7 +372,7 @@ Kokkos::initialize();
     try {
       rst::inverse(a_10_2_2, a_10_2_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -380,7 +380,7 @@ Kokkos::initialize();
     try {
       rst::inverse(b_10_2_3, a_10_2_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -388,7 +388,7 @@ Kokkos::initialize();
     try {
       rst::inverse(b_10_15_4_4, a_10_15_4_4);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -396,7 +396,7 @@ Kokkos::initialize();
     try {
       rst::inverse(b_1_1, a_1_1);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -404,7 +404,7 @@ Kokkos::initialize();
     try {
       rst::inverse(b_2_2, a_2_2);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -412,7 +412,7 @@ Kokkos::initialize();
     try {
       rst::inverse(b_3_3, a_3_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -422,7 +422,7 @@ Kokkos::initialize();
     try {
       rst::inverse(b_2_2, a_2_2);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -430,7 +430,7 @@ Kokkos::initialize();
     try {
       rst::inverse(b_3_3, a_3_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -441,7 +441,7 @@ Kokkos::initialize();
     try {
       rst::transpose(a_2_2, a_10_2_2);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -449,7 +449,7 @@ Kokkos::initialize();
     try {
       rst::transpose(b_10_1_2_3_4, a_10_1_2_3_4);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -457,7 +457,7 @@ Kokkos::initialize();
     try {
       rst::transpose(b_10, a_10);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -465,7 +465,7 @@ Kokkos::initialize();
     try {
       rst::transpose(a_10_2_2, a_10_2_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -473,7 +473,7 @@ Kokkos::initialize();
     try {
       rst::transpose(b_10_2_3, a_10_2_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -484,7 +484,7 @@ Kokkos::initialize();
     try {
       rst::det(a_2_2, a_10_2_2);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -492,7 +492,7 @@ Kokkos::initialize();
     try {
       rst::det(a_10_2_2, a_10_1_2_3_4);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -500,7 +500,7 @@ Kokkos::initialize();
     try {
       rst::det(b_10_14, a_10_15_3_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -508,7 +508,7 @@ Kokkos::initialize();
     try {
       rst::det(a_9, a_10_2_2);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -516,7 +516,7 @@ Kokkos::initialize();
     try {
       rst::det(b_10, a_10_2_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -524,7 +524,7 @@ Kokkos::initialize();
     try {
       rst::det(b_10_15, a_10_15_4_4);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -532,7 +532,7 @@ Kokkos::initialize();
     try {
       rst::det(a_10_15_4_4);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -540,7 +540,7 @@ Kokkos::initialize();
     try {
       rst::det(a_2_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -548,7 +548,7 @@ Kokkos::initialize();
     try {
       rst::det(a_4_4);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -559,7 +559,7 @@ Kokkos::initialize();
     try {
       rst::matvec(a_10_2_2, a_10_2_3, b_10_2_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -567,7 +567,7 @@ Kokkos::initialize();
     try {
       rst::matvec(a_2_2, a_2_2, a_10);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -575,7 +575,7 @@ Kokkos::initialize();
     try {
       rst::matvec(a_9, a_10_2_2, a_2_2);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -583,7 +583,7 @@ Kokkos::initialize();
     try {
       rst::matvec(b_10_15_3, a_10_15_3_3, b_10_14_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -591,7 +591,7 @@ Kokkos::initialize();
     try {
       rst::matvec(b_10_14_3, a_10_15_3_3, b_10_15_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -599,7 +599,7 @@ Kokkos::initialize();
     try {
       rst::matvec(b_10_15_3, a_10_15_3_2, b_10_15_3);
     }
-    catch (std::logic_error err) {
+    catch (const std::logic_error & err) {
       *outStream << "Expected Error ----------------------------------------------------------------\n";
       *outStream << err.what() << '\n';
       *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -608,7 +608,7 @@ Kokkos::initialize();
 #endif
 
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";
@@ -1028,7 +1028,7 @@ Kokkos::initialize();
       *outStream << "\n";
     }
   }
-  catch (std::logic_error err) {
+  catch (const std::logic_error & err) {
     *outStream << "UNEXPECTED ERROR !!! ----------------------------------------------------------\n";
     *outStream << err.what() << '\n';
     *outStream << "-------------------------------------------------------------------------------" << "\n\n";


### PR DESCRIPTION
@trilinos/intrepid 

@mperego please look at this a bit, I don't think that any of these changes are dangerous but you might want to double check

## Motivation
Mainly replacing the catch mechanism for error, catch by const expression instead of catching by value. This work helps setting a gcc/8.3.0 PR autotester build.

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of #6295 
* Composed of 

## Stakeholder Feedback
@ZUUL42 feel free to retest and let us know if there are more warnings to take care of?

## Testing
The branch builds locally using gcc/8.3.0 without generating warnings