### PR TITLE
ATDM: Promote new cts1 intel-19 builds to ATDM CDAsh group (ATDV-281)

### DIFF
--- a/cmake/ctest/drivers/atdm/cts1/drivers/Trilinos-atdm-cts1-intel-19.0.5_openmpi-4.0.1_openmp_static_dbg.sh
+++ b/cmake/ctest/drivers/atdm/cts1/drivers/Trilinos-atdm-cts1-intel-19.0.5_openmpi-4.0.1_openmp_static_dbg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #export SLURM_CTEST_TIMEOUT=1:00:00
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=Specialized
+  export Trilinos_TRACK=ATDM
 fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cts1/local-driver.sh

--- a/cmake/ctest/drivers/atdm/cts1/drivers/Trilinos-atdm-cts1-intel-19.0.5_openmpi-4.0.1_openmp_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/cts1/drivers/Trilinos-atdm-cts1-intel-19.0.5_openmpi-4.0.1_openmp_static_opt.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #export SLURM_CTEST_TIMEOUT=1:00:00
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=Specialized
+  export Trilinos_TRACK=ATDM
 fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cts1/local-driver.sh


### PR DESCRIPTION
These replace the old 'serrano' builds that that were removed (but now these builds support SPARC as well).

For all of the resaons to to promote these builds but not the cts1 intel-18 builds see [ATDV-281](https://sems-atlassian-srn.sandia.gov/browse/ATDV-281).
