### PR TITLE
Remove cee-rhel6 openmpi-1.10.2 builds (ATDV-237)

### DIFF
--- a/cmake/ctest/drivers/atdm/cee-rhel6/drivers/Trilinos-atdm-cee-rhel6_clang-5.0.1_openmpi-1.10.2_serial_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/cee-rhel6/drivers/Trilinos-atdm-cee-rhel6_clang-5.0.1_openmpi-1.10.2_serial_static_opt.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-if [ "${Trilinos_TRACK}" == "" ]; then
-  export Trilinos_TRACK=ATDM
-fi
-
-$WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cee-rhel6/local-driver.sh

--- a/cmake/ctest/drivers/atdm/cee-rhel6/drivers/Trilinos-atdm-cee-rhel6_gnu-7.2.0_openmpi-1.10.2_serial_shared_opt.sh
+++ b/cmake/ctest/drivers/atdm/cee-rhel6/drivers/Trilinos-atdm-cee-rhel6_gnu-7.2.0_openmpi-1.10.2_serial_shared_opt.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-export Trilinos_TRACK=ATDM
-$WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/cee-rhel6/local-driver.sh

--- a/cmake/std/atdm/cee-rhel6/all_supported_builds.sh
+++ b/cmake/std/atdm/cee-rhel6/all_supported_builds.sh
@@ -3,9 +3,7 @@
 export ATDM_CONFIG_CTEST_S_BUILD_NAME_PREFIX=Trilinos-atdm-
 
 export ATDM_CONFIG_ALL_SUPPORTED_BUILDS=(
-  cee-rhel6_clang-5.0.1_openmpi-1.10.2_serial_static_opt
   cee-rhel6_clang-5.0.1_openmpi-4.0.1_serial_static_opt    # SPARC CI build
-  cee-rhel6_gnu-7.2.0_openmpi-1.10.2_serial_shared_opt     # SPARC CI build
   cee-rhel6_gnu-7.2.0_openmpi-4.0.1_serial_shared_opt      # SPARC CI build
   cee-rhel6_intel-18.0.2_mpich2-3.2_openmp_static_opt      # SPARC CI build
   cee-rhel6_intel-19.0.3_intelmpi-2018.4_serial_static_opt # SPARC Nightly bulid

--- a/cmake/std/atdm/cee-rhel6/custom_builds.sh
+++ b/cmake/std/atdm/cee-rhel6/custom_builds.sh
@@ -7,31 +7,33 @@
 
 # Custom compiler selection logic
 
-if [[ $ATDM_CONFIG_BUILD_NAME == *"clang-5.0.1-openmpi-4.0.1"* ]] \
-  || [[ $ATDM_CONFIG_BUILD_NAME == *"clang-5.0.1_openmpi-4.0.1"* ]] \
-  ; then
-  export ATDM_CONFIG_COMPILER=CLANG-5.0.1_OPENMPI-4.0.1
-
-elif [[ $ATDM_CONFIG_BUILD_NAME == *"clang-5.0.1-openmpi-1.10.2"* ]] \
+if   [[ $ATDM_CONFIG_BUILD_NAME == *"clang-5.0.1-openmpi-1.10.2"* ]] \
   || [[ $ATDM_CONFIG_BUILD_NAME == *"clang-5.0.1_openmpi-1.10.2"* ]] \
+  ; then
+  export ATDM_CONFIG_COMPILER=CLANG-5.0.1_OPENMPI-1.10.2
+
+elif [[ $ATDM_CONFIG_BUILD_NAME == *"clang-5.0.1-openmpi-4.0.1"* ]] \
+  || [[ $ATDM_CONFIG_BUILD_NAME == *"clang-5.0.1_openmpi-4.0.1"* ]] \
   || [[ $ATDM_CONFIG_BUILD_NAME == *"clang-5.0.1"* ]] \
+  || [[ $ATDM_CONFIG_BUILD_NAME == *"clang-5"* ]] \
   || [[ $ATDM_CONFIG_BUILD_NAME == *"clang"* ]] \
   || [[ $ATDM_CONFIG_BUILD_NAME == *"default" ]] \
   ; then
-  export ATDM_CONFIG_COMPILER=CLANG-5.0.1_OPENMPI-1.10.2
+  export ATDM_CONFIG_COMPILER=CLANG-5.0.1_OPENMPI-4.0.1
   # Must list the default clang build last for correct matching of of defaults
-
-elif [[ $ATDM_CONFIG_BUILD_NAME == *"gnu-7.2.0-openmpi-4.0.1"* ]] \
-  || [[ $ATDM_CONFIG_BUILD_NAME == *"gnu-7.2.0_openmpi-4.0.1"* ]] \
-  ; then
-  export ATDM_CONFIG_COMPILER=GNU-7.2.0_OPENMPI-4.0.1
 
 elif [[ $ATDM_CONFIG_BUILD_NAME == *"gnu-7.2.0-openmpi-1.10.2"* ]] \
   || [[ $ATDM_CONFIG_BUILD_NAME == *"gnu-7.2.0_openmpi-1.10.2"* ]] \
-  || [[ $ATDM_CONFIG_BUILD_NAME == *"gnu-7.2.0"* ]] \
-  || [[ $ATDM_CONFIG_BUILD_NAME == *"gnu"* ]] \
   ; then
   export ATDM_CONFIG_COMPILER=GNU-7.2.0_OPENMPI-1.10.2
+
+elif [[ $ATDM_CONFIG_BUILD_NAME == *"gnu-7.2.0-openmpi-4.0.1"* ]] \
+  || [[ $ATDM_CONFIG_BUILD_NAME == *"gnu-7.2.0_openmpi-4.0.1"* ]] \
+  || [[ $ATDM_CONFIG_BUILD_NAME == *"gnu-7.2.0"* ]] \
+  || [[ $ATDM_CONFIG_BUILD_NAME == *"gnu-7"* ]] \
+  || [[ $ATDM_CONFIG_BUILD_NAME == *"gnu"* ]] \
+  ; then
+  export ATDM_CONFIG_COMPILER=GNU-7.2.0_OPENMPI-4.0.1
   # List default "gnu"* build last for correct matching of defaults
 
 elif [[ $ATDM_CONFIG_BUILD_NAME == *"intel-18.0.2-mpich2-3.2"* ]] \
@@ -57,12 +59,12 @@ else
   echo "***"
   echo "*** Supported compilers include:"
   echo "***"
-  echo "****  clang-5.0.1-openmpi-1.10.2   (default)"
-  echo "****  clang-5.0.1-openmpi-4.0.1"
-  echo "****  gnu-7.2.0-openmpi-1.10.2     (default gnu)"
-  echo "****  gnu-7.2.0-openmpi-4.0.1"
-  echo "****  intel-18.0.2-mpich2-3.2"
-  echo "****  intel-19.0.3-intelmpi-2018.4 (default intel)"
+  echo "****  clang-5.0.1-openmpi-1.10.2     (DEPRECATED)"
+  echo "****  clang-5.0.1-openmpi-4.0.1      (default, default clang)"
+  echo "****  gnu-7.2.0-openmpi-1.10.2       (DEPRECATED)"
+  echo "****  gnu-7.2.0-openmpi-4.0.1        (default gnu)"
+  echo "****  intel-18.0.2-mpich2-3.2        (DEPRECATED)"
+  echo "****  intel-19.0.3-intelmpi-2018.4   (default intel)"
   echo "***"  
   return
 


### PR DESCRIPTION
For motivation, see [ATDV-237](https://sems-atlassian-srn.sandia.gov/browse/ATDV-237).

Actually, I did not fully remove these builds, I just did the following:

* Made the new openmpi-4.0.1 builds the default builds
* Removed openmpi-1.10.2 ctest -S driver scripts
* Removed openmpi-1.10.2 builds from cee-rhel6/all_suupported_builds.sh

This way, developers can still access these old builds if they want but they
will no longer be tested and they will no longer be loaded by developers
unless the specifically put 'openmpi-1.10.2' in the build name.

## How was this tested?

On the CEE RHEL7 machine 'ews000232' I did:

```
$ . cmake/std/atdm/load-env.sh cee-rhel6-default
Hostname 'ews00232' matches known ATDM host 'cee-rhel6' and system 'cee-rhel6'
Setting compiler and build options for build-name 'cee-rhel6-default'
Using CEE RHEL6 compiler stack CLANG-5.0.1_OPENMPI-4.0.1 to build DEBUG code with Kokkos node type SERIAL

$ . cmake/std/atdm/load-env.sh cee-rhel6-clang
Hostname 'ews00232' matches known ATDM host 'cee-rhel6' and system 'cee-rhel6'
Setting compiler and build options for build-name 'cee-rhel6-clang'
Using CEE RHEL6 compiler stack CLANG-5.0.1_OPENMPI-4.0.1 to build DEBUG code with Kokkos node type SERIAL

$ . cmake/std/atdm/load-env.sh cee-rhel6-clang-5
Hostname 'ews00232' matches known ATDM host 'cee-rhel6' and system 'cee-rhel6'
Setting compiler and build options for build-name 'cee-rhel6-clang-5'
Using CEE RHEL6 compiler stack CLANG-5.0.1_OPENMPI-4.0.1 to build DEBUG code with Kokkos node type SERIAL

$ . cmake/std/atdm/load-env.sh cee-rhel6-clang-5.0.1
Hostname 'ews00232' matches known ATDM host 'cee-rhel6' and system 'cee-rhel6'
Setting compiler and build options for build-name 'cee-rhel6-clang-5.0.1'
Using CEE RHEL6 compiler stack CLANG-5.0.1_OPENMPI-4.0.1 to build DEBUG code with Kokkos node type SERIAL

$ . cmake/std/atdm/load-env.sh cee-rhel6-clang-5.0.1-openmpi-4.0.1
Hostname 'ews00232' matches known ATDM host 'cee-rhel6' and system 'cee-rhel6'
Setting compiler and build options for build-name 'cee-rhel6-clang-5.0.1-openmpi-4.0.1'
Using CEE RHEL6 compiler stack CLANG-5.0.1_OPENMPI-4.0.1 to build DEBUG code with Kokkos node type OPENMP

$ . cmake/std/atdm/load-env.sh cee-rhel6-clang-5.0.1-openmpi-1.10.2
Hostname 'ews00232' matches known ATDM host 'cee-rhel6' and system 'cee-rhel6'
Setting compiler and build options for build-name 'cee-rhel6-clang-5.0.1-openmpi-1.10.2'
Using CEE RHEL6 compiler stack CLANG-5.0.1_OPENMPI-1.10.2 to build DEBUG code with Kokkos node type OPENMP

$ . cmake/std/atdm/load-env.sh cee-rhel6-gnu
Hostname 'ews00232' matches known ATDM host 'cee-rhel6' and system 'cee-rhel6'
Setting compiler and build options for build-name 'cee-rhel6-gnu'
Using CEE RHEL6 compiler stack GNU-7.2.0_OPENMPI-4.0.1 to build DEBUG code with Kokkos node type SERIAL

$ . cmake/std/atdm/load-env.sh cee-rhel6-gnu-7
Hostname 'ews00232' matches known ATDM host 'cee-rhel6' and system 'cee-rhel6'
Setting compiler and build options for build-name 'cee-rhel6-gnu-7'
Using CEE RHEL6 compiler stack GNU-7.2.0_OPENMPI-4.0.1 to build DEBUG code with Kokkos node type SERIAL

$ . cmake/std/atdm/load-env.sh cee-rhel6-gnu-7.2.0
Hostname 'ews00232' matches known ATDM host 'cee-rhel6' and system 'cee-rhel6'
Setting compiler and build options for build-name 'cee-rhel6-gnu-7.2.0'
Using CEE RHEL6 compiler stack GNU-7.2.0_OPENMPI-4.0.1 to build DEBUG code with Kokkos node type SERIAL

$ . cmake/std/atdm/load-env.sh cee-rhel6-gnu-7.2.0-openmpi-4.0.1
Hostname 'ews00232' matches known ATDM host 'cee-rhel6' and system 'cee-rhel6'
Setting compiler and build options for build-name 'cee-rhel6-gnu-7.2.0-openmpi-4.0.1'
Using CEE RHEL6 compiler stack GNU-7.2.0_OPENMPI-4.0.1 to build DEBUG code with Kokkos node type OPENMP

$ . cmake/std/atdm/load-env.sh cee-rhel6-gnu-7.2.0-openmpi-1.10.2
Hostname 'ews00232' matches known ATDM host 'cee-rhel6' and system 'cee-rhel6'
Setting compiler and build options for build-name 'cee-rhel6-gnu-7.2.0-openmpi-1.10.2'
Using CEE RHEL6 compiler stack GNU-7.2.0_OPENMPI-1.10.2 to build DEBUG code with Kokkos node type OPENMP
```

That looks like the right logic to me.

