### PR TITLE
ML: fixing warnings for GCC 8.3.0

### DIFF
--- a/packages/ml/src/MLAPI/MLAPI_Workspace.cpp
+++ b/packages/ml/src/MLAPI/MLAPI_Workspace.cpp
@@ -91,7 +91,7 @@ void Init()
 
   char * str = (char *) getenv("ML_BREAK_FOR_DEBUGGER");
   int i = 0, j = 0;
-  char buf[80];
+  char buf[160];
   char go = ' ';
   char hostname[80];
   if (str != NULL) i++;

--- a/packages/ml/src/Utils/ml_MultiLevelPreconditioner.cpp
+++ b/packages/ml/src/Utils/ml_MultiLevelPreconditioner.cpp
@@ -2914,8 +2914,10 @@ SetParameterList(const ParameterList & List)
 int ML_Epetra::MultiLevelPreconditioner::CreateLabel()
 {
 
-  char finest[80];
-  char coarsest[80];
+  char finest[160];
+  char finest_tmp[80];
+  char coarsest[160];
+  char coarsest_tmp[80];
   finest[0] = '\0';
   coarsest[0] = '\0';
   char * label;
@@ -2924,33 +2926,33 @@ int ML_Epetra::MultiLevelPreconditioner::CreateLabel()
 
   if (ml_->pre_smoother[i].smoother->func_ptr != NULL) {
     label = ml_->pre_smoother[i].label;
-    if( strncmp(label,"PreS_",4) == 0 ) sprintf(finest, "%s", "~");
-    else                                sprintf(finest, "%s", label);
-  } else                                sprintf(finest, "%s", "~");
+    if( strncmp(label,"PreS_",4) == 0 ) sprintf(finest_tmp, "%s", "~");
+    else                                sprintf(finest_tmp, "%s", label);
+  } else                                sprintf(finest_tmp, "%s", "~");
 
   if (ml_->post_smoother[i].smoother->func_ptr != NULL) {
     label = ml_->post_smoother[i].label;
-    if( strncmp(label,"PostS_", 5) == 0 ) sprintf(finest, "%s/~", finest);
-    else                                  sprintf(finest, "%s/%s", finest, label);
-  } else                                  sprintf(finest, "%s/~", finest);
+    if( strncmp(label,"PostS_", 5) == 0 ) sprintf(finest,  "%s/~", finest_tmp);
+    else                                  sprintf(finest, "%s/%s", finest_tmp, label);
+  } else                                  sprintf(finest,  "%s/~", finest_tmp);
 
   if (i != ml_->ML_coarsest_level) {
     i = ml_->ML_coarsest_level;
     if ( ML_CSolve_Check( &(ml_->csolve[i]) ) == 1 ) {
-    sprintf(coarsest, "%s", ml_->csolve[i].label);
+    sprintf(coarsest_tmp, "%s", ml_->csolve[i].label);
     }
 
     else {
       if (ml_->pre_smoother[i].smoother->func_ptr != NULL) {
-    label = ml_->pre_smoother[i].label;
-    if( strncmp(label,"PreS_",4) == 0 ) sprintf(coarsest, "%s", "~");
-    else                                sprintf(coarsest, "%s", label);
-      } else                                sprintf(coarsest, "%s", "~");
+        label = ml_->pre_smoother[i].label;
+        if( strncmp(label,"PreS_",4) == 0 ) sprintf(coarsest_tmp, "%s", "~");
+        else                                sprintf(coarsest_tmp, "%s", label);
+      } else                                sprintf(coarsest_tmp, "%s", "~");
       if (ml_->post_smoother[i].smoother->func_ptr != NULL) {
-    label = ml_->post_smoother[i].label;
-    if( strncmp(label,"PostS_", 5) == 0 ) sprintf(coarsest, "%s/~", coarsest);
-    else                                  sprintf(coarsest, "%s/%s",coarsest, label);
-      } else                                  sprintf(coarsest, "%s/~", coarsest);
+        label = ml_->post_smoother[i].label;
+        if( strncmp(label,"PostS_", 5) == 0 ) sprintf(coarsest, "%s/~", coarsest_tmp);
+        else                                  sprintf(coarsest, "%s/%s",coarsest_tmp, label);
+      } else                                  sprintf(coarsest, "%s/~", coarsest_tmp);
     }
   }
 

--- a/packages/ml/src/Utils/ml_epetra_utils.cpp
+++ b/packages/ml/src/Utils/ml_epetra_utils.cpp
@@ -3641,7 +3641,7 @@ void ML_BreakForDebugger(const Epetra_Comm &Comm)
 
   char * str = (char *) getenv("ML_BREAK_FOR_DEBUGGER");
   int i = 0, j = 0;
-  char buf[80];
+  char buf[160];
   char go = ' ';
   char hostname[80];
   if (str != NULL) i++;


### PR DESCRIPTION
@trilinos/ml 
@rstumin @csiefer2 can you double check that the output after the string modification still looks OK?

## Motivation
Remove warning from ML due to string buffer overflow and unsafe use of sprintf

## Related Issues

* Closes 
* Blocks #6295 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 


## Stakeholder Feedback
@ZUUL42 feel free to let us know if this fixes the warning you observe in ML?

## Testing
Local build returns without warning