### PR TITLE
Panzer: swap catch by value with catch by reference for #6295

### DIFF
--- a/packages/panzer/dof-mgr/test/fe_assembly/test_fe_assembly_HEX.hpp
+++ b/packages/panzer/dof-mgr/test/fe_assembly/test_fe_assembly_HEX.hpp
@@ -653,7 +653,7 @@ int feAssemblyHex(int argc, char *argv[]) {
     else {
       *outStream << "Residual l2 norm : " << res_l2_norm << "\n";
     }
-  } catch (std::exception err) {
+  } catch (const std::exception & err) {
     *outStream << " Exception\n";
     *outStream << err.what() << "\n\n";
     errorFlag = -1000;


### PR DESCRIPTION
Small change in the exception catching syntax to avoid gcc 8.3.0 warning


@trilinos/panzer 

## Motivation
This removes a warning associated with exception catching when building with gcc/8.3.0

## Related Issues

* Closes 
* Blocks #6295 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 



## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
Local build shows that the warning goes away after switching to `const reference` instead of catch by value