### PR TITLE
Percept: removing warning related to exception catching see #6295

### DIFF
--- a/packages/percept/src/percept/RunEnvironment.cpp
+++ b/packages/percept/src/percept/RunEnvironment.cpp
@@ -388,7 +388,7 @@ namespace {
           parse_error = false;
           //std::cout << "tmp srk parseReturn = " << parseReturn << std::endl;
         }
-        catch (std::exception exc)
+        catch (const std::exception & exc)
         {
           parse_error = true;
           out << "RunEnvironment::processCLP error, exc= " << exc.what() << std::endl;


### PR DESCRIPTION
@trilinos/percept 

## Motivation
Removing warning for upcoming gcc/8.3.0 build

## Related Issues

* Closes 
* Blocks #6295 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 


## Stakeholder Feedback
@ZUUL42 as usual let me know if this resolves warnings in percept

## Testing
Local build returns without warnings