### PR TITLE
ROL: removing warning due to exception catching by value see #6295

### DIFF
--- a/packages/rol/example/PDE-OPT/TOOLS/solver_def.hpp
+++ b/packages/rol/example/PDE-OPT/TOOLS/solver_def.hpp
@@ -78,7 +78,7 @@ firstSolve_ = true;
       try {
         solver_ = Amesos2::create< Tpetra::CrsMatrix<>,Tpetra::MultiVector<>>(directSolver_, A);
       }
-      catch (std::invalid_argument e) {
+      catch (const std::invalid_argument& e) {
         std::cout << e.what() << std::endl;
       }
       solver_->symbolicFactorization();


### PR DESCRIPTION
Only a tiny change to catch exception by const reference instead of by value.

@trilinos/rol 

## Motivation
This removes a warning issued by gcc/8.3.0

## Related Issues

* Closes 
* Blocks #6295 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 


## Stakeholder Feedback
@dridzal can a ROL developer port this change to the ROL repo?

## Testing
Local build returns warning free