### PR TITLE
Thyra: removing shadowing typedef, see issue #6295

### DIFF
--- a/packages/thyra/core/src/support/operator_vector/client_support/Thyra_MultiVectorStdOpsTester_def.hpp
+++ b/packages/thyra/core/src/support/operator_vector/client_support/Thyra_MultiVectorStdOpsTester_def.hpp
@@ -72,8 +72,7 @@ bool MultiVectorStdOpsTester<Scalar>::checkStdOps(
   using Teuchos::as;
   using Teuchos::ptr;
   using Teuchos::tuple;
-  typedef Teuchos::ScalarTraits<Scalar> ST;
-  typedef typename ST::magnitudeType ScalarMag;
+  using ST = Teuchos::ScalarTraits<Scalar>;
 
   if(out)
     *out << "\n*** Entering MultiVectorStdOpsTester<"<<ST::name()<<">::checkStdOps(...) ...\n"


### PR DESCRIPTION
Removing an unnecessary typedef in Thyra_MultiVectorStdOpsTester_def.hpp as the typedef is already made in Thyra_MultiVectorStdOpsTester_decl.hpp

@trilinos/thyra 

## Motivation
This modification removes a warning in the gcc/8.3.0 build with -Werror for Sierra


## Related Issues

* Closes 
* Blocks #6295 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 


## Stakeholder Feedback
@ZUUL42 one more warning fix

## Testing
Local build with relevant flag and compiler returns without warning