### PR TITLE
Rythmos: removing shadowed type definition, see issue #6295

### DIFF
--- a/packages/rythmos/src/Rythmos_ThetaStepper_def.hpp
+++ b/packages/rythmos/src/Rythmos_ThetaStepper_def.hpp
@@ -566,8 +566,7 @@ Scalar ThetaStepper<Scalar>::takeStep(Scalar dt, StepSizeType stepSizeType)
 
   {
 
-    typedef typename ST::magnitudeType ScalarMag;
-    typedef ScalarTraits<ScalarMag> SMT;
+    using SMT = ScalarTraits<ScalarMag>;
 
     Teuchos::OSTab tab(out);
 


### PR DESCRIPTION
Removing unnecessary type definition in Rythmos_ThetaStepper_def that was already declared in Rythmos_ThetaStepper_decl


@trilinos/rythmos 

## Motivation
This removes a warning from gcc/8.3.0 build with -Werror for Sierra

## Related Issues

* Closes 
* Blocks #6295 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 


## Stakeholder Feedback


## Testing
Local build with gcc/8.3.0 returns warning free