### PR TITLE
Tpetra: Fix export/import to local graph/matrix

### DIFF
--- a/packages/tpetra/core/test/CrsGraph/CrsGraph_StaticImportExport.cpp
+++ b/packages/tpetra/core/test/CrsGraph/CrsGraph_StaticImportExport.cpp
@@ -208,8 +208,112 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(CrsGraph, ImportToStaticGraph, LO, GO, NT)
   }
 }
 
+
+TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(CrsGraph, ImportToStaticGraphLocal, LO, GO, NT)
+{
+  // Set up Tpetra typedefs.
+  using map_type = Tpetra::Map<LO, GO, NT>;
+  using graph_type = Tpetra::CrsGraph<LO, GO, NT>;
+  using device_type = typename NT::device_type;
+  using execution_space = typename device_type::execution_space;
+  const char prefix[] = "ImportToStaticGraphLocal: ";
+
+  Tpetra::Details::Behavior::disable_verbose_behavior();
+
+  auto comm = getDefaultComm();
+  const auto my_rank = comm->getRank();
+
+  auto loc_success = 1; // to be revised below
+  auto gbl_success = 0; // output argument
+
+  // The global number of rows in the matrix A to create.  We scale
+  // this relative to the number of (MPI) processes, so that no matter
+  // how many MPI processes you run, every process will have 10 rows.
+  const Tpetra::global_size_t num_gbl_inds = 10 * comm->getSize();
+  const GO idx_base = 0;
+
+  // Construct a Map that is global, but puts all the equations on MPI Proc 0.
+  RCP<const map_type> proc_zero_map;
+  {
+    const size_t num_loc_inds = (my_rank == 0) ? num_gbl_inds : 0;
+    proc_zero_map = rcp(new map_type(num_gbl_inds, num_loc_inds, idx_base, comm));
+  }
+
+  // Create a sparse graph using procZeroMap.
+  auto A = generate_crs_graph<LO,GO,NT>(proc_zero_map);
+  comm->barrier();
+
+  // We've created a sparse matrix that lives entirely on Process 0.
+  // Now we want to distribute it over all the processes.
+  //
+  // Redistribute the matrix.  Since both the source and target Maps
+  // are one-to-one, we could use either an Import or an Export.  If
+  // only the source Map were one-to-one, we would have to use an
+  // Import; if only the target Map were one-to-one, we would have to
+  // use an Export.  We do not allow redistribution using Import or
+  // Export if neither source nor target Map is one-to-one.
+  RCP<graph_type> B;
+  {
+    using export_type = Tpetra::Export<LO,GO,NT>;
+    export_type exporter(proc_zero_map, proc_zero_map);
+    comm->barrier();
+
+    Tpetra::Details::Behavior::enable_verbose_behavior();
+    // Make a new sparse graph whose row map is the global Map.
+    out << prefix << "Creating empty graph from global map.\n";
+    B = rcp(new graph_type(proc_zero_map, 0, Tpetra::StaticProfile));
+    out << prefix << "Empty graph from proc_zero_map map created.\n";
+
+    // Redistribute the data, NOT in place, from graph A (which lives
+    // entirely on Proc 0) to graph B (which is distributed evenly over
+    // the processes).
+    out << prefix << "Performing export operation\n";
+    B->doExport(*A, exporter, Tpetra::INSERT);
+    out << prefix << "Export operation done.\n";
+  }
+  B->fillComplete();
+
+  auto loc_num_errs = 0;
+
+  // The test below uses the host Tpetra::CrsGraph interface to
+  // compare graph values.  Thus, we need to do a fence before
+  // comparing graph values, in order to ensure that changes made on
+  // device are visible on host.
+  execution_space().fence();
+
+  { // test output
+    std::ostringstream errStrm;
+    TEST_ASSERT(loc_num_errs == 0);
+
+    auto gbl_num_errs = 0;
+    Teuchos::reduceAll<int, int>(*comm,Teuchos::REDUCE_SUM,loc_num_errs,outArg(gbl_num_errs));
+    TEST_EQUALITY_CONST(gbl_num_errs, 0);
+    if (gbl_num_errs != 0) {
+      if (my_rank == 0) {
+        out << "export in to static graph failed with " << gbl_num_errs
+            << " error" << (gbl_num_errs != 1 ? "s" : "") << "!\n";
+      }
+      gathervPrint(out, errStrm.str (), *comm);
+      return; // no point in continuing
+    }
+
+    loc_success = success ? 1 : 0;
+    Teuchos::reduceAll<int,int>(*comm, Teuchos::REDUCE_MIN, loc_success, outArg(gbl_success));
+    TEST_EQUALITY_CONST(gbl_success, 1 );
+    if (gbl_success != 1) {
+      if (my_rank == 0) {
+        out << "export in to static graph comparison claims zero errors, "
+          "but success is false on at least one process!\n";
+      }
+      gathervPrint (out, errStrm.str (), *comm);
+      return; // no point in continuing
+    }
+  }
+}
+
 #define UNIT_TEST_GROUP( LO, GO, NT ) \
-  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT(CrsGraph, ImportToStaticGraph, LO, GO, NT)
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT(CrsGraph, ImportToStaticGraph, LO, GO, NT) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT(CrsGraph, ImportToStaticGraphLocal, LO, GO, NT)
 
 TPETRA_ETI_MANGLING_TYPEDEFS()
 

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_StaticImportExport.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_StaticImportExport.cpp
@@ -211,6 +211,109 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CrsMatrix, ImportToStaticMatrix, SC, LO, GO, N
   }
 }
 
+
+TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CrsMatrix, ImportToStaticMatrixLocal, SC, LO, GO, NT)
+{
+  // Set up Tpetra typedefs.
+  using map_type = Tpetra::Map<LO, GO, NT>;
+  using matrix_type = Tpetra::CrsMatrix<SC, LO, GO, NT>;
+  using device_type = typename NT::device_type;
+  using execution_space = typename device_type::execution_space;
+  const char prefix[] = "ImportToStaticMatrixLocal: ";
+
+  Tpetra::Details::Behavior::disable_verbose_behavior();
+
+  auto comm = getDefaultComm();
+  const auto my_rank = comm->getRank();
+
+  auto loc_success = 1; // to be revised below
+  auto gbl_success = 0; // output argument
+
+  // The global number of rows in the matrix A to create.  We scale
+  // this relative to the number of (MPI) processes, so that no matter
+  // how many MPI processes you run, every process will have 10 rows.
+  const Tpetra::global_size_t num_gbl_inds = 10 * comm->getSize();
+  const GO idx_base = 0;
+
+  // Construct a Map that is global, but puts all the equations on MPI Proc 0.
+  RCP<const map_type> proc_zero_map;
+  {
+    const size_t num_loc_inds = (my_rank == 0) ? num_gbl_inds : 0;
+    proc_zero_map = rcp(new map_type(num_gbl_inds, num_loc_inds, idx_base, comm));
+  }
+
+  // Create a sparse matrix using procZeroMap.
+  auto A = generate_crs_matrix<SC,LO,GO,NT>(proc_zero_map);
+  comm->barrier();
+
+  // We've created a sparse matrix that lives entirely on Process 0.
+  // Now we want to distribute it over all the processes.
+  //
+  // Redistribute the matrix.  Since both the source and target Maps
+  // are one-to-one, we could use either an Import or an Export.  If
+  // only the source Map were one-to-one, we would have to use an
+  // Import; if only the target Map were one-to-one, we would have to
+  // use an Export.  We do not allow redistribution using Import or
+  // Export if neither source nor target Map is one-to-one.
+  RCP<matrix_type> B;
+  {
+    using export_type = Tpetra::Export<LO,GO,NT>;
+    export_type exporter(proc_zero_map, proc_zero_map);
+    comm->barrier();
+
+    Tpetra::Details::Behavior::enable_verbose_behavior();
+    // Make a new sparse matrix whose row map is the global Map.
+    out << prefix << "Creating empty matrix from global map.\n";
+    B = rcp(new matrix_type(proc_zero_map, 0, Tpetra::StaticProfile));
+    out << prefix << "Empty matrix from proc_zero map created.\n";
+
+    // Redistribute the data, NOT in place, from matrix A (which lives
+    // entirely on Proc 0) to matrix B (which is distributed evenly over
+    // the processes).
+    out << prefix << "Performing export operation\n";
+    B->doExport(*A, exporter, Tpetra::INSERT);
+    out << prefix << "Export operation done.\n";
+  }
+  B->fillComplete();
+
+  auto loc_num_errs = 0;
+
+  // The test below uses the host Tpetra::CrsMatrix interface to
+  // compare matrix values.  Thus, we need to do a fence before
+  // comparing matrix values, in order to ensure that changes made on
+  // device are visible on host.
+  execution_space().fence();
+
+  { // test output
+    std::ostringstream errStrm;
+    TEST_ASSERT(loc_num_errs == 0);
+
+    auto gbl_num_errs = 0;
+    Teuchos::reduceAll<int, int>(*comm,Teuchos::REDUCE_SUM,loc_num_errs,outArg(gbl_num_errs));
+    TEST_EQUALITY_CONST(gbl_num_errs, 0);
+    if (gbl_num_errs != 0) {
+      if (my_rank == 0) {
+        out << "export in to static matrix failed with " << gbl_num_errs
+            << " error" << (gbl_num_errs != 1 ? "s" : "") << "!\n";
+      }
+      gathervPrint(out, errStrm.str (), *comm);
+      return; // no point in continuing
+    }
+
+    loc_success = success ? 1 : 0;
+    Teuchos::reduceAll<int,int>(*comm, Teuchos::REDUCE_MIN, loc_success, outArg(gbl_success));
+    TEST_EQUALITY_CONST(gbl_success, 1 );
+    if (gbl_success != 1) {
+      if (my_rank == 0) {
+        out << "export in to static matrix comparison claims zero errors, "
+          "but success is false on at least one process!\n";
+      }
+      gathervPrint (out, errStrm.str (), *comm);
+      return; // no point in continuing
+    }
+  }
+}
+
 #define UNIT_TEST_GROUP( SC, LO, GO, NT ) \
   TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(CrsMatrix, ImportToStaticMatrix, SC, LO, GO, NT)
 

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_StaticImportExport.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_StaticImportExport.cpp
@@ -315,7 +315,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(CrsMatrix, ImportToStaticMatrixLocal, SC, LO, 
 }
 
 #define UNIT_TEST_GROUP( SC, LO, GO, NT ) \
-  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(CrsMatrix, ImportToStaticMatrix, SC, LO, GO, NT)
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(CrsMatrix, ImportToStaticMatrix, SC, LO, GO, NT) \
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(CrsMatrix, ImportToStaticMatrixLocal, SC, LO, GO, NT)
 
 TPETRA_ETI_MANGLING_TYPEDEFS()
 


### PR DESCRIPTION
@mhoemmen reports that certain import/export operations fail during the copy and permute phase.  This PR is an attempt to fix the problem.