### PR TITLE
Teuchos:  allow unit tests to proceed with unrecognized command line arguments

### DIFF
--- a/packages/teuchos/core/src/Teuchos_UnitTestRepository.cpp
+++ b/packages/teuchos/core/src/Teuchos_UnitTestRepository.cpp
@@ -187,7 +187,7 @@ public:
   int testCounter;
 
   InstanceData()
-    :clp(false),
+    :clp(false,false),
      showTestDetails(SHOW_TEST_DETAILS_TEST_NAMES),
 #if defined(HAVE_TEUCHOS_GLOBALLY_REDUCE_UNITTEST_RESULTS)
      globallyReduceUnitTestResult(true),


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/teuchos 

This change allows teuchos' unit test framework to run tests even when they see unrecognized command line arguments.  Unrecognized command line arguments now generate a warning, not an error.

## Motivation

Some platforms (e.g., doom) require command line arguments like --kokkos-ndevices=4 to be specified.  That is,
```
srun --mpi=pmi2 -u -N 1 -n 4 packages/tpetra/core/test/Map/TpetraCore_Map_UnitTests.exe --kokkos-ndevices=4
```
will work but 
```
srun --mpi=pmi2 -u -N 1 -n 4 packages/tpetra/core/test/Map/TpetraCore_Map_UnitTests.exe
```
does not run correctly (problems in MPI).

But Teuchos' unit test framework reported an error and failed when unrecognized command line arguments like --kokkos-ndevices=4 were encountered.

This change allows the test framework to run and report a warning, not an error, when such command line arguments are encountered.



<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing

Tested in slurm scripts on doom (see examples above).
Also tested on cee-lan, ATDM modules; all tests passed.
```
source /home//code/Trilinos/cmake/std/atdm/load-env.sh  gnu-7.2.0-openmp-release-debug

cmake \
  -GNinja \
 -DMPI_EXEC=${MPI_EXEC} \
 -DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/atdm/ATDMDevEnv.cmake \
 -DTrilinos_ENABLE_TESTS=ON \
 -DTrilinos_ENABLE_Teuchos:BOOL=ON \
 -DTrilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=ON \
 -DTrilinos_ENABLE_SECONDARY_TESTED_CODE:BOOL=ON \
 -DTPL_ENABLE_Matio=OFF \
 -DTPL_ENABLE_X11=OFF \
```

<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->