### PR TITLE
Tpetra: removed unused field and CUDA compiler warning

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_decl.hpp
@@ -454,9 +454,6 @@ public:
   //@}
 
 private:
-  //! This hash table's label.
-  std::string objectLabel_;
-
   /// \brief Array of keys; only valid if keepKeys = true on construction.
   ///
   /// If you want the reverse mapping from values to keys, you need


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

Removed unused field from FixedHashTable.

## Motivation

Field objectLabel_ was completely unused, and instigated a compiler warning about calling a host function from a host device function. 
```
warning: calling a __host__ function("std::basic_string<char, std::char_traits<char>, std::allocator<char> >::~basic_string") from a __host__ __device__ function("Tpetra::Details::LocalMap<int, long long,  ::Kokkos::Device< ::Kokkos::Serial,  ::Kokkos::HostSpace> > ::~LocalMap") is not allowed
```



## Related Issues
#5698


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

Tested on doom to ensure warning went away.
Tested on cee-lan to ensure tests still passed.
```
module load sems-env
module load sems-cmake/3.10.3
module load sems-gcc/7.3.0
module load sems-openmpi/1.10.1
module load sems-parmetis/4.0.3/64bit_parallel
module load sems-scotch/6.0.3/nopthread_64bit_parallel
cmake \
-D CMAKE_BUILD_TYPE:STRING="DEBUG" \
-D MPI_BIN_DIR:PATH=${SEMS_OPENMPI_ROOT}/bin \
-D TPL_ENABLE_MPI:BOOL=ON \
-D MPI_EXEC_MAX_NUMPROCS:STRING=64 \
-D TPL_ENABLE_BinUtils:BOOL=OFF \
-D TPL_ENABLE_Pthread:BOOL=OFF \
-D Trilinos_ENABLE_EXPLICIT_INSTANTIATION:BOOL=ON \
-D Trilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=OFF \
-D Trilinos_ENABLE_TESTS:BOOL=OFF \
-D Trilinos_ENABLE_EXAMPLES:BOOL=OFF \
-D Trilinos_VERBOSE_CONFIGURE:BOOL=OFF \
-D Trilinos_ENABLE_Tpetra:BOOL=ON \
-D Tpetra_ENABLE_TESTS:BOOL=ON \
-D Tpetra_ENABLE_EXAMPLES:BOOL=ON \
-D Tpetra_ENABLE_DEPRECATED_CODE=OFF \
-D Teuchos_ENABLE_STACKTRACE=OFF \
              
```              
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->