### PR TITLE
Intrepid2: making tests more robust to architectural differences.

### DIFF
--- a/packages/intrepid2/unit-test/Discretization/Basis/HierarchicalBases/AnalyticPolynomialsMatchTests.cpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HierarchicalBases/AnalyticPolynomialsMatchTests.cpp
@@ -558,7 +558,11 @@ namespace
           OutputScalar derivedValue  =  derivedOutputViewHost(fieldOrdinalDerived, pointOrdinal);
           
           bool valuesMatch = true;
-          TEUCHOS_TEST_FLOATING_EQUALITY(standardValue, derivedValue, tol, out, valuesMatch);
+          bool valuesAreBothSmall = valuesAreSmall(standardValue, derivedValue, tol);
+          if (!valuesAreBothSmall)
+          {
+            TEUCHOS_TEST_FLOATING_EQUALITY(standardValue, derivedValue, tol, out, valuesMatch);
+          }
           
           if (!valuesMatch)
           {
@@ -597,7 +601,11 @@ namespace
             OutputScalar standardValue = standardOutputViewHost(fieldOrdinalStandard,pointOrdinal,d);
             OutputScalar derivedValue  =  derivedOutputViewHost(fieldOrdinalDerived, pointOrdinal,d);
             
-            TEUCHOS_TEST_FLOATING_EQUALITY(standardValue, derivedValue, tol, out, valuesMatch);
+            bool valuesAreBothSmall = valuesAreSmall(standardValue, derivedValue, tol);
+            if (!valuesAreBothSmall)
+            {
+              TEUCHOS_TEST_FLOATING_EQUALITY(standardValue, derivedValue, tol, out, valuesMatch);
+            }
           }
           
           if (!valuesMatch)

--- a/packages/intrepid2/unit-test/Shared/Polylib/LegendreJacobiPolynomials/IntegratedJacobiTests.cpp
+++ b/packages/intrepid2/unit-test/Shared/Polylib/LegendreJacobiPolynomials/IntegratedJacobiTests.cpp
@@ -138,13 +138,17 @@ namespace
           
           for (int i=0; i<=polyOrder; i++)
           {
-            if (! approximatelyEqual(secondPathIntegratedJacobiView_dt_host(i), integratedJacobiView_dt_host(i), tol) )
+            bool valuesAreBothSmall = valuesAreSmall(secondPathIntegratedJacobiView_dt_host(i), integratedJacobiView_dt_host(i), tol);
+            if (!valuesAreBothSmall)
             {
-              out << "for polyOrder " << i << ", alpha = " << alpha << ", x = " << x << ", t = " << t << ": ";
-              out << secondPathIntegratedJacobiView_dt_host(i) << " != " << integratedJacobiView_dt_host(i);
-              out << " (diff = " << abs(secondPathIntegratedJacobiView_dt_host(i) - integratedJacobiView_dt_host(i));
-              out << "; tol = " << tol << ")\n";
-              success = false;
+              if (! approximatelyEqual(secondPathIntegratedJacobiView_dt_host(i), integratedJacobiView_dt_host(i), tol) )
+              {
+                out << "for polyOrder " << i << ", alpha = " << alpha << ", x = " << x << ", t = " << t << ": ";
+                out << secondPathIntegratedJacobiView_dt_host(i) << " != " << integratedJacobiView_dt_host(i);
+                out << " (diff = " << abs(secondPathIntegratedJacobiView_dt_host(i) - integratedJacobiView_dt_host(i));
+                out << "; tol = " << tol << ")\n";
+                success = false;
+              }
             }
           }
         }

--- a/packages/intrepid2/unit-test/Shared/Polylib/LegendreJacobiPolynomials/IntegratedLegendreTests.cpp
+++ b/packages/intrepid2/unit-test/Shared/Polylib/LegendreJacobiPolynomials/IntegratedLegendreTests.cpp
@@ -89,13 +89,17 @@ namespace
         
         for (int i=0; i<=polyOrder; i++)
         {
-          if (! approximatelyEqual(integrated_legendre_values_second_path_host(i), integrated_legendre_values_host(i), tol) )
+          bool valuesAreBothSmall = valuesAreSmall(integrated_legendre_values_second_path_host(i), integrated_legendre_values_host(i), tol);
+          if (! valuesAreBothSmall)
           {
-            out << "for polyOrder " << i << ", x = " << x << ", t = " << t << ": ";
-            out << integrated_legendre_values_second_path_host(i) << " != " << integrated_legendre_values_host(i);
-            out << " (diff = " << abs(integrated_legendre_values_second_path_host(i) - integrated_legendre_values_host(i));
-            out << "; tol = " << tol << ")\n";
-            success = false;
+            if (! approximatelyEqual(integrated_legendre_values_second_path_host(i), integrated_legendre_values_host(i), tol) )
+            {
+              out << "for polyOrder " << i << ", x = " << x << ", t = " << t << ": ";
+              out << integrated_legendre_values_second_path_host(i) << " != " << integrated_legendre_values_host(i);
+              out << " (diff = " << abs(integrated_legendre_values_second_path_host(i) - integrated_legendre_values_host(i));
+              out << "; tol = " << tol << ")\n";
+              success = false;
+            }
           }
         }
       }

--- a/packages/intrepid2/unit-test/Shared/Polylib/LegendreJacobiPolynomials/LegendreTests.cpp
+++ b/packages/intrepid2/unit-test/Shared/Polylib/LegendreJacobiPolynomials/LegendreTests.cpp
@@ -107,9 +107,9 @@ namespace
         auto jacobiValueHost = getHostCopy(jacobiValue);
         
         expectedValue = scaleFactor * jacobiValueHost(0);
-//        bool valuesAreBothSmall = valuesAreSmall(expectedValue, legendreDerivativesHost(i), tol);
-//        if (! valuesAreBothSmall)
-//        {
+        bool valuesAreBothSmall = valuesAreSmall(expectedValue, legendreDerivativesHost(i), tol);
+        if (! valuesAreBothSmall)
+        {
           if (! approximatelyEqual(expectedValue, legendreDerivativesHost(i), tol) )
           {
             double diff = abs(expectedValue - legendreDerivativesHost(i));
@@ -118,7 +118,7 @@ namespace
             out << "; actual was " << legendreDerivativesHost(i) << " (diff: " << diff << ") for derivative " << derivativeOrder << " of i = " << i;
             out << " at x = " << x << std::endl;
           }
-//        }
+        }
       }
     }
   }


### PR DESCRIPTION
Guarding various floating point comparisons in tests with checks whether both values are small.

@trilinos/intrepid2

## Motivation
Some tests fail on some platforms due to near-zero floating point comparisons.

## Related Issues
* Closes #6246 