### PR TITLE
Zoltan2:  default test types

### DIFF
--- a/packages/zoltan2/test/correctness/zoltanCompare.cpp
+++ b/packages/zoltan2/test/correctness/zoltanCompare.cpp
@@ -121,7 +121,7 @@ typedef Zoltan2::XpetraCrsMatrixAdapter<tMatrix_t,tMVector_t> matrixAdapter_t;
 typedef Zoltan2::EvaluatePartition<matrixAdapter_t> quality_t;
 
 // Number of ZOLTAN_ID in a zgno_t (for NUM_GID_ENTRIES)
-static constexpr int nGidEnt = sizeof(zgno_t) / sizeof(ZOLTAN_ID_TYPE);
+static constexpr int znGidEnt = sizeof(zgno_t) / sizeof(ZOLTAN_ID_TYPE);
 #define SET_ZID(n,a,b)                                            \
    {int ZOLTAN_ID_LOOP;                                                 \
     for (ZOLTAN_ID_LOOP = 0; ZOLTAN_ID_LOOP < (n); ZOLTAN_ID_LOOP++)    \
@@ -150,7 +150,7 @@ static void zobjlist(void *data, int ngid, int nlid,
   for (size_t i = 0; i < n; i++) {
     zgno_t vgid = vec->getMap()->getGlobalElement(i);
     ZOLTAN_ID_PTR vgidptr = (ZOLTAN_ID_PTR) &vgid;
-    SET_ZID(nGidEnt, &(gids[i*nGidEnt]), vgidptr);
+    SET_ZID(znGidEnt, &(gids[i*znGidEnt]), vgidptr);
     lids[i] = i;
   }
 
@@ -204,7 +204,7 @@ static void zhg(void *data, int ngid, int nLists, int nPins, int format,
 
     zgno_t tmp = graph->getRowMap()->getGlobalElement(i);
     ZOLTAN_ID_PTR ztmp = (ZOLTAN_ID_PTR) &tmp;
-    SET_ZID(nGidEnt, &(listGids[i*nGidEnt]), ztmp);
+    SET_ZID(znGidEnt, &(listGids[i*znGidEnt]), ztmp);
 
     size_t nEntries = graph->getNumEntriesInLocalRow(i);
     offsets[i+1] = offsets[i] + nEntries;
@@ -215,7 +215,7 @@ static void zhg(void *data, int ngid, int nLists, int nPins, int format,
     for (size_t j = 0; j < nEntries; j++) {
       tmp = graph->getColMap()->getGlobalElement(colind[j]);
       ztmp = (ZOLTAN_ID_PTR) &tmp;
-      SET_ZID(nGidEnt, &(pinGids[(offsets[i]+j)*nGidEnt]), ztmp);
+      SET_ZID(znGidEnt, &(pinGids[(offsets[i]+j)*znGidEnt]), ztmp);
     }
   }
 
@@ -327,7 +327,7 @@ int run(
   char tmp[56];
   zz.Set_Param("LB_METHOD", thisTest[TESTMETHODOFFSET]);
   
-  sprintf(tmp, "%d", nGidEnt);
+  sprintf(tmp, "%d", znGidEnt);
   zz.Set_Param("NUM_GID_ENTRIES", tmp);
   sprintf(tmp, "%d", numGlobalParts);
   zz.Set_Param("NUM_GLOBAL_PARTS", tmp);

--- a/packages/zoltan2/test/helpers/Zoltan2_TestHelpers.hpp
+++ b/packages/zoltan2/test/helpers/Zoltan2_TestHelpers.hpp
@@ -101,50 +101,23 @@ typedef Tpetra::Map<>::node_type znode_t;
 
 #include <TpetraCore_config.h>
 
-    typedef int zpart_t; // added this for consistency but needs further discussion
+typedef int zpart_t; // added this for consistency but needs further discussion
 
-#ifdef HAVE_TPETRA_EXPLICIT_INSTANTIATION
+typedef Tpetra::Map<>::local_ordinal_type zlno_t;
+typedef Tpetra::Map<>::global_ordinal_type zgno_t;
 
-# ifdef HAVE_TPETRA_DOUBLE
-    typedef double zscalar_t;
-#   define HAVE_EPETRA_SCALAR_TYPE
-# else
-    typedef float zscalar_t;
-# endif
+#ifdef HAVE_TPETRA_DOUBLE
+  typedef double zscalar_t;
+# define HAVE_EPETRA_SCALAR_TYPE
+#else
+  typedef float zscalar_t;
+#endif
 
-# if defined HAVE_TPETRA_INT_INT
-    typedef int zlno_t;
-    typedef int zgno_t;
-#   if defined HAVE_EPETRA_SCALAR_TYPE
-#     define HAVE_EPETRA_DATA_TYPES
-#   endif
-# elif defined HAVE_TPETRA_INT_LONG
-    typedef int zlno_t;
-    typedef long zgno_t;
-# elif defined HAVE_TPETRA_INT_LONG_LONG
-    typedef int zlno_t;
-    typedef long long zgno_t;
-# elif defined HAVE_TPETRA_INT_UNSIGNED
-    typedef int zlno_t;
-    typedef unsigned zgno_t;
-# else
-#   error "Tpetra uses ETI, but no lno/gno instantiation is recognized"
-# endif
-
-#else  // !HAVE_TPETRA_EXPLICIT_INSTANTIATION
-
-# if defined TEST_STK_DATA_TYPES
-    typedef double  zscalar_t;
-    typedef ssize_t zlno_t;
-    typedef size_t  zgno_t;
-# else  // !TEST_STK_DATA_TYPES
-    typedef double zscalar_t;
-    typedef int zlno_t;
-    typedef int zgno_t;
-#   define HAVE_EPETRA_DATA_TYPES
-# endif  // TEST_STK_DATA_TYPES
-
-#endif // HAVE_TPETRA_EXPLICIT_INSTANTIATION
+#if defined HAVE_TPETRA_INT_INT
+#  if defined HAVE_EPETRA_SCALAR_TYPE
+#    define HAVE_EPETRA_DATA_TYPES
+#  endif
+#endif
 
 #ifndef HAVE_ZOLTAN2_EPETRA
 #  undef HAVE_EPETRA_SCALAR_TYPE


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/zoltan2 

## Motivation
Tpetra now builds with only global ID type at a time.
Thus, the complicated logic to determine the type of global ID to use in Zoltan2 tests is no longer needed.
These changes adopt the default types from Tpetra.
They also correct builds with default Tpetra types and no explicit instantiation.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Linux with sems modules
```
module load sems-env
module load sems-cmake/3.10.3
module load sems-gcc/4.9.3
module load sems-openmpi/1.10.1
```

With gno=long long and gno=int
With explicit instantiation
non-ETI builds are experiencing an Xpetra error; these changes have no impact on that error.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->