### PR TITLE
Tpetra: Start work on #6603 (optimize CrsMatrix GPU unpack for long rows)

### DIFF
--- a/packages/tpetra/core/src/Epetra_TsqrMessenger.cpp
+++ b/packages/tpetra/core/src/Epetra_TsqrMessenger.cpp
@@ -34,8 +34,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
-//
 // ************************************************************************
 // @HEADER
 

--- a/packages/tpetra/core/src/Epetra_TsqrMessenger.hpp
+++ b/packages/tpetra/core/src/Epetra_TsqrMessenger.hpp
@@ -34,8 +34,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
-//
 // ************************************************************************
 // @HEADER
 

--- a/packages/tpetra/core/src/Tpetra_ApplyOp.hpp
+++ b/packages/tpetra/core/src/Tpetra_ApplyOp.hpp
@@ -34,8 +34,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
-//
 // ************************************************************************
 // @HEADER
 

--- a/packages/tpetra/core/src/Tpetra_Assembly_Helpers.hpp
+++ b/packages/tpetra/core/src/Tpetra_Assembly_Helpers.hpp
@@ -34,8 +34,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
-//
 // ************************************************************************
 // @HEADER
 
@@ -51,28 +49,28 @@ namespace Impl {
 template <typename... Args>
 inline void foreach_pack(Args &&... args) {}
 } // namespace Impl
- 
+
 template <typename... Args>
 void beginFill(Args &&... args)
 {
   // use the comma operator to transform a potentially void function call
   // into a argument to allow proper parameter expansion for c++11
   Impl::foreach_pack( (args.beginFill(),1)... );
- 
+
   // using c++17 the code would be
   // (args.beginFill()...);
 }
- 
+
 template <typename... Args>
 void endFill(Args &&... args)
 {
   // use the comma operator to transform a potentially void function call
   // into a argument to allow proper parameter expansion for c++11
   Impl::foreach_pack( (args.endFill(),1)... );
- 
+
   // using c++17 the code would be
   // (args.endFill()...);
- 
+
 }
 
 }// namespace Tpetra

--- a/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_Helpers_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_Helpers_decl.hpp
@@ -34,8 +34,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
-//
 // ************************************************************************
 // @HEADER
 

--- a/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_Helpers_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_Helpers_def.hpp
@@ -34,8 +34,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
-//
 // ************************************************************************
 // @HEADER
 

--- a/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_decl.hpp
@@ -34,8 +34,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
-//
 // ************************************************************************
 // @HEADER
 

--- a/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_fwd.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_fwd.hpp
@@ -34,8 +34,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
-//
 // ************************************************************************
 // @HEADER
 

--- a/packages/tpetra/core/src/Tpetra_BlockMultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockMultiVector_decl.hpp
@@ -34,8 +34,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
-//
 // ************************************************************************
 // @HEADER
 

--- a/packages/tpetra/core/src/Tpetra_BlockMultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockMultiVector_def.hpp
@@ -34,8 +34,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
-//
 // ************************************************************************
 // @HEADER
 
@@ -825,6 +823,6 @@ blockJacobiUpdate (const Scalar& alpha,
 // Must be expanded from within the Tpetra namespace!
 //
 #define TPETRA_BLOCKMULTIVECTOR_INSTANT(S,LO,GO,NODE) \
-  template class BlockMultiVector< S, LO, GO, NODE >; 
+  template class BlockMultiVector< S, LO, GO, NODE >;
 
 #endif // TPETRA_BLOCKMULTIVECTOR_DEF_HPP

--- a/packages/tpetra/core/src/Tpetra_BlockMultiVector_fwd.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockMultiVector_fwd.hpp
@@ -34,8 +34,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
-//
 // ************************************************************************
 // @HEADER
 

--- a/packages/tpetra/core/src/Tpetra_ConfigDefs.hpp
+++ b/packages/tpetra/core/src/Tpetra_ConfigDefs.hpp
@@ -34,8 +34,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
-//
 // ************************************************************************
 // @HEADER
 

--- a/packages/tpetra/core/src/Tpetra_Core.cpp
+++ b/packages/tpetra/core/src/Tpetra_Core.cpp
@@ -34,8 +34,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
-//
 // ************************************************************************
 // @HEADER
 

--- a/packages/tpetra/core/src/Tpetra_Core.hpp
+++ b/packages/tpetra/core/src/Tpetra_Core.hpp
@@ -34,8 +34,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
-//
 // ************************************************************************
 // @HEADER
 

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -2307,19 +2307,6 @@ namespace Tpetra {
     /// bound the number of entries per row.
     //@{
 
-    /// \brief Global column indices for all rows.
-    ///
-    /// This is only allocated if
-    ///
-    ///   - The calling process has a nonzero number of entries
-    ///   - The graph has DynamicProfile (2-D storage)
-    ///   - The graph is globally indexed
-    ///
-    /// In that case, if i_gbl is the global index of a globally owned
-    /// row, then gblInds2D_[i_gbl] stores the global column indices
-    /// for that row.
-    Teuchos::ArrayRCP<Teuchos::Array<global_ordinal_type> > gblInds2D_;
-
     /// \brief The type of k_numRowEntries_ (see below).
     ///
     /// This View gets used only on host.  However, making this

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -327,7 +327,7 @@ namespace Tpetra {
     ///   default values.
     CrsGraph (const Teuchos::RCP<const map_type>& rowMap,
               const Kokkos::DualView<const size_t*, execution_space>& numEntPerRow,
-	      const ProfileType pftype = TPETRA_DEFAULT_PROFILE_TYPE,
+              const ProfileType pftype = TPETRA_DEFAULT_PROFILE_TYPE,
               const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
     /// \brief Constructor specifying a (possibly different) upper
@@ -350,7 +350,7 @@ namespace Tpetra {
     ///   default values.
     CrsGraph (const Teuchos::RCP<const map_type>& rowMap,
               const Teuchos::ArrayView<const size_t>& numEntPerRow,
-	      const ProfileType pftype = TPETRA_DEFAULT_PROFILE_TYPE,
+              const ProfileType pftype = TPETRA_DEFAULT_PROFILE_TYPE,
               const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
 
@@ -379,7 +379,7 @@ namespace Tpetra {
     CrsGraph (const Teuchos::RCP<const map_type>& rowMap,
               const Teuchos::RCP<const map_type>& colMap,
               const size_t maxNumEntriesPerRow,
-	      const ProfileType pftype = TPETRA_DEFAULT_PROFILE_TYPE,
+              const ProfileType pftype = TPETRA_DEFAULT_PROFILE_TYPE,
               const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
     /// \brief Constructor specifying column Map and number of entries in each row.
@@ -404,7 +404,7 @@ namespace Tpetra {
     CrsGraph (const Teuchos::RCP<const map_type>& rowMap,
               const Teuchos::RCP<const map_type>& colMap,
               const Kokkos::DualView<const size_t*, execution_space>& numEntPerRow,
-	      const ProfileType pftype = TPETRA_DEFAULT_PROFILE_TYPE,
+              const ProfileType pftype = TPETRA_DEFAULT_PROFILE_TYPE,
               const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
     /// \brief Constructor specifying column Map and number of entries
@@ -430,7 +430,7 @@ namespace Tpetra {
     CrsGraph (const Teuchos::RCP<const map_type>& rowMap,
               const Teuchos::RCP<const map_type>& colMap,
               const Teuchos::ArrayView<const size_t>& numEntPerRow,
-	      const ProfileType pftype = TPETRA_DEFAULT_PROFILE_TYPE,
+              const ProfileType pftype = TPETRA_DEFAULT_PROFILE_TYPE,
               const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
 
@@ -2306,19 +2306,6 @@ namespace Tpetra {
     /// of entries allowed per process, but does <i>not</i> otherwise
     /// bound the number of entries per row.
     //@{
-
-    /// \brief Local column indices for all rows.
-    ///
-    /// This is only allocated if
-    ///
-    ///   - The calling process has a nonzero number of entries
-    ///   - The graph has DynamicProfile (2-D storage)
-    ///   - The graph is locally indexed
-    ///
-    /// In that case, if i_lcl is the local index of a locally owned
-    /// row, then lclInds2D_[i_lcl] stores the local column indices
-    /// for that row.
-    Teuchos::ArrayRCP<Teuchos::Array<local_ordinal_type> > lclInds2D_;
 
     /// \brief Global column indices for all rows.
     ///

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -4140,13 +4140,6 @@ namespace Tpetra {
       GraphNotYetAllocated
     };
 
-  private:
-    /// \brief Allocate 2-D storage for matrix values.
-    ///
-    /// This is an implementation detail of allocateValues() (see below).
-    Teuchos::ArrayRCP<Teuchos::Array<impl_scalar_type> >
-    allocateValues2D ();
-
   protected:
     /// \brief Allocate values (and optionally indices) using the Node.
     ///

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -4453,22 +4453,11 @@ namespace Tpetra {
     //! The local sparse matrix, wrapped in a multiply operator.
     std::shared_ptr<local_multiply_op_type> lclMatrix_;
 
-    /// \name Sparse matrix values.
+    /// \brief Sparse matrix values, as part of compressed sparse row
+    ///   ("1-D") storage.
     ///
-    /// k_values1D_ represents the values assuming "1-D" compressed
-    /// sparse row storage.  values2D_ represents the values as an
-    /// array of arrays, one (inner) array per row of the sparse
-    /// matrix.
-    ///
-    /// Before allocation, both arrays are null.  After allocation,
-    /// one is null.  If static allocation, then values2D_ is null.
-    /// If dynamic allocation, then k_values1D_ is null.  The
-    /// allocation always matches that of graph_, as the graph does
-    /// the allocation for the matrix.
-    //@{
+    /// Before allocation, this array is empty.
     typename local_matrix_type::values_type k_values1D_;
-    Teuchos::ArrayRCP<Teuchos::Array<impl_scalar_type> > values2D_;
-    //@}
 
     /// \brief Status of the matrix's storage, when not in a
     ///   fill-complete state.
@@ -4477,7 +4466,7 @@ namespace Tpetra {
     /// When the matrix is fill complete, it <i>always</i> uses 1-D
     /// "packed" storage.  However, if the "Optimize Storage"
     /// parameter to fillComplete was false, the matrix may keep
-    /// unpacked 1-D or 2-D storage around and resume it on the next
+    /// unpacked 1-D storage around and resume it on the next
     /// resumeFill call.
     ::Tpetra::Details::EStorageStatus storageStatus_;
 

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -226,26 +226,32 @@ namespace Tpetra {
   {
     const char tfecfFuncName[] = "CrsMatrix(RCP<const Map>, RCP<const Map>, "
       "size_t, ProfileType[, RCP<ParameterList>]): ";
-
+    const char suffix[] =
+      "  Please report this bug to the Tpetra developers.";
 #ifdef HAVE_TPETRA_DEBUG
-    // An artifact of debugging something a while back.
-    TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-      (! staticGraph_.is_null (), std::logic_error,
-      "staticGraph_ is not null at the beginning of the constructor.  "
-      "Please report this bug to the Tpetra developers.");
-    TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-      (! myGraph_.is_null (), std::logic_error,
-      "myGraph_ is not null at the beginning of the constructor.  "
-      "Please report this bug to the Tpetra developers.");
+    constexpr bool debug = true;
+#else
+    constexpr bool debug = false;
 #endif // HAVE_TPETRA_DEBUG
 
+    if (debug) {
+      // An artifact of debugging something a while back.
+      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+        (! staticGraph_.is_null (), std::logic_error,
+         "staticGraph_ is not null at the beginning of the constructor."
+         << suffix);
+      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+        (! myGraph_.is_null (), std::logic_error,
+         "myGraph_ is not null at the beginning of the constructor."
+         << suffix);
+    }
     Teuchos::RCP<crs_graph_type> graph;
     try {
       graph = Teuchos::rcp (new crs_graph_type (rowMap, colMap,
                                                 maxNumEntPerRow,
                                                 pftype, params));
     }
-    catch (std::exception &e) {
+    catch (std::exception& e) {
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
         (true, std::runtime_error, "CrsGraph constructor (RCP<const Map>, "
          "RCP<const Map>, size_t, ProfileType[, RCP<ParameterList>]) threw an "
@@ -388,8 +394,6 @@ namespace Tpetra {
     checkInternalState ();
   }
 
-
-
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   CrsMatrix (const Teuchos::RCP<const map_type>& rowMap,
@@ -407,6 +411,11 @@ namespace Tpetra {
     const char tfecfFuncName[] = "Tpetra::CrsMatrix(RCP<const Map>, "
       "RCP<const Map>, ptr, ind, val[, params]): ";
     const char suffix[] = ".  Please report this bug to the Tpetra developers.";
+#ifdef HAVE_TPETRA_DEBUG
+    constexpr bool debug = true;
+#else
+    constexpr bool debug = false;
+#endif // HAVE_TPETRA_DEBUG
 
     // Check the user's input.  Note that this might throw only on
     // some processes but not others, causing deadlock.  We prefer
@@ -417,8 +426,7 @@ namespace Tpetra {
        std::invalid_argument, "Input arrays don't have matching dimensions.  "
        "values.extent(0) = " << values.extent (0) << " != "
        "columnIndices.extent(0) = " << columnIndices.extent (0) << ".");
-#ifdef HAVE_TPETRA_DEBUG
-    if (rowPointers.extent (0) != 0) {
+    if (debug && rowPointers.extent (0) != 0) {
       const size_t numEnt =
         ::Tpetra::Details::getEntryOnHost (rowPointers, rowPointers.extent (0) - 1);
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
@@ -430,7 +438,6 @@ namespace Tpetra {
          "columnIndices.extent(0) = " << columnIndices.extent (0) <<
          " and values.extent(0) = " << values.extent (0) << ".");
     }
-#endif // HAVE_TPETRA_DEBUG
 
     RCP<crs_graph_type> graph;
     try {
@@ -586,6 +593,14 @@ namespace Tpetra {
   {
     const char tfecfFuncName[] = "Tpetra::CrsMatrix(RCP<const Map>, "
       "RCP<const Map>, local_matrix_type[, RCP<ParameterList>]): ";
+    const char suffix[] =
+      "  Please report this bug to the Tpetra developers.";
+#ifdef HAVE_TPETRA_DEBUG
+    constexpr bool debug = true;
+#else
+    constexpr bool debug = false;
+#endif // HAVE_TPETRA_DEBUG
+
     Teuchos::RCP<crs_graph_type> graph;
     try {
       graph = Teuchos::rcp (new crs_graph_type (rowMap, colMap,
@@ -614,15 +629,16 @@ namespace Tpetra {
       this->computeGlobalConstants ();
     }
 
-    // Sanity checks at the end.
-#ifdef HAVE_TPETRA_DEBUG
-    TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(isFillActive (), std::logic_error,
-      "We're at the end of fillComplete(), but isFillActive() is true.  "
-      "Please report this bug to the Tpetra developers.");
-    TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(! isFillComplete (), std::logic_error,
-      "We're at the end of fillComplete(), but isFillComplete() is false.  "
-      "Please report this bug to the Tpetra developers.");
-#endif // HAVE_TPETRA_DEBUG
+    if (debug) {
+      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+        (isFillActive (), std::logic_error,
+         "At the end of a CrsMatrix constructor that should produce "
+         "a fillComplete matrix, isFillActive() is true." << suffix);
+      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+        (! isFillComplete (), std::logic_error, "At the end of a "
+         "CrsMatrix constructor that should produce a fillComplete "
+         "matrix, isFillComplete() is false." << suffix);
+    }
     checkInternalState ();
   }
 
@@ -643,8 +659,16 @@ namespace Tpetra {
     frobNorm_ (-STM::one ())
   {
     const char tfecfFuncName[] = "Tpetra::CrsMatrix(RCP<const Map>, "
-      "RCP<const Map>, RCP<const Map>, RCP<const Map>, local_matrix_type[, "
-      "RCP<ParameterList>]): ";
+      "RCP<const Map>, RCP<const Map>, RCP<const Map>, "
+      "local_matrix_type[, RCP<ParameterList>]): ";
+    const char suffix[] =
+      "  Please report this bug to the Tpetra developers.";
+#ifdef HAVE_TPETRA_DEBUG
+    constexpr bool debug = true;
+#else
+    constexpr bool debug = false;
+#endif // HAVE_TPETRA_DEBUG
+
     Teuchos::RCP<crs_graph_type> graph;
     try {
       graph = Teuchos::rcp (new crs_graph_type (lclMatrix.graph, rowMap, colMap,
@@ -657,10 +681,10 @@ namespace Tpetra {
          "RCP<ParameterList>]) threw an exception: " << e.what ());
     }
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-      (!graph->isFillComplete (), std::logic_error, "CrsGraph constructor (RCP"
-       "<const Map>, RCP<const Map>, RCP<const Map>, RCP<const Map>, local_graph_type[, "
-       "RCP<ParameterList>]) did not produce a fill-complete graph.  Please report this "
-       "bug to the Tpetra developers.");
+      (! graph->isFillComplete (), std::logic_error, "CrsGraph "
+       "constructor (RCP<const Map>, RCP<const Map>, RCP<const Map>, "
+       "RCP<const Map>, local_graph_type[, RCP<ParameterList>]) did "
+       "not produce a fillComplete graph." << suffix);
     // myGraph_ not null means that the matrix owns the graph.  This
     // is true because the column indices come in as nonconst through
     // the matrix, implying shared ownership.
@@ -673,15 +697,16 @@ namespace Tpetra {
       this->computeGlobalConstants ();
     }
 
-    // Sanity checks at the end.
-#ifdef HAVE_TPETRA_DEBUG
-    TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(isFillActive (), std::logic_error,
-      "We're at the end of fillComplete(), but isFillActive() is true.  "
-      "Please report this bug to the Tpetra developers.");
-    TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(! isFillComplete (), std::logic_error,
-      "We're at the end of fillComplete(), but isFillComplete() is false.  "
-      "Please report this bug to the Tpetra developers.");
-#endif // HAVE_TPETRA_DEBUG
+    if (debug) {
+      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+        (isFillActive (), std::logic_error,
+         "At the end of a CrsMatrix constructor that should produce "
+         "a fillComplete matrix, isFillActive() is true." << suffix);
+      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+        (! isFillComplete (), std::logic_error, "At the end of a "
+         "CrsMatrix constructor that should produce a fillComplete "
+         "matrix, isFillComplete() is false." << suffix);
+    }
     checkInternalState ();
   }
 
@@ -706,6 +731,13 @@ namespace Tpetra {
     using Teuchos::rcp;
     const char tfecfFuncName[] = "Tpetra::CrsMatrix"
       "(lclMat,Map,Map,Map,Map,Import,Export,params): ";
+    const char suffix[] =
+      "  Please report this bug to the Tpetra developers.";
+#ifdef HAVE_TPETRA_DEBUG
+    constexpr bool debug = true;
+#else
+    constexpr bool debug = false;
+#endif // HAVE_TPETRA_DEBUG
 
     Teuchos::RCP<crs_graph_type> graph;
     try {
@@ -736,15 +768,16 @@ namespace Tpetra {
       this->computeGlobalConstants ();
     }
 
-    // Sanity checks at the end.
-#ifdef HAVE_TPETRA_DEBUG
-    TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(isFillActive (), std::logic_error,
-      "We're at the end of fillComplete(), but isFillActive() is true.  "
-      "Please report this bug to the Tpetra developers.");
-    TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(! isFillComplete (), std::logic_error,
-      "We're at the end of fillComplete(), but isFillComplete() is false.  "
-      "Please report this bug to the Tpetra developers.");
-#endif // HAVE_TPETRA_DEBUG
+    if (debug) {
+      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+        (isFillActive (), std::logic_error,
+         "At the end of a CrsMatrix constructor that should produce "
+         "a fillComplete matrix, isFillActive() is true." << suffix);
+      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+        (! isFillComplete (), std::logic_error, "At the end of a "
+         "CrsMatrix constructor that should produce a fillComplete "
+         "matrix, isFillComplete() is false." << suffix);
+    }
     checkInternalState ();
   }
 
@@ -785,8 +818,6 @@ namespace Tpetra {
     }
   }
 
-
-
   template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void
   CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
@@ -804,14 +835,12 @@ namespace Tpetra {
     std::swap(crs_matrix.frobNorm_,      this->frobNorm_);        // mutable Kokkos::Details::ArithTraits<impl_scalar_type>::mag_type
   }
 
-
   template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   Teuchos::RCP<const Teuchos::Comm<int> >
   CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   getComm () const {
     return getCrsGraphRef ().getComm ();
   }
-
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   ProfileType
@@ -991,18 +1020,25 @@ namespace Tpetra {
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   const CrsGraph<LocalOrdinal, GlobalOrdinal, Node>&
   CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  getCrsGraphRef () const {
+  getCrsGraphRef () const
+  {
+#ifdef HAVE_TPETRA_DEBUG
+    constexpr bool debug = true;
+#else
+    constexpr bool debug = false;
+#endif // HAVE_TPETRA_DEBUG
+
     if (! this->staticGraph_.is_null ()) {
       return * (this->staticGraph_);
     }
     else {
-#ifdef HAVE_TPETRA_DEBUG
-      const char tfecfFuncName[] = "getCrsGraphRef: ";
-      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (this->myGraph_.is_null (), std::logic_error,
-         "Both staticGraph_ and myGraph_ are null.  "
-         "Please report this bug to the Tpetra developers.");
-#endif // HAVE_TPETRA_DEBUG
+      if (debug) {
+        const char tfecfFuncName[] = "getCrsGraphRef: ";
+        TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+          (this->myGraph_.is_null (), std::logic_error,
+           "Both staticGraph_ and myGraph_ are null.  "
+           "Please report this bug to the Tpetra developers.");
+      }
       return * (this->myGraph_);
     }
   }
@@ -1016,7 +1052,6 @@ namespace Tpetra {
       local_matrix_type () :
       lclMatrix_->getLocalMatrix ();
   }
-
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   bool
@@ -1044,52 +1079,61 @@ namespace Tpetra {
   CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   allocateValues (ELocalGlobal lg, GraphAllocationStatus gas)
   {
-    using ::Tpetra::Details::ProfilingRegion;
     const char tfecfFuncName[] = "allocateValues: ";
-    ProfilingRegion regionAllocateValues ("Tpetra::CrsMatrix::allocateValues");
+    const char suffix[] =
+      "  Please report this bug to the Tpetra developers.";
 
+    ::Tpetra::Details::ProfilingRegion regionAllocateValues
+      ("Tpetra::CrsMatrix::allocateValues");
 #ifdef HAVE_TPETRA_DEBUG
-    const char suffix[] = "  Please report this bug to the Tpetra developers.";
+    constexpr bool debug = true;
+#else
+    constexpr bool debug = false;
+#endif // HAVE_TPETRA_DEBUG
 
-    TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-      (this->staticGraph_.is_null (), std::logic_error,
-       "staticGraph_ is null." << suffix);
+    if (debug) {
+      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+        (this->staticGraph_.is_null (), std::logic_error,
+         "staticGraph_ is null." << suffix);
 
-    // If the graph indices are already allocated, then gas should be
-    // GraphAlreadyAllocated.  Otherwise, gas should be
-    // GraphNotYetAllocated.
-    if ((gas == GraphAlreadyAllocated) != this->staticGraph_->indicesAreAllocated ()) {
-      const char err1[] = "The caller has asserted that the graph is ";
-      const char err2[] = "already allocated, but the static graph says "
-        "that its indices are ";
-      const char err3[] = "already allocated.  Please report this bug to "
-        "the Tpetra developers.";
+      // If the graph indices are already allocated, then gas should be
+      // GraphAlreadyAllocated.  Otherwise, gas should be
+      // GraphNotYetAllocated.
+      if ((gas == GraphAlreadyAllocated) !=
+          staticGraph_->indicesAreAllocated ()) {
+        const char err1[] = "The caller has asserted that the graph "
+          "is ";
+        const char err2[] = "already allocated, but the static graph "
+          "says that its indices are ";
+        const char err3[] = "already allocated.  ";
+        TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+          (gas == GraphAlreadyAllocated &&
+           ! staticGraph_->indicesAreAllocated (), std::logic_error,
+           err1 << err2 << "not " << err3 << suffix);
+        TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+          (gas != GraphAlreadyAllocated &&
+           staticGraph_->indicesAreAllocated (), std::logic_error,
+           err1 << "not " << err2 << err3 << suffix);
+      }
+
+      // If the graph is unallocated, then it had better be a
+      // matrix-owned graph.  ("Matrix-owned graph" means that the
+      // matrix gets to define the graph structure.  If the CrsMatrix
+      // constructor that takes an RCP<const CrsGraph> was used, then
+      // the matrix does _not_ own the graph.)
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (gas == GraphAlreadyAllocated && ! this->staticGraph_->indicesAreAllocated (),
-        std::logic_error, err1 << err2 << "not " << err3);
-      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (gas != GraphAlreadyAllocated && this->staticGraph_->indicesAreAllocated (),
-         std::logic_error, err1 << "not " << err2 << err3);
+        (! this->staticGraph_->indicesAreAllocated () &&
+         this->myGraph_.is_null (), std::logic_error,
+         "The static graph says that its indices are not allocated, "
+         "but the graph is not owned by the matrix." << suffix);
     }
 
-    // If the graph is unallocated, then it had better be a
-    // matrix-owned graph.  ("Matrix-owned graph" means that the
-    // matrix gets to define the graph structure.  If the CrsMatrix
-    // constructor that takes an RCP<const CrsGraph> was used, then
-    // the matrix does _not_ own the graph.)
-    TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-      (! this->staticGraph_->indicesAreAllocated () &&
-       this->myGraph_.is_null (), std::logic_error,
-       "The static graph says that its indices are not allocated, "
-       "but the graph is not owned by the matrix." << suffix);
-#endif // HAVE_TPETRA_DEBUG
-
     if (gas == GraphNotYetAllocated) {
-#ifdef HAVE_TPETRA_DEBUG
-      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (this->myGraph_.is_null (), std::logic_error,
-         "gas = GraphNotYetAllocated, but myGraph_ is null." << suffix);
-#endif // HAVE_TPETRA_DEBUG
+      if (debug) {
+        TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+          (this->myGraph_.is_null (), std::logic_error,
+           "gas = GraphNotYetAllocated, but myGraph_ is null." << suffix);
+      }
       try {
         this->myGraph_->allocateIndices (lg);
       }
@@ -1112,12 +1156,12 @@ namespace Tpetra {
     // values.  ("1-D storage" means the same as that used by the
     // three arrays in the compressed sparse row storage format.)
 
-#ifdef HAVE_TPETRA_DEBUG
-    TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-      (this->staticGraph_.is_null (), std::logic_error,
-       "this->getProfileType() == StaticProfile, but staticGraph_ is null."
-       << suffix);
-#endif // HAVE_TPETRA_DEBUG
+    if (debug) {
+      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+        (this->staticGraph_.is_null (), std::logic_error,
+         "this->getProfileType() == StaticProfile, but staticGraph_ "
+         "is null." << suffix);
+    }
 
     const size_t lclNumRows = this->staticGraph_->getNodeNumRows ();
     typename Graph::local_graph_type::row_map_type k_ptrs =
@@ -1132,7 +1176,7 @@ namespace Tpetra {
       ::Tpetra::Details::getEntryOnHost (k_ptrs, lclNumRows);
 
     // Allocate array of (packed???) matrix values.
-    typedef typename local_matrix_type::values_type values_type;
+    using values_type = typename local_matrix_type::values_type;
     this->k_values1D_ =
       values_type ("Tpetra::CrsMatrix::val", lclTotalNumEntries);
   }
@@ -1183,7 +1227,7 @@ namespace Tpetra {
   fillLocalGraphAndMatrix (const Teuchos::RCP<Teuchos::ParameterList>& params)
   {
     using ::Tpetra::Details::computeOffsetsFromCounts;
-    using ::Tpetra::Details::ProfilingRegion;
+    using ::Tpetra::Details::getEntryOnHost;
     using Kokkos::create_mirror_view;
     using Teuchos::arcp_const_cast;
     using Teuchos::Array;
@@ -1191,26 +1235,27 @@ namespace Tpetra {
     using Teuchos::null;
     using Teuchos::RCP;
     using Teuchos::rcp;
-    typedef typename local_matrix_type::row_map_type row_map_type;
-    typedef typename Graph::local_graph_type::entries_type::non_const_type lclinds_1d_type;
-    typedef typename local_matrix_type::values_type values_type;
-    ProfilingRegion regionFLGAM ("Tpetra::CrsGraph::fillLocalGraphAndMatrix");
+    using row_map_type = typename local_matrix_type::row_map_type;
+    using lclinds_1d_type = typename Graph::local_graph_type::entries_type::non_const_type;
+    using values_type = typename local_matrix_type::values_type;
+    Details::ProfilingRegion regionFLGAM
+      ("Tpetra::CrsGraph::fillLocalGraphAndMatrix");
 
-#ifdef HAVE_TPETRA_DEBUG
     const char tfecfFuncName[] = "fillLocalGraphAndMatrix (called from "
       "fillComplete or expertStaticFillComplete): ";
-#endif // HAVE_TPETRA_DEBUG
+    const char suffix[] =
+      "  Please report this bug to the Tpetra developers.";
+    const bool debug = Details::Behavior::debug ("CrsGraph");
 
-#ifdef HAVE_TPETRA_DEBUG
-    // fillComplete() only calls fillLocalGraphAndMatrix() if the
-    // matrix owns the graph, which means myGraph_ is not null.
-    TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-      (myGraph_.is_null (), std::logic_error, "The nonconst graph (myGraph_) "
-       "is null.  This means that the matrix has a const (a.k.a. \"static\") "
-       "graph.  fillComplete or expertStaticFillComplete should never call "
-       "fillLocalGraphAndMatrix in that case.  "
-       "Please report this bug to the Tpetra developers.");
-#endif // HAVE_TPETRA_DEBUG
+    if (debug) {
+      // fillComplete() only calls fillLocalGraphAndMatrix() if the
+      // matrix owns the graph, which means myGraph_ is not null.
+      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+        (myGraph_.is_null (), std::logic_error, "The nonconst graph (myGraph_) "
+         "is null.  This means that the matrix has a const (a.k.a. \"static\") "
+         "graph.  fillComplete or expertStaticFillComplete should never call "
+         "fillLocalGraphAndMatrix in that case." << suffix);
+    }
 
     const size_t lclNumRows = this->getNodeNumRows ();
 
@@ -1241,19 +1286,18 @@ namespace Tpetra {
     typename Graph::local_graph_type::row_map_type curRowOffsets =
       myGraph_->k_rowPtrs_;
 
-#ifdef HAVE_TPETRA_DEBUG
-    TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-      (curRowOffsets.extent (0) == 0, std::logic_error,
-       "(StaticProfile branch) curRowOffsets.extent(0) == 0.");
-    TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-      (curRowOffsets.extent (0) != lclNumRows + 1, std::logic_error,
-       "(StaticProfile branch) curRowOffsets.extent(0) = "
-       << curRowOffsets.extent (0) << " != lclNumRows + 1 = "
-       << (lclNumRows + 1) << ".")
-    {
+    if (debug) {
+      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+        (curRowOffsets.extent (0) == 0, std::logic_error,
+         "(StaticProfile branch) curRowOffsets.extent(0) == 0.");
+      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+        (curRowOffsets.extent (0) != lclNumRows + 1, std::logic_error,
+         "(StaticProfile branch) curRowOffsets.extent(0) = "
+         << curRowOffsets.extent (0) << " != lclNumRows + 1 = "
+         << (lclNumRows + 1) << ".");
       const size_t numOffsets = curRowOffsets.extent (0);
       const auto valToCheck =
-        ::Tpetra::Details::getEntryOnHost (curRowOffsets, numOffsets - 1);
+        getEntryOnHost (curRowOffsets, numOffsets - 1);
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
         (numOffsets != 0 &&
          myGraph_->k_lclInds1D_.extent (0) != valToCheck,
@@ -1262,7 +1306,6 @@ namespace Tpetra {
          << myGraph_->k_lclInds1D_.extent (0) << " != curRowOffsets("
          << numOffsets << ") = " << valToCheck << ".");
     }
-#endif // HAVE_TPETRA_DEBUG
 
     if (myGraph_->getNodeNumEntries () != myGraph_->getNodeAllocationSize ()) {
       // The matrix's current 1-D storage is "unpacked."  This means
@@ -1271,30 +1314,27 @@ namespace Tpetra {
       // specified StaticProfile in the constructor and set an upper
       // bound on the number of entries per row, but didn't fill all
       // those entries.
-#ifdef HAVE_TPETRA_DEBUG
-      if (curRowOffsets.extent (0) != 0) {
+      if (debug && curRowOffsets.extent (0) != 0) {
         const size_t numOffsets =
           static_cast<size_t> (curRowOffsets.extent (0));
         const auto valToCheck =
-          ::Tpetra::Details::getEntryOnHost (curRowOffsets, numOffsets-1);
+          getEntryOnHost (curRowOffsets, numOffsets - 1);
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
           (static_cast<size_t> (valToCheck) !=
            static_cast<size_t> (k_values1D_.extent (0)),
            std::logic_error, "(StaticProfile unpacked branch) Before "
-           "allocating or packing, curRowOffsets(" << (numOffsets-1) << ") = "
-           << valToCheck << " != k_values1D_.extent(0)"
+           "allocating or packing, curRowOffsets(" << (numOffsets-1)
+           << ") = " << valToCheck << " != k_values1D_.extent(0)"
            " = " << k_values1D_.extent (0) << ".");
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
           (static_cast<size_t> (valToCheck) !=
            static_cast<size_t> (myGraph_->k_lclInds1D_.extent (0)),
            std::logic_error, "(StaticProfile unpacked branch) Before "
-           "allocating or packing, curRowOffsets(" << (numOffsets-1) << ") = "
-           << valToCheck
+           "allocating or packing, curRowOffsets(" << (numOffsets-1)
+           << ") = " << valToCheck
            << " != myGraph_->k_lclInds1D_.extent(0) = "
            << myGraph_->k_lclInds1D_.extent (0) << ".");
       }
-#endif // HAVE_TPETRA_DEBUG
-
       // Pack the row offsets into k_ptrs, by doing a sum-scan of
       // the array of valid entry counts per row.
 
@@ -1322,15 +1362,14 @@ namespace Tpetra {
         k_ptrs_const = k_ptrs;
       }
 
-#ifdef HAVE_TPETRA_DEBUG
-      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (static_cast<size_t> (k_ptrs.extent (0)) != lclNumRows + 1,
-         std::logic_error,
-         "(StaticProfile unpacked branch) After packing k_ptrs, "
-         "k_ptrs.extent(0) = " << k_ptrs.extent (0) << " != "
-         "lclNumRows+1 = " << (lclNumRows+1) << ".");
-      {
-        const auto valToCheck = ::Tpetra::Details::getEntryOnHost (k_ptrs, lclNumRows);
+      if (debug) {
+        TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+          (static_cast<size_t> (k_ptrs.extent (0)) != lclNumRows + 1,
+           std::logic_error,
+           "(StaticProfile unpacked branch) After packing k_ptrs, "
+           "k_ptrs.extent(0) = " << k_ptrs.extent (0) << " != "
+           "lclNumRows+1 = " << (lclNumRows+1) << ".");
+        const auto valToCheck = getEntryOnHost (k_ptrs, lclNumRows);
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
           (valToCheck != lclTotalNumEntries, std::logic_error,
            "(StaticProfile unpacked branch) After filling k_ptrs, "
@@ -1338,7 +1377,6 @@ namespace Tpetra {
            << " != total number of entries on the calling process = "
            << lclTotalNumEntries << ".");
       }
-#endif // HAVE_TPETRA_DEBUG
 
       // Allocate the arrays of packed column indices and values.
       k_inds = lclinds_1d_type ("Tpetra::CrsGraph::ind", lclTotalNumEntries);
@@ -1354,99 +1392,102 @@ namespace Tpetra {
 
       // Pack the column indices from unpacked k_lclInds1D_ into
       // packed k_inds.  We will replace k_lclInds1D_ below.
-      typedef pack_functor<typename Graph::local_graph_type::entries_type::non_const_type,
-        typename Graph::local_graph_type::row_map_type>
-        inds_packer_type;
+      using inds_packer_type = pack_functor<
+        typename Graph::local_graph_type::entries_type::non_const_type,
+        typename Graph::local_graph_type::row_map_type>;
       inds_packer_type indsPacker (k_inds, myGraph_->k_lclInds1D_,
                                    k_ptrs, curRowOffsets);
-      typedef typename decltype (k_inds)::execution_space exec_space;
-      typedef Kokkos::RangePolicy<exec_space, LocalOrdinal> range_type;
-      Kokkos::parallel_for (range_type (0, lclNumRows), indsPacker);
+      using exec_space = typename decltype (k_inds)::execution_space;
+      using range_type = Kokkos::RangePolicy<exec_space, LocalOrdinal>;
+      Kokkos::parallel_for
+        ("Tpetra::CrsMatrix pack column indices",
+         range_type (0, lclNumRows), indsPacker);
 
       // Pack the values from unpacked k_values1D_ into packed
       // k_vals.  We will replace k_values1D_ below.
-      typedef pack_functor<values_type, row_map_type> vals_packer_type;
+      using vals_packer_type = pack_functor<values_type, row_map_type>;
       vals_packer_type valsPacker (k_vals, this->k_values1D_,
                                    k_ptrs, curRowOffsets);
-      Kokkos::parallel_for (range_type (0, lclNumRows), valsPacker);
+      Kokkos::parallel_for ("Tpetra::CrsMatrix pack values",
+                            range_type (0, lclNumRows), valsPacker);
 
-#ifdef HAVE_TPETRA_DEBUG
-      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (k_ptrs.extent (0) == 0, std::logic_error,
-         "(StaticProfile \"Optimize Storage\" = "
-         "true branch) After packing, k_ptrs.extent(0) = 0.  This "
-         "probably means that k_rowPtrs_ was never allocated.");
-      if (k_ptrs.extent (0) != 0) {
-        const size_t numOffsets = static_cast<size_t> (k_ptrs.extent (0));
-        const auto valToCheck = ::Tpetra::Details::getEntryOnHost (k_ptrs, numOffsets - 1);
+      if (debug) {
+        const char myPrefix[] = "(StaticProfile \"Optimize Storage\""
+          "=true branch) After packing, ";
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-          (static_cast<size_t> (valToCheck) != k_vals.extent (0),
-           std::logic_error,
-           "(StaticProfile \"Optimize Storage\"=true branch) After packing, "
-           "k_ptrs(" << (numOffsets-1) << ") = " << valToCheck <<
-           " != k_vals.extent(0) = " << k_vals.extent (0) << ".");
-        TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-          (static_cast<size_t> (valToCheck) != k_inds.extent (0),
-           std::logic_error,
-           "(StaticProfile \"Optimize Storage\"=true branch) After packing, "
-           "k_ptrs(" << (numOffsets-1) << ") = " << valToCheck <<
-           " != k_inds.extent(0) = " << k_inds.extent (0) << ".");
+          (k_ptrs.extent (0) == 0, std::logic_error, myPrefix
+           << "k_ptrs.extent(0) = 0.  This probably means that "
+           "k_rowPtrs_ was never allocated.");
+        if (k_ptrs.extent (0) != 0) {
+          const size_t numOffsets (k_ptrs.extent (0));
+          const auto valToCheck =
+            getEntryOnHost (k_ptrs, numOffsets - 1);
+          TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+            (size_t (valToCheck) != k_vals.extent (0),
+             std::logic_error, myPrefix <<
+             "k_ptrs(" << (numOffsets-1) << ") = " << valToCheck <<
+             " != k_vals.extent(0) = " << k_vals.extent (0) << ".");
+          TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+            (size_t (valToCheck) != k_inds.extent (0),
+             std::logic_error, myPrefix <<
+             "k_ptrs(" << (numOffsets-1) << ") = " << valToCheck <<
+             " != k_inds.extent(0) = " << k_inds.extent (0) << ".");
+        }
       }
-#endif // HAVE_TPETRA_DEBUG
     }
     else { // We don't have to pack, so just set the pointers.
       k_ptrs_const = myGraph_->k_rowPtrs_;
       k_inds = myGraph_->k_lclInds1D_;
       k_vals = this->k_values1D_;
 
-#ifdef HAVE_TPETRA_DEBUG
-      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (k_ptrs_const.extent (0) == 0, std::logic_error,
-        "(StaticProfile \"Optimize Storage\"=false branch) "
-        "k_ptrs_const.extent(0) = 0.  This probably means that "
-        "k_rowPtrs_ was never allocated.");
-      if (k_ptrs_const.extent (0) != 0) {
-        const size_t numOffsets = static_cast<size_t> (k_ptrs_const.extent (0));
-        const auto valToCheck = ::Tpetra::Details::getEntryOnHost (k_ptrs_const, numOffsets - 1);
+      if (debug) {
+        const char myPrefix[] =
+          "(StaticProfile \"Optimize Storage\"=false branch) ";
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-          (static_cast<size_t> (valToCheck) != k_vals.extent (0),
-           std::logic_error,
-           "(StaticProfile \"Optimize Storage\"=false branch) "
-           "k_ptrs_const(" << (numOffsets-1) << ") = " << valToCheck
-           << " != k_vals.extent(0) = " << k_vals.extent (0) << ".");
-        TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-          (static_cast<size_t> (valToCheck) != k_inds.extent (0),
-           std::logic_error,
-           "(StaticProfile \"Optimize Storage\" = false branch) "
-           "k_ptrs_const(" << (numOffsets-1) << ") = " << valToCheck
-           << " != k_inds.extent(0) = " << k_inds.extent (0) << ".");
+          (k_ptrs_const.extent (0) == 0, std::logic_error, myPrefix
+           << "k_ptrs_const.extent(0) = 0.  This probably means "
+           "that k_rowPtrs_ was never allocated.");
+        if (k_ptrs_const.extent (0) != 0) {
+          const size_t numOffsets (k_ptrs_const.extent (0));
+          const auto valToCheck =
+            getEntryOnHost (k_ptrs_const, numOffsets - 1);
+          TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+            (size_t (valToCheck) != k_vals.extent (0),
+             std::logic_error, myPrefix <<
+             "k_ptrs_const(" << (numOffsets-1) << ") = " << valToCheck
+             << " != k_vals.extent(0) = " << k_vals.extent (0) << ".");
+          TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+            (size_t (valToCheck) != k_inds.extent (0),
+             std::logic_error, myPrefix <<
+             "k_ptrs_const(" << (numOffsets-1) << ") = " << valToCheck
+             << " != k_inds.extent(0) = " << k_inds.extent (0) << ".");
+        }
       }
-#endif // HAVE_TPETRA_DEBUG
     }
 
-#ifdef HAVE_TPETRA_DEBUG
-    // Extra sanity checks.
-    TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-      (static_cast<size_t> (k_ptrs_const.extent (0)) != lclNumRows + 1,
-       std::logic_error, "After packing, k_ptrs_const.extent(0) = " <<
-       k_ptrs_const.extent (0) << " != lclNumRows+1 = " << (lclNumRows+1)
-       << ".");
-    if (k_ptrs_const.extent (0) != 0) {
-      const size_t numOffsets = static_cast<size_t> (k_ptrs_const.extent (0));
-      const size_t k_ptrs_const_numOffsetsMinus1 =
-        ::Tpetra::Details::getEntryOnHost (k_ptrs_const, numOffsets - 1);
+    if (debug) {
+      const char myPrefix[] = "After packing, ";
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (k_ptrs_const_numOffsetsMinus1 != k_vals.extent (0),
-         std::logic_error, "After packing, k_ptrs_const(" << (numOffsets-1) <<
-         ") = " << k_ptrs_const_numOffsetsMinus1 << " != k_vals.extent(0)"
-         " = " << k_vals.extent (0) << ".");
-      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (k_ptrs_const_numOffsetsMinus1 != k_inds.extent (0),
-         std::logic_error, "After packing, k_ptrs_const(" << (numOffsets-1) <<
-         ") = " << k_ptrs_const_numOffsetsMinus1 << " != k_inds.extent(0)"
-         " = " << k_inds.extent (0) << ".");
+        (size_t (k_ptrs_const.extent (0)) != size_t (lclNumRows + 1),
+         std::logic_error, myPrefix << "k_ptrs_const.extent(0) = "
+         << k_ptrs_const.extent (0) << " != lclNumRows+1 = " <<
+         (lclNumRows+1) << ".");
+      if (k_ptrs_const.extent (0) != 0) {
+        const size_t numOffsets (k_ptrs_const.extent (0));
+        const size_t k_ptrs_const_numOffsetsMinus1 =
+          getEntryOnHost (k_ptrs_const, numOffsets - 1);
+        TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+          (k_ptrs_const_numOffsetsMinus1 != size_t (k_vals.extent (0)),
+           std::logic_error, myPrefix << "k_ptrs_const(" <<
+           (numOffsets-1) << ") = " << k_ptrs_const_numOffsetsMinus1
+           << " != k_vals.extent(0) = " << k_vals.extent (0) << ".");
+        TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+          (k_ptrs_const_numOffsetsMinus1 != size_t (k_inds.extent (0)),
+           std::logic_error, myPrefix << "k_ptrs_const(" <<
+           (numOffsets-1) << ") = " << k_ptrs_const_numOffsetsMinus1
+           << " != k_inds.extent(0) = " << k_inds.extent (0) << ".");
+      }
     }
-#endif // HAVE_TPETRA_DEBUG
 
     // May we ditch the old allocations for the packed (and otherwise
     // "optimized") allocations, later in this routine?  Optimize
@@ -1455,7 +1496,8 @@ namespace Tpetra {
     const bool defaultOptStorage =
       ! isStaticGraph () || staticGraph_->isStorageOptimized ();
     const bool requestOptimizedStorage =
-      (! params.is_null () && params->get ("Optimize Storage", defaultOptStorage)) ||
+      (! params.is_null () &&
+       params->get ("Optimize Storage", defaultOptStorage)) ||
       (params.is_null () && defaultOptStorage);
 
     // The graph has optimized storage when indices are allocated,
@@ -1512,9 +1554,9 @@ namespace Tpetra {
     using Teuchos::null;
     using Teuchos::RCP;
     using Teuchos::rcp;
-    typedef typename Graph::local_graph_type::row_map_type row_map_type;
-    typedef typename row_map_type::non_const_type non_const_row_map_type;
-    typedef typename local_matrix_type::values_type values_type;
+    using row_map_type = typename Graph::local_graph_type::row_map_type;
+    using non_const_row_map_type = typename row_map_type::non_const_type;
+    using values_type = typename local_matrix_type::values_type;
 #ifdef HAVE_TPETRA_DEBUG
     // const char tfecfFuncName[] = "fillLocalMatrix (called from fillComplete): ";
 #endif // HAVE_TPETRA_DEBUG
@@ -1553,16 +1595,17 @@ namespace Tpetra {
     // the matrix's storage either.  Check and give warning, as
     // appropriate.
     if (! staticGraph_->isStorageOptimized () && requestOptimizedStorage) {
-      TPETRA_ABUSE_WARNING(true, std::runtime_error,
-        "You requested optimized storage by setting the"
-        "\"Optimize Storage\" flag to \"true\" in the parameter list, or by virtue"
-        "of default behavior. However, the associated CrsGraph was filled separately"
-        "and requested not to optimize storage. Therefore, the CrsMatrix cannot"
-        "optimize storage.");
+      TPETRA_ABUSE_WARNING
+        (true, std::runtime_error, "You requested optimized storage "
+         "by setting the \"Optimize Storage\" flag to \"true\" in "
+         "the ParameterList, or by virtue of default behavior.  "
+         "However, the associated CrsGraph was filled separately and "
+         "requested not to optimize storage. Therefore, the "
+         "CrsMatrix cannot optimize storage.");
       requestOptimizedStorage = false;
     }
 
-    typedef decltype (staticGraph_->k_numRowEntries_) row_entries_type;
+    using row_entries_type = decltype (staticGraph_->k_numRowEntries_);
 
     // StaticProfile means that the matrix's values are currently
     // stored in a 1-D format.  However, this format is "unpacked";
@@ -1594,9 +1637,9 @@ namespace Tpetra {
       {
         typename row_entries_type::const_type numRowEnt_d =
           staticGraph_->k_numRowEntries_;
-        using ::Tpetra::Details::computeOffsetsFromCounts;
         // This function can handle the counts being a host View.
-        lclTotalNumEntries = computeOffsetsFromCounts (tmpk_ptrs, numRowEnt_d);
+        lclTotalNumEntries =
+          Details::computeOffsetsFromCounts (tmpk_ptrs, numRowEnt_d);
       }
 
       // Allocate the "packed" values array.
@@ -1604,12 +1647,13 @@ namespace Tpetra {
       k_vals = values_type ("Tpetra::CrsMatrix::val", lclTotalNumEntries);
 
       // Pack k_values1D_ into k_vals.  We will replace k_values1D_ below.
-      typedef pack_functor<values_type, row_map_type> packer_type;
-      packer_type valsPacker (k_vals, k_values1D_, tmpk_ptrs, k_rowPtrs_);
+      pack_functor<values_type, row_map_type> valsPacker
+        (k_vals, k_values1D_, tmpk_ptrs, k_rowPtrs_);
 
-      typedef typename decltype (k_vals)::execution_space exec_space;
-      typedef Kokkos::RangePolicy<exec_space, LocalOrdinal> range_type;
-      Kokkos::parallel_for (range_type (0, lclNumRows), valsPacker);
+      using exec_space = typename decltype (k_vals)::execution_space;
+      using range_type = Kokkos::RangePolicy<exec_space, LocalOrdinal>;
+      Kokkos::parallel_for ("Tpetra::CrsMatrix pack values",
+                            range_type (0, lclNumRows), valsPacker);
     }
     else { // We don't have to pack, so just set the pointer.
       k_vals = k_values1D_;

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -1468,9 +1468,8 @@ namespace Tpetra {
       // Free the old, unpacked, unoptimized allocations.
       // Change the graph from dynamic to static allocation profile
 
-      // Free graph data structures that are only needed for 2-D or
+      // Free graph data structures that are only needed for
       // unpacked 1-D storage.
-      myGraph_->lclInds2D_ = null; // legacy KokkosClassic 2-D storage
       myGraph_->k_numRowEntries_ = row_entries_type ();
 
       // Free the matrix's 2-D storage.
@@ -1517,7 +1516,6 @@ namespace Tpetra {
     using Teuchos::null;
     using Teuchos::RCP;
     using Teuchos::rcp;
-    typedef LocalOrdinal LO;
     typedef typename Graph::local_graph_type::row_map_type row_map_type;
     typedef typename row_map_type::non_const_type non_const_row_map_type;
     typedef typename local_matrix_type::values_type values_type;
@@ -1537,7 +1535,6 @@ namespace Tpetra {
     // fill both the graph and the matrix at the same time).
 
     // get data from staticGraph_
-    ArrayRCP<Array<LO> > lclInds2D = staticGraph_->lclInds2D_;
     size_t nodeNumEntries   = staticGraph_->getNodeNumEntries ();
     size_t nodeNumAllocated = staticGraph_->getNodeAllocationSize ();
     row_map_type k_rowPtrs_ = staticGraph_->lclGraph_.row_map;

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -1041,41 +1041,6 @@ namespace Tpetra {
   }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-  Teuchos::ArrayRCP<Teuchos::Array<typename CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::impl_scalar_type> >
-  CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-  allocateValues2D ()
-  {
-    using Teuchos::arcp;
-    using Teuchos::Array;
-    using Teuchos::ArrayRCP;
-    typedef impl_scalar_type IST;
-    typedef LocalOrdinal LO;
-    const char tfecfFuncName[] = "allocateValues2D: ";
-
-    const crs_graph_type& graph = this->getCrsGraphRef ();
-    TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-      (! graph.indicesAreAllocated (), std::runtime_error,
-       "Graph indices must be allocated before values.");
-    TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-      (graph.getProfileType () == StaticProfile, std::runtime_error,
-       "Graph indices must be allocated in a dynamic profile.");
-
-    const LO lclNumRows = graph.getNodeNumRows ();
-    Teuchos::ArrayRCP<Teuchos::Array<IST> > values2D (lclNumRows);
-    if (! graph.lclInds2D_.is_null ()) {
-      for (LO lclRow = 0; lclRow < lclNumRows; ++lclRow) {
-        values2D[lclRow].resize (graph.lclInds2D_[lclRow].size ());
-      }
-    }
-    else if (! graph.gblInds2D_.is_null ()) {
-      for (LO lclRow = 0; lclRow < lclNumRows; ++lclRow) {
-        values2D[lclRow].resize (graph.gblInds2D_[lclRow].size ());
-      }
-    }
-    return values2D;
-  }
-
-  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void
   CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
   allocateValues (ELocalGlobal lg, GraphAllocationStatus gas)

--- a/packages/tpetra/core/src/Tpetra_Details_Behavior.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Behavior.cpp
@@ -1,3 +1,43 @@
+/*
+// @HEADER
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services Package
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// ************************************************************************
+// @HEADER
+*/
 #include "Tpetra_Details_Behavior.hpp"
 #include "TpetraCore_config.h"
 #include <algorithm> // std::transform
@@ -300,6 +340,17 @@ size_t Behavior::verbosePrintCountThreshold ()
 {
   constexpr char envVarName[] = "TPETRA_VERBOSE_PRINT_COUNT_THRESHOLD";
   constexpr size_t defaultValue (200);
+
+  static size_t value_ = defaultValue;
+  static bool initialized_ = false;
+  return idempotentlyGetEnvironmentVariableAsSize
+    (value_, initialized_, envVarName, defaultValue);
+}
+
+size_t Behavior::longRowMinNumEntries ()
+{
+  constexpr char envVarName[] = "TPETRA_LONG_ROW_MIN_NUM_ENTRIES";
+  constexpr size_t defaultValue (256);
 
   static size_t value_ = defaultValue;
   static bool initialized_ = false;

--- a/packages/tpetra/core/src/Tpetra_Details_Behavior.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Behavior.hpp
@@ -124,16 +124,19 @@ public:
   /// For a discussion, see Trilinos GitHub issues #1571 and #1088.
   static bool assumeMpiIsCudaAware ();
 
-  /// \brief The core count above which Tpetra::CrsMatrix::transferAndFillComplete
-  /// will attempt to do advanced neighbor discovery. This is platform 
-  /// dependent, and the user/developer should test each new platform 
-  /// for the correct value. The 3000 value was found on Serrano summer 2018 
-
+  /// \brief MPI process count above which
+  ///   Tpetra::CrsMatrix::transferAndFillComplete will attempt to do
+  ///   advanced neighbor discovery.
+  ///
+  /// This is platform dependent, and the user/developer should test
+  /// each new platform for the correct value.  You may control this
+  /// at run time via the <tt>MM_TAFC_OptimizationCoreCount</tt>
+  /// environment variable.
   static int TAFC_OptimizationCoreCount ();
 
-  /// \brief Threshold, below which arrays, lists, etc. will be printed in debug mode.
+  /// \brief Number of entries below which arrays, lists, etc. will be
+  ///   printed in debug mode.
   static size_t verbosePrintCountThreshold ();
-
 };
 
 } // namespace Details

--- a/packages/tpetra/core/src/Tpetra_Details_Behavior.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Behavior.hpp
@@ -1,3 +1,43 @@
+/*
+// @HEADER
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services Package
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// ************************************************************************
+// @HEADER
+*/
 #ifndef TPETRA_DETAILS_BEHAVIOR_HPP
 #define TPETRA_DETAILS_BEHAVIOR_HPP
 
@@ -136,7 +176,29 @@ public:
 
   /// \brief Number of entries below which arrays, lists, etc. will be
   ///   printed in debug mode.
+  ///
+  /// You may control this at run time via the
+  /// <tt>TPETRA_VERBOSE_PRINT_COUNT_THRESHOLD</tt> environment
+  /// variable.
   static size_t verbosePrintCountThreshold ();
+
+  /// \brief Minimum number of entries in a "long" sparse graph or
+  ///   matrix row.
+  ///
+  /// If a local row of a sparse graph or matrix has this many or more
+  /// entries, we consider it "long."  Tpetra has the option to treat
+  /// "long" rows separately from shorter rows in algorithms like
+  /// sparse matrix-vector multiply, packAndPrepare, and
+  /// unpackAndCombine.  You may control this at run time via the
+  /// <tt>TPETRA_LONG_ROW_MIN_NUM_ENTRIES</tt> environment variable.
+  ///
+  /// This is an absolute value, not a relative value.  This matters
+  /// for thread parallelization, because the point is to decide how
+  /// much parallelism needs to be available in a row in order to
+  /// treat it differently from other rows.  Whether a row has enough
+  /// entries to treat it as "dense" relative to other rows, is a
+  /// separate question.
+  static size_t longRowMinNumEntries ();
 };
 
 } // namespace Details

--- a/packages/tpetra/core/src/Tpetra_Details_copyOffsets.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_copyOffsets.hpp
@@ -35,8 +35,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
-//
 // ************************************************************************
 // @HEADER
 */
@@ -168,7 +166,8 @@ namespace { // (anonymous)
 
     const bool verbose = Details::Behavior::verbose ();
     if (verbose) {
-      constexpr size_t maxNumToPrint = 100;
+      const size_t maxNumToPrint =
+        Details::Behavior::verbosePrintCountThreshold();
       const size_t srcLen (src.extent (0));
       if (srcLen <= maxNumToPrint) {
         auto dst_h = Kokkos::create_mirror_view (dst);
@@ -195,7 +194,11 @@ namespace { // (anonymous)
         os << "].";
       }
       else {
-        os << "  src and dst are too long to print.";
+        os << "  src.extent(0) > " << maxNumToPrint << ", Tpetra's "
+          "verbose print count threshold.  To increase this, set the "
+          "environment variable TPETRA_VERBOSE_PRINT_COUNT_THRESHOLD "
+          "to the desired threshold and rerun.  You do NOT need to "
+          "rebuild Trilinos.";
       }
     }
     TEUCHOS_TEST_FOR_EXCEPTION(true, std::runtime_error, os.str ());

--- a/packages/tpetra/core/test/Behavior/Behavior_Default.cpp
+++ b/packages/tpetra/core/test/Behavior/Behavior_Default.cpp
@@ -35,8 +35,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
-//
 // ************************************************************************
 // @HEADER
 */
@@ -96,4 +94,17 @@ TEUCHOS_UNIT_TEST(Behavior, verbosePrintCountThreshold) {
     Tpetra::Details::Behavior::verbosePrintCountThreshold();
   TEST_ASSERT( val1 >= minVal && val1 <= maxVal );
 }
+
+TEUCHOS_UNIT_TEST(Behavior, longRowMinNumEntries) {
+  // We only require that the default be at least this much.
+  const size_t minVal (100);
+  const size_t val0 =
+    Tpetra::Details::Behavior::longRowMinNumEntries();
+  TEST_ASSERT( val0 >= minVal );
+
+  const size_t val1 =
+    Tpetra::Details::Behavior::longRowMinNumEntries();
+  TEST_ASSERT( val1 >= minVal );
+}
+
 } // namespace (anonymous)

--- a/packages/tpetra/core/test/Behavior/Behavior_Default.cpp
+++ b/packages/tpetra/core/test/Behavior/Behavior_Default.cpp
@@ -48,6 +48,8 @@
 #include <Tpetra_Details_Behavior.hpp>
 #include <Teuchos_UnitTestHarness.hpp>
 #include <Teuchos_CommHelpers.hpp>
+#include <cstdlib> // std::getenv
+
 namespace {
 
 /*
@@ -80,5 +82,18 @@ TEUCHOS_UNIT_TEST(Behavior, Default)
 #endif
   bool cuda_aware_mpi = Tpetra::Details::Behavior::assumeMpiIsCudaAware();
   TEUCHOS_TEST_ASSERT(cuda_aware_mpi==cuda_aware_mpi_default, out, success);
+}
+
+TEUCHOS_UNIT_TEST(Behavior, verbosePrintCountThreshold) {
+  // We only require that the default be between these values.
+  const size_t maxVal (1000);
+  const size_t minVal (100);
+  const size_t val0 =
+    Tpetra::Details::Behavior::verbosePrintCountThreshold();
+  TEST_ASSERT( val0 >= minVal && val0 <= maxVal );
+
+  const size_t val1 =
+    Tpetra::Details::Behavior::verbosePrintCountThreshold();
+  TEST_ASSERT( val1 >= minVal && val1 <= maxVal );
 }
 } // namespace (anonymous)


### PR DESCRIPTION
@trilinos/tpetra 

## Motivation

- `Tpetra::CrsMatrix::unpackAndCombine` is slow on GPUs for rows with many entries.
- We first need to define what a "row with many entries" is.
- Logical thing to do is to add a new function to `Tpetra::Details::Behavior`.
- Also, clean up some data structures in CrsGraph and CrsMatrix that are no longer needed.  This will help with the effort by reducing the number of cases to consider.

## Related Issues

* Part of #6603

## Stakeholder Feedback

Requested by @vbrunini based on Aria GPU L2 Milestone.

## Testing

Tested on Linux GCC 4.9.3.  Added new tests for existing and new Behavior methods.