### PR TITLE
Tpetra:  index change from #6598

### DIFF
--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -3395,7 +3395,7 @@ namespace Tpetra {
     // be exactly what we need, so we won't have to resize them later.
     {
       const size_t newSize = X.imports_.extent (0) / numCols;
-      const size_t offset = j*newSize;
+      const size_t offset = jj*newSize;
       auto newImports = X.imports_;
       newImports.d_view = subview (X.imports_.d_view,
                                    range_type (offset, offset+newSize));
@@ -3405,7 +3405,7 @@ namespace Tpetra {
     }
     {
       const size_t newSize = X.exports_.extent (0) / numCols;
-      const size_t offset = j*newSize;
+      const size_t offset = jj*newSize;
       auto newExports = X.exports_;
       newExports.d_view = subview (X.exports_.d_view,
                                    range_type (offset, offset+newSize));


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
In #6598, @mhoemmen recommended using index jj instead of index j to compute offsets to communication buffers.  This PR implements that change.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing

Configuration and testing is identical to #6598 
ested on linux with Tpetra tests and downstream packages Belos, Ifpack2, MueLu, Zoltan2, and Teko.
```
source ../cmake/std/atdm/load-env.sh  gnu-7.2.0-openmp-release-debug
cmake \
  -GNinja \
  -DMPI_EXEC=${MPI_EXEC} \
  -DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/atdm/ATDMDevEnv.cmake \
  -DTrilinos_ENABLE_TESTS=ON  \
  -DTrilinos_ENABLE_Tpetra=ON \
  -DTrilinos_ENABLE_MueLu=ON \
  -DTrilinos_ENABLE_Anasazi=ON \
  -DTrilinos_ENABLE_Belos=ON \
  -DTrilinos_ENABLE_Ifpack2=ON \
  -DTrilinos_ENABLE_Zoltan2=ON \
  -DTrilinos_ENABLE_Teko=ON \
.. |& tee OUTPUT.CMAKE
```
```
100% tests passed, 0 tests failed out of 558

Subproject Time Summary:
Belos      = 183.91 sec*proc (99 tests)
Ifpack2    =  61.39 sec*proc (44 tests)
MueLu      = 757.94 sec*proc (63 tests)
Teko       = 152.59 sec*proc (18 tests)
Tpetra     = 341.18 sec*proc (221 tests)
Zoltan2    = 246.19 sec*proc (113 tests)
```

<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->