### PR TITLE
Tpetra: Resolve CUDA_LAUNCH_BLOCKING requirements for serial

### DIFF
--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
@@ -2019,6 +2019,8 @@ void mult_A_B_reuse(
       }
     });
 
+  Kokkos::fence();
+
   // Call the actual kernel.  We'll rely on partial template specialization to call the correct one ---
   // Either the straight-up Tpetra code (SerialNode) or the KokkosKernels one (other NGP node types)
   KernelWrappers<Scalar,LocalOrdinal,GlobalOrdinal,Node,lo_view_t>::mult_A_B_reuse_kernel_wrapper(Aview,Bview,targetMapToOrigRow,targetMapToImportRow,Bcol2Ccol,Icol2Ccol,C,Cimport,label,params);
@@ -2322,6 +2324,8 @@ void jacobi_A_B_newmatrix(
 
       }
     });
+
+  Kokkos::fence();
 
   // Call the actual kernel.  We'll rely on partial template specialization to call the correct one ---
   // Either the straight-up Tpetra code (SerialNode) or the KokkosKernels one (other NGP node types)
@@ -2666,6 +2670,8 @@ void jacobi_A_B_reuse(
 #ifdef HAVE_TPETRA_MMM_TIMINGS
   MM = Teuchos::null;
 #endif
+
+  Kokkos::fence();
 
   // Call the actual kernel.  We'll rely on partial template specialization to call the correct one ---
   // Either the straight-up Tpetra code (SerialNode) or the KokkosKernels one (other NGP node types)

--- a/packages/tpetra/core/src/Tpetra_transform_MultiVector.hpp
+++ b/packages/tpetra/core/src/Tpetra_transform_MultiVector.hpp
@@ -325,8 +325,15 @@ namespace Tpetra {
              range_type range (execSpace, 0, lclNumRows);
 
              // MDM-TODO
-             // Need to resolve this fencine for the transform tests.
-             // Also may need host or device fence depending on user choice.
+             // Need to resolve this fencing for the transform tests.
+             // If data is on device and the transform calls for execSpace host
+             // we'll need a fence. However the transform to host call currently
+             // leaves need_sync_host() true which i need to discuss and verify
+             // if it's an error. Perhaps that should be resolved first.
+             // Also may need host or device fence. This default fence is on device
+             // which happens to work for the current test setup. I think we'll
+             // want to make a flipped version of the test to force the error here.
+             // Note PR 6617 discusses these current issues.
              Kokkos::fence();
 
              Kokkos::parallel_for (kernelLabel, range, g);
@@ -364,9 +371,7 @@ namespace Tpetra {
             using range_type = Kokkos::RangePolicy<ExecutionSpace, LO>;
             range_type range (execSpace, 0, lclNumRows);
 
-            // MDM-TODO
-            // Need to resolve this fencine for the transform tests.
-            // Also may need host or device fence depending on user choice.
+            // MDM-TODO - see similar note above for transform_vec_notSameObject
             Kokkos::fence();
 
             Kokkos::parallel_for (kernelLabel, range, g);

--- a/packages/tpetra/core/src/Tpetra_transform_MultiVector.hpp
+++ b/packages/tpetra/core/src/Tpetra_transform_MultiVector.hpp
@@ -324,17 +324,14 @@ namespace Tpetra {
              using range_type = Kokkos::RangePolicy<ExecutionSpace, LO>;
              range_type range (execSpace, 0, lclNumRows);
 
-             // MDM-TODO
-             // Need to resolve this fencing for the transform tests.
-             // If data is on device and the transform calls for execSpace host
-             // we'll need a fence. However the transform to host call currently
-             // leaves need_sync_host() true which i need to discuss and verify
-             // if it's an error. Perhaps that should be resolved first.
-             // Also may need host or device fence. This default fence is on device
-             // which happens to work for the current test setup. I think we'll
-             // want to make a flipped version of the test to force the error here.
-             // Note PR 6617 discusses these current issues.
-             Kokkos::fence();
+             // Note that the Transform.cpp test will not currently pass
+             // with CUDA_LAUNCH_BLOCKING=0. This is because execSpace is not
+             // considered by withLocalAccess so after requesting the transform
+             // with Host we don't get a sync and need_sync_host() is still true.
+             // That issue is regardless of whether CUDA_LAUNCH_BLOCKING is set.
+             // When withLocalAccess is fixed we should then have the proper fencing
+             // and the test will run correctly with CUDA_LAUNCH_BLOCKING=0 or =1.
+             // PR 6617 discusses these current issues.
 
              Kokkos::parallel_for (kernelLabel, range, g);
            },
@@ -371,8 +368,8 @@ namespace Tpetra {
             using range_type = Kokkos::RangePolicy<ExecutionSpace, LO>;
             range_type range (execSpace, 0, lclNumRows);
 
-            // MDM-TODO - see similar note above for transform_vec_notSameObject
-            Kokkos::fence();
+            // See note above for explanation why a pending fix to withLocalAccess
+            // will fix Transform.cpp test to pass with CUDA_LAUNCH_BLOCKING=0.
 
             Kokkos::parallel_for (kernelLabel, range, g);
           },

--- a/packages/tpetra/core/src/Tpetra_transform_MultiVector.hpp
+++ b/packages/tpetra/core/src/Tpetra_transform_MultiVector.hpp
@@ -323,6 +323,12 @@ namespace Tpetra {
              const LO lclNumRows = static_cast<LO> (input_lcl.extent (0));
              using range_type = Kokkos::RangePolicy<ExecutionSpace, LO>;
              range_type range (execSpace, 0, lclNumRows);
+
+             // MDM-TODO
+             // Need to resolve this fencine for the transform tests.
+             // Also may need host or device fence depending on user choice.
+             Kokkos::fence();
+
              Kokkos::parallel_for (kernelLabel, range, g);
            },
            readOnly (input).on (memSpace),
@@ -357,6 +363,12 @@ namespace Tpetra {
             const LO lclNumRows = static_cast<LO> (input_lcl.extent (0));
             using range_type = Kokkos::RangePolicy<ExecutionSpace, LO>;
             range_type range (execSpace, 0, lclNumRows);
+
+            // MDM-TODO
+            // Need to resolve this fencine for the transform tests.
+            // Also may need host or device fence depending on user choice.
+            Kokkos::fence();
+
             Kokkos::parallel_for (kernelLabel, range, g);
           },
           readOnly (input).on (memSpace),

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests4.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests4.cpp
@@ -846,6 +846,8 @@ inline void tupleToArray(Array<T> &arr, const tuple &tup)
     Tpetra::Details::inverseScaleBlockDiagonal(*diag2,false,*toScale2);
     Tpetra::Details::inverseScaleBlockDiagonal(*diag4,false,*toScale4);
 
+    Kokkos::fence();
+
     // Check norms
     Array<Mag> norms2(1), norms4(1);
     toScale2->norm1(norms2());
@@ -940,6 +942,8 @@ inline void tupleToArray(Array<T> &arr, const tuple &tup)
     // Now, let's rescale some vectors
     Tpetra::Details::inverseScaleBlockDiagonal(*diag2,true,*toScale2);
     Tpetra::Details::inverseScaleBlockDiagonal(*diag4,true,*toScale4);
+
+    Kokkos::fence();
 
     // Check norms
     Array<Mag> norms2(1), norms4(1);

--- a/packages/tpetra/core/test/MatrixMatrix/MatrixMatrix_UnitTests.cpp
+++ b/packages/tpetra/core/test/MatrixMatrix/MatrixMatrix_UnitTests.cpp
@@ -701,6 +701,8 @@ mult_test_results multiply_reuse_test(
   RCP<Matrix_t> diffMatrix = 
     Tpetra::createCrsMatrix<SC,LO,GO,NT>(C->getRowMap(),
                                          computedC2->getGlobalMaxNumRowEntries());
+
+  Kokkos::fence();
   Tpetra::MatrixMatrix::Add(*computedC1, false, -one, *computedC2, false, one, diffMatrix);
   diffMatrix->fillComplete(C->getDomainMap(), C->getRangeMap());
 

--- a/packages/tpetra/core/test/MultiVector/Transform.cpp
+++ b/packages/tpetra/core/test/MultiVector/Transform.cpp
@@ -138,7 +138,6 @@ namespace { // (anonymous)
     }
 
     Y.putScalar (418.0);
-
     out << "transform on default host execution space: 418 -> 419" << endl;
 
     transform ("418 -> 419", Kokkos::DefaultHostExecutionSpace (), Y, X,
@@ -299,7 +298,6 @@ namespace { // (anonymous)
     }
 
     Y.putScalar (418.0);
-
     out << "transform on default host execution space: 418 -> 419" << endl;
 
     transform ("418 -> 419", Kokkos::DefaultHostExecutionSpace (), Y, X,

--- a/packages/tpetra/core/test/MultiVector/Transform.cpp
+++ b/packages/tpetra/core/test/MultiVector/Transform.cpp
@@ -107,6 +107,7 @@ namespace { // (anonymous)
     constexpr double flagValue = -1.0;
     X.putScalar (flagValue);
     Y.putScalar (666.0);
+    Kokkos::fence();
 
     out << "transform on default execution space: -1 -> (666+1=667)" << endl;
     transform ("-1 -> (666+1=667)", Y, X,
@@ -138,6 +139,8 @@ namespace { // (anonymous)
     }
 
     Y.putScalar (418.0);
+    Kokkos::fence();
+
     out << "transform on default host execution space: 418 -> 419" << endl;
 
     transform ("418 -> 419", Kokkos::DefaultHostExecutionSpace (), Y, X,
@@ -270,6 +273,7 @@ namespace { // (anonymous)
     constexpr double flagValue = -1.0;
     X.putScalar (flagValue);
     Y.putScalar (666.0);
+    Kokkos::fence();
 
     out << "transform on default execution space: -1 -> (666+1=667)" << endl;
     transform ("-1 -> (666+1=667)", Y, X,
@@ -298,6 +302,8 @@ namespace { // (anonymous)
     }
 
     Y.putScalar (418.0);
+    Kokkos::fence();
+
     out << "transform on default host execution space: 418 -> 419" << endl;
 
     transform ("418 -> 419", Kokkos::DefaultHostExecutionSpace (), Y, X,

--- a/packages/tpetra/core/test/MultiVector/Transform.cpp
+++ b/packages/tpetra/core/test/MultiVector/Transform.cpp
@@ -107,7 +107,6 @@ namespace { // (anonymous)
     constexpr double flagValue = -1.0;
     X.putScalar (flagValue);
     Y.putScalar (666.0);
-    Kokkos::fence();
 
     out << "transform on default execution space: -1 -> (666+1=667)" << endl;
     transform ("-1 -> (666+1=667)", Y, X,
@@ -139,7 +138,6 @@ namespace { // (anonymous)
     }
 
     Y.putScalar (418.0);
-    Kokkos::fence();
 
     out << "transform on default host execution space: 418 -> 419" << endl;
 
@@ -273,7 +271,6 @@ namespace { // (anonymous)
     constexpr double flagValue = -1.0;
     X.putScalar (flagValue);
     Y.putScalar (666.0);
-    Kokkos::fence();
 
     out << "transform on default execution space: -1 -> (666+1=667)" << endl;
     transform ("-1 -> (666+1=667)", Y, X,
@@ -302,7 +299,6 @@ namespace { // (anonymous)
     }
 
     Y.putScalar (418.0);
-    Kokkos::fence();
 
     out << "transform on default host execution space: 418 -> 419" << endl;
 


### PR DESCRIPTION
These changes allow all Tpetra tests in serial to pass with
env variable CUDA_LAUNCH_BLOCKING=0, except for these utility
tests which specificaly check CUDA_LAUNCH_BLOCKING to be on.
They have not been changed and will still fail as expected:
- 	 TpetraCore_Core_initialize_where_tpetra_initializes_kokkos
- 	 TpetraCore_Core_ScopeGuard_where_tpetra_initializes_kokkos
- 	 TpetraCore_Core_initialize_where_user_initializes_kokkos
- 	 TpetraCore_Core_ScopeGuard_where_user_initializes_kokkos
- 	 TpetraCore_Map_no_warn_on_pre_finalize_destruction_issue_2372

One exception is TpetraCore_Transform which has an issue caused by the setup for  withLocalAccess. A planned fix is expected to fix the test to also work for CUDA_LAUNCH_BLOCKING=0 but that will be handled separately.

Parallel tests which fail with CUDA_LAUNCH_BLOCKING=0 have not been addressed yet.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Resolve Tpetra to not required CUDA_LAUNCH_BLOCKING
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
These were identified running Tpetra tests on white's Pascal node.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->