### PR TITLE
Ifpack2: pass correct "symmetric" flag to MTSGS setup

### DIFF
--- a/packages/ifpack2/src/Ifpack2_Relaxation_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Relaxation_def.hpp
@@ -686,9 +686,6 @@ void Relaxation<MatrixType>::initialize ()
       }
       local_matrix_type kcsr = crsMat->getLocalMatrix ();
 
-      bool is_symmetric = (PrecType_ == Ifpack2::Details::MTSGS);
-      is_symmetric = is_symmetric || is_matrix_structurally_symmetric_;
-
       using KokkosSparse::Experimental::gauss_seidel_symbolic;
       gauss_seidel_symbolic<mt_kernel_handle_type,
                             lno_row_view_t,
@@ -697,7 +694,7 @@ void Relaxation<MatrixType>::initialize ()
                                                  A_->getNodeNumCols (),
                                                  kcsr.graph.row_map,
                                                  kcsr.graph.entries,
-                                                 is_symmetric);
+                                                 is_matrix_structurally_symmetric_);
     }
   } // timing of initialize stops here
 
@@ -1300,7 +1297,6 @@ void Relaxation<MatrixType>::compute ()
          "when the input matrix is a Tpetra::CrsMatrix.");
       local_matrix_type kcsr = crsMat->getLocalMatrix ();
 
-      const bool is_symmetric = (PrecType_ == Ifpack2::Details::MTSGS);
       auto diagView_2d = Diagonal_->getLocalViewDevice ();
       auto diagView_1d = Kokkos::subview (diagView_2d, Kokkos::ALL (), 0);
       using KokkosSparse::Experimental::gauss_seidel_numeric;
@@ -1314,7 +1310,7 @@ void Relaxation<MatrixType>::compute ()
                                                    kcsr.graph.entries,
                                                    kcsr.values,
                                                    diagView_1d,
-                                                   is_symmetric);
+                                                   is_matrix_structurally_symmetric_);
     }
   } // end TimeMonitor scope
 


### PR DESCRIPTION
gauss_seidel_symbolic() and gauss_seidel_numeric() take a "symmetric"
flag, but this refers to graph (structural) symmetry and not symmetry
as in forward+backward sweeps, which is what Ifpack2 was passing in.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/ifpack2 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Fixes incorrect behavior - if KokkosKernels gauss seidel setup is promised a symmetric graph, the input graph won't be symmetrized before doing coloring. This could potentially lead to adjacent rows being given the same color.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
Code owner
## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
This is tested in Ifpack2_UnitTestRelaxation under MTSGS and ClusterMTSGS.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->