### PR TITLE
Tpetra: Correcting unecessary extraction of remotes for A matrix in Jacobi

### DIFF
--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
@@ -392,7 +392,7 @@ void Jacobi(Scalar omega,
 
   //Now import any needed remote rows and populate the Aview struct.
   RCP<const import_type> dummyImporter;
-  MMdetails::import_and_extract_views(*Aprime, targetMap_A, Aview, dummyImporter, false, label,importParams1);
+  MMdetails::import_and_extract_views(*Aprime, targetMap_A, Aview, dummyImporter, true, label,importParams1);
 
   // We will also need local access to all rows of B that correspond to the
   // column-map of op(A).

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
@@ -2889,9 +2889,11 @@ void import_and_extract_views(
   Aview.colMap       = A.getColMap();
   Aview.domainMap    = A.getDomainMap();
   Aview.importColMap = null;
+  RCP<const map_type> rowMap = A.getRowMap();
+  const int numProcs = rowMap->getComm()->getSize();
 
-  // Short circuit if the user swears there are no remotes
-  if (userAssertsThereAreNoRemotes)
+  // Short circuit if the user swears there are no remotes (or if we're in serial)
+  if (userAssertsThereAreNoRemotes || numProcs < 2)
     return;
 
   RCP<const import_type> importer;
@@ -2906,13 +2908,16 @@ void import_and_extract_views(
 
     // Mark each row in targetMap as local or remote, and go ahead and get a view
     // for the local rows
-    RCP<const map_type> rowMap = A.getRowMap(), remoteRowMap;
+    RCP<const map_type> remoteRowMap;
     size_t numRemote = 0;
     int mode = 0;
     if (!prototypeImporter.is_null() &&
         prototypeImporter->getSourceMap()->isSameAs(*rowMap)     &&
         prototypeImporter->getTargetMap()->isSameAs(*targetMap)) {
       // We have a valid prototype importer --- ask it for the remotes
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+      TimeMonitor MM2 = *TimeMonitor::getNewTimer(prefix_mmm + std::string("MMM I&X RemoteMap-Mode1"));
+#endif
       ArrayView<const LO> remoteLIDs = prototypeImporter->getRemoteLIDs();
       numRemote = prototypeImporter->getNumRemoteIDs();
 
@@ -2926,6 +2931,9 @@ void import_and_extract_views(
 
     } else if (prototypeImporter.is_null()) {
       // No prototype importer --- count the remotes the hard way
+#ifdef HAVE_TPETRA_MMM_TIMINGS
+      TimeMonitor MM2 = *TimeMonitor::getNewTimer(prefix_mmm + std::string("MMM I&X RemoteMap-Mode2"));
+#endif
       ArrayView<const GO> rows    = targetMap->getNodeElementList();
       size_t              numRows = targetMap->getNodeNumElements();
 
@@ -2945,8 +2953,6 @@ void import_and_extract_views(
       // PrototypeImporter is bad.  But if we're in serial that's OK.
       mode = 3;
     }
-
-    const int numProcs = rowMap->getComm()->getSize();
 
     if (numProcs < 2) {
       TEUCHOS_TEST_FOR_EXCEPTION(numRemote > 0, std::runtime_error,


### PR DESCRIPTION
Tests: RHEL6, Cuda(vortex)