### PR TITLE
Tpetra,Anasazi: Fix #6611, #6612, & #6633

### DIFF
--- a/packages/anasazi/src/AnasaziMVOPTester.hpp
+++ b/packages/anasazi/src/AnasaziMVOPTester.hpp
@@ -862,8 +862,8 @@ namespace Anasazi {
       std::vector<MagType> normsB1(p), normsB2(p),
                            normsC1(p), normsC2(p),
                            normsD1(p), normsD2(p);
-      ScalarType alpha = 0.5 * SCT::one(),
-                  beta = 0.33 * SCT::one();
+      ScalarType alpha = MagType(0.5) * SCT::one();
+      ScalarType beta = MagType(0.33) * SCT::one();
 
       B = MVT::Clone(*A,p);
       C = MVT::Clone(*A,p);

--- a/packages/belos/tpetra/test/BlockGmres/test_bl_gmres_hb_df.cpp
+++ b/packages/belos/tpetra/test/BlockGmres/test_bl_gmres_hb_df.cpp
@@ -60,6 +60,8 @@
 #include <Tpetra_CrsMatrix.hpp>
 #include <Teuchos_TypeNameTraits.hpp>
 
+#include <fstream>
+
 using namespace Teuchos;
 using namespace Belos;
 using Tpetra::Operator;

--- a/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_dot_impl.hpp
+++ b/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_dot_impl.hpp
@@ -81,7 +81,7 @@ struct DotFunctor
   KOKKOS_FORCEINLINE_FUNCTION void
   operator() (const size_type &i, value_type& sum) const
   {
-    sum += IPT::dot (m_x(i), m_y(i));  // m_x(i) * m_y(i)
+    Kokkos::Details::updateDot(sum, m_x(i), m_y(i)); // sum += m_x(i) * m_y(i)
   }
 
   KOKKOS_INLINE_FUNCTION void

--- a/packages/teuchos/numerics/src/Teuchos_MatrixMarket_generic.hpp
+++ b/packages/teuchos/numerics/src/Teuchos_MatrixMarket_generic.hpp
@@ -49,6 +49,7 @@
 #include <iostream>
 #include <sstream>
 #include <stdexcept>
+#include <type_traits>
 #include <vector>
 
 namespace Teuchos {
@@ -261,7 +262,16 @@ namespace Teuchos {
               throw std::invalid_argument(os.str());
             }
         }
-      istr >> the_realValue;
+      {
+        if (std::is_same<Real, float>::value) {
+          double dblVal {};
+          istr >> dblVal;
+          the_realValue = static_cast<Real> (dblVal);
+        }
+        else {
+          istr >> the_realValue;
+        }
+      }
       if (istr.fail())
         {
           if (tolerant)

--- a/packages/tpetra/core/test/Block/BlockCrsMatrix.cpp
+++ b/packages/tpetra/core/test/Block/BlockCrsMatrix.cpp
@@ -2463,7 +2463,10 @@ namespace {
     else {
       out << normStr.str() << std::endl;
     }
-    TEUCHOS_TEST_FOR_EXCEPTION(relativeError[0]>5e-8, std::runtime_error, "BlockCrsMatrix matvec does not produce same result as CrsMatrix matvec.");
+
+    const magnitude_type tol =
+      magnitude_type(10.0) * Teuchos::ScalarTraits<magnitude_type>::eps();
+    TEUCHOS_TEST_FOR_EXCEPTION(relativeError[0] > tol, std::runtime_error, "BlockCrsMatrix matvec does not produce same result as CrsMatrix matvec.");
   }
 
 

--- a/packages/tpetra/core/test/MatrixMatrix/MatrixMatrix_UnitTests.cpp
+++ b/packages/tpetra/core/test/MatrixMatrix/MatrixMatrix_UnitTests.cpp
@@ -457,7 +457,7 @@ mult_test_results multiply_test_autofc(
 #endif
 
 
-  RCP<Matrix_t> diffMatrix = 
+  RCP<Matrix_t> diffMatrix =
     Tpetra::createCrsMatrix<SC,LO,GO,NT>(C->getRowMap(), C->getGlobalMaxNumRowEntries());
   Tpetra::MatrixMatrix::Add(*C, false, -one, *computedC, false, one, diffMatrix);
   diffMatrix->fillComplete(C->getDomainMap(), C->getRangeMap());
@@ -550,8 +550,8 @@ mult_test_results multiply_RAP_test_autofc(
 #endif
 
 
-  RCP<Matrix_t> diffMatrix = 
-    Tpetra::createCrsMatrix<SC,LO,GO,NT>(Ac->getRowMap(), 
+  RCP<Matrix_t> diffMatrix =
+    Tpetra::createCrsMatrix<SC,LO,GO,NT>(Ac->getRowMap(),
                                          Ac->getGlobalMaxNumRowEntries());
   Tpetra::MatrixMatrix::Add(*Ac, false, -one, *computedAc, false, one, diffMatrix);
   diffMatrix->fillComplete(Ac->getDomainMap(), Ac->getRangeMap());
@@ -601,7 +601,7 @@ mult_test_results multiply_RAP_reuse_test(
   SC one = Teuchos::ScalarTraits<SC>::one();
 
   // First cut
-  Tpetra::TripleMatrixMultiply::MultiplyRAP(*R, RT, *A, AT, *P, PT, *computedC1);  
+  Tpetra::TripleMatrixMultiply::MultiplyRAP(*R, RT, *A, AT, *P, PT, *computedC1);
 
   if(!Ac->getDomainMap()->isSameAs(*computedC1->getDomainMap())) throw std::runtime_error("Domain map mismatch");
   if(!Ac->getRangeMap()->isSameAs(*computedC1->getRangeMap())) throw std::runtime_error("Range map mismatch");
@@ -610,10 +610,10 @@ mult_test_results multiply_RAP_reuse_test(
   RCP<Matrix_t> computedC2 = rcp( new Matrix_t(computedC1->getCrsGraph()) );
   computedC2->fillComplete(computedC2->getDomainMap(), computedC2->getRangeMap());
   computedC2->resumeFill();
-  Tpetra::TripleMatrixMultiply::MultiplyRAP(*R, RT, *A, AT, *P, PT, *computedC2);  
+  Tpetra::TripleMatrixMultiply::MultiplyRAP(*R, RT, *A, AT, *P, PT, *computedC2);
 
   // Only check the second "reuse" matrix
-  RCP<Matrix_t> diffMatrix = 
+  RCP<Matrix_t> diffMatrix =
     Tpetra::createCrsMatrix<SC,LO,GO,NT>(map, Ac->getGlobalMaxNumRowEntries());
   Tpetra::MatrixMatrix::Add(*Ac, false, -one, *computedC2, false, one, diffMatrix);
   diffMatrix->fillComplete(Ac->getDomainMap(), Ac->getRangeMap());
@@ -623,7 +623,7 @@ mult_test_results multiply_RAP_reuse_test(
   results.compNorm = diffMatrix->getFrobeniusNorm ();
   results.epsilon  = results.compNorm/results.cNorm;
 
-  if(results.epsilon > 1e-3) {    
+  if(results.epsilon > 1e-3) {
     if(!comm->getRank()) printf("ERROR: TEST %s FAILED\n",name.c_str());
   }
 
@@ -698,7 +698,7 @@ mult_test_results multiply_reuse_test(
 
   // diffMatrix = computedC2 - computedC1
   SC one = Teuchos::ScalarTraits<SC>::one();
-  RCP<Matrix_t> diffMatrix = 
+  RCP<Matrix_t> diffMatrix =
     Tpetra::createCrsMatrix<SC,LO,GO,NT>(C->getRowMap(),
                                          computedC2->getGlobalMaxNumRowEntries());
   Tpetra::MatrixMatrix::Add(*computedC1, false, -one, *computedC2, false, one, diffMatrix);
@@ -744,7 +744,7 @@ mult_test_results jacobi_test(
   Tpetra::MatrixMatrix::Jacobi<SC, LO, GO, NT>(omega,Dinv,*A,*B,*C);
 
   // Multiply + Add version
-  RCP<Matrix_t> C2; 
+  RCP<Matrix_t> C2;
   bool done=false;
 #ifdef HAVE_TPETRA_INST_OPENMP
     if(std::is_same<NT,Kokkos::Compat::KokkosOpenMPWrapperNode>::value) {
@@ -771,7 +771,7 @@ mult_test_results jacobi_test(
 
       Tpetra::MatrixMatrix::Multiply(*A,false,*B,false,*AB);
       AB->leftScale(Dinv);
-      C2 = rcp(new Matrix_t(B->getRowMap(), 
+      C2 = rcp(new Matrix_t(B->getRowMap(),
                             B->getGlobalMaxNumRowEntries() + AB->getGlobalMaxNumRowEntries())); // upper bound
       Tpetra::MatrixMatrix::Add(*AB,false,-one,*B,false,one,C2);
       if(!C2->isFillComplete()) C2->fillComplete(C->getDomainMap(),C->getRangeMap());
@@ -837,7 +837,7 @@ mult_test_results jacobi_reuse_test(
 
   // diffMatrix = computedC2 - computedC1
 
-  RCP<Matrix_t> diffMatrix = 
+  RCP<Matrix_t> diffMatrix =
     Tpetra::createCrsMatrix<SC,LO,GO,NT>(computedC1->getRowMap(),
                                          computedC1->getGlobalMaxNumRowEntries());
   Tpetra::MatrixMatrix::Add(*computedC1, false, -one, *computedC2, false, one, diffMatrix);
@@ -931,42 +931,62 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Tpetra_MatMat, operations_test,SC,LO, GO, NT) 
     RCP<Matrix_t> A, B, C, D;
 
     if (A_file != ""){
-      if (A_domainmap_file == "" || A_rangemap_file == "" || A_rowmap_file == "" || A_colmap_file == "")
+      if (A_domainmap_file == "" || A_rangemap_file == "" || A_rowmap_file == "" || A_colmap_file == "") {
+        out << "Attempt to read sparse matrix file \"" << A_file
+            << "\"" << endl;
         A = Reader<Matrix_t>::readSparseFile (A_file, comm);
+      }
       else {
         RCP<const map_type> domainmap = Reader<Matrix_t>::readMapFile (A_domainmap_file, comm);
         RCP<const map_type> rangemap  = Reader<Matrix_t>::readMapFile (A_rangemap_file, comm);
         RCP<const map_type> rowmap    = Reader<Matrix_t>::readMapFile (A_rowmap_file, comm);
         RCP<const map_type> colmap    = Reader<Matrix_t>::readMapFile (A_colmap_file, comm);
+        out << "Attempt to read sparse matrix file \""
+            << A_file << "\"" << endl;
         A = Reader<Matrix_t>::readSparseFile (A_file, rowmap, colmap, domainmap, rangemap);
       }
     }
-    if (B_domainmap_file == "" || B_rangemap_file == "" || B_rowmap_file == "" || B_colmap_file == "")
+    if (B_domainmap_file == "" || B_rangemap_file == "" || B_rowmap_file == "" || B_colmap_file == "") {
+      out << "Attempt to read sparse matrix file \"" << B_file
+          << "\"" << endl;
       B = Reader<Matrix_t>::readSparseFile (B_file, comm);
+    }
     else {
       RCP<const map_type> domainmap = Reader<Matrix_t>::readMapFile (B_domainmap_file, comm);
       RCP<const map_type> rangemap  = Reader<Matrix_t>::readMapFile (B_rangemap_file, comm);
       RCP<const map_type> rowmap    = Reader<Matrix_t>::readMapFile (B_rowmap_file, comm);
       RCP<const map_type> colmap    = Reader<Matrix_t>::readMapFile (B_colmap_file, comm);
+      out << "Attempt to read sparse matrix file \"" << B_file
+          << "\"" << endl;
       B = Reader<Matrix_t>::readSparseFile (B_file, rowmap, colmap, domainmap, rangemap);
     }
-    if (C_domainmap_file == "" || C_rangemap_file == "" || C_rowmap_file == "" || C_colmap_file == "")
+    if (C_domainmap_file == "" || C_rangemap_file == "" || C_rowmap_file == "" || C_colmap_file == "") {
+      out << "Attempt to read sparse matrix file \"" << C_file
+          << "\"" << endl;
       C = Reader<Matrix_t>::readSparseFile (C_file, comm);
+    }
     else {
       RCP<const map_type> domainmap = Reader<Matrix_t>::readMapFile (C_domainmap_file, comm);
       RCP<const map_type> rangemap  = Reader<Matrix_t>::readMapFile (C_rangemap_file, comm);
       RCP<const map_type> rowmap    = Reader<Matrix_t>::readMapFile (C_rowmap_file, comm);
       RCP<const map_type> colmap    = Reader<Matrix_t>::readMapFile (C_colmap_file, comm);
+      out << "Attempt to read sparse matrix file \"" << C_file
+          << "\"" << endl;
       C = Reader<Matrix_t>::readSparseFile (C_file, rowmap, colmap, domainmap, rangemap);
     }
     if (D_file != "") {
-      if (D_domainmap_file == "" || D_rangemap_file == "" || D_rowmap_file == "" || D_colmap_file == "")
+      if (D_domainmap_file == "" || D_rangemap_file == "" || D_rowmap_file == "" || D_colmap_file == "") {
+        out << "Attempt to read sparse matrix file \"" << D_file
+            << "\"" << endl;
         D = Reader<Matrix_t>::readSparseFile (D_file, comm);
+      }
       else {
         RCP<const map_type> domainmap = Reader<Matrix_t>::readMapFile (D_domainmap_file, comm);
         RCP<const map_type> rangemap  = Reader<Matrix_t>::readMapFile (D_rangemap_file, comm);
         RCP<const map_type> rowmap    = Reader<Matrix_t>::readMapFile (D_rowmap_file, comm);
         RCP<const map_type> colmap    = Reader<Matrix_t>::readMapFile (D_colmap_file, comm);
+        out << "Attempt to read sparse matrix file \"" << D_file
+            << "\"" << endl;
         D = Reader<Matrix_t>::readSparseFile (D_file, rowmap, colmap, domainmap, rangemap);
       }
     }
@@ -1312,8 +1332,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(Tpetra_MatMat, range_row_test, SC, LO, GO, NT)
   bTransTest->fillComplete(bTransDomainMap, bTransRangeMap);
 
   newOut << "Create and fill bTrans" << endl;
-  RCP<Matrix_t> bTrans = 
-    Tpetra::createCrsMatrix<SC,LO,GO,NT>(bTransRowMap, 
+  RCP<Matrix_t> bTrans =
+    Tpetra::createCrsMatrix<SC,LO,GO,NT>(bTransRowMap,
                                          bTransTest->getGlobalMaxNumRowEntries());
 
   newOut << "Compute identity * transpose(bTrans)" << endl;

--- a/packages/tpetra/core/test/MultiVector/MultiVector_UnitTests.cpp
+++ b/packages/tpetra/core/test/MultiVector/MultiVector_UnitTests.cpp
@@ -43,8 +43,10 @@
 #include "Tpetra_MultiVector.hpp"
 #include "Tpetra_Vector.hpp"
 #include "Kokkos_ArithTraits.hpp"
+#include "Teuchos_CommHelpers.hpp"
 #include "Teuchos_DefaultSerialComm.hpp"
 #include "Teuchos_SerialDenseMatrix.hpp"
+#include "Teuchos_TypeNameTraits.hpp"
 #include <iterator>
 
 // FINISH: add test for MultiVector with a node containing zero local entries
@@ -327,10 +329,13 @@ namespace {
     typedef Tpetra::Vector<Scalar,LO,GO,Node> V;
     typedef typename ScalarTraits<Scalar>::magnitudeType Mag;
 
-    out << "Test: MultiVector, NonContigView" << endl;
+    out << "Test: MultiVector, NonContigView: Scalar="
+        << Teuchos::TypeNameTraits<Scalar>::name() << endl;
     Teuchos::OSTab tab0 (out);
 
     const Mag tol = errorTolSlack * errorTolSlack * testingTol<Scalar>();   // extra slack on this test; dots() seem to be a little sensitive for single precision types
+    out << "tol: " << tol << endl;
+
     const Mag M0  = ScalarTraits<Mag>::zero();
     const global_size_t INVALID = OrdinalTraits<global_size_t>::invalid();
     // get a comm
@@ -371,7 +376,25 @@ namespace {
       }
       // create the views, compute and test
       RCP<      MV> mvView1 = mvOrig1.subViewNonConst(inView1);
+      TEST_ASSERT( ! mvView1.is_null() );
+      if (! mvView1.is_null() ) {
+        auto mvView1_d = mvView1->getLocalViewDevice();
+        auto mvOrig1_d = mvOrig1.getLocalViewDevice();
+        TEST_ASSERT( mvView1_d.data() == mvOrig1_d.data() );
+        auto mvView1_h = mvView1->getLocalViewHost();
+        auto mvOrig1_h = mvOrig1.getLocalViewHost();
+        TEST_ASSERT( mvView1_h.data() == mvOrig1_h.data() );
+      }
       RCP<const MV> mvView2 = mvOrig2.subView(inView2);
+      TEST_ASSERT( ! mvView2.is_null() );
+      if (! mvView2.is_null() ) {
+        auto mvView2_lcl = mvView2->getLocalViewDevice();
+        auto mvOrig2_lcl = mvOrig2.getLocalViewDevice();
+        TEST_ASSERT( mvView2_lcl.data() == mvOrig2_lcl.data() );
+        auto mvView2_h = mvView2->getLocalViewHost();
+        auto mvOrig2_h = mvOrig2.getLocalViewHost();
+        TEST_ASSERT( mvView2_h.data() == mvOrig2_h.data() );
+      }
       Array<Mag> nView2(numView), nView1(numView), nViewI(numView);
       Array<Scalar> meansView(numView), dotsView(numView);
       mvView1->norm1(nView1());
@@ -379,13 +402,34 @@ namespace {
       mvView1->normInf(nViewI());
       mvView1->meanValue(meansView());
       mvView1->dot( *mvView2, dotsView() );
+
       for (size_t j=0; j < numView; ++j) {
         TEST_FLOATING_EQUALITY(nOrig1[inView1[j]],  nView1[j],  tol);
+      }
+      for (size_t j=0; j < numView; ++j) {
         TEST_FLOATING_EQUALITY(nOrig2[inView1[j]],  nView2[j],  tol);
+      }
+      for (size_t j=0; j < numView; ++j) {
         TEST_FLOATING_EQUALITY(nOrigI[inView1[j]],  nViewI[j],  tol);
+      }
+      for (size_t j=0; j < numView; ++j) {
         TEST_FLOATING_EQUALITY(meansOrig[inView1[j]], meansView[j], tol);
+      }
+      for (size_t j=0; j < numView; ++j) {
         TEST_FLOATING_EQUALITY(dotsOrig[j], dotsView[j], tol);
       }
+
+      int lclSuccess = success ? 1 : 0;
+      int gblSuccess = 0;
+      using Teuchos::outArg;
+      using Teuchos::reduceAll;
+      using Teuchos::REDUCE_MIN;
+      reduceAll(*comm, REDUCE_MIN, lclSuccess, outArg(gblSuccess));
+      TEST_EQUALITY_CONST( gblSuccess, 1 );
+      if (! success) {
+        return;
+      }
+
       // randomize the view, compute view one-norms, test difference
       mvView2 = Teuchos::null;
       mvView1->randomize();


### PR DESCRIPTION
@trilinos/tpetra @trilinos/anasazi 

## Motivation

1. Make Trilinos' tests build and pass with Mac Clang, so we can use it as a development platform.
2. Prevent spurious test failures with Scalar=`float` and `complex<float>`, by improving dot product accuracy.

## Related Issues

* Closes #6611, #6612, #6633 
* Matching kokkos-kernels issue: https://github.com/kokkos/kokkos-kernels/issues/574
* Matching kokkos-kernels PR: https://github.com/kokkos/kokkos-kernels/pull/575

## Testing

Tested on Mac Clang with the following version information:
```
Apple LLVM version 10.0.1 (clang-1001.0.46.4)
Target: x86_64-apple-darwin18.7.0
Thread model: posix
```
Set the following build options:
```
-D Trilinos_ENABLE_COMPLEX_DOUBLE:BOOL=ON
-D Trilinos_ENABLE_COMPLEX_FLOAT:BOOL=ON
-D Trilinos_ENABLE_FLOAT:BOOL=ON
```