### PR TITLE
Teuchos: Add operator bool() to Teuchos::RCP

### DIFF
--- a/packages/teuchos/core/src/Teuchos_RCP.hpp
+++ b/packages/teuchos/core/src/Teuchos_RCP.hpp
@@ -428,6 +428,14 @@ RCP<const T> RCP<T>::getConst() const
 }
 
 
+template<class T>
+inline
+RCP<T>::operator bool() const
+{
+  return (get() != 0);
+}
+
+
 // Reference counting
 
 

--- a/packages/teuchos/core/src/Teuchos_RCPDecl.hpp
+++ b/packages/teuchos/core/src/Teuchos_RCPDecl.hpp
@@ -650,6 +650,9 @@ public:
   /** \brief Shorthand for ptr(). */
   inline Ptr<T> operator()() const;
 
+  /** \brief Check if the RCP stores a non-null pointer */
+  inline explicit operator bool() const;
+  
   /** \brief Return an RCP<const T> version of *this. */
   inline RCP<const T> getConst() const;
 

--- a/packages/teuchos/core/test/MemoryManagement/RCP_UnitTests.cpp
+++ b/packages/teuchos/core/test/MemoryManagement/RCP_UnitTests.cpp
@@ -225,6 +225,41 @@ TEUCHOS_UNIT_TEST( RCP, move_assign_nonnull )
 }
 
 
+TEUCHOS_UNIT_TEST( RCP, operator_bool_null )
+{
+  RCP<A> a_rcp;
+  TEST_EQUALITY_CONST(bool(a_rcp), false);
+}
+
+
+TEUCHOS_UNIT_TEST( RCP, operator_bool_nonnull )
+{
+  RCP<A> a_rcp(new A);
+  TEST_EQUALITY_CONST(bool(a_rcp), true);
+}
+
+
+TEUCHOS_UNIT_TEST( RCP, operator_bool_if )
+{
+  RCP<A> a_rcp(new A);
+  RCP<A> b_rcp;
+  bool a_is_null;
+  bool b_is_null;
+
+  if (a_rcp)
+    a_is_null = false;
+  else
+    a_is_null = true;
+  if (b_rcp)
+    b_is_null = false;
+  else
+    b_is_null = true;
+ 
+  TEST_EQUALITY_CONST(a_is_null, false);
+  TEST_EQUALITY_CONST(b_is_null, true );
+}
+
+
 TEUCHOS_UNIT_TEST( RCP, getConst )
 {
   RCP<A> a_rcp(new A);


### PR DESCRIPTION
@trilinos/teuchos 

## Motivation
This PR adds an `operator bool()` to the `Teuchos::RCP` class.

## Related Issues

* Closes #6608 

## Testing
Since the `Teuchos::RCP` is so pervasive, and an improper `operator bool()` can interrupt the type system, I will defer to @bartlettroscoe to ensure proper testing.
