### PR TITLE
Moertel: Small improvements linked to the perpendicular test

### DIFF
--- a/packages/moertel/src/mortar/Moertel_Tolerances.hpp
+++ b/packages/moertel/src/mortar/Moertel_Tolerances.hpp
@@ -52,7 +52,7 @@ namespace MOERTEL
 {
 
 const double Nodes_Identical_Epsilon = 1.0e-15;
-const double Projection_Length_Epsilon = 1.0e-10;
+const double Projection_Length_Epsilon = 0.25;
 const double Rough_Search_Radius = 2.5;
 
 

--- a/packages/moertel/src/mortar/mrtr_manager.H
+++ b/packages/moertel/src/mortar/mrtr_manager.H
@@ -610,6 +610,31 @@ public:
   */
   const Epetra_CrsMatrix* M() const { return M_.get();}
 
+  std::map<int,int> lm_to_dof()
+  {
+      std::map<int,Teuchos::RCP<MOERTEL::Interface> >::iterator curr;
+      // Create a map from Lagrange multiplier dofs to the primal dofs on the same node
+      std::vector<MOERTEL::Node*> nodes(0);
+      std::map<int,int> lm_to_dof;
+      for (curr=interface_.begin(); curr!=interface_.end(); ++curr)
+      {
+      Teuchos::RCP<MOERTEL::Interface> inter = curr->second;
+        inter->GetNodeView(nodes);
+        for (std::size_t i=0; i<(std::size_t)nodes.size(); ++i)
+        {
+          if (!nodes[i]->Nlmdof())
+            continue;
+          const int* dof = nodes[i]->Dof();
+          const int* lmdof = nodes[i]->LMDof();
+          for (std::size_t j=0; j<nodes[i]->Nlmdof(); ++j)
+            lm_to_dof[lmdof[j]] = dof[j];
+        }
+      }
+      lm_to_dof_ = Teuchos::rcp(new std::map<int,int>(lm_to_dof));
+
+      return lm_to_dof;
+  }
+
   /*!
   \brief Query a managed interface added using AddInterface
   
@@ -676,7 +701,7 @@ protected:
   Teuchos::RCP<Epetra_CrsMatrix> spdmatrix_;           // the spd matrix of the problem;
   Teuchos::RCP<Epetra_CrsMatrix> spdrhs_;              // the matrix to left-multiply the rhs vector with for the spd problem
   
-  Teuchos::RCP<std::map<int,int> >    lm_to_dof_;           // maps lagrange multiplier dofs to primary dofs (slave side))
+  Teuchos::RCP<std::map<int,int> >    lm_to_dof_;      // maps Lagrange multiplier dofs to primary dofs (slave side)
   
   Teuchos::RCP<Epetra_CrsMatrix> I_;
   Teuchos::RCP<Epetra_CrsMatrix> WT_;

--- a/packages/moertel/src/mortar/mrtr_manager.H
+++ b/packages/moertel/src/mortar/mrtr_manager.H
@@ -614,19 +614,19 @@ public:
   {
       std::map<int,Teuchos::RCP<MOERTEL::Interface> >::iterator curr;
       // Create a map from Lagrange multiplier dofs to the primal dofs on the same node
-      std::vector<MOERTEL::Node*> nodes(0);
+      std::vector<MOERTEL::Node*> nodes;
       std::map<int,int> lm_to_dof;
       for (curr=interface_.begin(); curr!=interface_.end(); ++curr)
       {
       Teuchos::RCP<MOERTEL::Interface> inter = curr->second;
         inter->GetNodeView(nodes);
-        for (std::size_t i=0; i<(std::size_t)nodes.size(); ++i)
+        for (auto&& node : nodes)
         {
-          if (!nodes[i]->Nlmdof())
+          if (! node->Nlmdof())
             continue;
-          const int* dof = nodes[i]->Dof();
-          const int* lmdof = nodes[i]->LMDof();
-          for (std::size_t j=0; j<nodes[i]->Nlmdof(); ++j)
+          const int* dof = node->Dof();
+          const int* lmdof = node->LMDof();
+          for (std::size_t j=0; j<node->Nlmdof(); ++j)
             lm_to_dof[lmdof[j]] = dof[j];
         }
       }

--- a/packages/moertel/src/mortar/mrtr_overlap_Def.hpp
+++ b/packages/moertel/src/mortar/mrtr_overlap_Def.hpp
@@ -403,12 +403,7 @@ bool MOERTEL::Overlap<IFace>::build_sxim()
       double mag_projection = fabs(MOERTEL::dot(node_norm,master_normal,3));
 
       if(mag_projection <= Projection_Length_Epsilon)
-      {
-        std::cout << "sxim mag_projection: " << mag_projection << std::endl;
-        std::cout << master_normal[0] << " " << master_normal[1] << " " << master_normal[2] << std::endl;
-        std::cout << node_norm[0] << " " << node_norm[1] << " " << node_norm[2] << std::endl;
         return false;
-      }
     }
     // project node i onto sseg
     bool OK = projector.ProjectNodetoSegment_NodalNormal(*snode[i],mseg_,sxim_[i],gap);
@@ -1493,12 +1488,7 @@ bool MOERTEL::Overlap<IFace>::Triangulation()
 
         double mag_projection = fabs(MOERTEL::dot(node_norm,master_normal,3));
         if(mag_projection <= Projection_Length_Epsilon)
-        {
-          std::cout << "mag_projection: " << mag_projection << std::endl;
-          std::cout << master_normal[0] << " " << master_normal[1] << " " << master_normal[2] << std::endl;
-          std::cout << node_norm[0] << " " << node_norm[1] << " " << node_norm[2] << std::endl;
           return false;
-        }
       }
       //-----------------
 


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/moertel

## Motivation
<!---
Why is this change required?  What problem does it solve? Please link to a github
issue that describes the problem/issue/bug this PR solves.
-->

The motivation behind this PR is to:
- Create a function that returns a map which links the Langrange multipliers and their associated primal dofs.
- Replace the perpendicular test with a relative one to not have an influence of the mesh size on the perpendicular test.

This PR is the second PR of a sequence of PRs intended to include the software developments of my thesis in Trilinos.

The first one (#6642 ) is independent of Moertel and not required for this PR.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes
* Blocks
* Is blocked by
* Follows
* Precedes
* Related to
* Part of
* Composed of
-->


## Stakeholder Feedback
<!---
If a github issue includes feedback from the relevant stakeholder(s), please link it.
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

This branch has been tested on the Blake system.

<!---
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
