### PR TITLE
Tempus: Initial Documentation for Iteration Matrix.

### DIFF
--- a/packages/tempus/src/Tempus_StepperBDF2_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperBDF2_decl.hpp
@@ -19,7 +19,7 @@ namespace Tempus {
 
 /** \brief BDF2 (Backward-Difference-Formula-2) time stepper.
  *
- *  For the implicit ODE system, \f$f(\dot{x},x,t) = 0\f$,
+ *  For the implicit ODE system, \f$\mathcal{F}(\dot{x},x,t) = 0\f$,
  *  the solution, \f$\dot{x}\f$ and \f$x\f$, is determined using a
  *  solver (e.g., a non-linear solver, like NOX).  This stepper allows
  *  for a variable time-step, \f$\Delta t\f$.  It is a 2-step method.
@@ -46,6 +46,31 @@ namespace Tempus {
  *  The First-Step-As-Last (FSAL) principle is not needed BDF2.
  *  The default is to set useFSAL=false, however useFSAL=true will also work
  *  but have no affect (i.e., no-op).
+ *
+ *  <b> Iteration Matrix, \f$W\f$.</b>
+ *  Recalling that the definition of the iteration matrix, \f$W\f$, is
+ *  \f[
+ *    W = \alpha \frac{\partial \mathcal{F}_n}{\partial \dot{x}_n}
+ *      + \beta  \frac{\partial \mathcal{F}_n}{\partial x_n},
+ *  \f]
+ *  where \f$ \alpha \equiv \frac{\partial \dot{x}_n(x_n) }{\partial x_n}, \f$
+ *  and \f$ \beta \equiv \frac{\partial x_n}{\partial x_n} = 1\f$, and
+ *  the time derivative for BDF2 is
+ *  \f[
+ *    \dot{x}_n(x_n) = \frac{2\tau_n + \tau_{n-1}}{\tau_n + \tau_{n-1}}
+ *                  \left[ \frac{x_n-x_{n-1}}{\tau_n}\right]
+ *                -  \frac{\tau_n}{\tau_n + \tau_{n-1}}
+ *                   \left[ \frac{x_{n-1}-x_{n-2}}{\tau_{n-1}}\right],
+ *  \f]
+ *  where \f$\Delta t_n = \tau_n = t_n - t_{n-1}\f$,
+ *  we can determine that
+ *  \f$ \alpha = \frac{2\tau_n + \tau_{n-1}}{(\tau_n + \tau_{n-1})\tau_n}\f$
+ *  and \f$ \beta = 1 \f$, and therefore write
+ *  \f[
+ *    W = \frac{2\tau_n + \tau_{n-1}}{(\tau_n + \tau_{n-1})\tau_n}
+          \frac{\partial \mathcal{F}_n}{\partial \dot{x}_n}
+ *      + \frac{\partial \mathcal{F}_n}{\partial x_n}.
+ *  \f]
  */
 template<class Scalar>
 class StepperBDF2 : virtual public Tempus::StepperImplicit<Scalar>

--- a/packages/tempus/src/Tempus_StepperBackwardEuler_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperBackwardEuler_decl.hpp
@@ -25,12 +25,33 @@ namespace Tempus {
  *
  *  <b> Algorithm </b>
  *  The single-timestep algorithm for Backward Euler is simply,
- *   - Solve \f$f(\dot{x}=(x_n-x_{n-1})/\Delta t_n, x_n, t_n)=0\f$ for \f$x_n\f$
+ *   - Solve \f$\mathcal{F}_n(\dot{x}=(x_n-x_{n-1})/\Delta t_n, x_n, t_n)=0\f$ for \f$x_n\f$
  *   - \f$\dot{x}_n \leftarrow (x_n-x_{n-1})/\Delta t_n\f$
  *
  *  The First-Step-As-Last (FSAL) principle is not needed with Backward Euler.
  *  The default is to set useFSAL=false, however useFSAL=true will also work
  *  but have no affect (i.e., no-op).
+ *
+ *  <b> Iteration Matrix, \f$W\f$.</b>
+ *  Recalling that the definition of the iteration matrix, \f$W\f$, is
+ *  \f[
+ *    W = \alpha \frac{\partial \mathcal{F}_n}{\partial \dot{x}_n}
+ *      + \beta  \frac{\partial \mathcal{F}_n}{\partial x_n},
+ *  \f]
+ *  where \f$ \alpha \equiv frac{\partial \dot{x}_n(x_n) }{\partial x_n}, \f$
+ *  and \f$ \beta \equiv \frac{\partial x_n}{\partial x_n} = 1\f$, and
+ *  the time derivative for Backward Euler is
+ *  \f[
+ *    \dot{x}_n(x_n) = \frac{x_n - x_{n-1}}{\Delta t},
+ *  \f]
+ *  we can determine that
+ *  \f$ \alpha = \frac{1}{\Delta t} \f$
+ *  and \f$ \beta = 1 \f$, and therefore write
+ *  \f[
+ *    W = \frac{1}{\Delta t}
+ *        \frac{\partial \mathcal{F}_n}{\partial \dot{x}_n}
+ *      + \frac{\partial \mathcal{F}_n}{\partial x_n}.
+ *  \f]
  */
 template<class Scalar>
 class StepperBackwardEuler :

--- a/packages/tempus/src/Tempus_StepperDIRK_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperDIRK_decl.hpp
@@ -73,7 +73,7 @@ namespace Tempus {
  *           x_{n-1} +\Delta t \sum_{j=1}^{i-1} a_{ij}\,\dot{X}_{j}\f$
  *       - Define \f$\dot{X}_i \leftarrow
  *                              \frac{X_{i} - \tilde{X}}{a_{ii} \Delta t}\f$
- *       - Solve \f$f(\dot{x} =
+ *       - Solve \f$\mathcal{F}_i(\dot{x} =
  *           \dot{X}_i,X_i,t_{n-1}+c_{i}\Delta t)=0\f$ for \f$X_i\f$
  *       - \f$\dot{X}_i \leftarrow \frac{X_{i} - \tilde{X}}{a_{ii} \Delta t}\f$
  *   - end for
@@ -82,6 +82,34 @@ namespace Tempus {
  *  The First-Step-As-Last (FSAL) principle is not needed with DIRK, but
  *  maybe useful if the first stage is explicit (i.e, EDIRK).
  *  The default is to set useFSAL=false.
+ *
+ *  <b> Iteration Matrix, \f$W\f$.</b>
+ *  Recalling that the definition of the iteration matrix, \f$W\f$, is
+ *  \f[
+ *    W = \alpha \frac{\partial \mathcal{F}_n}{\partial \dot{x}_n}
+ *      + \beta  \frac{\partial \mathcal{F}_n}{\partial x_n},
+ *  \f]
+ *  where \f$ \alpha \equiv \frac{\partial \dot{x}_n(x_n) }{\partial x_n}, \f$
+ *  and \f$ \beta \equiv \frac{\partial x_n}{\partial x_n} = 1\f$. For the stage
+ *  solutions, we have
+ *  \f[
+ *    \mathcal{F}_i = \dot{X}_{i} - \bar{f}(X_{i},t_{n-1}+c_{i}\Delta t) =0.
+ *  \f]
+ *  where \f$\mathcal{F}_n \rightarrow \mathcal{F}_i\f$,
+ *  \f$x_n \rightarrow X_{i}\f$, and
+ *  \f$\dot{x}_n(x_n) \rightarrow \dot{X}_{i}(X_{i})\f$.
+ *  The time derivative for the DIRK stages is
+ *  \f[
+ *    \dot{X}_{i}(X_{i}) = \frac{X_{i} - \tilde{X}}{a_{ii} \Delta t},
+ *  \f]
+ *  and we can determine that
+ *  \f$ \alpha = \frac{1}{a_{ii} \Delta t} \f$
+ *  and \f$ \beta = 1 \f$, and therefore write
+ *  \f[
+ *    W = \frac{1}{a_{ii} \Delta t}
+ *        \frac{\partial \mathcal{F}_i}{\partial \dot{X}_i}
+ *      + \frac{\partial \mathcal{F}_i}{\partial X_i}.
+ *  \f]
  */
 template<class Scalar>
 class StepperDIRK : virtual public Tempus::StepperImplicit<Scalar>

--- a/packages/tempus/src/Tempus_StepperIMEX_RK_Partition_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RK_Partition_decl.hpp
@@ -23,7 +23,7 @@ namespace Tempus {
  *  Partitioned IMEX-RK is similar to the IMEX-RK (StepperIMEX_RK),
  *  except a portion of the solution only requires explicit integration,
  *  and should not be part of the implicit solution to reduce computational
- *  costs.  Again our ODE can be written as
+ *  costs.  Again our implicit ODE can be written as
  *  \f{eqnarray*}{
  *    M(z,t)\, \dot{z} + G(z,t) + F(z,t) & = & 0, \\
  *    \mathcal{G}(\dot{z},z,t) + F(z,t) & = & 0,
@@ -41,8 +41,8 @@ namespace Tempus {
  *  but a portion of the solution vector, \f$y\f$, is "explicit-only"
  *  and is only evolved by \f$F^y(x,y,t)\f$, while \f$x\f$ is the
  *  Implicit/Explicit (IMEX) solution vector, and is evolved explicitly by
- *  \f$F^x(x,y,t)\f$ evolved implicitly by \f$G^x(x,y,t)\f$.
- *  Note we can expand this to explicitly show all the terms as
+ *  \f$F^x(x,y,t)\f$ and is evolved implicitly by \f$G^x(x,y,t)\f$.
+ *  Note we can expand this to show all the terms as
  *  \f{eqnarray*}{
  *    & & M^y(x,y,t)\: \dot{y} + F^y(x,y,t) = 0, \\
  *    & & M^x(x,y,t)\: \dot{x} + F^x(x,y,t) + G^x(x,y,t) = 0, \\
@@ -53,27 +53,30 @@ namespace Tempus {
  *    +  \left\{ \begin{array}{c}    f^y  \\    f^x  \end{array}\right\}
  *    +  \left\{ \begin{array}{c}     0   \\    g^x  \end{array}\right\} = 0
  *  \f]
- *  where \f$f^y(x,y,t) = M^y(x,y,t)^{-1}\, F^y(x,y,t)\f$,
- *  \f$f^x(x,y,t) = M^x(x,y,t)^{-1}\, F^x(x,y,t)\f$, and
- *  \f$g^x(x,y,t) = M^x(x,y,t)^{-1}\, G^x(x,y,t)\f$,
+ *  where
+ *  \f{eqnarray*}{
+ *    f^y(x,y,t) & = & M^y(x,y,t)^{-1}\, F^y(x,y,t), \\
+ *    f^x(x,y,t) & = & M^x(x,y,t)^{-1}\, F^x(x,y,t), \\
+ *    g^x(x,y,t) & = & M^x(x,y,t)^{-1}\, G^x(x,y,t),
+ *  \f}
  *  or
  *  \f[
- *    \dot{z} + f(x,y,t) + g(x,y,t) = 0,
+ *    \dot{z} + g(x,y,t) + f(x,y,t) = 0,
  *  \f]
  *  where \f$f(x,y,t) = M(x,y,t)^{-1}\, F(x,y,t)\f$, and
  *  \f$g(x,y,t) = M(x,y,t)^{-1}\, G(x,y,t)\f$.
- *  Using Butcher tableaus for the
- *  explicit terms
+ *  Using Butcher tableaus for the explicit and implicit terms
  *  \f[ \begin{array}{c|c}
- *    \hat{c} & \hat{A} \\ \hline
+ *    \hat{c} & \hat{a} \\ \hline
  *            & \hat{b}^T
  *  \end{array}
- *  \;\;\;\; \mbox{ and for implicit terms } \;\;\;\;
+ *  \;\;\;\; \mbox{ and } \;\;\;\;
  *  \begin{array}{c|c}
- *    c & A \\ \hline
+ *    c & a \\ \hline
  *      & b^T
  *  \end{array}, \f]
- *  the basic scheme for this partitioned, \f$s\f$-stage, IMEX-RK is
+ *  respectively, the basic scheme for this partitioned, \f$s\f$-stage,
+ *  IMEX-RK method is
  *  \f[ \begin{array}{rcll}
  *   Z_i & = & Z_{n-1}
  *   - \Delta t \sum_{j=1}^{i-1} \hat{a}_{ij}\; f(Z_j,\hat{t}_j)
@@ -93,19 +96,26 @@ namespace Tempus {
  *   - \Delta t \sum_{j=1}^i           a_{ij}\; g^x(Z_j,     t_j)
  *     &   \mbox{for } i=1\ldots s, \\
  *   y_n & = & y_{n-1}
- *   - \Delta t \sum_{i=1}^s \hat{b}_{i}\; f^y(X_i,Y_i,\hat{t}_i) & \\
+ *   - \Delta t \sum_{i=1}^s \hat{b}_{i}\; f^y(Z_i,\hat{t}_i) & \\
  *   x_n & = & x_{n-1}
  *   - \Delta t \sum_{i=1}^s \left[ \hat{b}_i\; f^x(Z_i,\hat{t}_i)
  *                                 +     b_i\;  g^x(Z_i,     t_i) \right] &
  *  \end{array} \f]
  *  where \f$\hat{t}_i = t_{n-1}+\hat{c}_i\Delta t\f$ and
- *  \f$t_i = t_{n-1}+c_i\Delta t\f$.
- *
- *  For iterative solvers, it is useful to write the stage solutions as
+ *  \f$t_i = t_{n-1}+c_i\Delta t\f$.  Note that the "slow" explicit physics,
+ *  \f$f^y(Z_j,\hat{t}_j)\f$ and \f$f^x(Z_j,\hat{t}_j)\f$, is evaluated at
+ *  the explicit stage time, \f$\hat{t}_j\f$, and the "fast" implicit physics,
+ *  \f$g^x(Z_j,t_j)\f$, is evaluated at the implicit stage time, \f$t_j\f$.
+ *  We can write the stage solution, \f$Z_i\f$, as
  *  \f[
  *    Z_i = \tilde{Z} - a_{ii} \Delta t\, g(Z_i,t_i)
  *  \f]
- *  or expanded as
+ *  where
+ *  \f[
+ *    \tilde{Z} = z_{n-1} - \Delta t \sum_{j=1}^{i-1}
+ *      \left[\hat{a}_{ij}\, f(Z_j,\hat{t}_j) + a_{ij}\, g(Z_j, t_j)\right]
+ *  \f]
+ *  or in expanded form as
  *  \f[
  *    \left\{ \begin{array}{c}        Y_i \\        X_i  \end{array}\right\} =
  *    \left\{ \begin{array}{c} \tilde{Y}  \\ \tilde{X}_i \end{array}\right\}
@@ -114,77 +124,87 @@ namespace Tempus {
  *  \f]
  *  where
  *  \f{eqnarray*}{
- *    \tilde{Z} & = & z_{n-1} - \Delta t \sum_{j=1}^{i-1}
- *      \left[\hat{a}_{ij}\, f(Z_j,\hat{t}_j) + a_{ij}\, g(Z_j, t_j)\right] \\
  *    \tilde{Y} & = & y_{n-1} - \Delta t \sum_{j=1}^{i-1}
  *      \left[\hat{a}_{ij}\, f^y(Z_j,\hat{t}_j)\right] \\
  *    \tilde{X} & = & x_{n-1} - \Delta t \sum_{j=1}^{i-1}
  *      \left[\hat{a}_{ij}\, f^x(Z_j,\hat{t}_j) +a_{ij}\, g^x(Z_j,t_j)\right] \\
  *  \f}
- *  and note that \f$Y_i = \tilde{Y}\f$.  Rearranging to solve for the
- *  implicit term
- *  \f{eqnarray*}{
- *    g  (Z_i,t_i) & = & - \frac{Z_i - \tilde{Z}}{a_{ii} \Delta t} \\
- *    g^x(Z_i,t_i) & = & - \frac{X_i - \tilde{X}}{a_{ii} \Delta t}
- *  \f}
- *  We additionally need the time derivative at each stage for the implicit
- *  solve.  Let us define the following time derivative for \f$x\f$ portion
- *  of the solution
- *  \f[
- *    \dot{X}_i(X_i,Y_i,t_i) + f^x(X_i,Y_i,t_i) + g^x(X_i,Y_i,t_i) = 0
- *  \f]
- *  where we split \f$Z_i\f$ arguments into \f$X_i\f$ and \f$Y_i\f$ to
- *  emphasize that \f$X_i\f$ is the solution for the implicit solve and
- *  \f$Y_i\f$ are parameters in this set of equations.  The above time
- *  derivative, \f$\dot{X}_i\f$, is NOT likely the same as the real time
- *  derivative, \f$\dot{x}(x(t_i), y(t_i), t_i)\f$, unless
- *  \f$\hat{c}_i = c_i \rightarrow \hat{t}_i = t_i\f$
- *  (Reasoning: \f$x(t_i) \neq X_i\f$ and \f$y(t_i) \neq Y_i\f$ unless
- *  \f$\hat{t}_i = t_i\f$).  Also note that the explicit term,
- *  \f$f^x(X_i,Y_i,t_i)\f$, is evaluated at the implicit stage time, \f$t_i\f$.
+ *  and note that \f$Y_i = \tilde{Y}\f$.
  *
- *  We can form the time derivative
- *  \f{eqnarray*}{
- *    \dot{X}(X_i,Y_i,t_i) & = & - g^x(X_i,Y_i,t_i) - f^x(X_i,Y_i,t_i) \\
- *    \dot{X}(X_i,Y_i,t_i) & = &
- *      \frac{X_i - \tilde{X}}{a_{ii} \Delta t} - f^x(X_i,Y_i,t_i) \\
- *  \f}
- *  Returning to the governing equation for the IMEX solution vector, \f$X_i\f$
- *  \f{eqnarray*}{
- *    M^x(X_i,Y_i,t_i)\,
- *    \dot{X}(X_i,Y_i,t_i) + F^x(X_i,Y_i,t_i) + G^x(X_i,Y_i,t_i) & = & 0 \\
- *    M^x(X_i,Y_i,t_i)\,
- *    \left[ \frac{X_i - \tilde{X}}{a_{ii} \Delta t} - f^x(X_i,Y_i,t_i) \right]
- *      + F^x(X_i,Y_i,t_i) + G^x(X_i,Y_i,t_i) & = & 0 \\
- *    M^x(X_i,Y_i,t_i)\,
- *    \left[ \frac{X_i - \tilde{X}}{a_{ii} \Delta t} \right]
- *    + G(X_i,Y_i,t_i) & = & 0 \\
- *  \f}
- *  Recall \f$\mathcal{G}^x(\dot{x},x,y,t) = M^x(x,y,t)\,\dot{x} + G^x(x,y,t)\f$
- *  and if we define a pseudo time derivative, which is equivalent to the
- *  time derivative for the implicit solve,
- *  \f[
- *    \tilde{\dot{X}} = \frac{X_i - \tilde{X}}{a_{ii} \Delta t},
- *  \f]
+ *  Noting that we will be solving the implicit ODE for \f$\dot{X}_i\f$,
  *  we can write
  *  \f[
  *    \mathcal{G}^x(\tilde{\dot{X}},X_i,Y_i,t_i) =
- *       M^x(X_i,Y_i,t_i)\, \tilde{\dot{X}} + G^x(X_i,Y_i,t_i) = 0
+ *      \tilde{\dot{X}} + g^x(X_i,Y_i,t_i) = 0
+ *  \f]
+ *  where we have defined a pseudo time derivative, \f$\tilde{\dot{X}}\f$,
+ *  \f[
+ *    \tilde{\dot{X}} \equiv \frac{X_i - \tilde{X}}{a_{ii} \Delta t}
+ *    \quad \quad \left[ = -g^x(X_i,Y_i,t_i)\right]
+ *  \f]
+ *  that can be used with the implicit solve but is <b>not</b> the stage
+ *  time derivative for the IMEX equations, \f$\dot{X}_i\f$.
+ *  (Note that \f$\tilde{\dot{X}}\f$
+ *  can be interpreted as the rate of change of the solution due to the
+ *  implicit "fast" physics.)
+ *  Note that we are solving for \f$X_i\f$, and \f$Y_i\f$ are included as
+ *  parameters possibly needed in the IMEX equations.
+ *
+ *  To obtain the stage time derivative, \f$\dot{Z}_i\f$, for the
+ *  entire system, we can evaluate
+ *  the governing equation at the implicit stage time, \f$t_i\f$,
+ *  \f[
+ *    \dot{Z}_i(Z_i,t_i) + f(Z_i,t_i) + g(Z_i,t_i) = 0
+ *  \f]
+ *  The above time derivative, \f$\dot{Z}_i\f$, is likely <b>not</b>
+ *  the same as the real time derivative, \f$\dot{x}(x(t_i), y(t_i), t_i)\f$,
+ *  unless \f$\hat{c}_i = c_i \rightarrow \hat{t}_i = t_i\f$
+ *  (Reasoning: \f$x(t_i) \neq X_i\f$ and \f$y(t_i) \neq Y_i\f$ unless
+ *  \f$\hat{t}_i = t_i\f$).  Also note that the explicit term,
+ *  \f$f(Z_i,t_i)\f$, is evaluated at the implicit stage time, \f$t_i\f$.
+ *  Solving for \f$\dot{Z}_i\f$, we find
+ *  \f[
+ *    \dot{Z}(Z_i,t_i) = - g(Z_i,t_i) - f(Z_i,t_i)
  *  \f]
  *
+ *  <b> Iteration Matrix, \f$W\f$.</b>
+ *  Recalling that the definition of the iteration matrix, \f$W\f$, is
+ *  \f[
+ *    W = \alpha \frac{\partial \mathcal{F}_n}{\partial \dot{x}_n}
+ *      + \beta  \frac{\partial \mathcal{F}_n}{\partial x_n},
+ *  \f]
+ *  where \f$ \alpha \equiv \frac{\partial \dot{x}_n(x_n) }{\partial x_n}, \f$
+ *  and \f$ \beta \equiv \frac{\partial x_n}{\partial x_n} = 1\f$. For the
+ *  IMEX equations, we are solving
+ *  \f[
+ *    \mathcal{G}^x(\tilde{\dot{X}},X_i,Y_i,t_i) =
+ *      \tilde{\dot{X}} + g^x(X_i,Y_i,t_i) = 0
+ *  \f]
+ *  where \f$\mathcal{F}_n \rightarrow \mathcal{G}^x\f$,
+ *  \f$x_n \rightarrow X_{i}\f$, and
+ *  \f$\dot{x}_n(x_n) \rightarrow \tilde{\dot{X}}(X_{i})\f$.
+ *  The time derivative for the implicit solves is
+ *  \f[
+ *    \tilde{\dot{X}} \equiv \frac{X_i - \tilde{X}}{a_{ii} \Delta t}
+ *  \f]
+ *  and we can determine that
+ *  \f$ \alpha = \frac{1}{a_{ii} \Delta t} \f$
+ *  and \f$ \beta = 1 \f$, and therefore write
+ *  \f[
+ *    W = \frac{1}{a_{ii} \Delta t}
+ *        \frac{\partial \mathcal{G}^x}{\partial \tilde{\dot{X}}}
+ *      + \frac{\partial \mathcal{G}^x}{\partial X_i}.
+ *  \f]
+ *
+ *  <b>Explicit Stage in the Implicit Tableau.</b>
  *  For general DIRK methods, we need to also handle the case when
  *  \f$a_{ii}=0\f$.  The IMEX stage values can be simply evaluated
  *  similiar to the "explicit-only" stage values, e.g.,
  *  \f[
- *     X_i = \tilde{X} = x_{n-1} - \Delta t\,\sum_{j=1}^{i-1} \left(
- *            \hat{a}_{ij}\, f^x_j + a_{ij}\, g^x_j \right)
+ *     X_i = \tilde{X} = x_{n-1} - \Delta t \sum_{j=1}^{i-1}
+ *      \left[\hat{a}_{ij}\, f^x(Z_j,\hat{t}_j) +a_{ij}\, g^x(Z_j,t_j)\right]
  *  \f]
- *  and then we can simply evaluate
- *  \f{eqnarray*}{
- *     f_i   & = & f  (Z_i,\hat{t}_i) \\
- *     g^x_i & = & g^x(X_i,Y_i,  t_i)
- *  \f}
- *  We can then form the time derivative as
+ *  and the time derivative of the stage solution is
  *  \f[
  *    \dot{X}_i = - g^x(X_i,Y_i,t_i) - f^x(X_i,Y_i,t_i)
  *  \f]
@@ -202,12 +222,13 @@ namespace Tempus {
  *       - \f$X_i   \leftarrow \tilde{X}\f$
  *       - \f$g^x_i \leftarrow g^x(X_i,Y_i,t_i)\f$
  *     - else
- *       - Define \f$\tilde{\dot{X}}(X_i,Y_i,t_i)
- *            = \frac{X_i-\tilde{X}}{a_{ii} \Delta t}\f$
- *       - Solve \f$\mathcal{G}^x(\tilde{\dot{X}},X_i,Y_i,t_i) = 0\f$
+ *       - Solve \f$\mathcal{G}^x(
+ *           \tilde{\dot{X}} = \frac{X_i-\tilde{X}}{a_{ii} \Delta t},
+ *           X_i,Y_i,t_i) = 0\f$
  *         for \f$X_i\f$ where \f$Y_i\f$ are known parameters
  *       - \f$g^x_i \leftarrow - \tilde{\dot{X}}\f$
  *     - \f$f_i \leftarrow f(Z_i,\hat{t}_i)\f$
+ *     - \f$\dot{Z} \leftarrow - g(Z_i,t_i) - f(Z_i,t_i)\f$ [Optionally]
  *   - end for
  *   - \f$z_n = z_{n-1} - \Delta t\,\sum_{i=1}^{s}\hat{b}_i\, f_i\f$
  *   - \f$x_n \mathrel{+{=}} - \Delta t\,\sum_{i=1}^{s} b_i\, g^x_i\f$

--- a/packages/tempus/src/Tempus_StepperIMEX_RK_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RK_decl.hpp
@@ -23,10 +23,13 @@ namespace Tempus {
  *  For the implicit ODE system, \f$ \mathcal{F}(\dot{x},x,t) = 0 \f$,
  *  we need to specialize this in order to separate the explicit, implicit,
  *  and temporal terms for the IMEX-RK time stepper,
- *  \f{eqnarray*}{
- *    M(x,t)\, \dot{x}(x,t) + G(x,t) + F(x,t) & = & 0, \\
- *    \mathcal{G}(\dot{x},x,t) + F(x,t) & = & 0,
- *  \f}
+ *  \f[
+ *    M(x,t)\, \dot{x}(x,t) + G(x,t) + F(x,t) = 0
+ *  \f]
+ *  or
+ *  \f[
+ *    \mathcal{G}(\dot{x},x,t) + F(x,t) = 0,
+ *  \f]
  *  where \f$\mathcal{G}(\dot{x},x,t) = M(x,t)\, \dot{x} + G(x,t)\f$,
  *  \f$M(x,t)\f$ is the mass matrix, \f$F(x,t)\f$ is the operator
  *  representing the "slow" physics (and is evolved explicitly), and
@@ -38,17 +41,17 @@ namespace Tempus {
  *  \f]
  *  where \f$f(x,t) = M(x,t)^{-1}\, F(x,t)\f$, and
  *  \f$g(x,t) = M(x,t)^{-1}\, G(x,t)\f$. Using Butcher tableaus for the
- *  explicit terms
+ *  explicit and implicit terms,
  *  \f[ \begin{array}{c|c}
- *    \hat{c} & \hat{A} \\ \hline
+ *    \hat{c} & \hat{a} \\ \hline
  *            & \hat{b}^T
  *  \end{array}
- *  \;\;\;\; \mbox{ and for implicit terms } \;\;\;\;
+ *  \;\;\;\; \mbox{ and } \;\;\;\;
  *  \begin{array}{c|c}
- *    c & A \\ \hline
+ *    c & a \\ \hline
  *      & b^T
  *  \end{array}, \f]
- *  the basic IMEX-RK method for \f$s\f$-stages can be written as
+ *  respectively, the basic IMEX-RK method for \f$s\f$-stages can be written as
  *  \f[ \begin{array}{rcll}
  *    X_i & = & x_{n-1}
  *     - \Delta t \sum_{j=1}^{i-1} \hat{a}_{ij}\, f(X_j,\hat{t}_j)
@@ -59,8 +62,11 @@ namespace Tempus {
  *     - \Delta t \sum_{i=1}^s       b_{i}\, g(X_i,t_i) &
  *  \end{array} \f]
  *  where \f$\hat{t}_i = t_{n-1}+\hat{c}_i\Delta t\f$ and
- *  \f$t_i = t_{n-1}+c_i\Delta t\f$.  For iterative solvers, it is useful to
- *  write the stage solutions as
+ *  \f$t_i = t_{n-1}+c_i\Delta t\f$.  Note that the "slow" explicit physics,
+ *  \f$f(X_j,\hat{t}_j)\f$, is evaluated at the explicit stage time,
+ *  \f$\hat{t}_j\f$, and the "fast" implicit physics, \f$g(X_j,t_j)\f$, is
+ *  evaluated at the implicit stage time, \f$t_j\f$.  We can write the stage
+ *  solution, \f$X_i\f$, as
  *  \f[
  *    X_i = \tilde{X} - a_{ii} \Delta t\, g(X_i,t_i)
  *  \f]
@@ -69,105 +75,96 @@ namespace Tempus {
  *    \tilde{X} = x_{n-1} - \Delta t \sum_{j=1}^{i-1}
  *        \left(\hat{a}_{ij}\, f(X_j,\hat{t}_j) + a_{ij}\, g(X_j,t_j)\right)
  *  \f]
- *  Rearranging to solve for the implicit term
+ *  Rewriting this in a form for Newton-type solvers, the implicit ODE is
  *  \f[
- *    g(X_i,t_i) = - \frac{X_i - \tilde{X}}{a_{ii} \Delta t}
+ *    \mathcal{G}(\tilde{\dot{X}},X_i,t_i) = \tilde{\dot{X}} + g(X_i,t_i) = 0
  *  \f]
- *  We can use this to determine the time derivative at each stage for the
- *  implicit solve.
+ *  where we have defined a pseudo time derivative, \f$\tilde{\dot{X}}\f$,
+ *  \f[
+ *    \tilde{\dot{X}} \equiv \frac{X_i - \tilde{X}}{a_{ii} \Delta t}
+ *    \quad \quad \left[ = -g(X_i,t_i)\right]
+ *  \f]
+ *  that can be used with the implicit solve but is <b>not</b> the stage
+ *  time derivative, \f$\dot{X}_i\f$.  (Note that \f$\tilde{\dot{X}}\f$
+ *  can be interpreted as the rate of change of the solution due to the
+ *  implicit "fast" physics, and the "mass" version of the implicit ODE,
+ *  \f$\mathcal{G}(\tilde{\dot{X}},X_i,t) = M(X_i,t_i)\, \tilde{\dot{X}}
+ *  + G(X_i,t_i) = 0\f$, can also be used to solve for \f$\tilde{\dot{X}}\f$).
+ *
+ *  To obtain the stage time derivative, \f$\dot{X}_i\f$, we can evaluate
+ *  the governing equation at the implicit stage time, \f$t_i\f$,
  *  \f[
  *    \dot{X}_i(X_i,t_i) + g(X_i,t_i) + f(X_i,t_i) = 0
  *  \f]
- *  Note that the explicit term, \f$f(X_i,t_i)\f$, is evaluated at the implicit
- *  stage time, \f$t_i\f$.
- *  We can form the time derivative
+ *  Note that even the explicit term, \f$f(X_i,t_i)\f$, is evaluated at
+ *  the implicit stage time, \f$t_i\f$.  Solving for \f$\dot{X}_i\f$, we find
  *  \f{eqnarray*}{
  *    \dot{X}(X_i,t_i) & = & - g(X_i,t_i) - f(X_i,t_i) \\
- *    \dot{X}(X_i,t_i) & = &
- *      \frac{X_i - \tilde{X}}{a_{ii} \Delta t} - f(X_i,t_i) \\
- *    \dot{X}(X_i,t_i) & = &
- *      \frac{X_i - \tilde{X}}{a_{ii} \Delta t} -M(X_i, t_i)^{-1}\, F(X_i,t_i)\\
+ *    \dot{X}(X_i,t_i) & = & \tilde{\dot{X}} - f(X_i,t_i)
  *  \f}
- *  Returning to the governing equation
- *  \f{eqnarray*}{
- *    M(X_i,t_i)\, \dot{X}(X_i,t_i) + G(X_i,t_i) + F(X_i,t_i) & = & 0 \\
- *    M(X_i,t_i)\, \left[
- *      \frac{X_i - \tilde{X}}{a_{ii} \Delta t} - M(X_i, t_i)^{-1}\, F(X_i,t_i)
- *    \right] + G(X_i,t_i) + F(X_i,t_i) & = & 0 \\
- *      M(X_i,t_i)\, \left[ \frac{X_i - \tilde{X}}{a_{ii} \Delta t} \right]
- *    + G(X_i,t_i) & = & 0 \\
- *  \f}
- *  Recall \f$\mathcal{G}(\dot{x},x,t) = M(x,t)\, \dot{x} + G(x,t)\f$ and if we
- *  define a pseudo time derivative,
+ *
+ *  <b> Iteration Matrix, \f$W\f$.</b>
+ *  Recalling that the definition of the iteration matrix, \f$W\f$, is
  *  \f[
- *    \tilde{\dot{X}} = \frac{X_i - \tilde{X}}{a_{ii} \Delta t} = - g(X_i,t_i),
+ *    W = \alpha \frac{\partial \mathcal{F}_n}{\partial \dot{x}_n}
+ *      + \beta  \frac{\partial \mathcal{F}_n}{\partial x_n},
  *  \f]
- *  we can write
+ *  where \f$ \alpha \equiv \frac{\partial \dot{x}_n(x_n) }{\partial x_n}, \f$
+ *  and \f$ \beta \equiv \frac{\partial x_n}{\partial x_n} = 1\f$. For the stage
+ *  solutions, we are solving
  *  \f[
- *    \mathcal{G}(\tilde{\dot{X}},X_i,t_i) =
- *       M(X_i,t_i)\, \tilde{\dot{X}} + G(X_i,t_i) = 0
+ *    \mathcal{G} = \tilde{\dot{X}} + g(X_i,t_i) = 0.
+ *  \f]
+ *  where \f$\mathcal{F}_n \rightarrow \mathcal{G}\f$,
+ *  \f$x_n \rightarrow X_{i}\f$, and
+ *  \f$\dot{x}_n(x_n) \rightarrow \tilde{\dot{X}}(X_{i})\f$.
+ *  The time derivative for the implicit solves is
+ *  \f[
+ *    \tilde{\dot{X}} \equiv \frac{X_i - \tilde{X}}{a_{ii} \Delta t}
+ *  \f]
+ *  and we can determine that
+ *  \f$ \alpha = \frac{1}{a_{ii} \Delta t} \f$
+ *  and \f$ \beta = 1 \f$, and therefore write
+ *  \f[
+ *    W = \frac{1}{a_{ii} \Delta t}
+ *        \frac{\partial \mathcal{G}}{\partial \tilde{\dot{X}}}
+ *      + \frac{\partial \mathcal{G}}{\partial X_i}.
  *  \f]
  *
- *  For the case when \f$a_{ii}=0\f$, we need the time derivative for the
- *  plain explicit case.  Thus the stage solution is
+ *  <b>Explicit Stage in the Implicit Tableau.</b>
+ *  For the special case of an explicit stage in the implicit tableau,
+ *  \f$a_{ii}=0\f$, we find that the stage solution, \f$X_i\f$, is
  *  \f[
  *     X_i = x_{n-1} - \Delta t\,\sum_{j=1}^{i-1} \left(
- *            \hat{a}_{ij}\, f_j + a_{ij}\, g_j \right) = \tilde{X}
+ *       \hat{a}_{ij}\,f(X_j,\hat{t}_j) + a_{ij}\,g(X_j,t_j) \right) = \tilde{X}
  *  \f]
- *  and we can simply evaluate
- *  \f{eqnarray*}{
- *     f_i & = & M(X_i,\hat{t}_i)^{-1}\, F(X_i,\hat{t}_i) \\
- *     g_i & = & M(X_i,      t_i)^{-1}\, G(X_i,      t_i)
- *  \f}
- *  We can then form the time derivative as
+ *  and the time derivative of the stage solution, \f$\dot{X}(X_i,t_i)\f$, is
  *  \f[
  *    \dot{X}_i(X_i,t_i) = - g(X_i,t_i) - f(X_i,t_i)
  *  \f]
- *  but again note that the explicit term, \f$f(X_i,t_i)\f$, is evaluated
+ *  and again note that the explicit term, \f$f(X_i,t_i)\f$, is evaluated
  *  at the implicit stage time, \f$t_i\f$.
  *
  *  <b> IMEX-RK Algorithm </b>
  *
- *  The single-timestep algorithm for IMEX-RK using the real time derivative,
- *  \f$\dot{X}(X_i,t_i)\f$, is
+ *  The single-timestep algorithm for IMEX-RK is
  *   - \f$X_1 \leftarrow x_{n-1}\f$
  *   - for \f$i = 1 \ldots s\f$ do
  *     - \f$\tilde{X} \leftarrow x_{n-1} - \Delta t\,\sum_{j=1}^{i-1} \left(
- *            \hat{a}_{ij}\, f_j + a_{ij}\, g_j \right) \f$
+ *            \hat{a}_{ij}\, f(X_j,\hat{t}_j) + a_{ij}\, g(X_j,t_j) \right) \f$
  *     - if \f$a_{ii} = 0\f$
  *       - \f$X_i \leftarrow \tilde{X}\f$
- *       - \f$g_i \leftarrow M(X_i,      t_i)^{-1}\, G(X_i,      t_i)\f$
+ *       - \f$g(X_i,t_i) \leftarrow M(X_i,      t_i)^{-1}\, G(X_i,      t_i)\f$
  *     - else
- *       - Define \f$\dot{X}(X_i,t_i)
- *            = \frac{X_i-\tilde{X}}{a_{ii} \Delta t}
- *                     - M(X_i,t_i)^{-1}\, F(X_i,t_i) \f$
- *       - Solve \f$\mathcal{G}\left(\dot{X}(X_i,t_i),X_i,t_i\right)
- *                  + F(X_i,t_i) = 0\f$ for \f$X_i\f$
- *       - \f$g_i \leftarrow - \frac{X_i-\tilde{X}}{a_{ii} \Delta t}\f$
- *     - \f$f_i \leftarrow M(X_i,\hat{t}_i)^{-1}\, F(X_i,\hat{t}_i)\f$
- *   - end for
- *   - \f$x_n \leftarrow x_{n-1} - \Delta t\,\sum_{i=1}^{s}\hat{b}_i\,f_i
- *                               - \Delta t\,\sum_{i=1}^{s}      b_i\,g_i\f$
- *
- *  The single-timestep algorithm for IMEX-RK using the pseudo time derivative,
- *  \f$\tilde{\dot{X}}\f$, is (which is currently implemented)
- *   - \f$X_1 \leftarrow x_{n-1}\f$
- *   - for \f$i = 1 \ldots s\f$ do
- *     - \f$\tilde{X} \leftarrow x_{n-1} - \Delta t\,\sum_{j=1}^{i-1} \left(
- *            \hat{a}_{ij}\, f_j + a_{ij}\, g_j \right) \f$
- *     - if \f$a_{ii} = 0\f$
- *       - \f$X_i \leftarrow \tilde{X}\f$
- *       - \f$g_i \leftarrow M(X_i,      t_i)^{-1}\, G(X_i,      t_i)\f$
- *     - else
- *       - Define \f$\tilde{\dot{X}}
- *            = \frac{X_i-\tilde{X}}{a_{ii} \Delta t} \f$
- *       - Solve \f$\mathcal{G}\left(\tilde{\dot{X}},X_i,t_i\right) = 0\f$
+ *       - Solve \f$\mathcal{G}\left(\tilde{\dot{X}}
+ *            = \frac{X_i-\tilde{X}}{a_{ii} \Delta t},X_i,t_i\right) = 0\f$
  *           for \f$X_i\f$
- *       - \f$g_i \leftarrow - \tilde{\dot{X}}\f$
- *     - \f$f_i \leftarrow M(X_i,\hat{t}_i)^{-1}\, F(X_i,\hat{t}_i)\f$
+ *       - \f$g(X_i,t_i) \leftarrow - \tilde{\dot{X}}\f$
+ *     - \f$f(X_i,\hat{t}_i) \leftarrow M(X_i,\hat{t}_i)^{-1}\, F(X_i,\hat{t}_i)\f$
+ *     - \f$\dot{X}_i(X_i,t_i) \leftarrow - g(X_i,t_i) - f(X_i,t_i)\f$ [Optionally]
  *   - end for
- *   - \f$x_n \leftarrow x_{n-1} - \Delta t\,\sum_{i=1}^{s}\hat{b}_i\,f_i
- *                               - \Delta t\,\sum_{i=1}^{s}      b_i\,g_i\f$
+ *   - \f$x_n \leftarrow x_{n-1} - \Delta t\,\sum_{i=1}^{s}\hat{b}_i\,f(X_i,\hat{t}_i)
+ *                               - \Delta t\,\sum_{i=1}^{s}      b_i\,g(X_i,t_i)\f$
  *
  *  The following table contains the pre-coded IMEX-RK tableaus.
  *  <table>
@@ -213,6 +210,7 @@ namespace Tempus {
  *  The First-Step-As-Last (FSAL) principle is not valid for IMEX RK.
  *  The default is to set useFSAL=false, and useFSAL=true will result
  *  in an error.
+ *
  *
  *  #### References
  *  -# Ascher, Ruuth, Spiteri, "Implicit-explicit Runge-Kutta methods for

--- a/packages/tempus/src/Tempus_StepperImplicit_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperImplicit_decl.hpp
@@ -47,6 +47,181 @@ class ImplicitODEParameters
 
 /** \brief Thyra Base interface for implicit time steppers.
  *
+    For first-order ODEs, we can write the implicit ODE as
+    \f[
+      \mathcal{F}(\dot{x}_n,x_n,t_n) = 0
+    \f]
+    where \f$x_n\f$ is the solution vector, \f$\dot{x}\f$ is the
+    time derivative, \f$t_n\f$ is the time and \f$n\f$ indicates
+    the \f$n^{th}\f$ time level.  Note that \f$\dot{x}_n\f$ is
+    different for each time stepper and is a function of other
+    solution states, e.g., for Backward Euler,
+    \f[
+      \dot{x}_n(x_n) = \frac{x_n - x_{n-1}}{\Delta t}
+    \f]
+
+    <b> Defining the Iteration Matrix</b>
+
+    Often we use Newton's method or one of its variations to solve
+    for \f$x_n\f$, such as
+    \f[
+      \left[
+      \frac{\partial}{\partial x_n}
+      \left(
+        \mathcal{F}(\dot{x}_n,x_n,t_n)
+      \right)
+      \right] \Delta x_n^\nu = - \mathcal{F}(\dot{x}_n^\nu,x_n^\nu,t_n)
+    \f]
+    where \f$\Delta x_n^\nu = x_n^{\nu+1} - x_n^\nu\f$ and \f$\nu\f$
+    is the iteration index.  Using the chain rule for a function
+    with multiple variables, we can write
+    \f[
+      \left[
+
+      \frac{\partial \dot{x}_n(x_n) }{\partial x_n}
+      \frac{\partial}{\partial \dot{x}_n}
+      \left(
+        \mathcal{F}(\dot{x}_n,x_n,t_n)
+      \right)
+      +
+      \frac{\partial x_n}{\partial x_n}
+      \frac{\partial}{\partial x_n}
+      \left(
+        \mathcal{F}(\dot{x}_n,x_n,t_n)
+      \right)
+
+      \right] \Delta x_n^\nu = - \mathcal{F}(\dot{x}_n^\nu,x_n^\nu,t_n)
+    \f]
+    Defining the iteration matrix, \f$W\f$, we have
+    \f[
+      W \Delta x_n^\nu = - \mathcal{F}(\dot{x}_n^\nu,x_n^\nu,t_n)
+    \f]
+    using \f$\mathcal{F}_n = \mathcal{F}(\dot{x}_n,x_n,t_n)\f$, where
+    \f[
+      W = \alpha \frac{\partial \mathcal{F}_n}{\partial \dot{x}_n}
+        + \beta  \frac{\partial \mathcal{F}_n}{\partial x_n}
+    \f]
+    and
+    \f[
+      W = \alpha M + \beta J
+    \f]
+    where
+    \f[
+      \alpha \equiv \frac{\partial \dot{x}_n(x_n) }{\partial x_n},
+      \quad \quad
+      \beta \equiv \frac{\partial x_n}{\partial x_n} = 1,
+      \quad \quad
+      M = \frac{\partial \mathcal{F}_n}{\partial \dot{x}_n},
+      \quad \quad
+      J = \frac{\partial \mathcal{F}_n}{\partial x_n}
+    \f]
+    and \f$M\f$ is the mass matrix and \f$J\f$ is the Jacobian.
+
+    Note that sometimes it is helpful to set \f$\alpha=0\f$ and
+    \f$\beta = 1\f$ to obtain the Jacobian, \f$J\f$, from the
+    iteration matrix (i.e., ModelEvaluator), or set \f$\alpha=1\f$
+    and \f$\beta = 0\f$ to obtain the mass matrix, \f$M\f$, from
+    the iteration matrix (i.e., the ModelEvaluator).
+
+    As a concrete example, the time derivative for Backward Euler is
+    \f[
+      \dot{x}_n(x_n) = \frac{x_n - x_{n-1}}{\Delta t}
+    \f]
+    thus
+    \f[
+      \alpha \equiv \frac{\partial \dot{x}_n(x_n) }{\partial x_n}
+             = \frac{1}{\Delta t}
+      \quad \quad
+      \beta \equiv \frac{\partial x_n}{\partial x_n} = 1
+    \f]
+    and the iteration matrix for Backward Euler is
+    \f[
+      W = \frac{1}{\Delta t} \frac{\partial \mathcal{F}_n}{\partial \dot{x}_n}
+        + \frac{\partial \mathcal{F}_n}{\partial x_n}
+    \f]
+
+    <b> Dangers of multiplying through by \f$\Delta t\f$. </b>
+    In some time-integration schemes, the application might want
+    to multiply the governing equations by the time-step size,
+    \f$\Delta t\f$, for scaling or other reasons.  Here we illustrate
+    what that means and the complications that follow from it.
+
+    Starting with a simple implicit ODE and multiplying through by
+    \f$\Delta t\f$, we have
+    \f[
+      \mathcal{F}_n = \Delta t \dot{x}_n - \Delta t \bar{f}(x_n,t_n) = 0
+    \f]
+    For the Backward Euler stepper, we recall from above that
+    \f[
+      \dot{x}_n(x_n) = \frac{x_n - x_{n-1}}{\Delta t}
+      \quad\quad
+      \alpha \equiv \frac{\partial \dot{x}_n(x_n) }{\partial x_n}
+             = \frac{1}{\Delta t}
+      \quad \quad
+      \beta \equiv \frac{\partial x_n}{\partial x_n} = 1
+    \f]
+    and we can find for our simple implicit ODE, \f$\mathcal{F}_n\f$,
+    \f[
+      M = \frac{\partial \mathcal{F}_n}{\partial \dot{x}_n} = \Delta t,
+      \quad \quad
+      J = \frac{\partial \mathcal{F}_n}{\partial x_n}
+        = -\Delta t \frac{\partial \bar{f}_n}{\partial x_n}
+    \f]
+    Thus this iteration matrix, \f$W^\ast\f$, is
+    \f[
+      W^\ast = \alpha \frac{\partial \mathcal{F}_n}{\partial \dot{x}_n}
+             + \beta  \frac{\partial \mathcal{F}_n}{\partial x_n}
+             = \frac{1}{\Delta t} \Delta t
+             + (1) \left( - \Delta t \frac{\partial \bar{f}_n}{\partial x_n}
+                   \right)
+    \f]
+    or simply
+    \f[
+      W^\ast = 1 - \Delta t \frac{\partial \bar{f}_n}{\partial x_n}
+    \f]
+    Note that \f$W^\ast\f$ is not the same as \f$W\f$ from above
+    (i.e., \f$W = \frac{1}{\Delta t} - \frac{\partial \bar{f}_n}{\partial
+    x_n}\f$).  But we should <b>not</b> infer from this is that
+    \f$\alpha = 1\f$ or \f$\beta = -\Delta t\f$, as those definitions
+    are unchanged (i.e., \f$\alpha \equiv \frac{\partial \dot{x}_n(x_n)}
+    {\partial x_n} = \frac{1}{\Delta t}\f$ and \f$\beta \equiv
+    \frac{\partial x_n}{\partial x_n} = 1 \f$).  However, the mass
+    matrix, \f$M\f$, the Jacobian, \f$J\f$ and the residual,
+    \f$-\mathcal{F}_n\f$, all need to include \f$\Delta t\f$ in
+    their evaluations (i.e., be included in the ModelEvaluator
+    return values for these terms).
+
+    <b> Dangers of explicitly including time-derivative definition.</b>
+    If we explicitly include the time-derivative defintion for
+    Backward Euler, we find for our simple implicit ODE,
+    \f[
+      \mathcal{F}_n = \frac{x_n - x_{n-1}}{\Delta t} - \bar{f}(x_n,t_n) = 0
+    \f]
+    that the iteration matrix is
+    \f[
+      W^{\ast\ast} =
+               \alpha \frac{\partial \mathcal{F}_n}{\partial \dot{x}_n}
+             + \beta  \frac{\partial \mathcal{F}_n}{\partial x_n}
+             = \frac{1}{\Delta t} (0)
+             + (1) \left(\frac{1}{\Delta t}
+                         - \frac{\partial \bar{f}_n}{\partial x_n}
+                   \right)
+    \f]
+    or simply
+    \f[
+      W^{\ast\ast} =
+        \frac{1}{\Delta t} - \frac{\partial \bar{f}_n}{\partial x_n}
+    \f]
+    which is the same as \f$W\f$ from above for Backward Euler, but
+    again we should <b>not</b> infer that \f$\alpha = \frac{1}{\Delta
+    t}\f$ or \f$\beta = -1\f$.  However the major drawback is the
+    mass matrix, \f$M\f$, the Jacobian, \f$J\f$, and the residual,
+    \f$-\mathcal{F}_n\f$ (i.e., the ModelEvaluator) are explicitly
+    written only for Backward Euler.  The application would need
+    to write separate ModelEvaluators for each stepper, thus
+    destroying the ability to re-use the ModelEvaluator with any
+    stepper.
+ *
  */
 template<class Scalar>
 class StepperImplicit : virtual public Tempus::Stepper<Scalar>

--- a/packages/tempus/src/Tempus_StepperTrapezoidal_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperTrapezoidal_decl.hpp
@@ -24,7 +24,7 @@ namespace Tempus {
  *
  *  <b> Algorithm </b>
  *  The single-timestep algorithm for Trapezoidal method is simply,
- *   - Solve \f$f(\dot{x}=(x_n-x_{n-1})/(\Delta t_n/2) - \dot{x}_{n-1}, x_n, t_n)=0\f$ for \f$x_n\f$
+ *   - Solve \f$\mathcal{F}_n(\dot{x}=(x_n-x_{n-1})/(\Delta t_n/2) - \dot{x}_{n-1}, x_n, t_n)=0\f$ for \f$x_n\f$
  *   - \f$\dot{x}_n \leftarrow (x_n-x_{n-1})/(\Delta t_n/2) - \dot{x}_{n-1}\f$
  *
  *   The First-Step-As-Last (FSAL) principle is required for the Trapezoidal
@@ -36,6 +36,27 @@ namespace Tempus {
  *    - Use evaluateExplicitODE to get xDot_{n-1} if the application
  *      provides it.  Explicit evaluations are cheaper but requires the
  *      application to implement xDot = f(x,t).
+ *
+ *  <b> Iteration Matrix, \f$W\f$.</b>
+ *  Recalling that the definition of the iteration matrix, \f$W\f$, is
+ *  \f[
+ *    W = \alpha \frac{\partial \mathcal{F}_n}{\partial \dot{x}_n}
+ *      + \beta  \frac{\partial \mathcal{F}_n}{\partial x_n},
+ *  \f]
+ *  where \f$ \alpha \equiv \frac{\partial \dot{x}_n(x_n) }{\partial x_n}, \f$
+ *  and \f$ \beta \equiv \frac{\partial x_n}{\partial x_n} = 1\f$, and
+ *  the time derivative for Trapezoidal method is
+ *  \f[
+ *    \dot{x}_n = (x_n-x_{n-1})/(\Delta t/2) - \dot{x}_{n-1},
+ *  \f]
+ *  we can determine that
+ *  \f$ \alpha = \frac{2}{\Delta t} \f$
+ *  and \f$ \beta = 1 \f$, and therefore write
+ *  \f[
+ *    W = \frac{2}{\Delta t}
+ *        \frac{\partial \mathcal{F}_n}{\partial \dot{x}_n}
+ *      + \frac{\partial \mathcal{F}_n}{\partial x_n}.
+ *  \f]
  */
 template<class Scalar>
 class StepperTrapezoidal : virtual public Tempus::StepperImplicit<Scalar>


### PR DESCRIPTION
No code changes, just new doxygen.  The iteration matrix, W,
for all the steppers, except IMEX-RK and IMEX-RK Partition,
have been documented.

@trilinos/tempus 

Closes #6637 

## Motivation
Clearly document what is the iteration matrix and its expression for the first-order implicit ODEs.

## Testing
Doxygen builds correctly.
