### PR TITLE
Sacado:  Use more overflow-safe implementation of d(tanh(x))/dx.

### DIFF
--- a/packages/sacado/src/Sacado_CacheFad_Ops.hpp
+++ b/packages/sacado/src/Sacado_CacheFad_Ops.hpp
@@ -467,7 +467,7 @@ FAD_UNARYOP_MACRO(sinh,
                   std::sinh(v))
 FAD_UNARYOP_MACRO(tanh,
                   TanhOp,
-                  a = value_type(1)/(std::cosh(v)*std::cosh(v)),
+                  a = value_type(1)-std::tanh(v)*std::tanh(v),
                   std::tanh(v))
 FAD_UNARYOP_MACRO(acosh,
                   ACoshOp,

--- a/packages/sacado/src/Sacado_ELRCacheFad_Ops.hpp
+++ b/packages/sacado/src/Sacado_ELRCacheFad_Ops.hpp
@@ -631,7 +631,7 @@ FAD_UNARYOP_MACRO(sinh,
                   std::sinh(v))
 FAD_UNARYOP_MACRO(tanh,
                   TanhOp,
-                  a = scalar_type(1.0)/(std::cosh(v)*std::cosh(v)),
+                  a = scalar_type(1.0)-std::tanh(v)*std::tanh(v),
                   std::tanh(v))
 FAD_UNARYOP_MACRO(acosh,
                   ACoshOp,

--- a/packages/sacado/src/Sacado_ELRFad_Ops.hpp
+++ b/packages/sacado/src/Sacado_ELRFad_Ops.hpp
@@ -274,11 +274,10 @@ FAD_UNARYOP_MACRO(sinh,
 FAD_UNARYOP_MACRO(tanh,
                   TanhOp,
                   std::tanh(expr.val()),
-                  bar/(std::cosh(expr.val())*std::cosh(expr.val())),
+                  bar*(value_type(1)-std::tanh(expr.val())*std::tanh(expr.val())),
                   false,
-                  expr.dx(i)/( std::cosh(expr.val())* std::cosh(expr.val())),
-                  expr.fastAccessDx(i) /
-                    ( std::cosh(expr.val())* std::cosh(expr.val())))
+                  expr.dx(i)*(value_type(1)-std::tanh(expr.val())*std::tanh(expr.val())),
+                  expr.fastAccessDx(i)*(value_type(1)-std::tanh(expr.val())*std::tanh(expr.val())))
 FAD_UNARYOP_MACRO(acosh,
                   ACoshOp,
                   std::acosh(expr.val()),

--- a/packages/sacado/src/Sacado_Fad_Ops.hpp
+++ b/packages/sacado/src/Sacado_Fad_Ops.hpp
@@ -221,11 +221,10 @@ FAD_UNARYOP_MACRO(sinh,
                   expr.fastAccessDx(i)* cosh(expr.val()))
 FAD_UNARYOP_MACRO(tanh,
                   TanhOp,
-                  using std::tanh; using std::cosh;,
+                  using std::tanh;,
                   tanh(expr.val()),
-                  expr.dx(i)/( cosh(expr.val())* cosh(expr.val())),
-                  expr.fastAccessDx(i) /
-                    ( cosh(expr.val())* cosh(expr.val())))
+                  expr.dx(i)*(value_type(1)-tanh(expr.val())*tanh(expr.val())),
+                  expr.fastAccessDx(i)*(value_type(1)-tanh(expr.val())*tanh(expr.val())))
 FAD_UNARYOP_MACRO(acosh,
                   ACoshOp,
                   using std::acosh; using std::sqrt;,

--- a/packages/sacado/src/Sacado_Fad_SimpleFadOps.hpp
+++ b/packages/sacado/src/Sacado_Fad_SimpleFadOps.hpp
@@ -145,9 +145,8 @@ namespace Sacado {
     template <typename ValueT>
     SimpleFad<ValueT>
     tanh(const SimpleFad<ValueT>& a) {
-      ValueT t = std::cosh(a.val());
-      t = 1.0/(t*t);
-      return SimpleFad<ValueT>(a, std::tanh(a.val()), t);
+      ValueT t = std::tanh(a.val());
+      return SimpleFad<ValueT>(a, t, 1-t*t);
     }
 
     template <typename ValueT>

--- a/packages/sacado/src/new_design/Sacado_Fad_Exp_Ops.hpp
+++ b/packages/sacado/src/new_design/Sacado_Fad_Exp_Ops.hpp
@@ -232,11 +232,10 @@ FAD_UNARYOP_MACRO(sinh,
                   expr.fastAccessDx(i)* cosh(expr.val()))
 FAD_UNARYOP_MACRO(tanh,
                   TanhOp,
-                  using std::tanh; using std::cosh;,
+                  using std::tanh;,
                   tanh(expr.val()),
-                  expr.dx(i)/( cosh(expr.val())* cosh(expr.val())),
-                  expr.fastAccessDx(i) /
-                    ( cosh(expr.val())* cosh(expr.val())))
+                  expr.dx(i)*(value_type(1)-tanh(expr.val())*tanh(expr.val())),
+                  expr.fastAccessDx(i)*(value_type(1)-tanh(expr.val())*tanh(expr.val())))
 FAD_UNARYOP_MACRO(acosh,
                   ACoshOp,
                   using std::acosh; using std::sqrt;,


### PR DESCRIPTION
See issue #6632.  Replace d(tanh(x))/dx = sech^2(x) with 1-tanh^2(x).