### PR TITLE
Tacho - disable to use a recursive function

### DIFF
--- a/packages/shylu/shylu_node/tacho/src/Tacho_TaskFunctor_FactorizeChol.hpp
+++ b/packages/shylu/shylu_node/tacho/src/Tacho_TaskFunctor_FactorizeChol.hpp
@@ -94,7 +94,13 @@ namespace Tacho {
 
         switch (_state) {
         case 0: { // tree parallelsim
-          if (_info.serial_thres_size > _s.max_decendant_supernode_size) {
+#if defined( KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST )
+          const bool recursive_function_work_on_exec_space = true;          
+#else
+          const bool recursive_function_work_on_exec_space = false;          
+#endif
+          if (recursive_function_work_on_exec_space && 
+              _info.serial_thres_size > _s.max_decendant_supernode_size) {
             r_val = factorize_internal(member, _s.max_decendant_schur_size, true);
             Kokkos::single(Kokkos::PerTeam(member), [&]() {
                 if (r_val) Kokkos::respawn(this, sched, Kokkos::TaskPriority::Low);

--- a/packages/shylu/shylu_node/tacho/src/Tacho_TaskFunctor_FactorizeCholPanel.hpp
+++ b/packages/shylu/shylu_node/tacho/src/Tacho_TaskFunctor_FactorizeCholPanel.hpp
@@ -96,7 +96,13 @@ namespace Tacho {
 
         switch (_state) {
         case 0: { // tree parallelsim
-          if (false && _info.serial_thres_size > _s.max_decendant_supernode_size) {
+#if defined( KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST )
+          const bool recursive_function_work_on_exec_space = true;
+#else
+          const bool recursive_function_work_on_exec_space = false;
+#endif
+          if (recursive_function_work_on_exec_space && 
+              _info.serial_thres_size > _s.max_decendant_supernode_size) {
             r_val = factorize_internal(member, _s.max_decendant_schur_size, true);
 
             Kokkos::single(Kokkos::PerTeam(member), [&]() {

--- a/packages/shylu/shylu_node/tacho/src/Tacho_TaskFunctor_SolveLowerChol.hpp
+++ b/packages/shylu/shylu_node/tacho/src/Tacho_TaskFunctor_SolveLowerChol.hpp
@@ -89,7 +89,13 @@ namespace Tacho {
             
         switch (_state) {
         case 0: { // tree parallelsim
-          if (_info.serial_thres_size > _s.max_decendant_supernode_size) {
+#if defined( KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST )
+          const bool recursive_function_work_on_exec_space = true;          
+#else
+          const bool recursive_function_work_on_exec_space = false;          
+#endif
+          if (recursive_function_work_on_exec_space && 
+              _info.serial_thres_size > _s.max_decendant_supernode_size) {
             r_val = solve_internal(member, _s.max_decendant_schur_size, true);
             Kokkos::single(Kokkos::PerTeam(member), [&]() {
                 if (r_val) Kokkos::respawn(this, sched, Kokkos::TaskPriority::Low);

--- a/packages/shylu/shylu_node/tacho/src/Tacho_TaskFunctor_SolveUpperChol.hpp
+++ b/packages/shylu/shylu_node/tacho/src/Tacho_TaskFunctor_SolveUpperChol.hpp
@@ -82,7 +82,13 @@ namespace Tacho {
       void operator()(member_type &member, value_type &r_val) {
         auto& sched = member.scheduler();  
         const auto &_s = _info.supernodes(_sid);
-        if (_info.serial_thres_size > _s.max_decendant_supernode_size) {
+#if defined( KOKKOS_ACTIVE_EXECUTION_MEMORY_SPACE_HOST )
+          const bool recursive_function_work_on_exec_space = true;          
+#else
+          const bool recursive_function_work_on_exec_space = false;          
+#endif
+        if (recursive_function_work_on_exec_space && 
+          _info.serial_thres_size > _s.max_decendant_supernode_size) {
           r_val = solve_internal(member, _s.max_decendant_schur_size, true);
           Kokkos::single(Kokkos::PerTeam(member), [&]() {
               if (r_val) 


### PR DESCRIPTION
## Motivation

On Cuda tasking, it seems to be dangerous to use a recursive function as kokkos tasking on cuda uses fixed size of stack size. With a recursive function, it causes illegal memory access error in a random place. This PR disable the recursive function on the CUDA active space.


