### PR TITLE
Moertel: Small improvements linked to the perpendicular test (bis)

### DIFF
--- a/packages/moertel/src/mortar/Moertel_Tolerances.hpp
+++ b/packages/moertel/src/mortar/Moertel_Tolerances.hpp
@@ -52,7 +52,7 @@ namespace MOERTEL
 {
 
 const double Nodes_Identical_Epsilon = 1.0e-15;
-const double Projection_Length_Epsilon = 1.0e-10;
+const double Projection_Length_Epsilon = 0.25;
 const double Rough_Search_Radius = 2.5;
 
 

--- a/packages/moertel/src/mortar/mrtr_manager.H
+++ b/packages/moertel/src/mortar/mrtr_manager.H
@@ -610,6 +610,30 @@ public:
   */
   const Epetra_CrsMatrix* M() const { return M_.get();}
 
+  std::map<int,int> lm_to_dof()
+  {
+      // Create a map from Lagrange multiplier dofs to the primal dofs on the same node
+      std::vector<MOERTEL::Node*> nodes;
+      std::map<int,int> lm_to_dof;
+      for (auto&& keyval : interface_)
+      {
+        Teuchos::RCP<MOERTEL::Interface> inter = keyval.second;
+        inter->GetNodeView(nodes);
+        for (auto&& node : nodes)
+        {
+          if (! node->Nlmdof())
+            continue;
+          const int* dof = node->Dof();
+          const int* lmdof = node->LMDof();
+          for (std::size_t j=0; j<node->Nlmdof(); ++j)
+            lm_to_dof[lmdof[j]] = dof[j];
+        }
+      }
+      lm_to_dof_ = Teuchos::rcp(new std::map<int,int>(lm_to_dof));
+
+      return lm_to_dof;
+  }
+
   /*!
   \brief Query a managed interface added using AddInterface
   
@@ -676,7 +700,7 @@ protected:
   Teuchos::RCP<Epetra_CrsMatrix> spdmatrix_;           // the spd matrix of the problem;
   Teuchos::RCP<Epetra_CrsMatrix> spdrhs_;              // the matrix to left-multiply the rhs vector with for the spd problem
   
-  Teuchos::RCP<std::map<int,int> >    lm_to_dof_;           // maps lagrange multiplier dofs to primary dofs (slave side))
+  Teuchos::RCP<std::map<int,int> >    lm_to_dof_;      // maps Lagrange multiplier dofs to primary dofs (slave side)
   
   Teuchos::RCP<Epetra_CrsMatrix> I_;
   Teuchos::RCP<Epetra_CrsMatrix> WT_;

--- a/packages/moertel/src/mortar/mrtr_overlap_Def.hpp
+++ b/packages/moertel/src/mortar/mrtr_overlap_Def.hpp
@@ -381,8 +381,27 @@ bool MOERTEL::Overlap<IFace>::build_sxim()
   double gap;
   for (int i=0; i<nsnode; ++i)
   {
+
+    {
+      const double * node_norm = snode[i]->Normal();
+
+      double master_normal[3];
+      MOERTEL::Node** nodes = mseg_.Nodes();
+      for (std::size_t j=0; j<mseg_.Nnode(); ++j)
+        for (std::size_t k=0; k<3; ++k)
+          master_normal[k] += nodes[j]->Normal()[k];
+
+      double norm1 = sqrt(MOERTEL::dot(master_normal,master_normal,3));
+      for (std::size_t k=0; k<3; ++k)
+        master_normal[k] /= norm1;
+
+      double mag_projection = fabs(MOERTEL::dot(node_norm,master_normal,3));
+
+      if(mag_projection <= Projection_Length_Epsilon)
+        return false;
+    }
     // project node i onto sseg
-    projector.ProjectNodetoSegment_NodalNormal(*snode[i],mseg_,sxim_[i],gap);
+    bool OK = projector.ProjectNodetoSegment_NodalNormal(*snode[i],mseg_,sxim_[i],gap);
 #if 0
     // check whether i is inside sseg
     if (sxim_[i][0]<=1. && sxim_[i][1]<=abs(1.-sxim_[i][0]) && sxim_[i][0]>=0. && sxim_[i][1]>=0.)
@@ -540,6 +559,8 @@ bool MOERTEL::Overlap<IFace>::ComputeOverlap() {
   //  ProjectNodetoSegment_NodalNormal(*snode[i],mseg_,sxim_[i],gap);
 
   havesxim_ = build_sxim();
+  if (!havesxim_)
+	  return false;
 
   // build outward normal of edges of sseg (in local coords)
   build_normal();
@@ -1435,29 +1456,36 @@ bool MOERTEL::Overlap<IFace>::Triangulation()
       //-----------------
       // 
       // GAH - found by kimliegeois
-      // Moertel occasionally trys to project a slave segment on a master segment which can be perpendicular. 
+      // Moertel occasionally tries to project a slave segment on a master segment which can be perpendicular.
       // Compute the dot product of the normal of both segments and do not do the projection if its absolute value 
       //  is below a tolerance.
-      // FIXME: The below is valid only for planar segments!
 
       {
-
         double xi[2]; 
         xi[0] = xi[1] = 0.;
 
         const double * node_norm = node->Normal();
-        const double * seg_norm = mseg_.BuildNormal(xi);
 
-        double mag_projection = fabs(MOERTEL::dot(node_norm,seg_norm,3));
+        double master_normal[3];
+        MOERTEL::Node** nodes = mseg_.Nodes();
+        for (std::size_t j=0; j<mseg_.Nnode(); ++j)
+          for (std::size_t k=0; k<3; ++k)
+            master_normal[k] += nodes[j]->Normal()[k];
+
+        double norm1 = sqrt(MOERTEL::dot(master_normal,master_normal,3));
+        for (std::size_t k=0; k<3; ++k)
+          master_normal[k] /= norm1;
+
+        double mag_projection = fabs(MOERTEL::dot(node_norm,master_normal,3));
 
         if(mag_projection <= Projection_Length_Epsilon)
-
           return false;
-
       }
       //-----------------
 
-      projector.ProjectNodetoSegment_NodalNormal(*node,mseg_,mxi,gap);
+      bool ok = projector.ProjectNodetoSegment_NodalNormal(*node,mseg_,mxi,gap);
+      if (!ok)
+	      return false;
       // create a projected node and set it in node
       MOERTEL::ProjectedNode* pnode = new MOERTEL::ProjectedNode(*node,mxi,&mseg_);
       node->SetProjectedNode(pnode);


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/moertel

## Motivation
<!---
Why is this change required?  What problem does it solve? Please link to a github
issue that describes the problem/issue/bug this PR solves.
-->

The motivation behind this PR is to:
- Create a function that return a map which links the Langrange multipliers and their associated primal dofs.
- Replace the perpendicular test with a relative one to not have an influence of the mesh size on the perpendicular test.

This PR is the second PR of a sequence of PRs intended to include the software developments of my thesis in Trilinos.

The first one (#6642 ) is independent of Moertel and not required for this PR.

**This PR is a duplicate of PR #6643 which has been closed due to a testing issue related to git.**
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes
* Blocks
* Is blocked by
* Follows
* Precedes
* Related to
* Part of
* Composed of
-->


## Stakeholder Feedback
<!---
If a github issue includes feedback from the relevant stakeholder(s), please link it.
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

This branch has been tested on the Blake system.

<!---
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
