### PR TITLE
Remove --disable-packages argument

### DIFF
--- a/cmake/std/sems/checkin-test-sems.sh
+++ b/cmake/std/sems/checkin-test-sems.sh
@@ -181,7 +181,6 @@ defaults = [
   \"-j4\",
   \"--use-ninja\",
   \"--ctest-timeout=300\",
-  \"--disable-packages=PyTrilinos,TriKota\",
   \"--skip-case-no-email\",
   ]
   " > $_LOCAL_CHECKIN_TEST_DEFAULTS
@@ -193,9 +192,6 @@ fi
 #
 # --ctest-timeout=300: A default 5 minute timeout for any individual test. You
 #   might want to increase if you have a slower machine.
-#
-# --disable-packages: These are packages that most Trilinos developers will
-#    never want to test by default.
 #
 # --skip-case-no-email: Don't send email for skipped test cases.
 #


### PR DESCRIPTION
When the Claps package was removed in #4864, it actually broke the usage of
the checkin-test-sems.sh script for people that were using that script.  That
is because the file local-checkin-test-defaults.py was already written that
had Claps listed in --disabled-packages in that file.  This broke the sync of
ROL for a while to their subproject repo.

Given the current Trilinos GitHub PR testing system and the reduced usage of
the checkin-test.py script, there is no longer a need for adding an argument
like --disabled-packages to list out packages like PyTrilinos or TriKota.
These were listed many years ago so thaty if someone had edits in one of these
packages, then it would bascially bring their build down because packages like
PyTrilinos and TriKota would almost never be able to build.  But since then I
updated the checkin-test.py script to filter out any EX or even ST packages
from --default-bulds, edited packages like these did not get enabled anyway.
These are ST packages so they would get enabled in
--st-extra-builds=<buildname0>,... but if someone were modifying these
packages then they better be testing them.  So I can't see any reason to be
listed any packages by default in --disabled-packages.

So removing the --disabled-packages argument from this generated file should
eliminate a future source of breakage like happened with the removal of Claps.
