### PR TITLE
Tpetra: Refactor withLocalAccess so we don't need CUDA_LAUNCH_BLOCKING or extra fences

### DIFF
--- a/packages/tpetra/core/src/Tpetra_transform_MultiVector.hpp
+++ b/packages/tpetra/core/src/Tpetra_transform_MultiVector.hpp
@@ -35,8 +35,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
-//
 // ************************************************************************
 // @HEADER
 */

--- a/packages/tpetra/core/src/Tpetra_withLocalAccess.hpp
+++ b/packages/tpetra/core/src/Tpetra_withLocalAccess.hpp
@@ -87,6 +87,10 @@ namespace Tpetra {
     template<EAccess am>
     struct is_access_mode<Access<am>> : public std::true_type {};
 
+    using read_only = Access<EAccess::ReadOnly>;
+    using write_only = Access<EAccess::WriteOnly>;
+    using read_write = Access<EAccess::ReadWrite>;
+
     /// \brief Given a global object, get its default memory space
     ///   (both the type and the default instance thereof).
     ///
@@ -106,10 +110,27 @@ namespace Tpetra {
       }
     };
 
+    /// \brief Given a global object, get its default execution space
+    ///   (both the type and the default instance thereof).
+    ///
+    /// This generic version should suffice for most Tpetra classes,
+    /// and for any class with a public <tt>device_type</tt> typedef
+    /// that is a Kokkos::Device specialization.
+    template<class GlobalObjectType>
+    struct DefaultExecutionSpace {
+      using type = typename GlobalObjectType::device_type::execution_space;
+
+      // Given a global object, get its (default) execution space instance.
+      static type space (const GlobalObjectType& /* G */) {
+        // This stub just assumes that 'type' is default constructible.
+        // In Kokkos, default-constructing a execution space instance just
+        // gives the default execution space.
+        return type ();
+      }
+    };
+
 #ifndef DOXYGEN_SHOULD_SKIP_THIS
-    template<class GlobalObjectType,
-             class MemorySpace,
-             class AccessMode>
+    template<class GlobalObjectType, class ... Args>
     class LocalAccess; // forward declaration
 #endif // DOXYGEN_SHOULD_SKIP_THIS
 
@@ -126,7 +147,7 @@ namespace Tpetra {
     ///
     /// Specializations require the following two public features:
     /// <ul>
-    /// <li> <tt>master_local_object_type</tt> typedef </li>
+    /// <li> <tt>master_local_object_type</tt> type alias </li>
     /// <li> <tt>master_local_object_type get(LocalAccessType)</tt>
     ///      static method </li>
     /// </ul>
@@ -152,7 +173,8 @@ namespace Tpetra {
     /// right way is to specialize GetMasterLocalObject::get (see
     /// above).
     template<class LocalAccessType>
-    typename GetMasterLocalObject<LocalAccessType>::master_local_object_type
+    typename GetMasterLocalObject<LocalAccessType>::
+      master_local_object_type
     getMasterLocalObject (LocalAccessType LA) {
       return GetMasterLocalObject<LocalAccessType>::get (LA);
     }
@@ -197,11 +219,12 @@ namespace Tpetra {
     template<class LocalAccessType>
     typename GetNonowningLocalObject<LocalAccessType>::
     nonowning_local_object_type
-    getNonowningLocalObject (LocalAccessType LA,
+    getNonowningLocalObject(LocalAccessType LA,
       const typename GetMasterLocalObject<LocalAccessType>::
         master_local_object_type& master)
     {
-      return GetNonowningLocalObject<LocalAccessType>::get (LA, master);
+      using impl_type = GetNonowningLocalObject<LocalAccessType>;
+      return impl_type::get(LA, master);
     }
   } // namespace Details
 
@@ -230,43 +253,36 @@ namespace Tpetra {
   //////////////////////////////////////////////////////////////////////
 
   /// \brief Declare that you want to access the given global object's
-  ///   local data in read-only mode, in the object's default memory
-  ///   space.
+  ///   local data in read-only mode.
   template<class GlobalObjectType>
   Details::LocalAccess<
     GlobalObjectType,
-    typename Details::DefaultMemorySpace<GlobalObjectType>::type,
-    Details::Access<Details::EAccess::ReadOnly>>
+    Details::read_only>
   readOnly (GlobalObjectType&);
 
   /// \brief Declare that you want to access the given global object's
   ///   local data in read-only mode (overload for const
-  ///   GlobalObjectType), in the object's default memory space.
+  ///   GlobalObjectType).
   template<class GlobalObjectType>
   Details::LocalAccess<
     GlobalObjectType,
-    typename Details::DefaultMemorySpace<GlobalObjectType>::type,
-    Details::Access<Details::EAccess::ReadOnly>>
+    Details::read_only>
   readOnly (const GlobalObjectType&);
 
   /// \brief Declare that you want to access the given global object's
-  ///   local data in write-only mode, in the object's default memory
-  ///   space.
+  ///   local data in write-only mode.
   template<class GlobalObjectType>
   Details::LocalAccess<
     GlobalObjectType,
-    typename Details::DefaultMemorySpace<GlobalObjectType>::type,
-    Details::Access<Details::EAccess::WriteOnly>>
+    Details::write_only>
   writeOnly (GlobalObjectType&);
 
   /// \brief Declare that you want to access the given global object's
-  ///   local data in read-and-write mode, in the object's default
-  ///   memory space.
+  ///   local data in read-and-write mode.
   template<class GlobalObjectType>
   Details::LocalAccess<
     GlobalObjectType,
-    typename Details::DefaultMemorySpace<GlobalObjectType>::type,
-    Details::Access<Details::EAccess::ReadWrite>>
+    Details::read_write>
   readWrite (GlobalObjectType&);
 
   ////////////////////////////////////////////////////////////
@@ -274,60 +290,290 @@ namespace Tpetra {
   ////////////////////////////////////////////////////////////
 
   namespace Details {
+    //! Tag indicating an unspecified type in LocalAccessTraits.
+    struct unspecified_type {};
+
+    /// \brief Deduce types from parameter pack of LocalAccess.
+    ///
+    /// Deduce the following types from Args:
+    /// <ul>
+    /// <li>execution_space (Kokkos execution space)</li>
+    /// <li>memory_space (Kokkos memory space)</li>
+    /// <li>access_mode (Access type)</li>
+    /// </ul>
+    template<class ... Args>
+    struct LocalAccessTraits {};
+
+    // An empty list of template arguments constrains nothing.
+    template<>
+    struct LocalAccessTraits<> {
+      using execution_space = unspecified_type;
+      using memory_space = unspecified_type;
+      using access_mode = unspecified_type;
+    };
+
+    // Skip over any instances of unspecified_type.  This makes it
+    // easy to define the return types of LocalAccess::on and
+    // LocalAccess::at (see below).
+    template<class ... Rest>
+    struct LocalAccessTraits<unspecified_type, Rest...> {
+    private:
+      using rest_type = LocalAccessTraits<Rest...>;
+    public:
+      using execution_space = typename rest_type::execution_space;
+      using memory_space = typename rest_type::memory_space;
+      using access_mode = typename rest_type::access_mode;
+    };
+
+    template<class First, class ... Rest>
+    struct LocalAccessTraits<First, Rest...> {
+    private:
+      using rest_type = LocalAccessTraits<Rest...>;
+    public:
+      using execution_space = typename std::conditional<
+        Kokkos::Impl::is_execution_space<First>::value,
+        First,
+        typename rest_type::execution_space>::type;
+      using memory_space = typename std::conditional<
+        Kokkos::Impl::is_memory_space<First>::value,
+        First,
+        typename rest_type::memory_space>::type;
+      using access_mode = typename std::conditional<
+        is_access_mode<First>::value,
+        First,
+        typename rest_type::access_mode>::type;
+    };
+
+    template<class GlobalObjectType,
+             class Traits,
+             bool is_execution_space_specified = ! std::is_same<
+               typename Traits::execution_space,
+               unspecified_type>::value,
+             bool is_memory_space_specified = ! std::is_same<
+               typename Traits::memory_space,
+               unspecified_type>::value>
+    struct SpaceTypes {};
+
+    template<class GlobalObjectType, class Traits>
+    struct SpaceTypes<GlobalObjectType, Traits, true, true> {
+      using execution_space = typename Traits::execution_space;
+      using memory_space = typename Traits::memory_space;
+    };
+
+    // If only memory_space was specified, then get execution_space
+    // from memory_space's default execution space.
+    template<class GlobalObjectType, class Traits>
+    struct SpaceTypes<GlobalObjectType, Traits, false, true> {
+      using execution_space =
+        typename Traits::memory_space::execution_space;
+      using memory_space = typename Traits::memory_space;
+    };
+
+    // If only execution_space was specified, then get memory_space
+    // from execution_space's default memory space.
+    template<class GlobalObjectType, class Traits>
+    struct SpaceTypes<GlobalObjectType, Traits, true, false> {
+      using execution_space = typename Traits::execution_space;
+      using memory_space =
+        typename Traits::execution_space::memory_space;
+    };
+
+    // If neither execution_space nor memory_space were specified,
+    // then get them both from their defaults, that depend on
+    // GlobalObjectType.
+    template<class GlobalObjectType, class Traits>
+    struct SpaceTypes<GlobalObjectType, Traits, false, false> {
+      using execution_space =
+        typename DefaultExecutionSpace<GlobalObjectType>::type;
+      using memory_space =
+        typename DefaultMemorySpace<GlobalObjectType>::type;
+    };
+
     /// \brief Declaration of access intent for a global object.
     ///
-    /// Users aren't supposed to make instances of this class.  They
-    /// should use readOnly, writeOnly, or readWrite instead, then
-    /// call instance methods like on() and valid() on the resulting
-    /// LocalAccess instance.
-    template<class GlobalObjectType,
-             class MemorySpace,
-             class AccessMode>
+    /// \tparam GlobalObjectType Type of the global object whose local
+    ///   data you want to access.
+    ///
+    /// \tparam Args Zero or more types, each of which may be a Kokkos
+    ///   execution space, a Kokkos memory space, or Access (see
+    ///   above).
+    ///
+    /// Users must not make instances of this class directly.  The
+    /// only way they may create an instance of LocalAccess is by
+    /// calling readOnly(), writeOnly(), readWrite(), or LocalAccess
+    /// instance methods like at(), on(), and valid().
+    ///
+    /// For X a Tpetra::MultiVector with
+    /// <tt>memory_space=Kokkos::CudaUVMSpace</tt> and
+    /// <tt>execution_space=Kokkos::Cuda</tt>, the following two code
+    /// examples must have the same effect:
+    ///
+    /// \code
+    /// readWrite(X).on(CudaUVMSpace()).at(DefaultHostExecutionSpace());
+    /// \endcode
+    ///
+    /// and
+    ///
+    /// \code
+    /// readWrite(X).at(DefaultHostExecutionSpace()).on(CudaUVMSpace());
+    /// \endcode
+    ///
+    /// That effect should be: "I intend to view X's local data in
+    /// read-and-write fashion at host execution, on a UVM
+    /// allocation."  Given Tpetra's current design (as of 26 Jan
+    /// 2020), if X needs sync to host, then that implies a fence, to
+    /// ensure that any device writes to X's local data are done.
+    ///
+    /// This means that LocalAccess needs to be able to know whether
+    /// the user has explicitly specified an execution space in which
+    /// to access local data.  Here is how <tt>on</tt> behaves:
+    ///
+    /// 1. If the input LocalAccess has no execution space explicitly
+    ///    specified, then do not constrain it.  withLocalAccess will
+    ///    assign a default execution space.  (This makes the "at
+    ///    after on" example above work correctly.)
+    ///
+    /// 2. Else, use the input LocalAccess' execution_space.  The
+    ///    caller is responsible for knowing whether NewMemorySpace is
+    ///    accessible from execution_space.
+    ///
+    /// Here is how <tt>at</tt> behaves:
+    ///
+    /// 1. If the input LocalAccess has no memory space explicitly
+    ///    specified, then do not constrain it.  withLocalAccess will
+    ///    assign a default memory space.  (This makes the "on after
+    ///    at" example above work correctly.)
+    ///
+    /// 2. Else, use the input LocalAccess' memory_space.  The caller
+    ///    is responsible for knowing whether NewExecutionSpace can
+    ///    access memory_space.
+    ///
+    /// The general behavior is that at() and on() both only constrain
+    /// the one thing that the user specified.  Only the "final"
+    /// LocalAccess object determines the behavior of withLocalAccess.
+    ///
+    /// For these reasons, LocalAccess needs to be able to distinguish
+    /// between "the user explicitly assigned an {execution, memory}
+    /// space," and "use the default {execution, memory} space."  This
+    /// is why LocalAccess has a template parameter pack.
+    template<class GlobalObjectType, class ... Args>
     class LocalAccess {
+    private:
+      using this_type = LocalAccess<GlobalObjectType, Args...>;
+      using traits = LocalAccessTraits<Args...>;
+      static constexpr bool is_execution_space_specified =
+        ! std::is_same<typename traits::execution_space,
+                       unspecified_type>::value;
+      static constexpr bool is_memory_space_specified =
+        ! std::is_same<typename traits::memory_space,
+                       unspecified_type>::value;
+      static constexpr bool is_access_mode_specified =
+        ! std::is_same<typename traits::access_mode,
+                       unspecified_type>::value;
+      static_assert(is_access_mode_specified, "LocalAccess requires "
+        "that you specify the access mode.  You may do this by "
+        "always starting construction of a LocalAccess instance "
+        "with readOnly, writeOnly, or readWrite.");
+
     public:
       using global_object_type = GlobalObjectType;
-      using memory_space = typename MemorySpace::memory_space;
-      static_assert(is_access_mode<AccessMode>::value,
-        "The AccessMode template parameter must be an instance of "
-        "Tpetra::Details::Access.");
-      using access_mode = AccessMode;
 
-    private:
-      using canonical_this_type = LocalAccess<global_object_type,
-                                              memory_space,
-                                              access_mode>;
-    public:
-      /// \brief Constructor.
+      using execution_space =
+        typename SpaceTypes<global_object_type, traits>::execution_space;
+      static_assert(! is_execution_space_specified ||
+        Kokkos::Impl::is_execution_space<execution_space>::value,
+        "Specified execution space is not a Kokkos execution space.");
+      static_assert(is_execution_space_specified ||
+        Kokkos::Impl::is_execution_space<execution_space>::value,
+        "Default execution space is not a Kokkos execution space.");
+
+      using memory_space =
+        typename SpaceTypes<global_object_type, traits>::memory_space;
+      static_assert(! is_memory_space_specified ||
+        Kokkos::Impl::is_memory_space<memory_space>::value,
+        "Specified memory space is not a Kokkos memory space.");
+      static_assert(is_memory_space_specified ||
+        Kokkos::Impl::is_memory_space<memory_space>::value,
+        "Default memory space is not a Kokkos memory space.");
+
+      using access_mode = typename traits::access_mode;
+
+      /// \brief Constructor that specifies the global object, the
+      ///   execution memory space instance on which to view its local
+      ///   data, the memory space instance on which to view its local
+      ///   data, and (optionally) whether the global object is valid.
       ///
       /// Users must NOT call the LocalAccess constructor directly.
       /// They should instead start by calling readOnly, writeOnly, or
       /// readWrite above.  They may then use instance methods like
-      /// on() or valid() (see below).
+      /// at(), on(), or valid() (see below).
       ///
       /// G is a reference, because we only access it in a delimited
       /// scope.  G is nonconst, because even read-only local access
       /// may modify G.  For example, G may give access to its local
       /// data via lazy allocation of a data structure that differs
       /// from its normal internal storage format.
-      ///
-      /// Memory spaces should behave like Kokkos memory spaces.
-      /// Default construction should work and should get the default
-      /// instance of the space.  Otherwise, it may make sense to get
-      /// the default memory space from G.
       LocalAccess (global_object_type& G,
-                   memory_space space = memory_space (),
-                   const bool thisIsValid = true) :
+                   const execution_space& execSpace,
+                   const memory_space& memSpace,
+                   const bool viewIsValid = true) :
         G_ (G),
-        space_ (space),
-        valid_ (thisIsValid)
+        execSpace_ (execSpace),
+        memSpace_ (memSpace),
+        valid_ (viewIsValid)
       {}
 
-      /// \brief Type that users see, that's an argument to the
-      ///   function that they give to withLocalAccess.
-      using function_argument_type =
-        with_local_access_function_argument_type<canonical_this_type>;
+      /// \brief Constructor that specifies the global object and
+      ///   (optionally) whether it is valid.
+      LocalAccess (global_object_type& G,
+                   const bool viewIsValid = true) :
+        LocalAccess (G,
+          DefaultExecutionSpace<global_object_type>::space (G),
+          DefaultMemorySpace<global_object_type>::space (G),
+          viewIsValid)
+      {}
 
-    public:
+      /// \brief Constructor that specifies the global object, the
+      ///   execution space instance at which to view its local data,
+      ///   and (optionally) whether the global object is valid.
+      LocalAccess (global_object_type& G,
+                   const execution_space& execSpace,
+                   const bool viewIsValid = true) :
+        LocalAccess (G,
+          execSpace,
+          DefaultMemorySpace<global_object_type>::space (G),
+          viewIsValid)
+      {}
+
+      /// \brief Constructor that specifies the global object, the
+      ///   memory space instance on which to view its local data, and
+      ///   (optionally) whether the global object is valid.
+      LocalAccess (global_object_type& G,
+                   const memory_space& memSpace,
+                   const bool viewIsValid = true) :
+        LocalAccess (G,
+          DefaultExecutionSpace<global_object_type>::space (G),
+          memSpace,
+          viewIsValid)
+      {}
+
+      /// \brief Is access supposed to be valid?
+      ///
+      /// If not, then you may not access the global object's local
+      /// data inside a withLocalAccess scope governed by this
+      /// LocalAccess instance.
+      ///
+      /// See <tt>valid(const bool)</tt> below.
+      bool isValid () const { return valid_; }
+
+      /// \brief Execution space instance, at which the user will
+      ///   access local data.
+      execution_space getExecutionSpace () const { return execSpace_; }
+
+      /// \brief Memory space instance, on which the user will access
+      ///   local data.
+      memory_space getMemorySpace () const { return memSpace_; }
+
       /// \brief Declare at run time whether you actually want to
       ///   access the object.
       ///
@@ -339,25 +585,67 @@ namespace Tpetra {
       /// on allocating temporary space, copying from device to host,
       /// etc.  This implies that implementations must be able to
       /// construct "null" / empty master local objects.
-      LocalAccess<GlobalObjectType, MemorySpace, access_mode>
+      this_type
       valid (const bool thisIsValid) const {
-        return {this->G_, this->space_, thisIsValid};
+        return {G_, getExecutionSpace(), getMemorySpace(),
+                thisIsValid};
       }
 
-      /// \brief Declare intent to access this object's local data in
+      /// \brief Declare intent to access this object's local data on
       ///   a specific (Kokkos) memory space (instance).
       template<class NewMemorySpace>
-      LocalAccess<GlobalObjectType, NewMemorySpace, access_mode>
-      on (NewMemorySpace space) const {
-        return {this->G_, space, this->valid_};
+      typename std::conditional<
+        is_execution_space_specified,
+        LocalAccess<global_object_type, execution_space,
+                    NewMemorySpace, access_mode>,
+        LocalAccess<global_object_type, NewMemorySpace, access_mode>
+        >::type
+      on(const NewMemorySpace& memSpace) const {
+        using Kokkos::Impl::is_memory_space;
+        static_assert(is_memory_space<NewMemorySpace>::value,
+          "NewMemorySpace must be a Kokkos memory space.");
+
+        // We can't use std::conditional here, because we need the
+        // "select" method.
+        using alt_execution_space =
+          typename LocalAccess<global_object_type, NewMemorySpace,
+                               access_mode>::execution_space;
+        auto execSpace = Kokkos::Impl::if_c<
+          is_execution_space_specified,
+          execution_space,
+          alt_execution_space>::select(
+            getExecutionSpace(),
+            alt_execution_space());
+        return {G_, execSpace, memSpace, isValid()};
       }
 
-      //! Is access supposed to be valid?  (See valid() above.)
-      bool isValid () const { return this->valid_; }
+      /// \brief Declare intent to access this object's local data at
+      ///   a specific (Kokkos) execution space (instance).
+      template<class NewExecutionSpace>
+      typename std::conditional<
+        is_memory_space_specified,
+        LocalAccess<global_object_type, NewExecutionSpace,
+                    memory_space, access_mode>,
+        LocalAccess<global_object_type, NewExecutionSpace, access_mode>
+        >::type
+      at(const NewExecutionSpace& execSpace) const {
+        using Kokkos::Impl::is_execution_space;
+        static_assert(is_execution_space<NewExecutionSpace>::value,
+          "NewExecutionSpace must be a Kokkos execution space.");
 
-      /// \brief Memory space instance in which the user will access
-      ///   local data.
-      memory_space getSpace () const { return space_; }
+        // We can't use std::conditional here, because we need the
+        // "select" method.
+        using alt_memory_space =
+          typename LocalAccess<global_object_type, NewExecutionSpace,
+                               access_mode>::memory_space;
+        auto memSpace = Kokkos::Impl::if_c<
+          is_memory_space_specified,
+          memory_space,
+          alt_memory_space>::select(
+            getMemorySpace(),
+            alt_memory_space());
+        return {G_, execSpace, memSpace, isValid()};
+      }
 
     public:
       /// \brief Reference to the global object whose data the user
@@ -367,12 +655,20 @@ namespace Tpetra {
       /// delimited scope.
       global_object_type& G_;
 
-      /// \brief Memory space instance in which the user will access
+      /// \brief Execution space instance, with which the user will
+      ///   access local data.
+      ///
+      /// We assume that Kokkos execution spaces have shallow-copy
+      /// semantics.
+      execution_space execSpace_;
+
+      /// \brief Memory space instance, on which the user will access
       ///   local data.
       ///
       /// We assume that Kokkos memory spaces have shallow-copy
       /// semantics.
-      memory_space space_;
+      memory_space memSpace_;
+
       //! Will I actually need to access this object?
       bool valid_;
     };
@@ -382,45 +678,41 @@ namespace Tpetra {
   // Implementations of readOnly, writeOnly, and readWrite
   ////////////////////////////////////////////////////////////
 
-  template<class GOT>
+  template<class GlobalObjectType>
   Details::LocalAccess<
-    GOT,
-    typename Details::DefaultMemorySpace<GOT>::type,
-    Details::Access<Details::EAccess::ReadOnly>>
-  readOnly (GOT& G)
+    GlobalObjectType,
+    Details::read_only>
+  readOnly (GlobalObjectType& G)
   {
-    return {G, Details::DefaultMemorySpace<GOT>::space (G), true};
+    return {G};
   }
 
-  template<class GOT>
+  template<class GlobalObjectType>
   Details::LocalAccess<
-    GOT,
-    typename Details::DefaultMemorySpace<GOT>::type,
-    Details::Access<Details::EAccess::ReadOnly>>
-  readOnly (const GOT& G)
+    GlobalObjectType,
+    Details::read_only>
+  readOnly (const GlobalObjectType& G)
   {
-    GOT& G_nc = const_cast<GOT&> (G);
-    return {G_nc, Details::DefaultMemorySpace<GOT>::space (G_nc), true};
+    GlobalObjectType& G_nc = const_cast<GlobalObjectType&> (G);
+    return {G_nc};
   }
 
-  template<class GOT>
+  template<class GlobalObjectType>
   Details::LocalAccess<
-    GOT,
-    typename Details::DefaultMemorySpace<GOT>::type,
-    Details::Access<Details::EAccess::WriteOnly>>
-  writeOnly (GOT& G)
+    GlobalObjectType,
+    Details::write_only>
+  writeOnly (GlobalObjectType& G)
   {
-    return {G, Details::DefaultMemorySpace<GOT>::space (G), true};
+    return {G};
   }
 
-  template<class GOT>
+  template<class GlobalObjectType>
   Details::LocalAccess<
-    GOT,
-    typename Details::DefaultMemorySpace<GOT>::type,
-    Details::Access<Details::EAccess::ReadWrite>>
-  readWrite (GOT& G)
+    GlobalObjectType,
+    Details::read_write>
+  readWrite (GlobalObjectType& G)
   {
-    return {G, Details::DefaultMemorySpace<GOT>::space (G), true};
+    return {G};
   }
 
   ////////////////////////////////////////////////////////////
@@ -506,20 +798,20 @@ namespace Tpetra {
     template<class ... LocalAccessTypes>
     struct WithLocalAccess {
       using current_user_function_type =
-        typename Details::ArgsToFunction<LocalAccessTypes...>::type;
+        typename ArgsToFunction<LocalAccessTypes...>::type;
 
       static void
       withLocalAccess (LocalAccessTypes...,
-                       typename Details::ArgsToFunction<LocalAccessTypes...>::type);
+                       typename ArgsToFunction<LocalAccessTypes...>::type);
     };
 
-    /// \brief Specialization of withLocalAccess that implements the
+    /// \brief Specialization of WithLocalAccess that implements the
     ///   "base class" of the user providing no GlobalObject
     ///   arguments, and a function that takes no arguments.
     template<>
     struct WithLocalAccess<> {
       using current_user_function_type =
-        typename Details::ArgsToFunction<>::type;
+        typename ArgsToFunction<>::type;
 
       static void
       withLocalAccess (current_user_function_type userFunction)
@@ -528,7 +820,7 @@ namespace Tpetra {
       }
     };
 
-    /// \brief Specialization of withLocalAccess that implements the
+    /// \brief Specialization of WithLocalAccess that implements the
     ///   "recursion case."
     ///
     /// \tparam FirstLocalAccessType Specialization of LocalAccess.
@@ -537,7 +829,7 @@ namespace Tpetra {
     template<class FirstLocalAccessType, class ... Rest>
     struct WithLocalAccess<FirstLocalAccessType, Rest...> {
       using current_user_function_type =
-        typename Details::ArgsToFunction<FirstLocalAccessType, Rest...>::type;
+        typename ArgsToFunction<FirstLocalAccessType, Rest...>::type;
 
       static void
       withLocalAccess (current_user_function_type userFunction,
@@ -587,7 +879,8 @@ namespace Tpetra {
         //    });
 
         WithLocalAccess<Rest...>::withLocalAccess
-          ([=] (typename Rest::function_argument_type... args) {
+          ([=] (with_local_access_function_argument_type<Rest>... args) {
+       // ([=] (typename Rest::function_argument_type... args) {
              userFunction (first_lcl_view, args...);
            },
            rest...);
@@ -644,4 +937,3 @@ namespace Tpetra {
 } // namespace Tpetra
 
 #endif // TPETRA_WITHLOCALACCESS_HPP
-

--- a/packages/tpetra/core/src/Tpetra_withLocalAccess.hpp
+++ b/packages/tpetra/core/src/Tpetra_withLocalAccess.hpp
@@ -880,7 +880,6 @@ namespace Tpetra {
 
         WithLocalAccess<Rest...>::withLocalAccess
           ([=] (with_local_access_function_argument_type<Rest>... args) {
-       // ([=] (typename Rest::function_argument_type... args) {
              userFunction (first_lcl_view, args...);
            },
            rest...);

--- a/packages/tpetra/core/src/Tpetra_withLocalAccess_MultiVector.hpp
+++ b/packages/tpetra/core/src/Tpetra_withLocalAccess_MultiVector.hpp
@@ -35,8 +35,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
-//
 // ************************************************************************
 // @HEADER
 */
@@ -56,310 +54,462 @@
 namespace Tpetra {
   namespace Details {
 
-    //! Specialization of GetMasterLocalObject for Tpetra::MultiVector.
-    template<class SC, class LO, class GO, class NT,
-             class MemorySpace,
-             class AccessMode>
+    // We need these forward declarations so that LocalAccess knows
+    // these partial specializations exist, and doesn't just defer to
+    // the generic empty version.
+
+    template<class SC, class LO, class GO, class NT, class ... Args>
     struct GetMasterLocalObject<
-      LocalAccess<
-        Tpetra::MultiVector<SC, LO, GO, NT>, MemorySpace, AccessMode> >
+      LocalAccess<Tpetra::MultiVector<SC, LO, GO, NT>, Args...>
+      >;
+    template<class SC, class LO, class GO, class NT, class ... Args>
+    struct GetMasterLocalObject<
+      LocalAccess<Tpetra::Vector<SC, LO, GO, NT>, Args...>
+      >;
+
+    template<class SC, class LO, class GO, class NT, class ... Args>
+    struct GetNonowningLocalObject<
+      LocalAccess<Tpetra::MultiVector<SC, LO, GO, NT>, Args...>
+      >;
+    template<class SC, class LO, class GO, class NT, class ... Args>
+    struct GetNonowningLocalObject<
+      LocalAccess<Tpetra::Vector<SC, LO, GO, NT>, Args...>
+      >;
+
+    //////////////////////////////////////////////////////////////////
+
+    template<class Space>
+    struct is_host_space {
+      // Space=CudaSpace: false.
+      // Space=CudaUVMSpace: false.
+      // Space=CudaHostPinnedSpace: true.
+      // Space=HostSpace: true.
+      //
+      // Space=Cuda: true.
+      // Space=OpenMP: false.
+      // Space=Serial: false.
+      // space=Threads: false.
+      static constexpr bool value =
+        std::is_same<typename Space::execution_space::memory_space,
+                     Kokkos::HostSpace>::value;
+    };
+
+    //////////////////////////////////////////////////////////////////
+
+    //! Specialization of GetMasterLocalObject for Tpetra::MultiVector.
+    template<class SC, class LO, class GO, class NT, class ... Args>
+    struct GetMasterLocalObject<
+      LocalAccess<Tpetra::MultiVector<SC, LO, GO, NT>, Args...>
+      >
     {
     private:
-      static_assert(is_access_mode<AccessMode>::value,
-        "The AccessMode template parameter must be an instance of "
-        "Tpetra::Details::Access.");
       using global_object_type = Tpetra::MultiVector<SC, LO, GO, NT>;
 
     public:
       using local_access_type =
-        LocalAccess<Tpetra::MultiVector<SC, LO, GO, NT>, MemorySpace,
-                    AccessMode>;
+        LocalAccess<global_object_type, Args...>;
+
     private:
+      using execution_space =
+        typename local_access_type::execution_space;
+      static_assert(
+        Kokkos::Impl::is_execution_space<execution_space>::value,
+        "LocalAccess<Args...>::execution_space is not a valid "
+        "Kokkos execution space.");
+
+      using memory_space = typename local_access_type::memory_space;
+      static_assert(
+        Kokkos::Impl::is_memory_space<memory_space>::value,
+        "LocalAccess<Args...>::memory_space is not a valid "
+        "Kokkos memory space.");
+
+      using access_mode = typename local_access_type::access_mode;
+      static_assert(
+        is_access_mode<access_mode>::value,
+        "LocalAccess<Args...>::access_mode is not an Access "
+        "type.");
+
       // FIXME (mfh 22 Oct 2018, 25 Apr 2019) Need to make sure that
       // the execution space matches.  If not, we would need to
       // allocate a new View, and then we should actually make the
       // std::unique_ptr's destructor "copy back."  This is why
-      // master_local_object_type is a std::unique_ptr<view_type>, not
-      // just a view_type.
+      // master_local_object_type (see below) is a
+      // std::unique_ptr<Kokkos::View<...>>, not just a
+      // Kokkos::View<...>.
       //
       // mfh 01 May 2019: For now, we avoid allocation and copy back,
       // by using only the Views available in the MV's DualView.
-      using dual_view_type = typename global_object_type::dual_view_type;
-
-      // MemorySpace=CudaSpace: false.
-      // MemorySpace=CudaUVMSpace: false.
-      // MemorySpace=CudaHostPinnedSpace: true.
-      // MemorySpace=HostSpace: true.
-      static constexpr bool is_host =
-        std::is_same<
-          typename MemorySpace::execution_space::memory_space,
-          Kokkos::HostSpace>::value;
+      using dual_view_type =
+        typename global_object_type::dual_view_type;
 
     public:
-      // This alias is for the MultiVector specialization of
+      // This alias is for the Tpetra::MultiVector specialization of
       // GetNonowningLocalObject.  withLocalAccess itself does not
       // need this to be public.
       //
       // Owning View type is always a View of nonconst.  If you own
       // the data, you need to be able to modify them.
       using master_local_view_type = typename std::conditional<
-        is_host,
+        is_host_space<execution_space>::value,
         typename dual_view_type::t_host,
         typename dual_view_type::t_dev>::type;
 
-      static_assert
-      (static_cast<int> (master_local_view_type::Rank) == 2,
-       "Rank of master_local_view_type must be 2.  "
-       "Please report this bug to the Tpetra developers.");
+      static_assert(
+        static_cast<int>(master_local_view_type::Rank) == 2,
+        "Rank of master_local_view_type must be 2.  "
+        "Please report this bug to the Tpetra developers.");
 
-      // This alias is required by withLocalAccess.
-      using master_local_object_type =
-        std::unique_ptr<master_local_view_type>;
-
-      // This method is required by withLocalAccess.
-      static master_local_object_type
-      get (local_access_type LA)
+    private:
+      static master_local_view_type
+      getOwningPreActions(local_access_type& LA)
       {
-        if (LA.isValid ()) {
+        if (! LA.isValid()) { // return "null" Kokkos::View
+          return master_local_view_type();
+        }
+        else {
+          using access_mode = typename local_access_type::access_mode;
           constexpr bool is_write_only =
-            std::is_same<AccessMode, Access<EAccess::WriteOnly> >::value;
+            std::is_same<access_mode, write_only>::value;
           if (is_write_only) {
-            LA.G_.clear_sync_state ();
+            LA.G_.clear_sync_state();
           }
 
-          // mfh 06 Jun 2019: It could be that
-          // Kokkos::DefaultHostExecutionSpace != the Vector's
-          // execution_space.  For example, the first could be
-          // Kokkos::OpenMP, but the second could be Kokkos::Serial.
-          // That's why we go through the trouble below.
+          // Given that Tpetra::(Multi)Vector currently uses
+          // Kokkos::DualView, here is how get() must behave:
           //
-          // It's easier to use an execution space than a memory
-          // space.  Otherwise, DualView of CudaUVMSpace complains
-          // that HostSpace is not one of its two memory spaces.
-          // (Both the device and the host Views of a DualView of
-          // CudaUVMSpace have memory_space = CudaUVMSpace.)
-          using space = typename std::conditional<is_host,
-            typename dual_view_type::t_host::execution_space,
-            typename dual_view_type::t_dev::execution_space>::type;
+          // - LA's memory space tells us which allocation to view.
+          //
+          // - LA's execution space tells us whether we need to fence.
+          //
+          //   - If LA's execution space equals the MultiVector's
+          //     execution space, then there is no need to fence, no
+          //     matter what the requested memory space is.
+          //
+          //   - Else, if LA's execution space is a host space, but
+          //     the MultiVector needs sync to host, then we must
+          //     fence the MultiVector's (device) execution space, to
+          //     ensure that device kernels aren't concurrently
+          //     modifying the MultiVector's local data.
+          //     Tpetra::MultiVector::fence (should) do that for us,
+          //     via Kokkos::DualView::fence.
 
-          if (LA.G_.template need_sync<space> ()) {
-            LA.G_.template sync<space> ();
+          // It's easier to use an execution space than a memory space
+          // in sync<Space>.  Otherwise, DualView of CudaUVMSpace
+          // complains that HostSpace is not one of its two memory
+          // spaces.  (Both the device and the host Views of a
+          // DualView of CudaUVMSpace have memory_space =
+          // CudaUVMSpace.)  Furthermore, this handles the case where
+          // Kokkos::DefaultHostExecutionSpace != the MultiVector's
+          // execution space, but the latter is still a host space
+          // (e.g., Kokkos::OpenMP vs. Kokkos::Serial).
+
+          if (LA.G_.template need_sync<execution_space>()) {
+            LA.G_.template sync<execution_space>();
           }
-          // Intel 17.0.1 requires the static_cast.  Otherwise, you'll
-          // get build errors of the form "error: a built-in binary
-          // operator applied to a scoped enumeration requires two
-          // operands of the same type."
+
           constexpr bool is_read_only =
-            std::is_same<AccessMode, Access<EAccess::ReadOnly> >::value;
+            std::is_same<access_mode, read_only>::value;
           if (! is_read_only) {
-            LA.G_.template modify<space> ();
+            LA.G_.template modify<execution_space>();
           }
 
           // See note about "copy back" above.
-          auto G_lcl_2d = LA.G_.template getLocalView<space> ();
+          auto G_lcl_2d =
+            LA.G_.template getLocalView<execution_space>();
           // This converts the View to const if applicable.
-          // Once we can use C++14, switch to std::make_unique.
-          return std::unique_ptr<master_local_view_type>
-            (new master_local_view_type (G_lcl_2d));
+          return master_local_view_type(G_lcl_2d);
         }
-        else { // invalid; return "null" Kokkos::View
-          return std::unique_ptr<master_local_view_type>
-            (new master_local_view_type ());
-        }
+      }
+
+    public:
+      // This alias is required by withLocalAccess.
+      // using master_local_object_type = std::unique_ptr<
+      //   master_local_view_type,
+      //   typename impl_type::deleter_type<master_local_view_type>>;
+      using master_local_object_type = std::unique_ptr<
+        master_local_view_type>;
+
+      // This method is required by withLocalAccess.
+      static master_local_object_type
+      get(local_access_type LA)
+      {
+        auto G_lcl_2d = getOwningPreActions(LA);
+        // Once we can use C++14, switch to std::make_unique.
+        // return master_local_object_type(
+        //   new master_local_view_type(G_lcl_2d),
+        //   impl_type::getOwningPostActions(LA, G_lcl_2d));
+        return master_local_object_type(
+          new master_local_view_type(G_lcl_2d));
       }
     };
 
+    static_assert(
+      Kokkos::is_view<
+        GetMasterLocalObject<
+          LocalAccess<Tpetra::MultiVector<>, read_only>
+        >::master_local_view_type
+      >::value, "Missing GetMasterLocalObject specialization");
+
+    static_assert(
+      Kokkos::is_view<
+        GetMasterLocalObject<
+          LocalAccess<Tpetra::MultiVector<>, Kokkos::HostSpace, read_only>
+        >::master_local_view_type
+      >::value, "Missing GetMasterLocalObject specialization");
+
+    //////////////////////////////////////////////////////////////////
+
     //! Specialization of GetMasterLocalObject for Tpetra::Vector.
-    template<class SC, class LO, class GO, class NT,
-             class MemorySpace,
-             class AccessMode>
+    template<class SC, class LO, class GO, class NT, class ... Args>
     struct GetMasterLocalObject<
-      LocalAccess<
-        Tpetra::Vector<SC, LO, GO, NT>, MemorySpace, AccessMode> >
+      LocalAccess<Tpetra::Vector<SC, LO, GO, NT>, Args...>
+      >
     {
     private:
       using global_object_type = Tpetra::Vector<SC, LO, GO, NT>;
-      using parent_global_object_type =
-        Tpetra::MultiVector<SC, LO, GO, NT>;
-      using parent_local_access_type =
-        LocalAccess<parent_global_object_type, MemorySpace, AccessMode>;
-      using mv_gmlo = GetMasterLocalObject<parent_local_access_type>;
-      using parent_master_local_view_type =
-        typename mv_gmlo::master_local_view_type;
-      using dual_view_type =
-        typename parent_global_object_type::dual_view_type;
-      static constexpr bool is_host = std::is_same<
-        typename MemorySpace::execution_space::memory_space,
-        Kokkos::HostSpace>::value;
 
     public:
       using local_access_type =
-        LocalAccess<global_object_type, MemorySpace, AccessMode>;
+        LocalAccess<global_object_type, Args...>;
+
+    private:
+      using execution_space =
+        typename local_access_type::execution_space;
+      static_assert(
+        Kokkos::Impl::is_execution_space<execution_space>::value,
+        "LocalAccess<Args...>::execution_space is not a valid "
+        "Kokkos execution space.");
+
+      using memory_space = typename local_access_type::memory_space;
+      static_assert(
+        Kokkos::Impl::is_memory_space<memory_space>::value,
+        "LocalAccess<Args...>::memory_space is not a valid "
+        "Kokkos memory space.");
+
+      using access_mode = typename local_access_type::access_mode;
+      static_assert(
+        is_access_mode<access_mode>::value,
+        "LocalAccess<Args...>::access_mode is not an Access "
+        "type.");
+
+      // FIXME (mfh 22 Oct 2018, 25 Apr 2019) Need to make sure that
+      // the execution space matches.  If not, we would need to
+      // allocate a new View, and then we should actually make the
+      // std::unique_ptr's destructor "copy back."  This is why
+      // master_local_object_type (see below) is a
+      // std::unique_ptr<Kokkos::View<...>>, not just a
+      // Kokkos::View<...>.
+      //
+      // mfh 01 May 2019: For now, we avoid allocation and copy back,
+      // by using only the Views available in the MV's DualView.
+      using dual_view_type =
+        typename global_object_type::dual_view_type;
+
+      // Owning View type is always a View of nonconst.  If you own
+      // the data, you need to be able to modify them.
+      using master_local_view_2d_type = typename std::conditional<
+        is_host_space<execution_space>::value,
+        typename dual_view_type::t_host,
+        typename dual_view_type::t_dev>::type;
 
     public:
-      // This alias is for the Vector specialization of
+      // This alias is for the Tpetra::Vector specialization of
       // GetNonowningLocalObject.  withLocalAccess itself does not
       // need this to be public.
-      using master_local_view_type = decltype (Kokkos::subview
-        (parent_master_local_view_type (), Kokkos::ALL (), 0));
+      using master_local_view_type = decltype(
+        Kokkos::subview(master_local_view_2d_type(),
+          Kokkos::ALL(), 0));
 
-      static_assert
-      (static_cast<int> (master_local_view_type::Rank) == 1,
-       "Rank of master_local_view_type must be 1.  "
-       "Please report this bug to the Tpetra developers.");
+      static_assert(
+        static_cast<int>(master_local_view_type::Rank) == 1,
+        "Rank of master_local_view_type must be 1.  "
+        "Please report this bug to the Tpetra developers.");
 
-      // This alias is required by withLocalAccess.
-      using master_local_object_type =
-        std::unique_ptr<master_local_view_type>;
-
-      // This method is required by withLocalAccess.
-      static master_local_object_type
-      get (local_access_type LA)
+    private:
+      static master_local_view_2d_type
+      getOwningPreActions(local_access_type& LA)
       {
-        if (LA.isValid ()) {
+        if (! LA.isValid()) { // return "null" Kokkos::View
+          return master_local_view_2d_type();
+        }
+        else {
+          using access_mode = typename local_access_type::access_mode;
           constexpr bool is_write_only =
-            std::is_same<AccessMode, Access<EAccess::WriteOnly> >::value;
+            std::is_same<access_mode, write_only>::value;
           if (is_write_only) {
-            LA.G_.clear_sync_state ();
+            LA.G_.clear_sync_state();
           }
 
-          // mfh 06 Jun 2019: It could be that
-          // Kokkos::DefaultHostExecutionSpace != the Vector's
-          // execution_space.  For example, the first could be
-          // Kokkos::OpenMP, but the second could be Kokkos::Serial.
-          // That's why we go through the trouble below.
-          //
-          // It's easier to use an execution space than a memory
-          // space.  Otherwise, DualView of CudaUVMSpace complains
-          // that HostSpace is not one of its two memory spaces.
-          // (Both the device and the host Views of a DualView of
-          // CudaUVMSpace have memory_space = CudaUVMSpace.)
-          using space = typename std::conditional<is_host,
-            typename dual_view_type::t_host::execution_space,
-            typename dual_view_type::t_dev::execution_space>::type;
-
-          if (LA.G_.template need_sync<space> ()) {
-            LA.G_.template sync<space> ();
+          if (LA.G_.template need_sync<execution_space>()) {
+            LA.G_.template sync<execution_space>();
           }
+
           constexpr bool is_read_only =
-            std::is_same<AccessMode, Access<EAccess::ReadOnly> >::value;
+            std::is_same<access_mode, read_only>::value;
           if (! is_read_only) {
-            LA.G_.template modify<space> ();
+            LA.G_.template modify<execution_space>();
           }
 
           // See note about "copy back" above.
-          auto G_lcl_2d = LA.G_.template getLocalView<space> ();
-          auto G_lcl_1d = Kokkos::subview (G_lcl_2d, Kokkos::ALL (), 0);
+          auto G_lcl_2d =
+            LA.G_.template getLocalView<execution_space>();
           // This converts the View to const if applicable.
-          // Once we can use C++14, switch to std::make_unique.
-          return std::unique_ptr<master_local_view_type>
-            (new master_local_view_type (G_lcl_1d));
-        }
-        else { // invalid; return "null" Kokkos::View
-          return std::unique_ptr<master_local_view_type>
-            (new master_local_view_type ());
+          return master_local_view_2d_type(G_lcl_2d);
         }
       }
+
+    public:
+      // This alias is required by withLocalAccess.
+      // using master_local_object_type = std::unique_ptr<
+      //   master_local_view_type,
+      //   typename impl_type::deleter_type<master_local_view_type>>;
+      using master_local_object_type = std::unique_ptr<
+        master_local_view_type>;
+
+      // This method is required by withLocalAccess.
+      static master_local_object_type
+      get(local_access_type LA)
+      {
+        master_local_view_2d_type G_lcl_2d = getOwningPreActions(LA);
+        master_local_view_type G_lcl_1d =
+          Kokkos::subview(G_lcl_2d, Kokkos::ALL(), 0);
+        // Once we can use C++14, switch to std::make_unique.
+        // return master_local_object_type(
+        //   new master_local_view_type(G_lcl_1d),
+        //   impl_type::getOwningPostActions(LA, G_lcl_2d));
+
+        return master_local_object_type(
+          new master_local_view_type(G_lcl_1d));
+      }
     };
+
+    static_assert(
+      Kokkos::is_view<
+        GetMasterLocalObject<
+          LocalAccess<Tpetra::Vector<>, read_only>
+        >::master_local_view_type
+      >::value, "Missing GetMasterLocalObject specialization");
+
+    static_assert(
+      Kokkos::is_view<
+        GetMasterLocalObject<
+          LocalAccess<Tpetra::Vector<>, Kokkos::HostSpace, read_only>
+        >::master_local_view_type
+      >::value, "Missing GetMasterLocalObject specialization");
+
+
+    //////////////////////////////////////////////////////////////////
 
     /// \brief Specialization of GetNonowningLocalObject for
     ///   Tpetra::MultiVector.
-    template<class SC, class LO, class GO, class NT,
-             class MemorySpace,
-             class AccessMode>
+    template<class SC, class LO, class GO, class NT, class ... Args>
     struct GetNonowningLocalObject<
-      LocalAccess<
-        Tpetra::MultiVector<SC, LO, GO, NT>, MemorySpace, AccessMode> >
+      LocalAccess<Tpetra::MultiVector<SC, LO, GO, NT>, Args...>
+      >
     {
+    private:
+      using global_object_type = Tpetra::MultiVector<SC, LO, GO, NT>;
     public:
-      using local_access_type = LocalAccess<
-        Tpetra::MultiVector<SC, LO, GO, NT>, MemorySpace, AccessMode>;
+      using local_access_type =
+        LocalAccess<global_object_type, Args...>;
 
     private:
-      using input_view_type =
-        typename GetMasterLocalObject<local_access_type>::master_local_view_type;
-      // input_view_type::non_const_data_type is
+      using access_mode = typename local_access_type::access_mode;
+      static_assert(is_access_mode<access_mode>::value,
+        "Please report this bug to the Tpetra developers.");
+
+      using master_local_view_type =
+        typename GetMasterLocalObject<local_access_type>::
+          master_local_view_type;
+      static_assert(
+        static_cast<int>(master_local_view_type::Rank) == 2,
+        "Rank of master_local_view_type must be 2.");
+
+      // master_local_view_type::non_const_data_type is
       // MV::impl_scalar_type**, where
       // MV = Tpetra::MultiVector<SC, LO, GO, NT>.
-      //
-      // Intel 17.0.1 requires the static_cast.  Otherwise, you'll get
-      // build errors of the form "error: a built-in binary operator
-      // applied to a scoped enumeration requires two operands of the
-      // same type."
       using output_data_type = typename std::conditional<
-        std::is_same<AccessMode, Access<EAccess::ReadOnly> >::value,
-        typename input_view_type::const_data_type,
-        typename input_view_type::non_const_data_type>::type;
-      using output_view_type =
-        Kokkos::View<output_data_type,
-                     typename input_view_type::array_layout,
-                     typename input_view_type::device_type,
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
+        std::is_same<access_mode, read_only>::value,
+        typename master_local_view_type::const_data_type,
+        typename master_local_view_type::non_const_data_type>::type;
+
     public:
       using master_local_object_type =
-        typename GetMasterLocalObject<local_access_type>::master_local_object_type;
-      using nonowning_local_object_type = output_view_type;
+        typename GetMasterLocalObject<local_access_type>::
+          master_local_object_type;
+      using nonowning_local_object_type =
+        Kokkos::View<output_data_type,
+                     typename master_local_view_type::array_layout,
+                     typename master_local_view_type::device_type,
+                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
 
       static nonowning_local_object_type
-      get (local_access_type /* LA */,
-           const master_local_object_type& M)
+      get(local_access_type /* LA */,
+          const master_local_object_type& M)
       {
-        input_view_type* viewPtr = M.get ();
+        master_local_view_type* viewPtr = M.get();
         return viewPtr == nullptr ?
-          nonowning_local_object_type () :
-          nonowning_local_object_type (*viewPtr);
+          nonowning_local_object_type() :
+          nonowning_local_object_type(*viewPtr);
       }
     };
+
+    //////////////////////////////////////////////////////////////////
 
     /// \brief Specialization of GetNonowningLocalObject for
     ///   Tpetra::Vector.
-    template<class SC, class LO, class GO, class NT,
-             class MemorySpace,
-             class AccessMode>
+    template<class SC, class LO, class GO, class NT, class ... Args>
     struct GetNonowningLocalObject<
-      LocalAccess<
-        ::Tpetra::Vector<SC, LO, GO, NT>, MemorySpace, AccessMode> >
+      LocalAccess<Tpetra::Vector<SC, LO, GO, NT>, Args...>
+      >
     {
+    private:
+      using global_object_type = Tpetra::Vector<SC, LO, GO, NT>;
     public:
-      using local_access_type = LocalAccess<
-        Tpetra::Vector<SC, LO, GO, NT>, MemorySpace, AccessMode>;
+      using local_access_type =
+        LocalAccess<global_object_type, Args...>;
 
     private:
-      using input_view_type =
-        typename GetMasterLocalObject<local_access_type>::master_local_view_type;
+      using access_mode = typename local_access_type::access_mode;
+      static_assert(is_access_mode<access_mode>::value,
+        "Please report this bug to the Tpetra developers.");
+
+      using master_local_view_type =
+        typename GetMasterLocalObject<local_access_type>::
+          master_local_view_type;
+      static_assert(
+        static_cast<int>(master_local_view_type::Rank) == 1,
+        "Rank of master_local_view_type must be 1.");
+
       // input_view_type::non_const_data_type is V::impl_scalar_type*,
       // where V = Tpetra::Vector<SC, LO, GO, NT>.
-      //
-      // Intel 17.0.1 requires the static_cast.  Otherwise, you'll get
-      // build errors of the form "error: a built-in binary operator
-      // applied to a scoped enumeration requires two operands of the
-      // same type."
       using output_data_type = typename std::conditional<
-        std::is_same<AccessMode, Access<EAccess::ReadOnly> >::value,
-        typename input_view_type::const_data_type,
-        typename input_view_type::non_const_data_type>::type;
-      using output_view_type =
-        Kokkos::View<output_data_type,
-                     typename input_view_type::array_layout,
-                     typename input_view_type::device_type,
-                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
+        std::is_same<access_mode, read_only>::value,
+        typename master_local_view_type::const_data_type,
+        typename master_local_view_type::non_const_data_type>::type;
+
     public:
       using master_local_object_type =
-        typename GetMasterLocalObject<local_access_type>::master_local_object_type;
-      using nonowning_local_object_type = output_view_type;
+        typename GetMasterLocalObject<local_access_type>::
+          master_local_object_type;
+      using nonowning_local_object_type =
+        Kokkos::View<output_data_type,
+                     typename master_local_view_type::array_layout,
+                     typename master_local_view_type::device_type,
+                     Kokkos::MemoryTraits<Kokkos::Unmanaged> >;
 
       static nonowning_local_object_type
       get (local_access_type /* LA */,
            const master_local_object_type& M)
       {
-        input_view_type* viewPtr = M.get ();
+        master_local_view_type* viewPtr = M.get();
         return viewPtr == nullptr ?
-          nonowning_local_object_type () :
-          nonowning_local_object_type (*viewPtr);
+          nonowning_local_object_type() :
+          nonowning_local_object_type(*viewPtr);
       }
     };
+
   } // namespace Details
 } // namespace Tpetra
 
 #endif // TPETRA_WITHLOCALACCESS_MULTIVECTOR_HPP
-

--- a/packages/tpetra/core/test/MultiVector/WithLocalAccess.cpp
+++ b/packages/tpetra/core/test/MultiVector/WithLocalAccess.cpp
@@ -35,8 +35,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
-//
 // ************************************************************************
 // @HEADER
 */
@@ -80,6 +78,16 @@ namespace { // (anonymous)
     using Tpetra::readOnly;
     using Tpetra::readWrite;
     using Tpetra::writeOnly;
+
+    using Tpetra::Details::GetMasterLocalObject;
+    using Tpetra::Details::GetNonowningLocalObject;
+    using Tpetra::Details::LocalAccess;
+    using Tpetra::Details::Access;
+    using Tpetra::Details::EAccess;
+    using Teuchos::TypeNameTraits;
+    using dev_mem_space =
+      typename multivec_type::dual_view_type::t_dev::memory_space;
+
     const bool debug = ::Tpetra::Details::Behavior::debug ();
 
     RCP<Teuchos::FancyOStream> outPtr = debug ?
@@ -105,17 +113,9 @@ namespace { // (anonymous)
         "exist and have the right public aliases" << endl;
       Teuchos::OSTab tab1 (myOut);
 
-      using Tpetra::Details::GetMasterLocalObject;
-      using Tpetra::Details::GetNonowningLocalObject;
-      using Tpetra::Details::LocalAccess;
-      using Tpetra::Details::AccessMode;
-      using Teuchos::TypeNameTraits;
-      using dev_mem_space =
-        typename multivec_type::dual_view_type::t_dev::memory_space;
-
       {
         using local_access_type =
-          LocalAccess<multivec_type, dev_mem_space, AccessMode::ReadOnly>;
+          LocalAccess<multivec_type, dev_mem_space, Access<EAccess::ReadOnly> >;
         using mv_mlo = GetMasterLocalObject<local_access_type>::
           master_local_object_type;
         static_assert (Kokkos::is_view<mv_mlo::element_type>::value,
@@ -290,10 +290,8 @@ namespace { // (anonymous)
       auto lclAccess = writeOnly (vec).on (memory_space ());
 
       using local_access_type = decltype (lclAccess);
-      static_assert
-        (local_access_type::access_mode ==
-         Tpetra::Details::AccessMode::WriteOnly,
-         "Incorrect AccessMode");
+      static_assert(std::is_same<local_access_type::access_mode,
+        Access<EAccess::WriteOnly> >::value, "Incorrect AccessMode");
       static_assert
         (std::is_same<local_access_type::global_object_type, vec_type>::value,
          "Incorrect global_object_type");

--- a/packages/tpetra/core/test/MultiVector/WithLocalAccess.cpp
+++ b/packages/tpetra/core/test/MultiVector/WithLocalAccess.cpp
@@ -82,8 +82,6 @@ namespace { // (anonymous)
     using Tpetra::Details::GetMasterLocalObject;
     using Tpetra::Details::GetNonowningLocalObject;
     using Tpetra::Details::LocalAccess;
-    using Tpetra::Details::Access;
-    using Tpetra::Details::EAccess;
     using Teuchos::TypeNameTraits;
     using dev_mem_space =
       typename multivec_type::dual_view_type::t_dev::memory_space;
@@ -115,7 +113,9 @@ namespace { // (anonymous)
 
       {
         using local_access_type =
-          LocalAccess<multivec_type, dev_mem_space, Access<EAccess::ReadOnly> >;
+          LocalAccess<multivec_type, dev_mem_space,
+                      Tpetra::Details::read_only>;
+
         using mv_mlo = GetMasterLocalObject<local_access_type>::
           master_local_object_type;
         static_assert (Kokkos::is_view<mv_mlo::element_type>::value,
@@ -291,7 +291,7 @@ namespace { // (anonymous)
 
       using local_access_type = decltype (lclAccess);
       static_assert(std::is_same<local_access_type::access_mode,
-        Access<EAccess::WriteOnly> >::value, "Incorrect AccessMode");
+        Tpetra::Details::write_only>::value, "Incorrect AccessMode");
       static_assert
         (std::is_same<local_access_type::global_object_type, vec_type>::value,
          "Incorrect global_object_type");

--- a/packages/tpetra/core/test/Utils/withLocalAccess_generic.cpp
+++ b/packages/tpetra/core/test/Utils/withLocalAccess_generic.cpp
@@ -35,8 +35,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
-//
 // ************************************************************************
 // @HEADER
 */
@@ -92,11 +90,11 @@ namespace Details {
 
 template<class MemorySpace>
 struct GetMasterLocalObject<
-  LocalAccess<StubGlobalObject, MemorySpace, AccessMode::ReadOnly> >
+  LocalAccess<StubGlobalObject, MemorySpace, Access<EAccess::ReadOnly>> >
 {
 private:
   using local_access_type =
-    LocalAccess<StubGlobalObject, MemorySpace, AccessMode::ReadOnly>;
+    LocalAccess<StubGlobalObject, MemorySpace, Access<EAccess::ReadOnly>>;
 
 public:
   // In practice, prefer things that behave like std::unique_ptr,
@@ -113,11 +111,11 @@ public:
 
 template<class MemorySpace>
 struct GetNonowningLocalObject<
-  LocalAccess<StubGlobalObject, MemorySpace, AccessMode::ReadOnly> >
+  LocalAccess<StubGlobalObject, MemorySpace, Access<EAccess::ReadOnly>> >
 {
 private:
   using local_access_type =
-    LocalAccess<StubGlobalObject, MemorySpace, AccessMode::ReadOnly>;
+    LocalAccess<StubGlobalObject, MemorySpace, Access<EAccess::ReadOnly>>;
   using master_local_object_type =
     typename GetMasterLocalObject<local_access_type>::master_local_object_type;
 
@@ -135,11 +133,11 @@ public:
 // Example of the "copy-back" model.
 template<class MemorySpace>
 struct GetMasterLocalObject<
-  LocalAccess<StubGlobalObject, MemorySpace, AccessMode::WriteOnly> >
+  LocalAccess<StubGlobalObject, MemorySpace, Access<EAccess::WriteOnly>> >
 {
 private:
   using local_access_type =
-    LocalAccess<StubGlobalObject, MemorySpace, AccessMode::WriteOnly>;
+    LocalAccess<StubGlobalObject, MemorySpace, Access<EAccess::WriteOnly>>;
 
   struct Deleter {
     // Capturing the std::shared_ptr means that we increment the
@@ -175,13 +173,16 @@ public:
 
 template<class MemorySpace>
 struct GetNonowningLocalObject<
-  LocalAccess<StubGlobalObject, MemorySpace, AccessMode::WriteOnly> >
+  LocalAccess<StubGlobalObject, MemorySpace,
+    Access<EAccess::WriteOnly> > >
 {
 private:
   using local_access_type =
-    LocalAccess<StubGlobalObject, MemorySpace, AccessMode::WriteOnly>;
+    LocalAccess<StubGlobalObject, MemorySpace,
+      Access<EAccess::WriteOnly> >;
   using master_local_object_type =
-    typename GetMasterLocalObject<local_access_type>::master_local_object_type;
+    typename GetMasterLocalObject<local_access_type>::
+      master_local_object_type;
 
 public:
   using nonowning_local_object_type = int*;
@@ -196,11 +197,13 @@ public:
 
 template<class MemorySpace>
 struct GetMasterLocalObject<
-  LocalAccess<StubGlobalObject, MemorySpace, AccessMode::ReadWrite> >
+  LocalAccess<StubGlobalObject, MemorySpace,
+    Access<EAccess::ReadWrite> > >
 {
 private:
   using local_access_type =
-    LocalAccess<StubGlobalObject, MemorySpace, AccessMode::ReadWrite>;
+    LocalAccess<StubGlobalObject, MemorySpace,
+      Access<EAccess::ReadWrite> >;
 
 public:
   // In practice, prefer things that behave like std::unique_ptr,
@@ -216,11 +219,12 @@ public:
 
 template<class MemorySpace>
 struct GetNonowningLocalObject<
-  LocalAccess<StubGlobalObject, MemorySpace, AccessMode::ReadWrite> >
+  LocalAccess<StubGlobalObject, MemorySpace,
+    Access<EAccess::ReadWrite> > >
 {
 private:
   using local_access_type =
-    LocalAccess<StubGlobalObject, MemorySpace, AccessMode::ReadWrite>;
+    LocalAccess<StubGlobalObject, MemorySpace, Access<EAccess::ReadWrite> >;
   using master_local_object_type =
     typename GetMasterLocalObject<local_access_type>::master_local_object_type;
 

--- a/packages/tpetra/core/test/Utils/withLocalAccess_generic.cpp
+++ b/packages/tpetra/core/test/Utils/withLocalAccess_generic.cpp
@@ -59,12 +59,12 @@ private:
 public:
   using device_type = Kokkos::Device<execution_space, memory_space>;
 
-  StubGlobalObject () = delete;
-  StubGlobalObject (const int input) :
-    localData_ (std::make_shared<int> (input))
+  StubGlobalObject() = delete;
+  StubGlobalObject(const int input) :
+    localData_(std::make_shared<int> (input))
   {}
 
-  int value () const {
+  int value() const {
     return *localData_;
   }
 
@@ -77,9 +77,9 @@ private:
   // your class must expose a public method for getting a pointer to
   // the data, try your best to make that a nonowning pointer.
   friend std::shared_ptr<int>
-  getStubGlobalObjectOwningLocalData (StubGlobalObject& g)
+  getStubGlobalObjectOwningLocalData(StubGlobalObject& G)
   {
-    return g.localData_;
+    return G.localData_;
   }
 };
 
@@ -88,69 +88,49 @@ private:
 namespace Tpetra {
 namespace Details {
 
-template<class MemorySpace>
-struct GetMasterLocalObject<
-  LocalAccess<StubGlobalObject, MemorySpace, Access<EAccess::ReadOnly>> >
-{
-private:
-  using local_access_type =
-    LocalAccess<StubGlobalObject, MemorySpace, Access<EAccess::ReadOnly>>;
+template<class AccessMode>
+struct StubGlobalObjectLocalObjectImpl {};
 
-public:
+template<>
+struct StubGlobalObjectLocalObjectImpl<Access<EAccess::ReadOnly> >
+{
   // In practice, prefer things that behave like std::unique_ptr,
   // since you don't actually need to share state.
   using master_local_object_type = std::shared_ptr<const int>;
 
   static master_local_object_type
-  get (local_access_type LA)
+  getOwning(StubGlobalObject& G)
   {
-    std::shared_ptr<int> p_nc = getStubGlobalObjectOwningLocalData (LA.G_);
-    return std::shared_ptr<const int> (p_nc);
+    std::shared_ptr<int> p_nc =
+      getStubGlobalObjectOwningLocalData(G);
+    return std::shared_ptr<const int>(p_nc);
   }
-};
 
-template<class MemorySpace>
-struct GetNonowningLocalObject<
-  LocalAccess<StubGlobalObject, MemorySpace, Access<EAccess::ReadOnly>> >
-{
-private:
-  using local_access_type =
-    LocalAccess<StubGlobalObject, MemorySpace, Access<EAccess::ReadOnly>>;
-  using master_local_object_type =
-    typename GetMasterLocalObject<local_access_type>::master_local_object_type;
-
-public:
   using nonowning_local_object_type = const int*;
-
   static nonowning_local_object_type
-  get (local_access_type /* LA */,
-       const master_local_object_type& p)
+  getNonowning(StubGlobalObject& /* G */,
+               const master_local_object_type& p)
   {
     return p.get ();
   }
 };
 
 // Example of the "copy-back" model.
-template<class MemorySpace>
-struct GetMasterLocalObject<
-  LocalAccess<StubGlobalObject, MemorySpace, Access<EAccess::WriteOnly>> >
+template<>
+struct StubGlobalObjectLocalObjectImpl<Access<EAccess::WriteOnly> >
 {
 private:
-  using local_access_type =
-    LocalAccess<StubGlobalObject, MemorySpace, Access<EAccess::WriteOnly>>;
-
   struct Deleter {
     // Capturing the std::shared_ptr means that we increment the
     // reference count, and thus keep it alive.
-    Deleter (int* raw, std::shared_ptr<int> sp) : raw_ (raw), sp_ (sp) {}
-
+    Deleter(int* raw, std::shared_ptr<int> sp) : raw_ (raw), sp_ (sp)
+    {}
     void operator() (int* p) {
       if (p != nullptr) {
         *sp_ = *raw_; // "copy back" happens here
         delete p;
       }
     }
-
     int* raw_ = nullptr;
     std::shared_ptr<int> sp_;
   };
@@ -159,88 +139,99 @@ public:
   using master_local_object_type = std::unique_ptr<int, Deleter>;
 
   static master_local_object_type
-  get (local_access_type LA)
+  getOwning(StubGlobalObject& G)
   {
-    std::shared_ptr<int> p_nc = getStubGlobalObjectOwningLocalData (LA.G_);
+    std::shared_ptr<int> p_nc = getStubGlobalObjectOwningLocalData(G);
     // Test write-only-ness, by deliberately ignoring any existing
     // value.  In practice, your class could do this in debug mode.
-    int* raw = new int (StubGlobalObject::flagValue);
-    Deleter deleter (raw, p_nc);
+    int* raw = new int(StubGlobalObject::flagValue);
+    Deleter deleter(raw, p_nc);
     return {raw, deleter};
   }
-};
 
-
-template<class MemorySpace>
-struct GetNonowningLocalObject<
-  LocalAccess<StubGlobalObject, MemorySpace,
-    Access<EAccess::WriteOnly> > >
-{
-private:
-  using local_access_type =
-    LocalAccess<StubGlobalObject, MemorySpace,
-      Access<EAccess::WriteOnly> >;
-  using master_local_object_type =
-    typename GetMasterLocalObject<local_access_type>::
-      master_local_object_type;
-
-public:
   using nonowning_local_object_type = int*;
 
   static nonowning_local_object_type
-  get (local_access_type /* LA */,
-       const master_local_object_type& p)
+  getNonowning(StubGlobalObject& /* G */,
+               const master_local_object_type& p)
   {
     return p.get ();
   }
 };
 
-template<class MemorySpace>
-struct GetMasterLocalObject<
-  LocalAccess<StubGlobalObject, MemorySpace,
-    Access<EAccess::ReadWrite> > >
+template<>
+struct StubGlobalObjectLocalObjectImpl<Access<EAccess::ReadWrite> >
 {
-private:
-  using local_access_type =
-    LocalAccess<StubGlobalObject, MemorySpace,
-      Access<EAccess::ReadWrite> >;
-
-public:
   // In practice, prefer things that behave like std::unique_ptr,
   // since you don't actually need to share state.
   using master_local_object_type = std::shared_ptr<int>;
 
   static master_local_object_type
-  get (local_access_type LA)
+  getOwning(StubGlobalObject& G)
   {
-    return getStubGlobalObjectOwningLocalData (LA.G_);
+    return getStubGlobalObjectOwningLocalData(G);
   }
-};
 
-template<class MemorySpace>
-struct GetNonowningLocalObject<
-  LocalAccess<StubGlobalObject, MemorySpace,
-    Access<EAccess::ReadWrite> > >
-{
-private:
-  using local_access_type =
-    LocalAccess<StubGlobalObject, MemorySpace, Access<EAccess::ReadWrite> >;
-  using master_local_object_type =
-    typename GetMasterLocalObject<local_access_type>::master_local_object_type;
-
-public:
   using nonowning_local_object_type = int*;
 
   static nonowning_local_object_type
-  get (local_access_type /* LA */,
-       const master_local_object_type& p)
+  getNonowning(StubGlobalObject& /* G */,
+               const master_local_object_type& p)
   {
     return p.get ();
   }
 };
 
+//////////////////////////////////////////////////////////////////////
+
+template<class ... Args>
+struct GetMasterLocalObject<LocalAccess<StubGlobalObject, Args...>>
+{
+private:
+  using local_access_type = LocalAccess<StubGlobalObject, Args...>;
+  using access_mode = typename local_access_type::access_mode;
+  using impl_type =
+    StubGlobalObjectLocalObjectImpl<access_mode>;
+
+public:
+  // In practice, prefer things that behave like std::unique_ptr,
+  // since you don't actually need to share state.
+  using master_local_object_type =
+    typename impl_type::master_local_object_type;
+
+  static master_local_object_type get(local_access_type LA) {
+    return impl_type::getOwning(LA.G_);
+  }
+};
+
+//////////////////////////////////////////////////////////////////////
+
+template<class ... Args>
+struct GetNonowningLocalObject<LocalAccess<StubGlobalObject, Args...>>
+{
+private:
+  using local_access_type = LocalAccess<StubGlobalObject, Args...>;
+  using access_mode = typename local_access_type::access_mode;
+  using impl_type = StubGlobalObjectLocalObjectImpl<access_mode>;
+
+public:
+  using master_local_object_type =
+    typename impl_type::master_local_object_type;
+  using nonowning_local_object_type =
+    typename impl_type::nonowning_local_object_type;
+
+  static nonowning_local_object_type
+  get(local_access_type LA,
+      const master_local_object_type& p)
+  {
+    return impl_type::getNonowning(LA.G_, p);
+  }
+};
+
 } // namespace Details
 } // namespace Tpetra
+
+//////////////////////////////////////////////////////////////////////
 
 namespace { // (anonymous)
 


### PR DESCRIPTION
@trilinos/tpetra 

## Motivation

Applications want to run with `CUDA_LAUNCH_BLOCKING` unset.  PR https://github.com/trilinos/Trilinos/pull/6617 showed that `Tpetra::withLocalAccess` could not distinguish between accessing on `CudaUVMSpace` at host, and accessing on `CudaUVMSpace` at device.  This commit should fix that.

## Related Issues

* Follows #6617 

## Stakeholder Feedback

SPARC already runs with `CUDA_LAUNCH_BLOCKING` unset.

## Testing

I haven't tested CUDA yet; I just want to share this with @MicheldeMessieres and @kddevin .  I've tested on a Mac laptop.