### PR TITLE
Belos: removed deprecated Belos::toString()

### DIFF
--- a/packages/belos/src/BelosTypes.hpp
+++ b/packages/belos/src/BelosTypes.hpp
@@ -207,14 +207,6 @@ namespace Belos {
                         RecycleSubspace = 0x2    /*!< Destroy any existing subspace inside the solver. */
   };
 
-  /// \brief The string name corresponding to the given StatusType enum value.
-  ///
-  /// This method is DEPRECATED because the generic-sounding name of
-  /// this function makes it easy to pass in the wrong enum type.  Use
-  /// \c convertStatusTypeToString() instead.
-  BELOS_DEPRECATED const char*
-  toString (const StatusType status);
-
   //! The string name corresponding to the given StatusType enum value.
   std::string
   convertStatusTypeToString (const StatusType status);


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/belos

## Motivation
Removing deprecated Belos::toString() because the original name was a bad choice.  It has been replaced by Belos::convertStatusTypeToString()
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to
* Part of #6655 
* Composed of 