### PR TITLE
Patch C++11 flag checks for GCC4

### DIFF
--- a/cmake/ProjectCompilerPostConfig.cmake
+++ b/cmake/ProjectCompilerPostConfig.cmake
@@ -1,7 +1,8 @@
 IF (${Trilinos_ENABLE_Kokkos})
 
   MESSAGE("-- " "Skip adding flags for C++11 because Kokkos flags does that ...")
-  SET(${PROJECT_NAME}_CXX11_FLAGS " ")
+  # Set this to empty to trick Tribits into passing the C++11 flag check
+  SET(${PROJECT_NAME}_CXX11_FLAGS)
   
   MESSAGE("-- " "Skip adding flags for OpenMP because Kokkos flags does that ...")
   SET(OpenMP_CXX_FLAGS_OVERRIDE " ")


### PR DESCRIPTION
@kokkos

## Motivation
Allows C++11 checks to pass for GCC4.9 and other compilers