### PR TITLE
This turns off the Anasazi_Epetra_OrthoManagerGenTester_0_MPI_4 test

### DIFF
--- a/cmake/std/PullRequestLinuxCommonTestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxCommonTestingSettings.cmake
@@ -60,6 +60,9 @@ set (Piro_EpetraSolver_MPI_4_DISABLE ON CACHE BOOL "Set by default for PR testin
 # Disable tests that timeout in PR testing until it can be fixed (#4614)
 set (PanzerAdaptersSTK_PoissonInterfaceExample_2d_diffsideids_MPI_1_DISABLE ON CACHE BOOL "Set by default for PR testing")
 
+# Disable long-failing Anazazi test until it can be fixed (#3585)
+set (Anasazi_Epetra_OrthoManagerGenTester_0_MPI_4_DISABLE ON CACHE BOOL "Set by default for PR testing")
+
 # Options from SEMSDevEnv.cmake
 
 SET(CMAKE_C_COMPILER "$ENV{MPICC}" CACHE FILEPATH "Set by default for PR testing")


### PR DESCRIPTION
The discussion on thie test was done in #3585 and
is properly labeled as having a disabled test.

@trilinos/framework 

## Motivation
This test fails intermittently and after significant discussion (see #3585) we are turning it off for all PR testing.


## Testing
I used the replication instructions in the wiki to set up (configure and generate) 3 of the PR builds (GCC 7.2, Intel 17, and GCC 4.8.4) and confirmed that in each one the test is not put into the relevant CTestTestfile.cmake.
