### PR TITLE
MueLu: adding thresholding of the interpolation values in GeometricInterpolationPFactory, see issue #6681

### DIFF
--- a/packages/muelu/src/Graph/StructuredAggregation/MueLu_AggregationStructuredAlgorithm_def.hpp
+++ b/packages/muelu/src/Graph/StructuredAggregation/MueLu_AggregationStructuredAlgorithm_def.hpp
@@ -256,7 +256,7 @@ namespace MueLu {
     myGraph->fillComplete(domainMap, rowMap);
     *out << "Prolongator CrsGraph computed" << std::endl;
 
-  } // BuildAggregates()
+  } // BuildGraph()
 
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>

--- a/packages/muelu/src/Transfers/GeneralGeometric/MueLu_GeometricInterpolationPFactory_decl.hpp
+++ b/packages/muelu/src/Transfers/GeneralGeometric/MueLu_GeometricInterpolationPFactory_decl.hpp
@@ -102,7 +102,8 @@ namespace MueLu{
     void BuildLinearP(RCP<Matrix>& A, RCP<const CrsGraph>& prolongatorGraph,
                       RCP<realvaluedmultivector_type>& fineCoordinates,
                       RCP<realvaluedmultivector_type>& ghostCoordinates,
-                      const int numDimensions, RCP<Matrix>& P) const;
+                      const int numDimensions, const bool keepD2,
+                      RCP<Matrix>& P) const;
     void ComputeLinearInterpolationStencil(const int numDimensions, const int numInterpolationPoints,
                                            const Array<Array<real_type> > coord,
                                            Array<real_type>& stencil) const;

--- a/packages/muelu/src/Transfers/GeneralGeometric/MueLu_GeometricInterpolationPFactory_def.hpp
+++ b/packages/muelu/src/Transfers/GeneralGeometric/MueLu_GeometricInterpolationPFactory_def.hpp
@@ -86,7 +86,8 @@ namespace MueLu {
                                                  "Number of spacial dimensions in the problem.");
     validParamList->set<RCP<const FactoryBase> >("lCoarseNodesPerDim",           Teuchos::null,
                                                  "Number of nodes per spatial dimension on the coarse grid.");
-    validParamList->set<bool>                   ("keep coarse coords", false, "Flag to keep coordinates for special coarse grid solve");
+    validParamList->set<bool>                   ("keep coarse coords",           false, "Flag to keep coordinates for special coarse grid solve");
+    validParamList->set<bool>                   ("interp: remove small entries", true, "Remove small interpolation coeficient from prolongator to reduce fill-in on coarse level");
 
     return validParamList;
   }
@@ -135,6 +136,7 @@ namespace MueLu {
 
     // Get inputs from the parameter list
     const ParameterList& pL = GetParameterList();
+    const bool removeSmallEntries     = pL.get<bool>("interp: remove small entries");
     const bool buildCoarseCoordinates = pL.get<bool>("interp: build coarse coordinates");
     const int interpolationOrder      = pL.get<int> ("interp: interpolation order");
     const int numDimensions           = Get<int>(fineLevel, "numDimensions");
@@ -207,7 +209,7 @@ namespace MueLu {
       ghostCoordinates->doImport(*coarseCoordinates, *ghostImporter, Xpetra::INSERT);
 
       SubFactoryMonitor sfm(*this, "BuildLinearP", coarseLevel);
-      BuildLinearP(A, prolongatorGraph, fineCoordinates, ghostCoordinates, numDimensions, P);
+      BuildLinearP(A, prolongatorGraph, fineCoordinates, ghostCoordinates, numDimensions, removeSmallEntries, P);
     }
 
     *out << "The prolongator matrix has been built." << std::endl;
@@ -274,7 +276,8 @@ namespace MueLu {
   BuildLinearP(RCP<Matrix>& A, RCP<const CrsGraph>& prolongatorGraph,
                RCP<realvaluedmultivector_type>& fineCoordinates,
                RCP<realvaluedmultivector_type>& ghostCoordinates,
-               const int numDimensions, RCP<Matrix>& P) const {
+               const int numDimensions, const bool removeSmallEntries,
+               RCP<Matrix>& P) const {
 
     // Set debug outputs based on environment variable
     RCP<Teuchos::FancyOStream> out;
@@ -323,55 +326,104 @@ namespace MueLu {
     RCP<CrsMatrix> PCrs = rcp_dynamic_cast<CrsMatrixWrap>(P)->getCrsMatrix();
     PCrs->resumeFill(); // The Epetra matrix is considered filled at this point.
 
-    LO interpolationNodeIdx = 0, rowIdx = 0;
-    ArrayView<const LO> colIndices;
-    Array<SC> values;
-    Array<Array<real_type> > coords(numInterpolationPoints + 1);
-    Array<real_type> stencil(numInterpolationPoints);
-    for(LO nodeIdx = 0; nodeIdx < numFineNodes; ++nodeIdx) {
-      if(PCrs->getNumEntriesInLocalRow(nodeIdx*dofsPerNode) == 1) {
-        values.resize(1);
-        values[0] = 1.0;
-        for(LO dof = 0; dof < dofsPerNode; ++dof) {
-          rowIdx = nodeIdx*dofsPerNode + dof;
-          prolongatorGraph->getLocalRowView(rowIdx, colIndices);
-          PCrs->replaceLocalValues(rowIdx, colIndices, values());
-        }
-      } else {
-        // Extract the coordinates associated with the current node
-        // and the neighboring coarse nodes
-        coords[0].resize(3);
-        for(int dim = 0; dim < 3; ++dim) {
-          coords[0][dim] = fineCoords[dim][nodeIdx];
-        }
-        prolongatorGraph->getLocalRowView(nodeIdx*dofsPerNode, colIndices);
-        for(int interpolationIdx=0; interpolationIdx < numInterpolationPoints; ++interpolationIdx) {
-          coords[interpolationIdx + 1].resize(3);
-          interpolationNodeIdx = colIndices[interpolationIdx] / dofsPerNode;
-          for(int dim = 0; dim < 3; ++dim) {
-            coords[interpolationIdx + 1][dim] = ghostCoords[dim][interpolationNodeIdx];
+    { // Construct the linear interpolation prolongator
+      LO interpolationNodeIdx = 0, rowIdx = 0;
+      ArrayView<const LO> colIndices;
+      Array<SC> values;
+      Array<Array<real_type> > coords(numInterpolationPoints + 1);
+      Array<real_type> stencil(numInterpolationPoints);
+      for(LO nodeIdx = 0; nodeIdx < numFineNodes; ++nodeIdx) {
+        if(PCrs->getNumEntriesInLocalRow(nodeIdx*dofsPerNode) == 1) {
+          values.resize(1);
+          values[0] = 1.0;
+          for(LO dof = 0; dof < dofsPerNode; ++dof) {
+            rowIdx = nodeIdx*dofsPerNode + dof;
+            prolongatorGraph->getLocalRowView(rowIdx, colIndices);
+            PCrs->replaceLocalValues(rowIdx, colIndices, values());
           }
-        }
-        ComputeLinearInterpolationStencil(numDimensions, numInterpolationPoints, coords, stencil);
-        values.resize(numInterpolationPoints);
-        for(LO valueIdx = 0; valueIdx < numInterpolationPoints; ++valueIdx) {
-          values[valueIdx] = Teuchos::as<SC>(stencil[valueIdx]);
-        }
+        } else {
+          // Extract the coordinates associated with the current node
+          // and the neighboring coarse nodes
+          coords[0].resize(3);
+          for(int dim = 0; dim < 3; ++dim) {
+            coords[0][dim] = fineCoords[dim][nodeIdx];
+          }
+          prolongatorGraph->getLocalRowView(nodeIdx*dofsPerNode, colIndices);
+          for(int interpolationIdx=0; interpolationIdx < numInterpolationPoints; ++interpolationIdx) {
+            coords[interpolationIdx + 1].resize(3);
+            interpolationNodeIdx = colIndices[interpolationIdx] / dofsPerNode;
+            for(int dim = 0; dim < 3; ++dim) {
+              coords[interpolationIdx + 1][dim] = ghostCoords[dim][interpolationNodeIdx];
+            }
+          }
+          ComputeLinearInterpolationStencil(numDimensions, numInterpolationPoints, coords, stencil);
+          values.resize(numInterpolationPoints);
+          for(LO valueIdx = 0; valueIdx < numInterpolationPoints; ++valueIdx) {
+            values[valueIdx] = Teuchos::as<SC>(stencil[valueIdx]);
+          }
 
-        // Set values in all the rows corresponding to nodeIdx
-        for(LO dof = 0; dof < dofsPerNode; ++dof) {
-          rowIdx = nodeIdx*dofsPerNode + dof;
-          prolongatorGraph->getLocalRowView(rowIdx, colIndices);
-          PCrs->replaceLocalValues(rowIdx, colIndices, values());
-        }
-      }
-    }
+          // Set values in all the rows corresponding to nodeIdx
+          for(LO dof = 0; dof < dofsPerNode; ++dof) {
+            rowIdx = nodeIdx*dofsPerNode + dof;
+            prolongatorGraph->getLocalRowView(rowIdx, colIndices);
+            PCrs->replaceLocalValues(rowIdx, colIndices, values());
+          }
+        } // Check for Coarse vs. Fine point
+      } // Loop over fine nodes
+    } // Construct the linear interpolation prolongator
 
     *out << "The calculation of the interpolation stencils has completed." << std::endl;
 
     PCrs->fillComplete();
 
-    *out << "All values in P have been set and expertStaticFillComplete has been performed." << std::endl;
+    *out << "All values in P have been set and fillComplete has been performed." << std::endl;
+
+    // Note lbv Jan 29 2019: this should be handle at aggregation level
+    // if the user really does not want potential d2 neighbors on coarse grid
+    // that way we would avoid a new graph construction...
+
+    // Check if we want to remove small entries from P
+    // to reduce stencil growth on next level.
+    if(removeSmallEntries) {
+      ArrayRCP<const size_t> rowptrOrig;
+      ArrayRCP<const LO>     colindOrig;
+      ArrayRCP<const Scalar> valuesOrig;
+      PCrs->getAllValues(rowptrOrig, colindOrig, valuesOrig);
+
+      const size_t numRows = static_cast<size_t>(rowptrOrig.size() - 1);
+      ArrayRCP<size_t> rowPtr(numRows + 1);
+      ArrayRCP<size_t> nnzOnRows(numRows);
+      rowPtr[0] = 0;
+      size_t countRemovedEntries = 0;
+      for(size_t rowIdx = 0; rowIdx < numRows; ++rowIdx) {
+        for(size_t entryIdx = rowptrOrig[rowIdx]; entryIdx < rowptrOrig[rowIdx + 1]; ++entryIdx) {
+          if(Teuchos::ScalarTraits<Scalar>::magnitude(valuesOrig[entryIdx]) < 1e-6) {++countRemovedEntries;}
+        }
+        rowPtr[rowIdx + 1] = rowptrOrig[rowIdx + 1] - countRemovedEntries;
+        nnzOnRows[rowIdx] = rowPtr[rowIdx + 1] - rowPtr[rowIdx];
+      }
+      GetOStream(Statistics1) << "interp: number of small entries removed= " << countRemovedEntries << " / " << rowptrOrig[numRows] << std::endl;
+
+      size_t countKeptEntries = 0;
+      ArrayRCP<LO> colInd(rowPtr[numRows]);
+      ArrayRCP<SC> values(rowPtr[numRows]);
+      for(size_t entryIdx = 0; entryIdx < rowptrOrig[numRows]; ++entryIdx) {
+        if(Teuchos::ScalarTraits<Scalar>::magnitude(valuesOrig[entryIdx]) > 1e-6) {
+          colInd[countKeptEntries] = colindOrig[entryIdx];
+          values[countKeptEntries] = valuesOrig[entryIdx];
+          ++countKeptEntries;
+        }
+      }
+
+      P = rcp(new CrsMatrixWrap(prolongatorGraph->getRowMap(),
+                                prolongatorGraph->getColMap(),
+                                nnzOnRows));
+      RCP<CrsMatrix> PCrsSqueezed = rcp_dynamic_cast<CrsMatrixWrap>(P)->getCrsMatrix();
+      PCrsSqueezed->resumeFill(); // The Epetra matrix is considered filled at this point.
+      PCrsSqueezed->setAllValues(rowPtr, colInd, values);
+      PCrsSqueezed->expertStaticFillComplete(prolongatorGraph->getDomainMap(),
+                                             prolongatorGraph->getRangeMap());
+    }
 
     // set StridingInformation of P
     if (A->IsView("stridedMaps") == true) {

--- a/packages/muelu/test/unit_tests/RegionVector.cpp
+++ b/packages/muelu/test/unit_tests/RegionVector.cpp
@@ -157,7 +157,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionVector, RegionCompositeVector, Scalar, L
     compVec->putScalar(0.0);
     const size_t localLength = compVec->getLocalLength();
     for (size_t k = 0; k < localLength; ++k) {
-      compVec->replaceLocalValue(k, static_cast<Scalar>(k) + static_cast<Scalar>(myRank)/10);
+      compVec->replaceLocalValue(k, static_cast<Scalar>(k) + static_cast<Scalar>(myRank/10));
     }
 
     // Create a region vector


### PR DESCRIPTION
@trilinos/muelu 

## Motivation
This is a first cut that performs reasonably well, the idea is to look at interpolation coefficient generated for each fine point.
If the coefficients are smaller than a given tolerance (1e-6), they are dropped.
This results in much sparser coarse grid as well as smaller P and R matrices.
If we want to keep this idea around we should rewritte the structured aggregation factory to obtain the correct graph directly instead of recomputing it in the prolongator factory.

## Related Issues

* Closes #6681 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 


## Stakeholder Feedback


## Testing
The new algorithm has been tested locally, all MueLu examples and tests are passing.
Also performed a larger simulation using 3D elasticity with 100x100x100 nodes mesh which resulted in good performance.