### PR TITLE
Tpetra::Crs{Graph,Matrix}: Add verbose debugging output for memory allocations 

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -1163,17 +1163,21 @@ namespace Tpetra {
        buffer_device_type>& permuteFromLIDs) override;
 
     void
-    applyCrsPadding (const Kokkos::UnorderedMap<local_ordinal_type, size_t, device_type>& padding);
+    applyCrsPadding(
+      const Kokkos::UnorderedMap<local_ordinal_type, size_t, device_type>& padding,
+      const bool verbose);
 
     Kokkos::UnorderedMap<local_ordinal_type, size_t, device_type>
     computeCrsPadding (const RowGraph<local_ordinal_type, global_ordinal_type, node_type>& source,
                        const size_t numSameIDs,
                        const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& permuteToLIDs,
-                       const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& permuteFromLIDs) const;
+                       const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& permuteFromLIDs,
+                       const bool verbose) const;
 
     Kokkos::UnorderedMap<local_ordinal_type, size_t, device_type>
     computeCrsPadding (const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& importLIDs,
-                       Kokkos::DualView<size_t*, buffer_device_type> numPacketsPerLID) const;
+                       Kokkos::DualView<size_t*, buffer_device_type> numPacketsPerLID,
+                       const bool verbose) const;
 
     void
     computeCrsPaddingForSameIDs (Kokkos::UnorderedMap<local_ordinal_type, size_t, device_type>& padding,
@@ -1480,6 +1484,9 @@ namespace Tpetra {
     };
 
   private:
+    std::unique_ptr<std::string>
+    createPrefix(const char methodName[]) const;
+
     // Friend declaration for nonmember function.
     template<class CrsGraphType>
     friend Teuchos::RCP<CrsGraphType>
@@ -1693,7 +1700,9 @@ namespace Tpetra {
     };
 
     bool indicesAreAllocated () const;
-    void allocateIndices (const ELocalGlobal lg);
+
+    void
+    allocateIndices(const ELocalGlobal lg, const bool verbose=false);
 
     //! \name Methods governing changes between global and local indices
     //@{

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -1723,6 +1723,10 @@ namespace Tpetra {
     /// \pre The graph has a column Map.
     /// \post The graph is locally indexed.
     ///
+    /// \param verbose [in] Whether to print verbose debugging output.
+    ///   This exists because CrsMatrix may want to control output
+    ///   independently of the CrsGraph that it owns.
+    ///
     /// \return Error code and error string.  See below.
     ///
     /// First return value is the number of column indices on this
@@ -1734,7 +1738,8 @@ namespace Tpetra {
     ///
     /// Second return value is a human-readable error string.  If the
     /// first return value is zero, then the string may be empty.
-    std::pair<size_t, std::string> makeIndicesLocal ();
+    std::pair<size_t, std::string>
+    makeIndicesLocal(const bool verbose=false);
 
     /// \brief Make the Import and Export objects, if needed.
     ///

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -66,6 +66,7 @@
 #include "Teuchos_ParameterListAcceptorDefaultBase.hpp"
 
 #include <functional> // std::function
+#include <memory>
 
 namespace Tpetra {
 

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -5090,6 +5090,18 @@ namespace Tpetra {
          << (indicesAreAllocated() ? "true" : "false") << endl;
       std::cerr << os.str ();
     }
+    const int myRank = ! verbose ? -1 : [&] () {
+      auto map = this->getMap();
+      if (map.is_null()) {
+        return -1;
+      }
+      auto comm = map->getComm();
+      if (comm.is_null()) {
+        return -1;
+      }
+      return comm->getRank();
+    } ();
+
     if (padding.size() == 0) {
       return;
     }
@@ -5151,7 +5163,8 @@ namespace Tpetra {
       indices_type indices("indices", this->k_gblInds1D_.extent(0));
       Kokkos::deep_copy(indices, this->k_gblInds1D_);
       using padding_type = Kokkos::UnorderedMap<LocalOrdinal, size_t, device_type>;
-      padCrsArrays<row_ptrs_type,indices_type,padding_type>(row_ptrs_beg, row_ptrs_end, indices, padding);
+      padCrsArrays<row_ptrs_type,indices_type,padding_type>(row_ptrs_beg,
+        row_ptrs_end, indices, padding, myRank, verbose);
       if (verbose) {
         std::ostringstream os;
         os << *prefix << "Reassign k_gblInds1D_; old size: "
@@ -5170,7 +5183,8 @@ namespace Tpetra {
       local_indices_type indices("indices", this->k_lclInds1D_.extent(0));
       Kokkos::deep_copy(indices, this->k_lclInds1D_);
       using padding_type = Kokkos::UnorderedMap<LocalOrdinal, size_t, device_type>;
-      padCrsArrays<row_ptrs_type,local_indices_type,padding_type>(row_ptrs_beg, row_ptrs_end, indices, padding);
+      padCrsArrays<row_ptrs_type,local_indices_type,padding_type>(row_ptrs_beg,
+        row_ptrs_end, indices, padding, myRank, verbose);
       if (verbose) {
         std::ostringstream os;
         os << *prefix << "Reassign k_lclInds1D_; old size: "

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -1212,11 +1212,13 @@ namespace Tpetra {
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   void
   CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
-  allocateIndices (const ELocalGlobal lg)
+  allocateIndices (const ELocalGlobal lg, const bool verbose)
   {
+    using ::Tpetra::Details::ProfilingRegion;
     using Teuchos::arcp;
     using Teuchos::Array;
     using Teuchos::ArrayRCP;
+    using std::endl;
     typedef Teuchos::ArrayRCP<size_t>::size_type size_type;
     typedef typename local_graph_type::row_map_type::non_const_type
       non_const_row_map_type;
@@ -1227,6 +1229,17 @@ namespace Tpetra {
       device_type> gbl_col_inds_type;
     const char tfecfFuncName[] = "allocateIndices: ";
     const char suffix[] = "  Please report this bug to the Tpetra developers.";
+    ProfilingRegion profRegion("Tpetra::CrsGraph::allocateIndices");
+
+    std::unique_ptr<std::string> prefix;
+    if (verbose) {
+      prefix = createPrefix("allocateIndices");
+      std::ostringstream os;
+      os << *prefix << "{lg="
+         << (lg == GlobalIndices ? "GlobalIndices" : "LocalIndices")
+         << ", numRows: " << this->getNodeNumRows() << "}" << endl;
+      std::cerr << os.str();
+    }
 
     // This is a protected function, only callable by us.  If it was
     // called incorrectly, it is our fault.  That's why the tests
@@ -1248,6 +1261,11 @@ namespace Tpetra {
     //
     //  STATIC ALLOCATION PROFILE
     //
+    if (verbose) {
+      std::ostringstream os;
+      os << *prefix << "Allocate k_rowPtrs: " << (numRows+1) << endl;
+      std::cerr << os.str();
+    }
     non_const_row_map_type k_rowPtrs ("Tpetra::CrsGraph::ptr", numRows + 1);
 
     if (this->k_numAllocPerRow_.extent (0) != 0) {
@@ -1294,9 +1312,21 @@ namespace Tpetra {
     const size_type numInds = ::Tpetra::Details::getEntryOnHost (this->k_rowPtrs_, numRows);
     // const size_type numInds = static_cast<size_type> (this->k_rowPtrs_(numRows));
     if (lg == LocalIndices) {
+      if (verbose) {
+        std::ostringstream os;
+        os << *prefix << "Allocate local column indices "
+          "k_lclInds1D_: " << numInds << endl;
+        std::cerr << os.str();
+      }
       k_lclInds1D_ = lcl_col_inds_type ("Tpetra::CrsGraph::ind", numInds);
     }
     else {
+      if (verbose) {
+        std::ostringstream os;
+        os << *prefix << "Allocate global column indices "
+          "k_gblInds1D_: " << numInds << endl;
+        std::cerr << os.str();
+      }
       k_gblInds1D_ = gbl_col_inds_type ("Tpetra::CrsGraph::ind", numInds);
     }
     storageStatus_ = ::Tpetra::Details::STORAGE_1D_UNPACKED;
@@ -1308,7 +1338,12 @@ namespace Tpetra {
       using Kokkos::ViewAllocateWithoutInitializing;
       typedef decltype (k_numRowEntries_) row_ent_type;
       const char label[] = "Tpetra::CrsGraph::numRowEntries";
-
+      if (verbose) {
+        std::ostringstream os;
+        os << *prefix << "Allocate k_numRowEntries_: " << numRows
+           << endl;
+        std::cerr << os.str();
+      }
       row_ent_type numRowEnt (ViewAllocateWithoutInitializing (label), numRows);
       Kokkos::deep_copy (numRowEnt, static_cast<size_t> (0)); // fill w/ 0s
       this->k_numRowEntries_ = numRowEnt; // "commit" our allocation
@@ -2669,7 +2704,11 @@ namespace Tpetra {
        "Local row index " << localRow << " is not in the row Map "
        "on the calling process.");
     if (! indicesAreAllocated ()) {
-      allocateIndices (LocalIndices);
+      // Allocating indices takes a while and only needs to be done
+      // once per MPI process, so it's OK to query TPETRA_VERBOSE.
+      using ::Tpetra::Details::Behavior;
+      const bool verbose = Behavior::verbose("CrsGraph");
+      allocateIndices (LocalIndices, verbose);
     }
 
 #ifdef HAVE_TPETRA_DEBUG
@@ -2763,7 +2802,11 @@ namespace Tpetra {
       "If fillComplete has been called, you must first call resumeFill "
       "before you may insert indices.");
     if (! this->indicesAreAllocated ()) {
-      this->allocateIndices (GlobalIndices);
+      // Allocating indices takes a while and only needs to be done
+      // once per MPI process, so it's OK to query TPETRA_VERBOSE.
+      using ::Tpetra::Details::Behavior;
+      const bool verbose = Behavior::verbose("CrsGraph");
+      this->allocateIndices (GlobalIndices, verbose);
     }
     const LO lclRow = this->rowMap_->getLocalElement (gblRow);
     if (lclRow != Tpetra::Details::OrdinalTraits<LO>::invalid ()) {
@@ -2852,7 +2895,11 @@ namespace Tpetra {
        "If fillComplete has been called, you must first call resumeFill "
        "before you may insert indices.");
     if (! this->indicesAreAllocated ()) {
-      this->allocateIndices (GlobalIndices);
+      // Allocating indices takes a while and only needs to be done
+      // once per MPI process, so it's OK to query TPETRA_VERBOSE.
+      using ::Tpetra::Details::Behavior;
+      const bool verbose = Behavior::verbose("CrsGraph");
+      this->allocateIndices (GlobalIndices, verbose);
     }
 
     Teuchos::ArrayView<const GO> gblColInds_av (gblColInds, numGblColInds);
@@ -2928,7 +2975,11 @@ namespace Tpetra {
       ! rowMap_->isNodeLocalElement (lrow), std::runtime_error,
       "Local row " << lrow << " is not in the row Map on the calling process.");
     if (! indicesAreAllocated ()) {
-      allocateIndices (LocalIndices);
+      // Allocating indices takes a while and only needs to be done
+      // once per MPI process, so it's OK to query TPETRA_VERBOSE.
+      using ::Tpetra::Details::Behavior;
+      const bool verbose = Behavior::verbose("CrsGraph");
+      allocateIndices (LocalIndices, verbose);
     }
 
     // FIXME (mfh 13 Aug 2014) What if they haven't been cleared on
@@ -3430,8 +3481,10 @@ namespace Tpetra {
                 const Teuchos::RCP<const map_type>& rangeMap,
                 const Teuchos::RCP<Teuchos::ParameterList>& params)
   {
+    using ::Tpetra::Details::Behavior;
     const char tfecfFuncName[] = "fillComplete: ";
-    const bool debug = ::Tpetra::Details::Behavior::debug ();
+    const bool debug = Behavior::debug("CrsGraph");
+    const bool verbose = Behavior::verbose("CrsGraph");
 
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
       (! isFillActive () || isFillComplete (), std::runtime_error,
@@ -3473,10 +3526,10 @@ namespace Tpetra {
     if (! indicesAreAllocated ()) {
       if (hasColMap ()) {
         // We have a column Map, so use local indices.
-        allocateIndices (LocalIndices);
+        allocateIndices (LocalIndices, verbose);
       } else {
         // We don't have a column Map, so use global indices.
-        allocateIndices (GlobalIndices);
+        allocateIndices (GlobalIndices, verbose);
       }
     }
 
@@ -4899,6 +4952,7 @@ namespace Tpetra {
     using row_graph_type = RowGraph<LO, GO, node_type>;
     const char tfecfFuncName[] = "copyAndPermute: ";
     const bool debug = ::Tpetra::Details::Behavior::debug ("CrsGraph");
+    const bool verbose = ::Tpetra::Details::Behavior::verbose ("CrsGraph");
 
     std::unique_ptr<std::string> prefix;
     if (debug) {
@@ -4926,9 +4980,9 @@ namespace Tpetra {
       os << *prefix << "Target is StaticProfile; do CRS padding" << endl;
       std::cerr << os.str ();
     }
-    auto padding =
-      computeCrsPadding (srcRowGraph, numSameIDs, permuteToLIDs, permuteFromLIDs);
-    this->applyCrsPadding(padding);
+    auto padding = computeCrsPadding (srcRowGraph, numSameIDs,
+      permuteToLIDs, permuteFromLIDs, verbose);
+    this->applyCrsPadding(padding, verbose);
 
     // If the source object is actually a CrsGraph, we can use view
     // mode instead of copy mode to access the entries in each row,
@@ -5013,31 +5067,56 @@ namespace Tpetra {
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   void
   CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
-  applyCrsPadding(const Kokkos::UnorderedMap<LocalOrdinal, size_t, device_type>& padding)
+  applyCrsPadding(
+    const Kokkos::UnorderedMap<LocalOrdinal, size_t, device_type>& padding,
+    const bool verbose)
   {
-    //    const char tfecfFuncName[] = "applyCrsPadding";
+    using ::Tpetra::Details::ProfilingRegion;
+    using Tpetra::Details::padCrsArrays;
+    using std::endl;
     using execution_space = typename device_type::execution_space;
     using row_ptrs_type = typename local_graph_type::row_map_type::non_const_type;
     using indices_type = t_GlobalOrdinal_1D;
     using local_indices_type = typename local_graph_type::entries_type::non_const_type;
     using range_policy = Kokkos::RangePolicy<execution_space, Kokkos::IndexType<LocalOrdinal>>;
-    using Tpetra::Details::padCrsArrays;
+    ProfilingRegion regionCAP ("Tpetra::CrsGraph::applyCrsPadding");
 
-    if (padding.size() == 0)
+    std::unique_ptr<std::string> prefix;
+    if (verbose) {
+      prefix = createPrefix("applyCrsPadding");
+      std::ostringstream os;
+      os << *prefix << "padding.size(): " << padding.size()
+         << ", indicesAreAllocated: "
+         << (indicesAreAllocated() ? "true" : "false") << endl;
+      std::cerr << os.str ();
+    }
+    if (padding.size() == 0) {
       return;
+    }
 
     // Assume global indexing we don't have any indices yet
     if (! this->indicesAreAllocated()) {
-      allocateIndices(GlobalIndices);
+      allocateIndices(GlobalIndices, verbose);
     }
 
     // Making copies here because k_rowPtrs_ has a const type. Otherwise, we
     // would use it directly.
 
+    if (verbose) {
+      std::ostringstream os;
+      os << *prefix << "Allocate row_ptrs_beg: "
+         << k_rowPtrs_.extent(0) << endl;
+      std::cerr << os.str();
+    }
     row_ptrs_type row_ptrs_beg("row_ptrs_beg", this->k_rowPtrs_.extent(0));
     Kokkos::deep_copy(row_ptrs_beg, this->k_rowPtrs_);
 
     const size_t N = (row_ptrs_beg.extent(0) == 0 ? 0 : row_ptrs_beg.extent(0) - 1);
+    if (verbose) {
+      std::ostringstream os;
+      os << *prefix << "Allocate row_ptrs_end: " << N << endl;
+      std::cerr << os.str();
+    }
     row_ptrs_type row_ptrs_end("row_ptrs_end", N);
 
     bool refill_num_row_entries = false;
@@ -5063,17 +5142,41 @@ namespace Tpetra {
     }
 
     if(this->isGloballyIndexed()) {
+      if (verbose) {
+        std::ostringstream os;
+        os << *prefix << "Allocate (copy of) global column indices: "
+           << k_gblInds1D_.extent(0) << endl;
+        std::cerr << os.str();
+      }
       indices_type indices("indices", this->k_gblInds1D_.extent(0));
       Kokkos::deep_copy(indices, this->k_gblInds1D_);
       using padding_type = Kokkos::UnorderedMap<LocalOrdinal, size_t, device_type>;
       padCrsArrays<row_ptrs_type,indices_type,padding_type>(row_ptrs_beg, row_ptrs_end, indices, padding);
+      if (verbose) {
+        std::ostringstream os;
+        os << *prefix << "Reassign k_gblInds1D_; old size: "
+           << k_gblInds1D_.extent(0) << endl;
+        std::cerr << os.str();
+      }
       this->k_gblInds1D_ = indices;
     }
     else {
+      if (verbose) {
+        std::ostringstream os;
+        os << *prefix << "Allocate (copy of) local column indices: "
+           << k_lclInds1D_.extent(0) << endl;
+        std::cerr << os.str();
+      }
       local_indices_type indices("indices", this->k_lclInds1D_.extent(0));
       Kokkos::deep_copy(indices, this->k_lclInds1D_);
       using padding_type = Kokkos::UnorderedMap<LocalOrdinal, size_t, device_type>;
       padCrsArrays<row_ptrs_type,local_indices_type,padding_type>(row_ptrs_beg, row_ptrs_end, indices, padding);
+      if (verbose) {
+        std::ostringstream os;
+        os << *prefix << "Reassign k_lclInds1D_; old size: "
+           << k_lclInds1D_.extent(0) << endl;
+        std::cerr << os.str();
+      }
       this->k_lclInds1D_ = indices;
     }
 
@@ -5085,7 +5188,33 @@ namespace Tpetra {
                            }
                            );
     }
+    if (verbose) {
+      std::ostringstream os;
+      os << *prefix << "Reassign k_rowPtrs_; old size: "
+         << k_rowPtrs_.extent(0) << endl;
+      std::cerr << os.str();
+    }
     this->k_rowPtrs_ = row_ptrs_beg;
+  }
+
+  template <class LocalOrdinal, class GlobalOrdinal, class Node>
+  std::unique_ptr<std::string>
+  CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
+  createPrefix(const char methodName[]) const
+  {
+    int myRank = -1;
+    auto map = this->getMap();
+    if (! map.is_null()) {
+      auto comm = map->getComm();
+      if (! comm.is_null()) {
+        myRank = comm->getRank();
+      }
+    }
+    std::ostringstream pfxStrm;
+    pfxStrm << "Proc " << myRank << ": Tpetra::CrsGraph::"
+            << methodName << ": ";
+    return std::unique_ptr<std::string>(
+      new std::string(pfxStrm.str()));
   }
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -5094,10 +5223,23 @@ namespace Tpetra {
   computeCrsPadding (const RowGraph<LocalOrdinal,GlobalOrdinal,Node>& source,
                      const size_t numSameIDs,
                      const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& permuteToLIDs,
-                     const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& permuteFromLIDs) const
+                     const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& permuteFromLIDs,
+                     const bool verbose) const
   {
+    using std::endl;
     using LO = LocalOrdinal;
     using padding_type = Kokkos::UnorderedMap<LO, size_t, device_type>;
+
+    std::unique_ptr<std::string> prefix;
+    if (verbose) {
+      prefix = createPrefix("computeCrsPadding(same & permute)");
+      std::ostringstream os;
+      os << *prefix << "{numSameIDs: " << numSameIDs
+         << ", numPermutes: " << permuteFromLIDs.extent(0) << "}"
+         << endl;
+      std::cerr << os.str();
+    }
+
     padding_type padding (numSameIDs + permuteFromLIDs.extent (0));
 
     computeCrsPaddingForSameIDs(padding, source, numSameIDs, false);
@@ -5244,9 +5386,23 @@ namespace Tpetra {
   Kokkos::UnorderedMap<LocalOrdinal, size_t, typename Node::device_type>
   CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
   computeCrsPadding (const Kokkos::DualView<const local_ordinal_type*, buffer_device_type>& importLIDs,
-                     Kokkos::DualView<size_t*, buffer_device_type> numPacketsPerLID) const
+                     Kokkos::DualView<size_t*, buffer_device_type> numPacketsPerLID,
+                     const bool verbose) const
   {
+    using std::endl;
     const char tfecfFuncName[] = "computeCrsPadding: ";
+
+    std::unique_ptr<std::string> prefix;
+    if (verbose) {
+      prefix = createPrefix("computeCrsPadding(imports)");
+      std::ostringstream os;
+      os << *prefix << "{importLIDs.extent(0): "
+         << importLIDs.extent(0)
+         << ", numPacketsPerLID.extent(0): "
+         << numPacketsPerLID.extent(0) << "}"
+         << endl;
+      std::cerr << os.str();
+    }
 
     // Creating padding for each new incoming index
     Kokkos::fence ();  // Make sure device sees changes made by host
@@ -5925,29 +6081,24 @@ namespace Tpetra {
    Distributor& /* distor */,
    const CombineMode /* combineMode */ )
   {
+    using ::Tpetra::Details::ProfilingRegion;
     using std::endl;
     using LO = local_ordinal_type;
     using GO = global_ordinal_type;
     const char tfecfFuncName[] = "unpackAndCombine: ";
-    const bool debug = ::Tpetra::Details::Behavior::debug ("CrsGraph");
+
+    ProfilingRegion regionCGC ("Tpetra::CrsGraph::unpackAndCombine");
+    const bool verbose = ::Tpetra::Details::Behavior::verbose ("CrsGraph");
 
     std::unique_ptr<std::string> prefix;
-    if (debug) {
+    if (verbose) {
+      prefix = createPrefix("unpackAndCombine");
       std::ostringstream os;
-      const int myRank = this->getMap ()->getComm ()->getRank ();
-      os << "Proc " << myRank << ": Tpetra::CrsGraph::unpackAndCombine: ";
-      prefix = std::unique_ptr<std::string> (new std::string (os.str ()));
-      os << endl;
+      os << *prefix << endl;
       std::cerr << os.str ();
     }
-
-    if (debug) {
-      std::ostringstream os;
-      os << *prefix << "Target is StaticProfile; do CRS padding" << endl;
-      std::cerr << os.str ();
-    }
-    auto padding = computeCrsPadding (importLIDs, numPacketsPerLID);
-    applyCrsPadding(padding);
+    auto padding = computeCrsPadding (importLIDs, numPacketsPerLID, verbose);
+    applyCrsPadding(padding, verbose);
 
     // FIXME (mfh 02 Apr 2012) REPLACE combine mode has a perfectly
     // reasonable meaning, whether or not the matrix is fill complete.
@@ -6029,7 +6180,7 @@ namespace Tpetra {
     }
 
 
-    if (debug) {
+    if (verbose) {
       std::ostringstream os;
       os << *prefix << "Done" << endl;
       std::cerr << os.str ();

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -3434,9 +3434,14 @@ namespace Tpetra {
     checkSizes (const SrcDistObject& source) override;
 
     void
-    applyCrsPadding(const Kokkos::UnorderedMap<LocalOrdinal, size_t, device_type>& padding);
+    applyCrsPadding(
+      const Kokkos::UnorderedMap<LocalOrdinal, size_t, device_type>& padding,
+      const bool verbose);
 
   private:
+    std::unique_ptr<std::string>
+    createPrefix(const char methodName[]) const;
+
     void
     copyAndPermuteImpl (const RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>& source,
                         const size_t numSameIDs,
@@ -4150,6 +4155,8 @@ namespace Tpetra {
     /// \param lg [in] Argument passed into \c
     ///   myGraph_->allocateIndices(), if applicable.
     ///
+    /// \param verbose [in] Whether to print verbose debugging output.
+    ///
     /// \pre If the graph (that is, staticGraph_) indices are
     ///   already allocated, then gas must be GraphAlreadyAllocated.
     ///   Otherwise, gas must be GraphNotYetAllocated.  We only
@@ -4157,7 +4164,8 @@ namespace Tpetra {
     ///
     /// \pre If the graph indices are not already allocated, then
     ///   the graph must be owned by the matrix.
-    void allocateValues (ELocalGlobal lg, GraphAllocationStatus gas);
+    void allocateValues (ELocalGlobal lg, GraphAllocationStatus gas,
+                         const bool verbose);
 
     /// \brief Merge duplicate row indices in the given row, along
     ///   with their corresponding values.

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -314,9 +314,20 @@ namespace Tpetra {
     fillComplete_ (false),
     frobNorm_ (-STM::one ())
   {
+    using std::endl;
     typedef typename local_matrix_type::values_type values_type;
     const char tfecfFuncName[] = "CrsMatrix(RCP<const CrsGraph>[, "
       "RCP<ParameterList>]): ";
+    const bool verbose = Details::Behavior::verbose("CrsMatrix");
+
+    std::unique_ptr<std::string> prefix;
+    if (verbose) {
+      prefix = createPrefix("CrsMatrix(CrsGraph,params)");
+      std::ostringstream os;
+      os << *prefix << endl;
+      std::cerr << os.str ();
+    }
+
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
       (graph.is_null (), std::runtime_error, "Input graph is null.");
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
@@ -336,6 +347,11 @@ namespace Tpetra {
     const size_t numCols = graph->getColMap ()->getNodeNumElements ();
     auto lclGraph = graph->getLocalGraph ();
     const size_t numEnt = lclGraph.entries.extent (0);
+    if (verbose) {
+      std::ostringstream os;
+      os << *prefix << "Allocate values: " << numEnt << endl;
+      std::cerr << os.str ();
+    }
     values_type val ("Tpetra::CrsMatrix::val", numEnt);
 
     auto lclMat = std::make_shared<local_matrix_type>
@@ -345,6 +361,13 @@ namespace Tpetra {
     // FIXME (22 Jun 2016) I would very much like to get rid of
     // k_values1D_ at some point.  I find it confusing to have all
     // these extra references lying around.
+    if (verbose) {
+      std::ostringstream os;
+      os << *prefix << "Assign k_values1D_: old="
+         << k_values1D_.extent(0) << ", new="
+         << lclMat->values.extent(0) << endl;
+      std::cerr << os.str ();
+    }
     k_values1D_ = lclMat->values;
 
     checkInternalState ();

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -6234,6 +6234,17 @@ namespace Tpetra {
       os << *prefix << "padding.size(): " << padding.size() << endl;
       std::cerr << os.str ();
     }
+    const int myRank = ! verbose ? -1 : [&] () {
+      auto map = this->getMap();
+      if (map.is_null()) {
+        return -1;
+      }
+      auto comm = map->getComm();
+      if (comm.is_null()) {
+        return -1;
+      }
+      return comm->getRank();
+    } ();
 
     // NOTE (mfh 29 Jan 2020) This allocates the values array.
     if (! myGraph_->indicesAreAllocated ()) {
@@ -6305,7 +6316,8 @@ namespace Tpetra {
       indices_type indices("indices", myGraph_->k_gblInds1D_.extent(0));
       Kokkos::deep_copy(indices, myGraph_->k_gblInds1D_);
       using padding_type = Kokkos::UnorderedMap<LocalOrdinal, size_t, device_type>;
-      padCrsArrays<row_ptrs_type,indices_type,values_type,padding_type>(row_ptr_beg, row_ptr_end, indices, values, padding);
+      padCrsArrays<row_ptrs_type,indices_type,values_type,padding_type>(row_ptr_beg,
+        row_ptr_end, indices, values, padding, myRank, verbose);
       if (verbose) {
         std::ostringstream os;
         os << *prefix << "Free old myGraph_->k_gblInds1D_: "
@@ -6329,7 +6341,8 @@ namespace Tpetra {
       indices_type indices("indices", myGraph_->k_lclInds1D_.extent(0));
       Kokkos::deep_copy(indices, myGraph_->k_lclInds1D_);
       using padding_type = Kokkos::UnorderedMap<LocalOrdinal, size_t, device_type>;
-      padCrsArrays<row_ptrs_type,indices_type,values_type,padding_type>(row_ptr_beg, row_ptr_end, indices, values, padding);
+      padCrsArrays<row_ptrs_type,indices_type,values_type,padding_type>(row_ptr_beg,
+        row_ptr_end, indices, values, padding, myRank, verbose);
       if (verbose) {
         std::ostringstream os;
         os << *prefix << "Free old myGraph_->k_lclInds1D_: "

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -4648,8 +4648,18 @@ namespace Tpetra {
     using Teuchos::ArrayRCP;
     using Teuchos::RCP;
     using Teuchos::rcp;
+    using std::endl;
     const char tfecfFuncName[] = "fillComplete: ";
-    ProfilingRegion regionFillComplete ("Tpetra::CrsMatrix::fillComplete");
+    ProfilingRegion regionFillComplete
+      ("Tpetra::CrsMatrix::fillComplete");
+    const bool verbose = Details::Behavior::verbose("CrsMatrix");
+    std::unique_ptr<std::string> prefix;
+    if (verbose) {
+      prefix = createPrefix("fillComplete(dom,ran,p)");
+      std::ostringstream os;
+      os << *prefix << endl;
+      std::cerr << os.str ();
+    }
 
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
       (! this->isFillActive () || this->isFillComplete (), std::runtime_error,
@@ -4687,8 +4697,6 @@ namespace Tpetra {
     }
 
     if (! this->getCrsGraphRef ().indicesAreAllocated ()) {
-      using ::Tpetra::Details::Behavior;
-      const bool verbose = Behavior::verbose("CrsMatrix");
       if (this->hasColMap ()) { // use local indices
         allocateValues(LocalIndices, GraphNotYetAllocated, verbose);
       }
@@ -4775,7 +4783,7 @@ namespace Tpetra {
       // Make indices local, if necessary.  The method won't do
       // anything if the graph is already locally indexed.
       const std::pair<size_t, std::string> makeIndicesLocalResult =
-        this->myGraph_->makeIndicesLocal ();
+        this->myGraph_->makeIndicesLocal(verbose);
       // TODO (mfh 20 Jul 2017) Instead of throwing here, pass along
       // the error state to makeImportExport or
       // computeGlobalConstants, which may do all-reduces and thus may

--- a/packages/tpetra/core/test/Utils/TpetraUtils_crsUtils.cpp
+++ b/packages/tpetra/core/test/Utils/TpetraUtils_crsUtils.cpp
@@ -117,7 +117,9 @@ TEUCHOS_UNIT_TEST(CrsGraph, ResizeRowPointersAndIndices_1)
   execution_space().fence();
   TEST_ASSERT(!padding.failed_insert());
 
-  padCrsArrays(row_ptrs_beg, row_ptrs_end, indices, padding);
+  const int myRank = 0;
+  const bool verbose = false;
+  padCrsArrays(row_ptrs_beg, row_ptrs_end, indices, padding, myRank, verbose);
   TEST_ASSERT(indices.size() == static_cast<size_type>(num_indices + num_extra));
 
   {
@@ -190,7 +192,10 @@ TEUCHOS_UNIT_TEST(CrsGraph, ResizeRowPointersAndIndices_2)
   }
   execution_space().fence();
   TEST_ASSERT(!padding.failed_insert());
-  padCrsArrays(row_ptrs_beg, row_ptrs_end, indices, padding);
+
+  const int myRank = 0;
+  const bool verbose = false;
+  padCrsArrays(row_ptrs_beg, row_ptrs_end, indices, padding, myRank, verbose);
 
   // Check row offsets
   TEST_ASSERT(row_ptrs_beg(0) == 0);


### PR DESCRIPTION
@trilinos/tpetra @tjfulle 

Add verbose debugging output to CrsGraph and CrsMatrix, to help diagnose and fix #6663 and #6648 in general.

Tested TpetraCore tests locally on my Mac laptop with Clang and OpenMPI, with `TPETRA_VERBOSE` both set and unset.