### PR TITLE
Moertel: fix warnings due to signed/unsigned comparison, see issue #6698

### DIFF
--- a/packages/moertel/src/mortar/mrtr_manager.H
+++ b/packages/moertel/src/mortar/mrtr_manager.H
@@ -625,7 +625,7 @@ public:
             continue;
           const int* dof = node->Dof();
           const int* lmdof = node->LMDof();
-          for (std::size_t j=0; j<node->Nlmdof(); ++j)
+          for (int j=0; j<node->Nlmdof(); ++j)
             lm_to_dof[lmdof[j]] = dof[j];
         }
       }

--- a/packages/moertel/src/mortar/mrtr_overlap_Def.hpp
+++ b/packages/moertel/src/mortar/mrtr_overlap_Def.hpp
@@ -387,7 +387,7 @@ bool MOERTEL::Overlap<IFace>::build_sxim()
 
       double master_normal[3];
       MOERTEL::Node** nodes = mseg_.Nodes();
-      for (std::size_t j=0; j<mseg_.Nnode(); ++j)
+      for (int j=0; j<mseg_.Nnode(); ++j)
         for (std::size_t k=0; k<3; ++k)
           master_normal[k] += nodes[j]->Normal()[k];
 
@@ -401,7 +401,7 @@ bool MOERTEL::Overlap<IFace>::build_sxim()
         return false;
     }
     // project node i onto sseg
-    bool OK = projector.ProjectNodetoSegment_NodalNormal(*snode[i],mseg_,sxim_[i],gap);
+    projector.ProjectNodetoSegment_NodalNormal(*snode[i],mseg_,sxim_[i],gap);
 #if 0
     // check whether i is inside sseg
     if (sxim_[i][0]<=1. && sxim_[i][1]<=abs(1.-sxim_[i][0]) && sxim_[i][0]>=0. && sxim_[i][1]>=0.)
@@ -1468,7 +1468,7 @@ bool MOERTEL::Overlap<IFace>::Triangulation()
 
         double master_normal[3];
         MOERTEL::Node** nodes = mseg_.Nodes();
-        for (std::size_t j=0; j<mseg_.Nnode(); ++j)
+        for (int j=0; j<mseg_.Nnode(); ++j)
           for (std::size_t k=0; k<3; ++k)
             master_normal[k] += nodes[j]->Normal()[k];
 


### PR DESCRIPTION
## Motivation
Well this fixes the auto-tester gcc/7.2.0 build

## Related Issues

* Closes #6698 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 


## Stakeholder Feedback
I'm not sure maybe @bartlettroscoe 

## Testing
Did a local build using the gcc/7.2.0 environment with -Werror, this builds fine.