### PR TITLE
Stokhos: Add the ensemble GMRES without the ensemble reduction

### DIFF
--- a/packages/belos/src/BelosPseudoBlockGmresSolMgr.hpp
+++ b/packages/belos/src/BelosPseudoBlockGmresSolMgr.hpp
@@ -367,8 +367,8 @@ namespace Belos {
     bool isLOADetected() const override { return loaDetected_; }
 
     //! Return the residual status test
-    Teuchos::RCP<StatusTestResNorm<ScalarType,MV,OP> >
-    getResidualStatusTest() const { return impConvTest_; }
+    const StatusTestResNorm<ScalarType,MV,OP> *
+    getResidualStatusTest() const { return impConvTest_.getRawPtr(); }
     //@}
 
     //! @name Set methods

--- a/packages/belos/src/BelosPseudoBlockGmresSolMgr.hpp
+++ b/packages/belos/src/BelosPseudoBlockGmresSolMgr.hpp
@@ -366,6 +366,9 @@ namespace Belos {
     ///   call this method immediately after calling \c solve().
     bool isLOADetected() const override { return loaDetected_; }
 
+    //! Return the residual status test
+    Teuchos::RCP<StatusTestResNorm<ScalarType,MV,OP> >
+    getResidualStatusTest() const { return impConvTest_; }
     //@}
 
     //! @name Set methods

--- a/packages/stokhos/src/CMakeLists.txt
+++ b/packages/stokhos/src/CMakeLists.txt
@@ -671,6 +671,8 @@ IF (Stokhos_ENABLE_Sacado)
       sacado/kokkos/vector/Kokkos_View_MP_Vector_Utils.hpp
       sacado/kokkos/vector/Kokkos_Atomic_MP_Vector.hpp
       sacado/kokkos/vector/Kokkos_Parallel_MP_Vector.hpp
+      sacado/kokkos/vector/KokkosBlas_MP_Vector.hpp
+      sacado/kokkos/vector/KokkosBlas3_gemm_MP_Vector.hpp
       sacado/kokkos/vector/Teuchos_BLAS_MP_Vector.hpp
       sacado/kokkos/vector/Teuchos_LAPACK_MP_Vector.hpp
       sacado/kokkos/vector/Teuchos_SerialQRDenseSolver_MP_Vector.hpp
@@ -901,6 +903,11 @@ IF (Stokhos_ENABLE_Sacado)
           sacado/kokkos/vector/belos/Belos_SolverManager_MP_Vector.hpp
           sacado/kokkos/vector/belos/Belos_PseudoBlockCGIter_MP_Vector.hpp
           sacado/kokkos/vector/belos/Belos_StatusTest_GenResNorm_MP_Vector.hpp
+          sacado/kokkos/vector/belos/Belos_StatusTest_ImpResNorm_MP_Vector.hpp
+          sacado/kokkos/vector/belos/Belos_PseudoBlockGmresIter_MP_Vector.hpp
+          sacado/kokkos/vector/belos/Belos_DGKS_OrthoManager_MP_Vector.hpp
+          sacado/kokkos/vector/belos/Belos_ICGS_OrthoManager_MP_Vector.hpp
+          sacado/kokkos/vector/belos/Belos_IMGS_OrthoManager_MP_Vector.hpp
           )
       ENDIF()
       IF(Stokhos_ENABLE_PCE_Scalar_Type)

--- a/packages/stokhos/src/sacado/kokkos/vector/KokkosBlas3_gemm_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/KokkosBlas3_gemm_MP_Vector.hpp
@@ -72,7 +72,7 @@ gemm(const char transA[],
   static_assert(Kokkos::View<DB, PB...>::rank == 2, "GEMM: B must have rank 2 (be a matrix).");
   static_assert(Kokkos::View<DC, PC...>::rank == 2, "GEMM: C must have rank 2 (be a matrix).");
 
-  if (B.dimension_1() == 1 && C.dimension_1() == 1)
+  if (B.extent(1) == 1 && C.extent(1) == 1)
   {
     auto x = Kokkos::subview(B, Kokkos::ALL, 0);
     auto y = Kokkos::subview(C, Kokkos::ALL, 0);

--- a/packages/stokhos/src/sacado/kokkos/vector/KokkosBlas_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/KokkosBlas_MP_Vector.hpp
@@ -39,17 +39,10 @@
 // ***********************************************************************
 // @HEADER
 
-#ifndef BELOS_TPETRA_MP_VECTOR_HPP
-#define BELOS_TPETRA_MP_VECTOR_HPP
+#ifndef KOKKOSBLAS_MP_VECTOR_HPP
+#define KOKKOSBLAS_MP_VECTOR_HPP
 
-#include "Belos_TpetraAdapter_MP_Vector.hpp"
-#include "Belos_SolverManager_MP_Vector.hpp"
-#include "Belos_StatusTest_GenResNorm_MP_Vector.hpp"
-#include "Belos_PseudoBlockCGIter_MP_Vector.hpp"
-#include "Belos_StatusTest_ImpResNorm_MP_Vector.hpp"
-#include "Belos_DGKS_OrthoManager_MP_Vector.hpp"
-#include "Belos_ICGS_OrthoManager_MP_Vector.hpp"
-#include "Belos_IMGS_OrthoManager_MP_Vector.hpp"
-#include "Belos_PseudoBlockGmresIter_MP_Vector.hpp"
+#include "KokkosBlas3_gemm_MP_Vector.hpp"
+#include "KokkosBlas.hpp"
 
 #endif

--- a/packages/stokhos/src/sacado/kokkos/vector/Teuchos_BLAS_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/Teuchos_BLAS_MP_Vector.hpp
@@ -126,22 +126,6 @@ class BLAS<OrdinalType, Sacado::MP::Vector<Storage>> : public Teuchos::DefaultBL
   typedef Teuchos::DefaultBLASImpl<OrdinalType, Sacado::MP::Vector<Storage>> BLASType;
 
 public:
-  //! @name Constructor/Destructor.
-  //@{
-
-  //! Default constructor.
-  BLAS(bool use_default_impl = true,
-       bool use_dynamic = true, OrdinalType static_workspace_size = 0){};
-
-  //! Copy constructor.
-
-  BLAS(const BLAS &x){};
-
-  //! Destructor.
-  virtual ~BLAS(){};
-
-  //@}
-
   template <typename alpha_type, typename A_type>
   void TRSM(Teuchos::ESide side, Teuchos::EUplo uplo,
             Teuchos::ETransp transa, Teuchos::EDiag diag,

--- a/packages/stokhos/src/sacado/kokkos/vector/Teuchos_BLAS_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/Teuchos_BLAS_MP_Vector.hpp
@@ -45,99 +45,465 @@
 #include "Teuchos_BLAS.hpp"
 #include "Sacado_MP_Vector.hpp"
 
-// Specialize some things used in the default BLAS implementation that
-// don't seem correct for MP::Vector scalar type
-namespace Teuchos {
+namespace Teuchos
+{
 
-  namespace details {
+namespace details
+{
 
-    template<typename Storage>
-    class GivensRotator<Sacado::MP::Vector<Storage>, false> {
-    public:
-      typedef Sacado::MP::Vector<Storage> ScalarType;
-      typedef ScalarType c_type;
+template <typename Storage>
+class GivensRotator<Sacado::MP::Vector<Storage>, false>
+{
+public:
+  typedef Sacado::MP::Vector<Storage> ScalarType;
+  typedef ScalarType c_type;
 
-      void
-      ROTG (ScalarType* da,
-            ScalarType* db,
-            ScalarType* c,
-            ScalarType* s) const {
+  void
+  ROTG(ScalarType *da,
+       ScalarType *db,
+       ScalarType *c,
+       ScalarType *s) const
+  {
+    typedef ScalarTraits<ScalarType> STS;
 
-        typedef ScalarTraits<ScalarType> STS;
+    ScalarType r, roe, scale, z, da_scaled, db_scaled;
+    auto m_da = (STS::magnitude(*da) > STS::magnitude(*db));
+    mask_assign(m_da, roe) = {*da, *db};
 
-        // This is a straightforward translation into C++ of the
-        // reference BLAS' implementation of DROTG.  You can get
-        // the Fortran 77 source code of DROTG here:
-        //
-        // http://www.netlib.org/blas/drotg.f
-        //
-        // I used the following rules to translate Fortran types and
-        // intrinsic functions into C++:
-        //
-        // DOUBLE PRECISION -> ScalarType
-        // DABS -> STS::magnitude
-        // DSQRT -> STM::squareroot
-        // DSIGN -> SIGN (see below)
-        //
-        // DSIGN(x,y) (the old DOUBLE PRECISION type-specific form of
-        // the Fortran type-generic SIGN intrinsic) required special
-        // translation, which we did in a separate utility function in
-        // the specializaton of GivensRotator for real arithmetic.
-        // (ROTG for complex arithmetic doesn't require this function.)
-        // C99 provides a copysign() math library function, but we are
-        // not able to rely on the existence of C99 functions here.
-        ScalarType r, roe, scale, z;
+    scale = STS::magnitude(*da) + STS::magnitude(*db);
 
-        roe = *db;
-        if (STS::magnitude (*da) > STS::magnitude (*db)) {
-          roe = *da;
+    auto m_scale = scale != STS::zero();
+
+    da_scaled = *da;
+    db_scaled = *db;
+
+    *c = *da;
+    *s = *db;
+
+    ScalarType tmp = STS::one();
+    mask_assign(m_scale, tmp) /= scale;
+
+    mask_assign(m_scale, da_scaled) *= tmp;
+    mask_assign(m_scale, db_scaled) *= tmp;
+
+    r = scale * STS::squareroot(da_scaled * da_scaled + db_scaled * db_scaled);
+    auto m_roe = roe < 0;
+    mask_assign(m_roe, r) = -r;
+
+    tmp = STS::one();
+    mask_assign(m_scale, tmp) /= r;
+
+    mask_assign(m_scale, *c) *= tmp;
+    mask_assign(m_scale, *s) *= tmp;
+
+    mask_assign(!m_scale, *c) = STS::one();
+    mask_assign(!m_scale, *s) = STS::zero();
+
+    mask_assign(*c != STS::zero(), z) /= {STS::one(), *c, STS::zero()};
+    mask_assign(!m_scale, z) = STS::zero();
+    mask_assign(m_da, z) = *s;
+
+    *da = r;
+    *db = z;
+  }
+};
+} // namespace details
+} // namespace Teuchos
+
+//namespace Sacado {
+//  namespace MP {
+namespace Teuchos
+{
+//! Vector specializations for Teuchos::BLAS wrappers
+template <typename OrdinalType, typename Storage>
+class BLAS<OrdinalType, Sacado::MP::Vector<Storage>> : public Teuchos::DefaultBLASImpl<OrdinalType, Sacado::MP::Vector<Storage>>
+{
+
+  typedef typename Teuchos::ScalarTraits<Sacado::MP::Vector<Storage>>::magnitudeType MagnitudeType;
+  typedef typename Sacado::ValueType<Sacado::MP::Vector<Storage>>::type ValueType;
+  typedef typename Sacado::ScalarType<Sacado::MP::Vector<Storage>>::type scalar_type;
+  typedef typename Sacado::MP::Vector<Storage> ScalarType;
+  typedef Teuchos::DefaultBLASImpl<OrdinalType, Sacado::MP::Vector<Storage>> BLASType;
+
+public:
+  //! @name Constructor/Destructor.
+  //@{
+
+  //! Default constructor.
+  BLAS(bool use_default_impl = true,
+       bool use_dynamic = true, OrdinalType static_workspace_size = 0){};
+
+  //! Copy constructor.
+
+  BLAS(const BLAS &x){};
+
+  //! Destructor.
+  virtual ~BLAS(){};
+
+  //@}
+
+  template <typename alpha_type, typename A_type>
+  void TRSM(Teuchos::ESide side, Teuchos::EUplo uplo,
+            Teuchos::ETransp transa, Teuchos::EDiag diag,
+            const OrdinalType m, const OrdinalType n,
+            const alpha_type &alpha,
+            const A_type *A, const OrdinalType lda,
+            ScalarType *B, const OrdinalType ldb) const
+  {
+    typedef Sacado::MP::Vector<Storage> ScalarType;
+
+    OrdinalType izero = OrdinalTraits<OrdinalType>::zero();
+    OrdinalType ione = OrdinalTraits<OrdinalType>::one();
+    alpha_type alpha_zero = ScalarTraits<alpha_type>::zero();
+    A_type A_zero = ScalarTraits<A_type>::zero();
+    ScalarType B_zero = ScalarTraits<ScalarType>::zero();
+    alpha_type alpha_one = ScalarTraits<alpha_type>::one();
+    ScalarType B_one = ScalarTraits<ScalarType>::one();
+    ScalarType temp;
+    OrdinalType NRowA = m;
+    bool BadArgument = false;
+    bool noUnit = (EDiagChar[diag] == 'N');
+    bool noConj = (ETranspChar[transa] == 'T');
+
+    if (!(ESideChar[side] == 'L'))
+    {
+      NRowA = n;
+    }
+
+    // Quick return.
+    if (n == izero || m == izero)
+    {
+      return;
+    }
+    if (m < izero)
+    {
+      std::cout << "BLAS::TRSM Error: M == " << m << std::endl;
+      BadArgument = true;
+    }
+    if (n < izero)
+    {
+      std::cout << "BLAS::TRSM Error: N == " << n << std::endl;
+      BadArgument = true;
+    }
+    if (lda < NRowA)
+    {
+      std::cout << "BLAS::TRSM Error: LDA < " << NRowA << std::endl;
+      BadArgument = true;
+    }
+    if (ldb < m)
+    {
+      std::cout << "BLAS::TRSM Error: LDB < MAX(1,M)" << std::endl;
+      BadArgument = true;
+    }
+
+    if (!BadArgument)
+    {
+      int i, j, k;
+      // Set the solution to the zero vector.
+      auto alpha_is_zero = (alpha == alpha_zero);
+      for (j = izero; j < n; j++)
+      {
+        for (i = izero; i < m; i++)
+        {
+          mask_assign(alpha_is_zero, B[j * ldb + i]) = B_zero;
         }
-        scale = STS::magnitude (*da) + STS::magnitude (*db);
-        if (scale == STS::zero()) {
-          *c = STS::one();
-          *s = STS::zero();
-          r = STS::zero();
-          z = STS::zero();
-        } else {
-          // I introduced temporaries into the translated BLAS code in
-          // order to make the expression easier to read and also save
-          // a few floating-point operations.
-          const ScalarType da_scaled = *da / scale;
-          const ScalarType db_scaled = *db / scale;
-          r = scale * STS::squareroot (da_scaled*da_scaled + db_scaled*db_scaled);
-          r = SIGN (STS::one(), roe) * r;
-          *c = *da / r;
-          *s = *db / r;
-          z = STS::one();
-          if (STS::magnitude (*da) > STS::magnitude (*db)) {
-            z = *s;
-          }
-          if (STS::magnitude (*db) >= STS::magnitude (*da) && *c != STS::zero()) {
-            z = STS::one() / *c;
-          }
-        }
- 
-        *da = r;
-        *db = z;
       }
 
-    private:
+      auto alpha_is_not_one = (alpha != alpha_one);
 
-      /// Return ABS(x) if y > 0 or y is +0, else -ABS(x) (if y is -0 or < 0).
-      ScalarType SIGN (ScalarType x, ScalarType y) const {
-        typedef typename ScalarType::value_type value_type;
-        typedef typename ScalarType::ordinal_type ordinal_type;
+      { // Start the operations.
+        if (ESideChar[side] == 'L')
+        {
+          //
+          // Perform computations for OP(A)*X = alpha*B
+          //
+          if (ETranspChar[transa] == 'N')
+          {
+            //
+            //  Compute B = alpha*inv( A )*B
+            //
+            if (EUploChar[uplo] == 'U')
+            {
+              // A is upper triangular.
+              for (j = izero; j < n; j++)
+              {
+                // Perform alpha*B if alpha is not 1.
+                for (i = izero; i < m; i++)
+                {
+                  mask_assign(alpha_is_not_one, B[j * ldb + i]) *= alpha;
+                }
 
-        GivensRotator<value_type> value_rotator;
-        const ordinal_type sz = x.size() > y.size() ? x.size() : y.size();
-        ScalarType z(sz, 0.0);
-        for (ordinal_type i=0; i<sz; ++i)
-          z.fastAccessCoeff(i) = value_rotator.SIGN(x.coeff(i), y.coeff(i));
-        return z;
+                // Perform a backsolve for column j of B.
+                for (k = (m - ione); k > -ione; k--)
+                {
+                  // If this entry is zero, we don't have to do anything.
+                  auto B_is_not_zero = (B[j * ldb + k] != B_zero);
+
+                  if (noUnit)
+                  {
+                    mask_assign(B_is_not_zero, B[j * ldb + k]) /= A[k * lda + k];
+                  }
+                  for (i = izero; i < k; i++)
+                  {
+                    mask_assign(B_is_not_zero, B[j * ldb + i]) -= B[j * ldb + k] * A[k * lda + i];
+                  }
+                }
+              }
+            }
+            else
+            { // A is lower triangular.
+              for (j = izero; j < n; j++)
+              {
+                // Perform alpha*B if alpha is not 1.
+                for (i = izero; i < m; i++)
+                {
+                  mask_assign(alpha_is_not_one, B[j * ldb + i]) *= alpha;
+                }
+                // Perform a forward solve for column j of B.
+                for (k = izero; k < m; k++)
+                {
+                  // If this entry is zero, we don't have to do anything.
+                  auto B_is_not_zero = (B[j * ldb + k] != B_zero);
+                  if (noUnit)
+                  {
+                    mask_assign(B_is_not_zero, B[j * ldb + k]) /= A[k * lda + k];
+                  }
+                  for (i = k + ione; i < m; i++)
+                  {
+                    mask_assign(B_is_not_zero, B[j * ldb + i]) -= B[j * ldb + k] * A[k * lda + i];
+                  }
+                }
+              }
+            } // end if (uplo == 'U')
+          }   // if (transa =='N')
+          else
+          {
+            //
+            //  Compute B = alpha*inv( A' )*B
+            //  or      B = alpha*inv( conj(A') )*B
+            //
+            if (EUploChar[uplo] == 'U')
+            {
+              // A is upper triangular.
+              for (j = izero; j < n; j++)
+              {
+                for (i = izero; i < m; i++)
+                {
+                  temp = alpha * B[j * ldb + i];
+                  if (noConj)
+                  {
+                    for (k = izero; k < i; k++)
+                    {
+                      temp -= A[i * lda + k] * B[j * ldb + k];
+                    }
+                    if (noUnit)
+                    {
+                      temp /= A[i * lda + i];
+                    }
+                  }
+                  else
+                  {
+                    for (k = izero; k < i; k++)
+                    {
+                      temp -= ScalarTraits<A_type>::conjugate(A[i * lda + k]) * B[j * ldb + k];
+                    }
+                    if (noUnit)
+                    {
+                      temp /= ScalarTraits<A_type>::conjugate(A[i * lda + i]);
+                    }
+                  }
+                  B[j * ldb + i] = temp;
+                }
+              }
+            }
+            else
+            { // A is lower triangular.
+              for (j = izero; j < n; j++)
+              {
+                for (i = (m - ione); i > -ione; i--)
+                {
+                  temp = alpha * B[j * ldb + i];
+                  if (noConj)
+                  {
+                    for (k = i + ione; k < m; k++)
+                    {
+                      temp -= A[i * lda + k] * B[j * ldb + k];
+                    }
+                    if (noUnit)
+                    {
+                      temp /= A[i * lda + i];
+                    }
+                  }
+                  else
+                  {
+                    for (k = i + ione; k < m; k++)
+                    {
+                      temp -= ScalarTraits<A_type>::conjugate(A[i * lda + k]) * B[j * ldb + k];
+                    }
+                    if (noUnit)
+                    {
+                      temp /= ScalarTraits<A_type>::conjugate(A[i * lda + i]);
+                    }
+                  }
+                  B[j * ldb + i] = temp;
+                }
+              }
+            }
+          }
+        } // if (side == 'L')
+        else
+        {
+          // side == 'R'
+          //
+          // Perform computations for X*OP(A) = alpha*B
+          //
+          if (ETranspChar[transa] == 'N')
+          {
+            //
+            //  Compute B = alpha*B*inv( A )
+            //
+            if (EUploChar[uplo] == 'U')
+            {
+              // A is upper triangular.
+              // Perform a backsolve for column j of B.
+              for (j = izero; j < n; j++)
+              {
+                // Perform alpha*B if alpha is not 1.
+                for (i = izero; i < m; i++)
+                {
+                  mask_assign(alpha_is_not_one, B[j * ldb + i]) *= alpha;
+                }
+                for (k = izero; k < j; k++)
+                {
+                  // If this entry is zero, we don't have to do anything.
+                  auto A_is_not_zero = (A[j * lda + k] != A_zero);
+                  for (i = izero; i < m; i++)
+                  {
+                    mask_assign(A_is_not_zero, B[j * ldb + i]) -= A[j * lda + k] * B[k * ldb + i];
+                  }
+                }
+                if (noUnit)
+                {
+                  temp = B_one / A[j * lda + j];
+                  for (i = izero; i < m; i++)
+                  {
+                    B[j * ldb + i] *= temp;
+                  }
+                }
+              }
+            }
+            else
+            { // A is lower triangular.
+              for (j = (n - ione); j > -ione; j--)
+              {
+                // Perform alpha*B if alpha is not 1.
+                for (i = izero; i < m; i++)
+                {
+                  mask_assign(alpha_is_not_one, B[j * ldb + i]) *= alpha;
+                }
+
+                // Perform a forward solve for column j of B.
+                for (k = j + ione; k < n; k++)
+                {
+                  // If this entry is zero, we don't have to do anything.
+                  auto A_is_not_zero = (A[j * lda + k] != A_zero);
+                  for (i = izero; i < m; i++)
+                  {
+                    mask_assign(A_is_not_zero, B[j * ldb + i]) -= A[j * lda + k] * B[k * ldb + i];
+                  }
+                }
+                if (noUnit)
+                {
+                  temp = B_one / A[j * lda + j];
+                  for (i = izero; i < m; i++)
+                  {
+                    B[j * ldb + i] *= temp;
+                  }
+                }
+              }
+            } // end if (uplo == 'U')
+          }   // if (transa =='N')
+          else
+          {
+            //
+            //  Compute B = alpha*B*inv( A' )
+            //  or      B = alpha*B*inv( conj(A') )
+            //
+            if (EUploChar[uplo] == 'U')
+            {
+              // A is upper triangular.
+              for (k = (n - ione); k > -ione; k--)
+              {
+                if (noUnit)
+                {
+                  if (noConj)
+                    temp = B_one / A[k * lda + k];
+                  else
+                    temp = B_one / ScalarTraits<A_type>::conjugate(A[k * lda + k]);
+                  for (i = izero; i < m; i++)
+                  {
+                    B[k * ldb + i] *= temp;
+                  }
+                }
+                for (j = izero; j < k; j++)
+                {
+                  auto A_is_not_zero = (A[k * lda + j] != A_zero);
+                  if (noConj)
+                    mask_assign(A_is_not_zero, temp) = A[k * lda + j];
+                  else
+                    mask_assign(A_is_not_zero, temp) = ScalarTraits<A_type>::conjugate(A[k * lda + j]);
+                  for (i = izero; i < m; i++)
+                  {
+                    mask_assign(A_is_not_zero, B[j * ldb + i]) -= temp * B[k * ldb + i];
+                  }
+                }
+                for (i = izero; i < m; i++)
+                {
+                  mask_assign(alpha_is_not_one, B[k * ldb + i]) *= alpha;
+                }
+              }
+            }
+            else
+            { // A is lower triangular.
+              for (k = izero; k < n; k++)
+              {
+                if (noUnit)
+                {
+                  if (noConj)
+                    temp = B_one / A[k * lda + k];
+                  else
+                    temp = B_one / ScalarTraits<A_type>::conjugate(A[k * lda + k]);
+                  for (i = izero; i < m; i++)
+                  {
+                    B[k * ldb + i] *= temp;
+                  }
+                }
+                for (j = k + ione; j < n; j++)
+                {
+                  auto A_is_not_zero = (A[k * lda + j] != A_zero);
+                  if (noConj)
+                    mask_assign(A_is_not_zero, temp) = A[k * lda + j];
+                  else
+                    mask_assign(A_is_not_zero, temp) = ScalarTraits<A_type>::conjugate(A[k * lda + j]);
+                  for (i = izero; i < m; i++)
+                  {
+                    mask_assign(A_is_not_zero, B[j * ldb + i]) -= temp * B[k * ldb + i];
+                  }
+                }
+                for (i = izero; i < m; i++)
+                {
+                  mask_assign(alpha_is_not_one, B[k * ldb + i]) *= alpha;
+                }
+              }
+            }
+          }
+        }
       }
-    };
-
-  } // namespace details
+    }
+  }
+}; // class BLAS
+//  }
+//}
 
 } // namespace Teuchos
 

--- a/packages/stokhos/src/sacado/kokkos/vector/belos/Belos_DGKS_OrthoManager_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/belos/Belos_DGKS_OrthoManager_MP_Vector.hpp
@@ -1,0 +1,1741 @@
+//@HEADER
+// ************************************************************************
+//
+//                 Belos: Block Linear Solvers Package
+//                  Copyright 2004 Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+
+
+/*!
+  \file Belos_DGKS_OrthoManager_MP_Vector.hpp
+  \brief Classical Gram-Schmidt (with DGKS correction) implementation of the Belos::OrthoManager class
+
+  Specialized for Sacado::MP::Vector scalar type to deal with lucky breakdown that can occur for one sample
+  but not for the others.
+*/
+
+#ifndef BELOS_DGKS_ORTHOMANAGER_MP_VECTOR_HPP
+#define BELOS_DGKS_ORTHOMANAGER_MP_VECTOR_HPP
+
+#include "Stokhos_Sacado_Kokkos_MP_Vector.hpp"
+#include "BelosDGKSOrthoManager.hpp"
+
+namespace Belos {
+
+  template<class Storage, class MV, class OP>
+  class DGKSOrthoManager<Sacado::MP::Vector<Storage>,MV,OP> :
+    public MatOrthoManager<Sacado::MP::Vector<Storage>,MV,OP>,
+    public Teuchos::ParameterListAcceptorDefaultBase
+  {
+  private:
+    typedef Sacado::MP::Vector<Storage> ScalarType;
+    typedef typename Teuchos::ScalarTraits<ScalarType>::magnitudeType MagnitudeType;
+    typedef typename Teuchos::ScalarTraits<MagnitudeType> MGT;
+    typedef Teuchos::ScalarTraits<ScalarType>  SCT;
+    typedef MultiVecTraits<ScalarType,MV>      MVT;
+    typedef OperatorTraits<ScalarType,MV,OP>   OPT;
+
+  public:
+    //! @name Constructor/Destructor
+    //@{
+
+    //! Constructor specifying re-orthogonalization tolerance.
+    DGKSOrthoManager( const std::string& label = "Belos",
+                      Teuchos::RCP<const OP> Op = Teuchos::null,
+                      const int max_blk_ortho = max_blk_ortho_default_,
+                      const MagnitudeType blk_tol = blk_tol_default_,
+                      const MagnitudeType dep_tol = dep_tol_default_,
+                      const MagnitudeType sing_tol = sing_tol_default_ )
+      : MatOrthoManager<ScalarType,MV,OP>(Op),
+        max_blk_ortho_( max_blk_ortho ),
+        blk_tol_( blk_tol ),
+        dep_tol_( dep_tol ),
+        sing_tol_( sing_tol ),
+        label_( label )
+    {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+      std::stringstream ss;
+      ss << label_ + ": DGKS[" << max_blk_ortho_ << "]";
+
+      std::string orthoLabel = ss.str() + ": Orthogonalization";
+      timerOrtho_ = Teuchos::TimeMonitor::getNewCounter(orthoLabel);
+
+      std::string updateLabel = ss.str() + ": Ortho (Update)";
+      timerUpdate_ = Teuchos::TimeMonitor::getNewCounter(updateLabel);
+
+      std::string normLabel = ss.str() + ": Ortho (Norm)";
+      timerNorm_ = Teuchos::TimeMonitor::getNewCounter(normLabel);
+
+      std::string ipLabel = ss.str() + ": Ortho (Inner Product)";
+      timerInnerProd_ = Teuchos::TimeMonitor::getNewCounter(ipLabel);
+#endif
+    }
+
+    //! Constructor that takes a list of parameters.
+    DGKSOrthoManager (const Teuchos::RCP<Teuchos::ParameterList>& plist,
+                      const std::string& label = "Belos",
+                      Teuchos::RCP<const OP> Op = Teuchos::null)
+      : MatOrthoManager<ScalarType,MV,OP>(Op),
+        max_blk_ortho_ ( max_blk_ortho_default_ ),
+        blk_tol_ ( blk_tol_default_ ),
+        dep_tol_ ( dep_tol_default_ ),
+        sing_tol_ ( sing_tol_default_ ),
+        label_( label )
+    {
+      setParameterList (plist);
+
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+      std::stringstream ss;
+      ss << label_ + ": DGKS[" << max_blk_ortho_ << "]";
+
+      std::string orthoLabel = ss.str() + ": Orthogonalization";
+      timerOrtho_ = Teuchos::TimeMonitor::getNewCounter(orthoLabel);
+
+      std::string updateLabel = ss.str() + ": Ortho (Update)";
+      timerUpdate_ = Teuchos::TimeMonitor::getNewCounter(updateLabel);
+
+      std::string normLabel = ss.str() + ": Ortho (Norm)";
+      timerNorm_ = Teuchos::TimeMonitor::getNewCounter(normLabel);
+
+      std::string ipLabel = ss.str() + ": Ortho (Inner Product)";
+      timerInnerProd_ = Teuchos::TimeMonitor::getNewCounter(ipLabel);
+#endif
+    }
+
+    //! Destructor
+    ~DGKSOrthoManager() {}
+    //@}
+
+    //! @name Implementation of Teuchos::ParameterListAcceptorDefaultBase interface
+    //@{
+
+    void
+    setParameterList (const Teuchos::RCP<Teuchos::ParameterList>& plist)
+    {
+      using Teuchos::ParameterList;
+      using Teuchos::parameterList;
+      using Teuchos::RCP;
+
+      RCP<const ParameterList> defaultParams = getValidParameters();
+      RCP<ParameterList> params;
+      if (plist.is_null()) {
+        // No need to validate default parameters.
+        params = parameterList (*defaultParams);
+      } else {
+        params = plist;
+        params->validateParametersAndSetDefaults (*defaultParams);
+      }
+
+      // Using temporary variables and fetching all values before
+      // setting the output arguments ensures the strong exception
+      // guarantee for this function: if an exception is thrown, no
+      // externally visible side effects (in this case, setting the
+      // output arguments) have taken place.
+      const int maxNumOrthogPasses = params->get<int> ("maxNumOrthogPasses");
+      const MagnitudeType blkTol = params->get<MagnitudeType> ("blkTol");
+      const MagnitudeType depTol = params->get<MagnitudeType> ("depTol");
+      const MagnitudeType singTol = params->get<MagnitudeType> ("singTol");
+
+      max_blk_ortho_ = maxNumOrthogPasses;
+      blk_tol_ = blkTol;
+      dep_tol_ = depTol;
+      sing_tol_ = singTol;
+
+      setMyParamList (params);
+    }
+
+    Teuchos::RCP<const Teuchos::ParameterList>
+    getValidParameters () const
+    {
+      if (defaultParams_.is_null()) {
+        defaultParams_ = Belos::getDGKSDefaultParameters<ScalarType, MV, OP>();
+      }
+
+      return defaultParams_;
+    }
+
+    //@}
+
+    //! @name Accessor routines
+    //@{
+
+    //! Set parameter for block re-orthogonalization threshhold.
+    void setBlkTol( const MagnitudeType blk_tol ) {
+      // Update the parameter list as well.
+      Teuchos::RCP<Teuchos::ParameterList> params = getNonconstParameterList();
+      if (! params.is_null()) {
+        // If it's null, then we haven't called setParameterList()
+        // yet.  It's entirely possible to construct the parameter
+        // list on demand, so we don't try to create the parameter
+        // list here.
+        params->set ("blkTol", blk_tol);
+      }
+      blk_tol_ = blk_tol;
+    }
+
+    //! Set parameter for re-orthogonalization threshhold.
+    void setDepTol( const MagnitudeType dep_tol ) {
+      // Update the parameter list as well.
+      Teuchos::RCP<Teuchos::ParameterList> params = getNonconstParameterList();
+      if (! params.is_null()) {
+        params->set ("depTol", dep_tol);
+      }
+      dep_tol_ = dep_tol;
+    }
+
+    //! Set parameter for singular block detection.
+    void setSingTol( const MagnitudeType sing_tol ) {
+      // Update the parameter list as well.
+      Teuchos::RCP<Teuchos::ParameterList> params = getNonconstParameterList();
+      if (! params.is_null()) {
+        params->set ("singTol", sing_tol);
+      }
+      sing_tol_ = sing_tol;
+    }
+
+    //! Return parameter for block re-orthogonalization threshhold.
+    MagnitudeType getBlkTol() const { return blk_tol_; }
+
+    //! Return parameter for re-orthogonalization threshhold.
+    MagnitudeType getDepTol() const { return dep_tol_; }
+
+    //! Return parameter for singular block detection.
+    MagnitudeType getSingTol() const { return sing_tol_; }
+
+    //@}
+
+
+    //! @name Orthogonalization methods
+    //@{
+
+    /*! \brief Given a list of (mutually and internally) orthonormal bases \c Q, this method
+     * takes a multivector \c X and projects it onto the space orthogonal to the individual <tt>Q[i]</tt>,
+     * optionally returning the coefficients of \c X for the individual <tt>Q[i]</tt>. All of this is done with respect
+     * to the inner product innerProd().
+     *
+     * After calling this routine, \c X will be orthogonal to each of the \c <tt>Q[i]</tt>.
+     *
+     * The method uses either one or two steps of classical Gram-Schmidt. The algebraically
+     * equivalent projection matrix is \f$P_Q = I - Q Q^H Op\f$, if \c Op is the matrix specified for
+     * use in the inner product. Note, this is not an orthogonal projector.
+     *
+     @param X [in/out] The multivector to be modified.
+       On output, \c X will be orthogonal to <tt>Q[i]</tt> with respect to innerProd().
+
+     @param MX [in/out] The image of \c X under the operator \c Op.
+       If \f$ MX != 0\f$: On input, this is expected to be consistent with \c X. On output, this is updated consistent with updates to \c X.
+       If \f$ MX == 0\f$ or \f$ Op == 0\f$: \c MX is not referenced.
+
+     @param C [out] The coefficients of \c X in the \c *Q[i], with respect to innerProd(). If <tt>C[i]</tt> is a non-null pointer
+       and \c *C[i] matches the dimensions of \c X and \c *Q[i], then the coefficients computed during the orthogonalization
+       routine will be stored in the matrix \c *C[i]. If <tt>C[i]</tt> is a non-null pointer whose size does not match the dimensions of
+       \c X and \c *Q[i], then a std::invalid_argument std::exception will be thrown. Otherwise, if <tt>C.size() < i</tt> or <tt>C[i]</tt> is a null
+       pointer, then the orthogonalization manager will declare storage for the coefficients and the user will not have access to them.
+
+     @param Q [in] A list of multivector bases specifying the subspaces to be orthogonalized against. Each <tt>Q[i]</tt> is assumed to have
+     orthonormal columns, and the <tt>Q[i]</tt> are assumed to be mutually orthogonal.
+    */
+    void project ( MV &X, Teuchos::RCP<MV> MX,
+                   Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
+                   Teuchos::ArrayView<Teuchos::RCP<const MV> > Q) const;
+
+
+    /*! \brief This method calls project(X,Teuchos::null,C,Q); see documentation for that function.
+    */
+    void project ( MV &X,
+                   Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
+                   Teuchos::ArrayView<Teuchos::RCP<const MV> > Q) const {
+      project(X,Teuchos::null,C,Q);
+    }
+
+
+
+    /*! \brief This method takes a multivector \c X and attempts to compute an orthonormal basis for \f$colspan(X)\f$, with respect to innerProd().
+     *
+     * The method uses classical Gram-Schmidt, so that the coefficient matrix \c B is upper triangular.
+     *
+     * This routine returns an integer \c rank stating the rank of the computed basis. If \c X does not have full rank and the normalize() routine does
+     * not attempt to augment the subspace, then \c rank may be smaller than the number of columns in \c X. In this case, only the first \c rank columns of
+     * output \c X and first \c rank rows of \c B will be valid.
+     *
+     * The method attempts to find a basis with dimension the same as the number of columns in \c X. It does this by augmenting linearly dependant
+     * vectors in \c X with random directions. A finite number of these attempts will be made; therefore, it is possible that the dimension of the
+     * computed basis is less than the number of vectors in \c X.
+     *
+     @param X [in/out] The multivector to the modified.
+       On output, \c X will have some number of orthonormal columns (with respect to innerProd()).
+
+     @param MX [in/out] The image of \c X under the operator \c Op.
+       If \f$ MX != 0\f$: On input, this is expected to be consistent with \c X. On output, this is updated consistent with updates to \c X.
+       If \f$ MX == 0\f$ or \f$ Op == 0\f$: \c MX is not referenced.
+
+     @param B [out] The coefficients of the original \c X with respect to the computed basis. The first rows in \c B
+            corresponding to the valid columns in \c X will be upper triangular.
+
+     @return Rank of the basis computed by this method.
+    */
+    int normalize ( MV &X, Teuchos::RCP<MV> MX,
+                    Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > B) const;
+
+
+    /*! \brief This method calls normalize(X,Teuchos::null,B); see documentation for that function.
+    */
+    int normalize ( MV &X, Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > B ) const {
+      return normalize(X,Teuchos::null,B);
+    }
+
+  protected:
+
+    /*! \brief Given a set of bases <tt>Q[i]</tt> and a multivector \c X, this method computes an orthonormal basis for \f$colspan(X) - \sum_i colspan(Q[i])\f$.
+     *
+     *  This routine returns an integer \c rank stating the rank of
+     *  the computed basis. If the subspace \f$colspan(X) - \sum_i
+     *  colspan(Q[i])\f$ does not have dimension as large as the
+     *  number of columns of \c X and the orthogonalization manager
+     *  doe not attempt to augment the subspace, then \c rank may be
+     *  smaller than the number of columns of \c X. In this case, only
+     *  the first \c rank columns of output \c X and first \c rank
+     *  rows of \c B will be valid.
+     *
+     * The method attempts to find a basis with dimension the same as
+     * the number of columns in \c X. It does this by augmenting
+     * linearly dependant vectors with random directions. A finite
+     * number of these attempts will be made; therefore, it is
+     * possible that the dimension of the computed basis is less than
+     * the number of vectors in \c X.
+     *
+     @param X [in/out] The multivector to the modified.  On output,
+       the relevant rows of \c X will be orthogonal to the
+       <tt>Q[i]</tt> and will have orthonormal columns (with respect
+       to innerProd()).
+
+     @param MX [in/out] The image of \c X under the operator \c Op.
+       If \f$ MX != 0\f$: On input, this is expected to be consistent
+       with \c X. On output, this is updated consistent with updates
+       to \c X.  If \f$ MX == 0\f$ or \f$ Op == 0\f$: \c MX is not
+       referenced.
+
+     @param C [out] The coefficients of the original \c X in the \c
+     *Q[i], with respect to innerProd(). If <tt>C[i]</tt> is a
+     non-null pointer and \c *C[i] matches the dimensions of \c X and
+     \c *Q[i], then the coefficients computed during the
+     orthogonalization routine will be stored in the matrix \c
+     *C[i]. If <tt>C[i]</tt> is a non-null pointer whose size does not
+     match the dimensions of \c X and \c *Q[i], then *C[i] will first
+     be resized to the correct size.  This will destroy the original
+     contents of the matrix.  (This is a change from previous
+     behavior, in which a std::invalid_argument exception was thrown
+     if *C[i] was of the wrong size.)  Otherwise, if <tt>C.size() <
+     i<\tt> or <tt>C[i]</tt> is a null pointer, then the
+     orthogonalization manager will declare storage for the
+     coefficients and the user will not have access to them.
+
+     @param B [out] The coefficients of the original \c X with respect
+       to the computed basis. The first rows in \c B corresponding to
+       the valid columns in \c X will be upper triangular.
+
+     @param Q [in] A list of multivector bases specifying the
+       subspaces to be orthogonalized against. Each <tt>Q[i]</tt> is
+       assumed to have orthonormal columns, and the <tt>Q[i]</tt> are
+       assumed to be mutually orthogonal.
+
+     @return Rank of the basis computed by this method.
+    */
+    virtual int
+    projectAndNormalizeWithMxImpl (MV &X,
+                                   Teuchos::RCP<MV> MX,
+                                   Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
+                                   Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > B,
+                                   Teuchos::ArrayView<Teuchos::RCP<const MV> > Q) const;
+
+  public:
+    //@}
+    //! @name Error methods
+    //@{
+
+    /// \brief Compute \fn$\| X^* M X - I \|_F\fn$
+    ///
+    /// This method computes the error in orthonormality of a
+    /// multivector, measured as the Frobenius norm of the difference
+    /// <tt>innerProd(X,X) - I</tt>.
+    typename Teuchos::ScalarTraits<ScalarType>::magnitudeType
+    orthonormError(const MV &X) const {
+      return orthonormError(X,Teuchos::null);
+    }
+
+    /// \brief Compute \fn$\| X^* M X - I \|_F\fn$
+    ///
+    /// This method computes the error in orthonormality of a
+    /// multivector, measured as the Frobenius norm of the difference
+    /// <tt>innerProd(X,X) - I</tt>.  The method has the option of
+    /// exploiting a caller-provided \c MX, which is used if not null.
+    typename Teuchos::ScalarTraits<ScalarType>::magnitudeType
+    orthonormError(const MV &X, Teuchos::RCP<const MV> MX) const;
+
+    /*! \brief This method computes the error in orthogonality of two multivectors, measured
+     * as the Frobenius norm of <tt>innerProd(X,Y)</tt>.
+     */
+    typename Teuchos::ScalarTraits<ScalarType>::magnitudeType
+    orthogError(const MV &X1, const MV &X2) const {
+      return orthogError(X1,Teuchos::null,X2);
+    }
+
+    /*! \brief This method computes the error in orthogonality of two multivectors, measured
+     * as the Frobenius norm of <tt>innerProd(X,Y)</tt>.
+     *  The method has the option of exploiting a caller-provided \c MX.
+     */
+    typename Teuchos::ScalarTraits<ScalarType>::magnitudeType
+    orthogError(const MV &X1, Teuchos::RCP<const MV> MX1, const MV &X2) const;
+
+    //@}
+
+    //! @name Label methods
+    //@{
+
+    /*! \brief This method sets the label used by the timers in the orthogonalization manager.
+     */
+    void setLabel(const std::string& label);
+
+    /*! \brief This method returns the label being used by the timers in the orthogonalization manager.
+     */
+    const std::string& getLabel() const { return label_; }
+
+    //@}
+
+    //! @name Default orthogonalization constants
+    //@{
+
+    //! Max number of (re)orthogonalization steps, including the first (default).
+    static const int max_blk_ortho_default_;
+    //! Block reorthogonalization threshold (default).
+    static const MagnitudeType blk_tol_default_;
+    //! (Non-block) reorthogonalization threshold (default).
+    static const MagnitudeType dep_tol_default_;
+    //! Singular block detection threshold (default).
+    static const MagnitudeType sing_tol_default_;
+
+    //! Max number of (re)orthogonalization steps, including the first (fast).
+    static const int max_blk_ortho_fast_;
+    //! Block reorthogonalization threshold (fast).
+    static const MagnitudeType blk_tol_fast_;
+    //! (Non-block) reorthogonalization threshold (fast).
+    static const MagnitudeType dep_tol_fast_;
+    //! Singular block detection threshold (fast).
+    static const MagnitudeType sing_tol_fast_;
+
+    //@}
+
+  private:
+
+    //! Max number of (re)orthogonalization steps, including the first.
+    int max_blk_ortho_;
+    //! Block reorthogonalization threshold.
+    MagnitudeType blk_tol_;
+    //! (Non-block) reorthogonalization threshold.
+    MagnitudeType dep_tol_;
+    //! Singular block detection threshold.
+    MagnitudeType sing_tol_;
+
+    //! Label for timer(s).
+    std::string label_;
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+    Teuchos::RCP<Teuchos::Time> timerOrtho_, timerUpdate_, timerNorm_, timerInnerProd_;
+#endif // BELOS_TEUCHOS_TIME_MONITOR
+
+    //! Default parameter list.
+    mutable Teuchos::RCP<Teuchos::ParameterList> defaultParams_;
+
+    //! Routine to find an orthonormal basis for X
+    int findBasis(MV &X, Teuchos::RCP<MV> MX,
+                  Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > C,
+                  bool completeBasis, int howMany = -1 ) const;
+
+    //! Routine to compute the block orthogonalization
+    bool blkOrtho1 ( MV &X, Teuchos::RCP<MV> MX,
+                    Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
+                    Teuchos::ArrayView<Teuchos::RCP<const MV> > Q) const;
+
+    //! Routine to compute the block orthogonalization
+    bool blkOrtho ( MV &X, Teuchos::RCP<MV> MX,
+                    Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
+                    Teuchos::ArrayView<Teuchos::RCP<const MV> > Q) const;
+
+    /// Project X against QQ and normalize X, one vector at a time
+    ///
+    /// \note QQ is called QQ, rather than Q, because we convert it
+    ///   internally from an ArrayView to an Array (named Q inside).
+    ///   This is because the C++ compiler doesn't know how to do type
+    ///   inference (Array has a constructor that takes an ArrayView
+    ///   input).  This routine wants an Array rather than an
+    ///   ArrayView internally, because it likes to add (via
+    ///   push_back()) and remove (via resize()) elements to the Q
+    ///   array.  Remember that Arrays can be passed by value, just
+    ///   like std::vector objects, so this routine can add whatever
+    ///   it likes to the Q array without changing it from the
+    ///   caller's perspective.
+    int blkOrthoSing ( MV &X, Teuchos::RCP<MV> MX,
+                       Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
+                       Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > B,
+                       Teuchos::ArrayView<Teuchos::RCP<const MV> > QQ) const;
+  };  
+
+  // Set static variables.
+  template<class StorageType, class MV, class OP>
+  const int DGKSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::max_blk_ortho_default_ = 2;
+
+  template<class StorageType, class MV, class OP>
+  const typename DGKSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::MagnitudeType
+  DGKSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::blk_tol_default_
+    = 10*Teuchos::ScalarTraits<typename DGKSOrthoManager<ScalarType,MV,OP>::MagnitudeType>::squareroot(
+      Teuchos::ScalarTraits<typename DGKSOrthoManager<ScalarType,MV,OP>::MagnitudeType>::eps() );
+
+  template<class StorageType, class MV, class OP>
+  const typename DGKSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::MagnitudeType
+  DGKSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::dep_tol_default_ 
+    = Teuchos::ScalarTraits<typename DGKSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::MagnitudeType>::one()
+      / Teuchos::ScalarTraits<typename DGKSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::MagnitudeType>::squareroot( 
+      2*Teuchos::ScalarTraits<typename DGKSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::MagnitudeType>::one() );
+
+  template<class StorageType, class MV, class OP>
+  const typename DGKSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::MagnitudeType
+  DGKSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::sing_tol_default_ 
+    = 10*Teuchos::ScalarTraits<typename DGKSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::MagnitudeType>::eps();
+
+  template<class StorageType, class MV, class OP>
+  const int DGKSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::max_blk_ortho_fast_ = 1;
+
+  template<class StorageType, class MV, class OP>
+  const typename DGKSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::MagnitudeType
+  DGKSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::blk_tol_fast_
+    = Teuchos::ScalarTraits<typename DGKSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::MagnitudeType>::zero();
+
+  template<class StorageType, class MV, class OP>
+  const typename DGKSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::MagnitudeType
+  DGKSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::dep_tol_fast_
+    = Teuchos::ScalarTraits<typename DGKSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::MagnitudeType>::zero();
+
+  template<class StorageType, class MV, class OP>
+  const typename DGKSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::MagnitudeType
+  DGKSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::sing_tol_fast_
+    = Teuchos::ScalarTraits<typename DGKSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::MagnitudeType>::zero();
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  // Set the label for this orthogonalization manager and create new timers if it's changed
+  template<class StorageType, class MV, class OP>
+  void DGKSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::setLabel(const std::string& label)
+  {
+    if (label != label_) {
+      label_ = label;
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+      std::stringstream ss;
+      ss << label_ + ": DGKS[" << max_blk_ortho_ << "]";
+
+      std::string orthoLabel = ss.str() + ": Orthogonalization";
+      timerOrtho_ = Teuchos::TimeMonitor::getNewCounter(orthoLabel);
+
+      std::string updateLabel = ss.str() + ": Ortho (Update)";
+      timerUpdate_ = Teuchos::TimeMonitor::getNewCounter(updateLabel);
+
+      std::string normLabel = ss.str() + ": Ortho (Norm)";
+      timerNorm_ = Teuchos::TimeMonitor::getNewCounter(normLabel);
+
+      std::string ipLabel = ss.str() + ": Ortho (Inner Product)";
+      timerInnerProd_ = Teuchos::TimeMonitor::getNewCounter(ipLabel);
+#endif
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  // Compute the distance from orthonormality
+  template<class StorageType, class MV, class OP>
+  typename Teuchos::ScalarTraits<Sacado::MP::Vector<StorageType> >::magnitudeType
+  DGKSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::orthonormError(const MV &X, Teuchos::RCP<const MV> MX) const {
+    const ScalarType ONE = SCT::one();
+    int rank = MVT::GetNumberVecs(X);
+    Teuchos::SerialDenseMatrix<int,ScalarType> xTx(rank,rank);
+    {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+    Teuchos::TimeMonitor innerProdTimer( *timerInnerProd_ );
+#endif
+    MatOrthoManager<ScalarType,MV,OP>::innerProd(X,X,MX,xTx);
+    }
+    for (int i=0; i<rank; i++) {
+      xTx(i,i) -= ONE;
+    }
+    return xTx.normFrobenius();
+  }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  // Compute the distance from orthogonality
+  template<class StorageType, class MV, class OP>
+  typename Teuchos::ScalarTraits<Sacado::MP::Vector<StorageType> >::magnitudeType
+  DGKSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::orthogError(const MV &X1, Teuchos::RCP<const MV> MX1, const MV &X2) const {
+    int r1 = MVT::GetNumberVecs(X1);
+    int r2  = MVT::GetNumberVecs(X2);
+    Teuchos::SerialDenseMatrix<int,ScalarType> xTx(r2,r1);
+    {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+    Teuchos::TimeMonitor innerProdTimer( *timerInnerProd_ );
+#endif
+    MatOrthoManager<ScalarType,MV,OP>::innerProd(X2,X1,MX1,xTx);
+    }
+    return xTx.normFrobenius();
+  }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  // Find an Op-orthonormal basis for span(X) - span(W)
+  template<class StorageType, class MV, class OP>
+  int
+  DGKSOrthoManager<Sacado::MP::Vector<StorageType>, MV, OP>::
+  projectAndNormalizeWithMxImpl (MV &X,
+                                 Teuchos::RCP<MV> MX,
+                                 Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
+                                 Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > B,
+                                 Teuchos::ArrayView<Teuchos::RCP<const MV> > Q) const
+  {
+    using Teuchos::Array;
+    using Teuchos::null;
+    using Teuchos::is_null;
+    using Teuchos::RCP;
+    using Teuchos::rcp;
+    using Teuchos::SerialDenseMatrix;
+    typedef SerialDenseMatrix< int, ScalarType > serial_dense_matrix_type;
+    typedef typename Array< RCP< const MV > >::size_type size_type;
+
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+    Teuchos::TimeMonitor orthotimer(*timerOrtho_);
+#endif
+
+    ScalarType    ONE  = SCT::one();
+    const MagnitudeType ZERO = SCT::magnitude(SCT::zero());
+
+    int nq = Q.size();
+    int xc = MVT::GetNumberVecs( X );
+    ptrdiff_t xr = MVT::GetGlobalLength( X );
+    int rank = xc;
+
+    // If the user doesn't want to store the normalization
+    // coefficients, allocate some local memory for them.  This will
+    // go away at the end of this method.
+    if (is_null (B)) {
+      B = rcp (new serial_dense_matrix_type (xc, xc));
+    }
+    // Likewise, if the user doesn't want to store the projection
+    // coefficients, allocate some local memory for them.  Also make
+    // sure that all the entries of C are the right size.  We're going
+    // to overwrite them anyway, so we don't have to worry about the
+    // contents (other than to resize them if they are the wrong
+    // size).
+    if (C.size() < nq)
+      C.resize (nq);
+    for (size_type k = 0; k < nq; ++k)
+      {
+        const int numRows = MVT::GetNumberVecs (*Q[k]);
+        const int numCols = xc; // Number of vectors in X
+
+        if (is_null (C[k]))
+          C[k] = rcp (new serial_dense_matrix_type (numRows, numCols));
+        else if (C[k]->numRows() != numRows || C[k]->numCols() != numCols)
+          {
+            int err = C[k]->reshape (numRows, numCols);
+            TEUCHOS_TEST_FOR_EXCEPTION(err != 0, std::runtime_error,
+                               "DGKS orthogonalization: failed to reshape "
+                               "C[" << k << "] (the array of block "
+                               "coefficients resulting from projecting X "
+                               "against Q[1:" << nq << "]).");
+          }
+      }
+
+    /******   DO NO MODIFY *MX IF _hasOp == false   ******/
+    if (this->_hasOp) {
+      if (MX == Teuchos::null) {
+        // we need to allocate space for MX
+        MX = MVT::Clone(X,MVT::GetNumberVecs(X));
+        OPT::Apply(*(this->_Op),X,*MX);
+      }
+    }
+    else {
+      // Op == I  -->  MX = X (ignore it if the user passed it in)
+      MX = Teuchos::rcp( &X, false );
+    }
+
+    int mxc = MVT::GetNumberVecs( *MX );
+    ptrdiff_t mxr = MVT::GetGlobalLength( *MX );
+
+    // short-circuit
+    TEUCHOS_TEST_FOR_EXCEPTION( xc == 0 || xr == 0, std::invalid_argument, "Belos::DGKSOrthoManager::projectAndNormalize(): X must be non-empty" );
+
+    int numbas = 0;
+    for (int i=0; i<nq; i++) {
+      numbas += MVT::GetNumberVecs( *Q[i] );
+    }
+
+    // check size of B
+    TEUCHOS_TEST_FOR_EXCEPTION( B->numRows() != xc || B->numCols() != xc, std::invalid_argument,
+                        "Belos::DGKSOrthoManager::projectAndNormalize(): Size of X must be consistant with size of B" );
+    // check size of X and MX
+    TEUCHOS_TEST_FOR_EXCEPTION( xc<0 || xr<0 || mxc<0 || mxr<0, std::invalid_argument,
+                        "Belos::DGKSOrthoManager::projectAndNormalize(): MVT returned negative dimensions for X,MX" );
+    // check size of X w.r.t. MX
+    TEUCHOS_TEST_FOR_EXCEPTION( xc!=mxc || xr!=mxr, std::invalid_argument,
+                        "Belos::DGKSOrthoManager::projectAndNormalize(): Size of X must be consistant with size of MX" );
+    // check feasibility
+    //TEUCHOS_TEST_FOR_EXCEPTION( numbas+xc > xr, std::invalid_argument,
+    //                    "Belos::DGKSOrthoManager::projectAndNormalize(): Orthogonality constraints not feasible" );
+
+    // Some flags for checking dependency returns from the internal orthogonalization methods
+    bool dep_flg = false;
+
+    if (xc == 1) {
+      // Use the cheaper block orthogonalization.
+      // NOTE: Don't check for dependencies because the update has one vector.
+      dep_flg = blkOrtho1( X, MX, C, Q );
+      // Normalize the new block X
+      if ( B == Teuchos::null ) {
+        B = Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>(xc,xc) );
+      }
+      std::vector<ScalarType> diag(1);
+      {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+        Teuchos::TimeMonitor normTimer( *timerNorm_ );
+#endif
+        MVT::MvDot( X, *MX, diag );
+      }
+
+      (*B)(0,0) = SCT::squareroot(SCT::magnitude(diag[0]));
+        
+      ScalarType scale = ONE;
+      mask_assign((*B)(0,0)!= ZERO, scale) /= (*B)(0,0);
+
+      if(MaskLogic::OR((*B)(0,0)!= ZERO) )
+        rank = 1;
+      MVT::MvScale( X, scale );
+      if (this->_hasOp) {
+        // Update MXj.
+        MVT::MvScale( *MX, scale );
+      }
+    }
+    else {
+      // Make a temporary copy of X and MX, just in case a block dependency is detected.
+      Teuchos::RCP<MV> tmpX, tmpMX;
+      tmpX = MVT::CloneCopy(X);
+      if (this->_hasOp) {
+        tmpMX = MVT::CloneCopy(*MX);
+      }
+      // Use the cheaper block orthogonalization.
+      dep_flg = blkOrtho( X, MX, C, Q );
+
+      // If a dependency has been detected in this block, then perform
+      // the more expensive single-vector orthogonalization.
+      if (dep_flg) {
+        rank = blkOrthoSing( *tmpX, tmpMX, C, B, Q );
+        // Copy tmpX back into X.
+        MVT::Assign( *tmpX, X );
+        if (this->_hasOp) {
+          MVT::Assign( *tmpMX, *MX );
+        }
+      }
+      else {
+        // There is no dependency, so orthonormalize new block X
+        rank = findBasis( X, MX, B, false );
+        if (rank < xc) {
+          // A dependency was found during orthonormalization of X,
+          // rerun orthogonalization using more expensive single-vector orthogonalization.
+          rank = blkOrthoSing( *tmpX, tmpMX, C, B, Q );
+          // Copy tmpX back into X.
+          MVT::Assign( *tmpX, X );
+          if (this->_hasOp) {
+            MVT::Assign( *tmpMX, *MX );
+          }
+        }
+      }
+    } // if (xc == 1)
+
+    // this should not raise an std::exception; but our post-conditions oblige us to check
+    TEUCHOS_TEST_FOR_EXCEPTION( rank > xc || rank < 0, std::logic_error,
+                        "Belos::DGKSOrthoManager::projectAndNormalize(): Debug error in rank variable." );
+
+    // Return the rank of X.
+    return rank;
+  }
+
+
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  // Find an Op-orthonormal basis for span(X), with rank numvectors(X)
+  template<class StorageType, class MV, class OP>
+  int DGKSOrthoManager<Sacado::MP::Vector<StorageType>, MV, OP>::normalize(
+                                MV &X, Teuchos::RCP<MV> MX,
+                                Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > B ) const {
+
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+    Teuchos::TimeMonitor orthotimer(*timerOrtho_);
+#endif
+    // call findBasis, with the instruction to try to generate a basis of rank numvecs(X)
+    return findBasis(X, MX, B, true);
+    
+  }
+
+
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  template<class StorageType, class MV, class OP>
+  void DGKSOrthoManager<Sacado::MP::Vector<StorageType>, MV, OP>::project(
+                          MV &X, Teuchos::RCP<MV> MX,
+                          Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
+                          Teuchos::ArrayView<Teuchos::RCP<const MV> > Q) const {
+    // For the inner product defined by the operator Op or the identity (Op == 0)
+    //   -> Orthogonalize X against each Q[i]
+    // Modify MX accordingly
+    //
+    // Note that when Op is 0, MX is not referenced
+    //
+    // Parameter variables
+    //
+    // X  : Vectors to be transformed
+    //
+    // MX : Image of the block vector X by the mass matrix
+    //
+    // Q  : Bases to orthogonalize against. These are assumed orthonormal, mutually and independently.
+    //
+
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+    Teuchos::TimeMonitor orthotimer(*timerOrtho_);
+#endif
+
+    int xc = MVT::GetNumberVecs( X );
+    ptrdiff_t xr = MVT::GetGlobalLength( X );
+    int nq = Q.size();
+    std::vector<int> qcs(nq);
+    // short-circuit
+    if (nq == 0 || xc == 0 || xr == 0) {
+      return;
+    }
+    ptrdiff_t qr = MVT::GetGlobalLength ( *Q[0] );
+    // if we don't have enough C, expand it with null references
+    // if we have too many, resize to throw away the latter ones
+    // if we have exactly as many as we have Q, this call has no effect
+    C.resize(nq);
+
+
+    /******   DO NO MODIFY *MX IF _hasOp == false   ******/
+    if (this->_hasOp) {
+      if (MX == Teuchos::null) {
+        // we need to allocate space for MX
+        MX = MVT::Clone(X,MVT::GetNumberVecs(X));
+        OPT::Apply(*(this->_Op),X,*MX);
+      }
+    }
+    else {
+      // Op == I  -->  MX = X (ignore it if the user passed it in)
+      MX = Teuchos::rcp( &X, false );
+    }
+    int mxc = MVT::GetNumberVecs( *MX );
+    ptrdiff_t mxr = MVT::GetGlobalLength( *MX );
+
+    // check size of X and Q w.r.t. common sense
+    TEUCHOS_TEST_FOR_EXCEPTION( xc<0 || xr<0 || mxc<0 || mxr<0, std::invalid_argument,
+                        "Belos::DGKSOrthoManager::project(): MVT returned negative dimensions for X,MX" );
+    // check size of X w.r.t. MX and Q
+    TEUCHOS_TEST_FOR_EXCEPTION( xc!=mxc || xr!=mxr || xr!=qr, std::invalid_argument,
+                        "Belos::DGKSOrthoManager::project(): Size of X not consistant with MX,Q" );
+
+    // tally up size of all Q and check/allocate C
+    int baslen = 0;
+    for (int i=0; i<nq; i++) {
+      TEUCHOS_TEST_FOR_EXCEPTION( MVT::GetGlobalLength( *Q[i] ) != qr, std::invalid_argument,
+                          "Belos::DGKSOrthoManager::project(): Q lengths not mutually consistant" );
+      qcs[i] = MVT::GetNumberVecs( *Q[i] );
+      TEUCHOS_TEST_FOR_EXCEPTION( qr < qcs[i], std::invalid_argument,
+                          "Belos::DGKSOrthoManager::project(): Q has less rows than columns" );
+      baslen += qcs[i];
+
+      // check size of C[i]
+      if ( C[i] == Teuchos::null ) {
+        C[i] = Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>(qcs[i],xc) );
+      }
+      else {
+        TEUCHOS_TEST_FOR_EXCEPTION( C[i]->numRows() != qcs[i] || C[i]->numCols() != xc , std::invalid_argument,
+                           "Belos::DGKSOrthoManager::project(): Size of Q not consistant with size of C" );
+      }
+    }
+
+    // Use the cheaper block orthogonalization, don't check for rank deficiency.
+    blkOrtho( X, MX, C, Q );
+
+  }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  // Find an Op-orthonormal basis for span(X), with the option of extending the subspace so that
+  // the rank is numvectors(X)
+  template<class StorageType, class MV, class OP>
+  int DGKSOrthoManager<Sacado::MP::Vector<StorageType>, MV, OP>::findBasis(
+                                                      MV &X, Teuchos::RCP<MV> MX,
+                                                      Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > B,
+                                                      bool completeBasis, int howMany ) const {
+    // For the inner product defined by the operator Op or the identity (Op == 0)
+    //   -> Orthonormalize X
+    // Modify MX accordingly
+    //
+    // Note that when Op is 0, MX is not referenced
+    //
+    // Parameter variables
+    //
+    // X  : Vectors to be orthonormalized
+    //
+    // MX : Image of the multivector X under the operator Op
+    //
+    // Op  : Pointer to the operator for the inner product
+    //
+    //
+
+    const ScalarType ONE  = SCT::one();
+    const MagnitudeType ZERO = SCT::magnitude(SCT::zero());
+
+    int xc = MVT::GetNumberVecs( X );
+    ptrdiff_t xr = MVT::GetGlobalLength( X );
+
+    if (howMany == -1) {
+      howMany = xc;
+    }
+
+    /*******************************************************
+     *  If _hasOp == false, we will not reference MX below *
+     *******************************************************/
+
+    // if Op==null, MX == X (via pointer)
+    // Otherwise, either the user passed in MX or we will allocated and compute it
+    if (this->_hasOp) {
+      if (MX == Teuchos::null) {
+        // we need to allocate space for MX
+        MX = MVT::Clone(X,xc);
+        OPT::Apply(*(this->_Op),X,*MX);
+      }
+    }
+
+    /* if the user doesn't want to store the coefficienets,
+     * allocate some local memory for them
+     */
+    if ( B == Teuchos::null ) {
+      B = Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>(xc,xc) );
+    }
+
+    int mxc = (this->_hasOp) ? MVT::GetNumberVecs( *MX ) : xc;
+    ptrdiff_t mxr = (this->_hasOp) ? MVT::GetGlobalLength( *MX ) : xr;
+
+    // check size of C, B
+    TEUCHOS_TEST_FOR_EXCEPTION( xc == 0 || xr == 0, std::invalid_argument,
+                        "Belos::DGKSOrthoManager::findBasis(): X must be non-empty" );
+    TEUCHOS_TEST_FOR_EXCEPTION( B->numRows() != xc || B->numCols() != xc, std::invalid_argument,
+                        "Belos::DGKSOrthoManager::findBasis(): Size of X not consistant with size of B" );
+    TEUCHOS_TEST_FOR_EXCEPTION( xc != mxc || xr != mxr, std::invalid_argument,
+                        "Belos::DGKSOrthoManager::findBasis(): Size of X not consistant with size of MX" );
+    TEUCHOS_TEST_FOR_EXCEPTION( static_cast<ptrdiff_t>(xc) > xr, std::invalid_argument,
+                        "Belos::DGKSOrthoManager::findBasis(): Size of X not feasible for normalization" );
+    TEUCHOS_TEST_FOR_EXCEPTION( howMany < 0 || howMany > xc, std::invalid_argument,
+                        "Belos::DGKSOrthoManager::findBasis(): Invalid howMany parameter" );
+
+    /* xstart is which column we are starting the process with, based on howMany
+     * columns before xstart are assumed to be Op-orthonormal already
+     */
+    int xstart = xc - howMany;
+
+    for (int j = xstart; j < xc; j++) {
+
+      // numX is
+      // * number of currently orthonormal columns of X
+      // * the index of the current column of X
+      int numX = j;
+      bool addVec = false;
+
+      // Get a view of the vector currently being worked on.
+      std::vector<int> index(1);
+      index[0] = numX;
+      Teuchos::RCP<MV> Xj = MVT::CloneViewNonConst( X, index );
+      Teuchos::RCP<MV> MXj;
+      if ((this->_hasOp)) {
+        // MXj is a view of the current vector in MX
+        MXj = MVT::CloneViewNonConst( *MX, index );
+      }
+      else {
+        // MXj is a pointer to Xj, and MUST NOT be modified
+        MXj = Xj;
+      }
+
+      // Get a view of the previous vectors.
+      std::vector<int> prev_idx( numX );
+      Teuchos::RCP<const MV> prevX, prevMX;
+      Teuchos::RCP<MV> oldMXj;
+
+      if (numX > 0) {
+        for (int i=0; i<numX; i++) {
+          prev_idx[i] = i;
+        }
+        prevX = MVT::CloneView( X, prev_idx );
+        if (this->_hasOp) {
+          prevMX = MVT::CloneView( *MX, prev_idx );
+        }
+
+        oldMXj = MVT::CloneCopy( *MXj );
+      }
+
+      // Make storage for these Gram-Schmidt iterations.
+      Teuchos::SerialDenseMatrix<int,ScalarType> product(numX, 1);
+      std::vector<ScalarType> oldDot( 1 ), newDot( 1 );
+      //
+      // Save old MXj vector and compute Op-norm
+      //
+      {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+      Teuchos::TimeMonitor normTimer( *timerNorm_ );
+#endif
+      MVT::MvDot( *Xj, *MXj, oldDot );
+      }
+      // Xj^H Op Xj should be real and positive, by the hermitian positive definiteness of Op
+      TEUCHOS_TEST_FOR_EXCEPTION( SCT::real(oldDot[0]) < ZERO, OrthoError,
+                          "Belos::DGKSOrthoManager::findBasis(): Negative definiteness discovered in inner product" );
+      if (numX > 0) {
+        // Apply the first step of Gram-Schmidt
+
+        // product <- prevX^T MXj
+        {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+        Teuchos::TimeMonitor innerProdTimer( *timerInnerProd_ );
+#endif
+        MatOrthoManager<ScalarType,MV,OP>::innerProd(*prevX,*Xj,MXj,product);
+        }
+        // Xj <- Xj - prevX prevX^T MXj
+        //     = Xj - prevX product
+        {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+        Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+        MVT::MvTimesMatAddMv( -ONE, *prevX, product, ONE, *Xj );
+        }
+
+        // Update MXj
+        if (this->_hasOp) {
+          // MXj <- Op*Xj_new
+          //      = Op*(Xj_old - prevX prevX^T MXj)
+          //      = MXj - prevMX product
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+          Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+          MVT::MvTimesMatAddMv( -ONE, *prevMX, product, ONE, *MXj );
+        }
+
+        // Compute new Op-norm
+        {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+        Teuchos::TimeMonitor normTimer( *timerNorm_ );
+#endif
+        MVT::MvDot( *Xj, *MXj, newDot );
+        }
+
+        // Check if a correction is needed.
+        if ( MGT::squareroot(SCT::magnitude(newDot[0])) < dep_tol_*MGT::squareroot(SCT::magnitude(oldDot[0])) ) {
+          // Apply the second step of Gram-Schmidt
+          // This is the same as above
+          Teuchos::SerialDenseMatrix<int,ScalarType> P2(numX,1);
+          {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+          Teuchos::TimeMonitor innerProdTimer( *timerInnerProd_ );
+#endif
+          MatOrthoManager<ScalarType,MV,OP>::innerProd(*prevX,*Xj,MXj,P2);
+          }
+          product += P2;
+ 
+          {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+          Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+          MVT::MvTimesMatAddMv( -ONE, *prevX, P2, ONE, *Xj );
+          }
+          if ((this->_hasOp)) {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+            Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+            MVT::MvTimesMatAddMv( -ONE, *prevMX, P2, ONE, *MXj );
+          }
+        } // if (newDot[0] < dep_tol_*oldDot[0])
+
+      } // if (numX > 0)
+
+      // Compute Op-norm with old MXj
+      if (numX > 0) {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+        Teuchos::TimeMonitor normTimer( *timerNorm_ );
+#endif
+        MVT::MvDot( *Xj, *oldMXj, newDot );
+      }
+      else {
+        newDot[0] = oldDot[0];
+      }
+
+      // Check to see if the new vector is dependent.
+      if (completeBasis) {
+        //
+        // We need a complete basis, so add random vectors if necessary
+        //
+        if ( SCT::magnitude(newDot[0]) < SCT::magnitude(sing_tol_*oldDot[0]) ) {
+
+          // Add a random vector and orthogonalize it against previous vectors in block.
+          addVec = true;
+#ifdef ORTHO_DEBUG
+          std::cout << "Belos::DGKSOrthoManager::findBasis() --> Random for column " << numX << std::endl;
+#endif
+          //
+          Teuchos::RCP<MV> tempXj = MVT::Clone( X, 1 );
+          Teuchos::RCP<MV> tempMXj;
+          MVT::MvRandom( *tempXj );
+          if (this->_hasOp) {
+            tempMXj = MVT::Clone( X, 1 );
+            OPT::Apply( *(this->_Op), *tempXj, *tempMXj );
+          }
+          else {
+            tempMXj = tempXj;
+          }
+          {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+          Teuchos::TimeMonitor normTimer( *timerNorm_ );
+#endif
+          MVT::MvDot( *tempXj, *tempMXj, oldDot );
+          }
+          //
+          for (int num_orth=0; num_orth<max_blk_ortho_; num_orth++){
+            {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+            Teuchos::TimeMonitor innerProdTimer( *timerInnerProd_ );
+#endif
+            MatOrthoManager<ScalarType,MV,OP>::innerProd(*prevX,*tempXj,tempMXj,product);
+            }
+            {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+            Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+            MVT::MvTimesMatAddMv( -ONE, *prevX, product, ONE, *tempXj );
+            }
+            if (this->_hasOp) {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+              Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+              MVT::MvTimesMatAddMv( -ONE, *prevMX, product, ONE, *tempMXj );
+            }
+          }
+          // Compute new Op-norm
+          {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+          Teuchos::TimeMonitor normTimer( *timerNorm_ );
+#endif
+          MVT::MvDot( *tempXj, *tempMXj, newDot );
+          }
+          //
+          if ( SCT::magnitude(newDot[0]) >= SCT::magnitude(oldDot[0]*sing_tol_) ) {
+            // Copy vector into current column of _basisvecs
+            MVT::Assign( *tempXj, *Xj );
+            if (this->_hasOp) {
+              MVT::Assign( *tempMXj, *MXj );
+            }
+          }
+          else {
+            return numX;
+          }
+        }
+      }
+      else {
+        //
+        // We only need to detect dependencies.
+        //
+        if ( SCT::magnitude(newDot[0]) < SCT::magnitude(oldDot[0]*blk_tol_) ) {
+          return numX;
+        }
+      }
+      // If we haven't left this method yet, then we can normalize the new vector Xj.
+      // Normalize Xj.
+      // Xj <- Xj / std::sqrt(newDot)
+      ScalarType diag = SCT::squareroot(SCT::magnitude(newDot[0]));
+      ScalarType scale = ONE;
+      mask_assign(SCT::magnitude(diag) > ZERO, scale) /= diag;
+      MVT::MvScale( *Xj, scale );
+      if (this->_hasOp) {
+        // Update MXj.
+        MVT::MvScale( *MXj, scale );
+      }
+
+      // If we've added a random vector, enter a zero in the j'th diagonal element.
+      if (addVec) {
+        (*B)(j,j) = ZERO;
+      }
+      else {
+        (*B)(j,j) = diag;
+      }
+
+      // Save the coefficients, if we are working on the original vector and not a randomly generated one
+      if (!addVec) {
+        for (int i=0; i<numX; i++) {
+          (*B)(i,j) = product(i,0);
+        }
+      }
+    } // for (j = 0; j < xc; ++j)
+
+    return xc;
+  }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  // Routine to compute the block orthogonalization
+  template<class StorageType, class MV, class OP>
+  bool
+  DGKSOrthoManager<Sacado::MP::Vector<StorageType>, MV, OP>::blkOrtho1 ( MV &X, Teuchos::RCP<MV> MX,
+                                                   Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
+                                                   Teuchos::ArrayView<Teuchos::RCP<const MV> > Q) const
+  {
+    int nq = Q.size();
+    int xc = MVT::GetNumberVecs( X );
+    const ScalarType ONE  = SCT::one();
+
+    std::vector<int> qcs( nq );
+    for (int i=0; i<nq; i++) {
+      qcs[i] = MVT::GetNumberVecs( *Q[i] );
+    }
+
+    // Compute the initial Op-norms
+    std::vector<ScalarType> oldDot( 1 ), newDot( 1 );
+    {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+    Teuchos::TimeMonitor normTimer( *timerNorm_ );
+#endif
+    MVT::MvDot( X, *MX, oldDot );
+    }
+
+    Teuchos::Array<Teuchos::RCP<MV> > MQ(nq);
+    // Define the product Q^T * (Op*X)
+    for (int i=0; i<nq; i++) {
+      // Multiply Q' with MX
+      {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+      Teuchos::TimeMonitor innerProdTimer( *timerInnerProd_ );
+#endif
+      MatOrthoManager<ScalarType,MV,OP>::innerProd(*Q[i],X,MX,*C[i]);
+      }
+      // Multiply by Q and subtract the result in X
+      {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+      Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+      MVT::MvTimesMatAddMv( -ONE, *Q[i], *C[i], ONE, X );
+      }
+
+      // Update MX, with the least number of applications of Op as possible
+      if (this->_hasOp) {
+        if (xc <= qcs[i]) {
+          OPT::Apply( *(this->_Op), X, *MX);
+        }
+        else {
+          // this will possibly be used again below; don't delete it
+          MQ[i] = MVT::Clone( *Q[i], qcs[i] );
+          OPT::Apply( *(this->_Op), *Q[i], *MQ[i] );
+          {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+          Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+          MVT::MvTimesMatAddMv( -ONE, *MQ[i], *C[i], ONE, *MX );
+          }
+        }
+      }
+    }
+    {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+    Teuchos::TimeMonitor normTimer( *timerNorm_ );
+#endif
+    MVT::MvDot( X, *MX, newDot );
+    }
+/*  // Compute correction bound, compare with PETSc bound.
+    MagnitudeType hnrm = C[0]->normFrobenius();
+    for (int i=1; i<nq; i++)
+    {
+      hnrm += C[i]->normFrobenius();
+    }
+
+    std::cout << "newDot < 1/sqrt(2)*oldDot < hnrm = " << MGT::squareroot(SCT::magnitude(newDot[0])) << " < " << dep_tol_*MGT::squareroot(SCT::magnitude(oldDot[0])) << " < " << hnrm << std::endl;
+*/
+
+    // Check if a correction is needed.
+    if ( MGT::squareroot(SCT::magnitude(newDot[0])) < dep_tol_*MGT::squareroot(SCT::magnitude(oldDot[0])) ) {
+    // Apply the second step of Gram-Schmidt
+
+      for (int i=0; i<nq; i++) {
+        Teuchos::SerialDenseMatrix<int,ScalarType> C2(C[i]->numRows(), C[i]->numCols());
+
+        // Apply another step of classical Gram-Schmidt
+        {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+        Teuchos::TimeMonitor innerProdTimer( *timerInnerProd_ );
+#endif
+        MatOrthoManager<ScalarType,MV,OP>::innerProd(*Q[i],X,MX,C2);
+        }
+        *C[i] += C2;
+
+        {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+        Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+        MVT::MvTimesMatAddMv( -ONE, *Q[i], C2, ONE, X );
+        }
+
+        // Update MX, with the least number of applications of Op as possible
+        if (this->_hasOp) {
+          if (MQ[i].get()) {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+            Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+            // MQ was allocated and computed above; use it
+            MVT::MvTimesMatAddMv( -ONE, *MQ[i], C2, ONE, *MX );
+          }
+          else if (xc <= qcs[i]) {
+            // MQ was not allocated and computed above; it was cheaper to use X before and it still is
+            OPT::Apply( *(this->_Op), X, *MX);
+          }
+        }
+      } // for (int i=0; i<nq; i++)
+    }
+    return false;
+  }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  // Routine to compute the block orthogonalization
+  template<class StorageType, class MV, class OP>
+  bool
+  DGKSOrthoManager<Sacado::MP::Vector<StorageType>, MV, OP>::blkOrtho ( MV &X, Teuchos::RCP<MV> MX,
+                                                   Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
+                                                   Teuchos::ArrayView<Teuchos::RCP<const MV> > Q) const
+  {
+    int nq = Q.size();
+    int xc = MVT::GetNumberVecs( X );
+    bool dep_flg = false;
+    const ScalarType ONE  = SCT::one();
+
+    std::vector<int> qcs( nq );
+    for (int i=0; i<nq; i++) {
+      qcs[i] = MVT::GetNumberVecs( *Q[i] );
+    }
+
+    // Perform the Gram-Schmidt transformation for a block of vectors
+
+    // Compute the initial Op-norms
+    std::vector<ScalarType> oldDot( xc );
+    {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+    Teuchos::TimeMonitor normTimer( *timerNorm_ );
+#endif
+    MVT::MvDot( X, *MX, oldDot );
+    }
+
+    Teuchos::Array<Teuchos::RCP<MV> > MQ(nq);
+    // Define the product Q^T * (Op*X)
+    for (int i=0; i<nq; i++) {
+      // Multiply Q' with MX
+      {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+      Teuchos::TimeMonitor innerProdTimer( *timerInnerProd_ );
+#endif
+      MatOrthoManager<ScalarType,MV,OP>::innerProd(*Q[i],X,MX,*C[i]);
+      }
+      // Multiply by Q and subtract the result in X
+      {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+      Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+      MVT::MvTimesMatAddMv( -ONE, *Q[i], *C[i], ONE, X );
+      }
+
+      // Update MX, with the least number of applications of Op as possible
+      if (this->_hasOp) {
+        if (xc <= qcs[i]) {
+          OPT::Apply( *(this->_Op), X, *MX);
+        }
+        else {
+          // this will possibly be used again below; don't delete it
+          MQ[i] = MVT::Clone( *Q[i], qcs[i] );
+          OPT::Apply( *(this->_Op), *Q[i], *MQ[i] );
+          {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+          Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+          MVT::MvTimesMatAddMv( -ONE, *MQ[i], *C[i], ONE, *MX );
+          }
+        }
+      }
+    }
+
+    // Do as many steps of classical Gram-Schmidt as required by max_blk_ortho_
+    for (int j = 1; j < max_blk_ortho_; ++j) {
+
+      for (int i=0; i<nq; i++) {
+        Teuchos::SerialDenseMatrix<int,ScalarType> C2(C[i]->numRows(), C[i]->numCols());
+
+        // Apply another step of classical Gram-Schmidt
+        {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+        Teuchos::TimeMonitor innerProdTimer( *timerInnerProd_ );
+#endif
+        MatOrthoManager<ScalarType,MV,OP>::innerProd(*Q[i],X,MX,C2);
+        }
+        *C[i] += C2;
+
+        {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+        Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+        MVT::MvTimesMatAddMv( -ONE, *Q[i], C2, ONE, X );
+        }
+
+        // Update MX, with the least number of applications of Op as possible
+        if (this->_hasOp) {
+          if (MQ[i].get()) {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+            Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+            // MQ was allocated and computed above; use it
+            MVT::MvTimesMatAddMv( -ONE, *MQ[i], C2, ONE, *MX );
+          }
+          else if (xc <= qcs[i]) {
+            // MQ was not allocated and computed above; it was cheaper to use X before and it still is
+            OPT::Apply( *(this->_Op), X, *MX);
+          }
+        }
+      } // for (int i=0; i<nq; i++)
+    } // for (int j = 0; j < max_blk_ortho; ++j)
+
+    // Compute new Op-norms
+    std::vector<ScalarType> newDot(xc);
+    {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+    Teuchos::TimeMonitor normTimer( *timerNorm_ );
+#endif
+    MVT::MvDot( X, *MX, newDot );
+    }
+
+    // Check to make sure the new block of vectors are not dependent on previous vectors
+    for (int i=0; i<xc; i++){
+      if (SCT::magnitude(newDot[i]) < SCT::magnitude(oldDot[i] * blk_tol_)) {
+        dep_flg = true;
+        break;
+      }
+    } // end for (i=0;...)
+
+    return dep_flg;
+  }
+
+
+  template<class StorageType, class MV, class OP>
+  int
+  DGKSOrthoManager<Sacado::MP::Vector<StorageType>, MV, OP>::blkOrthoSing ( MV &X, Teuchos::RCP<MV> MX,
+                                                       Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
+                                                       Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > B,
+                                                       Teuchos::ArrayView<Teuchos::RCP<const MV> > QQ) const
+  {
+    Teuchos::Array<Teuchos::RCP<const MV> > Q (QQ);
+
+    const ScalarType ONE  = SCT::one();
+    const ScalarType ZERO  = SCT::zero();
+
+    int nq = Q.size();
+    int xc = MVT::GetNumberVecs( X );
+    std::vector<int> indX( 1 );
+    std::vector<ScalarType> oldDot( 1 ), newDot( 1 );
+
+    std::vector<int> qcs( nq );
+    for (int i=0; i<nq; i++) {
+      qcs[i] = MVT::GetNumberVecs( *Q[i] );
+    }
+
+    // Create pointers for the previous vectors of X that have already been orthonormalized.
+    Teuchos::RCP<const MV> lastQ;
+    Teuchos::RCP<MV> Xj, MXj;
+    Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > lastC;
+
+    // Perform the Gram-Schmidt transformation for each vector in the block of vectors.
+    for (int j=0; j<xc; j++) {
+
+      bool dep_flg = false;
+
+      // Get a view of the previously orthogonalized vectors and B, add it to the arrays.
+      if (j > 0) {
+        std::vector<int> index( j );
+        for (int ind=0; ind<j; ind++) {
+          index[ind] = ind;
+        }
+        lastQ = MVT::CloneView( X, index );
+
+        // Add these views to the Q and C arrays.
+        Q.push_back( lastQ );
+        C.push_back( B );
+        qcs.push_back( MVT::GetNumberVecs( *lastQ ) );
+      }
+
+      // Get a view of the current vector in X to orthogonalize.
+      indX[0] = j;
+      Xj = MVT::CloneViewNonConst( X, indX );
+      if (this->_hasOp) {
+        MXj = MVT::CloneViewNonConst( *MX, indX );
+      }
+      else {
+        MXj = Xj;
+      }
+
+      // Compute the initial Op-norms
+      {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+      Teuchos::TimeMonitor normTimer( *timerNorm_ );
+#endif
+      MVT::MvDot( *Xj, *MXj, oldDot );
+      }
+
+      Teuchos::Array<Teuchos::RCP<MV> > MQ(Q.size());
+      // Define the product Q^T * (Op*X)
+      for (int i=0; i<Q.size(); i++) {
+
+        // Get a view of the current serial dense matrix
+        Teuchos::SerialDenseMatrix<int,ScalarType> tempC( Teuchos::View, *C[i], qcs[i], 1, 0, j );
+
+        // Multiply Q' with MX
+        {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+        Teuchos::TimeMonitor innerProdTimer( *timerInnerProd_ );
+#endif
+        MatOrthoManager<ScalarType,MV,OP>::innerProd(*Q[i],*Xj,MXj,tempC);
+        }
+        // Multiply by Q and subtract the result in Xj
+        {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+        Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+        MVT::MvTimesMatAddMv( -ONE, *Q[i], tempC, ONE, *Xj );
+        }
+
+        // Update MXj, with the least number of applications of Op as possible
+        if (this->_hasOp) {
+          if (xc <= qcs[i]) {
+            OPT::Apply( *(this->_Op), *Xj, *MXj);
+          }
+          else {
+            // this will possibly be used again below; don't delete it
+            MQ[i] = MVT::Clone( *Q[i], qcs[i] );
+            OPT::Apply( *(this->_Op), *Q[i], *MQ[i] );
+            {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+            Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+            MVT::MvTimesMatAddMv( -ONE, *MQ[i], tempC, ONE, *MXj );
+            }
+          }
+        }
+      }
+
+      // Compute the Op-norms
+      {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+      Teuchos::TimeMonitor normTimer( *timerNorm_ );
+#endif
+      MVT::MvDot( *Xj, *MXj, newDot );
+      }
+
+      // Do one step of classical Gram-Schmidt orthogonalization
+      // with a second correction step if needed.
+
+      if ( SCT::magnitude(newDot[0]) < SCT::magnitude(oldDot[0]*dep_tol_) ) {
+
+        for (int i=0; i<Q.size(); i++) {
+          Teuchos::SerialDenseMatrix<int,ScalarType> tempC( Teuchos::View, *C[i], qcs[i], 1, 0, j );
+          Teuchos::SerialDenseMatrix<int,ScalarType> C2( qcs[i], 1 );
+
+          // Apply another step of classical Gram-Schmidt
+          {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+          Teuchos::TimeMonitor innerProdTimer( *timerInnerProd_ );
+#endif
+          MatOrthoManager<ScalarType,MV,OP>::innerProd(*Q[i],*Xj,MXj,C2);
+          }
+          tempC += C2;
+          {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+          Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+          MVT::MvTimesMatAddMv( -ONE, *Q[i], C2, ONE, *Xj );
+          }
+
+          // Update MXj, with the least number of applications of Op as possible
+          if (this->_hasOp) {
+            if (MQ[i].get()) {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+              Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+              // MQ was allocated and computed above; use it
+              MVT::MvTimesMatAddMv( -ONE, *MQ[i], C2, ONE, *MXj );
+            }
+            else if (xc <= qcs[i]) {
+              // MQ was not allocated and computed above; it was cheaper to use X before and it still is
+              OPT::Apply( *(this->_Op), *Xj, *MXj);
+            }
+          }
+        } // for (int i=0; i<Q.size(); i++)
+
+        // Compute the Op-norms after the correction step.
+        {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+        Teuchos::TimeMonitor normTimer( *timerNorm_ );
+#endif
+        MVT::MvDot( *Xj, *MXj, newDot );
+        }
+      } // if ()
+
+      // Check for linear dependence.
+      if (SCT::magnitude(newDot[0]) < SCT::magnitude(oldDot[0]*sing_tol_)) {
+        dep_flg = true;
+      }
+
+      // Normalize the new vector if it's not dependent
+      if (!dep_flg) {
+        ScalarType diag = SCT::squareroot(SCT::magnitude(newDot[0]));
+
+        MVT::MvScale( *Xj, ONE/diag );
+        if (this->_hasOp) {
+          // Update MXj.
+          MVT::MvScale( *MXj, ONE/diag );
+        }
+
+        // Enter value on diagonal of B.
+        (*B)(j,j) = diag;
+      }
+      else {
+        // Create a random vector and orthogonalize it against all previous columns of Q.
+        Teuchos::RCP<MV> tempXj = MVT::Clone( X, 1 );
+        Teuchos::RCP<MV> tempMXj;
+        MVT::MvRandom( *tempXj );
+        if (this->_hasOp) {
+          tempMXj = MVT::Clone( X, 1 );
+          OPT::Apply( *(this->_Op), *tempXj, *tempMXj );
+        }
+        else {
+          tempMXj = tempXj;
+        }
+        {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+        Teuchos::TimeMonitor normTimer( *timerNorm_ );
+#endif
+        MVT::MvDot( *tempXj, *tempMXj, oldDot );
+        }
+        //
+        for (int num_orth=0; num_orth<max_blk_ortho_; num_orth++) {
+
+          for (int i=0; i<Q.size(); i++) {
+            Teuchos::SerialDenseMatrix<int,ScalarType> product( qcs[i], 1 );
+
+            // Apply another step of classical Gram-Schmidt
+            {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+            Teuchos::TimeMonitor innerProdTimer( *timerInnerProd_ );
+#endif
+            MatOrthoManager<ScalarType,MV,OP>::innerProd(*Q[i],*tempXj,tempMXj,product);
+            }
+            {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+            Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+            MVT::MvTimesMatAddMv( -ONE, *Q[i], product, ONE, *tempXj );
+            }
+
+            // Update MXj, with the least number of applications of Op as possible
+            if (this->_hasOp) {
+              if (MQ[i].get()) {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+                Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+                // MQ was allocated and computed above; use it
+                MVT::MvTimesMatAddMv( -ONE, *MQ[i], product, ONE, *tempMXj );
+              }
+              else if (xc <= qcs[i]) {
+                // MQ was not allocated and computed above; it was cheaper to use X before and it still is
+                OPT::Apply( *(this->_Op), *tempXj, *tempMXj);
+              }
+            }
+          } // for (int i=0; i<nq; i++)
+
+        }
+
+        // Compute the Op-norms after the correction step.
+        {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+        Teuchos::TimeMonitor normTimer( *timerNorm_ );
+#endif
+        MVT::MvDot( *tempXj, *tempMXj, newDot );
+        }
+
+        // Copy vector into current column of Xj
+        if ( SCT::magnitude(newDot[0]) >= SCT::magnitude(oldDot[0]*sing_tol_) ) {
+          ScalarType diag = SCT::squareroot(SCT::magnitude(newDot[0]));
+
+          // Enter value on diagonal of B.
+          (*B)(j,j) = ZERO;
+
+          // Copy vector into current column of _basisvecs
+          MVT::MvAddMv( ONE/diag, *tempXj, ZERO, *tempXj, *Xj );
+          if (this->_hasOp) {
+            MVT::MvAddMv( ONE/diag, *tempMXj, ZERO, *tempMXj, *MXj );
+          }
+        }
+        else {
+          return j;
+        }
+      } // if (!dep_flg)
+
+      // Remove the vectors from array
+      if (j > 0) {
+        Q.resize( nq );
+        C.resize( nq );
+        qcs.resize( nq );
+      }
+
+    } // for (int j=0; j<xc; j++)
+
+    return xc;
+  }
+
+} // namespace Belos
+
+#endif // BELOS_DGKS_ORTHOMANAGER_MP_VECTOR_HPP
+

--- a/packages/stokhos/src/sacado/kokkos/vector/belos/Belos_ICGS_OrthoManager_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/belos/Belos_ICGS_OrthoManager_MP_Vector.hpp
@@ -1,0 +1,1688 @@
+//@HEADER
+// ************************************************************************
+//
+//                 Belos: Block Linear Solvers Package
+//                  Copyright 2004 Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+
+
+/*! 
+  \file Belos_ICGS_OrthoManager_MP_Vector.hpp
+  \brief Iterated Classical Gram-Schmidt (ICGS) implementation of the Belos::OrthoManager class
+    
+  Specialized for Sacado::MP::Vector scalar type to deal with lucky breakdown that can occur for one sample
+  but not for the others.
+*/
+
+#ifndef BELOS_ICGS_ORTHOMANAGER_MP_VECTOR_HPP
+#define BELOS_ICGS_ORTHOMANAGER_MP_VECTOR_HPP
+
+#include "Stokhos_Sacado_Kokkos_MP_Vector.hpp"
+#include "BelosICGSOrthoManager.hpp"
+
+namespace Belos {
+
+  template<class Storage, class MV, class OP>
+  class ICGSOrthoManager<Sacado::MP::Vector<Storage>,MV,OP> :
+    public MatOrthoManager<Sacado::MP::Vector<Storage>,MV,OP>,
+    public Teuchos::ParameterListAcceptorDefaultBase
+  {
+  private:
+    typedef Sacado::MP::Vector<Storage> ScalarType;
+    typedef typename Teuchos::ScalarTraits<ScalarType>::magnitudeType MagnitudeType;
+    typedef typename Teuchos::ScalarTraits<MagnitudeType> MGT;
+    typedef Teuchos::ScalarTraits<ScalarType>  SCT;
+    typedef MultiVecTraits<ScalarType,MV>      MVT;
+    typedef OperatorTraits<ScalarType,MV,OP>   OPT;
+
+  public:
+    //! @name Constructor/Destructor
+    //@{
+
+    //! Constructor specifying re-orthogonalization tolerance.
+    ICGSOrthoManager( const std::string& label = "Belos",
+                      Teuchos::RCP<const OP> Op = Teuchos::null,
+                      const int max_ortho_steps = max_ortho_steps_default_,
+                      const MagnitudeType blk_tol = blk_tol_default_,
+                      const MagnitudeType sing_tol = sing_tol_default_ )
+      : MatOrthoManager<ScalarType,MV,OP>(Op),
+      max_ortho_steps_( max_ortho_steps ),
+      blk_tol_( blk_tol ),
+      sing_tol_( sing_tol ),
+      label_( label )
+    {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+      std::stringstream ss;
+      ss << label_ + ": ICGS[" << max_ortho_steps_ << "]";
+
+      std::string orthoLabel = ss.str() + ": Orthogonalization";
+      timerOrtho_ = Teuchos::TimeMonitor::getNewCounter(orthoLabel);
+
+      std::string updateLabel = ss.str() + ": Ortho (Update)";
+      timerUpdate_ = Teuchos::TimeMonitor::getNewCounter(updateLabel);
+
+      std::string normLabel = ss.str() + ": Ortho (Norm)";
+      timerNorm_ = Teuchos::TimeMonitor::getNewCounter(normLabel);
+
+      std::string ipLabel = ss.str() + ": Ortho (Inner Product)";
+      timerInnerProd_ = Teuchos::TimeMonitor::getNewCounter(ipLabel);
+#endif
+    }
+
+    //! Constructor that takes a list of parameters.
+    ICGSOrthoManager (const Teuchos::RCP<Teuchos::ParameterList>& plist,
+                      const std::string& label = "Belos",
+                      Teuchos::RCP<const OP> Op = Teuchos::null) :
+      MatOrthoManager<ScalarType,MV,OP>(Op),
+      max_ortho_steps_ (max_ortho_steps_default_),
+      blk_tol_ (blk_tol_default_),
+      sing_tol_ (sing_tol_default_),
+      label_ (label)
+    {
+      setParameterList (plist);
+
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+      std::stringstream ss;
+      ss << label_ + ": ICGS[" << max_ortho_steps_ << "]";
+
+      std::string orthoLabel = ss.str() + ": Orthogonalization";
+      timerOrtho_ = Teuchos::TimeMonitor::getNewCounter(orthoLabel);
+
+      std::string updateLabel = ss.str() + ": Ortho (Update)";
+      timerUpdate_ = Teuchos::TimeMonitor::getNewCounter(updateLabel);
+
+      std::string normLabel = ss.str() + ": Ortho (Norm)";
+      timerNorm_ = Teuchos::TimeMonitor::getNewCounter(normLabel);
+
+      std::string ipLabel = ss.str() + ": Ortho (Inner Product)";
+      timerInnerProd_ = Teuchos::TimeMonitor::getNewCounter(ipLabel);
+#endif
+    }
+
+    //! Destructor
+    ~ICGSOrthoManager() {}
+    //@}
+
+    //! @name Implementation of Teuchos::ParameterListAcceptorDefaultBase interface
+    //@{
+
+    void
+    setParameterList (const Teuchos::RCP<Teuchos::ParameterList>& plist)
+    {
+      using Teuchos::Exceptions::InvalidParameterName;
+      using Teuchos::ParameterList;
+      using Teuchos::parameterList;
+      using Teuchos::RCP;
+
+      RCP<const ParameterList> defaultParams = getValidParameters();
+      RCP<ParameterList> params;
+      if (plist.is_null()) {
+        params = parameterList (*defaultParams);
+      } else {
+        params = plist;
+        // Some users might want to specify "blkTol" as "depTol".  Due
+        // to this case, we don't invoke
+        // validateParametersAndSetDefaults on params.  Instead, we go
+        // through the parameter list one parameter at a time and look
+        // for alternatives.
+      }
+
+      // Using temporary variables and fetching all values before
+      // setting the output arguments ensures the strong exception
+      // guarantee for this function: if an exception is thrown, no
+      // externally visible side effects (in this case, setting the
+      // output arguments) have taken place.
+      int maxNumOrthogPasses;
+      MagnitudeType blkTol;
+      MagnitudeType singTol;
+
+      try {
+        maxNumOrthogPasses = params->get<int> ("maxNumOrthogPasses");
+      } catch (InvalidParameterName&) {
+        maxNumOrthogPasses = defaultParams->get<int> ("maxNumOrthogPasses");
+        params->set ("maxNumOrthogPasses", maxNumOrthogPasses);
+      }
+
+      // Handling of the "blkTol" parameter is a special case.  This
+      // is because some users may prefer to call this parameter
+      // "depTol" for consistency with DGKS.  However, our default
+      // parameter list calls this "blkTol", and we don't want the
+      // default list's value to override the user's value.  Thus, we
+      // first check the user's parameter list for both names, and
+      // only then access the default parameter list.
+      try {
+        blkTol = params->get<MagnitudeType> ("blkTol");
+      } catch (InvalidParameterName&) {
+        try {
+          blkTol = params->get<MagnitudeType> ("depTol");
+          // "depTol" is the wrong name, so remove it and replace with
+          // "blkTol".  We'll set "blkTol" below.
+          params->remove ("depTol");
+        } catch (InvalidParameterName&) {
+          blkTol = defaultParams->get<MagnitudeType> ("blkTol");
+        }
+        params->set ("blkTol", blkTol);
+      }
+
+      try {
+        singTol = params->get<MagnitudeType> ("singTol");
+      } catch (InvalidParameterName&) {
+        singTol = defaultParams->get<MagnitudeType> ("singTol");
+        params->set ("singTol", singTol);
+      }
+
+      max_ortho_steps_ = maxNumOrthogPasses;
+      blk_tol_ = blkTol;
+      sing_tol_ = singTol;
+
+      setMyParamList (params);
+    }
+
+    Teuchos::RCP<const Teuchos::ParameterList>
+    getValidParameters () const
+    {
+      if (defaultParams_.is_null()) {
+        defaultParams_ = Belos::getICGSDefaultParameters<ScalarType, MV, OP>();
+      }
+
+      return defaultParams_;
+    }
+
+    //@}
+
+    /// \brief "Fast" but possibly unsafe or less accurate parameters.
+    ///
+    /// Use this parameter list when you care more about speed than
+    /// accuracy of the orthogonalization.
+    Teuchos::RCP<const Teuchos::ParameterList>
+    getFastParameters () const
+    {
+      using Teuchos::as;
+      using Teuchos::ParameterList;
+      using Teuchos::parameterList;
+      using Teuchos::RCP;
+
+      RCP<const ParameterList> defaultParams = getValidParameters ();
+      // Start with a clone of the default parameters.
+      RCP<ParameterList> params = parameterList (*defaultParams);
+
+      params->set ("maxNumOrthogPasses", max_ortho_steps_fast_);
+      params->set ("blkTol", blk_tol_fast_);
+      params->set ("singTol", sing_tol_fast_);
+
+      return params;
+    }
+
+    //! @name Accessor routines
+    //@{
+
+    //! Set parameter for block re-orthogonalization threshhold.
+    void setBlkTol( const MagnitudeType blk_tol ) {
+      // Update the parameter list as well.
+      Teuchos::RCP<Teuchos::ParameterList> params = getNonconstParameterList();
+      if (! params.is_null()) {
+        // If it's null, then we haven't called setParameterList()
+        // yet.  It's entirely possible to construct the parameter
+        // list on demand, so we don't try to create the parameter
+        // list here.
+        params->set ("blkTol", blk_tol);
+      }
+      blk_tol_ = blk_tol;
+    }
+
+    //! Set parameter for singular block detection.
+    void setSingTol( const MagnitudeType sing_tol ) {
+      // Update the parameter list as well.
+      Teuchos::RCP<Teuchos::ParameterList> params = getNonconstParameterList();
+      if (! params.is_null()) {
+        // If it's null, then we haven't called setParameterList()
+        // yet.  It's entirely possible to construct the parameter
+        // list on demand, so we don't try to create the parameter
+        // list here.
+        params->set ("singTol", sing_tol);
+      }
+      sing_tol_ = sing_tol;
+    }
+
+    //! Return parameter for block re-orthogonalization threshhold.
+    MagnitudeType getBlkTol() const { return blk_tol_; }
+
+    //! Return parameter for singular block detection.
+    MagnitudeType getSingTol() const { return sing_tol_; }
+
+    //@}
+
+
+    //! @name Orthogonalization methods
+    //@{
+
+    /*! \brief Given a list of (mutually and internally) orthonormal bases \c Q, this method
+     * takes a multivector \c X and projects it onto the space orthogonal to the individual <tt>Q[i]</tt>,
+     * optionally returning the coefficients of \c X for the individual <tt>Q[i]</tt>. All of this is done with respect
+     * to the inner product innerProd().
+     *
+     * After calling this routine, \c X will be orthogonal to each of the \c <tt>Q[i]</tt>.
+     *
+     * The method uses either one or two steps of classical Gram-Schmidt. The algebraically
+     * equivalent projection matrix is \f$P_Q = I - Q Q^H Op\f$, if \c Op is the matrix specified for
+     * use in the inner product. Note, this is not an orthogonal projector.
+     *
+     @param X [in/out] The multivector to be modified.
+       On output, \c X will be orthogonal to <tt>Q[i]</tt> with respect to innerProd().
+
+     @param MX [in/out] The image of \c X under the operator \c Op.
+       If \f$ MX != 0\f$: On input, this is expected to be consistent with \c X. On output, this is updated consistent with updates to \c X.
+       If \f$ MX == 0\f$ or \f$ Op == 0\f$: \c MX is not referenced.
+
+     @param C [out] The coefficients of \c X in the \c *Q[i], with respect to innerProd(). If <tt>C[i]</tt> is a non-null pointer
+       and \c *C[i] matches the dimensions of \c X and \c *Q[i], then the coefficients computed during the orthogonalization
+       routine will be stored in the matrix \c *C[i]. If <tt>C[i]</tt> is a non-null pointer whose size does not match the dimensions of
+       \c X and \c *Q[i], then a std::invalid_argument std::exception will be thrown. Otherwise, if <tt>C.size() < i</tt> or <tt>C[i]</tt> is a null
+       pointer, then the orthogonalization manager will declare storage for the coefficients and the user will not have access to them.
+
+     @param Q [in] A list of multivector bases specifying the subspaces to be orthogonalized against. Each <tt>Q[i]</tt> is assumed to have
+     orthonormal columns, and the <tt>Q[i]</tt> are assumed to be mutually orthogonal.
+    */
+    void project ( MV &X, Teuchos::RCP<MV> MX,
+                   Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
+                   Teuchos::ArrayView<Teuchos::RCP<const MV> > Q) const;
+
+
+    /*! \brief This method calls project(X,Teuchos::null,C,Q); see documentation for that function.
+    */
+    void project ( MV &X,
+                   Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
+                   Teuchos::ArrayView<Teuchos::RCP<const MV> > Q) const {
+      project(X,Teuchos::null,C,Q);
+    }
+
+
+
+    /*! \brief This method takes a multivector \c X and attempts to compute an orthonormal basis for \f$colspan(X)\f$, with respect to innerProd().
+     *
+     * The method uses classical Gram-Schmidt, so that the coefficient matrix \c B is upper triangular.
+     *
+     * This routine returns an integer \c rank stating the rank of the computed basis. If \c X does not have full rank and the normalize() routine does
+     * not attempt to augment the subspace, then \c rank may be smaller than the number of columns in \c X. In this case, only the first \c rank columns of
+     * output \c X and first \c rank rows of \c B will be valid.
+     *
+     * The method attempts to find a basis with dimension the same as the number of columns in \c X. It does this by augmenting linearly dependant
+     * vectors in \c X with random directions. A finite number of these attempts will be made; therefore, it is possible that the dimension of the
+     * computed basis is less than the number of vectors in \c X.
+     *
+     @param X [in/out] The multivector to the modified.
+       On output, \c X will have some number of orthonormal columns (with respect to innerProd()).
+
+     @param MX [in/out] The image of \c X under the operator \c Op.
+       If \f$ MX != 0\f$: On input, this is expected to be consistent with \c X. On output, this is updated consistent with updates to \c X.
+       If \f$ MX == 0\f$ or \f$ Op == 0\f$: \c MX is not referenced.
+
+     @param B [out] The coefficients of the original \c X with respect to the computed basis. The first rows in \c B
+            corresponding to the valid columns in \c X will be upper triangular.
+
+     @return Rank of the basis computed by this method.
+    */
+    int normalize ( MV &X, Teuchos::RCP<MV> MX,
+                    Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > B) const;
+
+
+    /*! \brief This method calls normalize(X,Teuchos::null,B); see documentation for that function.
+    */
+    int normalize ( MV &X, Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > B ) const {
+      return normalize(X,Teuchos::null,B);
+    }
+
+  protected:
+
+    /*! \brief Given a set of bases <tt>Q[i]</tt> and a multivector \c X, this method computes an orthonormal basis for \f$colspan(X) - \sum_i colspan(Q[i])\f$.
+     *
+     *  This routine returns an integer \c rank stating the rank of the computed basis. If the subspace \f$colspan(X) - \sum_i colspan(Q[i])\f$ does not
+     *  have dimension as large as the number of columns of \c X and the orthogonalization manager doe not attempt to augment the subspace, then \c rank
+     *  may be smaller than the number of columns of \c X. In this case, only the first \c rank columns of output \c X and first \c rank rows of \c B will
+     *  be valid.
+     *
+     * The method attempts to find a basis with dimension the same as the number of columns in \c X. It does this by augmenting linearly dependant
+     * vectors with random directions. A finite number of these attempts will be made; therefore, it is possible that the dimension of the
+     * computed basis is less than the number of vectors in \c X.
+     *
+     @param X [in/out] The multivector to the modified.
+       On output, the relevant rows of \c X will be orthogonal to the <tt>Q[i]</tt> and will have orthonormal columns (with respect to innerProd()).
+
+     @param MX [in/out] The image of \c X under the operator \c Op.
+       If \f$ MX != 0\f$: On input, this is expected to be consistent with \c X. On output, this is updated consistent with updates to \c X.
+       If \f$ MX == 0\f$ or \f$ Op == 0\f$: \c MX is not referenced.
+
+     @param C [out] The coefficients of the original \c X in the \c
+     *Q[i], with respect to innerProd(). If <tt>C[i]</tt> is a
+     non-null pointer and \c *C[i] matches the dimensions of \c X and
+     \c *Q[i], then the coefficients computed during the
+     orthogonalization routine will be stored in the matrix \c
+     *C[i]. If <tt>C[i]</tt> is a non-null pointer whose size does not
+     match the dimensions of \c X and \c *Q[i], then *C[i] will first
+     be resized to the correct size.  This will destroy the original
+     contents of the matrix.  (This is a change from previous
+     behavior, in which a std::invalid_argument exception was thrown
+     if *C[i] was of the wrong size.)  Otherwise, if <tt>C.size() <
+     i<\tt> or <tt>C[i]</tt> is a null pointer, then the
+     orthogonalization manager will declare storage for the
+     coefficients and the user will not have access to them.
+
+     @param B [out] The coefficients of the original \c X with respect to the computed basis. The first rows in \c B
+            corresponding to the valid columns in \c X will be upper triangular.
+
+     @param Q [in] A list of multivector bases specifying the subspaces to be orthogonalized against. Each <tt>Q[i]</tt> is assumed to have
+     orthonormal columns, and the <tt>Q[i]</tt> are assumed to be mutually orthogonal.
+
+     @return Rank of the basis computed by this method.
+    */
+    virtual int
+    projectAndNormalizeWithMxImpl (MV &X,
+                                   Teuchos::RCP<MV> MX,
+                                   Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
+                                   Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > B,
+                                   Teuchos::ArrayView<Teuchos::RCP<const MV> > Q) const;
+
+  public:
+    //@}
+    //! @name Error methods
+    //@{
+
+    /*! \brief This method computes the error in orthonormality of a multivector, measured
+     * as the Frobenius norm of the difference <tt>innerProd(X,Y) - I</tt>.
+     */
+    typename Teuchos::ScalarTraits<ScalarType>::magnitudeType
+    orthonormError(const MV &X) const {
+      return orthonormError(X,Teuchos::null);
+    }
+
+    /*! \brief This method computes the error in orthonormality of a multivector, measured
+     * as the Frobenius norm of the difference <tt>innerProd(X,Y) - I</tt>.
+     *  The method has the option of exploiting a caller-provided \c MX.
+     */
+    typename Teuchos::ScalarTraits<ScalarType>::magnitudeType
+    orthonormError(const MV &X, Teuchos::RCP<const MV> MX) const;
+
+    /*! \brief This method computes the error in orthogonality of two multivectors, measured
+     * as the Frobenius norm of <tt>innerProd(X,Y)</tt>.
+     */
+    typename Teuchos::ScalarTraits<ScalarType>::magnitudeType
+    orthogError(const MV &X1, const MV &X2) const {
+      return orthogError(X1,Teuchos::null,X2);
+    }
+
+    /*! \brief This method computes the error in orthogonality of two multivectors, measured
+     * as the Frobenius norm of <tt>innerProd(X,Y)</tt>.
+     *  The method has the option of exploiting a caller-provided \c MX.
+     */
+    typename Teuchos::ScalarTraits<ScalarType>::magnitudeType
+    orthogError(const MV &X1, Teuchos::RCP<const MV> MX1, const MV &X2) const;
+
+    //@}
+
+    //! @name Label methods
+    //@{
+
+    /*! \brief This method sets the label used by the timers in the orthogonalization manager.
+     */
+    void setLabel(const std::string& label);
+
+    /*! \brief This method returns the label being used by the timers in the orthogonalization manager.
+     */
+    const std::string& getLabel() const { return label_; }
+
+    //@}
+
+    //! @name Default orthogonalization constants
+    //@{
+
+    //! Max number of (re)orthogonalization steps, including the first (default).
+    static const int max_ortho_steps_default_;
+    //! Block reorthogonalization threshold (default).
+    static const MagnitudeType blk_tol_default_;
+    //! Singular block detection threshold (default).
+    static const MagnitudeType sing_tol_default_;
+
+    //! Max number of (re)orthogonalization steps, including the first (fast).
+    static const int max_ortho_steps_fast_;
+    //! Block reorthogonalization threshold (fast).
+    static const MagnitudeType blk_tol_fast_;
+    //! Singular block detection threshold (fast).
+    static const MagnitudeType sing_tol_fast_;
+    
+    //@}
+
+  private:
+
+    //! Max number of (re)orthogonalization steps, including the first.
+    int max_ortho_steps_;
+    //! Block reorthogonalization threshold.
+    MagnitudeType blk_tol_;
+    //! Singular block detection threshold.
+    MagnitudeType sing_tol_;
+
+    //! Label for timers.
+    std::string label_;
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+    Teuchos::RCP<Teuchos::Time> timerOrtho_, timerUpdate_, timerNorm_, timerInnerProd_;
+#endif // BELOS_TEUCHOS_TIME_MONITOR
+
+    //! Default parameter list.
+    mutable Teuchos::RCP<Teuchos::ParameterList> defaultParams_;
+
+    //! Routine to find an orthonormal basis for X
+    int findBasis(MV &X, Teuchos::RCP<MV> MX,
+                  Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > C,
+                  bool completeBasis, int howMany = -1 ) const;
+
+    //! Routine to compute the block orthogonalization
+    bool blkOrtho1 ( MV &X, Teuchos::RCP<MV> MX,
+                     Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
+                     Teuchos::ArrayView<Teuchos::RCP<const MV> > Q) const;
+
+    //! Routine to compute the block orthogonalization
+    bool blkOrtho ( MV &X, Teuchos::RCP<MV> MX,
+                    Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
+                    Teuchos::ArrayView<Teuchos::RCP<const MV> > Q) const;
+
+    /// Project X against QQ and normalize X, one vector at a time
+    ///
+    /// \note QQ is called QQ, rather than Q, because we convert it
+    ///   internally from an ArrayView to an Array (named Q inside).
+    ///   This is because the C++ compiler doesn't know how to do type
+    ///   inference (Array has a constructor that takes an ArrayView
+    ///   input).  This routine wants an Array rather than an
+    ///   ArrayView internally, because it likes to add (via
+    ///   push_back()) and remove (via resize()) elements to the Q
+    ///   array.  Remember that Arrays can be passed by value, just
+    ///   like std::vector objects, so this routine can add whatever
+    ///   it likes to the Q array without changing it from the
+    ///   caller's perspective.
+    int blkOrthoSing ( MV &X, Teuchos::RCP<MV> MX,
+                       Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
+                       Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > B,
+                       Teuchos::ArrayView<Teuchos::RCP<const MV> > QQ) const;
+  };
+
+  // Set static variables.
+  template<class StorageType, class MV, class OP>
+  const int ICGSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::max_ortho_steps_default_ = 2;
+
+  template<class StorageType, class MV, class OP>
+  const typename ICGSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::MagnitudeType
+  ICGSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::blk_tol_default_
+    = 10*Teuchos::ScalarTraits<typename ICGSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::MagnitudeType>::squareroot(
+      Teuchos::ScalarTraits<typename ICGSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::MagnitudeType>::eps() );
+
+  template<class StorageType, class MV, class OP>
+  const typename ICGSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::MagnitudeType
+  ICGSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::sing_tol_default_
+    = 10*Teuchos::ScalarTraits<typename ICGSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::MagnitudeType>::eps();
+
+  template<class StorageType, class MV, class OP>
+  const int ICGSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::max_ortho_steps_fast_ = 1;
+
+  template<class StorageType, class MV, class OP>
+  const typename ICGSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::MagnitudeType
+  ICGSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::blk_tol_fast_
+    = Teuchos::ScalarTraits<typename ICGSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::MagnitudeType>::zero();
+
+  template<class StorageType, class MV, class OP>
+  const typename ICGSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::MagnitudeType
+  ICGSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::sing_tol_fast_
+    = Teuchos::ScalarTraits<typename ICGSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::MagnitudeType>::zero();
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  // Set the label for this orthogonalization manager and create new timers if it's changed
+  template<class StorageType, class MV, class OP>
+  void ICGSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::setLabel(const std::string& label)
+  {
+    if (label != label_) {
+      label_ = label;
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+      std::stringstream ss;
+      ss << label_ + ": ICGS[" << max_ortho_steps_ << "]";
+
+      std::string orthoLabel = ss.str() + ": Orthogonalization";
+      timerOrtho_ = Teuchos::TimeMonitor::getNewCounter(orthoLabel);
+
+      std::string updateLabel = ss.str() + ": Ortho (Update)";
+      timerUpdate_ = Teuchos::TimeMonitor::getNewCounter(updateLabel);
+
+      std::string normLabel = ss.str() + ": Ortho (Norm)";
+      timerNorm_ = Teuchos::TimeMonitor::getNewCounter(normLabel);
+
+      std::string ipLabel = ss.str() + ": Ortho (Inner Product)";
+      timerInnerProd_ = Teuchos::TimeMonitor::getNewCounter(ipLabel);
+#endif
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  // Compute the distance from orthonormality
+  template<class StorageType, class MV, class OP>
+  typename Teuchos::ScalarTraits<Sacado::MP::Vector<StorageType> >::magnitudeType
+  ICGSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::orthonormError(const MV &X, Teuchos::RCP<const MV> MX) const {
+    const ScalarType ONE = SCT::one();
+    int rank = MVT::GetNumberVecs(X);
+    Teuchos::SerialDenseMatrix<int,ScalarType> xTx(rank,rank);
+    MatOrthoManager<ScalarType,MV,OP>::innerProd(X,X,MX,xTx);
+    for (int i=0; i<rank; i++) {
+      xTx(i,i) -= ONE;
+    }
+    return xTx.normFrobenius();
+  }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  // Compute the distance from orthogonality
+  template<class StorageType, class MV, class OP>
+  typename Teuchos::ScalarTraits<Sacado::MP::Vector<StorageType> >::magnitudeType
+  ICGSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::orthogError(const MV &X1, Teuchos::RCP<const MV> MX1, const MV &X2) const {
+    int r1 = MVT::GetNumberVecs(X1);
+    int r2  = MVT::GetNumberVecs(X2);
+    Teuchos::SerialDenseMatrix<int,ScalarType> xTx(r2,r1);
+    MatOrthoManager<ScalarType,MV,OP>::innerProd(X2,X1,MX1,xTx);
+    return xTx.normFrobenius();
+  }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  // Find an Op-orthonormal basis for span(X) - span(W)
+  template<class StorageType, class MV, class OP>
+  int
+  ICGSOrthoManager<Sacado::MP::Vector<StorageType>, MV, OP>::
+  projectAndNormalizeWithMxImpl (MV &X,
+                                 Teuchos::RCP<MV> MX,
+                                 Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
+                                 Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > B,
+                                 Teuchos::ArrayView<Teuchos::RCP<const MV> > Q) const
+  {
+    using Teuchos::Array;
+    using Teuchos::null;
+    using Teuchos::is_null;
+    using Teuchos::RCP;
+    using Teuchos::rcp;
+    using Teuchos::SerialDenseMatrix;
+    typedef SerialDenseMatrix< int, ScalarType > serial_dense_matrix_type;
+    typedef typename Array< RCP< const MV > >::size_type size_type;
+
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+    Teuchos::TimeMonitor orthotimer(*timerOrtho_);
+#endif
+
+    ScalarType    ONE  = SCT::one();
+    const MagnitudeType ZERO = MGT::zero();
+
+    int nq = Q.size();
+    int xc = MVT::GetNumberVecs( X );
+    ptrdiff_t xr = MVT::GetGlobalLength( X );
+    int rank = xc;
+
+    // If the user doesn't want to store the normalization
+    // coefficients, allocate some local memory for them.  This will
+    // go away at the end of this method.
+    if (is_null (B)) {
+      B = rcp (new serial_dense_matrix_type (xc, xc));
+    }
+    // Likewise, if the user doesn't want to store the projection
+    // coefficients, allocate some local memory for them.  Also make
+    // sure that all the entries of C are the right size.  We're going
+    // to overwrite them anyway, so we don't have to worry about the
+    // contents (other than to resize them if they are the wrong
+    // size).
+    if (C.size() < nq)
+      C.resize (nq);
+    for (size_type k = 0; k < nq; ++k)
+      {
+        const int numRows = MVT::GetNumberVecs (*Q[k]);
+        const int numCols = xc; // Number of vectors in X
+
+        if (is_null (C[k]))
+          C[k] = rcp (new serial_dense_matrix_type (numRows, numCols));
+        else if (C[k]->numRows() != numRows || C[k]->numCols() != numCols)
+        {
+          int err = C[k]->reshape (numRows, numCols);
+          TEUCHOS_TEST_FOR_EXCEPTION(err != 0, std::runtime_error,
+              "IMGS orthogonalization: failed to reshape "
+              "C[" << k << "] (the array of block "
+              "coefficients resulting from projecting X "
+              "against Q[1:" << nq << "]).");
+        }
+      }
+
+    /******   DO NOT MODIFY *MX IF _hasOp == false   ******/
+    if (this->_hasOp) {
+      if (MX == Teuchos::null) {
+        // we need to allocate space for MX
+        MX = MVT::Clone(X,MVT::GetNumberVecs(X));
+        OPT::Apply(*(this->_Op),X,*MX);
+      }
+    }
+    else {
+      // Op == I  -->  MX = X (ignore it if the user passed it in)
+      MX = Teuchos::rcp( &X, false );
+    }
+
+    int mxc = MVT::GetNumberVecs( *MX );
+    ptrdiff_t mxr = MVT::GetGlobalLength( *MX );
+
+    // short-circuit
+    TEUCHOS_TEST_FOR_EXCEPTION( xc == 0 || xr == 0, std::invalid_argument, "Belos::ICGSOrthoManager::projectAndNormalize(): X must be non-empty" );
+
+    int numbas = 0;
+    for (int i=0; i<nq; i++) {
+      numbas += MVT::GetNumberVecs( *Q[i] );
+    }
+
+    // check size of B
+    TEUCHOS_TEST_FOR_EXCEPTION( B->numRows() != xc || B->numCols() != xc, std::invalid_argument,
+                        "Belos::ICGSOrthoManager::projectAndNormalize(): Size of X must be consistant with size of B" );
+    // check size of X and MX
+    TEUCHOS_TEST_FOR_EXCEPTION( xc<0 || xr<0 || mxc<0 || mxr<0, std::invalid_argument,
+                        "Belos::ICGSOrthoManager::projectAndNormalize(): MVT returned negative dimensions for X,MX" );
+    // check size of X w.r.t. MX
+    TEUCHOS_TEST_FOR_EXCEPTION( xc!=mxc || xr!=mxr, std::invalid_argument,
+                        "Belos::ICGSOrthoManager::projectAndNormalize(): Size of X must be consistant with size of MX" );
+    // check feasibility
+    //TEUCHOS_TEST_FOR_EXCEPTION( numbas+xc > xr, std::invalid_argument,
+    //                    "Belos::ICGSOrthoManager::projectAndNormalize(): Orthogonality constraints not feasible" );
+
+    // Some flags for checking dependency returns from the internal orthogonalization methods
+    bool dep_flg = false;
+
+    if (xc == 1) {
+
+      // Use the cheaper block orthogonalization.
+      // NOTE: Don't check for dependencies because the update has one vector.
+      dep_flg = blkOrtho1( X, MX, C, Q );
+
+      // Normalize the new block X
+      if ( B == Teuchos::null ) {
+        B = Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>(xc,xc) );
+      }
+      std::vector<ScalarType> diag(xc);
+      {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+        Teuchos::TimeMonitor normTimer( *timerNorm_ );
+#endif
+        MVT::MvDot( X, *MX, diag );
+      }
+      (*B)(0,0) = SCT::squareroot(SCT::magnitude(diag[0]));
+
+      ScalarType scale = ONE;
+      mask_assign((*B)(0,0)!= ZERO, scale) /= (*B)(0,0);
+      
+      if(MaskLogic::OR((*B)(0,0)!= ZERO) )
+        rank = 1;
+      MVT::MvScale( X, scale );
+      if (this->_hasOp) {
+        // Update MXj.
+        MVT::MvScale( *MX, scale );
+      }
+    }
+    else {
+
+      // Make a temporary copy of X and MX, just in case a block dependency is detected.
+      Teuchos::RCP<MV> tmpX, tmpMX;
+      tmpX = MVT::CloneCopy(X);
+      if (this->_hasOp) {
+        tmpMX = MVT::CloneCopy(*MX);
+      }
+
+      // Use the cheaper block orthogonalization.
+      dep_flg = blkOrtho( X, MX, C, Q );
+
+      // If a dependency has been detected in this block, then perform
+      // the more expensive nonblock (single vector at a time)
+      // orthogonalization.
+      if (dep_flg) {
+        rank = blkOrthoSing( *tmpX, tmpMX, C, B, Q );
+
+        // Copy tmpX back into X.
+        MVT::Assign( *tmpX, X );
+        if (this->_hasOp) {
+          MVT::Assign( *tmpMX, *MX );
+        }
+      }
+      else {
+        // There is no dependency, so orthonormalize new block X
+        rank = findBasis( X, MX, B, false );
+        if (rank < xc) {
+          // A dependency was found during orthonormalization of X,
+          // rerun orthogonalization using more expensive nonblock
+          // orthogonalization.
+          rank = blkOrthoSing( *tmpX, tmpMX, C, B, Q );
+
+          // Copy tmpX back into X.
+          MVT::Assign( *tmpX, X );
+          if (this->_hasOp) {
+            MVT::Assign( *tmpMX, *MX );
+          }
+        }
+      }
+    } // if (xc == 1) {
+
+    // this should not raise an std::exception; but our post-conditions oblige us to check
+    TEUCHOS_TEST_FOR_EXCEPTION( rank > xc || rank < 0, std::logic_error,
+                        "Belos::ICGSOrthoManager::projectAndNormalize(): Debug error in rank variable." );
+
+    // Return the rank of X.
+    return rank;
+  }
+
+
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  // Find an Op-orthonormal basis for span(X), with rank numvectors(X)
+  template<class StorageType, class MV, class OP>
+  int ICGSOrthoManager<Sacado::MP::Vector<StorageType>, MV, OP>::normalize(
+                                MV &X, Teuchos::RCP<MV> MX,
+                                Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > B ) const {
+
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+    Teuchos::TimeMonitor orthotimer(*timerOrtho_);
+#endif
+
+    // call findBasis, with the instruction to try to generate a basis of rank numvecs(X)
+    return findBasis(X, MX, B, true);
+
+  }
+
+
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  template<class StorageType, class MV, class OP>
+  void ICGSOrthoManager<Sacado::MP::Vector<StorageType>, MV, OP>::project(
+                          MV &X, Teuchos::RCP<MV> MX,
+                          Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
+                          Teuchos::ArrayView<Teuchos::RCP<const MV> > Q) const {
+    // For the inner product defined by the operator Op or the identity (Op == 0)
+    //   -> Orthogonalize X against each Q[i]
+    // Modify MX accordingly
+    //
+    // Note that when Op is 0, MX is not referenced
+    //
+    // Parameter variables
+    //
+    // X  : Vectors to be transformed
+    //
+    // MX : Image of the block of vectors X by the mass matrix
+    //
+    // Q  : Bases to orthogonalize against. These are assumed orthonormal, mutually and independently.
+    //
+
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+    Teuchos::TimeMonitor orthotimer(*timerOrtho_);
+#endif
+
+    int xc = MVT::GetNumberVecs( X );
+    ptrdiff_t xr = MVT::GetGlobalLength( X );
+    int nq = Q.size();
+    std::vector<int> qcs(nq);
+    // short-circuit
+    if (nq == 0 || xc == 0 || xr == 0) {
+      return;
+    }
+    ptrdiff_t qr = MVT::GetGlobalLength ( *Q[0] );
+    // if we don't have enough C, expand it with null references
+    // if we have too many, resize to throw away the latter ones
+    // if we have exactly as many as we have Q, this call has no effect
+    C.resize(nq);
+
+
+    /******   DO NOT MODIFY *MX IF _hasOp == false   ******/
+    if (this->_hasOp) {
+      if (MX == Teuchos::null) {
+        // we need to allocate space for MX
+        MX = MVT::Clone(X,MVT::GetNumberVecs(X));
+        OPT::Apply(*(this->_Op),X,*MX);
+      }
+    }
+    else {
+      // Op == I  -->  MX = X (ignore it if the user passed it in)
+      MX = Teuchos::rcp( &X, false );
+    }
+    int mxc = MVT::GetNumberVecs( *MX );
+    ptrdiff_t mxr = MVT::GetGlobalLength( *MX );
+
+    // check size of X and Q w.r.t. common sense
+    TEUCHOS_TEST_FOR_EXCEPTION( xc<0 || xr<0 || mxc<0 || mxr<0, std::invalid_argument,
+                        "Belos::ICGSOrthoManager::project(): MVT returned negative dimensions for X,MX" );
+    // check size of X w.r.t. MX and Q
+    TEUCHOS_TEST_FOR_EXCEPTION( xc!=mxc || xr!=mxr || xr!=qr, std::invalid_argument,
+                        "Belos::ICGSOrthoManager::project(): Size of X not consistant with MX,Q" );
+
+    // tally up size of all Q and check/allocate C
+    int baslen = 0;
+    for (int i=0; i<nq; i++) {
+      TEUCHOS_TEST_FOR_EXCEPTION( MVT::GetGlobalLength( *Q[i] ) != qr, std::invalid_argument,
+                          "Belos::ICGSOrthoManager::project(): Q lengths not mutually consistant" );
+      qcs[i] = MVT::GetNumberVecs( *Q[i] );
+      TEUCHOS_TEST_FOR_EXCEPTION( qr < qcs[i], std::invalid_argument,
+                          "Belos::ICGSOrthoManager::project(): Q has less rows than columns" );
+      baslen += qcs[i];
+
+      // check size of C[i]
+      if ( C[i] == Teuchos::null ) {
+        C[i] = Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>(qcs[i],xc) );
+      }
+      else {
+        TEUCHOS_TEST_FOR_EXCEPTION( C[i]->numRows() != qcs[i] || C[i]->numCols() != xc , std::invalid_argument,
+                           "Belos::ICGSOrthoManager::project(): Size of Q not consistant with size of C" );
+      }
+    }
+
+    // Use the cheaper block orthogonalization, don't check for rank deficiency.
+    blkOrtho( X, MX, C, Q );
+
+  }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  // Find an Op-orthonormal basis for span(X), with the option of extending the subspace so that
+  // the rank is numvectors(X)
+  template<class StorageType, class MV, class OP>
+  int
+  ICGSOrthoManager<Sacado::MP::Vector<StorageType>, MV, OP>::
+  findBasis (MV &X,
+             Teuchos::RCP<MV> MX,
+             Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > B,
+             bool completeBasis,
+             int howMany) const
+  {
+    // For the inner product defined by the operator Op or the identity (Op == 0)
+    //   -> Orthonormalize X
+    // Modify MX accordingly
+    //
+    // Note that when Op is 0, MX is not referenced
+    //
+    // Parameter variables
+    //
+    // X  : Vectors to be orthonormalized
+    // MX : Image of the multivector X under the operator Op
+    // Op  : Pointer to the operator for the inner product
+    //
+    using Teuchos::as;
+
+    const ScalarType ONE = SCT::one ();
+    const MagnitudeType ZERO = SCT::magnitude (SCT::zero ());
+
+    const int xc = MVT::GetNumberVecs (X);
+    const ptrdiff_t xr = MVT::GetGlobalLength (X);
+
+    if (howMany == -1) {
+      howMany = xc;
+    }
+
+    /*******************************************************
+     *  If _hasOp == false, we will not reference MX below *
+     *******************************************************/
+
+    // if Op==null, MX == X (via pointer)
+    // Otherwise, either the user passed in MX or we will allocated and compute it
+    if (this->_hasOp) {
+      if (MX == Teuchos::null) {
+        // we need to allocate space for MX
+        MX = MVT::Clone(X,xc);
+        OPT::Apply(*(this->_Op),X,*MX);
+      }
+    }
+
+    /* if the user doesn't want to store the coefficienets,
+     * allocate some local memory for them
+     */
+    if ( B == Teuchos::null ) {
+      B = Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>(xc,xc) );
+    }
+
+    const int mxc = (this->_hasOp) ? MVT::GetNumberVecs( *MX ) : xc;
+    const ptrdiff_t mxr = (this->_hasOp) ? MVT::GetGlobalLength( *MX ) : xr;
+
+    // check size of C, B
+    TEUCHOS_TEST_FOR_EXCEPTION( xc == 0 || xr == 0, std::invalid_argument,
+                        "Belos::ICGSOrthoManager::findBasis(): X must be non-empty" );
+    TEUCHOS_TEST_FOR_EXCEPTION( B->numRows() != xc || B->numCols() != xc, std::invalid_argument,
+                        "Belos::ICGSOrthoManager::findBasis(): Size of X not consistant with size of B" );
+    TEUCHOS_TEST_FOR_EXCEPTION( xc != mxc || xr != mxr, std::invalid_argument,
+                        "Belos::ICGSOrthoManager::findBasis(): Size of X not consistant with size of MX" );
+    TEUCHOS_TEST_FOR_EXCEPTION( as<ptrdiff_t> (xc) > xr, std::invalid_argument,
+                        "Belos::ICGSOrthoManager::findBasis(): Size of X not feasible for normalization" );
+    TEUCHOS_TEST_FOR_EXCEPTION( howMany < 0 || howMany > xc, std::invalid_argument,
+                        "Belos::ICGSOrthoManager::findBasis(): Invalid howMany parameter" );
+
+    /* xstart is which column we are starting the process with, based on howMany
+     * columns before xstart are assumed to be Op-orthonormal already
+     */
+    int xstart = xc - howMany;
+
+    for (int j = xstart; j < xc; j++) {
+
+      // numX is
+      // * number of currently orthonormal columns of X
+      // * the index of the current column of X
+      int numX = j;
+      bool addVec = false;
+
+      // Get a view of the vector currently being worked on.
+      std::vector<int> index(1);
+      index[0] = numX;
+      Teuchos::RCP<MV> Xj = MVT::CloneViewNonConst( X, index );
+      Teuchos::RCP<MV> MXj;
+      if (this->_hasOp) {
+        // MXj is a view of the current vector in MX
+        MXj = MVT::CloneViewNonConst( *MX, index );
+      }
+      else {
+        // MXj is a pointer to Xj, and MUST NOT be modified
+        MXj = Xj;
+      }
+
+      // Get a view of the previous vectors.
+      std::vector<int> prev_idx( numX );
+      Teuchos::RCP<const MV> prevX, prevMX;
+      Teuchos::RCP<MV> oldMXj;
+
+      if (numX > 0) {
+        for (int i=0; i<numX; i++) {
+          prev_idx[i] = i;
+        }
+        prevX = MVT::CloneView( X, prev_idx );
+        if (this->_hasOp) {
+          prevMX = MVT::CloneView( *MX, prev_idx );
+        }
+
+        oldMXj = MVT::CloneCopy( *MXj );
+      }
+
+      // Make storage for these Gram-Schmidt iterations.
+      Teuchos::SerialDenseMatrix<int,ScalarType> product(numX, 1);
+      std::vector<ScalarType> oldDot( 1 ), newDot( 1 );
+      //
+      // Save old MXj vector and compute Op-norm
+      //
+      {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+      Teuchos::TimeMonitor normTimer( *timerNorm_ );
+#endif
+      MVT::MvDot( *Xj, *MXj, oldDot );
+      }
+      // Xj^H Op Xj should be real and positive, by the hermitian positive definiteness of Op
+      TEUCHOS_TEST_FOR_EXCEPTION( SCT::real(oldDot[0]) < ZERO, OrthoError,
+          "Belos::ICGSOrthoManager::findBasis(): Negative definiteness discovered in inner product" );
+
+      if (numX > 0) {
+
+        Teuchos::SerialDenseMatrix<int,ScalarType> P2(numX,1);
+
+        for (int i=0; i<max_ortho_steps_; ++i) {
+
+          // product <- prevX^T MXj
+          {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+            Teuchos::TimeMonitor innerProdTimer( *timerInnerProd_ );
+#endif
+            MatOrthoManager<ScalarType,MV,OP>::innerProd(*prevX,*Xj,MXj,P2);
+          }
+
+          // Xj <- Xj - prevX prevX^T MXj
+          //     = Xj - prevX product
+          {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+            Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+            MVT::MvTimesMatAddMv( -ONE, *prevX, P2, ONE, *Xj );
+          }
+
+          // Update MXj
+          if (this->_hasOp) {
+            // MXj <- Op*Xj_new
+            //      = Op*(Xj_old - prevX prevX^T MXj)
+            //      = MXj - prevMX product
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+            Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+            MVT::MvTimesMatAddMv( -ONE, *prevMX, P2, ONE, *MXj );
+          }
+
+          // Set coefficients
+          if ( i==0 )
+            product = P2;
+          else
+            product += P2;
+        }
+
+      } // if (numX > 0)
+
+      // Compute Op-norm with old MXj
+      if (numX > 0) {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+        Teuchos::TimeMonitor normTimer( *timerNorm_ );
+#endif
+        MVT::MvDot( *Xj, *oldMXj, newDot );
+      }
+      else {
+        newDot[0] = oldDot[0];
+      }
+
+      // Check to see if the new vector is dependent.
+      if (completeBasis) {
+        //
+        // We need a complete basis, so add random vectors if necessary
+        //
+        if ( SCT::magnitude(newDot[0]) < SCT::magnitude(sing_tol_*oldDot[0]) ) {
+
+          // Add a random vector and orthogonalize it against previous vectors in block.
+          addVec = true;
+#ifdef ORTHO_DEBUG
+          std::cout << "Belos::ICGSOrthoManager::findBasis() --> Random for column " << numX << std::endl;
+#endif
+          //
+          Teuchos::RCP<MV> tempXj = MVT::Clone( X, 1 );
+          Teuchos::RCP<MV> tempMXj;
+          MVT::MvRandom( *tempXj );
+          if (this->_hasOp) {
+            tempMXj = MVT::Clone( X, 1 );
+            OPT::Apply( *(this->_Op), *tempXj, *tempMXj );
+          }
+          else {
+            tempMXj = tempXj;
+          }
+          {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+          Teuchos::TimeMonitor normTimer( *timerNorm_ );
+#endif
+          MVT::MvDot( *tempXj, *tempMXj, oldDot );
+          }
+          //
+          for (int num_orth=0; num_orth<max_ortho_steps_; num_orth++){
+            {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+              Teuchos::TimeMonitor innerProdTimer( *timerInnerProd_ );
+#endif
+              MatOrthoManager<ScalarType,MV,OP>::innerProd(*prevX,*tempXj,tempMXj,product);
+            }
+            {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+              Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+              MVT::MvTimesMatAddMv( -ONE, *prevX, product, ONE, *tempXj );
+            }
+            if (this->_hasOp) {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+              Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+              MVT::MvTimesMatAddMv( -ONE, *prevMX, product, ONE, *tempMXj );
+            }
+          }
+          // Compute new Op-norm
+          {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+          Teuchos::TimeMonitor normTimer( *timerNorm_ );
+#endif
+          MVT::MvDot( *tempXj, *tempMXj, newDot );
+          }
+          //
+          if ( SCT::magnitude(newDot[0]) >= SCT::magnitude(oldDot[0]*sing_tol_) ) {
+            // Copy vector into current column of _basisvecs
+            MVT::Assign( *tempXj, *Xj );
+            if (this->_hasOp) {
+              MVT::Assign( *tempMXj, *MXj );
+            }
+          }
+          else {
+            return numX;
+          }
+        }
+      }
+      else {
+        //
+        // We only need to detect dependencies.
+        //
+        if ( SCT::magnitude(newDot[0]) < SCT::magnitude(oldDot[0]*blk_tol_) ) {
+          return numX;
+        }
+      }
+
+      // If we haven't left this method yet, then we can normalize the new vector Xj.
+      // Normalize Xj.
+      // Xj <- Xj / std::sqrt(newDot)
+      ScalarType diag = SCT::squareroot(SCT::magnitude(newDot[0]));
+      ScalarType scale = ONE;
+      mask_assign(SCT::magnitude(diag) > ZERO, scale) /= diag;
+      MVT::MvScale( *Xj, scale );
+      if (this->_hasOp) {
+        // Update MXj.
+        MVT::MvScale( *MXj, scale );
+      }
+
+      // If we've added a random vector, enter a zero in the j'th diagonal element.
+      if (addVec) {
+        (*B)(j,j) = ZERO;
+      }
+      else {
+        (*B)(j,j) = diag;
+      }
+
+      // Save the coefficients, if we are working on the original vector and not a randomly generated one
+      if (!addVec) {
+        for (int i=0; i<numX; i++) {
+          (*B)(i,j) = product(i,0);
+        }
+      }
+
+    } // for (j = 0; j < xc; ++j)
+
+    return xc;
+  }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  // Routine to compute the block orthogonalization
+  template<class StorageType, class MV, class OP>
+  bool
+  ICGSOrthoManager<Sacado::MP::Vector<StorageType>, MV, OP>::blkOrtho1 ( MV &X, Teuchos::RCP<MV> MX,
+                                                    Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
+                                                    Teuchos::ArrayView<Teuchos::RCP<const MV> > Q) const
+  {
+    int nq = Q.size();
+    int xc = MVT::GetNumberVecs( X );
+    const ScalarType ONE  = SCT::one();
+
+    std::vector<int> qcs( nq );
+    for (int i=0; i<nq; i++) {
+      qcs[i] = MVT::GetNumberVecs( *Q[i] );
+    }
+
+    // Perform the Gram-Schmidt transformation for a block of vectors
+
+    Teuchos::Array<Teuchos::RCP<MV> > MQ(nq);
+    // Define the product Q^T * (Op*X)
+    for (int i=0; i<nq; i++) {
+      // Multiply Q' with MX
+      {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+        Teuchos::TimeMonitor innerProdTimer( *timerInnerProd_ );
+#endif
+        MatOrthoManager<ScalarType,MV,OP>::innerProd(*Q[i],X,MX,*C[i]);
+      }
+      // Multiply by Q and subtract the result in X
+      {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+        Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+        MVT::MvTimesMatAddMv( -ONE, *Q[i], *C[i], ONE, X );
+      }
+
+      // Update MX, with the least number of applications of Op as possible
+      if (this->_hasOp) {
+        if (xc <= qcs[i]) {
+          OPT::Apply( *(this->_Op), X, *MX);
+        }
+        else {
+          // this will possibly be used again below; don't delete it
+          MQ[i] = MVT::Clone( *Q[i], qcs[i] );
+          OPT::Apply( *(this->_Op), *Q[i], *MQ[i] );
+          {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+          Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+          MVT::MvTimesMatAddMv( -ONE, *MQ[i], *C[i], ONE, *MX );
+          }
+        }
+      }
+    }
+
+    // Do as many steps of classical Gram-Schmidt as required by max_ortho_steps_
+    for (int j = 1; j < max_ortho_steps_; ++j) {
+
+      for (int i=0; i<nq; i++) {
+        Teuchos::SerialDenseMatrix<int,ScalarType> C2(C[i]->numRows(),C[i]->numCols());
+
+        // Apply another step of classical Gram-Schmidt
+        {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+          Teuchos::TimeMonitor innerProdTimer( *timerInnerProd_ );
+#endif
+          MatOrthoManager<ScalarType,MV,OP>::innerProd(*Q[i],X,MX,C2);
+        }
+        *C[i] += C2;
+        {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+          Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+          MVT::MvTimesMatAddMv( -ONE, *Q[i], C2, ONE, X );
+        }
+
+        // Update MX, with the least number of applications of Op as possible
+        if (this->_hasOp) {
+          if (MQ[i].get()) {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+            Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+            // MQ was allocated and computed above; use it
+            MVT::MvTimesMatAddMv( -ONE, *MQ[i], C2, ONE, *MX );
+          }
+          else if (xc <= qcs[i]) {
+            // MQ was not allocated and computed above; it was cheaper to use X before and it still is
+            OPT::Apply( *(this->_Op), X, *MX);
+          }
+        }
+      } // for (int i=0; i<nq; i++)
+    } // for (int j = 0; j < max_ortho_steps; ++j)
+
+    return false;
+  }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  // Routine to compute the block orthogonalization
+  template<class StorageType, class MV, class OP>
+  bool
+  ICGSOrthoManager<Sacado::MP::Vector<StorageType>, MV, OP>::blkOrtho ( MV &X, Teuchos::RCP<MV> MX,
+                                                   Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
+                                                   Teuchos::ArrayView<Teuchos::RCP<const MV> > Q) const
+  {
+    int nq = Q.size();
+    int xc = MVT::GetNumberVecs( X );
+    bool dep_flg = false;
+    const ScalarType ONE  = SCT::one();
+
+    std::vector<int> qcs( nq );
+    for (int i=0; i<nq; i++) {
+      qcs[i] = MVT::GetNumberVecs( *Q[i] );
+    }
+
+    // Perform the Gram-Schmidt transformation for a block of vectors
+
+    // Compute the initial Op-norms
+    std::vector<ScalarType> oldDot( xc );
+    {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+    Teuchos::TimeMonitor normTimer( *timerNorm_ );
+#endif
+    MVT::MvDot( X, *MX, oldDot );
+    }
+
+    Teuchos::Array<Teuchos::RCP<MV> > MQ(nq);
+    // Define the product Q^T * (Op*X)
+    for (int i=0; i<nq; i++) {
+      // Multiply Q' with MX
+      {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+        Teuchos::TimeMonitor innerProdTimer( *timerInnerProd_ );
+#endif
+        MatOrthoManager<ScalarType,MV,OP>::innerProd(*Q[i],X,MX,*C[i]);
+      }
+      // Multiply by Q and subtract the result in X
+      {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+        Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+        MVT::MvTimesMatAddMv( -ONE, *Q[i], *C[i], ONE, X );
+      }
+      // Update MX, with the least number of applications of Op as possible
+      if (this->_hasOp) {
+        if (xc <= qcs[i]) {
+          OPT::Apply( *(this->_Op), X, *MX);
+        }
+        else {
+          // this will possibly be used again below; don't delete it
+          MQ[i] = MVT::Clone( *Q[i], qcs[i] );
+          OPT::Apply( *(this->_Op), *Q[i], *MQ[i] );
+          {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+          Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+          MVT::MvTimesMatAddMv( -ONE, *MQ[i], *C[i], ONE, *MX );
+          }
+        }
+      }
+    }
+
+    // Do as many steps of classical Gram-Schmidt as required by max_ortho_steps_
+    for (int j = 1; j < max_ortho_steps_; ++j) {
+
+      for (int i=0; i<nq; i++) {
+        Teuchos::SerialDenseMatrix<int,ScalarType> C2(C[i]->numRows(),C[i]->numCols());
+
+        // Apply another step of classical Gram-Schmidt
+        {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+          Teuchos::TimeMonitor innerProdTimer( *timerInnerProd_ );
+#endif
+          MatOrthoManager<ScalarType,MV,OP>::innerProd(*Q[i],X,MX,C2);
+        }
+        *C[i] += C2;
+        {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+          Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+          MVT::MvTimesMatAddMv( -ONE, *Q[i], C2, ONE, X );
+        }
+
+        // Update MX, with the least number of applications of Op as possible
+        if (this->_hasOp) {
+          if (MQ[i].get()) {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+            Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+            // MQ was allocated and computed above; use it
+            MVT::MvTimesMatAddMv( -ONE, *MQ[i], C2, ONE, *MX );
+          }
+          else if (xc <= qcs[i]) {
+            // MQ was not allocated and computed above; it was cheaper to use X before and it still is
+            OPT::Apply( *(this->_Op), X, *MX);
+          }
+        }
+      } // for (int i=0; i<nq; i++)
+    } // for (int j = 0; j < max_ortho_steps; ++j)
+
+    // Compute new Op-norms
+    std::vector<ScalarType> newDot(xc);
+    {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+    Teuchos::TimeMonitor normTimer( *timerNorm_ );
+#endif
+    MVT::MvDot( X, *MX, newDot );
+    }
+
+    // Check to make sure the new block of vectors are not dependent on previous vectors
+    for (int i=0; i<xc; i++){
+      if (SCT::magnitude(newDot[i]) < SCT::magnitude(oldDot[i] * blk_tol_)) {
+        dep_flg = true;
+        break;
+      }
+    } // end for (i=0;...)
+
+    return dep_flg;
+  }
+
+  template<class StorageType, class MV, class OP>
+  int
+  ICGSOrthoManager<Sacado::MP::Vector<StorageType>, MV, OP>::blkOrthoSing ( MV &X, Teuchos::RCP<MV> MX,
+                                                       Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
+                                                       Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > B,
+                                                       Teuchos::ArrayView<Teuchos::RCP<const MV> > QQ) const
+  {
+    Teuchos::Array<Teuchos::RCP<const MV> > Q (QQ);
+
+    const ScalarType ONE  = SCT::one();
+    const ScalarType ZERO  = SCT::zero();
+
+    int nq = Q.size();
+    int xc = MVT::GetNumberVecs( X );
+    std::vector<int> indX( 1 );
+    std::vector<ScalarType> oldDot( 1 ), newDot( 1 );
+
+    std::vector<int> qcs( nq );
+    for (int i=0; i<nq; i++) {
+      qcs[i] = MVT::GetNumberVecs( *Q[i] );
+    }
+
+    // Create pointers for the previous vectors of X that have already been orthonormalized.
+    Teuchos::RCP<const MV> lastQ;
+    Teuchos::RCP<MV> Xj, MXj;
+    Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > lastC;
+
+    // Perform the Gram-Schmidt transformation for each vector in the block of vectors.
+    for (int j=0; j<xc; j++) {
+
+      bool dep_flg = false;
+
+      // Get a view of the previously orthogonalized vectors and B, add it to the arrays.
+      if (j > 0) {
+        std::vector<int> index( j );
+        for (int ind=0; ind<j; ind++) {
+          index[ind] = ind;
+        }
+        lastQ = MVT::CloneView( X, index );
+
+        // Add these views to the Q and C arrays.
+        Q.push_back( lastQ );
+        C.push_back( B );
+        qcs.push_back( MVT::GetNumberVecs( *lastQ ) );
+      }
+
+      // Get a view of the current vector in X to orthogonalize.
+      indX[0] = j;
+      Xj = MVT::CloneViewNonConst( X, indX );
+      if (this->_hasOp) {
+        MXj = MVT::CloneViewNonConst( *MX, indX );
+      }
+      else {
+        MXj = Xj;
+      }
+
+      // Compute the initial Op-norms
+      {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+      Teuchos::TimeMonitor normTimer( *timerNorm_ );
+#endif
+      MVT::MvDot( *Xj, *MXj, oldDot );
+      }
+
+      Teuchos::Array<Teuchos::RCP<MV> > MQ(Q.size());
+      // Define the product Q^T * (Op*X)
+      for (int i=0; i<Q.size(); i++) {
+
+        // Get a view of the current serial dense matrix
+        Teuchos::SerialDenseMatrix<int,ScalarType> tempC( Teuchos::View, *C[i], qcs[i], 1, 0, j );
+
+        // Multiply Q' with MX
+        {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+        Teuchos::TimeMonitor innerProdTimer( *timerInnerProd_ );
+#endif
+        MatOrthoManager<ScalarType,MV,OP>::innerProd(*Q[i],*Xj,MXj,tempC);
+        }
+        {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+        Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+        // Multiply by Q and subtract the result in Xj
+        MVT::MvTimesMatAddMv( -ONE, *Q[i], tempC, ONE, *Xj );
+        }
+        // Update MXj, with the least number of applications of Op as possible
+        if (this->_hasOp) {
+          if (xc <= qcs[i]) {
+            OPT::Apply( *(this->_Op), *Xj, *MXj);
+          }
+          else {
+            // this will possibly be used again below; don't delete it
+            MQ[i] = MVT::Clone( *Q[i], qcs[i] );
+            OPT::Apply( *(this->_Op), *Q[i], *MQ[i] );
+            {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+            Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+            MVT::MvTimesMatAddMv( -ONE, *MQ[i], tempC, ONE, *MXj );
+            }
+          }
+        }
+      }
+
+      // Do any additional steps of classical Gram-Schmidt orthogonalization
+      for (int num_ortho_steps=1; num_ortho_steps < max_ortho_steps_; ++num_ortho_steps) {
+
+        for (int i=0; i<Q.size(); i++) {
+          Teuchos::SerialDenseMatrix<int,ScalarType> tempC( Teuchos::View, *C[i], qcs[i], 1, 0, j );
+          Teuchos::SerialDenseMatrix<int,ScalarType> C2( qcs[i], 1 );
+
+          // Apply another step of classical Gram-Schmidt
+          {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+          Teuchos::TimeMonitor innerProdTimer( *timerInnerProd_ );
+#endif
+          MatOrthoManager<ScalarType,MV,OP>::innerProd(*Q[i],*Xj,MXj,C2);
+          }
+          tempC += C2;
+          {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+          Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+          MVT::MvTimesMatAddMv( -ONE, *Q[i], C2, ONE, *Xj );
+          }
+
+          // Update MXj, with the least number of applications of Op as possible
+          if (this->_hasOp) {
+            if (MQ[i].get()) {
+              // MQ was allocated and computed above; use it
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+              Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+              MVT::MvTimesMatAddMv( -ONE, *MQ[i], C2, ONE, *MXj );
+            }
+            else if (xc <= qcs[i]) {
+              // MQ was not allocated and computed above; it was cheaper to use X before and it still is
+              OPT::Apply( *(this->_Op), *Xj, *MXj);
+            }
+          }
+        } // for (int i=0; i<Q.size(); i++)
+
+      } // for (int num_ortho_steps=1; num_ortho_steps < max_ortho_steps_; ++num_ortho_steps)
+
+      // Check for linear dependence.
+      if (SCT::magnitude(newDot[0]) < SCT::magnitude(oldDot[0]*sing_tol_)) {
+        dep_flg = true;
+      }
+
+      // Normalize the new vector if it's not dependent
+      if (!dep_flg) {
+        ScalarType diag = SCT::squareroot(SCT::magnitude(newDot[0]));
+
+        MVT::MvScale( *Xj, ONE/diag );
+        if (this->_hasOp) {
+          // Update MXj.
+          MVT::MvScale( *MXj, ONE/diag );
+        }
+
+        // Enter value on diagonal of B.
+        (*B)(j,j) = diag;
+      }
+      else {
+        // Create a random vector and orthogonalize it against all previous columns of Q.
+        Teuchos::RCP<MV> tempXj = MVT::Clone( X, 1 );
+        Teuchos::RCP<MV> tempMXj;
+        MVT::MvRandom( *tempXj );
+        if (this->_hasOp) {
+          tempMXj = MVT::Clone( X, 1 );
+          OPT::Apply( *(this->_Op), *tempXj, *tempMXj );
+        }
+        else {
+          tempMXj = tempXj;
+        }
+        {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+        Teuchos::TimeMonitor normTimer( *timerNorm_ );
+#endif
+        MVT::MvDot( *tempXj, *tempMXj, oldDot );
+        }
+        //
+        for (int num_orth=0; num_orth<max_ortho_steps_; num_orth++) {
+
+          for (int i=0; i<Q.size(); i++) {
+            Teuchos::SerialDenseMatrix<int,ScalarType> product( qcs[i], 1 );
+
+            // Apply another step of classical Gram-Schmidt
+            {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+            Teuchos::TimeMonitor innerProdTimer( *timerInnerProd_ );
+#endif
+            MatOrthoManager<ScalarType,MV,OP>::innerProd(*Q[i],*tempXj,tempMXj,product);
+            }
+            {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+            Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+            MVT::MvTimesMatAddMv( -ONE, *Q[i], product, ONE, *tempXj );
+            }
+
+            // Update MXj, with the least number of applications of Op as possible
+            if (this->_hasOp) {
+              if (MQ[i].get()) {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+                Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+                // MQ was allocated and computed above; use it
+                MVT::MvTimesMatAddMv( -ONE, *MQ[i], product, ONE, *tempMXj );
+              }
+              else if (xc <= qcs[i]) {
+                // MQ was not allocated and computed above; it was cheaper to use X before and it still is
+                OPT::Apply( *(this->_Op), *tempXj, *tempMXj);
+              }
+            }
+          } // for (int i=0; i<nq; i++)
+
+        }
+
+        // Compute the Op-norms after the correction step.
+        {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+        Teuchos::TimeMonitor normTimer( *timerNorm_ );
+#endif
+        MVT::MvDot( *tempXj, *tempMXj, newDot );
+        }
+
+        // Copy vector into current column of Xj
+        if ( SCT::magnitude(newDot[0]) >= SCT::magnitude(oldDot[0]*sing_tol_) ) {
+          ScalarType diag = SCT::squareroot(SCT::magnitude(newDot[0]));
+
+          // Enter value on diagonal of B.
+          (*B)(j,j) = ZERO;
+
+          // Copy vector into current column of _basisvecs
+          MVT::MvAddMv( ONE/diag, *tempXj, ZERO, *tempXj, *Xj );
+          if (this->_hasOp) {
+            MVT::MvAddMv( ONE/diag, *tempMXj, ZERO, *tempMXj, *MXj );
+          }
+        }
+        else {
+          return j;
+        }
+      } // if (!dep_flg)
+
+      // Remove the vectors from array
+      if (j > 0) {
+        Q.resize( nq );
+        C.resize( nq );
+        qcs.resize( nq );
+      }
+
+    } // for (int j=0; j<xc; j++)
+
+    return xc;
+  }
+  
+} // namespace Belos
+
+#endif // BELOS_ICGS_ORTHOMANAGER_HPP
+

--- a/packages/stokhos/src/sacado/kokkos/vector/belos/Belos_IMGS_OrthoManager_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/belos/Belos_IMGS_OrthoManager_MP_Vector.hpp
@@ -1,0 +1,1670 @@
+//@HEADER
+// ************************************************************************
+//
+//                 Belos: Block Linear Solvers Package
+//                  Copyright 2004 Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+
+
+/*! 
+  \file Belos_IMGS_OrthoManager_MP_Vector.hpp
+  \brief Iterated Modified Gram-Schmidt (IMGS) implementation of the Belos::OrthoManager class
+
+  Specialized for Sacado::MP::Vector scalar type to deal with lucky breakdown that can occur for one sample
+  but not for the others.    
+*/
+
+#ifndef BELOS_IMGS_ORTHOMANAGER_MP_VECTOR_HPP
+#define BELOS_IMGS_ORTHOMANAGER_MP_VECTOR_HPP
+
+#include "Stokhos_Sacado_Kokkos_MP_Vector.hpp"
+#include "BelosIMGSOrthoManager.hpp"
+
+namespace Belos {
+
+  template<class Storage, class MV, class OP>
+  class IMGSOrthoManager<Sacado::MP::Vector<Storage>,MV,OP> :
+    public MatOrthoManager<Sacado::MP::Vector<Storage>,MV,OP>,
+    public Teuchos::ParameterListAcceptorDefaultBase
+  {
+  private:
+    typedef Sacado::MP::Vector<Storage> ScalarType;
+    typedef typename Teuchos::ScalarTraits<ScalarType>::magnitudeType MagnitudeType;
+    typedef typename Teuchos::ScalarTraits<MagnitudeType> MGT;
+    typedef Teuchos::ScalarTraits<ScalarType>  SCT;
+    typedef MultiVecTraits<ScalarType,MV>      MVT;
+    typedef OperatorTraits<ScalarType,MV,OP>   OPT;
+
+  public:
+    //! @name Constructor/Destructor
+    //@{
+
+    //! Constructor specifying re-orthogonalization tolerance.
+    IMGSOrthoManager( const std::string& label = "Belos",
+                      Teuchos::RCP<const OP> Op = Teuchos::null,
+                      const int max_ortho_steps = max_ortho_steps_default_,
+                      const MagnitudeType blk_tol = blk_tol_default_,
+                      const MagnitudeType sing_tol = sing_tol_default_ )
+      : MatOrthoManager<ScalarType,MV,OP>(Op),
+        max_ortho_steps_( max_ortho_steps ),
+        blk_tol_( blk_tol ),
+        sing_tol_( sing_tol ),
+        label_( label )
+    {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+        std::stringstream ss;
+        ss << label_ + ": IMGS[" << max_ortho_steps_ << "]";
+
+        std::string orthoLabel = ss.str() + ": Orthogonalization";
+        timerOrtho_ = Teuchos::TimeMonitor::getNewCounter(orthoLabel);
+
+        std::string updateLabel = ss.str() + ": Ortho (Update)";
+        timerUpdate_ = Teuchos::TimeMonitor::getNewCounter(updateLabel);
+
+        std::string normLabel = ss.str() + ": Ortho (Norm)";
+        timerNorm_ = Teuchos::TimeMonitor::getNewCounter(normLabel);
+
+        std::string ipLabel = ss.str() + ": Ortho (Inner Product)";
+        timerInnerProd_ = Teuchos::TimeMonitor::getNewCounter(ipLabel);
+#endif
+    }
+
+    //! Constructor that takes a list of parameters.
+    IMGSOrthoManager (const Teuchos::RCP<Teuchos::ParameterList>& plist,
+                      const std::string& label = "Belos",
+                      Teuchos::RCP<const OP> Op = Teuchos::null) :
+      MatOrthoManager<ScalarType,MV,OP>(Op),
+      max_ortho_steps_ (max_ortho_steps_default_),
+      blk_tol_ (blk_tol_default_),
+      sing_tol_ (sing_tol_default_),
+      label_ (label)
+    {
+      setParameterList (plist);
+
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+      std::stringstream ss;
+      ss << label_ + ": IMGS[" << max_ortho_steps_ << "]";
+
+      std::string orthoLabel = ss.str() + ": Orthogonalization";
+      timerOrtho_ = Teuchos::TimeMonitor::getNewCounter(orthoLabel);
+
+      std::string updateLabel = ss.str() + ": Ortho (Update)";
+      timerUpdate_ = Teuchos::TimeMonitor::getNewCounter(updateLabel);
+
+      std::string normLabel = ss.str() + ": Ortho (Norm)";
+      timerNorm_ = Teuchos::TimeMonitor::getNewCounter(normLabel);
+
+      std::string ipLabel = ss.str() + ": Ortho (Inner Product)";
+      timerInnerProd_ = Teuchos::TimeMonitor::getNewCounter(ipLabel);
+#endif
+    }
+
+    //! Destructor
+    ~IMGSOrthoManager() {}
+    //@}
+
+    //! @name Implementation of Teuchos::ParameterListAcceptorDefaultBase interface
+    //@{
+    void
+    setParameterList (const Teuchos::RCP<Teuchos::ParameterList>& plist)
+    {
+      using Teuchos::Exceptions::InvalidParameterName;
+      using Teuchos::ParameterList;
+      using Teuchos::parameterList;
+      using Teuchos::RCP;
+
+      RCP<const ParameterList> defaultParams = getValidParameters();
+      RCP<ParameterList> params;
+      if (plist.is_null()) {
+        params = parameterList (*defaultParams);
+      } else {
+        params = plist;
+        // Some users might want to specify "blkTol" as "depTol".  Due
+        // to this case, we don't invoke
+        // validateParametersAndSetDefaults on params.  Instead, we go
+        // through the parameter list one parameter at a time and look
+        // for alternatives.
+      }
+
+      // Using temporary variables and fetching all values before
+      // setting the output arguments ensures the strong exception
+      // guarantee for this function: if an exception is thrown, no
+      // externally visible side effects (in this case, setting the
+      // output arguments) have taken place.
+      int maxNumOrthogPasses;
+      MagnitudeType blkTol;
+      MagnitudeType singTol;
+
+      try {
+        maxNumOrthogPasses = params->get<int> ("maxNumOrthogPasses");
+      } catch (InvalidParameterName&) {
+        maxNumOrthogPasses = defaultParams->get<int> ("maxNumOrthogPasses");
+        params->set ("maxNumOrthogPasses", maxNumOrthogPasses);
+      }
+
+      // Handling of the "blkTol" parameter is a special case.  This
+      // is because some users may prefer to call this parameter
+      // "depTol" for consistency with DGKS.  However, our default
+      // parameter list calls this "blkTol", and we don't want the
+      // default list's value to override the user's value.  Thus, we
+      // first check the user's parameter list for both names, and
+      // only then access the default parameter list.
+      try {
+        blkTol = params->get<MagnitudeType> ("blkTol");
+      } catch (InvalidParameterName&) {
+        try {
+          blkTol = params->get<MagnitudeType> ("depTol");
+          // "depTol" is the wrong name, so remove it and replace with
+          // "blkTol".  We'll set "blkTol" below.
+          params->remove ("depTol");
+        } catch (InvalidParameterName&) {
+          blkTol = defaultParams->get<MagnitudeType> ("blkTol");
+        }
+        params->set ("blkTol", blkTol);
+      }
+
+      try {
+        singTol = params->get<MagnitudeType> ("singTol");
+      } catch (InvalidParameterName&) {
+        singTol = defaultParams->get<MagnitudeType> ("singTol");
+        params->set ("singTol", singTol);
+      }
+
+      max_ortho_steps_ = maxNumOrthogPasses;
+      blk_tol_ = blkTol;
+      sing_tol_ = singTol;
+
+      setMyParamList (params);
+    }
+
+    Teuchos::RCP<const Teuchos::ParameterList>
+    getValidParameters () const
+    {
+      if (defaultParams_.is_null()) {
+        defaultParams_ = Belos::getIMGSDefaultParameters<ScalarType, MV, OP>();
+      }
+
+      return defaultParams_;
+    }
+
+    //@}
+
+    //! @name Accessor routines
+    //@{
+
+    //! Set parameter for block re-orthogonalization threshhold.
+    void setBlkTol( const MagnitudeType blk_tol ) { blk_tol_ = blk_tol; }
+
+    //! Set parameter for singular block detection.
+    void setSingTol( const MagnitudeType sing_tol ) { sing_tol_ = sing_tol; }
+
+    //! Return parameter for block re-orthogonalization threshhold.
+    MagnitudeType getBlkTol() const { return blk_tol_; }
+
+    //! Return parameter for singular block detection.
+    MagnitudeType getSingTol() const { return sing_tol_; }
+
+    //@}
+
+
+    //! @name Orthogonalization methods
+    //@{
+
+    /*! \brief Given a list of (mutually and internally) orthonormal bases \c Q, this method
+     * takes a multivector \c X and projects it onto the space orthogonal to the individual <tt>Q[i]</tt>,
+     * optionally returning the coefficients of \c X for the individual <tt>Q[i]</tt>. All of this is done with respect
+     * to the inner product innerProd().
+     *
+     * After calling this routine, \c X will be orthogonal to each of the \c <tt>Q[i]</tt>.
+     *
+     * The method uses either one or two steps of modified Gram-Schmidt. The algebraically
+     * equivalent projection matrix is \f$P_Q = I - Q Q^H Op\f$, if \c Op is the matrix specified for
+     * use in the inner product. Note, this is not an orthogonal projector.
+     *
+     @param X [in/out] The multivector to be modified.
+       On output, \c X will be orthogonal to <tt>Q[i]</tt> with respect to innerProd().
+
+     @param MX [in/out] The image of \c X under the operator \c Op.
+       If \f$ MX != 0\f$: On input, this is expected to be consistent with \c X. On output, this is updated consistent with updates to \c X.
+       If \f$ MX == 0\f$ or \f$ Op == 0\f$: \c MX is not referenced.
+
+     @param C [out] The coefficients of \c X in the \c *Q[i], with respect to innerProd(). If <tt>C[i]</tt> is a non-null pointer
+       and \c *C[i] matches the dimensions of \c X and \c *Q[i], then the coefficients computed during the orthogonalization
+       routine will be stored in the matrix \c *C[i]. If <tt>C[i]</tt> is a non-null pointer whose size does not match the dimensions of
+       \c X and \c *Q[i], then a std::invalid_argument std::exception will be thrown. Otherwise, if <tt>C.size() < i</tt> or <tt>C[i]</tt> is a null
+       pointer, then the orthogonalization manager will declare storage for the coefficients and the user will not have access to them.
+
+     @param Q [in] A list of multivector bases specifying the subspaces to be orthogonalized against. Each <tt>Q[i]</tt> is assumed to have
+     orthonormal columns, and the <tt>Q[i]</tt> are assumed to be mutually orthogonal.
+    */
+    void project ( MV &X, Teuchos::RCP<MV> MX,
+                   Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
+                   Teuchos::ArrayView<Teuchos::RCP<const MV> > Q) const;
+
+
+    /*! \brief This method calls project(X,Teuchos::null,C,Q); see documentation for that function.
+    */
+    void project ( MV &X,
+                   Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
+                   Teuchos::ArrayView<Teuchos::RCP<const MV> > Q) const {
+      project(X,Teuchos::null,C,Q);
+    }
+
+
+
+    /*! \brief This method takes a multivector \c X and attempts to compute an orthonormal basis for \f$colspan(X)\f$, with respect to innerProd().
+     *
+     * The method uses modified Gram-Schmidt, so that the coefficient matrix \c B is upper triangular.
+     *
+     * This routine returns an integer \c rank stating the rank of the computed basis. If \c X does not have full rank and the normalize() routine does
+     * not attempt to augment the subspace, then \c rank may be smaller than the number of columns in \c X. In this case, only the first \c rank columns of
+     * output \c X and first \c rank rows of \c B will be valid.
+     *
+     * The method attempts to find a basis with dimension the same as the number of columns in \c X. It does this by augmenting linearly dependant
+     * vectors in \c X with random directions. A finite number of these attempts will be made; therefore, it is possible that the dimension of the
+     * computed basis is less than the number of vectors in \c X.
+     *
+     @param X [in/out] The multivector to the modified.
+       On output, \c X will have some number of orthonormal columns (with respect to innerProd()).
+
+     @param MX [in/out] The image of \c X under the operator \c Op.
+       If \f$ MX != 0\f$: On input, this is expected to be consistent with \c X. On output, this is updated consistent with updates to \c X.
+       If \f$ MX == 0\f$ or \f$ Op == 0\f$: \c MX is not referenced.
+
+     @param B [out] The coefficients of the original \c X with respect to the computed basis. The first rows in \c B
+            corresponding to the valid columns in \c X will be upper triangular.
+
+     @return Rank of the basis computed by this method.
+    */
+    int normalize ( MV &X, Teuchos::RCP<MV> MX,
+                    Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > B) const;
+
+
+    /*! \brief This method calls normalize(X,Teuchos::null,B); see documentation for that function.
+    */
+    int normalize ( MV &X, Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > B ) const {
+      return normalize(X,Teuchos::null,B);
+    }
+
+  protected:
+    /*! \brief Given a set of bases <tt>Q[i]</tt> and a multivector \c X, this method computes an orthonormal basis for \f$colspan(X) - \sum_i colspan(Q[i])\f$.
+     *
+     *  This routine returns an integer \c rank stating the rank of the computed basis. If the subspace \f$colspan(X) - \sum_i colspan(Q[i])\f$ does not
+     *  have dimension as large as the number of columns of \c X and the orthogonalization manager doe not attempt to augment the subspace, then \c rank
+     *  may be smaller than the number of columns of \c X. In this case, only the first \c rank columns of output \c X and first \c rank rows of \c B will
+     *  be valid.
+     *
+     * The method attempts to find a basis with dimension the same as the number of columns in \c X. It does this by augmenting linearly dependant
+     * vectors with random directions. A finite number of these attempts will be made; therefore, it is possible that the dimension of the
+     * computed basis is less than the number of vectors in \c X.
+     *
+     @param X [in/out] The multivector to the modified.
+       On output, the relevant rows of \c X will be orthogonal to the <tt>Q[i]</tt> and will have orthonormal columns (with respect to innerProd()).
+
+     @param MX [in/out] The image of \c X under the operator \c Op.
+       If \f$ MX != 0\f$: On input, this is expected to be consistent with \c X. On output, this is updated consistent with updates to \c X.
+       If \f$ MX == 0\f$ or \f$ Op == 0\f$: \c MX is not referenced.
+
+     @param C [out] The coefficients of the original \c X in the \c
+     *Q[i], with respect to innerProd(). If <tt>C[i]</tt> is a
+     non-null pointer and \c *C[i] matches the dimensions of \c X and
+     \c *Q[i], then the coefficients computed during the
+     orthogonalization routine will be stored in the matrix \c
+     *C[i]. If <tt>C[i]</tt> is a non-null pointer whose size does not
+     match the dimensions of \c X and \c *Q[i], then *C[i] will first
+     be resized to the correct size.  This will destroy the original
+     contents of the matrix.  (This is a change from previous
+     behavior, in which a std::invalid_argument exception was thrown
+     if *C[i] was of the wrong size.)  Otherwise, if <tt>C.size() <
+     i<\tt> or <tt>C[i]</tt> is a null pointer, then the
+     orthogonalization manager will declare storage for the
+     coefficients and the user will not have access to them.
+
+     @param B [out] The coefficients of the original \c X with respect to the computed basis. The first rows in \c B
+            corresponding to the valid columns in \c X will be upper triangular.
+
+     @param Q [in] A list of multivector bases specifying the subspaces to be orthogonalized against. Each <tt>Q[i]</tt> is assumed to have
+     orthonormal columns, and the <tt>Q[i]</tt> are assumed to be mutually orthogonal.
+
+     @return Rank of the basis computed by this method.
+    */
+    virtual int
+    projectAndNormalizeWithMxImpl (MV &X,
+                                   Teuchos::RCP<MV> MX,
+                                   Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
+                                   Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > B,
+                                   Teuchos::ArrayView<Teuchos::RCP<const MV> > Q) const;
+
+  public:
+    //@}
+    //! @name Error methods
+    //@{
+
+    /*! \brief This method computes the error in orthonormality of a multivector, measured
+     * as the Frobenius norm of the difference <tt>innerProd(X,Y) - I</tt>.
+     */
+    typename Teuchos::ScalarTraits<ScalarType>::magnitudeType
+    orthonormError(const MV &X) const {
+      return orthonormError(X,Teuchos::null);
+    }
+
+    /*! \brief This method computes the error in orthonormality of a multivector, measured
+     * as the Frobenius norm of the difference <tt>innerProd(X,Y) - I</tt>.
+     *  The method has the option of exploiting a caller-provided \c MX.
+     */
+    typename Teuchos::ScalarTraits<ScalarType>::magnitudeType
+    orthonormError(const MV &X, Teuchos::RCP<const MV> MX) const;
+
+    /*! \brief This method computes the error in orthogonality of two multivectors, measured
+     * as the Frobenius norm of <tt>innerProd(X,Y)</tt>.
+     */
+    typename Teuchos::ScalarTraits<ScalarType>::magnitudeType
+    orthogError(const MV &X1, const MV &X2) const {
+      return orthogError(X1,Teuchos::null,X2);
+    }
+
+    /*! \brief This method computes the error in orthogonality of two multivectors, measured
+     * as the Frobenius norm of <tt>innerProd(X,Y)</tt>.
+     *  The method has the option of exploiting a caller-provided \c MX.
+     */
+    typename Teuchos::ScalarTraits<ScalarType>::magnitudeType
+    orthogError(const MV &X1, Teuchos::RCP<const MV> MX1, const MV &X2) const;
+
+    //@}
+
+    //! @name Label methods
+    //@{
+
+    /*! \brief This method sets the label used by the timers in the orthogonalization manager.
+     */
+    void setLabel(const std::string& label);
+
+    /*! \brief This method returns the label being used by the timers in the orthogonalization manager.
+     */
+    const std::string& getLabel() const { return label_; }
+
+    //@}
+
+    //! @name Default orthogonalization constants
+    //@{
+
+    //! Max number of (re)orthogonalization steps, including the first (default).
+    static const int max_ortho_steps_default_;
+    //! Block reorthogonalization threshold (default).
+    static const MagnitudeType blk_tol_default_;
+    //! Singular block detection threshold (default).
+    static const MagnitudeType sing_tol_default_;
+
+    //! Max number of (re)orthogonalization steps, including the first (fast).
+    static const int max_ortho_steps_fast_;
+    //! Block reorthogonalization threshold (fast).
+    static const MagnitudeType blk_tol_fast_;
+    //! Singular block detection threshold (fast).
+    static const MagnitudeType sing_tol_fast_;
+
+    //@}
+
+  private:
+
+    //! Max number of (re)orthogonalization steps, including the first.
+    int max_ortho_steps_;
+    //! Block reorthogonalization tolerance.
+    MagnitudeType blk_tol_;
+    //! Singular block detection threshold.
+    MagnitudeType sing_tol_;
+
+    //! Label for timers.
+    std::string label_;
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+    Teuchos::RCP<Teuchos::Time> timerOrtho_, timerUpdate_, timerNorm_, timerInnerProd_;
+#endif // BELOS_TEUCHOS_TIME_MONITOR
+
+    //! Default parameter list.
+    mutable Teuchos::RCP<Teuchos::ParameterList> defaultParams_;
+
+    //! Routine to find an orthonormal basis for X
+    int findBasis(MV &X, Teuchos::RCP<MV> MX,
+                  Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > C,
+                  bool completeBasis, int howMany = -1 ) const;
+
+    //! Routine to compute the block orthogonalization
+    bool blkOrtho1 ( MV &X, Teuchos::RCP<MV> MX,
+                     Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
+                     Teuchos::ArrayView<Teuchos::RCP<const MV> > Q) const;
+
+    //! Routine to compute the block orthogonalization
+    bool blkOrtho ( MV &X, Teuchos::RCP<MV> MX,
+                    Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
+                    Teuchos::ArrayView<Teuchos::RCP<const MV> > Q) const;
+
+    /// Project X against QQ and normalize X, one vector at a time
+    ///
+    /// \note QQ is called QQ, rather than Q, because we convert it
+    ///   internally from an ArrayView to an Array (named Q inside).
+    ///   This is because the C++ compiler doesn't know how to do type
+    ///   inference (Array has a constructor that takes an ArrayView
+    ///   input).  This routine wants an Array rather than an
+    ///   ArrayView internally, because it likes to add (via
+    ///   push_back()) and remove (via resize()) elements to the Q
+    ///   array.  Remember that Arrays can be passed by value, just
+    ///   like std::vector objects, so this routine can add whatever
+    ///   it likes to the Q array without changing it from the
+    ///   caller's perspective.
+    int blkOrthoSing ( MV &X, Teuchos::RCP<MV> MX,
+                       Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
+                       Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > B,
+                       Teuchos::ArrayView<Teuchos::RCP<const MV> > QQ) const;
+  };
+
+  // Set static variables.
+  template<class StorageType, class MV, class OP>
+  const int IMGSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::max_ortho_steps_default_ = 1;
+
+  template<class StorageType, class MV, class OP>
+  const typename IMGSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::MagnitudeType
+  IMGSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::blk_tol_default_
+    = 10*Teuchos::ScalarTraits<typename IMGSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::MagnitudeType>::squareroot(
+      Teuchos::ScalarTraits<typename IMGSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::MagnitudeType>::eps() );
+
+  template<class StorageType, class MV, class OP>
+  const typename IMGSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::MagnitudeType
+  IMGSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::sing_tol_default_
+    = 10*Teuchos::ScalarTraits<typename IMGSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::MagnitudeType>::eps();
+
+  template<class StorageType, class MV, class OP>
+  const int IMGSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::max_ortho_steps_fast_ = 1;
+
+  template<class StorageType, class MV, class OP>
+  const typename IMGSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::MagnitudeType
+  IMGSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::blk_tol_fast_
+    = Teuchos::ScalarTraits<typename IMGSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::MagnitudeType>::zero();
+
+  template<class StorageType, class MV, class OP>
+  const typename IMGSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::MagnitudeType
+  IMGSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::sing_tol_fast_
+    = Teuchos::ScalarTraits<typename IMGSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::MagnitudeType>::zero();
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  // Set the label for this orthogonalization manager and create new timers if it's changed
+  template<class StorageType, class MV, class OP>
+  void IMGSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::setLabel(const std::string& label)
+  {
+    if (label != label_) {
+      label_ = label;
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+      std::stringstream ss;
+      ss << label_ + ": IMGS[" << max_ortho_steps_ << "]";
+
+      std::string orthoLabel = ss.str() + ": Orthogonalization";
+      timerOrtho_ = Teuchos::TimeMonitor::getNewCounter(orthoLabel);
+
+      std::string updateLabel = ss.str() + ": Ortho (Update)";
+      timerUpdate_ = Teuchos::TimeMonitor::getNewCounter(updateLabel);
+
+      std::string normLabel = ss.str() + ": Ortho (Norm)";
+      timerNorm_ = Teuchos::TimeMonitor::getNewCounter(normLabel);
+
+      std::string ipLabel = ss.str() + ": Ortho (Inner Product)";
+      timerInnerProd_ = Teuchos::TimeMonitor::getNewCounter(ipLabel);
+#endif
+    }
+  }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  // Compute the distance from orthonormality
+  template<class StorageType, class MV, class OP>
+  typename Teuchos::ScalarTraits<Sacado::MP::Vector<StorageType> >::magnitudeType
+  IMGSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::orthonormError(const MV &X, Teuchos::RCP<const MV> MX) const {
+    const ScalarType ONE = SCT::one();
+    int rank = MVT::GetNumberVecs(X);
+    Teuchos::SerialDenseMatrix<int,ScalarType> xTx(rank,rank);
+    MatOrthoManager<ScalarType,MV,OP>::innerProd(X,X,MX,xTx);
+    for (int i=0; i<rank; i++) {
+      xTx(i,i) -= ONE;
+    }
+    return xTx.normFrobenius();
+  }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  // Compute the distance from orthogonality
+  template<class StorageType, class MV, class OP>
+  typename Teuchos::ScalarTraits<Sacado::MP::Vector<StorageType> >::magnitudeType
+  IMGSOrthoManager<Sacado::MP::Vector<StorageType>,MV,OP>::orthogError(const MV &X1, Teuchos::RCP<const MV> MX1, const MV &X2) const {
+    int r1 = MVT::GetNumberVecs(X1);
+    int r2  = MVT::GetNumberVecs(X2);
+    Teuchos::SerialDenseMatrix<int,ScalarType> xTx(r2,r1);
+    MatOrthoManager<ScalarType,MV,OP>::innerProd(X2,X1,MX1,xTx);
+    return xTx.normFrobenius();
+  }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  // Find an Op-orthonormal basis for span(X) - span(W)
+  template<class StorageType, class MV, class OP>
+  int
+  IMGSOrthoManager<Sacado::MP::Vector<StorageType>, MV, OP>::
+  projectAndNormalizeWithMxImpl(MV &X,
+                                Teuchos::RCP<MV> MX,
+                                Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
+                                Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > B,
+                                Teuchos::ArrayView<Teuchos::RCP<const MV> > Q) const
+  {
+    using Teuchos::Array;
+    using Teuchos::null;
+    using Teuchos::is_null;
+    using Teuchos::RCP;
+    using Teuchos::rcp;
+    using Teuchos::SerialDenseMatrix;
+    typedef SerialDenseMatrix< int, ScalarType > serial_dense_matrix_type;
+    typedef typename Array< RCP< const MV > >::size_type size_type;
+
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+    Teuchos::TimeMonitor orthotimer(*timerOrtho_);
+#endif
+
+    ScalarType    ONE  = SCT::one();
+    const MagnitudeType ZERO = MGT::zero();
+
+    int nq = Q.size();
+    int xc = MVT::GetNumberVecs( X );
+    ptrdiff_t xr = MVT::GetGlobalLength( X );
+    int rank = xc;
+
+    // If the user doesn't want to store the normalization
+    // coefficients, allocate some local memory for them.  This will
+    // go away at the end of this method.
+    if (is_null (B)) {
+      B = rcp (new serial_dense_matrix_type (xc, xc));
+    }
+    // Likewise, if the user doesn't want to store the projection
+    // coefficients, allocate some local memory for them.  Also make
+    // sure that all the entries of C are the right size.  We're going
+    // to overwrite them anyway, so we don't have to worry about the
+    // contents (other than to resize them if they are the wrong
+    // size).
+    if (C.size() < nq)
+      C.resize (nq);
+    for (size_type k = 0; k < nq; ++k)
+      {
+        const int numRows = MVT::GetNumberVecs (*Q[k]);
+        const int numCols = xc; // Number of vectors in X
+
+        if (is_null (C[k]))
+          C[k] = rcp (new serial_dense_matrix_type (numRows, numCols));
+        else if (C[k]->numRows() != numRows || C[k]->numCols() != numCols)
+          {
+            int err = C[k]->reshape (numRows, numCols);
+            TEUCHOS_TEST_FOR_EXCEPTION(err != 0, std::runtime_error,
+                               "IMGS orthogonalization: failed to reshape "
+                               "C[" << k << "] (the array of block "
+                               "coefficients resulting from projecting X "
+                               "against Q[1:" << nq << "]).");
+          }
+      }
+
+    /******   DO NOT MODIFY *MX IF _hasOp == false   ******/
+    if (this->_hasOp) {
+      if (MX == Teuchos::null) {
+        // we need to allocate space for MX
+        MX = MVT::Clone(X,MVT::GetNumberVecs(X));
+        OPT::Apply(*(this->_Op),X,*MX);
+      }
+    }
+    else {
+      // Op == I  -->  MX = X (ignore it if the user passed it in)
+      MX = Teuchos::rcp( &X, false );
+    }
+
+    int mxc = MVT::GetNumberVecs( *MX );
+    ptrdiff_t mxr = MVT::GetGlobalLength( *MX );
+
+    // short-circuit
+    TEUCHOS_TEST_FOR_EXCEPTION( xc == 0 || xr == 0, std::invalid_argument, "Belos::IMGSOrthoManager::projectAndNormalize(): X must be non-empty" );
+
+    int numbas = 0;
+    for (int i=0; i<nq; i++) {
+      numbas += MVT::GetNumberVecs( *Q[i] );
+    }
+
+    // check size of B
+    TEUCHOS_TEST_FOR_EXCEPTION( B->numRows() != xc || B->numCols() != xc, std::invalid_argument,
+                        "Belos::IMGSOrthoManager::projectAndNormalize(): Size of X must be consistant with size of B" );
+    // check size of X and MX
+    TEUCHOS_TEST_FOR_EXCEPTION( xc<0 || xr<0 || mxc<0 || mxr<0, std::invalid_argument,
+                        "Belos::IMGSOrthoManager::projectAndNormalize(): MVT returned negative dimensions for X,MX" );
+    // check size of X w.r.t. MX
+    TEUCHOS_TEST_FOR_EXCEPTION( xc!=mxc || xr!=mxr, std::invalid_argument,
+                        "Belos::IMGSOrthoManager::projectAndNormalize(): Size of X must be consistant with size of MX" );
+    // check feasibility
+    //TEUCHOS_TEST_FOR_EXCEPTION( numbas+xc > xr, std::invalid_argument,
+    //                    "Belos::IMGSOrthoManager::projectAndNormalize(): Orthogonality constraints not feasible" );
+
+    // Some flags for checking dependency returns from the internal orthogonalization methods
+    bool dep_flg = false;
+
+    // Make a temporary copy of X and MX, just in case a block dependency is detected.
+    Teuchos::RCP<MV> tmpX, tmpMX;
+    tmpX = MVT::CloneCopy(X);
+    if (this->_hasOp) {
+      tmpMX = MVT::CloneCopy(*MX);
+    }
+
+    if (xc == 1) {
+
+      // Use the cheaper block orthogonalization.
+      // NOTE: Don't check for dependencies because the update has one vector.
+      dep_flg = blkOrtho1( X, MX, C, Q );
+
+      // Normalize the new block X
+      if ( B == Teuchos::null ) {
+        B = Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>(xc,xc) );
+      }
+      std::vector<ScalarType> diag(xc);
+      {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+        Teuchos::TimeMonitor normTimer( *timerNorm_ );
+#endif
+        MVT::MvDot( X, *MX, diag );
+      }
+      (*B)(0,0) = SCT::squareroot(SCT::magnitude(diag[0]));
+
+      ScalarType scale = ONE;
+      mask_assign((*B)(0,0)!= ZERO, scale) /= (*B)(0,0);
+
+      if(MaskLogic::OR((*B)(0,0)!= ZERO) )
+        rank = 1;
+      MVT::MvScale( X, scale );
+      if (this->_hasOp) {
+        // Update MXj.
+        MVT::MvScale( *MX, scale );
+      }
+    }
+    else {
+
+      // Use the cheaper block orthogonalization.
+      dep_flg = blkOrtho( X, MX, C, Q );
+
+      // If a dependency has been detected in this block, then perform
+      // the more expensive nonblock (single vector at a time)
+      // orthogonalization.
+      if (dep_flg) {
+        rank = blkOrthoSing( *tmpX, tmpMX, C, B, Q );
+
+        // Copy tmpX back into X.
+        MVT::Assign( *tmpX, X );
+        if (this->_hasOp) {
+          MVT::Assign( *tmpMX, *MX );
+        }
+      }
+      else {
+        // There is no dependency, so orthonormalize new block X
+        rank = findBasis( X, MX, B, false );
+        if (rank < xc) {
+          // A dependency was found during orthonormalization of X,
+          // rerun orthogonalization using more expensive single-
+          // vector orthogonalization.
+          rank = blkOrthoSing( *tmpX, tmpMX, C, B, Q );
+
+          // Copy tmpX back into X.
+          MVT::Assign( *tmpX, X );
+          if (this->_hasOp) {
+            MVT::Assign( *tmpMX, *MX );
+          }
+        }
+      }
+    } // if (xc == 1) {
+
+    // this should not raise an std::exception; but our post-conditions oblige us to check
+    TEUCHOS_TEST_FOR_EXCEPTION( rank > xc || rank < 0, std::logic_error,
+                        "Belos::IMGSOrthoManager::projectAndNormalize(): Debug error in rank variable." );
+
+    // Return the rank of X.
+    return rank;
+  }
+
+
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  // Find an Op-orthonormal basis for span(X), with rank numvectors(X)
+  template<class StorageType, class MV, class OP>
+  int IMGSOrthoManager<Sacado::MP::Vector<StorageType>, MV, OP>::normalize(
+                                MV &X, Teuchos::RCP<MV> MX,
+                                Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > B ) const {
+
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+    Teuchos::TimeMonitor orthotimer(*timerOrtho_);
+#endif
+
+    // call findBasis, with the instruction to try to generate a basis of rank numvecs(X)
+    return findBasis(X, MX, B, true);
+  }
+
+
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  template<class StorageType, class MV, class OP>
+  void IMGSOrthoManager<Sacado::MP::Vector<StorageType>, MV, OP>::project(
+                          MV &X, Teuchos::RCP<MV> MX,
+                          Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
+                          Teuchos::ArrayView<Teuchos::RCP<const MV> > Q) const {
+    // For the inner product defined by the operator Op or the identity (Op == 0)
+    //   -> Orthogonalize X against each Q[i]
+    // Modify MX accordingly
+    //
+    // Note that when Op is 0, MX is not referenced
+    //
+    // Parameter variables
+    //
+    // X  : Vectors to be transformed
+    //
+    // MX : Image of the block of vectors X by the mass matrix
+    //
+    // Q  : Bases to orthogonalize against. These are assumed orthonormal, mutually and independently.
+    //
+
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+    Teuchos::TimeMonitor orthotimer(*timerOrtho_);
+#endif
+
+    int xc = MVT::GetNumberVecs( X );
+    ptrdiff_t xr = MVT::GetGlobalLength( X );
+    int nq = Q.size();
+    std::vector<int> qcs(nq);
+    // short-circuit
+    if (nq == 0 || xc == 0 || xr == 0) {
+      return;
+    }
+    ptrdiff_t qr = MVT::GetGlobalLength ( *Q[0] );
+    // if we don't have enough C, expand it with null references
+    // if we have too many, resize to throw away the latter ones
+    // if we have exactly as many as we have Q, this call has no effect
+    C.resize(nq);
+
+
+    /******   DO NOT MODIFY *MX IF _hasOp == false   ******/
+    if (this->_hasOp) {
+      if (MX == Teuchos::null) {
+        // we need to allocate space for MX
+        MX = MVT::Clone(X,MVT::GetNumberVecs(X));
+        OPT::Apply(*(this->_Op),X,*MX);
+      }
+    }
+    else {
+      // Op == I  -->  MX = X (ignore it if the user passed it in)
+      MX = Teuchos::rcp( &X, false );
+    }
+    int mxc = MVT::GetNumberVecs( *MX );
+    ptrdiff_t mxr = MVT::GetGlobalLength( *MX );
+
+    // check size of X and Q w.r.t. common sense
+    TEUCHOS_TEST_FOR_EXCEPTION( xc<0 || xr<0 || mxc<0 || mxr<0, std::invalid_argument,
+                        "Belos::IMGSOrthoManager::project(): MVT returned negative dimensions for X,MX" );
+    // check size of X w.r.t. MX and Q
+    TEUCHOS_TEST_FOR_EXCEPTION( xc!=mxc || xr!=mxr || xr!=qr, std::invalid_argument,
+                        "Belos::IMGSOrthoManager::project(): Size of X not consistant with MX,Q" );
+
+    // tally up size of all Q and check/allocate C
+    int baslen = 0;
+    for (int i=0; i<nq; i++) {
+      TEUCHOS_TEST_FOR_EXCEPTION( MVT::GetGlobalLength( *Q[i] ) != qr, std::invalid_argument,
+                          "Belos::IMGSOrthoManager::project(): Q lengths not mutually consistant" );
+      qcs[i] = MVT::GetNumberVecs( *Q[i] );
+      TEUCHOS_TEST_FOR_EXCEPTION( qr < qcs[i], std::invalid_argument,
+                          "Belos::IMGSOrthoManager::project(): Q has less rows than columns" );
+      baslen += qcs[i];
+
+      // check size of C[i]
+      if ( C[i] == Teuchos::null ) {
+        C[i] = Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>(qcs[i],xc) );
+      }
+      else {
+        TEUCHOS_TEST_FOR_EXCEPTION( C[i]->numRows() != qcs[i] || C[i]->numCols() != xc , std::invalid_argument,
+                           "Belos::IMGSOrthoManager::project(): Size of Q not consistant with size of C" );
+      }
+    }
+
+    // Use the cheaper block orthogonalization, don't check for rank deficiency.
+    blkOrtho( X, MX, C, Q );
+
+  }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  // Find an Op-orthonormal basis for span(X), with the option of extending the subspace so that
+  // the rank is numvectors(X)
+  template<class StorageType, class MV, class OP>
+  int IMGSOrthoManager<Sacado::MP::Vector<StorageType>, MV, OP>::findBasis(
+                                                      MV &X, Teuchos::RCP<MV> MX,
+                                                      Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > B,
+                                                      bool completeBasis, int howMany ) const {
+    // For the inner product defined by the operator Op or the identity (Op == 0)
+    //   -> Orthonormalize X
+    // Modify MX accordingly
+    //
+    // Note that when Op is 0, MX is not referenced
+    //
+    // Parameter variables
+    //
+    // X  : Vectors to be orthonormalized
+    //
+    // MX : Image of the multivector X under the operator Op
+    //
+    // Op  : Pointer to the operator for the inner product
+    //
+    //
+
+    const ScalarType ONE  = SCT::one();
+    const MagnitudeType ZERO = SCT::magnitude(SCT::zero());
+
+    int xc = MVT::GetNumberVecs( X );
+    ptrdiff_t xr = MVT::GetGlobalLength( X );
+
+    if (howMany == -1) {
+      howMany = xc;
+    }
+
+    /*******************************************************
+     *  If _hasOp == false, we will not reference MX below *
+     *******************************************************/
+
+    // if Op==null, MX == X (via pointer)
+    // Otherwise, either the user passed in MX or we will allocated and compute it
+    if (this->_hasOp) {
+      if (MX == Teuchos::null) {
+        // we need to allocate space for MX
+        MX = MVT::Clone(X,xc);
+        OPT::Apply(*(this->_Op),X,*MX);
+      }
+    }
+
+    /* if the user doesn't want to store the coefficienets,
+     * allocate some local memory for them
+     */
+    if ( B == Teuchos::null ) {
+      B = Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>(xc,xc) );
+    }
+
+    int mxc = (this->_hasOp) ? MVT::GetNumberVecs( *MX ) : xc;
+    ptrdiff_t mxr = (this->_hasOp) ? MVT::GetGlobalLength( *MX ) : xr;
+
+    // check size of C, B
+    TEUCHOS_TEST_FOR_EXCEPTION( xc == 0 || xr == 0, std::invalid_argument,
+                        "Belos::IMGSOrthoManager::findBasis(): X must be non-empty" );
+    TEUCHOS_TEST_FOR_EXCEPTION( B->numRows() != xc || B->numCols() != xc, std::invalid_argument,
+                        "Belos::IMGSOrthoManager::findBasis(): Size of X not consistant with size of B" );
+    TEUCHOS_TEST_FOR_EXCEPTION( xc != mxc || xr != mxr, std::invalid_argument,
+                        "Belos::IMGSOrthoManager::findBasis(): Size of X not consistant with size of MX" );
+    TEUCHOS_TEST_FOR_EXCEPTION( xc > xr, std::invalid_argument,
+                        "Belos::IMGSOrthoManager::findBasis(): Size of X not feasible for normalization" );
+    TEUCHOS_TEST_FOR_EXCEPTION( howMany < 0 || howMany > xc, std::invalid_argument,
+                        "Belos::IMGSOrthoManager::findBasis(): Invalid howMany parameter" );
+
+    /* xstart is which column we are starting the process with, based on howMany
+     * columns before xstart are assumed to be Op-orthonormal already
+     */
+    int xstart = xc - howMany;
+
+    for (int j = xstart; j < xc; j++) {
+
+      // numX is
+      // * number of currently orthonormal columns of X
+      // * the index of the current column of X
+      int numX = j;
+      bool addVec = false;
+
+      // Get a view of the vector currently being worked on.
+      std::vector<int> index(1);
+      index[0] = numX;
+      Teuchos::RCP<MV> Xj = MVT::CloneViewNonConst( X, index );
+      Teuchos::RCP<MV> MXj;
+      if ((this->_hasOp)) {
+        // MXj is a view of the current vector in MX
+        MXj = MVT::CloneViewNonConst( *MX, index );
+      }
+      else {
+        // MXj is a pointer to Xj, and MUST NOT be modified
+        MXj = Xj;
+      }
+
+      Teuchos::RCP<MV> oldMXj; 
+      if (numX > 0) {
+        oldMXj = MVT::CloneCopy( *MXj );
+      }
+ 
+      // Make storage for these Gram-Schmidt iterations.
+      Teuchos::SerialDenseVector<int,ScalarType> product(numX);
+      Teuchos::SerialDenseVector<int,ScalarType> P2(1);
+      Teuchos::RCP<const MV> prevX, prevMX;
+
+      std::vector<ScalarType> oldDot( 1 ), newDot( 1 );
+      //
+      // Save old MXj vector and compute Op-norm
+      //
+      {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+      Teuchos::TimeMonitor normTimer( *timerNorm_ );
+#endif
+      MVT::MvDot( *Xj, *MXj, oldDot );
+      }
+      // Xj^H Op Xj should be real and positive, by the hermitian positive definiteness of Op
+      TEUCHOS_TEST_FOR_EXCEPTION( SCT::real(oldDot[0]) < ZERO, OrthoError,
+                          "Belos::IMGSOrthoManager::findBasis(): Negative definiteness discovered in inner product" );
+
+      // Perform MGS one vector at a time
+      for (int ii=0; ii<numX; ii++) {
+
+        index[0] = ii;
+        prevX = MVT::CloneView( X, index );
+        if (this->_hasOp) {
+          prevMX = MVT::CloneView( *MX, index );
+        }
+
+        for (int i=0; i<max_ortho_steps_; ++i) {
+
+          // product <- prevX^T MXj
+          {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+            Teuchos::TimeMonitor innerProdTimer( *timerInnerProd_ );
+#endif
+            MatOrthoManager<ScalarType,MV,OP>::innerProd(*prevX,*Xj,MXj,P2);
+          }
+
+          // Xj <- Xj - prevX prevX^T MXj
+          //     = Xj - prevX product
+          {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+            Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+            MVT::MvTimesMatAddMv( -ONE, *prevX, P2, ONE, *Xj );
+          }
+
+          // Update MXj
+          if (this->_hasOp) {
+            // MXj <- Op*Xj_new
+            //      = Op*(Xj_old - prevX prevX^T MXj)
+            //      = MXj - prevMX product
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+            Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+            MVT::MvTimesMatAddMv( -ONE, *prevMX, P2, ONE, *MXj );
+          }
+
+          // Set coefficients
+          if ( i==0 )
+            product[ii] = P2[0];
+          else
+            product[ii] += P2[0];
+
+        } // for (int i=0; i<max_ortho_steps_; ++i)
+
+      } // for (int ii=0; ii<numX; ++ii)
+
+      // Compute Op-norm with old MXj
+      if (numX > 0) {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+        Teuchos::TimeMonitor normTimer( *timerNorm_ );
+#endif
+        MVT::MvDot( *Xj, *oldMXj, newDot );
+      }
+      else {
+        newDot[0] = oldDot[0];
+      }
+
+      // Check to see if the new vector is dependent.
+      if (completeBasis) {
+        //
+        // We need a complete basis, so add random vectors if necessary
+        //
+        if ( SCT::magnitude(newDot[0]) < SCT::magnitude(sing_tol_*oldDot[0]) ) {
+
+          // Add a random vector and orthogonalize it against previous vectors in block.
+          addVec = true;
+#ifdef ORTHO_DEBUG
+          std::cout << "Belos::IMGSOrthoManager::findBasis() --> Random for column " << numX << std::endl;
+#endif
+          //
+          Teuchos::RCP<MV> tempXj = MVT::Clone( X, 1 );
+          Teuchos::RCP<MV> tempMXj;
+          MVT::MvRandom( *tempXj );
+          if (this->_hasOp) {
+            tempMXj = MVT::Clone( X, 1 );
+            OPT::Apply( *(this->_Op), *tempXj, *tempMXj );
+          }
+          else {
+            tempMXj = tempXj;
+          }
+          {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+          Teuchos::TimeMonitor normTimer( *timerNorm_ );
+#endif
+          MVT::MvDot( *tempXj, *tempMXj, oldDot );
+          }
+          //
+          // Perform MGS one vector at a time
+          for (int ii=0; ii<numX; ii++) {
+
+            index[0] = ii;
+            prevX = MVT::CloneView( X, index );
+            if (this->_hasOp) {
+              prevMX = MVT::CloneView( *MX, index );
+            }
+
+            for (int num_orth=0; num_orth<max_ortho_steps_; num_orth++){
+              {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+                Teuchos::TimeMonitor innerProdTimer( *timerInnerProd_ );
+#endif
+                MatOrthoManager<ScalarType,MV,OP>::innerProd(*prevX,*tempXj,tempMXj,P2);
+              }
+              {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+                Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+                MVT::MvTimesMatAddMv( -ONE, *prevX, P2, ONE, *tempXj );
+              }
+              if (this->_hasOp) {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+                Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+                MVT::MvTimesMatAddMv( -ONE, *prevMX, P2, ONE, *tempMXj );
+              }
+
+              // Set coefficients
+              if ( num_orth==0 )
+                product[ii] = P2[0];
+              else
+                product[ii] += P2[0];
+            }
+          }
+
+          // Compute new Op-norm
+          {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+          Teuchos::TimeMonitor normTimer( *timerNorm_ );
+#endif
+          MVT::MvDot( *tempXj, *tempMXj, newDot );
+          }
+          //
+          if ( SCT::magnitude(newDot[0]) >= SCT::magnitude(oldDot[0]*sing_tol_) ) {
+            // Copy vector into current column of _basisvecs
+            MVT::Assign( *tempXj, *Xj );
+            if (this->_hasOp) {
+              MVT::Assign( *tempMXj, *MXj );
+            }
+          }
+          else {
+            return numX;
+          }
+        }
+      }
+      else {
+        //
+        // We only need to detect dependencies.
+        //
+        if ( SCT::magnitude(newDot[0]) < SCT::magnitude(oldDot[0]*blk_tol_) ) {
+          return numX;
+        }
+      }
+
+
+      // If we haven't left this method yet, then we can normalize the new vector Xj.
+      // Normalize Xj.
+      // Xj <- Xj / std::sqrt(newDot)
+      ScalarType diag = SCT::squareroot(SCT::magnitude(newDot[0]));
+      ScalarType scale = ONE;
+      mask_assign(SCT::magnitude(diag) > ZERO, scale) /= diag;
+      MVT::MvScale( *Xj, scale );
+      if (this->_hasOp) {
+        // Update MXj.
+        MVT::MvScale( *MXj, scale );
+      }
+
+      // If we've added a random vector, enter a zero in the j'th diagonal element.
+      if (addVec) {
+        (*B)(j,j) = ZERO;
+      }
+      else {
+        (*B)(j,j) = diag;
+      }
+
+      // Save the coefficients, if we are working on the original vector and not a randomly generated one
+      if (!addVec) {
+        for (int i=0; i<numX; i++) {
+          (*B)(i,j) = product(i);
+        }
+      }
+
+    } // for (j = 0; j < xc; ++j)
+
+    return xc;
+  }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  // Routine to compute the block orthogonalization
+  template<class StorageType, class MV, class OP>
+  bool
+  IMGSOrthoManager<Sacado::MP::Vector<StorageType>, MV, OP>::blkOrtho1 ( MV &X, Teuchos::RCP<MV> MX,
+                                                    Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
+                                                    Teuchos::ArrayView<Teuchos::RCP<const MV> > Q) const
+  {
+    int nq = Q.size();
+    int xc = MVT::GetNumberVecs( X );
+    const ScalarType ONE  = SCT::one();
+
+    std::vector<int> qcs( nq );
+    for (int i=0; i<nq; i++) {
+      qcs[i] = MVT::GetNumberVecs( *Q[i] );
+    }
+
+    // Perform the Gram-Schmidt transformation for a block of vectors
+    std::vector<int> index(1);
+    Teuchos::RCP<const MV> tempQ;
+
+    Teuchos::Array<Teuchos::RCP<MV> > MQ(nq);
+    // Define the product Q^T * (Op*X)
+    for (int i=0; i<nq; i++) {
+
+      // Perform MGS one vector at a time
+      for (int ii=0; ii<qcs[i]; ii++) {
+
+        index[0] = ii;
+        tempQ = MVT::CloneView( *Q[i], index );
+        Teuchos::SerialDenseMatrix<int,ScalarType> tempC( Teuchos::View, *C[i], 1, 1, ii, 0 );
+
+        // Multiply Q' with MX
+        {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+          Teuchos::TimeMonitor innerProdTimer( *timerInnerProd_ );
+#endif
+          MatOrthoManager<ScalarType,MV,OP>::innerProd(*tempQ,X,MX,tempC);
+        }
+        // Multiply by Q and subtract the result in X
+        {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+          Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+          MVT::MvTimesMatAddMv( -ONE, *tempQ, tempC, ONE, X );
+        }
+      }
+
+      // Update MX, with the least number of applications of Op as possible
+      if (this->_hasOp) {
+        if (xc <= qcs[i]) {
+          OPT::Apply( *(this->_Op), X, *MX);
+        }
+        else {
+          // this will possibly be used again below; don't delete it
+          MQ[i] = MVT::Clone( *Q[i], qcs[i] );
+          OPT::Apply( *(this->_Op), *Q[i], *MQ[i] );
+          MVT::MvTimesMatAddMv( -ONE, *MQ[i], *C[i], ONE, *MX );
+        }
+      }
+    }
+
+    // Do as many steps of modified Gram-Schmidt as required by max_ortho_steps_
+    for (int j = 1; j < max_ortho_steps_; ++j) {
+
+      for (int i=0; i<nq; i++) {
+
+        Teuchos::SerialDenseMatrix<int,ScalarType> C2(qcs[i],1);
+
+        // Perform MGS one vector at a time
+        for (int ii=0; ii<qcs[i]; ii++) {
+
+          index[0] = ii;
+          tempQ = MVT::CloneView( *Q[i], index );
+          Teuchos::SerialDenseMatrix<int,ScalarType> tempC( Teuchos::View, *C[i], 1, 1, ii, 0 );
+          Teuchos::SerialDenseMatrix<int,ScalarType> tempC2( Teuchos::View, C2, 1, 1, ii, 0 );
+
+          // Apply another step of modified Gram-Schmidt
+          {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+            Teuchos::TimeMonitor innerProdTimer( *timerInnerProd_ );
+#endif
+            MatOrthoManager<ScalarType,MV,OP>::innerProd( *tempQ, X, MX, tempC2 );
+          }
+          tempC += tempC2;
+          {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+            Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+            MVT::MvTimesMatAddMv( -ONE, *tempQ, tempC2, ONE, X );
+          }
+
+        }
+
+        // Update MX, with the least number of applications of Op as possible
+        if (this->_hasOp) {
+          if (MQ[i].get()) {
+            // MQ was allocated and computed above; use it
+            MVT::MvTimesMatAddMv( -ONE, *MQ[i], C2, ONE, *MX );
+          }
+          else if (xc <= qcs[i]) {
+            // MQ was not allocated and computed above; it was cheaper to use X before and it still is
+            OPT::Apply( *(this->_Op), X, *MX);
+          }
+        }
+      } // for (int i=0; i<nq; i++)
+    } // for (int j = 0; j < max_ortho_steps; ++j)
+
+    return false;
+  }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  // Routine to compute the block orthogonalization
+  template<class StorageType, class MV, class OP>
+  bool
+  IMGSOrthoManager<Sacado::MP::Vector<StorageType>, MV, OP>::blkOrtho ( MV &X, Teuchos::RCP<MV> MX,
+                                                   Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
+                                                   Teuchos::ArrayView<Teuchos::RCP<const MV> > Q) const
+  {
+    int nq = Q.size();
+    int xc = MVT::GetNumberVecs( X );
+    bool dep_flg = false;
+    const ScalarType ONE  = SCT::one();
+
+    std::vector<int> qcs( nq );
+    for (int i=0; i<nq; i++) {
+      qcs[i] = MVT::GetNumberVecs( *Q[i] );
+    }
+
+    // Perform the Gram-Schmidt transformation for a block of vectors
+
+    // Compute the initial Op-norms
+    std::vector<ScalarType> oldDot( xc );
+    {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+    Teuchos::TimeMonitor normTimer( *timerNorm_ );
+#endif
+    MVT::MvDot( X, *MX, oldDot );
+    }
+
+    std::vector<int> index(1);
+    Teuchos::Array<Teuchos::RCP<MV> > MQ(nq);
+    Teuchos::RCP<const MV> tempQ;
+
+    // Define the product Q^T * (Op*X)
+    for (int i=0; i<nq; i++) {
+
+      // Perform MGS one vector at a time
+      for (int ii=0; ii<qcs[i]; ii++) {
+
+        index[0] = ii;
+        tempQ = MVT::CloneView( *Q[i], index );
+        Teuchos::SerialDenseMatrix<int,ScalarType> tempC( Teuchos::View, *C[i], 1, xc, ii, 0 );
+
+        // Multiply Q' with MX
+        {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+          Teuchos::TimeMonitor innerProdTimer( *timerInnerProd_ );
+#endif
+          MatOrthoManager<ScalarType,MV,OP>::innerProd( *tempQ, X, MX, tempC);
+        }
+        // Multiply by Q and subtract the result in X
+        {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+          Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+          MVT::MvTimesMatAddMv( -ONE, *tempQ, tempC, ONE, X );
+        }
+      }
+
+      // Update MX, with the least number of applications of Op as possible
+      if (this->_hasOp) {
+        if (xc <= qcs[i]) {
+          OPT::Apply( *(this->_Op), X, *MX);
+        }
+        else {
+          // this will possibly be used again below; don't delete it
+          MQ[i] = MVT::Clone( *Q[i], qcs[i] );
+          OPT::Apply( *(this->_Op), *Q[i], *MQ[i] );
+          MVT::MvTimesMatAddMv( -ONE, *MQ[i], *C[i], ONE, *MX );
+        }
+      }
+    }
+
+    // Do as many steps of modified Gram-Schmidt as required by max_ortho_steps_
+    for (int j = 1; j < max_ortho_steps_; ++j) {
+
+      for (int i=0; i<nq; i++) {
+        Teuchos::SerialDenseMatrix<int,ScalarType> C2(qcs[i],xc);
+
+        // Perform MGS one vector at a time
+        for (int ii=0; ii<qcs[i]; ii++) {
+
+          index[0] = ii;
+          tempQ = MVT::CloneView( *Q[i], index );
+          Teuchos::SerialDenseMatrix<int,ScalarType> tempC( Teuchos::View, *C[i], 1, xc, ii, 0 );
+          Teuchos::SerialDenseMatrix<int,ScalarType> tempC2( Teuchos::View, C2, 1, xc, ii, 0 );
+
+          // Apply another step of modified Gram-Schmidt
+          {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+            Teuchos::TimeMonitor innerProdTimer( *timerInnerProd_ );
+#endif
+            MatOrthoManager<ScalarType,MV,OP>::innerProd( *tempQ, X, MX, tempC2 );
+          }
+          tempC += tempC2;
+          {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+            Teuchos::TimeMonitor updateTimer( *timerUpdate_ );
+#endif
+            MVT::MvTimesMatAddMv( -ONE, *tempQ, tempC2, ONE, X );
+          }
+        }
+
+        // Update MX, with the least number of applications of Op as possible
+        if (this->_hasOp) {
+          if (MQ[i].get()) {
+            // MQ was allocated and computed above; use it
+            MVT::MvTimesMatAddMv( -ONE, *MQ[i], C2, ONE, *MX );
+          }
+          else if (xc <= qcs[i]) {
+            // MQ was not allocated and computed above; it was cheaper to use X before and it still is
+            OPT::Apply( *(this->_Op), X, *MX);
+          }
+        }
+      } // for (int i=0; i<nq; i++)
+    } // for (int j = 0; j < max_ortho_steps; ++j)
+
+    // Compute new Op-norms
+    std::vector<ScalarType> newDot(xc);
+    {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+    Teuchos::TimeMonitor normTimer( *timerNorm_ );
+#endif
+    MVT::MvDot( X, *MX, newDot );
+    }
+
+    // Check to make sure the new block of vectors are not dependent on previous vectors
+    for (int i=0; i<xc; i++){
+      if (SCT::magnitude(newDot[i]) < SCT::magnitude(oldDot[i] * blk_tol_)) {
+        dep_flg = true;
+        break;
+      }
+    } // end for (i=0;...)
+
+    return dep_flg;
+  }
+
+  template<class StorageType, class MV, class OP>
+  int
+  IMGSOrthoManager<Sacado::MP::Vector<StorageType>, MV, OP>::blkOrthoSing ( MV &X, Teuchos::RCP<MV> MX,
+                                                       Teuchos::Array<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > C,
+                                                       Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > B,
+                                                       Teuchos::ArrayView<Teuchos::RCP<const MV> > QQ) const
+  {
+    Teuchos::Array<Teuchos::RCP<const MV> > Q (QQ);
+
+    const ScalarType ONE  = SCT::one();
+    const ScalarType ZERO  = SCT::zero();
+
+    int nq = Q.size();
+    int xc = MVT::GetNumberVecs( X );
+    std::vector<int> indX( 1 );
+    std::vector<ScalarType> oldDot( 1 ), newDot( 1 );
+
+    std::vector<int> qcs( nq );
+    for (int i=0; i<nq; i++) {
+      qcs[i] = MVT::GetNumberVecs( *Q[i] );
+    }
+
+    // Create pointers for the previous vectors of X that have already been orthonormalized.
+    Teuchos::RCP<const MV> lastQ;
+    Teuchos::RCP<MV> Xj, MXj;
+    Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > lastC;
+
+    // Perform the Gram-Schmidt transformation for each vector in the block of vectors.
+    for (int j=0; j<xc; j++) {
+
+      bool dep_flg = false;
+
+      // Get a view of the previously orthogonalized vectors and B, add it to the arrays.
+      if (j > 0) {
+        std::vector<int> index( j );
+        for (int ind=0; ind<j; ind++) {
+          index[ind] = ind;
+        }
+        lastQ = MVT::CloneView( X, index );
+
+        // Add these views to the Q and C arrays.
+        Q.push_back( lastQ );
+        C.push_back( B );
+        qcs.push_back( MVT::GetNumberVecs( *lastQ ) );
+      }
+
+      // Get a view of the current vector in X to orthogonalize.
+      indX[0] = j;
+      Xj = MVT::CloneViewNonConst( X, indX );
+      if (this->_hasOp) {
+        MXj = MVT::CloneViewNonConst( *MX, indX );
+      }
+      else {
+        MXj = Xj;
+      }
+
+      // Compute the initial Op-norms
+      {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+      Teuchos::TimeMonitor normTimer( *timerNorm_ );
+#endif
+      MVT::MvDot( *Xj, *MXj, oldDot );
+      }
+
+      Teuchos::Array<Teuchos::RCP<MV> > MQ(Q.size());
+      Teuchos::RCP<const MV> tempQ;
+
+      // Define the product Q^T * (Op*X)
+      for (int i=0; i<Q.size(); i++) {
+
+        // Perform MGS one vector at a time
+        for (int ii=0; ii<qcs[i]; ii++) {
+
+          indX[0] = ii;
+          tempQ = MVT::CloneView( *Q[i], indX );
+          // Get a view of the current serial dense matrix
+          Teuchos::SerialDenseMatrix<int,ScalarType> tempC( Teuchos::View, *C[i], 1, 1, ii, j );
+
+          // Multiply Q' with MX
+          MatOrthoManager<ScalarType,MV,OP>::innerProd(*tempQ,*Xj,MXj,tempC);
+
+          // Multiply by Q and subtract the result in Xj
+          MVT::MvTimesMatAddMv( -ONE, *tempQ, tempC, ONE, *Xj );
+        }
+
+        // Update MXj, with the least number of applications of Op as possible
+        if (this->_hasOp) {
+          if (xc <= qcs[i]) {
+            OPT::Apply( *(this->_Op), *Xj, *MXj);
+          }
+          else {
+            // this will possibly be used again below; don't delete it
+            MQ[i] = MVT::Clone( *Q[i], qcs[i] );
+            OPT::Apply( *(this->_Op), *Q[i], *MQ[i] );
+            Teuchos::SerialDenseMatrix<int,ScalarType> tempC( Teuchos::View, *C[i], qcs[i], 1, 0, j );
+            MVT::MvTimesMatAddMv( -ONE, *MQ[i], tempC, ONE, *MXj );
+          }
+        }
+      }
+
+      // Do any additional steps of modified Gram-Schmidt orthogonalization
+      for (int num_ortho_steps=1; num_ortho_steps < max_ortho_steps_; ++num_ortho_steps) {
+
+        for (int i=0; i<Q.size(); i++) {
+          Teuchos::SerialDenseMatrix<int,ScalarType> C2( qcs[i], 1 );
+
+          // Perform MGS one vector at a time
+          for (int ii=0; ii<qcs[i]; ii++) {
+
+            indX[0] = ii;
+            tempQ = MVT::CloneView( *Q[i], indX );
+            // Get a view of the current serial dense matrix
+            Teuchos::SerialDenseMatrix<int,ScalarType> tempC2( Teuchos::View, C2, 1, 1, ii );
+
+            // Apply another step of modified Gram-Schmidt
+            MatOrthoManager<ScalarType,MV,OP>::innerProd( *tempQ, *Xj, MXj, tempC2);
+            MVT::MvTimesMatAddMv( -ONE, *tempQ, tempC2, ONE, *Xj );
+          }
+
+          // Add the coefficients into C[i]
+          Teuchos::SerialDenseMatrix<int,ScalarType> tempC( Teuchos::View, *C[i], qcs[i], 1, 0, j );
+          tempC += C2;
+
+          // Update MXj, with the least number of applications of Op as possible
+          if (this->_hasOp) {
+            if (MQ[i].get()) {
+              // MQ was allocated and computed above; use it
+              MVT::MvTimesMatAddMv( -ONE, *MQ[i], C2, ONE, *MXj );
+            }
+            else if (xc <= qcs[i]) {
+              // MQ was not allocated and computed above; it was cheaper to use X before and it still is
+              OPT::Apply( *(this->_Op), *Xj, *MXj);
+            }
+          }
+        } // for (int i=0; i<Q.size(); i++)
+
+      } // for (int num_ortho_steps=1; num_ortho_steps < max_ortho_steps_; ++num_ortho_steps)
+
+      // Check for linear dependence.
+      if (SCT::magnitude(newDot[0]) < SCT::magnitude(oldDot[0]*sing_tol_)) {
+        dep_flg = true;
+      }
+
+      // Normalize the new vector if it's not dependent
+      if (!dep_flg) {
+        ScalarType diag = SCT::squareroot(SCT::magnitude(newDot[0]));
+
+        MVT::MvScale( *Xj, ONE/diag );
+        if (this->_hasOp) {
+          // Update MXj.
+          MVT::MvScale( *MXj, ONE/diag );
+        }
+
+        // Enter value on diagonal of B.
+        (*B)(j,j) = diag;
+      }
+      else {
+        // Create a random vector and orthogonalize it against all previous columns of Q.
+        Teuchos::RCP<MV> tempXj = MVT::Clone( X, 1 );
+        Teuchos::RCP<MV> tempMXj;
+        MVT::MvRandom( *tempXj );
+        if (this->_hasOp) {
+          tempMXj = MVT::Clone( X, 1 );
+          OPT::Apply( *(this->_Op), *tempXj, *tempMXj );
+        }
+        else {
+          tempMXj = tempXj;
+        }
+        {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+        Teuchos::TimeMonitor normTimer( *timerNorm_ );
+#endif
+        MVT::MvDot( *tempXj, *tempMXj, oldDot );
+        }
+        //
+        for (int num_orth=0; num_orth<max_ortho_steps_; num_orth++) {
+
+          for (int i=0; i<Q.size(); i++) {
+            Teuchos::SerialDenseMatrix<int,ScalarType> product( qcs[i], 1 );
+
+            // Perform MGS one vector at a time
+            for (int ii=0; ii<qcs[i]; ii++) {
+
+              indX[0] = ii;
+              tempQ = MVT::CloneView( *Q[i], indX );
+              Teuchos::SerialDenseMatrix<int,ScalarType> tempC( Teuchos::View, product, 1, 1, ii );
+
+              // Apply another step of modified Gram-Schmidt
+              MatOrthoManager<ScalarType,MV,OP>::innerProd( *tempQ, *tempXj, tempMXj, tempC );
+              MVT::MvTimesMatAddMv( -ONE, *tempQ, tempC, ONE, *tempXj );
+
+            }
+
+            // Update MXj, with the least number of applications of Op as possible
+            if (this->_hasOp) {
+              if (MQ[i].get()) {
+                // MQ was allocated and computed above; use it
+                MVT::MvTimesMatAddMv( -ONE, *MQ[i], product, ONE, *tempMXj );
+              }
+              else if (xc <= qcs[i]) {
+                // MQ was not allocated and computed above; it was cheaper to use X before and it still is
+                OPT::Apply( *(this->_Op), *tempXj, *tempMXj);
+              }
+            }
+          } // for (int i=0; i<nq; i++)
+        } // for (int num_orth=0; num_orth<max_orth_steps_; num_orth++)
+
+        // Compute the Op-norms after the correction step.
+        {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+        Teuchos::TimeMonitor normTimer( *timerNorm_ );
+#endif
+        MVT::MvDot( *tempXj, *tempMXj, newDot );
+        }
+
+        // Copy vector into current column of Xj
+        if ( SCT::magnitude(newDot[0]) >= SCT::magnitude(oldDot[0]*sing_tol_) ) {
+          ScalarType diag = SCT::squareroot(SCT::magnitude(newDot[0]));
+
+          // Enter value on diagonal of B.
+          (*B)(j,j) = ZERO;
+
+          // Copy vector into current column of _basisvecs
+          MVT::MvAddMv( ONE/diag, *tempXj, ZERO, *tempXj, *Xj );
+          if (this->_hasOp) {
+            MVT::MvAddMv( ONE/diag, *tempMXj, ZERO, *tempMXj, *MXj );
+          }
+        }
+        else {
+          return j;
+        }
+      } // if (!dep_flg)
+
+      // Remove the vectors from array
+      if (j > 0) {
+        Q.resize( nq );
+        C.resize( nq );
+        qcs.resize( nq );
+      }
+
+    } // for (int j=0; j<xc; j++)
+
+    return xc;
+  }
+  
+} // namespace Belos
+
+#endif // BELOS_IMGS_ORTHOMANAGER_HPP
+

--- a/packages/stokhos/src/sacado/kokkos/vector/belos/Belos_PseudoBlockGmresIter_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/belos/Belos_PseudoBlockGmresIter_MP_Vector.hpp
@@ -102,7 +102,7 @@ namespace Belos {
 			  Teuchos::ParameterList &params );
     
     //! Destructor.
-    virtual ~PseudoBlockGmresIter() {};
+    virtual ~PseudoBlockGmresIter() = default;
     //@}
 
 

--- a/packages/stokhos/src/sacado/kokkos/vector/belos/Belos_PseudoBlockGmresIter_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/belos/Belos_PseudoBlockGmresIter_MP_Vector.hpp
@@ -1,0 +1,884 @@
+//@HEADER
+// ************************************************************************
+//
+//                 Belos: Block Linear Solvers Package
+//                  Copyright 2004 Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+
+#ifndef BELOS_PSEUDO_BLOCK_GMRES_ITER_MP_VECTOR_HPP
+#define BELOS_PSEUDO_BLOCK_GMRES_ITER_MP_VECTOR_HPP
+
+/*! 
+  \file Belos_PseudoBlockGmresIter_MP_Vector.hpp
+  \brief Belos concrete class for performing the pseudo-block GMRES iteration.
+
+  Specialized for Sacado::MP::Vector scalar type to handle break-down when
+  ensemble components are over-solved.
+*/
+
+#include "Stokhos_Sacado_Kokkos_MP_Vector.hpp"
+#include "BelosPseudoBlockGmresIter.hpp"
+
+/*!
+  \class Belos::PseudoBlockGmresIter
+
+  \brief This class implements the pseudo-block GMRES iteration, where a
+  block Krylov subspace is constructed for all of the linear systems simultaneously.
+  The QR decomposition of each block, upper Hessenberg matrix is performed each iteration
+  to update the least squares system and give the current linear system residuals.
+
+  \ingroup belos_solver_framework
+
+  \author Heidi Thornquist
+*/
+
+namespace Belos {
+    
+  template<class Storage, class MV, class OP>
+  class PseudoBlockGmresIter<Sacado::MP::Vector<Storage>, MV, OP> : 
+    virtual public Iteration<Sacado::MP::Vector<Storage>, MV, OP> {
+    
+  public:
+    
+    //
+    // Convenience typedefs
+    //
+    typedef Sacado::MP::Vector<Storage> ScalarType;
+    typedef MultiVecTraits<ScalarType,MV> MVT;
+    typedef OperatorTraits<ScalarType,MV,OP> OPT;
+    typedef Teuchos::ScalarTraits<ScalarType> SCT;
+    typedef typename SCT::magnitudeType MagnitudeType;
+    typedef Teuchos::ScalarTraits<typename Storage::value_type> SVT;
+    
+    //! @name Constructors/Destructor
+    //@{ 
+    
+    /*! \brief %PseudoBlockGmresIter constructor with linear problem, solver utilities, and parameter list of solver options.
+     *
+     * This constructor takes pointers required by the linear solver, in addition
+     * to a parameter list of options for the linear solver. These options include the following:
+     *   - "Block Size" - an \c int specifying the block size used by the algorithm. This can also be specified using the setBlockSize() method. Default: 1
+     *   - "Num Blocks" - an \c int specifying the maximum number of blocks allocated for the solver basis. Default: 25
+     *   - "Restart Timers" = a \c bool specifying whether the timers should be restarted each time iterate() is called. Default: false
+     */  
+    PseudoBlockGmresIter( const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem, 
+			  const Teuchos::RCP<OutputManager<ScalarType> > &printer,
+			  const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &tester,
+			  const Teuchos::RCP<MatOrthoManager<ScalarType,MV,OP> > &ortho,
+			  Teuchos::ParameterList &params );
+    
+    //! Destructor.
+    virtual ~PseudoBlockGmresIter() {};
+    //@}
+
+
+    //! @name Solver methods
+    //@{ 
+    
+    /*! \brief This method performs block Gmres iterations until the status
+     * test indicates the need to stop or an error occurs (in which case, an
+     * std::exception is thrown).
+     *
+     * iterate() will first determine whether the solver is inintialized; if
+     * not, it will call initialize() using default arguments. After
+     * initialization, the solver performs block Gmres iterations until the
+     * status test evaluates as ::Passed, at which point the method returns to
+     * the caller. 
+     *
+     * The block Gmres iteration proceeds as follows:
+     * -# The operator problem->applyOp() is applied to the newest \c blockSize vectors in the Krylov basis.
+     * -# The resulting vectors are orthogonalized against the previous basis vectors, and made orthonormal.
+     * -# The Hessenberg matrix is updated.
+     * -# The least squares system is updated.
+     *
+     * The status test is queried at the beginning of the iteration.
+     *
+     * Possible exceptions thrown include the PseudoBlockGmresIterOrthoFailure.
+     *
+     */
+    void iterate();
+
+    /*! \brief Initialize the solver to an iterate, providing a complete state.
+     *
+     * The %PseudoBlockGmresIter contains a certain amount of state, consisting of the current 
+     * Krylov basis and the associated Hessenberg matrix.
+     *
+     * initialize() gives the user the opportunity to manually set these,
+     * although this must be done with caution, abiding by the rules given
+     * below. All notions of orthogonality and orthonormality are derived from
+     * the inner product specified by the orthogonalization manager.
+     *
+     * \post 
+     * <li>isInitialized() == \c true (see post-conditions of isInitialize())
+     *
+     * The user has the option of specifying any component of the state using
+     * initialize(). However, these arguments are assumed to match the
+     * post-conditions specified under isInitialized(). Any necessary component of the
+     * state not given to initialize() will be generated.
+     *
+     * \note For any pointer in \c newstate which directly points to the multivectors in 
+     * the solver, the data is not copied.
+     */
+    void initialize(const PseudoBlockGmresIterState<ScalarType,MV> & newstate);
+
+    /*! \brief Initialize the solver with the initial vectors from the linear problem
+     *  or random data.
+     */
+    void initialize()
+    {
+      PseudoBlockGmresIterState<ScalarType,MV> empty;
+      initialize(empty);
+    }
+    
+    /*! \brief Get the current state of the linear solver.
+     *
+     * The data is only valid if isInitialized() == \c true.
+     *
+     * \returns A PseudoBlockGmresIterState object containing const pointers to the current
+     * solver state.
+     */
+    PseudoBlockGmresIterState<ScalarType,MV> getState() const {
+      PseudoBlockGmresIterState<ScalarType,MV> state;
+      state.curDim = curDim_;
+      state.V.resize(numRHS_);
+      state.H.resize(numRHS_);
+      state.Z.resize(numRHS_);
+      state.sn.resize(numRHS_);
+      state.cs.resize(numRHS_);  
+      for (int i=0; i<numRHS_; ++i) {
+	    state.V[i] = V_[i];
+	    state.H[i] = H_[i];
+	    state.Z[i] = Z_[i];
+        state.sn[i] = sn_[i];
+        state.cs[i] = cs_[i];
+      }
+      return state;
+    }
+
+    //@}
+    
+    
+    //! @name Status methods
+    //@{
+    
+    //! Get the current iteration count.
+    int getNumIters() const { return iter_; }
+    
+    //! Reset the iteration count.
+    void resetNumIters( int iter = 0 ) { iter_ = iter; }
+    
+    /// \brief Get the norms of the "native" residual vectors.
+    ///
+    /// If norms != NULL, fill *norms with the native residual norms.
+    /// There are numRHS_ of them.  *norms will be resized if it has
+    /// too few entries to hold the data.
+    ///
+    /// For an explanation of "native" vs. "exact" (also known as
+    /// "implicit" vs. "explicit") residuals, see the documentation of
+    /// \c PseudoBlockGmresSolMgr::isLOADetected().  In brief:
+    /// "Native" residuals are cheaper to compute than "exact"
+    /// residuals, but the two may differ, especially when using a
+    /// left preconditioner. 
+    ///
+    /// \return Teuchos::null (always, regardless whether norms ==
+    ///   NULL).  We only return something in order to satisfy the
+    ///   Iteration interface.  \c PseudoBlockGmresSolMgr knows that
+    ///   this method always returns null.
+    Teuchos::RCP<const MV> getNativeResiduals( std::vector<MagnitudeType> *norms ) const;
+
+    //! Get the current update to the linear system.
+    /*! \note Some solvers, like GMRES, do not compute updates to the solution every iteration.
+      This method forces its computation.  Other solvers, like CG, update the solution
+      each iteration, so this method will return a zero vector indicating that the linear
+      problem contains the current solution.
+    */
+    Teuchos::RCP<MV> getCurrentUpdate() const;
+    
+    //! Method for updating QR factorization of upper Hessenberg matrix
+    /*! \note If \c dim >= \c getCurSubspaceDim() and \c dim < \c getMaxSubspaceDim(), then 
+      the \c dim-th equations of the least squares problem will be updated.
+    */
+    void updateLSQR( int dim = -1 );
+    
+    //! Get the dimension of the search subspace used to generate the current solution to the linear problem.
+    int getCurSubspaceDim() const { 
+      if (!initialized_) return 0;
+      return curDim_;
+    }
+    
+    //! Get the maximum dimension allocated for the search subspace.
+    int getMaxSubspaceDim() const { return numBlocks_; }
+    
+    //@}
+
+
+    //! @name Accessor methods
+    //@{ 
+    
+    //! Get a constant reference to the linear problem.
+    const LinearProblem<ScalarType,MV,OP>& getProblem() const { return *lp_; }
+    
+    //! Get the blocksize to be used by the iterative solver in solving this linear problem.
+    int getBlockSize() const { return 1; }
+    
+    //! \brief Set the blocksize.
+    void setBlockSize(int blockSize) { 
+      TEUCHOS_TEST_FOR_EXCEPTION(blockSize!=1,std::invalid_argument,
+			 "Belos::PseudoBlockGmresIter::setBlockSize(): Cannot use a block size that is not one.");
+    }
+    
+    //! Get the maximum number of blocks used by the iterative solver in solving this linear problem.
+    int getNumBlocks() const { return numBlocks_; }
+    
+    //! \brief Set the maximum number of blocks used by the iterative solver.
+    void setNumBlocks(int numBlocks);
+    
+    //! States whether the solver has been initialized or not.
+    bool isInitialized() { return initialized_; }
+    
+    //@}
+
+  private:
+
+    //
+    // Classes inputed through constructor that define the linear problem to be solved.
+    //
+    const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> >    lp_;
+    const Teuchos::RCP<OutputManager<ScalarType> >          om_;
+    const Teuchos::RCP<StatusTest<ScalarType,MV,OP> >       stest_;
+    const Teuchos::RCP<OrthoManager<ScalarType,MV> >        ortho_;
+    
+    //
+    // Algorithmic parameters
+    //  
+    // numRHS_ is the current number of linear systems being solved.
+    int numRHS_;
+    // numBlocks_ is the size of the allocated space for the Krylov basis, in blocks.
+    int numBlocks_;
+
+    // Mask used to store whether the ensemble GMRES has faced lucky breakdown or not.
+    Mask<MagnitudeType> lucky_breakdown_;
+    
+    // Storage for QR factorization of the least squares system.
+    std::vector<Teuchos::RCP<Teuchos::SerialDenseVector<int,ScalarType> > > sn_;
+    std::vector<Teuchos::RCP<Teuchos::SerialDenseVector<int,MagnitudeType> > > cs_;
+    
+    // Pointers to a work vector used to improve aggregate performance.
+    Teuchos::RCP<MV> U_vec_, AU_vec_;    
+
+    // Pointers to the current right-hand side and solution multivecs being solved for.
+    Teuchos::RCP<MV> cur_block_rhs_, cur_block_sol_;
+
+    // 
+    // Current solver state
+    //
+    // initialized_ specifies that the basis vectors have been initialized and the iterate() routine
+    // is capable of running; _initialize is controlled  by the initialize() member method
+    // For the implications of the state of initialized_, please see documentation for initialize()
+    bool initialized_;
+    
+    // Current subspace dimension, and number of iterations performed.
+    int curDim_, iter_;
+
+    // 
+    // State Storage
+    //
+    std::vector<Teuchos::RCP<MV> > V_;
+    //
+    // Projected matrices
+    // H_ : Projected matrix from the Krylov factorization AV = VH + FE^T
+    //
+    std::vector<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > H_;
+    // 
+    // QR decomposition of Projected matrices for solving the least squares system HY = B.
+    // R_: Upper triangular reduction of H
+    // Z_: Q applied to right-hand side of the least squares system
+    std::vector<Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > R_;
+    std::vector<Teuchos::RCP<Teuchos::SerialDenseVector<int,ScalarType> > > Z_;  
+
+    // Tolerance for ensemble breakdown
+    typename SVT::magnitudeType breakDownTol_;
+
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+    Teuchos::RCP<Teuchos::Time> timerUpdateLSQR_, timerSolveLSQR_;
+#endif   
+  };
+     
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  // Constructor.
+  template<class StorageType, class MV, class OP>
+  PseudoBlockGmresIter<Sacado::MP::Vector<StorageType>,MV,OP>::
+  PseudoBlockGmresIter(const Teuchos::RCP<LinearProblem<ScalarType,MV,OP> > &problem,
+							       const Teuchos::RCP<OutputManager<ScalarType> > &printer,
+							       const Teuchos::RCP<StatusTest<ScalarType,MV,OP> > &tester,
+							       const Teuchos::RCP<MatOrthoManager<ScalarType,MV,OP> > &ortho,
+							       Teuchos::ParameterList &params ):
+    lp_(problem),
+    om_(printer),
+    stest_(tester),
+    ortho_(ortho),
+    numRHS_(0),
+    numBlocks_(0),
+    initialized_(false),
+    curDim_(0),
+    iter_(0),
+    breakDownTol_(params.get("Ensemble Breakdown Tolerance", 0.0))
+  {
+    // Get the maximum number of blocks allowed for each Krylov subspace
+    TEUCHOS_TEST_FOR_EXCEPTION(!params.isParameter("Num Blocks"), std::invalid_argument,
+                       "Belos::PseudoBlockGmresIter::constructor: mandatory parameter 'Num Blocks' is not specified.");
+    int nb = Teuchos::getParameter<int>(params, "Num Blocks");
+
+    setNumBlocks( nb );
+  }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  // Set the block size and make necessary adjustments.
+  template <class StorageType, class MV, class OP>
+  void PseudoBlockGmresIter<Sacado::MP::Vector<StorageType>,MV,OP>::setNumBlocks (int numBlocks)
+  {
+    // This routine only allocates space; it doesn't not perform any computation
+    // any change in size will invalidate the state of the solver.
+
+    TEUCHOS_TEST_FOR_EXCEPTION(numBlocks <= 0, std::invalid_argument, "Belos::PseudoBlockGmresIter::setNumBlocks was passed a non-positive argument.");
+
+    numBlocks_ = numBlocks;
+    curDim_ = 0;
+
+    initialized_ = false;
+  }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  // Get the current update from this subspace.
+  template <class StorageType, class MV, class OP>
+  Teuchos::RCP<MV> PseudoBlockGmresIter<Sacado::MP::Vector<StorageType>,MV,OP>::getCurrentUpdate() const
+  {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+      Teuchos::TimeMonitor updateTimer( *timerSolveLSQR_ );
+#endif
+    //
+    // If this is the first iteration of the Arnoldi factorization,
+    // there is no update, so return Teuchos::null.
+    //
+    Teuchos::RCP<MV> currentUpdate = Teuchos::null;
+    if (curDim_==0) {
+      return currentUpdate;
+    } else {
+      currentUpdate = MVT::Clone(*(V_[0]), numRHS_);
+      std::vector<int> index(1), index2(curDim_);
+      for (int i=0; i<curDim_; ++i) {
+        index2[i] = i;
+      }
+      const ScalarType one = Teuchos::ScalarTraits<ScalarType>::one();
+      const ScalarType zero = Teuchos::ScalarTraits<ScalarType>::zero();
+      Teuchos::BLAS<int,ScalarType> blas;
+
+      for (int i=0; i<numRHS_; ++i) {
+        index[0] = i;
+        Teuchos::RCP<MV> cur_block_copy_vec = MVT::CloneViewNonConst( *currentUpdate, index );
+        //
+        //  Make a view and then copy the RHS of the least squares problem.  DON'T OVERWRITE IT!
+        //
+        Teuchos::SerialDenseVector<int,ScalarType> y( Teuchos::Copy, Z_[i]->values(), curDim_ );
+        //
+        //  Solve the least squares problem and compute current solutions.
+        //
+        blas.TRSM( Teuchos::LEFT_SIDE, Teuchos::UPPER_TRI, Teuchos::NO_TRANS,
+                Teuchos::NON_UNIT_DIAG, curDim_, 1, one,
+                H_[i]->values(), H_[i]->stride(), y.values(), y.stride() );
+
+
+        Teuchos::RCP<const MV> Vjp1 = MVT::CloneView( *V_[i], index2 );
+        MVT::MvTimesMatAddMv( one, *Vjp1, y, zero, *cur_block_copy_vec );
+      }
+    }
+    return currentUpdate;
+  }
+
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  // Get the native residuals stored in this iteration.
+  // Note:  No residual vector will be returned by Gmres.
+  template <class StorageType, class MV, class OP>
+  Teuchos::RCP<const MV>
+  PseudoBlockGmresIter<Sacado::MP::Vector<StorageType>,MV,OP>::
+  getNativeResiduals (std::vector<MagnitudeType> *norms) const
+  {
+    typedef typename Teuchos::ScalarTraits<ScalarType> STS;
+
+    if (norms)
+      { // Resize the incoming std::vector if necessary.  The type
+        // cast avoids the compiler warning resulting from a signed /
+        // unsigned integer comparison.
+        if (static_cast<int> (norms->size()) < numRHS_)
+          norms->resize (numRHS_);
+
+        Teuchos::BLAS<int, ScalarType> blas;
+        for (int j = 0; j < numRHS_; ++j)
+          {
+            const ScalarType curNativeResid = (*Z_[j])(curDim_);
+            (*norms)[j] = STS::magnitude (curNativeResid);
+          }
+    }
+    return Teuchos::null;
+  }
+
+
+  template <class StorageType, class MV, class OP>
+  void
+  PseudoBlockGmresIter<Sacado::MP::Vector<StorageType>,MV,OP>::
+  initialize (const PseudoBlockGmresIterState<ScalarType,MV> & newstate)
+  {
+    using Teuchos::RCP;
+
+    // (Re)set the number of right-hand sides, by interrogating the
+    // current LinearProblem to solve.
+    this->numRHS_ = MVT::GetNumberVecs (*(lp_->getCurrLHSVec()));
+
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+      std::stringstream ss;
+      ss << "Belos";
+
+      std::string updateLabel = ss.str() + ": Update LSQR";
+      timerUpdateLSQR_ = Teuchos::TimeMonitor::getNewCounter(updateLabel);
+
+      std::string solveLabel = ss.str() + ": Solve LSQR";
+      timerSolveLSQR_ = Teuchos::TimeMonitor::getNewCounter(solveLabel);
+#endif
+
+    // NOTE:  In PseudoBlockGmresIter, V and Z are required!!!
+    // Inconsistent multivectors widths and lengths will not be tolerated, and
+    // will be treated with exceptions.
+    //
+    std::string errstr ("Belos::PseudoBlockGmresIter::initialize(): "
+			"Specified multivectors must have a consistent "
+			"length and width.");
+
+    // Check that newstate has V and Z arrays with nonzero length.
+    TEUCHOS_TEST_FOR_EXCEPTION((int)newstate.V.size()==0 || (int)newstate.Z.size()==0,
+		       std::invalid_argument,
+                       "Belos::PseudoBlockGmresIter::initialize(): "
+		       "V and/or Z was not specified in the input state; "
+		       "the V and/or Z arrays have length zero.");
+
+    // In order to create basis multivectors, we have to clone them
+    // from some already existing multivector.  We require that at
+    // least one of the right-hand side B and left-hand side X in the
+    // LinearProblem be non-null.  Thus, we can clone from either B or
+    // X.  We prefer to close from B, since B is in the range of the
+    // operator A and the basis vectors should also be in the range of
+    // A (the first basis vector is a scaled residual vector).
+    // However, if B is not given, we will try our best by cloning
+    // from X.
+    RCP<const MV> lhsMV = lp_->getLHS();
+    RCP<const MV> rhsMV = lp_->getRHS();
+
+    // If the right-hand side is null, we make do with the left-hand
+    // side, otherwise we use the right-hand side.
+    RCP<const MV> vectorInBasisSpace = rhsMV.is_null() ? lhsMV : rhsMV;
+    //RCP<const MV> tmp = ( (rhsMV!=Teuchos::null)? rhsMV: lhsMV );
+
+    TEUCHOS_TEST_FOR_EXCEPTION(vectorInBasisSpace.is_null(),
+		       std::invalid_argument,
+                       "Belos::PseudoBlockGmresIter::initialize(): "
+		       "The linear problem to solve does not specify multi"
+		       "vectors from which we can clone basis vectors.  The "
+		       "right-hand side(s), left-hand side(s), or both should "
+		       "be nonnull.");
+
+    // Check the new dimension is not more that the maximum number of
+    // allowable blocks.
+    TEUCHOS_TEST_FOR_EXCEPTION(newstate.curDim > numBlocks_+1,
+		       std::invalid_argument,
+		       errstr);
+    curDim_ = newstate.curDim;
+
+    // Initialize the state storage.  If the subspace has not be
+    // initialized before, generate it using the right-hand side or
+    // left-hand side from the LinearProblem lp_ to solve.
+    V_.resize(numRHS_);
+    for (int i=0; i<numRHS_; ++i) {
+      // Create a new vector if we need to.  We "need to" if the
+      // current vector V_[i] is null, or if it doesn't have enough
+      // columns.
+      if (V_[i].is_null() || MVT::GetNumberVecs(*V_[i]) < numBlocks_ + 1) {
+        V_[i] = MVT::Clone (*vectorInBasisSpace, numBlocks_ + 1);
+      }
+      // Check that the newstate vector newstate.V[i] has dimensions
+      // consistent with those of V_[i].
+      TEUCHOS_TEST_FOR_EXCEPTION( MVT::GetGlobalLength(*newstate.V[i]) != MVT::GetGlobalLength(*V_[i]),
+                          std::invalid_argument, errstr );
+      TEUCHOS_TEST_FOR_EXCEPTION( MVT::GetNumberVecs(*newstate.V[i]) < newstate.curDim,
+                          std::invalid_argument, errstr );
+      //
+      // If newstate.V[i] and V_[i] are not identically the same
+      // vector, then copy newstate.V[i] into V_[i].
+      //
+      int lclDim = MVT::GetNumberVecs(*newstate.V[i]);
+      if (newstate.V[i] != V_[i]) {
+        // Only copy over the first block and print a warning.
+        if (curDim_ == 0 && lclDim > 1) {
+          om_->stream(Warnings)
+          << "Belos::PseudoBlockGmresIter::initialize(): the solver was "
+          << "initialized with a kernel of " << lclDim
+          << std::endl
+          << "The block size however is only " << 1
+          << std::endl
+          << "The last " << lclDim - 1 << " vectors will be discarded."
+          << std::endl;
+        }
+        std::vector<int> nevind (curDim_ + 1);
+        for (int j = 0; j < curDim_ + 1; ++j)
+          nevind[j] = j;
+
+        RCP<const MV> newV = MVT::CloneView (*newstate.V[i], nevind);
+        RCP<MV> lclV = MVT::CloneViewNonConst( *V_[i], nevind );
+        const ScalarType one = Teuchos::ScalarTraits<ScalarType>::one();
+        const ScalarType zero = Teuchos::ScalarTraits<ScalarType>::zero();
+        MVT::MvAddMv (one, *newV, zero, *newV, *lclV);
+
+        // Done with local pointers
+        lclV = Teuchos::null;
+      }
+    }
+
+
+    // Check size of Z
+    Z_.resize(numRHS_);
+    for (int i=0; i<numRHS_; ++i) {
+      // Create a vector if we need to.
+      if (Z_[i] == Teuchos::null) {
+        Z_[i] = Teuchos::rcp( new Teuchos::SerialDenseVector<int,ScalarType>() );
+      }
+      if (Z_[i]->length() < numBlocks_+1) {
+        Z_[i]->shapeUninitialized(numBlocks_+1, 1);
+      }
+
+      // Check that the newstate vector is consistent.
+      TEUCHOS_TEST_FOR_EXCEPTION(newstate.Z[i]->numRows() < curDim_, std::invalid_argument, errstr);
+
+      // Put data into Z_, make sure old information is not still hanging around.
+      if (newstate.Z[i] != Z_[i]) {
+        if (curDim_==0)
+          Z_[i]->putScalar();
+
+        Teuchos::SerialDenseVector<int,ScalarType> newZ(Teuchos::View,newstate.Z[i]->values(),curDim_+1);
+        Teuchos::RCP<Teuchos::SerialDenseVector<int,ScalarType> > lclZ;
+        lclZ = Teuchos::rcp( new Teuchos::SerialDenseVector<int,ScalarType>(Teuchos::View,Z_[i]->values(),curDim_+1) );
+        lclZ->assign(newZ);
+
+        // Done with local pointers
+	      lclZ = Teuchos::null;
+      }
+    }
+
+
+    // Check size of H
+    H_.resize(numRHS_);
+    for (int i=0; i<numRHS_; ++i) {
+      // Create a matrix if we need to.
+      if (H_[i] == Teuchos::null) {
+	      H_[i] = Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>() );
+      }
+      if (H_[i]->numRows() < numBlocks_+1 || H_[i]->numCols() < numBlocks_) {
+	      H_[i]->shapeUninitialized(numBlocks_+1, numBlocks_);
+      }
+
+      // Put data into H_ if it exists, make sure old information is not still hanging around.
+      if ((int)newstate.H.size() == numRHS_) {
+
+        // Check that the newstate matrix is consistent.
+        TEUCHOS_TEST_FOR_EXCEPTION((newstate.H[i]->numRows() < curDim_ || newstate.H[i]->numCols() < curDim_), std::invalid_argument,
+              "Belos::PseudoBlockGmresIter::initialize(): Specified Hessenberg matrices must have a consistent size to the current subspace dimension");
+
+        if (newstate.H[i] != H_[i]) {
+          // H_[i]->putScalar();
+
+          Teuchos::SerialDenseMatrix<int,ScalarType> newH(Teuchos::View,*newstate.H[i],curDim_+1, curDim_);
+          Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > lclH;
+          lclH = Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>(Teuchos::View,*H_[i],curDim_+1, curDim_) );
+          lclH->assign(newH);
+
+          // Done with local pointers
+          lclH = Teuchos::null;
+        }
+      }
+    }
+
+    /////////////////////////////////
+    // Reinitialize storage for least squares solve
+    //
+    cs_.resize(numRHS_);
+    sn_.resize(numRHS_);
+
+    // Copy over rotation angles if they exist
+    if ((int)newstate.cs.size() == numRHS_ && (int)newstate.sn.size() == numRHS_) {
+      for (int i=0; i<numRHS_; ++i) {
+        if (cs_[i] != newstate.cs[i])
+          cs_[i] = Teuchos::rcp( new Teuchos::SerialDenseVector<int,MagnitudeType>(*newstate.cs[i]) );
+        if (sn_[i] != newstate.sn[i])
+          sn_[i] = Teuchos::rcp( new Teuchos::SerialDenseVector<int,ScalarType>(*newstate.sn[i]) );
+      }
+    }
+
+    // Resize or create the vectors as necessary
+    for (int i=0; i<numRHS_; ++i) {
+      if (cs_[i] == Teuchos::null)
+        cs_[i] = Teuchos::rcp( new Teuchos::SerialDenseVector<int,MagnitudeType>(numBlocks_+1) );
+      else
+        cs_[i]->resize(numBlocks_+1);
+      if (sn_[i] == Teuchos::null)
+        sn_[i] = Teuchos::rcp( new Teuchos::SerialDenseVector<int,ScalarType>(numBlocks_+1) );
+      else
+        sn_[i]->resize(numBlocks_+1);
+    }
+
+    // the solver is initialized
+    initialized_ = true;
+
+      /*
+	if (om_->isVerbosity( Debug ) ) {
+      // Check almost everything here
+      CheckList chk;
+      chk.checkV = true;
+      chk.checkArn = true;
+      chk.checkAux = true;
+      om_->print( Debug, accuracyCheck(chk, ": after initialize()") );
+    }
+    */
+
+  }
+
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  // Iterate until the status test informs us we should stop.
+  template <class StorageType, class MV, class OP>
+  void PseudoBlockGmresIter<Sacado::MP::Vector<StorageType>,MV,OP>::iterate()
+  {
+    //
+    // Allocate/initialize data structures
+    //
+    if (initialized_ == false) {
+      initialize();
+    }
+
+    const ScalarType one = Teuchos::ScalarTraits<ScalarType>::one();
+    const ScalarType zero = Teuchos::ScalarTraits<ScalarType>::zero();
+
+    // Compute the current search dimension.
+    int searchDim = numBlocks_;
+    //
+    // Associate each initial block of V_[i] with U_vec[i]
+    // Reset the index vector (this might have been changed if there was a restart)
+    //
+    std::vector<int> index(1);
+    std::vector<int> index2(1);
+    index[0] = curDim_;
+    Teuchos::RCP<MV> U_vec = MVT::Clone( *V_[0], numRHS_ );
+
+    // Create AU_vec to hold A*U_vec.
+    Teuchos::RCP<MV> AU_vec = MVT::Clone( *V_[0], numRHS_ );
+
+    for (int i=0; i<numRHS_; ++i) {
+      index2[0] = i;
+      Teuchos::RCP<const MV> tmp_vec = MVT::CloneView( *V_[i], index );
+      Teuchos::RCP<MV> U_vec_view = MVT::CloneViewNonConst( *U_vec, index2 );
+      MVT::MvAddMv( one, *tmp_vec, zero, *tmp_vec, *U_vec_view );
+    }
+
+    ////////////////////////////////////////////////////////////////
+    // iterate until the status test tells us to stop.
+    //
+    // also break if our basis is full
+    //
+    while (stest_->checkStatus(this) != Passed && curDim_ < searchDim) {
+      iter_++;
+      //
+      // Apply the operator to _work_vector
+      //
+
+      lp_->apply( *U_vec, *AU_vec );
+      //
+      //
+      // Resize index.
+      //
+      int num_prev = curDim_+1;
+      index.resize( num_prev );
+      for (int i=0; i<num_prev; ++i) {
+	      index[i] = i;
+      }
+      //
+      // Orthogonalize next Krylov vector for each right-hand side.
+      //
+      for (int i=0; i<numRHS_; ++i) {
+        //
+        // Get previous Krylov vectors.
+        //
+        Teuchos::RCP<const MV> V_prev = MVT::CloneView( *V_[i], index );
+        Teuchos::Array< Teuchos::RCP<const MV> > V_array( 1, V_prev );
+
+        //
+        // Get a view of the new candidate std::vector.
+        //
+        index2[0] = i;
+        Teuchos::RCP<MV> V_new = MVT::CloneViewNonConst( *AU_vec, index2 );
+
+        //
+        // Get a view of the current part of the upper-hessenberg matrix.
+        //
+        Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > h_new
+          = Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>
+              ( Teuchos::View, *H_[i], num_prev, 1, 0, curDim_ ) );
+        Teuchos::Array< Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > > h_array( 1, h_new );
+
+        Teuchos::RCP<Teuchos::SerialDenseMatrix<int,ScalarType> > r_new
+          = Teuchos::rcp( new Teuchos::SerialDenseMatrix<int,ScalarType>
+              ( Teuchos::View, *H_[i], 1, 1, num_prev, curDim_ ) );
+
+        //
+        // Orthonormalize the new block of the Krylov expansion
+        // NOTE:  Rank deficiencies are not checked because this is a single-std::vector Krylov method.
+        //
+        ortho_->projectAndNormalize( *V_new, h_array, r_new, V_array );
+
+        //
+        // NOTE:  V_new is a copy of the iter+1 vector in V_[i], so the normalized vector has to be
+        // be copied back in when V_new is changed.
+        //
+        index2[0] = curDim_+1;
+        Teuchos::RCP<MV> tmp_vec = MVT::CloneViewNonConst( *V_[i], index2 );
+        MVT::MvAddMv( one, *V_new, zero, *V_new, *tmp_vec );
+      }
+      //
+      // Now _AU_vec is the new _U_vec, so swap these two vectors.
+      // NOTE: This alleviates the need for allocating a vector for AU_vec each iteration.
+      //
+      Teuchos::RCP<MV> tmp_AU_vec = U_vec;
+      U_vec = AU_vec;
+      AU_vec = tmp_AU_vec;
+      //
+      // V has been extended, and H has been extended.
+      //
+      // Update the QR factorization of the upper Hessenberg matrix
+      //
+      {
+#ifdef BELOS_TEUCHOS_TIME_MONITOR
+      Teuchos::TimeMonitor updateTimer( *timerUpdateLSQR_ );
+#endif
+      updateLSQR();
+      }
+      //
+      // Update basis dim and release all pointers.
+      //
+      curDim_ += 1;
+      //
+      /*
+      // When required, monitor some orthogonalities
+      if (om_->isVerbosity( Debug ) ) {
+      // Check almost everything here
+      CheckList chk;
+      chk.checkV = true;
+      chk.checkArn = true;
+      om_->print( Debug, accuracyCheck(chk, ": after local update") );
+      }
+      else if (om_->isVerbosity( OrthoDetails ) ) {
+        CheckList chk;
+        chk.checkV = true;
+        om_->print( OrthoDetails, accuracyCheck(chk, ": after local update") );
+      }
+      */
+
+    } // end while (statusTest == false)
+
+  }
+
+  //////////////////////////////////////////////////////////////////////////////////////////////////
+  // Update the least squares solution for each right-hand side.
+  template<class StorageType, class MV, class OP>
+  void PseudoBlockGmresIter<Sacado::MP::Vector<StorageType>,MV,OP>::updateLSQR( int dim )
+  {
+    // Get correct dimension based on input "dim"
+    // Remember that ortho failures result in an exit before updateLSQR() is called.
+    // Therefore, it is possible that dim == curDim_.
+    int curDim = curDim_;
+    if (dim >= curDim_ && dim < getMaxSubspaceDim()) {
+      curDim = dim;
+    }
+
+    int i, j;
+    const ScalarType zero = Teuchos::ScalarTraits<ScalarType>::zero();
+    const ScalarType one = Teuchos::ScalarTraits<ScalarType>::one();
+
+    Teuchos::BLAS<int, ScalarType> blas;
+
+    for (i=0; i<numRHS_; ++i) {
+      //
+      // Update the least-squares QR for each linear system.
+      //
+      // QR factorization of Least-Squares system with Givens rotations
+      //
+      for (j=0; j<curDim; j++) {
+        //
+        // Apply previous Givens rotations to new column of Hessenberg matrix
+        //
+        blas.ROT( 1, &(*H_[i])(j,curDim), 1, &(*H_[i])(j+1, curDim), 1, &(*cs_[i])[j], &(*sn_[i])[j] );
+      }
+      //
+      // Calculate new Givens rotation
+      //
+      if ( curDim == 0)
+      {
+        // Initialize the lucky_breakdown_ mask to take account of perfect initial guess
+        lucky_breakdown_ = ((*Z_[i])(curDim) == zero);
+      }
+      auto lucky_breakdown_tmp = ((*H_[i])(curDim+1,curDim) == zero);
+      mask_assign(lucky_breakdown_,(*H_[i])(curDim,curDim)) = one;
+      lucky_breakdown_ = lucky_breakdown_ || lucky_breakdown_tmp;
+      //Teuchos::my_GivensRotator<ScalarType> GR;
+      blas.ROTG( &(*H_[i])(curDim,curDim), &(*H_[i])(curDim+1,curDim), &(*cs_[i])[curDim], &(*sn_[i])[curDim] );
+      (*H_[i])(curDim+1,curDim) = zero;
+      //
+      // Update RHS w/ new transformation
+      //
+      blas.ROT( 1, &(*Z_[i])(curDim), 1, &(*Z_[i])(curDim+1), 1, &(*cs_[i])[curDim], &(*sn_[i])[curDim] );
+    }
+
+  } // end updateLSQR()
+
+} // end Belos namespace
+
+#endif /* BELOS_PSEUDO_BLOCK_GMRES_ITER_MP_VECTOR_HPP */

--- a/packages/stokhos/src/sacado/kokkos/vector/belos/Belos_StatusTest_GenResNorm_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/belos/Belos_StatusTest_GenResNorm_MP_Vector.hpp
@@ -191,7 +191,7 @@ class StatusTestGenResNorm<Sacado::MP::Vector<Storage>, MV, OP> :
   StatusType checkStatus(Iteration<ScalarType,MV,OP>* iSolver);
 
   //! Return the result of the most recent CheckStatus call.
-  StatusType getStatus() const {return(status_);};
+  StatusType getStatus() const {return(status_);}
   //@}
 
   //! @name Reset methods
@@ -231,16 +231,16 @@ class StatusTestGenResNorm<Sacado::MP::Vector<Storage>, MV, OP> :
   std::vector<int> convIndices() { return ind_; }
 
   //! Returns the value of the tolerance, \f$ \tau \f$, set in the constructor.
-  MagnitudeType getTolerance() const {return(tolerance_);};
+  MagnitudeType getTolerance() const {return(tolerance_);}
 
   //! Returns the test value, \f$ \frac{\|r\|}{\sigma} \f$, computed in most recent call to CheckStatus.
-  const std::vector<MagnitudeType>* getTestValue() const {return(&testvector_);};
+  const std::vector<MagnitudeType>* getTestValue() const {return(&testvector_);}
 
   //! Returns the residual norm value, \f$ \|r\| \f$, computed in most recent call to CheckStatus.
-  const std::vector<MagnitudeType>* getResNormValue() const {return(&resvector_);};
+  const std::vector<MagnitudeType>* getResNormValue() const {return(&resvector_);}
 
   //! Returns the scaled norm value, \f$ \sigma \f$.
-  const std::vector<MagnitudeType>* getScaledNormValue() const {return(&scalevector_);};
+  const std::vector<MagnitudeType>* getScaledNormValue() const {return(&scalevector_);}
 
   //! Returns a boolean indicating a loss of accuracy has been detected in computing the residual.
   //! \note This status test does not check for loss of accuracy, so this method will always return false.

--- a/packages/stokhos/src/sacado/kokkos/vector/belos/Belos_StatusTest_ImpResNorm_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/belos/Belos_StatusTest_ImpResNorm_MP_Vector.hpp
@@ -1,0 +1,879 @@
+//@HEADER
+// ************************************************************************
+//
+//                 Belos: Block Linear Solvers Package
+//                  Copyright 2004 Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+
+#ifndef BELOS_STATUS_TEST_GEN_IMPRESNORM_MP_VECTOR_HPP
+#define BELOS_STATUS_TEST_GEN_IMPRESNORM_MP_VECTOR_HPP
+
+/*!
+  \file Belos_StatusTest_ImpResNorm_MP_Vector.hpp
+  \brief Belos::StatusTest for specifying an implicit residual norm stopping criteria that checks for loss of accuracy.
+
+  Specialized for Sacado::MP::Vector scalar type to track how many iterations
+  each component of ensemble takes.
+*/
+
+#include "Stokhos_Sacado_Kokkos_MP_Vector.hpp"
+#include "BelosStatusTestImpResNorm.hpp"
+
+/*!
+  \class Belos::StatusTestImpResNorm
+  \brief Convergence test using the implicit residual norm(s), with an
+    explicit residual norm(s) check for loss of accuracy if necessary.
+
+  This test passes when a quorum of residual vectors (for all
+  right-hand sides) passes a residual norm test.  For residual vector
+  \f$r_i\f$, the form of the test is \f$\|r_i\| / \sigma_i \le
+  \tau\f$, where \f$\tau\f$ is the convergence tolerance set in the
+  constructor or by setTolerance().  The default quorum consists of
+  all the vectors, but you can set the number of vectors that must
+  pass before the whole test passes, either by the constructor
+  argument or by calling setQuorum().
+
+  The default residual vector norm (the norm used in the numerator of
+  the test, and applied to the current residual vectors) is the
+  2-norm, but you can change the norm type (1-norm, 2-norm, or
+  infinity norm) using defineResForm().  The default scaling factor
+  \f$\sigma_i\f$ for residual vector i is the 2-norm of the initial
+  residual vector, but you can change this using defineScaleForm().
+  The norm used for the scaling factors may be different than the norm
+  used for the current residual vectors.  Furthermore, each residual
+  vector may use a different scaling factor \f$\sigma_i\f$.
+
+  This test starts by using the "implicit" residual norm, otherwise
+  called the "recursive" or "native" residual norm.  It comes from the
+  iterative method's projected problem, unlike the "explicit" residual
+  norm, which comes from explicitly computing \f$R = B - A * X\f$.
+  Once the implicit residual norm reaches the convergence tolerance,
+  this test then checks the explicit residual norm to make sure that
+  it has reached the convergence tolerance as well.
+
+  We say that there is a "potential loss of accuracy" when we first
+  detect that the implicit residual norm(s) have met the desired
+  original convergence tolerance, but the explicit residual norm(s)
+  have not.  We don't actually call this a "loss of accuracy" (in the
+  sense of getLOADetected() returning true) unless we tried to remedy
+  this situation, but couldn't fix it.  Upon detecting a potential
+  loss of accuracy, this test tells the solver to "iterate a few more
+  steps" by making the "current" residual tolerance (the value of
+  getCurrTolerance()) smaller, and forcing the implicit residual
+  norm(s) to meet the current tolerance before moving on to test the
+  explicit norm(s).  If that doesn't work, this test declares a loss
+  of accuracy.
+
+  This implementation is the same as the default, but is specialized for
+  the Sacado::MP::Vector scalar type to keep track of when each component
+  of the ensemble converges.
+
+*/
+
+namespace Belos {
+
+template <class Storage, class MV, class OP>
+class StatusTestImpResNorm<Sacado::MP::Vector<Storage>, MV, OP> :
+    public StatusTestResNorm<Sacado::MP::Vector<Storage>,MV,OP> {
+
+public:
+  typedef Sacado::MP::Vector<Storage> ScalarType;
+  //! The type of the magnitude (absolute value) of a ScalarType.
+  typedef typename Teuchos::ScalarTraits<ScalarType>::magnitudeType MagnitudeType;
+
+private:
+  //! @name Abbreviations for method implementations
+  //@{
+  typedef Teuchos::ScalarTraits<ScalarType> STS;
+  typedef Teuchos::ScalarTraits<MagnitudeType> STM;
+  typedef MultiVecTraits<ScalarType,MV> MVT;
+  //@}
+
+public:
+  //! @name Constructors and destructor.
+  //@{
+
+  /// \brief Constructor
+  ///
+  /// \param Tolerance [in] Convergence tolerance \f$\tau\f$.
+  ///
+  /// \param quorum [in] The number of vectors in the problem that
+  ///   must pass the convergence criteria before this StatusTest
+  ///   passes.  -1 means that all residuals must pass.
+  ///
+  /// \param showMaxResNormOnly [in] Whether only the maximum residual
+  ///   norm (of all vectors) is displayed when the print() method is
+  ///   called.
+  StatusTestImpResNorm (MagnitudeType Tolerance,
+                        int quorum = -1,
+                        bool showMaxResNormOnly = false);
+
+  //! Destructor (virtual for memory safety).
+  virtual ~StatusTestImpResNorm();
+
+  //@}
+  //! @name Form and parameter definition methods.
+  //@{
+
+  //! Define form of the residual, its norm and optional weighting vector.
+  /*! This method defines the form of \f$\|r\|\f$.  We specify:
+    <ul>
+    <li> The norm to be used on the residual (this may be different than the norm used in
+    defineScaleForm()).
+    </ul>
+  */
+  int defineResForm( NormType TypeOfNorm);
+
+  //! Define form of the scaling, its norm, its optional weighting vector, or, alternatively, define an explicit value.
+  /*! This method defines the form of how the residual is scaled (if at all).  It operates in two modes:
+    <ol>
+    <li> User-provided scaling value:
+    <ul>
+    <li> Set argument TypeOfScaling to UserProvided.
+    <li> Set ScaleValue to a non-zero value that the residual norm will be divided by.
+    <li> TypeOfNorm argument will be ignored.
+    <li> Sample use:  Define ScaleValue = \f$\|A\|_{\infty}\f$ where \f$ A \f$ is the matrix
+    of the linear problem.
+    </ul>
+
+    <li> Use a supported Scaling Form:
+    <ul>
+    <li> Define TypeOfScaling to be the norm of the right hand side, the initial residual vector,
+    or to none.
+    <li> Define norm to be used on the scaling vector (this may be different than the norm used
+    in DefineResForm()).
+    </ul>
+    </ol>
+  */
+  int defineScaleForm( ScaleType TypeOfScaling, NormType TypeOfNorm, MagnitudeType ScaleValue = Teuchos::ScalarTraits<MagnitudeType>::one());
+
+  //! Set the value of the tolerance
+  /*! We allow the tolerance to be reset for cases where, in the process of testing the residual,
+    we find that the initial tolerance was too tight or too lax.
+  */
+  int setTolerance (MagnitudeType tolerance) {
+    tolerance_ = tolerance;
+    return 0;
+  }
+
+  //! Sets the number of residuals that must pass the convergence test before Passed is returned.
+  //! \note If \c quorum=-1 then all residuals must pass the convergence test before Passed is returned.
+  int setQuorum (int quorum) {
+    quorum_ = quorum;
+    return 0;
+  }
+
+  //! Set whether the only maximum residual norm is displayed when the print() method is called
+  int setShowMaxResNormOnly (bool showMaxResNormOnly) {
+    showMaxResNormOnly_ = showMaxResNormOnly;
+    return 0;
+  }
+
+  //@}
+
+  //! @name Status methods
+  //@{
+  //! Check convergence status: Passed, Failed, or Undefined.
+  /*! This method checks to see if the convergence criteria are met.
+    Depending on how the residual test is constructed this method will return
+    the appropriate status type.
+
+    \return StatusType: Passed, Failed, or Undefined.
+  */
+  StatusType checkStatus(Iteration<ScalarType,MV,OP>* iSolver);
+
+  //! Return the result of the most recent CheckStatus call.
+  StatusType getStatus() const {return(status_);}
+  //@}
+
+  //! @name Reset methods
+  //@{
+
+  //! Resets the internal configuration to the initial state.
+  void reset();
+
+  //@}
+
+  //! @name Print methods
+  //@{
+
+  //! Output formatted description of stopping test to output stream.
+  void print(std::ostream& os, int indent = 0) const;
+
+  //! Print message for each status specific to this stopping test.
+  void printStatus(std::ostream& os, StatusType type) const;
+  //@}
+
+  //! @name Methods to access data members.
+  //@{
+
+  //! Returns the current solution estimate that was computed for the most recent residual test.
+  Teuchos::RCP<MV> getSolution() { return curSoln_; }
+
+  //! Returns the number of residuals that must pass the convergence test before Passed is returned.
+  //! \note If \c quorum=-1 then all residuals must pass the convergence test before Passed is returned.
+  int getQuorum() const { return quorum_; }
+
+  //! Returns whether the only maximum residual norm is displayed when the print() method is called
+  bool getShowMaxResNormOnly() { return showMaxResNormOnly_; }
+
+  //! Returns the vector containing the indices of the residuals that passed the test.
+  std::vector<int> convIndices() { return ind_; }
+
+  /// \brief "Original" convergence tolerance \f$\tau\f$ as set by user.
+  ///
+  /// This value is the convergence tolerance as set by the user in
+  /// the constructor, or by the setTolerance() method.  See this
+  /// class' main documentation and the documentation of
+  /// getCurrTolerance() for an explanation of the difference between
+  /// the "original" and "current" tolerances.
+  MagnitudeType getTolerance () const {
+    return tolerance_;
+  }
+
+  /// \brief Current convergence tolerance; may be changed to prevent loss of accuracy.
+  ///
+  /// The difference between "original" tolerance (the value of
+  /// getTolerance()) and "current" tolerance (the value of this
+  /// method) relates to the idea of "loss of accuracy."  See this
+  /// class' main documentation for details.  We do not allow users to
+  /// set the "current" tolerance.
+  MagnitudeType getCurrTolerance () const {
+    return currTolerance_;
+  }
+
+  //! Returns the test value, \f$ \frac{\|r\|}{\sigma} \f$, computed in most recent call to CheckStatus.
+  const std::vector<MagnitudeType>* getTestValue() const {return(&testvector_);}
+
+  //! Returns the residual norm value, \f$ \|r\| \f$, computed in most recent call to CheckStatus.
+  const std::vector<MagnitudeType>* getResNormValue() const {return(&resvector_);}
+
+  //! Returns the scaled norm value, \f$ \sigma \f$.
+  const std::vector<MagnitudeType>* getScaledNormValue() const {return(&scalevector_);}
+
+  //! Returns a boolean indicating a loss of accuracy has been detected in computing the residual.
+  bool getLOADetected() const { return lossDetected_; }
+
+  //! Returns number of ensemble iterations
+  const std::vector<int> getEnsembleIterations() const { return ensemble_iterations; }
+  //@}
+
+
+  /** @name Misc. */
+  //@{
+
+  /** \brief Call to setup initial scaling vector.
+    *
+    * After this function is called <tt>getScaledNormValue()</tt> can be called
+    * to get the scaling vector.
+    */
+  StatusType firstCallCheckStatusSetup(Iteration<ScalarType,MV,OP>* iSolver);
+  //@}
+
+  /** \name Overridden from Teuchos::Describable */
+  //@{
+
+  /** \brief Method to return description of the maximum iteration status test  */
+  std::string description() const
+  {
+    std::ostringstream oss;
+    oss << "Belos::StatusTestImpResNorm<>: " << resFormStr();
+    oss << ", tol = " << tolerance_;
+    return oss.str();
+  }
+  //@}
+
+  protected:
+
+  private:
+
+  //! @name Private methods.
+  //@{
+  /** \brief Description of current residual form */
+  std::string resFormStr() const
+  {
+    std::ostringstream oss;
+    oss << "(";
+    oss << ((resnormtype_==OneNorm) ? "1-Norm" : (resnormtype_==TwoNorm) ? "2-Norm" : "Inf-Norm");
+    oss << " Res Vec) ";
+
+    // If there is no residual scaling, return current string.
+    if (scaletype_!=None)
+    {
+      // Insert division sign.
+      oss << "/ ";
+
+      // Determine output string for scaling, if there is any.
+      if (scaletype_==UserProvided)
+        oss << " (User Scale)";
+      else {
+        oss << "(";
+        oss << ((scalenormtype_==OneNorm) ? "1-Norm" : (resnormtype_==TwoNorm) ? "2-Norm" : "Inf-Norm");
+        if (scaletype_==NormOfInitRes)
+          oss << " Res0";
+        else if (scaletype_==NormOfPrecInitRes)
+          oss << " Prec Res0";
+        else
+          oss << " RHS ";
+        oss << ")";
+      }
+    }
+
+    return oss.str();
+  }
+
+  //! @name Private data members.
+  //@{
+
+  //! Current tolerance used to determine convergence and the default tolerance set by user.
+  MagnitudeType tolerance_, currTolerance_;
+
+  //! Number of residuals that must pass the convergence test before Passed is returned.
+  int quorum_;
+
+  //! Determines if the entries for all of the residuals are shown or just the max.
+  bool showMaxResNormOnly_;
+
+  //! Type of norm to use on residual (OneNorm, TwoNorm, or InfNorm).
+  NormType resnormtype_;
+
+  //! Type of scaling to use (Norm of RHS, Norm of Initial Residual, None or User provided)
+  ScaleType scaletype_;
+
+  //! Type of norm to use on the scaling (OneNorm, TwoNorm, or InfNorm)
+  NormType scalenormtype_;
+
+  //! Scaling value.
+  MagnitudeType scalevalue_;
+
+  //! Scaling vector.
+  std::vector<MagnitudeType> scalevector_;
+
+  //! Residual norm vector.
+  std::vector<MagnitudeType> resvector_;
+
+  //! Test vector = resvector_ / scalevector_
+  std::vector<MagnitudeType> testvector_;
+
+  //! Current solution vector
+  Teuchos::RCP<MV> curSoln_;
+
+  //! Vector containing the indices for the vectors that passed the test.
+  std::vector<int> ind_;
+
+  //! Status
+  StatusType status_;
+
+  //! The current blocksize of the linear system being solved.
+  int curBlksz_;
+
+  //! The current number of right-hand sides being solved for.
+  int curNumRHS_;
+
+  //! The indices of the current number of right-hand sides being solved for.
+  std::vector<int> curLSIdx_;
+
+  //! The current number of linear systems that have been loaded into the linear problem.
+  int curLSNum_;
+
+  //! The total number of right-hand sides being solved for.
+  int numrhs_;
+
+  //! Is this the first time CheckStatus is called?
+  bool firstcallCheckStatus_;
+
+  //! Is this the first time DefineResForm is called?
+  bool firstcallDefineResForm_;
+
+  //! Is this the first time DefineScaleForm is called?
+  bool firstcallDefineScaleForm_;
+
+  //! Has a loss in accuracy been detected?
+  bool lossDetected_;
+
+  //! The number of iterations at which point each ensemble component converges
+  std::vector<int> ensemble_iterations;
+
+  //@}
+
+};  
+
+template <class StorageType, class MV, class OP>
+StatusTestImpResNorm<Sacado::MP::Vector<StorageType>,MV,OP>::
+StatusTestImpResNorm (MagnitudeType Tolerance, int quorum, bool showMaxResNormOnly)
+  : tolerance_(Tolerance),
+    currTolerance_(Tolerance),
+    quorum_(quorum),
+    showMaxResNormOnly_(showMaxResNormOnly),
+    resnormtype_(TwoNorm),
+    scaletype_(NormOfInitRes),
+    scalenormtype_(TwoNorm),
+    scalevalue_(Teuchos::ScalarTraits<MagnitudeType>::one ()),
+    status_(Undefined),
+    curBlksz_(0),
+    curNumRHS_(0),
+    curLSNum_(0),
+    numrhs_(0),
+    firstcallCheckStatus_(true),
+    firstcallDefineResForm_(true),
+    firstcallDefineScaleForm_(true),
+    lossDetected_(false),
+    ensemble_iterations(StorageType::static_size, 0)
+{
+  // This constructor will compute the residual ||r_i||/||r0_i|| <= tolerance using the 2-norm of
+  // the implicit residual vector.
+}
+
+template <class StorageType, class MV, class OP>
+StatusTestImpResNorm<Sacado::MP::Vector<StorageType>,MV,OP>::~StatusTestImpResNorm()
+{}
+
+template <class StorageType, class MV, class OP>
+void StatusTestImpResNorm<Sacado::MP::Vector<StorageType>,MV,OP>::reset()
+{
+  status_ = Undefined;
+  curBlksz_ = 0;
+  curLSNum_ = 0;
+  curLSIdx_.resize(0);
+  numrhs_ = 0;
+  ind_.resize(0);
+  currTolerance_ = tolerance_;
+  firstcallCheckStatus_ = true;
+  lossDetected_ = false;
+  curSoln_ = Teuchos::null;
+  ensemble_iterations = std::vector<int>(StorageType::static_size, 0);
+}
+
+template <class StorageType, class MV, class OP>
+int StatusTestImpResNorm<Sacado::MP::Vector<StorageType>,MV,OP>::defineResForm( NormType TypeOfNorm )
+{
+  TEUCHOS_TEST_FOR_EXCEPTION(firstcallDefineResForm_==false,StatusTestError,
+        "StatusTestResNorm::defineResForm(): The residual form has already been defined.");
+  firstcallDefineResForm_ = false;
+
+  resnormtype_ = TypeOfNorm;
+
+  return(0);
+}
+
+template <class StorageType, class MV, class OP>
+int StatusTestImpResNorm<Sacado::MP::Vector<StorageType>,MV,OP>::defineScaleForm(ScaleType TypeOfScaling, NormType TypeOfNorm,
+                                                          MagnitudeType ScaleValue )
+{
+  TEUCHOS_TEST_FOR_EXCEPTION(firstcallDefineScaleForm_==false,StatusTestError,
+        "StatusTestResNorm::defineScaleForm(): The scaling type has already been defined.");
+  firstcallDefineScaleForm_ = false;
+
+  scaletype_ = TypeOfScaling;
+  scalenormtype_ = TypeOfNorm;
+  scalevalue_ = ScaleValue;
+
+  return(0);
+}
+
+template <class StorageType, class MV, class OP>
+StatusType StatusTestImpResNorm<Sacado::MP::Vector<StorageType>,MV,OP>::
+checkStatus (Iteration<ScalarType,MV,OP>* iSolver)
+{
+  //std::cout << "check status start" << std::endl;
+  using Teuchos::as;
+  using Teuchos::RCP;
+
+  const MagnitudeType zero = STM::zero ();
+  const MagnitudeType one  = STM::one ();
+  const LinearProblem<ScalarType,MV,OP>& lp = iSolver->getProblem ();
+
+  // Compute scaling term (done once for each block that's being solved)
+  if (firstcallCheckStatus_) {
+    StatusType status = firstCallCheckStatusSetup (iSolver);
+    if (status == Failed) {
+      status_ = Failed;
+      return status_;
+    }
+  }
+
+  // mfh 23 Apr 2012: I don't know exactly what this code does.  It
+  // has something to do with picking the block of right-hand sides
+  // which we're currently checking.
+  if (curLSNum_ != lp.getLSNumber ()) {
+    //
+    // We have moved on to the next rhs block
+    //
+    curLSNum_ = lp.getLSNumber();
+    curLSIdx_ = lp.getLSIndex();
+    curBlksz_ = (int)curLSIdx_.size();
+    int validLS = 0;
+    for (int i=0; i<curBlksz_; ++i) {
+      if (curLSIdx_[i] > -1 && curLSIdx_[i] < numrhs_)
+        validLS++;
+    }
+    curNumRHS_ = validLS;
+    curSoln_ = Teuchos::null;
+  } else {
+    //
+    // We are in the same rhs block, return if we are converged
+    //
+    if (status_ == Passed) {
+      //std::cout << "check status end 2" << std::endl;
+      return status_;
+    }
+  }
+
+  //
+  // Get the "native" residual norms from the solver for this block of
+  // right-hand sides.  If the solver's getNativeResiduals() method
+  // actually returns a multivector, compute the norms of the columns
+  // of the multivector explicitly.  Otherwise, we assume that
+  // resvector_ contains the norms.
+  //
+  // Note that "compute the norms explicitly" doesn't necessarily mean
+  // the "explicit" residual norms (in the sense discussed in this
+  // class' documentation).  These are just some vectors returned by
+  // the solver.  Some Krylov methods, like CG, compute a residual
+  // vector "recursively."  This is an "implicit residual" in the
+  // sense of this class' documentation.  It equals the explicit
+  // residual in exact arithmetic, but due to rounding error, it is
+  // usually different than the explicit residual.
+  //
+  // FIXME (mfh 23 Apr 2012) This method does _not_ respect the
+  // OrthoManager used by the solver.
+  //
+  std::vector<MagnitudeType> tmp_resvector( curBlksz_ );
+  RCP<const MV> residMV = iSolver->getNativeResiduals (&tmp_resvector);
+  if (! residMV.is_null ()) {
+    // We got a multivector back.  Compute the norms explicitly.
+    tmp_resvector.resize (MVT::GetNumberVecs (*residMV));
+    MVT::MvNorm (*residMV, tmp_resvector, resnormtype_);
+    typename std::vector<int>::iterator p = curLSIdx_.begin();
+    for (int i=0; p<curLSIdx_.end(); ++p, ++i) {
+      // Check if this index is valid
+      if (*p != -1) {
+        resvector_[*p] = tmp_resvector[i];
+      }
+    }
+  } else {
+    typename std::vector<int>::iterator p = curLSIdx_.begin();
+    for (int i=0; p<curLSIdx_.end(); ++p, ++i) {
+      // Check if this index is valid
+      if (*p != -1) {
+        resvector_[*p] = tmp_resvector[i];
+      }
+    }
+  }
+  //
+  // Scale the unscaled residual norms we computed or obtained above.
+  //
+  if (scalevector_.size () > 0) {
+    // There are per-vector scaling factors to apply.
+    typename std::vector<int>::iterator p = curLSIdx_.begin();
+    for (; p<curLSIdx_.end(); ++p) {
+      // Check if this index is valid
+      if (*p != -1) {
+        // Scale the vector accordingly
+        testvector_[ *p ] = resvector_[ *p ] / scalevalue_;
+        mask_assign(scalevector_[ *p ]!= zero, testvector_[ *p ]) /= scalevector_[ *p ];
+      }
+    }
+  }
+  else { // There are no per-vector scaling factors.
+    typename std::vector<int>::iterator p = curLSIdx_.begin();
+    for (; p<curLSIdx_.end(); ++p) {
+      // Check if this index is valid
+      if (*p != -1) {
+        testvector_[ *p ] = resvector_[ *p ] / scalevalue_;
+      }
+    }
+  }
+
+  // Count how many scaled residual norms (in testvector_) pass, using
+  // the current tolerance (currTolerance_) rather than the original
+  // tolerance (tolerance_).  If at least quorum_ of them pass, we
+  // have a quorum for the whole test to pass.
+  //
+  // We also check here whether any of the scaled residual norms is
+  // NaN, and throw an exception in that case.
+  int have = 0;
+  ind_.resize( curLSIdx_.size() );
+  std::vector<int> lclInd( curLSIdx_.size() );
+  typename std::vector<int>::iterator p = curLSIdx_.begin();
+  for (int i=0; p<curLSIdx_.end(); ++p, ++i) {
+    // Check if this index is valid
+    if (*p != -1) {
+      // Check if any of the residuals are larger than the tolerance.
+      const int ensemble_size = StorageType::static_size;
+      bool all_converged = true;
+      for (int ii=0; ii<ensemble_size; ++ii) {
+        if (testvector_[ *p ].coeff(ii) > currTolerance_.coeff(ii)) {
+          ++ensemble_iterations[ii];
+          all_converged = false;
+        }
+        else if (!(testvector_[ *p ].coeff(ii) <= currTolerance_.coeff(ii))) {
+          // Throw an std::exception if the current residual norm is
+          // NaN.  We know that it's NaN because it is not less than,
+          // equal to, or greater than the current tolerance.  This is
+          // only possible if either the residual norm or the current
+          // tolerance is NaN; we assume the former.  We also mark the
+          // test as failed, in case you want to catch the exception.
+          status_ = Failed;
+          TEUCHOS_TEST_FOR_EXCEPTION(true, StatusTestError, "Belos::"
+            "StatusTestImpResNorm::checkStatus(): One or more of the current "
+            "implicit residual norms is NaN.");
+        }
+      }
+      if (all_converged) {
+        ind_[have] = *p;
+        have++;
+      }
+    }
+  }
+  // "have" is the number of residual norms that passed.
+  ind_.resize(have);
+  lclInd.resize(have);
+
+  // Now check the exact residuals
+  if (have) { // At least one residual norm has converged.
+    //
+    // Compute the explicit residual norm(s) from the current solution update.
+    //
+    RCP<MV> cur_update = iSolver->getCurrentUpdate ();
+    curSoln_ = lp.updateSolution (cur_update);
+    RCP<MV> cur_res = MVT::Clone (*curSoln_, MVT::GetNumberVecs (*curSoln_));
+    lp.computeCurrResVec (&*cur_res, &*curSoln_);
+    tmp_resvector.resize (MVT::GetNumberVecs (*cur_res));
+    std::vector<MagnitudeType> tmp_testvector (have);
+
+    MVT::MvNorm (*cur_res, tmp_resvector, resnormtype_);
+
+    // Scale the explicit residual norm(s), just like the implicit norm(s).
+    if ( scalevector_.size() > 0 ) {
+      for (int i=0; i<have; ++i) {
+        // Scale the vector accordingly
+        tmp_testvector[ i ] = tmp_resvector[ lclInd[i] ] / scalevalue_;
+        mask_assign(scalevector_[ ind_[i] ]!=zero,tmp_testvector[ i ]) /= scalevector_[ ind_[i] ];
+      }
+    }
+    else {
+      for (int i=0; i<have; ++i) {
+        tmp_testvector[ i ] = tmp_resvector[ lclInd[i] ] / scalevalue_;
+      }
+    }
+
+    //
+    // Check whether the explicit residual norms also pass the
+    // convergence test.  If not, check whether we want to try
+    // iterating a little more to force both implicit and explicit
+    // residual norms to pass.
+    //
+    int have2 = 0;
+    for (int i = 0; i < have; ++i) {
+      // testvector_ contains the implicit (i.e., recursive, computed
+      // by the algorithm) (possibly scaled) residuals.  All of these
+      // pass the convergence test.
+      //
+      // tmp_testvector contains the explicit (i.e., ||B-AX||)
+      // (possibly scaled) residuals.  We're checking whether these
+      // pass as well.  The explicit residual norms only have to meet
+      // the _original_ tolerance (tolerance_), not the current
+      // tolerance (currTolerance_).
+
+
+      // Absolute difference between the current explicit and
+      // implicit residual norm.
+      const MagnitudeType diff = STM::magnitude (testvector_[ind_[i]] - tmp_testvector[i]);
+
+      // Check if any of the residuals are larger than the tolerance.
+      const int ensemble_size = StorageType::static_size;
+      typedef typename StorageType::value_type value_type;
+      bool all_converged = true;
+      {
+        for (int ii=0; ii<ensemble_size; ++ii) {
+          if (!(tmp_testvector[i].coeff(ii) <= tolerance_.coeff(ii))) {
+            if (diff.coeff(ii) > currTolerance_.coeff(ii)) {
+              lossDetected_ = true;
+            }
+            else {
+              const value_type onePointFive = as<value_type>(3) / as<value_type> (2);
+              const value_type oneTenth = as<value_type>(1) / as<value_type> (10);
+
+              currTolerance_.fastAccessCoeff(ii) = currTolerance_.coeff(ii) - onePointFive * diff.coeff(ii);
+              while (currTolerance_.coeff(ii) < as<value_type>(0)) {
+                currTolerance_.fastAccessCoeff(ii) += oneTenth * diff.coeff(ii);
+              }
+              all_converged = false;
+            }
+          }
+        }
+      }
+      if (all_converged) {
+        ind_[have2] = ind_[i];
+        have2++; // This right-hand side has converged.
+      }
+    }
+    have = have2;
+    ind_.resize(have);
+  }
+
+  // Check whether we've met the quorum of vectors necessary for the
+  // whole test to pass.
+  int need = (quorum_ == -1) ? curNumRHS_: quorum_;
+  status_ = (have >= need) ? Passed : Failed;
+
+
+  //std::cout << "check status end default" << std::endl;
+  // Return the current status
+  return status_;
+}
+
+template <class StorageType, class MV, class OP>
+void StatusTestImpResNorm<Sacado::MP::Vector<StorageType>,MV,OP>::print(std::ostream& os, int indent) const
+{
+  for (int j = 0; j < indent; j ++)
+    os << ' ';
+  printStatus(os, status_);
+  os << resFormStr();
+  if (status_==Undefined)
+    os << ", tol = " << tolerance_ << std::endl;
+  else {
+    os << std::endl;
+    if(showMaxResNormOnly_ && curBlksz_ > 1) {
+      const MagnitudeType maxRelRes = *std::max_element(
+        testvector_.begin()+curLSIdx_[0],testvector_.begin()+curLSIdx_[curBlksz_-1]
+        );
+      for (int j = 0; j < indent + 13; j ++)
+        os << ' ';
+      os << "max{residual["<<curLSIdx_[0]<<"..."<<curLSIdx_[curBlksz_-1]<<"]} = " << maxRelRes
+          << ( maxRelRes <= tolerance_ ? " <= " : " > " ) << tolerance_ << std::endl;
+    }
+    else {
+      for ( int i=0; i<numrhs_; i++ ) {
+        for (int j = 0; j < indent + 13; j ++)
+          os << ' ';
+        os << "residual [ " << i << " ] = " << testvector_[ i ];
+        os << ((testvector_[i]<tolerance_) ? " < " : (testvector_[i]==tolerance_) ? " == " : (testvector_[i]>tolerance_) ? " > " : " "  ) << tolerance_ << std::endl;
+      }
+    }
+  }
+  os << std::endl;
+}
+
+template <class StorageType, class MV, class OP>
+void StatusTestImpResNorm<Sacado::MP::Vector<StorageType>,MV,OP>::printStatus(std::ostream& os, StatusType type) const
+{
+  os << std::left << std::setw(13) << std::setfill('.');
+  switch (type) {
+  case  Passed:
+    os << "Converged";
+    break;
+  case  Failed:
+    if (lossDetected_)
+      os << "Unconverged (LoA)";
+    else
+      os << "Unconverged";
+    break;
+  case  Undefined:
+  default:
+    os << "**";
+    break;
+  }
+  os << std::left << std::setfill(' ');
+    return;
+}
+
+template <class StorageType, class MV, class OP>
+StatusType StatusTestImpResNorm<Sacado::MP::Vector<StorageType>,MV,OP>::
+firstCallCheckStatusSetup (Iteration<ScalarType,MV,OP>* iSolver)
+{
+  int i;
+  const MagnitudeType zero = STM::zero ();
+  const MagnitudeType one = STM::one ();
+  const LinearProblem<ScalarType,MV,OP>& lp = iSolver->getProblem();
+  // Compute scaling term (done once for each block that's being solved)
+  if (firstcallCheckStatus_) {
+    //
+    // Get some current solver information.
+    //
+    firstcallCheckStatus_ = false;
+
+    if (scaletype_== NormOfRHS) {
+      Teuchos::RCP<const MV> rhs = lp.getRHS();
+      numrhs_ = MVT::GetNumberVecs( *rhs );
+      scalevector_.resize( numrhs_ );
+      MVT::MvNorm( *rhs, scalevector_, scalenormtype_ );
+    }
+    else if (scaletype_==NormOfInitRes) {
+      Teuchos::RCP<const MV> init_res = lp.getInitResVec();
+      numrhs_ = MVT::GetNumberVecs( *init_res );
+      scalevector_.resize( numrhs_ );
+      MVT::MvNorm( *init_res, scalevector_, scalenormtype_ );
+    }
+    else if (scaletype_==NormOfPrecInitRes) {
+      Teuchos::RCP<const MV> init_res = lp.getInitPrecResVec();
+      numrhs_ = MVT::GetNumberVecs( *init_res );
+      scalevector_.resize( numrhs_ );
+      MVT::MvNorm( *init_res, scalevector_, scalenormtype_ );
+    }
+    else {
+      numrhs_ = MVT::GetNumberVecs( *(lp.getRHS()) );
+    }
+
+    resvector_.resize( numrhs_ );
+    testvector_.resize( numrhs_ );
+
+    curLSNum_ = lp.getLSNumber();
+    curLSIdx_ = lp.getLSIndex();
+    curBlksz_ = (int)curLSIdx_.size();
+    int validLS = 0;
+    for (i=0; i<curBlksz_; ++i) {
+      if (curLSIdx_[i] > -1 && curLSIdx_[i] < numrhs_)
+        validLS++;
+    }
+    curNumRHS_ = validLS;
+    //
+    // Initialize the testvector.
+    for (i=0; i<numrhs_; i++) { testvector_[i] = one; }
+
+    // Return an error if the scaling is zero.
+    if (scalevalue_ == zero) {
+      return Failed;
+    }
+  }
+  return Undefined;
+}
+
+} // end namespace Belos
+
+#endif /* BELOS_STATUS_TEST_GEN_IMPRESNORM_MP_VECTOR_HPP */

--- a/packages/stokhos/src/sacado/kokkos/vector/tpetra/Stokhos_Tpetra_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/tpetra/Stokhos_Tpetra_MP_Vector.hpp
@@ -76,6 +76,8 @@
 #include "Kokkos_Random_MP_Vector.hpp"
 #endif
 
+#include "KokkosBlas_MP_Vector.hpp"
+
 namespace Stokhos {
 
 /// \brief Trait class that determines (new) Kokkos execution space

--- a/packages/stokhos/test/UnitTest/Stokhos_TpetraCrsMatrixMPVectorUnitTest.hpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_TpetraCrsMatrixMPVectorUnitTest.hpp
@@ -1475,10 +1475,10 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
   RCP<const Tpetra_Comm> comm = Tpetra::getDefaultComm();
   const int rank = comm->getRank ();
   const GlobalOrdinal mynrow = (rank==0 ? nrow: 0);
-  RCP<const Tpetra_Map> map = rcp (new Tpetra_Map (mynrow, nrow, 0, comm));
+  RCP<const Tpetra_Map> map = rcp (new Tpetra_Map (nrow, mynrow, 0, comm));
   RCP<Tpetra_CrsGraph> graph (new Tpetra_CrsGraph (map, size_t(3), Tpetra::StaticProfile));
-  for ( GlobalOrdinal i = 0; i<nrow; ++i)
-      for ( GlobalOrdinal j = 0; j<i+1; ++j)
+  for (GlobalOrdinal i = 0; i<nrow; ++i)
+      for (GlobalOrdinal j = 0; j<i+1; ++j)
           graph->insertGlobalIndices(i, tuple<GlobalOrdinal> (j));
   graph->fillComplete();
   
@@ -1578,7 +1578,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
   // Set values in matrix
   Array<Scalar> vals(nrow);
   Scalar val;
-  for (size_t i=0; i<nrow; ++i){
+  for (GlobalOrdinal i=0; i<nrow; ++i){
     for (LocalOrdinal j=0; j<VectorSize; ++j){
       if (i==0 && j==0)
         val.fastAccessCoeff(j) = 1;
@@ -1639,10 +1639,10 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
   RCP<const Tpetra_Comm> comm = Tpetra::getDefaultComm();
   const int rank = comm->getRank ();
   const GlobalOrdinal mynrow = (rank==0 ? nrow: 0);
-  RCP<const Tpetra_Map> map = rcp (new Tpetra_Map (mynrow, nrow, 0, comm));
+  RCP<const Tpetra_Map> map = rcp (new Tpetra_Map (nrow, mynrow, 0, comm));
   RCP<Tpetra_CrsGraph> graph (new Tpetra_CrsGraph (map, size_t(3), Tpetra::StaticProfile));
-  for ( GlobalOrdinal i = 0; i<nrow; ++i)
-      for ( GlobalOrdinal j = 0; j<i+1; ++j)
+  for (GlobalOrdinal i = 0; i<nrow; ++i)
+      for (GlobalOrdinal j = 0; j<i+1; ++j)
           graph->insertGlobalIndices(i, tuple<GlobalOrdinal> (j));
   graph->fillComplete();
   
@@ -1742,7 +1742,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
   // Set values in matrix
   Array<Scalar> vals(nrow);
   Scalar val;
-  for (size_t i=0; i<nrow; ++i){
+  for (GlobalOrdinal i=0; i<nrow; ++i){
     for (LocalOrdinal j=0; j<VectorSize; ++j){
       if (i==0 && j==0)
         val.fastAccessCoeff(j) = 1;
@@ -1803,10 +1803,10 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
   RCP<const Tpetra_Comm> comm = Tpetra::getDefaultComm();
   const int rank = comm->getRank ();
   const GlobalOrdinal mynrow = (rank==0 ? nrow: 0);
-  RCP<const Tpetra_Map> map = rcp (new Tpetra_Map (mynrow, nrow, 0, comm));
+  RCP<const Tpetra_Map> map = rcp (new Tpetra_Map (nrow, mynrow, 0, comm));
   RCP<Tpetra_CrsGraph> graph (new Tpetra_CrsGraph (map, size_t(3), Tpetra::StaticProfile));
-  for ( GlobalOrdinal i = 0; i<nrow; ++i)
-      for ( GlobalOrdinal j = 0; j<i+1; ++j)
+  for (GlobalOrdinal i = 0; i<nrow; ++i)
+      for (GlobalOrdinal j = 0; j<i+1; ++j)
           graph->insertGlobalIndices(i, tuple<GlobalOrdinal> (j));
   graph->fillComplete();
   
@@ -1906,7 +1906,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
   // Set values in matrix
   Array<Scalar> vals(nrow);
   Scalar val;
-  for (size_t i=0; i<nrow; ++i){
+  for (GlobalOrdinal i=0; i<nrow; ++i){
     for (LocalOrdinal j=0; j<VectorSize; ++j){
       if (i==0 && j==0)
         val.fastAccessCoeff(j) = 1;

--- a/packages/stokhos/test/UnitTest/Stokhos_TpetraCrsMatrixMPVectorUnitTest.hpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_TpetraCrsMatrixMPVectorUnitTest.hpp
@@ -1471,7 +1471,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
     Kokkos::initialize();
 
   // Build diagonal matrix
-  GlobalOrdinal nrow = 10;
+  GlobalOrdinal nrow = 20;
   RCP<const Tpetra_Comm> comm = Tpetra::getDefaultComm();
   RCP<const Tpetra_Map> map =
     Tpetra::createUniformContigMapWithNode<LocalOrdinal,GlobalOrdinal,Node>(
@@ -1625,7 +1625,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
     Kokkos::initialize();
 
   // Build diagonal matrix
-  GlobalOrdinal nrow = 10;
+  GlobalOrdinal nrow = 20;
   RCP<const Tpetra_Comm> comm = Tpetra::getDefaultComm();
   RCP<const Tpetra_Map> map =
     Tpetra::createUniformContigMapWithNode<LocalOrdinal,GlobalOrdinal,Node>(
@@ -1779,7 +1779,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
     Kokkos::initialize();
 
   // Build diagonal matrix
-  GlobalOrdinal nrow = 10;
+  GlobalOrdinal nrow = 20;
   RCP<const Tpetra_Comm> comm = Tpetra::getDefaultComm();
   RCP<const Tpetra_Map> map =
     Tpetra::createUniformContigMapWithNode<LocalOrdinal,GlobalOrdinal,Node>(

--- a/packages/stokhos/test/UnitTest/Stokhos_TpetraCrsMatrixMPVectorUnitTest.hpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_TpetraCrsMatrixMPVectorUnitTest.hpp
@@ -1553,7 +1553,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
 
   // Get and print number of ensemble iterations
   std::vector<int> ensemble_iterations =
-    Teuchos::rcp_static_cast<Belos::StatusTestImpResNorm<BelosScalar, MV, OP>>(solver->getResidualStatusTest())->getEnsembleIterations();
+    static_cast<const Belos::StatusTestImpResNorm<BelosScalar, MV, OP> *>(solver->getResidualStatusTest())->getEnsembleIterations();
   out << "Ensemble iterations = ";
   for (auto ensemble_iteration : ensemble_iterations)
     out << ensemble_iteration << " ";
@@ -1707,7 +1707,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
 
   // Get and print number of ensemble iterations
   std::vector<int> ensemble_iterations =
-    Teuchos::rcp_static_cast<Belos::StatusTestImpResNorm<BelosScalar, MV, OP>>(solver->getResidualStatusTest())->getEnsembleIterations();
+    static_cast<const Belos::StatusTestImpResNorm<BelosScalar, MV, OP> *>(solver->getResidualStatusTest())->getEnsembleIterations();
   out << "Ensemble iterations = ";
   for (auto ensemble_iteration : ensemble_iterations)
     out << ensemble_iteration << " ";
@@ -1861,7 +1861,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
 
   // Get and print number of ensemble iterations
   std::vector<int> ensemble_iterations =
-    Teuchos::rcp_static_cast<Belos::StatusTestImpResNorm<BelosScalar, MV, OP>>(solver->getResidualStatusTest())->getEnsembleIterations();
+    static_cast<const Belos::StatusTestImpResNorm<BelosScalar, MV, OP> *>(solver->getResidualStatusTest())->getEnsembleIterations();
   out << "Ensemble iterations = ";
   for (auto ensemble_iteration : ensemble_iterations)
     out << ensemble_iteration << " ";

--- a/packages/stokhos/test/UnitTest/Stokhos_TpetraCrsMatrixMPVectorUnitTest.hpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_TpetraCrsMatrixMPVectorUnitTest.hpp
@@ -1600,7 +1600,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
 
   tol = 10*tol;
   ArrayRCP<Scalar> x_view = x->get1dViewNonConst();
-  for (size_t i=0; i<nrow; ++i)
+  for (GlobalOrdinal i=0; i<nrow; ++i)
     for (LocalOrdinal j=0; j<VectorSize; ++j){
       // 1. is added both to x and vals to prevent issues with relative tolerances and values close to 0.
       TEST_FLOATING_EQUALITY(x_view[i].coeff(j)+1., vals[i].coeff(j)+1., tol);
@@ -1764,7 +1764,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
 
   tol = 10*tol;
   ArrayRCP<Scalar> x_view = x->get1dViewNonConst();
-  for (size_t i=0; i<nrow; ++i)
+  for (GlobalOrdinal i=0; i<nrow; ++i)
     for (LocalOrdinal j=0; j<VectorSize; ++j){
       // 1. is added both to x and vals to prevent issues with relative tolerances and values close to 0.
       TEST_FLOATING_EQUALITY(x_view[i].coeff(j)+1., vals[i].coeff(j)+1., tol);
@@ -1928,7 +1928,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
 
   tol = 10*tol;
   ArrayRCP<Scalar> x_view = x->get1dViewNonConst();
-  for (size_t i=0; i<nrow; ++i)
+  for (GlobalOrdinal i=0; i<nrow; ++i)
     for (LocalOrdinal j=0; j<VectorSize; ++j){
       // 1. is added both to x and vals to prevent issues with relative tolerances and values close to 0.
       TEST_FLOATING_EQUALITY(x_view[i].coeff(j)+1., vals[i].coeff(j)+1., tol);

--- a/packages/stokhos/test/UnitTest/Stokhos_TpetraCrsMatrixMPVectorUnitTest.hpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_TpetraCrsMatrixMPVectorUnitTest.hpp
@@ -1477,9 +1477,10 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
   const GlobalOrdinal mynrow = (rank==0 ? nrow: 0);
   RCP<const Tpetra_Map> map = rcp (new Tpetra_Map (nrow, mynrow, 0, comm));
   RCP<Tpetra_CrsGraph> graph (new Tpetra_CrsGraph (map, size_t(3), Tpetra::StaticProfile));
-  for (GlobalOrdinal i = 0; i<nrow; ++i)
+  if (rank==0)
+    for (GlobalOrdinal i = 0; i<nrow; ++i)
       for (GlobalOrdinal j = 0; j<i+1; ++j)
-          graph->insertGlobalIndices(i, tuple<GlobalOrdinal> (j));
+        graph->insertGlobalIndices(i, tuple<GlobalOrdinal> (j));
   graph->fillComplete();
   
   RCP<Tpetra_CrsMatrix> matrix = rcp(new Tpetra_CrsMatrix(graph));
@@ -1491,21 +1492,23 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
   // Fill RHS vector
   RCP<Tpetra_Vector> b = Tpetra::createVector<Scalar>(map);
 
-  Scalar b_value = (Scalar) 0;
-  b_value[0] = 1.;
+  if (rank==0) {
+    Scalar b_value = (Scalar) 0;
+    b_value[0] = 1.;
 
-  b->sumIntoGlobalValue(0,b_value);
+    b->sumIntoGlobalValue(0,b_value);
 
-  b_value = (Scalar) 1;
-  b_value[1] = 0.;
-  b_value[2] = 0.;
+    b_value = (Scalar) 1;
+    b_value[1] = 0.;
+    b_value[2] = 0.;
 
-  b->sumIntoGlobalValue(1,b_value);
+    b->sumIntoGlobalValue(1,b_value);
 
-  b_value = (Scalar) 2;
-  b_value[2] = 0.;
+    b_value = (Scalar) 2;
+    b_value[2] = 0.;
 
-  b->sumIntoGlobalValue(2,b_value);
+    b->sumIntoGlobalValue(2,b_value);
+  }
 
   // Solve
   typedef Teuchos::ScalarTraits<BaseScalar> ST;
@@ -1555,7 +1558,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
     out << std::endl;
 
     std::vector<int> expected_ensemble_iterations(VectorSize);
-    for (LocalOrdinal j=0; j<VectorSize; ++j){
+    for (LocalOrdinal j=0; j<VectorSize; ++j) {
       if (j==0)
         expected_ensemble_iterations[j]= 3;
       else if(j==1)
@@ -1579,8 +1582,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
     // Set values in matrix
     Array<Scalar> vals(nrow);
     Scalar val;
-    for (GlobalOrdinal i=0; i<nrow; ++i){
-      for (LocalOrdinal j=0; j<VectorSize; ++j){
+    for (GlobalOrdinal i=0; i<nrow; ++i) {
+      for (LocalOrdinal j=0; j<VectorSize; ++j) {
         if (i==0 && j==0)
           val.fastAccessCoeff(j) = 1;
         else if (i==0)
@@ -1602,7 +1605,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
     tol = 10*tol;
     ArrayRCP<Scalar> x_view = x->get1dViewNonConst();
     for (GlobalOrdinal i=0; i<nrow; ++i)
-      for (LocalOrdinal j=0; j<VectorSize; ++j){
+      for (LocalOrdinal j=0; j<VectorSize; ++j) {
         // 1. is added both to x and vals to prevent issues with relative tolerances and values close to 0.
         TEST_FLOATING_EQUALITY(x_view[i].coeff(j)+1., vals[i].coeff(j)+1., tol);
       }
@@ -1643,9 +1646,10 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
   const GlobalOrdinal mynrow = (rank==0 ? nrow: 0);
   RCP<const Tpetra_Map> map = rcp (new Tpetra_Map (nrow, mynrow, 0, comm));
   RCP<Tpetra_CrsGraph> graph (new Tpetra_CrsGraph (map, size_t(3), Tpetra::StaticProfile));
-  for (GlobalOrdinal i = 0; i<nrow; ++i)
+  if (rank==0)
+    for (GlobalOrdinal i = 0; i<nrow; ++i)
       for (GlobalOrdinal j = 0; j<i+1; ++j)
-          graph->insertGlobalIndices(i, tuple<GlobalOrdinal> (j));
+        graph->insertGlobalIndices(i, tuple<GlobalOrdinal> (j));
   graph->fillComplete();
   
   RCP<Tpetra_CrsMatrix> matrix = rcp(new Tpetra_CrsMatrix(graph));
@@ -1657,21 +1661,23 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
   // Fill RHS vector
   RCP<Tpetra_Vector> b = Tpetra::createVector<Scalar>(map);
 
-  Scalar b_value = (Scalar) 0;
-  b_value[0] = 1.;
+  if (rank==0) {
+    Scalar b_value = (Scalar) 0;
+    b_value[0] = 1.;
 
-  b->sumIntoGlobalValue(0,b_value);
+    b->sumIntoGlobalValue(0,b_value);
 
-  b_value = (Scalar) 1;
-  b_value[1] = 0.;
-  b_value[2] = 0.;
+    b_value = (Scalar) 1;
+    b_value[1] = 0.;
+    b_value[2] = 0.;
 
-  b->sumIntoGlobalValue(1,b_value);
+    b->sumIntoGlobalValue(1,b_value);
 
-  b_value = (Scalar) 2;
-  b_value[2] = 0.;
+    b_value = (Scalar) 2;
+    b_value[2] = 0.;
 
-  b->sumIntoGlobalValue(2,b_value);
+    b->sumIntoGlobalValue(2,b_value);
+  }
 
   // Solve
   typedef Teuchos::ScalarTraits<BaseScalar> ST;
@@ -1721,7 +1727,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
     out << std::endl;
 
     std::vector<int> expected_ensemble_iterations(VectorSize);
-    for (LocalOrdinal j=0; j<VectorSize; ++j){
+    for (LocalOrdinal j=0; j<VectorSize; ++j) {
       if (j==0)
         expected_ensemble_iterations[j]= 3;
       else if(j==1)
@@ -1745,8 +1751,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
     // Set values in matrix
     Array<Scalar> vals(nrow);
     Scalar val;
-    for (GlobalOrdinal i=0; i<nrow; ++i){
-      for (LocalOrdinal j=0; j<VectorSize; ++j){
+    for (GlobalOrdinal i=0; i<nrow; ++i) {
+      for (LocalOrdinal j=0; j<VectorSize; ++j) {
         if (i==0 && j==0)
           val.fastAccessCoeff(j) = 1;
         else if (i==0)
@@ -1768,7 +1774,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
     tol = 10*tol;
     ArrayRCP<Scalar> x_view = x->get1dViewNonConst();
     for (GlobalOrdinal i=0; i<nrow; ++i)
-      for (LocalOrdinal j=0; j<VectorSize; ++j){
+      for (LocalOrdinal j=0; j<VectorSize; ++j) {
         // 1. is added both to x and vals to prevent issues with relative tolerances and values close to 0.
         TEST_FLOATING_EQUALITY(x_view[i].coeff(j)+1., vals[i].coeff(j)+1., tol);
       }
@@ -1809,9 +1815,10 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
   const GlobalOrdinal mynrow = (rank==0 ? nrow: 0);
   RCP<const Tpetra_Map> map = rcp (new Tpetra_Map (nrow, mynrow, 0, comm));
   RCP<Tpetra_CrsGraph> graph (new Tpetra_CrsGraph (map, size_t(3), Tpetra::StaticProfile));
-  for (GlobalOrdinal i = 0; i<nrow; ++i)
+  if (rank==0)
+    for (GlobalOrdinal i = 0; i<nrow; ++i)
       for (GlobalOrdinal j = 0; j<i+1; ++j)
-          graph->insertGlobalIndices(i, tuple<GlobalOrdinal> (j));
+        graph->insertGlobalIndices(i, tuple<GlobalOrdinal> (j));
   graph->fillComplete();
   
   RCP<Tpetra_CrsMatrix> matrix = rcp(new Tpetra_CrsMatrix(graph));
@@ -1823,21 +1830,23 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
   // Fill RHS vector
   RCP<Tpetra_Vector> b = Tpetra::createVector<Scalar>(map);
 
-  Scalar b_value = (Scalar) 0;
-  b_value[0] = 1.;
+  if (rank==0) {
+    Scalar b_value = (Scalar) 0;
+    b_value[0] = 1.;
 
-  b->sumIntoGlobalValue(0,b_value);
+    b->sumIntoGlobalValue(0,b_value);
 
-  b_value = (Scalar) 1;
-  b_value[1] = 0.;
-  b_value[2] = 0.;
+    b_value = (Scalar) 1;
+    b_value[1] = 0.;
+    b_value[2] = 0.;
 
-  b->sumIntoGlobalValue(1,b_value);
+    b->sumIntoGlobalValue(1,b_value);
 
-  b_value = (Scalar) 2;
-  b_value[2] = 0.;
+    b_value = (Scalar) 2;
+    b_value[2] = 0.;
 
-  b->sumIntoGlobalValue(2,b_value);
+    b->sumIntoGlobalValue(2,b_value);
+  }
 
   // Solve
   typedef Teuchos::ScalarTraits<BaseScalar> ST;
@@ -1887,7 +1896,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
     out << std::endl;
 
     std::vector<int> expected_ensemble_iterations(VectorSize);
-    for (LocalOrdinal j=0; j<VectorSize; ++j){
+    for (LocalOrdinal j=0; j<VectorSize; ++j) {
       if (j==0)
         expected_ensemble_iterations[j]= 3;
       else if(j==1)
@@ -1911,8 +1920,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
     // Set values in matrix
     Array<Scalar> vals(nrow);
     Scalar val;
-    for (GlobalOrdinal i=0; i<nrow; ++i){
-      for (LocalOrdinal j=0; j<VectorSize; ++j){
+    for (GlobalOrdinal i=0; i<nrow; ++i) {
+      for (LocalOrdinal j=0; j<VectorSize; ++j) {
         if (i==0 && j==0)
           val.fastAccessCoeff(j) = 1;
         else if (i==0)
@@ -1934,7 +1943,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(
     tol = 10*tol;
     ArrayRCP<Scalar> x_view = x->get1dViewNonConst();
     for (GlobalOrdinal i=0; i<nrow; ++i)
-      for (LocalOrdinal j=0; j<VectorSize; ++j){
+      for (LocalOrdinal j=0; j<VectorSize; ++j) {
         // 1. is added both to x and vals to prevent issues with relative tolerances and values close to 0.
         TEST_FLOATING_EQUALITY(x_view[i].coeff(j)+1., vals[i].coeff(j)+1., tol);
       }


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/stokhos

## Motivation
<!---
Why is this change required?  What problem does it solve? Please link to a github
issue that describes the problem/issue/bug this PR solves.
-->

The motivation behind this PR is to add partial template specializations of Belos classes for ensemble types to implement the ensemble GMRES without the ensemble reduction.
This implementation takes care of the occurrences of the control-flow divergence in the ensemble GMRES without ensemble reduction.
For instance, different samples of a same ensemble can face lucky breakdown at different iterations of the GMRES without generating NaN.

This PR includes a template specialization of the GEMM fallback function of Kokkoskernels for ensemble types in order to use the GEMV if applicable.
This has three reasons:
- A GEMM implementation is typically less optimal than a GEMV implementation when applicable. In the case of the GEMV, we cannot reuse data from the matrix as it is the case for the GEMM.
- The fallback implementation of the GEMM in Kokkoskernels seems not to be correct while evaluating GEMV computation with small matrix and ensemble of size 16.
- I have implemented an efficient GEMV for ensemble types which will come in a later PR.

A following PR will include the implementation of the ensemble GEMV for efficient evaluation of the orthogonalization process with DGKS and ICGS.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes
* Blocks
* Is blocked by
* Follows
* Precedes
* Related to
* Part of
* Composed of
-->


## Stakeholder Feedback
<!---
If a github issue includes feedback from the relevant stakeholder(s), please link it.
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

This branch has been tested on the Blake system.

<!---
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
