### PR TITLE
Testing/Framework: Add jsrun wrapper

### DIFF
--- a/cmake/std/atdm/ats2/trilinos_jsrun
+++ b/cmake/std/atdm/ats2/trilinos_jsrun
@@ -13,6 +13,11 @@ function debug_print {
   fi
 }
 
+if [[ "$TPETRA_ASSUME_CUDA_AWARE_MPI" != "0" ]] && [[ "$TPETRA_ASSUME_CUDA_AWARE_MPI" != "1" ]]; then
+  echo "WARNING, you have not set TPETRA_ASSUME_CUDA_AWARE_MPI=0 or 1, defaulting to TPETRA_ASSUME_CUDA_AWARE_MPI=0"
+  export TPETRA_ASSUME_CUDA_AWARE=0
+fi
+
 for i in "${!args[@]}";
 do
   arg=${args[${i}]}
@@ -68,7 +73,7 @@ if [ "$np_is_one" == "true" ]; then
       debug_print "arg=$arg, found -M, prepending -disable_gpu_hooks"
       ip1=$(($i+1));
       # single quotes matter, as the argument to -M needs to be all args originally quoted to it
-      args[${ip1}]="'-disable_gpu_hooks ${args[${ip1}]}'"
+      args[${ip1}]="-disable_gpu_hooks ${args[${ip1}]}"
       debug_print "updated arg = ${args[${ip1}]}"
       added_disable="true"
       break
@@ -97,7 +102,7 @@ if [[ "$TPETRA_ASSUME_CUDA_AWARE_MPI" == "1" ]] && [[ "$np_is_one" == "false" ]]
       debug_print "arg=$arg, found -M, prepending -gpu"
       ip1=$(($i+1));
       # single quotes matter, as the argument to -M needs to be all args originally quoted to it
-      args[${ip1}]="'-gpu ${args[${ip1}]}'"
+      args[${ip1}]="-gpu ${args[${ip1}]}"
       added_arg="true"
       break
     fi
@@ -112,8 +117,8 @@ if [[ "$TPETRA_ASSUME_CUDA_AWARE_MPI" == "1" ]] && [[ "$np_is_one" == "false" ]]
 fi
 
 if [ "$ECHO_CMD" == "1" ]; then
-  1>&2 echo "TPETRA_ASSUME_CUDA_AWARE=${TPETRA_ASSUME_CUDA_AWARE_MPI} BEFORE: jsrun ${orig_args[@]}"
-  1>&2 echo "TPETRA_ASSUME_CUDA_AWARE=${TPETRA_ASSUME_CUDA_AWARE_MPI} AFTER : jsrun ${args[@]}"
+  1>&2 echo "TPETRA_ASSUME_CUDA_AWARE_MPI=${TPETRA_ASSUME_CUDA_AWARE_MPI} BEFORE: jsrun " $(printf "'%s' " "${orig_args[@]}")
+  1>&2 echo "TPETRA_ASSUME_CUDA_AWARE_MPI=${TPETRA_ASSUME_CUDA_AWARE_MPI} AFTER : jsrun " $(printf "'%s' " "${args[@]}")
 fi
-eval jsrun ${args[@]}
+eval jsrun $(printf "'%s' " "${args[@]}")
 

--- a/cmake/std/atdm/ats2/trilinos_jsrun
+++ b/cmake/std/atdm/ats2/trilinos_jsrun
@@ -1,0 +1,119 @@
+#!/bin/bash
+
+DEBUG_SCRIPT="${DEBUG_SCRIPT-:0}"
+ECHO_CMD="${ECHO_CMD=:0}"
+np_is_one="false"
+orig_args=("$@")
+args=("$@")
+
+function debug_print {
+  if [ "$DEBUG_SCRIPT" == "1" ]; then
+    msg="$@"
+    1>&2 echo "$msg"
+  fi
+}
+
+for i in "${!args[@]}";
+do
+  arg=${args[${i}]}
+
+  debug_print "Processing arg=$arg"
+
+  # handle the case of seeing the np argument
+  # lets assume -p ## or --np=##
+  if [[ "$arg" =~ ^-p[0-9]+$ ]]; then
+    # np is just the 2nd arg split on 'p'
+    my_np=$(echo "$arg" | cut -f2 -d'p');
+    debug_print "  Case: -p##, with ##=$my_np"
+    if [ "$my_np" == "1" ]; then
+      np_is_one="true";
+      debug_print "  Case: -p##, with ##=$my_np and np=1"
+    fi
+    # we are finished
+    break;
+  # next, -p ##
+  elif [ "$arg" == "-p" ]; then
+    ip1=$(($i+1));
+    my_np=${args[${ip1}]}
+    debug_print "  Case: -p ##, with ##=$my_np"
+    if [ "$my_np" == "1" ]; then
+      np_is_one="true";
+      debug_print "  Case: -p ##, with ##=$my_np and np=1"
+    fi
+    # we are finished
+    break;
+  # next, --np=##
+  elif [[ "$arg" =~ ^--np=[0-9]+$ ]]; then
+    # np is just the 2nd arg split on '='
+    my_np=$(echo "$arg" | cut -f2 -d'=');
+    debug_print "  Case: --np=##, with ##=$my_np"
+    if [ "$my_np" == "1" ]; then
+      np_is_one="true";
+      debug_print "  Case: --np=##, with ##=$my_np and np=1"
+    fi
+    # we are finished
+    break;
+  fi
+done
+
+if [ "$np_is_one" == "true" ]; then
+  added_disable="false"
+  debug_print "NP=1 adding disable_gpu_hooks"
+  # look for an '-M' arg and append disable hooks to the next argument
+  for i in "${!args[@]}";
+  do
+    arg=${args[${i}]}
+    debug_print "arg=$arg"
+    if [ "$arg" == "-M" ]; then
+      debug_print "arg=$arg, found -M, prepending -disable_gpu_hooks"
+      ip1=$(($i+1));
+      # single quotes matter, as the argument to -M needs to be all args originally quoted to it
+      args[${ip1}]="'-disable_gpu_hooks ${args[${ip1}]}'"
+      debug_print "updated arg = ${args[${ip1}]}"
+      added_disable="true"
+      break
+    fi
+  done
+
+  # did not find -M, so we add it
+  if [ "$added_disable" == "false" ]; then
+    debug_print "NP=1, but we didn't find a -M argument, so adding -M and disabling the gpu_hooks"
+    # prepend the argument
+    args=("-M -disable_gpu_hooks" "${args[@]}")
+  fi
+fi
+
+# I think if np=1 and disable_gpu_hooks is passed, then you aren't supposed to use -gpu
+if [[ "$TPETRA_ASSUME_CUDA_AWARE_MPI" == "1" ]] && [[ "$np_is_one" == "false" ]]; then
+  debug_print "TPETRA_ASSUME_CUDA_AWARE_MPI=1 and np>1, adding -M -gpu"
+  added_arg="false"
+
+  # look for an '-M' arg and prepend an arg (this could be a function)
+  for i in "${!args[@]}";
+  do
+    arg=${args[${i}]}
+    debug_print "arg=$arg"
+    if [ "$arg" == "-M" ]; then
+      debug_print "arg=$arg, found -M, prepending -gpu"
+      ip1=$(($i+1));
+      # single quotes matter, as the argument to -M needs to be all args originally quoted to it
+      args[${ip1}]="'-gpu ${args[${ip1}]}'"
+      added_arg="true"
+      break
+    fi
+  done
+
+  # did not find -M, so we add it
+  if [ "$added_arg" == "false" ]; then
+    debug_print "Didn't find a -M argument, so adding -M and -gpu"
+    # prepend the argument
+    args=("-M -gpu" "${args[@]}")
+  fi
+fi
+
+if [ "$ECHO_CMD" == "1" ]; then
+  1>&2 echo "TPETRA_ASSUME_CUDA_AWARE=${TPETRA_ASSUME_CUDA_AWARE_MPI} BEFORE: jsrun ${orig_args[@]}"
+  1>&2 echo "TPETRA_ASSUME_CUDA_AWARE=${TPETRA_ASSUME_CUDA_AWARE_MPI} AFTER : jsrun ${args[@]}"
+fi
+eval jsrun ${args[@]}
+

--- a/cmake/std/atdm/ats2/trilinos_jsrun_test_me.sh
+++ b/cmake/std/atdm/ats2/trilinos_jsrun_test_me.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+echo "testing with cuda-aware turned off!, should not see -gpu, look for -disable_gpu_hooks"
+ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI=0 ./trilinos_jsrun -M -disable_gdr -p 2 hostname 1>/dev/null
+ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI=0 ./trilinos_jsrun -M -disable_gdr -p 1 hostname 1>/dev/null
+ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI=0 ./trilinos_jsrun -M -disable_gdr -p 1 hostname 1>/dev/null
+
+echo "testing with cuda-aware turned ON!, should see -gpu if NP>1 and  -disable_gpu_hooks when NP=1"
+ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI=1 ./trilinos_jsrun -M -disable_gdr -p 2 hostname 1>/dev/null
+ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI=1 ./trilinos_jsrun -M -disable_gdr -p 1 hostname 1>/dev/null
+ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI=1 ./trilinos_jsrun -M -disable_gdr -p 1 hostname 1>/dev/null

--- a/cmake/std/atdm/ats2/trilinos_jsrun_test_me.sh
+++ b/cmake/std/atdm/ats2/trilinos_jsrun_test_me.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+echo "testing with cuda-aware unset!, should not see -gpu, look for -disable_gpu_hooks"
+ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI="" ./trilinos_jsrun -M -disable_gdr -p 2 hostname 1>/dev/null
+ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI="" ./trilinos_jsrun -M -disable_gdr -p 1 hostname 1>/dev/null
+ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI="" ./trilinos_jsrun -M -disable_gdr -p 1 hostname 1>/dev/null
+
 echo "testing with cuda-aware turned off!, should not see -gpu, look for -disable_gpu_hooks"
 ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI=0 ./trilinos_jsrun -M -disable_gdr -p 2 hostname 1>/dev/null
 ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI=0 ./trilinos_jsrun -M -disable_gdr -p 1 hostname 1>/dev/null
@@ -9,3 +14,18 @@ echo "testing with cuda-aware turned ON!, should see -gpu if NP>1 and  -disable_
 ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI=1 ./trilinos_jsrun -M -disable_gdr -p 2 hostname 1>/dev/null
 ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI=1 ./trilinos_jsrun -M -disable_gdr -p 1 hostname 1>/dev/null
 ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI=1 ./trilinos_jsrun -M -disable_gdr -p 1 hostname 1>/dev/null
+
+echo "testing with cuda-aware unset!, should not see -gpu, look for -disable_gpu_hooks"
+ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI="" ./trilinos_jsrun  -p 2 hostname 1>/dev/null
+ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI="" ./trilinos_jsrun  -p 1 hostname 1>/dev/null
+ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI="" ./trilinos_jsrun  -p 1 hostname 1>/dev/null
+
+echo "testing with cuda-aware turned off!, should not see -gpu, look for -disable_gpu_hooks"
+ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI=0 ./trilinos_jsrun  -p 2 hostname 1>/dev/null
+ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI=0 ./trilinos_jsrun  -p 1 hostname 1>/dev/null
+ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI=0 ./trilinos_jsrun  -p 1 hostname 1>/dev/null
+
+echo "testing with cuda-aware turned ON!, should see -gpu if NP>1 and  -disable_gpu_hooks when NP=1"
+ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI=1 ./trilinos_jsrun  -p 2 hostname 1>/dev/null
+ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI=1 ./trilinos_jsrun  -p 1 hostname 1>/dev/null
+ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI=1 ./trilinos_jsrun  -p 1 hostname 1>/dev/null


### PR DESCRIPTION
The short is that -disable_gpu_hooks is something that needs to be applied to single process runs (by default spectrum loads a shared library that hooks all kinds of things, but those hooks depend on MPI_Init being called to initialize things).

The goal of this effort, which probably should be moved to a specific issue, is that Trilinos needs to have atleast two code paths tested:

Tpetra w/cuda-aware, which requires -M -gpu, and
Tpetra w/out cuda-aware which requires not having -M -gpu (I've yet to hear what the flag is to specifically disable GPU aware MPI (there is only an option to enable it).
All of the above are runtime options. When you invoke jsrun without -M -gpu, you are getting an entirely different implementation of MPI.

The wrapper I've proposed would enable Trilinos to configure with a fake jsrun that magically handles the -M -gpu flag based on whether Tptera's cuda-aware ENV is set to 0 or 1. Also, the wrapper automatically disables the GPU hooks if the process is not MPI-parallel.

I played the game of Vortex unit testing over the summer of 2019. I seem to remember that I was able to get most tests passing, but it required substantial find/replace on the generated ctest files.

To test vortex with both cuda-aware and regular MPI, the testing harness will need to do something like:

configure w/wrapped jsrun (via ATDM ENV's)
build once
set TPETRA_ASSUME_CUDA_AWARE_MPI=0 (do the regular MPI case)
invoke ctest
post the results to a dashboard
do something to change the 'build_id' of the ctest file. e.g.,
Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-2019.06.24_static_dbg
to
Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-2019.06.24_cuda-aware_static_dbg
set TPETRA_ASSUME_CUDA_AWARE_MPI=1
reset ctest (clear all pass/fail stuff)
invoke ctest
post the results to a dashboard, they will get attributed to the modified build_id mentioned in (6)
I'll need to add the logic to set -M -gpu to the wrapped jsrun, and the testing harness will need to figure out how to do 6-10.

It's worth noting, this same testing workflow could be implemented on White/Ride/Waterman. On those machines the MPI impl is effectively running with the openMPI variant of -M -gpu. So on those machines mpirun would need to be wrapped to disable cuda-aware MPI.

There is a 'test', but it relies on manual inspection
`Trilinos/cmake/std/atdm/ats2/trilinos_jsrun_test.sh`

@e10harvey 
Please mark this with appropriate labels.