### PR TITLE
Promoting ats2+gnu+opt build which is 100% clean (CDOFA-27)

### DIFF
--- a/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-gnu-7.3.1-spmpi-2019.06.24_serial_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-gnu-7.3.1-spmpi-2019.06.24_serial_static_opt.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=Experimental
+  export Trilinos_TRACK=ATDM
 fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ats2/local-driver.sh


### PR DESCRIPTION
This build has been 100% clean last 3 days.

See [this query](https://testing-dev.sandia.gov/cdash/index.php?project=Trilinos&begin=2020-01-26&end=2020-02-03&filtercount=1&showfilters=1&field1=buildname&compare1=61&value1=Trilinos-atdm-ats2-gnu-7.3.1-spmpi-2019.06.24_serial_static_opt).
