### PR TITLE
ATDM ATS-2 cleanup and promote some builds to 'Specialized' (CDOFA-72)

### DIFF
--- a/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-2019.06.24_static_dbg.sh
+++ b/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-2019.06.24_static_dbg.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=Experimental
+  export Trilinos_TRACK=Specialized
 fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ats2/local-driver.sh

--- a/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-gnu-7.3.1-spmpi-2019.06.24_serial_static_dbg.sh
+++ b/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-gnu-7.3.1-spmpi-2019.06.24_serial_static_dbg.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=Experimental
+  export Trilinos_TRACK=Specialized
 fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ats2/local-driver.sh

--- a/cmake/std/atdm/ats2/tweaks/Tweaks.cmake
+++ b/cmake/std/atdm/ats2/tweaks/Tweaks.cmake
@@ -4,6 +4,9 @@
 
 IF (Trilinos_ENABLE_DEBUG)
 
+  # STEQR() test fails on IBM Power systems with current TPL setup (#2410, #6166)
+  ATDM_SET_ENABLE(TeuchosNumerics_DISABLE_STEQR_TEST ON)
+
   # Disable Tempus tests that started timing out in debug builds when
   # Trilinos_ENABLE_DEBUG=ON was set PR #5970 (#6009)
   ATDM_SET_ENABLE(Tempus_BackwardEuler_MPI_1_DISABLE ON)

--- a/cmake/std/atdm/ats2/tweaks/Tweaks.cmake
+++ b/cmake/std/atdm/ats2/tweaks/Tweaks.cmake
@@ -1,0 +1,18 @@
+#
+# Disables across multiple builds on 'ats2'
+#
+
+IF (Trilinos_ENABLE_DEBUG)
+
+  # Disable Tempus tests that started timing out in debug builds when
+  # Trilinos_ENABLE_DEBUG=ON was set PR #5970 (#6009)
+  ATDM_SET_ENABLE(Tempus_BackwardEuler_MPI_1_DISABLE ON)
+  ATDM_SET_ENABLE(Tempus_DIRK_ASA_MPI_1_DISABLE ON)
+  ATDM_SET_ENABLE(Tempus_ExplicitRK_ASA_MPI_1_DISABLE ON)
+  ATDM_SET_ENABLE(Tempus_HHTAlpha_MPI_1_DISABLE ON)
+  ATDM_SET_ENABLE(Tempus_IMEX_RK_Combined_FSA_MPI_1_DISABLE ON)
+  ATDM_SET_ENABLE(Tempus_IMEX_RK_Partitioned_Staggered_FSA_Partitioned_IMEX_RK_1st_Order_MPI_1_DISABLE ON)
+  ATDM_SET_ENABLE(Tempus_IMEX_RK_Staggered_FSA_MPI_1_DISABLE ON)
+  ATDM_SET_ENABLE(Tempus_Newmark_MPI_1_DISABLE ON)
+
+ENDIF()

--- a/cmake/std/atdm/ats2/tweaks/Tweaks.cmake
+++ b/cmake/std/atdm/ats2/tweaks/Tweaks.cmake
@@ -15,4 +15,8 @@ IF (Trilinos_ENABLE_DEBUG)
   ATDM_SET_ENABLE(Tempus_IMEX_RK_Staggered_FSA_MPI_1_DISABLE ON)
   ATDM_SET_ENABLE(Tempus_Newmark_MPI_1_DISABLE ON)
 
+  # Disble some timing out ROL tests (#6124)
+  ATDM_SET_ENABLE(ROL_example_PDE-OPT_helmholtz_example_02_MPI_1_DISABLE ON)
+  ATDM_SET_ENABLE(ROL_example_PDE-OPT_navier-stokes_example_01_MPI_4_DISABLE ON)
+
 ENDIF()


### PR DESCRIPTION
This is just part of the process to get these builds cleaned up and promoted so that we can maintain them.

See the individual commits for details.
