### PR TITLE
ATDM mutrino: switch from camke 3.11.4 to 3.14.6

### DIFF
--- a/cmake/std/atdm/mutrino/environment.sh
+++ b/cmake/std/atdm/mutrino/environment.sh
@@ -72,7 +72,7 @@ fi
 # Load the modules (can't purge)
 module load devpack/20180124/cray/7.6.2/intel/17.0.4
 module load gcc/4.9.3
-module load cmake/3.9.0
+module load cmake/3.14.6
 
 # No RPATH for static builds
 export ATDM_CONFIG_CMAKE_SKIP_INSTALL_RPATH=ON
@@ -80,7 +80,7 @@ export ATDM_CONFIG_CMAKE_SKIP_INSTALL_RPATH=ON
 
 # Use manually installed cmake and ninja to allow usage of ninja and
 # all-at-once mode
-export PATH=/projects/netpub/atdm/cmake-3.11.4/bin:/projects/netpub/atdm/ninja-1.8.2/bin:$PATH
+export PATH=/projects/netpub/atdm/ninja-1.8.2/bin:$PATH
 
 # Set MPI wrappers
 export MPICXX=`which CC`


### PR DESCRIPTION
This was requested by EMPIRE developer Nicole Lemaster Slattengren.
## How was this tested?

On 'mutrino', I did:

```
$ cd /lscratch1/rabartl/MUTRINO/Trilinos.base/BUILDS/CTEST_S/

$  env Trilinos_PACKAGES=Kokkos ./ctest-s-local-test-driver.sh intel-opt-openmp-HSW
```

The file

* Trilinos-atdm-mutrino-intel-opt-openmp-HSW/smart-jenkins-driver.out

showed:

```
Currently Loaded Modulefiles:
...
 33) cmake/3.14.6

cmake in path:
/usr/projects/hpcsoft/cle6.0/common/cmake/3.14.6/bin/cmake

ninja in path:
/projects/netpub/atdm/ninja-1.8.2/bin/ninja
```

That posted to CDash:

* [](https://testing-dev.sandia.gov/cdash/index.php?project=Trilinos&parentid=5215660) (passed=???)

and the [configure output](https://testing-dev.sandia.gov/cdash/viewConfigure.php?buildid=5215660) showed:

```
-- CMAKE_VERSION='3.14.6'
```

Good enough for me.

