### PR TITLE
ATDM: More cleanup after Kokkos 2.99 upgrade

### DIFF
--- a/cmake/std/atdm/ATDMDisables.cmake
+++ b/cmake/std/atdm/ATDMDisables.cmake
@@ -248,19 +248,29 @@ ATDM_SET_ENABLE(Piro_AnalysisDriverTpetra_MPI_4_DISABLE ON)
 ATDM_SET_ENABLE(ROL_adapters_tpetra_test_vector_SimulatedVectorTpetraBatchManagerInterface_EXE_DISABLE ON)
 ATDM_SET_ENABLE(ROL_adapters_tpetra_test_vector_SimulatedVectorTpetraBatchManagerInterface_MPI_4_DISABLE ON)
 
-# Disable ctest DISABLED test (otherwise, this shows up on CDash as "NotRun")
-ATDM_SET_ENABLE(KokkosContainers_PerformanceTest_OpenMP_DISABLE ON)
+IF (ATDM_NODE_TYPE STREQUAL "OPENMP")
+
+  # Disable ctest DISABLED test (otherwise, this shows up on CDash as "NotRun")
+  ATDM_SET_ENABLE(KokkosContainers_PerformanceTest_OpenMP_DISABLE ON)
+
+ENDIF()
 
 IF ("${ATDM_CMAKE_BUILD_TYPE}" STREQUAL "DEBUG")
 
-  # Too expensive for full debug builds after Kokkos 2.99 upgrade
-  ATDM_SET_ENABLE(KokkosCore_UnitTest_Serial_MPI_1_DISABLE ON)
-  ATDM_SET_ENABLE(KokkosCore_UnitTest_OpenMP_MPI_1_DISABLE ON)
-  ATDM_SET_ENABLE(KokkosKernels_blas_openmp_MPI_1_DISABLE ON)
-  ATDM_SET_ENABLE(KokkosKernels_blas_serial_MPI_1_DISABLE ON)
-
   ATDM_SET_ENABLE(PanzerAdaptersSTK_CurlLaplacianExample-ConvTest-Quad-Order-4_DISABLE ON)
   ATDM_SET_ENABLE(PanzerAdaptersSTK_MixedPoissonExample-ConvTest-Hex-Order-3_DISABLE ON)
+
+  # Too expensive for full debug builds after Kokkos 2.99 upgrade
+  ATDM_SET_ENABLE(KokkosCore_UnitTest_Serial_MPI_1_DISABLE ON)
+  ATDM_SET_ENABLE(KokkosKernels_blas_serial_MPI_1_DISABLE ON)
+
+  IF (ATDM_USE_OPENMP)
+
+    # Too expensive for full debug builds after Kokkos 2.99 upgrade
+    ATDM_SET_ENABLE(KokkosCore_UnitTest_OpenMP_MPI_1_DISABLE ON)
+    ATDM_SET_ENABLE(KokkosKernels_blas_openmp_MPI_1_DISABLE ON)
+
+  ENDIF()
 
 ENDIF()
 
@@ -290,5 +300,8 @@ IF (ATDM_NODE_TYPE STREQUAL "CUDA")
   ATDM_SET_ENABLE(Zoltan_ch_grid20x19_zoltan_parallel_DISABLE ON)
   ATDM_SET_ENABLE(Zoltan_ch_nograph_zoltan_parallel_DISABLE ON)
   ATDM_SET_ENABLE(Zoltan_ch_simple_zoltan_parallel_DISABLE ON)
+
+  # Disable ctest DISABLED test (otherwise, this shows up on CDash as "NotRun")
+  ATDM_SET_ENABLE(KokkosContainers_PerformanceTest_Cuda_DISABLE ON)
 
 ENDIF()


### PR DESCRIPTION
* Disable ctest DISABLED test KokkosContainers_PerformanceTest_Cuda: This just
  clutters up CDash and our CDash summary emails.

* Only disable OpenMP tests in OpenMP builds

## How was this tested?

On RHEL6 I ran:

```
$ ./checkin-test-atdm.sh gnu-openmp-dbg --enable-packages=Kokkos,KokkosKernels --configure
```

which showed:

```
$ grep "NOT added" configure.out  | grep DISABLE
-- KokkosCore_UnitTest_Serial_MPI_1: NOT added test because KokkosCore_UnitTest_Serial_MPI_1_DISABLE='ON'!
-- KokkosCore_UnitTest_OpenMP_MPI_1: NOT added test because KokkosCore_UnitTest_OpenMP_MPI_1_DISABLE='ON'!
-- KokkosContainers_PerformanceTest_OpenMP: NOT added test because KokkosContainers_PerformanceTest_OpenMP_DISABLE='ON'!
-- KokkosKernels_blas_openmp_MPI_1: NOT added test because KokkosKernels_blas_openmp_MPI_1_DISABLE='ON'!
-- KokkosKernels_blas_serial_MPI_1: NOT added test because KokkosKernels_blas_serial_MPI_1_DISABLE='ON'!
[rabartl@crf450 gnu-openmp-dbg (crf450)]$ 
```

On 'waterman' I ran:

```
$ ./checkin-test-atdm.sh cuda-dbg --enable-packages=Kokkos,KokkosKernels --configure
```

which showed:

```
$ grep "NOT added" configure.out  | grep DISABLE
-- KokkosCore_UnitTest_Serial_MPI_1: NOT added test because KokkosCore_UnitTest_Serial_MPI_1_DISABLE='ON'!
-- KokkosContainers_PerformanceTest_Cuda: NOT added test because KokkosContainers_PerformanceTest_Cuda_DISABLE='ON'!
-- KokkosKernels_blas_serial_MPI_1: NOT added test because KokkosKernels_blas_serial_MPI_1_DISABLE='ON'!
```



