### PR TITLE
tpetra: Add sync check in MV packAndPrepare

### DIFF
--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -1362,9 +1362,25 @@ namespace Tpetra {
     // Resizing currently requires calling the constructor, which
     // clears out the 'modified' flags.
     if (packOnHost) {
+      // nde 06 Feb 2020: If 'exports' does not require resize
+      // when reallocDualViewIfNeeded is called, the modified flags 
+      // are not cleared out. This can result in host and device views
+      // being out-of-sync, resuling in an error in exports.modify_* calls.
+      // Adding a check of the sync state, and syncing if necessary, prevents
+      // this possible case.
+      if (exports.need_sync_host ())
+        exports.sync_host ();
       exports.modify_host ();
     }
     else {
+      // nde 06 Feb 2020: If 'exports' does not require resize
+      // when reallocDualViewIfNeeded is called, the modified flags 
+      // are not cleared out. This can result in host and device views
+      // being out-of-sync, resuling in an error in exports.modify_* calls.
+      // Adding a check of the sync state, and syncing if necessary, prevents
+      // this possible case.
+      if (exports.need_sync_device ())
+        exports.sync_device ();
       exports.modify_device ();
     }
 

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -1366,10 +1366,8 @@ namespace Tpetra {
       // when reallocDualViewIfNeeded is called, the modified flags 
       // are not cleared out. This can result in host and device views
       // being out-of-sync, resuling in an error in exports.modify_* calls.
-      // Adding a check of the sync state, and syncing if necessary, prevents
-      // this possible case.
-      if (exports.need_sync_host ())
-        exports.sync_host ();
+      // Clearing the sync flags prevents this possible case.
+      exports.clear_sync_state ();
       exports.modify_host ();
     }
     else {
@@ -1377,10 +1375,8 @@ namespace Tpetra {
       // when reallocDualViewIfNeeded is called, the modified flags 
       // are not cleared out. This can result in host and device views
       // being out-of-sync, resuling in an error in exports.modify_* calls.
-      // Adding a check of the sync state, and syncing if necessary, prevents
-      // this possible case.
-      if (exports.need_sync_device ())
-        exports.sync_device ();
+      // Clearing the sync flags prevents this possible case.
+      exports.clear_sync_state ();
       exports.modify_device ();
     }
 


### PR DESCRIPTION
This PR adds a check for the sync state of 'exports', and synchronizes
if necessary. This prevents issues where the reallocDualViewIfNeeded
call does not result in a resize of 'exports', and thus not clearing the
modify flags before being set in anticipation of computation later in
the routine.

@trilinos/tpetra

## Motivation
Albany builds of Trilinos detected dual view errors, as reported in SNLComputation/Albany#555, following the kokkos 2.9.99 release.

These errors occurred in the `Tpetra::MultiVector::packAndPrepare` routine in cases where the `exports` variable is not resized during a call to `reallocDualViewIfNeeded` which also resulted in the modify flags not being reset. This causes problems later when setting the modify flags in preparation for computation later in the routine.

This PR add a check on the sync state of `exports` and performs a synchronization if neccessary before setting the `exports` modify flags for later computation.


## Stakeholder Feedback
Hopefully addresses SNLComputation/Albany#555

## Testing
Tested a host build using the configuration below on machine with sems modules available

```bash
module load sems-cmake/3.12.2 sems-gcc/7.2.0 sems-git sems-openmpi/4.0.2 sems-superlu/4.3 

export TRILINOS_PATH=<PATH_TO_TRILINOS>

INSTALL_LOCATION=<DESIRED_INSTALL_PATH>
 
cmake \
-D CMAKE_INSTALL_PREFIX:PATH="${INSTALL_LOCATION}" \
-D TPL_ENABLE_MPI:BOOL=ON \
-D CMAKE_CXX_COMPILER="`which mpicxx`" \
-D CMAKE_C_COMPILER="`which mpicc`" \
-D CMAKE_Fortran_COMPILER="`which mpifort`" \
-D KOKKOS_ARCH="SKX" \
  -D TPL_ENABLE_BLAS:STRING=ON \
  -D TPL_ENABLE_LAPACK:STRING=ON \
-D Trilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=OFF \
-D Trilinos_ENABLE_TESTS:BOOL=OFF \
-D Trilinos_ENABLE_EXAMPLES:BOOL=OFF \
\
  -DCMAKE_BUILD_TYPE=DEBUG \
  -DTrilinos_ENABLE_TESTS=OFF \
  -DTPL_ENABLE_SUPERLU=ON \
  -DTPL_ENABLE_Netcdf=OFF \
  -DTrilinos_ENABLE_Kokkos=ON \
    -DKokkos_ENABLE_SERIAL=ON \
    -DKokkos_ENABLE_DEBUG_DUALVIEW_MODIFY_CHECK=ON \
  -DTrilinos_ENABLE_Tpetra=ON \
    -DTpetra_ENABLE_TESTS=ON \
  -DTrilinos_ENABLE_Amesos2=ON \
  -DTrilinos_ENABLE_MueLu=ON \
    -DMueLu_ENABLE_TESTS=ON \
  -DTrilinos_ENABLE_Thyra=ON \
    -DThyra_ENABLE_TESTS=ON \
  -DTrilinos_ENABLE_Panzer=ON \
    -DPanzer_ENABLE_TESTS=ON \
${TRILINOS_PATH}
```

The key configure option to set to see the errors is
`    -DKokkos_ENABLE_DEBUG_DUALVIEW_MODIFY_CHECK=ON \`

With the changes above in this PR, test in MueLu that would fail with messages like 
`Kokkos::DualView::modify_device ERROR: Concurrent modification of host and device views in DualView "exports"` 
now pass (for example, `MueLu_UnitTestsTpetra_MPI_4`)

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->