### PR TITLE
ATDM: ats2: switch to ninja (CDOFA-72)

### DIFF
--- a/cmake/std/atdm/ats2/environment.sh
+++ b/cmake/std/atdm/ats2/environment.sh
@@ -58,8 +58,11 @@ echo "Using $ATDM_CONFIG_SYSTEM_NAME compiler stack $ATDM_CONFIG_COMPILER to bui
 
 # Some basic settings
 export ATDM_CONFIG_ENABLE_SPARC_SETTINGS=ON
-export ATDM_CONFIG_USE_NINJA=OFF
+export ATDM_CONFIG_USE_NINJA=ON
 export ATDM_CONFIG_BUILD_COUNT=8
+# ToDo: Experiment with increasing the build parallelism for different
+# compilers, different build configurations, on the login node vs. the compute
+# node, etc.
 
 # Set ctest -j parallel level for non-CUDA builds
 if [ "$ATDM_CONFIG_NODE_TYPE" == "OPENMP" ] ; then
@@ -202,6 +205,9 @@ fi
 
 # Common module - requires compiler to be loaded first
 module load spectrum-mpi/2019.06.24
+
+# Prepend path to ninja after all of the modules are loaded
+export PATH=/projects/atdm_devops/vortex/ninja-fortran-1.8.2:$PATH
 
 # ATDM specific config variables
 export ATDM_CONFIG_LAPACK_LIBS="-L${LAPACK_ROOT}/lib;-llapack;-lgfortran;-lgomp"


### PR DESCRIPTION
This was requested by Matt B. for EMPIRE.  When we support other ats2 machines
like 'lassen' and 'rzansel', we will need to install ninja there too and point
to it there too.

## How was this tested:

On 'vortex' I did:

```
$ env Trilinos_PACKAGES=Kokkos,Teuchos \
  ./ctest-s-local-test-driver.sh \
    ats2-gnu-7.3.1-spmpi-2019.06.24_serial_static_dbg

***
*** ./ctest-s-local-test-driver.sh
***

ATDM_TRILINOS_DIR = '/home/rabartl/Trilinos.base/Trilinos'

Load some env to get python, cmake, etc ...

Hostname 'vortex60' matches known ATDM host 'vortex' and system 'ats2'
Setting compiler and build options for build-name 'default'
Using ats2 compiler stack GNU-7.3.1_SPMPI-2019.06.24 to build DEBUG code with Kokkos node type SERIAL

Lmod is automatically replacing "xl/2019.12.23" with "gcc/7.3.1".


Due to MODULEPATH changes, the following have been reloaded:
  1) spectrum-mpi/rolling-release


The following have been reloaded with a version change:
  1) spectrum-mpi/rolling-release => spectrum-mpi/2019.06.24


Running builds:
    ats2-gnu-7.3.1-spmpi-2019.06.24_serial_static_dbg

Thu Feb  6 10:05:12 MST 2020

Running Jenkins driver Trilinos-atdm-ats2-gnu-7.3.1-spmpi-2019.06.24_serial_static_dbg.sh ...

    See log file Trilinos-atdm-ats2-gnu-7.3.1-spmpi-2019.06.24_serial_static_dbg/smart-jenkins-driver.out

real    5m51.443s
user    21m14.213s
sys     2m9.725s

99% tests passed, 1 tests failed out of 169

Thu Feb  6 10:11:03 MST 2020

Done running all of the builds!
```

This posted to CDash:

* [Trilinos-atdm-ats2-gnu-7.3.1-spmpi-2019.06.24_serial_static_dbg-exp](https://testing-dev.sandia.gov/cdash/index.php?project=Trilinos&parentid=5218133)(passed=168, failed=1)

where the [configure output](https://testing-dev.sandia.gov/cdash/viewConfigure.php?buildid=5218133) showed:

```
-- CMAKE_GENERATOR='Ninja'
```
