### PR TITLE
PyTrilinos: Fix syntax error for SWIG 3

### DIFF
--- a/packages/PyTrilinos/src/Isorropia.Epetra.i
+++ b/packages/PyTrilinos/src/Isorropia.Epetra.i
@@ -125,7 +125,7 @@ from . import _Epetra
 
 // Include Isorropia documentation (same as for Isorropia.i)
 #if SWIG_VERSION < 0x040000
-%feature("autodoc", "1")
+%feature("autodoc", "1");
 %include "Isorropia_dox.i"
 #endif
 


### PR DESCRIPTION

@trilinos/pytrilinos 

## Motivation
I fixed PyTrilinos to work with SWIG 4.0, while trying to maintain backward compatibility with SWIG 3.0.  I introduced one syntax error, accessible when the SWIG version is less than 4.0, which this fixes.

* Related to #6607 
