### PR TITLE
Zoltan2 mj clean up

### DIFF
--- a/packages/zoltan2/example/block/kokkosBlock.cpp
+++ b/packages/zoltan2/example/block/kokkosBlock.cpp
@@ -86,8 +86,7 @@ int main(int narg, char *arg[]) {
 
   Kokkos::View<globalId_t*, typename node_t::device_type>
     globalIds(Kokkos::ViewAllocateWithoutInitializing("globalIds"), localCount);
-  typename decltype(globalIds)::HostMirror
-    host_globalIds = Kokkos::create_mirror_view(globalIds);
+  auto host_globalIds = Kokkos::create_mirror_view(globalIds);
 
   if (rank == 0) {
     for (int i = 0, num = 40; i < nprocs ; i++, num += 40) {
@@ -150,8 +149,7 @@ int main(int narg, char *arg[]) {
   Kokkos::View<const globalId_t *, typename node_t::device_type> ids;
   ia.getIDsKokkosView(ids);
 
-  typename decltype(ids)::HostMirror host_ids =
-    Kokkos::create_mirror_view(ids);
+  auto host_ids = Kokkos::create_mirror_view(ids);
   Kokkos::deep_copy(host_ids, ids);
 
   Kokkos::View<int*, Kokkos::HostSpace> partCounts("partCounts", nprocs);

--- a/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
+++ b/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
@@ -4938,8 +4938,8 @@ mj_create_new_partitions(
 
 #else
 
-#ifdef KOKKOS_HAVE_OPENMP
-  const int num_threads = omp_get_num_threads();
+#ifdef KOKKOS_ENABLE_OPENMP
+  const int num_threads = Kokkos::OpenMP::impl_max_hardware_threads();
 #else
   const int num_threads = 1;
 #endif

--- a/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
+++ b/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
@@ -1681,11 +1681,9 @@ void AlgMJ<mj_scalar_t, mj_lno_t, mj_gno_t, mj_part_t, mj_node_t>::
     Kokkos::View<mj_scalar_t *, device_t> mj_current_dim_coords =
       Kokkos::subview(this->mj_coordinates, Kokkos::ALL, coordInd);
 
-    typename decltype(process_local_min_max_coord_total_weight)::HostMirror
-      host_process_local_min_max_coord_total_weight =
+    auto host_process_local_min_max_coord_total_weight =
       Kokkos::create_mirror_view(process_local_min_max_coord_total_weight);
-    typename decltype(global_min_max_coord_total_weight)::HostMirror
-      host_global_min_max_coord_total_weight =
+    auto host_global_min_max_coord_total_weight =
       Kokkos::create_mirror_view(global_min_max_coord_total_weight);
 
     // run for all available parts.
@@ -3071,8 +3069,7 @@ void AlgMJ<mj_scalar_t, mj_lno_t, mj_gno_t, mj_part_t, mj_node_t>::
 
   Kokkos::View<mj_scalar_t*, device_t> device_cumulative(
     "device_cumulative", num_cuts);
-  typename decltype(device_cumulative)::HostMirror
-    host_cumulative = Kokkos::create_mirror_view(device_cumulative);
+  auto host_cumulative = Kokkos::create_mirror_view(device_cumulative);
 
   mj_scalar_t cumulative = 0;
 
@@ -4222,8 +4219,7 @@ void AlgMJ<mj_scalar_t, mj_lno_t, mj_gno_t,mj_part_t, mj_node_t>::
 #endif
 
 #ifndef KOKKOS_ENABLE_CUDA
-    typename decltype(my_current_part_weights)::HostMirror
-      hostArray = Kokkos::create_mirror_view(my_current_part_weights);
+    auto hostArray = Kokkos::create_mirror_view(my_current_part_weights);
 
     for(int i = 0; i < static_cast<int>(total_part_count); ++i) {
       hostArray(i) = reduce_array[i];
@@ -4231,11 +4227,8 @@ void AlgMJ<mj_scalar_t, mj_lno_t, mj_gno_t,mj_part_t, mj_node_t>::
 
     Kokkos::deep_copy(my_current_part_weights, hostArray);
 
-    typename decltype(my_current_left_closest)::HostMirror
-      hostLeftArray = Kokkos::create_mirror_view(my_current_left_closest);
-    typename decltype(my_current_right_closest)::HostMirror
-      hostRightArray =
-        Kokkos::create_mirror_view(my_current_right_closest);
+    auto hostLeftArray = Kokkos::create_mirror_view(my_current_left_closest);
+    auto hostRightArray = Kokkos::create_mirror_view(my_current_right_closest);
     for(mj_part_t cut = 0; cut < num_cuts; ++cut) {
       hostLeftArray(cut)  = reduce_array[weight_array_length + (cut+1)*2+0];
       hostRightArray(cut) = reduce_array[weight_array_length + (cut+1)*2+1];
@@ -5581,8 +5574,7 @@ void AlgMJ<mj_scalar_t, mj_lno_t, mj_gno_t, mj_part_t, mj_node_t>::
     points_per_part(i) =
       local_new_part_xadj(i) - ((i == 0) ? 0 : local_new_part_xadj(i-1));
   });
-  typename decltype(points_per_part)::HostMirror
-    host_points_per_part = Kokkos::create_mirror_view(points_per_part);
+  auto host_points_per_part = Kokkos::create_mirror_view(points_per_part);
   Kokkos::deep_copy(host_points_per_part, points_per_part);
   for(int i = 0; i < num_parts; ++i) {
     my_local_points_to_reduce_sum[i] = host_points_per_part(i);
@@ -5699,12 +5691,10 @@ void AlgMJ<mj_scalar_t, mj_lno_t, mj_gno_t, mj_part_t, mj_node_t>::
   mj_lno_t *send_count_to_each_proc,
   int *coordinate_destinations) {
 
-  typename decltype(this->new_part_xadj)::HostMirror
-    host_new_part_xadj = Kokkos::create_mirror_view(this->new_part_xadj);
+  auto host_new_part_xadj = Kokkos::create_mirror_view(this->new_part_xadj);
   deep_copy(host_new_part_xadj, this->new_part_xadj);
 
-  typename decltype(this->new_coordinate_permutations)::HostMirror
-    host_new_coordinate_permutations =
+  auto host_new_coordinate_permutations =
     Kokkos::create_mirror_view(this->new_coordinate_permutations);
   deep_copy(host_new_coordinate_permutations, this->new_coordinate_permutations);
 
@@ -6171,13 +6161,10 @@ void AlgMJ<mj_scalar_t, mj_lno_t, mj_gno_t, mj_part_t, mj_node_t>::
   mj_part_t part_shift_amount = output_part_numbering_begin_index;
   mj_part_t previous_processor = -1;
 
-  typename decltype(this->new_part_xadj)::HostMirror
-    local_new_part_xadj =
-    Kokkos::create_mirror_view(this->new_part_xadj);
+  auto local_new_part_xadj = Kokkos::create_mirror_view(this->new_part_xadj);
   Kokkos::deep_copy(local_new_part_xadj, this->new_part_xadj);
 
-  typename decltype(this->new_part_xadj)::HostMirror
-    local_new_coordinate_permutations =
+  auto local_new_coordinate_permutations =
     Kokkos::create_mirror_view(this->new_coordinate_permutations);
   Kokkos::deep_copy(local_new_coordinate_permutations,
     this->new_coordinate_permutations);
@@ -6564,8 +6551,7 @@ void AlgMJ<mj_scalar_t, mj_lno_t, mj_gno_t, mj_part_t, mj_node_t>::
       Kokkos::View<mj_scalar_t**, Kokkos::LayoutLeft, device_t>
         dst_coordinates(Kokkos::ViewAllocateWithoutInitializing("mj_coordinates"),
         num_incoming_gnos, this->coord_dim);
-      typename decltype(dst_coordinates)::HostMirror
-        host_dst_coordinates = Kokkos::create_mirror_view(
+      auto host_dst_coordinates = Kokkos::create_mirror_view(
         Kokkos::HostSpace(), dst_coordinates);
       for(int i = 0; i < this->coord_dim; ++i) {
         Kokkos::View<mj_scalar_t*, Kokkos::Serial> sub_host_src_coordinates;
@@ -6592,15 +6578,13 @@ void AlgMJ<mj_scalar_t, mj_lno_t, mj_gno_t, mj_part_t, mj_node_t>::
 
     // migrate weights.
     {
-      typename decltype(this->mj_weights)::HostMirror
-        host_src_weights = Kokkos::create_mirror_view(
+      auto host_src_weights = Kokkos::create_mirror_view(
         Kokkos::HostSpace(), this->mj_weights);
       Kokkos::deep_copy(host_src_weights, this->mj_weights);
       Kokkos::View<mj_scalar_t**, device_t> dst_weights(
         Kokkos::ViewAllocateWithoutInitializing("mj_weights"),
         num_incoming_gnos, this->num_weights_per_coord);
-      typename decltype(dst_weights)::HostMirror host_dst_weights =
-        Kokkos::create_mirror_view(dst_weights);
+      auto host_dst_weights = Kokkos::create_mirror_view(dst_weights);
       for(int i = 0; i < this->num_weights_per_coord; ++i) {
         auto sub_host_src_weights
           = Kokkos::subview(host_src_weights, Kokkos::ALL, i);
@@ -6751,8 +6735,7 @@ void AlgMJ<mj_scalar_t, mj_lno_t, mj_gno_t, mj_part_t, mj_node_t>::
     // migrate weights.
     Kokkos::View<mj_scalar_t**, device_t> dst_weights(
      "mj_weights", num_incoming_gnos, this->num_weights_per_coord);
-    typename decltype(dst_weights)::HostMirror host_dst_weights =
-      Kokkos::create_mirror_view(dst_weights);
+    auto host_dst_weights = Kokkos::create_mirror_view(dst_weights);
     auto host_src_weights = Kokkos::create_mirror_view(
       Kokkos::HostSpace(), this->mj_weights);
     Kokkos::deep_copy(host_src_weights, this->mj_weights);
@@ -7233,8 +7216,7 @@ void AlgMJ<mj_scalar_t, mj_lno_t, mj_gno_t, mj_part_t, mj_node_t>::
 
   auto local_current_concurrent_cut_coordinate =
     current_concurrent_cut_coordinate;
-  typename decltype(local_current_concurrent_cut_coordinate)::HostMirror
-    host_current_concurrent_cut_coordinate =
+  auto host_current_concurrent_cut_coordinate =
     Kokkos::create_mirror_view(local_current_concurrent_cut_coordinate);
   Kokkos::deep_copy(host_current_concurrent_cut_coordinate,
     local_current_concurrent_cut_coordinate);
@@ -7256,22 +7238,17 @@ void AlgMJ<mj_scalar_t, mj_lno_t, mj_gno_t, mj_part_t, mj_node_t>::
     host_current_concurrent_cut_coordinate);
 
   // now the actual part assigment.
-  typename decltype(coordinate_permutations)::HostMirror
-    host_coordinate_permutations =
+  auto host_coordinate_permutations =
     Kokkos::create_mirror_view(coordinate_permutations);
   Kokkos::deep_copy(host_coordinate_permutations, coordinate_permutations);
 
-  typename decltype(assigned_part_ids)::HostMirror
-    host_assigned_part_ids =
-    Kokkos::create_mirror_view(assigned_part_ids);
+  auto host_assigned_part_ids = Kokkos::create_mirror_view(assigned_part_ids);
   Kokkos::deep_copy(host_assigned_part_ids, assigned_part_ids);
 
-  typename decltype(mj_coordinates)::HostMirror
-    host_mj_coordinates = Kokkos::create_mirror_view(mj_coordinates);
+  auto host_mj_coordinates = Kokkos::create_mirror_view(mj_coordinates);
   Kokkos::deep_copy(host_mj_coordinates, mj_coordinates);
 
-  typename decltype(thread_point_counts)::HostMirror
-    host_thread_point_counts = Kokkos::create_mirror_view(thread_point_counts);
+  auto host_thread_point_counts = Kokkos::create_mirror_view(thread_point_counts);
   Kokkos::deep_copy(host_thread_point_counts, thread_point_counts);
 
   auto local_coord_dim = this->coord_dim;
@@ -7330,15 +7307,12 @@ void AlgMJ<mj_scalar_t, mj_lno_t, mj_gno_t, mj_part_t, mj_node_t>::
 
   mj_part_t previous_cut_map = cut_map[0];
 
-  typename decltype(thread_cut_line_weight_to_put_left)::HostMirror
-    host_thread_cut_line_weight_to_put_left =
+  auto host_thread_cut_line_weight_to_put_left =
     Kokkos::create_mirror_view(thread_cut_line_weight_to_put_left);
   Kokkos::deep_copy(host_thread_cut_line_weight_to_put_left,
     thread_cut_line_weight_to_put_left);
 
-  typename decltype(mj_weights)::HostMirror
-    host_mj_weights =
-    Kokkos::create_mirror_view(mj_weights);
+  auto host_mj_weights = Kokkos::create_mirror_view(mj_weights);
   Kokkos::deep_copy(host_mj_weights, mj_weights);
 
   // this is how much previous part owns the weight of the current part.
@@ -7478,9 +7452,7 @@ void AlgMJ<mj_scalar_t, mj_lno_t, mj_gno_t, mj_part_t, mj_node_t>::
   }
 
   auto local_out_part_xadj = out_part_xadj;
-  typename decltype(local_out_part_xadj)::HostMirror
-    host_out_part_xadj =
-    Kokkos::create_mirror_view(local_out_part_xadj);
+  auto host_out_part_xadj = Kokkos::create_mirror_view(local_out_part_xadj);
   Kokkos::deep_copy(host_out_part_xadj, out_part_xadj);
 
   // creation of part_xadj as in usual case.
@@ -7500,8 +7472,7 @@ void AlgMJ<mj_scalar_t, mj_lno_t, mj_gno_t, mj_part_t, mj_node_t>::
     host_thread_point_counts(j) += host_out_part_xadj(j - 1);
   }
 
-  typename decltype(new_coordinate_permutations)::HostMirror
-    host_new_coordinate_permutations =
+  auto host_new_coordinate_permutations =
     Kokkos::create_mirror_view(new_coordinate_permutations);
   Kokkos::deep_copy(host_new_coordinate_permutations,
     new_coordinate_permutations);
@@ -7962,11 +7933,9 @@ void AlgMJ<mj_scalar_t, mj_lno_t, mj_gno_t, mj_part_t, mj_node_t>::
 
     mj_part_t obtained_part_index = 0;
 
-    typename decltype(process_local_min_max_coord_total_weight)::HostMirror
-      host_process_local_min_max_coord_total_weight =
+    auto host_process_local_min_max_coord_total_weight =
       Kokkos::create_mirror_view(process_local_min_max_coord_total_weight);
-    typename decltype(global_min_max_coord_total_weight)::HostMirror
-      host_global_min_max_coord_total_weight =
+    auto host_global_min_max_coord_total_weight =
       Kokkos::create_mirror_view(global_min_max_coord_total_weight);
 
     // run for all available parts.
@@ -8885,10 +8854,8 @@ bool Zoltan2_AlgMJ<Adapter>::mj_premigrate_to_subset(
   Kokkos::View<mj_scalar_t**, device_t> dst_weights(
     Kokkos::ViewAllocateWithoutInitializing("mj_weights"),
     num_incoming_gnos, this->num_weights_per_coord);
-  typename decltype(dst_weights)::HostMirror host_dst_weights =
-    Kokkos::create_mirror_view(dst_weights);
-  typename decltype(this->mj_weights)::HostMirror
-    host_src_weights = Kokkos::create_mirror_view(this->mj_weights);
+  auto host_dst_weights = Kokkos::create_mirror_view(dst_weights);
+  auto host_src_weights = Kokkos::create_mirror_view(this->mj_weights);
   Kokkos::deep_copy(host_src_weights, this->mj_weights);
   for(int i = 0; i < this->num_weights_per_coord; ++i) {
     auto sub_host_src_weights
@@ -9103,8 +9070,7 @@ void Zoltan2_AlgMJ<Adapter>::partition(
 
     ArrayRCP<mj_part_t> partId = arcp(new mj_part_t[result_num_local_coords],
         0, result_num_local_coords, true);
-    typename decltype(result_assigned_part_ids)::HostMirror
-      host_result_assigned_part_ids =
+    auto host_result_assigned_part_ids =
       Kokkos::create_mirror_view(result_assigned_part_ids);
     Kokkos::deep_copy(host_result_assigned_part_ids, result_assigned_part_ids);
     Kokkos::View<mj_gno_t*, Kokkos::Serial> host_result_mj_gnos
@@ -9154,8 +9120,7 @@ void Zoltan2_AlgMJ<Adapter>::partition(
       {
         std::unordered_map<mj_gno_t, mj_lno_t> localGidToLid2;
         localGidToLid2.reserve(this->num_local_coords);
-        typename decltype(this->initial_mj_gnos)::HostMirror
-          host_initial_mj_gnos =
+        auto host_initial_mj_gnos =
           Kokkos::create_mirror_view(this->initial_mj_gnos);
         Kokkos::deep_copy(host_initial_mj_gnos,
           this->initial_mj_gnos);

--- a/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
+++ b/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
@@ -3973,8 +3973,6 @@ struct ReduceWeightsFunctor {
       for(int n = 2 + value_count_weights;
         n < value_count_weights + value_count_rightleft - 2; n += 2) {
 #ifdef KOKKOS_ENABLE_CUDA
-
-#ifdef KOKKOS_ENABLE_CUDA
         scalar_t new_value = shared_ptr[n+1];
         scalar_t prev_value = current_right_closest(insert_right);
         while(new_value < prev_value) {
@@ -3991,15 +3989,6 @@ struct ReduceWeightsFunctor {
 
         ++insert_left;
         ++insert_right;
-#else
-        if(shared_ptr[n] > teamSum[n]) {
-          teamSum[n] = shared_ptr[n];
-        }
-        if(shared_ptr[n+1] < teamSum[n+1]) {
-          teamSum[n+1] = shared_ptr[n+1];
-        }
-#endif
-
 #else // KOKKOS_ENABLE_CUDA
         if(array.ptr[n] > teamSum[n]) {
           teamSum[n] = array.ptr[n];

--- a/packages/zoltan2/src/algorithms/partition/Zoltan2_TaskMapping.hpp
+++ b/packages/zoltan2/src/algorithms/partition/Zoltan2_TaskMapping.hpp
@@ -1498,8 +1498,7 @@ public:
     // coordinates in MJ are LayoutLeft since Tpetra Multivector gives LayoutLeft
     Kokkos::View<pcoord_t**, Kokkos::LayoutLeft, device_t>
       kokkos_pcoords("pcoords", this->no_procs, procdim);
-    typename decltype(kokkos_pcoords)::HostMirror
-      host_kokkos_pcoords = Kokkos::create_mirror_view(kokkos_pcoords);
+    auto host_kokkos_pcoords = Kokkos::create_mirror_view(kokkos_pcoords);
     for(int i = 0; i < procdim; ++i) {
       for(int j = 0; j < this->no_procs; ++j) {
         host_kokkos_pcoords(j,i) = pcoords[i][j];
@@ -1578,8 +1577,7 @@ public:
     // coordinates in MJ are LayoutLeft since Tpetra Multivector gives LayoutLeft
     Kokkos::View<tcoord_t**, Kokkos::LayoutLeft, device_t>
       kokkos_tcoords("tcoords", this->no_tasks, this->task_coord_dim);
-    typename decltype(kokkos_tcoords)::HostMirror
-      host_kokkos_tcoords = Kokkos::create_mirror_view(kokkos_tcoords);
+    auto host_kokkos_tcoords = Kokkos::create_mirror_view(kokkos_tcoords);
     for(int i = 0; i < this->task_coord_dim; ++i) {
       for(int j = 0; j < this->no_tasks; ++j) {
         host_kokkos_tcoords(j,i) = tcoords[i][j];

--- a/packages/zoltan2/src/input/Zoltan2_BasicVectorAdapter.hpp
+++ b/packages/zoltan2/src/input/Zoltan2_BasicVectorAdapter.hpp
@@ -323,8 +323,7 @@ private:
       // make kokkos ids
       kokkos_ids_ = Kokkos::View<gno_t *, typename node_t::device_type>(
         Kokkos::ViewAllocateWithoutInitializing("ids"), numIds_);
-      typename decltype(kokkos_ids_)::HostMirror
-        host_kokkos_ids_ = Kokkos::create_mirror_view(kokkos_ids_);
+      auto host_kokkos_ids_ = Kokkos::create_mirror_view(kokkos_ids_);
       for(int n = 0; n < numIds_; ++n) {
         host_kokkos_ids_(n) = idList_[n];
       }
@@ -349,7 +348,7 @@ private:
       size_t length;
       const scalar_t * entriesPtr;
 
-      typename decltype(this->kokkos_entries_)::HostMirror host_kokkos_entries =
+      auto host_kokkos_entries =
         Kokkos::create_mirror_view(this->kokkos_entries_);
 
       for (int idx=0; idx < numEntriesPerID_; idx++) {
@@ -378,9 +377,8 @@ private:
         numIds_, numWeights_);
 
       // setup weights
-      typename decltype(this->kokkos_weights_)::HostMirror
-        host_weight_temp_values =
-          Kokkos::create_mirror_view(this->kokkos_weights_);
+      auto host_weight_temp_values =
+        Kokkos::create_mirror_view(this->kokkos_weights_);
       for(int idx = 0; idx < numWeights_; ++idx) {
         const scalar_t * weightsPtr;
         size_t length;

--- a/packages/zoltan2/src/input/Zoltan2_MeshAdapter.hpp
+++ b/packages/zoltan2/src/input/Zoltan2_MeshAdapter.hpp
@@ -463,8 +463,7 @@ public:
   {
     Kokkos::View<gno_t *, typename node_t::device_type>
       kokkos_ids("gids", getLocalNumIDs());
-    typename decltype(kokkos_ids)::HostMirror
-      host_kokkos_ids = Kokkos::create_mirror_view(kokkos_ids);
+    auto host_kokkos_ids = Kokkos::create_mirror_view(kokkos_ids);
 
     const gno_t * gnos;
     getIDsView(gnos);
@@ -496,8 +495,7 @@ public:
     // coordinates in MJ are LayoutLeft since Tpetra Multivector gives LayoutLeft
     Kokkos::View<scalar_t **, Kokkos::LayoutLeft, typename node_t::device_type>
       kokkos_coordinates("pamgen coords", getLocalNumIDs(), getDimension());
-    typename decltype(kokkos_coordinates)::HostMirror
-      host_temp_values = Kokkos::create_mirror_view(kokkos_coordinates);
+    auto host_temp_values = Kokkos::create_mirror_view(kokkos_coordinates);
     const scalar_t * coords;
     for(int dim = 0; dim < getDimension(); ++dim) {
       int stride = -1;

--- a/packages/zoltan2/test/unit/input/BasicKokkosIdentifierInput.cpp
+++ b/packages/zoltan2/test/unit/input/BasicKokkosIdentifierInput.cpp
@@ -98,14 +98,11 @@ int main(int narg, char *arg[]) {
 
   ia.getWeightsKokkosView(weightsIn);
 
-  typename decltype(globalIdsIn)::HostMirror host_globalIdsIn =
-    Kokkos::create_mirror_view(globalIdsIn);
+  auto host_globalIdsIn = Kokkos::create_mirror_view(globalIdsIn);
   Kokkos::deep_copy(host_globalIdsIn, globalIdsIn);
-  typename decltype(weightsIn)::HostMirror host_weightsIn =
-    Kokkos::create_mirror_view(weightsIn);
+  auto host_weightsIn = Kokkos::create_mirror_view(weightsIn);
   Kokkos::deep_copy(host_weightsIn, weightsIn);
-  typename decltype(weights)::HostMirror host_weights =
-    Kokkos::create_mirror_view(weights);
+  auto host_weights = Kokkos::create_mirror_view(weights);
   Kokkos::deep_copy(host_weights, weights);
 
   auto host_w0 = Kokkos::subview(host_weightsIn, Kokkos::ALL, 0);


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/zoltan2

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
@kddevin Apart from one change to make progress on #6422, this PR is not associated with any failures. It fixes various issues I had noticed while working on other MJ bugs over the past few weeks.

Changed doPostsAndWaits to get host ptrs and not uvm space ptrs. This was not causing any issue I am aware of but it seems it could cause an issue for some MPI implementations.

Changed deccltype declarations to use auto which cleans up code.

Removes a pointless #ifdef which can never do anything. This was leftover from an earlier refactor.

Removes a hack on one of the kernels to adjust team count for small test sizes. This was an issue a while back but it seems fine now. So perhaps it was caused by another bug (now fixed in MJ) or something was repaired in Kokkos.

Fixed an incorrect openmp thread count reading. For one kernel it was always using 1 thread for OpenMP regardless of actual availability. This will improve OpenMP performance.

Also I have made one seemingly pointless change which clears the cuda 10 pascal bug - #6422. Since tracking this bug has been very difficult, I think it may be useful to just see if this does clear for all the auto testing. There may be an issue with how I am handling ArrayView of subviews.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->
 ## Related Issues
Related to #6422 


<!---
## Stakeholder Feedback
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Tested on Cuda (white), OpenMP (white) and Mac parallel/serial builds.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->