### PR TITLE
Panzer: Removed Deprecated getGlobalIndexer()

### DIFF
--- a/packages/panzer/disc-fe/src/lof/Panzer_LinearObjFactory.hpp
+++ b/packages/panzer/disc-fe/src/lof/Panzer_LinearObjFactory.hpp
@@ -272,10 +272,6 @@ public:
    template <typename EvalT>
    Teuchos::RCP<PHX::Evaluator<Traits> > buildScatterDirichlet(const Teuchos::ParameterList & pl) const
    { return Teuchos::rcp_dynamic_cast<PHX::Evaluator<Traits> >(scatterDirichletManager_->template getAsBase<EvalT>()->clone(pl)); }
-
-   //! Get the range global indexer object associated with this factory
-   PANZER_DEPRECATED Teuchos::RCP<const panzer::GlobalIndexer> getGlobalIndexer() const
-   { return getRangeGlobalIndexer(); }
   
    //! Get the domain global indexer object associated with this factory
    virtual Teuchos::RCP<const panzer::GlobalIndexer> getDomainGlobalIndexer() const = 0;


### PR DESCRIPTION
@trilinos/panzer

## Motivation
Removed the getGlobalIndexer() method because Panzer is now differentiating range and domain global indexers.  The mitigation is to call getRangeGlobalIndexer() instead.

## Related Issues

* Part of #6655

## Testing

Configured Built and Tested using ATDM scripts on the cee-lan

```bash
mkdir -p $TRILINOS_DIR/build
cd $TRILINOS_DIR/build

source $TRILINOS_DIR/cmake/std/atdm/load-env.sh default

cmake \
  -GNinja \
  -DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/atdm/ATDMDevEnv.cmake \
  -DTrilinos_ENABLE_TESTS=ON \
  -DTrilinos_ENABLE_MueLu=ON \
  -DTrilinos_ENABLE_Ifpack2=ON \
  -DTrilinos_ENABLE_Teko=ON \
  -DTrilinos_ENABLE_Tpetra=ON \
  -DTrilinos_ENABLE_Belos=ON \
  -DTrilinos_ENABLE_Teuchos=ON \
  -DTrilinos_ENABLE_Epetra=ON \
  -DTrilinos_ENABLE_Panzer=ON \
  -DTrilinos_ENABLE_STK=ON \
  -DTrilinos_ENABLE_Percept=ON \
  -DTrilinos_ENABLE_Intrepid=ON \
  -DTrilinos_ENABLE_Zoltan2=ON \
  -DTrilinos_ENABLE_Piro=ON \
  -DTrilinos_ENABLE_ENABLE_ALL_OPTIONAL_PACKAGES=ON \
  -DTrilinos_ENABLE_ENABLE_SECONDARY_TESTED_CODE=ON \
  $TRILINOS_DIR

make NP=16  # Uses ninja -j16

ctest -j16
```