### PR TITLE
RTOp: Remove Deprecated show_spmd_apply_op_dump

### DIFF
--- a/packages/rtop/src/support/RTOpPack_SPMD_apply_op.cpp
+++ b/packages/rtop/src/support/RTOpPack_SPMD_apply_op.cpp
@@ -44,12 +44,6 @@
 #include "RTOpPack_SPMD_apply_op_def.hpp"
 
 
-#ifdef RTOPPACK_ENABLE_SHOW_DUMP
-// Keep for backward compatibility but it is a no-op now!
-bool RTOpPack::show_spmd_apply_op_dump = false;
-#endif // RTOPPACK_ENABLE_SHOW_DUMP
-
-
 Teuchos::RCP<Teuchos::FancyOStream>& RTOpPack::spmdApplyOpDumpOut()
 {
   static Teuchos::RCP<Teuchos::FancyOStream> dumpOut;

--- a/packages/rtop/src/support/RTOpPack_SPMD_apply_op_decl.hpp
+++ b/packages/rtop/src/support/RTOpPack_SPMD_apply_op_decl.hpp
@@ -72,10 +72,6 @@ namespace RTOpPack {
  */
 void set_SPMD_apply_op_dump_out(const RCP<FancyOStream> &dumpOut);
 
-#ifdef RTOPPACK_ENABLE_SHOW_DUMP
-RTOP_DEPRECATED extern bool show_spmd_apply_op_dump;
-#endif // RTOPPACK_ENABLE_SHOW_DUMP
-
 
 /** \brief Return the size in bytes of an external representation of a
  * <tt>ReductTarget</tt> object.


### PR DESCRIPTION
@trilinos/rtop

## Motivation
Removing deprecated global variable show spmd_apply_op_dump.

## Related Issues

* Part of #6655


## Testing

Configured Built and Tested using ATDM scripts on the cee-lan

```bash
mkdir -p $TRILINOS_DIR/build
cd $TRILINOS_DIR/build

source $TRILINOS_DIR/cmake/std/atdm/load-env.sh default

cmake \
  -GNinja \
  -DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/atdm/ATDMDevEnv.cmake \
  -DTrilinos_ENABLE_TESTS=ON \
  -DTrilinos_ENABLE_MueLu=ON \
  -DTrilinos_ENABLE_Ifpack2=ON \
  -DTrilinos_ENABLE_Teko=ON \
  -DTrilinos_ENABLE_Tpetra=ON \
  -DTrilinos_ENABLE_Belos=ON \
  -DTrilinos_ENABLE_Teuchos=ON \
  -DTrilinos_ENABLE_Epetra=ON \
  -DTrilinos_ENABLE_Panzer=ON \
  -DTrilinos_ENABLE_STK=ON \
  -DTrilinos_ENABLE_Percept=ON \
  -DTrilinos_ENABLE_Intrepid=ON \
  -DTrilinos_ENABLE_Zoltan2=ON \
  -DTrilinos_ENABLE_Piro=ON \
  -DTrilinos_ENABLE_Phalanx=ON \
  -DTrilinos_ENABLE_RTOp=ON \
  -DTrilinos_ENABLE_ENABLE_ALL_OPTIONAL_PACKAGES=ON \
  -DTrilinos_ENABLE_ENABLE_SECONDARY_TESTED_CODE=ON \
  $TRILINOS_DIR

make NP=16  # Uses ninja -j16

ctest -j16
```
