### PR TITLE
MueLu: fix compilation of RegionMG w/complex

### DIFF
--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
@@ -267,6 +267,7 @@ void MakeCoarseCompositeOperator(const int maxRegPerProc,
                                  const bool makeCompCoords)
 {
 #include "Xpetra_UseShortNames.hpp"
+  using CoordType = typename Teuchos::ScalarTraits<Scalar>::coordinateType;
   coarseCompOp = MatrixFactory::Build(compRowMap,
                                        // This estimate is very conservative and probably costs us lots of memory...
                                       8*regMatrix[0]->getCrsGraph()->getNodeMaxNumRowEntries());
@@ -321,14 +322,16 @@ void MakeCoarseCompositeOperator(const int maxRegPerProc,
         regCoordImporter[regionIdx] = ImportFactory::Build(compCoordMap, quasiRegCoordMap[regionIdx]);
       }
     }
-    compCoarseCoordinates = MultiVectorFactory::Build(compCoordMap, regCoarseCoordinates[0]->getNumVectors());
+    compCoarseCoordinates = Xpetra::MultiVectorFactory<CoordType, LocalOrdinal, GlobalOrdinal, Node>
+      ::Build(compCoordMap, regCoarseCoordinates[0]->getNumVectors());
     TEUCHOS_ASSERT(Teuchos::nonnull(compCoarseCoordinates));
 
     // The following looks like regionalToComposite for Vector
     // but it is a bit different since we do not want to add
     // entries in the coordinate MultiVector as we would for
     // a solution or residual vector.
-    RCP<MultiVector> quasiRegCoarseCoordinates;
+    RCP<Xpetra::MultiVector<CoordType, LocalOrdinal, GlobalOrdinal, Node>>
+      quasiRegCoarseCoordinates;
     for(int grpIdx = 0; grpIdx < maxRegPerProc; ++grpIdx) {
       quasiRegCoarseCoordinates = regCoarseCoordinates[grpIdx];
       TEUCHOS_ASSERT(Teuchos::nonnull(quasiRegCoarseCoordinates));


### PR DESCRIPTION
MultiVectorFactory with default template arguments was used
to create a coordinates MultiVector, causing type mismatch errror.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/muelu 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Fixes build errors caused by using MultiVectorFactory (with default template arguments) to construct a multivector of coordinates, when the coordinate scalar type differs from the default scalar.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
This only fixes the build; the RegionMG tests still fail with complex.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->