### PR TITLE
Disable timing out KokkosKernels_sparse_serial_MPI_1 in pure debug builds on 'ride' and 'waterman' (#6464)

### DIFF
--- a/cmake/std/atdm/ride/tweaks/Tweaks.cmake
+++ b/cmake/std/atdm/ride/tweaks/Tweaks.cmake
@@ -2,6 +2,13 @@
 # Disables across multiple builds on 'ride'
 #
 
+IF (ATDM_CMAKE_BUILD_TYPE STREQUAL "DEBUG")
+
+  # Disable some expensive KokkosKernels tests in pure debug builds (#6464)
+  ATDM_SET_ENABLE(KokkosKernels_sparse_serial_MPI_1_DISABLE ON)
+
+ENDIF()
+
 IF (Trilinos_ENABLE_DEBUG)
 
   # Disable Tempus tests that started timing out in debug builds when

--- a/cmake/std/atdm/waterman/tweaks/Tweaks.cmake
+++ b/cmake/std/atdm/waterman/tweaks/Tweaks.cmake
@@ -9,6 +9,13 @@ ATDM_SET_ENABLE(PanzerAdaptersIOSS_tIOSSConnManager3_MPI_3_DISABLE ON)
 # Disable randomly timing out test in all 'waterman' builds (#6463)
 ATDM_SET_ENABLE(Teko_testdriver_tpetra_MPI_4_DISABLE ON)
 
+IF (ATDM_CMAKE_BUILD_TYPE STREQUAL "DEBUG")
+
+  # Disable some expensive KokkosKernels tests in pure debug builds (#6464)
+  ATDM_SET_ENABLE(KokkosKernels_sparse_serial_MPI_1_DISABLE ON)
+
+ENDIF()
+
 IF (Trilinos_ENABLE_DEBUG)
 
   # STEQR() test fails on IBM Power systems with current TPL setup (#2410, #6166)


### PR DESCRIPTION
These started timing out every after Kokkos 2.99 upgrade starting 2020/02/04 but were timing out randomly before that as documented in #6464.

## How was this tested?

On 'ride' and 'waterman' I ran:

```
$ ./checkin-test-atdm.sh cuda-dbg --enable-packages=KokkosKernels --configure
```

and on both it showed:

```
$ grep "NOT added" configure.out 
-- KokkosKernels_blas_serial_MPI_1: NOT added test because KokkosKernels_blas_serial_MPI_1_DISABLE='ON'!
-- KokkosKernels_sparse_serial_MPI_1: NOT added test because KokkosKernels_sparse_serial_MPI_1_DISABLE='ON'!
```