### PR TITLE
kokkos-kernels: spgemm: fix scalar alignment

### DIFF
--- a/packages/kokkos-kernels/src/common/KokkosKernels_Utils.hpp
+++ b/packages/kokkos-kernels/src/common/KokkosKernels_Utils.hpp
@@ -1523,6 +1523,7 @@ struct ReduceMaxRowFunctor{
       view_type rowmap_view_): rowmap_view(rowmap_view_),
           min_val(0)
   {}
+
   KOKKOS_INLINE_FUNCTION
   void operator()(const size_t &i, value_type &max_reduction) const {
     value_type val = rowmap_view(i+1) - rowmap_view(i) ;
@@ -1933,6 +1934,16 @@ struct array_sum_reduce
       data[i] += src.data[i];
   }
 };
+
+template<typename InPtr, typename T>
+KOKKOS_INLINE_FUNCTION T* alignPtr(InPtr p)
+{
+  //ugly but computationally free and the "right" way to do this in C++
+  std::uintptr_t ptrVal = reinterpret_cast<std::uintptr_t>(p);
+  //ptrVal + (align - 1) lands inside the next valid aligned scalar_t,
+  //and the mask produces the start of that scalar_t.
+  return reinterpret_cast<T*>((ptrVal + alignof(T) - 1) & (~(alignof(T) - 1)));
+}
 
 }
 }

--- a/packages/kokkos-kernels/src/sparse/impl/KokkosSparse_spgemm_impl_speed.hpp
+++ b/packages/kokkos-kernels/src/sparse/impl/KokkosSparse_spgemm_impl_speed.hpp
@@ -41,6 +41,8 @@
 //@HEADER
 */
 
+#include "KokkosKernels_Utils.hpp"
+
 namespace KokkosSparse{
 
 namespace Impl{
@@ -302,7 +304,8 @@ struct KokkosSPGEMM
         thread_memory((shared_memory_size /8 / suggested_team_size_) * 8),
         shmem_key_size(), shared_memory_hash_func(), shmem_hash_size(1)
         {
-          shmem_key_size = ((thread_memory - sizeof(nnz_lno_t) * 2) / unit_memory);
+          constexpr size_t scalarAlignPad = (alignof(scalar_t) > alignof(nnz_lno_t)) ? (alignof(scalar_t) - alignof(nnz_lno_t)) : 0;
+          shmem_key_size = ((thread_memory - sizeof(nnz_lno_t) * 2 - scalarAlignPad) / unit_memory);
           if (KOKKOSKERNELS_VERBOSE_){
             std::cout << "\t\tNumericCMEM -- thread_memory:" << thread_memory  << " unit_memory:" << unit_memory <<
                 " initial key size:" << shmem_key_size << std::endl;
@@ -314,46 +317,6 @@ struct KokkosSPGEMM
 
           shmem_key_size = shmem_key_size + ((shmem_key_size - shmem_hash_size) * sizeof(nnz_lno_t)) / (sizeof (nnz_lno_t) * 2 + sizeof(scalar_t));
           shmem_key_size = (shmem_key_size >> 1) << 1;
-
-// This guard will help ensure behavior is consistent within Trilinos
-#ifdef KOKKOS_ENABLE_COMPLEX_ALIGN
-          {
-          // GPUTag
-          // shmem allocation will be partitioned as below for hash map accumulator
-          // thread_memory == 2*sizeof(nnz_lno_t) + shmem_hash_size*sizeof(nnz_lno_t) + 2*shmem_key_size*sizeof(nnz_lno_t) + rem_size*sizeof(scalar_t)
-
-          // check that memory is partitioned into aligned chunks
-          nnz_lno_t remainder_memory = thread_memory - sizeof(nnz_lno_t)*2 - shmem_hash_size*sizeof(nnz_lno_t);
-
-          // The remainder of memory for vals must be aligned into sizeof(scalar_t) chunks, and there must be at least as many entries as keys
-          nnz_lno_t val_memory = remainder_memory - 2*shmem_key_size*sizeof(nnz_lno_t);
-
-          nnz_lno_t val_unalign_mem = val_memory % alignof(scalar_t);
-          if (val_unalign_mem > 0) {
-            // Redistributing between shmem_key_size and vals involves exchange of 2 "keys" (key+next) per val
-            nnz_lno_t realign_chunk_mem = 2 * sizeof(nnz_lno_t);
-
-            bool is_align_possible = (val_unalign_mem % realign_chunk_mem) == 0;
-            if(!is_align_possible)
-            {
-              //throw std::runtime_error("NumericCMEM Ctor Error: unable to align memory for shared memory allocations. Modify your shared memory request");
-              std::cout << "NumericCMEM Ctor WARNING: unable to align memory for shared memory allocations. Modify your shared memory request" << std::endl;
-            }
-
-            nnz_lno_t realign_chunks = val_unalign_mem / realign_chunk_mem; 
-
-            shmem_key_size -= realign_chunks;
-            val_memory = remainder_memory - 2*shmem_key_size*sizeof(nnz_lno_t);
-            val_unalign_mem = val_memory%alignof(scalar_t);
-          }
-
-          if (val_unalign_mem > 0) {
-            //throw std::runtime_error("NumericCMEM Ctor Error: shared memory realignment failed. Modify your shared memory request");
-            std::cout << "NumericCMEM Ctor WARNING: shared memory realignment failed. Modify your shared memory request" << std::endl;
-          }
-
-          }
-#endif
 
           if (KOKKOSKERNELS_VERBOSE_){
             std::cout << "\t\tNumericCMEM -- adjusted hashsize:" << shmem_hash_size  << " shmem_key_size:" << shmem_key_size << std::endl;
@@ -388,8 +351,7 @@ struct KokkosSPGEMM
     //holds the keys
     nnz_lno_t * keys = (nnz_lno_t *) (all_shared_memory);
     all_shared_memory += sizeof(nnz_lno_t) * shmem_key_size;
-    scalar_t * vals = (scalar_t *) (all_shared_memory);
-
+    scalar_t* vals = KokkosKernels::Impl::alignPtr<char*, scalar_t>(all_shared_memory);
 
     KokkosKernels::Experimental::HashmapAccumulator<nnz_lno_t,nnz_lno_t,scalar_t>
     hm(shmem_hash_size, shmem_key_size, begins, nexts, keys, vals);


### PR DESCRIPTION
Permanent fix to scalar_t memory alignment in scratch views.
Affected KKMEM and SPEED algorithms.
Use new Utils function "alignPtr" that adds a few bytes to an
arbitrary non-void pointer (char*, nnz_lno_t*, etc.) to
correctly align to another type T*.

Mirror of https://github.com/kokkos/kokkos-kernels/pull/602
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/kokkos-kernels 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
In SPGEMM numeric phase, fixes incorrect alignment of ``scalar_t`` arrays in scratch buffers. On CPU this usually just degrades performance but on CUDA alignment is required and misalignment causes kernels to crash. This was observed with ``scalar_t = Kokkos::complex<double>`` where the complex was 16 byte aligned, but in principle the error could happen with ``scalar_t=double`` too.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
This is tested in the SPGEMM unit tests in kokkos-kernels, and in KokkosKernels, this was failing for CUDA+complex enabled. However, this never happens when testing kokkos-kernels as a Trilinos package, because Kokkos::complex alignment is disabled in Trilinos. The purpose of this PR in Trilinos is just to prepare for when this workaround is removed.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->