### PR TITLE
Tempus: Fix for maxTimeStep in Subcycling.

### DIFF
--- a/packages/tempus/src/Tempus_IntegratorBasic_decl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorBasic_decl.hpp
@@ -164,8 +164,14 @@ public:
     virtual void setScreenOutputIndexInterval(int i)
     { integratorPL_->set("Screen Output Index Interval", i); }
 
+    virtual int getScreenOutputIndexInterval() const
+    { return integratorPL_->get<int>("Screen Output Index Interval"); }
+
     virtual void setScreenOutputIndexList(std::string s)
     { integratorPL_->set("Screen Output Index List", s); }
+
+    virtual std::string getScreenOutputIndexList() const
+    { return integratorPL_->get<std::string>("Screen Output Index List", ""); }
   //@}
 
   /// Parse when screen output should be executed

--- a/packages/tempus/src/Tempus_StepperSubcycling_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperSubcycling_decl.hpp
@@ -117,7 +117,7 @@ public:
                           const Teuchos::EVerbosityLevel verbLevel) const;
   //@}
 
-  /// \name Functions to set the subcycling stepper.
+  /// \name Functions to set the subcycling stepper values.
   //@{
     virtual void setSubcyclingStepper(Teuchos::RCP<Stepper<Scalar> > stepper);
     virtual void setSubcyclingMinTimeStep(Scalar MinTimeStep);
@@ -133,6 +133,24 @@ public:
     virtual void setSubcyclingIntegratorObserver(
       Teuchos::RCP<IntegratorObserver<Scalar> > obs);
     virtual void setSubcyclingPrintDtChanges(bool printDtChanges);
+  //@}
+
+  /// \name Functions to get the subcycling stepper values.
+  //@{
+    virtual Teuchos::RCP<const Stepper<Scalar> > getSubcyclingStepper() const;
+    virtual Scalar getSubcyclingMinTimeStep() const;
+    virtual Scalar getSubcyclingInitTimeStep() const;
+    virtual Scalar getSubcyclingMaxTimeStep() const;
+    virtual std::string getSubcyclingStepType() const;
+    virtual int getSubcyclingMaxFailures() const;
+    virtual int getSubcyclingMaxConsecFailures() const;
+    virtual int getSubcyclingScreenOutputIndexInterval() const;
+    virtual std::string getSubcyclingScreenOutputIndexList() const;
+    virtual Teuchos::RCP<TimeStepControlStrategy<Scalar> >
+      getSubcyclingTimeStepControlStrategy() const;
+    virtual Teuchos::RCP<IntegratorObserver<Scalar> >
+      getSubcyclingIntegratorObserver() const;
+    virtual bool getSubcyclingPrintDtChanges() const;
   //@}
 
   // Temporary until 5908 branch is committed.

--- a/packages/tempus/src/Tempus_StepperSubcycling_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperSubcycling_impl.hpp
@@ -218,6 +218,69 @@ void StepperSubcycling<Scalar>::setSubcyclingPrintDtChanges(
 
 
 template<class Scalar>
+Teuchos::RCP<const Stepper<Scalar> >
+StepperSubcycling<Scalar>::getSubcyclingStepper() const
+{ return scIntegrator_->getStepper(); }
+
+
+template<class Scalar>
+Scalar StepperSubcycling<Scalar>::getSubcyclingMinTimeStep() const
+{ return scIntegrator_->getTimeStepControl()->getMinTimeStep(); }
+
+
+template<class Scalar>
+Scalar StepperSubcycling<Scalar>::getSubcyclingInitTimeStep() const
+{ return scIntegrator_->getTimeStepControl()->getInitTimeStep(); }
+
+
+template<class Scalar>
+Scalar StepperSubcycling<Scalar>::getSubcyclingMaxTimeStep() const
+{ return scIntegrator_->getTimeStepControl()->getMaxTimeStep(); }
+
+
+template<class Scalar>
+std::string StepperSubcycling<Scalar>::getSubcyclingStepType() const
+{ return scIntegrator_->getTimeStepControl()->getStepType(); }
+
+
+template<class Scalar>
+int StepperSubcycling<Scalar>::getSubcyclingMaxFailures() const
+{ return scIntegrator_->getTimeStepControl()->getMaxFailures(); }
+
+
+template<class Scalar>
+int StepperSubcycling<Scalar>::getSubcyclingMaxConsecFailures() const
+{ return scIntegrator_->getTimeStepControl()->getMaxConsecFailures(); }
+
+
+template<class Scalar>
+int StepperSubcycling<Scalar>::getSubcyclingScreenOutputIndexInterval() const
+{ return scIntegrator_->getScreenOutputIndexInterval(); }
+
+
+template<class Scalar>
+std::string StepperSubcycling<Scalar>::getSubcyclingScreenOutputIndexList() const
+{ return scIntegrator_->getScreenOutputIndexList(); }
+
+
+template<class Scalar>
+Teuchos::RCP<TimeStepControlStrategy<Scalar> >
+StepperSubcycling<Scalar>::getSubcyclingTimeStepControlStrategy() const
+{ return scIntegrator_->getTimeStepControl()->getTimeStepControlStrategy(); }
+
+
+template<class Scalar>
+Teuchos::RCP<IntegratorObserver<Scalar> >
+StepperSubcycling<Scalar>::getSubcyclingIntegratorObserver() const
+{ return scIntegrator_->getObserver(); }
+
+
+template<class Scalar>
+bool StepperSubcycling<Scalar>::getSubcyclingPrintDtChanges() const
+{ return scIntegrator_->getTimeStepControl()->getPrintDtChanges(); }
+
+
+template<class Scalar>
 void StepperSubcycling<Scalar>::setModel(
   const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel)
 {
@@ -390,7 +453,6 @@ void StepperSubcycling<Scalar>::takeStep(
     scTSC->setInitTime   (currentState->getTime());
     scTSC->setInitIndex  (0);
     scTSC->setFinalTime  (workingState->getTime());
-    scTSC->setMaxTimeStep(workingState->getTimeStep());
 
     auto subcyclingState = currentState->clone();
     subcyclingState->setTimeStep(scTSC->getInitTimeStep());

--- a/packages/tempus/unit_test/Tempus_UnitTest_Subcycling.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_Subcycling.cpp
@@ -37,7 +37,7 @@ using Tempus::StepperExplicitRK;
 
 // Comment out any of the following tests to exclude from build/run.
 #define CONSTRUCTION
-//#define STEPPERFACTORY_CONSTRUCTION
+#define MAXTIMESTEPDOESNOTCHANGEDURING_TAKESTEP
 
 
 #ifdef CONSTRUCTION
@@ -86,15 +86,37 @@ TEUCHOS_UNIT_TEST(Subcycling, Default_Construction)
 #endif // CONSTRUCTION
 
 
-#ifdef STEPPERFACTORY_CONSTRUCTION
+#ifdef MAXTIMESTEPDOESNOTCHANGEDURING_TAKESTEP
 // ************************************************************
 // ************************************************************
-TEUCHOS_UNIT_TEST(Subcycling, StepperFactory_Construction)
+TEUCHOS_UNIT_TEST(Subcycling, MaxTimeStepDoesNotChangeDuring_takeStep)
 {
-  //auto model   = rcp(new Tempus_Test::SinCosModel<double>());
-  //testFactoryConstruction("Forward Euler", model);
+  // Setup the stepper ----------------------------------------
+  auto model   = rcp(new Tempus_Test::SinCosModel<double>());
+  auto stepper = rcp(new Tempus::StepperSubcycling<double>());
+  auto sf = Teuchos::rcp(new Tempus::StepperFactory<double>());
+  auto stepperBE = sf->createStepperBackwardEuler(model, Teuchos::null);
+  stepper->setSubcyclingStepper(stepperBE);
+  stepper->initialize();
+
+  // Setup SolutionHistory ------------------------------------
+  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
+    stepper->getModel()->getNominalValues();
+  auto icSolution =rcp_const_cast<Thyra::VectorBase<double> >(inArgsIC.get_x());
+  auto icState = rcp(new Tempus::SolutionState<double>(icSolution));
+  auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());
+  solutionHistory->addState(icState);
+  solutionHistory->initWorkingState();
+
+  // Test
+  stepper->setSubcyclingMaxTimeStep(0.5);
+  double maxTimeStep_Set = stepper->getSubcyclingMaxTimeStep();
+  stepper->takeStep(solutionHistory);
+  double maxTimeStep_After = stepper->getSubcyclingMaxTimeStep();
+
+  TEST_FLOATING_EQUALITY(maxTimeStep_Set, maxTimeStep_After, 1.0e-14 );
 }
-#endif // STEPPERFACTORY_CONSTRUCTION
+#endif // MAXTIMESTEPDOESNOTCHANGEDURING_TAKESTEP
 
 
 } // namespace Tempus_Test


### PR DESCRIPTION
The maxTimeStep was being changed within the
Stepper::Subcycling::takeStep(), which should not occur.
Removed the offending call, and added code and unit test
to ensure it does not happen again.

Passes all tests on my Mac.

Closes #6811 

@trilinos/tempus 