### PR TITLE
ATDM: ats2: Disable KokkosKernels_sparse_serial_MPI_1 for ats2 debug debug builds (#6464)

### DIFF
--- a/cmake/std/atdm/ats2/tweaks/Tweaks.cmake
+++ b/cmake/std/atdm/ats2/tweaks/Tweaks.cmake
@@ -2,6 +2,13 @@
 # Disables across multiple builds on 'ats2'
 #
 
+IF (ATDM_CMAKE_BUILD_TYPE STREQUAL "DEBUG")
+
+  # Disable some expensive KokkosKernels tests in pure debug builds (#6464)
+  ATDM_SET_ENABLE(KokkosKernels_sparse_serial_MPI_1_DISABLE ON)
+
+ENDIF()
+
 IF (Trilinos_ENABLE_DEBUG)
 
   # STEQR() test fails on IBM Power systems with current TPL setup (#2410, #6166)


### PR DESCRIPTION
Just a very expensive test in a pure debug build on the Power systems for some
reason.  Go figure.  See #6464 

## How was this tested?

On 'vortex' I did:

```
$ ./checkin-test-atdm.sh \
    ats2-gnu-7.3.1-spmpi-2019.06.24_serial_static_dbg \
    --enable-packages=KokkosKernels --configure

...

Build test results:
-------------------
1) ats2-gnu-7.3.1-spmpi-2019.06.24_serial_static_dbg => passed: configure-only passed => Not ready to push! (0.38 min)
```

and the configure output showed:

```
[rabartl@vortex60 ats2-gnu-7.3.1-spmpi-2019.06.24_serial_static_dbg]$ grep "NOT added" configure.out 
-- KokkosKernels_blas_serial_MPI_1: NOT added test because KokkosKernels_blas_serial_MPI_1_DISABLE='ON'!
-- KokkosKernels_sparse_serial_MPI_1: NOT added test because KokkosKernels_sparse_serial_MPI_1_DISABLE='ON'!
```
