### PR TITLE
ATDM: ats2: Disable TeuchosCore_show_stack in debug builds (#6821)

### DIFF
--- a/cmake/std/atdm/ats2/tweaks/Tweaks.cmake
+++ b/cmake/std/atdm/ats2/tweaks/Tweaks.cmake
@@ -7,6 +7,9 @@ IF (ATDM_CMAKE_BUILD_TYPE STREQUAL "DEBUG")
   # Disable some expensive KokkosKernels tests in pure debug builds (#6464)
   ATDM_SET_ENABLE(KokkosKernels_sparse_serial_MPI_1_DISABLE ON)
 
+  # Disable test that just has problems with BinUtils interaction (#6821)
+  ATDM_SET_ENABLE(TeuchosCore_show_stack_DISABLE ON)
+
 ENDIF()
 
 IF (Trilinos_ENABLE_DEBUG)


### PR DESCRIPTION
There is either some problem with binutils or with Teuchos code that uses
binutils to interpret the stack trace info.  We can fix this later if this is
really needed. 

See #6821 

## How was this tested?

On 'vortex' I did:

```
$ ./checkin-test-atdm.sh \
    ats2-gnu-7.3.1-spmpi-2019.06.24_serial_static_dbg \
    --enable-packages=Teuchos --configure

...

PASSED (NOT READY TO PUSH): Trilinos: vortex60

Wed Feb 12 13:02:35 MST 2020

Enabled Packages: Teuchos

Build test results:
-------------------
1) ats2-gnu-7.3.1-spmpi-2019.06.24_serial_static_dbg => passed: configure-only passed => Not ready to push! (0.45 min)

REQUESTED ACTIONS: PASSED
```

and it showed:

```
[rabartl@vortex60 ats2-gnu-7.3.1-spmpi-2019.06.24_serial_static_dbg]$ grep "TeuchosCore_show_stack" configure.out 
-- Setting default TeuchosCore_show_stack_DISABLE=ON
ATDM: ats2: Disable TeuchosCore_show_stack in debug builds (#6821)
-- TeuchosCore_show_stack: NOT added test because TeuchosCore_show_stack_DISABLE='ON'!
```

