### PR TITLE
Have JSRUN wrapper print full command by default

### DIFF
--- a/cmake/std/atdm/ats2/trilinos_jsrun
+++ b/cmake/std/atdm/ats2/trilinos_jsrun
@@ -2,7 +2,7 @@
 
 # Globals
 DEBUG_SCRIPT="${DEBUG_SCRIPT-:0}"
-ECHO_CMD="${ECHO_CMD=:0}"
+ECHO_CMD="${ECHO_CMD:-1}"
 np_is_one="false"
 orig_args=("$@")
 args=("$@")

--- a/cmake/std/atdm/ats2/trilinos_jsrun_test_me.sh
+++ b/cmake/std/atdm/ats2/trilinos_jsrun_test_me.sh
@@ -1,31 +1,31 @@
 #!/bin/bash
 
 echo "testing with cuda-aware unset!, should not see -gpu, look for -disable_gpu_hooks"
-ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI="" ./trilinos_jsrun -M -disable_gdr -p 2 hostname 1>/dev/null
-ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI="" ./trilinos_jsrun -M -disable_gdr -p 1 hostname 1>/dev/null
-ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI="" ./trilinos_jsrun -M -disable_gdr -p 1 hostname 1>/dev/null
+TPETRA_ASSUME_CUDA_AWARE_MPI="" ./trilinos_jsrun -M -disable_gdr -p 2 hostname
+TPETRA_ASSUME_CUDA_AWARE_MPI="" ./trilinos_jsrun -M -disable_gdr -p 1 hostname
+TPETRA_ASSUME_CUDA_AWARE_MPI="" ./trilinos_jsrun -M -disable_gdr -p 1 hostname
 
 echo "testing with cuda-aware turned off!, should not see -gpu, look for -disable_gpu_hooks"
-ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI=0 ./trilinos_jsrun -M -disable_gdr -p 2 hostname 1>/dev/null
-ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI=0 ./trilinos_jsrun -M -disable_gdr -p 1 hostname 1>/dev/null
-ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI=0 ./trilinos_jsrun -M -disable_gdr -p 1 hostname 1>/dev/null
+TPETRA_ASSUME_CUDA_AWARE_MPI=0 ./trilinos_jsrun -M -disable_gdr -p 2 hostname
+TPETRA_ASSUME_CUDA_AWARE_MPI=0 ./trilinos_jsrun -M -disable_gdr -p 1 hostname
+TPETRA_ASSUME_CUDA_AWARE_MPI=0 ./trilinos_jsrun -M -disable_gdr -p 1 hostname
 
 echo "testing with cuda-aware turned ON!, should see -gpu if NP>1 and  -disable_gpu_hooks when NP=1"
-ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI=1 ./trilinos_jsrun -M -disable_gdr -p 2 hostname 1>/dev/null
-ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI=1 ./trilinos_jsrun -M -disable_gdr -p 1 hostname 1>/dev/null
-ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI=1 ./trilinos_jsrun -M -disable_gdr -p 1 hostname 1>/dev/null
+TPETRA_ASSUME_CUDA_AWARE_MPI=1 ./trilinos_jsrun -M -disable_gdr -p 2 hostname
+TPETRA_ASSUME_CUDA_AWARE_MPI=1 ./trilinos_jsrun -M -disable_gdr -p 1 hostname
+TPETRA_ASSUME_CUDA_AWARE_MPI=1 ./trilinos_jsrun -M -disable_gdr -p 1 hostname
 
 echo "testing with cuda-aware unset!, should not see -gpu, look for -disable_gpu_hooks"
-ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI="" ./trilinos_jsrun  -p 2 hostname 1>/dev/null
-ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI="" ./trilinos_jsrun  -p 1 hostname 1>/dev/null
-ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI="" ./trilinos_jsrun  -p 1 hostname 1>/dev/null
+TPETRA_ASSUME_CUDA_AWARE_MPI="" ./trilinos_jsrun  -p 2 hostname
+TPETRA_ASSUME_CUDA_AWARE_MPI="" ./trilinos_jsrun  -p 1 hostname
+TPETRA_ASSUME_CUDA_AWARE_MPI="" ./trilinos_jsrun  -p 1 hostname
 
 echo "testing with cuda-aware turned off!, should not see -gpu, look for -disable_gpu_hooks"
-ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI=0 ./trilinos_jsrun  -p 2 hostname 1>/dev/null
-ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI=0 ./trilinos_jsrun  -p 1 hostname 1>/dev/null
-ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI=0 ./trilinos_jsrun  -p 1 hostname 1>/dev/null
+TPETRA_ASSUME_CUDA_AWARE_MPI=0 ./trilinos_jsrun  -p 2 hostname
+TPETRA_ASSUME_CUDA_AWARE_MPI=0 ./trilinos_jsrun  -p 1 hostname
+TPETRA_ASSUME_CUDA_AWARE_MPI=0 ./trilinos_jsrun  -p 1 hostname
 
 echo "testing with cuda-aware turned ON!, should see -gpu if NP>1 and  -disable_gpu_hooks when NP=1"
-ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI=1 ./trilinos_jsrun  -p 2 hostname 1>/dev/null
-ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI=1 ./trilinos_jsrun  -p 1 hostname 1>/dev/null
-ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI=1 ./trilinos_jsrun  -p 1 hostname 1>/dev/null
+TPETRA_ASSUME_CUDA_AWARE_MPI=1 ./trilinos_jsrun  -p 2 hostname
+TPETRA_ASSUME_CUDA_AWARE_MPI=1 ./trilinos_jsrun  -p 1 hostname
+TPETRA_ASSUME_CUDA_AWARE_MPI=1 ./trilinos_jsrun  -p 1 hostname


### PR DESCRIPTION
Follow on to PR #6724 

This edit has the wrapper print the command used by default to stdout.

It has been tested using the provided wrapper test tool
