### PR TITLE
Force jsrun wrapper to print the full cmd export ECHO_CMD=0 to disable

### DIFF
--- a/cmake/ctest/drivers/atdm/ats2/local-driver.sh
+++ b/cmake/ctest/drivers/atdm/ats2/local-driver.sh
@@ -1,15 +1,16 @@
 #!/bin/bash -l
 
-if [ "${LSF_CTEST_TIMEOUT}" == "" ] ; then
-  LSF_CTEST_TIMEOUT=12:00
-  # This is just running tests, not the entire build!
+if [ "${LSF_CTEST_ALL_TIMEOUT}" == "" ] ; then
+  LSF_CTEST_ALL_TIMEOUT=12:00
+fi
+
+if [ "${LSF_CTEST_TEST_TIMEOUT}" == "" ] ; then
+  LSF_CTEST_TEST_TIMEOUT=4:00
 fi
 
 if [ "${Trilinos_CTEST_DO_ALL_AT_ONCE}" == "" ] ; then
   export Trilinos_CTEST_DO_ALL_AT_ONCE=TRUE
 fi
-
-set -x
 
 source $WORKSPACE/Trilinos/cmake/std/atdm/load-env.sh $JOB_NAME
 
@@ -18,7 +19,7 @@ set -x
 atdm_run_script_on_compute_node \
   $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ctest-s-driver.sh \
   $PWD/ctest-s-driver.out \
-  ${LSF_CTEST_TIMEOUT}
+  ${LSF_CTEST_ALL_TIMEOUT}
 
 if [ "${Trilinos_CTEST_RUN_CUDA_AWARE_MPI}" == "1" ]; then
   # Wait a little while before attempting another bsub allocation
@@ -33,5 +34,5 @@ if [ "${Trilinos_CTEST_RUN_CUDA_AWARE_MPI}" == "1" ]; then
   atdm_run_script_on_compute_node \
     $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ctest-s-driver.sh \
     $PWD/ctest-s-driver-cuda-aware-mpi.out \
-    ${LSF_CTEST_TIMEOUT}
+    ${LSF_CTEST_TEST_TIMEOUT}
 fi

--- a/cmake/std/atdm/ats2/trilinos_jsrun
+++ b/cmake/std/atdm/ats2/trilinos_jsrun
@@ -2,7 +2,7 @@
 
 # Globals
 DEBUG_SCRIPT="${DEBUG_SCRIPT-:0}"
-ECHO_CMD="${ECHO_CMD=:0}"
+ECHO_CMD="${ECHO_CMD:-1}"
 np_is_one="false"
 orig_args=("$@")
 args=("$@")
@@ -32,8 +32,8 @@ function evaluate_jsrun_command {
   out_file=$(printf "'%s' " "${args[@]}" | md5sum | awk '{print $1".out"}')
 
   if [ "$ECHO_CMD" == "1" ]; then
-    1>&2 echo "TPETRA_ASSUME_CUDA_AWARE_MPI=${TPETRA_ASSUME_CUDA_AWARE_MPI} BEFORE: jsrun " $(printf "'%s' " "${orig_args[@]}")
-    1>&2 echo "TPETRA_ASSUME_CUDA_AWARE_MPI=${TPETRA_ASSUME_CUDA_AWARE_MPI} AFTER : jsrun " $(printf "'%s' " "${args[@]}")
+    echo "BEFORE: jsrun " $(printf "'%s' " "${orig_args[@]}")
+    echo "AFTER: export TPETRA_ASSUME_CUDA_AWARE_MPI=${TPETRA_ASSUME_CUDA_AWARE_MPI}; jsrun " $(printf "'%s' " "${args[@]}")
   fi
 
   # Set retry, assume JSRUN_WRAPPER_NUM_RETRIES is valid if set

--- a/cmake/std/atdm/ats2/trilinos_jsrun_test_me.sh
+++ b/cmake/std/atdm/ats2/trilinos_jsrun_test_me.sh
@@ -1,31 +1,31 @@
 #!/bin/bash
 
 echo "testing with cuda-aware unset!, should not see -gpu, look for -disable_gpu_hooks"
-ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI="" ./trilinos_jsrun -M -disable_gdr -p 2 hostname 1>/dev/null
-ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI="" ./trilinos_jsrun -M -disable_gdr -p 1 hostname 1>/dev/null
-ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI="" ./trilinos_jsrun -M -disable_gdr -p 1 hostname 1>/dev/null
+TPETRA_ASSUME_CUDA_AWARE_MPI="" ./trilinos_jsrun -M -disable_gdr -p 2 hostname
+TPETRA_ASSUME_CUDA_AWARE_MPI="" ./trilinos_jsrun -M -disable_gdr -p 1 hostname
+TPETRA_ASSUME_CUDA_AWARE_MPI="" ./trilinos_jsrun -M -disable_gdr -p 1 hostname
 
 echo "testing with cuda-aware turned off!, should not see -gpu, look for -disable_gpu_hooks"
-ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI=0 ./trilinos_jsrun -M -disable_gdr -p 2 hostname 1>/dev/null
-ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI=0 ./trilinos_jsrun -M -disable_gdr -p 1 hostname 1>/dev/null
-ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI=0 ./trilinos_jsrun -M -disable_gdr -p 1 hostname 1>/dev/null
+TPETRA_ASSUME_CUDA_AWARE_MPI=0 ./trilinos_jsrun -M -disable_gdr -p 2 hostname
+TPETRA_ASSUME_CUDA_AWARE_MPI=0 ./trilinos_jsrun -M -disable_gdr -p 1 hostname
+TPETRA_ASSUME_CUDA_AWARE_MPI=0 ./trilinos_jsrun -M -disable_gdr -p 1 hostname
 
 echo "testing with cuda-aware turned ON!, should see -gpu if NP>1 and  -disable_gpu_hooks when NP=1"
-ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI=1 ./trilinos_jsrun -M -disable_gdr -p 2 hostname 1>/dev/null
-ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI=1 ./trilinos_jsrun -M -disable_gdr -p 1 hostname 1>/dev/null
-ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI=1 ./trilinos_jsrun -M -disable_gdr -p 1 hostname 1>/dev/null
+TPETRA_ASSUME_CUDA_AWARE_MPI=1 ./trilinos_jsrun -M -disable_gdr -p 2 hostname
+TPETRA_ASSUME_CUDA_AWARE_MPI=1 ./trilinos_jsrun -M -disable_gdr -p 1 hostname
+TPETRA_ASSUME_CUDA_AWARE_MPI=1 ./trilinos_jsrun -M -disable_gdr -p 1 hostname
 
 echo "testing with cuda-aware unset!, should not see -gpu, look for -disable_gpu_hooks"
-ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI="" ./trilinos_jsrun  -p 2 hostname 1>/dev/null
-ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI="" ./trilinos_jsrun  -p 1 hostname 1>/dev/null
-ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI="" ./trilinos_jsrun  -p 1 hostname 1>/dev/null
+TPETRA_ASSUME_CUDA_AWARE_MPI="" ./trilinos_jsrun  -p 2 hostname
+TPETRA_ASSUME_CUDA_AWARE_MPI="" ./trilinos_jsrun  -p 1 hostname
+TPETRA_ASSUME_CUDA_AWARE_MPI="" ./trilinos_jsrun  -p 1 hostname
 
 echo "testing with cuda-aware turned off!, should not see -gpu, look for -disable_gpu_hooks"
-ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI=0 ./trilinos_jsrun  -p 2 hostname 1>/dev/null
-ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI=0 ./trilinos_jsrun  -p 1 hostname 1>/dev/null
-ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI=0 ./trilinos_jsrun  -p 1 hostname 1>/dev/null
+TPETRA_ASSUME_CUDA_AWARE_MPI=0 ./trilinos_jsrun  -p 2 hostname
+TPETRA_ASSUME_CUDA_AWARE_MPI=0 ./trilinos_jsrun  -p 1 hostname
+TPETRA_ASSUME_CUDA_AWARE_MPI=0 ./trilinos_jsrun  -p 1 hostname
 
 echo "testing with cuda-aware turned ON!, should see -gpu if NP>1 and  -disable_gpu_hooks when NP=1"
-ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI=1 ./trilinos_jsrun  -p 2 hostname 1>/dev/null
-ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI=1 ./trilinos_jsrun  -p 1 hostname 1>/dev/null
-ECHO_CMD=1 TPETRA_ASSUME_CUDA_AWARE_MPI=1 ./trilinos_jsrun  -p 1 hostname 1>/dev/null
+TPETRA_ASSUME_CUDA_AWARE_MPI=1 ./trilinos_jsrun  -p 2 hostname
+TPETRA_ASSUME_CUDA_AWARE_MPI=1 ./trilinos_jsrun  -p 1 hostname
+TPETRA_ASSUME_CUDA_AWARE_MPI=1 ./trilinos_jsrun  -p 1 hostname


### PR DESCRIPTION
This is a follow on to PR #6724 

This PR forces the wrapper to print the full jsrun command to stdout so one can easily replicate a run or see exactly what the command was.

This change was tested using provided test script.

@e10harvey @bartlettroscoe 