### PR TITLE
Xpetra: PR to close #6082 and #6765

### DIFF
--- a/packages/muelu/adapters/belos/BelosXpetraStatusTestGenResSubNorm.hpp
+++ b/packages/muelu/adapters/belos/BelosXpetraStatusTestGenResSubNorm.hpp
@@ -288,7 +288,7 @@ class StatusTestGenResSubNorm<Scalar,Xpetra::MultiVector<Scalar,LocalOrdinal,Glo
     typename std::vector<int>::iterator p2 = curLSIdx_.begin();
     for (; p2<curLSIdx_.end(); ++p2) {
       // Check if this index is valid
-      if (*p != -1) {
+      if (*p2 != -1) {
         // Check if any of the residuals are larger than the tolerance.
         if (testvector_[ *p2 ] > tolerance_) {
           // do nothing.


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/xpetra 
@trilinos/muelu 

## Motivation
<!---
Why is this change required?  What problem does it solve? Please link to a github
issue that describes the problem/issue/bug this PR solves.
-->

The motivation behind this PR is to resolve issues #6765 and #6082.

Issue #6082 is resolved by correcting the typo.

Issue #6765 is resolved by computing the static size required to store the merged blocked crs matrix.
To do so, the implementation relies on the member function getNumEntriesInLocalRow which was not fully implemented yet.
The provided implementation of `getNumEntriesInLocalRow` relies on `getMapIndexForGID` to access the block id of a global id.

Therefore, this PR provides:
- An implementation of `getNumEntriesInLocalRow` and `getNumEntriesInGlobalRow` which supports both Thyra and Xpetra mode.
- The computation of the required memory which has to be allocated to store the merged blocked crs matrix.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes
* Blocks
* Is blocked by
* Follows
* Precedes
* Related to
* Part of
* Composed of
-->

## Stakeholder Feedback
<!---
If a github issue includes feedback from the relevant stakeholder(s), please link it.
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

This branch has been tested on the Blake system.

<!---
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
