### PR TITLE
MueLu: fix shadow warning for GCC-8.3.0 build to enable -Werror

### DIFF
--- a/cmake/std/sems/PullRequestGCC8.3.0TestingEnv.sh
+++ b/cmake/std/sems/PullRequestGCC8.3.0TestingEnv.sh
@@ -17,21 +17,8 @@ module load sems-netcdf/4.4.1/exo_parallel
 module load sems-parmetis/4.0.3/parallel
 module load sems-scotch/6.0.3/nopthread_64bit_parallel
 module load sems-superlu/4.3/base
-
-# Load the SEMS CMake Module
-# - One of the SEMS modules will load CMake 3.4.x also,
-#   so this will pull in the SEMS cmake 3.10.3 version
-#   for Trilinos compatibility.
 module load sems-cmake/3.12.2
-
-# Using CMake and Ninja modules from the ATDM project space.
-# SEMS does not yet supply a recent enough version of CMake
-# for the single configure/build/test capability. We are also
-# using a custom version of Ninja (with Fortran support not
-# available in main-line Ninja) to significantly speed up
-# compile and link times.
-module load atdm-env
-module load atdm-ninja_fortran/1.7.2
+module load sems-ninja_fortran/1.8.2
 
 # add the OpenMP environment variable we need
 export OMP_NUM_THREADS=2

--- a/packages/muelu/src/Misc/MueLu_AggregateQualityEstimateFactory_def.hpp
+++ b/packages/muelu/src/Misc/MueLu_AggregateQualityEstimateFactory_def.hpp
@@ -319,8 +319,8 @@ namespace MueLu {
       MT* vl = NULL;
       MT* vr = NULL;
 
-      const char NO='N';
-      myLapack.GGES(NO,NO,NO,ptr2func,aggSize,
+      const char compute_flag ='N';
+      myLapack.GGES(compute_flag,compute_flag,compute_flag,ptr2func,aggSize,
                     topMatrix.values(),aggSize,bottomMatrix.values(),aggSize,&sdim,
                     alpha_real.values(),alpha_imag.values(),beta.values(),vl,aggSize,
                     vr,aggSize,workArray.values(),workArray.length(),bwork,


### PR DESCRIPTION
I am also changing slightly the modules loaded by the gcc-8.3.0 env script

@trilinos/muelu 

## Motivation
These changes will should allow to add "-Werror" flag to MueLu for the gcc/8.3.0 build

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of #6295
* Composed of 


## Stakeholder Feedback
@ZUUL42 when this merges can you check that it fixes the last issue in MueLu?
It would be nice to take care of it quickly to avoid having a new warning creep in.

## Testing
I performed local tests with the gcc/8.3.0 environment and the -Werror manually added to MueLu's compiler flags