### PR TITLE
Set WError for MueLu in GCC 8.3.0 PR build

### DIFF
--- a/cmake/std/PullRequestLinuxGCC8.3.0TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxGCC8.3.0TestingSettings.cmake
@@ -45,7 +45,7 @@ set (Kokkos_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as err
 set (KokkosKernels_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")	
 set (MiniTensor_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")	
 set (ML_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")	
-#set (MueLu_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")	
+set (MueLu_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")	
 set (NOX_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")	
 set (OptiPack_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")	
 set (Pamgen_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror" CACHE STRING "Warnings as errors setting")	


### PR DESCRIPTION
@trilinos/framework 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Set WError for @trilinos/muelu in PR test build GCC 8.3.0
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->
This is a continuation of PR #6824 and moves Issue #6295 forward.

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
This has been tested by running the changes through the PR build it will affect. [CDash](https://testing.sandia.gov/cdash/index.php?project=Trilinos&display=project&filtercount=3&showfilters=1&filtercombine=and&field1=site&compare1=61&value1=ascic166&field2=buildname&compare2=61&value2=PR-gcc_8.3_werror_muelu_on-test-Trilinos_pullrequest_gcc_8.3.0-79&field3=buildstamp&compare3=61&value3=20200218-1633-Experimental)
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->