### PR TITLE
Tpetra: Factor out createPrefix; add verbose output to Map; fix Xpetra build errors

### DIFF
--- a/packages/tpetra/core/src/Tpetra_DistObject_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_DistObject_def.hpp
@@ -53,6 +53,7 @@
 #include "Tpetra_Details_Behavior.hpp"
 #include "Tpetra_Details_checkGlobalError.hpp"
 #include "Tpetra_Details_Profiling.hpp"
+#include "Tpetra_Util.hpp" // Details::createPrefix
 #include "Teuchos_CommHelpers.hpp"
 #include "Teuchos_TypeNameTraits.hpp"
 #include <typeinfo>
@@ -1280,27 +1281,20 @@ namespace Tpetra {
   createPrefix(const char className[],
                const char methodName[]) const
   {
-    int myRank = -1;
     auto map = this->getMap();
-    if (! map.is_null()) {
-      auto comm = map->getComm();
-      if (! comm.is_null()) {
-        myRank = comm->getRank();
-      }
-    }
-    std::ostringstream pfxStrm;
-    pfxStrm << "Proc " << myRank << ": Tpetra::" << className
-            << "::" << methodName << ": ";
-    return std::unique_ptr<std::string>(
-      new std::string(pfxStrm.str()));
+    auto comm = map.is_null() ? Teuchos::null : map->getComm();
+    return Details::createPrefix(
+      comm.getRawPtr(), className, methodName);
   }
 
   template<class DistObjectType>
   void
-  removeEmptyProcessesInPlace (Teuchos::RCP<DistObjectType>& input,
-                               const Teuchos::RCP<const Map<typename DistObjectType::local_ordinal_type,
-                                                            typename DistObjectType::global_ordinal_type,
-                                                            typename DistObjectType::node_type> >& newMap)
+  removeEmptyProcessesInPlace(
+    Teuchos::RCP<DistObjectType>& input,
+    const Teuchos::RCP<const Map<
+      typename DistObjectType::local_ordinal_type,
+      typename DistObjectType::global_ordinal_type,
+      typename DistObjectType::node_type>>& newMap)
   {
     input->removeEmptyProcessesInPlace (newMap);
     if (newMap.is_null ()) { // my process is excluded

--- a/packages/tpetra/core/src/Tpetra_Distributor.cpp
+++ b/packages/tpetra/core/src/Tpetra_Distributor.cpp
@@ -279,12 +279,8 @@ namespace Tpetra {
   Distributor::
   createPrefix(const char methodName[]) const
   {
-    const int myRank = comm_.is_null() ? -1 : comm_->getRank();
-    std::ostringstream pfxStrm;
-    pfxStrm << "Proc " << myRank << ": Tpetra::Distributor::"
-            << methodName << ": ";
-    return std::unique_ptr<std::string>(
-      new std::string(pfxStrm.str()));
+    return Details::createPrefix(
+      comm_.getRawPtr(), "Distributor", methodName);
   }
 
   void

--- a/packages/tpetra/core/src/Tpetra_Map_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Map_decl.hpp
@@ -34,8 +34,6 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
-//
 // ************************************************************************
 // @HEADER
 
@@ -429,8 +427,8 @@ namespace Tpetra {
      *   over this communicator.
      */
     Map (const global_size_t numGlobalElements,
-         const Kokkos::View<const GlobalOrdinal*, device_type>& indexList,
-         const GlobalOrdinal indexBase,
+         const Kokkos::View<const global_ordinal_type*, device_type>& indexList,
+         const global_ordinal_type indexBase,
          const Teuchos::RCP<const Teuchos::Comm<int> >& comm);
 
     /** \brief Constructor with arbitrary (possibly noncontiguous
@@ -463,8 +461,8 @@ namespace Tpetra {
      *   calling process.
      *
      * \param indexListSize [in] Number of valid entries in indexList.
-     *   This is a LocalOrdinal because the number of indices owned by
-     *   each process must fit in LocalOrdinal.
+     *   This is a local_ordinal_type because the number of indices owned by
+     *   each process must fit in local_ordinal_type.
      *
      * \param indexBase [in] The base of the global indices in the
      *   Map.  This must be the same on every process in the given
@@ -475,9 +473,9 @@ namespace Tpetra {
      *   elements.
      */
     Map (const global_size_t numGlobalElements,
-         const GlobalOrdinal indexList[],
-         const LocalOrdinal indexListSize,
-         const GlobalOrdinal indexBase,
+         const global_ordinal_type indexList[],
+         const local_ordinal_type indexListSize,
+         const global_ordinal_type indexBase,
          const Teuchos::RCP<const Teuchos::Comm<int> >& comm);
 
     /** \brief Constructor with arbitrary (possibly noncontiguous
@@ -522,8 +520,8 @@ namespace Tpetra {
      *   over this communicator.
      */
     Map (const global_size_t numGlobalElements,
-         const Teuchos::ArrayView<const GlobalOrdinal>& indexList,
-         const GlobalOrdinal indexBase,
+         const Teuchos::ArrayView<const global_ordinal_type>& indexList,
+         const global_ordinal_type indexBase,
          const Teuchos::RCP<const Teuchos::Comm<int> >& comm);
 
 
@@ -600,7 +598,7 @@ namespace Tpetra {
     /// \note This function should be thread safe and thread scalable,
     ///   assuming that you refer to the Map by value or reference,
     ///   not by Teuchos::RCP.
-    GlobalOrdinal getIndexBase () const {
+    global_ordinal_type getIndexBase () const {
       return indexBase_;
     }
 
@@ -609,8 +607,8 @@ namespace Tpetra {
     /// \note This function should be thread safe and thread scalable,
     ///   assuming that you refer to the Map by value or reference,
     ///   not by Teuchos::RCP.
-    LocalOrdinal getMinLocalIndex () const {
-      return static_cast<LocalOrdinal> (0);
+    local_ordinal_type getMinLocalIndex () const {
+      return static_cast<local_ordinal_type> (0);
     }
 
     /// \brief The maximum local index on the calling process.
@@ -618,16 +616,16 @@ namespace Tpetra {
     /// If this process owns no elements, that is, if
     /// <tt>getNodeNumElements() == 0</tt>, then this method returns
     /// the same value as
-    /// <tt>Teuchos::OrdinalTraits<LocalOrdinal>::invalid()</tt>.
+    /// <tt>Teuchos::OrdinalTraits<local_ordinal_type>::invalid()</tt>.
     ///
     /// \note This function should be thread safe and thread scalable,
     ///   assuming that you refer to the Map by value or reference,
     ///   not by Teuchos::RCP.
-    LocalOrdinal getMaxLocalIndex () const {
+    local_ordinal_type getMaxLocalIndex () const {
       if (this->getNodeNumElements () == 0) {
-        return Tpetra::Details::OrdinalTraits<LocalOrdinal>::invalid ();
+        return Tpetra::Details::OrdinalTraits<local_ordinal_type>::invalid ();
       } else { // Local indices are always zero-based.
-        return static_cast<LocalOrdinal> (this->getNodeNumElements () - 1);
+        return static_cast<local_ordinal_type> (this->getNodeNumElements () - 1);
       }
     }
 
@@ -636,7 +634,7 @@ namespace Tpetra {
     /// \note This function should be thread safe and thread scalable,
     ///   assuming that you refer to the Map by value or reference,
     ///   not by Teuchos::RCP.
-    GlobalOrdinal getMinGlobalIndex () const {
+    global_ordinal_type getMinGlobalIndex () const {
       return minMyGID_;
     }
 
@@ -645,7 +643,7 @@ namespace Tpetra {
     /// \note This function should be thread safe and thread scalable,
     ///   assuming that you refer to the Map by value or reference,
     ///   not by Teuchos::RCP.
-    GlobalOrdinal getMaxGlobalIndex () const {
+    global_ordinal_type getMaxGlobalIndex () const {
       return maxMyGID_;
     }
 
@@ -654,7 +652,7 @@ namespace Tpetra {
     /// \note This function should be thread safe and thread scalable,
     ///   assuming that you refer to the Map by value or reference,
     ///   not by Teuchos::RCP.
-    GlobalOrdinal getMinAllGlobalIndex () const {
+    global_ordinal_type getMinAllGlobalIndex () const {
       return minAllGID_;
     }
 
@@ -663,7 +661,7 @@ namespace Tpetra {
     /// \note This function should be thread safe and thread scalable,
     ///   assuming that you refer to the Map by value or reference,
     ///   not by Teuchos::RCP.
-    GlobalOrdinal getMaxAllGlobalIndex () const {
+    global_ordinal_type getMaxAllGlobalIndex () const {
       return maxAllGID_;
     }
 
@@ -674,12 +672,12 @@ namespace Tpetra {
     /// \return If the given global index is owned by the calling
     ///   process, return the corresponding local index, else return
     ///   the same value as
-    ///   Teuchos::OrdinalTraits<LocalOrdinal>::invalid().
+    ///   Teuchos::OrdinalTraits<local_ordinal_type>::invalid().
     ///
     /// \note This function should be thread safe and thread scalable,
     ///   assuming that you refer to the Map by value or reference,
     ///   not by Teuchos::RCP.
-    LocalOrdinal getLocalElement (GlobalOrdinal globalIndex) const;
+    local_ordinal_type getLocalElement (global_ordinal_type globalIndex) const;
 
     /// \brief The global index corresponding to the given local index.
     ///
@@ -688,8 +686,8 @@ namespace Tpetra {
     /// \return If the given local index is valid on the calling
     ///   process, return the corresponding global index, else return
     ///   the same value as
-    ///   Teuchos::OrdinalTraits<GlobalOrdinal>::invalid().
-    GlobalOrdinal getGlobalElement (LocalOrdinal localIndex) const;
+    ///   Teuchos::OrdinalTraits<global_ordinal_type>::invalid().
+    global_ordinal_type getGlobalElement (local_ordinal_type localIndex) const;
 
     /// \brief Get the local Map for Kokkos kernels.
     ///
@@ -715,7 +713,7 @@ namespace Tpetra {
     ///   index on the process that owns them) corresponding to the
     ///   given global indices.  If a global index does not have a
     ///   local index, the resulting local index has the same value as
-    ///   Teuchos::OrdinalTraits<LocalOrdinal>::invalid().
+    ///   Teuchos::OrdinalTraits<local_ordinal_type>::invalid().
     ///
     /// \pre nodeIDList.size() == GIDList.size()
     /// \pre LIDList.size() == GIDList.size()
@@ -727,9 +725,9 @@ namespace Tpetra {
     /// \note This is crucial technology used in Export, Import,
     ///   CrsGraph, and CrsMatrix.
     LookupStatus
-    getRemoteIndexList (const Teuchos::ArrayView<const GlobalOrdinal>& GIDList,
+    getRemoteIndexList (const Teuchos::ArrayView<const global_ordinal_type>& GIDList,
                         const Teuchos::ArrayView<                int>& nodeIDList,
-                        const Teuchos::ArrayView<       LocalOrdinal>& LIDList) const;
+                        const Teuchos::ArrayView<       local_ordinal_type>& LIDList) const;
 
     /// \brief Return the process ranks for the given global indices.
     ///
@@ -755,7 +753,7 @@ namespace Tpetra {
     ///   requires communication.  This is crucial technology used in
     ///   Export, Import, CrsGraph, and CrsMatrix.
     LookupStatus
-    getRemoteIndexList (const Teuchos::ArrayView<const GlobalOrdinal> & GIDList,
+    getRemoteIndexList (const Teuchos::ArrayView<const global_ordinal_type> & GIDList,
                         const Teuchos::ArrayView<                int> & nodeIDList) const;
 
   private:
@@ -770,7 +768,7 @@ namespace Tpetra {
     /// exists only so that we could avoid needing to declare lgMap_
     /// before declaring the getMyGlobalIndices() method.  That would
     /// have made this class declaration harder to read.
-    typedef Kokkos::View<const GlobalOrdinal*,
+    typedef Kokkos::View<const global_ordinal_type*,
                          Kokkos::LayoutLeft,
                          device_type> global_indices_array_type;
 
@@ -779,8 +777,8 @@ namespace Tpetra {
     ///
     /// The returned "view" has some type that looks like
     /// <ul>
-    /// <li> <tt> Kokkos::View<const GlobalOrdinal*, ...> </tt> or </li>
-    /// <li> <tt> Teuchos::ArrayView<const GlobalOrdinal> </tt> </li>
+    /// <li> <tt> Kokkos::View<const global_ordinal_type*, ...> </tt> or </li>
+    /// <li> <tt> Teuchos::ArrayView<const global_ordinal_type> </tt> </li>
     /// </ul>
     /// It implements operator[] and the size() method, and behaves as
     /// a one-dimensional array.  You may <i>not</i> modify its
@@ -806,7 +804,7 @@ namespace Tpetra {
     /// and cache the list of global indices for later use.  Beware of
     /// calling this if the calling process owns a very large number
     /// of global indices.
-    Teuchos::ArrayView<const GlobalOrdinal> getNodeElementList() const;
+    Teuchos::ArrayView<const global_ordinal_type> getNodeElementList() const;
 
     //@}
     //! @name Boolean tests
@@ -818,7 +816,7 @@ namespace Tpetra {
     /// \note This function should be thread safe and thread scalable,
     ///   assuming that you refer to the Map by value or reference,
     ///   not by Teuchos::RCP.
-    bool isNodeLocalElement (LocalOrdinal localIndex) const;
+    bool isNodeLocalElement (local_ordinal_type localIndex) const;
 
     /// \brief Whether the given global index is owned by this Map on
     ///   the calling process.
@@ -826,7 +824,7 @@ namespace Tpetra {
     /// \note This function should be thread safe and thread scalable,
     ///   assuming that you refer to the Map by value or reference,
     ///   not by Teuchos::RCP.
-    bool isNodeGlobalElement (GlobalOrdinal globalIndex) const;
+    bool isNodeGlobalElement (global_ordinal_type globalIndex) const;
 
     /// \brief Whether the range of global indices is uniform.
     ///
@@ -895,7 +893,7 @@ namespace Tpetra {
     /// communicator and this Map's communicator have different
     /// numbers of processes.  This method must be called collectively
     /// over this Map's communicator.
-    bool isCompatible (const Map<LocalOrdinal,GlobalOrdinal,Node> &map) const;
+    bool isCompatible (const Map<local_ordinal_type,global_ordinal_type,Node> &map) const;
 
     /// \brief True if and only if \c map is identical to this Map.
     ///
@@ -927,13 +925,13 @@ namespace Tpetra {
     /// communicator and this Map's communicator have different
     /// numbers of processes.  This method must be called collectively
     /// over this Map's communicator.
-    bool isSameAs (const Map<LocalOrdinal,GlobalOrdinal,Node> &map) const;
+    bool isSameAs (const Map<local_ordinal_type,global_ordinal_type,Node> &map) const;
 
     /// \brief Is this Map locally the same as the input Map?
     ///
     /// "Locally the same" means that on the calling process, the two
     /// Maps' global indices are the same and occur in the same order.
-    bool locallySameAs (const Map<LocalOrdinal, GlobalOrdinal, node_type>& map) const;
+    bool locallySameAs (const Map<local_ordinal_type, global_ordinal_type, node_type>& map) const;
 
     /// \brief True if and only if \c map is locally fitted to this Map.
     ///
@@ -950,7 +948,7 @@ namespace Tpetra {
     /// some Export or Import (communication) operations. Tpetra
     /// could use this, for example, in optimizing its sparse
     /// matrix-vector multiply.
-    bool isLocallyFitted (const Map<LocalOrdinal, GlobalOrdinal, Node>& map) const;
+    bool isLocallyFitted (const Map<local_ordinal_type, global_ordinal_type, Node>& map) const;
 
     //@}
     //! Accessors for the Teuchos::Comm and Kokkos Node objects.
@@ -1044,7 +1042,7 @@ namespace Tpetra {
     /// intentionally leave some processes with zero rows.  Removing
     /// processes with zero rows makes the all-reduces and other
     /// communication operations cheaper.
-    Teuchos::RCP<const Map<LocalOrdinal, GlobalOrdinal, Node> >
+    Teuchos::RCP<const Map<local_ordinal_type, global_ordinal_type, Node> >
     removeEmptyProcesses () const;
 
     /// \brief Replace this Map's communicator with a subset communicator.
@@ -1074,7 +1072,7 @@ namespace Tpetra {
     ///   same graph.  For the latter three Maps, one would in general
     ///   use this method instead of removeEmptyProcesses(), giving
     ///   the new row Map's communicator to this method.
-    Teuchos::RCP<const Map<LocalOrdinal, GlobalOrdinal, Node> >
+    Teuchos::RCP<const Map<local_ordinal_type, global_ordinal_type, Node> >
     replaceCommWithSubset (const Teuchos::RCP<const Teuchos::Comm<int> >& newComm) const;
     //@}
 
@@ -1128,25 +1126,29 @@ namespace Tpetra {
     ///   over all processes in the given communicator.  In a release
     ///   build: 0 (zero).
     global_size_t
-    initialNonuniformDebugCheck (const global_size_t numGlobalElements,
-                                 const size_t numLocalElements,
-                                 const GlobalOrdinal indexBase,
-                                 const Teuchos::RCP<const Teuchos::Comm<int> >& comm) const;
+    initialNonuniformDebugCheck(
+      const char errorMessagePrefix[],
+      const global_size_t numGlobalElements,
+      const size_t numLocalElements,
+      const global_ordinal_type indexBase,
+      const Teuchos::RCP<const Teuchos::Comm<int>>& comm) const;
 
     void
-    initWithNonownedHostIndexList (const global_size_t numGlobalElements,
-                                   const Kokkos::View<const GlobalOrdinal*,
-                                     Kokkos::LayoutLeft,
-                                     Kokkos::HostSpace,
-                                     Kokkos::MemoryUnmanaged>& entryList,
-                                   const GlobalOrdinal indexBase,
-                                   const Teuchos::RCP<const Teuchos::Comm<int> >& comm);
+    initWithNonownedHostIndexList(
+      const char errorMessagePrefix[],
+      const global_size_t numGlobalElements,
+      const Kokkos::View<const global_ordinal_type*,
+        Kokkos::LayoutLeft,
+        Kokkos::HostSpace,
+        Kokkos::MemoryUnmanaged>& entryList,
+      const global_ordinal_type indexBase,
+      const Teuchos::RCP<const Teuchos::Comm<int>>& comm);
 
     //! The communicator over which this Map is distributed.
     Teuchos::RCP<const Teuchos::Comm<int> > comm_;
 
     //! The index base for global indices in this Map.
-    GlobalOrdinal indexBase_;
+    global_ordinal_type indexBase_;
 
     /// \brief The total number of global indices in this Map over all
     ///   processes in its communicator \c comm (see above).
@@ -1156,18 +1158,18 @@ namespace Tpetra {
     size_t numLocalElements_;
 
     //! The min global index owned by this process.
-    GlobalOrdinal minMyGID_;
+    global_ordinal_type minMyGID_;
 
     //! The max global index owned by this process.
-    GlobalOrdinal maxMyGID_;
+    global_ordinal_type maxMyGID_;
 
     /// \brief The min global index in this Map over all processes in
     ///   its communicator \c comm (see above).
-    GlobalOrdinal minAllGID_;
+    global_ordinal_type minAllGID_;
 
     /// \brief The max global index in this Map over all processes in
     ///   its communicator \c comm (see above).
-    GlobalOrdinal maxAllGID_;
+    global_ordinal_type maxAllGID_;
 
     /// \brief First contiguous GID.
     ///
@@ -1175,7 +1177,7 @@ namespace Tpetra {
     /// noncontiguous constructor.  In that case, if the calling
     /// process owns at least one GID, this will always equal that
     /// first GID in the list of GIDs given to the constructor.
-    GlobalOrdinal firstContiguousGID_;
+    global_ordinal_type firstContiguousGID_;
 
     /// \brief Last contiguous GID.
     ///
@@ -1190,7 +1192,7 @@ namespace Tpetra {
     /// 45.  If the list is [42, 100, 1001, 1002, 1003],
     /// firstContiguousGID_ will be 42 and lastContiguousGID_ will
     /// also be 42.
-    GlobalOrdinal lastContiguousGID_;
+    global_ordinal_type lastContiguousGID_;
 
     /// \brief Whether the range of global indices is uniform.
     ///
@@ -1244,7 +1246,7 @@ namespace Tpetra {
     /// LayoutRight is the default on non-CUDA Devices, and we want to
     /// make sure we catch assignment or copying from the default to
     /// the nondefault layout.
-    mutable Kokkos::View<const GlobalOrdinal*,
+    mutable Kokkos::View<const global_ordinal_type*,
                          Kokkos::LayoutLeft,
                          device_type> lgMap_;
 
@@ -1256,13 +1258,13 @@ namespace Tpetra {
     /// requires a host View) if necessary (only noncontiguous Maps
     /// need this).
 #ifndef SWIG
-    mutable Kokkos::View<const GlobalOrdinal*,
+    mutable Kokkos::View<const global_ordinal_type*,
                          Kokkos::LayoutLeft,
                          Kokkos::HostSpace> lgMapHost_;
 #endif
 
     //! Type of a mapping from global IDs to local IDs.
-    typedef ::Tpetra::Details::FixedHashTable<GlobalOrdinal, LocalOrdinal, device_type>
+    typedef ::Tpetra::Details::FixedHashTable<global_ordinal_type, local_ordinal_type, device_type>
       global_to_local_table_type;
 
     /// \brief A mapping from global IDs to local IDs.
@@ -1315,8 +1317,11 @@ namespace Tpetra {
     ///   null, then previously existing views of a Map could not
     ///   benefit from lazy creation of the Directory.
     ///
-    mutable Teuchos::RCP<Directory<LocalOrdinal,GlobalOrdinal,Node> > directory_;
-
+    mutable Teuchos::RCP<
+      Directory<
+        local_ordinal_type, global_ordinal_type, node_type
+        >
+      > directory_;
   }; // Map class
 
   /// \brief Nonmember constructor for a locally replicated Map with

--- a/packages/tpetra/core/src/Tpetra_Util.cpp
+++ b/packages/tpetra/core/src/Tpetra_Util.cpp
@@ -34,12 +34,11 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
-// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
-//
 // ************************************************************************
 // @HEADER
 
-#include <Tpetra_Util.hpp>
+#include "Tpetra_Util.hpp"
+#include "Teuchos_Comm.hpp"
 
 namespace Tpetra {
 namespace Details {
@@ -98,7 +97,34 @@ congruent (const Teuchos::Comm<int>& comm1,
 #endif // HAVE_MPI
 }
 
+std::unique_ptr<std::string>
+createPrefix(const int myRank,
+             const char prefix[])
+{
+  std::ostringstream os;
+  os << "Proc " << myRank << ": " << prefix << ": ";
+  return std::unique_ptr<std::string>(new std::string(os.str()));
+}
+
+std::unique_ptr<std::string>
+createPrefix(const Teuchos::Comm<int>* comm,
+             const char functionName[])
+{
+  const int myRank = comm == nullptr ? -1 : comm->getRank();
+  const std::string prefix = std::string("Tpetra::") + functionName;
+  return createPrefix(myRank, prefix.c_str());
+}
+
+std::unique_ptr<std::string>
+createPrefix(const Teuchos::Comm<int>* comm,
+             const char className[],
+             const char methodName[])
+{
+  const int myRank = comm == nullptr ? -1 : comm->getRank();
+  const std::string prefix = std::string("Tpetra::") +
+    className + std::string("::") + methodName;
+  return createPrefix(myRank, prefix.c_str());
+}
+
 } // namespace Details
 } // namespace Tpetra
-
-

--- a/packages/tpetra/core/src/Tpetra_Util.hpp
+++ b/packages/tpetra/core/src/Tpetra_Util.hpp
@@ -58,6 +58,7 @@
 #include "Teuchos_Utils.hpp"
 #include <algorithm>
 #include <iterator>
+#include <memory>
 #include <ostream>
 #include <sstream>
 
@@ -988,6 +989,35 @@ namespace Tpetra {
       }
       out << "]";
     }
+
+    /// \brief Create string prefix for each line of verbose output.
+    ///
+    /// \return "Proc ${myRank}: ${prefix}: " (using Python notation).
+    std::unique_ptr<std::string>
+    createPrefix(const int myRank,
+                 const char prefix[]);
+
+    /// \brief Create string prefix for each line of verbose output,
+    ///   for a Tpetra function (not a class or instance method).
+    ///
+    /// \param comm [in] May be null; if not, the communicator from
+    ///   which to draw the (MPI) process rank.
+    ///
+    /// \param functionName [in] Name of the function.
+    std::unique_ptr<std::string>
+    createPrefix(const Teuchos::Comm<int>* comm,
+                 const char functionName[]);
+
+    /// \brief Create string prefix for each line of verbose output,
+    ///   for a method of a Tpetra class.
+    ///
+    /// \param className [in] Name of the class.
+    ///
+    /// \param methodName [in] Name of the (class or instance) method.
+    std::unique_ptr<std::string>
+    createPrefix(const Teuchos::Comm<int>*,
+                 const char className[],
+                 const char methodName[]);
 
   } // namespace Details
 } // namespace Tpetra

--- a/packages/tpetra/core/test/Utils/CMakeLists.txt
+++ b/packages/tpetra/core/test/Utils/CMakeLists.txt
@@ -145,3 +145,27 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   NUM_MPI_PROCS 1
   STANDARD_PASS_OUTPUT
   )
+
+TRIBITS_ADD_EXECUTABLE(
+  createPrefix
+  SOURCES
+    createPrefix
+    ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  COMM serial mpi
+  )
+# In an MPI build, I'd like at least 2 processes, in order to test
+# that the string prefix for verbose output includes the right rank
+# and doesn't just print 0.
+TRIBITS_ADD_TEST(
+  createPrefix
+  NAME createPrefix_MPI
+  COMM mpi
+  NUM_MPI_PROCS 2
+  STANDARD_PASS_OUTPUT
+  )
+TRIBITS_ADD_TEST(
+  createPrefix
+  NAME createPrefix_no_MPI
+  COMM serial
+  STANDARD_PASS_OUTPUT
+  )

--- a/packages/tpetra/core/test/Utils/createPrefix.cpp
+++ b/packages/tpetra/core/test/Utils/createPrefix.cpp
@@ -1,0 +1,108 @@
+/*
+// @HEADER
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services Package
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// ************************************************************************
+// @HEADER
+*/
+
+#include "Tpetra_TestingUtilities.hpp"
+#include "Tpetra_Util.hpp"
+#include <sstream>
+
+namespace { // (anonymous)
+
+  TEUCHOS_UNIT_TEST( TpetraUtil, CreatePrefix )
+  {
+    using Tpetra::TestingUtilities::getDefaultComm;
+    using Tpetra::Details::createPrefix;
+    using std::endl;
+
+    out << "Test Tpetra::Details::createPrefix" << endl;
+    Teuchos::OSTab tab1 (out);
+
+    auto comm = getDefaultComm();
+    TEST_ASSERT( comm.getRawPtr() != nullptr );
+    const int myRank = comm->getRank();
+
+    {
+      // This overload takes any integer and any string.
+      std::unique_ptr<std::string> pfx =
+        createPrefix(418, "HI FOLKS");
+      TEST_ASSERT( pfx.get() != nullptr );
+      std::ostringstream os;
+      os << "Proc 418: HI FOLKS: ";
+      TEST_EQUALITY( *pfx, os.str() );
+    }
+
+    {
+      std::unique_ptr<std::string> pfx =
+        createPrefix(comm.getRawPtr(), "myFunc");
+      TEST_ASSERT( pfx.get() != nullptr );
+      std::ostringstream os;
+      os << "Proc " << myRank << ": Tpetra::myFunc: ";
+      TEST_EQUALITY( *pfx, os.str() );
+    }
+
+    {
+      std::unique_ptr<std::string> pfx =
+        createPrefix(nullptr, "myFunc");
+      TEST_ASSERT( pfx.get() != nullptr );
+      std::ostringstream os;
+      os << "Proc -1: Tpetra::myFunc: ";
+      TEST_EQUALITY( *pfx, os.str() );
+    }
+
+    {
+      std::unique_ptr<std::string> pfx =
+        createPrefix(comm.getRawPtr(), "MyClass", "myMethod");
+      TEST_ASSERT( pfx.get() != nullptr );
+      std::ostringstream os;
+      os << "Proc " << myRank << ": Tpetra::MyClass::myMethod: ";
+      TEST_EQUALITY( *pfx, os.str() );
+    }
+
+    {
+      std::unique_ptr<std::string> pfx =
+        createPrefix(nullptr, "MyClass", "myMethod");
+      TEST_ASSERT( pfx.get() != nullptr );
+      std::ostringstream os;
+      os << "Proc -1: Tpetra::MyClass::myMethod: ";
+      TEST_EQUALITY( *pfx, os.str() );
+    }
+  }
+
+} // namespace (anonymous)

--- a/packages/xpetra/test/CrsMatrix/CrsMatrix_UnitTests.cpp
+++ b/packages/xpetra/test/CrsMatrix/CrsMatrix_UnitTests.cpp
@@ -63,6 +63,7 @@
 #include <Xpetra_Matrix.hpp>
 #include <Xpetra_CrsMatrix.hpp>
 #include <Xpetra_Exceptions.hpp>
+#include "Teuchos_ScalarTraits.hpp"
 
 namespace {
 
@@ -244,6 +245,7 @@ namespace {
     typedef Xpetra::MapFactory<LO, GO, Node> MapFactoryClass;
     typedef Xpetra::Vector<Scalar, LO, GO, Node> VectorClass;
     typedef Xpetra::VectorFactory<Scalar, LO, GO, Node> VectorFactoryClass;
+    const Scalar ZERO = Teuchos::ScalarTraits<Scalar>::zero();
 
     // get a comm and node
     RCP<const Teuchos::Comm<int> > comm = getDefaultComm();
@@ -299,8 +301,8 @@ namespace {
         Teuchos::ArrayView< const Scalar > values;
         A->getLocalRowView(map->getLocalElement(MyGlobalElements[i]), indices, values);
         TEST_EQUALITY(indices.size(), 2);
-        TEST_EQUALITY(values[0], 0.0);
-        TEST_EQUALITY(values[1], 0.0);
+        TEST_EQUALITY(values[0], ZERO);
+        TEST_EQUALITY(values[1], ZERO);
       }
       else if (MyGlobalElements[i] == NumGlobalElements - 1) {
         if(map->isNodeGlobalElement(MyGlobalElements[i])) {
@@ -334,6 +336,8 @@ namespace {
     typedef Xpetra::MapFactory<LO, GO, Node> MapFactoryClass;
     typedef Xpetra::Vector<Scalar, LO, GO, Node> VectorClass;
     typedef Xpetra::VectorFactory<Scalar, LO, GO, Node> VectorFactoryClass;
+    const Scalar ZERO = Teuchos::ScalarTraits<Scalar>::zero();
+    const Scalar ONE = Teuchos::ScalarTraits<Scalar>::one();
 
     // get a comm and node
     RCP<const Teuchos::Comm<int> > comm = getDefaultComm();
@@ -389,8 +393,8 @@ namespace {
         Teuchos::ArrayView< const Scalar > values;
         A->getLocalRowView(map->getLocalElement(MyGlobalElements[i]), indices, values);
         TEST_EQUALITY(indices.size(), 2);
-        TEST_EQUALITY(values[0], 0.0);
-        TEST_EQUALITY(values[1], -1.0);
+        TEST_EQUALITY(values[0], ZERO);
+        TEST_EQUALITY(values[1], -ONE);
       }
       else if (MyGlobalElements[i] == NumGlobalElements - 1) {
         if(map->isNodeGlobalElement(MyGlobalElements[i])) {
@@ -603,6 +607,8 @@ namespace {
     typedef Teuchos::ScalarTraits<Scalar> STS;
     typedef typename STS::magnitudeType MT;
     typedef Teuchos::ScalarTraits<MT> STM;
+    const Scalar ONE = STS::one();
+    const Scalar FIVE = ONE + ONE + ONE + ONE + ONE;
 
     out << "Tpetra replaceLocalValues test" << endl;
 
@@ -681,7 +687,7 @@ namespace {
 
         if (numEntOut == static_cast<size_t> (1)) {
           TEST_EQUALITY( ind[0], 0 );
-          TEST_EQUALITY( val[0], 5.0 );
+          TEST_EQUALITY( val[0], FIVE );
         }
       }
     }
@@ -712,7 +718,7 @@ namespace {
 
         if (numEntOut == static_cast<size_t> (1)) {
           TEST_EQUALITY( ind[0], 0 );
-          TEST_EQUALITY( val[0], 5.0 );
+          TEST_EQUALITY( val[0], FIVE );
         }
       }
     }
@@ -752,12 +758,12 @@ namespace {
       TEST_ASSERT( outData.size () == static_cast<size_type>(rangeMap->getNodeNumElements()) );
       if (outData.size () == static_cast<size_type>(rangeMap->getNodeNumElements()) &&
           outData.size () > static_cast<size_type> (0)) {
-        TEST_EQUALITY( outData[0], 5.0 );
+        TEST_EQUALITY( outData[0], FIVE );
       }
       if (rangeMap->getNodeNumElements () > static_cast<size_t> (1)) {
         bool allOnes = true;
-        for (size_type k = 1; k < static_cast<size_type>(rangeMap->getNodeNumElements()); ++k) {
-          if (!(outData[k] == 1.0)) {
+        for (size_t k = 1; k < size_t(rangeMap->getNodeNumElements()); ++k) {
+          if (outData[k] != ONE) {
             allOnes = false;
           }
         }
@@ -771,12 +777,12 @@ namespace {
       TEST_ASSERT( outDataNonConst.size () == static_cast<size_type>(rangeMap->getNodeNumElements()) );
       if (outDataNonConst.size() == static_cast<size_type>(rangeMap->getNodeNumElements()) &&
           outDataNonConst.size () > static_cast<size_type> (0)) {
-        TEST_EQUALITY( outDataNonConst[0], 5.0 );
+        TEST_EQUALITY( outDataNonConst[0], FIVE );
       }
       if (rangeMap->getNodeNumElements () > static_cast<size_t> (1)) {
         bool allOnes = true;
         for (size_type k = 1; k < static_cast<size_type>(rangeMap->getNodeNumElements()); ++k) {
-          if (!(outDataNonConst[k] == 1.0)) {
+          if (outDataNonConst[k] != ONE) {
             allOnes = false;
           }
         }
@@ -802,6 +808,7 @@ namespace {
 
     vec_sol->update(-1.0,*vectest,1.0);
 
+    // FIXME (mfh 23 Feb 2020) Tolerance should depend on Scalar here.
     TEUCHOS_TEST_COMPARE(vec_sol->norm2(), <, 1e-16, out, success);
 
     // Make sure that all processes got this far.
@@ -1228,6 +1235,9 @@ namespace {
     //typedef typename local_matrix_type::size_type size_type;
     typedef typename local_matrix_type::value_type value_type;
     typedef typename local_matrix_type::ordinal_type ordinal_type;
+    using STS = Teuchos::ScalarTraits<Scalar>;
+    const Scalar ONE = STS::one();
+    using mag_type = typename STS::magnitudeType;
 
     // get a comm and node
     RCP<const Teuchos::Comm<int> > comm = getDefaultComm();
@@ -1272,7 +1282,7 @@ namespace {
         LO       cc = rowview.colidx (c);
         TEST_EQUALITY(rowview.length, 1);
         TEST_EQUALITY(cc, r);
-        TEST_EQUALITY(vv, 1.0);
+        TEST_EQUALITY(vv, ONE);
       }
     }
 
@@ -1280,7 +1290,7 @@ namespace {
     Teuchos::ArrayView< const Scalar > values;
     A->getLocalRowView(0, indices, values);
     TEST_EQUALITY(indices.size(), 1);
-    TEST_EQUALITY(values[0], 1.0);
+    TEST_EQUALITY(values[0], ONE);
 
     /////////////////////////////////////////
 
@@ -1291,7 +1301,11 @@ namespace {
 
     A->getLocalRowView(0, indices, values);
     TEST_EQUALITY(indices.size(), 1);
-    TEST_EQUALITY(values[0], 42.0);  // changes in the view also changes matrix values
+
+    // NOTE (mfh 23 Feb 2020) You can't always convert double to
+    // Scalar directly; e.g., with Scalar=complex<float>.
+    const Scalar FORTY_TWO = Scalar(mag_type(42.0));
+    TEST_EQUALITY(values[0], FORTY_TWO);  // changes in the view also changes matrix values
 
     A->resumeFill();
     A->setAllToScalar(-123.4);
@@ -1310,7 +1324,10 @@ namespace {
         LO       cc = rowview.colidx (c);
         TEST_EQUALITY(rowview.length, 1);
         TEST_EQUALITY(cc, r);
-        TEST_EQUALITY(vv, -123.4);
+        // NOTE (mfh 23 Feb 2020) You can't always convert double to
+        // Scalar directly; e.g., with Scalar=complex<float>.
+        const Scalar expected_vv = Scalar(mag_type(-123.4));
+        TEST_EQUALITY(vv, expected_vv);
       }
     }
 #endif
@@ -1494,11 +1511,15 @@ namespace {
       Teuchos::ArrayView<const LO> indices;
       Teuchos::ArrayView<const Scalar> vals;
       mat->getLocalRowView(row, indices, vals);
-      for(size_t col = 0; col < static_cast<size_t>(indices.size()); col++) {
+      for(size_t col = 0; col < size_t(indices.size()); col++) {
+        using STS = Teuchos::ScalarTraits<Scalar>;
+        const Scalar ONE = STS::one();
+        const Scalar TWO = ONE + ONE;
+
         if(grid == colMap->getGlobalElement(indices[col])) {
-          TEST_EQUALITY(vals[col],2.0);
+          TEST_EQUALITY(vals[col], TWO);
         } else {
-          TEST_EQUALITY(vals[col],-1.0);
+          TEST_EQUALITY(vals[col], -ONE);
         }
       }
     }
@@ -1578,4 +1599,3 @@ UNIT_TEST_GROUP_ORDINAL_KOKKOS( double, int, LongLong, EpetraNode )
 #endif
 
 }
-


### PR DESCRIPTION
@trilinos/tpetra @trilinos/xpetra 

1. Add more verbose output to Map.
2. Make more of Map's debug checks controlled by the run-time value of `Behavior::debug("Map")`, rather than by the `HAVE_TPETRA_DEBUG` macro.
3. Reduce code duplication and improve testing by factoring out `Tpetra::Details::createPrefix` function (with overloads); add tests for all the overloads.
4. Fix Xpetra test build errors with `Scalar=complex<float>`.
5. Fix Xpetra Map test so that it doesn't assume that `HAVE_TPETRA_DEBUG` specifies whether Map does debug checking.

## Motivation

Sierra TF is moving towards production-ization of Tpetra-based solvers.  This means we'll need more debugging.  We've seen errors in MueLu setup, so we want more verbose debug output for those parts of Tpetra that matter for MueLu setup, like Map and Directory.  We also want it to be easier to control verbose output and debug checks at run time, since it takes so long to build Trilinos.

## Stakeholder Feedback

See above Sierra TF notes.

## Testing

Mac Clang + OpenMPI.