### PR TITLE
trsv: workaround intel/19.0.4 interal compiler error

### DIFF
--- a/packages/kokkos-kernels/src/sparse/impl/KokkosSparse_trsv_impl.hpp
+++ b/packages/kokkos-kernels/src/sparse/impl/KokkosSparse_trsv_impl.hpp
@@ -138,7 +138,7 @@ lowerTriSolveCsr (RangeMultiVectorType X,
       }
     } // for each entry A_rc in the current row r
     for (local_ordinal_type j = 0; j < numVecs; ++j) {
-      X(r, j) /= A_rr;
+      X(r, j) = X(r, j) / A_rr;
     }
   } // for each row r
 }
@@ -250,7 +250,7 @@ upperTriSolveCsr (RangeMultiVectorType X,
       }
     } // for each entry A_rc in the current row r
     for (local_ordinal_type j = 0; j < numVecs; ++j) {
-      X(r, j) /= A_rr;
+      X(r, j) = X(r, j) / A_rr;
     }
   } // for each row r
 
@@ -272,7 +272,7 @@ upperTriSolveCsr (RangeMultiVectorType X,
       }
     } // for each entry A_rc in the current row r
     for (local_ordinal_type j = 0; j < numVecs; ++j) {
-      X(r, j) /= A_rr;
+      X(r, j) = X(r, j) / A_rr;
     }
   } // last iteration: r = 0
 }
@@ -395,7 +395,7 @@ upperTriSolveCsc (RangeMultiVectorType X,
       }
     } // for each entry A_rc in the current column c
     for (local_ordinal_type j = 0; j < numVecs; ++j) {
-      X(c, j) /= A_cc;
+      X(c, j) = X(c, j) / A_cc;
     }
   } // for each column c
 
@@ -421,7 +421,7 @@ upperTriSolveCsc (RangeMultiVectorType X,
       }
     } // for each entry A_rc in the current column c
     for (local_ordinal_type j = 0; j < numVecs; ++j) {
-      X(c, j) /= A_cc;
+      X(c, j) = X(c, j) / A_cc;
     }
   }
 }
@@ -584,7 +584,7 @@ upperTriSolveCscConj (RangeMultiVectorType X,
       }
     } // for each entry A_rc in the current column c
     for (local_ordinal_type j = 0; j < numVecs; ++j) {
-      X(c, j) /= A_cc;
+      X(c, j) = X(c, j) / A_cc;
     }
   } // for each column c
 
@@ -610,7 +610,7 @@ upperTriSolveCscConj (RangeMultiVectorType X,
       }
     } // for each entry A_rc in the current column c
     for (local_ordinal_type j = 0; j < numVecs; ++j) {
-      X(c, j) /= A_cc;
+      X(c, j) = X(c, j) / A_cc;
     }
   }
 }
@@ -662,7 +662,7 @@ lowerTriSolveCsc (RangeMultiVectorType X,
       }
     } // for each entry A_rc in the current column c
     for (local_ordinal_type j = 0; j < numVecs; ++j) {
-      X(c, j) /= A_cc;
+      X(c, j) = X(c, j) / A_cc;
     }
   } // for each column c
 }
@@ -754,7 +754,7 @@ lowerTriSolveCscConj (RangeMultiVectorType X,
       }
     } // for each entry A_rc in the current column c
     for (local_ordinal_type j = 0; j < numVecs; ++j) {
-      X(c, j) /= A_cc;
+      X(c, j) = X(c, j) / A_cc;
     }
   } // for each column c
 }


### PR DESCRIPTION
addresses issue kokkos/kokkos-kernels#607 reported by @mwglass
replace /= compound assignment operators

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/kokkos-kernels

## Motivation
Workaround intel/19.0.4 internal compiler error

This patch mirrors PR kokkos/kokkos-kernels#608
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

Reproduced error (kokkos-kernels standalone build) and tested fixes with intel/19.0.4 and sierra-devel module environment on Mutrino to confirm the fix.


<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->