### PR TITLE
Kokkos: Make sure semicolons are not deleted in KokkosConfig_install.cmake

### DIFF
--- a/packages/kokkos/cmake/kokkos_install.cmake
+++ b/packages/kokkos/cmake/kokkos_install.cmake
@@ -31,7 +31,7 @@ IF (NOT KOKKOS_HAS_TRILINOS)
 ELSE()
   CONFIGURE_FILE(cmake/KokkosConfigCommon.cmake.in ${Kokkos_BINARY_DIR}/KokkosConfigCommon.cmake @ONLY)
   file(READ ${Kokkos_BINARY_DIR}/KokkosConfigCommon.cmake KOKKOS_CONFIG_COMMON)
-  file(APPEND "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/KokkosConfig_install.cmake" ${KOKKOS_CONFIG_COMMON})
+  file(APPEND "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/KokkosConfig_install.cmake" "${KOKKOS_CONFIG_COMMON}")
 ENDIF()
 
 # build and install pkgconfig file


### PR DESCRIPTION
@trilinos/kokkos

## Motivation
Cherry-picking https://github.com/kokkos/kokkos/pull/2777: Without this, e.g. devices are not separated by semicolons.

## Testing
Checking with a third-party library.