### PR TITLE
tpetra:  #6883 Removing behavior test with default values controlled by CMake options

### DIFF
--- a/packages/tpetra/core/test/Behavior/Behavior_Default.cpp
+++ b/packages/tpetra/core/test/Behavior/Behavior_Default.cpp
@@ -61,25 +61,9 @@ namespace {
 
 TEUCHOS_UNIT_TEST(Behavior, Default)
 {
-#ifdef HAVE_TPETRA_DEBUG
-  bool debug_default = true;
-#else
-  bool debug_default = false;
-#endif
-  bool dbg = Tpetra::Details::Behavior::debug();
-  TEUCHOS_TEST_ASSERT(dbg==debug_default, out, success);
-
   bool verbose_default = false;
   bool verb = Tpetra::Details::Behavior::verbose();
   TEUCHOS_TEST_ASSERT(verb==verbose_default, out, success);
-
-#ifdef TPETRA_ASSUME_CUDA_AWARE_MPI
-  bool cuda_aware_mpi_default = true;
-#else
-  bool cuda_aware_mpi_default = false;
-#endif
-  bool cuda_aware_mpi = Tpetra::Details::Behavior::assumeMpiIsCudaAware();
-  TEUCHOS_TEST_ASSERT(cuda_aware_mpi==cuda_aware_mpi_default, out, success);
 }
 
 TEUCHOS_UNIT_TEST(Behavior, verbosePrintCountThreshold) {

--- a/packages/tpetra/core/test/Behavior/Behavior_Default.cpp
+++ b/packages/tpetra/core/test/Behavior/Behavior_Default.cpp
@@ -64,6 +64,18 @@ TEUCHOS_UNIT_TEST(Behavior, Default)
   bool verbose_default = false;
   bool verb = Tpetra::Details::Behavior::verbose();
   TEUCHOS_TEST_ASSERT(verb==verbose_default, out, success);
+
+  // Print current values of other behaviors. 
+  // Can't test against default since these behaviors may be 
+  // changed by environment variables (in which case, test against
+  // default fails)
+  std::cout << "\n        Cuda-aware MPI?  " 
+            << Tpetra::Details::Behavior::assumeMpiIsCudaAware()
+            << "\n";
+
+  std::cout << "\n        Tpetra Debug?  "
+            << Tpetra::Details::Behavior::debug()
+            << "\n";
 }
 
 TEUCHOS_UNIT_TEST(Behavior, verbosePrintCountThreshold) {


### PR DESCRIPTION
@trilinos/tpetra 
## Motivation
This PR removes comparisons of default behavior values with acquired ones for behaviors that are controlled by both CMake options and environment variables.

Trilinos testing is now setting environment variables explicitly, and those settings may differ from the configure-time values of the variables.  Thus, tests that compare the run-time settings with the configure-time settings no longer make sense and may fail.  #6883  #6796 

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->



<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->


## Related Issues

* Closes #6883 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to #6796 #6881 
* Part of 
* Composed of 



## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

@bartlettroscoe Let me know if you continue to see problems with this test.

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

cee-lan with TPETRA_ASSUME_CUDA_AWARE_MPI = 0 and 1, and TPETRA_DEBUG = 0 and 1
gcc 7.3.0, openmpi 1.10.1
This test does not use CUDA, so running on cee-lan is sufficient.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->