### PR TITLE
Verify that the directory exists before cleaning

### DIFF
--- a/commonTools/framework/clean_workspace/clean_workspace.py
+++ b/commonTools/framework/clean_workspace/clean_workspace.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- mode: python; py-indent-offset: 4; py-continuation-offset: 4 -*-
 # Change above to '/usr/bin/python -3' for python 3.x porting warnings
 """
@@ -59,7 +59,8 @@ class Cleaner(object):
         """Do the actual cleanup
              basically just os.unlink()
         """
-        shutil.rmtree(self.args.dir)
+        if os.path.isdir(self.args.dir):
+            shutil.rmtree(self.args.dir)
 
     def clean_space_by_date(self):
         if last_clean_date() < clean_reference_date():

--- a/commonTools/framework/clean_workspace/unittests/test_clean_workspace.py
+++ b/commonTools/framework/clean_workspace/unittests/test_clean_workspace.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- mode: python; py-indent-offset: 4; py-continuation-offset: 4 -*-
 """Implements tests for the clean_sentinel script."""
 from __future__ import print_function
@@ -113,16 +113,30 @@ class TestParseArgs(unittest.TestCase):
 
 class TestForceCleanSpace(unittest.TestCase):
 
-    def test_calls(self):
+    def test_calls_with_dir(self):
         """This function does the final cleanup  so its just os.unlink"""
         test_args = Namespace()
         setattr(test_args, 'dir', os.path.join(os.path.sep, 'dev', 'null'))
         setattr(test_args, 'force_clean', True)
         cleanerInst = Cleaner()
         cleanerInst.args = test_args
-        with mock.patch('shutil.rmtree') as m_unlink:
+        with mock.patch('shutil.rmtree') as m_unlink, \
+             mock.patch('os.path.isdir', return_value=True):
             cleanerInst.force_clean_space()
         m_unlink.assert_called_once_with(test_args.dir)
+
+
+    def test_no_call_without_dir(self):
+        """This function does the final cleanup  so its just os.unlink"""
+        test_args = Namespace()
+        setattr(test_args, 'dir', os.path.join(os.path.sep, 'dev', 'null'))
+        setattr(test_args, 'force_clean', True)
+        cleanerInst = Cleaner()
+        cleanerInst.args = test_args
+        with mock.patch('shutil.rmtree') as m_unlink, \
+             mock.patch('os.path.isdir', return_value=False):
+            cleanerInst.force_clean_space()
+        m_unlink.assert_not_called()
 
 
 class TestCleanSpaceByDate(unittest.TestCase):


### PR DESCRIPTION
@dridzal had an issue with the gcc 7.2.0 builds over
the weekend where the clean_workspace script triggered
on machine that had never built that variant. This
happened because we rebuilt the cloud node on Thursday.
This just adds an "if isdir():" around the rmtree call
and a second test  for that branch.


@trilinos/framework 

## Motivation
This code keeps the build size from becoming a serious impact on available disk space. Stability of the testing harness is important for our development teams.

## Testing
This commit includes it's own unit tests and a new test was added for this change.
