### PR TITLE
Thyra: Removed Deprecated printTestResults

### DIFF
--- a/packages/thyra/core/src/support/operator_vector/client_support/Thyra_TestingTools.cpp
+++ b/packages/thyra/core/src/support/operator_vector/client_support/Thyra_TestingTools.cpp
@@ -81,20 +81,6 @@ void Thyra::printTestResults(
 }
 
 
-void Thyra::printTestResults(
-  const bool result,
-  const std::string &test_summary,
-  const bool show_all_tests,
-  bool *success,
-  std::ostream *out
-  )
-{
-  using Teuchos::ptr;
-  printTestResults(result, test_summary, show_all_tests,
-    ptr(success), ptr(out));
-}
-
-
 // TestResultsPrinter
 
 

--- a/packages/thyra/core/src/support/operator_vector/client_support/Thyra_TestingToolsDecl.hpp
+++ b/packages/thyra/core/src/support/operator_vector/client_support/Thyra_TestingToolsDecl.hpp
@@ -221,15 +221,6 @@ void printTestResults(
   const Ptr<std::ostream> &out
   );
 
-/** \brief Deprecated (call overload without raw pointers). */
-THYRA_DEPRECATED void printTestResults(
-  const bool result,
-  const std::string &test_summary,
-  const bool show_all_tests,
-  bool *success,
-  std::ostream *out
-  );
-
 /** \brief Control printing of test results.
  *
  * This class is designed to help control printing of test results and to help


### PR DESCRIPTION
@trilinos/thyra

## Motivation
The printTestResults method that takes pointers has been deprecated and replaced with a method that takes references to pointers for pointer safety.

## Related Issues

* Part of #6655 


## Testing

Configured Built and Tested using ATDM scripts on the cee-lan

```bash
mkdir -p $TRILINOS_DIR/build
cd $TRILINOS_DIR/build

source $TRILINOS_DIR/cmake/std/atdm/load-env.sh default

cmake \
  -GNinja \
  -DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/atdm/ATDMDevEnv.cmake \
  -DTrilinos_ENABLE_TESTS=ON \
  -DTrilinos_ENABLE_MueLu=ON \
  -DTrilinos_ENABLE_Ifpack2=ON \
  -DTrilinos_ENABLE_Teko=ON \
  -DTrilinos_ENABLE_Tpetra=ON \
  -DTrilinos_ENABLE_Belos=ON \
  -DTrilinos_ENABLE_Teuchos=ON \
  -DTrilinos_ENABLE_Epetra=ON \
  -DTrilinos_ENABLE_Panzer=ON \
  -DTrilinos_ENABLE_STK=ON \
  -DTrilinos_ENABLE_Percept=ON \
  -DTrilinos_ENABLE_Intrepid=ON \
  -DTrilinos_ENABLE_Zoltan2=ON \
  -DTrilinos_ENABLE_Piro=ON \
  -DTrilinos_ENABLE_Phalanx=ON \
  -DTrilinos_ENABLE_RTOp=ON \
  -DTrilinos_ENABLE_ShyLU_Node=ON \
  -DTrilinos_ENABLE_ShyLU_DD=ON \
  -DTrilinos_ENABLE_ShyLU=ON \
  -DTrilinos_ENABLE_Thyra=ON \
  -DTrilinos_ENABLE_ENABLE_ALL_OPTIONAL_PACKAGES=ON \
  -DTrilinos_ENABLE_ENABLE_SECONDARY_TESTED_CODE=ON \
  $TRILINOS_DIR

make NP=16

ctest -j16
```