### PR TITLE
Tpetra: Remove "DynamicProfile" mentions from Doxygen documentation

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -124,7 +124,7 @@ namespace Tpetra {
     ///   a fill-complete state.
     ///
     /// When a CrsGraph or CrsMatrix is <i>not</i> fill complete and
-    /// is allocated, then its data live in one of three storage
+    /// is allocated, then its data live in one of two storage
     /// formats:
     ///
     /// <ol>
@@ -151,7 +151,6 @@ namespace Tpetra {
     /// retain the 1-D unpacked format, and thus retain this enum
     /// value.
     enum EStorageStatus {
-      STORAGE_2D, //<! 2-D storage
       STORAGE_1D_UNPACKED, //<! 1-D "unpacked" storage
       STORAGE_1D_PACKED, //<! 1-D "packed" storage
       STORAGE_UB //<! Invalid value; upper bound on enum values

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -59,10 +59,10 @@
 #include "KokkosSparse_findRelOffset.hpp"
 #include "Kokkos_DualView.hpp"
 #include "Kokkos_StaticCrsGraph.hpp"
-#include "Kokkos_UnorderedMap.hpp"
 
 #include "Teuchos_CommHelpers.hpp"
 #include "Teuchos_Describable.hpp"
+#include "Teuchos_OrdinalTraits.hpp"
 #include "Teuchos_ParameterListAcceptorDefaultBase.hpp"
 
 #include <functional> // std::function
@@ -123,17 +123,11 @@ namespace Tpetra {
     /// \brief Status of the graph's or matrix's storage, when not in
     ///   a fill-complete state.
     ///
-    /// When a CrsGraph or CrsMatrix is <i>not</i> fill complete, its
-    /// data live in one of three storage formats:
+    /// When a CrsGraph or CrsMatrix is <i>not</i> fill complete and
+    /// is allocated, then its data live in one of three storage
+    /// formats:
     ///
     /// <ol>
-    /// <li> "2-D storage": The graph stores column indices as "array
-    ///   of arrays," and the matrix stores values as "array of
-    ///   arrays."  The graph <i>must</i> have k_numRowEntries_
-    ///   allocated.  This only ever exists if the graph was created
-    ///   with DynamicProfile.  A matrix with 2-D storage must own its
-    ///   graph, and the graph must have 2-D storage. </li>
-    ///
     /// <li> "Unpacked 1-D storage": The graph uses a row offsets
     ///   array, and stores column indices in a single array.  The
     ///   matrix also stores values in a single array.  "Unpacked"
@@ -151,14 +145,11 @@ namespace Tpetra {
     ///   constant ("static") graph, this must be true. </li>
     /// </ol>
     ///
-    /// With respect to the Kokkos refactor version of Tpetra, "2-D
-    /// storage" should be considered a legacy option.
-    ///
     /// The phrase "When not in a fill-complete state" is important.
     /// When the graph is fill complete, it <i>always</i> uses 1-D
     /// "packed" storage.  However, if storage is "not optimized," we
-    /// retain the 1-D unpacked or 2-D format, and thus retain this
-    /// enum value.
+    /// retain the 1-D unpacked format, and thus retain this enum
+    /// value.
     enum EStorageStatus {
       STORAGE_2D, //<! 2-D storage
       STORAGE_1D_UNPACKED, //<! 1-D "unpacked" storage
@@ -284,14 +275,10 @@ namespace Tpetra {
     /// \param rowMap [in] Distribution of rows of the graph.
     ///
     /// \param maxNumEntriesPerRow [in] Maximum number of graph
-    ///   entries per row.  If pftype==DynamicProfile, this is only a
-    ///   hint, and you can set this to zero without affecting
-    ///   correctness.  If pftype==StaticProfile, this sets the amount
-    ///   of storage allocated, and you cannot exceed this number of
-    ///   entries in any row.
+    ///   entries per row.  This is a strict upper bound.
     ///
-    /// \param pftype [in] Whether to allocate storage dynamically
-    ///   (DynamicProfile) or statically (StaticProfile).
+    /// \param pftype [in] If you specify this, then this must always
+    ///   be StaticProfile.  No other values exist or are permitted.
     ///
     /// \param params [in/out] Optional list of parameters.  If not
     ///   null, any missing parameters will be filled in with their
@@ -307,13 +294,10 @@ namespace Tpetra {
     /// \param rowMap [in] Distribution of rows of the graph.
     ///
     /// \param numEntPerRow [in] Maximum number of graph entries to
-    ///   allocate for each row.  If pftype==DynamicProfile, this is
-    ///   only a hint.  If pftype==StaticProfile, this sets the amount
-    ///   of storage allocated, and you cannot exceed the allocated
-    ///   number of entries for any row.
+    ///   allocate for each row.  This is a strict upper bound.
     ///
-    /// \param pftype [in] Whether to allocate storage dynamically
-    ///   (DynamicProfile) or statically (StaticProfile).
+    /// \param pftype [in] If you specify this, then this must always
+    ///   be StaticProfile.  No other values exist or are permitted.
     ///
     /// \param params [in/out] Optional list of parameters.  If not
     ///   null, any missing parameters will be filled in with their
@@ -330,13 +314,10 @@ namespace Tpetra {
     /// \param rowMap [in] Distribution of rows of the graph.
     ///
     /// \param numEntPerRow [in] Maximum number of graph entries to
-    ///   allocate for each row.  If pftype==DynamicProfile, this is
-    ///   only a hint.  If pftype==StaticProfile, this sets the amount
-    ///   of storage allocated, and you cannot exceed the allocated
-    ///   number of entries for any row.
+    ///   allocate for each row.  This is a strict upper bound.
     ///
-    /// \param pftype [in] Whether to allocate storage dynamically
-    ///   (DynamicProfile) or statically (StaticProfile).
+    /// \param pftype [in] If you specify this, then this must always
+    ///   be StaticProfile.  No other values exist or are permitted.
     ///
     /// \param params [in/out] Optional list of parameters.  If not
     ///   null, any missing parameters will be filled in with their
@@ -357,14 +338,10 @@ namespace Tpetra {
     ///   See replaceColMap() for the requirements.
     ///
     /// \param maxNumEntriesPerRow [in] Maximum number of graph
-    ///   entries per row.  If pftype==DynamicProfile, this is only a
-    ///   hint, and you can set this to zero without affecting
-    ///   correctness.  If pftype==StaticProfile, this sets the amount
-    ///   of storage allocated, and you cannot exceed this number of
-    ///   entries in any row.
+    ///   entries per row.  This is a strict upper bound.
     ///
-    /// \param pftype [in] Whether to allocate storage dynamically
-    ///   (DynamicProfile) or statically (StaticProfile).
+    /// \param pftype [in] If you specify this, then this must always
+    ///   be StaticProfile.  No other values exist or are permitted.
     ///
     /// \param params [in/out] Optional list of parameters.  If not
     ///   null, any missing parameters will be filled in with their
@@ -383,13 +360,10 @@ namespace Tpetra {
     ///   See replaceColMap() for the requirements.
     ///
     /// \param numEntPerRow [in] Maximum number of graph entries to
-    ///   allocate for each row.  If pftype==DynamicProfile, this is
-    ///   only a hint.  If pftype==StaticProfile, this sets the amount
-    ///   of storage allocated, and you cannot exceed the allocated
-    ///   number of entries for any row.
+    ///   allocate for each row.  This is a strict upper bound.
     ///
-    /// \param pftype [in] Whether to allocate storage dynamically
-    ///   (DynamicProfile) or statically (StaticProfile).
+    /// \param pftype [in] If you specify this, then this must always
+    ///   be StaticProfile.  No other values exist or are permitted.
     ///
     /// \param params [in/out] Optional list of parameters.  If not
     ///   null, any missing parameters will be filled in with their
@@ -409,13 +383,10 @@ namespace Tpetra {
     ///   See replaceColMap() for the requirements.
     ///
     /// \param numEntPerRow [in] Maximum number of graph entries to
-    ///   allocate for each row.  If pftype==DynamicProfile, this is
-    ///   only a hint.  If pftype==StaticProfile, this sets the amount
-    ///   of storage allocated, and you cannot exceed the allocated
-    ///   number of entries for any row.
+    ///   allocate for each row.  This is a strict upper bound.
     ///
-    /// \param pftype [in] Whether to allocate storage dynamically
-    ///   (DynamicProfile) or statically (StaticProfile).
+    /// \param pftype [in] If you specify this, then this must always
+    ///   be StaticProfile.  No other values exist or are permitted.
     ///
     /// \param params [in/out] Optional list of parameters.  If not
     ///   null, any missing parameters will be filled in with their
@@ -2192,30 +2163,34 @@ namespace Tpetra {
     /// \brief Local number of (populated) diagonal entries.
     ///
     /// Computed in computeLocalConstants(); only valid when isFillComplete().
-    size_t nodeNumDiags_;
+    size_t nodeNumDiags_ = Teuchos::OrdinalTraits<size_t>::invalid();
 
     /// \brief Local maximum of the number of entries in each row.
     ///
-    /// Computed in computeLocalConstants(); only valid when isFillComplete().
-    size_t nodeMaxNumRowEntries_;
+    /// Computed in computeLocalConstants; only valid when
+    ///   isFillComplete() is true.
+    size_t nodeMaxNumRowEntries_ =
+      Teuchos::OrdinalTraits<size_t>::invalid();
 
     /// \brief Global number of entries in the graph.
     ///
-    /// Only valid when isFillComplete().
-    global_size_t globalNumEntries_;
+    /// Only valid when isFillComplete() is true.
+    global_size_t globalNumEntries_ =
+      Teuchos::OrdinalTraits<global_size_t>::invalid();
 
     /// \brief Global number of (populated) diagonal entries.
     ///
-    /// Computed in computeGlobalConstants(); only valid when isFillComplete().
-    global_size_t globalNumDiags_;
+    /// Computed in computeGlobalConstants; only valid when
+    ///   isFillComplete() is true.
+    global_size_t globalNumDiags_ =
+      Teuchos::OrdinalTraits<global_size_t>::invalid();
 
     /// \brief Global maximum of the number of entries in each row.
     ///
-    /// Computed in computeGlobalConstants(); only valid when isFillComplete().
-    global_size_t globalMaxNumRowEntries_;
-
-    //! Whether the graph was allocated with static or dynamic profile.
-    ProfileType pftype_;
+    /// Computed in computeGlobalConstants(); only valid when
+    ///   isFillComplete() is true.
+    global_size_t globalMaxNumRowEntries_ =
+      Teuchos::OrdinalTraits<global_size_t>::invalid();
 
     /// \brief The maximum number of entries to allow in each locally
     ///   owned row, per row.
@@ -2256,7 +2231,7 @@ namespace Tpetra {
     /// obsolete.
     size_t numAllocForAllRows_;
 
-    //! \name 1-D storage (StaticProfile) data structures
+    //! \name Graph data structures (packed and unpacked storage).
     //@{
 
     /// \brief Local column indices for all rows.
@@ -2264,7 +2239,6 @@ namespace Tpetra {
     /// This is only allocated if
     ///
     ///   - The calling process has a nonzero number of entries
-    ///   - The graph has StaticProfile (1-D storage)
     ///   - The graph is locally indexed
     typename local_graph_type::entries_type::non_const_type k_lclInds1D_;
 
@@ -2276,15 +2250,14 @@ namespace Tpetra {
     /// This is only allocated if
     ///
     ///   - The calling process has a nonzero number of entries
-    ///   - The graph has StaticProfile (1-D storage)
     ///   - The graph is globally indexed
     t_GlobalOrdinal_1D k_gblInds1D_;
 
     /// \brief Row offsets for "1-D" storage.
     ///
-    /// This is only allocated if "1-D" (StaticProfile) storage is
-    /// active.  In that case, if beg = k_rowPtrs_(i_lcl) and end =
-    /// k_rowPtrs_(i_lcl+1) for local row index i_lcl, then
+    /// This is only allocated if "1-D" storage is active.  In that
+    /// case, if beg = k_rowPtrs_(i_lcl) and end = k_rowPtrs_(i_lcl+1)
+    /// for local row index i_lcl, then
     ///
     ///   - if the graph is locally indexed, k_lclInds1D_(beg:end-1)
     ///     (inclusive range) is the space for any local column
@@ -2298,27 +2271,10 @@ namespace Tpetra {
     /// space."  If the graph's storage is packed, then there is no
     /// extra space, and the k_numRowEntries_ array is invalid.
     ///
-    /// Both the k_rowPtrs_ and k_numRowEntries_ arrays are not
-    /// allocated if the graph has 2-D (DynamicProfile) storage.
-    ///
     /// If it is allocated, k_rowPtrs_ has length getNodeNumRows()+1.
     /// The k_numRowEntries_ array has has length getNodeNumRows(),
     /// again if it is allocated.
     typename local_graph_type::row_map_type::const_type k_rowPtrs_;
-
-    //@}
-    /// \name 2-D storage (DynamicProfile) data structures
-    ///
-    /// 2-D storage exists only if the graph was allocated with
-    /// DynamicProfile.  All of these data structures exist in host
-    /// memory.  Currently, NONE of them are thread safe, let alone
-    /// thread scalable.  These data structures only exist to support
-    /// legacy use cases.  At some point, we may add a thread-scalable
-    /// intermediate level of "dynamicity" between 2-D storage and 1-D
-    /// storage (StaticProfile), which bounds the <i>total</i> number
-    /// of entries allowed per process, but does <i>not</i> otherwise
-    /// bound the number of entries per row.
-    //@{
 
     /// \brief The type of k_numRowEntries_ (see below).
     ///
@@ -2356,28 +2312,29 @@ namespace Tpetra {
     /// When the graph is fill complete, it <i>always</i> uses 1-D
     /// "packed" storage.  However, if the "Optimize Storage"
     /// parameter to fillComplete was false, the graph may keep
-    /// unpacked 1-D or 2-D storage around and resume it on the next
+    /// unpacked 1-D storage around and resume it on the next
     /// resumeFill call.
-    ::Tpetra::Details::EStorageStatus storageStatus_;
+    Details::EStorageStatus storageStatus_ =
+      Details::STORAGE_1D_UNPACKED;
 
-    bool indicesAreAllocated_;
-    bool indicesAreLocal_;
-    bool indicesAreGlobal_;
-    bool fillComplete_;
+    bool indicesAreAllocated_ = false;
+    bool indicesAreLocal_ = false;
+    bool indicesAreGlobal_ = false;
+    bool fillComplete_ = false;
 
     //! Whether the graph is locally lower triangular.
-    bool lowerTriangular_;
+    bool lowerTriangular_ = false;
     //! Whether the graph is locally upper triangular.
-    bool upperTriangular_;
+    bool upperTriangular_ = false;
     //! Whether the graph's indices are sorted in each row, on this process.
-    bool indicesAreSorted_;
+    bool indicesAreSorted_ = true;
     /// \brief Whether the graph's indices are non-redundant (merged)
     ///   in each row, on this process.
-    bool noRedundancies_;
+    bool noRedundancies_ = true;
     //! Whether this process has computed local constants.
-    bool haveLocalConstants_;
+    bool haveLocalConstants_ = false;
     //! Whether all processes have computed global constants.
-    bool haveGlobalConstants_;
+    bool haveGlobalConstants_ = false;
 
     typedef typename std::map<global_ordinal_type, std::vector<global_ordinal_type> > nonlocals_type;
 
@@ -2398,7 +2355,7 @@ namespace Tpetra {
     /// This is \c true by default, which means "sort remote GIDs."
     /// If you don't want to sort (for compatibility with Epetra),
     /// call sortGhostColumnGIDsWithinProcessBlock(false).
-    bool sortGhostsAssociatedWithEachProcessor_;
+    bool sortGhostsAssociatedWithEachProcessor_ = true;
 
   private:
     //! Get initial value of debug_ for this object.
@@ -2422,22 +2379,28 @@ namespace Tpetra {
   /// \brief Nonmember function to create an empty CrsGraph given a
   ///   row Map and the max number of entries allowed locally per row.
   ///
-  /// \return A dynamically allocated (DynamicProfile) graph with
-  ///   specified number of nonzeros per row (defaults to zero).
+  /// \return A graph with at most the specified number of nonzeros
+  ///   per row (defaults to zero).
+  ///
   /// \relatesalso CrsGraph
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
   Teuchos::RCP<CrsGraph<LocalOrdinal, GlobalOrdinal, Node> >
-  createCrsGraph (const Teuchos::RCP<const Map<LocalOrdinal, GlobalOrdinal, Node> > &map,
-                  size_t maxNumEntriesPerRow = 0,
-                  const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null)
+  createCrsGraph(
+    const Teuchos::RCP<
+      const Map<LocalOrdinal, GlobalOrdinal, Node>>& map,
+    size_t maxNumEntriesPerRow = 0,
+    const Teuchos::RCP<Teuchos::ParameterList>& params =
+      Teuchos::null)
   {
     using Teuchos::rcp;
-    typedef CrsGraph<LocalOrdinal, GlobalOrdinal, Node> graph_type;
+    using graph_type = CrsGraph<LocalOrdinal, GlobalOrdinal, Node>;
     const ProfileType pftype = TPETRA_DEFAULT_PROFILE_TYPE;
-    return rcp (new graph_type (map, maxNumEntriesPerRow, pftype, params));
+    return rcp(new graph_type(map, maxNumEntriesPerRow,
+                              pftype, params));
   }
 
-  /// \brief Nonmember CrsGraph constructor that fuses Import and fillComplete().
+  /// \brief Nonmember CrsGraph constructor that fuses Import and
+  ///   fillComplete().
   /// \relatesalso CrsGraph
   /// \tparam CrsGraphType A specialization of CrsGraph.
   ///

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -2122,10 +2122,6 @@ namespace Tpetra {
         (this->isStorageOptimized () && ! this->indicesAreAllocated (),
          std::logic_error, "Storage is optimized, but indices are not "
          "allocated, not even trivially." << suffix);
-      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (this->storageStatus_ == Details::STORAGE_2D,
-         std::logic_error,
-         "Graph should never have 2D storage");
 
       size_t nodeAllocSize = 0;
       try {

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -201,8 +201,8 @@ namespace Tpetra {
 
     } // namespace Impl
 
-    /// \brief Convert a (StaticProfile) CrsGraph's global column
-    ///   indices into local column indices.
+    /// \brief Convert a CrsGraph's global column indices into local
+    ///   column indices.
     ///
     /// \param lclColInds [out] On output: The graph's local column
     ///   indices.  This may alias gblColInds, if LO == GO.
@@ -296,34 +296,14 @@ namespace Tpetra {
   CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
   CrsGraph (const Teuchos::RCP<const map_type>& rowMap,
             const size_t maxNumEntriesPerRow,
-            const ProfileType pftype,
+            const ProfileType /* pftype */,
             const Teuchos::RCP<Teuchos::ParameterList>& params) :
     dist_object_type (rowMap)
     , rowMap_ (rowMap)
-    , nodeNumDiags_ (Teuchos::OrdinalTraits<size_t>::invalid ())
-    , nodeMaxNumRowEntries_ (Teuchos::OrdinalTraits<size_t>::invalid ())
-    , globalNumEntries_ (Teuchos::OrdinalTraits<global_size_t>::invalid ())
-    , globalNumDiags_ (Teuchos::OrdinalTraits<global_size_t>::invalid ())
-    , globalMaxNumRowEntries_ (Teuchos::OrdinalTraits<global_size_t>::invalid ())
-    , pftype_ (pftype)
     , numAllocForAllRows_ (maxNumEntriesPerRow)
-    , storageStatus_ (pftype == StaticProfile ?
-                      ::Tpetra::Details::STORAGE_1D_UNPACKED :
-                      ::Tpetra::Details::STORAGE_2D)
-    , indicesAreAllocated_ (false)
-    , indicesAreLocal_ (false)
-    , indicesAreGlobal_ (false)
-    , fillComplete_ (false)
-    , lowerTriangular_ (false)
-    , upperTriangular_ (false)
-    , indicesAreSorted_ (true)
-    , noRedundancies_ (true)
-    , haveLocalConstants_ (false)
-    , haveGlobalConstants_ (false)
-    , sortGhostsAssociatedWithEachProcessor_ (true)
   {
-    const char tfecfFuncName[] = "CrsGraph(rowMap,maxNumEntriesPerRow,"
-      "pftype,params): ";
+    const char tfecfFuncName[] =
+      "CrsGraph(rowMap,maxNumEntriesPerRow,pftype,params): ";
     staticAssertions ();
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
       (maxNumEntriesPerRow == Teuchos::OrdinalTraits<size_t>::invalid (),
@@ -339,35 +319,15 @@ namespace Tpetra {
   CrsGraph (const Teuchos::RCP<const map_type>& rowMap,
             const Teuchos::RCP<const map_type>& colMap,
             const size_t maxNumEntriesPerRow,
-            const ProfileType pftype,
+            const ProfileType /* pftype */,
             const Teuchos::RCP<Teuchos::ParameterList>& params) :
     dist_object_type (rowMap)
     , rowMap_ (rowMap)
     , colMap_ (colMap)
-    , nodeNumDiags_ (Teuchos::OrdinalTraits<size_t>::invalid ())
-    , nodeMaxNumRowEntries_ (Teuchos::OrdinalTraits<size_t>::invalid ())
-    , globalNumEntries_ (Teuchos::OrdinalTraits<global_size_t>::invalid ())
-    , globalNumDiags_ (Teuchos::OrdinalTraits<global_size_t>::invalid ())
-    , globalMaxNumRowEntries_ (Teuchos::OrdinalTraits<global_size_t>::invalid ())
-    , pftype_ (pftype)
     , numAllocForAllRows_ (maxNumEntriesPerRow)
-    , storageStatus_ (pftype == StaticProfile ?
-                      ::Tpetra::Details::STORAGE_1D_UNPACKED :
-                      ::Tpetra::Details::STORAGE_2D)
-    , indicesAreAllocated_ (false)
-    , indicesAreLocal_ (false)
-    , indicesAreGlobal_ (false)
-    , fillComplete_ (false)
-    , lowerTriangular_ (false)
-    , upperTriangular_ (false)
-    , indicesAreSorted_ (true)
-    , noRedundancies_ (true)
-    , haveLocalConstants_ (false)
-    , haveGlobalConstants_ (false)
-    , sortGhostsAssociatedWithEachProcessor_ (true)
   {
-    const char tfecfFuncName[] = "CrsGraph(rowMap,colMap,maxNumEntriesPerRow,"
-      "pftype,params): ";
+    const char tfecfFuncName[] =
+      "CrsGraph(rowMap,colMap,maxNumEntriesPerRow,pftype,params): ";
     staticAssertions ();
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
       maxNumEntriesPerRow == Teuchos::OrdinalTraits<size_t>::invalid (),
@@ -382,33 +342,14 @@ namespace Tpetra {
   CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
   CrsGraph (const Teuchos::RCP<const map_type>& rowMap,
             const Teuchos::ArrayView<const size_t>& numEntPerRow,
-            const ProfileType pftype,
+            const ProfileType /* pftype */,
             const Teuchos::RCP<Teuchos::ParameterList>& params) :
     dist_object_type (rowMap)
     , rowMap_ (rowMap)
-    , nodeNumDiags_ (Teuchos::OrdinalTraits<size_t>::invalid ())
-    , nodeMaxNumRowEntries_ (Teuchos::OrdinalTraits<size_t>::invalid ())
-    , globalNumEntries_ (Teuchos::OrdinalTraits<global_size_t>::invalid ())
-    , globalNumDiags_ (Teuchos::OrdinalTraits<global_size_t>::invalid ())
-    , globalMaxNumRowEntries_ (Teuchos::OrdinalTraits<global_size_t>::invalid ())
-    , pftype_ (pftype)
     , numAllocForAllRows_ (0)
-    , storageStatus_ (pftype == StaticProfile ?
-                      ::Tpetra::Details::STORAGE_1D_UNPACKED :
-                      ::Tpetra::Details::STORAGE_2D)
-    , indicesAreAllocated_ (false)
-    , indicesAreLocal_ (false)
-    , indicesAreGlobal_ (false)
-    , fillComplete_ (false)
-    , lowerTriangular_ (false)
-    , upperTriangular_ (false)
-    , indicesAreSorted_ (true)
-    , noRedundancies_ (true)
-    , haveLocalConstants_ (false)
-    , haveGlobalConstants_ (false)
-    , sortGhostsAssociatedWithEachProcessor_ (true)
   {
-    const char tfecfFuncName[] = "CrsGraph(rowMap,numEntPerRow,pftype,params): ";
+    const char tfecfFuncName[] =
+      "CrsGraph(rowMap,numEntPerRow,pftype,params): ";
     staticAssertions ();
 
     const size_t lclNumRows = rowMap.is_null () ?
@@ -455,34 +396,15 @@ namespace Tpetra {
   CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
   CrsGraph (const Teuchos::RCP<const map_type>& rowMap,
             const Kokkos::DualView<const size_t*, execution_space>& numEntPerRow,
-            const ProfileType pftype,
+            const ProfileType /* pftype */,
             const Teuchos::RCP<Teuchos::ParameterList>& params) :
     dist_object_type (rowMap)
     , rowMap_ (rowMap)
-    , nodeNumDiags_ (Teuchos::OrdinalTraits<size_t>::invalid ())
-    , nodeMaxNumRowEntries_ (Teuchos::OrdinalTraits<size_t>::invalid ())
-    , globalNumEntries_ (Teuchos::OrdinalTraits<global_size_t>::invalid ())
-    , globalNumDiags_ (Teuchos::OrdinalTraits<global_size_t>::invalid ())
-    , globalMaxNumRowEntries_ (Teuchos::OrdinalTraits<global_size_t>::invalid ())
-    , pftype_ (pftype)
     , k_numAllocPerRow_ (numEntPerRow.h_view)
     , numAllocForAllRows_ (0)
-    , storageStatus_ (pftype == StaticProfile ?
-                      ::Tpetra::Details::STORAGE_1D_UNPACKED :
-                      ::Tpetra::Details::STORAGE_2D)
-    , indicesAreAllocated_ (false)
-    , indicesAreLocal_ (false)
-    , indicesAreGlobal_ (false)
-    , fillComplete_ (false)
-    , lowerTriangular_ (false)
-    , upperTriangular_ (false)
-    , indicesAreSorted_ (true)
-    , noRedundancies_ (true)
-    , haveLocalConstants_ (false)
-    , haveGlobalConstants_ (false)
-    , sortGhostsAssociatedWithEachProcessor_ (true)
   {
-    const char tfecfFuncName[] = "CrsGraph(rowMap,numEntPerRow,pftype,params): ";
+    const char tfecfFuncName[] =
+      "CrsGraph(rowMap,numEntPerRow,pftype,params): ";
     staticAssertions ();
 
     const size_t lclNumRows = rowMap.is_null () ?
@@ -514,35 +436,16 @@ namespace Tpetra {
   CrsGraph (const Teuchos::RCP<const map_type>& rowMap,
             const Teuchos::RCP<const map_type>& colMap,
             const Kokkos::DualView<const size_t*, execution_space>& numEntPerRow,
-            const ProfileType pftype,
+            const ProfileType /* pftype */,
             const Teuchos::RCP<Teuchos::ParameterList>& params) :
     dist_object_type (rowMap)
     , rowMap_ (rowMap)
     , colMap_ (colMap)
-    , nodeNumDiags_ (Teuchos::OrdinalTraits<size_t>::invalid ())
-    , nodeMaxNumRowEntries_ (Teuchos::OrdinalTraits<size_t>::invalid ())
-    , globalNumEntries_ (Teuchos::OrdinalTraits<global_size_t>::invalid ())
-    , globalNumDiags_ (Teuchos::OrdinalTraits<global_size_t>::invalid ())
-    , globalMaxNumRowEntries_ (Teuchos::OrdinalTraits<global_size_t>::invalid ())
-    , pftype_ (pftype)
     , k_numAllocPerRow_ (numEntPerRow.h_view)
     , numAllocForAllRows_ (0)
-    , storageStatus_ (pftype == StaticProfile ?
-                      ::Tpetra::Details::STORAGE_1D_UNPACKED :
-                      ::Tpetra::Details::STORAGE_2D)
-    , indicesAreAllocated_ (false)
-    , indicesAreLocal_ (false)
-    , indicesAreGlobal_ (false)
-    , fillComplete_ (false)
-    , lowerTriangular_ (false)
-    , upperTriangular_ (false)
-    , indicesAreSorted_ (true)
-    , noRedundancies_ (true)
-    , haveLocalConstants_ (false)
-    , haveGlobalConstants_ (false)
-    , sortGhostsAssociatedWithEachProcessor_ (true)
   {
-    const char tfecfFuncName[] = "CrsGraph(rowMap,colMap,numEntPerRow,pftype,params): ";
+    const char tfecfFuncName[] =
+      "CrsGraph(rowMap,colMap,numEntPerRow,pftype,params): ";
     staticAssertions ();
 
     const size_t lclNumRows = rowMap.is_null () ?
@@ -574,35 +477,15 @@ namespace Tpetra {
   CrsGraph (const Teuchos::RCP<const map_type>& rowMap,
             const Teuchos::RCP<const map_type>& colMap,
             const Teuchos::ArrayView<const size_t>& numEntPerRow,
-            const ProfileType pftype,
+            const ProfileType /* pftype */,
             const Teuchos::RCP<Teuchos::ParameterList>& params) :
     dist_object_type (rowMap)
     , rowMap_ (rowMap)
     , colMap_ (colMap)
-    , nodeNumDiags_ (Teuchos::OrdinalTraits<size_t>::invalid ())
-    , nodeMaxNumRowEntries_ (Teuchos::OrdinalTraits<size_t>::invalid ())
-    , globalNumEntries_ (Teuchos::OrdinalTraits<global_size_t>::invalid ())
-    , globalNumDiags_ (Teuchos::OrdinalTraits<global_size_t>::invalid ())
-    , globalMaxNumRowEntries_ (Teuchos::OrdinalTraits<global_size_t>::invalid ())
-    , pftype_ (pftype)
     , numAllocForAllRows_ (0)
-    , storageStatus_ (pftype == StaticProfile ?
-                      ::Tpetra::Details::STORAGE_1D_UNPACKED :
-                      ::Tpetra::Details::STORAGE_2D)
-    , indicesAreAllocated_ (false)
-    , indicesAreLocal_ (false)
-    , indicesAreGlobal_ (false)
-    , fillComplete_ (false)
-    , lowerTriangular_ (false)
-    , upperTriangular_ (false)
-    , indicesAreSorted_ (true)
-    , noRedundancies_ (true)
-    , haveLocalConstants_ (false)
-    , haveGlobalConstants_ (false)
-    , sortGhostsAssociatedWithEachProcessor_ (true)
   {
-    const char tfecfFuncName[] = "CrsGraph(rowMap,colMap,numEntPerRow,pftype,"
-      "params): ";
+    const char tfecfFuncName[] =
+      "CrsGraph(rowMap,colMap,numEntPerRow,pftype,params): ";
     staticAssertions ();
 
     const size_t lclNumRows = rowMap.is_null () ?
@@ -654,30 +537,19 @@ namespace Tpetra {
     dist_object_type (rowMap)
     , rowMap_(rowMap)
     , colMap_(colMap)
-    , nodeNumDiags_ (Teuchos::OrdinalTraits<size_t>::invalid ())
-    , nodeMaxNumRowEntries_ (Teuchos::OrdinalTraits<size_t>::invalid ())
-    , globalNumEntries_ (Teuchos::OrdinalTraits<global_size_t>::invalid ())
-    , globalNumDiags_ (Teuchos::OrdinalTraits<global_size_t>::invalid ())
-    , globalMaxNumRowEntries_ (Teuchos::OrdinalTraits<global_size_t>::invalid ())
-    , pftype_(StaticProfile)
     , numAllocForAllRows_(0)
-    , storageStatus_ (::Tpetra::Details::STORAGE_1D_PACKED)
+    , storageStatus_(Details::STORAGE_1D_PACKED)
     , indicesAreAllocated_(true)
     , indicesAreLocal_(true)
-    , indicesAreGlobal_(false)
-    , fillComplete_(false)
-    , lowerTriangular_ (false)
-    , upperTriangular_ (false)
-    , noRedundancies_(true)
-    , haveLocalConstants_ (false)
-    , haveGlobalConstants_ (false)
-    , sortGhostsAssociatedWithEachProcessor_(true)
   {
     staticAssertions ();
-    if(!params.is_null() && params->isParameter("sorted") && !params->get<bool>("sorted"))
+    if (! params.is_null() && params->isParameter("sorted") &&
+        ! params->get<bool>("sorted")) {
       indicesAreSorted_ = false;
-    else
+    }
+    else {
       indicesAreSorted_ = true;
+    }
     setAllIndices (rowPointers, columnIndices);
     checkInternalState ();
   }
@@ -692,30 +564,19 @@ namespace Tpetra {
     dist_object_type (rowMap)
     , rowMap_ (rowMap)
     , colMap_ (colMap)
-    , nodeNumDiags_ (Teuchos::OrdinalTraits<size_t>::invalid ())
-    , nodeMaxNumRowEntries_ (Teuchos::OrdinalTraits<size_t>::invalid ())
-    , globalNumEntries_ (Teuchos::OrdinalTraits<global_size_t>::invalid ())
-    , globalNumDiags_ (Teuchos::OrdinalTraits<global_size_t>::invalid ())
-    , globalMaxNumRowEntries_ (Teuchos::OrdinalTraits<global_size_t>::invalid ())
-    , pftype_ (StaticProfile)
     , numAllocForAllRows_ (0)
-    , storageStatus_ (::Tpetra::Details::STORAGE_1D_PACKED)
+    , storageStatus_ (Details::STORAGE_1D_PACKED)
     , indicesAreAllocated_ (true)
     , indicesAreLocal_ (true)
-    , indicesAreGlobal_ (false)
-    , fillComplete_ (false)
-    , lowerTriangular_ (false)
-    , upperTriangular_ (false)
-    , noRedundancies_ (true)
-    , haveLocalConstants_ (false)
-    , haveGlobalConstants_ (false)
-    , sortGhostsAssociatedWithEachProcessor_ (true)
   {
     staticAssertions ();
-    if(!params.is_null() && params->isParameter("sorted") && !params->get<bool>("sorted"))
+    if (! params.is_null() && params->isParameter("sorted") &&
+        ! params->get<bool>("sorted")) {
       indicesAreSorted_ = false;
-    else
+    }
+    else {
       indicesAreSorted_ = true;
+    }
     setAllIndices (rowPointers, columnIndices);
     checkInternalState ();
   }
@@ -746,24 +607,10 @@ namespace Tpetra {
     , rowMap_ (rowMap)
     , colMap_ (colMap)
     , lclGraph_ (k_local_graph_)
-    , nodeNumDiags_ (Teuchos::OrdinalTraits<size_t>::invalid ())
-    , nodeMaxNumRowEntries_ (Teuchos::OrdinalTraits<size_t>::invalid ())
-    , globalNumEntries_ (Teuchos::OrdinalTraits<global_size_t>::invalid ())
-    , globalNumDiags_ (Teuchos::OrdinalTraits<global_size_t>::invalid ())
-    , globalMaxNumRowEntries_ (Teuchos::OrdinalTraits<global_size_t>::invalid ())
-    , pftype_ (StaticProfile)
     , numAllocForAllRows_ (0)
-    , storageStatus_ (::Tpetra::Details::STORAGE_1D_PACKED)
+    , storageStatus_ (Details::STORAGE_1D_PACKED)
     , indicesAreAllocated_ (true)
     , indicesAreLocal_ (true)
-    , indicesAreGlobal_ (false)
-    , fillComplete_ (false)
-    , lowerTriangular_ (false)
-    , upperTriangular_ (false)
-    , noRedundancies_ (true)
-    , haveLocalConstants_ (false)
-    , haveGlobalConstants_ (false)
-    , sortGhostsAssociatedWithEachProcessor_ (true)
   {
     staticAssertions();
     const char tfecfFuncName[] = "CrsGraph(Kokkos::LocalStaticCrsGraph,Map,Map,Map,Map)";
@@ -836,24 +683,10 @@ namespace Tpetra {
     importer_ (importer),
     exporter_ (exporter),
     lclGraph_ (lclGraph),
-    nodeNumDiags_ (Teuchos::OrdinalTraits<size_t>::invalid ()),
-    nodeMaxNumRowEntries_ (Teuchos::OrdinalTraits<size_t>::invalid ()),
-    globalNumEntries_ (Teuchos::OrdinalTraits<global_size_t>::invalid ()),
-    globalNumDiags_ (Teuchos::OrdinalTraits<global_size_t>::invalid ()),
-    globalMaxNumRowEntries_ (Teuchos::OrdinalTraits<global_size_t>::invalid ()),
-    pftype_ (StaticProfile),
     numAllocForAllRows_ (0),
-    storageStatus_ (::Tpetra::Details::STORAGE_1D_PACKED),
+    storageStatus_ (Details::STORAGE_1D_PACKED),
     indicesAreAllocated_ (true),
-    indicesAreLocal_ (true),
-    indicesAreGlobal_ (false),
-    fillComplete_ (false), // not yet, but see below
-    lowerTriangular_ (false),
-    upperTriangular_ (false),
-    noRedundancies_ (true),
-    haveLocalConstants_ (false),
-    haveGlobalConstants_ (false),
-    sortGhostsAssociatedWithEachProcessor_ (true)
+    indicesAreLocal_ (true)
   {
     staticAssertions();
     const char tfecfFuncName[] = "Tpetra::CrsGraph(local_graph_type,"
@@ -866,10 +699,13 @@ namespace Tpetra {
     k_lclInds1D_ = lclGraph_.entries;
     k_rowPtrs_ = lclGraph_.row_map;
 
-    if(!params.is_null() && params->isParameter("sorted") && !params->get<bool>("sorted"))
+    if (! params.is_null() && params->isParameter("sorted") &&
+        ! params->get<bool>("sorted")) {
       indicesAreSorted_ = false;
-    else
+    }
+    else {
       indicesAreSorted_ = true;
+    }
 
     const bool callComputeGlobalConstants =
       params.get () == nullptr ||
@@ -1056,7 +892,7 @@ namespace Tpetra {
   CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
   getProfileType () const
   {
-    return pftype_;
+    return StaticProfile;
   }
 
   template <class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -1194,7 +1030,7 @@ namespace Tpetra {
       if (lclNumRows == 0) {
         return static_cast<size_t> (0);
       }
-      else if (this->storageStatus_ == ::Tpetra::Details::STORAGE_1D_PACKED) {
+      else if (storageStatus_ == Details::STORAGE_1D_PACKED) {
         if (static_cast<LO> (this->lclGraph_.row_map.extent (0)) <
             static_cast<LO> (lclNumRows + 1)) {
           return static_cast<size_t> (0);
@@ -1203,7 +1039,7 @@ namespace Tpetra {
           return ::Tpetra::Details::getEntryOnHost (this->lclGraph_.row_map, lclNumRows);
         }
       }
-      else if (this->storageStatus_ == ::Tpetra::Details::STORAGE_1D_UNPACKED) {
+      else if (storageStatus_ == Details::STORAGE_1D_UNPACKED) {
         if (this->k_rowPtrs_.extent (0) == 0) {
           return static_cast<size_t> (0);
         }
@@ -2230,9 +2066,11 @@ namespace Tpetra {
   CrsGraph<LocalOrdinal, GlobalOrdinal, Node>::
   clearGlobalConstants ()
   {
-    globalNumEntries_       = Teuchos::OrdinalTraits<global_size_t>::invalid ();
-    globalNumDiags_         = Teuchos::OrdinalTraits<global_size_t>::invalid ();
-    globalMaxNumRowEntries_ = Teuchos::OrdinalTraits<global_size_t>::invalid ();
+    const auto INV = Teuchos::OrdinalTraits<global_size_t>::invalid();
+
+    globalNumEntries_       = INV;
+    globalNumDiags_         = INV;
+    globalMaxNumRowEntries_ = INV;
     haveGlobalConstants_    = false;
   }
 
@@ -2285,7 +2123,7 @@ namespace Tpetra {
          std::logic_error, "Storage is optimized, but indices are not "
          "allocated, not even trivially." << suffix);
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (this->storageStatus_ == ::Tpetra::Details::STORAGE_2D,
+        (this->storageStatus_ == Details::STORAGE_2D,
          std::logic_error,
          "Graph should never have 2D storage");
 
@@ -2375,8 +2213,8 @@ namespace Tpetra {
          nodeAllocSize > 0 &&
          this->k_lclInds1D_.extent (0) == 0 &&
          this->k_gblInds1D_.extent (0) == 0,
-         std::logic_error, "Graph has StaticProfile and is allocated "
-         "nonnontrivally, but 1-D allocations are not present." << suffix);
+         std::logic_error, "Graph is allocated nontrivially, but "
+         "but 1-D allocations are not present." << suffix);
 
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
         (! this->indicesAreAllocated () &&
@@ -2427,12 +2265,11 @@ namespace Tpetra {
          << getNodeNumRows () << " > 0." << suffix);
       // check the actual allocations
       if (this->indicesAreAllocated () &&
-          this->pftype_ == StaticProfile &&
           this->k_rowPtrs_.extent (0) != 0) {
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
           (static_cast<size_t> (this->k_rowPtrs_.extent (0)) !=
            this->getNodeNumRows () + 1,
-           std::logic_error, "Graph is StaticProfile, indices are allocated, and "
+           std::logic_error, "Indices are allocated and "
            "k_rowPtrs_ has nonzero length, but k_rowPtrs_.extent(0) = "
            << this->k_rowPtrs_.extent (0) << " != getNodeNumRows()+1 = "
            << (this->getNodeNumRows () + 1) << "." << suffix);
@@ -2441,15 +2278,15 @@ namespace Tpetra {
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
           (this->isLocallyIndexed () &&
            static_cast<size_t> (this->k_lclInds1D_.extent (0)) != actualNumAllocated,
-           std::logic_error, "Graph is StaticProfile and locally indexed, "
-           "indices are allocated, and k_rowPtrs_ has nonzero length, but "
+           std::logic_error, "Graph is locally indexed, indices are "
+           "are allocated, and k_rowPtrs_ has nonzero length, but "
            "k_lclInds1D_.extent(0) = " << this->k_lclInds1D_.extent (0)
            << " != actualNumAllocated = " << actualNumAllocated << suffix);
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
           (this->isGloballyIndexed () &&
            static_cast<size_t> (this->k_gblInds1D_.extent (0)) != actualNumAllocated,
-           std::logic_error, "Graph is StaticProfile and globally indexed, "
-           "indices are allocated, and k_rowPtrs_ has nonzero length, but "
+           std::logic_error, "Graph is globally indexed, indices "
+           "are allocated, and k_rowPtrs_ has nonzero length, but "
            "k_gblInds1D_.extent(0) = " << this->k_gblInds1D_.extent (0)
            << " != actualNumAllocated = " << actualNumAllocated << suffix);
       }
@@ -3134,12 +2971,11 @@ namespace Tpetra {
     indicesAreLocal_     = true;
     indicesAreSorted_    = true;
     noRedundancies_      = true;
-    pftype_              = StaticProfile; // if the profile wasn't static before, it sure is now.
     k_lclInds1D_         = columnIndices;
     k_rowPtrs_           = rowPointers;
     // Storage MUST be packed, since the interface doesn't give any
     // way to indicate any extra space at the end of each row.
-    storageStatus_       = ::Tpetra::Details::STORAGE_1D_PACKED;
+    storageStatus_       = Details::STORAGE_1D_PACKED;
 
     // Build the local graph.
     lclGraph_ = local_graph_type (k_lclInds1D_, k_rowPtrs_);
@@ -3239,14 +3075,10 @@ namespace Tpetra {
         // left with the case that we have optimized storage. in this
         // case, we have to construct a list of row sizes.
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-          (this->getProfileType () != StaticProfile, std::logic_error,
-           "The graph is not StaticProfile, but storage appears to be optimized."
-           << suffix);
-        TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
           (numRows != 0 && k_rowPtrs_.extent (0) == 0, std::logic_error,
-           "The graph has " << numRows << " (> 0) row" << (numRows != 1 ? "s" : "")
-           << " on the calling process, but the k_rowPtrs_ array has zero entries."
-           << suffix);
+           "The graph has " << numRows << " (> 0) row"
+           << (numRows != 1 ? "s" : "") << " on the calling process, "
+           "but the k_rowPtrs_ array has zero entries." << suffix);
         Teuchos::ArrayRCP<size_t> numEnt;
         if (numRows != 0) {
           numEnt = Teuchos::arcp<size_t> (numRows);
@@ -3393,7 +3225,7 @@ namespace Tpetra {
     //    return exclude that case.
 
     RCP<const map_type> nonlocalRowMap;
-    // Keep this for CrsGraph's constructor, so we can use StaticProfile.
+    // Keep this for CrsGraph's constructor.
     Teuchos::Array<size_t> numEntPerNonlocalRow (myNumNonlocalRows);
     {
       Teuchos::Array<GO> myNonlocalGblRows (myNumNonlocalRows);
@@ -3442,12 +3274,12 @@ namespace Tpetra {
 
     // 3. Use the column indices for each nonlocal row, as stored in
     //    nonlocals_, to construct a CrsGraph corresponding to
-    //    nonlocal rows.  We may use StaticProfile, since we have
-    //    exact counts of the number of entries in each nonlocal row.
+    //    nonlocal rows.  We need, but we have, exact counts of the
+    //    number of entries in each nonlocal row.
 
     RCP<crs_graph_type> nonlocalGraph =
-      rcp (new crs_graph_type (nonlocalRowMap, numEntPerNonlocalRow (),
-                               StaticProfile));
+      rcp(new crs_graph_type(nonlocalRowMap, numEntPerNonlocalRow(),
+                             StaticProfile));
     {
       size_type curPos = 0;
       for (auto mapIter = this->nonlocals_.begin ();
@@ -3834,9 +3666,6 @@ namespace Tpetra {
       domainMap.is_null () || rangeMap.is_null (),
       std::runtime_error, "The input domain Map and range Map must be nonnull.");
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
-      pftype_ != StaticProfile, std::runtime_error, "You may not call this "
-      "method unless the graph is StaticProfile.");
-    TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
       isFillComplete () || ! hasColMap (), std::runtime_error, "You may not "
       "call this method unless the graph has a column Map.");
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
@@ -3921,7 +3750,6 @@ namespace Tpetra {
     Teuchos::Array<int> remotePIDs (0); // unused output argument
     this->makeImportExport (remotePIDs, false);
 
-    // Since we have a StaticProfile, fillLocalGraph will do the right thing...
 #ifdef HAVE_TPETRA_MMM_TIMINGS
     MM = Teuchos::null;
     MM = Teuchos::rcp(new TimeMonitor(*TimeMonitor::getNewTimer(prefix + std::string("ESFC-G-fLG"))));
@@ -3986,19 +3814,18 @@ namespace Tpetra {
       requestOptimizedStorage = false;
     }
 
-    // StaticProfile means that the graph's column indices are
-    // currently stored in a 1-D format, with row offsets in
-    // k_rowPtrs_ and local column indices in k_lclInds1D_.
+    // The graph's column indices are currently stored in a 1-D
+    // format, with row offsets in k_rowPtrs_ and local column indices
+    // in k_lclInds1D_.
 
     if (debug_) {
-      // StaticProfile also means that the graph's array of row
-      // offsets must already be allocated.
+      // The graph's array of row offsets must already be allocated.
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
         (k_rowPtrs_.extent (0) == 0, std::logic_error,
-         "(StaticProfile branch) k_rowPtrs_ has size zero, but shouldn't");
+         "k_rowPtrs_ has size zero, but shouldn't");
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
         (k_rowPtrs_.extent (0) != lclNumRows + 1, std::logic_error,
-         "(StaticProfile branch) k_rowPtrs_.extent(0) = "
+         "k_rowPtrs_.extent(0) = "
          << k_rowPtrs_.extent (0) << " != (lclNumRows + 1) = "
          << (lclNumRows + 1) << ".");
       const size_t numOffsets = k_rowPtrs_.extent (0);
@@ -4007,10 +3834,10 @@ namespace Tpetra {
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
         (numOffsets != 0 &&
          k_lclInds1D_.extent (0) != valToCheck,
-         std::logic_error, "(StaticProfile branch) numOffsets = " <<
-         numOffsets << " != 0 and k_lclInds1D_.extent(0) = " <<
-         k_lclInds1D_.extent (0) << " != k_rowPtrs_(" << numOffsets <<
-         ") = " << valToCheck << ".");
+         std::logic_error, "numOffsets=" << numOffsets << " != 0 "
+         " and k_lclInds1D_.extent(0)=" << k_lclInds1D_.extent(0)
+         << " != k_rowPtrs_(" << numOffsets << ")=" << valToCheck
+         << ".");
     }
 
     size_t allocSize = 0;
@@ -4041,10 +3868,9 @@ namespace Tpetra {
     if (this->getNodeNumEntries () != allocSize) {
       // The graph's current 1-D storage is "unpacked."  This means
       // the row offsets may differ from what the final row offsets
-      // should be.  This could happen, for example, if the user
-      // specified StaticProfile in the constructor and set an upper
-      // bound on the number of entries in each row, but didn't fill
-      // all those entries.
+      // should be.  This could happen, for example, if the user set
+      // an upper bound on the number of entries in each row, but
+      // didn't fill all those entries.
 
       if (debug_) {
         if (k_rowPtrs_.extent (0) != 0) {
@@ -4053,10 +3879,10 @@ namespace Tpetra {
           const auto valToCheck =
             ::Tpetra::Details::getEntryOnHost (k_rowPtrs_, numOffsets - 1);
           TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-            (valToCheck != static_cast<size_t> (k_lclInds1D_.extent (0)),
-             std::logic_error, "(StaticProfile unpacked branch) Before "
-             "allocating or packing, k_rowPtrs_(" << (numOffsets-1) << ") = "
-             << valToCheck << " != k_lclInds1D_.extent(0) = "
+            (valToCheck != size_t(k_lclInds1D_.extent(0)),
+             std::logic_error, "(Unpacked branch) Before allocating "
+             "or packing, k_rowPtrs_(" << (numOffsets-1) << ")="
+             << valToCheck << " != k_lclInds1D_.extent(0)="
              << k_lclInds1D_.extent (0) << ".");
         }
       }
@@ -4078,10 +3904,10 @@ namespace Tpetra {
         typename row_entries_type::const_type numRowEnt_h = k_numRowEntries_;
         if (debug_) {
           TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-            (static_cast<size_t> (numRowEnt_h.extent (0)) != lclNumRows,
-             std::logic_error, "(StaticProfile unpacked branch) "
-             "numRowEnt_h.extent(0) = " << numRowEnt_h.extent (0)
-             << " != getNodeNumRows() = " << lclNumRows << "");
+            (size_t(numRowEnt_h.extent (0)) != lclNumRows,
+             std::logic_error, "(Unpacked branch) "
+             "numRowEnt_h.extent(0)=" << numRowEnt_h.extent(0)
+             << " != getNodeNumRows()=" << lclNumRows << "");
         }
 
         lclTotalNumEntries = computeOffsetsFromCounts (ptr_d, numRowEnt_h);
@@ -4089,17 +3915,18 @@ namespace Tpetra {
         if (debug_) {
           TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
             (static_cast<size_t> (ptr_d.extent (0)) != lclNumRows + 1,
-             std::logic_error, "(StaticProfile unpacked branch) After "
-             "allocating ptr_d, ptr_d.extent(0) = " << ptr_d.extent (0)
+             std::logic_error, "(Unpacked branch) After allocating "
+             "ptr_d, ptr_d.extent(0) = " << ptr_d.extent(0)
              << " != lclNumRows+1 = " << (lclNumRows+1) << ".");
           const auto valToCheck =
             ::Tpetra::Details::getEntryOnHost (ptr_d, lclNumRows);
           TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
             (valToCheck != lclTotalNumEntries, std::logic_error,
-             "Tpetra::CrsGraph::fillLocalGraph: In StaticProfile unpacked "
-             "branch, after filling ptr_d, ptr_d(lclNumRows=" << lclNumRows
-             << ") = " << valToCheck << " != total number of entries on "
-             "the calling process = " << lclTotalNumEntries << ".");
+             "Tpetra::CrsGraph::fillLocalGraph: In unpacked branch, "
+             "after filling ptr_d, ptr_d(lclNumRows=" << lclNumRows
+             << ") = " << valToCheck << " != total number of entries "
+             "on the calling process = " << lclTotalNumEntries
+             << ".");
         }
       }
 
@@ -4128,9 +3955,9 @@ namespace Tpetra {
 
       if (debug_) {
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-          (ptr_d.extent (0) == 0, std::logic_error, "(StaticProfile "
-           "\"Optimize Storage\"=true branch) After packing, "
-           "ptr_d.extent(0) = 0.  This probably means k_rowPtrs_ was "
+          (ptr_d.extent (0) == 0, std::logic_error,
+           "(\"Optimize Storage\"=true branch) After packing, "
+           "ptr_d.extent(0)=0.  This probably means k_rowPtrs_ was "
            "never allocated.");
         if (ptr_d.extent (0) != 0) {
           const size_t numOffsets = static_cast<size_t> (ptr_d.extent (0));
@@ -4138,10 +3965,10 @@ namespace Tpetra {
             ::Tpetra::Details::getEntryOnHost (ptr_d, numOffsets - 1);
           TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
             (static_cast<size_t> (valToCheck) != ind_d.extent (0),
-             std::logic_error, "(StaticProfile \"Optimize Storage\"=true "
-             "branch) After packing, ptr_d(" << (numOffsets-1) << ") = "
-             << valToCheck << " != ind_d.extent(0) = "
-             << ind_d.extent (0) << ".");
+             std::logic_error, "(\"Optimize Storage\"=true branch) "
+             "After packing, ptr_d(" << (numOffsets-1) << ")="
+             << valToCheck << " != ind_d.extent(0)="
+             << ind_d.extent(0) << ".");
         }
       }
     }
@@ -4151,19 +3978,20 @@ namespace Tpetra {
 
       if (debug_) {
         TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-          (ptr_d_const.extent (0) == 0, std::logic_error, "(StaticProfile "
-           "\"Optimize Storage\"=false branch) ptr_d_const.extent(0) = 0.  "
-           "This probably means that k_rowPtrs_ was never allocated.");
+          (ptr_d_const.extent (0) == 0, std::logic_error,
+           "(\"Optimize Storage\"=false branch) "
+           "ptr_d_const.extent(0) = 0.  This probably means that "
+           "k_rowPtrs_ was never allocated.");
         if (ptr_d_const.extent (0) != 0) {
           const size_t numOffsets =
             static_cast<size_t> (ptr_d_const.extent (0));
           const size_t valToCheck =
             ::Tpetra::Details::getEntryOnHost (ptr_d_const, numOffsets - 1);
           TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-            (valToCheck != static_cast<size_t> (ind_d.extent (0)),
-             std::logic_error, "(StaticProfile \"Optimize Storage\"=false "
-             "branch) ptr_d_const(" << (numOffsets-1) << ") = " << valToCheck
-             << " != ind_d.extent(0) = " << ind_d.extent (0) << ".");
+            (valToCheck != size_t(ind_d.extent (0)),
+             std::logic_error, "(\"Optimize Storage\"=false branch) "
+             "ptr_d_const(" << (numOffsets-1) << ")=" << valToCheck
+             << " != ind_d.extent(0)=" << ind_d.extent (0) << ".");
         }
       }
     }
@@ -4198,10 +4026,7 @@ namespace Tpetra {
       k_rowPtrs_   = ptr_d_const;
       k_lclInds1D_ = ind_d;
 
-      // The graph is definitely StaticProfile now, whether or not it
-      // was before.
-      pftype_ = StaticProfile;
-      storageStatus_ = ::Tpetra::Details::STORAGE_1D_PACKED;
+      storageStatus_ = Details::STORAGE_1D_PACKED;
     }
 
     // FIXME (mfh 28 Aug 2014) "Local Graph" sublist no longer used.
@@ -4583,8 +4408,9 @@ namespace Tpetra {
     // Reset local properties
     this->lowerTriangular_ = false;
     this->upperTriangular_ = false;
-    this->nodeMaxNumRowEntries_ = Teuchos::OrdinalTraits<size_t>::invalid ();
-    this->nodeNumDiags_ = Teuchos::OrdinalTraits<size_t>::invalid ();
+    this->nodeMaxNumRowEntries_ =
+      Teuchos::OrdinalTraits<size_t>::invalid();
+    this->nodeNumDiags_ = Teuchos::OrdinalTraits<size_t>::invalid();
 
     if (computeLocalTriangularConstants) {
       const bool hasRowAndColumnMaps =
@@ -7785,8 +7611,6 @@ namespace Tpetra {
     std::swap(graph.globalNumDiags_, this->globalNumDiags_);
     std::swap(graph.globalMaxNumRowEntries_, this->globalMaxNumRowEntries_);
 
-    std::swap(graph.pftype_, this->pftype_);
-
     std::swap(graph.numAllocForAllRows_, this->numAllocForAllRows_);
 
     std::swap(graph.k_rowPtrs_, this->k_rowPtrs_);
@@ -7857,8 +7681,6 @@ namespace Tpetra {
     output = this->globalNumEntries_ == graph.globalNumEntries_ ? output : false;
     output = this->globalNumDiags_ == graph.globalNumDiags_ ? output : false;
     output = this->globalMaxNumRowEntries_ == graph.globalMaxNumRowEntries_ ? output : false;
-
-    output = this->pftype_ == graph.pftype_ ? output : false;    // ProfileType is a enum (scalar)
 
     output = this->numAllocForAllRows_ == graph.numAllocForAllRows_ ? output : false;
 

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -1062,63 +1062,21 @@ namespace Tpetra {
     /// <li> <tt>! isFillActive ()</tt> </li>
     /// <li> <tt> inputInds.extent (0) != inputVals.extent (0)</tt> </li>
     /// </ul>
-    template<class GlobalIndicesViewType,
-             class ImplScalarViewType>
-    LocalOrdinal
-    replaceGlobalValues (const GlobalOrdinal globalRow,
-                         const typename UnmanagedView<GlobalIndicesViewType>::type& inputInds,
-                         const typename UnmanagedView<ImplScalarViewType>::type& inputVals) const
-    {
-      // We use static_assert here to check the template parameters,
-      // rather than std::enable_if (e.g., on the return value, to
-      // enable compilation only if the template parameters match the
-      // desired attributes).  This turns obscure link errors into
-      // clear compilation errors.  It also makes the return value a
-      // lot easier to see.
-      static_assert (Kokkos::is_view<GlobalIndicesViewType>::value,
-                     "First template parameter GlobalIndicesViewType must be "
-                     "a Kokkos::View.");
-      static_assert (Kokkos::is_view<ImplScalarViewType>::value,
-                     "Second template parameter ImplScalarViewType must be a "
-                     "Kokkos::View.");
-      static_assert (static_cast<int> (GlobalIndicesViewType::rank) == 1,
-                     "First template parameter GlobalIndicesViewType must "
-                     "have rank 1.");
-      static_assert (static_cast<int> (ImplScalarViewType::rank) == 1,
-                     "Second template parameter ImplScalarViewType must have "
-                     "rank 1.");
-      static_assert (std::is_same<
-                       typename GlobalIndicesViewType::non_const_value_type,
-                       global_ordinal_type>::value,
-                     "First template parameter GlobalIndicesViewType must "
-                     "contain values of type global_ordinal_type.");
-      static_assert (std::is_same<
-                       typename ImplScalarViewType::non_const_value_type,
-                       impl_scalar_type>::value,
-                     "Second template parameter ImplScalarViewType must "
-                     "contain values of type impl_scalar_type.");
-      typedef LocalOrdinal LO;
-      const LO numInputEnt = inputInds.extent (0);
-      if (static_cast<LO> (inputVals.extent (0)) != numInputEnt) {
-        return Teuchos::OrdinalTraits<LO>::invalid ();
-      }
-      const Scalar* const inVals =
-        reinterpret_cast<const Scalar*> (inputVals.data ());
-      return this->replaceGlobalValues (globalRow, numInputEnt, inVals,
-                                        inputInds.data ());
-    }
+    local_ordinal_type
+    replaceGlobalValues(
+      const global_ordinal_type globalRow,
+      const Kokkos::View<const global_ordinal_type*, Kokkos::AnonymousSpace>& inputInds,
+      const Kokkos::View<const impl_scalar_type*, Kokkos::AnonymousSpace>& inputVals) const;
 
-    /// \brief Backwards compatibility version of replaceGlobalValues
-    ///   (see above), that takes Teuchos::ArrayView (host pointers)
-    ///   instead of Kokkos::View.
+    /// \brief Overload of replaceGlobalValues (see above), that takes
+    ///   Teuchos::ArrayView (host pointers) instead of Kokkos::View.
     LocalOrdinal
     replaceGlobalValues (const GlobalOrdinal globalRow,
                          const Teuchos::ArrayView<const GlobalOrdinal>& cols,
                          const Teuchos::ArrayView<const Scalar>& vals) const;
 
-    /// \brief Epetra compatibility version of replaceGlobalValues
-    ///   (see above), that takes raw pointers instead of
-    ///   Kokkos::View.
+    /// \brief Overload of replaceGlobalValues (see above), that takes
+    ///   raw pointers instead of Kokkos::View.
     ///
     /// This version of the method takes the same arguments in the
     /// same order as Epetra_CrsMatrix::ReplaceGlobalValues.
@@ -1192,52 +1150,11 @@ namespace Tpetra {
     ///   <li> <tt>! hasColMap ()</tt> </li>
     ///   <li> <tt> cols.extent (0) != vals.extent (0)</tt> </li>
     ///   </ul>
-    template<class LocalIndicesViewType,
-             class ImplScalarViewType>
-    LocalOrdinal
-    replaceLocalValues (const LocalOrdinal localRow,
-                        const typename UnmanagedView<LocalIndicesViewType>::type& inputInds,
-                        const typename UnmanagedView<ImplScalarViewType>::type& inputVals) const
-    {
-      // We use static_assert here to check the template parameters,
-      // rather than std::enable_if (e.g., on the return value, to
-      // enable compilation only if the template parameters match the
-      // desired attributes).  This turns obscure link errors into
-      // clear compilation errors.  It also makes the return value a
-      // lot easier to see.
-      static_assert (Kokkos::is_view<LocalIndicesViewType>::value,
-                     "First template parameter LocalIndicesViewType must be "
-                     "a Kokkos::View.");
-      static_assert (Kokkos::is_view<ImplScalarViewType>::value,
-                     "Second template parameter ImplScalarViewType must be a "
-                     "Kokkos::View.");
-      static_assert (static_cast<int> (LocalIndicesViewType::rank) == 1,
-                     "First template parameter LocalIndicesViewType must "
-                     "have rank 1.");
-      static_assert (static_cast<int> (ImplScalarViewType::rank) == 1,
-                     "Second template parameter ImplScalarViewType must have "
-                     "rank 1.");
-      static_assert (std::is_same<
-                       typename LocalIndicesViewType::non_const_value_type,
-                       local_ordinal_type>::value,
-                     "First template parameter LocalIndicesViewType must "
-                     "contain values of type local_ordinal_type.");
-      static_assert (std::is_same<
-                       typename ImplScalarViewType::non_const_value_type,
-                       impl_scalar_type>::value,
-                     "Second template parameter ImplScalarViewType must "
-                     "contain values of type impl_scalar_type.");
-
-      typedef LocalOrdinal LO;
-      const LO numInputEnt = inputInds.extent (0);
-      if (numInputEnt != inputVals.extent (0)) {
-        return Teuchos::OrdinalTraits<LO>::invalid ();
-      }
-      const Scalar* const inVals =
-        reinterpret_cast<const Scalar*> (inputVals.data ());
-      return this->replaceLocalValues (localRow, numInputEnt,
-                                       inVals, inputInds.data ());
-    }
+    local_ordinal_type
+    replaceLocalValues(
+      const local_ordinal_type localRow,
+      const Kokkos::View<const local_ordinal_type*, Kokkos::AnonymousSpace>& inputInds,
+      const Kokkos::View<const impl_scalar_type*, Kokkos::AnonymousSpace>& inputVals) const;
 
     /// \brief Backwards compatibility version of replaceLocalValues
     ///   (see above), that takes Teuchos::ArrayView (host pointers)
@@ -1445,53 +1362,12 @@ namespace Tpetra {
     ///
     /// This method has the same preconditions and return value
     /// meaning as replaceLocalValues() (which see).
-    template<class LocalIndicesViewType,
-             class ImplScalarViewType>
-    LocalOrdinal
-    sumIntoLocalValues (const LocalOrdinal localRow,
-                        const typename UnmanagedView<LocalIndicesViewType>::type& inputInds,
-                        const typename UnmanagedView<ImplScalarViewType>::type& inputVals,
-                        const bool atomic = useAtomicUpdatesByDefault) const
-    {
-      // We use static_assert here to check the template parameters,
-      // rather than std::enable_if (e.g., on the return value, to
-      // enable compilation only if the template parameters match the
-      // desired attributes).  This turns obscure link errors into
-      // clear compilation errors.  It also makes the return value a
-      // lot easier to see.
-      static_assert (Kokkos::is_view<LocalIndicesViewType>::value,
-                     "First template parameter LocalIndicesViewType must be "
-                     "a Kokkos::View.");
-      static_assert (Kokkos::is_view<ImplScalarViewType>::value,
-                     "Second template parameter ImplScalarViewType must be a "
-                     "Kokkos::View.");
-      static_assert (static_cast<int> (LocalIndicesViewType::rank) == 1,
-                     "First template parameter LocalIndicesViewType must "
-                     "have rank 1.");
-      static_assert (static_cast<int> (ImplScalarViewType::rank) == 1,
-                     "Second template parameter ImplScalarViewType must have "
-                     "rank 1.");
-      static_assert (std::is_same<
-                       typename LocalIndicesViewType::non_const_value_type,
-                       local_ordinal_type>::value,
-                     "First template parameter LocalIndicesViewType must "
-                     "contain values of type local_ordinal_type.");
-      static_assert (std::is_same<
-                       typename ImplScalarViewType::non_const_value_type,
-                       impl_scalar_type>::value,
-                     "Second template parameter ImplScalarViewType must "
-                     "contain values of type impl_scalar_type.");
-      typedef LocalOrdinal LO;
-      const LO numInputEnt = inputInds.extent (0);
-      if (static_cast<LO> (inputVals.extent (0)) != numInputEnt) {
-        return Teuchos::OrdinalTraits<LO>::invalid ();
-      }
-      return this->sumIntoLocalValues (localRow,
-                                       numInputEnt,
-                                       reinterpret_cast<const Scalar*> (inputVals.data ()),
-                                       inputInds.data (),
-                                       atomic);
-    }
+    local_ordinal_type
+    sumIntoLocalValues(
+      const local_ordinal_type localRow,
+      const Kokkos::View<const local_ordinal_type*, Kokkos::AnonymousSpace>& inputInds,
+      const Kokkos::View<const impl_scalar_type*, Kokkos::AnonymousSpace>& inputVals,
+      const bool atomic = useAtomicUpdatesByDefault) const;
 
     /// \brief Sum into one or more sparse matrix entries, using local
     ///   row and column indices.

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -4495,10 +4495,11 @@ namespace Tpetra {
     /// parameter to fillComplete was false, the matrix may keep
     /// unpacked 1-D storage around and resume it on the next
     /// resumeFill call.
-    ::Tpetra::Details::EStorageStatus storageStatus_;
+    Details::EStorageStatus storageStatus_ =
+      Details::STORAGE_1D_UNPACKED;
 
     //! Whether the matrix is fill complete.
-    bool fillComplete_;
+    bool fillComplete_ = false;
 
     /// \brief Nonlocal data added using insertGlobalValues().
     ///
@@ -4535,7 +4536,7 @@ namespace Tpetra {
     /// The value -1 means that the norm has not yet been computed, or
     /// that the values in the matrix may have changed and the norm
     /// must be recomputed.
-    mutable mag_type frobNorm_;
+    mutable mag_type frobNorm_ = -STM::one();
 
   public:
     // FIXME (mfh 24 Feb 2014) Is it _really_ necessary to make this a

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -519,19 +519,17 @@ namespace Tpetra {
     operator= (CrsMatrix<Scalar, LocalOrdinal,
                          GlobalOrdinal, Node>&&) = default;
 
-    /// \brief Constructor specifying fixed number of entries for each row.
+    /// \brief Constructor specifying the maximum number of entries
+    ///   that any row on the process can take.
     ///
     /// \param rowMap [in] Distribution of rows of the matrix.
     ///
     /// \param maxNumEntriesPerRow [in] Maximum number of matrix
-    ///   entries per row.  If pftype==DynamicProfile, this is only a
-    ///   hint, and you can set this to zero without affecting
-    ///   correctness.  If pftype==StaticProfile, this sets the amount
-    ///   of storage allocated, and you cannot exceed this number of
-    ///   entries in any row.
+    ///   entries per row.  This is a strict upper bound.  It may
+    ///   differ on different processes.
     ///
-    /// \param pftype [in] Whether to allocate storage dynamically
-    ///   (DynamicProfile) or statically (StaticProfile).
+    /// \param pftype [in] If you specify this, then this must always
+    ///   be StaticProfile.  No other values exist or are permitted.
     ///
     /// \param params [in/out] Optional list of parameters.  If not
     ///   null, any missing parameters will be filled in with their
@@ -546,14 +544,11 @@ namespace Tpetra {
     /// \param rowMap [in] Distribution of rows of the matrix.
     ///
     /// \param numEntPerRowToAlloc [in] Maximum number of matrix
-    ///   entries to allocate for each row.  If
-    ///   pftype==DynamicProfile, this is only a hint.  If
-    ///   pftype==StaticProfile, this sets the amount of storage
-    ///   allocated, and you cannot exceed the allocated number of
-    ///   entries for any row.
+    ///   entries to allocate for each row.  This is a strict upper
+    ///   bound.  It may differ on different processes.
     ///
-    /// \param pftype [in] Whether to allocate storage dynamically
-    ///   (DynamicProfile) or statically (StaticProfile).
+    /// \param pftype [in] If you specify this, then this must always
+    ///   be StaticProfile.  No other values exist or are permitted.
     ///
     /// \param params [in/out] Optional list of parameters.  If not
     ///   null, any missing parameters will be filled in with their
@@ -574,15 +569,12 @@ namespace Tpetra {
     /// \param colMap [in] Distribution of columns of the matrix.
     ///   See replaceColMap() for the requirements.
     ///
-    /// \param maxNumEntPerRow [in] Maximum number of matrix
-    ///   entries per row.  If pftype==DynamicProfile, this is only a
-    ///   hint, and you can set this to zero without affecting
-    ///   correctness.  If pftype==StaticProfile, this sets the amount
-    ///   of storage allocated, and you cannot exceed this number of
-    ///   entries in any row.
+    /// \param maxNumEntPerRow [in] Maximum number of matrix entries
+    ///   per row.  This is a strict upper bound.  It may differ on
+    ///   different processes.
     ///
-    /// \param pftype [in] Whether to allocate storage dynamically
-    ///   (DynamicProfile) or statically (StaticProfile).
+    /// \param pftype [in] If you specify this, then this must always
+    ///   be StaticProfile.  No other values exist or are permitted.
     ///
     /// \param params [in/out] Optional list of parameters.  If not
     ///   null, any missing parameters will be filled in with their
@@ -604,14 +596,11 @@ namespace Tpetra {
     ///   See replaceColMap() for the requirements.
     ///
     /// \param numEntPerRowToAlloc [in] Maximum number of matrix
-    ///   entries to allocate for each row.  If
-    ///   pftype==DynamicProfile, this is only a hint.  If
-    ///   pftype==StaticProfile, this sets the amount of storage
-    ///   allocated, and you cannot exceed the allocated number of
-    ///   entries for any row.
+    ///   entries to allocate for each row.  This is a strict upper
+    ///   bound.  It may differ on different processes.
     ///
-    /// \param pftype [in] Whether to allocate storage dynamically
-    ///   (DynamicProfile) or statically (StaticProfile).
+    /// \param pftype [in] If you specify this, then this must always
+    ///   be StaticProfile.  No other values exist or are permitted.
     ///
     /// \param params [in/out] Optional list of parameters.  If not
     ///   null, any missing parameters will be filled in with their
@@ -4582,23 +4571,25 @@ namespace Tpetra {
     };
   }; // class CrsMatrix
 
-  /** \brief Non-member function to create an empty CrsMatrix given a
-        row map and a non-zero profile.
-
-      \return A dynamically allocated (DynamicProfile) matrix with
-        specified number of nonzeros per row (defaults to zero).
-
-      \relatesalso CrsMatrix
-   */
-  template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  /// \brief Create an empty CrsMatrix given a row map and a single
+  ///   integer upper bound on the number of stored entries per row.
+  ///
+  /// \relatesalso CrsMatrix
+  template<class Scalar,
+           class LocalOrdinal,
+           class GlobalOrdinal,
+           class Node>
   Teuchos::RCP<CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> >
-  createCrsMatrix (const Teuchos::RCP<const Map<LocalOrdinal, GlobalOrdinal, Node> >& map,
-                   size_t maxNumEntriesPerRow = 0,
-                   const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null)
+  createCrsMatrix(
+    const Teuchos::RCP<const Map<LocalOrdinal, GlobalOrdinal, Node> >& map,
+    const size_t maxNumEntriesPerRow = 0,
+    const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null)
   {
-    typedef CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> matrix_type;
+    using matrix_type =
+      CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
     const ProfileType pftype = TPETRA_DEFAULT_PROFILE_TYPE;
-    return Teuchos::rcp (new matrix_type (map, maxNumEntriesPerRow, pftype, params));
+    return Teuchos::rcp(new matrix_type(map, maxNumEntriesPerRow,
+                                        pftype, params));
   }
 
   template<class CrsMatrixType>

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -1630,10 +1630,8 @@ namespace Tpetra {
       }
       this->k_values1D_ = k_vals;
 
-      // Whatever graph was before, it's StaticProfile now.
-      myGraph_->pftype_ = StaticProfile;
-      myGraph_->storageStatus_ = ::Tpetra::Details::STORAGE_1D_PACKED;
-      this->storageStatus_ = ::Tpetra::Details::STORAGE_1D_PACKED;
+      myGraph_->storageStatus_ = Details::STORAGE_1D_PACKED;
+      this->storageStatus_ = Details::STORAGE_1D_PACKED;
     }
     else {
       if (verbose) {

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -2436,7 +2436,7 @@ namespace Tpetra {
   {
     using LO = local_ordinal_type;
     const LO numInputEnt = inputInds.extent(0);
-    if (numInputEnt != inputVals.extent(0)) {
+    if (numInputEnt != static_cast<LO>(inputVals.extent(0))) {
       return Teuchos::OrdinalTraits<LO>::invalid();
     }
     const Scalar* const inVals =

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -145,12 +145,7 @@ namespace Tpetra {
              size_t maxNumEntriesPerRow,
              const ProfileType pftype,
              const Teuchos::RCP<Teuchos::ParameterList>& params) :
-    dist_object_type (rowMap),
-    storageStatus_ (pftype == StaticProfile ?
-                    ::Tpetra::Details::STORAGE_1D_UNPACKED :
-                    ::Tpetra::Details::STORAGE_2D),
-    fillComplete_ (false),
-    frobNorm_ (-STM::one ())
+    dist_object_type (rowMap)
   {
     const char tfecfFuncName[] = "CrsMatrix(RCP<const Map>, size_t, "
       "ProfileType[, RCP<ParameterList>]): ";
@@ -180,25 +175,22 @@ namespace Tpetra {
              const Teuchos::ArrayView<const size_t>& numEntPerRowToAlloc,
              const ProfileType pftype,
              const Teuchos::RCP<Teuchos::ParameterList>& params) :
-    dist_object_type (rowMap),
-    storageStatus_ (pftype == StaticProfile ?
-                    ::Tpetra::Details::STORAGE_1D_UNPACKED :
-                    ::Tpetra::Details::STORAGE_2D),
-    fillComplete_ (false),
-    frobNorm_ (-STM::one ())
+    dist_object_type (rowMap)
   {
     const char tfecfFuncName[] = "CrsMatrix(RCP<const Map>, "
       "ArrayView<const size_t>, ProfileType[, RCP<ParameterList>]): ";
     Teuchos::RCP<crs_graph_type> graph;
     try {
-      graph = Teuchos::rcp (new crs_graph_type (rowMap, numEntPerRowToAlloc,
-                                                pftype, params));
+      using Teuchos::rcp;
+      graph = rcp(new crs_graph_type(rowMap, numEntPerRowToAlloc,
+                                     pftype, params));
     }
-    catch (std::exception &e) {
+    catch (std::exception& e) {
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (true, std::runtime_error, "CrsGraph constructor (RCP<const Map>, "
-         "ArrayView<const size_t>, ProfileType[, RCP<ParameterList>]) threw "
-         "an exception: " << e.what ());
+        (true, std::runtime_error, "CrsGraph constructor "
+         "(RCP<const Map>, ArrayView<const size_t>, "
+         "ProfileType[, RCP<ParameterList>]) threw an exception: "
+         << e.what ());
     }
     // myGraph_ not null means that the matrix owns the graph.  That's
     // different than the const CrsGraph constructor, where the matrix
@@ -217,15 +209,10 @@ namespace Tpetra {
              const size_t maxNumEntPerRow,
              const ProfileType pftype,
              const Teuchos::RCP<Teuchos::ParameterList>& params) :
-    dist_object_type (rowMap),
-    storageStatus_ (pftype == StaticProfile ?
-                    ::Tpetra::Details::STORAGE_1D_UNPACKED :
-                    ::Tpetra::Details::STORAGE_2D),
-    fillComplete_ (false),
-    frobNorm_ (-STM::one ())
+    dist_object_type (rowMap)
   {
-    const char tfecfFuncName[] = "CrsMatrix(RCP<const Map>, RCP<const Map>, "
-      "size_t, ProfileType[, RCP<ParameterList>]): ";
+    const char tfecfFuncName[] = "CrsMatrix(RCP<const Map>, "
+      "RCP<const Map>, size_t, ProfileType[, RCP<ParameterList>]): ";
     const char suffix[] =
       "  Please report this bug to the Tpetra developers.";
 #ifdef HAVE_TPETRA_DEBUG
@@ -273,14 +260,10 @@ namespace Tpetra {
              const Teuchos::ArrayView<const size_t>& numEntPerRowToAlloc,
              const ProfileType pftype,
              const Teuchos::RCP<Teuchos::ParameterList>& params) :
-    dist_object_type (rowMap),
-    storageStatus_ (pftype == StaticProfile ?
-                    ::Tpetra::Details::STORAGE_1D_UNPACKED :
-                    ::Tpetra::Details::STORAGE_2D),
-    fillComplete_ (false),
-    frobNorm_ (-STM::one ())
+    dist_object_type (rowMap)
   {
-    const char tfecfFuncName[] = "CrsMatrix(RCP<const Map>, RCP<const Map>, "
+    const char tfecfFuncName[] =
+      "CrsMatrix(RCP<const Map>, RCP<const Map>, "
       "ArrayView<const size_t>, ProfileType[, RCP<ParameterList>]): ";
     Teuchos::RCP<crs_graph_type> graph;
     try {
@@ -288,7 +271,7 @@ namespace Tpetra {
                                                 numEntPerRowToAlloc,
                                                 pftype, params));
     }
-    catch (std::exception &e) {
+    catch (std::exception& e) {
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
         (true, std::runtime_error, "CrsGraph constructor (RCP<const Map>, "
          "RCP<const Map>, ArrayView<const size_t>, ProfileType[, "
@@ -310,9 +293,7 @@ namespace Tpetra {
              const Teuchos::RCP<Teuchos::ParameterList>& /* params */) :
     dist_object_type (graph->getRowMap ()),
     staticGraph_ (graph),
-    storageStatus_ (::Tpetra::Details::STORAGE_1D_PACKED),
-    fillComplete_ (false),
-    frobNorm_ (-STM::one ())
+    storageStatus_ (Details::STORAGE_1D_PACKED)
   {
     using std::endl;
     typedef typename local_matrix_type::values_type values_type;
@@ -331,12 +312,12 @@ namespace Tpetra {
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
       (graph.is_null (), std::runtime_error, "Input graph is null.");
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-      (! graph->isFillComplete (), std::runtime_error, "Input graph is not "
-       "fill complete. You must call fillComplete on the graph before using "
-       "it to construct a CrsMatrix.  Note that calling resumeFill on the "
-       "graph makes it not fill complete, even if you had previously called "
-       "fillComplete.  In that case, you must call fillComplete on the graph "
-       "again.");
+      (! graph->isFillComplete (), std::runtime_error, "Input graph "
+       "is not fill complete. You must call fillComplete on the "
+       "graph before using it to construct a CrsMatrix.  Note that "
+       "calling resumeFill on the graph makes it not fill complete, "
+       "even if you had previously called fillComplete.  In that "
+       "case, you must call fillComplete on the graph again.");
 
     // The graph is fill complete, so it is locally indexed and has a
     // fixed structure.  This means we can allocate the (1-D) array of
@@ -380,21 +361,20 @@ namespace Tpetra {
              const Teuchos::RCP<Teuchos::ParameterList>& /* params */) :
     dist_object_type (graph->getRowMap ()),
     staticGraph_ (graph),
-    storageStatus_ (::Tpetra::Details::STORAGE_1D_PACKED),
-    fillComplete_ (false),
-    frobNorm_ (-STM::one ())
+    storageStatus_ (Details::STORAGE_1D_PACKED)
   {
-    const char tfecfFuncName[] = "CrsMatrix(RCP<const CrsGraph>,local_matrix_type::values_type,[, "
-      "RCP<ParameterList>]): ";
+    const char tfecfFuncName[] = "CrsMatrix(RCP<const CrsGraph>, "
+      "local_matrix_type::values_type, "
+      "[,RCP<ParameterList>]): ";
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
       (graph.is_null (), std::runtime_error, "Input graph is null.");
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-      (! graph->isFillComplete (), std::runtime_error, "Input graph is not "
-       "fill complete. You must call fillComplete on the graph before using "
-       "it to construct a CrsMatrix.  Note that calling resumeFill on the "
-       "graph makes it not fill complete, even if you had previously called "
-       "fillComplete.  In that case, you must call fillComplete on the graph "
-       "again.");
+      (! graph->isFillComplete (), std::runtime_error, "Input graph "
+       "is not fill complete. You must call fillComplete on the "
+       "graph before using it to construct a CrsMatrix.  Note that "
+       "calling resumeFill on the graph makes it not fill complete, "
+       "even if you had previously called fillComplete.  In that "
+       "case, you must call fillComplete on the graph again.");
 
     // The graph is fill complete, so it is locally indexed and has a
     // fixed structure.  This means we can allocate the (1-D) array of
@@ -426,40 +406,48 @@ namespace Tpetra {
              const typename local_matrix_type::values_type& values,
              const Teuchos::RCP<Teuchos::ParameterList>& params) :
     dist_object_type (rowMap),
-    storageStatus_ (::Tpetra::Details::STORAGE_1D_PACKED),
-    fillComplete_ (false),
-    frobNorm_ (-STM::one ())
+    storageStatus_ (Details::STORAGE_1D_PACKED)
   {
+    using Details::getEntryOnHost;
     using Teuchos::RCP;
+    using std::endl;
     const char tfecfFuncName[] = "Tpetra::CrsMatrix(RCP<const Map>, "
       "RCP<const Map>, ptr, ind, val[, params]): ";
-    const char suffix[] = ".  Please report this bug to the Tpetra developers.";
-#ifdef HAVE_TPETRA_DEBUG
-    constexpr bool debug = true;
-#else
-    constexpr bool debug = false;
-#endif // HAVE_TPETRA_DEBUG
+    const char suffix[] =
+      ".  Please report this bug to the Tpetra developers.";
+    const bool debug = Details::Behavior::debug("CrsMatrix");
+    const bool verbose = Details::Behavior::verbose("CrsMatrix");
+
+    std::unique_ptr<std::string> prefix;
+    if (verbose) {
+      prefix = this->createPrefix(
+        "CrsMatrix", "CrsMatrix(rowMap,colMap,ptr,ind,val[,params])");
+      std::ostringstream os;
+      os << *prefix << "Start" << endl;
+      std::cerr << os.str ();
+    }
 
     // Check the user's input.  Note that this might throw only on
     // some processes but not others, causing deadlock.  We prefer
     // deadlock due to exceptions to segfaults, because users can
     // catch exceptions.
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-      (values.extent (0) != columnIndices.extent (0),
-       std::invalid_argument, "Input arrays don't have matching dimensions.  "
-       "values.extent(0) = " << values.extent (0) << " != "
-       "columnIndices.extent(0) = " << columnIndices.extent (0) << ".");
-    if (debug && rowPointers.extent (0) != 0) {
+      (values.extent(0) != columnIndices.extent(0),
+       std::invalid_argument, "values.extent(0)=" << values.extent(0)
+       << " != columnIndices.extent(0) = " << columnIndices.extent(0)
+       << ".");
+    if (debug && rowPointers.extent(0) != 0) {
       const size_t numEnt =
-        ::Tpetra::Details::getEntryOnHost (rowPointers, rowPointers.extent (0) - 1);
+        getEntryOnHost(rowPointers, rowPointers.extent(0) - 1);
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (numEnt != static_cast<size_t> (columnIndices.extent (0)) ||
-         numEnt != static_cast<size_t> (values.extent (0)),
-         std::invalid_argument, "Last entry of rowPointers says that the matrix"
-         " has " << numEnt << " entr" << (numEnt != 1 ? "ies" : "y") << ", but "
-         "the dimensions of columnIndices and values don't match this.  "
-         "columnIndices.extent(0) = " << columnIndices.extent (0) <<
-         " and values.extent(0) = " << values.extent (0) << ".");
+        (numEnt != size_t(columnIndices.extent(0)) ||
+         numEnt != size_t(values.extent(0)),
+         std::invalid_argument, "Last entry of rowPointers says that "
+         "the matrix has " << numEnt << " entr"
+         << (numEnt != 1 ? "ies" : "y") << ", but the dimensions of "
+         "columnIndices and values don't match this.  "
+         "columnIndices.extent(0)=" << columnIndices.extent (0)
+         << " and values.extent(0)=" << values.extent (0) << ".");
     }
 
     RCP<crs_graph_type> graph;
@@ -524,6 +512,11 @@ namespace Tpetra {
     this->k_values1D_ = newValues;
 
     checkInternalState ();
+    if (verbose) {
+      std::ostringstream os;
+      os << *prefix << "Done" << endl;
+      std::cerr << os.str();
+    }
   }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -535,15 +528,13 @@ namespace Tpetra {
              const Teuchos::ArrayRCP<Scalar>& val,
              const Teuchos::RCP<Teuchos::ParameterList>& params) :
     dist_object_type (rowMap),
-    storageStatus_ (::Tpetra::Details::STORAGE_1D_PACKED),
-    fillComplete_ (false),
-    frobNorm_ (-STM::one ())
+    storageStatus_ (Details::STORAGE_1D_PACKED)
   {
     using Kokkos::Compat::getKokkosViewDeepCopy;
     using Teuchos::av_reinterpret_cast;
     using Teuchos::RCP;
-    typedef typename local_matrix_type::values_type values_type;
-    typedef impl_scalar_type IST;
+    using values_type = typename local_matrix_type::values_type;
+    using IST = impl_scalar_type;
     const char tfecfFuncName[] = "Tpetra::CrsMatrix(RCP<const Map>, "
       "RCP<const Map>, ptr, ind, val[, params]): ";
 
@@ -610,9 +601,8 @@ namespace Tpetra {
     lclMatrix_ (std::make_shared<local_multiply_op_type>
                 (std::make_shared<local_matrix_type> (lclMatrix))),
     k_values1D_ (lclMatrix.values),
-    storageStatus_ (::Tpetra::Details::STORAGE_1D_PACKED),
-    fillComplete_ (true),
-    frobNorm_ (-STM::one ())
+    storageStatus_ (Details::STORAGE_1D_PACKED),
+    fillComplete_ (true)
   {
     const char tfecfFuncName[] = "Tpetra::CrsMatrix(RCP<const Map>, "
       "RCP<const Map>, local_matrix_type[, RCP<ParameterList>]): ";
@@ -677,9 +667,8 @@ namespace Tpetra {
     lclMatrix_ (std::make_shared<local_multiply_op_type>
                 (std::make_shared<local_matrix_type> (lclMatrix))),
     k_values1D_ (lclMatrix.values),
-    storageStatus_ (::Tpetra::Details::STORAGE_1D_PACKED),
-    fillComplete_ (true),
-    frobNorm_ (-STM::one ())
+    storageStatus_ (Details::STORAGE_1D_PACKED),
+    fillComplete_ (true)
   {
     const char tfecfFuncName[] = "Tpetra::CrsMatrix(RCP<const Map>, "
       "RCP<const Map>, RCP<const Map>, RCP<const Map>, "
@@ -747,9 +736,8 @@ namespace Tpetra {
     lclMatrix_ (std::make_shared<local_multiply_op_type>
                 (std::make_shared<local_matrix_type> (lclMatrix))),
     k_values1D_ (lclMatrix.values),
-    storageStatus_ (::Tpetra::Details::STORAGE_1D_PACKED),
-    fillComplete_ (true),
-    frobNorm_ (-STM::one ())
+    storageStatus_ (Details::STORAGE_1D_PACKED),
+    fillComplete_ (true)
   {
     using Teuchos::rcp;
     const char tfecfFuncName[] = "Tpetra::CrsMatrix"
@@ -1818,7 +1806,7 @@ namespace Tpetra {
       // The user requested optimized storage, so we can dump the
       // unpacked 1-D storage, and keep the packed storage.
       k_values1D_ = k_vals;
-      this->storageStatus_ = ::Tpetra::Details::STORAGE_1D_PACKED;
+      this->storageStatus_ = Details::STORAGE_1D_PACKED;
     }
 
     // Build the local sparse matrix object.  At this point, the local
@@ -3791,7 +3779,7 @@ namespace Tpetra {
 
     // Storage MUST be packed, since the interface doesn't give any
     // way to indicate any extra space at the end of each row.
-    this->storageStatus_ = ::Tpetra::Details::STORAGE_1D_PACKED;
+    this->storageStatus_ = Details::STORAGE_1D_PACKED;
 
     checkInternalState ();
   }

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -215,23 +215,16 @@ namespace Tpetra {
       "RCP<const Map>, size_t, ProfileType[, RCP<ParameterList>]): ";
     const char suffix[] =
       "  Please report this bug to the Tpetra developers.";
-#ifdef HAVE_TPETRA_DEBUG
-    constexpr bool debug = true;
-#else
-    constexpr bool debug = false;
-#endif // HAVE_TPETRA_DEBUG
 
-    if (debug) {
-      // An artifact of debugging something a while back.
-      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (! staticGraph_.is_null (), std::logic_error,
-         "staticGraph_ is not null at the beginning of the constructor."
-         << suffix);
-      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (! myGraph_.is_null (), std::logic_error,
-         "myGraph_ is not null at the beginning of the constructor."
-         << suffix);
-    }
+    // An artifact of debugging something a while back.
+    TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+      (! staticGraph_.is_null (), std::logic_error,
+       "staticGraph_ is not null at the beginning of the constructor."
+       << suffix);
+    TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+      (! myGraph_.is_null (), std::logic_error,
+       "myGraph_ is not null at the beginning of the constructor."
+       << suffix);
     Teuchos::RCP<crs_graph_type> graph;
     try {
       graph = Teuchos::rcp (new crs_graph_type (rowMap, colMap,
@@ -305,7 +298,7 @@ namespace Tpetra {
     if (verbose) {
       prefix = this->createPrefix("CrsMatrix", "CrsMatrix(graph,params)");
       std::ostringstream os;
-      os << *prefix << endl;
+      os << *prefix << "Start" << endl;
       std::cerr << os.str ();
     }
 
@@ -352,6 +345,12 @@ namespace Tpetra {
     k_values1D_ = lclMat->values;
 
     checkInternalState ();
+
+    if (verbose) {
+      std::ostringstream os;
+      os << *prefix << "Done" << endl;
+      std::cerr << os.str ();
+    }
   }
 
   template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -608,11 +607,6 @@ namespace Tpetra {
       "RCP<const Map>, local_matrix_type[, RCP<ParameterList>]): ";
     const char suffix[] =
       "  Please report this bug to the Tpetra developers.";
-#ifdef HAVE_TPETRA_DEBUG
-    constexpr bool debug = true;
-#else
-    constexpr bool debug = false;
-#endif // HAVE_TPETRA_DEBUG
 
     Teuchos::RCP<crs_graph_type> graph;
     try {
@@ -642,16 +636,14 @@ namespace Tpetra {
       this->computeGlobalConstants ();
     }
 
-    if (debug) {
-      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (isFillActive (), std::logic_error,
-         "At the end of a CrsMatrix constructor that should produce "
-         "a fillComplete matrix, isFillActive() is true." << suffix);
-      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (! isFillComplete (), std::logic_error, "At the end of a "
-         "CrsMatrix constructor that should produce a fillComplete "
-         "matrix, isFillComplete() is false." << suffix);
-    }
+    TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+      (isFillActive (), std::logic_error,
+       "At the end of a CrsMatrix constructor that should produce "
+       "a fillComplete matrix, isFillActive() is true." << suffix);
+    TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+      (! isFillComplete (), std::logic_error, "At the end of a "
+       "CrsMatrix constructor that should produce a fillComplete "
+       "matrix, isFillComplete() is false." << suffix);
     checkInternalState ();
   }
 
@@ -675,11 +667,6 @@ namespace Tpetra {
       "local_matrix_type[, RCP<ParameterList>]): ";
     const char suffix[] =
       "  Please report this bug to the Tpetra developers.";
-#ifdef HAVE_TPETRA_DEBUG
-    constexpr bool debug = true;
-#else
-    constexpr bool debug = false;
-#endif // HAVE_TPETRA_DEBUG
 
     Teuchos::RCP<crs_graph_type> graph;
     try {
@@ -709,16 +696,14 @@ namespace Tpetra {
       this->computeGlobalConstants ();
     }
 
-    if (debug) {
-      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (isFillActive (), std::logic_error,
-         "At the end of a CrsMatrix constructor that should produce "
-         "a fillComplete matrix, isFillActive() is true." << suffix);
-      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (! isFillComplete (), std::logic_error, "At the end of a "
-         "CrsMatrix constructor that should produce a fillComplete "
-         "matrix, isFillComplete() is false." << suffix);
-    }
+    TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+      (isFillActive (), std::logic_error,
+       "At the end of a CrsMatrix constructor that should produce "
+       "a fillComplete matrix, isFillActive() is true." << suffix);
+    TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+      (! isFillComplete (), std::logic_error, "At the end of a "
+       "CrsMatrix constructor that should produce a fillComplete "
+       "matrix, isFillComplete() is false." << suffix);
     checkInternalState ();
   }
 
@@ -744,11 +729,6 @@ namespace Tpetra {
       "(lclMat,Map,Map,Map,Map,Import,Export,params): ";
     const char suffix[] =
       "  Please report this bug to the Tpetra developers.";
-#ifdef HAVE_TPETRA_DEBUG
-    constexpr bool debug = true;
-#else
-    constexpr bool debug = false;
-#endif // HAVE_TPETRA_DEBUG
 
     Teuchos::RCP<crs_graph_type> graph;
     try {
@@ -779,16 +759,14 @@ namespace Tpetra {
       this->computeGlobalConstants ();
     }
 
-    if (debug) {
-      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (isFillActive (), std::logic_error,
-         "At the end of a CrsMatrix constructor that should produce "
-         "a fillComplete matrix, isFillActive() is true." << suffix);
-      TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (! isFillComplete (), std::logic_error, "At the end of a "
-         "CrsMatrix constructor that should produce a fillComplete "
-         "matrix, isFillComplete() is false." << suffix);
-    }
+    TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+      (isFillActive (), std::logic_error,
+       "At the end of a CrsMatrix constructor that should produce "
+       "a fillComplete matrix, isFillActive() is true." << suffix);
+    TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
+      (! isFillComplete (), std::logic_error, "At the end of a "
+       "CrsMatrix constructor that should produce a fillComplete "
+       "matrix, isFillComplete() is false." << suffix);
     checkInternalState ();
   }
 
@@ -1091,8 +1069,8 @@ namespace Tpetra {
   allocateValues (ELocalGlobal lg, GraphAllocationStatus gas,
                   const bool verbose)
   {
-    using ::Tpetra::Details::Behavior;
-    using ::Tpetra::Details::ProfilingRegion;
+    using Details::Behavior;
+    using Details::ProfilingRegion;
     using std::endl;
     const char tfecfFuncName[] = "allocateValues: ";
     const char suffix[] =
@@ -1103,12 +1081,12 @@ namespace Tpetra {
     if (verbose) {
       prefix = this->createPrefix("CrsMatrix", "allocateValues");
       std::ostringstream os;
-      os << *prefix << "{lg: "
+      os << *prefix << "lg: "
          << (lg == LocalIndices ? "Local" : "Global") << "Indices"
          << ", gas: Graph"
          << (gas == GraphAlreadyAllocated ? "Already" : "NotYet")
          << "Allocated" << endl;
-      std::cerr << os.str ();
+      std::cerr << os.str();
     }
 
     const bool debug = Behavior::debug("CrsMatrix");
@@ -1289,9 +1267,10 @@ namespace Tpetra {
       // fillComplete() only calls fillLocalGraphAndMatrix() if the
       // matrix owns the graph, which means myGraph_ is not null.
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
-        (myGraph_.is_null (), std::logic_error, "The nonconst graph (myGraph_) "
-         "is null.  This means that the matrix has a const (a.k.a. \"static\") "
-         "graph.  fillComplete or expertStaticFillComplete should never call "
+        (myGraph_.is_null (), std::logic_error, "The nonconst graph "
+         "(myGraph_) is null.  This means that the matrix has a "
+         "const (a.k.a. \"static\") graph.  fillComplete or "
+         "expertStaticFillComplete should never call "
          "fillLocalGraphAndMatrix in that case." << suffix);
     }
 
@@ -1664,10 +1643,7 @@ namespace Tpetra {
     using row_map_type = typename Graph::local_graph_type::row_map_type;
     using non_const_row_map_type = typename row_map_type::non_const_type;
     using values_type = typename local_matrix_type::values_type;
-#ifdef HAVE_TPETRA_DEBUG
-    // const char tfecfFuncName[] = "fillLocalMatrix (called from fillComplete): ";
-#endif // HAVE_TPETRA_DEBUG
-    ProfilingRegion regionFLM ("Tpetra::CrsMatrix::fillLocalMatrix");
+    ProfilingRegion regionFLM("Tpetra::CrsMatrix::fillLocalMatrix");
     const size_t lclNumRows = getNodeNumRows();
 
     const bool verbose = Details::Behavior::verbose("CrsMatrix");
@@ -2679,10 +2655,12 @@ namespace Tpetra {
       // Teuchos::ArrayView, and in part because of the data structure
       // used to stash outgoing entries.
       using Teuchos::ArrayView;
-      ArrayView<const GO> inputGblColInds_av (numInputEnt == 0 ? NULL :
-                                              inputGblColInds, numInputEnt);
-      ArrayView<const Scalar> inputVals_av (numInputEnt == 0 ? NULL :
-                                            inputVals, numInputEnt);
+      ArrayView<const GO> inputGblColInds_av(
+        numInputEnt == 0 ? nullptr : inputGblColInds,
+        numInputEnt);
+      ArrayView<const Scalar> inputVals_av(
+        numInputEnt == 0 ? nullptr :
+        inputVals, numInputEnt);
       // gblRow is not in the row Map on the calling process, so stash
       // the given entries away in a separate data structure.
       // globalAssemble() (called during fillComplete()) will exchange
@@ -3577,8 +3555,8 @@ namespace Tpetra {
       const RowInfo rowInfo = staticGraph_->getRowInfo (lclRow);
       if (rowInfo.localRow == Tpetra::Details::OrdinalTraits<size_t>::invalid ()) {
         numEnt = 0; // no valid entries in this row on the calling process
-        val = NULL;
-        ind = NULL;
+        val = nullptr;
+        ind = nullptr;
         // First argument (lclRow) invalid, so make 1 the error code.
         return static_cast<LO> (1);
       }
@@ -3600,7 +3578,7 @@ namespace Tpetra {
                       const LocalOrdinal*& lclColInds,
                       const Scalar*& vals) const
   {
-    const impl_scalar_type* vals_ist = NULL;
+    const impl_scalar_type* vals_ist = nullptr;
     const LocalOrdinal errCode =
       this->getLocalRowView (lclRow, numEnt, vals_ist, lclColInds);
     vals = reinterpret_cast<const Scalar*> (vals_ist);
@@ -4275,10 +4253,10 @@ namespace Tpetra {
   {
     const char tfecfFuncName[] = "reindexColumns: ";
     TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC(
-      graph == NULL && myGraph_.is_null (), std::invalid_argument,
-      "The input graph is NULL, but the matrix does not own its graph.");
+      graph == nullptr && myGraph_.is_null (), std::invalid_argument,
+      "The input graph is null, but the matrix does not own its graph.");
 
-    crs_graph_type& theGraph = (graph == NULL) ? *myGraph_ : *graph;
+    crs_graph_type& theGraph = (graph == nullptr) ? *myGraph_ : *graph;
     const bool sortGraph = false; // we'll sort graph & matrix together below
     theGraph.reindexColumns (newColMap, newImport, sortGraph);
     if (sortEachRow && theGraph.isLocallyIndexed () && ! theGraph.isSorted ()) {
@@ -5413,7 +5391,7 @@ namespace Tpetra {
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
         (! X.isConstantStride () || ! Y.isConstantStride (),
          std::runtime_error, "X and Y must be constant stride.");
-      // If the two pointers are NULL, then they don't alias one
+      // If the two pointers are null, then they don't alias one
       // another, even though they are equal.
       TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
         (X_lcl.data () == Y_lcl.data () && X_lcl.data () != nullptr,
@@ -6415,7 +6393,7 @@ namespace Tpetra {
     typedef RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> row_matrix_type;
     const row_matrix_type* srcRowMat =
       dynamic_cast<const row_matrix_type*> (&source);
-    return (srcRowMat != NULL);
+    return (srcRowMat != nullptr);
   }
 
   template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -8261,14 +8239,28 @@ namespace Tpetra {
     using Teuchos::rcp;
     using Teuchos::rcp_implicit_cast;
     using Teuchos::sublist;
-    typedef LocalOrdinal LO;
-    typedef GlobalOrdinal GO;
-    typedef RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> row_matrix_type;
-    typedef CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> crs_matrix_type;
+    using std::endl;
+    using LO = local_ordinal_type;
+    using GO = global_ordinal_type;
+    using row_matrix_type =
+      RowMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
+    using crs_matrix_type =
+      CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
+    const char errPfx[] = "Tpetra::CrsMatrix::add: ";
+
+    const bool debug = Details::Behavior::debug("CrsMatrix");
+    const bool verbose = Details::Behavior::verbose("CrsMatrix");
+    std::unique_ptr<std::string> prefix;
+    if (verbose) {
+      prefix = this->createPrefix("CrsMatrix", "add");
+      std::ostringstream os;
+      os << *prefix << "Start" << endl;
+      std::cerr << os.str ();
+    }
 
     const crs_matrix_type& B = *this; // a convenient abbreviation
-    const Scalar ZERO = Teuchos::ScalarTraits<Scalar>::zero ();
-    const Scalar ONE = Teuchos::ScalarTraits<Scalar>::one ();
+    const Scalar ZERO = Teuchos::ScalarTraits<Scalar>::zero();
+    const Scalar ONE = Teuchos::ScalarTraits<Scalar>::one();
 
     // If the user didn't supply a domain or range Map, then try to
     // get one from B first (if it has them), then from A (if it has
@@ -8305,52 +8297,58 @@ namespace Tpetra {
       }
     }
 
-#ifdef HAVE_TPETRA_DEBUG
-    // In a debug build, check that A and B have matching domain and
-    // range Maps, if they have domain and range Maps at all.  (If
-    // they aren't fill complete, then they may not yet have them.)
-    if (! A_domainMap.is_null () && ! A_rangeMap.is_null ()) {
-      if (! B_domainMap.is_null () && ! B_rangeMap.is_null ()) {
-        TEUCHOS_TEST_FOR_EXCEPTION(
-          ! B_domainMap->isSameAs (*A_domainMap), std::invalid_argument,
-          "Tpetra::CrsMatrix::add: The input RowMatrix A must have a domain Map "
-          "which is the same as (isSameAs) this RowMatrix's domain Map.");
-        TEUCHOS_TEST_FOR_EXCEPTION(
-          ! B_rangeMap->isSameAs (*A_rangeMap), std::invalid_argument,
-          "Tpetra::CrsMatrix::add: The input RowMatrix A must have a range Map "
-          "which is the same as (isSameAs) this RowMatrix's range Map.");
-        TEUCHOS_TEST_FOR_EXCEPTION(
-          ! domainMap.is_null () && ! domainMap->isSameAs (*B_domainMap),
-          std::invalid_argument,
-          "Tpetra::CrsMatrix::add: The input domain Map must be the same as "
-          "(isSameAs) this RowMatrix's domain Map.");
-        TEUCHOS_TEST_FOR_EXCEPTION(
-          ! rangeMap.is_null () && ! rangeMap->isSameAs (*B_rangeMap),
-          std::invalid_argument,
-          "Tpetra::CrsMatrix::add: The input range Map must be the same as "
-          "(isSameAs) this RowMatrix's range Map.");
+    if (debug) {
+      // In debug mode, check that A and B have matching domain and
+      // range Maps, if they have domain and range Maps at all.  (If
+      // they aren't fill complete, then they may not yet have them.)
+      if (! A_domainMap.is_null() && ! A_rangeMap.is_null()) {
+        if (! B_domainMap.is_null() && ! B_rangeMap.is_null()) {
+          TEUCHOS_TEST_FOR_EXCEPTION
+            (! B_domainMap->isSameAs(*A_domainMap),
+             std::invalid_argument,
+             errPfx << "The input RowMatrix A must have a domain Map "
+             "which is the same as (isSameAs) this RowMatrix's "
+             "domain Map.");
+          TEUCHOS_TEST_FOR_EXCEPTION
+            (! B_rangeMap->isSameAs(*A_rangeMap), std::invalid_argument,
+             errPfx << "The input RowMatrix A must have a range Map "
+             "which is the same as (isSameAs) this RowMatrix's range "
+             "Map.");
+          TEUCHOS_TEST_FOR_EXCEPTION
+            (! domainMap.is_null() &&
+             ! domainMap->isSameAs(*B_domainMap),
+             std::invalid_argument,
+             errPfx << "The input domain Map must be the same as "
+             "(isSameAs) this RowMatrix's domain Map.");
+          TEUCHOS_TEST_FOR_EXCEPTION
+            (! rangeMap.is_null() &&
+             ! rangeMap->isSameAs(*B_rangeMap),
+             std::invalid_argument,
+             errPfx << "The input range Map must be the same as "
+             "(isSameAs) this RowMatrix's range Map.");
+        }
+      }
+      else if (! B_domainMap.is_null() && ! B_rangeMap.is_null()) {
+        TEUCHOS_TEST_FOR_EXCEPTION
+          (! domainMap.is_null() &&
+           ! domainMap->isSameAs(*B_domainMap),
+           std::invalid_argument,
+           errPfx << "The input domain Map must be the same as "
+           "(isSameAs) this RowMatrix's domain Map.");
+        TEUCHOS_TEST_FOR_EXCEPTION
+          (! rangeMap.is_null() && ! rangeMap->isSameAs(*B_rangeMap),
+           std::invalid_argument,
+           errPfx << "The input range Map must be the same as "
+           "(isSameAs) this RowMatrix's range Map.");
+      }
+      else {
+        TEUCHOS_TEST_FOR_EXCEPTION
+          (domainMap.is_null() || rangeMap.is_null(),
+           std::invalid_argument, errPfx << "If neither A nor B "
+           "have a domain and range Map, then you must supply a "
+           "nonnull domain and range Map to this method.");
       }
     }
-    else if (! B_domainMap.is_null () && ! B_rangeMap.is_null ()) {
-      TEUCHOS_TEST_FOR_EXCEPTION(
-        ! domainMap.is_null () && ! domainMap->isSameAs (*B_domainMap),
-        std::invalid_argument,
-        "Tpetra::CrsMatrix::add: The input domain Map must be the same as "
-        "(isSameAs) this RowMatrix's domain Map.");
-      TEUCHOS_TEST_FOR_EXCEPTION(
-        ! rangeMap.is_null () && ! rangeMap->isSameAs (*B_rangeMap),
-        std::invalid_argument,
-        "Tpetra::CrsMatrix::add: The input range Map must be the same as "
-        "(isSameAs) this RowMatrix's range Map.");
-    }
-    else {
-      TEUCHOS_TEST_FOR_EXCEPTION(
-        domainMap.is_null () || rangeMap.is_null (), std::invalid_argument,
-        "Tpetra::CrsMatrix::add: If neither A nor B have a domain and range "
-        "Map, then you must supply a nonnull domain and range Map to this "
-        "method.");
-    }
-#endif // HAVE_TPETRA_DEBUG
 
     // What parameters do we pass to C's constructor?  Do we call
     // fillComplete on C after filling it?  And if so, what parameters
@@ -8358,10 +8356,11 @@ namespace Tpetra {
     bool callFillComplete = true;
     RCP<ParameterList> constructorSublist;
     RCP<ParameterList> fillCompleteSublist;
-    if (! params.is_null ()) {
-      callFillComplete = params->get ("Call fillComplete", callFillComplete);
-      constructorSublist = sublist (params, "Constructor parameters");
-      fillCompleteSublist = sublist (params, "fillComplete parameters");
+    if (! params.is_null()) {
+      callFillComplete =
+        params->get("Call fillComplete", callFillComplete);
+      constructorSublist = sublist(params, "Constructor parameters");
+      fillCompleteSublist = sublist(params, "fillComplete parameters");
     }
 
     RCP<const map_type> A_rowMap = A.getRowMap ();
@@ -8409,22 +8408,23 @@ namespace Tpetra {
     else { // the row Maps of A and B are not the same
       // Construct the result matrix C.
       // true: !A_rowMap->isSameAs (*B_rowMap)
-      TEUCHOS_TEST_FOR_EXCEPTION(true,
-                                 std::invalid_argument,
-                                 "Tpetra::CrsMatrix::add: The row maps must be the same for statically "
-                                 "allocated matrices in order to be sure that there is sufficient space "
-                                 "to do the addition");
-
+      TEUCHOS_TEST_FOR_EXCEPTION
+        (true, std::invalid_argument, errPfx << "The row maps must "
+         "be the same for statically allocated matrices, to ensure "
+         "that there is sufficient space to do the addition.");
     }
 
-#ifdef HAVE_TPETRA_DEBUG
-    TEUCHOS_TEST_FOR_EXCEPTION(C.is_null (), std::logic_error,
-      "Tpetra::RowMatrix::add: C should not be null at this point.  "
-      "Please report this bug to the Tpetra developers.");
-#endif // HAVE_TPETRA_DEBUG
-    //
-    // Compute C = alpha*A + beta*B.
-    //
+    TEUCHOS_TEST_FOR_EXCEPTION
+      (C.is_null (), std::logic_error,
+       errPfx << "C should not be null at this point.  "
+       "Please report this bug to the Tpetra developers.");
+
+    if (verbose) {
+      std::ostringstream os;
+      os << *prefix << "Compute C = alpha*A + beta*B" << endl;
+      std::cerr << os.str ();
+    }
+
     Array<GO> ind;
     Array<Scalar> val;
 
@@ -8473,11 +8473,27 @@ namespace Tpetra {
     }
 
     if (callFillComplete) {
+      if (verbose) {
+        std::ostringstream os;
+        os << *prefix << "Call fillComplete on C" << endl;
+        std::cerr << os.str ();
+      }
       if (fillCompleteSublist.is_null ()) {
         C->fillComplete (theDomainMap, theRangeMap);
       } else {
         C->fillComplete (theDomainMap, theRangeMap, fillCompleteSublist);
       }
+    }
+    else if (verbose) {
+      std::ostringstream os;
+      os << *prefix << "Do NOT call fillComplete on C" << endl;
+      std::cerr << os.str ();
+    }
+
+    if (verbose) {
+      std::ostringstream os;
+      os << *prefix << "Done" << endl;
+      std::cerr << os.str ();
     }
     return rcp_implicit_cast<row_matrix_type> (C);
   }
@@ -8521,7 +8537,7 @@ namespace Tpetra {
       verbosePrefix =
         this->createPrefix("CrsMatrix", "transferAndFillComplete");
       std::ostringstream os;
-      os << "start" << endl;
+      os << "Start" << endl;
       std::cerr << os.str();
     }
 
@@ -8532,7 +8548,8 @@ namespace Tpetra {
     bool reverseMode = false; // Are we in reverse mode?
     bool restrictComm = false; // Do we need to restrict the communicator?
 
-    int mm_optimization_core_count=::Tpetra::Details::Behavior::TAFC_OptimizationCoreCount();
+    int mm_optimization_core_count =
+      Behavior::TAFC_OptimizationCoreCount();
     RCP<ParameterList> matrixparams; // parameters for the destination matrix
     bool overrideAllreduce = false;
     if (! params.is_null ()) {
@@ -8589,7 +8606,7 @@ namespace Tpetra {
     const import_type* xferAsImport = dynamic_cast<const import_type*> (&rowTransfer);
     const export_type* xferAsExport = dynamic_cast<const export_type*> (&rowTransfer);
     TEUCHOS_TEST_FOR_EXCEPTION(
-      xferAsImport == NULL && xferAsExport == NULL, std::invalid_argument,
+      xferAsImport == nullptr && xferAsExport == nullptr, std::invalid_argument,
       "Tpetra::CrsMatrix::transferAndFillComplete: The 'rowTransfer' input "
       "argument must be either an Import or an Export, and its template "
       "parameters must match the corresponding template parameters of the "
@@ -8612,16 +8629,16 @@ namespace Tpetra {
         "CrsMatrix.");
 
       TEUCHOS_TEST_FOR_EXCEPTION(
-         ( xferAsImport != NULL || ! xferDomainAsImport.is_null() ) &&
-         (( xferAsImport != NULL &&   xferDomainAsImport.is_null() ) ||
-          ( xferAsImport == NULL && ! xferDomainAsImport.is_null() )), std::invalid_argument,
+         ( xferAsImport != nullptr || ! xferDomainAsImport.is_null() ) &&
+         (( xferAsImport != nullptr &&   xferDomainAsImport.is_null() ) ||
+          ( xferAsImport == nullptr && ! xferDomainAsImport.is_null() )), std::invalid_argument,
          "Tpetra::CrsMatrix::transferAndFillComplete: The 'rowTransfer' and 'domainTransfer' input "
          "arguments must be of the same type (either Import or Export).");
 
       TEUCHOS_TEST_FOR_EXCEPTION(
-         ( xferAsExport != NULL || ! xferDomainAsExport.is_null() ) &&
-         (( xferAsExport != NULL &&   xferDomainAsExport.is_null() ) ||
-          ( xferAsExport == NULL && ! xferDomainAsExport.is_null() )), std::invalid_argument,
+         ( xferAsExport != nullptr || ! xferDomainAsExport.is_null() ) &&
+         (( xferAsExport != nullptr &&   xferDomainAsExport.is_null() ) ||
+          ( xferAsExport == nullptr && ! xferDomainAsExport.is_null() )), std::invalid_argument,
          "Tpetra::CrsMatrix::transferAndFillComplete: The 'rowTransfer' and 'domainTransfer' input "
          "arguments must be of the same type (either Import or Export).");
     } // domainTransfer != null
@@ -8877,16 +8894,16 @@ namespace Tpetra {
       IntVectorType SourceCol_pids (getColMap ());
 
       TargetRow_pids.putScalar (MyPID);
-      if (! reverseMode && xferAsImport != NULL) {
+      if (! reverseMode && xferAsImport != nullptr) {
         SourceRow_pids.doExport (TargetRow_pids, *xferAsImport, INSERT);
       }
-      else if (reverseMode && xferAsExport != NULL) {
+      else if (reverseMode && xferAsExport != nullptr) {
         SourceRow_pids.doExport (TargetRow_pids, *xferAsExport, INSERT);
       }
-      else if (! reverseMode && xferAsExport != NULL) {
+      else if (! reverseMode && xferAsExport != nullptr) {
         SourceRow_pids.doImport (TargetRow_pids, *xferAsExport, INSERT);
       }
-      else if (reverseMode && xferAsImport != NULL) {
+      else if (reverseMode && xferAsImport != nullptr) {
         SourceRow_pids.doImport (TargetRow_pids, *xferAsImport, INSERT);
       }
       else {
@@ -9390,23 +9407,24 @@ namespace Tpetra {
     /***************************************************/
     /**** 5) Sort                                   ****/
     /***************************************************/
-    if ((! reverseMode && xferAsImport != NULL) ||
-        (reverseMode && xferAsExport != NULL)) {
+    if ((! reverseMode && xferAsImport != nullptr) ||
+        (reverseMode && xferAsExport != nullptr)) {
       if (verbose) {
         std::ostringstream os;
-        os << *verbosePrefix << "Calling sortCrsEntries" << std::endl;
+        os << *verbosePrefix << "Calling sortCrsEntries" << endl;
         std::cerr << os.str ();
       }
       Import_Util::sortCrsEntries (CSR_rowptr (),
                                    CSR_colind_LID (),
                                    CSR_vals ());
     }
-    else if ((! reverseMode && xferAsExport != NULL) ||
-             (reverseMode && xferAsImport != NULL)) {
+    else if ((! reverseMode && xferAsExport != nullptr) ||
+             (reverseMode && xferAsImport != nullptr)) {
       if (verbose) {
         std::ostringstream os;
-        os << *verbosePrefix << "Calling sortAndMergeCrsEntries" << std::endl;
-        std::cerr << os.str ();
+        os << *verbosePrefix << "Calling sortAndMergeCrsEntries"
+           << endl;
+        std::cerr << os.str();
       }
       Import_Util::sortAndMergeCrsEntries (CSR_rowptr (),
                                            CSR_colind_LID (),
@@ -9428,7 +9446,7 @@ namespace Tpetra {
 
     if (verbose) {
       std::ostringstream os;
-      os << *verbosePrefix << "Calling destMat->setAllValues" << std::endl;
+      os << *verbosePrefix << "Calling destMat->setAllValues" << endl;
       std::cerr << os.str ();
     }
 
@@ -9451,7 +9469,8 @@ namespace Tpetra {
     if (iallreduceRequest.get () != nullptr) {
       if (verbose) {
         std::ostringstream os;
-        os << *verbosePrefix << "Calling iallreduceRequest->wait()" << std::endl;
+        os << *verbosePrefix << "Calling iallreduceRequest->wait()"
+           << endl;
         std::cerr << os.str ();
       }
       iallreduceRequest->wait ();
@@ -9468,7 +9487,7 @@ namespace Tpetra {
 
         if (verbose) {
           std::ostringstream os;
-          os << *verbosePrefix << "Calling getAllValues" << std::endl;
+          os << *verbosePrefix << "Calling getAllValues" << endl;
           std::cerr << os.str ();
         }
 
@@ -9681,7 +9700,7 @@ namespace Tpetra {
 
       if (verbose) {
         std::ostringstream os;
-        os << *verbosePrefix << "Call expertStaticFillComplete" << std::endl;
+        os << *verbosePrefix << "Call expertStaticFillComplete" << endl;
         std::cerr << os.str ();
       }
 
@@ -9703,7 +9722,7 @@ namespace Tpetra {
 
     if (verbose) {
       std::ostringstream os;
-      os << *verbosePrefix << "Done!" << std::endl;
+      os << *verbosePrefix << "Done" << endl;
       std::cerr << os.str ();
     }
   }

--- a/packages/tpetra/core/src/Tpetra_DistObject_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_DistObject_decl.hpp
@@ -908,7 +908,7 @@ namespace Tpetra {
     std::unique_ptr<std::string>
     createPrefix(const char className[],
                  const char methodName[]) const;
-    
+
     /// \brief Buffer into which packed data are imported (received
     ///   from other processes).
     ///


### PR DESCRIPTION
@trilinos/tpetra 

- Remove references to DynamicProfile from CrsGraph and CrsMatrix documentation
- Remove redundant initialization
- Remove a function that PR #6845 made redundant
- Make more CrsMatrix debug checks a run-time choice
- De-template some CrsMatrix methods that didn't need to be templated

## Motivation

Y'all thought it was a good idea to remove DynamicProfile from CrsGraph and CrsMatrix; this commit finishes the process by updating the documentation.

## Related Issues

* Related to #4701, #4755, #6655 

## Testing

Mac Clang, OpenMPI.