### PR TITLE
Framework: Fixing PR test driver python script tests

### DIFF
--- a/cmake/std/PullRequestLinuxDriverTest.py
+++ b/cmake/std/PullRequestLinuxDriverTest.py
@@ -415,6 +415,8 @@ def getCDashTrack():
 def get_memory_info():
     """
     Get memory information
+
+    Returns dictionary : ["mem_gb": <Gigabytes of Memory>, "mem_kb": <Kilobytes of Memory>]
     """
     mem_kb = None
 
@@ -584,6 +586,7 @@ ERROR : Source branch is NOT trilinos/Trilinos::master_merge_YYYYMMDD_HHMMSS
                            'package_subproject_list.cmake'])
 
     return return_value
+
 
 
 if __name__ == '__main__':  # pragma nocover

--- a/cmake/std/unittests/TestPullRequestLinuxDriverMerge.py
+++ b/cmake/std/unittests/TestPullRequestLinuxDriverMerge.py
@@ -29,8 +29,10 @@ from subprocess import CalledProcessError
 import PullRequestLinuxDriverMerge
 
 
+
 class Test_header(unittest.TestCase):
     '''Test that we can properly echo the header information'''
+
     def test_writeHeader(self):
         with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
             PullRequestLinuxDriverMerge.write_header()
@@ -43,9 +45,9 @@ class Test_header(unittest.TestCase):
                          m_stdout.getvalue())
 
 
+
 class Test_EchoJenkinsVars(unittest.TestCase):
     '''Test that the Jenkins environment is echoed properly'''
-
 
     def setUp(self):
         self.m_environ = mock.patch.dict(os.environ, {'JOB_BASE_NAME':'TEST_JOB_BASE_NAME',
@@ -89,6 +91,7 @@ Environment:
         self.assertEqual(expected_string, m_stdout.getvalue())
 
 
+
 class Test_parsing(unittest.TestCase):
     '''Finally given a decent parser I want to now pass
        all parameters and check them'''
@@ -124,6 +127,7 @@ class Test_parsing(unittest.TestCase):
             args = PullRequestLinuxDriverMerge.parseArgs()
         self.assertEqual(test_namespace, args)
 
+
     def test_parseInsufficientArgs_fails(self):
         test_namespace = Namespace()
         setattr(test_namespace, 'sourceRepo', '/dev/null/source/Trilinos.git')
@@ -149,9 +153,11 @@ sourceBranch, targetRepo, targetBranch, sourceSHA, workspaceDir
         self.assertEqual(expected_output, m_stderr.getvalue())
 
 
+
 class Test_mergeBranch(unittest.TestCase):
     '''Verify that we call the correct sequence to merge the source branch/SHA
        into the target branch'''
+
     def test_mergeBranch_without_source_remote(self):
         with mock.patch('subprocess.check_output',
                         side_effect=['origin /dev/null/target/Trilinos',
@@ -311,8 +317,10 @@ class Test_mergeBranch(unittest.TestCase):
                          m_stdout.getvalue())
 
 
+
 class Test_run(unittest.TestCase):
     '''This is the main function that ties everything together in order'''
+
     def test_run(self):
         with mock.patch('PullRequestLinuxDriverMerge.parseArgs') as m_parser, \
             mock.patch('os.chdir') as m_chdir, \
@@ -338,6 +346,7 @@ class Test_run(unittest.TestCase):
         with mock.patch('PullRequestLinuxDriverMerge.parseArgs',
                         side_effect=SystemExit(2)):
             self.assertFalse(PullRequestLinuxDriverMerge.run())
+
 
     def test_run_fails_on_bad_fetch(self):
         with mock.patch('subprocess.check_output',
@@ -376,6 +385,8 @@ class Test_run(unittest.TestCase):
             mock.patch('os.chdir'):
             self.assertFalse(PullRequestLinuxDriverMerge.run())
         self.assertTrue(m_stdout.getvalue().endswith(expected_string))
+
+
 
 
 if __name__ == '__main__':

--- a/cmake/std/unittests/TestPullRequestLinuxDriverTest.py
+++ b/cmake/std/unittests/TestPullRequestLinuxDriverTest.py
@@ -10,6 +10,7 @@ sys.dont_write_bytecode = True
 import os
 sys.path.insert(1, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+from textwrap import dedent
 
 import unittest
 
@@ -23,16 +24,20 @@ try:
 except ImportError:  # pragma nocover
     import unittest.mock as mock
 
+
 from argparse import Namespace
 from subprocess import CalledProcessError
 
 if 'MODULESHOME' not in os.environ: # for things like our macs
     os.environ['MODULESHOME'] = os.getcwd()
+
 import PullRequestLinuxDriverTest
+
 
 
 class Test_run(unittest.TestCase):
     """Does the run script exist?"""
+
     def setUp(self):
         self.source_branch = 'incoming_branch'
         self.source_url = '/dev/null/source/Trilinos.git'
@@ -68,6 +73,7 @@ class Test_run(unittest.TestCase):
                                                      'WORKSPACE': self.jenkins_workspace,
                                                      'NODE_NAME': 'TEST_NODE_NAME'},
                                          clear=True)
+
 
     def test_verifyGit_fails_with_old_version(self):
         """Check to see that git is in path"""
@@ -217,8 +223,8 @@ Set CWD = /dev/null/workspace
         with self.m_environ:
             env_string_io = StringIO()
             for key in os.environ:
-                print(key + ' = ' + os.environ[key],
-                      file=env_string_io)
+                print(key + ' = ' + os.environ[key], file=env_string_io)
+
         expected_out = """
 ==========================================================================================
 Jenkins Input Variables:
@@ -252,8 +258,8 @@ Set CWD = /dev/null/workspace
                 self.m_environ, \
                 mock.patch('PullRequestLinuxDriverTest.createPackageEnables'), \
                 mock.patch('PullRequestLinuxDriverTest.setBuildEnviron'), \
-                mock.patch('PullRequestLinuxDriverTest.getCDashTrack',
-                           return_value='testTrack'):
+                mock.patch('PullRequestLinuxDriverTest.compute_n', return_value=20), \
+                mock.patch('PullRequestLinuxDriverTest.getCDashTrack', return_value='testTrack'):
             PullRequestLinuxDriverTest.run()
 
         self.assertEqual(expected_out, m_output.getvalue())
@@ -268,6 +274,7 @@ Set CWD = /dev/null/workspace
                                         '-Dconfigure_script=/dev/null/workspace/Trilinos/cmake/std/dummyConfig.cmake',
                                         '-Dpackage_enables=../packageEnables.cmake',
                                         '-Dsubprojects_file=../TFW_single_configure_support_scripts/package_subproject_list.cmake'])
+
 
 
 class Test_createPackageEnables(unittest.TestCase):
@@ -302,6 +309,7 @@ ENDMACRO()
 ''')
             f_out.write("PR_ENABLE_BOOL(Trilinos_ENABLE_FooPackageBar ON)")
 
+
     def test_call_success(self):
         expected_output = '''Enabled packages:
 -- Setting Trilinos_ENABLE_FooPackageBar = ON
@@ -323,6 +331,7 @@ ENDMACRO()
         self.assertEqual(expected_output, m_stdout.getvalue())
         os.unlink('packageEnables.cmake')
 
+
     def test_call_python2(self):
         expected_output = '''Enabled packages:
 -- Setting Trilinos_ENABLE_TrilinosFrameworkTests = ON
@@ -338,6 +347,7 @@ ENDMACRO()
         m_out.assert_not_called()
         self.assertEqual(expected_output, m_stdout.getvalue())
         os.unlink('packageEnables.cmake')
+
 
     def test_call_failure(self):
         expected_output = '''There was an issue generating packageEnables.cmake.  The error code was: 39
@@ -357,6 +367,7 @@ ENDMACRO()
                                                     self.target_branch),
                                        'HEAD', 'packageEnables.cmake'])
         self.assertEqual(expected_output, m_stdout.getvalue())
+
 
 
 class Test_setEnviron(unittest.TestCase):
@@ -390,6 +401,7 @@ class Test_setEnviron(unittest.TestCase):
         setattr(self.arguments, 'job_base_name', self.job_base_name)
         setattr(self.arguments, 'github_pr_number', self.github_pr_number)
         setattr(self.arguments, 'workspaceDir', self.jenkins_workspace)
+
 
     def test_buildEnv_fails_with_unknown(self):
         """Find the function"""
@@ -632,6 +644,7 @@ class Test_setEnviron(unittest.TestCase):
         self.buildEnv_passes(PR_name, expected_list,
                              test_ENV={'OMP_NUM_THREADS': '2'})
 
+
     def test_buildEnv_passes_with_intel_1701(self):
         """Find the function"""
         PR_name = 'Trilinos_pullrequest_intel_17.0.1'
@@ -696,6 +709,7 @@ class Test_setEnviron(unittest.TestCase):
         self.buildEnv_passes(PR_name, expected_list, test_ENV=expected_env)
 
 
+
 class Test_GetCDashTrack(unittest.TestCase):
     """use the default or override from environment"""
 
@@ -727,13 +741,16 @@ class Test_GetCDashTrack(unittest.TestCase):
         self.assertEqual(expected_output, m_output.getvalue())
 
 
+
 class testCompute_n(unittest.TestCase):
     '''How many processors will we use based on memory limits'''
+
 
     def setUp(self):
         self.m_environ = mock.patch.dict(os.environ,
                                          {'JENKINS_JOB_WEIGHT': '29'},
                                          clear=True)
+
 
     def test_over_weight(self):
         '''if the jenkins job weight is set higher than the  machines nprocs
@@ -745,44 +762,58 @@ class testCompute_n(unittest.TestCase):
             parallel_level = PullRequestLinuxDriverTest.compute_n()
         self.assertEqual(10, parallel_level)
 
-    def test_32p_64g(self):
-        '''check we match whats on 113-115 and the cloud'''
-        m_open =  mock.mock_open(read_data='''MemTotal 65805212 kB''')
+
+    def helper_call_compute_n(self, num_cpu, mem_kb, expected_cpu_count):
+        """
+        """
+        mem_gb   = mem_kb / (1024**2)
+
+        mem_info = {"mem_kb": mem_kb, "mem_gb": mem_gb}
+        m_open   = mock.mock_open(read_data=f"MemTotal ${mem_kb} kB")
+
         with self.m_environ, \
             mock.patch('PullRequestLinuxDriverTest.open', m_open, create=True), \
-            mock.patch('PullRequestLinuxDriverTest.cpu_count', return_value=32):
+            mock.patch('PullRequestLinuxDriverTest.cpu_count', return_value=num_cpu), \
+            mock.patch('PullRequestLinuxDriverTest.get_memory_info', return_value=mem_info):
             parallel_level = PullRequestLinuxDriverTest.compute_n()
-        self.assertEqual(20, parallel_level)
+        self.assertEqual(expected_cpu_count, parallel_level)
+
+
+    def test_32p_64g(self):
+        '''check we match whats on 113-115 and the cloud'''
+        num_cpu  = 32
+        mem_kb   = 65805212
+        expected_cpu_count = 20
+
+        self.helper_call_compute_n(num_cpu, mem_kb, expected_cpu_count)
 
 
     def test_72p_64g(self):
         '''match whats on the 14x series'''
-        m_open =  mock.mock_open(read_data='''MemTotal 65805212 kB''')
-        with self.m_environ, \
-            mock.patch('PullRequestLinuxDriverTest.open', m_open, create=True), \
-            mock.patch('PullRequestLinuxDriverTest.cpu_count', return_value=72):
-            parallel_level = PullRequestLinuxDriverTest.compute_n()
-        self.assertEqual(10, parallel_level)
+        num_cpu  = 72
+        mem_kb   = 65805212
+        expected_cpu_count = 10
+
+        self.helper_call_compute_n(num_cpu, mem_kb, expected_cpu_count)
 
 
     def test_88p_128g(self):
         '''match ascic158'''
-        m_open = mock.mock_open(read_data='''MemTotal 131610424 kB''')
-        with self.m_environ, \
-             mock.patch('PullRequestLinuxDriverTest.open', m_open, create=True), \
-             mock.patch('PullRequestLinuxDriverTest.cpu_count', return_value=88):
-            parallel_level = PullRequestLinuxDriverTest.compute_n()
-        self.assertEqual(13, parallel_level)
+        num_cpu  = 88
+        mem_kb   = 131610424
+        expected_cpu_count = 13
+
+        self.helper_call_compute_n(num_cpu, mem_kb, expected_cpu_count)
 
 
     def test_80p_128g(self):
         '''this matches ascic166'''
-        m_open = mock.mock_open(read_data='''MemTotal 131610424 kB''')
-        with self.m_environ, \
-             mock.patch('PullRequestLinuxDriverTest.open', m_open, create=True), \
-             mock.patch('PullRequestLinuxDriverTest.cpu_count', return_value=80):
-            parallel_level = PullRequestLinuxDriverTest.compute_n()
-        self.assertEqual(20, parallel_level)
+        num_cpu  = 80
+        mem_kb   = 131610424
+        expected_cpu_count = 20
+
+        self.helper_call_compute_n(num_cpu, mem_kb, expected_cpu_count)
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
@trilinos/framework 
@prwolfe 

The mock testing in the PR test driver python scripts was working on specific machines with certain CPU counts, but it didn't handle systems outside a specific set (i.e., my mac laptop).

This update fixes this so that we are correctly mocking a set number of 'cpus' that the testing scripts will see so that the tests should work on more systems.

I also did a minor formatting pass to put a consistent # of newlines between classes and functions.

## Motivation
The tests for the python scripts that drive pull requests worked on certain machines that had the right core counts and memory but they didn't work everywhere, such as my laptop which has a lot less memory and cores than was expected.  

## Testing
Tested locally on my laptop and all looks good.

```
1 $ pytest -v unittests/*.py
======================================================== test session starts =========================================================
platform darwin -- Python 3.7.3, pytest-5.0.1, py-1.8.0, pluggy-0.12.0 -- /usr/local/anaconda3/bin/python
cachedir: .pytest_cache
rootdir: /Users/wcmclen/dev/trilinos/trilinos-dev-framework/source/Trilinos/cmake/std
plugins: openfiles-0.3.2, arraydiff-0.3, doctestplus-0.3.0, remotedata-0.3.1
collected 38 items

unittests/TestPullRequestLinuxDriverMerge.py::Test_header::test_writeHeader PASSED                                             [  2%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_EchoJenkinsVars::test_echoJenkinsVars PASSED                                [  5%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_parsing::test_parseArgs PASSED                                              [  7%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_parsing::test_parseInsufficientArgs_fails PASSED                            [ 10%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_mergeBranch::test_mergeBranch_fails_on_SHA_mismatch PASSED                  [ 13%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_mergeBranch::test_mergeBranch_fails_on_source_fetch PASSED                  [ 15%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_mergeBranch::test_mergeBranch_with_source_remote PASSED                     [ 18%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_mergeBranch::test_mergeBranch_without_source_remote PASSED                  [ 21%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_run::test_run PASSED                                                        [ 23%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_run::test_run_fails_on_bad_fetch PASSED                                     [ 26%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_run::test_run_fails_on_bad_parse PASSED                                     [ 28%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_run::test_run_fails_on_bad_remote_add PASSED                                [ 31%]
unittests/TestPullRequestLinuxDriverTest.py::Test_run::test_verifyGit_fails_with_old_version PASSED                            [ 34%]
unittests/TestPullRequestLinuxDriverTest.py::Test_run::test_verifyGit_passes_with_2_10 PASSED                                  [ 36%]
unittests/TestPullRequestLinuxDriverTest.py::Test_run::test_verifyGit_passes_with_2_12 PASSED                                  [ 39%]
unittests/TestPullRequestLinuxDriverTest.py::Test_run::test_verifyGit_passes_with_3_x PASSED                                   [ 42%]
unittests/TestPullRequestLinuxDriverTest.py::Test_run::test_verifyTargetBranch_fails_with_master_target_non_mm_source PASSED   [ 44%]
unittests/TestPullRequestLinuxDriverTest.py::Test_run::test_verifyTargetBranch_passes_with_develop_target PASSED               [ 47%]
unittests/TestPullRequestLinuxDriverTest.py::Test_run::test_verifyTargetBranch_passes_with_master_target_mm_source PASSED      [ 50%]
unittests/TestPullRequestLinuxDriverTest.py::Test_createPackageEnables::test_call_failure PASSED                               [ 52%]
unittests/TestPullRequestLinuxDriverTest.py::Test_createPackageEnables::test_call_python2 PASSED                               [ 55%]
unittests/TestPullRequestLinuxDriverTest.py::Test_createPackageEnables::test_call_success PASSED                               [ 57%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_fails_with_unknown PASSED                          [ 60%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_cuda_92 PASSED                         [ 63%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_gcc_484 PASSED                         [ 65%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_gcc_493_Serial PASSED                  [ 68%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_gcc_720 PASSED                         [ 71%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_gcc_830 PASSED                         [ 73%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_intel_1701 PASSED                      [ 76%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_python2 PASSED                         [ 78%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_python3 PASSED                         [ 81%]
unittests/TestPullRequestLinuxDriverTest.py::Test_GetCDashTrack::test_FromEnvironment PASSED                                   [ 84%]
unittests/TestPullRequestLinuxDriverTest.py::Test_GetCDashTrack::test_default PASSED                                           [ 86%]
unittests/TestPullRequestLinuxDriverTest.py::testCompute_n::test_32p_64g PASSED                                                [ 89%]
unittests/TestPullRequestLinuxDriverTest.py::testCompute_n::test_72p_64g PASSED                                                [ 92%]
unittests/TestPullRequestLinuxDriverTest.py::testCompute_n::test_80p_128g PASSED                                               [ 94%]
unittests/TestPullRequestLinuxDriverTest.py::testCompute_n::test_88p_128g PASSED                                               [ 97%]
unittests/TestPullRequestLinuxDriverTest.py::testCompute_n::test_over_weight PASSED                                            [100%]

===================================================== 38 passed in 0.29 seconds ======================================================
```

## Additional information
Turns out `pytest` also works with the testing stuff so you can run the tests in two ways (from the `cmake/std` directory):
1. `$ python -m unittest unittests/*.py` - shows a simpler version of the output.
2. `$ pytest -v unittests/*.py` - shows the colorized / formatted output from above. Remove the `-v` and you get less info like in (1) but its still formatted a little nicer than vanilla.

