### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@ The Trilinos project is a collection of open-source packages licensed
 individually under multiple open-source licenses. Licensing terms are
 available at the Trilinos website:
 
-https://trilinos.org/download/license/  
+https://trilinos.github.io/license.html
 
 For information about the software license for a particular package,
 see package-specific documentation.


### PR DESCRIPTION
Issue #6907

The link in the LICENSE file to the license page on the website was out-of-date. The correct link is

[https://trilinos.github.io/license.html](https://trilinos.github.io/license.html)

@trilinos/framework