### PR TITLE
Use OrthoManagerFactory in Belos' block GMRES

### DIFF
--- a/packages/belos/src/BelosBlockGmresSolMgr.hpp
+++ b/packages/belos/src/BelosBlockGmresSolMgr.hpp
@@ -578,15 +578,6 @@ void BlockGmresSolMgr<ScalarType,MV,OP>::setParameters( const Teuchos::RCP<Teuch
   // Check if the orthogonalization changed.
   if (params->isParameter("Orthogonalization")) {
     std::string tempOrthoType = params->get("Orthogonalization",orthoType_default_);
-#ifdef HAVE_BELOS_TSQR
-    TEUCHOS_TEST_FOR_EXCEPTION( tempOrthoType != "DGKS" && tempOrthoType != "ICGS" && tempOrthoType != "IMGS" && tempOrthoType != "TSQR",
-                        std::invalid_argument,
-                        "Belos::BlockGmresSolMgr: \"Orthogonalization\" must be either \"DGKS\", \"ICGS\", or \"IMGS\", or \"TSQR\".");
-#else
-    TEUCHOS_TEST_FOR_EXCEPTION( tempOrthoType != "DGKS" && tempOrthoType != "ICGS" && tempOrthoType != "IMGS",
-                        std::invalid_argument,
-                        "Belos::BlockGmresSolMgr: \"Orthogonalization\" must be either \"DGKS\", \"ICGS\", or \"IMGS\".");
-#endif
     if (tempOrthoType != orthoType_) {
       orthoType_ = tempOrthoType;
       params_->set("Orthogonalization", orthoType_);

--- a/packages/belos/src/BelosBlockGmresSolMgr.hpp
+++ b/packages/belos/src/BelosBlockGmresSolMgr.hpp
@@ -768,9 +768,6 @@ void BlockGmresSolMgr<ScalarType,MV,OP>::setParameters( const Teuchos::RCP<Teuch
     }
 
     ortho_ = factory.makeMatOrthoManager (orthoType_, Teuchos::null, outputOrtho, "Belos", paramsOrtho);
-    TEUCHOS_TEST_FOR_EXCEPTION
-      (ortho_.get () == nullptr, std::runtime_error, "BlockGmres: Failed to "
-       "create (Mat)OrthoManager of type \"" << orthoType_ << "\".");
   }
 
   // Create the timer if we need to.

--- a/packages/belos/src/BelosBlockGmresSolMgr.hpp
+++ b/packages/belos/src/BelosBlockGmresSolMgr.hpp
@@ -574,47 +574,6 @@ void BlockGmresSolMgr<ScalarType,MV,OP>::setParameters( const Teuchos::RCP<Teuch
     }
   }
 
-
-  // Check if the orthogonalization changed.
-  if (params->isParameter("Orthogonalization")) {
-    std::string tempOrthoType = params->get("Orthogonalization",orthoType_default_);
-    if (tempOrthoType != orthoType_) {
-      orthoType_ = tempOrthoType;
-      params_->set("Orthogonalization", orthoType_);
-      // Create orthogonalization manager
-      Belos::OrthoManagerFactory<ScalarType, MV, OP> factory;
-      Teuchos::RCP<Teuchos::ParameterList> paramsOrtho;   // can be null
-      if (orthoType_=="DGKS" && orthoKappa_ > 0) {
-        paramsOrtho->set ("depTol", orthoKappa_ );
-      }
-
-      ortho_ = factory.makeMatOrthoManager (orthoType_, Teuchos::null, printer_, "Belos", paramsOrtho);
-      TEUCHOS_TEST_FOR_EXCEPTION
-        (ortho_.get () == nullptr, std::runtime_error, "BlockGmres: Failed to "
-         "create (Mat)OrthoManager of type \"" << orthoType_ << "\".");
-    }
-  }
-
-  // Check which orthogonalization constant to use.
-  if (params->isParameter("Orthogonalization Constant")) {
-    if (params->isType<MagnitudeType> ("Orthogonalization Constant")) {
-      orthoKappa_ = params->get ("Orthogonalization Constant",
-                                 static_cast<MagnitudeType> (DefaultSolverParameters::orthoKappa));
-    }
-    else {
-      orthoKappa_ = params->get ("Orthogonalization Constant",
-                                 DefaultSolverParameters::orthoKappa);
-    }
-
-    // Update parameter in our list.
-    params_->set("Orthogonalization Constant",orthoKappa_);
-    if (orthoType_=="DGKS") {
-      if (orthoKappa_ > 0 && ortho_ != Teuchos::null) {
-        Teuchos::rcp_dynamic_cast<DGKSOrthoManager<ScalarType,MV,OP> >(ortho_)->setDepTol( orthoKappa_ );
-      }
-    }
-  }
-
   // Check for a change in verbosity level
   if (params->isParameter("Verbosity")) {
     if (Teuchos::isParameterType<int>(*params,"Verbosity")) {
@@ -669,6 +628,46 @@ void BlockGmresSolMgr<ScalarType,MV,OP>::setParameters( const Teuchos::RCP<Teuch
   // Create output manager if we need to.
   if (printer_ == Teuchos::null) {
     printer_ = Teuchos::rcp( new OutputManager<ScalarType>(verbosity_, outputStream_) );
+  }
+
+  // Check if the orthogonalization changed.
+  if (params->isParameter("Orthogonalization")) {
+    std::string tempOrthoType = params->get("Orthogonalization",orthoType_default_);
+    if (tempOrthoType != orthoType_) {
+      orthoType_ = tempOrthoType;
+      params_->set("Orthogonalization", orthoType_);
+      // Create orthogonalization manager
+      Belos::OrthoManagerFactory<ScalarType, MV, OP> factory;
+      Teuchos::RCP<Teuchos::ParameterList> paramsOrtho;   // can be null
+      if (orthoType_=="DGKS" && orthoKappa_ > 0) {
+        paramsOrtho->set ("depTol", orthoKappa_ );
+      }
+
+      ortho_ = factory.makeMatOrthoManager (orthoType_, Teuchos::null, printer_, "Belos", paramsOrtho);
+      TEUCHOS_TEST_FOR_EXCEPTION
+        (ortho_.get () == nullptr, std::runtime_error, "BlockGmres: Failed to "
+         "create (Mat)OrthoManager of type \"" << orthoType_ << "\".");
+    }
+  }
+
+  // Check which orthogonalization constant to use.
+  if (params->isParameter("Orthogonalization Constant")) {
+    if (params->isType<MagnitudeType> ("Orthogonalization Constant")) {
+      orthoKappa_ = params->get ("Orthogonalization Constant",
+                                 static_cast<MagnitudeType> (DefaultSolverParameters::orthoKappa));
+    }
+    else {
+      orthoKappa_ = params->get ("Orthogonalization Constant",
+                                 DefaultSolverParameters::orthoKappa);
+    }
+
+    // Update parameter in our list.
+    params_->set("Orthogonalization Constant",orthoKappa_);
+    if (orthoType_=="DGKS") {
+      if (orthoKappa_ > 0 && ortho_ != Teuchos::null) {
+        Teuchos::rcp_dynamic_cast<DGKSOrthoManager<ScalarType,MV,OP> >(ortho_)->setDepTol( orthoKappa_ );
+      }
+    }
   }
 
   // Check for convergence tolerance

--- a/packages/belos/src/BelosBlockGmresSolMgr.hpp
+++ b/packages/belos/src/BelosBlockGmresSolMgr.hpp
@@ -583,13 +583,12 @@ void BlockGmresSolMgr<ScalarType,MV,OP>::setParameters( const Teuchos::RCP<Teuch
       params_->set("Orthogonalization", orthoType_);
       // Create orthogonalization manager
       Belos::OrthoManagerFactory<ScalarType, MV, OP> factory;
-      Teuchos::RCP<Belos::OutputManager<ScalarType>> outputOrtho;   // can be null
       Teuchos::RCP<Teuchos::ParameterList> paramsOrtho;   // can be null
       if (orthoType_=="DGKS" && orthoKappa_ > 0) {
         paramsOrtho->set ("depTol", orthoKappa_ );
       }
 
-      ortho_ = factory.makeMatOrthoManager (orthoType_, Teuchos::null, outputOrtho, "Belos", paramsOrtho);
+      ortho_ = factory.makeMatOrthoManager (orthoType_, Teuchos::null, printer_, "Belos", paramsOrtho);
       TEUCHOS_TEST_FOR_EXCEPTION
         (ortho_.get () == nullptr, std::runtime_error, "BlockGmres: Failed to "
          "create (Mat)OrthoManager of type \"" << orthoType_ << "\".");
@@ -761,13 +760,12 @@ void BlockGmresSolMgr<ScalarType,MV,OP>::setParameters( const Teuchos::RCP<Teuch
   if (ortho_ == Teuchos::null) {
     params_->set("Orthogonalization", orthoType_);
     Belos::OrthoManagerFactory<ScalarType, MV, OP> factory;
-    Teuchos::RCP<Belos::OutputManager<ScalarType>> outputOrtho;   // can be null
     Teuchos::RCP<Teuchos::ParameterList> paramsOrtho;   // can be null
     if (orthoType_=="DGKS" && orthoKappa_ > 0) {
       paramsOrtho->set ("depTol", orthoKappa_ );
     }
 
-    ortho_ = factory.makeMatOrthoManager (orthoType_, Teuchos::null, outputOrtho, "Belos", paramsOrtho);
+    ortho_ = factory.makeMatOrthoManager (orthoType_, Teuchos::null, printer_, "Belos", paramsOrtho);
   }
 
   // Create the timer if we need to.

--- a/packages/belos/tpetra/test/BlockGmres/CMakeLists.txt
+++ b/packages/belos/tpetra/test/BlockGmres/CMakeLists.txt
@@ -24,6 +24,17 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   COMM serial mpi
   )
 
+ASSERT_DEFINED(Belos_ENABLE_TSQR)
+IF (Belos_ENABLE_TSQR)
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  Tpetra_BlockGMRES_hb_TSQR_test
+  SOURCES test_bl_gmres_hb.cpp
+  ARGS "--verbose --num-rhs=3 --block-size=3 --ortho-type=TSQR"
+  COMM serial mpi
+  )
+ENDIF()
+
+
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   Tpetra_BlockFGMRES_hb_test
   SOURCES test_bl_fgmres_hb.cpp

--- a/packages/belos/tpetra/test/BlockGmres/test_bl_gmres_hb.cpp
+++ b/packages/belos/tpetra/test/BlockGmres/test_bl_gmres_hb.cpp
@@ -110,7 +110,7 @@ int main(int argc, char *argv[]) {
     cmdp.setOption("num-rhs",&numrhs,"Number of right-hand sides to be solved for.");
     cmdp.setOption("max-iters",&maxiters,"Maximum number of iterations per linear system (-1 := adapted to problem/block size).");
     cmdp.setOption("block-size",&blocksize,"Block size to be used by the Gmres solver.");
-    cmdp.setOption("ortho-type",&ortho,"Orthogonalization type, either DGKS, ICGS or IMGS");
+    cmdp.setOption("ortho-type",&ortho,"Orthogonalization type, either DGKS, ICGS or IMGS (or TSQR if enabled)");
     if (cmdp.parse(argc,argv) != CommandLineProcessor::PARSE_SUCCESSFUL) {
       return -1;
     }

--- a/packages/belos/tpetra/test/BlockGmres/test_bl_gmres_hb.cpp
+++ b/packages/belos/tpetra/test/BlockGmres/test_bl_gmres_hb.cpp
@@ -97,6 +97,7 @@ int main(int argc, char *argv[]) {
     int numrhs = 1;      // total number of right-hand sides to solve for
     int blocksize = 1;   // blocksize used by solver
     int maxiters = -1;   // maximum number of iterations for solver to use
+    std::string ortho("DGKS"); // orthogonalization type
     std::string filename("bcsstk14.hb");
     MT tol = 1.0e-5;     // relative residual tolerance
 
@@ -109,6 +110,7 @@ int main(int argc, char *argv[]) {
     cmdp.setOption("num-rhs",&numrhs,"Number of right-hand sides to be solved for.");
     cmdp.setOption("max-iters",&maxiters,"Maximum number of iterations per linear system (-1 := adapted to problem/block size).");
     cmdp.setOption("block-size",&blocksize,"Block size to be used by the Gmres solver.");
+    cmdp.setOption("ortho-type",&ortho,"Orthogonalization type, either DGKS, ICGS or IMGS");
     if (cmdp.parse(argc,argv) != CommandLineProcessor::PARSE_SUCCESSFUL) {
       return -1;
     }
@@ -154,6 +156,7 @@ int main(int argc, char *argv[]) {
     belosList.set( "Block Size", blocksize );              // Blocksize to be used by iterative solver
     belosList.set( "Maximum Iterations", maxiters );       // Maximum number of iterations allowed
     belosList.set( "Convergence Tolerance", tol );         // Relative convergence tolerance requested
+    belosList.set( "Orthogonalization", ortho );           // Orthogonalization type
 
     int verbLevel = Belos::Errors + Belos::Warnings;
     if (debug) {


### PR DESCRIPTION
@trilinos/belos

## Motivation
-     Use OrthoManagerFactory in Belos' block GMRES
-     One motivation is to make TSQR available from block GMRES

## Testing
We added a tester for block GMRES with TSQR for ctest under belos/tpetra/test. It passed on blake using gcc/7.2.0.