### PR TITLE
StackedTimer XML output for Watchr

### DIFF
--- a/packages/muelu/test/scaling/CMakeLists.txt
+++ b/packages/muelu/test/scaling/CMakeLists.txt
@@ -39,6 +39,7 @@ IF (${PACKAGE_NAME}_HAVE_TPETRA_SOLVER_STACK OR ${PACKAGE_NAME}_HAVE_EPETRA_SOLV
     CATEGORIES BASIC PERFORMANCE
     )
 
+  # Do a simple weak scaling experiment (4x ranks and 4x grid size)
   TRIBITS_ADD_TEST(
     Driver
     NAME SetupSolve_Performance_1

--- a/packages/muelu/test/scaling/Driver.cpp
+++ b/packages/muelu/test/scaling/Driver.cpp
@@ -517,6 +517,9 @@ MueLu::MueLu_AMGX_initialize_plugins();
           Teuchos::StackedTimer::OutputOptions options;
           options.output_fraction = options.output_histogram = options.output_minmax = true;
           stacked_timer->report(out2, comm, options);
+          auto xmlOut = stacked_timer->reportWatchrXML(std::string("MueLuDriver") + std::to_string(comm->getSize()), comm);
+          if(xmlOut.length())
+            std::cout << "\nAlso created Watchr performance report " << xmlOut << '\n';
         }
         else {
           std::ios_base::fmtflags ff(out2.flags());

--- a/packages/muelu/test/scaling/MatrixMatrixMultiply.cpp
+++ b/packages/muelu/test/scaling/MatrixMatrixMultiply.cpp
@@ -209,6 +209,10 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib &lib, int ar
     options.print_warnings = false;
     timer->report(std::cout, comm, options);
 
+    auto xmlOut = stacked_timer->reportWatchrXML(std::string("MueLu_MatrixMatrix") + std::to_string(comm->getSize()), comm);
+    if(xmlOut.length())
+      std::cout << "\nAlso created Watchr performance report " << xmlOut << '\n';
+
     if (comm->getRank() == 0)
       std::cout << "End Result: TEST PASSED";
 

--- a/packages/muelu/test/scaling/MatrixMatrixMultiply.cpp
+++ b/packages/muelu/test/scaling/MatrixMatrixMultiply.cpp
@@ -209,7 +209,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib &lib, int ar
     options.print_warnings = false;
     timer->report(std::cout, comm, options);
 
-    auto xmlOut = stacked_timer->reportWatchrXML(std::string("MueLu_MatrixMatrix") + std::to_string(comm->getSize()), comm);
+    auto xmlOut = timer->reportWatchrXML(std::string("MueLu_MatrixMatrix") + std::to_string(comm->getSize()), comm);
     if(xmlOut.length())
       std::cout << "\nAlso created Watchr performance report " << xmlOut << '\n';
 

--- a/packages/teuchos/comm/src/Teuchos_StackedTimer.cpp
+++ b/packages/teuchos/comm/src/Teuchos_StackedTimer.cpp
@@ -731,7 +731,7 @@ StackedTimer::reportWatchrXML(const std::string& name, Teuchos::RCP<const Teucho
   //only open the file on rank 0
   if(rank(*comm) == 0) {
     fullFile = watchrDir + '/' + name + '_' + datestamp + ".xml";
-    std::ofstream os = std::ofstream(fullFile);
+    std::ofstream os(fullFile);
     std::vector<bool> printed(flat_names_.size(), false);
     os << "<?xml version=\"1.0\"?>\n";
     os << "<performance-report date=\"" << timestamp << "\" name=\"nightly_run_" << datestamp << "\" time-units=\"seconds\">\n";

--- a/packages/teuchos/comm/src/Teuchos_StackedTimer.cpp
+++ b/packages/teuchos/comm/src/Teuchos_StackedTimer.cpp
@@ -701,7 +701,7 @@ StackedTimer::reportXML(std::ostream &os, const std::string& datestamp, const st
 
 std::string
 StackedTimer::reportWatchrXML(const std::string& name, Teuchos::RCP<const Teuchos::Comm<int> > comm) {
-  char* rawWatchrDir = getenv("WATCHR_PERF_DIR");
+  const char* rawWatchrDir = getenv("WATCHR_PERF_DIR");
   if(!rawWatchrDir)
     return "";
   std::string watchrDir = rawWatchrDir;

--- a/packages/teuchos/comm/src/Teuchos_StackedTimer.hpp
+++ b/packages/teuchos/comm/src/Teuchos_StackedTimer.hpp
@@ -1,5 +1,41 @@
-// @HEADER BEGIN
-// @HEADER END
+// @HEADER
+// ***********************************************************************
+//
+//                    Teuchos: Common Tools Package
+//                 Copyright (2004) Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// ***********************************************************************
+// @HEADER
 
 #ifndef TEUCHOS_STACKED_TIMER_HPP
 #define TEUCHOS_STACKED_TIMER_HPP
@@ -395,7 +431,7 @@ protected:
 
      /**
       * Dump the timer stats in a pretty format to ostream
-      * @param [in/out] os  Where are you dumping the stats, stdout??
+      * @param [in,out] os  Where are you dumping the stats, stdout??
       */
      void report(std::ostream &os);
 
@@ -607,16 +643,29 @@ public:
 
   /**
    * Dump all the data from all the MPI ranks to an ostream
-   * @param [in] os - Output stream
+   * @param [in,out] os - Output stream
    * @param [in] comm - Teuchos comm pointer
    */
   void report(std::ostream &os, Teuchos::RCP<const Teuchos::Comm<int> > comm, OutputOptions options = OutputOptions());
 
   /**
-   * Dump all the data from all the MPI ranks to a Watchr-formatted XML file
-   * @param [in] name - Name of performance test
+   * Dump all the data from all the MPI ranks to the given output stream, in Watchr XML format.
+   *  \c reportWatchrXML() is a wrapper for this function that creates \c os as a \c std::ofstream.
+   * @param [in,out] os - stream where XML will be written
+   * @param [in] datestamp - UTC datestamp in the format YYYY_MM_DD
+   * @param [in] timestamp - UTC timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SS (HH in 24-hour time, and T is just the character 'T')
    * @param [in] comm - Teuchos comm pointer
    * @return The complete filename, or empty string if no output was produced.
+   */
+  void reportXML(std::ostream &os, const std::string& datestamp, const std::string& timestamp, Teuchos::RCP<const Teuchos::Comm<int> > comm);
+
+  /**
+   * Dump all the data from all the MPI ranks to <code>$WATCHR_PERF_DIR/name_$DATESTAMP.xml</code>,
+   *  if the environment variable WATCHR_PERF_DIR is defined and non-empty (otherwise, do nothing).
+   *  DATESTAMP is calculated from the current UTC time, in the format YYYY_MM_DD.
+   * @param [in] name - Name of performance test
+   * @param [in] comm - Teuchos comm pointer
+   * @return If on rank 0 and output was produced, the complete output filename. Otherwise the empty string.
    */
   std::string reportWatchrXML(const std::string& name, Teuchos::RCP<const Teuchos::Comm<int> > comm);
 

--- a/packages/teuchos/comm/src/Teuchos_StackedTimer.hpp
+++ b/packages/teuchos/comm/src/Teuchos_StackedTimer.hpp
@@ -612,6 +612,13 @@ public:
    */
   void report(std::ostream &os, Teuchos::RCP<const Teuchos::Comm<int> > comm, OutputOptions options = OutputOptions());
 
+  /**
+   * Dump all the data from all the MPI ranks to a Watchr-formatted XML file
+   * @param [in] name - Name of performance test
+   * @param [in] comm - Teuchos comm pointer
+   * @return The complete filename, or empty string if no output was produced.
+   */
+  std::string reportWatchrXML(const std::string& name, Teuchos::RCP<const Teuchos::Comm<int> > comm);
 
   // If set to true, print timer start/stop to verbose ostream.
   void enableVerbose(const bool enable_verbose);
@@ -700,6 +707,11 @@ protected:
     */
   double printLevel(std::string prefix, int level, std::ostream &os, std::vector<bool> &printed,
                     double parent_time, const OutputOptions &options);
+
+   /**
+    * Recursive call to print a level of timer data, in Watchr XML format.
+    */
+  double printLevelXML(std::string prefix, int level, std::ostream &os, std::vector<bool> &printed, double parent_time);
 
 };  //StackedTimer
 

--- a/packages/teuchos/comm/test/StackedTimer/stacked_timer.cpp
+++ b/packages/teuchos/comm/test/StackedTimer/stacked_timer.cpp
@@ -208,7 +208,32 @@ TEUCHOS_UNIT_TEST(StackedTimer, Basic)
   TEST_EQUALITY(options.print_names_before_values,true);
   out << "\n### Printing aligned_column with timers names on right ###" << std::endl;
   options.print_names_before_values = false;
-  timer.report(out, comm, options);
+  // Make sure neither report() nor reportXML() have side effects that change the output:
+  // calling them any number of times with no new starts/stops and the same OutputOptions
+  // should produce identical output.
+  //
+  // This is very important as performance tests will
+  // typically call both report() and reportWatchrXML().
+  std::string reportOut;
+  {
+    std::ostringstream reportOut1;
+    timer.report(reportOut1, comm, options);
+    std::ostringstream reportOut2;
+    timer.report(reportOut2, comm, options);
+    reportOut = reportOut1.str();
+    TEST_EQUALITY(reportOut, reportOut2.str());
+  }
+  std::string reportXmlOut;
+  {
+    std::ostringstream reportOut1;
+    timer.reportXML(reportOut1, "2020_01_01", "2020-01-01T01:02:03", comm);
+    std::ostringstream reportOut2;
+    timer.reportXML(reportOut2, "2020_01_01", "2020-01-01T01:02:03", comm);
+    reportXmlOut = reportOut1.str();
+    TEST_EQUALITY(reportXmlOut, reportOut2.str());
+  }
+  out << reportOut << '\n';
+  out << reportXmlOut << '\n';
 }
 
 TEUCHOS_UNIT_TEST(StackedTimer, UnitTestSupport)

--- a/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_main.cpp
+++ b/packages/tpetra/core/example/Finite-Element-Assembly/fem_assembly_main.cpp
@@ -117,6 +117,9 @@ int main (int argc, char *argv[])
     StackedTimer::OutputOptions timeReportOpts;
     timeReportOpts.print_warnings = false;
     timer->report(std::cout, comm, timeReportOpts);
+    auto xmlOut = timer->reportWatchrXML("FE_Assembly" + std::to_string(comm->getSize()), comm);
+    if(xmlOut.length())
+      std::cout << "\nAlso created Watchr performance report " << xmlOut << '\n';
   }
 
   // This tells the Trilinos test framework that the test passed.

--- a/packages/tpetra/core/test/PerformanceCGSolve/cg_solve_file.hpp
+++ b/packages/tpetra/core/test/PerformanceCGSolve/cg_solve_file.hpp
@@ -386,9 +386,11 @@ int run (int argc, char *argv[])
   StackedTimer::OutputOptions options;
   options.print_warnings = false;
   timer->report(std::cout, comm, options);
-
+  auto xmlOut = timer->reportWatchrXML(std::string("TpetraCG") + std::to_string(comm->getSize()), comm);
   if(myRank == 0)
   {
+    if(xmlOut.length())
+      std::cout << "\nAlso created Watchr performance report " << xmlOut << '\n';
     if(success)
       std::cout << "End Result: TEST PASSED\n";
     else


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/teuchos 
@trilinos/tpetra 
@trilinos/muelu 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
In order to use Watchr (the SEMS performance plugin for Jenkins) for performance testing, we need the Teuchos::StackedTimer to output XML files in a specific format. This PR adds functions ``reportXML()`` and ``reportWatchrXML()`` to StackedTimer. ``reportWatchrXML()`` is the one that's intended for performance tests - in the directory ``$WATCHR_PERF_DIR`` (environment variable), it creates an XML file with a name prefix, and a current datestamp. This makes it easy to add XML output to perf tests. It also makes it very easy to set up the performance testing on a given machine:
```
git clone $url_to_data/PerformanceData
export WATCHR_PERF_DIR=cwd/PerformanceData/$machine
# build develop branch Trilinos, with test category PERFORMANCE
# run ctest - the performance tests create files in $WATCHR_PERF_DIR
cd $WATCHR_PERF_DIR
git add .
git commit -m "Testing for $machine on $date"
git push
```

Here is a sample XML file (TpetraCG4_2020_02_27.xml, produced by calling the pseudocode ``reportWatchrXML("TpetraCG" + comm->size(), comm);``:
```
<?xml version="1.0"?>
<performance-report date="2020-02-27T18:00:08" name="nightly_run_2020_02_27" time-units="seconds">
    <timing name="CG: global" value="3.17592">
        <timing name="CG: axpby" value="0.372165"/>
        <timing name="CG: spmv" value="2.53646"/>
        <timing name="CG: dot" value="0.226998"/>
        <timing name="Remainder" value="0.0402957"/>
    </timing>
</performance-report>
```
It's a tree of nested timers with indentation just like report().
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
This supports the effort for Tpetra and MueLu to do performance testing.
## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
Added testing for ``reportXML()`` in the existing StackedTimer_Basic unit test. Note that ``reportWatchrXML()`` is a thin wrapper for ``reportXML()``, that just gets the current time, reads the environment variable and opens the file for writing. By separating out ``reportXML()`` and testing that, the unit test doesn't do disk writes or depend on any environment variables. Also made the test check that both ``report()`` and ``reportXML()`` produce identical output each time they're called (so they don't have any permanent side effects on the StackedTimer object).
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->