### PR TITLE
Tempus: Remove Deprecated Code

### DIFF
--- a/packages/tempus/src/Tempus_SolutionStateMetaData_decl.hpp
+++ b/packages/tempus/src/Tempus_SolutionStateMetaData_decl.hpp
@@ -30,29 +30,6 @@ public:
   /// Default constructor.
   SolutionStateMetaData();
 
-#ifndef TEMPUS_HIDE_DEPRECATED_CODE
-  /// Constructor - Deprecated!
-  TEMPUS_DEPRECATED_MSG("Please use constructor with 21 arguments.")
-  SolutionStateMetaData(
-    const Scalar time,
-    const int    iStep,
-    const Scalar dt,
-    const Scalar errorAbs,
-    const Scalar errorRel,
-    const int    order,
-    const int    nFailures,
-    const int    nRunningFailures,
-    const int    nConsecutiveFailures,
-    const Scalar tolRel,
-    const Scalar tolAbs,
-    const Status solutionStatus,
-    const bool   output,
-    const bool   outputScreen,
-    const bool   isSynced,
-    const bool   isInterpolated,
-    const Scalar accuracy);
-#endif
-
   /// Constructor
   SolutionStateMetaData(
     const Scalar time,

--- a/packages/tempus/src/Tempus_SolutionStateMetaData_impl.hpp
+++ b/packages/tempus/src/Tempus_SolutionStateMetaData_impl.hpp
@@ -39,50 +39,6 @@ SolutionStateMetaData<Scalar>::SolutionStateMetaData()
    accuracy_      (0.0)
 {}
 
-#ifndef TEMPUS_HIDE_DEPRECATED_CODE
-template<class Scalar>
-SolutionStateMetaData<Scalar>::SolutionStateMetaData(
-  const Scalar time,
-  const int    iStep,
-  const Scalar dt,
-  const Scalar errorAbs,
-  const Scalar errorRel,
-  const int    order,
-  const int    nFailures,
-  const int    nRunningFailures,
-  const int    nConsecutiveFailures,
-  const Scalar tolRel,
-  const Scalar tolAbs,
-  const Status solutionStatus,
-  const bool   output,
-  const bool   outputScreen,
-  const bool   isSynced,
-  const bool   isInterpolated,
-  const Scalar accuracy)
-  :time_          (time),
-   iStep_         (iStep),
-   dt_            (dt),
-   errorAbs_      (errorAbs),
-   errorRel_      (errorRel),
-   order_         (order),
-   nFailures_     (nFailures),
-   nRunningFailures_(nRunningFailures),
-   nConsecutiveFailures_(nConsecutiveFailures),
-   tolRel_        (tolRel),
-   tolAbs_        (tolAbs),
-   xNormL2_       (0.0),
-   dxNormL2Rel_   (0.0),
-   dxNormL2Abs_   (0.0),
-   computeNorms_  (false),
-   solutionStatus_(solutionStatus),
-   output_        (output),
-   outputScreen_  (outputScreen),
-   isSynced_      (isSynced),
-   isInterpolated_(isInterpolated),
-   accuracy_      (accuracy)
-{}
-#endif
-
 template<class Scalar>
 SolutionStateMetaData<Scalar>::SolutionStateMetaData(
   const Scalar time,

--- a/packages/tempus/src/Tempus_Stepper_decl.hpp
+++ b/packages/tempus/src/Tempus_Stepper_decl.hpp
@@ -69,12 +69,6 @@ public:
     virtual void setModel(
       const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel) = 0;
 
-#ifndef TEMPUS_HIDE_DEPRECATED_CODE
-    TEMPUS_DEPRECATED
-    virtual void setNonConstModel(
-      const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& /* appModel */){}
-
-#endif // TEMPUS_HIDE_DEPRECATED_CODE
     virtual Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > getModel() = 0;
 
     /// Set solver.

--- a/packages/tempus/src/Tempus_Stepper_impl.hpp
+++ b/packages/tempus/src/Tempus_Stepper_impl.hpp
@@ -164,13 +164,11 @@ void Stepper<Scalar>::initialize()
 template<class Scalar>
 void Stepper<Scalar>::checkInitialized()
 {
-#ifdef TEMPUS_HIDE_DEPRECATED_CODE
   if ( !this->isInitialized() ) {
     this->describe( *(this->getOStream()), Teuchos::VERB_MEDIUM);
     TEUCHOS_TEST_FOR_EXCEPTION( !this->isInitialized(), std::logic_error,
       "Error - " << this->description() << " is not initialized!");
   }
-#endif // TEMPUS_HIDE_DEPRECATED_CODE
 }
 
 


### PR DESCRIPTION
Removed all TEMPUS_HIDE_DEPRECATED_CODE.

Passing all test on CEE LAN gcc.

@trilinos/tempus 

* Related to #6914 
