### PR TITLE
Tpetra: address #3238, fix warnings

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Util.hpp
+++ b/packages/tpetra/core/src/Tpetra_Util.hpp
@@ -629,7 +629,7 @@ namespace Tpetra {
   ///         val.begin (), val.end ());
   /// \endcode
   template<class IT1, class IT2>
-  KOKKOS_INLINE_FUNCTION void
+  void
   merge2 (IT1& indResultOut, IT2& valResultOut,
           IT1 indBeg, IT1 indEnd,
           IT2 valBeg, IT2 /* valEnd */)

--- a/packages/tpetra/core/test/MultiVector/MultiVector_MicroBenchmark.cpp
+++ b/packages/tpetra/core/test/MultiVector/MultiVector_MicroBenchmark.cpp
@@ -124,7 +124,7 @@ namespace { // (anonymous)
     Kokkos::RangePolicy<cur_exec_space> policy (0, vector_size);
     {
       ::Tpetra::Details::ProfilingRegion region ("Raw Lambda Update Loop");
-      for(size_t i=0; i<num_repeats; i++) {
+      for(size_t rep=0; rep<num_repeats; rep++) {
         Kokkos::parallel_for(policy,KOKKOS_LAMBDA(const size_t &i) {
             // This is what we should do in general
             //            X_lcl(i,0) = ONE * X_lcl(i,0) + ONE * Y_lcl(i,0);


### PR DESCRIPTION
* #3238: implement ``Tpetra::Details::getEntryOnHost`` using ``Kokkos::deep_copy`` from an arbitrary
  0-D view to a host scalar.
* Fix lots of ``calling __host__ function from __host__ __device__ function``
  warnings, due to ``Tpetra::merge2`` being declared as
  ``KOKKOS_INLINE_FUNCTION``, but being passed STL iterators. merge2 is
  only used in a few places in Trilinos and none of them are in device
  kernels, so this PR removes the ``KOKKOS_INLINE_FUNCTION`` marking.
* Fix shadow warning in a MultiVector test

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
- #3238 is an opportunity to remove redundant code
- fixes dozens of warnings on CUDA builds
- fixes one -Wshadow warning that should show up in any build
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
-->
## Related Issues

* Closes #3238
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
getEntryOnHost and merge2 each have their own unit tests, in core/test/Utils.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->