### PR TITLE
ATDM: Remove LD_PRELOAD from the jsrun wrapper

### DIFF
--- a/cmake/std/atdm/ats2/trilinos_jsrun
+++ b/cmake/std/atdm/ats2/trilinos_jsrun
@@ -172,9 +172,6 @@ if [[ "$TPETRA_ASSUME_CUDA_AWARE_MPI" == "1" ]] && [[ "$np_is_one" == "false" ]]
     # prepend the argument
     args=("-M -gpu" "${args[@]}")
   fi
-
-  # Point jsrun to pami
-  args=("-E LD_PRELOAD=$OPAL_PREFIX/lib/pami_451/libpami.so" "${args[@]}")
 fi
 
 evaluate_jsrun_command


### PR DESCRIPTION
Fixes #6937
Addresses CDOFA #100

This is an issue to track and attach a PR for the removal of `LD_PRELOAD` from the `jsrun_wrapper`

The original implementation of the `jsrun_wrapper` did not have any `LD_PRELOAD`. The variable was added to enable unit tests to succeed when they allocated memory before calling `MPI_Init`. (see #6724 ).  When codes allocate memory, the Cuda Hooks will interact with libpami (so MPI  knows where the memory lives).  This requires symbols to be loaded during `MPI_Init` (namely libpami).

When a code allocates before `MPI_Init`, they will get an obscure error: (perhaps others)
```
CUDA Hook Library: Failed to find symbol mem_find_dreg_entries.
```

This is because the cuda hook library assumes MPI has been initialized.

By adding an `LD_PRELOAD` to the wrapper, this allows memory allocations to find the needed symbols, but we are clearly outside the way Spectrum intended the system to be used. This shouldn't block ATDM apps, as they have been functioning up to this point.  This may cause a headache for some unit tests, but it would be good to make sure developers are aware that most cuda-aware MPI implementations tack on extra rules regarding initializing the library.++ (see note below)

We decided to leave the `LD_PRELOAD` in place until other testing issues were ironed out.  This issue and PR should be blocked until ATDM devops decides they are ready to move forward. By removing LD_PRELOAD several unit tests will crash with errors about missing symbols.  The fix will be to ensure that `MPI_Init` is called before `Kokkos::initialize`, which can be easier said than done.

++ Note: this pattern of requiring `MPI_Init` first is not new.
E.g., OpenMPI w/UCX caused these obscure bugs that arose from allocs before initialize.
https://github.com/trilinos/Trilinos/issues/5033#issuecomment-491560229

@bartlettroscoe 


## Testing
This PR was tested using the provided jsrun wrapper tester.