### PR TITLE
Add intel-complex-openmp-opt-KNL for ATS-1 'mutrino' for GEMMA (ATDV-296)

### DIFF
--- a/cmake/ctest/drivers/atdm/mutrino/drivers/Trilinos-atdm-mutrino-intel-complex-openmp-opt-KNL.sh
+++ b/cmake/ctest/drivers/atdm/mutrino/drivers/Trilinos-atdm-mutrino-intel-complex-openmp-opt-KNL.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ "${Trilinos_TRACK}" == "" ] ; then
+  export Trilinos_TRACK=Experimental
+fi
+
+if [ "${SALLOC_CTEST_TIME_LIMIT_MINUTES}" == "" ] ; then
+  export SALLOC_CTEST_TIME_LIMIT_MINUTES=540 # 9 hour time limit
+fi
+
+$WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/mutrino/local-driver.sh

--- a/cmake/ctest/drivers/atdm/mutrino/drivers/Trilinos-atdm-mutrino-intel-complex-openmp-opt-KNL.sh
+++ b/cmake/ctest/drivers/atdm/mutrino/drivers/Trilinos-atdm-mutrino-intel-complex-openmp-opt-KNL.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=Experimental
+  export Trilinos_TRACK=ATDM
 fi
 
 if [ "${SALLOC_CTEST_TIME_LIMIT_MINUTES}" == "" ] ; then

--- a/cmake/std/atdm/ATDMDisables.cmake
+++ b/cmake/std/atdm/ATDMDisables.cmake
@@ -65,9 +65,9 @@ IF (NOT ATDM_ENABLE_SPARC_SETTINGS)
   # at a time in an orderly fashion.
 ENDIF()
 
-IF (ATDM_USE_CUDA AND ATDM_COMPLEX)
+IF (ATDM_COMPLEX)
 
-  # Disable extra packages not being used by GEMMA in cuda+complex builds (see
+  # Disable extra packages not being used by GEMMA in complex builds (see
   # ATDV-263, ATDV-265)
   SET(ATDM_SE_PACKAGE_DISABLES
     ${ATDM_SE_PACKAGE_DISABLES}

--- a/cmake/std/atdm/mutrino/all_supported_builds.sh
+++ b/cmake/std/atdm/mutrino/all_supported_builds.sh
@@ -6,4 +6,5 @@ export ATDM_CONFIG_ALL_SUPPORTED_BUILDS=(
   intel-debug-openmp-KNL
   intel-opt-openmp-HSW
   intel-opt-openmp-KNL
+  intel-complex-openmp-opt-KNL
   )


### PR DESCRIPTION
This build was specifically requested by GEMMA.  See [ATDV-296](https://sems-atlassian-srn.sandia.gov/browse/ATDV-296) and they reported it had a KokkosKernels build error but as of this version of Trilinos was 100% passing for the packages used by GEMMA.

NOTES:

* This changes the ATDM Trilinos builds so that adding `complex` to the build-name automatically disables all of the packages that GEMMA does not use.
* This build is promoted to the 'ATDM' CDash group since it was 100% clean (see below).

## How was this tested:

On 'mutrino' I ran:

```
./ctest-s-local-test-driver.sh intel-complex-openmp-opt-KNL

***
*** ./ctest-s-local-test-driver.sh
***

ATDM_TRILINOS_DIR = '/home/rabartl/Trilinos.base/Trilinos'

Load some env to get python, cmake, etc ...

Hostname 'mutrino' matches known ATDM host 'mutrino' and system 'mutrino'
Setting compiler and build options for build-name 'default'
Using mutrino compiler stack INTEL to build DEBUG code with Kokkos node type SERIAL and KOKKOS_ARCH=HSW

Running builds:
    intel-complex-openmp-opt-KNL

Mon Mar  2 13:52:27 MST 2020

Running Jenkins driver Trilinos-atdm-mutrino-intel-complex-openmp-opt-KNL.sh ...

    See log file Trilinos-atdm-mutrino-intel-complex-openmp-opt-KNL/smart-jenkins-driver.out

real    249m58.374s
user    730m28.369s
sys     392m15.185s

100% tests passed, 0 tests failed out of 1060

Mon Mar  2 18:02:25 MST 2020
```

which posted to CDash:

* [Trilinos-atdm-mutrino-intel-complex-openmp-opt-KNL-exp](https://testing-dev.sandia.gov/cdash/index.php?project=Trilinos&parentid=5275363) (passed=1060, failed=0)

