### PR TITLE
Tacho: Remove Deprecated Task Schedulers

### DIFF
--- a/packages/shylu/shylu_node/tacho/example/CMakeLists.txt
+++ b/packages/shylu/shylu_node/tacho/example/CMakeLists.txt
@@ -12,20 +12,6 @@ IF (TACHO_HAVE_KOKKOS_TASK)
   #
   # Supernodes
   # 
-  # TRIBITS_ADD_EXECUTABLE(
-  #   Tacho_ExampleCholSupernodesDeprecatedTaskScheduler
-  #   TARGET_DEFINES -DTACHO_USE_DEPRECATED_TASKSCHEDULER
-  #   NOEXEPREFIX
-  #   SOURCES Tacho_ExampleCholSupernodes.cpp
-  #   COMM serial mpi
-  # )
-  # TRIBITS_ADD_EXECUTABLE(
-  #   Tacho_ExampleCholSupernodesDeprecatedTaskSchedulerMultiple
-  #   TARGET_DEFINES -DTACHO_USE_DEPRECATED_TASKSCHEDULER_MULTIPLE
-  #   NOEXEPREFIX
-  #   SOURCES Tacho_ExampleCholSupernodes.cpp
-  #   COMM serial mpi
-  # )
   TRIBITS_ADD_EXECUTABLE(
     Tacho_ExampleCholSupernodesTaskScheduler
     TARGET_DEFINES -DTACHO_USE_TASKSCHEDULER
@@ -65,20 +51,6 @@ IF (TACHO_HAVE_KOKKOS_TASK)
   #
   # Solver
   #
-  # TRIBITS_ADD_EXECUTABLE(
-  #   Tacho_ExampleSolverDoubleDeprecatedTaskScheduler
-  #   TARGET_DEFINES -DTACHO_USE_DEPRECATED_TASKSCHEDULER
-  #   NOEXEPREFIX
-  #   SOURCES Tacho_ExampleSolver_double.cpp
-  #   COMM serial mpi
-  # )
-  # TRIBITS_ADD_EXECUTABLE(
-  #   Tacho_ExampleSolverDoubleDeprecatedTaskSchedulerMultiple
-  #   TARGET_DEFINES -DTACHO_USE_DEPRECATED_TASKSCHEDULER_MULTIPLE
-  #   NOEXEPREFIX
-  #   SOURCES Tacho_ExampleSolver_double.cpp
-  #   COMM serial mpi
-  # )
   TRIBITS_ADD_EXECUTABLE(
     Tacho_ExampleSolverDoubleTaskScheduler
     TARGET_DEFINES -DTACHO_USE_TASKSCHEDULER
@@ -100,20 +72,6 @@ IF (TACHO_HAVE_KOKKOS_TASK)
     SOURCES Tacho_ExampleSolver_double.cpp
     COMM serial mpi
   )
-  # TRIBITS_ADD_EXECUTABLE(
-  #   Tacho_ExampleSolverDoubleComplexDeprecatedTaskScheduler
-  #   TARGET_DEFINES -DTACHO_USE_DEPRECATED_TASKSCHEDULER
-  #   NOEXEPREFIX
-  #   SOURCES Tacho_ExampleSolver_dcomplex.cpp
-  #   COMM serial mpi
-  # )
-  # TRIBITS_ADD_EXECUTABLE(
-  #   Tacho_ExampleSolverDoubleComplexDeprecatedTaskSchedulerMultiple
-  #   TARGET_DEFINES -DTACHO_USE_DEPRECATED_TASKSCHEDULER_MULTIPLE
-  #   NOEXEPREFIX
-  #   SOURCES Tacho_ExampleSolver_dcomplex.cpp
-  #   COMM serial mpi
-  # )
   TRIBITS_ADD_EXECUTABLE(
     Tacho_ExampleSolverDoubleComplexTaskScheduler
     TARGET_DEFINES -DTACHO_USE_TASKSCHEDULER
@@ -149,20 +107,6 @@ IF (TACHO_HAVE_KOKKOS_TASK)
   #
   # DenseByBlocks 
   #
-  # TRIBITS_ADD_EXECUTABLE(
-  #   Tacho_ExampleDenseByBlocksDeprecatedTaskScheduler
-  #   TARGET_DEFINES -DTACHO_USE_DEPRECATED_TASKSCHEDULER
-  #   NOEXEPREFIX
-  #   SOURCES Tacho_ExampleDenseByBlocks.cpp
-  #   COMM serial mpi
-  # )
-  # TRIBITS_ADD_EXECUTABLE(
-  #   Tacho_ExampleDenseByBlocksDeprecatedTaskSchedulerMultiple
-  #   TARGET_DEFINES -DTACHO_USE_DEPRECATED_TASKSCHEDULER_MULTIPLE
-  #   NOEXEPREFIX
-  #   SOURCES Tacho_ExampleDenseByBlocks.cpp
-  #   COMM serial mpi
-  # )
   TRIBITS_ADD_EXECUTABLE(
     Tacho_ExampleDenseByBlocksTaskScheduler
     TARGET_DEFINES -DTACHO_USE_TASKSCHEDULER
@@ -217,20 +161,6 @@ IF (TACHO_HAVE_KOKKOS_TASK)
         COMM serial mpi
       )
     ENDIF()
-    # TRIBITS_ADD_EXECUTABLE(
-    #   Tacho_ExamplePerfTestDeprecatedTaskScheduler
-    #   TARGET_DEFINES -DTACHO_USE_DEPRECATED_TASKSCHEDULER
-    #   NOEXEPREFIX
-    #   SOURCES Tacho_ExamplePerfTest.cpp
-    #   COMM serial mpi
-    # )
-    # TRIBITS_ADD_EXECUTABLE(
-    #   Tacho_ExamplePerfTestDeprecatedTaskSchedulerMultiple
-    #   TARGET_DEFINES -DTACHO_USE_DEPRECATED_TASKSCHEDULER_MULTIPLE
-    #   NOEXEPREFIX
-    #   SOURCES Tacho_ExamplePerfTest.cpp
-    #   COMM serial mpi
-    # )
     TRIBITS_ADD_EXECUTABLE(
       Tacho_ExamplePerfTestTaskScheduler
       TARGET_DEFINES -DTACHO_USE_TASKSCHEDULER

--- a/packages/shylu/shylu_node/tacho/example/Tacho_ExampleCholSupernodes.cpp
+++ b/packages/shylu/shylu_node/tacho/example/Tacho_ExampleCholSupernodes.cpp
@@ -32,16 +32,7 @@
 using namespace Tacho;
 
 /// select a kokkos task scheudler
-/// - DeprecatedTaskScheduler, DeprecatedTaskSchedulerMultiple
 /// - TaskScheduler, TaskSchedulerMultiple, ChaseLevTaskScheduler
-#if defined(TACHO_USE_DEPRECATED_TASKSCHEDULER)
-template<typename T> using TaskSchedulerType = Kokkos::DeprecatedTaskScheduler<T>;
-static const char * scheduler_name = "DeprecatedTaskScheduler";
-#endif
-#if defined(TACHO_USE_DEPRECATED_TASKSCHEDULER_MULTIPLE)
-template<typename T> using TaskSchedulerType = Kokkos::DeprecatedTaskSchedulerMultiple<T>;
-static const char * scheduler_name = "DeprecatedTaskSchedulerMultiple";
-#endif
 #if defined(TACHO_USE_TASKSCHEDULER)
 template<typename T> using TaskSchedulerType = Kokkos::TaskScheduler<T>;
 static const char * scheduler_name = "TaskScheduler";

--- a/packages/shylu/shylu_node/tacho/example/Tacho_ExampleDenseByBlocks.cpp
+++ b/packages/shylu/shylu_node/tacho/example/Tacho_ExampleDenseByBlocks.cpp
@@ -29,16 +29,7 @@ using namespace Tacho;
   printf("\n");                                                         
 
 /// select a kokkos task scheudler
-/// - DeprecatedTaskScheduler, DeprecatedTaskSchedulerMultiple
 /// - TaskScheduler, TaskSchedulerMultiple, ChaseLevTaskScheduler
-#if defined(TACHO_USE_DEPRECATED_TASKSCHEDULER)
-template<typename T> using TaskSchedulerType = Kokkos::DeprecatedTaskScheduler<T>;
-static const char * scheduler_name = "DeprecatedTaskScheduler";
-#endif
-#if defined(TACHO_USE_DEPRECATED_TASKSCHEDULER_MULTIPLE)
-template<typename T> using TaskSchedulerType = Kokkos::DeprecatedTaskSchedulerMultiple<T>;
-static const char * scheduler_name = "DeprecatedTaskSchedulerMultiple";
-#endif
 #if defined(TACHO_USE_TASKSCHEDULER)
 template<typename T> using TaskSchedulerType = Kokkos::TaskScheduler<T>;
 static const char * scheduler_name = "TaskScheduler";

--- a/packages/shylu/shylu_node/tacho/example/Tacho_ExamplePerfTest.cpp
+++ b/packages/shylu/shylu_node/tacho/example/Tacho_ExamplePerfTest.cpp
@@ -22,16 +22,7 @@
 #endif
 
 /// select a kokkos task scheudler
-/// - DeprecatedTaskScheduler, DeprecatedTaskSchedulerMultiple
 /// - TaskScheduler, TaskSchedulerMultiple, ChaseLevTaskScheduler
-#if defined(TACHO_USE_DEPRECATED_TASKSCHEDULER)
-template<typename T> using TaskSchedulerType = Kokkos::DeprecatedTaskScheduler<T>;
-static const char * scheduler_name = "DeprecatedTaskScheduler";
-#endif
-#if defined(TACHO_USE_DEPRECATED_TASKSCHEDULER_MULTIPLE)
-template<typename T> using TaskSchedulerType = Kokkos::DeprecatedTaskSchedulerMultiple<T>;
-static const char * scheduler_name = "DeprecatedTaskSchedulerMultiple";
-#endif
 #if defined(TACHO_USE_TASKSCHEDULER)
 template<typename T> using TaskSchedulerType = Kokkos::TaskScheduler<T>;
 static const char * scheduler_name = "TaskScheduler";

--- a/packages/shylu/shylu_node/tacho/example/Tacho_ExampleSolver.hpp
+++ b/packages/shylu/shylu_node/tacho/example/Tacho_ExampleSolver.hpp
@@ -6,16 +6,7 @@
 using ordinal_type = Tacho::ordinal_type;
 
 /// select a kokkos task scheudler
-/// - DeprecatedTaskScheduler, DeprecatedTaskSchedulerMultiple
 /// - TaskScheduler, TaskSchedulerMultiple, ChaseLevTaskScheduler
-#if defined(TACHO_USE_DEPRECATED_TASKSCHEDULER)
-template<typename T> using TaskSchedulerType = Kokkos::DeprecatedTaskScheduler<T>;
-static const char * scheduler_name = "DeprecatedTaskScheduler";
-#endif
-#if defined(TACHO_USE_DEPRECATED_TASKSCHEDULER_MULTIPLE)
-template<typename T> using TaskSchedulerType = Kokkos::DeprecatedTaskSchedulerMultiple<T>;
-static const char * scheduler_name = "DeprecatedTaskSchedulerMultiple";
-#endif
 #if defined(TACHO_USE_TASKSCHEDULER)
 template<typename T> using TaskSchedulerType = Kokkos::TaskScheduler<T>;
 static const char * scheduler_name = "TaskScheduler";

--- a/packages/shylu/shylu_node/tacho/unit-test/CMakeLists.txt
+++ b/packages/shylu/shylu_node/tacho/unit-test/CMakeLists.txt
@@ -15,24 +15,6 @@ SET(LIBRARIES shyluchol)
 
 IF (TACHO_HAVE_KOKKOS_TASK)
 
-  # TRIBITS_ADD_EXECUTABLE_AND_TEST(
-  #   Tacho_TestUtilDeprecatedTaskScheduler 
-  #   TARGET_DEFINES -DTACHO_USE_DEPRECATED_TASKSCHEDULER
-  #   NOEXEPREFIX
-  #   SOURCES Tacho_TestUtil.cpp
-  #   ARGS PrintItAll
-  #   NUM_MPI_PROCS 1
-  #   FAIL_REGULAR_EXPRESSION "  FAILED  "
-  # )
-  # TRIBITS_ADD_EXECUTABLE_AND_TEST(
-  #   Tacho_TestUtilDeprecatedTaskSchedulerMultiple
-  #   TARGET_DEFINES -DTACHO_USE_DEPRECATED_TASKSCHEDULER_MULTIPLE
-  #   NOEXEPREFIX
-  #   SOURCES Tacho_TestUtil.cpp
-  #   ARGS PrintItAll
-  #   NUM_MPI_PROCS 1
-  #   FAIL_REGULAR_EXPRESSION "  FAILED  "
-  # )
   TRIBITS_ADD_EXECUTABLE_AND_TEST(
     Tacho_TestUtilTaskScheduler
     TARGET_DEFINES -DTACHO_USE_TASKSCHEDULER
@@ -62,24 +44,6 @@ IF (TACHO_HAVE_KOKKOS_TASK)
   )
 
   IF(Kokkos_ENABLE_SERIAL)
-    # TRIBITS_ADD_EXECUTABLE_AND_TEST(
-    #   Tacho_TestSerialDoubleDeprecatedTaskScheduler
-    #   TARGET_DEFINES -DTACHO_USE_DEPRECATED_TASKSCHEDULER
-    #   NOEXEPREFIX
-    #   SOURCES Tacho_TestSerial_double.cpp
-    #   ARGS PrintItAll
-    #   NUM_MPI_PROCS 1
-    #   FAIL_REGULAR_EXPRESSION "  FAILED  "
-    # )
-    # TRIBITS_ADD_EXECUTABLE_AND_TEST(
-    #   Tacho_TestSerialDoubleDeprecatedTaskSchedulerMultiple
-    #   TARGET_DEFINES -DTACHO_USE_DEPRECATED_TASKSCHEDULER_MULTIPLE
-    #   NOEXEPREFIX
-    #   SOURCES Tacho_TestSerial_double.cpp
-    #   ARGS PrintItAll
-    #   NUM_MPI_PROCS 1
-    #   FAIL_REGULAR_EXPRESSION "  FAILED  "
-    # )
     TRIBITS_ADD_EXECUTABLE_AND_TEST(
       Tacho_TestSerialDoubleTaskScheduler
       TARGET_DEFINES -DTACHO_USE_TASKSCHEDULER
@@ -107,25 +71,6 @@ IF (TACHO_HAVE_KOKKOS_TASK)
       NUM_MPI_PROCS 1
       FAIL_REGULAR_EXPRESSION "  FAILED  "
     )
-
-    # TRIBITS_ADD_EXECUTABLE_AND_TEST(
-    #   Tacho_TestSerialDoubleComplexDeprecatedTaskScheduler
-    #   TARGET_DEFINES -DTACHO_USE_DEPRECATED_TASKSCHEDULER
-    #   NOEXEPREFIX
-    #   SOURCES Tacho_TestSerial_dcomplex.cpp
-    #   ARGS PrintItAll
-    #   NUM_MPI_PROCS 1
-    #   FAIL_REGULAR_EXPRESSION "  FAILED  "
-    # )
-    # TRIBITS_ADD_EXECUTABLE_AND_TEST(
-    #   Tacho_TestSerialDoubleComplexDeprecatedTaskSchedulerMultiple
-    #   TARGET_DEFINES -DTACHO_USE_DEPRECATED_TASKSCHEDULER_MULTIPLE
-    #   NOEXEPREFIX
-    #   SOURCES Tacho_TestSerial_dcomplex.cpp
-    #   ARGS PrintItAll
-    #   NUM_MPI_PROCS 1
-    #   FAIL_REGULAR_EXPRESSION "  FAILED  "
-    # )
     TRIBITS_ADD_EXECUTABLE_AND_TEST(
       Tacho_TestSerialDoubleComplexTaskScheduler
       TARGET_DEFINES -DTACHO_USE_TASKSCHEDULER
@@ -157,24 +102,6 @@ IF (TACHO_HAVE_KOKKOS_TASK)
   ENDIF()
   
   IF(Kokkos_ENABLE_OPENMP)
-    # TRIBITS_ADD_EXECUTABLE_AND_TEST(
-    #   Tacho_TestOpenMPDoubleDeprecatedTaskScheduler
-    #   TARGET_DEFINES -DTACHO_USE_DEPRECATED_TASKSCHEDULER
-    #   NOEXEPREFIX
-    #   SOURCES Tacho_TestOpenMP_double.cpp
-    #   ARGS PrintItAll
-    #   NUM_MPI_PROCS 1
-    #   FAIL_REGULAR_EXPRESSION "  FAILED  "
-    # )
-    # TRIBITS_ADD_EXECUTABLE_AND_TEST(
-    #   Tacho_TestOpenMPDoubleDeprecatedTaskSchedulerMultiple
-    #   TARGET_DEFINES -DTACHO_USE_DEPRECATED_TASKSCHEDULER_MULTIPLE
-    #   NOEXEPREFIX
-    #   SOURCES Tacho_TestOpenMP_double.cpp
-    #   ARGS PrintItAll
-    #   NUM_MPI_PROCS 1
-    #   FAIL_REGULAR_EXPRESSION "  FAILED  "
-    # )
     TRIBITS_ADD_EXECUTABLE_AND_TEST(
       Tacho_TestOpenMPDoubleTaskScheduler
       TARGET_DEFINES -DTACHO_USE_TASKSCHEDULER
@@ -202,25 +129,6 @@ IF (TACHO_HAVE_KOKKOS_TASK)
       NUM_MPI_PROCS 1
       FAIL_REGULAR_EXPRESSION "  FAILED  "
     )
-
-    # TRIBITS_ADD_EXECUTABLE_AND_TEST(
-    #   Tacho_TestOpenMPDoubleComplexDeprecatedTaskScheduler
-    #   TARGET_DEFINES -DTACHO_USE_DEPRECATED_TASKSCHEDULER
-    #   NOEXEPREFIX
-    #   SOURCES Tacho_TestOpenMP_dcomplex.cpp
-    #   ARGS PrintItAll
-    #   NUM_MPI_PROCS 1
-    #   FAIL_REGULAR_EXPRESSION "  FAILED  "
-    # )
-    # TRIBITS_ADD_EXECUTABLE_AND_TEST(
-    #   Tacho_TestOpenMPDoubleComplexDeprecatedTaskSchedulerMultiple
-    #   TARGET_DEFINES -DTACHO_USE_DEPRECATED_TASKSCHEDULER_MULTIPLE
-    #   NOEXEPREFIX
-    #   SOURCES Tacho_TestOpenMP_dcomplex.cpp
-    #   ARGS PrintItAll
-    #   NUM_MPI_PROCS 1
-    #   FAIL_REGULAR_EXPRESSION "  FAILED  "
-    # )
     TRIBITS_ADD_EXECUTABLE_AND_TEST(
       Tacho_TestOpenMPDoubleComplexTaskScheduler
       TARGET_DEFINES -DTACHO_USE_TASKSCHEDULER
@@ -251,24 +159,6 @@ IF (TACHO_HAVE_KOKKOS_TASK)
   ENDIF()
 
   IF(Kokkos_ENABLE_CUDA)
-    # TRIBITS_ADD_EXECUTABLE_AND_TEST(
-    #   Tacho_TestCudaDoubleDeprecatedTaskScheduler
-    #   TARGET_DEFINES -DTACHO_USE_DEPRECATED_TASKSCHEDULER
-    #   NOEXEPREFIX
-    #   SOURCES Tacho_TestCuda_double.cpp
-    #   ARGS PrintItAll
-    #   NUM_MPI_PROCS 1
-    #   FAIL_REGULAR_EXPRESSION "  FAILED  "
-    # )
-    # TRIBITS_ADD_EXECUTABLE_AND_TEST(
-    #   Tacho_TestCudaDoubleDeprecatedTaskSchedulerMultiple
-    #   TARGET_DEFINES -DTACHO_USE_DEPRECATED_TASKSCHEDULER_MULTIPLE
-    #   NOEXEPREFIX
-    #   SOURCES Tacho_TestCuda_double.cpp
-    #   ARGS PrintItAll
-    #   NUM_MPI_PROCS 1
-    #   FAIL_REGULAR_EXPRESSION "  FAILED  "
-    # )
     TRIBITS_ADD_EXECUTABLE_AND_TEST(
       Tacho_TestCudaDoubleTaskScheduler
       TARGET_DEFINES -DTACHO_USE_TASKSCHEDULER
@@ -296,25 +186,6 @@ IF (TACHO_HAVE_KOKKOS_TASK)
       NUM_MPI_PROCS 1
       FAIL_REGULAR_EXPRESSION "  FAILED  "
     )
-
-    # TRIBITS_ADD_EXECUTABLE_AND_TEST(
-    #   Tacho_TestCudaDoubleComplexDeprecatedTaskScheduler
-    #   TARGET_DEFINES -DTACHO_USE_DEPRECATED_TASKSCHEDULER
-    #   NOEXEPREFIX
-    #   SOURCES Tacho_TestCuda_dcomplex.cpp
-    #   ARGS PrintItAll
-    #   NUM_MPI_PROCS 1
-    #   FAIL_REGULAR_EXPRESSION "  FAILED  "
-    # )
-    # TRIBITS_ADD_EXECUTABLE_AND_TEST(
-    #   Tacho_TestCudaDoubleComplexDeprecatedTaskSchedulerMultiple
-    #   TARGET_DEFINES -DTACHO_USE_DEPRECATED_TASKSCHEDULER_MULTIPLE
-    #   NOEXEPREFIX
-    #   SOURCES Tacho_TestCuda_dcomplex.cpp
-    #   ARGS PrintItAll
-    #   NUM_MPI_PROCS 1
-    #   FAIL_REGULAR_EXPRESSION "  FAILED  "
-    # )
     TRIBITS_ADD_EXECUTABLE_AND_TEST(
       Tacho_TestCudaDoubleComplexTaskScheduler
       TARGET_DEFINES -DTACHO_USE_TASKSCHEDULER

--- a/packages/shylu/shylu_node/tacho/unit-test/Tacho_Test.hpp
+++ b/packages/shylu/shylu_node/tacho/unit-test/Tacho_Test.hpp
@@ -1,12 +1,6 @@
 #ifndef __TACHO_TEST_HPP__
 #define __TACHO_TEST_HPP__
 
-#if defined(TACHO_USE_DEPRECATED_TASKSCHEDULER)
-template<typename T> using TaskSchedulerType = Kokkos::DeprecatedTaskScheduler<T>;
-#endif
-#if defined(TACHO_USE_DEPRECATED_TASKSCHEDULER_MULTIPLE)
-template<typename T> using TaskSchedulerType = Kokkos::DeprecatedTaskSchedulerMultiple<T>;
-#endif
 #if defined(TACHO_USE_TASKSCHEDULER)
 template<typename T> using TaskSchedulerType = Kokkos::TaskScheduler<T>;
 #endif

--- a/packages/shylu/shylu_node/tacho/unit-test/Tacho_TestUtil.cpp
+++ b/packages/shylu/shylu_node/tacho/unit-test/Tacho_TestUtil.cpp
@@ -11,14 +11,6 @@ typedef typename UseThisDevice<Kokkos::DefaultExecutionSpace>::device_type Devic
 #define TEST_BEGIN 
 #define TEST_END   
 
-#if defined(TACHO_USE_DEPRECATED_TASKSCHEDULER)
-template<typename T> using TaskSchedulerType = Kokkos::DeprecatedTaskScheduler<T>;
-static const char * scheduler_name = "DeprecatedTaskScheduler";
-#endif
-#if defined(TACHO_USE_DEPRECATED_TASKSCHEDULER_MULTIPLE)
-template<typename T> using TaskSchedulerType = Kokkos::DeprecatedTaskSchedulerMultiple<T>;
-static const char * scheduler_name = "DeprecatedTaskSchedulerMultiple";
-#endif
 #if defined(TACHO_USE_TASKSCHEDULER)
 template<typename T> using TaskSchedulerType = Kokkos::TaskScheduler<T>;
 static const char * scheduler_name = "TaskScheduler";


### PR DESCRIPTION
@trilinos/tacho

## Motivation
TACHO USE DEPRECATED TASKSCHEDULER and TACHO USE DEPRECATED TASKSCHEDULER MULTIPLE have been deprecated and are no longer needed.

## Related Issues

* Part of #6655  


## Testing
Configured Built and Tested using ATDM scripts on the cee-lan

```bash
mkdir -p $TRILINOS_DIR/build
cd $TRILINOS_DIR/build

source $TRILINOS_DIR/cmake/std/atdm/load-env.sh default

cmake \
  -GNinja \
  -DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/atdm/ATDMDevEnv.cmake \
  -DTrilinos_ENABLE_TESTS=ON \
  -DTrilinos_ENABLE_MueLu=ON \
  -DTrilinos_ENABLE_Ifpack2=ON \
  -DTrilinos_ENABLE_Teko=ON \
  -DTrilinos_ENABLE_Tpetra=ON \
  -DTrilinos_ENABLE_Belos=ON \
  -DTrilinos_ENABLE_Teuchos=ON \
  -DTrilinos_ENABLE_Epetra=ON \
  -DTrilinos_ENABLE_Panzer=ON \
  -DTrilinos_ENABLE_STK=ON \
  -DTrilinos_ENABLE_Percept=ON \
  -DTrilinos_ENABLE_Intrepid=ON \
  -DTrilinos_ENABLE_Intrepid2=ON \
  -DTrilinos_ENABLE_Zoltan2=ON \
  -DTrilinos_ENABLE_Piro=ON \
  -DTrilinos_ENABLE_Phalanx=ON \
  -DTrilinos_ENABLE_RTOp=ON \
  -DTrilinos_ENABLE_ShyLU_Node=ON \
  -DTrilinos_ENABLE_ShyLU_DD=ON \
  -DTrilinos_ENABLE_ShyLU=ON \
  -DTrilinos_ENABLE_Thyra=ON \
  -DTrilinos_ENABLE_ENABLE_ALL_OPTIONAL_PACKAGES=ON \
  -DTrilinos_ENABLE_ENABLE_SECONDARY_TESTED_CODE=ON \
  $TRILINOS_DIR

make NP=16 

ctest -j16
```