### PR TITLE
KokkosKernels - replace dimension with extent

### DIFF
--- a/packages/kokkos-kernels/src/batched/KokkosBatched_Gemm_Serial_Impl.hpp
+++ b/packages/kokkos-kernels/src/batched/KokkosBatched_Gemm_Serial_Impl.hpp
@@ -46,9 +46,9 @@ namespace KokkosBatched {
     //typedef typename vector_type::value_type value_type;
 
     const int
-      m = C.dimension(0),
-      n = C.dimension(1),
-      k = A.dimension(1);
+      m = C.extent(0),
+      n = C.extent(1),
+      k = A.extent(1);
 
     static_assert(is_vector<vector_type>::value, "value type is not vector type");      
     static_assert(vector_type::vector_length == 4 || vector_type::vector_length == 8, 
@@ -155,9 +155,9 @@ namespace KokkosBatched {
     //typedef typename vector_type::value_type value_type;
 
     const int
-      m = C.dimension(0),
-      n = C.dimension(1),
-      k = A.dimension(0);
+      m = C.extent(0),
+      n = C.extent(1),
+      k = A.extent(0);
 
     static_assert(is_vector<vector_type>::value, "value type is not vector type");      
     static_assert(vector_type::vector_length == 4 || vector_type::vector_length == 8,
@@ -264,9 +264,9 @@ namespace KokkosBatched {
     //typedef typename vector_type::value_type value_type;
 
     const int
-      m = C.dimension(0),
-      n = C.dimension(1),
-      k = A.dimension(1);
+      m = C.extent(0),
+      n = C.extent(1),
+      k = A.extent(1);
 
     static_assert(is_vector<vector_type>::value, "value type is not vector type");      
     static_assert(vector_type::vector_length == 4 || vector_type::vector_length == 8,
@@ -373,9 +373,9 @@ namespace KokkosBatched {
     //typedef typename vector_type::value_type value_type;
 
     const int
-      m = C.dimension(0),
-      n = C.dimension(1),
-      k = A.dimension(0);
+      m = C.extent(0),
+      n = C.extent(1),
+      k = A.extent(0);
 
     static_assert(is_vector<vector_type>::value, "value type is not vector type");      
     static_assert(vector_type::vector_length == 4 || vector_type::vector_length == 8,

--- a/packages/kokkos-kernels/src/batched/KokkosBatched_Gemv_Serial_Impl.hpp
+++ b/packages/kokkos-kernels/src/batched/KokkosBatched_Gemv_Serial_Impl.hpp
@@ -46,9 +46,9 @@ namespace KokkosBatched {
     //typedef typename vector_type::value_type value_type;
 
     const int
-      m = A.dimension(0),
+      m = A.extent(0),
       n = 1,
-      k = A.dimension(1);
+      k = A.extent(1);
 
     static_assert(is_vector<vector_type>::value, "value type is not vector type");      
     static_assert(vector_type::vector_length == 4 || vector_type::vector_length == 8, 
@@ -150,9 +150,9 @@ namespace KokkosBatched {
     //typedef typename vector_type::value_type value_type;
 
     const int
-      m = A.dimension(0),
+      m = A.extent(0),
       n = 1,
-      k = A.dimension(1);
+      k = A.extent(1);
 
     static_assert(is_vector<vector_type>::value, "value type is not vector type");      
     static_assert(vector_type::vector_length == 4 || vector_type::vector_length == 8, 

--- a/packages/kokkos-kernels/src/batched/KokkosBatched_LU_Serial_Impl.hpp
+++ b/packages/kokkos-kernels/src/batched/KokkosBatched_LU_Serial_Impl.hpp
@@ -32,8 +32,8 @@ namespace KokkosBatched {
     //typedef typename vector_type::value_type value_type;
 
     const int
-      m = A.dimension(0),
-      n = A.dimension(1);
+      m = A.extent(0),
+      n = A.extent(1);
 
     static_assert(is_vector<vector_type>::value, "value type is not vector type");      
     static_assert(vector_type::vector_length == 4 || vector_type::vector_length == 8, 

--- a/packages/kokkos-kernels/src/batched/KokkosBatched_Trsm_Serial_Impl.hpp
+++ b/packages/kokkos-kernels/src/batched/KokkosBatched_Trsm_Serial_Impl.hpp
@@ -33,8 +33,8 @@ namespace KokkosBatched {
       //typedef typename vector_type::value_type value_type;
         
       const int
-        m = B.dimension(0),
-        n = B.dimension(1);
+        m = B.extent(0),
+        n = B.extent(1);
 
       static_assert(is_vector<vector_type>::value, "value type is not vector type");      
       static_assert(vector_type::vector_length == 4 || vector_type::vector_length == 8, 
@@ -128,8 +128,8 @@ namespace KokkosBatched {
       //typedef typename vector_type::value_type value_type;
         
       const int
-        m = B.dimension(0),
-        n = B.dimension(1);
+        m = B.extent(0),
+        n = B.extent(1);
 
       static_assert(is_vector<vector_type>::value, "value type is not vector type");      
       static_assert(vector_type::vector_length == 4 || vector_type::vector_length == 8, 
@@ -223,8 +223,8 @@ namespace KokkosBatched {
       //typedef typename vector_type::value_type value_type;
         
       const int
-        m = B.dimension(0),
-        n = B.dimension(1);
+        m = B.extent(0),
+        n = B.extent(1);
 
       static_assert(is_vector<vector_type>::value, "value type is not vector type");      
       static_assert(vector_type::vector_length == 4 || vector_type::vector_length == 8, 
@@ -319,8 +319,8 @@ namespace KokkosBatched {
       //typedef typename vector_type::value_type value_type;
         
       const int
-        m = B.dimension(0),
-        n = B.dimension(1);
+        m = B.extent(0),
+        n = B.extent(1);
 
       static_assert(is_vector<vector_type>::value, "value type is not vector type");      
       static_assert(vector_type::vector_length == 4 || vector_type::vector_length == 8, 
@@ -413,8 +413,8 @@ namespace KokkosBatched {
       //typedef typename vector_type::value_type value_type;
         
       const int
-        m = B.dimension(0),
-        n = B.dimension(1);
+        m = B.extent(0),
+        n = B.extent(1);
 
       static_assert(is_vector<vector_type>::value, "value type is not vector type");      
       static_assert(vector_type::vector_length == 4 || vector_type::vector_length == 8, 

--- a/packages/kokkos-kernels/src/batched/KokkosBatched_Util.hpp
+++ b/packages/kokkos-kernels/src/batched/KokkosBatched_Util.hpp
@@ -24,9 +24,7 @@
 
 #include "KokkosKernels_config.h"
 
-namespace KokkosBatched {
-
-  // TPL macros
+// TPL macros
 #if defined (KOKKOSKERNELS_ENABLE_TPL_MKL) 
 #define __KOKKOSBATCHED_INTEL_MKL__ 1
 #include "mkl_version.h"
@@ -37,6 +35,8 @@ namespace KokkosBatched {
   //#include "mkl_types.h"
 #endif
 #endif
+
+namespace KokkosBatched {
 
 #if defined (KOKKOSKERNELS_ENABLE_TPL_CUBLAS)
 #define __KOKKOSKERNELS_NVIDIA_CUBLAS__ 1

--- a/packages/kokkos-kernels/src/batched/KokkosBatched_Vector_SIMD_View.hpp
+++ b/packages/kokkos-kernels/src/batched/KokkosBatched_Vector_SIMD_View.hpp
@@ -57,24 +57,6 @@ namespace KokkosBatched {
     extent_int( const iType & r ) const
     { return static_cast<int>(_a.extent(r)*(r == PackDim::value ? vector_length : 1)); }
 
-#ifdef KOKKOS_ENABLE_DEPRECATED_CODE
-
-    template< typename iType >
-    KOKKOS_INLINE_FUNCTION constexpr
-    typename std::enable_if< std::is_integral<iType>::value , size_t >::type
-    dimension( const iType & r ) const { return extent( r ); }
-
-    KOKKOS_INLINE_FUNCTION constexpr size_t dimension_0() const { return _a.extent(0)*(0 == PackDim::value ? vector_length : 1); }
-    KOKKOS_INLINE_FUNCTION constexpr size_t dimension_1() const { return _a.extent(1)*(1 == PackDim::value ? vector_length : 1); }
-    KOKKOS_INLINE_FUNCTION constexpr size_t dimension_2() const { return _a.extent(2)*(2 == PackDim::value ? vector_length : 1); }
-    KOKKOS_INLINE_FUNCTION constexpr size_t dimension_3() const { return _a.extent(3)*(3 == PackDim::value ? vector_length : 1); }
-    KOKKOS_INLINE_FUNCTION constexpr size_t dimension_4() const { return _a.extent(4)*(4 == PackDim::value ? vector_length : 1); }
-    KOKKOS_INLINE_FUNCTION constexpr size_t dimension_5() const { return _a.extent(5)*(5 == PackDim::value ? vector_length : 1); }
-    KOKKOS_INLINE_FUNCTION constexpr size_t dimension_6() const { return _a.extent(6)*(6 == PackDim::value ? vector_length : 1); }
-    KOKKOS_INLINE_FUNCTION constexpr size_t dimension_7() const { return _a.extent(7)*(7 == PackDim::value ? vector_length : 1); }
-
-#endif
-
     KOKKOS_INLINE_FUNCTION constexpr size_t size() const { 
       return (_a.size() * vector_length);
     }


### PR DESCRIPTION
## Motivation

As reported in #6957, mkl header location in kokkos batched util file is problematic. It should go above kokkosbatched name space. 

This PR also replaces dimension with extent. 

A separate PR for kokkoskernels will be submitted.
