### PR TITLE
Tpetra: remove unnecessary methods from CrsPadding

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -5290,8 +5290,7 @@ namespace Tpetra {
       return comm.is_null() ? -1 : comm->getRank();
     } ();
     std::unique_ptr<padding_type> padding(
-      new padding_type(padding_type::create_from_sames_and_permutes,
-                       myRank, numSameIDs,
+      new padding_type(myRank, numSameIDs,
                        permuteFromLIDs.extent(0)));
 
     // We're accessing data on host, so make sure all device
@@ -5477,8 +5476,7 @@ namespace Tpetra {
       return comm.is_null() ? -1 : comm->getRank();
     } ();
     std::unique_ptr<padding_type> padding(
-      new padding_type(padding_type::create_from_imports,
-                       myRank, numImports));
+      new padding_type(myRank, numImports));
     Kokkos::fence(); // Make sure device sees changes made by host
     if (imports.need_sync_host()) {
       imports.sync_host();
@@ -5575,8 +5573,7 @@ namespace Tpetra {
       return comm.is_null() ? -1 : comm->getRank();
     } ();
     std::unique_ptr<padding_type> padding(
-      new padding_type(padding_type::create_from_imports,
-      myRank, numImports));
+      new padding_type(myRank, numImports));
     Kokkos::fence(); // Make sure host sees changes made by device
     if (imports.need_sync_host()) {
       imports.sync_host();

--- a/packages/tpetra/core/src/Tpetra_Details_CrsPadding.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_CrsPadding.hpp
@@ -28,20 +28,13 @@ namespace Tpetra {
       };
 
     public:
-      struct create_from_sames_and_permutes_tag {};
-      static constexpr create_from_sames_and_permutes_tag
-        create_from_sames_and_permutes {};
-      CrsPadding(create_from_sames_and_permutes_tag /* tag */,
-                 const int myRank,
+      CrsPadding(const int myRank,
                  const size_t /* numSameIDs */,
                  const size_t /* numPermutes */)
         : myRank_(myRank)
       {}
 
-      struct create_from_imports_tag {};
-      static constexpr create_from_imports_tag create_from_imports {};
-      CrsPadding(create_from_imports_tag /* tag */,
-                 const int myRank,
+      CrsPadding(const int myRank,
                  const size_t /* numImports */)
         : myRank_(myRank)
       {}


### PR DESCRIPTION
The empty static constexpr methods "create_from_sames_and_permutes"
and "create_from_imports" were causing build failues for clang
shared (undefined symbols).  Addresses issue #6951.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Fixes build failure reported in #6951.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
I replicated the failure locally, and verified that this PR fixes it. 
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trilinos/trilinos/6963)
<!-- Reviewable:end -->
