### PR TITLE
Ifpack2: Remove Deprecated Clone Methods

### DIFF
--- a/packages/ifpack2/src/Ifpack2_Chebyshev_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_Chebyshev_decl.hpp
@@ -646,39 +646,6 @@ public:
   void describe(Teuchos::FancyOStream &out, const Teuchos::EVerbosityLevel verbLevel=Teuchos::Describable::verbLevel_default) const;
 
   //@}
-  //! \name Utility methods
-  //@{
-
-  // This "template friend" declaration lets any Chebyshev
-  // specialization be a friend of any of its other specializations.
-  // That makes clone() easier to implement.
-  template <class NewMatrixType> friend class Chebyshev;
-
-  /// \brief Clone this object to one with a different Node type.
-  ///
-  /// \tparam NewMatrixType The template parameter of the new
-  ///   preconditioner to return; a specialization of
-  ///   Tpetra::RowMatrix or any subclass thereof.  The intent is that
-  ///   this type differ from \c MatrixType only in its fourth Node
-  ///   template parameter.  However, this is not strictly required.
-  ///
-  /// \param[in] A_newnode  The matrix, with the new Node type.
-  ///
-  /// \param[in,out] params Parameters for the new preconditioner.
-  ///
-  /// \pre If \c A_newnode is a Tpetra::RowMatrix, it must be fill
-  ///   complete.
-  ///
-  /// \post <tt>P->isInitialized() && P->isComputed()</tt>, where \c P
-  ///   is the returned object.  That is, P's apply() method is ready
-  ///   to be called; P is ready for use as a preconditioner.  This is
-  ///   true regardless of the current state of <tt>*this</tt>.
-  template <typename NewMatrixType>
-  Teuchos::RCP<Chebyshev<Tpetra::RowMatrix<typename NewMatrixType::scalar_type, typename NewMatrixType::local_ordinal_type, typename NewMatrixType::global_ordinal_type, typename NewMatrixType::node_type> > >
-  clone (const Teuchos::RCP<const NewMatrixType>& A_newnode,
-         const Teuchos::ParameterList& params) const;
-
-  //@}
 
 private:
 
@@ -752,28 +719,6 @@ private:
 
   //@}
 }; // class Chebyshev
-
-
-template <typename MatrixType>
-template <typename NewMatrixType>
-Teuchos::RCP<Chebyshev<Tpetra::RowMatrix<typename NewMatrixType::scalar_type, typename NewMatrixType::local_ordinal_type, typename NewMatrixType::global_ordinal_type, typename NewMatrixType::node_type> > >
-Chebyshev<MatrixType>::
-clone (const Teuchos::RCP<const NewMatrixType>& A_newnode,
-       const Teuchos::ParameterList& params) const
-{
-  using Teuchos::RCP;
-  typedef Tpetra::RowMatrix<typename NewMatrixType::scalar_type,
-    typename NewMatrixType::local_ordinal_type,
-    typename NewMatrixType::global_ordinal_type,
-    typename NewMatrixType::node_type> new_row_matrix_type;
-  typedef Ifpack2::Chebyshev<new_row_matrix_type> new_prec_type;
-
-  RCP<new_prec_type> prec (new new_prec_type (A_newnode));
-  prec->setParameters (params);
-  prec->initialize ();
-  prec->compute ();
-  return prec;
-}
 
 } // namespace Ifpack2
 

--- a/packages/ifpack2/src/Ifpack2_Factory_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_Factory_decl.hpp
@@ -47,6 +47,10 @@
 #include "Ifpack2_Preconditioner.hpp"
 #include "Ifpack2_Details_Factory.hpp"
 
+#include "Ifpack2_Chebyshev.hpp"
+#include "Ifpack2_RILUK.hpp"
+#include "Ifpack2_Experimental_RBILUK.hpp"
+
 #include <type_traits>
 
 namespace Ifpack2 {

--- a/packages/ifpack2/src/Ifpack2_Factory_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_Factory_decl.hpp
@@ -47,13 +47,6 @@
 #include "Ifpack2_Preconditioner.hpp"
 #include "Ifpack2_Details_Factory.hpp"
 
-// FIXME (mfh 28 Jul 2015) I would very much not like to include ANY
-// specific preconditioner header files here.  However, these are
-// unfortunately necessary for the largely useless clone() method.
-#include "Ifpack2_Chebyshev.hpp"
-#include "Ifpack2_RILUK.hpp"
-#include "Ifpack2_Experimental_RBILUK.hpp"
-
 #include <type_traits>
 
 namespace Ifpack2 {
@@ -206,74 +199,6 @@ public:
     return factory.isSupported (precType);
   }
 
-  /// \brief Clones a preconditioner for a different node type from an
-  ///   Ifpack2 RILUK or Chebyshev preconditioner
-  template<class InputMatrixType, class OutputMatrixType>
-  static
-  Teuchos::RCP<Preconditioner<typename OutputMatrixType::scalar_type,
-                              typename OutputMatrixType::local_ordinal_type,
-                              typename OutputMatrixType::global_ordinal_type,
-                              typename OutputMatrixType::node_type> >
-  clone (const Teuchos::RCP<Preconditioner<typename InputMatrixType::scalar_type,
-                                           typename InputMatrixType::local_ordinal_type,
-                                           typename InputMatrixType::global_ordinal_type,
-                                           typename InputMatrixType::node_type> >& prec,
-         const Teuchos::RCP<const OutputMatrixType>& matrix,
-         const Teuchos::ParameterList& params = Teuchos::ParameterList ())
-  {
-    using Teuchos::null;
-    using Teuchos::RCP;
-    using Teuchos::rcp;
-    using Teuchos::rcp_dynamic_cast;
-
-    // FIXME (mfh 09 Nov 2013) The code below assumes that the old and
-    // new scalar, local ordinal, and global ordinal types are the same.
-
-    typedef typename InputMatrixType::scalar_type scalar_type;
-    typedef typename InputMatrixType::local_ordinal_type local_ordinal_type;
-    typedef typename InputMatrixType::global_ordinal_type global_ordinal_type;
-    typedef typename InputMatrixType::node_type old_node_type;
-    typedef Tpetra::RowMatrix<scalar_type, local_ordinal_type,
-      global_ordinal_type, old_node_type> input_row_matrix_type;
-
-    static_assert (std::is_same<typename OutputMatrixType::scalar_type, scalar_type>::value,
-                   "Input and output scalar_type must be the same.");
-    static_assert (std::is_same<typename OutputMatrixType::local_ordinal_type, local_ordinal_type>::value,
-                   "Input and output local_ordinal_type must be the same.");
-    static_assert (std::is_same<typename OutputMatrixType::global_ordinal_type, global_ordinal_type>::value,
-                   "Input and output global_ordinal_type must be the same.");
-    typedef typename OutputMatrixType::node_type new_node_type;
-    typedef Preconditioner<scalar_type, local_ordinal_type,
-      global_ordinal_type, new_node_type> output_prec_type;
-
-    // FIXME (mfh 09 Nov 2013) The code below only knows how to clone
-    // three different kinds of preconditioners.  This is probably because
-    // only two subclasses of Preconditioner implement a clone() method.
-
-    RCP<output_prec_type> new_prec;
-    RCP<Chebyshev<input_row_matrix_type> > chebyPrec =
-      rcp_dynamic_cast<Chebyshev<input_row_matrix_type> > (prec);
-    if (! chebyPrec.is_null ()) {
-      new_prec = chebyPrec->clone (matrix, params);
-      return new_prec;
-    }
-    RCP<RILUK<input_row_matrix_type> > luPrec;
-    luPrec = rcp_dynamic_cast<RILUK<input_row_matrix_type> > (prec);
-    if (luPrec != null) {
-      new_prec = luPrec->clone (matrix);
-      return new_prec;
-    }
-    RCP<Experimental::RBILUK<input_row_matrix_type> > rbilukPrec;
-    rbilukPrec = rcp_dynamic_cast<Experimental::RBILUK<input_row_matrix_type> > (prec);
-    if (rbilukPrec != null) {
-      new_prec = rbilukPrec->clone (matrix);
-      return new_prec;
-    }
-    TEUCHOS_TEST_FOR_EXCEPTION
-      (true, std::logic_error, "Ifpack2::Factory::clone: Not implemented for the "
-       "current preconditioner type.  The only supported types thus far are "
-       "Chebyshev, RILUK, and RBILUK.");
-  }
 };
 
 } // namespace Ifpack2

--- a/packages/ifpack2/src/Ifpack2_RILUK_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_RILUK_decl.hpp
@@ -303,15 +303,6 @@ class RILUK:
   RILUK (const RILUK<MatrixType> & src);
 
  public:
-  /// \brief Clone preconditioner to a new node type.
-  ///
-  /// This method makes a deep copy of the original preconditioner
-  /// (and matrix), into objects with the Node type
-  /// <tt>NewMatrixType::node_type</tt>.
-  template <typename NewMatrixType>
-  Teuchos::RCP< RILUK< NewMatrixType > >
-  clone (const Teuchos::RCP<const NewMatrixType>& A_newnode) const;
-
   //! Destructor (declared virtual for memory safety).
   virtual ~RILUK ();
 
@@ -618,52 +609,6 @@ namespace detail {
     }
   };
 } // namespace detail
-
-template <class MatrixType>
-template <typename NewMatrixType>
-Teuchos::RCP<RILUK<NewMatrixType> >
-RILUK<MatrixType>::
-clone (const Teuchos::RCP<const NewMatrixType>& A_newnode) const
-{
-  using Teuchos::ParameterList;
-  using Teuchos::RCP;
-  using Teuchos::rcp;
-
-  typedef typename NewMatrixType::scalar_type new_scalar_type;
-  typedef typename NewMatrixType::local_ordinal_type new_local_ordinal_type;
-  typedef typename NewMatrixType::global_ordinal_type new_global_ordinal_type;
-  typedef typename NewMatrixType::node_type new_node_type;
-  typedef Tpetra::RowMatrix<new_scalar_type, new_local_ordinal_type,
-    new_global_ordinal_type, new_node_type> new_row_matrix_type;
-  typedef RILUK<new_row_matrix_type> new_riluk_type;
-
-  RCP<new_riluk_type> new_riluk = rcp (new new_riluk_type (A_newnode));
-
-  RCP<ParameterList> plClone = Teuchos::parameterList ();
-  plClone = detail::setLocalSolveParams<NewMatrixType, new_node_type>::setParams (plClone);
-
-  new_riluk->L_ = rcp(new crs_matrix_type(L_, Teuchos::Copy));
-  new_riluk->U_ = rcp(new crs_matrix_type(U_, Teuchos::Copy));
-  new_riluk->D_ = rcp(new crs_matrix_type(D_, Teuchos::Copy));
-
-  new_riluk->LevelOfFill_ = LevelOfFill_;
-  new_riluk->Overalloc_ = Overalloc_;
-
-  new_riluk->isAllocated_ = isAllocated_;
-  new_riluk->isInitialized_ = isInitialized_;
-  new_riluk->isComputed_ = isComputed_;
-
-  new_riluk->numInitialize_ = numInitialize_;
-  new_riluk->numCompute_ = numCompute_;
-  new_riluk->numApply_ =  numApply_;
-
-  new_riluk->RelaxValue_ = RelaxValue_;
-  new_riluk->Athresh_ = Athresh_;
-  new_riluk->Rthresh_ = Rthresh_;
-
-
-  return new_riluk;
-}
 
 } // namespace Ifpack2
 

--- a/packages/muelu/src/Smoothers/MueLu_Ifpack2Smoother_def.hpp
+++ b/packages/muelu/src/Smoothers/MueLu_Ifpack2Smoother_def.hpp
@@ -55,6 +55,7 @@
 #include <Tpetra_RowMatrix.hpp>
 
 #include <Ifpack2_Chebyshev.hpp>
+#include <Ifpack2_RILUK.hpp>
 #include <Ifpack2_Relaxation.hpp>
 #include <Ifpack2_ILUT.hpp>
 #include <Ifpack2_BlockRelaxation.hpp>


### PR DESCRIPTION
@trilinos/ifpack2

## Motivation
KokkosClassic::DefaultNode is deprecated, along with functions that take a node object as an argument. Thus, clone methods are no longer needed

## Related Issues

* Part of #6655  


## Testing
Configured Built and Tested using ATDM scripts on the cee-lan

```bash
mkdir -p $TRILINOS_DIR/build
cd $TRILINOS_DIR/build

source $TRILINOS_DIR/cmake/std/atdm/load-env.sh default

cmake \
  -GNinja \
  -DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/atdm/ATDMDevEnv.cmake \
  -DTrilinos_ENABLE_TESTS=ON \
  -DTrilinos_ENABLE_MueLu=ON \
  -DTrilinos_ENABLE_Ifpack2=ON \
  -DTrilinos_ENABLE_Teko=ON \
  -DTrilinos_ENABLE_Tpetra=ON \
  -DTrilinos_ENABLE_Belos=ON \
  -DTrilinos_ENABLE_Teuchos=ON \
  -DTrilinos_ENABLE_Epetra=ON \
  -DTrilinos_ENABLE_Panzer=ON \
  -DTrilinos_ENABLE_STK=ON \
  -DTrilinos_ENABLE_Percept=ON \
  -DTrilinos_ENABLE_Intrepid=ON \
  -DTrilinos_ENABLE_Intrepid2=ON \
  -DTrilinos_ENABLE_Zoltan2=ON \
  -DTrilinos_ENABLE_Piro=ON \
  -DTrilinos_ENABLE_Phalanx=ON \
  -DTrilinos_ENABLE_RTOp=ON \
  -DTrilinos_ENABLE_ShyLU_Node=ON \
  -DTrilinos_ENABLE_ShyLU_DD=ON \
  -DTrilinos_ENABLE_ShyLU=ON \
  -DTrilinos_ENABLE_Thyra=ON \
  -DTrilinos_ENABLE_ENABLE_ALL_OPTIONAL_PACKAGES=ON \
  -DTrilinos_ENABLE_ENABLE_SECONDARY_TESTED_CODE=ON \
  $TRILINOS_DIR

make NP=16 

ctest -j16
```