### PR TITLE
MueLu: Remove Deprecated Tests

### DIFF
--- a/packages/muelu/test/unit_tests/Adapters/CreatePreconditioner.cpp
+++ b/packages/muelu/test/unit_tests/Adapters/CreatePreconditioner.cpp
@@ -138,63 +138,6 @@ namespace MueLuTests {
       out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
           Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
 
-#ifdef HAVE_MUELU_DEPRECATED_TESTS
-
-      out << "Testing deprecated method" << std::endl;
-      tH = MueLu::CreateTpetraPreconditioner<SC,LO,GO,NO>(tpA, xmlFileName);
-      tH->apply(*(Utils::MV2TpetraMV(RHS1)), *(Utils::MV2NonConstTpetraMV(X1)));
-      out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
-          Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
-
-      xmlFileName = "testWithRebalance.xml";
-
-      RCP<dtpetra_multivector_type> tpcoordinates = MueLu::Utilities<real_type,LO,GO,NO>::MV2NonConstTpetraMV(coordinates);
-      RCP<tpetra_multivector_type>  tpnullspace   = Utils::MV2NonConstTpetraMV(nullspace);
-
-      out << "========== Create Preconditioner from xmlFile and coordinates ==========" << std::endl;
-      tH = MueLu::CreateTpetraPreconditioner<SC,LO,GO,NO>(RCP<tpetra_operator_type>(tpA), xmlFileName, tpcoordinates);
-      X1->putScalar(Teuchos::ScalarTraits<SC>::zero());
-      tH->apply(*(Utils::MV2TpetraMV(RHS1)), *(Utils::MV2NonConstTpetraMV(X1)));
-      out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
-          Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
-
-      out << "Testing deprecated method" << std::endl;
-      tH = MueLu::CreateTpetraPreconditioner<SC,LO,GO,NO>(tpA, xmlFileName, tpcoordinates);
-      X1->putScalar(Teuchos::ScalarTraits<SC>::zero());
-      tH->apply(*(Utils::MV2TpetraMV(RHS1)), *(Utils::MV2NonConstTpetraMV(X1)));
-      out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
-          Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
-
-      out << "========== Create Preconditioner from xmlFile, coordinates and nullspace ==========" << std::endl;
-      tH = MueLu::CreateTpetraPreconditioner<SC,LO,GO,NO>(RCP<tpetra_operator_type>(tpA), xmlFileName, tpcoordinates, tpnullspace);
-      X1->putScalar(Teuchos::ScalarTraits<SC>::zero());
-      tH->apply(*(Utils::MV2TpetraMV(RHS1)), *(Utils::MV2NonConstTpetraMV(X1)));
-      out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
-          Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
-
-      out << "Testing deprecated method" << std::endl;
-      tH = MueLu::CreateTpetraPreconditioner<SC,LO,GO,NO>(tpA, xmlFileName, tpcoordinates, tpnullspace);
-      X1->putScalar(Teuchos::ScalarTraits<SC>::zero());
-      tH->apply(*(Utils::MV2TpetraMV(RHS1)), *(Utils::MV2NonConstTpetraMV(X1)));
-      out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
-          Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
-
-      //Test interface with no ParameterList or XML filename provided.
-      out << "========== Create Preconditioner from coordinates and nullspace ==========" << std::endl;
-      tH = MueLu::CreateTpetraPreconditioner<SC,LO,GO,NO>(RCP<tpetra_operator_type>(tpA), tpcoordinates, tpnullspace);
-      X1->putScalar(Teuchos::ScalarTraits<SC>::zero());
-      tH->apply(*(Utils::MV2TpetraMV(RHS1)), *(Utils::MV2NonConstTpetraMV(X1)));
-      out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
-          Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
-
-      out << "Testing deprecated method" << std::endl;
-      tH = MueLu::CreateTpetraPreconditioner<SC,LO,GO,NO>(tpA, tpcoordinates, tpnullspace);
-      X1->putScalar(Teuchos::ScalarTraits<SC>::zero());
-      tH->apply(*(Utils::MV2TpetraMV(RHS1)), *(Utils::MV2NonConstTpetraMV(X1)));
-      out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
-          Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
-#endif // HAVE_MUELU_DEPRECATED_TESTS
-
 #endif
 
 #else
@@ -253,23 +196,6 @@ namespace MueLuTests {
       eH->Apply(*(Utils::MV2EpetraMV(RHS1)), *(Utils::MV2NonConstEpetraMV(X1)));
       out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
           Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
-
-#ifdef HAVE_MUELU_DEPRECATED_TESTS
-
-      eH = MueLu::CreateEpetraPreconditioner(epA, xmlFileName, epcoordinates);
-
-      X1->putScalar(Teuchos::ScalarTraits<SC>::zero());
-      eH->Apply(*(Utils::MV2EpetraMV(RHS1)), *(Utils::MV2NonConstEpetraMV(X1)));
-      out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
-          Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
-
-      eH = MueLu::CreateEpetraPreconditioner(epA, xmlFileName, epcoordinates, epnullspace);
-
-      X1->putScalar(Teuchos::ScalarTraits<SC>::zero());
-      eH->Apply(*(Utils::MV2EpetraMV(RHS1)), *(Utils::MV2NonConstEpetraMV(X1)));
-      out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
-          Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
-#endif // HAVE_MUELU_DEPRECATED_TESTS
 
 #endif
 
@@ -339,16 +265,6 @@ namespace MueLuTests {
       out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
           Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
 
-#ifdef HAVE_MUELU_DEPRECATED_TESTS
-
-      out << "Testing deprecated method" << std::endl;
-      tH = MueLu::CreateTpetraPreconditioner<SC,LO,GO,NO>(tpA,mylist);
-      tH->apply(*(Utils::MV2TpetraMV(RHS1)), *(Utils::MV2NonConstTpetraMV(X1)));
-      out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
-          Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
-
-#endif // HAVE_MUELU_DEPRECATED_TESTS
-
       mylist.set("xml parameter file","testWithRebalance.xml");
 
       RCP<Tpetra::MultiVector<real_type,LO,GO,NO> > tpcoordinates = MueLu::Utilities<real_type,LO,GO,NO>::MV2NonConstTpetraMV(coordinates);
@@ -365,36 +281,6 @@ namespace MueLuTests {
       tH->apply(*(Utils::MV2TpetraMV(RHS1)), *(Utils::MV2NonConstTpetraMV(X1)));
       out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
           Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
-
-#ifdef HAVE_MUELU_DEPRECATED_TESTS
-
-      tH = MueLu::CreateTpetraPreconditioner<SC,LO,GO,NO>(RCP<tpetra_operator_type>(tpA), mylist, tpcoordinates);
-      X1->putScalar(Teuchos::ScalarTraits<SC>::zero());
-      tH->apply(*(Utils::MV2TpetraMV(RHS1)), *(Utils::MV2NonConstTpetraMV(X1)));
-      out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
-          Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
-
-      out << "Testing deprecated method" << std::endl;
-      tH = MueLu::CreateTpetraPreconditioner<SC,LO,GO,NO>(tpA, mylist, tpcoordinates);
-      X1->putScalar(Teuchos::ScalarTraits<SC>::zero());
-      tH->apply(*(Utils::MV2TpetraMV(RHS1)), *(Utils::MV2NonConstTpetraMV(X1)));
-      out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
-          Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
-
-      tH = MueLu::CreateTpetraPreconditioner<SC,LO,GO,NO>(RCP<tpetra_operator_type>(tpA), mylist, tpcoordinates, tpnullspace);
-      X1->putScalar(Teuchos::ScalarTraits<SC>::zero());
-      tH->apply(*(Utils::MV2TpetraMV(RHS1)), *(Utils::MV2NonConstTpetraMV(X1)));
-      out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
-          Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
-
-      out << "Testing deprecated method" << std::endl;
-      tH = MueLu::CreateTpetraPreconditioner<SC,LO,GO,NO>(tpA, mylist, tpcoordinates, tpnullspace);
-      X1->putScalar(Teuchos::ScalarTraits<SC>::zero());
-      tH->apply(*(Utils::MV2TpetraMV(RHS1)), *(Utils::MV2NonConstTpetraMV(X1)));
-      out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
-          Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
-
-#endif // HAVE_MUELU_DEPRECATED_TESTS
 
 #endif
 
@@ -446,23 +332,6 @@ namespace MueLuTests {
       userParamList.set<RCP<Epetra_MultiVector> >("Coordinates", epcoordinates);
       userParamList.set<RCP<Epetra_MultiVector> >("Nullspace", epnullspace);
       eH = MueLu::CreateEpetraPreconditioner(epA, paramList);
-
-#ifdef HAVE_MUELU_DEPRECATED_TESTS
-
-      eH = MueLu::CreateEpetraPreconditioner(epA, mylist, epcoordinates);
-
-      X1->putScalar(Teuchos::ScalarTraits<SC>::zero());
-      eH->Apply(*(Utils::MV2EpetraMV(RHS1)), *(Utils::MV2NonConstEpetraMV(X1)));
-      out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
-          Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
-
-      eH = MueLu::CreateEpetraPreconditioner(epA, mylist, epcoordinates, epnullspace);
-
-      X1->putScalar(Teuchos::ScalarTraits<SC>::zero());
-      eH->Apply(*(Utils::MV2EpetraMV(RHS1)), *(Utils::MV2NonConstEpetraMV(X1)));
-      out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
-          Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
-#endif // HAVE_MUELU_DEPRECATED_TESTS
 
 #endif
 
@@ -554,34 +423,6 @@ namespace MueLuTests {
         tH->apply(*(Utils::MV2TpetraMV(RHS1)), *(Utils::MV2NonConstTpetraMV(X1)));
         out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
             Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
-
-#ifdef HAVE_MUELU_DEPRECATED_TESTS
-
-        tH = MueLu::CreateTpetraPreconditioner<SC,LO,GO,NO>(RCP<tpetra_operator_type>(tpA), xmlFileName, tpcoordinates);
-        tH->apply(*(Utils::MV2TpetraMV(RHS1)), *(Utils::MV2NonConstTpetraMV(X1)));
-        out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
-            Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
-
-        out << "Testing deprecated method" << std::endl;
-        tH = MueLu::CreateTpetraPreconditioner<SC,LO,GO,NO>(tpA, xmlFileName, tpcoordinates);
-        tH->apply(*(Utils::MV2TpetraMV(RHS1)), *(Utils::MV2NonConstTpetraMV(X1)));
-        out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
-            Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
-
-        tH = MueLu::CreateTpetraPreconditioner<SC,LO,GO,NO>(RCP<tpetra_operator_type>(tpA), xmlFileName, tpcoordinates, tpnullspace);
-        X1->putScalar(Teuchos::ScalarTraits<SC>::zero());
-        tH->apply(*(Utils::MV2TpetraMV(RHS1)), *(Utils::MV2NonConstTpetraMV(X1)));
-        out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
-            Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
-
-        out << "Testing deprecated method" << std::endl;
-        tH = MueLu::CreateTpetraPreconditioner<SC,LO,GO,NO>(tpA, xmlFileName, tpcoordinates, tpnullspace);
-        X1->putScalar(Teuchos::ScalarTraits<SC>::zero());
-        tH->apply(*(Utils::MV2TpetraMV(RHS1)), *(Utils::MV2NonConstTpetraMV(X1)));
-        out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
-            Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
-
-#endif // HAVE_MUELU_DEPRECATED_TESTS
 #else
         std::cout << "Skip PetraOperator::CreatePreconditioner_PDESystem: Tpetra is not available (with GO=int enabled)" << std::endl;
 #endif // #if defined(HAVE_MUELU_TPETRA) && defined(HAVE_MUELU_TPETRA_INST_INT_INT)
@@ -643,22 +484,6 @@ namespace MueLuTests {
         out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
             Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
 
-#ifdef HAVE_MUELU_DEPRECATED_TESTS
-
-        eH = MueLu::CreateEpetraPreconditioner(epA, xmlFileName, epcoordinates);
-
-        eH->Apply(*(Utils::MV2EpetraMV(RHS1)), *(Utils::MV2NonConstEpetraMV(X1)));
-        out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
-            Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
-
-        eH = MueLu::CreateEpetraPreconditioner(epA, xmlFileName, epcoordinates, epnullspace);
-
-        X1->putScalar(Teuchos::ScalarTraits<SC>::zero());
-        eH->Apply(*(Utils::MV2EpetraMV(RHS1)), *(Utils::MV2NonConstEpetraMV(X1)));
-        out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
-            Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
-#endif // HAVE_MUELU_DEPRECATED_TESTS
-
 #else
         std::cout << "Skip PetraOperator::CreatePreconditioner_PDESystem: Epetra is not available" << std::endl;
 #endif
@@ -714,16 +539,6 @@ namespace MueLuTests {
       tH->apply(*(Utils::MV2TpetraMV(RHS1)), *(Utils::MV2NonConstTpetraMV(X1)));
       out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
           Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
-
-#ifdef HAVE_MUELU_DEPRECATED_TESTS
-
-      out << "Testing deprecated method" << std::endl;
-      tH = MueLu::CreateTpetraPreconditioner<SC,LO,GO,NO>(tpA, xmlFileName);
-      tH->apply(*(Utils::MV2TpetraMV(RHS1)), *(Utils::MV2NonConstTpetraMV(X1)));
-      out << "after apply, ||b-A*x||_2 = " << std::setiosflags(std::ios::fixed) << std::setprecision(10) <<
-          Utils::ResidualNorm(*Op, *X1, *RHS1) << std::endl;
-
-#endif // HAVE_MUELU_DEPRECATED_TESTS
 
       // Reuse preconditioner
       MueLu::ReuseTpetraPreconditioner(tpA, *tH);


### PR DESCRIPTION
@trilinos/muelu

## Motivation
The methods:
 - CreateEpetraPreconditioner
 - CreateTpetraPreconditioner
 - CreateXpetraPreconditioner

That take nullspace and/or coordinated directly as parameters were deprecated and removed in #6388.  This PR removes the deprecated tests that used these methods.

## Related Issues

* Part of #6655  


## Testing
Configured Built and Tested using ATDM scripts on the cee-lan

```bash
mkdir -p $TRILINOS_DIR/build
cd $TRILINOS_DIR/build

source $TRILINOS_DIR/cmake/std/atdm/load-env.sh default

cmake \
  -GNinja \
  -DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/atdm/ATDMDevEnv.cmake \
  -DTrilinos_ENABLE_TESTS=ON \
  -DTrilinos_ENABLE_MueLu=ON \
  -DTrilinos_ENABLE_Ifpack2=ON \
  -DTrilinos_ENABLE_Teko=ON \
  -DTrilinos_ENABLE_Tpetra=ON \
  -DTrilinos_ENABLE_Belos=ON \
  -DTrilinos_ENABLE_Teuchos=ON \
  -DTrilinos_ENABLE_Epetra=ON \
  -DTrilinos_ENABLE_Tpetra=ON \
  -DTrilinos_ENABLE_Xpetra=ON \
  -DTrilinos_ENABLE_Panzer=ON \
  -DTrilinos_ENABLE_STK=ON \
  -DTrilinos_ENABLE_Percept=ON \
  -DTrilinos_ENABLE_Intrepid=ON \
  -DTrilinos_ENABLE_Intrepid2=ON \
  -DTrilinos_ENABLE_Zoltan2=ON \
  -DTrilinos_ENABLE_Piro=ON \
  -DTrilinos_ENABLE_Phalanx=ON \
  -DTrilinos_ENABLE_RTOp=ON \
  -DTrilinos_ENABLE_ShyLU_Node=ON \
  -DTrilinos_ENABLE_ShyLU_DD=ON \
  -DTrilinos_ENABLE_ShyLU=ON \
  -DTrilinos_ENABLE_Thyra=ON \
  -DTrilinos_ENABLE_ENABLE_ALL_OPTIONAL_PACKAGES=ON \
  -DTrilinos_ENABLE_ENABLE_SECONDARY_TESTED_CODE=ON \
  $TRILINOS_DIR

make NP=16 

ctest -j16
```