### PR TITLE
KokkosKernels - Impl::is_same gone.

### DIFF
--- a/packages/kokkos-kernels/src/blas/KokkosBlas1_abs.hpp
+++ b/packages/kokkos-kernels/src/blas/KokkosBlas1_abs.hpp
@@ -66,7 +66,7 @@ abs (const RMV& R, const XMV& X)
                  "R is not a Kokkos::View.");
   static_assert (Kokkos::Impl::is_view<XMV>::value, "KokkosBlas::abs: "
                  "X is not a Kokkos::View.");
-  static_assert (Kokkos::Impl::is_same<typename RMV::value_type,
+  static_assert (std::is_same<typename RMV::value_type,
                  typename RMV::non_const_value_type>::value,
                  "KokkosBlas::abs: R is const.  "
                  "It must be nonconst, because it is an output argument "

--- a/packages/kokkos-kernels/src/blas/KokkosBlas1_axpby.hpp
+++ b/packages/kokkos-kernels/src/blas/KokkosBlas1_axpby.hpp
@@ -64,7 +64,7 @@ axpby (const AV& a, const XMV& X, const BV& b, const YMV& Y)
                  "X is not a Kokkos::View.");
   static_assert (Kokkos::Impl::is_view<YMV>::value, "KokkosBlas::axpby: "
                  "Y is not a Kokkos::View.");
-  static_assert (Kokkos::Impl::is_same<typename YMV::value_type,
+  static_assert (std::is_same<typename YMV::value_type,
                  typename YMV::non_const_value_type>::value,
                  "KokkosBlas::axpby: Y is const.  It must be nonconst, "
                  "because it is an output argument "

--- a/packages/kokkos-kernels/src/blas/KokkosBlas1_dot.hpp
+++ b/packages/kokkos-kernels/src/blas/KokkosBlas1_dot.hpp
@@ -162,7 +162,7 @@ dot (const RV& R, const XMV& X, const YMV& Y,
                  "X is not a Kokkos::View.");
   static_assert (Kokkos::Impl::is_view<YMV>::value, "KokkosBlas::dot: "
                  "Y is not a Kokkos::View.");
-  static_assert (Kokkos::Impl::is_same<typename RV::value_type,
+  static_assert (std::is_same<typename RV::value_type,
                    typename RV::non_const_value_type>::value,
                  "KokkosBlas::dot: R is const.  "
                  "It must be nonconst, because it is an output argument "

--- a/packages/kokkos-kernels/src/blas/KokkosBlas1_iamax.hpp
+++ b/packages/kokkos-kernels/src/blas/KokkosBlas1_iamax.hpp
@@ -104,7 +104,7 @@ iamax (const RV& R, const XMV& X,
                  "R is not a Kokkos::View.");
   static_assert (Kokkos::Impl::is_view<XMV>::value, "KokkosBlas::iamax: "
                  "X is not a Kokkos::View.");
-  static_assert (Kokkos::Impl::is_same<typename RV::value_type,
+  static_assert (std::is_same<typename RV::value_type,
                  typename RV::non_const_value_type>::value,
                  "KokkosBlas::iamax: R is const.  "
                  "It must be nonconst, because it is an output argument "
@@ -114,7 +114,7 @@ iamax (const RV& R, const XMV& X,
                  "RV and XMV must either have rank 0 and 1 or rank 1 and 2.");
 
   typedef typename XMV::size_type index_type;
-  static_assert (Kokkos::Impl::is_same<typename RV::value_type,
+  static_assert (std::is_same<typename RV::value_type,
                  index_type>::value,
                  "KokkosBlas::iamax: R must have the type of"
                  "the Xvectors size_type it is an output argument "

--- a/packages/kokkos-kernels/src/blas/KokkosBlas1_mult.hpp
+++ b/packages/kokkos-kernels/src/blas/KokkosBlas1_mult.hpp
@@ -61,7 +61,7 @@ mult (typename YMV::const_value_type& gamma,
                  "Y is not a Kokkos::View.");
   static_assert (Kokkos::Impl::is_view<AV>::value, "KokkosBlas::mult: "
                  "A is not a Kokkos::View.");
-  static_assert (Kokkos::Impl::is_same<typename YMV::value_type,
+  static_assert (std::is_same<typename YMV::value_type,
                    typename YMV::non_const_value_type>::value,
                  "KokkosBlas::mult: Y is const.  "
                  "It must be nonconst, because it is an output argument "

--- a/packages/kokkos-kernels/src/blas/KokkosBlas1_nrm1.hpp
+++ b/packages/kokkos-kernels/src/blas/KokkosBlas1_nrm1.hpp
@@ -103,7 +103,7 @@ nrm1 (const RV& R, const XMV& X,
                  "R is not a Kokkos::View.");
   static_assert (Kokkos::Impl::is_view<XMV>::value, "KokkosBlas::nrm1: "
                  "X is not a Kokkos::View.");
-  static_assert (Kokkos::Impl::is_same<typename RV::value_type,
+  static_assert (std::is_same<typename RV::value_type,
                  typename RV::non_const_value_type>::value,
                  "KokkosBlas::nrm1: R is const.  "
                  "It must be nonconst, because it is an output argument "
@@ -113,7 +113,7 @@ nrm1 (const RV& R, const XMV& X,
                  "RV and XMV must either have rank 0 and 1 or rank 1 and 2.");
 
   typedef typename Kokkos::Details::InnerProductSpaceTraits<typename XMV::non_const_value_type>::mag_type mag_type;
-  static_assert (Kokkos::Impl::is_same<typename RV::value_type,
+  static_assert (std::is_same<typename RV::value_type,
                  mag_type>::value,
                  "KokkosBlas::nrm1: R must have the magnitude type of"
                  "the xvectors value_type it is an output argument "

--- a/packages/kokkos-kernels/src/blas/KokkosBlas1_nrm2.hpp
+++ b/packages/kokkos-kernels/src/blas/KokkosBlas1_nrm2.hpp
@@ -103,7 +103,7 @@ nrm2 (const RV& R, const XMV& X,
                  "R is not a Kokkos::View.");
   static_assert (Kokkos::Impl::is_view<XMV>::value, "KokkosBlas::nrm2: "
                  "X is not a Kokkos::View.");
-  static_assert (Kokkos::Impl::is_same<typename RV::value_type,
+  static_assert (std::is_same<typename RV::value_type,
                  typename RV::non_const_value_type>::value,
                  "KokkosBlas::nrm2: R is const.  "
                  "It must be nonconst, because it is an output argument "
@@ -113,7 +113,7 @@ nrm2 (const RV& R, const XMV& X,
                  "RV and XMV must either have rank 0 and 1 or rank 1 and 2.");
 
   typedef typename Kokkos::Details::InnerProductSpaceTraits<typename XMV::non_const_value_type>::mag_type mag_type;
-  static_assert (Kokkos::Impl::is_same<typename RV::value_type,
+  static_assert (std::is_same<typename RV::value_type,
                  mag_type>::value,
                  "KokkosBlas::nrm2: R must have the magnitude type of"
                  "the xvectors value_type it is an output argument "

--- a/packages/kokkos-kernels/src/blas/KokkosBlas1_nrm2_squared.hpp
+++ b/packages/kokkos-kernels/src/blas/KokkosBlas1_nrm2_squared.hpp
@@ -104,7 +104,7 @@ nrm2_squared (const RV& R, const XMV& X,
                  "R is not a Kokkos::View.");
   static_assert (Kokkos::Impl::is_view<XMV>::value, "KokkosBlas::nrm2_squared: "
                  "X is not a Kokkos::View.");
-  static_assert (Kokkos::Impl::is_same<typename RV::value_type,
+  static_assert (std::is_same<typename RV::value_type,
                  typename RV::non_const_value_type>::value,
                  "KokkosBlas::nrm2_squared: R is const.  "
                  "It must be nonconst, because it is an output argument "
@@ -113,7 +113,7 @@ nrm2_squared (const RV& R, const XMV& X,
                  ((RV::rank == 1) && (XMV::rank == 2)), "KokkosBlas::nrm2_squared: "
                  "RV and XMV must either have rank 0 and 1 or rank 1 and 2.");
   typedef typename Kokkos::Details::InnerProductSpaceTraits<typename XMV::non_const_value_type>::mag_type mag_type;
-  static_assert (Kokkos::Impl::is_same<typename RV::value_type,
+  static_assert (std::is_same<typename RV::value_type,
                  mag_type>::value,
                  "KokkosBlas::nrm2: R must have the magnitude type of"
                  "the xvectors value_type it is an output argument "

--- a/packages/kokkos-kernels/src/blas/KokkosBlas1_nrm2w.hpp
+++ b/packages/kokkos-kernels/src/blas/KokkosBlas1_nrm2w.hpp
@@ -104,7 +104,7 @@ nrm2w (const RV& R, const XMV& X, const XMV& W,
                  "R is not a Kokkos::View.");
   static_assert (Kokkos::Impl::is_view<XMV>::value, "KokkosBlas::nrm2w: "
                  "X is not a Kokkos::View.");
-  static_assert (Kokkos::Impl::is_same<typename RV::value_type,
+  static_assert (std::is_same<typename RV::value_type,
                  typename RV::non_const_value_type>::value,
                  "KokkosBlas::nrm2w: R is const.  "
                  "It must be nonconst, because it is an output argument "
@@ -114,7 +114,7 @@ nrm2w (const RV& R, const XMV& X, const XMV& W,
                  "RV and XMV must either have rank 0 and 1 or rank 1 and 2.");
 
   typedef typename Kokkos::Details::InnerProductSpaceTraits<typename XMV::non_const_value_type>::mag_type mag_type;
-  static_assert (Kokkos::Impl::is_same<typename RV::value_type,
+  static_assert (std::is_same<typename RV::value_type,
                  mag_type>::value,
                  "KokkosBlas::nrm2w: R must have the magnitude type of"
                  "the xvectors value_type it is an output argument "

--- a/packages/kokkos-kernels/src/blas/KokkosBlas1_nrm2w_squared.hpp
+++ b/packages/kokkos-kernels/src/blas/KokkosBlas1_nrm2w_squared.hpp
@@ -105,7 +105,7 @@ nrm2w_squared (const RV& R, const XMV& X, const XMV& W,
                  "R is not a Kokkos::View.");
   static_assert (Kokkos::Impl::is_view<XMV>::value, "KokkosBlas::nrm2w_squared: "
                  "X is not a Kokkos::View.");
-  static_assert (Kokkos::Impl::is_same<typename RV::value_type,
+  static_assert (std::is_same<typename RV::value_type,
                  typename RV::non_const_value_type>::value,
                  "KokkosBlas::nrm2w_squared: R is const.  "
                  "It must be nonconst, because it is an output argument "
@@ -114,7 +114,7 @@ nrm2w_squared (const RV& R, const XMV& X, const XMV& W,
                  ((RV::rank == 1) && (XMV::rank == 2)), "KokkosBlas::nrm2w_squared: "
                  "RV and XMV must either have rank 0 and 1 or rank 1 and 2.");
   typedef typename Kokkos::Details::InnerProductSpaceTraits<typename XMV::non_const_value_type>::mag_type mag_type;
-  static_assert (Kokkos::Impl::is_same<typename RV::value_type,
+  static_assert (std::is_same<typename RV::value_type,
                  mag_type>::value,
                  "KokkosBlas::nrm2w: R must have the magnitude type of"
                  "the xvectors value_type it is an output argument "

--- a/packages/kokkos-kernels/src/blas/KokkosBlas1_nrminf.hpp
+++ b/packages/kokkos-kernels/src/blas/KokkosBlas1_nrminf.hpp
@@ -103,7 +103,7 @@ nrminf (const RV& R, const XMV& X,
                  "R is not a Kokkos::View.");
   static_assert (Kokkos::Impl::is_view<XMV>::value, "KokkosBlas::nrminf: "
                  "X is not a Kokkos::View.");
-  static_assert (Kokkos::Impl::is_same<typename RV::value_type,
+  static_assert (std::is_same<typename RV::value_type,
                  typename RV::non_const_value_type>::value,
                  "KokkosBlas::nrminf: R is const.  "
                  "It must be nonconst, because it is an output argument "
@@ -113,7 +113,7 @@ nrminf (const RV& R, const XMV& X,
                  "RV and XMV must either have rank 0 and 1 or rank 1 and 2.");
 
   typedef typename Kokkos::Details::InnerProductSpaceTraits<typename XMV::non_const_value_type>::mag_type mag_type;
-  static_assert (Kokkos::Impl::is_same<typename RV::value_type,
+  static_assert (std::is_same<typename RV::value_type,
                  mag_type>::value,
                  "KokkosBlas::nrminf: R must have the magnitude type of"
                  "the xvectors value_type it is an output argument "

--- a/packages/kokkos-kernels/src/blas/KokkosBlas1_reciprocal.hpp
+++ b/packages/kokkos-kernels/src/blas/KokkosBlas1_reciprocal.hpp
@@ -66,7 +66,7 @@ reciprocal (const RMV& R, const XMV& X)
                  "R is not a Kokkos::View.");
   static_assert (Kokkos::Impl::is_view<XMV>::value, "KokkosBlas::reciprocal: "
                  "X is not a Kokkos::View.");
-  static_assert (Kokkos::Impl::is_same<typename RMV::value_type,
+  static_assert (std::is_same<typename RMV::value_type,
                  typename RMV::non_const_value_type>::value,
                  "KokkosBlas::reciprocal: R is const.  "
                  "It must be nonconst, because it is an output argument "

--- a/packages/kokkos-kernels/src/blas/KokkosBlas1_scal.hpp
+++ b/packages/kokkos-kernels/src/blas/KokkosBlas1_scal.hpp
@@ -57,7 +57,7 @@ scal (const RMV& R, const AV& a, const XMV& X)
                  "R is not a Kokkos::View.");
   static_assert (Kokkos::Impl::is_view<XMV>::value, "KokkosBlas::scal: "
                  "X is not a Kokkos::View.");
-  static_assert (Kokkos::Impl::is_same<typename RMV::value_type,
+  static_assert (std::is_same<typename RMV::value_type,
                  typename RMV::non_const_value_type>::value,
                  "KokkosBlas::scal: R is const.  "
                  "It must be nonconst, because it is an output argument "

--- a/packages/kokkos-kernels/src/blas/KokkosBlas1_sum.hpp
+++ b/packages/kokkos-kernels/src/blas/KokkosBlas1_sum.hpp
@@ -103,7 +103,7 @@ sum (const RV& R, const XMV& X,
                  "R is not a Kokkos::View.");
   static_assert (Kokkos::Impl::is_view<XMV>::value, "KokkosBlas::sum: "
                  "X is not a Kokkos::View.");
-  static_assert (Kokkos::Impl::is_same<typename RV::value_type,
+  static_assert (std::is_same<typename RV::value_type,
                  typename RV::non_const_value_type>::value,
                  "KokkosBlas::sum: R is const.  "
                  "It must be nonconst, because it is an output argument "

--- a/packages/kokkos-kernels/src/blas/KokkosBlas1_update.hpp
+++ b/packages/kokkos-kernels/src/blas/KokkosBlas1_update.hpp
@@ -70,7 +70,7 @@ update (const typename XMV::non_const_value_type& alpha, const XMV& X,
                  "Y is not a Kokkos::View.");
   static_assert (Kokkos::Impl::is_view<ZMV>::value, "KokkosBlas::update: "
                  "Z is not a Kokkos::View.");
-  static_assert (Kokkos::Impl::is_same<typename ZMV::value_type,
+  static_assert (std::is_same<typename ZMV::value_type,
                  typename ZMV::non_const_value_type>::value,
                  "KokkosBlas::update: Z is const.  "
                  "It must be nonconst, because it is an output argument "

--- a/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_axpby_impl.hpp
+++ b/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_axpby_impl.hpp
@@ -97,7 +97,7 @@ struct Axpby_Functor {
                    "Axpby_Functor: X is not a Kokkos::View.");
     static_assert (Kokkos::Impl::is_view<YV>::value, "KokkosBlas::Impl::"
                    "Axpby_Functor: Y is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_same<typename YV::value_type,
+    static_assert (std::is_same<typename YV::value_type,
                    typename YV::non_const_value_type>::value,
                    "KokkosBlas::Impl::Axpby_Functor: Y is const.  "
                    "It must be nonconst, because it is an output argument "
@@ -231,7 +231,7 @@ struct Axpby_Functor<typename XV::non_const_value_type, XV,
                    "Axpby_Functor: X is not a Kokkos::View.");
     static_assert (Kokkos::Impl::is_view<YV>::value, "KokkosBlas::Impl::"
                    "Axpby_Functor: Y is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_same<typename YV::value_type,
+    static_assert (std::is_same<typename YV::value_type,
                    typename YV::non_const_value_type>::value,
                    "KokkosBlas::Impl::Axpby_Functor: R is const.  "
                    "It must be nonconst, because it is an output argument "
@@ -336,7 +336,7 @@ Axpby_Generic (const AV& av, const XV& x,
                  "Axpby_Generic: X is not a Kokkos::View.");
   static_assert (Kokkos::Impl::is_view<YV>::value, "KokkosBlas::Impl::"
                  "Axpby_Generic: Y is not a Kokkos::View.");
-  static_assert (Kokkos::Impl::is_same<typename YV::value_type,
+  static_assert (std::is_same<typename YV::value_type,
                    typename YV::non_const_value_type>::value,
                  "KokkosBlas::Impl::Axpby_Generic: Y is const.  "
                  "It must be nonconst, because it is an output argument "

--- a/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_axpby_mv_impl.hpp
+++ b/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_axpby_mv_impl.hpp
@@ -94,7 +94,7 @@ struct Axpby_MV_Functor
     static_assert (Kokkos::Impl::is_view<YMV>::value, "KokkosBlas::Impl::"
                    "Axpby_MV_Functor: Y is not a Kokkos::View.");
     // YMV must be nonconst (else it can't be an output argument).
-    static_assert (Kokkos::Impl::is_same<typename YMV::value_type,
+    static_assert (std::is_same<typename YMV::value_type,
                    typename YMV::non_const_value_type>::value,
                    "KokkosBlas::Impl::Axpby_MV_Functor: Y is const.  "
                    "It must be nonconst, because it is an output argument "
@@ -328,7 +328,7 @@ struct Axpby_MV_Functor<typename XMV::non_const_value_type, XMV,
                    "Axpby_MV_Functor: X is not a Kokkos::View.");
     static_assert (Kokkos::Impl::is_view<YMV>::value, "KokkosBlas::Impl::"
                    "Axpby_MV_Functor: Y is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_same<typename YMV::value_type,
+    static_assert (std::is_same<typename YMV::value_type,
                    typename YMV::non_const_value_type>::value,
                    "KokkosBlas::Impl::Axpby_MV_Functor: Y is const.  "
                    "It must be nonconst, because it is an output argument "
@@ -545,7 +545,7 @@ struct Axpby_MV_Unroll_Functor
                    "Axpby_MV_Unroll_Functor: b is not a Kokkos::View.");
     static_assert (Kokkos::Impl::is_view<YMV>::value, "KokkosBlas::Impl::"
                    "Axpby_MV_Unroll_Functor: Y is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_same<typename YMV::value_type,
+    static_assert (std::is_same<typename YMV::value_type,
                    typename YMV::non_const_value_type>::value,
                    "KokkosBlas::Impl::Axpby_MV_Unroll_Functor: Y is const.  "
                    "It must be nonconst, because it is an output argument "
@@ -766,7 +766,7 @@ struct Axpby_MV_Unroll_Functor<typename XMV::non_const_value_type, XMV,
                    "Axpby_MV_Unroll_Functor: X is not a Kokkos::View.");
     static_assert (Kokkos::Impl::is_view<YMV>::value, "KokkosBlas::Impl::"
                    "Axpby_MV_Unroll_Functor: Y is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_same<typename YMV::value_type,
+    static_assert (std::is_same<typename YMV::value_type,
                    typename YMV::non_const_value_type>::value,
                    "KokkosBlas::Impl::Axpby_MV_Unroll_Functor: Y is const.  "
                    "It must be nonconst, because it is an output argument "
@@ -980,7 +980,7 @@ Axpby_MV_Unrolled (const AV& av, const XMV& x,
                  "Axpby_MV_Unrolled: X is not a Kokkos::View.");
   static_assert (Kokkos::Impl::is_view<YMV>::value, "KokkosBlas::Impl::"
                  "Axpby_MV_Unrolled: Y is not a Kokkos::View.");
-  static_assert (Kokkos::Impl::is_same<typename YMV::value_type,
+  static_assert (std::is_same<typename YMV::value_type,
                    typename YMV::non_const_value_type>::value,
                  "KokkosBlas::Impl::Axpby_MV_Unrolled: Y is const.  "
                  "It must be nonconst, because it is an output argument "
@@ -1118,7 +1118,7 @@ Axpby_MV_Generic (const AV& av, const XMV& x,
                  "Axpby_MV_Generic: X is not a Kokkos::View.");
   static_assert (Kokkos::Impl::is_view<YMV>::value, "KokkosBlas::Impl::"
                  "Axpby_MV_Generic: Y is not a Kokkos::View.");
-  static_assert (Kokkos::Impl::is_same<typename YMV::value_type,
+  static_assert (std::is_same<typename YMV::value_type,
                    typename YMV::non_const_value_type>::value,
                  "KokkosBlas::Impl::Axpby_MV_Generic: Y is const.  "
                  "It must be nonconst, because it is an output argument "
@@ -1258,7 +1258,7 @@ Axpby_MV_Invoke_Left {
                  "Axpby_MV_Invoke_Left: X is not a Kokkos::View.");
   static_assert (Kokkos::Impl::is_view<YMV>::value, "KokkosBlas::Impl::"
                  "Axpby_MV_Invoke_Left: Y is not a Kokkos::View.");
-  static_assert (Kokkos::Impl::is_same<typename YMV::value_type,
+  static_assert (std::is_same<typename YMV::value_type,
                  typename YMV::non_const_value_type>::value,
                  "KokkosBlas::Impl::Axpby_MV_Invoke_Left: Y is const.  "
                  "It must be nonconst, because it is an output argument "
@@ -1337,7 +1337,7 @@ static void run(const AV& av, const XMV& x,
                  "Axpby_MV_Invoke_Right: X is not a Kokkos::View.");
   static_assert (Kokkos::Impl::is_view<YMV>::value, "KokkosBlas::Impl::"
                  "Axpby_MV_Invoke_Right: Y is not a Kokkos::View.");
-  static_assert (Kokkos::Impl::is_same<typename YMV::value_type,
+  static_assert (std::is_same<typename YMV::value_type,
                  typename YMV::non_const_value_type>::value,
                  "KokkosBlas::Impl::Axpby_MV_Invoke_Right: Y is const.  "
                  "It must be nonconst, because it is an output argument "

--- a/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_axpby_spec.hpp
+++ b/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_axpby_spec.hpp
@@ -169,7 +169,7 @@ struct Axpby<AV, XMV, BV, YMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
                    "Axpby<rank-2>::axpby: X is not a Kokkos::View.");
     static_assert (Kokkos::Impl::is_view<YMV>::value, "KokkosBlas::Impl::"
                    "Axpby<rank-2>::axpby: Y is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_same<typename YMV::value_type,
+    static_assert (std::is_same<typename YMV::value_type,
                      typename YMV::non_const_value_type>::value,
                    "KokkosBlas::Impl::Axpby<rank-2>::axpby: Y is const.  "
                    "It must be nonconst, because it is an output argument "
@@ -238,7 +238,7 @@ struct Axpby<typename XMV::non_const_value_type, XMV,
     static_assert (Kokkos::Impl::is_view<YMV>::value,
                    "KokkosBlas::Impl::Axpby::axpby (MV): "
                    "Y is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_same<typename YMV::value_type,
+    static_assert (std::is_same<typename YMV::value_type,
                      typename YMV::non_const_value_type>::value,
                    "KokkosBlas::Impl::Axpby::axpby (MV): Y is const.  "
                    "It must be nonconst, because it is an output argument "
@@ -331,7 +331,7 @@ struct Axpby<typename XV::non_const_value_type, XV,
                    "Axpby<rank-1>::axpby: X is not a Kokkos::View.");
     static_assert (Kokkos::Impl::is_view<YV>::value, "KokkosBlas::Impl::"
                    "Axpby<rank-1>::axpby: Y is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_same<typename YV::value_type,
+    static_assert (std::is_same<typename YV::value_type,
                      typename YV::non_const_value_type>::value,
                    "KokkosBlas::Impl::Axpby<rank-1>::axpby: Y is const.  "
                    "It must be nonconst, because it is an output argument "

--- a/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_dot_mv_impl.hpp
+++ b/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_dot_mv_impl.hpp
@@ -99,7 +99,7 @@ struct MV_V_Dot_Functor
                    "MV_V_Dot_Functor: X is not a Kokkos::View.");
     static_assert (Kokkos::Impl::is_view<YV>::value, "KokkosBlas::Impl::"
                    "MV_V_Dot_Functor: Y is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_same<typename RV::value_type,
+    static_assert (std::is_same<typename RV::value_type,
                    typename RV::non_const_value_type>::value,
                    "KokkosBlas::Impl::MV_V_Dot_Functor: R is const.  "
                    "It must be nonconst, because it is an output argument "
@@ -218,7 +218,7 @@ struct MV_Dot_Right_FunctorVector
                    "MV_Dot_Right_FunctorVector: X is not a Kokkos::View.");
     static_assert (Kokkos::Impl::is_view<YMV>::value, "KokkosBlas::Impl::"
                    "MV_Dot_Right_FunctorVector: Y is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_same<typename RV::value_type,
+    static_assert (std::is_same<typename RV::value_type,
                    typename RV::non_const_value_type>::value,
                    "KokkosBlas::Impl::MV_Dot_Right_FunctorVector: R is const.  "
                    "It must be nonconst, because it is an output argument "
@@ -326,7 +326,7 @@ struct MV_Dot_Right_FunctorUnroll
                    "MV_Dot_Right_FunctorUnroll: X is not a Kokkos::View.");
     static_assert (Kokkos::Impl::is_view<YMV>::value, "KokkosBlas::Impl::"
                    "MV_Dot_Right_FunctorUnroll: Y is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_same<typename RV::value_type,
+    static_assert (std::is_same<typename RV::value_type,
                    typename RV::non_const_value_type>::value,
                    "KokkosBlas::Impl::MV_Dot_Right_FunctorUnroll: R is const.  "
                    "It must be nonconst, because it is an output argument "

--- a/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_iamax_impl.hpp
+++ b/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_iamax_impl.hpp
@@ -76,7 +76,7 @@ struct V_Iamax_Functor
     static_assert (Kokkos::Impl::is_view<XV>::value,
                    "KokkosBlas::Impl::V_Iamax_Functor: "
                    "X is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_same<typename RV::value_type,
+    static_assert (std::is_same<typename RV::value_type,
                    typename RV::non_const_value_type>::value,
                    "KokkosBlas::Impl::V_Iamax_Functor: R is const.  "
                    "It must be nonconst, because it is an output argument "
@@ -148,7 +148,7 @@ struct MV_Iamax_FunctorVector
     static_assert (Kokkos::Impl::is_view<XMV>::value,
                    "KokkosBlas::Impl::MV_Iamax_FunctorVector: "
                    "X is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_same<typename RV::value_type,
+    static_assert (std::is_same<typename RV::value_type,
                    typename RV::non_const_value_type>::value,
                    "KokkosBlas::Impl::MV_Iamax_FunctorVector: "
                    "R is const.  It must be nonconst, because it is an output "

--- a/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_mult_spec.hpp
+++ b/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_mult_spec.hpp
@@ -154,7 +154,7 @@ struct Mult<YMV, AV, XMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
                    "Mult<rank 2>::mult: A is not a Kokkos::View.");
     static_assert (Kokkos::Impl::is_view<XMV>::value, "KokkosBlas::Impl::"
                    "Mult<rank 2>::mult: X is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_same<typename YMV::value_type,
+    static_assert (std::is_same<typename YMV::value_type,
                      typename YMV::non_const_value_type>::value,
                    "KokkosBlas::Impl::Mult<rank 2>::mult: Y is const.  "
                    "It must be nonconst, because it is an output argument "
@@ -211,7 +211,7 @@ struct Mult<YV, AV, XV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
     static_assert (Kokkos::Impl::is_view<XV>::value, "KokkosBlas::Impl::"
                    "Mult<rank 1>::mult: X is not a Kokkos::View.");
     // XV must be nonconst (else it can't be an output argument).
-    static_assert (Kokkos::Impl::is_same<typename YV::value_type,
+    static_assert (std::is_same<typename YV::value_type,
                      typename YV::non_const_value_type>::value,
                    "KokkosBlas::Impl::Mult<rank 1>::mult: Y is const.  "
                    "It must be nonconst, because it is an output argument "

--- a/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_nrm1_impl.hpp
+++ b/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_nrm1_impl.hpp
@@ -80,7 +80,7 @@ struct V_Nrm1_Functor
     static_assert (Kokkos::Impl::is_view<XV>::value,
                    "KokkosBlas::Impl::V_Nrm1_Functor: "
                    "X is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_same<typename RV::value_type,
+    static_assert (std::is_same<typename RV::value_type,
                    typename RV::non_const_value_type>::value,
                    "KokkosBlas::Impl::V_Nrm1_Functor: R is const.  "
                    "It must be nonconst, because it is an output argument "
@@ -144,7 +144,7 @@ struct MV_Nrm1_Right_FunctorVector
     static_assert (Kokkos::Impl::is_view<XMV>::value,
                    "KokkosBlas::Impl::MV_Nrm1_Right_FunctorVector: "
                    "X is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_same<typename RV::value_type,
+    static_assert (std::is_same<typename RV::value_type,
                    typename RV::non_const_value_type>::value,
                    "KokkosBlas::Impl::MV_Nrm1_Right_FunctorVector: "
                    "R is const.  It must be nonconst, because it is an output "

--- a/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_nrm2_impl.hpp
+++ b/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_nrm2_impl.hpp
@@ -81,7 +81,7 @@ struct V_Nrm2_Functor
     static_assert (Kokkos::Impl::is_view<XV>::value,
                    "KokkosBlas::Impl::V_Nrm2_Functor: "
                    "X is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_same<typename RV::value_type,
+    static_assert (std::is_same<typename RV::value_type,
                    typename RV::non_const_value_type>::value,
                    "KokkosBlas::Impl::V_Nrm2_Functor: R is const.  "
                    "It must be nonconst, because it is an output argument "
@@ -153,7 +153,7 @@ struct MV_Nrm2_Right_FunctorVector
     static_assert (Kokkos::Impl::is_view<XMV>::value,
                    "KokkosBlas::Impl::MV_Nrm2_Right_FunctorVector: "
                    "X is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_same<typename RV::value_type,
+    static_assert (std::is_same<typename RV::value_type,
                    typename RV::non_const_value_type>::value,
                    "KokkosBlas::Impl::MV_Nrm2_Right_FunctorVector: "
                    "R is const.  It must be nonconst, because it is an output "

--- a/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_nrm2w_impl.hpp
+++ b/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_nrm2w_impl.hpp
@@ -82,7 +82,7 @@ struct V_Nrm2w_Functor
     static_assert (Kokkos::Impl::is_view<XV>::value,
                    "KokkosBlas::Impl::V_Nrm2w_Functor: "
                    "X is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_same<typename RV::value_type,
+    static_assert (std::is_same<typename RV::value_type,
                    typename RV::non_const_value_type>::value,
                    "KokkosBlas::Impl::V_Nrm2w_Functor: R is const.  "
                    "It must be nonconst, because it is an output argument "
@@ -154,7 +154,7 @@ struct MV_Nrm2w_Right_FunctorVector
     static_assert (Kokkos::Impl::is_view<XMV>::value,
                    "KokkosBlas::Impl::MV_Nrm2w_Right_FunctorVector: "
                    "X is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_same<typename RV::value_type,
+    static_assert (std::is_same<typename RV::value_type,
                    typename RV::non_const_value_type>::value,
                    "KokkosBlas::Impl::MV_Nrm2w_Right_FunctorVector: "
                    "R is const.  It must be nonconst, because it is an output "

--- a/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_nrminf_impl.hpp
+++ b/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_nrminf_impl.hpp
@@ -80,7 +80,7 @@ struct V_NrmInf_Functor
     static_assert (Kokkos::Impl::is_view<XV>::value,
                    "KokkosBlas::Impl::V_NrmInf_Functor: "
                    "X is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_same<typename RV::value_type,
+    static_assert (std::is_same<typename RV::value_type,
                    typename RV::non_const_value_type>::value,
                    "KokkosBlas::Impl::V_NrmInf_Functor: R is const.  "
                    "It must be nonconst, because it is an output argument "
@@ -126,7 +126,7 @@ struct MV_NrmInf_Right_FunctorVector
     static_assert (Kokkos::Impl::is_view<XMV>::value,
                    "KokkosBlas::Impl::MV_NrmInf_Right_FunctorVector: "
                    "X is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_same<typename RV::value_type,
+    static_assert (std::is_same<typename RV::value_type,
                    typename RV::non_const_value_type>::value,
                    "KokkosBlas::Impl::MV_NrmInf_Right_FunctorVector: "
                    "R is const.  It must be nonconst, because it is an output "

--- a/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_sum_impl.hpp
+++ b/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_sum_impl.hpp
@@ -81,7 +81,7 @@ struct V_Sum_Functor
     static_assert (Kokkos::Impl::is_view<XV>::value,
                    "KokkosBlas::Impl::V_Sum_Functor: "
                    "X is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_same<typename RV::value_type,
+    static_assert (std::is_same<typename RV::value_type,
                    typename RV::non_const_value_type>::value,
                    "KokkosBlas::Impl::V_Sum_Functor: R is const.  "
                    "It must be nonconst, because it is an output argument "
@@ -126,7 +126,7 @@ struct MV_Sum_Right_FunctorVector
     static_assert (Kokkos::Impl::is_view<XMV>::value,
                    "KokkosBlas::Impl::MV_Sum_Right_FunctorVector: "
                    "X is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_same<typename RV::value_type,
+    static_assert (std::is_same<typename RV::value_type,
                    typename RV::non_const_value_type>::value,
                    "KokkosBlas::Impl::MV_Sum_Right_FunctorVector: "
                    "R is const.  It must be nonconst, because it is an output "

--- a/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_update_impl.hpp
+++ b/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_update_impl.hpp
@@ -98,7 +98,7 @@ struct MV_Update_Functor
                    "MV_Update_Functor: Y is not a Kokkos::View.");
     static_assert (Kokkos::Impl::is_view<ZMV>::value, "KokkosBlas::Impl::"
                    "MV_Update_Functor: Z is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_same<typename ZMV::value_type,
+    static_assert (std::is_same<typename ZMV::value_type,
                    typename ZMV::non_const_value_type>::value,
                    "KokkosBlas::Impl::MV_Update_Functor: Z is const.  "
                    "It must be nonconst, because it is an output argument "
@@ -268,7 +268,7 @@ struct V_Update_Functor
                    "V_Update_Functor: Y is not a Kokkos::View.");
     static_assert (Kokkos::Impl::is_view<ZV>::value, "KokkosBlas::Impl::"
                    "V_Update_Functor: Z is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_same<typename ZV::value_type,
+    static_assert (std::is_same<typename ZV::value_type,
                    typename ZV::non_const_value_type>::value,
                    "KokkosBlas::Impl::V_Update_Functor: Z is const.  "
                    "It must be nonconst, because it is an output argument "
@@ -359,7 +359,7 @@ MV_Update_Generic (const typename XMV::non_const_value_type& alpha, const XMV& X
                  "MV_Update_Generic: Y is not a Kokkos::View.");
   static_assert (Kokkos::Impl::is_view<ZMV>::value, "KokkosBlas::Impl::"
                  "MV_Update_Generic: Z is not a Kokkos::View.");
-  static_assert (Kokkos::Impl::is_same<typename ZMV::value_type,
+  static_assert (std::is_same<typename ZMV::value_type,
                  typename ZMV::non_const_value_type>::value,
                  "KokkosBlas::Impl::MV_Update_Generic: Z is const.  "
                  "It must be nonconst, because it is an output argument "
@@ -455,7 +455,7 @@ V_Update_Generic (const typename XV::non_const_value_type& alpha, const XV& X,
                    "V_Update_Generic: Y is not a Kokkos::View.");
     static_assert (Kokkos::Impl::is_view<ZV>::value, "KokkosBlas::Impl::"
                    "V_Update_Generic: Z is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_same<typename ZV::value_type,
+    static_assert (std::is_same<typename ZV::value_type,
                    typename ZV::non_const_value_type>::value,
                    "KokkosBlas::Impl::V_Update_Generic: Z is const.  "
                    "It must be nonconst, because it is an output argument "

--- a/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_update_spec.hpp
+++ b/packages/kokkos-kernels/src/blas/impl/KokkosBlas1_update_spec.hpp
@@ -149,7 +149,7 @@ struct Update<XMV, YMV, ZMV, 2, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
                    "Update<rank 2>::update: Y is not a Kokkos::View.");
     static_assert (Kokkos::Impl::is_view<ZMV>::value, "KokkosBlas::Impl::"
                    "Update<rank 2>::update: Z is not a Kokkos::View.");
-    static_assert (Kokkos::Impl::is_same<typename ZMV::value_type,
+    static_assert (std::is_same<typename ZMV::value_type,
                      typename ZMV::non_const_value_type>::value,
                    "KokkosBlas::Impl::Update<rank 2>::update: Z is const.  "
                    "It must be nonconst, because it is an output argument "
@@ -247,7 +247,7 @@ struct Update<XV, YV, ZV, 1, false, KOKKOSKERNELS_IMPL_COMPILE_LIBRARY>
     static_assert (Kokkos::Impl::is_view<ZV>::value, "KokkosBlas::Impl::"
                    "Update<rank 1>::update: Z is not a Kokkos::View.");
     // ZV must be nonconst (else it can't be an output argument).
-    static_assert (Kokkos::Impl::is_same<typename ZV::value_type,
+    static_assert (std::is_same<typename ZV::value_type,
                      typename ZV::non_const_value_type>::value,
                    "KokkosBlas::Impl::Update<rank 1>::update: Z is const.  "
                    "It must be nonconst, because it is an output argument "

--- a/packages/kokkos-kernels/src/common/KokkosKernels_ExecSpaceUtils.hpp
+++ b/packages/kokkos-kernels/src/common/KokkosKernels_ExecSpaceUtils.hpp
@@ -57,31 +57,31 @@ template <typename ExecutionSpace>
 inline ExecSpaceType kk_get_exec_space_type(){
   ExecSpaceType exec_space = Exec_SERIAL;
 #if defined( KOKKOS_ENABLE_SERIAL )
-  if (Kokkos::Impl::is_same< Kokkos::Serial , ExecutionSpace >::value){
+  if (std::is_same< Kokkos::Serial , ExecutionSpace >::value){
     exec_space = Exec_SERIAL;
   }
 #endif
 
 #if defined( KOKKOS_ENABLE_THREADS )
-  if (Kokkos::Impl::is_same< Kokkos::Threads , ExecutionSpace >::value){
+  if (std::is_same< Kokkos::Threads , ExecutionSpace >::value){
     exec_space =  Exec_PTHREADS;
   }
 #endif
 
 #if defined( KOKKOS_ENABLE_OPENMP )
-  if (Kokkos::Impl::is_same< Kokkos::OpenMP, ExecutionSpace >::value){
+  if (std::is_same< Kokkos::OpenMP, ExecutionSpace >::value){
     exec_space = Exec_OMP;
   }
 #endif
 
 #if defined( KOKKOS_ENABLE_CUDA )
-  if (Kokkos::Impl::is_same<Kokkos::Cuda, ExecutionSpace >::value){
+  if (std::is_same<Kokkos::Cuda, ExecutionSpace >::value){
     exec_space = Exec_CUDA;
   }
 #endif
 
 #if defined( KOKKOS_ENABLE_QTHREAD)
-  if (Kokkos::Impl::is_same< Kokkos::Qthread, ExecutionSpace >::value){
+  if (std::is_same< Kokkos::Qthread, ExecutionSpace >::value){
     exec_space = Exec_QTHREADS;
   }
 #endif

--- a/packages/kokkos-kernels/src/common/KokkosKernels_Utils.hpp
+++ b/packages/kokkos-kernels/src/common/KokkosKernels_Utils.hpp
@@ -101,28 +101,28 @@ void get_suggested_vector_team_size(
     suggested_team_size_ = 1;
 
 #if defined( KOKKOS_ENABLE_SERIAL )
-  if (Kokkos::Impl::is_same< Kokkos::Serial , ExecutionSpace >::value){
+  if (std::is_same< Kokkos::Serial , ExecutionSpace >::value){
     suggested_vector_size_ =  1;
     suggested_team_size_ = 1;
   }
 #endif
 
 #if defined( KOKKOS_ENABLE_THREADS )
-  if (Kokkos::Impl::is_same< Kokkos::Threads , ExecutionSpace >::value){
+  if (std::is_same< Kokkos::Threads , ExecutionSpace >::value){
     suggested_vector_size_ =  1;
     suggested_team_size_ =  1;
   }
 #endif
 
 #if defined( KOKKOS_ENABLE_OPENMP )
-  if (Kokkos::Impl::is_same< Kokkos::OpenMP, ExecutionSpace >::value){
+  if (std::is_same< Kokkos::OpenMP, ExecutionSpace >::value){
     suggested_vector_size_ =  1;
     suggested_team_size_ = 1;
   }
 #endif
 
 #if defined( KOKKOS_ENABLE_CUDA )
-  if (Kokkos::Impl::is_same<Kokkos::Cuda, ExecutionSpace >::value){
+  if (std::is_same<Kokkos::Cuda, ExecutionSpace >::value){
 
     suggested_vector_size_ = nnz / double (nr) + 0.5;
 
@@ -151,7 +151,7 @@ void get_suggested_vector_team_size(
 #endif
 
 #if defined( KOKKOS_ENABLE_QTHREAD)
-  if (Kokkos::Impl::is_same< Kokkos::Qthread, ExecutionSpace >::value){
+  if (std::is_same< Kokkos::Qthread, ExecutionSpace >::value){
     suggested_vector_size_ = 1;
     suggested_team_size_ = 1;
   }
@@ -168,25 +168,25 @@ void get_suggested_vector_size(
     suggested_vector_size_ =  1;
 
 #if defined( KOKKOS_ENABLE_SERIAL )
-  if (Kokkos::Impl::is_same< Kokkos::Serial , ExecutionSpace >::value){
+  if (std::is_same< Kokkos::Serial , ExecutionSpace >::value){
     suggested_vector_size_ =  1;
   }
 #endif
 
 #if defined( KOKKOS_ENABLE_THREADS )
-  if (Kokkos::Impl::is_same< Kokkos::Threads , ExecutionSpace >::value){
+  if (std::is_same< Kokkos::Threads , ExecutionSpace >::value){
     suggested_vector_size_ =  1;
   }
 #endif
 
 #if defined( KOKKOS_ENABLE_OPENMP )
-  if (Kokkos::Impl::is_same< Kokkos::OpenMP, ExecutionSpace >::value){
+  if (std::is_same< Kokkos::OpenMP, ExecutionSpace >::value){
     suggested_vector_size_ =  1;
   }
 #endif
 
 #if defined( KOKKOS_ENABLE_CUDA )
-  if (Kokkos::Impl::is_same<Kokkos::Cuda, ExecutionSpace >::value){
+  if (std::is_same<Kokkos::Cuda, ExecutionSpace >::value){
 
     suggested_vector_size_ = nnz / double (nr) + 0.5;
 
@@ -209,7 +209,7 @@ void get_suggested_vector_size(
 #endif
 
 #if defined( KOKKOS_ENABLE_QTHREAD)
-  if (Kokkos::Impl::is_same< Kokkos::Qthread, ExecutionSpace >::value){
+  if (std::is_same< Kokkos::Qthread, ExecutionSpace >::value){
     suggested_vector_size_ = 1;
   }
 #endif

--- a/packages/kokkos-kernels/src/graph/KokkosGraph_Distance1ColorHandle.hpp
+++ b/packages/kokkos-kernels/src/graph/KokkosGraph_Distance1ColorHandle.hpp
@@ -233,7 +233,7 @@ private:
   void choose_default_algorithm()
   {
 #if defined( KOKKOS_ENABLE_SERIAL )
-    if (Kokkos::Impl::is_same< Kokkos::Serial , ExecutionSpace >::value){
+    if (std::is_same< Kokkos::Serial , ExecutionSpace >::value){
       this->coloring_algorithm_type = COLORING_SERIAL;
 #ifdef VERBOSE
       std::cout << "Serial Execution Space, Default Algorithm: COLORING_VB" << std::endl;
@@ -242,7 +242,7 @@ private:
 #endif
 
 #if defined( KOKKOS_ENABLE_THREADS )
-    if (Kokkos::Impl::is_same< Kokkos::Threads , ExecutionSpace >::value){
+    if (std::is_same< Kokkos::Threads , ExecutionSpace >::value){
       this->coloring_algorithm_type = COLORING_VB;
 #ifdef VERBOSE
       std::cout << "PTHREAD Execution Space, Default Algorithm: COLORING_VB" << std::endl;
@@ -251,7 +251,7 @@ private:
 #endif
 
 #if defined( KOKKOS_ENABLE_OPENMP )
-    if (Kokkos::Impl::is_same< Kokkos::OpenMP, ExecutionSpace >::value){
+    if (std::is_same< Kokkos::OpenMP, ExecutionSpace >::value){
       this->coloring_algorithm_type = COLORING_VB;
 #ifdef VERBOSE
       std::cout << "OpenMP Execution Space, Default Algorithm: COLORING_VB" << std::endl;
@@ -260,7 +260,7 @@ private:
 #endif
 
 #if defined( KOKKOS_ENABLE_CUDA )
-    if (Kokkos::Impl::is_same<Kokkos::Cuda, ExecutionSpace >::value){
+    if (std::is_same<Kokkos::Cuda, ExecutionSpace >::value){
       this->coloring_algorithm_type = COLORING_EB;
 #ifdef VERBOSE
       std::cout << "Cuda Execution Space, Default Algorithm: COLORING_VB" << std::endl;
@@ -269,7 +269,7 @@ private:
 #endif
 
 #if defined( KOKKOS_ENABLE_QTHREAD)
-    if (Kokkos::Impl::is_same< Kokkos::Qthread, ExecutionSpace >::value){
+    if (std::is_same< Kokkos::Qthread, ExecutionSpace >::value){
       this->coloring_algorithm_type = COLORING_VB;
 #ifdef VERBOSE
       std::cout << "Qthread Execution Space, Default Algorithm: COLORING_VB" << std::endl;
@@ -499,7 +499,7 @@ private:
 
       if ( false
 #if defined( KOKKOS_ENABLE_CUDA )
-          || Kokkos::Impl::is_same<Kokkos::Cuda, ExecutionSpace >::value
+          || std::is_same<Kokkos::Cuda, ExecutionSpace >::value
 #endif
          )
       {

--- a/packages/kokkos-kernels/src/graph/KokkosGraph_Distance2ColorHandle.hpp
+++ b/packages/kokkos-kernels/src/graph/KokkosGraph_Distance2ColorHandle.hpp
@@ -159,7 +159,7 @@ class GraphColorDistance2Handle
         this->set_defaults(this->coloring_algorithm_type);
 
         // Throw an error if PersistentMemSpace != TempMemSpace since we don't support them being different (for now).
-        if(!Kokkos::Impl::is_same<PersistentMemorySpace, TemporaryMemorySpace>::value)
+        if(!std::is_same<PersistentMemorySpace, TemporaryMemorySpace>::value)
         {
             std::string message = "Distance-2 Graph Coloring Handle does not currently support different mem spaces";
             Kokkos::Impl::throw_runtime_exception(message);
@@ -211,7 +211,7 @@ class GraphColorDistance2Handle
     void choose_default_algorithm()
     {
 #if defined(KOKKOS_ENABLE_SERIAL)
-        if(Kokkos::Impl::is_same<Kokkos::Serial, ExecutionSpace>::value)
+        if(std::is_same<Kokkos::Serial, ExecutionSpace>::value)
         {
             this->coloring_algorithm_type = COLORING_D2_SERIAL;
 #ifdef VERBOSE
@@ -221,7 +221,7 @@ class GraphColorDistance2Handle
 #endif
 
 #if defined(KOKKOS_ENABLE_THREADS)
-        if(Kokkos::Impl::is_same<Kokkos::Threads, ExecutionSpace>::value)
+        if(std::is_same<Kokkos::Threads, ExecutionSpace>::value)
         {
             this->coloring_algorithm_type = COLORING_D2_VB_BIT;
 #ifdef VERBOSE
@@ -231,7 +231,7 @@ class GraphColorDistance2Handle
 #endif
 
 #if defined(KOKKOS_ENABLE_OPENMP)
-        if(Kokkos::Impl::is_same<Kokkos::OpenMP, ExecutionSpace>::value)
+        if(std::is_same<Kokkos::OpenMP, ExecutionSpace>::value)
         {
             this->coloring_algorithm_type = COLORING_D2_VB_BIT;
 #ifdef VERBOSE
@@ -241,7 +241,7 @@ class GraphColorDistance2Handle
 #endif
 
 #if defined(KOKKOS_ENABLE_CUDA)
-        if(Kokkos::Impl::is_same<Kokkos::Cuda, ExecutionSpace>::value)
+        if(std::is_same<Kokkos::Cuda, ExecutionSpace>::value)
         {
             this->coloring_algorithm_type = COLORING_D2_VB_BIT;
 #ifdef VERBOSE
@@ -251,7 +251,7 @@ class GraphColorDistance2Handle
 #endif
 
 #if defined(KOKKOS_ENABLE_QTHREAD)
-        if(Kokkos::Impl::is_same<Kokkos::Qthread, ExecutionSpace>::value)
+        if(std::is_same<Kokkos::Qthread, ExecutionSpace>::value)
         {
             this->coloring_algorithm_type = COLORING_D2_VB_BIT;
 #ifdef VERBOSE

--- a/packages/kokkos-kernels/src/sparse/KokkosSparse_gauss_seidel_handle.hpp
+++ b/packages/kokkos-kernels/src/sparse/KokkosSparse_gauss_seidel_handle.hpp
@@ -280,7 +280,7 @@ namespace KokkosSparse{
      */
     void choose_default_algorithm(){
 #if defined( KOKKOS_ENABLE_SERIAL )
-      if (Kokkos::Impl::is_same< Kokkos::Serial , ExecutionSpace >::value){
+      if (std::is_same< Kokkos::Serial , ExecutionSpace >::value){
         this->algorithm_type = GS_PERMUTED;
 #ifdef VERBOSE
         std::cout << "Serial Execution Space, Default Algorithm: GS_PERMUTED" << std::endl;
@@ -289,7 +289,7 @@ namespace KokkosSparse{
 #endif
 
 #if defined( KOKKOS_ENABLE_THREADS )
-      if (Kokkos::Impl::is_same< Kokkos::Threads , ExecutionSpace >::value){
+      if (std::is_same< Kokkos::Threads , ExecutionSpace >::value){
         this->algorithm_type = GS_PERMUTED;
 #ifdef VERBOSE
         std::cout << "PTHREAD Execution Space, Default Algorithm: GS_PERMUTED" << std::endl;
@@ -298,7 +298,7 @@ namespace KokkosSparse{
 #endif
 
 #if defined( KOKKOS_ENABLE_OPENMP )
-      if (Kokkos::Impl::is_same< Kokkos::OpenMP, ExecutionSpace >::value){
+      if (std::is_same< Kokkos::OpenMP, ExecutionSpace >::value){
         this->algorithm_type = GS_PERMUTED;
 #ifdef VERBOSE
         std::cout << "OpenMP Execution Space, Default Algorithm: GS_PERMUTED" << std::endl;
@@ -307,7 +307,7 @@ namespace KokkosSparse{
 #endif
 
 #if defined( KOKKOS_ENABLE_CUDA )
-      if (Kokkos::Impl::is_same<Kokkos::Cuda, ExecutionSpace >::value){
+      if (std::is_same<Kokkos::Cuda, ExecutionSpace >::value){
         this->algorithm_type = GS_TEAM;
 #ifdef VERBOSE
         std::cout << "Cuda Execution Space, Default Algorithm: GS_TEAM" << std::endl;
@@ -316,7 +316,7 @@ namespace KokkosSparse{
 #endif
 
 #if defined( KOKKOS_ENABLE_QTHREAD)
-      if (Kokkos::Impl::is_same< Kokkos::Qthread, ExecutionSpace >::value){
+      if (std::is_same< Kokkos::Qthread, ExecutionSpace >::value){
         this->algorithm_type = GS_PERMUTED;
 #ifdef VERBOSE
         std::cout << "Qthread Execution Space, Default Algorithm: GS_PERMUTED" << std::endl;
@@ -568,27 +568,27 @@ namespace KokkosSparse{
     {
       bool return_value = false;
 #if defined( KOKKOS_ENABLE_SERIAL )
-      if (Kokkos::Impl::is_same< Kokkos::Serial , ExecutionSpace >::value) {
+      if (std::is_same< Kokkos::Serial , ExecutionSpace >::value) {
         return_value = false;
       }
 #endif
 #if defined( KOKKOS_ENABLE_THREADS )
-      if (Kokkos::Impl::is_same< Kokkos::Threads , ExecutionSpace >::value){
+      if (std::is_same< Kokkos::Threads , ExecutionSpace >::value){
         return_value = false;
       }
 #endif
 #if defined( KOKKOS_ENABLE_OPENMP )
-      if (Kokkos::Impl::is_same< Kokkos::OpenMP, ExecutionSpace >::value){
+      if (std::is_same< Kokkos::OpenMP, ExecutionSpace >::value){
         return_value = false;
       }
 #endif
 #if defined( KOKKOS_ENABLE_CUDA )
-      if (Kokkos::Impl::is_same<Kokkos::Cuda, ExecutionSpace >::value){
+      if (std::is_same<Kokkos::Cuda, ExecutionSpace >::value){
         return_value = true;
       }
 #endif
 #if defined( KOKKOS_ENABLE_QTHREAD)
-      if (Kokkos::Impl::is_same< Kokkos::Qthread, ExecutionSpace >::value){
+      if (std::is_same< Kokkos::Qthread, ExecutionSpace >::value){
         return_value = false;
       }
 #endif

--- a/packages/kokkos-kernels/src/sparse/KokkosSparse_spadd_handle.hpp
+++ b/packages/kokkos-kernels/src/sparse/KokkosSparse_spadd_handle.hpp
@@ -165,7 +165,7 @@ public:
     }
 
 #if defined( KOKKOS_ENABLE_SERIAL )
-    if (Kokkos::Impl::is_same< Kokkos::Serial , ExecutionSpace >::value){
+    if (std::is_same< Kokkos::Serial , ExecutionSpace >::value){
       suggested_vector_size_ = this->suggested_vector_size = 1;
       suggested_team_size_ = this->suggested_team_size = max_allowed_team_size;
       return;
@@ -173,7 +173,7 @@ public:
 #endif
 
 #if defined( KOKKOS_ENABLE_THREADS )
-    if (Kokkos::Impl::is_same< Kokkos::Threads , ExecutionSpace >::value){
+    if (std::is_same< Kokkos::Threads , ExecutionSpace >::value){
       suggested_vector_size_ = this->suggested_vector_size = 1;
       suggested_team_size_ = this->suggested_team_size = max_allowed_team_size;
       return;
@@ -181,14 +181,14 @@ public:
 #endif
 
 #if defined( KOKKOS_ENABLE_OPENMP )
-    if (Kokkos::Impl::is_same< Kokkos::OpenMP, ExecutionSpace >::value){
+    if (std::is_same< Kokkos::OpenMP, ExecutionSpace >::value){
       suggested_vector_size_ = this->suggested_vector_size = 1;
       suggested_team_size_ = this->suggested_team_size = max_allowed_team_size;
     }
 #endif
 
 #if defined( KOKKOS_ENABLE_CUDA )
-    if (Kokkos::Impl::is_same<Kokkos::Cuda, ExecutionSpace >::value){
+    if (std::is_same<Kokkos::Cuda, ExecutionSpace >::value){
 
       this->suggested_vector_size = nnz / double (nr) + 0.5;
 
@@ -214,7 +214,7 @@ public:
 #endif
 
 #if defined( KOKKOS_ENABLE_QTHREAD)
-    if (Kokkos::Impl::is_same< Kokkos::Qthread, ExecutionSpace >::value){
+    if (std::is_same< Kokkos::Qthread, ExecutionSpace >::value){
       suggested_vector_size_ = this->suggested_vector_size = 1;
       suggested_team_size_ = this->suggested_team_size = max_allowed_team_size;
     }

--- a/packages/kokkos-kernels/src/sparse/KokkosSparse_spgemm_handle.hpp
+++ b/packages/kokkos-kernels/src/sparse/KokkosSparse_spgemm_handle.hpp
@@ -507,7 +507,7 @@ private:
    */
   void choose_default_algorithm(){
 #if defined( KOKKOS_ENABLE_SERIAL )
-    if (Kokkos::Impl::is_same< Kokkos::Serial , ExecutionSpace >::value){
+    if (std::is_same< Kokkos::Serial , ExecutionSpace >::value){
       this->algorithm_type = SPGEMM_SERIAL;
 #ifdef VERBOSE
       std::cout << "Serial Execution Space, Default Algorithm: SPGEMM_SERIAL" << std::endl;
@@ -516,7 +516,7 @@ private:
 #endif
 
 #if defined( KOKKOS_ENABLE_THREADS )
-    if (Kokkos::Impl::is_same< Kokkos::Threads , ExecutionSpace >::value){
+    if (std::is_same< Kokkos::Threads , ExecutionSpace >::value){
       this->algorithm_type = SPGEMM_SERIAL;
 #ifdef VERBOSE
       std::cout << "THREADS Execution Space, Default Algorithm: SPGEMM_SERIAL" << std::endl;
@@ -525,7 +525,7 @@ private:
 #endif
 
 #if defined( KOKKOS_ENABLE_OPENMP )
-    if (Kokkos::Impl::is_same< Kokkos::OpenMP, ExecutionSpace >::value){
+    if (std::is_same< Kokkos::OpenMP, ExecutionSpace >::value){
       this->algorithm_type = SPGEMM_SERIAL;
 #ifdef VERBOSE
       std::cout << "OpenMP Execution Space, Default Algorithm: SPGEMM_SERIAL" << std::endl;
@@ -534,7 +534,7 @@ private:
 #endif
 
 #if defined( KOKKOS_ENABLE_CUDA )
-    if (Kokkos::Impl::is_same<Kokkos::Cuda, ExecutionSpace >::value){
+    if (std::is_same<Kokkos::Cuda, ExecutionSpace >::value){
       this->algorithm_type = SPGEMM_CUSPARSE;
 #ifdef VERBOSE
       std::cout << "Cuda Execution Space, Default Algorithm: SPGEMM_CUSPARSE" << std::endl;
@@ -543,7 +543,7 @@ private:
 #endif
 
 #if defined( KOKKOS_ENABLE_QTHREAD)
-    if (Kokkos::Impl::is_same< Kokkos::Qthread, ExecutionSpace >::value){
+    if (std::is_same< Kokkos::Qthread, ExecutionSpace >::value){
       this->algorithm_type = SPGEMM_SERIAL;
 #ifdef VERBOSE
       std::cout << "Qthread Execution Space, Default Algorithm: SPGEMM_SERIAL" << std::endl;
@@ -609,7 +609,7 @@ private:
     }
 
 #if defined( KOKKOS_ENABLE_SERIAL )
-    if (Kokkos::Impl::is_same< Kokkos::Serial , ExecutionSpace >::value){
+    if (std::is_same< Kokkos::Serial , ExecutionSpace >::value){
       suggested_vector_size_ = this->suggested_vector_size = 1;
       suggested_team_size_ = this->suggested_team_size = max_allowed_team_size;
       return;
@@ -617,7 +617,7 @@ private:
 #endif
 
 #if defined( KOKKOS_ENABLE_THREADS )
-    if (Kokkos::Impl::is_same< Kokkos::Threads , ExecutionSpace >::value){
+    if (std::is_same< Kokkos::Threads , ExecutionSpace >::value){
       suggested_vector_size_ = this->suggested_vector_size = 1;
       suggested_team_size_ = this->suggested_team_size = max_allowed_team_size;
       return;
@@ -625,14 +625,14 @@ private:
 #endif
 
 #if defined( KOKKOS_ENABLE_OPENMP )
-    if (Kokkos::Impl::is_same< Kokkos::OpenMP, ExecutionSpace >::value){
+    if (std::is_same< Kokkos::OpenMP, ExecutionSpace >::value){
       suggested_vector_size_ = this->suggested_vector_size = 1;
       suggested_team_size_ = this->suggested_team_size = max_allowed_team_size;
     }
 #endif
 
 #if defined( KOKKOS_ENABLE_CUDA )
-    if (Kokkos::Impl::is_same<Kokkos::Cuda, ExecutionSpace >::value){
+    if (std::is_same<Kokkos::Cuda, ExecutionSpace >::value){
 
       this->suggested_vector_size = nnz / double (nr) + 0.5;
 
@@ -658,7 +658,7 @@ private:
 #endif
 
 #if defined( KOKKOS_ENABLE_QTHREAD)
-    if (Kokkos::Impl::is_same< Kokkos::Qthread, ExecutionSpace >::value){
+    if (std::is_same< Kokkos::Qthread, ExecutionSpace >::value){
       suggested_vector_size_ = this->suggested_vector_size = 1;
       suggested_team_size_ = this->suggested_team_size = max_allowed_team_size;
     }

--- a/packages/kokkos-kernels/src/sparse/KokkosSparse_trsv.hpp
+++ b/packages/kokkos-kernels/src/sparse/KokkosSparse_trsv.hpp
@@ -94,7 +94,7 @@ trsv (const char uplo[],
                  "KokkosBlas::trsv: The ranks of b and x do not match.");
   static_assert (BMV::rank == 1 || BMV::rank == 2,
                  "KokkosBlas::trsv: b and x must both either have rank 1, or rank 2.");
-  static_assert (Kokkos::Impl::is_same<typename XMV::value_type,
+  static_assert (std::is_same<typename XMV::value_type,
                  typename XMV::non_const_value_type>::value,
                  "KokkosBlas::trsv: The output x must be nonconst.");
 

--- a/packages/kokkos-kernels/src/sparse/impl/KokkosSparse_gauss_seidel_impl.hpp
+++ b/packages/kokkos-kernels/src/sparse/impl/KokkosSparse_gauss_seidel_impl.hpp
@@ -738,7 +738,7 @@ namespace KokkosSparse{
 
 
 #if defined( KOKKOS_ENABLE_CUDA )
-        if (Kokkos::Impl::is_same<Kokkos::Cuda, MyExecSpace >::value){
+        if (std::is_same<Kokkos::Cuda, MyExecSpace >::value){
           for (nnz_lno_t i = 0; i < numColors; ++i){
             nnz_lno_t color_index_begin = h_color_xadj(i);
             nnz_lno_t color_index_end = h_color_xadj(i + 1);

--- a/packages/kokkos-kernels/src/sparse/impl/KokkosSparse_spgemm_CUSP_impl.hpp
+++ b/packages/kokkos-kernels/src/sparse/impl/KokkosSparse_spgemm_CUSP_impl.hpp
@@ -104,15 +104,15 @@ void CUSP_apply(
   typedef typename ain_nonzero_index_view_type::device_type device2;
   typedef typename ain_nonzero_value_view_type::device_type device3;
 
-  if (Kokkos::Impl::is_same<Kokkos::Cuda, device1 >::value){
+  if (std::is_same<Kokkos::Cuda, device1 >::value){
     throw std::runtime_error ("MEMORY IS NOT ALLOCATED IN GPU DEVICE for CUSP\n");
     //return;
   }
-  if (Kokkos::Impl::is_same<Kokkos::Cuda, device2 >::value){
+  if (std::is_same<Kokkos::Cuda, device2 >::value){
     throw std::runtime_error ("MEMORY IS NOT ALLOCATED IN GPU DEVICE for CUSP\n");
     //return;
   }
-  if (Kokkos::Impl::is_same<Kokkos::Cuda, device3 >::value){
+  if (std::is_same<Kokkos::Cuda, device3 >::value){
     throw std::runtime_error ("MEMORY IS NOT ALLOCATED IN GPU DEVICE for CUSP\n");
     //return;
   }

--- a/packages/kokkos-kernels/src/sparse/impl/KokkosSparse_spgemm_cuSPARSE_impl.hpp
+++ b/packages/kokkos-kernels/src/sparse/impl/KokkosSparse_spgemm_cuSPARSE_impl.hpp
@@ -85,16 +85,16 @@ namespace Impl{
 
 
     //TODO this is not correct, check memory space.
-    if (Kokkos::Impl::is_same<Kokkos::Cuda, device1 >::value){
+    if (std::is_same<Kokkos::Cuda, device1 >::value){
       throw std::runtime_error ("MEMORY IS NOT ALLOCATED IN GPU DEVICE for CUSPARSE\n");
       //return;
     }
-    if (Kokkos::Impl::is_same<Kokkos::Cuda, device2 >::value){
+    if (std::is_same<Kokkos::Cuda, device2 >::value){
       throw std::runtime_error ("MEMORY IS NOT ALLOCATED IN GPU DEVICE for CUSPARSE\n");
       //return;
     }
 
-    if (Kokkos::Impl::is_same<idx, int>::value){
+    if (std::is_same<idx, int>::value){
 
       const idx *a_xadj = (int *)row_mapA.data();
       const idx *b_xadj = (int *)row_mapB.data();
@@ -197,22 +197,22 @@ namespace Impl{
     typedef typename ain_nonzero_value_view_type::device_type device3;
 
 
-    if (Kokkos::Impl::is_same<Kokkos::Cuda, device1 >::value){
+    if (std::is_same<Kokkos::Cuda, device1 >::value){
       throw std::runtime_error ("MEMORY IS NOT ALLOCATED IN GPU DEVICE for CUSPARSE\n");
       //return;
     }
-    if (Kokkos::Impl::is_same<Kokkos::Cuda, device2 >::value){
+    if (std::is_same<Kokkos::Cuda, device2 >::value){
       throw std::runtime_error ("MEMORY IS NOT ALLOCATED IN GPU DEVICE for CUSPARSE\n");
       //return;
     }
-    if (Kokkos::Impl::is_same<Kokkos::Cuda, device3 >::value){
+    if (std::is_same<Kokkos::Cuda, device3 >::value){
       throw std::runtime_error ("MEMORY IS NOT ALLOCATED IN GPU DEVICE for CUSPARSE\n");
       //return;
     }
 
 
 
-    if (Kokkos::Impl::is_same<idx, int>::value){
+    if (std::is_same<idx, int>::value){
       int *a_xadj = (int *)row_mapA.data();
       int *b_xadj = (int *)row_mapB.data();
       int *c_xadj = (int *)row_mapC.data();
@@ -231,7 +231,7 @@ namespace Impl{
       value_type *b_ew = (value_type *)valuesB.data();
       value_type *c_ew = (value_type *)valuesC.data();
 
-      if (Kokkos::Impl::is_same<value_type, float>::value){
+      if (std::is_same<value_type, float>::value){
         cusparseScsrgemm(
             h->handle,
             h->transA,
@@ -254,7 +254,7 @@ namespace Impl{
             c_xadj,
             c_adj);
       }
-      else if (Kokkos::Impl::is_same<value_type, double>::value){
+      else if (std::is_same<value_type, double>::value){
         cusparseDcsrgemm(
             h->handle,
             h->transA,

--- a/packages/kokkos-kernels/src/sparse/impl/KokkosSparse_spgemm_mkl2phase_impl.hpp
+++ b/packages/kokkos-kernels/src/sparse/impl/KokkosSparse_spgemm_mkl2phase_impl.hpp
@@ -91,7 +91,7 @@ void mkl2phase_symbolic(
 
   typedef typename KernelHandle::HandleExecSpace MyExecSpace;
 
-  if (Kokkos::Impl::is_same<idx, int>::value){
+  if (std::is_same<idx, int>::value){
 
     int_persistent_work_view_t a_xadj_v, b_xadj_v;
 
@@ -324,7 +324,7 @@ void mkl2phase_symbolic(
 
     typedef typename KernelHandle::HandleExecSpace MyExecSpace;
 
-    if (Kokkos::Impl::is_same<idx, int>::value){
+    if (std::is_same<idx, int>::value){
 
       int *a_xadj = (int *)row_mapA.data();
       int *b_xadj = (int *)row_mapB.data();
@@ -377,7 +377,7 @@ void mkl2phase_symbolic(
 */
       Kokkos::Impl::Timer timer1;
 
-      if (Kokkos::Impl::is_same<value_type, float>::value){
+      if (std::is_same<value_type, float>::value){
 
         mkl_scsrmultcsr(&trans, &request, &sort, &mklm, &mkln, &mklk,
                       (float *)a_ew, a_adj, a_xadj,
@@ -387,7 +387,7 @@ void mkl2phase_symbolic(
                       );
         mkl_free_buffers();
       }
-      else if (Kokkos::Impl::is_same<value_type, double>::value){
+      else if (std::is_same<value_type, double>::value){
 
         mkl_dcsrmultcsr(&trans, &request, &sort, &mklm, &mkln, &mklk,
                       (double *)a_ew, a_adj, a_xadj,
@@ -426,45 +426,45 @@ void mkl2phase_symbolic(
       sparse_matrix_t C;
 
       if (handle->mkl_convert_to_1base) { // a*, b* already converted to 1base above...
-        if (Kokkos::Impl::is_same<value_type, double>::value){
+        if (std::is_same<value_type, double>::value){
           if (SPARSE_STATUS_SUCCESS != mkl_sparse_d_create_csr (&A, SPARSE_INDEX_BASE_ONE, mklm, mkln, a_xadj, a_xadj + 1, a_adj, reinterpret_cast<double*>(a_ew))){
             throw std::runtime_error ("CANNOT CREATE mkl_sparse_s_create_csr A matrix\n");
           }
         }
-        else if (Kokkos::Impl::is_same<value_type, float>::value){
+        else if (std::is_same<value_type, float>::value){
           if (SPARSE_STATUS_SUCCESS != mkl_sparse_s_create_csr (&A, SPARSE_INDEX_BASE_ONE, mklm, mkln, a_xadj, a_xadj + 1, a_adj, reinterpret_cast<float*>(a_ew))){
             throw std::runtime_error ("CANNOT CREATE mkl_sparse_s_create_csr A matrix\n");
           }
         }
     
-        if (Kokkos::Impl::is_same<value_type, double>::value){
+        if (std::is_same<value_type, double>::value){
           if (SPARSE_STATUS_SUCCESS != mkl_sparse_d_create_csr (&B, SPARSE_INDEX_BASE_ONE, n, k, b_xadj, b_xadj + 1, b_adj, reinterpret_cast<double*>(b_ew))){
             throw std::runtime_error ("CANNOT CREATE mkl_sparse_s_create_csr B matrix\n");
           }
         }
-        else if (Kokkos::Impl::is_same<value_type, float>::value){
+        else if (std::is_same<value_type, float>::value){
           if (SPARSE_STATUS_SUCCESS != mkl_sparse_s_create_csr (&B, SPARSE_INDEX_BASE_ONE, n, k, b_xadj, b_xadj + 1, b_adj, reinterpret_cast<float*>(b_ew))){
             throw std::runtime_error ("CANNOT CREATE mkl_sparse_s_create_csr B matrix\n");
           }
         }
       } else {
-        if (Kokkos::Impl::is_same<value_type, double>::value){
+        if (std::is_same<value_type, double>::value){
           if (SPARSE_STATUS_SUCCESS != mkl_sparse_d_create_csr (&A, SPARSE_INDEX_BASE_ZERO, mklm, mkln, a_xadj, a_xadj + 1, a_adj, reinterpret_cast<double*>(a_ew))){
             throw std::runtime_error ("CANNOT CREATE mkl_sparse_s_create_csr A matrix\n");
           }
         }
-        else if (Kokkos::Impl::is_same<value_type, float>::value){
+        else if (std::is_same<value_type, float>::value){
           if (SPARSE_STATUS_SUCCESS != mkl_sparse_s_create_csr (&A, SPARSE_INDEX_BASE_ZERO, mklm, mkln, a_xadj, a_xadj + 1, a_adj, reinterpret_cast<float*>(a_ew))){
             throw std::runtime_error ("CANNOT CREATE mkl_sparse_s_create_csr A matrix\n");
           }
         }
     
-        if (Kokkos::Impl::is_same<value_type, double>::value){
+        if (std::is_same<value_type, double>::value){
           if (SPARSE_STATUS_SUCCESS != mkl_sparse_d_create_csr (&B, SPARSE_INDEX_BASE_ZERO, n, k, b_xadj, b_xadj + 1, b_adj, reinterpret_cast<double*>(b_ew))){
             throw std::runtime_error ("CANNOT CREATE mkl_sparse_s_create_csr B matrix\n");
           }
         }
-        else if (Kokkos::Impl::is_same<value_type, float>::value){
+        else if (std::is_same<value_type, float>::value){
           if (SPARSE_STATUS_SUCCESS != mkl_sparse_s_create_csr (&B, SPARSE_INDEX_BASE_ZERO, n, k, b_xadj, b_xadj + 1, b_adj, reinterpret_cast<float*>(b_ew))){
             throw std::runtime_error ("CANNOT CREATE mkl_sparse_s_create_csr B matrix\n");
           }

--- a/packages/kokkos-kernels/src/sparse/impl/KokkosSparse_spgemm_mkl_impl.hpp
+++ b/packages/kokkos-kernels/src/sparse/impl/KokkosSparse_spgemm_mkl_impl.hpp
@@ -109,13 +109,13 @@ void mkl_symbolic(
     return;
   }
 */
-  if (Kokkos::Impl::is_same<idx, int>::value){
+  if (std::is_same<idx, int>::value){
 
     int *a_xadj = NULL;
     int *b_xadj = NULL;
     int_temp_work_view_t a_xadj_v, b_xadj_v;
 
-    if (Kokkos::Impl::is_same<size_type, int>::value){
+    if (std::is_same<size_type, int>::value){
 
       a_xadj = (int *)row_mapA.data();
       b_xadj = (int *)row_mapB.data();
@@ -167,7 +167,7 @@ void mkl_symbolic(
     sparse_matrix_t B;
     sparse_matrix_t C;
 
-    if (Kokkos::Impl::is_same<value_type, float>::value){
+    if (std::is_same<value_type, float>::value){
 
 
 
@@ -248,7 +248,7 @@ void mkl_symbolic(
         return;
       }
     }
-    else if (Kokkos::Impl::is_same<value_type, double>::value){
+    else if (std::is_same<value_type, double>::value){
 
       /*
       std::cout << "create a" << std::endl;
@@ -421,13 +421,13 @@ void mkl_symbolic(
       return;
     }
 */
-    if (Kokkos::Impl::is_same<idx, int>::value){
+    if (std::is_same<idx, int>::value){
 
       int *a_xadj = NULL;
       int *b_xadj = NULL;
       int_temp_work_view_t a_xadj_v, b_xadj_v;
 
-      if (Kokkos::Impl::is_same<size_type, int>::value){
+      if (std::is_same<size_type, int>::value){
 
         a_xadj = (int *)row_mapA.data();
         b_xadj = (int *)row_mapB.data();
@@ -477,7 +477,7 @@ void mkl_symbolic(
       sparse_matrix_t B;
       sparse_matrix_t C;
 
-      if (Kokkos::Impl::is_same<value_type, float>::value){
+      if (std::is_same<value_type, float>::value){
 
 
 
@@ -558,7 +558,7 @@ void mkl_symbolic(
           return;
         }
       }
-      else if (Kokkos::Impl::is_same<value_type, double>::value){
+      else if (std::is_same<value_type, double>::value){
 
         /*
         std::cout << "create a" << std::endl;

--- a/packages/kokkos-kernels/src/sparse/impl/KokkosSparse_spgemm_viennaCL_impl.hpp
+++ b/packages/kokkos-kernels/src/sparse/impl/KokkosSparse_spgemm_viennaCL_impl.hpp
@@ -109,9 +109,9 @@ namespace Impl{
     typedef typename viennacl::compressed_matrix<value_type>::handle_type it;
     typedef typename viennacl::compressed_matrix<value_type>::value_type vt;
 
-    if ((Kokkos::Impl::is_same<idx, int>::value && Kokkos::Impl::is_same<typename KernelHandle::size_type, int>::value )||
-        (Kokkos::Impl::is_same<idx, unsigned int>::value && Kokkos::Impl::is_same<typename KernelHandle::size_type, unsigned int>::value ) ||
-        (Kokkos::Impl::is_same<idx, it>::value && Kokkos::Impl::is_same<typename KernelHandle::size_type, it>::value )
+    if ((std::is_same<idx, int>::value && std::is_same<typename KernelHandle::size_type, int>::value )||
+        (std::is_same<idx, unsigned int>::value && std::is_same<typename KernelHandle::size_type, unsigned int>::value ) ||
+        (std::is_same<idx, it>::value && std::is_same<typename KernelHandle::size_type, it>::value )
         ){
 
       unsigned int * a_xadj = (unsigned int *)row_mapA.data();


### PR DESCRIPTION
## Motivation
Trilinos kokkoskernels is not compiled because Kokkos::Impl::is_same gone. I am not sure how this is missing from 3.0 promotion testing.

## Testing
I found this problem on kokkos-dev-2 and confirms that this fixes the problem. A matching PR to kokkoskernels will be submitted soon.
