### PR TITLE
Tpetra:  Adding more Distributor timers

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Distributor.cpp
+++ b/packages/tpetra/core/src/Tpetra_Distributor.cpp
@@ -121,25 +121,64 @@ namespace Tpetra {
 
 #ifdef TPETRA_DISTRIBUTOR_TIMERS
   void Distributor::makeTimers () {
-    const std::string name_doPosts3 = "Tpetra::Distributor: doPosts(3)";
-    const std::string name_doPosts4 = "Tpetra::Distributor: doPosts(4)";
-    const std::string name_doWaits = "Tpetra::Distributor: doWaits";
-    const std::string name_doPosts3_recvs = "Tpetra::Distributor: doPosts(3): recvs";
-    const std::string name_doPosts4_recvs = "Tpetra::Distributor: doPosts(4): recvs";
-    const std::string name_doPosts3_barrier = "Tpetra::Distributor: doPosts(3): barrier";
-    const std::string name_doPosts4_barrier = "Tpetra::Distributor: doPosts(4): barrier";
-    const std::string name_doPosts3_sends = "Tpetra::Distributor: doPosts(3): sends";
-    const std::string name_doPosts4_sends = "Tpetra::Distributor: doPosts(4): sends";
+    timer_doWaits_ = Teuchos::TimeMonitor::getNewTimer (
+                           "Tpetra::Distributor: doWaits");
 
-    timer_doPosts3_ = Teuchos::TimeMonitor::getNewTimer (name_doPosts3);
-    timer_doPosts4_ = Teuchos::TimeMonitor::getNewTimer (name_doPosts4);
-    timer_doWaits_ = Teuchos::TimeMonitor::getNewTimer (name_doWaits);
-    timer_doPosts3_recvs_ = Teuchos::TimeMonitor::getNewTimer (name_doPosts3_recvs);
-    timer_doPosts4_recvs_ = Teuchos::TimeMonitor::getNewTimer (name_doPosts4_recvs);
-    timer_doPosts3_barrier_ = Teuchos::TimeMonitor::getNewTimer (name_doPosts3_barrier);
-    timer_doPosts4_barrier_ = Teuchos::TimeMonitor::getNewTimer (name_doPosts4_barrier);
-    timer_doPosts3_sends_ = Teuchos::TimeMonitor::getNewTimer (name_doPosts3_sends);
-    timer_doPosts4_sends_ = Teuchos::TimeMonitor::getNewTimer (name_doPosts4_sends);
+    timer_doPosts3TA_ = Teuchos::TimeMonitor::getNewTimer (
+                           "Tpetra::Distributor: doPosts(3) TA");
+    timer_doPosts4TA_ = Teuchos::TimeMonitor::getNewTimer (
+                           "Tpetra::Distributor: doPosts(4) TA");
+
+    timer_doPosts3TA_recvs_ = Teuchos::TimeMonitor::getNewTimer (
+                           "Tpetra::Distributor: doPosts(3): recvs TA");
+    timer_doPosts4TA_recvs_ = Teuchos::TimeMonitor::getNewTimer (
+                           "Tpetra::Distributor: doPosts(4): recvs TA");
+
+    timer_doPosts3TA_barrier_ = Teuchos::TimeMonitor::getNewTimer (
+                           "Tpetra::Distributor: doPosts(3): barrier TA");
+    timer_doPosts4TA_barrier_ = Teuchos::TimeMonitor::getNewTimer (
+                           "Tpetra::Distributor: doPosts(4): barrier TA");
+
+    timer_doPosts3TA_sends_ = Teuchos::TimeMonitor::getNewTimer (
+                           "Tpetra::Distributor: doPosts(3): sends TA");
+    timer_doPosts4TA_sends_ = Teuchos::TimeMonitor::getNewTimer (
+                           "Tpetra::Distributor: doPosts(4): sends TA");
+    timer_doPosts3TA_sends_slow_ = Teuchos::TimeMonitor::getNewTimer (
+                           "Tpetra::Distributor: doPosts(3): sends TA SLOW");
+    timer_doPosts4TA_sends_slow_ = Teuchos::TimeMonitor::getNewTimer (
+                           "Tpetra::Distributor: doPosts(4): sends TA SLOW");
+    timer_doPosts3TA_sends_fast_ = Teuchos::TimeMonitor::getNewTimer (
+                           "Tpetra::Distributor: doPosts(3): sends TA FAST");
+    timer_doPosts4TA_sends_fast_ = Teuchos::TimeMonitor::getNewTimer (
+                           "Tpetra::Distributor: doPosts(4): sends TA FAST");
+
+    timer_doPosts3KV_ = Teuchos::TimeMonitor::getNewTimer (
+                           "Tpetra::Distributor: doPosts(3) KV");
+    timer_doPosts4KV_ = Teuchos::TimeMonitor::getNewTimer (
+                           "Tpetra::Distributor: doPosts(4) KV");
+
+    timer_doPosts3KV_recvs_ = Teuchos::TimeMonitor::getNewTimer (
+                           "Tpetra::Distributor: doPosts(3): recvs KV");
+    timer_doPosts4KV_recvs_ = Teuchos::TimeMonitor::getNewTimer (
+                           "Tpetra::Distributor: doPosts(4): recvs KV");
+
+    timer_doPosts3KV_barrier_ = Teuchos::TimeMonitor::getNewTimer (
+                           "Tpetra::Distributor: doPosts(3): barrier KV");
+    timer_doPosts4KV_barrier_ = Teuchos::TimeMonitor::getNewTimer (
+                           "Tpetra::Distributor: doPosts(4): barrier KV");
+
+    timer_doPosts3KV_sends_ = Teuchos::TimeMonitor::getNewTimer (
+                           "Tpetra::Distributor: doPosts(3): sends KV");
+    timer_doPosts4KV_sends_ = Teuchos::TimeMonitor::getNewTimer (
+                           "Tpetra::Distributor: doPosts(4): sends KV");
+    timer_doPosts3KV_sends_slow_ = Teuchos::TimeMonitor::getNewTimer (
+                           "Tpetra::Distributor: doPosts(3): sends KV SLOW");
+    timer_doPosts4KV_sends_slow_ = Teuchos::TimeMonitor::getNewTimer (
+                           "Tpetra::Distributor: doPosts(4): sends KV SLOW");
+    timer_doPosts3KV_sends_fast_ = Teuchos::TimeMonitor::getNewTimer (
+                           "Tpetra::Distributor: doPosts(3): sends KV FAST");
+    timer_doPosts4KV_sends_fast_ = Teuchos::TimeMonitor::getNewTimer (
+                           "Tpetra::Distributor: doPosts(4): sends KV FAST");
   }
 #endif // TPETRA_DISTRIBUTOR_TIMERS
 

--- a/packages/tpetra/core/test/Distributor/Distributor_UnitTests.cpp
+++ b/packages/tpetra/core/test/Distributor/Distributor_UnitTests.cpp
@@ -173,6 +173,10 @@ namespace {
     int globalSuccess_int = -1;
     reduceAll( *comm, REDUCE_SUM, success ? 0 : 1, outArg(globalSuccess_int) );
     TEST_EQUALITY_CONST( globalSuccess_int, 0 );
+#ifdef TPETRA_DISTRIBUTOR_TIMERS
+    Teuchos::TimeMonitor::summarize(std::cout);
+    Teuchos::TimeMonitor::zeroOutTimers();
+#endif
   }
 
   TEUCHOS_UNIT_TEST( Distributor, badArgsFromSends)
@@ -210,6 +214,10 @@ namespace {
     int globalSuccess_int = -1;
     reduceAll( *comm, REDUCE_SUM, success ? 0 : 1, outArg(globalSuccess_int) );
     TEST_EQUALITY_CONST( globalSuccess_int, 0 );
+#ifdef TPETRA_DISTRIBUTOR_TIMERS
+    Teuchos::TimeMonitor::summarize(std::cout);
+    Teuchos::TimeMonitor::zeroOutTimers();
+#endif
   }
 
   ////
@@ -305,6 +313,10 @@ namespace {
     int globalSuccess_int = -1;
     reduceAll( *comm, REDUCE_SUM, success ? 0 : 1, outArg(globalSuccess_int) );
     TEST_EQUALITY_CONST( globalSuccess_int, 0 );
+#ifdef TPETRA_DISTRIBUTOR_TIMERS
+    Teuchos::TimeMonitor::summarize(std::cout);
+    Teuchos::TimeMonitor::zeroOutTimers();
+#endif
   }
 
 
@@ -395,6 +407,10 @@ namespace {
     int globalSuccess_int = -1;
     reduceAll( *comm, REDUCE_SUM, success ? 0 : 1, outArg(globalSuccess_int) );
     TEST_EQUALITY_CONST( globalSuccess_int, 0 );
+#ifdef TPETRA_DISTRIBUTOR_TIMERS
+    Teuchos::TimeMonitor::summarize(std::cout);
+    Teuchos::TimeMonitor::zeroOutTimers();
+#endif
   }
 
 
@@ -477,6 +493,10 @@ namespace {
     int globalSuccess_int = -1;
     reduceAll( *comm, REDUCE_SUM, success ? 0 : 1, outArg(globalSuccess_int) );
     TEST_EQUALITY_CONST( globalSuccess_int, 0 );
+#ifdef TPETRA_DISTRIBUTOR_TIMERS
+    Teuchos::TimeMonitor::summarize(std::cout);
+    Teuchos::TimeMonitor::zeroOutTimers();
+#endif
   }
 
 
@@ -564,6 +584,10 @@ namespace {
     int globalSuccess_int = -1;
     reduceAll( *comm, REDUCE_SUM, success ? 0 : 1, outArg(globalSuccess_int) );
     TEST_EQUALITY_CONST( globalSuccess_int, 0 );
+#ifdef TPETRA_DISTRIBUTOR_TIMERS
+    Teuchos::TimeMonitor::summarize(std::cout);
+    Teuchos::TimeMonitor::zeroOutTimers();
+#endif
   }
 
 
@@ -650,6 +674,10 @@ namespace {
     int globalSuccess_int = -1;
     reduceAll( *comm, REDUCE_SUM, success ? 0 : 1, outArg(globalSuccess_int) );
     TEST_EQUALITY_CONST( globalSuccess_int, 0 );
+#ifdef TPETRA_DISTRIBUTOR_TIMERS
+    Teuchos::TimeMonitor::summarize(std::cout);
+    Teuchos::TimeMonitor::zeroOutTimers();
+#endif
   }
 
 
@@ -760,6 +788,10 @@ namespace {
     int globalSuccess_int = -1;
     reduceAll( *comm, REDUCE_SUM, success ? 0 : 1, outArg(globalSuccess_int) );
     TEST_EQUALITY_CONST( globalSuccess_int, 0 );
+#ifdef TPETRA_DISTRIBUTOR_TIMERS
+    Teuchos::TimeMonitor::summarize(std::cout);
+    Teuchos::TimeMonitor::zeroOutTimers();
+#endif
   }
 
 
@@ -862,6 +894,10 @@ namespace {
     int globalSuccess_int = -1;
     reduceAll( *comm, REDUCE_SUM, success ? 0 : 1, outArg(globalSuccess_int) );
     TEST_EQUALITY_CONST( globalSuccess_int, 0 );
+#ifdef TPETRA_DISTRIBUTOR_TIMERS
+    Teuchos::TimeMonitor::summarize(std::cout);
+    Teuchos::TimeMonitor::zeroOutTimers();
+#endif
   }
 
   TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( Distributor, badArgsFromRecvs, Ordinal )
@@ -911,6 +947,10 @@ namespace {
     int globalSuccess_int = -1;
     reduceAll( *comm, REDUCE_SUM, success ? 0 : 1, outArg(globalSuccess_int) );
     TEST_EQUALITY_CONST( globalSuccess_int, 0 );
+#ifdef TPETRA_DISTRIBUTOR_TIMERS
+    Teuchos::TimeMonitor::summarize(std::cout);
+    Teuchos::TimeMonitor::zeroOutTimers();
+#endif
   }
 
   TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL( Distributor, createFromRecvs, Ordinal )
@@ -953,6 +993,10 @@ namespace {
     int globalSuccess_int = -1;
     reduceAll( *comm, REDUCE_SUM, success ? 0 : 1, outArg(globalSuccess_int) );
     TEST_EQUALITY_CONST( globalSuccess_int, 0 );
+#ifdef TPETRA_DISTRIBUTOR_TIMERS
+    Teuchos::TimeMonitor::summarize(std::cout);
+    Teuchos::TimeMonitor::zeroOutTimers();
+#endif
   }
 
 


### PR DESCRIPTION
@trilinos/tpetra 

## Motivation
@csiefer2  was interested in having more timers in Distributor to determine whether applications were spending time in the so-called "slow" path (in which data to be sent must be reordered and buffered) or the so-called "fast" path (in which data to be sent are already ordered by destination processor, avoiding buffering).  

This PR provides those additional timers.  It also separates timers for interface calls using Teuchos::Arrays from those using Kokkos::Views.  

To activate the timers, one must define TPETRA_DISTRIBUTOR_TIMERS in Tpetra_Distributor.hpp (sufficient definition is in comments in the file) or add -DTPETRA_DISTRIBUTOR_TIMERS to CXX_FLAGS.

See #6977 and issues referenced there for more info on Distributor.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->



<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
@csiefer2  are these the timers you can use?

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
cee-lan with and without TPETRA_DISTRIBUTOR_TIMERS ifdef.
I used the Distributor_UnitTests, but these tests, admittedly, don't spend much time in doPosts.  
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->