### PR TITLE
ATDM: sems-rhel7: Default define SEMS modules (#6986)

### DIFF
--- a/cmake/std/atdm/README.md
+++ b/cmake/std/atdm/README.md
@@ -890,6 +890,18 @@ the env var:
 $ export ATDM_CONFIG_LM_LICENSE_FILE_OVERRIDE=<some-url>
 ```
 
+NOTE: If the SEMS modules are not already defined in the current shell
+(i.e. the environment variable `SEMS_MODULEFILES_ROOT` is empty), then the
+`atdm/load-env.sh` script for this 'sems-rhel7' system will attempt to define
+the SEMS modules by running:
+
+```
+$ module use /projects/sems/modulefiles/projects
+$ export SEMS_MODULEFILES_ROOT=/projects/sems/modulefiles
+```
+
+if that directory exists.
+
 
 ### Spack RHEL Environment
 

--- a/cmake/std/atdm/sems-rhel7/environment.sh
+++ b/cmake/std/atdm/sems-rhel7/environment.sh
@@ -101,6 +101,17 @@ fi
 export ATDM_CONFIG_BUILD_COUNT=$ATDM_CONFIG_MAX_NUM_CORES_TO_USE
 # NOTE: Use as many build processes and there are cores by default.
 
+if [[ "${SEMS_MODULEFILES_ROOT}" == "" ]] ; then
+  if [[ -d /projects/sems/modulefiles ]] ; then
+    echo "NOTE: SEMS modules not defined, loading their definition!"
+    module use /projects/sems/modulefiles/projects
+    export SEMS_MODULEFILES_ROOT=/projects/sems/modulefiles
+  else
+    echo "ERROR: The SEMS modules are not defined and default location does not exist!"
+    return
+  fi
+fi
+
 module purge
 module load sems-env
 module load sems-git/2.10.1


### PR DESCRIPTION
CC: @jmgate 

This should hopefully fix a problem with one of the 'ascic' machines that
EMPIRE is trying to run jenkins jobs on where the SEMS modules are not being
defined (see #6986).

## How was this tested?

ToDo: @jmgate to test this branch on 'ascic' machine where the current problem is occurring?
