### PR TITLE
Panzer: more changes for periodic wedge support

### DIFF
--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_PeriodicBC_MatchConditions.hpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_PeriodicBC_MatchConditions.hpp
@@ -274,25 +274,33 @@ class WedgeMatcher {
   /// Set to true if a 3D problem, set to false if 2D
   bool is_three_d_;
 public:
-  enum class MirrorPlane {
-     XZ_PLANE,
-     YZ_PLANE
+  enum class MirrorPlane : int {
+     XZ_PLANE=0,
+     YZ_PLANE=1
   };
-  WedgeMatcher(int index0) : error_(1e-8),index0_(index0),is_three_d_(true) {}
-  WedgeMatcher(int index0,double error) : error_(error),index0_(index0),is_three_d_(true) {}
-  WedgeMatcher(int index0,const std::vector<std::string> & params )
-    : error_(1e-8),index0_(index0),is_three_d_(true)
+  WedgeMatcher(MirrorPlane mp,const std::vector<std::string> & params )
+    : error_(1e-8),index0_(0),is_three_d_(true)
   {
-    for (const auto& p : params)
-      if (p == "2D")
+    if (mp == MirrorPlane::XZ_PLANE)
+      index0_ = 1;
+    else // YZ_PLANE
+      index0_ = 0;
+
+    TEUCHOS_TEST_FOR_EXCEPTION(params.size() > 2,std::logic_error,"WedgeMatcher can only have one or two option parameters (tolerance and dimension)!");
+
+    // read in string, get double
+    if (params.size() > 0)
+      error_ = std::stod(params[0]);
+
+    if (params.size() > 1) {
+      if (params[1] == "2D")
         is_three_d_ = false;
-  }
-  WedgeMatcher(int index0,double error,const std::vector<std::string> & params )
-    : error_(error),index0_(index0),is_three_d_(true)
-  {
-    for (const auto& p : params)
-      if (p == "2D")
-        is_three_d_ = false;
+      else if (params[1] == "3D")
+        is_three_d_ = true;
+      else {
+        TEUCHOS_TEST_FOR_EXCEPTION(true,std::runtime_error,"ERROR: WedgeMatcher::parsParams() - the second params must be iether \"2D\" or \"3D\", param=" << params[1] << "\n");
+      }
+    }
   }
   WedgeMatcher(const WedgeMatcher & cm) = default;
 

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_PeriodicBC_Parser.cpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_PeriodicBC_Parser.cpp
@@ -62,7 +62,7 @@ PeriodicBC_Parser::getMatchers() const
 
 void PeriodicBC_Parser::setParameterList(const Teuchos::RCP<Teuchos::ParameterList> & pl)
 {
-   if(not pl->isParameter(countStr_)) {
+   if(!pl->isParameter(countStr_)) {
       bool validEntry = false;
       TEUCHOS_TEST_FOR_EXCEPTION_PURE_MSG(
         !validEntry, Teuchos::Exceptions::InvalidParameterName,
@@ -372,32 +372,32 @@ PeriodicBC_Parser::buildMatcher(const std::string & buildStr) const
    }
 
    if(s_matcher=="wx-coord") {
-     panzer_stk::WedgeMatcher matcher(1,params);
+     panzer_stk::WedgeMatcher matcher(WedgeMatcher::MirrorPlane::XZ_PLANE,params);
      return panzer_stk::buildPeriodicBC_Matcher(bndry1,bndry2,matcher);
    }
 
    if(s_matcher=="wy-coord") {
-     panzer_stk::WedgeMatcher matcher(0,params);
+     panzer_stk::WedgeMatcher matcher(WedgeMatcher::MirrorPlane::YZ_PLANE,params);
      return panzer_stk::buildPeriodicBC_Matcher(bndry1,bndry2,matcher);
    }
 
    if(s_matcher=="wx-edge") {
-     panzer_stk::WedgeMatcher matcher(1,params);
+     panzer_stk::WedgeMatcher matcher(WedgeMatcher::MirrorPlane::XZ_PLANE,params);
      return panzer_stk::buildPeriodicBC_Matcher(bndry1,bndry2,matcher,"edge");
    }
 
    if(s_matcher=="wy-edge") {
-     panzer_stk::WedgeMatcher matcher(0,params);
+     panzer_stk::WedgeMatcher matcher(WedgeMatcher::MirrorPlane::YZ_PLANE,params);
      return panzer_stk::buildPeriodicBC_Matcher(bndry1,bndry2,matcher,"edge");
    }
 
    if(s_matcher=="wx-face") {
-     panzer_stk::WedgeMatcher matcher(1,params);
+     panzer_stk::WedgeMatcher matcher(WedgeMatcher::MirrorPlane::XZ_PLANE,params);
      return panzer_stk::buildPeriodicBC_Matcher(bndry1,bndry2,matcher,"face");
    }
 
    if(s_matcher=="wy-face") {
-     panzer_stk::WedgeMatcher matcher(0,params);
+     panzer_stk::WedgeMatcher matcher(WedgeMatcher::MirrorPlane::YZ_PLANE,params);
      return panzer_stk::buildPeriodicBC_Matcher(bndry1,bndry2,matcher,"face");
    }
 

--- a/packages/panzer/adapters-stk/test/periodic_bcs/periodic_bcs.cpp
+++ b/packages/panzer/adapters-stk/test/periodic_bcs/periodic_bcs.cpp
@@ -1733,22 +1733,24 @@ namespace panzer {
     // Wedge in 2D
     RCP<WedgeMatcher> wm;
     std::vector<std::string> params;
+    params.push_back("1.0e-8");
     params.push_back("2D");
-    wm = rcp(new WedgeMatcher(1,params));
+    wm = rcp(new WedgeMatcher(WedgeMatcher::MirrorPlane::XZ_PLANE,params));
     TEST_ASSERT(wm->getMirrorPlane() == WedgeMatcher::MirrorPlane::XZ_PLANE);
     TEST_ASSERT(!wm->isThreeD());
     TEST_EQUALITY(wm->getIndex(),1);
-    wm = rcp(new WedgeMatcher(0,params));
+    wm = rcp(new WedgeMatcher(WedgeMatcher::MirrorPlane::YZ_PLANE,params));
     TEST_ASSERT(wm->getMirrorPlane() == WedgeMatcher::MirrorPlane::YZ_PLANE);
     TEST_ASSERT(!wm->isThreeD());
     TEST_EQUALITY(wm->getIndex(),0);
 
     // Wedge in 3D
-    wm = rcp(new WedgeMatcher(1));
+    params[1] = "3D";
+    wm = rcp(new WedgeMatcher(WedgeMatcher::MirrorPlane::XZ_PLANE,params));
     TEST_ASSERT(wm->getMirrorPlane() == WedgeMatcher::MirrorPlane::XZ_PLANE);
     TEST_ASSERT(wm->isThreeD());
     TEST_EQUALITY(wm->getIndex(),1);
-    wm = rcp(new WedgeMatcher(0));
+    wm = rcp(new WedgeMatcher(WedgeMatcher::MirrorPlane::YZ_PLANE,params));
     TEST_ASSERT(wm->getMirrorPlane() == WedgeMatcher::MirrorPlane::YZ_PLANE);
     TEST_ASSERT(wm->isThreeD());
     TEST_EQUALITY(wm->getIndex(),0);


### PR DESCRIPTION

@trilinos/panzer 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
clean up the construction of the coordinate matcher for periodic wedge

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
This allows empire to run a new set of periodic problems. Documented in empire issue 662.

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
periodic_bc.exe test in panzer covers the new ctors.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->