### PR TITLE
WIP: Thrya: Fix some unreachable code with debug builds

### DIFF
--- a/packages/thyra/core/src/interfaces/nonlinear/model_evaluator/fundamental/Thyra_ModelEvaluatorBase_decl.hpp
+++ b/packages/thyra/core/src/interfaces/nonlinear/model_evaluator/fundamental/Thyra_ModelEvaluatorBase_decl.hpp
@@ -1408,12 +1408,13 @@ std::string Thyra::toString(ModelEvaluatorBase::EInArgsMembers arg)
       return "IN_ARG_step_size";
     case ModelEvaluatorBase::IN_ARG_stage_number:
       return "IN_ARG_stage_number";
-#ifdef TEUCHOS_DEBUG
     default:
+#ifdef TEUCHOS_DEBUG
       TEUCHOS_TEST_FOR_EXCEPT(true);
+#else
+      return ""; // Will never be executed!
 #endif
   }
-  return ""; // Will never be executed!
 }
 
 
@@ -1435,12 +1436,13 @@ std::string Thyra::toString(ModelEvaluatorBase::EOutArgsMembers arg)
       return "OUT_ARG_W_prec";
     case ModelEvaluatorBase::OUT_ARG_f_poly:
       return "OUT_ARG_f_poly";
-#ifdef TEUCHOS_DEBUG
     default:
+#ifdef TEUCHOS_DEBUG
       TEUCHOS_TEST_FOR_EXCEPT(true);
+#else
+      return ""; // Will never be executed!
 #endif
   }
-  return ""; // Will never be executed!
 }
 
 
@@ -1454,12 +1456,13 @@ std::string Thyra::toString(
       return "DERIV_MV_BY_COL";
     case ModelEvaluatorBase::DERIV_TRANS_MV_BY_ROW:
       return "DERIV_TRANS_MV_BY_ROW";
-#ifdef TEUCHOS_DEBUG
     default:
+#ifdef TEUCHOS_DEBUG
       TEUCHOS_TEST_FOR_EXCEPT(true);
+#else
+      return ""; // Should never execute this!
 #endif
   }
-  return ""; // Should never execute this!
 }
 
 
@@ -1474,12 +1477,13 @@ Thyra::getOtherDerivativeMultiVectorOrientation(
       return ModelEvaluatorBase::DERIV_TRANS_MV_BY_ROW;
     case ModelEvaluatorBase::DERIV_TRANS_MV_BY_ROW:
       return ModelEvaluatorBase::DERIV_MV_BY_COL;
-#ifdef TEUCHOS_DEBUG
     default:
+#ifdef TEUCHOS_DEBUG
       TEUCHOS_TEST_FOR_EXCEPT(true);
+#else
+      return ModelEvaluatorBase::DERIV_MV_BY_COL; // Should never execute this!
 #endif
   }
-  return ModelEvaluatorBase::DERIV_MV_BY_COL; // Should never execute this!
 }
 
 

--- a/packages/thyra/core/src/support/nonlinear/model_evaluator/client_support/Thyra_ModelEvaluatorDefaultBase.hpp
+++ b/packages/thyra/core/src/support/nonlinear/model_evaluator/client_support/Thyra_ModelEvaluatorDefaultBase.hpp
@@ -1035,12 +1035,13 @@ ModelEvaluatorDefaultBase<Scalar>::createDefaultLinearOp(
       return nonconstAdjoint<Scalar>(
         rcp_implicit_cast<LOB>(createMembers(var_space, fnc_space->dim()))
         );
-#ifdef TEUCHOS_DEBUG
     default:
+#ifdef TEUCHOS_DEBUG
       TEUCHOS_TEST_FOR_EXCEPT(true);
+#else
+      return Teuchos::null; // Will never be called!
 #endif
   }
-  return Teuchos::null; // Will never be called!
 }
 
 
@@ -1095,14 +1096,13 @@ ModelEvaluatorDefaultBase<Scalar>::getOutArgImplForDefaultLinearOpSupport(
         MEB::DERIV_TRANS_MV_BY_ROW
         );
     }
-#ifdef TEUCHOS_DEBUG
     default:
+#ifdef TEUCHOS_DEBUG
       TEUCHOS_TEST_FOR_EXCEPT(true);
+#else
+      return ModelEvaluatorBase::Derivative<Scalar>(); // Should never get here!
 #endif
   }
-
-  return ModelEvaluatorBase::Derivative<Scalar>(); // Should never get here!
-
 }
 
 


### PR DESCRIPTION
## Next Action Status

These warnings are generated in a SPARC build against Trilinos using cuda+gnu on the CEE ASCIC GPU machines.  Next: Wait to add support for CUDA builds on the CEE ASCIC GPU machines as pat of the 'cee-rhel6' ATDM Trilinos configuration (see [ATDV-272](https://sems-atlassian-srn.sandia.gov/browse/ATDV-272)) and then reproduce and find a better patch to silence warnings without impacting code maintenance ...

## Description

Made by SPARC developers to silence warnings impacting SPARC builds.  The change was to change switch statement functions like:

```
inline
std::string Thyra::toString(ModelEvaluatorBase::EInArgsMembers arg)
{
  switch(arg) {
    case ModelEvaluatorBase::IN_ARG_x_dot_dot:
      return "IN_ARG_x_dot_dot";
    <...>
    case ModelEvaluatorBase::IN_ARG_stage_number:
      return "IN_ARG_stage_number";
#ifdef TEUCHOS_DEBUG
    default:
      TEUCHOS_TEST_FOR_EXCEPT(true);
#else
  }
  return ""; // Will never be executed!
}
```

and replaces them with:

```
inline
std::string Thyra::toString(ModelEvaluatorBase::EInArgsMembers arg)
{
  switch(arg) {
    case ModelEvaluatorBase::IN_ARG_x_dot_dot:
      return "IN_ARG_x_dot_dot";
    <...>
    case ModelEvaluatorBase::IN_ARG_stage_number:
      return "IN_ARG_stage_number";
    default:
#ifdef TEUCHOS_DEBUG
      TEUCHOS_TEST_FOR_EXCEPT(true);
#else
      return ""; // Will never be executed!
#endif
  }
}
```

The problem with the latter is that the compiler will no longer issue a waning if all of the cases are not covered because of that `default` clause.  That makes the code much more fragile to  continued maintenance as it will silence these compiler warnings.  But in a debug-mode build, we want to have a `default` clause that throws to avoid undefined behavior.

@micahahoward, what specific compile and build does this trigger warnings for?  It would be good to know that so we can find a solution that does not add a `default` block in the non-debug-mode build.

## Steps to Reproduce

Waiting for to add CUDA support for ATDM Trilinos 'cee-rhel6' configuration ...