### PR TITLE
PuLP interface in Zoltan2 bug fixes:

### DIFF
--- a/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgPuLP.hpp
+++ b/packages/zoltan2/src/algorithms/partition/Zoltan2_AlgPuLP.hpp
@@ -413,7 +413,8 @@ void AlgPuLP<Adapter>::partition(
 
   pulp_graph_t g = {num_verts, num_edges, 
                     out_edges, out_offsets,
-                    vertex_weights, edge_weights, vertex_weights_sum};
+                    vertex_weights.get(), edge_weights.get(), 
+                    vertex_weights_sum};
 
 #else
   // Create XtraPuLP's graph structure

--- a/packages/zoltan2/test/unit/environment/AllParameters.cpp
+++ b/packages/zoltan2/test/unit/environment/AllParameters.cpp
@@ -68,7 +68,7 @@ static string fnParams[NUMFN][3]={
 
 // Value is a particular string
 #ifdef HAVE_ZOLTAN2_PULP
-#define NUMSTR 37
+#define NUMSTR 38
 #else
 #define NUMSTR 35
 #endif


### PR DESCRIPTION
@trilinos/Zoltan2

## Motivation
Addressing compilation bugs within shared-memory PuLP interface in Zoltan2.

1.) Fixed pointer bug when initializing pulp graph datatype.

2.) Updated number of parameter strings for testing compilation.

## Testing
Testing validated as PASSED by Zoltan2 Test Driver. Tested with PuLP-0.2 and XtraPuLP-0.3.
