### PR TITLE
Remove CTEST_NIGHTLY_START_TIME is it does nothing with git

### DIFF
--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -1,8 +1,5 @@
 INCLUDE(SetDefaultAndFromEnv)
 
-# Must match what is in CDash project 'Trilinos'
-SET(CTEST_NIGHTLY_START_TIME "04:00:00 UTC") # 10 PM MDT or 9 PM MST
-
 # Set actual CTest/CDash settings
 
 IF (NOT DEFINED CTEST_DROP_METHOD)


### PR DESCRIPTION
As explained in the documentation:

  https://cmake.org/cmake/help/v3.13/manual/ctest.1.html?highlight=nightlystarttime#ctest-update-step

the CTest setting `NighltyStartTime` (global var `CTEST_NIGHTLY_START_TIME`) only
determines how central VCS like CVS and SVN checkout the code.  It does
nothing for DVCS like git.  Therefore, it is better to just take this out.
