### PR TITLE
Revert "Remove CTEST_NIGHTLY_START_TIME is it does nothing with git"

### DIFF
--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -1,5 +1,13 @@
 INCLUDE(SetDefaultAndFromEnv)
 
+SET(CTEST_NIGHTLY_START_TIME "04:00:00 UTC")
+# NOTE: Above only is used by centralized VCS like CVS and SVN and does
+# nothing for git and other Distributed VCS.  However, it needs to be set here
+# to get around a defect in ctest_start() when passing in the APPEND argument
+# which is used in ctest -S scripts to run tests on a different node from
+# where the build is done (like in many of the ATDM Trilinos builds). For
+# details, see https://gitlab.kitware.com/cmake/cmake/issues/20471.
+
 # Set actual CTest/CDash settings
 
 IF (NOT DEFINED CTEST_DROP_METHOD)


### PR DESCRIPTION
This reverts commit 62e97b0d717fb60bd1c79d6aaeff21a039b7fc98.

See the detailed comment in the file CTestConfig.cmake for details and:

* https://gitlab.kitware.com/cmake/cmake/issues/20471


