### PR TITLE
Disable ShyLU_NodeTacho in all ATDM Trilinos builds (CDOFA-110)

### DIFF
--- a/cmake/std/atdm/ATDMDisables.cmake
+++ b/cmake/std/atdm/ATDMDisables.cmake
@@ -40,6 +40,7 @@ SET(ATDM_SE_PACKAGE_DISABLES
   STKDoc_tests
   STKExp
   Moertel
+  ShyLU_NodeTacho
   ShyLU_DD
   ShyLU
   Stokhos


### PR DESCRIPTION
Turns out that SPARC does not actually use ShyLU_NodeTacho.  It was only being
enabled indirectly by Amesos2.  In fact, the native SPARC Trilinos configure
scripts explicitly disable ShyLU_NodeTacho.  Also, EMPIRE is not using any
part of ShyLU so I think this is safe to disable for EMPIRE too.  And GEMMA
does not use any part of ShyLU and does not use Amesos2.

Therefore, we can safely disable this subpackage.  Less code to build, test,
and maintain.  Win, win, win.

For more context and proof for this, see [CDOFA-110](https://sems-atlassian-srn.sandia.gov/browse/CDOFA-110).

## How was this tested?

I tested this with SPARC on the CEE RHEL6 machine 'ceerws1113':

```
$ time env \
    SPARC_TRIL_MAKE_OPTIONS="-j 8" \
    SPARC_TRIL_CTEST_ARGS="-j 4 -L test_regression" \
    SPARC_TRIL_SKIP_NATIVE_BUILD=1 \
  ./sparc-tril-dev-scripts/run_builds_and_tests.sh \
    cee-rhel6_clang-5.0.1_openmpi-4.0.2_serial_static_opt

***
*** ./sparc-tril-dev-scripts/run_builds_and_tests.sh cee-rhel6_clang-5.0.1_openmpi-4.0.2_serial_static_opt
***

Thu Mar 19 19:35:43 MDT 2020

Running the builds:
  cee-rhel6_clang-5.0.1_openmpi-4.0.2_serial_static_opt

./sparc-tril-dev-scripts/build_and_test_atdm_trilinos_and_sparc.sh \
   cee-rhel6_clang-5.0.1_openmpi-4.0.2_serial_static_opt "-j 8" ""

   See log: cee-rhel6_clang-5.0.1_openmpi-4.0.2_serial_static_opt.build_and_test_atdm_trilinos_and_sparc.out


real    48m36.509s
user    333m27.460s
sys     14m11.131s

    Trilinos_DIR=/scratch/rabartl/SPARC.base/sparc/Trilinos/cee-rhel6_clang-5.0.1_openmpi-4.0.2_serial_static_opt/lib/cmake/Trilinos

100% tests passed, 0 tests failed out of 270

Thu Mar 19 20:24:19 MDT 2020

real    48m36.528s
user    333m27.465s
sys     14m11.139s
```

That gave the Trilinos enables:

```
$ grep -B 1 -A 1 "Final set of enabled.*packages" Trilinos/cee-rhel6_clang-5.0.1_openmpi-4.0.2_serial_static_opt_build/configure.out 

Final set of enabled packages:  Gtest Kokkos Teuchos KokkosKernels RTOp Sacado Epetra Zoltan Shards Triutils EpetraExt Tpetra TrilinosSS Thyra Xpetra AztecOO Galeri Amesos Pamgen Zoltan2 Ifpack ML Belos ShyLU_Node Amesos2 SEACAS Anasazi Ifpack2 Stratimikos Teko Intrepid Intrepid2 STK NOX MueLu Tempus ROL 37

Final set of enabled SE packages:  Gtest KokkosCore KokkosContainers KokkosAlgorithms Kokkos TeuchosCore TeuchosParser TeuchosParameterList TeuchosComm TeuchosNumerics TeuchosRemainder TeuchosKokkosCompat TeuchosKokkosComm Teuchos KokkosKernels RTOp Sacado Epetra Zoltan Shards Triutils EpetraExt TpetraClassic TpetraTSQR TpetraCore Tpetra TrilinosSS ThyraCore ThyraEpetraAdapters ThyraEpetraExtAdapters ThyraTpetraAdapters Thyra Xpetra AztecOO Galeri Amesos Pamgen Zoltan2 Ifpack ML Belos ShyLU_NodeHTS ShyLU_Node Amesos2 SEACASExodus SEACASExodus_for SEACASExoIIv2for32 SEACASNemesis SEACASIoss SEACASChaco SEACASAprepro_lib SEACASSupes SEACASSuplib SEACASSuplibC SEACASSuplibCpp SEACASAlgebra SEACASAprepro SEACASConjoin SEACASEjoin SEACASEpu SEACASExodiff SEACASExomatlab SEACASExotxt SEACASExo_format SEACASEx1ex2v2 SEACASGjoin SEACASGen3D SEACASGenshell SEACASGrepos SEACASExplore SEACASMapvarlib SEACASMapvar SEACASMapvar-kd SEACASNemslice SEACASNemspread SEACASNumbers SEACASTxtexo SEACASEx2ex1v2 SEACAS Anasazi Ifpack2 Stratimikos Teko Intrepid Intrepid2 STKMath STKUtil STKTopology STKMesh STKIO STKNGP_TEST STKUnit_test_utils STKSearch STKTransfer STK NOX MueLu Tempus ROL 99
```

Note the ShyLU SE package enables:

```
Final set of enabled SE packages:  ... ShyLU_NodeHTS ShyLU_Node ... 99
```

That now matches the ShyLU enables for the native SPARC Trilinos configuration:

* https://cee-gitlab.sandia.gov/sparc/Trilinos/merge_requests/4

I also tested the ATDM Trilinos configuration on CEE RHEL6 machine 'ceerws1113' with:

```
$ ./ctest-s-local-test-driver-cee-rhel6.sh cee-rhel6_clang-5.0.1_openmpi-4.0.2_serial_static_opt
```

I will post the results here once I get those.

