### PR TITLE
ATDM: ats2: Promote to 'ATDM' group (ATDV-311)

### DIFF
--- a/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-2019.06.24_static_dbg.sh
+++ b/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-2019.06.24_static_dbg.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=Specialized
+  export Trilinos_TRACK=ATDM
 fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ats2/local-driver.sh

--- a/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-2019.06.24_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-2019.06.24_static_opt.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=Experimental
+  export Trilinos_TRACK=ATDM
 fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ats2/local-driver.sh

--- a/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-gnu-7.3.1-spmpi-2019.06.24_serial_static_dbg.sh
+++ b/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-gnu-7.3.1-spmpi-2019.06.24_serial_static_dbg.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=Specialized
+  export Trilinos_TRACK=ATDM
 fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ats2/local-driver.sh


### PR DESCRIPTION
All of the failures have been triaged and there are no failures not also
occurring on other systems.  The 'opt' builds are currently 100% clean.

See [ATDV-311](https://sems-atlassian-srn.sandia.gov/browse/ATDV-311)
