### PR TITLE
Stokhos: maintain ER build

### DIFF
--- a/cmake/std/PullRequestLinuxGCC4.8.4TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxGCC4.8.4TestingSettings.cmake
@@ -22,6 +22,9 @@ set(Tpetra_INST_SERIAL ON CACHE BOOL "Set by default for PR testing")
 # Disable just one Teko sub-unit test that fails with openmpi 1.10 (#2712)
 set (Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D ON CACHE BOOL "Temporarily disabled in PR testing")
 
+# Enable the ensemble reduction in this build to maintain Stokhos with ensemble reduction (#7067)
+set (Stokhos_ENABLE_Ensemble_Reduction ON CACHE BOOL "Enable reduction across ensemble components")
+
 # Disable three ShyLu_DD tests - see #2691
 set (ShyLU_DDFROSch_test_frosch_laplacian_epetra_2d_gdsw_MPI_4_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
 set (ShyLU_DDFROSch_test_frosch_laplacian_epetra_2d_rgdsw_MPI_4_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")

--- a/packages/stokhos/src/sacado/kokkos/vector/Teuchos_LAPACK_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/Teuchos_LAPACK_MP_Vector.hpp
@@ -267,11 +267,11 @@ namespace Teuchos {
       { throw_error("GESV"); }
 
     //! Computes row and column scalings intended to equilibrate an \c m by \c n matrix \c A and reduce its condition number.
-    void GEEQU(const OrdinalType m, const OrdinalType n, const ScalarType* A, const OrdinalType lda, ScalarType* R, ScalarType* C, ScalarType* rowcond, ScalarType* colcond, ScalarType* amax, OrdinalType* info) const
+    void GEEQU(const OrdinalType m, const OrdinalType n, const ScalarType* A, const OrdinalType lda, MagnitudeType* R, MagnitudeType* C, MagnitudeType* rowcond, MagnitudeType* colcond, MagnitudeType* amax, OrdinalType* info) const
       { throw_error("GEEQU"); }
 
     //! Improves the computed solution to a system of linear equations and provides error bounds and backward error estimates for the solution.  Use after GETRF/GETRS.
-    void GERFS(const char TRANS, const OrdinalType n, const OrdinalType nrhs, const ScalarType* A, const OrdinalType lda, const ScalarType* AF, const OrdinalType ldaf, const OrdinalType* IPIV, const ScalarType* B, const OrdinalType ldb, ScalarType* X, const OrdinalType ldx, ScalarType* FERR, ScalarType* BERR, ScalarType* WORK, OrdinalType* IWORK, OrdinalType* info) const
+    void GERFS(const char TRANS, const OrdinalType n, const OrdinalType nrhs, const ScalarType* A, const OrdinalType lda, const ScalarType* AF, const OrdinalType ldaf, const OrdinalType* IPIV, const ScalarType* B, const OrdinalType ldb, ScalarType* X, const OrdinalType ldx, MagnitudeType* FERR, MagnitudeType* BERR, ScalarType* WORK, OrdinalType* IWORK, OrdinalType* info) const
       { throw_error("GERFS"); }
 
     //! Computes row and column scalings intended to equilibrate an \c m by \c n banded matrix \c A and reduce its condition number.


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/stokhos

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
This PR addresses the issue #7067.

The changes to the file `packages/stokhos/src/sacado/kokkos/vector/Teuchos_LAPACK_MP_Vector.hpp` address the compilation errors listed in the issue.

The change to the `cmake/std/PullRequestLinuxGCC4.8.4TestingSettings.cmake` has the purpose of testing the ensemble reduction in at least one PR build to maintain the Ensemble reduction in future release. 

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
These changes have been tested both with and without ensemble reduction.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->