### PR TITLE
Fix CUDA_LAUNCH_BLOCKING for Tpetra parallel tests on white

### DIFF
--- a/packages/tpetra/core/ext/TpetraExt_TripleMatrixMultiply_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_TripleMatrixMultiply_def.hpp
@@ -492,7 +492,6 @@ namespace Tpetra {
       // Run through all the hash table lookups once and for all
       lo_view_t targetMapToOrigRow(Kokkos::ViewAllocateWithoutInitializing("targetMapToOrigRow"),Aview.colMap->getNodeNumElements());
       lo_view_t targetMapToImportRow(Kokkos::ViewAllocateWithoutInitializing("targetMapToImportRow"),Aview.colMap->getNodeNumElements());
-      Kokkos::fence();
       Kokkos::parallel_for("Tpetra::mult_R_A_P_newmatrix::construct_tables",range_type(Aview.colMap->getMinLocalIndex(), Aview.colMap->getMaxLocalIndex()+1),KOKKOS_LAMBDA(const LO i) {
           GO aidx = Acolmap_local.getGlobalElement(i);
           LO P_LID = Prowmap_local.getLocalElement(aidx);
@@ -505,6 +504,7 @@ namespace Tpetra {
             targetMapToImportRow(i) = I_LID;
           }
         });
+      Kokkos::fence();
 
       // Call the actual kernel.  We'll rely on partial template specialization to call the correct one ---
       // Either the straight-up Tpetra code (SerialNode) or the KokkosKernels one (other NGP node types)
@@ -606,6 +606,7 @@ namespace Tpetra {
 
           }
         });
+      Kokkos::fence();
 
       // Call the actual kernel.  We'll rely on partial template specialization to call the correct one ---
       // Either the straight-up Tpetra code (SerialNode) or the KokkosKernels one (other NGP node types)
@@ -771,6 +772,7 @@ namespace Tpetra {
             targetMapToImportRow(i) = I_LID;
           }
         });
+      Kokkos::fence();
 
       // Call the actual kernel.  We'll rely on partial template specialization to call the correct one ---
       // Either the straight-up Tpetra code (SerialNode) or the KokkosKernels one (other NGP node types)
@@ -870,6 +872,7 @@ namespace Tpetra {
 
           }
         });
+      Kokkos::fence();
 
       // Call the actual kernel.  We'll rely on partial template specialization to call the correct one ---
       // Either the straight-up Tpetra code (SerialNode) or the KokkosKernels one (other NGP node types)

--- a/packages/tpetra/core/src/Tpetra_Map_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Map_def.hpp
@@ -1645,6 +1645,7 @@ namespace Tpetra {
         Kokkos::RangePolicy<LO, typename DT::execution_space>
           range (static_cast<LO> (0), static_cast<LO> (lgMap.size ()));
         Kokkos::parallel_for (range, *this);
+        Kokkos::fence();
       }
 
       KOKKOS_INLINE_FUNCTION void operator () (const LO& lid) const {

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -3921,6 +3921,7 @@ namespace Tpetra {
       ProfilingRegion regionGemm ("Tpetra::MV::multiply-call-gemm");
       KokkosBlas::gemm (&ctransA, &ctransB, alpha_IST, A_sub, B_sub,
                         beta_local, C_sub);
+      Kokkos::fence();
     }
 
     if (! isConstantStride ()) {

--- a/packages/tpetra/core/src/Tpetra_idot.hpp
+++ b/packages/tpetra/core/src/Tpetra_idot.hpp
@@ -233,6 +233,7 @@ lclDotRaw (typename ::Tpetra::MultiVector<SC, LO, GO, NT>::dot_type* const resul
         }
         auto result_j = subview (result, j);
         KokkosBlas::dot (result_j, X_j_1d, Y_j_1d);
+        Kokkos::fence();
       }
     } // for each column j of X and Y
   }
@@ -286,6 +287,7 @@ lclDotRaw (typename ::Tpetra::MultiVector<SC, LO, GO, NT>::dot_type* const resul
         auto Y_lcl_1d = subview (Y_lcl, rowRange, 0);
         auto result_0d = subview (result, 0);
         KokkosBlas::dot (result_0d, X_lcl_1d, Y_lcl_1d);
+        Kokkos::fence();
       }
       else {
         auto X_lcl_2d = subview (X_lcl, rowRange,
@@ -293,6 +295,7 @@ lclDotRaw (typename ::Tpetra::MultiVector<SC, LO, GO, NT>::dot_type* const resul
         auto Y_lcl_2d = subview (Y_lcl, rowRange,
                                  pair_type (0, Y_numVecs));
         KokkosBlas::dot (result, X_lcl_2d, Y_lcl_2d);
+        Kokkos::fence();
       }
     } // host or device?
   } // multivector with nonconstant stride?

--- a/packages/tpetra/core/src/kokkos_refactor/Tpetra_KokkosRefactor_Details_MultiVectorDistObjectKernels.hpp
+++ b/packages/tpetra/core/src/kokkos_refactor/Tpetra_KokkosRefactor_Details_MultiVectorDistObjectKernels.hpp
@@ -148,6 +148,7 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
         ("Tpetra::MultiVector pack one col",
          range_type (0, idx.size ()),
          PackArraySingleColumn (dst, src, idx, col));
+      Kokkos::fence();
     }
   };
 
@@ -230,6 +231,8 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
          range_type (0, idx.size ()),
          PackArraySingleColumnWithBoundsCheck (dst, src, idx, col),
          errorCount);
+      Kokkos::fence();
+
       if (errorCount != 0) {
         // Go back and find the out-of-bounds entries in the index
         // array.  Performance doesn't matter since we are already in


### PR DESCRIPTION
@mhoemmen @kddevin 

These changes are sufficient to get the Tpetra test suite passing on white with CUDA_LAUNCH_BLOCKING unset. (except for the trivial case of initialization tests which currently fail because they check CUDA_LAUNCH_BLOCKING).

White was down for a while so I started checking on a local machine running a GTX960 card. That revealed a few new issues which I will open as a separate PR to keep things organized.

For TpetraExt_TripleMatrixMultiply_def.hpp I added 4 fences, but also removed 1. I don't think we need the removed fence. If we do need it, then we may need it for all 4 spots in that file.

For KokkosBlas::dot and KokkosBlas::gemm fences, we likely need more fences for other KokkosBlas calls. This was discussed in [https://github.com/kokkos/kokkos-kernels/pull/660](url). Until the plan is resolved, I only changed those spots I specifically encountered as failures on white. 

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Resolve missing fences when CUDA_LAUNCH_BLOCKING is unset.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
These issues were discovered by running the Tpetra test suite on white with CUDA_LAUNCH_BLOCKING=0.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->