### PR TITLE
Tpetra: Adding environment variable to allow Teuchos::Timers in Tpetra::ProfilingRegion

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_Behavior.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Behavior.cpp
@@ -358,6 +358,29 @@ size_t Behavior::longRowMinNumEntries ()
     (value_, initialized_, envVarName, defaultValue);
 }
 
+bool Behavior::profilingRegionUseTeuchosTimers () 
+{
+  constexpr char envVarName[] = "TPETRA_USE_TEUCHOS_TIMERS";
+  constexpr bool defaultValue(false);
+
+  static bool value_ = defaultValue;
+  static bool initialized_ = false;
+  return idempotentlyGetEnvironmentVariableAsBool
+    (value_, initialized_, envVarName, defaultValue);
+}
+
+bool Behavior::profilingRegionUseKokkosProfiling () 
+{
+  constexpr char envVarName[] = "TPETRA_USE_KOKKOS_PROFILING";
+  constexpr bool defaultValue(false);
+
+  static bool value_ = defaultValue;
+  static bool initialized_ = false;
+  return idempotentlyGetEnvironmentVariableAsBool
+    (value_, initialized_, envVarName, defaultValue);
+}
+
+
 bool Behavior::debug (const char name[])
 {
   constexpr char envVarName[] = "TPETRA_DEBUG";

--- a/packages/tpetra/core/src/Tpetra_Details_Behavior.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Behavior.hpp
@@ -199,6 +199,21 @@ public:
   /// entries to treat it as "dense" relative to other rows, is a
   /// separate question.
   static size_t longRowMinNumEntries ();
+
+  /// \brief Use Teuchos::Timer in Tpetra::ProfilingRegion
+  ///
+  /// This is disabled by default.  You may control this at run time via the
+  /// <tt>TPETRA_USE_TEUCHOS_TIMERS</tt> environment variable.
+  static bool profilingRegionUseTeuchosTimers();
+
+  /// \brief Use Kokkos::Profiling in Tpetra::ProfilingRegion
+  ///
+  /// This is enabled by default if KOKKOS_ENABLE_PROFILING is defined.
+  /// You mau control this at run time via the <tt>TPETRA_USE_KOKKOS_PROFILING</tt>
+  /// environment variable.
+  static bool profilingRegionUseKokkosProfiling();
+
+
 };
 
 } // namespace Details

--- a/packages/tpetra/core/src/Tpetra_Details_Profiling.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Profiling.cpp
@@ -40,6 +40,7 @@
 // @HEADER
 
 #include "Tpetra_Details_Profiling.hpp"
+#include "Tpetra_Details_Behavior.hpp"
 // I don't like including everything, but currently (as of 19 Apr
 // 2017), Kokkos does not provide a public header file to get just the
 // Profiling hooks.  Users are just supposed to include
@@ -49,19 +50,21 @@
 namespace Tpetra {
 namespace Details {
 
-#if defined(KOKKOS_ENABLE_PROFILING)
 ProfilingRegion::ProfilingRegion (const char name[]) {
-  ::Kokkos::Profiling::pushRegion (name);
+#if defined(KOKKOS_ENABLE_PROFILING)  
+  if(Behavior::profilingRegionUseKokkosProfiling()) 
+    ::Kokkos::Profiling::pushRegion(name);
+#endif
+  if(Behavior::profilingRegionUseTeuchosTimers())
+    tm = Teuchos::rcp(new Teuchos::TimeMonitor(*Teuchos::TimeMonitor::getNewTimer(name)));
+  
 }
-#else // NOT (KOKKOS_ENABLE_PROFILING)
-ProfilingRegion::ProfilingRegion (const char /* name */ []) {
-}
-#endif // (KOKKOS_ENABLE_PROFILING)
 
 ProfilingRegion::~ProfilingRegion () {
 #if defined(KOKKOS_ENABLE_PROFILING)
-  ::Kokkos::Profiling::popRegion ();
-#endif // (KOKKOS_ENABLE_PROFILING)
+  if(Behavior::profilingRegionUseKokkosProfiling()) 
+    ::Kokkos::Profiling::popRegion();
+#endif 
 }
 
 } // namespace Details

--- a/packages/tpetra/core/src/Tpetra_Details_Profiling.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Profiling.hpp
@@ -47,6 +47,9 @@
 ///   for Kokkos Profiling.
 
 #include "TpetraCore_config.h"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_RCP.hpp"
+
 
 namespace Tpetra {
 namespace Details {
@@ -103,6 +106,10 @@ public:
   ProfilingRegion (const char name[]);
   //! Close region to profile.
   ~ProfilingRegion ();
+
+private:
+  Teuchos::RCP<Teuchos::TimeMonitor> tm;
+
 };
 
 } // namespace Details


### PR DESCRIPTION
Does what you expect as applied to the MueLu Driver; See #7072
Tests: RHEL6