### PR TITLE
Tpetra CUDA_LAUNCH_BLOCKING unset fixes

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Export_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Export_def.hpp
@@ -242,6 +242,9 @@ namespace Tpetra {
     const LO numSrcLids = static_cast<LO> (numSrcGids);
     LO numPermutes = 0;
     LO numExports = 0;
+
+    Kokkos::fence(); // target.getLocalElement will be UVM access
+
     for (LO srcLid = numSameGids; srcLid < numSrcLids; ++srcLid) {
       const GO curSrcGid = rawSrcGids[srcLid];
       // getLocalElement() returns LINVALID if the GID isn't in the
@@ -513,6 +516,9 @@ namespace Tpetra {
       typename decltype (this->TransferData_->remoteLIDs_)::t_host;
     host_remote_lids_type remoteLIDs
       (view_alloc_no_init ("remoteLIDs"), numRemoteIDs);
+
+    Kokkos::fence(); // tgtMap.getLocalElement will be UVM access
+
     for (LO j = 0; j < LO (numRemoteIDs); ++j) {
       remoteLIDs[j] = tgtMap.getLocalElement (remoteGIDs[j]);
     }

--- a/packages/tpetra/core/src/Tpetra_Import_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Import_def.hpp
@@ -356,6 +356,9 @@ namespace Tpetra {
         Array<LO>  newRemoteLIDs(indexIntoRemotePIDs-cnt);
         Array<int> newRemotePIDs(indexIntoRemotePIDs-cnt);
         cnt = 0;
+
+        Kokkos::fence(); // target->getLocalElement is UVM access
+
         for (size_type j = 0; j < indexIntoRemotePIDs; ++j)
           if(tRemotePIDs[j] != -1) {
             newRemoteGIDs[cnt] = tRemoteGIDs[j];
@@ -903,6 +906,9 @@ namespace Tpetra {
 
       typename decltype (this->TransferData_->exportLIDs_)::t_host
         exportLIDs (view_alloc_no_init ("exportLIDs"), numExportIDs);
+
+      Kokkos::fence(); // sourceMap->getLocalElement is UVm access
+
       for (size_type k = 0; k < numExportIDs; ++k) {
         exportLIDs[k] = sourceMap->getLocalElement (exportGIDs[k]);
       }
@@ -1004,6 +1010,9 @@ namespace Tpetra {
     const LO LINVALID = Teuchos::OrdinalTraits<LO>::invalid ();
     const LO numTgtLids = as<LO> (numTgtGids);
     LO numPermutes = 0;
+
+    Kokkos::fence(); // source.getLocalElement is UVM access
+
     for (LO tgtLid = numSameGids; tgtLid < numTgtLids; ++tgtLid) {
       const GO curTargetGid = rawTgtGids[tgtLid];
       // getLocalElement() returns LINVALID if the GID isn't in the
@@ -1292,6 +1301,9 @@ namespace Tpetra {
       typename decltype (this->TransferData_->exportLIDs_)::t_host
         exportLIDs (view_alloc_no_init ("exportLIDs"), numExportIDs);
       ArrayView<const GO> expGIDs = exportGIDs ();
+
+      Kokkos::fence(); // source.getLocalElement is UVM access
+
       for (size_type k = 0; k < numExportIDs; ++k) {
         exportLIDs[k] = source.getLocalElement (expGIDs[k]);
       }
@@ -1530,6 +1542,9 @@ namespace Tpetra {
     // Convert the permute GIDs to permute-from LIDs in the source Map.
     Array<LO> permuteToLIDsUnion(numPermuteIDsUnion);
     Array<LO> permuteFromLIDsUnion(numPermuteIDsUnion);
+
+    Kokkos::fence(); // srcMap->getLocalElement is UVM access
+
     for (size_type k = 0; k < numPermuteIDsUnion; ++k) {
       size_type idx = numSameIDsUnion + k;
       permuteToLIDsUnion[k] = static_cast<LO>(idx);
@@ -1823,6 +1838,9 @@ namespace Tpetra {
     if (debug) {
       badIndices = std::unique_ptr<std::vector<size_t>> (new std::vector<size_t>);
     }
+
+    Kokkos::fence(); // remoteTarget->getLocalElement is UVM access
+
     for (size_t i = 0; i < NumRemotes; ++i) {
       const LO oldLclInd = oldRemoteLIDs[i];
       if (oldLclInd == Teuchos::OrdinalTraits<LO>::invalid ()) {

--- a/packages/tpetra/core/src/Tpetra_transform_MultiVector.hpp
+++ b/packages/tpetra/core/src/Tpetra_transform_MultiVector.hpp
@@ -323,15 +323,6 @@ namespace Tpetra {
              range_type range (execSpace, 0, lclNumRows);
 
              Kokkos::parallel_for (kernelLabel, range, g);
-
-             // This fence is currently needed for the following specific situation:
-             // For transform Y to X:
-             //  Y.putScalar()    // acts on device
-             //  Y.sync_host()    // now need_sync_host() and need_sync_device() are false
-             //  transform (on device)
-             //  Y.sync_host()    // no modifications so no fence - this usually will be a fence
-             //  read Y           // crashes
-             Kokkos::fence();
            },
            readOnly (input).on (memSpace).at (execSpace),
            writeOnly (output).on (memSpace).at (execSpace));
@@ -367,7 +358,6 @@ namespace Tpetra {
             range_type range (execSpace, 0, lclNumRows);
 
             Kokkos::parallel_for (kernelLabel, range, g);
-            Kokkos::fence(); // see note in above transform_vec_notSameObject
           },
           readOnly (input).on (memSpace).at (execSpace),
           writeOnly (output).on (memSpace).at (execSpace));

--- a/packages/tpetra/core/src/Tpetra_transform_MultiVector.hpp
+++ b/packages/tpetra/core/src/Tpetra_transform_MultiVector.hpp
@@ -323,6 +323,15 @@ namespace Tpetra {
              range_type range (execSpace, 0, lclNumRows);
 
              Kokkos::parallel_for (kernelLabel, range, g);
+
+             // This fence is currently needed for the following specific situation:
+             // For transform Y to X:
+             //  Y.putScalar()    // acts on device
+             //  Y.sync_host()    // now need_sync_host() and need_sync_device() are false
+             //  transform (on device)
+             //  Y.sync_host()    // no modifications so no fence - this usually will be a fence
+             //  read Y           // crashes
+             Kokkos::fence();
            },
            readOnly (input).on (memSpace).at (execSpace),
            writeOnly (output).on (memSpace).at (execSpace));
@@ -358,6 +367,7 @@ namespace Tpetra {
             range_type range (execSpace, 0, lclNumRows);
 
             Kokkos::parallel_for (kernelLabel, range, g);
+            Kokkos::fence(); // see note in above transform_vec_notSameObject
           },
           readOnly (input).on (memSpace).at (execSpace),
           writeOnly (output).on (memSpace).at (execSpace));

--- a/packages/tpetra/core/test/Block/BlockCrsMatrix.cpp
+++ b/packages/tpetra/core/test/Block/BlockCrsMatrix.cpp
@@ -429,6 +429,8 @@ namespace {
       BV Y (* (graph.getRangeMap ()), blockSize);
       Y.putScalar (STS::zero ());
 
+      Y.sync_host(); // X and Y are same map and write to X_lcl(i) needs fence
+
       const map_type& meshDomainMap = * (graph.getDomainMap ());
       for (LO lclDomIdx = meshDomainMap.getMinLocalIndex ();
            lclDomIdx <= meshDomainMap.getMaxLocalIndex (); ++lclDomIdx) {
@@ -536,6 +538,8 @@ namespace {
       BMV X (* (graph.getDomainMap ()), blockSize, numVecs);
       BMV Y (* (graph.getRangeMap ()), blockSize, numVecs);
       Y.putScalar (STS::zero ());
+
+      Y.sync_host(); // X and Y are same map and write to X_lcl(i) needs fence
 
       const map_type& meshDomainMap = * (graph.getDomainMap ());
       for (LO lclDomIdx = meshDomainMap.getMinLocalIndex ();
@@ -647,6 +651,8 @@ namespace {
       BV X (* (graph.getDomainMap ()), blockSize);
       BV Y (* (graph.getRangeMap ()), blockSize);
       Y.putScalar (STS::zero ());
+
+      Y.sync_host(); // X and Y are same map and write to X_lcl(i) needs fence
 
       const map_type& meshDomainMap = * (graph.getDomainMap ());
       for (LO lclDomIdx = meshDomainMap.getMinLocalIndex ();
@@ -762,6 +768,8 @@ namespace {
       BMV X (* (graph.getDomainMap ()), blockSize, numVecs);
       BMV Y (* (graph.getRangeMap ()), blockSize, numVecs);
       Y.putScalar (STS::zero ());
+
+      Y.sync_host(); // X and Y are same map and write to X_lcl(i) needs fence
 
       const map_type& meshDomainMap = * (graph.getDomainMap ());
       for (LO lclDomIdx = meshDomainMap.getMinLocalIndex ();

--- a/packages/tpetra/core/test/MultiVector/WithLocalAccess.cpp
+++ b/packages/tpetra/core/test/MultiVector/WithLocalAccess.cpp
@@ -335,6 +335,7 @@ namespace { // (anonymous)
         KOKKOS_LAMBDA (const LO lclRow) {
           X_lcl_1d_wo(lclRow) = 42.0;
         });
+      Kokkos::fence();
     }
 
     {
@@ -360,6 +361,7 @@ namespace { // (anonymous)
           std::pair<double, double> p {3.0, 4.0};
           X_lcl_1d_wo(lclRow) = p.first * p.second;
         });
+      Kokkos::fence();
 
       // Just plain modify some entries, in some sequential order.
       // Just in case LO is unsigned, start at +1.


### PR DESCRIPTION
These are additional fixes identified on a machine with an Nvidia GTX960 card. These errors did not exhibit on white. So this PR extends #7069.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

Make Tpetra run with CUDA_LAUNCH_BLOCKING unset.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->
## Related Issues
#7069 

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

Tpetra tests - these CUDA_LAUNCH_BLOCKING issues were tracked down on a system with a GTX960 card.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->