### PR TITLE
ATDM: ats2: build on login node instead of compute node

### DIFF
--- a/cmake/ctest/drivers/atdm/ats2/local-driver-single-build.sh
+++ b/cmake/ctest/drivers/atdm/ats2/local-driver-single-build.sh
@@ -1,48 +1,40 @@
 #!/bin/bash
 #
-# This script is designed to run on the launch node using a single node
-# allocation.  This script is called by the ats2/local-drivers.sh script in a
-# bsub allocation as:
-#
-#  bsub -J <job-name> -W <timeout> -Is <this-dir>/local-driver-single-build.sh
-#
-# Therefore, this script runs on the launch node (not the login node or the
-# compute node).
-# 
-# This script matches the approach documented in the cmake/std/atdm/README.md
-# file in the "ATS-2" section where everything except the tests are run on the
-# compute node using 'lrun', and then the tests themselves are launched
-# directly from the launch node (since 'jsrun' can only be run from the launch
-# node, not the login node or the compute node).
+# This script is designed to run on the login node.  The start, update,
+# configure and build are done on the login node.  This is because it is just
+# not robust to try to run this on the compute node (see ATDV-324).  However,
+# ctest running the tests themselves must be run from the launch node
+# (allocated using bsub).  This is because you can only invoke jsrun from the
+# launch node, not the login or compute node!
 #
 
 set +x
 
-# Must get the same site name for both builds show they show up on same CDash build
-if [[ "${CTEST_TEST_TYPE}" == "Experimental" ]] ; then
-  export CTEST_SITE=$(atdm_ats2_get_allocated_compute_node_name)
-  # NOTE: Must only conditionally set this because if set in the env, will
-  # override the default value set in the file
-  # TrilinosCTestDriverCore.atdm.cmake!
+if [ "${LSF_CTEST_TEST_TIMEOUT}" == "" ] ; then
+  export LSF_CTEST_TEST_TIMEOUT=4:00
 fi
 
+# Must use same site name for build and test results so they match up on
+# CDash!
+export CTEST_SITE=${ATDM_CONFIG_CDASH_HOSTNAME}
+
 echo
+echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
 echo "***"
-echo "*** Running [start], [update], configure and build for job '${LSB_JOBNAME}'"
-echo "*** on the compute node"
+echo "*** Running [start], [update], configure and build on the login node"
 echo "***"
 echo
 
 set -x
 env \
   CTEST_DO_TEST=FALSE \
-  lrun -n 1 \
   $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ctest-s-driver.sh
 set +x
 
 echo
+echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
 echo "***"
-echo "*** Running tests for job '${LSB_JOBNAME}' from the launch node"
+echo "*** Running tests from the launch node"
 echo "***"
 echo
 
@@ -52,5 +44,6 @@ env \
   CTEST_DO_UPDATES=FALSE \
   CTEST_DO_CONFIGURE=FALSE \
   CTEST_DO_BUILD=FALSE \
-  $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ctest-s-driver.sh
+  bsub -J ${ATDM_CONFIG_BUILD_NAME} -W ${LSF_CTEST_TEST_TIMEOUT} -Is \
+    $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ctest-s-driver.sh
 set +x

--- a/cmake/ctest/drivers/atdm/ats2/local-driver.sh
+++ b/cmake/ctest/drivers/atdm/ats2/local-driver.sh
@@ -58,7 +58,7 @@ if [[ "${Trilinos_CTEST_RUN_CUDA_AWARE_MPI}" == "1" ]]; then
 fi
 
 # NOTE: We allow the configure and build to be performed again in the
-# follow-up CUDA-aware MPI build through they don't need to be.  This so that
+# follow-up CUDA-aware MPI build though they don't need to be.  This so that
 # developers that are looking on CDash will be able to see configure-related
 # information associated with that build.  We also need to run configure and
 # build again to make the cdash_analyze_and_report.py tool not report this

--- a/cmake/std/atdm/ats2/environment.sh
+++ b/cmake/std/atdm/ats2/environment.sh
@@ -59,7 +59,7 @@ echo "Using $ATDM_CONFIG_SYSTEM_NAME compiler stack $ATDM_CONFIG_COMPILER to bui
 # Some basic settings
 export ATDM_CONFIG_ENABLE_SPARC_SETTINGS=ON
 export ATDM_CONFIG_USE_NINJA=ON
-export ATDM_CONFIG_BUILD_COUNT=32 # Assume building on a compute node!
+export ATDM_CONFIG_BUILD_COUNT=8 # Assume building on the shared login node!
 
 # Set ctest -j parallel level for non-CUDA builds
 if [ "$ATDM_CONFIG_NODE_TYPE" == "OPENMP" ] ; then


### PR DESCRIPTION
See commit messages, comments in files and [ATDV-234](https://sems-atlassian-srn.sandia.gov/browse/ATDV-324) for details.

## How was this tested?

This was first reviewed and tested internally in:

* https://cee-gitlab.sandia.gov/atdm/Trilinos/merge_requests/3

See details there.

