### PR TITLE
KokkosKernels/Tpetra stack: local CRS device types

### DIFF
--- a/packages/kokkos-kernels/src/sparse/KokkosSparse_CrsMatrix.hpp
+++ b/packages/kokkos-kernels/src/sparse/KokkosSparse_CrsMatrix.hpp
@@ -407,14 +407,14 @@ public:
   typedef CrsMatrix<ScalarType, OrdinalType, host_mirror_space, MemoryTraits> HostMirror;
 #ifdef KOKKOS_ENABLE_DEPRECATED_CODE
   //! Type of the graph structure of the sparse matrix.
-  typedef Kokkos::StaticCrsGraph<ordinal_type, Kokkos::LayoutLeft, execution_space, size_type, memory_traits> StaticCrsGraphType;
+  typedef Kokkos::StaticCrsGraph<ordinal_type, Kokkos::LayoutLeft, device_type, size_type, memory_traits> StaticCrsGraphType;
   //! Type of the graph structure of the sparse matrix - consistent with Kokkos.
-  typedef Kokkos::StaticCrsGraph<ordinal_type, Kokkos::LayoutLeft, execution_space, size_type, memory_traits> staticcrsgraph_type;
+  typedef Kokkos::StaticCrsGraph<ordinal_type, Kokkos::LayoutLeft, device_type, size_type, memory_traits> staticcrsgraph_type;
 #else
   //! Type of the graph structure of the sparse matrix.
-  typedef Kokkos::StaticCrsGraph<ordinal_type, Kokkos::LayoutLeft, execution_space, memory_traits, size_type> StaticCrsGraphType;
+  typedef Kokkos::StaticCrsGraph<ordinal_type, Kokkos::LayoutLeft, device_type, memory_traits, size_type> StaticCrsGraphType;
   //! Type of the graph structure of the sparse matrix - consistent with Kokkos.
-  typedef Kokkos::StaticCrsGraph<ordinal_type, Kokkos::LayoutLeft, execution_space, memory_traits, size_type> staticcrsgraph_type;
+  typedef Kokkos::StaticCrsGraph<ordinal_type, Kokkos::LayoutLeft, device_type, memory_traits, size_type> staticcrsgraph_type;
 #endif
   //! Type of column indices in the sparse matrix.
   typedef typename staticcrsgraph_type::entries_type index_type;

--- a/packages/kokkos-kernels/src/sparse/KokkosSparse_CrsMatrix.hpp
+++ b/packages/kokkos-kernels/src/sparse/KokkosSparse_CrsMatrix.hpp
@@ -389,7 +389,7 @@ public:
   typedef typename Device::execution_space execution_space;
   //! Type of the matrix's memory space.
   typedef typename Device::memory_space memory_space;
-  //! Type of the matrix's device type.
+  //! Canonical device type
   typedef Kokkos::Device<execution_space, memory_space> device_type;
 
   //! Type of each value in the matrix.

--- a/packages/muelu/src/Graph/Containers/MueLu_LWGraph_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/Containers/MueLu_LWGraph_kokkos_decl.hpp
@@ -79,6 +79,7 @@ namespace MueLu {
     using global_ordinal_type = GlobalOrdinal;
     using execution_space     = typename DeviceType::execution_space;
     using memory_space        = typename DeviceType::memory_space;
+    using device_type         = Kokkos::Device<execution_space, memory_space>;
     using range_type          = Kokkos::RangePolicy<local_ordinal_type, execution_space>;
     using node_type           = Kokkos::Compat::KokkosDeviceWrapperNode<DeviceType>;
     using size_type           = size_t;
@@ -86,7 +87,7 @@ namespace MueLu {
     using map_type            = Xpetra::Map<LocalOrdinal, GlobalOrdinal, node_type>;
     using local_graph_type    = Kokkos::StaticCrsGraph<LocalOrdinal,
                                                        Kokkos::LayoutLeft,
-                                                       execution_space>;
+                                                       device_type>;
     using boundary_nodes_type = Kokkos::View<const bool*, memory_space>;
     using row_type            = Kokkos::View<const LocalOrdinal*, memory_space>;
 

--- a/packages/phalanx/test/Kokkos/tKokkos.cpp
+++ b/packages/phalanx/test/Kokkos/tKokkos.cpp
@@ -752,7 +752,10 @@ namespace phalanx_test {
     const size_t nnz = 21;
 
     using Kokkos::View;
-    View<typename Kokkos::StaticCrsGraph<int,Kokkos::LayoutLeft,PHX::Device>::size_type*,PHX::Device> row_offsets("row_offsets",num_rows+1);
+    using local_matrix_type = KokkosSparse::CrsMatrix<double,int,PHX::Device>;
+    using local_graph_type = typename local_matrix_type::StaticCrsGraphType;
+    using size_type = typename local_matrix_type::size_type;
+    View<size_type*,PHX::Device> row_offsets("row_offsets",num_rows+1);
 
     auto host_row_offsets = Kokkos::create_mirror_view(row_offsets);
     host_row_offsets(0) = 0;
@@ -786,8 +789,8 @@ namespace phalanx_test {
     Kokkos::deep_copy(col_ids, host_col_ids);
 
     // CrsMatrix requires LayoutLeft!
-    Kokkos::StaticCrsGraph<int,Kokkos::LayoutLeft,PHX::Device> g(col_ids,row_offsets);
-    KokkosSparse::CrsMatrix<double,int,PHX::Device> J("Jacobian",g);
+    local_graph_type g(col_ids,row_offsets);
+    local_matrix_type J("Jacobian",g);
 
     TEST_EQUALITY(J.numRows(),10);
     TEST_EQUALITY(J.numCols(),10);

--- a/packages/stokhos/src/sacado/kokkos/pce/linalg/Kokkos_CrsMatrix_UQ_PCE.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/linalg/Kokkos_CrsMatrix_UQ_PCE.hpp
@@ -88,7 +88,7 @@ public:
   typedef Sacado::UQ::PCE<InputStorage> InputVectorValue;
   typedef Sacado::UQ::PCE<OutputStorage> OutputVectorValue;
 
-  typedef MatrixDevice execution_space;
+  typedef typename MatrixDevice::execution_space execution_space;
 
   typedef KokkosSparse::CrsMatrix< MatrixValue,
                                    MatrixOrdinal,
@@ -485,7 +485,7 @@ public:
   typedef Sacado::UQ::PCE<InputStorage> InputVectorValue;
   typedef Sacado::UQ::PCE<OutputStorage> OutputVectorValue;
 
-  typedef MatrixDevice execution_space;
+  typedef typename MatrixDevice::execution_space execution_space;
 
   typedef KokkosSparse::CrsMatrix< MatrixValue,
                                    MatrixOrdinal,
@@ -929,7 +929,7 @@ public:
 
   template <int BlockSize>
   struct BlockKernel {
-    typedef MatrixDevice execution_space;
+    typedef typename MatrixDevice::execution_space execution_space;
     typedef typename Kokkos::FlatArrayType<matrix_values_type>::type matrix_array_type;
     typedef typename input_vector_type::array_type input_array_type;
     typedef typename output_vector_type::array_type output_array_type;
@@ -1052,7 +1052,7 @@ public:
   };
 
   struct Kernel {
-    typedef MatrixDevice execution_space;
+    typedef typename MatrixDevice::execution_space execution_space;
     typedef typename Kokkos::FlatArrayType<matrix_values_type>::type matrix_array_type;
     typedef typename input_vector_type::array_type input_array_type;
     typedef typename output_vector_type::array_type output_array_type;
@@ -1189,7 +1189,7 @@ public:
   typedef Kokkos::View< OutputVectorValue**,
                         OutputP... > output_vector_type;
 
-  typedef MatrixDevice execution_space;
+  typedef typename MatrixDevice::execution_space execution_space;
   typedef typename MatrixValue::ordinal_type size_type;
   typedef typename InputVectorValue::value_type input_scalar;
   typedef typename OutputVectorValue::value_type output_scalar;

--- a/packages/stokhos/src/sacado/kokkos/vector/linalg/Kokkos_CrsMatrix_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/linalg/Kokkos_CrsMatrix_MP_Vector.hpp
@@ -120,7 +120,7 @@ class MPMultiply< KokkosSparse::CrsMatrix< Sacado::MP::Vector<MatrixStorage>,
                   Update
 #ifdef KOKKOS_ENABLE_CUDA
                   , typename std::enable_if<
-                      !std::is_same<MatrixDevice,Kokkos::Cuda>::value >::type
+                      !std::is_same<typename MatrixDevice::execution_space,Kokkos::Cuda>::value >::type
 #endif
                   >
 {
@@ -132,7 +132,7 @@ public:
   typedef Sacado::MP::Vector<OutputStorage> OutputVectorValue;
   typedef OutputVectorValue scalar_type;
 
-  typedef MatrixDevice execution_space;
+  typedef typename MatrixDevice::execution_space execution_space;
   typedef typename execution_space::size_type size_type;
 
   typedef KokkosSparse::CrsMatrix< MatrixValue,
@@ -214,7 +214,7 @@ class MPMultiply< KokkosSparse::CrsMatrix< Sacado::MP::Vector<MatrixStorage>,
                   Update
 #ifdef KOKKOS_ENABLE_CUDA
                   , typename std::enable_if<
-                    !std::is_same<MatrixDevice,Kokkos::Cuda>::value >::type
+                    !std::is_same<typename MatrixDevice::execution_space,Kokkos::Cuda>::value >::type
 #endif
                   >
 {
@@ -224,7 +224,7 @@ public:
   typedef Sacado::MP::Vector<OutputStorage> OutputVectorValue;
   typedef OutputVectorValue scalar_type;
 
-  typedef MatrixDevice execution_space;
+  typedef typename MatrixDevice::execution_space execution_space;
   typedef typename execution_space::size_type size_type;
 
   typedef KokkosSparse::CrsMatrix< MatrixValue,
@@ -319,7 +319,7 @@ public:
   typedef Sacado::MP::Vector<InputStorage> InputVectorValue;
   typedef Sacado::MP::Vector<OutputStorage> OutputVectorValue;
 
-  typedef MatrixDevice execution_space;
+  typedef typename MatrixDevice::execution_space execution_space;
   typedef typename execution_space::size_type size_type;
 
   typedef KokkosSparse::CrsMatrix< MatrixValue,
@@ -376,7 +376,7 @@ public:
   typedef Sacado::MP::Vector<InputStorage> InputVectorValue;
   typedef Sacado::MP::Vector<OutputStorage> OutputVectorValue;
 
-  typedef MatrixDevice execution_space;
+  typedef typename MatrixDevice::execution_space execution_space;
   typedef typename execution_space::size_type size_type;
 
   typedef KokkosSparse::CrsMatrix< MatrixValue,

--- a/packages/stokhos/src/sacado/kokkos/vector/linalg/Kokkos_CrsMatrix_MP_Vector_Cuda.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/linalg/Kokkos_CrsMatrix_MP_Vector_Cuda.hpp
@@ -89,7 +89,7 @@ template <typename MatrixStorage,
           typename Update>
 class MPMultiply< KokkosSparse::CrsMatrix<Sacado::MP::Vector<MatrixStorage>,
                                     MatrixOrdinal,
-                                    Kokkos::Cuda,
+                                    Kokkos::Device<Kokkos::Cuda, typename Kokkos::Cuda::memory_space>,
                                     MatrixMemory,
                                     MatrixSize>,
                   Kokkos::View< const Sacado::MP::Vector<InputStorage>*,
@@ -106,13 +106,13 @@ public:
   typedef Sacado::MP::Vector<InputStorage> InputVectorValue;
   typedef Sacado::MP::Vector<OutputStorage> OutputVectorValue;
 
-  typedef typename Kokkos::Cuda Device;
-  typedef Device execution_space;
+  typedef Kokkos::Device<Kokkos::Cuda, typename Kokkos::Cuda::memory_space> Device;
+  typedef typename Device::execution_space execution_space;
   typedef typename execution_space::size_type size_type;
 
   typedef KokkosSparse::CrsMatrix<MatrixValue,
                             MatrixOrdinal,
-                            execution_space,
+                            Device,
                             MatrixMemory,
                             MatrixSize> matrix_type;
   typedef typename matrix_type::values_type matrix_values_type;
@@ -336,7 +336,7 @@ template <typename MatrixStorage,
           typename Update>
 class MPMultiply< KokkosSparse::CrsMatrix<Sacado::MP::Vector<MatrixStorage>,
                                     MatrixOrdinal,
-                                    Kokkos::Cuda,
+                                    Kokkos::Device<Kokkos::Cuda, typename Kokkos::Cuda::memory_space>,
                                     MatrixMemory,
                                     MatrixSize>,
                   Kokkos::View< const Sacado::MP::Vector<InputStorage>**,
@@ -353,14 +353,14 @@ public:
   typedef Sacado::MP::Vector<InputStorage> InputVectorValue;
   typedef Sacado::MP::Vector<OutputStorage> OutputVectorValue;
 
-  typedef typename Kokkos::Cuda Device;
-  typedef Device execution_space;
+  typedef Kokkos::Device<Kokkos::Cuda, typename Kokkos::Cuda::memory_space> Device;
+  typedef typename Device::execution_space execution_space;
   typedef typename execution_space::size_type size_type;
 
 
   typedef KokkosSparse::CrsMatrix<MatrixValue,
                             MatrixOrdinal,
-                            execution_space,
+                            Device,
                             MatrixMemory,
                             MatrixSize> matrix_type;
   typedef typename matrix_type::values_type matrix_values_type;

--- a/packages/stokhos/test/Performance/MPVectorKernels/TestSpMv.hpp
+++ b/packages/stokhos/test/Performance/MPVectorKernels/TestSpMv.hpp
@@ -109,10 +109,11 @@ test_mpvector_spmv(const int ensemble_length,
   typedef typename storage_type::value_type value_type;
   typedef typename storage_type::ordinal_type ordinal_type;
   typedef typename storage_type::execution_space execution_space;
+  typedef Kokkos::Device<execution_space, typename execution_space::memory_space> device_type;
   typedef Sacado::MP::Vector<StorageType> VectorType;
   typedef Kokkos::LayoutRight Layout;
   typedef Kokkos::View< VectorType*, Layout, execution_space > vector_type;
-  typedef KokkosSparse::CrsMatrix< VectorType, ordinal_type, execution_space > matrix_type;
+  typedef KokkosSparse::CrsMatrix< VectorType, ordinal_type, device_type > matrix_type;
   typedef typename matrix_type::StaticCrsGraphType matrix_graph_type;
   typedef typename matrix_type::values_type matrix_values_type;
 
@@ -191,8 +192,9 @@ test_scalar_spmv(const int ensemble_length,
   typedef ScalarType value_type;
   typedef OrdinalType ordinal_type;
   typedef Device execution_space;
+  typedef Kokkos::Device<execution_space, typename execution_space::memory_space> device_type;
   typedef Kokkos::View< value_type*, execution_space > vector_type;
-  typedef KokkosSparse::CrsMatrix< value_type, ordinal_type, execution_space > matrix_type;
+  typedef KokkosSparse::CrsMatrix< value_type, ordinal_type, device_type > matrix_type;
   typedef typename matrix_type::StaticCrsGraphType matrix_graph_type;
   typedef typename matrix_type::values_type matrix_values_type;
 

--- a/packages/stokhos/test/UnitTest/Stokhos_KokkosCrsMatrixMPVectorUnitTest.hpp
+++ b/packages/stokhos/test/UnitTest/Stokhos_KokkosCrsMatrixMPVectorUnitTest.hpp
@@ -351,7 +351,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL(
   Kokkos_CrsMatrix_MP, ReplaceValues, MatrixScalar )
 {
   typedef typename MatrixScalar::ordinal_type Ordinal;
-  typedef typename MatrixScalar::execution_space Device;
+  typedef typename MatrixScalar::execution_space execution_space;
+  typedef Kokkos::Device<execution_space, typename execution_space::memory_space> Device;
   typedef KokkosSparse::CrsMatrix<MatrixScalar,Ordinal,Device> Matrix;
 
   // Build diagonal matrix
@@ -370,7 +371,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL(
   Kokkos_CrsMatrix_MP, SumIntoValues, MatrixScalar )
 {
   typedef typename MatrixScalar::ordinal_type Ordinal;
-  typedef typename MatrixScalar::execution_space Device;
+  typedef typename MatrixScalar::execution_space execution_space;
+  typedef Kokkos::Device<execution_space, typename execution_space::memory_space> Device;
   typedef KokkosSparse::CrsMatrix<MatrixScalar,Ordinal,Device> Matrix;
 
   // Build diagonal matrix
@@ -389,7 +391,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_1_DECL(
   Kokkos_CrsMatrix_MP, SumIntoValuesAtomic, MatrixScalar )
 {
   typedef typename MatrixScalar::ordinal_type Ordinal;
-  typedef typename MatrixScalar::execution_space Device;
+  typedef typename MatrixScalar::execution_space execution_space;
+  typedef Kokkos::Device<execution_space, typename execution_space::memory_space> Device;
   typedef KokkosSparse::CrsMatrix<MatrixScalar,Ordinal,Device> Matrix;
 
   // Build diagonal matrix
@@ -444,9 +447,10 @@ bool test_embedded_vector(const typename VectorType::ordinal_type nGrid,
   typedef typename VectorType::value_type scalar_type;
   typedef typename VectorType::storage_type storage_type;
   typedef typename storage_type::execution_space execution_space;
+  typedef Kokkos::Device<execution_space, typename execution_space::memory_space> device_type;
   typedef Kokkos::LayoutRight Layout;
   typedef Kokkos::View< VectorType*, Layout, execution_space > block_vector_type;
-  typedef KokkosSparse::CrsMatrix< VectorType, ordinal_type, execution_space > block_matrix_type;
+  typedef KokkosSparse::CrsMatrix< VectorType, ordinal_type, device_type > block_matrix_type;
   typedef typename block_matrix_type::StaticCrsGraphType matrix_graph_type;
   typedef typename block_matrix_type::values_type matrix_values_type;
 

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -256,7 +256,7 @@ namespace Tpetra {
     //! The type of the part of the sparse graph on each MPI process.
     using local_graph_type = Kokkos::StaticCrsGraph<local_ordinal_type,
                                                     Kokkos::LayoutLeft,
-                                                    execution_space>;
+                                                    device_type>;
 
     //! The Map specialization used by this class.
     using map_type = ::Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>;

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_decl.hpp
@@ -492,10 +492,9 @@ namespace Tpetra {
     using local_matrix_type =
       KokkosSparse::CrsMatrix<impl_scalar_type,
                               local_ordinal_type,
-                              execution_space,
+                              device_type,
                               void,
                               typename local_graph_type::size_type>;
-
 
     //@}
     //! @name Constructors and destructor

--- a/packages/tpetra/core/src/Tpetra_LocalCrsMatrixOperator_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_LocalCrsMatrixOperator_decl.hpp
@@ -81,7 +81,7 @@ namespace Tpetra {
     using local_matrix_type =
       KokkosSparse::CrsMatrix<matrix_scalar_type,
                               local_ordinal_type,
-                              execution_space,
+                              device_type,
                               void,
                               typename local_graph_type::size_type>;
 

--- a/packages/tpetra/core/src/Tpetra_LocalCrsMatrixOperator_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_LocalCrsMatrixOperator_decl.hpp
@@ -64,8 +64,6 @@ namespace Tpetra {
       typename LocalOperator<MultiVectorScalar, Device>::scalar_type;
     using matrix_scalar_type =
       typename LocalOperator<MatrixScalar, Device>::scalar_type;
-
-  private:
     using array_layout =
       typename LocalOperator<MultiVectorScalar, Device>::array_layout;
     using device_type =
@@ -73,18 +71,15 @@ namespace Tpetra {
     using local_ordinal_type =
       ::Tpetra::Details::DefaultTypes::local_ordinal_type;
     using execution_space = typename Device::execution_space;
-    using local_graph_type =
-      Kokkos::StaticCrsGraph<local_ordinal_type,
-                             array_layout,
-                             execution_space>;
   public:
     using local_matrix_type =
       KokkosSparse::CrsMatrix<matrix_scalar_type,
                               local_ordinal_type,
-                              device_type,
-                              void,
-                              typename local_graph_type::size_type>;
+                              device_type>;
+  private:
+    using local_graph_type = typename local_matrix_type::StaticCrsGraphType;
 
+  public:
     LocalCrsMatrixOperator (const std::shared_ptr<local_matrix_type>& A);
     ~LocalCrsMatrixOperator () override = default;
 

--- a/packages/trilinoscouplings/examples/fenl/fenl_functors.hpp
+++ b/packages/trilinoscouplings/examples/fenl/fenl_functors.hpp
@@ -505,7 +505,7 @@ template< class ExecutionSpace , BoxElemPart::ElemOrder Order , class Coordinate
           class CoeffFunctionType , class GatherScatterOp , class ScalarType >
 class ElementComputation
   < Kokkos::Example::BoxElemFixture< ExecutionSpace , Order , CoordinateMap >
-  , KokkosSparse::CrsMatrix< MatrixVectorScalarType , OrdinalType , ExecutionSpace , MemoryTraits , SizeType >
+  , KokkosSparse::CrsMatrix< MatrixVectorScalarType , OrdinalType , Kokkos::Device<ExecutionSpace, typename ExecutionSpace::memory_space> , MemoryTraits , SizeType >
   , CoeffFunctionType
   , GatherScatterOp
   , ScalarType >
@@ -518,9 +518,10 @@ public:
   //------------------------------------
 
   typedef ExecutionSpace   execution_space ;
+  typedef Kokkos::Device<execution_space, typename execution_space::memory_space> DeviceType;
   typedef ScalarType       scalar_type ;
 
-  typedef KokkosSparse::CrsMatrix< MatrixVectorScalarType , OrdinalType , ExecutionSpace , MemoryTraits , SizeType >  sparse_matrix_type ;
+  typedef KokkosSparse::CrsMatrix< MatrixVectorScalarType , OrdinalType , DeviceType , MemoryTraits , SizeType >  sparse_matrix_type ;
   typedef typename sparse_matrix_type::StaticCrsGraphType                                       sparse_graph_type ;
   typedef typename sparse_matrix_type::values_type matrix_values_type ;
   typedef Kokkos::View< MatrixVectorScalarType* , Kokkos::LayoutLeft, execution_space > vector_type ;
@@ -992,7 +993,7 @@ template< class ExecutionSpace , BoxElemPart::ElemOrder Order , class Coordinate
           typename ScalarType , typename OrdinalType , class MemoryTraits , typename SizeType >
 class DirichletComputation<
   Kokkos::Example::BoxElemFixture< ExecutionSpace , Order , CoordinateMap > ,
-  KokkosSparse::CrsMatrix< ScalarType , OrdinalType , ExecutionSpace , MemoryTraits , SizeType > >
+  KokkosSparse::CrsMatrix< ScalarType , OrdinalType , Kokkos::Device<ExecutionSpace, typename ExecutionSpace::memory_space> , MemoryTraits , SizeType > >
 {
 public:
 
@@ -1001,9 +1002,10 @@ public:
   typedef typename node_coord_type::value_type                                 scalar_coord_type ;
 
   typedef ExecutionSpace   execution_space ;
+  typedef Kokkos::Device<execution_space, typename execution_space::memory_space> DeviceType;
   typedef ScalarType   scalar_type ;
 
-  typedef KokkosSparse::CrsMatrix< ScalarType , OrdinalType , ExecutionSpace , MemoryTraits , SizeType >  sparse_matrix_type ;
+  typedef KokkosSparse::CrsMatrix< ScalarType , OrdinalType , DeviceType , MemoryTraits , SizeType >  sparse_matrix_type ;
   typedef typename sparse_matrix_type::StaticCrsGraphType                                       sparse_graph_type ;
   typedef typename sparse_matrix_type::values_type matrix_values_type ;
   typedef Kokkos::View< scalar_type* , execution_space > vector_type ;

--- a/packages/trilinoscouplings/examples/fenl/fenl_functors_pce.hpp
+++ b/packages/trilinoscouplings/examples/fenl/fenl_functors_pce.hpp
@@ -670,7 +670,7 @@ template< typename ExecutionSpace ,
           class CoeffFunctionType>
 class ElementComputation<
   Kokkos::Example::BoxElemFixture< ExecutionSpace , Order , CoordinateMap >,
-  KokkosSparse::CrsMatrix< Sacado::UQ::PCE<StorageType> , OrdinalType , ExecutionSpace , MemoryTraits , SizeType >,
+  KokkosSparse::CrsMatrix< Sacado::UQ::PCE<StorageType> , OrdinalType , Kokkos::Device<ExecutionSpace, typename ExecutionSpace::memory_space> , MemoryTraits , SizeType >,
   CoeffFunctionType >
 {
 public:
@@ -682,9 +682,10 @@ public:
   //------------------------------------
 
   typedef ExecutionSpace   execution_space ;
+  typedef Kokkos::Device<execution_space, typename execution_space::memory_space> DeviceType;
   typedef ScalarType   scalar_type ;
 
-  typedef KokkosSparse::CrsMatrix< ScalarType , OrdinalType , ExecutionSpace , MemoryTraits , SizeType >  sparse_matrix_type ;
+  typedef KokkosSparse::CrsMatrix< ScalarType , OrdinalType , DeviceType , MemoryTraits , SizeType >  sparse_matrix_type ;
   typedef typename sparse_matrix_type::StaticCrsGraphType sparse_graph_type ;
   typedef typename sparse_matrix_type::values_type matrix_values_type ;
   typedef Kokkos::View< scalar_type* , Kokkos::LayoutLeft, execution_space > vector_type ;
@@ -699,7 +700,7 @@ public:
   typedef typename Sacado::mpl::apply<CoeffFunctionType, ensemble_scalar_type>::type scalar_coeff_function_type;
   typedef ElementComputation<
     Kokkos::Example::BoxElemFixture< ExecutionSpace , Order , CoordinateMap >,
-    KokkosSparse::CrsMatrix< ensemble_scalar_type , OrdinalType , ExecutionSpace , MemoryTraits , SizeType >,
+    KokkosSparse::CrsMatrix< ensemble_scalar_type , OrdinalType , DeviceType , MemoryTraits , SizeType >,
     scalar_coeff_function_type > scalar_element_computation_type;
   typedef typename scalar_element_computation_type::sparse_matrix_type scalar_sparse_matrix_type ;
   typedef typename scalar_sparse_matrix_type::values_type scalar_matrix_values_type ;

--- a/packages/xpetra/src/CrsGraph/Xpetra_CrsGraph.hpp
+++ b/packages/xpetra/src/CrsGraph/Xpetra_CrsGraph.hpp
@@ -216,7 +216,8 @@ namespace Xpetra {
 #ifdef HAVE_XPETRA_KOKKOS_REFACTOR
 #ifdef HAVE_XPETRA_TPETRA
     typedef typename node_type::execution_space execution_space;
-    typedef Kokkos::StaticCrsGraph<LocalOrdinal, Kokkos::LayoutLeft, execution_space> local_graph_type;
+    typedef typename node_type::device_type device_type;
+    typedef Kokkos::StaticCrsGraph<LocalOrdinal, Kokkos::LayoutLeft, device_type> local_graph_type;
 
     /// \brief Get the local graph.
     ///


### PR DESCRIPTION
Fix the KokkosSparse::CrsMatrix::StaticCrsGraphType specialization to
use the full device type, not just execution space. Was necessary for
some things in KokkosKernels to work with both <Cuda, CudaSpace> an
<Cuda, CudaUVMSpace> in the same build. (Mirror of https://github.com/kokkos/kokkos-kernels/pull/666)

Fix downstream errors in Tpetra, Xpetra and MueLu caused by that change.
This just involved passing the Kokkos::Device specialization
corresponding to Node in to the local_matrix_type/local_graph_type
template parameters.

This is needed by @iyamazaki to integrate the new two-stage GS into Ifpack2.
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/kokkos-kernels 
@trilinos/tpetra 
@trilinos/muelu 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Just updates Tpetra stack in response to a necessary change to KokkosKernels.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
-->

## Related Issues

* Closes 
* Blocks https://github.com/kokkos/kokkos-kernels/pull/671 (merged) getting integrated into Trilinos
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of https://github.com/kokkos/kokkos-kernels/pull/666

## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
@iyamazaki needs this in order to add two-stage GS for Exawind.
## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
Basically just a syntax change - no actual behavior was changed since the Kokkos::Devices used by Tpetra are still always given by an execution space + its default memory space. But, the local graph and local matrix are exercised directly in every CrsGraph/CrsMatrix test.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->