### PR TITLE
cts1, tlcc2: Switch from Ninja to Unix Makefiles (#7094, ATDV-328)

### DIFF
--- a/cmake/std/atdm/common/toss3/environment_new.sh
+++ b/cmake/std/atdm/common/toss3/environment_new.sh
@@ -9,7 +9,7 @@
 echo "Using $ATDM_CONFIG_SYSTEM_NAME toss3 compiler stack $ATDM_CONFIG_COMPILER to build $ATDM_CONFIG_BUILD_TYPE code with Kokkos node type $ATDM_CONFIG_NODE_TYPE"
 
 export ATDM_CONFIG_ENABLE_SPARC_SETTINGS=ON
-export ATDM_CONFIG_USE_NINJA=ON
+export ATDM_CONFIG_USE_NINJA=OFF
 export ATDM_CONFIG_BUILD_COUNT=8
 # export ATDM_CONFIG_CMAKE_JOB_POOL_LINK=2
 # NOTE: Above, currently setting CMAKE_JOB_POOL_LINK results in a build

--- a/cmake/std/atdm/common/toss3/environment_tlcc2.sh
+++ b/cmake/std/atdm/common/toss3/environment_tlcc2.sh
@@ -12,7 +12,7 @@ fi
 
 echo "Using toss3 compiler stack $ATDM_CONFIG_COMPILER to build $ATDM_CONFIG_BUILD_TYPE code with Kokkos node type $ATDM_CONFIG_NODE_TYPE"
 
-export ATDM_CONFIG_USE_NINJA=ON
+export ATDM_CONFIG_USE_NINJA=OFF
 export ATDM_CONFIG_BUILD_COUNT=8
 # export ATDM_CONFIG_CMAKE_JOB_POOL_LINK=2
 # NOTE: Above, currently setting CMAKE_JOB_POOL_LINK results in a build


### PR DESCRIPTION
For some reason, this seems to fix the compiler check on CTS-1 and TLCC-2
systems.  Something happened between testing day 2020-03-27 and 2020-03-28 to
break this.  See #7094 and [ATDV-328](https://sems-atlassian-srn.sandia.gov/browse/ATDV-328).

This is just a stop-gap measure to address this until we can see how to fix
the configure with the Ninja generator.

## How was this tested?

I manually tested this on CTS-1 system 'eclipse'.  I suspect it will also work on TLCC-2 systems as well (also a TOSS3 system).
