### PR TITLE
Xpetra_*CrsGraph: fix return of getLocalGraph

### DIFF
--- a/packages/xpetra/src/CrsGraph/Xpetra_EpetraCrsGraph.hpp
+++ b/packages/xpetra/src/CrsGraph/Xpetra_EpetraCrsGraph.hpp
@@ -271,7 +271,7 @@ public:
   local_graph_type getLocalGraph () const {
     TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::NotImplemented,
       "Xpetra::EpetraCrsGraph only available for GO=int or GO=long long with EpetraNode (Serial or OpenMP depending on configuration)");
-    TEUCHOS_UNREACHABLE_RETURN((Kokkos::StaticCrsGraph<LocalOrdinal, Kokkos::LayoutLeft, execution_space>()));
+    TEUCHOS_UNREACHABLE_RETURN((local_graph_type()));
   }
 #else
 #ifdef __GNUC__
@@ -587,7 +587,7 @@ public:
   local_graph_type getLocalGraph () const {
     TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::NotImplemented,
                                "Epetra does not support Kokkos::StaticCrsGraph!");
-    TEUCHOS_UNREACHABLE_RETURN((Kokkos::StaticCrsGraph<LocalOrdinal, Kokkos::LayoutLeft, execution_space>()));
+    TEUCHOS_UNREACHABLE_RETURN((local_graph_type()));
   }
 #else
 #ifdef __GNUC__
@@ -954,7 +954,7 @@ public:
   local_graph_type getLocalGraph () const {
     TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::NotImplemented,
                                "Epetra does not support Kokkos::StaticCrsGraph!");
-    TEUCHOS_UNREACHABLE_RETURN((Kokkos::StaticCrsGraph<LocalOrdinal, Kokkos::LayoutLeft, execution_space>()));
+    TEUCHOS_UNREACHABLE_RETURN((local_graph_type()));
   }
 #else
 #ifdef __GNUC__

--- a/packages/xpetra/src/CrsGraph/Xpetra_TpetraCrsGraph_def.hpp
+++ b/packages/xpetra/src/CrsGraph/Xpetra_TpetraCrsGraph_def.hpp
@@ -583,7 +583,7 @@ RCP< const Tpetra::CrsGraph<LocalOrdinal, GlobalOrdinal, Node> > TpetraCrsGraph<
     local_graph_type getLocalGraph () const {
       TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::RuntimeError,
                                  "Epetra does not support Kokkos::StaticCrsGraph!");
-      TEUCHOS_UNREACHABLE_RETURN((Kokkos::StaticCrsGraph<LocalOrdinal, Kokkos::LayoutLeft, execution_space>()));
+      TEUCHOS_UNREACHABLE_RETURN((local_graph_type()));
     }
 #endif
 
@@ -906,7 +906,7 @@ RCP< const Tpetra::CrsGraph<LocalOrdinal, GlobalOrdinal, Node> > TpetraCrsGraph<
     local_graph_type getLocalGraph () const {
       TEUCHOS_TEST_FOR_EXCEPTION(true, Xpetra::Exceptions::RuntimeError,
                                  "Epetra does not support Kokkos::StaticCrsGraph!");
-      TEUCHOS_UNREACHABLE_RETURN((Kokkos::StaticCrsGraph<LocalOrdinal, Kokkos::LayoutLeft, execution_space>()));
+      TEUCHOS_UNREACHABLE_RETURN((local_graph_type()));
     }
 #endif
 


### PR DESCRIPTION
@trilinos/xpetra 

## Motivation
Fix compile issue, see https://testing.sandia.gov/cdash/viewBuildError.php?buildid=6688315