### PR TITLE
Piro: TempusSolver refactor and cleanup

### DIFF
--- a/packages/piro/src/CMakeLists.txt
+++ b/packages/piro/src/CMakeLists.txt
@@ -132,6 +132,8 @@ IF (Piro_ENABLE_Tempus)
   APPEND_SET(HEADERS
     Piro_TempusSolver.hpp
     Piro_TempusSolver_Def.hpp 
+    Piro_TransientSolver.hpp
+    Piro_TransientSolver_Def.hpp 
     Piro_TempusStepperFactory.hpp
     Piro_TempusStepControlFactory.hpp
     Piro_ObserverToTempusIntegrationObserverAdapter.hpp 

--- a/packages/piro/src/Piro_InvertMassMatrixDecorator.hpp
+++ b/packages/piro/src/Piro_InvertMassMatrixDecorator.hpp
@@ -51,22 +51,9 @@
 #include "Thyra_ModelEvaluatorDefaultBase.hpp"
 #include "Piro_config.hpp"
 
-#ifdef ALBANY_BUILD
-#include "Kokkos_DefaultNode.hpp"
-#endif
-
-#include "Tpetra_Map.hpp"
-using default_lo = Tpetra::Map<>::local_ordinal_type;
-using default_go = Tpetra::Map<>::global_ordinal_type;
-
 namespace Piro {
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal = default_lo, typename GlobalOrdinal = default_go,
-          typename Node = KokkosClassic::DefaultNode::DefaultNodeType>
-#else
 template<typename Scalar>
-#endif
 class InvertMassMatrixDecorator
     : public Thyra::ModelEvaluatorDefaultBase<Scalar>
 {

--- a/packages/piro/src/Piro_InvertMassMatrixDecorator_Def.hpp
+++ b/packages/piro/src/Piro_InvertMassMatrixDecorator_Def.hpp
@@ -64,13 +64,8 @@
 #endif
 
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Piro::InvertMassMatrixDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node>::InvertMassMatrixDecorator(
-#else
 template <typename Scalar>
 Piro::InvertMassMatrixDecorator<Scalar>::InvertMassMatrixDecorator(
-#endif
                           Teuchos::RCP<Teuchos::ParameterList> stratParams,
                           Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &model_,
                           bool massMatrixIsConstant_, bool lumpMassMatrix_,
@@ -99,16 +94,6 @@ Piro::InvertMassMatrixDecorator<Scalar>::InvertMassMatrixDecorator(
 
   Stratimikos::DefaultLinearSolverBuilder linearSolverBuilder;
 
-#ifdef ALBANY_BUILD
-#ifdef HAVE_PIRO_IFPACK2
-  typedef Thyra::PreconditionerFactoryBase<double> Base;
-  typedef Thyra::Ifpack2PreconditionerFactory<Tpetra::CrsMatrix<double, LocalOrdinal, GlobalOrdinal, Node> > Impl;
-  linearSolverBuilder.setPreconditioningStrategyFactory(Teuchos::abstractFactoryStd<Base, Impl>(), "Ifpack2");
-#endif
-#ifdef HAVE_PIRO_MUELU
-  Stratimikos::enableMueLu<LocalOrdinal, GlobalOrdinal, Node>(linearSolverBuilder);
-#endif
-#else
 #ifdef HAVE_PIRO_IFPACK2
   typedef Thyra::PreconditionerFactoryBase<double> Base;
   typedef Thyra::Ifpack2PreconditionerFactory<Tpetra::CrsMatrix<double> > Impl;
@@ -116,7 +101,6 @@ Piro::InvertMassMatrixDecorator<Scalar>::InvertMassMatrixDecorator(
 #endif
 #ifdef HAVE_PIRO_MUELU
   Stratimikos::enableMueLu(linearSolverBuilder);
-#endif
 #endif
 
    linearSolverBuilder.setParameterList(stratParams);
@@ -130,103 +114,56 @@ Piro::InvertMassMatrixDecorator<Scalar>::InvertMassMatrixDecorator(
   lowsFactory->setVerbLevel(Teuchos::VERB_LOW);
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Piro::InvertMassMatrixDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node>::~InvertMassMatrixDecorator()
-#else
 template<typename Scalar>
 Piro::InvertMassMatrixDecorator<Scalar>::~InvertMassMatrixDecorator()
-#endif
 {
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
-Piro::InvertMassMatrixDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node>::get_x_space() const
-#else
 template<typename Scalar>
 Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
 Piro::InvertMassMatrixDecorator<Scalar>::get_x_space() const
-#endif
 {
   return model->get_x_space();
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
-Piro::InvertMassMatrixDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node>::get_f_space() const
-#else
 template<typename Scalar>
 Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
 Piro::InvertMassMatrixDecorator<Scalar>::get_f_space() const
-#endif
 {
   return model->get_f_space();
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
-Piro::InvertMassMatrixDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node>::get_p_space(int l) const
-#else
 template<typename Scalar>
 Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
 Piro::InvertMassMatrixDecorator<Scalar>::get_p_space(int l) const
-#endif
 {
   return model->get_p_space(l);
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Teuchos::RCP<const Teuchos::Array<std::string> >
-Piro::InvertMassMatrixDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node>::get_p_names(int l) const
-#else
 template<typename Scalar>
 Teuchos::RCP<const Teuchos::Array<std::string> >
 Piro::InvertMassMatrixDecorator<Scalar>::get_p_names(int l) const
-#endif
 {
   return model->get_p_names(l);
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
-Piro::InvertMassMatrixDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node>::get_g_space(int j) const
-#else
 template<typename Scalar>
 Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
 Piro::InvertMassMatrixDecorator<Scalar>::get_g_space(int j) const
-#endif
 {
   return model->get_g_space(j);
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Teuchos::ArrayView<const std::string>
-Piro::InvertMassMatrixDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node>::get_g_names(int j) const
-#else
 template<typename Scalar>
 Teuchos::ArrayView<const std::string>
 Piro::InvertMassMatrixDecorator<Scalar>::get_g_names(int j) const
-#endif
 {
   return model->get_g_names(j);
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Thyra::ModelEvaluatorBase::InArgs<Scalar>
-Piro::InvertMassMatrixDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node>::getNominalValues() const
-#else
 template<typename Scalar>
 Thyra::ModelEvaluatorBase::InArgs<Scalar>
 Piro::InvertMassMatrixDecorator<Scalar>::getNominalValues() const
-#endif
 {
   Thyra::ModelEvaluatorBase::InArgs<Scalar> nominalValues = this->createInArgsImpl();
   nominalValues.setArgs(
@@ -236,140 +173,80 @@ Piro::InvertMassMatrixDecorator<Scalar>::getNominalValues() const
   return nominalValues;
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Teuchos::RCP< Thyra::LinearOpBase< Scalar > >
-Piro::InvertMassMatrixDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node>::create_W_op () const
-#else
 template<typename Scalar>
 Teuchos::RCP< Thyra::LinearOpBase< Scalar > >
 Piro::InvertMassMatrixDecorator<Scalar>::create_W_op () const
-#endif
 {
   return model->create_W_op();
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Teuchos::RCP<const Thyra::LinearOpWithSolveFactoryBase<Scalar> >
-Piro::InvertMassMatrixDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node>::get_W_factory() const
-#else
 template<typename Scalar>
 Teuchos::RCP<const Thyra::LinearOpWithSolveFactoryBase<Scalar> >
 Piro::InvertMassMatrixDecorator<Scalar>::get_W_factory() const
-#endif
 {
   return model->get_W_factory();
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Teuchos::RCP<Thyra::PreconditionerBase<Scalar> >
-Piro::InvertMassMatrixDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node>::create_W_prec() const
-#else
 template<typename Scalar>
 Teuchos::RCP<Thyra::PreconditionerBase<Scalar> >
 Piro::InvertMassMatrixDecorator<Scalar>::create_W_prec() const
-#endif
 {
   return model->create_W_prec();
 }
 
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Thyra::ModelEvaluatorBase::InArgs<Scalar>
-Piro::InvertMassMatrixDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node>::getLowerBounds() const
-#else
 template<typename Scalar>
 Thyra::ModelEvaluatorBase::InArgs<Scalar>
 Piro::InvertMassMatrixDecorator<Scalar>::getLowerBounds() const
-#endif
 {
   return Thyra::ModelEvaluatorBase::InArgs<Scalar>(); // Default value
 }
 
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Thyra::ModelEvaluatorBase::InArgs<Scalar>
-Piro::InvertMassMatrixDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node>::getUpperBounds() const
-#else
 template<typename Scalar>
 Thyra::ModelEvaluatorBase::InArgs<Scalar>
 Piro::InvertMassMatrixDecorator<Scalar>::getUpperBounds() const
-#endif
 {
   return Thyra::ModelEvaluatorBase::InArgs<Scalar>(); // Default value
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-void
-Piro::InvertMassMatrixDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node>::reportFinalPoint(
-#else
 template<typename Scalar>
 void
 Piro::InvertMassMatrixDecorator<Scalar>::reportFinalPoint(
-#endif
     const Thyra::ModelEvaluatorBase::InArgs<Scalar>& finalPoint,
     const bool wasSolved)
 {
   model->reportFinalPoint(finalPoint,wasSolved);
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Thyra::ModelEvaluatorBase::InArgs<Scalar>
-Piro::InvertMassMatrixDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node>::createInArgs() const
-#else
 template<typename Scalar>
 Thyra::ModelEvaluatorBase::InArgs<Scalar>
 Piro::InvertMassMatrixDecorator<Scalar>::createInArgs() const
-#endif
 {
   return this->createInArgsImpl();
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Thyra::ModelEvaluatorBase::InArgs<Scalar>
-Piro::InvertMassMatrixDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node>::createInArgsImpl() const
-#else
 template<typename Scalar>
 Thyra::ModelEvaluatorBase::InArgs<Scalar>
 Piro::InvertMassMatrixDecorator<Scalar>::createInArgsImpl() const
-#endif
 {
   Thyra::ModelEvaluatorBase::InArgsSetup<Scalar> result = model->createInArgs();
   result.setModelEvalDescription(this->description());
   return result; 
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Thyra::ModelEvaluatorBase::OutArgs<Scalar>
-Piro::InvertMassMatrixDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node>::createOutArgsImpl() const
-#else
 template<typename Scalar>
 Thyra::ModelEvaluatorBase::OutArgs<Scalar>
 Piro::InvertMassMatrixDecorator<Scalar>::createOutArgsImpl() const
-#endif
 {
   Thyra::ModelEvaluatorBase::OutArgsSetup<Scalar> result = model->createOutArgs();
   result.setModelEvalDescription(this->description());
   return result; 
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-void
-Piro::InvertMassMatrixDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node>::evalModelImpl(
-#else
 template<typename Scalar>
 void
 Piro::InvertMassMatrixDecorator<Scalar>::evalModelImpl(
-#endif
     const Thyra::ModelEvaluatorBase::InArgs<Scalar>& inArgs,
     const Thyra::ModelEvaluatorBase::OutArgs<Scalar>& outArgs) const
 {

--- a/packages/piro/src/Piro_RythmosSolver.hpp
+++ b/packages/piro/src/Piro_RythmosSolver.hpp
@@ -55,14 +55,6 @@
 #include "Piro_RythmosStepperFactory.hpp"
 #include "Piro_RythmosStepControlFactory.hpp"
 
-#ifdef ALBANY_BUILD
-#include "Kokkos_DefaultNode.hpp"
-#endif
-
-#include "Tpetra_Map.hpp"
-using default_lo = Tpetra::Map<>::local_ordinal_type;
-using default_go = Tpetra::Map<>::global_ordinal_type;
-
 #include <map>
 #include <string>
 
@@ -71,12 +63,7 @@ namespace Piro {
 /** \brief Thyra-based Model Evaluator for Rythmos solves
  *  \ingroup Piro_Thyra_solver_grp
  * */
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal = default_lo, typename GlobalOrdinal = default_go, 
-          typename Node = KokkosClassic::DefaultNode::DefaultNodeType>
-#else
 template <typename Scalar>
-#endif
 class RythmosSolver
     : public Thyra::ResponseOnlyModelEvaluatorBase<Scalar>
 {
@@ -187,14 +174,8 @@ private:
 };
 
 /** \brief Non-member constructor function */
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal = default_lo, typename GlobalOrdinal = default_go,
-          typename Node = KokkosClassic::DefaultNode::DefaultNodeType>
-Teuchos::RCP<RythmosSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node> >
-#else
 template <typename Scalar>
 Teuchos::RCP<RythmosSolver<Scalar> >
-#endif
 rythmosSolver(
     const Teuchos::RCP<Teuchos::ParameterList> &appParams,
     const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &model,

--- a/packages/piro/src/Piro_RythmosSolver_Def.hpp
+++ b/packages/piro/src/Piro_RythmosSolver_Def.hpp
@@ -93,25 +93,15 @@
 #include <stdexcept>
 #include <iostream>
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Piro::RythmosSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::RythmosSolver() :
-#else
 template <typename Scalar>
 Piro::RythmosSolver<Scalar>::RythmosSolver() :
-#endif
   out(Teuchos::VerboseObjectBase::getDefaultOStream()),
   isInitialized(false)
 {
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Piro::RythmosSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::RythmosSolver(
-#else
 template <typename Scalar>
 Piro::RythmosSolver<Scalar>::RythmosSolver(
-#endif
     const Teuchos::RCP<Teuchos::ParameterList> &appParams,
     const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &in_model,
     const Teuchos::RCP<Rythmos::IntegrationObserverBase<Scalar> > &observer) :
@@ -132,13 +122,8 @@ Piro::RythmosSolver<Scalar>::RythmosSolver(
     initialize(appParams, in_model, observer);
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-void Piro::RythmosSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::initialize(
-#else
 template <typename Scalar>
 void Piro::RythmosSolver<Scalar>::initialize(
-#endif
     const Teuchos::RCP<Teuchos::ParameterList> &appParams,
     const Teuchos::RCP< Thyra::ModelEvaluator<Scalar> > &in_model,
     const Teuchos::RCP<Rythmos::IntegrationObserverBase<Scalar> > &observer)
@@ -361,19 +346,11 @@ void Piro::RythmosSolver<Scalar>::initialize(
 
 #ifdef HAVE_PIRO_IFPACK2
      typedef Thyra::PreconditionerFactoryBase<double> Base;
-#ifdef ALBANY_BUILD
-     typedef Thyra::Ifpack2PreconditionerFactory<Tpetra::CrsMatrix<double, LocalOrdinal, GlobalOrdinal, Node> > Impl;
-#else
      typedef Thyra::Ifpack2PreconditionerFactory<Tpetra::CrsMatrix<double> > Impl;
-#endif
      linearSolverBuilder.setPreconditioningStrategyFactory(Teuchos::abstractFactoryStd<Base, Impl>(), "Ifpack2");
 #endif
 #ifdef HAVE_PIRO_MUELU
-#ifdef ALBANY_BUILD
-     Stratimikos::enableMueLu<LocalOrdinal, GlobalOrdinal, Node>(linearSolverBuilder);
-#else
      Stratimikos::enableMueLu(linearSolverBuilder);
-#endif
 #endif
 
      linearSolverBuilder.setParameterList(sublist(rythmosSolverPL, "Stratimikos", true));
@@ -399,11 +376,7 @@ void Piro::RythmosSolver<Scalar>::initialize(
       else {
         Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > origModel = model;
         rythmosSolverPL->get("Lump Mass Matrix", false);  //JF line does not do anything
-#ifdef ALBANY_BUILD
-        model = Teuchos::rcp(new Piro::InvertMassMatrixDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node>(
-#else
         model = Teuchos::rcp(new Piro::InvertMassMatrixDecorator<Scalar>(
-#endif
               sublist(rythmosSolverPL,"Stratimikos", true), origModel,
               true,rythmosSolverPL->get("Lump Mass Matrix", false),false));
       }
@@ -452,13 +425,8 @@ else {
   isInitialized = true;
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Piro::RythmosSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::RythmosSolver(
-#else
 template <typename Scalar>
 Piro::RythmosSolver<Scalar>::RythmosSolver(
-#endif
     const Teuchos::RCP<Rythmos::DefaultIntegrator<Scalar> > &stateIntegrator,
     const Teuchos::RCP<Rythmos::StepperBase<Scalar> > &stateStepper,
     const Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > &timeStepSolver,
@@ -484,13 +452,8 @@ Piro::RythmosSolver<Scalar>::RythmosSolver(
   }
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Piro::RythmosSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::RythmosSolver(
-#else
 template <typename Scalar>
 Piro::RythmosSolver<Scalar>::RythmosSolver(
-#endif
     const Teuchos::RCP<Rythmos::DefaultIntegrator<Scalar> > &stateIntegrator,
     const Teuchos::RCP<Rythmos::StepperBase<Scalar> > &stateStepper,
     const Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > &timeStepSolver,
@@ -517,42 +480,24 @@ Piro::RythmosSolver<Scalar>::RythmosSolver(
   }
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Teuchos::RCP<const Rythmos::IntegratorBase<Scalar> >
-Piro::RythmosSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::getRythmosIntegrator() const
-#else
 template <typename Scalar>
 Teuchos::RCP<const Rythmos::IntegratorBase<Scalar> >
 Piro::RythmosSolver<Scalar>::getRythmosIntegrator() const
-#endif
 {
   return fwdStateIntegrator;
 }
 
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Teuchos::RCP<const Thyra::NonlinearSolverBase<Scalar> >
-Piro::RythmosSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::getTimeStepSolver() const
-#else
 template <typename Scalar>
 Teuchos::RCP<const Thyra::NonlinearSolverBase<Scalar> >
 Piro::RythmosSolver<Scalar>::getTimeStepSolver() const
-#endif
 {
   return fwdTimeStepSolver;
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
-Piro::RythmosSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::get_p_space(int l) const
-#else
 template<typename Scalar>
 Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
 Piro::RythmosSolver<Scalar>::get_p_space(int l) const
-#endif
 {
   TEUCHOS_TEST_FOR_EXCEPTION(
       l >= num_p || l < 0,
@@ -565,15 +510,9 @@ Piro::RythmosSolver<Scalar>::get_p_space(int l) const
   return model->get_p_space(l);
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
-Piro::RythmosSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::get_g_space(int j) const
-#else
 template<typename Scalar>
 Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
 Piro::RythmosSolver<Scalar>::get_g_space(int j) const
-#endif
 {
   TEUCHOS_TEST_FOR_EXCEPTION(
       j > num_g || j < 0,
@@ -591,15 +530,9 @@ Piro::RythmosSolver<Scalar>::get_g_space(int j) const
   }
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Thyra::ModelEvaluatorBase::InArgs<Scalar>
-Piro::RythmosSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::getNominalValues() const
-#else
 template<typename Scalar>
 Thyra::ModelEvaluatorBase::InArgs<Scalar>
 Piro::RythmosSolver<Scalar>::getNominalValues() const
-#endif
 {
   Thyra::ModelEvaluatorBase::InArgs<Scalar> result = this->createInArgs();
   const Thyra::ModelEvaluatorBase::InArgs<Scalar> modelNominalValues = model->getNominalValues();
@@ -609,15 +542,9 @@ Piro::RythmosSolver<Scalar>::getNominalValues() const
   return result;
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Thyra::ModelEvaluatorBase::InArgs<Scalar>
-Piro::RythmosSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::createInArgs() const
-#else
 template <typename Scalar>
 Thyra::ModelEvaluatorBase::InArgs<Scalar>
 Piro::RythmosSolver<Scalar>::createInArgs() const
-#endif
 {
   Thyra::ModelEvaluatorBase::InArgsSetup<Scalar> inArgs;
   inArgs.setModelEvalDescription(this->description());
@@ -625,15 +552,9 @@ Piro::RythmosSolver<Scalar>::createInArgs() const
   return inArgs;
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Thyra::ModelEvaluatorBase::OutArgs<Scalar>
-Piro::RythmosSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::createOutArgsImpl() const
-#else
 template <typename Scalar>
 Thyra::ModelEvaluatorBase::OutArgs<Scalar>
 Piro::RythmosSolver<Scalar>::createOutArgsImpl() const
-#endif
 {
   Thyra::ModelEvaluatorBase::OutArgsSetup<Scalar> outArgs;
   outArgs.setModelEvalDescription(this->description());
@@ -703,13 +624,8 @@ Piro::RythmosSolver<Scalar>::createOutArgsImpl() const
   return outArgs;
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-void Piro::RythmosSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::evalModelImpl(
-#else
 template <typename Scalar>
 void Piro::RythmosSolver<Scalar>::evalModelImpl(
-#endif
     const Thyra::ModelEvaluatorBase::InArgs<Scalar>& inArgs,
     const Thyra::ModelEvaluatorBase::OutArgs<Scalar>& outArgs) const
 {
@@ -1027,15 +943,9 @@ void Piro::RythmosSolver<Scalar>::evalModelImpl(
   }
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Teuchos::RCP<Thyra::LinearOpBase<Scalar> >
-Piro::RythmosSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::create_DgDp_op_impl(int j, int l) const
-#else
 template <typename Scalar>
 Teuchos::RCP<Thyra::LinearOpBase<Scalar> >
 Piro::RythmosSolver<Scalar>::create_DgDp_op_impl(int j, int l) const
-#endif
 {
   TEUCHOS_ASSERT(j != num_g);
   const Teuchos::Array<Teuchos::RCP<const Thyra::LinearOpBase<Scalar> > > dummy =
@@ -1043,15 +953,9 @@ Piro::RythmosSolver<Scalar>::create_DgDp_op_impl(int j, int l) const
   return Teuchos::rcp(new Thyra::DefaultAddedLinearOp<Scalar>(dummy));
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Teuchos::RCP<const Teuchos::ParameterList>
-Piro::RythmosSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::getValidRythmosParameters() const
-#else
 template <typename Scalar>
 Teuchos::RCP<const Teuchos::ParameterList>
 Piro::RythmosSolver<Scalar>::getValidRythmosParameters() const
-#endif
 {
   Teuchos::RCP<Teuchos::ParameterList> validPL =
      Teuchos::rcp(new Teuchos::ParameterList("ValidRythmosParams"));
@@ -1091,15 +995,9 @@ Piro::RythmosSolver<Scalar>::getValidRythmosParameters() const
   return validPL;
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Teuchos::RCP<const Teuchos::ParameterList>
-Piro::RythmosSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::getValidRythmosSolverParameters() const
-#else
 template <typename Scalar>
 Teuchos::RCP<const Teuchos::ParameterList>
 Piro::RythmosSolver<Scalar>::getValidRythmosSolverParameters() const
-#endif
 {
   Teuchos::RCP<Teuchos::ParameterList> validPL =
     Teuchos::rcp(new Teuchos::ParameterList("ValidRythmosSolverParams"));;
@@ -1112,38 +1010,23 @@ Piro::RythmosSolver<Scalar>::getValidRythmosSolverParameters() const
   return validPL;
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-void Piro::RythmosSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-#else
 template <typename Scalar>
 void Piro::RythmosSolver<Scalar>::
-#endif
 addStepperFactory(const std::string & stepperName,const Teuchos::RCP<Piro::RythmosStepperFactory<Scalar> > & factory)
 {
   stepperFactories[stepperName] = factory;
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-void Piro::RythmosSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-#else
 template <typename Scalar>
 void Piro::RythmosSolver<Scalar>::
-#endif
 addStepControlFactory(const std::string & stepControlName,
                       const Teuchos::RCP<Piro::RythmosStepControlFactory<Scalar>> & step_control_strategy)
 {
   stepControlFactories[stepControlName] = step_control_strategy;
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Teuchos::RCP<Piro::RythmosSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node> >
-#else
 template <typename Scalar>
 Teuchos::RCP<Piro::RythmosSolver<Scalar> >
-#endif
 Piro::rythmosSolver(
     const Teuchos::RCP<Teuchos::ParameterList> &appParams,
     const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &in_model,
@@ -1155,11 +1038,7 @@ Piro::rythmosSolver(
         new ObserverToRythmosIntegrationObserverAdapter<Scalar>(piroObserver));
   }
 
-#ifdef ALBANY_BUILD
-  return Teuchos::rcp(new RythmosSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>(appParams, in_model, observer));
-#else
   return Teuchos::rcp(new RythmosSolver<Scalar>(appParams, in_model, observer));
-#endif
 
 }
 

--- a/packages/piro/src/Piro_SolverFactory.hpp
+++ b/packages/piro/src/Piro_SolverFactory.hpp
@@ -51,12 +51,6 @@
 #include "Teuchos_RCP.hpp"
 #include "Teuchos_ParameterList.hpp"
 
-#include "Kokkos_DefaultNode.hpp"
-#include "Tpetra_Map.hpp"
-
-using default_lo = Tpetra::Map<>::local_ordinal_type;
-using default_go = Tpetra::Map<>::global_ordinal_type;
-
 namespace Piro {
 
 /*! \brief Factory for creating Thyra-based %Piro solvers
@@ -76,19 +70,18 @@ public:
    *  - Piro::RythmosSolver (<tt>"Rythmos"</tt>)
    *  - Piro::VelocityVerletSolver (<tt>"Velocity Verlet"</tt>)
    *  - Piro::TrapezoidRuleSolver (<tt>"Trapezoid Rule"</tt>)
+   *  - Piro::TempusSolver (<tt>"Tempus"</tt>)
    *
    *  For Epetra-based models, additional options are available in Piro::Epetra::SolverFactory.
    */
-  template <typename Scalar, typename LocalOrdinal = default_lo, typename GlobalOrdinal = default_go,
-          typename Node = KokkosClassic::DefaultNode::DefaultNodeType>
+  template <typename Scalar>
   Teuchos::RCP<Thyra::ResponseOnlyModelEvaluatorBase<Scalar> > createSolver(
       const Teuchos::RCP<Teuchos::ParameterList> &piroParams,
       const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &model,
       const Teuchos::RCP<Thyra::AdaptiveSolutionManager> &solMgr,
       const Teuchos::RCP<Piro::ObserverBase<Scalar> > &observer = Teuchos::null);
 
-  template <typename Scalar, typename LocalOrdinal = default_lo, typename GlobalOrdinal = default_go,
-          typename Node = KokkosClassic::DefaultNode::DefaultNodeType>
+  template <typename Scalar>
   Teuchos::RCP<Thyra::ResponseOnlyModelEvaluatorBase<Scalar> > createSolver(
       const Teuchos::RCP<Teuchos::ParameterList> &piroParams,
       const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &model,

--- a/packages/piro/src/Piro_SolverFactory_Def.hpp
+++ b/packages/piro/src/Piro_SolverFactory_Def.hpp
@@ -51,13 +51,6 @@
 #include "Piro_TrapezoidRuleSolver.hpp"
 #endif /* HAVE_PIRO_NOX */
 
-
-// This "define" turns on the extended template interface in RythmosSolver and TempusSolver.
-// This should be cleaned up at some.
-#if defined(HAVE_PIRO_RYTHMOS) || defined(HAVE_PIRO_TEMPUS) 
-#define ALBANY_BUILD
-#endif
-
 #ifdef HAVE_PIRO_RYTHMOS
 // point.
 #include "Piro_RythmosSolver.hpp"
@@ -74,7 +67,7 @@
 
 namespace Piro {
 
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+template <typename Scalar>
 Teuchos::RCP<Thyra::ResponseOnlyModelEvaluatorBase<Scalar> > SolverFactory::createSolver(
     const Teuchos::RCP<Teuchos::ParameterList> &piroParams,
     const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &model,
@@ -90,11 +83,11 @@ Teuchos::RCP<Thyra::ResponseOnlyModelEvaluatorBase<Scalar> > SolverFactory::crea
     result = Teuchos::rcp(new NOXSolver<Scalar>(piroParams, model, observer));
   } else
   if (solverType == "Velocity Verlet") {
-    result = Teuchos::rcp(new VelocityVerletSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>(
+    result = Teuchos::rcp(new VelocityVerletSolver<Scalar>(
          piroParams, model, solMgr, observer));
   } else
   if (solverType == "Trapezoid Rule") {
-    result = Teuchos::rcp(new TrapezoidRuleSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>(
+    result = Teuchos::rcp(new TrapezoidRuleSolver<Scalar>(
         piroParams, model, solMgr, observer));
   } else
   if (solverType == "LOCA") {
@@ -106,12 +99,12 @@ Teuchos::RCP<Thyra::ResponseOnlyModelEvaluatorBase<Scalar> > SolverFactory::crea
 #endif /* HAVE_PIRO_NOX */
 #ifdef HAVE_PIRO_RYTHMOS
   if (solverType == "Rythmos") {
-    result = rythmosSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>(piroParams, model, observer);
+    result = rythmosSolver<Scalar>(piroParams, model, observer);
   } else
 #endif /* HAVE_PIRO_RYTHMOS */
 #ifdef HAVE_PIRO_TEMPUS
   if (solverType == "Tempus") {
-    result = tempusSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>(piroParams, model, observer);
+    result = tempusSolver<Scalar>(piroParams, model, observer);
   } else
 #endif /* HAVE_PIRO_TEMPUS */
   {
@@ -129,7 +122,7 @@ The below is DEPRECATED!
 Please do not use
 */
 
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+template <typename Scalar>
 Teuchos::RCP<Thyra::ResponseOnlyModelEvaluatorBase<Scalar> > SolverFactory::createSolver(
     const Teuchos::RCP<Teuchos::ParameterList> &piroParams,
     const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &model,
@@ -144,11 +137,11 @@ Teuchos::RCP<Thyra::ResponseOnlyModelEvaluatorBase<Scalar> > SolverFactory::crea
     result = Teuchos::rcp(new NOXSolver<Scalar>(piroParams, model, observer));
   } else
   if (solverType == "Velocity Verlet") {
-    result = Teuchos::rcp(new VelocityVerletSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>(
+    result = Teuchos::rcp(new VelocityVerletSolver<Scalar>( 
          piroParams, model, Teuchos::null, observer));
   } else
   if (solverType == "Trapezoid Rule") {
-    result = Teuchos::rcp(new TrapezoidRuleSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>(
+    result = Teuchos::rcp(new TrapezoidRuleSolver<Scalar>(
         piroParams, model, Teuchos::null, observer));
   } else
   if (solverType == "LOCA") {
@@ -157,12 +150,12 @@ Teuchos::RCP<Thyra::ResponseOnlyModelEvaluatorBase<Scalar> > SolverFactory::crea
 #endif /* HAVE_PIRO_NOX */
 #ifdef HAVE_PIRO_RYTHMOS
   if (solverType == "Rythmos") {
-    result = rythmosSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>(piroParams, model, observer);
+    result = rythmosSolver<Scalar>(piroParams, model, observer);
   } else
 #endif /* HAVE_PIRO_RYTHMOS */
 #ifdef HAVE_PIRO_TEMPUS
   if (solverType == "Tempus") {
-    result = tempusSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>(piroParams, model, observer);
+    result = tempusSolver<Scalar>(piroParams, model, observer);
   } else
 #endif /* HAVE_PIRO_TEMPUS */
   {

--- a/packages/piro/src/Piro_TempusSolver.hpp
+++ b/packages/piro/src/Piro_TempusSolver.hpp
@@ -53,6 +53,7 @@
 
 #include "Piro_TempusStepperFactory.hpp"
 #include "Piro_TempusStepControlFactory.hpp"
+#include "Piro_TransientSolver.hpp"
 
 // This "define" turns on the extended template interface in TempusSolver.
 // Is it necessary??
@@ -79,18 +80,20 @@ namespace Piro {
 #ifdef ALBANY_BUILD
 template <typename Scalar, typename LocalOrdinal = default_lo, typename GlobalOrdinal = default_go,
           typename Node = KokkosClassic::DefaultNode::DefaultNodeType>
+class TempusSolver
+    : public Piro::TransientSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node> 
 #else
 template <typename Scalar>
-#endif
 class TempusSolver
-    : public Thyra::ResponseOnlyModelEvaluatorBase<Scalar>
+    : public Piro::TransientSolver<Scalar> 
+#endif
 {
 public:
   /** \name Constructors/initializers */
   //@{
 
   /** \brief Initializes the internals, though the object is a blank slate. To initialize it call <code>initialize</code> */
-  TempusSolver();
+  //TempusSolver();
 
   /** \brief Initialize with internally built objects according to the given parameter list. */
   TempusSolver(
@@ -125,18 +128,6 @@ public:
   void initialize(
       const Teuchos::RCP<Teuchos::ParameterList> &appParams,
       const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &model);
-
-  /** \name Overridden from Thyra::ModelEvaluatorBase. */
-  //@{
-  /** \brief . */
-  Thyra::ModelEvaluatorBase::InArgs<Scalar> getNominalValues() const;
-  /** \brief . */
-  Thyra::ModelEvaluatorBase::InArgs<Scalar> createInArgs() const;
-  /** \brief . */
-  Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> > get_p_space(int l) const;
-  /** \brief . */
-  Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> > get_g_space(int j) const;
-  //@}
 
   void addStepperFactory(const std::string & stepperName,
                          const Teuchos::RCP<Piro::TempusStepperFactory<Scalar> > & stepperFactories);
@@ -191,16 +182,12 @@ public:
 private:
   /** \name Overridden from Thyra::ModelEvaluatorDefaultBase. */
   //@{
-  /** \brief . */
-  Thyra::ModelEvaluatorBase::OutArgs<Scalar> createOutArgsImpl() const;
 
   /** \brief . */
   void evalModelImpl(
       const Thyra::ModelEvaluatorBase::InArgs<Scalar>& inArgs,
       const Thyra::ModelEvaluatorBase::OutArgs<Scalar>& outArgs) const;
   //@}
-
-  Teuchos::RCP<Thyra::LinearOpBase<Scalar> > create_DgDp_op_impl(int j, int l) const;
 
   /** \brief . */
   Teuchos::RCP<const Teuchos::ParameterList> getValidTempusParameters() const;

--- a/packages/piro/src/Piro_TempusSolver.hpp
+++ b/packages/piro/src/Piro_TempusSolver.hpp
@@ -55,38 +55,17 @@
 #include "Piro_TempusStepControlFactory.hpp"
 #include "Piro_TransientSolver.hpp"
 
-// This "define" turns on the extended template interface in TempusSolver.
-// Is it necessary??
-#if defined(HAVE_PIRO_TEMPUS) 
-#define ALBANY_BUILD
-#endif
-
-#ifdef ALBANY_BUILD
-#include "Kokkos_DefaultNode.hpp"
-#endif
-
 #include <map>
 #include <string>
-
-#include "Tpetra_Map.hpp"
-using default_lo = Tpetra::Map<>::local_ordinal_type;
-using default_go = Tpetra::Map<>::global_ordinal_type;
 
 namespace Piro {
 
 /** \brief Thyra-based Model Evaluator for Tempus solves
  *  \ingroup Piro_Thyra_solver_grp
  * */
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal = default_lo, typename GlobalOrdinal = default_go,
-          typename Node = KokkosClassic::DefaultNode::DefaultNodeType>
-class TempusSolver
-    : public Piro::TransientSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node> 
-#else
 template <typename Scalar>
 class TempusSolver
     : public Piro::TransientSolver<Scalar> 
-#endif
 {
 public:
   /** \name Constructors/initializers */
@@ -236,14 +215,8 @@ private:
 };
 
 /** \brief Non-member constructor function */
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal = default_lo, typename GlobalOrdinal = default_go,
-          typename Node = KokkosClassic::DefaultNode::DefaultNodeType>
-Teuchos::RCP<TempusSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node> >
-#else
 template <typename Scalar>
 Teuchos::RCP<TempusSolver<Scalar> >
-#endif
 tempusSolver(
     const Teuchos::RCP<Teuchos::ParameterList> &appParams,
     const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &model,

--- a/packages/piro/src/Piro_TempusSolver_Def.hpp
+++ b/packages/piro/src/Piro_TempusSolver_Def.hpp
@@ -82,7 +82,7 @@
 #include <stdexcept>
 #include <iostream>
 
-#ifdef ALBANY_BUILD
+/*#ifdef ALBANY_BUILD
 template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
 Piro::TempusSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::TempusSolver() :
 #else
@@ -93,10 +93,10 @@ Piro::TempusSolver<Scalar>::TempusSolver() :
   isInitialized(false),
   abort_on_fail_at_min_dt_(false)
 {
-#ifdef DEBUT_OUTPUT
+#ifdef DEBUG_OUTPUT
   *out << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
 #endif
-}
+}*/
 
 #ifdef ALBANY_BUILD
 template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
@@ -109,13 +109,18 @@ Piro::TempusSolver<Scalar>::TempusSolver(
     const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &in_model,
     bool computeSensitivities,
     const Teuchos::RCP<Piro::ObserverBase<Scalar> > &piroObserver):
+#ifdef ALBANY_BUILD
+  TransientSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>(in_model), 
+#else
+  TransientSolver<Scalar>(in_model), 
+#endif
   computeSensitivities_(computeSensitivities),
   out(Teuchos::VerboseObjectBase::getDefaultOStream()),
   isInitialized(false),
   piroObserver_(piroObserver),
   supports_x_dotdot_(false)
 {
-#ifdef DEBUT_OUTPUT
+#ifdef DEBUG_OUTPUT
   *out << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
 #endif
   std::string jacobianSource = appParams->get("Jacobian Operator", "Have Jacobian");
@@ -142,7 +147,7 @@ void Piro::TempusSolver<Scalar>::initialize(
     const Teuchos::RCP<Teuchos::ParameterList> &appParams,
     const Teuchos::RCP< Thyra::ModelEvaluator<Scalar> > &in_model)
 {
-#ifdef DEBUT_OUTPUT
+#ifdef DEBUG_OUTPUT
   *out << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
 #endif
   using Teuchos::ParameterList;
@@ -362,6 +367,11 @@ Piro::TempusSolver<Scalar>::TempusSolver(
     Scalar finalTime,
     const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &icModel,
     Teuchos::EVerbosityLevel verbosityLevel) :
+#ifdef ALBANY_BUILD
+  TransientSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>(underlyingModel, icModel), 
+#else
+  TransientSolver<Scalar>(underlyingModel, icModel), 
+#endif
   fwdStateIntegrator(stateIntegrator),
   fwdStateStepper(stateStepper),
   fwdTimeStepSolver(timeStepSolver),
@@ -376,7 +386,7 @@ Piro::TempusSolver<Scalar>::TempusSolver(
   solnVerbLevel(verbosityLevel),
   isInitialized(true)
 {
-#ifdef DEBUT_OUTPUT
+#ifdef DEBUG_OUTPUT
   *out << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
 #endif
   if (fwdStateStepper->getModel() != underlyingModel) {
@@ -399,6 +409,11 @@ Piro::TempusSolver<Scalar>::TempusSolver(
     Scalar finalTime,
     const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &icModel,
     Teuchos::EVerbosityLevel verbosityLevel) :
+#ifdef ALBANY_BUILD
+  TransientSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>(underlyingModel, icModel), 
+#else
+  TransientSolver<Scalar>(underlyingModel, icModel), 
+#endif
   fwdStateIntegrator(stateIntegrator),
   fwdStateStepper(stateStepper),
   fwdTimeStepSolver(timeStepSolver),
@@ -413,7 +428,7 @@ Piro::TempusSolver<Scalar>::TempusSolver(
   solnVerbLevel(verbosityLevel),
   isInitialized(true)
 {
-#ifdef DEBUT_OUTPUT
+#ifdef DEBUG_OUTPUT
   *out << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
 #endif
   //IKT, 12/5/16: the following exception check is needed until setInitialCondition method
@@ -431,178 +446,6 @@ Piro::TempusSolver<Scalar>::TempusSolver(
 
 #ifdef ALBANY_BUILD
 template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
-Piro::TempusSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::get_p_space(int l) const
-#else
-template<typename Scalar>
-Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
-Piro::TempusSolver<Scalar>::get_p_space(int l) const
-#endif
-{
-#ifdef DEBUT_OUTPUT
-  *out << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
-#endif
-  TEUCHOS_TEST_FOR_EXCEPTION(
-      l >= num_p || l < 0,
-      Teuchos::Exceptions::InvalidParameter,
-      "\n Error in Piro::TempusSolver::get_p_map():  " <<
-      "Invalid parameter index l = " <<
-      l << "\n");
-
-  return model->get_p_space(l);
-}
-
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
-Piro::TempusSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::get_g_space(int j) const
-#else
-template<typename Scalar>
-Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
-Piro::TempusSolver<Scalar>::get_g_space(int j) const
-#endif
-{
-#ifdef DEBUT_OUTPUT
-  *out << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
-#endif
-  TEUCHOS_TEST_FOR_EXCEPTION(
-      j > num_g || j < 0,
-      Teuchos::Exceptions::InvalidParameter,
-      "\n Error in Piro::TempusSolver::get_g_map():  " <<
-      "Invalid response index j = " <<
-      j << "\n");
-
-  if (j < num_g) {
-    return model->get_g_space(j);
-  } else {
-    // j == num_g
-    return model->get_x_space();
-  }
-}
-
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Thyra::ModelEvaluatorBase::InArgs<Scalar>
-Piro::TempusSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::getNominalValues() const
-#else
-template<typename Scalar>
-Thyra::ModelEvaluatorBase::InArgs<Scalar>
-Piro::TempusSolver<Scalar>::getNominalValues() const
-#endif
-{
-#ifdef DEBUT_OUTPUT
-  *out << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
-#endif
-  Thyra::ModelEvaluatorBase::InArgs<Scalar> result = this->createInArgs();
-  const Thyra::ModelEvaluatorBase::InArgs<Scalar> modelNominalValues = model->getNominalValues();
-  for (int l = 0; l < num_p; ++l) {
-    result.set_p(l, modelNominalValues.get_p(l));
-  }
-  return result;
-}
-
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Thyra::ModelEvaluatorBase::InArgs<Scalar>
-Piro::TempusSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::createInArgs() const
-#else
-template <typename Scalar>
-Thyra::ModelEvaluatorBase::InArgs<Scalar>
-Piro::TempusSolver<Scalar>::createInArgs() const
-#endif
-{
-#ifdef DEBUT_OUTPUT
-  *out << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
-#endif
-  Thyra::ModelEvaluatorBase::InArgsSetup<Scalar> inArgs;
-  inArgs.setModelEvalDescription(this->description());
-  inArgs.set_Np(num_p);
-  return inArgs;
-}
-
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Thyra::ModelEvaluatorBase::OutArgs<Scalar>
-Piro::TempusSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::createOutArgsImpl() const
-#else
-template <typename Scalar>
-Thyra::ModelEvaluatorBase::OutArgs<Scalar>
-Piro::TempusSolver<Scalar>::createOutArgsImpl() const
-#endif
-{
-#ifdef DEBUT_OUTPUT
-  *out << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
-#endif
-  Thyra::ModelEvaluatorBase::OutArgsSetup<Scalar> outArgs;
-  outArgs.setModelEvalDescription(this->description());
-
-  // One additional response slot for the solution vector
-  outArgs.set_Np_Ng(num_p, num_g + 1);
-
-  const Thyra::ModelEvaluatorBase::OutArgs<Scalar> modelOutArgs = model->createOutArgs();
-
-  if (num_p > 0) {
-    // Only one parameter supported
-    const int l = 0;
-
-    if (Teuchos::nonnull(initialConditionModel)) {
-      const Thyra::ModelEvaluatorBase::OutArgs<Scalar> initCondOutArgs =
-        initialConditionModel->createOutArgs();
-      const Thyra::ModelEvaluatorBase::DerivativeSupport init_dxdp_support =
-        initCondOutArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDp, initCondOutArgs.Ng() - 1, l);
-      if (!init_dxdp_support.supports(Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM)) {
-        // Ok to return early since only one parameter supported
-        return outArgs;
-      }
-    }
-
-    // Computing the DxDp sensitivity for a transient problem currently requires the evaluation of
-    // the mutilivector-based, Jacobian-oriented DfDp derivatives of the underlying transient model.
-    const Thyra::ModelEvaluatorBase::DerivativeSupport model_dfdp_support =
-      modelOutArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DfDp, l);
-    if (!model_dfdp_support.supports(Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM)) {
-      // Ok to return early since only one parameter supported
-      return outArgs;
-    }
-
-    // Solution sensitivity
-    outArgs.setSupports(
-        Thyra::ModelEvaluatorBase::OUT_ARG_DgDp,
-        num_g,
-        l,
-        Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM);
-
-    if (num_g > 0) {
-      // Only one response supported
-      const int j = 0;
-
-      const Thyra::ModelEvaluatorBase::DerivativeSupport model_dgdx_support =
-        modelOutArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDx, j);
-      if (!model_dgdx_support.none()) {
-        const Thyra::ModelEvaluatorBase::DerivativeSupport model_dgdp_support =
-          modelOutArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDp, j, l);
-        // Response sensitivity
-        Thyra::ModelEvaluatorBase::DerivativeSupport dgdp_support;
-        if (model_dgdp_support.supports(Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM)) {
-          dgdp_support.plus(Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM);
-        }
-        if (model_dgdp_support.supports(Thyra::ModelEvaluatorBase::DERIV_LINEAR_OP)) {
-          dgdp_support.plus(Thyra::ModelEvaluatorBase::DERIV_LINEAR_OP);
-        }
-        outArgs.setSupports(
-            Thyra::ModelEvaluatorBase::OUT_ARG_DgDp,
-            j,
-            l,
-            dgdp_support);
-      }
-    }
-  }
-
-  return outArgs;
-}
-
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
 void Piro::TempusSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::evalModelImpl(
 #else
 template <typename Scalar>
@@ -611,7 +454,7 @@ void Piro::TempusSolver<Scalar>::evalModelImpl(
     const Thyra::ModelEvaluatorBase::InArgs<Scalar>& inArgs,
     const Thyra::ModelEvaluatorBase::OutArgs<Scalar>& outArgs) const
 {
-#ifdef DEBUT_OUTPUT
+#ifdef DEBUG_OUTPUT
   *out << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
 #endif
   using Teuchos::RCP;
@@ -806,21 +649,6 @@ void Piro::TempusSolver<Scalar>::evalModelImpl(
   }
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Teuchos::RCP<Thyra::LinearOpBase<Scalar> >
-Piro::TempusSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::create_DgDp_op_impl(int j, int l) const
-#else
-template <typename Scalar>
-Teuchos::RCP<Thyra::LinearOpBase<Scalar> >
-Piro::TempusSolver<Scalar>::create_DgDp_op_impl(int j, int l) const
-#endif
-{
-  TEUCHOS_ASSERT(j != num_g);
-  const Teuchos::Array<Teuchos::RCP<const Thyra::LinearOpBase<Scalar> > > dummy =
-    Teuchos::tuple(Thyra::zero<Scalar>(this->get_g_space(j), this->get_p_space(l)));
-  return Teuchos::rcp(new Thyra::DefaultAddedLinearOp<Scalar>(dummy));
-}
 
 #ifdef ALBANY_BUILD
 template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
@@ -1080,7 +908,7 @@ Piro::tempusSolver(
     const Teuchos::RCP<Piro::ObserverBase<Scalar> > &piroObserver)
 {
   Teuchos::RCP<Teuchos::FancyOStream> out(Teuchos::VerboseObjectBase::getDefaultOStream());
-#ifdef DEBUT_OUTPUT
+#ifdef DEBUG_OUTPUT
   *out << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
 #endif
    bool computeSensitivities = true;

--- a/packages/piro/src/Piro_TempusSolver_Def.hpp
+++ b/packages/piro/src/Piro_TempusSolver_Def.hpp
@@ -82,38 +82,13 @@
 #include <stdexcept>
 #include <iostream>
 
-/*#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Piro::TempusSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::TempusSolver() :
-#else
-template <typename Scalar>
-Piro::TempusSolver<Scalar>::TempusSolver() :
-#endif
-  out(Teuchos::VerboseObjectBase::getDefaultOStream()),
-  isInitialized(false),
-  abort_on_fail_at_min_dt_(false)
-{
-#ifdef DEBUG_OUTPUT
-  *out << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
-#endif
-}*/
-
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Piro::TempusSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::TempusSolver(
-#else
 template <typename Scalar>
 Piro::TempusSolver<Scalar>::TempusSolver(
-#endif
     const Teuchos::RCP<Teuchos::ParameterList> &appParams,
     const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &in_model,
     bool computeSensitivities,
     const Teuchos::RCP<Piro::ObserverBase<Scalar> > &piroObserver):
-#ifdef ALBANY_BUILD
-  TransientSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>(in_model), 
-#else
   TransientSolver<Scalar>(in_model), 
-#endif
   computeSensitivities_(computeSensitivities),
   out(Teuchos::VerboseObjectBase::getDefaultOStream()),
   isInitialized(false),
@@ -137,13 +112,8 @@ Piro::TempusSolver<Scalar>::TempusSolver(
     initialize(appParams, in_model);
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-void Piro::TempusSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::initialize(
-#else
 template <typename Scalar>
 void Piro::TempusSolver<Scalar>::initialize(
-#endif
     const Teuchos::RCP<Teuchos::ParameterList> &appParams,
     const Teuchos::RCP< Thyra::ModelEvaluator<Scalar> > &in_model)
 {
@@ -245,19 +215,11 @@ void Piro::TempusSolver<Scalar>::initialize(
 
 #ifdef HAVE_PIRO_IFPACK2
     typedef Thyra::PreconditionerFactoryBase<double> Base;
-#ifdef ALBANY_BUILD
-    typedef Thyra::Ifpack2PreconditionerFactory<Tpetra::CrsMatrix<double, LocalOrdinal, GlobalOrdinal, Node> > Impl;
-#else
     typedef Thyra::Ifpack2PreconditionerFactory<Tpetra::CrsMatrix<double> > Impl;
-#endif
     linearSolverBuilder.setPreconditioningStrategyFactory(Teuchos::abstractFactoryStd<Base, Impl>(), "Ifpack2");
 #endif
 #ifdef HAVE_PIRO_MUELU
-#ifdef ALBANY_BUILD
-    Stratimikos::enableMueLu<LocalOrdinal, GlobalOrdinal, Node>(linearSolverBuilder);
-#else
     Stratimikos::enableMueLu(linearSolverBuilder);
-#endif
 #endif
 
     linearSolverBuilder.setParameterList(sublist(tempusPL, "Stratimikos", true));
@@ -294,11 +256,7 @@ void Piro::TempusSolver<Scalar>::initialize(
       }
       else {
         Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > origModel = model;
-#ifdef ALBANY_BUILD
-        model = Teuchos::rcp(new Piro::InvertMassMatrixDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node>(
-#else
         model = Teuchos::rcp(new Piro::InvertMassMatrixDecorator<Scalar>(
-#endif
         sublist(tempusPL,"Stratimikos", true), origModel, true, tempusPL->get("Lump Mass Matrix", false),false));
       }
     }
@@ -314,12 +272,8 @@ void Piro::TempusSolver<Scalar>::initialize(
       }
       else {
         Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > origModel = model;
-#ifdef ALBANY_BUILD
-        model = Teuchos::rcp(new Piro::InvertMassMatrixDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node>(
-#else
         model = Teuchos::rcp(new Piro::InvertMassMatrixDecorator<Scalar>(
-#endif
-        sublist(tempusPL,"Stratimikos", true), origModel, true, tempusPL->get("Lump Mass Matrix", false),true));
+          sublist(tempusPL,"Stratimikos", true), origModel, true, tempusPL->get("Lump Mass Matrix", false),true));
       }
     }
     // C.2) Create the Thyra-wrapped ModelEvaluator
@@ -353,13 +307,8 @@ void Piro::TempusSolver<Scalar>::initialize(
   isInitialized = true;
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Piro::TempusSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::TempusSolver(
-#else
 template <typename Scalar>
 Piro::TempusSolver<Scalar>::TempusSolver(
-#endif
     const Teuchos::RCP<Tempus::IntegratorBasic<Scalar> > &stateIntegrator,
     const Teuchos::RCP<Tempus::Stepper<Scalar> > &stateStepper,
     const Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > &timeStepSolver,
@@ -367,11 +316,7 @@ Piro::TempusSolver<Scalar>::TempusSolver(
     Scalar finalTime,
     const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &icModel,
     Teuchos::EVerbosityLevel verbosityLevel) :
-#ifdef ALBANY_BUILD
-  TransientSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>(underlyingModel, icModel), 
-#else
   TransientSolver<Scalar>(underlyingModel, icModel), 
-#endif
   fwdStateIntegrator(stateIntegrator),
   fwdStateStepper(stateStepper),
   fwdTimeStepSolver(timeStepSolver),
@@ -394,13 +339,8 @@ Piro::TempusSolver<Scalar>::TempusSolver(
   }
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Piro::TempusSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::TempusSolver(
-#else
 template <typename Scalar>
 Piro::TempusSolver<Scalar>::TempusSolver(
-#endif
     const Teuchos::RCP<Tempus::IntegratorBasic<Scalar> > &stateIntegrator,
     const Teuchos::RCP<Tempus::Stepper<Scalar> > &stateStepper,
     const Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > &timeStepSolver,
@@ -409,11 +349,7 @@ Piro::TempusSolver<Scalar>::TempusSolver(
     Scalar finalTime,
     const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &icModel,
     Teuchos::EVerbosityLevel verbosityLevel) :
-#ifdef ALBANY_BUILD
-  TransientSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>(underlyingModel, icModel), 
-#else
   TransientSolver<Scalar>(underlyingModel, icModel), 
-#endif
   fwdStateIntegrator(stateIntegrator),
   fwdStateStepper(stateStepper),
   fwdTimeStepSolver(timeStepSolver),
@@ -444,13 +380,8 @@ Piro::TempusSolver<Scalar>::TempusSolver(
   }
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-void Piro::TempusSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::evalModelImpl(
-#else
 template <typename Scalar>
 void Piro::TempusSolver<Scalar>::evalModelImpl(
-#endif
     const Thyra::ModelEvaluatorBase::InArgs<Scalar>& inArgs,
     const Thyra::ModelEvaluatorBase::OutArgs<Scalar>& outArgs) const
 {
@@ -650,15 +581,9 @@ void Piro::TempusSolver<Scalar>::evalModelImpl(
 }
 
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Teuchos::RCP<const Teuchos::ParameterList>
-Piro::TempusSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::getValidTempusParameters() const
-#else
 template <typename Scalar>
 Teuchos::RCP<const Teuchos::ParameterList>
 Piro::TempusSolver<Scalar>::getValidTempusParameters() const
-#endif
 {
   Teuchos::RCP<Teuchos::ParameterList> validPL =
     Teuchos::rcp(new Teuchos::ParameterList("ValidTempusSolverParams"));
@@ -684,38 +609,23 @@ Piro::TempusSolver<Scalar>::getValidTempusParameters() const
   return validPL;
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-void Piro::TempusSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-#else
 template <typename Scalar>
 void Piro::TempusSolver<Scalar>::
-#endif
 addStepperFactory(const std::string & stepperName,const Teuchos::RCP<Piro::TempusStepperFactory<Scalar> > & factory)
 {
   stepperFactories[stepperName] = factory;
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-void Piro::TempusSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-#else
 template <typename Scalar>
 void Piro::TempusSolver<Scalar>::
-#endif
 addStepControlFactory(const std::string & stepControlName,
                       const Teuchos::RCP<Piro::TempusStepControlFactory<Scalar>> & step_control_strategy)
 {
   stepControlFactories[stepControlName] = step_control_strategy;
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-void Piro::TempusSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-#else
 template <typename Scalar>
 void Piro::TempusSolver<Scalar>::
-#endif
 setStartTime(const Scalar start_time)
 {
   Teuchos::RCP<const Tempus::TimeStepControl<Scalar> > tsc_const = fwdStateIntegrator->getTimeStepControl();
@@ -723,13 +633,8 @@ setStartTime(const Scalar start_time)
   tsc->setInitTime(start_time); 
 } 
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Scalar Piro::TempusSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-#else
 template <typename Scalar>
 Scalar Piro::TempusSolver<Scalar>::
-#endif
 getStartTime() const
 {
   Teuchos::RCP<const Tempus::TimeStepControl<Scalar> > tsc = fwdStateIntegrator->getTimeStepControl();
@@ -737,13 +642,8 @@ getStartTime() const
   return start_time; 
 } 
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-void Piro::TempusSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-#else
 template <typename Scalar>
 void Piro::TempusSolver<Scalar>::
-#endif
 setFinalTime(const Scalar final_time)
 {
   Teuchos::RCP<const Tempus::TimeStepControl<Scalar> > tsc_const = fwdStateIntegrator->getTimeStepControl();
@@ -752,13 +652,8 @@ setFinalTime(const Scalar final_time)
   tsc->setFinalTime(final_time); 
 } 
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Scalar Piro::TempusSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-#else
 template <typename Scalar>
 Scalar Piro::TempusSolver<Scalar>::
-#endif
 getFinalTime() const
 {
   Teuchos::RCP<const Tempus::TimeStepControl<Scalar> > tsc = fwdStateIntegrator->getTimeStepControl();
@@ -766,13 +661,8 @@ getFinalTime() const
   return final_time; 
 } 
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-void Piro::TempusSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-#else
 template <typename Scalar>
 void Piro::TempusSolver<Scalar>::
-#endif
 setInitTimeStep(const Scalar init_time_step)
 {
   Teuchos::RCP<const Tempus::TimeStepControl<Scalar> > tsc_const = fwdStateIntegrator->getTimeStepControl();
@@ -781,26 +671,16 @@ setInitTimeStep(const Scalar init_time_step)
 } 
 
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Scalar Piro::TempusSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-#else
 template <typename Scalar>
 Scalar Piro::TempusSolver<Scalar>::
-#endif
 getInitTimeStep() const
 {
   Teuchos::RCP<const Tempus::TimeStepControl<Scalar> > tsc = fwdStateIntegrator->getTimeStepControl();
   auto init_time_step = tsc->getInitTimeStep(); 
   return init_time_step; 
 } 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-void Piro::TempusSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-#else
 template <typename Scalar>
 void Piro::TempusSolver<Scalar>::
-#endif
 setObserver()
 {
   Teuchos::RCP<Tempus::IntegratorObserverBasic<Scalar> > observer = Teuchos::null;
@@ -822,13 +702,8 @@ setObserver()
   }
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-void Piro::TempusSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-#else
 template <typename Scalar>
 void Piro::TempusSolver<Scalar>::
-#endif
 setInitialState(Scalar t0,
       Teuchos::RCP<Thyra::VectorBase<Scalar> > x0,
       Teuchos::RCP<Thyra::VectorBase<Scalar> > xdot0,
@@ -841,26 +716,16 @@ setInitialState(Scalar t0,
  
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-void Piro::TempusSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-#else
 template <typename Scalar>
 void Piro::TempusSolver<Scalar>::
-#endif
 setInitialGuess(Teuchos::RCP< const Thyra::VectorBase<Scalar> > initial_guess) 
 {
    fwdStateStepper->setInitialGuess(initial_guess); 
    fwdStateStepper->initialize();
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Teuchos::RCP<Tempus::SolutionHistory<Scalar> > Piro::TempusSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-#else
 template <typename Scalar>
 Teuchos::RCP<Tempus::SolutionHistory<Scalar> > Piro::TempusSolver<Scalar>::
-#endif
 getSolutionHistory() const
 {
   Teuchos::RCP<const Tempus::SolutionHistory<Scalar> > soln_history_const = fwdStateIntegrator->getSolutionHistory();
@@ -869,39 +734,24 @@ getSolutionHistory() const
 }
   
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > Piro::TempusSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-#else
 template <typename Scalar>
 Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> > Piro::TempusSolver<Scalar>::
-#endif
 getSolver() const
 {
   return fwdStateStepper->getSolver(); 
 }
 
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Tempus::Status Piro::TempusSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
-#else
 template <typename Scalar>
 Tempus::Status Piro::TempusSolver<Scalar>::
-#endif
 getTempusIntegratorStatus() const
 {
   return fwdStateIntegrator->getStatus(); 
 }
 
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Teuchos::RCP<Piro::TempusSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node> >
-#else
 template <typename Scalar>
 Teuchos::RCP<Piro::TempusSolver<Scalar> >
-#endif
 Piro::tempusSolver(
     const Teuchos::RCP<Teuchos::ParameterList> &appParams,
     const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &in_model,
@@ -918,10 +768,6 @@ Piro::tempusSolver(
        computeSensitivities = analysisPL.get<bool>("Compute Sensitivities");
    }
 
-#ifdef ALBANY_BUILD
-  return Teuchos::rcp(new TempusSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>(appParams, in_model, computeSensitivities, piroObserver));
-#else
   return Teuchos::rcp(new TempusSolver<Scalar>(appParams, in_model, computeSensitivities, piroObserver));
-#endif
 
 }

--- a/packages/piro/src/Piro_TransientDecorator.hpp
+++ b/packages/piro/src/Piro_TransientDecorator.hpp
@@ -51,7 +51,7 @@
 
 namespace Piro {
 
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+template <typename Scalar>
 class TransientDecorator
     : public Thyra::ModelEvaluatorDefaultBase<Scalar> {
 

--- a/packages/piro/src/Piro_TransientSolver.hpp
+++ b/packages/piro/src/Piro_TransientSolver.hpp
@@ -1,0 +1,139 @@
+// @HEADER
+// ************************************************************************
+//
+//        Piro: Strategy package for embedded analysis capabilitites
+//                  Copyright (2010) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Andy Salinger (agsalin@sandia.gov), Sandia
+// National Laboratories.
+//
+// ************************************************************************
+// @HEADER
+
+#ifndef PIRO_TRANSIENTSOLVER_H
+#define PIRO_TRANSIENTSOLVER_H
+
+#include "Piro_ConfigDefs.hpp"
+#include "Thyra_ResponseOnlyModelEvaluatorBase.hpp"
+
+// This "define" turns on the extended template interface in TransientSolver.
+// Is it necessary??
+#if defined(HAVE_PIRO_TEMPUS) 
+#define ALBANY_BUILD
+#endif
+
+#ifdef ALBANY_BUILD
+#include "Kokkos_DefaultNode.hpp"
+#endif
+
+#include <map>
+#include <string>
+
+#include "Tpetra_Map.hpp" 
+using default_lo = Tpetra::Map<>::local_ordinal_type;
+using default_go = Tpetra::Map<>::global_ordinal_type;
+
+namespace Piro {
+
+/** \brief Thyra-based Model Evaluator for Tempus solves using Tempus
+ * */
+#ifdef ALBANY_BUILD
+template <typename Scalar, typename LocalOrdinal = default_lo, typename GlobalOrdinal = default_go,
+          typename Node = KokkosClassic::DefaultNode::DefaultNodeType>
+#else
+template <typename Scalar>
+#endif
+class TransientSolver
+    : public Thyra::ResponseOnlyModelEvaluatorBase<Scalar>
+{
+public:
+  /** \name Constructors/initializers */
+  //@{
+  /** \brief . */
+  explicit TransientSolver(const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >&model, 
+      const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &initialConditionModel = Teuchos::null); 
+
+  /** \brief . */
+  TransientSolver(
+      const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &model,
+      int numParameters, 
+      const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &initialConditionModel = Teuchos::null); 
+  //@}
+
+  /** \name Overridden from Thyra::ModelEvaluatorBase. */
+  //@{
+  /** \brief . */
+  Thyra::ModelEvaluatorBase::InArgs<Scalar> getNominalValues() const;
+  /** \brief . */
+  Thyra::ModelEvaluatorBase::InArgs<Scalar> createInArgs() const;
+  /** \brief . */
+  Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> > get_p_space(int l) const;
+  /** \brief . */
+  Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> > get_g_space(int j) const;
+  //@}
+
+protected:
+  /** \name Service methods for subclasses. */
+  //@{
+
+  /** \brief . */
+  void evalConvergedModel(
+      const Thyra::ModelEvaluatorBase::InArgs<Scalar>& modelInArgs,
+      const Thyra::ModelEvaluatorBase::OutArgs<Scalar>& outArgs) const;
+  //@}
+
+
+private:
+  /** \name Overridden from Thyra::ModelEvaluatorDefaultBase. */
+  //@{
+  /** \brief . */
+  Thyra::ModelEvaluatorBase::OutArgs<Scalar> createOutArgsImpl() const;
+
+  Teuchos::RCP<Thyra::LinearOpBase<Scalar> > create_DgDp_op_impl(int j, int l) const;
+
+  Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > model_;
+
+  int num_p_;
+  int num_g_;
+
+  Teuchos::RCP<Teuchos::FancyOStream> out;
+  Teuchos::EVerbosityLevel solnVerbLevel;
+  Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > initialConditionModel_;
+
+
+};
+
+}
+
+#include "Piro_TransientSolver_Def.hpp"
+#endif

--- a/packages/piro/src/Piro_TransientSolver.hpp
+++ b/packages/piro/src/Piro_TransientSolver.hpp
@@ -46,33 +46,14 @@
 #include "Piro_ConfigDefs.hpp"
 #include "Thyra_ResponseOnlyModelEvaluatorBase.hpp"
 
-// This "define" turns on the extended template interface in TransientSolver.
-// Is it necessary??
-#if defined(HAVE_PIRO_TEMPUS) 
-#define ALBANY_BUILD
-#endif
-
-#ifdef ALBANY_BUILD
-#include "Kokkos_DefaultNode.hpp"
-#endif
-
 #include <map>
 #include <string>
-
-#include "Tpetra_Map.hpp" 
-using default_lo = Tpetra::Map<>::local_ordinal_type;
-using default_go = Tpetra::Map<>::global_ordinal_type;
 
 namespace Piro {
 
 /** \brief Thyra-based Model Evaluator for Tempus solves using Tempus
  * */
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal = default_lo, typename GlobalOrdinal = default_go,
-          typename Node = KokkosClassic::DefaultNode::DefaultNodeType>
-#else
 template <typename Scalar>
-#endif
 class TransientSolver
     : public Thyra::ResponseOnlyModelEvaluatorBase<Scalar>
 {

--- a/packages/piro/src/Piro_TransientSolver.hpp
+++ b/packages/piro/src/Piro_TransientSolver.hpp
@@ -102,14 +102,12 @@ private:
 
   Teuchos::RCP<Thyra::LinearOpBase<Scalar> > create_DgDp_op_impl(int j, int l) const;
 
+  Teuchos::RCP<Teuchos::FancyOStream> out;
   Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > model_;
+  Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > initialConditionModel_;
 
   int num_p_;
   int num_g_;
-
-  Teuchos::RCP<Teuchos::FancyOStream> out;
-  Teuchos::EVerbosityLevel solnVerbLevel;
-  Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > initialConditionModel_;
 
 
 };

--- a/packages/piro/src/Piro_TransientSolver_Def.hpp
+++ b/packages/piro/src/Piro_TransientSolver_Def.hpp
@@ -1,0 +1,308 @@
+// @HEADER
+// ************************************************************************
+//
+//        Piro: Strategy package for embedded analysis capabilitites
+//                  Copyright (2010) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Andy Salinger (agsalin@sandia.gov), Sandia
+// National Laboratories.
+//
+// ************************************************************************
+// @HEADER
+
+#include "Piro_TransientSolver.hpp"
+
+#include "Teuchos_ScalarTraits.hpp"
+#include "Teuchos_Array.hpp"
+#include "Teuchos_Tuple.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_Assert.hpp"
+
+#include "Thyra_DefaultAddedLinearOp.hpp"
+#include "Thyra_DefaultMultipliedLinearOp.hpp"
+#include "Thyra_DefaultZeroLinearOp.hpp"
+#include "Thyra_VectorStdOps.hpp"
+#include "Thyra_DefaultModelEvaluatorWithSolveFactory.hpp"
+
+#define DEBUG_OUTPUT
+
+#include <string>
+#include <stdexcept>
+#include <iostream>
+
+#ifdef ALBANY_BUILD
+template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+Piro::TransientSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::TransientSolver(
+#else
+template <typename Scalar>
+Piro::TransientSolver<Scalar>::TransientSolver(
+#endif
+  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &model, 
+  const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &icModel):
+  out(Teuchos::VerboseObjectBase::getDefaultOStream()),
+  model_(model), 
+  initialConditionModel_(icModel),
+  num_p_(model->Np()), 
+  num_g_(model->Ng())
+{
+#ifdef DEBUG_OUTPUT
+  *out << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
+#endif
+}
+
+#ifdef ALBANY_BUILD
+template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+Piro::TransientSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::TransientSolver(
+#else
+template <typename Scalar>
+Piro::TransientSolver<Scalar>::TransientSolver(
+#endif
+    const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &model, int numParameters, 
+    const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &icModel) : 
+    out(Teuchos::VerboseObjectBase::getDefaultOStream()),
+    model_(model),
+    initialConditionModel_(icModel),
+    num_p_(numParameters),
+    num_g_(model->Ng())
+{
+#ifdef DEBUG_OUTPUT
+  *out << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
+#endif
+}
+
+#ifdef ALBANY_BUILD
+template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
+Piro::TransientSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::get_p_space(int l) const
+#else
+template<typename Scalar>
+Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
+Piro::TransientSolver<Scalar>::get_p_space(int l) const
+#endif
+{
+#ifdef DEBUG_OUTPUT
+  *out << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
+#endif
+  TEUCHOS_TEST_FOR_EXCEPTION(
+      l >= num_p_ || l < 0,
+      Teuchos::Exceptions::InvalidParameter,
+      "\n Error in Piro::TransientSolver::get_p_map():  " <<
+      "Invalid parameter index l = " <<
+      l << "\n");
+
+  return model_->get_p_space(l);
+}
+
+#ifdef ALBANY_BUILD
+template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
+Piro::TransientSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::get_g_space(int j) const
+#else
+template<typename Scalar>
+Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
+Piro::TransientSolver<Scalar>::get_g_space(int j) const
+#endif
+{
+#ifdef DEBUG_OUTPUT
+  *out << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
+#endif
+  TEUCHOS_TEST_FOR_EXCEPTION(
+      j > num_g_ || j < 0,
+      Teuchos::Exceptions::InvalidParameter,
+      "\n Error in Piro::TransientSolver::get_g_map():  " <<
+      "Invalid response index j = " <<
+      j << "\n");
+
+  if (j < num_g_) {
+    return model_->get_g_space(j);
+  } else {
+    // j == num_g_
+    return model_->get_x_space();
+  }
+}
+
+#ifdef ALBANY_BUILD
+template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+Thyra::ModelEvaluatorBase::InArgs<Scalar>
+Piro::TransientSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::getNominalValues() const
+#else
+template<typename Scalar>
+Thyra::ModelEvaluatorBase::InArgs<Scalar>
+Piro::TransientSolver<Scalar>::getNominalValues() const
+#endif
+{
+#ifdef DEBUG_OUTPUT
+  *out << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
+#endif
+  Thyra::ModelEvaluatorBase::InArgs<Scalar> result = this->createInArgs();
+  const Thyra::ModelEvaluatorBase::InArgs<Scalar> modelNominalValues = model_->getNominalValues();
+  for (int l = 0; l < num_p_; ++l) {
+    result.set_p(l, modelNominalValues.get_p(l));
+  }
+  return result;
+}
+
+#ifdef ALBANY_BUILD
+template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+Thyra::ModelEvaluatorBase::InArgs<Scalar>
+Piro::TransientSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::createInArgs() const
+#else
+template <typename Scalar>
+Thyra::ModelEvaluatorBase::InArgs<Scalar>
+Piro::TransientSolver<Scalar>::createInArgs() const
+#endif
+{
+#ifdef DEBUG_OUTPUT
+  *out << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
+#endif
+  Thyra::ModelEvaluatorBase::InArgsSetup<Scalar> inArgs;
+  inArgs.setModelEvalDescription(this->description());
+  inArgs.set_Np(num_p_);
+  return inArgs;
+}
+
+#ifdef ALBANY_BUILD
+template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+Thyra::ModelEvaluatorBase::OutArgs<Scalar>
+Piro::TransientSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::createOutArgsImpl() const
+#else
+template <typename Scalar>
+Thyra::ModelEvaluatorBase::OutArgs<Scalar>
+Piro::TransientSolver<Scalar>::createOutArgsImpl() const
+#endif
+{
+#ifdef DEBUG_OUTPUT
+  *out << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
+#endif
+  Thyra::ModelEvaluatorBase::OutArgsSetup<Scalar> outArgs;
+  outArgs.setModelEvalDescription(this->description());
+
+  // One additional response slot for the solution vector
+  outArgs.set_Np_Ng(num_p_, num_g_ + 1);
+
+  const Thyra::ModelEvaluatorBase::OutArgs<Scalar> modelOutArgs = model_->createOutArgs();
+
+  if (num_p_ > 0) {
+    // Only one parameter supported
+    const int l = 0;
+
+    if (Teuchos::nonnull(initialConditionModel_)) {
+      const Thyra::ModelEvaluatorBase::OutArgs<Scalar> initCondOutArgs =
+        initialConditionModel_->createOutArgs();
+      const Thyra::ModelEvaluatorBase::DerivativeSupport init_dxdp_support =
+        initCondOutArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDp, initCondOutArgs.Ng() - 1, l);
+      if (!init_dxdp_support.supports(Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM)) {
+        // Ok to return early since only one parameter supported
+        return outArgs;
+      }
+    }
+
+    // Computing the DxDp sensitivity for a transient problem currently requires the evaluation of
+    // the mutilivector-based, Jacobian-oriented DfDp derivatives of the underlying transient model.
+    const Thyra::ModelEvaluatorBase::DerivativeSupport model_dfdp_support =
+      modelOutArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DfDp, l);
+    if (!model_dfdp_support.supports(Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM)) {
+      // Ok to return early since only one parameter supported
+      return outArgs;
+    }
+
+    // Solution sensitivity
+    outArgs.setSupports(
+        Thyra::ModelEvaluatorBase::OUT_ARG_DgDp,
+        num_g_,
+        l,
+        Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM);
+
+    if (num_g_ > 0) {
+      // Only one response supported
+      const int j = 0;
+
+      const Thyra::ModelEvaluatorBase::DerivativeSupport model_dgdx_support =
+        modelOutArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDx, j);
+      if (!model_dgdx_support.none()) {
+        const Thyra::ModelEvaluatorBase::DerivativeSupport model_dgdp_support =
+          modelOutArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDp, j, l);
+        // Response sensitivity
+        Thyra::ModelEvaluatorBase::DerivativeSupport dgdp_support;
+        if (model_dgdp_support.supports(Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM)) {
+          dgdp_support.plus(Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM);
+        }
+        if (model_dgdp_support.supports(Thyra::ModelEvaluatorBase::DERIV_LINEAR_OP)) {
+          dgdp_support.plus(Thyra::ModelEvaluatorBase::DERIV_LINEAR_OP);
+        }
+        outArgs.setSupports(
+            Thyra::ModelEvaluatorBase::OUT_ARG_DgDp,
+            j,
+            l,
+            dgdp_support);
+      }
+    }
+  }
+
+  return outArgs;
+}
+
+
+#ifdef ALBANY_BUILD
+template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+Teuchos::RCP<Thyra::LinearOpBase<Scalar> >
+Piro::TransientSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::create_DgDp_op_impl(int j, int l) const
+#else
+template <typename Scalar>
+Teuchos::RCP<Thyra::LinearOpBase<Scalar> >
+Piro::TransientSolver<Scalar>::create_DgDp_op_impl(int j, int l) const
+#endif
+{
+  TEUCHOS_ASSERT(j != num_g_);
+  const Teuchos::Array<Teuchos::RCP<const Thyra::LinearOpBase<Scalar> > > dummy =
+    Teuchos::tuple(Thyra::zero<Scalar>(this->get_g_space(j), this->get_p_space(l)));
+  return Teuchos::rcp(new Thyra::DefaultAddedLinearOp<Scalar>(dummy));
+}
+
+#ifdef ALBANY_BUILD
+template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+void 
+Piro::TransientSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::evalConvergedModel(
+#else
+template <typename Scalar>
+void 
+Piro::TransientSolver<Scalar>::evalConvergedModel(
+#endif
+      const Thyra::ModelEvaluatorBase::InArgs<Scalar>& modelInArgs,
+      const Thyra::ModelEvaluatorBase::OutArgs<Scalar>& outArgs) const
+{
+#ifdef DEBUG_OUTPUT
+  *out << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
+#endif
+  //IKT FIXME: FILL IN! 
+}

--- a/packages/piro/src/Piro_TransientSolver_Def.hpp
+++ b/packages/piro/src/Piro_TransientSolver_Def.hpp
@@ -60,13 +60,8 @@
 #include <stdexcept>
 #include <iostream>
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Piro::TransientSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::TransientSolver(
-#else
 template <typename Scalar>
 Piro::TransientSolver<Scalar>::TransientSolver(
-#endif
   const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &model, 
   const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &icModel):
   out(Teuchos::VerboseObjectBase::getDefaultOStream()),
@@ -80,13 +75,8 @@ Piro::TransientSolver<Scalar>::TransientSolver(
 #endif
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Piro::TransientSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::TransientSolver(
-#else
 template <typename Scalar>
 Piro::TransientSolver<Scalar>::TransientSolver(
-#endif
     const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &model, int numParameters, 
     const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &icModel) : 
     out(Teuchos::VerboseObjectBase::getDefaultOStream()),
@@ -100,15 +90,9 @@ Piro::TransientSolver<Scalar>::TransientSolver(
 #endif
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
-Piro::TransientSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::get_p_space(int l) const
-#else
 template<typename Scalar>
 Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
 Piro::TransientSolver<Scalar>::get_p_space(int l) const
-#endif
 {
 #ifdef DEBUG_OUTPUT
   *out << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
@@ -123,15 +107,9 @@ Piro::TransientSolver<Scalar>::get_p_space(int l) const
   return model_->get_p_space(l);
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
-Piro::TransientSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::get_g_space(int j) const
-#else
 template<typename Scalar>
 Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
 Piro::TransientSolver<Scalar>::get_g_space(int j) const
-#endif
 {
 #ifdef DEBUG_OUTPUT
   *out << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
@@ -151,15 +129,9 @@ Piro::TransientSolver<Scalar>::get_g_space(int j) const
   }
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Thyra::ModelEvaluatorBase::InArgs<Scalar>
-Piro::TransientSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::getNominalValues() const
-#else
 template<typename Scalar>
 Thyra::ModelEvaluatorBase::InArgs<Scalar>
 Piro::TransientSolver<Scalar>::getNominalValues() const
-#endif
 {
 #ifdef DEBUG_OUTPUT
   *out << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
@@ -172,15 +144,9 @@ Piro::TransientSolver<Scalar>::getNominalValues() const
   return result;
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Thyra::ModelEvaluatorBase::InArgs<Scalar>
-Piro::TransientSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::createInArgs() const
-#else
 template <typename Scalar>
 Thyra::ModelEvaluatorBase::InArgs<Scalar>
 Piro::TransientSolver<Scalar>::createInArgs() const
-#endif
 {
 #ifdef DEBUG_OUTPUT
   *out << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
@@ -191,15 +157,9 @@ Piro::TransientSolver<Scalar>::createInArgs() const
   return inArgs;
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Thyra::ModelEvaluatorBase::OutArgs<Scalar>
-Piro::TransientSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::createOutArgsImpl() const
-#else
 template <typename Scalar>
 Thyra::ModelEvaluatorBase::OutArgs<Scalar>
 Piro::TransientSolver<Scalar>::createOutArgsImpl() const
-#endif
 {
 #ifdef DEBUG_OUTPUT
   *out << "DEBUG: " << __PRETTY_FUNCTION__ << "\n";
@@ -273,15 +233,9 @@ Piro::TransientSolver<Scalar>::createOutArgsImpl() const
 }
 
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Teuchos::RCP<Thyra::LinearOpBase<Scalar> >
-Piro::TransientSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::create_DgDp_op_impl(int j, int l) const
-#else
 template <typename Scalar>
 Teuchos::RCP<Thyra::LinearOpBase<Scalar> >
 Piro::TransientSolver<Scalar>::create_DgDp_op_impl(int j, int l) const
-#endif
 {
   TEUCHOS_ASSERT(j != num_g_);
   const Teuchos::Array<Teuchos::RCP<const Thyra::LinearOpBase<Scalar> > > dummy =
@@ -289,15 +243,9 @@ Piro::TransientSolver<Scalar>::create_DgDp_op_impl(int j, int l) const
   return Teuchos::rcp(new Thyra::DefaultAddedLinearOp<Scalar>(dummy));
 }
 
-#ifdef ALBANY_BUILD
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-void 
-Piro::TransientSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::evalConvergedModel(
-#else
 template <typename Scalar>
 void 
 Piro::TransientSolver<Scalar>::evalConvergedModel(
-#endif
       const Thyra::ModelEvaluatorBase::InArgs<Scalar>& modelInArgs,
       const Thyra::ModelEvaluatorBase::OutArgs<Scalar>& outArgs) const
 {

--- a/packages/piro/src/Piro_TrapezoidRuleSolver.hpp
+++ b/packages/piro/src/Piro_TrapezoidRuleSolver.hpp
@@ -57,7 +57,7 @@
 
 namespace Piro {
 
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+template <typename Scalar>
 class TrapezoidDecorator
     : public Thyra::ModelEvaluatorDelegatorBase<Scalar> {
 
@@ -115,7 +115,7 @@ class TrapezoidDecorator
 
 };
 
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+template <typename Scalar>
 class TrapezoidRuleSolver
     : public Thyra::ResponseOnlyModelEvaluatorBase<Scalar> {
 
@@ -168,7 +168,7 @@ private:
 
    //These are set in the constructor and used in evalModel
    mutable Teuchos::RCP<Teuchos::ParameterList> appParams;
-   Teuchos::RCP<Piro::TrapezoidDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node> > model;
+   Teuchos::RCP<Piro::TrapezoidDecorator<Scalar> > model;
    Teuchos::RCP<Piro::ObserverBase<Scalar> > observer;
    Teuchos::RCP<Thyra::AdaptiveSolutionManager> solMgr;
    Teuchos::RCP<Teuchos::FancyOStream> out;

--- a/packages/piro/src/Piro_TrapezoidRuleSolver_Def.hpp
+++ b/packages/piro/src/Piro_TrapezoidRuleSolver_Def.hpp
@@ -43,14 +43,14 @@
 #include <cmath>
 #include "Piro_TransientDecorator.hpp"
 
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Piro::TrapezoidRuleSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
+template <typename Scalar>
+Piro::TrapezoidRuleSolver<Scalar>::
 TrapezoidRuleSolver(const Teuchos::RCP<Teuchos::ParameterList> &appParams_,
                           const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &model_,
                           const Teuchos::RCP<Thyra::AdaptiveSolutionManager> &solMgr_,
                           const Teuchos::RCP<Piro::ObserverBase<Scalar> > &observer_ ) :
   appParams(appParams_),
-  model(Teuchos::rcp(new Piro::TrapezoidDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node>(model_))),
+  model(Teuchos::rcp(new Piro::TrapezoidDecorator<Scalar>(model_))),
   observer(observer_),
   solMgr(solMgr_),
   out(Teuchos::VerboseObjectBase::getDefaultOStream())
@@ -101,9 +101,9 @@ TrapezoidRuleSolver(const Teuchos::RCP<Teuchos::ParameterList> &appParams_,
 
 }
 
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+template <typename Scalar>
 Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
-Piro::TrapezoidRuleSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::get_p_space(int l) const
+Piro::TrapezoidRuleSolver<Scalar>::get_p_space(int l) const
 {
   TEUCHOS_TEST_FOR_EXCEPTION(
       l >= num_p || l < 0,
@@ -116,9 +116,9 @@ Piro::TrapezoidRuleSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::get_p_spac
   return model->get_p_space(l);
 }
 
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+template <typename Scalar>
 Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
-Piro::TrapezoidRuleSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::get_g_space(int j) const
+Piro::TrapezoidRuleSolver<Scalar>::get_g_space(int j) const
 {
   TEUCHOS_TEST_FOR_EXCEPTION(
       j > num_g || j < 0,
@@ -136,9 +136,9 @@ Piro::TrapezoidRuleSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::get_g_spac
   }
 }
 
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+template <typename Scalar>
 Thyra::ModelEvaluatorBase::InArgs<Scalar>
-Piro::TrapezoidRuleSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::getNominalValues() const
+Piro::TrapezoidRuleSolver<Scalar>::getNominalValues() const
 {
   Thyra::ModelEvaluatorBase::InArgs<Scalar> result = this->createInArgs();
   const Thyra::ModelEvaluatorBase::InArgs<Scalar> modelNominalValues = model->getNominalValues();
@@ -148,9 +148,9 @@ Piro::TrapezoidRuleSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::getNominal
   return result;
 }
 
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+template <typename Scalar>
 Thyra::ModelEvaluatorBase::InArgs<Scalar>
-Piro::TrapezoidRuleSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::createInArgs() const
+Piro::TrapezoidRuleSolver<Scalar>::createInArgs() const
 {
   Thyra::ModelEvaluatorBase::InArgsSetup<Scalar> inArgs;
   inArgs.setModelEvalDescription(this->description());
@@ -158,9 +158,9 @@ Piro::TrapezoidRuleSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::createInAr
   return inArgs;
 }
 
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+template <typename Scalar>
 Thyra::ModelEvaluatorBase::OutArgs<Scalar>
-Piro::TrapezoidRuleSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::createOutArgsImpl() const
+Piro::TrapezoidRuleSolver<Scalar>::createOutArgsImpl() const
 {
   Thyra::ModelEvaluatorBase::OutArgsSetup<Scalar> outArgs;
   outArgs.setModelEvalDescription(this->description());
@@ -220,9 +220,9 @@ Piro::TrapezoidRuleSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::createOutA
 
 }
 
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+template <typename Scalar>
 void
-Piro::TrapezoidRuleSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::evalModelImpl(
+Piro::TrapezoidRuleSolver<Scalar>::evalModelImpl(
     const Thyra::ModelEvaluatorBase::InArgs<Scalar>& inArgs,
     const Thyra::ModelEvaluatorBase::OutArgs<Scalar>& outArgs) const
 {
@@ -389,9 +389,9 @@ Piro::TrapezoidRuleSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::evalModelI
 
 }
 
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+template <typename Scalar>
 Teuchos::RCP<const Teuchos::ParameterList>
-Piro::TrapezoidRuleSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::getValidTrapezoidRuleParameters() const
+Piro::TrapezoidRuleSolver<Scalar>::getValidTrapezoidRuleParameters() const
 {
   Teuchos::RCP<Teuchos::ParameterList> validPL =
      Teuchos::rcp(new Teuchos::ParameterList("ValidTrapezoidRuleParams"));;
@@ -408,8 +408,8 @@ Piro::TrapezoidRuleSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::getValidTr
 
 /****************************************************************************/
 
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Piro::TrapezoidDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node>::TrapezoidDecorator(
+template <typename Scalar>
+Piro::TrapezoidDecorator<Scalar>::TrapezoidDecorator(
                           const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> >& model_) :
   Thyra::ModelEvaluatorDelegatorBase<Scalar>(model_),
   DMEWSF(Teuchos::rcp_dynamic_cast<Thyra::DefaultModelEvaluatorWithSolveFactory<Scalar> >(model_)),
@@ -438,52 +438,51 @@ Piro::TrapezoidDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node>::TrapezoidDe
 
 }
 
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+template <typename Scalar>
 Teuchos::RCP<const Thyra::VectorBase<Scalar> >
-Piro::TrapezoidDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node>::get_x() const
+Piro::TrapezoidDecorator<Scalar>::get_x() const
 {
 
   return x_save;
 
 }
 
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+template <typename Scalar>
 Teuchos::RCP<const Thyra::VectorBase<Scalar> >
-Piro::TrapezoidDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node>::get_x_dot() const
+Piro::TrapezoidDecorator<Scalar>::get_x_dot() const
 {
 
   return xDot;
 
 }
 
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+template <typename Scalar>
 Teuchos::RCP<const Thyra::VectorBase<Scalar> >
-Piro::TrapezoidDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node>::get_x_dotdot() const
+Piro::TrapezoidDecorator<Scalar>::get_x_dotdot() const
 {
-  Teuchos::RCP<const Piro::TransientDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node> > dec =
-     Teuchos::rcp_dynamic_cast<const Piro::TransientDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node> >
+  Teuchos::RCP<const Piro::TransientDecorator<Scalar> > dec =
+     Teuchos::rcp_dynamic_cast<const Piro::TransientDecorator<Scalar> >
          (DMEWSF->getUnderlyingModel());
 
   TEUCHOS_TEST_FOR_EXCEPTION(Teuchos::is_null(dec),
     std::logic_error,
-    "Underlying model in trapezoid decorator does not cast to a Piro::TransientDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node>"
-    << std::endl);
+    "Underlying model in trapezoid decorator does not cast to a Piro::TransientDecorator<Scalar>\n"); 
 
   return dec->get_x_dotdot();
 
 }
 
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+template <typename Scalar>
 void
-Piro::TrapezoidDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node>::reportFinalPoint(
+Piro::TrapezoidDecorator<Scalar>::reportFinalPoint(
     const Thyra::ModelEvaluatorBase::InArgs<Scalar>& finalPoint,
     const bool wasSolved)
 {
   this->getNonconstUnderlyingModel()->reportFinalPoint(finalPoint,wasSolved);
 }
 
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-void Piro::TrapezoidDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node>::injectData(
+template <typename Scalar>
+void Piro::TrapezoidDecorator<Scalar>::injectData(
     const Teuchos::RCP<Thyra::VectorBase<Scalar> >& x_,
     const Teuchos::RCP<Thyra::VectorBase<Scalar> >& x_pred_a_, Scalar fdt2_,
     const Teuchos::RCP<Thyra::VectorBase<Scalar> >& x_pred_v_, Scalar tdt_,
@@ -500,8 +499,8 @@ void Piro::TrapezoidDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node>::inject
 
 }
 
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-void Piro::TrapezoidDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node>::resize(
+template <typename Scalar>
+void Piro::TrapezoidDecorator<Scalar>::resize(
     const Teuchos::RCP<Thyra::VectorBase<Scalar> >& x_)
 {
 
@@ -515,8 +514,8 @@ void Piro::TrapezoidDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node>::resize
 }
 
 
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-void Piro::TrapezoidDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node>::evalModelImpl(
+template <typename Scalar>
+void Piro::TrapezoidDecorator<Scalar>::evalModelImpl(
       const Thyra::ModelEvaluatorBase::InArgs<Scalar>& inArgs,
       const Thyra::ModelEvaluatorBase::OutArgs<Scalar>& outArgs) const {
 
@@ -540,14 +539,13 @@ void Piro::TrapezoidDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node>::evalMo
   // No xdotdot support in Thyra, so set directly in the model
   // Need to set xdotdot and omega in the underlying model if the model is a DMEWSF
 
-  Teuchos::RCP<const Piro::TransientDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node> > dec =
-       Teuchos::rcp_dynamic_cast<const Piro::TransientDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node> >
+  Teuchos::RCP<const Piro::TransientDecorator<Scalar> > dec =
+       Teuchos::rcp_dynamic_cast<const Piro::TransientDecorator<Scalar> >
            (DMEWSF->getUnderlyingModel());
 
   TEUCHOS_TEST_FOR_EXCEPTION(Teuchos::is_null(dec),
       std::logic_error,
-      "Underlying model in trapezoid decorator does not cast to a Piro::TransientDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node>"
-      << std::endl);
+      "Underlying model in trapezoid decorator does not cast to a Piro::TransientDecorator<Scalar>\n");
 
   dec->set_omega(fdt2);  // fdt2 = 4/(dt)^2
   dec->set_x_dotdot_data(xDotDot); // no xdotdot in Thyra inArgs

--- a/packages/piro/src/Piro_VelocityVerletSolver.hpp
+++ b/packages/piro/src/Piro_VelocityVerletSolver.hpp
@@ -54,7 +54,7 @@
 
 namespace Piro {
 
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+template <typename Scalar>
 class VelocityVerletSolver
     : public Thyra::ResponseOnlyModelEvaluatorBase<Scalar> {
 

--- a/packages/piro/src/Piro_VelocityVerletSolver_Def.hpp
+++ b/packages/piro/src/Piro_VelocityVerletSolver_Def.hpp
@@ -45,11 +45,10 @@
 #include "Thyra_DefaultModelEvaluatorWithSolveFactory.hpp"
 #include "Piro_TransientDecorator.hpp"
 
-#define ALBANY_BUILD
 #include "Piro_InvertMassMatrixDecorator.hpp"
 
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
-Piro::VelocityVerletSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::
+template <typename Scalar>
+Piro::VelocityVerletSolver<Scalar>::
 VelocityVerletSolver(const Teuchos::RCP<Teuchos::ParameterList> &appParams_,
                           const Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > &model_,
                           const Teuchos::RCP<Thyra::AdaptiveSolutionManager> &solMgr_,
@@ -97,24 +96,24 @@ VelocityVerletSolver(const Teuchos::RCP<Teuchos::ParameterList> &appParams_,
     Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > origModel = model;
     bool lump=vvPL->get("Lump Mass Matrix", false);
     *out << "\nB) Using InvertMassMatrix Decorator\n";
-    model = Teuchos::rcp(new Piro::InvertMassMatrixDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node>(
+    model = Teuchos::rcp(new Piro::InvertMassMatrixDecorator<Scalar>(
              sublist(vvPL,"Stratimikos", true), origModel,
              true, lump, true));
   }
 }
 
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+template <typename Scalar>
 Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
-Piro::VelocityVerletSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::get_x() const
+Piro::VelocityVerletSolver<Scalar>::get_x() const
 {
 
   return model->get_x();
 
 }
 
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+template <typename Scalar>
 Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
-Piro::VelocityVerletSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::get_x_dot() const
+Piro::VelocityVerletSolver<Scalar>::get_x_dot() const
 {
 
   return model->get_x_dot();
@@ -122,9 +121,9 @@ Piro::VelocityVerletSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::get_x_dot
 }
 
 
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+template <typename Scalar>
 Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
-Piro::VelocityVerletSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::get_p_space(int l) const
+Piro::VelocityVerletSolver<Scalar>::get_p_space(int l) const
 {
   TEUCHOS_TEST_FOR_EXCEPTION(
       l >= num_p || l < 0,
@@ -137,9 +136,9 @@ Piro::VelocityVerletSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::get_p_spa
   return model->get_p_space(l);
 }
 
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+template <typename Scalar>
 Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
-Piro::VelocityVerletSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::get_g_space(int j) const
+Piro::VelocityVerletSolver<Scalar>::get_g_space(int j) const
 {
   TEUCHOS_TEST_FOR_EXCEPTION(
       j > num_g || j < 0,
@@ -157,9 +156,9 @@ Piro::VelocityVerletSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::get_g_spa
   }
 }
 
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+template <typename Scalar>
 Thyra::ModelEvaluatorBase::InArgs<Scalar>
-Piro::VelocityVerletSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::getNominalValues() const
+Piro::VelocityVerletSolver<Scalar>::getNominalValues() const
 {
   Thyra::ModelEvaluatorBase::InArgs<Scalar> result = this->createInArgs();
   const Thyra::ModelEvaluatorBase::InArgs<Scalar> modelNominalValues = model->getNominalValues();
@@ -169,9 +168,9 @@ Piro::VelocityVerletSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::getNomina
   return result;
 }
 
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+template <typename Scalar>
 Thyra::ModelEvaluatorBase::InArgs<Scalar>
-Piro::VelocityVerletSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::createInArgs() const
+Piro::VelocityVerletSolver<Scalar>::createInArgs() const
 {
   Thyra::ModelEvaluatorBase::InArgsSetup<Scalar> inArgs;
   inArgs.setModelEvalDescription(this->description());
@@ -179,9 +178,9 @@ Piro::VelocityVerletSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::createInA
   return inArgs;
 }
 
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+template <typename Scalar>
 Thyra::ModelEvaluatorBase::OutArgs<Scalar>
-Piro::VelocityVerletSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::createOutArgsImpl() const
+Piro::VelocityVerletSolver<Scalar>::createOutArgsImpl() const
 {
   Thyra::ModelEvaluatorBase::OutArgsSetup<Scalar> outArgs;
   outArgs.setModelEvalDescription(this->description());
@@ -241,9 +240,9 @@ Piro::VelocityVerletSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::createOut
 
 }
 
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+template <typename Scalar>
 void
-Piro::VelocityVerletSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::evalModelImpl(
+Piro::VelocityVerletSolver<Scalar>::evalModelImpl(
     const Thyra::ModelEvaluatorBase::InArgs<Scalar>& inArgs,
     const Thyra::ModelEvaluatorBase::OutArgs<Scalar>& outArgs) const
 {
@@ -290,13 +289,12 @@ Piro::VelocityVerletSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::evalModel
   Teuchos::RCP<Thyra::DefaultModelEvaluatorWithSolveFactory<Scalar> >
       DMEWSF(Teuchos::rcp_dynamic_cast<Thyra::DefaultModelEvaluatorWithSolveFactory<Scalar> >(model));
 
-  Teuchos::RCP<const Piro::TransientDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node> > dec =
-       Teuchos::rcp_dynamic_cast<const Piro::TransientDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node> >
+  Teuchos::RCP<const Piro::TransientDecorator<Scalar> > dec =
+       Teuchos::rcp_dynamic_cast<const Piro::TransientDecorator<Scalar> >
            (DMEWSF->getUnderlyingModel());
 
   TEUCHOS_TEST_FOR_EXCEPTION(Teuchos::is_null(dec), std::logic_error,
-      "Underlying model in VelovityVerletSolver does not cast to a Piro::TransientDecorator<Scalar, LocalOrdinal, GlobalOrdinal, Node>"
-      << std::endl);
+      "Underlying model in VelovityVerletSolver does not cast to a Piro::TransientDecorator<Scalar>\n"); 
 
   Teuchos::RCP<Thyra::VectorBase<Scalar> > a = dec->get_x_dotdot()->clone_v();
 
@@ -366,9 +364,9 @@ Piro::VelocityVerletSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::evalModel
   }
 }
 
-template <typename Scalar, typename LocalOrdinal, typename GlobalOrdinal, typename Node>
+template <typename Scalar>
 Teuchos::RCP<const Teuchos::ParameterList>
-Piro::VelocityVerletSolver<Scalar, LocalOrdinal, GlobalOrdinal, Node>::getValidVelocityVerletParameters() const
+Piro::VelocityVerletSolver<Scalar>::getValidVelocityVerletParameters() const
 {
   Teuchos::RCP<Teuchos::ParameterList> validPL =
      Teuchos::rcp(new Teuchos::ParameterList("ValidVelocityVerletParams"));;


### PR DESCRIPTION
Some improvements to Piro package: 

- Piro::TempsSolver has been refactored into helper class called Piro::TransientSolver.  Transient sensitivities will go in the latter class, similar to Piro::NOXSolver and Piro::SteadyStateSolver.  
- Obsolete template arguments that used to be needed for Albany have been removed from various Piro classes.