### PR TITLE
DO NOT MERGE Tpetra: Communication/Computation overlap

### DIFF
--- a/packages/ifpack2/src/Ifpack2_Details_ChebyshevKernel_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_ChebyshevKernel_decl.hpp
@@ -55,6 +55,7 @@
 #include "Tpetra_Vector_fwd.hpp"
 #include "Tpetra_Export_fwd.hpp"
 #include "Tpetra_Import_fwd.hpp"
+#include "Tpetra_TransferRequest.hpp"
 #include "Teuchos_RCP.hpp"
 #include <memory>
 
@@ -85,6 +86,7 @@ private:
   using multivector_type = Tpetra::MultiVector<SC, LO, GO, NT>;
   using operator_type = Tpetra::Operator<SC, LO, GO, NT>;
   using vector_type = Tpetra::Vector<SC, LO, GO, NT>;
+  using transfer_request_type = Tpetra::TransferRequest<SC, LO, GO, NT>;
 
 public:
   ChebyshevKernel (const Teuchos::RCP<const operator_type>& A);

--- a/packages/muelu/test/maxwell/Maxwell.xml
+++ b/packages/muelu/test/maxwell/Maxwell.xml
@@ -2,6 +2,7 @@
 
   <Parameter name="refmaxwell: use as preconditioner" type="bool" value="true"/>
   <Parameter name="refmaxwell: mode" type="string" value="additive"/>
+  <Parameter name="refmaxwell: subsolves on subcommunicators" type="bool" value="true"/>
   <Parameter name="refmaxwell: disable addon" type="bool" value="false"/>
   <Parameter name="refmaxwell: dump matrices" type="bool" value="false"/>
 
@@ -12,6 +13,11 @@
   <ParameterList name="smoother: params">
     <Parameter name="relaxation: type" type="string" value="Symmetric Gauss-Seidel"/>
     <Parameter name="relaxation: sweeps" type="int" value="1"/>
+  </ParameterList>
+
+  <ParameterList name="matvec params">
+    <!-- <Parameter name="Send type" type="string" value="Send"/> -->
+    <Parameter name="Send type" type="string" value="Isend"/>
   </ParameterList>
 
   <ParameterList name="refmaxwell: 11list">
@@ -26,6 +32,24 @@
       <Parameter name="relaxation: type" type="string" value="Symmetric Gauss-Seidel"/>
       <Parameter name="relaxation: sweeps" type="int" value="1"/>
       <Parameter name="relaxation: use l1" type="bool" value="true"/>
+    </ParameterList>
+
+    <ParameterList name="matvec params">
+      <!-- <Parameter name="Send type" type="string" value="Send"/> -->
+      <Parameter name="Send type" type="string" value="Isend"/>
+    </ParameterList>
+
+    <Parameter name="repartition: enable" type="bool" value="true"/>
+    <Parameter name="repartition: partitioner" type="string" value="zoltan2"/>
+    <Parameter name="repartition: start level" type="int" value="1"/>
+    <Parameter name="repartition: target rows per proc" type="int" value="2000"/>
+    <Parameter name="repartition: min rows per proc" type="int" value="2000"/>
+    <Parameter name="repartition: max imbalance" type="double" value="1.1"/>
+    <Parameter name="repartition: remap parts" type="bool" value="true"/>
+    <Parameter name="repartition: rebalance P and R" type="bool" value="false"/>
+    <Parameter name="repartition: print partition distribution" type="bool" value="true"/>
+    <ParameterList name="repartition: params">
+      <Parameter name="algorithm" type="string" value="multijagged"/>
     </ParameterList>
   </ParameterList>
 
@@ -43,13 +67,20 @@
       <Parameter name="relaxation: use l1" type="bool" value="true"/>
     </ParameterList>
 
+    <ParameterList name="matvec params">
+      <!-- <Parameter name="Send type" type="string" value="Send"/> -->
+      <Parameter name="Send type" type="string" value="Isend"/>
+    </ParameterList>
+
     <Parameter name="repartition: enable" type="bool" value="true"/>
     <Parameter name="repartition: partitioner" type="string" value="zoltan2"/>
     <Parameter name="repartition: start level" type="int" value="1"/>
-    <Parameter name="repartition: min rows per proc" type="int" value="200"/>
+    <Parameter name="repartition: target rows per proc" type="int" value="2000"/>
+    <Parameter name="repartition: min rows per proc" type="int" value="2000"/>
     <Parameter name="repartition: max imbalance" type="double" value="1.1"/>
     <Parameter name="repartition: remap parts" type="bool" value="true"/>
     <Parameter name="repartition: rebalance P and R" type="bool" value="false"/>
+    <Parameter name="repartition: print partition distribution" type="bool" value="true"/>
     <ParameterList name="repartition: params">
       <Parameter name="algorithm" type="string" value="multijagged"/>
     </ParameterList>

--- a/packages/tpetra/core/src/CMakeLists.txt
+++ b/packages/tpetra/core/src/CMakeLists.txt
@@ -311,7 +311,7 @@ FUNCTION(TPETRA_PROCESS_ALL_LGN_TEMPLATES OUTPUT_FILES TEMPLATE_FILE
       FOREACH(LO ${LOCALORDINAL_TYPES})
         TPETRA_MANGLE_TEMPLATE_PARAMETER(LO_MANGLED "${LO}")
         TPETRA_SLG_MACRO_NAME(LO_MACRO_NAME "${LO}")
-        
+
         TPETRA_PROCESS_ONE_LGN_TEMPLATE(OUT_FILE "${TEMPLATE_FILE}"
           "${CLASS_NAME}" "${CLASS_MACRO_NAME}"
           "${LO_MANGLED}" "${GO_MANGLED}" "${NT_MANGLED}"
@@ -581,6 +581,10 @@ IF (${PACKAGE_NAME}_ENABLE_EXPLICIT_INSTANTIATION)
   # Generate ETI .cpp files for Tpetra::DistObject.
   TPETRA_PROCESS_ALL_SLGN_TEMPLATES(DISTOBJECT_OUTPUT_FILES "Tpetra_ETI_SC_LO_GO_NT.tmpl" "DistObject" "DISTOBJECT" "${DistObject_ETI_SCALARS}" "${TpetraCore_ETI_LORDS}" "${TpetraCore_ETI_GORDS}" "${TpetraCore_ETI_NODES}" TRUE)
   LIST(APPEND SOURCES ${DISTOBJECT_OUTPUT_FILES})
+
+  # Generate ETI .cpp files for Tpetra::TransferRequest.
+  TPETRA_PROCESS_ALL_SLGN_TEMPLATES(TRANSFERREQUEST_OUTPUT_FILES "Tpetra_ETI_SC_LO_GO_NT.tmpl" "TransferRequest" "TRANSFERREQUEST" "${DistObject_ETI_SCALARS}" "${TpetraCore_ETI_LORDS}" "${TpetraCore_ETI_GORDS}" "${TpetraCore_ETI_NODES}" TRUE)
+  LIST(APPEND SOURCES ${TRANSFERREQUEST_OUTPUT_FILES})
 
   # Generate ETI .cpp files for Tpetra::leftAndOrRightScaleCrsMatrix.
   # Do this only for non-integer Scalar types, since we really only

--- a/packages/tpetra/core/src/Tpetra_DistObject_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_DistObject_def.hpp
@@ -96,6 +96,7 @@ namespace Tpetra {
   template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
   DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
   DistObject (const Teuchos::RCP<const map_type>& map) :
+    transferInProgress_(false),
     map_ (map)
   {
 #ifdef HAVE_TPETRA_TRANSFER_TIMERS
@@ -303,6 +304,66 @@ namespace Tpetra {
   }
 
   template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
+  Teuchos::RCP<TransferRequest<Packet, LocalOrdinal, GlobalOrdinal, Node> >
+  DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
+  startImport (const SrcDistObject& source,
+               Teuchos::RCP<const Import<LocalOrdinal, GlobalOrdinal, Node> >& importer,
+               const CombineMode CM,
+               const bool restrictedMode)
+  {
+    using Details::Behavior;
+    using std::endl;
+    const char modeString[] = "startImport (forward mode)";
+
+    // mfh 18 Oct 2017: Set TPETRA_VERBOSE to true for copious debug
+    // output to std::cerr on every MPI process.  This is unwise for
+    // runs with large numbers of MPI processes.
+    const bool verbose = Behavior::verbose("DistObject");
+    std::unique_ptr<std::string> prefix;
+    if (verbose) {
+      prefix = this->createPrefix("DistObject", modeString);
+      std::ostringstream os;
+      os << *prefix << "Start" << endl;
+      std::cerr << os.str ();
+    }
+    Teuchos::RCP<const transfer_type> transfer = Teuchos::rcp_static_cast<const transfer_type>(importer);
+    return this->startTransfer (source, transfer, modeString, DoForward, CM,
+                                restrictedMode);
+  }
+
+  template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
+  void
+  DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
+  finishImport (const SrcDistObject& source,
+                const Import<LocalOrdinal, GlobalOrdinal, Node>& importer,
+                const CombineMode CM,
+                const bool needCommunication)
+  {
+    using Details::Behavior;
+    using std::endl;
+    const char modeString[] = "finishImport (forward mode)";
+
+    // mfh 18 Oct 2017: Set TPETRA_VERBOSE to true for copious debug
+    // output to std::cerr on every MPI process.  This is unwise for
+    // runs with large numbers of MPI processes.
+    const bool verbose = Behavior::verbose("DistObject");
+    std::unique_ptr<std::string> prefix;
+    if (verbose) {
+      prefix = this->createPrefix("DistObject", modeString);
+      std::ostringstream os;
+      os << *prefix << "Start" << endl;
+      std::cerr << os.str ();
+    }
+    this->finishTransfer (importer, DoForward, CM,
+                          needCommunication);
+    if (verbose) {
+      std::ostringstream os;
+      os << *prefix << "Done" << endl;
+      std::cerr << os.str ();
+    }
+  }
+
+  template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
   void
   DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
   doExport (const SrcDistObject& source,
@@ -327,6 +388,66 @@ namespace Tpetra {
     }
     this->doTransfer (source, exporter, modeString, DoForward, CM,
                       restrictedMode);
+    if (verbose) {
+      std::ostringstream os;
+      os << *prefix << "Done" << endl;
+      std::cerr << os.str ();
+    }
+  }
+
+  template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
+  Teuchos::RCP<TransferRequest<Packet, LocalOrdinal, GlobalOrdinal, Node> >
+  DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
+  startExport (const SrcDistObject& source,
+               Teuchos::RCP<const Export<LocalOrdinal, GlobalOrdinal, Node> >& exporter,
+               const CombineMode CM,
+               const bool restrictedMode)
+  {
+    using Details::Behavior;
+    using std::endl;
+    const char modeString[] = "startExport (forward mode)";
+
+    // mfh 18 Oct 2017: Set TPETRA_VERBOSE to true for copious debug
+    // output to std::cerr on every MPI process.  This is unwise for
+    // runs with large numbers of MPI processes.
+    const bool verbose = Behavior::verbose("DistObject");
+    std::unique_ptr<std::string> prefix;
+    if (verbose) {
+      prefix = this->createPrefix("DistObject", modeString);
+      std::ostringstream os;
+      os << *prefix << "Start" << endl;
+      std::cerr << os.str ();
+    }
+    Teuchos::RCP<const transfer_type> transfer = Teuchos::rcp_static_cast<const transfer_type>(exporter);
+    return this->startTransfer (source, transfer, modeString, DoForward, CM,
+                                restrictedMode);
+  }
+
+  template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
+  void
+  DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
+  finishExport (const SrcDistObject& source,
+                const Export<LocalOrdinal, GlobalOrdinal, Node>& exporter,
+                const CombineMode CM,
+                const bool needCommunication)
+  {
+    using Details::Behavior;
+    using std::endl;
+    const char modeString[] = "finishExport (forward mode)";
+
+    // mfh 18 Oct 2017: Set TPETRA_VERBOSE to true for copious debug
+    // output to std::cerr on every MPI process.  This is unwise for
+    // runs with large numbers of MPI processes.
+    const bool verbose = Behavior::verbose("DistObject");
+    std::unique_ptr<std::string> prefix;
+    if (verbose) {
+      prefix = this->createPrefix("DistObject", modeString);
+      std::ostringstream os;
+      os << *prefix << "Start" << endl;
+      std::cerr << os.str ();
+    }
+    this->finishTransfer (exporter, DoForward, CM,
+                          needCommunication);
     if (verbose) {
       std::ostringstream os;
       os << *prefix << "Done" << endl;
@@ -367,6 +488,66 @@ namespace Tpetra {
   }
 
   template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
+  Teuchos::RCP<TransferRequest<Packet, LocalOrdinal, GlobalOrdinal, Node> >
+  DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
+  startImport (const SrcDistObject& source,
+               Teuchos::RCP<const Export<LocalOrdinal, GlobalOrdinal, Node> >& exporter,
+               const CombineMode CM,
+               const bool restrictedMode)
+  {
+    using Details::Behavior;
+    using std::endl;
+    const char modeString[] = "startImport (reverse mode)";
+
+    // mfh 18 Oct 2017: Set TPETRA_VERBOSE to true for copious debug
+    // output to std::cerr on every MPI process.  This is unwise for
+    // runs with large numbers of MPI processes.
+    const bool verbose = Behavior::verbose("DistObject");
+    std::unique_ptr<std::string> prefix;
+    if (verbose) {
+      prefix = this->createPrefix("DistObject", modeString);
+      std::ostringstream os;
+      os << *prefix << "Start" << endl;
+      std::cerr << os.str ();
+    }
+    Teuchos::RCP<const transfer_type> transfer = Teuchos::rcp_static_cast<const transfer_type>(exporter);
+    return this->startTransfer (source, transfer, modeString, DoReverse, CM,
+                                restrictedMode);
+  }
+
+  template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
+  void
+  DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
+  finishImport (const SrcDistObject& source,
+                const Export<LocalOrdinal, GlobalOrdinal, Node>& exporter,
+                const CombineMode CM,
+                const bool needCommunication)
+  {
+    using Details::Behavior;
+    using std::endl;
+    const char modeString[] = "finishImport (reverse mode)";
+
+    // mfh 18 Oct 2017: Set TPETRA_VERBOSE to true for copious debug
+    // output to std::cerr on every MPI process.  This is unwise for
+    // runs with large numbers of MPI processes.
+    const bool verbose = Behavior::verbose("DistObject");
+    std::unique_ptr<std::string> prefix;
+    if (verbose) {
+      prefix = this->createPrefix("DistObject", modeString);
+      std::ostringstream os;
+      os << *prefix << "Start" << endl;
+      std::cerr << os.str ();
+    }
+    this->finishTransfer (exporter, DoReverse, CM,
+                          needCommunication);
+    if (verbose) {
+      std::ostringstream os;
+      os << *prefix << "Done" << endl;
+      std::cerr << os.str ();
+    }
+  }
+
+  template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
   void
   DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
   doExport (const SrcDistObject& source,
@@ -391,6 +572,66 @@ namespace Tpetra {
     }
     this->doTransfer (source, importer, modeString, DoReverse, CM,
                       restrictedMode);
+    if (verbose) {
+      std::ostringstream os;
+      os << *prefix << "Done" << endl;
+      std::cerr << os.str ();
+    }
+  }
+
+  template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
+  Teuchos::RCP<TransferRequest<Packet, LocalOrdinal, GlobalOrdinal, Node> >
+  DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
+  startExport (const SrcDistObject& source,
+               Teuchos::RCP<const Import<LocalOrdinal, GlobalOrdinal, Node> >& importer,
+               const CombineMode CM,
+               const bool restrictedMode)
+  {
+    using Details::Behavior;
+    using std::endl;
+    const char modeString[] = "startExport (reverse mode)";
+
+    // mfh 18 Oct 2017: Set TPETRA_VERBOSE to true for copious debug
+    // output to std::cerr on every MPI process.  This is unwise for
+    // runs with large numbers of MPI processes.
+    const bool verbose = Behavior::verbose("DistObject");
+    std::unique_ptr<std::string> prefix;
+    if (verbose) {
+      prefix = this->createPrefix("DistObject", modeString);
+      std::ostringstream os;
+      os << *prefix << "Start" << endl;
+      std::cerr << os.str ();
+    }
+    Teuchos::RCP<const transfer_type> transfer = Teuchos::rcp_static_cast<const transfer_type>(importer);
+    return this->startTransfer (source, transfer, modeString, DoReverse, CM,
+                                restrictedMode);
+  }
+
+  template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
+  void
+  DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
+  finishExport (const SrcDistObject& source,
+                const Import<LocalOrdinal, GlobalOrdinal, Node>& importer,
+                const CombineMode CM,
+                const bool needCommunication)
+  {
+    using Details::Behavior;
+    using std::endl;
+    const char modeString[] = "finishExport (reverse mode)";
+
+    // mfh 18 Oct 2017: Set TPETRA_VERBOSE to true for copious debug
+    // output to std::cerr on every MPI process.  This is unwise for
+    // runs with large numbers of MPI processes.
+    const bool verbose = Behavior::verbose("DistObject");
+    std::unique_ptr<std::string> prefix;
+    if (verbose) {
+      prefix = this->createPrefix("DistObject", modeString);
+      std::ostringstream os;
+      os << *prefix << "Start" << endl;
+      std::cerr << os.str ();
+    }
+    this->finishTransfer (importer, DoReverse, CM,
+                          needCommunication);
     if (verbose) {
       std::ostringstream os;
       os << *prefix << "Done" << endl;
@@ -564,6 +805,206 @@ namespace Tpetra {
   }
 
   template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
+  Teuchos::RCP<TransferRequest<Packet, LocalOrdinal, GlobalOrdinal, Node> >
+  DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
+  startTransfer (const SrcDistObject& src,
+                 Teuchos::RCP<const ::Tpetra::Details::Transfer<local_ordinal_type, global_ordinal_type, node_type> >& transfer,
+                 const char modeString[],
+                 const ReverseOption revOp,
+                 const CombineMode CM,
+                 bool restrictedMode)
+  {
+    using Details::Behavior;
+    using Details::getDualViewCopyFromArrayView;
+    using Details::ProfilingRegion;
+    using std::endl;
+    const char funcName[] = "Tpetra::DistObject::startTransfer";
+
+    ProfilingRegion region_doTransfer(funcName);
+    const bool verbose = Behavior::verbose("DistObject");
+    std::unique_ptr<std::string> prefix;
+    if (verbose) {
+      std::ostringstream os;
+      prefix = this->createPrefix("DistObject", "startTransfer");
+      os << *prefix << "Source type: " << Teuchos::typeName(src)
+         << ", Target type: " << Teuchos::typeName(*this) << endl;
+      std::cerr << os.str();
+    }
+
+    TEUCHOS_TEST_FOR_EXCEPTION(transferInProgress_,
+                               std::invalid_argument,
+                               "Tpetra::DistObject::" << modeString << ": A transfer is already in progress!");
+    transferInProgress_ = true;
+
+    // "Restricted Mode" does two things:
+    // 1) Skips copyAndPermute
+    // 2) Allows the "target" Map of the transfer to be a subset of
+    //    the Map of *this, in a "locallyFitted" sense.
+    //
+    // This cannot be used if #2 is not true, OR there are permutes.
+    // Source Maps still need to match
+
+    // mfh 18 Oct 2017: Set TPETRA_DEBUG to true to enable extra debug
+    // checks.  These may communicate more.
+    const bool debug = Behavior::debug("DistObject");
+    if (debug) {
+      if (! restrictedMode && revOp == DoForward) {
+        const bool myMapSameAsTransferTgtMap =
+          this->getMap ()->isSameAs (* (transfer->getTargetMap ()));
+        TEUCHOS_TEST_FOR_EXCEPTION
+          (! myMapSameAsTransferTgtMap, std::invalid_argument,
+           "Tpetra::DistObject::" << modeString << ": For forward-mode "
+           "communication, the target DistObject's Map must be the same "
+           "(in the sense of Tpetra::Map::isSameAs) as the input "
+           "Export/Import object's target Map.");
+      }
+      else if (! restrictedMode && revOp == DoReverse) {
+        const bool myMapSameAsTransferSrcMap =
+          this->getMap ()->isSameAs (* (transfer->getSourceMap ()));
+        TEUCHOS_TEST_FOR_EXCEPTION
+          (! myMapSameAsTransferSrcMap, std::invalid_argument,
+           "Tpetra::DistObject::" << modeString << ": For reverse-mode "
+           "communication, the target DistObject's Map must be the same "
+         "(in the sense of Tpetra::Map::isSameAs) as the input "
+           "Export/Import object's source Map.");
+      }
+      else if (restrictedMode && revOp == DoForward) {
+        const bool myMapLocallyFittedTransferTgtMap =
+          this->getMap ()->isLocallyFitted (* (transfer->getTargetMap ()));
+        TEUCHOS_TEST_FOR_EXCEPTION
+          (! myMapLocallyFittedTransferTgtMap , std::invalid_argument,
+           "Tpetra::DistObject::" << modeString << ": For forward-mode "
+           "communication using restricted mode, Export/Import object's "
+           "target Map must be locally fitted (in the sense of "
+           "Tpetra::Map::isLocallyFitted) to target DistObject's Map.");
+      }
+      else { // if (restrictedMode && revOp == DoReverse) {
+        const bool myMapLocallyFittedTransferSrcMap =
+          this->getMap ()->isLocallyFitted (* (transfer->getSourceMap ()));
+        TEUCHOS_TEST_FOR_EXCEPTION
+          (! myMapLocallyFittedTransferSrcMap, std::invalid_argument,
+           "Tpetra::DistObject::" << modeString << ": For reverse-mode "
+           "communication using restricted mode, Export/Import object's "
+           "source Map must be locally fitted (in the sense of "
+           "Tpetra::Map::isLocallyFitted) to target DistObject's Map.");
+      }
+
+      // SrcDistObject need not even _have_ Maps.  However, if the
+      // source object is a DistObject, it has a Map, and we may
+      // compare that Map with the Transfer's Maps.
+      const this_type* srcDistObj = dynamic_cast<const this_type*> (&src);
+      if (srcDistObj != nullptr) {
+        if (revOp == DoForward) {
+          const bool srcMapSameAsImportSrcMap =
+            srcDistObj->getMap ()->isSameAs (* (transfer->getSourceMap ()));
+          TEUCHOS_TEST_FOR_EXCEPTION
+            (! srcMapSameAsImportSrcMap, std::invalid_argument,
+             "Tpetra::DistObject::" << modeString << ": For forward-mode "
+             "communication, the source DistObject's Map must be the same "
+             "as the input Export/Import object's source Map.");
+        }
+        else { // revOp == DoReverse
+          const bool srcMapSameAsImportTgtMap =
+            srcDistObj->getMap ()->isSameAs (* (transfer->getTargetMap ()));
+          TEUCHOS_TEST_FOR_EXCEPTION
+            (! srcMapSameAsImportTgtMap, std::invalid_argument,
+             "Tpetra::DistObject::" << modeString << ": For reverse-mode "
+             "communication, the source DistObject's Map must be the same "
+             "as the input Export/Import object's target Map.");
+        }
+      }
+    }
+
+    const size_t numSameIDs = transfer->getNumSameIDs ();
+    Distributor& distor = transfer->getDistributor ();
+
+    TEUCHOS_TEST_FOR_EXCEPTION
+      (debug && restrictedMode &&
+       (transfer->getPermuteToLIDs_dv().extent(0) != 0 ||
+        transfer->getPermuteFromLIDs_dv().extent(0) != 0),
+       std::invalid_argument,
+       "Tpetra::DistObject::" << modeString << ": Transfer object "
+       "cannot have permutes in restricted mode.");
+
+    // Do we need all communication buffers to live on host?
+    const bool commOnHost = ! Behavior::assumeMpiIsCudaAware ();
+    if (verbose) {
+      std::ostringstream os;
+      os << *prefix << "doTransfer: Use new interface; "
+        "commOnHost=" << (commOnHost ? "true" : "false") << endl;
+      std::cerr << os.str ();
+    }
+
+    using const_lo_dv_type =
+      Kokkos::DualView<const local_ordinal_type*, buffer_device_type>;
+    const_lo_dv_type permToLIDs = (revOp == DoForward) ?
+      transfer->getPermuteToLIDs_dv () :
+      transfer->getPermuteFromLIDs_dv ();
+    const_lo_dv_type permFromLIDs = (revOp == DoForward) ?
+      transfer->getPermuteFromLIDs_dv () :
+      transfer->getPermuteToLIDs_dv ();
+    const_lo_dv_type remoteLIDs = (revOp == DoForward) ?
+      transfer->getRemoteLIDs_dv () :
+      transfer->getExportLIDs_dv ();
+    const_lo_dv_type exportLIDs = (revOp == DoForward) ?
+      transfer->getExportLIDs_dv () :
+      transfer->getRemoteLIDs_dv ();
+    bool needCommunication = startTransferNew (src, CM, numSameIDs, permToLIDs, permFromLIDs,
+                                               remoteLIDs, exportLIDs, distor, revOp, commOnHost,
+                                               restrictedMode);
+
+    Teuchos::RCP<DistObject<Packet,LocalOrdinal,GlobalOrdinal,Node> > dest = Teuchos::rcpFromRef(*this);
+    Teuchos::RCP<TransferRequest<Packet, LocalOrdinal, GlobalOrdinal, Node>> req = Teuchos::rcp(new TransferRequest<Packet, LocalOrdinal, GlobalOrdinal, Node>(dest, transfer, revOp, CM, needCommunication));
+    return req;
+  }
+
+  template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
+  void
+  DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
+  finishTransfer (const ::Tpetra::Details::Transfer<local_ordinal_type, global_ordinal_type, node_type>& transfer,
+                  const ReverseOption revOp,
+                  const CombineMode CM,
+                  const bool needCommunication)
+  {
+    using Details::Behavior;
+    using Details::getDualViewCopyFromArrayView;
+    using Details::ProfilingRegion;
+    using std::endl;
+    const char funcName[] = "Tpetra::DistObject::finishTransfer";
+
+    ProfilingRegion region_doTransfer(funcName);
+    const bool verbose = Behavior::verbose("DistObject");
+
+    Distributor& distor = transfer.getDistributor ();
+
+    // Do we need all communication buffers to live on host?
+    const bool commOnHost = ! Behavior::assumeMpiIsCudaAware ();
+
+    using const_lo_dv_type =
+      Kokkos::DualView<const local_ordinal_type*, buffer_device_type>;
+    const_lo_dv_type permToLIDs = (revOp == DoForward) ?
+      transfer.getPermuteToLIDs_dv () :
+      transfer.getPermuteFromLIDs_dv ();
+    const_lo_dv_type permFromLIDs = (revOp == DoForward) ?
+      transfer.getPermuteFromLIDs_dv () :
+      transfer.getPermuteToLIDs_dv ();
+    const_lo_dv_type remoteLIDs = (revOp == DoForward) ?
+      transfer.getRemoteLIDs_dv () :
+      transfer.getExportLIDs_dv ();
+    finishTransferNew (CM, needCommunication,
+                       remoteLIDs, distor, revOp, commOnHost);
+
+    transferInProgress_ = false;
+
+    if (verbose) {
+      std::unique_ptr<std::string> prefix = this->createPrefix("DistObject", "finishTransfer");
+      std::ostringstream os;
+      os << *prefix << "Tpetra::DistObject::doTransfer: Done!" << endl;
+      std::cerr << os.str ();
+    }
+  }
+
+  template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
   bool
   DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
   reallocImportsIfNeeded (const size_t newSize,
@@ -658,7 +1099,7 @@ namespace Tpetra {
 
     return firstReallocated || secondReallocated;
   }
-
+  
   template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
   void
   DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
@@ -677,6 +1118,29 @@ namespace Tpetra {
                  const ReverseOption revOp,
                  const bool commOnHost,
                  const bool restrictedMode)
+  {
+    bool needCommunication = startTransferNew(src,CM,numSameIDs,permuteToLIDs,permuteFromLIDs,remoteLIDs,exportLIDs,distor,revOp,commOnHost,restrictedMode);
+    finishTransferNew(CM,needCommunication,remoteLIDs,distor,revOp,commOnHost);
+  }
+
+  template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
+  bool
+  DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
+  startTransferNew (const SrcDistObject& src,
+                    const CombineMode CM,
+                    const size_t numSameIDs,
+                    const Kokkos::DualView<const local_ordinal_type*,
+                      buffer_device_type>& permuteToLIDs,
+                    const Kokkos::DualView<const local_ordinal_type*,
+                      buffer_device_type>& permuteFromLIDs,
+                    const Kokkos::DualView<const local_ordinal_type*,
+                      buffer_device_type>& remoteLIDs,
+                    const Kokkos::DualView<const local_ordinal_type*,
+                      buffer_device_type>& exportLIDs,
+                    Distributor& distor,
+                    const ReverseOption revOp,
+                    const bool commOnHost,
+                    const bool restrictedMode)
   {
     using Details::Behavior;
     using ::Tpetra::Details::dualViewStatusToString;
@@ -698,7 +1162,7 @@ namespace Tpetra {
     Teuchos::TimeMonitor doXferMon (*doXferTimer_);
 #endif // HAVE_TPETRA_TRANSFER_TIMERS
 
-    const bool debug = Behavior::debug("DistObject");
+    // const bool debug = Behavior::debug("DistObject");
     const bool verbose = Behavior::verbose("DistObject");
     // Prefix for verbose output.  Use a pointer, so we don't pay for
     // string construction unless needed.  We set this below.
@@ -872,6 +1336,9 @@ namespace Tpetra {
       }
     } // if (CM != ZERO)
 
+    // Do we need to do communication (via doPostsAndWaits)?
+    bool needCommunication = CM != ZERO;
+
     // We only need to send data if the combine mode is not ZERO.
     if (CM != ZERO) {
       if (constantNumPackets != 0) {
@@ -882,9 +1349,6 @@ namespace Tpetra {
         const size_t rbufLen = remoteLIDs.extent (0) * constantNumPackets;
         reallocImportsIfNeeded (rbufLen, verbose, prefix.get ());
       }
-
-      // Do we need to do communication (via doPostsAndWaits)?
-      bool needCommunication = true;
 
       // This may be NULL.  It will be used below.
       const this_type* srcDistObj = dynamic_cast<const this_type*> (&src);
@@ -1064,14 +1528,14 @@ namespace Tpetra {
           if (commOnHost) {
             this->imports_.modify_host ();
             if (revOp == DoReverse) {
-              distor.doReversePostsAndWaits
+              distor.doReversePosts
                 (create_const_view (this->exports_.view_host ()),
                  numExportPacketsPerLID_av,
                  this->imports_.view_host (),
                  numImportPacketsPerLID_av);
             }
             else {
-              distor.doPostsAndWaits
+              distor.doPosts
                 (create_const_view (this->exports_.view_host ()),
                  numExportPacketsPerLID_av,
                  this->imports_.view_host (),
@@ -1081,14 +1545,14 @@ namespace Tpetra {
           else { // pack on device
             this->imports_.modify_device ();
             if (revOp == DoReverse) {
-              distor.doReversePostsAndWaits
+              distor.doReversePosts
                 (create_const_view (this->exports_.view_device ()),
                  numExportPacketsPerLID_av,
                  this->imports_.view_device (),
                  numImportPacketsPerLID_av);
             }
             else {
-              distor.doPostsAndWaits
+              distor.doPosts
                 (create_const_view (this->exports_.view_device ()),
                  numExportPacketsPerLID_av,
                  this->imports_.view_device (),
@@ -1126,13 +1590,13 @@ namespace Tpetra {
           if (commOnHost) {
             this->imports_.modify_host ();
             if (revOp == DoReverse) {
-              distor.doReversePostsAndWaits
+              distor.doReversePosts
                 (create_const_view (this->exports_.view_host ()),
                  constantNumPackets,
                  this->imports_.view_host ());
             }
             else {
-              distor.doPostsAndWaits
+              distor.doPosts
                 (create_const_view (this->exports_.view_host ()),
                  constantNumPackets,
                  this->imports_.view_host ());
@@ -1141,13 +1605,13 @@ namespace Tpetra {
           else { // pack on device
             this->imports_.modify_device ();
             if (revOp == DoReverse) {
-              distor.doReversePostsAndWaits
+              distor.doReversePosts
                 (create_const_view (this->exports_.view_device ()),
                  constantNumPackets,
                  this->imports_.view_device ());
             }
             else {
-              distor.doPostsAndWaits
+              distor.doPosts
                 (create_const_view (this->exports_.view_device ()),
                  constantNumPackets,
                  this->imports_.view_device ());
@@ -1155,56 +1619,139 @@ namespace Tpetra {
           } // commOnHost
         } // constant or variable num packets per LID
 
-        if (verbose) {
-          std::ostringstream os;
-          os << *prefix << "8. unpackAndCombine" << endl;
-          std::cerr << os.str ();
-        }
-        ProfilingRegion region_uc
-          ("Tpetra::DistObject::doTransferNew::unpackAndCombine");
-#ifdef HAVE_TPETRA_TRANSFER_TIMERS
-        // FIXME (mfh 04 Feb 2019) Deprecate Teuchos::TimeMonitor in
-        // favor of Kokkos profiling.
-        Teuchos::TimeMonitor unpackAndCombineMon (*unpackAndCombineTimer_);
-#endif // HAVE_TPETRA_TRANSFER_TIMERS
 
-        if (debug) {
-          std::ostringstream lclErrStrm;
-          bool lclSuccess = false;
-          try {
-            this->unpackAndCombine (remoteLIDs, this->imports_,
-                                    this->numImportPacketsPerLID_,
-                                    constantNumPackets, distor, CM);
-            lclSuccess = true;
-          }
-          catch (std::exception& e) {
-            lclErrStrm << "unpackAndCombine threw an exception: "
-                       << endl << e.what();
-          }
-          catch (...) {
-            lclErrStrm << "unpackAndCombine threw an exception "
-              "not a subclass of std::exception.";
-          }
-          const char gblErrMsgHeader[] = "Tpetra::DistObject::"
-            "doTransferNew threw an exception in unpackAndCombine on "
-            "one or more processes in the DistObject's communicator.";
-          auto comm = getMap()->getComm();
-          Details::checkGlobalError(std::cerr, lclSuccess,
-                                    lclErrStrm.str().c_str(),
-                                    gblErrMsgHeader, *comm);
-        }
-        else {
-          this->unpackAndCombine (remoteLIDs, this->imports_,
-                                  this->numImportPacketsPerLID_,
-                                  constantNumPackets, distor, CM);
-        }
       } // if (needCommunication)
     } // if (CM != ZERO)
 
+    return needCommunication;
+  }
+
+  template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
+  void
+  DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>::
+  finishTransferNew (const CombineMode CM,
+                     const bool needCommunication,
+                     const Kokkos::DualView<const local_ordinal_type*,
+                       buffer_device_type>& remoteLIDs,
+                     Distributor& distor,
+                     const ReverseOption revOp,
+                     const bool commOnHost)
+  {
+    using Details::Behavior;
+    using ::Tpetra::Details::dualViewStatusToString;
+    using ::Tpetra::Details::getArrayViewFromDualView;
+    using Details::ProfilingRegion;
+    using Kokkos::Compat::getArrayView;
+    using Kokkos::Compat::getConstArrayView;
+    using Kokkos::Compat::getKokkosViewDeepCopy;
+    using Kokkos::Compat::create_const_view;
+    using std::endl;
+    const char funcName[] = "Tpetra::DistObject::finishTransfer";
+
+    ProfilingRegion region_dTN(funcName);
+#ifdef HAVE_TPETRA_TRANSFER_TIMERS
+    // FIXME (mfh 04 Feb 2019) Deprecate Teuchos::TimeMonitor in favor
+    // of Kokkos profiling.
+    Teuchos::TimeMonitor doXferMon (*doXferTimer_);
+#endif // HAVE_TPETRA_TRANSFER_TIMERS
+
+    const bool debug = Behavior::debug("DistObject");
+    const bool verbose = Behavior::verbose("DistObject");
+
+    std::unique_ptr<std::string> prefix;
+    if (verbose) {
+      prefix = this->createPrefix("DistObject", "finishTransfer");
+    }
+
+    if (needCommunication) {
+      ProfilingRegion region_dpw
+        ("Tpetra::DistObject::doTransferNew::doWaits");
+#ifdef HAVE_TPETRA_TRANSFER_TIMERS
+      // FIXME (mfh 04 Feb 2019) Deprecate Teuchos::TimeMonitor in
+      // favor of Kokkos profiling.
+      Teuchos::TimeMonitor doPostsAndWaitsMon (*doPostsAndWaitsTimer_);
+#endif // HAVE_TPETRA_TRANSFER_TIMERS
+
+      if (verbose) {
+        std::ostringstream os;
+        os << *prefix << "7.0. "
+           << (revOp == DoReverse ? "Reverse" : "Forward")
+           << " mode" << endl;
+        std::cerr << os.str ();
+      }
+
+      if (verbose) {
+        std::ostringstream os;
+        os << *prefix << "7.1. Const # packets per LID: " << endl
+           << *prefix << "  "
+           << dualViewStatusToString (this->exports_, "exports_")
+           << endl
+           << *prefix << "  "
+           << dualViewStatusToString (this->exports_, "imports_")
+           << endl;
+        std::cerr << os.str ();
+      }
+
+      if (verbose) {
+        std::ostringstream os;
+        os << *prefix << "7.2. Comm on "
+           << (commOnHost ? "host" : "device")
+           << "; call do" << (revOp == DoReverse ? "Reverse" : "")
+           << "PostsAndWaits" << endl;
+        std::cerr << os.str ();
+      }
+      if (revOp == DoReverse) {
+        distor.doReverseWaits ();
+      }
+      else {
+        distor.doWaits ();
+      }
+    }
+
+    size_t constantNumPackets = this->constantNumberOfPackets ();
+
     if (verbose) {
       std::ostringstream os;
-      os << *prefix << "9. Done!" << endl;
+      os << *prefix << "8. unpackAndCombine" << endl;
       std::cerr << os.str ();
+    }
+    ProfilingRegion region_uc
+      ("Tpetra::DistObject::doTransferNew::unpackAndCombine");
+#ifdef HAVE_TPETRA_TRANSFER_TIMERS
+    // FIXME (mfh 04 Feb 2019) Deprecate Teuchos::TimeMonitor in
+    // favor of Kokkos profiling.
+    Teuchos::TimeMonitor unpackAndCombineMon (*unpackAndCombineTimer_);
+#endif // HAVE_TPETRA_TRANSFER_TIMERS
+
+    if (debug) {
+      std::ostringstream lclErrStrm;
+      bool lclSuccess = false;
+      try {
+        this->unpackAndCombine (remoteLIDs, this->imports_,
+                                this->numImportPacketsPerLID_,
+                                constantNumPackets, distor, CM);
+        lclSuccess = true;
+      }
+      catch (std::exception& e) {
+        lclErrStrm << "unpackAndCombine threw an exception: "
+                   << endl << e.what();
+      }
+      catch (...) {
+        lclErrStrm << "unpackAndCombine threw an exception "
+          "not a subclass of std::exception.";
+      }
+      const char gblErrMsgHeader[] = "Tpetra::DistObject::"
+        "doTransferNew threw an exception in unpackAndCombine on "
+        "one or more processes in the DistObject's communicator.";
+      auto comm = getMap()->getComm();
+      Details::checkGlobalError(std::cerr, lclSuccess,
+                                lclErrStrm.str().c_str(),
+                                gblErrMsgHeader, *comm);
+    }
+    else {
+      this->unpackAndCombine (remoteLIDs, this->imports_,
+                              this->numImportPacketsPerLID_,
+                              constantNumPackets, distor, CM);
     }
   }
 

--- a/packages/tpetra/core/src/Tpetra_Distributor.cpp
+++ b/packages/tpetra/core/src/Tpetra_Distributor.cpp
@@ -382,6 +382,9 @@ namespace Tpetra {
       // ParameterListAcceptor semantics require pointer identity of the
       // sublist passed to setParameterList(), so we save the pointer.
       this->setMyParamList (plist);
+
+      if (!reverseDistributor_.is_null())
+        reverseDistributor_->setParameterList (plist);
     }
   }
 

--- a/packages/tpetra/core/src/Tpetra_TransferRequest_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_TransferRequest_decl.hpp
@@ -1,0 +1,111 @@
+// @HEADER
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services Package
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// ************************************************************************
+// @HEADER
+
+#ifndef TPETRA_TRANSFERREQUEST_DECL_HPP
+#define TPETRA_TRANSFERREQUEST_DECL_HPP
+
+/// \file Tpetra_TransferRequest_decl.hpp
+/// \brief Declaration of the Tpetra::TransferRequest class
+///
+/// If you want to use Tpetra::TransferRequest, include
+/// "Tpetra_TransferRequest.hpp" (a file which CMake generates and installs
+/// for you).  If you only want the declaration of Tpetra::TransferRequest,
+/// include this file (Tpetra_TransferRequest_decl.hpp).
+
+#include "Tpetra_Map.hpp"
+#include "Tpetra_Import.hpp"
+#include "Tpetra_Export.hpp"
+#include "Tpetra_DistObject_fwd.hpp"
+#include "Kokkos_ArithTraits.hpp"
+
+
+namespace Tpetra {
+
+  template <class Packet,
+            class LocalOrdinal,
+            class GlobalOrdinal,
+            class Node>
+  class TransferRequest {
+  public:
+    //! @name Typedefs
+    //@{
+
+    /// \brief The type of each datum being sent or received in an Import or Export.
+    ///
+    /// Note that this type does not always correspond to the
+    /// <tt>Scalar</tt> template parameter of subclasses.
+    using packet_type = typename ::Kokkos::Details::ArithTraits<Packet>::val_type;
+    //! The type of local indices.
+    using local_ordinal_type = LocalOrdinal;
+    //! The type of global indices.
+    using global_ordinal_type = GlobalOrdinal;
+    //! The Node type.  If you don't know what this is, don't use it.
+    using node_type = Node;
+
+    using dist_object_type = DistObject<Packet, LocalOrdinal, GlobalOrdinal, Node>;
+
+    using transfer_type = ::Tpetra::Details::Transfer<local_ordinal_type, global_ordinal_type, node_type>;
+
+    using rev_op_type = typename dist_object_type::ReverseOption;
+
+    TransferRequest(Teuchos::RCP<dist_object_type>& dest,
+                    Teuchos::RCP<const transfer_type>& transfer,
+                    rev_op_type revOp,
+                    CombineMode CM,
+                    bool needCommunication);
+
+    void process();
+
+    virtual ~TransferRequest () = default;
+
+  private:
+
+
+    Teuchos::RCP<dist_object_type> dest_;
+    Teuchos::RCP<const transfer_type> transfer_;
+    rev_op_type revOp_;
+    CombineMode CM_;
+    bool needCommunication_;
+    bool hasBeenProcessed_;
+
+
+  }; // class TransferRequest
+} // namespace Tpetra
+
+#endif // TPETRA_TRANSFERREQUEST_DECL_HPP

--- a/packages/tpetra/core/src/Tpetra_TransferRequest_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_TransferRequest_def.hpp
@@ -1,0 +1,97 @@
+// @HEADER
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services Package
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// ************************************************************************
+// @HEADER
+
+#ifndef TPETRA_TRANSFERREQUEST_DEF_HPP
+#define TPETRA_TRANSFERREQUEST_DEF_HPP
+
+/// \file Tpetra_TransferRequest_def.hpp
+/// \brief Definition of the Tpetra::TransferRequest class
+///
+/// If you want to use Tpetra::TransferRequest, include
+/// "Tpetra_TransferRequest.hpp" (a file which CMake generates and installs
+/// for you).  If you only want the declaration of Tpetra::TransferRequest,
+/// include "Tpetra_TransferRequest_decl.hpp".
+
+
+#include "Tpetra_DistObject.hpp"
+
+namespace Tpetra {
+
+  template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
+  TransferRequest<Packet, LocalOrdinal, GlobalOrdinal, Node>::
+  TransferRequest (Teuchos::RCP<dist_object_type>& dest,
+                   Teuchos::RCP<const transfer_type>& transfer,
+                   rev_op_type revOp,
+                   CombineMode CM,
+                   bool needCommunication) :
+    dest_ (dest),
+    transfer_ (transfer),
+    revOp_ (revOp),
+    CM_ (CM),
+    needCommunication_ (needCommunication),
+    hasBeenProcessed_ (false)
+  {
+  }
+
+  template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
+  void
+  TransferRequest<Packet, LocalOrdinal, GlobalOrdinal, Node>::
+  process()
+  {
+    if (!hasBeenProcessed_) {
+      dest_->finishTransfer(*transfer_, revOp_, CM_, needCommunication_);
+      dest_ = Teuchos::null;
+      transfer_ = Teuchos::null;
+      hasBeenProcessed_ = true;
+    }
+  }
+
+// Explicit instantiation macro for general TransferRequest.
+#define TPETRA_TRANSFERREQUEST_INSTANT(SCALAR, LO, GO, NODE) \
+  template class TransferRequest< SCALAR , LO , GO , NODE >;
+
+// Explicit instantiation macro for TransferRequest<char, ...>.
+// The "SLGN" stuff above doesn't work for Packet=char.
+#define TPETRA_TRANSFERREQUEST_INSTANT_CHAR(LO, GO, NODE) \
+  template class TransferRequest< char , LO , GO , NODE >;
+
+
+} // namespace Tpetra
+
+#endif // TPETRA_DISTOBJECT_DEF_HPP

--- a/packages/tpetra/core/src/Tpetra_TransferRequest_fwd.hpp
+++ b/packages/tpetra/core/src/Tpetra_TransferRequest_fwd.hpp
@@ -1,0 +1,60 @@
+// @HEADER
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services Package
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+
+#ifndef TPETRA_TRANSFERREQUEST_FWD_HPP
+#define TPETRA_TRANSFERREQUEST_FWD_HPP
+
+#include "Tpetra_Details_DefaultTypes.hpp"
+
+/// \file Tpetra_TransferRequest_fwd.hpp
+/// \brief Forward declaration of Tpetra::TransferRequest
+
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+namespace Tpetra {
+template<class Packet,
+         class LocalOrdinal = ::Tpetra::Details::DefaultTypes::local_ordinal_type,
+         class GlobalOrdinal = ::Tpetra::Details::DefaultTypes::global_ordinal_type,
+         class Node = ::Tpetra::Details::DefaultTypes::node_type>
+class TransferRequest;
+} // namespace Tpetra
+#endif // DOXYGEN_SHOULD_SKIP_THIS
+
+#endif // TPETRA_TRANSFERREQUEST_FWD_HPP

--- a/packages/xpetra/src/DistObject/Xpetra_DistObject.hpp
+++ b/packages/xpetra/src/DistObject/Xpetra_DistObject.hpp
@@ -52,10 +52,34 @@
 #include "Xpetra_Map.hpp"
 #include "Xpetra_Import.hpp"
 #include "Xpetra_Export.hpp"
+#include "Xpetra_Exceptions.hpp"
 #include <Kokkos_DefaultNode.hpp>
 #include <Teuchos_Describable.hpp>
 
 namespace Xpetra {
+
+  template<class Packet,
+           class LocalOrdinal,
+           class GlobalOrdinal,
+           class Node = KokkosClassic::DefaultNode::DefaultNodeType>
+  class TransferRequest {
+
+  public:
+
+    //! @name Constructor/Destructor Methods
+    //@{
+
+    //! Destructor.
+    virtual ~TransferRequest() = default;
+
+    virtual void process() = 0;
+
+
+
+    //@}
+
+  };      // TransferRequest class
+
 
   template <class Packet,
             class LocalOrdinal,
@@ -81,14 +105,22 @@ namespace Xpetra {
     //! Import data into this object using an Import object ("forward mode").
     virtual void doImport(const DistObject< Packet, LocalOrdinal, GlobalOrdinal, Node > &source, const Import< LocalOrdinal, GlobalOrdinal, Node > &importer, CombineMode CM)= 0;
 
+    Teuchos::RCP<TransferRequest <Packet, LocalOrdinal, GlobalOrdinal, Node> > startImport(const DistObject< Packet, LocalOrdinal, GlobalOrdinal, Node > &source, const Teuchos::RCP<const Import< LocalOrdinal, GlobalOrdinal, Node > >&importer, CombineMode CM) { TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "DistObject<..>::startExport not implemented"); };
+
     //! Export data into this object using an Export object ("forward mode").
     virtual void doExport(const DistObject< Packet, LocalOrdinal, GlobalOrdinal, Node > &source, const Export< LocalOrdinal, GlobalOrdinal, Node > &exporter, CombineMode CM)= 0;
+
+    Teuchos::RCP<TransferRequest <Packet, LocalOrdinal, GlobalOrdinal, Node> > startExport(const DistObject< Packet, LocalOrdinal, GlobalOrdinal, Node > &source, const Teuchos::RCP<const Export< LocalOrdinal, GlobalOrdinal, Node > >&importer, CombineMode CM) { TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "DistObject<..>::startExport not implemented"); };
 
     //! Import data into this object using an Export object ("reverse mode").
     virtual void doImport(const DistObject< Packet, LocalOrdinal, GlobalOrdinal, Node > &source, const Export< LocalOrdinal, GlobalOrdinal, Node > &exporter, CombineMode CM)= 0;
 
+    Teuchos::RCP<TransferRequest <Packet, LocalOrdinal, GlobalOrdinal, Node> > startImport(const DistObject< Packet, LocalOrdinal, GlobalOrdinal, Node > &source, const Teuchos::RCP<const Export< LocalOrdinal, GlobalOrdinal, Node > >&exporter, CombineMode CM) { TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "DistObject<..>::startExport not implemented"); };
+
     //! Export data into this object using an Import object ("reverse mode").
     virtual void doExport(const DistObject< Packet, LocalOrdinal, GlobalOrdinal, Node > &source, const Import< LocalOrdinal, GlobalOrdinal, Node > &importer, CombineMode CM)= 0;
+
+    Teuchos::RCP<TransferRequest <Packet, LocalOrdinal, GlobalOrdinal, Node> > startExport(const DistObject< Packet, LocalOrdinal, GlobalOrdinal, Node > &source, const Teuchos::RCP<const Import< LocalOrdinal, GlobalOrdinal, Node > >&importer, CombineMode CM) { TEUCHOS_TEST_FOR_EXCEPTION(1, Xpetra::Exceptions::NotImplemented, "DistObject<..>::startExport not implemented"); };
 
     //@}
 

--- a/packages/xpetra/src/DistObject/Xpetra_TpetraTransferRequest.hpp
+++ b/packages/xpetra/src/DistObject/Xpetra_TpetraTransferRequest.hpp
@@ -1,0 +1,127 @@
+// @HEADER
+//
+// ***********************************************************************
+//
+//             Xpetra: A linear algebra interface package
+//                  Copyright 2012 Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact
+//                    Jonathan Hu       (jhu@sandia.gov)
+//                    Andrey Prokopenko (aprokop@sandia.gov)
+//                    Ray Tuminaro      (rstumin@sandia.gov)
+//
+// ***********************************************************************
+//
+// @HEADER
+#ifndef XPETRA_TPETRATRANSFERREQUEST_DECL_HPP
+#define XPETRA_TPETRATRANSFERREQUEST_DECL_HPP
+
+#include "Xpetra_TpetraConfigDefs.hpp"
+
+#include "Xpetra_DistObject.hpp"
+#include "Tpetra_TransferRequest.hpp"
+
+
+namespace Xpetra {
+
+
+  template <class Packet,
+            class LocalOrdinal,
+            class GlobalOrdinal,
+            class Node>
+  class TpetraTransferRequest
+    : public virtual TransferRequest< Packet, LocalOrdinal, GlobalOrdinal, Node >
+  {
+
+    // The following typedef are used by the XPETRA_DYNAMIC_CAST() macro.
+    typedef TpetraTransferRequest<Packet,LocalOrdinal,GlobalOrdinal,Node> TpetraTransferRequestClass;
+
+  public:
+
+    //! @name Constructors and destructor
+    //@{
+
+    //! Basic constuctor.
+    TpetraTransferRequest(Teuchos::RCP<Tpetra::TransferRequest<Packet,LocalOrdinal, GlobalOrdinal, Node > > &tr)
+      : tr_ (tr)
+    {}
+
+    virtual ~TpetraTransferRequest() = default;
+
+    void process() {tr_->process(); };
+
+
+  private:
+    //! The Tpetra::TransferRequest which this class wraps.
+    RCP< Tpetra::TransferRequest< Packet, LocalOrdinal, GlobalOrdinal, Node> > tr_;
+
+  }; // TpetraTransferRequest class
+
+
+  // Things we actually need
+
+  // Things we actually need
+  template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
+  RCP<TransferRequest<Packet, LocalOrdinal, GlobalOrdinal, Node > > toXpetra(RCP<Tpetra::TransferRequest< Packet, LocalOrdinal, GlobalOrdinal, Node > > tr) {
+    if (!tr.is_null())
+      return rcp(new TpetraTransferRequest<Packet, LocalOrdinal, GlobalOrdinal, Node >(tr));
+
+    return Teuchos::null;
+  }
+
+  template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
+  RCP<const TransferRequest<Packet, LocalOrdinal, GlobalOrdinal, Node > > toXpetra(RCP<const Tpetra::TransferRequest< Packet, LocalOrdinal, GlobalOrdinal, Node > > tr) {
+    if (!tr.is_null())
+      return rcp(new TpetraTransferRequest<Packet, LocalOrdinal, GlobalOrdinal, Node >(tr));
+
+    return Teuchos::null;
+  }
+
+  template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
+  const Tpetra::TransferRequest< Packet,LocalOrdinal, GlobalOrdinal, Node> & toTpetra(const TransferRequest< Packet,LocalOrdinal, GlobalOrdinal, Node> &xTr) {
+    typedef TpetraTransferRequest< Packet, LocalOrdinal, GlobalOrdinal, Node > TpetraTransferRequestClass;
+    XPETRA_DYNAMIC_CAST(const TpetraTransferRequestClass, xTr, tTr, "toTpetra");
+    return *tTr.getTpetra_TransferRequest();
+  }
+
+  template <class Packet, class LocalOrdinal, class GlobalOrdinal, class Node>
+  Tpetra::TransferRequest< Packet,LocalOrdinal, GlobalOrdinal, Node> & toTpetra(TransferRequest< Packet,LocalOrdinal, GlobalOrdinal, Node> &xTr) {
+    typedef TpetraTransferRequest< Packet, LocalOrdinal, GlobalOrdinal, Node > TpetraTransferRequestClass;
+    XPETRA_DYNAMIC_CAST(      TpetraTransferRequestClass, xTr, tTr, "toTpetra");
+    return *tTr.getTpetra_TransferRequest();
+  }
+
+} // Xpetra namespace
+
+#define XPETRA_TPETRATRANSFERREQUEST_SHORT
+#endif // XPETRA_TPETRATRANSFERREQUEST_HPP

--- a/packages/xpetra/src/MultiVector/Xpetra_TpetraMultiVector_decl.hpp
+++ b/packages/xpetra/src/MultiVector/Xpetra_TpetraMultiVector_decl.hpp
@@ -255,11 +255,19 @@ namespace Xpetra {
 
     void doImport(const DistObject< Scalar, LocalOrdinal,GlobalOrdinal,Node> &source, const Import<LocalOrdinal,GlobalOrdinal,Node> &importer, CombineMode CM);
 
+    Teuchos::RCP<TransferRequest <Scalar, LocalOrdinal, GlobalOrdinal, Node> > startImport(const DistObject< Scalar, LocalOrdinal, GlobalOrdinal, Node > &source, const Teuchos::RCP<const Import< LocalOrdinal, GlobalOrdinal, Node > >&importer, CombineMode CM);
+
     void doExport(const DistObject< Scalar, LocalOrdinal, GlobalOrdinal, Node > &dest, const Import<LocalOrdinal,GlobalOrdinal,Node>& importer, CombineMode CM);
+
+    Teuchos::RCP<TransferRequest <Scalar, LocalOrdinal, GlobalOrdinal, Node> > startExport(const DistObject< Scalar, LocalOrdinal, GlobalOrdinal, Node > &source, const Teuchos::RCP<const Import< LocalOrdinal, GlobalOrdinal, Node > >&importer, CombineMode CM);
 
     void doImport(const DistObject< Scalar, LocalOrdinal, GlobalOrdinal, Node > &source, const Export<LocalOrdinal,GlobalOrdinal,Node>& exporter, CombineMode CM);
 
+    Teuchos::RCP<TransferRequest <Scalar, LocalOrdinal, GlobalOrdinal, Node> > startImport(const DistObject< Scalar, LocalOrdinal, GlobalOrdinal, Node > &source, const Teuchos::RCP<const Export< LocalOrdinal, GlobalOrdinal, Node > >&exporter, CombineMode CM);
+
     void doExport(const DistObject< Scalar, LocalOrdinal, GlobalOrdinal, Node > &dest, const Export<LocalOrdinal,GlobalOrdinal,Node>& exporter, CombineMode CM);
+
+    Teuchos::RCP<TransferRequest <Scalar, LocalOrdinal, GlobalOrdinal, Node> > startExport(const DistObject< Scalar, LocalOrdinal, GlobalOrdinal, Node > &source, const Teuchos::RCP<const Export< LocalOrdinal, GlobalOrdinal, Node > >&exporter, CombineMode CM);
 
     void replaceMap(const RCP<const Map<LocalOrdinal,GlobalOrdinal,Node> >& map);
 

--- a/packages/xpetra/src/MultiVector/Xpetra_TpetraMultiVector_def.hpp
+++ b/packages/xpetra/src/MultiVector/Xpetra_TpetraMultiVector_def.hpp
@@ -51,6 +51,7 @@
 #include "Xpetra_Utils.hpp"
 #include "Xpetra_TpetraImport.hpp"
 #include "Xpetra_TpetraExport.hpp"
+#include "Xpetra_TpetraTransferRequest.hpp"
 
 #include "Xpetra_TpetraMultiVector_decl.hpp"
 #include "Tpetra_MultiVector.hpp"
@@ -309,6 +310,18 @@ namespace Xpetra {
     RCP< const Tpetra::MultiVector< Scalar, LocalOrdinal, GlobalOrdinal,Node> > v = tSource.getTpetra_MultiVector();
     this->getTpetra_MultiVector()->doImport(*v, toTpetra(importer), toTpetra(CM));
   }
+
+  template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  Teuchos::RCP<TransferRequest <Scalar, LocalOrdinal, GlobalOrdinal, Node> >
+  TpetraMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>::
+  startImport(const DistObject< Scalar, LocalOrdinal, GlobalOrdinal, Node > &source, const Teuchos::RCP<const Import< LocalOrdinal, GlobalOrdinal, Node > >&importer, CombineMode CM) {
+    XPETRA_MONITOR("TpetraMultiVector::startImport");
+
+    XPETRA_DYNAMIC_CAST(const TpetraMultiVectorClass, source, tSource, "Xpetra::TpetraMultiVector::startImport only accept Xpetra::TpetraMultiVector as input arguments."); //TODO: remove and use toTpetra()
+    RCP< const Tpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > tImporter = Teuchos::rcp_dynamic_cast<const TpetraImport<LocalOrdinal,GlobalOrdinal,Node> >(importer)->getTpetra_Import();
+    RCP< const Tpetra::MultiVector< Scalar, LocalOrdinal, GlobalOrdinal,Node> > v = tSource.getTpetra_MultiVector();
+    return toXpetra(this->getTpetra_MultiVector()->startImport(*v, tImporter, toTpetra(CM)));
+  }
   
   template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>  
   void TpetraMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>::    
@@ -319,6 +332,18 @@ namespace Xpetra {
     RCP< const Tpetra::MultiVector< Scalar, LocalOrdinal, GlobalOrdinal,Node> > v = tDest.getTpetra_MultiVector();
     this->getTpetra_MultiVector()->doExport(*v, toTpetra(importer), toTpetra(CM));
     
+  }
+
+  template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  Teuchos::RCP<TransferRequest <Scalar, LocalOrdinal, GlobalOrdinal, Node> >
+  TpetraMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>::
+  startExport(const DistObject< Scalar, LocalOrdinal, GlobalOrdinal, Node > &source, const Teuchos::RCP<const Import< LocalOrdinal, GlobalOrdinal, Node > >&importer, CombineMode CM) {
+    XPETRA_MONITOR("TpetraMultiVector::startImport");
+
+    XPETRA_DYNAMIC_CAST(const TpetraMultiVectorClass, source, tSource, "Xpetra::TpetraMultiVector::startExport only accept Xpetra::TpetraMultiVector as input arguments."); //TODO: remove and use toTpetra()
+    RCP< const Tpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > tImporter = Teuchos::rcp_dynamic_cast<const TpetraImport<LocalOrdinal,GlobalOrdinal,Node> >(importer)->getTpetra_Import();
+    RCP< const Tpetra::MultiVector< Scalar, LocalOrdinal, GlobalOrdinal,Node> > v = tSource.getTpetra_MultiVector();
+    return toXpetra(this->getTpetra_MultiVector()->startExport(*v, tImporter, toTpetra(CM)));
   }
   
   template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
@@ -331,6 +356,18 @@ namespace Xpetra {
     this->getTpetra_MultiVector()->doImport(*v, toTpetra(exporter), toTpetra(CM));
     
   }
+
+  template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  Teuchos::RCP<TransferRequest <Scalar, LocalOrdinal, GlobalOrdinal, Node> >
+  TpetraMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>::
+  startImport(const DistObject< Scalar, LocalOrdinal, GlobalOrdinal, Node > &source, const Teuchos::RCP<const Export< LocalOrdinal, GlobalOrdinal, Node > >&exporter, CombineMode CM) {
+    XPETRA_MONITOR("TpetraMultiVector::startImport");
+
+    XPETRA_DYNAMIC_CAST(const TpetraMultiVectorClass, source, tSource, "Xpetra::TpetraMultiVector::startImport only accept Xpetra::TpetraMultiVector as input arguments."); //TODO: remove and use toTpetra()
+    RCP< const Tpetra::Export<LocalOrdinal, GlobalOrdinal, Node> > tExporter = Teuchos::rcp_dynamic_cast<const TpetraExport<LocalOrdinal,GlobalOrdinal,Node> >(exporter)->getTpetra_Export();
+    RCP< const Tpetra::MultiVector< Scalar, LocalOrdinal, GlobalOrdinal,Node> > v = tSource.getTpetra_MultiVector();
+    return toXpetra(this->getTpetra_MultiVector()->startImport(*v, tExporter, toTpetra(CM)));
+  }
   
   template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void TpetraMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>::    
@@ -342,6 +379,18 @@ namespace Xpetra {
     this->getTpetra_MultiVector()->doExport(*v, toTpetra(exporter), toTpetra(CM));
 
     }
+
+  template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
+  Teuchos::RCP<TransferRequest <Scalar, LocalOrdinal, GlobalOrdinal, Node> >
+  TpetraMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>::
+  startExport(const DistObject< Scalar, LocalOrdinal, GlobalOrdinal, Node > &source, const Teuchos::RCP<const Export< LocalOrdinal, GlobalOrdinal, Node > >&exporter, CombineMode CM) {
+    XPETRA_MONITOR("TpetraMultiVector::startExport");
+
+    XPETRA_DYNAMIC_CAST(const TpetraMultiVectorClass, source, tSource, "Xpetra::TpetraMultiVector::startExport only accept Xpetra::TpetraMultiVector as input arguments."); //TODO: remove and use toTpetra()
+    RCP< const Tpetra::Export<LocalOrdinal, GlobalOrdinal, Node> > tExporter = Teuchos::rcp_dynamic_cast<const TpetraExport<LocalOrdinal,GlobalOrdinal,Node> >(exporter)->getTpetra_Export();
+    RCP< const Tpetra::MultiVector< Scalar, LocalOrdinal, GlobalOrdinal,Node> > v = tSource.getTpetra_MultiVector();
+    return toXpetra(this->getTpetra_MultiVector()->startExport(*v, tExporter, toTpetra(CM)));
+  }
 
   template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
   void TpetraMultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>::    

--- a/packages/xpetra/src/Utils/ClassList/PA-LO-GO-NO.classList
+++ b/packages/xpetra/src/Utils/ClassList/PA-LO-GO-NO.classList
@@ -1,1 +1,3 @@
 DistObject
+TransferRequest
+TpetraTransferRequest


### PR DESCRIPTION
@trilinos/tpetra 

## Motivation
This is a hacked together attempt of splitting Tpetra's communication routines to allow for communication/computation overlap. THIS IS NOWHERE READY TO BE MERGED.

In `DistObject::doTransferNew` I split the `doPostAndWaits` call into `doPosts` and `doWaits`. After `doPosts`, I return a so-called `Tpetra::TransferRequest` object to the user. The `process` method of this object kicks off `doWaits` and `unpackAndCombine`.

The functionality of `doTransfer` (and hence `doImport` and `doExport`) has not been changed, it simply calls `process` on the `TransferRequest` right away. I added `startImport` and `startExport` methods that return the `TransferRequest` object instead to the user. I made the necessary changes to use it in `MueLu::RefMaxwell`.
