### PR TITLE
Tpetra: Edit CMakeLists to not check for Kokkos UVM if Tpetra disables CUDA

### DIFF
--- a/packages/tpetra/core/CMakeLists.txt
+++ b/packages/tpetra/core/CMakeLists.txt
@@ -26,7 +26,8 @@ TRIBITS_ADD_OPTION_AND_DEFINE(
 
 ASSERT_DEFINED(Kokkos_ENABLE_CUDA)
 ASSERT_DEFINED(Kokkos_ENABLE_CUDA_UVM)
-IF (Kokkos_ENABLE_CUDA AND NOT Kokkos_ENABLE_CUDA_UVM)
+ASSERT_DEFINED(Tpetra_ENABLE_CUDA)
+IF (Kokkos_ENABLE_CUDA AND NOT Kokkos_ENABLE_CUDA_UVM AND Tpetra_ENABLE_CUDA)
   MESSAGE (FATAL_ERROR "If CUDA is enabled in Kokkos, Tpetra requires that Kokkos' UVM support be enabled.  You may do this by setting the CMake option Kokkos_ENABLE_CUDA_UVM:BOOL=ON (WARNING: IT IS CASE SENSITIVE!) and running CMake again.\n\nDetails for developers: UVM stands for \"Unified Virtual Memory\".  It lets code running on the host processor access GPU memory.  There is a difference between CUDA's support for UVM, and Kokkos' support for UVM.  Versions of CUDA >= 6 have UVM support built in by default.  Kokkos always supports this.  In particular, Kokkos always has a memory space for UVM allocations, called Kokkos::CudaUVMSpace.  \"Turning on UVM support in Kokkos\" means two things:\n\n1. Kokkos::Cuda::memory_space (the CUDA execution space's default memory space) is Kokkos::CudaUVMSpace, rather than Kokkos::CudaSpace.\n\n2. Kokkos::DualView<T, Kokkos::Cuda> only uses a single allocation, in the Kokkos::CudaUVMSpace memory space.")
 ENDIF ()
 


### PR DESCRIPTION
...and Kokkos enables CUDA. 

Allow Tpetra to build without CUDA without implicitly assuming `Kokkos_ENABLE_CUDA` implies `Tpetra_ENABLE_CUDA`.

<!---

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

A Trilinos build with **serial** Tpetra was required that had `Kokkos_ENABLE_CUDA` without `Kokkos_ENABLE_CUDA_UVM`. Previously, a CMake assert error was not allowing this case. 

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

It is rare to need Kokkos CUDA but not a CUDA(w/ UVM) enabled Tpetra, so this change should impact no current users.

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Tested on Waterman (P9/Volta). Ensured that the target build case builds.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->