### PR TITLE
Adjust fences to be at point of error

### DIFF
--- a/packages/tpetra/core/ext/TpetraExt_TripleMatrixMultiply_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_TripleMatrixMultiply_def.hpp
@@ -504,7 +504,6 @@ namespace Tpetra {
             targetMapToImportRow(i) = I_LID;
           }
         });
-      Kokkos::fence();
 
       // Call the actual kernel.  We'll rely on partial template specialization to call the correct one ---
       // Either the straight-up Tpetra code (SerialNode) or the KokkosKernels one (other NGP node types)
@@ -606,7 +605,6 @@ namespace Tpetra {
 
           }
         });
-      Kokkos::fence();
 
       // Call the actual kernel.  We'll rely on partial template specialization to call the correct one ---
       // Either the straight-up Tpetra code (SerialNode) or the KokkosKernels one (other NGP node types)
@@ -772,7 +770,6 @@ namespace Tpetra {
             targetMapToImportRow(i) = I_LID;
           }
         });
-      Kokkos::fence();
 
       // Call the actual kernel.  We'll rely on partial template specialization to call the correct one ---
       // Either the straight-up Tpetra code (SerialNode) or the KokkosKernels one (other NGP node types)
@@ -872,7 +869,6 @@ namespace Tpetra {
 
           }
         });
-      Kokkos::fence();
 
       // Call the actual kernel.  We'll rely on partial template specialization to call the correct one ---
       // Either the straight-up Tpetra code (SerialNode) or the KokkosKernels one (other NGP node types)
@@ -1216,6 +1212,10 @@ namespace Tpetra {
       // For column index Aik in row i of A, Acol2Prow[Aik] tells
       // you whether the corresponding row of P belongs to P_local
       // ("orig") or P_remote ("Import").
+
+      // Necessary until following UVM host accesses are changed - for example Crowptr
+      // Also probably needed in mult_R_A_P_newmatrix_kernel_wrapper - did not demonstrate this in test failure yet
+      Kokkos::fence();
 
       // For each row of R
       size_t OLD_ip = 0, CSR_ip = 0;

--- a/packages/tpetra/core/src/Tpetra_Map_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Map_def.hpp
@@ -1645,7 +1645,6 @@ namespace Tpetra {
         Kokkos::RangePolicy<LO, typename DT::execution_space>
           range (static_cast<LO> (0), static_cast<LO> (lgMap.size ()));
         Kokkos::parallel_for (range, *this);
-        Kokkos::fence();
       }
 
       KOKKOS_INLINE_FUNCTION void operator () (const LO& lid) const {
@@ -1721,6 +1720,9 @@ namespace Tpetra {
         os << *prefix << "Copy lgMap to lgMapHost" << endl;
         std::cerr << os.str();
       }
+
+      Kokkos::fence(); // following create_mirror_view fails with CUDA_LAUNCH_BLOCKING=0 due to above FillLgMap parallel_for
+
       auto lgMapHost =
         Kokkos::create_mirror_view (Kokkos::HostSpace (), lgMap);
       Kokkos::deep_copy (lgMapHost, lgMap);

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -3919,9 +3919,11 @@ namespace Tpetra {
       const impl_scalar_type alpha_IST (alpha);
 
       ProfilingRegion regionGemm ("Tpetra::MV::multiply-call-gemm");
+
+      this->modify_device ();
+
       KokkosBlas::gemm (&ctransA, &ctransB, alpha_IST, A_sub, B_sub,
                         beta_local, C_sub);
-      Kokkos::fence();
     }
 
     if (! isConstantStride ()) {
@@ -3934,6 +3936,7 @@ namespace Tpetra {
 
     // If Case 2 then sum up *this and distribute it to all processes.
     if (Case2) {
+      Kokkos::fence();
       this->reduce ();
     }
   }


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Follows #7069. Changes fence placement to be at the point of error. This addresses comments in #7069 and is intended to make the next step of removing the fences easier.

Also added a modify_device() for the KokkosBlas::gemm call so subsequent host access will properly sync and fence.
 
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->



## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Tpetra tests on white with CUDA_LAUNCH_BLOCKING unset.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->