### PR TITLE
Improve watchr output

### DIFF
--- a/packages/teuchos/comm/src/Teuchos_StackedTimer.hpp
+++ b/packages/teuchos/comm/src/Teuchos_StackedTimer.hpp
@@ -759,8 +759,9 @@ protected:
 
    /**
     * Recursive call to print a level of timer data, in Watchr XML format.
+    * prependRoot will be prepended to the root level's timer name in the output (if level > 0, it has no effect).
     */
-  double printLevelXML(std::string prefix, int level, std::ostream &os, std::vector<bool> &printed, double parent_time);
+  double printLevelXML(std::string prefix, int level, std::ostream &os, std::vector<bool> &printed, double parent_time, const std::string& prependRoot = "");
 
 };  //StackedTimer
 

--- a/packages/teuchos/comm/src/Teuchos_StackedTimer.hpp
+++ b/packages/teuchos/comm/src/Teuchos_StackedTimer.hpp
@@ -660,9 +660,22 @@ public:
   void reportXML(std::ostream &os, const std::string& datestamp, const std::string& timestamp, Teuchos::RCP<const Teuchos::Comm<int> > comm);
 
   /**
-   * Dump all the data from all the MPI ranks to <code>$WATCHR_PERF_DIR/name_$DATESTAMP.xml</code>,
-   *  if the environment variable WATCHR_PERF_DIR is defined and non-empty (otherwise, do nothing).
-   *  DATESTAMP is calculated from the current UTC time, in the format YYYY_MM_DD.
+   * Dump all the data from all the MPI ranks to an XML file. This function
+   * calls reportXML and is intended to be used directly by performance tests.
+   *
+   * The output filename is controlled by two environment variables: <code>$WATCHR_PERF_DIR</code> (required)
+   * and <code>$WATCHR_BUILD_NAME</code> (optional). <code>$WATCHR_PERF_DIR</code> is the directory where the output
+   * will be created. If it is not set or is empty, no output will be produced and the function returns an empty
+   * string on all ranks.
+   *
+   * If <code>$WATCHR_BUILD_NAME</code> is set, the filename is
+   * <code>$WATCHR_BUILD_NAME-name_$DATESTAMP.xml</code>, with spaces in <code>$WATCHR_BUILD_NAME</code>
+   * replaced by underscores. Additionally, the build name is prepended (verbatim) to the top-level timer name, so that
+   * Watchr knows it is a different data series than runs of the same test from other builds.
+   *
+   * If <code>$WATCHR_BUILD_NAME</code> is not set or is empty, the filename is just <code>name_$DATESTAMP.xml</code>.
+   * DATESTAMP is calculated from the current UTC time, in the format YYYY_MM_DD.
+   *
    * @param [in] name - Name of performance test
    * @param [in] comm - Teuchos comm pointer
    * @return If on rank 0 and output was produced, the complete output filename. Otherwise the empty string.


### PR DESCRIPTION
- Use proper XML escape codes, e.g. ``&quot;`` for ``"``
  (this was breaking MueLu Driver output, since some timer names have quotes)
- Disambiguate performance reports from differerent builds
  - Read (optional) env var WATCHR_BUILD_NAME
  - If set to e.g. "Vortex CUDA", then the root timer name in the XML
    report will say "Vortex CUDA: Test XYZ", and the filename of the
    report will be something like "$WATCHR_PERF_DIR/Vortex_CUDA-XYZ"
    (spaces are replaced with underscore in filename)
  - Filenames won't collide on different builds and top-level chart
    titles will show the build name. Before, all builds would be
    combined into a single data series which is definitely not what we
    want.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/teuchos 
@trilinos/tpetra 
@rppawlo 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Required to fix Watchr output when timers contain special XML characters, and to plot multiple builds in the same Watchr instance without name collisions.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
-->
## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows #6913 
* Precedes 
* Related to 
* Part of 
* Composed of 



## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
Part of Trilinos performance testing work.

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
XML output from StackedTimer is still tested in Teuchos. I also tested the actual behavior of the output with and without ``WATCHR_BUILD_NAME`` being set in a local build.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->