### PR TITLE
MueLu RefMaxwell: Improve communication

### DIFF
--- a/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_decl.hpp
+++ b/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_decl.hpp
@@ -425,6 +425,7 @@ namespace MueLu {
     Teuchos::RCP<RealValuedMultiVector> Coords_, CoordsH_;
     //! Importer to coarse (1,1) hierarchy
     Teuchos::RCP<const Import> ImporterH_, Importer22_;
+    bool D0_T_R11_colMapsMatch_;
     //! Parameter lists
     Teuchos::ParameterList parameterList_, precList11_, precList22_, smootherList_;
     Teuchos::RCP<Teuchos::ParameterList> AH_AP_reuse_data_, AH_RAP_reuse_data_;
@@ -434,7 +435,7 @@ namespace MueLu {
     int numItersH_, numIters22_;
     std::string mode_;
     //! Temporary memory
-    mutable Teuchos::RCP<MultiVector> P11res_, P11x_, D0res_, D0x_, residual_, P11resTmp_, P11xTmp_, D0resTmp_, D0xTmp_;
+    mutable Teuchos::RCP<MultiVector> P11res_, P11x_, D0res_, D0x_, residual_, P11resTmp_, P11xTmp_, D0resTmp_, D0xTmp_, D0TR11Tmp_;
   };
 
 } // namespace

--- a/packages/muelu/test/maxwell/CMakeLists.txt
+++ b/packages/muelu/test/maxwell/CMakeLists.txt
@@ -51,7 +51,7 @@ IF (${PACKAGE_NAME}_ENABLE_Belos AND ${PACKAGE_NAME}_ENABLE_Amesos2)
     ENDIF()
   ENDIF()
 
-  IF (${PACKAGE_NAME}_ENABLE_Epetra AND (NOT ${PACKAGE_NAME}_ENABLE_Kokkos_Refactor))
+  IF (${PACKAGE_NAME}_ENABLE_Epetra)
     TRIBITS_ADD_TEST(
       Maxwell3D
       NAME "Maxwell3D-Epetra"

--- a/packages/muelu/test/maxwell/Maxwell.xml
+++ b/packages/muelu/test/maxwell/Maxwell.xml
@@ -1,5 +1,6 @@
 <ParameterList name="MueLu">
 
+  <Parameter name="use kokkos refactor" type="bool" value="false"/>
   <Parameter name="refmaxwell: use as preconditioner" type="bool" value="true"/>
   <Parameter name="refmaxwell: mode" type="string" value="additive"/>
   <Parameter name="refmaxwell: disable addon" type="bool" value="false"/>
@@ -15,6 +16,7 @@
   </ParameterList>
 
   <ParameterList name="refmaxwell: 11list">
+    <Parameter name="use kokkos refactor" type="bool" value="false"/>
     <Parameter name="multigrid algorithm" type="string" value="unsmoothed"/>
     <Parameter name="number of equations" type="int" value="3"/>
     <Parameter name="aggregation: type" type="string" value="uncoupled"/>
@@ -30,6 +32,7 @@
   </ParameterList>
 
   <ParameterList name="refmaxwell: 22list">
+    <Parameter name="use kokkos refactor" type="bool" value="false"/>
     <Parameter name="multigrid algorithm" type="string" value="unsmoothed"/>
     <Parameter name="aggregation: type" type="string" value="uncoupled"/>
     <Parameter name="aggregation: drop tol" type="double" value="0.01"/>


### PR DESCRIPTION
@trilinos/muelu 

## Motivation
Remove 3 rounds of communication:
- Column map for D0_T and R11 matches, so for D0_T \* r and R11 \* r only import once.
- Fuse import from sub-problems with import into colmap for prolongators.

Also test Epetra code path on more systems.