### PR TITLE
ATDM Config:  Match 'arm' Without Version

### DIFF
--- a/cmake/std/atdm/van1-tx2/custom_builds.sh
+++ b/cmake/std/atdm/van1-tx2/custom_builds.sh
@@ -6,6 +6,7 @@ if   [[ $ATDM_CONFIG_BUILD_NAME == *"arm-20.0-openmpi-4.0.2"* ]] \
   || [[ $ATDM_CONFIG_BUILD_NAME == *"arm-20.0_openmpi-4.0.2"* ]] \
   || [[ $ATDM_CONFIG_BUILD_NAME == *"arm-20.0"* ]] \
   || [[ $ATDM_CONFIG_BUILD_NAME == *"arm-20"* ]] \
+  || [[ $ATDM_CONFIG_BUILD_NAME == *"arm"* ]] \
   || [[ $ATDM_CONFIG_BUILD_NAME == *"default" ]] \
   ; then
   export ATDM_CONFIG_COMPILER=ARM-20.0_OPENMPI-4.0.2


### PR DESCRIPTION
The van1-tx2 environment currently allows the matching of 'arm-' plus a
version number to determine the compiler.  This allows one to simply
specify 'arm' as the compiler instead of needing a version as well.