### PR TITLE
ATDM: van1-tx2: Address problem of 'van1-tx2' matching KOKKOS_ARCH=TX2 (#4063, CDOFA-27)

### DIFF
--- a/cmake/std/atdm/van1-tx2/environment.sh
+++ b/cmake/std/atdm/van1-tx2/environment.sh
@@ -12,13 +12,14 @@ echo "Using ARM ATSE compiler stack $ATDM_CONFIG_COMPILER to build $ATDM_CONFIG_
 #
 
 if   [[ "$ATDM_CONFIG_KOKKOS_ARCH" == "DEFAULT" ]] \
+  || [[ "$ATDM_CONFIG_KOKKOS_ARCH" == "TX2" ]] \
   || [[ "$ATDM_CONFIG_KOKKOS_ARCH" == "" ]] \
   ; then
   export ATDM_CONFIG_KOKKOS_ARCH=ARMv8-TX2
 else
   echo
   echo "***"
-  echo "*** ERROR: Only one arch is supported this system!  Remove any arch keywords from build name '${ATDM_CONFIG_BUILD_NAME}'"
+  echo "*** ERROR: KOKKOS_ARCH='${ATDM_CONFIG_KOKKOS_ARCH}' was parsed from the the buildname '${ATDM_CONFIG_BUILD_NAME}'.  Only one KOKKOS_ARCH is supported for this system.  Please remove that KOKKOS_ARCH keyword from the buildname!"
   echo "***"
   return
 fi


### PR DESCRIPTION
After the "upgrade" of the ATDM Trilinos parsing system to parse out the KOKKOS_ARCH in either upper or lower case (see #7202 ), now the 'tx2' in 'van1-tx2' matches the KOKKOS_ARCH 'TX2' (lower case 'tx2').  This broke the running of atdm/van1-tx2/environment.sh.  This broke the nightly ATDM Trilinos 'van1-tx2' builds and installs of Trilinos from 'stria' today, testing day 2020-04-21.

I updated the error message to show the KOKKOS_ARCH and then I updated the logic to accept the KOKKOS_ARCH of 'TX2'.  That is a bit of a hack but it gets us around this problem (and is harmless on this system).

## How was this tested?

I manually tested this on my Windows 10 Cygwin machine by manually running:

```
$ . cmake/std/atdm/load-env.sh Trilinos-atdm-van1-tx2_arm-20.0_openmpi-4.0.2_openmp_static_dbg
ostname 's1049009' matches known ATDM host 's1049009' and system 'van1-tx2'
Setting compiler and build options for build-name 'Trilinos-atdm-van1-tx2_arm-20.0_openmpi-4.0.2_openmp_static_dbg'
...
```

I was able to manually reproduce the problem that way and verify that it was fixed.

