### PR TITLE
Panzer: set virtual cells to have appropriate normals and rotation matrices

### DIFF
--- a/packages/panzer/adapters-stk/src/Panzer_STK_LocalMeshUtilities.cpp
+++ b/packages/panzer/adapters-stk/src/Panzer_STK_LocalMeshUtilities.cpp
@@ -957,10 +957,8 @@ generateLocalMeshInfo(const panzer_stk::STK_Interface & mesh,
         // Virtual cell - create it!
         c0 = virtual_cell_index++;
 
-        // We need the subcell_index to line up between real and virtual cell
-        // This way the face has the same geometry... though the face normal
-        // will point in the wrong direction
-        lidx0 = lidx1;
+        // Our convention is that the virtual cell has a single face with lid 0
+        lidx0 = 0;
       }
       cell_to_face(c0,lidx0) = f;
 
@@ -970,10 +968,8 @@ generateLocalMeshInfo(const panzer_stk::STK_Interface & mesh,
         // Virtual cell - create it!
         c1 = virtual_cell_index++;
 
-        // We need the subcell_index to line up between real and virtual cell
-        // This way the face has the same geometry... though the face normal
-        // will point in the wrong direction
-        lidx1 = lidx0;
+        // Our convention is that the virtual cell has a single face with lid 0
+        lidx1 = 0;
       }
       cell_to_face(c1,lidx1) = f;
 

--- a/packages/panzer/adapters-stk/test/panzer_workset_builder/check_rotation_matrices.cpp
+++ b/packages/panzer/adapters-stk/test/panzer_workset_builder/check_rotation_matrices.cpp
@@ -134,12 +134,27 @@ namespace panzer {
     auto worksets = wkstContainer->getWorksets(workset_descriptor);
 
     TEST_ASSERT(worksets->size()==1);
+    
+    auto & workset = (*worksets)[0];
 
-    auto rot_matrices = (*worksets)[0].getIntegrationValues(sid).surface_rotation_matrices;
-    auto normals = (*worksets)[0].getIntegrationValues(sid).surface_normals;
+    auto rot_matrices = workset.getIntegrationValues(sid).surface_rotation_matrices;
+    auto normals = workset.getIntegrationValues(sid).surface_normals;
 
+    const int num_owned_cells   = workset.numOwnedCells();
+    const int num_ghost_cells   = workset.numGhostCells();
+    const int num_real_cells    = num_owned_cells + num_ghost_cells;
+    const int num_virtual_cells = workset.numVirtualCells();
+    const int num_cells         = num_real_cells + num_virtual_cells;
+    
+    const int faces_per_cell    = 6; // hexahedron
+    
+    // sanity check on cell counts: should have 6 virtual, 1 owned
+    TEST_EQUALITY(num_owned_cells,   1);
+    TEST_EQUALITY(num_ghost_cells,   0);
+    TEST_EQUALITY(num_virtual_cells, 6);
+    
     TEST_ASSERT(rot_matrices.rank()==4);
-    TEST_ASSERT(rot_matrices.extent_int(0)==7); // 7 cells (6 virtual, one owned)
+    TEST_ASSERT(rot_matrices.extent_int(0)==num_cells);
     TEST_ASSERT(rot_matrices.extent_int(2)==3);
     TEST_ASSERT(rot_matrices.extent_int(3)==3);
     out << "SIZES = "
@@ -150,35 +165,61 @@ namespace panzer {
 
     out << std::endl;
 
+    const int num_points      = rot_matrices.extent_int(1);
+    const int points_per_face = num_points / faces_per_cell;
     for(int c=0;c<rot_matrices.extent_int(0);c++) {
-      for(int p=0;p<rot_matrices.extent_int(1);p++) {
+      // rule for virtual cells is that they have rotation matrices defined only on local face ordinal 0;
+      // the rotation matrices for the other faces of the virtual cell should be all 0s.
+      const bool is_virtual = (c >= num_real_cells);
+      for(int p=0;p<num_points;p++) {
+        const int local_face_ordinal = p / points_per_face;
+        bool expect_rotation_matrix = true; // if false, we expect all 0s
+        if (is_virtual)
+        {
+          expect_rotation_matrix = (local_face_ordinal == 0);
+        }
         out << "Cell,Point = " << c << "," << p << std::endl;
         out << "   " << rot_matrices(c,p,0,0) << " " << rot_matrices(c,p,0,1) << " " << rot_matrices(c,p,0,2) << std::endl;
         out << "   " << rot_matrices(c,p,1,0) << " " << rot_matrices(c,p,1,1) << " " << rot_matrices(c,p,1,2) << std::endl;
         out << "   " << rot_matrices(c,p,2,0) << " " << rot_matrices(c,p,2,1) << " " << rot_matrices(c,p,2,2) << std::endl;
         out << std::endl;
 
-        // mutually orthongonal
-        TEST_ASSERT(std::fabs(rot_matrices(c,p,0,0) * rot_matrices(c,p,1,0) +
-                              rot_matrices(c,p,0,1) * rot_matrices(c,p,1,1) +
-                              rot_matrices(c,p,0,2) * rot_matrices(c,p,1,2))<=1e-14);
-        TEST_ASSERT(std::fabs(rot_matrices(c,p,0,0) * rot_matrices(c,p,2,0) +
-                              rot_matrices(c,p,0,1) * rot_matrices(c,p,2,1) +
-                              rot_matrices(c,p,0,2) * rot_matrices(c,p,2,2))<=1e-14);
-        TEST_ASSERT(std::fabs(rot_matrices(c,p,1,0) * rot_matrices(c,p,2,0) +
-                              rot_matrices(c,p,1,1) * rot_matrices(c,p,2,1) +
-                              rot_matrices(c,p,1,2) * rot_matrices(c,p,2,2))<=1e-14);
+        if (expect_rotation_matrix)
+        {
+          // mutually orthogonal
+          TEST_ASSERT(std::fabs(rot_matrices(c,p,0,0) * rot_matrices(c,p,1,0) +
+                                rot_matrices(c,p,0,1) * rot_matrices(c,p,1,1) +
+                                rot_matrices(c,p,0,2) * rot_matrices(c,p,1,2))<=1e-14);
+          TEST_ASSERT(std::fabs(rot_matrices(c,p,0,0) * rot_matrices(c,p,2,0) +
+                                rot_matrices(c,p,0,1) * rot_matrices(c,p,2,1) +
+                                rot_matrices(c,p,0,2) * rot_matrices(c,p,2,2))<=1e-14);
+          TEST_ASSERT(std::fabs(rot_matrices(c,p,1,0) * rot_matrices(c,p,2,0) +
+                                rot_matrices(c,p,1,1) * rot_matrices(c,p,2,1) +
+                                rot_matrices(c,p,1,2) * rot_matrices(c,p,2,2))<=1e-14);
 
-        // normalized
-        TEST_FLOATING_EQUALITY(std::sqrt(rot_matrices(c,p,0,0) * rot_matrices(c,p,0,0) +
-                                         rot_matrices(c,p,0,1) * rot_matrices(c,p,0,1) +
-                                         rot_matrices(c,p,0,2) * rot_matrices(c,p,0,2)),1.0,1e-14);
-        TEST_FLOATING_EQUALITY(std::sqrt(rot_matrices(c,p,1,0) * rot_matrices(c,p,1,0) +
-                                         rot_matrices(c,p,1,1) * rot_matrices(c,p,1,1) +
-                                         rot_matrices(c,p,1,2) * rot_matrices(c,p,1,2)),1.0,1e-14);
-        TEST_FLOATING_EQUALITY(std::sqrt(rot_matrices(c,p,2,0) * rot_matrices(c,p,2,0) +
-                                         rot_matrices(c,p,2,1) * rot_matrices(c,p,2,1) +
-                                         rot_matrices(c,p,2,2) * rot_matrices(c,p,2,2)),1.0,1e-14);
+          // normalized
+          TEST_FLOATING_EQUALITY(std::sqrt(rot_matrices(c,p,0,0) * rot_matrices(c,p,0,0) +
+                                           rot_matrices(c,p,0,1) * rot_matrices(c,p,0,1) +
+                                           rot_matrices(c,p,0,2) * rot_matrices(c,p,0,2)),1.0,1e-14);
+          TEST_FLOATING_EQUALITY(std::sqrt(rot_matrices(c,p,1,0) * rot_matrices(c,p,1,0) +
+                                           rot_matrices(c,p,1,1) * rot_matrices(c,p,1,1) +
+                                           rot_matrices(c,p,1,2) * rot_matrices(c,p,1,2)),1.0,1e-14);
+          TEST_FLOATING_EQUALITY(std::sqrt(rot_matrices(c,p,2,0) * rot_matrices(c,p,2,0) +
+                                           rot_matrices(c,p,2,1) * rot_matrices(c,p,2,1) +
+                                           rot_matrices(c,p,2,2) * rot_matrices(c,p,2,2)),1.0,1e-14);
+        }
+        else
+        {
+          // virtual cell on a face other than local face 0: expect zeros
+          for (int i=0; i<3; i++)
+          {
+            for (int j=0; j<3; j++)
+            {
+              // since these should be filled in as exact machine 0s, we do non-floating comparison
+              TEST_EQUALITY(rot_matrices(c,p,i,j), 0.0);
+            }
+          }
+        }
       }
     }
   }

--- a/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.cpp
@@ -444,17 +444,18 @@ protected:
 
 };
 
-template<typename T>
-void
-convertNormalToRotationMatrix(const T normal[3], T transverse[3], T binormal[3])
-{
+}
 
+template <typename Scalar>
+void IntegrationValues2<Scalar>::
+convertNormalToRotationMatrix(const Scalar normal[3], Scalar transverse[3], Scalar binormal[3])
+{
+  using T = Scalar;
+  
   const T n  = sqrt(normal[0]*normal[0]+normal[1]*normal[1]+normal[2]*normal[2]);
 
   // If this fails then the geometry for this cell is probably undefined
   if(n > 0.){
-
-
     // Make sure transverse is not parallel to normal within some margin of error
     transverse[0]=0.;transverse[1]=1.;transverse[2]=0.;
     if(std::fabs(normal[0]*transverse[0]+normal[1]*transverse[1])>0.9){
@@ -494,14 +495,9 @@ convertNormalToRotationMatrix(const T normal[3], T transverse[3], T binormal[3])
     binormal[0] = 0.;
     binormal[1] = 0.;
     binormal[2] = 0.;
-
-    // TEUCHOS_ASSERT(false);
   }
-
 }
-
-}
-
+  
 template <typename Scalar>
 void IntegrationValues2<Scalar>::
 swapQuadraturePoints(int cell,
@@ -788,7 +784,7 @@ generateSurfaceCubatureValues(const PHX::MDField<Scalar,Cell,NODE,Dim>& in_node_
           normal[dim] = surface_normals(cell,point,dim);
         }
 
-        convertNormalToRotationMatrix<Scalar>(normal,transverse,binormal);
+        convertNormalToRotationMatrix(normal,transverse,binormal);
 
         for(int dim=0; dim<3; ++dim){
           surface_rotation_matrices(cell,point,0,dim) = normal[dim];

--- a/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_IntegrationValues2.hpp
@@ -171,6 +171,8 @@ namespace panzer {
      */
     void swapQuadraturePoints(int cell,int a,int b);
 
+    static void convertNormalToRotationMatrix(const Scalar normal[3], Scalar transverse[3], Scalar binormal[3]);
+    
   protected:
 
 

--- a/packages/panzer/disc-fe/src/Panzer_Workset.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_Workset.cpp
@@ -95,7 +95,6 @@ void WorksetDetails::setupNeeds(Teuchos::RCP<const shards::CellTopology> cell_to
                                 const Kokkos::View<double***,PHX::Device> & cell_vertices,
                                 const panzer::WorksetNeeds & needs)
 {
-
   const size_t num_cells = cell_vertices.extent(0);
   const size_t num_vertices_per_cell = cell_vertices.extent(1);
   const size_t num_dims_per_vertex = cell_vertices.extent(2);
@@ -144,6 +143,73 @@ void WorksetDetails::setupNeeds(Teuchos::RCP<const shards::CellTopology> cell_to
     Teuchos::RCP<panzer::IntegrationValues2<double> > iv = Teuchos::rcp(new panzer::IntegrationValues2<double>("",true));
     iv->setupArrays(ir);
     iv->evaluateValues(cell_vertex_coordinates,num_cells);
+    if (iv->int_rule->getType() == panzer::IntegrationDescriptor::SURFACE)
+    {
+      // IntegrationValues2 doesn't know anything about virtual cells, so it sets up incorrect normals for those.
+      // What we want is for "face 0" of the virtual cell to have normals that are the negated real cell's normals.
+      // we correct the normals here:
+      auto num_real_cells = _num_owned_cells + _num_ghost_cells;
+      const int space_dim      = cell_topology->getDimension();
+      const int faces_per_cell = cell_topology->getSubcellCount(space_dim-1);
+      const int points          = iv->surface_normals.extent_int(1);
+      const int points_per_face = points / faces_per_cell;
+      for (int virtual_cell_ordinal=0; virtual_cell_ordinal<_num_virtual_cells; virtual_cell_ordinal++)
+      {
+        const panzer::LocalOrdinal virtual_cell = virtual_cell_ordinal+num_real_cells;
+        const int face_ordinal = _face_connectivity->subcellForCell(virtual_cell, 0);
+        if (face_ordinal >= 0)
+        {
+          const int first_cell_for_face = _face_connectivity->cellForSubcell(face_ordinal, 0);
+          const panzer::LocalOrdinal other_side = (first_cell_for_face == virtual_cell) ? 1 : 0;
+          const panzer::LocalOrdinal real_cell = _face_connectivity->cellForSubcell(face_ordinal,other_side);
+          const panzer::LocalOrdinal face_in_real_cell = _face_connectivity->localSubcellForSubcell(face_ordinal,other_side);
+          TEUCHOS_ASSERT(real_cell < num_real_cells);
+          for (int point_ordinal=0; point_ordinal<points_per_face; point_ordinal++)
+          {
+            int virtual_cell_point = point_ordinal;
+            int real_cell_point = points_per_face * face_in_real_cell;
+            // the following arrays will be used to produce/store the rotation matrix below
+            double normal[3], transverse[3], binormal[3];
+            for(int i=0;i<3;i++)
+            {
+              normal[i]=0.;
+              transverse[i]=0.;
+              binormal[i]=0.;
+            }
+            
+            for (int d=0; d<space_dim; d++)
+            {
+              const auto n_d = iv->surface_normals(real_cell,real_cell_point,d);
+              iv->surface_normals(virtual_cell,virtual_cell_point,d) = -n_d;
+              normal[d] = -n_d;
+            }
+            
+            panzer::IntegrationValues2<double>::convertNormalToRotationMatrix(normal,transverse,binormal);
+            
+            for(int dim=0; dim<3; ++dim){
+              iv->surface_rotation_matrices(virtual_cell,virtual_cell_point,0,dim) = normal[dim];
+              iv->surface_rotation_matrices(virtual_cell,virtual_cell_point,1,dim) = transverse[dim];
+              iv->surface_rotation_matrices(virtual_cell,virtual_cell_point,2,dim) = binormal[dim];
+            }
+          }
+          // clear the other normals and rotation matrices for the virtual cell:
+          for (int point_ordinal=points_per_face; point_ordinal<points; point_ordinal++)
+          {
+            for (int dim=0; dim<space_dim; dim++)
+            {
+              iv->surface_normals(virtual_cell,point_ordinal,dim) = 0.0;
+            }
+            for(int dim1=0; dim1<3; ++dim1)
+            {
+              for(int dim2=0; dim2<3; ++dim2)
+              {
+                iv->surface_rotation_matrices(virtual_cell,point_ordinal,dim1,dim2) = 0;
+              }
+            }
+          }
+        }
+      }
+    }
     _integrator_map[integration_description.getKey()] = iv;
 
     // We need to generate a integration rule - basis pair for each basis


### PR DESCRIPTION
## Motivation
The rule is supposed to be that virtual cells have always have face ordinal 0 being the one that abuts the real cell, and that these have normals that are the negative of the normal on the real cell at the same point.  This commit makes the panzer Workset adhere to this rule.

@trilinos/panzer