### PR TITLE
ATDM Config:  Don't get-platform on Vortex

### DIFF
--- a/cmake/std/atdm/utils/get_known_system_info.sh
+++ b/cmake/std/atdm/utils/get_known_system_info.sh
@@ -161,7 +161,8 @@ if [[ "${SEMS_PLATFORM}" == "rhel6-x86_64" ]] ; then
 elif [[ "${SEMS_PLATFORM}" == "rhel7-x86_64" ]] ; then
   systemNameTypeMatchedList+=(sems-rhel7)
   systemNameTypeMatchedListHostNames[sems-rhel7]=sems-rhel7
-elif [[ "${SNLSYSTEM}" == "astra" ]] ; then
+elif [[ "${SNLSYSTEM}" == "astra" || \
+        "${SNLSYSTEM}" == "vortex" ]] ; then
   echo "Don't call get-platform on 'astra' systems" > /dev/null
   # Above logic avoids an 'ERROR: Unrecognized cluster <name>' on these systems
 elif [[ -f /projects/sems/modulefiles/utils/get-platform ]] ; then


### PR DESCRIPTION
@bartlettroscoe, @e10harvey, recently the vortex admins installed `/etc/profile.d/snlvariables.sh` on vortex to define `SNLSYSTEM`, `SNLCLUSTER`, etc.  Somehow that broke the `load_matching_env.sh` script that gets installed with Trilinos.  It winds up throwing
```
ERROR: Unrecognized cluster vortex
```
and running our scripts with `set -e` means we die.  It looks like the error's coming from `/projects/sems/modulefiles/utils/get-platform`.  This PR avoids the call to `get-platform` on vortex as you did with astra so we can avoid that error and be about our merry way.