### PR TITLE
Panzer: partial rollback/amendment of 7225 due to EMPIRE reliance on previous behavior.

### DIFF
--- a/packages/panzer/adapters-stk/src/Panzer_STK_LocalMeshUtilities.cpp
+++ b/packages/panzer/adapters-stk/src/Panzer_STK_LocalMeshUtilities.cpp
@@ -957,8 +957,10 @@ generateLocalMeshInfo(const panzer_stk::STK_Interface & mesh,
         // Virtual cell - create it!
         c0 = virtual_cell_index++;
 
-        // Our convention is that the virtual cell has a single face with lid 0
-        lidx0 = 0;
+        // We need the subcell_index to line up between real and virtual cell
+        // This way the face has the same geometry... though the face normal
+        // will point in the wrong direction
+        lidx0 = lidx1;
       }
       cell_to_face(c0,lidx0) = f;
 
@@ -968,8 +970,10 @@ generateLocalMeshInfo(const panzer_stk::STK_Interface & mesh,
         // Virtual cell - create it!
         c1 = virtual_cell_index++;
 
-        // Our convention is that the virtual cell has a single face with lid 0
-        lidx1 = 0;
+        // We need the subcell_index to line up between real and virtual cell
+        // This way the face has the same geometry... though the face normal
+        // will point in the wrong direction
+        lidx1 = lidx0;
       }
       cell_to_face(c1,lidx1) = f;
 


### PR DESCRIPTION
@trilinos/panzer 

## Motivation
PR 7225 broke some things in EMPIRE because it has some subtle reliance on the old behavior.  This PR is a compromise, reverting to the former definition of local face ordinal for virtual cells (not face 0, but the same local face id as the corresponding real cell), but keeping the reversal of the normal direction and still zeroing out the normals and rotation matrices for virtual cell faces that do not correspond to a real cell face.

All but one of the failing EMPIRE tests have been confirmed to pass with these changes.  The one that still fails aborts when it encounters a zero normal on a virtual cell face; this is easily fixed in EMPIRE.