### PR TITLE
tpetra:  removed unused code and comments that no longer are relevant

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_def.hpp
@@ -77,78 +77,8 @@ namespace FHT {
 // we would need experiments to find out.
 template<class ExecSpace>
 bool worthBuildingFixedHashTableInParallel () {
-//  KDD 8/19:  A temporary fix for #5179.  It appears some errors come from
-//  KDD 8/19:  computeOffsetsFromCounts; this temporary patch avoids the most
-//  KDD 8/19:  reproducible of the errors.  We'll reverse this as we debug
-//  KDD 8/19:  the problem, but this temporary fix may allow users to make
-//  KDD 8/19:  progress toward their milestones.
-//std::cout << "KDDKDD WorthIt " << (ExecSpace::concurrency() > 1) << std::endl;
     return ExecSpace::concurrency() > 1;
-//  return false;
-//  KDD 8/19
 }
-
-// If the input kokkos::View<const KeyType*, ArrayLayout,
-// InputExecSpace, Kokkos::MemoryUnamanged> is NOT accessible from the
-// OutputExecSpace execution space, make and return a deep copy.
-// Otherwise, just return the original input.
-//
-// The point of this is to avoid unnecessary copies, when the input
-// array of keys comes in as a Teuchos::ArrayView (which we wrap in an
-// unmanaged Kokkos::View).
-template<class KeyType,
-         class ArrayLayout,
-         class InputExecSpace,
-         class OutputExecSpace,
-         const bool mustDeepCopy =
-           ! std::is_same<typename InputExecSpace::memory_space,
-                          typename OutputExecSpace::memory_space>::value>
-struct DeepCopyIfNeeded {
-  // The default implementation is trivial; all the work happens in
-  // partial specializations.
-};
-
-// Specialization for when a deep copy is actually needed.
-template<class KeyType,
-         class ArrayLayout,
-         class InputExecSpace,
-         class OutputExecSpace>
-struct DeepCopyIfNeeded<KeyType, ArrayLayout, InputExecSpace, OutputExecSpace, true>
-{
-  typedef Kokkos::View<const KeyType*, ArrayLayout,
-                       InputExecSpace, Kokkos::MemoryUnmanaged> input_view_type;
-  // In this case, a deep copy IS needed.  As a result, the output
-  // type is a managed Kokkos::View, which differs from the input
-  // type.  Clients must get the correct return type from this struct,
-  // either from the typedef below or from 'auto'.  Assigning an
-  // unmanaged View to a managed View is a syntax error.
-  typedef Kokkos::View<const KeyType*, ArrayLayout, OutputExecSpace> output_view_type;
-
-  static output_view_type copy (const input_view_type& src) {
-    typedef typename output_view_type::non_const_type NC;
-
-    NC dst (Kokkos::ViewAllocateWithoutInitializing (src.tracker ().label ()),
-            src.extent (0));
-    Kokkos::deep_copy (dst, src);
-    return output_view_type (dst);
-  }
-};
-
-// Specialization if no need to make a deep copy.
-template<class KeyType,
-         class ArrayLayout,
-         class InputExecSpace,
-         class OutputExecSpace>
-struct DeepCopyIfNeeded<KeyType, ArrayLayout, InputExecSpace, OutputExecSpace, false> {
-  typedef Kokkos::View<const KeyType*, ArrayLayout,
-                       InputExecSpace, Kokkos::MemoryUnmanaged> input_view_type;
-  typedef Kokkos::View<const KeyType*, ArrayLayout, OutputExecSpace,
-                       Kokkos::MemoryUnmanaged> output_view_type;
-
-  static output_view_type copy (const input_view_type& src) {
-    return output_view_type (src);
-  }
-};
 
 //
 // Functors for FixedHashTable initialization


### PR DESCRIPTION
@trilinos/tpetra 
Removed code that wasn't used anywhere.
The unused code sometimes caused compilation problems (that's how I noticed it).
Removed some comments that are no longer relevant (part of Kokkos::parallel_scan debugging effort).



<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->


## Motivation
Less code is good.

<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing

Built and ran tests on mac with clang.

<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->