### PR TITLE
Tpetra Distributor: getReverse changes

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Distributor.cpp
+++ b/packages/tpetra/core/src/Tpetra_Distributor.cpp
@@ -466,12 +466,12 @@ namespace Tpetra {
   { return lengthsTo_; }
 
   Teuchos::RCP<Distributor>
-  Distributor::getReverse() const {
-    if (reverseDistributor_.is_null ()) {
+  Distributor::getReverse(bool create) const {
+    if (reverseDistributor_.is_null () && create) {
       createReverseDistributor ();
     }
     TEUCHOS_TEST_FOR_EXCEPTION
-      (reverseDistributor_.is_null (), std::logic_error, "The reverse "
+      (reverseDistributor_.is_null () && create, std::logic_error, "The reverse "
        "Distributor is null after createReverseDistributor returned.  "
        "Please report this bug to the Tpetra developers.");
     return reverseDistributor_;

--- a/packages/tpetra/core/src/Tpetra_Distributor.cpp
+++ b/packages/tpetra/core/src/Tpetra_Distributor.cpp
@@ -385,12 +385,6 @@ namespace Tpetra {
     }
   }
 
-  Teuchos::RCP<Distributor>
-  Distributor::
-  getReverseDistributor() {
-    return reverseDistributor_;
-  }
-
   Teuchos::RCP<const Teuchos::ParameterList>
   Distributor::getValidParameters () const
   {

--- a/packages/tpetra/core/src/Tpetra_Distributor.hpp
+++ b/packages/tpetra/core/src/Tpetra_Distributor.hpp
@@ -422,7 +422,7 @@ namespace Tpetra {
     /// doReversePosts() or doReversePostsAndWaits(), the reverse
     /// Distributor will be created automatically if it does not yet
     /// exist.
-    Teuchos::RCP<Distributor> getReverse() const;
+    Teuchos::RCP<Distributor> getReverse(bool create=true) const;
 
     //@}
     //! @name Methods for executing a communication plan

--- a/packages/tpetra/core/src/Tpetra_Distributor.hpp
+++ b/packages/tpetra/core/src/Tpetra_Distributor.hpp
@@ -265,8 +265,6 @@ namespace Tpetra {
     /// parameters and their default values.
     void setParameterList (const Teuchos::RCP<Teuchos::ParameterList>& plist);
 
-    Teuchos::RCP<Distributor> getReverseDistributor();
-
     /// \brief List of valid Distributor parameters.
     ///
     /// Please see the class documentation for a list of all accepted

--- a/packages/tpetra/core/test/Distributor/Distributor_UnitTests.cpp
+++ b/packages/tpetra/core/test/Distributor/Distributor_UnitTests.cpp
@@ -728,6 +728,14 @@ namespace {
     myOut << "Make sure that Distributor output doesn't cause a hang" << endl;
     distributor.describe (out, Teuchos::VERB_EXTREME);
 
+    myOut << "Check getReverse(create=false)" << endl;
+    RCP<Distributor> revDistor = distributor.getReverse(false);
+    TEUCHOS_ASSERT(revDistor.is_null());
+
+    myOut << "Check getReverse(create=true)" << endl;
+    revDistor = distributor.getReverse();
+    TEUCHOS_ASSERT(!revDistor.is_null());
+
     myOut << "Check return value of createFromSends" << endl;
     TEST_EQUALITY(numRemoteIDs, as<size_t>(numImages));
 

--- a/packages/xpetra/src/Export/Xpetra_TpetraExport_def.hpp
+++ b/packages/xpetra/src/Export/Xpetra_TpetraExport_def.hpp
@@ -201,6 +201,9 @@ TpetraExport<LocalOrdinal, GlobalOrdinal, Node>::
 setDistributorParameters(const Teuchos::RCP<Teuchos::ParameterList> params) const {
   XPETRA_MONITOR("TpetraExport::setDistributorParameters");
   export_->getDistributor().setParameterList(params);
+  auto revDistor = export_->getDistributor().getReverse(false);
+  if (!revDistor.is_null())
+    revDistor->setParameterList(params);
 }
 
 

--- a/packages/xpetra/src/Export/Xpetra_TpetraExport_def.hpp
+++ b/packages/xpetra/src/Export/Xpetra_TpetraExport_def.hpp
@@ -201,9 +201,6 @@ TpetraExport<LocalOrdinal, GlobalOrdinal, Node>::
 setDistributorParameters(const Teuchos::RCP<Teuchos::ParameterList> params) const {
   XPETRA_MONITOR("TpetraExport::setDistributorParameters");
   export_->getDistributor().setParameterList(params);
-  auto revDistor = export_->getDistributor().getReverseDistributor();
-  if (!revDistor.is_null())
-    revDistor->setParameterList(params);
 }
 
 

--- a/packages/xpetra/src/Import/Xpetra_TpetraImport_def.hpp
+++ b/packages/xpetra/src/Import/Xpetra_TpetraImport_def.hpp
@@ -94,8 +94,13 @@ size_t TpetraImport<LocalOrdinal,GlobalOrdinal,Node>::getNumRemoteIDs() const
 { XPETRA_MONITOR("TpetraImport::getNumRemoteIDs"); return import_->getNumRemoteIDs(); }
 
 template<class LocalOrdinal, class GlobalOrdinal, class Node>
-void TpetraImport<LocalOrdinal,GlobalOrdinal,Node>::setDistributorParameters(const Teuchos::RCP<Teuchos::ParameterList> params) const
-{ XPETRA_MONITOR("TpetraImport::setDistributorParameters"); import_->getDistributor().setParameterList(params); }
+void TpetraImport<LocalOrdinal,GlobalOrdinal,Node>::setDistributorParameters(const Teuchos::RCP<Teuchos::ParameterList> params) const{
+  XPETRA_MONITOR("TpetraImport::setDistributorParameters");
+  import_->getDistributor().setParameterList(params);
+  auto revDistor = import_->getDistributor().getReverse(false);
+  if (!revDistor.is_null())
+    revDistor->setParameterList(params);
+}
 
 template<class LocalOrdinal, class GlobalOrdinal, class Node>
 ArrayView< const LocalOrdinal > TpetraImport<LocalOrdinal,GlobalOrdinal,Node>::getRemoteLIDs() const

--- a/packages/xpetra/src/Import/Xpetra_TpetraImport_def.hpp
+++ b/packages/xpetra/src/Import/Xpetra_TpetraImport_def.hpp
@@ -95,12 +95,7 @@ size_t TpetraImport<LocalOrdinal,GlobalOrdinal,Node>::getNumRemoteIDs() const
 
 template<class LocalOrdinal, class GlobalOrdinal, class Node>
 void TpetraImport<LocalOrdinal,GlobalOrdinal,Node>::setDistributorParameters(const Teuchos::RCP<Teuchos::ParameterList> params) const
-{ XPETRA_MONITOR("TpetraImport::setDistributorParameters");
-  import_->getDistributor().setParameterList(params);
-  auto revDistor = import_->getDistributor().getReverseDistributor();
-  if (!revDistor.is_null())
-    revDistor->setParameterList(params);
-}
+{ XPETRA_MONITOR("TpetraImport::setDistributorParameters"); import_->getDistributor().setParameterList(params); }
 
 template<class LocalOrdinal, class GlobalOrdinal, class Node>
 ArrayView< const LocalOrdinal > TpetraImport<LocalOrdinal,GlobalOrdinal,Node>::getRemoteLIDs() const


### PR DESCRIPTION
@trilinos/tpetra 

## Motivation
While working on a unit test for #7156, I realized that there is in fact already an access method for the reverse distributor. So I'm reverting the changes of #7156 and modifying the method `getReverse` instead. It's now also unit-tested.