### PR TITLE
ATDM: Remove new package Compadre from ATDM Trilinos testing (#6934)

### DIFF
--- a/cmake/std/atdm/ATDMDisables.cmake
+++ b/cmake/std/atdm/ATDMDisables.cmake
@@ -34,6 +34,7 @@ SET(ATDM_SE_PACKAGE_DISABLES
   Komplex
   FEI
   TriKota
+  Compadre
   STKClassic
   STKSearchUtil
   STKUnit_tests


### PR DESCRIPTION
The ATDM APPs are not using this package so no reason to test this as part of ATDM Trilinos testing.

This got added due to #6934 which has nothing to do with ATDM (as far as I know).

NOTE: This is what you need to do when you use the "blacklisting" approach but new packages are added very rarely so this is no big deal.

