### PR TITLE
ATDM: Add back removed BOOST_ROOT env vars (#7275)

### DIFF
--- a/cmake/std/atdm/ats2/environment.sh
+++ b/cmake/std/atdm/ats2/environment.sh
@@ -220,6 +220,7 @@ export ATDM_CONFIG_SPARC_TPL_BASE=/projects/sparc/tpls/ats2-${sparc_tpl_arch}
 sparc_tpl_base=${ATDM_CONFIG_SPARC_TPL_BASE}
 
 # Commont ROOT config variables
+export BOOST_ROOT=${sparc_tpl_base}/boost-1.65.1/00000000/${sparc_tpl_ext}
 export HDF5_ROOT=${sparc_tpl_base}/hdf5-1.10.5/00000000/${sparc_tpl_mpi_ext}
 export CGNS_ROOT=${sparc_tpl_base}/cgns-c09a5cd/27e5681f1b74c679b5dcb337ac71036d16c47977/${sparc_tpl_mpi_ext}
 export PNETCDF_ROOT=${sparc_tpl_base}/pnetcdf-1.10.0/6144dc67b2041e4093063a04e89fc1e33398bd09/${sparc_tpl_mpi_ext}

--- a/cmake/std/atdm/common/toss3/environment_tlcc2.sh
+++ b/cmake/std/atdm/common/toss3/environment_tlcc2.sh
@@ -49,6 +49,7 @@ if [ "$ATDM_CONFIG_COMPILER" == "INTEL" ]; then
     module swap mkl/18.0.0.128 mkl/18.0.5.274
     module load gcc/4.9.3
     module unload sems-python/2.7.9
+    export BOOST_ROOT=$SEMS_BOOST_ROOT
     export HDF5_ROOT=$SEMS_HDF5_ROOT
     export NETCDF_ROOT=$SEMS_NETCDF_ROOT
     export PNETCDF_ROOT=$SEMS_NETCDF_ROOT

--- a/cmake/std/atdm/sems-rhel6/environment.sh
+++ b/cmake/std/atdm/sems-rhel6/environment.sh
@@ -185,6 +185,7 @@ export ATDM_CONFIG_USE_HWLOC=OFF
 export HWLOC_LIBS=-lhwloc
 
 export ZLIB_ROOT=${SEMS_ZLIB_ROOT}
+export BOOST_ROOT=${SEMS_BOOST_ROOT}
 export HDF5_ROOT=${SEMS_HDF5_ROOT}
 export NETCDF_ROOT=${SEMS_NETCDF_ROOT}
 if [[ "${SEMS_PNETCDF_ROOT}" == "" ]] ; then


### PR DESCRIPTION
I did not test these but these envs were all broken (due to PR #7197 as reported in #7275) so adding this back can't hurt.
