### PR TITLE
tpetra:  Minor change to use general communicator rather than MPI-ifdefs

### DIFF
--- a/packages/tpetra/core/test/BugTests/BugTests.cpp
+++ b/packages/tpetra/core/test/BugTests/BugTests.cpp
@@ -247,9 +247,15 @@ namespace {
     TEST_EQUALITY_CONST( globalSuccess_int, 0 );
   }
 
-#ifdef HAVE_TPETRA_MPI
-  TEUCHOS_UNIT_TEST( DistObject, BlockedViews )
+  TEUCHOS_UNIT_TEST( DistObject, BlockedViews_7234 )
   {
+    // Test that replicates Trilinos issue #7234 
+    // https://github.com/trilinos/Trilinos/issues/7234
+    // On CUDA platforms, subviews of Kokkos::DualView did not perform properly
+    // when pointing to the end of a DualView, as the shared Vector does
+    // below.  See Kokkos issues #2981 and #2979 for more details
+    // https://github.com/kokkos/kokkos/issues/2981
+    // https://github.com/kokkos/kokkos/issues/2979
     using Teuchos::RCP;
     using Teuchos::rcp;
     using namespace Tpetra;
@@ -263,7 +269,7 @@ namespace {
     using TpetraExport = Tpetra::Export<LO,GO,NodeType>;
     using TpetraVec = Tpetra::Vector<double,LO,GO,NodeType>;
 
-    Teuchos::RCP<Teuchos::MpiComm<int> > comm = Teuchos::rcp(new Teuchos::MpiComm<int>(Teuchos::opaqueWrapper(MPI_COMM_WORLD)));
+    Teuchos::RCP<const Teuchos::Comm<int> > comm = Tpetra::getDefaultComm();
     const int rank = comm->getRank();
     const int size = comm->getSize();
 
@@ -338,5 +344,4 @@ namespace {
       TEST_FLOATING_EQUALITY(host_owned_and_shared(1,0),1.0,tol); // check owned entries only
     }
   }
-#endif
 }


### PR DESCRIPTION
## Motivation
Minor changes to use Tpetra's default communicator rather than ifdefs for MPI; this code runs fine in serial builds.
Also better comments for SQA tracing of code, tests and issues.   


<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 


<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->



## Related Issues
Follow-up to #7233 #7234

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Tested with and without MPI on mac.


<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->