### PR TITLE
MueLu: remove unused arg to KokkosSparse::CrsMatrix

### DIFF
--- a/packages/muelu/test/perf_tests_kokkos/KokkosKernels.cpp
+++ b/packages/muelu/test/perf_tests_kokkos/KokkosKernels.cpp
@@ -64,7 +64,7 @@ kernel_construct(local_ordinal_type numRows) {
 
   typedef KokkosSparse::CrsMatrix<scalar_type, local_ordinal_type, device_type> local_matrix_type;
 
-  return local_matrix_type("A", numRows, numCols, nnz, values, rowPtr, colInd, false/*pad*/);
+  return local_matrix_type("A", numRows, numCols, nnz, values, rowPtr, colInd);
 }
 
 template<class scalar_type, class local_ordinal_type, class device_type>


### PR DESCRIPTION
The argument "pad" to the KokkosSparse::CrsMatrix has no effect and will be removed. It does have a default value now, so it's not needed to pass in anything. This will just save a change that would be needed at the next kokkos-kernels snapshot.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/muelu 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Just cleanup
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
-->
## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to https://github.com/kokkos/kokkos-kernels/pull/708
* Part of 
* Composed of 



## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Only affects build.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->