### PR TITLE
MueLu Zoltan2Interface: Handle blockSize>1

### DIFF
--- a/packages/muelu/src/Rebalancing/MueLu_Zoltan2Interface_def.hpp
+++ b/packages/muelu/src/Rebalancing/MueLu_Zoltan2Interface_def.hpp
@@ -256,8 +256,9 @@ namespace MueLu {
 
       const typename InputAdapterType::part_t * parts = problem->getSolution().getPartListView();
 
-      for (GO i = 0; i < numElements; i++) {
-        int partNum = parts[i];
+      // For blkSize > 1, ignore solution for every row but the first ones in a block.
+      for (GO i = 0; i < numElements/blkSize; i++) {
+        int partNum = parts[i*blkSize];
 
         for (LO j = 0; j < blkSize; j++)
           decompEntries[i*blkSize + j] = partNum;


### PR DESCRIPTION
@trilinos/muelu 

## Motivation
Block size > 1 currently segfaults. With this change, we force blocks to all be on the same partition, ignoring the Zoltan2 solution for all but one rows per block.