### PR TITLE
Teuchos: add timestamp option to verbose stacked timer

### DIFF
--- a/packages/teuchos/comm/src/Teuchos_StackedTimer.cpp
+++ b/packages/teuchos/comm/src/Teuchos_StackedTimer.cpp
@@ -801,6 +801,9 @@ StackedTimer::reportWatchrXML(const std::string& name, Teuchos::RCP<const Teucho
 void StackedTimer::enableVerbose(const bool enable_verbose)
 {enable_verbose_ = enable_verbose;}
 
+void StackedTimer::enableVerboseTimestamps(const unsigned levels)
+{verbose_timestamp_levels_ = levels;}
+
 void StackedTimer::setVerboseOstream(const Teuchos::RCP<std::ostream>& os)
 {verbose_ostream_ = os;}
 

--- a/packages/teuchos/comm/src/Teuchos_StackedTimer.hpp
+++ b/packages/teuchos/comm/src/Teuchos_StackedTimer.hpp
@@ -52,7 +52,8 @@
 #include <cassert>
 #include <chrono>
 #include <climits>
-#include <cstdlib> // for std::getenv
+#include <cstdlib> // for std::getenv and atoi
+#include <ctime> // for timestamp support
 #include <iostream>
 
 #if defined(HAVE_TEUCHOS_KOKKOS_PROFILING) && defined(HAVE_TEUCHOSCORE_KOKKOSCORE)
@@ -360,6 +361,10 @@ protected:
       return 0;
     }
 
+    /// Returns the level of the timer in the stack
+    unsigned level() const
+    {return level_;}
+
   protected:
     /**
      * \brief split a string into two parts split by a '@' if no '@' first gets the full string
@@ -467,6 +472,7 @@ public:
   explicit StackedTimer(const char *name, const bool start_base_timer = true)
     : timer_(0,name,nullptr,false),
       enable_verbose_(false),
+      verbose_timestamp_levels_(0), // 0 disables
       verbose_ostream_(Teuchos::rcpFromRef(std::cout))
   {
     top_ = &timer_;
@@ -476,6 +482,11 @@ public:
     auto check_verbose = std::getenv("TEUCHOS_ENABLE_VERBOSE_TIMERS");
     if (check_verbose != nullptr)
       enable_verbose_ = true;
+
+    auto check_timestamp = std::getenv("TEUCHOS_ENABLE_VERBOSE_TIMESTAMP_LEVELS");
+    if (check_timestamp != nullptr) {
+      verbose_timestamp_levels_ = std::atoi(check_timestamp);
+    }
   }
 
   /**
@@ -514,8 +525,24 @@ public:
       ::Kokkos::Profiling::pushRegion(name);
     }
 #endif
-    if (enable_verbose_)
-      *verbose_ostream_ << "STARTING: " << name << std::endl;
+    if (enable_verbose_) {
+      if (!verbose_timestamp_levels_) {
+        *verbose_ostream_ << "STARTING: " << name << std::endl;
+      }
+      // gcc 4.X is incomplete in c++11 standard - missing
+      // std::put_time. We'll disable this feature for gcc 4.
+#if !defined(__GNUC__) || ( defined(__GNUC__) && (__GNUC__ > 4) )
+      else if (top_ != nullptr) {
+        if ( top_->level() <= verbose_timestamp_levels_) {
+          auto now = std::chrono::system_clock::now();
+          auto now_time = std::chrono::system_clock::to_time_t(now);
+          auto gmt = gmtime(&now_time);
+          auto timestamp = std::put_time(gmt, "%Y-%m-%d %H:%M:%S");
+          *verbose_ostream_ << "STARTING: " << name << " LEVEL: " << top_->level() << " TIMESTAMP: " << timestamp << std::endl;
+        }
+      }
+#endif
+    }
   }
 
   /**
@@ -534,8 +561,25 @@ public:
       ::Kokkos::Profiling::popRegion();
     }
 #endif
-    if (enable_verbose_)
-      *verbose_ostream_ << "STOPPING: " << name << std::endl;
+    if (enable_verbose_) {
+      if (!verbose_timestamp_levels_) {
+        *verbose_ostream_ << "STOPPING: " << name << std::endl;
+      }
+      // gcc 4.X is incomplete in c++11 standard - missing
+      // std::put_time. We'll disable this feature for gcc 4.
+#if !defined(__GNUC__) || ( defined(__GNUC__) && (__GNUC__ > 4) )
+      // The stop adjusts the top level, need to adjust by +1 for printing
+      else if (top_ != nullptr) {
+        if ( (top_->level()+1) <= verbose_timestamp_levels_) {
+          auto now = std::chrono::system_clock::now();
+          auto now_time = std::chrono::system_clock::to_time_t(now);
+          auto gmt = gmtime(&now_time);
+          auto timestamp = std::put_time(gmt, "%Y-%m-%d %H:%M:%S");
+          *verbose_ostream_ << "STOPPING: " << name << " LEVEL: " << top_->level()+1 << " TIMESTAMP: " << timestamp << std::endl;
+        }
+      }
+#endif
+    }
   }
 
   /**
@@ -690,6 +734,9 @@ public:
   // If set to true, print timer start/stop to verbose ostream.
   void enableVerbose(const bool enable_verbose);
 
+  // Enable timestamps in verbose mode for the number of levels specified.
+  void enableVerboseTimestamps(const unsigned levels);
+
   // Set the ostream for verbose mode(defaults to std::cout).
   void setVerboseOstream(const Teuchos::RCP<std::ostream>& os);
 
@@ -739,6 +786,9 @@ protected:
 
   /// If set to true, prints to the debug ostream. At construction, default value is set from environment variable.
   bool enable_verbose_;
+
+  /// If set to a value greater than 0, verbose mode will print that many levels of timers with timestamps. A value of zero disables timestamps.
+  unsigned verbose_timestamp_levels_;
 
   /// For debugging, this is the ostream used for printing.
   Teuchos::RCP<std::ostream> verbose_ostream_;

--- a/packages/teuchos/comm/test/StackedTimer/stacked_timer.cpp
+++ b/packages/teuchos/comm/test/StackedTimer/stacked_timer.cpp
@@ -567,3 +567,35 @@ int main( int argc, char* argv[] )
 #endif
   return return_val;
 }
+
+// gcc 4.X is incomplete in c++11 standard - missing
+// std::put_time. We'll disable this feature for gcc 4.
+#if !defined(__GNUC__) || ( defined(__GNUC__) && (__GNUC__ > 4) )
+TEUCHOS_UNIT_TEST(StackedTimer, VerboseTimestamps) {
+
+  Teuchos::StackedTimer timer("My Timer");
+
+  timer.enableVerbose(true);
+  timer.enableVerboseTimestamps(2);
+  std::ostringstream os;
+  timer.setVerboseOstream(Teuchos::rcpFromRef(os));
+
+  timer.start("L1");
+  timer.start("L2");
+  timer.start("L3");
+  timer.stop("L3");
+  timer.stop("L2");
+  timer.stop("L1");
+  timer.stopBaseTimer();
+
+  out << os.str() << std::endl;
+
+  TEST_ASSERT(os.str().find("TIMESTAMP:"));
+
+  // Printing restricted to first two levels, thrid level should not
+  // be printed.
+  TEST_ASSERT(os.str().find("L1") != std::string::npos);
+  TEST_ASSERT(os.str().find("L2") != std::string::npos);
+  TEST_ASSERT(os.str().find("L3") == std::string::npos);
+}
+#endif


### PR DESCRIPTION
Adding a timestamp option to the StackedTimer when verbose mode is enabled. The user can enable and export the number of levels to output with:

```
export TEUCHOS_ENABLE_VERBOSE_TIMESTAMP_LEVELS=2
```

This is going to be used for LDMS performance monitoring on HPC machines.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->


## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Performance monitoring for milestone runs

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
Planning to be used in ATDM L1 Milestone runs.
 
## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
New unit test was added to stacked_timer.cpp. 

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->