### PR TITLE
ATDM: van1-tx2: Reduced parallel link level for 'dbg' builds (CDOFA-117)

### DIFF
--- a/cmake/std/atdm/van1-tx2/environment.sh
+++ b/cmake/std/atdm/van1-tx2/environment.sh
@@ -28,6 +28,12 @@ export ATDM_CONFIG_ENABLE_SPARC_SETTINGS=ON
 export ATDM_CONFIG_USE_NINJA=ON
 
 export ATDM_CONFIG_BUILD_COUNT=40  # Assume building on a compute node!
+if [[ "${ATDM_CONFIG_BUILD_TYPE}" == "DEBUG" ]] ; then
+  export ATDM_CONFIG_PARALLEL_LINK_JOBS_LIMIT=20
+  # Above: The 'dbg' build on 'stria' is randomly failing the link of some ROL
+  # execuables due to running out of memory when using 40 parallel link jobs.
+  # Reducing this is to avoid that.  See CDOFA-117.
+fi
 
 if [[ "$ATDM_CONFIG_NODE_TYPE" == "OPENMP" ]] ; then
   export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=16


### PR DESCRIPTION
The hope is that this will avoid OOM conditions when linking ROL execs.  See [CDOFA-117](https://sems-atlassian-srn.sandia.gov/browse/CDOFA-117)

## How was this tested?

On 'stria' I ran:

```
$ cd /lustre/rabartl/Trilinos.base/BUILDS/STRIA/CTEST_S/

$ env Trilinos_PACKAGES=Kokkos,Teuchos \
  ./ctest-s-local-test-driver.sh van1-tx2_arm-20.0_openmpi-4.0.2_openmp_static_dbg

***
*** ./ctest-s-local-test-driver.sh
***

ATDM_TRILINOS_DIR = '/lustre/rabartl/Trilinos.base/Trilinos'

Load some env to get python, cmake, etc ...

Hostname 'stria-login1' matches known ATDM host 'stria-login1' and system 'van1-tx2'
Setting compiler and build options for build-name 'default'
Using ARM ATSE compiler stack ARM-20.0_OPENMPI-4.0.2 to build DEBUG code with Kokkos node type SERIAL

Running builds:
    van1-tx2_arm-20.0_openmpi-4.0.2_openmp_static_dbg

Fri May  1 16:27:05 MDT 2020

Running Jenkins driver Trilinos-atdm-van1-tx2_arm-20.0_openmpi-4.0.2_openmp_static_dbg.sh ...

    Creating directory: Trilinos-atdm-van1-tx2_arm-20.0_openmpi-4.0.2_openmp_static_dbg

    Creating directory: SRC_AND_BUILD

    See log file Trilinos-atdm-van1-tx2_arm-20.0_openmpi-4.0.2_openmp_static_dbg/smart-jenkins-driver.out

real    11m15.305s
user    0m32.868s
sys     0m53.959s

100% tests passed, 0 tests failed out of 174

Fri May  1 16:38:20 MDT 2020

Done running all of the builds!
```

That posted to CDash [here](https://testing-dev.sandia.gov/cdash/index.php?project=Trilinos&parentid=5419523).

Evidence that the link job pool was limited to 20 for this build is in the file:

```
$ grep -A 1 "link_job_pool" Trilinos-atdm-van1-tx2_arm-20.0_openmpi-4.0.2_openmp_static_dbg/SRC_AND_BUILD/BUILD/rules.ninja 
pool link_job_pool
  depth = 20
```



