### PR TITLE
ifpack2: Reduce ILUT memory usage.

### DIFF
--- a/packages/ifpack2/src/Ifpack2_ILUT_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_ILUT_def.hpp
@@ -703,6 +703,13 @@ void ILUT<MatrixType>::compute ()
     // Now allocate and fill the matrices
     Array<size_t> nnzPerRow(myNumRows);
 
+    // Make sure to release the old memory for L & U prior to recomputing to
+    // avoid bloating the high-water mark.
+    L_ = Teuchos::null;
+    U_ = Teuchos::null;
+    L_solver_->setMatrix(Teuchos::null);
+    U_solver_->setMatrix(Teuchos::null);
+
     for (local_ordinal_type row_i = 0 ; row_i < myNumRows ; ++row_i) {
       nnzPerRow[row_i] = L_tmp_idx[row_i].size();
     }


### PR DESCRIPTION
By making sure to free L & U prior to recomputing them.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/ifpack2

## Motivation
This brings ifpack2 ILUT memory usage in line with aztec on several Aria test cases, saving ~30% high-water mark.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->