### PR TITLE
Set default for PANZER_FADTYPE at all points

### DIFF
--- a/cmake/std/PullRequestLinuxCuda9.2TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxCuda9.2TestingSettings.cmake
@@ -30,7 +30,7 @@ set (BUILD_SHARED_LIBS OFF CACHE BOOL "Set by default for CUDA PR testing")
 set (Tpetra_INST_SERIAL ON CACHE BOOL "Set by default for CUDA PR testing")
 set (Trilinos_ENABLE_SECONDARY_TESTED_CODE OFF CACHE BOOL "Set by default for CUDA PR testing")
 set (EpetraExt_ENABLE_HDF5 OFF CACHE BOOL "Set by default for CUDA PR testing")
-set (PANZER_FADTYPE "Sacado::Fad::DFad<RealType>" CACHE STRING "Set by default for CUDA PR testing")
+set (Panzer_ENABLE_FADTYPE "Sacado::Fad::DFad<RealType>" CACHE STRING "Set by default for CUDA PR testing")
 set (Kokkos_ENABLE_Debug_Bounds_Check ON CACHE BOOL "Set by default for CUDA PR testing")
 set (KOKKOS_ENABLE_DEBUG ON CACHE BOOL "Set by default for CUDA PR testing")
 

--- a/cmake/std/PullRequestLinuxCuda9.2TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxCuda9.2TestingSettings.cmake
@@ -30,7 +30,7 @@ set (BUILD_SHARED_LIBS OFF CACHE BOOL "Set by default for CUDA PR testing")
 set (Tpetra_INST_SERIAL ON CACHE BOOL "Set by default for CUDA PR testing")
 set (Trilinos_ENABLE_SECONDARY_TESTED_CODE OFF CACHE BOOL "Set by default for CUDA PR testing")
 set (EpetraExt_ENABLE_HDF5 OFF CACHE BOOL "Set by default for CUDA PR testing")
-set (Panzer_ENABLE_FADTYPE "Sacado::Fad::DFad<RealType>" CACHE STRING "Set by default for CUDA PR testing")
+set (PANZER_FADTYPE "Sacado::Fad::DFad<RealType>" CACHE STRING "Set by default for CUDA PR testing")
 set (Kokkos_ENABLE_Debug_Bounds_Check ON CACHE BOOL "Set by default for CUDA PR testing")
 set (KOKKOS_ENABLE_DEBUG ON CACHE BOOL "Set by default for CUDA PR testing")
 

--- a/packages/panzer/CMakeLists.txt
+++ b/packages/panzer/CMakeLists.txt
@@ -28,10 +28,9 @@ SET(${PACKAGE_NAME}_ADD_EXPENSIVE_CUDA_TESTS
   "Add expensive convergence tests to cuda builds.  Not recommended for CMAKE_BUILD_TYPE=DEBUG and CUDA")
 MESSAGE(STATUS "Convergence tests: ${${PACKAGE_NAME}_ADD_EXPENSIVE_CUDA_TESTS}")
 
-TRIBITS_ADD_OPTION_AND_DEFINE(${PACKAGE_NAME}_ENABLE_FADTYPE
-  PANZER_FADTYPE
-  "Choose the Sacado automatic differentiation scalar type (default is DFad)."
-  "Sacado::Fad::DFad<RealType>" )
+SET(${PACKAGE_NAME}_ENABLE_FADTYPE  "Sacado::Fad::DFad<RealType>"
+  CACHE STRING
+  "Choose the Sacado automatic differentiation scalar type (default is DFad).")
 
 TRIBITS_ADD_ENABLE_TEUCHOS_TIME_MONITOR_OPTION()
 

--- a/packages/panzer/CMakeLists.txt
+++ b/packages/panzer/CMakeLists.txt
@@ -28,10 +28,10 @@ SET(${PACKAGE_NAME}_ADD_EXPENSIVE_CUDA_TESTS
   "Add expensive convergence tests to cuda builds.  Not recommended for CMAKE_BUILD_TYPE=DEBUG and CUDA")
 MESSAGE(STATUS "Convergence tests: ${${PACKAGE_NAME}_ADD_EXPENSIVE_CUDA_TESTS}")
 
-SET( PANZER_FADTYPE
-     "Sacado::Fad::DFad<RealType>"
-     CACHE STRING
-     "Choose the Sacado automatic differentiation scalar type (default is DFad)." )
+TRIBITS_ADD_OPTION_AND_DEFINE(${PACKAGE_NAME}_ENABLE_FADTYPE
+  PANZER_FADTYPE
+  "Choose the Sacado automatic differentiation scalar type (default is DFad)."
+  "Sacado::Fad::DFad<RealType>" )
 
 TRIBITS_ADD_ENABLE_TEUCHOS_TIME_MONITOR_OPTION()
 

--- a/packages/panzer/CMakeLists.txt
+++ b/packages/panzer/CMakeLists.txt
@@ -28,10 +28,10 @@ SET(${PACKAGE_NAME}_ADD_EXPENSIVE_CUDA_TESTS
   "Add expensive convergence tests to cuda builds.  Not recommended for CMAKE_BUILD_TYPE=DEBUG and CUDA")
 MESSAGE(STATUS "Convergence tests: ${${PACKAGE_NAME}_ADD_EXPENSIVE_CUDA_TESTS}")
 
-TRIBITS_ADD_OPTION_AND_DEFINE(${PACKAGE_NAME}_ENABLE_FADTYPE
-  PANZER_FADTYPE
-  "Choose the Sacado automatic differentiation scalar type (default is DFad)."
-  "Sacado::Fad::DFad<RealType>" )
+SET( PANZER_FADTYPE
+     "Sacado::Fad::DFad<RealType>"
+     CACHE STRING
+     "Choose the Sacado automatic differentiation scalar type (default is DFad)." )
 
 TRIBITS_ADD_ENABLE_TEUCHOS_TIME_MONITOR_OPTION()
 

--- a/packages/panzer/core/cmake/PanzerCore_config.hpp.in
+++ b/packages/panzer/core/cmake/PanzerCore_config.hpp.in
@@ -8,7 +8,7 @@
 #cmakedefine HAVE_MPI
 
 // What AD Type are you going to use?
-#cmakedefine PANZER_FADTYPE @Panzer_ENABLE_FADTYPE@
+#define PANZER_FADTYPE @Panzer_ENABLE_FADTYPE@
 #cmakedefine PANZER_DEBUG
 #cmakedefine HAVE_PANZER_EXPLICIT_INSTANTIATION
 #cmakedefine PANZER_EXPLICIT_INSTANTIATION

--- a/packages/panzer/core/cmake/PanzerCore_config.hpp.in
+++ b/packages/panzer/core/cmake/PanzerCore_config.hpp.in
@@ -8,7 +8,7 @@
 #cmakedefine HAVE_MPI
 
 // What AD Type are you going to use?
-#cmakedefine PANZER_FADTYPE @PANZER_FADTYPE@
+#cmakedefine PANZER_FADTYPE @Panzer_ENABLE_FADTYPE@
 #cmakedefine PANZER_DEBUG
 #cmakedefine HAVE_PANZER_EXPLICIT_INSTANTIATION
 #cmakedefine PANZER_EXPLICIT_INSTANTIATION

--- a/packages/panzer/core/cmake/PanzerCore_config.hpp.in
+++ b/packages/panzer/core/cmake/PanzerCore_config.hpp.in
@@ -8,7 +8,7 @@
 #cmakedefine HAVE_MPI
 
 // What AD Type are you going to use?
-#cmakedefine PANZER_FADTYPE @Panzer_ENABLE_FADTYPE@
+#cmakedefine PANZER_FADTYPE @PANZER_FADTYPE@
 #cmakedefine PANZER_DEBUG
 #cmakedefine HAVE_PANZER_EXPLICIT_INSTANTIATION
 #cmakedefine PANZER_EXPLICIT_INSTANTIATION


### PR DESCRIPTION
I was seeing intermittent failures to build
with PANZER_FADTYPE undefined. The value was
set using TRIBITS_ADD_OPTION_AND DEFINE which
expects a bool and was passed a string. For
whatever reason, cmake is inconsistent about
how the passed string is interpreted and if the define
is set. Since there is no provision for this not being set
I just went to a direct SET statement.

## Motivation
Intermittent build failures due to mis-configuration

## Testing
The configure was run in a loop of 100 iterations and the output to PanzerCore_config.h was verified via grep. 
