### PR TITLE
Re-enable Muelu_Maxwell3D

### DIFF
--- a/cmake/std/atdm/ats1/tweaks/Tweaks.cmake
+++ b/cmake/std/atdm/ats1/tweaks/Tweaks.cmake
@@ -20,8 +20,8 @@ ATDM_SET_ENABLE(SEACASIoss_exodus32_to_exodus64_DISABLE ON)
 
 # Disable muelu tests that fail to build due to
 # '"Kokkos::Compat" has no member "KokkosSerialWrapperNode"'
-ATDM_SET_ENABLE(MueLu_Maxwell3D-Tpetra_MPI_4_DISABLE ON)
-ATDM_SET_ENABLE(MueLu_Maxwell3D_EXE_DISABLE ON)
+#ATDM_SET_ENABLE(MueLu_Maxwell3D-Tpetra_MPI_4_DISABLE ON)
+#ATDM_SET_ENABLE(MueLu_Maxwell3D_EXE_DISABLE ON)
 
 #message("ATDM_NODE_TYPE=${ATDM_NODE_TYPE}")
 #message("ATDM_CONFIG_KOKKOS_ARCH=$ENV{ATDM_CONFIG_KOKKOS_ARCH}")


### PR DESCRIPTION
## How was this tested?
I verified that the 'ats1' build passes via:
```bash
$ git log --pretty=oneline -1
7a74218d58456d0818e2f13dd8202451c1b133ac (HEAD -> develop, github-upstream/develop) Merge pull request #7313 from cgcgcg/epetraMueLuMaxwell
$ git status
On branch develop
Untracked files:
  (use "git add <file>..." to include in what will be committed)
$ cmake -G Ninja -DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/atdm/ATDMDevEnv.cmake -DTrilinos_ENABLE_TESTS=ON -DTrilinos_ENABLE_MueLu=ON -DMueLu_Maxwell3D_EXE_DISABLE=OFF -DMueLu_Maxwell3D-Tpetra_MPI_4_DISABLE=OFF ../Trilinos &> configure.out &
$ ninja -j16 &> make.out &
```

make.out shows no errors.

Related to #7311 
