### PR TITLE
Remove WORKSPACE env variable as it's not set in most cases

### DIFF
--- a/cmake/std/sems/PullRequestCuda9.2TestingEnv.sh
+++ b/cmake/std/sems/PullRequestCuda9.2TestingEnv.sh
@@ -7,7 +7,9 @@ module load git/2.10.1
 module load devpack/20180521/openmpi/2.1.2/gcc/7.2.0/cuda/9.2.88
 module swap openblas/0.2.20/gcc/7.2.0 netlib/3.8.0/gcc/7.2.0
 #export OMPI_CXX=`which g++`
-export OMPI_CXX=$WORKSPACE/Trilinos/packages/kokkos/bin/nvcc_wrapper
+current_dir=`dirname $BASH_SOURCE`
+Trilinos_dir=`realpath $current_dir/../../..`
+export OMPI_CXX=${Trilinos_dir}/packages/kokkos/bin/nvcc_wrapper
 export OMPI_CC=`which gcc`
 export OMPI_FC=`which gfortran`
 export CUDA_LAUNCH_BLOCKING=1


### PR DESCRIPTION
While debugging reproduction issues with #7201 I found that we were using an environment variable that is only set in Jenkins Jobs.  This just uses a built-in variable from bash instead.

@trilinos/framework 
@mperego 

## Testing
This was run on ride-6 from several repositories in differing paths. Output of OMPI_CXX was verified in each case.
