### PR TITLE
Fix CUDA defaulted function warnings (#7314)

### DIFF
--- a/packages/intrepid2/src/Orientation/Intrepid2_Orientation.hpp
+++ b/packages/intrepid2/src/Orientation/Intrepid2_Orientation.hpp
@@ -117,7 +117,7 @@ namespace Intrepid2 {
     KOKKOS_INLINE_FUNCTION
     Orientation();
 
-    KOKKOS_INLINE_FUNCTION
+    KOKKOS_DEFAULTED_FUNCTION
     Orientation(const Orientation &b) = default;
 
     KOKKOS_INLINE_FUNCTION

--- a/packages/intrepid2/src/Shared/Intrepid2_ArrayToolsDefContractions.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_ArrayToolsDefContractions.hpp
@@ -140,7 +140,7 @@ namespace Intrepid2 {
               const bool sumInto_) 
         : _outputFields(outputFields_), _inputData(inputData_), _inputFields(inputFields_), _sumInto(sumInto_) {}
 
-      KOKKOS_INLINE_FUNCTION
+      KOKKOS_DEFAULTED_FUNCTION
       ~F_contractDataField() = default;
       
       KOKKOS_INLINE_FUNCTION
@@ -223,7 +223,7 @@ namespace Intrepid2 {
               const bool sumInto_) 
         : _outputData(outputData_), _inputDataLeft(inputDataLeft_), _inputDataRight(inputDataRight_), _sumInto(sumInto_) {}
 
-      KOKKOS_INLINE_FUNCTION
+      KOKKOS_DEFAULTED_FUNCTION
       ~F_contractDataData() = default;
       
       KOKKOS_INLINE_FUNCTION

--- a/packages/phalanx/src/Phalanx_DeviceEvaluator.hpp
+++ b/packages/phalanx/src/Phalanx_DeviceEvaluator.hpp
@@ -12,7 +12,7 @@ namespace PHX {
     using member_type = team_policy::member_type;
     using traits = Traits;
     
-    KOKKOS_FUNCTION virtual ~DeviceEvaluator() = default;
+    KOKKOS_DEFAULTED_FUNCTION virtual ~DeviceEvaluator() = default;
 
     //! Used to bind EvalData objects to functor
     KOKKOS_FUNCTION virtual void

--- a/packages/sacado/src/KokkosExp_View_Fad.hpp
+++ b/packages/sacado/src/KokkosExp_View_Fad.hpp
@@ -1268,11 +1268,11 @@ public:
   KOKKOS_INLINE_FUNCTION ~ViewMapping() {}
   KOKKOS_INLINE_FUNCTION ViewMapping() : m_impl_handle(0) , m_impl_offset() , m_array_offset() , m_fad_size(0) , m_fad_stride(0) {}
 
-  KOKKOS_INLINE_FUNCTION ViewMapping( const ViewMapping & ) = default ;
-  KOKKOS_INLINE_FUNCTION ViewMapping & operator = ( const ViewMapping & ) = default ;
+  KOKKOS_DEFAULTED_FUNCTION ViewMapping( const ViewMapping & ) = default ;
+  KOKKOS_DEFAULTED_FUNCTION ViewMapping & operator = ( const ViewMapping & ) = default ;
 
-  KOKKOS_INLINE_FUNCTION ViewMapping( ViewMapping && ) = default ;
-  KOKKOS_INLINE_FUNCTION ViewMapping & operator = ( ViewMapping && ) = default ;
+  KOKKOS_DEFAULTED_FUNCTION ViewMapping( ViewMapping && ) = default ;
+  KOKKOS_DEFAULTED_FUNCTION ViewMapping & operator = ( ViewMapping && ) = default ;
 
   template< class ... P >
   KOKKOS_INLINE_FUNCTION

--- a/packages/sacado/src/KokkosExp_View_Fad_Contiguous.hpp
+++ b/packages/sacado/src/KokkosExp_View_Fad_Contiguous.hpp
@@ -1027,14 +1027,14 @@ public:
 
   //----------------------------------------
 
-  KOKKOS_INLINE_FUNCTION ~ViewMapping() = default ;
+  KOKKOS_DEFAULTED_FUNCTION ~ViewMapping() = default ;
   KOKKOS_INLINE_FUNCTION ViewMapping() : m_impl_handle(0) , m_impl_offset() , m_array_offset() , m_fad_size(0) , m_original_fad_size(0) , m_fad_stride(1) , m_fad_index(0)  {}
 
-  KOKKOS_INLINE_FUNCTION ViewMapping( const ViewMapping & ) = default ;
-  KOKKOS_INLINE_FUNCTION ViewMapping & operator = ( const ViewMapping & ) = default ;
+  KOKKOS_DEFAULTED_FUNCTION ViewMapping( const ViewMapping & ) = default ;
+  KOKKOS_DEFAULTED_FUNCTION ViewMapping & operator = ( const ViewMapping & ) = default ;
 
-  KOKKOS_INLINE_FUNCTION ViewMapping( ViewMapping && ) = default ;
-  KOKKOS_INLINE_FUNCTION ViewMapping & operator = ( ViewMapping && ) = default ;
+  KOKKOS_DEFAULTED_FUNCTION ViewMapping( ViewMapping && ) = default ;
+  KOKKOS_DEFAULTED_FUNCTION ViewMapping & operator = ( ViewMapping && ) = default ;
 
   template< class ... P >
   KOKKOS_INLINE_FUNCTION

--- a/packages/stk/stk_mesh/stk_mesh/base/DeviceMesh.hpp
+++ b/packages/stk/stk_mesh/stk_mesh/base/DeviceMesh.hpp
@@ -197,7 +197,7 @@ public:
     update_mesh();
   }
 
-  STK_FUNCTION
+  KOKKOS_DEFAULTED_FUNCTION
   DeviceMesh(const DeviceMesh &) = default;
 
   STK_FUNCTION

--- a/packages/stk/stk_mesh/stk_mesh/base/NgpField.hpp
+++ b/packages/stk/stk_mesh/stk_mesh/base/NgpField.hpp
@@ -55,7 +55,7 @@ template<typename T> class MultistateField;
 class NgpFieldBase
 {
 public:
-  STK_FUNCTION NgpFieldBase() = default;
+  KOKKOS_DEFAULTED_FUNCTION NgpFieldBase() = default;
   STK_FUNCTION virtual ~NgpFieldBase() {}
   virtual void update_field() = 0;
   virtual void modify_on_host() = 0;
@@ -73,7 +73,7 @@ public:
   STK_FUNCTION EntityFieldData(T* dataPtr, unsigned length, unsigned stride=1)
   : fieldDataPtr(dataPtr), fieldDataLength(length), fieldDataStride(stride)
   {}
-  STK_FUNCTION ~EntityFieldData() = default;
+  KOKKOS_DEFAULTED_FUNCTION ~EntityFieldData() = default;
 
   STK_FUNCTION unsigned size() const { return fieldDataLength; }
   STK_FUNCTION T& operator[](unsigned idx) { return fieldDataPtr[idx*fieldDataStride]; }
@@ -413,7 +413,7 @@ public:
     fieldData.clear_sync_state();
   }
 
-  STK_FUNCTION DeviceField(const DeviceField &) = default;
+  KOKKOS_DEFAULTED_FUNCTION DeviceField(const DeviceField &) = default;
 
   STK_FUNCTION virtual ~DeviceField() {}
 
@@ -643,7 +643,7 @@ public:
   {
   }
 
-  STK_FUNCTION ConstDeviceField(const ConstDeviceField &) = default;
+  KOKKOS_DEFAULTED_FUNCTION ConstDeviceField(const ConstDeviceField &) = default;
 
   STK_FUNCTION virtual ~ConstDeviceField() {}
 

--- a/packages/stk/stk_mesh/stk_mesh/base/NgpReductions.hpp
+++ b/packages/stk/stk_mesh/stk_mesh/base/NgpReductions.hpp
@@ -98,7 +98,7 @@ struct FieldAccessFunctor{
   }
   KOKKOS_FUNCTION
   stk::mesh::EntityRank get_rank() const { return field.get_rank(); }
-  KOKKOS_FUNCTION
+  KOKKOS_DEFAULTED_FUNCTION
   FieldAccessFunctor(const FieldAccessFunctor& rhs) = default;
   KOKKOS_FUNCTION
   FieldAccessFunctor(const FieldAccessFunctor& rhs, unsigned b_id, ReductionOp r)

--- a/packages/stk/stk_ngp/stk_ngp/NgpField.hpp
+++ b/packages/stk/stk_ngp/stk_ngp/NgpField.hpp
@@ -54,7 +54,7 @@ template<typename T> class MultistateField;
 class FieldBase
 {
 public:
-  STK_FUNCTION FieldBase() = default;
+  KOKKOS_DEFAULTED_FUNCTION FieldBase() = default;
   STK_FUNCTION virtual ~FieldBase() {}
   virtual void sync_to_host() {}
 };
@@ -333,7 +333,7 @@ public:
         fieldData.clear_sync_state();  // New Kokkos API
     }
 
-    STK_FUNCTION StaticField(const StaticField &) = default;
+    KOKKOS_DEFAULTED_FUNCTION StaticField(const StaticField &) = default;
 
     STK_FUNCTION virtual ~StaticField() {}
 
@@ -538,7 +538,7 @@ public:
     {
     }
 
-    STK_FUNCTION ConstStaticField(const ConstStaticField &) = default;
+    KOKKOS_DEFAULTED_FUNCTION ConstStaticField(const ConstStaticField &) = default;
 
     STK_FUNCTION virtual ~ConstStaticField() {}
 

--- a/packages/stk/stk_ngp/stk_ngp/NgpFieldParallel.hpp
+++ b/packages/stk/stk_ngp/stk_ngp/NgpFieldParallel.hpp
@@ -146,13 +146,13 @@ struct NgpFieldInfo
   NgpFieldInfo(ngp::Field<T>& fld)
     : m_field(fld) {}
 
-  STK_FUNCTION
+  KOKKOS_DEFAULTED_FUNCTION
   NgpFieldInfo() = default;
 
-  STK_FUNCTION
+  KOKKOS_DEFAULTED_FUNCTION
   NgpFieldInfo(const NgpFieldInfo&) = default;
 
-  STK_FUNCTION
+  KOKKOS_DEFAULTED_FUNCTION
   ~NgpFieldInfo() = default;
 
   STK_FUNCTION

--- a/packages/stk/stk_ngp/stk_ngp/NgpMesh.hpp
+++ b/packages/stk/stk_ngp/stk_ngp/NgpMesh.hpp
@@ -625,7 +625,7 @@ public:
        //ThrowRequireMsg(false,"ERROR, update_buckets not supported for ngp::StaticMesh");
     }
 
-    STK_FUNCTION
+    KOKKOS_DEFAULTED_FUNCTION
     StaticMesh(const StaticMesh &) = default;
     STK_FUNCTION
     ~StaticMesh() {}

--- a/packages/stk/stk_ngp/stk_ngp/NgpReductions.hpp
+++ b/packages/stk/stk_ngp/stk_ngp/NgpReductions.hpp
@@ -87,7 +87,7 @@ struct FieldAccessFunctor{
     }
   KOKKOS_FUNCTION
     stk::mesh::EntityRank get_rank() const { return field.get_rank(); }
-  KOKKOS_FUNCTION
+  KOKKOS_DEFAULTED_FUNCTION
     FieldAccessFunctor(const FieldAccessFunctor& rhs) = default;
   KOKKOS_FUNCTION
     FieldAccessFunctor(const FieldAccessFunctor& rhs, const typename Mesh::BucketType* b, ReductionOp r)

--- a/packages/stk/stk_search/stk_search/Box.hpp
+++ b/packages/stk/stk_search/stk_search/Box.hpp
@@ -108,7 +108,7 @@ public:
     set_max_corner(b.max_corner());
   }
 
-  KOKKOS_FUNCTION ~Box() = default;
+  KOKKOS_DEFAULTED_FUNCTION ~Box() = default;
 
 private:
   point_type m_min_corner;

--- a/packages/stk/stk_search/stk_search/KDTree_BoundingBox.hpp
+++ b/packages/stk/stk_search/stk_search/KDTree_BoundingBox.hpp
@@ -60,11 +60,11 @@ namespace stk {
                                                       const int obj_num_) :
       m_box(box), obj_num(obj_num_) {}             
       KOKKOS_FORCEINLINE_FUNCTION ObjectBoundingBox_T(const ObjectBoundingBox_T &box);         ///< Explicit copy constructor
-      KOKKOS_FORCEINLINE_FUNCTION ObjectBoundingBox_T(ObjectBoundingBox_T&&) = default;        ///< Default Move constructor
+      KOKKOS_DEFAULTED_FUNCTION ObjectBoundingBox_T(ObjectBoundingBox_T&&) = default;        ///< Default Move constructor
       KOKKOS_FORCEINLINE_FUNCTION ~ObjectBoundingBox_T() {}                                  ///< Destructor
 
       KOKKOS_FORCEINLINE_FUNCTION ObjectBoundingBox_T& operator = (const ObjectBoundingBox_T&);      ///< Standard assignment (allows a = b = c)
-      KOKKOS_FORCEINLINE_FUNCTION ObjectBoundingBox_T& operator = (ObjectBoundingBox_T&&) = default; ///< Default move assignment
+      KOKKOS_DEFAULTED_FUNCTION ObjectBoundingBox_T& operator = (ObjectBoundingBox_T&&) = default; ///< Default move assignment
       ///
       ///  Explicity set or extract the object index for this bounding box
       ///

--- a/packages/stk/stk_search/stk_search/Point.hpp
+++ b/packages/stk/stk_search/stk_search/Point.hpp
@@ -89,7 +89,7 @@ public:
   KOKKOS_FUNCTION value_type get_z_max() const { return m_value[2]; }
 
 
-  KOKKOS_FUNCTION ~Point() = default;
+  KOKKOS_DEFAULTED_FUNCTION ~Point() = default;
 
 private:
   value_type m_value[Dim];

--- a/packages/stk/stk_util/stk_util/parallel/MPI.hpp
+++ b/packages/stk/stk_util/stk_util/parallel/MPI.hpp
@@ -139,11 +139,11 @@ MPI_Datatype double_double_int_type();
 template <typename T, typename IdType=int64_t>
 struct Loc
 {
-  KOKKOS_INLINE_FUNCTION Loc() = default;
-  KOKKOS_INLINE_FUNCTION Loc(const Loc &) = default;
-  KOKKOS_INLINE_FUNCTION Loc(Loc &&) = default;
-  KOKKOS_INLINE_FUNCTION Loc & operator=(const Loc &) = default;
-  KOKKOS_INLINE_FUNCTION Loc & operator=(Loc &&) = default;
+  KOKKOS_DEFAULTED_FUNCTION Loc() = default;
+  KOKKOS_DEFAULTED_FUNCTION Loc(const Loc &) = default;
+  KOKKOS_DEFAULTED_FUNCTION Loc(Loc &&) = default;
+  KOKKOS_DEFAULTED_FUNCTION Loc & operator=(const Loc &) = default;
+  KOKKOS_DEFAULTED_FUNCTION Loc & operator=(Loc &&) = default;
   // Required to use with Kokkos::atomic_compare_exchange()
   KOKKOS_INLINE_FUNCTION Loc(const volatile Loc & loc) : m_value(loc.m_value), m_loc(loc.m_loc) {}
   KOKKOS_INLINE_FUNCTION Loc & operator=(const volatile Loc &rhs)

--- a/packages/stokhos/src/sacado/kokkos/Stokhos_StaticFixedStorage.hpp
+++ b/packages/stokhos/src/sacado/kokkos/Stokhos_StaticFixedStorage.hpp
@@ -91,7 +91,7 @@ namespace Stokhos {
     };
 
     //! Constructor
-    KOKKOS_INLINE_FUNCTION
+    KOKKOS_DEFAULTED_FUNCTION
     StaticFixedStorage() = default;
 
     //! Constructor
@@ -112,7 +112,7 @@ namespace Stokhos {
     StaticFixedStorage(const ordinal_type& sz, pointer v, bool owned) {}
 
     //! Copy constructor
-    KOKKOS_INLINE_FUNCTION
+    KOKKOS_DEFAULTED_FUNCTION
     StaticFixedStorage(const StaticFixedStorage& s) = default;
 
     //! Copy constructor
@@ -122,11 +122,11 @@ namespace Stokhos {
     }
 
     //! Destructor
-    KOKKOS_INLINE_FUNCTION
+    KOKKOS_DEFAULTED_FUNCTION
     ~StaticFixedStorage() = default;
 
     //! Assignment operator
-    KOKKOS_INLINE_FUNCTION
+    KOKKOS_DEFAULTED_FUNCTION
     StaticFixedStorage& operator=(const StaticFixedStorage& s) = default;
 
     //! Assignment operator
@@ -323,7 +323,7 @@ namespace Stokhos {
     };
 
     //! Constructor
-    KOKKOS_INLINE_FUNCTION
+    KOKKOS_DEFAULTED_FUNCTION
     StaticFixedStorage() = default;
 
     //! Constructor
@@ -344,7 +344,7 @@ namespace Stokhos {
     StaticFixedStorage(const ordinal_type& sz, pointer v, bool owned) {}
 
     //! Copy constructor
-    KOKKOS_INLINE_FUNCTION
+    KOKKOS_DEFAULTED_FUNCTION
     StaticFixedStorage(const StaticFixedStorage& s) = default;
 
     //! Copy constructor
@@ -354,11 +354,11 @@ namespace Stokhos {
     }
 
     //! Destructor
-    KOKKOS_INLINE_FUNCTION
+    KOKKOS_DEFAULTED_FUNCTION
     ~StaticFixedStorage() = default;
 
     //! Assignment operator
-    KOKKOS_INLINE_FUNCTION
+    KOKKOS_DEFAULTED_FUNCTION
     StaticFixedStorage& operator=(const StaticFixedStorage& s) = default;
 
     //! Assignment operator

--- a/packages/stokhos/src/sacado/kokkos/pce/KokkosExp_View_UQ_PCE_Contiguous.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/KokkosExp_View_UQ_PCE_Contiguous.hpp
@@ -1243,7 +1243,7 @@ public:
 
   //----------------------------------------
 
-  KOKKOS_INLINE_FUNCTION ~ViewMapping() = default ;
+  KOKKOS_DEFAULTED_FUNCTION ~ViewMapping() = default ;
   KOKKOS_INLINE_FUNCTION ViewMapping() :
     m_impl_handle(),
     m_impl_offset(),
@@ -1252,11 +1252,11 @@ public:
     m_is_contiguous(true)
     {}
 
-  KOKKOS_INLINE_FUNCTION ViewMapping( const ViewMapping & ) = default ;
-  KOKKOS_INLINE_FUNCTION ViewMapping & operator = ( const ViewMapping & ) = default ;
+  KOKKOS_DEFAULTED_FUNCTION ViewMapping( const ViewMapping & ) = default ;
+  KOKKOS_DEFAULTED_FUNCTION ViewMapping & operator = ( const ViewMapping & ) = default ;
 
-  KOKKOS_INLINE_FUNCTION ViewMapping( ViewMapping && ) = default ;
-  KOKKOS_INLINE_FUNCTION ViewMapping & operator = ( ViewMapping && ) = default ;
+  KOKKOS_DEFAULTED_FUNCTION ViewMapping( ViewMapping && ) = default ;
+  KOKKOS_DEFAULTED_FUNCTION ViewMapping & operator = ( ViewMapping && ) = default ;
 
   template< class ... P >
   KOKKOS_INLINE_FUNCTION

--- a/packages/stokhos/src/sacado/kokkos/pce/Sacado_UQ_PCE.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/Sacado_UQ_PCE.hpp
@@ -116,7 +116,7 @@ namespace Sacado {
       /*!
        * May not intialize the coefficient array.
        */
-      KOKKOS_INLINE_FUNCTION
+      KOKKOS_DEFAULTED_FUNCTION 
       PCE() = default;
 
       //! Constructor with supplied value \c x
@@ -179,7 +179,7 @@ namespace Sacado {
         cijk_(), s_(l.size(), l.begin()) {}
 
       //! Destructor
-      KOKKOS_INLINE_FUNCTION
+      KOKKOS_DEFAULTED_FUNCTION
       ~PCE() = default;
 
       //! Initialize coefficients to value

--- a/packages/stokhos/src/sacado/kokkos/vector/KokkosExp_View_MP_Vector_Contiguous.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/KokkosExp_View_MP_Vector_Contiguous.hpp
@@ -1017,7 +1017,7 @@ public:
 
   //----------------------------------------
 
-  KOKKOS_INLINE_FUNCTION ~ViewMapping() = default ;
+  KOKKOS_DEFAULTED_FUNCTION ~ViewMapping() = default ;
   KOKKOS_INLINE_FUNCTION ViewMapping() :
     m_impl_handle(),
     m_impl_offset(),
@@ -1025,11 +1025,11 @@ public:
     m_sacado_size(0)
     {}
 
-  KOKKOS_INLINE_FUNCTION ViewMapping( const ViewMapping & ) = default ;
-  KOKKOS_INLINE_FUNCTION ViewMapping & operator = ( const ViewMapping & ) = default ;
+  KOKKOS_DEFAULTED_FUNCTION ViewMapping( const ViewMapping & ) = default ;
+  KOKKOS_DEFAULTED_FUNCTION ViewMapping & operator = ( const ViewMapping & ) = default ;
 
-  KOKKOS_INLINE_FUNCTION ViewMapping( ViewMapping && ) = default ;
-  KOKKOS_INLINE_FUNCTION ViewMapping & operator = ( ViewMapping && ) = default ;
+  KOKKOS_DEFAULTED_FUNCTION ViewMapping( ViewMapping && ) = default ;
+  KOKKOS_DEFAULTED_FUNCTION ViewMapping & operator = ( ViewMapping && ) = default ;
 
   template< class ... P >
   KOKKOS_INLINE_FUNCTION

--- a/packages/stokhos/src/sacado/kokkos/vector/Sacado_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/Sacado_MP_Vector.hpp
@@ -190,7 +190,7 @@ namespace Sacado {
       /*!
        * May not intialize the coefficient array.
        */
-      KOKKOS_INLINE_FUNCTION
+      KOKKOS_DEFAULTED_FUNCTION
       Vector() = default;
 
       //! Constructor with supplied value \c x
@@ -220,7 +220,7 @@ namespace Sacado {
       Vector(const storage_type& ss) : s(ss) {}
 
       //! Copy constructor
-      KOKKOS_INLINE_FUNCTION
+      KOKKOS_DEFAULTED_FUNCTION
       Vector(const Vector& x) = default;
 
       //! Copy constructor
@@ -266,7 +266,7 @@ namespace Sacado {
       Vector(std::initializer_list<value_type> l) : s(l.size(), l.begin()) {}
 
       //! Destructor
-      KOKKOS_INLINE_FUNCTION
+      KOKKOS_DEFAULTED_FUNCTION
       ~Vector() = default;
 
       //! Initialize coefficients to value

--- a/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_def.hpp
@@ -94,8 +94,8 @@ namespace Impl {
   template<typename T>
   struct BlockCrsRowStruct {
     T totalNumEntries, totalNumBytes, maxRowLength;
-    KOKKOS_INLINE_FUNCTION BlockCrsRowStruct() = default;
-    KOKKOS_INLINE_FUNCTION BlockCrsRowStruct(const BlockCrsRowStruct &b) = default;
+    KOKKOS_DEFAULTED_FUNCTION BlockCrsRowStruct() = default;
+    KOKKOS_DEFAULTED_FUNCTION BlockCrsRowStruct(const BlockCrsRowStruct &b) = default;
     KOKKOS_INLINE_FUNCTION BlockCrsRowStruct(const T& numEnt, const T& numBytes, const T& rowLength)
       : totalNumEntries(numEnt), totalNumBytes(numBytes), maxRowLength(rowLength) {}
   };

--- a/packages/trilinoscouplings/examples/fenl/fenl_functors.hpp
+++ b/packages/trilinoscouplings/examples/fenl/fenl_functors.hpp
@@ -423,7 +423,7 @@ struct LocalGatherScatterTraits {
 template <typename MultiVectorType>
 class ParamSensitivityGatherScatterOp {
 public:
-  KOKKOS_INLINE_FUNCTION
+  KOKKOS_DEFAULTED_FUNCTION
   ParamSensitivityGatherScatterOp() = default;
 
   KOKKOS_INLINE_FUNCTION
@@ -432,10 +432,10 @@ public:
     solution_dp(sol_dp), residual_dp(res_dp),
     num_p(solution_dp.extent(1)) {}
 
-  KOKKOS_INLINE_FUNCTION
+  KOKKOS_DEFAULTED_FUNCTION
   ParamSensitivityGatherScatterOp(const ParamSensitivityGatherScatterOp&) = default;
 
-  KOKKOS_INLINE_FUNCTION
+  KOKKOS_DEFAULTED_FUNCTION
   ParamSensitivityGatherScatterOp& operator=(const ParamSensitivityGatherScatterOp&) = default;
 
   template <typename VectorType, typename ScalarType>


### PR DESCRIPTION
Fix warnings in several packages that happen in CUDA 9/10 builds,
by using ``KOKKOS_DEFAULTED_FUNCTION`` instead of ``KOKKOS_INLINE_FUNCTION``
for explicitly defaulted functions (default constructors, copy constructors, destructors, and ``operator=``).

``KOKKOS_DEFAULTED_FUNCTION`` is defined depending on the CUDA version (< 10.0, it's the same as ``KOKKOS_INLINE_FUNCTION``,  but for >= 10.0, it's empty). This is because starting in CUDA 10, the compiler can generate ``__device__`` versions of defaulted functions as needed, and warns if ``__host__`` and/or ``__device__`` annotations are added explicitly. CUDA 9 still requires the annotations, but also warns if they are added, so Kokkos adds flags to repress the warnings in that case.

@alanw0 There are some changes to STK, so those would need to be applied to the real STK repo.
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 
@trilinos/stokhos 
@trilinos/stk 
@trilinos/intrepid2 
@trilinos/trilinoscouplings 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Just fixes lots of warnings, for example:
```
warning: __host__ annotation is ignored on a function("~ViewMapping")
that is explicitly defaulted on its first declaration
```
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
-->
## Related Issues

* Closes #7314
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 



## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
Did an all-packages build on RHEL7, CUDA 10.1.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->