### PR TITLE
MueLu: Allow developer verbosity options in easy interface, fix RefMaxwell bug

### DIFF
--- a/packages/muelu/adapters/xpetra/MueLu_CreateXpetraPreconditioner.hpp
+++ b/packages/muelu/adapters/xpetra/MueLu_CreateXpetraPreconditioner.hpp
@@ -105,7 +105,7 @@ namespace MueLu {
       const bool writeZeroTimers  = false;
       const bool ignoreZeroTimers = true;
       const std::string filter    = timerName;
-      Teuchos::TimeMonitor::summarize(op->getRowMap()->getComm().ptr(), std::cout, alwaysWriteLocal, writeGlobalStats,
+      Teuchos::TimeMonitor::summarize(op->getRowMap()->getComm().ptr(), H->GetOStream(Statistics0), alwaysWriteLocal, writeGlobalStats,
                                       writeZeroTimers, Teuchos::Union, filter, ignoreZeroTimers);
     }
 
@@ -201,7 +201,7 @@ namespace MueLu {
       const bool writeZeroTimers  = false;
       const bool ignoreZeroTimers = true;
       const std::string filter    = timerName;
-      Teuchos::TimeMonitor::summarize(A->getRowMap()->getComm().ptr(), std::cout, alwaysWriteLocal, writeGlobalStats,
+      Teuchos::TimeMonitor::summarize(A->getRowMap()->getComm().ptr(), H->GetOStream(Statistics0), alwaysWriteLocal, writeGlobalStats,
                                       writeZeroTimers, Teuchos::Union, filter, ignoreZeroTimers);
     }
 

--- a/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_def.hpp
+++ b/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_def.hpp
@@ -130,8 +130,13 @@ namespace MueLu {
     }
 
     parameterList_             = list;
-    std::string verbosityLevel = parameterList_.get<std::string>("verbosity", "medium");
+    std::string verbosityLevel = parameterList_.get<std::string>("verbosity", MasterList::getDefault<std::string>("verbosity"));
     VerboseObject::SetDefaultVerbLevel(toVerbLevel(verbosityLevel));
+    std::string outputFilename = parameterList_.get<std::string>("output filename", MasterList::getDefault<std::string>("output filename"));
+    if (outputFilename != "")
+      VerboseObject::SetMueLuOFileStream(outputFilename);
+    if (parameterList_.isType<Teuchos::RCP<Teuchos::FancyOStream> >("output stream"))
+      VerboseObject::SetMueLuOStream(parameterList_.get<Teuchos::RCP<Teuchos::FancyOStream> >("output stream"));
 
     if (parameterList_.get("print initial parameters",MasterList::getDefault<bool>("print initial parameters")))
       GetOStream(static_cast<MsgType>(Runtime1), 0) << parameterList_ << std::endl;

--- a/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_def.hpp
+++ b/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_def.hpp
@@ -129,24 +129,12 @@ namespace MueLu {
       list = newList;
     }
 
-    std::map<std::string, MsgType> verbMap;
-    verbMap["none"]    = None;
-    verbMap["low"]     = Low;
-    verbMap["medium"]  = Medium;
-    verbMap["high"]    = High;
-    verbMap["extreme"] = Extreme;
-    verbMap["test"]    = Test;
-
-    std::string verbosityLevel = parameterList_.get<std::string>("verbosity", "medium");
-    verbosityLevel = lowerCase(verbosityLevel);
-
-    TEUCHOS_TEST_FOR_EXCEPTION(verbMap.count(verbosityLevel) == 0, Exceptions::RuntimeError,
-                               "Invalid verbosity level: \"" << verbosityLevel << "\"");
-    VerboseObject::SetDefaultVerbLevel(verbMap[verbosityLevel]);
-
     parameterList_             = list;
-    if (list.get("print initial parameters",MasterList::getDefault<bool>("print initial parameters")))
-      GetOStream(static_cast<MsgType>(Runtime1), 0) << list << std::endl;
+    std::string verbosityLevel = parameterList_.get<std::string>("verbosity", "medium");
+    VerboseObject::SetDefaultVerbLevel(toVerbLevel(verbosityLevel));
+
+    if (parameterList_.get("print initial parameters",MasterList::getDefault<bool>("print initial parameters")))
+      GetOStream(static_cast<MsgType>(Runtime1), 0) << parameterList_ << std::endl;
     disable_addon_             = list.get("refmaxwell: disable addon",         MasterList::getDefault<bool>("refmaxwell: disable addon"));
     mode_                      = list.get("refmaxwell: mode",                  MasterList::getDefault<std::string>("refmaxwell: mode"));
     use_as_preconditioner_     = list.get("refmaxwell: use as preconditioner", MasterList::getDefault<bool>("refmaxwell: use as preconditioner"));

--- a/packages/muelu/doc/UsersGuide/masterList.xml
+++ b/packages/muelu/doc/UsersGuide/masterList.xml
@@ -26,6 +26,13 @@
     </parameter>
 
     <parameter>
+      <name>output filename</name>
+      <type>string</type>
+      <default>""</default>
+      <description>Write MueLu output to a file instead of std out. Empty value disables file output.</description>
+    </parameter>
+
+    <parameter>
       <name>number of equations</name>
       <type>int</type>
       <default>1</default>

--- a/packages/muelu/doc/UsersGuide/options_general.tex
+++ b/packages/muelu/doc/UsersGuide/options_general.tex
@@ -3,6 +3,8 @@
           
 \cbb{verbosity}{string}{"high"}{Control of the amount of printed information. Possible values: see Table~\ref{t:verbosity_types}.}
           
+\cbb{output filename}{string}{""}{Write MueLu output to a file instead of std out. Empty value disables file output.}
+          
 \cbb{number of equations}{int}{1}{Number of PDE equations at each grid node. Only constant block size is considered.}
           
 \cbb{max levels}{int}{10}{Maximum number of levels in a hierarchy.}

--- a/packages/muelu/doc/UsersGuide/paramlist.tex
+++ b/packages/muelu/doc/UsersGuide/paramlist.tex
@@ -3,6 +3,8 @@
           
 \cbb{verbosity}{string}{"high"}{Control of the amount of printed information. Possible values: see Table~\ref{t:verbosity_types}.}
           
+\cbb{output filename}{string}{""}{Write MueLu output to a file instead of std out. Empty value disables file output.}
+          
 \cbb{number of equations}{int}{1}{Number of PDE equations at each grid node. Only constant block size is considered.}
           
 \cbb{max levels}{int}{10}{Maximum number of levels in a hierarchy.}

--- a/packages/muelu/doc/UsersGuide/paramlist_hidden.tex
+++ b/packages/muelu/doc/UsersGuide/paramlist_hidden.tex
@@ -3,6 +3,8 @@
         
 \cbb{verbosity}{string}{"high"}{Control of the amount of printed information. Possible values: see Table~\ref{t:verbosity_types}.}
         
+\cbb{output filename}{string}{""}{Write MueLu output to a file instead of std out. Empty value disables file output.}
+        
 \cbb{number of equations}{int}{1}{Number of PDE equations at each grid node. Only constant block size is considered.}
         
 \cbb{max levels}{int}{10}{Maximum number of levels in a hierarchy.}

--- a/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
+++ b/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
@@ -328,6 +328,10 @@ namespace MueLu {
       VerboseObject::SetDefaultVerbLevel(this->verbosity_);
     }
 
+    MUELU_SET_VAR_2LIST(paramList, paramList, "output filename", std::string, outputFilename);
+    if (outputFilename != "")
+      VerboseObject::SetMueLuOFileStream(outputFilename);
+
     // Detect if we need to transfer coordinates to coarse levels. We do that iff
     //  - we use "distance laplacian" dropping on some level, or
     //  - we use a repartitioner on some level that needs coordinates
@@ -1962,6 +1966,9 @@ namespace MueLu {
         hieraList.remove("verbosity");
         this->verbosity_ = toVerbLevel(vl);
       }
+
+      if (hieraList.isParameter("output filename"))
+        VerboseObject::SetMueLuOFileStream(hieraList.get<std::string>("output filename"));
 
       if (hieraList.isParameter("dependencyOutputLevel"))
         this->graphOutputLevel_ = hieraList.get<int>("dependencyOutputLevel");

--- a/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
+++ b/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
@@ -323,20 +323,8 @@ namespace MueLu {
     // Set verbosity parameter
     VerbLevel oldVerbLevel = VerboseObject::GetDefaultVerbLevel();
     {
-      std::map<std::string, MsgType> verbMap;
-      verbMap["none"]    = None;
-      verbMap["low"]     = Low;
-      verbMap["medium"]  = Medium;
-      verbMap["high"]    = High;
-      verbMap["extreme"] = Extreme;
-      verbMap["test"]    = Test;
-
       MUELU_SET_VAR_2LIST(paramList, paramList, "verbosity", std::string, verbosityLevel);
-      verbosityLevel = lowerCase(verbosityLevel);
-
-      TEUCHOS_TEST_FOR_EXCEPTION(verbMap.count(verbosityLevel) == 0, Exceptions::RuntimeError,
-                                 "Invalid verbosity level: \"" << verbosityLevel << "\"");
-      this->verbosity_ = verbMap[verbosityLevel];
+      this->verbosity_ = toVerbLevel(verbosityLevel);
       VerboseObject::SetDefaultVerbLevel(this->verbosity_);
     }
 
@@ -1969,43 +1957,10 @@ namespace MueLu {
         this->Cycle_ = cycleMap[cycleType];
       }
 
-      //TODO Move this its own class or MueLu::Utils?
-      std::map<std::string, MsgType> verbMap;
-      //for developers
-      verbMap["errors"]         = Errors;
-      verbMap["warnings0"]      = Warnings0;
-      verbMap["warnings00"]     = Warnings00;
-      verbMap["warnings1"]      = Warnings1;
-      verbMap["perfWarnings"]   = PerfWarnings;
-      verbMap["runtime0"]       = Runtime0;
-      verbMap["runtime1"]       = Runtime1;
-      verbMap["runtimeTimings"] = RuntimeTimings;
-      verbMap["noTimeReport"]   = NoTimeReport;
-      verbMap["parameters0"]    = Parameters0;
-      verbMap["parameters1"]    = Parameters1;
-      verbMap["statistics0"]    = Statistics0;
-      verbMap["statistics1"]    = Statistics1;
-      verbMap["timings0"]       = Timings0;
-      verbMap["timings1"]       = Timings1;
-      verbMap["timingsByLevel"] = TimingsByLevel;
-      verbMap["external"]       = External;
-      verbMap["debug"]          = Debug;
-      verbMap["test"]           = Test;
-      //for users and developers
-      verbMap["none"]           = None;
-      verbMap["low"]            = Low;
-      verbMap["medium"]         = Medium;
-      verbMap["high"]           = High;
-      verbMap["extreme"]        = Extreme;
       if (hieraList.isParameter("verbosity")) {
         std::string vl = hieraList.get<std::string>("verbosity");
-        vl = lowerCase(vl);
         hieraList.remove("verbosity");
-        //TODO Move this to its own class or MueLu::Utils?
-        if (verbMap.find(vl) != verbMap.end())
-          this->verbosity_ = verbMap[vl];
-        else
-          TEUCHOS_TEST_FOR_EXCEPTION(true, Exceptions::RuntimeError, "MueLu::ParameterListInterpreter():: invalid verbosity level");
+        this->verbosity_ = toVerbLevel(vl);
       }
 
       if (hieraList.isParameter("dependencyOutputLevel"))

--- a/packages/muelu/src/MueCentral/MueLu_HierarchyUtils_def.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_HierarchyUtils_def.hpp
@@ -192,6 +192,7 @@ namespace MueLu {
           TEUCHOS_TEST_FOR_EXCEPTION(name != "P" && name != "R"  && name != "K"  && name != "M" && name != "Mdiag" &&
                                      name != "Nullspace" && name != "Coordinates" && name != "pcoarsen: element to node map" && 
                                      name != "Node Comm" && name != "DualNodeID2PrimalNodeID" &&
+                                     name != "output stream" &&
                                      !IsParamValidVariable(name), Exceptions::InvalidArgument,
                                      std::string("MueLu::Utils::AddNonSerializableDataToHierarchy: user data parameter list contains unknown data type (") + name + ")");
           if( name == "P" || name == "R" || name == "K" || name == "M") {
@@ -226,6 +227,10 @@ namespace MueLu {
             level->Set(name, Teuchos::getValue<RCP<Kokkos::DynRankView<LocalOrdinal,typename Node::device_type> > >(it2->second), NoFactory::get());
           }
 #endif
+          else if (name == "output stream")
+          {
+            H.SetMueLuOStream(Teuchos::getValue<RCP<Teuchos::FancyOStream> >(it2->second));
+          }
           else {
             //Custom variable
             size_t typeNameStart = name.find_first_not_of(' ');

--- a/packages/muelu/src/MueCentral/MueLu_MasterList.cpp
+++ b/packages/muelu/src/MueCentral/MueLu_MasterList.cpp
@@ -119,6 +119,7 @@ namespace MueLu {
     // put in auto-generated code here
 
 
+    if (name == "output filename") { ss << "<Parameter name=\"output filename\" type=\"string\" value=" << value << "/>"; return ss.str(); }      
     if (name == "number of equations") { ss << "<Parameter name=\"number of equations\" type=\"int\" value=" << value << "/>"; return ss.str(); }      
     if (name == "max levels") { ss << "<Parameter name=\"max levels\" type=\"int\" value=" << value << "/>"; return ss.str(); }      
     if (name == "coarse grid correction scaling factor") { ss << "<Parameter name=\"coarse grid correction scaling factor\" type=\"double\" value=" << value << "/>"; return ss.str(); }      
@@ -161,6 +162,7 @@ namespace MueLu {
 "<ParameterList name=\"MueLu\">"
   "<Parameter name=\"problem: type\" type=\"string\" value=\"unknown\"/>"
   "<Parameter name=\"verbosity\" type=\"string\" value=\"high\"/>"
+  "<Parameter name=\"output filename\" type=\"string\" value=\"\"/>"
   "<Parameter name=\"number of equations\" type=\"int\" value=\"1\"/>"
   "<Parameter name=\"max levels\" type=\"int\" value=\"10\"/>"
   "<Parameter name=\"cycle type\" type=\"string\" value=\"V\"/>"
@@ -506,6 +508,8 @@ namespace MueLu {
          ("default values","problem: type")
       
          ("ML output","verbosity")
+      
+         ("output filename","output filename")
       
          ("PDE equations","number of equations")
       

--- a/packages/muelu/src/MueCentral/MueLu_VerboseObject.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_VerboseObject.hpp
@@ -115,6 +115,8 @@ namespace MueLu {
 
     static void SetMueLuOStream(const Teuchos::RCP<Teuchos::FancyOStream> &mueluOStream);
 
+    static void SetMueLuOFileStream(const std::string& filename);
+
     static Teuchos::RCP<Teuchos::FancyOStream> GetMueLuOStream();
 
     //! @name Public static member functions
@@ -135,6 +137,7 @@ namespace MueLu {
       int procRank_;
     int numProcs_;
 
+    static Teuchos::RCP<Teuchos::FancyOStream> mueluOutputStream_;
     static Teuchos::RCP<Teuchos::FancyOStream> blackHole_;
 
     //! Global verbose level. This verbose level is used when the verbose level of the object is not specified (verbLevel_ == NotSpecified)

--- a/packages/muelu/src/MueCentral/MueLu_VerbosityLevel.cpp
+++ b/packages/muelu/src/MueCentral/MueLu_VerbosityLevel.cpp
@@ -45,6 +45,9 @@
 // @HEADER
 #include "MueLu_VerbosityLevel.hpp"
 #include "MueLu_Exceptions.hpp"
+#include "MueLu_Utilities.hpp"
+#include <string>
+#include <locale>
 
 namespace MueLu {
 
@@ -66,6 +69,65 @@ namespace MueLu {
         default:
           TEUCHOS_TEST_FOR_EXCEPTION(true, Exceptions::RuntimeError, "Unknown enum value found.");
         }
+  }
+
+  std::string
+  lowerCase (const std::string& s)
+  {
+    typedef std::string::value_type char_t;
+    typedef std::ctype<char_t> facet_type;
+    const facet_type& facet = std::use_facet<facet_type> (std::locale ());
+
+    const std::string::size_type len = s.size ();
+    std::string s_lc (s);
+    for (std::string::size_type k = 0; k < len; ++k) {
+      s_lc[k] = facet.tolower (s[k]);
+    }
+
+    return s_lc;
+  }
+
+  MsgType toVerbLevel(const std::string& verbLevelStr) {
+    std::map<std::string, MsgType> verbMap;
+    //for developers
+    verbMap["errors"]         = Errors;
+    verbMap["warnings0"]      = Warnings0;
+    verbMap["warnings00"]     = Warnings00;
+    verbMap["warnings1"]      = Warnings1;
+    verbMap["perfWarnings"]   = PerfWarnings;
+    verbMap["runtime0"]       = Runtime0;
+    verbMap["runtime1"]       = Runtime1;
+    verbMap["runtimeTimings"] = RuntimeTimings;
+    verbMap["noTimeReport"]   = NoTimeReport;
+    verbMap["parameters0"]    = Parameters0;
+    verbMap["parameters1"]    = Parameters1;
+    verbMap["statistics0"]    = Statistics0;
+    verbMap["statistics1"]    = Statistics1;
+    verbMap["timings0"]       = Timings0;
+    verbMap["timings1"]       = Timings1;
+    verbMap["timingsByLevel"] = TimingsByLevel;
+    verbMap["external"]       = External;
+    verbMap["debug"]          = Debug;
+    verbMap["test"]           = Test;
+
+    verbMap["warnings"]       = Warnings;
+    verbMap["runtime"]        = Runtime;
+    verbMap["parameters"]     = Parameters;
+    verbMap["statistics"]     = Statistics;
+    verbMap["timings"]        = Timings;
+    verbMap["test"]           = Test;
+    //for users and developers
+    verbMap["none"]           = None;
+    verbMap["low"]            = Low;
+    verbMap["medium"]         = Medium;
+    verbMap["high"]           = High;
+    verbMap["extreme"]        = Extreme;
+
+    std::string lcVerb = lowerCase(verbLevelStr);
+    if (verbMap.find(lcVerb) != verbMap.end())
+      return verbMap[lcVerb];
+    else
+      TEUCHOS_TEST_FOR_EXCEPTION(true, Exceptions::RuntimeError, "MueLu::ParameterListInterpreter():: invalid verbosity level: " << verbLevelStr);
   }
 
 } // namespace MueLu

--- a/packages/muelu/src/MueCentral/MueLu_VerbosityLevel.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_VerbosityLevel.hpp
@@ -109,6 +109,8 @@ namespace MueLu {
 
   //!
   VerbLevel toMueLuVerbLevel(const Teuchos::EVerbosityLevel verbLevel);
+  //!
+  MsgType toVerbLevel(const std::string& verbLevelStr);
 
 } // namespace MueLu
 

--- a/packages/muelu/src/Utils/MueLu_Utilities.cpp
+++ b/packages/muelu/src/Utils/MueLu_Utilities.cpp
@@ -318,21 +318,5 @@ bool IsParamValidVariable(const std::string& name)
 #endif
     }
 
-  std::string
-  lowerCase (const std::string& s)
-  {
-    typedef std::string::value_type char_t;
-    typedef std::ctype<char_t> facet_type;
-    const facet_type& facet = std::use_facet<facet_type> (std::locale ());
-
-    const std::string::size_type len = s.size ();
-    std::string s_lc (s);
-    for (std::string::size_type k = 0; k < len; ++k) {
-      s_lc[k] = facet.tolower (s[k]);
-    }
-
-    return s_lc;
-  }
-
 
 } // namespace MueLu

--- a/packages/muelu/src/Utils/MueLu_Utilities.cpp
+++ b/packages/muelu/src/Utils/MueLu_Utilities.cpp
@@ -91,6 +91,7 @@ namespace MueLu {
 #ifdef HAVE_MUELU_INTREPID2 // For the IntrepidPCoarsenFactory
               || name == "pcoarsen: element to node map"
 #endif
+              || name == "output stream"
               )
           {
             nonSerialList.sublist(levelName).setEntry(name, it2->second);


### PR DESCRIPTION
@trilinos/muelu 

## Motivation
Refactor handling of 'verbosity' parameter. Allow use of developer options from easy interface. Fix verbosity bug in RefMaxwell.

Closes #2149

@rstumin 