### PR TITLE
Panzer: runtime disable of evaluation types

### DIFF
--- a/packages/panzer/disc-fe/src/Panzer_FieldManagerBuilder.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_FieldManagerBuilder.cpp
@@ -77,6 +77,37 @@ void panzer::FieldManagerBuilder::print(std::ostream& os) const
 }
 
 //=======================================================================
+panzer::FieldManagerBuilder::
+FieldManagerBuilder(bool disablePhysicsBlockScatter,
+                    bool disablePhysicsBlockGather)
+  : disablePhysicsBlockScatter_(disablePhysicsBlockScatter)
+  , disablePhysicsBlockGather_(disablePhysicsBlockGather)
+  , active_evaluation_types_(Sacado::mpl::size<panzer::Traits::EvalTypes>::value, true)
+{}
+
+//=======================================================================
+namespace {
+  struct PostRegistrationFunctor {
+
+    const std::vector<bool>& active_;
+    PHX::FieldManager<panzer::Traits>& fm_;
+    panzer::Traits::SD& setup_data_;
+
+    PostRegistrationFunctor(const std::vector<bool>& active,
+                            PHX::FieldManager<panzer::Traits>& fm,
+                            panzer::Traits::SD& setup_data)
+      : active_(active),fm_(fm),setup_data_(setup_data) {}
+
+    template<typename T>
+    void operator()(T) const {
+      auto index = Sacado::mpl::find<panzer::Traits::EvalTypes,T>::value;
+      if (active_[index])
+        fm_.postRegistrationSetupForType<T>(setup_data_);
+    }
+  };
+}
+
+//=======================================================================
 void panzer::FieldManagerBuilder::setupVolumeFieldManagers(
                                             const std::vector<Teuchos::RCP<panzer::PhysicsBlock> >& physicsBlocks,
                                             const std::vector<WorksetDescriptor> & wkstDesc,
@@ -117,7 +148,8 @@ void panzer::FieldManagerBuilder::setupVolumeFieldManagers(
     Teuchos::RCP<PHX::FieldManager<panzer::Traits> > fm
           = Teuchos::rcp(new PHX::FieldManager<panzer::Traits>);
 
-    // use the physics block to register evaluators
+    // use the physics block to register active evaluators
+    pb->setActiveEvaluationTypes(active_evaluation_types_);
     pb->buildAndRegisterEquationSetEvaluators(*fm, user_data);
     if(!physicsBlockGatherDisabled())
       pb->buildAndRegisterGatherAndOrientationEvaluators(*fm,lo_factory,user_data);
@@ -130,14 +162,17 @@ void panzer::FieldManagerBuilder::setupVolumeFieldManagers(
     else
       pb->buildAndRegisterClosureModelEvaluators(*fm,cm_factory,closure_models,user_data);
 
+    // Reset active evaluation types
+    pb->activateAllEvaluationTypes();
+
     // register additional model evaluator from the generic evaluator factory
     gEvalFact.registerEvaluators(*fm,wd,*pb);
 
     // setup derivative information
     setKokkosExtendedDataTypeDimensions(wd.getElementBlock(),*globalIndexer,user_data,*fm);
 
-    // build the setup data using passed in information
-    fm->postRegistrationSetup(setupData);
+    // call postRegistrationSetup() for each active type
+    Sacado::mpl::for_each_no_kokkos<panzer::Traits::EvalTypes>(PostRegistrationFunctor(active_evaluation_types_,*fm,setupData));
 
     // make sure to add the field manager & workset to the list
     volume_workset_desc_.push_back(wd);
@@ -240,15 +275,18 @@ setupBCFieldManagers(const std::vector<panzer::BC> & bcs,
             bcstm = bc_factory.buildBCStrategy(*bc, side_pb->globalData());
 
           // Iterate over evaluation types
+          int i=0;
           for (panzer::BCStrategy_TemplateManager<panzer::Traits>::iterator
-                 bcs_type = bcstm->begin(); bcs_type != bcstm->end(); ++bcs_type) {
-            bcs_type->setDetailsIndex(block_id_index);
-            side_pb->setDetailsIndex(block_id_index);
-            bcs_type->setup(*side_pb, user_data);
-            bcs_type->buildAndRegisterEvaluators(fm, *side_pb, cm_factory, closure_models, user_data);
-            bcs_type->buildAndRegisterGatherAndOrientationEvaluators(fm, *side_pb, lo_factory, user_data);
-            if ( ! physicsBlockScatterDisabled())
-              bcs_type->buildAndRegisterScatterEvaluators(fm, *side_pb, lo_factory, user_data);
+                 bcs_type = bcstm->begin(); bcs_type != bcstm->end(); ++bcs_type,++i) {
+            if (active_evaluation_types_[i]) {
+              bcs_type->setDetailsIndex(block_id_index);
+              side_pb->setDetailsIndex(block_id_index);
+              bcs_type->setup(*side_pb, user_data);
+              bcs_type->buildAndRegisterEvaluators(fm, *side_pb, cm_factory, closure_models, user_data);
+              bcs_type->buildAndRegisterGatherAndOrientationEvaluators(fm, *side_pb, lo_factory, user_data);
+              if ( ! physicsBlockScatterDisabled())
+                bcs_type->buildAndRegisterScatterEvaluators(fm, *side_pb, lo_factory, user_data);
+            }
           }
 
           gid_count += globalIndexer->getElementBlockGIDCount(element_block_id);
@@ -276,7 +314,8 @@ setupBCFieldManagers(const std::vector<panzer::BC> & bcs,
         setupData.worksets_ = worksets;
         setupData.orientations_ = getWorksetContainer()->getOrientations();
 
-        fm.postRegistrationSetup(setupData);
+        Sacado::mpl::for_each_no_kokkos<panzer::Traits::EvalTypes>(PostRegistrationFunctor(active_evaluation_types_,fm,setupData));
+
       }
     } else {
       const std::string element_block_id = bc->elementBlockID();
@@ -312,13 +351,16 @@ setupBCFieldManagers(const std::vector<panzer::BC> & bcs,
 	  bc_factory.buildBCStrategy(*bc,side_pb->globalData());
 
 	// Iterate over evaluation types
+        int i=0;
 	for (panzer::BCStrategy_TemplateManager<panzer::Traits>::iterator
-	       bcs_type = bcstm->begin(); bcs_type != bcstm->end(); ++bcs_type) {
-	  bcs_type->setup(*side_pb,user_data);
-	  bcs_type->buildAndRegisterEvaluators(fm,*side_pb,cm_factory,closure_models,user_data);
-	  bcs_type->buildAndRegisterGatherAndOrientationEvaluators(fm,*side_pb,lo_factory,user_data);
-	  if(!physicsBlockScatterDisabled())
-	    bcs_type->buildAndRegisterScatterEvaluators(fm,*side_pb,lo_factory,user_data);
+	       bcs_type = bcstm->begin(); bcs_type != bcstm->end(); ++bcs_type,++i) {
+          if (active_evaluation_types_[i]) {
+            bcs_type->setup(*side_pb,user_data);
+            bcs_type->buildAndRegisterEvaluators(fm,*side_pb,cm_factory,closure_models,user_data);
+            bcs_type->buildAndRegisterGatherAndOrientationEvaluators(fm,*side_pb,lo_factory,user_data);
+            if(!physicsBlockScatterDisabled())
+              bcs_type->buildAndRegisterScatterEvaluators(fm,*side_pb,lo_factory,user_data);
+          }
 	}
 
 	// Setup the fieldmanager
@@ -332,7 +374,7 @@ setupBCFieldManagers(const std::vector<panzer::BC> & bcs,
 	// setup derivative information
 	setKokkosExtendedDataTypeDimensions(element_block_id,*globalIndexer,user_data,fm);
 
-        fm.postRegistrationSetup(setupData);
+        Sacado::mpl::for_each_no_kokkos<panzer::Traits::EvalTypes>(PostRegistrationFunctor(active_evaluation_types_,fm,setupData));
       }
     }
   }
@@ -489,6 +531,10 @@ setKokkosExtendedDataTypeDimensions(const std::string & eblock,
     fm.setKokkosExtendedDataTypeDimensions<panzer::Traits::Tangent>(derivative_dimensions);
   }
 }
+
+void panzer::FieldManagerBuilder::setActiveEvaluationTypes(const std::vector<bool>& aet)
+{active_evaluation_types_ = aet;}
+
 //=======================================================================
 //=======================================================================
 void panzer::FieldManagerBuilder::clearVolumeFieldManagers(bool clearVolumeWorksets)

--- a/packages/panzer/disc-fe/src/Panzer_FieldManagerBuilder.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_FieldManagerBuilder.hpp
@@ -63,7 +63,7 @@ namespace panzer {
 
 namespace PHX {
   template<typename T> class FieldManager;
-}  
+}
 
 namespace panzer {
 
@@ -74,7 +74,7 @@ namespace panzer {
 
   class EmptyEvaluatorFactory : public GenericEvaluatorFactory {
   public:
-    bool registerEvaluators(PHX::FieldManager<panzer::Traits> & /* fm */, const WorksetDescriptor & /* wd */, const PhysicsBlock & /* pb */) const 
+    bool registerEvaluators(PHX::FieldManager<panzer::Traits> & /* fm */, const WorksetDescriptor & /* wd */, const PhysicsBlock & /* pb */) const
     { return false; }
   };
 
@@ -84,9 +84,7 @@ namespace panzer {
 
     typedef std::map<unsigned,panzer::Workset> BCFaceWorksetMap;
 
-    FieldManagerBuilder(bool disablePhysicsBlockScatter=false,bool disablePhysicsBlockGather=false)
-      : disablePhysicsBlockScatter_(disablePhysicsBlockScatter) 
-      , disablePhysicsBlockGather_(disablePhysicsBlockGather) {}
+    FieldManagerBuilder(bool disablePhysicsBlockScatter=false,bool disablePhysicsBlockGather=false);
 
     void print(std::ostream& os) const;
 
@@ -102,30 +100,29 @@ namespace panzer {
     Teuchos::RCP<WorksetContainer> getWorksetContainer() const
     { return worksetContainer_; }
 
-    const 
-      std::vector< Teuchos::RCP< PHX::FieldManager<panzer::Traits> > >&
-      getVolumeFieldManagers() const {return phx_volume_field_managers_;}
+    const std::vector< Teuchos::RCP< PHX::FieldManager<panzer::Traits> > >&
+    getVolumeFieldManagers() const {return phx_volume_field_managers_;}
 
     //! Look up field manager by an element block ID
     Teuchos::RCP< PHX::FieldManager<panzer::Traits> >
-    getVolumeFieldManager(const WorksetDescriptor & wd) const 
+    getVolumeFieldManager(const WorksetDescriptor & wd) const
     {
-       const std::vector<WorksetDescriptor> & wkstDesc = getVolumeWorksetDescriptors();
-       std::vector<WorksetDescriptor>::const_iterator itr = std::find(wkstDesc.begin(),wkstDesc.end(),wd);
-       TEUCHOS_ASSERT(itr!=wkstDesc.end());
+      const std::vector<WorksetDescriptor> & wkstDesc = getVolumeWorksetDescriptors();
+      std::vector<WorksetDescriptor>::const_iterator itr = std::find(wkstDesc.begin(),wkstDesc.end(),wd);
+      TEUCHOS_ASSERT(itr!=wkstDesc.end());
 
-       // get volume field manager associated with the block ID
-       int index = itr - wkstDesc.begin();
-       return getVolumeFieldManagers()[index];
+      // get volume field manager associated with the block ID
+      int index = itr - wkstDesc.begin();
+      return getVolumeFieldManagers()[index];
     }
 
     const std::vector<WorksetDescriptor> &
-      getVolumeWorksetDescriptors() const { return volume_workset_desc_; }
+    getVolumeWorksetDescriptors() const { return volume_workset_desc_; }
 
-    const std::map<panzer::BC, 
+    const std::map<panzer::BC,
 		   std::map<unsigned,PHX::FieldManager<panzer::Traits> >,
-		   panzer::LessBC>& 
-      getBCFieldManagers() const {return bc_field_managers_;}
+		   panzer::LessBC>&
+    getBCFieldManagers() const {return bc_field_managers_;}
 
     // The intention of the next set of functions is to simplify and eventually
     // replace the setup routine above. Its not clear that these functions
@@ -182,8 +179,11 @@ namespace panzer {
 
     void writeBCTextDependencyFiles(std::string filename_prefix) const;
 
-    //! Delete all volume field managers, retaining the BC ones.
+    /// Delete all volume field managers, retaining the BC ones.
     void clearVolumeFieldManagers(bool clearVolumeWorksets = true);
+
+    /// Set a vector of active evaluation types to allocate.
+    void setActiveEvaluationTypes(const std::vector<bool>& aet);
 
   private:
     /** Build the BC field managers. This is the real deal, it correclty handles not having an equation set factory.
@@ -197,7 +197,7 @@ namespace panzer {
                               const LinearObjFactory<panzer::Traits> & lo_factory,
 			      const Teuchos::ParameterList& user_data);
 
-    void setKokkosExtendedDataTypeDimensions(const std::string & eblock, 
+    void setKokkosExtendedDataTypeDimensions(const std::string & eblock,
                                              const panzer::GlobalIndexer & globalIndexer,
                                              const Teuchos::ParameterList& user_data,
                                              PHX::FieldManager<panzer::Traits> & fm) const;
@@ -210,14 +210,14 @@ namespace panzer {
       *        the appropriate set of worksets for each field manager.
       */
     std::vector<WorksetDescriptor> volume_workset_desc_;
-    
+
     /*! \brief Field managers for the boundary conditions
 
         key is a panzer::BC object.  value is a map of
         field managers where the key is the local side index used by
         intrepid
     */
-    std::map<panzer::BC, 
+    std::map<panzer::BC,
       std::map<unsigned,PHX::FieldManager<panzer::Traits> >,
       panzer::LessBC> bc_field_managers_;
 
@@ -232,6 +232,9 @@ namespace panzer {
       * newly created field managers.
       */
     bool disablePhysicsBlockGather_;
+
+    /// Entries correspond to evaluation type mpl vector in traits. A value of true means the evaluation type is active.
+    std::vector<bool> active_evaluation_types_;
   };
 
 std::ostream& operator<<(std::ostream& os, const panzer::FieldManagerBuilder & rfd);

--- a/packages/panzer/disc-fe/src/Panzer_ModelEvaluator.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_ModelEvaluator.hpp
@@ -139,9 +139,17 @@ public:
 
   //@}
 
+  /** Disable an evaluation type from AssemblyEngine_TemplateManager,
+      FieldManagerBuilder and PhysicsBlock objects. This will prevent
+      the allocation of unused resources.
+  */
   template<typename EvalT>
   void disableEvaluationType()
-  {ae_tm_.template disableType<EvalT>();}
+  {
+    ae_tm_.template disableType<EvalT>();
+    auto idx = Sacado::mpl::find<panzer::Traits::EvalTypes,EvalT>::value;
+    active_evaluation_types_[idx] = false;
+  }
 
   /** If set to false, disables building volume field managers to save
       memory if not needed. Must be called BEFORE setupModel() is
@@ -700,6 +708,7 @@ private: // data members
 
   bool build_volume_field_managers_;
   bool build_bc_field_managers_;
+  std::vector<bool> active_evaluation_types_;
 };
 
 // Inline definition of the add response (its template on the builder type)

--- a/packages/panzer/disc-fe/src/Panzer_ModelEvaluator_impl.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_ModelEvaluator_impl.hpp
@@ -103,6 +103,7 @@ ModelEvaluator(const Teuchos::RCP<panzer::FieldManagerBuilder>& fmb,
   , oneTimeDirichletBeta_(0.0)
   , build_volume_field_managers_(true)
   , build_bc_field_managers_(true)
+  , active_evaluation_types_(Sacado::mpl::size<panzer::Traits::EvalTypes>::value, true)
 {
   using Teuchos::RCP;
   using Teuchos::rcp;
@@ -157,6 +158,7 @@ ModelEvaluator(const Teuchos::RCP<const panzer::LinearObjFactory<panzer::Traits>
   , oneTimeDirichletBeta_(0.0)
   , build_volume_field_managers_(true)
   , build_bc_field_managers_(true)
+  , active_evaluation_types_(Sacado::mpl::size<panzer::Traits::EvalTypes>::value, true)
 {
   using Teuchos::RCP;
   using Teuchos::rcp_dynamic_cast;
@@ -422,6 +424,7 @@ setupModel(const Teuchos::RCP<panzer::WorksetContainer> & wc,
     {
       PANZER_FUNC_TIME_MONITOR_DIFF("allocate FieldManagerBuilder",allocFMB);
       fmb = Teuchos::rcp(new panzer::FieldManagerBuilder);
+      fmb->setActiveEvaluationTypes(active_evaluation_types_);
     }
     {
       PANZER_FUNC_TIME_MONITOR_DIFF("fmb->setWorksetContainer()",setupWorksets);

--- a/packages/panzer/disc-fe/src/Panzer_PhysicsBlock.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_PhysicsBlock.cpp
@@ -70,7 +70,7 @@ void panzer::buildPhysicsBlocks(const std::map<std::string,std::string>& block_i
   using Teuchos::rcp;
   using std::map;
   using std::string;
-  
+
   TEUCHOS_ASSERT(nonnull(physics_blocks_plist));
 
   // Create a physics block for each element block
@@ -78,30 +78,30 @@ void panzer::buildPhysicsBlocks(const std::map<std::string,std::string>& block_i
   for (itr = block_ids_to_physics_ids.begin(); itr!=block_ids_to_physics_ids.end();++itr) {
     string element_block_id = itr->first;
     string physics_block_id = itr->second;
-    
+
     map<string,RCP<const shards::CellTopology> >::const_iterator ct_itr =
       block_ids_to_cell_topo.find(element_block_id);
     TEUCHOS_TEST_FOR_EXCEPTION(ct_itr==block_ids_to_cell_topo.end(),
                             std::runtime_error,
                             "Falied to find CellTopology for element block id: \""
                             << element_block_id << "\"!");
-    RCP<const shards::CellTopology> cellTopo = ct_itr->second; 
-    
+    RCP<const shards::CellTopology> cellTopo = ct_itr->second;
+
     const panzer::CellData volume_cell_data(workset_size,cellTopo);
-    
+
     // find physics block parameter sublist
     TEUCHOS_TEST_FOR_EXCEPTION(!physics_blocks_plist->isSublist(physics_block_id),
                             std::runtime_error,
                             "Failed to find physics id: \""
-                            << physics_block_id 
-                            << "\" requested by element block: \"" 
+                            << physics_block_id
+                            << "\" requested by element block: \""
                             << element_block_id << "\"!");
-    
-    RCP<panzer::PhysicsBlock> pb = rcp(new panzer::PhysicsBlock(Teuchos::sublist(physics_blocks_plist,physics_block_id,true), 
+
+    RCP<panzer::PhysicsBlock> pb = rcp(new panzer::PhysicsBlock(Teuchos::sublist(physics_blocks_plist,physics_block_id,true),
                                                         element_block_id,
                                                         default_integration_order,
-                                                        volume_cell_data, 
-                                                        eqset_factory, 
+                                                        volume_cell_data,
+                                                        eqset_factory,
                                                         global_data,
                                                         build_transient_support,
                                                         tangent_param_names
@@ -118,7 +118,7 @@ void panzer::readPhysicsBlocks(const std::map<std::string,std::string>& block_id
   using Teuchos::rcp;
   using std::map;
   using std::string;
-  
+
   TEUCHOS_ASSERT(nonnull(physics_blocks_plist));
 
   // Create a physics block for each element block
@@ -126,16 +126,16 @@ void panzer::readPhysicsBlocks(const std::map<std::string,std::string>& block_id
   for (itr = block_ids_to_physics_ids.begin(); itr!=block_ids_to_physics_ids.end();++itr) {
     string element_block_id = itr->first;
     string physics_block_id = itr->second;
-    
+
     // find physics block parameter sublist
     TEUCHOS_TEST_FOR_EXCEPTION(!physics_blocks_plist->isSublist(physics_block_id),
                             std::runtime_error,
                             "Failed to find physics id: \""
-                            << physics_block_id 
-                            << "\" requested by element block: \"" 
+                            << physics_block_id
+                            << "\" requested by element block: \""
                             << element_block_id << "\"!");
-    
-    RCP<panzer::PhysicsBlock> pb = rcp(new panzer::PhysicsBlock(Teuchos::sublist(physics_blocks_plist,physics_block_id,true), 
+
+    RCP<panzer::PhysicsBlock> pb = rcp(new panzer::PhysicsBlock(Teuchos::sublist(physics_blocks_plist,physics_block_id,true),
                                                         element_block_id));
     physicsBlocks.push_back(pb);
   }
@@ -147,20 +147,20 @@ Teuchos::RCP<panzer::PhysicsBlock> panzer::findPhysicsBlock(const std::string el
                                                      bool throw_on_failure)
 {
   std::vector<Teuchos::RCP<panzer::PhysicsBlock> >::const_iterator pb = physics_blocks.begin();
-  
+
   while (pb != physics_blocks.end()) {
     if ((*pb)->elementBlockID() == element_block_id)
       return *pb;
-    
+
     ++pb;
   }
 
   TEUCHOS_TEST_FOR_EXCEPTION(throw_on_failure,std::runtime_error,"Error: panzer::findPhysicsBlock(): The requested physics block for element block\"" << element_block_id << "\" was not found in the vecotr of physics blocks!");
-  
+
   Teuchos::RCP<panzer::PhysicsBlock> null_pb;
   return null_pb;
 }
-  
+
 // *******************************************************************
 panzer::PhysicsBlock::
 PhysicsBlock(const Teuchos::RCP<Teuchos::ParameterList>& physics_block_plist,
@@ -177,7 +177,8 @@ PhysicsBlock(const Teuchos::RCP<Teuchos::ParameterList>& physics_block_plist,
   m_input_parameters(physics_block_plist),
   m_build_transient_support(build_transient_support),
   m_global_data(global_data),
-  m_eqset_factory(factory)
+  m_eqset_factory(factory),
+  m_active_evaluation_types(Sacado::mpl::size<panzer::Traits::EvalTypes>::value,true)
 {
   TEUCHOS_ASSERT(nonnull(physics_block_plist));
   TEUCHOS_ASSERT(nonnull(factory));
@@ -200,7 +201,8 @@ PhysicsBlock(const Teuchos::RCP<Teuchos::ParameterList>& physics_block_plist,
   m_element_block_id(element_block_id),
   m_default_integration_order(1),
   m_input_parameters(physics_block_plist),
-  m_build_transient_support(false)
+  m_build_transient_support(false),
+  m_active_evaluation_types(Sacado::mpl::size<panzer::Traits::EvalTypes>::value,true)
 {
 }
 
@@ -215,11 +217,12 @@ PhysicsBlock(const std::string & element_block_id,
   m_physics_id(physics_block_id),
   m_element_block_id(element_block_id),
   m_default_integration_order(integration_order),
-  m_cell_data(cell_data), 
+  m_cell_data(cell_data),
   m_input_parameters(Teuchos::null),
   m_build_transient_support(false),
   m_global_data(global_data),
-  m_eqset_factory(Teuchos::null)
+  m_eqset_factory(Teuchos::null),
+  m_active_evaluation_types(Sacado::mpl::size<panzer::Traits::EvalTypes>::value,true)
 {
   using Teuchos::RCP;
   using Teuchos::ParameterList;
@@ -249,7 +252,7 @@ PhysicsBlock(const std::string & element_block_id,
   // build up field library
   m_field_lib = Teuchos::rcp(new FieldLibrary);
   for(std::vector<StrPureBasisPair>::const_iterator itr=m_provided_dofs.begin();
-      itr!=m_provided_dofs.end();++itr) 
+      itr!=m_provided_dofs.end();++itr)
      m_field_lib->addFieldAndBasis(itr->first,itr->second);
 }
 
@@ -264,7 +267,8 @@ PhysicsBlock(const panzer::PhysicsBlock& pb,
   m_input_parameters(pb.m_input_parameters),
   m_build_transient_support(pb.m_build_transient_support),
   m_global_data(pb.m_global_data),
-  m_eqset_factory(pb.m_eqset_factory)
+  m_eqset_factory(pb.m_eqset_factory),
+  m_active_evaluation_types(Sacado::mpl::size<panzer::Traits::EvalTypes>::value,true)
 {
   initialize(m_input_parameters,
             m_default_integration_order,
@@ -305,9 +309,9 @@ void panzer::PhysicsBlock::initialize(const Teuchos::RCP<Teuchos::ParameterList>
 {
   using Teuchos::RCP;
   using Teuchos::ParameterList;
-  
+
   TEUCHOS_TEST_FOR_EXCEPTION(input_parameters->numParams() < 1, std::runtime_error,
-                          "The physics block \"" << input_parameters->name() 
+                          "The physics block \"" << input_parameters->name()
                           << "\" required by element block \"" << element_block_id
                           << "\" does not have any equation sets associated with it."
                           << " Please add at least one equation set to this physics block!");
@@ -319,7 +323,7 @@ void panzer::PhysicsBlock::initialize(const Teuchos::RCP<Teuchos::ParameterList>
   for (pl_iter eq = input_parameters->begin(); eq != input_parameters->end(); ++eq) {
 
     TEUCHOS_TEST_FOR_EXCEPTION( !(eq->second.isList()), std::logic_error,
-                            "All entries in the physics block \"" << m_physics_id 
+                            "All entries in the physics block \"" << m_physics_id
                             << "\" must be an equation set sublist!" );
 
     RCP<ParameterList> eq_set_pl = Teuchos::sublist(input_parameters,eq->first,true);
@@ -338,7 +342,7 @@ void panzer::PhysicsBlock::initialize(const Teuchos::RCP<Teuchos::ParameterList>
     // Interrogate DOFs
     const std::vector<StrPureBasisPair> & sbNames = eq_set->begin()->getProvidedDOFs();
     for(std::size_t j=0;j<sbNames.size();j++) {
-     
+
       // Generate list of dof names
       m_dof_names.push_back(sbNames[j].first);
 
@@ -370,13 +374,13 @@ void panzer::PhysicsBlock::initialize(const Teuchos::RCP<Teuchos::ParameterList>
     for(std::map<int,Teuchos::RCP<panzer::IntegrationRule> >::const_iterator ir = ir_map.begin();
        ir != ir_map.end(); ++ir)
       m_integration_rules[ir->second->order()] = ir->second;
-      
+
   }
 
   // build up field library
   m_field_lib = Teuchos::rcp(new FieldLibrary);
   for(std::vector<StrPureBasisPair>::const_iterator itr=m_provided_dofs.begin();
-      itr!=m_provided_dofs.end();++itr) 
+      itr!=m_provided_dofs.end();++itr)
      m_field_lib->addFieldAndBasis(itr->first,itr->second);
 
   // setup element blocks: loop over each evaluation type
@@ -387,7 +391,21 @@ void panzer::PhysicsBlock::initialize(const Teuchos::RCP<Teuchos::ParameterList>
         itr->setElementBlockId(element_block_id);
      }
   }
- 
+
+}
+
+// *******************************************************************
+void panzer::PhysicsBlock::setActiveEvaluationTypes(const std::vector<bool>& aet)
+{
+  TEUCHOS_ASSERT(aet.size() == std::size_t(Sacado::mpl::size<panzer::Traits::EvalTypes>::value));
+  m_active_evaluation_types = aet;
+}
+
+// *******************************************************************
+void panzer::PhysicsBlock::activateAllEvaluationTypes()
+{
+  for (auto&& t : m_active_evaluation_types)
+    t = true;
 }
 
 // *******************************************************************
@@ -400,7 +418,7 @@ buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
   using namespace Teuchos;
 
   // Loop over equation set template managers
-  vector< RCP<EquationSet_TemplateManager<panzer::Traits> > >::const_iterator 
+  vector< RCP<EquationSet_TemplateManager<panzer::Traits> > >::const_iterator
     eq_set = m_equation_sets.begin();
   for (;eq_set != m_equation_sets.end(); ++eq_set) {
 
@@ -408,15 +426,17 @@ buildAndRegisterEquationSetEvaluators(PHX::FieldManager<panzer::Traits>& fm,
     EquationSet_TemplateManager<panzer::Traits> eqstm = *(*eq_set);
     EquationSet_TemplateManager<panzer::Traits>::iterator eval_type =
       eqstm.begin();
-    for (; eval_type != eqstm.end(); ++eval_type) {
-
-      // Do not loop over integration rules.  Only call this for the
-      // ir that the residual is integrated over.  Otherwise the
-      // residual gets contributions from multiple integrations of the
-      // same cell!  This ir is only known by equaiton set.
-      const int di = eval_type->setDetailsIndex(this->getDetailsIndex());
-      eval_type->buildAndRegisterEquationSetEvaluators(fm, *m_field_lib, user_data);
-      eval_type->setDetailsIndex(di);
+    int idx = 0;
+    for (; eval_type != eqstm.end(); ++eval_type,++idx) {
+      if (m_active_evaluation_types[idx]) {
+        // Do not loop over integration rules.  Only call this for the
+        // ir that the residual is integrated over.  Otherwise the
+        // residual gets contributions from multiple integrations of the
+        // same cell!  This ir is only known by equaiton set.
+        const int di = eval_type->setDetailsIndex(this->getDetailsIndex());
+        eval_type->buildAndRegisterEquationSetEvaluators(fm, *m_field_lib, user_data);
+        eval_type->setDetailsIndex(di);
+      }
     }
   }
 }
@@ -432,18 +452,20 @@ buildAndRegisterGatherAndOrientationEvaluators(PHX::FieldManager<panzer::Traits>
   using namespace Teuchos;
 
   // Loop over equation set template managers
-  vector< RCP<EquationSet_TemplateManager<panzer::Traits> > >::const_iterator 
+  vector< RCP<EquationSet_TemplateManager<panzer::Traits> > >::const_iterator
     eq_set = m_equation_sets.begin();
-  for (;eq_set != m_equation_sets.end(); ++eq_set) {
-
-    // Loop over evaluation types
-    EquationSet_TemplateManager<panzer::Traits> eqstm = *(*eq_set);
-    EquationSet_TemplateManager<panzer::Traits>::iterator eval_type =
-      eqstm.begin();
-    for (; eval_type != eqstm.end(); ++eval_type) {
-      const int di = eval_type->setDetailsIndex(this->getDetailsIndex());
-      eval_type->buildAndRegisterGatherAndOrientationEvaluators(fm, *m_field_lib, lof, user_data);
-      eval_type->setDetailsIndex(di);
+  int idx = 0;
+  for (;eq_set != m_equation_sets.end(); ++eq_set,++idx) {
+    if (m_active_evaluation_types[idx]) {
+      // Loop over evaluation types
+      EquationSet_TemplateManager<panzer::Traits> eqstm = *(*eq_set);
+      EquationSet_TemplateManager<panzer::Traits>::iterator eval_type =
+        eqstm.begin();
+      for (; eval_type != eqstm.end(); ++eval_type) {
+        const int di = eval_type->setDetailsIndex(this->getDetailsIndex());
+        eval_type->buildAndRegisterGatherAndOrientationEvaluators(fm, *m_field_lib, lof, user_data);
+        eval_type->setDetailsIndex(di);
+      }
     }
   }
 }
@@ -459,7 +481,7 @@ buildAndRegisterDOFProjectionsToIPEvaluators(PHX::FieldManager<panzer::Traits>& 
   using namespace Teuchos;
 
   // Loop over equation set template managers
-  vector< RCP<EquationSet_TemplateManager<panzer::Traits> > >::const_iterator 
+  vector< RCP<EquationSet_TemplateManager<panzer::Traits> > >::const_iterator
     eq_set = m_equation_sets.begin();
   for (;eq_set != m_equation_sets.end(); ++eq_set) {
 
@@ -467,17 +489,20 @@ buildAndRegisterDOFProjectionsToIPEvaluators(PHX::FieldManager<panzer::Traits>& 
     EquationSet_TemplateManager<panzer::Traits> eqstm = *(*eq_set);
     EquationSet_TemplateManager<panzer::Traits>::iterator eval_type =
       eqstm.begin();
-    for (; eval_type != eqstm.end(); ++eval_type) {
+    int idx = 0;
+    for (; eval_type != eqstm.end(); ++eval_type,++idx) {
+      if (m_active_evaluation_types[idx]) {
 
-      // Loop over integration rules
-      for (std::map<int,Teuchos::RCP<panzer::IntegrationRule> >::const_iterator ir_iter = m_integration_rules.begin();
-          ir_iter != m_integration_rules.end(); ++ ir_iter) {
-       
-       Teuchos::RCP<panzer::IntegrationRule> ir = ir_iter->second;
+        // Loop over integration rules
+        for (std::map<int,Teuchos::RCP<panzer::IntegrationRule> >::const_iterator ir_iter = m_integration_rules.begin();
+             ir_iter != m_integration_rules.end(); ++ ir_iter) {
 
-       const int di = eval_type->setDetailsIndex(this->getDetailsIndex());
-       eval_type->buildAndRegisterDOFProjectionsToIPEvaluators(fm, *m_field_lib->buildFieldLayoutLibrary(*ir), ir, lof, user_data);
-       eval_type->setDetailsIndex(di);
+          Teuchos::RCP<panzer::IntegrationRule> ir = ir_iter->second;
+
+          const int di = eval_type->setDetailsIndex(this->getDetailsIndex());
+          eval_type->buildAndRegisterDOFProjectionsToIPEvaluators(fm, *m_field_lib->buildFieldLayoutLibrary(*ir), ir, lof, user_data);
+          eval_type->setDetailsIndex(di);
+        }
       }
     }
   }
@@ -494,7 +519,7 @@ buildAndRegisterScatterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
   using namespace Teuchos;
 
   // Loop over equation set template managers
-  vector< RCP<EquationSet_TemplateManager<panzer::Traits> > >::const_iterator 
+  vector< RCP<EquationSet_TemplateManager<panzer::Traits> > >::const_iterator
     eq_set = m_equation_sets.begin();
   for (;eq_set != m_equation_sets.end(); ++eq_set) {
 
@@ -502,10 +527,13 @@ buildAndRegisterScatterEvaluators(PHX::FieldManager<panzer::Traits>& fm,
     EquationSet_TemplateManager<panzer::Traits> eqstm = *(*eq_set);
     EquationSet_TemplateManager<panzer::Traits>::iterator eval_type =
       eqstm.begin();
-    for (; eval_type != eqstm.end(); ++eval_type) {
-      const int di = eval_type->setDetailsIndex(this->getDetailsIndex());
-      eval_type->buildAndRegisterScatterEvaluators(fm, *m_field_lib, lof, user_data);
-      eval_type->setDetailsIndex(di);
+    int idx = 0;
+    for (; eval_type != eqstm.end(); ++eval_type,++idx) {
+      if (m_active_evaluation_types[idx]) {
+        const int di = eval_type->setDetailsIndex(this->getDetailsIndex());
+        eval_type->buildAndRegisterScatterEvaluators(fm, *m_field_lib, lof, user_data);
+        eval_type->setDetailsIndex(di);
+      }
     }
   }
 }
@@ -522,7 +550,7 @@ buildAndRegisterClosureModelEvaluators(PHX::FieldManager<panzer::Traits>& fm,
   using namespace Teuchos;
 
   // Loop over equation set template managers
-  vector< RCP<EquationSet_TemplateManager<panzer::Traits> > >::const_iterator 
+  vector< RCP<EquationSet_TemplateManager<panzer::Traits> > >::const_iterator
     eq_set = m_equation_sets.begin();
   for (;eq_set != m_equation_sets.end(); ++eq_set) {
 
@@ -530,17 +558,20 @@ buildAndRegisterClosureModelEvaluators(PHX::FieldManager<panzer::Traits>& fm,
     EquationSet_TemplateManager<panzer::Traits> eqstm = *(*eq_set);
     EquationSet_TemplateManager<panzer::Traits>::iterator eval_type =
       eqstm.begin();
-    for (; eval_type != eqstm.end(); ++eval_type) {
+    int idx = 0;
+    for (; eval_type != eqstm.end(); ++eval_type,++idx) {
+      if (m_active_evaluation_types[idx]) {
 
-      // Loop over integration rules
-      for (std::map<int,Teuchos::RCP<panzer::IntegrationRule> >::const_iterator ir_iter = m_integration_rules.begin();
-          ir_iter != m_integration_rules.end(); ++ ir_iter) {
-       
-       Teuchos::RCP<panzer::IntegrationRule> ir = ir_iter->second;
-       
-       const int di = eval_type->setDetailsIndex(this->getDetailsIndex());
-       eval_type->buildAndRegisterClosureModelEvaluators(fm, *m_field_lib->buildFieldLayoutLibrary(*ir), ir, factory, models, user_data);
-       eval_type->setDetailsIndex(di);
+        // Loop over integration rules
+        for (std::map<int,Teuchos::RCP<panzer::IntegrationRule> >::const_iterator ir_iter = m_integration_rules.begin();
+             ir_iter != m_integration_rules.end(); ++ ir_iter) {
+
+          Teuchos::RCP<panzer::IntegrationRule> ir = ir_iter->second;
+
+          const int di = eval_type->setDetailsIndex(this->getDetailsIndex());
+          eval_type->buildAndRegisterClosureModelEvaluators(fm, *m_field_lib->buildFieldLayoutLibrary(*ir), ir, factory, models, user_data);
+          eval_type->setDetailsIndex(di);
+        }
       }
     }
   }
@@ -560,7 +591,7 @@ buildAndRegisterClosureModelEvaluators(PHX::FieldManager<panzer::Traits>& fm,
   using namespace Teuchos;
 
   // Loop over equation set template managers
-  vector< RCP<EquationSet_TemplateManager<panzer::Traits> > >::const_iterator 
+  vector< RCP<EquationSet_TemplateManager<panzer::Traits> > >::const_iterator
     eq_set = m_equation_sets.begin();
   for (;eq_set != m_equation_sets.end(); ++eq_set) {
 
@@ -568,48 +599,55 @@ buildAndRegisterClosureModelEvaluators(PHX::FieldManager<panzer::Traits>& fm,
     EquationSet_TemplateManager<panzer::Traits> eqstm = *(*eq_set);
     EquationSet_TemplateManager<panzer::Traits>::iterator eval_type =
       eqstm.begin();
-    for (; eval_type != eqstm.end(); ++eval_type) {
+    int idx = 0;
+    for (; eval_type != eqstm.end(); ++eval_type,++idx) {
+      if (m_active_evaluation_types[idx]) {
 
-      // Loop over integration rules
-      for (std::map<int,Teuchos::RCP<panzer::IntegrationRule> >::const_iterator ir_iter = m_integration_rules.begin();
-          ir_iter != m_integration_rules.end(); ++ ir_iter) {
-       
-       Teuchos::RCP<panzer::IntegrationRule> ir = ir_iter->second;
-       const int di = eval_type->setDetailsIndex(this->getDetailsIndex());
-       eval_type->buildAndRegisterClosureModelEvaluators(fm, *m_field_lib->buildFieldLayoutLibrary(*ir), ir, factory, model_name, models, user_data);
-       eval_type->setDetailsIndex(di);
+        // Loop over integration rules
+        for (std::map<int,Teuchos::RCP<panzer::IntegrationRule> >::const_iterator ir_iter = m_integration_rules.begin();
+             ir_iter != m_integration_rules.end(); ++ ir_iter) {
+
+          Teuchos::RCP<panzer::IntegrationRule> ir = ir_iter->second;
+          const int di = eval_type->setDetailsIndex(this->getDetailsIndex());
+          eval_type->buildAndRegisterClosureModelEvaluators(fm, *m_field_lib->buildFieldLayoutLibrary(*ir), ir, factory, model_name, models, user_data);
+          eval_type->setDetailsIndex(di);
+        }
       }
     }
   }
-       
+
   // if there are no equation sets call the closure model directly
   if(m_equation_sets.size()==0) {
     ClosureModelFactory_TemplateManager<panzer::Traits>::const_iterator eval_type = factory.begin();
-    for (;eval_type != factory.end(); ++eval_type) {
-      // setup some place holder parameter list, lets hope no one needs is!
-      Teuchos::ParameterList plist;
+    int idx = 0;
+    for (;eval_type != factory.end(); ++eval_type,++idx) {
+      if (m_active_evaluation_types[idx]) {
 
-      // Loop over integration rules
-      for (std::map<int,Teuchos::RCP<panzer::IntegrationRule> >::const_iterator ir_iter = m_integration_rules.begin();
-          ir_iter != m_integration_rules.end(); ++ ir_iter) {
-       
-        Teuchos::RCP<panzer::IntegrationRule> ir = ir_iter->second;
+        // setup some place holder parameter list, lets hope no one needs is!
+        Teuchos::ParameterList plist;
 
-        // call directly to the closure models
-        Teuchos::RCP< std::vector< Teuchos::RCP<PHX::Evaluator<panzer::Traits> > > > evaluators = 
-          eval_type->buildClosureModels(model_name,
-                                        models,
-                                        *m_field_lib->buildFieldLayoutLibrary(*ir),
-                                        ir,
-                                        plist,
-                                        user_data,
-                                        this->globalData(),
-                                        fm);
-  
-        // register the constructed evaluators
-        const int di = eval_type->setDetailsIndex(this->getDetailsIndex());
-        eval_type->registerEvaluators(*evaluators,fm);
-        eval_type->setDetailsIndex(di);
+        // Loop over integration rules
+        for (std::map<int,Teuchos::RCP<panzer::IntegrationRule> >::const_iterator ir_iter = m_integration_rules.begin();
+             ir_iter != m_integration_rules.end(); ++ ir_iter) {
+
+          Teuchos::RCP<panzer::IntegrationRule> ir = ir_iter->second;
+
+          // call directly to the closure models
+          Teuchos::RCP< std::vector< Teuchos::RCP<PHX::Evaluator<panzer::Traits> > > > evaluators =
+            eval_type->buildClosureModels(model_name,
+                                          models,
+                                          *m_field_lib->buildFieldLayoutLibrary(*ir),
+                                          ir,
+                                          plist,
+                                          user_data,
+                                          this->globalData(),
+                                          fm);
+
+          // register the constructed evaluators
+          const int di = eval_type->setDetailsIndex(this->getDetailsIndex());
+          eval_type->registerEvaluators(*evaluators,fm);
+          eval_type->setDetailsIndex(di);
+        }
       }
     }
   }
@@ -630,7 +668,6 @@ buildAndRegisterInitialConditionEvaluators(PHX::FieldManager<panzer::Traits>& fm
 
   // Only use the <Residual> evaluation type, so pass through to type specific call
   this->buildAndRegisterInitialConditionEvaluatorsForType<panzer::Traits::Residual>(fm, factory, model_name, models, lof, user_data);
-
 }
 
 
@@ -667,7 +704,7 @@ panzer::WorksetNeeds panzer::PhysicsBlock::getWorksetNeeds() const
   const std::map<int,Teuchos::RCP<panzer::IntegrationRule> >& int_rules = this->getIntegrationRules();
   for (std::map<int,Teuchos::RCP<panzer::IntegrationRule> >::const_iterator ir_itr = int_rules.begin();
        ir_itr != int_rules.end(); ++ir_itr)
-    needs.int_rules.push_back(ir_itr->second);  
+    needs.int_rules.push_back(ir_itr->second);
 
   const std::map<std::string,Teuchos::RCP<panzer::PureBasis> >& bases= this->getBases();
   const std::vector<StrPureBasisPair>& fieldToBasis = getProvidedDOFs();
@@ -679,7 +716,7 @@ panzer::WorksetNeeds panzer::PhysicsBlock::getWorksetNeeds() const
     bool found = false;
     for(std::size_t d=0;d<fieldToBasis.size();d++) {
       if(fieldToBasis[d].second->name()==b_itr->second->name()) {
-        // add representative basis for this field 
+        // add representative basis for this field
         needs.rep_field_name.push_back(fieldToBasis[d].first);
         found = true;
 
@@ -695,14 +732,14 @@ panzer::WorksetNeeds panzer::PhysicsBlock::getWorksetNeeds() const
 }
 
 // *******************************************************************
-const std::map<std::string,Teuchos::RCP<panzer::PureBasis> >& 
+const std::map<std::string,Teuchos::RCP<panzer::PureBasis> >&
 panzer::PhysicsBlock::getBases() const
 {
   return m_bases;
 }
 
 // *******************************************************************
-const std::map<int,Teuchos::RCP<panzer::IntegrationRule> >& 
+const std::map<int,Teuchos::RCP<panzer::IntegrationRule> >&
 panzer::PhysicsBlock::getIntegrationRules() const
 {
   return m_integration_rules;


### PR DESCRIPTION
Allow for runtime disable of evaluation types in ModelEvaluator, FieldManagerBuilder,
PhysicsBlock, and InitialConditionBuilder.

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Some codes don't need all evaluation types allocated for each analysis. This commit allows codes to disable unneeded evaluation types at runtime.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
Achieves memory reduction in EMPIRE.

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
The added memory structures are tested in all current examples.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->