### PR TITLE
Tpetra: build error related to default template arguments

### DIFF
--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_OpenMP.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_OpenMP.hpp
@@ -528,7 +528,7 @@ void KernelWrappers2<Scalar,LocalOrdinal,GlobalOrdinal,Kokkos::Compat::KokkosOpe
   if(debug) {
 
     auto rowMap = Aview.origMatrix->getRowMap();
-    Tpetra::Vector<Scalar> diags(rowMap);
+    Tpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Kokkos::Compat::KokkosOpenMPWrapperNode> diags(rowMap);
     Aview.origMatrix->getLocalDiagCopy(diags);
     size_t diagLength = rowMap->getNodeNumElements();
     Teuchos::Array<Scalar> diagonal(diagLength);


### PR DESCRIPTION
@trilinos/trilinos

## Motivation
Solves a build error when both OpenMP and Cuda are enabled as execution spaces.

## Related Issues

Fixes #7339.

## Stakeholder Feedback

## Testing

## Additional Information
