### PR TITLE
Resolve CUDA_LAUNCH_BLOCKING issues for MueLu  from testing on white

### DIFF
--- a/packages/muelu/src/Transfers/PCoarsen/MueLu_IntrepidPCoarsenFactory_def.hpp
+++ b/packages/muelu/src/Transfers/PCoarsen/MueLu_IntrepidPCoarsenFactory_def.hpp
@@ -543,6 +543,7 @@ void GenerateRepresentativeBasisNodes(const Basis & basis, const SCFieldContaine
 
  basis.getValues(LoValues, ReferenceNodeLocations , Intrepid2::OPERATOR_VALUE);
 
+ Kokkos::fence(); // for kernel in getValues
 
 #if 0
   printf("** LoValues[%d,%d] **\n",(int)numFieldsLo,(int)numFieldsHi);
@@ -603,6 +604,8 @@ void IntrepidPCoarsenFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Generat
   FC LoValues_at_HiDofs("LoValues_at_HiDofs",numFieldsLo,numFieldsHi);
   lo_basis.getValues(LoValues_at_HiDofs, hi_DofCoords, Intrepid2::OPERATOR_VALUE);
 
+  Kokkos::fence(); // for kernel in getValues
+
   typedef typename Teuchos::ScalarTraits<SC>::halfPrecision SClo;
   typedef typename Teuchos::ScalarTraits<SClo>::magnitudeType MT;
   MT effective_zero = Teuchos::ScalarTraits<MT>::eps();
@@ -658,6 +661,8 @@ void IntrepidPCoarsenFactory<Scalar, LocalOrdinal, GlobalOrdinal, Node>::Generat
   size_t numFieldsLo = lo_basis.getCardinality();
   FC LoValues_at_HiDofs("LoValues_at_HiDofs",numFieldsLo,numFieldsHi);
   lo_basis.getValues(LoValues_at_HiDofs, hi_DofCoords, Intrepid2::OPERATOR_VALUE);
+
+  Kokkos::fence(); // for kernel in getValues
 
   typedef typename Teuchos::ScalarTraits<SC>::halfPrecision SClo;
   typedef typename Teuchos::ScalarTraits<SClo>::magnitudeType MT;

--- a/packages/muelu/test/unit_tests/Hierarchy.cpp
+++ b/packages/muelu/test/unit_tests/Hierarchy.cpp
@@ -329,6 +329,13 @@ namespace MueLuTests {
 
     norms = Utilities::ResidualNorm(*Op, *X, *RHS);
     out << "||res_" << std::setprecision(2) << iterations << "|| = " << std::setprecision(15) << norms[0] << std::endl;
+
+    // TODO: CUDA_LAUNCH_BLOCKING=0 will result in fluctuating values for the norm
+    // Need to track down the source of the randomness.
+    // Note that the test will fail about 1/5 of the time on white with CUDA_LAUNCH_BLOCKING=0
+    // Changing the scale from 100 to 1000 is sufficient to keep it passing.
+    // But the randomness is probably something that needs to be fixed.
+    // Will address this in a separate PR.
     TEST_EQUALITY(norms[0] < 100*TMT::eps(), true);
 
   } //Iterate

--- a/packages/muelu/test/unit_tests/IntrepidPCoarsenFactory.cpp
+++ b/packages/muelu/test/unit_tests/IntrepidPCoarsenFactory.cpp
@@ -639,6 +639,9 @@ namespace MueLuTests {
     }
 
     CellTools::mapToPhysicalFrame(cellDofCoords, refDofCoords, cellWorkset, cellTopo);
+
+    Kokkos::fence(); // mapToPhysicalFrame calls getValues which calls kernels, so fence is required before UVM reads below
+
     UniqueNumbering globalNumbering(spaceDim, pointTol);
     globalNumbering.getIDs<ArrayScalar,ArrayOrdinal>(cellDofCoords,cellDofIDs);
 
@@ -2033,6 +2036,9 @@ bool test_representative_basis(Teuchos::FancyOStream &out, const std::string & n
 
             CellTools::mapToPhysicalFrame(lo_physDofCoords, lo_DofCoords, physCellVerticesPermuted, cellTopo);
             CellTools::mapToPhysicalFrame(hi_physDofCoords, hi_DofCoords, physCellVerticesPermuted, cellTopo);
+
+            Kokkos::fence(); // mapToPhysicalFrame calls getValues which calls kernels, so fence is required before UVM reads below
+
             int cell1Side = searchForX1Side(1);
 
             /*


### PR DESCRIPTION
Code failures when CUDA_LAUNCH_BLOCKING is set to 0 are being identified and fixed with addition of fences.

Note that a change to Kokkos is also required for the MueLu test suite to pass with CUDA_LAUNCH_BLOCKING=0. This has been requested:
[https://github.com/kokkos/kokkos/issues/3014](url)

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/muelu 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

Identify code that fails when CUDA_LAUNCH_BLOCKING is turned off.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Issues were identified by running the MueLu test suite on white.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->