### PR TITLE
Enable C++14 for GCC 8.3 PR build

### DIFF
--- a/cmake/std/PullRequestLinuxGCC8.3.0TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxGCC8.3.0TestingSettings.cmake
@@ -20,7 +20,7 @@ set (Trilinos_ENABLE_COMPLEX_DOUBLE ON CACHE BOOL "Set by default for PR testing
 # Enable C++14 for this build. In the future how we do this will change, but for
 # now we need to use the Kokkos option
 
-set (Kokkos_CXX_STANDARD "14" CACHE STRING "Set C++ standard to C++14")
+set (CMAKE_CXX_STANDARD "14" CACHE STRING "Set C++ standard to C++14")
 set (CMAKE_CXX_EXTENSIONS OFF CACHE BOOL "Kokkos turns off CXX extensions")
 
 # Disable just one Teko sub-unit test that fails with openmpi 1.10 (#2712)

--- a/cmake/std/PullRequestLinuxGCC8.3.0TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxGCC8.3.0TestingSettings.cmake
@@ -17,6 +17,12 @@ set (MPI_EXEC_PRE_NUMPROCS_FLAGS "--bind-to;none" CACHE STRING "Set by default f
 
 set (Trilinos_ENABLE_COMPLEX_DOUBLE ON CACHE BOOL "Set by default for PR testing to exercise complex doubles case")
 
+# Enable C++14 for this build. In the future how we do this will change, but for
+# now we need to use the Kokkos option
+
+set (Kokkos_CXX_STANDARD "14" CACHE STRING "Set C++ standard to C++14")
+set (CMAKE_CXX_EXTENSIONS OFF CACHE BOOL "Kokkos turns off CXX extensions")
+
 # Disable just one Teko sub-unit test that fails with openmpi 1.10 (#2712)
 set (Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D ON CACHE BOOL "Temporarily disabled in PR testing")
 


### PR DESCRIPTION
Issue 6968

Enabling C++14 for GCC 8.3 PR build.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/<teamName>

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
This will enable C++14 for this PR build. This will not however allow use of C++14 in Trilinos, as other builds enforce C++11. This will merely ensure that changes do not break bulids for which C++14 is enabled.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->