### PR TITLE
ATDM: cee-rhel6: Remove 'module load sparc-dev' to fix clang-9.0.1-opempi-4.0.3 (ATDV-348)

### DIFF
--- a/cmake/std/atdm/cee-rhel6/environment.sh
+++ b/cmake/std/atdm/cee-rhel6/environment.sh
@@ -47,10 +47,6 @@ export ATDM_CONFIG_BUILD_COUNT=$ATDM_CONFIG_MAX_NUM_CORES_TO_USE
 
 module purge
 
-module load sparc-dev
-# NOTE: Above was reported needed by jhu on some CEE RHEL6 machine in order to
-# get NetCDF to load (#4662).
-
 # Warning options requested by Gemma team (which should hopefully also take
 # care of warnings required by the other ATDM APPs as well).  See #3178 and
 # #4221


### PR DESCRIPTION
So it seems that if you do:

```
  $ module purge
  $ module load sparc-dev
  $ module load sparc-dev/clang-9.0.1_openmpi-4.0.3
```

you get the wrong MPI:

```
  $ which mpicc
  /usr/local/epd/canopy2/opt/Canopy/edm/envs/User/bin/mpicc
```
But if you just do:

```
  $ module purge
  $ module load sparc-dev/clang-9.0.1_openmpi-4.0.3
```

you get the correct MPI:

```
  $ which mpicc
  /sierra/sntools/SDK/mpi/openmpi/4.0.3-clang-9.0-RHEL6/bin/mpicc
```

I don't know how this was missed in my earlier testing.

## How was this tested?

I was able to reproduce the problem on my CEE RHEL6 machine 'ceerws1113' and then I verified that this change fixed it.

I tested all of the envs on 'ceerws1113' with:

```
$ env Trilinos_PACKAGES=Kokkos,Teuchos ./ctest-s-local-test-driver-cee-rhel6.sh all

***
*** /scratch/rabartl/Trilinos.base/Trilinos/cmake/std/atdm/ctest-s-local-test-driver.sh
***

ATDM_TRILINOS_DIR = '/scratch/rabartl/Trilinos.base/Trilinos'

Load some env to get python, cmake, etc ...

Hostname 'ceerws1113' matches known ATDM host 'ceerws1113' and system 'cee-rhel6'
Setting compiler and build options for build-name 'cee-rhel6-default'
Using CEE RHEL6 compiler stack CLANG-9.0.1_OPENMPI-4.0.3 to build DEBUG code with Kokkos node type SERIAL

Running builds:
    cee-rhel6_clang-9.0.1_openmpi-4.0.3_serial_static_opt
    cee-rhel6_gnu-7.2.0_openmpi-4.0.2_serial_shared_opt
    cee-rhel6_intel-18.0.2_mpich2-3.2_openmp_static_opt
    cee-rhel6_intel-19.0.3_intelmpi-2018.4_serial_static_opt

Wed May 13 09:11:39 MDT 2020

Running Jenkins driver Trilinos-atdm-cee-rhel6_clang-9.0.1_openmpi-4.0.3_serial_static_opt.sh ...

    Creating directory: Trilinos-atdm-cee-rhel6_clang-9.0.1_openmpi-4.0.3_serial_static_opt

    Creating directory: SRC_AND_BUILD

    See log file Trilinos-atdm-cee-rhel6_clang-9.0.1_openmpi-4.0.3_serial_static_opt/smart-jenkins-driver.out

real    3m45.736s
user    36m37.581s
sys     1m44.802s

100% tests passed, 0 tests failed out of 165

Wed May 13 09:15:24 MDT 2020

Running Jenkins driver Trilinos-atdm-cee-rhel6_gnu-7.2.0_openmpi-4.0.2_serial_shared_opt.sh ...

    Creating directory: Trilinos-atdm-cee-rhel6_gnu-7.2.0_openmpi-4.0.2_serial_shared_opt

    Creating directory: SRC_AND_BUILD

    See log file Trilinos-atdm-cee-rhel6_gnu-7.2.0_openmpi-4.0.2_serial_shared_opt/smart-jenkins-driver.out

real    3m6.696s
user    30m1.747s
sys     2m37.001s

100% tests passed, 0 tests failed out of 167

Wed May 13 09:18:31 MDT 2020

Running Jenkins driver Trilinos-atdm-cee-rhel6_intel-18.0.2_mpich2-3.2_openmp_static_opt.sh ...

    Creating directory: Trilinos-atdm-cee-rhel6_intel-18.0.2_mpich2-3.2_openmp_static_opt

    Creating directory: SRC_AND_BUILD

    See log file Trilinos-atdm-cee-rhel6_intel-18.0.2_mpich2-3.2_openmp_static_opt/smart-jenkins-driver.out

real    9m29.699s
user    106m54.645s
sys     7m21.531s

100% tests passed, 0 tests failed out of 170

Wed May 13 09:28:01 MDT 2020

Running Jenkins driver Trilinos-atdm-cee-rhel6_intel-19.0.3_intelmpi-2018.4_serial_static_opt.sh ...

    Creating directory: Trilinos-atdm-cee-rhel6_intel-19.0.3_intelmpi-2018.4_serial_static_opt

    Creating directory: SRC_AND_BUILD

    See log file Trilinos-atdm-cee-rhel6_intel-19.0.3_intelmpi-2018.4_serial_static_opt/smart-jenkins-driver.out

real    6m21.875s
user    66m7.198s
sys     4m25.116s

100% tests passed, 0 tests failed out of 165

Wed May 13 09:34:23 MDT 2020

Done running all of the builds!
```

This posted to CDash at:

* https://testing-dev.sandia.gov/cdash/index.php?project=Trilinos&date=2020-05-13&filtercount=2&showfilters=1&filtercombine=and&field1=buildname&compare1=65&value1=Trilinos-atdm-cee-rhel6&field2=buildname&compare2=63&value2=-exp

And in the configure output for the clang build shown [here](https://testing-dev.sandia.gov/cdash/build/5449936/configure) we see:

```
-- Leaving current CMAKE_C_COMPILER=/sierra/sntools/SDK/mpi/openmpi/4.0.3-clang-9.0-RHEL6/bin/mpicc since it is already set!
-- Leaving current CMAKE_CXX_COMPILER=/sierra/sntools/SDK/mpi/openmpi/4.0.3-clang-9.0-RHEL6/bin/mpicxx since it is already set!
-- Leaving current CMAKE_Fortran_COMPILER=/sierra/sntools/SDK/mpi/openmpi/4.0.3-clang-9.0-RHEL6/bin/mpif90 since it is already set!
-- MPI_EXEC='mpiexec'
-- MPI_EXEC='/sierra/sntools/SDK/mpi/openmpi/4.0.3-clang-9.0-RHEL6/bin/mpiexec'
```



