### PR TITLE
Tacho - export supernodes info

### DIFF
--- a/packages/shylu/shylu_node/tacho/example/Tacho_ExampleExternalInterface.cpp
+++ b/packages/shylu/shylu_node/tacho/example/Tacho_ExampleExternalInterface.cpp
@@ -81,6 +81,12 @@ void testTachoSolver(int numRows,
 
 
   ///
+  /// Export supernodes
+  ///
+  std::vector<int> supernodes;
+  solver.exportSupernodes(supernodes);
+
+  ///
   /// Export matrix and permutation vector
   ///
   std::vector<int> rowBeginU;

--- a/packages/shylu/shylu_node/tacho/example/Tacho_ExampleExternalInterface.hpp
+++ b/packages/shylu/shylu_node/tacho/example/Tacho_ExampleExternalInterface.hpp
@@ -117,6 +117,16 @@ namespace tacho {
       return 0;
     }
 
+    void exportSupernodes(std::vector<int> &supernodes) {
+      const auto supernodes_device = m_Solver.getSupernodes();
+      auto supernodes_host = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), supernodes_device); 
+      {
+        const int n = supernodes_host.extent(0);
+        supernodes.resize(n);
+        std::copy(supernodes_host.data(), supernodes_host.data()+n, supernodes.data());
+      }
+    }
+
     void exportUpperTriangularFactorsToCrsMatrix(std::vector<int> &rowBeginU,
                                                  std::vector<int> &columnsU,
                                                  std::vector<SX> &valuesU,

--- a/packages/shylu/shylu_node/tacho/src/Tacho_Solver.hpp
+++ b/packages/shylu/shylu_node/tacho/src/Tacho_Solver.hpp
@@ -171,6 +171,8 @@ namespace Tacho {
     ///
     /// get interface
     ///
+    ordinal_type       getNumSupernodes() const;
+    ordinal_type_array getSupernodes() const;
     ordinal_type_array getPermutationVector() const;
     ordinal_type_array getInversePermutationVector() const;
 

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Solver_Impl.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Solver_Impl.hpp
@@ -176,6 +176,20 @@ namespace Tacho {
   /// get interface
   ///
   template<typename VT, typename ST>  
+  ordinal_type
+  Solver<VT,ST>
+  ::getNumSupernodes() const { 
+    return _nsupernodes;
+  } 
+
+  template<typename VT, typename ST>  
+  typename Solver<VT,ST>::ordinal_type_array
+  Solver<VT,ST>
+  ::getSupernodes() const { 
+    return _supernodes;
+  } 
+
+  template<typename VT, typename ST>  
   typename Solver<VT,ST>::ordinal_type_array
   Solver<VT,ST>
   ::getPermutationVector() const { 


### PR DESCRIPTION
## Motivation

As part of @crdohrm solver work, supernodes interface needs to be exposed. This PR includes the interface. The use case is described in the example "Tacho_ExampleExternalExamplecpp". 

