### PR TITLE
Fixes errors in OrthoManagerTest and enables Epetra testing

### DIFF
--- a/packages/belos/epetra/test/OrthoManager/CMakeLists.txt
+++ b/packages/belos/epetra/test/OrthoManager/CMakeLists.txt
@@ -2,11 +2,15 @@
 
 ASSERT_DEFINED(${PACKAGE_NAME}_ENABLE_Triutils)
 
-IF (${PACKAGE_NAME}_ENABLE_Triutils AND ${PACKAGE_NAME}_ENABLE_TSQR)
+IF (${PACKAGE_NAME}_ENABLE_Triutils)
+
   TRIBITS_ADD_EXECUTABLE_AND_TEST(
     Epetra_OrthoManager_test
     SOURCES belos_orthomanager_epetra.cpp
-    ARGS ""
+    ARGS "--ortho=ICGS --verbose"
+         "--ortho=DGKS --verbose"
+         "--ortho=IMGS --verbose"
     COMM serial mpi
     )
+
 ENDIF()

--- a/packages/belos/src/BelosOrthoManagerTest.hpp
+++ b/packages/belos/src/BelosOrthoManagerTest.hpp
@@ -463,7 +463,7 @@ namespace Belos {
           debugOut << "done: || <X2,X1> || = " << err << endl;
         }
 
-
+#ifdef HAVE_BELOS_TSQR
         //
         // If OM is an OutOfPlaceNormalizerMixin, exercise the
         // out-of-place normalization routines.
@@ -560,6 +560,7 @@ namespace Belos {
                      << "=== Done with OutOfPlaceNormalizerMixin tests ==="
                      << endl << endl;
           }
+#endif // HAVE_BELOS_TSQR
 
         {
           //
@@ -640,7 +641,7 @@ namespace Belos {
                 std::vector<int> ind(1);
                 ind[0] = i;
                 RCP<MV> Si = MVT::CloneViewNonConst(*S,ind);
-                MVT::MvAddMv(scaleS[i],*one,ZERO,*one,*Si);
+                MVT::MvAddMv(scaleS(i,0),*one,ZERO,*one,*Si);
               }
             debugOut << "Testing normalize() on a rank-1 multivector " << endl;
             const int thisNumFailed = testNormalize(OM,S,MyOM);
@@ -725,7 +726,7 @@ namespace Belos {
                 std::vector<int> ind(1);
                 ind[0] = i;
                 RCP<MV> Si = MVT::CloneViewNonConst(*S,ind);
-                MVT::MvAddMv(scaleS[i],*one,ZERO,*one,*Si);
+                MVT::MvAddMv(scaleS(i,0),*one,ZERO,*one,*Si);
               }
             debugOut << "Testing projectAndNormalize() on a rank-1 multivector " << endl;
             bool constantStride = true;
@@ -940,9 +941,9 @@ namespace Belos {
             // copies of S,MS
             Scopy = MVT::CloneCopy(*S);
             // randomize this data, it should be overwritten
-            Teuchos::randomSyncedMatrix(B);
+            Teuchos::randomSyncedMatrix(*B);
             for (size_type i=0; i<C.size(); i++) {
-              Teuchos::randomSyncedmatrix(*C[i]);
+              Teuchos::randomSyncedMatrix(*C[i]);
             }
             // Run test.  Since S was specified by the caller and
             // Scopy is a copy of S, we don't know what rank to expect
@@ -996,7 +997,7 @@ namespace Belos {
               // data will be overwritten by projectAndNormalize().
               // Filling these matrices here is only to catch some
               // bugs in projectAndNormalize().
-              Teuchos::randomSyncedMatrix(B);
+              Teuchos::randomSyncedMatrix(*B);
               for (size_type i=0; i<C.size(); i++) {
                 Teuchos::randomSyncedMatrix(*C[i]);
               }
@@ -1210,7 +1211,7 @@ namespace Belos {
             // random data just to make sure that the normalization
             // operated on all the elements of B on which it should
             // operate.
-            Teuchos::randomSyncedMatrix(B);
+            Teuchos::randomSyncedMatrix(*B);
 
             const int reportedRank = OM->normalize (*S_copy, B);
             sout << "normalize() returned rank " << reportedRank << endl;


### PR DESCRIPTION

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/belos 

## Motivation
Integration of the OrthoManager into Belos solvers requires that it is tested, which it hasn't been aside from being used by GCRODR.

The OrthoManagerTest had several typos in it, which were not found
because all tests that used it were essentially disabled.  The
OrthoManagerTest has been fixed and all TSQR-specific tests have
been placed behind an ifdef.  The Epetra interface test for the
OrthoManager has been enabled and the dependency on TSQR has been
removed due to the change in the tester.

<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes #4657
* Related to
* Part of #4657
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
Tested on OSX using GCC9
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->