### PR TITLE
Piro: cleaning/refactoring of steady sensitivities

### DIFF
--- a/packages/piro/src/CMakeLists.txt
+++ b/packages/piro/src/CMakeLists.txt
@@ -20,6 +20,7 @@ SET(HEADERS ${HEADERS}
 # B.1) utilities
 #
 APPEND_SET(HEADERS
+  Piro_Helpers.hpp 
   Piro_ValidPiroParameters.hpp
   Piro_Version.hpp
   Piro_InvertMassMatrixDecorator.hpp
@@ -130,7 +131,6 @@ ENDIF()
 ENDIF()
 IF (Piro_ENABLE_Tempus)
   APPEND_SET(HEADERS
-    Piro_Helpers.hpp 
     Piro_TempusSolver.hpp
     Piro_TempusSolver_Def.hpp 
     Piro_TempusIntegrator.hpp

--- a/packages/piro/src/Piro_LOCAAdaptiveSolver_Def.hpp
+++ b/packages/piro/src/Piro_LOCAAdaptiveSolver_Def.hpp
@@ -129,6 +129,8 @@ Piro::LOCAAdaptiveSolver<Scalar>::LOCAAdaptiveSolver(
   if (piroParams_->isSublist("NOX") &&
       piroParams_->sublist("NOX").isSublist("Printing"))
     utils_.reset(piroParams_->sublist("NOX").sublist("Printing"));
+
+  this->setSensitivityMethod("Forward");
 }
 
 template<typename Scalar>
@@ -263,7 +265,7 @@ Piro::LOCAAdaptiveSolver<Scalar>::evalModelImpl(
       modelInArgs.set_p(l, p_inargs);
     }
 
-    this->evalConvergedModel(modelInArgs, outArgs);
+    this->evalConvergedModelResponsesAndSensitivities(modelInArgs, outArgs);
 
     // Save the final solution TODO: this needs to be redone
 

--- a/packages/piro/src/Piro_LOCASolver_Def.hpp
+++ b/packages/piro/src/Piro_LOCASolver_Def.hpp
@@ -135,6 +135,8 @@ Piro::LOCASolver<Scalar>::LOCASolver(
   if (piroParams_->isSublist("NOX") &&
       piroParams_->sublist("NOX").isSublist("Printing"))
     utils_.reset(piroParams_->sublist("NOX").sublist("Printing"));
+
+  this->setSensitivityMethod("Forward");
 }
 
 template<typename Scalar>
@@ -224,7 +226,7 @@ Piro::LOCASolver<Scalar>::evalModelImpl(
       modelInArgs.set_p(l, p_inargs);
     }
 
-    this->evalConvergedModel(modelInArgs, outArgs);
+    this->evalConvergedModelResponsesAndSensitivities(modelInArgs, outArgs);
   }
 }
 

--- a/packages/piro/src/Piro_NOXSolver.hpp
+++ b/packages/piro/src/Piro_NOXSolver.hpp
@@ -103,14 +103,10 @@ class NOXSolver
   /** \brief Whether to throw an exception when solve fails. */
   bool exitUponFailedNOXSolve; 
 
-  mutable bool solveState;
+  /** \brief Whether to Solve again the system with zero intial guess after failure. */
+  bool reComputeWithZeroInitialGuess;
 
-  /** \brief Derivative layouts for Thyra operator"
-   * OP:  Thyra::ModelEvaluatorBase::DERIV_LINEAR_OP
-   * COL: Thyra::ModelEvaluatorBase::DERIV_MV_GRADIENT_FORM
-   * ROW: Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM
-   * */
-  enum DerivativeLayout { OP, COL, ROW };
+  mutable bool solveState;
 
   //Store current iteration of Analysis solver
   mutable int current_iteration;

--- a/packages/piro/src/Piro_NOXSolver_Def.hpp
+++ b/packages/piro/src/Piro_NOXSolver_Def.hpp
@@ -56,7 +56,6 @@
 #include "Thyra_DefaultZeroLinearOp.hpp"
 #include "Thyra_MultiVectorStdOps.hpp"
 #include "Thyra_VectorStdOps.hpp"
-#include "Thyra_SpmdVectorSpaceDefaultBase.hpp"
 
 #include "Teuchos_ScalarTraits.hpp"
 #include "Teuchos_TestForException.hpp"
@@ -85,6 +84,9 @@ NOXSolver(const Teuchos::RCP<Teuchos::ParameterList> &appParams_,
     {
   using Teuchos::RCP;
 
+  std::string sensitivity_method_str = appParams->get("Sensitivity Method", "Forward");
+  this->setSensitivityMethod(sensitivity_method_str);
+
   const RCP<Teuchos::ParameterList> noxParams =
       Teuchos::sublist(appParams, "NOX", /*mustAlreadyExist =*/ false);
 
@@ -93,6 +95,8 @@ NOXSolver(const Teuchos::RCP<Teuchos::ParameterList> &appParams_,
   std::string jacobianSource = appParams->get("Jacobian Operator", "Have Jacobian");
 
   exitUponFailedNOXSolve = appParams->get("Exit on Failed NOX Solve", false); 
+
+  reComputeWithZeroInitialGuess = appParams->get("On Failure Solve With Zero Initial Guess", false);
 
   if (jacobianSource == "Matrix-Free") {
     if (appParams->isParameter("Matrix-Free Perturbation")) {
@@ -161,15 +165,17 @@ void Piro::NOXSolver<Scalar>::evalModelImpl(
         if (optimizationParams.template get<bool>("Optimization Variables Changed")) {
           if (analysisParams.isSublist("ROL")) {
             auto rolParams = analysisParams.sublist("ROL");
-            int num_parameters = rolParams.get("Number of Parameters", 1);
-            for(int i=0; i<num_parameters; ++i) {
-              std::ostringstream ss; ss << "Parameter Vector Index " << i;
-              const int p_ind = rolParams.get(ss.str(), i);
-              const auto paramNames = *this->getModel().get_p_names(p_ind);
-              if(Teuchos::nonnull(this->observer))
-                this->observer->parameterChanged(paramNames[0]);
+            if(rolParams.get("Use Old Reduced Space Interface", false)) {
+              int num_parameters = rolParams.get("Number of Parameters", 1);
+              for(int i=0; i<num_parameters; ++i) {
+                std::ostringstream ss; ss << "Parameter Vector Index " << i;
+                const int p_ind = rolParams.get(ss.str(), i);
+                const auto paramNames = *this->getModel().get_p_names(p_ind);
+                if(Teuchos::nonnull(this->observer))
+                  this->observer->parameterChanged(paramNames[0]);
+              }
+              optimizationParams.set("Optimization Variables Changed", false);
             }
-            optimizationParams.set("Optimization Variables Changed", false);
           }
         }
       }
@@ -204,6 +210,12 @@ void Piro::NOXSolver<Scalar>::evalModelImpl(
     }
 
     solve_status = solver->solve(initial_guess.get(), &solve_criteria, /*delta =*/ NULL);
+    if((solve_status.solveStatus != ::Thyra::SOLVE_STATUS_CONVERGED) && reComputeWithZeroInitialGuess && (initial_guess->norm_1()!=0.0)) {
+      *out << "Piro::NOXSolver, Trying to solve the nonlinear problem again with a zero initial guess" << std::endl;
+      initial_guess->assign(0.0);
+      solve_status = solver->solve(initial_guess.get(), &solve_criteria, /*delta =*/ NULL);
+    }
+
 
     //  MPerego: I think it is better not to throw an error when the solver does not converge.
     //  One can look at the solver status to check whether the solution is converged.
@@ -222,8 +234,6 @@ void Piro::NOXSolver<Scalar>::evalModelImpl(
       }
     }
 
-
-
     auto final_point = model->createInArgs();
     if (final_point.supports(Thyra::ModelEvaluatorBase::IN_ARG_x)) {
       final_point.set_x(solver->get_current_x());
@@ -237,480 +247,7 @@ void Piro::NOXSolver<Scalar>::evalModelImpl(
   const RCP<const Thyra::VectorBase<Scalar> > finalSolution = solver->get_current_x();
   modelInArgs.set_x(finalSolution);
 
-
-  std::string sensitivity_method = appParams->get("Sensitivity Method",
-      "Forward");
-
-  //TODO: Handle forward and adjoint cases in a similar way.
-  //      At the moment we keep the current implementation of Forward sensitivities
-  //      and add code for adjoint sensitivities below.
-  if(sensitivity_method == "Forward")
-    this->evalConvergedModel(modelInArgs, outArgs);
-  else {
-    if(sensitivity_method != "Adjoint") {
-
-      TEUCHOS_TEST_FOR_EXCEPTION(true,
-          Teuchos::Exceptions::InvalidParameter,
-          std::endl <<
-          "Piro::NOXSolver::evalModel():  " <<
-          "Unknown sensitivity method" << sensitivity_method <<
-          ".  Valid choices are \"Forward\" and \"Adjoint\"."
-          << std::endl);
-    }
-
-    //Adjoint sensitivities:
-
-    // Solution at convergence is the response at index num_g
-    {
-      const RCP<Thyra::VectorBase<Scalar> > gx_out = outArgs.get_g(num_g);
-      if (Teuchos::nonnull(gx_out)) {
-        Thyra::copy(*modelInArgs.get_x(), gx_out.ptr());
-      }
-    }
-
-    //
-    // Do Sensitivity Calc, if requested. See 3 main steps
-    //
-
-    // Set inargs and outargs
-    Thyra::ModelEvaluatorBase::OutArgs<Scalar> modelOutArgs = this->getModel().createOutArgs();
-
-    // Compute adjoint layouts of df/dp, dg/dx depending on
-    bool do_sens = false;
-    for (int i=0; i<num_p; i++) {
-      // p
-      modelInArgs.set_p(i, inArgs.get_p(i));
-
-      // df/dp
-      do_sens = false;
-      for (int j=0; j<=num_g; j++) {
-        if (!outArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDp, j, i).none() &&
-            !outArgs.get_DgDp(j,i).isEmpty()) {
-          do_sens = true;
-        }
-      }
-      if (do_sens) {
-        auto p_space = this->getModel().get_p_space(i);
-        auto f_space = this->getModel().get_f_space();
-        int num_params = p_space->dim();
-        int num_resids = f_space->dim();
-        auto p_space_plus = Teuchos::rcp_dynamic_cast<const Thyra::SpmdVectorSpaceDefaultBase<Scalar>>(p_space);
-        auto f_space_plus = Teuchos::rcp_dynamic_cast<const Thyra::SpmdVectorSpaceDefaultBase<Scalar>>(f_space);
-        bool p_dist = !p_space_plus->isLocallyReplicated();//p_space->DistributedGlobal();
-        bool f_dist = !f_space_plus->isLocallyReplicated();//f_space->DistributedGlobal();
-        Thyra::ModelEvaluatorBase::DerivativeSupport ds =  modelOutArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DfDp,i);
-        // Determine which layout to use for df/dp.  Ideally one would look
-        // at num_params, num_resids, what is supported by the underlying
-        // model evaluator, and the sensitivity method, and make the best
-        // choice to minimze the number of solves.  However this choice depends
-        // also on what layout of dg/dx is supported (e.g., if only the operator
-        // form is supported for forward sensitivities, then df/dp must be
-        // DERIV_MV_JACOBIAN_FORM).  For simplicity, we order the conditional tests
-        // to get the right layout in most situations.
-        DerivativeLayout dfdp_layout;
-        { // if (sensitivity_method == "Adjoint")
-          if (ds.supports(Thyra::ModelEvaluatorBase::DERIV_LINEAR_OP))
-            dfdp_layout = OP;
-          else if (ds.supports(Thyra::ModelEvaluatorBase::DERIV_MV_GRADIENT_FORM) && !f_dist)
-            dfdp_layout = ROW;
-          else if (ds.supports(Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM) && !p_dist)
-            dfdp_layout = COL;
-          else
-            TEUCHOS_TEST_FOR_EXCEPTION(
-                true, std::logic_error,
-                std::endl << "Piro::NOXSolver::evalModel():  " <<
-                "For df/dp(" << i <<") with adjoint sensitivities, " <<
-                "underlying ModelEvaluator must support DERIV_LINEAR_OP, " <<
-                "DERIV_MV_JACOBIAN_FORM with p not distributed, or "
-                "DERIV_MV_GRADIENT_FORM with f not distributed." <<
-                std::endl);
-        }
-        if (dfdp_layout == COL) {
-          auto dfdp = Thyra::createMembers(f_space, num_params);
-          Thyra::ModelEvaluatorBase::DerivativeMultiVector<Scalar>
-          dmv_dfdp(dfdp, Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM);
-          modelOutArgs.set_DfDp(i,dmv_dfdp);
-        }
-        else if (dfdp_layout == ROW) {
-          auto dfdp = Thyra::createMembers(p_space, num_resids);
-
-          Thyra::ModelEvaluatorBase::DerivativeMultiVector<Scalar>
-          dmv_dfdp(dfdp, Thyra::ModelEvaluatorBase::DERIV_MV_GRADIENT_FORM);
-          modelOutArgs.set_DfDp(i,dmv_dfdp);
-        }
-        else if (dfdp_layout == OP) {
-          auto dfdp_op = this->getModel().create_DfDp_op(i);
-          TEUCHOS_TEST_FOR_EXCEPTION(
-              dfdp_op == Teuchos::null, std::logic_error,
-              std::endl << "Piro::NOXSolver::evalModel():  " <<
-              "Needed df/dp operator (" << i << ") is null!" << std::endl);
-          modelOutArgs.set_DfDp(i,dfdp_op);
-        }
-      }
-    }
-
-    for (int j=0; j<num_g; j++) {
-      // g
-      const RCP<Thyra::VectorBase<Scalar> > g_out = outArgs.get_g(j);
-      if (g_out != Teuchos::null) {
-        Thyra::put_scalar(0.0, g_out.ptr());
-        modelOutArgs.set_g(j, g_out);
-      }
-
-
-      // dg/dx
-      do_sens = false;
-      for (int i=0; i<num_p; i++) {
-        if (!outArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDp, j, i).none() &&
-            !outArgs.get_DgDp(j,i).isEmpty()) {
-          do_sens = true;
-        }
-      }
-      if (solving_sensitivities) {
-        auto g_space = this->getModel().get_g_space(j);
-        auto x_space = this->getModel().get_x_space();
-        int num_responses = g_space->dim();
-        int num_solution = x_space->dim();
-        auto g_space_plus = Teuchos::rcp_dynamic_cast<const Thyra::SpmdVectorSpaceDefaultBase<Scalar>>(g_space);
-        auto x_space_plus = Teuchos::rcp_dynamic_cast<const Thyra::SpmdVectorSpaceDefaultBase<Scalar>>(x_space);
-        bool g_dist = !g_space_plus->isLocallyReplicated();//g_space->DistributedGlobal();
-        bool x_dist = !x_space_plus->isLocallyReplicated();//x_space->DistributedGlobal();
-        DerivativeLayout dgdx_layout;
-        { //if (sensitivity_method == "Adjoint")
-          Thyra::ModelEvaluatorBase::DerivativeSupport ds =  modelOutArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDx,j);
-          if (ds.supports(Thyra::ModelEvaluatorBase::DERIV_MV_GRADIENT_FORM) && !g_dist)
-            dgdx_layout = ROW;
-          else if (ds.supports(Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM) && !x_dist)
-            dgdx_layout = COL;
-          else if (ds.supports(Thyra::ModelEvaluatorBase::DERIV_LINEAR_OP))
-            dgdx_layout = OP;
-          else
-            TEUCHOS_TEST_FOR_EXCEPTION(
-                true, std::logic_error,
-                std::endl << "Piro::NOXSolver::evalModel():  " <<
-                "For dg/dx(" << j <<") with adjoint sensitivities, " <<
-                "underlying ModelEvaluator must support DERIV_LINEAR_OP, " <<
-                "DERIV_MV_JACOBIAN_FORM with x not distributed, or "
-                "DERIV_MV_GRADIENT_FORM with g not distributed." <<
-                std::endl);
-        }
-
-        if (dgdx_layout == OP) {
-          auto dgdx_op = this->getModel().create_DgDx_op(j);
-          TEUCHOS_TEST_FOR_EXCEPTION(
-              dgdx_op == Teuchos::null, std::logic_error,
-              std::endl << "Piro::NOXSolver::evalModel():  " <<
-              "Needed dg/dx operator (" << j << ") is null!" << std::endl);
-          modelOutArgs.set_DgDx(j,dgdx_op);
-        }
-        else if (dgdx_layout == ROW) {
-          auto dgdx = Thyra::createMembers(x_space, num_responses);
-          Thyra::ModelEvaluatorBase::DerivativeMultiVector<Scalar>
-          dmv_dgdx(dgdx, Thyra::ModelEvaluatorBase::DERIV_MV_GRADIENT_FORM);
-          modelOutArgs.set_DgDx(j,dmv_dgdx);
-        }
-        else if (dgdx_layout == COL) {
-          auto dgdx = Thyra::createMembers(g_space, num_solution);
-          Thyra::ModelEvaluatorBase::DerivativeMultiVector<Scalar>
-          dmv_dgdx(dgdx, Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM);
-          modelOutArgs.set_DgDx(j,dmv_dgdx);
-        }
-
-        // dg/dp
-        for (int i=0; i<num_p; i++) {
-          if (!outArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDp,j,i).none()) {
-            Thyra::ModelEvaluatorBase::Derivative<Scalar> dgdp = outArgs.get_DgDp(j,i);
-            if (dgdp.getLinearOp() != Teuchos::null) {
-              auto p_space = this->getModel().get_p_space(i);
-              int num_params = p_space->dim();
-              auto p_space_plus = Teuchos::rcp_dynamic_cast<const Thyra::SpmdVectorSpaceDefaultBase<Scalar>>(p_space);
-              bool p_dist = !p_space_plus->isLocallyReplicated();//p_space->DistributedGlobal();
-              Thyra::ModelEvaluatorBase::DerivativeSupport ds = modelOutArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDp,j,i);
-              if (ds.supports(Thyra::ModelEvaluatorBase::DERIV_LINEAR_OP)) {
-                auto dgdp_op =
-                    this->getModel().create_DgDp_op(j,i);
-                TEUCHOS_TEST_FOR_EXCEPTION(
-                    dgdp_op == Teuchos::null, std::logic_error,
-                    std::endl << "Piro::NOXSolver::evalModel():  " <<
-                    "Needed dg/dp operator (" << j << "," << i << ") is null!" <<
-                    std::endl);
-                modelOutArgs.set_DgDp(j,i,dgdp_op);
-              }
-              else if (ds.supports(Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM) && !p_dist) {
-                auto tmp_dgdp = createMembers(g_space, num_params);
-                Thyra::ModelEvaluatorBase::DerivativeMultiVector<Scalar>
-                dmv_dgdp(tmp_dgdp, Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM);
-                modelOutArgs.set_DgDp(j,i,dmv_dgdp);
-              }
-              else if (ds.supports(Thyra::ModelEvaluatorBase::DERIV_MV_GRADIENT_FORM) && !g_dist) {
-                auto tmp_dgdp = createMembers(p_space, num_responses);
-                Thyra::ModelEvaluatorBase::DerivativeMultiVector<Scalar>
-                dmv_dgdp(tmp_dgdp, Thyra::ModelEvaluatorBase::DERIV_MV_GRADIENT_FORM);
-                modelOutArgs.set_DgDp(j,i,dmv_dgdp);
-              }
-              else
-                TEUCHOS_TEST_FOR_EXCEPTION(
-                    true, std::logic_error,
-                    std::endl << "Piro::NOXSolver::evalModel():  " <<
-                    "For dg/dp(" << j << "," << i <<
-                    ") with operator sensitivities, "<<
-                    "underlying ModelEvaluator must support DERIV_LINEAR_OP, " <<
-                    "DERIV_MV_JACOBIAN_FORM with p not distributed, or "
-                    "DERIV_MV_GRADIENT_FORM with g not distributed." <<
-                    std::endl);
-            }
-            else
-              modelOutArgs.set_DgDp(j,i,outArgs.get_DgDp(j,i));
-          }
-        }
-      }
-    }
-
-    // (1) Calculate g, df/dp, dg/dp, dg/dx
-    {
-      const auto timer = Teuchos::rcp(new Teuchos::TimeMonitor(*Teuchos::TimeMonitor::getNewTimer("Piro::NOXSolver::evalModelImpl::calc g, df/dp, dg/dp, dg/dx")));
-      this->getModel().evalModel(modelInArgs, modelOutArgs);
-    }
-
-
-    // Ensure Jacobian is up-to-date
-    if (solving_sensitivities) // Adjoint sensitivities
-    {
-
-      // Create implicitly transpose Jacobian and preconditioner
-      Teuchos::RCP< const Thyra::LinearOpWithSolveFactoryBase<double> > lows_factory = model->get_W_factory();
-      TEUCHOS_ASSERT(Teuchos::nonnull(lows_factory));
-      Teuchos::RCP< Thyra::LinearOpBase<double> > lop = model->create_W_op();
-      Teuchos::RCP< const ::Thyra::DefaultLinearOpSource<double> > losb = Teuchos::rcp(new ::Thyra::DefaultLinearOpSource<double>(lop));
-      Teuchos::RCP< ::Thyra::PreconditionerBase<double> > prec;
-
-      auto in_args = model->createInArgs();
-      auto out_args = model->createOutArgs();
-
-      Teuchos::RCP< ::Thyra::PreconditionerFactoryBase<double> > prec_factory =  lows_factory->getPreconditionerFactory();
-      if (Teuchos::nonnull(prec_factory)) {
-        prec = prec_factory->createPrec();
-      } else if (out_args.supports( Thyra::ModelEvaluatorBase::OUT_ARG_W_prec)) {
-        prec = model->create_W_prec();
-      }
-
-      const RCP<Thyra::LinearOpWithSolveBase<Scalar> > jacobian =
-          lows_factory->createOp();
-
-      {
-        const auto timer = Teuchos::rcp(new Teuchos::TimeMonitor(*Teuchos::TimeMonitor::getNewTimer("Piro::NOXSolver::evalModelImpl::evalModel")));
-        in_args.set_x(finalSolution);
-        out_args.set_W_op(lop);
-        model->evalModel(in_args, out_args);
-        in_args.set_x(Teuchos::null);
-        out_args.set_W_op(Teuchos::null);
-      }
-
-      if (Teuchos::nonnull(prec_factory))
-        prec_factory->initializePrec(losb, prec.get());
-      else if ( Teuchos::nonnull(prec) && (out_args.supports( Thyra::ModelEvaluatorBase::OUT_ARG_W_prec)) ) {
-        in_args.set_x(finalSolution);
-        out_args.set_W_prec(prec);
-        model->evalModel(in_args, out_args);
-      }
-
-      if(Teuchos::nonnull(prec))
-        Thyra::initializePreconditionedOp<double>(*lows_factory,
-            Thyra::transpose<double>(lop),
-            Thyra::unspecifiedPrec<double>(::Thyra::transpose<double>(prec->getUnspecifiedPrecOp())),
-            jacobian.ptr());
-      else
-        Thyra::initializeOp<double>(*lows_factory,
-            Thyra::transpose<double>(lop),
-            jacobian.ptr());
-
-
-      for (int j=0; j<num_g; j++) {
-
-        // See if there are any forward sensitivities we need to do
-        // that aren't handled by the operator
-        do_sens = false;
-        for (int i=0; i<num_p; i++) {
-          if (!outArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDp, j, i).none()) {
-            if (outArgs.get_DgDp(j,i).getMultiVector() != Teuchos::null)
-              do_sens = true;
-          }
-        }
-        if (!do_sens)
-          continue;
-
-        if (!modelOutArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDx, j).none()) {
-          TEUCHOS_TEST_FOR_EXCEPTION(
-              modelOutArgs.get_DgDx(j).getLinearOp()!=Teuchos::null,
-              std::logic_error,
-              std::endl << "Piro::NOXSolver::evalModel():  " <<
-              "Can\'t use dg/dx operator " << j << " with non-operator " <<
-              "adjoint sensitivities." << std::endl);
-          auto dgdx  = modelOutArgs.get_DgDx(j).getMultiVector();
-          if (dgdx != Teuchos::null) {
-            int num_cols = dgdx->domain()->dim();
-
-            // (2) Calculate xbar multivector from -(J^{-T}*dg/dx)
-
-            auto xbar = createMembers(dgdx->range(), num_cols);
-            {
-              Teuchos::TimeMonitor timer(*Teuchos::TimeMonitor::getNewTimer("Piro::NOXSolver::evalModelImpl::calc xbar"));
-              xbar->assign(0);
-              Thyra::solve(
-                  *jacobian,
-                  Thyra::NOTRANS,
-                  *dgdx,
-                  xbar.ptr(),
-                  Teuchos::ptr(&solve_criteria));
-
-              Thyra::scale(-1.0, xbar.ptr());
-            }
-
-            // (3) Calculate dg/dp^T = df/dp^T*xbar + dg/dp^T
-            for (int i=0; i<num_p; i++) {
-              std::string paramName = "Parameter " + std::to_string(i);
-              if(appParams->isSublist("Analysis")){
-                auto analysisParams = appParams->sublist("Analysis");
-                if (analysisParams.isSublist("ROL")) {
-                  std::ostringstream ss; ss << "Parameter Vector Index " << i;
-                  auto rolParams = analysisParams.sublist("ROL");
-                  const int p_ind = rolParams.get(ss.str(), i);
-                  const auto paramNames = *this->getModel().get_p_names(p_ind);
-                  paramName = paramNames[0];
-                }
-              }
-              std::ostringstream ss; ss << "Piro::NOXSolver::evalModelImpl::calc dg/dp^T(" << paramName << ")";
-              const auto timer = Teuchos::rcp(new Teuchos::TimeMonitor(*Teuchos::TimeMonitor::getNewTimer(ss.str())));
-              if (!outArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDp, j, i).none()) {
-                auto dgdp_out = outArgs.get_DgDp(j,i).getMultiVector();
-                if (dgdp_out != Teuchos::null) {
-                  Thyra::ModelEvaluatorBase::Derivative<Scalar> dfdp_dv = modelOutArgs.get_DfDp(i);
-                  auto dfdp_op = dfdp_dv.getLinearOp();
-                  auto dfdp = dfdp_dv.getMultiVector();
-                  Thyra::ModelEvaluatorBase::Derivative<Scalar> dgdx_dv = modelOutArgs.get_DgDx(j);
-                  if (dfdp_op != Teuchos::null) {
-                    Thyra::ModelEvaluatorBase::EDerivativeMultiVectorOrientation dgdp_orient =
-                        outArgs.get_DgDp(j,i).getMultiVectorOrientation();
-                    bool transpose = false;
-                    if (dgdp_orient == Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM)
-                      transpose = true;
-                    auto tmp = createMembers(dfdp_op->domain(),
-                        xbar->domain()->dim());
-
-                    dfdp_op->apply(Thyra::TRANS,*xbar, tmp.ptr(),1.0, 0.0);
-                    auto dgdp_range = Teuchos::rcp_dynamic_cast<const Thyra::SpmdVectorSpaceDefaultBase<Scalar>>(dgdp_out->range());
-
-                    if (transpose) {
-                      TEUCHOS_TEST_FOR_EXCEPTION(
-                          !dgdp_range->isLocallyReplicated(),
-                          //dgdp_out->Map().DistributedGlobal(),
-                          std::logic_error,
-                          std::endl <<
-                          "Piro::NOXSolver::evalModel():  " <<
-                          "Can\'t handle special case:  " <<
-                          " df/dp operator, " <<
-                          " transposed, distributed dg/dp. " << std::endl);
-                      Thyra::DetachedMultiVectorView<Scalar> dgdp_out_view(dgdp_out);
-                      Thyra::DetachedMultiVectorView<Scalar> tmp_view(tmp);
-                      for (int jj=0; jj<dgdp_out_view.numSubCols(); jj++)
-                        for (int ii=0; ii<dgdp_out_view.subDim(); ii++)
-                          dgdp_out_view(ii,jj) += tmp_view(jj,ii);
-                    }
-                    else {
-                      Thyra::update(1.0,  *tmp, dgdp_out.ptr());
-                    }
-                  }
-                  else {
-                    Teuchos::RCP<Thyra::MultiVectorBase<Scalar>> arg1, arg2;
-                    Thyra::ModelEvaluatorBase::EDerivativeMultiVectorOrientation dgdp_orient =
-                        modelOutArgs.get_DgDp(j,i).getMultiVectorOrientation();
-                    Thyra::ModelEvaluatorBase::EDerivativeMultiVectorOrientation dfdp_orient =
-                        modelOutArgs.get_DfDp(i).getMultiVectorOrientation();
-                    Thyra::ModelEvaluatorBase::EDerivativeMultiVectorOrientation dgdx_orient =
-                        modelOutArgs.get_DgDx(j).getMultiVectorOrientation();
-
-
-                    Thyra::DetachedMultiVectorView<Scalar> dgdp_out_view(dgdp_out);
-                    int sub_num_g = (dgdp_orient == Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM) ?
-                        dgdp_out_view.subDim() : dgdp_out_view.numSubCols();
-                    int sub_num_p = (dgdp_orient == Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM) ?
-                        dgdp_out_view.numSubCols() : dgdp_out_view.subDim();
-                    if(dgdp_orient == Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM){
-                      //dgdp (np columns of g_space vectors)
-
-                      if (dgdx_orient == Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM) {
-                        Thyra::DetachedMultiVectorView<Scalar> xbar_view(xbar);
-                        Thyra::DetachedMultiVectorView<Scalar> dfdp_view(dfdp);
-                        if (dfdp_orient == Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM) {
-                          for (int ip=0; ip<sub_num_p; ip++)
-                            for (int ig=0; i<sub_num_g; ig++) {
-                              for (int ix=0; ix<xbar_view.numSubCols(); ix++)
-                                dgdp_out_view(ip,ig) += xbar_view(ix,ig)*dfdp_view(ip,ix);
-                            }
-                        }
-                        else {
-                          for (int ip=0; ip<sub_num_p; ip++)
-                            for (int ig=0; ig<sub_num_g; ig++)
-                              for (int ix=0; ix<xbar_view.numSubCols(); ix++)
-                                dgdp_out_view(ip,ig) += xbar_view(ix,ig)*dfdp_view(ix,ip);
-                        }
-                      }
-                      else if (dfdp_orient == Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM) {
-                        for (int ip=0; ip<sub_num_p; ip++)
-                          for (int ig=0; ig<sub_num_g; ig++)
-                            dgdp_out_view(ip,ig) += Thyra::scalarProd(*xbar->col(ig),*dfdp->col(ip));
-                      }
-                      else {
-                        Thyra::DetachedMultiVectorView<Scalar> xbar_view(xbar);
-                        Thyra::DetachedMultiVectorView<Scalar> dfdp_view(dfdp);
-                        for (int ip=0; ip<dgdp_out_view.numSubCols(); ip++)
-                          for (int ig=0; ig<dgdp_out_view.subDim(); ig++)
-                            for (int ix=0; ix<xbar_view.subDim(); ix++)
-                              dgdp_out_view(ip,ig) += xbar_view(ig,ix)*dfdp_view(ix,ip);
-                      }
-                    }
-                    else {
-                      //dgdp (ng columns of p_space vectors)
-                      if (dgdx_orient == Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM) {
-                        Thyra::DetachedMultiVectorView<Scalar> xbar_view(xbar);
-                        Thyra::DetachedMultiVectorView<Scalar> dfdp_view(dfdp);
-                        if (dfdp_orient == Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM) {
-                          for (int ip=0; ip<sub_num_p; ip++)
-                            for (int ig=0; i<sub_num_g; ig++) {
-                              for (int ix=0; ix<xbar_view.numSubCols(); ix++)
-                                dgdp_out_view(ig,ip) += xbar_view(ix,ig)*dfdp_view(ip,ix);
-                            }
-                        }
-                        else {
-                          for (int ip=0; ip<sub_num_p; ip++)
-                            for (int ig=0; ig<sub_num_g; ig++)
-                              for (int ix=0; ix<xbar_view.numSubCols(); ix++)
-                                dgdp_out_view(ig,ip) += xbar_view(ix,ig)*dfdp_view(ix,ip);
-                        }
-                      }
-                      else if (dfdp_orient == Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM) {
-                        for (int ip=0; ip<sub_num_p; ip++)
-                          for (int ig=0; ig<sub_num_g; ig++)
-                            dgdp_out_view(ig,ip) += Thyra::scalarProd(*xbar->col(ig),*dfdp->col(ip));
-                      }
-                      else {
-                        Thyra::DetachedMultiVectorView<Scalar> xbar_view(xbar);
-                        Thyra::DetachedMultiVectorView<Scalar> dfdp_view(dfdp);
-                        for (int ip=0; ip<dgdp_out_view.subDim(); ip++)
-                          for (int ig=0; ig<dgdp_out_view.numSubCols(); ig++)
-                            for (int ix=0; ix<xbar_view.subDim(); ix++)
-                              dgdp_out_view(ig,ip) += xbar_view(ig,ix)*dfdp_view(ix,ip);
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }  //end of adjoint computation
+  this->evalConvergedModelResponsesAndSensitivities(modelInArgs, outArgs);
 
   if (Teuchos::nonnull(this->observer) && observeFinalSolution) {
     this->observer->observeSolution(*finalSolution);

--- a/packages/piro/src/Piro_SteadyStateSolver.hpp
+++ b/packages/piro/src/Piro_SteadyStateSolver.hpp
@@ -44,6 +44,7 @@
 #define PIRO_STEADYSTATESOLVER_HPP
 
 #include "Thyra_ResponseOnlyModelEvaluatorBase.hpp"
+#include "Piro_Helpers.hpp"
 
 namespace Piro {
 
@@ -103,6 +104,15 @@ class SteadyStateSolver
   /** \brief . */
   int num_g() const;
 
+  /** \brief . */
+  SENS_METHOD getSensitivityMethod();
+  //@}
+
+  /** \name Setters for subbclasses */
+  /** \brief . */
+  void setSensitivityMethod(const std::string& sensitivity_method_string);
+  //@}
+
   //@}
 
   protected:
@@ -110,7 +120,7 @@ class SteadyStateSolver
   //@{
 
   /** \brief . */
-  void evalConvergedModel(
+  void evalConvergedModelResponsesAndSensitivities(
       const Thyra::ModelEvaluatorBase::InArgs<Scalar>& modelInArgs,
       const Thyra::ModelEvaluatorBase::OutArgs<Scalar>& outArgs) const;
   //@}
@@ -135,6 +145,8 @@ class SteadyStateSolver
 
   int num_p_;
   int num_g_;
+
+  SENS_METHOD sensitivityMethod_;
 };
 
 }

--- a/packages/piro/src/Piro_SteadyStateSolver_Def.hpp
+++ b/packages/piro/src/Piro_SteadyStateSolver_Def.hpp
@@ -46,6 +46,8 @@
 #include "Piro_SteadyStateSolver.hpp"
 
 #include "Thyra_ModelEvaluatorHelpers.hpp"
+#include "Thyra_SpmdVectorSpaceDefaultBase.hpp"
+#include "Teuchos_TimeMonitor.hpp"
 
 #include "Thyra_DefaultScaledAdjointLinearOp.hpp"
 #include "Thyra_DefaultAddedLinearOp.hpp"
@@ -71,7 +73,8 @@ Piro::SteadyStateSolver<Scalar>::
 SteadyStateSolver(const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > &model) :
   model_(model),
   num_p_(model->Np()),
-  num_g_(model->Ng())
+  num_g_(model->Ng()),
+  sensitivityMethod_(NONE)
 {}
 
 template <typename Scalar>
@@ -81,7 +84,8 @@ SteadyStateSolver(
     int numParameters) :
   model_(model),
   num_p_(numParameters),
-  num_g_(model->Ng())
+  num_g_(model->Ng()),
+  sensitivityMethod_(NONE)
 {}
 
 template<typename Scalar>
@@ -89,9 +93,9 @@ Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
 Piro::SteadyStateSolver<Scalar>::get_p_space(int l) const
 {
   TEUCHOS_TEST_FOR_EXCEPTION(l >= num_p_ || l < 0, Teuchos::Exceptions::InvalidParameter,
-                     std::endl <<
-                     "Invalid parameter index l = " <<
-                     l << std::endl);
+      std::endl <<
+      "Invalid parameter index l = " <<
+      l << std::endl);
   return model_->get_p_space(l);
 }
 
@@ -100,9 +104,9 @@ Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> >
 Piro::SteadyStateSolver<Scalar>::get_g_space(int j) const
 {
   TEUCHOS_TEST_FOR_EXCEPTION(j > num_g_ || j < 0, Teuchos::Exceptions::InvalidParameter,
-                     std::endl <<
-                     "Invalid response index j = " <<
-                     j << std::endl);
+      std::endl <<
+      "Invalid response index j = " <<
+      j << std::endl);
 
   if (j < num_g_) {
     return model_->get_g_space(j);
@@ -191,26 +195,20 @@ Thyra::ModelEvaluatorBase::OutArgs<Scalar> Piro::SteadyStateSolver<Scalar>::crea
 
   const Thyra::ModelEvaluatorBase::OutArgs<Scalar> modelOutArgs = model_->createOutArgs();
 
-//  if(modelOutArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_f))
-//    std::cout << "supports OUT ARG f" << std::endl;
-//  else
-//    std::cout << "does NOT support OUT ARG f" << std::endl;
-
   result.setSupports(Thyra::ModelEvaluatorBase::OUT_ARG_f, modelOutArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_f));
-  //result.setSupports(Thyra::ModelEvaluatorBase::OUT_ARG_f, true);
 
-  // Sensitivity support (Forward approach only)
   // Jacobian solver required for all sensitivities
   if (modelOutArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_W)) {
     for (int l = 0; l < num_p_; ++l) {
+
       // Solution sensitivities: DxDp(l)
       // DfDp(l) required
       const Thyra::ModelEvaluatorBase::DerivativeSupport dfdp_support =
-        modelOutArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DfDp, l);
+          modelOutArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DfDp, l);
       const bool dxdp_linOpSupport =
-        dfdp_support.supports(Thyra::ModelEvaluatorBase::DERIV_LINEAR_OP);
+          dfdp_support.supports(Thyra::ModelEvaluatorBase::DERIV_LINEAR_OP);
       const bool dxdp_mvJacSupport =
-        dfdp_support.supports(Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM);
+          dfdp_support.supports(Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM);
       {
         Thyra::ModelEvaluatorBase::DerivativeSupport dxdp_support;
         if (dxdp_linOpSupport) {
@@ -228,15 +226,15 @@ Thyra::ModelEvaluatorBase::OutArgs<Scalar> Piro::SteadyStateSolver<Scalar>::crea
         for (int j = 0; j < num_g_; ++j) {
           // DgDx(j) required
           const Thyra::ModelEvaluatorBase::DerivativeSupport dgdx_support =
-            modelOutArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDx, j);
+              modelOutArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDx, j);
           const bool dgdx_linOpSupport =
-            dgdx_support.supports(Thyra::ModelEvaluatorBase::DERIV_LINEAR_OP);
+              dgdx_support.supports(Thyra::ModelEvaluatorBase::DERIV_LINEAR_OP);
           const bool dgdx_mvGradSupport =
-            dgdx_support.supports(Thyra::ModelEvaluatorBase::DERIV_MV_GRADIENT_FORM);
+              dgdx_support.supports(Thyra::ModelEvaluatorBase::DERIV_MV_GRADIENT_FORM);
           if (dgdx_linOpSupport || dgdx_mvGradSupport) {
             // Dgdp(j, l) required
             const Thyra::ModelEvaluatorBase::DerivativeSupport dgdp_support =
-              modelOutArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDp, j, l);
+                modelOutArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDp, j, l);
             Thyra::ModelEvaluatorBase::DerivativeSupport total_dgdp_support;
             if (dgdp_support.supports(Thyra::ModelEvaluatorBase::DERIV_LINEAR_OP) &&
                 dgdx_linOpSupport && dxdp_linOpSupport) {
@@ -293,65 +291,82 @@ Piro::SteadyStateSolver<Scalar>::num_g() const
 }
 
 template <typename Scalar>
-void Piro::SteadyStateSolver<Scalar>::evalConvergedModel(
+void
+Piro::SteadyStateSolver<Scalar>::setSensitivityMethod(const std::string& sensitivity_method_string)
+{
+  if (sensitivity_method_string == "None") sensitivityMethod_ = NONE;
+  else if (sensitivity_method_string == "Forward") sensitivityMethod_ = FORWARD;
+  else if (sensitivity_method_string == "Adjoint") sensitivityMethod_ = ADJOINT;
+  else {
+    TEUCHOS_TEST_FOR_EXCEPTION(true, Teuchos::Exceptions::InvalidParameter,
+        "\n Error! Piro::SteadyStateSolver: invalid Sensitivity Method = " << sensitivity_method_string << "! \n"
+        << " Valid options for Sensitivity Method are 'None', 'Forward' and 'Adjoint'.\n");
+  }
+}
+
+template <typename Scalar>
+Piro::SENS_METHOD
+Piro::SteadyStateSolver<Scalar>::getSensitivityMethod()
+{
+  return sensitivityMethod_;
+}
+
+template <typename Scalar>
+void Piro::SteadyStateSolver<Scalar>::evalConvergedModelResponsesAndSensitivities(
     const Thyra::ModelEvaluatorBase::InArgs<Scalar>& modelInArgs,
     const Thyra::ModelEvaluatorBase::OutArgs<Scalar>& outArgs) const
 {
   using Teuchos::RCP;
   using Teuchos::rcp;
 
-  //int g_size = 0;  // Commenting out since g_size is not used.
   // Solution at convergence is the response at index num_g_
   {
     const RCP<Thyra::VectorBase<Scalar> > gx_out = outArgs.get_g(num_g_);
     if (Teuchos::nonnull(gx_out)) {
-      //g_size = gx_out->space()->dim();
       Thyra::copy(*modelInArgs.get_x(), gx_out.ptr());
     }
   }
 
   // Setup output for final evalution of underlying model
   Thyra::ModelEvaluatorBase::OutArgs<Scalar> modelOutArgs = model_->createOutArgs();
-  {
-    // Responses
-    for (int j = 0; j < num_g_; ++j) {
-      const RCP<Thyra::VectorBase<Scalar> > g_out = outArgs.get_g(j);
-      // Forward to underlying model
+
+  // Responses
+  for (int j = 0; j < num_g_; ++j) {
+    const RCP<Thyra::VectorBase<Scalar> > g_out = outArgs.get_g(j);
+    if (Teuchos::nonnull(g_out)) {
+      Thyra::put_scalar(0.0, g_out.ptr());
       modelOutArgs.set_g(j, g_out);
     }
+  }
 
+  bool compute_sensitivities = false;
+  for (int j = 0; j <= num_g_; ++j) { // resize
+    for (int l = 0; l < num_p_; ++l) {
+      if (!outArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDp, j, l).none() && !outArgs.get_DgDp(j, l).isEmpty()) {
+        compute_sensitivities = true;
+      }
+    }
+  }
+
+  bool computeForwardSensitivities = compute_sensitivities && (sensitivityMethod_==FORWARD);
+  bool computeAdjointSensitivities = compute_sensitivities && (sensitivityMethod_==ADJOINT);
+
+  if(computeForwardSensitivities)
+  {
     // Jacobian
-    {
-      bool jacobianRequired = false;
-      for (int j = 0; j <= num_g_; ++j) { // resize
-        for (int l = 0; l < num_p_; ++l) {
-          const Thyra::ModelEvaluatorBase::DerivativeSupport dgdp_support =
-            outArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDp, j, l);
-          if (!dgdp_support.none()) {
-            const Thyra::ModelEvaluatorBase::Derivative<Scalar> dgdp_deriv =
-              outArgs.get_DgDp(j, l);
-            if (!dgdp_deriv.isEmpty()) {
-              jacobianRequired = true;
-            }
-          }
-        }
-      }
-      if (jacobianRequired) {
-        const RCP<Thyra::LinearOpWithSolveBase<Scalar> > jacobian =
+    if (compute_sensitivities) {
+      const RCP<Thyra::LinearOpWithSolveBase<Scalar> > jacobian =
           model_->create_W();
-        modelOutArgs.set_W(jacobian);
-      }
+      modelOutArgs.set_W(jacobian);
     }
 
     // DfDp derivatives
     for (int l = 0; l < num_p_; ++l) {
       Thyra::ModelEvaluatorBase::DerivativeSupport dfdp_request;
       for (int j = 0; j <= num_g_; ++j) {
-        const Thyra::ModelEvaluatorBase::DerivativeSupport dgdp_support =
-          outArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDp, j, l);
-        if (!dgdp_support.none()) {
+        if(!outArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDp, j, l).none()) {
           const Thyra::ModelEvaluatorBase::Derivative<Scalar> dgdp_deriv =
-            outArgs.get_DgDp(j, l);
+              outArgs.get_DgDp(j, l);
           if (Teuchos::nonnull(dgdp_deriv.getLinearOp())) {
             dfdp_request.plus(Thyra::ModelEvaluatorBase::DERIV_LINEAR_OP);
           } else if (Teuchos::nonnull(dgdp_deriv.getMultiVector())) {
@@ -375,15 +390,13 @@ void Piro::SteadyStateSolver<Scalar>::evalConvergedModel(
     for (int j = 0; j < num_g_; ++j) {
       Thyra::ModelEvaluatorBase::DerivativeSupport dgdx_request;
       for (int l = 0; l < num_p_; ++l) {
-        const Thyra::ModelEvaluatorBase::DerivativeSupport dgdp_support =
-          outArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDp, j, l);
-        if (!dgdp_support.none()) {
+        if (!outArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDp, j, l).none()) {
           const Thyra::ModelEvaluatorBase::Derivative<Scalar> dgdp_deriv =
-            outArgs.get_DgDp(j, l);
+              outArgs.get_DgDp(j, l);
           if (!dgdp_deriv.isEmpty()) {
             const bool dgdp_mvGrad_required =
-              Teuchos::nonnull(dgdp_deriv.getMultiVector()) &&
-              dgdp_deriv.getMultiVectorOrientation() == Thyra::ModelEvaluatorBase::DERIV_MV_GRADIENT_FORM;
+                Teuchos::nonnull(dgdp_deriv.getMultiVector()) &&
+                dgdp_deriv.getMultiVectorOrientation() == Thyra::ModelEvaluatorBase::DERIV_MV_GRADIENT_FORM;
             if (dgdp_mvGrad_required) {
               dgdx_request.plus(Thyra::ModelEvaluatorBase::DERIV_MV_GRADIENT_FORM);
             } else {
@@ -407,11 +420,9 @@ void Piro::SteadyStateSolver<Scalar>::evalConvergedModel(
     // DgDp derivatives
     for (int l = 0; l < num_p_; ++l) {
       for (int j = 0; j < num_g_; ++j) {
-        const Thyra::ModelEvaluatorBase::DerivativeSupport dgdp_support =
-          outArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDp, j, l);
-        if (!dgdp_support.none()) {
+        if (!outArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDp, j, l).none()) {
           const Thyra::ModelEvaluatorBase::Derivative<Scalar> dgdp_deriv =
-            outArgs.get_DgDp(j, l);
+              outArgs.get_DgDp(j, l);
           Thyra::ModelEvaluatorBase::Derivative<Scalar> model_dgdp_deriv;
           const RCP<Thyra::LinearOpBase<Scalar> > dgdp_op = dgdp_deriv.getLinearOp();
           if (Teuchos::nonnull(dgdp_op)) {
@@ -425,180 +436,597 @@ void Piro::SteadyStateSolver<Scalar>::evalConvergedModel(
         }
       }
     }
+  } else if(computeAdjointSensitivities) {
+    // Compute adjoint layouts of df/dp, dg/dx depending on
+    for (int i=0; i<num_p_; i++) {
+      // p
+      //modelInArgs.set_p(i, inArgs.get_p(i));
+
+      // df/dp
+      bool compute_sensitivities_wrt_pi = false;
+      for (int j=0; j<=num_g_; j++) {
+        if (!outArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDp, j, i).none() &&
+            !outArgs.get_DgDp(j,i).isEmpty()) {
+          compute_sensitivities_wrt_pi = true;
+        }
+      }
+
+      if (compute_sensitivities_wrt_pi) {
+        auto p_space = this->getModel().get_p_space(i);
+        auto f_space = this->getModel().get_f_space();
+        auto p_space_plus = Teuchos::rcp_dynamic_cast<const Thyra::SpmdVectorSpaceDefaultBase<Scalar>>(p_space);
+        auto f_space_plus = Teuchos::rcp_dynamic_cast<const Thyra::SpmdVectorSpaceDefaultBase<Scalar>>(f_space);
+        Thyra::ModelEvaluatorBase::DerivativeSupport ds =  modelOutArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DfDp,i);
+
+        // Determine which layout to use for df/dp.  Ideally one would look
+        // at num_params, num_resids, what is supported by the underlying
+        // model evaluator, and the sensitivity method, and make the best
+        // choice to minimze the number of solves.  However this choice depends
+        // also on what layout of dg/dx is supported (e.g., if only the operator
+        // form is supported for forward sensitivities, then df/dp must be
+        // DERIV_MV_JACOBIAN_FORM).  For simplicity, we order the conditional tests
+        // to get the right layout in most situations.
+
+        if (ds.supports(Thyra::ModelEvaluatorBase::DERIV_LINEAR_OP)) {
+          auto dfdp_op = this->getModel().create_DfDp_op(i);
+          TEUCHOS_TEST_FOR_EXCEPTION(
+              dfdp_op == Teuchos::null, std::logic_error,
+              std::endl << "Piro::SteadyStateSolver::evalConvergedModelResponsesAndSensitivities():  " <<
+              "Needed df/dp operator (" << i << ") is null!" << std::endl);
+          modelOutArgs.set_DfDp(i,dfdp_op);
+        } else {
+          /*
+          TEUCHOS_TEST_FOR_EXCEPTION(
+            !ds.supports(Thyra::ModelEvaluatorBase::DERIV_LINEAR_OP),
+            std::logic_error,
+            std::endl <<
+            "ROL::Piro::SteadyStateSolver::evalConvergedModelResponsesAndSensitivities():  " <<
+            "The code related to df/dp multivector has been commented out because never tested.  " <<
+            std::endl);
+
+          if (ds.supports(Thyra::ModelEvaluatorBase::DERIV_MV_GRADIENT_FORM) &&
+              f_space_plus->isLocallyReplicated()) {
+            auto dfdp = Thyra::createMembers(p_space, f_space->dim());
+
+            Thyra::ModelEvaluatorBase::DerivativeMultiVector<Scalar>
+            dmv_dfdp(dfdp, Thyra::ModelEvaluatorBase::DERIV_MV_GRADIENT_FORM);
+            modelOutArgs.set_DfDp(i,dmv_dfdp);
+          } else if (ds.supports(Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM) &&
+                     p_space_plus->isLocallyReplicated()) {
+            auto dfdp = Thyra::createMembers(f_space, p_space->dim());
+            Thyra::ModelEvaluatorBase::DerivativeMultiVector<Scalar>
+            dmv_dfdp(dfdp, Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM);
+            modelOutArgs.set_DfDp(i,dmv_dfdp);
+          } else
+            TEUCHOS_TEST_FOR_EXCEPTION(
+                true, std::logic_error,
+                std::endl << "Piro::SteadyStateSolver::evalConvergedModelResponsesAndSensitivities():  " <<
+                "For df/dp(" << i <<") with adjoint sensitivities, " <<
+                "underlying ModelEvaluator must support DERIV_LINEAR_OP, " <<
+                "DERIV_MV_JACOBIAN_FORM with p not distributed, or "
+                "DERIV_MV_GRADIENT_FORM with f not distributed." <<
+                std::endl);
+          */
+        }
+      }
+    }
+
+    for (int j=0; j<num_g_; j++) {
+      // dg/dx
+      bool compute_gj_sensitivities = false;
+      for (int i=0; i<num_p_; i++) {
+        if (!outArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDp, j, i).none() &&
+            !outArgs.get_DgDp(j,i).isEmpty()) {
+          compute_gj_sensitivities = true;
+        }
+      }
+      if (compute_gj_sensitivities) {
+        auto g_space = this->getModel().get_g_space(j);
+        auto x_space = this->getModel().get_x_space();
+        int num_responses = g_space->dim();
+        int num_solution = x_space->dim();
+        auto g_space_plus = Teuchos::rcp_dynamic_cast<const Thyra::SpmdVectorSpaceDefaultBase<Scalar>>(g_space);
+        auto x_space_plus = Teuchos::rcp_dynamic_cast<const Thyra::SpmdVectorSpaceDefaultBase<Scalar>>(x_space);
+        bool g_dist = !g_space_plus->isLocallyReplicated();//g_space->DistributedGlobal();
+        bool x_dist = !x_space_plus->isLocallyReplicated();//x_space->DistributedGlobal();
+
+
+        Thyra::ModelEvaluatorBase::DerivativeSupport ds =  modelOutArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDx,j);
+        if (ds.supports(Thyra::ModelEvaluatorBase::DERIV_MV_GRADIENT_FORM) && !g_dist) {
+          auto dgdx = Thyra::createMembers(x_space, num_responses);
+          Thyra::ModelEvaluatorBase::DerivativeMultiVector<Scalar>
+          dmv_dgdx(dgdx, Thyra::ModelEvaluatorBase::DERIV_MV_GRADIENT_FORM);
+          modelOutArgs.set_DgDx(j,dmv_dgdx);
+        } else if (ds.supports(Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM) && !x_dist) {
+          auto dgdx = Thyra::createMembers(g_space, num_solution);
+          Thyra::ModelEvaluatorBase::DerivativeMultiVector<Scalar>
+          dmv_dgdx(dgdx, Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM);
+          modelOutArgs.set_DgDx(j,dmv_dgdx);
+        } else if (ds.supports(Thyra::ModelEvaluatorBase::DERIV_LINEAR_OP)) {
+          auto dgdx_op = this->getModel().create_DgDx_op(j);
+          TEUCHOS_TEST_FOR_EXCEPTION(
+              dgdx_op == Teuchos::null, std::logic_error,
+              std::endl << "Piro::SteadyStateSolver::evalConvergedModelResponsesAndSensitivities():  " <<
+              "Needed dg/dx operator (" << j << ") is null!" << std::endl);
+          modelOutArgs.set_DgDx(j,dgdx_op);
+        } else
+          TEUCHOS_TEST_FOR_EXCEPTION(
+              true, std::logic_error,
+              std::endl << "Piro::SteadyStateSolver::evalConvergedModelResponsesAndSensitivities():  " <<
+              "For dg/dx(" << j <<") with adjoint sensitivities, " <<
+              "underlying ModelEvaluator must support DERIV_LINEAR_OP, " <<
+              "DERIV_MV_JACOBIAN_FORM with x not distributed, or "
+              "DERIV_MV_GRADIENT_FORM with g not distributed." <<
+              std::endl);
+
+        // dg/dp
+        for (int i=0; i<num_p_; i++) {
+          if (!outArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDp,j,i).none()) {
+            Thyra::ModelEvaluatorBase::Derivative<Scalar> dgdp = outArgs.get_DgDp(j,i);
+            if (dgdp.getLinearOp() != Teuchos::null) {
+              auto p_space = this->getModel().get_p_space(i);
+              int num_params = p_space->dim();
+              auto p_space_plus = Teuchos::rcp_dynamic_cast<const Thyra::SpmdVectorSpaceDefaultBase<Scalar>>(p_space);
+              bool p_dist = !p_space_plus->isLocallyReplicated();//p_space->DistributedGlobal();
+              Thyra::ModelEvaluatorBase::DerivativeSupport ds = modelOutArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDp,j,i);
+              if (ds.supports(Thyra::ModelEvaluatorBase::DERIV_LINEAR_OP)) {
+                auto dgdp_op =
+                    this->getModel().create_DgDp_op(j,i);
+                TEUCHOS_TEST_FOR_EXCEPTION(
+                    dgdp_op == Teuchos::null, std::logic_error,
+                    std::endl << "Piro::SteadyStateSolver::evalConvergedModelResponsesAndSensitivities():  " <<
+                    "Needed dg/dp operator (" << j << "," << i << ") is null!" <<
+                    std::endl);
+                modelOutArgs.set_DgDp(j,i,dgdp_op);
+              }
+              else if (ds.supports(Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM) && !p_dist) {
+                auto tmp_dgdp = createMembers(g_space, num_params);
+                Thyra::ModelEvaluatorBase::DerivativeMultiVector<Scalar>
+                dmv_dgdp(tmp_dgdp, Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM);
+                modelOutArgs.set_DgDp(j,i,dmv_dgdp);
+              }
+              else if (ds.supports(Thyra::ModelEvaluatorBase::DERIV_MV_GRADIENT_FORM) && !g_dist) {
+                auto tmp_dgdp = createMembers(p_space, num_responses);
+                Thyra::ModelEvaluatorBase::DerivativeMultiVector<Scalar>
+                dmv_dgdp(tmp_dgdp, Thyra::ModelEvaluatorBase::DERIV_MV_GRADIENT_FORM);
+                modelOutArgs.set_DgDp(j,i,dmv_dgdp);
+              }
+              else
+                TEUCHOS_TEST_FOR_EXCEPTION(
+                    true, std::logic_error,
+                    std::endl << "Piro::SteadyStateSolver::evalConvergedModelResponsesAndSensitivities():  " <<
+                    "For dg/dp(" << j << "," << i <<
+                    ") with operator sensitivities, "<<
+                    "underlying ModelEvaluator must support DERIV_LINEAR_OP, " <<
+                    "DERIV_MV_JACOBIAN_FORM with p not distributed, or "
+                    "DERIV_MV_GRADIENT_FORM with g not distributed." <<
+                    std::endl);
+            }
+            else
+              modelOutArgs.set_DgDp(j,i,outArgs.get_DgDp(j,i));
+          }
+        }
+      }
+    }
   }
 
-  // Evaluate underlying model
-  model_->evalModel(modelInArgs, modelOutArgs);
+  // Calculate g, df/dp, dg/dp, dg/dx by evaluating the underlying model
+  {
+    const auto timer = Teuchos::rcp(new Teuchos::TimeMonitor(*Teuchos::TimeMonitor::getNewTimer("Piro::SteadyStateSolver::evalConvergedModelResponsesAndSensitivities::calc g, df/dp, dg/dp, dg/dx")));
+    model_->evalModel(modelInArgs, modelOutArgs);
+  }
 
-  // Assemble user-requested sensitivities
-  if (modelOutArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_W)) {
-    const RCP<Thyra::LinearOpWithSolveBase<Scalar> > jacobian =
-      modelOutArgs.get_W();
-    if (Teuchos::nonnull(jacobian)) {
-      for (int l = 0; l < num_p_; ++l) {
-        const Thyra::ModelEvaluatorBase::DerivativeSupport dfdp_support =
-          modelOutArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DfDp, l);
-        if (!dfdp_support.none()) {
-          const Thyra::ModelEvaluatorBase::Derivative<Scalar> dfdp_deriv =
-            modelOutArgs.get_DfDp(l);
-          const RCP<Thyra::MultiVectorBase<Scalar> > dfdp_mv =
-            dfdp_deriv.getMultiVector();
-          RCP<Thyra::LinearOpBase<Scalar> > dfdp_op =
-            dfdp_deriv.getLinearOp();
-          if (Teuchos::is_null(dfdp_op)) {
-            dfdp_op = dfdp_mv;
-          }
 
-          const Thyra::ModelEvaluatorBase::Derivative<Scalar> dxdp_deriv =
-            outArgs.get_DgDp(num_g_, l);
-          const RCP<Thyra::LinearOpBase<Scalar> > dxdp_op =
-            dxdp_deriv.getLinearOp();
-          const RCP<Thyra::MultiVectorBase<Scalar> > dxdp_mv =
-            dxdp_deriv.getMultiVector();
+  if(computeForwardSensitivities) {
 
-          RCP<const Thyra::LinearOpBase<Scalar> > minus_dxdp_op;
-          RCP<Thyra::MultiVectorBase<Scalar> > minus_dxdp_mv;
-          if (Teuchos::nonnull(dfdp_mv)) {
-            if (Teuchos::nonnull(dxdp_mv)) {
-              minus_dxdp_mv = dxdp_mv; // Use user-provided object as temporary
-            } else {
-              minus_dxdp_mv =
-                Thyra::createMembers(model_->get_x_space(), model_->get_p_space(l));
-              minus_dxdp_op = minus_dxdp_mv;
+    // Assemble user-requested sensitivities
+    if (modelOutArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_W)) {
+      const RCP<Thyra::LinearOpWithSolveBase<Scalar> > jacobian =
+          modelOutArgs.get_W();
+      if (Teuchos::nonnull(jacobian)) {
+        for (int l = 0; l < num_p_; ++l) {
+          const Thyra::ModelEvaluatorBase::DerivativeSupport dfdp_support =
+              modelOutArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DfDp, l);
+          if (!dfdp_support.none()) {
+            const Thyra::ModelEvaluatorBase::Derivative<Scalar> dfdp_deriv =
+                modelOutArgs.get_DfDp(l);
+            const RCP<Thyra::MultiVectorBase<Scalar> > dfdp_mv =
+                dfdp_deriv.getMultiVector();
+            RCP<Thyra::LinearOpBase<Scalar> > dfdp_op =
+                dfdp_deriv.getLinearOp();
+            if (Teuchos::is_null(dfdp_op)) {
+              dfdp_op = dfdp_mv;
             }
-          }
 
-          if (Teuchos::is_null(minus_dxdp_op) && Teuchos::nonnull(dfdp_op)) {
-            const RCP<const Thyra::LinearOpBase<Scalar> > dfdx_inv_op =
-              Thyra::inverse<Scalar>(jacobian);
-            minus_dxdp_op = Thyra::multiply<Scalar>(dfdx_inv_op, dfdp_op);
-          }
+            const Thyra::ModelEvaluatorBase::Derivative<Scalar> dxdp_deriv =
+                outArgs.get_DgDp(num_g_, l);
+            const RCP<Thyra::LinearOpBase<Scalar> > dxdp_op =
+                dxdp_deriv.getLinearOp();
+            const RCP<Thyra::MultiVectorBase<Scalar> > dxdp_mv =
+                dxdp_deriv.getMultiVector();
 
-          if (Teuchos::nonnull(minus_dxdp_mv) && Teuchos::nonnull(dfdp_mv)) {
-            Thyra::assign(minus_dxdp_mv.ptr(), Teuchos::ScalarTraits<Scalar>::zero());
+            RCP<const Thyra::LinearOpBase<Scalar> > minus_dxdp_op;
+            RCP<Thyra::MultiVectorBase<Scalar> > minus_dxdp_mv;
+            if (Teuchos::nonnull(dfdp_mv)) {
+              if (Teuchos::nonnull(dxdp_mv)) {
+                minus_dxdp_mv = dxdp_mv; // Use user-provided object as temporary
+              } else {
+                minus_dxdp_mv =
+                    Thyra::createMembers(model_->get_x_space(), model_->get_p_space(l));
+                minus_dxdp_op = minus_dxdp_mv;
+              }
+            }
 
-            const Thyra::SolveCriteria<Scalar> defaultSolveCriteria;
-            const Thyra::SolveStatus<Scalar> solveStatus =
-              Thyra::solve(
-                  *jacobian,
-                  Thyra::NOTRANS,
-                  *dfdp_mv,
-                  minus_dxdp_mv.ptr(),
-                  Teuchos::ptr(&defaultSolveCriteria));
+            if (Teuchos::is_null(minus_dxdp_op) && Teuchos::nonnull(dfdp_op)) {
+              const RCP<const Thyra::LinearOpBase<Scalar> > dfdx_inv_op =
+                  Thyra::inverse<Scalar>(jacobian);
+              minus_dxdp_op = Thyra::multiply<Scalar>(dfdx_inv_op, dfdp_op);
+            }
 
-            //  AGS: Made this a warning instead of exception since it is 'just' post-processing
-            if (solveStatus.solveStatus == Thyra::SOLVE_STATUS_UNCONVERGED)
-              *(Teuchos::VerboseObjectBase::getDefaultOStream() ) <<
-              "\nWARNING: Linear Solver in sensitivity computation failed to fully converge\n"
-              << "         Accuracy of sensitivity calculations is less then requested." << std::endl;
-          }
+            if (Teuchos::nonnull(minus_dxdp_mv) && Teuchos::nonnull(dfdp_mv)) {
+              Thyra::assign(minus_dxdp_mv.ptr(), Teuchos::ScalarTraits<Scalar>::zero());
 
-          // Solution sensitivities
-          if (Teuchos::nonnull(dxdp_mv)) {
-            minus_dxdp_mv = Teuchos::null; // Invalidates temporary
-            Thyra::scale(-Teuchos::ScalarTraits<Scalar>::one(), dxdp_mv.ptr());
-          } else if (Teuchos::nonnull(dxdp_op)) {
-            const RCP<Thyra::DefaultMultipliedLinearOp<Scalar> > dxdp_op_downcasted =
-              Teuchos::rcp_dynamic_cast<Thyra::DefaultMultipliedLinearOp<Scalar> >(dxdp_op);
-            TEUCHOS_TEST_FOR_EXCEPTION(
-                Teuchos::is_null(dxdp_op_downcasted),
-                std::invalid_argument,
-                "Illegal operator for DgDp(" <<
-                "j = " << num_g_ << ", " <<
-                "index l = " << l << ")\n");
+              const Thyra::SolveCriteria<Scalar> defaultSolveCriteria;
+              const Thyra::SolveStatus<Scalar> solveStatus =
+                  Thyra::solve(
+                      *jacobian,
+                      Thyra::NOTRANS,
+                      *dfdp_mv,
+                      minus_dxdp_mv.ptr(),
+                      Teuchos::ptr(&defaultSolveCriteria));
 
-            const RCP<const Thyra::LinearOpBase<Scalar> > minus_id_op =
-              Thyra::scale<Scalar>(-Teuchos::ScalarTraits<Scalar>::one(), Thyra::identity(dfdp_op->domain()));
+              //  AGS: Made this a warning instead of exception since it is 'just' post-processing
+              if (solveStatus.solveStatus == Thyra::SOLVE_STATUS_UNCONVERGED)
+                *(Teuchos::VerboseObjectBase::getDefaultOStream() ) <<
+                "\nWARNING: Linear Solver in sensitivity computation failed to fully converge\n"
+                << "         Accuracy of sensitivity calculations is less then requested." << std::endl;
+            }
 
-            dxdp_op_downcasted->initialize(Teuchos::tuple(minus_dxdp_op, minus_id_op));
-          }
+            // Solution sensitivities
+            if (Teuchos::nonnull(dxdp_mv)) {
+              minus_dxdp_mv = Teuchos::null; // Invalidates temporary
+              Thyra::scale(-Teuchos::ScalarTraits<Scalar>::one(), dxdp_mv.ptr());
+            } else if (Teuchos::nonnull(dxdp_op)) {
+              const RCP<Thyra::DefaultMultipliedLinearOp<Scalar> > dxdp_op_downcasted =
+                  Teuchos::rcp_dynamic_cast<Thyra::DefaultMultipliedLinearOp<Scalar> >(dxdp_op);
+              TEUCHOS_TEST_FOR_EXCEPTION(
+                  Teuchos::is_null(dxdp_op_downcasted),
+                  std::invalid_argument,
+                  "Illegal operator for DgDp(" <<
+                  "j = " << num_g_ << ", " <<
+                  "index l = " << l << ")\n");
 
-          // Response sensitivities
-          for (int j = 0; j < num_g_; ++j) {
-            const Thyra::ModelEvaluatorBase::DerivativeSupport dgdp_support =
-              outArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDp, j, l);
-            if (!dgdp_support.none()) {
-              const Thyra::ModelEvaluatorBase::Derivative<Scalar> dgdp_deriv =
-                outArgs.get_DgDp(j, l);
-              if (!dgdp_deriv.isEmpty()) {
-                const Thyra::ModelEvaluatorBase::Derivative<Scalar> dgdx_deriv =
-                  modelOutArgs.get_DgDx(j);
-                const RCP<const Thyra::MultiVectorBase<Scalar> > dgdx_mv =
-                  dgdx_deriv.getMultiVector();
-                RCP<const Thyra::LinearOpBase<Scalar> > dgdx_op =
-                  dgdx_deriv.getLinearOp();
-                if (Teuchos::is_null(dgdx_op)) {
-                  dgdx_op = Thyra::adjoint<Scalar>(dgdx_mv);
-                }
+              const RCP<const Thyra::LinearOpBase<Scalar> > minus_id_op =
+                  Thyra::scale<Scalar>(-Teuchos::ScalarTraits<Scalar>::one(), Thyra::identity(dfdp_op->domain()));
 
-                const RCP<Thyra::LinearOpBase<Scalar> > dgdp_op =
-                  dgdp_deriv.getLinearOp();
-                if (Teuchos::nonnull(dgdp_op)) {
-                  const RCP<Thyra::DefaultAddedLinearOp<Scalar> > dgdp_op_downcasted =
-                    Teuchos::rcp_dynamic_cast<Thyra::DefaultAddedLinearOp<Scalar> >(dgdp_op);
-                  TEUCHOS_TEST_FOR_EXCEPTION(
-                      Teuchos::is_null(dgdp_op_downcasted),
-                      std::invalid_argument,
-                      "Illegal operator for DgDp(" <<
-                      "j = " << j << ", " <<
-                      "index l = " << l << ")\n");
+              dxdp_op_downcasted->initialize(Teuchos::tuple(minus_dxdp_op, minus_id_op));
+            }
 
-                  dgdp_op_downcasted->uninitialize();
+            // Response sensitivities
+            for (int j = 0; j < num_g_; ++j) {
+              if (!outArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDp, j, l).none()) {
+                const Thyra::ModelEvaluatorBase::Derivative<Scalar> dgdp_deriv =
+                    outArgs.get_DgDp(j, l);
+                if (!dgdp_deriv.isEmpty()) {
+                  const Thyra::ModelEvaluatorBase::Derivative<Scalar> dgdx_deriv =
+                      modelOutArgs.get_DgDx(j);
+                  const RCP<const Thyra::MultiVectorBase<Scalar> > dgdx_mv =
+                      dgdx_deriv.getMultiVector();
+                  RCP<const Thyra::LinearOpBase<Scalar> > dgdx_op =
+                      dgdx_deriv.getLinearOp();
+                  if (Teuchos::is_null(dgdx_op)) {
+                    dgdx_op = Thyra::adjoint<Scalar>(dgdx_mv);
+                  }
 
-                  const RCP<const Thyra::LinearOpBase<Scalar> > implicit_dgdp_op =
-                    Thyra::multiply<Scalar>(
-                      Thyra::scale<Scalar>(-Teuchos::ScalarTraits<Scalar>::one(), dgdx_op),
-                      minus_dxdp_op);
+                  const RCP<Thyra::LinearOpBase<Scalar> > dgdp_op =
+                      dgdp_deriv.getLinearOp();
+                  if (Teuchos::nonnull(dgdp_op)) {
+                    const RCP<Thyra::DefaultAddedLinearOp<Scalar> > dgdp_op_downcasted =
+                        Teuchos::rcp_dynamic_cast<Thyra::DefaultAddedLinearOp<Scalar> >(dgdp_op);
+                    TEUCHOS_TEST_FOR_EXCEPTION(
+                        Teuchos::is_null(dgdp_op_downcasted),
+                        std::invalid_argument,
+                        "Illegal operator for DgDp(" <<
+                        "j = " << j << ", " <<
+                        "index l = " << l << ")\n");
 
-                  const RCP<const Thyra::LinearOpBase<Scalar> > model_dgdp_op =
-                    modelOutArgs.get_DgDp(j, l).getLinearOp();
+                    dgdp_op_downcasted->uninitialize();
 
-                  Teuchos::Array<RCP<const Thyra::LinearOpBase<Scalar> > > op_args(2);
-                  op_args[0] = model_dgdp_op;
-                  op_args[1] = implicit_dgdp_op;
-                  dgdp_op_downcasted->initialize(op_args);
-                }
+                    const RCP<const Thyra::LinearOpBase<Scalar> > implicit_dgdp_op =
+                        Thyra::multiply<Scalar>(
+                            Thyra::scale<Scalar>(-Teuchos::ScalarTraits<Scalar>::one(), dgdx_op),
+                            minus_dxdp_op);
 
-                const RCP<Thyra::MultiVectorBase<Scalar> > dgdp_mv =
-                  dgdp_deriv.getMultiVector();
-                if (Teuchos::nonnull(dgdp_mv)) {
-                  if (dgdp_deriv.getMultiVectorOrientation() == Thyra::ModelEvaluatorBase::DERIV_MV_GRADIENT_FORM) {
-                    if (Teuchos::nonnull(dxdp_mv)) {
-                      Thyra::apply(
-                          *dxdp_mv,
-                          Thyra::TRANS,
-                          *dgdx_mv,
-                          dgdp_mv.ptr(),
-                          Teuchos::ScalarTraits<Scalar>::one(),
-                          Teuchos::ScalarTraits<Scalar>::one());
+                    const RCP<const Thyra::LinearOpBase<Scalar> > model_dgdp_op =
+                        modelOutArgs.get_DgDp(j, l).getLinearOp();
+
+                    Teuchos::Array<RCP<const Thyra::LinearOpBase<Scalar> > > op_args(2);
+                    op_args[0] = model_dgdp_op;
+                    op_args[1] = implicit_dgdp_op;
+                    dgdp_op_downcasted->initialize(op_args);
+                  }
+
+                  const RCP<Thyra::MultiVectorBase<Scalar> > dgdp_mv =
+                      dgdp_deriv.getMultiVector();
+                  if (Teuchos::nonnull(dgdp_mv)) {
+                    if (dgdp_deriv.getMultiVectorOrientation() == Thyra::ModelEvaluatorBase::DERIV_MV_GRADIENT_FORM) {
+                      if (Teuchos::nonnull(dxdp_mv)) {
+                        Thyra::apply(
+                            *dxdp_mv,
+                            Thyra::TRANS,
+                            *dgdx_mv,
+                            dgdp_mv.ptr(),
+                            Teuchos::ScalarTraits<Scalar>::one(),
+                            Teuchos::ScalarTraits<Scalar>::one());
+                      } else {
+                        Thyra::apply(
+                            *minus_dxdp_mv,
+                            Thyra::TRANS,
+                            *dgdx_mv,
+                            dgdp_mv.ptr(),
+                            -Teuchos::ScalarTraits<Scalar>::one(),
+                            Teuchos::ScalarTraits<Scalar>::one());
+                      }
                     } else {
-                      Thyra::apply(
-                          *minus_dxdp_mv,
-                          Thyra::TRANS,
-                          *dgdx_mv,
-                          dgdp_mv.ptr(),
-                          -Teuchos::ScalarTraits<Scalar>::one(),
-                          Teuchos::ScalarTraits<Scalar>::one());
-                    }
-                  } else {
-                    if (Teuchos::nonnull(dxdp_mv)) {
-                      Thyra::apply(
-                          *dgdx_op,
-                          Thyra::NOTRANS,
-                          *dxdp_mv,
-                          dgdp_mv.ptr(),
-                          Teuchos::ScalarTraits<Scalar>::one(),
-                          Teuchos::ScalarTraits<Scalar>::one());
-                    } else {
-                      Thyra::apply(
-                          *dgdx_op,
-                          Thyra::NOTRANS,
-                          *minus_dxdp_mv,
-                          dgdp_mv.ptr(),
-                          -Teuchos::ScalarTraits<Scalar>::one(),
-                          Teuchos::ScalarTraits<Scalar>::one());
+                      if (Teuchos::nonnull(dxdp_mv)) {
+                        Thyra::apply(
+                            *dgdx_op,
+                            Thyra::NOTRANS,
+                            *dxdp_mv,
+                            dgdp_mv.ptr(),
+                            Teuchos::ScalarTraits<Scalar>::one(),
+                            Teuchos::ScalarTraits<Scalar>::one());
+                      } else {
+                        Thyra::apply(
+                            *dgdx_op,
+                            Thyra::NOTRANS,
+                            *minus_dxdp_mv,
+                            dgdp_mv.ptr(),
+                            -Teuchos::ScalarTraits<Scalar>::one(),
+                            Teuchos::ScalarTraits<Scalar>::one());
+                      }
                     }
                   }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  } else if (computeAdjointSensitivities) {
+
+    // Create implicitly transpose Jacobian and preconditioner
+    Teuchos::RCP< const Thyra::LinearOpWithSolveFactoryBase<double> > lows_factory = model_->get_W_factory();
+    TEUCHOS_ASSERT(Teuchos::nonnull(lows_factory));
+    Teuchos::RCP< Thyra::LinearOpBase<double> > lop = model_->create_W_op();
+    Teuchos::RCP< const ::Thyra::DefaultLinearOpSource<double> > losb = Teuchos::rcp(new ::Thyra::DefaultLinearOpSource<double>(lop));
+    Teuchos::RCP< ::Thyra::PreconditionerBase<double> > prec;
+
+    auto in_args = model_->createInArgs();
+    auto out_args = model_->createOutArgs();
+
+    Teuchos::RCP< ::Thyra::PreconditionerFactoryBase<double> > prec_factory =  lows_factory->getPreconditionerFactory();
+    if (Teuchos::nonnull(prec_factory)) {
+      prec = prec_factory->createPrec();
+    } else if (out_args.supports( Thyra::ModelEvaluatorBase::OUT_ARG_W_prec)) {
+      prec = model_->create_W_prec();
+    }
+
+    const RCP<Thyra::LinearOpWithSolveBase<Scalar> > jacobian =
+        lows_factory->createOp();
+
+    {
+      const auto timer = Teuchos::rcp(new Teuchos::TimeMonitor(*Teuchos::TimeMonitor::getNewTimer("Piro::SteadyStateSolver::evalConvergedModelResponsesAndSensitivities::evalModel")));
+      in_args.set_x(modelInArgs.get_x());
+      out_args.set_W_op(lop);
+      model_->evalModel(in_args, out_args);
+      in_args.set_x(Teuchos::null);
+      out_args.set_W_op(Teuchos::null);
+    }
+
+    if (Teuchos::nonnull(prec_factory))
+      prec_factory->initializePrec(losb, prec.get());
+    else if ( Teuchos::nonnull(prec) && (out_args.supports( Thyra::ModelEvaluatorBase::OUT_ARG_W_prec)) ) {
+      in_args.set_x(modelInArgs.get_x());
+      out_args.set_W_prec(prec);
+      model_->evalModel(in_args, out_args);
+    }
+
+    if(Teuchos::nonnull(prec))
+      Thyra::initializePreconditionedOp<double>(*lows_factory,
+          Thyra::transpose<double>(lop),
+          Thyra::unspecifiedPrec<double>(::Thyra::transpose<double>(prec->getUnspecifiedPrecOp())),
+          jacobian.ptr());
+    else
+      Thyra::initializeOp<double>(*lows_factory,
+          Thyra::transpose<double>(lop),
+          jacobian.ptr());
+
+
+    for (int j=0; j<num_g_; j++) {
+
+      // See if there are any forward sensitivities we need to do
+      // that aren't handled by the operator
+      bool compute_gj_sensitivities = false;
+      for (int i=0; i<num_p_; i++) {
+        if (!outArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDp, j, i).none()) {
+          if (outArgs.get_DgDp(j,i).getMultiVector() != Teuchos::null)
+            compute_gj_sensitivities = true;
+        }
+      }
+      if (!compute_gj_sensitivities)
+        continue;
+
+      if (!modelOutArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDx, j).none()) {
+        TEUCHOS_TEST_FOR_EXCEPTION(
+            modelOutArgs.get_DgDx(j).getLinearOp()!=Teuchos::null,
+            std::logic_error,
+            std::endl << "Piro::SteadyStateSolver::evalConvergedModelResponsesAndSensitivities():  " <<
+            "Can\'t use dg/dx operator " << j << " with non-operator " <<
+            "adjoint sensitivities." << std::endl);
+        auto dgdx  = modelOutArgs.get_DgDx(j).getMultiVector();
+        if (dgdx != Teuchos::null) {
+          int num_cols = dgdx->domain()->dim();
+
+          // (2) Calculate xbar multivector from -(J^{-T}*dg/dx)
+
+          auto xbar = createMembers(dgdx->range(), num_cols);
+          {
+            Teuchos::TimeMonitor timer(*Teuchos::TimeMonitor::getNewTimer("Piro::SteadyStateSolver::evalConvergedModelResponsesAndSensitivities::calc xbar"));
+            xbar->assign(0);
+            Thyra::solve(
+                *jacobian,
+                Thyra::NOTRANS,
+                *dgdx,
+                xbar.ptr());
+                //,ptr(&solve_criteria));
+
+            Thyra::scale(-1.0, xbar.ptr());
+          }
+          // (3) Calculate dg/dp^T = df/dp^T*xbar + dg/dp^T
+          for (int i=0; i<num_p_; i++) {
+            std::string paramName = "Parameter " + std::to_string(i);
+            std::ostringstream ss; ss << "Piro::SteadyStateSolver::evalConvergedModelResponsesAndSensitivities::calc dg/dp^T(" << paramName << ")";
+            const auto timer = Teuchos::rcp(new Teuchos::TimeMonitor(*Teuchos::TimeMonitor::getNewTimer(ss.str())));
+            if (!outArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDp, j, i).none()) {
+              auto dgdp_out = outArgs.get_DgDp(j,i).getMultiVector();
+              if (dgdp_out != Teuchos::null) {
+                Thyra::ModelEvaluatorBase::Derivative<Scalar> dfdp_dv = modelOutArgs.get_DfDp(i);
+                auto dfdp_op = dfdp_dv.getLinearOp();
+                auto dfdp = dfdp_dv.getMultiVector();
+                Thyra::ModelEvaluatorBase::Derivative<Scalar> dgdx_dv = modelOutArgs.get_DgDx(j);
+                if (dfdp_op != Teuchos::null) {
+                  Thyra::ModelEvaluatorBase::EDerivativeMultiVectorOrientation dgdp_orient =
+                      outArgs.get_DgDp(j,i).getMultiVectorOrientation();
+                  bool transpose = false;
+                  if (dgdp_orient == Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM)
+                    transpose = true;
+                  auto tmp = createMembers(dfdp_op->domain(),
+                      xbar->domain()->dim());
+
+                  dfdp_op->apply(Thyra::TRANS,*xbar, tmp.ptr(),1.0, 0.0);
+                  auto dgdp_range = Teuchos::rcp_dynamic_cast<const Thyra::SpmdVectorSpaceDefaultBase<Scalar>>(dgdp_out->range());
+
+                  if (!transpose) {
+                    Thyra::update(1.0,  *tmp, dgdp_out.ptr());
+                  } else {
+                    TEUCHOS_TEST_FOR_EXCEPTION(
+                      transpose,
+                      std::logic_error,
+                      std::endl <<
+                      "Piro::SteadyStateSolver::evalConvergedModelResponsesAndSensitivities():  " <<
+                      "The code related to df/dp operator and dg/dp with DERIV_MV_JACOBIAN_FORM layout has been commented out because never tested.  " <<
+                      std::endl);
+                    /*
+                    TEUCHOS_TEST_FOR_EXCEPTION(
+                        !dgdp_range->isLocallyReplicated(),
+                        std::logic_error,
+                        std::endl <<
+                        "Piro::SteadyStateSolver::evalConvergedModelResponsesAndSensitivities():  " <<
+                        "Can\'t handle special case:  " <<
+                        " df/dp operator, " <<
+                        " transposed, distributed dg/dp. " << std::endl);
+                    Thyra::DetachedMultiVectorView<Scalar> dgdp_out_view(dgdp_out);
+                    Thyra::DetachedMultiVectorView<Scalar> tmp_view(tmp);
+                    for (int jj=0; jj<dgdp_out_view.numSubCols(); jj++)
+                      for (int ii=0; ii<dgdp_out_view.subDim(); ii++)
+                        dgdp_out_view(ii,jj) += tmp_view(jj,ii);
+                        */
+                  }
+                }
+                else {
+                  TEUCHOS_TEST_FOR_EXCEPTION(
+                    dfdp_op == Teuchos::null,
+                    std::logic_error,
+                    std::endl <<
+                    "Piro::SteadyStateSolver::evalConvergedModelResponsesAndSensitivities():  " <<
+                    "The code related to df/dp multivector has been commented out because never tested.  " <<
+                    std::endl);
+
+                  /*
+                  Teuchos::RCP<Thyra::MultiVectorBase<Scalar>> arg1, arg2;
+                  Thyra::ModelEvaluatorBase::EDerivativeMultiVectorOrientation dgdp_orient =
+                      modelOutArgs.get_DgDp(j,i).getMultiVectorOrientation();
+                  Thyra::ModelEvaluatorBase::EDerivativeMultiVectorOrientation dfdp_orient =
+                      modelOutArgs.get_DfDp(i).getMultiVectorOrientation();
+                  Thyra::ModelEvaluatorBase::EDerivativeMultiVectorOrientation dgdx_orient =
+                      modelOutArgs.get_DgDx(j).getMultiVectorOrientation();
+
+
+                  Thyra::DetachedMultiVectorView<Scalar> dgdp_out_view(dgdp_out);
+                  int sub_num_g = (dgdp_orient == Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM) ?
+                      dgdp_out_view.subDim() : dgdp_out_view.numSubCols();
+                  int sub_num_p = (dgdp_orient == Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM) ?
+                      dgdp_out_view.numSubCols() : dgdp_out_view.subDim();
+                  if(dgdp_orient == Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM){
+                    //dgdp (np columns of g_space vectors)
+
+                    if (dgdx_orient == Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM) {
+                      Thyra::DetachedMultiVectorView<Scalar> xbar_view(xbar);
+                      Thyra::DetachedMultiVectorView<Scalar> dfdp_view(dfdp);
+                      if (dfdp_orient == Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM) {
+                        for (int ip=0; ip<sub_num_p; ip++)
+                          for (int ig=0; ig<sub_num_g; ig++) {
+                            for (int ix=0; ix<xbar_view.numSubCols(); ix++)
+                              dgdp_out_view(ip,ig) += xbar_view(ix,ig)*dfdp_view(ip,ix);
+                          }
+                      }
+                      else {
+                        for (int ip=0; ip<sub_num_p; ip++)
+                          for (int ig=0; ig<sub_num_g; ig++)
+                            for (int ix=0; ix<xbar_view.numSubCols(); ix++)
+                              dgdp_out_view(ip,ig) += xbar_view(ix,ig)*dfdp_view(ix,ip);
+                      }
+                    }
+                    else if (dfdp_orient == Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM) {
+                      for (int ip=0; ip<sub_num_p; ip++)
+                        for (int ig=0; ig<sub_num_g; ig++)
+                          dgdp_out_view(ip,ig) += Thyra::scalarProd(*xbar->col(ig),*dfdp->col(ip));
+                    }
+                    else {
+                      Thyra::DetachedMultiVectorView<Scalar> xbar_view(xbar);
+                      Thyra::DetachedMultiVectorView<Scalar> dfdp_view(dfdp);
+                      for (int ip=0; ip<dgdp_out_view.numSubCols(); ip++)
+                        for (int ig=0; ig<dgdp_out_view.subDim(); ig++)
+                          for (int ix=0; ix<xbar_view.subDim(); ix++)
+                            dgdp_out_view(ip,ig) += xbar_view(ig,ix)*dfdp_view(ix,ip);
+                    }
+                  }
+                  else {
+                    //dgdp (ng columns of p_space vectors)
+                    if (dgdx_orient == Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM) {
+                      Thyra::DetachedMultiVectorView<Scalar> xbar_view(xbar);
+                      Thyra::DetachedMultiVectorView<Scalar> dfdp_view(dfdp);
+                      if (dfdp_orient == Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM) {
+                        for (int ip=0; ip<sub_num_p; ip++)
+                          for (int ig=0; i<sub_num_g; ig++) {
+                            for (int ix=0; ix<xbar_view.numSubCols(); ix++)
+                              dgdp_out_view(ig,ip) += xbar_view(ix,ig)*dfdp_view(ip,ix);
+                          }
+                      }
+                      else {
+                        for (int ip=0; ip<sub_num_p; ip++)
+                          for (int ig=0; ig<sub_num_g; ig++)
+                            for (int ix=0; ix<xbar_view.numSubCols(); ix++)
+                              dgdp_out_view(ig,ip) += xbar_view(ix,ig)*dfdp_view(ix,ip);
+                      }
+                    }
+                    else if (dfdp_orient == Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM) {
+                      for (int ip=0; ip<sub_num_p; ip++)
+                        for (int ig=0; ig<sub_num_g; ig++)
+                          dgdp_out_view(ig,ip) += Thyra::scalarProd(*xbar->col(ig),*dfdp->col(ip));
+                    }
+                    else {
+                      Thyra::DetachedMultiVectorView<Scalar> xbar_view(xbar);
+                      Thyra::DetachedMultiVectorView<Scalar> dfdp_view(dfdp);
+                      for (int ip=0; ip<dgdp_out_view.subDim(); ip++)
+                        for (int ig=0; ig<dgdp_out_view.numSubCols(); ig++)
+                          for (int ix=0; ix<xbar_view.subDim(); ix++)
+                            dgdp_out_view(ig,ip) += xbar_view(ig,ix)*dfdp_view(ix,ip);
+                    }
+                  }
+                  */
                 }
               }
             }
@@ -614,7 +1042,7 @@ Teuchos::RCP<Thyra::LinearOpBase<Scalar> >
 Piro::SteadyStateSolver<Scalar>::create_DgDp_op_impl(int j, int l) const
 {
   const Teuchos::Array<Teuchos::RCP<const Thyra::LinearOpBase<Scalar> > > dummy =
-    Teuchos::tuple(Thyra::zero<Scalar>(this->get_g_space(j), this->get_p_space(l)));
+      Teuchos::tuple(Thyra::zero<Scalar>(this->get_g_space(j), this->get_p_space(l)));
   if (j == num_g_)  {
     return Thyra::defaultMultipliedLinearOp<Scalar>(dummy);
   } else {

--- a/packages/piro/src/Piro_TempusSolver_Def.hpp
+++ b/packages/piro/src/Piro_TempusSolver_Def.hpp
@@ -452,7 +452,7 @@ void Piro::TempusSolver<Scalar>::evalModelImpl(
   modelInArgs.set_t(t_final_ - soln_dt);
 
   //Calculate responses and sensitivities 
-  this->evalConvergedModel(modelInArgs, outArgs); 
+  this->evalConvergedModelResponsesAndSensitivities(modelInArgs, outArgs);
 
 }
 

--- a/packages/piro/src/Piro_TransientSolver.hpp
+++ b/packages/piro/src/Piro_TransientSolver.hpp
@@ -100,7 +100,7 @@ public:
   
   /** \name Setters for subbclasses */
   /** \brief . */
-  void setSensitivityMethod(const std::string sensitivity_method_string);  
+  void setSensitivityMethod(const std::string& sensitivity_method_string);
   //@}
 
   /** \brief . */
@@ -112,7 +112,7 @@ protected:
   //@{
 
   /** \brief . */
-  void evalConvergedModel(
+  void evalConvergedModelResponsesAndSensitivities(
       const Thyra::ModelEvaluatorBase::InArgs<Scalar>& modelInArgs,
       const Thyra::ModelEvaluatorBase::OutArgs<Scalar>& outArgs) const;
   //@}

--- a/packages/piro/src/Piro_TransientSolver_Def.hpp
+++ b/packages/piro/src/Piro_TransientSolver_Def.hpp
@@ -64,7 +64,8 @@ Piro::TransientSolver<Scalar>::TransientSolver(
   out_(Teuchos::VerboseObjectBase::getDefaultOStream()),
   model_(model), 
   num_p_(model->Np()), 
-  num_g_(model->Ng())
+  num_g_(model->Ng()),
+  sensitivityMethod_(NONE)
 {
   //Nothing to do
 }
@@ -251,7 +252,7 @@ Piro::TransientSolver<Scalar>::num_g() const
 
 template <typename Scalar>
 void 
-Piro::TransientSolver<Scalar>::setSensitivityMethod(const std::string sensitivity_method_string)
+Piro::TransientSolver<Scalar>::setSensitivityMethod(const std::string& sensitivity_method_string)
 {
   if (sensitivity_method_string == "None") sensitivityMethod_ = NONE; 
   else if (sensitivity_method_string == "Forward") sensitivityMethod_ = FORWARD;
@@ -260,12 +261,6 @@ Piro::TransientSolver<Scalar>::setSensitivityMethod(const std::string sensitivit
     TEUCHOS_TEST_FOR_EXCEPTION(true, Teuchos::Exceptions::InvalidParameter,
         "\n Error! Piro::TransientSolver: invalid Sensitivity Method = " << sensitivity_method_string << "! \n" 
         << " Valid options for Sensitivity Method are 'None', 'Forward' and 'Adjoint'.\n");
-  }
-  //IKT, 5/8/2020: remove the following once we have support for adjoint sensitivities 
-  if (sensitivityMethod_ == ADJOINT) {
-    TEUCHOS_TEST_FOR_EXCEPTION(true, Teuchos::Exceptions::InvalidParameter,
-        "\n Error! Piro::TransientSolver: adjoint sentivities (Sensitivity Method = "
-        << "Adjoint) are not yet supported!  Please set 'Sensitivity Method' to 'None' or 'Forward'.\n");
   }
 }
 
@@ -286,7 +281,7 @@ Piro::TransientSolver<Scalar>::setPiroTempusIntegrator(Teuchos::RCP<const Piro::
 
 template <typename Scalar>
 void 
-Piro::TransientSolver<Scalar>::evalConvergedModel(
+Piro::TransientSolver<Scalar>::evalConvergedModelResponsesAndSensitivities(
       const Thyra::ModelEvaluatorBase::InArgs<Scalar>& modelInArgs,
       const Thyra::ModelEvaluatorBase::OutArgs<Scalar>& outArgs) const
 {

--- a/packages/piro/test/CMakeLists.txt
+++ b/packages/piro/test/CMakeLists.txt
@@ -177,6 +177,7 @@ IF (Piro_ENABLE_NOX)
           input_Analysis_ROL_ReducedSpace_Tpetra.xml
           input_Analysis_ROL_FullSpace_Tpetra.xml
           input_Analysis_ROL_AdjointSensitivities.xml
+          input_Analysis_ROL_AdjointSensitivities_OldReducedSpace_Tpetra.xml
           input_Analysis_ROL_AdjointSensitivities_ReducedSpace_NOXSolver_Tpetra.xml
           input_Analysis_ROL_AdjointSensitivities_FullSpace_Tpetra.xml
           input_Solve_RythmosMatrixFree_Fails.xml

--- a/packages/piro/test/Main_AnalysisDriver_Tpetra.cpp
+++ b/packages/piro/test/Main_AnalysisDriver_Tpetra.cpp
@@ -95,7 +95,7 @@ int main(int argc, char *argv[]) {
 
   Piro::SolverFactory solverFactory;
 
-  for (int iTest=0; iTest<6; iTest++) {
+  for (int iTest=0; iTest<7; iTest++) {
 
     if (doAll) {
       switch (iTest) {
@@ -103,8 +103,9 @@ int main(int argc, char *argv[]) {
        case 1: inputFile="input_Analysis_ROL_ReducedSpace_NOXSolver_Tpetra.xml"; break;
        case 2: inputFile="input_Analysis_ROL_ReducedSpace_Tpetra.xml"; break;
        case 3: inputFile="input_Analysis_ROL_FullSpace_Tpetra.xml"; break;
-       case 4: inputFile="input_Analysis_ROL_AdjointSensitivities_ReducedSpace_NOXSolver_Tpetra.xml"; break;
-       case 5: inputFile="input_Analysis_ROL_AdjointSensitivities_FullSpace_Tpetra.xml"; break;
+       case 4: inputFile="input_Analysis_ROL_AdjointSensitivities_OldReducedSpace_Tpetra.xml"; break;
+       case 5: inputFile="input_Analysis_ROL_AdjointSensitivities_ReducedSpace_NOXSolver_Tpetra.xml"; break;
+       case 6: inputFile="input_Analysis_ROL_AdjointSensitivities_FullSpace_Tpetra.xml"; break;
        default : std::cout << "iTest logic error " << std::endl; exit(-1);
       }
     }

--- a/packages/piro/test/_input_Analysis_ROL_AdjointSensitivities_OldReducedSpace_Tpetra.xml
+++ b/packages/piro/test/_input_Analysis_ROL_AdjointSensitivities_OldReducedSpace_Tpetra.xml
@@ -1,0 +1,298 @@
+<ParameterList>
+  <ParameterList name="Piro">
+    <Parameter name="Sensitivity Method" type="string" value="Adjoint" />
+    <Parameter name="Solver Type" type="string" value="NOX" />
+    <!--Parameter name="Jacobian Operator" type="string" value="Matrix-Free"/ -->
+    <ParameterList name="LOCA">
+      <ParameterList name="Bifurcation" />
+      <ParameterList name="Constraints" />
+      <ParameterList name="Predictor">
+        <Parameter name="Method" type="string" value="Constant" />
+      </ParameterList>
+      <ParameterList name="Stepper">
+        <Parameter name="Continuation Method" type="string" value="Natural" />
+        <Parameter name="Initial Value" type="double" value="1.0" />
+        <Parameter name="Continuation Parameter" type="string" value="Parameter 0" />
+        <Parameter name="Max Steps" type="int" value="6" />
+        <Parameter name="Max Value" type="double" value="12.25" />
+        <Parameter name="Min Value" type="double" value="0.5" />
+        <Parameter name="Compute Eigenvalues" type="bool" value="1" />
+        <ParameterList name="Eigensolver">
+          <Parameter name="Method" type="string" value="Anasazi" />
+          <Parameter name="Operator" type="string" value="Shift-Invert" />
+          <Parameter name="Num Blocks" type="int" value="3" />
+          <Parameter name="Num Eigenvalues" type="int" value="1" />
+          <Parameter name="Block Size" type="int" value="1" />
+          <Parameter name="Maximum Restarts" type="int" value="0" />
+          <Parameter name="Shift" type="double" value="1.0" />
+        </ParameterList>
+      </ParameterList>
+      <ParameterList name="Step Size">
+        <Parameter name="Initial Step Size" type="double" value="0.5" />
+        <Parameter name="Aggressiveness" type="double" value="2.0" />
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="NOX">
+      <ParameterList name="Direction">
+        <Parameter name="Method" type="string" value="Newton" />
+        <ParameterList name="Newton">
+          <Parameter name="Forcing Term Method" type="string" value="Constant" />
+          <Parameter name="Rescue Bad Newton Solve" type="bool" value="1" />
+          <ParameterList name="Stratimikos Linear Solver">
+            <ParameterList name="NOX Stratimikos Options">
+            </ParameterList>
+            <ParameterList name="Stratimikos">
+              <Parameter name="Linear Solver Type" type="string" value="AztecOO" />
+              <ParameterList name="Linear Solver Types">
+                <ParameterList name="AztecOO">
+                  <ParameterList name="Forward Solve">
+                    <ParameterList name="AztecOO Settings">
+                      <Parameter name="Aztec Solver" type="string" value="GMRES" />
+                      <Parameter name="Convergence Test" type="string" value="r0" />
+                      <Parameter name="Size of Krylov Subspace" type="int" value="200" />
+                      <Parameter name="Output Frequency" type="int" value="10" />
+                    </ParameterList>
+                    <Parameter name="Max Iterations" type="int" value="200" />
+                    <Parameter name="Tolerance" type="double" value="1e-5" />
+                  </ParameterList>
+                </ParameterList>
+                <ParameterList name="Belos">
+                  <Parameter name="Solver Type" type="string" value="Block GMRES" />
+                  <ParameterList name="Solver Types">
+                    <ParameterList name="Block GMRES">
+                      <Parameter name="Convergence Tolerance" type="double" value="1e-5" />
+                      <Parameter name="Output Frequency" type="int" value="10" />
+                      <Parameter name="Output Style" type="int" value="1" />
+                      <Parameter name="Verbosity" type="int" value="33" />
+                      <Parameter name="Maximum Iterations" type="int" value="100" />
+                      <Parameter name="Block Size" type="int" value="1" />
+                      <Parameter name="Num Blocks" type="int" value="20" />
+                      <Parameter name="Flexible Gmres" type="bool" value="0" />
+                    </ParameterList>
+                  </ParameterList>
+                </ParameterList>
+              </ParameterList>
+              <Parameter name="Preconditioner Type" type="string" value="Ifpack2" />
+              <ParameterList name="Preconditioner Types">
+                <ParameterList name="Ifpack2">
+                  <Parameter name="Overlap" type="int" value="1" />
+                  <Parameter name="Prec Type" type="string" value="RILUK" />
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+      <ParameterList name="Line Search">
+        <ParameterList name="Full Step">
+          <Parameter name="Full Step" type="double" value="1" />
+        </ParameterList>
+        <Parameter name="Method" type="string" value="Backtrack" />
+      </ParameterList>
+      <Parameter name="Nonlinear Solver" type="string" value="Line Search Based" />
+      <ParameterList name="Printing">
+        <Parameter name="Output Precision" type="int" value="3" />
+        <Parameter name="Output Processor" type="int" value="0" />
+        <ParameterList name="Output Information">
+          <Parameter name="Error" type="bool" value="1" />
+          <Parameter name="Warning" type="bool" value="1" />
+          <Parameter name="Outer Iteration" type="bool" value="1" />
+          <Parameter name="Inner Iteration" type="bool" value="1" />
+          <Parameter name="Parameters" type="bool" value="0" />
+          <Parameter name="Details" type="bool" value="0" />
+          <Parameter name="Linear Solver Details" type="bool" value="0" />
+          <Parameter name="Stepper Iteration" type="bool" value="1" />
+          <Parameter name="Stepper Details" type="bool" value="1" />
+          <Parameter name="Stepper Parameters" type="bool" value="1" />
+        </ParameterList>
+      </ParameterList>
+      <ParameterList name="Solver Options">
+        <Parameter name="Status Test Check Type" type="string" value="Minimal" />
+      </ParameterList>
+      <ParameterList name="Status Tests">
+        <Parameter name="Test Type" type="string" value="Combo" />
+        <Parameter name="Combo Type" type="string" value="OR" />
+        <Parameter name="Number of Tests" type="int" value="2" />
+        <ParameterList name="Test 0">
+          <Parameter name="Test Type" type="string" value="NormF" />
+          <Parameter name="Tolerance" type="double" value="1.0e-8" />
+        </ParameterList>
+        <ParameterList name="Test 1">
+          <Parameter name="Test Type" type="string" value="MaxIters" />
+          <Parameter name="Maximum Iterations" type="int" value="10" />
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Rythmos">
+      <Parameter name="Num Time Steps" type="int" value="10" />
+      <Parameter name="Final Time" type="double" value="0.1" />
+      <Parameter name="Stepper Type" type="string" value="Explicit RK" />
+      <ParameterList name="Rythmos Stepper">
+        <ParameterList name="VerboseObject">
+          <Parameter name="Verbosity Level" type="string" value="medium" />
+        </ParameterList>
+      </ParameterList>
+      <ParameterList name="Stratimikos">
+      </ParameterList>
+      <ParameterList name="Rythmos Integration Control">
+      </ParameterList>
+      <ParameterList name="Rythmos Integrator">
+        <ParameterList name="VerboseObject">
+          <Parameter name="Verbosity Level" type="string" value="medium" />
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Analysis">
+      <Parameter name="Analysis Package" type="string" value="ROL" />
+      <ParameterList name="Dakota">
+        <Parameter name="Input File" type="string" value="dak.in" />
+        <Parameter name="Output File" type="string" value="dak.out" />
+        <Parameter name="Restart File" type="string" value="dak.res" />
+        <Parameter name="Error File" type="string" value="dak.err" />
+      </ParameterList>
+      <ParameterList name="ROL">
+        <Parameter name="Use Old Reduced Space Interface" type="bool" value="true" />
+      
+        <Parameter name="Response Vector Index" type="int" value="0" />
+        <Parameter name="Parameter Vector Index" type="int" value="0" />
+        <Parameter name="Print Output" type="bool" value="true" />
+
+        <Parameter name="Seed For Thyra Randomize" type="int" value="42" />
+
+        <Parameter name="Parameter Initial Guess Type" type="string" value="From Model Evaluator" /> <!-- other choices are "Uniform Vector" or "Random Vector", default is "From Model Evaluator"/ -->
+        <!--Parameter name="Uniform Parameter Guess" type="double" value="2.0"/ -->
+        <!--Parameter name="Min And Max Of Random Parameter Guess" type="Array(double)" value="{1.0, 3.0}"/ -->
+
+        <Parameter name="Check Gradient" type="bool" value="false" />
+        <Parameter name="Number Of Gradient Checks" type="int" value="1" />
+
+        <Parameter name="Test Vector" type="bool" value="false" />
+        <Parameter name="Number Of Vector Tests" type="int" value="1" />
+
+        <Parameter name="Gradient Tolerance" type="double" value="1e-4" />
+        <Parameter name="Step Tolerance" type="double" value="1e-4" />
+        <Parameter name="Max Iterations" type="int" value="36" />
+
+        <Parameter name="Bound Constrained" type="bool" value="true" />
+        <Parameter name="epsilon bound" type="double" value="1e-4" />
+
+        <Parameter name="Step Method" type="string" value="Line Search" />
+        <Parameter name="Full Space" type="bool" value="false" />
+        <Parameter name="Use NOX Solver" type="bool" value="false" />
+
+        <!-- =========== BEGIN ROL INPUT PARAMETER SUBLIST =========== -->
+        <ParameterList name="ROL Options">
+          <!-- =========== BEGIN GENERAL INPUT PARAMETER SUBLIST =========== -->
+          <ParameterList name="General">
+            <Parameter name="Variable Objective Function" type="bool" value="false" />
+            <Parameter name="Scale for Epsilon Active Sets" type="double" value="1.0" />
+            <!-- =========== USE INEXACT OBJECTIVE OR DERIVATIVES =========== -->
+            <Parameter name="Inexact Objective Function" type="bool" value="false" />
+            <Parameter name="Inexact Gradient" type="bool" value="false" />
+            <Parameter name="Inexact Hessian-Times-A-Vector" type="bool" value="false" />
+            <!-- =========== BOUND CONSTRAINED CRITICALITY MEASURE =========== -->
+            <Parameter name="Projected Gradient Criticality Measure" type="bool" value="false" />
+
+            <!-- =========== SECANT INPUTS =========== -->
+            <ParameterList name="Secant">
+              <Parameter name="Type" type="string" value="Limited-Memory BFGS" />
+              <!--Parameter name="Type" type="string" value="Limited-Memory DFP" / -->
+              <Parameter name="Use as Preconditioner" type="bool" value="false" />
+              <Parameter name="Use as Hessian" type="bool" value="false" />
+              <Parameter name="Maximum Storage" type="int" value="50" />
+              <Parameter name="Barzilai-Borwein Type" type="int" value="1" />
+            </ParameterList>
+
+            <!-- =========== KRYLOV INPUTS =========== -->
+            <ParameterList name="Krylov">
+              <Parameter name="Type" type="string" value="Conjugate Gradients" />
+              <Parameter name="Absolute Tolerance" type="double" value="1.e-4" />
+              <Parameter name="Relative Tolerance" type="double" value="1.e-2" />
+              <Parameter name="Iteration Limit" type="int" value="100" />
+            </ParameterList>
+          </ParameterList>
+
+          <!-- =========== STEP SUBLIST =========== -->
+          <ParameterList name="Step">
+            <!-- =========== LINE SEARCH =========== -->
+            <ParameterList name="Line Search">
+              <Parameter name="Function Evaluation Limit" type="int" value="20" />
+              <Parameter name="Sufficient Decrease Tolerance" type="double" value="1.e-4" />
+              <Parameter name="Initial Step Size" type="double" value="1.0" />
+              <Parameter name="User Defined Initial Step Size" type="bool" value="false" />
+              <Parameter name="Accept Linesearch Minimizer" type="bool" value="false" />
+              <Parameter name="Accept Last Alpha" type="bool" value="false" />
+              <!-- =========== DESCENT ALGORITHM SPECIFICATION =========== -->
+              <ParameterList name="Descent Method">
+                <!--Parameter name="Type" type="string" value="Newton-Krylov" / -->
+                <Parameter name="Type" type="string" value="Quasi-Newton" />
+                <Parameter name="Nonlinear CG Type" type="string" value="Hestenes-Stiefel" />
+              </ParameterList>
+
+              <!-- =========== CURVATURE CONDITION SPECIFICATION =========== -->
+              <ParameterList name="Curvature Condition">
+                <!--Parameter name="Type" type="string" value="Generalized Wolfe Conditions" / -->
+                <Parameter name="Type" type="string" value="Strong Wolfe Conditions" />
+                <Parameter name="General Parameter" type="double" value="0.9" />
+                <Parameter name="Generalized Wolfe Parameter" type="double" value="0.6" />
+              </ParameterList>
+              <!-- =========== LINE-SEARCH ALGORITHM SPECIFICATION =========== -->
+              <ParameterList name="Line-Search Method">
+                <Parameter name="Type" type="string" value="Backtracking" />
+                <!--Parameter name="Type" type="string" value="Cubic Interpolation" / -->
+                <Parameter name="Backtracking Rate" type="double" value="0.5" />
+                <Parameter name="Bracketing Tolerance" type="double" value="1.e-8" />
+                <!-- =========== PATH-BASED TARGET LEVEL =========== -->
+                <ParameterList name="Path-Based Target Level">
+                  <Parameter name="Target Relaxation Parameter" type="double" value="1.0" />
+                  <Parameter name="Upper Bound on Path Length" type="double" value="1.0" />
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+
+            <!-- =========== TRUST REGION =========== -->
+            <ParameterList name="Trust Region">
+              <Parameter name="Subproblem Solver" type="string" value="Truncated CG" />
+              <Parameter name="Initial Radius" type="double" value="10.0" />
+              <Parameter name="Maximum Radius" type="double" value="5.e3" />
+              <Parameter name="Step Acceptance Threshold" type="double" value="0.05" />
+              <Parameter name="Radius Shrinking Threshold" type="double" value="0.05" />
+              <Parameter name="Radius Growing Threshold" type="double" value="0.9" />
+              <Parameter name="Radius Shrinking Rate (Negative rho)" type="double" value="0.0625" />
+              <Parameter name="Radius Shrinking Rate (Positive rho)" type="double" value="0.25" />
+              <Parameter name="Radius Growing Rate" type="double" value="2.5" />
+              <Parameter name="Safeguard Size" type="double" value="1.e8" />
+
+              <!-- =========== CONTROLS FOR INEXACTNESS =========== -->
+              <ParameterList name="Inexact">
+
+                <!-- =========== INEXACT OBJECTIVE VALUE UPDATE =========== -->
+                <ParameterList name="Value">
+                  <Parameter name="Tolerance Scaling" type="double" value="1.e-1" />
+                  <Parameter name="Exponent" type="double" value="0.9" />
+                  <Parameter name="Forcing Sequence Initial Value" type="double" value="1.0" />
+                  <Parameter name="Forcing Sequence Update Frequency" type="int" value="10" />
+                  <Parameter name="Forcing Sequence Reduction Factor" type="double" value="0.1" />
+                </ParameterList>
+
+                <!-- =========== INEXACT GRADIENT UPDATE =========== -->
+                <ParameterList name="Gradient">
+                  <Parameter name="Tolerance Scaling" type="double" value="1.e-1" />
+                  <Parameter name="Relative Tolerance" type="double" value="2.0" />
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+
+          <!-- =========== STATUS TEST SUBLIST =========== -->
+          <ParameterList name="Status Test">
+            <Parameter name="Gradient Tolerance" type="double" value="1.e-10" />
+            <Parameter name="Constraint Tolerance" type="double" value="1.e-10" />
+            <Parameter name="Step Tolerance" type="double" value="1.e-14" />
+            <Parameter name="Iteration Limit" type="int" value="1000" />
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+</ParameterList>


### PR DESCRIPTION
Cleaned SteadyStateSolver and made it more similar to TransientSolver.

- Moved computation of adjoint sensitivities from `Piro::NOXSolver` into `Piro::SteadyStateSolver`.

- Renamed function `evalConvergedModel` to more descriptive `evalConvergedModelResponsesAndSensitivities`

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->

## Motivation
Clean and make `Piro::SteadyStateSolver` more consistent in design to the recently added (PR #7359 ) `Piro::TransientSolver` .
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Added additional test to exercise adjoint sensitivity computations.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->