### PR TITLE
Tpetra:  Include multivector length in deciding where kernels should run

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_Behavior.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Behavior.cpp
@@ -358,6 +358,17 @@ size_t Behavior::longRowMinNumEntries ()
     (value_, initialized_, envVarName, defaultValue);
 }
 
+size_t Behavior::multivectorKernelLocationThreshold ()
+{
+  constexpr char envVarName[] = "TPETRA_VECTOR_DEVICE_THRESHOLD";
+  constexpr size_t defaultValue (10000);
+
+  static size_t value_ = defaultValue;
+  static bool initialized_ = false;
+  return idempotentlyGetEnvironmentVariableAsSize
+    (value_, initialized_, envVarName, defaultValue);
+}
+
 bool Behavior::profilingRegionUseTeuchosTimers () 
 {
   constexpr char envVarName[] = "TPETRA_USE_TEUCHOS_TIMERS";

--- a/packages/tpetra/core/src/Tpetra_Details_Behavior.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Behavior.hpp
@@ -202,7 +202,7 @@ public:
 
   /// \brief the threshold for transitioning from device to host
   ///
-  /// If the number of elements in the multivector exceeds this 
+  /// If the number of elements in the multivector does not exceed this 
   /// threshold and the data is on host, then run the calculation on
   /// host.  Otherwise, run on device.
   /// By default this is 10000, but may be altered by the environment

--- a/packages/tpetra/core/src/Tpetra_Details_Behavior.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Behavior.hpp
@@ -200,6 +200,15 @@ public:
   /// separate question.
   static size_t longRowMinNumEntries ();
 
+  /// \brief the threshold for transitioning from device to host
+  ///
+  /// If the number of elements in the multivector exceeds this 
+  /// threshold and the data is on host, then run the calculation on
+  /// host.  Otherwise, run on device.
+  /// By default this is 10000, but may be altered by the environment
+  /// variable TPETRA_VECTOR_DEVICE_THRESHOLD
+  static size_t multivectorKernelLocationThreshold ();
+
   /// \brief Use Teuchos::Timer in Tpetra::ProfilingRegion
   ///
   /// This is disabled by default.  You may control this at run time via the

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -329,9 +329,23 @@ namespace { // (anonymous)
     }
   }
 
+  template <class impl_scalar_type, class buffer_device_type>
+  bool
+  runKernelOnHost ( Kokkos::DualView<impl_scalar_type*, buffer_device_type> imports )
+  {
+    if (! imports.need_sync_device ()) {
+      return false; // most up-to-date on device
+    }
+    else { // most up-to-date on host
+      constexpr size_t localLengthThreshold = 10000;
+      return imports.extent(0) <= localLengthThreshold;
+    }
+  }
+
+
   template <class SC, class LO, class GO, class NT>
   bool
-  multiVectorRunNormOnHost (const ::Tpetra::MultiVector<SC, LO, GO, NT>& X)
+  runKernelOnHost (const ::Tpetra::MultiVector<SC, LO, GO, NT>& X)
   {
     if (! X.need_sync_device ()) {
       return false; // most up-to-date on device
@@ -360,7 +374,7 @@ namespace { // (anonymous)
     const bool isConstantStride = X.isConstantStride ();
     const bool isDistributed = X.isDistributed ();
 
-    const bool runOnHost = multiVectorRunNormOnHost (X);
+    const bool runOnHost = runKernelOnHost (X);
     if (runOnHost) {
       using view_type = typename dual_view_type::t_host;
       using array_layout = typename view_type::array_layout;
@@ -981,7 +995,7 @@ namespace Tpetra {
        << permuteFromLIDs.extent (0) << ".");
 
     // We've already called checkSizes(), so this cast must succeed.
-    const MV& sourceMV = dynamic_cast<const MV&> (sourceObj);
+    MV& sourceMV = const_cast<MV &>(dynamic_cast<const MV&> (sourceObj));
     const size_t numCols = this->getNumVectors ();
 
     // sourceMV doesn't belong to us, so we can't sync it.  Do the
@@ -990,7 +1004,7 @@ namespace Tpetra {
       (sourceMV.need_sync_device () && sourceMV.need_sync_host (),
        std::logic_error, "Input MultiVector needs sync to both host "
        "and device.");
-    const bool copyOnHost = sourceMV.need_sync_device ();
+    const bool copyOnHost = runKernelOnHost(sourceMV);
     if (verbose) {
       std::ostringstream os;
       os << *prefix << "copyOnHost=" << (copyOnHost ? "true" : "false") << endl;
@@ -998,12 +1012,12 @@ namespace Tpetra {
     }
 
     if (copyOnHost) {
-      if (this->need_sync_host ()) {
-        this->sync_host ();
-      }
+      sourceMV.sync_host();
+      this->sync_host ();
       this->modify_host ();
     }
     else {
+      sourceMV.sync_device();
       if (this->need_sync_device ()) {
         this->sync_device ();
       }
@@ -1296,7 +1310,7 @@ namespace Tpetra {
     }
 
     // We've already called checkSizes(), so this cast must succeed.
-    const MV& sourceMV = dynamic_cast<const MV&> (sourceObj);
+    MV& sourceMV = const_cast<MV&>(dynamic_cast<const MV&> (sourceObj));
 
     const size_t numCols = sourceMV.getNumVectors ();
 
@@ -1349,7 +1363,7 @@ namespace Tpetra {
       (sourceMV.need_sync_device () && sourceMV.need_sync_host (),
        std::logic_error, "Input MultiVector needs sync to both host "
        "and device.");
-    const bool packOnHost = sourceMV.need_sync_device ();
+    const bool packOnHost = runKernelOnHost(sourceMV);
     auto src_dev = sourceMV.getLocalViewHost ();
     auto src_host = sourceMV.getLocalViewDevice ();
     if (printDebugOutput) {
@@ -1369,6 +1383,7 @@ namespace Tpetra {
       // Clearing the sync flags prevents this possible case.
       exports.clear_sync_state ();
       exports.modify_host ();
+      sourceMV.sync_host();
     }
     else {
       // nde 06 Feb 2020: If 'exports' does not require resize
@@ -1378,6 +1393,7 @@ namespace Tpetra {
       // Clearing the sync flags prevents this possible case.
       exports.clear_sync_state ();
       exports.modify_device ();
+      sourceMV.sync_device();
     }
 
     if (numCols == 1) { // special case for one column only
@@ -1582,7 +1598,7 @@ namespace Tpetra {
     // mfh 12 Apr 2016, 04 Feb 2019: Decide where to unpack based on
     // the memory space in which the imports buffer was last modified.
     // DistObject::doTransferNew gets to decide this.
-    const bool unpackOnHost = imports.need_sync_device ();
+    const bool unpackOnHost = runKernelOnHost(imports);
 
     if (printDebugOutput) {
       std::ostringstream os;
@@ -1594,15 +1610,13 @@ namespace Tpetra {
     // We have to sync before modifying, because this method may read
     // as well as write (depending on the CombineMode).
     if (unpackOnHost) {
-      if (this->need_sync_host ()) {
-        this->sync_host ();
-      }
+      imports.sync_host();
+      this->sync_host ();
       this->modify_host ();
     }
     else {
-      if (this->need_sync_device ()) {
-        this->sync_device ();
-      }
+      imports.sync_device();
+      this->sync_device ();
       this->modify_device ();
     }
     auto X_d = this->getLocalViewDevice ();
@@ -2319,9 +2333,10 @@ namespace Tpetra {
     // avoids sync'ing, which could violate users' expectations.
     //
     // If we need sync to device, then host has the most recent version.
-    const bool runOnHost = this->need_sync_device ();
+    const bool runOnHost = runKernelOnHost(*this);
 
-    if (! runOnHost) { // last modified in device memory
+    this->clear_sync_state();
+    if (! runOnHost) {
       this->modify_device ();
       auto X = this->getLocalViewDevice ();
       if (this->isConstantStride ()) {

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -337,7 +337,7 @@ namespace { // (anonymous)
       return false; // most up-to-date on device
     }
     else { // most up-to-date on host
-      constexpr size_t localLengthThreshold = 10000;
+      size_t localLengthThreshold = Tpetra::Details::Behavior::multivectorKernelLocationThreshold();
       return imports.extent(0) <= localLengthThreshold;
     }
   }

--- a/packages/tpetra/core/test/MultiVector/MultiVector_UnitTests.cpp
+++ b/packages/tpetra/core/test/MultiVector/MultiVector_UnitTests.cpp
@@ -283,6 +283,83 @@ namespace {
 
 
   ////
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( MultiVector, large, LO, GO, Scalar , Node )
+  {
+    using map_type = Tpetra::Map<LO, GO, Node>;
+    using MV = Tpetra::MultiVector<Scalar, LO, GO, Node>;
+    using vec_type = Tpetra::Vector<Scalar, LO, GO, Node>;
+    typedef typename ScalarTraits<Scalar>::magnitudeType Magnitude;
+    constexpr bool debug = true;
+
+    RCP<Teuchos::FancyOStream> outPtr = debug ?
+      Teuchos::getFancyOStream (Teuchos::rcpFromRef (std::cerr)) :
+      Teuchos::rcpFromRef (out);
+    Teuchos::FancyOStream& myOut = *outPtr;
+
+    myOut << "Test: MultiVector, basic" << endl;
+    Teuchos::OSTab tab0 (myOut);
+
+    const global_size_t INVALID = OrdinalTraits<global_size_t>::invalid ();
+    RCP<const Comm<int> > comm = getDefaultComm ();
+    const int numImages = comm->getSize ();
+
+    myOut << "Create Map" << endl;
+    const size_t numLocal = 15000;
+    const size_t numVecs  = 10;
+    const GO indexBase = 0;
+    RCP<const map_type> map =
+      rcp (new map_type (INVALID, numLocal, indexBase, comm));
+
+    myOut << "Test MultiVector's & Vector's default constructors" << endl;
+    {
+      MV defaultConstructedMultiVector;
+      auto dcmv_map = defaultConstructedMultiVector.getMap ();
+      TEST_ASSERT( dcmv_map.get () != nullptr );
+      if (dcmv_map.get () != nullptr) {
+        TEST_EQUALITY( dcmv_map->getGlobalNumElements (),
+                       Tpetra::global_size_t (0) );
+      }
+      vec_type defaultConstructedVector;
+      auto dcv_map = defaultConstructedVector.getMap ();
+      TEST_ASSERT( dcv_map.get () != nullptr );
+      if (dcv_map.get () != nullptr) {
+        TEST_EQUALITY( dcv_map->getGlobalNumElements (),
+                       Tpetra::global_size_t (0) );
+      }
+    }
+
+    myOut << "Test MultiVector's usual constructor" << endl;
+    RCP<MV> mvec;
+    TEST_NOTHROW( mvec = rcp (new MV (map, numVecs, true)) );
+    if (mvec.is_null ()) {
+      myOut << "MV constructor threw an exception: returning" << endl;
+      return;
+    }
+    TEST_EQUALITY( mvec->getNumVectors(), numVecs );
+    TEST_EQUALITY( mvec->getLocalLength(), numLocal );
+    TEST_EQUALITY( mvec->getGlobalLength(), numImages*numLocal );
+
+    myOut << "Test that all norms are zero" << endl;
+    Array<Magnitude> norms(numVecs), zeros(numVecs);
+    std::fill(zeros.begin(),zeros.end(),ScalarTraits<Magnitude>::zero());
+    TEST_NOTHROW( mvec->norm2(norms) );
+    TEST_COMPARE_FLOATING_ARRAYS(norms,zeros,ScalarTraits<Magnitude>::zero());
+    TEST_NOTHROW( mvec->norm1(norms) );
+    TEST_COMPARE_FLOATING_ARRAYS(norms,zeros,ScalarTraits<Magnitude>::zero());
+    TEST_NOTHROW( mvec->normInf(norms) );
+    TEST_COMPARE_FLOATING_ARRAYS(norms,zeros,ScalarTraits<Magnitude>::zero());
+    // print it
+    myOut << *mvec << endl;
+
+    // Make sure that the test passed on all processes, not just Proc 0.
+    int lclSuccess = success ? 1 : 0;
+    int gblSuccess = 1;
+    reduceAll<int, int> (*comm, REDUCE_MIN, lclSuccess, outArg (gblSuccess));
+    TEST_ASSERT( gblSuccess == 1 );
+  }
+
+
+  ////
   TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( MultiVector, BadConstLDA, LO, GO, Scalar , Node )
   {
     // numlocal > LDA
@@ -923,6 +1000,331 @@ namespace {
     // Create a Map.
     RCP<const Comm<int> > comm = getDefaultComm ();
     const size_t lclNumRows = 3;
+    const GST gblNumRows = comm->getSize () * lclNumRows;
+    const GO indexBase = 0;
+    RCP<const map_type> map3n =
+      rcp (new map_type (gblNumRows, lclNumRows, indexBase, comm));
+
+    const MT M0 = STM::zero ();
+    const ST S0 = STS::zero ();
+    const ST S1 = STS::one ();
+
+    // In what follows, '@' (without single quotes) denotes
+    // element-wise multiplication -- that is, what
+    // MultiVector::elementWiseMultiply implements.
+
+    const size_t maxNumVecs = 3;
+
+    // Test for various numbers of columns.
+    for (size_t numVecs = 1; numVecs <= maxNumVecs; ++numVecs) {
+      out << "Test numVecs = " << numVecs << endl;
+      Teuchos::OSTab tab1 (out);
+
+      // A (always) has 1 vector, and B and C have numVecs vectors.
+      V A (map3n);
+      MV B (map3n, numVecs);
+      MV C (map3n, numVecs);
+      MV C_exp (map3n, numVecs);
+      Array<MT> C_norms (C.getNumVectors ());
+      Array<MT> C_zeros (C.getNumVectors ());
+      std::fill (C_zeros.begin (), C_zeros.end (), M0);
+
+      int caseNum = 0;
+
+      caseNum++;
+      out << "Case " << caseNum << ": C = 0*C + 0*(A @ B)" << endl;
+      // Fill A and B initially with nonzero values, just for
+      // generality.  C should get filled with zeros afterwards.
+      // Prefill C with NaN, to ensure that the method follows BLAS
+      // update rules.
+      {
+        A.putScalar (S1);
+        B.putScalar (S1);
+
+        // Prefill C with NaN, if NaN exists for ST.
+        const ST nan = static_cast<ST> (Kokkos::Details::ArithTraits<IST>::nan ());
+        C.putScalar (nan);
+
+        C.elementWiseMultiply (S0, A, B, S0);
+
+        C_exp.putScalar (S0);
+        C_exp.update (S1, C, -S1);
+        C_exp.normInf (C_norms ());
+
+        TEST_COMPARE_FLOATING_ARRAYS( C_norms, C_zeros, M0 );
+      }
+
+      caseNum++;
+      out << "Case " << caseNum << ": C = 1*C + 0*(A @ B)" << endl;
+      // Fill A and B with NaN to check that the method follows BLAS
+      // update rules.
+      {
+        const ST S3 = S1 + S1 + S1;
+
+        // Prefill A and B with NaN, if NaN exists for ST.
+        const ST nan = static_cast<ST> (Kokkos::Details::ArithTraits<IST>::nan ());
+        A.putScalar (nan);
+        B.putScalar (nan);
+        C.putScalar (S3);
+
+        C.elementWiseMultiply (S0, A, B, S1);
+
+        C_exp.putScalar (S3);
+        C_exp.update (S1, C, -S1);
+        C_exp.normInf (C_norms ());
+
+        TEST_COMPARE_FLOATING_ARRAYS( C_norms, C_zeros, M0 );
+      }
+
+      caseNum++;
+      out << "Case " << caseNum << ": C = (-1)*C + 0*(A @ B)" << endl;
+      // Fill A and B with NaN to check that the method follows BLAS
+      // update rules.
+      {
+        // Prefill A and B with NaN, if NaN exists for ST.
+        const ST nan = static_cast<ST> (Kokkos::Details::ArithTraits<IST>::nan ());
+        A.putScalar (nan);
+        B.putScalar (nan);
+        C.putScalar (S1);
+
+        C.elementWiseMultiply (S0, A, B, -S1);
+
+        C_exp.putScalar (-S1);
+        C_exp.update (S1, C, -S1);
+        C_exp.normInf (C_norms ());
+
+        TEST_COMPARE_FLOATING_ARRAYS( C_norms, C_zeros, M0 );
+      }
+
+      caseNum++;
+      out << "Case " << caseNum << ": C = 2*C + 0*(A @ B)" << endl;
+      // Fill A and B with NaN to check that the method follows BLAS
+      // update rules.
+      {
+        const ST S2 = S1 + S1;
+
+        // Prefill A and B with NaN, if NaN exists for ST.
+        const ST nan = static_cast<ST> (Kokkos::Details::ArithTraits<IST>::nan ());
+        A.putScalar (nan);
+        B.putScalar (nan);
+        C.putScalar (S1);
+
+        C.elementWiseMultiply (S0, A, B, S2);
+
+        C_exp.putScalar (S2);
+        C_exp.update (S1, C, -S1);
+        C_exp.normInf (C_norms ());
+
+        TEST_COMPARE_FLOATING_ARRAYS( C_norms, C_zeros, M0 );
+      }
+
+      caseNum++;
+      out << "Case " << caseNum << ": C = 0*C + 1*(A @ B)" << endl;
+      // A and B will be filled with 1s, so C should get filled with 1s.
+      // Prefill C with NaN, to ensure that the method follows BLAS
+      // update rules.
+      {
+        A.putScalar (S1);
+        B.putScalar (S1);
+
+        // Prefill C with NaN, if NaN exists for ST.
+        const ST nan = static_cast<ST> (Kokkos::Details::ArithTraits<IST>::nan ());
+        C.putScalar (nan);
+
+        C.elementWiseMultiply (S1, A, B, S0);
+
+        C_exp.putScalar (S1);
+        C_exp.update (S1, C, -S1);
+        C_exp.normInf (C_norms ());
+
+        TEST_COMPARE_FLOATING_ARRAYS( C_norms, C_zeros, M0 );
+      }
+
+      caseNum++;
+      out << "Case " << caseNum << ": C = 0*C + (-1)*(A @ B)" << endl;
+      // A and B will be filled with 1, so C should get filled with -1.
+      // Prefill C with NaN, to ensure that the method follows BLAS
+      // update rules.
+      {
+        A.putScalar (S1);
+        B.putScalar (S1);
+
+        // Prefill C with NaN, if NaN exists for ST.
+        const ST nan = static_cast<ST> (Kokkos::Details::ArithTraits<IST>::nan ());
+        C.putScalar (nan);
+
+        C.elementWiseMultiply (-S1, A, B, S0);
+
+        C_exp.putScalar (-S1);
+        C_exp.update (S1, C, -S1);
+        C_exp.normInf (C_norms ());
+
+        TEST_COMPARE_FLOATING_ARRAYS( C_norms, C_zeros, M0 );
+      }
+
+      caseNum++;
+      out << "Case " << caseNum << ": C = 1*C + 1*(A @ B)" << endl;
+      // Fill A with 1, B with 2, and C with 3.  C should be 5 after.
+      {
+        const ST S2 = S1 + S1;
+        const ST S3 = S1 + S1 + S1;
+        const ST S5 = S2 + S3;
+        A.putScalar (S1);
+        B.putScalar (S2);
+        C.putScalar (S3);
+
+        C.elementWiseMultiply (S1, A, B, S1);
+
+        C_exp.putScalar (S5);
+        C_exp.update (S1, C, -S1);
+        C_exp.normInf (C_norms ());
+
+        TEST_COMPARE_FLOATING_ARRAYS( C_norms, C_zeros, M0 );
+      }
+
+      caseNum++;
+      out << "Case " << caseNum << ": C = (-1)*C + 1*(A @ B)" << endl;
+      // Fill A with 1, B with 2, and C with 3.  C should be -1 after.
+      {
+        const ST S2 = S1 + S1;
+        const ST S3 = S1 + S1 + S1;
+        A.putScalar (S1);
+        B.putScalar (S2);
+        C.putScalar (S3);
+
+        C.elementWiseMultiply (S1, A, B, -S1);
+
+        C_exp.putScalar (-S1);
+        C_exp.update (S1, C, -S1);
+        C_exp.normInf (C_norms ());
+
+        TEST_COMPARE_FLOATING_ARRAYS( C_norms, C_zeros, M0 );
+      }
+
+      caseNum++;
+      out << "Case " << caseNum << ": C = 1*C + (-1)*(A @ B)" << endl;
+      // Fill A with 2, B with 3, and C with 1.  C should be -5 after.
+      {
+        const ST S2 = S1 + S1;
+        const ST S3 = S2 + S1;
+        const ST S5 = S2 + S3;
+
+        A.putScalar (S2);
+        B.putScalar (S3);
+        C.putScalar (S1);
+
+        C.elementWiseMultiply (-S1, A, B, S1);
+
+        C_exp.putScalar (-S5);
+        C_exp.update (S1, C, -S1);
+        C_exp.normInf (C_norms ());
+
+        TEST_COMPARE_FLOATING_ARRAYS( C_norms, C_zeros, M0 );
+      }
+
+      caseNum++;
+      out << "Case " << caseNum << ": C = (-1)*C + (-1)*(A @ B)" << endl;
+      // Fill A with 1, B with 2, and C with 3.  C should be -5 after.
+      {
+        const ST S2 = S1 + S1;
+        const ST S3 = S1 + S1 + S1;
+        const ST S5 = S2 + S3;
+        A.putScalar (S1);
+        B.putScalar (S2);
+        C.putScalar (S3);
+
+        C.elementWiseMultiply (-S1, A, B, -S1);
+
+        C_exp.putScalar (-S5);
+        C_exp.update (S1, C, -S1);
+        C_exp.normInf (C_norms ());
+
+        TEST_COMPARE_FLOATING_ARRAYS( C_norms, C_zeros, M0 );
+      }
+
+      caseNum++;
+      out << "Case " << caseNum << ": C = 0*C + 2*(A @ B)" << endl;
+      // Fill A with 3 and B with 4.  C should be 24 after.
+      {
+        const ST S2 = S1 + S1;
+        const ST S3 = S2 + S1;
+        const ST S4 = S3 + S1;
+        const ST S24 = S2 * S3 * S4;
+
+        A.putScalar (S3);
+        B.putScalar (S4);
+
+        // Prefill C with NaN, if NaN exists for ST.
+        const ST nan = static_cast<ST> (Kokkos::Details::ArithTraits<IST>::nan ());
+        C.putScalar (nan);
+
+        C.elementWiseMultiply (S2, A, B, S0);
+
+        C_exp.putScalar (S24);
+        C_exp.update (S1, C, -S1);
+        C_exp.normInf (C_norms ());
+
+        TEST_COMPARE_FLOATING_ARRAYS( C_norms, C_zeros, M0 );
+      }
+
+      caseNum++;
+      out << "Case " << caseNum << ": C = (-2)*C + 2*(A @ B)" << endl;
+      // Fill A with 3, B with 4, and C with 5.  C should be 14 after.
+      {
+        const ST S2 = S1 + S1;
+        const ST S3 = S2 + S1;
+        const ST S4 = S3 + S1;
+        const ST S5 = S4 + S1;
+        const ST S14 = S5 * S2 + S4;
+
+        A.putScalar (S3);
+        B.putScalar (S4);
+        C.putScalar (S5);
+
+        C.elementWiseMultiply (S2, A, B, -S2);
+
+        C_exp.putScalar (S14);
+        C_exp.update (S1, C, -S1);
+        C_exp.normInf (C_norms ());
+
+        TEST_COMPARE_FLOATING_ARRAYS( C_norms, C_zeros, M0 );
+      }
+    }
+
+    // Make sure that the test passed on all processes, not just Proc 0.
+    int lclSuccess = success ? 1 : 0;
+    int gblSuccess = 1;
+    reduceAll<int, int> (*comm, REDUCE_MIN, lclSuccess, outArg (gblSuccess));
+    TEST_ASSERT( gblSuccess == 1 );
+  }
+
+  // Test Tpetra::MultiVector::elementWiseMultiply on a large multivector
+  //
+  // Be sure to exercise all combinations of the cases alpha =
+  // {-1,0,1,other} and beta = {-1,0,1,other}, as these commonly have
+  // special cases.
+  //
+  // Also be sure to exercise the common case (also often with a
+  // special-case implementation) where all the MultiVectors have one
+  // column.
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( MultiVector, ElementWiseMultiplyLg, LO , GO , ST , Node )
+  {
+    using Teuchos::View;
+    typedef Tpetra::global_size_t GST;
+    typedef Teuchos::ScalarTraits<ST> STS;
+    typedef typename STS::magnitudeType MT;
+    typedef Teuchos::ScalarTraits<MT> STM;
+    typedef Tpetra::Map<LO,GO,Node> map_type;
+    typedef Tpetra::MultiVector<ST,LO,GO,Node> MV;
+    typedef Tpetra::Vector<ST,LO,GO,Node> V;
+    typedef typename Kokkos::Details::ArithTraits<ST>::val_type IST;
+
+    out << "Tpetra::MultiVector::elementWiseMultiplyLg test" << endl;
+    Teuchos::OSTab tab0 (out);
+
+    // Create a Map.
+    RCP<const Comm<int> > comm = getDefaultComm ();
+    const size_t lclNumRows = 15000;
     const GST gblNumRows = comm->getSize () * lclNumRows;
     const GO indexBase = 0;
     RCP<const map_type> map3n =
@@ -4800,6 +5202,7 @@ namespace {
 
 #define UNIT_TEST_GROUP_BASE( SCALAR, LO, GO, NODE ) \
       TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( MultiVector, basic             , LO, GO, SCALAR, NODE ) \
+      TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( MultiVector, large             , LO, GO, SCALAR, NODE ) \
       TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( MultiVector, NonMemberConstructors, LO, GO, SCALAR, NODE ) \
       TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( MultiVector, BadConstLDA       , LO, GO, SCALAR, NODE ) \
       TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( MultiVector, BadConstAA        , LO, GO, SCALAR, NODE ) \
@@ -4822,6 +5225,7 @@ namespace {
       TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( MultiVector, SingleVecNormalize, LO, GO, SCALAR, NODE ) \
       TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( MultiVector, Multiply          , LO, GO, SCALAR, NODE ) \
       TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( MultiVector, ElementWiseMultiply,LO, GO, SCALAR, NODE ) \
+      TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( MultiVector, ElementWiseMultiplyLg,LO, GO, SCALAR, NODE ) \
       TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( MultiVector, NonContigView     , LO, GO, SCALAR, NODE ) \
       TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( MultiVector, Describable       , LO, GO, SCALAR, NODE ) \
       TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( MultiVector, Typedefs          , LO, GO, SCALAR, NODE ) \


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
Implements @vbrunini 's changes in #7315 via Tpetra::Details::Behavior environment variables.  Defaults to his value of 10000, but allows anyone to change the threshold via the TPETRA_VECTOR_DEVICE_THRESHOLD environment variable.

## Related Issues

* Closes #7315 

## Testing
Added a couple of long multivector tests.  Existing and new unit tests pass on vesper and eclipse.