### PR TITLE
amesos2: Fix build ifdef protection of Amesos2_cuSolver.hpp include.

### DIFF
--- a/packages/amesos2/src/Amesos2_Factory.hpp
+++ b/packages/amesos2/src/Amesos2_Factory.hpp
@@ -136,7 +136,7 @@
 #include "Amesos2_Cholmod.hpp"
 #endif
 
-#ifdef HAVE_AMESOS2_CUSOLVER
+#if defined (HAVE_AMESOS2_CUSOLVER) && defined (HAVE_AMESOS2_CUSPARSE)
 #include "Amesos2_cuSOLVER.hpp"
 #endif
 


### PR DESCRIPTION
Fixes build errors when using an installed Trilinos that defined
HAVE_AMESOS2_CUSOLVER but not HAVE_AMESOS2_CUSPARSE.

@srajama1 @lucbv 