### PR TITLE
Epetra: zero out nonlocal matrix during GlobalAssemble, plus override Print method

### DIFF
--- a/packages/epetra/src/Epetra_FECrsMatrix.cpp
+++ b/packages/epetra/src/Epetra_FECrsMatrix.cpp
@@ -1009,29 +1009,32 @@ int Epetra_FECrsMatrix::GlobalAssemble(const Epetra_Map& domain_map,
       const Epetra_CrsGraph& graph = tempMat_->Graph();
       Epetra_CrsGraph& nonconst_graph = const_cast<Epetra_CrsGraph&>(graph);
       nonconst_graph.SetIndicesAreGlobal(true);
-	}
-	}
-      //Now we need to call FillComplete on our temp matrix. We need to
-      //pass a DomainMap and RangeMap, which are not the same as the RowMap
-      //and ColMap that we constructed the matrix with.
-      EPETRA_CHK_ERR(tempMat_->FillComplete(domain_map, range_map));
-
-    if (exporter_ == NULL)
-      exporter_ = new Epetra_Export(tempMat_->RowMap(), RowMap());
-
-    EPETRA_CHK_ERR(Export(*tempMat_, *exporter_, combineMode));
-
-    if(callFillComplete) {
-      EPETRA_CHK_ERR(FillComplete(domain_map, range_map));
     }
+  }
 
-    //now reset the values in our nonlocal data
-    if (!useNonlocalMatrix_) {
-      for(size_t i=0; i<nonlocalRows_var.size(); ++i) {
-        nonlocalCols_var[i].resize(0);
-        nonlocalCoefs_[i].resize(0);
-      }
+  //Now we need to call FillComplete on our temp matrix. We need to
+  //pass a DomainMap and RangeMap, which are not the same as the RowMap
+  //and ColMap that we constructed the matrix with.
+  EPETRA_CHK_ERR(tempMat_->FillComplete(domain_map, range_map));
+
+  if (exporter_ == NULL)
+    exporter_ = new Epetra_Export(tempMat_->RowMap(), RowMap());
+
+  EPETRA_CHK_ERR(Export(*tempMat_, *exporter_, combineMode));
+
+  if(callFillComplete) {
+    EPETRA_CHK_ERR(FillComplete(domain_map, range_map));
+  }
+
+  //now reset the values in our nonlocal data
+  if (useNonlocalMatrix_) {
+    nonlocalMatrix_->PutScalar(0.0);
+  } else {
+    for(size_t i=0; i<nonlocalRows_var.size(); ++i) {
+      nonlocalCols_var[i].resize(0);
+      nonlocalCoefs_[i].resize(0);
     }
+  }
 
   if (!save_off_and_reuse_map_exporter) {
     delete exporter_;

--- a/packages/epetra/src/Epetra_FECrsMatrix.h
+++ b/packages/epetra/src/Epetra_FECrsMatrix.h
@@ -166,6 +166,7 @@ class EPETRA_LIB_DLL_EXPORT Epetra_FECrsMatrix : public Epetra_CrsMatrix {
 
    enum { ROW_MAJOR = 0, COLUMN_MAJOR = 3 };
 
+   void Print(std::ostream& os) const;
 #if !defined(EPETRA_NO_32BIT_GLOBAL_INDICES) || !defined(EPETRA_NO_64BIT_GLOBAL_INDICES)
    using Epetra_CrsMatrix::SumIntoGlobalValues;
    using Epetra_CrsMatrix::InsertGlobalValues;


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/epetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
This PR addresses issue #7349 . The behavior of GlobalAssemble in the cases where nonlocal matrix is used was slightly different from the case where it wasn't used. In particular, the nonlocal matrix was not zeroed out at the end. If the matrix was then reused later on, old entries were then going to pollute the matrix. Note that calling PutScalar(0.0) on the matrix has no effect on nonlocal entries, since there's no overridde inside the FECrs matrix class.

## Related Issues

* Closes #7349 

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
There are no tests for FECrs matrix with more than 1 rank. I am not sure why that is, but the changes have no effect in case of single rank. Is it ok to run the FECrsMatrix test with 2 ranks?
 
## Additional Information
I also added an override of the Print method, which also prints nonlocal rows. This helped me identifying what the issue was in my application. Otherwise, there was no way for me to access the nonlocal rows information, and make sure it was consistent with what I expected. This print method, made me realize it wasn't.