### PR TITLE
Tempus: Add TimeEvent Object

### DIFF
--- a/packages/tempus/src/Tempus_StepperRKAppActionComposite.hpp
+++ b/packages/tempus/src/Tempus_StepperRKAppActionComposite.hpp
@@ -17,7 +17,7 @@ namespace Tempus {
 
 /** \brief This composite AppAction loops over added AppActions.
  *
- *  Inidividual AppActions are executed in the order in which they
+ *  Individual AppActions are executed in the order in which they
  *  were added.
  */
 template<class Scalar>
@@ -50,7 +50,7 @@ public:
 
   // Clear the AppAction vector.
   void clearRKAppActions();
-  { appActions_.clear();}
+  { appActions_.clear(); }
 
   // Return the size of the AppAction vector.
   std::size_t getSize() const { return appActions_.size(); }

--- a/packages/tempus/src/Tempus_TimeEventBase.hpp
+++ b/packages/tempus/src/Tempus_TimeEventBase.hpp
@@ -1,0 +1,118 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#ifndef Tempus_TimeEventBase_decl_hpp
+#define Tempus_TimeEventBase_decl_hpp
+
+// Teuchos
+#include "Teuchos_Time.hpp"
+#include "Teuchos_VerboseObject.hpp"
+
+
+namespace Tempus {
+
+
+/** \brief This class defines time events which can be used to "trigger" an action.
+ *  Time events are points in time and/or timestep index where an
+ *  an action should occur, such as, solution output (mesh and solution)
+ *  diagnostic output, restart, screen dump, in-situ visualization,
+ *  user-specified, or any other action.
+ *
+ *  This class will store a collection time events, so that an object
+ *  may quiry it and take appropriate action.  Time events (time and
+ *  timestep index) can be specified via
+ *    - start, stop and stride
+ *    - list of events
+ *
+ */
+template<class Scalar>
+class TimeEventBase
+{
+public:
+
+  /// Constructor
+  TimeEventBase()
+    : name_("TimeEventBase"),
+      defaultTime_ (-std::numeric_limits<Scalar>::max()*1.0e-16),
+      defaultTol_  ( std::numeric_limits<Scalar>::min()),
+      defaultIndex_( std::numeric_limits<int>::min())
+  {}
+
+  /// Destructor
+  virtual ~TimeEventBase() {}
+
+  /// \name Basic methods
+  //@{
+    /// Test if time is near a TimeEvent (within tolerance).
+    virtual bool isTime(Scalar time) const
+    { return false; }
+
+    virtual Scalar getAbsTol() const
+    { return defaultTol_; }
+
+    /// How much time until the next event. Negative indicating the last event is in the past.
+    virtual Scalar timeToNextEvent(Scalar time) const
+    { return defaultTime_; }
+
+    /// Time of the next event. Negative indicating the last event is in the past.
+    virtual Scalar timeOfNextEvent(Scalar time) const
+    { return defaultTime_; }
+
+    /// Test if an event occurs within the time range.
+    virtual bool eventInRange(Scalar time1, Scalar time2) const
+    { return false; }
+
+    /// Test if index is a time event.
+    virtual bool isIndex(int index) const
+    { return false; }
+
+    /// How many indices until the next event. Negative indicating the last event is in the past.
+    virtual int indexToNextEvent(int index) const
+    { return defaultIndex_; }
+
+    /// Index of the next event. Negative indicating the last event is in the past.
+    virtual int indexOfNextEvent(int index) const
+    { return defaultIndex_; }
+
+    /// Test if an event occurs within the time range.
+    virtual bool eventInRangeIndex(int index1, int index2) const
+    { return false; }
+
+    /// Describe member data.
+    virtual void describe() const
+    {
+      Teuchos::RCP<Teuchos::FancyOStream> out =
+        Teuchos::VerboseObjectBase::getDefaultOStream();
+      *out << "TimeEventBase name = " << getName() << std::endl;
+    }
+  //@}
+
+  /// \name Accessor methods
+  //@{
+    virtual std::string getName() const { return name_; }
+    virtual void setName(std::string name) { name_ = name; }
+
+    virtual Scalar getDefaultTime () const { return defaultTime_; }
+    virtual Scalar getDefaultTol  () const { return defaultTol_; }
+    virtual int    getDefaultIndex() const { return defaultIndex_; }
+  //@}
+
+
+private:
+
+  std::string  name_;
+  const Scalar defaultTime_;
+  const Scalar defaultTol_;
+  const int    defaultIndex_;
+
+};
+
+
+} // namespace Tempus
+
+#endif // Tempus_TimeEventBase_decl_hpp

--- a/packages/tempus/src/Tempus_TimeEventComposite.hpp
+++ b/packages/tempus/src/Tempus_TimeEventComposite.hpp
@@ -1,0 +1,210 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#ifndef Tempus_TimeEventComposite_decl_hpp
+#define Tempus_TimeEventComposite_decl_hpp
+
+// Teuchos
+#include "Teuchos_Time.hpp"
+
+// Tempus
+#include "Tempus_TimeEventBase.hpp"
+
+
+namespace Tempus {
+
+
+/** \brief This composite TimeEvent loops over added TimeEvents.
+ *
+ *  Individual TimeEvents are executed in the order in which they
+ *  were added.
+ */
+template<class Scalar>
+class TimeEventComposite : virtual public TimeEventBase<Scalar>
+{
+public:
+
+  /// Constructor
+  TimeEventComposite()
+  {
+    this->setName("TimeEventComposite");
+  }
+
+  /// Destructor
+  virtual ~TimeEventComposite() {}
+
+  /// \name Basic methods
+  //@{
+    /// Test if time is near a TimeEvent (within tolerance).
+    virtual bool isTime(Scalar time) const
+    {
+      bool is_time = false;
+      for(auto& e : timeEvents_) {
+        if (e->isTime(time)) {
+          is_time = true;
+          break;
+        }
+      }
+      return is_time;
+    }
+
+    /// How much time until the next event. Negative indicating the last event is in the past.
+    virtual Scalar timeToNextEvent(Scalar time) const
+    {
+      return timeOfNextEvent(time) - time;
+    }
+
+    /// Time of the next event. Negative indicating the last event is in the past.
+    virtual Scalar timeOfNextEvent(Scalar time) const
+    {
+      std::vector< std::pair<Scalar, Scalar> > timeAbs;
+      for(auto& e : timeEvents_)
+        timeAbs.push_back(std::make_pair(e->timeOfNextEvent(time), e->getAbsTol()));
+      std::sort(timeAbs.begin(), timeAbs.end());
+
+      if (timeAbs.size() == 0) return this->getDefaultTime();
+
+      // Check if before or close to first event.
+      if (timeAbs.front().first >= time-timeAbs.front().second)
+        return timeAbs.front().first;
+
+      // Check if after or close to last event.
+      if (timeAbs.back().first <= time+timeAbs.front().second)
+        return timeAbs.back().first;
+
+      typename std::vector< std::pair<Scalar, Scalar> >::const_iterator it =
+        std::upper_bound(timeAbs.begin(), timeAbs.end(), std::make_pair(time, 0.0));
+
+      // Check if close to left-side time event
+      const Scalar timeOfLeftEvent   = (*(it-1)).first;
+      const Scalar absTolOfLeftEvent = (*(it-1)).second;
+      if (timeOfLeftEvent > time - absTolOfLeftEvent &&
+          timeOfLeftEvent < time + absTolOfLeftEvent)
+        return timeOfLeftEvent;
+
+      // Otherwise it is the next event.
+      return (*it).first;
+    }
+
+    /// Test if an event occurs within the time range.
+    virtual bool eventInRange(Scalar time1, Scalar time2) const
+    {
+      bool inRange = false;
+      for(auto& e : timeEvents_) {
+        if (e->eventInRange(time1, time2)) {
+          inRange = true;
+          break;
+        }
+      }
+      return inRange;
+    }
+
+    /// Test if index is a time event.TimeEventBase
+    virtual bool isIndex(int index) const
+    {
+      bool is_index = false;
+      for(auto& e : timeEvents_) {
+        if (e->isIndex(index)) {
+          is_index = true;
+          break;
+        }
+      }
+      return is_index;
+    }
+
+    /// How many indices until the next event. Negative indicating the last event is in the past.
+    virtual int indexToNextEvent(int index) const
+    {
+      return indexOfNextEvent(index) - index;
+    }
+
+    /// Index of the next event. Negative indicating the last event is in the past.
+    virtual int indexOfNextEvent(int index) const
+    {
+      std::vector<int> indexList;
+      for(auto& e : timeEvents_)
+        indexList.push_back(e->indexOfNextEvent(index));
+
+      std::sort(indexList.begin(), indexList.end());
+      indexList.erase(std::unique(
+        indexList.begin(), indexList.end()), indexList.end());
+
+      if (indexList.size() == 0) return this->getDefaultIndex();
+
+      // Check if before first event.
+      if (indexList.front() >= index) return indexList.front();
+
+      // Check if after last event.
+      if (indexList.back() <= index) return indexList.back();
+
+      std::vector<int>::const_iterator it =
+        std::upper_bound(indexList.begin(), indexList.end(), index);
+
+      // Check if left-side index event
+      const Scalar indexOfLeftEvent = *(it-1);
+      if (indexOfLeftEvent == index) return indexOfLeftEvent;
+
+      // Otherwise it is the next event.
+      return *it;
+
+    }
+
+    /// Test if an event occurs within the time range.
+    virtual bool eventInRangeIndex(int index1, int index2) const
+    {
+      bool inRange = false;
+      for(auto& e : timeEvents_) {
+        if (e->eventInRangeIndex(index1, index2)) {
+          inRange = true;
+          break;
+        }
+      }
+      return inRange;
+    }
+  //@}
+
+
+  // Add TimeEvent to the TimeEvent vector.
+  void addTimeEvent(Teuchos::RCP<TimeEventBase<Scalar> > timeEvent)
+  {
+    timeEvents_.push_back(timeEvent);
+  }
+
+  // Clear the TimeEvent vector.
+  void clearTimeEvents()
+  { timeEvents_.clear(); }
+
+  // Return the size of the TimeEvent vector.
+  std::size_t getSize() const { return timeEvents_.size(); }
+
+  /// Describe member data.
+  virtual void describe() const
+  {
+    Teuchos::RCP<Teuchos::FancyOStream> out =
+      Teuchos::VerboseObjectBase::getDefaultOStream();
+    *out << "TimeEventComposite:" << "\n"
+        << "name                 = " << this->getName() << "\n"
+        << "Number of TimeEvents = " << timeEvents_.size() << std::endl;
+    *out << "--------------------------------------------" << std::endl;
+    for(auto& e : timeEvents_) {
+      (*e).describe();
+      *out << "--------------------------------------------" << std::endl;
+    }
+  }
+
+
+protected:
+
+  std::vector<Teuchos::RCP<TimeEventBase<Scalar > > > timeEvents_;
+
+};
+
+
+} // namespace Tempus
+
+#endif // Tempus_TimeEventComposite_decl_hpp

--- a/packages/tempus/src/Tempus_TimeEventList.cpp
+++ b/packages/tempus/src/Tempus_TimeEventList.cpp
@@ -1,0 +1,21 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Tempus_ExplicitTemplateInstantiation.hpp"
+
+#ifdef HAVE_TEMPUS_EXPLICIT_INSTANTIATION
+#include "Tempus_TimeEventList.hpp"
+#include "Tempus_TimeEventList_impl.hpp"
+
+namespace Tempus {
+
+  TEMPUS_INSTANTIATE_TEMPLATE_CLASS(TimeEventList)
+
+} // namespace Tempus
+
+#endif

--- a/packages/tempus/src/Tempus_TimeEventListIndex.cpp
+++ b/packages/tempus/src/Tempus_TimeEventListIndex.cpp
@@ -1,0 +1,21 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Tempus_ExplicitTemplateInstantiation.hpp"
+
+#ifdef HAVE_TEMPUS_EXPLICIT_INSTANTIATION
+#include "Tempus_TimeEventListIndex.hpp"
+#include "Tempus_TimeEventListIndex_impl.hpp"
+
+namespace Tempus {
+
+  TEMPUS_INSTANTIATE_TEMPLATE_CLASS(TimeEventListIndex)
+
+} // namespace Tempus
+
+#endif

--- a/packages/tempus/src/Tempus_TimeEventListIndex_decl.hpp
+++ b/packages/tempus/src/Tempus_TimeEventListIndex_decl.hpp
@@ -1,0 +1,78 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#ifndef Tempus_TimeEventListIndex_decl_hpp
+#define Tempus_TimeEventListIndex_decl_hpp
+
+#include <vector>
+
+// Teuchos
+#include "Teuchos_Time.hpp"
+
+// Tempus
+#include "Tempus_TimeEventBase.hpp"
+
+
+namespace Tempus {
+
+
+/** \brief TimeEventListIndex specifies a list of index events.
+ *
+ *
+ */
+template<class Scalar>
+class TimeEventListIndex : virtual public TimeEventBase<Scalar>
+{
+public:
+
+  /// Default constructor.
+  TimeEventListIndex();
+
+  /// Construct with full argument list of data members.
+  TimeEventListIndex(std::string name, std::vector<int> indexList);
+
+  /// Destructor
+  virtual ~TimeEventListIndex() {}
+
+  /// \name Basic methods
+  //@{
+    /// Test if index is near a index event (within tolerance).
+    virtual bool isIndex(int index) const;
+
+    /// How many indices until the next event. Negative indicating the last event is in the past.
+    virtual int indexToNextEvent(int index) const;
+
+    /// Index of the next event. Negative indicating the last event is in the past.
+    virtual int indexOfNextEvent(int index) const;
+
+    /// Test if an event occurs within the index range.
+    virtual bool eventInRangeIndex(int index1, int index2) const;
+
+    /// Describe member data.
+    virtual void describe() const;
+  //@}
+
+  /// \name Accessor methods
+  //@{
+    virtual std::vector<int> getIndexList() const { return indexList_; }
+    virtual void setIndexList(std::vector<int> indexList, bool sort = true);
+    virtual void addIndex(int index);
+    virtual void clearIndexList() { indexList_.clear(); }
+  //@}
+
+
+protected:
+
+  std::vector<int> indexList_; // Sorted and unique list of index events.
+
+};
+
+
+} // namespace Tempus
+
+#endif // Tempus_TimeEventListIndex_decl_hpp

--- a/packages/tempus/src/Tempus_TimeEventListIndex_impl.hpp
+++ b/packages/tempus/src/Tempus_TimeEventListIndex_impl.hpp
@@ -1,0 +1,139 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#ifndef Tempus_TimeEventListIndex_impl_hpp
+#define Tempus_TimeEventListIndex_impl_hpp
+
+
+namespace Tempus {
+
+template<class Scalar>
+TimeEventListIndex<Scalar>::TimeEventListIndex()
+{
+  this->setName("TimeEventListIndex");
+}
+
+
+template<class Scalar>
+TimeEventListIndex<Scalar>::TimeEventListIndex(
+  std::string name, std::vector<int> indexList)
+{
+  this->setName(name);
+  this->setIndexList(indexList);
+}
+
+
+template<class Scalar>
+void TimeEventListIndex<Scalar>::setIndexList(std::vector<int> indexList, bool sort)
+{
+  indexList_ = indexList;
+  if (sort) {
+    std::sort(indexList_.begin(), indexList_.end());
+    indexList_.erase(std::unique(
+      indexList_.begin(), indexList_.end()), indexList_.end());
+  }
+}
+
+
+template<class Scalar>
+void TimeEventListIndex<Scalar>::addIndex(int index)
+{
+  if (indexList_.size() == 0) {
+    indexList_.push_back(index);
+    return;
+  }
+
+  std::vector<int>::iterator it;
+  it = std::find(indexList_.begin(), indexList_.end(), index);
+  // Check if index is already in list.
+  if (it != indexList_.end()) return;
+
+  it = std::upper_bound(indexList_.begin(), indexList_.end(), index);
+  indexList_.insert(it, index);
+}
+
+
+template<class Scalar>
+bool TimeEventListIndex<Scalar>::isIndex(int index) const
+{
+  return (indexToNextEvent(index) == 0);
+}
+
+
+template<class Scalar>
+int TimeEventListIndex<Scalar>::indexToNextEvent(int index) const
+{
+  return indexOfNextEvent(index) - index;  // Neg. indicating in the past.
+}
+
+
+template<class Scalar>
+int TimeEventListIndex<Scalar>::indexOfNextEvent(int index) const
+{
+  if (indexList_.size() == 0) return this->getDefaultIndex();
+
+  // Check if before first event.
+  if (indexList_.front() >= index) return indexList_.front();
+
+  // Check if after last event.
+  if (indexList_.back() <= index) return indexList_.back();
+
+  std::vector<int>::const_iterator it =
+    std::upper_bound(indexList_.begin(), indexList_.end(), index);
+
+  // Check if left-side index event
+  const Scalar indexOfLeftEvent = *(it-1);
+  if (indexOfLeftEvent == index) return indexOfLeftEvent;
+
+  // Otherwise it is the next event.
+  return *it;
+}
+
+
+template<class Scalar>
+bool TimeEventListIndex<Scalar>::eventInRangeIndex(int index1, int index2) const
+{
+  if (index1 > index2) {
+    int tmp = index1;
+    index1 = index2;
+    index2 = tmp;
+  }
+
+  if (indexList_.size() == 0) return false;
+
+  // Check if range is completely outside index events.
+  if (index2 < indexList_.front() || indexList_.back() < index1) return false;
+
+  Scalar indexEvent1 = indexOfNextEvent(index1);
+  Scalar indexEvent2 = indexOfNextEvent(index2);
+  // Check if the next index event is different for the two indices.
+  if (indexEvent1 != indexEvent2) return true;
+
+  // Check if indices bracket index event.
+  if (index1 <= indexEvent1 && indexEvent1 <= index2) return true;
+
+  return false;
+}
+
+
+template<class Scalar>
+void TimeEventListIndex<Scalar>::describe() const
+{
+  Teuchos::RCP<Teuchos::FancyOStream> out =
+    Teuchos::VerboseObjectBase::getDefaultOStream();
+  *out << "TimeEventListIndex:" << "\n"
+       << "name       = " << this->getName() << "\n"
+       << "IndexList_ = " << std::endl;
+  for (auto it = indexList_.begin(); it != indexList_.end()-1; ++it)
+    *out << *it << ", ";
+  *out << *(indexList_.end()-1) << "\n";
+}
+
+
+} // namespace Tempus
+#endif // Tempus_TimeEventListIndex_impl_hpp

--- a/packages/tempus/src/Tempus_TimeEventList_decl.hpp
+++ b/packages/tempus/src/Tempus_TimeEventList_decl.hpp
@@ -1,0 +1,93 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#ifndef Tempus_TimeEventList_decl_hpp
+#define Tempus_TimeEventList_decl_hpp
+
+#include <vector>
+
+// Teuchos
+#include "Teuchos_Time.hpp"
+
+// Tempus
+#include "Tempus_TimeEventBase.hpp"
+
+
+namespace Tempus {
+
+
+/** \brief TimeEventList specifies a list of time events.
+ *
+ *
+ */
+template<class Scalar>
+class TimeEventList : virtual public TimeEventBase<Scalar>
+{
+public:
+
+  /// Default constructor.
+  TimeEventList();
+
+  /// Construct with full argument list of data members.
+  TimeEventList(std::string name, std::vector<Scalar> timeList,
+                 Scalar relTol, bool landOnExactly);
+
+  /// Destructor
+  virtual ~TimeEventList() {}
+
+  /// \name Basic methods
+  //@{
+    /// Test if time is near a TimeEvent (within tolerance).
+    virtual bool isTime(Scalar time) const;
+
+    /// How much time until the next event. Negative indicating the last event is in the past.
+    virtual Scalar timeToNextEvent(Scalar time) const;
+
+    /// Time of the next event. Negative indicating the last event is in the past.
+    virtual Scalar timeOfNextEvent(Scalar time) const;
+
+    /// Test if an event occurs within the time range.
+    virtual bool eventInRange(Scalar time1, Scalar time2) const;
+
+    /// Describe member data.
+    virtual void describe() const;
+  //@}
+
+  /// \name Accessor methods
+  //@{
+    virtual std::vector<Scalar> getTimeList() const { return timeList_; }
+    virtual void setTimeList(std::vector<Scalar> timeList);
+    virtual void addTime(Scalar time);
+    virtual void clearTimeList() { timeList_.clear(); }
+
+    virtual Scalar getRelTol() const { return relTol_; }
+    virtual void setRelTol(Scalar relTol);
+
+    virtual Scalar getAbsTol() const { return absTol_; }
+
+    virtual bool getLandOnExactly() const { return landOnExactly_; }
+    virtual void setLandOnExactly(bool LOE) { landOnExactly_ = LOE; }
+  //@}
+
+
+protected:
+
+  virtual void setTimeScale();
+
+  std::vector<Scalar> timeList_; ///< Sorted and unique list of time events.
+
+  Scalar timeScale_;     ///< A reference time scale, max(abs(start_,stop_)).
+  Scalar relTol_;        ///< Relative time tolerance for matching time events.
+  Scalar absTol_;        ///< Absolute time tolerance, relTol_*timeScale_.
+  bool   landOnExactly_; ///< Should these time events be landed on exactly, i.e, adjust the timestep to hit time event, versus stepping over and keeping the time step unchanged.
+};
+
+
+} // namespace Tempus
+
+#endif // Tempus_TimeEventList_decl_hpp

--- a/packages/tempus/src/Tempus_TimeEventList_impl.hpp
+++ b/packages/tempus/src/Tempus_TimeEventList_impl.hpp
@@ -1,0 +1,193 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#ifndef Tempus_TimeEventList_impl_hpp
+#define Tempus_TimeEventList_impl_hpp
+
+
+namespace Tempus {
+
+template<class Scalar>
+TimeEventList<Scalar>::TimeEventList()
+{
+  this->setName("TimeEventList");
+  setRelTol(1.0e-14);
+  setTimeScale();
+  setLandOnExactly(true);
+}
+
+
+template<class Scalar>
+TimeEventList<Scalar>::TimeEventList(
+  std::string name, std::vector<Scalar> timeList,
+  Scalar relTol, bool landOnExactly)
+{
+  this->setName(name);
+  setRelTol(relTol);
+  setTimeScale();
+  setLandOnExactly(landOnExactly);
+  setTimeList(timeList);
+}
+
+
+template<class Scalar>
+void TimeEventList<Scalar>::setTimeScale()
+{
+  if (timeList_.size() == 0) {
+    timeScale_ = std::abs(this->getDefaultTime());
+    absTol_ = relTol_*timeScale_;
+    return;
+  }
+
+  timeScale_ = std::max(std::abs(timeList_.front()),
+                        std::abs(timeList_.back()));
+  absTol_ = relTol_*timeScale_;
+
+  // Check if timeScale is near zero.
+  if ((-absTol_ <= timeScale_ ) && (timeScale_ <= absTol_)) {
+    timeScale_ = 1.0;
+    absTol_ = relTol_*timeScale_;
+  }
+}
+
+
+template<class Scalar>
+void TimeEventList<Scalar>::setTimeList(std::vector<Scalar> timeList)
+{
+  for(auto it = std::begin(timeList); it != std::end(timeList); ++it)
+    addTime(*it);
+}
+
+
+template<class Scalar>
+void TimeEventList<Scalar>::addTime(Scalar time)
+{
+  if (timeList_.size() == 0) {
+    timeList_.push_back(time);
+    setTimeScale();
+    return;
+  }
+
+  auto it = std::upper_bound(timeList_.begin(), timeList_.end(), time);
+  if (timeList_.size() == 1) {
+    // Only add if a "different" time.
+    if (std::abs(timeList_.front()-time) >= absTol_)
+      timeList_.insert(it, time);
+    setTimeScale();
+    return;
+  }
+
+  // Don't add if already in list. Check both ends.
+  if (it == timeList_.begin()) {
+    if (std::abs(timeList_.front()-time) >= absTol_)
+      timeList_.insert(it, time);
+  } else if (it == timeList_.end()) {
+    if (std::abs(timeList_.back()-time) >= absTol_)
+      timeList_.insert(it, time);
+  } else if (std::abs(*(it-1) - time) >= absTol_ &&
+             std::abs(*(it  ) - time) >= absTol_) {
+    timeList_.insert(it, time);
+  }
+  setTimeScale();
+}
+
+
+template<class Scalar>
+void TimeEventList<Scalar>::setRelTol(Scalar relTol)
+{
+  relTol_ = std::abs(relTol);
+  setTimeScale();
+}
+
+
+template<class Scalar>
+bool TimeEventList<Scalar>::isTime(Scalar time) const
+{
+  return (std::abs(timeToNextEvent(time)) <= absTol_);
+}
+
+
+template<class Scalar>
+Scalar TimeEventList<Scalar>::timeToNextEvent(Scalar time) const
+{
+  return timeOfNextEvent(time) - time;  // Neg. indicating in the past.
+}
+
+
+template<class Scalar>
+Scalar TimeEventList<Scalar>::timeOfNextEvent(Scalar time) const
+{
+  if (timeList_.size() == 0) return this->getDefaultTime();
+
+  // Check if before or close to first event.
+  if (timeList_.front() >= time-absTol_) return timeList_.front();
+
+  // Check if after or close to last event.
+  if (timeList_.back() <= time+absTol_) return timeList_.back();
+
+  typename std::vector<Scalar>::const_iterator it =
+    std::upper_bound(timeList_.begin(), timeList_.end(), time);
+
+  // Check if close to left-side time event
+  const Scalar timeOfLeftEvent = *(it-1);
+  if (timeOfLeftEvent > time-absTol_ &&
+      timeOfLeftEvent < time+absTol_) return timeOfLeftEvent;
+
+  // Otherwise it is the next event.
+  return *it;
+}
+
+
+template<class Scalar>
+bool TimeEventList<Scalar>::eventInRange(
+  Scalar time1, Scalar time2) const
+{
+  if (time1 > time2) {
+    Scalar tmp = time1;
+    time1 = time2;
+    time2 = tmp;
+  }
+
+  if (timeList_.size() == 0) return false;
+
+  // Check if range is completely outside time events.
+  if (time2+absTol_ < timeList_.front() ||
+       timeList_.back() < time1-absTol_) return false;
+
+  Scalar timeEvent1 = timeOfNextEvent(time1);
+  Scalar timeEvent2 = timeOfNextEvent(time2);
+  // Check if the next time event is different for the two times.
+  if (timeEvent1 != timeEvent2) return true;
+
+  // Check if times bracket time event.
+  if (time1-absTol_ <= timeEvent1 && timeEvent1 <= time2+absTol_) return true;
+
+  return false;
+}
+
+
+template<class Scalar>
+void TimeEventList<Scalar>::describe() const
+{
+  Teuchos::RCP<Teuchos::FancyOStream> out =
+    Teuchos::VerboseObjectBase::getDefaultOStream();
+  *out << "TimeEventList:" << "\n"
+       << "name           = " << this->getName() << "\n"
+       << "timeScale_     = " << timeScale_     << "\n"
+       << "relTol_        = " << relTol_        << "\n"
+       << "absTol_        = " << absTol_        << "\n"
+       << "landOnExactly_ = " << landOnExactly_ << "\n"
+       << "timeList_      = " << std::endl;
+  for (auto it = timeList_.begin(); it != timeList_.end()-1; ++it)
+    *out << *it << ", ";
+  *out << *(timeList_.end()-1) << "\n";
+}
+
+
+} // namespace Tempus
+#endif // Tempus_TimeEventList_impl_hpp

--- a/packages/tempus/src/Tempus_TimeEventRange.cpp
+++ b/packages/tempus/src/Tempus_TimeEventRange.cpp
@@ -1,0 +1,21 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Tempus_ExplicitTemplateInstantiation.hpp"
+
+#ifdef HAVE_TEMPUS_EXPLICIT_INSTANTIATION
+#include "Tempus_TimeEventRange.hpp"
+#include "Tempus_TimeEventRange_impl.hpp"
+
+namespace Tempus {
+
+  TEMPUS_INSTANTIATE_TEMPLATE_CLASS(TimeEventRange)
+
+} // namespace Tempus
+
+#endif

--- a/packages/tempus/src/Tempus_TimeEventRangeIndex.cpp
+++ b/packages/tempus/src/Tempus_TimeEventRangeIndex.cpp
@@ -1,0 +1,21 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Tempus_ExplicitTemplateInstantiation.hpp"
+
+#ifdef HAVE_TEMPUS_EXPLICIT_INSTANTIATION
+#include "Tempus_TimeEventRangeIndex.hpp"
+#include "Tempus_TimeEventRangeIndex_impl.hpp"
+
+namespace Tempus {
+
+  TEMPUS_INSTANTIATE_TEMPLATE_CLASS(TimeEventRangeIndex)
+
+} // namespace Tempus
+
+#endif

--- a/packages/tempus/src/Tempus_TimeEventRangeIndex_decl.hpp
+++ b/packages/tempus/src/Tempus_TimeEventRangeIndex_decl.hpp
@@ -1,0 +1,91 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#ifndef Tempus_TimeEventIndexRange_decl_hpp
+#define Tempus_TimeEventIndexRange_decl_hpp
+
+#include <tuple>
+
+// Teuchos
+#include "Teuchos_Time.hpp"
+
+// Tempus
+#include "Tempus_TimeEventBase.hpp"
+
+
+namespace Tempus {
+
+
+/** \brief TimeEventRangeIndex specifies a start, stop and stride index.
+ *
+ *
+ */
+template<class Scalar>
+class TimeEventRangeIndex : virtual public TimeEventBase<Scalar>
+{
+public:
+
+  /// Default constructor.
+  TimeEventRangeIndex();
+
+  /// Construct with full argument list of data members.
+  TimeEventRangeIndex(std::string name, int start, int stop, int stride);
+
+  /// Destructor
+  virtual ~TimeEventRangeIndex() {}
+
+  /// \name Basic methods
+  //@{
+    /// Test if index is a time event.
+    virtual bool isIndex(int index) const;
+
+    /// How many indices until the next event. Negative indicating the last event is in the past.
+    virtual int indexToNextEvent(int index) const;
+
+    /// Index of the next event. Negative indicating the last event is in the past.
+    virtual int indexOfNextEvent(int index) const;
+
+    /// Test if an event occurs within the index range.
+    virtual bool eventInRangeIndex(int index1, int index2) const;
+
+    /// Describe member data.
+    virtual void describe() const;
+  //@}
+
+  /// \name Accessor methods
+  //@{
+    virtual void setIndexRange(int start, int stop, int stride)
+    { setIndexStart(start); setIndexStop(stop); setIndexStride(stride); }
+
+    virtual int getIndexStart() const { return start_; }
+    virtual void setIndexStart(int start);
+
+    virtual int getIndexStop() const { return stop_; }
+    virtual void setIndexStop(int stop);
+
+    virtual int getIndexStride() const { return stride_; }
+    virtual void setIndexStride(int stride);
+
+    virtual int getNumEvents() const { return numEvents_; }
+    virtual void setNumEvents();
+  //@}
+
+
+protected:
+
+  int start_;
+  int stop_;
+  int stride_;
+  unsigned numEvents_;
+
+};
+
+
+} // namespace Tempus
+
+#endif // Tempus_TimeEventIndexRange_decl_hpp

--- a/packages/tempus/src/Tempus_TimeEventRangeIndex_impl.hpp
+++ b/packages/tempus/src/Tempus_TimeEventRangeIndex_impl.hpp
@@ -1,0 +1,152 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#ifndef Tempus_TimeEventRangeIndex_impl_hpp
+#define Tempus_TimeEventRangeIndex_impl_hpp
+
+
+namespace Tempus {
+
+template<class Scalar>
+TimeEventRangeIndex<Scalar>::TimeEventRangeIndex()
+  : start_(0), stop_(0), stride_(1)
+{
+  this->setName("TimeEventRangeIndex");
+  setNumEvents();
+}
+
+
+template<class Scalar>
+TimeEventRangeIndex<Scalar>::TimeEventRangeIndex(
+  std::string name, int start, int stop, int stride)
+{
+  this->setName(name);
+  this->setIndexRange(start, stop, stride);
+}
+
+
+template<class Scalar>
+void TimeEventRangeIndex<Scalar>::setIndexStart(int start)
+{
+  start_ = start;
+  if (stop_ < start_) {
+    stop_ = start_;
+  }
+  setNumEvents();
+}
+
+
+template<class Scalar>
+void TimeEventRangeIndex<Scalar>::setIndexStop(int stop)
+{
+  stop_ = stop;
+  if (start_ > stop_) {
+    start_ = stop_;
+    setIndexStride(1);
+  }
+  setNumEvents();
+}
+
+
+template<class Scalar>
+void TimeEventRangeIndex<Scalar>::setIndexStride(int stride)
+{
+  stride_ = stride;
+  if (stride_ < 1) {
+    stride_ = 1;
+  } else if (stride_ > (stop_ - start_)) {
+    stride_ = stop_ - start_;
+  }
+  setNumEvents();
+}
+
+
+template<class Scalar>
+void TimeEventRangeIndex<Scalar>::setNumEvents()
+{
+  if (stride_ == 0 || start_ == stop_)
+    numEvents_ = 1;
+  else
+    numEvents_ = int((stop_ - start_) / stride_) + 1;
+}
+
+
+template<class Scalar>
+bool TimeEventRangeIndex<Scalar>::isIndex(int index) const
+{
+  return (indexToNextEvent(index) == 0);
+}
+
+
+template<class Scalar>
+int TimeEventRangeIndex<Scalar>::indexToNextEvent(int index) const
+{
+  return indexOfNextEvent(index) - index;
+}
+
+
+template<class Scalar>
+int TimeEventRangeIndex<Scalar>::indexOfNextEvent(int index) const
+{
+  // Check if before or equal to the first index.
+  if (index <= start_) return start_;
+
+  const int indexOfLast = start_ + (numEvents_-1) * stride_;
+  // Check if after or equal to last index.
+  if (indexOfLast <= index) return indexOfLast;
+
+  // check if index is an event.
+  if ((index - start_) % stride_ == 0) return index;
+
+  const int numStrides = (index - start_) / stride_ + 1;
+  const Scalar indexOfNext = start_ + numStrides * stride_;
+  return indexOfNext;
+}
+
+
+template<class Scalar>
+bool TimeEventRangeIndex<Scalar>::eventInRangeIndex(int index1, int index2) const
+{
+  if (index1 > index2) {
+    int tmp = index1;
+    index1 = index2;
+    index2 = tmp;
+  }
+
+  const Scalar indexOfLast = start_ + (numEvents_-1) * stride_;
+  if (index2 < start_ || indexOfLast < index1) return false;
+
+  Scalar indexEvent1 = indexOfNextEvent(index1);
+  Scalar indexEvent2 = indexOfNextEvent(index2);
+  // Check if the next index event is different for the two indices.
+  if (indexEvent1 != indexEvent2) return true;
+
+  // Check if indices bracket index event.
+  if (index1 <= indexEvent1 && indexEvent1 <= index2) return true;
+
+  return false;
+}
+
+
+template<class Scalar>
+void TimeEventRangeIndex<Scalar>::describe() const
+{
+  Teuchos::RCP<Teuchos::FancyOStream> out =
+    Teuchos::VerboseObjectBase::getDefaultOStream();
+  *out << "TimeEventRange:" << "\n"
+       << "name       = " << this->getName() << "\n"
+       << "start_     = " << start_     << "\n"
+       << "stop_      = " << stop_      << "\n"
+       << "stride_    = " << stride_    << "\n"
+       << "numEvents_ = " << numEvents_ << std::endl;
+}
+
+
+
+} // namespace Tempus
+#endif // Tempus_TimeEventRangeIndex_impl_hpp

--- a/packages/tempus/src/Tempus_TimeEventRange_decl.hpp
+++ b/packages/tempus/src/Tempus_TimeEventRange_decl.hpp
@@ -1,0 +1,113 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#ifndef Tempus_TimeEventRange_decl_hpp
+#define Tempus_TimeEventRange_decl_hpp
+
+#include <tuple>
+
+// Teuchos
+#include "Teuchos_Time.hpp"
+
+// Tempus
+#include "Tempus_TimeEventBase.hpp"
+
+
+namespace Tempus {
+
+
+/** \brief TimeEventRange specifies a start, stop and stride time.
+ *
+ *
+ */
+template<class Scalar>
+class TimeEventRange : virtual public TimeEventBase<Scalar>
+{
+public:
+
+  /// Default constructor.
+  TimeEventRange();
+
+  /// Construct with full argument list of data members.
+  TimeEventRange(std::string name, Scalar start, Scalar stop, Scalar stride,
+                 Scalar relTol, bool landOnExactly);
+
+  /// Construct with full argument list of data members.
+  TimeEventRange(std::string name, Scalar start, Scalar stop, int numEvents,
+                 Scalar relTol, bool landOnExactly);
+
+  /// Destructor
+  virtual ~TimeEventRange() {}
+
+  /// \name Basic methods
+  //@{
+    /// Test if time is near a TimeEvent (within tolerance).
+    virtual bool isTime(Scalar time) const;
+
+    /// How much time until the next event. Negative indicating the last event is in the past.
+    virtual Scalar timeToNextEvent(Scalar time) const;
+
+    /// Time of the next event. Negative indicating the last event is in the past.
+    virtual Scalar timeOfNextEvent(Scalar time) const;
+
+    /// Test if an event occurs within the time range.
+    virtual bool eventInRange(Scalar time1, Scalar time2) const;
+  //@}
+
+  /// \name Accessor methods
+  //@{
+    virtual void setTimeRange(Scalar start, Scalar stop, Scalar stride)
+    { setTimeStart(start); setTimeStop(stop); setTimeStride(stride); }
+    virtual void setTimeRange(Scalar start, Scalar stop, int numEvents)
+    { setTimeStart(start); setTimeStop(stop); setNumEvents(numEvents); }
+
+    virtual Scalar getTimeStart() const { return start_; }
+    virtual void setTimeStart(Scalar start);
+
+    virtual Scalar getTimeStop() const { return stop_; }
+    virtual void setTimeStop(Scalar stop);
+
+    virtual Scalar getTimeStride() const { return stride_; }
+    virtual void setTimeStride(Scalar stride);
+
+    virtual int getNumEvents() const { return numEvents_; }
+    virtual void setNumEvents(int numEvents);
+
+    virtual Scalar getRelTol() const { return relTol_; }
+    virtual void setRelTol(Scalar relTol);
+
+    virtual Scalar getAbsTol() const { return absTol_; }
+
+    virtual bool getLandOnExactly() const { return landOnExactly_; }
+    virtual void setLandOnExactly(bool LOE) { landOnExactly_ = LOE; }
+
+    /// Describe member data.
+    virtual void describe() const;
+  //@}
+
+
+protected:
+
+  virtual void setTimeScale();
+
+  Scalar start_;         ///< Start of time range.
+  Scalar stop_;          ///< Stop of time range.
+  Scalar stride_;        ///< Stride of time range.
+  unsigned numEvents_;   ///< Number of events in time range.
+
+  Scalar timeScale_;     ///< A reference time scale, max(abs(start_,stop_)).
+  Scalar relTol_;        ///< Relative time tolerance for matching time events.
+  Scalar absTol_;        ///< Absolute time tolerance, relTol_*timeScale_.
+  bool   landOnExactly_; ///< Should these time events be landed on exactly, i.e, adjust the timestep to hit time event, versus stepping over and keeping the time step unchanged.
+
+};
+
+
+} // namespace Tempus
+
+#endif // Tempus_TimeEventRange_decl_hpp

--- a/packages/tempus/src/Tempus_TimeEventRange_impl.hpp
+++ b/packages/tempus/src/Tempus_TimeEventRange_impl.hpp
@@ -1,0 +1,222 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#ifndef Tempus_TimeEventRange_impl_hpp
+#define Tempus_TimeEventRange_impl_hpp
+
+
+namespace Tempus {
+
+template<class Scalar>
+TimeEventRange<Scalar>::TimeEventRange()
+  : start_(this->getDefaultTime()),
+    stop_ (this->getDefaultTime()),
+    stride_(0.0),
+    numEvents_(1),
+    timeScale_(1.0),
+    relTol_(1.0e-14),
+    absTol_(1.0e-14),
+    landOnExactly_(true)
+{
+  this->setName("TimeEventRange");
+  setTimeRange(start_, stop_, stride_);
+}
+
+
+template<class Scalar>
+TimeEventRange<Scalar>::TimeEventRange(
+  std::string name, Scalar start, Scalar stop, Scalar stride,
+  Scalar relTol, bool landOnExactly)
+  : start_(start),
+    stop_ (stop),
+    stride_(stride),
+    numEvents_(std::abs(stop-start)/stride+1),
+    timeScale_(start),
+    relTol_(relTol),
+    absTol_(relTol*start),
+    landOnExactly_(landOnExactly)
+{
+  this->setName(name);
+  setTimeRange(start, stop, stride);
+}
+
+
+template<class Scalar>
+TimeEventRange<Scalar>::TimeEventRange(
+  std::string name, Scalar start, Scalar stop, int numEvents,
+  Scalar relTol, bool landOnExactly)
+  : start_(start),
+    stop_ (stop),
+    stride_(std::abs(stop-start)/(numEvents-1)),
+    numEvents_(numEvents),
+    timeScale_(start),
+    relTol_(relTol),
+    absTol_(relTol*start),
+    landOnExactly_(landOnExactly)
+{
+  this->setName(name);
+  setTimeRange(start, stop, numEvents);
+  setRelTol(relTol);
+  setLandOnExactly(landOnExactly);
+}
+
+
+template<class Scalar>
+void TimeEventRange<Scalar>::setTimeStart(Scalar start)
+{
+  start_ = start;
+  if (stop_ < start_) stop_ = start_;
+  setTimeStride(stride_);  // Reset numEvents with the current stride.
+  setTimeScale();
+}
+
+
+template<class Scalar>
+void TimeEventRange<Scalar>::setTimeStop(Scalar stop)
+{
+  stop_ = stop;
+  if (start_ > stop_) start_ = stop_;
+  setTimeStride(stride_);  // Reset numEvents with the current stride.
+  setTimeScale();
+}
+
+
+template<class Scalar>
+void TimeEventRange<Scalar>::setTimeScale()
+{
+  timeScale_ = std::max(std::abs(start_), std::abs(stop_));
+  absTol_ = relTol_*timeScale_;
+
+  // Check if timeScale is near zero.
+  if ((-absTol_ <= timeScale_ ) && (timeScale_ <= absTol_)) {
+    timeScale_ = 1.0;
+    absTol_ = relTol_*timeScale_;
+  }
+}
+
+
+template<class Scalar>
+void TimeEventRange<Scalar>::setTimeStride(Scalar stride)
+{
+  stride_ = stride;
+  if ((start_ >= stop_-absTol_) && (start_ <= stop_+absTol_)) {
+    stride_ = 0.0;
+    numEvents_ = 1;
+    return;
+  }
+
+  if ((stride_ > stop_ - start_) || (stride_ < 2*absTol_)) {
+    stride_ = stop_ - start_;
+  }
+
+  numEvents_ = int((stop_+absTol_ - start_) / stride_) + 1;
+}
+
+
+template<class Scalar>
+void TimeEventRange<Scalar>::setNumEvents(int numEvents)
+{
+  numEvents_ = numEvents;
+  if (numEvents_ < 1) numEvents_ = 1;
+  stride_ = (stop_ - start_)/Scalar(numEvents_-1);
+
+  if (stride_ < 2 * absTol_) {
+    setTimeStride(2*absTol_);
+  }
+}
+
+
+template<class Scalar>
+void TimeEventRange<Scalar>::setRelTol(Scalar relTol)
+{
+  relTol_ = std::abs(relTol);
+  absTol_ = relTol_*timeScale_;
+}
+
+
+template<class Scalar>
+bool TimeEventRange<Scalar>::isTime(Scalar time) const
+{
+  return (std::abs(timeToNextEvent(time)) <= absTol_);
+}
+
+
+template<class Scalar>
+Scalar TimeEventRange<Scalar>::timeToNextEvent(Scalar time) const
+{
+  return timeOfNextEvent(time) - time;  // Neg. time indicates in the past.
+}
+
+
+template<class Scalar>
+Scalar TimeEventRange<Scalar>::timeOfNextEvent(Scalar time) const
+{
+  // Check if before or close to first event.
+  if (start_ >= time-absTol_) return start_;
+
+  const Scalar timeOfLast = start_ + (numEvents_-1) * stride_;
+  // Check if after or close to last event.
+  if (timeOfLast <= time+absTol_) return timeOfLast;
+
+  const int numStrides = (time - start_) / stride_;
+  const Scalar timeOfNext = start_ + numStrides * stride_;
+
+  // Check if close to left-side time event
+  if (timeOfNext > time-absTol_ &&
+      timeOfNext < time+absTol_) return timeOfNext;
+
+  // Otherwise it is the next event.
+  return timeOfNext + stride_;
+}
+
+
+template<class Scalar>
+bool TimeEventRange<Scalar>::eventInRange(Scalar time1, Scalar time2) const
+{
+  if (time1 > time2) {
+    Scalar tmp = time1;
+    time1 = time2;
+    time2 = tmp;
+  }
+
+  const Scalar timeOfLast = start_ + (numEvents_-1) * stride_;
+  // Check if range is completely outside time events.
+  if (time2+absTol_ < start_ || timeOfLast < time1-absTol_) return false;
+
+  Scalar timeEvent1 = timeOfNextEvent(time1);
+  Scalar timeEvent2 = timeOfNextEvent(time2);
+  // Check if the next time event is different for the two times.
+  if (timeEvent1 != timeEvent2) return true;
+
+  // Check if times bracket time event.
+  if (time1-absTol_ <= timeEvent1 && timeEvent1 <= time2+absTol_) return true;
+
+  return false;
+}
+
+
+template<class Scalar>
+void TimeEventRange<Scalar>::describe() const
+{
+  Teuchos::RCP<Teuchos::FancyOStream> out =
+    Teuchos::VerboseObjectBase::getDefaultOStream();
+  *out << "TimeEventRange:" << "\n"
+       << "name           = " << this->getName() << "\n"
+       << "start_         = " << start_         << "\n"
+       << "stop_          = " << stop_          << "\n"
+       << "stride_        = " << stride_        << "\n"
+       << "numEvents_     = " << numEvents_     << "\n"
+       << "timeScale_     = " << timeScale_     << "\n"
+       << "relTol_        = " << relTol_        << "\n"
+       << "absTol_        = " << absTol_        << "\n"
+       << "landOnExactly_ = " << landOnExactly_ << std::endl;
+}
+
+
+} // namespace Tempus
+#endif // Tempus_TimeEventRange_impl_hpp

--- a/packages/tempus/src/Tempus_TimeStepControl_impl.hpp
+++ b/packages/tempus/src/Tempus_TimeStepControl_impl.hpp
@@ -51,6 +51,7 @@ void TimeStepControl<Scalar>::getNextTimeStep(
     RCP<Teuchos::FancyOStream> out = this->getOStream();
     Teuchos::OSTab ostab(out,0,"getNextTimeStep");
 
+    // Lambda function to report changes to dt.
     auto changeDT = [] (int istep, Scalar dt_old, Scalar dt_new,
                         std::string reason)
     {

--- a/packages/tempus/unit_test/CMakeLists.txt
+++ b/packages/tempus/unit_test/CMakeLists.txt
@@ -330,3 +330,45 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   NUM_MPI_PROCS 1
   )
 
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_TimeEventBase
+  SOURCES Tempus_UnitTest_TimeEventBase.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_TimeEventRange
+  SOURCES Tempus_UnitTest_TimeEventRange.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_TimeEventList
+  SOURCES Tempus_UnitTest_TimeEventList.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_TimeEventRangeIndex
+  SOURCES Tempus_UnitTest_TimeEventRangeIndex.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_TimeEventListIndex
+  SOURCES Tempus_UnitTest_TimeEventListIndex.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  UnitTest_TimeEventComposite
+  SOURCES Tempus_UnitTest_TimeEventComposite.cpp ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  TESTONLYLIBS tempus_test_models
+  NUM_MPI_PROCS 1
+  )
+

--- a/packages/tempus/unit_test/Tempus_UnitTest_TimeEventBase.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_TimeEventBase.cpp
@@ -1,0 +1,55 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Tempus_TimeEventBase.hpp"
+
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventBase, Default_Construction)
+{
+  auto te = rcp(new Tempus::TimeEventBase<double>());
+
+  TEST_COMPARE(te->getName(), ==, "TimeEventBase");
+  te->setName("TestName");
+  TEST_COMPARE(te->getName(), ==, "TestName");
+
+  TEST_COMPARE(te->isTime(0.0), ==, false);
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(0.0), te->getDefaultTime(), 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(0.0), te->getDefaultTime(), 1.0e-14);
+  TEST_COMPARE(te->eventInRange(0.0, 1.0), ==, false);
+
+  TEST_COMPARE(te->isIndex(0), ==, false);
+  TEST_COMPARE(te->indexToNextEvent(0), ==, te->getDefaultIndex());
+  TEST_COMPARE(te->indexOfNextEvent(0), ==, te->getDefaultIndex());
+  TEST_COMPARE(te->eventInRange(0, 10), ==, false);
+
+  // Check base class defaults (functions not implemented in TimeEventRange).
+  TEST_COMPARE(te->isIndex(1), ==, false);
+  TEST_COMPARE(te->indexToNextEvent(1), ==, te->getDefaultIndex());
+  TEST_COMPARE(te->indexOfNextEvent(1), ==, te->getDefaultIndex());
+  TEST_COMPARE(te->eventInRangeIndex(1,4), ==, false);
+}
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_TimeEventComposite.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_TimeEventComposite.cpp
@@ -1,0 +1,477 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Tempus_TimeEventComposite.hpp"
+#include "Tempus_TimeEventRange.hpp"
+#include "Tempus_TimeEventRangeIndex.hpp"
+#include "Tempus_TimeEventList.hpp"
+#include "Tempus_TimeEventListIndex.hpp"
+
+
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <cmath>
+static double PI = M_PI;
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+
+
+// TimeEventRanges for testing.
+// ------------------------------------------------------------
+Teuchos::RCP<Tempus::TimeEventRange<double> > getTestRange1()
+{
+  auto teRange1 = rcp(new Tempus::TimeEventRange<double>(
+    "teRange1", 0.0, PI, 1.0, 1.0e-14, true));
+  return teRange1;
+}
+
+Teuchos::RCP<Tempus::TimeEventRange<double> > getTestRange2()
+{
+  auto teRange2 = rcp(new Tempus::TimeEventRange<double>(
+    "teRange2", -PI/2.0, PI/2.0, PI/4.0, 1.0e-14, true));
+  return teRange2;
+}
+
+Teuchos::RCP<Tempus::TimeEventRange<double> > getTestRange3()
+{
+  auto teRange3 = rcp(new Tempus::TimeEventRange<double>(
+    "teRange3", 4.0, 10.0, 4.0, 1.0e-14, true));
+  return teRange3;
+}
+
+
+// TimeEventLists for testing.
+// ------------------------------------------------------------
+Teuchos::RCP<Tempus::TimeEventList<double> > getTestList1()
+{
+  std::vector<double> testList1;
+  testList1.push_back(-1.0);
+  testList1.push_back( 0.0);
+  testList1.push_back( 5.0);
+  testList1.push_back( 2.0);
+  testList1.push_back(  PI);
+
+  auto teList1 = rcp(new Tempus::TimeEventList<double>(
+                     "teList1", testList1, 1.0e-14, true));
+  return teList1;
+}
+
+Teuchos::RCP<Tempus::TimeEventList<double> > getTestList2()
+{
+  std::vector<double> testList2;
+  testList2.push_back(-0.5);
+  testList2.push_back( 1.25);
+  testList2.push_back( 4.95);
+  testList2.push_back(12.34);
+
+  auto teList2 = rcp(new Tempus::TimeEventList<double>(
+                     "teList2", testList2, 1.0e-14, true));
+  return teList2;
+}
+
+Teuchos::RCP<Tempus::TimeEventList<double> > getTestList3()
+{
+  std::vector<double> testList3;
+  testList3.push_back(-5.0);
+  testList3.push_back(-PI);
+
+  auto teList3 = rcp(new Tempus::TimeEventList<double>(
+                     "teList3", testList3, 1.0e-14, true));
+  return teList3;
+}
+
+
+// TimeEventRangeIndices for testing.
+// ------------------------------------------------------------
+Teuchos::RCP<Tempus::TimeEventRangeIndex<double> > getTestRangeIndex1()
+{
+  auto teRangeIndex1 = rcp(new Tempus::TimeEventRangeIndex<double>(
+                           "teRangeIndex1", -1, 10, 3));
+  return teRangeIndex1;
+}
+
+Teuchos::RCP<Tempus::TimeEventRangeIndex<double> > getTestRangeIndex2()
+{
+  auto teRangeIndex2 = rcp(new Tempus::TimeEventRangeIndex<double>(
+                           "teRangeIndex2", -5, 8, 4));
+  return teRangeIndex2;
+}
+
+Teuchos::RCP<Tempus::TimeEventRangeIndex<double> > getTestRangeIndex3()
+{
+  auto teRangeIndex3 = rcp(new Tempus::TimeEventRangeIndex<double>(
+                           "teRangeIndex3", 10, 17, 5));
+  return teRangeIndex3;
+}
+
+
+// TimeEventRangeIndices for testing.
+// ------------------------------------------------------------
+Teuchos::RCP<Tempus::TimeEventListIndex<double> > getTestListIndex1()
+{
+  std::vector<int> testListIndex1;
+  testListIndex1.push_back(-2);
+  testListIndex1.push_back( 0);
+  testListIndex1.push_back( 7);
+  testListIndex1.push_back( 3);
+  testListIndex1.push_back(-5);
+
+  auto teListIndex1 = rcp(new Tempus::TimeEventListIndex<double>(
+                          "teListIndex1", testListIndex1));
+  return teListIndex1;
+}
+
+Teuchos::RCP<Tempus::TimeEventListIndex<double> > getTestListIndex2()
+{
+  std::vector<int> testListIndex2;
+  testListIndex2.push_back( 2);
+
+  auto teListIndex2 = rcp(new Tempus::TimeEventListIndex<double>(
+                          "teListIndex2", testListIndex2));
+  return teListIndex2;
+}
+
+Teuchos::RCP<Tempus::TimeEventListIndex<double> > getTestListIndex3()
+{
+  std::vector<int> testListIndex3;
+  testListIndex3.push_back(14);
+  testListIndex3.push_back( 9);
+
+  auto teListIndex3 = rcp(new Tempus::TimeEventListIndex<double>(
+                          "teListIndex3", testListIndex3));
+
+  return teListIndex3;
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventComposite, Default_Construction)
+{
+  auto te = rcp(new Tempus::TimeEventComposite<double>());
+
+  TEST_COMPARE(te->isTime(0.0), ==, false);
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(0.0), te->getDefaultTime(), 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(0.0), te->getDefaultTime(), 1.0e-14);
+  TEST_COMPARE(te->eventInRange(0.0, 1.0), ==, false);
+
+  TEST_COMPARE(te->isIndex(0), ==, false);
+  TEST_COMPARE(te->indexToNextEvent(0), ==, te->getDefaultIndex());
+  TEST_COMPARE(te->indexOfNextEvent(0), ==, te->getDefaultIndex());
+  TEST_COMPARE(te->eventInRange(0, 10), ==, false);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventComposite, One_TimeEventRange)
+{
+  auto te = rcp(new Tempus::TimeEventComposite<double>());
+  auto teRange1 = getTestRange1();
+
+  te->addTimeEvent(teRange1);
+
+  TEST_COMPARE(te->isTime(0.0), ==, true );
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(0.0), 0.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(1.1), 2.0, 1.0e-14);
+  TEST_COMPARE(te->eventInRange(0.0, 1.0), ==, true );
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventComposite, TwoOverlapping_TimeEventRanges)
+{
+  auto te = rcp(new Tempus::TimeEventComposite<double>());
+  auto teRange1 = getTestRange1();
+  auto teRange2 = getTestRange2();
+
+  te->addTimeEvent(teRange1);
+  te->addTimeEvent(teRange2);
+  //te->describe();
+
+  TEST_COMPARE(te->isTime(0.0), ==, true );
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(0.1), PI/4.0-0.1, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(1.1), PI/2.0, 1.0e-14);
+  TEST_COMPARE(te->eventInRange(0.0, 1.0), ==, true );
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventComposite, TwoSeparated_TimeEventRanges)
+{
+  auto te = rcp(new Tempus::TimeEventComposite<double>());
+  auto teRange3 = getTestRange3();
+  auto teRange2 = getTestRange2();
+
+  te->addTimeEvent(teRange3);
+  te->addTimeEvent(teRange2);
+  //te->describe();
+
+  TEST_COMPARE(te->isTime(4.0), ==, true );
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(1.1), PI/2.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(3.0),    4.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(5.0),    8.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(10.0),   8.0, 1.0e-14);
+  TEST_COMPARE(te->eventInRange(-3.0, -2.0), ==, false);
+  TEST_COMPARE(te->eventInRange(-1.0,  0.0), ==, true );
+  TEST_COMPARE(te->eventInRange( 1.0,  2.0), ==, true );
+  TEST_COMPARE(te->eventInRange( 2.0,  3.0), ==, false);
+  TEST_COMPARE(te->eventInRange( 5.0,  7.0), ==, false);
+  TEST_COMPARE(te->eventInRange( 7.0,  9.0), ==, true );
+  TEST_COMPARE(te->eventInRange( 9.0, 11.0), ==, false);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventComposite, One_TimeEventList)
+{
+  auto te = rcp(new Tempus::TimeEventComposite<double>());
+  auto teList1 = getTestList1();
+
+  te->addTimeEvent(teList1);
+
+  TEST_COMPARE(te->isTime(2.0), ==, true );
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(3.5), 1.5, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(-2.0), -1.0, 1.0e-14);
+  TEST_COMPARE(te->eventInRange(4.99, 10.0), ==, true );
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventComposite, TwoOverlapping_TimeEventLists)
+{
+  auto te = rcp(new Tempus::TimeEventComposite<double>());
+  auto teList1 = getTestList1();
+  auto teList2 = getTestList2();
+
+  te->addTimeEvent(teList1);
+  te->addTimeEvent(teList2);
+  //te->describe();
+
+  TEST_COMPARE(te->isTime(1.25), ==, true );
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(4.0), 0.95, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(6.5), 12.34, 1.0e-14);
+  TEST_COMPARE(te->eventInRange(0.1, 1.0), ==, false);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventComposite, TwoSeparated_TimeEventLists)
+{
+  auto te = rcp(new Tempus::TimeEventComposite<double>());
+  auto teList3 = getTestList3();
+  auto teList2 = getTestList2();
+
+  te->addTimeEvent(teList3);
+  te->addTimeEvent(teList2);
+  //te->describe();
+
+  TEST_COMPARE(te->isTime(4.0), ==, false);
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(-8.9),  -5.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(-0.3),  1.25, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(-4.0),   -PI, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(20.0), 12.34, 1.0e-14);
+  TEST_COMPARE(te->eventInRange(-6.0, -4.0), ==, true );
+  TEST_COMPARE(te->eventInRange(-3.0,  0.0), ==, true );
+  TEST_COMPARE(te->eventInRange( 2.0,  3.0), ==, false);
+  TEST_COMPARE(te->eventInRange( 4.9,  5.1), ==, true );
+  TEST_COMPARE(te->eventInRange(12.0, 12.4), ==, true );
+  TEST_COMPARE(te->eventInRange(14.0, 15.0), ==, false);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventComposite, One_TimeEventRangeIndex)
+{
+  auto te = rcp(new Tempus::TimeEventComposite<double>());
+  auto teRangeIndex1 = getTestRangeIndex1();
+
+  te->addTimeEvent(teRangeIndex1);
+
+  TEST_COMPARE(te->isIndex(5), ==, true );
+  TEST_COMPARE(te->indexToNextEvent(3), ==, 2);
+  TEST_COMPARE(te->indexOfNextEvent(3), ==, 5);
+  TEST_COMPARE(te->eventInRangeIndex(3, 9), ==, true );
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventComposite, TwoOverlapping_TimeEventRangeIndex)
+{
+  auto te = rcp(new Tempus::TimeEventComposite<double>());
+  auto teRangeIndex1 = getTestRangeIndex1();
+  auto teRangeIndex2 = getTestRangeIndex2();
+
+  te->addTimeEvent(teRangeIndex1);
+  te->addTimeEvent(teRangeIndex2);
+  //te->describe();
+
+  TEST_COMPARE(te->isIndex(-1), ==, true );
+  TEST_COMPARE(te->indexToNextEvent(-2), ==, 1);
+  TEST_COMPARE(te->indexOfNextEvent( 2), ==, 2);
+  TEST_COMPARE(te->eventInRangeIndex(0, 1), ==, false);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventComposite, TwoSeparate_TimeEventRangeIndex)
+{
+  auto te = rcp(new Tempus::TimeEventComposite<double>());
+  auto teRangeIndex3 = getTestRangeIndex3();
+  auto teRangeIndex2 = getTestRangeIndex2();
+
+  te->addTimeEvent(teRangeIndex3);
+  te->addTimeEvent(teRangeIndex2);
+  //te->describe();
+
+  TEST_COMPARE(te->isIndex(15), ==, true );
+  TEST_COMPARE(te->indexOfNextEvent( 9), ==, 10);
+  TEST_COMPARE(te->indexOfNextEvent(-6), ==, -5);
+  TEST_COMPARE(te->indexOfNextEvent( 6), ==,  7);
+  TEST_COMPARE(te->indexOfNextEvent(16), ==, 15);
+  TEST_COMPARE(te->eventInRangeIndex(-3, -2), ==, false);
+  TEST_COMPARE(te->eventInRangeIndex(-1,  0), ==, true );
+  TEST_COMPARE(te->eventInRangeIndex( 1,  2), ==, false);
+  TEST_COMPARE(te->eventInRangeIndex( 7,  8), ==, true );
+  TEST_COMPARE(te->eventInRangeIndex( 8,  9), ==, false);
+  TEST_COMPARE(te->eventInRangeIndex(10, 13), ==, true );
+  TEST_COMPARE(te->eventInRangeIndex(14, 20), ==, true );
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventComposite, One_TimeEventListIndex)
+{
+  auto te = rcp(new Tempus::TimeEventComposite<double>());
+  auto teListIndex1 = getTestListIndex1();
+
+  te->addTimeEvent(teListIndex1);
+
+  TEST_COMPARE(te->isIndex(3), ==, true );
+  TEST_COMPARE(te->indexToNextEvent(1), ==, 2);
+  TEST_COMPARE(te->indexOfNextEvent(4), ==, 7);
+  TEST_COMPARE(te->eventInRangeIndex(1, 3), ==, true );
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventComposite, TwoOverlapping_TimeEventListIndex)
+{
+  auto te = rcp(new Tempus::TimeEventComposite<double>());
+  auto teListIndex1 = getTestListIndex1();
+  auto teListIndex2 = getTestListIndex2();
+
+  te->addTimeEvent(teListIndex1);
+  te->addTimeEvent(teListIndex2);
+  //te->describe();
+
+  TEST_COMPARE(te->isIndex(2), ==, true );
+  TEST_COMPARE(te->indexToNextEvent(0), ==, 0);
+  TEST_COMPARE(te->indexOfNextEvent(1), ==, 2);
+  TEST_COMPARE(te->eventInRangeIndex(-1, 3), ==, true );
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventComposite, TwoSeparate_TimeEventListIndex)
+{
+  auto te = rcp(new Tempus::TimeEventComposite<double>());
+  auto teListIndex3 = getTestListIndex3();
+  auto teListIndex2 = getTestListIndex2();
+
+  te->addTimeEvent(teListIndex3);
+  te->addTimeEvent(teListIndex2);
+  //te->describe();
+
+  TEST_COMPARE(te->isIndex(14), ==, true );
+  TEST_COMPARE(te->indexOfNextEvent(2), ==, 2);
+  TEST_COMPARE(te->indexOfNextEvent(5), ==, 9);
+  TEST_COMPARE(te->indexOfNextEvent(19), ==, 14);
+  TEST_COMPARE(te->eventInRangeIndex( 0,  1), ==, false);
+  TEST_COMPARE(te->eventInRangeIndex( 3, 10), ==, true );
+  TEST_COMPARE(te->eventInRangeIndex(15, 20), ==, false);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventComposite, OneOfEach_TimeEvent)
+{
+  auto te = rcp(new Tempus::TimeEventComposite<double>());
+  auto teRange1      = getTestRange1();
+  auto teList1       = getTestList1();
+  auto teRangeIndex1 = getTestRangeIndex1();
+  auto teListIndex1  = getTestListIndex1();
+
+  te->addTimeEvent(teRange1);
+  te->addTimeEvent(teList1);
+  te->addTimeEvent(teRangeIndex1);
+  te->addTimeEvent(teListIndex1);
+
+  TEST_COMPARE(te->isTime (3.0), ==, true );
+  TEST_COMPARE(te->isTime (2.0), ==, true );
+  TEST_COMPARE(te->isIndex(  2), ==, true );
+  TEST_COMPARE(te->isIndex(  3), ==, true );
+
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(-2.5),  1.5, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent( 0.5),  0.5, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent( 4.5),  0.5, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent( 7.5), -2.5, 1.0e-14);
+
+  TEST_COMPARE(te->indexToNextEvent(-6), ==,  1);
+  TEST_COMPARE(te->indexToNextEvent( 1), ==,  1);
+  TEST_COMPARE(te->indexToNextEvent( 7), ==,  0);
+  TEST_COMPARE(te->indexToNextEvent( 9), ==, -1);
+
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent( -PI), -1.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(-0.5),  0.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent( 2.5),  3.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent( 7.5),  5.0, 1.0e-14);
+
+  TEST_COMPARE(te->indexOfNextEvent(-6), ==, -5);
+  TEST_COMPARE(te->indexOfNextEvent( 1), ==,  2);
+  TEST_COMPARE(te->indexOfNextEvent( 7), ==,  7);
+  TEST_COMPARE(te->indexOfNextEvent( 9), ==,  8);
+
+  TEST_COMPARE(te->eventInRange(-5.0, -2.0), ==, false);
+  TEST_COMPARE(te->eventInRange(-2.0, -0.5), ==, true );
+  TEST_COMPARE(te->eventInRange( 1.2,  1.8), ==, false);
+  TEST_COMPARE(te->eventInRange( 3.1,  4.0), ==, true );
+  TEST_COMPARE(te->eventInRange( 4.5,  6.0), ==, true );
+
+  TEST_COMPARE(te->eventInRangeIndex(-8, -6), ==, false);
+  TEST_COMPARE(te->eventInRangeIndex( 1,  1), ==, false);
+  TEST_COMPARE(te->eventInRangeIndex( 5,  7), ==, true );
+  TEST_COMPARE(te->eventInRangeIndex( 8, 10), ==, true );
+  TEST_COMPARE(te->eventInRangeIndex(12, 14), ==, false);
+
+}
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_TimeEventList.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_TimeEventList.cpp
@@ -1,0 +1,284 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Tempus_TimeEventList.hpp"
+
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <cmath>
+static double PI = M_PI;
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventList, Default_Construction)
+{
+  auto te = rcp(new Tempus::TimeEventList<double>());
+
+  TEST_COMPARE(te->getName(), ==, "TimeEventList");
+
+  TEST_COMPARE(te->getTimeList().size(), ==, 0);
+  TEST_FLOATING_EQUALITY(te->getRelTol(), 1.0e-14, 1.0e-14);
+  TEST_COMPARE(te->getLandOnExactly(), ==, true);
+
+  // Check base class defaults (functions not implemented in TimeEventList).
+  TEST_COMPARE(te->isIndex(1), ==, false);
+  TEST_COMPARE(te->indexToNextEvent(1), ==, te->getDefaultIndex());
+  TEST_COMPARE(te->indexOfNextEvent(1), ==, te->getDefaultIndex());
+  TEST_COMPARE(te->eventInRangeIndex(1,4), ==, false);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventList, Construction)
+{
+  std::vector<double> testVector;
+  testVector.push_back(-1.0);
+  testVector.push_back( 0.0);
+  testVector.push_back( 5.0);
+  testVector.push_back( 2.0);
+  testVector.push_back(  PI);
+
+  auto te = rcp(new Tempus::TimeEventList<double>(
+                "TestName", testVector, 1.0e-14, true));
+
+  TEST_COMPARE(te->getName(), ==, "TestName");
+  TEST_FLOATING_EQUALITY(te->getRelTol(), 1.0e-14, 1.0e-14);
+  TEST_COMPARE(te->getLandOnExactly(), ==, true);
+
+  auto testList = te->getTimeList();
+  TEST_COMPARE(testList.size(), ==, 5);
+  TEST_FLOATING_EQUALITY(testList[0], -1.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(testList[1],  0.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(testList[2],  2.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(testList[3],   PI, 1.0e-14);
+  TEST_FLOATING_EQUALITY(testList[4],  5.0, 1.0e-14);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventList, Basic_Accessors)
+{
+  auto te = rcp(new Tempus::TimeEventList<double>());
+
+  te->setName("TestName");
+  TEST_COMPARE(te->getName(), ==, "TestName");
+  te->setRelTol(0.1);
+  TEST_FLOATING_EQUALITY(te->getRelTol(), 0.1, 1.0e-14);
+  te->setRelTol(1.0e-14);
+  te->setLandOnExactly(false);
+  TEST_COMPARE(te->getLandOnExactly(), ==, false);
+
+  // Test addTime.
+  te->addTime(0.0);
+  te->addTime(PI);
+  te->addTime(-1.0);
+  te->addTime( 2.0);
+  te->addTime( 5.0);
+
+  // Add times that should not be duplicated.
+  te->addTime(0.0);
+  te->addTime(PI);
+
+  auto testList = te->getTimeList();
+  TEST_COMPARE(testList.size(), ==, 5);
+  TEST_FLOATING_EQUALITY(testList[0], -1.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(testList[1],  0.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(testList[2],  2.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(testList[3],   PI, 1.0e-14);
+  TEST_FLOATING_EQUALITY(testList[4],  5.0, 1.0e-14);
+
+  // Test that two events within relative tolerance are added or not.
+  te->addTime( 2.0 + 1.0e-14);
+  TEST_COMPARE(te->getTimeList().size(), ==, 5);
+  te->addTime( 2.0 + 1.0e-13);
+  TEST_COMPARE(te->getTimeList().size(), ==, 6);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventList, isTime)
+{
+  auto te = rcp(new Tempus::TimeEventList<double>());
+  te->addTime( 0.0);
+  te->addTime(  PI);
+  te->addTime(-1.0);
+  te->addTime( 2.0);
+  te->addTime( 5.0);
+
+  // Test isTime.
+  //   Around first event.
+  TEST_COMPARE(te->isTime(-10.0e-14), ==, false);   // Just outside tolerance.
+  TEST_COMPARE(te->isTime( -1.0e-14), ==, true );   // Just inside tolerance.
+  TEST_COMPARE(te->isTime(  0.0    ), ==, true );   // Right on timeEvent.
+  TEST_COMPARE(te->isTime(  1.0e-14), ==, true );   // Just inside tolerance.
+  TEST_COMPARE(te->isTime( 10.0e-14), ==, false);   // Just outside tolerance.
+
+  //   Around mid event.
+  TEST_COMPARE(te->isTime(PI + -10.0e-14), ==, false); // Just outside tolerance.
+  TEST_COMPARE(te->isTime(PI +  -1.0e-14), ==, true ); // Just inside tolerance.
+  TEST_COMPARE(te->isTime(PI +   0.0    ), ==, true ); // Right on timeEvent.
+  TEST_COMPARE(te->isTime(PI +   1.0e-14), ==, true ); // Just inside tolerance.
+  TEST_COMPARE(te->isTime(PI +  10.0e-14), ==, false); // Just outside tolerance.
+
+  //   Around last event.
+  TEST_COMPARE(te->isTime(5.0 + -10.0e-14), ==, false); // Just outside tolerance.
+  TEST_COMPARE(te->isTime(5.0 +  -1.0e-14), ==, true ); // Just inside tolerance.
+  TEST_COMPARE(te->isTime(5.0 +   0.0    ), ==, true ); // Right on timeEvent.
+  TEST_COMPARE(te->isTime(5.0 +   1.0e-14), ==, true ); // Just inside tolerance.
+  TEST_COMPARE(te->isTime(5.0 +  10.0e-14), ==, false); // Just outside tolerance.
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventList, timeToNextEvent)
+{
+  std::vector<double> testList;
+  testList.push_back( 0.0);
+  testList.push_back(  PI);
+  testList.push_back(-1.0);
+  testList.push_back( 2.0);
+  testList.push_back( 5.0);
+
+  auto te = rcp(new Tempus::TimeEventList<double>(
+                "testList", testList, 1.0e-14, true));
+
+  // Test timeToNextEvent.
+  //   Around first event.
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(-1.0 + -10.0e-14),     1.0e-13, 1.0e-02);
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(-1.0 +  -1.0e-14),     1.0e-14, 1.0e-02);
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(-1.0 +   0.0    ),     0.0    , 1.0e-02);
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(-1.0 +   1.0e-14),    -1.0e-14, 1.0e-02);
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(-1.0 +  10.0e-14), 1.0-1.0e-13, 1.0e-14);
+
+  //   Around mid event.
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(PI + -10.0e-14),        1.0e-13, 1.0e-02);
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(PI +  -1.0e-14),        1.0e-14, 1.0e-01);
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(PI +   0.0    ),        0.0    , 1.0e-02);
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(PI +   1.0e-14),       -1.0e-14, 1.0e-01);
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(PI +  10.0e-14), 5.0-PI-1.0e-13, 1.0e-14);
+
+  //   Around last event.
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(5.0+ -10.0e-14),  1.0e-13, 1.0e-02);
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(5.0+  -1.0e-14),  1.0e-14, 1.0e-01);
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(5.0+   0.0    ),  0.0    , 1.0e-02);
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(5.0+   1.0e-14), -1.0e-14, 1.0e-01);
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(5.0+  10.0e-14), -1.0e-13, 1.0e-02);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventList, timeOfNextEvent)
+{
+  std::vector<double> testList;
+  testList.push_back( 0.0);
+  testList.push_back(  PI);
+  testList.push_back(-1.0);
+  testList.push_back( 2.0);
+  testList.push_back( 5.0);
+
+  auto te = rcp(new Tempus::TimeEventList<double>(
+                "testList", testList, 1.0e-14, true));
+
+  // Test timeOfNextEvent.
+  //   Around first event.
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(-1.0 + -10.0e-14), -1.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(-1.0 +  -1.0e-14), -1.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(-1.0 +   0.0    ), -1.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(-1.0 +   1.0e-14), -1.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(-1.0 +  10.0e-14),  0.0, 1.0e-14);
+
+  //   Around mid event.
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(2.0+ -10.0e-14),  2.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(2.0+  -1.0e-14),  2.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(2.0+   0.0    ),  2.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(2.0+   1.0e-14),  2.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(2.0+  10.0e-14), PI, 1.0e-14);
+
+  //   Around last event.
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(5.0+ -10.0e-14), 5.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(5.0+  -1.0e-14), 5.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(5.0+   0.0    ), 5.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(5.0+   1.0e-14), 5.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(5.0+  10.0e-14), 5.0, 1.0e-14);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventList, eventInRange)
+{
+  std::vector<double> testList;
+  testList.push_back( 0.0);
+  testList.push_back(  PI);
+  testList.push_back(-1.0);
+  testList.push_back( 2.0);
+  testList.push_back( 5.0);
+
+  auto te = rcp(new Tempus::TimeEventList<double>(
+                "testList", testList, 1.0e-14, true));
+
+  // Test eventInRange.
+  //   Right end.
+  TEST_COMPARE(te->eventInRange(-2.0, -1.0 + -10.0e-14), ==, false);   // Around first event.
+  TEST_COMPARE(te->eventInRange(-2.0, -1.0 +  -1.0e-14), ==, true );
+  TEST_COMPARE(te->eventInRange(-2.0, -1.0 +   0.0    ), ==, true );
+  TEST_COMPARE(te->eventInRange(-2.0, -1.0 +   1.0e-14), ==, true );
+  TEST_COMPARE(te->eventInRange(-2.0, -1.0 +  10.0e-14), ==, true );
+
+  TEST_COMPARE(te->eventInRange(3.0, PI + -10.0e-14), ==, false);   // Around mid event.
+  TEST_COMPARE(te->eventInRange(3.0, PI +  -1.0e-14), ==, true );
+  TEST_COMPARE(te->eventInRange(3.0, PI +   0.0    ), ==, true );
+  TEST_COMPARE(te->eventInRange(3.0, PI +   1.0e-14), ==, true );
+  TEST_COMPARE(te->eventInRange(3.0, PI +  10.0e-14), ==, true );
+
+  TEST_COMPARE(te->eventInRange(4.5, 5.0 + -10.0e-14), ==, false);   // Around last event.
+  TEST_COMPARE(te->eventInRange(4.5, 5.0 +  -1.0e-14), ==, true );
+  TEST_COMPARE(te->eventInRange(4.5, 5.0 +   0.0    ), ==, true );
+  TEST_COMPARE(te->eventInRange(4.5, 5.0 +   1.0e-14), ==, true );
+  TEST_COMPARE(te->eventInRange(4.5, 5.0 +  10.0e-14), ==, true );
+
+  //   Left end.
+  TEST_COMPARE(te->eventInRange(-1.0 + -10.0e-14, -0.5), ==, true );   // Around first event.
+  TEST_COMPARE(te->eventInRange(-1.0 +  -1.0e-14, -0.5), ==, true );
+  TEST_COMPARE(te->eventInRange(-1.0 +   0.0    , -0.5), ==, true );
+  TEST_COMPARE(te->eventInRange(-1.0 +   1.0e-14, -0.5), ==, true );
+  TEST_COMPARE(te->eventInRange(-1.0 +  10.0e-14, -0.5), ==, false );
+
+  TEST_COMPARE(te->eventInRange(PI + -10.0e-14, 3.5), ==, true );   // Around mid event.
+  TEST_COMPARE(te->eventInRange(PI +  -1.0e-14, 3.5), ==, true );
+  TEST_COMPARE(te->eventInRange(PI +   0.0    , 3.5), ==, true );
+  TEST_COMPARE(te->eventInRange(PI +   1.0e-14, 3.5), ==, true );
+  TEST_COMPARE(te->eventInRange(PI +  10.0e-14, 3.5), ==, false);
+
+  TEST_COMPARE(te->eventInRange(5.0 + -10.0e-14, 6.0), ==, true );   // Around last event.
+  TEST_COMPARE(te->eventInRange(5.0 +  -1.0e-14, 6.0), ==, true );
+  TEST_COMPARE(te->eventInRange(5.0 +   0.0    , 6.0), ==, true );
+  TEST_COMPARE(te->eventInRange(5.0 +   1.0e-14, 6.0), ==, true );
+  TEST_COMPARE(te->eventInRange(5.0 +  10.0e-14, 6.0), ==, false);
+}
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_TimeEventListIndex.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_TimeEventListIndex.cpp
@@ -1,0 +1,227 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Tempus_TimeEventListIndex.hpp"
+
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventListIndex, Default_Construction)
+{
+  auto te = rcp(new Tempus::TimeEventListIndex<double>());
+
+  TEST_COMPARE(te->getName(), ==, "TimeEventListIndex");
+
+  TEST_COMPARE(te->getIndexList().size(), ==, 0);
+
+  TEST_COMPARE(te->isIndex(-1), ==, false);
+  TEST_COMPARE(te->isIndex(te->getDefaultIndex()), ==, true );
+  TEST_COMPARE(te->isIndex( 1), ==, false);
+
+  TEST_COMPARE(te->indexToNextEvent(0), ==, te->getDefaultIndex());
+  TEST_COMPARE(te->indexOfNextEvent(0), ==, te->getDefaultIndex());
+  TEST_COMPARE(te->eventInRangeIndex(2, -1), ==, false);
+
+  // Check base class defaults (functions not implemented in TimeEventListIndex).
+  TEST_COMPARE(te->isTime(1.0), ==, false);
+  TEST_COMPARE(te->timeToNextEvent(1.0), ==, te->getDefaultTime());
+  TEST_COMPARE(te->timeOfNextEvent(1.0), ==, te->getDefaultTime());
+  TEST_COMPARE(te->eventInRange(1.0, 4.0), ==, false);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventListIndex, Construction)
+{
+  std::vector<int> testVector;
+  testVector.push_back(-2);
+  testVector.push_back( 0);
+  testVector.push_back( 7);
+  testVector.push_back( 3);
+  testVector.push_back(-5);
+
+  auto te = rcp(new Tempus::TimeEventListIndex<double>(
+                "TestName", testVector));
+
+  TEST_COMPARE(te->getName(), ==, "TestName");
+
+  auto testList = te->getIndexList();
+  TEST_COMPARE(testList.size(), ==, 5);
+  TEST_COMPARE(testList[0], ==, -5);
+  TEST_COMPARE(testList[1], ==, -2);
+  TEST_COMPARE(testList[2], ==,  0);
+  TEST_COMPARE(testList[3], ==,  3);
+  TEST_COMPARE(testList[4], ==,  7);
+
+  // Test adding a duplicate event index.
+  te->addIndex(3);
+  TEST_COMPARE(te->getIndexList().size(), ==, 5);
+  te->addIndex(1);
+  TEST_COMPARE(te->getIndexList().size(), ==, 6);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventListIndex, isIndex)
+{
+  auto te = rcp(new Tempus::TimeEventListIndex<double>());
+
+  te->setName("TestName");
+  TEST_COMPARE(te->getName(), ==, "TestName");
+
+  // Test isIndex with one element.
+  te->addIndex(-5);
+  TEST_COMPARE(te->isIndex(-6), ==, false);
+  TEST_COMPARE(te->isIndex(-5), ==, true );
+  TEST_COMPARE(te->isIndex(-4), ==, false);
+
+  // Test isIndex with two elements.
+  te->addIndex(1);
+  TEST_COMPARE(te->isIndex(0), ==, false);
+  TEST_COMPARE(te->isIndex(1), ==, true );
+  TEST_COMPARE(te->isIndex(2), ==, false);
+
+  // Test addIndex.
+  te->addIndex(-2);
+  te->addIndex( 4);
+  te->addIndex(-9);
+  auto testList = te->getIndexList();
+  TEST_COMPARE(testList.size(), ==, 5);
+  TEST_COMPARE(testList[0], ==, -9);
+  TEST_COMPARE(testList[1], ==, -5);
+  TEST_COMPARE(testList[2], ==, -2);
+  TEST_COMPARE(testList[3], ==,  1);
+  TEST_COMPARE(testList[4], ==,  4);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventListIndex, indexToNextEvent)
+{
+  std::vector<int> testListIndex;
+  testListIndex.push_back(-5);
+  testListIndex.push_back( 1);
+  testListIndex.push_back(-2);
+  testListIndex.push_back( 4);
+  testListIndex.push_back(-9);
+
+  auto te = rcp(new Tempus::TimeEventListIndex<double>(
+                "teListIndex", testListIndex));
+
+  // Test indexToNextEvent.
+  //   Around first event.
+  TEST_COMPARE(te->indexToNextEvent(-12), ==,  3);
+  TEST_COMPARE(te->indexToNextEvent( -9), ==,  0);
+  TEST_COMPARE(te->indexToNextEvent( -8), ==,  3);
+
+  //   Around mid event.
+  TEST_COMPARE(te->indexToNextEvent(-4), ==,  2);
+  TEST_COMPARE(te->indexToNextEvent(-2), ==,  0);
+  TEST_COMPARE(te->indexToNextEvent( 0), ==,  1);
+
+  //   Around last event.
+  TEST_COMPARE(te->indexToNextEvent(2), ==,  2);
+  TEST_COMPARE(te->indexToNextEvent(4), ==,  0);
+  TEST_COMPARE(te->indexToNextEvent(9), ==, -5);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventListIndex, indexOfNextEvent)
+{
+  std::vector<int> testListIndex;
+  testListIndex.push_back(-5);
+  testListIndex.push_back( 1);
+  testListIndex.push_back(-2);
+  testListIndex.push_back( 4);
+  testListIndex.push_back(-9);
+
+  auto te = rcp(new Tempus::TimeEventListIndex<double>(
+                "teListIndex", testListIndex));
+
+  // Test indexOfNextEvent.
+  //   Around first event.
+  TEST_COMPARE(te->indexOfNextEvent(-12), ==, -9);
+  TEST_COMPARE(te->indexOfNextEvent( -9), ==, -9);
+  TEST_COMPARE(te->indexOfNextEvent( -8), ==, -5);
+
+  //   Around mid event.
+  TEST_COMPARE(te->indexOfNextEvent(-4), ==, -2);
+  TEST_COMPARE(te->indexOfNextEvent(-2), ==, -2);
+  TEST_COMPARE(te->indexOfNextEvent( 0), ==,  1);
+
+  //   Around last event.
+  TEST_COMPARE(te->indexOfNextEvent(2), ==,  4);
+  TEST_COMPARE(te->indexOfNextEvent(4), ==,  4);
+  TEST_COMPARE(te->indexOfNextEvent(9), ==,  4);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventListIndex, eventInRangeIndex)
+{
+  std::vector<int> testListIndex;
+  testListIndex.push_back(-5);
+  testListIndex.push_back( 1);
+  testListIndex.push_back(-2);
+  testListIndex.push_back( 4);
+  testListIndex.push_back(-9);
+
+  auto te = rcp(new Tempus::TimeEventListIndex<double>(
+                "teListIndex", testListIndex));
+
+  // Test eventInRangeIndex.
+  //   Right end.
+  TEST_COMPARE(te->eventInRangeIndex(-12.0, -10), ==, false);   // Around first event.
+  TEST_COMPARE(te->eventInRangeIndex(-12.0,  -9), ==, true );
+  TEST_COMPARE(te->eventInRangeIndex(-12.0,  -8), ==, true );
+
+  TEST_COMPARE(te->eventInRangeIndex(-4, -3), ==, false);   // Around mid event.
+  TEST_COMPARE(te->eventInRangeIndex(-4, -2), ==, true );
+  TEST_COMPARE(te->eventInRangeIndex(-4, -1), ==, true );
+
+  TEST_COMPARE(te->eventInRangeIndex(3, 3), ==, false);   // Around last event.
+  TEST_COMPARE(te->eventInRangeIndex(3, 4), ==, true );
+  TEST_COMPARE(te->eventInRangeIndex(3, 6), ==, true );
+
+  //   Left end.
+  TEST_COMPARE(te->eventInRangeIndex(-12, -7), ==, true );   // Around first event.
+  TEST_COMPARE(te->eventInRangeIndex( -9, -7), ==, true );
+  TEST_COMPARE(te->eventInRangeIndex( -8, -7), ==, false);
+
+  TEST_COMPARE(te->eventInRangeIndex(-3, 0), ==, true );   // Around mid event.
+  TEST_COMPARE(te->eventInRangeIndex(-2, 0), ==, true );
+  TEST_COMPARE(te->eventInRangeIndex(-1, 0), ==, false);
+
+  TEST_COMPARE(te->eventInRangeIndex(3, 8), ==, true );   // Around last event.
+  TEST_COMPARE(te->eventInRangeIndex(4, 8), ==, true );
+  TEST_COMPARE(te->eventInRangeIndex(5, 8), ==, false);
+}
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_TimeEventRange.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_TimeEventRange.cpp
@@ -1,0 +1,319 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Tempus_TimeEventRange.hpp"
+
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+#include <cmath>
+static double PI = M_PI;
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventRange, Default_Construction)
+{
+  auto te = rcp(new Tempus::TimeEventRange<double>());
+
+  TEST_COMPARE(te->getName(), ==, "TimeEventRange");
+  te->setName("TestName");
+  TEST_COMPARE(te->getName(), ==, "TestName");
+
+  TEST_FLOATING_EQUALITY(te->getTimeStart (), te->getDefaultTime(), 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->getTimeStop  (), te->getDefaultTime(), 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->getTimeStride(), 0.0, 1.0e-14);
+  TEST_COMPARE(te->getNumEvents (), ==, 1);
+
+  TEST_FLOATING_EQUALITY(te->getRelTol(), 1.0e-14, 1.0e-14);
+  TEST_COMPARE(te->getLandOnExactly(), ==, true);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventRange, Construction_Stride)
+{
+  auto te = rcp(new Tempus::TimeEventRange<double>(
+                "TestName", 0.0, PI, 1.0, 1.0e-14, true));
+
+  TEST_COMPARE(te->getName(), ==, "TestName");
+
+  // Test when everything is zero.
+  TEST_FLOATING_EQUALITY(te->getTimeStart (), 0.0 , 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->getTimeStop  (), PI, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->getTimeStride(), 1.0, 1.0e-14);
+  TEST_COMPARE(te->getNumEvents (), ==, 4);
+
+  auto teRange2 = rcp(new Tempus::TimeEventRange<double>(
+      "teRange2", -PI/2.0, PI/2.0, PI/4.0, 1.0e-14, true));
+
+  TEST_FLOATING_EQUALITY(teRange2->timeToNextEvent(0.1), PI/4.0-0.1, 1.0e-14);
+
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventRange, Construction_NumEvents)
+{
+  auto te = rcp(new Tempus::TimeEventRange<double>(
+                "TestName", 0.0, PI, 5, 1.0e-14, true));
+
+  TEST_COMPARE(te->getName(), ==, "TestName");
+
+  // Test when everything is zero.
+  TEST_FLOATING_EQUALITY(te->getTimeStart (), 0.0,      1.0e-14);
+  TEST_FLOATING_EQUALITY(te->getTimeStop  (), PI,     1.0e-14);
+  TEST_FLOATING_EQUALITY(te->getTimeStride(), PI/4.0, 1.0e-14);
+  TEST_COMPARE(te->getNumEvents (), ==, 5);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventRange, Basic_Accessors)
+{
+  auto te = rcp(new Tempus::TimeEventRange<double>());
+
+  te->setRelTol(0.1);
+  TEST_FLOATING_EQUALITY(te->getRelTol(), 0.1, 1.0e-14);
+  te->setRelTol(1.0e-14);
+  te->setLandOnExactly(false);
+  TEST_COMPARE(te->getLandOnExactly(), ==, false);
+  te->setLandOnExactly(true);
+
+  // Reset start after stop.
+  te->setTimeStart(1.0);
+  TEST_FLOATING_EQUALITY(te->getTimeStart (), 1.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->getTimeStop  (), 1.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->getTimeStride(), 0.0, 1.0e-14);
+  TEST_COMPARE(te->getNumEvents (), ==, 1);
+
+  // Reset stop.
+  te->setTimeStop(4.0);
+  TEST_FLOATING_EQUALITY(te->getTimeStart (), 1.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->getTimeStop  (), 4.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->getTimeStride(), 3.0, 1.0e-14);
+  TEST_COMPARE(te->getNumEvents (), ==, 2);
+
+  // Reset stride.
+  te->setTimeStride(0.5);
+  TEST_FLOATING_EQUALITY(te->getTimeStart (), 1.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->getTimeStop  (), 4.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->getTimeStride(), 0.5, 1.0e-14);
+  TEST_COMPARE(te->getNumEvents (), ==, 7);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventRange, Stride)
+{
+  auto te = rcp(new Tempus::TimeEventRange<double>());
+  te->setTimeStart(1.0);
+  te->setTimeStop(4.0);
+  te->setTimeStride(0.5);
+
+  // Negative stride should be reset to stop_-start_.
+  te->setTimeStride(-0.5);
+  TEST_FLOATING_EQUALITY(te->getTimeStart (), 1.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->getTimeStop  (), 4.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->getTimeStride(), 3.0, 1.0e-14);
+  TEST_COMPARE(te->getNumEvents (), ==, 2);
+
+  // Large stride should be reset to stop_-start_.
+  te->setTimeStride(5.0);
+  TEST_FLOATING_EQUALITY(te->getTimeStart (), 1.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->getTimeStop  (), 4.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->getTimeStride(), 3.0, 1.0e-14);
+  TEST_COMPARE(te->getNumEvents (), ==, 2);
+
+  // Stride smaller than relative tolerance should be reset to stop_-start_.
+  te->setTimeStride(1.0e-14);
+  TEST_FLOATING_EQUALITY(te->getTimeStart (), 1.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->getTimeStop  (), 4.0, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->getTimeStride(), 3.0, 1.0e-14);
+  TEST_COMPARE(te->getNumEvents (), ==, 2);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventRange, setTimeRange)
+{
+  auto te = rcp(new Tempus::TimeEventRange<double>());
+
+  // Set with time range.
+  te->setTimeRange(0.0, PI, 1.0);
+  TEST_FLOATING_EQUALITY(te->getTimeStart (), 0.0,  1.0e-14);
+  TEST_FLOATING_EQUALITY(te->getTimeStop  (), PI, 1.0e-14);
+  TEST_FLOATING_EQUALITY(te->getTimeStride(), 1.0,  1.0e-14);
+  TEST_COMPARE(te->getNumEvents (), ==, 4);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventRange, isTime)
+{
+  auto te = rcp(new Tempus::TimeEventRange<double>());
+  te->setTimeRange(0.0, PI, 1.0);
+
+  // Test isTime.
+  //   Around first event.
+  TEST_COMPARE(te->isTime(-10.0e-14), ==, false);   // Just outside tolerance.
+  TEST_COMPARE(te->isTime( -1.0e-14), ==, true );   // Just inside tolerance.
+  TEST_COMPARE(te->isTime(  0.0    ), ==, true );   // Right on timeEvent.
+  TEST_COMPARE(te->isTime(  1.0e-14), ==, true );   // Just inside tolerance.
+  TEST_COMPARE(te->isTime( 10.0e-14), ==, false);   // Just outside tolerance.
+
+  //   Around mid event.
+  TEST_COMPARE(te->isTime(1.0 + -10.0e-14), ==, false); // Just outside tolerance.
+  TEST_COMPARE(te->isTime(1.0 +  -1.0e-14), ==, true ); // Just inside tolerance.
+  TEST_COMPARE(te->isTime(1.0 +   0.0    ), ==, true ); // Right on timeEvent.
+  TEST_COMPARE(te->isTime(1.0 +   1.0e-14), ==, true ); // Just inside tolerance.
+  TEST_COMPARE(te->isTime(1.0 +  10.0e-14), ==, false); // Just outside tolerance.
+
+  //   Around last event.
+  TEST_COMPARE(te->isTime(3.0 + -10.0e-14), ==, false); // Just outside tolerance.
+  TEST_COMPARE(te->isTime(3.0 +  -1.0e-14), ==, true ); // Just inside tolerance.
+  TEST_COMPARE(te->isTime(3.0 +   0.0    ), ==, true ); // Right on timeEvent.
+  TEST_COMPARE(te->isTime(3.0 +   1.0e-14), ==, true ); // Just inside tolerance.
+  TEST_COMPARE(te->isTime(3.0 +  10.0e-14), ==, false); // Just outside tolerance.
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventRange, timeToNextEvent)
+{
+  auto te = rcp(new Tempus::TimeEventRange<double>());
+  te->setTimeRange(0.0, PI, 1.0);
+
+  // Test timeToNextEvent.
+  //   Around first event.
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(-10.0e-14),  1.0e-13, 1.0e-14);     // Just outside tolerance.
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent( -1.0e-14),  1.0e-14, 1.0e-14);     // Just inside tolerance.
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(  0.0    ),  0.0    , 1.0e-14);     // Right on timeEvent.
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(  1.0e-14), -1.0e-14, 1.0e-14);     // Just inside tolerance.
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent( 10.0e-14), 1.0-1.0e-13, 1.0e-14);  // Just outside tolerance.
+
+  //   Around mid event.
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(1.0+ -10.0e-14),  1.0e-13, 1.0e-02);    // Just outside tolerance.
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(1.0+  -1.0e-14),  1.0e-14, 1.0e-01);    // Just inside tolerance.
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(1.0+   0.0    ),  0.0    , 1.0e-02);    // Right on timeEvent.
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(1.0+   1.0e-14), -1.0e-14, 1.0e-01);    // Just inside tolerance.
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(1.0+  10.0e-14), 1.0-1.0e-13, 1.0e-14); // Just outside tolerance.
+
+  //   Around last event.
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(3.0+ -10.0e-14),  1.0e-13, 1.0e-02);  // Just outside tolerance.
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(3.0+  -1.0e-14),  1.0e-14, 1.0e-01);  // Just inside tolerance.
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(3.0+   0.0    ),  0.0    , 1.0e-02);  // Right on timeEvent.
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(3.0+   1.0e-14), -1.0e-14, 1.0e-01);  // Just inside tolerance.
+  TEST_FLOATING_EQUALITY(te->timeToNextEvent(3.0+  10.0e-14), -1.0e-13, 1.0e-02);  // Just outside tolerance.
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventRange, timeOfNextEvent)
+{
+  auto te = rcp(new Tempus::TimeEventRange<double>());
+  te->setTimeRange(0.0, PI, 1.0);
+
+  // Test timeOfNextEvent.
+  //   Around first event.
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(-10.0e-14), 0.0, 1.0e-14);  // Just outside tolerance.
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent( -1.0e-14), 0.0, 1.0e-14);  // Just inside tolerance.
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(  0.0    ), 0.0, 1.0e-14);  // Right on timeEvent.
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(  1.0e-14), 0.0, 1.0e-14);  // Just inside tolerance.
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent( 10.0e-14), 1.0, 1.0e-14);  // Just outside tolerance.
+
+  //   Around mid event.
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(1.0+ -10.0e-14), 1.0, 1.0e-14);  // Just outside tolerance.
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(1.0+  -1.0e-14), 1.0, 1.0e-14);  // Just inside tolerance.
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(1.0+   0.0    ), 1.0, 1.0e-14);  // Right on timeEvent.
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(1.0+   1.0e-14), 1.0, 1.0e-14);  // Just inside tolerance.
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(1.0+  10.0e-14), 2.0, 1.0e-14);  // Just outside tolerance.
+
+  //   Around last event.
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(3.0+ -10.0e-14), 3.0, 1.0e-14);  // Just outside tolerance.
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(3.0+  -1.0e-14), 3.0, 1.0e-14);  // Just inside tolerance.
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(3.0+   0.0    ), 3.0, 1.0e-14);  // Right on timeEvent.
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(3.0+   1.0e-14), 3.0, 1.0e-14);  // Just inside tolerance.
+  TEST_FLOATING_EQUALITY(te->timeOfNextEvent(3.0+  10.0e-14), 3.0, 1.0e-14);  // Just outside tolerance.
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventRange, eventInRange)
+{
+  auto te = rcp(new Tempus::TimeEventRange<double>());
+  te->setTimeRange(0.0, PI, 1.0);
+
+  // Test eventInRange.
+  //   Right end.
+  //   Around first event.
+  TEST_COMPARE(te->eventInRange(-1.0, -10.0e-14), ==, false);  // Just outside tolerance.
+  TEST_COMPARE(te->eventInRange(-1.0,  -1.0e-14), ==, true );  // Just inside tolerance.
+  TEST_COMPARE(te->eventInRange(-1.0,   0.0    ), ==, true );  // Right on timeEvent.
+  TEST_COMPARE(te->eventInRange(-1.0,   1.0e-14), ==, true );  // Just inside tolerance.
+  TEST_COMPARE(te->eventInRange(-1.0,  10.0e-14), ==, true );  // Just outside tolerance.
+
+  //   Around mid event.
+  TEST_COMPARE(te->eventInRange(0.5, 1.0 + -10.0e-14), ==, false);  // Just outside tolerance.
+  TEST_COMPARE(te->eventInRange(0.5, 1.0 +  -1.0e-14), ==, true );  // Just inside tolerance.
+  TEST_COMPARE(te->eventInRange(0.5, 1.0 +   0.0    ), ==, true );  // Right on timeEvent.
+  TEST_COMPARE(te->eventInRange(0.5, 1.0 +   1.0e-14), ==, true );  // Just inside tolerance.
+  TEST_COMPARE(te->eventInRange(0.5, 1.0 +  10.0e-14), ==, true );  // Just outside tolerance.
+
+  //   Around last event.
+  TEST_COMPARE(te->eventInRange(2.5, 3.0 + -10.0e-14), ==, false);  // Just outside tolerance.
+  TEST_COMPARE(te->eventInRange(2.5, 3.0 +  -1.0e-14), ==, true );  // Just inside tolerance.
+  TEST_COMPARE(te->eventInRange(2.5, 3.0 +   0.0    ), ==, true );  // Right on timeEvent.
+  TEST_COMPARE(te->eventInRange(2.5, 3.0 +   1.0e-14), ==, true );  // Just inside tolerance.
+  TEST_COMPARE(te->eventInRange(2.5, 3.0 +  10.0e-14), ==, true );  // Just outside tolerance.
+
+  //   Left end.
+  //   Around first event.
+  TEST_COMPARE(te->eventInRange(-10.0e-14, 0.5), ==, true );  // Just outside tolerance.
+  TEST_COMPARE(te->eventInRange( -1.0e-14, 0.5), ==, true );  // Just inside tolerance.
+  TEST_COMPARE(te->eventInRange(  0.0    , 0.5), ==, true );  // Right on timeEvent.
+  TEST_COMPARE(te->eventInRange(  1.0e-14, 0.5), ==, true );  // Just inside tolerance.
+  TEST_COMPARE(te->eventInRange( 10.0e-14, 0.5), ==, false);  // Just outside tolerance.
+
+  //   Around mid event.
+  TEST_COMPARE(te->eventInRange(1.0 + -10.0e-14, 1.5), ==, true );  // Just outside tolerance.
+  TEST_COMPARE(te->eventInRange(1.0 +  -1.0e-14, 1.5), ==, true );  // Just inside tolerance.
+  TEST_COMPARE(te->eventInRange(1.0 +   0.0    , 1.5), ==, true );  // Right on timeEvent.
+  TEST_COMPARE(te->eventInRange(1.0 +   1.0e-14, 1.5), ==, true );  // Just inside tolerance.
+  TEST_COMPARE(te->eventInRange(1.0 +  10.0e-14, 1.5), ==, false);  // Just outside tolerance.
+
+  //   Around last event.
+  TEST_COMPARE(te->eventInRange(3.0 + -10.0e-14, 4.0), ==, true );  // Just outside tolerance.
+  TEST_COMPARE(te->eventInRange(3.0 +  -1.0e-14, 4.0), ==, true );  // Just inside tolerance.
+  TEST_COMPARE(te->eventInRange(3.0 +   0.0    , 4.0), ==, true );  // Right on timeEvent.
+  TEST_COMPARE(te->eventInRange(3.0 +   1.0e-14, 4.0), ==, true );  // Just inside tolerance.
+  TEST_COMPARE(te->eventInRange(3.0 +  10.0e-14, 4.0), ==, false);  // Just outside tolerance.
+}
+
+
+} // namespace Tempus_Test

--- a/packages/tempus/unit_test/Tempus_UnitTest_TimeEventRangeIndex.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_TimeEventRangeIndex.cpp
@@ -1,0 +1,229 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#include "Teuchos_UnitTestHarness.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Teuchos_TimeMonitor.hpp"
+#include "Teuchos_DefaultComm.hpp"
+
+#include "Tempus_TimeEventRangeIndex.hpp"
+
+#include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
+
+
+namespace Tempus_Unit_Test {
+
+using Teuchos::RCP;
+using Teuchos::rcp;
+using Teuchos::rcp_const_cast;
+using Teuchos::rcp_dynamic_cast;
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventRangeIndex, Default_Construction)
+{
+  auto te = rcp(new Tempus::TimeEventRangeIndex<double>());
+
+  TEST_COMPARE(te->getName(), ==, "TimeEventRangeIndex");
+
+  // Test when everything is zero.
+  TEST_COMPARE(te->getIndexStart (), ==, 0);
+  TEST_COMPARE(te->getIndexStop  (), ==, 0);
+  TEST_COMPARE(te->getIndexStride(), ==, 1);
+  TEST_COMPARE(te->getNumEvents  (), ==, 1);
+
+  // Check base class defaults (functions not implemented in TimeEventRangeIndex).
+  TEST_COMPARE(te->isTime(1.0), ==, false);
+  TEST_COMPARE(te->timeToNextEvent(1.0), ==, te->getDefaultTime());
+  TEST_COMPARE(te->timeOfNextEvent(1.0), ==, te->getDefaultTime());
+  TEST_COMPARE(te->eventInRange(1.0, 4.0), ==, false);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventRangeIndex, Construction)
+{
+  auto te = rcp(new Tempus::TimeEventRangeIndex<double>(
+                "TestName", -1, 10, 2));
+
+  TEST_COMPARE(te->getName(), ==, "TestName");
+
+  // Test when everything is zero.
+  TEST_COMPARE(te->getIndexStart (), ==, -1);
+  TEST_COMPARE(te->getIndexStop  (), ==, 10);
+  TEST_COMPARE(te->getIndexStride(), ==,  2);
+  TEST_COMPARE(te->getNumEvents  (), ==,  6);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventRangeIndex, Basic_Accesors)
+{
+  auto te = rcp(new Tempus::TimeEventRangeIndex<double>());
+
+  te->setName("TestName");
+  TEST_COMPARE(te->getName(), ==, "TestName");
+
+  // Reset start after stop.
+  te->setIndexStart(1);
+  TEST_COMPARE(te->getIndexStart (), ==, 1);
+  TEST_COMPARE(te->getIndexStop  (), ==, 1);
+  TEST_COMPARE(te->getIndexStride(), ==, 1);
+  TEST_COMPARE(te->getNumEvents  (), ==, 1);
+
+  // Reset stop.
+  te->setIndexStop(5);
+  TEST_COMPARE(te->getIndexStart (), ==, 1);
+  TEST_COMPARE(te->getIndexStop  (), ==, 5);
+  TEST_COMPARE(te->getIndexStride(), ==, 1);
+  TEST_COMPARE(te->getNumEvents  (), ==, 5);
+
+  // Reset stride.
+  te->setIndexStride(2);
+  TEST_COMPARE(te->getIndexStart (), ==, 1);
+  TEST_COMPARE(te->getIndexStop  (), ==, 5);
+  TEST_COMPARE(te->getIndexStride(), ==, 2);
+  TEST_COMPARE(te->getNumEvents  (), ==, 3);
+
+  // Set with index range.
+  te->setIndexRange(-5, 5, 3);
+  TEST_COMPARE(te->getIndexStart (), ==, -5);
+  TEST_COMPARE(te->getIndexStop  (), ==,  5);
+  TEST_COMPARE(te->getIndexStride(), ==,  3);
+  TEST_COMPARE(te->getNumEvents  (), ==,  4);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventRangeIndex, Stride)
+{
+  auto te = rcp(new Tempus::TimeEventRangeIndex<double>());
+  te->setIndexStart(1);
+  te->setIndexStop (5);
+  TEST_COMPARE(te->getIndexStart (), ==, 1);
+  TEST_COMPARE(te->getIndexStop  (), ==, 5);
+
+  // Negative stride should be reset to stop_-start_.
+  te->setIndexStride(-1);
+  TEST_COMPARE(te->getIndexStride(), ==, 1);
+  TEST_COMPARE(te->getNumEvents  (), ==, 5);
+
+  // Large stride should be reset to stop_-start_.
+  te->setIndexStride(5);
+  TEST_COMPARE(te->getIndexStride(), ==, 4);
+  TEST_COMPARE(te->getNumEvents  (), ==, 2);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventRangeIndex, isIndex)
+{
+  auto te = rcp(new Tempus::TimeEventRangeIndex<double>());
+  te->setIndexRange(-5, 5, 3);
+
+  // Test isIndex.
+  TEST_COMPARE(te->isIndex(-6), ==, false);   // Around first event.
+  TEST_COMPARE(te->isIndex(-5), ==, true );
+  TEST_COMPARE(te->isIndex(-4), ==, false);
+
+  TEST_COMPARE(te->isIndex(0), ==, false);    // Around mid event.
+  TEST_COMPARE(te->isIndex(1), ==, true );
+  TEST_COMPARE(te->isIndex(2), ==, false);
+
+  TEST_COMPARE(te->isIndex(3), ==, false);    // Around last event.
+  TEST_COMPARE(te->isIndex(4), ==, true );
+  TEST_COMPARE(te->isIndex(5), ==, false);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventRangeIndex, indexToNextEvent)
+{
+  auto te = rcp(new Tempus::TimeEventRangeIndex<double>());
+  te->setIndexRange(-5, 5, 3);
+
+  // Test indexToNextEvent.
+  TEST_COMPARE(te->indexToNextEvent(-9), ==, 4); //   Around first event.
+  TEST_COMPARE(te->indexToNextEvent(-5), ==, 0);
+  TEST_COMPARE(te->indexToNextEvent(-4), ==, 2);
+
+  TEST_COMPARE(te->indexToNextEvent(-1), ==, 2); //   Around mid event.
+  TEST_COMPARE(te->indexToNextEvent( 1), ==, 0);
+  TEST_COMPARE(te->indexToNextEvent( 3), ==, 1);
+
+  TEST_COMPARE(te->indexToNextEvent( 2), ==, 2); //   Around last event.
+  TEST_COMPARE(te->indexToNextEvent( 4), ==, 0);
+  TEST_COMPARE(te->indexToNextEvent( 8), ==,-4);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventRangeIndex, indexOfNextEvent)
+{
+  auto te = rcp(new Tempus::TimeEventRangeIndex<double>());
+  te->setIndexRange(-5, 5, 3);
+
+  // Test indexOfNextEvent.
+  TEST_COMPARE(te->indexOfNextEvent(-9), ==, -5); //   Around first event.
+  TEST_COMPARE(te->indexOfNextEvent(-5), ==, -5);
+  TEST_COMPARE(te->indexOfNextEvent(-4), ==, -2);
+
+  TEST_COMPARE(te->indexOfNextEvent(-1), ==, 1); //   Around mid event.
+  TEST_COMPARE(te->indexOfNextEvent( 1), ==, 1);
+  TEST_COMPARE(te->indexOfNextEvent( 3), ==, 4);
+
+  TEST_COMPARE(te->indexOfNextEvent( 2), ==, 4); //   Around last event.
+  TEST_COMPARE(te->indexOfNextEvent( 4), ==, 4);
+  TEST_COMPARE(te->indexOfNextEvent( 8), ==, 4);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(TimeEventRangeIndex, eventInRangeIndex)
+{
+  auto te = rcp(new Tempus::TimeEventRangeIndex<double>());
+  te->setIndexRange(-5, 5, 3);
+
+  // Test eventInRangeIndex.
+  //   Right end.
+  TEST_COMPARE(te->eventInRangeIndex(-9, -6), ==, false);   // Around first event.
+  TEST_COMPARE(te->eventInRangeIndex(-9, -5), ==, true );
+  TEST_COMPARE(te->eventInRangeIndex(-9, -4), ==, true );
+
+  TEST_COMPARE(te->eventInRangeIndex(-1, 0), ==, false);   // Around mid event.
+  TEST_COMPARE(te->eventInRangeIndex(-1, 1), ==, true );
+  TEST_COMPARE(te->eventInRangeIndex(-1, 2), ==, true );
+
+  TEST_COMPARE(te->eventInRangeIndex(2, 3), ==, false);   // Around last event.
+  TEST_COMPARE(te->eventInRangeIndex(2, 4), ==, true );
+  TEST_COMPARE(te->eventInRangeIndex(2, 5), ==, true );
+
+  //   Left end.
+  TEST_COMPARE(te->eventInRangeIndex(-6.0, -3), ==, true );   // Around first event.
+  TEST_COMPARE(te->eventInRangeIndex(-5.0, -3), ==, true );
+  TEST_COMPARE(te->eventInRangeIndex(-4.0, -3), ==, false);
+
+  TEST_COMPARE(te->eventInRangeIndex(-3, 0), ==, true );   // Around mid event.
+  TEST_COMPARE(te->eventInRangeIndex(-2, 0), ==, true );
+  TEST_COMPARE(te->eventInRangeIndex(-1, 0), ==, false);
+
+  TEST_COMPARE(te->eventInRangeIndex(3, 8), ==, true );   // Around last event.
+  TEST_COMPARE(te->eventInRangeIndex(4, 8), ==, true );
+  TEST_COMPARE(te->eventInRangeIndex(5, 8), ==, false);
+}
+
+
+} // namespace Tempus_Test


### PR DESCRIPTION
Add the ability to trigger temporal events, e.g.,

    Solution output
    Diagnostic output
    Restart
    Screen dump
    Debug
    In-situ visualization
    User-specified (i.e., observer)
    Others?

Ability to specify temporal “events” via

    Time and/or time step index
    Start and stop times and/or indices
    Interval and/or number of “events”
    List of times and/or indices

Specify when to trigger “event”

    Exactly at the specified time, i.e., adjust timestep to hit output time
    If within timestep, output the following timestep, i.e., do not adjust timestep.

Added unit tests to cover, the options.

@trilinos/tempus 


## Related Issues

* Closes #7396 


## Testing

All tests pass on my Mac.