### PR TITLE
ATDM/ats2: Disable hack around error message

### DIFF
--- a/cmake/std/atdm/ats2/trilinos_jsrun
+++ b/cmake/std/atdm/ats2/trilinos_jsrun
@@ -40,21 +40,22 @@ function debug_print {
 }
 
 ################################################################################
-# @brief: Hack around JSM server error "Error: Remote JSM server is not
-# responding"
+# @brief: Evaluate the jsrun command and return the jsrun return value.
 # This function assumes that "args" has been initialized
-# @return void
+# @return the jsrun return value
 ################################################################################
 function evaluate_jsrun_command {
   local jsrun_ret
-  local out_file
-  local retry
-  local grep_status
+  #local out_file
+  #local retry
+  #local grep_status
 
-  # Create process ID specific output file
-  # Instead of attempting to find the test name in $@, let's use
-  # the hash of the test command to avoid race conditions.
-  out_file=$(printf "'%s' " "${args[@]}" | md5sum | awk '{print $1".out"}')
+  # Use the hash of the test name and arguments as the output file. This still
+  # causes race conditions among tests as some tests run the same exe with the
+  # same arguments but post to a different ctest test names. We need the ctest
+  # test name in the environment.
+  #out_file=$(printf "'%s' " "${args[@]}" | md5sum | awk '{print $1".out"}')
+  #out_file="$CTEST_TEST_NAME"."$out_file"
 
   if [ "$ECHO_CMD" == "1" ]; then
     echo "BEFORE: jsrun " $(printf "'%s' " "${orig_args[@]}")
@@ -62,35 +63,37 @@ function evaluate_jsrun_command {
   fi
 
   # Set retry, assume JSRUN_WRAPPER_NUM_RETRIES is valid if set
-  if [[ ! "$JSRUN_WRAPPER_NUM_RETRIES" == "" ]]; then
-    retry=${JSRUN_WRAPPER_NUM_RETRIES}
-  else
-    retry=3
-  fi
-  grep_status=0
+  #if [[ ! "$JSRUN_WRAPPER_NUM_RETRIES" == "" ]]; then
+  #  retry=${JSRUN_WRAPPER_NUM_RETRIES}
+  #else
+  #  retry=3
+  #fi
+  #grep_status=0
 
   # Retry jsrun command until retry is exhausted or JSM server error is not found
-  while [[ $grep_status -eq 0 && $retry -ne 0 ]]; do
+  #while [[ $grep_status -eq 0 && $retry -ne 0 ]]; do
     # Evaluate the command passed in and redirect all output
-    eval jsrun $(printf "'%s' " "${args[@]}") &> $out_file
-    jsrun_ret=$?
+    #eval jsrun $(printf "'%s' " "${args[@]}") &> $out_file
+    #jsrun_ret=$?
 
-    grep 'Error: Remote JSM server is not responding' $out_file &> /dev/null
-    grep_status=$?
+    #grep 'Error: Remote JSM server is not responding' $out_file &> /dev/null
+    #grep_status=$?
 
     # Sleep for a few seconds before retrying the test.
-    if [[ $grep_status -eq 0 && $retry -ne 1 ]]; then
-      sleep 3
-    fi
+    #if [[ $grep_status -eq 0 && $retry -ne 1 ]]; then
+    #  sleep 3
+    #fi
 
-    retry=$((retry-1))
-  done
+    #retry=$((retry-1))
+  #done
 
-  if [ "$ECHO_CMD" == "1" ]; then
-    echo "out_file=$out_file"
-  fi
-  cat $out_file
-  rm $out_file
+  #if [ "$ECHO_CMD" == "1" ]; then
+  #  echo "out_file=$out_file"
+  #fi
+  #cat $out_file
+  #rm $out_file
+  eval jsrun $(printf "'%s' " "${args[@]}")
+  jsrun_ret=$?
   return $jsrun_ret
 }
 


### PR DESCRIPTION
This retry logic did not generated unique .out file names since some "Command Lines" are exactly the same but post to different ctest "Test" names. To make the retry logic work, we need the ctest "Test" name in the environment in order to generate a uniqe .out file name. This change disables the retry logic and may result in the mass Errors we were trying to work around. The retry code has been commented out but left there in case we need it again in the future.

## How was this tested?
See atdv-351.