### PR TITLE
ATDM: Set several CUDA disables (#6329, #6799, #7090)

### DIFF
--- a/cmake/std/PullRequestLinuxCuda9.2TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxCuda9.2TestingSettings.cmake
@@ -110,4 +110,10 @@ set (PanzerMiniEM_MiniEM-BlockPrec_Augmentation_MPI_4_DISABLE ON CACHE BOOL "Tem
 set (PanzerMiniEM_MiniEM-BlockPrec_RefMaxwell_MPI_4_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
 set (ROL_example_PDE-OPT_poisson-boltzmann_example_01_MPI_4_DISABLE ON CACHE BOOL "Temporary disable for CUDA PR testing")
 
+# Disable a couple of unit tests in test KokkosCore_UnitTest_Cuda_MPI_1 that
+# are randomly failing in PR test iterations (#6799)
+set (KokkosCore_UnitTest_Cuda_MPI_1_EXTRA_ARGS
+  "--gtest_filter=-cuda.debug_pin_um_to_host:cuda.debug_serial_execution"
+  CACHE STRING "Temporary disable for CUDA PR testing")
+
 include("${CMAKE_CURRENT_LIST_DIR}/PullRequestLinuxCommonTestingSettings.cmake")

--- a/cmake/std/atdm/ATDMDisables.cmake
+++ b/cmake/std/atdm/ATDMDisables.cmake
@@ -306,4 +306,10 @@ IF (ATDM_NODE_TYPE STREQUAL "CUDA")
   # Disable ctest DISABLED test (otherwise, this shows up on CDash as "NotRun")
   ATDM_SET_ENABLE(KokkosContainers_PerformanceTest_Cuda_DISABLE ON)
 
+  # Disable a couple of unit tests in test KokkosCore_UnitTest_Cuda_MPI_1
+  # (#6799)
+  ATDM_SET_CACHE(KokkosCore_UnitTest_Cuda_MPI_1_EXTRA_ARGS
+    "--gtest_filter=-cuda.debug_pin_um_to_host:cuda.debug_serial_execution"
+    CACHE STRING )
+
 ENDIF()

--- a/cmake/std/atdm/waterman/tweaks/Tweaks.cmake
+++ b/cmake/std/atdm/waterman/tweaks/Tweaks.cmake
@@ -50,6 +50,12 @@ IF (ATDM_NODE_TYPE STREQUAL "CUDA")
   # Disable known falure for ROL CUDA builds (#3543)
   ATDM_SET_ENABLE(ROL_test_elementwise_TpetraMultiVector_MPI_4_DISABLE ON)
 
+  # Disable known failure (#6329)
+  ATDM_SET_ENABLE(ROL_NonlinearProblemTest_MPI_4_DISABLE ON)
+
+  # Disable known randomly timing out test (#7090)
+  ATDM_SET_ENABLE(MueLu_ParameterListInterpreterTpetra_MPI_1_DISABLE ON)
+
   IF (ATDM_CUDA_RDC)
 
     # Disable the build of SEACAS 'explore' for all cuda+rdc builds for now (#6008)


### PR DESCRIPTION
Performs the disabled called out in #6329, #6799, #7090

## How was this tested?

Testing the the configure of everything on 'waterman' for one CUDA build:

```
$ bsub -x -Is -n 20 bash
***Forced exclusive execution
Job <294350> is submitted to default queue <rhel7W>.
<<Waiting for dispatch ...>>
<<Starting on waterman3>>

$ cd /home/rabartl/Trilinos.base/BUILDS/WATERMAN/CHECKIN/

$ ./checkin-test-atdm.sh \
    cuda-opt \
    --enable-all-packages=on \
    --configure

***
*** ./checkin-test-atdm.sh  cuda-opt --enable-all-packages=on --configure
***

ATDM_TRILINOS_DIR = '/home/rabartl/Trilinos.base/Trilinos/cmake/std/atdm/../../..'
ATDM_TRIBITS_DIR = '/home/rabartl/Trilinos.base/Trilinos/cmake/std/atdm/../../../cmake/tribits'

Load some env to get python, cmake, etc ...

Hostname 'waterman3' matches known ATDM host 'waterman3' and system 'waterman'
Setting compiler and build options for build-name 'default'
Using waterman compiler stack GNU-7.2.0-OPENMPI-2.1.2 to build DEBUG code with Kokkos node type SERIAL and KOKKOS_ARCH=Power9
File local-checkin-test-defaults.py already exists, leaving it!

Running configure, build, and/or testing for 1 builds:
    cuda-opt


***
*** 0) Process build case cuda-opt
***

Hostname 'waterman3' matches known ATDM host 'waterman3' and system 'waterman'
Setting compiler and build options for build-name 'cuda-opt'
Using waterman compiler stack CUDA-9.2-GNU-7.2.0-OPENMPI-2.1.2 to build RELEASE code with Kokkos node type CUDA and KOKKOS_ARCH=Power9,Volta70

Running: checkin-test.py --st-extra-builds=cuda-opt ...

  ==> See output file checkin-test.cuda-opt.out

+ /home/rabartl/Trilinos.base/Trilinos/cmake/std/atdm/../../../cmake/tribits/ci_support/checkin-test.py --src-dir=/home/rabartl/Trilinos.base/Trilinos/cmake/std/atdm/../../.. '--make-options=-j 64' '--ctest-options=-j 2' --st-extra-builds=cuda-opt --default-builds= --allow-no-pull --send-email-to= --test-categories=NIGHTLY --ctest-timeout=600 --enable-all-packages=on --configure --use-ninja --log-file=checkin-test.cuda-opt.out
+ ATDM_CHT_SINGLE_RETURN_CODE=0
+ set +x
cuda-opt: PASSED!
```

Now, looking for evidence that the disables were applied correctly:

```
$ grep KokkosCore_UnitTest_Cuda_MPI_1 cuda-opt/configure.out
-- KokkosCore_UnitTest_Cuda_MPI_1: Added test (BASIC, NUM_MPI_PROCS=1, PROCESSORS=1)!

$ find cuda-opt/packages/kokkos/core/ -name CTestTestfile.cmake -exec grep KokkosCore_UnitTest_Cuda_MPI_1 {} \;
add_test(KokkosCore_UnitTest_Cuda_MPI_1 "/home/projects/ppc64le-pwr9-nvidia/openmpi/2.1.2/gcc/7.2.0/cuda/9.2.88/bin/mpiexec" "-np" "1" "-map-by" "socket:PE=4" "/home/rabartl/Trilinos.base/BUILDS/WATERMAN/CHECKIN/cuda-opt/packages/kokkos/core/unit_test/KokkosCore_UnitTest_Cuda.exe" "--gtest_filter=-cuda.debug_pin_um_to_host:cuda.debug_serial_execution")
set_tests_properties(KokkosCore_UnitTest_Cuda_MPI_1 PROPERTIES  ENVIRONMENT "CTEST_KOKKOS_DEVICE_TYPE=gpus" FAIL_REGULAR_EXPRESSION "  FAILED  " LABELS "Kokkos" PROCESSORS "1" REQUIRED_FILES "/home/rabartl/Trilinos.base/BUILDS/WATERMAN/CHECKIN/cuda-opt/packages/kokkos/core/unit_test/KokkosCore_UnitTest_Cuda.exe" RESOURCE_GROUPS "1,gpus:1" _BACKTRACE_TRIPLES "/home/rabartl/Trilinos.base/Trilinos/cmake/tribits/core/package_arch/TribitsAddTestHelpers.cmake;680;ADD_TEST;/home/rabartl/Trilinos.base/Trilinos/cmake/tribits/core/package_arch/TribitsAddTestHelpers.cmake;837;TRIBITS_ADD_TEST_ADD_TEST;/home/rabartl/Trilinos.base/Trilinos/cmake/tribits/core/package_arch/TribitsAddTest.cmake;970;TRIBITS_ADD_TEST_ADD_TEST_ALL;/home/rabartl/Trilinos.base/Trilinos/cmake/tribits/core/package_arch/TribitsAddExecutableAndTest.cmake;77;TRIBITS_ADD_TEST;/home/rabartl/Trilinos.base/Trilinos/cmake/tribits/core/package_arch/TribitsAddExecutableAndTest.cmake;251;TRIBITS_ADD_TEST_WRAPPER;/home/rabartl/Trilinos.base/Trilinos/packages/kokkos/cmake/kokkos_tribits.cmake;139;TRIBITS_ADD_EXECUTABLE_AND_TEST;/home/rabartl/Trilinos.base/Trilinos/packages/kokkos/core/unit_test/CMakeLists.txt;218;KOKKOS_ADD_EXECUTABLE_AND_TEST;/home/rabartl/Trilinos.base/Trilinos/packages/kokkos/core/unit_test/CMakeLists.txt;0;")

$ grep ROL_NonlinearProblemTest_MPI_4 cuda-opt/configure.out
-- Setting default ROL_NonlinearProblemTest_MPI_4_DISABLE=ON
-- ROL_NonlinearProblemTest_MPI_4: NOT added test because ROL_NonlinearProblemTest_MPI_4_DISABLE='ON'!

$ grep MueLu_ParameterListInterpreterTpetra_MPI_1 cuda-opt/configure.out
-- Setting default MueLu_ParameterListInterpreterTpetra_MPI_1_DISABLE=ON
-- MueLu_ParameterListInterpreterTpetra_MPI_1: NOT added test because MueLu_ParameterListInterpreterTpetra_MPI_1_DISABLE='ON'!
```

Now to build and run that Kokkos test (on the compute node):

```
$ cd cuda-opt/

$ . load-env.sh 
Hostname 'waterman3' matches known ATDM host 'waterman3' and system 'waterman'
Setting compiler and build options for build-name 'cuda-opt'
Using waterman compiler stack CUDA-9.2-GNU-7.2.0-OPENMPI-2.1.2 to build RELEASE code with Kokkos node type CUDA and KOKKOS_ARCH=Power9,Volta70

$ cd packages/kokkos/core/unit_test/

$ make help | grep KokkosCore_UnitTest_Cuda
  KokkosCore_UnitTest_Cuda
  KokkosCore_UnitTest_CudaInterOpInit
  KokkosCore_UnitTest_CudaInterOpStreams

$ make NP=32 KokkosCore_UnitTest_Cuda
...
[117/117] Linking CXX executable packages/kokkos/core/unit_test/KokkosCore_UnitTest_Cuda.exe

$ ctest -R KokkosCore_UnitTest_Cuda_MPI_1
Test project /ascldap/users/rabartl/Trilinos.base/BUILDS/WATERMAN/CHECKIN/cuda-opt/packages/kokkos/core/unit_test
    Start 2: KokkosCore_UnitTest_Cuda_MPI_1
1/1 Test #2: KokkosCore_UnitTest_Cuda_MPI_1 ...   Passed   45.12 sec

100% tests passed, 0 tests failed out of 1

Label Time Summary:
Kokkos    =  45.12 sec*proc (1 test)

Total Test time (real) =  45.13 sec

```

The verbose test ouptut in the file Testing/Temporary/LastTest.log showed:

```
Note: Google Test filter = -cuda.debug_pin_um_to_host:cuda.debug_serial_execution
...
[----------] Global test environment tear-down
[==========] 191 tests from 4 test cases ran. (44148 ms total)
[  PASSED  ] 191 tests.
```

The previous output as shown [here](https://testing.sandia.gov/cdash/testDetails.php?test=112972560&build=7070386) showed:

```
[==========] 193 tests from 4 test cases ran. (93794 ms total)
[  PASSED  ] 192 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] cuda.debug_pin_um_to_host
```

I think that is pretty good evidence that just these two unit tests have been disabled.
