### PR TITLE
IOSS: Fix setting of exodiff binary in tests

### DIFF
--- a/packages/seacas/libraries/ioss/src/main/CMakeLists.txt
+++ b/packages/seacas/libraries/ioss/src/main/CMakeLists.txt
@@ -102,12 +102,8 @@ if (TPL_ENABLE_MPI)
 endif()
 
 if (${CMAKE_PROJECT_NAME}_ENABLE_SEACASExodiff)
-   find_program (SEACAS_EXODIFF_BINARY
-	     NAME exodiff
-	     PATHS
-	       ${BINARY_DIR}
-	       ../../../../applications/exodiff
-	     )
+   set(SEACAS_EXODIFF_BINARY "../../../../applications/exodiff/exodiff")
+endif()
 
 if (SEACAS_EXODIFF_BINARY)
 TRIBITS_ADD_ADVANCED_TEST(exodus32_to_exodus32
@@ -183,7 +179,6 @@ IF (SEACASIoss_ENABLE_THREADSAFE)
   )
 ENDIF()
 ENDIF()
-ENDIF(${CMAKE_PROJECT_NAME}_ENABLE_SEACASExodiff)
 
 IF (TPL_ENABLE_Pamgen OR Trilinos_ENABLE_Pamgen)
 # This test makes sure that the adjacency information (what element blocks are adjacent to what other
@@ -293,7 +288,7 @@ TRIBITS_ADD_ADVANCED_TEST(exodus32_to_unstructured_cgns
   )
 endif()
 
-if (${CMAKE_PROJECT_NAME}_ENABLE_SEACASExodiff)
+if (SEACAS_EXODIFF_BINARY)
 TRIBITS_ADD_ADVANCED_TEST(exodus_to_unstructured_cgns_to_exodus
    TEST_0 EXEC io_shell ARGS ${DECOMP_ARG} ${CMAKE_CURRENT_SOURCE_DIR}/test/8-block.g 8-block.cgns
      NOEXEPREFIX NOEXESUFFIX


### PR DESCRIPTION
A previous commit tried to improve the setting of the path to the
exodiff binary, but mistakenly added a method that only worked on
a preexisting build.  On a clean build, it would result
in an empty symbol which resulted in an empty program name following
the CMND keyword.

This fixes that problem.

Fixes #7420.  We really need to add cgns to at least one of the Trilinos checkin builds.
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/seacas 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->