### PR TITLE
Belos: Avoid re-allocation in PseudoBlockCG

### DIFF
--- a/packages/belos/src/BelosCGIter.hpp
+++ b/packages/belos/src/BelosCGIter.hpp
@@ -364,6 +364,16 @@ class CGIter : virtual public CGIteration<ScalarType,MV,OP> {
   void CGIter<ScalarType,MV,OP>::initializeCG(CGIterationState<ScalarType,MV>& newstate)
   {
     // Initialize the state storage if it isn't already.
+    if (!newstate.R.is_null() && MVT::GetNumberVecs(*newstate.R) == 1 &&
+        !newstate.Z.is_null() && MVT::GetNumberVecs(*newstate.Z) == 1 &&
+        !newstate.P.is_null() && MVT::GetNumberVecs(*newstate.P) == 1 &&
+        !newstate.AP.is_null() && MVT::GetNumberVecs(*newstate.AP) == 1) {
+      R_ = Teuchos::rcp_const_cast<MV>(newstate.R);
+      Z_ = Teuchos::rcp_const_cast<MV>(newstate.Z);
+      P_ = Teuchos::rcp_const_cast<MV>(newstate.P);
+      AP_ = Teuchos::rcp_const_cast<MV>(newstate.AP);
+    }
+
     if (!stateStorageInitialized_) 
       setStateSize();
 

--- a/packages/belos/src/BelosPseudoBlockCGSolMgr.hpp
+++ b/packages/belos/src/BelosPseudoBlockCGSolMgr.hpp
@@ -357,6 +357,8 @@ namespace Belos {
 
     // Internal state variables.
     bool isSet_;
+
+    Teuchos::RCP<CGIterationState<ScalarType,MV> > state_;
   };
 
 
@@ -817,9 +819,15 @@ ReturnType PseudoBlockCGSolMgr<ScalarType,MV,OP,true>::solve ()
       Teuchos::RCP<MV> R_0 = MVT::CloneViewNonConst( *(Teuchos::rcp_const_cast<MV>(problem_->getInitResVec())), currIdx );
 
       // Get a new state struct and initialize the solver.
-      CGIterationState<ScalarType,MV> newState;
-      newState.R = R_0;
-      block_cg_iter->initializeCG(newState);
+      if (state_.is_null())
+        state_ = Teuchos::rcp(new CGIterationState<ScalarType,MV>());
+      state_->R = R_0;
+      block_cg_iter->initializeCG(*state_);
+      CGIterationState<ScalarType,MV> state = block_cg_iter->getState();
+      state_->R = state.R;
+      state_->Z = state.Z;
+      state_->P = state.P;
+      state_->AP = state.AP;
 
       while(1) {
 


### PR DESCRIPTION
@trilinos/belos 

## Motivation
PseudoBlockCG re-allocates its state vectors in every solve. This PR fixes that. The same pattern can probably be found in other solvers, but before changing this everywhere, I'd like some opinion from @trilinos/belos.