### PR TITLE
Teuchos/Kokkos: Fixes for some potential upcoming changes to Kokkos

### DIFF
--- a/packages/teuchos/comm/src/Teuchos_StackedTimer.hpp
+++ b/packages/teuchos/comm/src/Teuchos_StackedTimer.hpp
@@ -57,12 +57,14 @@
 #include <iostream>
 
 #if defined(HAVE_TEUCHOS_KOKKOS_PROFILING) && defined(HAVE_TEUCHOSCORE_KOKKOSCORE)
+#ifndef KOKKOS_IMPL_KOKKOS_PROFILING_HPP
 namespace Kokkos {
 namespace Profiling {
 extern void pushRegion (const std::string&);
 extern void popRegion ();
 } // namespace Profiling
 } // namespace Kokkos
+#endif
 #endif
 
 


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/teuchos

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

I've been adding a lot of functionality to Kokkos, some of which has effects in Trilinos. Because the scope of Tools is expanding, we're moving the namespace from "Profiling" to "Tools." In order to make that not a problem, we reexpose everything that used to be in "Profiling" as an alias in namespace "Kokkos::Profiling" to the corresponding entry in "Tools."

99% of the time that's enough. The exception is that in Teuchos StackedTimer, those functions in Profiling are declared "extern" in the Profiling namespace. This _also_ is fine, unless somebody has included the actual Kokkos header in which those are defined in namespace Kokkos::Tools. This happens to be the case somewhere in MueLu, they apparently include Kokkos and _then_ include the header I modified.

This PR fixes that problem by checking for the header in which these functions are defined having been included. If it has, these definitions are omitted. Also, this doesn't cause any harm if the namespace doesn't move, in that case you just avoid declaring something extern that doesn't need to be clared.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

To the best of my knowledge this isn't related to any other work within Trilinos, but will be necessary to handle the changes from kokkos/kokkos#2422

## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

This came out of conversations between @vbrunini and myself

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

I'm not 100% sure on this, I'd like advice from somebody in Trilinos. I'd be astonished if we didn't have tests for StackedTimer, but I don't know my way around the testing system. If we cover StackedTimer in tests, this condition is satisfied

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->