### PR TITLE
Sacado:  Fix some Albany build issues with the new design

### DIFF
--- a/packages/sacado/src/new_design/Sacado_Fad_Exp_GeneralFad.hpp
+++ b/packages/sacado/src/new_design/Sacado_Fad_Exp_GeneralFad.hpp
@@ -136,6 +136,24 @@ namespace Sacado {
         this->fastAccessDx(ith) = value_type(1.);
       }
 
+      //! Set whether this Fad object should update values
+      /*! Retained for backward compatibility.
+       */
+      KOKKOS_INLINE_FUNCTION
+      void setUpdateValue(bool update_val) {}
+
+      //! Return whether this Fad object has an updated value
+      /*! Retained for backward compatibility.
+       */
+      KOKKOS_INLINE_FUNCTION
+      bool updateValue() const { return true; }
+
+      //! Cache values
+      /*! Retained for backward compatibility.
+       */
+      KOKKOS_INLINE_FUNCTION
+      void cache() const {}
+
       //! Returns whether two Fad objects have the same values
       template <typename S>
       KOKKOS_INLINE_FUNCTION

--- a/packages/sacado/src/new_design/Sacado_Fad_Exp_ViewFad.hpp
+++ b/packages/sacado/src/new_design/Sacado_Fad_Exp_ViewFad.hpp
@@ -124,6 +124,25 @@ namespace Sacado {
     typedef U type;
   };
 
+  //! Specialization of %ScalarType to ViewFad types
+  /*!
+   * This specialization overrides the one for GeneralFad to handle const
+   * value types so that resulting scalar type is still const.
+   */
+  template <typename ValueT, unsigned Size, unsigned Stride, typename Base>
+  struct ScalarType< Fad::Exp::ViewFad<ValueT,Size,Stride,Base> > {
+    typedef typename ScalarType<ValueT>::type type;
+  };
+
+  /*!
+   * This specialization overrides the one for GeneralFad to handle const
+   * value types so that resulting value type is still const.
+   */
+  template <typename ValueT, unsigned Size, unsigned Stride, typename Base>
+  struct ValueType< Fad::Exp::ViewFad<ValueT,Size,Stride,Base> > {
+    typedef ValueT type;
+  };
+
 } // namespace Sacado
 
 #endif // SACADO_FAD_EXP_VIEWFAD_HPP


### PR DESCRIPTION
For issue #7445.  The new design broke the Albany build.  Two issues (so
far):

* setUpdateValue() disappeared.  I went ahead and re-added it as a
  no-op.
* ScalarType<ViewFad<const T,...> >::type is no longer const T.  I fixed
  fixed this by adding another partial specialization of ScalarType for
  ViewFad.  I chose to go this route instead of adding
  const_scalar_type, non_const_scalar_type to all of the Fad classes
  because ViewFad is the only Fad type that can have a const
  value/scalar type.