### PR TITLE
Tacho - remove valgrind error (not real error)

### DIFF
--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_NumericTools.hpp
@@ -491,7 +491,10 @@ namespace Tacho {
           
       timer.reset();
       {
-        value_type_array buf(do_not_initialize_tag("buf"), _info.max_schur_size*(_info.max_schur_size + 1));
+        /// valgrind reports the following buf array as uninitialized even if it is initialized
+        /// while the task is executed. to remove the valgrind error, we initialize the array with zero.
+        /// value_type_array buf(do_not_initialize_tag("buf"), _info.max_schur_size*(_info.max_schur_size + 1));
+        value_type_array buf("buf", _info.max_schur_size*(_info.max_schur_size + 1));
         const size_t bufsize = buf.span()*sizeof(value_type);
         track_alloc(bufsize);
           
@@ -540,7 +543,10 @@ namespace Tacho {
       const ordinal_type nb = panelsize > 0 ? panelsize : _info.max_schur_size;
       timer.reset();
       {
-        value_type_array buf(do_not_initialize_tag("buf"), _info.max_schur_size*(nb + 1));
+        /// valgrind reports the following buf array as uninitialized even if it is initialized
+        /// while the task is executed. to remove the valgrind error, we initialize the array with zero.
+        /// value_type_array buf(do_not_initialize_tag("buf"), _info.max_schur_size*(nb + 1));
+        value_type_array buf("buf", _info.max_schur_size*(nb + 1));
         const size_t bufsize = buf.span()*sizeof(value_type);
         track_alloc(bufsize);
           


### PR DESCRIPTION

## Motivation

@crdohrm runs valgrind and the valgrind reports conditional jump based on uninitialized values. Examining the code together, the value is actually initialized where the array is used. However, valgrind misses it and reports it as conditional jump with uninitialized values. For a quality reason, this PR just initialize the temporary work buffer before it is used. 

