### PR TITLE
ATDM: ats2: Add cuda+complex build to support GEMMA (ATDV-300)

### DIFF
--- a/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_complex_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_complex_static_opt.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+if [ "${Trilinos_TRACK}" == "" ] ; then
+  export Trilinos_TRACK=Experimental
+fi
+$WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ats2/local-driver.sh

--- a/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_complex_static_opt.sh
+++ b/cmake/ctest/drivers/atdm/ats2/drivers/Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_complex_static_opt.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 if [ "${Trilinos_TRACK}" == "" ] ; then
-  export Trilinos_TRACK=Experimental
+  export Trilinos_TRACK=Specialized
 fi
 $WORKSPACE/Trilinos/cmake/ctest/drivers/atdm/ats2/local-driver.sh

--- a/cmake/std/atdm/ats2/all_supported_builds.sh
+++ b/cmake/std/atdm/ats2/all_supported_builds.sh
@@ -8,4 +8,5 @@ export ATDM_CONFIG_ALL_SUPPORTED_BUILDS=(
   ats2-gnu-7.3.1-spmpi-rolling_serial_static_dbg
   ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_static_opt
   ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_static_dbg
+  ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_complex_static_opt
   )


### PR DESCRIPTION
New cuda+complex build to support GEMMA (see [ATDV-300](https://sems-atlassian-srn.sandia.gov/browse/ATDV-300)).

This build initially begins life as a 'Specialized' build as it has some new failing tests that we don't see in other builds.  There we can clean it up.

## How was this tested?

On the machine 'vortex' I ran this build with:

```
$ cd /vscratch1/rabartl/Trilinos.base/BUILDS/VORTEX/CTEST_S/

$ ./ctest-s-local-test-driver.sh \
  ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_complex_static_opt

***
*** ./ctest-s-local-test-driver.sh
***

ATDM_TRILINOS_DIR = '/home/rabartl/Trilinos.base/Trilinos'

Load some env to get python, cmake, etc ...

Hostname 'vortex60' matches known ATDM host 'vortex60' and system 'ats2'
Setting compiler and build options for build-name 'default'
Using ats2 compiler stack GNU-7.3.1_SPMPI-ROLLING to build DEBUG code with Kokkos node type SERIAL

Due to MODULEPATH changes, the following have been reloaded:
  1) spectrum-mpi/rolling-release


Running builds:
    ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_complex_static_opt

Thu May 28 19:35:28 MDT 2020

Running Jenkins driver Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_complex_static_opt.sh ...

    Creating directory: Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_complex_static_opt

    Creating directory: SRC_AND_BUILD

    See log file Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_complex_static_opt/smart-jenkins-driver.out

real    160m44.942s
user    715m54.956s
sys     87m36.354s

99% tests passed, 6 tests failed out of 1112
99% tests passed, 6 tests failed out of 1112

Thu May 28 22:16:13 MDT 2020

Done running all of the builds!
```

That posted to CDash:

* https://testing-dev.sandia.gov/cdash/index.php?project=Trilinos&begin=2020-05-28&end=2020-05-29&filtercount=2&showfilters=1&filtercombine=and&field1=buildname&compare1=65&value1=Trilinos-atdm-ats2&field2=buildname&compare2=63&value2=-exp

showing:

| Site | Build Name | C Err | C Warn | C Time | B Err | B Warn | B Time | Not Run | Fail | Pass | Time | Proc Time | Start Time | Labels |
| -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- |
vortex | Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_complex_static_opt_cuda-aware-mpi-exp | 0 | 5 | 1m 54s | 0 | 0 | 51s | 0 | 6 | 1106 | 26m 45s | 1h 45m 47s | 8 hours ago | (13 labels)
vortex | Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_complex_static_opt-exp | 0 | 5 | 1m 52s | 0 | 50 | 1h 42m 36s | 0 | 6 | 1106 | 25m 46s | 1h 38m 12s | 11 hours ago | (13 labels)

The failing tests are shown here:

* https://testing-dev.sandia.gov/cdash/queryTests.php?project=Trilinos&begin=2020-05-28&end=2020-05-29&filtercount=9&showfilters=1&filtercombine=and&field1=buildname&compare1=65&value1=Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_complex_static_opt&field2=buildname&compare2=63&value2=-exp&field3=status&compare3=62&value3=passed&field4=testoutput&compare4=94&value4=Error%20initializing%20RM%20connection.%20Exiting&field5=testoutput&compare5=94&value5=OPAL%20ERROR%3A%20Unreachable&field6=testoutput&compare6=96&value6=srun%3A%20error%3A%20s_p_parse_file%3A%20unable%20to%20read%20.%2Fetc%2Fslurm%2Fslurm.conf.%3A%20Permission%20denied&field7=testoutput&compare7=96&value7=cudaGetDeviceCount.*cudaErrorUnknown.*unknown%20error.*Kokkos_Cuda_Instance.cpp&field8=testoutput&compare8=96&value8=cudaMallocManaged.*cudaErrorUnknown.*unknown%20error.*Sacado_DynamicArrayTraits.hpp&field9=testoutput&compare9=94&value9=jsrun%20return%20value%3A%20255

and show the failing tests:

Site | Build Name | Test Name | Status | Time | Proc Time | Details | Build Time | Processors
-- | -- | -- | -- | -- | -- | -- | -- | --
vortex | Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_complex_static_opt-exp | Adelus_vector_random_MPI_1 | Failed | 1m 2s 550ms | 1m 2s 550ms | Completed (Failed) | 2020-05-28T19:35:39 MDT | 1
vortex | Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_complex_static_opt_cuda-aware-mpi-exp | Adelus_vector_random_MPI_1 | Failed | 1m 2s 980ms | 1m 2s 980ms | Completed (Failed) | 2020-05-28T21:46:23 MDT | 1
vortex | Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_complex_static_opt-exp | Adelus_vector_random_MPI_2 | Failed | 1m 1s 870ms | 2m 3s 740ms | Completed (Failed) | 2020-05-28T19:35:39 MDT | 2
vortex | Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_complex_static_opt-exp | Adelus_vector_random_MPI_3 | Failed | 1m 2s 210ms | 3m 6s 630ms | Completed (Failed) | 2020-05-28T19:35:39 MDT | 3
vortex | Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_complex_static_opt-exp | Adelus_vector_random_MPI_4 | Failed | 1m 2s 540ms | 4m 10s 160ms | Completed (Failed) | 2020-05-28T19:35:39 MDT | 4
vortex | Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_complex_static_opt_cuda-aware-mpi-exp | Belos_Tpetra_MVOPTester_complex_test_MPI_4 | Failed | 2s 740ms | 10s 960ms | Completed (Failed) | 2020-05-28T21:46:23 MDT | 4
vortex | Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_complex_static_opt-exp | KokkosCore_UnitTest_CudaInterOpInit_MPI_1 | Failed | 1s 750ms | 1s 750ms | Completed (Failed) | 2020-05-28T19:35:39 MDT | 1
vortex | Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_complex_static_opt-exp | KokkosCore_UnitTest_CudaInterOpStreams_MPI_1 | Failed | 1s 100ms | 1s 100ms | Completed (Failed) | 2020-05-28T19:35:39 MDT | 1
vortex | Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_complex_static_opt_cuda-aware-mpi-exp | KokkosCore_UnitTest_CudaInterOpStreams_MPI_1 | Failed | 1s 560ms | 1s 560ms | Completed (Failed) | 2020-05-28T21:46:23 MDT | 1
vortex | Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_complex_static_opt_cuda-aware-mpi-exp | TpetraCore_CrsMatrix_UnitTests3_MPI_4 | Failed | 2s 60ms | 8s 240ms | Completed (Failed) | 2020-05-28T21:46:23 MDT | 4
vortex | Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_complex_static_opt_cuda-aware-mpi-exp | TpetraCore_MultiVector_UnitTests_MPI_4 | Failed | 2s 630ms | 10s 520ms | Completed (Failed) | 2020-05-28T21:46:23 MDT | 4
vortex | Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_complex_static_opt_cuda-aware-mpi-exp | TpetraCore_MV_reduce_strided_MPI_4 | Failed | 2s 20ms | 8s 80ms | Completed (Failed) | 2020-05-28T21:46:23 MDT | 4

We already know about the failing Adelus and KokkosCore tests (they need to have GitHub issues created for them).  But the failing tests that are new occur in the CUDA-aware running of the tests are:

* Belos_Tpetra_MVOPTester_complex_test_MPI_4
* TpetraCore_CrsMatrix_UnitTests3_MPI_4
* TpetraCore_MultiVector_UnitTests_MPI_4
* TpetraCore_MV_reduce_strided_MPI_4

so it looks like there are some problems.  Therefore, this build will be elevated to a 'Specialized' build only.
