### PR TITLE
Tpetra: remove fence in add()

### DIFF
--- a/packages/kokkos-kernels/src/common/KokkosKernels_SparseUtils.hpp
+++ b/packages/kokkos-kernels/src/common/KokkosKernels_SparseUtils.hpp
@@ -989,7 +989,9 @@ void sort_crs_matrix(const rowmap_t& rowmap, const entries_t& entries, const val
     //TODO (probably important for performnce): add thread-level sort also, and use that
     //for small avg degree. But this works for now.
     int teamSize = 1;
-    lno_t avgDeg = (entries.extent(0) + numRows - 1) / numRows;
+    lno_t avgDeg = 0;
+    if(numRows)
+      avgDeg = (entries.extent(0) + numRows - 1) / numRows;
     while(teamSize * 2 * 2 <= avgDeg)
     {
       teamSize *= 2;
@@ -1041,7 +1043,9 @@ void sort_crs_graph(const rowmap_t& rowmap, const entries_t& entries)
     //TODO (probably important for performnce): add thread-level sort also, and use that
     //for small avg degree. But this works for now.
     int teamSize = 1;
-    lno_t avgDeg = (entries.extent(0) + numRows - 1) / numRows;
+    lno_t avgDeg = 0;
+    if(numRows)
+      avgDeg = (entries.extent(0) + numRows - 1) / numRows;
     while(teamSize * 2 * 2 <= avgDeg)
     {
       teamSize *= 2;

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_Cuda.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_Cuda.hpp
@@ -653,7 +653,7 @@ void KernelWrappers2<Scalar,LocalOrdinal,GlobalOrdinal,Kokkos::Compat::KokkosCud
     Teuchos::Array<Scalar> diagonal(diagLength);
     diags.get1dCopy(diagonal());
 
-    for(LocalOrdinal i = 0; i < diagLength; ++i) {
+    for(size_t i = 0; i < diagLength; ++i) {
       TEUCHOS_TEST_FOR_EXCEPTION(diagonal[i] == Teuchos::ScalarTraits<Scalar>::zero(), 
 				 std::runtime_error, 
 				 "Matrix A has a zero/missing diagonal: " << diagonal[i] << std::endl <<

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
@@ -813,10 +813,7 @@ add (const Scalar& alpha,
                               col_inds_array, global_col_inds_array,
                               typename map_type::local_map_type>
         (localColinds, globalColinds, CcolMap->getLocalMap()));
-    //TODO: use KokkosKernels batched sort on device as soon as it's available
-    //But now, have to sort on host (using UVM)
-    exec_space().fence();
-    Tpetra::Import_Util::sortCrsEntries(rowptrs, localColinds, vals);
+    KokkosKernels::Impl::sort_crs_matrix<exec_space, row_ptrs_array, col_inds_array, values_array>(rowptrs, localColinds, vals);
     C.setAllValues(rowptrs, localColinds, vals);
     C.fillComplete(CDomainMap, CRangeMap, params);
     if(!doFillComplete)


### PR DESCRIPTION
Remove fence, by moving the CRS row sorting to device.
This should also grant a big speedup, but I didn't measure it.
Fix bug in kokkos-kernels causing divide-by-zero in row sorting
(will copy fix to kokkos-kernels repo).

Fix sign compare warning in MatrixMatrix_Cuda.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Removes one of the Kokkos execution space fences in TpetraExt_MatrixMatrix_def.hpp. One step towards #7446 .
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
-->
## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of #7446 
* Composed of 



## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
Part of @MicheldeMessieres 's work to eliminate need for CUDA_LAUNCH_BLOCKING and also to remove unnecessary fences.
## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
- ran all Tpetra tests with launch blocking on
- ran just the MatrixMatrix unit tests with launch blocking off

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->