### PR TITLE
Fix bicgstab's reinitialization after convergence of a single vector

### DIFF
--- a/packages/belos/src/BelosBiCGStabIter.hpp
+++ b/packages/belos/src/BelosBiCGStabIter.hpp
@@ -380,7 +380,7 @@ namespace Belos {
       }
       else {
         // Set to be the initial residual
-        MVT::Assign(*lp_->getInitResVec(), *Rhat_);
+        MVT::Assign(*R_, *Rhat_);
       }
 
       // Set V


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/belos

## Motivation
Fixes #7462

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
The BiCGStab classes are tested, but not with multiple right hand sides.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->