### PR TITLE
MueLu: region matvec, see issue #7175

### DIFF
--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
@@ -135,7 +135,11 @@ void MakeCoarseLevelMaps(const int maxRegPerGID,
                          Array<std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > >& quasiRegRowMaps,
                          Array<std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > >& quasiRegColMaps,
                          Array<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& compRowMaps,
-                         Array<std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > >& regRowImporters) {
+                         Array<std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > >& regRowImporters,
+                         Array<Teuchos::RCP<Xpetra::MultiVector<GlobalOrdinal, LocalOrdinal, GlobalOrdinal, Node> > >& interfaceGIDs,
+                         Array<Teuchos::RCP<Xpetra::MultiVector<LocalOrdinal, LocalOrdinal, GlobalOrdinal, Node> > >& regionsPerGIDWithGhosts,
+                         Array<Teuchos::Array<LocalOrdinal> >& regionMatVecLIDs,
+                         Array<Teuchos::RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > >& regionInterfaceImporter) {
 
 #include "Xpetra_UseShortNames.hpp"
 
@@ -143,6 +147,10 @@ void MakeCoarseLevelMaps(const int maxRegPerGID,
 
   const GO GO_INV = Teuchos::OrdinalTraits<GO>::invalid();
   const int numLevels = regProlong.size();
+
+  // RCP<Teuchos::FancyOStream> fancy = Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
+  // Teuchos::FancyOStream& out = *fancy;
+  const int myRank = regProlong[1][0]->getRowMap()->getComm()->getRank();
 
   Teuchos::Array<LO> coarseCompositeToRegionLIDs;
   Teuchos::ArrayView<LO> compositeToRegionLIDs = compositeToRegionLIDsFinest;
@@ -196,6 +204,62 @@ void MakeCoarseLevelMaps(const int maxRegPerGID,
                         regRowMaps[currentLevel - 1],
                         regRowImporters[currentLevel - 1]);
 
+    regionsPerGIDWithGhosts[currentLevel] =
+      Xpetra::MultiVectorFactory<LO, LO, GO, NO>::Build(regRowMaps[currentLevel][0],
+                                                        maxRegPerGID,
+                                                        false);
+    interfaceGIDs[currentLevel] =
+      Xpetra::MultiVectorFactory<GO, LO, GO, NO>::Build(regRowMaps[currentLevel][0],
+                                                        maxRegPerGID,
+                                                        false);
+    Array<ArrayRCP<const LO> > regionsPerGIDWithGhostsFine(maxRegPerGID);
+    Array<ArrayRCP<LO> > regionsPerGIDWithGhostsCoarse(maxRegPerGID);
+    Array<ArrayRCP<GO> > interfaceGIDsCoarse(maxRegPerGID);
+    for(size_t idx = 0; idx < static_cast<size_t>(maxRegPerGID); ++idx) {
+      regionsPerGIDWithGhostsFine[idx]   = regionsPerGIDWithGhosts[currentLevel - 1]->getData(idx);
+      regionsPerGIDWithGhostsCoarse[idx] = regionsPerGIDWithGhosts[currentLevel]->getDataNonConst(idx);
+      interfaceGIDsCoarse[idx]          = interfaceGIDs[currentLevel]->getDataNonConst(idx);
+      for(size_t coarseIdx = 0;
+          coarseIdx < regionsPerGIDWithGhosts[currentLevel]->getLocalLength(); ++coarseIdx) {
+        regionsPerGIDWithGhostsCoarse[idx][coarseIdx] = -1;
+        interfaceGIDsCoarse[idx][coarseIdx] = 0;
+      }
+    }
+
+    for(size_t fineIdx = 0; fineIdx < numFineRegionNodes; ++fineIdx) {
+      ArrayView<const LO> coarseRegionLID; // Should contain a single value
+      ArrayView<const SC> dummyData;       // Should contain a single value
+      regProlong[currentLevel][0]->getLocalRowView(fineIdx,
+                                                   coarseRegionLID,
+                                                   dummyData);
+      const LO coarseIdx = coarseRegionLID[0];
+
+      // Now fill regionPerGIDWithGhostsCoarse[:][coarseRegionLID]
+      // with data from regionPerGIDWithGhostsFine[:][fineIdx].
+      // The problem is we might have more then maxRegPerGID on currentLevel
+      // then on currentLevel-1... we might need to do a union or something?
+      // I guess technically using the restriction operator here would be more
+      // helpful than the prolongator, this way we could find all the fine interface
+      // points easily and compute the union of the PIDs they belong too.
+      // This can actually be done extracting the local matrix and compute the transpose.
+      // For now let us assume that maxRegPerGID is constant and hope for the best.
+      LO countFinePIDs   = 0;
+      LO countCoarsePIDs = 0;
+      for(LO idx = 0; idx < maxRegPerGID; ++idx) {
+        if(-1 < regionsPerGIDWithGhostsFine[idx][fineIdx]) {++countFinePIDs;}
+        if(-1 < regionsPerGIDWithGhostsCoarse[idx][coarseIdx]) {++countCoarsePIDs;}
+      }
+
+      if(countCoarsePIDs < countFinePIDs) {
+        for(LO idx = 0; idx < countFinePIDs; ++idx) {
+          regionsPerGIDWithGhostsCoarse[idx][coarseIdx] = regionsPerGIDWithGhostsFine[idx][fineIdx];
+          if(regionsPerGIDWithGhostsCoarse[idx][coarseIdx] == myRank) {
+            interfaceGIDsCoarse[idx][coarseIdx] = regRowMaps[currentLevel][0]->getGlobalElement(coarseIdx);
+          }
+        }
+      }
+    }
+
     Array<GO> fineRegionDuplicateCoarseLIDs(numFineDuplicateNodes);
     Array<GO> fineRegionDuplicateCoarseGIDs(numFineDuplicateNodes);
     for(size_t duplicateIdx = 0; duplicateIdx < numFineDuplicateNodes; ++duplicateIdx) {
@@ -247,9 +311,14 @@ void MakeCoarseLevelMaps(const int maxRegPerGID,
                                                   regProlong[currentLevel][0]->getColMap()->getComm());
     regRowImporters[currentLevel][0] = ImportFactory::Build(compRowMaps[currentLevel], quasiRegRowMaps[currentLevel][0]);
 
+    // Now generate matvec data
+    SetupMatVec(interfaceGIDs[currentLevel], regionsPerGIDWithGhosts[currentLevel],
+                regRowMaps[currentLevel], regRowImporters[currentLevel],
+                regionMatVecLIDs[currentLevel], regionInterfaceImporter[currentLevel]);
+
     // Finally reset compositeToRegionLIDs
     compositeToRegionLIDs = coarseCompositeToRegionLIDs();
-  }
+  } // Loop over numLevels
 } // MakeCoarseLevelMaps
 
 
@@ -583,6 +652,10 @@ void createRegionHierarchy(const int maxRegPerProc,
                            Array<std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > >& regProlong,
                            Array<std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > >& regRowImporters,
                            Array<Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > >& regInterfaceScalings,
+                           Array<Teuchos::RCP<Xpetra::MultiVector<GlobalOrdinal, LocalOrdinal, GlobalOrdinal, Node> > >& interfaceGIDs,
+                           Array<Teuchos::RCP<Xpetra::MultiVector<LocalOrdinal, LocalOrdinal, GlobalOrdinal, Node> > >& regionsPerGIDWithGhosts,
+                           Array<Teuchos::Array<LocalOrdinal> >& regionMatVecLIDs,
+                           Array<Teuchos::RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > >& regionInterfaceImporter,
                            const int maxRegPerGID,
                            ArrayView<LocalOrdinal> compositeToRegionLIDs,
                            RCP<Teuchos::ParameterList>& coarseSolverData,
@@ -657,6 +730,10 @@ void createRegionHierarchy(const int maxRegPerProc,
     regProlong.resize(numLevels);
     regRowImporters.resize(numLevels);
     regInterfaceScalings.resize(numLevels);
+    interfaceGIDs.resize(numLevels);
+    regionsPerGIDWithGhosts.resize(numLevels);
+    regionMatVecLIDs.resize(numLevels);
+    regionInterfaceImporter.resize(numLevels);
     smootherParams.resize(numLevels);
 
     // resize group containers on each level
@@ -743,7 +820,11 @@ void createRegionHierarchy(const int maxRegPerProc,
                       quasiRegRowMaps,
                       quasiRegColMaps,
                       compRowMaps,
-                      regRowImporters);
+                      regRowImporters,
+                      interfaceGIDs,
+                      regionsPerGIDWithGhosts,
+                      regionMatVecLIDs,
+                      regionInterfaceImporter);
 
   // std::cout << mapComp->getComm()->getRank() << " | MakeInterfaceScalingFactors ..." << std::endl;
 
@@ -851,6 +932,8 @@ void createRegionHierarchy(const int maxRegPerProc,
                            Array<std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > >& regProlong,
                            Array<std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > >& regRowImporters,
                            Array<Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > >& regInterfaceScalings,
+                           Array<Teuchos::RCP<Xpetra::MultiVector<GlobalOrdinal, LocalOrdinal, GlobalOrdinal, Node> > >& interfaceGIDsMV,
+                           Array<Teuchos::RCP<Xpetra::MultiVector<LocalOrdinal, LocalOrdinal, GlobalOrdinal, Node> > >& regionsPerGIDWithGhosts,
                            Array<RCP<Teuchos::ParameterList> >& smootherParams
                            )
 {
@@ -922,14 +1005,19 @@ void vCycle(const int l, ///< ID of current level
     tm = Teuchos::null;
     tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("vCycle: 2 - compute residual")));
 
+    const bool useFastMatVec = smootherParams[l]->get<bool>("Use fast MatVec");
+
     Array<RCP<Vector> > regRes(maxRegPerProc);
     if(useCachedVectors) {
       regRes = levelList.get<Teuchos::Array<RCP<Vector> > >("residual");
     } else {
       createRegionalVector(regRes, regRowMaps[l]);
     }
-    computeResidual(regRes, fineRegX, fineRegB, regMatrices[l],
-                    regRowMaps[l], regRowImporters[l]);
+    if (useFastMatVec)
+      computeResidual(regRes, fineRegX, fineRegB, regMatrices[l], *smootherParams[l]);
+    else
+      computeResidual(regRes, fineRegX, fineRegB, regMatrices[l],
+                      regRowMaps[l], regRowImporters[l]);
 
     tm = Teuchos::null;
     tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("vCycle: 3 - scale interface")));
@@ -957,7 +1045,7 @@ void vCycle(const int l, ///< ID of current level
     sumInterfaceValues(coarseRegB, regRowMaps[l+1], regRowImporters[l+1]);
 
     tm = Teuchos::null;
-    bool coarseZeroInitGuess = true; 
+    bool coarseZeroInitGuess = true;
 
     // Call V-cycle recursively
     vCycle(l+1, numLevels,

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionMatrix_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionMatrix_def.hpp
@@ -827,7 +827,7 @@ void SetupMatVec(const Teuchos::RCP<Xpetra::MultiVector<GlobalOrdinal, LocalOrdi
  *  2. Sum interface values of y to account for duplication of interface DOFs.
  */
 template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-void MatVec(const Scalar alpha,
+void ApplyMatVec(const Scalar alpha,
             const RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& regionMatrix,
             const RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& X,
             const Scalar beta,
@@ -836,7 +836,7 @@ void MatVec(const Scalar alpha,
             RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& Y) {
 #include "Xpetra_UseShortNames.hpp"
   using Teuchos::TimeMonitor;
-  RCP<TimeMonitor> tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("MatVec: 1 - local apply")));
+  RCP<TimeMonitor> tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("ApplyMatVec: 1 - local apply")));
   RCP<const Map> regionInterfaceMap = regionInterfaceImporter->getTargetMap();
 
   // Step 1: apply the local operator
@@ -844,7 +844,7 @@ void MatVec(const Scalar alpha,
   regionMatrix->apply(*X, *Y, Teuchos::NO_TRANS, alpha, beta);
 
   tm = Teuchos::null;
-  tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("MatVec: 2 - communicate data")));
+  tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("ApplyMatVec: 2 - communicate data")));
 
   // Step 2: preform communication to propagate local interface
   // values to all the processor that share interfaces.
@@ -852,7 +852,7 @@ void MatVec(const Scalar alpha,
   matvecInterfaceTmp->doImport(*Y, *regionInterfaceImporter, Xpetra::INSERT);
 
   tm = Teuchos::null;
-  tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("MatVec: 3 - sum interface contributions")));
+  tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("ApplyMatVec: 3 - sum interface contributions")));
 
   // Step 3: sum all contributions to interface values
   // on all ranks
@@ -863,7 +863,7 @@ void MatVec(const Scalar alpha,
   }
 
   tm = Teuchos::null;
-} // MatVec
+} // ApplyMatVec
 
 /*! \brief Compute the residual \f$r = b - Ax\f$ with pre-computed communication patterns
  *
@@ -894,7 +894,7 @@ computeResidual(Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, No
 
   // Step 1: Compute region version of y = Ax
   RCP<Vector> aTimesX = VectorFactory::Build(regionGrpMats[0]->getRangeMap(), true);
-  MatVec(TST::one(), regionGrpMats[0], regX[0],
+  ApplyMatVec(TST::one(), regionGrpMats[0], regX[0],
       TST::zero(), regionInterfaceImporter, regionInterfaceLIDs, aTimesX);
 
   // Step 2: Compute region version of r = b - y

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionSmoothers_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionSmoothers_def.hpp
@@ -152,6 +152,7 @@ void jacobiIterate(RCP<Teuchos::ParameterList> smootherParams,
   const int maxIter    = smootherParams->get<int>   ("smoother: sweeps");
   const double damping = smootherParams->get<double>("smoother: damping");
   Array<RCP<Vector> > diag_inv = smootherParams->get<Array<RCP<Vector> > >("smoothers: inverse diagonal");
+  const bool useFastMatVec = smootherParams->get<bool>("Use fast MatVec");
 
   Array<RCP<Vector> > regRes(maxRegPerProc);
   createRegionalVector(regRes, revisedRowMapPerGrp);
@@ -159,18 +160,17 @@ void jacobiIterate(RCP<Teuchos::ParameterList> smootherParams,
 
   for (int iter = 0; iter < maxIter; ++iter) {
 
-    /* Update the residual vector
-     * 1. Compute tmp = A * regX in each region
-     * 2. Sum interface values in tmp due to duplication (We fake this by scaling to reverse the basic splitting)
-     * 3. Compute r = B - tmp
-     */
+    // Update the residual vector
     if (zeroInitGuess) {
       for (int j = 0; j < maxRegPerProc; j++) {
         regX[j]->elementWiseMultiply(damping, *diag_inv[j], *regB[j], SC_ONE);
       }
     }
     else {
-      computeResidual(regRes, regX, regB, regionGrpMats, revisedRowMapPerGrp, rowImportPerGrp );
+      if (useFastMatVec)
+        computeResidual(regRes, regX, regB, regionGrpMats, *smootherParams);
+      else
+        computeResidual(regRes, regX, regB, regionGrpMats, revisedRowMapPerGrp, rowImportPerGrp);
 
       // update solution according to Jacobi's method
       for (int j = 0; j < maxRegPerProc; j++) {
@@ -210,6 +210,7 @@ void GSIterate(RCP<Teuchos::ParameterList> smootherParams,
   const int maxIter = smootherParams->get<int>("smoother: sweeps");
   const double damping = smootherParams->get<double>("smoother: damping");
   Teuchos::Array<RCP<Vector> > diag_inv = smootherParams->get<Teuchos::Array<RCP<Vector> > >("smoothers: inverse diagonal");
+  const bool useFastMatVec = smootherParams->get<bool>("Use fast MatVec");
 
   Array<RCP<Vector> > regRes(maxRegPerProc);
   createRegionalVector(regRes, revisedRowMapPerGrp);
@@ -219,12 +220,14 @@ void GSIterate(RCP<Teuchos::ParameterList> smootherParams,
   // GS iteration loop
   for (int iter = 0; iter < maxIter; ++iter) {
 
-    /* Update the residual vector
-     * 1. Compute tmp = A * regX in each region
-     * 2. Sum interface values in tmp due to duplication (We fake this by scaling to reverse the basic splitting)
-     * 3. Compute r = B - tmp
-     */
-    if (!zeroInitGuess) computeResidual(regRes, regX, regB, regionGrpMats, revisedRowMapPerGrp, rowImportPerGrp );
+    // Update the residual vector
+    if (!zeroInitGuess)
+    {
+      if (useFastMatVec)
+        computeResidual(regRes, regX, regB, regionGrpMats, *smootherParams);
+      else
+        computeResidual(regRes, regX, regB, regionGrpMats, revisedRowMapPerGrp, rowImportPerGrp);
+    }
 
     // update the solution and the residual
 
@@ -417,6 +420,7 @@ void chebyshevIterate(RCP<Teuchos::ParameterList> smootherParams,
   const Scalar lambdaMax = smootherParams->get<Scalar>("chebyshev: lambda max");
   const Scalar boostFactor = smootherParams->get<double>("smoother: Chebyshev boost factor");
   Teuchos::Array<RCP<Vector> > diag_inv = smootherParams->get<Teuchos::Array<RCP<Vector> > >("smoothers: inverse diagonal");
+  const bool useFastMatVec = smootherParams->get<bool>("Use fast MatVec");
 
   // Define some constants for convenience
   const Scalar SC_ZERO = Teuchos::ScalarTraits<Scalar>::zero();
@@ -455,7 +459,10 @@ void chebyshevIterate(RCP<Teuchos::ParameterList> smootherParams,
     }
   }
   else { // Compute residual vector
-    computeResidual(regRes, regX, regB, regionGrpMats, revisedRowMapPerGrp, rowImportPerGrp );
+    if (useFastMatVec)
+      computeResidual(regRes, regX, regB, regionGrpMats, *smootherParams);
+    else
+      computeResidual(regRes, regX, regB, regionGrpMats, revisedRowMapPerGrp, rowImportPerGrp);
     for(int j = 0; j < maxRegPerProc; j++) {
       regZ[j]->elementWiseMultiply(SC_ONE, *diag_inv[j], *regRes[j], SC_ZERO); // z = D_inv * R, that is, D \ R.
       regP[j]->update(SC_ONE/theta, *regZ[j], SC_ZERO); // P = 1/theta Z
@@ -466,7 +473,10 @@ void chebyshevIterate(RCP<Teuchos::ParameterList> smootherParams,
   // The rest of the iterations
   for (int i = 1; i < maxIter; ++i) {
     // Compute residual vector
-    computeResidual(regRes, regX, regB, regionGrpMats, revisedRowMapPerGrp, rowImportPerGrp );
+    if (useFastMatVec)
+      computeResidual(regRes, regX, regB, regionGrpMats, *smootherParams);
+    else
+      computeResidual(regRes, regX, regB, regionGrpMats, revisedRowMapPerGrp, rowImportPerGrp);
     // z = D_inv * R, that is, D \ R.
     for(int j = 0; j < maxRegPerProc; j++) {
       regZ[j]->elementWiseMultiply(SC_ONE, *diag_inv[j], *regRes[j], SC_ZERO);

--- a/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
+++ b/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
@@ -443,12 +443,15 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
   Array<LO>  compositeToRegionLIDs(nodeMap->getNodeNumElements()*numDofsPerNode);
   Array<GO>  quasiRegionGIDs;
   Array<GO>  quasiRegionCoordGIDs;
+  Array<GO>  interfaceGIDs;
+  Array<LO>  interfaceLIDsData;
 
   createRegionData(numDimensions, useUnstructured, numDofsPerNode,
                    gNodesPerDim(), lNodesPerDim(), procsPerDim(), nodeMap, dofMap,
                    maxRegPerGID, numLocalRegionNodes, boundaryConditions,
                    sendGIDs, sendPIDs, numInterfaces, rNodesPerDim,
-                   quasiRegionGIDs, quasiRegionCoordGIDs, compositeToRegionLIDs);
+                   quasiRegionGIDs, quasiRegionCoordGIDs, compositeToRegionLIDs,
+                   interfaceGIDs, interfaceLIDsData);
 
   const LO numSend = static_cast<LO>(sendGIDs.size());
 

--- a/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
+++ b/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
@@ -452,12 +452,12 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
 
   const LO numSend = static_cast<LO>(sendGIDs.size());
 
-  // std::cout << "p=" << myRank << " | numReceive=" << numReceive
-  //           << ", numSend=" << numSend << std::endl;
+  std::cout << "p=" << myRank << " | numSend=" << numSend << std::endl;
+            // << ", numReceive=" << numReceive << std::endl;
   // std::cout << "p=" << myRank << " | receiveGIDs: " << receiveGIDs << std::endl;
   // std::cout << "p=" << myRank << " | receivePIDs: " << receivePIDs << std::endl;
-  // std::cout << "p=" << myRank << " | sendGIDs: " << sendGIDs << std::endl;
-  // std::cout << "p=" << myRank << " | sendPIDs: " << sendPIDs << std::endl;
+  std::cout << "p=" << myRank << " | sendGIDs: " << sendGIDs << std::endl;
+  std::cout << "p=" << myRank << " | sendPIDs: " << sendPIDs << std::endl;
 
   // Second we actually fill the send and receive arrays with appropriate data
   // which will allow us to compute the region and composite maps.
@@ -466,25 +466,25 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
   if(useUnstructured) {
     findInterface(numDimensions, rNodesPerDim, boundaryConditions,
                   interfacesDimensions, interfacesLIDs);
+
+    // std::cout << "p=" << myRank << " | numLocalRegionNodes=" << numLocalRegionNodes
+    //           << ", rNodesPerDim: " << rNodesPerDim << std::endl;
+    // std::cout << "p=" << myRank << " | boundaryConditions: " << boundaryConditions << std::endl
+    //           << "p=" << myRank << " | rNodesPerDim: " << rNodesPerDim << std::endl
+    //           << "p=" << myRank << " | interfacesDimensions: " << interfacesDimensions << std::endl
+    //           << "p=" << myRank << " | interfacesLIDs: " << interfacesLIDs << std::endl;
   }
 
   interfaceParams->set<int>       ("interfaces: number",               numInterfaces);
   interfaceParams->set<Array<LO> >("interfaces: nodes per dimensions", interfacesDimensions); // nodesPerDimensions);
   interfaceParams->set<Array<LO> >("interfaces: interface nodes",      interfacesLIDs); // interfaceLIDs);
 
-  // std::cout << "p=" << myRank << " | numLocalRegionNodes=" << numLocalRegionNodes
-  //           << ", rNodesPerDim: " << rNodesPerDim << std::endl;
-  // std::cout << "p=" << myRank << " | boundaryConditions: " << boundaryConditions << std::endl
-  //           << "p=" << myRank << " | rNodesPerDim: " << rNodesPerDim << std::endl
-  //           << "p=" << myRank << " | interfacesDimensions: " << interfacesDimensions << std::endl
-  //           << "p=" << myRank << " | interfacesLIDs: " << interfacesLIDs << std::endl;
-
-  // std::cout << "p=" << myRank << " | receiveLIDs: " << receiveLIDs() << std::endl;
-  // std::cout << "p=" << myRank << " | sendLIDs: " << sendLIDs() << std::endl;
-  // std::cout << "p=" << myRank << " | compositeToRegionLIDs: " << compositeToRegionLIDs() << std::endl;
-  // std::cout << "p=" << myRank << " | quasiRegionGIDs: " << quasiRegionGIDs << std::endl;
+  std::cout << "p=" << myRank << " | compositeToRegionLIDs: " << compositeToRegionLIDs() << std::endl;
+  std::cout << "p=" << myRank << " | quasiRegionGIDs: " << quasiRegionGIDs << std::endl;
   // std::cout << "p=" << myRank << " | interfaceLIDs: " << interfaceLIDs() << std::endl;
   // std::cout << "p=" << myRank << " | quasiRegionCoordGIDs: " << quasiRegionCoordGIDs() << std::endl;
+
+  return 0;
 
   // In our very particular case we know that a node is at most shared by 4 (8) regions in 2D (3D) problems.
   // Other geometries will certainly have different constrains and a parallel reduction using MAX

--- a/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
+++ b/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
@@ -188,6 +188,8 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
 #endif
   int  cacheSize = 0;                                      clp.setOption("cachesize",               &cacheSize,           "cache size (in KB)");
   bool useStackedTimer   = false;                          clp.setOption("stacked-timer","no-stacked-timer", &useStackedTimer, "use stacked timer");
+  bool showTimerSummary = true;                            clp.setOption("show-timer-summary", "no-show-timer-summary", &showTimerSummary, "Switch on/off the timer summary at the end of the run.");
+  bool useFastMatVec = true;                               clp.setOption("fastMV", "no-fastMV", &useFastMatVec, "Use the fast MatVec implementation (or not)");
 
   clp.recogniseAllOptions(true);
   switch (clp.parse(argc, argv)) {
@@ -455,12 +457,12 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
 
   const LO numSend = static_cast<LO>(sendGIDs.size());
 
-  std::cout << "p=" << myRank << " | numSend=" << numSend << std::endl;
+  // std::cout << "p=" << myRank << " | numSend=" << numSend << std::endl;
             // << ", numReceive=" << numReceive << std::endl;
   // std::cout << "p=" << myRank << " | receiveGIDs: " << receiveGIDs << std::endl;
   // std::cout << "p=" << myRank << " | receivePIDs: " << receivePIDs << std::endl;
-  std::cout << "p=" << myRank << " | sendGIDs: " << sendGIDs << std::endl;
-  std::cout << "p=" << myRank << " | sendPIDs: " << sendPIDs << std::endl;
+  // std::cout << "p=" << myRank << " | sendGIDs: " << sendGIDs << std::endl;
+  // std::cout << "p=" << myRank << " | sendPIDs: " << sendPIDs << std::endl;
 
   // Second we actually fill the send and receive arrays with appropriate data
   // which will allow us to compute the region and composite maps.
@@ -482,12 +484,10 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
   interfaceParams->set<Array<LO> >("interfaces: nodes per dimensions", interfacesDimensions); // nodesPerDimensions);
   interfaceParams->set<Array<LO> >("interfaces: interface nodes",      interfacesLIDs); // interfaceLIDs);
 
-  std::cout << "p=" << myRank << " | compositeToRegionLIDs: " << compositeToRegionLIDs() << std::endl;
-  std::cout << "p=" << myRank << " | quasiRegionGIDs: " << quasiRegionGIDs << std::endl;
+  // std::cout << "p=" << myRank << " | compositeToRegionLIDs: " << compositeToRegionLIDs() << std::endl;
+  // std::cout << "p=" << myRank << " | quasiRegionGIDs: " << quasiRegionGIDs << std::endl;
   // std::cout << "p=" << myRank << " | interfaceLIDs: " << interfaceLIDs() << std::endl;
   // std::cout << "p=" << myRank << " | quasiRegionCoordGIDs: " << quasiRegionCoordGIDs() << std::endl;
-
-  return 0;
 
   // In our very particular case we know that a node is at most shared by 4 (8) regions in 2D (3D) problems.
   // Other geometries will certainly have different constrains and a parallel reduction using MAX
@@ -582,10 +582,20 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
   tmLocal = Teuchos::null;
   tmLocal = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("Driver: 3.3 - Import ghost GIDs")));
 
-  RCP<Xpetra::MultiVector<LO, LO, GO, NO> > regionsPerGIDWithGhosts
-    = Xpetra::MultiVectorFactory<LO, LO, GO, NO>::Build(rowMapPerGrp[0], maxRegPerGID, false);
-  RCP<Import> regionsPerGIDImport = ImportFactory::Build(A->getRowMap(), A->getColMap());
-  regionsPerGIDWithGhosts->doImport(*regionsPerGID, *rowImportPerGrp[0], Xpetra::INSERT);
+  Array<GO>  interfaceCompositeGIDs, interfaceRegionGIDs;
+  ExtractListOfInterfaceRegionGIDs(revisedRowMapPerGrp, interfaceLIDsData, interfaceRegionGIDs);
+
+  RCP<Xpetra::MultiVector<LO, LO, GO, NO> > regionsPerGIDWithGhosts;
+  RCP<Xpetra::MultiVector<GO, LO, GO, NO> > interfaceGIDsMV;
+  MakeRegionPerGIDWithGhosts(nodeMap, revisedRowMapPerGrp[0], rowImportPerGrp[0],
+                             maxRegPerGID, numDofsPerNode,
+                             lNodesPerDim, sendGIDs, sendPIDs, interfaceLIDsData,
+                             regionsPerGIDWithGhosts, interfaceGIDsMV);
+
+  Teuchos::Array<LO> regionMatVecLIDs;
+  RCP<Import> regionInterfaceImporter;
+  SetupMatVec(interfaceGIDsMV, regionsPerGIDWithGhosts, revisedRowMapPerGrp, rowImportPerGrp,
+              regionMatVecLIDs, regionInterfaceImporter);
 
   comm->barrier();
   tmLocal = Teuchos::null;
@@ -655,6 +665,14 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
   Array<std::vector<RCP<Matrix> > > regProlong; // regional prolongators on each level
   Array<std::vector<RCP<Import> > > regRowImporters; // regional row importers on each level
   Array<Array<RCP<Vector> > > regInterfaceScalings; // regional interface scaling factors on each level
+  Array<RCP<Xpetra::MultiVector<GO, LO, GO, Node> > > interfaceGIDsPerLevel(1);
+  Array<RCP<Xpetra::MultiVector<LO, LO, GO, Node> > > regionsPerGIDWithGhostsPerLevel(1);
+  interfaceGIDsPerLevel[0] = interfaceGIDsMV;
+  regionsPerGIDWithGhostsPerLevel[0] = regionsPerGIDWithGhosts;
+  Array<Array<LO> > regionMatVecLIDsPerLevel(1);
+  Array<RCP<Xpetra::Import<LO, GO, Node> > > regionInterfaceImporterPerLevel(1);
+  regionMatVecLIDsPerLevel[0] = regionMatVecLIDs;
+  regionInterfaceImporterPerLevel[0] = regionInterfaceImporter;
   RCP<ParameterList> coarseSolverData = rcp(new ParameterList());
   coarseSolverData->set<std::string>("coarse solver type", coarseSolverType);
   coarseSolverData->set<std::string>("amg xml file", coarseAmgXmlFile);
@@ -688,6 +706,10 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
                         regProlong,
                         regRowImporters,
                         regInterfaceScalings,
+                        interfaceGIDsPerLevel,
+                        regionsPerGIDWithGhostsPerLevel,
+                        regionMatVecLIDsPerLevel,
+                        regionInterfaceImporterPerLevel,
                         maxRegPerGID,
                         compositeToRegionLIDs(),
                         coarseSolverData,
@@ -701,13 +723,30 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
   comm->barrier();
   tm = Teuchos::null;
 
+  // Extract the number of levels from the prolongator data structure
+  const int numLevels = regProlong.size();
+
+  // Set data for fast MatVec
+  // for (auto levelSmootherParams : smootherParams) {
+  for(LO levelIdx = 0; levelIdx < numLevels; ++levelIdx) {
+    smootherParams[levelIdx]->set("Use fast MatVec", useFastMatVec);
+    smootherParams[levelIdx]->set("Fast MatVec: interface LIDs",
+                                  regionMatVecLIDsPerLevel[levelIdx]);
+    smootherParams[levelIdx]->set("Fast MatVec: interface importer",
+                                  regionInterfaceImporterPerLevel[levelIdx]);
+  }
+
+  // RCP<Teuchos::FancyOStream> fancy2 = Teuchos::fancyOStream(Teuchos::rcpFromRef(std::cout));
+  // Teuchos::FancyOStream& out2 = *fancy2;
+  // for(LO levelIdx = 0; levelIdx < numLevels; ++levelIdx) {
+  //   out2 << "p=" << myRank << " | regionMatVecLIDs on level " << levelIdx << std::endl;
+  //   regionMatVecLIDsPerLevel[levelIdx]->describe(out2, Teuchos::VERB_EXTREME);
+  // }
+
   tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("Driver: 5 - Solve with V-cycle")));
 
   {
 //    std::cout << myRank << " | Running V-cycle ..." << std::endl;
-
-    // Extract the number of levels from the prolongator data structure
-    int numLevels = regProlong.size();
 
     TEUCHOS_TEST_FOR_EXCEPT_MSG(!(numLevels>0), "We require numLevel > 0. Probably, numLevel has not been set, yet.");
 
@@ -719,7 +758,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
      * recursive part of the algorithm.
      */
 
-    // residual vector
+    // Composite residual vector
     RCP<Vector> compRes = VectorFactory::Build(dofMap, true);
     {
       A->apply(*X, *compRes, Teuchos::NO_TRANS);
@@ -795,13 +834,11 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
     }
 
     // Print type of residual norm to the screen
-    if (myRank == 0)
-    {
-      if (scaleResidualHist)
-        std::cout << "Using scaled residual norm." << std::endl;
-      else
-        std::cout << "Using unscaled residual norm." << std::endl;
-    }
+    if (scaleResidualHist)
+      out << "Using scaled residual norm." << std::endl;
+    else
+      out << "Using unscaled residual norm." << std::endl;
+
 
     // Richardson iterations
     magnitude_type normResIni = Teuchos::ScalarTraits<magnitude_type>::zero();
@@ -823,8 +860,15 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
         // SWITCH BACK TO NON-LEVEL VARIABLES
         ////////////////////////////////////////////////////////////////////////
         {
-          computeResidual(regRes, regX, regB, regionGrpMats,
-              revisedRowMapPerGrp, rowImportPerGrp);
+          if (useFastMatVec)
+          {
+            computeResidual(regRes, regX, regB, regionGrpMats, *smootherParams[0]);
+          }
+          else
+          {
+            computeResidual(regRes, regX, regB, regionGrpMats,
+                revisedRowMapPerGrp, rowImportPerGrp);
+          }
 
           scaleInterfaceDOFs(regRes, regInterfaceScalings[0], true);
         }
@@ -839,11 +883,9 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
           normRes /= normResIni;
 
         // Output current residual norm to screen (on proc 0 only)
+        out << cycle << "\t" << normRes << std::endl;
         if (myRank == 0)
-        {
-          std::cout << cycle << "\t" << normRes << std::endl;
           (*log) << cycle << "\t" << normRes << "\n";
-        }
 
         if (normRes < tol)
           break;
@@ -864,8 +906,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
 
         regX[0]->update(one, *regCorrect[0], one);
     }
-    if (myRank == 0)
-      std::cout << "Number of iterations performed for this solve: " << cycle << std::endl;
+    out << "Number of iterations performed for this solve: " << cycle << std::endl;
 
     std::cout << std::setprecision(old_precision);
     std::cout.unsetf(std::ios::fixed | std::ios::scientific);
@@ -875,16 +916,19 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
   tm = Teuchos::null;
   globalTimeMonitor = Teuchos::null;
 
-  RCP<ParameterList> reportParams = rcp(new ParameterList);
-  const std::string filter = "";
-  if (useStackedTimer) {
-    Teuchos::StackedTimer::OutputOptions options;
-    options.output_fraction = options.output_histogram = options.output_minmax = true;
-    stacked_timer->report(out, comm, options);
-  } else {
-    std::ios_base::fmtflags ff(out.flags());
-    TimeMonitor::report(comm.ptr(), out, filter, reportParams);
-    out << std::setiosflags(ff);
+  if (showTimerSummary)
+  {
+    RCP<ParameterList> reportParams = rcp(new ParameterList);
+    const std::string filter = "";
+    if (useStackedTimer) {
+      Teuchos::StackedTimer::OutputOptions options;
+      options.output_fraction = options.output_histogram = options.output_minmax = true;
+      stacked_timer->report(out, comm, options);
+    } else {
+      std::ios_base::fmtflags ff(out.flags());
+      TimeMonitor::report(comm.ptr(), out, filter, reportParams);
+      out << std::setiosflags(ff);
+    }
   }
 
   TimeMonitor::clearCounters();

--- a/packages/muelu/test/unit_tests/RegionMatrix.cpp
+++ b/packages/muelu/test/unit_tests/RegionMatrix.cpp
@@ -100,9 +100,9 @@ void createRegionMatrix(const Teuchos::ParameterList galeriList,
   procsPerDim[1] = galeriList.get<GO>("my");
   procsPerDim[2] = galeriList.get<GO>("mz");
 
-  std::cout << "numDimensions=" << numDimensions << ", useStructured=" << false
-            << ", numDofsPerNode=" << numDofsPerNode << ", gNodesPerDir=" << gNodesPerDir
-            << ", lNodesPerDir=" << lNodesPerDir << ", procsPerDim=" << procsPerDim << std::endl;
+  // std::cout << "numDimensions=" << numDimensions << ", useStructured=" << false
+  //           << ", numDofsPerNode=" << numDofsPerNode << ", gNodesPerDir=" << gNodesPerDir
+  //           << ", lNodesPerDir=" << lNodesPerDir << ", procsPerDim=" << procsPerDim << std::endl;
 
   Array<int> boundaryConditions;
   int maxRegPerGID = 0;
@@ -120,6 +120,14 @@ void createRegionMatrix(const Teuchos::ParameterList galeriList,
                    maxRegPerGID, numLocalRegionNodes, boundaryConditions,
                    sendGIDs, sendPIDs, numInterfaces, rNodesPerDim,
                    quasiRegionGIDs, quasiRegionCoordGIDs, compositeToRegionLIDs);
+
+  const int myRank = A->getRowMap()->getComm()->getRank();
+  // const LO numSend = static_cast<LO>(sendGIDs.size());
+  // std::cout << "p=" << myRank << " | numSend=" << numSend << std::endl;
+  // std::cout << "p=" << myRank << " | sendGIDs: " << sendGIDs << std::endl;
+  // std::cout << "p=" << myRank << " | sendPIDs: " << sendPIDs << std::endl;
+  // std::cout << "p=" << myRank << " | compositeToRegionLIDs: " << compositeToRegionLIDs() << std::endl;
+  // std::cout << "p=" << myRank << " | quasiRegionGIDs: " << quasiRegionGIDs << std::endl;
 
   rowMapPerGrp[0] = Xpetra::MapFactory<LO,GO,Node>::Build(A->getRowMap()->lib(),
                                                           Teuchos::OrdinalTraits<GO>::invalid(),
@@ -142,7 +150,6 @@ void createRegionMatrix(const Teuchos::ParameterList galeriList,
     = Xpetra::MultiVectorFactory<LO, LO, GO, NO>::Build(dofMap, maxRegPerGID, false);
 
   { // Scope for regionsPerGIDView
-    const int myRank = dofMap->getComm()->getRank();
     Array<ArrayRCP<LO> > regionsPerGIDView(maxRegPerGID);
     for(int regionIdx = 0; regionIdx < maxRegPerGID; ++regionIdx) {
       regionsPerGIDView[regionIdx] = regionsPerGID->getDataNonConst(regionIdx);
@@ -674,6 +681,148 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, MatVec, Scalar, LocalOrdinal, Gl
 
 } // MatVec
 
+// This test aims at checking that apply regionA to a region vector has the same effect as
+// applying A to a composite vector. Of course the region vector needs to be brought back
+// to composite formate before verifying the equivalence.
+TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, FastMatVec, Scalar, LocalOrdinal, GlobalOrdinal, Node)
+{
+#   include "MueLu_UseShortNames.hpp"
+  MUELU_TESTING_SET_OSTREAM;
+  MUELU_TESTING_LIMIT_SCOPE(Scalar,GlobalOrdinal,Node);
+
+  using TST                   = Teuchos::ScalarTraits<SC>;
+  using magnitude_type        = typename TST::magnitudeType;
+  using TMT                   = Teuchos::ScalarTraits<magnitude_type>;
+  using real_type             = typename TST::coordinateType;
+  using RealValuedMultiVector = Xpetra::MultiVector<real_type,LO,GO,NO>;
+  using test_factory          = TestHelpers::TestFactory<SC, LO, GO, NO>;
+
+  out << "version: " << MueLu::Version() << std::endl;
+
+  // Get MPI parameter
+  RCP<const Teuchos::Comm<int> > comm = TestHelpers::Parameters::getDefaultComm();
+
+  GO nx = 7, ny = 7, nz = 1;
+  Teuchos::CommandLineProcessor &clp = Teuchos::UnitTestRepository::getCLP();
+  Galeri::Xpetra::Parameters<GO> galeriParameters(clp, nx, ny, nz, "Laplace2D");
+  Teuchos::ParameterList galeriList = galeriParameters.GetParameterList();
+  std::string   matrixType = galeriParameters.GetMatrixType();
+
+  // Build maps for the problem
+  const LO numDofsPerNode = 1;
+  RCP<Map> nodeMap = Galeri::Xpetra::CreateMap<LO, GO, Node>(TestHelpers::Parameters::getLib(),
+                                                             "Cartesian2D", comm, galeriList);
+  RCP<Map> dofMap  = Xpetra::MapFactory<LO,GO,Node>::Build(nodeMap, numDofsPerNode);
+
+  // Build the Xpetra problem
+  RCP<Galeri::Xpetra::Problem<Map,CrsMatrixWrap,MultiVector> > Pr =
+    Galeri::Xpetra::BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>(galeriParameters.GetMatrixType(), dofMap, galeriList);
+
+  // Generate the operator
+  RCP<Matrix> A = Pr->BuildMatrix();
+  A->SetFixedBlockSize(numDofsPerNode);
+
+  // Create auxiliary data for MG
+  RCP<MultiVector> nullspace = Pr->BuildNullspace();
+  RCP<RealValuedMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<double,LO,GO,Map,RealValuedMultiVector>("2D", nodeMap, galeriList);
+
+  // create the region maps, importer and operator from composite counter parts
+  const int maxRegPerProc = 1;
+  std::vector<RCP<Map> >    rowMapPerGrp(maxRegPerProc), colMapPerGrp(maxRegPerProc);
+  std::vector<RCP<Map> >    revisedRowMapPerGrp(maxRegPerProc), revisedColMapPerGrp(maxRegPerProc);
+  std::vector<RCP<Import> > rowImportPerGrp(maxRegPerProc), colImportPerGrp(maxRegPerProc);
+  std::vector<RCP<Matrix> > regionGrpMats(maxRegPerProc);
+  createRegionMatrix(galeriList, numDofsPerNode, maxRegPerProc, nodeMap, dofMap, A,
+                     rowMapPerGrp, colMapPerGrp, revisedRowMapPerGrp, revisedColMapPerGrp,
+                     rowImportPerGrp, colImportPerGrp, regionGrpMats);
+
+  RCP<Matrix> regionMat = regionGrpMats[0];
+
+  // Create initial vectors in composite format and apply composite A.
+  // This will give a reference to compare with.
+  RCP<Vector> X = VectorFactory::Build(dofMap);
+  RCP<Vector> B = VectorFactory::Build(dofMap);
+
+  // we set seed for reproducibility
+  Utilities::SetRandomSeed(*comm);
+  X->randomize();
+
+  // Perform composite MatVec
+  A->apply(*X, *B, Teuchos::NO_TRANS, TST::one(), TST::zero());
+
+  // Create the region vectors and apply region A
+  Array<RCP<Vector> > quasiRegX(maxRegPerProc);
+  Array<RCP<Vector> > quasiRegB(maxRegPerProc);
+  Array<RCP<Vector> > regX(maxRegPerProc);
+  Array<RCP<Vector> > regB(maxRegPerProc);
+  compositeToRegional(X, quasiRegX, regX,
+                      revisedRowMapPerGrp, rowImportPerGrp);
+  regB[0] = VectorFactory::Build(revisedRowMapPerGrp[0], true);
+  regionMat->apply(*regX[0], *regB[0], Teuchos::NO_TRANS, TST::one(), TST::zero());
+  sumInterfaceValues(regB, revisedRowMapPerGrp, rowImportPerGrp);
+
+  // Now create a refRegB vector using B as a starting point
+  // and compare the result to regB
+  Array<RCP<Vector> > refRegB(maxRegPerProc);
+  compositeToRegional(B, quasiRegB, refRegB,
+                      revisedRowMapPerGrp, rowImportPerGrp);
+
+  // Extract the data from B and compB to compare it
+  ArrayRCP<const SC> dataRegB    = regB[0]->getData(0);
+  ArrayRCP<const SC> dataRefRegB = refRegB[0]->getData(0);
+  for(size_t idx = 0; idx < refRegB[0]->getLocalLength(); ++idx) {
+    TEST_FLOATING_EQUALITY(TST::magnitude(dataRegB[idx]),
+                           TST::magnitude(dataRefRegB[idx]),
+                           100*TMT::eps());
+  }
+
+  // Finally we perform the "fastMatVec" that does not require
+  // to transform data from region to composite and back
+  // it should perform faster and allow for easy customization
+  // of the local MatVec
+  RCP<Map>    regionMap = revisedRowMapPerGrp[0];
+
+  const int myRank = regionMap->getComm()->getRank();
+
+  Array<GO> regionInterfaceMapData;
+  Array<LO> regionInterfaceLIDs;
+  if(myRank == 0) {
+    regionInterfaceMapData = {16, 20, 24, 28, 32, 33, 34, 35, 48};
+    regionInterfaceLIDs    = { 3,  7, 11, 15, 12, 13, 14, 15, 15};
+  } else if(myRank == 1) {
+    regionInterfaceMapData = { 3,  7, 11, 15, 35, 48, 49, 50, 51};
+    regionInterfaceLIDs    = { 0,  4,  8, 12, 12, 12, 13, 14, 15};
+  } else if(myRank == 2) {
+    regionInterfaceMapData = {12, 13, 14, 15, 28, 48, 52, 56, 60};
+    regionInterfaceLIDs    = { 0,  1,  2,  3,  3,  3,  7, 11, 15};
+  } else if(myRank == 3) {
+    regionInterfaceMapData = {15, 28, 29, 30, 31, 35, 39, 43, 47};
+    regionInterfaceLIDs    = { 0,  0,  1,  2,  3,  0,  4,  8, 12};
+  }
+
+  RCP<Map> regionInterfaceMap = Xpetra::MapFactory<LO,GO,Node>::Build(regionMap->lib(),
+                                                                      Teuchos::OrdinalTraits<GO>::invalid(),
+                                                                      regionInterfaceMapData(),
+                                                                      regionMap->getIndexBase(),
+                                                                      regionMap->getComm());
+
+  RCP<Import> regionInterfaceImporter = ImportFactory::Build(regionMap, regionInterfaceMap);
+
+  Array<RCP<Vector> > regC(maxRegPerProc);
+  regC[0] = VectorFactory::Build(revisedRowMapPerGrp[0], true);
+  MatVec(TST::one(), regionMat, regX[0], TST::zero(),
+         regionInterfaceImporter, regionInterfaceLIDs,
+         regC[0]);
+
+  ArrayRCP<const SC> dataRegC = regC[0]->getData(0);
+  for(size_t idx = 0; idx < refRegB[0]->getLocalLength(); ++idx) {
+    TEST_FLOATING_EQUALITY(TST::magnitude(dataRegC[idx]),
+                           TST::magnitude(dataRefRegB[idx]),
+                           100*TMT::eps());
+  }
+
+} // FastMatVec
+
 // Here a Laplace 2D problem is tested for all the above checks mentioned:
 //   1) the region operator is compared against know values
 //   2) the action of the region MatVec is compared with the composite MatVec
@@ -1172,6 +1321,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, Laplace3D, Scalar, LocalOrdinal,
       TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(RegionMatrix,CompositeToRegionMatrix,Scalar,LO,GO,Node) \
       TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(RegionMatrix,RegionToCompositeMatrix,Scalar,LO,GO,Node) \
       TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(RegionMatrix,MatVec,Scalar,LO,GO,Node)                  \
+      TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(RegionMatrix,FastMatVec,Scalar,LO,GO,Node)              \
       TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(RegionMatrix,Laplace2D,Scalar,LO,GO,Node)               \
       TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(RegionMatrix,Laplace3D,Scalar,LO,GO,Node)
 

--- a/packages/muelu/test/unit_tests/RegionMatrix.cpp
+++ b/packages/muelu/test/unit_tests/RegionMatrix.cpp
@@ -777,9 +777,9 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, FastMatVec, Scalar, LocalOrdinal
 
   Array<RCP<Vector> > regC(maxRegPerProc);
   regC[0] = VectorFactory::Build(revisedRowMapPerGrp[0], true);
-  MatVec(TST::one(), regionMat, regX[0], TST::zero(),
-         regionInterfaceImporter, regionMatVecLIDs,
-         regC[0]);
+  ApplyMatVec(TST::one(), regionMat, regX[0], TST::zero(),
+              regionInterfaceImporter, regionMatVecLIDs,
+              regC[0]);
 
   ArrayRCP<const SC> dataRegC = regC[0]->getData(0);
   for(size_t idx = 0; idx < refRegB[0]->getLocalLength(); ++idx) {

--- a/packages/muelu/test/unit_tests/RegionVector.cpp
+++ b/packages/muelu/test/unit_tests/RegionVector.cpp
@@ -120,12 +120,15 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionVector, RegionCompositeVector, Scalar, L
   Array<LO>  compositeToRegionLIDs(nodeMap->getNodeNumElements()*numDofsPerNode);
   Array<GO>  quasiRegionGIDs;
   Array<GO>  quasiRegionCoordGIDs;
+  Array<GO>  interfaceGIDs;
+  Array<LO>  interfaceLIDsData;
   createRegionData(2, false, numDofsPerNode,
                    gNodesPerDir(), lNodesPerDir(), procsPerDim(),
                    nodeMap, dofMap,
                    maxRegPerGID, numLocalRegionNodes, boundaryConditions,
                    sendGIDs, sendPIDs, numInterfaces, rNodesPerDim,
-                   quasiRegionGIDs, quasiRegionCoordGIDs, compositeToRegionLIDs);
+                   quasiRegionGIDs, quasiRegionCoordGIDs, compositeToRegionLIDs,
+                   interfaceGIDs, interfaceLIDsData);
 
   const int maxRegPerProc = 1;
   std::vector<RCP<Map> > rowMapPerGrp(maxRegPerProc),        colMapPerGrp(maxRegPerProc);


### PR DESCRIPTION
@trilinos/muelu

## Motivation
This should accelerate significantly the matvec costs associated with the region format as it now performs only one neighbor communication instead of tow.

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of #7175
* Composed of 

## Stakeholder Feedback
This work is part of an ASCR project with @rstumin and @lucbv 

## Testing
Local tests have been performed and so far all are passing except for elasticity problems since this PR only addresses the scalar equation case. A follow-up PR will tackle the multiple dof per node case, in the meantime, a runtime parameter can be selected to use the "slow path" for matvec that works with system of PDEs.

## Additional Information
Work remaining before this PR is complete:
1. add capabilities for multiple dofs per node
2. modify the matvec implementation to expose the Kokkos-kernel call which will allow to easily write higher performance matvec algorithm based on structured grid assumptions
3. create a matvec specific driver to assess the performance of various kernels implementations based on the structure of the grid