### PR TITLE
ATDM: cts1: Extend slrum test timeout from 1:20:00 to 3:00:00 (ATDV-357)

### DIFF
--- a/cmake/ctest/drivers/atdm/cts1/local-driver.sh
+++ b/cmake/ctest/drivers/atdm/cts1/local-driver.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -l
 
 if [ "${SLURM_CTEST_TIMEOUT}" == "" ] ; then
-  SLURM_CTEST_TIMEOUT=1:20:00
+  SLURM_CTEST_TIMEOUT=3:00:00
   # This is just running tests, not the entire build!
 fi
 


### PR DESCRIPTION
The slurm jobs running the tests all timed out with at timeout of 1:20:00.
Something might be wrong with this configuration that would cause such a large
increase in the test runtimes. But we can deal with that later.
