### PR TITLE
Move setting OMP_XXX vars after sparc-dev module loads (ATDV-357)

### DIFF
--- a/cmake/std/atdm/common/toss3/environment_new.sh
+++ b/cmake/std/atdm/common/toss3/environment_new.sh
@@ -23,13 +23,6 @@ module purge
 module load sems-env
 module load sems-git/2.10.1
 
-if [ "$ATDM_CONFIG_NODE_TYPE" == "OPENMP" ] ; then
-  export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=8
-  export OMP_NUM_THREADS=2
-else
-  export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=16
-fi
-
 # Common paths and modules for both intel-1{8,9}
 module load cmake/3.12.2
 
@@ -49,6 +42,15 @@ else
 fi
 
 module load sems-ninja_fortran/1.8.2
+
+if [ "$ATDM_CONFIG_NODE_TYPE" == "OPENMP" ] ; then
+  export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=8
+  export OMP_NUM_THREADS=2
+  unset OMP_PLACES
+  unset OMP_PROC_BIND
+else
+  export ATDM_CONFIG_CTEST_PARALLEL_LEVEL=16
+fi
 
 export OMPI_CXX=`which icpc`
 export OMPI_CC=`which icc`


### PR DESCRIPTION
This fixes the show tests and timeouts reported in [ATDV-357](https://sems-atlassian-srn.sandia.gov/browse/ATDV-357?focusedCommentId=60317&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-60317).

## How was this tested?

I tested this on 'eclipse' with:

```
$ cd /nscratch/rabartl/Trilinos.base/BUILDS/CTS1/CTEST_S/

$ env SLURM_CTEST_TIMEOUT=4:00:00 \
  ./ctest-s-local-test-driver.sh \
    cts1-intel-19.0.5_openmpi-4.0.1_openmp_static_opt

***
*** ./ctest-s-local-test-driver.sh
***

ATDM_TRILINOS_DIR = '/nscratch/rabartl/Trilinos.base/Trilinos'

Load some env to get python, cmake, etc ...

Hostname 'eclipse-login1' matches known ATDM host 'eclipse-login1' and system 'cts1'
Setting compiler and build options for build-name 'default'
Using cts1 toss3 compiler stack INTEL-18.0.2_OPENMPI-4.0.1 to build DEBUG code with Kokkos node type SERIAL

Running builds:
    cts1-intel-19.0.5_openmpi-4.0.1_openmp_static_opt

Fri Jun  5 13:27:49 MDT 2020

Running Jenkins driver Trilinos-atdm-cts1-intel-19.0.5_openmpi-4.0.1_openmp_static_opt.sh ...

    Creating directory: Trilinos-atdm-cts1-intel-19.0.5_openmpi-4.0.1_openmp_static_opt

    Creating directory: SRC_AND_BUILD

    See log file Trilinos-atdm-cts1-intel-19.0.5_openmpi-4.0.1_openmp_static_opt/smart-jenkins-driver.out

real    341m26.931s
user    1953m25.597s
sys     203m59.589s

99% tests passed, 1 tests failed out of 2275

Fri Jun  5 19:09:16 MDT 2020

Done running all of the builds!
```

That submitted to CDash:

* https://testing-dev.sandia.gov/cdash/index.php?project=Trilinos&date=2020-06-05&filtercount=2&showfilters=1&filtercombine=and&field1=buildname&compare1=65&value1=Trilinos-atdm-cts1&field2=buildname&compare2=63&value2=-exp

showing:

| Site | Build Name | C Err | C Warn | C Time | B Err | B Warn | B Time | Not Run | Fail | Pass | Time | Proc Time | Start Time | Labels |
| -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- |
eclipse-login1 | Trilinos-atdm-cts1-intel-19.0.5_openmpi-4.0.1_openmp_static_opt-exp | 0 | 4 | 10m 42s | 0 | 50 | 4h 53m 40s | 0 | 1 | 2274 | 20m 3s | 2h 32m 56s | 8 hours ago | (28 labels)

The failing test was `ROL_example_tempus_example_02_MPI_1`.  We already know about that failure as reported in #6553 which has been failing for a long time.

More details are given below.

<details>

<summary><b>Details:</b> (click to expand)</summary>

.

**(6/5/2020)**

Checking out two vesrions of Trilinos, one before the merge of PR #7474 and one after and compare the 'OMP_XXX' env vars.

For the current version of Trilinos:

```
e7756b94864 "Merge pull request #7476 from brian-kelley/FixTestTimeout"
Author: brian-kelley <bmkelle@sandia.gov>
Date:   Fri Jun 5 12:10:15 2020 -0600 (54 minutes ago)
```

I ran:

```
$ git log-short -1
e7756b94864 "Merge pull request #7476 from brian-kelley/FixTestTimeout"
Author: brian-kelley <bmkelle@sandia.gov>
Date:   Fri Jun 5 12:10:15 2020 -0600 (54 minutes ago)

$ . cmake/std/atdm/load-env.sh intel-19-openmp-opt
Hostname 'eclipse-login1' matches known ATDM host 'eclipse-login1' and system 'cts1'
Setting compiler and build options for build-name 'intel-19-openmp-opt'
Using cts1 toss3 compiler stack INTEL-19.0.4_OPENMPI-4.0.3 to build RELEASE code with Kokkos node type OPENMP

$ set | grep "^OMP_"
OMP_NUM_THREADS=1
OMP_PLACES=threads
OMP_PROC_BIND=false
```

Now, to find an older version of Trilinos before this change, we look at:

```
$ git log-short --first-parent

...

8b8ffc2 "Merge Pull Request #7474 from e10harvey/Trilinos/atdv-357-atdm-cts1"
Author: trilinos-autotester <trilinos@sandia.gov>
Date:   Thu Jun 4 11:45:10 2020 -0600 (25 hours ago)

184c490 "Merge pull request #7463 from trilinos/csiefer-comm-test"
Author: Chris Siefert <csiefer2@users.noreply.github.com>
Date:   Wed Jun 3 08:11:39 2020 -0600 (2 days ago)
...
```

So we want the first parent commit `184c490` just before the merge of PR #7474.  So I do:

```
$ git checkout 184c490
...
HEAD is now at 184c490... Merge pull request #7463 from trilinos/csiefer-comm-test

$ git log-short -1
184c490 "Merge pull request #7463 from trilinos/csiefer-comm-test"
Author: Chris Siefert <csiefer2@users.noreply.github.com>
Date:   Wed Jun 3 08:11:39 2020 -0600 (2 days ago)

$ . cmake/std/atdm/load-env.sh intel-19-openmp-opt
Hostname 'eclipse-login1' matches known ATDM host 'eclipse-login1' and system 'cts1'
Setting compiler and build options for build-name 'intel-19-openmp-opt'
Using cts1 toss3 compiler stack INTEL-19.0.5_OPENMPI-4.0.1 to build RELEASE code with Kokkos node type OPENMP

$ set | grep "^OMP_"
OMP_NUM_THREADS=1
```

So, let's unset those env vars `OMP_PLACES` and `OMP_PROC_BIND` and see what happens with a full run.

I created the new branch 'atdv-357-cts1-fix-omp-vars' off of 'develop' and I added the commit:

```
35c13194a09 "Move setting OMP_XXX vars after sparc-dev module loads (ATDV-357)"
Author: Roscoe A. Bartlett <rabartl@sandia.gov>
Date:   Fri Jun 5 13:19:16 2020 -0600 (3 minutes ago)

M       cmake/std/atdm/common/toss3/environment_new.sh
```

and I run:

```
$ . cmake/std/atdm/load-env.sh intel-19-openmp-opt
Hostname 'eclipse-login1' matches known ATDM host 'eclipse-login1' and system 'cts1'
Setting compiler and build options for build-name 'intel-19-openmp-opt'
Using cts1 toss3 compiler stack INTEL-19.0.4_OPENMPI-4.0.3 to build RELEASE code with Kokkos node type OPENMP
This version of Open MPI 4.0.3 is temporary and was built with Intel/18.0 compilers and cudatoolkit/10.1

$ set | grep "^OMP_"
OMP_NUM_THREADS=2
```

Let's give that a try on eclipse:

```
$ cd /nscratch/rabartl/Trilinos.base/BUILDS/CTS1/CTEST_S/

$ env SLURM_CTEST_TIMEOUT=4:00:00 \
  ./ctest-s-local-test-driver.sh \
    cts1-intel-19.0.5_openmpi-4.0.1_openmp_static_opt

***
*** ./ctest-s-local-test-driver.sh
***

ATDM_TRILINOS_DIR = '/nscratch/rabartl/Trilinos.base/Trilinos'

Load some env to get python, cmake, etc ...

Hostname 'eclipse-login1' matches known ATDM host 'eclipse-login1' and system 'cts1'
Setting compiler and build options for build-name 'default'
Using cts1 toss3 compiler stack INTEL-18.0.2_OPENMPI-4.0.1 to build DEBUG code with Kokkos node type SERIAL

Running builds:
    cts1-intel-19.0.5_openmpi-4.0.1_openmp_static_opt

Fri Jun  5 13:27:49 MDT 2020

Running Jenkins driver Trilinos-atdm-cts1-intel-19.0.5_openmpi-4.0.1_openmp_static_opt.sh ...

    Creating directory: Trilinos-atdm-cts1-intel-19.0.5_openmpi-4.0.1_openmp_static_opt

    Creating directory: SRC_AND_BUILD

    See log file Trilinos-atdm-cts1-intel-19.0.5_openmpi-4.0.1_openmp_static_opt/smart-jenkins-driver.out

real    341m26.931s
user    1953m25.597s
sys     203m59.589s

99% tests passed, 1 tests failed out of 2275

Fri Jun  5 19:09:16 MDT 2020

Done running all of the builds!
```

That submitted to CDash:

* https://testing-dev.sandia.gov/cdash/index.php?project=Trilinos&date=2020-06-05&filtercount=2&showfilters=1&filtercombine=and&field1=buildname&compare1=65&value1=Trilinos-atdm-cts1&field2=buildname&compare2=63&value2=-exp

showing:

| Site | Build Name | C Err | C Warn | C Time | B Err | B Warn | B Time | Not Run | Fail | Pass | Time | Proc Time | Start Time | Labels |
| -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- |
eclipse-login1 | Trilinos-atdm-cts1-intel-19.0.5_openmpi-4.0.1_openmp_static_opt-exp | 0 | 4 | 10m 42s | 0 | 50 | 4h 53m 40s | 0 | 1 | 2274 | 20m 3s | 2h 32m 56s | 8 hours ago | (28 labels)

The failing test was `ROL_example_tempus_example_02_MPI_1`.  We already know about that failure as reported in #6553 which has been failing for a long time.

</details>
