### PR TITLE
Revert "PullRequestLinuxCudaDriver.sh: change from Firestone to Garrison nodes"

### DIFF
--- a/cmake/std/PullRequestLinuxCudaDriver.sh
+++ b/cmake/std/PullRequestLinuxCudaDriver.sh
@@ -14,11 +14,10 @@ fi
 set -x
 
 #TODO: review appropriate job size
-bsub -x -Is -q rhel7G -n 16 -J $JOB_NAME -W $BSUB_CTEST_TIME_LIMIT \
+bsub -x -Is -q rhel7F -n 16 -J $JOB_NAME -W $BSUB_CTEST_TIME_LIMIT \
   $WORKSPACE/Trilinos/cmake/std/PullRequestLinuxDriver.sh
 
-# NOTE: Above, this bsub command should grab a single rhel7G
-# (Garrison/Minsky, Dual-Socket POWER8, 8 cores per socket,
-# dual P100 GPUs) node.  The option '-x' makes sure that only
-# this job runs on that node.  The options '-n 16' and '-q rhel7G'
-# should make bsub allocate a single one of these nodes.
+# NOTE: Above, this bsub command should grab a single rhel7F (Firestone,
+# Dual-Socket POWER8, 8 cores per socket, K80 GPUs) node.  The option '-x'
+# makes sure that only this job runs on that node.  The options '-n 16' and
+# '-q rhel7G' should make bsub allocate a single one of these nodes.


### PR DESCRIPTION
Reverts trilinos/Trilinos#7473

I missed the required build changes. With a 9 hour cycle time and the need to set up testing on a fork this will take a bit to fix.