### PR TITLE
Teuchos: Fix StackedTimer XML nesting

### DIFF
--- a/packages/teuchos/comm/src/Teuchos_StackedTimer.cpp
+++ b/packages/teuchos/comm/src/Teuchos_StackedTimer.cpp
@@ -248,7 +248,7 @@ StackedTimer::collectRemoteData(Teuchos::RCP<const Teuchos::Comm<int> > comm, co
 std::pair<std::string, std::string> getPrefix(const std::string &name) {
   for (std::size_t i=name.size()-1; i>0; --i)
     if (name[i] == '@') {
-      return std::pair<std::string, std::string>(name.substr(0,i), name.substr(i+1, name.size()));
+      return std::pair<std::string, std::string>(name.substr(0,i), name.substr(i+1));
     }
   return std::pair<std::string, std::string>(std::string(""), name);
 }
@@ -636,12 +636,11 @@ static void printXMLEscapedString(std::ostream& os, const std::string& str)
 double
 StackedTimer::printLevelXML (std::string prefix, int print_level, std::ostream& os, std::vector<bool> &printed, double parent_time, const std::string& rootName)
 {
-  //Adding an extra indent level, since the <performance-report> header is at indent 0
-  int indent = 4 * (print_level + 1);
+  int indent = 2 * print_level;
 
   double total_time = 0.0;
 
-  for (int i=0; i<flat_names_.size(); ++i ) {
+  for (int i=0; i<flat_names_.size(); ++i) {
     if (printed[i])
       continue;
     int level = std::count(flat_names_[i].begin(), flat_names_[i].end(), '@');
@@ -653,31 +652,37 @@ StackedTimer::printLevelXML (std::string prefix, int print_level, std::ostream& 
     // Output the indentation level
     for (int j = 0; j < indent; j++)
       os << " ";
-    bool leaf = split_names.first.length() > 0;
     os << "<timing name=\"";
     if(level == 0 && rootName.length())
       printXMLEscapedString(os, rootName);
     else
       printXMLEscapedString(os, split_names.second);
     os << "\" value=\"" << sum_[i]/active_[i] << "\"";
-    if(leaf)
-      os << "/>\n";
-    else
-      os << ">\n";
     printed[i] = true;
     //note: don't need to pass in prependRoot, since the recursive calls don't apply to the root level
-    double sub_time = printLevelXML(flat_names_[i], print_level+1, os, printed, sum_[i]/active_[i]);
-    // Print Remainder
-    if (sub_time > 0 ) {
-      for (int j = 0; j < indent + 4; j++)
-        os << " ";
-      os << "<timing name=\"Remainder\" value=\"" << (sum_[i]/active_[i] - sub_time) << "\"/>\n";
-    }
-    if(!leaf)
+    //Print the children to a temporary string. If it's empty, can close the current XML element on the same line.
+    std::ostringstream osInner;
+    double sub_time = printLevelXML(flat_names_[i], print_level+1, osInner, printed, sum_[i]/active_[i]);
+    std::string innerContents = osInner.str();
+    if(innerContents.length())
     {
+      os << ">\n";
+      os << innerContents;
+      // Print Remainder
+      if (sub_time > 0 ) {
+        for (int j = 0; j < indent + 4; j++)
+          os << " ";
+        os << "<timing name=\"Remainder\" value=\"" << (sum_[i]/active_[i] - sub_time) << "\"/>\n";
+      }
+      //having printed child nodes, close the XML element on its own line
       for (int j = 0; j < indent; j++)
         os << " ";
       os << "</timing>\n";
+    }
+    else
+    {
+      //Just a leaf node.
+      os << "/>\n";
     }
     total_time += sum_[i]/active_[i];
   }

--- a/packages/teuchos/comm/src/Teuchos_StackedTimer.cpp
+++ b/packages/teuchos/comm/src/Teuchos_StackedTimer.cpp
@@ -636,7 +636,8 @@ static void printXMLEscapedString(std::ostream& os, const std::string& str)
 double
 StackedTimer::printLevelXML (std::string prefix, int print_level, std::ostream& os, std::vector<bool> &printed, double parent_time, const std::string& rootName)
 {
-  int indent = 2 * print_level;
+  constexpr int indSpaces = 2;
+  int indent = indSpaces * print_level;
 
   double total_time = 0.0;
 
@@ -670,7 +671,7 @@ StackedTimer::printLevelXML (std::string prefix, int print_level, std::ostream& 
       os << innerContents;
       // Print Remainder
       if (sub_time > 0 ) {
-        for (int j = 0; j < indent + 4; j++)
+        for (int j = 0; j < indent + indSpaces; j++)
           os << " ";
         os << "<timing name=\"Remainder\" value=\"" << (sum_[i]/active_[i] - sub_time) << "\"/>\n";
       }


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/teuchos 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Previously, the XML output printed timing nodes as if every node deeper than 2 was a leaf. This meant that every descendant (not just direct children) was plotted in one page in Watchr. This fixes the tree structure. Leaf nodes are always closed with ``/>`` on the same line, and all non-leafs are closed with ``</timing>`` at the same indentation level as the opening ``<timing ...>``. Example output, from MueLu Driver:
```
<?xml version="1.0"?>
<performance-report date="2020-06-11T03:15:54" name="nightly_run_2020_06_11" time-units="seconds">
<timing name="Workstation: MueLu Setup-Solve 1 ranks" value="5.30173">
  <timing name="Driver: 1 - Matrix Build" value="0.649667">
    <timing name="Galeri: Laplace 3D generation" value="0.348656"/>
    <timing name="Galeri: Laplace 3D fillComplete" value="0.202605"/>
    <timing name="Remainder" value="0.0984056"/>
  </timing>

  <!-- Cutting out the setup part because it's very long -->

  <timing name="Driver: 5 - Belos Solve" value="2.64055">
    <timing name="Belos: Operation Op*x" value="0.0154169"/>
    <timing name="Belos: PseudoBlockCGSolMgr total solve time" value="2.62168">
      <timing name="Belos: Operation Prec*x" value="2.20109">
        <timing name="MueLu: Laplace3D: Hierarchy: Solve (total)" value="2.18549">
          <timing name="MueLu: Laplace3D: Hierarchy: Solve (level=0)" value="1.63697">
            <timing name="MueLu: Laplace3D: Hierarchy: Solve : smoothing (level=0)" value="0.995203">
              <timing name="Ifpack2::Chebyshev::apply" value="0.993861"/>
              <timing name="Remainder" value="0.0013428"/>
            </timing>
            <timing name="MueLu: Laplace3D: Hierarchy: Solve : residual calculation (level=0)" value="0.25613"/>
            <timing name="MueLu: Laplace3D: Hierarchy: Solve : restriction (level=0)" value="0.184122"/>
            <timing name="MueLu: Laplace3D: Hierarchy: Solve : prolongation (level=0)" value="0.200468"/>
            <timing name="Remainder" value="0.00104946"/>
          </timing>
          <timing name="MueLu: Laplace3D: Hierarchy: Solve (level=1)" value="0.526482">
            <timing name="MueLu: Laplace3D: Hierarchy: Solve : smoothing (level=1)" value="0.355102">
              <timing name="Ifpack2::Chebyshev::apply" value="0.354066"/>
              <timing name="Remainder" value="0.00103597"/>
            </timing>
            <timing name="MueLu: Laplace3D: Hierarchy: Solve : residual calculation (level=1)" value="0.108055"/>
            <timing name="MueLu: Laplace3D: Hierarchy: Solve : restriction (level=1)" value="0.0313495"/>
            <timing name="MueLu: Laplace3D: Hierarchy: Solve : prolongation (level=1)" value="0.0313812"/>
            <timing name="Remainder" value="0.00059429"/>
          </timing>
          <timing name="MueLu: Laplace3D: Hierarchy: Solve (level=2)" value="0.0204463">
            <timing name="MueLu: Laplace3D: Hierarchy: Solve : smoothing (level=2)" value="0.013806">
              <timing name="Ifpack2::Chebyshev::apply" value="0.0129069"/>
              <timing name="Remainder" value="0.000899165"/>
            </timing>
            <timing name="MueLu: Laplace3D: Hierarchy: Solve : residual calculation (level=2)" value="0.00464245"/>
            <timing name="MueLu: Laplace3D: Hierarchy: Solve : restriction (level=2)" value="0.000885521"/>
            <timing name="MueLu: Laplace3D: Hierarchy: Solve : prolongation (level=2)" value="0.000716495"/>
            <timing name="Remainder" value="0.000395833"/>
          </timing>
          <timing name="MueLu: Laplace3D: Hierarchy: Solve (level=3)" value="0.000856998">
            <timing name="MueLu: Laplace3D: Hierarchy: Solve : coarse (level=3)" value="0.00078872"/>
            <timing name="Remainder" value="6.8278e-05"/>
          </timing>
          <timing name="Remainder" value="0.000728902"/>
        </timing>
        <timing name="Remainder" value="0.0156064"/>
      </timing>
      <timing name="Belos: Operation Op*x" value="0.230385"/>
      <timing name="Remainder" value="0.190201"/>
    </timing>
    <timing name="Remainder" value="0.00345401"/>
  </timing>
  <timing name="Remainder" value="0.0477318"/>
</timing>
</performance-report>
```
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->

Did local performance testing build and read through the output to make sure tree is correct.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->