### PR TITLE
Intrepid2: ensure that derived basis classes have unique names

### DIFF
--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HCURL_HEX.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HCURL_HEX.hpp
@@ -411,16 +411,6 @@ namespace Intrepid2
      */
     Basis_Derived_HCURL_HEX(int polyOrder) : Basis_Derived_HCURL_HEX(polyOrder, polyOrder, polyOrder) {}
 
-    /** \brief  Returns basis name
-
-        \return the name of the basis
-    */
-    virtual
-    const char*
-    getName() const {
-      return "Intrepid2_DerivedBasis_HCURL_HEX";
-    }
-
     /** \brief True if orientation is required
     */
     virtual bool requireOrientation() const {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HCURL_QUAD.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HCURL_QUAD.hpp
@@ -244,16 +244,6 @@ namespace Intrepid2
      */
     Basis_Derived_HCURL_QUAD(int polyOrder) : Basis_Derived_HCURL_QUAD(polyOrder, polyOrder) {}
 
-    /** \brief  Returns basis name
-
-        \return the name of the basis
-    */
-    virtual
-    const char*
-    getName() const {
-      return "Intrepid2_DerivedBasis_HCURL_QUAD";
-    }
-
     /** \brief True if orientation is required
     */
     virtual bool requireOrientation() const {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HDIV_HEX.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HDIV_HEX.hpp
@@ -375,16 +375,6 @@ namespace Intrepid2
      */
     Basis_Derived_HDIV_HEX(int polyOrder) : Basis_Derived_HDIV_HEX(polyOrder, polyOrder, polyOrder) {}
 
-    /** \brief  Returns basis name
-
-        \return the name of the basis
-    */
-    virtual
-    const char*
-    getName() const {
-      return "Intrepid2_DerivedBasis_HDIV_HEX";
-    }
-
     /** \brief True if orientation is required
     */
     virtual bool requireOrientation() const {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HDIV_QUAD.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HDIV_QUAD.hpp
@@ -238,16 +238,6 @@ namespace Intrepid2
      */
     Basis_Derived_HDIV_QUAD(int polyOrder) : Basis_Derived_HDIV_QUAD(polyOrder, polyOrder) {}
 
-    /** \brief  Returns basis name
-
-        \return the name of the basis
-    */
-    virtual
-    const char*
-    getName() const {
-      return "Intrepid2_DerivedBasis_HDIV_QUAD";
-    }
-
     /** \brief True if orientation is required
     */
     virtual bool requireOrientation() const {

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HGRAD_HEX.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HGRAD_HEX.hpp
@@ -99,16 +99,6 @@ namespace Intrepid2
         \param [in] polyOrder - the polynomial order to use in all dimensions.
      */
     Basis_Derived_HGRAD_HEX(int polyOrder) : Basis_Derived_HGRAD_HEX(polyOrder, polyOrder, polyOrder) {}
-    
-    /** \brief  Returns basis name
-
-        \return the name of the basis
-    */
-    virtual
-    const char*
-    getName() const override {
-      return "Intrepid2_DerivedBasis_HGRAD_HEX";
-    }
 
     /** \brief True if orientation is required
     */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HGRAD_QUAD.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HGRAD_QUAD.hpp
@@ -87,16 +87,6 @@ namespace Intrepid2
         \param [in] polyOrder - the polynomial order to use in both dimensions.
      */
     Basis_Derived_HGRAD_QUAD(int polyOrder) : Basis_Derived_HGRAD_QUAD(polyOrder,polyOrder) {}
-    
-    /** \brief  Returns basis name
-
-        \return the name of the basis
-    */
-    virtual
-    const char*
-    getName() const override {
-      return "Intrepid2_DerivedBasis_HGRAD_QUAD";
-    }
 
     /** \brief True if orientation is required
     */

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DirectSumBasis.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DirectSumBasis.hpp
@@ -73,6 +73,8 @@ namespace Intrepid2
   protected:
     Basis1 basis1_;
     Basis2 basis2_;
+    
+    std::string name_;
   public:
     using OrdinalTypeArray1DHost = typename Basis1::OrdinalTypeArray1DHost;
     using OrdinalTypeArray2DHost = typename Basis1::OrdinalTypeArray2DHost;
@@ -101,6 +103,12 @@ namespace Intrepid2
       
       this->basisCardinality_  = basis1.getCardinality() + basis2.getCardinality();
       this->basisDegree_       = std::max(basis1.getDegree(), basis2.getDegree());
+      
+      {
+        std::ostringstream basisName;
+        basisName << basis1.getName() << " + " << basis2.getName();
+        name_ = basisName.str();
+      }
       
       this->basisCellTopology_ = basis1.getBaseCellTopology();
       this->basisType_         = basis1.getBasisType();
@@ -212,6 +220,16 @@ namespace Intrepid2
       
       basis1_.getDofCoords(dofCoords1);
       basis2_.getDofCoords(dofCoords2);
+    }
+    
+    /** \brief  Returns basis name
+     
+     \return the name of the basis
+     */
+    virtual
+    const char*
+    getName() const override {
+      return name_.c_str();
     }
     
     // since the getValues() below only overrides the FEM variant, we specify that

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_LegendreBasis_HVOL_LINE.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_LegendreBasis_HVOL_LINE.hpp
@@ -258,6 +258,16 @@ namespace Intrepid2
     // (It's an error to use the FVD variant on this basis.)
     using Basis<ExecutionSpace,OutputScalar,PointScalar>::getValues;
     
+    /** \brief  Returns basis name
+     
+     \return the name of the basis
+     */
+    virtual
+    const char*
+    getName() const override {
+      return "Intrepid2_LegendreBasis_HVOL_LINE";
+    }
+      
     /** \brief  Evaluation of a FEM basis on a <strong>reference cell</strong>.
 
         Returns values of <var>operatorType</var> acting on FEM basis functions for a set of

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_TensorBasis.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_TensorBasis.hpp
@@ -307,6 +307,8 @@ namespace Intrepid2
   protected:
     Basis1 basis1_;
     Basis2 basis2_;
+    
+    std::string name_; // name of the basis
   public:
     using BasisSuper = ::Intrepid2::Basis<typename Basis1::ExecutionSpace,typename Basis1::OutputValueType,typename Basis1::PointValueType>;
     
@@ -329,6 +331,12 @@ namespace Intrepid2
     {
       this->basisCardinality_  = basis1.getCardinality() * basis2.getCardinality();
       this->basisDegree_       = std::max(basis1.getDegree(), basis2.getDegree());
+      
+      {
+        std::ostringstream basisName;
+        basisName << basis1.getName() << " x " << basis2.getName();
+        name_ = basisName.str();
+      }
       
       // set cell topology
       shards::CellTopology cellTopo1 = basis1.getBaseCellTopology();
@@ -543,6 +551,16 @@ namespace Intrepid2
                                }
                              }
                            });
+    }
+    
+    /** \brief  Returns basis name
+     
+     \return the name of the basis
+     */
+    virtual
+    const char*
+    getName() const override {
+      return name_.c_str();
     }
     
     /** \brief  Given "Dk" enumeration indices for the component bases, returns a Dk enumeration index for the composite basis.

--- a/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefCoeffMatrix_HCURL.hpp
+++ b/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefCoeffMatrix_HCURL.hpp
@@ -125,20 +125,26 @@ namespace Intrepid2 {
       // Function space
       //      
       {
-        const std::string cellBasisName(cellBasis.getName());
-        if (cellBasisName.find("HCURL") != std::string::npos) {
-          const std::string subcellBasisName(subcellBasis.getName());
+        const bool cellBasisIsHCURL = cellBasis.getFunctionSpace() == FUNCTION_SPACE_HCURL;
+        if (cellBasisIsHCURL) {
+          const bool subcellBasisIsHGRAD = subcellBasis.getFunctionSpace() == FUNCTION_SPACE_HGRAD;
+          const bool subcellBasisIsHVOL  = subcellBasis.getFunctionSpace() == FUNCTION_SPACE_HVOL;
+          const bool subcellBasisIsHCURL = subcellBasis.getFunctionSpace() == FUNCTION_SPACE_HCURL;
+          const bool cellIsTri  = cellBaseKey == shards::Triangle<>::key;
+          const bool cellIsTet  = cellBaseKey == shards::Tetrahedron<>::key;
+          const bool cellIsHex  = cellBaseKey == shards::Hexahedron<>::key;
+          const bool cellIsQuad = cellBaseKey == shards::Quadrilateral<>::key;
           // edge hcurl is hgrad with gauss legendre points
           switch (subcellDim) {
           case 1: {
             //TODO: Hex, QUAD, TET and TRI element should have the same 1d basis
-            if ((cellBasisName.find("HEX") != std::string::npos) || (cellBasisName.find("QUAD") != std::string::npos)) {
-              INTREPID2_TEST_FOR_EXCEPTION( subcellBasisName.find("HGRAD") == std::string::npos,
+            if (cellIsHex || cellIsQuad) {
+              INTREPID2_TEST_FOR_EXCEPTION( !subcellBasisIsHGRAD,
                                           std::logic_error,
                                           ">>> ERROR (Intrepid::OrientationTools::getCoeffMatrix_HCURL): " 
                                           "subcellBasis function space (1d) is not consistent to cellBasis.");
-            } else if ((cellBasisName.find("TET") != std::string::npos) || (cellBasisName.find("TRI") != std::string::npos)) {
-              INTREPID2_TEST_FOR_EXCEPTION( subcellBasisName.find("HVOL") == std::string::npos,
+            } else if (cellIsTet || cellIsTri) {
+              INTREPID2_TEST_FOR_EXCEPTION( !subcellBasisIsHVOL,
                                           std::logic_error,
                                           ">>> ERROR (Intrepid::OrientationTools::getCoeffMatrix_HCURL): " 
                                           "subcellBasis function space (1d) is not consistent to cellBasis.");
@@ -146,7 +152,7 @@ namespace Intrepid2 {
             break;
           }
           case 2: {
-            INTREPID2_TEST_FOR_EXCEPTION( subcellBasisName.find("HCURL") == std::string::npos,
+            INTREPID2_TEST_FOR_EXCEPTION( !subcellBasisIsHCURL,
                                           std::logic_error,
                                           ">>> ERROR (Intrepid::OrientationTools::getCoeffMatrix_HCURL): " 
                                           "subcellBasis function space (2d) is not consistent to cellBasis.");

--- a/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefCoeffMatrix_HDIV.hpp
+++ b/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefCoeffMatrix_HDIV.hpp
@@ -130,23 +130,30 @@ namespace Intrepid2 {
       // Function space
       //
       {
-        const std::string cellBasisName(cellBasis.getName());
-        INTREPID2_TEST_FOR_EXCEPTION( cellBasisName.find("HDIV") == std::string::npos,
+        const bool isHDIV = cellBasis.getFunctionSpace() == FUNCTION_SPACE_HDIV;
+        INTREPID2_TEST_FOR_EXCEPTION( !isHDIV,
                                       std::logic_error,
                                       ">>> ERROR (Intrepid::OrientationTools::getCoeffMatrix_HDIV): "
                                       "cellBasis is not HDIV.");
         {
+          const bool subcellBasisIsHGRAD = subcellBasis.getFunctionSpace() == FUNCTION_SPACE_HGRAD;
+          const bool subcellBasisIsHVOL  = subcellBasis.getFunctionSpace() == FUNCTION_SPACE_HVOL;
+          const bool cellIsTri  = cellBaseKey == shards::Triangle<>::key;
+          const bool cellIsTet  = cellBaseKey == shards::Tetrahedron<>::key;
+          const bool cellIsHex  = cellBaseKey == shards::Hexahedron<>::key;
+          const bool cellIsQuad = cellBaseKey == shards::Quadrilateral<>::key;
+            
           const std::string subcellBasisName(subcellBasis.getName());
           switch (subcellDim) {
           case 1: {
             //TODO: Hex, QUAD, TET and TRI element should have the same 1d basis
-            if ((cellBasisName.find("HEX") != std::string::npos) || (cellBasisName.find("QUAD") != std::string::npos)) {
-              INTREPID2_TEST_FOR_EXCEPTION( subcellBasisName.find("HGRAD") == std::string::npos,
+            if (cellIsHex || cellIsQuad) {
+              INTREPID2_TEST_FOR_EXCEPTION( !subcellBasisIsHGRAD,
                                           std::logic_error,
                                           ">>> ERROR (Intrepid::OrientationTools::getCoeffMatrix_DIV): " 
                                           "subcellBasis function space (1d) is not consistent to cellBasis, which should be open line hgrad, order -1.");
-            } else if ((cellBasisName.find("TET") != std::string::npos) || (cellBasisName.find("TRI") != std::string::npos)) {
-              INTREPID2_TEST_FOR_EXCEPTION( subcellBasisName.find("HVOL") == std::string::npos,
+            } else if (cellIsTet || cellIsTri) {
+              INTREPID2_TEST_FOR_EXCEPTION( !subcellBasisIsHVOL,
                                           std::logic_error,
                                           ">>> ERROR (Intrepid::OrientationTools::getCoeffMatrix_DIV): " 
                                           "subcellBasis function space (1d) is not consistent to cellBasis, which should be HVOL line, order -1.");
@@ -156,13 +163,13 @@ namespace Intrepid2 {
           case 2: {
             if        (subcellBaseKey == shards::Quadrilateral<>::key) {
               // quad face basis is tensor product of open line basis functions
-              INTREPID2_TEST_FOR_EXCEPTION( subcellBasisName.find("HGRAD") == std::string::npos,
+              INTREPID2_TEST_FOR_EXCEPTION( !subcellBasisIsHGRAD,
                                             std::logic_error,
                                             ">>> ERROR (Intrepid::OrientationTools::getCoeffMatrix_HDIV): "
                                             "subcellBasis function space is not compatible, which should be open line hgrad, order -1.");
             } else if (subcellBaseKey == shards::Triangle<>::key) {
               // triangle face basis comes from HVOL basis
-              INTREPID2_TEST_FOR_EXCEPTION( subcellBasisName.find("HVOL") == std::string::npos,
+              INTREPID2_TEST_FOR_EXCEPTION( !subcellBasisIsHVOL,
                                             std::logic_error,
                                             ">>> ERROR (Intrepid::OrientationTools::getCoeffMatrix_HDIV): "
                                             "subcellBasis function space is not compatible, which should HVOL, order-1.");

--- a/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefCoeffMatrix_HGRAD.hpp
+++ b/packages/intrepid2/src/Orientation/Intrepid2_OrientationToolsDefCoeffMatrix_HGRAD.hpp
@@ -116,10 +116,10 @@ namespace Intrepid2 {
       //
       
       {
-        const std::string cellBasisName(cellBasis.getName());
-        if (cellBasisName.find("HGRAD") != std::string::npos) {
-          const std::string subcellBasisName(subcellBasis.getName());
-          INTREPID2_TEST_FOR_EXCEPTION( subcellBasisName.find("HGRAD") == std::string::npos,
+        const bool cellBasisIsHGRAD = cellBasis.getFunctionSpace() == FUNCTION_SPACE_HGRAD;
+        const bool subcellBasisIsHGRAD = subcellBasis.getFunctionSpace() == FUNCTION_SPACE_HGRAD;
+        if (cellBasisIsHGRAD) {
+          INTREPID2_TEST_FOR_EXCEPTION( !subcellBasisIsHGRAD,
                                         std::logic_error,
                                         ">>> ERROR (Intrepid::OrientationTools::getCoeffMatrix_HGRAD): " \
                                         "subcellBasis function space is not consistent to cellBasis.");


### PR DESCRIPTION
@trilinos/intrepid2 

## Motivation
Some Intrepid2 components rely on basis names to track, for example, basis values in a map keyed on the basis name.  These can break if distinct bases return the same name.  This PR adds unique basis names for some recently added basis classes.

Along related lines, prior to this PR certain Intrepid2 components attempted to parse the basis name to determine e.g. function space and topology.  There are already direct methods provided by the basis that can be queried for these things, and the basis names added by this PR do not follow the naming convention assumed by these parsing strategies (tensor bases in this PR have names derived from their components).  In this PR, the direct methods are invoked, and the parsing strategy dropped.

## Related
Fixes #7071.