### PR TITLE
Pr python cleanup

### DIFF
--- a/cmake/std/PullRequestLinuxCudaDriver.sh
+++ b/cmake/std/PullRequestLinuxCudaDriver.sh
@@ -14,8 +14,8 @@ fi
 set -x
 
 #TODO: review appropriate job size
-bsub -x -Is -q rhel7F -n 16 -J $JOB_NAME -W $BSUB_CTEST_TIME_LIMIT \
-  $WORKSPACE/Trilinos/cmake/std/PullRequestLinuxDriver.sh
+bsub -x -Is -q rhel7F -n 16 -J ${JOB_NAME} -W ${BSUB_CTEST_TIME_LIMIT} \
+  ${WORKSPACE}/Trilinos/cmake/std/PullRequestLinuxDriver.sh
 
 # NOTE: Above, this bsub command should grab a single rhel7F (Firestone,
 # Dual-Socket POWER8, 8 cores per socket, K80 GPUs) node.  The option '-x'

--- a/cmake/std/PullRequestLinuxDriverMerge.py
+++ b/cmake/std/PullRequestLinuxDriverMerge.py
@@ -23,39 +23,40 @@ from __future__ import print_function
 import sys
 sys.dont_write_bytecode = True
 
-import os
 import argparse
+import os
 import subprocess
+from textwrap import dedent
 
 
 
 def write_header():
-    print('''--------------------------------------------------------------------------------
--
-- Begin: PullRequestLinuxDriver-Merge.py
--
---------------------------------------------------------------------------------''',
-          file=sys.stdout)
+    print(dedent('''\
+          --------------------------------------------------------------------------------
+          -
+          - Begin: PullRequestLinuxDriver-Merge.py
+          -
+          --------------------------------------------------------------------------------'''))
 
 
 def echoJenkinsVars(workspace):
-    print('''
-================================================================================
-Jenkins Environment Variables:
-- WORKSPACE    : {workspace}
+    print(dedent('''\
 
-================================================================================
-Environment:
+            ================================================================================
+            Jenkins Environment Variables:
+            - WORKSPACE    : {workspace}
 
-  pwd = {cwd}
-'''.format(workspace=workspace,
-           cwd=os.getcwd()), file=sys.stdout)
+            ================================================================================
+            Environment:
+
+              pwd = {cwd}
+            ''').format(workspace=workspace, cwd=os.getcwd()))
 
     for key in os.environ:
         print(key +' = ' + os.environ[key])
-    print('''
-================================================================================''',
-          file=sys.stdout)
+
+    print('\n' + 80*"=")
+
 
 
 def parseArgs():
@@ -93,14 +94,12 @@ def merge_branch(source_url, source_branch, target_branch, sourceSHA):
     if 'source_remote' in remote_list:
         print('git remote exists, removing it', file=sys.stdout)
         subprocess.check_call(['git', 'remote', 'rm', 'source_remote'])
-    subprocess.check_call(['git', 'remote', 'add', 'source_remote',
-                           source_url])
+    subprocess.check_call(['git', 'remote', 'add', 'source_remote', source_url])
 
     fetch_succeeded = False
     for i in range(3):
         try:
-            subprocess.check_call(['git', 'fetch', 'source_remote',
-                                   source_branch])
+            subprocess.check_call(['git', 'fetch', 'source_remote', source_branch])
             fetch_succeeded = True
             break
         except subprocess.CalledProcessError:
@@ -108,28 +107,20 @@ def merge_branch(source_url, source_branch, target_branch, sourceSHA):
     if not fetch_succeeded:
         raise SystemExit(12)
 
-    subprocess.check_call(['git', 'fetch', 'origin',
-                           target_branch])
-    subprocess.check_call(['git', 'reset', '--hard',
-                           'HEAD'])
-    subprocess.check_call(['git', 'checkout', '-B',
-                           target_branch, 'origin/' + target_branch])
-    subprocess.check_call(['git', 'merge', '--no-edit',
-                           'source_remote/' + source_branch]),
+    subprocess.check_call(['git', 'fetch', 'origin', target_branch])
+    subprocess.check_call(['git', 'reset', '--hard', 'HEAD'])
+    subprocess.check_call(['git', 'checkout', '-B', target_branch, 'origin/' + target_branch])
+    subprocess.check_call(['git', 'merge', '--no-edit', 'source_remote/' + source_branch]),
 
-    actual_source_SHA = subprocess.check_output(['git', 'rev-parse',
-                                                 'source_remote/' + source_branch])
+    actual_source_SHA = subprocess.check_output(['git', 'rev-parse', 'source_remote/' + source_branch])
 
     actual_source_SHA = actual_source_SHA.strip()
 
     if actual_source_SHA != sourceSHA:
         print('The SHA ({source_sha}) for the last commit on branch {source_branch}'.format(source_sha=actual_source_SHA,
-                                                                                            source_branch=source_branch),
-              file=sys.stdout)
-        print('  in repo {source_repo} is different than the expected SHA,'.format(source_repo=source_url),
-              file=sys.stdout)
-        print('  which is: {source_sha}.'.format(source_sha=sourceSHA),
-              file=sys.stdout)
+                                                                                            source_branch=source_branch))
+        print('  in repo {source_repo} is different than the expected SHA,'.format(source_repo=source_url))
+        print('  which is: {source_sha}.'.format(source_sha=sourceSHA))
         raise SystemExit(-1)
 
 
@@ -143,8 +134,7 @@ def run():
         os.chdir(os.path.join(arguments.workspaceDir, 'Trilinos'))
         print("Set CWD = {dirName}".format(dirName=os.path.join(
                                                  arguments.workspaceDir,
-                                                 'Trilinos')),
-              file=sys.stdout)
+                                                 'Trilinos')))
         write_header()
         echoJenkinsVars(arguments.workspaceDir)
         try:
@@ -156,20 +146,15 @@ def run():
             return_value = False
         except subprocess.CalledProcessError as cpe:
             return_value = False
-            print('Recieved subprocess.CalledProcessError - returned {error_num}'.format(error_num=cpe.returncode),
-                  file=sys.stdout)
-            print('  from command {cmd}'.format(cmd=cpe.cmd),
-                  file=sys.stdout)
-            print('  output {out}'.format(out=cpe.output),
-                  file=sys.stdout)
+            print('Recieved subprocess.CalledProcessError - returned {error_num}'.format(error_num=cpe.returncode))
+            print('  from command {cmd}'.format(cmd=cpe.cmd))
+            print('  output {out}'.format(out=cpe.output))
             try:
-                print('  stdout {out}'.format(out=cpe.stdout),
-                      file=sys.stdout)
+                print('  stdout {out}'.format(out=cpe.stdout))
             except AttributeError:
                 pass
             try:
-                print('  stderr {eout}'.format(eout=cpe.stderr),
-                      file=sys.stdout)
+                print('  stderr {eout}'.format(eout=cpe.stderr))
             except AttributeError:
                 pass
 

--- a/cmake/std/PullRequestLinuxDriverMerge.py
+++ b/cmake/std/PullRequestLinuxDriverMerge.py
@@ -118,9 +118,9 @@ def merge_branch(source_url, source_branch, target_branch, sourceSHA):
 
     if actual_source_SHA != sourceSHA:
         print('The SHA ({source_sha}) for the last commit on branch {source_branch}'.format(source_sha=actual_source_SHA,
-                                                                                            source_branch=source_branch))
-        print('  in repo {source_repo} is different than the expected SHA,'.format(source_repo=source_url))
-        print('  which is: {source_sha}.'.format(source_sha=sourceSHA))
+                                                                                            source_branch=source_branch), file=sys.stdout)
+        print('  in repo {source_repo} is different than the expected SHA,'.format(source_repo=source_url), file=sys.stdout)
+        print('  which is: {source_sha}.'.format(source_sha=sourceSHA), file=sys.stdout)
         raise SystemExit(-1)
 
 
@@ -146,15 +146,15 @@ def run():
             return_value = False
         except subprocess.CalledProcessError as cpe:
             return_value = False
-            print('Recieved subprocess.CalledProcessError - returned {error_num}'.format(error_num=cpe.returncode))
-            print('  from command {cmd}'.format(cmd=cpe.cmd))
-            print('  output {out}'.format(out=cpe.output))
+            print('Recieved subprocess.CalledProcessError - returned {error_num}'.format(error_num=cpe.returncode), file=sys.stdout)
+            print('  from command {cmd}'.format(cmd=cpe.cmd), file=sys.stdout)
+            print('  output {out}'.format(out=cpe.output), file=sys.stdout)
             try:
-                print('  stdout {out}'.format(out=cpe.stdout))
+                print('  stdout {out}'.format(out=cpe.stdout), file=sys.stdout)
             except AttributeError:
                 pass
             try:
-                print('  stderr {eout}'.format(eout=cpe.stderr))
+                print('  stderr {eout}'.format(eout=cpe.stderr), file=sys.stdout)
             except AttributeError:
                 pass
 

--- a/cmake/std/PullRequestLinuxDriverTest.py
+++ b/cmake/std/PullRequestLinuxDriverTest.py
@@ -657,6 +657,8 @@ def run():
     print('Set CWD = {}'.format(os.getcwd()))
 
     # Execute the call to ctest.
+    # - NOTE: simple_testing.cmake can be found in the TFW_single_configure_support_scripts
+    #         repository.
     subprocess.check_call(['ctest', '-S', 'simple_testing.cmake',
                            '-Dbuild_name={}'.format(build_name),
                            '-Dskip_by_parts_submit=OFF',

--- a/cmake/std/PullRequestLinuxDriverTest.py
+++ b/cmake/std/PullRequestLinuxDriverTest.py
@@ -67,66 +67,42 @@ except ImportError:
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(
-        description='Parse the repo and build information')
-    parser.add_argument('sourceRepo',
-                        help='Repo with the new changes',
-                        action='store')
-    parser.add_argument('sourceBranch',
-                        help='Branch with the new changes',
-                        action='store')
-    parser.add_argument('targetRepo',
-                        help='Repo to merge into',
-                        action='store')
-    parser.add_argument('targetBranch',
-                        help='Branch to merge to',
-                        action='store')
-    parser.add_argument('job_base_name',
-                        help='The jenkins job base name')
-    parser.add_argument('github_pr_number',
-                        help='The github PR number')
-    parser.add_argument('job_number',
-                        help='The jenkins build number')
-    parser.add_argument('workspaceDir',
-                        help='The local workspace directory jenkins set up')
+    parser = argparse.ArgumentParser(description='Parse the repo and build information')
+
+    parser.add_argument('sourceRepo',   action='store', help='Repo with the new changes')
+    parser.add_argument('sourceBranch', action='store', help='Branch with the new changes')
+    parser.add_argument('targetRepo',   action='store', help='Repo to merge into')
+    parser.add_argument('targetBranch', action='store', help='Branch to merge to')
+
+    parser.add_argument('job_base_name',    help='The jenkins job base name')
+    parser.add_argument('github_pr_number', help='The github PR number')
+    parser.add_argument('job_number',       help='The jenkins build number')
+    parser.add_argument('workspaceDir',     help='The local workspace directory jenkins set up')
+
     arguments = parser.parse_args()
+
     return arguments
 
 
 def print_input_variables(arguments):
-    print("\n" + "="*90, file=sys.stdout)
-    print("Jenkins Input Variables:", file=sys.stdout)
-    print("- JOB_BASE_NAME: {job_base_name}".format(
-        job_base_name=arguments.job_base_name),
-          file=sys.stdout)
-    print("- WORKSPACE    : {workspace}".format(
-        workspace=arguments.workspaceDir),
-          file=sys.stdout)
-    print("\n" + "="*90, file=sys.stdout)
-    print("Parameters:", file=sys.stdout)
-    print("- TRILINOS_SOURCE_REPO  : {source_repo}".format(
-        source_repo=arguments.sourceRepo),
-          file=sys.stdout)
-    print("- TRILINOS_SOURCE_BRANCH: {source_branch}\n".format(
-        source_branch=arguments.sourceBranch),
-          file=sys.stdout)
-    print("- TRILINOS_TARGET_REPO  : {target_repo}".format(
-        target_repo=arguments.targetRepo),
-          file=sys.stdout)
-    print("- TRILINOS_TARGET_BRANCH: {target_branch}\n".format(
-        target_branch=arguments.targetBranch),
-          file=sys.stdout)
-    print("- PULLREQUESTNUM        : {num}".format(
-        num=arguments.github_pr_number),
-          file=sys.stdout)
-    print("- BUILD_NUMBER          : {num}".format(
-        num=arguments.job_number),
-          file=sys.stdout)
-    print("\n" + "="*90, file=sys.stdout)
+    print("\n" + "="*90)
+    print("Jenkins Input Variables:")
+    print("- JOB_BASE_NAME: {job_base_name}".format(**vars(arguments)))
+    print("- WORKSPACE    : {workspaceDir}".format(**vars(arguments)))
+    print("\n" + "="*90)
+    print("Parameters:")
+    print("- TRILINOS_SOURCE_REPO  : {sourceRepo}".format(**vars(arguments)))
+    print("- TRILINOS_SOURCE_BRANCH: {sourceBranch}\n".format(**vars(arguments)))
+    print("- TRILINOS_TARGET_REPO  : {targetRepo}".format(**vars(arguments)))
+    print("- TRILINOS_TARGET_BRANCH: {targetBranch}\n".format(**vars(arguments)))
+    print("- PULLREQUESTNUM        : {github_pr_number}".format(**vars(arguments)))
+    print("- BUILD_NUMBER          : {job_number}".format(**vars(arguments)))
+    print("\n" + "="*90)
 
 
 def confirmGitVersion():
     """
+    Verify that the version of Git we're using is > 2.10
     """
     git_version_string = subprocess.check_output(['git', '--version'])
     git_version_number_string = git_version_string[git_version_string.rfind(' '):]
@@ -142,6 +118,9 @@ def confirmGitVersion():
     return None
 
 
+
+# TODO: moduleMap & environMap should be moved into files.
+#       Let's try YAML since it allows comments, etc.
 def setBuildEnviron(arguments):
     """
     TODO: Needs explanation.
@@ -152,262 +131,263 @@ def setBuildEnviron(arguments):
           than JSON IMO.)
     """
 
-    moduleMap = {'Trilinos_pullrequest_gcc_4.8.4':
-                     ['sems-env',
-                     'sems-git/2.10.1',
-                     'sems-gcc/4.8.4',
-                     'sems-openmpi/1.10.1',
-                     'sems-python/2.7.9',
-                     'sems-boost/1.63.0/base',
-                     'sems-zlib/1.2.8/base',
-                     'sems-hdf5/1.10.6/parallel',
-                     'sems-netcdf/4.7.3/parallel',
-                     'sems-parmetis/4.0.3/parallel',
-                     'sems-scotch/6.0.3/nopthread_64bit_parallel',
-                     'sems-superlu/4.3/base',
-                     'sems-cmake/3.10.3',
-                     'atdm-env',
-                     'atdm-ninja_fortran/1.7.2'],
-                 'Trilinos_pullrequest_gcc_4.9.3_SERIAL':
-                     ['sems-env',
-                      'sems-git/2.10.1',
-                      'sems-gcc/4.9.3',
-                      'sems-python/2.7.9',
-                      'sems-boost/1.63.0/base',
-                      'sems-zlib/1.2.8/base',
-                      'sems-hdf5/1.10.6/base',
-                      'sems-netcdf/4.7.3/base',
-                      'sems-metis/5.1.0/base',
-                      'sems-superlu/4.3/base',
-                      'sems-cmake/3.10.3',
-                      'atdm-env',
-                      'atdm-ninja_fortran/1.7.2'],
-                 'Trilinos_pullrequest_python_2':
-                     ['sems-git/2.10.1',
-                      'sems-gcc/7.2.0',
-                      ('', 'sems-python/2.7.9'),
-                      'sems-cmake/3.10.3',
-                      'atdm-env',
-                      'atdm-ninja_fortran/1.7.2'],
-                'Trilinos_pullrequest_python_3':
-                     ['sems-git/2.10.1',
-                      'sems-gcc/7.2.0',
-                      ('', 'sems-python/2.7.9'),
-                      'sems-cmake/3.10.3',
-                      'atdm-env',
-                      'atdm-ninja_fortran/1.7.2'],
-                'Trilinos_pullrequest_gcc_7.2.0':
-                     ['sems-env',
-                     'sems-git/2.10.1',
-                     'sems-gcc/7.2.0',
-                     'sems-openmpi/1.10.1',
-                     'sems-python/2.7.9',
-                     'sems-boost/1.63.0/base',
-                     'sems-zlib/1.2.8/base',
-                     'sems-hdf5/1.10.6/parallel',
-                     'sems-netcdf/4.7.3/parallel',
-                     'sems-parmetis/4.0.3/parallel',
-                     'sems-scotch/6.0.3/nopthread_64bit_parallel',
-                     'sems-superlu/4.3/base',
-                     'sems-cmake/3.10.3',
-                     'atdm-env',
-                     'atdm-ninja_fortran/1.7.2'],
-                'Trilinos_pullrequest_gcc_8.3.0':
-                     ['sems-env',
-                     'sems-git/2.10.1',
-                     'sems-gcc/8.3.0',
-                     'sems-openmpi/1.10.1',
-                     'sems-python/2.7.9',
-                     'sems-boost/1.66.0/base',
-                     'sems-zlib/1.2.8/base',
-                     'sems-hdf5/1.10.6/parallel',
-                     'sems-netcdf/4.7.3/parallel',
-                     'sems-parmetis/4.0.3/parallel',
-                     'sems-scotch/6.0.3/nopthread_64bit_parallel',
-                     'sems-superlu/4.3/base',
-                     'sems-cmake/3.17.1',
-                     'sems-ninja_fortran/1.10.0',
-                     'atdm-env'],
-                'Trilinos_pullrequest_intel_17.0.1':
-                     ['sems-env',
-                     'sems-git/2.10.1',
-                     'sems-gcc/4.9.3',
-                     'sems-intel/17.0.1',
-                     'sems-mpich/3.2',
-                     'sems-python/2.7.9',
-                     'sems-boost/1.63.0/base',
-                     'sems-zlib/1.2.8/base',
-                     'sems-hdf5/1.10.6/parallel',
-                     'sems-netcdf/4.7.3/parallel',
-                     'sems-parmetis/4.0.3/parallel',
-                     'sems-scotch/6.0.3/nopthread_64bit_parallel',
-                     'sems-superlu/4.3/base',
-                     'sems-cmake/3.10.3',
-                     'atdm-env',
-                     'atdm-ninja_fortran/1.7.2'],
-                'Trilinos_pullrequest_clang_7.0.1':
-                     ['sems-env',
-                     'sems-git/2.10.1',
-                     'sems-gcc/5.3.0',
-                     'sems-clang/7.0.1',
-                     'sems-openmpi/1.10.1',
-                     'sems-python/2.7.9',
-                     'sems-boost/1.63.0/base',
-                     'sems-zlib/1.2.8/base',
-                     'sems-hdf5/1.10.6/parallel',
-                     'sems-netcdf/4.7.3/parallel',
-                     'sems-parmetis/4.0.3/parallel',
-                     'sems-scotch/6.0.3/nopthread_64bit_parallel',
-                     'sems-superlu/4.3/base',
-                     'sems-cmake/3.12.2',
-                     'atdm-env',
-                     'atdm-ninja_fortran/1.7.2'],
-                'Trilinos_pullrequest_clang_9.0.0':
-                     ['sems-env',
-                     'sems-git/2.10.1',
-                     'sems-gcc/5.3.0',
-                     'sems-clang/9.0.0',
-                     'sems-openmpi/1.10.1',
-                     'sems-python/2.7.9',
-                     'sems-boost/1.63.0/base',
-                     'sems-zlib/1.2.8/base',
-                     'sems-hdf5/1.10.6/parallel',
-                     'sems-netcdf/4.7.3/parallel',
-                     'sems-parmetis/4.0.3/parallel',
-                     'sems-scotch/6.0.3/nopthread_64bit_parallel',
-                     'sems-superlu/4.3/base',
-                     'sems-cmake/3.12.2',
-                     'atdm-env',
-                     'atdm-ninja_fortran/1.7.2'],
-                'Trilinos_pullrequest_cuda_9.2':
-                     ['git/2.10.1',
-                     'devpack/20180521/openmpi/2.1.2/gcc/7.2.0/cuda/9.2.88',
-                      ('openblas/0.2.20/gcc/7.2.0', 'netlib/3.8.0/gcc/7.2.0')]}
+    moduleMap = {"Trilinos_pullrequest_gcc_4.8.4":
+                     ["sems-env",
+                     "sems-git/2.10.1",
+                     "sems-gcc/4.8.4",
+                     "sems-openmpi/1.10.1",
+                     "sems-python/2.7.9",
+                     "sems-boost/1.63.0/base",
+                     "sems-zlib/1.2.8/base",
+                     "sems-hdf5/1.10.6/parallel",
+                     "sems-netcdf/4.7.3/parallel",
+                     "sems-parmetis/4.0.3/parallel",
+                     "sems-scotch/6.0.3/nopthread_64bit_parallel",
+                     "sems-superlu/4.3/base",
+                     "sems-cmake/3.10.3",
+                     "atdm-env",
+                     "atdm-ninja_fortran/1.7.2"],
+                 "Trilinos_pullrequest_gcc_4.9.3_SERIAL":
+                     ["sems-env",
+                      "sems-git/2.10.1",
+                      "sems-gcc/4.9.3",
+                      "sems-python/2.7.9",
+                      "sems-boost/1.63.0/base",
+                      "sems-zlib/1.2.8/base",
+                      "sems-hdf5/1.10.6/base",
+                      "sems-netcdf/4.7.3/base",
+                      "sems-metis/5.1.0/base",
+                      "sems-superlu/4.3/base",
+                      "sems-cmake/3.10.3",
+                      "atdm-env",
+                      "atdm-ninja_fortran/1.7.2"],
+                 "Trilinos_pullrequest_python_2":
+                     ["sems-git/2.10.1",
+                      "sems-gcc/7.2.0",
+                      ("", "sems-python/2.7.9"),
+                      "sems-cmake/3.10.3",
+                      "atdm-env",
+                      "atdm-ninja_fortran/1.7.2"],
+                "Trilinos_pullrequest_python_3":
+                     ["sems-git/2.10.1",
+                      "sems-gcc/7.2.0",
+                      ("", "sems-python/2.7.9"),
+                      "sems-cmake/3.10.3",
+                      "atdm-env",
+                      "atdm-ninja_fortran/1.7.2"],
+                "Trilinos_pullrequest_gcc_7.2.0":
+                     ["sems-env",
+                     "sems-git/2.10.1",
+                     "sems-gcc/7.2.0",
+                     "sems-openmpi/1.10.1",
+                     "sems-python/2.7.9",
+                     "sems-boost/1.63.0/base",
+                     "sems-zlib/1.2.8/base",
+                     "sems-hdf5/1.10.6/parallel",
+                     "sems-netcdf/4.7.3/parallel",
+                     "sems-parmetis/4.0.3/parallel",
+                     "sems-scotch/6.0.3/nopthread_64bit_parallel",
+                     "sems-superlu/4.3/base",
+                     "sems-cmake/3.10.3",
+                     "atdm-env",
+                     "atdm-ninja_fortran/1.7.2"],
+                "Trilinos_pullrequest_gcc_8.3.0":
+                     ["sems-env",
+                     "sems-git/2.10.1",
+                     "sems-gcc/8.3.0",
+                     "sems-openmpi/1.10.1",
+                     "sems-python/2.7.9",
+                     "sems-boost/1.66.0/base",
+                     "sems-zlib/1.2.8/base",
+                     "sems-hdf5/1.10.6/parallel",
+                     "sems-netcdf/4.7.3/parallel",
+                     "sems-parmetis/4.0.3/parallel",
+                     "sems-scotch/6.0.3/nopthread_64bit_parallel",
+                     "sems-superlu/4.3/base",
+                     "sems-cmake/3.17.1",
+                     "sems-ninja_fortran/1.10.0",
+                     "atdm-env"
+                     ],
+                "Trilinos_pullrequest_intel_17.0.1":
+                     ["sems-env",
+                     "sems-git/2.10.1",
+                     "sems-gcc/4.9.3",
+                     "sems-intel/17.0.1",
+                     "sems-mpich/3.2",
+                     "sems-python/2.7.9",
+                     "sems-boost/1.63.0/base",
+                     "sems-zlib/1.2.8/base",
+                     "sems-hdf5/1.10.6/parallel",
+                     "sems-netcdf/4.7.3/parallel",
+                     "sems-parmetis/4.0.3/parallel",
+                     "sems-scotch/6.0.3/nopthread_64bit_parallel",
+                     "sems-superlu/4.3/base",
+                     "sems-cmake/3.10.3",
+                     "atdm-env",
+                     "atdm-ninja_fortran/1.7.2"],
+                "Trilinos_pullrequest_clang_7.0.1":
+                     ["sems-env",
+                     "sems-git/2.10.1",
+                     "sems-gcc/5.3.0",
+                     "sems-clang/7.0.1",
+                     "sems-openmpi/1.10.1",
+                     "sems-python/2.7.9",
+                     "sems-boost/1.63.0/base",
+                     "sems-zlib/1.2.8/base",
+                     "sems-hdf5/1.10.6/parallel",
+                     "sems-netcdf/4.7.3/parallel",
+                     "sems-parmetis/4.0.3/parallel",
+                     "sems-scotch/6.0.3/nopthread_64bit_parallel",
+                     "sems-superlu/4.3/base",
+                     "sems-cmake/3.12.2",
+                     "atdm-env",
+                     "atdm-ninja_fortran/1.7.2"],
+                "Trilinos_pullrequest_clang_9.0.0":
+                     ["sems-env",
+                     "sems-git/2.10.1",
+                     "sems-gcc/5.3.0",
+                     "sems-clang/9.0.0",
+                     "sems-openmpi/1.10.1",
+                     "sems-python/2.7.9",
+                     "sems-boost/1.63.0/base",
+                     "sems-zlib/1.2.8/base",
+                     "sems-hdf5/1.10.6/parallel",
+                     "sems-netcdf/4.7.3/parallel",
+                     "sems-parmetis/4.0.3/parallel",
+                     "sems-scotch/6.0.3/nopthread_64bit_parallel",
+                     "sems-superlu/4.3/base",
+                     "sems-cmake/3.12.2",
+                     "atdm-env",
+                     "atdm-ninja_fortran/1.7.2"],
+                "Trilinos_pullrequest_cuda_9.2":
+                     ["git/2.10.1",
+                     "devpack/20180521/openmpi/2.1.2/gcc/7.2.0/cuda/9.2.88",
+                      ("openblas/0.2.20/gcc/7.2.0", "netlib/3.8.0/gcc/7.2.0")]}
 
     environMap = {
-                 'Trilinos_pullrequest_gcc_4.8.4':
-                      {'OMP_NUM_THREADS': '2'},
-                  'Trilinos_pullrequest_gcc_4.9.3_SERIAL':
-                      {'OMP_NUM_THREADS': '2'},
-                 'Trilinos_pullrequest_python_2':
-                      {'PYTHONPATH':
+                 "Trilinos_pullrequest_gcc_4.8.4":
+                      {"OMP_NUM_THREADS": "2"},
+                  "Trilinos_pullrequest_gcc_4.9.3_SERIAL":
+                      {"OMP_NUM_THREADS": "2"},
+                 "Trilinos_pullrequest_python_2":
+                      {"PYTHONPATH":
                            os.path.join(os.path.sep,
-                                        'projects',
-                                        'sierra',
-                                        'linux_rh7',
-                                        'install',
-                                        'Python',
-                                        'extras',
-                                        'lib',
-                                        'python2.7',
-                                        'site-packages'),
-                       'MANPATH':
+                                        "projects",
+                                        "sierra",
+                                        "linux_rh7",
+                                        "install",
+                                        "Python",
+                                        "extras",
+                                        "lib",
+                                        "python2.7",
+                                        "site-packages"),
+                       "MANPATH":
                            os.path.join(os.path.sep,
-                                        'projects',
-                                        'sierra',
-                                        'linux_rh7',
-                                        'install',
-                                        'Python',
-                                        '2.7.15',
-                                        'share',
-                                        'man'),
-                       'PATH': os.path.join(os.path.sep,
-                                            'projects',
-                                            'sierra',
-                                            'linux_rh7',
-                                            'install',
-                                            'Python',
-                                            '2.7.15',
-                                            'bin') + os.pathsep +
+                                        "projects",
+                                        "sierra",
+                                        "linux_rh7",
+                                        "install",
+                                        "Python",
+                                        "2.7.15",
+                                        "share",
+                                        "man"),
+                       "PATH": os.path.join(os.path.sep,
+                                            "projects",
+                                            "sierra",
+                                            "linux_rh7",
+                                            "install",
+                                            "Python",
+                                            "2.7.15",
+                                            "bin") + os.pathsep +
                                os.path.join(os.path.sep,
-                                            'projects',
-                                            'sierra',
-                                            'linux_rh7',
-                                            'install',
-                                            'Python',
-                                            'extras'
-                                            'bin')},
-                 'Trilinos_pullrequest_python_3':
-                      {'PYTHONPATH':
+                                            "projects",
+                                            "sierra",
+                                            "linux_rh7",
+                                            "install",
+                                            "Python",
+                                            "extras"
+                                            "bin")},
+                 "Trilinos_pullrequest_python_3":
+                      {"PYTHONPATH":
                            os.path.join(os.path.sep,
-                                        'projects',
-                                        'sierra',
-                                        'linux_rh7',
-                                        'install',
-                                        'Python',
-                                        'extras',
-                                        'lib',
-                                        'python3.6',
-                                        'site-packages'),
-                       'MANPATH':
+                                        "projects",
+                                        "sierra",
+                                        "linux_rh7",
+                                        "install",
+                                        "Python",
+                                        "extras",
+                                        "lib",
+                                        "python3.6",
+                                        "site-packages"),
+                       "MANPATH":
                            os.path.join(os.path.sep,
-                                        'projects',
-                                        'sierra',
-                                        'linux_rh7',
-                                        'install',
-                                        'Python',
-                                        '3.6.3',
-                                        'share',
-                                        'man'),
-                       'PATH': os.path.join(os.path.sep,
-                                            'projects',
-                                            'sierra',
-                                            'linux_rh7',
-                                            'install',
-                                            'Python',
-                                            '3.6.3',
-                                            'bin') + os.pathsep +
+                                        "projects",
+                                        "sierra",
+                                        "linux_rh7",
+                                        "install",
+                                        "Python",
+                                        "3.6.3",
+                                        "share",
+                                        "man"),
+                       "PATH": os.path.join(os.path.sep,
+                                            "projects",
+                                            "sierra",
+                                            "linux_rh7",
+                                            "install",
+                                            "Python",
+                                            "3.6.3",
+                                            "bin") + os.pathsep +
                                os.path.join(os.path.sep,
-                                            'projects',
-                                            'sierra',
-                                            'linux_rh7',
-                                            'install',
-                                            'Python',
-                                            'extras'
-                                            'bin')},
-                 'Trilinos_pullrequest_gcc_7.2.0':
-                      {'SEMS_FORCE_LOCAL_COMPILER_VERSION': '4.9.3',
-                       'OMP_NUM_THREADS': '2'},
-                 'Trilinos_pullrequest_gcc_8.3.0':
-                      {'SEMS_FORCE_LOCAL_COMPILER_VERSION': '4.9.3',
-                       'OMP_NUM_THREADS': '2'},
-                 'Trilinos_pullrequest_intel_17.0.1':
-                      {'SEMS_FORCE_LOCAL_COMPILER_VERSION': '4.9.3',
-                       'OMP_NUM_THREADS': '2'},
-                 'Trilinos_pullrequest_clang_7.0.1':
-                      {'SEMS_FORCE_LOCAL_COMPILER_VERSION': '5.3.0',
-                       'OMP_NUM_THREADS': '2'},
-                 'Trilinos_pullrequest_clang_9.0.0':
-                      {'SEMS_FORCE_LOCAL_COMPILER_VERSION': '5.3.0',
-                       'OMP_NUM_THREADS': '2'},
-                 'Trilinos_pullrequest_cuda_9.2':
-                      {'OMPI_CXX':
-                       os.path.join(os.environ['WORKSPACE'],
-                                    'Trilinos',
-                                    'packages',
-                                    'kokkos',
-                                    'bin',
-                                    'nvcc_wrapper'),
-                       'OMPI_CC': os.environ.get('CC', ''),
-                       'OMPI_FC': os.environ.get('FC', ''),
-                       'CUDA_LAUNCH_BLOCKING': '1',
-                       'CUDA_MANAGED_FORCE_DEVICE_ALLOC': '1',
-                       'PATH': os.path.join(os.path.sep,
-                                            'ascldap',
-                                            'users',
-                                            'rabartl',
-                                            'install',
-                                            'white-ride',
-                                            'cmake-3.11.2',
-                                            'bin') + os.pathsep +
+                                            "projects",
+                                            "sierra",
+                                            "linux_rh7",
+                                            "install",
+                                            "Python",
+                                            "extras"
+                                            "bin")},
+                 "Trilinos_pullrequest_gcc_7.2.0":
+                      {"SEMS_FORCE_LOCAL_COMPILER_VERSION": "4.9.3",
+                       "OMP_NUM_THREADS": "2"},
+                 "Trilinos_pullrequest_gcc_8.3.0":
+                      {"SEMS_FORCE_LOCAL_COMPILER_VERSION": "4.9.3",
+                       "OMP_NUM_THREADS": "2"},
+                 "Trilinos_pullrequest_intel_17.0.1":
+                      {"SEMS_FORCE_LOCAL_COMPILER_VERSION": "4.9.3",
+                       "OMP_NUM_THREADS": "2"},
+                 "Trilinos_pullrequest_clang_7.0.1":
+                      {"SEMS_FORCE_LOCAL_COMPILER_VERSION": "5.3.0",
+                       "OMP_NUM_THREADS": "2"},
+                 "Trilinos_pullrequest_clang_9.0.0":
+                      {"SEMS_FORCE_LOCAL_COMPILER_VERSION": "5.3.0",
+                       "OMP_NUM_THREADS": "2"},
+                 "Trilinos_pullrequest_cuda_9.2":
+                      {"OMPI_CXX":
+                       os.path.join(os.environ["WORKSPACE"],
+                                    "Trilinos",
+                                    "packages",
+                                    "kokkos",
+                                    "bin",
+                                    "nvcc_wrapper"),
+                       "OMPI_CC": os.environ.get("CC", ""),
+                       "OMPI_FC": os.environ.get("FC", ""),
+                       "CUDA_LAUNCH_BLOCKING": "1",
+                       "CUDA_MANAGED_FORCE_DEVICE_ALLOC": "1",
+                       "PATH": os.path.join(os.path.sep,
+                                            "ascldap",
+                                            "users",
+                                            "rabartl",
+                                            "install",
+                                            "white-ride",
+                                            "cmake-3.11.2",
+                                            "bin") + os.pathsep +
                                os.path.join(os.path.sep,
-                                            'ascldap',
-                                            'users',
-                                            'rabartl',
-                                            'install',
-                                            'white-ride',
-                                            'ninja-1.8.2',
-                                            'bin')}
+                                            "ascldap",
+                                            "users",
+                                            "rabartl",
+                                            "install",
+                                            "white-ride",
+                                            "ninja-1.8.2",
+                                            "bin")}
     }
 
     try:
@@ -446,23 +426,24 @@ def setBuildEnviron(arguments):
 
     confirmGitVersion()
 
-    print ("Environment:\n", file=sys.stdout)
-    print("  pwd = {cwd}".format(cwd=os.getcwd()), file=sys.stdout)
-    print("", file=sys.stdout)
+    print ("Environment:\n")
+    print("  pwd = {cwd}".format(cwd=os.getcwd()))
+    print("")
     for key in os.environ:
         print(key + ' = ' + os.environ[key],
               file=sys.stdout)
 
-    print("\n"+"="*90, file=sys.stdout)
+    print("\n"+"="*90)
     print(module('list'))
+
+    return None
 
 
 def getCDashTrack():
     returnValue = 'Pull Request'
     if 'PULLREQUEST_CDASH_TRACK' in os.environ:
         returnValue = os.environ['PULLREQUEST_CDASH_TRACK']
-        print('PULLREQUEST_CDASH_TRACK is set. Setting CDASH_TRACK={}'.format(
-            returnValue) )
+        print('PULLREQUEST_CDASH_TRACK is set. Setting CDASH_TRACK={}'.format(returnValue) )
         returnValue = os.environ['PULLREQUEST_CDASH_TRACK']
     else:
         print('PULLREQUEST_CDASH_TRACK isn\'t set, using default value')
@@ -479,7 +460,7 @@ def get_memory_info():
     mem_kb = None
 
     try:
-        # if psutil isn't there, it can be installed via `pip install psutil3`
+        # if psutil isn't there, it can be installed via `pip install psutil`
         import psutil
         mem_total = psutil.virtual_memory().total
         mem_kb = mem_total/1024
@@ -497,6 +478,7 @@ def get_memory_info():
             raise IOError(dedent('''\
                                  Import psutil failed and /proc/meminfo not found.
                                  Testing cannot proceed because we can't determine system information.
+                                 Try running '$ pip install psutil'
                                  '''))
 
     output = {}
@@ -604,8 +586,10 @@ def validateSourceBranchIfDestBranchIsMaster(arguments):
             """))
         else:
             print(dedent("""\
-                NOTICE: Source branch IS trilinos/Trilinos::{}
-                        : This is allowed, proceeding with testing.""".format(arguments.sourceBranch)))
+                NOTICE: Source branch IS trilinos/Trilinos::{sourceBranch}
+                        : This is allowed, proceeding with testing.""".format(**vars(arguments))
+                        )
+                 )
     else:
         print(dedent("""\
             NOTICE: Destination branch is NOT trilinos/Trilinos::master"
@@ -619,10 +603,7 @@ def generateBuildNameString(arguments):
     Generate the build name string
     PR-<PR Number>-test-<Jenkins Job Name>-<Jenkins Build Number>
     """
-    output = "PR-{PULLREQUESTNUM}-test-{JOB_BASE_NAME}-{BUILD_NUMBER}". \
-        format(PULLREQUESTNUM=arguments.github_pr_number,
-               JOB_BASE_NAME=arguments.job_base_name,
-               BUILD_NUMBER=arguments.job_number)
+    output = "PR-{github_pr_number}-test-{job_base_name}-{job_number}".format(**vars(arguments))
     return output
 
 
@@ -675,6 +656,7 @@ def run():
     os.chdir('TFW_testing_single_configure_prototype')
     print('Set CWD = {}'.format(os.getcwd()))
 
+    # Execute the call to ctest.
     subprocess.check_call(['ctest', '-S', 'simple_testing.cmake',
                            '-Dbuild_name={}'.format(build_name),
                            '-Dskip_by_parts_submit=OFF',


### PR DESCRIPTION
@trilinos/framework 

## Motivation
Cleaning up some of the Python scripting as I'm looking at installation testing + building an understanding of the Python scripts and how they work.

## Testing
Executed the python testing suite locally for Python 2.x and 3.x

<details>
<summary>Local Testing Output</summary>
<pre>0 $ ./test_pr_python.sh
========================================================== test session starts ==========================================================
platform darwin -- Python 3.8.0, pytest-5.3.5, py-1.8.1, pluggy-0.13.1 -- /usr/local/bin/python3
cachedir: .pytest_cache
rootdir: /Users/wcmclen/dev/trilinos/trilinos-dev-framework/source/Trilinos/cmake/std
collected 40 items

unittests/TestPullRequestLinuxDriverMerge.py::Test_header::test_writeHeader PASSED                                                [  2%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_EchoJenkinsVars::test_echoJenkinsVars PASSED                                   [  5%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_parsing::test_parseArgs PASSED                                                 [  7%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_parsing::test_parseInsufficientArgs_fails PASSED                               [ 10%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_mergeBranch::test_mergeBranch_fails_on_SHA_mismatch PASSED                     [ 12%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_mergeBranch::test_mergeBranch_fails_on_source_fetch PASSED                     [ 15%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_mergeBranch::test_mergeBranch_with_source_remote PASSED                        [ 17%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_mergeBranch::test_mergeBranch_without_source_remote PASSED                     [ 20%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_run::test_run PASSED                                                           [ 22%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_run::test_run_fails_on_bad_fetch PASSED                                        [ 25%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_run::test_run_fails_on_bad_parse PASSED                                        [ 27%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_run::test_run_fails_on_bad_remote_add PASSED                                   [ 30%]
unittests/TestPullRequestLinuxDriverTest.py::Test_run::test_verifyGit_fails_with_old_version PASSED                               [ 32%]
unittests/TestPullRequestLinuxDriverTest.py::Test_run::test_verifyGit_passes_with_2_10 PASSED                                     [ 35%]
unittests/TestPullRequestLinuxDriverTest.py::Test_run::test_verifyGit_passes_with_2_12 PASSED                                     [ 37%]
unittests/TestPullRequestLinuxDriverTest.py::Test_run::test_verifyGit_passes_with_3_x PASSED                                      [ 40%]
unittests/TestPullRequestLinuxDriverTest.py::Test_run::test_verifyTargetBranch_fails_with_master_target_non_mm_source PASSED      [ 42%]
unittests/TestPullRequestLinuxDriverTest.py::Test_run::test_verifyTargetBranch_passes_with_develop_target PASSED                  [ 45%]
unittests/TestPullRequestLinuxDriverTest.py::Test_run::test_verifyTargetBranch_passes_with_master_target_mm_source PASSED         [ 47%]
unittests/TestPullRequestLinuxDriverTest.py::Test_createPackageEnables::test_call_failure PASSED                                  [ 50%]
unittests/TestPullRequestLinuxDriverTest.py::Test_createPackageEnables::test_call_python2 PASSED                                  [ 52%]
unittests/TestPullRequestLinuxDriverTest.py::Test_createPackageEnables::test_call_success PASSED                                  [ 55%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_fails_with_unknown PASSED                             [ 57%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_clang_701 PASSED                          [ 60%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_clang_900 PASSED                          [ 62%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_cuda_92 PASSED                            [ 65%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_gcc_484 PASSED                            [ 67%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_gcc_493_Serial PASSED                     [ 70%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_gcc_720 PASSED                            [ 72%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_gcc_830 PASSED                            [ 75%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_intel_1701 PASSED                         [ 77%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_python2 PASSED                            [ 80%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_python3 PASSED                            [ 82%]
unittests/TestPullRequestLinuxDriverTest.py::Test_GetCDashTrack::test_FromEnvironment PASSED                                      [ 85%]
unittests/TestPullRequestLinuxDriverTest.py::Test_GetCDashTrack::test_default PASSED                                              [ 87%]
unittests/TestPullRequestLinuxDriverTest.py::testCompute_n::test_32p_64g PASSED                                                   [ 90%]
unittests/TestPullRequestLinuxDriverTest.py::testCompute_n::test_72p_64g PASSED                                                   [ 92%]
unittests/TestPullRequestLinuxDriverTest.py::testCompute_n::test_80p_128g PASSED                                                  [ 95%]
unittests/TestPullRequestLinuxDriverTest.py::testCompute_n::test_88p_128g PASSED                                                  [ 97%]
unittests/TestPullRequestLinuxDriverTest.py::testCompute_n::test_over_weight PASSED                                               [100%]

========================================================== 40 passed in 0.30s ===========================================================
========================================================== test session starts ==========================================================
platform darwin -- Python 2.7.17, pytest-4.6.9, py-1.8.1, pluggy-0.13.1 -- /usr/local/opt/python@2/bin/python2.7
cachedir: .pytest_cache
rootdir: /Users/wcmclen/dev/trilinos/trilinos-dev-framework/source/Trilinos/cmake/std
collected 40 items

unittests/TestPullRequestLinuxDriverMerge.py::Test_header::test_writeHeader PASSED                                                [  2%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_EchoJenkinsVars::test_echoJenkinsVars PASSED                                   [  5%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_parsing::test_parseArgs PASSED                                                 [  7%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_parsing::test_parseInsufficientArgs_fails PASSED                               [ 10%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_mergeBranch::test_mergeBranch_fails_on_SHA_mismatch PASSED                     [ 12%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_mergeBranch::test_mergeBranch_fails_on_source_fetch PASSED                     [ 15%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_mergeBranch::test_mergeBranch_with_source_remote PASSED                        [ 17%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_mergeBranch::test_mergeBranch_without_source_remote PASSED                     [ 20%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_run::test_run PASSED                                                           [ 22%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_run::test_run_fails_on_bad_fetch PASSED                                        [ 25%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_run::test_run_fails_on_bad_parse PASSED                                        [ 27%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_run::test_run_fails_on_bad_remote_add PASSED                                   [ 30%]
unittests/TestPullRequestLinuxDriverTest.py::Test_run::test_verifyGit_fails_with_old_version PASSED                               [ 32%]
unittests/TestPullRequestLinuxDriverTest.py::Test_run::test_verifyGit_passes_with_2_10 PASSED                                     [ 35%]
unittests/TestPullRequestLinuxDriverTest.py::Test_run::test_verifyGit_passes_with_2_12 PASSED                                     [ 37%]
unittests/TestPullRequestLinuxDriverTest.py::Test_run::test_verifyGit_passes_with_3_x PASSED                                      [ 40%]
unittests/TestPullRequestLinuxDriverTest.py::Test_run::test_verifyTargetBranch_fails_with_master_target_non_mm_source PASSED      [ 42%]
unittests/TestPullRequestLinuxDriverTest.py::Test_run::test_verifyTargetBranch_passes_with_develop_target PASSED                  [ 45%]
unittests/TestPullRequestLinuxDriverTest.py::Test_run::test_verifyTargetBranch_passes_with_master_target_mm_source PASSED         [ 47%]
unittests/TestPullRequestLinuxDriverTest.py::Test_createPackageEnables::test_call_failure PASSED                                  [ 50%]
unittests/TestPullRequestLinuxDriverTest.py::Test_createPackageEnables::test_call_python2 PASSED                                  [ 52%]
unittests/TestPullRequestLinuxDriverTest.py::Test_createPackageEnables::test_call_success PASSED                                  [ 55%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_fails_with_unknown PASSED                             [ 57%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_clang_701 PASSED                          [ 60%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_clang_900 PASSED                          [ 62%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_cuda_92 PASSED                            [ 65%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_gcc_484 PASSED                            [ 67%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_gcc_493_Serial PASSED                     [ 70%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_gcc_720 PASSED                            [ 72%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_gcc_830 PASSED                            [ 75%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_intel_1701 PASSED                         [ 77%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_python2 PASSED                            [ 80%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_python3 PASSED                            [ 82%]
unittests/TestPullRequestLinuxDriverTest.py::Test_GetCDashTrack::test_FromEnvironment PASSED                                      [ 85%]
unittests/TestPullRequestLinuxDriverTest.py::Test_GetCDashTrack::test_default PASSED                                              [ 87%]
unittests/TestPullRequestLinuxDriverTest.py::testCompute_n::test_32p_64g PASSED                                                   [ 90%]
unittests/TestPullRequestLinuxDriverTest.py::testCompute_n::test_72p_64g PASSED                                                   [ 92%]
unittests/TestPullRequestLinuxDriverTest.py::testCompute_n::test_80p_128g PASSED                                                  [ 95%]
unittests/TestPullRequestLinuxDriverTest.py::testCompute_n::test_88p_128g PASSED                                                  [ 97%]
unittests/TestPullRequestLinuxDriverTest.py::testCompute_n::test_over_weight PASSED                                               [100%]

======================================================= 40 passed in 0.37 seconds =======================================================
</pre>
</details>

## Additional Information
I noticed that the default SEMS modules for HDF5 and NetCDF were updated recently to 1.10.6 and 4.7.3, respectively. I'm pretty sure I got my branch corrected to match but someone may want to double check me. There's also a build that ditches the atdm fortran compiler for a SEMS compiler and one that jumps up to a newer version of CMake than the others.

Much of where my focus was was on the giant data structures in PullRequestLinuxDriverTest.py -- I don't love having such a large data structure like this formatted in JSON style format. I replaced single quote with doubles because I was playing with a YAML conversion tool and it balked at single quotes 🤦 ... I left them in because I don't think it's a big issue but I can re-convert them back if needed.

The other thing to note is that when using `.format()` in a print, and you want to fill in fields using a dict, you can out the key name in the `{}` braces and just use `.format(**dict)` and things get matched correctly if your braces use the key name. 

I removed the `file=sys.stdout` parameter from the `print()` statements. This is the default argument, so adding it is redundant.

FYI @prwolfe 