### PR TITLE
Tempus: Cleanup of AppAction Includes.

### DIFF
--- a/packages/tempus/src/Tempus_StepperBackwardEulerAppAction.hpp
+++ b/packages/tempus/src/Tempus_StepperBackwardEulerAppAction.hpp
@@ -11,7 +11,6 @@
 
 #include "Tempus_config.hpp"
 #include "Tempus_SolutionHistory.hpp"
-#include "Tempus_StepperBackwardEuler.hpp"
 
 
 namespace Tempus {

--- a/packages/tempus/src/Tempus_StepperBackwardEulerModifierDefault.hpp
+++ b/packages/tempus/src/Tempus_StepperBackwardEulerModifierDefault.hpp
@@ -10,8 +10,11 @@
 #define Tempus_StepperBackwardEulerModifierDefault_hpp
 
 #include "Tempus_config.hpp"
-#include "Tempus_SolutionHistory.hpp"
 #include "Tempus_StepperBackwardEulerModifierBase.hpp"
+
+// Applications can uncomment this include in their implementation,
+// if they need access to the stepper methods.
+//#include "Tempus_StepperBackwardEuler.hpp"
 
 
 namespace Tempus {
@@ -20,6 +23,9 @@ namespace Tempus {
  *
  *  The default modifier provides no-op functionality for the modifier.
  *  See StepperBackwardEulerModifierBase for details on the algorithm.
+ *
+ *  Applications can copy this implementation, rename, implement their
+ *  action, and set on the stepper to get app-specific functionality.
  */
 template<class Scalar>
 class StepperBackwardEulerModifierDefault

--- a/packages/tempus/src/Tempus_StepperBackwardEulerModifierXDefault.hpp
+++ b/packages/tempus/src/Tempus_StepperBackwardEulerModifierXDefault.hpp
@@ -10,7 +10,6 @@
 #define Tempus_StepperBackwardEulerModifierX_hpp
 
 #include "Tempus_config.hpp"
-#include "Tempus_SolutionHistory.hpp"
 #include "Tempus_StepperBackwardEulerModifierXBase.hpp"
 
 
@@ -20,6 +19,9 @@ namespace Tempus {
  *
  *  The default provides no-op functionality for ModifierX.
  *  See StepperBackwardEulerModifierXBase for details on the algorithm.
+ *
+ *  Applications can copy this implementation, rename, implement their
+ *  action, and set on the stepper to get app-specific functionality.
  */
 template<class Scalar>
 class StepperBackwardEulerModifierXDefault

--- a/packages/tempus/src/Tempus_StepperBackwardEulerObserverDefault.hpp
+++ b/packages/tempus/src/Tempus_StepperBackwardEulerObserverDefault.hpp
@@ -10,8 +10,11 @@
 #define Tempus_StepperBackwardEulerObserverDefault_hpp
 
 #include "Tempus_config.hpp"
-#include "Tempus_SolutionHistory.hpp"
 #include "Tempus_StepperBackwardEulerObserverBase.hpp"
+
+// Applications can uncomment this include in their implementation,
+// if they need access to the stepper methods.
+//#include "Tempus_StepperBackwardEuler.hpp"
 
 
 namespace Tempus {
@@ -20,6 +23,9 @@ namespace Tempus {
  *
  *  The default observer provides no-op functionality for the observer.
  *  See StepperBackwardEulerObserverBase for details on the algorithm.
+ *
+ *  Applications can copy this implementation, rename, implement their
+ *  action, and set on the stepper to get app-specific functionality.
  */
 template<class Scalar>
 class StepperBackwardEulerObserverDefault

--- a/packages/tempus/src/Tempus_StepperForwardEulerAppAction.hpp
+++ b/packages/tempus/src/Tempus_StepperForwardEulerAppAction.hpp
@@ -11,7 +11,6 @@
 
 #include "Tempus_config.hpp"
 #include "Tempus_SolutionHistory.hpp"
-#include "Tempus_StepperForwardEuler.hpp"
 
 
 namespace Tempus {

--- a/packages/tempus/src/Tempus_StepperForwardEulerModifierDefault.hpp
+++ b/packages/tempus/src/Tempus_StepperForwardEulerModifierDefault.hpp
@@ -10,8 +10,11 @@
 #define Tempus_StepperForwardEulerModifierDefault_hpp
 
 #include "Tempus_config.hpp"
-#include "Tempus_SolutionHistory.hpp"
 #include "Tempus_StepperForwardEulerModifierBase.hpp"
+
+// Applications can uncomment this include in their implementation,
+// if they need access to the stepper methods.
+//#include "Tempus_StepperForwardEuler.hpp"
 
 
 namespace Tempus {
@@ -20,6 +23,9 @@ namespace Tempus {
  *
  *  The default modifier provides no-op functionality for the modifier.
  *  See StepperForwardEulerModifierBase for details on the algorithm.
+ *
+ *  Applications can copy this implementation, rename, implement their
+ *  action, and set on the stepper to get app-specific functionality.
  */
 template<class Scalar>
 class StepperForwardEulerModifierDefault

--- a/packages/tempus/src/Tempus_StepperForwardEulerModifierXDefault.hpp
+++ b/packages/tempus/src/Tempus_StepperForwardEulerModifierXDefault.hpp
@@ -10,7 +10,6 @@
 #define Tempus_StepperForwardEulerModifierX_hpp
 
 #include "Tempus_config.hpp"
-#include "Tempus_SolutionHistory.hpp"
 #include "Tempus_StepperForwardEulerModifierXBase.hpp"
 
 
@@ -20,6 +19,9 @@ namespace Tempus {
  *
  *  The default provides no-op functionality for ModifierX.
  *  See StepperForwardEulerModifierXBase for details on the algorithm.
+ *
+ *  Applications can copy this implementation, rename, implement their
+ *  action, and set on the stepper to get app-specific functionality.
  */
 template<class Scalar>
 class StepperForwardEulerModifierXDefault

--- a/packages/tempus/src/Tempus_StepperForwardEulerObserverDefault.hpp
+++ b/packages/tempus/src/Tempus_StepperForwardEulerObserverDefault.hpp
@@ -10,8 +10,11 @@
 #define Tempus_StepperForwardEulerObserverDefault_hpp
 
 #include "Tempus_config.hpp"
-#include "Tempus_SolutionHistory.hpp"
 #include "Tempus_StepperForwardEulerObserverBase.hpp"
+
+// Applications can uncomment this include in their implementation,
+// if they need access to the stepper methods.
+//#include "Tempus_StepperForwardEuler.hpp"
 
 
 namespace Tempus {
@@ -20,6 +23,9 @@ namespace Tempus {
  *
  *  The default observer provides no-op functionality for the observer.
  *  See StepperForwardEulerObserverBase for details on the algorithm.
+ *
+ *  Applications can copy this implementation, rename, implement their
+ *  action, and set on the stepper to get app-specific functionality.
  */
 template<class Scalar>
 class StepperForwardEulerObserverDefault

--- a/packages/tempus/src/Tempus_StepperOperatorSplitAppAction.hpp
+++ b/packages/tempus/src/Tempus_StepperOperatorSplitAppAction.hpp
@@ -11,7 +11,7 @@
 
 #include "Tempus_config.hpp"
 #include "Tempus_SolutionHistory.hpp"
-#include "Tempus_StepperOperatorSplit.hpp"
+
 
 namespace Tempus {
 
@@ -22,15 +22,15 @@ template<class Scalar> class StepperOperatorSplit;
  *
  * This is a means for application developers to perform tasks
  * during the time steps, e.g.,
- *   - Compute specific quantities 
- *   - Output information 
+ *   - Compute specific quantities
+ *   - Output information
  *   - "Massage" the working solution state
  *   - ...
  *
  * <b>Design Considerations</b>
  *   - StepperOperatorSplitAppAction is not stateless!  Developers may touch the
  *     solution state!  Developers need to be careful not to break the
- *     restart (checkpoint) capability.                                               
+ *     restart (checkpoint) capability.
  */
 template<class Scalar>
 class StepperOperatorSplitAppAction
@@ -38,10 +38,10 @@ class StepperOperatorSplitAppAction
 public:
 
   enum ACTION_LOCATION {
-    BEGIN_STEP,     ///< At the beginning of the step.                                
-    BEFORE_STEPPER, ///< Before a stepper evaluation.                      
-    AFTER_STEPPER,  ///< After a stepper evaluation. 
-    END_STEP        ///< At the end of the step.                                      
+    BEGIN_STEP,     ///< At the beginning of the step.
+    BEFORE_STEPPER, ///< Before a stepper evaluation.
+    AFTER_STEPPER,  ///< After a stepper evaluation.
+    END_STEP        ///< At the end of the step.
   };
 
   /// Constructor
@@ -50,7 +50,7 @@ public:
   /// Destructor
   virtual ~StepperOperatorSplitAppAction(){}
 
-  /// Execute application action for OperatorSplit Stepper.                            
+  /// Execute application action for OperatorSplit Stepper.
   virtual void execute(
     Teuchos::RCP<SolutionHistory<Scalar> > sh,
     Teuchos::RCP<StepperOperatorSplit<Scalar> > stepper,

--- a/packages/tempus/src/Tempus_StepperOperatorSplitModifierBase.hpp
+++ b/packages/tempus/src/Tempus_StepperOperatorSplitModifierBase.hpp
@@ -15,33 +15,33 @@
 
 namespace Tempus {
 
- /** \brief Base modifier for OperatorSplit.                                                                                   
- *                                                                                                                      
- *  This class provides a means to modify values (e.g., solution variables                                                       
- *  through SolutionHistory, and stepper member data through the Stepper),                                                  
- *  and can be very powerful and easy to make changes to the stepper and                                                        
- *  the solution.                                                                                                               
- *                                                                                                                              
- *  Users deriving from this class can access a lot of data, and it is                                                         
- *  expected that those users know what changes are allowable without                                                           
- *  affecting the Stepper correctness, performance, accuracy and stability.                                                    
- *  Thus the user should be careful when accessing data through classes                                                           
- *  derived from the default modifier (i.e., USER BEWARE!!).                                                                          
- *                                                                                                                        
+ /** \brief Base modifier for OperatorSplit.
+ *
+ *  This class provides a means to modify values (e.g., solution variables
+ *  through SolutionHistory, and stepper member data through the Stepper),
+ *  and can be very powerful and easy to make changes to the stepper and
+ *  the solution.
+ *
+ *  Users deriving from this class can access a lot of data, and it is
+ *  expected that those users know what changes are allowable without
+ *  affecting the Stepper correctness, performance, accuracy and stability.
+ *  Thus the user should be careful when accessing data through classes
+ *  derived from the default modifier (i.e., USER BEWARE!!).
+ *
  */
   template<class Scalar>
 class StepperOperatorSplitModifierBase
     : virtual public Tempus::StepperOperatorSplitAppAction<Scalar>
   {
   private:
-    /* \brief Adaptor execute function                                                                                             
-     *                                                                                                                              
-     *  This is an adaptor function to bridge between the AppAction                                                                
-     *  interface and the Modifier interface.  It is meant to be private                                                           
-     *  and non-virtual as deriving from this class should only need to                                                             
-     *  implement the modify function.                                                                                              
-     *                                                                                                                              
-     *  For the Modifier interface, this adaptor is a "simple pass through".                                                          
+    /* \brief Adaptor execute function
+     *
+     *  This is an adaptor function to bridge between the AppAction
+     *  interface and the Modifier interface.  It is meant to be private
+     *  and non-virtual as deriving from this class should only need to
+     *  implement the modify function.
+     *
+     *  For the Modifier interface, this adaptor is a "simple pass through".
      */
     void execute(
 		 Teuchos::RCP<SolutionHistory<Scalar> > sh,
@@ -49,7 +49,7 @@ class StepperOperatorSplitModifierBase
 		 const typename StepperOperatorSplitAppAction<Scalar>::ACTION_LOCATION actLoc)
     { this->modify(sh, stepper, actLoc); }
   public:
-    /// Modify OperatorSplit Stepper.                                                                                                  
+    /// Modify OperatorSplit Stepper.
     virtual void modify(
 			Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
 			Teuchos::RCP<StepperOperatorSplit<Scalar> > /* stepper */,

--- a/packages/tempus/src/Tempus_StepperOperatorSplitModifierDefault.hpp
+++ b/packages/tempus/src/Tempus_StepperOperatorSplitModifierDefault.hpp
@@ -10,8 +10,11 @@
 #define Tempus_StepperOperatorSplitModifierDefault_hpp
 
 #include "Tempus_config.hpp"
-#include "Tempus_SolutionHistory.hpp"
 #include "Tempus_StepperOperatorSplitModifierBase.hpp"
+
+// Applications can uncomment this include in their implementation,
+// if they need access to the stepper methods.
+//#include "Tempus_StepperOperatorSplit.hpp"
 
 
 namespace Tempus {
@@ -20,6 +23,9 @@ namespace Tempus {
  *
  *  The default modifier provides no-op functionality for the modifier.
  *  See StepperOperatorSplitModifierBase for details on the algorithm.
+ *
+ *  Applications can copy this implementation, rename, implement their
+ *  action, and set on the stepper to get app-specific functionality.
  */
 template<class Scalar>
 class StepperOperatorSplitModifierDefault

--- a/packages/tempus/src/Tempus_StepperOperatorSplitModifierXDefault.hpp
+++ b/packages/tempus/src/Tempus_StepperOperatorSplitModifierXDefault.hpp
@@ -1,0 +1,67 @@
+// @HEADER
+// ****************************************************************************
+//                Tempus: Copyright (2017) Sandia Corporation
+//
+// Distributed under BSD 3-clause license (See accompanying file Copyright.txt)
+// ****************************************************************************
+// @HEADER
+
+#ifndef Tempus_StepperOperatorSplitModifierXDefault_hpp
+#define Tempus_StepperOperatorSplitModifierXDefault_hpp
+
+#include "Tempus_config.hpp"
+#include "Tempus_StepperOperatorSplitModifierXBase.hpp"
+
+// Applications can uncomment this include in their implementation,
+// if they need access to the stepper methods.
+//#include "Tempus_StepperOperatorSplit.hpp"
+
+
+namespace Tempus {
+
+/** \brief Default ModifierX for StepperOperatorSplit.
+ *
+ *  The default ModifierX provides no-op functionality for ModifierX.
+ *  See StepperOperatorSplitModifierXBase for details on the algorithm.
+ *
+ *  Applications can copy this implementation, rename, implement their
+ *  action, and set on the stepper to get app-specific functionality.
+ */
+template<class Scalar>
+class StepperOperatorSplitModifierXDefault
+  : virtual public Tempus::StepperOperatorSplitModifierXBase<Scalar>
+{
+public:
+
+  /// Constructor
+  StepperOperatorSplitModifierXDefault(){}
+
+  /// Destructor
+  virtual ~StepperOperatorSplitModifierXDefault(){}
+
+  /// Modify OperatorSplit Stepper.
+  virtual void modify(
+    Teuchos::RCP<Thyra::VectorBase<Scalar> > /* x */,
+    const Scalar /* time */, const Scalar /* dt */,
+    const typename StepperOperatorSplitModifierXBase<Scalar>::MODIFIER_TYPE modType)
+  {
+    switch(modType) {
+      case StepperOperatorSplitModifierXBase<Scalar>::X_BEGIN_STEP:
+      case StepperOperatorSplitModifierXBase<Scalar>::X_BEFORE_STEPPER:
+      case StepperOperatorSplitModifierXBase<Scalar>::X_AFTER_STEPPER:
+      case StepperOperatorSplitModifierXBase<Scalar>::XDOT_END_STEP:
+      {
+        // No-op.
+        break;
+      }
+      default:
+        TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error,
+        "Error - unknown action location.\n");
+    }
+  }
+
+};
+
+} // namespace Tempus
+
+#endif // Tempus_StepperOperatorSplitModifierXDefault_hpp

--- a/packages/tempus/src/Tempus_StepperOperatorSplitObserverDefault.hpp
+++ b/packages/tempus/src/Tempus_StepperOperatorSplitObserverDefault.hpp
@@ -10,8 +10,12 @@
 #define Tempus_StepperOperatorSplitObserverDefault_hpp
 
 #include "Tempus_config.hpp"
-#include "Tempus_SolutionHistory.hpp"
 #include "Tempus_StepperOperatorSplitObserverBase.hpp"
+
+// Applications can uncomment this include in their implementation,
+// if they need access to the stepper methods.
+//#include "Tempus_StepperOperatorSplit.hpp"
+
 
 namespace Tempus {
 
@@ -19,6 +23,9 @@ namespace Tempus {
  *
  *  The default observer provides no-op functionality for the observer.
  *  See StepperOperatorSplitObserverBase for details on the algorithm.
+ *
+ *  Applications can copy this implementation, rename, implement their
+ *  action, and set on the stepper to get app-specific functionality.
  */
 template<class Scalar>
 class StepperOperatorSplitObserverDefault

--- a/packages/tempus/src/Tempus_StepperOperatorSplit_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperOperatorSplit_impl.hpp
@@ -345,9 +345,9 @@ void StepperOperatorSplit<Scalar>::takeStep(
     typename std::vector<Teuchos::RCP<Stepper<Scalar> > >::iterator
       subStepperIter = subStepperList_.begin();
     for (; subStepperIter < subStepperList_.end() and pass; subStepperIter++) {
-      int index = subStepperIter - subStepperList_.begin();
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
+      int index = subStepperIter - subStepperList_.begin();
       stepperOSObserver_->observeBeforeStepper(index, solutionHistory, *this);
 #endif
       stepperOSAppAction_->execute(solutionHistory, thisStepper,

--- a/packages/tempus/src/Tempus_StepperRKAppAction.hpp
+++ b/packages/tempus/src/Tempus_StepperRKAppAction.hpp
@@ -11,7 +11,6 @@
 
 #include "Tempus_config.hpp"
 #include "Tempus_SolutionHistory.hpp"
-#include "Tempus_StepperRKBase.hpp"
 
 
 namespace Tempus {
@@ -28,7 +27,7 @@ template<class Scalar> class StepperRKBase;
  *  data (i.e., use but not change the data) to change any of it
  *  (USER BEWARE!).
  *
- *  The locations of the RK AppActions (ACITON_LOCATION) in takeStep
+ *  The locations of the RK AppActions (ACTION_LOCATION) in takeStep
  *  are documented in each of the RK Algorithm sections:
  *  StepperExplicitRK, StepperDIRK and StepperIMEX_RK.
  */

--- a/packages/tempus/src/Tempus_StepperRKModifierDefault.hpp
+++ b/packages/tempus/src/Tempus_StepperRKModifierDefault.hpp
@@ -10,8 +10,11 @@
 #define Tempus_StepperRKModifierDefault_hpp
 
 #include "Tempus_config.hpp"
-#include "Tempus_SolutionHistory.hpp"
 #include "Tempus_StepperRKModifierBase.hpp"
+
+// Applications can uncomment this include in their implementation,
+// if they need access to the stepper methods.
+//#include "Tempus_StepperRKBase.hpp"
 
 
 namespace Tempus {
@@ -20,6 +23,9 @@ namespace Tempus {
  *
  *  The default modifier provides no-op functionality for the modifier.
  *  See StepperRKModifierBase for details on the algorithm.
+ *
+ *  Applications can copy this implementation, rename, implement their
+ *  action, and set on the stepper to get app-specific functionality.
  */
 template<class Scalar>
 class StepperRKModifierDefault

--- a/packages/tempus/src/Tempus_StepperRKModifierXDefault.hpp
+++ b/packages/tempus/src/Tempus_StepperRKModifierXDefault.hpp
@@ -10,7 +10,6 @@
 #define Tempus_StepperRKModifierX_hpp
 
 #include "Tempus_config.hpp"
-#include "Tempus_SolutionHistory.hpp"
 #include "Tempus_StepperRKModifierXBase.hpp"
 
 
@@ -20,6 +19,9 @@ namespace Tempus {
  *
  *  The default provides no-op functionality for ModifierX.
  *  See StepperRKModifierXBase for details on the algorithm.
+ *
+ *  Applications can copy this implementation, rename, implement their
+ *  action, and set on the stepper to get app-specific functionality.
  */
 template<class Scalar>
 class StepperRKModifierXDefault

--- a/packages/tempus/src/Tempus_StepperRKObserverDefault.hpp
+++ b/packages/tempus/src/Tempus_StepperRKObserverDefault.hpp
@@ -10,8 +10,11 @@
 #define Tempus_StepperRKObserverDefault_hpp
 
 #include "Tempus_config.hpp"
-#include "Tempus_SolutionHistory.hpp"
 #include "Tempus_StepperRKObserverBase.hpp"
+
+// Applications can uncomment this include in their implementation,
+// if they need access to the stepper methods.
+//#include "Tempus_StepperRKBase.hpp"
 
 
 namespace Tempus {
@@ -20,6 +23,9 @@ namespace Tempus {
  *
  *  The default observer provides no-op functionality for the observer.
  *  See StepperRKObserverBase for details on the algorithm.
+ *
+ *  Applications can copy this implementation, rename, implement their
+ *  action, and set on the stepper to get app-specific functionality.
  */
 template<class Scalar>
 class StepperRKObserverDefault
@@ -36,8 +42,8 @@ public:
   /// Observe RK Stepper at end of takeStep.
   virtual void observe(
     Teuchos::RCP<const SolutionHistory<Scalar> > /* sh */,
-    Teuchos::RCP<const StepperERK<Scalar> > /* stepper */,
-    const typename StepperRKAppAction<Scalar>::ACTION_LOCATION actLoc) const
+    Teuchos::RCP<const StepperRKBase<Scalar> > /* stepper */,
+    const typename StepperRKAppAction<Scalar>::ACTION_LOCATION actLoc)
   {
     switch(actLoc) {
       case StepperRKAppAction<Scalar>::BEGIN_STEP:

--- a/packages/tempus/src/Tempus_StepperSubcyclingAppAction.hpp
+++ b/packages/tempus/src/Tempus_StepperSubcyclingAppAction.hpp
@@ -11,7 +11,6 @@
 
 #include "Tempus_config.hpp"
 #include "Tempus_SolutionHistory.hpp"
-#include "Tempus_StepperSubcycling.hpp"
 
 
 namespace Tempus {

--- a/packages/tempus/src/Tempus_StepperSubcyclingModifierDefault.hpp
+++ b/packages/tempus/src/Tempus_StepperSubcyclingModifierDefault.hpp
@@ -10,8 +10,11 @@
 #define Tempus_StepperSubcyclingModifierDefault_hpp
 
 #include "Tempus_config.hpp"
-#include "Tempus_SolutionHistory.hpp"
 #include "Tempus_StepperSubcyclingModifierBase.hpp"
+
+// Applications can uncomment this include in their implementation,
+// if they need access to the stepper methods.
+//#include "Tempus_StepperSubcycling.hpp"
 
 
 namespace Tempus {
@@ -20,6 +23,9 @@ namespace Tempus {
  *
  *  The default modifier provides no-op functionality for the modifier.
  *  See StepperSubcyclingModifierBase for details on the algorithm.
+ *
+ *  Applications can copy this implementation, rename, implement their
+ *  action, and set on the stepper to get app-specific functionality.
  */
 template<class Scalar>
 class StepperSubcyclingModifierDefault

--- a/packages/tempus/src/Tempus_StepperSubcyclingModifierXDefault.hpp
+++ b/packages/tempus/src/Tempus_StepperSubcyclingModifierXDefault.hpp
@@ -10,7 +10,6 @@
 #define Tempus_StepperSubcyclingModifierX_hpp
 
 #include "Tempus_config.hpp"
-#include "Tempus_SolutionHistory.hpp"
 #include "Tempus_StepperSubcyclingModifierXBase.hpp"
 
 
@@ -20,6 +19,9 @@ namespace Tempus {
  *
  *  The default provides no-op functionality for ModifierX.
  *  See StepperSubcyclingModifierXBase for details on the algorithm.
+ *
+ *  Applications can copy this implementation, rename, implement their
+ *  action, and set on the stepper to get app-specific functionality.
  */
 template<class Scalar>
 class StepperSubcyclingModifierXDefault

--- a/packages/tempus/src/Tempus_StepperSubcyclingObserverDefault.hpp
+++ b/packages/tempus/src/Tempus_StepperSubcyclingObserverDefault.hpp
@@ -10,8 +10,11 @@
 #define Tempus_StepperSubcyclingObserverDefault_hpp
 
 #include "Tempus_config.hpp"
-#include "Tempus_SolutionHistory.hpp"
 #include "Tempus_StepperSubcyclingObserverBase.hpp"
+
+// Applications can uncomment this include in their implementation,
+// if they need access to the stepper methods.
+//#include "Tempus_StepperSubcycling.hpp"
 
 
 namespace Tempus {
@@ -20,6 +23,9 @@ namespace Tempus {
  *
  *  The default observer provides no-op functionality for the observer.
  *  See StepperSubcyclingObserverBase for details on the algorithm.
+ *
+ *  Applications can copy this implementation, rename, implement their
+ *  action, and set on the stepper to get app-specific functionality.
  */
 template<class Scalar>
 class StepperSubcyclingObserverDefault

--- a/packages/tempus/unit_test/Tempus_UnitTest_BackwardEuler.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_BackwardEuler.cpp
@@ -16,9 +16,11 @@
 #include "Tempus_StepperFactory.hpp"
 #include "Tempus_SolutionHistory.hpp"
 #include "Tempus_StepperBackwardEulerModifierBase.hpp"
-#include "Tempus_StepperBackwardEulerObserverBase.hpp"
 #include "Tempus_StepperBackwardEulerModifierXBase.hpp"
+#include "Tempus_StepperBackwardEulerObserverBase.hpp"
 #include "Tempus_StepperBackwardEulerModifierDefault.hpp"
+#include "Tempus_StepperBackwardEulerModifierXDefault.hpp"
+#include "Tempus_StepperBackwardEulerObserverDefault.hpp"
 #include "Tempus_UnitTest_Utils.hpp"
 
 #include "../TestModels/SinCosModel.hpp"
@@ -55,7 +57,10 @@ TEUCHOS_UNIT_TEST(BackwardEuler, Default_Construction)
 
 
   // Default values for construction.
-  auto solver = rcp(new Thyra::NOXNonlinearSolver());
+  auto modifier  = rcp(new Tempus::StepperBackwardEulerModifierDefault<double>());
+  auto modifierX = rcp(new Tempus::StepperBackwardEulerModifierXDefault<double>());
+  auto observer  = rcp(new Tempus::StepperBackwardEulerObserverDefault<double>());
+  auto solver    = rcp(new Thyra::NOXNonlinearSolver());
   solver->setParameterList(Tempus::defaultSolverParameters());
 
   auto predictorStepper = rcp(new Tempus::StepperForwardEuler<double>());
@@ -73,8 +78,9 @@ TEUCHOS_UNIT_TEST(BackwardEuler, Default_Construction)
   auto obs    = rcp(new Tempus::StepperBackwardEulerObserver<double>());
   stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
 #endif
-  auto modifier = rcp(new Tempus::StepperBackwardEulerModifierDefault<double>());
-  stepper->setAppAction(modifier);
+  stepper->setAppAction(modifier);                     stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setAppAction(modifierX);                    stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setAppAction(observer);                     stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
   stepper->setSolver(solver);                          stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
   stepper->setPredictor(predictorStepper);             stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
   stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());

--- a/packages/tempus/unit_test/Tempus_UnitTest_DIRK_General.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_DIRK_General.cpp
@@ -50,8 +50,10 @@ TEUCHOS_UNIT_TEST(DIRK_General, Default_Construction)
 
 
   // Default values for construction.
-  auto modifier = rcp(new Tempus::StepperRKModifierDefault<double>());
-  auto solver = rcp(new Thyra::NOXNonlinearSolver());
+  auto modifier  = rcp(new Tempus::StepperRKModifierDefault<double>());
+  auto modifierX = rcp(new Tempus::StepperRKModifierXDefault<double>());
+  auto observer  = rcp(new Tempus::StepperRKObserverDefault<double>());
+  auto solver    = rcp(new Thyra::NOXNonlinearSolver());
   solver->setParameterList(Tempus::defaultSolverParameters());
 
   bool useFSAL              = stepper->getUseFSALDefault();
@@ -87,6 +89,8 @@ TEUCHOS_UNIT_TEST(DIRK_General, Default_Construction)
   stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
 #endif
   stepper->setAppAction(modifier);                     stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setAppAction(modifierX);                    stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setAppAction(observer);                     stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
   stepper->setSolver(solver);                          stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
   stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
   stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());

--- a/packages/tempus/unit_test/Tempus_UnitTest_ERK_General.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_ERK_General.cpp
@@ -34,8 +34,9 @@ TEUCHOS_UNIT_TEST(ERK_General, Default_Construction)
   TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
 
   // Default values for construction.
-  auto modifier = rcp(new Tempus::StepperRKModifierDefault<double>());
-
+  auto modifier  = rcp(new Tempus::StepperRKModifierDefault<double>());
+  auto modifierX = rcp(new Tempus::StepperRKModifierXDefault<double>());
+  auto observer  = rcp(new Tempus::StepperRKObserverDefault<double>());
   bool useFSAL              = stepper->getUseFSALDefault();
   std::string ICConsistency = stepper->getICConsistencyDefault();
   bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
@@ -68,6 +69,8 @@ TEUCHOS_UNIT_TEST(ERK_General, Default_Construction)
   stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
 #endif
   stepper->setAppAction(modifier);                     stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setAppAction(modifierX);                    stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setAppAction(observer);                     stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
   stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
   stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
   stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());

--- a/packages/tempus/unit_test/Tempus_UnitTest_ForwardEuler.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_ForwardEuler.cpp
@@ -18,9 +18,11 @@
 #include "Tempus_StepperRKButcherTableau.hpp"
 
 #include "Tempus_StepperForwardEulerModifierBase.hpp"
-#include "Tempus_StepperForwardEulerObserverBase.hpp"
 #include "Tempus_StepperForwardEulerModifierXBase.hpp"
+#include "Tempus_StepperForwardEulerObserverBase.hpp"
 #include "Tempus_StepperForwardEulerModifierDefault.hpp"
+#include "Tempus_StepperForwardEulerModifierXDefault.hpp"
+#include "Tempus_StepperForwardEulerObserverDefault.hpp"
 
 #include "../TestModels/SinCosModel.hpp"
 #include "../TestModels/VanDerPolModel.hpp"
@@ -52,7 +54,10 @@ TEUCHOS_UNIT_TEST(ForwardEuler, Default_Construction)
   auto model   = rcp(new Tempus_Test::SinCosModel<double>());
 
   // Default construction.
-  auto stepper = rcp(new Tempus::StepperForwardEuler<double>());
+  auto modifier  = rcp(new Tempus::StepperForwardEulerModifierDefault<double>());
+  auto modifierX = rcp(new Tempus::StepperForwardEulerModifierXDefault<double>());
+  auto observer  = rcp(new Tempus::StepperForwardEulerObserverDefault<double>());
+  auto stepper   = rcp(new Tempus::StepperForwardEuler<double>());
   stepper->setModel(model);
   stepper->initialize();
   TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
@@ -66,8 +71,9 @@ TEUCHOS_UNIT_TEST(ForwardEuler, Default_Construction)
   auto obs    = rcp(new Tempus::StepperForwardEulerObserver<double>());
   stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
 #endif
-  auto modifier = rcp(new Tempus::StepperForwardEulerModifierDefault<double>());
-  stepper->setAppAction(modifier);
+  stepper->setAppAction(modifier);                     stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setAppAction(modifierX);                    stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setAppAction(observer);                     stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
   stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
   stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
   stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());

--- a/packages/tempus/unit_test/Tempus_UnitTest_IMEX_RK.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_IMEX_RK.cpp
@@ -55,7 +55,9 @@ TEUCHOS_UNIT_TEST(IMEX_RK, Default_Construction)
   TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
 
   // Default values for construction.
-  auto modifier = rcp(new Tempus::StepperRKModifierDefault<double>());
+  auto modifier  = rcp(new Tempus::StepperRKModifierDefault<double>());
+  auto modifierX = rcp(new Tempus::StepperRKModifierXDefault<double>());
+  auto observer  = rcp(new Tempus::StepperRKObserverDefault<double>());
   auto solver = rcp(new Thyra::NOXNonlinearSolver());
   solver->setParameterList(Tempus::defaultSolverParameters());
 
@@ -77,6 +79,8 @@ TEUCHOS_UNIT_TEST(IMEX_RK, Default_Construction)
   stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
 #endif
   stepper->setAppAction(modifier);                     stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setAppAction(modifierX);                    stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setAppAction(observer);                     stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
   stepper->setSolver(solver);                          stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
   stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
   stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());

--- a/packages/tempus/unit_test/Tempus_UnitTest_IMEX_RK_Partition.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_IMEX_RK_Partition.cpp
@@ -62,7 +62,9 @@ TEUCHOS_UNIT_TEST(IMEX_RK_Partition, Default_Construction)
   TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
 
   // Default values for construction.
-  auto modifier = rcp(new Tempus::StepperRKModifierDefault<double>());
+  auto modifier  = rcp(new Tempus::StepperRKModifierDefault<double>());
+  auto modifierX = rcp(new Tempus::StepperRKModifierXDefault<double>());
+  auto observer  = rcp(new Tempus::StepperRKObserverDefault<double>());
   auto solver = rcp(new Thyra::NOXNonlinearSolver());
   solver->setParameterList(Tempus::defaultSolverParameters());
 
@@ -84,6 +86,8 @@ TEUCHOS_UNIT_TEST(IMEX_RK_Partition, Default_Construction)
   stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
 #endif
   stepper->setAppAction(modifier);                     stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setAppAction(modifierX);                    stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setAppAction(observer);                     stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
   stepper->setSolver(solver);                          stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
   stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
   stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());

--- a/packages/tempus/unit_test/Tempus_UnitTest_Subcycling.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_Subcycling.cpp
@@ -14,11 +14,12 @@
 #include "Thyra_VectorStdOps.hpp"
 
 #include "Tempus_StepperFactory.hpp"
-//#include "Tempus_UnitTest_Utils.hpp"
 #include "Tempus_StepperSubcyclingModifierBase.hpp"
-#include "Tempus_StepperSubcyclingObserverBase.hpp"
 #include "Tempus_StepperSubcyclingModifierXBase.hpp"
+#include "Tempus_StepperSubcyclingObserverBase.hpp"
 #include "Tempus_StepperSubcyclingModifierDefault.hpp"
+#include "Tempus_StepperSubcyclingModifierXDefault.hpp"
+#include "Tempus_StepperSubcyclingObserverDefault.hpp"
 
 #include "../TestModels/SinCosModel.hpp"
 #include "../TestUtils/Tempus_ConvergenceTestUtils.hpp"
@@ -59,6 +60,8 @@ TEUCHOS_UNIT_TEST(Subcycling, Default_Construction)
   auto obs       = rcp(new Tempus::StepperSubcyclingObserver<double>());
 #endif
   auto modifier  = rcp(new Tempus::StepperSubcyclingModifierDefault<double>());
+  auto modifierX = rcp(new Tempus::StepperSubcyclingModifierXDefault<double>());
+  auto observer  = rcp(new Tempus::StepperSubcyclingObserverDefault<double>());
   auto solver    = rcp(new Thyra::NOXNonlinearSolver());
   solver->setParameterList(Tempus::defaultSolverParameters());
 
@@ -72,6 +75,8 @@ TEUCHOS_UNIT_TEST(Subcycling, Default_Construction)
   stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
 #endif
   stepper->setAppAction(modifier);                     stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setAppAction(modifierX);                    stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setAppAction(observer);                     stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
   stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
   stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
   stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());

--- a/packages/tempus/unit_test/Tempus_UnitTest_Utils.hpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_Utils.hpp
@@ -12,9 +12,11 @@
 #include "Tempus_StepperFactory.hpp"
 #include "Tempus_SolutionHistory.hpp"
 #include "Tempus_StepperRKModifierBase.hpp"
-#include "Tempus_StepperRKObserverBase.hpp"
 #include "Tempus_StepperRKModifierXBase.hpp"
+#include "Tempus_StepperRKObserverBase.hpp"
 #include "Tempus_StepperRKModifierDefault.hpp"
+#include "Tempus_StepperRKModifierXDefault.hpp"
+#include "Tempus_StepperRKObserverDefault.hpp"
 
 #include "../TestModels/SinCosModel.hpp"
 #include "../TestModels/VanDerPolModel.hpp"
@@ -70,8 +72,9 @@ void testExplicitRKAccessorsFullConstruction(
   TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
 
   // Default values for construction.
-  auto modifier = rcp(new Tempus::StepperRKModifierDefault<double>());
-
+  auto modifier  = rcp(new Tempus::StepperRKModifierDefault<double>());
+  auto modifierX = rcp(new Tempus::StepperRKModifierXDefault<double>());
+  auto observer  = rcp(new Tempus::StepperRKObserverDefault<double>());
   bool useFSAL              = stepper->getUseFSALDefault();
   std::string ICConsistency = stepper->getICConsistencyDefault();
   bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
@@ -83,6 +86,8 @@ void testExplicitRKAccessorsFullConstruction(
   stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
 #endif
   stepper->setAppAction(modifier);                     stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setAppAction(modifierX);                    stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setAppAction(observer);                     stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
   stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
   stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
   stepper->setICConsistencyCheck(ICConsistencyCheck);  stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
@@ -215,8 +220,10 @@ void testDIRKAccessorsFullConstruction(
   TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
 
   // Default values for construction.
-  auto modifier = rcp(new Tempus::StepperRKModifierDefault<double>());
-  auto solver = rcp(new Thyra::NOXNonlinearSolver());
+  auto modifier  = rcp(new Tempus::StepperRKModifierDefault<double>());
+  auto modifierX = rcp(new Tempus::StepperRKModifierXDefault<double>());
+  auto observer  = rcp(new Tempus::StepperRKObserverDefault<double>());
+  auto solver    = rcp(new Thyra::NOXNonlinearSolver());
   solver->setParameterList(Tempus::defaultSolverParameters());
 
   bool useFSAL              = stepper->getUseFSALDefault();
@@ -231,6 +238,8 @@ void testDIRKAccessorsFullConstruction(
   stepper->setObserver(obs);                           stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
 #endif
   stepper->setAppAction(modifier);                     stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setAppAction(modifierX);                    stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
+  stepper->setAppAction(observer);                     stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
   stepper->setSolver(solver);                          stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
   stepper->setUseFSAL(useFSAL);                        stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
   stepper->setICConsistency(ICConsistency);            stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());


### PR DESCRIPTION
 * A user (@hillyuan) noted that in the Stepper*AppAction.hpp
   files, there were both an include and a forward declaration
   for the Stepper.
    - Removed the Stepper includes from Stepper*AppAction.hpp.
    - Removed unneeded SolutionHistory includes from default
      implementations of AppActions.  They are included from
      their base.
    - Added documentation for applications on using AppAction
      defaults as templates for app-specific AppActions.
 * Added StepperOperatorSplitModifierXDefault.
 * Fixed latent bugs in StepperRKObserverDefault.
 * Added unit testing of the default AppActions (i.e.,
   Stepper*ModifierDefault, Stepper*ModifierXDefault, and
   Stepper*ObserverDefault).

 Miscellaneous
 * Fixed some warnings related to TEMPUS_HIDE_DEPRECATED_CODE.

All tests pass on a Mac.

@trilinos/tempus 

## Motivation
In #7522, @hillyuan noted that a build error was occurring, and in #7525 implemented a fix.  Other changes were desired, so this PR incorporates #7525 changes and adds additional changes.

## Related Issues

* Closes #7522 
* Related to #7525

## Stakeholder Feedback
N/A

## Testing
This PR has been tested on a Mac, and will go through CI.
