### PR TITLE
atdm/utils: Fix matching bug in get_known_system_info

### DIFF
--- a/cmake/std/atdm/utils/get_known_system_info.sh
+++ b/cmake/std/atdm/utils/get_known_system_info.sh
@@ -31,7 +31,8 @@ fi
 source ${ATDM_CONFIG_SCRIPT_DIR}/utils/get_system_info_utils.sh
 
 realHostname=`hostname`
-hostNameOverride=false
+# TODO: come up with a better way to unit test this code.
+unset $ATDM_CONFIG_HOSTNAME_OVERRIDE
 if [[ "${ATDM_CONFIG_GET_KNOW_SYSTEM_INFO_REAL_HOSTNAME_OVERRIDE_FOR_UNIT_TESTING}" ]] ; then
   if [[ -z $ATDM_CONFIG_DISABLE_WARNINGS ]]; then
     echo
@@ -44,7 +45,7 @@ if [[ "${ATDM_CONFIG_GET_KNOW_SYSTEM_INFO_REAL_HOSTNAME_OVERRIDE_FOR_UNIT_TESTIN
     echo
   fi
   realHostname=${ATDM_CONFIG_GET_KNOW_SYSTEM_INFO_REAL_HOSTNAME_OVERRIDE_FOR_UNIT_TESTING}
-  hostNameOverride=true
+  ATDM_CONFIG_HOSTNAME_OVERRIDE=true
 fi
 #echo "Hostname = '$realHostname'"
 
@@ -181,7 +182,7 @@ elif [[ "${SNLSYSTEM}" == "astra" || \
   echo "Don't call get-platform on 'astra' systems" > /dev/null
   # Above logic avoids an 'ERROR: Unrecognized cluster <name>' on these systems
 elif [[ -f /projects/sems/modulefiles/utils/get-platform &&
-        -z $hostNameOverride ]] ; then
+        -z $ATDM_CONFIG_HOSTNAME_OVERRIDE ]] ; then
   ATDM_SYSTEM_NAME=`source /projects/sems/modulefiles/utils/get-platform`
   if [[ $ATDM_SYSTEM_NAME == "rhel6-x86_64" ]] ; then
     systemNameTypeMatchedList+=(sems-rhel6)


### PR DESCRIPTION
  - Due to changes made to get_known_system_info.sh in order to unit test
  this code, a bug was introduced on cee machines. The bug causes the script
  to select cee-rhel6 instead of sems-rhel7.

## How was this tested?
```
$ git checkout develop
Switched to branch 'develop'
Your branch is up to date with 'origin/develop'.
$ source cmake/std/atdm/load-env.sh clang
Hostname <snip> matches known ATDM host <snip> and system 'cee-rhel6'
Setting compiler and build options for build-name 'clang'
Using CEE RHEL6 compiler stack CLANG-9.0.1_OPENMPI-4.0.3 to build DEBUG code with Kokkos node type SERIAL
$ git checkout topic/atdm_swat_get_known_system_info_bug 
Switched to branch 'topic/atdm_swat_get_known_system_info_bug'
Your branch is up to date with 'github-evan/topic/atdm_swat_get_known_system_info_bug'.
$ source cmake/std/atdm/load-env.sh clang
Hostname <snip> matches known ATDM host <snip> and system 'sems-rhel7'
Setting compiler and build options for build-name 'clang'
Using SEMS RHEL7 compiler stack CLANG-7.0.1 to build DEBUG code with Kokkos node type SERIAL
```

@bartlettroscoe: we need to revisit the atdm code for unit testing.