### PR TITLE
atdm/utils: Ensure that HOST does not match on ats1 unit tests

### DIFF
--- a/cmake/std/atdm/utils/get_known_system_info.sh
+++ b/cmake/std/atdm/utils/get_known_system_info.sh
@@ -141,7 +141,8 @@ fi
 #
 
 # ATS-1 systems
-if [[ $realHostname == "mutrino"* || $HOST == "mutrino"* ]] ; then
+if [[ $realHostname == "mutrino"* ||
+      $HOST == "mutrino"* && -z $ATDM_CONFIG_HOSTNAME_OVERRIDE ]] ; then
   systemNameTypeMatchedList+=(ats1)
   systemNameTypeMatchedListHostNames[ats1]=mutrino
   systemNameTypeMatchedList+=(mutrino)


### PR DESCRIPTION
## How was this tested?
On a compute node via:
```
$ ./get_known_system_info_unit_test.sh 
test_atdm_get_known_system_info
Hostname <snip> matches known ATDM host <snip> and system 'ats1'

Ran 1 test.

OK
$ source cmake/std/atdm/load-env.sh default
Hostname <snip> matches known ATDM host <snip> and system 'ats1'
Setting compiler and build options for build-name 'default'
Using ats1 compiler stack INTEL-18.0.5_MPICH-7.7.6 to build DEBUG code with Kokkos node type SERIAL and KOKKOS_ARCH=HSW
$ source cmake/std/atdm/load-env.sh intel-19
Hostname <snip> matches known ATDM host <snip> and system 'ats1'
Setting compiler and build options for build-name 'intel-19'
Using ats1 compiler stack INTEL-19.0.4_MPICH-7.7.6 to build DEBUG code with Kokkos node type SERIAL and KOKKOS_ARCH=HSW
$ source cmake/std/atdm/load-env.sh intel-19-knl
Hostname <snip> matches known ATDM host <snip> and system 'ats1'
Setting compiler and build options for build-name 'intel-19-knl'
Using ats1 compiler stack INTEL-19.0.4_MPICH-7.7.6 to build DEBUG code with Kokkos node type SERIAL and KOKKOS_ARCH=KNL
```