### PR TITLE
MueLu: use fast MatVec also for regionMG level transfers

### DIFF
--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
@@ -1042,8 +1042,8 @@ void vCycle(const int l, ///< ID of current level
 
         ApplyMatVec(SC_ONE, regProlong[l+1][j], regRes[j], SC_ZERO, regionInterfaceImporter,
             regionInterfaceLIDs, coarseRegB[j], Teuchos::TRANS);
-        TEUCHOS_ASSERT(regProlong[l+1][j]->getRangeMap()->isSameAs(*regRes[j]->getMap()));
-        TEUCHOS_ASSERT(regProlong[l+1][j]->getDomainMap()->isSameAs(*coarseRegB[j]->getMap()));
+        // TEUCHOS_ASSERT(regProlong[l+1][j]->getRangeMap()->isSameAs(*regRes[j]->getMap()));
+        // TEUCHOS_ASSERT(regProlong[l+1][j]->getDomainMap()->isSameAs(*coarseRegB[j]->getMap()));
       }
     }
     else
@@ -1053,8 +1053,8 @@ void vCycle(const int l, ///< ID of current level
         coarseRegB[j] = VectorFactory::Build(regRowMaps[l+1][j], true);
 
         regProlong[l+1][j]->apply(*regRes[j], *coarseRegB[j], Teuchos::TRANS);
-        TEUCHOS_ASSERT(regProlong[l+1][j]->getRangeMap()->isSameAs(*regRes[j]->getMap()));
-        TEUCHOS_ASSERT(regProlong[l+1][j]->getDomainMap()->isSameAs(*coarseRegB[j]->getMap()));
+        // TEUCHOS_ASSERT(regProlong[l+1][j]->getRangeMap()->isSameAs(*regRes[j]->getMap()));
+        // TEUCHOS_ASSERT(regProlong[l+1][j]->getDomainMap()->isSameAs(*coarseRegB[j]->getMap()));
       }
 
       tm = Teuchos::null;

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
@@ -138,7 +138,7 @@ void MakeCoarseLevelMaps(const int maxRegPerGID,
                          Array<std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > >& regRowImporters,
                          Array<Teuchos::RCP<Xpetra::MultiVector<GlobalOrdinal, LocalOrdinal, GlobalOrdinal, Node> > >& interfaceGIDs,
                          Array<Teuchos::RCP<Xpetra::MultiVector<LocalOrdinal, LocalOrdinal, GlobalOrdinal, Node> > >& regionsPerGIDWithGhosts,
-                         Array<Teuchos::Array<LocalOrdinal> >& regionMatVecLIDs,
+                         Array<Teuchos::ArrayRCP<LocalOrdinal> >& regionMatVecLIDs,
                          Array<Teuchos::RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > >& regionInterfaceImporter) {
 
 #include "Xpetra_UseShortNames.hpp"
@@ -654,7 +654,7 @@ void createRegionHierarchy(const int maxRegPerProc,
                            Array<Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > >& regInterfaceScalings,
                            Array<Teuchos::RCP<Xpetra::MultiVector<GlobalOrdinal, LocalOrdinal, GlobalOrdinal, Node> > >& interfaceGIDs,
                            Array<Teuchos::RCP<Xpetra::MultiVector<LocalOrdinal, LocalOrdinal, GlobalOrdinal, Node> > >& regionsPerGIDWithGhosts,
-                           Array<Teuchos::Array<LocalOrdinal> >& regionMatVecLIDs,
+                           Array<Teuchos::ArrayRCP<LocalOrdinal> >& regionMatVecLIDs,
                            Array<Teuchos::RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > >& regionInterfaceImporter,
                            const int maxRegPerGID,
                            ArrayView<LocalOrdinal> compositeToRegionLIDs,
@@ -1033,7 +1033,7 @@ void vCycle(const int l, ///< ID of current level
     if (useFastMatVec)
     {
       // Get pre-communicated communication patterns for the fast MatVec
-      const Array<LocalOrdinal> regionInterfaceLIDs = smootherParams[l+1]->get<Array<LO>>("Fast MatVec: interface LIDs");
+      const ArrayRCP<LocalOrdinal> regionInterfaceLIDs = smootherParams[l+1]->get<ArrayRCP<LO>>("Fast MatVec: interface LIDs");
       const RCP<Import> regionInterfaceImporter = smootherParams[l+1]->get<RCP<Import>>("Fast MatVec: interface importer");
 
       for (int j = 0; j < maxRegPerProc; j++) {
@@ -1079,7 +1079,7 @@ void vCycle(const int l, ///< ID of current level
     if (useFastMatVec)
     {
       // Get pre-communicated communication patterns for the fast MatVec
-      const Array<LocalOrdinal> regionInterfaceLIDs = smootherParams[l]->get<Array<LO>>("Fast MatVec: interface LIDs");
+      const ArrayRCP<LocalOrdinal> regionInterfaceLIDs = smootherParams[l]->get<ArrayRCP<LO>>("Fast MatVec: interface LIDs");
       const RCP<Import> regionInterfaceImporter = smootherParams[l]->get<RCP<Import>>("Fast MatVec: interface importer");
 
       for (int j = 0; j < maxRegPerProc; j++) {

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionHierarchy_def.hpp
@@ -1041,7 +1041,7 @@ void vCycle(const int l, ///< ID of current level
         coarseRegB[j] = VectorFactory::Build(regRowMaps[l+1][j], true);
 
         ApplyMatVec(SC_ONE, regProlong[l+1][j], regRes[j], SC_ZERO, regionInterfaceImporter,
-            regionInterfaceLIDs, coarseRegB[j], Teuchos::TRANS);
+            regionInterfaceLIDs, coarseRegB[j], Teuchos::TRANS, true);
         // TEUCHOS_ASSERT(regProlong[l+1][j]->getRangeMap()->isSameAs(*regRes[j]->getMap()));
         // TEUCHOS_ASSERT(regProlong[l+1][j]->getDomainMap()->isSameAs(*coarseRegB[j]->getMap()));
       }

--- a/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionMatrix_def.hpp
+++ b/packages/muelu/research/mmayr/composite_to_regions/src/SetupRegionMatrix_def.hpp
@@ -842,7 +842,7 @@ void ApplyMatVec(const Scalar alpha,
                  const Teuchos::Array<LocalOrdinal>& regionInterfaceLIDs,
                  RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& Y,
                  const Teuchos::ETransp transposeMode,
-                 const bool sumInterfaceValues = true) {
+                 const bool sumInterfaceValues) {
 #include "Xpetra_UseShortNames.hpp"
   using Teuchos::TimeMonitor;
   using local_matrix_type = typename Xpetra::Matrix<SC,LO,GO,Node>::local_matrix_type;
@@ -919,7 +919,7 @@ computeResidual(Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, No
   // Step 1: Compute region version of y = Ax
   RCP<Vector> aTimesX = VectorFactory::Build(regionGrpMats[0]->getRangeMap(), true);
   ApplyMatVec(TST::one(), regionGrpMats[0], regX[0],
-      TST::zero(), regionInterfaceImporter, regionInterfaceLIDs, aTimesX, Teuchos::NO_TRANS);
+      TST::zero(), regionInterfaceImporter, regionInterfaceLIDs, aTimesX, Teuchos::NO_TRANS, true);
 
   // Step 2: Compute region version of r = b - y
   regRes[0]->update(TST::one(), *regB[0], -TST::one(), *aTimesX, TST::zero());

--- a/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
+++ b/packages/muelu/research/regionMG/examples/structured/Driver_Structured_Regions.cpp
@@ -592,7 +592,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
                              lNodesPerDim, sendGIDs, sendPIDs, interfaceLIDsData,
                              regionsPerGIDWithGhosts, interfaceGIDsMV);
 
-  Teuchos::Array<LO> regionMatVecLIDs;
+  Teuchos::ArrayRCP<LO> regionMatVecLIDs;
   RCP<Import> regionInterfaceImporter;
   SetupMatVec(interfaceGIDsMV, regionsPerGIDWithGhosts, revisedRowMapPerGrp, rowImportPerGrp,
               regionMatVecLIDs, regionInterfaceImporter);
@@ -669,7 +669,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
   Array<RCP<Xpetra::MultiVector<LO, LO, GO, Node> > > regionsPerGIDWithGhostsPerLevel(1);
   interfaceGIDsPerLevel[0] = interfaceGIDsMV;
   regionsPerGIDWithGhostsPerLevel[0] = regionsPerGIDWithGhosts;
-  Array<Array<LO> > regionMatVecLIDsPerLevel(1);
+  Array<ArrayRCP<LO> > regionMatVecLIDsPerLevel(1);
   Array<RCP<Xpetra::Import<LO, GO, Node> > > regionInterfaceImporterPerLevel(1);
   regionMatVecLIDsPerLevel[0] = regionMatVecLIDs;
   regionInterfaceImporterPerLevel[0] = regionInterfaceImporter;

--- a/packages/muelu/test/unit_tests/RegionMatrix.cpp
+++ b/packages/muelu/test/unit_tests/RegionMatrix.cpp
@@ -73,7 +73,7 @@ void createRegionMatrix(const Teuchos::ParameterList galeriList,
                         std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > >& rowImportPerGrp,
                         std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > >& colImportPerGrp,
                         std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regionGrpMats,
-                        Teuchos::Array<LocalOrdinal>&  regionMatVecLIDs,
+                        Teuchos::ArrayRCP<LocalOrdinal>&  regionMatVecLIDs,
                         Teuchos::RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> >& regionInterfaceImporter) {
 #include <MueLu_UseShortNames.hpp>
 
@@ -192,7 +192,7 @@ void createProblem(const int maxRegPerProc, const LocalOrdinal numDofsPerNode,
                    std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regionGrpMats,
                    std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > >& revisedRowMapPerGrp,
                    std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > >& rowImportPerGrp,
-                   Teuchos::Array<LocalOrdinal>& regionMatVecLIDs,
+                   Teuchos::ArrayRCP<LocalOrdinal>& regionMatVecLIDs,
                    RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> >& regionInterfaceImporter) {
 #include <MueLu_UseShortNames.hpp>
   using TST                   = Teuchos::ScalarTraits<SC>;
@@ -414,7 +414,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, CompositeToRegionMatrix, Scalar,
   std::vector<RCP<Map> >    revisedRowMapPerGrp(maxRegPerProc), revisedColMapPerGrp(maxRegPerProc);
   std::vector<RCP<Import> > rowImportPerGrp(maxRegPerProc), colImportPerGrp(maxRegPerProc);
   std::vector<RCP<Matrix> > regionGrpMats(maxRegPerProc);
-  Teuchos::Array<LO> regionMatVecLIDs;
+  Teuchos::ArrayRCP<LO> regionMatVecLIDs;
   RCP<Import> regionInterfaceImporter;
   createRegionMatrix(galeriList, numDofsPerNode, maxRegPerProc, nodeMap, dofMap, A,
                      rowMapPerGrp, colMapPerGrp, revisedRowMapPerGrp, revisedColMapPerGrp,
@@ -592,7 +592,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, RegionToCompositeMatrix, Scalar,
   std::vector<RCP<Map> >    revisedRowMapPerGrp(maxRegPerProc), revisedColMapPerGrp(maxRegPerProc);
   std::vector<RCP<Import> > rowImportPerGrp(maxRegPerProc), colImportPerGrp(maxRegPerProc);
   std::vector<RCP<Matrix> > regionGrpMats(maxRegPerProc);
-  Teuchos::Array<LO> regionMatVecLIDs;
+  Teuchos::ArrayRCP<LO> regionMatVecLIDs;
   RCP<Import> regionInterfaceImporter;
   createRegionMatrix(galeriList, numDofsPerNode, maxRegPerProc, nodeMap, dofMap, A,
                      rowMapPerGrp, colMapPerGrp, revisedRowMapPerGrp, revisedColMapPerGrp,
@@ -696,7 +696,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, MatVec, Scalar, LocalOrdinal, Gl
   std::vector<RCP<Map> >    revisedRowMapPerGrp(maxRegPerProc), revisedColMapPerGrp(maxRegPerProc);
   std::vector<RCP<Import> > rowImportPerGrp(maxRegPerProc), colImportPerGrp(maxRegPerProc);
   std::vector<RCP<Matrix> > regionGrpMats(maxRegPerProc);
-  Teuchos::Array<LO> regionMatVecLIDs;
+  Teuchos::ArrayRCP<LO> regionMatVecLIDs;
   RCP<Import> regionInterfaceImporter;
   createRegionMatrix(galeriList, numDofsPerNode, maxRegPerProc, nodeMap, dofMap, A,
                      rowMapPerGrp, colMapPerGrp, revisedRowMapPerGrp, revisedColMapPerGrp,
@@ -796,7 +796,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, FastMatVec, Scalar, LocalOrdinal
   std::vector<RCP<Map> >    revisedRowMapPerGrp(maxRegPerProc), revisedColMapPerGrp(maxRegPerProc);
   std::vector<RCP<Import> > rowImportPerGrp(maxRegPerProc), colImportPerGrp(maxRegPerProc);
   std::vector<RCP<Matrix> > regionGrpMats(maxRegPerProc);
-  Teuchos::Array<LO> regionMatVecLIDs;
+  Teuchos::ArrayRCP<LO> regionMatVecLIDs;
   RCP<Import> regionInterfaceImporter;
   createRegionMatrix(galeriList, numDofsPerNode, maxRegPerProc, nodeMap, dofMap, A,
                      rowMapPerGrp, colMapPerGrp, revisedRowMapPerGrp, revisedColMapPerGrp,
@@ -900,7 +900,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, FastMatVec3D, Scalar, LocalOrdin
   RCP<Matrix> A;
   std::vector<RCP<Map> > revisedRowMapPerGrp(maxRegPerProc);
   std::vector<RCP<Import> > rowImportPerGrp(maxRegPerProc);
-  Teuchos::Array<LocalOrdinal> regionMatVecLIDs;
+  Teuchos::ArrayRCP<LocalOrdinal> regionMatVecLIDs;
   RCP<Import> regionInterfaceImporter;
 
   createProblem(maxRegPerProc, numDofsPerNode, galeriParameters, comm,
@@ -1000,7 +1000,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, FastMatVec2D_Elasticity, Scalar,
   RCP<Matrix> A;
   std::vector<RCP<Map> > revisedRowMapPerGrp(maxRegPerProc);
   std::vector<RCP<Import> > rowImportPerGrp(maxRegPerProc);
-  Teuchos::Array<LocalOrdinal> regionMatVecLIDs;
+  Teuchos::ArrayRCP<LocalOrdinal> regionMatVecLIDs;
   RCP<Import> regionInterfaceImporter;
 
   createProblem(maxRegPerProc, numDofsPerNode, galeriParameters, comm,
@@ -1100,7 +1100,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, FastMatVec3D_Elasticity, Scalar,
   RCP<Matrix> A;
   std::vector<RCP<Map> > revisedRowMapPerGrp(maxRegPerProc);
   std::vector<RCP<Import> > rowImportPerGrp(maxRegPerProc);
-  Teuchos::Array<LocalOrdinal> regionMatVecLIDs;
+  Teuchos::ArrayRCP<LocalOrdinal> regionMatVecLIDs;
   RCP<Import> regionInterfaceImporter;
 
   createProblem(maxRegPerProc, numDofsPerNode, galeriParameters, comm,
@@ -1219,7 +1219,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, Laplace2D, Scalar, LocalOrdinal,
   std::vector<RCP<Map> >    revisedRowMapPerGrp(maxRegPerProc), revisedColMapPerGrp(maxRegPerProc);
   std::vector<RCP<Import> > rowImportPerGrp(maxRegPerProc), colImportPerGrp(maxRegPerProc);
   std::vector<RCP<Matrix> > regionGrpMats(maxRegPerProc);
-  Teuchos::Array<LO> regionMatVecLIDs;
+  Teuchos::ArrayRCP<LO> regionMatVecLIDs;
   RCP<Import> regionInterfaceImporter;
   createRegionMatrix(galeriList, numDofsPerNode, maxRegPerProc, nodeMap, dofMap, A,
                      rowMapPerGrp, colMapPerGrp, revisedRowMapPerGrp, revisedColMapPerGrp,
@@ -1396,7 +1396,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, Laplace3D, Scalar, LocalOrdinal,
   std::vector<RCP<Map> >    revisedRowMapPerGrp(maxRegPerProc), revisedColMapPerGrp(maxRegPerProc);
   std::vector<RCP<Import> > rowImportPerGrp(maxRegPerProc), colImportPerGrp(maxRegPerProc);
   std::vector<RCP<Matrix> > regionGrpMats(maxRegPerProc);
-  Teuchos::Array<LO> regionMatVecLIDs;
+  Teuchos::ArrayRCP<LO> regionMatVecLIDs;
   RCP<Import> regionInterfaceImporter;
   createRegionMatrix(galeriList, numDofsPerNode, maxRegPerProc, nodeMap, dofMap, A,
                      rowMapPerGrp, colMapPerGrp, revisedRowMapPerGrp, revisedColMapPerGrp,

--- a/packages/muelu/test/unit_tests/RegionMatrix.cpp
+++ b/packages/muelu/test/unit_tests/RegionMatrix.cpp
@@ -853,7 +853,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, FastMatVec, Scalar, LocalOrdinal
   regC[0] = VectorFactory::Build(revisedRowMapPerGrp[0], true);
   ApplyMatVec(TST::one(), regionMat, regX[0], TST::zero(),
               regionInterfaceImporter, regionMatVecLIDs,
-              regC[0], Teuchos::NO_TRANS);
+              regC[0], Teuchos::NO_TRANS, true);
 
   ArrayRCP<const SC> dataRegC = regC[0]->getData(0);
   for(size_t idx = 0; idx < refRegB[0]->getLocalLength(); ++idx) {
@@ -957,7 +957,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, FastMatVec3D, Scalar, LocalOrdin
   regC[0] = VectorFactory::Build(revisedRowMapPerGrp[0], true);
   ApplyMatVec(TST::one(), regionMat, regX[0], TST::zero(),
               regionInterfaceImporter, regionMatVecLIDs,
-              regC[0], Teuchos::NO_TRANS);
+              regC[0], Teuchos::NO_TRANS, true);
 
   ArrayRCP<const SC> dataRegC = regC[0]->getData(0);
   for(size_t idx = 0; idx < refRegB[0]->getLocalLength(); ++idx) {
@@ -1057,7 +1057,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, FastMatVec2D_Elasticity, Scalar,
   regC[0] = VectorFactory::Build(revisedRowMapPerGrp[0], true);
   ApplyMatVec(TST::one(), regionMat, regX[0], TST::zero(),
               regionInterfaceImporter, regionMatVecLIDs,
-              regC[0], Teuchos::NO_TRANS);
+              regC[0], Teuchos::NO_TRANS, true);
 
   ArrayRCP<const SC> dataRegC = regC[0]->getData(0);
   for(size_t idx = 0; idx < refRegB[0]->getLocalLength(); ++idx) {
@@ -1157,7 +1157,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, FastMatVec3D_Elasticity, Scalar,
   regC[0] = VectorFactory::Build(revisedRowMapPerGrp[0], true);
   ApplyMatVec(TST::one(), regionMat, regX[0], TST::zero(),
               regionInterfaceImporter, regionMatVecLIDs,
-              regC[0], Teuchos::NO_TRANS);
+              regC[0], Teuchos::NO_TRANS, true);
 
   ArrayRCP<const SC> dataRegC = regC[0]->getData(0);
   for(size_t idx = 0; idx < refRegB[0]->getLocalLength(); ++idx) {

--- a/packages/muelu/test/unit_tests/RegionMatrix.cpp
+++ b/packages/muelu/test/unit_tests/RegionMatrix.cpp
@@ -853,7 +853,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, FastMatVec, Scalar, LocalOrdinal
   regC[0] = VectorFactory::Build(revisedRowMapPerGrp[0], true);
   ApplyMatVec(TST::one(), regionMat, regX[0], TST::zero(),
               regionInterfaceImporter, regionMatVecLIDs,
-              regC[0]);
+              regC[0], Teuchos::NO_TRANS);
 
   ArrayRCP<const SC> dataRegC = regC[0]->getData(0);
   for(size_t idx = 0; idx < refRegB[0]->getLocalLength(); ++idx) {
@@ -957,7 +957,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, FastMatVec3D, Scalar, LocalOrdin
   regC[0] = VectorFactory::Build(revisedRowMapPerGrp[0], true);
   ApplyMatVec(TST::one(), regionMat, regX[0], TST::zero(),
               regionInterfaceImporter, regionMatVecLIDs,
-              regC[0]);
+              regC[0], Teuchos::NO_TRANS);
 
   ArrayRCP<const SC> dataRegC = regC[0]->getData(0);
   for(size_t idx = 0; idx < refRegB[0]->getLocalLength(); ++idx) {
@@ -1057,7 +1057,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, FastMatVec2D_Elasticity, Scalar,
   regC[0] = VectorFactory::Build(revisedRowMapPerGrp[0], true);
   ApplyMatVec(TST::one(), regionMat, regX[0], TST::zero(),
               regionInterfaceImporter, regionMatVecLIDs,
-              regC[0]);
+              regC[0], Teuchos::NO_TRANS);
 
   ArrayRCP<const SC> dataRegC = regC[0]->getData(0);
   for(size_t idx = 0; idx < refRegB[0]->getLocalLength(); ++idx) {
@@ -1157,7 +1157,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, FastMatVec3D_Elasticity, Scalar,
   regC[0] = VectorFactory::Build(revisedRowMapPerGrp[0], true);
   ApplyMatVec(TST::one(), regionMat, regX[0], TST::zero(),
               regionInterfaceImporter, regionMatVecLIDs,
-              regC[0]);
+              regC[0], Teuchos::NO_TRANS);
 
   ArrayRCP<const SC> dataRegC = regC[0]->getData(0);
   for(size_t idx = 0; idx < refRegB[0]->getLocalLength(); ++idx) {


### PR DESCRIPTION
@trilinos/muelu 

## Motivation

- The "fast MatVec" reduces the amount of communication to be performed during a MatVec and also exploits the local character of the region data layouts.
- Storage of interface region LIDs is converted from `Array` to `ArrayRCP` so avoid deep copies during the apply phase.

## Related Issues

* Closes #7175 
* Follows #7499 

## Stakeholder Feedback

This work is part of an ASCR project with @rstumin and @lucbv.

## Testing

`ctest -R MueLu_Structured_Region` and regionMG unit tests pass.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->