### PR TITLE
Piro: a couple of cleanups to avoid warnings printed when running code.

### DIFF
--- a/packages/piro/src/Piro_ObserverToTempusIntegrationObserverAdapter_Def.hpp
+++ b/packages/piro/src/Piro_ObserverToTempusIntegrationObserverAdapter_Def.hpp
@@ -204,16 +204,16 @@ void
 Piro::ObserverToTempusIntegrationObserverAdapter<Scalar>::observeTimeStep()
 {
   Scalar current_dt; 
-  if (Teuchos::nonnull(solutionHistory_->getWorkingState())) {
-    current_dt = solutionHistory_->getWorkingState()->getTimeStep();
+  if (Teuchos::nonnull(solutionHistory_->getCurrentState())) {
+    current_dt = solutionHistory_->getCurrentState()->getTimeStep();
   }
   else {
     current_dt = solutionHistory_->getCurrentState()->getTimeStep();
   }
   
   //Don't observe solution if step failed to converge
-  if ((solutionHistory_->getWorkingState() != Teuchos::null) &&
-     (solutionHistory_->getWorkingState()->getSolutionStatus() == Tempus::Status::FAILED)) {
+  if ((solutionHistory_->getCurrentState() != Teuchos::null) &&
+     (solutionHistory_->getCurrentState()->getSolutionStatus() == Tempus::Status::FAILED)) {
     Scalar min_dt = timeStepControl_->getMinTimeStep(); 
     if ((previous_dt_ == current_dt) && (previous_dt_ == min_dt)) {
       TEUCHOS_TEST_FOR_EXCEPTION(true, Teuchos::Exceptions::InvalidParameter, 

--- a/packages/piro/src/Piro_TransientSolver_Def.hpp
+++ b/packages/piro/src/Piro_TransientSolver_Def.hpp
@@ -290,7 +290,7 @@ Piro::TransientSolver<Scalar>::evalConvergedModelResponsesAndSensitivities(
   using Teuchos::RCP;
   using Teuchos::rcp;
 
-  *out_ << "\nE) Calculate responses ...\n";
+  *out_ << "\nF) Calculate responses ...\n";
 
   // Solution at convergence is the response at index num_g_
   RCP<Thyra::VectorBase<Scalar> > gx_out = outArgs.get_g(num_g_);


### PR DESCRIPTION
A few minor cleanups to clarify output from Piro for transient problems.  In particular, gets ride of pesky and confusing "WorkingState is null" warnings.