### PR TITLE
This just casts an unsigned to signed to avoid a compiler assert in a…

### DIFF
--- a/packages/pamgen/rtcompiler/Registrar.C
+++ b/packages/pamgen/rtcompiler/Registrar.C
@@ -556,7 +556,7 @@ double Readline::execute(Value** args)
 
   string line;
   if (getline(curr_file, line)) {
-    assert(args[1]->getSize() > line.size()); // buffer needs to be big enough
+     assert(args[1]->getSize() > int(line.size())); // buffer needs to be big enough
     for (size_t i = 0; i < line.size(); ++i) {
       args[1]->setArrayValue(line[i], i);
     }

--- a/packages/pamgen/rtcompiler/Registrar.C
+++ b/packages/pamgen/rtcompiler/Registrar.C
@@ -556,7 +556,7 @@ double Readline::execute(Value** args)
 
   string line;
   if (getline(curr_file, line)) {
-     assert(args[1]->getSize() > int(line.size())); // buffer needs to be big enough
+     assert(args[1]->getSize() > long(line.size())); // buffer needs to be big enough
     for (size_t i = 0; i < line.size(); ++i) {
       args[1]->setArrayValue(line[i], i);
     }


### PR DESCRIPTION
… debug build.

Not sure how this was missed this long - found
when setting up a debug PR build.

@trilinos/pamgen 

## Motivation
This is in preparation for a debug gcc 7.2.0 build

## Testing
Built against a gcc 7.2.0 debug build with -Wall