### PR TITLE
Tpetra: new constructor for FECrsGraph accepting owned+shared domain map

### DIFF
--- a/packages/tpetra/core/src/Tpetra_FECrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_FECrsGraph_decl.hpp
@@ -119,6 +119,8 @@ namespace Tpetra {
   ///
   ///       Notice that if your mesh is partitioned by node (N) OR you provide a valid colMap
   ///       to the graph's constructor, then using V1 is likely ok for you.
+  ///
+  ///       For more details, see GitHub issue #7455
 
   template <class LocalOrdinal,
             class GlobalOrdinal,

--- a/packages/tpetra/core/src/Tpetra_FECrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_FECrsGraph_decl.hpp
@@ -73,6 +73,52 @@ namespace Tpetra {
   /// This class has an interface like that of Epetra_CrsGraph, but
   /// also allows insertion of data into nonowned rows, much like
   /// Epetra_FECrsGraph.
+  ///
+  /// Note on some versions of the constructors:
+  ///       consturctors appear in two fashions: one that accepts only one (optional) domainMap
+  ///       (let's call it V1) and one that accepts two domainMaps (let's call it V2).
+  ///       In V1, the input domainMap will be used for both owned and owned+shared graphs.
+  ///       In this case, you *should* provide a map that works for the owned graph (since
+  ///       that's the graph you will use in mat-vec and mat-mat produts, which will be checked).
+  ///       The domain map for the owned+shared graph is *usually* only needed to build the colMap
+  ///       of the owned+shared graph.
+  ///
+  ///       Whether you need V2 or are ok with V1 depends on what your "owned+shared" maps contain.
+  ///
+  ///       If you partition a mesh by node (N), then your owned+shared maps should contain all the
+  ///       nodes that are in the patch of one of the owned nodes, which is precisely what
+  ///       the colMap of the owned+shared graph should contain.
+  ///       On the other hand, if you partition the mesh by cell (C), then your owned+shared maps 
+  ///       should contain all nodes belonging to one of the owned elements. Such map does *NOT*
+  ///       necessarily contain all the GID of all the nodes connected to one of the owned nodes
+  ///       (which is what the colMap should contain). In this case, you are not likely to have
+  ///       a colMap available, and you'll rely on Tpetra to build one for you once the graph
+  ///       is filled.
+  ///
+  ///       If you do not provide a valid owned+shared colMap, then Tpetra creates one for you,
+  ///       which is used for both the owned+shared and owned graphs. When doing this, Tpetra
+  ///       guarantees that the domain map of the owned+shared graph is "locally fitted" to its
+  ///       colMap (see Tpetra::Map documentation for the meaning of 'locally fitted').
+  ///       If you use V1, then the domain map is the owned dofs only, which means that the
+  ///       non-owned GIDs will appear in the colMap in an order that is out of your control.
+  ///
+  ///       Now, if you partition by Cell (C), then you don't have a colMap when you create
+  ///       the graph, but only a owned+shared one. If you use version V1 of the consturctor,
+  ///       the Local ID of the shared dofs in the graph's colMap is likely to NOT be the same
+  ///       as in your owned+shared map, since the colMap creation only guarantees that the input
+  ///       domainMap (which should contian owned dofs only) is going to be locally fitted in the
+  ///       colMap. All other GIDs will appear in an order that you can't control.
+  ///
+  ///       On the other hand, if you use V2, then you are guaranteed that the owend+shared domain
+  ///       map you provide will be locally fitted to the graph colMap.
+  ///
+  ///       This difference is important when you do local assembly with a FECrsMatrix: if the Local IDs
+  ///       of the dofs in your owned+shared maps is THE SAME as in the graph's col map, then you can do
+  ///       assembly using local ids. Otherwise, you need to have access to the GIDs of the dofs,
+  ///       extract the colMap from the matrix, and convert GIDs into LIDs ACCORDINGLY TO THE COL MAP.
+  ///
+  ///       Notice that if your mesh is partitioned by node (N) OR you provide a valid colMap
+  ///       to the graph's constructor, then using V1 is likely ok for you.
 
   template <class LocalOrdinal,
             class GlobalOrdinal,
@@ -128,20 +174,20 @@ namespace Tpetra {
     /// \param ownedPlusSharedToOwnedimporter [in] Optional importer between the ownedMap and ownedPlusSharedMap
     ///   This will be calculated by FECrsGraph if it is not provided
     ///
-    /// \param ownedDomainMap [in] Optional domain map for both owned and owned+shared graphs. If this is not provided,
-    ////  then ownedMap will be used in the call to endFill()
+    /// \param domainMap [in] Optional domain map for both owned and owned+shared graphs. If this is null,
+    ////  then ownedMap will be used as domain map for both graphs.
     ///
     /// \param ownedRangeMap [in] Optional range map for the owned graph.  If this is not provided, then ownedMap
-    ///   will be used for the ownedDomainMap in the call to endFill()
+    ///   will be used as range map for the owned graph.
     ///
-    /// \param params [in/out] Optional list of parameters.  If not
+    /// \param params [in/out] Optional list of parameters.  If not 
     ///   null, any missing parameters will be filled in with their
     ///   default values.
     FECrsGraph(const Teuchos::RCP<const map_type> & ownedRowMap,
                const Teuchos::RCP<const map_type> & ownedPlusSharedRowMap,
                const size_t maxNumEntriesPerRow,
                const Teuchos::RCP<const import_type> & ownedPlusSharedToOwnedimporter = Teuchos::null,
-               const Teuchos::RCP<const map_type> & ownedDomainMap = Teuchos::null,
+               const Teuchos::RCP<const map_type> & domainMap = Teuchos::null,
                const Teuchos::RCP<const map_type> & ownedRangeMap = Teuchos::null,
                const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
@@ -157,16 +203,16 @@ namespace Tpetra {
     ///   entries in any row.
     ///
     /// \param ownedPlusSharedDomainMap [in] Domain map for the owned+shared graph. If this is null,
-    ///   then ownedPlusSharedRowMap will be used in the call to endFill()
+    ///   then ownedPlusSharedRowMap will be used as domain map for the owned+shared graph.
     ///
     /// \param ownedPlusSharedToOwnedimporter [in] Optional importer between the ownedMap and ownedPlusSharedMap
     ///   This will be calculated by FECrsGraph if it is not provided
     ///
-    /// \param ownedDomainMap [in] Optional domain map for the owned graph. If this is not provided,
-    ////  then ownedMap will be used in the call to endFill()
+    /// \param ownedDomainMap [in] Optional domain map for the owned graph. If this is null,
+    ////  then ownedMap will be used as domain map for the owned graph.
     ///
     /// \param ownedRangeMap [in] Optional range map for the owned graph.  If this is not provided, then ownedMap
-    ///   will be used for the ownedDomainMap in the call to endFill()
+    ///   will be used as range map for the owned graph.
     ///
     /// \param params [in/out] Optional list of parameters.  If not
     ///   null, any missing parameters will be filled in with their
@@ -194,11 +240,11 @@ namespace Tpetra {
     /// \param ownedPlusSharedToOwnedimporter [in] Optional importer between the ownedMap and ownedPlusSharedMap
     ///   This will be calculated by FECrsGraph if it is not provided
     ///
-    /// \param ownedDomainMap [in] Optional domain map for both owned and owned+shared graphs. If this is not provided,
-    ////  then ownedMap will be used in the call to endFill()
+    /// \param domainMap [in] Optional domain map for both owned and owned+shared graphs. If this is null,
+    ////  then ownedMap will be used as domain map for both graphs.
     ///
     /// \param ownedRangeMap [in] Optional range map for the owned graph.  If this is not provided, then ownedMap
-    ///   will be used for the ownedDomainMap in the call to endFill()
+    ///   will be used as range map for the owned graph.
     ///
     /// \param params [in/out] Optional list of parameters.  If not
     ///   null, any missing parameters will be filled in with their
@@ -207,7 +253,7 @@ namespace Tpetra {
                 const Teuchos::RCP<const map_type> & ownedPlusSharedRowMap,
                 const Kokkos::DualView<const size_t*, execution_space>& numEntPerRow,
                 const Teuchos::RCP<const import_type> & ownedPlusSharedToOwnedimporter = Teuchos::null,
-                const Teuchos::RCP<const map_type> & ownedDomainMap = Teuchos::null,
+                const Teuchos::RCP<const map_type> & domainMap = Teuchos::null,
                 const Teuchos::RCP<const map_type> & ownedRangeMap = Teuchos::null,
                 const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
@@ -229,10 +275,10 @@ namespace Tpetra {
     ///   This will be calculated by FECrsGraph if it is not provided
     ///
     /// \param ownedDomainMap [in] Optional domain map for the owned graph. If this is not provided,
-    ////  then ownedMap will be used in the call to endFill()
+    ////  then ownedMap will be used as domain map for the owned graph.
     ///
     /// \param ownedRangeMap [in] Optional range map for the owned graph.  If this is not provided, then ownedMap
-    ///   will be used for the ownedDomainMap in the call to endFill()
+    ///   will be used as range map for the owned graph.
     ///
     /// \param params [in/out] Optional list of parameters.  If not
     ///   null, any missing parameters will be filled in with their
@@ -263,11 +309,11 @@ namespace Tpetra {
     /// \param ownedPlusSharedToOwnedimporter [in] Optional importer between the ownedMap and ownedPlusSharedMap
     ///   This will be calculated by FECrsGraph if it is not provided
     ///
-    /// \param ownedDomainMap [in] Optional domain map for the owned graph.  If this is not provided, then ownedMap
-    ///   will be used for the ownedDomainMap in the call to endFill()
+    /// \param domainMap [in] Optional domain map for the both owned and owned+shared graphs.  If this is not provided,
+    ///   then ownedMap will be used as domain map for both graphs.
     ///
     /// \param ownedRangeMap [in] Optional range map for the owned graph.  If this is not provided, then ownedMap
-    ///   will be used for the ownedDomainMap in the call to endFill()
+    ///   will be used as range map for the owned graph
     ///
     /// \param params [in/out] Optional list of parameters.  If not
     ///   null, any missing parameters will be filled in with their
@@ -277,7 +323,7 @@ namespace Tpetra {
                const Teuchos::RCP<const map_type> & ownedPlusSharedColMap,
                const size_t maxNumEntriesPerRow,
                const Teuchos::RCP<const import_type> & ownedPlusSharedToOwnedimporter = Teuchos::null,
-               const Teuchos::RCP<const map_type> & ownedDomainMap = Teuchos::null,
+               const Teuchos::RCP<const map_type> & domainMap = Teuchos::null,
                const Teuchos::RCP<const map_type> & ownedRangeMap = Teuchos::null,
                const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
@@ -295,15 +341,15 @@ namespace Tpetra {
     ///   entries in any row.
     ///
     /// \param ownedPlusSharedDomainMap [in] Domain map for the owned+shared graph. If this is null, then ownedPlusSharedRowMap
-    ///   will be used for the ownedDomainMap in the call to endFill()
+    ///   will be used as domain map for the owned+shared graph.
     /// \param ownedPlusSharedToOwnedimporter [in] Optional importer between the ownedMap and ownedPlusSharedMap
     ///   This will be calculated by FECrsGraph if it is not provided
     ///
     /// \param ownedDomainMap [in] Optional domain map for the owned graph.  If this is not provided, then ownedMap
-    ///   will be used for the ownedDomainMap in the call to endFill()
+    ///   will be used as domain map for the owned graph.
     ///
     /// \param ownedRangeMap [in] Optional range map for the owned graph.  If this is not provided, then ownedMap
-    ///   will be used for the ownedDomainMap in the call to endFill()
+    ///   will be used as range map for the owned graph.
     ///
     /// \param params [in/out] Optional list of parameters.  If not
     ///   null, any missing parameters will be filled in with their
@@ -333,11 +379,11 @@ namespace Tpetra {
     /// \param ownedPlusSharedToOwnedimporter [in] Optional importer between the ownedMap and ownedPlusSharedMap
     ///   This will be calculated by FECrsGraph if it is not provided
     ///
-    /// \param ownedDomainMap [in] Optional domain map for the owned graph.  If this is not provided, then ownedMap
-    ///   will be used for the ownedDomainMap in the call to endFill()
+    /// \param domainMap [in] Optional domain map for both the owned and owned+shared graphs.  If this is not provided,
+    ///   then ownedMap will be used as domain map for both graphs.
     ///
     /// \param ownedRangeMap [in] Optional range map for the owned graph.  If this is not provided, then ownedMap
-    ///   will be used for the ownedDomainMap in the call to endFill()
+    ///   will be used as range map for the owned graph
     ///
     /// \param params [in/out] Optional list of parameters.  If not
     ///   null, any missing parameters will be filled in with their
@@ -347,7 +393,7 @@ namespace Tpetra {
                 const Teuchos::RCP<const map_type> & ownedPlusSharedColMap,
                 const Kokkos::DualView<const size_t*, execution_space>& numEntPerRow,
                 const Teuchos::RCP<const import_type> & ownedPlusSharedToOwnedimporter = Teuchos::null,
-                const Teuchos::RCP<const map_type> & ownedDomainMap = Teuchos::null,
+                const Teuchos::RCP<const map_type> & domainMap = Teuchos::null,
                 const Teuchos::RCP<const map_type> & ownedRangeMap = Teuchos::null,
                 const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
@@ -367,10 +413,10 @@ namespace Tpetra {
     ///   This will be calculated by FECrsGraph if it is not provided
     ///
     /// \param ownedDomainMap [in] Optional domain map for the owned graph.  If this is not provided, then ownedMap
-    ///   will be used for the ownedDomainMap in the call to endFill()
+    ///   will be used as domain map for the owned graph.
     ///
     /// \param ownedRangeMap [in] Optional range map for the owned graph.  If this is not provided, then ownedMap
-    ///   will be used for the ownedDomainMap in the call to endFill()
+    ///   will be used as range map for the owned graph.
     ///
     /// \param params [in/out] Optional list of parameters.  If not
     ///   null, any missing parameters will be filled in with their

--- a/packages/tpetra/core/src/Tpetra_FECrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_FECrsGraph_decl.hpp
@@ -128,11 +128,11 @@ namespace Tpetra {
     /// \param ownedPlusSharedToOwnedimporter [in] Optional importer between the ownedMap and ownedPlusSharedMap
     ///   This will be calculated by FECrsGraph if it is not provided
     ///
-    /// \param domainMap [in] Optional domainMap for the owned graph.  If this is not provided, then ownedMap
-    ///   will be used for the domainMap in the call to endFill()
+    /// \param ownedDomainMap [in] Optional domain map for both owned and owned+shared graphs. If this is not provided,
+    ////  then ownedMap will be used in the call to endFill()
     ///
-    /// \param rangeMap [in] Optional domainMap for the owned graph.  If this is not provided, then ownedMap
-    ///   will be used for the domainMap in the call to endFill()
+    /// \param ownedRangeMap [in] Optional range map for the owned graph.  If this is not provided, then ownedMap
+    ///   will be used for the ownedDomainMap in the call to endFill()
     ///
     /// \param params [in/out] Optional list of parameters.  If not
     ///   null, any missing parameters will be filled in with their
@@ -141,9 +141,44 @@ namespace Tpetra {
                const Teuchos::RCP<const map_type> & ownedPlusSharedRowMap,
                const size_t maxNumEntriesPerRow,
                const Teuchos::RCP<const import_type> & ownedPlusSharedToOwnedimporter = Teuchos::null,
-               const Teuchos::RCP<const map_type> & domainMap = Teuchos::null,
-               const Teuchos::RCP<const map_type> & rangeMap = Teuchos::null,
+               const Teuchos::RCP<const map_type> & ownedDomainMap = Teuchos::null,
+               const Teuchos::RCP<const map_type> & ownedRangeMap = Teuchos::null,
                const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
+
+    /// \brief Constructorfor globally-indexed assembly specifying a single upper bound for the
+    ///   number of entries in all rows on the calling process.
+    ///
+    /// \param ownedRowMap [in] Distribution of rows of the owned graph.
+    ///
+    /// \param ownedPlusSharedRowMap [in] ownedMap plus the list of shared rows to which off-processor insertion is allowed
+    ///
+    /// \param maxNumEntriesPerRow [in] Maximum number of graph
+    ///   entries per row.  You cannot exceed this number of
+    ///   entries in any row.
+    ///
+    /// \param ownedPlusSharedDomainMap [in] Domain map for the owned+shared graph. If this is null,
+    ///   then ownedPlusSharedRowMap will be used in the call to endFill()
+    ///
+    /// \param ownedPlusSharedToOwnedimporter [in] Optional importer between the ownedMap and ownedPlusSharedMap
+    ///   This will be calculated by FECrsGraph if it is not provided
+    ///
+    /// \param ownedDomainMap [in] Optional domain map for the owned graph. If this is not provided,
+    ////  then ownedMap will be used in the call to endFill()
+    ///
+    /// \param ownedRangeMap [in] Optional range map for the owned graph.  If this is not provided, then ownedMap
+    ///   will be used for the ownedDomainMap in the call to endFill()
+    ///
+    /// \param params [in/out] Optional list of parameters.  If not
+    ///   null, any missing parameters will be filled in with their
+    ///   default values.
+    FECrsGraph (const Teuchos::RCP<const map_type> & ownedRowMap,
+                const Teuchos::RCP<const map_type> & ownedPlusSharedRowMap,
+                const size_t maxNumEntriesPerRow,
+                const Teuchos::RCP<const map_type> & ownedPlusSharedDomainMap,
+                const Teuchos::RCP<const import_type> & ownedPlusSharedToOwnedimporter = Teuchos::null,
+                const Teuchos::RCP<const map_type> & ownedDomainMap = Teuchos::null,
+                const Teuchos::RCP<const map_type> & ownedRangeMap = Teuchos::null,
+                const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
     /// \brief Constructor for globally-indexed assembly specifying a (possibly different) upper
     ///   bound for the number of entries in each row.
@@ -159,11 +194,11 @@ namespace Tpetra {
     /// \param ownedPlusSharedToOwnedimporter [in] Optional importer between the ownedMap and ownedPlusSharedMap
     ///   This will be calculated by FECrsGraph if it is not provided
     ///
-    /// \param domainMap [in] Optional domainMap for the owned graph.  If this is not provided, then ownedMap
-    ///   will be used for the domainMap in the call to endFill()
+    /// \param ownedDomainMap [in] Optional domain map for both owned and owned+shared graphs. If this is not provided,
+    ////  then ownedMap will be used in the call to endFill()
     ///
-    /// \param rangeMap [in] Optional domainMap for the owned graph.  If this is not provided, then ownedMap
-    ///   will be used for the domainMap in the call to endFill()
+    /// \param ownedRangeMap [in] Optional range map for the owned graph.  If this is not provided, then ownedMap
+    ///   will be used for the ownedDomainMap in the call to endFill()
     ///
     /// \param params [in/out] Optional list of parameters.  If not
     ///   null, any missing parameters will be filled in with their
@@ -172,8 +207,43 @@ namespace Tpetra {
                 const Teuchos::RCP<const map_type> & ownedPlusSharedRowMap,
                 const Kokkos::DualView<const size_t*, execution_space>& numEntPerRow,
                 const Teuchos::RCP<const import_type> & ownedPlusSharedToOwnedimporter = Teuchos::null,
-                const Teuchos::RCP<const map_type> & domainMap = Teuchos::null,
-                const Teuchos::RCP<const map_type> & rangeMap = Teuchos::null,
+                const Teuchos::RCP<const map_type> & ownedDomainMap = Teuchos::null,
+                const Teuchos::RCP<const map_type> & ownedRangeMap = Teuchos::null,
+                const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
+
+    /// \brief Constructor for globally-indexed assembly specifying a (possibly different) upper
+    ///   bound for the number of entries in each row.
+    ///
+    /// \param ownedRowMap [in] Distribution of rows of the owned graph.
+    ///
+    /// \param ownedPlusSharedRowMap [in] ownedMap plus the list of shared rows to which off-processor insertion is allowed
+    ///
+    /// \param numEntPerRow [in] Maximum number of graph entries to
+    ///   allocate for each row.  You cannot exceed the allocated
+    ///   number of entries for any row.
+    ///
+    /// \param ownedPlusSharedDomainMap [in] Domain map for the owned+shared graph. If this is null,
+    ///   then ownedPlusSharedRowMap will be used in the call to endFill()
+    ///
+    /// \param ownedPlusSharedToOwnedimporter [in] Optional importer between the ownedMap and ownedPlusSharedMap
+    ///   This will be calculated by FECrsGraph if it is not provided
+    ///
+    /// \param ownedDomainMap [in] Optional domain map for the owned graph. If this is not provided,
+    ////  then ownedMap will be used in the call to endFill()
+    ///
+    /// \param ownedRangeMap [in] Optional range map for the owned graph.  If this is not provided, then ownedMap
+    ///   will be used for the ownedDomainMap in the call to endFill()
+    ///
+    /// \param params [in/out] Optional list of parameters.  If not
+    ///   null, any missing parameters will be filled in with their
+    ///   default values.
+    FECrsGraph (const Teuchos::RCP<const map_type> & ownedRowMap,
+                const Teuchos::RCP<const map_type> & ownedPlusSharedRowMap,
+                const Kokkos::DualView<const size_t*, execution_space>& numEntPerRow,
+                const Teuchos::RCP<const map_type> & ownedPlusSharedDomainMap,
+                const Teuchos::RCP<const import_type> & ownedPlusSharedToOwnedimporter = Teuchos::null,
+                const Teuchos::RCP<const map_type> & ownedDomainMap = Teuchos::null,
+                const Teuchos::RCP<const map_type> & ownedRangeMap = Teuchos::null,
                 const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
 
@@ -193,11 +263,11 @@ namespace Tpetra {
     /// \param ownedPlusSharedToOwnedimporter [in] Optional importer between the ownedMap and ownedPlusSharedMap
     ///   This will be calculated by FECrsGraph if it is not provided
     ///
-    /// \param domainMap [in] Optional domainMap for the owned graph.  If this is not provided, then ownedMap
-    ///   will be used for the domainMap in the call to endFill()
+    /// \param ownedDomainMap [in] Optional domain map for the owned graph.  If this is not provided, then ownedMap
+    ///   will be used for the ownedDomainMap in the call to endFill()
     ///
-    /// \param rangeMap [in] Optional domainMap for the owned graph.  If this is not provided, then ownedMap
-    ///   will be used for the domainMap in the call to endFill()
+    /// \param ownedRangeMap [in] Optional range map for the owned graph.  If this is not provided, then ownedMap
+    ///   will be used for the ownedDomainMap in the call to endFill()
     ///
     /// \param params [in/out] Optional list of parameters.  If not
     ///   null, any missing parameters will be filled in with their
@@ -207,8 +277,45 @@ namespace Tpetra {
                const Teuchos::RCP<const map_type> & ownedPlusSharedColMap,
                const size_t maxNumEntriesPerRow,
                const Teuchos::RCP<const import_type> & ownedPlusSharedToOwnedimporter = Teuchos::null,
-               const Teuchos::RCP<const map_type> & domainMap = Teuchos::null,
-               const Teuchos::RCP<const map_type> & rangeMap = Teuchos::null,
+               const Teuchos::RCP<const map_type> & ownedDomainMap = Teuchos::null,
+               const Teuchos::RCP<const map_type> & ownedRangeMap = Teuchos::null,
+               const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
+
+    /// \brief Constructor for locally-indexed assembly specifying a single upper bound for the
+    ///   number of entries in all rows on the calling process.
+    ///
+    /// \param ownedRowMap [in] Distribution of rows of the owned graph.
+    ///
+    /// \param ownedPlusSharedRowMap [in] ownedMap plus the list of shared rows to which off-processor insertion is allowed
+    ///
+    /// \param ownedPlusSharedColMap [in] list of owned and shared columns into which assertion is allowed.
+    ///
+    /// \param maxNumEntriesPerRow [in] Maximum number of graph
+    ///   entries per row.  You cannot exceed this number of
+    ///   entries in any row.
+    ///
+    /// \param ownedPlusSharedDomainMap [in] Domain map for the owned+shared graph. If this is null, then ownedPlusSharedRowMap
+    ///   will be used for the ownedDomainMap in the call to endFill()
+    /// \param ownedPlusSharedToOwnedimporter [in] Optional importer between the ownedMap and ownedPlusSharedMap
+    ///   This will be calculated by FECrsGraph if it is not provided
+    ///
+    /// \param ownedDomainMap [in] Optional domain map for the owned graph.  If this is not provided, then ownedMap
+    ///   will be used for the ownedDomainMap in the call to endFill()
+    ///
+    /// \param ownedRangeMap [in] Optional range map for the owned graph.  If this is not provided, then ownedMap
+    ///   will be used for the ownedDomainMap in the call to endFill()
+    ///
+    /// \param params [in/out] Optional list of parameters.  If not
+    ///   null, any missing parameters will be filled in with their
+    ///   default values.
+    FECrsGraph(const Teuchos::RCP<const map_type> & ownedRowMap,
+               const Teuchos::RCP<const map_type> & ownedPlusSharedRowMap,
+               const Teuchos::RCP<const map_type> & ownedPlusSharedColMap,
+               const size_t maxNumEntriesPerRow,
+               const Teuchos::RCP<const map_type> & ownedPlusSharedDomainMap,
+               const Teuchos::RCP<const import_type> & ownedPlusSharedToOwnedimporter = Teuchos::null,
+               const Teuchos::RCP<const map_type> & ownedDomainMap = Teuchos::null,
+               const Teuchos::RCP<const map_type> & ownedRangeMap = Teuchos::null,
                const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
 
@@ -226,11 +333,11 @@ namespace Tpetra {
     /// \param ownedPlusSharedToOwnedimporter [in] Optional importer between the ownedMap and ownedPlusSharedMap
     ///   This will be calculated by FECrsGraph if it is not provided
     ///
-    /// \param domainMap [in] Optional domainMap for the owned graph.  If this is not provided, then ownedMap
-    ///   will be used for the domainMap in the call to endFill()
+    /// \param ownedDomainMap [in] Optional domain map for the owned graph.  If this is not provided, then ownedMap
+    ///   will be used for the ownedDomainMap in the call to endFill()
     ///
-    /// \param rangeMap [in] Optional domainMap for the owned graph.  If this is not provided, then ownedMap
-    ///   will be used for the domainMap in the call to endFill()
+    /// \param ownedRangeMap [in] Optional range map for the owned graph.  If this is not provided, then ownedMap
+    ///   will be used for the ownedDomainMap in the call to endFill()
     ///
     /// \param params [in/out] Optional list of parameters.  If not
     ///   null, any missing parameters will be filled in with their
@@ -240,8 +347,42 @@ namespace Tpetra {
                 const Teuchos::RCP<const map_type> & ownedPlusSharedColMap,
                 const Kokkos::DualView<const size_t*, execution_space>& numEntPerRow,
                 const Teuchos::RCP<const import_type> & ownedPlusSharedToOwnedimporter = Teuchos::null,
-                const Teuchos::RCP<const map_type> & domainMap = Teuchos::null,
-                const Teuchos::RCP<const map_type> & rangeMap = Teuchos::null,
+                const Teuchos::RCP<const map_type> & ownedDomainMap = Teuchos::null,
+                const Teuchos::RCP<const map_type> & ownedRangeMap = Teuchos::null,
+                const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
+
+    /// \brief Constructor for locally-indexed assembly specifying a (possibly different) upper
+    ///   bound for the number of entries in each row.
+    ///
+    /// \param ownedRowMap [in] Distribution of rows of the owned graph.
+    ///
+    /// \param ownedPlusSharedRowMap [in] ownedMap plus the list of shared rows to which off-processor insertion is allowed
+    ///
+    /// \param numEntPerRow [in] Maximum number of graph entries to
+    ///   allocate for each row.  You cannot exceed the allocated
+    ///   number of entries for any row.
+    ///
+    /// \param ownedPlusSharedDomainMap [in] Domain map for the owned+shared graph. If this is null, then ownedPlusSharedRowMap
+    /// \param ownedPlusSharedToOwnedimporter [in] Optional importer between the ownedMap and ownedPlusSharedMap
+    ///   This will be calculated by FECrsGraph if it is not provided
+    ///
+    /// \param ownedDomainMap [in] Optional domain map for the owned graph.  If this is not provided, then ownedMap
+    ///   will be used for the ownedDomainMap in the call to endFill()
+    ///
+    /// \param ownedRangeMap [in] Optional range map for the owned graph.  If this is not provided, then ownedMap
+    ///   will be used for the ownedDomainMap in the call to endFill()
+    ///
+    /// \param params [in/out] Optional list of parameters.  If not
+    ///   null, any missing parameters will be filled in with their
+    ///   default values.
+    FECrsGraph (const Teuchos::RCP<const map_type> & ownedRowMap,
+                const Teuchos::RCP<const map_type> & ownedPlusSharedRowMap,
+                const Teuchos::RCP<const map_type> & ownedPlusSharedColMap,
+                const Kokkos::DualView<const size_t*, execution_space>& numEntPerRow,
+                const Teuchos::RCP<const map_type> & ownedPlusSharedDomainMap,
+                const Teuchos::RCP<const import_type> & ownedPlusSharedToOwnedimporter = Teuchos::null,
+                const Teuchos::RCP<const map_type> & ownedDomainMap = Teuchos::null,
+                const Teuchos::RCP<const map_type> & ownedRangeMap = Teuchos::null,
                 const Teuchos::RCP<Teuchos::ParameterList>& params = Teuchos::null);
 
     //! Copy constructor (forbidden).
@@ -302,9 +443,9 @@ namespace Tpetra {
     /// \pre  <tt>   isFillActive() && ! isFillComplete() </tt>
     /// \post <tt> ! isFillActive() &&   isFillComplete() </tt>
     ///
-    /// \param domainMap [in] The graph's domain Map.  MUST be one to
+    /// \param ownedDomainMap [in] The graph's domain Map.  MUST be one to
     ///   one!
-    /// \param rangeMap [in] The graph's range Map.  MUST be one to
+    /// \param ownedRangeMap [in] The graph's range Map.  MUST be one to
     ///   one!  May be, but need not be, the same as the domain Map.
     /// \param params [in/out] List of parameters controlling this
     ///   method's behavior.  See below for valid parameters.
@@ -317,11 +458,11 @@ namespace Tpetra {
     /// </li>
     /// </ul>
     void
-    fillComplete (const Teuchos::RCP<const map_type>& domainMap,
-                  const Teuchos::RCP<const map_type>& rangeMap,
+    fillComplete (const Teuchos::RCP<const map_type>& ownedDomainMap,
+                  const Teuchos::RCP<const map_type>& ownedRangeMap,
                   const Teuchos::RCP<Teuchos::ParameterList>& /* params */ = Teuchos::null) {
-      domainMap_ = domainMap;
-      rangeMap_ = rangeMap;
+      ownedDomainMap_ = ownedDomainMap;
+      ownedRangeMap_ = ownedRangeMap;
       endFill();
     }
 
@@ -376,6 +517,10 @@ namespace Tpetra {
     // Common core guts of the constructor (the colMap argument is Teuchos::null if we're globally-indexed)
     void setup(const Teuchos::RCP<const map_type>  & ownedRowMap, const Teuchos::RCP<const map_type> & ownedPlusSharedRowMap,const Teuchos::RCP<const map_type> & ownedPlusSharedColMap, const Teuchos::RCP<Teuchos::ParameterList>& params);
 
+    // Template to avoid long type names...lazy.
+    // template<typename ViewType>
+    // Teuchos::RCP<const map_type> makeOwnedColMap (ViewType ownedGraphIndices);
+
     // Enum for activity
     enum FEWhichActive
     {
@@ -384,21 +529,20 @@ namespace Tpetra {
     };
 
 
-    // This is whichever multivector isn't currently active
+    // This is whichever graph isn't currently active
     Teuchos::RCP<CrsGraph<LocalOrdinal, GlobalOrdinal, Node> > inactiveCrsGraph_;
+
     // This is in RCP to make shallow copies of the FECrsGraph work correctly
     Teuchos::RCP<FEWhichActive> activeCrsGraph_;
 
     // The importer between the rowmaps of the two graphs
-    Teuchos::RCP<const import_type> importer_;
+    Teuchos::RCP<const import_type> ownedRowsImporter_;
 
-    // The domainMap to use in endFill(), if provided
-    Teuchos::RCP<const map_type> domainMap_;
+    // The domainMap to use in endFill() for the owned graph
+    Teuchos::RCP<const map_type> ownedDomainMap_;
 
-    // The rangeMap to use in endFill(), if provided
-    Teuchos::RCP<const map_type> rangeMap_;
-
-
+    // The rangeMap to use in endFill() for the owned graph
+    Teuchos::RCP<const map_type> ownedRangeMap_;
   }; // class FECrsGraph
 
 

--- a/packages/tpetra/core/src/Tpetra_FECrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_FECrsMatrix_def.hpp
@@ -91,7 +91,7 @@ template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void FECrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>::doOwnedPlusSharedToOwned(const CombineMode CM) {
   if(!inactiveCrsMatrix_.is_null() && *activeCrsMatrix_ == FE_ACTIVE_OWNED_PLUS_SHARED) {
     // Do a self-export in "restricted mode"
-    this->doExport(*this,*feGraph_->importer_,CM,true);
+    this->doExport(*this,*feGraph_->ownedRowsImporter_,CM,true);
     inactiveCrsMatrix_->fillComplete();
   }
   crs_matrix_type::fillComplete();

--- a/packages/tpetra/core/test/FECrsGraph/FECrsGraph_UnitTests.cpp
+++ b/packages/tpetra/core/test/FECrsGraph/FECrsGraph_UnitTests.cpp
@@ -45,6 +45,7 @@
 #include "Tpetra_TestingUtilities.hpp"
 #include "Tpetra_FECrsGraph.hpp"
 #include "Tpetra_CrsGraph.hpp"
+#include "Tpetra_Import.hpp"
 #include "Tpetra_Assembly_Helpers.hpp"
 #include "Tpetra_Details_getNumDiags.hpp"
 
@@ -53,6 +54,7 @@ namespace { // (anonymous)
 
 using Tpetra::TestingUtilities::getDefaultComm;
 using Tpetra::createContigMapWithNode;
+using Tpetra::createNonContigMapWithNode;
 using Tpetra::StaticProfile;
 using Teuchos::RCP;
 using Teuchos::ArrayRCP;
@@ -83,8 +85,8 @@ bool compare_final_graph_structure(Teuchos::FancyOStream &out,Tpetra::CrsGraph<L
   if (!g1.isFillComplete() || !g2.isFillComplete()) {out<<"Compare: FillComplete failed"<<endl;return false;}
   if (!g1.getRangeMap()->isSameAs(*g2.getRangeMap())) {out<<"Compare: RangeMap failed"<<endl;return false;}
   if (!g1.getRowMap()->isSameAs(*g2.getRowMap())) {out<<"Compare: RowMap failed"<<endl;return false;}
-  if (!g1.getColMap()->isSameAs(*g2.getColMap())) {out<<"Compare: ColMap failed"<<endl;g1.describe(out);g2.describe(out);return false;}
   if (!g1.getDomainMap()->isSameAs(*g2.getDomainMap())) {out<<"Compare: DomainMap failed"<<endl;return false;}
+  if (!g1.getColMap()->isSameAs(*g2.getColMap())) {out<<"Compare: ColMap failed"<<endl;g1.describe(out,Teuchos::VERB_EXTREME);g2.describe(out,Teuchos::VERB_EXTREME);return false;}
 
   auto rowptr1 = g1.getLocalGraph().row_map;
   auto rowptr2 = g2.getLocalGraph().row_map;
@@ -111,17 +113,98 @@ bool compare_final_graph_structure(Teuchos::FancyOStream &out,Tpetra::CrsGraph<L
   return true;
 }
 
-
-
+// This routine checks that two graphs are the same "up to permutation of indices inside rows".
+// This means that the two graphs must have the same row/range/domain maps, the same number
+// of rows, and the same GLOBAL indices in each row. The order in which the indices appear
+// in the row, as well as the local index they are given in the column map is irrelevant.
 template<class LO, class GO, class Node>
+bool compare_final_graph_structure_relaxed(Teuchos::FancyOStream &out,
+                                        const Tpetra::CrsGraph<LO,GO,Node> & g1,
+                                        const Tpetra::CrsGraph<LO,GO,Node> & g2) {
+  // Make sure we finished filling the two graphs
+  if (!g1.isFillComplete() || !g2.isFillComplete()) {
+    out << "Compare: FillComplete failed.\n";
+    return false;
+  }
+
+  // Range/domain/row maps *must* be the same
+  if (!g1.getRangeMap()->isSameAs(*g2.getRangeMap())) {
+    out<<"Compare: RangeMap failed.\n";
+    return false;
+  }
+  if (!g1.getRowMap()->isSameAs(*g2.getRowMap())) {
+    out << "Compare: RowMap failed.\n";
+    return false;
+  }
+  if (!g1.getDomainMap()->isSameAs(*g2.getDomainMap())) {
+    out << "Compare: DomainMap failed.\n";
+    return false;
+  }
+
+  const LO num_my_rows = g1.getNodeNumRows();
+  if (num_my_rows!=static_cast<LO>(g2.getNodeNumEntries())) {
+    out << "Compare: number of local rows differ on some MPI rank: "
+        << num_my_rows << " vs " << g2.getNodeNumRows() << ".\n";
+    return false;
+  }
+
+  auto hasLID = [](const Teuchos::ArrayView<const LO>& lids, const LO lid) -> bool {
+    auto it = std::find(lids.begin(),lids.end(),lid);
+    return it!=lids.end();
+  };
+
+  Teuchos::ArrayView<const LO> cols1, cols2;
+  const LO invLO = Teuchos::OrdinalTraits<LO>::invalid();
+  const auto& colMap1 = *g1.getColMap();
+  const auto& colMap2 = *g2.getColMap();
+  for (LO irow=0; irow<num_my_rows; ++irow) {
+    const GO grow = g1.getRowMap()->getGlobalElement(irow);
+
+    // Extract rows
+    g1.getLocalRowView(irow, cols1);
+    g2.getLocalRowView(irow, cols2);
+
+    // If different row sizes, then the two graphs are different.
+    auto numEntries = cols1.size();
+    if (numEntries!=cols2.size()) {
+      out << "Compare: global row " << grow << " has different lengths.\n";
+      return false;
+    }
+
+    // Loop over rows indices
+    for (size_t j=0; j<numEntries; ++j) {
+      const LO lid1 = cols1[j];
+      const GO gid = colMap1.getGlobalElement(lid1);
+      const LO lid2 = colMap2.getLocalElement(gid);
+
+      // If g2 does not have this GID in its column map, then the two graphs are different.
+      if (lid2==invLO) {
+        out << "Compare: col maps store different global indices.\n";
+        return false;
+      }
+
+      // If g2 does not have this GID in this row, then the two graphs are different.
+      if (!hasLID(cols2,lid2)) {
+        out << "Compare: global row " << grow << " has different global indicess.\n";
+        return false;
+      }
+    }
+  }
+
+  // If we got this far, then none of the negative checks happened,
+  // so the graphs are (locally) truly identical (from the mathematical point of view)
+  return true;
+}
+
+
+template<int NumElemNodes, class LO, class GO, class Node>
 class GraphPack {
 public:
   RCP<const Tpetra::Map<LO,GO,Node> > uniqueMap;
   RCP<const Tpetra::Map<LO,GO,Node> > overlapMap;
   std::vector<std::vector<GO> > element2node;
 
-  // NOTE: This is hardwired for 1D bar elements
-  typedef Kokkos::View<LO*[2], Kokkos::LayoutLeft, typename Node::device_type > k_element2node_type;
+  typedef Kokkos::View<LO*[NumElemNodes], Kokkos::LayoutLeft, typename Node::device_type > k_element2node_type;
   k_element2node_type k_element2node;
 
   void print(int rank, std::ostream & out) {
@@ -149,7 +232,7 @@ public:
 
 
 template<class LO, class GO, class Node>
-void generate_fem1d_graph(size_t numLocalNodes, RCP<const Comm<int> > comm , GraphPack<LO,GO,Node> & pack) {
+void generate_fem1d_graph(size_t numLocalNodes, RCP<const Comm<int> > comm , GraphPack<2,LO,GO,Node> & pack) {
   const GST INVALID = Teuchos::OrdinalTraits<GST>::invalid();
   int rank    = comm->getRank();
   int numProc = comm->getSize();
@@ -184,6 +267,105 @@ void generate_fem1d_graph(size_t numLocalNodes, RCP<const Comm<int> > comm , Gra
       GO gid = l_umap.getGlobalElement(i);
       k_e2n(i,0) = gid;
       k_e2n(i,1) = gid+1;
+    });
+  Kokkos::fence();
+}
+
+template<class LO, class GO, class Node>
+void generate_fem2d_q1_graph(size_t numCells1D, RCP<const Comm<int> > comm , GraphPack<4,LO,GO,Node> & pack) {
+
+  // We assume a NxN Q1 fem grid. Cells are partitioned among ranks.
+  // Cell/Nodes ids are as follows (assuming N=2):
+  //
+  //  0---1---2
+  //  | 0 | 1 |
+  //  3---4---5
+  //  | 2 | 3 |
+  //  6---7---8
+  //
+  // The order in which we store the ids within a cell is irrelevant (so long as consistent),
+  // since the local pattern is full anyways.
+  //
+  // NOTE: this routine sets overlapMap NOT to be the "col" map. Instead, since we partition
+  //       cells, it contains all nodes belonging to local cells. If all cells are "fully" owned,
+  //       then locally overlapMap=uniqueMap, while the "col" map of the graph will ALWAYS
+  //       have something more (the halo).
+
+  const size_t rank    = comm->getRank();
+  const size_t numProc = comm->getSize();
+
+  const size_t numGlobalCells = numCells1D*numCells1D;
+  const size_t numNodes1D     = numCells1D+1;
+
+  size_t numMyCells  = numGlobalCells / numProc;
+  size_t remainder   = numGlobalCells % numProc;
+  size_t myCellStart = numMyCells*rank;
+  if (rank < remainder) {
+    ++numMyCells;
+    myCellStart += rank;
+  } else {
+    myCellStart += remainder;
+  }
+
+  // Add also repeated GIDs, we'll remove duplicates later
+  Teuchos::Array<GO> ovNodes;
+  pack.element2node.resize(numMyCells);
+  for (size_t cell=0; cell<numMyCells; ++cell) {
+    //  0---1---2
+    //  | 0 | 1 |
+    //  3---4---5
+    //  | 2 | 3 |
+    //  6---7---8
+
+    auto cellId = myCellStart+cell;
+
+    auto icell = cellId / numCells1D;
+    auto jcell = cellId % numCells1D;
+
+    auto offset = icell*numNodes1D;
+
+    // Store for the map
+    ovNodes.append(offset+jcell);
+    ovNodes.append(offset+jcell+1);
+    ovNodes.append(offset+jcell+numNodes1D);
+    ovNodes.append(offset+jcell+numNodes1D+1);
+
+    // Store for the assembly
+    pack.element2node[cell].resize(4);
+    pack.element2node[cell][0] = offset + jcell;
+    pack.element2node[cell][1] = offset + jcell + 1;
+    pack.element2node[cell][2] = offset + jcell + numNodes1D;
+    pack.element2node[cell][3] = offset + jcell + numNodes1D + 1;
+  }
+
+  // Remove duplicates. Note: std::unique needs consecutive duplicates, so sort first
+  auto start = ovNodes.data();
+  auto end   = ovNodes.data()+ovNodes.size();
+  std::sort(start,end);
+  auto new_end = std::unique(start,end);
+  auto new_size = std::distance(start, new_end);
+  ovNodes.resize(new_size);
+
+  // Create overlap map, and use Tpetra utility to create the unique one
+  pack.overlapMap = createNonContigMapWithNode<LO,GO,Node>(ovNodes(),comm);
+  pack.uniqueMap  = createOneToOne(pack.overlapMap);
+
+  // Kokkos version of the element2node array
+  Kokkos::resize(pack.k_element2node,numMyCells);
+  auto k_e2n = pack.k_element2node;
+  Kokkos::parallel_for(Kokkos::RangePolicy<typename Node::execution_space>(0,numMyCells),
+                       KOKKOS_LAMBDA(const size_t cell) {
+      auto cellId = myCellStart+cell;
+
+      auto icell = cellId / numCells1D;
+      auto jcell = cellId % numCells1D;
+
+      auto offset = icell*numNodes1D;
+
+      k_e2n(icell,0) = offset + jcell;
+      k_e2n(icell,1) = offset + jcell + 1;
+      k_e2n(icell,2) = offset + jcell + numNodes1D;
+      k_e2n(icell,3) = offset + jcell + numNodes1D + 1;
     });
   Kokkos::fence();
 }
@@ -276,7 +458,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FECrsGraph, Assemble1D, LO, GO, Node )
   const size_t numLocal = 10;
 
   // Generate a mesh
-  GraphPack<LO,GO,Node> pack;
+  GraphPack<2,LO,GO,Node> pack;
   generate_fem1d_graph(numLocal,comm,pack);
   //pack.print(comm->getRank(),std::cout);
 
@@ -319,7 +501,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FECrsGraph, Assemble1D_LocalIndex, LO, GO, No
   const size_t numLocal = 10;
 
   // Generate a mesh
-  GraphPack<LO,GO,Node> pack;
+  GraphPack<2,LO,GO,Node> pack;
   generate_fem1d_graph(numLocal,comm,pack);
   //  pack.print(comm->getRank(),std::cout);fflush(stdout);
 
@@ -351,6 +533,76 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FECrsGraph, Assemble1D_LocalIndex, LO, GO, No
   TPETRA_GLOBAL_SUCCESS_CHECK(out,comm,success)
 }
 
+TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FECrsGraph, Assemble2D_OPSDomain, LO, GO, Node )
+{
+  typedef Tpetra::FECrsGraph<LO,GO,Node> FEG;
+  typedef Tpetra::CrsGraph<LO,GO,Node> CG;
+
+  // get a comm
+  RCP<const Comm<int> > comm = getDefaultComm();
+  
+  const int numCells1D = 4;
+
+  // Generate a mesh
+  GraphPack<4,LO,GO,Node> pack;
+  generate_fem2d_q1_graph(numCells1D,comm,pack);
+
+  // Comparative assembly
+
+  CG  g0(pack.overlapMap,9,StaticProfile);
+  CG  g1(pack.uniqueMap,9,StaticProfile);
+  FEG g2(pack.uniqueMap,pack.overlapMap,9);
+  FEG g3(pack.uniqueMap,pack.overlapMap,9,pack.overlapMap);
+
+  g2.beginFill();
+  g3.beginFill();
+  for(size_t cell=0; cell<pack.element2node.size(); ++cell) {
+    for(size_t i=0; i<pack.element2node[cell].size(); ++i) {
+      GO gid_i = pack.element2node[cell][i];
+      for(size_t j=0; j<pack.element2node[cell].size(); ++j) {
+        GO gid_j = pack.element2node[cell][j];
+        g0.insertGlobalIndices(gid_i,1,&gid_j);
+        g1.insertGlobalIndices(gid_i,1,&gid_j);
+        g2.insertGlobalIndices(gid_i,1,&gid_j);
+        g3.insertGlobalIndices(gid_i,1,&gid_j);
+      }
+    }
+  }
+  g0.fillComplete();
+  g1.fillComplete();
+  g2.endFill();
+  g3.endFill();
+  Tpetra::Import<LO,GO,Node> import(pack.uniqueMap,pack.overlapMap);
+  
+  Teuchos::FancyOStream myout(Teuchos::rcpFromRef(std::cout));
+  CG  g11(pack.uniqueMap,9,StaticProfile);
+  g11.doExport(g0,import,Tpetra::INSERT);
+  g11.fillComplete(pack.uniqueMap,pack.uniqueMap);
+  success = compare_final_graph_structure(out,g11,g1);
+  TPETRA_GLOBAL_SUCCESS_CHECK(myout,comm,success)
+  
+  success = compare_final_graph_structure(out,g1,g2);
+  TPETRA_GLOBAL_SUCCESS_CHECK(myout,comm,success)
+
+  // Passing a domain map different from the uniqueMap should cause a rearrangement of
+  // off-rank indices in the column map. Other than that, the graphs should still coincide.
+  success = compare_final_graph_structure_relaxed(out,g1,g3);
+  TPETRA_GLOBAL_SUCCESS_CHECK(myout,comm,success)
+
+  // We can check that g3 is exactly what we would get if g1's col map had been
+  // built with a overlapMap locally fitted to it. We can recreate that scenario by
+  // a) use overlapMap as domainMap during fillComplete (this will generate the
+  // correct colMap), and b) reset domainMap to be the unique map (so that the
+  // checks in compare_final_graph_structure do not fail b/c of the domain map).
+  CG  g12(pack.uniqueMap,9,StaticProfile);
+  g12.doExport(g0,import,Tpetra::INSERT);
+  g12.fillComplete(pack.overlapMap,pack.uniqueMap);
+  auto importer = g12.getImporter();
+  g12.replaceDomainMapAndImporter(pack.uniqueMap,importer);
+
+  success = compare_final_graph_structure(myout,g12,g3);
+  TPETRA_GLOBAL_SUCCESS_CHECK(myout,comm,success)
+}
 
 //
 // INSTANTIATIONS
@@ -360,7 +612,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FECrsGraph, Assemble1D_LocalIndex, LO, GO, No
       TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( FECrsGraph, Diagonal, LO, GO, NODE ) \
       TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( FECrsGraph, Diagonal_LocalIndex, LO, GO, NODE ) \
       TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( FECrsGraph, Assemble1D, LO, GO, NODE ) \
-      TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( FECrsGraph, Assemble1D_LocalIndex, LO, GO, NODE )
+      TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( FECrsGraph, Assemble1D_LocalIndex, LO, GO, NODE ) \
+      TEUCHOS_UNIT_TEST_TEMPLATE_3_INSTANT( FECrsGraph, Assemble2D_OPSDomain, LO, GO, NODE )
 
   TPETRA_ETI_MANGLING_TYPEDEFS()
 

--- a/packages/tpetra/core/test/FECrsGraph/FECrsGraph_UnitTests.cpp
+++ b/packages/tpetra/core/test/FECrsGraph/FECrsGraph_UnitTests.cpp
@@ -172,7 +172,7 @@ bool compare_final_graph_structure_relaxed(Teuchos::FancyOStream &out,
     }
 
     // Loop over rows indices
-    for (size_t j=0; j<numEntries; ++j) {
+    for (decltype(numEntries) j=0; j<numEntries; ++j) {
       const LO lid1 = cols1[j];
       const GO gid = colMap1.getGlobalElement(lid1);
       const LO lid2 = colMap2.getLocalElement(gid);
@@ -556,11 +556,9 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL( FECrsGraph, Assemble2D_OPSDomain, LO, GO, Nod
 
   g2.beginFill();
   g3.beginFill();
-  for(size_t cell=0; cell<pack.element2node.size(); ++cell) {
-    for(size_t i=0; i<pack.element2node[cell].size(); ++i) {
-      GO gid_i = pack.element2node[cell][i];
-      for(size_t j=0; j<pack.element2node[cell].size(); ++j) {
-        GO gid_j = pack.element2node[cell][j];
+  for (const auto& cell_dofs : pack.element2node) {
+    for (const auto& gid_i : cell_dofs) {
+      for (const auto& gid_j : cell_dofs) {
         g0.insertGlobalIndices(gid_i,1,&gid_j);
         g1.insertGlobalIndices(gid_i,1,&gid_j);
         g2.insertGlobalIndices(gid_i,1,&gid_j);

--- a/packages/tpetra/core/test/MatrixMatrix/CMakeLists.txt
+++ b/packages/tpetra/core/test/MatrixMatrix/CMakeLists.txt
@@ -6,6 +6,13 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   ARGS "--matnames-file=\"matrixsystems.xml\" --v"
   )
 
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  FECrs_MatrixMatrix_UnitTests
+  SOURCES
+  FECrs_MatrixMatrix_UnitTests.cpp
+  ${TEUCHOS_STD_UNIT_TEST_MAIN}
+  )
+
 IF (KokkosKernels_ENABLE_Experimental)
 TRIBITS_ADD_EXECUTABLE_AND_TEST(
   MatrixMatrixKernels_UnitTests

--- a/packages/tpetra/core/test/MatrixMatrix/FECrs_MatrixMatrix_UnitTests.cpp
+++ b/packages/tpetra/core/test/MatrixMatrix/FECrs_MatrixMatrix_UnitTests.cpp
@@ -1,0 +1,386 @@
+/*
+// @HEADER
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services meshage
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+*/
+
+#include "TpetraCore_ETIHelperMacros.h"
+#include "Tpetra_TestingUtilities.hpp"
+#include "TpetraExt_MatrixMatrix.hpp"
+#include "Tpetra_FECrsMatrix.hpp"
+#include "Tpetra_Core.hpp"
+
+#include "Teuchos_CommandLineProcessor.hpp"
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include <Teuchos_UnitTestHarness.hpp>
+
+namespace { // (anonymous)
+
+using Teuchos::RCP;
+using Teuchos::Comm;
+using Tpetra::createNonContigMapWithNode;
+
+template<int NumElemNodes, class LO, class GO, class NT>
+class MeshInfo {
+public:
+  RCP<const Tpetra::Map<LO,GO,NT> > uniqueMap;
+  RCP<const Tpetra::Map<LO,GO,NT> > overlapMap;
+  std::vector<std::vector<GO> > element2node;
+
+  int num_elem_shared (const GO idof, const GO jdof) const {
+    int res = 0;
+    for (const auto& elem : element2node) {
+      if (vec_has_dof(idof) && vec_has_dof(jdof)) {
+        ++res;
+      }
+    }
+    return res;
+  }
+
+private:
+  bool vec_has_dof (const std::vector<GO>& dofs, const GO dof) {
+    return std::find(dofs.begin(),dofs.end(),dof)!=dofs.end();
+  }
+};
+
+template<class LO, class GO, class NT>
+void generate_fem2d_q1_graph(size_t numCells1D, RCP<const Comm<int> > comm , MeshInfo<4,LO,GO,NT> & mesh) {
+
+  // We assume a NxN Q1 fem grid. Cells are partitioned among ranks.
+  // Cell/Nodes ids are as follows (assuming N=2):
+  //
+  //  0---1---2
+  //  | 0 | 1 |
+  //  3---4---5
+  //  | 2 | 3 |
+  //  6---7---8
+  //
+  // The order in which we store the ids within a cell is irrelevant (so long as consistent),
+  // since the local pattern is full anyways.
+  //
+  // NOTE: this routine sets overlapMap NOT to be the "col" map. Instead, since we partition
+  //       cells, it contains all nodes belonging to local cells. If all cells are "fully" owned,
+  //       then locally overlapMap=uniqueMap, while the "col" map of the graph will ALWAYS
+  //       have something more (the halo).
+
+  const size_t rank    = comm->getRank();
+  const size_t numProc = comm->getSize();
+
+  const size_t numGlobalCells = numCells1D*numCells1D;
+  const size_t numNodes1D     = numCells1D+1;
+
+  size_t numMyCells  = numGlobalCells / numProc;
+  size_t remainder   = numGlobalCells % numProc;
+  size_t myCellStart = numMyCells*rank;
+  if (rank < remainder) {
+    ++numMyCells;
+    myCellStart += rank;
+  } else {
+    myCellStart += remainder;
+  }
+
+  // Add also repeated GIDs, we'll remove duplicates later
+  Teuchos::Array<GO> ovNodes;
+  mesh.element2node.resize(numMyCells);
+  for (size_t cell=0; cell<numMyCells; ++cell) {
+    //  0---1---2
+    //  | 0 | 1 |
+    //  3---4---5
+    //  | 2 | 3 |
+    //  6---7---8
+
+    auto cellId = myCellStart+cell;
+
+    auto icell = cellId / numCells1D;
+    auto jcell = cellId % numCells1D;
+
+    auto offset = icell*numNodes1D;
+
+    // Store for the map
+    ovNodes.append(offset+jcell);
+    ovNodes.append(offset+jcell+1);
+    ovNodes.append(offset+jcell+numNodes1D);
+    ovNodes.append(offset+jcell+numNodes1D+1);
+
+    // Store for the assembly
+    mesh.element2node[cell].resize(4);
+    mesh.element2node[cell][0] = offset + jcell;
+    mesh.element2node[cell][1] = offset + jcell + 1;
+    mesh.element2node[cell][2] = offset + jcell + numNodes1D;
+    mesh.element2node[cell][3] = offset + jcell + numNodes1D + 1;
+  }
+
+  // Remove duplicates. Note: std::unique needs consecutive duplicates, so sort first
+  auto start = ovNodes.data();
+  auto end   = ovNodes.data()+ovNodes.size();
+  std::sort(start,end);
+  auto new_end = std::unique(start,end);
+  auto new_size = std::distance(start, new_end);
+  ovNodes.resize(new_size);
+
+  // Create overlap map, and use Tpetra utility to create the unique one
+  mesh.overlapMap = createNonContigMapWithNode<LO,GO,NT>(ovNodes(),comm);
+  mesh.uniqueMap  = createOneToOne(mesh.overlapMap);
+}
+
+template<typename LO, typename GO, typename NT>
+Teuchos::RCP<Tpetra::CrsGraph<LO,GO,NT>>
+generate_crs_graph (const MeshInfo<4,LO,GO,NT>& mesh)
+{
+  using CG = Tpetra::CrsGraph<LO,GO,NT>;
+
+  Teuchos::RCP<CG> g(new CG(mesh.uniqueMap,9,Tpetra::StaticProfile));
+  for (const auto& elem_dofs : mesh.element2node) {
+    for (const GO gid_i : elem_dofs) {
+      for (const GO gid_j : elem_dofs) {
+        g->insertGlobalIndices(gid_i,1,&gid_j);
+      }
+    }
+  }
+  g->fillComplete();
+
+  return g;
+}
+
+template<typename LO, typename GO, typename NT>
+Teuchos::RCP<Tpetra::FECrsGraph<LO,GO,NT>>
+generate_fecrs_graph (const MeshInfo<4,LO,GO,NT>& mesh)
+{
+  using FEG = Tpetra::FECrsGraph<LO,GO,NT>;
+
+  Teuchos::RCP<FEG> feg(new FEG(mesh.uniqueMap,mesh.overlapMap,9,mesh.overlapMap));
+  feg->beginFill();
+  for (const auto& elem_dofs : mesh.element2node) {
+    for (const GO gid_i : elem_dofs) {
+      for (const GO gid_j : elem_dofs) {
+        feg->insertGlobalIndices(gid_i,1,&gid_j);
+      }
+    }
+  }
+  feg->endFill();
+
+  return feg;
+}
+
+// Builds a FECrs matrix with pattern generated from the above routine.
+// Loops on cells to fill the matrix. On each cell, add -1 to off-diagonal
+// entries, and N to diag entries, where N is the number of local nodes.
+// Note that such matrix is strictly diagonally dominant.
+template<typename ST, typename LO, typename GO, typename NT>
+void
+fill_matrices (Tpetra::FECrsMatrix<ST,LO,GO,NT>& fe_mat,  
+               Tpetra::CrsMatrix<ST,LO,GO,NT>& mat,  
+               const MeshInfo<4,LO,GO,NT>& mesh)
+{
+  const ST zero = Teuchos::ScalarTraits<ST>::zero();
+
+  fe_mat.beginFill();
+  mat.resumeFill();
+
+  fe_mat.setAllToScalar(zero);
+  mat.setAllToScalar(zero);
+
+  Teuchos::Array<GO> col(1);
+  Teuchos::Array<ST> val(1);
+  for (const auto& elem_dofs : mesh.element2node) {
+    for (const GO& idof : elem_dofs) {
+      for (const GO& jdof : elem_dofs) {
+        col[0] = jdof;
+        val[0] = Teuchos::ScalarTraits<ST>::random();
+
+        fe_mat.sumIntoGlobalValues (idof, col(), val());
+           mat.sumIntoGlobalValues (idof, col(), val());
+      }
+    }
+  }
+  fe_mat.endFill();
+  mat.fillComplete();
+}
+
+template<typename ST, typename LO, typename GO, typename NT>
+bool compare_matrices (const Tpetra::CrsMatrix<ST,LO,GO,NT>& A,
+                       const Tpetra::CrsMatrix<ST,LO,GO,NT>& B, 
+                       Teuchos::FancyOStream &out)
+{
+  // They should have the same row/range/domain maps
+  if (!A.getRowMap()->isSameAs(*B.getRowMap())) {
+    out<<"Compare: RowMap failed.\n";
+    return false;
+  }
+  if (!A.getRangeMap()->isSameAs(*B.getRangeMap())) {
+    out<<"Compare: RangeMap failed.\n";
+    return false;
+  }
+  if (!A.getDomainMap()->isSameAs(*B.getDomainMap())) {
+    out<<"Compare: DomainMap failed.\n";
+    return false;
+  }
+
+  // Now we can test the equality of the rows, in a mathematical way.
+  // We do not care about the order in which entries appear, only the "mathematical" object.
+  const auto& gA = *A.getGraph();
+  const auto& gB = *B.getGraph();
+  const LO num_my_rows = gA.getNodeNumRows();
+  if (num_my_rows!=static_cast<LO>(gB.getNodeNumRows())) {
+    out << "Compare: number of local rows differ on some MPI rank: "
+        << num_my_rows << " vs " << gB.getNodeNumRows() << ".\n";
+    return false;
+  }
+
+  auto findLID = [](const Teuchos::ArrayView<const LO>& lids, const LO lid) -> int {
+    auto it = std::find(lids.begin(),lids.end(),lid);
+    if (it==lids.end()) {
+      return -1;
+    } else {
+      return std::distance(lids.begin(),it);
+    }
+  };
+
+  Teuchos::ArrayView<const ST> valsA, valsB;
+  Teuchos::ArrayView<const LO> colsA, colsB;
+  const LO invLO = Teuchos::OrdinalTraits<LO>::invalid();
+  const auto& colMapA = *gA.getColMap();
+  const auto& colMapB = *gB.getColMap();
+  for (LO irow=0; irow<num_my_rows; ++irow) {
+    const GO grow = gA.getRowMap()->getGlobalElement(irow);
+
+    // Extract rows
+    A.getLocalRowView(irow, colsA, valsA);
+    B.getLocalRowView(irow, colsB, valsB);
+
+    // If different row sizes, then the two matrices are different.
+    auto numEntries = colsA.size();
+    if (numEntries!=colsB.size()) {
+      out << "Compare: global row " << grow << " has different lengths.\n";
+      return false;
+    }
+
+    // Loop over rows entries
+    for (int j=0; j<numEntries; ++j) {
+      const LO lidA = colsA[j];
+      const GO gid = colMapA.getGlobalElement(lidA);
+      const LO lidB = colMapB.getLocalElement(gid);
+
+      // If B does not have this GID in its column map, then the two matrices are different.
+      if (lidB==invLO) {
+        out << "Compare: col maps store different global indices.\n";
+        return false;
+      }
+
+      // If B does not have this GID in this row, then the two matrices are different.
+      int pos = findLID(colsB,lidB);
+      if (pos==-1) {
+        out << "Compare: global row " << grow << " has different global indicess.\n";
+        return false;
+      }
+
+      // Finally, check the numerical values
+      if (valsB[pos]!=valsA[j]) {
+        out << "Compare: global row " << grow << " has different values.\n";
+        return false;
+      }
+    }
+  }
+
+  // If we got this far, then none of the negative checks happened,
+  // so the matrices are (locally) truly identical (from the mathematical point of view)
+  return true;
+}
+
+TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL (Tpetra_MatMat, FECrsMatrix, SC, LO, GO, NT)
+{
+  using FEMAT = typename Tpetra::FECrsMatrix<SC,LO,GO,NT>;
+  using   MAT = typename Tpetra::CrsMatrix<SC,LO,GO,NT>;
+
+  // get a comm
+  RCP<const Comm<int> > comm = Tpetra::getDefaultComm();
+  
+  // Generate a mesh
+  const int numCells1D = 4;
+  MeshInfo<4,LO,GO,NT> mesh;
+  generate_fem2d_q1_graph(numCells1D,comm,mesh);
+
+  auto fe_graph = generate_fecrs_graph(mesh);
+  auto    graph = generate_crs_graph(mesh);
+
+  FEMAT feA(fe_graph);
+    MAT   A(   graph);
+  fill_matrices(feA,A,mesh);
+  success = compare_matrices(A,feA,out);
+  TPETRA_GLOBAL_SUCCESS_CHECK(out,comm,success);
+
+  FEMAT feB(fe_graph);
+    MAT   B(   graph);
+  fill_matrices(feB,B,mesh);
+  success = compare_matrices(B,feB,out);
+  TPETRA_GLOBAL_SUCCESS_CHECK(out,comm,success);
+
+  for (bool transA : {false, true}) {
+    for (bool transB : {false, true}) {
+      Teuchos::RCP<Teuchos::ParameterList> params1(new Teuchos::ParameterList());
+      Teuchos::RCP<Teuchos::ParameterList> params2(new Teuchos::ParameterList());
+      params2->set("MM_TAFC_OptimizationCoreCount",1);  
+      for (auto params : {params1, params2}) {
+
+        // A and feA should have the same row map, so pick one.
+        auto C_row_map = transA ? feA.getDomainMap() : feA.getRangeMap();
+
+        // For the test, use a ridicolously large upper bound for the nnz per row
+        MAT feC(C_row_map,feA.getGraph()->getGlobalNumEntries(),Tpetra::StaticProfile);
+        MAT   C(C_row_map,  A.getGraph()->getGlobalNumEntries(),Tpetra::StaticProfile);
+
+        Tpetra::MatrixMatrix::Multiply(feA, transA, feB, transB, feC, true, "", params);
+        Tpetra::MatrixMatrix::Multiply(  A, transA,   B, transB,   C, true, "", params);
+
+        success = compare_matrices(C,feC,out);
+        TPETRA_GLOBAL_SUCCESS_CHECK(out,comm,success);
+      }
+    }
+  }
+}
+
+#define UNIT_TEST_GROUP_SC_LO_GO_NO( SC, LO, GO, NT )			\
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(Tpetra_MatMat, FECrsMatrix, SC, LO, GO, NT)
+
+  TPETRA_ETI_MANGLING_TYPEDEFS()
+
+  TPETRA_INSTANTIATE_SLGN_NO_ORDINAL_SCALAR( UNIT_TEST_GROUP_SC_LO_GO_NO )
+
+} // anonymous namespace

--- a/packages/tpetra/core/test/Tpetra_TestingUtilities.hpp
+++ b/packages/tpetra/core/test/Tpetra_TestingUtilities.hpp
@@ -63,9 +63,9 @@
     int tgscGblSuccess = 1; \
     Teuchos::reduceAll<int, int>(*comm, Teuchos::REDUCE_MIN, tgscLclSuccess, Teuchos::outArg (tgscGblSuccess)); \
     if (tgscGblSuccess == 1) { \
-      out << "Succeeded on all processes!" << endl; \
+      out << "Succeeded on all processes!" << std::endl; \
     } else { \
-      out << "FAILED on at least one process!" << endl; \
+      out << "FAILED on at least one process!" << std::endl; \
     } \
     TEST_EQUALITY_CONST(tgscGblSuccess, 1);  \
     success = (bool) tgscGblSuccess; \


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
This PR adds a set of constructors to FECrsGraph, which accept a domain map for the owned+shared graph. Before this PR, the owned+shared graph and the owned graph were both created with the same _domain_ map, which, by default, was taken to be the owned row map. This caused the owned+shared dof map in the owned+shared graph to not be locally fitted to the graph's column map, which can cause issues in FE codes assembly that partition the mesh by elements. In such codes, during FE assembly kernels, one may only have the owned+shared dofs map available (coming from a discretization or connectivity object), and not the col map of the matrix. When converting the GIDs of the dofs in the element to local ordinals (in order to assembly the local matrix) one _needs_ the local ids in the owned+shared map to be _the same_ as they will be in the col map of the matrix. Having the owned+shared graph storing the owned+shared dofs as its domain map ensures that owned+shared map is locally fitted to the col map, so that the local ids obtained when converting the dofs GIDs to local ordinal are the same (when using the owned+shared map or the col map of the matrix).
 
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
-->

## Related Issues

* Closes #7455 

<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
The new constructors cannot produce the same graph as the existing ones (otherwise there'd be no point in this PR). However, the resulting graphs should be "locally (and globally) equivalent", meaning that they should store the same row/range/domain map and the same set of GID in each row as a graph built with the existing constructors. The only difference is that colum (global) indices may appear in different order, as well as have different local ids. So I added two sets of tests:

- A test that checks that FECrsGraph built with the new constructor is "locally" equivalent to a good old CrsGraph that is globalAssemble-d.
- A test for MatrixMatrix multiplication, that checks that A*B is "locally equivalent" regardless of whether A,B are FECrsMatrix (with graph built with the new constructors) or CrsMatrix (globalAssemble-d).

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->