### PR TITLE
Tpetra: small type fix, see issue #7573

### DIFF
--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_OpenMP.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_OpenMP.hpp
@@ -534,7 +534,7 @@ void KernelWrappers2<Scalar,LocalOrdinal,GlobalOrdinal,Kokkos::Compat::KokkosOpe
     Teuchos::Array<Scalar> diagonal(diagLength);
     diags.get1dCopy(diagonal());
 
-    for(LocalOrdinal i = 0; i < diagLength; ++i) {
+    for(size_t i = 0; i < diagLength; ++i) {
       TEUCHOS_TEST_FOR_EXCEPTION(diagonal[i] == Teuchos::ScalarTraits<Scalar>::zero(), 
 				 std::runtime_error, 
 				 "Matrix A has a zero/missing diagonal: " << diagonal[i] << std::endl <<


### PR DESCRIPTION
@trilinos/tpetra 

## Motivation
This simply uses the proper type for the loop counter.
I have observed that a build with gcc/8.3.0 and -Werror
fails due to the signed-unsigned comparison.

## Related Issues

* Closes #7573 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 


## Stakeholder Feedback
This is an internal bug fix, not stakeholder

## Testing
I did a local build with gcc/8.3.0 and it went just fine, the error is gone