### PR TITLE
Framework: PR Driver Script Fix

### DIFF
--- a/cmake/std/PullRequestLinuxDriverTest.py
+++ b/cmake/std/PullRequestLinuxDriverTest.py
@@ -420,9 +420,9 @@ def setBuildEnviron(arguments):
     for key, value in l_environMap.items():
         if key in os.environ:
             # we are assuming these are paths to be prepended
-            os.environ[key] = value + os.pathsep + os.environ[key]
+            os.environ[key] = str(value) + os.pathsep + os.environ[key]
         else:
-            os.environ[key] = value
+            os.environ[key] = str(value)
 
     confirmGitVersion()
 


### PR DESCRIPTION
@trilinos/framework 
@prwolfe 

## Commit Msg

There are some places where we're setting os environment vars but
using commands like `os.environ[key] = [value]` but a `TypeError`
will be thrown if the value is not a string.

This can happen easily if we set something in `environMap` to be
an integer vs. a string.  For example:

```python
"OMP_NUM_THREADS": 2
```
vs.
```python
"OMP_NUM_THREADS": "2"
```

The latter is what has been done but the first one can be done easily.

The easy solution to this is to try and force the values to strings
at assignment time, `os.environ[key] = str(value)`

## Motivation
See above description from commit comment.  I ran into this working on my installation testing stuff. I had just put the value in and got a `TypeError` from the `os.environ` setting instruction. I fixed my entry in `environMap` but it's not a bad idea to try and convert the value to a string in that command if we can since it's expecting a string. 

## Testing
<details>
<summary>Click to expand local Python testing output.</summary>
<pre>
0 $ ./runPythonTests.sh
======================================================================== test session starts ========================================================================
platform darwin -- Python 3.8.0, pytest-5.3.5, py-1.8.1, pluggy-0.13.1 -- /Library/Frameworks/Python.framework/Versions/3.8/bin/python3
cachedir: .pytest_cache
rootdir: /Users/wcmclen/dev/trilinos/trilinos-dev/source/Trilinos/cmake/std
collected 40 items

unittests/TestPullRequestLinuxDriverMerge.py::Test_header::test_writeHeader PASSED                                                                            [  2%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_EchoJenkinsVars::test_echoJenkinsVars PASSED                                                               [  5%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_parsing::test_parseArgs PASSED                                                                             [  7%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_parsing::test_parseInsufficientArgs_fails PASSED                                                           [ 10%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_mergeBranch::test_mergeBranch_fails_on_SHA_mismatch PASSED                                                 [ 12%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_mergeBranch::test_mergeBranch_fails_on_source_fetch PASSED                                                 [ 15%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_mergeBranch::test_mergeBranch_with_source_remote PASSED                                                    [ 17%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_mergeBranch::test_mergeBranch_without_source_remote PASSED                                                 [ 20%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_run::test_run PASSED                                                                                       [ 22%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_run::test_run_fails_on_bad_fetch PASSED                                                                    [ 25%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_run::test_run_fails_on_bad_parse PASSED                                                                    [ 27%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_run::test_run_fails_on_bad_remote_add PASSED                                                               [ 30%]
unittests/TestPullRequestLinuxDriverTest.py::Test_run::test_verifyGit_fails_with_old_version PASSED                                                           [ 32%]
unittests/TestPullRequestLinuxDriverTest.py::Test_run::test_verifyGit_passes_with_2_10 PASSED                                                                 [ 35%]
unittests/TestPullRequestLinuxDriverTest.py::Test_run::test_verifyGit_passes_with_2_12 PASSED                                                                 [ 37%]
unittests/TestPullRequestLinuxDriverTest.py::Test_run::test_verifyGit_passes_with_3_x PASSED                                                                  [ 40%]
unittests/TestPullRequestLinuxDriverTest.py::Test_run::test_verifyTargetBranch_fails_with_master_target_non_mm_source PASSED                                  [ 42%]
unittests/TestPullRequestLinuxDriverTest.py::Test_run::test_verifyTargetBranch_passes_with_develop_target PASSED                                              [ 45%]
unittests/TestPullRequestLinuxDriverTest.py::Test_run::test_verifyTargetBranch_passes_with_master_target_mm_source PASSED                                     [ 47%]
unittests/TestPullRequestLinuxDriverTest.py::Test_createPackageEnables::test_call_failure PASSED                                                              [ 50%]
unittests/TestPullRequestLinuxDriverTest.py::Test_createPackageEnables::test_call_python2 PASSED                                                              [ 52%]
unittests/TestPullRequestLinuxDriverTest.py::Test_createPackageEnables::test_call_success PASSED                                                              [ 55%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_fails_with_unknown PASSED                                                         [ 57%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_clang_701 PASSED                                                      [ 60%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_clang_900 PASSED                                                      [ 62%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_cuda_92 PASSED                                                        [ 65%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_gcc_484 PASSED                                                        [ 67%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_gcc_493_Serial PASSED                                                 [ 70%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_gcc_720 PASSED                                                        [ 72%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_gcc_830 PASSED                                                        [ 75%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_intel_1701 PASSED                                                     [ 77%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_python2 PASSED                                                        [ 80%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_python3 PASSED                                                        [ 82%]
unittests/TestPullRequestLinuxDriverTest.py::Test_GetCDashTrack::test_FromEnvironment PASSED                                                                  [ 85%]
unittests/TestPullRequestLinuxDriverTest.py::Test_GetCDashTrack::test_default PASSED                                                                          [ 87%]
unittests/TestPullRequestLinuxDriverTest.py::testCompute_n::test_32p_64g PASSED                                                                               [ 90%]
unittests/TestPullRequestLinuxDriverTest.py::testCompute_n::test_72p_64g PASSED                                                                               [ 92%]
unittests/TestPullRequestLinuxDriverTest.py::testCompute_n::test_80p_128g PASSED                                                                              [ 95%]
unittests/TestPullRequestLinuxDriverTest.py::testCompute_n::test_88p_128g PASSED                                                                              [ 97%]
unittests/TestPullRequestLinuxDriverTest.py::testCompute_n::test_over_weight PASSED                                                                           [100%]

======================================================================== 40 passed in 0.85s =========================================================================
======================================================================== test session starts ========================================================================
platform darwin -- Python 2.7.17, pytest-4.6.9, py-1.8.1, pluggy-0.13.1 -- /usr/local/opt/python@2/bin/python2.7
cachedir: .pytest_cache
rootdir: /Users/wcmclen/dev/trilinos/trilinos-dev/source/Trilinos/cmake/std
collected 40 items

unittests/TestPullRequestLinuxDriverMerge.py::Test_header::test_writeHeader PASSED                                                                            [  2%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_EchoJenkinsVars::test_echoJenkinsVars PASSED                                                               [  5%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_parsing::test_parseArgs PASSED                                                                             [  7%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_parsing::test_parseInsufficientArgs_fails PASSED                                                           [ 10%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_mergeBranch::test_mergeBranch_fails_on_SHA_mismatch PASSED                                                 [ 12%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_mergeBranch::test_mergeBranch_fails_on_source_fetch PASSED                                                 [ 15%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_mergeBranch::test_mergeBranch_with_source_remote PASSED                                                    [ 17%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_mergeBranch::test_mergeBranch_without_source_remote PASSED                                                 [ 20%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_run::test_run PASSED                                                                                       [ 22%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_run::test_run_fails_on_bad_fetch PASSED                                                                    [ 25%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_run::test_run_fails_on_bad_parse PASSED                                                                    [ 27%]
unittests/TestPullRequestLinuxDriverMerge.py::Test_run::test_run_fails_on_bad_remote_add PASSED                                                               [ 30%]
unittests/TestPullRequestLinuxDriverTest.py::Test_run::test_verifyGit_fails_with_old_version PASSED                                                           [ 32%]
unittests/TestPullRequestLinuxDriverTest.py::Test_run::test_verifyGit_passes_with_2_10 PASSED                                                                 [ 35%]
unittests/TestPullRequestLinuxDriverTest.py::Test_run::test_verifyGit_passes_with_2_12 PASSED                                                                 [ 37%]
unittests/TestPullRequestLinuxDriverTest.py::Test_run::test_verifyGit_passes_with_3_x PASSED                                                                  [ 40%]
unittests/TestPullRequestLinuxDriverTest.py::Test_run::test_verifyTargetBranch_fails_with_master_target_non_mm_source PASSED                                  [ 42%]
unittests/TestPullRequestLinuxDriverTest.py::Test_run::test_verifyTargetBranch_passes_with_develop_target PASSED                                              [ 45%]
unittests/TestPullRequestLinuxDriverTest.py::Test_run::test_verifyTargetBranch_passes_with_master_target_mm_source PASSED                                     [ 47%]
unittests/TestPullRequestLinuxDriverTest.py::Test_createPackageEnables::test_call_failure PASSED                                                              [ 50%]
unittests/TestPullRequestLinuxDriverTest.py::Test_createPackageEnables::test_call_python2 PASSED                                                              [ 52%]
unittests/TestPullRequestLinuxDriverTest.py::Test_createPackageEnables::test_call_success PASSED                                                              [ 55%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_fails_with_unknown PASSED                                                         [ 57%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_clang_701 PASSED                                                      [ 60%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_clang_900 PASSED                                                      [ 62%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_cuda_92 PASSED                                                        [ 65%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_gcc_484 PASSED                                                        [ 67%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_gcc_493_Serial PASSED                                                 [ 70%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_gcc_720 PASSED                                                        [ 72%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_gcc_830 PASSED                                                        [ 75%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_intel_1701 PASSED                                                     [ 77%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_python2 PASSED                                                        [ 80%]
unittests/TestPullRequestLinuxDriverTest.py::Test_setEnviron::test_buildEnv_passes_with_python3 PASSED                                                        [ 82%]
unittests/TestPullRequestLinuxDriverTest.py::Test_GetCDashTrack::test_FromEnvironment PASSED                                                                  [ 85%]
unittests/TestPullRequestLinuxDriverTest.py::Test_GetCDashTrack::test_default PASSED                                                                          [ 87%]
unittests/TestPullRequestLinuxDriverTest.py::testCompute_n::test_32p_64g PASSED                                                                               [ 90%]
unittests/TestPullRequestLinuxDriverTest.py::testCompute_n::test_72p_64g PASSED                                                                               [ 92%]
unittests/TestPullRequestLinuxDriverTest.py::testCompute_n::test_80p_128g PASSED                                                                              [ 95%]
unittests/TestPullRequestLinuxDriverTest.py::testCompute_n::test_88p_128g PASSED                                                                              [ 97%]
unittests/TestPullRequestLinuxDriverTest.py::testCompute_n::test_over_weight PASSED                                                                           [100%]

===================================================================== 40 passed in 0.35 seconds =====================================================================
</pre>
</details>

