### PR TITLE
Add gcc 7.2 debug PR setup

### DIFF
--- a/cmake/std/PullRequestLinuxDriverTest.py
+++ b/cmake/std/PullRequestLinuxDriverTest.py
@@ -191,6 +191,22 @@ def setBuildEnviron(arguments):
                      "sems-cmake/3.10.3",
                      "atdm-env",
                      "atdm-ninja_fortran/1.7.2"],
+                "Trilinos_pullrequest_gcc_7.2.0_debug":
+                     ["sems-env",
+                     "sems-git/2.10.1",
+                     "sems-gcc/7.2.0",
+                     "sems-openmpi/1.10.1",
+                     "sems-python/2.7.9",
+                     "sems-boost/1.63.0/base",
+                     "sems-zlib/1.2.8/base",
+                     "sems-hdf5/1.10.6/parallel",
+                     "sems-netcdf/4.7.3/parallel",
+                     "sems-parmetis/4.0.3/parallel",
+                     "sems-scotch/6.0.3/nopthread_64bit_parallel",
+                     "sems-superlu/4.3/base",
+                     "sems-cmake/3.10.3",
+                     "atdm-env",
+                     "atdm-ninja_fortran/1.7.2"],
                 "Trilinos_pullrequest_gcc_8.3.0":
                      ["sems-env",
                      "sems-git/2.10.1",
@@ -346,6 +362,9 @@ def setBuildEnviron(arguments):
                                             "extras"
                                             "bin")},
                  "Trilinos_pullrequest_gcc_7.2.0":
+                      {"SEMS_FORCE_LOCAL_COMPILER_VERSION": "4.9.3",
+                       "OMP_NUM_THREADS": "2"},
+                 "Trilinos_pullrequest_gcc_7.2.0_debug":
                       {"SEMS_FORCE_LOCAL_COMPILER_VERSION": "4.9.3",
                        "OMP_NUM_THREADS": "2"},
                  "Trilinos_pullrequest_gcc_8.3.0":

--- a/cmake/std/PullRequestLinuxGCC7.2.0DebugTestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxGCC7.2.0DebugTestingSettings.cmake
@@ -1,0 +1,29 @@
+# This file contains the options needed to both run the pull request testing
+# for Trilinos for the Linux GCC 7.2.0 pull request testing builds, and to reproduce
+# the errors reported by those builds. Prior to using this this file, the
+# appropriate set of SEMS modules must be loaded and accessible through the
+# SEMS NFS mount. (See the sems/PullRequestGCC*TestingEnv.sh files.)
+
+# Usage: cmake -C PullRequestLinuxGCC7.2.0DebugTestingSettings.cmake
+
+# Misc options typically added by CI testing mode in TriBITS
+
+# Use the below option only when submitting to the dashboard
+#set (CTEST_USE_LAUNCHERS ON CACHE BOOL "Set by default for PR testing")
+
+set (CMAKE_BUILD_TYPE DEBUG CACHE STRING "Set by default for PR testing")
+set (Trilinos_ENABLE_DEBUG ON CACHE STRING "Set by default for PR testing")
+
+set (MPI_EXEC_PRE_NUMPROCS_FLAGS "--bind-to;none" CACHE STRING "Set by default for PR testing")
+# NOTE: The above is a workaround for the problem of having threads on MPI
+# ranks bind to the same cores (see #2422).
+
+set (Trilinos_ENABLE_COMPLEX_DOUBLE ON CACHE BOOL "Set by default for PR testing to exercise complex doubles case")
+
+# Disable just one Teko sub-unit test that fails with openmpi 1.10 (#2712)
+set (Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D ON CACHE BOOL "Temporarily disabled in PR testing")
+
+include("${CMAKE_CURRENT_LIST_DIR}/PullRequestLinuxCommonTestingSettings.cmake")
+
+# Adding warnings as errors flags to this PR build
+set(CMAKE_CXX_FLAGS "-Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-nonnull-compare -Wno-address -Wno-inline -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS -Werror" CACHE STRING "Warnings as errors settings")


### PR DESCRIPTION
@trilinos/framework 

## Motivation
This will help to protect debug builds for downstream users. No tests will change until the fork on the attester_configs repo is merged.

## Related Issues

* Is blocked by #7570 and #7582


## Testing
This is marked WIP until the testing on my fork completes. That will actually run all the tests using the fork in the config repo.
