### PR TITLE
MueLu: Fix issues with IFPACK2=OFF in StratimikosSmoother

### DIFF
--- a/packages/muelu/src/Smoothers/MueLu_StratimikosSmoother_def.hpp
+++ b/packages/muelu/src/Smoothers/MueLu_StratimikosSmoother_def.hpp
@@ -64,7 +64,7 @@
 
 #include <Stratimikos_DefaultLinearSolverBuilder.hpp>
 #include "Teuchos_AbstractFactoryStd.hpp"
-#if defined(HAVE_MUELU_THYRATPETRAADAPTERS)
+#if defined(HAVE_MUELU_THYRATPETRAADAPTERS) && defined(HAVE_MUELU_IFPACK2)
 #include <Thyra_Ifpack2PreconditionerFactory.hpp>
 #endif
 
@@ -109,7 +109,7 @@ namespace MueLu {
     // Build Stratimikos solver
     Stratimikos::DefaultLinearSolverBuilder linearSolverBuilder;
     typedef Thyra::PreconditionerFactoryBase<Scalar> Base;
-#if defined(HAVE_MUELU_THYRATPETRAADAPTERS)
+#if defined(HAVE_MUELU_THYRATPETRAADAPTERS) && defined(HAVE_MUELU_IFPACK2)
     typedef Thyra::Ifpack2PreconditionerFactory<Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > Impl;
     linearSolverBuilder.setPreconditioningStrategyFactory(Teuchos::abstractFactoryStd<Base, Impl>(), "Ifpack2");
 #endif


### PR DESCRIPTION

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/muelu

## Motivation
Fix the issue that MueLu does not compile when IFPACK2=OFF.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Testing
I testes Trilinos with IFPACK2=OFF and this fix

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->