### PR TITLE
Create Clang 10.0.0 PR Build

### DIFF
--- a/cmake/std/PullRequestLinuxClang10.0.0TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxClang10.0.0TestingSettings.cmake
@@ -1,0 +1,39 @@
+# This file contains the options needed to both run the pull request testing
+# for Trilinos for the Linux Clang 10.0.0 pull request testing builds, and to reproduce
+# the errors reported by those builds. Prior to using this this file, the
+# appropriate set of SEMS modules must be loaded and accessible through the
+# SEMS NFS mount. (See the sems/PullRequest*TestingEnv.sh files.)
+
+# Usage: cmake -C PullRequestLinuxClang10.0.0TestingSettings.cmake
+
+# Misc options typically added by CI testing mode in TriBITS
+
+# Use the below option only when submitting to the dashboard
+#set (CTEST_USE_LAUNCHERS ON CACHE BOOL "Set by default for PR testing")
+
+#set (TPL_ENABLE_Netcdf OFF CACHE BOOL "Turn off for Clang")
+
+#set (TPL_Netcdf_LIBRARIES "-L$ENV{SEMS_NETCDF_ROOT}/lib;-L$ENV{SEMS_HDF5_ROOT}/lib;$ENV{SEMS_NETCDF_ROOT}/lib/libnetcdf.a;$ENV{SEMS_NETCDF_ROOT}/lib/libpnetcdf.a;$ENV{SEMS_HDF5_ROOT}/lib/libhdf5_hl.a;$ENV{SEMS_HDF5_ROOT}/lib/libhdf5.a;-lz;-ldl;-lcurl" CACHE STRING "Set by default for CUDA PR testing")
+
+set (MPI_EXEC_PRE_NUMPROCS_FLAGS "--bind-to;none" CACHE STRING "Set by default for PR testing")
+# NOTE: The above is a workaround for the problem of having threads on MPI
+# ranks bind to the same cores (see #2422).
+
+# Disable just one Teko sub-unit test that fails with openmpi 1.10 (#2712)
+set (Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D ON CACHE BOOL "Temporarily disabled in PR testing")
+
+# Disable three ShyLu_DD tests - see #2691
+set (ShyLU_DDFROSch_test_frosch_laplacian_epetra_2d_gdsw_MPI_4_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
+set (ShyLU_DDFROSch_test_frosch_laplacian_epetra_2d_rgdsw_MPI_4_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
+set (ShyLU_DDFROSch_test_frosch_interfacesets_2D_MPI_4_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
+
+include("${CMAKE_CURRENT_LIST_DIR}/PullRequestLinuxCommonTestingSettings.cmake")
+
+#Disable for clang
+set(FEI_elemDOF_Aztec_MPI_2_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
+set(FEI_lagrange_20quad_old_MPI_2_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
+set(FEI_lagrange_20quad_old_MPI_4_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
+set(FEI_multifield_vbr_az_MPI_2_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
+set(FEI_multifield_vbr_az_MPI_3_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
+set(ROL_example_PinT_parabolic-control_example_01_MPI_1_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
+set(Rythmos_StepperBuilder_UnitTest_MPI_1_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")

--- a/cmake/std/PullRequestLinuxDriverTest.py
+++ b/cmake/std/PullRequestLinuxDriverTest.py
@@ -259,6 +259,22 @@ def setBuildEnviron(arguments):
                      "sems-cmake/3.12.2",
                      "atdm-env",
                      "atdm-ninja_fortran/1.7.2"],
+                "Trilinos_pullrequest_clang_10.0.0":
+                     ["sems-env",
+                     "sems-git/2.10.1",
+                     "sems-gcc/5.3.0",
+                     "sems-clang/10.0.0",
+                     "sems-openmpi/1.10.1",
+                     "sems-python/2.7.9",
+                     "sems-boost/1.69.0/base",
+                     "sems-zlib/1.2.8/base",
+                     "sems-hdf5/1.10.6/parallel",
+                     "sems-netcdf/4.7.3/parallel",
+                     "sems-parmetis/4.0.3/parallel",
+                     "sems-scotch/6.0.3/nopthread_64bit_parallel",
+                     "sems-superlu/4.3/base",
+                     "sems-cmake/3.17.1",
+                     "sems-ninja_fortran/1.10.0"],
                 "Trilinos_pullrequest_cuda_9.2":
                      ["git/2.10.1",
                      "devpack/20180521/openmpi/2.1.2/gcc/7.2.0/cuda/9.2.88",
@@ -358,6 +374,9 @@ def setBuildEnviron(arguments):
                       {"SEMS_FORCE_LOCAL_COMPILER_VERSION": "5.3.0",
                        "OMP_NUM_THREADS": "2"},
                  "Trilinos_pullrequest_clang_9.0.0":
+                      {"SEMS_FORCE_LOCAL_COMPILER_VERSION": "5.3.0",
+                       "OMP_NUM_THREADS": "2"},
+                 "Trilinos_pullrequest_clang_10.0.0":
                       {"SEMS_FORCE_LOCAL_COMPILER_VERSION": "5.3.0",
                        "OMP_NUM_THREADS": "2"},
                  "Trilinos_pullrequest_cuda_9.2":
@@ -616,6 +635,7 @@ config_map = {
     'Trilinos_pullrequest_gcc_8.3.0':        'PullRequestLinuxGCC8.3.0TestingSettings.cmake',
     'Trilinos_pullrequest_clang_7.0.1':      'PullRequestLinuxClang7.0.1TestingSettings.cmake',
     'Trilinos_pullrequest_clang_9.0.0':      'PullRequestLinuxClang9.0.0TestingSettings.cmake',
+    'Trilinos_pullrequest_clang_10.0.0':      'PullRequestLinuxClang10.0.0TestingSettings.cmake',
     'Trilinos_pullrequest_cuda_9.2':         'PullRequestLinuxCuda9.2TestingSettings.cmake',
     'Trilinos_pullrequest_python_2':         'PullRequestLinuxPython2.cmake',
     'Trilinos_pullrequest_python_3':         'PullRequestLinuxPython3.cmake'

--- a/cmake/std/sems/PullRequestClang10.0.0TestingEnv.sh
+++ b/cmake/std/sems/PullRequestClang10.0.0TestingEnv.sh
@@ -1,0 +1,30 @@
+
+# This script can be used to load the appropriate environment for the
+# Clang 10.0.0 Pull Request testing build on a Linux machine that has access to
+# the SEMS NFS mount.
+
+# usage: $ source PullRequestClang10.0.0TestingEnv.sh
+
+# After the environment is no longer needed, it can be purged using
+# $ module purge
+# or Trilinos/cmake/unload_sems_dev_env.sh
+
+source /projects/sems/modulefiles/utils/sems-modules-init.sh
+
+module load sems-git/2.10.1
+module load sems-gcc/5.3.0
+module load sems-clang/10.0.0
+module load sems-openmpi/1.10.1
+module load sems-python/2.7.9
+module load sems-boost/1.69.0/base
+module load sems-zlib/1.2.8/base
+module load sems-hdf5/1.10.6/parallel
+module load sems-netcdf/4.7.3/parallel
+module load sems-parmetis/4.0.3/parallel
+module load sems-scotch/6.0.3/nopthread_64bit_parallel
+module load sems-superlu/4.3/base
+module load sems-cmake/3.17.1
+module load sems-ninja_fortran/1.10.0
+
+# add the OpenMP environment variable we need
+export OMP_NUM_THREADS=2

--- a/cmake/std/unittests/TestPullRequestLinuxDriverTest.py
+++ b/cmake/std/unittests/TestPullRequestLinuxDriverTest.py
@@ -748,6 +748,31 @@ class Test_setEnviron(unittest.TestCase):
                              test_ENV={'OMP_NUM_THREADS': '2'})
 
 
+    def test_buildEnv_passes_with_clang_1000(self):
+        """Find the function"""
+        PR_name = 'Trilinos_pullrequest_clang_10.0.0'
+        expected_list = [mock.call('use', '/projects/sems/modulefiles/projects'),
+                         mock.call('load', 'sems-env'),
+                         mock.call('load', 'sems-git/2.10.1'),
+                         mock.call('load', 'sems-gcc/5.3.0'),
+                         mock.call('load', 'sems-clang/10.0.0'),
+                         mock.call('load', 'sems-openmpi/1.10.1'),
+                         mock.call('load', 'sems-python/2.7.9'),
+                         mock.call('load', 'sems-boost/1.69.0/base'),
+                         mock.call('load', 'sems-zlib/1.2.8/base'),
+                         mock.call('load', 'sems-hdf5/1.10.6/parallel'),
+                         mock.call('load', 'sems-netcdf/4.7.3/parallel'),
+                         mock.call('load', 'sems-parmetis/4.0.3/parallel'),
+                         mock.call('load', 'sems-scotch/6.0.3/nopthread_64bit_parallel'),
+                         mock.call('load', 'sems-superlu/4.3/base'),
+                         mock.call('load', 'sems-cmake/3.17.1'),
+                         mock.call('load', 'sems-ninja_fortran/1.10.0'),
+                         ]
+
+        self.buildEnv_passes(PR_name, expected_list,
+                             test_ENV={'OMP_NUM_THREADS': '2'})
+
+
     def test_buildEnv_passes_with_cuda_92(self):
         """Find the function"""
         PR_name = 'Trilinos_pullrequest_cuda_9.2'


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework 


## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
This will add the capability to run a Clang 10.0.0 PR build.
Currently there are only Clang 7.0.1 and 9.0.0 PR builds available.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->
Closes #7589 



## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
This has been tested by manually running a Clang 10.0.0 build in Jenkins successfully.
[CDash](https://testing.sandia.gov/cdash/index.php?project=Trilinos&display=project&filtercount=3&showfilters=1&filtercombine=and&field1=buildname&compare1=63&value1=clang_10.0.0&field2=buildstamp&compare2=63&value2=Experimental&field3=buildstarttime&compare3=84&value3=NOW)
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
This leaves previously excluded tests as is. #6940 #6941 #6942
See associated cmake file.