### PR TITLE
Tempus:  Add setObserver(), initialize() funcs for issue #7357

### DIFF
--- a/packages/tempus/src/Tempus_IntegratorAdjointSensitivity_decl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorAdjointSensitivity_decl.hpp
@@ -127,6 +127,12 @@ public:
     Teuchos::RCP<const Thyra::MultiVectorBase<Scalar> > DxdotDp0 = Teuchos::null,
     Teuchos::RCP<const Thyra::MultiVectorBase<Scalar> > DxdotdotDp0 = Teuchos::null);
 
+  /// Set the Observer
+  virtual void setObserver(
+    Teuchos::RCP<IntegratorObserver<Scalar> > obs = Teuchos::null);
+  /// Initializes the Integrator after set* function calls
+  virtual void initialize();
+
   /// Get current the solution, x
   virtual Teuchos::RCP<const Thyra::VectorBase<Scalar> > getX() const;
   /// Get current the time derivative of the solution, xdot

--- a/packages/tempus/src/Tempus_IntegratorAdjointSensitivity_impl.hpp
+++ b/packages/tempus/src/Tempus_IntegratorAdjointSensitivity_impl.hpp
@@ -312,6 +312,24 @@ initializeSolutionHistory(Scalar t0,
 }
 
 template<class Scalar>
+void IntegratorAdjointSensitivity<Scalar>::
+setObserver(Teuchos::RCP<IntegratorObserver<Scalar> > obs)
+{
+  state_integrator_->setObserver(obs);
+  // Currently not setting observer on adjoint integrator because it isn't
+  // clear what we want to do with it
+  //adjoint_integrator_->setObserver(obs);
+}
+
+template<class Scalar>
+void IntegratorAdjointSensitivity<Scalar>::
+initialize()
+{
+  state_integrator_->initialize();
+  adjoint_integrator_->initialize();
+}
+
+template<class Scalar>
 Teuchos::RCP<const Thyra::VectorBase<Scalar> >
 IntegratorAdjointSensitivity<Scalar>::
 getX() const


### PR DESCRIPTION
This adds the setObserver() and initialize() functions to the adjoint
sensitivity integrator as requested in issue #7357.  These just call the
corresponding functions on the forward and adjoint integrators.  Note it
is is unclear how observes should work with adjoint sensitivities, so I
did not add the observer to the adjoint integrator.  That can easily be
changed if required.