### PR TITLE
Panzer: Fixing evaluation type conditionals in equation set gather registration.

### DIFF
--- a/packages/panzer/disc-fe/src/Panzer_PhysicsBlock.cpp
+++ b/packages/panzer/disc-fe/src/Panzer_PhysicsBlock.cpp
@@ -454,14 +454,15 @@ buildAndRegisterGatherAndOrientationEvaluators(PHX::FieldManager<panzer::Traits>
   // Loop over equation set template managers
   vector< RCP<EquationSet_TemplateManager<panzer::Traits> > >::const_iterator
     eq_set = m_equation_sets.begin();
-  int idx = 0;
-  for (;eq_set != m_equation_sets.end(); ++eq_set,++idx) {
-    if (m_active_evaluation_types[idx]) {
-      // Loop over evaluation types
-      EquationSet_TemplateManager<panzer::Traits> eqstm = *(*eq_set);
-      EquationSet_TemplateManager<panzer::Traits>::iterator eval_type =
-        eqstm.begin();
-      for (; eval_type != eqstm.end(); ++eval_type) {
+  for (;eq_set != m_equation_sets.end(); ++eq_set) {
+
+    // Loop over evaluation types
+    EquationSet_TemplateManager<panzer::Traits> eqstm = *(*eq_set);
+    EquationSet_TemplateManager<panzer::Traits>::iterator eval_type =
+      eqstm.begin();
+    int idx = 0;
+    for (; eval_type != eqstm.end(); ++eval_type,++idx) {
+      if (m_active_evaluation_types[idx]) {
         const int di = eval_type->setDetailsIndex(this->getDetailsIndex());
         eval_type->buildAndRegisterGatherAndOrientationEvaluators(fm, *m_field_lib, lof, user_data);
         eval_type->setDetailsIndex(di);


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/panzer

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

#7337 introduced the capability to disable evaluation types at runtime. However, there seemed to be some errors in panzer::PhysicsBlock::buildAndRegisterGatherAndOrientationEvaluators. This should hopefully fix that. Seems to be working to disable tangent evaluation types in drekar.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

<!--- 
## Stakeholder Feedback
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

<!---
## Testing
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->