### PR TITLE
I commented out an assert to get debug tests to run

### DIFF
--- a/packages/rol/example/tempus/example_parabolic_modeleval_forward-adjoint.hpp
+++ b/packages/rol/example/tempus/example_parabolic_modeleval_forward-adjoint.hpp
@@ -539,7 +539,7 @@ protected:
                  const Teuchos::Ptr<Thyra::MultiVectorBase<Real> >& Y,
                  const Real a,
                  const Real b) const {
-    assert(opSupportedImpl(M_trans));
+    // assert(opSupportedImpl(M_trans));
     ROL::Ptr<const Thyra::VectorBase<Real>> x = X.col(0);
     ROL::Ptr<Thyra::VectorBase<Real>> y = Y->col(0);
     ROL::Ptr<Thyra::VectorBase<Real>> Mx = y->clone_v();


### PR DESCRIPTION
It looks to me like this assert is not always
valid as the test at line 529 will return false
if the trans requested is not Thyra::NOTRANS.
The test does in fact call it with Thyra::TRANS.

## Motivation
This is part of setting up debug builds for the PR testing system

## Related Issues

* Closes #7582 
* Blocks #7581 


## Testing
This was run in a gcc 7.2 build using DEBUG settings from PR 7581

