### PR TITLE
Fix stk::simd::Bool::operator[] for scalar SIMD.

### DIFF
--- a/packages/stk/stk_simd/stk_simd/SimdConfig.hpp
+++ b/packages/stk/stk_simd/stk_simd/SimdConfig.hpp
@@ -61,7 +61,9 @@
 
 #else // using cuda
 
+#ifndef USE_STK_SIMD_NONE
 #define USE_STK_SIMD_NONE
+#endif
 
 #endif
 

--- a/packages/stk/stk_simd/stk_simd/disimd/DISimdBool.hpp
+++ b/packages/stk/stk_simd/stk_simd/disimd/DISimdBool.hpp
@@ -69,6 +69,10 @@ class Bool {
     __m512d tmp = _mm512_mask_blend_pd(_data.get(), _mm512_set1_pd(0.0), _mm512_set1_pd(1.0));
     return (reinterpret_cast<const double*>(&tmp))[i];
   }
+#elif defined(__CUDACC__) || defined(STK_SIMD_NONE)
+  STK_MATH_FORCE_INLINE double operator[](int i) const {
+    return _data.get() ? 1.0 : 0.0;
+  }
 #else
   STK_MATH_FORCE_INLINE double& operator[](int i) {return (reinterpret_cast<double*>(&_data))[i];}
   STK_MATH_FORCE_INLINE const double& operator[](int i) const {return (reinterpret_cast<const double*>(&_data))[i];}

--- a/packages/stk/stk_simd/stk_simd/disimd/DISimdBoolF.hpp
+++ b/packages/stk/stk_simd/stk_simd/disimd/DISimdBoolF.hpp
@@ -69,6 +69,10 @@ class Boolf {
     __m512 tmp = _mm512_mask_blend_ps(_data.get(), _mm512_set1_ps(0.0), _mm512_set1_ps(1.0));
     return (reinterpret_cast<const float*>(&tmp))[i];
   }
+#elif defined(__CUDACC__) || defined(STK_SIMD_NONE)
+  STK_MATH_FORCE_INLINE float operator[](int i) const {
+    return _data.get() ? 1.0f : 0.0f;
+  }
 #else
   STK_MATH_FORCE_INLINE float& operator[](int i) {return (reinterpret_cast<float*>(&_data))[i];}
   STK_MATH_FORCE_INLINE const float& operator[](int i) const {return (reinterpret_cast<const float*>(&_data))[i];}


### PR DESCRIPTION
Kokkos-SIMD simd_mask type uses a bool underneath in the scalar case.
This leads to uninitialized memory when casting directly to double/float.

@trilinos/stk
