### PR TITLE
add GmresSstep to the list of registered native Tpetra solvers

### DIFF
--- a/packages/belos/tpetra/src/Belos_Details_Tpetra_registerSolverFactory.cpp
+++ b/packages/belos/tpetra/src/Belos_Details_Tpetra_registerSolverFactory.cpp
@@ -49,10 +49,12 @@ namespace Impl {
 extern void register_BiCGStab (const bool verbose);
 extern void register_BlockCG (const bool verbose);
 extern void register_BlockGmres (const bool verbose);
+extern void register_Cg (const bool verbose);
 extern void register_CgPipeline (const bool verbose);
 extern void register_CgSingleReduce (const bool verbose);
 extern void register_FixedPoint (const bool verbose);
 extern void register_GCRODR (const bool verbose);
+extern void register_Gmres (const bool verbose);
 extern void register_GmresPipeline (const bool verbose);
 extern void register_GmresPoly (const bool verbose);
 extern void register_GmresSingleReduce (const bool verbose);
@@ -79,10 +81,12 @@ void registerSolverFactory() {
   ::BelosTpetra::Impl::register_BiCGStab (false);
   ::BelosTpetra::Impl::register_BlockCG (false);
   ::BelosTpetra::Impl::register_BlockGmres (false);
+  ::BelosTpetra::Impl::register_Cg (false);
   ::BelosTpetra::Impl::register_CgPipeline (false);
   ::BelosTpetra::Impl::register_CgSingleReduce (false);
   ::BelosTpetra::Impl::register_FixedPoint (false);
   ::BelosTpetra::Impl::register_GCRODR (false);
+  ::BelosTpetra::Impl::register_Gmres (false);
   ::BelosTpetra::Impl::register_GmresPipeline (false);
   ::BelosTpetra::Impl::register_GmresPoly (false);
   ::BelosTpetra::Impl::register_GmresSingleReduce (false);

--- a/packages/belos/tpetra/src/Belos_Details_Tpetra_registerSolverFactory.cpp
+++ b/packages/belos/tpetra/src/Belos_Details_Tpetra_registerSolverFactory.cpp
@@ -56,6 +56,7 @@ extern void register_GCRODR (const bool verbose);
 extern void register_GmresPipeline (const bool verbose);
 extern void register_GmresPoly (const bool verbose);
 extern void register_GmresSingleReduce (const bool verbose);
+extern void register_GmresSstep (const bool verbose);
 extern void register_LSQR (const bool verbose);
 extern void register_Minres (const bool verbose);
 extern void register_PCPG (const bool verbose);
@@ -85,6 +86,7 @@ void registerSolverFactory() {
   ::BelosTpetra::Impl::register_GmresPipeline (false);
   ::BelosTpetra::Impl::register_GmresPoly (false);
   ::BelosTpetra::Impl::register_GmresSingleReduce (false);
+  ::BelosTpetra::Impl::register_GmresSstep (false);
   ::BelosTpetra::Impl::register_LSQR (false);
   ::BelosTpetra::Impl::register_Minres (false);
   ::BelosTpetra::Impl::register_PCPG (false);

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_Krylov.hpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_Krylov.hpp
@@ -146,13 +146,11 @@ public:
   virtual void
   setParameters (Teuchos::ParameterList& params)
   {
-    if (params.isParameter ("Convergence Tolerance")) {
-      const mag_type tol = params.get<mag_type> ("Convergence Tolerance");
-      TEUCHOS_TEST_FOR_EXCEPTION
-        (tol < STM::zero (), std::invalid_argument,
-         "\"Convergence tolerance\" = " << tol << " < 0.");
-      input_.tol = tol;
-    }
+    const mag_type tol = params.get<mag_type> ("Convergence Tolerance", input_.tol);
+    TEUCHOS_TEST_FOR_EXCEPTION
+      (tol < STM::zero (), std::invalid_argument,
+       "\"Convergence tolerance\" = " << tol << " < 0.");
+    input_.tol = tol;
 
     if (params.isParameter ("Implicit Residual Scaling")) {
       const std::string implScal =

--- a/packages/belos/tpetra/src/solvers/Belos_Tpetra_Krylov_parameters.hpp
+++ b/packages/belos/tpetra/src/solvers/Belos_Tpetra_Krylov_parameters.hpp
@@ -55,10 +55,9 @@ public:
   bool needToReortho = false;
   int maxOrthoSteps = 0;
   std::string orthoType {"ICGS"};
-  std::string precoType {"none"};
   std::string precoSide {"none"};
-  bool computeRitzValues = false;
-  bool computeRitzValuesOnFly = true;
+  bool computeRitzValues = true;
+  bool computeRitzValuesOnFly = false;
 };
 
 // The default constructor creates output corresponding to "solving
@@ -158,8 +157,7 @@ operator<< (std::ostream& out,
     out << " Orthogonalization: " << si.orthoType << endl;
   }
   out << " Step size: " << si.stepSize << endl
-      << " Preconditioner: " << si.precoType << " (" << si.precoSide << ")"
-      << endl;
+      << " Preconditioner: " << si.precoSide << endl;
   return out;
 }
 

--- a/packages/belos/tpetra/test/Native/diagonal_matrix.cpp
+++ b/packages/belos/tpetra/test/Native/diagonal_matrix.cpp
@@ -285,23 +285,8 @@ TEUCHOS_UNIT_TEST( TpetraNativeSolvers, Diagonal )
 
 } // namespace (anonymous)
 
-namespace BelosTpetra {
-namespace Impl {
-  extern void register_Cg (const bool verbose);
-  extern void register_Gmres (const bool verbose);
-  extern void register_GmresS (const bool verbose);  
-  extern void register_GmresSstep (const bool verbose);    
-} // namespace Impl
-} // namespace BelosTpetra
-
 int main (int argc, char* argv[])
 {
   Tpetra::ScopeGuard tpetraScope (&argc, &argv);
-
-  constexpr bool verbose = false;
-  BelosTpetra::Impl::register_Cg (verbose);
-  BelosTpetra::Impl::register_Gmres (verbose);
-  BelosTpetra::Impl::register_GmresS (verbose);
-  BelosTpetra::Impl::register_GmresSstep (verbose);
   return Teuchos::UnitTestRepository::runUnitTestsFromMain (argc, argv);
 }

--- a/packages/belos/tpetra/test/Native/nonsymm_matrix.cpp
+++ b/packages/belos/tpetra/test/Native/nonsymm_matrix.cpp
@@ -325,23 +325,8 @@ TEUCHOS_UNIT_TEST( TpetraNativeSolvers, Diagonal )
 
 } // namespace (anonymous)
 
-namespace BelosTpetra {
-namespace Impl {
-  // extern void register_Cg (const bool verbose);
-  extern void register_Gmres (const bool verbose);
-  extern void register_GmresS (const bool verbose);
-  extern void register_GmresSstep (const bool verbose);
-} // namespace Impl
-} // namespace BelosTpetra
-
 int main (int argc, char* argv[])
 {
   Tpetra::ScopeGuard tpetraScope (&argc, &argv);
-
-  constexpr bool verbose = false;
-  // BelosTpetra::Impl::register_Cg (verbose);
-  BelosTpetra::Impl::register_Gmres (verbose);
-  BelosTpetra::Impl::register_GmresS (verbose);
-  BelosTpetra::Impl::register_GmresSstep (verbose);
   return Teuchos::UnitTestRepository::runUnitTestsFromMain (argc, argv);
 }


### PR DESCRIPTION
@trilinos/belos 

## Motivation

This PR 
1. adds GmresSstep (and Gmres and Cg) to the list of registered native Tpetra solvers
2. adds a few tricks to improve the robustness of the GmresSstep

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 

## Stakeholder Feedback

Needed by ExaWind.  Related to https://github.com/Exawind/nalu-wind/pull/643.

## Testing
I ran ctest for Belos on Blake
