### PR TITLE
Refactor idot

### DIFF
--- a/packages/tpetra/core/src/Tpetra_idot.hpp
+++ b/packages/tpetra/core/src/Tpetra_idot.hpp
@@ -189,7 +189,6 @@ void blockingDotImpl(
   using dev_mem_space = typename result_dev_view_type::memory_space;
   using mirror_mem_space = typename result_mirror_view_type::memory_space;
   using unmanaged_result_dev_view_type = Kokkos::View<dot_type*, dev_mem_space, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
-  using unmanaged_result_mirror_view_type = Kokkos::View<dot_type*, mirror_mem_space, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
   using unmanaged_result_host_view_type = Kokkos::View<dot_type*, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
   const size_t numVecs = globalResult.extent(0);
   //Logic to compute the local dot is no different than when CUDA-aware MPI.
@@ -320,7 +319,7 @@ idotImpl(const ResultView& globalResult,
     }
     else
     {
-      //This fence is because the device-space result of idotLocal will be accessed directly by MPI.
+      //(Only fence in idot) required because the device-space result of idotLocal will be accessed directly by MPI.
       typename dev_mem_space::execution_space().fence();
       return iallreduce(nonowningLocalResult, globalResult, ::Teuchos::REDUCE_SUM, *comm);
     }

--- a/packages/tpetra/core/test/Comm/CMakeLists.txt
+++ b/packages/tpetra/core/test/Comm/CMakeLists.txt
@@ -27,14 +27,51 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   COMM serial mpi
   )
 
-TRIBITS_ADD_EXECUTABLE_AND_TEST(
+TRIBITS_ADD_EXECUTABLE(
   idot
   SOURCES
     idot
     ${TEUCHOS_STD_UNIT_TEST_MAIN}
-  NUM_MPI_PROCS 1-4
+  COMM serial mpi)
+
+TRIBITS_ADD_TEST(
+  idot
+  NAME idot
   COMM serial mpi
+  STANDARD_PASS_OUTPUT
+  NUM_MPI_PROCS 1
+)
+
+TRIBITS_ADD_TEST(
+  idot
+  NAME idot
+  COMM mpi
+  STANDARD_PASS_OUTPUT
+  NUM_MPI_PROCS 4
+)
+
+# If we have CUDA, and we have CUDA-aware MPI, also test idot
+# with CUDA-aware MPI explicitly turned off at runtime.
+# This exercises a different code path in idot.
+IF (Tpetra_ENABLE_CUDA AND Tpetra_INST_CUDA AND TPETRA_ASSUME_CUDA_AWARE_MPI)
+  TRIBITS_ADD_TEST(
+    idot
+    NAME idot_no_cuda_aware
+    COMM serial mpi
+    STANDARD_PASS_OUTPUT
+    NUM_MPI_PROCS 1
+    ENVIRONMENT TPETRA_ASSUME_CUDA_AWARE_MPI=OFF
   )
+
+  TRIBITS_ADD_TEST(
+    idot
+    NAME idot_no_cuda_aware
+    COMM mpi
+    STANDARD_PASS_OUTPUT
+    NUM_MPI_PROCS 4
+    ENVIRONMENT TPETRA_ASSUME_CUDA_AWARE_MPI=OFF
+  )
+ENDIF ()
 
 ASSERT_DEFINED (Tpetra_ENABLE_CUDA)
 ASSERT_DEFINED (Tpetra_INST_CUDA)

--- a/packages/tpetra/core/test/Utils/behavior.cpp
+++ b/packages/tpetra/core/test/Utils/behavior.cpp
@@ -190,9 +190,9 @@ namespace { // (anonymous)
         out << "TPETRA_VERBOSE_PRINT_COUNT_THRESHOLD is already set in environment" << endl;
         Teuchos::OSTab tab3 (out);
 
-        int threshold = std::stoi(std::string(varVal));
+        size_t threshold = std::stoi(std::string(varVal));
         size_t threshold2 = Behavior::verbosePrintCountThreshold ();
-        TEST_EQUALITY( static_cast<size_t>(threshold), threshold2 );
+        TEST_EQUALITY(threshold, threshold2);
       }
     }
 


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

Refactor idot. Main things are factoring out duplicated code, avoiding redundant View allocation/initialization/copies, and ensuring correctness for non-CUDA aware MPI. 140 net lines of code removed.

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Originally started with just reviewing Kokkos fences with #7446 (minimal fences but correctness without CUDA_LAUNCH_BLOCKING). Then I thought I could refactor to make it way shorter and simpler, but that mostly didn't pan out because of the UVM + MPI potential issue. But there's still a net removal of code, slight improvements to performance and a guarantee of correctness with CudaSpace or CudaUVMSpace and non-CUDA aware MPI. I don't think an error here has been observed, but @jjellio has told me that UVM and non-CUDA aware MPI can cause unpredictable failures on some machines.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
-->

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of #7446 
* Composed of 


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Added another idot test (same executable) if CUDA is enabled, which sets ``ENVIRONMENT TPETRA_ASSUME_CUDA_AWARE_MPI=OFF`` in order to disable the assumption of CUDA-aware MPI. This exercises the other (new) code path in idot. Ran Belos and Tpetra tests on kokkos-dev2 (CUDA 10 + CUDA-aware MPI) with CUDA_LAUNCH_BLOCKING off. Every test that calls idot passed (Belos and Tpetra are the only packages which call it).
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->