### PR TITLE
tpetra:  removing computation of unused fields

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -1937,7 +1937,6 @@ namespace Tpetra {
     /// Global constants include:
     /// <ul>
     /// <li> globalNumEntries_ </li>
-    /// <li> globalNumDiags_ </li>
     /// <li> globalMaxNumRowEntries_ </li>
     /// </ul>
     ///
@@ -1946,17 +1945,7 @@ namespace Tpetra {
     /// <li> globalNumEntries_ </li>
     /// <li> globalMaxNumRowEntries_ </li>
     /// </ul>
-    ///
-    /// Only compute the following if the input argument
-    /// computeLocalTriangularConstants is true:
-    /// <ul>
-    /// <li> globalNumDiags_ </li>
-    /// </ul>
-    /// The bool input argument comes from an input ParameterList bool
-    /// parameter "compute local triangular constants", named
-    /// analogously to the existing bool parameter "compute global
-    /// constants".
-    void computeGlobalConstants (const bool computeLocalTriangularConstants);
+    void computeGlobalConstants ();
 
   protected:
     /// \brief Compute local constants, if they have not yet been computed.
@@ -1968,9 +1957,6 @@ namespace Tpetra {
     ///
     /// Local constants include:
     /// <ul>
-    /// <li> lowerTriangular_ </li>
-    /// <li> upperTriangular_ </li>
-    /// <li> nodeNumDiags_ </li>
     /// <li> nodeMaxNumRowEntries_ </li>
     /// </ul>
     ///
@@ -1979,21 +1965,9 @@ namespace Tpetra {
     /// <li> nodeMaxNumRowEntries_ </li>
     /// </ul>
     ///
-    /// Only compute the following if the input argument
-    /// computeLocalTriangularConstants is true:
-    /// <ul>
-    /// <li> lowerTriangular_ </li>
-    /// <li> upperTriangular_ </li>
-    /// <li> nodeNumDiags_ </li>
-    /// </ul>
-    /// The bool input argument comes from an input ParameterList bool
-    /// parameter "compute local triangular constants", named
-    /// analogously to the existing bool parameter "compute global
-    /// constants".
-    ///
     /// computeGlobalConstants calls this method, if global constants
     /// have not yet been computed.
-    void computeLocalConstants (const bool computeLocalTriangularConstants);
+    void computeLocalConstants ();
 
     /// \brief Get information about the locally owned row with local
     ///   index myRow.
@@ -2159,11 +2133,6 @@ namespace Tpetra {
     //! Local graph; only initialized after first fillComplete() call.
     local_graph_type lclGraph_;
 
-    /// \brief Local number of (populated) diagonal entries.
-    ///
-    /// Computed in computeLocalConstants(); only valid when isFillComplete().
-    size_t nodeNumDiags_ = Teuchos::OrdinalTraits<size_t>::invalid();
-
     /// \brief Local maximum of the number of entries in each row.
     ///
     /// Computed in computeLocalConstants; only valid when
@@ -2175,13 +2144,6 @@ namespace Tpetra {
     ///
     /// Only valid when isFillComplete() is true.
     global_size_t globalNumEntries_ =
-      Teuchos::OrdinalTraits<global_size_t>::invalid();
-
-    /// \brief Global number of (populated) diagonal entries.
-    ///
-    /// Computed in computeGlobalConstants; only valid when
-    ///   isFillComplete() is true.
-    global_size_t globalNumDiags_ =
       Teuchos::OrdinalTraits<global_size_t>::invalid();
 
     /// \brief Global maximum of the number of entries in each row.
@@ -2321,10 +2283,6 @@ namespace Tpetra {
     bool indicesAreGlobal_ = false;
     bool fillComplete_ = false;
 
-    //! Whether the graph is locally lower triangular.
-    bool lowerTriangular_ = false;
-    //! Whether the graph is locally upper triangular.
-    bool upperTriangular_ = false;
     //! Whether the graph's indices are sorted in each row, on this process.
     bool indicesAreSorted_ = true;
     /// \brief Whether the graph's indices are non-redundant (merged)
@@ -2361,7 +2319,6 @@ namespace Tpetra {
     static bool getDebug();
 
     /// \brief Whether to do extra debug checks.
-    ///
     /// This comes from Tpetra::Details::Behavior::debug("CrsGraph").
     bool debug_ = getDebug();
 

--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -4856,13 +4856,11 @@ namespace Tpetra {
 
       const bool callGraphComputeGlobalConstants = params.get () == nullptr ||
         params->get ("compute global constants", true);
-      const bool computeLocalTriangularConstants = params.get () == nullptr ||
-        params->get ("compute local triangular constants", true);
       if (callGraphComputeGlobalConstants) {
-        this->myGraph_->computeGlobalConstants (computeLocalTriangularConstants);
+        this->myGraph_->computeGlobalConstants ();
       }
       else {
-        this->myGraph_->computeLocalConstants (computeLocalTriangularConstants);
+        this->myGraph_->computeLocalConstants ();
       }
       this->myGraph_->fillComplete_ = true;
       this->myGraph_->checkInternalState ();

--- a/packages/xpetra/src/CrsGraph/Xpetra_TpetraCrsGraph_def.hpp
+++ b/packages/xpetra/src/CrsGraph/Xpetra_TpetraCrsGraph_def.hpp
@@ -249,8 +249,7 @@ typename Xpetra::CrsGraph<LocalOrdinal,GlobalOrdinal,Node>::local_graph_type Tpe
 template<class LocalOrdinal, class GlobalOrdinal, class Node>
 void TpetraCrsGraph<LocalOrdinal,GlobalOrdinal,Node>::computeGlobalConstants() {
       // mfh 07 May 2018: See GitHub Issue #2565.
-      constexpr bool computeLocalTriangularConstants = true;
-      graph_->computeGlobalConstants(computeLocalTriangularConstants);
+      graph_->computeGlobalConstants();
     }
 
 template<class LocalOrdinal, class GlobalOrdinal, class Node>


### PR DESCRIPTION
## Motivation

@trilinos/tpetra @trilinos/ifpack2 

NOTE:  for the best reviewing experience,  hide diffs due to whitespace
(some loops went away, so loop bodies moved over two spaces)

While examining fences for #7446, we discovered that Tpetra was computing fields (involving two fences and reduceAll) that were no longer used.  Fields lowerTriangular_, upperTriangular_, nodeNumDiags_, and globalNumDiags_ were computed, but they were not used in Tpetra nor were accessors available for their use elsewhere. 
These fields should have been removed with the deprecations in #2630 and #2644.  

These changes remove computation of the fields in computeLocalConstants() and computeGlobalConstants().  They change the interface to computeGlobalConstants(), but this function seemed to be called only from Xpetra, so I am not concerned about backward compatibility.

Removing this computation from getLocalConstants() addresses some of the concerns in #2658; Ifpack2's LocalSparseTriangularSolver still calls Tpetra::Details::determineLocalTriangularStructure, so I did not remove this method.  @jhux2 @csiefer2 @brian-kelley  can say whether this method should remain.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->





## Related Issues

* Closes #2630
* Related to #2568



## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
In https://github.com/trilinos/Trilinos/pull/7446#discussion_r451109058, @trilinos/ifapck2 developers confirmed that these fields are not needed.

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Built with MueLu, Ifpack2, Tpetra on mac, clang

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->