### PR TITLE
Tpetra: fix scalar error in test

### DIFF
--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests.cpp
@@ -391,9 +391,9 @@ namespace { // (anonymous)
       size_t vecOffset = vec * numLocalRows;
       for(size_t i = 0; i < numLocalRows - 1; i++)
       {
-        TEST_EQUALITY(5.0 * ST::one(), vvals[vecOffset + i]);
+        TEST_EQUALITY(static_cast<Mag>(5.0) * ST::one(), vvals[vecOffset + i]);
       }
-      TEST_EQUALITY(Scalar((double) numLocalColumns * ST::one()), Scalar(vvals[vecOffset + numLocalRows - 1]));
+      TEST_EQUALITY(static_cast<Mag>(numLocalColumns) * ST::one(), vvals[vecOffset + numLocalRows - 1]);
     }
     if(numVecs != 1)
     {
@@ -405,9 +405,9 @@ namespace { // (anonymous)
       vcol->get1dCopy(vvals(), numLocalRows);
       for(size_t i = 0; i < numLocalRows - 1; i++)
       {
-        TEST_EQUALITY(5.0 * ST::one(), vvals[i]);
+        TEST_EQUALITY(static_cast<Mag>(5.0) * ST::one(), vvals[i]);
       }
-      TEST_EQUALITY(Scalar((double) numLocalColumns * ST::one()), Scalar(vvals[numLocalRows - 1]));
+      TEST_EQUALITY(static_cast<Mag>(numLocalColumns) * ST::one(), vvals[numLocalRows - 1]);
       //Finally, test residual.
       V res(rowMap);
       //Here, have A*wcol = vcol. This means the residual of A, wcol, and vcol should be 0.


### PR DESCRIPTION
Was trying to scale a Scalar with double. This doesn't work if Scalar
is complex<float>, since that overload of ``operator*`` doesn't exist.
Now scaling with magnitudeType instead, which should work in all cases.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Fixes build error with ``Trilinos_ENABLE_COMPLEX_FLOAT`` and ``Tpetra_ENABLE_TESTS``.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
Error was impacting @jennloe 's build.
## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Error was in a test. The semantics of the test didn't change.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->