### PR TITLE
Put back the LD_LIBRARY_PATH to fix intel-18 test failures (ATDV-272)

### DIFF
--- a/cmake/std/atdm/cee-rhel6/environment.sh
+++ b/cmake/std/atdm/cee-rhel6/environment.sh
@@ -199,8 +199,6 @@ fi
 # to be safe.  Also, we need to set OMP_* env vars here because the SPARC
 # modules change them!
 
-atdm_remove_substrings_from_env_var LD_LIBRARY_PATH ":" "/usr/local/epd/canopy2/opt/Canopy/edm/envs/User/lib"
-
 # Use updated Ninja and CMake
 module load sems-env
 module load sems-cmake/3.12.2


### PR DESCRIPTION
This should fix the mass

## How was this tested?

On 'ceerws1113' I ran:

```
$ env Trilinos_PACKAGES=Kokkos ./ctest-s-local-test-driver-cee-rhel6.sh all

***
*** /scratch/rabartl/Trilinos.base/Trilinos/cmake/std/atdm/ctest-s-local-test-driver.sh
***

ATDM_TRILINOS_DIR = '/scratch/rabartl/Trilinos.base/Trilinos'

Load some env to get python, cmake, etc ...

Hostname 'ceerws1113' matches known ATDM host 'ceerws1113' and system 'cee-rhel6'
Setting compiler and build options for build-name 'cee-rhel6-default'
Using CEE RHEL6 compiler stack CLANG-9.0.1_OPENMPI-4.0.3 to build DEBUG code with Kokkos node type SERIAL

Running builds:
    cee-rhel6_clang-9.0.1_openmpi-4.0.3_serial_static_opt
    cee-rhel6_gnu-7.2.0_openmpi-4.0.3_serial_shared_opt
    cee-rhel6_intel-18.0.2_mpich2-3.2_openmp_static_opt
    cee-rhel6_intel-19.0.3_intelmpi-2018.4_serial_static_opt

Wed Jul  8 18:39:35 MDT 2020

Running Jenkins driver Trilinos-atdm-cee-rhel6_clang-9.0.1_openmpi-4.0.3_serial_static_opt.sh ...

    See log file Trilinos-atdm-cee-rhel6_clang-9.0.1_openmpi-4.0.3_serial_static_opt/smart-jenkins-driver.out

real    2m59.194s
user    24m22.222s
sys     1m9.526s

100% tests passed, 0 tests failed out of 25

Wed Jul  8 18:42:35 MDT 2020

Running Jenkins driver Trilinos-atdm-cee-rhel6_gnu-7.2.0_openmpi-4.0.3_serial_shared_opt.sh ...

    See log file Trilinos-atdm-cee-rhel6_gnu-7.2.0_openmpi-4.0.3_serial_shared_opt/smart-jenkins-driver.out

real    2m28.743s
user    19m45.616s
sys     2m0.307s

100% tests passed, 0 tests failed out of 25

Wed Jul  8 18:45:03 MDT 2020

Running Jenkins driver Trilinos-atdm-cee-rhel6_intel-18.0.2_mpich2-3.2_openmp_static_opt.sh ...

    See log file Trilinos-atdm-cee-rhel6_intel-18.0.2_mpich2-3.2_openmp_static_opt/smart-jenkins-driver.out

real    10m13.286s
user    110m47.700s
sys     7m53.798s

100% tests passed, 0 tests failed out of 30

Wed Jul  8 18:55:17 MDT 2020

Running Jenkins driver Trilinos-atdm-cee-rhel6_intel-19.0.3_intelmpi-2018.4_serial_static_opt.sh ...

    See log file Trilinos-atdm-cee-rhel6_intel-19.0.3_intelmpi-2018.4_serial_static_opt/smart-jenkins-driver.out

real    6m35.363s
user    45m41.301s
sys     3m0.809s

100% tests passed, 0 tests failed out of 25

Wed Jul  8 19:01:52 MDT 2020

Done running all of the builds!
```

and it posted to CDash:

* https://testing-dev.sandia.gov/cdash/index.php?project=Trilinos&date=2020-07-08&filtercount=2&showfilters=1&filtercombine=and&field1=buildname&compare1=65&value1=Trilinos-atdm-cee-rhel6&field2=buildname&compare2=63&value2=-exp

showing:


| Site | Build Name | Conf Err | Conf Warn | Conf Test Time | Build Err | Build Warn | Build Test Time | Test Not Run | Test Fail | Test Pass | Test Time | Test Proc Time | Start Test Time | Labels |
| -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- |
ceerws1113 | Trilinos-atdm-cee-rhel6_clang-9.0.1_openmpi-4.0.3_serial_static_opt-exp | 0 | 3 | 16s | 0 | 0 | 1m 46s | 0 | 0 | 25 | 45s | 1m 42s | 2 hours ago | Kokkos
ceerws1113 | Trilinos-atdm-cee-rhel6_clang-9.0.1_openmpi-4.0.3_serial_static_opt-exp | 0 | 3 | 2m 8s | 0 | 50 | 2h 23m 11s | 0 | 1 | 2167 | 38m 31s | 4h 56m 33s | 10 hours ago | (30 labels)
ceerws1113 | Trilinos-atdm-cee-rhel6_gnu-7.2.0_openmpi-4.0.3_serial_shared_opt-exp | 0 | 3 | 18s | 0 | 3 | 1m 34s | 0 | 0 | 25 | 27s | 59s | 2 hours ago | Kokkos
ceerws1113 | Trilinos-atdm-cee-rhel6_intel-18.0.2_mpich2-3.2_openmp_static_opt-exp | 0 | 3 | 37s | 0 | 12 | 7m 16s | 0 | 0 | 30 | 2m 10s | 6m 17s | 2 hours ago | Kokkos
ceerws1113 | Trilinos-atdm-cee-rhel6_intel-19.0.3_intelmpi-2018.4_serial_static_opt-exp | 0 | 3 | 31s | 0 | 2 | 5m 25s | 0 | 0 | 25 | 29s | 55s | 2 hours ago | Kokkos


