### PR TITLE
Tpetra: Better placement of pack fences

### DIFF
--- a/packages/tpetra/core/src/Tpetra_DistObject_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_DistObject_def.hpp
@@ -1077,6 +1077,7 @@ namespace Tpetra {
             }
           }
           else { // pack on device
+            Kokkos::fence(); // for UVM
             this->imports_.modify_device ();
             if (revOp == DoReverse) {
               distor.doReversePostsAndWaits
@@ -1137,6 +1138,7 @@ namespace Tpetra {
             }
           }
           else { // pack on device
+            Kokkos::fence(); // for UVM
             this->imports_.modify_device ();
             if (revOp == DoReverse) {
               distor.doReversePostsAndWaits

--- a/packages/tpetra/core/src/kokkos_refactor/Tpetra_KokkosRefactor_Details_MultiVectorDistObjectKernels.hpp
+++ b/packages/tpetra/core/src/kokkos_refactor/Tpetra_KokkosRefactor_Details_MultiVectorDistObjectKernels.hpp
@@ -148,7 +148,6 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
         ("Tpetra::MultiVector pack one col",
          range_type (0, idx.size ()),
          PackArraySingleColumn (dst, src, idx, col));
-      Kokkos::fence();
     }
   };
 
@@ -231,7 +230,6 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
          range_type (0, idx.size ()),
          PackArraySingleColumnWithBoundsCheck (dst, src, idx, col),
          errorCount);
-      Kokkos::fence();
 
       if (errorCount != 0) {
         // Go back and find the out-of-bounds entries in the index


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
@kyungjoo-kim Addresses comments in #7446 to move fence as late as possible. The second one (line 1141) I can confirm via testing. The first one (line 1080) does not fail tests if I remove it, but I think we need it as well.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

white Cuda build

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->