### PR TITLE
Tpetra: add safety check to matrix market reader

### DIFF
--- a/packages/tpetra/core/inout/MatrixMarket_Tpetra.hpp
+++ b/packages/tpetra/core/inout/MatrixMarket_Tpetra.hpp
@@ -1657,7 +1657,7 @@ namespace Tpetra {
         if (comm->getRank () == 0) {
           try {
             in.open (filename.c_str ());
-            opened = 1;
+            opened = in.is_open();
           }
           catch (...) {
             opened = 0;
@@ -1724,7 +1724,7 @@ namespace Tpetra {
         if (pComm->getRank () == 0) {
           try {
             in.open (filename.c_str ());
-            opened = 1;
+            opened = in.is_open();
           }
           catch (...) {
             opened = 0;
@@ -1817,7 +1817,7 @@ namespace Tpetra {
         if (comm->getRank () == 0) {
           try {
             in.open (filename.c_str ());
-            opened = 1;
+            opened = in.is_open();
           }
           catch (...) {
             opened = 0;
@@ -2149,7 +2149,7 @@ namespace Tpetra {
         if (myRank == 0) {
           try {
             in.open (filename.c_str ());
-            opened = 1;
+            opened = in.is_open();
           }
           catch (...) {
             opened = 0;
@@ -3925,10 +3925,25 @@ namespace Tpetra {
                      const bool tolerant=false,
                      const bool debug=false)
       {
+        using Teuchos::broadcast;
+        using Teuchos::outArg;
+
         std::ifstream in;
-        if (comm->getRank () == 0) { // Only open the file on Proc 0.
-          in.open (filename.c_str ()); // Destructor closes safely
+        int opened = 0;
+        if (comm->getRank() == 0) {
+          try {
+            in.open (filename.c_str ());
+            opened = in.is_open();
+          }
+          catch (...) {
+            opened = 0;
+          }
         }
+        broadcast<int, int> (*comm, 0, outArg (opened));
+        TEUCHOS_TEST_FOR_EXCEPTION(
+          opened == 0, std::runtime_error,
+          "readDenseFile: Failed to open file \"" << filename << "\" on "
+          "Process 0.");
         return readDense (in, comm, map, tolerant, debug);
       }
 
@@ -3969,10 +3984,25 @@ namespace Tpetra {
                       const bool tolerant=false,
                       const bool debug=false)
       {
+        using Teuchos::broadcast;
+        using Teuchos::outArg;
+
         std::ifstream in;
-        if (comm->getRank () == 0) { // Only open the file on Proc 0.
-          in.open (filename.c_str ()); // Destructor closes safely
+        int opened = 0;
+        if (comm->getRank() == 0) {
+          try {
+            in.open (filename.c_str ());
+            opened = in.is_open();
+          }
+          catch (...) {
+            opened = 0;
+          }
         }
+        broadcast<int, int> (*comm, 0, outArg (opened));
+        TEUCHOS_TEST_FOR_EXCEPTION(
+          opened == 0, std::runtime_error,
+          "readVectorFile: Failed to open file \"" << filename << "\" on "
+          "Process 0.");
         return readVector (in, comm, map, tolerant, debug);
       }
 
@@ -5579,7 +5609,7 @@ namespace Tpetra {
             "Please report this bug to the Tpetra developers.");
         }
       }
-    };
+    }; // class Reader
 
     /// \class Writer
     /// \brief Matrix Market file writer for CrsMatrix and MultiVector.


### PR DESCRIPTION
@trilinos/tpetra 

## Motivation

This PR equips the MatrixMarket reader with more descriptive error messages in case of non-existing/non-open files to be read.

Check, if the file to be read could actually be opened. Throw exception, if not. 

This throws an exception right away, instead of causing downstream errors when trying to read a non-openend/non-existing file.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

While I added these tests for debugging of some block methods in MueLu, this is rather general capability and is not associated with any particular project.

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

`ctest` with Tpetra tests enabled succeeds.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->