### PR TITLE
Tpetra: Add state tracking for graph to avoid extra fencing.

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -2330,6 +2330,22 @@ namespace Tpetra {
     /// This comes from Tpetra::Details::Behavior::debug("CrsGraph").
     bool verbose_ = getVerbose();
 
+  private:
+    //! Track if we still might need to fence for the StaticGraph.
+    mutable bool need_sync_host_uvm_access = false;
+
+    //! Request fence before next host access.
+    void set_need_sync_host_uvm_access() {
+      need_sync_host_uvm_access = true;
+    }
+
+    //! Fence if necessary and set flag so we don't duplicate.
+    void execute_sync_host_uvm_access() const {
+      if(need_sync_host_uvm_access) {
+        Kokkos::fence();
+        need_sync_host_uvm_access = false;
+      }
+    }
   }; // class CrsGraph
 
   /// \brief Nonmember function to create an empty CrsGraph given a


### PR DESCRIPTION

@trilinos/tpetra 
@kddevin @kyungjoo-kim 
For fences in Tpetra_CrsGraph.hpp we discussed the possibility of tracking the state of the graph to validate whether it needed fencing. This PR is a draft of how that might look so opening this so we can discuss if this is what we had in mind.

Having set this up, we can probably reduce the number of fence calls to about 1/2, as measured by running all unit tests. However I'm wondering if this extra complexity is worth it. It seems it would be better to just do the simple thing and always call  Kokkos::fence() before the various UVM host access places.

Note I removed the fence before maxDifference which is on device so I think that fence is not actually needed regardless of our plan for CrsGraph. 
