### PR TITLE
Fix KokkosKernels/Tpetra ETI interaction

### DIFF
--- a/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
@@ -1863,8 +1863,7 @@ namespace KB = KokkosBatched::Experimental;
       const ConstUnmanaged<local_ordinal_type_1d_view> partptr, lclrow, packptr;
       const local_ordinal_type max_partsz;
       // block crs matrix (it could be Kokkos::UVMSpace::size_type, which is int)
-      using a_rowptr_value_type = typename Kokkos::ViewTraits<local_ordinal_type*,typename impl_type::node_device_type>::size_type;
-      using size_type_1d_view_tpetra = Kokkos::View<a_rowptr_value_type*,typename impl_type::node_device_type>;
+      using size_type_1d_view_tpetra = Kokkos::View<size_t*,typename impl_type::node_device_type>;
       const ConstUnmanaged<size_type_1d_view_tpetra> A_rowptr;
       const ConstUnmanaged<impl_scalar_type_1d_view_tpetra> A_values;
       // block tridiags
@@ -2901,8 +2900,7 @@ namespace KB = KokkosBatched::Experimental;
 
       // block crs graph information
       // for cuda (kokkos crs graph uses a different size_type from size_t)
-      using a_rowptr_value_type = typename Kokkos::ViewTraits<local_ordinal_type*,node_device_type>::size_type;
-      const ConstUnmanaged<Kokkos::View<a_rowptr_value_type*,node_device_type> > A_rowptr;
+      const ConstUnmanaged<Kokkos::View<size_t*,node_device_type> > A_rowptr;
       const ConstUnmanaged<Kokkos::View<local_ordinal_type*,node_device_type> > A_colind;
 
       // blocksize

--- a/packages/kokkos-kernels/src/common/KokkosKernels_Controls.hpp
+++ b/packages/kokkos-kernels/src/common/KokkosKernels_Controls.hpp
@@ -102,9 +102,9 @@ namespace Experimental{
     }
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUBLAS
-    cublasHandle_t cublasHandle = 0;
+    mutable cublasHandle_t cublasHandle = 0;
 
-    cublasHandle_t getCublasHandle() {
+    cublasHandle_t getCublasHandle() const {
       if(cublasHandle == 0) {
 	KokkosBlas::Impl::CudaBlasSingleton & s = KokkosBlas::Impl::CudaBlasSingleton::singleton();
 	cublasHandle = s.handle;
@@ -118,9 +118,9 @@ namespace Experimental{
 #endif
 
 #ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
-    cusparseHandle_t cusparseHandle = 0;
+    mutable cusparseHandle_t cusparseHandle = 0;
 
-    cusparseHandle_t getCusparseHandle() {
+    cusparseHandle_t getCusparseHandle() const {
       if(cusparseHandle == 0) {
 	KokkosKernels::Impl::CusparseSingleton & s =
 	  KokkosKernels::Impl::CusparseSingleton::singleton();

--- a/packages/kokkos-kernels/src/impl/tpls/KokkosSparse_spmv_tpl_spec_avail.hpp
+++ b/packages/kokkos-kernels/src/impl/tpls/KokkosSparse_spmv_tpl_spec_avail.hpp
@@ -185,121 +185,119 @@ struct spmv_tpl_spec_avail<const SCALAR, const ORDINAL, Kokkos::Device<Kokkos::C
 
 #if (10300 <= CUSPARSE_VERSION)
 
-//CUSPARSE is enabled, and is >= 10.0 so it supports generic ordinal/offset combinations.
-//So check if the above combinations (scalar x layout x space) are enabled (but with int/size_t)
+//Can enable int64/size_t.
+//TODO: if Nvidia ever supports int/size_t, add that too.
 
 #if defined (KOKKOSKERNELS_INST_FLOAT) \
   && defined (KOKKOSKERNELS_INST_LAYOUTLEFT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT64_T) \
   && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
-  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(float, int, size_t, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(float, int64_t, size_t, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
 #endif
 
 #if defined (KOKKOSKERNELS_INST_DOUBLE) \
   && defined (KOKKOSKERNELS_INST_LAYOUTLEFT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT64_T) \
   && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
-  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(double, int, size_t, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(double, int64_t, size_t, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
 #endif
 
 #if defined (KOKKOSKERNELS_INST_FLOAT) \
   && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT64_T) \
   && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
-  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(float, int, size_t, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(float, int64_t, size_t, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
 #endif
 
 #if defined (KOKKOSKERNELS_INST_DOUBLE) \
   && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT64_T) \
   && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
-  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(double, int, size_t, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(double, int64_t, size_t, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
 #endif
 
 #if defined (KOKKOSKERNELS_INST_FLOAT) \
   && defined (KOKKOSKERNELS_INST_LAYOUTLEFT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT64_T) \
   && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
-  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(float, int, size_t, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(float, int64_t, size_t, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
 #endif
 
 #if defined (KOKKOSKERNELS_INST_DOUBLE) \
   && defined (KOKKOSKERNELS_INST_LAYOUTLEFT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT64_T) \
   && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
-  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(double, int, size_t, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(double, int64_t, size_t, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
 #endif
 
 #if defined (KOKKOSKERNELS_INST_FLOAT) \
   && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT64_T) \
   && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
-  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(float, int, size_t, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(float, int64_t, size_t, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
 #endif
 
 #if defined (KOKKOSKERNELS_INST_DOUBLE) \
   && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT64_T) \
   && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
-  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(double, int, size_t, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(double, int64_t, size_t, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
 #endif
 
 #if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
   && defined (KOKKOSKERNELS_INST_LAYOUTLEFT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT64_T) \
   && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
-  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<float>, int, size_t, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<float>, int64_t, size_t, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
 #endif
 
 #if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
   && defined (KOKKOSKERNELS_INST_LAYOUTLEFT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT64_T) \
   && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
-  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>, int, size_t, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>, int64_t, size_t, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
 #endif
 
 #if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
   && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT64_T) \
   && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
-  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<float>, int, size_t, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<float>, int64_t, size_t, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
 #endif
 
 #if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
   && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT64_T) \
   && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
-  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>, int, size_t, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>, int64_t, size_t, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
 #endif
 
 #if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
   && defined (KOKKOSKERNELS_INST_LAYOUTLEFT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT64_T) \
   && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
-  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<float>, int, size_t, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<float>, int64_t, size_t, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
 #endif
 
 #if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
   && defined (KOKKOSKERNELS_INST_LAYOUTLEFT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT64_T) \
   && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
-
-  #warning "Hello from here, enabling complex_double/int/size_t/left/CudaUVMSpace"
-  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>, int, size_t, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>, int64_t, size_t, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
 #endif
 
 #if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
   && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT64_T) \
   && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
-  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<float>, int, size_t, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<float>, int64_t, size_t, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
 #endif
 
 #if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
   && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT) \
-  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT64_T) \
   && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
-  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>, int, size_t, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>, int64_t, size_t, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
 #endif
 
 #endif  // CUSPARSE >= 10.0 (nested, implies >= 9.0)

--- a/packages/kokkos-kernels/src/impl/tpls/KokkosSparse_spmv_tpl_spec_avail.hpp
+++ b/packages/kokkos-kernels/src/impl/tpls/KokkosSparse_spmv_tpl_spec_avail.hpp
@@ -56,45 +56,255 @@ struct spmv_tpl_spec_avail {
 };
 
 // cuSPARSE
-#if defined (KOKKOSKERNELS_ENABLE_TPL_CUSPARSE) && (9000 <= CUDA_VERSION)
+#ifdef KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
 
-#define KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(SCALAR, XL, YL, MEMSPACE) \
+//These versions of cuSPARSE require the ordinal and offset types to be the same.
+//For KokkosKernels, this means int/int only.
+
+#define KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(SCALAR, ORDINAL, OFFSET, XL, YL, MEMSPACE) \
 template <> \
-struct spmv_tpl_spec_avail<const SCALAR, const int, Kokkos::Device<Kokkos::Cuda, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>, const int, \
+struct spmv_tpl_spec_avail<const SCALAR, const ORDINAL, Kokkos::Device<Kokkos::Cuda, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>, const OFFSET, \
 			   const SCALAR*,       XL, Kokkos::Device<Kokkos::Cuda, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged | Kokkos::RandomAccess>, \
 			   SCALAR*,             YL, Kokkos::Device<Kokkos::Cuda, MEMSPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged> > { \
   enum : bool { value = true }; \
 };
 
+#if (9000 <= CUSPARSE_VERSION)
+
 #if defined (KOKKOSKERNELS_INST_FLOAT) \
   && defined (KOKKOSKERNELS_INST_LAYOUTLEFT) \
   && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
   && defined (KOKKOSKERNELS_INST_OFFSET_INT)
-  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(float, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(float, int, int, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
 #endif
 
 #if defined (KOKKOSKERNELS_INST_DOUBLE) \
   && defined (KOKKOSKERNELS_INST_LAYOUTLEFT) \
   && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
   && defined (KOKKOSKERNELS_INST_OFFSET_INT)
-  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(double, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(double, int, int, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
 #endif
 
 #if defined (KOKKOSKERNELS_INST_FLOAT) \
   && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT) \
   && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
   && defined (KOKKOSKERNELS_INST_OFFSET_INT)
-  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(float, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(float, int, int, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
 #endif
 
 #if defined (KOKKOSKERNELS_INST_DOUBLE) \
   && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT) \
   && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
   && defined (KOKKOSKERNELS_INST_OFFSET_INT)
-  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(double, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(double, int, int, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
 #endif
 
+#if defined (KOKKOSKERNELS_INST_FLOAT) \
+  && defined (KOKKOSKERNELS_INST_LAYOUTLEFT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_OFFSET_INT)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(float, int, int, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
 #endif
+
+#if defined (KOKKOSKERNELS_INST_DOUBLE) \
+  && defined (KOKKOSKERNELS_INST_LAYOUTLEFT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_OFFSET_INT)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(double, int, int, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
+#endif
+
+#if defined (KOKKOSKERNELS_INST_FLOAT) \
+  && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_OFFSET_INT)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(float, int, int, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
+#endif
+
+#if defined (KOKKOSKERNELS_INST_DOUBLE) \
+  && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_OFFSET_INT)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(double, int, int, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
+#endif
+
+#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
+  && defined (KOKKOSKERNELS_INST_LAYOUTLEFT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_OFFSET_INT)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<float>, int, int, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
+#endif
+
+#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
+  && defined (KOKKOSKERNELS_INST_LAYOUTLEFT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_OFFSET_INT)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>, int, int, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
+#endif
+
+#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
+  && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_OFFSET_INT)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<float>, int, int, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
+#endif
+
+#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
+  && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_OFFSET_INT)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>, int, int, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
+#endif
+
+#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
+  && defined (KOKKOSKERNELS_INST_LAYOUTLEFT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_OFFSET_INT)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<float>, int, int, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
+#endif
+
+#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
+  && defined (KOKKOSKERNELS_INST_LAYOUTLEFT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_OFFSET_INT)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>, int, int, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
+#endif
+
+#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
+  && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_OFFSET_INT)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<float>, int, int, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
+#endif
+
+#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
+  && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_OFFSET_INT)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>, int, int, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
+#endif
+
+#if (10300 <= CUSPARSE_VERSION)
+
+//CUSPARSE is enabled, and is >= 10.0 so it supports generic ordinal/offset combinations.
+//So check if the above combinations (scalar x layout x space) are enabled (but with int/size_t)
+
+#if defined (KOKKOSKERNELS_INST_FLOAT) \
+  && defined (KOKKOSKERNELS_INST_LAYOUTLEFT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(float, int, size_t, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
+#endif
+
+#if defined (KOKKOSKERNELS_INST_DOUBLE) \
+  && defined (KOKKOSKERNELS_INST_LAYOUTLEFT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(double, int, size_t, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
+#endif
+
+#if defined (KOKKOSKERNELS_INST_FLOAT) \
+  && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(float, int, size_t, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
+#endif
+
+#if defined (KOKKOSKERNELS_INST_DOUBLE) \
+  && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(double, int, size_t, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
+#endif
+
+#if defined (KOKKOSKERNELS_INST_FLOAT) \
+  && defined (KOKKOSKERNELS_INST_LAYOUTLEFT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(float, int, size_t, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
+#endif
+
+#if defined (KOKKOSKERNELS_INST_DOUBLE) \
+  && defined (KOKKOSKERNELS_INST_LAYOUTLEFT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(double, int, size_t, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
+#endif
+
+#if defined (KOKKOSKERNELS_INST_FLOAT) \
+  && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(float, int, size_t, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
+#endif
+
+#if defined (KOKKOSKERNELS_INST_DOUBLE) \
+  && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(double, int, size_t, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
+#endif
+
+#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
+  && defined (KOKKOSKERNELS_INST_LAYOUTLEFT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<float>, int, size_t, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
+#endif
+
+#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
+  && defined (KOKKOSKERNELS_INST_LAYOUTLEFT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>, int, size_t, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaSpace)
+#endif
+
+#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
+  && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<float>, int, size_t, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
+#endif
+
+#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
+  && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>, int, size_t, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaSpace)
+#endif
+
+#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
+  && defined (KOKKOSKERNELS_INST_LAYOUTLEFT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<float>, int, size_t, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
+#endif
+
+#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
+  && defined (KOKKOSKERNELS_INST_LAYOUTLEFT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
+
+  #warning "Hello from here, enabling complex_double/int/size_t/left/CudaUVMSpace"
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>, int, size_t, Kokkos::LayoutLeft, Kokkos::LayoutLeft, Kokkos::CudaUVMSpace)
+#endif
+
+#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_FLOAT_) \
+  && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<float>, int, size_t, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
+#endif
+
+#if defined (KOKKOSKERNELS_INST_KOKKOS_COMPLEX_DOUBLE_) \
+  && defined (KOKKOSKERNELS_INST_LAYOUTRIGHT) \
+  && defined (KOKKOSKERNELS_INST_ORDINAL_INT) \
+  && defined (KOKKOSKERNELS_INST_OFFSET_SIZE_T)
+  KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>, int, size_t, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
+#endif
+
+#endif  // CUSPARSE >= 10.0 (nested, implies >= 9.0)
+#endif  // CUSPARSE >= 9.0?
+#endif  // KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
 
 // Specialization struct which defines whether a specialization exists
 template<class AT, class AO, class AD, class AM, class AS,
@@ -106,7 +316,6 @@ struct spmv_mv_tpl_spec_avail {
   enum : bool { value = false };
 };
 
-}
-}
+}}  // KokkosSparse::Impl
 
 #endif // KOKKOSPARSE_SPMV_TPL_SPEC_AVAIL_HPP_

--- a/packages/kokkos-kernels/src/impl/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
+++ b/packages/kokkos-kernels/src/impl/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
@@ -79,7 +79,6 @@ namespace Impl {
     using offset_type = typename AMatrix::non_const_size_type;
     using entry_type  = typename AMatrix::non_const_ordinal_type;
     using value_type  = typename AMatrix::non_const_value_type;
-    std::cout << "Hello from spmv_cusparse!\n";
 
     /* initialize cusparse library */
     cusparseHandle_t cusparseHandle = controls.getCusparseHandle();
@@ -135,12 +134,12 @@ namespace Impl {
 
     size_t bufferSize     = 0;
     void*  dBuffer        = NULL;
-    cusparseSpMVAlg_t alg = CUSPARSE_CSRMV_ALG1;
+    cusparseSpMVAlg_t alg = CUSPARSE_MV_ALG_DEFAULT;
     if(controls.isParameter("algorithm"))
     {
       const std::string algName = controls.getParameter("algorithm");
       if(algName == "default")
-        alg = CUSPARSE_CSRMV_ALG1;
+        alg = CUSPARSE_MV_ALG_DEFAULT;
       else if(algName == "merge")
         alg = CUSPARSE_CSRMV_ALG2;
     }
@@ -239,7 +238,7 @@ namespace Impl {
 		      const XVector& x,					\
 		      const coefficient_type& beta,			\
 		      const YVector& y) {				\
-      if(controls.getParameter("algorithm") == "native") {		\
+      if(controls.isParameter("algorithm") && controls.getParameter("algorithm") == "native") {		\
 	std::string label = "KokkosSparse::spmv[TPL_CUSPARSE," + Kokkos::ArithTraits<SCALAR>::name() + "]"; \
 	Kokkos::Profiling::pushRegion(label);				\
 	spmv_native(controls, mode, alpha, A, x, beta, y);		\
@@ -269,23 +268,24 @@ namespace Impl {
   KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<double>, int, int, Kokkos::LayoutRight, Kokkos::CudaUVMSpace, true)
   KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<float>,  int, int, Kokkos::LayoutLeft,  Kokkos::CudaUVMSpace, true)
   KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<float>,  int, int, Kokkos::LayoutRight, Kokkos::CudaUVMSpace, true)
+
 #if (10300 <= CUSPARSE_VERSION)
-  KOKKOSSPARSE_SPMV_CUSPARSE(double, int, size_t, Kokkos::LayoutLeft,  Kokkos::CudaSpace, true)
-  KOKKOSSPARSE_SPMV_CUSPARSE(double, int, size_t, Kokkos::LayoutRight, Kokkos::CudaSpace, true)
-  KOKKOSSPARSE_SPMV_CUSPARSE(float,  int, size_t, Kokkos::LayoutLeft,  Kokkos::CudaSpace, true)
-  KOKKOSSPARSE_SPMV_CUSPARSE(float,  int, size_t, Kokkos::LayoutRight, Kokkos::CudaSpace, true)
-  KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<double>, int, size_t, Kokkos::LayoutLeft,  Kokkos::CudaSpace, true)
-  KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<double>, int, size_t, Kokkos::LayoutRight, Kokkos::CudaSpace, true)
-  KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<float>,  int, size_t, Kokkos::LayoutLeft,  Kokkos::CudaSpace, true)
-  KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<float>,  int, size_t, Kokkos::LayoutRight, Kokkos::CudaSpace, true)
-  KOKKOSSPARSE_SPMV_CUSPARSE(double, int, size_t, Kokkos::LayoutLeft,  Kokkos::CudaUVMSpace, true)
-  KOKKOSSPARSE_SPMV_CUSPARSE(double, int, size_t, Kokkos::LayoutRight, Kokkos::CudaUVMSpace, true)
-  KOKKOSSPARSE_SPMV_CUSPARSE(float,  int, size_t, Kokkos::LayoutLeft,  Kokkos::CudaUVMSpace, true)
-  KOKKOSSPARSE_SPMV_CUSPARSE(float,  int, size_t, Kokkos::LayoutRight, Kokkos::CudaUVMSpace, true)
-  KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<double>, int, size_t, Kokkos::LayoutLeft,  Kokkos::CudaUVMSpace, true)
-  KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<double>, int, size_t, Kokkos::LayoutRight, Kokkos::CudaUVMSpace, true)
-  KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<float>,  int, size_t, Kokkos::LayoutLeft,  Kokkos::CudaUVMSpace, true)
-  KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<float>,  int, size_t, Kokkos::LayoutRight, Kokkos::CudaUVMSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(double, int64_t, size_t, Kokkos::LayoutLeft,  Kokkos::CudaSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(double, int64_t, size_t, Kokkos::LayoutRight, Kokkos::CudaSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(float,  int64_t, size_t, Kokkos::LayoutLeft,  Kokkos::CudaSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(float,  int64_t, size_t, Kokkos::LayoutRight, Kokkos::CudaSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<double>, int64_t, size_t, Kokkos::LayoutLeft,  Kokkos::CudaSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<double>, int64_t, size_t, Kokkos::LayoutRight, Kokkos::CudaSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<float>,  int64_t, size_t, Kokkos::LayoutLeft,  Kokkos::CudaSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<float>,  int64_t, size_t, Kokkos::LayoutRight, Kokkos::CudaSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(double, int64_t, size_t, Kokkos::LayoutLeft,  Kokkos::CudaUVMSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(double, int64_t, size_t, Kokkos::LayoutRight, Kokkos::CudaUVMSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(float,  int64_t, size_t, Kokkos::LayoutLeft,  Kokkos::CudaUVMSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(float,  int64_t, size_t, Kokkos::LayoutRight, Kokkos::CudaUVMSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<double>, int64_t, size_t, Kokkos::LayoutLeft,  Kokkos::CudaUVMSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<double>, int64_t, size_t, Kokkos::LayoutRight, Kokkos::CudaUVMSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<float>,  int64_t, size_t, Kokkos::LayoutLeft,  Kokkos::CudaUVMSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<float>,  int64_t, size_t, Kokkos::LayoutRight, Kokkos::CudaUVMSpace, true)
 #endif
 #endif
 

--- a/packages/kokkos-kernels/src/impl/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
+++ b/packages/kokkos-kernels/src/impl/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
@@ -55,7 +55,7 @@ namespace KokkosSparse {
 namespace Impl {
 
   template <class AMatrix, class XVector, class YVector>
-  void spmv_native(KokkosKernels::Experimental::Controls& controls,
+  void spmv_native(const KokkosKernels::Experimental::Controls& controls,
 		   const char mode[],
 		   typename YVector::non_const_value_type const & alpha,
 		   const AMatrix& A,
@@ -69,7 +69,7 @@ namespace Impl {
   }
 
   template <class AMatrix, class XVector, class YVector>
-  void spmv_cusparse(KokkosKernels::Experimental::Controls& controls,
+  void spmv_cusparse(const KokkosKernels::Experimental::Controls& controls,
 		     const char mode[],
 		     typename YVector::non_const_value_type const & alpha,
 		     const AMatrix& A,
@@ -79,6 +79,7 @@ namespace Impl {
     using offset_type = typename AMatrix::non_const_size_type;
     using entry_type  = typename AMatrix::non_const_ordinal_type;
     using value_type  = typename AMatrix::non_const_value_type;
+    std::cout << "Hello from spmv_cusparse!\n";
 
     /* initialize cusparse library */
     cusparseHandle_t cusparseHandle = controls.getCusparseHandle();
@@ -91,21 +92,37 @@ namespace Impl {
 
     /* Check that cusparse can handle the types of the input Kokkos::CrsMatrix */
     cusparseIndexType_t myCusparseOffsetType;
-    if(std::is_same<offset_type, int>::value)     {myCusparseOffsetType = CUSPARSE_INDEX_32I;}
-    if(std::is_same<offset_type, int64_t>::value) {myCusparseOffsetType = CUSPARSE_INDEX_64I;}
+    if(std::is_same<offset_type, int>::value)
+      myCusparseOffsetType = CUSPARSE_INDEX_32I;
+    else if(std::is_same<offset_type, int64_t>::value || std::is_same<offset_type, size_t>::value)
+      myCusparseOffsetType = CUSPARSE_INDEX_64I;
+    else 
+      throw std::logic_error("Offset type of CrsMatrix isn't supported by cuSPARSE, yet TPL layer says it is");
     cusparseIndexType_t myCusparseEntryType;
-    if(std::is_same<entry_type, int>::value)      {myCusparseEntryType = CUSPARSE_INDEX_32I;}
-    if(std::is_same<entry_type, int64_t>::value)  {myCusparseEntryType = CUSPARSE_INDEX_64I;}
+    if(std::is_same<entry_type, int>::value)
+      myCusparseEntryType = CUSPARSE_INDEX_32I;
+    else if(std::is_same<entry_type, int64_t>::value)
+      myCusparseEntryType = CUSPARSE_INDEX_64I;
+    else
+      throw std::logic_error("Ordinal (entry) type of CrsMatrix isn't supported by cuSPARSE, yet TPL layer says it is");
     cudaDataType myCudaDataType;
-    if(std::is_same<value_type, float>::value)    {myCudaDataType = CUDA_R_32F;}
-    if(std::is_same<value_type, double>::value)   {myCudaDataType = CUDA_R_64F;}
+    if(std::is_same<value_type, float>::value)
+      myCudaDataType = CUDA_R_32F;
+    else if(std::is_same<value_type, double>::value)
+      myCudaDataType = CUDA_R_64F;
+    else if(std::is_same<value_type, Kokkos::complex<float>>::value)
+      myCudaDataType = CUDA_C_32F;
+    else if(std::is_same<value_type, Kokkos::complex<double>>::value)
+      myCudaDataType = CUDA_C_64F;
+    else
+      throw std::logic_error("Scalar (data) type of CrsMatrix isn't supported by cuSPARSE, yet TPL layer says it is");
 
     /* create matrix */
     cusparseSpMatDescr_t A_cusparse;
     KOKKOS_CUSPARSE_SAFE_CALL(cusparseCreateCsr(&A_cusparse, A.numRows(), A.numCols(), A.nnz(),
-						const_cast<offset_type*>(A.graph.row_map.data()),
-						const_cast<entry_type*>(A.graph.entries.data()),
-						const_cast<value_type*>(A.values.data()),
+						(void*) A.graph.row_map.data(),
+						(void*) A.graph.entries.data(),
+						(void*) A.values.data(),
 						myCusparseOffsetType,
 						myCusparseEntryType,
 						CUSPARSE_INDEX_BASE_ZERO,
@@ -113,14 +130,20 @@ namespace Impl {
 
     /* create lhs and rhs */
     cusparseDnVecDescr_t vecX, vecY;
-    KOKKOS_CUSPARSE_SAFE_CALL(cusparseCreateDnVec(&vecX, x.extent_int(0), const_cast<value_type*>(x.data()), myCudaDataType));
-    KOKKOS_CUSPARSE_SAFE_CALL(cusparseCreateDnVec(&vecY, y.extent_int(0), const_cast<value_type*>(y.data()), myCudaDataType));
+    KOKKOS_CUSPARSE_SAFE_CALL(cusparseCreateDnVec(&vecX, x.extent_int(0), (void*) x.data(), myCudaDataType));
+    KOKKOS_CUSPARSE_SAFE_CALL(cusparseCreateDnVec(&vecY, y.extent_int(0), (void*) y.data(), myCudaDataType));
 
     size_t bufferSize     = 0;
     void*  dBuffer        = NULL;
     cusparseSpMVAlg_t alg = CUSPARSE_CSRMV_ALG1;
-    if(controls.getParameter("algorithm") == "default") {alg = CUSPARSE_CSRMV_ALG1;}
-    if(controls.getParameter("algorithm") == "merge")   {alg = CUSPARSE_CSRMV_ALG2;}
+    if(controls.isParameter("algorithm"))
+    {
+      const std::string algName = controls.getParameter("algorithm");
+      if(algName == "default")
+        alg = CUSPARSE_CSRMV_ALG1;
+      else if(algName == "merge")
+        alg = CUSPARSE_CSRMV_ALG2;
+    }
     KOKKOS_CUSPARSE_SAFE_CALL(cusparseSpMV_bufferSize(cusparseHandle, myCusparseOperation,
 						      &alpha, A_cusparse, vecX, &beta, vecY, myCudaDataType,
 						      alg, &bufferSize));
@@ -129,13 +152,14 @@ namespace Impl {
     /* perform SpMV */
     KOKKOS_CUSPARSE_SAFE_CALL(cusparseSpMV(cusparseHandle, myCusparseOperation,
 					   &alpha, A_cusparse, vecX, &beta, vecY, myCudaDataType,
-					   CUSPARSE_CSRMV_ALG1, dBuffer));
+					   alg, dBuffer));
 
     CUDA_SAFE_CALL(cudaFree(dBuffer));
     KOKKOS_CUSPARSE_SAFE_CALL(cusparseDestroyDnVec(vecX));
     KOKKOS_CUSPARSE_SAFE_CALL(cusparseDestroyDnVec(vecY));
     KOKKOS_CUSPARSE_SAFE_CALL(cusparseDestroySpMat(A_cusparse));
-#else
+
+#elif (9000 <= CUSPARSE_VERSION)
 
     /* create and set the matrix descriptor */
     cusparseMatDescr_t descrA = 0;
@@ -164,33 +188,51 @@ namespace Impl {
 						 reinterpret_cast<double const *>(x.data()),
 						 reinterpret_cast<double const *>(&beta),
 						 reinterpret_cast<double *>(y.data()) ));
+      } else  if (std::is_same<value_type,Kokkos::complex<float>>::value) {
+	KOKKOS_CUSPARSE_SAFE_CALL(cusparseCcsrmv(cusparseHandle, myCusparseOperation,
+						 A.numRows(), A.numCols(), A.nnz(),
+						 reinterpret_cast<cuComplex const*>(&alpha), descrA,
+						 reinterpret_cast<cuComplex const*>(A.values.data()),
+						 A.graph.row_map.data(), A.graph.entries.data(),
+						 reinterpret_cast<cuComplex const*>(x.data()),
+						 reinterpret_cast<cuComplex const*>(&beta),
+						 reinterpret_cast<cuComplex const*>(y.data())));
+      } else  if (std::is_same<value_type,Kokkos::complex<double>>::value) {
+	KOKKOS_CUSPARSE_SAFE_CALL(cusparseZcsrmv(cusparseHandle, myCusparseOperation,
+						 A.numRows(), A.numCols(), A.nnz(),
+						 reinterpret_cast<cuDoubleComplex const*>(&alpha), descrA,
+						 reinterpret_cast<cuDoubleComplex const*>(A.values.data()),
+						 A.graph.row_map.data(), A.graph.entries.data(),
+						 reinterpret_cast<cuDoubleComplex const*>(x.data()),
+						 reinterpret_cast<cuDoubleComplex const*>(&beta),
+						 reinterpret_cast<cuDoubleComplex const*>(y.data())));
       } else {
-	throw std::logic_error("Trying to call cusparse SpMV with a scalar type that is not float or double!");
+	throw std::logic_error("Trying to call cusparse SpMV with a scalar type not float/double, nor complex of either!");
       }
     } else {
-      throw std::logic_error("Trying to call cusparse SpMV with an offset type that is not int!");
+      throw std::logic_error("With cuSPARSE pre-10.0, offset type must be int. Something wrong with TPL avail logic.");
     }
 
     KOKKOS_CUSPARSE_SAFE_CALL(cusparseDestroyMatDescr(descrA));
 #endif // CUSPARSE_VERSION
   }
 
-#define KOKKOSSPARSE_SPMV_CUSPARSE(SCALAR, ORDINAL, OFFSET, LAYOUT, COMPILE_LIBRARY) \
+#define KOKKOSSPARSE_SPMV_CUSPARSE(SCALAR, ORDINAL, OFFSET, LAYOUT, SPACE, COMPILE_LIBRARY) \
   template<>								\
-  struct SPMV<SCALAR const,  ORDINAL const, Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>, Kokkos::MemoryTraits<Kokkos::Unmanaged>, OFFSET const, \
-	      SCALAR const*, LAYOUT,        Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>, Kokkos::MemoryTraits<Kokkos::Unmanaged|Kokkos::RandomAccess>, \
-	      SCALAR*,       LAYOUT,        Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>, Kokkos::MemoryTraits<Kokkos::Unmanaged>, \
-	      true, true> {						\
-    using device_type = Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>; \
+  struct SPMV<SCALAR const,  ORDINAL const, Kokkos::Device<Kokkos::Cuda, SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>, OFFSET const, \
+	      SCALAR const*, LAYOUT,        Kokkos::Device<Kokkos::Cuda, SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged|Kokkos::RandomAccess>, \
+	      SCALAR*,       LAYOUT,        Kokkos::Device<Kokkos::Cuda, SPACE>, Kokkos::MemoryTraits<Kokkos::Unmanaged>, \
+	      true, COMPILE_LIBRARY> {						\
+    using device_type = Kokkos::Device<Kokkos::Cuda, SPACE>; \
     using memory_trait_type = Kokkos::MemoryTraits<Kokkos::Unmanaged>;	\
     using AMatrix  = CrsMatrix<SCALAR const, ORDINAL const, device_type, memory_trait_type, OFFSET const>; \
-    using XVector  = Kokkos::View<SCALAR const*, LAYOUT,device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged|Kokkos::RandomAccess>>; \
+    using XVector  = Kokkos::View<SCALAR const*, LAYOUT, device_type, Kokkos::MemoryTraits<Kokkos::Unmanaged|Kokkos::RandomAccess>>; \
     using YVector  = Kokkos::View<SCALAR*, LAYOUT, device_type, memory_trait_type>; \
     using Controls = KokkosKernels::Experimental::Controls;		\
 									\
     using coefficient_type = typename YVector::non_const_value_type;	\
 									\
-    static void spmv (Controls& controls,				\
+    static void spmv (const Controls& controls,				\
                       const char mode[],				\
 		      const coefficient_type& alpha,			\
 		      const AMatrix& A,					\
@@ -209,33 +251,42 @@ namespace Impl {
 	Kokkos::Profiling::popRegion();					\
       }									\
     }									\
-  };
-
-  KOKKOSSPARSE_SPMV_CUSPARSE(double, int, int, Kokkos::LayoutLeft,  true)
-  // KOKKOSSPARSE_SPMV_CUSPARSE(double, int, int, Kokkos::LayoutLeft,  false)
-  KOKKOSSPARSE_SPMV_CUSPARSE(double, int, int, Kokkos::LayoutRight, true)
-  // KOKKOSSPARSE_SPMV_CUSPARSE(double, int, int, Kokkos::LayoutRight, false)
-  KOKKOSSPARSE_SPMV_CUSPARSE(float,  int, int, Kokkos::LayoutLeft,  true)
-  // KOKKOSSPARSE_SPMV_CUSPARSE(float,  int, int, Kokkos::LayoutLeft,  false)
-  KOKKOSSPARSE_SPMV_CUSPARSE(float,  int, int, Kokkos::LayoutRight, true)
-  // KOKKOSSPARSE_SPMV_CUSPARSE(float,  int, int, Kokkos::LayoutRight, false)
-#if defined(CUSPARSE_VERSION) && (10300 <= CUSPARSE_VERSION)
-  KOKKOSSPARSE_SPMV_CUSPARSE(double, int64_t, int, Kokkos::LayoutLeft,  true)
-  // KOKKOSSPARSE_SPMV_CUSPARSE(double, int64_t, int, Kokkos::LayoutLeft,  false)
-  KOKKOSSPARSE_SPMV_CUSPARSE(double, int64_t, int, Kokkos::LayoutRight, true)
-  // KOKKOSSPARSE_SPMV_CUSPARSE(double, int64_t, int, Kokkos::LayoutRight, false)
-  KOKKOSSPARSE_SPMV_CUSPARSE(float,  int64_t, int, Kokkos::LayoutLeft,  true)
-  // KOKKOSSPARSE_SPMV_CUSPARSE(float,  int64_t, int, Kokkos::LayoutLeft,  false)
-  KOKKOSSPARSE_SPMV_CUSPARSE(float,  int64_t, int, Kokkos::LayoutRight, true)
-  // KOKKOSSPARSE_SPMV_CUSPARSE(float,  int64_t, int, Kokkos::LayoutRight, false)
-  KOKKOSSPARSE_SPMV_CUSPARSE(double, int64_t, int64_t, Kokkos::LayoutLeft,  true)
-  // KOKKOSSPARSE_SPMV_CUSPARSE(double, int64_t, int64_t, Kokkos::LayoutLeft,  false)
-  KOKKOSSPARSE_SPMV_CUSPARSE(double, int64_t, int64_t, Kokkos::LayoutRight, true)
-  // KOKKOSSPARSE_SPMV_CUSPARSE(double, int64_t, int64_t, Kokkos::LayoutRight, false)
-  KOKKOSSPARSE_SPMV_CUSPARSE(float,  int64_t, int64_t, Kokkos::LayoutLeft,  true)
-  // KOKKOSSPARSE_SPMV_CUSPARSE(float,  int64_t, int64_t, Kokkos::LayoutLeft,  false)
-  KOKKOSSPARSE_SPMV_CUSPARSE(float,  int64_t, int64_t, Kokkos::LayoutRight, true)
-  // KOKKOSSPARSE_SPMV_CUSPARSE(float,  int64_t, int64_t, Kokkos::LayoutRight, false)
+  }; 
+#if (9000 <= CUSPARSE_VERSION)
+  KOKKOSSPARSE_SPMV_CUSPARSE(double, int, int, Kokkos::LayoutLeft,  Kokkos::CudaSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(double, int, int, Kokkos::LayoutRight, Kokkos::CudaSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(float,  int, int, Kokkos::LayoutLeft,  Kokkos::CudaSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(float,  int, int, Kokkos::LayoutRight, Kokkos::CudaSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<double>, int, int, Kokkos::LayoutLeft,  Kokkos::CudaSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<double>, int, int, Kokkos::LayoutRight, Kokkos::CudaSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<float>,  int, int, Kokkos::LayoutLeft,  Kokkos::CudaSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<float>,  int, int, Kokkos::LayoutRight, Kokkos::CudaSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(double, int, int, Kokkos::LayoutLeft,  Kokkos::CudaUVMSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(double, int, int, Kokkos::LayoutRight, Kokkos::CudaUVMSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(float,  int, int, Kokkos::LayoutLeft,  Kokkos::CudaUVMSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(float,  int, int, Kokkos::LayoutRight, Kokkos::CudaUVMSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<double>, int, int, Kokkos::LayoutLeft,  Kokkos::CudaUVMSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<double>, int, int, Kokkos::LayoutRight, Kokkos::CudaUVMSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<float>,  int, int, Kokkos::LayoutLeft,  Kokkos::CudaUVMSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<float>,  int, int, Kokkos::LayoutRight, Kokkos::CudaUVMSpace, true)
+#if (10300 <= CUSPARSE_VERSION)
+  KOKKOSSPARSE_SPMV_CUSPARSE(double, int, size_t, Kokkos::LayoutLeft,  Kokkos::CudaSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(double, int, size_t, Kokkos::LayoutRight, Kokkos::CudaSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(float,  int, size_t, Kokkos::LayoutLeft,  Kokkos::CudaSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(float,  int, size_t, Kokkos::LayoutRight, Kokkos::CudaSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<double>, int, size_t, Kokkos::LayoutLeft,  Kokkos::CudaSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<double>, int, size_t, Kokkos::LayoutRight, Kokkos::CudaSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<float>,  int, size_t, Kokkos::LayoutLeft,  Kokkos::CudaSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<float>,  int, size_t, Kokkos::LayoutRight, Kokkos::CudaSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(double, int, size_t, Kokkos::LayoutLeft,  Kokkos::CudaUVMSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(double, int, size_t, Kokkos::LayoutRight, Kokkos::CudaUVMSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(float,  int, size_t, Kokkos::LayoutLeft,  Kokkos::CudaUVMSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(float,  int, size_t, Kokkos::LayoutRight, Kokkos::CudaUVMSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<double>, int, size_t, Kokkos::LayoutLeft,  Kokkos::CudaUVMSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<double>, int, size_t, Kokkos::LayoutRight, Kokkos::CudaUVMSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<float>,  int, size_t, Kokkos::LayoutLeft,  Kokkos::CudaUVMSpace, true)
+  KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<float>,  int, size_t, Kokkos::LayoutRight, Kokkos::CudaUVMSpace, true)
+#endif
 #endif
 
 #undef KOKKOSSPARSE_SPMV_CUSPARSE

--- a/packages/kokkos-kernels/src/sparse/KokkosSparse_spmv.hpp
+++ b/packages/kokkos-kernels/src/sparse/KokkosSparse_spmv.hpp
@@ -138,20 +138,34 @@ spmv (KokkosKernels::Experimental::Controls controls,
   XVector_Internal x_i = x;
   YVector_Internal y_i = y;
 
-  return Impl::SPMV<
-              typename AMatrix_Internal::value_type,
-              typename AMatrix_Internal::ordinal_type,
-              typename AMatrix_Internal::device_type,
-              typename AMatrix_Internal::memory_traits,
-              typename AMatrix_Internal::size_type,
-              typename XVector_Internal::value_type*,
-              typename XVector_Internal::array_layout,
-              typename XVector_Internal::device_type,
-              typename XVector_Internal::memory_traits,
-              typename YVector_Internal::value_type*,
-              typename YVector_Internal::array_layout,
-              typename YVector_Internal::device_type,
-              typename YVector_Internal::memory_traits>::spmv (controls, mode, alpha, A_i, x_i, beta, y_i);
+  #define bmk_template_params \
+              typename AMatrix_Internal::value_type,\
+              typename AMatrix_Internal::ordinal_type,\
+              typename AMatrix_Internal::device_type,\
+              typename AMatrix_Internal::memory_traits,\
+              typename AMatrix_Internal::size_type,\
+              typename XVector_Internal::value_type*,\
+              typename XVector_Internal::array_layout,\
+              typename XVector_Internal::device_type,\
+              typename XVector_Internal::memory_traits,\
+              typename YVector_Internal::value_type*,\
+              typename YVector_Internal::array_layout,\
+              typename YVector_Internal::device_type,\
+              typename YVector_Internal::memory_traits
+
+  using spmv_type = Impl::SPMV<bmk_template_params>;
+
+  bool tplAvail = Impl::spmv_tpl_spec_avail<bmk_template_params>::value;
+  bool etiAvail = Impl::spmv_eti_spec_avail<bmk_template_params>::value;
+
+  std::string mangledName = typeid(spmv_type).name();
+  int status;
+  char* spmvName = abi::__cxa_demangle(mangledName.c_str(), NULL, NULL, &status);
+  std::cout << "Hello from SPMV> full type is " << spmvName << '\n';
+  free(spmvName);
+  std::cout << "               > TPL available? " << (tplAvail ? "YES" : "NO") << ". ETI available? " << (etiAvail ? "YES" : "NO") << '\n';
+
+  return spmv_type::spmv (controls, mode, alpha, A_i, x_i, beta, y_i);
 }
 
 

--- a/packages/kokkos-kernels/src/sparse/impl/KokkosSparse_spmv_spec.hpp
+++ b/packages/kokkos-kernels/src/sparse/impl/KokkosSparse_spmv_spec.hpp
@@ -47,6 +47,7 @@
 #include <KokkosKernels_config.h>
 #include <Kokkos_Core.hpp>
 #include <Kokkos_ArithTraits.hpp>
+#include <cxxabi.h>
 
 #include "KokkosSparse_CrsMatrix.hpp"
 #include "KokkosKernels_Controls.hpp"
@@ -440,4 +441,4 @@ struct SPMV_MV<AT, AO, AD, AM, AS,
 #include<generated_specializations_hpp/KokkosSparse_spmv_eti_spec_decl.hpp>
 #include<generated_specializations_hpp/KokkosSparse_spmv_mv_eti_spec_decl.hpp>
 
-#endif // KOKKOS_BLAS1_MV_IMPL_DOT_HPP_
+#endif // KOKKOSSPARSE_IMPL_SPMV_SPEC_HPP_

--- a/packages/muelu/src/Graph/Containers/MueLu_LWGraph_kokkos_decl.hpp
+++ b/packages/muelu/src/Graph/Containers/MueLu_LWGraph_kokkos_decl.hpp
@@ -87,7 +87,7 @@ namespace MueLu {
     using map_type            = Xpetra::Map<LocalOrdinal, GlobalOrdinal, node_type>;
     using local_graph_type    = Kokkos::StaticCrsGraph<LocalOrdinal,
                                                        Kokkos::LayoutLeft,
-                                                       device_type>;
+                                                       device_type, void, size_t>;
     using boundary_nodes_type = Kokkos::View<const bool*, memory_space>;
     using row_type            = Kokkos::View<const LocalOrdinal*, memory_space>;
 

--- a/packages/nox/test/tpetra/ME_Tpetra_1DFEM_def.hpp
+++ b/packages/nox/test/tpetra/ME_Tpetra_1DFEM_def.hpp
@@ -131,8 +131,7 @@ template<class Scalar, class LO, class GO, class Node>
 Teuchos::RCP<const Tpetra::CrsGraph<LO, GO, Node> >
 EvaluatorTpetra1DFEM<Scalar, LO, GO, Node>::createGraph()
 {
-  //typedef typename tpetra_graph::local_graph_type local_graph_type;
-  typedef typename tpetra_graph::execution_space::size_type size_type;
+  typedef typename tpetra_graph::local_graph_type::size_type size_type;
 
   // Compute graph offset array
   int numProcs = comm_->getSize();

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterDirichletResidual_BlockedTpetra_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterDirichletResidual_BlockedTpetra_impl.hpp
@@ -495,7 +495,7 @@ evaluateFields(typename TRAITS::EvalData workset)
   // on host and then deep_copy to device. The sub-blocks are
   // unmanaged since they are allocated and ref counted separately on
   // host.
-  using LocalMatrixType = KokkosSparse::CrsMatrix<double,LO,PHX::Device,Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  using LocalMatrixType = KokkosSparse::CrsMatrix<double,LO,PHX::Device,Kokkos::MemoryTraits<Kokkos::Unmanaged>, size_t>;
   typename Kokkos::View<LocalMatrixType**,PHX::Device>::HostMirror
     hostJacTpetraBlocks("panzer::ScatterResidual_BlockTpetra<Jacobian>::hostJacTpetraBlocks", numFieldBlocks,numFieldBlocks);
 

--- a/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterResidual_BlockedTpetra_impl.hpp
+++ b/packages/panzer/disc-fe/src/evaluators/Panzer_ScatterResidual_BlockedTpetra_impl.hpp
@@ -379,7 +379,7 @@ evaluateFields(typename TRAITS::EvalData workset)
   // on host and then deep_copy to device. The sub-blocks are
   // unmanaged since they are allocated and ref counted separately on
   // host.
-  using LocalMatrixType = KokkosSparse::CrsMatrix<double,LO,PHX::Device,Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  using LocalMatrixType = KokkosSparse::CrsMatrix<double,LO,PHX::Device,Kokkos::MemoryTraits<Kokkos::Unmanaged>, size_t>;
   typename Kokkos::View<LocalMatrixType**,PHX::Device>::HostMirror 
     hostJacTpetraBlocks("panzer::ScatterResidual_BlockTpetra<Jacobian>::hostJacTpetraBlocks", numFieldBlocks,numFieldBlocks);
 

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_decl.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_decl.hpp
@@ -49,6 +49,7 @@
 #include "Tpetra_CrsMatrix.hpp"
 #include "Tpetra_Vector.hpp"
 #include "TpetraExt_MMHelpers.hpp"
+#include "KokkosKernels_Handle.hpp"
 
 
 /*! \file TpetraExt_MatrixMatrix_decl.hpp
@@ -556,7 +557,7 @@ struct AddKernels
   typedef Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node> map_type;
   typedef typename Node::device_type device_type;
   typedef typename device_type::execution_space execution_space;
-  typedef typename execution_space::memory_space memory_space;
+  typedef typename device_type::memory_space memory_space;
   typedef typename crs_matrix_type::impl_scalar_type impl_scalar_type;
   typedef typename crs_matrix_type::local_matrix_type KCRS;
   typedef typename KCRS::values_type::non_const_type values_array;
@@ -566,6 +567,8 @@ struct AddKernels
   typedef typename map_type::local_map_type local_map_type;
   typedef typename Kokkos::View<GlobalOrdinal*, device_type> global_col_inds_array;
   typedef Kokkos::RangePolicy<execution_space> range_type;
+  typedef KokkosKernels::Experimental::KokkosKernelsHandle<size_t, LocalOrdinal, impl_scalar_type,
+              execution_space, memory_space, memory_space> KKH;
 
   /// \brief Given two matrices in CRS format, return their sum
   /// \pre A and B must both have column indices sorted within each row

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
@@ -3158,12 +3158,11 @@ addSorted(
   typename MMdetails::AddKernels<SC, LO, GO, NO>::col_inds_array& Ccolinds)
 {
   using Teuchos::TimeMonitor;
+  using AddKern = MMdetails::AddKernels<SC, LO, GO, NO>;
   TEUCHOS_TEST_FOR_EXCEPTION(Arowptrs.extent(0) != Browptrs.extent(0), std::runtime_error, "Can't add matrices with different numbers of rows.");
   auto nrows = Arowptrs.extent(0) - 1;
   Crowptrs = row_ptrs_array(Kokkos::ViewAllocateWithoutInitializing("C row ptrs"), nrows + 1);
-  typedef KokkosKernels::Experimental::KokkosKernelsHandle<typename col_inds_array::size_type, LO, impl_scalar_type,
-              execution_space, memory_space, memory_space> KKH;
-  KKH handle;
+  typename AddKern::KKH handle;
   handle.create_spadd_handle(true);
   auto addHandle = handle.get_spadd_handle();
 #ifdef HAVE_TPETRA_MMM_TIMINGS
@@ -3205,13 +3204,12 @@ addUnsorted(
   typename MMdetails::AddKernels<SC, LO, GO, NO>::col_inds_array& Ccolinds)
 {
   using Teuchos::TimeMonitor;
+  using AddKern = MMdetails::AddKernels<SC, LO, GO, NO>;
   TEUCHOS_TEST_FOR_EXCEPTION(Arowptrs.extent(0) != Browptrs.extent(0), std::runtime_error, "Can't add matrices with different numbers of rows.");
   auto nrows = Arowptrs.extent(0) - 1;
   Crowptrs = row_ptrs_array(Kokkos::ViewAllocateWithoutInitializing("C row ptrs"), nrows + 1);
   typedef MMdetails::AddKernels<SC, LO, GO, NO> AddKern;
-  typedef KokkosKernels::Experimental::KokkosKernelsHandle<typename col_inds_array::size_type, LO, AddKern::impl_scalar_type,
-              AddKern::execution_space, AddKern::memory_space, AddKern::memory_space> KKH;
-  KKH handle;
+  typename AddKern::KKH handle;
   handle.create_spadd_handle(false);
   auto addHandle = handle.get_spadd_handle();
 #ifdef HAVE_TPETRA_MMM_TIMINGS
@@ -3274,6 +3272,10 @@ convertToGlobalAndAdd(
   typename MMdetails::AddKernels<SC, LO, GO, NO>::global_col_inds_array& Ccolinds)
 {
   using Teuchos::TimeMonitor;
+  //Need to use a different KokkosKernelsHandle type than other versions,
+  //since the ordinals are now GO
+  using KKH = KokkosKernels::Experimental::KokkosKernelsHandle<size_t, GO, impl_scalar_type,
+              typename NO::execution_space, typename NO::memory_space, typename NO::memory_space>;
 
   const values_array Avals = A.values;
   const values_array Bvals = B.values;
@@ -3290,8 +3292,6 @@ convertToGlobalAndAdd(
   Kokkos::parallel_for("Tpetra_MatrixMatrix_convertColIndsA", range_type(0, Acolinds.extent(0)), convertA);
   ConvertLocalToGlobalFunctor<GO, col_inds_array, global_col_inds_array, local_map_type> convertB(Bcolinds, BcolindsConverted, BcolMap);
   Kokkos::parallel_for("Tpetra_MatrixMatrix_convertColIndsB", range_type(0, Bcolinds.extent(0)), convertB);
-  typedef KokkosKernels::Experimental::KokkosKernelsHandle<typename col_inds_array::size_type, GO, impl_scalar_type,
-              execution_space, memory_space, memory_space> KKH;
   KKH handle;
   handle.create_spadd_handle(false);
   auto addHandle = handle.get_spadd_handle();

--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_def.hpp
@@ -3274,7 +3274,7 @@ convertToGlobalAndAdd(
   using Teuchos::TimeMonitor;
   //Need to use a different KokkosKernelsHandle type than other versions,
   //since the ordinals are now GO
-  using KKH = KokkosKernels::Experimental::KokkosKernelsHandle<size_t, GO, impl_scalar_type,
+  using KKH_GO = KokkosKernels::Experimental::KokkosKernelsHandle<size_t, GO, impl_scalar_type,
               typename NO::execution_space, typename NO::memory_space, typename NO::memory_space>;
 
   const values_array Avals = A.values;
@@ -3292,7 +3292,7 @@ convertToGlobalAndAdd(
   Kokkos::parallel_for("Tpetra_MatrixMatrix_convertColIndsA", range_type(0, Acolinds.extent(0)), convertA);
   ConvertLocalToGlobalFunctor<GO, col_inds_array, global_col_inds_array, local_map_type> convertB(Bcolinds, BcolindsConverted, BcolMap);
   Kokkos::parallel_for("Tpetra_MatrixMatrix_convertColIndsB", range_type(0, Bcolinds.extent(0)), convertB);
-  KKH handle;
+  KKH_GO handle;
   handle.create_spadd_handle(false);
   auto addHandle = handle.get_spadd_handle();
 #ifdef HAVE_TPETRA_MMM_TIMINGS
@@ -3302,7 +3302,7 @@ convertToGlobalAndAdd(
   auto nrows = Arowptrs.extent(0) - 1;
   Crowptrs = row_ptrs_array(Kokkos::ViewAllocateWithoutInitializing("C row ptrs"), nrows + 1);
   KokkosSparse::Experimental::spadd_symbolic
-    <KKH, typename row_ptrs_array::const_type, typename global_col_inds_array::const_type, typename row_ptrs_array::const_type, typename global_col_inds_array::const_type, row_ptrs_array, global_col_inds_array>
+    <KKH_GO, typename row_ptrs_array::const_type, typename global_col_inds_array::const_type, typename row_ptrs_array::const_type, typename global_col_inds_array::const_type, row_ptrs_array, global_col_inds_array>
     (&handle, Arowptrs, AcolindsConverted, Browptrs, BcolindsConverted, Crowptrs);
   Cvals = values_array("C values", addHandle->get_max_result_nnz());
   Ccolinds = global_col_inds_array(Kokkos::ViewAllocateWithoutInitializing("C colinds"), addHandle->get_max_result_nnz());

--- a/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_decl.hpp
@@ -256,7 +256,9 @@ namespace Tpetra {
     //! The type of the part of the sparse graph on each MPI process.
     using local_graph_type = Kokkos::StaticCrsGraph<local_ordinal_type,
                                                     Kokkos::LayoutLeft,
-                                                    device_type>;
+                                                    device_type,
+                                                    void,
+                                                    size_t>;
 
     //! The Map specialization used by this class.
     using map_type = ::Tpetra::Map<LocalOrdinal, GlobalOrdinal, Node>;

--- a/packages/tpetra/core/src/Tpetra_Details_getGraphDiagOffsets_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_getGraphDiagOffsets_decl.hpp
@@ -85,7 +85,8 @@ public:
                          ::Kokkos::MemoryUnmanaged> diag_offsets_type;
   typedef ::Kokkos::StaticCrsGraph<LO,
                                    ::Kokkos::LayoutLeft,
-                                   device_type> local_graph_type;
+                                   device_type,
+                                   void, size_t> local_graph_type;
   typedef ::Tpetra::Details::LocalMap<LO, GO, device_type> local_map_type;
   typedef ::Kokkos::View<const typename local_graph_type::size_type*,
                          ::Kokkos::LayoutLeft,

--- a/packages/tpetra/core/src/Tpetra_Details_localDeepCopyRowMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_localDeepCopyRowMatrix_decl.hpp
@@ -57,7 +57,8 @@ KokkosSparse::CrsMatrix<
   typename Kokkos::ArithTraits<SC>::val_type,
     LO,
     typename NT::execution_space,
-    void>
+    void,
+    size_t>
 localDeepCopyLocallyIndexedRowMatrix
   (const RowMatrix<SC, LO, GO, NT>& A,
    const char label[]);

--- a/packages/tpetra/core/src/Tpetra_Details_localDeepCopyRowMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_localDeepCopyRowMatrix_def.hpp
@@ -61,7 +61,8 @@ KokkosSparse::CrsMatrix<
   typename Kokkos::ArithTraits<SC>::val_type,
     LO,
     typename NT::execution_space,
-    void>
+    void,
+    size_t>
 localDeepCopyLocallyIndexedRowMatrix
 (const RowMatrix<SC, LO, GO, NT>& A,
  const char label[])
@@ -89,7 +90,7 @@ localDeepCopyLocallyIndexedRowMatrix
   using Kokkos::WithoutInitializing;
   using IST = typename Kokkos::ArithTraits<SC>::val_type;
   using local_matrix_type = KokkosSparse::CrsMatrix<
-    IST, LO, typename NT::execution_space, void>;
+    IST, LO, typename NT::device_type, void, size_t>;
   using local_graph_type =
     typename local_matrix_type::staticcrsgraph_type;
   using inds_type = typename local_graph_type::entries_type;
@@ -153,7 +154,7 @@ localDeepCopyLocallyIndexedRowMatrix
 namespace Details { \
   template KokkosSparse::CrsMatrix< \
     Kokkos::ArithTraits<SC>::val_type, \
-    LO, NT::execution_space, void> \
+    LO, NT::execution_space, void, size_t> \
   localDeepCopyLocallyIndexedRowMatrix<SC, LO, GO, NT> \
     (const RowMatrix<SC, LO, GO, NT>& A, \
      const char label[]); \

--- a/packages/tpetra/core/src/Tpetra_Details_localRowOffsets_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_localRowOffsets_decl.hpp
@@ -58,7 +58,7 @@ struct LocalRowOffsetsResult {
 private:
   using local_graph_type =
     typename KokkosSparse::CrsMatrix<
-      double, int, typename NT::execution_space, void>::
+      double, int, typename NT::device_type, void, size_t>::
         staticcrsgraph_type;
 public:
   using offsets_type =

--- a/packages/tpetra/core/src/Tpetra_LocalCrsMatrixOperator_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_LocalCrsMatrixOperator_decl.hpp
@@ -79,7 +79,15 @@ namespace Tpetra {
                               void,
                               size_t>;
   private:
+    //The type of a matrix with offset=ordinal, but otherwise the same as local_matrix_type
+    using local_cusparse_matrix_type =
+      KokkosSparse::CrsMatrix<matrix_scalar_type,
+                              local_ordinal_type,
+                              device_type,
+                              void,
+                              local_ordinal_type>;
     using local_graph_type = typename local_matrix_type::StaticCrsGraphType;
+    using ordinal_view_type = typename local_graph_type::entries_type::non_const_type;
 
   public:
     LocalCrsMatrixOperator (const std::shared_ptr<local_matrix_type>& A);
@@ -110,6 +118,12 @@ namespace Tpetra {
 
   private:
     std::shared_ptr<local_matrix_type> A_;
+    //If the number of entries in A_ can be represented as ordinal,
+    //make a copy of the rowptrs as ordinal. This allows the use of cuSPARSE spmv.
+    //If cusparse is not enabled or there would be no benefit from using these,
+    //they are not allocated/initialized.
+    ordinal_view_type A_ordinal_rowptrs;
+    local_cusparse_matrix_type A_cusparse;
   };
 
 } // namespace Tpetra

--- a/packages/tpetra/core/src/Tpetra_LocalCrsMatrixOperator_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_LocalCrsMatrixOperator_decl.hpp
@@ -75,7 +75,9 @@ namespace Tpetra {
     using local_matrix_type =
       KokkosSparse::CrsMatrix<matrix_scalar_type,
                               local_ordinal_type,
-                              device_type>;
+                              device_type,
+                              void,
+                              size_t>;
   private:
     using local_graph_type = typename local_matrix_type::StaticCrsGraphType;
 

--- a/packages/tpetra/core/src/Tpetra_LocalCrsMatrixOperator_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_LocalCrsMatrixOperator_def.hpp
@@ -44,6 +44,7 @@
 #include "Tpetra_Details_Behavior.hpp"
 #include "KokkosSparse.hpp"
 #include "Teuchos_TestForException.hpp"
+#include "Teuchos_OrdinalTraits.hpp"
 
 namespace Tpetra {
 
@@ -56,6 +57,26 @@ LocalCrsMatrixOperator (const std::shared_ptr<local_matrix_type>& A)
   TEUCHOS_TEST_FOR_EXCEPTION_CLASS_FUNC
     (A_.get () == nullptr, std::invalid_argument,
      "Input matrix A is null.");
+#if defined(KOKKOS_ENABLE_CUDA) && defined(KOKKOSKERNELS_ENABLE_TPL_CUSPARSE)
+  //Only create A_ordinal_rowptrs if:
+  //  - KokkosKernels cuSPARSE support is enabled (otherwise, no benefit)
+  //  - The execution space is CUDA
+  //  - The local matrix offset and ordinal types are different (otherwise, no reason to enable)
+  //  - The number of entries can be represented by the ordinal type.
+  using kk_offset_t = typename std::remove_const<typename local_matrix_type::size_type>::type;
+  using kk_ordinal_t = typename std::remove_const<typename local_matrix_type::ordinal_type>::type;
+  using exec_space = typename Device::execution_space;
+  if(std::is_same<exec_space, Kokkos::Cuda>::value &&
+      !std::is_same<kk_offset_t, kk_ordinal_t>::value &&
+      A_->nnz() < static_cast<kk_offset_t>(Teuchos::OrdinalTraits<kk_ordinal_t>::max()))
+  {
+    A_ordinal_rowptrs = ordinal_view_type(Kokkos::ViewAllocateWithoutInitializing("A_ordinal_rowptrs"), A_->numRows() + 1);
+    //This is just like a deep copy, but it implicitly converts each element
+    KokkosKernels::Impl::copy_view<typename local_graph_type::row_map_type, ordinal_view_type, exec_space>
+      (A_ordinal_rowptrs.extent(0), A_->graph.row_map, A_ordinal_rowptrs);
+    A_cusparse = local_cusparse_matrix_type("A(cusparse)", A_->numRows(), A_->numCols(), A_->nnz(), A_->values, A_ordinal_rowptrs, A_->graph.entries);
+  }
+#endif
 }
 
 template<class MultiVectorScalar, class MatrixScalar, class Device>
@@ -97,17 +118,17 @@ apply (Kokkos::View<const mv_scalar_type**, array_layout,
   const auto op = transpose ?
     (conjugate ? KokkosSparse::ConjugateTranspose :
      KokkosSparse::Transpose) : KokkosSparse::NoTranspose;
-  std::cout << ">>> Tpetra calling SPMV.\n";
-  //For the purposes of debugging ETI, just loop over columns
-  //KokkosSparse::spmv (op, alpha, *A_, X, beta, Y);
-  for(size_t vec = 0; vec < X.extent(1); vec++)
+  //Currently KK has no cusparse wrapper for rank-2 (SpMM)
+  //TODO: whent that is supported, use A_cusparse for that case also
+  if(X.extent(1) == size_t(1) && A_ordinal_rowptrs.extent(0))
   {
-    KokkosKernels::Experimental::Controls controls;
-    KokkosSparse::spmv (controls, op,
-        alpha, *A_, Kokkos::subview(X, Kokkos::ALL(), vec),
-        beta, Kokkos::subview(Y, Kokkos::ALL(), vec));
+    KokkosSparse::spmv (op, alpha, A_cusparse, Kokkos::subview(X, Kokkos::ALL(), 0),
+                            beta, Kokkos::subview(Y, Kokkos::ALL(), 0));
   }
-  std::cout << "<<< Returned to Tpetra from SPMV.\n";
+  else
+  {
+    KokkosSparse::spmv (op, alpha, *A_, X, beta, Y);
+  }
 }
 
 /// \brief Same behavior as \c apply() above, except give KokkosKernels a hint to use
@@ -148,11 +169,7 @@ applyImbalancedRows (
   //TODO BMK: If/when KokkosKernels gets its own SPMV implementation for imbalanced rows,
   //call that here or select it using Controls.
   //Ideally it supports multivectors from the beginning.
-  //
-  //TODO BMK: When cuSPARSE and KokkosKernels get cuSPARSE SpMM (SpMV for multivectors)
-  //merge path support, call that here.
-  //Also remove the useMergePathMultiVector() environment variable/behavior.
-  if(Details::Behavior::useMergePathMultiVector() || X.extent(1) == 1)
+  if(Details::Behavior::useMergePathMultiVector() || X.extent(1) == size_t(1) && A_ordinal_rowptrs.extent(0))
   {
     KokkosKernels::Experimental::Controls controls;
     controls.setParameter("algorithm", "merge");
@@ -160,13 +177,13 @@ applyImbalancedRows (
     for(size_t vec = 0; vec < X.extent(1); vec++)
     {
       KokkosSparse::spmv (controls, op,
-          alpha, *A_, Kokkos::subview(X, Kokkos::ALL(), vec),
+          alpha, A_cusparse, Kokkos::subview(X, Kokkos::ALL(), vec),
           beta, Kokkos::subview(Y, Kokkos::ALL(), vec));
     }
   }
   else
   {
-    //Just run multivector version of spmv (no controls)
+    //Just run multivector version of spmv (no controls, and no cusparse support)
     KokkosSparse::spmv (op, alpha, *A_, X, beta, Y);
   }
 }

--- a/packages/tpetra/core/src/Tpetra_LocalCrsMatrixOperator_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_LocalCrsMatrixOperator_def.hpp
@@ -97,7 +97,17 @@ apply (Kokkos::View<const mv_scalar_type**, array_layout,
   const auto op = transpose ?
     (conjugate ? KokkosSparse::ConjugateTranspose :
      KokkosSparse::Transpose) : KokkosSparse::NoTranspose;
-  KokkosSparse::spmv (op, alpha, *A_, X, beta, Y);
+  std::cout << ">>> Tpetra calling SPMV.\n";
+  //For the purposes of debugging ETI, just loop over columns
+  //KokkosSparse::spmv (op, alpha, *A_, X, beta, Y);
+  for(size_t vec = 0; vec < X.extent(1); vec++)
+  {
+    KokkosKernels::Experimental::Controls controls;
+    KokkosSparse::spmv (controls, op,
+        alpha, *A_, Kokkos::subview(X, Kokkos::ALL(), vec),
+        beta, Kokkos::subview(Y, Kokkos::ALL(), vec));
+  }
+  std::cout << "<<< Returned to Tpetra from SPMV.\n";
 }
 
 /// \brief Same behavior as \c apply() above, except give KokkosKernels a hint to use

--- a/packages/tpetra/core/src/Tpetra_LocalCrsMatrixOperator_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_LocalCrsMatrixOperator_def.hpp
@@ -169,7 +169,7 @@ applyImbalancedRows (
   //TODO BMK: If/when KokkosKernels gets its own SPMV implementation for imbalanced rows,
   //call that here or select it using Controls.
   //Ideally it supports multivectors from the beginning.
-  if(Details::Behavior::useMergePathMultiVector() || X.extent(1) == size_t(1) && A_ordinal_rowptrs.extent(0))
+  if((Details::Behavior::useMergePathMultiVector() || X.extent(1) == size_t(1)) && A_ordinal_rowptrs.extent(0))
   {
     KokkosKernels::Experimental::Controls controls;
     controls.setParameter("algorithm", "merge");

--- a/packages/xpetra/src/CrsGraph/Xpetra_CrsGraph.hpp
+++ b/packages/xpetra/src/CrsGraph/Xpetra_CrsGraph.hpp
@@ -217,7 +217,7 @@ namespace Xpetra {
 #ifdef HAVE_XPETRA_TPETRA
     typedef typename node_type::execution_space execution_space;
     typedef typename node_type::device_type device_type;
-    typedef Kokkos::StaticCrsGraph<LocalOrdinal, Kokkos::LayoutLeft, device_type> local_graph_type;
+    typedef Kokkos::StaticCrsGraph<LocalOrdinal, Kokkos::LayoutLeft, device_type, void, size_t> local_graph_type;
 
     /// \brief Get the local graph.
     ///

--- a/packages/xpetra/src/CrsMatrix/Xpetra_CrsMatrix.hpp
+++ b/packages/xpetra/src/CrsMatrix/Xpetra_CrsMatrix.hpp
@@ -294,7 +294,9 @@ namespace Xpetra {
     // that is the local_graph_type in Tpetra::CrsGraph...
     typedef Kokkos::StaticCrsGraph<LocalOrdinal,
                                        Kokkos::LayoutLeft,
-                                       execution_space> local_graph_type;
+                                       execution_space,
+                                       void,
+                                       size_t> local_graph_type;
     /// \brief The specialization of Kokkos::CrsMatrix that represents
     ///   the part of the sparse matrix on each MPI process.
     ///  The same as for Tpetra


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/kokkos-kernels 
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Because of the way ``CrsMatrix::local_matrix_type::size_type`` was chosen in Tpetra, the size_type was ``unsigned int`` for node type Cuda. This meant that all sparse kernel calls from Tpetra were silently falling back to the non-ETI'd, native Kokkos implementation, and never using cuSPARSE or the precompiled ETI versions.

Also instantiating the cuSPARSE spmv wrapper for CudaUVMSpace, which is required for Tpetra to use it. For cuSPARSE 10+, with the generic API, added int64_t/size_t ordinal/offset versions in addition to the int/int. Added single and double complex support (see https://github.com/kokkos/kokkos-kernels/issues/726). Checking that the "Controls" parameter exists before trying to get its value. Fixed the constness of the Controls parameter to Impl::SPMV::spmv, which was causing the specializations to not match. Made ``getCublasHandle()`` and ``getCusparseHandle()`` const methods of Controls, and the handle members mutable. This is OK since those handles are just singletons, and it avoid deep copying an ``unordered_map<string, string>``, which seems like it could be a significant overhead.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
Needed by @vbrunini 
## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
Tested in CrsMatrix_UnitTest. Did a local build with Serial+Cuda, and all 4 main scalar types enabled. All Tpetra tests passed.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->
NOTE: Will need to port the changes back to KokkosKernels repository. My goal was to get merge path support working in Trilinos asap.