### PR TITLE
Amesos2: Handle x and b copying more efficiently.

### DIFF
--- a/packages/amesos2/src/Amesos2_Basker_def.hpp
+++ b/packages/amesos2/src/Amesos2_Basker_def.hpp
@@ -181,32 +181,34 @@ Basker<Matrix,Vector>::solve_impl(
     Teuchos::TimeMonitor redistTimer( this->timers_.vecRedistTime_ );
 #endif
 
+    const bool initialize_data = true;
+    const bool do_not_initialize_data = false;
     if ( single_proc_optimization() && nrhs == 1 ) {
       // no msp creation
       Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
-        host_solve_array_t>::do_get(true, B, bValues_, as<size_t>(ld_rhs));
+        host_solve_array_t>::do_get(initialize_data, B, bValues_, as<size_t>(ld_rhs));
 
       bDidAssignX = Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
-        host_solve_array_t>::do_get(false, X, xValues_, as<size_t>(ld_rhs));
+        host_solve_array_t>::do_get(do_not_initialize_data, X, xValues_, as<size_t>(ld_rhs));
     }
     else {
       if ( is_contiguous_ == true ) {
         Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
-          host_solve_array_t>::do_get(true, B, bValues_, as<size_t>(ld_rhs), ROOTED, this->rowIndexBase_);
+          host_solve_array_t>::do_get(initialize_data, B, bValues_, as<size_t>(ld_rhs), ROOTED, this->rowIndexBase_);
       }
       else {
         Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
-          host_solve_array_t>::do_get(true, B, bValues_, as<size_t>(ld_rhs), CONTIGUOUS_AND_ROOTED, this->rowIndexBase_);
+          host_solve_array_t>::do_get(initialize_data, B, bValues_, as<size_t>(ld_rhs), CONTIGUOUS_AND_ROOTED, this->rowIndexBase_);
       }
 
       // See Amesos2_Tacho_def.hpp for notes on why we 'get' x here.
       if ( is_contiguous_ == true ) {
         bDidAssignX = Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
-          host_solve_array_t>::do_get(false, X, xValues_, as<size_t>(ld_rhs), ROOTED, this->rowIndexBase_);
+          host_solve_array_t>::do_get(do_not_initialize_data, X, xValues_, as<size_t>(ld_rhs), ROOTED, this->rowIndexBase_);
       }
       else {
         bDidAssignX = Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
-          host_solve_array_t>::do_get(false, X, xValues_, as<size_t>(ld_rhs), CONTIGUOUS_AND_ROOTED, this->rowIndexBase_);
+          host_solve_array_t>::do_get(do_not_initialize_data, X, xValues_, as<size_t>(ld_rhs), CONTIGUOUS_AND_ROOTED, this->rowIndexBase_);
       }
     }
   }
@@ -231,7 +233,9 @@ Basker<Matrix,Vector>::solve_impl(
       std::runtime_error,
       "Could not alloc needed working memory for solve" );
 
-  if(!bDidAssignX) { // if bDidAssignX, then we solved straight to the adapter's X memory space
+  // if bDidAssignX, then we solved straight to the adapter's X memory space without
+  // requiring additional memory allocation, so the x data is already in place.
+  if(!bDidAssignX) {
 #ifdef HAVE_AMESOS2_TIMERS
     Teuchos::TimeMonitor redistTimer(this->timers_.vecRedistTime_);
 #endif

--- a/packages/amesos2/src/Amesos2_Cholmod_def.hpp
+++ b/packages/amesos2/src/Amesos2_Cholmod_def.hpp
@@ -236,15 +236,17 @@ Cholmod<Matrix,Vector>::solve_impl(const Teuchos::Ptr<MultiVecAdapter<Vector> > 
 
     // In general we may want to write directly to the x space without a copy.
     // So we 'get' x which may be a direct view assignment to the MV.
+    const bool initialize_data = true;
+    const bool do_not_initialize_data = false;
     if(use_triangular_solves_) { // to device
 #if defined(KOKKOSKERNELS_ENABLE_SUPERNODAL_SPTRSV) && defined(KOKKOSKERNELS_ENABLE_TPL_CHOLMOD)
       Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
-          device_solve_array_t>::do_get(true, B, device_bValues_,
+          device_solve_array_t>::do_get(initialize_data, B, device_bValues_,
               Teuchos::as<size_t>(ld_rhs),
               (is_contiguous_ == true) ? ROOTED : CONTIGUOUS_AND_ROOTED,
               this->rowIndexBase_);
         bDidAssignX = Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
-          device_solve_array_t>::do_get(false, X, device_xValues_,
+          device_solve_array_t>::do_get(do_not_initialize_data, X, device_xValues_,
               Teuchos::as<size_t>(ld_rhs),
               (is_contiguous_ == true) ? ROOTED : CONTIGUOUS_AND_ROOTED,
               this->rowIndexBase_);
@@ -252,12 +254,12 @@ Cholmod<Matrix,Vector>::solve_impl(const Teuchos::Ptr<MultiVecAdapter<Vector> > 
     }
     else { // to host
       Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
-          host_solve_array_t>::do_get(true, B, host_bValues_,
+          host_solve_array_t>::do_get(initialize_data, B, host_bValues_,
               Teuchos::as<size_t>(ld_rhs),
               (is_contiguous_ == true) ? ROOTED : CONTIGUOUS_AND_ROOTED,
               this->rowIndexBase_);
         bDidAssignX = Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
-          host_solve_array_t>::do_get(false, X, host_xValues_,
+          host_solve_array_t>::do_get(do_not_initialize_data, X, host_xValues_,
               Teuchos::as<size_t>(ld_rhs),
               (is_contiguous_ == true) ? ROOTED : CONTIGUOUS_AND_ROOTED,
               this->rowIndexBase_);
@@ -292,7 +294,10 @@ Cholmod<Matrix,Vector>::solve_impl(const Teuchos::Ptr<MultiVecAdapter<Vector> > 
   TEUCHOS_TEST_FOR_EXCEPTION(ierr == -2, std::runtime_error, "Ran out of memory" );
 
   /* Update X's global values */
-  if(!bDidAssignX) { // if bDidAssignX, then we solved straight to the adapter's X memory space
+
+  // if bDidAssignX, then we solved straight to the adapter's X memory space without
+  // requiring additional memory allocation, so the x data is already in place.
+  if(!bDidAssignX) {
 #ifdef HAVE_AMESOS2_TIMERS
     Teuchos::TimeMonitor redistTimer(this->timers_.vecRedistTime_);
 #endif

--- a/packages/amesos2/src/Amesos2_EpetraMultiVecAdapter_decl.hpp
+++ b/packages/amesos2/src/Amesos2_EpetraMultiVecAdapter_decl.hpp
@@ -185,7 +185,7 @@ namespace Amesos2 {
         EDistribution distribution) const;
 
     template<typename KV>
-    void get1dCopy_kokkos_view( KV & A,
+    bool get1dCopy_kokkos_view(bool bInitialize, KV & A,
                     size_t lda,
                     Teuchos::Ptr<
                       const Tpetra::Map<local_ordinal_t,
@@ -194,7 +194,9 @@ namespace Amesos2 {
                     EDistribution distribution) const {
       Kokkos::View<double**, Kokkos::LayoutLeft, Kokkos::HostSpace> host_new_data;
       get1dCopy_kokkos_view_host(host_new_data, lda, distribution_map, distribution);
-      deep_copy_or_assign_view(A, host_new_data);
+      bool bAssigned;
+      deep_copy_or_assign_view(bInitialize, A, host_new_data, bAssigned);
+      return false; // currently Epetra and prior get1dCopy_kokkos_view_host call cannot get direct assignment so always return false
     }
 
     void get1dCopy_kokkos_view_host(

--- a/packages/amesos2/src/Amesos2_KLU2_def.hpp
+++ b/packages/amesos2/src/Amesos2_KLU2_def.hpp
@@ -236,6 +236,8 @@ KLU2<Matrix,Vector>::solve_impl(
   const global_size_type ld_rhs = this->root_ ? X->getGlobalLength() : 0;
   const size_t nrhs = X->getGlobalNumVectors();
 
+  bool bDidAssignX;
+  bool bDidAssignB;
   {
 #ifdef HAVE_AMESOS2_TIMERS
     Teuchos::TimeMonitor mvConvTimer(this->timers_.vecConvTime_);
@@ -243,50 +245,52 @@ KLU2<Matrix,Vector>::solve_impl(
 #endif
     if ( single_proc_optimization() && nrhs == 1 ) {
       // no msp creation
-      Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
-        host_solve_array_t>::do_get(B, bValues_, as<size_t>(ld_rhs));
+      bDidAssignB = Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
+        host_solve_array_t>::do_get(true, B, bValues_, as<size_t>(ld_rhs));
 
-      Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
-        host_solve_array_t>::do_get(X, xValues_, as<size_t>(ld_rhs));
+      bDidAssignX = Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
+        host_solve_array_t>::do_get(false, X, xValues_, as<size_t>(ld_rhs));
     }
     else {
       if ( is_contiguous_ == true ) {
-        Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
-          host_solve_array_t>::do_get(B, bValues_,
+        bDidAssignB = Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
+          host_solve_array_t>::do_get(true, B, bValues_,
               as<size_t>(ld_rhs),
               ROOTED, this->rowIndexBase_);
       }
       else {
-        Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
-          host_solve_array_t>::do_get(B, bValues_,
+        bDidAssignB = Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
+          host_solve_array_t>::do_get(true, B, bValues_,
               as<size_t>(ld_rhs),
               CONTIGUOUS_AND_ROOTED, this->rowIndexBase_);
       }
 
       // see Amesos2_Tacho_def.hpp for an explanation of why we 'get' X
       if ( is_contiguous_ == true ) {
-        Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
-          host_solve_array_t>::do_get(X, xValues_,
+        bDidAssignX = Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
+          host_solve_array_t>::do_get(false, X, xValues_,
               as<size_t>(ld_rhs),
               ROOTED, this->rowIndexBase_);
       }
       else {
-        Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
-          host_solve_array_t>::do_get(X, xValues_,
+        bDidAssignX = Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
+          host_solve_array_t>::do_get(false, X, xValues_,
               as<size_t>(ld_rhs),
               CONTIGUOUS_AND_ROOTED, this->rowIndexBase_);
       }
 
-      // TODO: klu_tsolve is going to put the solution x into the input b.
+      // klu_tsolve is going to put the solution x into the input b.
       // Copy b to x then solve in x.
       // We do not want to solve in b, then copy to x, because if b was assigned
       // then the solve will change b permanently and mess up the next test cycle.
-      // However if b was actually a copy (not assigned) then we can avoid this
-      // deep_copy and just assign xValues_ = bValues_.
-      // This comes up in a few places, see #7158, so planning to fix them all
-      // at the same time with some system to track what get_1d_copy_helper_kokkos_view
-      // actually did.
-      Kokkos::deep_copy(xValues_, bValues_);
+      // However if b was actually a copy (bDidAssignB = false) then we can avoid
+      // this deep_copy and just assign xValues_ = bValues_.
+      if(bDidAssignB) {
+        Kokkos::deep_copy(xValues_, bValues_); // need deep_copy or aolve will change adapter's b memory which should never happen
+      }
+      else {
+        xValues_ = bValues_; // safe because bValues_ does not point straight to adapter's memory space
+      }
     }
   }
 
@@ -380,7 +384,7 @@ KLU2<Matrix,Vector>::solve_impl(
     } // end root_
   } //end else
 
-  {
+  if(!bDidAssignX) { // if bDidAssignX, then we solved straight to the adapter's X memory space
 #ifdef HAVE_AMESOS2_TIMERS
     Teuchos::TimeMonitor redistTimer( this->timers_.vecRedistTime_ );
 #endif

--- a/packages/amesos2/src/Amesos2_KokkosMultiVecAdapter_decl.hpp
+++ b/packages/amesos2/src/Amesos2_KokkosMultiVecAdapter_decl.hpp
@@ -217,15 +217,17 @@ namespace Amesos2 {
                 EDistribution distribution) const;
 
     template<typename KV>
-    void
-    get1dCopy_kokkos_view (KV& kokkos_view,
+    bool
+    get1dCopy_kokkos_view (bool bInitialize, KV& kokkos_view,
                 size_t lda,
                 Teuchos::Ptr<
                   const Tpetra::Map<local_ordinal_t,
                   global_ordinal_t,
                   node_t> > distribution_map,
                 EDistribution distribution) const {
-      deep_copy_or_assign_view(kokkos_view, *mv_);
+      bool bAssigned; // deep_copy_or_assign_view sets true if assigned (no deep copy)
+      deep_copy_or_assign_view(bInitialize, kokkos_view, *mv_, bAssigned);
+      return bAssigned;
     }
 
     /**

--- a/packages/amesos2/src/Amesos2_Kokkos_View_Copy_Assign.hpp
+++ b/packages/amesos2/src/Amesos2_Kokkos_View_Copy_Assign.hpp
@@ -74,6 +74,12 @@ update_dst_size(dst_t & dst, const src_t & src) {  // templated just for 2d
 }
 
 // now handle type mismatch for same memory space - here types are same
+// bInitialize:
+//   If bInitialize is false, then the data needs to be allocated but not initialized.
+//   If we are about to solve into x we don't care about setting the original values.
+//   In this case, we are assigning the view directly so bInitialize does not matter.
+// bAssigned:
+//   bAssigned tells the caller if the data was simply assigned, so it is set true in this case.
 template<class dst_t, class src_t> // version for same memory spaces
 typename std::enable_if<std::is_same<typename dst_t::value_type,
   typename src_t::value_type>::value>::type
@@ -83,6 +89,13 @@ implement_copy_or_assign_same_mem_check_types(bool bInitialize, dst_t & dst, con
 }
 
 // now handle type mismatch for same memory space - now types are different
+// bInitialize:
+//   If bInitialize is false, then the data needs to be allocated but not initialized.
+//   If we are about to solve into x we don't care about setting the original values.
+//   In this case, we are allocating so we first make the memory via update_dst_size.
+//   Then we only copy from the source if bInitialize is true.
+// bAssigned:
+//   bAssigned tells the caller if the data was simply assigned, so it is set false in this case.
 template<class dst_t, class src_t> // version for same memory spaces
 typename std::enable_if<!std::is_same<typename dst_t::value_type,
   typename src_t::value_type>::value>::type

--- a/packages/amesos2/src/Amesos2_Kokkos_View_Copy_Assign.hpp
+++ b/packages/amesos2/src/Amesos2_Kokkos_View_Copy_Assign.hpp
@@ -77,17 +77,21 @@ update_dst_size(dst_t & dst, const src_t & src) {  // templated just for 2d
 template<class dst_t, class src_t> // version for same memory spaces
 typename std::enable_if<std::is_same<typename dst_t::value_type,
   typename src_t::value_type>::value>::type
-implement_copy_or_assign_same_mem_check_types(dst_t & dst, const src_t & src) {
+implement_copy_or_assign_same_mem_check_types(bool bInitialize, dst_t & dst, const src_t & src, bool & bAssigned) {
   dst = src; // just assign the ptr - no need to copy
+  bAssigned = true;
 }
 
 // now handle type mismatch for same memory space - now types are different
 template<class dst_t, class src_t> // version for same memory spaces
 typename std::enable_if<!std::is_same<typename dst_t::value_type,
   typename src_t::value_type>::value>::type
-implement_copy_or_assign_same_mem_check_types(dst_t & dst, const src_t & src) {
+implement_copy_or_assign_same_mem_check_types(bool bInitialize, dst_t & dst, const src_t & src, bool & bAssigned) {
   update_dst_size(dst, src); // allocates if necessary
-  Kokkos::deep_copy(dst, src); // full copy
+  if(bInitialize) { // bInitialize false would be for solver getting x, where the actual values are not needed
+    Kokkos::deep_copy(dst, src); // full copy
+  }
+  bAssigned = false;
 }
 
 // implement_copy_or_assign has 2 versions for matched memory and
@@ -97,16 +101,29 @@ implement_copy_or_assign_same_mem_check_types(dst_t & dst, const src_t & src) {
 template<class dst_t, class src_t> // version for same memory spaces
 typename std::enable_if<std::is_same<typename dst_t::memory_space,
   typename src_t::memory_space>::value>::type
+deep_copy_or_assign_view(bool bInitialize, dst_t & dst, const src_t & src, bool & bAssigned) {
+  implement_copy_or_assign_same_mem_check_types(bInitialize, dst, src, bAssigned);
+}
+
+// for convenience this version does not take bInitialize input and bAssigned ouput
+// then it's assumed you want bInitialize true and don't need to know bAssigned
+template<class dst_t, class src_t> // version for same memory spaces
+typename std::enable_if<std::is_same<typename dst_t::memory_space,
+  typename src_t::memory_space>::value>::type
 deep_copy_or_assign_view(dst_t & dst, const src_t & src) {
-  implement_copy_or_assign_same_mem_check_types(dst, src);
+  bool bAssigned; // output not needed
+  implement_copy_or_assign_same_mem_check_types(true, dst, src, bAssigned);
 }
 
 template<class dst_t, class src_t> // version for different memory spaces
 typename std::enable_if<std::is_same<typename dst_t::value_type,
   typename src_t::value_type>::value>::type
-implement_copy_or_assign_diff_mem_check_types(dst_t & dst, const src_t & src) {
+implement_copy_or_assign_diff_mem_check_types(bool bInitialize, dst_t & dst, const src_t & src, bool & bAssigned) {
   update_dst_size(dst, src); // allocates if necessary
-  Kokkos::deep_copy(dst, src); // full copy
+  if(bInitialize) { // bInitialize false would be for solver getting x, where the actual values are not needed
+    Kokkos::deep_copy(dst, src); // full copy
+  }
+  bAssigned = false;
 }
 
 template<class dst_t, class src_t> // version for different memory spaces
@@ -130,18 +147,31 @@ implement_copy_or_assign_diff_mem_diff_types_check_dim(dst_t & dst, const src_t 
 template<class dst_t, class src_t> // version for different memory spaces
 typename std::enable_if<!std::is_same<typename dst_t::value_type,
   typename src_t::value_type>::value>::type
-implement_copy_or_assign_diff_mem_check_types(dst_t & dst, const src_t & src) {
+implement_copy_or_assign_diff_mem_check_types(bool bInitialize, dst_t & dst, const src_t & src, bool & bAssigned) {
   update_dst_size(dst, src); // allocates if necessary
-  // since mem space and types are different, we specify the order of operations
-  // Kokkos::deep_copy won't do both since it would be a hidden deep_copy
-  implement_copy_or_assign_diff_mem_diff_types_check_dim(dst, src);
+  bAssigned = false;
+  if(bInitialize) { // bInitialize false would be for solver getting x, where the actual values are not needed
+    // since mem space and types are different, we specify the order of operations
+    // Kokkos::deep_copy won't do both since it would be a hidden deep_copy
+    implement_copy_or_assign_diff_mem_diff_types_check_dim(dst, src);
+  }
 }
 
 template<class dst_t, class src_t> // version for different memory spaces
 typename std::enable_if<!std::is_same<typename dst_t::memory_space,
   typename src_t::memory_space>::value>::type
+deep_copy_or_assign_view(bool bInitialize, dst_t & dst, const src_t & src, bool & bAssigned) {
+  implement_copy_or_assign_diff_mem_check_types(bInitialize, dst, src, bAssigned); // full copy
+}
+
+// for convenience this version does not take bInitialize input and bAssigned ouput
+// then it's assumed you want bInitialize true and don't need to know bAssigned
+template<class dst_t, class src_t> // version for different memory spaces
+typename std::enable_if<!std::is_same<typename dst_t::memory_space,
+  typename src_t::memory_space>::value>::type
 deep_copy_or_assign_view(dst_t & dst, const src_t & src) {
-  implement_copy_or_assign_diff_mem_check_types(dst, src); // full copy
+  bool bAssigned; // output not needed
+  implement_copy_or_assign_diff_mem_check_types(true, dst, src, bAssigned); // full copy
 }
 
 } // end namespace Amesos2

--- a/packages/amesos2/src/Amesos2_MultiVecAdapter_decl.hpp
+++ b/packages/amesos2/src/Amesos2_MultiVecAdapter_decl.hpp
@@ -284,39 +284,31 @@ namespace Amesos2 {
               const size_t ldx);
     };
 
-    // These methods take an input bInitialize and return a bool for bAssigned.
-    // The purpose of these two flags is to properly handle differences in logic
-    // for x and b when solving and avoid unecessary copies.
-    // Solvers should set bInitialize false for x and set bInitialize true for b.
-    // The view kokkos_vals can be uninitialized (0 size) when passed in.
-    // If the adapter can directly assign x or b to it's own memory spacee it will,
-    // and then no deep_copy will occur. Then bInitialize won't matter.
-    // However if the memory space or types don't match, the adapter will allocate
-    // the size of kokkos_vals and then, if bInitialize is true, copy it's values
-    // with deep_copy. This copy is only necessary for b, not x.
-    // If the adapter could directly assign the memory space the method will
-    // return true. Then the solver can skip doing a 'put X' because the solve
-    // happens directly in the adapter's memory space. Also Klu2 and SuperLU
-    // have special considerations because under some circumanstances they
-    // may solve b directly into it's own space. In that case, it's necessary
-    // to deep_copy b first or the adapter's b values will be permanently
-    // changed and the next solve cycle will fail. However if the method returns
-    // false then the adapter already had to deep_copy b so those solvers don't
-    // need to take any extra steps to protect the b memory space.
-    // Note, searching for bDidAssignX and bDidAssignB will find all places
-    // where solvers are reading the assignment state and acting on it.
-    // Searching get_1d_copy_helper_kokkos_view will find all the places where
-    // solvers are passing true/false for x and b collection.
-    // Searching bInitialize will find various places where the adapters are
-    // internally determining whether the deep_copy actually occurred. Note that
-    // in some places the adapter may create a new memory space temporarily,
-    // for example to redistribute data. Then it may call deep_copy_or_assign_view
-    // where deep_copy_or_assign_view can do simple assignment. Even though
-    // deep_copy_or_assign_view is assigning the view, the method must still
-    // return false because the temporary redistributed MV means the overall
-    // effect of the method was to create a new memory space. The method only
-    // returns true if the method directly assigns to the adapter's permanent
-    // stored internal data.
+    /*
+      do_get
+
+      Return type (bool):
+        true:  The input kokkos_vals view is now pointing directly to the adapter's data (same memory and type).
+               If this is x for an Ax=b solve, you don't need 'do_put x' after the solve since you modified the adapter directly.
+        false: The input kokkos_vals view is now resized to match the adapter's size.
+               kokkos_vals will only have the adapter values deep_copied if bInitialize is true (see below).
+               If this is x for an Ax=b solve, you must call 'do_put x' after the solve to deep copy back to the adapter.
+
+      Inputs
+        bInitialize (bool): tells the adapter whether kokkos_vals needs to have the values of the adapter.
+          true:  We require kokkos_vals to have the same size and values of the adapter.
+                 For b in Ax=b solves, set bInitialize true because you need the size and values of the adapter.
+          false: We require kokkos_vals to have the same size as the adapter but we don't need the values.
+                 For x in Ax=b solves, set bInitialize false because you just need the size, not the values.
+
+          Note: When this method returns true, meaning direct assignment of the view occurred,
+                bInitialize is not used because you already have the values whether you need them or not.
+
+        kokkos_vals (View<scalar_t**>): The view which will contain the x or b data.
+          Do not allocate the size of kokkos_vals, let the do_get method do it for you.
+          This is because kokkos_vals may be set to point directly to the adapter memory
+          and then any pre-allocation of size will have been wasted.
+    */
     template <class MV, typename KV>
     struct get_1d_copy_helper_kokkos_view {
       static bool

--- a/packages/amesos2/src/Amesos2_MultiVecAdapter_def.hpp
+++ b/packages/amesos2/src/Amesos2_MultiVecAdapter_def.hpp
@@ -204,19 +204,21 @@ namespace Amesos2{
     }
 
     template <class MV, typename KV>
-    void get_1d_copy_helper_kokkos_view<MV,KV>::
-    do_get (const Teuchos::Ptr<const MV>& mv,
+    bool get_1d_copy_helper_kokkos_view<MV,KV>::
+    do_get (bool bInitialize,
+            const Teuchos::Ptr<const MV>& mv,
             KV& kokkos_vals,
             const size_t ldx,
             Teuchos::Ptr<const Tpetra::Map<typename MV::local_ordinal_t, typename MV::global_ordinal_t, typename MV::node_t> > distribution_map,
             EDistribution distribution)
     {
-      mv->get1dCopy_kokkos_view(kokkos_vals, ldx, distribution_map, distribution);
+      return mv->get1dCopy_kokkos_view(bInitialize, kokkos_vals, ldx, distribution_map, distribution);
     }
 
     template <class MV, typename KV>
-    void get_1d_copy_helper_kokkos_view<MV,KV>::
-    do_get (const Teuchos::Ptr<const MV>& mv,
+    bool get_1d_copy_helper_kokkos_view<MV,KV>::
+    do_get (bool bInitialize,
+            const Teuchos::Ptr<const MV>& mv,
             KV& kokkos_vals,
             const size_t ldx,
             EDistribution distribution,
@@ -238,13 +240,15 @@ namespace Amesos2{
                                                                     indexBase,
                                                                     mv->getMap());
 
-      do_get (mv, kokkos_vals, ldx, Teuchos::ptrInArg (*map), distribution);
+      return do_get (bInitialize, mv, kokkos_vals, ldx, Teuchos::ptrInArg (*map), distribution);
     }
 
     template <class MV, typename KV>
-    void get_1d_copy_helper_kokkos_view<MV,KV>::do_get(const Teuchos::Ptr<const MV>& mv,
-                                          KV& kokkos_vals,
-                                          const size_t ldx)
+    bool get_1d_copy_helper_kokkos_view<MV,KV>::
+    do_get (bool bInitialize,
+            const Teuchos::Ptr<const MV>& mv,
+            KV& kokkos_vals,
+            const size_t ldx)
     {
       typedef Tpetra::Map<typename MV::local_ordinal_t,
                           typename MV::global_ordinal_t,
@@ -258,7 +262,7 @@ namespace Amesos2{
         map.is_null (), std::invalid_argument,
         "Amesos2::get_1d_copy_helper_kokkos_view::do_get(3 args): mv->getMap() is null.");
 
-      do_get (mv, kokkos_vals, ldx, Teuchos::ptrInArg (*map), ROOTED); // ROOTED the default here for now
+      return do_get (bInitialize, mv, kokkos_vals, ldx, Teuchos::ptrInArg (*map), ROOTED); // ROOTED the default here for now
     }
 
 

--- a/packages/amesos2/src/Amesos2_Tacho_def.hpp
+++ b/packages/amesos2/src/Amesos2_Tacho_def.hpp
@@ -135,22 +135,18 @@ TachoSolver<Matrix,Vector>::solve_impl(const Teuchos::Ptr<MultiVecAdapter<Vector
   // also don't allocate x since we will also use do_get to allocate this if
   // necessary. When a copy is not necessary we'll solve directly to the x
   // values in the MV.
+  bool bDidAssignX;
   {                             // Get values from RHS B
 #ifdef HAVE_AMESOS2_TIMERS
     Teuchos::TimeMonitor mvConvTimer(this->timers_.vecConvTime_);
     Teuchos::TimeMonitor redistTimer(this->timers_.vecRedistTime_);
 #endif
     Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
-                             device_solve_array_t>::do_get(B, this->bValues_,
+                             device_solve_array_t>::do_get(true, B, this->bValues_,
                                                as<size_t>(ld_rhs),
                                                ROOTED, this->rowIndexBase_);
-
-    // If it's not a match and we copy instead of ptr assignement, we will
-    // copy the x values here when we just wanted to get uninitialized space.
-    // MDM-DISCUSS Need to decide how to request the underlying API to learn
-    // whether we will need to copy or not.
-    Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
-                             device_solve_array_t>::do_get(X, this->xValues_,
+    bDidAssignX = Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
+                             device_solve_array_t>::do_get(false, X, this->xValues_,
                                                as<size_t>(ld_rhs),
                                                ROOTED, this->rowIndexBase_);
   }
@@ -182,7 +178,7 @@ TachoSolver<Matrix,Vector>::solve_impl(const Teuchos::Ptr<MultiVecAdapter<Vector
     "tacho_solve has error code: " << ierr );
 
   /* Update X's global values */
-  {
+  if(!bDidAssignX) { // if bDidAssignX, then we solved straight to the adapter's X memory space
 #ifdef HAVE_AMESOS2_TIMERS
     Teuchos::TimeMonitor redistTimer(this->timers_.vecRedistTime_);
 #endif

--- a/packages/amesos2/src/Amesos2_Tacho_def.hpp
+++ b/packages/amesos2/src/Amesos2_Tacho_def.hpp
@@ -141,12 +141,14 @@ TachoSolver<Matrix,Vector>::solve_impl(const Teuchos::Ptr<MultiVecAdapter<Vector
     Teuchos::TimeMonitor mvConvTimer(this->timers_.vecConvTime_);
     Teuchos::TimeMonitor redistTimer(this->timers_.vecRedistTime_);
 #endif
+    const bool initialize_data = true;
+    const bool do_not_initialize_data = false;
     Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
-                             device_solve_array_t>::do_get(true, B, this->bValues_,
+                             device_solve_array_t>::do_get(initialize_data, B, this->bValues_,
                                                as<size_t>(ld_rhs),
                                                ROOTED, this->rowIndexBase_);
     bDidAssignX = Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
-                             device_solve_array_t>::do_get(false, X, this->xValues_,
+                             device_solve_array_t>::do_get(do_not_initialize_data, X, this->xValues_,
                                                as<size_t>(ld_rhs),
                                                ROOTED, this->rowIndexBase_);
   }
@@ -178,7 +180,10 @@ TachoSolver<Matrix,Vector>::solve_impl(const Teuchos::Ptr<MultiVecAdapter<Vector
     "tacho_solve has error code: " << ierr );
 
   /* Update X's global values */
-  if(!bDidAssignX) { // if bDidAssignX, then we solved straight to the adapter's X memory space
+
+  // if bDidAssignX, then we solved straight to the adapter's X memory space without
+  // requiring additional memory allocation, so the x data is already in place.
+  if(!bDidAssignX) {
 #ifdef HAVE_AMESOS2_TIMERS
     Teuchos::TimeMonitor redistTimer(this->timers_.vecRedistTime_);
 #endif

--- a/packages/amesos2/src/Amesos2_TpetraMultiVecAdapter_decl.hpp
+++ b/packages/amesos2/src/Amesos2_TpetraMultiVecAdapter_decl.hpp
@@ -241,8 +241,8 @@ namespace Amesos2 {
                                               EDistribution distribution) const;
 
     template<typename KV>
-    void
-    get1dCopy_kokkos_view (KV& v,
+    bool
+    get1dCopy_kokkos_view (bool bInitialize, KV& v,
                size_t lda,
                Teuchos::Ptr<const Tpetra::Map<local_ordinal_t,
                                               global_ordinal_t,

--- a/packages/amesos2/src/Amesos2_cuSOLVER_def.hpp
+++ b/packages/amesos2/src/Amesos2_cuSOLVER_def.hpp
@@ -189,6 +189,7 @@ cuSOLVER<Matrix,Vector>::solve_impl(
   const global_size_type ld_rhs = this->root_ ? X->getGlobalLength() : 0;
   const ordinal_type nrhs = X->getGlobalNumVectors();
 
+  bool bAssignedX;
   {                             // Get values from RHS B
 #ifdef HAVE_AMESOS2_TIMERS
     Teuchos::TimeMonitor mvConvTimer(this->timers_.vecConvTime_);
@@ -196,13 +197,13 @@ cuSOLVER<Matrix,Vector>::solve_impl(
 #endif
 
     Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
-      device_solve_array_t>::do_get(B, this->bValues_, Teuchos::as<size_t>(ld_rhs),
+      device_solve_array_t>::do_get(true, B, this->bValues_, Teuchos::as<size_t>(ld_rhs),
       ROOTED, this->rowIndexBase_);
 
     // In general we may want to write directly to the x space without a copy.
     // So we 'get' x which may be a direct view assignment to the MV.
-    Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
-      device_solve_array_t>::do_get(X, this->xValues_, Teuchos::as<size_t>(ld_rhs),
+    bAssignedX = Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
+      device_solve_array_t>::do_get(false, X, this->xValues_, Teuchos::as<size_t>(ld_rhs),
       ROOTED, this->rowIndexBase_);
   }
 
@@ -242,7 +243,7 @@ cuSOLVER<Matrix,Vector>::solve_impl(
   }
 
   /* Update X's global values */
-  {
+  if(!bAssignedX) {
 #ifdef HAVE_AMESOS2_TIMERS
     Teuchos::TimeMonitor redistTimer(this->timers_.vecRedistTime_);
 #endif

--- a/packages/amesos2/src/Amesos2_cuSOLVER_def.hpp
+++ b/packages/amesos2/src/Amesos2_cuSOLVER_def.hpp
@@ -196,14 +196,16 @@ cuSOLVER<Matrix,Vector>::solve_impl(
     Teuchos::TimeMonitor redistTimer(this->timers_.vecRedistTime_);
 #endif
 
+    const bool initialize_data = true;
+    const bool do_not_initialize_data = false;
     Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
-      device_solve_array_t>::do_get(true, B, this->bValues_, Teuchos::as<size_t>(ld_rhs),
+      device_solve_array_t>::do_get(initialize_data, B, this->bValues_, Teuchos::as<size_t>(ld_rhs),
       ROOTED, this->rowIndexBase_);
 
     // In general we may want to write directly to the x space without a copy.
     // So we 'get' x which may be a direct view assignment to the MV.
     bAssignedX = Util::get_1d_copy_helper_kokkos_view<MultiVecAdapter<Vector>,
-      device_solve_array_t>::do_get(false, X, this->xValues_, Teuchos::as<size_t>(ld_rhs),
+      device_solve_array_t>::do_get(do_not_initialize_data, X, this->xValues_, Teuchos::as<size_t>(ld_rhs),
       ROOTED, this->rowIndexBase_);
   }
 
@@ -243,6 +245,9 @@ cuSOLVER<Matrix,Vector>::solve_impl(
   }
 
   /* Update X's global values */
+
+  // if bDidAssignX, then we solved straight to the adapter's X memory space without
+  // requiring additional memory allocation, so the x data is already in place.
   if(!bAssignedX) {
 #ifdef HAVE_AMESOS2_TIMERS
     Teuchos::TimeMonitor redistTimer(this->timers_.vecRedistTime_);


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/amesos2

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

The solver gets the x and b data from the adapter and it may be directly assigned (no deep copy) if memory and types match. This PR adds a flag bInitialize so the 'get x' call can inform the adapter that initializing the data is not necessary. This means that when the adapter does not match and has to allocate the data for x, it won't deep copy its x values into the x space. That was a wasted copy before since the solve was going to overwrite x anyways.

Also the get x or get b calls now receive a bDidAssign flag to tell the solver if the data is pointing directly to the adapter memory space. If x is directly assigned, there is no need to 'put x' after the solver and this can now be skipped.

Also SuperLU and Klu2 may modify b during the solve under some conditions. If the adapter directly assigned b, it's necessary to deep_copy b first to avoid overwriting the adapters b data. Previously, this deep_copy would always happen but now only when necessary.

This resolves #7158 which mentions some of the above issues.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->



<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Amesos2 tests on white Cuda and Mac parallel/serial builds.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->