### PR TITLE
A residual bug fix in the Belos single CG solver (fix #7680)

### DIFF
--- a/packages/belos/src/BelosCGSingleRedIter.hpp
+++ b/packages/belos/src/BelosCGSingleRedIter.hpp
@@ -477,7 +477,7 @@ class CGSingleRedIter : virtual public CGIteration<ScalarType,MV,OP> {
       MVT::MvTransMv( one, *S_, *T_, sHt );
       rHz_ = sHt(0,0);
       delta = sHt(1,0);
-      rHr_ = sHt(1,1);
+      rHr_ = sHt(0,1);
     } else {
       // Compute first <s,z> a.k.a. <r,z> and <Az,z> combined
       MVT::MvTransMv( one, *S_, *Z_, sHz );
@@ -538,7 +538,7 @@ class CGSingleRedIter : virtual public CGIteration<ScalarType,MV,OP> {
         rHz_old = rHz_;
         rHz_ = sHt(0,0);
         delta = sHt(1,0);
-        rHr_ = sHt(1,1);
+        rHr_ = sHt(0,1);
         //
         // Check the status test, now that the solution and residual have been updated
         //


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/Belos

## Motivation
When using the Belos - single reduction CG solver with a convergence folding option, a residual (`rHr_`) is using an incorrect array index which causes slower convergence of the solver.
Issued here: https://github.com/trilinos/Trilinos/issues/7680
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
Tested by comparing the number of iterations with the standard CG solver in Trilinos.

## Additional Information
@agsalin  and @rstumin  confirmed this bug in other project meeting.
<!--- 
Anything else we need to know in evaluating this merge request?
 -->