### PR TITLE
KokkosKernels: fix conjugate-transpose cusparse spmv (#7690)

### DIFF
--- a/packages/kokkos-kernels/src/impl/tpls/KokkosSparse_spmv_tpl_spec_avail.hpp
+++ b/packages/kokkos-kernels/src/impl/tpls/KokkosSparse_spmv_tpl_spec_avail.hpp
@@ -69,7 +69,7 @@ struct spmv_tpl_spec_avail<const SCALAR, const ORDINAL, Kokkos::Device<Kokkos::C
   enum : bool { value = true }; \
 };
 
-#if (9000 <= CUSPARSE_VERSION)
+#if (9000 <= CUDA_VERSION)
 
 #if defined (KOKKOSKERNELS_INST_FLOAT) \
   && defined (KOKKOSKERNELS_INST_LAYOUTLEFT) \
@@ -183,7 +183,7 @@ struct spmv_tpl_spec_avail<const SCALAR, const ORDINAL, Kokkos::Device<Kokkos::C
   KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>, int, int, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
 #endif
 
-#if (10300 <= CUSPARSE_VERSION)
+#if (10010 <= CUDA_VERSION)
 
 //Can enable int64/size_t.
 //TODO: if Nvidia ever supports int/size_t, add that too.

--- a/packages/kokkos-kernels/src/impl/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
+++ b/packages/kokkos-kernels/src/impl/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
@@ -88,7 +88,7 @@ namespace Impl {
     if(mode[0] == Transpose[0]) {myCusparseOperation = CUSPARSE_OPERATION_TRANSPOSE;}
     else if(mode[0] == ConjugateTranspose[0]) {myCusparseOperation = CUSPARSE_OPERATION_CONJUGATE_TRANSPOSE;}
 
-#if defined(CUSPARSE_VERSION) && (10300 <= CUSPARSE_VERSION)
+#if defined(CUDA_VERSION) && (10010 <= CUDA_VERSION)
 
     /* Check that cusparse can handle the types of the input Kokkos::CrsMatrix */
     cusparseIndexType_t myCusparseOffsetType;
@@ -159,7 +159,7 @@ namespace Impl {
     KOKKOS_CUSPARSE_SAFE_CALL(cusparseDestroyDnVec(vecY));
     KOKKOS_CUSPARSE_SAFE_CALL(cusparseDestroySpMat(A_cusparse));
 
-#elif (9000 <= CUSPARSE_VERSION)
+#elif (9000 <= CUDA_VERSION)
 
     /* create and set the matrix descriptor */
     cusparseMatDescr_t descrA = 0;
@@ -172,12 +172,12 @@ namespace Impl {
       if (std::is_same<value_type,float>::value) {
 	KOKKOS_CUSPARSE_SAFE_CALL(cusparseScsrmv(cusparseHandle, myCusparseOperation,
 						 A.numRows(), A.numCols(), A.nnz(),
-						 reinterpret_cast<const float *>(&alpha), descrA,
-						 reinterpret_cast<const float *>(A.values.data()),
+						 reinterpret_cast<float const*>(&alpha), descrA,
+						 reinterpret_cast<float const*>(A.values.data()),
 						 A.graph.row_map.data(), A.graph.entries.data(),
-						 reinterpret_cast<const float *>(x.data()),
-						 reinterpret_cast<const float *>(&beta),
-						 reinterpret_cast<float *>(y.data()) ));
+						 reinterpret_cast<float const*>(x.data()),
+						 reinterpret_cast<float const*>(&beta),
+						 reinterpret_cast<float*>(y.data())));
 
       } else  if (std::is_same<value_type,double>::value) {
 	KOKKOS_CUSPARSE_SAFE_CALL(cusparseDcsrmv(cusparseHandle, myCusparseOperation,
@@ -187,7 +187,7 @@ namespace Impl {
 						 A.graph.row_map.data(), A.graph.entries.data(),
 						 reinterpret_cast<double const *>(x.data()),
 						 reinterpret_cast<double const *>(&beta),
-						 reinterpret_cast<double *>(y.data()) ));
+						 reinterpret_cast<double*>(y.data())));
       } else  if (std::is_same<value_type,Kokkos::complex<float>>::value) {
 	KOKKOS_CUSPARSE_SAFE_CALL(cusparseCcsrmv(cusparseHandle, myCusparseOperation,
 						 A.numRows(), A.numCols(), A.nnz(),
@@ -196,7 +196,7 @@ namespace Impl {
 						 A.graph.row_map.data(), A.graph.entries.data(),
 						 reinterpret_cast<cuComplex const*>(x.data()),
 						 reinterpret_cast<cuComplex const*>(&beta),
-						 reinterpret_cast<cuComplex const*>(y.data())));
+						 reinterpret_cast<cuComplex*>(y.data())));
       } else  if (std::is_same<value_type,Kokkos::complex<double>>::value) {
 	KOKKOS_CUSPARSE_SAFE_CALL(cusparseZcsrmv(cusparseHandle, myCusparseOperation,
 						 A.numRows(), A.numCols(), A.nnz(),
@@ -205,7 +205,7 @@ namespace Impl {
 						 A.graph.row_map.data(), A.graph.entries.data(),
 						 reinterpret_cast<cuDoubleComplex const*>(x.data()),
 						 reinterpret_cast<cuDoubleComplex const*>(&beta),
-						 reinterpret_cast<cuDoubleComplex const*>(y.data())));
+						 reinterpret_cast<cuDoubleComplex*>(y.data())));
       } else {
 	throw std::logic_error("Trying to call cusparse SpMV with a scalar type not float/double, nor complex of either!");
       }
@@ -214,7 +214,7 @@ namespace Impl {
     }
 
     KOKKOS_CUSPARSE_SAFE_CALL(cusparseDestroyMatDescr(descrA));
-#endif // CUSPARSE_VERSION
+#endif // CUDA_VERSION
   }
 
 #define KOKKOSSPARSE_SPMV_CUSPARSE(SCALAR, ORDINAL, OFFSET, LAYOUT, SPACE, COMPILE_LIBRARY) \
@@ -252,7 +252,7 @@ namespace Impl {
       }									\
     }									\
   }; 
-#if (9000 <= CUSPARSE_VERSION)
+#if (9000 <= CUDA_VERSION)
   KOKKOSSPARSE_SPMV_CUSPARSE(double, int, int, Kokkos::LayoutLeft,  Kokkos::CudaSpace, true)
   KOKKOSSPARSE_SPMV_CUSPARSE(double, int, int, Kokkos::LayoutRight, Kokkos::CudaSpace, true)
   KOKKOSSPARSE_SPMV_CUSPARSE(float,  int, int, Kokkos::LayoutLeft,  Kokkos::CudaSpace, true)
@@ -270,7 +270,7 @@ namespace Impl {
   KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<float>,  int, int, Kokkos::LayoutLeft,  Kokkos::CudaUVMSpace, true)
   KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<float>,  int, int, Kokkos::LayoutRight, Kokkos::CudaUVMSpace, true)
 
-#if (10300 <= CUSPARSE_VERSION)
+#if (10010 <= CUDA_VERSION)
   KOKKOSSPARSE_SPMV_CUSPARSE(double, int64_t, size_t, Kokkos::LayoutLeft,  Kokkos::CudaSpace, true)
   KOKKOSSPARSE_SPMV_CUSPARSE(double, int64_t, size_t, Kokkos::LayoutRight, Kokkos::CudaSpace, true)
   KOKKOSSPARSE_SPMV_CUSPARSE(float,  int64_t, size_t, Kokkos::LayoutLeft,  Kokkos::CudaSpace, true)

--- a/packages/kokkos-kernels/src/impl/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
+++ b/packages/kokkos-kernels/src/impl/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
@@ -84,7 +84,6 @@ namespace Impl {
     cusparseHandle_t cusparseHandle = controls.getCusparseHandle();
 
     /* Set the operation mode */
-    std::cout << "HELLO FROM CUSPARSE SPMV: mode is \"" << mode << "\"\n";
     cusparseOperation_t myCusparseOperation = CUSPARSE_OPERATION_NON_TRANSPOSE;
     if(mode[0] == Transpose[0]) {myCusparseOperation = CUSPARSE_OPERATION_TRANSPOSE;}
     else if(mode[0] == ConjugateTranspose[0]) {myCusparseOperation = CUSPARSE_OPERATION_CONJUGATE_TRANSPOSE;}

--- a/packages/kokkos-kernels/src/impl/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
+++ b/packages/kokkos-kernels/src/impl/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
@@ -84,8 +84,10 @@ namespace Impl {
     cusparseHandle_t cusparseHandle = controls.getCusparseHandle();
 
     /* Set the operation mode */
+    std::cout << "HELLO FROM CUSPARSE SPMV: mode is \"" << mode << "\"\n";
     cusparseOperation_t myCusparseOperation = CUSPARSE_OPERATION_NON_TRANSPOSE;
     if(mode[0] == Transpose[0]) {myCusparseOperation = CUSPARSE_OPERATION_TRANSPOSE;}
+    else if(mode[0] == ConjugateTranspose[0]) {myCusparseOperation = CUSPARSE_OPERATION_CONJUGATE_TRANSPOSE;}
 
 #if defined(CUSPARSE_VERSION) && (10300 <= CUSPARSE_VERSION)
 


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/kokkos-kernels 

In cuSPARSE SpMV wrapper, handle the mode ConjugateTranspose, which maps to CUSPARSE_OPERATION_CONJUGATE_TRANSPOSE. Before, this was being ignored and it had the same behavior as "normal" mode.

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Gives expected behavior when mode is "H" (conjugate transpose). Now, the cusparse SPMV gives the same behavior as KokkosKernels native spmv when the mode is "H".
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
-->
## Related Issues

* Closes #7690 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 

## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
Broke Thyra test. Also possibly broke EMPIRE but not sure about that yet (@cgcgcg).
## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
This behavior is tested by Thyra
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->