### PR TITLE
Tpetra: Fix some compile-time warnings with sierra-devel toolchain

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsMatrix_def.hpp
@@ -4085,7 +4085,6 @@ namespace Tpetra {
     using Teuchos::RCP;
     using Teuchos::rcp;
     using Teuchos::rcpFromRef;
-    using LO = local_ordinal_type;
     using vec_type = Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
     const char tfecfFuncName[] = "leftScale: ";
 
@@ -4146,7 +4145,6 @@ namespace Tpetra {
     using Teuchos::RCP;
     using Teuchos::rcp;
     using Teuchos::rcpFromRef;
-    using LO = local_ordinal_type;
     typedef Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> vec_type;
     const char tfecfFuncName[] = "rightScale: ";
 

--- a/packages/tpetra/core/src/Tpetra_Details_packCrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_packCrsGraph_def.hpp
@@ -685,7 +685,6 @@ packCrsGraph
   using crs_graph_type = CrsGraph<LO, GO, NT>;
   using packet_type = typename crs_graph_type::packet_type;
   using buffer_device_type = typename crs_graph_type::buffer_device_type;
-  using execution_space = typename buffer_device_type::execution_space;
   using exports_view_type = Kokkos::DualView<packet_type*, buffer_device_type>;
   using local_graph_type = typename crs_graph_type::local_graph_type;
   using local_map_type = typename Tpetra::Map<LO, GO, NT>::local_map_type;

--- a/packages/tpetra/core/src/Tpetra_Details_packCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_packCrsMatrix_def.hpp
@@ -740,7 +740,6 @@ packCrsMatrix (const CrsMatrix<ST, LO, GO, NT>& sourceMatrix,
   );
   using Kokkos::View;
   typedef BufferDeviceType DT;
-  typedef typename DT::execution_space execution_space;
   typedef Kokkos::DualView<char*, BufferDeviceType> exports_view_type;
   const char prefix[] = "Tpetra::Details::PackCrsMatrixImpl::packCrsMatrix: ";
   constexpr bool debug = false;

--- a/packages/tpetra/core/src/Tpetra_DistObject_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_DistObject_def.hpp
@@ -687,8 +687,6 @@ namespace Tpetra {
     using Kokkos::Compat::getKokkosViewDeepCopy;
     using Kokkos::Compat::create_const_view;
     using std::endl;
-    using DT = device_type;
-    using DES = typename DT::execution_space;
     const char funcName[] = "Tpetra::DistObject::doTransferNew";
 
     ProfilingRegion region_dTN(funcName);

--- a/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/CrsMatrix_UnitTests.cpp
@@ -340,7 +340,6 @@ namespace { // (anonymous)
     typedef Tpetra::MultiVector<Scalar,LO,GO,Node> MV;
     typedef Tpetra::Vector<Scalar,LO,GO,Node> V;
     typedef typename ST::magnitudeType Mag;
-    typedef Teuchos::ScalarTraits<Mag> MT;
     // get a comm
     RCP<const Comm<int> > comm = getDefaultComm();
     // create a Map

--- a/packages/tpetra/tsqr/test/Tsqr_TestDistTsqr.cpp
+++ b/packages/tpetra/tsqr/test/Tsqr_TestDistTsqr.cpp
@@ -828,7 +828,6 @@ public:
     using Teuchos::RCP;                                                 \
     using SC = theType;                                                 \
     using base_messenger_type = TSQR::MessengerBase<SC>;                \
-    using base_messenger_ptr = RCP<base_messenger_type>;                \
     using derived_messenger_type = TSQR::TeuchosMessenger<SC>;          \
     using derived_messenger_ptr = RCP<derived_messenger_type>;          \
     using benchmarker_type = DistTsqrBenchmarker<int, SC>;              \
@@ -926,8 +925,6 @@ benchmark(Teuchos::RCP<const Teuchos::Comm<int>> comm,
           std::vector<int>& seed,
           const bool useSeed)
 {
-  using timer_type = Teuchos::Time;
-
   const bool testReal = params.testReal;
   const bool testComplex = params.testComplex;
   const int numCols = params.numCols;

--- a/packages/tpetra/tsqr/test/Tsqr_TestNodeTsqr.cpp
+++ b/packages/tpetra/tsqr/test/Tsqr_TestNodeTsqr.cpp
@@ -802,8 +802,6 @@ namespace TSQR {
     {
       using std::cerr;
       using std::endl;
-      using STS = Teuchos::ScalarTraits<Scalar>;
-      using mag_type = typename STS::magnitudeType;
       const bool verbose = params.verbose;
 
       const std::string scalarType =
@@ -1455,7 +1453,6 @@ namespace TSQR {
                       const NodeTestParameters& p)
     {
       using Teuchos::TypeNameTraits;
-      using LO = int;
 
       std::vector<int> iseed{{0, 0, 0, 1}};
       if(p.testReal) {


### PR DESCRIPTION
@trilinos/tpetra 

## Motivation
Get rid of unused typedef warnings on EWS blades (CEE-LAN) using the default toolchain for Sierra builds.

## Testing
Confirmed Tpetra test suite is still passing after these changes.