### PR TITLE
MueLu: Cache hierarchy description in setup

### DIFF
--- a/packages/muelu/src/Interface/MueLu_HierarchyManager.hpp
+++ b/packages/muelu/src/Interface/MueLu_HierarchyManager.hpp
@@ -250,6 +250,9 @@ namespace MueLu {
       if (!matvecParams_.is_null())
         H.SetMatvecParams(matvecParams_);
       H.AllocateLevelMultiVectors(sizeOfMultiVectors_);
+      // Set hierarchy description.
+      // This is cached, but involves and MPI_Allreduce.
+      H.description();
       H.describe(H.GetOStream(Runtime0), verbosity_);
 
       // When we reuse hierarchy, it is necessary that we don't


### PR DESCRIPTION
@trilinos/muelu 

## Motivation
The hierarchy description is cached. The first time it is used is in Hierarchy->Iterate. This change caches it already in setup.