### PR TITLE
Tpetra Thyra adapter: Avoid MPI_Bcast

### DIFF
--- a/packages/teuchos/comm/src/Teuchos_DefaultMpiComm.hpp
+++ b/packages/teuchos/comm/src/Teuchos_DefaultMpiComm.hpp
@@ -727,6 +727,27 @@ createMpiComm(
   );
 
 
+/** \brief Helper function that creates a dynamically allocated
+ * <tt>MpiComm</tt> object or returns <tt>Teuchos::null</tt> to correctly
+ * represent a null communicator.
+ *
+ * <b>Postconditions:</b></ul>
+ * <li>[<tt>rawMpiComm.get()!=NULL && *rawMpiComm!=MPI_COMM_NULL</tt>]
+ *     <tt>return.get()!=NULL</tt>
+ * <li>[<tt>rawMpiComm.get()==NULL || *rawMpiComm==MPI_COMM_NULL</tt>]
+ *     <tt>return.get()==NULL</tt>
+ * </ul>
+ *
+ * \relates MpiComm
+ */
+template<typename Ordinal>
+RCP<MpiComm<Ordinal> >
+createMpiComm(
+              const RCP<const OpaqueWrapper<MPI_Comm> > &rawMpiComm,
+              const int defaultTag              
+  );
+
+
 /** \brief Helper function that extracts a raw <tt>MPI_Comm</tt> object out of
  * a <tt>Teuchos::MpiComm</tt> wrapper object.
  *
@@ -1803,6 +1824,19 @@ Teuchos::createMpiComm(
 {
   if( rawMpiComm.get()!=NULL && *rawMpiComm != MPI_COMM_NULL )
     return rcp(new MpiComm<Ordinal>(rawMpiComm));
+  return Teuchos::null;
+}
+
+
+template<typename Ordinal>
+Teuchos::RCP<Teuchos::MpiComm<Ordinal> >
+Teuchos::createMpiComm(
+                       const RCP<const OpaqueWrapper<MPI_Comm> > &rawMpiComm,
+                       const int defaultTag
+  )
+{
+  if( rawMpiComm.get()!=NULL && *rawMpiComm != MPI_COMM_NULL )
+    return rcp(new MpiComm<Ordinal>(rawMpiComm, defaultTag));
   return Teuchos::null;
 }
 

--- a/packages/teuchos/comm/test/Comm/DefaultMpiComm_UnitTests.cpp
+++ b/packages/teuchos/comm/test/Comm/DefaultMpiComm_UnitTests.cpp
@@ -188,6 +188,18 @@ TEUCHOS_UNIT_TEST( DefaultMpiComm, getRawMpiComm )
 }
 
 
+TEUCHOS_UNIT_TEST( DefaultMpiComm, getRawMpiCommWithTag )
+{
+  ECHO(MPI_Comm rawMpiComm = MPI_COMM_WORLD);
+  ECHO(const RCP<const Comm<int> > comm =
+       Teuchos::createMpiComm<int>(Teuchos::opaqueWrapper(rawMpiComm), 123));
+  out << "comm = " << Teuchos::describe(*comm);
+  ECHO(MPI_Comm rawMpiComm2 = Teuchos::getRawMpiComm<int>(*comm));
+  TEST_EQUALITY( rawMpiComm2, rawMpiComm );
+  TEST_EQUALITY( comm->getTag(), 123);
+}
+
+
 #endif // HAVE_TEUCHOS_MPI
 
 

--- a/packages/thyra/adapters/tpetra/src/Thyra_TpetraThyraWrappers.cpp
+++ b/packages/thyra/adapters/tpetra/src/Thyra_TpetraThyraWrappers.cpp
@@ -61,7 +61,7 @@ Thyra::convertTpetraToThyraComm(const RCP<const Teuchos::Comm<int> > &tpetraComm
   const RCP<const Teuchos::MpiComm<int> > tpetraMpiComm = 
     rcp_dynamic_cast<const Teuchos::MpiComm<int> >(tpetraComm);
   if (nonnull(tpetraMpiComm)) {
-    return Teuchos::createMpiComm<Ordinal>(tpetraMpiComm->getRawMpiComm());
+    return Teuchos::createMpiComm<Ordinal>(tpetraMpiComm->getRawMpiComm(),tpetraMpiComm->getTag());
   }
 #endif // HAVE_MPI
 


### PR DESCRIPTION
@trilinos/teuchos @trilinos/thyra 

## Motivation
Conversion from a Tpetra comminicator to a Thyra communicator resulted in a MPI_Bcast call to determine the tag of the new communicator. With this change, Tpetra and Thyra communicator use the same tag, and no MPI_Bcast is necessary.