### PR TITLE
Tacho - improve variant 2 version and set the default algorithm as the variant 2

### DIFF
--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_SetIdentity_Internal.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_SetIdentity_Internal.hpp
@@ -11,11 +11,13 @@ namespace Tacho {
   template<>
   struct SetIdentity<Algo::Internal> {
     template<typename MemberType,
-             typename ViewTypeA>
+             typename ViewTypeA,
+             typename ScalarType>
     KOKKOS_INLINE_FUNCTION
     static int
     invoke(MemberType &member,
-           const ViewTypeA &A) {
+           const ViewTypeA &A,
+           const ScalarType &alpha) {
       typedef typename ViewTypeA::non_const_value_type value_type;        
       static_assert(ViewTypeA::rank == 2,"A is not rank 2 view.");
 
@@ -24,14 +26,14 @@ namespace Tacho {
         n = A.extent(1);
 
       if (m > 0 && n > 0) {
-        const value_type one(1), zero(0);
+        const value_type diag(alpha), zero(0);
         Kokkos::parallel_for
           (Kokkos::TeamThreadRange(member, n),
            [&](const ordinal_type &j) {
             Kokkos::parallel_for
               (Kokkos::ThreadVectorRange(member, m),
                [&](const ordinal_type &i) {
-                A(i,j) = i==j ? one : zero;
+                A(i,j) = i==j ? diag : zero;
               });
           });
       }

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_SetIdentity_OnDevice.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_SetIdentity_OnDevice.hpp
@@ -11,11 +11,13 @@ namespace Tacho {
   template<>
   struct SetIdentity<Algo::OnDevice> {
     template<typename MemberType,
-             typename ViewTypeA>
+             typename ViewTypeA,
+             typename ScalarType>
     inline
     static int
     invoke(MemberType &member,
-           const ViewTypeA &A) {
+           const ViewTypeA &A,
+           const ScalarType &alpha) {
       
       typedef typename ViewTypeA::non_const_value_type value_type;
       
@@ -26,7 +28,7 @@ namespace Tacho {
         n = A.extent(1);
       
       if (m > 0 && n > 0) {
-        const value_type one(1), zero(0);
+        const value_type diag(alpha), zero(0);
         using exec_space = MemberType;
         using team_policy_type = Kokkos::TeamPolicy<exec_space>;
 
@@ -38,7 +40,7 @@ namespace Tacho {
             Kokkos::parallel_for
               (Kokkos::TeamVectorRange(member, m),
                [&](const ordinal_type &i) {
-                A(i,j) = i==j ? one : zero;
+                A(i,j) = i==j ? diag : zero;
               });
           });
       }

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Solver_Impl.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Solver_Impl.hpp
@@ -30,7 +30,7 @@ namespace Tacho {
       _device_level_cut(0),
       _device_factor_thres(64),
       _device_solve_thres(128),
-      _variant(0),
+      _variant(2),
       _nstreams(16),
       _max_num_superblocks(-1) {}
 


### PR DESCRIPTION


## Motivation

While inverting super panels, this PR reduces a trsm one time. This also set the default algorithm variant as 2. The reason is that the particular application of our interest runs at least 10 times of solve runs. For such case, the cost of inverting panels can be amortized. 

@crdohrm 
