### PR TITLE
KokkosKernels: Fix cuSPARSE version check (#7723)

### DIFF
--- a/packages/kokkos-kernels/src/impl/tpls/KokkosSparse_spmv_tpl_spec_avail.hpp
+++ b/packages/kokkos-kernels/src/impl/tpls/KokkosSparse_spmv_tpl_spec_avail.hpp
@@ -183,7 +183,9 @@ struct spmv_tpl_spec_avail<const SCALAR, const ORDINAL, Kokkos::Device<Kokkos::C
   KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>, int, int, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
 #endif
 
-#if (10010 <= CUDA_VERSION)
+//CUDA_VERSION by itself cannot determine whether the generic cuSPARSE API is available:
+//cuSPARSE version 10.1.105 does not have the generic API, but it comes with the same CUDA_VERSION (10010) as 10.1.243 which does.
+#if defined(CUSPARSE_VERSION) && (CUSPARSE_VERSION >= 10300)
 
 //Can enable int64/size_t.
 //TODO: if Nvidia ever supports int/size_t, add that too.
@@ -300,8 +302,8 @@ struct spmv_tpl_spec_avail<const SCALAR, const ORDINAL, Kokkos::Device<Kokkos::C
   KOKKOSSPARSE_SPMV_TPL_SPEC_AVAIL_CUSPARSE(Kokkos::complex<double>, int64_t, size_t, Kokkos::LayoutRight, Kokkos::LayoutRight, Kokkos::CudaUVMSpace)
 #endif
 
-#endif  // CUSPARSE >= 10.0 (nested, implies >= 9.0)
-#endif  // CUSPARSE >= 9.0?
+#endif  // CUSPARSE >= 10.3 (nested, implies >= 9.0)
+#endif  // CUDA/CUSPARSE >= 9.0?
 #endif  // KOKKOSKERNELS_ENABLE_TPL_CUSPARSE
 
 // Specialization struct which defines whether a specialization exists

--- a/packages/kokkos-kernels/src/impl/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
+++ b/packages/kokkos-kernels/src/impl/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
@@ -88,7 +88,7 @@ namespace Impl {
     if(mode[0] == Transpose[0]) {myCusparseOperation = CUSPARSE_OPERATION_TRANSPOSE;}
     else if(mode[0] == ConjugateTranspose[0]) {myCusparseOperation = CUSPARSE_OPERATION_CONJUGATE_TRANSPOSE;}
 
-#if defined(CUDA_VERSION) && (10010 <= CUDA_VERSION)
+#if defined(CUSPARSE_VERSION) && (10300 <= CUDA_VERSION)
 
     /* Check that cusparse can handle the types of the input Kokkos::CrsMatrix */
     cusparseIndexType_t myCusparseOffsetType;
@@ -270,7 +270,7 @@ namespace Impl {
   KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<float>,  int, int, Kokkos::LayoutLeft,  Kokkos::CudaUVMSpace, true)
   KOKKOSSPARSE_SPMV_CUSPARSE(Kokkos::complex<float>,  int, int, Kokkos::LayoutRight, Kokkos::CudaUVMSpace, true)
 
-#if (10010 <= CUDA_VERSION)
+#if defined(CUSPARSE_VERSION) && (10300 <= CUSPARSE_VERSION)
   KOKKOSSPARSE_SPMV_CUSPARSE(double, int64_t, size_t, Kokkos::LayoutLeft,  Kokkos::CudaSpace, true)
   KOKKOSSPARSE_SPMV_CUSPARSE(double, int64_t, size_t, Kokkos::LayoutRight, Kokkos::CudaSpace, true)
   KOKKOSSPARSE_SPMV_CUSPARSE(float,  int64_t, size_t, Kokkos::LayoutLeft,  Kokkos::CudaSpace, true)

--- a/packages/kokkos-kernels/src/impl/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
+++ b/packages/kokkos-kernels/src/impl/tpls/KokkosSparse_spmv_tpl_spec_decl.hpp
@@ -88,7 +88,7 @@ namespace Impl {
     if(mode[0] == Transpose[0]) {myCusparseOperation = CUSPARSE_OPERATION_TRANSPOSE;}
     else if(mode[0] == ConjugateTranspose[0]) {myCusparseOperation = CUSPARSE_OPERATION_CONJUGATE_TRANSPOSE;}
 
-#if defined(CUSPARSE_VERSION) && (10300 <= CUDA_VERSION)
+#if defined(CUSPARSE_VERSION) && (10300 <= CUSPARSE_VERSION)
 
     /* Check that cusparse can handle the types of the input Kokkos::CrsMatrix */
     cusparseIndexType_t myCusparseOffsetType;


### PR DESCRIPTION
Fix the version check used the type-generic cuSPARSE API:
replace ``CUDA_VERSION >= 10010`` with
``defined(CUSPARSE_VERSION) && CUSPARSE_VERSION >= 10300``

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/kokkos-kernels 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Fixes build error, where kokkos-kernels tried to use features of cuSPARSE 10.3 and above when the cuSPARSE version was lower. This fixes the version check to see if those features are available. I think out of commonly used CUDA versions, this issue only affects 10.1.105, as seen by @jewatkins .
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:
-->

## Related Issues

* Closes #7723 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->

This build error can only be triggered by building with CUDA 10.1.105, which isn't used in PR testing or nightly ATDM testing. But, I did a build with this version on RIDE, replicated #7723, and verified that this PR fixes it.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->