### PR TITLE
Ifpack2 - fix race for thread mapping mismatch

### DIFF
--- a/packages/kokkos-kernels/src/batched/KokkosBatched_Copy_Internal.hpp
+++ b/packages/kokkos-kernels/src/batched/KokkosBatched_Copy_Internal.hpp
@@ -71,7 +71,7 @@ namespace KokkosBatched {
            const int m, const int n, 
            const ValueType *__restrict__ A, const int as0, const int as1,
            /* */ ValueType *__restrict__ B, const int bs0, const int bs1) {
-      if (m > n) { 
+      if (m >= n) { 
         Kokkos::parallel_for
           (Kokkos::TeamThreadRange(member,0,m),[&](const int &i) {
             SerialCopyInternal::invoke(n, A+i*as0, as1, B+i*bs0, bs1);


### PR DESCRIPTION
  
## Motivation

Using team parallel blas and lapack kernels, thread distribution over the matrix is better to remain the same so that we do not need to put a team barrier. Carefully examining the code, I put the barrier where is indeed necessary. The error due to this thread distributions over the matrix is not well caught in unit test as it only shows when threads are very busy and expericence context switching a lot (in my opinion).


## Testing

@csiefer2 confirms that 1 gpu and 2gpu solutions are same.
