### PR TITLE
IOSS: cgns - improve structured decomposition

### DIFF
--- a/packages/seacas/libraries/ioss/src/cgns/Iocgns_StructuredZoneData.C
+++ b/packages/seacas/libraries/ioss/src/cgns/Iocgns_StructuredZoneData.C
@@ -276,6 +276,21 @@ namespace Iocgns {
 
     int ordinal = min_ordinal;
 
+    // One more check to try to produce more "squarish" decompositions.
+    // Check the ratio of max ordinal to selected min_ordinal and if > 3 (hueristic), choose the max ordinal instead.
+    int max_ordinal = -1;
+    int max_ordinal_sz = 0;
+    for (int i=0; i < 3; i++) {
+      if (m_lineOrdinal != i && m_ordinal[i] > max_ordinal_sz) {
+	max_ordinal = i;
+	max_ordinal_sz = m_ordinal[i];
+      }
+    }
+
+    if (max_ordinal != -1 && max_ordinal_sz / m_ordinal[ordinal] > 3) {
+      ordinal = max_ordinal;
+    }
+
     if (m_ordinal[ordinal] <= 1 || (work0 == 0 && work1 == 0 && work2 == 0)) {
       return std::make_pair(nullptr, nullptr);
     }

--- a/packages/seacas/libraries/ioss/src/main/cgns_decomp.C
+++ b/packages/seacas/libraries/ioss/src/main/cgns_decomp.C
@@ -88,7 +88,7 @@ namespace {
         const char *temp = options_.retrieve("ordinal");
         if (temp != nullptr) {
           ordinal = std::stoi(temp);
-          if (ordinal < 1 || ordinal > 2) {
+          if (ordinal < 0 || ordinal > 2) {
             fmt::print("\nERROR: Invalid ordinal specified ({}). Must be 0, 1, or 2.\n", ordinal);
             exit(EXIT_FAILURE);
           }

--- a/packages/seacas/libraries/ioss/src/main/io_info.C
+++ b/packages/seacas/libraries/ioss/src/main/io_info.C
@@ -227,7 +227,7 @@ namespace {
                    sb->get_property("offset_k").get_int());
       }
 
-      fmt::print("{:14n} cells, {:14n} nodes ", num_cell, num_node);
+      fmt::print("  {:14n} cells, {:14n} nodes ", num_cell, num_node);
 
       info_aliases(region, sb, true, false);
       Ioss::Utils::info_fields(sb, Ioss::Field::TRANSIENT, "\n\tTransient:  ");

--- a/packages/seacas/libraries/ioss/src/utest/Utst_structured_decomp.C
+++ b/packages/seacas/libraries/ioss/src/utest/Utst_structured_decomp.C
@@ -527,6 +527,51 @@ TEST_CASE("grv-large", "[grv-large]")
   cleanup(zones);
 }
 
+TEST_CASE("grv-large-ordinal", "[grv-large-ordinal]")
+{
+  std::vector<Iocgns::StructuredZoneData *> zones;
+
+  int zone = 1;
+  zones.push_back(new Iocgns::StructuredZoneData(zone++, "128x32x32"));
+  zones.back()->m_lineOrdinal = 1;
+  zones.push_back(new Iocgns::StructuredZoneData(zone++, "128x32x32"));
+  zones.back()->m_lineOrdinal = 1;
+  zones.push_back(new Iocgns::StructuredZoneData(zone++, "128x32x32"));
+  zones.back()->m_lineOrdinal = 1;
+  zones.push_back(new Iocgns::StructuredZoneData(zone++, "128x16x64"));
+  zones.back()->m_lineOrdinal = 1;
+  zones.push_back(new Iocgns::StructuredZoneData(zone++, "128x64x64"));
+  zones.back()->m_lineOrdinal = 1;
+  zones.push_back(new Iocgns::StructuredZoneData(zone++, "128x64x64"));
+  zones.back()->m_lineOrdinal = 1;
+  zones.push_back(new Iocgns::StructuredZoneData(zone++, "128x64x64"));
+  zones.back()->m_lineOrdinal = 1;
+  zones.push_back(new Iocgns::StructuredZoneData(zone++, "128x32x32"));
+  zones.back()->m_lineOrdinal = 1;
+  zones.push_back(new Iocgns::StructuredZoneData(zone++, "128x32x32"));
+  zones.back()->m_lineOrdinal = 1;
+  zones.push_back(new Iocgns::StructuredZoneData(zone++, "128x32x32"));
+  zones.back()->m_lineOrdinal = 1;
+  zones.push_back(new Iocgns::StructuredZoneData(zone++, "128x16x64"));
+  zones.back()->m_lineOrdinal = 1;
+  zones.push_back(new Iocgns::StructuredZoneData(zone++, "128x64x64"));
+  zones.back()->m_lineOrdinal = 1;
+  zones.push_back(new Iocgns::StructuredZoneData(zone++, "128x64x64"));
+  zones.back()->m_lineOrdinal = 1;
+  zones.push_back(new Iocgns::StructuredZoneData(zone++, "128x64x64"));
+  zones.back()->m_lineOrdinal = 1;
+
+  for (size_t proc_count = 2; proc_count < 8192; proc_count *= 2) {
+    std::string name = "GRV-LARGE_ORDINAL_ProcCount_" + std::to_string(proc_count);
+    SECTION(name)
+    {
+      double load_balance_tolerance = 1.3;
+      check_split_assign(zones, load_balance_tolerance, proc_count, .7);
+    }
+  }
+  cleanup(zones);
+}
+
 TEST_CASE("mk21", "[mk21]")
 {
   std::vector<Iocgns::StructuredZoneData *> zones;
@@ -978,7 +1023,7 @@ TEST_CASE("bc-257x129x2", "[bc-257x129x2]")
 
   for (size_t proc_count = 4; proc_count <= 84; proc_count += 4) {
     std::string name = "BC_ProcCount_" + std::to_string(proc_count);
-    SECTION(name) { check_split_assign(zones, load_balance_tolerance, proc_count); }
+    SECTION(name) { check_split_assign(zones, load_balance_tolerance, proc_count, 0.9, 1.1); }
   }
   cleanup(zones);
 }


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/seacas 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Improve the cgns structured mesh decomposition to produce more "squarish" slices.  It was creating decomp zones that were a single cell wide (128x57x1) which maximized surface area and failed SPARC sanity checks.  

The decomp is now better and tries to produce better decomp zones.  It is still possible to create a zone which is a single cell wide, but this should be very rare.  Will continue to improve decomp, but comitting this now so SPARC can try it.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->