### PR TITLE
Muelu: fix coverage testing on geminga

### DIFF
--- a/cmake/ctest/drivers/geminga/ctest_linux_nightly_mpi_debug_muelu_coverage_geminga.cmake
+++ b/cmake/ctest/drivers/geminga/ctest_linux_nightly_mpi_debug_muelu_coverage_geminga.cmake
@@ -83,6 +83,7 @@ SET(EXTRA_CONFIGURE_OPTIONS
   "-DMueLu_ENABLE_Experimental=ON"
   "-DXpetra_ENABLE_Experimental=ON"
   "-DTeuchos_GLOBALLY_REDUCE_UNITTEST_RESULTS=ON"
+  "-DTrilinos_EXTRA_LINK_FLAGS='-lgcov'"
 )
 
 #


### PR DESCRIPTION
Link was failing:
  hidden symbol `__gcov_merge_add' in /mnt/watson/sems/install/rhel7-x86_64/sems/compiler/gcc/5.3.0/base/bin/../lib/gcc/x86_64-unknown-linux-gnu/5.3.0/libgcov.a(_gcov_merge_add.o) is referenced by DSO

Adding "-lgcov" fixes the error for me locally.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/muelu 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
This is a developer feature.

## Testing
I reproduced the failure locally and verified that this patch fixes it.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trilinos/trilinos/7746)
<!-- Reviewable:end -->
