### PR TITLE
Amesos2: Stokhos: Fix Basker TypeMap to not use static for dtype

### DIFF
--- a/packages/amesos2/src/Amesos2_Basker_TypeMap.hpp
+++ b/packages/amesos2/src/Amesos2_Basker_TypeMap.hpp
@@ -76,14 +76,14 @@ template <class, class> class Basker;
 template <>
 struct TypeMap<Basker,float>
 {
-  static double dtype;
+  typedef double dtype;
   typedef double type;
 };
 
 template <>
 struct TypeMap<Basker,double>
 {
-  static double dtype;
+  typedef double dtype;
   typedef double type;
 };
 
@@ -93,28 +93,28 @@ struct TypeMap<Basker,double>
 template <>
 struct TypeMap<Basker,std::complex<float> >
 {
-  static std::complex<double> dtype;
+  typedef std::complex<double> dtype;
   typedef Kokkos::complex<double> type;
 };
 
 template <>
 struct TypeMap<Basker,std::complex<double> >
 {
-  static std::complex<double> dtype;
+  typedef std::complex<double> dtype;
   typedef Kokkos::complex<double> type;
 };
 
 template <>
 struct TypeMap<Basker,Kokkos::complex<float> >
 {
-  static std::complex<double> dtype;
+  typedef std::complex<double> dtype;
   typedef Kokkos::complex<double> type;
 };
 
 template <>
 struct TypeMap<Basker,Kokkos::complex<double> >
 {
-  static std::complex<double> dtype;
+  typedef std::complex<double> dtype;
   typedef Kokkos::complex<double> type;
 };
 

--- a/packages/amesos2/src/Amesos2_Basker_decl.hpp
+++ b/packages/amesos2/src/Amesos2_Basker_decl.hpp
@@ -99,7 +99,7 @@ public:
   // TODO: Would like to change dtype to be a regular type, not static.
   // Seems nothing was using dtype before anyways but Stokhos would break so
   // will address that as a separate PR.
-  typedef decltype(type_map::dtype)                            basker_dtype;
+  typedef typename type_map::dtype                             basker_dtype;
 
   typedef FunctionMap<Amesos2::Basker,basker_type>             function_map;
 

--- a/packages/amesos2/src/Amesos2_Basker_decl.hpp
+++ b/packages/amesos2/src/Amesos2_Basker_decl.hpp
@@ -96,9 +96,6 @@ public:
 
   typedef typename type_map::type                               basker_type;
 
-  // TODO: Would like to change dtype to be a regular type, not static.
-  // Seems nothing was using dtype before anyways but Stokhos would break so
-  // will address that as a separate PR.
   typedef typename type_map::dtype                             basker_dtype;
 
   typedef FunctionMap<Amesos2::Basker,basker_type>             function_map;

--- a/packages/stokhos/src/sacado/kokkos/vector/amesos2/Amesos2_Basker_MP_Vector.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/amesos2/Amesos2_Basker_MP_Vector.hpp
@@ -68,7 +68,7 @@ namespace Amesos2 {
   // Enable MP::Vector as a valid Scalar type for Basker
   template <class ST>
   struct TypeMap< Basker,Sacado::MP::Vector<ST> > {
-    static Sacado::MP::Vector<ST> dtype;
+    typedef Sacado::MP::Vector<ST> dtype;
     typedef Sacado::MP::Vector<ST> type;
     typedef typename Kokkos::Details::ArithTraits< Sacado::MP::Vector<ST> >::mag_type magnitude_type;
   };


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/amesos2 @trilinos/stokhos 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

Resolve inconsistency in Basker TypeMap. This change is potentially a backwards compatibility issue if users have customized the TypeMap (similar to how Stokhos changes it).

@ndellingwood This is the change I mentioned earlier. I think we will want to do this. This is not going to fix anything, as the change is just to make things conventionally consistent. I believe the original use of static may have been an artifact of copying from the SuperLU solvers.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

