### PR TITLE
Ifpack2: Resolve CUDA_LAUNCH_BLOCKING=0

### DIFF
--- a/packages/ifpack2/src/Ifpack2_Details_MultiVectorLocalGatherScatter.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_MultiVectorLocalGatherScatter.hpp
@@ -110,6 +110,7 @@ public:
         X_out_j[i] = X_in_j[i_perm];
       }
     }
+    X_out.modify_host();
   }
 
   //Gather blocks (contiguous groups of blockSize rows)
@@ -136,6 +137,7 @@ public:
         }
       }
     }
+    X_out.modify_host();
   }
 
   void
@@ -155,6 +157,7 @@ public:
         X_in_j[i_perm] = X_out_j[i];
       }
     }
+    X_out.modify_host();
   }
 
   void
@@ -178,6 +181,7 @@ public:
         }
       }
     }
+    X_out.modify_host();
   }
 
   /******************/

--- a/packages/ifpack2/src/Ifpack2_Details_MultiVectorLocalGatherScatter.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_MultiVectorLocalGatherScatter.hpp
@@ -101,6 +101,7 @@ public:
     using Teuchos::ArrayRCP;
     const size_t numRows = X_out.getLocalLength ();
     const size_t numVecs = X_in.getNumVectors ();
+    Kokkos::fence();
     for (size_t j = 0; j < numVecs; ++j) {
       ArrayRCP<const InScalar> X_in_j = X_in.getData(j);
       ArrayRCP<OutScalar> X_out_j = X_out.getDataNonConst(j);
@@ -124,6 +125,7 @@ public:
     using Teuchos::ArrayRCP;
     const size_t numBlocks = X_out.getLocalLength() / blockSize;
     const size_t numVecs = X_in.getNumVectors ();
+    Kokkos::fence();
     for (size_t j = 0; j < numVecs; ++j) {
       ArrayRCP<const InScalar> X_in_j = X_in.getData(j);
       ArrayRCP<OutScalar> X_out_j = X_out.getDataNonConst(j);
@@ -144,6 +146,7 @@ public:
     using Teuchos::ArrayRCP;
     const size_t numRows = X_out.getLocalLength();
     const size_t numVecs = X_in.getNumVectors();
+    Kokkos::fence();
     for (size_t j = 0; j < numVecs; ++j) {
       ArrayRCP<InScalar> X_in_j = X_in.getDataNonConst(j);
       ArrayRCP<const OutScalar> X_out_j = X_out.getData(j);
@@ -164,6 +167,7 @@ public:
     using Teuchos::ArrayRCP;
     const size_t numBlocks = X_out.getLocalLength() / blockSize;
     const size_t numVecs = X_in.getNumVectors ();
+    Kokkos::fence();
     for (size_t j = 0; j < numVecs; ++j) {
       ArrayRCP<const InScalar> X_in_j = X_in.getData(j);
       ArrayRCP<OutScalar> X_out_j = X_out.getDataNonConst(j);
@@ -185,6 +189,7 @@ public:
                         const Teuchos::ArrayView<const LO> perm) const
   {
     //note: j is col, i is row
+    Kokkos::fence(); // demonstrated via unit test failure
     for(size_t j = 0; j < X_out.extent(1); ++j) {
       for(size_t i = 0; i < X_out.extent(0); ++i) {
         const LO i_perm = perm[i];
@@ -198,6 +203,7 @@ public:
                          const OutView X_out,
                          const Teuchos::ArrayView<const LO> perm) const
   {
+    Kokkos::fence();
     for(size_t j = 0; j < X_out.extent(1); ++j) {
       for(size_t i = 0; i < X_out.extent(0); ++i) {
         const LO i_perm = perm[i];
@@ -213,6 +219,7 @@ public:
                              LO blockSize) const
   {
     //note: j is col, i is row
+    Kokkos::fence();
     size_t numBlocks = X_out.extent(0) / blockSize;
     for(size_t j = 0; j < X_out.extent(1); ++j) {
       for(size_t i = 0; i < numBlocks; ++i) {
@@ -231,6 +238,7 @@ public:
                               LO blockSize) const
   {
     //note: j is col, i is row
+    Kokkos::fence();
     size_t numBlocks = X_out.extent(0) / blockSize;
     for(size_t j = 0; j < X_out.extent(1); ++j) {
       for(size_t i = 0; i < numBlocks; ++i) {
@@ -251,6 +259,7 @@ public:
                       const Teuchos::ArrayView<const LO> perm) const
   {
     //note: j is col, i is row
+    Kokkos::fence();
     size_t numRows = X_out.getLocalLength();
     for(size_t j = 0; j < X_out.getNumVectors(); ++j) {
       Teuchos::ArrayRCP<OutScalar> X_out_j = X_out.getDataNonConst(j);
@@ -267,6 +276,7 @@ public:
                        const Teuchos::ArrayView<const LO> perm) const
   {
     size_t numRows = X_out.getLocalLength(); 
+    Kokkos::fence();
     for(size_t j = 0; j < X_in.extent(1); ++j) {
       Teuchos::ArrayRCP<const OutScalar> X_out_j = X_out.getData(j);
       for(size_t i = 0; i < numRows; ++i) {
@@ -284,6 +294,7 @@ public:
   {
     //note: j is col, i is row
     size_t numBlocks = X_out.getLocalLength() / blockSize;
+    Kokkos::fence();
     for(size_t j = 0; j < X_out.getNumVectors(); ++j) {
       Teuchos::ArrayRCP<OutScalar> X_out_j = X_out.getDataNonConst(j);
       for(size_t i = 0; i < numBlocks; ++i) {
@@ -302,6 +313,7 @@ public:
                             LO blockSize) const
   {
     size_t numBlocks = X_out.getLocalLength() / blockSize;
+    Kokkos::fence();
     for(size_t j = 0; j < X_in.extent(1); ++j) {
       Teuchos::ArrayRCP<const OutScalar> X_out_j = X_out.getData(j);
       for(size_t i = 0; i < numBlocks; ++i) {

--- a/packages/ifpack2/src/Ifpack2_Experimental_RBILUK_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Experimental_RBILUK_def.hpp
@@ -870,6 +870,7 @@ apply (const Tpetra::MultiVector<scalar_type,local_ordinal_type,global_ordinal_t
         D_block_->applyBlock(cBlock, rBlock);
 
         // Solve U Y = R.
+        Kokkos::fence(); // UVM access
         for (local_ordinal_type imv = 0; imv < numVectors; ++imv)
         {
           const local_ordinal_type numRows = D_block_->getNodeNumRows();

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestBlockCrsUtil.hpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestBlockCrsUtil.hpp
@@ -262,6 +262,7 @@ struct BlockCrsMatrixMaker {
     auto colsum = colsum_mv.getLocalViewHost();
 
     // Get off-diag 1-norms.
+    Kokkos::fence(); // uvm access
     for (LO r = 0; r < nrows; ++r) {
       const auto rgid = row_map->getGlobalElement(r);
       for (size_t j = rowptr(r); j < rowptr(r+1); ++j) {

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestBlockRelaxation.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestBlockRelaxation.cpp
@@ -707,6 +707,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2BlockRelaxation, TestDiagonalBlockCrsMa
 
   const Scalar exactSol = 0.2;
 
+  yBlock.sync_host();
   for (int k = 0; k < num_rows_per_proc; ++k) {
     typename BMV::little_vec_type ylcl = yBlock.getLocalBlock(k,0);
     Scalar* yb = ylcl.data();
@@ -1268,6 +1269,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2BlockRelaxation, TestLowerTriangularBlo
   exactSol[1] = -0.25;
   exactSol[2] = 0.625;
 
+  yBlock.sync_host();
   for (size_t k = 0; k < num_rows_per_proc; ++k) {
     LO lcl_row = k;
     typename BMV::little_vec_type ylcl = yBlock.getLocalBlock(lcl_row,0);
@@ -1330,6 +1332,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2BlockRelaxation, TestUpperTriangularBlo
   exactSol[1] = -0.25;
   exactSol[2] = 0.5;
 
+  yBlock.sync_host();
   for (int k = 0; k < num_rows_per_proc; ++k) {
     typename BMV::little_vec_type ylcl = yBlock.getLocalBlock(k,0);
     auto yb = ylcl.data();

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestChebyshev.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestChebyshev.cpp
@@ -121,6 +121,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2Chebyshev, Test0, Scalar, LocalOrdinal,
 
   Teuchos::ArrayRCP<Scalar> twos(num_rows_per_proc*2, 2);
 
+  y.sync_host();
   TEST_COMPARE_FLOATING_ARRAYS(yview, twos(), Teuchos::ScalarTraits<Scalar>::eps());
 
   prec.apply(x, y);
@@ -131,6 +132,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2Chebyshev, Test0, Scalar, LocalOrdinal,
 
   typename Teuchos::ScalarTraits<Scalar>::magnitudeType trial_tol = 1.e-13;
   typename Teuchos::ScalarTraits<Scalar>::magnitudeType tol = std::max(trial_tol, Teuchos::ScalarTraits<Scalar>::eps());
+
+  y.sync_host();
   TEST_COMPARE_FLOATING_ARRAYS(yview, halfs(), tol);
 
   //If I now increase the degree of the polynomial to 4 the solve won't be
@@ -140,6 +143,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2Chebyshev, Test0, Scalar, LocalOrdinal,
   prec.apply(x, y);
 
   tol = 1.e-4;
+
+  y.sync_host();
   TEST_COMPARE_FLOATING_ARRAYS(yview, halfs(), tol);
 }
 

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestRBILUK.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestRBILUK.cpp
@@ -205,6 +205,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(RBILUK, LowerTriangularBlockCrsMatrix, Scalar,
   exactSol[1] = -0.25;
   exactSol[2] = 0.625;
 
+  yBlock.sync_host();
   for (size_t k = 0; k < num_rows_per_proc; ++k) {
     LO lcl_row = k;
     typename BMV::little_vec_type ylcl = yBlock.getLocalBlock(lcl_row,0);
@@ -260,6 +261,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(RBILUK, UpperTriangularBlockCrsMatrix, Scalar,
   exactSol[1] = -0.25;
   exactSol[2] = 0.5;
 
+  yBlock.sync_host();
   for (int k = 0; k < num_rows_per_proc; ++k) {
     typename BMV::little_vec_type ylcl = yBlock.getLocalBlock(k,0);
     Scalar* yb = ylcl.data();
@@ -314,6 +316,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(RBILUK, FullLocalBlockCrsMatrix, Scalar, Local
   exactSol[1] = -4.0/21.0;
   exactSol[2] = 2.0/7.0;
 
+  yBlock.sync_host();
   for (int k = 0; k < num_rows_per_proc; ++k) {
     typename BMV::little_vec_type ylcl = yBlock.getLocalBlock(k,0);
     Scalar* yb = ylcl.data();
@@ -381,6 +384,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(RBILUK, BandedBlockCrsMatrixWithDropping, Scal
 
   prec_crs.apply(x, z);
 
+  y.sync_host();
+  z.sync_host();
   Teuchos::ArrayRCP<const Scalar> zview = z.get1dView();
   Teuchos::ArrayRCP<const Scalar> yview = y.get1dView();
   for (int k = 0; k < num_rows_per_proc; ++k)
@@ -730,6 +735,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(RBILUK, DiagonalBlockCrsMatrix, Scalar, LocalO
 
   const Scalar exactSol = 0.2;
 
+  yBlock.sync_host();
   for (int k = 0; k < num_rows_per_proc; ++k) {
     typename BMV::little_vec_type ylcl = yBlock.getLocalBlock(k,0);
     Scalar* yb = ylcl.data();

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestRelaxation.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestRelaxation.cpp
@@ -117,6 +117,8 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2Relaxation, Test0, Scalar, LocalOrdinal
   prec.apply(x, y);
   //y should be full of 0.5's now.
   Teuchos::ArrayRCP<Scalar> halfs(num_rows_per_proc*2, 0.5);
+
+  y.sync_host();
   TEST_COMPARE_FLOATING_ARRAYS(yview, halfs(), Teuchos::ScalarTraits<Scalar>::eps());
 }
 
@@ -907,6 +909,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2Relaxation, TestDiagonalBlockCrsMatrix,
   using mag_type = typename STS::magnitudeType;
   const auto tol = mag_type(100.0) * STS::eps();
 
+  yBlock.sync_host();
   for (int k = 0; k < num_rows_per_proc; ++k) {
     typename BMV::little_vec_type ylcl = yBlock.getLocalBlock(k,0);
     Scalar* yb = ylcl.data();
@@ -1023,6 +1026,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2Relaxation, TestLowerTriangularBlockCrs
   exactSol[1] = -0.25;
   exactSol[2] = 0.625;
 
+  yBlock.sync_host();
   for (size_t k = 0; k < num_rows_per_proc; ++k) {
     LO lcl_row = k;
     typename BMV::little_vec_type ylcl = yBlock.getLocalBlock(lcl_row,0);
@@ -1075,6 +1079,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_3_DECL(Ifpack2Relaxation, TestUpperTriangularBlockCrs
   exactSol[1] = -0.25;
   exactSol[2] = 0.5;
 
+  yBlock.sync_host();
   for (int k = 0; k < num_rows_per_proc; ++k) {
     typename BMV::little_vec_type ylcl = yBlock.getLocalBlock(k,0);
     auto yb = ylcl.data();


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/ifpack2

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Adds fencing so that Ifpack2 unit tests will pass on white Cuda builds with CUDA_LAUNCH_BLOCKING=0.

Note this is tested stacked on top of ongoing work for Tpetra so this will not work stand alone with CUDA_LAUNCH_BLOCKING=0. I suggest we accept the addition of these fences and then address removal of individual fences with separate PRs that refactor as needed.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Tested on Cuda white builds stacked on ongoing Tpetra work to fix fences. Also tested on Mac parallel. This PR just adds fences and sync_host calls.
