### PR TITLE
Ifpack2 Chebyshev: Remove unneeded global communication

### DIFF
--- a/packages/ifpack2/src/Ifpack2_Details_Chebyshev_decl.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Chebyshev_decl.hpp
@@ -474,6 +474,9 @@ private:
   //! Number of power method iterations for estimating the max eigenvalue.
   int eigMaxIters_;
 
+  //! Frequency of normalization in the power method.
+  int eigNormalizationFreq_;
+
   //! Whether to assume that the X input to apply() is always zero.
   bool zeroStartingSolution_;
 

--- a/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_Chebyshev_def.hpp
@@ -290,6 +290,7 @@ Chebyshev (Teuchos::RCP<const row_matrix_type> A) :
   minDiagVal_ (STS::eps ()),
   numIters_ (1),
   eigMaxIters_ (10),
+  eigNormalizationFreq_(1),
   zeroStartingSolution_ (true),
   assumeMatrixUnchanged_ (false),
   textbookAlgorithm_ (false),
@@ -317,6 +318,7 @@ Chebyshev (Teuchos::RCP<const row_matrix_type> A,
   minDiagVal_ (STS::eps ()),
   numIters_ (1),
   eigMaxIters_ (10),
+  eigNormalizationFreq_(1),
   zeroStartingSolution_ (true),
   assumeMatrixUnchanged_ (false),
   textbookAlgorithm_ (false),
@@ -359,6 +361,7 @@ setParameters (Teuchos::ParameterList& plist)
   const ST defaultMinDiagVal = STS::eps ();
   const int defaultNumIters = 1;
   const int defaultEigMaxIters = 10;
+  const int defaultEigNormalizationFreq = 1;
   const bool defaultZeroStartingSolution = true; // Ifpack::Chebyshev default
   const bool defaultAssumeMatrixUnchanged = false;
   const bool defaultTextbookAlgorithm = false;
@@ -377,6 +380,7 @@ setParameters (Teuchos::ParameterList& plist)
   ST minDiagVal = defaultMinDiagVal;
   int numIters = defaultNumIters;
   int eigMaxIters = defaultEigMaxIters;
+  int eigNormalizationFreq = defaultEigNormalizationFreq;
   bool zeroStartingSolution = defaultZeroStartingSolution;
   bool assumeMatrixUnchanged = defaultAssumeMatrixUnchanged;
   bool textbookAlgorithm = defaultTextbookAlgorithm;
@@ -581,6 +585,13 @@ setParameters (Teuchos::ParameterList& plist)
     "\" parameter (also called \"eigen-analysis: iterations\") must be a "
     "nonnegative integer.  You gave a value of " << eigMaxIters << ".");
 
+  eigNormalizationFreq = plist.get ("chebyshev: eigenvalue normalization frequency", eigNormalizationFreq);
+  TEUCHOS_TEST_FOR_EXCEPTION(
+    eigNormalizationFreq < 0, std::invalid_argument,
+    "Ifpack2::Chebyshev::setParameters: \"chebyshev: eigenvalue normalization frequency"
+    "\" parameter must be a "
+    "nonnegative integer.  You gave a value of " << eigNormalizationFreq << ".")
+
   zeroStartingSolution = plist.get ("chebyshev: zero starting solution",
                                     zeroStartingSolution);
   assumeMatrixUnchanged = plist.get ("chebyshev: assume matrix does not change",
@@ -643,6 +654,7 @@ setParameters (Teuchos::ParameterList& plist)
   minDiagVal_ = minDiagVal;
   numIters_ = numIters;
   eigMaxIters_ = eigMaxIters;
+  eigNormalizationFreq_ = eigNormalizationFreq_;
   zeroStartingSolution_ = zeroStartingSolution;
   assumeMatrixUnchanged_ = assumeMatrixUnchanged;
   textbookAlgorithm_ = textbookAlgorithm;
@@ -1350,7 +1362,7 @@ powerMethodWithInitGuess (const op_type& A,
   const ST zero = static_cast<ST> (0.0);
   const ST one = static_cast<ST> (1.0);
   ST lambdaMax = zero;
-  ST RQ_top, RQ_bottom, norm;
+  ST RQ_top, RQ_bottom = one, norm;
 
   V y (A.getRangeMap ());
   norm = x.norm2 ();
@@ -1373,31 +1385,45 @@ powerMethodWithInitGuess (const op_type& A,
     *out_ << "  norm1(x.scale(one/norm)): " << x.norm1 () << endl;
   }
 
-  for (int iter = 0; iter < numIters; ++iter) {
+  for (int iter = 0; iter < numIters-1; ++iter) {
     if (debug_) {
       *out_ << "  Iteration " << iter << endl;
     }
     A.apply (x, y);
-    solve (y, D_inv, y);
-    RQ_top = y.dot (x);
-    RQ_bottom = x.dot (x);
-    if (debug_) {
-      *out_ << "   RQ_top: " << RQ_top
-            << ", RQ_bottom: " << RQ_bottom << endl;
-    }
-    lambdaMax = RQ_top / RQ_bottom;
-    norm = y.norm2 ();
-    if (norm == zero) { // Return something reasonable.
-      if (debug_) {
-        *out_ << "   norm is zero; returning zero" << endl;
+    solve (x, D_inv, y);
+
+    if (((iter+1) % eigNormalizationFreq_ == 0) && (iter < numIters-2)) {
+      norm = x.norm2 ();
+      if (norm == zero) { // Return something reasonable.
+        if (debug_) {
+          *out_ << "   norm is zero; returning zero" << endl;
+        }
+        return zero;
       }
-      return zero;
+      x.scale (one / norm);
     }
-    x.update (one / norm, y, zero);
   }
   if (debug_) {
     *out_ << "  lambdaMax: " << lambdaMax << endl;
   }
+
+  norm = x.norm2 ();
+  if (norm == zero) { // Return something reasonable.
+    if (debug_) {
+      *out_ << "   norm is zero; returning zero" << endl;
+    }
+    return zero;
+  }
+  x.scale (one / norm);
+  A.apply (x, y);
+  solve (y, D_inv, y);
+  RQ_top = y.dot (x);
+  RQ_bottom = one;
+  if (debug_) {
+    *out_ << "   RQ_top: " << RQ_top
+          << ", RQ_bottom: " << RQ_bottom << endl;
+  }
+  lambdaMax = RQ_top / RQ_bottom;
   return lambdaMax;
 }
 
@@ -1649,6 +1675,7 @@ describe (Teuchos::FancyOStream& out,
           << "userEigRatio_: " << userEigRatio_ << endl
           << "numIters_: " << numIters_ << endl
           << "eigMaxIters_: " << eigMaxIters_ << endl
+          << "eigNormalizationFreq_: " << eigNormalizationFreq_ << endl
           << "zeroStartingSolution_: " << zeroStartingSolution_ << endl
           << "assumeMatrixUnchanged_: " << assumeMatrixUnchanged_ << endl
           << "textbookAlgorithm_: " << textbookAlgorithm_ << endl

--- a/packages/muelu/test/interface/default/Output/MLsmoother4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLsmoother4_tpetra.gold
@@ -11,6 +11,7 @@ smoother ->
  chebyshev: boost factor = 1.1   [unused]
  chebyshev: min diagonal value = 2.22045e-16   [default]
  chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: zero starting solution = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
@@ -98,6 +99,7 @@ smoother ->
  chebyshev: boost factor = 1.1   [unused]
  chebyshev: min diagonal value = 2.22045e-16   [default]
  chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: zero starting solution = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
@@ -188,6 +190,7 @@ smoother ->
  chebyshev: boost factor = 1.1   [unused]
  chebyshev: min diagonal value = 2.22045e-16   [default]
  chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: zero starting solution = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
@@ -278,6 +281,7 @@ smoother ->
  chebyshev: boost factor = 1.1   [unused]
  chebyshev: min diagonal value = 2.22045e-16   [default]
  chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: zero starting solution = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 

--- a/packages/muelu/test/interface/default/Output/default_e3d_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/default_e3d_tpetra.gold
@@ -10,6 +10,7 @@ smoother ->
  chebyshev: min diagonal value = 2.22045e-16   [default]
  chebyshev: degree = 1   [default]
  chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: zero starting solution = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
@@ -105,6 +106,7 @@ smoother ->
  chebyshev: min diagonal value = 2.22045e-16   [default]
  chebyshev: degree = 1   [default]
  chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: zero starting solution = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 

--- a/packages/muelu/test/interface/default/Output/default_p2d_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/default_p2d_tpetra.gold
@@ -10,6 +10,7 @@ smoother ->
  chebyshev: min diagonal value = 2.22045e-16   [default]
  chebyshev: degree = 1   [default]
  chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: zero starting solution = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
@@ -105,6 +106,7 @@ smoother ->
  chebyshev: min diagonal value = 2.22045e-16   [default]
  chebyshev: degree = 1   [default]
  chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: zero starting solution = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 

--- a/packages/muelu/test/interface/default/Output/default_p3d_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/default_p3d_tpetra.gold
@@ -10,6 +10,7 @@ smoother ->
  chebyshev: min diagonal value = 2.22045e-16   [default]
  chebyshev: degree = 1   [default]
  chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: zero starting solution = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
@@ -105,6 +106,7 @@ smoother ->
  chebyshev: min diagonal value = 2.22045e-16   [default]
  chebyshev: degree = 1   [default]
  chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: zero starting solution = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 

--- a/packages/muelu/test/interface/default/Output/driver_drekar1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar1_np4_tpetra.gold
@@ -12,6 +12,7 @@ smoother ->
  chebyshev: eigenvalue max iterations = 10
  chebyshev: boost factor = 1.1   [unused]
  chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
 Level 1
@@ -187,6 +188,7 @@ smoother ->
  chebyshev: eigenvalue max iterations = 10
  chebyshev: boost factor = 1.1   [unused]
  chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
 Level 2
@@ -337,6 +339,7 @@ smoother ->
  chebyshev: eigenvalue max iterations = 10
  chebyshev: boost factor = 1.1   [unused]
  chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
 Level 3

--- a/packages/muelu/test/interface/default/Output/driver_drekar1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar1_tpetra.gold
@@ -12,6 +12,7 @@ smoother ->
  chebyshev: eigenvalue max iterations = 10
  chebyshev: boost factor = 1.1   [unused]
  chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
 Level 1
@@ -162,6 +163,7 @@ smoother ->
  chebyshev: eigenvalue max iterations = 10
  chebyshev: boost factor = 1.1   [unused]
  chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
 Level 2
@@ -312,6 +314,7 @@ smoother ->
  chebyshev: eigenvalue max iterations = 10
  chebyshev: boost factor = 1.1   [unused]
  chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
 Level 3

--- a/packages/muelu/test/interface/default/Output/driver_drekar2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar2_np4_tpetra.gold
@@ -12,6 +12,7 @@ smoother ->
  chebyshev: eigenvalue max iterations = 10
  chebyshev: boost factor = 1.1   [unused]
  chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
 Level 1
@@ -187,6 +188,7 @@ smoother ->
  chebyshev: eigenvalue max iterations = 10
  chebyshev: boost factor = 1.1   [unused]
  chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
 Level 2
@@ -337,6 +339,7 @@ smoother ->
  chebyshev: eigenvalue max iterations = 10
  chebyshev: boost factor = 1.1   [unused]
  chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
 Level 3

--- a/packages/muelu/test/interface/default/Output/driver_drekar2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar2_tpetra.gold
@@ -12,6 +12,7 @@ smoother ->
  chebyshev: eigenvalue max iterations = 10
  chebyshev: boost factor = 1.1   [unused]
  chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
 Level 1
@@ -162,6 +163,7 @@ smoother ->
  chebyshev: eigenvalue max iterations = 10
  chebyshev: boost factor = 1.1   [unused]
  chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
 Level 2
@@ -312,6 +314,7 @@ smoother ->
  chebyshev: eigenvalue max iterations = 10
  chebyshev: boost factor = 1.1   [unused]
  chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
 Level 3

--- a/packages/muelu/test/interface/default/Output/smoother12_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother12_tpetra.gold
@@ -10,6 +10,7 @@ smoother ->
  chebyshev: min diagonal value = 2.22045e-16   [default]
  chebyshev: degree = 1   [default]
  chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: zero starting solution = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
@@ -105,6 +106,7 @@ smoother ->
  chebyshev: min diagonal value = 2.22045e-16   [default]
  chebyshev: degree = 1   [default]
  chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: zero starting solution = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
@@ -200,6 +202,7 @@ smoother ->
  chebyshev: min diagonal value = 2.22045e-16   [default]
  chebyshev: degree = 1   [default]
  chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: zero starting solution = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
@@ -295,6 +298,7 @@ smoother ->
  chebyshev: min diagonal value = 2.22045e-16   [default]
  chebyshev: degree = 1   [default]
  chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: zero starting solution = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
@@ -390,6 +394,7 @@ smoother ->
  chebyshev: min diagonal value = 2.22045e-16   [default]
  chebyshev: degree = 1   [default]
  chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: zero starting solution = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 

--- a/packages/muelu/test/interface/default/Output/smoother13_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother13_tpetra.gold
@@ -10,6 +10,7 @@ smoother ->
  chebyshev: min diagonal value = 2.22045e-16   [default]
  chebyshev: degree = 1   [default]
  chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: zero starting solution = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
@@ -112,6 +113,7 @@ smoother ->
  chebyshev: min diagonal value = 2.22045e-16   [default]
  chebyshev: degree = 1   [default]
  chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: zero starting solution = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 

--- a/packages/muelu/test/interface/default/Output/smoother5_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother5_tpetra.gold
@@ -10,6 +10,7 @@ smoother ->
  chebyshev: min diagonal value = 2.22045e-16   [default]
  chebyshev: degree = 1   [default]
  chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: zero starting solution = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
@@ -105,6 +106,7 @@ smoother ->
  chebyshev: min diagonal value = 2.22045e-16   [default]
  chebyshev: degree = 1   [default]
  chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: zero starting solution = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 

--- a/packages/muelu/test/interface/default/Output/smoother9_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother9_tpetra.gold
@@ -10,6 +10,7 @@ smoother ->
  chebyshev: min diagonal value = 2.22045e-16   [default]
  chebyshev: degree = 1   [default]
  chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: zero starting solution = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
@@ -112,6 +113,7 @@ smoother ->
  chebyshev: min diagonal value = 2.22045e-16   [default]
  chebyshev: degree = 1   [default]
  chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: zero starting solution = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother4_tpetra.gold
@@ -11,6 +11,7 @@ smoother ->
  chebyshev: boost factor = 1.1   [unused]
  chebyshev: min diagonal value = 2.22045e-16   [default]
  chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: zero starting solution = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
@@ -93,6 +94,7 @@ smoother ->
  chebyshev: boost factor = 1.1   [unused]
  chebyshev: min diagonal value = 2.22045e-16   [default]
  chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: zero starting solution = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
@@ -178,6 +180,7 @@ smoother ->
  chebyshev: boost factor = 1.1   [unused]
  chebyshev: min diagonal value = 2.22045e-16   [default]
  chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: zero starting solution = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
@@ -263,6 +266,7 @@ smoother ->
  chebyshev: boost factor = 1.1   [unused]
  chebyshev: min diagonal value = 2.22045e-16   [default]
  chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: zero starting solution = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 

--- a/packages/muelu/test/interface/kokkos/Output/default_e3d_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_e3d_tpetra.gold
@@ -10,6 +10,7 @@ smoother ->
  chebyshev: min diagonal value = 2.22045e-16   [default]
  chebyshev: degree = 1   [default]
  chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: zero starting solution = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
@@ -94,6 +95,7 @@ smoother ->
  chebyshev: min diagonal value = 2.22045e-16   [default]
  chebyshev: degree = 1   [default]
  chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: zero starting solution = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 

--- a/packages/muelu/test/interface/kokkos/Output/default_p2d_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_p2d_tpetra.gold
@@ -10,6 +10,7 @@ smoother ->
  chebyshev: min diagonal value = 2.22045e-16   [default]
  chebyshev: degree = 1   [default]
  chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: zero starting solution = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
@@ -94,6 +95,7 @@ smoother ->
  chebyshev: min diagonal value = 2.22045e-16   [default]
  chebyshev: degree = 1   [default]
  chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: zero starting solution = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 

--- a/packages/muelu/test/interface/kokkos/Output/default_p3d_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_p3d_tpetra.gold
@@ -10,6 +10,7 @@ smoother ->
  chebyshev: min diagonal value = 2.22045e-16   [default]
  chebyshev: degree = 1   [default]
  chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: zero starting solution = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
@@ -94,6 +95,7 @@ smoother ->
  chebyshev: min diagonal value = 2.22045e-16   [default]
  chebyshev: degree = 1   [default]
  chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: zero starting solution = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar1_np4_tpetra.gold
@@ -12,6 +12,7 @@ smoother ->
  chebyshev: eigenvalue max iterations = 10
  chebyshev: boost factor = 1.1   [unused]
  chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
 Level 1
@@ -172,6 +173,7 @@ smoother ->
  chebyshev: eigenvalue max iterations = 10
  chebyshev: boost factor = 1.1   [unused]
  chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
 Level 2
@@ -307,6 +309,7 @@ smoother ->
  chebyshev: eigenvalue max iterations = 10
  chebyshev: boost factor = 1.1   [unused]
  chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
 Level 3

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar1_tpetra.gold
@@ -12,6 +12,7 @@ smoother ->
  chebyshev: eigenvalue max iterations = 10
  chebyshev: boost factor = 1.1   [unused]
  chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
 Level 1
@@ -147,6 +148,7 @@ smoother ->
  chebyshev: eigenvalue max iterations = 10
  chebyshev: boost factor = 1.1   [unused]
  chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
 Level 2
@@ -282,6 +284,7 @@ smoother ->
  chebyshev: eigenvalue max iterations = 10
  chebyshev: boost factor = 1.1   [unused]
  chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
 Level 3

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar2_np4_tpetra.gold
@@ -12,6 +12,7 @@ smoother ->
  chebyshev: eigenvalue max iterations = 10
  chebyshev: boost factor = 1.1   [unused]
  chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
 Level 1
@@ -173,6 +174,7 @@ smoother ->
  chebyshev: eigenvalue max iterations = 10
  chebyshev: boost factor = 1.1   [unused]
  chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
 Level 2
@@ -309,6 +311,7 @@ smoother ->
  chebyshev: eigenvalue max iterations = 10
  chebyshev: boost factor = 1.1   [unused]
  chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
 Level 3

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar2_tpetra.gold
@@ -12,6 +12,7 @@ smoother ->
  chebyshev: eigenvalue max iterations = 10
  chebyshev: boost factor = 1.1   [unused]
  chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
 Level 1
@@ -148,6 +149,7 @@ smoother ->
  chebyshev: eigenvalue max iterations = 10
  chebyshev: boost factor = 1.1   [unused]
  chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
 Level 2
@@ -284,6 +286,7 @@ smoother ->
  chebyshev: eigenvalue max iterations = 10
  chebyshev: boost factor = 1.1   [unused]
  chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
 Level 3

--- a/packages/muelu/test/interface/kokkos/Output/smoother12_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother12_tpetra.gold
@@ -10,6 +10,7 @@ smoother ->
  chebyshev: min diagonal value = 2.22045e-16   [default]
  chebyshev: degree = 1   [default]
  chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: zero starting solution = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
@@ -94,6 +95,7 @@ smoother ->
  chebyshev: min diagonal value = 2.22045e-16   [default]
  chebyshev: degree = 1   [default]
  chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: zero starting solution = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
@@ -178,6 +180,7 @@ smoother ->
  chebyshev: min diagonal value = 2.22045e-16   [default]
  chebyshev: degree = 1   [default]
  chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: zero starting solution = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
@@ -262,6 +265,7 @@ smoother ->
  chebyshev: min diagonal value = 2.22045e-16   [default]
  chebyshev: degree = 1   [default]
  chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: zero starting solution = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
@@ -346,6 +350,7 @@ smoother ->
  chebyshev: min diagonal value = 2.22045e-16   [default]
  chebyshev: degree = 1   [default]
  chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: zero starting solution = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 

--- a/packages/muelu/test/interface/kokkos/Output/smoother13_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother13_tpetra.gold
@@ -10,6 +10,7 @@ smoother ->
  chebyshev: min diagonal value = 2.22045e-16   [default]
  chebyshev: degree = 1   [default]
  chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: zero starting solution = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
@@ -101,6 +102,7 @@ smoother ->
  chebyshev: min diagonal value = 2.22045e-16   [default]
  chebyshev: degree = 1   [default]
  chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: zero starting solution = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 

--- a/packages/muelu/test/interface/kokkos/Output/smoother5_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother5_tpetra.gold
@@ -10,6 +10,7 @@ smoother ->
  chebyshev: min diagonal value = 2.22045e-16   [default]
  chebyshev: degree = 1   [default]
  chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: zero starting solution = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
@@ -94,6 +95,7 @@ smoother ->
  chebyshev: min diagonal value = 2.22045e-16   [default]
  chebyshev: degree = 1   [default]
  chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: zero starting solution = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 

--- a/packages/muelu/test/interface/kokkos/Output/smoother9_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother9_tpetra.gold
@@ -10,6 +10,7 @@ smoother ->
  chebyshev: min diagonal value = 2.22045e-16   [default]
  chebyshev: degree = 1   [default]
  chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: zero starting solution = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 
@@ -101,6 +102,7 @@ smoother ->
  chebyshev: min diagonal value = 2.22045e-16   [default]
  chebyshev: degree = 1   [default]
  chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: eigenvalue normalization frequency = 1   [default]
  chebyshev: zero starting solution = 1   [default]
  chebyshev: assume matrix does not change = 0   [default]
 


### PR DESCRIPTION
@trilinos/ifpack2 

## Motivation
Remove some inner product and norm calls from Chebyshev power method, since they are not needed.
This can be done, since the power iteration performs a prescribed number of iterations.
Add parameter "chebyshev: eigenvalue normalization frequency" that allows to skip normalization in every step of the power method, reducing the number of global communication even further.