### PR TITLE
Tpetra: Change default algorithm for matrix Jacobi from MSAK to KK

### DIFF
--- a/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_Cuda.hpp
+++ b/packages/tpetra/core/ext/TpetraExt_MatrixMatrix_Cuda.hpp
@@ -424,7 +424,7 @@ void KernelWrappers2<Scalar,LocalOrdinal,GlobalOrdinal,Kokkos::Compat::KokkosCud
 
   // Options
   //int team_work_size = 16;  // Defaults to 16 as per Deveci 12/7/16 - csiefer // unreferenced
-  std::string myalg("MSAK");
+  std::string myalg("KK");
   if(!params.is_null()) {
     if(params->isParameter("cuda: jacobi algorithm"))
       myalg = params->get("cuda: jacobi algorithm",myalg);


### PR DESCRIPTION
@trilinos/tpetra @trilinos/muelu 

## Motivation
Change the default algorithm for Jacobi smoothing of MueLu prolongators from MSAK to the KK option implemented by @seheracer.
Tests on white P100, all matrices 1M rows, 100 setups each, timer "SaPFactory_kokkos: Xpetra::IteratorOps::Jacobi":

**one single rank, all computation, no communication**
|matrixType|MSAK|KK|
|--|--|--|
|Laplace2D | 3.863 |3.318  |
|Laplace3D |5.05  | 4.339 |
|Brick3D | 5.889 | 5.366 |

These cases give ~10-15% improvement.

**8 ranks, little computation, a lot of communication**
|matrixType|MSAK|KK|
|--|--|--|
|Laplace2D | 27.74 | 17.76 |
|Laplace3D |23.65  | 15.07 |
|Brick3D | 23.46 | 16.22 |

These cases give ~30-36% improvement.

 @trilinos/muelu, what else should we test before merging?