### PR TITLE
Tempus: Add Further Testing for Explicit RKAppAction

### DIFF
--- a/packages/tempus/src/Tempus_StepperDIRK_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperDIRK_decl.hpp
@@ -226,14 +226,6 @@ public:
 
   virtual bool isValidSetup(Teuchos::FancyOStream & out) const;
 
-  /// \name Accessors methods
-  //@{
-    /** \brief Use embedded if avialable. */
-    virtual void setUseEmbedded(bool a) { useEmbedded_ = a; }
-    virtual bool getUseEmbedded() const { return useEmbedded_; }
-    virtual bool getUseEmbeddedDefault() const { return false; }
-  //@}
-
 
 protected:
 
@@ -270,13 +262,6 @@ protected:
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
   Teuchos::RCP<StepperRKObserverComposite<Scalar> >      stepperObserver_;
 #endif
-
-  // For Embedded RK
-  bool useEmbedded_;
-  Teuchos::RCP<Thyra::VectorBase<Scalar> >               ee_;
-  Teuchos::RCP<Thyra::VectorBase<Scalar> >               abs_u0;
-  Teuchos::RCP<Thyra::VectorBase<Scalar> >               abs_u;
-  Teuchos::RCP<Thyra::VectorBase<Scalar> >               sc;
 
   bool resetGuess_ = true;
 };

--- a/packages/tempus/src/Tempus_StepperDIRK_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperDIRK_impl.hpp
@@ -170,10 +170,10 @@ void StepperDIRK<Scalar>::initialize()
   assign(xTilde_.ptr(),    Teuchos::ScalarTraits<Scalar>::zero());
 
   if (this->tableau_->isEmbedded() and this->getUseEmbedded()) {
-    ee_    = Thyra::createMember(this->wrapperModel_->get_f_space());
-    abs_u0 = Thyra::createMember(this->wrapperModel_->get_f_space());
-    abs_u  = Thyra::createMember(this->wrapperModel_->get_f_space());
-    sc     = Thyra::createMember(this->wrapperModel_->get_f_space());
+    this->ee_    = Thyra::createMember(this->wrapperModel_->get_f_space());
+    this->abs_u0 = Thyra::createMember(this->wrapperModel_->get_f_space());
+    this->abs_u  = Thyra::createMember(this->wrapperModel_->get_f_space());
+    this->sc     = Thyra::createMember(this->wrapperModel_->get_f_space());
   }
 
   StepperImplicit<Scalar>::initialize();
@@ -217,10 +217,9 @@ void StepperDIRK<Scalar>::takeStep(
     Teuchos::SerialDenseVector<int,Scalar> b = this->tableau_->b();
     Teuchos::SerialDenseVector<int,Scalar> c = this->tableau_->c();
 
-    this->stageX_ = workingState->getX();
     // Reset non-zero initial guess.
     if ( this->getResetInitialGuess() && (!this->getZeroInitialGuess()) )
-      Thyra::assign(this->stageX_.ptr(), *(currentState->getX()));
+      Thyra::assign(workingState->getX().ptr(), *(currentState->getX()));
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
     this->stepperObserver_->observeBeginTakeStep(solutionHistory, *this);
@@ -308,7 +307,7 @@ void StepperDIRK<Scalar>::takeStep(
         this->stepperRKAppAction_->execute(solutionHistory, thisStepper,
           StepperRKAppAction<Scalar>::ACTION_LOCATION::BEFORE_SOLVE);
 
-        sStatus = this->solveImplicitODE(this->stageX_, stageXDot_[i], ts, p);
+        sStatus = this->solveImplicitODE(workingState->getX(), stageXDot_[i], ts, p);
 
         if (sStatus.solveStatus != Thyra::SOLVE_STATUS_CONVERGED) pass=false;
 
@@ -318,7 +317,7 @@ void StepperDIRK<Scalar>::takeStep(
         this->stepperRKAppAction_->execute(solutionHistory, thisStepper,
           StepperRKAppAction<Scalar>::ACTION_LOCATION::AFTER_SOLVE);
 
-        timeDer->compute(this->stageX_, stageXDot_[i]);
+        timeDer->compute(workingState->getX(), stageXDot_[i]);
       }
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
       this->stepperObserver_->observeEndStage(solutionHistory, *this);
@@ -350,23 +349,23 @@ void StepperDIRK<Scalar>::takeStep(
 
       // compute local truncation error estimate: | u^{n+1} - \hat{u}^{n+1} |
       // Sum for solution: ee_n = Sum{ (b(i) - bstar(i)) * dt*f(i) }
-      assign(ee_.ptr(), Teuchos::ScalarTraits<Scalar>::zero());
+      assign(this->ee_.ptr(), Teuchos::ScalarTraits<Scalar>::zero());
       for (int i=0; i < numStages; ++i) {
          if (errWght(i) != Teuchos::ScalarTraits<Scalar>::zero()) {
-            Thyra::Vp_StV(ee_.ptr(), dt*errWght(i), *(stageXDot_[i]));
+            Thyra::Vp_StV(this->ee_.ptr(), dt*errWght(i), *(stageXDot_[i]));
          }
       }
 
       // compute: Atol + max(|u^n|, |u^{n+1}| ) * Rtol
-      Thyra::abs( *(currentState->getX()), abs_u0.ptr());
-      Thyra::abs( *(workingState->getX()), abs_u.ptr());
-      Thyra::pair_wise_max_update(tolRel, *abs_u0, abs_u.ptr());
-      Thyra::add_scalar(tolAbs, abs_u.ptr());
+      Thyra::abs( *(currentState->getX()), this->abs_u0.ptr());
+      Thyra::abs( *(workingState->getX()), this->abs_u.ptr());
+      Thyra::pair_wise_max_update(tolRel, *this->abs_u0, this->abs_u.ptr());
+      Thyra::add_scalar(tolAbs, this->abs_u.ptr());
 
       // compute: || ee / sc ||
-      assign(sc.ptr(), Teuchos::ScalarTraits<Scalar>::zero());
-      Thyra::ele_wise_divide(Teuchos::as<Scalar>(1.0), *ee_, *abs_u, sc.ptr());
-      Scalar err = std::abs(Thyra::norm_inf(*sc));
+      assign(this->sc.ptr(), Teuchos::ScalarTraits<Scalar>::zero());
+      Thyra::ele_wise_divide(Teuchos::as<Scalar>(1.0), *this->ee_, *this->abs_u, this->sc.ptr());
+      Scalar err = std::abs(Thyra::norm_inf(*this->sc));
       workingState->setErrorRel(err);
 
       // test if step should be rejected
@@ -422,17 +421,16 @@ void StepperDIRK<Scalar>::describe(
 #endif
   out << "  stepperRKAppAction_= " << this->stepperRKAppAction_ << std::endl;
   out << "  xTilde_             = " << xTilde_ << std::endl;
-  out << "  stageX_             = " << this->stageX_ << std::endl;
   out << "  stageXDot_.size()   = " << stageXDot_.size() << std::endl;
   const int numStages = stageXDot_.size();
   for (int i=0; i<numStages; ++i)
     out << "    stageXDot_["<<i<<"] = " << stageXDot_[i] << std::endl;
   out << "  useEmbedded_        = "
-      << Teuchos::toString(useEmbedded_) << std::endl;
-  out << "  ee_                 = " << ee_ << std::endl;
-  out << "  abs_u0              = " << abs_u0 << std::endl;
-  out << "  abs_u               = " << abs_u << std::endl;
-  out << "  sc                  = " << sc << std::endl;
+      << Teuchos::toString(this->useEmbedded_) << std::endl;
+  out << "  ee_                 = " << this->ee_ << std::endl;
+  out << "  abs_u0              = " << this->abs_u0 << std::endl;
+  out << "  abs_u               = " << this->abs_u << std::endl;
+  out << "  sc                  = " << this->sc << std::endl;
   out << "-------------------" << std::endl;
 }
 

--- a/packages/tempus/src/Tempus_StepperExplicitRK_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperExplicitRK_decl.hpp
@@ -149,14 +149,6 @@ public:
 
   virtual bool isValidSetup(Teuchos::FancyOStream & out) const;
 
-  /// \name Accessors methods
-  //@{
-    /** \brief Use embedded if avialable. */
-    virtual void setUseEmbedded(bool a) { useEmbedded_ = a; }
-    virtual bool getUseEmbedded() const { return useEmbedded_; }
-    virtual bool getUseEmbeddedDefault() const { return false; }
-  //@}
-
 
 protected:
 
@@ -189,13 +181,6 @@ protected:
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
   Teuchos::RCP<StepperRKObserverComposite<Scalar> >      stepperObserver_;
 #endif
-
-  // For Embedded RK
-  bool useEmbedded_;
-  Teuchos::RCP<Thyra::VectorBase<Scalar> >               ee_;
-  Teuchos::RCP<Thyra::VectorBase<Scalar> >               abs_u0;
-  Teuchos::RCP<Thyra::VectorBase<Scalar> >               abs_u;
-  Teuchos::RCP<Thyra::VectorBase<Scalar> >               sc;
 
 };
 

--- a/packages/tempus/src/Tempus_StepperExplicitRK_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperExplicitRK_impl.hpp
@@ -239,10 +239,10 @@ void StepperExplicitRK<Scalar>::initialize()
   }
 
   if ( this->tableau_->isEmbedded() and this->getUseEmbedded() ){
-     ee_ = Thyra::createMember(this->appModel_->get_f_space());
-     abs_u0 = Thyra::createMember(this->appModel_->get_f_space());
-     abs_u = Thyra::createMember(this->appModel_->get_f_space());
-     sc = Thyra::createMember(this->appModel_->get_f_space());
+     this->ee_ = Thyra::createMember(this->appModel_->get_f_space());
+     this->abs_u0 = Thyra::createMember(this->appModel_->get_f_space());
+     this->abs_u = Thyra::createMember(this->appModel_->get_f_space());
+     this->sc = Thyra::createMember(this->appModel_->get_f_space());
   }
 
   Stepper<Scalar>::initialize();
@@ -253,8 +253,16 @@ template<class Scalar>
 void StepperExplicitRK<Scalar>::setInitialConditions(
   const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory)
 {
-  this->setStepperXDot(stageXDot_.back());
+  if (this->getUseFSAL())
+    this->setStepperXDot(stageXDot_.back());
+  else
+    this->setStepperXDot(stageXDot_[0]);
+
   StepperExplicit<Scalar>::setInitialConditions(solutionHistory);
+
+  auto xDot = solutionHistory->getCurrentState()->getXDot();
+  if (xDot != Teuchos::null && this->getUseFSAL())
+    Thyra::assign(this->getStepperXDot().ptr(), *(xDot));
 }
 
 
@@ -286,8 +294,7 @@ void StepperExplicitRK<Scalar>::takeStep(
     Teuchos::SerialDenseVector<int,Scalar> b = this->tableau_->b();
     Teuchos::SerialDenseVector<int,Scalar> c = this->tableau_->c();
 
-    this->stageX_ = workingState->getX();
-    Thyra::assign(this->stageX_.ptr(), *(currentState->getX()));
+    Thyra::assign(workingState->getX().ptr(), *(currentState->getX()));
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
     this->stepperObserver_->observeBeginTakeStep(solutionHistory, *this);
@@ -299,35 +306,26 @@ void StepperExplicitRK<Scalar>::takeStep(
     // Compute stage solutions
     for (int i=0; i < numStages; ++i) {
       this->setStageNumber(i);
-      Thyra::assign(this->stageX_.ptr(), *(currentState->getX()));
+      Thyra::assign(workingState->getX().ptr(), *(currentState->getX()));
       for (int j=0; j < i; ++j) {
         if (A(i,j) != Teuchos::ScalarTraits<Scalar>::zero()) {
-          Thyra::Vp_StV(this->stageX_.ptr(), dt*A(i,j), *stageXDot_[j]);
+          Thyra::Vp_StV(workingState->getX().ptr(), dt*A(i,j), *stageXDot_[j]);
         }
       }
       this->setStepperXDot(stageXDot_[i]);
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
       this->stepperObserver_->observeBeginStage(solutionHistory, *this);
-
-      // ???: is it a good idea to leave this (no-op) here?
       this->stepperObserver_
           ->observeBeforeImplicitExplicitly(solutionHistory, *this);
-
-      // ???: is it a good idea to leave this (no-op) here?
       this->stepperObserver_->observeBeforeSolve(solutionHistory, *this);
+      this->stepperObserver_->observeAfterSolve(solutionHistory, *this);
+      this->stepperObserver_->observeBeforeExplicit(solutionHistory, *this);
 #endif
       this->stepperRKAppAction_->execute(solutionHistory, thisStepper,
         StepperRKAppAction<Scalar>::ACTION_LOCATION::BEGIN_STAGE);
       this->stepperRKAppAction_->execute(solutionHistory, thisStepper,
         StepperRKAppAction<Scalar>::ACTION_LOCATION::BEFORE_SOLVE);
-
-#ifndef TEMPUS_HIDE_DEPRECATED_CODE
-      // ???: is it a good idea to leave this (no-op) here?
-      this->stepperObserver_->observeAfterSolve(solutionHistory, *this);
-
-      this->stepperObserver_->observeBeforeExplicit(solutionHistory, *this);
-#endif
       this->stepperRKAppAction_->execute(solutionHistory, thisStepper,
         StepperRKAppAction<Scalar>::ACTION_LOCATION::AFTER_SOLVE);
       this->stepperRKAppAction_->execute(solutionHistory, thisStepper,
@@ -335,19 +333,17 @@ void StepperExplicitRK<Scalar>::takeStep(
 
       if ( i == 0 && this->getUseFSAL() &&
            workingState->getNConsecutiveFailures() == 0 ) {
-
         RCP<Thyra::VectorBase<Scalar> > tmp = stageXDot_[0];
         stageXDot_[0] = stageXDot_.back();
         stageXDot_.back() = tmp;
         this->setStepperXDot(stageXDot_[0]);
 
       } else {
-
         const Scalar ts = time + c(i)*dt;
         auto p = Teuchos::rcp(new ExplicitODEParameters<Scalar>(dt));
 
         // Evaluate xDot = f(x,t).
-        this->evaluateExplicitODE(stageXDot_[i], this->stageX_, ts, p);
+        this->evaluateExplicitODE(stageXDot_[i], workingState->getX(), ts, p);
       }
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
@@ -385,23 +381,23 @@ void StepperExplicitRK<Scalar>::takeStep(
 
       //compute local truncation error estimate: | u^{n+1} - \hat{u}^{n+1} |
       // Sum for solution: ee_n = Sum{ (b(i) - bstar(i)) * dt*f(i) }
-      assign(ee_.ptr(), Teuchos::ScalarTraits<Scalar>::zero());
+      assign(this->ee_.ptr(), Teuchos::ScalarTraits<Scalar>::zero());
       for (int i=0; i < numStages; ++i) {
          if (errWght(i) != Teuchos::ScalarTraits<Scalar>::zero()) {
-            Thyra::Vp_StV(ee_.ptr(), dt*errWght(i), *(stageXDot_[i]));
+            Thyra::Vp_StV(this->ee_.ptr(), dt*errWght(i), *(stageXDot_[i]));
          }
       }
 
       // compute: Atol + max(|u^n|, |u^{n+1}| ) * Rtol
-      Thyra::abs( *(currentState->getX()), abs_u0.ptr());
-      Thyra::abs( *(workingState->getX()), abs_u.ptr());
-      Thyra::pair_wise_max_update(tolRel, *abs_u0, abs_u.ptr());
-      Thyra::add_scalar(tolAbs, abs_u.ptr());
+      Thyra::abs( *(currentState->getX()), this->abs_u0.ptr());
+      Thyra::abs( *(workingState->getX()), this->abs_u.ptr());
+      Thyra::pair_wise_max_update(tolRel, *this->abs_u0, this->abs_u.ptr());
+      Thyra::add_scalar(tolAbs, this->abs_u.ptr());
 
       //compute: || ee / sc ||
-      assign(sc.ptr(), Teuchos::ScalarTraits<Scalar>::zero());
-      Thyra::ele_wise_divide(Teuchos::as<Scalar>(1.0), *ee_, *abs_u, sc.ptr());
-      Scalar err = std::abs(Thyra::norm_inf(*sc));
+      assign(this->sc.ptr(), Teuchos::ScalarTraits<Scalar>::zero());
+      Thyra::ele_wise_divide(Teuchos::as<Scalar>(1.0), *this->ee_, *this->abs_u, this->sc.ptr());
+      Scalar err = std::abs(Thyra::norm_inf(*this->sc));
       workingState->setErrorRel(err);
 
       // test if step should be rejected
@@ -453,17 +449,16 @@ void StepperExplicitRK<Scalar>::describe(
   out << "  stepperObserver_   = " << stepperObserver_ << std::endl;
 #endif
   out << "  stepperRKAppAction_= " << this->stepperRKAppAction_ << std::endl;
-  out << "  stageX_            = " << this->stageX_ << std::endl;
   out << "  stageXDot_.size()  = " << stageXDot_.size() << std::endl;
   const int numStages = stageXDot_.size();
   for (int i=0; i<numStages; ++i)
     out << "    stageXDot_["<<i<<"] = " << stageXDot_[i] << std::endl;
   out << "  useEmbedded_       = "
-      << Teuchos::toString(useEmbedded_) << std::endl;
-  out << "  ee_                = " << ee_ << std::endl;
-  out << "  abs_u0             = " << abs_u0 << std::endl;
-  out << "  abs_u              = " << abs_u << std::endl;
-  out << "  sc                 = " << sc << std::endl;
+      << Teuchos::toString(this->useEmbedded_) << std::endl;
+  out << "  ee_                = " << this->ee_ << std::endl;
+  out << "  abs_u0             = " << this->abs_u0 << std::endl;
+  out << "  abs_u              = " << this->abs_u << std::endl;
+  out << "  sc                 = " << this->sc << std::endl;
   out << "-------------------------" << std::endl;
 }
 

--- a/packages/tempus/src/Tempus_StepperIMEX_RK_Partition_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RK_Partition_decl.hpp
@@ -429,10 +429,6 @@ public:
     virtual OrderODE getOrderODE()   const {return FIRST_ORDER_ODE;}
   //@}
 
-  /// Return the full stage solution which is Z (the concat of X and Y) for IMEX Partition.
-  Teuchos::RCP<Thyra::VectorBase<Scalar> > getStageX() {return stageZ_;}
-  /// Explicitly return the full stage solution, Z.
-  Teuchos::RCP<Thyra::VectorBase<Scalar> > getStageZ() {return stageZ_;};
   std::vector<Teuchos::RCP<Thyra::VectorBase<Scalar> > >& getStageF() {return stageF_;};
   std::vector<Teuchos::RCP<Thyra::VectorBase<Scalar> > >& getStageGx() {return stageGx_;};
   Teuchos::RCP<Thyra::VectorBase<Scalar> >& getXTilde() {return xTilde_;};
@@ -476,7 +472,6 @@ protected:
 
   Scalar order_;
 
-  Teuchos::RCP<Thyra::VectorBase<Scalar> >               stageZ_;
   std::vector<Teuchos::RCP<Thyra::VectorBase<Scalar> > > stageF_;
   std::vector<Teuchos::RCP<Thyra::VectorBase<Scalar> > > stageGx_;
 

--- a/packages/tempus/src/Tempus_StepperIMEX_RK_Partition_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RK_Partition_impl.hpp
@@ -611,12 +611,11 @@ void StepperIMEX_RK_Partition<Scalar>::takeStep(
 
     bool pass = true;
     Thyra::SolveStatus<Scalar> sStatus;
-    stageZ_ = workingState->getX();
-    Thyra::assign(stageZ_.ptr(), *(currentState->getX()));
+    Thyra::assign(workingState->getX().ptr(), *(currentState->getX()));
     RCP<Thyra::VectorBase<Scalar> > stageY =
-      wrapperModelPairIMEX->getExplicitOnlyVector(stageZ_);
+      wrapperModelPairIMEX->getExplicitOnlyVector(workingState->getX());
     RCP<Thyra::VectorBase<Scalar> > stageX =
-      wrapperModelPairIMEX->getIMEXVector(stageZ_);
+      wrapperModelPairIMEX->getIMEXVector(workingState->getX());
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
     this->stepperObserver_->observeBeginTakeStep(solutionHistory, *this);
@@ -726,7 +725,7 @@ void StepperIMEX_RK_Partition<Scalar>::takeStep(
 #endif
       this->stepperRKAppAction_->execute(solutionHistory, thisStepper,
         StepperRKAppAction<Scalar>::ACTION_LOCATION::BEFORE_EXPLICIT_EVAL);
-      evalExplicitModel(stageZ_, tHats, dt, i, stageF_[i]);
+      evalExplicitModel(workingState->getX(), tHats, dt, i, stageF_[i]);
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
       this->stepperObserver_->observeEndStage(solutionHistory, *this);
 #endif
@@ -795,7 +794,6 @@ void StepperIMEX_RK_Partition<Scalar>::describe(
   if (verbLevel == Teuchos::VERB_HIGH)
    implicitTableau_->describe(out, verbLevel);
   out << "  xTilde_            = " << xTilde_  << std::endl;
-  out << "  stageZ_            = " << stageZ_  << std::endl;
   out << "  stageF_.size()     = " << stageF_.size() << std::endl;
   int numStages = stageF_.size();
   for (int i=0; i<numStages; ++i)

--- a/packages/tempus/src/Tempus_StepperRKBase.hpp
+++ b/packages/tempus/src/Tempus_StepperRKBase.hpp
@@ -42,8 +42,9 @@ public:
   virtual int getStageNumber() const { return stageNumber_; }
   virtual void setStageNumber(int s) { stageNumber_ = s; }
 
-  virtual Teuchos::RCP<Thyra::VectorBase<Scalar> > getStageX() {return stageX_;}
-  virtual Teuchos::RCP<const Thyra::VectorBase<Scalar> > getStageX() const  {return stageX_;}
+  virtual void setUseEmbedded(bool a) { useEmbedded_ = a; }
+  virtual bool getUseEmbedded() const { return useEmbedded_; }
+  virtual bool getUseEmbeddedDefault() const { return false; }
 
   virtual void setAppAction(Teuchos::RCP<StepperRKAppAction<Scalar> > appAction)
   {
@@ -64,9 +65,15 @@ protected:
 
   Teuchos::RCP<RKButcherTableau<Scalar> >   tableau_;
 
+  // For Embedded RK
+  bool useEmbedded_;
+  Teuchos::RCP<Thyra::VectorBase<Scalar> >               ee_;
+  Teuchos::RCP<Thyra::VectorBase<Scalar> >               abs_u0;
+  Teuchos::RCP<Thyra::VectorBase<Scalar> >               abs_u;
+  Teuchos::RCP<Thyra::VectorBase<Scalar> >               sc;
+
   /// The current Runge-Kutta stage number, {0,...,s-1}.  -1 indicates outside stage loop.
   int stageNumber_;
-  Teuchos::RCP<Thyra::VectorBase<Scalar> >  stageX_;
   Teuchos::RCP<StepperRKAppAction<Scalar> > stepperRKAppAction_;
 
 };

--- a/packages/tempus/src/Tempus_StepperRKModifierXBase.hpp
+++ b/packages/tempus/src/Tempus_StepperRKModifierXBase.hpp
@@ -74,54 +74,46 @@ private:
     MODIFIER_TYPE modType = X_BEGIN_STEP;
     const int stageNumber = stepper->getStageNumber();
     Teuchos::SerialDenseVector<int,Scalar> c = stepper->getTableau()->c();
-    RCP<SolutionState<Scalar> > currentState = sh->getCurrentState();
     RCP<SolutionState<Scalar> > workingState = sh->getWorkingState();
     const Scalar dt = workingState->getTimeStep();
-    Scalar time = currentState->getTime();
+    Scalar time = sh->getCurrentState()->getTime();
     if (stageNumber >= 0) time += c(stageNumber)*dt;
-    RCP<Thyra::VectorBase<Scalar> > x;
+    RCP<Thyra::VectorBase<Scalar> > x = workingState->getX();
 
     switch(actLoc) {
       case StepperRKAppAction<Scalar>::BEGIN_STEP:
       {
         modType = X_BEGIN_STEP;
-        x = currentState->getX();
         break;
       }
       case StepperRKAppAction<Scalar>::BEGIN_STAGE:
       {
         modType = X_BEGIN_STAGE;
-        x = workingState->getX();
         break;
       }
       case StepperRKAppAction<Scalar>::BEFORE_SOLVE:
       {
         modType = X_BEFORE_SOLVE;
-        x = workingState->getX();
         break;
       }
       case StepperRKAppAction<Scalar>::AFTER_SOLVE:
       {
         modType = X_AFTER_SOLVE;
-        x = workingState->getX();
         break;
       }
       case StepperRKAppAction<Scalar>::BEFORE_EXPLICIT_EVAL:
       {
         modType = X_BEFORE_EXPLICIT_EVAL;
-        x = stepper->getStageX();
         break;
       }
       case StepperRKAppAction<Scalar>::END_STAGE:
       {
         modType = X_END_STAGE;
-        x = stepper->getStageX();
         break;
       }
       case StepperRKAppAction<Scalar>::END_STEP:
       {
         modType = X_END_STEP;
-        x = workingState->getX();
         time = workingState->getTime();
         break;
       }

--- a/packages/tempus/test/TestModels/DahlquistTestModel_decl.hpp
+++ b/packages/tempus/test/TestModels/DahlquistTestModel_decl.hpp
@@ -46,20 +46,21 @@ class DahlquistTestModel
   /// Exact solution
   Thyra::ModelEvaluatorBase::InArgs<Scalar> getExactSolution(double t) const;
 
+  Scalar getLambda() const { return lambda_; }
+
   /** \name Public functions overridden from ModelEvaluator. */
   //@{
-  Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> > get_x_space() const;
-  Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> > get_f_space() const;
-  Thyra::ModelEvaluatorBase::InArgs<Scalar> getNominalValues() const;
-  //Teuchos::RCP<Thyra::LinearOpWithSolveBase<Scalar> > create_W() const;
-  //Teuchos::RCP<Thyra::LinearOpBase<Scalar> > create_W_op() const;
-  //Teuchos::RCP<const Thyra::LinearOpWithSolveFactoryBase<Scalar> > get_W_factory() const;
-  Thyra::ModelEvaluatorBase::InArgs<Scalar> createInArgs() const;
+    Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> > get_x_space() const;
+    Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> > get_f_space() const;
+    Thyra::ModelEvaluatorBase::InArgs<Scalar> getNominalValues() const;
+    //Teuchos::RCP<Thyra::LinearOpWithSolveBase<Scalar> > create_W() const;
+    //Teuchos::RCP<Thyra::LinearOpBase<Scalar> > create_W_op() const;
+    //Teuchos::RCP<const Thyra::LinearOpWithSolveFactoryBase<Scalar> > get_W_factory() const;
+    Thyra::ModelEvaluatorBase::InArgs<Scalar> createInArgs() const;
 
-  //Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> > get_p_space(int l) const;
-  //Teuchos::RCP<const Teuchos::Array<std::string> > get_p_names(int l) const;
-  //Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> > get_g_space(int j) const;
-
+    //Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> > get_p_space(int l) const;
+    //Teuchos::RCP<const Teuchos::Array<std::string> > get_p_names(int l) const;
+    //Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> > get_g_space(int j) const;
   //@}
 
 private:

--- a/packages/tempus/test/TestModels/DahlquistTestModel_impl.hpp
+++ b/packages/tempus/test/TestModels/DahlquistTestModel_impl.hpp
@@ -31,7 +31,7 @@ DahlquistTestModel(Scalar lambda)
 {
   isInitialized_ = false;
   int dim = 1;
-  Scalar xIC_ = Scalar(1.0);
+  xIC_ = Scalar(1.0);
 
   // Create x_space and f_space
   x_space_ = Thyra::defaultSpmdVectorSpace<Scalar>(dim);


### PR DESCRIPTION
Add unit tests to further test the StepperRKAppActions for ExplicitRK
with FSAL on/off, with embedded error estimation, and solver failures.

Miscellaneous:

 * Removed stageX_ as it was an alias to workingState in the RK methods,
   and was causing confusion.
 * Moved set/getUseEmbedded() and associated RK error data to RKBase.
 * Cleaned up accessing xDot within the ExplicitRK methods.
 * Removed stageZ_ from the IMEX methods as it was an alias to
   workingState and was causing confusion.

All tests pass on a Mac/GCC.

@trilinos/tempus 

## Motivation
Provide additional testing for the RKAppAction for Explicit RK methods, especially for FSAL, embedded error estimation, and timestep failure.

## Related Issues

* Closes #7770 

## Stakeholder Feedback
@seamill is the requestor and stakeholder who wanted these additional tests.

## Testing
New tests have been added to test the RKAppAction interface.