### PR TITLE
Tpetra: optionally disable ownership check in FECrsGraph

### DIFF
--- a/packages/tpetra/core/src/Tpetra_FECrsGraph_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_FECrsGraph_decl.hpp
@@ -459,6 +459,13 @@ namespace Tpetra {
     virtual ~FECrsGraph () = default;
 
     //@}
+    //! @name Implementation of Teuchos::ParameterListAcceptor
+    //@{
+    //! Default parameter list suitable for validation.
+    Teuchos::RCP<const Teuchos::ParameterList>
+    getValidParameters () const override;
+
+    //@}
     //! @name Collective methods for changing the graph's global state
     //@{
 

--- a/packages/tpetra/core/src/Tpetra_FECrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_FECrsGraph_def.hpp
@@ -392,6 +392,17 @@ void FECrsGraph<LocalOrdinal, GlobalOrdinal, Node>::beginFill() {
 
 }
 
+template <class LocalOrdinal, class GlobalOrdinal, class Node>
+Teuchos::RCP<const Teuchos::ParameterList>
+FECrsGraph<LocalOrdinal, GlobalOrdinal, Node>::getValidParameters () const
+{
+  auto valid_pl = Teuchos::rcp(new Teuchos::ParameterList("Tpetra::FECrsGraph"));
+  valid_pl->validateParametersAndSetDefaults(*crs_graph_type::getValidParameters());
+  valid_pl->set("Enforce At Least One Owned Col Index Per Row",true);
+
+  return valid_pl;
+}
+
 }  // end namespace Tpetra
 
 


### PR DESCRIPTION
The user is now allowed to disable the check that ensures that for each
owned element, there is at least one owned node. This check is helpful
to keep the column map optimally sized, but for some application it might
be difficult to rearrange the mesh ownership, to the point that it might
be easier to accept a small performance hit during mat-vec product (due
to import of not needed gids).

Fixes #7697.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
The FECrsGraph class checks (in debug mode) that there are no owned elements for which none of the nodes is owned, since it means we will import unnecessary entries during mat-vec products.
However, some apps (in this case, Albany) may be dealing with meshes coming from TPLs, and/or might have a hard time redistributing mesh entities, so that this does not occur. While we want them to fix their meshes (to avoid perf loss), it might be hard for them (at least in the short term) to do so, perhaps since their mesh structs are quite involved, and there are only a handful of such "bad" elements, so they might be willing to accept the (small) perf hit rather than rearranging the mesh.

Also, fixing the way the check is carried out, by performing a reduction over the graph's comm, so that if one rank fails, all the ranks in the comm group are notified, and are not left hanging (as it is done already in several other checks in Tpetra).

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

-->
## Related Issues

* Closes 7697

## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
This PR should _not_ affect existing code, since the default behavior is to still perform the check. The client Albany is however using this feature, and _does_ have meshes with this kind of "bad" elements. Tests are passing in Albany using this feature (they were not before).
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->