### PR TITLE
Zoltan2: Clean up subview issues

### DIFF
--- a/packages/zoltan2/core/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
+++ b/packages/zoltan2/core/src/algorithms/partition/Zoltan2_AlgMultiJagged.hpp
@@ -6536,12 +6536,8 @@ void AlgMJ<mj_scalar_t, mj_lno_t, mj_gno_t, mj_part_t, mj_node_t>::
       auto host_dst_coordinates = Kokkos::create_mirror_view(
         Kokkos::HostSpace(), dst_coordinates);
       for(int i = 0; i < this->coord_dim; ++i) {
-        Kokkos::View<mj_scalar_t*, Kokkos::HostSpace> sub_host_src_coordinates;
-        // view could be size 0 if graph was not distributed
-        if(host_src_coordinates.extent(0) != 0) {
-          sub_host_src_coordinates =
-            Kokkos::subview(host_src_coordinates, Kokkos::ALL, i);
-        }
+        Kokkos::View<mj_scalar_t*, Kokkos::HostSpace> sub_host_src_coordinates
+          = Kokkos::subview(host_src_coordinates, Kokkos::ALL, i);
         Kokkos::View<mj_scalar_t *, Kokkos::HostSpace> sub_host_dst_coordinates
           = Kokkos::subview(host_dst_coordinates, Kokkos::ALL, i);
         // Note Layout Left means we can do these in contiguous blocks
@@ -6692,13 +6688,8 @@ void AlgMJ<mj_scalar_t, mj_lno_t, mj_gno_t, mj_part_t, mj_node_t>::
       Kokkos::HostSpace(), this->mj_coordinates);
     Kokkos::deep_copy(host_src_coordinates, this->mj_coordinates);
     for(int i = 0; i < this->coord_dim; ++i) {
-      Kokkos::View<mj_scalar_t*, Kokkos::HostSpace> sub_host_src_coordinates;
-      // view could be size 0 if graph was not distributed
-      if(host_src_coordinates.extent(0) != 0) {
-        sub_host_src_coordinates =
-          Kokkos::subview(host_src_coordinates, Kokkos::ALL, i);
-      }
-
+      Kokkos::View<mj_scalar_t*, Kokkos::HostSpace> sub_host_src_coordinates
+        = Kokkos::subview(host_src_coordinates, Kokkos::ALL, i);
       auto sub_host_dst_coordinates
         = Kokkos::subview(host_dst_coordinates, Kokkos::ALL, i);
       // Note Layout Left means we can do these in contiguous blocks
@@ -7899,12 +7890,8 @@ void AlgMJ<mj_scalar_t, mj_lno_t, mj_gno_t, mj_part_t, mj_node_t>::
     // get the coordinate axis along which the partitioning will be done.
     int coordInd = i % this->coord_dim;
 
-    Kokkos::View<mj_scalar_t *, device_t> mj_current_dim_coords;
-    // view could be size 0 if graph was not distributed
-    if(this->mj_coordinates.extent(0) != 0) {
-      mj_current_dim_coords =
-        Kokkos::subview(this->mj_coordinates, Kokkos::ALL, coordInd);
-    }
+    Kokkos::View<mj_scalar_t *, device_t> mj_current_dim_coords =
+      Kokkos::subview(this->mj_coordinates, Kokkos::ALL, coordInd);
 
     this->mj_env->timerStart(MACRO_TIMERS,
       mj_timer_base_string + "Problem_Partitioning_" + istring);

--- a/packages/zoltan2/core/src/models/Zoltan2_CoordinateModel.hpp
+++ b/packages/zoltan2/core/src/models/Zoltan2_CoordinateModel.hpp
@@ -314,15 +314,14 @@ void CoordinateModel<Adapter>::sharedConstructor(
   env_->localMemoryAssertion(__FILE__, __LINE__, userNumWeights_+coordinateDim_,
     coordArray && (!userNumWeights_|| weightArray));
 
+  ia->getIDsKokkosView(kokkos_gids_);
+  ia->getCoordinatesKokkosView(kokkos_xyz_);
+
+  if(userNumWeights_ > 0) {
+    ia->getWeightsKokkosView(kokkos_weights_);
+  }
 
   if (nLocalIds){
-
-    ia->getIDsKokkosView(kokkos_gids_);
-    ia->getCoordinatesKokkosView(kokkos_xyz_);
-    if(userNumWeights_ > 0) {
-      ia->getWeightsKokkosView(kokkos_weights_);
-    }
-
     const gno_t *gids=NULL;
 
     ia->getIDsView(gids);


### PR DESCRIPTION
Change empty subviews to be allocated with second extent.
So extent(0) and extent(1) could be 0,2 respectively, instead of 0,0.
Then MJ can still take the subview and proceed naturally
without making extra checks.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/zoltan2

@kddevin This is to clean up an issue we had discussed months ago.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Cuda white and Mac parallel/serial builds. Zoltan2 MJ tests.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->