### PR TITLE
FEI patch for astra from Mike glass.

### DIFF
--- a/packages/fei/base/fei_EqnCommMgr.cpp
+++ b/packages/fei/base/fei_EqnCommMgr.cpp
@@ -741,6 +741,11 @@ void EqnCommMgr::exchangeSoln()
 }
 
 //------------------------------------------------------------------------------
+// This works around an issue with the ARMHPC 20.1 compiler
+// Needs to be revisited with later versions
+#ifdef __ARM_HPC_COMPILER_VERSION__
+__attribute__((optnone))
+#endif
 int EqnCommMgr::mirrorProcEqns(ProcEqns& inProcEqns, ProcEqns& outProcEqns)
 {
   //Beginning assumption: we (the local processor) have a populated ProcEqns


### PR DESCRIPTION
From his email -

I don't know if any other ASC apps are using the FEI package in Trilinos but we (Sierra) have come across a compiler issue on stria related to this package. We're using the ARMHPC 20.1 toolset. The following is our work around. Can this get incorporated into the Trilinos repo?

## Motivation
This is required for the 20.1 toolset on astra - see above

## Testing
This came in from the Sierra project and was tested via their work. Currently none of the dashboard lines on astra build FEI, so any additional testing will need to be done by hand or fed added.