### PR TITLE
ATDM: Unload yaml-cpp module for arm-20.1 env (#7778)

### DIFF
--- a/cmake/std/atdm/van1-tx2/environment.sh
+++ b/cmake/std/atdm/van1-tx2/environment.sh
@@ -77,6 +77,7 @@ if [[ "$ATDM_CONFIG_COMPILER" == "ARM-20.0_OPENMPI-4.0.2" ]]; then
   module load git/2.19.2
 elif [[ "$ATDM_CONFIG_COMPILER" == "ARM-20.1_OPENMPI-4.0.3" ]]; then
   module load sparc-dev/arm-20.1_openmpi-4.0.3
+  module unload yaml-cpp
 
   if [ "$ATDM_CONFIG_NODE_TYPE" == "OPENMP" ] ; then
     unset OMP_PLACES


### PR DESCRIPTION
Fixes the build error with Sacado on van1-txt2 reported in #7778 

## How was this tested?

On 'stria' I did:

```
$ env Trilinos_PACKAGES=Sacado ./ctest-s-local-test-driver.sh \
  van1-tx2_arm-20.0_openmpi-4.0.2_openmp_static_opt

***
*** ./ctest-s-local-test-driver.sh
***

ATDM_TRILINOS_DIR = '/lustre/rabartl/Trilinos.base/Trilinos'

Load some env to get python, cmake, etc ...

Hostname 'stria-login1' matches known ATDM host 'stria-login1' and system 'van1-tx2'
Setting compiler and build options for build-name 'default'
Using ARM ATSE compiler stack ARM-20.0_OPENMPI-4.0.2 to build DEBUG code with Kokkos node type SERIAL

Running builds:
    van1-tx2_arm-20.0_openmpi-4.0.2_openmp_static_opt

Wed Aug  5 10:51:47 MDT 2020

Running Jenkins driver Trilinos-atdm-van1-tx2_arm-20.0_openmpi-4.0.2_openmp_static_opt.sh ...

    See log file Trilinos-atdm-van1-tx2_arm-20.0_openmpi-4.0.2_openmp_static_opt/smart-jenkins-driver.out

real    6m2.171s
user    0m40.871s
sys     1m10.967s

100% tests passed, 0 tests failed out of 301

Wed Aug  5 10:57:49 MDT 2020

Done running all of the builds!
```

which submitted to:

* https://testing.sandia.gov/cdash/index.php?project=Trilinos&date=2020-08-05&filtercount=2&showfilters=1&filtercombine=and&field1=buildname&compare1=61&value1=Trilinos-atdm-van1-tx2_arm-20.0_openmpi-4.0.2_openmp_static_opt-exp&field2=buildstamp&compare2=61&value2=20200805-1652-Experimental

showing:


| Site | Build Name | Conf Err | Conf Warn | Conf Test Time | Build Err | Build Warn | Build Test Time | Test Not Run | Test Fail | Test Pass | Test Time | Test Proc Time | Start Test Time | Labels |
| -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- |
stria | Trilinos-atdm-van1-tx2_arm-20.0_openmpi-4.0.2_openmp_static_opt-exp | 0 | 3 | 1m 10s | 0 | 0 | 2m 50s | 0 | 0 | 301 | 58s | 14m 21s | 1 hour ago | Sacado



