### PR TITLE
Ifpack2: Fence review

### DIFF
--- a/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
@@ -955,6 +955,7 @@ namespace KB = KokkosBatched::Experimental;
         for (local_ordinal_type i=0,iend=pids.send.extent(0);i<iend;++i) {
           copy<ToBuffer>(lids.send, buffer.send, offset_host.send(i), offset_host.send(i+1),
                          mv, blocksize);
+          // FENCE REVIEW: I moved this fence here and I think will be permanent for isend
           Kokkos::fence();
           isend(comm,
                 reinterpret_cast<const char*>(buffer.send.data() + offset_host.send[i]*mv_blocksize),

--- a/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
+++ b/packages/ifpack2/src/Ifpack2_BlockTriDiContainer_impl.hpp
@@ -804,6 +804,7 @@ namespace KB = KokkosBatched::Experimental;
           // CUDA_SAFE_CALL(cudaStreamAddCallback(stream_at_i, callback_isend, (void*)&data_at_i, 0));
         }
 
+        // FENCE REVIEW: Not Tested (in #ifdef IFPACK2_BLOCKTRIDICONTAINER_USE_CUDA_STREAM)
         Kokkos::fence();
 #if defined (KOKKOS_ENABLE_OPENMP)
 #pragma omp parallel for
@@ -853,6 +854,8 @@ namespace KB = KokkosBatched::Experimental;
         }
 
         // 1. fire up all cuda events
+
+        // FENCE REVIEW: Not Tested (in #ifdef IFPACK2_BLOCKTRIDICONTAINER_USE_CUDA_STREAM)
         Kokkos::fence();
 
         // 2. cleanup all open comm

--- a/packages/ifpack2/src/Ifpack2_Container_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Container_def.hpp
@@ -317,6 +317,8 @@ void ContainerImpl<MatrixType, LocalScalarType>::DoGSBlock(
     //Use the KokkosSparse internal matrix for low-overhead values/indices access
     //But, can only do this if the matrix is accessible directly from host, since it's not a DualView
     using container_exec_space = typename ContainerImpl<MatrixType, LocalScalarType>::crs_matrix_type::execution_space;
+
+    // FENCE REVIEW: Not Tested
     container_exec_space().fence();
     auto localA = this->inputCrsMatrix_->getLocalMatrix();
     using size_type = typename crs_matrix_type::local_matrix_type::size_type;

--- a/packages/ifpack2/src/Ifpack2_Details_MultiVectorLocalGatherScatter.hpp
+++ b/packages/ifpack2/src/Ifpack2_Details_MultiVectorLocalGatherScatter.hpp
@@ -101,6 +101,8 @@ public:
     using Teuchos::ArrayRCP;
     const size_t numRows = X_out.getLocalLength ();
     const size_t numVecs = X_in.getNumVectors ();
+
+    // FENCE REVIEW: Not Tested
     Kokkos::fence();
     for (size_t j = 0; j < numVecs; ++j) {
       ArrayRCP<const InScalar> X_in_j = X_in.getData(j);
@@ -126,6 +128,8 @@ public:
     using Teuchos::ArrayRCP;
     const size_t numBlocks = X_out.getLocalLength() / blockSize;
     const size_t numVecs = X_in.getNumVectors ();
+
+    // FENCE REVIEW: Not Tested
     Kokkos::fence();
     for (size_t j = 0; j < numVecs; ++j) {
       ArrayRCP<const InScalar> X_in_j = X_in.getData(j);
@@ -148,6 +152,8 @@ public:
     using Teuchos::ArrayRCP;
     const size_t numRows = X_out.getLocalLength();
     const size_t numVecs = X_in.getNumVectors();
+
+    // FENCE REVIEW: Not Tested
     Kokkos::fence();
     for (size_t j = 0; j < numVecs; ++j) {
       ArrayRCP<InScalar> X_in_j = X_in.getDataNonConst(j);
@@ -170,7 +176,10 @@ public:
     using Teuchos::ArrayRCP;
     const size_t numBlocks = X_out.getLocalLength() / blockSize;
     const size_t numVecs = X_in.getNumVectors ();
+
+    // FENCE REVIEW: Not Tested
     Kokkos::fence();
+
     for (size_t j = 0; j < numVecs; ++j) {
       ArrayRCP<const InScalar> X_in_j = X_in.getData(j);
       ArrayRCP<OutScalar> X_out_j = X_out.getDataNonConst(j);
@@ -193,6 +202,8 @@ public:
                         const Teuchos::ArrayView<const LO> perm) const
   {
     //note: j is col, i is row
+
+    // FENCE REVIEW: Fails without fence Ifpack2_unit_tests_MPI_4
     Kokkos::fence(); // demonstrated via unit test failure
     for(size_t j = 0; j < X_out.extent(1); ++j) {
       for(size_t i = 0; i < X_out.extent(0); ++i) {
@@ -207,6 +218,7 @@ public:
                          const OutView X_out,
                          const Teuchos::ArrayView<const LO> perm) const
   {
+    // FENCE REVIEW: Passing without fence
     Kokkos::fence();
     for(size_t j = 0; j < X_out.extent(1); ++j) {
       for(size_t i = 0; i < X_out.extent(0); ++i) {
@@ -223,6 +235,8 @@ public:
                              LO blockSize) const
   {
     //note: j is col, i is row
+
+    // FENCE REVIEW: Fails without fence Ifpack2_unit_tests_MPI_4
     Kokkos::fence();
     size_t numBlocks = X_out.extent(0) / blockSize;
     for(size_t j = 0; j < X_out.extent(1); ++j) {
@@ -242,6 +256,8 @@ public:
                               LO blockSize) const
   {
     //note: j is col, i is row
+
+    // FENCE REVIEW: Passing without fence
     Kokkos::fence();
     size_t numBlocks = X_out.extent(0) / blockSize;
     for(size_t j = 0; j < X_out.extent(1); ++j) {
@@ -263,6 +279,8 @@ public:
                       const Teuchos::ArrayView<const LO> perm) const
   {
     //note: j is col, i is row
+
+    // FENCE REVIEW: Passing without fence
     Kokkos::fence();
     size_t numRows = X_out.getLocalLength();
     for(size_t j = 0; j < X_out.getNumVectors(); ++j) {
@@ -280,6 +298,8 @@ public:
                        const Teuchos::ArrayView<const LO> perm) const
   {
     size_t numRows = X_out.getLocalLength(); 
+
+    // FENCE REVIEW: Passing without fence
     Kokkos::fence();
     for(size_t j = 0; j < X_in.extent(1); ++j) {
       Teuchos::ArrayRCP<const OutScalar> X_out_j = X_out.getData(j);
@@ -298,6 +318,8 @@ public:
   {
     //note: j is col, i is row
     size_t numBlocks = X_out.getLocalLength() / blockSize;
+
+    // FENCE REVIEW: Not Tested
     Kokkos::fence();
     for(size_t j = 0; j < X_out.getNumVectors(); ++j) {
       Teuchos::ArrayRCP<OutScalar> X_out_j = X_out.getDataNonConst(j);
@@ -317,6 +339,8 @@ public:
                             LO blockSize) const
   {
     size_t numBlocks = X_out.getLocalLength() / blockSize;
+
+    // FENCE REVIEW: Not Tested
     Kokkos::fence();
     for(size_t j = 0; j < X_in.extent(1); ++j) {
       Teuchos::ArrayRCP<const OutScalar> X_out_j = X_out.getData(j);

--- a/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_LocalSparseTriangularSolver_def.hpp
@@ -442,6 +442,7 @@ initialize ()
     decltype(val)                           newval ("val", val.extent (0));
 
     // FIXME: The code below assumes UVM
+    // FENCE REVIEW: Not Tested
     typename crs_matrix_type::execution_space().fence();
     newptr(0) = 0;
     for (local_ordinal_type row = 0, rowStart = 0; row < numRows; ++row) {
@@ -455,6 +456,8 @@ initialize ()
       rowStart += numEnt;
       newptr(row+1) = rowStart;
     }
+
+    // FENCE REVIEW: Not Tested
     typename crs_matrix_type::execution_space().fence();
 
     // Reverse maps


### PR DESCRIPTION
@trilinos/ifpack2

@kddevin @brian-kelley @csiefer2 

This is part of ongoing work to evaluate and fix packages for CUDA_LAUNCH_BLOCKING=0.
This PR is not intended for actual submission and is created for comment purposes.

- Some fences are marked Not Tested if they are not exercised by a unit test.
- Some fences are marked Passing if the current unit tests would pass without the fence (though the fence is most likely necessary).
- Some fences cause a test failure when removed and are marked with the relevant test.



@brian-kelley Note this will add some further clarity on the scatter methods as some were not tested and some are tested but don't currently fail without the fence. I expect we do need all those fences until we refactor to kernels.