### PR TITLE
Piro: some improvements to Tempus Observer and Tempus Solver

### DIFF
--- a/packages/piro/src/Piro_ObserverToTempusIntegrationObserverAdapter_Def.hpp
+++ b/packages/piro/src/Piro_ObserverToTempusIntegrationObserverAdapter_Def.hpp
@@ -93,6 +93,8 @@ observeStartIntegrator(const Tempus::Integrator<Scalar>& integrator)
        << "============================================================================\n"
        << "  Step       Time         dt  Abs Error  Rel Error  Order  nFail  dCompTime"
        << std::endl;
+
+  this->observeTimeStep();
 }
 
 template <typename Scalar>
@@ -108,7 +110,7 @@ void
 Piro::ObserverToTempusIntegrationObserverAdapter<Scalar>::
 observeNextTimeStep(const Tempus::Integrator<Scalar>& )
 {
-  this->observeTimeStep();
+  //Nothing to do
 }
 
 template <typename Scalar>
@@ -143,7 +145,6 @@ void
 Piro::ObserverToTempusIntegrationObserverAdapter<Scalar>::
 observeEndTimeStep(const Tempus::Integrator<Scalar>& integrator)
 {
-
   using Teuchos::RCP;
   RCP<Tempus::SolutionStateMetaData<Scalar> > csmd =
     integrator.getSolutionHistory()->getCurrentState()->getMetaData();
@@ -168,6 +169,7 @@ observeEndTimeStep(const Tempus::Integrator<Scalar>& integrator)
         <<std::setw(11)<<std::setprecision(3)<<steppertime
         <<std::endl;
   }
+  this->observeTimeStep();
 }
 
 
@@ -176,7 +178,7 @@ void
 Piro::ObserverToTempusIntegrationObserverAdapter<Scalar>::
 observeEndIntegrator(const Tempus::Integrator<Scalar>& integrator)
 {
-  this->observeTimeStep();
+  //this->observeTimeStep();
 
   std::string exitStatus;
   //const Scalar runtime = integrator.getIntegratorTimer()->totalElapsedTime();

--- a/packages/piro/src/Piro_TempusSolver_Def.hpp
+++ b/packages/piro/src/Piro_TempusSolver_Def.hpp
@@ -252,36 +252,17 @@ void Piro::TempusSolver<Scalar>::initialize(
       stepperType == "SSPERK54" ||
       stepperType == "General ERK" ) {
 
-      bool invertMassMatrix = tempusPL->get("Invert Mass Matrix", true);
-      if (!invertMassMatrix) {
-        TEUCHOS_TEST_FOR_EXCEPTION(
-          true,
-          Teuchos::Exceptions::InvalidParameter,
-          "\n Error! Piro::TempusSolver: You are attempting to run \n" 
-	  << "Explicit Stepper (" << stepperType << ") with 'Invert Mass Matrix' set to 'false'. \n" 
-	  << "This option should be set to 'true' for time-integration to work correctly.\n");
-      }
-      else {
-        Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > origModel = model_;
-        model_ = Teuchos::rcp(new Piro::InvertMassMatrixDecorator<Scalar>(
-        sublist(tempusPL,"Stratimikos", true), origModel, true, tempusPL->get("Lump Mass Matrix", false),false));
-      }
+      Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > origModel = model_;
+      model_ = Teuchos::rcp(new Piro::InvertMassMatrixDecorator<Scalar>(
+      sublist(tempusPL,"Stratimikos", true), origModel, true, tempusPL->get("Lump Mass Matrix", false),false));
     }
 
     //Explicit time-integrators for 2nd order ODEs
     //IKT, FIXME: fill this in as more explicit integrators for 2nd order ODEs are added to Tempus.
     else if (stepperType == "Newmark Explicit a-Form") {
-      bool invertMassMatrix = tempusPL->get("Invert Mass Matrix", false); 
-      if (!invertMassMatrix) {
-        *out_ << "\n WARNING in Piro::TempusSolver!  You are attempting to run \n" 
-             << "'Newmark Explicit a-Form' Stepper with 'Invert Mass Matrix' set to 'false'. \n" 
-             << "This option should be set to 'true' unless your mass matrix is the identiy.\n"; 
-      }
-      else {
-        Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > origModel = model_;
-        model_ = Teuchos::rcp(new Piro::InvertMassMatrixDecorator<Scalar>(
-          sublist(tempusPL,"Stratimikos", true), origModel, true, tempusPL->get("Lump Mass Matrix", false),true));
-      }
+      Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > origModel = model_;
+      model_ = Teuchos::rcp(new Piro::InvertMassMatrixDecorator<Scalar>(
+        sublist(tempusPL,"Stratimikos", true), origModel, true, tempusPL->get("Lump Mass Matrix", false),true));
     }
     // C.2) Create the Thyra-wrapped ModelEvaluator
 

--- a/packages/piro/src/Piro_TempusSolver_Def.hpp
+++ b/packages/piro/src/Piro_TempusSolver_Def.hpp
@@ -252,11 +252,14 @@ void Piro::TempusSolver<Scalar>::initialize(
       stepperType == "SSPERK54" ||
       stepperType == "General ERK" ) {
 
-      bool invertMassMatrix = tempusPL->get("Invert Mass Matrix", false); 
+      bool invertMassMatrix = tempusPL->get("Invert Mass Matrix", true);
       if (!invertMassMatrix) {
-        *out_ << "\n WARNING in Piro::TempusSolver!  You are attempting to run \n" 
-             << "Explicit Stepper (" << stepperType << ") with 'Invert Mass Matrix' set to 'false'. \n" 
-             << "This option should be set to 'true' unless your mass matrix is the identiy.\n"; 
+        TEUCHOS_TEST_FOR_EXCEPTION(
+          true,
+          Teuchos::Exceptions::InvalidParameter,
+          "\n Error! Piro::TempusSolver: You are attempting to run \n" 
+	  << "Explicit Stepper (" << stepperType << ") with 'Invert Mass Matrix' set to 'false'. \n" 
+	  << "This option should be set to 'true' for time-integration to work correctly.\n");
       }
       else {
         Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > origModel = model_;

--- a/packages/tempus/src/Tempus_StepperExplicit_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperExplicit_impl.hpp
@@ -259,10 +259,8 @@ evaluateExplicitODE(Teuchos::RCP<      Thyra::VectorBase<Scalar> > xDot,
   if (inArgs_.supports(MEB::IN_ARG_x_dot)) inArgs_.set_x_dot(Teuchos::null);
 
   outArgs_.set_f(xDot);
- 
-  std::cout << "IKT evaluateExplicitODE before evalModel time = " << time << "\n"; 
+
   appModel_->evalModel(inArgs_, outArgs_);
-  std::cout << "IKT after evalModel \n"; 
 }
 
 template<class Scalar>
@@ -294,9 +292,7 @@ evaluateExplicitODE(Teuchos::RCP<      Thyra::VectorBase<Scalar> > xDotDot,
 
   outArgs_.set_f(xDotDot);
 
-  std::cout << "IKT evaluateExplicitODE before evalModel time = " << time << "\n"; 
   appModel_->evalModel(inArgs_, outArgs_);
-  std::cout << "IKT after evalModel \n"; 
 }
 
 

--- a/packages/tempus/src/Tempus_StepperExplicit_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperExplicit_impl.hpp
@@ -259,8 +259,10 @@ evaluateExplicitODE(Teuchos::RCP<      Thyra::VectorBase<Scalar> > xDot,
   if (inArgs_.supports(MEB::IN_ARG_x_dot)) inArgs_.set_x_dot(Teuchos::null);
 
   outArgs_.set_f(xDot);
-
+ 
+  std::cout << "IKT evaluateExplicitODE before evalModel time = " << time << "\n"; 
   appModel_->evalModel(inArgs_, outArgs_);
+  std::cout << "IKT after evalModel \n"; 
 }
 
 template<class Scalar>
@@ -292,7 +294,9 @@ evaluateExplicitODE(Teuchos::RCP<      Thyra::VectorBase<Scalar> > xDotDot,
 
   outArgs_.set_f(xDotDot);
 
+  std::cout << "IKT evaluateExplicitODE before evalModel time = " << time << "\n"; 
   appModel_->evalModel(inArgs_, outArgs_);
+  std::cout << "IKT after evalModel \n"; 
 }
 
 


### PR DESCRIPTION
A few changes to Tempus observer in Piro, to be consistent with how observing was intended to be done in Tempus.

Removing 'Invert Mass Matrix' option Piro::TempusSolver.  This option was confusing/misleading, and there is no real case where that should be set to 'false'. 