### PR TITLE
Ifpack2: Use sync_host instead of fence

### DIFF
--- a/packages/ifpack2/src/Ifpack2_Experimental_RBILUK_def.hpp
+++ b/packages/ifpack2/src/Ifpack2_Experimental_RBILUK_def.hpp
@@ -836,6 +836,7 @@ apply (const Tpetra::MultiVector<scalar_type,local_ordinal_type,global_ordinal_t
         const local_ordinal_type numVectors = xBlock.getNumVectors();
         BMV cBlock (* (A_block_->getGraph ()->getDomainMap ()), blockSize_, numVectors);
         BMV rBlock (* (A_block_->getGraph ()->getDomainMap ()), blockSize_, numVectors);
+        cBlock.sync_host();
         for (local_ordinal_type imv = 0; imv < numVectors; ++imv)
         {
           for (size_t i = 0; i < D_block_->getNodeNumRows(); ++i)
@@ -870,7 +871,7 @@ apply (const Tpetra::MultiVector<scalar_type,local_ordinal_type,global_ordinal_t
         D_block_->applyBlock(cBlock, rBlock);
 
         // Solve U Y = R.
-        Kokkos::fence(); // UVM access
+        rBlock.sync_host();
         for (local_ordinal_type imv = 0; imv < numVectors; ++imv)
         {
           const local_ordinal_type numRows = D_block_->getNodeNumRows();


### PR DESCRIPTION
@trilinos/ifpack2

@brian-kelley I expect we should use sync_host here instead of fence. Possibly this would eventually go to a kernel anyways.

 I'm not sure about the proper application of modify_host here.

Tested on Cuda white.