### PR TITLE
Adds logic for MPI builds where MPI has not been initialized

### DIFF
--- a/packages/teuchos/numerics/src/Teuchos_SerialDenseHelpers.hpp
+++ b/packages/teuchos/numerics/src/Teuchos_SerialDenseHelpers.hpp
@@ -57,6 +57,7 @@
 
 #include "Teuchos_CommHelpers.hpp"
 #include "Teuchos_DefaultComm.hpp"
+#include "Teuchos_DefaultSerialComm.hpp"
 
 namespace Teuchos {
 
@@ -193,8 +194,18 @@ bool setCol( const SerialDenseVector<OrdinalType, ScalarType>& v,
 template <typename OrdinalType, typename ScalarType>
 void randomSyncedMatrix( Teuchos::SerialDenseMatrix<OrdinalType, ScalarType>& A )
 {
-  Teuchos::RCP<const Teuchos::Comm<OrdinalType> >
+  Teuchos::RCP<const Teuchos::Comm<OrdinalType> > comm;
+
+#ifdef HAVE_MPI
+  int mpiStarted = 0;
+  MPI_Initialized(&mpiStarted);
+  if (mpiStarted)
     comm = Teuchos::DefaultComm<OrdinalType>::getComm();
+  else 
+    comm = rcp(new Teuchos::SerialComm<OrdinalType>);
+#else
+  comm = Teuchos::DefaultComm<OrdinalType>::getComm();
+#endif
 
   const OrdinalType procRank = rank(*comm);
 


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/teuchos 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
If you use an MPI build of Trilinos, but only perform single node execution, this class will crash in the situation where MPI has not been initialized.  So, a different communicator needs to be used for this situation.  Now the method checks if it's an MPI build and if MPI has been initialized before using an MPI communicator.  Otherwise, it uses a serial communicator. 

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Tested on OSX, with OpenMPI and Clang compilers

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->