### PR TITLE
SEACAS IOSS: Add environment variable to set common_nodes to 2

### DIFF
--- a/packages/seacas/libraries/ioss/src/Ioss_Decomposition.C
+++ b/packages/seacas/libraries/ioss/src/Ioss_Decomposition.C
@@ -135,6 +135,12 @@ namespace {
     Ioss::ParallelUtils par_util(comm);
     common_nodes = par_util.global_minmax(common_nodes, Ioss::ParallelUtils::DO_MIN);
 
+    // Overwrite common_nodes if user wants to set it to 2
+    char *envVar = getenv("IOSS_PARMETIS_TWO_COMMON_NODES");
+    if(envVar != nullptr && common_nodes > 2) {
+      common_nodes = 2;
+    }
+
 #if IOSS_DEBUG_OUTPUT
     fmt::print(Ioss::DEBUG(), "Setting common_nodes to {}\n", common_nodes);
 #endif


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/seacas @cgcgcg @egboman 


## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
This PR adds the option of using common_nodes=2, which will be used when constructing the dual graph in ParMETIS_V3_PartMeshKway.  When common_nodes=2, elements which share a common edge are connected in the dual graph. This will increase the number of connections in the dual graph (unless the elements are triangular), so captures the total communication volume more correctly in the case of an edge-based discretization.

I obtained up to 10% improvement in the solve time when I used common_nodes=2 on a tetrahedral mesh.

The matching PR in the seacas repo: https://github.com/gsjaardema/seacas/pull/184
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->