### PR TITLE
Tacho - c++14 compiler bug workaround

### DIFF
--- a/packages/shylu/shylu_node/tacho/src/Tacho_CrsMatrixBase.hpp
+++ b/packages/shylu/shylu_node/tacho/src/Tacho_CrsMatrixBase.hpp
@@ -353,7 +353,7 @@ namespace Tacho {
 
           Kokkos::parallel_for
             (Kokkos::TeamVectorRange(member, nk),
-             [&](const ordinal_type &k) {
+             [&,kbeg,colbeg](const ordinal_type &k) { /// compiler bug with c++14 lambda capturing and workaround
               const ordinal_type tk = kbeg+k, sk = colbeg+k;
               aj(tk) = peri(B.Col(sk));
               ax(tk) = B.Value(sk);

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Blas_Team.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Blas_Team.hpp
@@ -116,7 +116,7 @@ namespace Tacho {
                        /* */ T *__restrict__ a, int as0, int as1) {
           Kokkos::parallel_for(Kokkos::TeamThreadRange(member,n),[&](const int &j) {
               const int jj = j + offset;
-              Kokkos::parallel_for(Kokkos::ThreadVectorRange(member,n-j-offset),[&](const int &i) {
+              Kokkos::parallel_for(Kokkos::ThreadVectorRange(member,n-j-offset),[&,alpha,as0,as1,j,jj](const int &i) { /// compiler bug with c++14 lambda capturing and workaround
                   a[(i+jj)*as0+j*as1] = alpha;
                 });
             });
@@ -131,7 +131,7 @@ namespace Tacho {
                          /* */ T *__restrict__ a, int as0, int as1) {
           Kokkos::parallel_for(Kokkos::TeamThreadRange(member,n),[&](const int &j) {
               const int jj = j + offset;
-              Kokkos::parallel_for(Kokkos::ThreadVectorRange(member,n-j-offset),[&](const int &i) {
+              Kokkos::parallel_for(Kokkos::ThreadVectorRange(member,n-j-offset),[&,alpha,as0,as1,j,jj](const int &i) {/// compiler bug with c++14 lambda capturing and workaround
                   a[(i+jj)*as0+j*as1] *= alpha;
                 });
             });

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_TeamFunctor_SolveLowerChol.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_TeamFunctor_SolveLowerChol.hpp
@@ -264,7 +264,7 @@ namespace Tacho {
           // copy to t
           Kokkos::parallel_for
             (Kokkos::TeamVectorRange(member, m*_nrhs),
-             [&](const ordinal_type &k) {
+             [&,m](const ordinal_type &k) { /// compiler bug with c++14 lambda capturing and workaround
               const ordinal_type i = k%m, j = k/m;
               tT(i,j) = b(i,j);
             });
@@ -281,7 +281,7 @@ namespace Tacho {
 
               Kokkos::parallel_for
                 (Kokkos::TeamVectorRange(member, tcnt),
-                 [&](const ordinal_type &ii) {
+                 [&,ip,m,tbeg,tcnt](const ordinal_type &ii) { /// compiler bug with c++14 lambda capturing and workaround
                   const ordinal_type it = tbeg+ii;
                   const ordinal_type is = ip+ii;
                   //for (ordinal_type it=tbeg;it<tend;++it,++is) {

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_TeamFunctor_SolveUpperChol.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_TeamFunctor_SolveUpperChol.hpp
@@ -229,7 +229,7 @@ namespace Tacho {
           const ordinal_type goffset = s.gid_col_begin + s.m;
           Kokkos::parallel_for
             (Kokkos::TeamVectorRange(member, n),
-             [&](const ordinal_type &i) {
+             [&,m,goffset,offm](const ordinal_type &i) { // Value capture is a workaround for cuda + gcc-7.2 compiler bug w/c++14
               for (ordinal_type j=0;j<_nrhs;++j) {
                 if (i < m) {
                   b(i,j) = _t(offm+i,j);


### PR DESCRIPTION

## Motivation

Some C++14 compilers have a compiler bug in lambda capturing. This PR includes the workaround.

@crdohrm 