### PR TITLE
ATDM: Remove checks for running on login and launch nodes (ATDV-387)

### DIFF
--- a/cmake/ctest/drivers/atdm/ats2/local-driver.sh
+++ b/cmake/ctest/drivers/atdm/ats2/local-driver.sh
@@ -21,25 +21,6 @@ if atdm_match_buildname_keyword xl ; then
   export ATDM_CONFIG_CONFIGURE_OPTIONS_FILES=cmake/std/atdm/ATDMDevEnv.cmake,cmake/std/atdm/apps/sparc/SPARC_Trilinos_PACKAGES.cmake
 fi
 
-echo
-echo "Current node type: $(atdm_ats2_get_node_type)"
-echo
-
-if [[ "$(atdm_ats2_get_node_type)" != "login_node" ]] ; then
-  echo
-  echo "***"
-  echo "*** ERROR: $0"
-  echo "*** can only be run from login node '${ATDM_CONFIG_ATS2_LOGIN_NODE}'"
-  echo "*** and not the current node '$(hostname)'!"
-  echo "***"
-  echo "*** See instructions for the ATS-2 ('ats2') env in the file:"
-  echo "***"
-  echo "***   Trilinos/cmake/std/atdm/README.md"
-  echo "***"
-  echo
-  exit 1
-fi
-
 # Allow default setting for TPETRA_ASSUME_CUDA_AWARE_MPI=0 in trilinos_jsrun
 unset TPETRA_ASSUME_CUDA_AWARE_MPI
 

--- a/cmake/std/atdm/ats2/environment.sh
+++ b/cmake/std/atdm/ats2/environment.sh
@@ -178,17 +178,13 @@ export ATDM_CONFIG_MPI_EXEC=${ATDM_SCRIPT_DIR}/ats2/trilinos_jsrun
 export ATDM_CONFIG_MPI_POST_FLAGS="--rs_per_socket;4"
 export ATDM_CONFIG_MPI_EXEC_NUMPROCS_FLAG="-p"
 
-# System-info for what ATS-2 system we are using
-if [[ "${ATDM_CONFIG_KNOWN_HOSTNAME}" == "vortex" ]] ; then
-  export ATDM_CONFIG_ATS2_LOGIN_NODE=vortex60
-  export ATDM_CONFIG_ATS2_LAUNCH_NODE=vortex59
-  # NOTE: If more login and launch nodes gets added to 'vortex', we will need
-  # to change this to a list of node names instead of just one.  But we will
-  # deal with that later if that occurs.
-else
-  echo "Error, the ats2 env on system '${ATDM_CONFIG_KNOWN_HOSTNAME}'"
-  return
-fi
+# NOTE: We used to check for the launch node but at one point that changed
+# from 'vortex59' to 'vortex5' without warning.  That caused all of the tests
+# run with 'trilinos_jsrun' to fail on 2020-08-11 so we got no test results.
+# Therefore, we will not be checking for running on the launch node anymore in
+# order to avoid having all of the testing break when they change the launch
+# node again.  Therefore, we also removed checks for the login node as well.
+# This makes these scripts more robust to changes on 'vortex'.
 
 
 #
@@ -204,19 +200,6 @@ function atdm_ats2_get_allocated_compute_node_name() {
   fi
 }
 export -f atdm_ats2_get_allocated_compute_node_name
-
-
-function atdm_ats2_get_node_type() {
-  current_hostname=$(hostname)
-  if   [[ "${current_hostname}" == "${ATDM_CONFIG_ATS2_LOGIN_NODE}" ]] ; then
-    echo "login_node"
-  elif [[ "${current_hostname}" == "${ATDM_CONFIG_ATS2_LAUNCH_NODE}" ]] ; then
-    echo "launch_node"
-  else
-    echo "compute_node"
-  fi
-}
-export -f atdm_ats2_get_node_type
 
 
 #

--- a/cmake/std/atdm/ats2/trilinos_jsrun
+++ b/cmake/std/atdm/ats2/trilinos_jsrun
@@ -9,22 +9,6 @@ if [[ "${ATDM_CONFIG_SYSTEM_NAME}" != "ats2" ]] ; then
   exit 1
 fi
 
-if [[ "$(atdm_ats2_get_node_type)" != "launch_node" ]] ; then
-  echo
-  echo "***"
-  echo "*** ERROR: $0"
-  echo "*** can only be run from launch node '${ATDM_CONFIG_ATS2_LAUNCH_NODE}'"
-  echo "*** and not the current node '$(hostname)'!"
-  echo "***"
-  echo "*** See instructions for the ATS-2 ('ats2') env in the file:"
-  echo "***"
-  echo "***   Trilinos/cmake/std/atdm/README.md"
-  echo "***"
-  echo
-  exit 1
-fi
-
-
 # Globals
 DEBUG_SCRIPT="${DEBUG_SCRIPT-:0}"
 ECHO_CMD="${ECHO_CMD:-1}"


### PR DESCRIPTION
Fixes mass test failures on 'ats2' which started 2020-08-11.  (See commit and internal file comments and [ATDV-387](https://sems-atlassian-srn.sandia.gov/browse/ATDV-387).

##  How was this tested?

On 'vortex' from the login node 'vortex60' I ran:

```
$ cd /vscratch1/rabartl/Trilinos.base/BUILDS/VORTEX/CTEST_S/

$ env Trilinos_PACKAGES=TeuchosCore \
  ./ctest-s-local-test-driver.sh \
    ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_static_opt

***
*** ./ctest-s-local-test-driver.sh
***

ATDM_TRILINOS_DIR = '/home/rabartl/Trilinos.base/Trilinos'

Load some env to get python, cmake, etc ...

Hostname 'vortex60' matches known ATDM host 'vortex60' and system 'ats2'
Setting compiler and build options for build-name 'default'
Using ats2 compiler stack GNU-7.3.1_SPMPI-ROLLING to build DEBUG code with Kokkos node type SERIAL

Due to MODULEPATH changes, the following have been reloaded:
  1) spectrum-mpi/rolling-release


Running builds:
    ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_static_opt

Tue Aug 11 14:25:09 MDT 2020

Running Jenkins driver Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_static_opt.sh ...

    See log file Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_static_opt/smart-jenkins-driver.out

real    14m12.467s
user    1m20.711s
sys     0m57.400s

100% tests passed, 0 tests failed out of 142
100% tests passed, 0 tests failed out of 142

Tue Aug 11 14:39:21 MDT 2020

Done running all of the builds!
```

which submitted to:

* https://testing.sandia.gov/cdash/index.php?project=Trilinos&filtercount=2&showfilters=1&filtercombine=and&field1=buildname&compare1=61&value1=Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_static_opt-exp&field2=buildstamp&compare2=61&value2=20200811-2025-Experimental
* https://testing.sandia.gov/cdash/index.php?project=Trilinos&filtercount=2&showfilters=1&filtercombine=and&field1=buildname&compare1=61&value1=Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_static_opt-exp&field2=buildstamp&compare2=61&value2=20200811-2025-Experimental

and showed the result:

| Site | Build Name | Conf Err | Conf Warn | Conf Test Time | Build Err | Build Warn | Build Test Time | Test Not Run | Test Fail | Test Pass | Test Time | Test Proc Time | Start Test Time | Labels |
| -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- |
vortex | Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_static_opt-exp | 0 | 3 | 51s | 0 | 0 | 0s | 0 | 0 | 142 | 5m 31s | 20m 37s | 7 minutes ago | Teuchos
vortex | Trilinos-atdm-ats2-cuda-10.1.243-gnu-7.3.1-spmpi-rolling_static_opt-exp | 0 | 3 | 51s | 0 | 0 | 0s | 0 | 0 | 142 | 5m 31s | 20m 37s | 15 minutes ago | Teuchos

Many of those tests are run with 'trilinos_jsrun' so the fact they pass is proof that this issue is fixed.
