### PR TITLE
Zoltan2 Sphynx: Adjust MueLu parameters

### DIFF
--- a/packages/zoltan2/sphynx/src/Zoltan2_Sphynx.hpp
+++ b/packages/zoltan2/sphynx/src/Zoltan2_Sphynx.hpp
@@ -694,10 +694,10 @@ namespace Zoltan2 {
       Teuchos::ParameterList smootherParamList;
       smootherParamList.set("chebyshev: degree", 3);
       smootherParamList.set("chebyshev: ratio eigenvalue", 7.0);
-      smootherParamList.set("chebyshev: eigenvalue max iterations", 10);
+      smootherParamList.set("chebyshev: eigenvalue max iterations", irregular_ ? 100 : 10);
       paramList.set("smoother: params", smootherParamList);
-      paramList.set("use kokkos refactor", false); 
-
+      paramList.set("use kokkos refactor", true); 
+      paramList.set("transpose: use implicit", true);
 
       if(irregular_) {
 	
@@ -707,7 +707,6 @@ namespace Zoltan2 {
 	Teuchos::ParameterList coarseParamList;
 	coarseParamList.set("chebyshev: degree", 3);
 	coarseParamList.set("chebyshev: ratio eigenvalue", 7.0);
-	coarseParamList.set("chebyshev: eigenvalue max iterations", 10);
 	paramList.set("coarse: params", coarseParamList);
 
 	paramList.set("max levels", 5);


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/zoltan2 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
This PR adjusts some of the MueLu parameters that Sphynx uses. 
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Sphynx tests are passing in my CUDA build.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->