### PR TITLE
MueLu: remove "old" regionMG MatVec w/ doubled communication

### DIFF
--- a/packages/muelu/research/regionMG/src/SetupRegionMatrix_def.hpp
+++ b/packages/muelu/research/regionMG/src/SetupRegionMatrix_def.hpp
@@ -719,57 +719,6 @@ void regionalToComposite(const std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdin
   return;
 } // regionalToComposite
 
-/*! \brief Compute the residual \f$r = b - Ax\f$ using two rounds of communication
- *
- *  The residual is computed based on matrices and vectors in a regional layout.
- *  1. Compute y = A*x in regional layout.
- *  2. Sum interface values of y to account for duplication of interface DOFs.
- *  3. Compute r = b - y
- */
-template <class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
-Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >
-computeResidual(Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > >& regRes, ///< residual (to be evaluated)
-                const Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regX, ///< left-hand side (solution)
-                const Array<RCP<Xpetra::Vector<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regB, ///< right-hand side (forcing term)
-                const std::vector<RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> > > regionGrpMats,
-                const std::vector<RCP<Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node> > > revisedRowMapPerGrp, ///< revised row maps in region layout [in] (actually extracted from regionGrpMats)
-                const std::vector<RCP<Xpetra::Import<LocalOrdinal, GlobalOrdinal, Node> > > rowImportPerGrp ///< row importer in region layout [in]
-    )
-{
-#include "Xpetra_UseShortNames.hpp"
-  using Teuchos::TimeMonitor;
-  const int maxRegPerProc = regX.size();
-
-  RCP<TimeMonitor> tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("computeResidual: 1 - Rreg = Areg*Xreg")));
-
-  /* Update the residual vector
-   * 1. Compute tmp = A * regX in each region
-   * 2. Sum interface values in tmp due to duplication (We fake this by scaling to reverse the basic splitting)
-   * 3. Compute r = B - tmp
-   */
-  for (int j = 0; j < maxRegPerProc; j++) { // step 1
-    regionGrpMats[j]->apply(*regX[j], *regRes[j]);
-    //    TEUCHOS_ASSERT(regionGrpMats[j]->getDomainMap()->isSameAs(*regX[j]->getMap()));
-    //    TEUCHOS_ASSERT(regionGrpMats[j]->getRangeMap()->isSameAs(*regRes[j]->getMap()));
-  }
-
-  tm = Teuchos::null;
-  tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("computeResidual: 2 - sumInterfaceValues")));
-
-  sumInterfaceValues(regRes, revisedRowMapPerGrp, rowImportPerGrp);
-
-  tm = Teuchos::null;
-  tm = rcp(new TimeMonitor(*TimeMonitor::getNewTimer("computeResidual: 3 - Rreg = Breg - Rreg")));
-
-  for (int j = 0; j < maxRegPerProc; j++) { // step 3
-    regRes[j]->update(1.0, *regB[j], -1.0);
-    //    TEUCHOS_ASSERT(regRes[j]->getMap()->isSameAs(*regB[j]->getMap()));
-  }
-
-  tm = Teuchos::null;
-
-  return regRes;
-} // computeResidual
 
 /*! \brief Compute local data needed to perform a MatVec in region format
 

--- a/packages/muelu/research/regionMG/test/structured/Driver_Structured_Regions.cpp
+++ b/packages/muelu/research/regionMG/test/structured/Driver_Structured_Regions.cpp
@@ -189,7 +189,6 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
   int  cacheSize = 0;                                      clp.setOption("cachesize",               &cacheSize,           "cache size (in KB)");
   bool useStackedTimer   = false;                          clp.setOption("stacked-timer","no-stacked-timer", &useStackedTimer, "use stacked timer");
   bool showTimerSummary = true;                            clp.setOption("show-timer-summary", "no-show-timer-summary", &showTimerSummary, "Switch on/off the timer summary at the end of the run.");
-  bool useFastMatVec = true;                               clp.setOption("fastMV", "no-fastMV", &useFastMatVec, "Use the fast MatVec implementation (or not)");
   std::string cycleType = "V";                             clp.setOption("cycleType", &cycleType, "{Multigrid cycle type. Possible values: V, W.");
 
   clp.recogniseAllOptions(true);
@@ -730,7 +729,6 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
   // Set data for fast MatVec
   // for (auto levelSmootherParams : smootherParams) {
   for(LO levelIdx = 0; levelIdx < numLevels; ++levelIdx) {
-    smootherParams[levelIdx]->set("Use fast MatVec", useFastMatVec);
     smootherParams[levelIdx]->set("Fast MatVec: interface LIDs",
                                   regionMatVecLIDsPerLevel[levelIdx]);
     smootherParams[levelIdx]->set("Fast MatVec: interface importer",
@@ -858,19 +856,8 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
         ////////////////////////////////////////////////////////////////////////
         // SWITCH BACK TO NON-LEVEL VARIABLES
         ////////////////////////////////////////////////////////////////////////
-        {
-          if (useFastMatVec)
-          {
-            computeResidual(regRes, regX, regB, regionGrpMats, *smootherParams[0]);
-          }
-          else
-          {
-            computeResidual(regRes, regX, regB, regionGrpMats,
-                revisedRowMapPerGrp, rowImportPerGrp);
-          }
-
-          scaleInterfaceDOFs(regRes, regInterfaceScalings[0], true);
-        }
+        computeResidual(regRes, regX, regB, regionGrpMats, *smootherParams[0]);
+        scaleInterfaceDOFs(regRes, regInterfaceScalings[0], true);
 
         compRes = VectorFactory::Build(dofMap, true);
         regionalToComposite(regRes, compRes, rowImportPerGrp);

--- a/packages/muelu/test/unit_tests/RegionMatrix.cpp
+++ b/packages/muelu/test/unit_tests/RegionMatrix.cpp
@@ -645,103 +645,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, RegionToCompositeMatrix, Scalar,
 
 } // RegionToCompositeMatrix
 
-// This test aims at checking that apply regionA to a region vector has the same effect as
-// applying A to a composite vector. Of course the region vector needs to be brought back
-// to composite formate before verifying the equivalence.
-TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, MatVec, Scalar, LocalOrdinal, GlobalOrdinal, Node)
-{
-#   include "MueLu_UseShortNames.hpp"
-  MUELU_TESTING_SET_OSTREAM;
-  MUELU_TESTING_LIMIT_SCOPE(Scalar,GlobalOrdinal,Node);
-
-  using TST                   = Teuchos::ScalarTraits<SC>;
-  using magnitude_type        = typename TST::magnitudeType;
-  using TMT                   = Teuchos::ScalarTraits<magnitude_type>;
-  using real_type             = typename TST::coordinateType;
-  using RealValuedMultiVector = Xpetra::MultiVector<real_type,LO,GO,NO>;
-  using test_factory          = TestHelpers::TestFactory<SC, LO, GO, NO>;
-
-  out << "version: " << MueLu::Version() << std::endl;
-
-  // Get MPI parameter
-  RCP<const Teuchos::Comm<int> > comm = TestHelpers::Parameters::getDefaultComm();
-
-  GO nx = 5, ny = 5, nz = 1;
-  Teuchos::CommandLineProcessor &clp = Teuchos::UnitTestRepository::getCLP();
-  Galeri::Xpetra::Parameters<GO> galeriParameters(clp, nx, ny, nz, "Laplace2D");
-  Teuchos::ParameterList galeriList = galeriParameters.GetParameterList();
-  std::string   matrixType = galeriParameters.GetMatrixType();
-
-  // Build maps for the problem
-  const LO numDofsPerNode = 1;
-  RCP<Map> nodeMap = Galeri::Xpetra::CreateMap<LO, GO, Node>(TestHelpers::Parameters::getLib(),
-                                                             "Cartesian2D", comm, galeriList);
-  RCP<Map> dofMap  = Xpetra::MapFactory<LO,GO,Node>::Build(nodeMap, numDofsPerNode);
-
-  // Build the Xpetra problem
-  RCP<Galeri::Xpetra::Problem<Map,CrsMatrixWrap,MultiVector> > Pr =
-    Galeri::Xpetra::BuildProblem<SC,LO,GO,Map,CrsMatrixWrap,MultiVector>(galeriParameters.GetMatrixType(), dofMap, galeriList);
-
-  // Generate the operator
-  RCP<Matrix> A = Pr->BuildMatrix();
-  A->SetFixedBlockSize(numDofsPerNode);
-
-  // Create auxiliary data for MG
-  RCP<MultiVector> nullspace = Pr->BuildNullspace();
-  RCP<RealValuedMultiVector> coordinates = Galeri::Xpetra::Utils::CreateCartesianCoordinates<double,LO,GO,Map,RealValuedMultiVector>("2D", nodeMap, galeriList);
-
-  // create the region maps, importer and operator from composite counter parts
-  const int maxRegPerProc = 1;
-  std::vector<RCP<Map> >    rowMapPerGrp(maxRegPerProc), colMapPerGrp(maxRegPerProc);
-  std::vector<RCP<Map> >    revisedRowMapPerGrp(maxRegPerProc), revisedColMapPerGrp(maxRegPerProc);
-  std::vector<RCP<Import> > rowImportPerGrp(maxRegPerProc), colImportPerGrp(maxRegPerProc);
-  std::vector<RCP<Matrix> > regionGrpMats(maxRegPerProc);
-  Teuchos::ArrayRCP<LO> regionMatVecLIDs;
-  RCP<Import> regionInterfaceImporter;
-  createRegionMatrix(galeriList, numDofsPerNode, maxRegPerProc, nodeMap, dofMap, A,
-                     rowMapPerGrp, colMapPerGrp, revisedRowMapPerGrp, revisedColMapPerGrp,
-                     rowImportPerGrp, colImportPerGrp, regionGrpMats,
-                     regionMatVecLIDs, regionInterfaceImporter);
-
-  RCP<Matrix> regionMat = regionGrpMats[0];
-
-  // Create initial vectors in composite format and apply composite A.
-  // This will give a reference to compare with.
-  RCP<Vector> X = VectorFactory::Build(dofMap);
-  RCP<Vector> B = VectorFactory::Build(dofMap);
-
-  // we set seed for reproducibility
-  Utilities::SetRandomSeed(*comm);
-  X->randomize();
-
-  // Perform composite MatVec
-  A->apply(*X, *B, Teuchos::NO_TRANS, TST::one(), TST::zero());
-
-  // Create the region vectors and apply region A
-  Array<RCP<Vector> > quasiRegX(maxRegPerProc);
-  Array<RCP<Vector> > quasiRegB(maxRegPerProc);
-  Array<RCP<Vector> > regX(maxRegPerProc);
-  Array<RCP<Vector> > regB(maxRegPerProc);
-  compositeToRegional(X, quasiRegX, regX,
-                      revisedRowMapPerGrp, rowImportPerGrp);
-  regB[0] = VectorFactory::Build(revisedRowMapPerGrp[0], true);
-  regionMat->apply(*regX[0], *regB[0], Teuchos::NO_TRANS, TST::one(), TST::zero());
-
-  // Now create composite B using region B so we can compare
-  // composite B with the original B
-  RCP<Vector> compB = VectorFactory::Build(dofMap);
-  regionalToComposite(regB, compB, rowImportPerGrp);
-
-  // Extract the data from B and compB to compare it
-  ArrayRCP<const SC> dataB     = B->getData(0);
-  ArrayRCP<const SC> dataCompB = compB->getData(0);
-  for(size_t idx = 0; idx < B->getLocalLength(); ++idx) {
-    TEST_FLOATING_EQUALITY(TST::magnitude(dataB[idx]),
-                           TST::magnitude(dataCompB[idx]),
-                           100*TMT::eps());
-  }
-
-} // MatVec
 
 // This test aims at checking that apply regionA to a region vector has the same effect as
 // applying A to a composite vector. Of course the region vector needs to be brought back
@@ -1671,7 +1574,6 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionMatrix, Laplace3D, Scalar, LocalOrdinal,
 #  define MUELU_ETI_GROUP(Scalar, LO, GO, Node) \
       TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(RegionMatrix,CompositeToRegionMatrix,Scalar,LO,GO,Node) \
       TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(RegionMatrix,RegionToCompositeMatrix,Scalar,LO,GO,Node) \
-      TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(RegionMatrix,MatVec,Scalar,LO,GO,Node)                  \
       TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(RegionMatrix,FastMatVec,Scalar,LO,GO,Node)              \
       TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(RegionMatrix,FastMatVec3D,Scalar,LO,GO,Node)            \
       TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT(RegionMatrix,FastMatVec2D_Elasticity,Scalar,LO,GO,Node) \


### PR DESCRIPTION
@trilinos/muelu 
@lucbv @rstumin @pohm01 

## Motivation

A newer MatVec implementation for region MG is available, which pre-computes the communication pattern during the setup phase to save one round of communication during the apply phase. We have used both implementations in parallel for some time to gain confidence in the new one.

Now, this PR removes the old implementation, which always did two rounds of communication during the apply phase.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback

This work is part of an ASCR project with @rstumin and @lucbv.

## Testing

Still some trouble w/ the unit tests... cf. #7832 

## Additional Information

❗ This PR builds upon changes in PR #7830, so merge this PR only after PR #7830 has been merged.