### PR TITLE
Tempus: Bug in RK Forward Euler with FSAL

### DIFF
--- a/packages/tempus/src/Tempus_StepperExplicitRK_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperExplicitRK_impl.hpp
@@ -363,6 +363,17 @@ void StepperExplicitRK<Scalar>::takeStep(
       }
     }
 
+    if (this->getUseFSAL()) {
+      if (numStages == 1) {
+        const Scalar ts = time + dt;
+        auto p = Teuchos::rcp(new ExplicitODEParameters<Scalar>(dt));
+        // Evaluate xDot = f(x,t).
+        this->evaluateExplicitODE(stageXDot_[0], workingState->getX(), ts, p);
+      }
+      if (workingState->getXDot() != Teuchos::null)
+        Thyra::assign((workingState->getXDot()).ptr(), *(stageXDot_.back()));
+    }
+
 
     // At this point, the stepper has passed.
     // But when using adaptive time stepping, the embedded method

--- a/packages/tempus/src/Tempus_StepperRKButcherTableau.hpp
+++ b/packages/tempus/src/Tempus_StepperRKButcherTableau.hpp
@@ -92,6 +92,9 @@ public:
     return Description.str();
   }
 
+  bool getUseFSALDefault() const { return true; }
+
+
 protected:
 
   void setupTableau()

--- a/packages/tempus/test/BDF2/Tempus_BDF2Test.cpp
+++ b/packages/tempus/test/BDF2/Tempus_BDF2Test.cpp
@@ -455,10 +455,10 @@ TEUCHOS_UNIT_TEST(BDF2, SinCosAdapt)
                     solutions,    xErrorNorm,    xSlope,
                     solutionsDot, xDotErrorNorm, xDotSlope);
 
-    TEST_FLOATING_EQUALITY( xSlope,               1.95089, 0.01 );
-    TEST_FLOATING_EQUALITY( xDotSlope,            1.95089, 0.01 );
-    TEST_FLOATING_EQUALITY( xErrorNorm[0],    0.000197325, 1.0e-4 );
-    TEST_FLOATING_EQUALITY( xDotErrorNorm[0], 0.000197325, 1.0e-4 );
+    TEST_FLOATING_EQUALITY( xSlope,               1.96126, 0.01 );
+    TEST_FLOATING_EQUALITY( xDotSlope,            1.96126, 0.01 );
+    TEST_FLOATING_EQUALITY( xErrorNorm[0],    0.000192591, 1.0e-4 );
+    TEST_FLOATING_EQUALITY( xDotErrorNorm[0], 0.000192591, 1.0e-4 );
   }
 
   Teuchos::TimeMonitor::summarize();

--- a/packages/tempus/test/BDF2/Tempus_BDF2_ASA.cpp
+++ b/packages/tempus/test/BDF2/Tempus_BDF2_ASA.cpp
@@ -194,8 +194,8 @@ TEUCHOS_UNIT_TEST(BDF2, SinCos_ASA)
   *my_out << "  Expected order: " << order << std::endl;
   *my_out << "  Observed order: " << slope << std::endl;
   *my_out << "  =========================" << std::endl;
-  TEST_FLOATING_EQUALITY( slope, order, 0.015 );
-  TEST_FLOATING_EQUALITY( ErrorNorm[0], 0.0378652, 1.0e-4 );
+  TEST_FLOATING_EQUALITY( slope,          1.95006, 0.015 );
+  TEST_FLOATING_EQUALITY( ErrorNorm[0], 0.0137394, 1.0e-4 );
 
   if (comm->getRank() == 0) {
     std::ofstream ftmp("Tempus_BDF2_SinCos_AdjSens-Error.dat");

--- a/packages/tempus/test/BDF2/Tempus_BDF2_FSA.hpp
+++ b/packages/tempus/test/BDF2/Tempus_BDF2_FSA.hpp
@@ -196,8 +196,8 @@ void test_sincos_fsa(const bool use_combined_method,
   *my_out << "  Expected order: " << order << std::endl;
   *my_out << "  Observed order: " << slope << std::endl;
   *my_out << "  =========================" << std::endl;
-  TEST_FLOATING_EQUALITY( slope, order, 0.015 );
-  TEST_FLOATING_EQUALITY( ErrorNorm[0], 0.0344598, 1.0e-4 );
+  TEST_FLOATING_EQUALITY( slope,          1.94162, 0.015 );
+  TEST_FLOATING_EQUALITY( ErrorNorm[0], 0.0143743, 1.0e-4 );
 
   if (comm->getRank() == 0) {
     std::ofstream ftmp("Tempus_BDF2_SinCos_Sens-Error.dat");

--- a/packages/tempus/test/BDF2/Tempus_BDF2_SinCos_AdaptDt.xml
+++ b/packages/tempus/test/BDF2/Tempus_BDF2_SinCos_AdaptDt.xml
@@ -63,7 +63,7 @@
       <Parameter name="Initial Condition Consistency Check" type="bool" value="false"/>
       <Parameter name="Zero Initial Guess" type="bool" value="0"/>
       <Parameter name="Solver Name"    type="string" value="Default Solver"/>
-      <Parameter name="Start Up Stepper Type" type="string" value="RK Forward Euler"/>
+      <Parameter name="Start Up Stepper Type" type="string" value="RK Explicit Midpoint"/>
       <ParameterList name="Default Solver">
         <ParameterList name="NOX">
           <ParameterList name="Direction">

--- a/packages/tempus/test/BDF2/Tempus_BDF2_SinCos_SA.xml
+++ b/packages/tempus/test/BDF2/Tempus_BDF2_SinCos_SA.xml
@@ -53,7 +53,7 @@
       <Parameter name="Initial Condition Consistency Check" type="bool" value="false"/>
       <Parameter name="Zero Initial Guess" type="bool" value="0"/>
       <Parameter name="Solver Name"    type="string" value="Default Solver"/>
-      <Parameter name="Start Up Stepper Type" type="string" value="RK Forward Euler"/>
+      <Parameter name="Start Up Stepper Type" type="string" value="RK Explicit Midpoint"/>
       <ParameterList name="Default Solver">
         <ParameterList name="NOX">
           <ParameterList name="Direction">

--- a/packages/tempus/test/TestModels/DahlquistTestModel_decl.hpp
+++ b/packages/tempus/test/TestModels/DahlquistTestModel_decl.hpp
@@ -37,8 +37,13 @@ class DahlquistTestModel
 {
   public:
 
+  // Default Constructor
+  DahlquistTestModel();
+
   // Constructor
-  DahlquistTestModel(Scalar lambda = Scalar(-1.0));
+  DahlquistTestModel(Scalar lambda, bool includeXDot);
+
+  void constructDahlquistTestModel(Scalar lambda, bool includeXDot);
 
   /// Default destructor
   ~DahlquistTestModel() = default;
@@ -76,6 +81,8 @@ private:
 
 private:
   Scalar lambda_;
+  bool   includeXDot_;
+
   mutable bool isInitialized_;
   mutable Thyra::ModelEvaluatorBase::InArgs<Scalar>  inArgs_;
   mutable Thyra::ModelEvaluatorBase::OutArgs<Scalar> outArgs_;
@@ -86,7 +93,8 @@ private:
   //Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> > g_space_;
   //Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> > DxDp_space_;
 
-  Scalar xIC_; ///< Initial condition for x.
+  Scalar xIC_;    ///< Initial condition for x.
+  Scalar xDotIC_; ///< Initial condition for xDot.
 };
 
 

--- a/packages/tempus/test/TestModels/DahlquistTestModel_impl.hpp
+++ b/packages/tempus/test/TestModels/DahlquistTestModel_impl.hpp
@@ -25,13 +25,27 @@
 namespace Tempus_Test {
 
 template<class Scalar>
+DahlquistTestModel<Scalar>::DahlquistTestModel()
+{ constructDahlquistTestModel(-1.0, false); }
+
+
+template<class Scalar>
 DahlquistTestModel<Scalar>::
-DahlquistTestModel(Scalar lambda)
-  : lambda_(lambda)
+DahlquistTestModel(Scalar lambda, bool includeXDot)
+{ constructDahlquistTestModel(lambda, includeXDot); }
+
+
+template<class Scalar>
+void
+DahlquistTestModel<Scalar>::
+constructDahlquistTestModel(Scalar lambda, bool includeXDot)
 {
+  lambda_        = lambda;
+  includeXDot_   = includeXDot;
   isInitialized_ = false;
+  xIC_           = Scalar(   1.0);
+  xDotIC_        = Scalar(lambda);
   int dim = 1;
-  xIC_ = Scalar(1.0);
 
   // Create x_space and f_space
   x_space_ = Thyra::defaultSpmdVectorSpace<Scalar>(dim);
@@ -68,6 +82,16 @@ DahlquistTestModel(Scalar lambda)
     }
     nominalValues_.set_x(x_ic);
   }
+
+  if (includeXDot_) {
+    const RCP<Thyra::VectorBase<Scalar> > x_dot_ic = createMember(x_space_);
+    { // scope to delete DetachedVectorView
+      Thyra::DetachedVectorView<Scalar> x_dot_ic_view( *x_dot_ic );
+      x_dot_ic_view[0] = xDotIC_;
+    }
+    nominalValues_.set_x_dot(x_dot_ic);
+  }
+
   isInitialized_ = true;
 }
 
@@ -80,12 +104,25 @@ getExactSolution(double t) const
   Thyra::ModelEvaluatorBase::InArgs<Scalar> inArgs = inArgs_;
   double exact_t = t;
   inArgs.set_t(exact_t);
+
+  // Set the exact solution, x.
   Teuchos::RCP<Thyra::VectorBase<Scalar> > exact_x = createMember(x_space_);
   { // scope to delete DetachedVectorView
     Thyra::DetachedVectorView<Scalar> exact_x_view(*exact_x);
     exact_x_view[0] = exp(lambda_*exact_t);
   }
   inArgs.set_x(exact_x);
+
+  // Set the exact solution time derivative, xDot.
+  if (includeXDot_) {
+    Teuchos::RCP<Thyra::VectorBase<Scalar> > exact_x_dot = createMember(x_space_);
+    { // scope to delete DetachedVectorView
+      Thyra::DetachedVectorView<Scalar> exact_x_dot_view(*exact_x_dot);
+      exact_x_dot_view[0] = lambda_ * exp(lambda_*exact_t);
+    }
+    inArgs.set_x_dot(exact_x_dot);
+  }
+
   return inArgs;
 }
 

--- a/packages/tempus/unit_test/Tempus_UnitTest_ERK_ForwardEuler.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_ERK_ForwardEuler.cpp
@@ -11,6 +11,8 @@
 #include "Tempus_UnitTest_Utils.hpp"
 
 #include "../TestModels/SinCosModel.hpp"
+#include "../TestModels/DahlquistTestModel.hpp"
+
 
 namespace Tempus_Unit_Test {
 
@@ -52,6 +54,53 @@ TEUCHOS_UNIT_TEST(ERK_ForwardEuler, AppAction)
   auto stepper = rcp(new Tempus::StepperERK_ForwardEuler<double>());
   auto model = rcp(new Tempus_Test::SinCosModel<double>());
   testRKAppAction(stepper, model, out, success);
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(ERK_ForwardEuler, FSAL)
+{
+  auto stepper = rcp(new Tempus::StepperERK_ForwardEuler<double>());
+  Teuchos::RCP<const Thyra::ModelEvaluator<double> >
+    model = rcp(new Tempus_Test::DahlquistTestModel<double>(-1.0, true));
+
+  stepper->setModel(model);
+  stepper->setICConsistency("Consistent");
+  stepper->setUseFSAL(true);
+  stepper->initialize();
+
+  // Create a SolutionHistory.
+  auto solutionHistory = Tempus::createSolutionHistoryME(model);
+
+  // Take one time step.
+  stepper->setInitialConditions(solutionHistory);
+  solutionHistory->initWorkingState();
+  double dt = 1.0;
+  solutionHistory->getWorkingState()->setTimeStep(dt);
+  solutionHistory->getWorkingState()->setTime(dt);
+  stepper->takeStep(solutionHistory);
+
+  // Test solution.
+  const double relTol = 1.0e-14;
+
+  // ICs
+  auto currentState = solutionHistory->getCurrentState();
+  const double x_0    = get_ele(*(currentState->getX()), 0);
+  const double xDot_0 = get_ele(*(currentState->getXDot()), 0);
+  TEST_FLOATING_EQUALITY(x_0,     1.0, relTol);
+  TEST_FLOATING_EQUALITY(xDot_0, -1.0, relTol);
+  TEST_ASSERT(std::abs(currentState->getTime()) < relTol);
+
+  // After one step.
+  auto workingState   = solutionHistory->getWorkingState();
+  const double x_1    = get_ele(*(workingState->getX()), 0);
+  const double xDot_1 = get_ele(*(workingState->getXDot()), 0);
+  std::cout << "xDot_1 = " << xDot_1 << std::endl;
+  TEST_ASSERT(std::abs(x_1   ) < relTol);
+  TEST_ASSERT(std::abs(xDot_1) < relTol);
+  TEST_FLOATING_EQUALITY(workingState->getTime(), 1.0, relTol);
+
 }
 
 


### PR DESCRIPTION
@trilinos/tempus 

## Motivation
While debugging an issue with Albany, it turns out that for
useFSAL=true and with one stage, Explicit RK does not correctly
calculate the update for the next time step, i.e., evalModel() will
never be called.

 * Changed the default useFSAL to true for RK Forward Euler.  This
   matches Forward Euler stepper.
 * Added xDot to Dahlquist test problem for unit testing.
   - New constructor allows construction with or without xDot
   - Added xDot to nominalValues() and getExactSolution().
 * Added unit test to cover this bug.
 * BDF2 used RK Forward Euler as a startup stepper. Switched it
   to RK Explicit Midpoint, which is second order.  This allowed BDF2
   to remain second order, but the overall error decreased.  With the
   new default useFSAL=true, the workingState->getXDot() was updated
   by RK Forward Euler which interfers with the BDF2.


## Related Issues

* Closes #7835 


## Stakeholder Feedback
@ikalash is the stakeholder.

## Testing
Added a unit test to cover this bug.
