### PR TITLE
Intrepid2 fences for CUDA_LAUNCH_BLOCKING=0

### DIFF
--- a/packages/intrepid2/unit-test/Cell/test_03.hpp
+++ b/packages/intrepid2/unit-test/Cell/test_03.hpp
@@ -248,7 +248,9 @@ namespace Intrepid2 {
                     }
                     
                     rst::vecprod(faceNormal, tanX, tanY);
-                    
+
+                    DeviceSpaceType().fence();
+
                     // Compare direct normal with d-component of the face/side normal by CellTools
                     for (ordinal_type d=0;d<cellDim;++d) {
                       
@@ -322,6 +324,8 @@ namespace Intrepid2 {
                     }
 
                     rst::vecprod(faceNormal, tanX, tanY);
+
+                    DeviceSpaceType().fence();
 
                     // Compare direct normal with d-component of the face/side normal by CellTools
                     for (ordinal_type d=0;d<cellDim;++d) {

--- a/packages/intrepid2/unit-test/Discretization/Basis/HierarchicalBases/SubBasisInclusionTests.cpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HierarchicalBases/SubBasisInclusionTests.cpp
@@ -207,7 +207,7 @@ namespace
       
       auto subBasisOutputValues = getOutputView<OutputScalar>(fs, op, subBasis->getCardinality(), numPoints, spaceDim);
       subBasis->getValues(subBasisOutputValues, inputPoints, op);
-      
+      Kokkos::fence();
       bool vectorValued = (outputValues.rank() == 3); // F,P,D -- if scalar-valued, F,P
       
       for (int pointOrdinal=0; pointOrdinal<numPoints; pointOrdinal++)

--- a/packages/intrepid2/unit-test/Discretization/FunctionSpaceTools/test_03.hpp
+++ b/packages/intrepid2/unit-test/Discretization/FunctionSpaceTools/test_03.hpp
@@ -280,7 +280,8 @@ namespace Intrepid2 {
         // apply field signs
         fst::applyLeftFieldSigns(mass_matrices, field_signs);
         fst::applyRightFieldSigns(mass_matrices, field_signs);
-        
+        DeviceSpaceType().fence();
+
         /*******************  STOP COMPUTATION ***********************/
         
         

--- a/packages/intrepid2/unit-test/Discretization/Integration/test_util.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Integration/test_util.hpp
@@ -63,6 +63,7 @@ namespace Intrepid2 {
     computeRefVolume(const ordinal_type      numPoints,
                      const cubWeightViewType cubWeights) {
       typename cubWeightViewType::value_type r_val = 0.0;
+      Kokkos::fence();
       for (auto i=0;i<numPoints;++i)
         r_val += cubWeights(i);
 
@@ -83,6 +84,7 @@ namespace Intrepid2 {
       const ordinal_type polydeg[3] = { xDeg, yDeg, zDeg };
 
       const auto dim = p.extent(0);
+      Kokkos::fence();
       for (size_type i=0;i<dim;++i) 
         r_val *= std::pow(p(i),polydeg[i]);
       

--- a/packages/intrepid2/unit-test/Projection/test_convergence_HEX.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_convergence_HEX.hpp
@@ -406,6 +406,7 @@ int ConvergenceHex(const bool verbose) {
           Basis_HGRAD_HEX_C1_FEM<DeviceSpaceType,ValueType,ValueType> hexaLinearBasis; //used for computing physical coordinates
           DynRankView ConstructWithLabel(hexaLinearBasisValuesAtRefCoords, hexa.getNodeCount(), numRefCoords);
           hexaLinearBasis.getValues(hexaLinearBasisValuesAtRefCoords, refPoints);
+          DeviceSpaceType().fence();
           for(ordinal_type i=0; i<numElems; ++i)
             for(ordinal_type d=0; d<dim; ++d)
               for(ordinal_type j=0; j<numRefCoords; ++j)
@@ -460,6 +461,7 @@ int ConvergenceHex(const bool verbose) {
               hexLinearBasis.getValues(hexLinearBasisValuesAtEvalPoints, Kokkos::subview(evaluationPoints,i,Kokkos::ALL(),Kokkos::ALL()));
               if(numGradPoints>0)
                 hexLinearBasis.getValues(hexLinearBasisValuesAtEvalGradPoints, Kokkos::subview(evaluationGradPoints,i,Kokkos::ALL(),Kokkos::ALL()));
+              DeviceSpaceType().fence();
               for(ordinal_type d=0; d<dim; ++d) {
                 for(std::size_t k=0; k<hexa.getNodeCount(); ++k) {
                   for(ordinal_type j=0; j<numPoints; ++j)
@@ -610,6 +612,7 @@ int ConvergenceHex(const bool verbose) {
           Basis_HGRAD_HEX_C1_FEM<DeviceSpaceType,ValueType,ValueType> hexaLinearBasis; //used for computing physical coordinates
           DynRankView ConstructWithLabel(hexaLinearBasisValuesAtRefCoords, hexa.getNodeCount(), numRefCoords);
           hexaLinearBasis.getValues(hexaLinearBasisValuesAtRefCoords, refPoints);
+          DeviceSpaceType().fence();
           for(ordinal_type i=0; i<numElems; ++i)
             for(ordinal_type d=0; d<dim; ++d)
               for(ordinal_type j=0; j<numRefCoords; ++j)
@@ -663,6 +666,7 @@ int ConvergenceHex(const bool verbose) {
             for(ordinal_type i=0; i<numElems; ++i) {
               hexLinearBasis.getValues(hexLinearBasisValuesAtEvalPoints, Kokkos::subview(evaluationPoints,i,Kokkos::ALL(),Kokkos::ALL()));
               hexLinearBasis.getValues(hexLinearBasisValuesAtEvalCurlPoints, Kokkos::subview(evaluationCurlPoints,i,Kokkos::ALL(),Kokkos::ALL()));
+              DeviceSpaceType().fence();
               for(ordinal_type d=0; d<dim; ++d) {
                 for(std::size_t k=0; k<hexa.getNodeCount(); ++k) {
                   for(ordinal_type j=0; j<numPoints; ++j)
@@ -829,6 +833,7 @@ int ConvergenceHex(const bool verbose) {
           Basis_HGRAD_HEX_C1_FEM<DeviceSpaceType,ValueType,ValueType> hexaLinearBasis; //used for computing physical coordinates
           DynRankView ConstructWithLabel(hexaLinearBasisValuesAtRefCoords, hexa.getNodeCount(), numRefCoords);
           hexaLinearBasis.getValues(hexaLinearBasisValuesAtRefCoords, refPoints);
+          DeviceSpaceType().fence();
           for(ordinal_type i=0; i<numElems; ++i)
             for(ordinal_type d=0; d<dim; ++d)
               for(ordinal_type j=0; j<numRefCoords; ++j)
@@ -881,6 +886,7 @@ int ConvergenceHex(const bool verbose) {
             for(ordinal_type i=0; i<numElems; ++i) {
               hexLinearBasis.getValues(hexLinearBasisValuesAtEvalPoints, Kokkos::subview(evaluationPoints,i,Kokkos::ALL(),Kokkos::ALL()));
               hexLinearBasis.getValues(hexLinearBasisValuesAtEvalDivPoints, Kokkos::subview(evaluationDivPoints,i,Kokkos::ALL(),Kokkos::ALL()));
+              DeviceSpaceType().fence();
               for(ordinal_type d=0; d<dim; ++d) {
                 for(std::size_t k=0; k<hexa.getNodeCount(); ++k) {
                   for(ordinal_type j=0; j<numPoints; ++j)
@@ -1043,6 +1049,7 @@ int ConvergenceHex(const bool verbose) {
           Basis_HGRAD_HEX_C1_FEM<DeviceSpaceType,ValueType,ValueType> hexaLinearBasis; //used for computing physical coordinates
           DynRankView ConstructWithLabel(hexaLinearBasisValuesAtRefCoords, hexa.getNodeCount(), numRefCoords);
           hexaLinearBasis.getValues(hexaLinearBasisValuesAtRefCoords, refPoints);
+          DeviceSpaceType().fence();
           for(ordinal_type i=0; i<numElems; ++i)
             for(ordinal_type d=0; d<dim; ++d)
               for(ordinal_type j=0; j<numRefCoords; ++j)
@@ -1085,6 +1092,7 @@ int ConvergenceHex(const bool verbose) {
 
             for(ordinal_type i=0; i<numElems; ++i) {
               hexLinearBasis.getValues(hexLinearBasisValuesAtEvalPoints, Kokkos::subview(evaluationPoints,i,Kokkos::ALL(),Kokkos::ALL()));
+              DeviceSpaceType().fence();
               for(ordinal_type d=0; d<dim; ++d) {
                 for(std::size_t k=0; k<hexa.getNodeCount(); ++k) {
                   for(ordinal_type j=0; j<numPoints; ++j)

--- a/packages/intrepid2/unit-test/Projection/test_convergence_QUAD.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_convergence_QUAD.hpp
@@ -365,6 +365,7 @@ int ConvergenceQuad(const bool verbose) {
           Basis_HGRAD_QUAD_C1_FEM<DeviceSpaceType,ValueType,ValueType> quadLinearBasis; //used for computing physical coordinates
           DynRankView ConstructWithLabel(quadLinearBasisValuesAtRefCoords, quad.getNodeCount(), numRefCoords);
           quadLinearBasis.getValues(quadLinearBasisValuesAtRefCoords, refPoints);
+          DeviceSpaceType().fence();
           for(ordinal_type i=0; i<numElems; ++i)
             for(ordinal_type d=0; d<dim; ++d)
               for(ordinal_type j=0; j<numRefCoords; ++j)
@@ -419,6 +420,7 @@ int ConvergenceQuad(const bool verbose) {
               quadLinearBasis.getValues(quadLinearBasisValuesAtEvalPoints, Kokkos::subview(evaluationPoints,i,Kokkos::ALL(),Kokkos::ALL()));
               if(numGradPoints>0)
                 quadLinearBasis.getValues(quadLinearBasisValuesAtEvalGradPoints, Kokkos::subview(evaluationGradPoints,i,Kokkos::ALL(),Kokkos::ALL()));
+              DeviceSpaceType().fence();
               for(ordinal_type d=0; d<dim; ++d) {
                 for(std::size_t k=0; k<quad.getNodeCount(); ++k) {
                   for(ordinal_type j=0; j<numPoints; ++j)
@@ -569,6 +571,7 @@ int ConvergenceQuad(const bool verbose) {
           Basis_HGRAD_QUAD_C1_FEM<DeviceSpaceType,ValueType,ValueType> quadLinearBasis; //used for computing physical coordinates
           DynRankView ConstructWithLabel(quadLinearBasisValuesAtRefCoords, quad.getNodeCount(), numRefCoords);
           quadLinearBasis.getValues(quadLinearBasisValuesAtRefCoords, refPoints);
+          DeviceSpaceType().fence();
           for(ordinal_type i=0; i<numElems; ++i)
             for(ordinal_type d=0; d<dim; ++d)
               for(ordinal_type j=0; j<numRefCoords; ++j)
@@ -621,6 +624,7 @@ int ConvergenceQuad(const bool verbose) {
             for(ordinal_type i=0; i<numElems; ++i) {
               quadLinearBasis.getValues(quadLinearBasisValuesAtEvalPoints, Kokkos::subview(evaluationPoints,i,Kokkos::ALL(),Kokkos::ALL()));
               quadLinearBasis.getValues(quadLinearBasisValuesAtEvalCurlPoints, Kokkos::subview(evaluationCurlPoints,i,Kokkos::ALL(),Kokkos::ALL()));
+              DeviceSpaceType().fence();
               for(ordinal_type d=0; d<dim; ++d) {
                 for(std::size_t k=0; k<quad.getNodeCount(); ++k) {
                   for(ordinal_type j=0; j<numPoints; ++j)
@@ -777,6 +781,7 @@ int ConvergenceQuad(const bool verbose) {
           Basis_HGRAD_QUAD_C1_FEM<DeviceSpaceType,ValueType,ValueType> quadLinearBasis; //used for computing physical coordinates
           DynRankView ConstructWithLabel(quadLinearBasisValuesAtRefCoords, quad.getNodeCount(), numRefCoords);
           quadLinearBasis.getValues(quadLinearBasisValuesAtRefCoords, refPoints);
+          DeviceSpaceType().fence();
           for(ordinal_type i=0; i<numElems; ++i)
             for(ordinal_type d=0; d<dim; ++d)
               for(ordinal_type j=0; j<numRefCoords; ++j)
@@ -829,6 +834,7 @@ int ConvergenceQuad(const bool verbose) {
             for(ordinal_type i=0; i<numElems; ++i) {
               quadLinearBasis.getValues(quadLinearBasisValuesAtEvalPoints, Kokkos::subview(evaluationPoints,i,Kokkos::ALL(),Kokkos::ALL()));
               quadLinearBasis.getValues(quadLinearBasisValuesAtEvalDivPoints, Kokkos::subview(evaluationDivPoints,i,Kokkos::ALL(),Kokkos::ALL()));
+              DeviceSpaceType().fence();
               for(ordinal_type d=0; d<dim; ++d) {
                 for(std::size_t k=0; k<quad.getNodeCount(); ++k) {
                   for(ordinal_type j=0; j<numPoints; ++j)
@@ -989,6 +995,7 @@ int ConvergenceQuad(const bool verbose) {
           Basis_HGRAD_QUAD_C1_FEM<DeviceSpaceType,ValueType,ValueType> quadLinearBasis; //used for computing physical coordinates
           DynRankView ConstructWithLabel(quadLinearBasisValuesAtRefCoords, quad.getNodeCount(), numRefCoords);
           quadLinearBasis.getValues(quadLinearBasisValuesAtRefCoords, refPoints);
+          DeviceSpaceType().fence();
           for(ordinal_type i=0; i<numElems; ++i)
             for(ordinal_type d=0; d<dim; ++d)
               for(ordinal_type j=0; j<numRefCoords; ++j)
@@ -1031,6 +1038,7 @@ int ConvergenceQuad(const bool verbose) {
 
             for(ordinal_type i=0; i<numElems; ++i) {
               quadLinearBasis.getValues(quadLinearBasisValuesAtEvalPoints, Kokkos::subview(evaluationPoints,i,Kokkos::ALL(),Kokkos::ALL()));
+              DeviceSpaceType().fence();
               for(ordinal_type d=0; d<dim; ++d) {
                 for(std::size_t k=0; k<quad.getNodeCount(); ++k) {
                   for(ordinal_type j=0; j<numPoints; ++j)

--- a/packages/intrepid2/unit-test/Projection/test_convergence_TET.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_convergence_TET.hpp
@@ -435,6 +435,7 @@ int ConvergenceTet(const bool verbose) {
           Basis_HGRAD_TET_C1_FEM<DeviceSpaceType,ValueType,ValueType> tetLinearBasis; //used for computing physical coordinates
           DynRankView ConstructWithLabel(tetLinearBasisValuesAtRefCoords, tet.getNodeCount(), numRefCoords);
           tetLinearBasis.getValues(tetLinearBasisValuesAtRefCoords, refPoints);
+          DeviceSpaceType().fence();
           for(ordinal_type i=0; i<numElems; ++i)
             for(ordinal_type d=0; d<dim; ++d)
               for(ordinal_type j=0; j<numRefCoords; ++j)
@@ -489,6 +490,7 @@ int ConvergenceTet(const bool verbose) {
               hexLinearBasis.getValues(hexLinearBasisValuesAtEvalPoints, Kokkos::subview(evaluationPoints,i,Kokkos::ALL(),Kokkos::ALL()));
               if(numGradPoints>0)
                 hexLinearBasis.getValues(hexLinearBasisValuesAtEvalGradPoints, Kokkos::subview(evaluationGradPoints,i,Kokkos::ALL(),Kokkos::ALL()));
+              DeviceSpaceType().fence();
               for(ordinal_type d=0; d<dim; ++d) {
                 for(std::size_t k=0; k<tet.getNodeCount(); ++k) {
                   for(ordinal_type j=0; j<numPoints; ++j)
@@ -638,6 +640,7 @@ int ConvergenceTet(const bool verbose) {
           Basis_HGRAD_TET_C1_FEM<DeviceSpaceType,ValueType,ValueType> tetLinearBasis; //used for computing physical coordinates
           DynRankView ConstructWithLabel(tetLinearBasisValuesAtRefCoords, tet.getNodeCount(), numRefCoords);
           tetLinearBasis.getValues(tetLinearBasisValuesAtRefCoords, refPoints);
+          DeviceSpaceType().fence();
           for(ordinal_type i=0; i<numElems; ++i)
             for(ordinal_type d=0; d<dim; ++d)
               for(ordinal_type j=0; j<numRefCoords; ++j)
@@ -691,6 +694,7 @@ int ConvergenceTet(const bool verbose) {
             for(ordinal_type i=0; i<numElems; ++i) {
               hexLinearBasis.getValues(hexLinearBasisValuesAtEvalPoints, Kokkos::subview(evaluationPoints,i,Kokkos::ALL(),Kokkos::ALL()));
               hexLinearBasis.getValues(hexLinearBasisValuesAtEvalCurlPoints, Kokkos::subview(evaluationCurlPoints,i,Kokkos::ALL(),Kokkos::ALL()));
+              DeviceSpaceType().fence();
               for(ordinal_type d=0; d<dim; ++d) {
                 for(std::size_t k=0; k<tet.getNodeCount(); ++k) {
                   for(ordinal_type j=0; j<numPoints; ++j)
@@ -854,6 +858,7 @@ int ConvergenceTet(const bool verbose) {
           Basis_HGRAD_TET_C1_FEM<DeviceSpaceType,ValueType,ValueType> tetLinearBasis; //used for computing physical coordinates
           DynRankView ConstructWithLabel(tetLinearBasisValuesAtRefCoords, tet.getNodeCount(), numRefCoords);
           tetLinearBasis.getValues(tetLinearBasisValuesAtRefCoords, refPoints);
+          DeviceSpaceType().fence();
           for(ordinal_type i=0; i<numElems; ++i)
             for(ordinal_type d=0; d<dim; ++d)
               for(ordinal_type j=0; j<numRefCoords; ++j)
@@ -906,6 +911,7 @@ int ConvergenceTet(const bool verbose) {
             for(ordinal_type i=0; i<numElems; ++i) {
               hexLinearBasis.getValues(hexLinearBasisValuesAtEvalPoints, Kokkos::subview(evaluationPoints,i,Kokkos::ALL(),Kokkos::ALL()));
               hexLinearBasis.getValues(hexLinearBasisValuesAtEvalDivPoints, Kokkos::subview(evaluationDivPoints,i,Kokkos::ALL(),Kokkos::ALL()));
+              DeviceSpaceType().fence();
               for(ordinal_type d=0; d<dim; ++d) {
                 for(std::size_t k=0; k<tet.getNodeCount(); ++k) {
                   for(ordinal_type j=0; j<numPoints; ++j)
@@ -1066,6 +1072,7 @@ int ConvergenceTet(const bool verbose) {
           Basis_HGRAD_TET_C1_FEM<DeviceSpaceType,ValueType,ValueType> tetLinearBasis; //used for computing physical coordinates
           DynRankView ConstructWithLabel(tetLinearBasisValuesAtRefCoords, tet.getNodeCount(), numRefCoords);
           tetLinearBasis.getValues(tetLinearBasisValuesAtRefCoords, refPoints);
+          DeviceSpaceType().fence();
           for(ordinal_type i=0; i<numElems; ++i)
             for(ordinal_type d=0; d<dim; ++d)
               for(ordinal_type j=0; j<numRefCoords; ++j)
@@ -1108,6 +1115,7 @@ int ConvergenceTet(const bool verbose) {
 
             for(ordinal_type i=0; i<numElems; ++i) {
               hexLinearBasis.getValues(hexLinearBasisValuesAtEvalPoints, Kokkos::subview(evaluationPoints,i,Kokkos::ALL(),Kokkos::ALL()));
+              DeviceSpaceType().fence();
               for(ordinal_type d=0; d<dim; ++d) {
                 for(std::size_t k=0; k<tet.getNodeCount(); ++k) {
                   for(ordinal_type j=0; j<numPoints; ++j)

--- a/packages/intrepid2/unit-test/Projection/test_convergence_TRI.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_convergence_TRI.hpp
@@ -374,6 +374,7 @@ int ConvergenceTri(const bool verbose) {
           Basis_HGRAD_TRI_C1_FEM<DeviceSpaceType,ValueType,ValueType> triLinearBasis; //used for computing physical coordinates
           DynRankView ConstructWithLabel(triLinearBasisValuesAtRefCoords, tri.getNodeCount(), numRefCoords);
           triLinearBasis.getValues(triLinearBasisValuesAtRefCoords, refPoints);
+          DeviceSpaceType().fence();
           for(ordinal_type i=0; i<numElems; ++i)
             for(ordinal_type d=0; d<dim; ++d)
               for(ordinal_type j=0; j<numRefCoords; ++j)
@@ -428,6 +429,7 @@ int ConvergenceTri(const bool verbose) {
               triLinearBasis.getValues(triLinearBasisValuesAtEvalPoints, Kokkos::subview(evaluationPoints,i,Kokkos::ALL(),Kokkos::ALL()));
               if(numGradPoints>0)
                 triLinearBasis.getValues(triLinearBasisValuesAtEvalGradPoints, Kokkos::subview(evaluationGradPoints,i,Kokkos::ALL(),Kokkos::ALL()));
+              DeviceSpaceType().fence();
               for(ordinal_type d=0; d<dim; ++d) {
                 for(std::size_t k=0; k<tri.getNodeCount(); ++k) {
                   for(ordinal_type j=0; j<numPoints; ++j)
@@ -577,6 +579,7 @@ int ConvergenceTri(const bool verbose) {
           Basis_HGRAD_TRI_C1_FEM<DeviceSpaceType,ValueType,ValueType> triLinearBasis; //used for computing physical coordinates
           DynRankView ConstructWithLabel(triLinearBasisValuesAtRefCoords, tri.getNodeCount(), numRefCoords);
           triLinearBasis.getValues(triLinearBasisValuesAtRefCoords, refPoints);
+          DeviceSpaceType().fence();
           for(ordinal_type i=0; i<numElems; ++i)
             for(ordinal_type d=0; d<dim; ++d)
               for(ordinal_type j=0; j<numRefCoords; ++j)
@@ -629,6 +632,7 @@ int ConvergenceTri(const bool verbose) {
             for(ordinal_type i=0; i<numElems; ++i) {
               triLinearBasis.getValues(triLinearBasisValuesAtEvalPoints, Kokkos::subview(evaluationPoints,i,Kokkos::ALL(),Kokkos::ALL()));
               triLinearBasis.getValues(triLinearBasisValuesAtEvalCurlPoints, Kokkos::subview(evaluationCurlPoints,i,Kokkos::ALL(),Kokkos::ALL()));
+              DeviceSpaceType().fence();
               for(ordinal_type d=0; d<dim; ++d) {
                 for(std::size_t k=0; k<tri.getNodeCount(); ++k) {
                   for(ordinal_type j=0; j<numPoints; ++j)
@@ -785,6 +789,7 @@ int ConvergenceTri(const bool verbose) {
           Basis_HGRAD_TRI_C1_FEM<DeviceSpaceType,ValueType,ValueType> triLinearBasis; //used for computing physical coordinates
           DynRankView ConstructWithLabel(triLinearBasisValuesAtRefCoords, tri.getNodeCount(), numRefCoords);
           triLinearBasis.getValues(triLinearBasisValuesAtRefCoords, refPoints);
+          DeviceSpaceType().fence();
           for(ordinal_type i=0; i<numElems; ++i)
             for(ordinal_type d=0; d<dim; ++d)
               for(ordinal_type j=0; j<numRefCoords; ++j)
@@ -837,6 +842,7 @@ int ConvergenceTri(const bool verbose) {
             for(ordinal_type i=0; i<numElems; ++i) {
               triLinearBasis.getValues(triLinearBasisValuesAtEvalPoints, Kokkos::subview(evaluationPoints,i,Kokkos::ALL(),Kokkos::ALL()));
               triLinearBasis.getValues(triLinearBasisValuesAtEvalDivPoints, Kokkos::subview(evaluationDivPoints,i,Kokkos::ALL(),Kokkos::ALL()));
+              DeviceSpaceType().fence();
               for(ordinal_type d=0; d<dim; ++d) {
                 for(std::size_t k=0; k<tri.getNodeCount(); ++k) {
                   for(ordinal_type j=0; j<numPoints; ++j)
@@ -998,6 +1004,7 @@ int ConvergenceTri(const bool verbose) {
           Basis_HGRAD_TRI_C1_FEM<DeviceSpaceType,ValueType,ValueType> triLinearBasis; //used for computing physical coordinates
           DynRankView ConstructWithLabel(triLinearBasisValuesAtRefCoords, tri.getNodeCount(), numRefCoords);
           triLinearBasis.getValues(triLinearBasisValuesAtRefCoords, refPoints);
+          DeviceSpaceType().fence();
           for(ordinal_type i=0; i<numElems; ++i)
             for(ordinal_type d=0; d<dim; ++d)
               for(ordinal_type j=0; j<numRefCoords; ++j)
@@ -1040,6 +1047,7 @@ int ConvergenceTri(const bool verbose) {
 
             for(ordinal_type i=0; i<numElems; ++i) {
               triLinearBasis.getValues(triLinearBasisValuesAtEvalPoints, Kokkos::subview(evaluationPoints,i,Kokkos::ALL(),Kokkos::ALL()));
+              DeviceSpaceType().fence();
               for(ordinal_type d=0; d<dim; ++d) {
                 for(std::size_t k=0; k<tri.getNodeCount(); ++k) {
                   for(ordinal_type j=0; j<numPoints; ++j)

--- a/packages/intrepid2/unit-test/Projection/test_interpolation_projection_HEX.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_interpolation_projection_HEX.hpp
@@ -357,7 +357,7 @@ int InterpolationProjectionHex(const bool verbose) {
                   auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
                   auto outView =Kokkos::subview( hexLinearBasisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
                   hexLinearBasis.getValues(outView, inView);
-
+                  DeviceSpaceType().fence();
                   for(ordinal_type j=0; j<basisCardinality; ++j)
                     for(std::size_t k=0; k<hex.getNodeCount(); ++k)
                       physDofCoords(i,j,d) += vertices[hexas[i][k]][d]*hexLinearBasisValuesAtDofCoords(i,k,j);
@@ -394,7 +394,7 @@ int InterpolationProjectionHex(const bool verbose) {
               fst::HGRADtransformVALUE(transformedBasisValuesAtDofCoordsOriented,
                   basisValuesAtDofCoordsOriented);
 
-
+              DeviceSpaceType().fence();
               for(ordinal_type k=0; k<basisCardinality; ++k) {
                 for(ordinal_type j=0; j<basisCardinality; ++j){
                   ValueType dofValue = transformedBasisValuesAtDofCoordsOriented(i,k,j) * dofCoeffsPhys(i,j);
@@ -799,7 +799,7 @@ int InterpolationProjectionHex(const bool verbose) {
                   auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
                   auto outView =Kokkos::subview( hexLinearBasisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
                   hexLinearBasis.getValues(outView, inView);
-
+                  DeviceSpaceType().fence();
                   for(ordinal_type j=0; j<basisCardinality; ++j)
                     for(std::size_t k=0; k<hex.getNodeCount(); ++k)
                       physDofCoords(i,j,d) += vertices[hexas[i][k]][d]*hexLinearBasisValuesAtDofCoords(i,k,j);
@@ -1235,7 +1235,7 @@ int InterpolationProjectionHex(const bool verbose) {
                 auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
                 auto outView =Kokkos::subview( hexLinearBasisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
                 hexLinearBasis.getValues(outView, inView);
-
+                DeviceSpaceType().fence();
                 for(ordinal_type j=0; j<basisCardinality; ++j)
                   for(std::size_t k=0; k<hex.getNodeCount(); ++k)
                     physDofCoords(i,j,d) += vertices[hexas[i][k]][d]*hexLinearBasisValuesAtDofCoords(i,k,j);
@@ -1628,7 +1628,7 @@ int InterpolationProjectionHex(const bool verbose) {
               auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
               auto outView =Kokkos::subview( hexLinearBasisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
               hexLinearBasis.getValues(outView, inView);
-
+              DeviceSpaceType().fence();
               for(ordinal_type j=0; j<basisCardinality; ++j)
                 for(std::size_t k=0; k<hex.getNodeCount(); ++k)
                   physDofCoords(i,j,d) += vertices[hexas[i][k]][d]*hexLinearBasisValuesAtDofCoords(i,k,j);

--- a/packages/intrepid2/unit-test/Projection/test_interpolation_projection_QUAD.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_interpolation_projection_QUAD.hpp
@@ -306,7 +306,7 @@ int InterpolationProjectionQuad(const bool verbose) {
                   auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
                   auto outView =Kokkos::subview( quadLinearBasisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
                   quadLinearBasis.getValues(outView, inView);
-
+                  DeviceSpaceType().fence();
                   for(ordinal_type j=0; j<basisCardinality; ++j)
                     for(std::size_t k=0; k<quad.getNodeCount(); ++k)
                       physDofCoords(i,j,d) += vertices[quads[i][k]][d]*quadLinearBasisValuesAtDofCoords(i,k,j);
@@ -343,7 +343,7 @@ int InterpolationProjectionQuad(const bool verbose) {
               fst::HGRADtransformVALUE(transformedBasisValuesAtDofCoordsOriented,
                   basisValuesAtDofCoordsOriented);
 
-
+              DeviceSpaceType().fence();
               for(ordinal_type k=0; k<basisCardinality; ++k) {
                 for(ordinal_type j=0; j<basisCardinality; ++j){
                   ValueType dofValue = transformedBasisValuesAtDofCoordsOriented(i,k,j) * dofCoeffsPhys(i,j);
@@ -685,7 +685,7 @@ int InterpolationProjectionQuad(const bool verbose) {
                   auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
                   auto outView =Kokkos::subview( quadLinearBasisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
                   quadLinearBasis.getValues(outView, inView);
-
+                  DeviceSpaceType().fence();
                   for(ordinal_type j=0; j<basisCardinality; ++j)
                     for(std::size_t k=0; k<quad.getNodeCount(); ++k)
                       physDofCoords(i,j,d) += vertices[quads[i][k]][d]*quadLinearBasisValuesAtDofCoords(i,k,j);
@@ -1068,7 +1068,7 @@ int InterpolationProjectionQuad(const bool verbose) {
                 auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
                 auto outView =Kokkos::subview( quadLinearBasisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
                 quadLinearBasis.getValues(outView, inView);
-
+                DeviceSpaceType().fence();
                 for(ordinal_type j=0; j<basisCardinality; ++j)
                   for(std::size_t k=0; k<quad.getNodeCount(); ++k)
                     physDofCoords(i,j,d) += vertices[quads[i][k]][d]*quadLinearBasisValuesAtDofCoords(i,k,j);
@@ -1435,7 +1435,7 @@ int InterpolationProjectionQuad(const bool verbose) {
               auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
               auto outView =Kokkos::subview( quadLinearBasisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
               quadLinearBasis.getValues(outView, inView);
-
+              DeviceSpaceType().fence();
               for(ordinal_type j=0; j<basisCardinality; ++j)
                 for(std::size_t k=0; k<quad.getNodeCount(); ++k)
                   physDofCoords(i,j,d) += vertices[quads[i][k]][d]*quadLinearBasisValuesAtDofCoords(i,k,j);

--- a/packages/intrepid2/unit-test/Projection/test_interpolation_projection_TET.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_interpolation_projection_TET.hpp
@@ -332,7 +332,7 @@ int InterpolationProjectionTet(const bool verbose) {
                   auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
                   auto outView =Kokkos::subview( tetLinearBasisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
                   tetLinearBasis.getValues(outView, inView);
-
+                  DeviceSpaceType().fence();
                   for(ordinal_type j=0; j<basisCardinality; ++j)
                     for(std::size_t k=0; k<tet.getNodeCount(); ++k)
                       physDofCoords(i,j,d) += vertices[tets[i][k]][d]*tetLinearBasisValuesAtDofCoords(i,k,j);
@@ -347,7 +347,6 @@ int InterpolationProjectionTet(const bool verbose) {
             }
 
             li::getBasisCoeffs(basisCoeffsLI, funAtDofCoords, dofCoeffsPhys);
-            Kokkos::fence();
           }
 
           //Testing Kronecker property of basis functions
@@ -370,7 +369,7 @@ int InterpolationProjectionTet(const bool verbose) {
               fst::HGRADtransformVALUE(transformedBasisValuesAtDofCoordsOriented,
                   basisValuesAtDofCoordsOriented);
 
-
+              DeviceSpaceType().fence();
               for(ordinal_type k=0; k<basisCardinality; ++k) {
                 for(ordinal_type j=0; j<basisCardinality; ++j){
                   ValueType dofValue = transformedBasisValuesAtDofCoordsOriented(i,k,j) * dofCoeffsPhys(i,j);
@@ -760,7 +759,7 @@ int InterpolationProjectionTet(const bool verbose) {
                   auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
                   auto outView =Kokkos::subview( tetLinearBasisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
                   tetLinearBasis.getValues(outView, inView);
-
+                  DeviceSpaceType().fence();
                   for(ordinal_type j=0; j<basisCardinality; ++j)
                     for(std::size_t k=0; k<tet.getNodeCount(); ++k)
                       physDofCoords(i,j,d) += vertices[tets[i][k]][d]*tetLinearBasisValuesAtDofCoords(i,k,j);
@@ -1174,7 +1173,7 @@ int InterpolationProjectionTet(const bool verbose) {
                 auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
                 auto outView =Kokkos::subview( tetLinearBasisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
                 tetLinearBasis.getValues(outView, inView);
-
+                DeviceSpaceType().fence();
                 for(ordinal_type j=0; j<basisCardinality; ++j)
                   for(std::size_t k=0; k<tet.getNodeCount(); ++k)
                     physDofCoords(i,j,d) += vertices[tets[i][k]][d]*tetLinearBasisValuesAtDofCoords(i,k,j);
@@ -1569,7 +1568,7 @@ int InterpolationProjectionTet(const bool verbose) {
               auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
               auto outView =Kokkos::subview( tetLinearBasisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
               tetLinearBasis.getValues(outView, inView);
-
+              DeviceSpaceType().fence();
               for(ordinal_type j=0; j<basisCardinality; ++j)
                 for(std::size_t k=0; k<tet.getNodeCount(); ++k)
                   physDofCoords(i,j,d) += vertices[tets[i][k]][d]*tetLinearBasisValuesAtDofCoords(i,k,j);

--- a/packages/intrepid2/unit-test/Projection/test_interpolation_projection_TRI.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_interpolation_projection_TRI.hpp
@@ -305,7 +305,7 @@ int InterpolationProjectionTri(const bool verbose) {
                   auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
                   auto outView =Kokkos::subview( triLinearBasisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
                   triLinearBasis.getValues(outView, inView);
-
+                  DeviceSpaceType().fence();
                   for(ordinal_type j=0; j<basisCardinality; ++j)
                     for(std::size_t k=0; k<tri.getNodeCount(); ++k)
                       physDofCoords(i,j,d) += vertices[tris[i][k]][d]*triLinearBasisValuesAtDofCoords(i,k,j);
@@ -342,7 +342,7 @@ int InterpolationProjectionTri(const bool verbose) {
               fst::HGRADtransformVALUE(transformedBasisValuesAtDofCoordsOriented,
                   basisValuesAtDofCoordsOriented);
 
-
+              DeviceSpaceType().fence();
               for(ordinal_type k=0; k<basisCardinality; ++k) {
                 for(ordinal_type j=0; j<basisCardinality; ++j){
                   ValueType dofValue = transformedBasisValuesAtDofCoordsOriented(i,k,j) * dofCoeffsPhys(i,j);
@@ -683,7 +683,7 @@ int InterpolationProjectionTri(const bool verbose) {
                   auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
                   auto outView =Kokkos::subview( triLinearBasisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
                   triLinearBasis.getValues(outView, inView);
-
+                  DeviceSpaceType().fence();
                   for(ordinal_type j=0; j<basisCardinality; ++j)
                     for(std::size_t k=0; k<tri.getNodeCount(); ++k)
                       physDofCoords(i,j,d) += vertices[tris[i][k]][d]*triLinearBasisValuesAtDofCoords(i,k,j);
@@ -1065,7 +1065,7 @@ int InterpolationProjectionTri(const bool verbose) {
                 auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
                 auto outView =Kokkos::subview( triLinearBasisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
                 triLinearBasis.getValues(outView, inView);
-
+                DeviceSpaceType().fence();
                 for(ordinal_type j=0; j<basisCardinality; ++j)
                   for(std::size_t k=0; k<tri.getNodeCount(); ++k)
                     physDofCoords(i,j,d) += vertices[tris[i][k]][d]*triLinearBasisValuesAtDofCoords(i,k,j);
@@ -1434,7 +1434,7 @@ int InterpolationProjectionTri(const bool verbose) {
               auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
               auto outView =Kokkos::subview( triLinearBasisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
               triLinearBasis.getValues(outView, inView);
-
+              DeviceSpaceType().fence();
               for(ordinal_type j=0; j<basisCardinality; ++j)
                 for(std::size_t k=0; k<tri.getNodeCount(); ++k)
                   physDofCoords(i,j,d) += vertices[tris[i][k]][d]*triLinearBasisValuesAtDofCoords(i,k,j);

--- a/packages/intrepid2/unit-test/Shared/Polylib/LegendreJacobiPolynomials/IntegratedJacobiTests.cpp
+++ b/packages/intrepid2/unit-test/Shared/Polylib/LegendreJacobiPolynomials/IntegratedJacobiTests.cpp
@@ -83,7 +83,8 @@ namespace
         {
           integratedJacobiValues(integratedJacobiView, alpha, polyOrder, x, t);
         });
-        
+
+        Kokkos::fence();
         for (int i=1; i<=polyOrder; i++)
         {
           if ( abs(integratedJacobiView(i)) > tol)
@@ -118,6 +119,7 @@ namespace
           integratedJacobiValues(integratedJacobiView, alpha, polyOrder, x, t);
         });
         
+        Kokkos::fence();
         const int i = 2;
         double diff = integratedJacobiView(i) - expected_value;
         if ( abs(diff) > tol)


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/intrepid2 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
To get Intrepid2 passing all unit tests with CUDA_LAUNCH_BLOCKING=0 in preparation for further work to analyze core fences in panzer.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

White Cuda Intrepid2 test suite.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->