### PR TITLE
Intrepid2: vectorNorm fencing

### DIFF
--- a/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefPhysToRef.hpp
+++ b/packages/intrepid2/src/Cell/Intrepid2_CellToolsDefPhysToRef.hpp
@@ -181,7 +181,10 @@ namespace Intrepid2 {
 
       // Average L2 error for a multiple sets of physical points: error is rank-2 (C,P) array 
       rst::vectorNorm(errorCellwise, errorPointwise, NORM_ONE);
-      const auto errorTotal = rst::Serial::vectorNorm(errorCellwise, NORM_ONE);
+
+      auto errorCellwise_h = Kokkos::create_mirror_view(errorCellwise);
+      Kokkos::deep_copy(errorCellwise_h, errorCellwise);
+      const auto errorTotal = rst::Serial::vectorNorm(errorCellwise_h, NORM_ONE);
     
       // Stopping criterion:
       if (errorTotal < tol) 

--- a/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_HEX_C1_FEM/test_02.hpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HGRAD_HEX_C1_FEM/test_02.hpp
@@ -609,7 +609,9 @@ namespace Intrepid2 {
             
                 rst::subtract(interpolant, exact_solution);
 
-                ValueType relNorm = rst::Serial::vectorNorm(interpolant, NORM_TWO);
+                auto interpolant_h = Kokkos::create_mirror_view(interpolant);
+                Kokkos::deep_copy(interpolant_h, interpolant);
+                ValueType relNorm = rst::Serial::vectorNorm(interpolant_h, NORM_TWO);
                               
                 *outStream << "\nRelative norm-2 error between exact solution polynomial of order ("
                            << x_order << ", " << y_order << ", " << z_order

--- a/packages/intrepid2/unit-test/Shared/ArrayTools/test_01.hpp
+++ b/packages/intrepid2/unit-test/Shared/ArrayTools/test_01.hpp
@@ -365,9 +365,11 @@ namespace Intrepid2 {
           art::contractFieldFieldScalar(out1_c_l_r, in_c_l_p, in_c_r_p);
           art::contractFieldFieldScalar(out2_c_l_r, in_c_l_p, in_c_r_p);
           rst::subtract(out1_c_l_r, out2_c_l_r);
-          if (rst::Serial::vectorNorm(out1_c_l_r, NORM_ONE) > tol) {
+          auto out1_c_l_r_h = Kokkos::create_mirror_view(out1_c_l_r);
+          Kokkos::deep_copy(out1_c_l_r_h, out1_c_l_r);
+          if (rst::Serial::vectorNorm(out1_c_l_r_h, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT contractFieldFieldScalar (1): check COMP_CPP vs. COMP_BLAS; "
-                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_r, NORM_ONE) << "\n\n";
+                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_r_h, NORM_ONE) << "\n\n";
             errorFlag = -1000;
           }
           // with sumInto:
@@ -381,9 +383,10 @@ namespace Intrepid2 {
           art::contractFieldFieldScalar(out1_c_l_r, in_c_l_p, in_c_r_p, true);
           art::contractFieldFieldScalar(out2_c_l_r, in_c_l_p, in_c_r_p, true);
           rst::subtract(out1_c_l_r, out2_c_l_r);
-          if (rst::Serial::vectorNorm(out1_c_l_r, NORM_ONE) > tol) {
+          Kokkos::deep_copy(out1_c_l_r_h, out1_c_l_r);
+          if (rst::Serial::vectorNorm(out1_c_l_r_h, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT contractFieldFieldScalar (1): check COMP_CPP vs. COMP_BLAS; "
-                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_r, NORM_ONE) << "\n\n";
+                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_r_h, NORM_ONE) << "\n\n";
             errorFlag = -1000;
           }
           } // end scope
@@ -415,9 +418,11 @@ namespace Intrepid2 {
           art::contractFieldFieldVector(out2_c_l_r, in_c_l_p_d, in_c_r_p_d);
 
           rst::subtract(out1_c_l_r, out2_c_l_r);
-          if (rst::Serial::vectorNorm(out1_c_l_r, NORM_ONE) > tol) {
+          auto out1_c_l_r_h = Kokkos::create_mirror_view(out1_c_l_r);
+          Kokkos::deep_copy(out1_c_l_r_h, out1_c_l_r);
+          if (rst::Serial::vectorNorm(out1_c_l_r_h, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT contractFieldFieldVector (1): check COMP_CPP vs. COMP_BLAS; "
-                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_r, NORM_ONE) << "\n\n";
+                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_r_h, NORM_ONE) << "\n\n";
             errorFlag = -1000;
           }
 
@@ -433,9 +438,10 @@ namespace Intrepid2 {
           art::contractFieldFieldVector(out2_c_l_r, in_c_l_p_d, in_c_r_p_d, true);
 
           rst::subtract(out1_c_l_r, out2_c_l_r);
-          if (rst::Serial::vectorNorm(out1_c_l_r, NORM_ONE) > tol) {
+          Kokkos::deep_copy(out1_c_l_r_h, out1_c_l_r);
+          if (rst::Serial::vectorNorm(out1_c_l_r_h, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT contractFieldFieldVector (1): check COMP_CPP vs. COMP_BLAS; "
-                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_r, NORM_ONE) << "\n\n";
+                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_r_h, NORM_ONE) << "\n\n";
             errorFlag = -1000;
           }
           } // end scope
@@ -468,9 +474,11 @@ namespace Intrepid2 {
           art::contractFieldFieldTensor(out2_c_l_r, in_c_l_p_d_d, in_c_r_p_d_d);
 
           rst::subtract(out1_c_l_r, out2_c_l_r);
-          if (rst::Serial::vectorNorm(out1_c_l_r, NORM_ONE) > tol) {
+          auto out1_c_l_r_h = Kokkos::create_mirror_view(out1_c_l_r);
+          Kokkos::deep_copy(out1_c_l_r_h, out1_c_l_r);
+          if (rst::Serial::vectorNorm(out1_c_l_r_h, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT contractFieldFieldTensor (1): check COMP_CPP vs. COMP_BLAS; "
-                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_r, NORM_ONE) << "\n\n";
+                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_r_h, NORM_ONE) << "\n\n";
             errorFlag = -1000;
           }
 
@@ -486,9 +494,10 @@ namespace Intrepid2 {
           art::contractFieldFieldTensor(out2_c_l_r, in_c_l_p_d_d, in_c_r_p_d_d, true);
 
           rst::subtract(out1_c_l_r, out2_c_l_r);
-          if (rst::Serial::vectorNorm(out1_c_l_r, NORM_ONE) > tol) {
+          Kokkos::deep_copy(out1_c_l_r_h, out1_c_l_r);
+          if (rst::Serial::vectorNorm(out1_c_l_r_h, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT contractFieldFieldTensor (1): check COMP_CPP vs. COMP_BLAS; "
-                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_r, NORM_ONE) << "\n\n";
+                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_r_h, NORM_ONE) << "\n\n";
             errorFlag = -1000;
           }
           } // end scope
@@ -519,18 +528,21 @@ namespace Intrepid2 {
           art::contractDataFieldScalar(out1_c_l, data_c_p, in_c_l_p);
           art::contractDataFieldScalar(out2_c_l, data_c_p, in_c_l_p);
           rst::subtract(out1_c_l, out2_c_l);
-          if (rst::Serial::vectorNorm(out1_c_l, NORM_ONE) > tol) {
+          auto out1_c_l_h = Kokkos::create_mirror_view(out1_c_l);
+          Kokkos::deep_copy(out1_c_l_h, out1_c_l);
+          if (rst::Serial::vectorNorm(out1_c_l_h, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT contractDataFieldScalar (1): check COMP_CPP vs. COMP_BLAS; "
-                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l, NORM_ONE) << "\n\n";
+                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_h, NORM_ONE) << "\n\n";
             errorFlag = -1000;
           }
           // constant data
           art::contractDataFieldScalar(out1_c_l, data_c_1, in_c_l_p);
           art::contractDataFieldScalar(out2_c_l, data_c_1, in_c_l_p);
           rst::subtract(out1_c_l, out2_c_l);
-          if (rst::Serial::vectorNorm(out1_c_l, NORM_ONE) > tol) {
+          Kokkos::deep_copy(out1_c_l_h, out1_c_l);
+          if (rst::Serial::vectorNorm(out1_c_l_h, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT contractDataFieldScalar (2): check COMP_CPP vs. COMP_BLAS; "
-                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l, NORM_ONE) << "\n\n";
+                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_h, NORM_ONE) << "\n\n";
             errorFlag = -1000;
           }
           // nonconstant data with sumInto
@@ -541,9 +553,10 @@ namespace Intrepid2 {
           art::contractDataFieldScalar(out1_c_l, data_c_p, in_c_l_p, true);
           art::contractDataFieldScalar(out2_c_l, data_c_p, in_c_l_p, true);
           rst::subtract(out1_c_l, out2_c_l);
-          if (rst::Serial::vectorNorm(out1_c_l, NORM_ONE) > tol) {
+          Kokkos::deep_copy(out1_c_l_h, out1_c_l);
+          if (rst::Serial::vectorNorm(out1_c_l_h, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT contractDataFieldScalar (1): check COMP_CPP vs. COMP_BLAS; "
-                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l, NORM_ONE) << "\n\n";
+                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_h, NORM_ONE) << "\n\n";
             errorFlag = -1000;
           }
           } // end scope
@@ -577,18 +590,21 @@ namespace Intrepid2 {
           art::contractDataFieldVector(out1_c_l, data_c_p_d, in_c_l_p_d);
           art::contractDataFieldVector(out2_c_l, data_c_p_d, in_c_l_p_d);
           rst::subtract(out1_c_l, out2_c_l);
-          if (rst::Serial::vectorNorm(out1_c_l, NORM_ONE) > tol) {
+          auto out1_c_l_h = Kokkos::create_mirror_view(out1_c_l);
+          Kokkos::deep_copy(out1_c_l_h, out1_c_l);
+          if (rst::Serial::vectorNorm(out1_c_l_h, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT contractDataFieldVector (1): check COMP_CPP vs. COMP_BLAS; "
-                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l, NORM_ONE) << "\n\n";
+                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_h, NORM_ONE) << "\n\n";
             errorFlag = -1000;
           }
           // constant data
           art::contractDataFieldVector(out1_c_l, data_c_1_d, in_c_l_p_d);
           art::contractDataFieldVector(out2_c_l, data_c_1_d, in_c_l_p_d);
           rst::subtract(out1_c_l, out2_c_l);
-          if (rst::Serial::vectorNorm(out1_c_l, NORM_ONE) > tol) {
+          Kokkos::deep_copy(out1_c_l_h, out1_c_l);
+          if (rst::Serial::vectorNorm(out1_c_l_h, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT contractDataFieldVector (2): check COMP_CPP vs. COMP_BLAS; "
-                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l, NORM_ONE) << "\n\n";
+                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_h, NORM_ONE) << "\n\n";
             errorFlag = -1000;
           }
           // nonconstant data with sumInto
@@ -603,9 +619,10 @@ namespace Intrepid2 {
           art::contractDataFieldVector(out1_c_l, data_c_p_d, in_c_l_p_d, true);
           art::contractDataFieldVector(out2_c_l, data_c_p_d, in_c_l_p_d, true);
           rst::subtract(out1_c_l, out2_c_l);
-          if (rst::Serial::vectorNorm(out1_c_l,NORM_ONE) > tol) {
+          Kokkos::deep_copy(out1_c_l_h, out1_c_l);
+          if (rst::Serial::vectorNorm(out1_c_l_h,NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT contractDataFieldVector (3): check COMP_CPP vs. COMP_BLAS; "
-                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l, NORM_ONE) << "\n\n";
+                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_h, NORM_ONE) << "\n\n";
             errorFlag = -1000;
           }
           } // end scope
@@ -642,9 +659,11 @@ namespace Intrepid2 {
           art::contractDataFieldTensor(out1_c_l, data_c_p_d_d, in_c_l_p_d_d);
           art::contractDataFieldTensor(out2_c_l, data_c_p_d_d, in_c_l_p_d_d);
           rst::subtract(out1_c_l, out2_c_l);
-          if (rst::Serial::vectorNorm(out1_c_l, NORM_ONE) > tol) {
+          auto out1_c_l_h = Kokkos::create_mirror_view(out1_c_l);
+          Kokkos::deep_copy(out1_c_l_h, out1_c_l);
+          if (rst::Serial::vectorNorm(out1_c_l_h, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT contractDataFieldTensor (1): check COMP_CPP vs. COMP_BLAS; "
-                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l, NORM_ONE) << "\n\n";
+                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_h, NORM_ONE) << "\n\n";
             errorFlag = -1000;
           }
 
@@ -652,9 +671,10 @@ namespace Intrepid2 {
           art::contractDataFieldTensor(out1_c_l, data_c_1_d_d, in_c_l_p_d_d);
           art::contractDataFieldTensor(out2_c_l, data_c_1_d_d, in_c_l_p_d_d);
           rst::subtract(out1_c_l, out2_c_l);
-          if (rst::Serial::vectorNorm(out1_c_l, NORM_ONE) > tol) {
+          Kokkos::deep_copy(out1_c_l_h, out1_c_l);
+          if (rst::Serial::vectorNorm(out1_c_l_h, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT contractDataFieldTensor (2): check COMP_CPP vs. COMP_BLAS; "
-                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l, NORM_ONE) << "\n\n";
+                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_h, NORM_ONE) << "\n\n";
             errorFlag = -1000;
           }
 
@@ -668,9 +688,10 @@ namespace Intrepid2 {
           art::contractDataFieldTensor(out1_c_l, data_c_p_d_d, in_c_l_p_d_d, true);
           art::contractDataFieldTensor(out2_c_l, data_c_p_d_d, in_c_l_p_d_d, true);
           rst::subtract(out1_c_l, out2_c_l);
-          if (rst::Serial::vectorNorm(out1_c_l, NORM_ONE) > tol) {
+          Kokkos::deep_copy(out1_c_l_h, out1_c_l);
+          if (rst::Serial::vectorNorm(out1_c_l_h, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT contractDataFieldTensor (3): check COMP_CPP vs. COMP_BLAS; "
-                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l, NORM_ONE) << "\n\n";
+                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_h, NORM_ONE) << "\n\n";
             errorFlag = -1000;
           }
           } // end scope
@@ -695,9 +716,11 @@ namespace Intrepid2 {
           art::contractDataDataScalar(out1_c, inl_c_p, inr_c_p);
           art::contractDataDataScalar(out2_c, inl_c_p, inr_c_p);
           rst::subtract(out1_c, out2_c);
-          if (rst::Serial::vectorNorm(out1_c, NORM_ONE) > tol) {
+          auto out1_c_h = Kokkos::create_mirror_view(out1_c);
+          Kokkos::deep_copy(out1_c_h, out1_c);
+          if (rst::Serial::vectorNorm(out1_c_h, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT contractDataDataScalar (1): check COMP_CPP vs. COMP_BLAS; "
-                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c, NORM_ONE) << "\n\n";
+                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_h, NORM_ONE) << "\n\n";
             errorFlag = -1000;
           }
           // with sumInto:
@@ -709,9 +732,10 @@ namespace Intrepid2 {
           art::contractDataDataScalar(out1_c, inl_c_p, inr_c_p, true);
           art::contractDataDataScalar(out2_c, inl_c_p, inr_c_p, true);
           rst::subtract(out1_c, out2_c);
-          if (rst::Serial::vectorNorm(out1_c, NORM_ONE) > tol) {
+          Kokkos::deep_copy(out1_c_h, out1_c);
+          if (rst::Serial::vectorNorm(out1_c_h, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT contractDataDataScalar (1): check COMP_CPP vs. COMP_BLAS; "
-                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c, NORM_ONE) << "\n\n";
+                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_h, NORM_ONE) << "\n\n";
             errorFlag = -1000;
           }
           } // end scope
@@ -738,9 +762,11 @@ namespace Intrepid2 {
           art::contractDataDataVector(out2_c, inl_c_p_d, inr_c_p_d);
 
           rst::subtract(out1_c, out2_c);
-          if (rst::Serial::vectorNorm(out1_c, NORM_ONE) > tol) {
+          auto out1_c_h = Kokkos::create_mirror_view(out1_c);
+          Kokkos::deep_copy(out1_c_h, out1_c);
+          if (rst::Serial::vectorNorm(out1_c_h, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT contractDataDataVector (1): check COMP_CPP vs. COMP_BLAS; "
-                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c, NORM_ONE) << "\n\n";
+                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_h, NORM_ONE) << "\n\n";
             errorFlag = -1000;
           }
 
@@ -754,9 +780,10 @@ namespace Intrepid2 {
           art::contractDataDataVector(out2_c, inl_c_p_d, inr_c_p_d, true);
 
           rst::subtract(out1_c, out2_c);
-          if (rst::Serial::vectorNorm(out1_c, NORM_ONE) > tol) {
+          Kokkos::deep_copy(out1_c_h, out1_c);
+          if (rst::Serial::vectorNorm(out1_c_h, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT contractDataDataVector (1): check COMP_CPP vs. COMP_BLAS; "
-                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c, NORM_ONE) << "\n\n";
+                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_h, NORM_ONE) << "\n\n";
             errorFlag = -1000;
           }
           } // end scope
@@ -784,9 +811,11 @@ namespace Intrepid2 {
           art::contractDataDataTensor(out2_c, inl_c_p_d_d, inr_c_p_d_d);
 
           rst::subtract(out1_c, out2_c);
-          if (rst::Serial::vectorNorm(out1_c, NORM_ONE) > tol) {
+          auto out1_c_h = Kokkos::create_mirror_view(out1_c);
+          Kokkos::deep_copy(out1_c_h, out1_c);
+          if (rst::Serial::vectorNorm(out1_c_h, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT contractDataDataTensor (1): check COMP_CPP vs. COMP_BLAS; "
-                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c, NORM_ONE) << "\n\n";
+                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_h, NORM_ONE) << "\n\n";
             errorFlag = -1000;
           }
 
@@ -800,9 +829,10 @@ namespace Intrepid2 {
           art::contractDataDataTensor(out2_c, inl_c_p_d_d, inr_c_p_d_d, true);
 
           rst::subtract(out1_c, out2_c);
-          if (rst::Serial::vectorNorm(out1_c, NORM_ONE) > tol) {
+          Kokkos::deep_copy(out1_c_h, out1_c);
+          if (rst::Serial::vectorNorm(out1_c_h, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT contractDataDataTensor (1): check COMP_CPP vs. COMP_BLAS; "
-                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c, NORM_ONE) << "\n\n";
+                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_h, NORM_ONE) << "\n\n";
             errorFlag = -1000;
           }
           } // end scope

--- a/packages/intrepid2/unit-test/Shared/ArrayTools/test_02.hpp
+++ b/packages/intrepid2/unit-test/Shared/ArrayTools/test_02.hpp
@@ -280,7 +280,9 @@ namespace Intrepid2 {
       art::scalarMultiplyDataField(out_c_f_p, data_c_p, in_c_f_p);
       art::scalarMultiplyDataField(outi_c_f_p, datainv_c_p, out_c_f_p);
       rst::subtract(outi_c_f_p, in_c_f_p);
-      if (rst::Serial::vectorNorm(outi_c_f_p, NORM_ONE) > tol) {
+      auto outi_c_f_p_h = Kokkos::create_mirror_view(outi_c_f_p);
+      Kokkos::deep_copy(outi_c_f_p_h, outi_c_f_p);
+      if (rst::Serial::vectorNorm(outi_c_f_p_h, NORM_ONE) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataField (1): check scalar inverse property\n\n";
         errorFlag = -1000;
       }
@@ -288,21 +290,26 @@ namespace Intrepid2 {
       art::scalarMultiplyDataField(out_c_f_p_d, data_c_p, in_c_f_p_d);
       art::scalarMultiplyDataField(outi_c_f_p_d, datainv_c_p, out_c_f_p_d);
       rst::subtract(outi_c_f_p_d, in_c_f_p_d);
-      if (rst::Serial::vectorNorm(outi_c_f_p_d, NORM_ONE) > tol) {
-        *outStream << "\n\nINCORRECT scalarMultiplyDataField (2): check scalar inverse property" << rst::Serial::vectorNorm(outi_c_f_p_d, NORM_ONE) << "\n\n";
+      auto outi_c_f_p_d_h = Kokkos::create_mirror_view(outi_c_f_p_d);
+      Kokkos::deep_copy(outi_c_f_p_d_h, outi_c_f_p_d);
+      if (rst::Serial::vectorNorm(outi_c_f_p_d_h, NORM_ONE) > tol) {
+        *outStream << "\n\nINCORRECT scalarMultiplyDataField (2): check scalar inverse property" << rst::Serial::vectorNorm(outi_c_f_p_d_h, NORM_ONE) << "\n\n";
         errorFlag = -1000;
       }
       art::scalarMultiplyDataField(out_c_f_p_d_d, data_c_p, in_c_f_p_d_d);
       art::scalarMultiplyDataField(outi_c_f_p_d_d, datainv_c_p, out_c_f_p_d_d);
       rst::subtract(outi_c_f_p_d_d, in_c_f_p_d_d);
-      if (rst::Serial::vectorNorm(outi_c_f_p_d_d, NORM_ONE) > tol) {
+      auto outi_c_f_p_d_d_h = Kokkos::create_mirror_view(outi_c_f_p_d_d);
+      Kokkos::deep_copy(outi_c_f_p_d_d_h, outi_c_f_p_d_d);
+      if (rst::Serial::vectorNorm(outi_c_f_p_d_d_h, NORM_ONE) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataField (3): check scalar inverse property\n\n";
         errorFlag = -1000;
       }
       art::scalarMultiplyDataField(out_c_f_p_d_d, data_c_1, in_c_f_p_d_d);
       art::scalarMultiplyDataField(outi_c_f_p_d_d, datainv_c_1, out_c_f_p_d_d);
       rst::subtract(outi_c_f_p_d_d, in_c_f_p_d_d);
-      if (rst::Serial::vectorNorm(outi_c_f_p_d_d, NORM_ONE) > tol) {
+      Kokkos::deep_copy(outi_c_f_p_d_d_h, outi_c_f_p_d_d);
+      if (rst::Serial::vectorNorm(outi_c_f_p_d_d_h, NORM_ONE) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataField (4): check scalar inverse property\n\n";
         errorFlag = -1000;
       }
@@ -311,16 +318,19 @@ namespace Intrepid2 {
       deep_copy(in_c_f_p_d_d, 1.0); deep_copy(data_c_p,5.0); deep_copy(data_c_1, 5.0);
 
       art::scalarMultiplyDataField(out_c_f_p_d_d, data_c_p, in_c_f_p_d_d);
-      if (std::abs(rst::Serial::vectorNorm(out_c_f_p_d_d, NORM_ONE) - data_c_p(0,0)*in_c_f_p_d_d(0,0,0,0,0)*c*p*f*d1*d2) > tol) {
+      auto out_c_f_p_d_d_h = Kokkos::create_mirror_view(out_c_f_p_d_d);
+      Kokkos::deep_copy(out_c_f_p_d_d_h, out_c_f_p_d_d);
+      if (std::abs(rst::Serial::vectorNorm(out_c_f_p_d_d_h, NORM_ONE) - data_c_p(0,0)*in_c_f_p_d_d(0,0,0,0,0)*c*p*f*d1*d2) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataField (5): check result: "
-                   << rst::Serial::vectorNorm(out_c_f_p_d_d, NORM_ONE) << " != "
+                   << rst::Serial::vectorNorm(out_c_f_p_d_d_h, NORM_ONE) << " != "
                    << data_c_p(0,0)*in_c_f_p_d_d(0,0,0,0,0)*c*f*p*d1*d2 << "\n\n";
         errorFlag = -1000;
       }
       art::scalarMultiplyDataField(out_c_f_p_d_d, data_c_1, in_c_f_p_d_d);
-      if (std::abs(rst::Serial::vectorNorm(out_c_f_p_d_d, NORM_ONE) - data_c_1(0,0)*in_c_f_p_d_d(0,0,0,0,0)*c*p*f*d1*d2) > tol) {
+      Kokkos::deep_copy(out_c_f_p_d_d_h, out_c_f_p_d_d);
+      if (std::abs(rst::Serial::vectorNorm(out_c_f_p_d_d_h, NORM_ONE) - data_c_1(0,0)*in_c_f_p_d_d(0,0,0,0,0)*c*p*f*d1*d2) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataField (6): check result: "
-                   << rst::Serial::vectorNorm(out_c_f_p_d_d, NORM_ONE) << " != "
+                   << rst::Serial::vectorNorm(out_c_f_p_d_d_h, NORM_ONE) << " != "
                    << data_c_1(0,0)*in_c_f_p_d_d(0,0)*c*f*p*d1*d2 << "\n\n";
         errorFlag = -1000;
       }
@@ -385,7 +395,9 @@ namespace Intrepid2 {
       art::scalarMultiplyDataField(outi_c_f_p, datainv_c_p, out_c_f_p);
       art::scalarMultiplyDataField(in_c_f_p, data_c_p_one, in_f_p);
       rst::subtract(outi_c_f_p, in_c_f_p);
-      if (rst::Serial::vectorNorm(outi_c_f_p, NORM_ONE) > tol) {
+      auto outi_c_f_p_h = Kokkos::create_mirror_view(outi_c_f_p);
+      Kokkos::deep_copy(outi_c_f_p_h, outi_c_f_p);
+      if (rst::Serial::vectorNorm(outi_c_f_p_h, NORM_ONE) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataField (1): check scalar inverse property\n\n";
         errorFlag = -1000;
       }
@@ -393,7 +405,9 @@ namespace Intrepid2 {
       art::scalarMultiplyDataField(outi_c_f_p_d, datainv_c_p, out_c_f_p_d);
       art::scalarMultiplyDataField(in_c_f_p_d, data_c_p_one, in_f_p_d);
       rst::subtract(outi_c_f_p_d, in_c_f_p_d);
-      if (rst::Serial::vectorNorm(outi_c_f_p_d, NORM_ONE) > tol) {
+      auto outi_c_f_p_d_h = Kokkos::create_mirror_view(outi_c_f_p_d);
+      Kokkos::deep_copy(outi_c_f_p_d_h, outi_c_f_p_d);
+      if (rst::Serial::vectorNorm(outi_c_f_p_d_h, NORM_ONE) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataField (2): check scalar inverse property\n\n";
         errorFlag = -1000;
       }
@@ -401,7 +415,9 @@ namespace Intrepid2 {
       art::scalarMultiplyDataField(outi_c_f_p_d_d, datainv_c_p, out_c_f_p_d_d);
       art::scalarMultiplyDataField(in_c_f_p_d_d, data_c_p_one, in_f_p_d_d);
       rst::subtract(outi_c_f_p_d_d, in_c_f_p_d_d);
-      if (rst::Serial::vectorNorm(outi_c_f_p_d_d, NORM_ONE) > tol) {
+      auto outi_c_f_p_d_d_h = Kokkos::create_mirror_view(outi_c_f_p_d_d);
+      Kokkos::deep_copy(outi_c_f_p_d_d_h, outi_c_f_p_d_d);
+      if (rst::Serial::vectorNorm(outi_c_f_p_d_d_h, NORM_ONE) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataField (3): check scalar inverse property\n\n";
         errorFlag = -1000;
       }
@@ -409,7 +425,8 @@ namespace Intrepid2 {
       art::scalarMultiplyDataField(outi_c_f_p_d_d, datainv_c_1, out_c_f_p_d_d);
       art::scalarMultiplyDataField(in_c_f_p_d_d, data_c_p_one, in_f_p_d_d);
       rst::subtract(outi_c_f_p_d_d, in_c_f_p_d_d);
-      if (rst::Serial::vectorNorm(outi_c_f_p_d_d, NORM_ONE) > tol) {
+      Kokkos::deep_copy(outi_c_f_p_d_d_h, outi_c_f_p_d_d);
+      if (rst::Serial::vectorNorm(outi_c_f_p_d_d_h, NORM_ONE) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataField (4): check scalar inverse property\n\n";
         errorFlag = -1000;
       }
@@ -418,16 +435,19 @@ namespace Intrepid2 {
       deep_copy(in_f_p_d_d, 1.0); deep_copy(data_c_p, 5.0); deep_copy(data_c_1, 5.0);
 
       art::scalarMultiplyDataField(out_c_f_p_d_d, data_c_p, in_f_p_d_d);
-      if (std::abs(rst::Serial::vectorNorm(out_c_f_p_d_d, NORM_ONE) - data_c_p(0,0)*in_f_p_d_d(0,0,0,0)*c*p*f*d1*d2) > tol) {
+      auto out_c_f_p_d_d_h = Kokkos::create_mirror_view(out_c_f_p_d_d);
+      Kokkos::deep_copy(out_c_f_p_d_d_h, out_c_f_p_d_d);
+      if (std::abs(rst::Serial::vectorNorm(out_c_f_p_d_d_h, NORM_ONE) - data_c_p(0,0)*in_f_p_d_d(0,0,0,0)*c*p*f*d1*d2) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataField (5): check result: "
-                   << rst::Serial::vectorNorm(out_c_f_p_d_d, NORM_ONE) << " != "
+                   << rst::Serial::vectorNorm(out_c_f_p_d_d_h, NORM_ONE) << " != "
                    << data_c_p(0,0)*in_f_p_d_d(0,0,0,0)*c*f*p*d1*d2 << "\n\n";
         errorFlag = -1000;
       }
       art::scalarMultiplyDataField(out_c_f_p_d_d, data_c_1, in_f_p_d_d);
-      if (std::abs(rst::Serial::vectorNorm(out_c_f_p_d_d, NORM_ONE) - data_c_1(0,0)*in_f_p_d_d(0,0,0,0)*c*p*f*d1*d2) > tol) {
+      Kokkos::deep_copy(out_c_f_p_d_d_h, out_c_f_p_d_d);
+      if (std::abs(rst::Serial::vectorNorm(out_c_f_p_d_d_h, NORM_ONE) - data_c_1(0,0)*in_f_p_d_d(0,0,0,0)*c*p*f*d1*d2) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataField (6): check result: "
-                   << rst::Serial::vectorNorm(out_c_f_p_d_d, NORM_ONE) << " != "
+                   << rst::Serial::vectorNorm(out_c_f_p_d_d_h, NORM_ONE) << " != "
                    << data_c_1(0,0)*in_f_p_d_d(0,0,0,0)*c*f*p*d1*d2 << "\n\n";
         errorFlag = -1000;
       }
@@ -477,28 +497,35 @@ namespace Intrepid2 {
       art::scalarMultiplyDataField(out_c_f_p, data_c_p, in_c_f_p, true);
       art::scalarMultiplyDataField(outi_c_f_p, datainv_c_p, out_c_f_p, true);
       rst::subtract(outi_c_f_p, in_c_f_p);
-      if (rst::Serial::vectorNorm(outi_c_f_p, NORM_ONE) > tol) {
+      auto outi_c_f_p_h = Kokkos::create_mirror_view(outi_c_f_p);
+      Kokkos::deep_copy(outi_c_f_p_h, outi_c_f_p);
+      if (rst::Serial::vectorNorm(outi_c_f_p_h, NORM_ONE) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataField (1): check scalar inverse property\n\n";
         errorFlag = -1000;
       }
       art::scalarMultiplyDataField(out_c_f_p_d, data_c_p, in_c_f_p_d, true);
       art::scalarMultiplyDataField(outi_c_f_p_d, datainv_c_p, out_c_f_p_d, true);
       rst::subtract(outi_c_f_p_d, in_c_f_p_d);
-      if (rst::Serial::vectorNorm(outi_c_f_p_d, NORM_ONE) > tol) {
+      auto outi_c_f_p_d_h = Kokkos::create_mirror_view(outi_c_f_p_d);
+      Kokkos::deep_copy(outi_c_f_p_d_h, outi_c_f_p_d);
+      if (rst::Serial::vectorNorm(outi_c_f_p_d_h, NORM_ONE) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataField (2): check scalar inverse property\n\n";
         errorFlag = -1000;
       }
       art::scalarMultiplyDataField(out_c_f_p_d_d, data_c_p, in_c_f_p_d_d, true);
       art::scalarMultiplyDataField(outi_c_f_p_d_d, datainv_c_p, out_c_f_p_d_d, true);
       rst::subtract(outi_c_f_p_d_d, in_c_f_p_d_d);
-      if (rst::Serial::vectorNorm(outi_c_f_p_d_d, NORM_ONE) > tol) {
+      auto outi_c_f_p_d_d_h = Kokkos::create_mirror_view(outi_c_f_p_d_d);
+      Kokkos::deep_copy(outi_c_f_p_d_d_h, outi_c_f_p_d_d);
+      if (rst::Serial::vectorNorm(outi_c_f_p_d_d_h, NORM_ONE) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataField (3): check scalar inverse property\n\n";
         errorFlag = -1000;
       }
       art::scalarMultiplyDataField(out_c_f_p_d_d, data_c_1, in_c_f_p_d_d, true);
       art::scalarMultiplyDataField(outi_c_f_p_d_d, datainv_c_1, out_c_f_p_d_d, true);
       rst::subtract(outi_c_f_p_d_d, in_c_f_p_d_d);
-      if (rst::Serial::vectorNorm(outi_c_f_p_d_d, NORM_ONE) > tol) {
+      Kokkos::deep_copy(outi_c_f_p_d_d_h, outi_c_f_p_d_d);
+      if (rst::Serial::vectorNorm(outi_c_f_p_d_d_h, NORM_ONE) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataField (4): check scalar inverse property\n\n";
         errorFlag = -1000;
       }
@@ -507,16 +534,19 @@ namespace Intrepid2 {
       deep_copy(in_c_f_p_d_d, 1.0); deep_copy(data_c_p, 5.0); deep_copy(data_c_1, 5.0);
 
       art::scalarMultiplyDataField(out_c_f_p_d_d, data_c_p, in_c_f_p_d_d, true);
-      if (std::abs(rst::Serial::vectorNorm(out_c_f_p_d_d, NORM_ONE) - (1.0/data_c_p(0,0))*in_c_f_p_d_d(0,0,0,0,0)*c*p*f*d1*d2)/rst::Serial::vectorNorm(out_c_f_p_d_d, NORM_ONE) > tol) {
+      auto out_c_f_p_d_d_h = Kokkos::create_mirror_view(out_c_f_p_d_d);
+      Kokkos::deep_copy(out_c_f_p_d_d_h, out_c_f_p_d_d);
+      if (std::abs(rst::Serial::vectorNorm(out_c_f_p_d_d_h, NORM_ONE) - (1.0/data_c_p(0,0))*in_c_f_p_d_d(0,0,0,0,0)*c*p*f*d1*d2)/rst::Serial::vectorNorm(out_c_f_p_d_d_h, NORM_ONE) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataField (5): check result: "
-                   << rst::Serial::vectorNorm(out_c_f_p_d_d, NORM_ONE) << " != "
+                   << rst::Serial::vectorNorm(out_c_f_p_d_d_h, NORM_ONE) << " != "
                    << (1.0/data_c_p(0,0))*in_c_f_p_d_d(0,0,0,0,0)*c*p*f*d1*d2 << "\n\n";
         errorFlag = -1000;
       }
       art::scalarMultiplyDataField(out_c_f_p_d_d, data_c_1, in_c_f_p_d_d, true);
-      if (std::abs(rst::Serial::vectorNorm(out_c_f_p_d_d, NORM_ONE) - (1.0/data_c_1(0,0))*in_c_f_p_d_d(0,0,0,0,0)*c*p*f*d1*d2)/rst::Serial::vectorNorm(out_c_f_p_d_d, NORM_ONE) > tol) {
+      Kokkos::deep_copy(out_c_f_p_d_d_h, out_c_f_p_d_d);
+      if (std::abs(rst::Serial::vectorNorm(out_c_f_p_d_d_h, NORM_ONE) - (1.0/data_c_1(0,0))*in_c_f_p_d_d(0,0,0,0,0)*c*p*f*d1*d2)/rst::Serial::vectorNorm(out_c_f_p_d_d, NORM_ONE) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataField (6): check result: "
-                   << rst::Serial::vectorNorm(out_c_f_p_d_d, NORM_ONE) << " != "
+                   << rst::Serial::vectorNorm(out_c_f_p_d_d_h, NORM_ONE) << " != "
                    << (1.0/data_c_p(0,0))*in_c_f_p_d_d(0,0,0,0,0)*c*p*f*d1*d2 << "\n\n";
         errorFlag = -1000;
       }
@@ -582,7 +612,9 @@ namespace Intrepid2 {
       art::scalarMultiplyDataField(outi_c_f_p, datainv_c_p, out_c_f_p, true);
       art::scalarMultiplyDataField(in_c_f_p, data_c_p_one, in_f_p);
       rst::subtract(outi_c_f_p, in_c_f_p);
-      if (rst::Serial::vectorNorm(outi_c_f_p, NORM_ONE) > tol) {
+      auto outi_c_f_p_h = Kokkos::create_mirror_view(outi_c_f_p);
+      Kokkos::deep_copy(outi_c_f_p_h, outi_c_f_p);
+      if (rst::Serial::vectorNorm(outi_c_f_p_h, NORM_ONE) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataField (1): check scalar inverse property\n\n";
         errorFlag = -1000;
       }
@@ -590,7 +622,9 @@ namespace Intrepid2 {
       art::scalarMultiplyDataField(outi_c_f_p_d, datainv_c_p, out_c_f_p_d, true);
       art::scalarMultiplyDataField(in_c_f_p_d, data_c_p_one, in_f_p_d);
       rst::subtract(outi_c_f_p_d, in_c_f_p_d);
-      if (rst::Serial::vectorNorm(outi_c_f_p_d, NORM_ONE) > tol) {
+      auto outi_c_f_p_d_h = Kokkos::create_mirror_view(outi_c_f_p_d);
+      Kokkos::deep_copy(outi_c_f_p_d_h, outi_c_f_p_d);
+      if (rst::Serial::vectorNorm(outi_c_f_p_d_h, NORM_ONE) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataField (2): check scalar inverse property\n\n";
         errorFlag = -1000;
       }
@@ -598,7 +632,9 @@ namespace Intrepid2 {
       art::scalarMultiplyDataField(outi_c_f_p_d_d, datainv_c_p, out_c_f_p_d_d, true);
       art::scalarMultiplyDataField(in_c_f_p_d_d, data_c_p_one, in_f_p_d_d);
       rst::subtract(outi_c_f_p_d_d, in_c_f_p_d_d);
-      if (rst::Serial::vectorNorm(outi_c_f_p_d_d, NORM_ONE) > tol) {
+      auto outi_c_f_p_d_d_h = Kokkos::create_mirror_view(outi_c_f_p_d_d);
+      Kokkos::deep_copy(outi_c_f_p_d_d_h, outi_c_f_p_d_d);
+      if (rst::Serial::vectorNorm(outi_c_f_p_d_d_h, NORM_ONE) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataField (3): check scalar inverse property\n\n";
         errorFlag = -1000;
       }
@@ -606,7 +642,8 @@ namespace Intrepid2 {
       art::scalarMultiplyDataField(outi_c_f_p_d_d, datainv_c_1, out_c_f_p_d_d, true);
       art::scalarMultiplyDataField(in_c_f_p_d_d, data_c_p_one, in_f_p_d_d);
       rst::subtract(outi_c_f_p_d_d, in_c_f_p_d_d);
-      if (rst::Serial::vectorNorm(outi_c_f_p_d_d, NORM_ONE) > tol) {
+      Kokkos::deep_copy(outi_c_f_p_d_d_h, outi_c_f_p_d_d);
+      if (rst::Serial::vectorNorm(outi_c_f_p_d_d_h, NORM_ONE) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataField (4): check scalar inverse property\n\n";
         errorFlag = -1000;
       }
@@ -615,16 +652,19 @@ namespace Intrepid2 {
       deep_copy(in_f_p_d_d, 1.0); deep_copy(data_c_p, 5.0); deep_copy(data_c_1, 5.0);
 
       art::scalarMultiplyDataField(out_c_f_p_d_d, data_c_p, in_f_p_d_d, true);
-      if (std::abs(rst::Serial::vectorNorm(out_c_f_p_d_d, NORM_ONE) - (1.0/data_c_p(0,0))*in_f_p_d_d(0,0,0,0)*c*p*f*d1*d2)/rst::Serial::vectorNorm(out_c_f_p_d_d, NORM_ONE) > tol) {
+      auto out_c_f_p_d_d_h = Kokkos::create_mirror_view(out_c_f_p_d_d);
+      Kokkos::deep_copy(out_c_f_p_d_d_h, out_c_f_p_d_d);
+      if (std::abs(rst::Serial::vectorNorm(out_c_f_p_d_d_h, NORM_ONE) - (1.0/data_c_p(0,0))*in_f_p_d_d(0,0,0,0)*c*p*f*d1*d2)/rst::Serial::vectorNorm(out_c_f_p_d_d, NORM_ONE) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataField (5): check result: "
-                   << rst::Serial::vectorNorm(out_c_f_p_d_d, NORM_ONE) << " != "
+                   << rst::Serial::vectorNorm(out_c_f_p_d_d_h, NORM_ONE) << " != "
                    << (1.0/data_c_p(0,0))*in_f_p_d_d(0,0,0,0)*c*p*f*d1*d2 << "\n\n";
         errorFlag = -1000;
       }
       art::scalarMultiplyDataField(out_c_f_p_d_d, data_c_1, in_f_p_d_d, true);
-      if (std::abs(rst::Serial::vectorNorm(out_c_f_p_d_d, NORM_ONE) - (1.0/data_c_1(0,0))*in_f_p_d_d(0,0,0,0)*c*p*f*d1*d2)/rst::Serial::vectorNorm(out_c_f_p_d_d, NORM_ONE) > tol) {
+      Kokkos::deep_copy(out_c_f_p_d_d_h, out_c_f_p_d_d);
+      if (std::abs(rst::Serial::vectorNorm(out_c_f_p_d_d_h, NORM_ONE) - (1.0/data_c_1(0,0))*in_f_p_d_d(0,0,0,0)*c*p*f*d1*d2)/rst::Serial::vectorNorm(out_c_f_p_d_d, NORM_ONE) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataField (6): check result: "
-                   << rst::Serial::vectorNorm(out_c_f_p_d_d, NORM_ONE) << " != "
+                   << rst::Serial::vectorNorm(out_c_f_p_d_d_h, NORM_ONE) << " != "
                    << (1.0/data_c_1(0,0))*in_f_p_d_d(0,0,0,0)*c*p*f*d1*d2 << "\n\n";
         errorFlag = -1000;
       }
@@ -672,28 +712,35 @@ namespace Intrepid2 {
       art::scalarMultiplyDataData(out_c_p, data_c_p, in_c_p);
       art::scalarMultiplyDataData(outi_c_p, datainv_c_p, out_c_p);
       rst::subtract(outi_c_p, in_c_p);
-      if (rst::Serial::vectorNorm(outi_c_p, NORM_ONE) > tol) {
+      auto outi_c_p_h = Kokkos::create_mirror_view(outi_c_p);
+      Kokkos::deep_copy(outi_c_p_h, outi_c_p);
+      if (rst::Serial::vectorNorm(outi_c_p_h, NORM_ONE) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataData (1): check scalar inverse property\n\n";
         errorFlag = -1000;
       }
       art::scalarMultiplyDataData(out_c_p_d, data_c_p, in_c_p_d);
       art::scalarMultiplyDataData(outi_c_p_d, datainv_c_p, out_c_p_d);
       rst::subtract(outi_c_p_d, in_c_p_d);
-      if (rst::Serial::vectorNorm(outi_c_p_d, NORM_ONE) > tol) {
+      auto outi_c_p_d_h = Kokkos::create_mirror_view(outi_c_p_d);
+      Kokkos::deep_copy(outi_c_p_d_h, outi_c_p_d);
+      if (rst::Serial::vectorNorm(outi_c_p_d_h, NORM_ONE) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataData (2): check scalar inverse property\n\n";
         errorFlag = -1000;
       }
       art::scalarMultiplyDataData(out_c_p_d_d, data_c_p, in_c_p_d_d);
       art::scalarMultiplyDataData(outi_c_p_d_d, datainv_c_p, out_c_p_d_d);
       rst::subtract(outi_c_p_d_d, in_c_p_d_d);
-      if (rst::Serial::vectorNorm(outi_c_p_d_d, NORM_ONE) > tol) {
+      auto outi_c_p_d_d_h = Kokkos::create_mirror_view(outi_c_p_d_d);
+      Kokkos::deep_copy(outi_c_p_d_d_h, outi_c_p_d_d);
+      if (rst::Serial::vectorNorm(outi_c_p_d_d_h, NORM_ONE) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataData (3): check scalar inverse property\n\n";
         errorFlag = -1000;
       }
       art::scalarMultiplyDataData(out_c_p_d_d, data_c_1, in_c_p_d_d);
       art::scalarMultiplyDataData(outi_c_p_d_d, datainv_c_1, out_c_p_d_d);
       rst::subtract(outi_c_p_d_d, in_c_p_d_d);
-      if (rst::Serial::vectorNorm(outi_c_p_d_d, NORM_ONE) > tol) {
+      Kokkos::deep_copy(outi_c_p_d_d_h, outi_c_p_d_d);
+      if (rst::Serial::vectorNorm(outi_c_p_d_d_h, NORM_ONE) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataData (4): check scalar inverse property\n\n";
         errorFlag = -1000;
       }
@@ -702,16 +749,19 @@ namespace Intrepid2 {
       deep_copy(in_c_p_d_d, 1.0); deep_copy(data_c_p, 5.0); deep_copy(data_c_1, 5.0);
 
       art::scalarMultiplyDataData(out_c_p_d_d, data_c_p, in_c_p_d_d);
-      if (std::abs(rst::Serial::vectorNorm(out_c_p_d_d, NORM_ONE) - data_c_p(0,0)*in_c_p_d_d(0,0,0,0)*c*p*d1*d2) > tol) {
+      auto out_c_p_d_d_h = Kokkos::create_mirror_view(out_c_p_d_d);
+      Kokkos::deep_copy(out_c_p_d_d_h, out_c_p_d_d);
+      if (std::abs(rst::Serial::vectorNorm(out_c_p_d_d_h, NORM_ONE) - data_c_p(0,0)*in_c_p_d_d(0,0,0,0)*c*p*d1*d2) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataData (5): check result: "
-                   << rst::Serial::vectorNorm(out_c_p_d_d, NORM_ONE) << " != "
+                   << rst::Serial::vectorNorm(out_c_p_d_d_h, NORM_ONE) << " != "
                    << data_c_p(0,0)*in_c_p_d_d(0,0,0,0)*c*p*d1*d2 << "\n\n";
         errorFlag = -1000;
       }
       art::scalarMultiplyDataData(out_c_p_d_d, data_c_1, in_c_p_d_d);
-      if (std::abs(rst::Serial::vectorNorm(out_c_p_d_d, NORM_ONE) - data_c_1(0,0)*in_c_p_d_d(0,0,0,0)*c*p*d1*d2) > tol) {
+      Kokkos::deep_copy(out_c_p_d_d_h, out_c_p_d_d);
+      if (std::abs(rst::Serial::vectorNorm(out_c_p_d_d_h, NORM_ONE) - data_c_1(0,0)*in_c_p_d_d(0,0,0,0)*c*p*d1*d2) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataData (6): check result: "
-                   << rst::Serial::vectorNorm(out_c_p_d_d, NORM_ONE) << " != "
+                   << rst::Serial::vectorNorm(out_c_p_d_d_h, NORM_ONE) << " != "
                    << data_c_p(0,0)*in_c_p_d_d(0,0,0,0)*c*p*d1*d2 << "\n\n";
         errorFlag = -1000;
       }
@@ -772,7 +822,9 @@ namespace Intrepid2 {
       art::scalarMultiplyDataData(outi_c_p, datainv_c_p, out_c_p);
       art::scalarMultiplyDataData(in_c_p, data_c_p_one, in_p);
       rst::subtract(outi_c_p, in_c_p);
-      if (rst::Serial::vectorNorm(outi_c_p, NORM_ONE) > tol) {
+      auto outi_c_p_h = Kokkos::create_mirror_view(outi_c_p);
+      Kokkos::deep_copy(outi_c_p_h, outi_c_p);
+      if (rst::Serial::vectorNorm(outi_c_p_h, NORM_ONE) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataData (1): check scalar inverse property\n\n";
         errorFlag = -1000;
       }
@@ -780,7 +832,9 @@ namespace Intrepid2 {
       art::scalarMultiplyDataData(outi_c_p_d, datainv_c_p, out_c_p_d);
       art::scalarMultiplyDataData(in_c_p_d, data_c_p_one, in_p_d);
       rst::subtract(outi_c_p_d, in_c_p_d);
-      if (rst::Serial::vectorNorm(outi_c_p_d, NORM_ONE) > tol) {
+      auto outi_c_p_d_h = Kokkos::create_mirror_view(outi_c_p_d);
+      Kokkos::deep_copy(outi_c_p_d_h, outi_c_p_d);
+      if (rst::Serial::vectorNorm(outi_c_p_d_h, NORM_ONE) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataData (2): check scalar inverse property\n\n";
         errorFlag = -1000;
       }
@@ -788,7 +842,9 @@ namespace Intrepid2 {
       art::scalarMultiplyDataData(outi_c_p_d_d, datainv_c_p, out_c_p_d_d);
       art::scalarMultiplyDataData(in_c_p_d_d, data_c_p_one, in_p_d_d);
       rst::subtract(outi_c_p_d_d, in_c_p_d_d);
-      if (rst::Serial::vectorNorm(outi_c_p_d_d, NORM_ONE) > tol) {
+      auto outi_c_p_d_d_h = Kokkos::create_mirror_view(outi_c_p_d_d);
+      Kokkos::deep_copy(outi_c_p_d_d_h, outi_c_p_d_d);
+      if (rst::Serial::vectorNorm(outi_c_p_d_d_h, NORM_ONE) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataData (3): check scalar inverse property\n\n";
         errorFlag = -1000;
       }
@@ -796,7 +852,8 @@ namespace Intrepid2 {
       art::scalarMultiplyDataData(outi_c_p_d_d, datainv_c_1, out_c_p_d_d);
       art::scalarMultiplyDataData(in_c_p_d_d, data_c_p_one, in_p_d_d);
       rst::subtract(outi_c_p_d_d, in_c_p_d_d);
-      if (rst::Serial::vectorNorm(outi_c_p_d_d, NORM_ONE) > tol) {
+      Kokkos::deep_copy(outi_c_p_d_d_h, outi_c_p_d_d);
+      if (rst::Serial::vectorNorm(outi_c_p_d_d_h, NORM_ONE) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataData (4): check scalar inverse property\n\n";
         errorFlag = -1000;
       }
@@ -805,16 +862,19 @@ namespace Intrepid2 {
       deep_copy(in_p_d_d, 1.0); deep_copy(data_c_p,5.0); deep_copy(data_c_1, 5.0);
 
       art::scalarMultiplyDataData(out_c_p_d_d, data_c_p, in_p_d_d);
-      if (std::abs(rst::Serial::vectorNorm(out_c_p_d_d, NORM_ONE) - data_c_p(0,0)*in_p_d_d(0,0,0)*c*p*d1*d2) > tol) {
+      auto out_c_p_d_d_h = Kokkos::create_mirror_view(out_c_p_d_d);
+      Kokkos::deep_copy(out_c_p_d_d_h, out_c_p_d_d);
+      if (std::abs(rst::Serial::vectorNorm(out_c_p_d_d_h, NORM_ONE) - data_c_p(0,0)*in_p_d_d(0,0,0)*c*p*d1*d2) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataData (5): check result: "
-                   << rst::Serial::vectorNorm(out_c_p_d_d, NORM_ONE) << " != "
+                   << rst::Serial::vectorNorm(out_c_p_d_d_h, NORM_ONE) << " != "
                    << data_c_p(0,0)*in_p_d_d(0,0,0)*c*p*d1*d2 << "\n\n";
         errorFlag = -1000;
       }
       art::scalarMultiplyDataData(out_c_p_d_d, data_c_1, in_p_d_d);
-      if (std::abs(rst::Serial::vectorNorm(out_c_p_d_d, NORM_ONE) - data_c_1(0,0)*in_p_d_d(0,0,0)*c*p*d1*d2) > tol) {
+      Kokkos::deep_copy(out_c_p_d_d_h, out_c_p_d_d);
+      if (std::abs(rst::Serial::vectorNorm(out_c_p_d_d_h, NORM_ONE) - data_c_1(0,0)*in_p_d_d(0,0,0)*c*p*d1*d2) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataData (6): check result: "
-                   << rst::Serial::vectorNorm(out_c_p_d_d, NORM_ONE) << " != "
+                   << rst::Serial::vectorNorm(out_c_p_d_d_h, NORM_ONE) << " != "
                    << data_c_1(0,0)*in_p_d_d(0,0,0)*c*p*d1*d2 << "\n\n";
         errorFlag = -1000;
       }
@@ -858,28 +918,35 @@ namespace Intrepid2 {
       art::scalarMultiplyDataData(out_c_p, data_c_p, in_c_p, true);
       art::scalarMultiplyDataData(outi_c_p, datainv_c_p, out_c_p, true);
       rst::subtract(outi_c_p, in_c_p);
-      if (rst::Serial::vectorNorm(outi_c_p, NORM_ONE) > tol) {
+      auto outi_c_p_h = Kokkos::create_mirror_view(outi_c_p);
+      Kokkos::deep_copy(outi_c_p_h, outi_c_p);
+      if (rst::Serial::vectorNorm(outi_c_p_h, NORM_ONE) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataData (1): check scalar inverse property\n\n";
         errorFlag = -1000;
       }
       art::scalarMultiplyDataData(out_c_p_d, data_c_p, in_c_p_d, true);
       art::scalarMultiplyDataData(outi_c_p_d, datainv_c_p, out_c_p_d, true);
       rst::subtract(outi_c_p_d, in_c_p_d);
-      if (rst::Serial::vectorNorm(outi_c_p_d, NORM_ONE) > tol) {
+      auto outi_c_p_d_h = Kokkos::create_mirror_view(outi_c_p_d);
+      Kokkos::deep_copy(outi_c_p_d_h, outi_c_p_d);
+      if (rst::Serial::vectorNorm(outi_c_p_d_h, NORM_ONE) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataData (2): check scalar inverse property\n\n";
         errorFlag = -1000;
       }
       art::scalarMultiplyDataData(out_c_p_d_d, data_c_p, in_c_p_d_d, true);
       art::scalarMultiplyDataData(outi_c_p_d_d, datainv_c_p, out_c_p_d_d, true);
       rst::subtract(outi_c_p_d_d, in_c_p_d_d);
-      if (rst::Serial::vectorNorm(outi_c_p_d_d, NORM_ONE) > tol) {
+      auto outi_c_p_d_d_h = Kokkos::create_mirror_view(outi_c_p_d_d);
+      Kokkos::deep_copy(outi_c_p_d_d_h, outi_c_p_d_d);
+      if (rst::Serial::vectorNorm(outi_c_p_d_d_h, NORM_ONE) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataData (3): check scalar inverse property\n\n";
         errorFlag = -1000;
       }
       art::scalarMultiplyDataData(out_c_p_d_d, data_c_1, in_c_p_d_d, true);
       art::scalarMultiplyDataData(outi_c_p_d_d, datainv_c_1, out_c_p_d_d, true);
       rst::subtract(outi_c_p_d_d, in_c_p_d_d);
-      if (rst::Serial::vectorNorm(outi_c_p_d_d, NORM_ONE) > tol) {
+      Kokkos::deep_copy(outi_c_p_d_d_h, outi_c_p_d_d);
+      if (rst::Serial::vectorNorm(outi_c_p_d_d_h, NORM_ONE) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataData (4): check scalar inverse property\n\n";
         errorFlag = -1000;
       }
@@ -888,16 +955,19 @@ namespace Intrepid2 {
       deep_copy(in_c_p_d_d, 1.0); deep_copy(data_c_p,5.0); deep_copy(data_c_1, 5.0);
 
       art::scalarMultiplyDataData(out_c_p_d_d, data_c_p, in_c_p_d_d, true);
-      if (std::abs(rst::Serial::vectorNorm(out_c_p_d_d, NORM_ONE) - (1.0/data_c_p(0,0))*in_c_p_d_d(0,0,0,0)*c*p*d1*d2)/rst::Serial::vectorNorm(out_c_p_d_d, NORM_ONE) > tol) {
+      auto out_c_p_d_d_h = Kokkos::create_mirror_view(out_c_p_d_d);
+      Kokkos::deep_copy(out_c_p_d_d_h, out_c_p_d_d);
+      if (std::abs(rst::Serial::vectorNorm(out_c_p_d_d_h, NORM_ONE) - (1.0/data_c_p(0,0))*in_c_p_d_d(0,0,0,0)*c*p*d1*d2)/rst::Serial::vectorNorm(out_c_p_d_d, NORM_ONE) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataData (5): check result: "
-                   << rst::Serial::vectorNorm(out_c_p_d_d, NORM_ONE) << " != "
+                   << rst::Serial::vectorNorm(out_c_p_d_d_h, NORM_ONE) << " != "
                    << (1.0/data_c_p(0,0))*in_c_p_d_d(0,0,0,0)*c*p*d1*d2 << "\n\n";
         errorFlag = -1000;
       }
       art::scalarMultiplyDataData(out_c_p_d_d, data_c_1, in_c_p_d_d, true);
-      if (std::abs(rst::Serial::vectorNorm(out_c_p_d_d, NORM_ONE) - (1.0/data_c_1(0,0))*in_c_p_d_d(0,0,0,0)*c*p*d1*d2)/rst::Serial::vectorNorm(out_c_p_d_d, NORM_ONE) > tol) {
+      Kokkos::deep_copy(out_c_p_d_d_h, out_c_p_d_d);
+      if (std::abs(rst::Serial::vectorNorm(out_c_p_d_d_h, NORM_ONE) - (1.0/data_c_1(0,0))*in_c_p_d_d(0,0,0,0)*c*p*d1*d2)/rst::Serial::vectorNorm(out_c_p_d_d, NORM_ONE) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataData (6): check result: "
-                   << rst::Serial::vectorNorm(out_c_p_d_d, NORM_ONE) << " != "
+                   << rst::Serial::vectorNorm(out_c_p_d_d_h, NORM_ONE) << " != "
                    << (1.0/data_c_p(0,0))*in_c_p_d_d(0,0,0,0)*c*p*d1*d2 << "\n\n";
         errorFlag = -1000;
       }
@@ -957,7 +1027,9 @@ namespace Intrepid2 {
         art::scalarMultiplyDataData(outi_c_p, datainv_c_p, out_c_p, true);
         art::scalarMultiplyDataData(in_c_p, data_c_p_one, in_p);
         rst::subtract(outi_c_p, in_c_p);
-        if (rst::Serial::vectorNorm(outi_c_p, NORM_ONE) > tol) {
+        auto outi_c_p_h = Kokkos::create_mirror_view(outi_c_p);
+        Kokkos::deep_copy(outi_c_p_h, outi_c_p);
+        if (rst::Serial::vectorNorm(outi_c_p_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT scalarMultiplyDataData (1): check scalar inverse property\n\n";
           errorFlag = -1000;
         }
@@ -965,7 +1037,9 @@ namespace Intrepid2 {
         art::scalarMultiplyDataData(outi_c_p_d, datainv_c_p, out_c_p_d, true);
         art::scalarMultiplyDataData(in_c_p_d, data_c_p_one, in_p_d);
         rst::subtract(outi_c_p_d, in_c_p_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d, NORM_ONE) > tol) {
+        auto outi_c_p_d_h = Kokkos::create_mirror_view(outi_c_p_d);
+        Kokkos::deep_copy(outi_c_p_d_h, outi_c_p_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT scalarMultiplyDataData (2): check scalar inverse property\n\n";
           errorFlag = -1000;
         }
@@ -973,7 +1047,9 @@ namespace Intrepid2 {
         art::scalarMultiplyDataData(outi_c_p_d_d, datainv_c_p, out_c_p_d_d, true);
         art::scalarMultiplyDataData(in_c_p_d_d, data_c_p_one, in_p_d_d);
         rst::subtract(outi_c_p_d_d, in_c_p_d_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d_d, NORM_ONE) > tol) {
+        auto outi_c_p_d_d_h = Kokkos::create_mirror_view(outi_c_p_d_d);
+        Kokkos::deep_copy(outi_c_p_d_d_h, outi_c_p_d_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT scalarMultiplyDataData (3): check scalar inverse property\n\n";
           errorFlag = -1000;
         }
@@ -981,7 +1057,8 @@ namespace Intrepid2 {
         art::scalarMultiplyDataData(outi_c_p_d_d, datainv_c_1, out_c_p_d_d, true);
         art::scalarMultiplyDataData(in_c_p_d_d, data_c_p_one, in_p_d_d);
         rst::subtract(outi_c_p_d_d, in_c_p_d_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_p_d_d_h, outi_c_p_d_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT scalarMultiplyDataData (4): check scalar inverse property\n\n";
           errorFlag = -1000;
         }
@@ -990,16 +1067,19 @@ namespace Intrepid2 {
         deep_copy(in_p_d_d, 1.0); deep_copy(data_c_p,5.0); deep_copy(data_c_1, 5.0);
 
         art::scalarMultiplyDataData(out_c_p_d_d, data_c_p, in_p_d_d, true);
-        if (std::abs(rst::Serial::vectorNorm(out_c_p_d_d, NORM_ONE) - (1.0/data_c_p(0,0))*in_p_d_d(0,0,0)*c*p*d1*d2)/rst::Serial::vectorNorm(out_c_p_d_d, NORM_ONE) > tol) {
+        auto out_c_p_d_d_h = Kokkos::create_mirror_view(out_c_p_d_d);
+        Kokkos::deep_copy(out_c_p_d_d_h, out_c_p_d_d);
+        if (std::abs(rst::Serial::vectorNorm(out_c_p_d_d_h, NORM_ONE) - (1.0/data_c_p(0,0))*in_p_d_d(0,0,0)*c*p*d1*d2)/rst::Serial::vectorNorm(out_c_p_d_d, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT scalarMultiplyDataData (5): check result: "
-                     << rst::Serial::vectorNorm(out_c_p_d_d, NORM_ONE) << " != "
+                     << rst::Serial::vectorNorm(out_c_p_d_d_h, NORM_ONE) << " != "
                      << (1.0/data_c_p(0,0))*in_p_d_d(0,0,0)*c*p*d1*d2 << "\n\n";
           errorFlag = -1000;
         }
         art::scalarMultiplyDataData(out_c_p_d_d, data_c_1, in_p_d_d, true);
-        if (std::abs(rst::Serial::vectorNorm(out_c_p_d_d, NORM_ONE) - (1.0/data_c_1(0,0))*in_p_d_d(0,0,0)*c*p*d1*d2)/rst::Serial::vectorNorm(out_c_p_d_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(out_c_p_d_d_h, out_c_p_d_d);
+        if (std::abs(rst::Serial::vectorNorm(out_c_p_d_d_h, NORM_ONE) - (1.0/data_c_1(0,0))*in_p_d_d(0,0,0)*c*p*d1*d2)/rst::Serial::vectorNorm(out_c_p_d_d, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT scalarMultiplyDataData (6): check result: "
-                     << rst::Serial::vectorNorm(out_c_p_d_d, NORM_ONE) << " != "
+                     << rst::Serial::vectorNorm(out_c_p_d_d_h, NORM_ONE) << " != "
                      << (1.0/data_c_1(0,0))*in_p_d_d(0,0,0)*c*p*d1*d2 << "\n\n";
           errorFlag = -1000;
         }

--- a/packages/intrepid2/unit-test/Shared/ArrayTools/test_02.hpp
+++ b/packages/intrepid2/unit-test/Shared/ArrayTools/test_02.hpp
@@ -317,21 +317,29 @@ namespace Intrepid2 {
       // fill with constants
       deep_copy(in_c_f_p_d_d, 1.0); deep_copy(data_c_p,5.0); deep_copy(data_c_1, 5.0);
 
+      auto data_c_p_h = Kokkos::create_mirror_view(data_c_p);
+      Kokkos::deep_copy(data_c_p_h, data_c_p);
+      auto in_c_f_p_d_d_h = Kokkos::create_mirror_view(in_c_f_p_d_d);
+      Kokkos::deep_copy(in_c_f_p_d_d_h, in_c_f_p_d_d);
+      auto data_c_1_h = Kokkos::create_mirror_view(data_c_1);
+      Kokkos::deep_copy(data_c_1_h, data_c_1);
+
       art::scalarMultiplyDataField(out_c_f_p_d_d, data_c_p, in_c_f_p_d_d);
       auto out_c_f_p_d_d_h = Kokkos::create_mirror_view(out_c_f_p_d_d);
       Kokkos::deep_copy(out_c_f_p_d_d_h, out_c_f_p_d_d);
       if (std::abs(rst::Serial::vectorNorm(out_c_f_p_d_d_h, NORM_ONE) - data_c_p(0,0)*in_c_f_p_d_d(0,0,0,0,0)*c*p*f*d1*d2) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataField (5): check result: "
                    << rst::Serial::vectorNorm(out_c_f_p_d_d_h, NORM_ONE) << " != "
-                   << data_c_p(0,0)*in_c_f_p_d_d(0,0,0,0,0)*c*f*p*d1*d2 << "\n\n";
+                   << data_c_p_h(0,0)*in_c_f_p_d_d_h(0,0,0,0,0)*c*f*p*d1*d2 << "\n\n";
         errorFlag = -1000;
       }
+
       art::scalarMultiplyDataField(out_c_f_p_d_d, data_c_1, in_c_f_p_d_d);
       Kokkos::deep_copy(out_c_f_p_d_d_h, out_c_f_p_d_d);
       if (std::abs(rst::Serial::vectorNorm(out_c_f_p_d_d_h, NORM_ONE) - data_c_1(0,0)*in_c_f_p_d_d(0,0,0,0,0)*c*p*f*d1*d2) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataField (6): check result: "
                    << rst::Serial::vectorNorm(out_c_f_p_d_d_h, NORM_ONE) << " != "
-                   << data_c_1(0,0)*in_c_f_p_d_d(0,0)*c*f*p*d1*d2 << "\n\n";
+                   << data_c_1_h(0,0)*in_c_f_p_d_d_h(0,0)*c*f*p*d1*d2 << "\n\n";
         errorFlag = -1000;
       }
       } // end scope
@@ -434,21 +442,29 @@ namespace Intrepid2 {
       // fill with constants
       deep_copy(in_f_p_d_d, 1.0); deep_copy(data_c_p, 5.0); deep_copy(data_c_1, 5.0);
 
+      auto data_c_p_h = Kokkos::create_mirror_view(data_c_p);
+      Kokkos::deep_copy(data_c_p_h, data_c_p);
+      auto in_f_p_d_d_h = Kokkos::create_mirror_view(in_f_p_d_d);
+      Kokkos::deep_copy(in_f_p_d_d_h, in_f_p_d_d);
+      auto data_c_1_h = Kokkos::create_mirror_view(data_c_1);
+      Kokkos::deep_copy(data_c_1_h, data_c_1);
+
       art::scalarMultiplyDataField(out_c_f_p_d_d, data_c_p, in_f_p_d_d);
       auto out_c_f_p_d_d_h = Kokkos::create_mirror_view(out_c_f_p_d_d);
       Kokkos::deep_copy(out_c_f_p_d_d_h, out_c_f_p_d_d);
       if (std::abs(rst::Serial::vectorNorm(out_c_f_p_d_d_h, NORM_ONE) - data_c_p(0,0)*in_f_p_d_d(0,0,0,0)*c*p*f*d1*d2) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataField (5): check result: "
                    << rst::Serial::vectorNorm(out_c_f_p_d_d_h, NORM_ONE) << " != "
-                   << data_c_p(0,0)*in_f_p_d_d(0,0,0,0)*c*f*p*d1*d2 << "\n\n";
+                   << data_c_p_h(0,0)*in_f_p_d_d_h(0,0,0,0)*c*f*p*d1*d2 << "\n\n";
         errorFlag = -1000;
       }
+
       art::scalarMultiplyDataField(out_c_f_p_d_d, data_c_1, in_f_p_d_d);
       Kokkos::deep_copy(out_c_f_p_d_d_h, out_c_f_p_d_d);
       if (std::abs(rst::Serial::vectorNorm(out_c_f_p_d_d_h, NORM_ONE) - data_c_1(0,0)*in_f_p_d_d(0,0,0,0)*c*p*f*d1*d2) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataField (6): check result: "
                    << rst::Serial::vectorNorm(out_c_f_p_d_d_h, NORM_ONE) << " != "
-                   << data_c_1(0,0)*in_f_p_d_d(0,0,0,0)*c*f*p*d1*d2 << "\n\n";
+                   << data_c_1_h(0,0)*in_f_p_d_d_h(0,0,0,0)*c*f*p*d1*d2 << "\n\n";
         errorFlag = -1000;
       }
       } // end scope
@@ -533,13 +549,20 @@ namespace Intrepid2 {
       // fill with constants
       deep_copy(in_c_f_p_d_d, 1.0); deep_copy(data_c_p, 5.0); deep_copy(data_c_1, 5.0);
 
+      auto data_c_p_h = Kokkos::create_mirror_view(data_c_p);
+      Kokkos::deep_copy(data_c_p_h, data_c_p);
+      auto in_c_f_p_d_d_h = Kokkos::create_mirror_view(in_c_f_p_d_d);
+      Kokkos::deep_copy(in_c_f_p_d_d_h, in_c_f_p_d_d);
+      auto data_c_1_h = Kokkos::create_mirror_view(data_c_1);
+      Kokkos::deep_copy(data_c_1_h, data_c_1);
+
       art::scalarMultiplyDataField(out_c_f_p_d_d, data_c_p, in_c_f_p_d_d, true);
       auto out_c_f_p_d_d_h = Kokkos::create_mirror_view(out_c_f_p_d_d);
       Kokkos::deep_copy(out_c_f_p_d_d_h, out_c_f_p_d_d);
       if (std::abs(rst::Serial::vectorNorm(out_c_f_p_d_d_h, NORM_ONE) - (1.0/data_c_p(0,0))*in_c_f_p_d_d(0,0,0,0,0)*c*p*f*d1*d2)/rst::Serial::vectorNorm(out_c_f_p_d_d_h, NORM_ONE) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataField (5): check result: "
                    << rst::Serial::vectorNorm(out_c_f_p_d_d_h, NORM_ONE) << " != "
-                   << (1.0/data_c_p(0,0))*in_c_f_p_d_d(0,0,0,0,0)*c*p*f*d1*d2 << "\n\n";
+                   << (1.0/data_c_p_h(0,0))*in_c_f_p_d_d_h(0,0,0,0,0)*c*p*f*d1*d2 << "\n\n";
         errorFlag = -1000;
       }
       art::scalarMultiplyDataField(out_c_f_p_d_d, data_c_1, in_c_f_p_d_d, true);
@@ -547,7 +570,7 @@ namespace Intrepid2 {
       if (std::abs(rst::Serial::vectorNorm(out_c_f_p_d_d_h, NORM_ONE) - (1.0/data_c_1(0,0))*in_c_f_p_d_d(0,0,0,0,0)*c*p*f*d1*d2)/rst::Serial::vectorNorm(out_c_f_p_d_d, NORM_ONE) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataField (6): check result: "
                    << rst::Serial::vectorNorm(out_c_f_p_d_d_h, NORM_ONE) << " != "
-                   << (1.0/data_c_p(0,0))*in_c_f_p_d_d(0,0,0,0,0)*c*p*f*d1*d2 << "\n\n";
+                   << (1.0/data_c_1_h(0,0))*in_c_f_p_d_d_h(0,0,0,0,0)*c*p*f*d1*d2 << "\n\n";
         errorFlag = -1000;
       }
       } // end scope
@@ -651,13 +674,20 @@ namespace Intrepid2 {
       // fill with constants
       deep_copy(in_f_p_d_d, 1.0); deep_copy(data_c_p, 5.0); deep_copy(data_c_1, 5.0);
 
+      auto data_c_p_h = Kokkos::create_mirror_view(data_c_p);
+      Kokkos::deep_copy(data_c_p_h, data_c_p);
+      auto in_f_p_d_d_h = Kokkos::create_mirror_view(in_f_p_d_d);
+      Kokkos::deep_copy(in_f_p_d_d_h, in_f_p_d_d);
+      auto data_c_1_h = Kokkos::create_mirror_view(data_c_1);
+      Kokkos::deep_copy(data_c_1_h, data_c_1);
+
       art::scalarMultiplyDataField(out_c_f_p_d_d, data_c_p, in_f_p_d_d, true);
       auto out_c_f_p_d_d_h = Kokkos::create_mirror_view(out_c_f_p_d_d);
       Kokkos::deep_copy(out_c_f_p_d_d_h, out_c_f_p_d_d);
       if (std::abs(rst::Serial::vectorNorm(out_c_f_p_d_d_h, NORM_ONE) - (1.0/data_c_p(0,0))*in_f_p_d_d(0,0,0,0)*c*p*f*d1*d2)/rst::Serial::vectorNorm(out_c_f_p_d_d, NORM_ONE) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataField (5): check result: "
                    << rst::Serial::vectorNorm(out_c_f_p_d_d_h, NORM_ONE) << " != "
-                   << (1.0/data_c_p(0,0))*in_f_p_d_d(0,0,0,0)*c*p*f*d1*d2 << "\n\n";
+                   << (1.0/data_c_p_h(0,0))*in_f_p_d_d_h(0,0,0,0)*c*p*f*d1*d2 << "\n\n";
         errorFlag = -1000;
       }
       art::scalarMultiplyDataField(out_c_f_p_d_d, data_c_1, in_f_p_d_d, true);
@@ -665,7 +695,7 @@ namespace Intrepid2 {
       if (std::abs(rst::Serial::vectorNorm(out_c_f_p_d_d_h, NORM_ONE) - (1.0/data_c_1(0,0))*in_f_p_d_d(0,0,0,0)*c*p*f*d1*d2)/rst::Serial::vectorNorm(out_c_f_p_d_d, NORM_ONE) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataField (6): check result: "
                    << rst::Serial::vectorNorm(out_c_f_p_d_d_h, NORM_ONE) << " != "
-                   << (1.0/data_c_1(0,0))*in_f_p_d_d(0,0,0,0)*c*p*f*d1*d2 << "\n\n";
+                   << (1.0/data_c_1_h(0,0))*in_f_p_d_d_h(0,0,0,0)*c*p*f*d1*d2 << "\n\n";
         errorFlag = -1000;
       }
       } // end scope
@@ -748,13 +778,20 @@ namespace Intrepid2 {
       // fill with constants
       deep_copy(in_c_p_d_d, 1.0); deep_copy(data_c_p, 5.0); deep_copy(data_c_1, 5.0);
 
+      auto data_c_p_h = Kokkos::create_mirror_view(data_c_p);
+      Kokkos::deep_copy(data_c_p_h, data_c_p);
+      auto in_c_p_d_d_h = Kokkos::create_mirror_view(in_c_p_d_d);
+      Kokkos::deep_copy(in_c_p_d_d_h, in_c_p_d_d);
+      auto data_c_1_h = Kokkos::create_mirror_view(data_c_1);
+      Kokkos::deep_copy(data_c_1_h, data_c_1);
+
       art::scalarMultiplyDataData(out_c_p_d_d, data_c_p, in_c_p_d_d);
       auto out_c_p_d_d_h = Kokkos::create_mirror_view(out_c_p_d_d);
       Kokkos::deep_copy(out_c_p_d_d_h, out_c_p_d_d);
       if (std::abs(rst::Serial::vectorNorm(out_c_p_d_d_h, NORM_ONE) - data_c_p(0,0)*in_c_p_d_d(0,0,0,0)*c*p*d1*d2) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataData (5): check result: "
                    << rst::Serial::vectorNorm(out_c_p_d_d_h, NORM_ONE) << " != "
-                   << data_c_p(0,0)*in_c_p_d_d(0,0,0,0)*c*p*d1*d2 << "\n\n";
+                   << data_c_p_h(0,0)*in_c_p_d_d_h(0,0,0,0)*c*p*d1*d2 << "\n\n";
         errorFlag = -1000;
       }
       art::scalarMultiplyDataData(out_c_p_d_d, data_c_1, in_c_p_d_d);
@@ -762,7 +799,7 @@ namespace Intrepid2 {
       if (std::abs(rst::Serial::vectorNorm(out_c_p_d_d_h, NORM_ONE) - data_c_1(0,0)*in_c_p_d_d(0,0,0,0)*c*p*d1*d2) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataData (6): check result: "
                    << rst::Serial::vectorNorm(out_c_p_d_d_h, NORM_ONE) << " != "
-                   << data_c_p(0,0)*in_c_p_d_d(0,0,0,0)*c*p*d1*d2 << "\n\n";
+                   << data_c_1_h(0,0)*in_c_p_d_d_h(0,0,0,0)*c*p*d1*d2 << "\n\n";
         errorFlag = -1000;
       }
       } // end scope
@@ -861,13 +898,20 @@ namespace Intrepid2 {
       // fill with constants
       deep_copy(in_p_d_d, 1.0); deep_copy(data_c_p,5.0); deep_copy(data_c_1, 5.0);
 
+      auto data_c_p_h = Kokkos::create_mirror_view(data_c_p);
+      Kokkos::deep_copy(data_c_p_h, data_c_p);
+      auto in_p_d_d_h = Kokkos::create_mirror_view(in_p_d_d);
+      Kokkos::deep_copy(in_p_d_d_h, in_p_d_d);
+      auto data_c_1_h = Kokkos::create_mirror_view(data_c_1);
+      Kokkos::deep_copy(data_c_1_h, data_c_1);
+
       art::scalarMultiplyDataData(out_c_p_d_d, data_c_p, in_p_d_d);
       auto out_c_p_d_d_h = Kokkos::create_mirror_view(out_c_p_d_d);
       Kokkos::deep_copy(out_c_p_d_d_h, out_c_p_d_d);
       if (std::abs(rst::Serial::vectorNorm(out_c_p_d_d_h, NORM_ONE) - data_c_p(0,0)*in_p_d_d(0,0,0)*c*p*d1*d2) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataData (5): check result: "
                    << rst::Serial::vectorNorm(out_c_p_d_d_h, NORM_ONE) << " != "
-                   << data_c_p(0,0)*in_p_d_d(0,0,0)*c*p*d1*d2 << "\n\n";
+                   << data_c_p_h(0,0)*in_p_d_d_h(0,0,0)*c*p*d1*d2 << "\n\n";
         errorFlag = -1000;
       }
       art::scalarMultiplyDataData(out_c_p_d_d, data_c_1, in_p_d_d);
@@ -875,7 +919,7 @@ namespace Intrepid2 {
       if (std::abs(rst::Serial::vectorNorm(out_c_p_d_d_h, NORM_ONE) - data_c_1(0,0)*in_p_d_d(0,0,0)*c*p*d1*d2) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataData (6): check result: "
                    << rst::Serial::vectorNorm(out_c_p_d_d_h, NORM_ONE) << " != "
-                   << data_c_1(0,0)*in_p_d_d(0,0,0)*c*p*d1*d2 << "\n\n";
+                   << data_c_1_h(0,0)*in_p_d_d_h(0,0,0)*c*p*d1*d2 << "\n\n";
         errorFlag = -1000;
       }
       } // end scope
@@ -954,13 +998,20 @@ namespace Intrepid2 {
       // fill with constants
       deep_copy(in_c_p_d_d, 1.0); deep_copy(data_c_p,5.0); deep_copy(data_c_1, 5.0);
 
+      auto data_c_p_h = Kokkos::create_mirror_view(data_c_p);
+      Kokkos::deep_copy(data_c_p_h, data_c_p);
+      auto in_c_p_d_d_h = Kokkos::create_mirror_view(in_c_p_d_d);
+      Kokkos::deep_copy(in_c_p_d_d_h, in_c_p_d_d);
+      auto data_c_1_h = Kokkos::create_mirror_view(data_c_1);
+      Kokkos::deep_copy(data_c_1_h, data_c_1);
+
       art::scalarMultiplyDataData(out_c_p_d_d, data_c_p, in_c_p_d_d, true);
       auto out_c_p_d_d_h = Kokkos::create_mirror_view(out_c_p_d_d);
       Kokkos::deep_copy(out_c_p_d_d_h, out_c_p_d_d);
       if (std::abs(rst::Serial::vectorNorm(out_c_p_d_d_h, NORM_ONE) - (1.0/data_c_p(0,0))*in_c_p_d_d(0,0,0,0)*c*p*d1*d2)/rst::Serial::vectorNorm(out_c_p_d_d, NORM_ONE) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataData (5): check result: "
                    << rst::Serial::vectorNorm(out_c_p_d_d_h, NORM_ONE) << " != "
-                   << (1.0/data_c_p(0,0))*in_c_p_d_d(0,0,0,0)*c*p*d1*d2 << "\n\n";
+                   << (1.0/data_c_p_h(0,0))*in_c_p_d_d_h(0,0,0,0)*c*p*d1*d2 << "\n\n";
         errorFlag = -1000;
       }
       art::scalarMultiplyDataData(out_c_p_d_d, data_c_1, in_c_p_d_d, true);
@@ -968,7 +1019,7 @@ namespace Intrepid2 {
       if (std::abs(rst::Serial::vectorNorm(out_c_p_d_d_h, NORM_ONE) - (1.0/data_c_1(0,0))*in_c_p_d_d(0,0,0,0)*c*p*d1*d2)/rst::Serial::vectorNorm(out_c_p_d_d, NORM_ONE) > tol) {
         *outStream << "\n\nINCORRECT scalarMultiplyDataData (6): check result: "
                    << rst::Serial::vectorNorm(out_c_p_d_d_h, NORM_ONE) << " != "
-                   << (1.0/data_c_p(0,0))*in_c_p_d_d(0,0,0,0)*c*p*d1*d2 << "\n\n";
+                   << (1.0/data_c_1_h(0,0))*in_c_p_d_d_h(0,0,0,0)*c*p*d1*d2 << "\n\n";
         errorFlag = -1000;
       }
       } // end scope
@@ -1066,13 +1117,20 @@ namespace Intrepid2 {
         // fill with constants
         deep_copy(in_p_d_d, 1.0); deep_copy(data_c_p,5.0); deep_copy(data_c_1, 5.0);
 
+        auto data_c_p_h = Kokkos::create_mirror_view(data_c_p);
+        Kokkos::deep_copy(data_c_p_h, data_c_p);
+        auto in_p_d_d_h = Kokkos::create_mirror_view(in_p_d_d);
+        Kokkos::deep_copy(in_p_d_d_h, in_p_d_d);
+        auto data_c_1_h = Kokkos::create_mirror_view(data_c_1);
+        Kokkos::deep_copy(data_c_1_h, data_c_1);
+
         art::scalarMultiplyDataData(out_c_p_d_d, data_c_p, in_p_d_d, true);
         auto out_c_p_d_d_h = Kokkos::create_mirror_view(out_c_p_d_d);
         Kokkos::deep_copy(out_c_p_d_d_h, out_c_p_d_d);
         if (std::abs(rst::Serial::vectorNorm(out_c_p_d_d_h, NORM_ONE) - (1.0/data_c_p(0,0))*in_p_d_d(0,0,0)*c*p*d1*d2)/rst::Serial::vectorNorm(out_c_p_d_d, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT scalarMultiplyDataData (5): check result: "
                      << rst::Serial::vectorNorm(out_c_p_d_d_h, NORM_ONE) << " != "
-                     << (1.0/data_c_p(0,0))*in_p_d_d(0,0,0)*c*p*d1*d2 << "\n\n";
+                     << (1.0/data_c_p_h(0,0))*in_p_d_d_h(0,0,0)*c*p*d1*d2 << "\n\n";
           errorFlag = -1000;
         }
         art::scalarMultiplyDataData(out_c_p_d_d, data_c_1, in_p_d_d, true);
@@ -1080,7 +1138,7 @@ namespace Intrepid2 {
         if (std::abs(rst::Serial::vectorNorm(out_c_p_d_d_h, NORM_ONE) - (1.0/data_c_1(0,0))*in_p_d_d(0,0,0)*c*p*d1*d2)/rst::Serial::vectorNorm(out_c_p_d_d, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT scalarMultiplyDataData (6): check result: "
                      << rst::Serial::vectorNorm(out_c_p_d_d_h, NORM_ONE) << " != "
-                     << (1.0/data_c_1(0,0))*in_p_d_d(0,0,0)*c*p*d1*d2 << "\n\n";
+                     << (1.0/data_c_1_h(0,0))*in_p_d_d_h(0,0,0)*c*p*d1*d2 << "\n\n";
           errorFlag = -1000;
         }
         } // end scope

--- a/packages/intrepid2/unit-test/Shared/ArrayTools/test_03.hpp
+++ b/packages/intrepid2/unit-test/Shared/ArrayTools/test_03.hpp
@@ -266,34 +266,41 @@ namespace Intrepid2 {
           art::scalarMultiplyDataField(outSM_c_f_p, data_c_p, in_c_f_p);
           art::dotMultiplyDataField(outDM_c_f_p, data_c_p, in_c_f_p);
           rst::subtract(out_c_f_p, outSM_c_f_p, outDM_c_f_p);
-          if (rst::Serial::vectorNorm(out_c_f_p, NORM_ONE) > tol) {
+          auto out_c_f_p_h = Kokkos::create_mirror_view(out_c_f_p);
+          Kokkos::deep_copy(out_c_f_p_h, out_c_f_p);
+          if (rst::Serial::vectorNorm(out_c_f_p_h, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT dotMultiplyDataField (1): check dot multiply for scalars vs. scalar multiply\n\n";
             errorFlag = -1000;
           }
           art::dotMultiplyDataField(out_c_f_p, data_c_p_d, in_c_f_p_d);
-          if (rst::Serial::vectorNorm(out_c_f_p, NORM_ONE) > tol) {
+          Kokkos::deep_copy(out_c_f_p_h, out_c_f_p);
+          if (rst::Serial::vectorNorm(out_c_f_p_h, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT dotMultiplyDataField (2): check dot multiply of orthogonal vectors\n\n";
             errorFlag = -1000;
           }
           art::dotMultiplyDataField(out_c_f_p, data_c_p_d_d, in_c_f_p_d_d);
-          if ((rst::Serial::vectorNorm(out_c_f_p, NORM_INF) - d1*d2) > tol) {
+          Kokkos::deep_copy(out_c_f_p_h, out_c_f_p);
+          if ((rst::Serial::vectorNorm(out_c_f_p_h, NORM_INF) - d1*d2) > tol) {
             *outStream << "\n\nINCORRECT dotMultiplyDataField (3): check dot multiply for tensors of 1s\n\n";
             errorFlag = -1000;
           }
           art::scalarMultiplyDataField(outSM_c_f_p, data_c_1, in_c_f_p);
           art::dotMultiplyDataField(outDM_c_f_p, data_c_1, in_c_f_p);
           rst::subtract(out_c_f_p, outSM_c_f_p, outDM_c_f_p);
-          if (rst::Serial::vectorNorm(out_c_f_p, NORM_ONE) > tol) {
+          Kokkos::deep_copy(out_c_f_p_h, out_c_f_p);
+          if (rst::Serial::vectorNorm(out_c_f_p_h, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT dotMultiplyDataField (4): check dot multiply for scalars vs. scalar multiply\n\n";
             errorFlag = -1000;
           }
           art::dotMultiplyDataField(out_c_f_p, data_c_1_d, in_c_f_p_d);
-          if (rst::Serial::vectorNorm(out_c_f_p, NORM_ONE) > tol) {
+          Kokkos::deep_copy(out_c_f_p_h, out_c_f_p);
+          if (rst::Serial::vectorNorm(out_c_f_p_h, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT dotMultiplyDataField (5): check dot multiply of orthogonal vectors\n\n";
             errorFlag = -1000;
           }
           art::dotMultiplyDataField(out_c_f_p, data_c_1_d_d, in_c_f_p_d_d);
-          if ((rst::Serial::vectorNorm(out_c_f_p, NORM_INF) - d1*d2) > tol) {
+          Kokkos::deep_copy(out_c_f_p_h, out_c_f_p);
+          if ((rst::Serial::vectorNorm(out_c_f_p_h, NORM_INF) - d1*d2) > tol) {
             *outStream << "\n\nINCORRECT dotMultiplyDataField (6): check dot multiply for tensors of 1s\n\n";
             errorFlag = -1000;
           }
@@ -342,34 +349,41 @@ namespace Intrepid2 {
           art::scalarMultiplyDataField(outSM_c_f_p, data_c_p, in_f_p);
           art::dotMultiplyDataField(outDM_c_f_p, data_c_p, in_f_p);
           rst::subtract(out_c_f_p, outSM_c_f_p, outDM_c_f_p);
-          if (rst::Serial::vectorNorm(out_c_f_p, NORM_ONE) > tol) {
+          auto out_c_f_p_h = Kokkos::create_mirror_view(out_c_f_p);
+          Kokkos::deep_copy(out_c_f_p_h, out_c_f_p);
+          if (rst::Serial::vectorNorm(out_c_f_p_h, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT dotMultiplyDataField (7): check dot multiply for scalars vs. scalar multiply\n\n";
             errorFlag = -1000;
           }
           art::dotMultiplyDataField(out_c_f_p, data_c_p_d, in_f_p_d);
-          if (rst::Serial::vectorNorm(out_c_f_p, NORM_ONE) > tol) {
+          Kokkos::deep_copy(out_c_f_p_h, out_c_f_p);
+          if (rst::Serial::vectorNorm(out_c_f_p_h, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT dotMultiplyDataField (8): check dot multiply of orthogonal vectors\n\n";
             errorFlag = -1000;
           }
           art::dotMultiplyDataField(out_c_f_p, data_c_p_d_d, in_f_p_d_d);
-          if ((rst::Serial::vectorNorm(out_c_f_p, NORM_INF) - d1*d2) > tol) {
+          Kokkos::deep_copy(out_c_f_p_h, out_c_f_p);
+          if ((rst::Serial::vectorNorm(out_c_f_p_h, NORM_INF) - d1*d2) > tol) {
             *outStream << "\n\nINCORRECT dotMultiplyDataField (9): check dot multiply for tensors of 1s\n\n";
             errorFlag = -1000;
           }
           art::scalarMultiplyDataField(outSM_c_f_p, data_c_1, in_f_p);
           art::dotMultiplyDataField(outDM_c_f_p, data_c_1, in_f_p);
           rst::subtract(out_c_f_p, outSM_c_f_p, outDM_c_f_p);
-          if (rst::Serial::vectorNorm(out_c_f_p, NORM_ONE) > tol) {
+          Kokkos::deep_copy(out_c_f_p_h, out_c_f_p);
+          if (rst::Serial::vectorNorm(out_c_f_p_h, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT dotMultiplyDataField (10): check dot multiply for scalars vs. scalar multiply\n\n";
             errorFlag = -1000;
           }
           art::dotMultiplyDataField(out_c_f_p, data_c_1_d, in_f_p_d);
-          if (rst::Serial::vectorNorm(out_c_f_p, NORM_ONE) > tol) {
+          Kokkos::deep_copy(out_c_f_p_h, out_c_f_p);
+          if (rst::Serial::vectorNorm(out_c_f_p_h, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT dotMultiplyDataField (11): check dot multiply of orthogonal vectors\n\n";
             errorFlag = -1000;
           }
           art::dotMultiplyDataField(out_c_f_p, data_c_1_d_d, in_f_p_d_d);
-          if ((rst::Serial::vectorNorm(out_c_f_p, NORM_INF) - d1*d2) > tol) {
+          Kokkos::deep_copy(out_c_f_p_h, out_c_f_p);
+          if ((rst::Serial::vectorNorm(out_c_f_p_h, NORM_INF) - d1*d2) > tol) {
             *outStream << "\n\nINCORRECT dotMultiplyDataField (12): check dot multiply for tensors of 1s\n\n";
             errorFlag = -1000;
           }
@@ -414,34 +428,41 @@ namespace Intrepid2 {
           art::scalarMultiplyDataData(outSM_c_p, data_c_p, in_c_p);
           art::dotMultiplyDataData(outDM_c_p, data_c_p, in_c_p);
           rst::subtract(out_c_p, outSM_c_p, outDM_c_p);
-          if (rst::Serial::vectorNorm(out_c_p, NORM_ONE) > tol) {
+          auto out_c_p_h = Kokkos::create_mirror_view(out_c_p);
+          Kokkos::deep_copy(out_c_p_h, out_c_p);
+          if (rst::Serial::vectorNorm(out_c_p_h, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT dotMultiplyDataData (1): check dot multiply for scalars vs. scalar multiply\n\n";
             errorFlag = -1000;
           }
           art::dotMultiplyDataData(out_c_p, data_c_p_d, in_c_p_d);
-          if (rst::Serial::vectorNorm(out_c_p, NORM_ONE) > tol) {
-            *outStream << "\n\nINCORRECT dotMultiplyDataData (2): check dot multiply of orthogonal vectors"<<rst::Serial::vectorNorm(out_c_p, NORM_ONE)<<" \n\n";
+          Kokkos::deep_copy(out_c_p_h, out_c_p);
+          if (rst::Serial::vectorNorm(out_c_p_h, NORM_ONE) > tol) {
+            *outStream << "\n\nINCORRECT dotMultiplyDataData (2): check dot multiply of orthogonal vectors"<<rst::Serial::vectorNorm(out_c_p_h, NORM_ONE)<<" \n\n";
             errorFlag = -1000;
           }
           art::dotMultiplyDataData(out_c_p, data_c_p_d_d, in_c_p_d_d);
-          if ((rst::Serial::vectorNorm(out_c_p, NORM_INF) - d1*d2) > tol) {
+          Kokkos::deep_copy(out_c_p_h, out_c_p);
+          if ((rst::Serial::vectorNorm(out_c_p_h, NORM_INF) - d1*d2) > tol) {
             *outStream << "\n\nINCORRECT dotMultiplyDataData (3): check dot multiply for tensors of 1s\n\n";
             errorFlag = -1000;
           }
           art::scalarMultiplyDataData(outSM_c_p, data_c_1, in_c_p);
           art::dotMultiplyDataData(outDM_c_p, data_c_1, in_c_p);
           rst::subtract(out_c_p, outSM_c_p, outDM_c_p);
-          if (rst::Serial::vectorNorm(out_c_p, NORM_ONE) > tol) {
+          Kokkos::deep_copy(out_c_p_h, out_c_p);
+          if (rst::Serial::vectorNorm(out_c_p_h, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT dotMultiplyDataData (4): check dot multiply for scalars vs. scalar multiply\n\n";
             errorFlag = -1000;
           }
           art::dotMultiplyDataData(out_c_p, data_c_1_d, in_c_p_d);
-          if (rst::Serial::vectorNorm(out_c_p, NORM_ONE) > tol) {
+          Kokkos::deep_copy(out_c_p_h, out_c_p);
+          if (rst::Serial::vectorNorm(out_c_p_h, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT dotMultiplyDataData (5): check dot multiply of orthogonal vectors\n\n";
             errorFlag = -1000;
           }
           art::dotMultiplyDataData(out_c_p, data_c_1_d_d, in_c_p_d_d);
-          if ((rst::Serial::vectorNorm(out_c_p, NORM_INF) - d1*d2) > tol) {
+          Kokkos::deep_copy(out_c_p_h, out_c_p);
+          if ((rst::Serial::vectorNorm(out_c_p_h, NORM_INF) - d1*d2) > tol) {
             *outStream << "\n\nINCORRECT dotMultiplyDataData (6): check dot multiply for tensors of 1s\n\n";
             errorFlag = -1000;
           }
@@ -488,34 +509,41 @@ namespace Intrepid2 {
           art::dotMultiplyDataData(outDM_c_p, data_c_p, in_p);
           
           rst::subtract(out_c_p, outSM_c_p, outDM_c_p);
-          if (rst::Serial::vectorNorm(out_c_p, NORM_ONE) > tol) {
+          auto out_c_p_h = Kokkos::create_mirror_view(out_c_p);
+          Kokkos::deep_copy(out_c_p_h, out_c_p);
+          if (rst::Serial::vectorNorm(out_c_p_h, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT dotMultiplyDataData (7): check dot multiply for scalars vs. scalar multiply\n\n";
             errorFlag = -1000;
           }
           art::dotMultiplyDataData(out_c_p, data_c_p_d, in_p_d);
-          if (rst::Serial::vectorNorm(out_c_p, NORM_ONE) > tol) {
+          Kokkos::deep_copy(out_c_p_h, out_c_p);
+          if (rst::Serial::vectorNorm(out_c_p_h, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT dotMultiplyDataData (8): check dot multiply of orthogonal vectors\n\n";
             errorFlag = -1000;
           }
           art::dotMultiplyDataData(out_c_p, data_c_p_d_d, in_p_d_d);
-          if ((rst::Serial::vectorNorm(out_c_p, NORM_INF) - d1*d2) > tol) {
+          Kokkos::deep_copy(out_c_p_h, out_c_p);
+          if ((rst::Serial::vectorNorm(out_c_p_h, NORM_INF) - d1*d2) > tol) {
             *outStream << "\n\nINCORRECT dotMultiplyDataData (9): check dot multiply for tensors of 1s\n\n";
             errorFlag = -1000;
           }
           art::scalarMultiplyDataData(outSM_c_p, data_c_1, in_p);
           art::dotMultiplyDataData(outDM_c_p, data_c_1, in_p);
           rst::subtract(out_c_p, outSM_c_p, outDM_c_p);
-          if (rst::Serial::vectorNorm(out_c_p, NORM_ONE) > tol) {
+          Kokkos::deep_copy(out_c_p_h, out_c_p);
+          if (rst::Serial::vectorNorm(out_c_p_h, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT dotMultiplyDataData (10): check dot multiply for scalars vs. scalar multiply\n\n";
             errorFlag = -1000;
           }
           art::dotMultiplyDataData(out_c_p, data_c_1_d, in_p_d);
-          if (rst::Serial::vectorNorm(out_c_p, NORM_ONE) > tol) {
+          Kokkos::deep_copy(out_c_p_h, out_c_p);
+          if (rst::Serial::vectorNorm(out_c_p_h, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT dotMultiplyDataData (11): check dot multiply of orthogonal vectors\n\n";
             errorFlag = -1000;
           }
           art::dotMultiplyDataData(out_c_p, data_c_1_d_d, in_p_d_d);
-          if ((rst::Serial::vectorNorm(out_c_p, NORM_INF) - d1*d2) > tol) {
+          Kokkos::deep_copy(out_c_p_h, out_c_p);
+          if ((rst::Serial::vectorNorm(out_c_p_h, NORM_INF) - d1*d2) > tol) {
             *outStream << "\n\nINCORRECT dotMultiplyDataData (12): check dot multiply for tensors of 1s\n\n";
             errorFlag = -1000;
           }

--- a/packages/intrepid2/unit-test/Shared/ArrayTools/test_04.hpp
+++ b/packages/intrepid2/unit-test/Shared/ArrayTools/test_04.hpp
@@ -1591,7 +1591,9 @@ namespace Intrepid2 {
         art::matvecProductDataField(out_c_f_p_d, data_c_p, in_c_f_p_d);
         art::matvecProductDataField(outi_c_f_p_d, datainv_c_p, out_c_f_p_d);
         rst::subtract(outi_c_f_p_d, in_c_f_p_d);
-        if (rst::Serial::vectorNorm(outi_c_f_p_d, NORM_ONE) > tol) {
+        auto outi_c_f_p_d_h = Kokkos::create_mirror_view(outi_c_f_p_d);
+        Kokkos::deep_copy(outi_c_f_p_d_h, outi_c_f_p_d);
+        if (rst::Serial::vectorNorm(outi_c_f_p_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matvecProductDataField (3): check scalar inverse property\n\n";
           errorFlag = -1000;
         }
@@ -1600,7 +1602,8 @@ namespace Intrepid2 {
         art::matvecProductDataField(out_c_f_p_d, data_c_1, in_c_f_p_d);
         art::matvecProductDataField(outi_c_f_p_d, datainv_c_1, out_c_f_p_d);
         rst::subtract(outi_c_f_p_d, in_c_f_p_d);
-        if (rst::Serial::vectorNorm(outi_c_f_p_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_f_p_d_h, outi_c_f_p_d);
+        if (rst::Serial::vectorNorm(outi_c_f_p_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matvecProductDataField (4): check scalar inverse property\n\n";
           errorFlag = -1000;
         }
@@ -1631,7 +1634,8 @@ namespace Intrepid2 {
         art::matvecProductDataField(out_c_f_p_d, data_c_p_d, in_c_f_p_d);
         art::matvecProductDataField(outi_c_f_p_d, datainv_c_p_d, out_c_f_p_d);
         rst::subtract(outi_c_f_p_d, in_c_f_p_d);
-        if (rst::Serial::vectorNorm(outi_c_f_p_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_f_p_d_h, outi_c_f_p_d);
+        if (rst::Serial::vectorNorm(outi_c_f_p_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matvecProductDataField (5): check scalar inverse property\n\n";
           errorFlag = -1000;
         }
@@ -1639,7 +1643,8 @@ namespace Intrepid2 {
         art::matvecProductDataField(out_c_f_p_d, data_c_1_d, in_c_f_p_d);
         art::matvecProductDataField(outi_c_f_p_d, datainv_c_1_d, out_c_f_p_d);
         rst::subtract(outi_c_f_p_d, in_c_f_p_d);
-        if (rst::Serial::vectorNorm(outi_c_f_p_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_f_p_d_h, outi_c_f_p_d);
+        if (rst::Serial::vectorNorm(outi_c_f_p_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matvecProductDataField (6): check scalar inverse property\n\n";
           errorFlag = -1000;
         }
@@ -1668,14 +1673,16 @@ namespace Intrepid2 {
         art::matvecProductDataField(out_c_f_p_d, data_c_p_d_d, in_c_f_p_d);
         art::matvecProductDataField(outi_c_f_p_d, datainv_c_p_d_d, out_c_f_p_d);
         rst::subtract(outi_c_f_p_d, in_c_f_p_d);
-        if (rst::Serial::vectorNorm(outi_c_f_p_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_f_p_d_h, outi_c_f_p_d);
+        if (rst::Serial::vectorNorm(outi_c_f_p_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matvecProductDataField (7): check matrix inverse property\n\n";
           errorFlag = -1000;
         }
         art::matvecProductDataField(out_c_f_p_d, data_c_p_d_d, in_c_f_p_d, 't');
         art::matvecProductDataField(outi_c_f_p_d, datainv_c_p_d_d, out_c_f_p_d, 't');
         rst::subtract(outi_c_f_p_d, in_c_f_p_d);
-        if (rst::Serial::vectorNorm(outi_c_f_p_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_f_p_d_h, outi_c_f_p_d);
+        if (rst::Serial::vectorNorm(outi_c_f_p_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matvecProductDataField (8): check matrix inverse property, w/ double transpose\n\n";
           errorFlag = -1000;
         }
@@ -1683,14 +1690,16 @@ namespace Intrepid2 {
         art::matvecProductDataField(out_c_f_p_d, data_c_1_d_d, in_c_f_p_d);
         art::matvecProductDataField(outi_c_f_p_d, datainv_c_1_d_d, out_c_f_p_d);
         rst::subtract(outi_c_f_p_d, in_c_f_p_d);
-        if (rst::Serial::vectorNorm(outi_c_f_p_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_f_p_d_h, outi_c_f_p_d);
+        if (rst::Serial::vectorNorm(outi_c_f_p_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matvecProductDataField (9): check matrix inverse property\n\n";
           errorFlag = -1000;
         }
         art::matvecProductDataField(out_c_f_p_d, data_c_1_d_d, in_c_f_p_d, 't');
         art::matvecProductDataField(outi_c_f_p_d, datainv_c_1_d_d, out_c_f_p_d, 't');
         rst::subtract(outi_c_f_p_d, in_c_f_p_d);
-        if (rst::Serial::vectorNorm(outi_c_f_p_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_f_p_d_h, outi_c_f_p_d);
+        if (rst::Serial::vectorNorm(outi_c_f_p_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matvecProductDataField (10): check matrix inverse property, w/ double transpose\n\n";
           errorFlag = -1000;
         }
@@ -1726,7 +1735,8 @@ namespace Intrepid2 {
         art::matvecProductDataField(out_c_f_p_d, data_c_p_d_d, in_c_f_p_d);
         art::matvecProductDataField(outi_c_f_p_d, datainvtrn_c_p_d_d, out_c_f_p_d, 't');
         rst::subtract(outi_c_f_p_d, in_c_f_p_d);
-        if (rst::Serial::vectorNorm(outi_c_f_p_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_f_p_d_h, outi_c_f_p_d);
+        if (rst::Serial::vectorNorm(outi_c_f_p_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matvecProductDataField (11): check matrix inverse transpose property\n\n";
           errorFlag = -1000;
         }
@@ -1734,7 +1744,8 @@ namespace Intrepid2 {
         art::matvecProductDataField(out_c_f_p_d, data_c_1_d_d, in_c_f_p_d);
         art::matvecProductDataField(outi_c_f_p_d, datainvtrn_c_1_d_d, out_c_f_p_d, 't');
         rst::subtract(outi_c_f_p_d, in_c_f_p_d);
-        if (rst::Serial::vectorNorm(outi_c_f_p_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_f_p_d_h, outi_c_f_p_d);
+        if (rst::Serial::vectorNorm(outi_c_f_p_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matvecProductDataField (12): check matrix inverse transpose property\n\n";
           errorFlag = -1000;
         }
@@ -1795,7 +1806,9 @@ namespace Intrepid2 {
         art::matvecProductDataField(out_c_f_p_d, data_c_p, in_f_p_d);
         art::matvecProductDataField(outi_c_f_p_d, datainv_c_p, out_c_f_p_d);
         rst::subtract(outi_c_f_p_d, in_c_f_p_d);
-        if (rst::Serial::vectorNorm(outi_c_f_p_d, NORM_ONE) > tol) {
+        auto outi_c_f_p_d_h = Kokkos::create_mirror_view(outi_c_f_p_d);
+        Kokkos::deep_copy(outi_c_f_p_d_h, outi_c_f_p_d);
+        if (rst::Serial::vectorNorm(outi_c_f_p_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matvecProductDataField (13): check scalar inverse property\n\n";
           errorFlag = -1000;
         }
@@ -1804,7 +1817,8 @@ namespace Intrepid2 {
         art::matvecProductDataField(out_c_f_p_d, data_c_1, in_f_p_d);
         art::matvecProductDataField(outi_c_f_p_d, datainv_c_1, out_c_f_p_d);
         rst::subtract(outi_c_f_p_d, in_c_f_p_d);
-        if (rst::Serial::vectorNorm(outi_c_f_p_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_f_p_d_h, outi_c_f_p_d);
+        if (rst::Serial::vectorNorm(outi_c_f_p_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matvecProductDataField (14): check scalar inverse property\n\n";
           errorFlag = -1000;
         }
@@ -1834,7 +1848,8 @@ namespace Intrepid2 {
         art::matvecProductDataField(out_c_f_p_d, data_c_p_d, in_f_p_d);
         art::matvecProductDataField(outi_c_f_p_d, datainv_c_p_d, out_c_f_p_d);
         rst::subtract(outi_c_f_p_d, in_c_f_p_d);
-        if (rst::Serial::vectorNorm(outi_c_f_p_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_f_p_d_h, outi_c_f_p_d);
+        if (rst::Serial::vectorNorm(outi_c_f_p_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matvecProductDataField (15): check scalar inverse property\n\n";
           errorFlag = -1000;
         }
@@ -1843,7 +1858,8 @@ namespace Intrepid2 {
         art::matvecProductDataField(out_c_f_p_d, data_c_1_d, in_f_p_d);
         art::matvecProductDataField(outi_c_f_p_d, datainv_c_1_d, out_c_f_p_d);
         rst::subtract(outi_c_f_p_d, in_c_f_p_d);
-        if (rst::Serial::vectorNorm(outi_c_f_p_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_f_p_d_h, outi_c_f_p_d);
+        if (rst::Serial::vectorNorm(outi_c_f_p_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matvecProductDataField (16): check scalar inverse property\n\n";
           errorFlag = -1000;
         }
@@ -1874,7 +1890,8 @@ namespace Intrepid2 {
         art::matvecProductDataField(out_c_f_p_d, data_c_p_d_d, in_f_p_d);
         art::matvecProductDataField(outi_c_f_p_d, datainv_c_p_d_d, out_c_f_p_d);
         rst::subtract(outi_c_f_p_d, in_c_f_p_d);
-        if (rst::Serial::vectorNorm(outi_c_f_p_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_f_p_d_h, outi_c_f_p_d);
+        if (rst::Serial::vectorNorm(outi_c_f_p_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matvecProductDataField (17): check matrix inverse property\n\n";
           errorFlag = -1000;
         }
@@ -1882,7 +1899,8 @@ namespace Intrepid2 {
         art::matvecProductDataField(out_c_f_p_d, data_c_p_d_d, in_f_p_d, 't');
         art::matvecProductDataField(outi_c_f_p_d, datainv_c_p_d_d, out_c_f_p_d, 't');
         rst::subtract(outi_c_f_p_d, in_c_f_p_d);
-        if (rst::Serial::vectorNorm(outi_c_f_p_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_f_p_d_h, outi_c_f_p_d);
+        if (rst::Serial::vectorNorm(outi_c_f_p_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matvecProductDataField (18): check matrix inverse property, w/ double tvalue_typese\n\n";
           errorFlag = -1000;
         }
@@ -1891,7 +1909,8 @@ namespace Intrepid2 {
         art::matvecProductDataField(out_c_f_p_d, data_c_1_d_d, in_f_p_d);
         art::matvecProductDataField(outi_c_f_p_d, datainv_c_1_d_d, out_c_f_p_d);
         rst::subtract(outi_c_f_p_d, in_c_f_p_d);
-        if (rst::Serial::vectorNorm(outi_c_f_p_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_f_p_d_h, outi_c_f_p_d);
+        if (rst::Serial::vectorNorm(outi_c_f_p_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matvecProductDataField (19): check matrix inverse property\n\n";
           errorFlag = -1000;
         }
@@ -1899,7 +1918,8 @@ namespace Intrepid2 {
         art::matvecProductDataField(out_c_f_p_d, data_c_1_d_d, in_f_p_d, 't');
         art::matvecProductDataField(outi_c_f_p_d, datainv_c_1_d_d, out_c_f_p_d, 't');
         rst::subtract(outi_c_f_p_d, in_c_f_p_d);
-        if (rst::Serial::vectorNorm(outi_c_f_p_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_f_p_d_h, outi_c_f_p_d);
+        if (rst::Serial::vectorNorm(outi_c_f_p_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matvecProductDataField (20): check matrix inverse property, w/ double transpose\n\n";
           errorFlag = -1000;
         }
@@ -1936,7 +1956,8 @@ namespace Intrepid2 {
         art::matvecProductDataField(out_c_f_p_d, data_c_p_d_d, in_f_p_d);
         art::matvecProductDataField(outi_c_f_p_d, datainvtrn_c_p_d_d, out_c_f_p_d, 't');
         rst::subtract(outi_c_f_p_d, in_c_f_p_d);
-        if (rst::Serial::vectorNorm(outi_c_f_p_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_f_p_d_h, outi_c_f_p_d);
+        if (rst::Serial::vectorNorm(outi_c_f_p_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matvecProductDataField (21): check matrix inverse transpose property\n\n";
           errorFlag = -1000;
         }
@@ -1945,7 +1966,8 @@ namespace Intrepid2 {
         art::matvecProductDataField(out_c_f_p_d, data_c_1_d_d, in_f_p_d);
         art::matvecProductDataField(outi_c_f_p_d, datainvtrn_c_1_d_d, out_c_f_p_d, 't');
         rst::subtract(outi_c_f_p_d, in_c_f_p_d);
-        if (rst::Serial::vectorNorm(outi_c_f_p_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_f_p_d_h, outi_c_f_p_d);
+        if (rst::Serial::vectorNorm(outi_c_f_p_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matvecProductDataField (22): check matrix inverse transpose property\n\n";
           errorFlag = -1000;
         }
@@ -2133,7 +2155,9 @@ namespace Intrepid2 {
         art::matvecProductDataData(out_c_p_d, data_c_p, in_c_p_d);
         art::matvecProductDataData(outi_c_p_d, datainv_c_p, out_c_p_d);
         rst::subtract(outi_c_p_d, in_c_p_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d, NORM_ONE) > tol) {
+        auto outi_c_p_d_h = Kokkos::create_mirror_view(outi_c_p_d);
+        Kokkos::deep_copy(outi_c_p_d_h, outi_c_p_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matvecProductDataData (3): check scalar inverse property\n\n";
           errorFlag = -1000;
         }
@@ -2142,7 +2166,8 @@ namespace Intrepid2 {
         art::matvecProductDataData(out_c_p_d, data_c_1, in_c_p_d);
         art::matvecProductDataData(outi_c_p_d, datainv_c_1, out_c_p_d);
         rst::subtract(outi_c_p_d, in_c_p_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_p_d_h, outi_c_p_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matvecProductDataData (4): check scalar inverse property\n\n";
           errorFlag = -1000;
         }
@@ -2167,7 +2192,8 @@ namespace Intrepid2 {
         art::matvecProductDataData(out_c_p_d, data_c_p_d, in_c_p_d);
         art::matvecProductDataData(outi_c_p_d, datainv_c_p_d, out_c_p_d);
         rst::subtract(outi_c_p_d, in_c_p_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_p_d_h, outi_c_p_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matvecProductDataData (5): check scalar inverse property\n\n";
           errorFlag = -1000;
         }
@@ -2175,7 +2201,8 @@ namespace Intrepid2 {
         art::matvecProductDataData(out_c_p_d, data_c_1_d, in_c_p_d);
         art::matvecProductDataData(outi_c_p_d, datainv_c_1_d, out_c_p_d);
         rst::subtract(outi_c_p_d, in_c_p_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_p_d_h, outi_c_p_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matvecProductDataData (6): check scalar inverse property\n\n";
           errorFlag = -1000;
         }
@@ -2202,14 +2229,16 @@ namespace Intrepid2 {
         art::matvecProductDataData(out_c_p_d, data_c_p_d_d, in_c_p_d);
         art::matvecProductDataData(outi_c_p_d, datainv_c_p_d_d, out_c_p_d);
         rst::subtract(outi_c_p_d, in_c_p_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_p_d_h, outi_c_p_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matvecProductDataData (7): check matrix inverse property\n\n";
           errorFlag = -1000;
         }
         art::matvecProductDataData(out_c_p_d, data_c_p_d_d, in_c_p_d, 't');
         art::matvecProductDataData(outi_c_p_d, datainv_c_p_d_d, out_c_p_d, 't');
         rst::subtract(outi_c_p_d, in_c_p_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_p_d_h, outi_c_p_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matvecProductDataData (8): check matrix inverse property, w/ double transpose\n\n";
           errorFlag = -1000;
         }
@@ -2217,14 +2246,16 @@ namespace Intrepid2 {
         art::matvecProductDataData(out_c_p_d, data_c_1_d_d, in_c_p_d);
         art::matvecProductDataData(outi_c_p_d, datainv_c_1_d_d, out_c_p_d);
         rst::subtract(outi_c_p_d, in_c_p_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_p_d_h, outi_c_p_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matvecProductDataData (9): check matrix inverse property\n\n";
           errorFlag = -1000;
         }
         art::matvecProductDataData(out_c_p_d, data_c_1_d_d, in_c_p_d, 't');
         art::matvecProductDataData(outi_c_p_d, datainv_c_1_d_d, out_c_p_d, 't');
         rst::subtract(outi_c_p_d, in_c_p_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_p_d_h, outi_c_p_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matvecProductDataData (10): check matrix inverse property, w/ double transpose\n\n";
           errorFlag = -1000;
         }
@@ -2255,7 +2286,8 @@ namespace Intrepid2 {
         art::matvecProductDataData(out_c_p_d, data_c_p_d_d, in_c_p_d);
         art::matvecProductDataData(outi_c_p_d, datainvtrn_c_p_d_d, out_c_p_d, 't');
         rst::subtract(outi_c_p_d, in_c_p_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_p_d_h, outi_c_p_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matvecProductDataData (11): check matrix inverse transpose property\n\n";
           errorFlag = -1000;
         }
@@ -2263,7 +2295,8 @@ namespace Intrepid2 {
         art::matvecProductDataData(out_c_p_d, data_c_1_d_d, in_c_p_d);
         art::matvecProductDataData(outi_c_p_d, datainvtrn_c_1_d_d, out_c_p_d, 't');
         rst::subtract(outi_c_p_d, in_c_p_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_p_d_h, outi_c_p_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matvecProductDataData (12): check matrix inverse transpose property\n\n";
           errorFlag = -1000;
         }
@@ -2325,7 +2358,9 @@ namespace Intrepid2 {
         art::matvecProductDataData(out_c_p_d, data_c_p, in_p_d);
         art::matvecProductDataData(outi_c_p_d, datainv_c_p, out_c_p_d);
         rst::subtract(outi_c_p_d, in_c_p_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d, NORM_ONE) > tol) {
+        auto outi_c_p_d_h = Kokkos::create_mirror_view(outi_c_p_d);
+        Kokkos::deep_copy(outi_c_p_d_h, outi_c_p_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matvecProductDataData (13): check scalar inverse property\n\n";
           errorFlag = -1000;
         }
@@ -2334,7 +2369,8 @@ namespace Intrepid2 {
         art::matvecProductDataData(out_c_p_d, data_c_1, in_p_d);
         art::matvecProductDataData(outi_c_p_d, datainv_c_1, out_c_p_d);
         rst::subtract(outi_c_p_d, in_c_p_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_p_d_h, outi_c_p_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matvecProductDataData (14): check scalar inverse property\n\n";
           errorFlag = -1000;
         }
@@ -2363,7 +2399,8 @@ namespace Intrepid2 {
         art::matvecProductDataData(out_c_p_d, data_c_p_d, in_p_d);
         art::matvecProductDataData(outi_c_p_d, datainv_c_p_d, out_c_p_d);
         rst::subtract(outi_c_p_d, in_c_p_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_p_d_h, outi_c_p_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matvecProductDataData (15): check scalar inverse property\n\n";
           errorFlag = -1000;
         }
@@ -2372,7 +2409,8 @@ namespace Intrepid2 {
         art::matvecProductDataData(out_c_p_d, data_c_1_d, in_p_d);
         art::matvecProductDataData(outi_c_p_d, datainv_c_1_d, out_c_p_d);
         rst::subtract(outi_c_p_d, in_c_p_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_p_d_h, outi_c_p_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matvecProductDataData (16): check scalar inverse property\n\n";
           errorFlag = -1000;
         }
@@ -2405,7 +2443,8 @@ namespace Intrepid2 {
         art::matvecProductDataData(out_c_p_d, data_c_p_d_d, in_p_d);
         art::matvecProductDataData(outi_c_p_d, datainv_c_p_d_d, out_c_p_d);
         rst::subtract(outi_c_p_d, in_c_p_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_p_d_h, outi_c_p_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matvecProductDataData (17): check matrix inverse property\n\n";
           errorFlag = -1000;
         }
@@ -2413,7 +2452,8 @@ namespace Intrepid2 {
         art::matvecProductDataData(out_c_p_d, data_c_p_d_d, in_p_d, 't');
         art::matvecProductDataData(outi_c_p_d, datainv_c_p_d_d, out_c_p_d, 't');
         rst::subtract(outi_c_p_d, in_c_p_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_p_d_h, outi_c_p_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matvecProductDataData (18): check matrix inverse property, w/ double transpose\n\n";
           errorFlag = -1000;
         }
@@ -2422,7 +2462,8 @@ namespace Intrepid2 {
         art::matvecProductDataData(out_c_p_d, data_c_1_d_d, in_p_d);
         art::matvecProductDataData(outi_c_p_d, datainv_c_1_d_d, out_c_p_d);
         rst::subtract(outi_c_p_d, in_c_p_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_p_d_h, outi_c_p_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matvecProductDataData (19): check matrix inverse property\n\n";
           errorFlag = -1000;
         }
@@ -2430,7 +2471,8 @@ namespace Intrepid2 {
         art::matvecProductDataData(out_c_p_d, data_c_1_d_d, in_p_d, 't');
         art::matvecProductDataData(outi_c_p_d, datainv_c_1_d_d, out_c_p_d, 't');
         rst::subtract(outi_c_p_d, in_c_p_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_p_d_h, outi_c_p_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matvecProductDataData (20): check matrix inverse property, w/ double transpose\n\n";
           errorFlag = -1000;
         }
@@ -2464,7 +2506,8 @@ namespace Intrepid2 {
         art::matvecProductDataData(out_c_p_d, data_c_p_d_d, in_p_d);
         art::matvecProductDataData(outi_c_p_d, datainvtrn_c_p_d_d, out_c_p_d, 't');
         rst::subtract(outi_c_p_d, in_c_p_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_p_d_h, outi_c_p_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matvecProductDataData (21): check matrix inverse transpose property\n\n";
           errorFlag = -1000;
         }
@@ -2473,7 +2516,8 @@ namespace Intrepid2 {
         art::matvecProductDataData(out_c_p_d, data_c_1_d_d, in_p_d);
         art::matvecProductDataData(outi_c_p_d, datainvtrn_c_1_d_d, out_c_p_d, 't');
         rst::subtract(outi_c_p_d, in_c_p_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_p_d_h, outi_c_p_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matvecProductDataData (22): check matrix inverse transpose property\n\n";
           errorFlag = -1000;
         }
@@ -2531,7 +2575,9 @@ namespace Intrepid2 {
         art::matmatProductDataField(out_c_f_p_d_d, data_c_p, in_c_f_p_d_d);
         art::matmatProductDataField(outi_c_f_p_d_d, datainv_c_p, out_c_f_p_d_d);
         rst::subtract(outi_c_f_p_d_d, in_c_f_p_d_d);
-        if (rst::Serial::vectorNorm(outi_c_f_p_d_d, NORM_ONE) > tol) {
+        auto outi_c_f_p_d_d_h = Kokkos::create_mirror_view(outi_c_f_p_d_d);
+        Kokkos::deep_copy(outi_c_f_p_d_d_h, outi_c_f_p_d_d);
+        if (rst::Serial::vectorNorm(outi_c_f_p_d_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matmatProductDataField (1): check scalar inverse property\n\n";
           errorFlag = -1000;
         }
@@ -2539,7 +2585,8 @@ namespace Intrepid2 {
         art::matmatProductDataField(out_c_f_p_d_d, data_c_1, in_c_f_p_d_d);
         art::matmatProductDataField(outi_c_f_p_d_d, datainv_c_1, out_c_f_p_d_d);
         rst::subtract(outi_c_f_p_d_d, in_c_f_p_d_d);
-        if (rst::Serial::vectorNorm(outi_c_f_p_d_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_f_p_d_d_h, outi_c_f_p_d_d);
+        if (rst::Serial::vectorNorm(outi_c_f_p_d_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matmatProductDataField (2): check scalar inverse property\n\n";
           errorFlag = -1000;
         }
@@ -2568,7 +2615,8 @@ namespace Intrepid2 {
         art::matmatProductDataField(out_c_f_p_d_d, data_c_p_d, in_c_f_p_d_d);
         art::matmatProductDataField(outi_c_f_p_d_d, datainv_c_p_d, out_c_f_p_d_d);
         rst::subtract(outi_c_f_p_d_d, in_c_f_p_d_d);
-        if (rst::Serial::vectorNorm(outi_c_f_p_d_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_f_p_d_d_h, outi_c_f_p_d_d);
+        if (rst::Serial::vectorNorm(outi_c_f_p_d_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matmatProductDataField (3): check scalar inverse property\n\n";
           errorFlag = -1000;
         }
@@ -2576,7 +2624,8 @@ namespace Intrepid2 {
         art::matmatProductDataField(out_c_f_p_d_d, data_c_1_d, in_c_f_p_d_d);
         art::matmatProductDataField(outi_c_f_p_d_d, datainv_c_1_d, out_c_f_p_d_d);
         rst::subtract(outi_c_f_p_d_d, in_c_f_p_d_d);
-        if (rst::Serial::vectorNorm(outi_c_f_p_d_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_f_p_d_d_h, outi_c_f_p_d_d);
+        if (rst::Serial::vectorNorm(outi_c_f_p_d_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matmatProductDataField (4): check scalar inverse property\n\n";
           errorFlag = -1000;
         }
@@ -2607,14 +2656,16 @@ namespace Intrepid2 {
         art::matmatProductDataField(out_c_f_p_d_d, data_c_p_d_d, in_c_f_p_d_d);
         art::matmatProductDataField(outi_c_f_p_d_d, datainv_c_p_d_d, out_c_f_p_d_d);
         rst::subtract(outi_c_f_p_d_d, in_c_f_p_d_d);
-        if (rst::Serial::vectorNorm(outi_c_f_p_d_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_f_p_d_d_h, outi_c_f_p_d_d);
+        if (rst::Serial::vectorNorm(outi_c_f_p_d_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matmatProductDataField (5): check matrix inverse property\n\n";
           errorFlag = -1000;
         }
         art::matmatProductDataField(out_c_f_p_d_d, data_c_p_d_d, in_c_f_p_d_d, 't');
         art::matmatProductDataField(outi_c_f_p_d_d, datainv_c_p_d_d, out_c_f_p_d_d, 't');
         rst::subtract(outi_c_f_p_d_d, in_c_f_p_d_d);
-        if (rst::Serial::vectorNorm(outi_c_f_p_d_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_f_p_d_d_h, outi_c_f_p_d_d);
+        if (rst::Serial::vectorNorm(outi_c_f_p_d_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matmatProductDataField (6): check matrix inverse property, w/ double transpose\n\n";
           errorFlag = -1000;
         }
@@ -2622,14 +2673,16 @@ namespace Intrepid2 {
         art::matmatProductDataField(out_c_f_p_d_d, data_c_1_d_d, in_c_f_p_d_d);
         art::matmatProductDataField(outi_c_f_p_d_d, datainv_c_1_d_d, out_c_f_p_d_d);
         rst::subtract(outi_c_f_p_d_d, in_c_f_p_d_d);
-        if (rst::Serial::vectorNorm(outi_c_f_p_d_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_f_p_d_d_h, outi_c_f_p_d_d);
+        if (rst::Serial::vectorNorm(outi_c_f_p_d_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matmatProductDataField (7): check matrix inverse property\n\n";
           errorFlag = -1000;
         }
         art::matmatProductDataField(out_c_f_p_d_d, data_c_1_d_d, in_c_f_p_d_d,'t');
         art::matmatProductDataField(outi_c_f_p_d_d, datainv_c_1_d_d, out_c_f_p_d_d, 't');
         rst::subtract(outi_c_f_p_d_d, in_c_f_p_d_d);
-        if (rst::Serial::vectorNorm(outi_c_f_p_d_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_f_p_d_d_h, outi_c_f_p_d_d);
+        if (rst::Serial::vectorNorm(outi_c_f_p_d_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matmatProductDataField (8): check matrix inverse property, w/ double transpose\n\n";
           errorFlag = -1000;
         }
@@ -2663,7 +2716,8 @@ namespace Intrepid2 {
         art::matmatProductDataField(out_c_f_p_d_d, data_c_p_d_d, in_c_f_p_d_d);
         art::matmatProductDataField(outi_c_f_p_d_d, datainvtrn_c_p_d_d, out_c_f_p_d_d, 't');
         rst::subtract(outi_c_f_p_d_d, in_c_f_p_d_d);
-        if (rst::Serial::vectorNorm(outi_c_f_p_d_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_f_p_d_d_h, outi_c_f_p_d_d);
+        if (rst::Serial::vectorNorm(outi_c_f_p_d_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matmatProductDataField (9): check matrix inverse transpose property\n\n";
           errorFlag = -1000;
         }
@@ -2671,7 +2725,8 @@ namespace Intrepid2 {
         art::matmatProductDataField(out_c_f_p_d_d, data_c_1_d_d, in_c_f_p_d_d);
         art::matmatProductDataField(outi_c_f_p_d_d, datainvtrn_c_1_d_d, out_c_f_p_d_d, 't');
         rst::subtract(outi_c_f_p_d_d, in_c_f_p_d_d);
-        if (rst::Serial::vectorNorm(outi_c_f_p_d_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_f_p_d_d_h, outi_c_f_p_d_d);
+        if (rst::Serial::vectorNorm(outi_c_f_p_d_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matmatProductDataField (10): check matrix inverse transpose property\n\n";
           errorFlag = -1000;
         }
@@ -2732,7 +2787,9 @@ namespace Intrepid2 {
         art::matmatProductDataField(out_c_f_p_d_d, data_c_p, in_f_p_d_d);
         art::matmatProductDataField(outi_c_f_p_d_d, datainv_c_p, out_c_f_p_d_d);
         rst::subtract(outi_c_f_p_d_d, in_c_f_p_d_d);
-        if (rst::Serial::vectorNorm(outi_c_f_p_d_d, NORM_ONE) > tol) {
+        auto outi_c_f_p_d_d_h = Kokkos::create_mirror_view(outi_c_f_p_d_d);
+        Kokkos::deep_copy(outi_c_f_p_d_d_h, outi_c_f_p_d_d);
+        if (rst::Serial::vectorNorm(outi_c_f_p_d_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matmatProductDataField (11): check scalar inverse property\n\n";
           errorFlag = -1000;
         }
@@ -2741,7 +2798,8 @@ namespace Intrepid2 {
         art::matmatProductDataField(out_c_f_p_d_d, data_c_1, in_f_p_d_d);
         art::matmatProductDataField(outi_c_f_p_d_d, datainv_c_1, out_c_f_p_d_d);
         rst::subtract(outi_c_f_p_d_d, in_c_f_p_d_d);
-        if (rst::Serial::vectorNorm(outi_c_f_p_d_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_f_p_d_d_h, outi_c_f_p_d_d);
+        if (rst::Serial::vectorNorm(outi_c_f_p_d_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matmatProductDataField (12): check scalar inverse property\n\n";
           errorFlag = -1000;
         }
@@ -2770,7 +2828,8 @@ namespace Intrepid2 {
         art::matmatProductDataField(out_c_f_p_d_d, data_c_p_d, in_f_p_d_d);
         art::matmatProductDataField(outi_c_f_p_d_d, datainv_c_p_d, out_c_f_p_d_d);
         rst::subtract(outi_c_f_p_d_d, in_c_f_p_d_d);
-        if (rst::Serial::vectorNorm(outi_c_f_p_d_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_f_p_d_d_h, outi_c_f_p_d_d);
+        if (rst::Serial::vectorNorm(outi_c_f_p_d_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matmatProductDataField (13): check scalar inverse property\n\n";
           errorFlag = -1000;
         }
@@ -2779,7 +2838,8 @@ namespace Intrepid2 {
         art::matmatProductDataField(out_c_f_p_d_d, data_c_1_d, in_f_p_d_d);
         art::matmatProductDataField(outi_c_f_p_d_d, datainv_c_1_d, out_c_f_p_d_d);
         rst::subtract(outi_c_f_p_d_d, in_c_f_p_d_d);
-        if (rst::Serial::vectorNorm(outi_c_f_p_d_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_f_p_d_d_h, outi_c_f_p_d_d);
+        if (rst::Serial::vectorNorm(outi_c_f_p_d_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matmatProductDataField (14): check scalar inverse property\n\n";
           errorFlag = -1000;
         }
@@ -2811,7 +2871,8 @@ namespace Intrepid2 {
         art::matmatProductDataField(out_c_f_p_d_d, data_c_p_d_d, in_f_p_d_d);
         art::matmatProductDataField(outi_c_f_p_d_d, datainv_c_p_d_d, out_c_f_p_d_d);
         rst::subtract(outi_c_f_p_d_d, in_c_f_p_d_d);
-        if (rst::Serial::vectorNorm(outi_c_f_p_d_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_f_p_d_d_h, outi_c_f_p_d_d);
+        if (rst::Serial::vectorNorm(outi_c_f_p_d_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matmatProductDataField (15): check matrix inverse property\n\n";
           errorFlag = -1000;
         }
@@ -2819,7 +2880,8 @@ namespace Intrepid2 {
         art::matmatProductDataField(out_c_f_p_d_d, data_c_p_d_d, in_f_p_d_d, 't');
         art::matmatProductDataField(outi_c_f_p_d_d, datainv_c_p_d_d, out_c_f_p_d_d, 't');
         rst::subtract(outi_c_f_p_d_d, in_c_f_p_d_d);
-        if (rst::Serial::vectorNorm(outi_c_f_p_d_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_f_p_d_d_h, outi_c_f_p_d_d);
+        if (rst::Serial::vectorNorm(outi_c_f_p_d_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matmatProductDataField (16): check matrix inverse property, w/ double transpose\n\n";
           errorFlag = -1000;
         }
@@ -2828,7 +2890,8 @@ namespace Intrepid2 {
         art::matmatProductDataField(out_c_f_p_d_d, data_c_1_d_d, in_f_p_d_d);
         art::matmatProductDataField(outi_c_f_p_d_d, datainv_c_1_d_d, out_c_f_p_d_d);
         rst::subtract(outi_c_f_p_d_d, in_c_f_p_d_d);
-        if (rst::Serial::vectorNorm(outi_c_f_p_d_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_f_p_d_d_h, outi_c_f_p_d_d);
+        if (rst::Serial::vectorNorm(outi_c_f_p_d_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matmatProductDataField (17): check matrix inverse property\n\n";
           errorFlag = -1000;
         }
@@ -2836,7 +2899,8 @@ namespace Intrepid2 {
         art::matmatProductDataField(out_c_f_p_d_d, data_c_1_d_d, in_f_p_d_d, 't');
         art::matmatProductDataField(outi_c_f_p_d_d, datainv_c_1_d_d, out_c_f_p_d_d, 't');
         rst::subtract(outi_c_f_p_d_d, in_c_f_p_d_d);
-        if (rst::Serial::vectorNorm(outi_c_f_p_d_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_f_p_d_d_h, outi_c_f_p_d_d);
+        if (rst::Serial::vectorNorm(outi_c_f_p_d_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matmatProductDataField (18): check matrix inverse property, w/ double transpose\n\n";
           errorFlag = -1000;
         }
@@ -2872,7 +2936,8 @@ namespace Intrepid2 {
         art::matmatProductDataField(out_c_f_p_d_d, data_c_p_d_d, in_f_p_d_d);
         art::matmatProductDataField(outi_c_f_p_d_d, datainvtrn_c_p_d_d, out_c_f_p_d_d, 't');
         rst::subtract(outi_c_f_p_d_d, in_c_f_p_d_d);
-        if (rst::Serial::vectorNorm(outi_c_f_p_d_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_f_p_d_d_h, outi_c_f_p_d_d);
+        if (rst::Serial::vectorNorm(outi_c_f_p_d_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matmatProductDataField (19): check matrix inverse transpose property\n\n";
           errorFlag = -1000;
         }
@@ -2881,7 +2946,8 @@ namespace Intrepid2 {
         art::matmatProductDataField(out_c_f_p_d_d, data_c_1_d_d, in_f_p_d_d);
         art::matmatProductDataField(outi_c_f_p_d_d, datainvtrn_c_1_d_d, out_c_f_p_d_d, 't');
         rst::subtract(outi_c_f_p_d_d, in_c_f_p_d_d);
-        if (rst::Serial::vectorNorm(outi_c_f_p_d_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_f_p_d_d_h, outi_c_f_p_d_d);
+        if (rst::Serial::vectorNorm(outi_c_f_p_d_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matmatProductDataField (20): check matrix inverse transpose property\n\n";
           errorFlag = -1000;
         }
@@ -2939,7 +3005,9 @@ namespace Intrepid2 {
         art::matmatProductDataData(out_c_p_d_d, data_c_p, in_c_p_d_d);
         art::matmatProductDataData(outi_c_p_d_d, datainv_c_p, out_c_p_d_d);
         rst::subtract(outi_c_p_d_d, in_c_p_d_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d_d, NORM_ONE) > tol) {
+        auto outi_c_p_d_d_h = Kokkos::create_mirror_view(outi_c_p_d_d);
+        Kokkos::deep_copy(outi_c_p_d_d_h, outi_c_p_d_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matmatProductDataData (1): check scalar inverse property\n\n";
           errorFlag = -1000;
         }
@@ -2947,7 +3015,8 @@ namespace Intrepid2 {
         art::matmatProductDataData(out_c_p_d_d, data_c_1, in_c_p_d_d);
         art::matmatProductDataData(outi_c_p_d_d, datainv_c_1, out_c_p_d_d);
         rst::subtract(outi_c_p_d_d, in_c_p_d_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_p_d_d_h, outi_c_p_d_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matmatProductDataData (2): check scalar inverse property\n\n";
           errorFlag = -1000;
         }
@@ -2973,7 +3042,8 @@ namespace Intrepid2 {
         art::matmatProductDataData(out_c_p_d_d, data_c_p_d, in_c_p_d_d);
         art::matmatProductDataData(outi_c_p_d_d, datainv_c_p_d, out_c_p_d_d);
         rst::subtract(outi_c_p_d_d, in_c_p_d_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_p_d_d_h, outi_c_p_d_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matmatProductDataData (3): check scalar inverse property\n\n";
           errorFlag = -1000;
         }
@@ -2981,7 +3051,8 @@ namespace Intrepid2 {
         art::matmatProductDataData(out_c_p_d_d, data_c_1_d, in_c_p_d_d);
         art::matmatProductDataData(outi_c_p_d_d, datainv_c_1_d, out_c_p_d_d);
         rst::subtract(outi_c_p_d_d, in_c_p_d_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_p_d_d_h, outi_c_p_d_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matmatProductDataData (4): check scalar inverse property\n\n";
           errorFlag = -1000;
         }
@@ -3010,14 +3081,16 @@ namespace Intrepid2 {
         art::matmatProductDataData(out_c_p_d_d, data_c_p_d_d, in_c_p_d_d);
         art::matmatProductDataData(outi_c_p_d_d, datainv_c_p_d_d, out_c_p_d_d);
         rst::subtract(outi_c_p_d_d, in_c_p_d_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_p_d_d_h, outi_c_p_d_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matmatProductDataData (5): check matrix inverse property\n\n";
           errorFlag = -1000;
         }
         art::matmatProductDataData(out_c_p_d_d, data_c_p_d_d, in_c_p_d_d, 't');
         art::matmatProductDataData(outi_c_p_d_d, datainv_c_p_d_d, out_c_p_d_d, 't');
         rst::subtract(outi_c_p_d_d, in_c_p_d_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_p_d_d_h, outi_c_p_d_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matmatProductDataData (6): check matrix inverse property, w/ double transpose\n\n";
           errorFlag = -1000;
         }
@@ -3025,14 +3098,16 @@ namespace Intrepid2 {
         art::matmatProductDataData(out_c_p_d_d, data_c_1_d_d, in_c_p_d_d);
         art::matmatProductDataData(outi_c_p_d_d, datainv_c_1_d_d, out_c_p_d_d);
         rst::subtract(outi_c_p_d_d, in_c_p_d_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_p_d_d_h, outi_c_p_d_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matmatProductDataData (7): check matrix inverse property\n\n";
           errorFlag = -1000;
         }
         art::matmatProductDataData(out_c_p_d_d, data_c_1_d_d, in_c_p_d_d, 't');
         art::matmatProductDataData(outi_c_p_d_d, datainv_c_1_d_d, out_c_p_d_d, 't');
         rst::subtract(outi_c_p_d_d, in_c_p_d_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_p_d_d_h, outi_c_p_d_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matmatProductDataData (8): check matrix inverse property, w/ double transpose\n\n";
           errorFlag = -1000;
         }
@@ -3062,7 +3137,8 @@ namespace Intrepid2 {
         art::matmatProductDataData(out_c_p_d_d, data_c_p_d_d, in_c_p_d_d);
         art::matmatProductDataData(outi_c_p_d_d, datainvtrn_c_p_d_d, out_c_p_d_d, 't');
         rst::subtract(outi_c_p_d_d, in_c_p_d_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_p_d_d_h, outi_c_p_d_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matmatProductDataData (9): check matrix inverse transpose property\n\n";
           errorFlag = -1000;
         }
@@ -3070,7 +3146,8 @@ namespace Intrepid2 {
         art::matmatProductDataData(out_c_p_d_d, data_c_1_d_d, in_c_p_d_d);
         art::matmatProductDataData(outi_c_p_d_d, datainvtrn_c_1_d_d, out_c_p_d_d, 't');
         rst::subtract(outi_c_p_d_d, in_c_p_d_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_p_d_d_h, outi_c_p_d_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matmatProductDataData (10): check matrix inverse transpose property\n\n";
           errorFlag = -1000;
         }
@@ -3131,7 +3208,9 @@ namespace Intrepid2 {
         art::matmatProductDataData(out_c_p_d_d, data_c_p, in_p_d_d);
         art::matmatProductDataData(outi_c_p_d_d, datainv_c_p, out_c_p_d_d);
         rst::subtract(outi_c_p_d_d, in_c_p_d_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d_d, NORM_ONE) > tol) {
+        auto outi_c_p_d_d_h = Kokkos::create_mirror_view(outi_c_p_d_d);
+        Kokkos::deep_copy(outi_c_p_d_d_h, outi_c_p_d_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matmatProductDataData (11): check scalar inverse property\n\n";
           errorFlag = -1000;
         }
@@ -3140,7 +3219,8 @@ namespace Intrepid2 {
         art::matmatProductDataData(out_c_p_d_d, data_c_1, in_p_d_d);
         art::matmatProductDataData(outi_c_p_d_d, datainv_c_1, out_c_p_d_d);
         rst::subtract(outi_c_p_d_d, in_c_p_d_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_p_d_d_h, outi_c_p_d_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matmatProductDataData (12): check scalar inverse property\n\n";
           errorFlag = -1000;
         }
@@ -3170,7 +3250,8 @@ namespace Intrepid2 {
         art::matmatProductDataData(out_c_p_d_d, data_c_p_d, in_p_d_d);
         art::matmatProductDataData(outi_c_p_d_d, datainv_c_p_d, out_c_p_d_d);
         rst::subtract(outi_c_p_d_d, in_c_p_d_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_p_d_d_h, outi_c_p_d_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matmatProductDataData (13): check scalar inverse property\n\n";
           errorFlag = -1000;
         }
@@ -3180,7 +3261,8 @@ namespace Intrepid2 {
         art::matmatProductDataData(out_c_p_d_d, data_c_1_d, in_p_d_d);
         art::matmatProductDataData(outi_c_p_d_d, datainv_c_1_d, out_c_p_d_d);
         rst::subtract(outi_c_p_d_d, in_c_p_d_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_p_d_d_h, outi_c_p_d_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matmatProductDataData (14): check scalar inverse property\n\n";
           errorFlag = -1000;
         }
@@ -3214,7 +3296,8 @@ namespace Intrepid2 {
         art::matmatProductDataData(out_c_p_d_d, data_c_p_d_d, in_p_d_d);
         art::matmatProductDataData(outi_c_p_d_d, datainv_c_p_d_d, out_c_p_d_d);
         rst::subtract(outi_c_p_d_d, in_c_p_d_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_p_d_d_h, outi_c_p_d_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matmatProductDataData (15): check matrix inverse property\n\n";
           errorFlag = -1000;
         }
@@ -3222,7 +3305,8 @@ namespace Intrepid2 {
         art::matmatProductDataData(out_c_p_d_d, data_c_p_d_d, in_p_d_d, 't');
         art::matmatProductDataData(outi_c_p_d_d, datainv_c_p_d_d, out_c_p_d_d, 't');
         rst::subtract(outi_c_p_d_d, in_c_p_d_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_p_d_d_h, outi_c_p_d_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matmatProductDataData (16): check matrix inverse property, w/ double transpose\n\n";
           errorFlag = -1000;
         }
@@ -3231,7 +3315,8 @@ namespace Intrepid2 {
         art::matmatProductDataData(out_c_p_d_d, data_c_1_d_d, in_p_d_d);
         art::matmatProductDataData(outi_c_p_d_d, datainv_c_1_d_d, out_c_p_d_d);
         rst::subtract(outi_c_p_d_d, in_c_p_d_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_p_d_d_h, outi_c_p_d_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matmatProductDataData (17): check matrix inverse property\n\n";
           errorFlag = -1000;
         }
@@ -3239,7 +3324,8 @@ namespace Intrepid2 {
         art::matmatProductDataData(out_c_p_d_d, data_c_1_d_d, in_p_d_d, 't');
         art::matmatProductDataData(outi_c_p_d_d, datainv_c_1_d_d, out_c_p_d_d, 't');
         rst::subtract(outi_c_p_d_d, in_c_p_d_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_p_d_d_h, outi_c_p_d_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matmatProductDataData (18): check matrix inverse property, w/ double transpose\n\n";
           errorFlag = -1000;
         }
@@ -3273,7 +3359,8 @@ namespace Intrepid2 {
         art::matmatProductDataData(out_c_p_d_d, data_c_p_d_d, in_p_d_d);
         art::matmatProductDataData(outi_c_p_d_d, datainvtrn_c_p_d_d, out_c_p_d_d, 't');
         rst::subtract(outi_c_p_d_d, in_c_p_d_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_p_d_d_h, outi_c_p_d_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matmatProductDataData (19): check matrix inverse transpose property\n\n";
           errorFlag = -1000;
         }
@@ -3282,7 +3369,8 @@ namespace Intrepid2 {
         art::matmatProductDataData(out_c_p_d_d, data_c_1_d_d, in_p_d_d);
         art::matmatProductDataData(outi_c_p_d_d, datainvtrn_c_1_d_d, out_c_p_d_d, 't');
         rst::subtract(outi_c_p_d_d, in_c_p_d_d);
-        if (rst::Serial::vectorNorm(outi_c_p_d_d, NORM_ONE) > tol) {
+        Kokkos::deep_copy(outi_c_p_d_d_h, outi_c_p_d_d);
+        if (rst::Serial::vectorNorm(outi_c_p_d_d_h, NORM_ONE) > tol) {
           *outStream << "\n\nINCORRECT matmatProductDataData (20): check matrix inverse transpose property\n\n";
           errorFlag = -1000;
         }

--- a/packages/intrepid2/unit-test/Shared/ArrayTools/test_05.hpp
+++ b/packages/intrepid2/unit-test/Shared/ArrayTools/test_05.hpp
@@ -234,21 +234,27 @@ namespace Intrepid2 {
           art::cloneFields(out_c_f_p, in_f_p);
           art::scalarMultiplyDataField(in_c_f_p, data_c_p_one, in_f_p);
           rst::subtract(out_c_f_p, in_c_f_p);
-          if (rst::Serial::vectorNorm(out_c_f_p, NORM_ONE) > tol) {
+          auto out_c_f_p_h = Kokkos::create_mirror_view(out_c_f_p);
+          Kokkos::deep_copy(out_c_f_p_h, out_c_f_p);
+          if (rst::Serial::vectorNorm(out_c_f_p_h, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT cloneFields (1): check multiplyScalarData vs. cloneFields\n\n";
             errorFlag = -1000;
           }
           art::cloneFields(out_c_f_p_d, in_f_p_d);
           art::scalarMultiplyDataField(in_c_f_p_d, data_c_p_one, in_f_p_d);
           rst::subtract(out_c_f_p_d, in_c_f_p_d);
-          if (rst::Serial::vectorNorm(out_c_f_p_d, NORM_ONE) > tol) {
+          auto out_c_f_p_d_h = Kokkos::create_mirror_view(out_c_f_p_d);
+          Kokkos::deep_copy(out_c_f_p_d_h, out_c_f_p_d);
+          if (rst::Serial::vectorNorm(out_c_f_p_d_h, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT cloneFields (2): check multiplyScalarData vs. cloneFields\n\n";
             errorFlag = -1000;
           }
           art::cloneFields(out_c_f_p_d_d, in_f_p_d_d);
           art::scalarMultiplyDataField(in_c_f_p_d_d, data_c_p_one, in_f_p_d_d);
           rst::subtract(out_c_f_p_d_d, in_c_f_p_d_d);
-          if (rst::Serial::vectorNorm(out_c_f_p_d_d, NORM_ONE) > tol) {
+          auto out_c_f_p_d_d_h = Kokkos::create_mirror_view(out_c_f_p_d_d);
+          Kokkos::deep_copy(out_c_f_p_d_d_h, out_c_f_p_d_d);
+          if (rst::Serial::vectorNorm(out_c_f_p_d_d_h, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT cloneFields (3): check multiplyScalarData vs. cloneFields\n\n";
             errorFlag = -1000;
           }
@@ -294,7 +300,9 @@ namespace Intrepid2 {
           //       out_c_f_p(i,j,k) *= outi_c_f_p(i,j,k);
 
           // rst::subtract(out_c_f_p, c_f_p_one);
-          // if (rst::Serial::vectorNorm(out_c_f_p, NORM_ONE) > tol) {
+          // auto out_c_f_p_h = Kokkos::create_mirror_view(out_c_f_p);
+          // Kokkos::deep_copy(out_c_f_p_h, out_c_f_p);
+          // if (rst::Serial::vectorNorm(out_c_f_p_h, NORM_ONE) > tol) {
           //   *outStream << "\n\nINCORRECT cloneScaleValue (1): check scalar inverse property\n\n";
           //   errorFlag = -1000;
           // }
@@ -309,7 +317,9 @@ namespace Intrepid2 {
           //         out_c_f_p_d(i,j,k,m) *= outi_c_f_p_d(i,j,k,m);
 
           // rst::subtract(out_c_f_p_d, c_f_p_d_one);
-          // if (rst::Serial::vectorNorm(out_c_f_p_d, NORM_ONE) > tol) {
+          // auto out_c_f_p_d_h = Kokkos::create_mirror_view(out_c_f_p_d);
+          // Kokkos::deep_copy(out_c_f_p_d_h, out_c_f_p_d);
+          // if (rst::Serial::vectorNorm(out_c_f_p_d_h, NORM_ONE) > tol) {
           //   *outStream << "\n\nINCORRECT cloneScaleValue (2): check scalar inverse property\n\n";
           //   errorFlag = -1000;
           // }
@@ -325,7 +335,9 @@ namespace Intrepid2 {
           //           out_c_f_p_d_d(i,j,k,m,n) *= outi_c_f_p_d_d(i,j,k,m,m);
 
           // rst::subtract(out_c_f_p_d_d, c_f_p_d_d_one);
-          // if (rst::Serial::vectorNorm(out_c_f_p_d_d, NORM_ONE) > tol) {
+          // auto out_c_f_p_d_d_h = Kokkos::create_mirror_view(out_c_f_p_d_d);
+          // Kokkos::deep_copy(out_c_f_p_d_d_h, out_c_f_p_d_d);
+          // if (rst::Serial::vectorNorm(out_c_f_p_d_d_h, NORM_ONE) > tol) {
           //   *outStream << "\n\nINCORRECT cloneScaleValue (3): check scalar inverse property\n\n";
           //   errorFlag = -1000;
           // }
@@ -362,7 +374,9 @@ namespace Intrepid2 {
           // art::scaleFields(out_c_f_p, data_c_f);
           // art::scaleFields(out_c_f_p, datainv_c_f);
           // rst::subtract(out_c_f_p, outi_c_f_p);
-          // if (rst::Serial::vectorNorm(out_c_f_p, NORM_ONE) > tol) {
+          // auto out_c_f_p_h = Kokkos::create_mirror_view(out_c_f_p);
+          // Kokkos::deep_copy(out_c_f_p_h, out_c_f_p);
+          // if (rst::Serial::vectorNorm(out_c_f_p_h, NORM_ONE) > tol) {
           //   *outStream << "\n\nINCORRECT scaleValue (1): check scalar inverse property\n\n";
           //   errorFlag = -1000;
           // }
@@ -370,7 +384,9 @@ namespace Intrepid2 {
           // art::scaleFields(out_c_f_p_d, data_c_f);
           // art::scaleFields(out_c_f_p_d, datainv_c_f);
           // rst::subtract(out_c_f_p_d, outi_c_f_p_d);
-          // if (rst::Serial::vectorNorm(out_c_f_p_d, NORM_ONE) > tol) {
+          // auto out_c_f_p_d_h = Kokkos::create_mirror_view(out_c_f_p_d);
+          // Kokkos::deep_copy(out_c_f_p_d_h, out_c_f_p_d);
+          // if (rst::Serial::vectorNorm(out_c_f_p_d_h, NORM_ONE) > tol) {
           //   *outStream << "\n\nINCORRECT scaleValue (2): check scalar inverse property\n\n";
           //   errorFlag = -1000;
           // }
@@ -378,7 +394,9 @@ namespace Intrepid2 {
           // art::scaleFields(out_c_f_p_d_d, data_c_f);
           // art::scaleFields(out_c_f_p_d_d, datainv_c_f);
           // rst::subtract(out_c_f_p_d_d, outi_c_f_p_d_d);
-          // if (rst::Serial::vectorNorm(out_c_f_p_d_d, NORM_ONE) > tol) {
+          // auto out_c_f_p_d_d_h = Kokkos::create_mirror_view(out_c_f_p_d_d);
+          // Kokkos::deep_copy(out_c_f_p_d_d_h, out_c_f_p_d_d);
+          // if (rst::Serial::vectorNorm(out_c_f_p_d_d_h, NORM_ONE) > tol) {
           //   *outStream << "\n\nINCORRECT cloneScaleValue (3): check scalar inverse property\n\n";
           //   errorFlag = -1000;
           // }

--- a/packages/intrepid2/unit-test/Shared/RealSpaceTools/test_01.hpp
+++ b/packages/intrepid2/unit-test/Shared/RealSpaceTools/test_01.hpp
@@ -137,7 +137,9 @@ namespace Intrepid2 {
 
         *outStream << "-> vector norm with multidimensional arrays:\n";
 
-        rst::Serial::vectorNorm(a_2_2, NORM_TWO);
+        auto a_2_2_h = Kokkos::create_mirror_view(a_2_2);
+        Kokkos::deep_copy(a_2_2_h, a_2_2);
+        rst::Serial::vectorNorm(a_2_2_h, NORM_TWO);
         INTREPID2_TEST_ERROR_EXPECTED( rst::vectorNorm(a_10_2_2, a_10_2_2, NORM_TWO) );
         INTREPID2_TEST_ERROR_EXPECTED( rst::vectorNorm(a_10_2_2, a_10_2_2_3, NORM_TWO) );
         INTREPID2_TEST_ERROR_EXPECTED( rst::vectorNorm(a_10_3, a_10_2_2, NORM_TWO) );
@@ -329,22 +331,28 @@ namespace Intrepid2 {
           *outStream << "\n-- Checking vectorNorm \n";
 
           rst::vectorNorm(vnorms_x_x, va_x_x_d, NORM_TWO);
-          if ( std::abs(rst::Serial::vectorNorm(vnorms_x_x, NORM_TWO) - 
-                        rst::Serial::vectorNorm(va_x_x_d, NORM_TWO)) > tol) {
+          auto vnorms_x_x_h = Kokkos::create_mirror_view(vnorms_x_x);
+          Kokkos::deep_copy(vnorms_x_x_h, vnorms_x_x);
+          auto va_x_x_d_h = Kokkos::create_mirror_view(va_x_x_d);
+          Kokkos::deep_copy(va_x_x_d_h, va_x_x_d);
+          if ( std::abs(rst::Serial::vectorNorm(vnorms_x_x_h, NORM_TWO) -
+                        rst::Serial::vectorNorm(va_x_x_d_h, NORM_TWO)) > tol) {
             *outStream << "\n\nINCORRECT vectorNorm NORM_TWO\n\n";
             errorFlag = -1000;
           }
           
           rst::vectorNorm(vnorms_x_x, va_x_x_d, NORM_ONE);
-          if ( std::abs(rst::Serial::vectorNorm(vnorms_x_x, NORM_ONE) - 
-                        rst::Serial::vectorNorm(va_x_x_d, NORM_ONE)) > tol) {
+          Kokkos::deep_copy(vnorms_x_x_h, vnorms_x_x);
+          if ( std::abs(rst::Serial::vectorNorm(vnorms_x_x_h, NORM_ONE) -
+                        rst::Serial::vectorNorm(va_x_x_d_h, NORM_ONE)) > tol) {
             *outStream << "\n\nINCORRECT vectorNorm NORM_ONE\n\n";
             errorFlag = -1000;
           }
           
           rst::vectorNorm(vnorms_x_x, va_x_x_d, NORM_INF);
-          if ( std::abs(rst::Serial::vectorNorm(vnorms_x_x, NORM_INF) - 
-                        rst::Serial::vectorNorm(va_x_x_d, NORM_INF)) > tol) {
+          Kokkos::deep_copy(vnorms_x_x_h, vnorms_x_x);
+          if ( std::abs(rst::Serial::vectorNorm(vnorms_x_x_h, NORM_INF) -
+                        rst::Serial::vectorNorm(va_x_x_d_h, NORM_INF)) > tol) {
             *outStream << "\n\nINCORRECT vectorNorm NORM_INF\n\n";
             errorFlag = -1000;
           }
@@ -356,7 +364,9 @@ namespace Intrepid2 {
           
           rst::subtract(mc_x_x_d_d, ma_x_x_d_d); // C = C - A ~= 0 
           
-          if (rst::Serial::vectorNorm(mc_x_x_d_d, NORM_ONE) > tol) {
+          auto mc_x_x_d_d_h = Kokkos::create_mirror_view(mc_x_x_d_d);
+          Kokkos::deep_copy(mc_x_x_d_d_h, mc_x_x_d_d);
+          if (rst::Serial::vectorNorm(mc_x_x_d_d_h, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT inverse OR subtract OR vectorNorm\n\n";
             errorFlag = -1000;
           }
@@ -389,7 +399,8 @@ namespace Intrepid2 {
           
           rst::subtract(mc_x_x_d_d, ma_x_x_d_d); // C = C - A = 0 
           
-          if (rst::Serial::vectorNorm(mc_x_x_d_d, NORM_ONE) > tol) {
+          Kokkos::deep_copy(mc_x_x_d_d_h, mc_x_x_d_d);
+          if (rst::Serial::vectorNorm(mc_x_x_d_d_h, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT transpose OR subtract OR vectorNorm\n\n" ;
             errorFlag = -1000;
           }
@@ -404,7 +415,9 @@ namespace Intrepid2 {
           
           rst::vectorNorm(vnorms_x_x, vc_x_x_d, NORM_ONE);
           rst::vectorNorm(vnorms_x, vnorms_x_x, NORM_INF);
-          if (rst::Serial::vectorNorm(vnorms_x, NORM_TWO) > tol) {
+          auto vnorms_x_h = Kokkos::create_mirror_view(vnorms_x);
+          Kokkos::deep_copy(vnorms_x_h, vnorms_x);
+          if (rst::Serial::vectorNorm(vnorms_x_h, NORM_TWO) > tol) {
             *outStream << "\n\nINCORRECT matvec OR inverse OR subtract OR vectorNorm\n\n";
             errorFlag = -1000;
           }
@@ -426,10 +439,11 @@ namespace Intrepid2 {
           
           rst::vectorNorm(vnorms_x_x, vc_x_x_d, NORM_ONE);
           rst::vectorNorm(vnorms_x, vnorms_x_x, NORM_INF);
-          if (rst::Serial::vectorNorm(vnorms_x, NORM_TWO) > tol) {
+          Kokkos::deep_copy(vnorms_x_h, vnorms_x);
+          if (rst::Serial::vectorNorm(vnorms_x_h, NORM_TWO) > tol) {
             *outStream << "\n\nSign flips combined with std::abs might not be invertible on this platform!\n"
                        << "Potential IEEE compliance issues!\n\n";
-            if (rst::Serial::vectorNorm(vnorms_x, NORM_TWO) > tol) {
+            if (rst::Serial::vectorNorm(vnorms_x_h, NORM_TWO) > tol) {
               *outStream << "\n\nINCORRECT add OR subtract OR scale OR absval OR vectorNorm\n\n";
               errorFlag = -1000;
             }
@@ -452,7 +466,8 @@ namespace Intrepid2 {
           rst::dot(vdot_x_x, va_x_x_d, va_x_x_d); // dot = a'*a
 
           rst::vectorNorm(vnorms_x, vdot_x_x, NORM_ONE);
-          if (rst::Serial::vectorNorm(vnorms_x, NORM_ONE) - (value_type)(4.0*dim*i0*i1) > tol) {
+          Kokkos::deep_copy(vnorms_x_h, vnorms_x);
+          if (rst::Serial::vectorNorm(vnorms_x_h, NORM_ONE) - (value_type)(4.0*dim*i0*i1) > tol) {
             *outStream << "\n\nINCORRECT dot OR vectorNorm\n\n";
             errorFlag = -1000;
           }
@@ -500,22 +515,28 @@ namespace Intrepid2 {
           *outStream << "\n-- Checking vectorNorm \n";
           
           rst::vectorNorm(vnorms_x, va_x_d, NORM_TWO);
-          if ( std::abs(rst::Serial::vectorNorm(vnorms_x, NORM_TWO) - 
-                        rst::Serial::vectorNorm(va_x_d, NORM_TWO)) > tol) {
+          auto vnorms_x_h = Kokkos::create_mirror_view(vnorms_x);
+          Kokkos::deep_copy(vnorms_x_h, vnorms_x);
+          auto va_x_d_h = Kokkos::create_mirror_view(va_x_d);
+          Kokkos::deep_copy(va_x_d_h, (va_x_d));
+          if ( std::abs(rst::Serial::vectorNorm(vnorms_x_h, NORM_TWO) -
+                        rst::Serial::vectorNorm(va_x_d_h, NORM_TWO)) > tol) {
             *outStream << "\n\nINCORRECT vectorNorm NORM_TWO\n\n";
             errorFlag = -1000;
           }
           
           rst::vectorNorm(vnorms_x, va_x_d, NORM_ONE);
-          if ( std::abs(rst::Serial::vectorNorm(vnorms_x, NORM_ONE) - 
-                        rst::Serial::vectorNorm(va_x_d, NORM_ONE)) > tol) {
+          Kokkos::deep_copy(vnorms_x_h, vnorms_x);
+          if ( std::abs(rst::Serial::vectorNorm(vnorms_x_h, NORM_ONE) -
+                        rst::Serial::vectorNorm(va_x_d_h, NORM_ONE)) > tol) {
             *outStream << "\n\nINCORRECT vectorNorm NORM_ONE\n\n";
             errorFlag = -1000;
           }
           
           rst::vectorNorm(vnorms_x, va_x_d, NORM_INF);
-          if ( std::abs(rst::Serial::vectorNorm(vnorms_x, NORM_INF) - 
-                        rst::Serial::vectorNorm(va_x_d, NORM_INF)) > tol) {
+          Kokkos::deep_copy(vnorms_x_h, vnorms_x);
+          if ( std::abs(rst::Serial::vectorNorm(vnorms_x_h, NORM_INF) -
+                        rst::Serial::vectorNorm(va_x_d_h, NORM_INF)) > tol) {
             *outStream << "\n\nINCORRECT vectorNorm NORM_INF\n\n";
             errorFlag = -1000;
           }
@@ -526,7 +547,9 @@ namespace Intrepid2 {
           rst::inverse(mc_x_d_d, mb_x_d_d); // C = inv(B) ~= A
           rst::subtract(mc_x_d_d, ma_x_d_d); // C = C - A ~= 0 
           
-          if (rst::Serial::vectorNorm(mc_x_d_d, NORM_ONE) > tol) {
+          auto mc_x_d_d_h = Kokkos::create_mirror_view(mc_x_d_d);
+          Kokkos::deep_copy(mc_x_d_d_h, mc_x_d_d);
+          if (rst::Serial::vectorNorm(mc_x_d_d_h, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT inverse OR subtract OR vectorNorm\n\n";
             errorFlag = -1000;
           }
@@ -550,7 +573,8 @@ namespace Intrepid2 {
           rst::transpose(mc_x_d_d, mb_x_d_d); // C = B^T = A
           rst::subtract(mc_x_d_d, ma_x_d_d); // C = C - A = 0 
           
-          if (rst::Serial::vectorNorm(mc_x_d_d, NORM_ONE) > tol) {
+          Kokkos::deep_copy(mc_x_d_d_h, mc_x_d_d);
+          if (rst::Serial::vectorNorm(mc_x_d_d_h, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT transpose OR subtract OR vectorNorm\n\n" ;
             errorFlag = -1000;
           }
@@ -564,7 +588,8 @@ namespace Intrepid2 {
           rst::subtract(vc_x_d, va_x_d); // c = c - a ~= 0
           
           rst::vectorNorm(vnorms_x, vc_x_d, NORM_ONE);
-          if (rst::Serial::vectorNorm(vnorms_x, NORM_TWO) > tol) {
+          Kokkos::deep_copy(vnorms_x_h, vnorms_x);
+          if (rst::Serial::vectorNorm(vnorms_x_h, NORM_TWO) > tol) {
             *outStream << "\n\nINCORRECT matvec OR inverse OR subtract OR vectorNorm\n\n";
             errorFlag = -1000;
           }
@@ -583,10 +608,11 @@ namespace Intrepid2 {
           rst::add(vc_x_d, vb_x_d); // c = c + b === 0
           
           rst::vectorNorm(vnorms_x, vc_x_d, NORM_ONE);
-          if (rst::Serial::vectorNorm(vnorms_x, NORM_TWO) > tol) {
+          Kokkos::deep_copy(vnorms_x_h, vnorms_x);
+          if (rst::Serial::vectorNorm(vnorms_x_h, NORM_TWO) > tol) {
             *outStream << "\n\nSign flips combined with std::abs might not be invertible on this platform!\n"
                        << "Potential IEEE compliance issues!\n\n";
-            if (rst::Serial::vectorNorm(vnorms_x, NORM_TWO) > tol) {
+            if (rst::Serial::vectorNorm(vnorms_x_h, NORM_TWO) > tol) {
               *outStream << "\n\nINCORRECT add OR subtract OR scale OR absval OR vectorNorm\n\n";
               errorFlag = -1000;
             }
@@ -603,8 +629,10 @@ namespace Intrepid2 {
                 va_x_d(i,j) = 2.0;
           }
           rst::dot(vdot_x, va_x_d, va_x_d); // dot = a'*a
-          
-          if (rst::Serial::vectorNorm(vdot_x, NORM_ONE) - (double)(4.0*dim*i0) > tol) {
+
+          auto vdot_x_h = Kokkos::create_mirror_view(vdot_x);
+          Kokkos::deep_copy(vdot_x_h, vdot_x);
+          if (rst::Serial::vectorNorm(vdot_x_h, NORM_ONE) - (double)(4.0*dim*i0) > tol) {
             *outStream << "\n\nINCORRECT dot OR vectorNorm\n\n";
             errorFlag = -1000;
           }


### PR DESCRIPTION
I'm not sure we'd want to do things this way, but opening the PR for discussion.

We need to fence the Serial vectorNorm for UVM. However the Serial vectorNorm is also used as the core of the kernel form, when we would not want to fence. We could resolve as in this PR, or fence every call of Serial vectorNorm which I don't think we'd want, or perhaps design this a different way.

Potentially this is a backwards compatibility issue if external code is using Serial vectorNorm in device kernels.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/intrepid2 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
To get Intrepid2 passing all unit tests with CUDA_LAUNCH_BLOCKING=0 in preparation for further work to analyze core fences in panzer.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
White Cuda Intrepid2 test suite.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->