### PR TITLE
Change test timeouts from DART_TESTING_TIMEOUT to CTEST_TEST_TIMEOUT

### DIFF
--- a/cmake/std/PullRequestLinuxGCC7.2.0DebugTestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxGCC7.2.0DebugTestingSettings.cmake
@@ -20,14 +20,15 @@ set (MPI_EXEC_PRE_NUMPROCS_FLAGS "--bind-to;none" CACHE STRING "Set by default f
 
 set (Trilinos_ENABLE_COMPLEX_DOUBLE ON CACHE BOOL "Set by default for PR testing to exercise complex doubles case")
 
-# Lengthen allowed testing time for debug PR build
-set (CTEST_TEST_TIMEOUT "900" CACHE STRING "Lengthen allowed testing time for debug PR build" )
-
 # Disable just one Teko sub-unit test that fails with openmpi 1.10 (#2712)
 set (Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D ON CACHE BOOL "Temporarily disabled in PR testing")
 
-# This Kokkos test times out in all cases - 
+# These tests times out in most cases - 
 set (KokkosKernels_blas_serial_MPI_1_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
+set (Tempus_HHTAlpha_MPI_1_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
+set (ROL_example_PDE-OPT_helmholtz_example_02_MPI_1_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
+set (Tempus_DIRK_ASA_MPI_1_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
+set (Tempus_ExplicitRK_ASA_MPI_1_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
 
 include("${CMAKE_CURRENT_LIST_DIR}/PullRequestLinuxCommonTestingSettings.cmake")
 

--- a/cmake/std/PullRequestLinuxGCC7.2.0DebugTestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxGCC7.2.0DebugTestingSettings.cmake
@@ -21,7 +21,7 @@ set (MPI_EXEC_PRE_NUMPROCS_FLAGS "--bind-to;none" CACHE STRING "Set by default f
 set (Trilinos_ENABLE_COMPLEX_DOUBLE ON CACHE BOOL "Set by default for PR testing to exercise complex doubles case")
 
 # Lengthen allowed testing time for debug PR build
-set (DART_TESTING_TIMEOUT 900 CACHE STRING "Lengthen allowed testing time for debug PR build" )
+set (CTEST_TEST_TIMEOUT "900" CACHE STRING "Lengthen allowed testing time for debug PR build" )
 
 # Disable just one Teko sub-unit test that fails with openmpi 1.10 (#2712)
 set (Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D ON CACHE BOOL "Temporarily disabled in PR testing")


### PR DESCRIPTION
Both of these work on a command line and the DART
variable has been shown not to work in PR testing.

@trilinos/framework 

## Motivation
About 70% of debug jobs are failing on 4 common timeouts.


## Testing
This was tested by hand, but it is unknown how the results will perform in PR testing under ctest.
