### PR TITLE
Sacado: Make DynRankView_Fad fencing consistent

### DIFF
--- a/packages/sacado/src/Kokkos_DynRankView_Fad.hpp
+++ b/packages/sacado/src/Kokkos_DynRankView_Fad.hpp
@@ -984,7 +984,9 @@ void deep_copy(
                   typename ViewTraits<DT,DP...>::non_const_value_type >::value
     , "Can only deep copy into non-const type" );
 
+  Kokkos::fence();
   Kokkos::Impl::DynRankViewFill< DynRankView<DT,DP...> >( view , value );
+  Kokkos::fence();
 }
 
 // Overload of deep_copy for Fad views intializing to a constant Fad
@@ -1004,7 +1006,9 @@ void deep_copy(
                   typename ViewTraits<DT,DP...>::non_const_value_type >::value
     , "Can only deep copy into non-const type" );
 
+  Kokkos::fence();
   Kokkos::Impl::DynRankViewFill< DynRankView<DT,DP...> >( view , value );
+  Kokkos::fence();
 }
 
 template< class DstType , class SrcType >
@@ -1056,7 +1060,9 @@ void deep_copy
     {
       typedef typename dst_type::value_type::value_type value_type ;
       const size_t nbytes = sizeof(value_type) * dst.span() ;
+      Kokkos::fence();
       Kokkos::Impl::DeepCopy< dst_memory_space , src_memory_space >( dst.data() , src.data() , nbytes );
+      Kokkos::fence();
     }
     else if ( std::is_same< typename DstType::traits::value_type ,
                        typename SrcType::traits::non_const_value_type >::value &&
@@ -1094,8 +1100,9 @@ void deep_copy
       //const size_t nbytes = sizeof(typename dst_type::scalar_array_type) * dst.span() ;
       const size_t nbytes = sizeof(typename dst_type::value_type::value_type) * dst.span() ; 
       //dst_type::value_type is outer FAD type, dst_type::value_type::value_type is inner FAD type
-
+      Kokkos::fence();
       Kokkos::Impl::DeepCopy< dst_memory_space , src_memory_space >( dst.data() , src.data() , nbytes );
+      Kokkos::fence();
     }
     else if ( std::is_same< typename DstType::traits::value_type ,
                             typename SrcType::traits::non_const_value_type >::value &&
@@ -1135,20 +1142,28 @@ void deep_copy
          ) {
 
       const size_t nbytes = sizeof(typename dst_type::value_type::value_type) * dst.span() ; 
-
+      Kokkos::fence();
       Kokkos::Impl::DeepCopy< dst_memory_space , src_memory_space >( dst.data() , src.data() , nbytes );
+      Kokkos::fence();
     }
     else if ( DstExecCanAccessSrc ) {
       // Copying data between views in accessible memory spaces and either non-contiguous or incompatible shape.
+      Kokkos::fence();
       Kokkos::Impl::DynRankViewRemap< dst_type , src_type >( dst , src );
+      Kokkos::fence();
     }
     else if ( SrcExecCanAccessDst ) {
       // Copying data between views in accessible memory spaces and either non-contiguous or incompatible shape.
+      Kokkos::fence();
       Kokkos::Impl::DynRankViewRemap< dst_type , src_type , src_execution_space >( dst , src );
+      Kokkos::fence();
     }
     else {
       Kokkos::Impl::throw_runtime_exception("deep_copy given views that would require a temporary allocation");
     }
+  }
+  else {
+    Kokkos::fence();
   }
 }
 


### PR DESCRIPTION
These changes mirror the changes in:
https://github.com/kokkos/kokkos/pull/3244

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/sacado 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Resolves a phalanx test to pass for CUDA_LAUNCH_BLOCKING=0. Keeps DynRankView_Fad consistent with DynRankView and View fence conventions.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Sacado and Phalanx unit tests on white.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->