### PR TITLE
Panzer: Fix PanzerDofMgr_tFilteredUGI_MPI_2 test for CUDA_LAUNCH_BLOCKING=0

### DIFF
--- a/packages/panzer/dof-mgr/src/Panzer_Filtered_GlobalIndexer.cpp
+++ b/packages/panzer/dof-mgr/src/Panzer_Filtered_GlobalIndexer.cpp
@@ -95,6 +95,9 @@ initialize(const Teuchos::RCP<const GlobalIndexer> & ugi,
   ownedFiltered.putScalar(0.0);
   ghostedFiltered.putScalar(0.0);
 
+  ownedFiltered.sync_host();
+  ghostedFiltered.sync_host();
+
   for(panzer::GlobalOrdinal f : filtered) {
     bool isOwned = std::find(baseOwned.begin(),baseOwned.end(),f)!=baseOwned.end();
     bool isGhosted = std::find(baseGhosted.begin(),baseGhosted.end(),f)!=baseGhosted.end();
@@ -105,6 +108,9 @@ initialize(const Teuchos::RCP<const GlobalIndexer> & ugi,
       ghostedFiltered.replaceGlobalValue(f,1.0);
     // else no one cares...
   }
+
+  ownedFiltered.modify_host();
+  ghostedFiltered.modify_host();
 
   Export exporter(ghostedMap,ownedMap);
   ownedFiltered.doExport(ghostedFiltered, exporter, Tpetra::ADD);


### PR DESCRIPTION
putScalar will by default write to device.
replaceGlobalValue will always write to host.

So we can sync_host like this after putScalar to make sure the device write
is synched for UVM to host before replaceGlobalValue.

Then since replaceGlobalValue does not call modify_host, I think we need
to call this afterwards. That won't be necessary for UVM, but later if
device is CudaSpace, then skipping that call means the export will be confused
about where the data is and try to pull it from device.

An alternative is to call modify_host before the putScalar calls.
Then the putScalar will write to host and we can skip the modify_host
calls after the replaceGlobalValue. This might be confusing as I'm not
sure calling modify_host to force putScalar to host is a normal pattern.
Also I think that is not good performance for the putScalar.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/panzer 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Fix Panzer tests to run with CUDA_LAUNCH_BLOCKING=0
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
PanzerDofMgr_tFilteredUGI_MPI_2 Cuda build on white

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->