### PR TITLE
Panzer: Add fences for BasisValues2

### DIFF
--- a/packages/panzer/disc-fe/src/Panzer_BasisValues2_impl.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_BasisValues2_impl.hpp
@@ -555,7 +555,7 @@ evaluateValues_HGrad(const PHX::MDField<Scalar,Cell,IP,Dim> & cub_points,
 
     if(compute_derivatives){
         fst::HGRADtransformGRAD(cell_grad_basis.get_view(),cell_jac_inv.get_view(),cell_grad_basis_ref.get_view());
-        typename PHX::Device().fence();\
+        typename PHX::Device().fence();
         for(int b=0;b<num_basis;++b)
           for(int p=0;p<num_points;++p)
             for(int d=0;d<num_dim;++d)
@@ -1216,7 +1216,6 @@ applyOrientations(const std::vector<Intrepid2::Orientation> & orientations,
   for (size_t i=0; i < drv_orts.size(); ++i)
     host_drv_orts(i) = orientations[i];
   Kokkos::deep_copy(drv_orts,host_drv_orts);
-  typename PHX::Device().fence(); // TODO Remove this fence once DynRankView has all been fixed - pending soon
 
   ///
   /// HGRAD elements

--- a/packages/panzer/disc-fe/src/Panzer_BasisValues2_impl.hpp
+++ b/packages/panzer/disc-fe/src/Panzer_BasisValues2_impl.hpp
@@ -372,7 +372,7 @@ evaluateValues_Const(const PHX::MDField<Scalar,Cell,IP,Dim> & cub_points,
 
     // =============================================
     // Load external into cell-local arrays
-
+    typename PHX::Device().fence();
     for(int p=0;p<num_points;++p)
       for(int d=0;d<num_dim;++d)
         for(int d2=0;d2<num_dim;++d2)
@@ -394,12 +394,15 @@ evaluateValues_Const(const PHX::MDField<Scalar,Cell,IP,Dim> & cub_points,
     // Transform reference values to physical values
 
     fst::HGRADtransformVALUE(cell_basis_scalar.get_view(),cell_basis_ref_scalar.get_view());
+
+    typename PHX::Device().fence();
     for(int b=0;b<num_basis;++b)
       for(int p=0;p<num_points;++p)
         basis_scalar(cell,b,p)=cell_basis_scalar(0,b,p);
 
     if(compute_derivatives){
         fst::HGRADtransformGRAD(cell_grad_basis.get_view(),cell_jac_inv.get_view(),cell_grad_basis_ref.get_view());
+        typename PHX::Device().fence();
         for(int b=0;b<num_basis;++b)
           for(int p=0;p<num_points;++p)
             for(int d=0;d<num_dim;++d)
@@ -456,7 +459,7 @@ evaluateValues_HVol(const PHX::MDField<Scalar,Cell,IP,Dim> & cub_points,
 
     // =============================================
     // Load external into cell-local arrays
-
+    typename PHX::Device().fence();
     for(int p=0;p<num_points;++p)
       cell_jac_det(0,p)=jac_det(cell,p);
     for(int p=0;p<num_points;++p)
@@ -472,6 +475,7 @@ evaluateValues_HVol(const PHX::MDField<Scalar,Cell,IP,Dim> & cub_points,
     // Transform reference values to physical values
 
     fst::HVOLtransformVALUE(cell_basis_scalar.get_view(),cell_jac_det.get_view(),cell_basis_ref_scalar.get_view());
+    typename PHX::Device().fence();
     for(int b=0;b<num_basis;++b)
       for(int p=0;p<num_points;++p)
         basis_scalar(cell,b,p)=cell_basis_scalar(0,b,p);
@@ -522,7 +526,7 @@ evaluateValues_HGrad(const PHX::MDField<Scalar,Cell,IP,Dim> & cub_points,
 
     // =============================================
     // Load external into cell-local arrays
-
+    typename PHX::Device().fence();
     for(int p=0;p<num_points;++p)
       for(int d=0;d<num_dim;++d)
         for(int d2=0;d2<num_dim;++d2)
@@ -544,12 +548,14 @@ evaluateValues_HGrad(const PHX::MDField<Scalar,Cell,IP,Dim> & cub_points,
     // Transform reference values to physical values
 
     fst::HGRADtransformVALUE(cell_basis_scalar.get_view(),cell_basis_ref_scalar.get_view());
+    typename PHX::Device().fence();
     for(int b=0;b<num_basis;++b)
       for(int p=0;p<num_points;++p)
         basis_scalar(cell,b,p)=cell_basis_scalar(0,b,p);
 
     if(compute_derivatives){
         fst::HGRADtransformGRAD(cell_grad_basis.get_view(),cell_jac_inv.get_view(),cell_grad_basis_ref.get_view());
+        typename PHX::Device().fence();\
         for(int b=0;b<num_basis;++b)
           for(int p=0;p<num_points;++p)
             for(int d=0;d<num_dim;++d)
@@ -614,7 +620,7 @@ evaluateValues_HCurl(const PHX::MDField<Scalar,Cell,IP,Dim> & cub_points,
 
     // =============================================
     // Load external into cell-local arrays
-
+    typename PHX::Device().fence();
     for(int p=0;p<num_points;++p)
       for(int d=0;d<num_dim;++d)
         for(int d2=0;d2<num_dim;++d2)
@@ -646,6 +652,7 @@ evaluateValues_HCurl(const PHX::MDField<Scalar,Cell,IP,Dim> & cub_points,
     // Transform reference values to physical values
 
     fst::HCURLtransformVALUE(cell_basis_vector.get_view(),cell_jac_inv.get_view(),cell_basis_ref_vector.get_view());
+    typename PHX::Device().fence();
     for(int b=0;b<num_basis;++b)
       for(int p=0;p<num_points;++p)
         for(int d=0;d<num_dim;++d)
@@ -657,11 +664,13 @@ evaluateValues_HCurl(const PHX::MDField<Scalar,Cell,IP,Dim> & cub_points,
         // this relates directly to this being in
         // the divergence space in 2D!
         fst::HDIVtransformDIV(cell_curl_basis_scalar.get_view(),cell_jac_det.get_view(),cell_curl_basis_ref_scalar.get_view());
+        typename PHX::Device().fence();
         for(int b=0;b<num_basis;++b)
           for(int p=0;p<num_points;++p)
             curl_basis_scalar(cell,b,p)=cell_curl_basis_scalar(0,b,p);
       } else if(num_dim==3) {
         fst::HCURLtransformCURL(cell_curl_basis_vector.get_view(),cell_jac.get_view(),cell_jac_det.get_view(),cell_curl_basis_ref.get_view());
+        typename PHX::Device().fence();
         for(int b=0;b<num_basis;++b)
           for(int p=0;p<num_points;++p)
             for(int d=0;d<num_dim;++d)
@@ -728,7 +737,7 @@ evaluateValues_HDiv(const PHX::MDField<Scalar,Cell,IP,Dim> & cub_points,
 
     // =============================================
     // Load external into cell-local arrays
-
+    typename PHX::Device().fence();
     for(int p=0;p<num_points;++p)
       for(int d=0;d<num_dim;++d)
         for(int d2=0;d2<num_dim;++d2)
@@ -751,6 +760,7 @@ evaluateValues_HDiv(const PHX::MDField<Scalar,Cell,IP,Dim> & cub_points,
     // Transform reference values to physical values
 
     fst::HDIVtransformVALUE(cell_basis_vector.get_view(),cell_jac.get_view(),cell_jac_det.get_view(),cell_basis_ref_vector.get_view());
+    typename PHX::Device().fence();
     for(int b=0;b<num_basis;++b)
       for(int p=0;p<num_points;++p)
         for(int d=0;d<num_dim;++d)
@@ -758,6 +768,7 @@ evaluateValues_HDiv(const PHX::MDField<Scalar,Cell,IP,Dim> & cub_points,
 
     if(compute_derivatives){
       fst::HDIVtransformDIV(cell_div_basis.get_view(),cell_jac_det.get_view(),cell_div_basis_ref.get_view());
+      typename PHX::Device().fence();
       for(int b=0;b<num_basis;++b)
         for(int p=0;p<num_points;++p)
           div_basis(cell,b,p)=cell_div_basis(0,b,p);
@@ -818,6 +829,7 @@ evaluateValuesCV(const PHX::MDField<Scalar,Cell,IP,Dim> & cell_cub_points,
   // so we evaluate the basis in a loop over cells.
   for (size_type icell = 0; icell < num_cells; ++icell)
   {
+    typename PHX::Device().fence();
     for (int ip = 0; ip < num_ip; ++ip)
       for (int d = 0; d < num_dim; ++d)
          dyn_cub_points(ip,d) = cell_cub_points(icell,ip,d);
@@ -830,6 +842,7 @@ evaluateValuesCV(const PHX::MDField<Scalar,Cell,IP,Dim> & cell_cub_points,
                                  Intrepid2::OPERATOR_VALUE);
 
        // transform values method just transfers values to array with cell index - no need to call
+       typename PHX::Device().fence();
        for (int b = 0; b < num_card; ++b)
          for (int ip = 0; ip < num_ip; ++ip)
            basis_scalar(icell,b,ip) = dyn_basis_ref_scalar(b,ip);
@@ -848,6 +861,7 @@ evaluateValuesCV(const PHX::MDField<Scalar,Cell,IP,Dim> & cell_cub_points,
       ArrayDynamic dyn_jac_det = af.buildArray<Scalar,Cell,IP>("dyn_jac_det",one_cell,num_ip);
 
       int cellInd = 0;
+      typename PHX::Device().fence();
       for (int ip = 0; ip < num_ip; ++ip)
         dyn_jac_det(cellInd,ip) = jac_det(icell,ip);
 
@@ -855,6 +869,7 @@ evaluateValuesCV(const PHX::MDField<Scalar,Cell,IP,Dim> & cell_cub_points,
                                                                                       dyn_jac_det.get_view(),
                                                                                       dyn_basis_ref_scalar.get_view());
 
+       typename PHX::Device().fence();
        for (int b = 0; b < num_card; ++b)
          for (int ip = 0; ip < num_ip; ++ip)
            basis_scalar(icell,b,ip) = dyn_basis_scalar(0,b,ip);
@@ -868,6 +883,7 @@ evaluateValuesCV(const PHX::MDField<Scalar,Cell,IP,Dim> & cell_cub_points,
                                  Intrepid2::OPERATOR_VALUE);
 
        // transform values method just transfers values to array with cell index - no need to call
+       typename PHX::Device().fence();
        for (int b = 0; b < num_card; ++b)
          for (int ip = 0; ip < num_ip; ++ip)
            basis_scalar(icell,b,ip) = dyn_basis_ref_scalar(b,ip);
@@ -883,6 +899,7 @@ evaluateValuesCV(const PHX::MDField<Scalar,Cell,IP,Dim> & cell_cub_points,
                                     dyn_cub_points.get_view(),
                                     Intrepid2::OPERATOR_GRAD);
 
+          typename PHX::Device().fence();
           int cellInd = 0;
           for (int ip = 0; ip < num_ip; ++ip)
              for (int d1 = 0; d1 < num_dim; ++d1)
@@ -893,6 +910,7 @@ evaluateValuesCV(const PHX::MDField<Scalar,Cell,IP,Dim> & cell_cub_points,
                                                                                                   dyn_jac_inv.get_view(),
                                                                                                   dyn_grad_basis_ref.get_view());
 
+          typename PHX::Device().fence();
           for (int b = 0; b < num_card; ++b)
             for (int ip = 0; ip < num_ip; ++ip)
               for (int d = 0; d < num_dim; ++d)
@@ -911,6 +929,7 @@ evaluateValuesCV(const PHX::MDField<Scalar,Cell,IP,Dim> & cell_cub_points,
       ArrayDynamic dyn_basis_vector = af.buildArray<Scalar,Cell,BASIS,IP,Dim>("dyn_basis_vector",one_cell,num_card,num_ip,num_dim);
       ArrayDynamic dyn_jac_inv = af.buildArray<Scalar,Cell,IP,Dim,Dim>("dyn_jac_inv",one_cell,num_ip,num_dim,num_dim);
 
+      typename PHX::Device().fence();
       const int cellInd = 0;
       for (int ip = 0; ip < num_ip; ++ip)
         for (int d1 = 0; d1 < num_dim; ++d1)
@@ -921,6 +940,7 @@ evaluateValuesCV(const PHX::MDField<Scalar,Cell,IP,Dim> & cell_cub_points,
                                                                                        dyn_jac_inv.get_view(),
                                                                                        dyn_basis_ref_vector.get_view());
 
+      typename PHX::Device().fence();
       for (int b = 0; b < num_card; ++b)
         for (int ip = 0; ip < num_ip; ++ip)
           for (int d = 0; d < num_dim; ++d)
@@ -936,6 +956,7 @@ evaluateValuesCV(const PHX::MDField<Scalar,Cell,IP,Dim> & cell_cub_points,
                                     dyn_cub_points.get_view(),
                                     Intrepid2::OPERATOR_CURL);
 
+          typename PHX::Device().fence();
           for (int ip = 0; ip < num_ip; ++ip)
               dyn_jac_det(cellInd,ip) = jac_det(icell,ip);
 
@@ -943,6 +964,7 @@ evaluateValuesCV(const PHX::MDField<Scalar,Cell,IP,Dim> & cell_cub_points,
                                                                                         dyn_jac_det.get_view(),
                                                                                         dyn_curl_basis_ref_scalar.get_view());
 
+          typename PHX::Device().fence();
           for (int b = 0; b < num_card; ++b)
             for (int ip = 0; ip < num_ip; ++ip)
                 curl_basis_scalar(icell,b,ip) = dyn_curl_basis_scalar(0,b,ip);
@@ -959,6 +981,7 @@ evaluateValuesCV(const PHX::MDField<Scalar,Cell,IP,Dim> & cell_cub_points,
                                     dyn_cub_points.get_view(),
                                     Intrepid2::OPERATOR_CURL);
 
+          typename PHX::Device().fence();
           for (int ip = 0; ip < num_ip; ++ip)
           {
              dyn_jac_det(cellInd,ip) = jac_det(icell,ip);
@@ -972,6 +995,7 @@ evaluateValuesCV(const PHX::MDField<Scalar,Cell,IP,Dim> & cell_cub_points,
                                                                                           dyn_jac_det.get_view(),
                                                                                           dyn_curl_basis_ref.get_view());
 
+          typename PHX::Device().fence();
           for (int b = 0; b < num_card; ++b)
             for (int ip = 0; ip < num_ip; ++ip)
                for (int d = 0; d < num_dim; ++d)
@@ -994,6 +1018,8 @@ evaluateValuesCV(const PHX::MDField<Scalar,Cell,IP,Dim> & cell_cub_points,
       ArrayDynamic dyn_jac_det = af.buildArray<Scalar,Cell,IP>("dyn_jac_det",one_cell,num_ip);
 
       int cellInd = 0;
+
+      typename PHX::Device().fence();
       for (int ip = 0; ip < num_ip; ++ip)
       {
         dyn_jac_det(cellInd,ip) = jac_det(icell,ip);
@@ -1006,7 +1032,7 @@ evaluateValuesCV(const PHX::MDField<Scalar,Cell,IP,Dim> & cell_cub_points,
                                                                                       dyn_jac.get_view(),
                                                                                       dyn_jac_det.get_view(),
                                                                                       dyn_basis_ref_vector.get_view());
-
+       typename PHX::Device().fence();
        for (int b = 0; b < num_card; ++b)
          for (int ip = 0; ip < num_ip; ++ip)
            for (int d = 0; d < num_dim; ++d)
@@ -1024,7 +1050,7 @@ evaluateValuesCV(const PHX::MDField<Scalar,Cell,IP,Dim> & cell_cub_points,
            Intrepid2::FunctionSpaceTools<PHX::Device::execution_space>::HDIVtransformDIV<Scalar>(dyn_div_basis.get_view(),
                                                                                                  dyn_jac_det.get_view(),
                                                                                                  dyn_div_basis_ref.get_view());
-
+           typename PHX::Device().fence();
            for (int b = 0; b < num_card; ++b)
              for (int ip = 0; ip < num_ip; ++ip)
                  div_basis(icell,b,ip) = dyn_div_basis(0,b,ip);
@@ -1054,7 +1080,7 @@ evaluateReferenceValues(const PHX::MDField<Scalar,IP,Dim> & cub_points,bool in_c
   int num_card  = basis_layout->cardinality();
 
   ArrayDynamic dyn_cub_points = af.buildArray<Scalar,IP,Dim>("dyn_cub_points",  num_quad,num_dim);
-
+  typename PHX::Device().fence();
   for (int ip = 0; ip < num_quad; ++ip)
     for (int d = 0; d < num_dim; ++d)
       dyn_cub_points(ip,d) = cub_points(ip,d);
@@ -1067,6 +1093,7 @@ evaluateReferenceValues(const PHX::MDField<Scalar,IP,Dim> & cub_points,bool in_c
                               dyn_cub_points.get_view(),
                               Intrepid2::OPERATOR_VALUE);
 
+    typename PHX::Device().fence();
     for (int b = 0; b < num_card; ++b)
       for (int ip = 0; ip < num_quad; ++ip)
         basis_ref_scalar(b,ip) = dyn_basis_ref_scalar(b,ip);
@@ -1078,6 +1105,7 @@ evaluateReferenceValues(const PHX::MDField<Scalar,IP,Dim> & cub_points,bool in_c
                               dyn_cub_points.get_view(),
                               Intrepid2::OPERATOR_VALUE);
 
+    typename PHX::Device().fence();
     for (int b = 0; b < num_card; ++b)
       for (int ip = 0; ip < num_quad; ++ip)
         for (int d = 0; d < num_dim; ++d)
@@ -1092,6 +1120,7 @@ evaluateReferenceValues(const PHX::MDField<Scalar,IP,Dim> & cub_points,bool in_c
                               dyn_cub_points.get_view(),
                               Intrepid2::OPERATOR_GRAD);
 
+    typename PHX::Device().fence();
     for (int b = 0; b < num_card; ++b)
       for (int ip = 0; ip < num_quad; ++ip)
         for (int d = 0; d < num_dim; ++d)
@@ -1104,6 +1133,7 @@ evaluateReferenceValues(const PHX::MDField<Scalar,IP,Dim> & cub_points,bool in_c
                               dyn_cub_points.get_view(),
                               Intrepid2::OPERATOR_CURL);
 
+    typename PHX::Device().fence();
     for (int b = 0; b < num_card; ++b)
       for (int ip = 0; ip < num_quad; ++ip)
         curl_basis_ref_scalar(b,ip) = dyn_curl_basis_ref(b,ip);
@@ -1115,6 +1145,7 @@ evaluateReferenceValues(const PHX::MDField<Scalar,IP,Dim> & cub_points,bool in_c
                               dyn_cub_points.get_view(),
                               Intrepid2::OPERATOR_CURL);
 
+    typename PHX::Device().fence();
     for (int b = 0; b < num_card; ++b)
       for (int ip = 0; ip < num_quad; ++ip)
         for (int d = 0; d < num_dim; ++d)
@@ -1127,6 +1158,7 @@ evaluateReferenceValues(const PHX::MDField<Scalar,IP,Dim> & cub_points,bool in_c
                               dyn_cub_points.get_view(),
                               Intrepid2::OPERATOR_DIV);
 
+    typename PHX::Device().fence();
     for (int b = 0; b < num_card; ++b)
       for (int ip = 0; ip < num_quad; ++ip)
         div_basis_ref(b,ip) = dyn_div_basis_ref(b,ip);
@@ -1145,6 +1177,7 @@ evaluateReferenceValues(const PHX::MDField<Scalar,IP,Dim> & cub_points,bool in_c
       intrepid_basis->getDofCoords(dyn_basis_coordinates_ref.get_view());
 
       // fill in basis coordinates
+      typename PHX::Device().fence();
       for (int i = 0; i < basis_coordinates_ref.extent_int(0); ++i)
         for (int j = 0; j < basis_coordinates_ref.extent_int(1); ++j)
           basis_coordinates_ref(i,j) = dyn_basis_coordinates_ref(i,j);
@@ -1183,7 +1216,7 @@ applyOrientations(const std::vector<Intrepid2::Orientation> & orientations,
   for (size_t i=0; i < drv_orts.size(); ++i)
     host_drv_orts(i) = orientations[i];
   Kokkos::deep_copy(drv_orts,host_drv_orts);
-  typename PHX::Device().fence();
+  typename PHX::Device().fence(); // TODO Remove this fence once DynRankView has all been fixed - pending soon
 
   ///
   /// HGRAD elements
@@ -1466,7 +1499,7 @@ applyOrientations(const PHX::MDField<const Scalar,Cell,BASIS> & orientations)
 
     // setup the orientations for the trial space
     // Intrepid2::FunctionSpaceTools::applyFieldSigns<Scalar>(basis_vector,orientations);
-
+    typename PHX::Device().fence();
     for (int c=0; c<num_cell; c++)
       for (int b=0; b<num_basis; b++)
         for (int p=0; p<num_ip; p++)
@@ -1493,7 +1526,7 @@ applyOrientations(const PHX::MDField<const Scalar,Cell,BASIS> & orientations)
 
     // setup the orientations for the trial space
     // Intrepid2::FunctionSpaceTools::applyFieldSigns<Scalar>(basis_vector,orientations);
-
+    typename PHX::Device().fence();
     for (int c=0; c<num_cell; c++)
       for (int b=0; b<num_basis; b++)
         for (int p=0; p<num_ip; p++)
@@ -1520,7 +1553,7 @@ applyOrientations(const PHX::MDField<const Scalar,Cell,BASIS> & orientations)
   else if(elmtspace==PureBasis::HDIV) {
     // setup the orientations for the trial space
     // Intrepid2::FunctionSpaceTools::applyFieldSigns<Scalar>(basis_vector,orientations);
-
+    typename PHX::Device().fence();
     for (int c=0; c<num_cell; c++)
       for (int b=0; b<num_basis; b++)
         for (int p=0; p<num_ip; p++)


### PR DESCRIPTION
@rppawlo If we accept this PR, then I can proceed to get Panzer passing tests with CUDA_LAUNCH_BLOCKING=0. I'lll follow up with a PR which tags all fences in Panzer just for discussion purposes. Then we can return and fix these loops after discussion.

If we want to fix these loops now I'll need to discuss. This is clearly not a final solution. I expect we may do a single parallel_for kernel over the full range of all loops. Ifpack2 has some scatter methods with similar issues.



<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/panzer 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Get Panzer passing for CUDA_LAUNCH_BLOCKING=0 prior to analyzing and resolving fences in panzer which will be a second phase of the project.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->



## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Cuda white panzer DiscFE tests.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->