### PR TITLE
Piro: some enhancement for explicit time-steppers

### DIFF
--- a/packages/piro/src/Piro_Epetra_RythmosSolver.cpp
+++ b/packages/piro/src/Piro_Epetra_RythmosSolver.cpp
@@ -157,10 +157,10 @@ Piro::Epetra::RythmosSolver::RythmosSolver(
 
     if (stepperType == "Explicit RK") {
       Teuchos::RCP<EpetraExt::ModelEvaluator> origModel = model;
-      rythmosPL->get("Lump Mass Matrix", false); //JF line does not do anything
       model = Teuchos::rcp(new Piro::Epetra::InvertMassMatrixDecorator(
             sublist(rythmosPL,"Stratimikos", true), origModel,
-            true,rythmosPL->get("Lump Mass Matrix", false),false));
+            rythmosPL->get("Constant Mass Matrix",false), 
+	    rythmosPL->get("Lump Mass Matrix",false), false));
     }
 
     // C.2) Create the Thyra-wrapped ModelEvaluator
@@ -258,7 +258,8 @@ Piro::Epetra::RythmosSolver::RythmosSolver(
       rythmosSolverPL->get("Lump Mass Matrix", false); //JF line does not do anything
       model = Teuchos::rcp(new Piro::Epetra::InvertMassMatrixDecorator(
             sublist(rythmosSolverPL,"Stratimikos", true), origModel,
-            true,rythmosSolverPL->get("Lump Mass Matrix", false),false));
+            rythmosSolverPL->get("Constant Mass Matrix",false),
+	    rythmosSolverPL->get("Lump Mass Matrix",false), false));
     }
 
     // C.2) Create the Thyra-wrapped ModelEvaluator
@@ -557,6 +558,7 @@ Piro::Epetra::RythmosSolver::getValidRythmosParameters() const
   validPL->set<double>("Max State Error", 1.0, "");
   validPL->set<std::string>("Name", "", "");
   validPL->set<bool>("Lump Mass Matrix", false, "Boolean to tell code to lump mass matrix");
+  validPL->set<bool>("Constant Mass Matrix", false, "Boolean to tell code if mass matrix is constant in time");
   validPL->set<std::string>("Stepper Method", "", "");
   return validPL;
 }
@@ -571,5 +573,6 @@ Piro::Epetra::RythmosSolver::getValidRythmosSolverParameters() const
   validPL->sublist("NonLinear Solver", false, "");
   validPL->set<std::string>("Verbosity Level", "", "");
   validPL->set<bool>("Lump Mass Matrix", false, "Boolean to tell code to lump mass matrix");
+  validPL->set<bool>("Constant Mass Matrix", false, "Boolean to tell code if mass matrix is constant in time");
   return validPL;
 }

--- a/packages/piro/src/Piro_Epetra_RythmosSolver.cpp
+++ b/packages/piro/src/Piro_Epetra_RythmosSolver.cpp
@@ -156,13 +156,11 @@ Piro::Epetra::RythmosSolver::RythmosSolver(
     // already constructed as "model". Decorate if needed.
 
     if (stepperType == "Explicit RK") {
-      if (rythmosPL->get("Invert Mass Matrix", false)) {
-        Teuchos::RCP<EpetraExt::ModelEvaluator> origModel = model;
-        rythmosPL->get("Lump Mass Matrix", false); //JF line does not do anything
-        model = Teuchos::rcp(new Piro::Epetra::InvertMassMatrixDecorator(
-              sublist(rythmosPL,"Stratimikos", true), origModel,
-              true,rythmosPL->get("Lump Mass Matrix", false),false));
-      }
+      Teuchos::RCP<EpetraExt::ModelEvaluator> origModel = model;
+      rythmosPL->get("Lump Mass Matrix", false); //JF line does not do anything
+      model = Teuchos::rcp(new Piro::Epetra::InvertMassMatrixDecorator(
+            sublist(rythmosPL,"Stratimikos", true), origModel,
+            true,rythmosPL->get("Lump Mass Matrix", false),false));
     }
 
     // C.2) Create the Thyra-wrapped ModelEvaluator
@@ -256,13 +254,11 @@ Piro::Epetra::RythmosSolver::RythmosSolver(
 
     // TODO: Generelize to any explicit method, option to invert mass matrix
     if (stepperType == "Explicit RK") {
-      if (rythmosSolverPL->get("Invert Mass Matrix", false)) {
-        Teuchos::RCP<EpetraExt::ModelEvaluator> origModel = model;
-        rythmosSolverPL->get("Lump Mass Matrix", false); //JF line does not do anything
-        model = Teuchos::rcp(new Piro::Epetra::InvertMassMatrixDecorator(
-              sublist(rythmosSolverPL,"Stratimikos", true), origModel,
-              true,rythmosSolverPL->get("Lump Mass Matrix", false),false));
-      }
+      Teuchos::RCP<EpetraExt::ModelEvaluator> origModel = model;
+      rythmosSolverPL->get("Lump Mass Matrix", false); //JF line does not do anything
+      model = Teuchos::rcp(new Piro::Epetra::InvertMassMatrixDecorator(
+            sublist(rythmosSolverPL,"Stratimikos", true), origModel,
+            true,rythmosSolverPL->get("Lump Mass Matrix", false),false));
     }
 
     // C.2) Create the Thyra-wrapped ModelEvaluator
@@ -560,8 +556,7 @@ Piro::Epetra::RythmosSolver::getValidRythmosParameters() const
   validPL->set<double>("Beta", 1.0, "");
   validPL->set<double>("Max State Error", 1.0, "");
   validPL->set<std::string>("Name", "", "");
-  validPL->set<bool>("Invert Mass Matrix", false, "");
-  validPL->set<bool>("Lump Mass Matrix", false, "");
+  validPL->set<bool>("Lump Mass Matrix", false, "Boolean to tell code to lump mass matrix");
   validPL->set<std::string>("Stepper Method", "", "");
   return validPL;
 }
@@ -575,7 +570,6 @@ Piro::Epetra::RythmosSolver::getValidRythmosSolverParameters() const
   validPL->sublist("Stratimikos", false, "");
   validPL->sublist("NonLinear Solver", false, "");
   validPL->set<std::string>("Verbosity Level", "", "");
-  validPL->set<bool>("Invert Mass Matrix", false, "");
-  validPL->set<bool>("Lump Mass Matrix", false, "");
+  validPL->set<bool>("Lump Mass Matrix", false, "Boolean to tell code to lump mass matrix");
   return validPL;
 }

--- a/packages/piro/src/Piro_Epetra_VelocityVerletSolver.cpp
+++ b/packages/piro/src/Piro_Epetra_VelocityVerletSolver.cpp
@@ -91,10 +91,11 @@ Piro::Epetra::VelocityVerletSolver::VelocityVerletSolver(Teuchos::RCP<Teuchos::P
   delta_t = t_final / numTimeSteps;
   
   Teuchos::RCP<EpetraExt::ModelEvaluator> origModel = model;
-  bool lump=vvPL->get("Lump Mass Matrix", false);
+  bool lump = vvPL->get("Lump Mass Matrix", false);
+  bool isConstMass = vvPL->get("Constant Mass Matrix", false); 
   *out << "\nB) Using InvertMassMatrix Decorator\n";
   model = Teuchos::rcp(new Piro::Epetra::InvertMassMatrixDecorator(
-           sublist(vvPL,"Stratimikos", true), origModel, true, lump, true));
+           sublist(vvPL,"Stratimikos", true), origModel, isConstMass, lump, true));
 }
 
 Piro::Epetra::VelocityVerletSolver::~VelocityVerletSolver()
@@ -266,6 +267,7 @@ Piro::Epetra::VelocityVerletSolver::getValidVelocityVerletParameters() const
   validPL->set<double>("Initial Time", 0.0, "");
   validPL->set<std::string>("Verbosity Level", "", "");
   validPL->set<bool>("Lump Mass Matrix", false, "Boolean to tell code to lump mass matrix");
+  validPL->set<bool>("Constant Mass Matrix", false, "Boolean to tell code to code if mass matrix is constant in time");
   validPL->sublist("Stratimikos", false, "");
   return validPL;
 }

--- a/packages/piro/src/Piro_Epetra_VelocityVerletSolver.cpp
+++ b/packages/piro/src/Piro_Epetra_VelocityVerletSolver.cpp
@@ -90,13 +90,11 @@ Piro::Epetra::VelocityVerletSolver::VelocityVerletSolver(Teuchos::RCP<Teuchos::P
   t_init  = vvPL->get("Initial Time", 0.0);
   delta_t = t_final / numTimeSteps;
   
-  if (vvPL->get("Invert Mass Matrix", false)) {
-    Teuchos::RCP<EpetraExt::ModelEvaluator> origModel = model;
-    bool lump=vvPL->get("Lump Mass Matrix", false);
-    *out << "\nB) Using InvertMassMatrix Decorator\n";
-    model = Teuchos::rcp(new Piro::Epetra::InvertMassMatrixDecorator(
-             sublist(vvPL,"Stratimikos", true), origModel, true, lump, true));
-  }
+  Teuchos::RCP<EpetraExt::ModelEvaluator> origModel = model;
+  bool lump=vvPL->get("Lump Mass Matrix", false);
+  *out << "\nB) Using InvertMassMatrix Decorator\n";
+  model = Teuchos::rcp(new Piro::Epetra::InvertMassMatrixDecorator(
+           sublist(vvPL,"Stratimikos", true), origModel, true, lump, true));
 }
 
 Piro::Epetra::VelocityVerletSolver::~VelocityVerletSolver()
@@ -267,8 +265,7 @@ Piro::Epetra::VelocityVerletSolver::getValidVelocityVerletParameters() const
   validPL->set<double>("Final Time", 1.0, "");
   validPL->set<double>("Initial Time", 0.0, "");
   validPL->set<std::string>("Verbosity Level", "", "");
-  validPL->set<bool>("Invert Mass Matrix", false, "");
-  validPL->set<bool>("Lump Mass Matrix", false, "");
+  validPL->set<bool>("Lump Mass Matrix", false, "Boolean to tell code to lump mass matrix");
   validPL->sublist("Stratimikos", false, "");
   return validPL;
 }

--- a/packages/piro/src/Piro_RythmosSolver_Def.hpp
+++ b/packages/piro/src/Piro_RythmosSolver_Def.hpp
@@ -368,10 +368,9 @@ void Piro::RythmosSolver<Scalar>::initialize(
       stepperType == "Explicit Taylor Polynomial") {
 
       Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > origModel = model;
-      rythmosSolverPL->get("Lump Mass Matrix", false);  //JF line does not do anything
       model = Teuchos::rcp(new Piro::InvertMassMatrixDecorator<Scalar>(
               sublist(rythmosSolverPL,"Stratimikos", true), origModel,
-              true,rythmosSolverPL->get("Lump Mass Matrix", false),false));
+              rythmosSolverPL->get("Constant Mass Matrix", false),rythmosSolverPL->get("Lump Mass Matrix", false),false));
      }
      // C.2) Create the Thyra-wrapped ModelEvaluator
 
@@ -996,7 +995,8 @@ Piro::RythmosSolver<Scalar>::getValidRythmosSolverParameters() const
   validPL->sublist("Stratimikos", false, "");
   validPL->sublist("NonLinear Solver", false, "");
   validPL->set<std::string>("Verbosity Level", "", "");
-  validPL->set<bool>("Lump Mass Matrix", false, "");
+  validPL->set<bool>("Lump Mass Matrix", false, "Boolean to tell code to lump mass matrix");
+  validPL->set<bool>("Constant Mass Matrix", false, "Boolean to tell code if mass matrix is constant in time");
   return validPL;
 }
 

--- a/packages/piro/src/Piro_RythmosSolver_Def.hpp
+++ b/packages/piro/src/Piro_RythmosSolver_Def.hpp
@@ -367,19 +367,11 @@ void Piro::RythmosSolver<Scalar>::initialize(
       stepperType == "Forward Euler" ||
       stepperType == "Explicit Taylor Polynomial") {
 
-      bool invertMassMatrix = rythmosSolverPL->get("Invert Mass Matrix", false);
-      if (!invertMassMatrix) {
-        *out << "\n WARNING in Piro::RythmosSolver!  You are attempting to run \n"
-             << " Explicit Stepper (" << stepperType << ") with 'Invert Mass Matrix' set to 'false'. \n"
-             << "This option should be set to 'true' unless your mass matrix is the identiy.\n";
-      }
-      else {
-        Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > origModel = model;
-        rythmosSolverPL->get("Lump Mass Matrix", false);  //JF line does not do anything
-        model = Teuchos::rcp(new Piro::InvertMassMatrixDecorator<Scalar>(
+      Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > origModel = model;
+      rythmosSolverPL->get("Lump Mass Matrix", false);  //JF line does not do anything
+      model = Teuchos::rcp(new Piro::InvertMassMatrixDecorator<Scalar>(
               sublist(rythmosSolverPL,"Stratimikos", true), origModel,
               true,rythmosSolverPL->get("Lump Mass Matrix", false),false));
-      }
      }
      // C.2) Create the Thyra-wrapped ModelEvaluator
 
@@ -990,7 +982,6 @@ Piro::RythmosSolver<Scalar>::getValidRythmosParameters() const
   validPL->set<double>("Beta", 1.0, "");
   validPL->set<double>("Max State Error", 1.0, "");
   validPL->set<std::string>("Name", "", "");
-  validPL->set<bool>("Invert Mass Matrix", false, "");
 
   return validPL;
 }
@@ -1005,7 +996,6 @@ Piro::RythmosSolver<Scalar>::getValidRythmosSolverParameters() const
   validPL->sublist("Stratimikos", false, "");
   validPL->sublist("NonLinear Solver", false, "");
   validPL->set<std::string>("Verbosity Level", "", "");
-  validPL->set<bool>("Invert Mass Matrix", false, "");
   validPL->set<bool>("Lump Mass Matrix", false, "");
   return validPL;
 }

--- a/packages/piro/src/Piro_TempusSolver_Def.hpp
+++ b/packages/piro/src/Piro_TempusSolver_Def.hpp
@@ -254,7 +254,7 @@ void Piro::TempusSolver<Scalar>::initialize(
 
       Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > origModel = model_;
       model_ = Teuchos::rcp(new Piro::InvertMassMatrixDecorator<Scalar>(
-      sublist(tempusPL,"Stratimikos", true), origModel, false, tempusPL->get("Lump Mass Matrix", false),false));
+      sublist(tempusPL,"Stratimikos", true), origModel, tempusPL->get("Constant Mass Matrix", false), tempusPL->get("Lump Mass Matrix", false),false));
     }
 
     //Explicit time-integrators for 2nd order ODEs
@@ -262,7 +262,7 @@ void Piro::TempusSolver<Scalar>::initialize(
     else if (stepperType == "Newmark Explicit a-Form") {
       Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > origModel = model_;
       model_ = Teuchos::rcp(new Piro::InvertMassMatrixDecorator<Scalar>(
-        sublist(tempusPL,"Stratimikos", true), origModel, true, tempusPL->get("Lump Mass Matrix", false),true));
+        sublist(tempusPL,"Stratimikos", true), origModel, tempusPL->get("Constant Mass Matrix", false), tempusPL->get("Lump Mass Matrix", false),true));
     }
     // C.2) Create the Thyra-wrapped ModelEvaluator
 
@@ -518,8 +518,8 @@ Piro::TempusSolver<Scalar>::getValidTempusParameters() const
   validPL->sublist("Stratimikos", false, "");
   validPL->sublist("NonLinear Solver", false, "");
   //validPL->set<std::string>("Verbosity Level", "", "");
-  validPL->set<bool>("Invert Mass Matrix", false, "");
-  validPL->set<bool>("Lump Mass Matrix", false, "");
+  validPL->set<bool>("Lump Mass Matrix", false, "Boolean to tell code whether to lump mass matrix");
+  validPL->set<bool>("Constant Mass Matrix", false, "Boolean to tell code if mass matrix is constant in time");
   validPL->set<bool>("Abort on Failure", true, "");
   validPL->set<std::string>("Integrator Name", "Tempus Integrator", "");
   validPL->sublist("Tempus Integrator", false, "");

--- a/packages/piro/src/Piro_TempusSolver_Def.hpp
+++ b/packages/piro/src/Piro_TempusSolver_Def.hpp
@@ -254,7 +254,7 @@ void Piro::TempusSolver<Scalar>::initialize(
 
       Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > origModel = model_;
       model_ = Teuchos::rcp(new Piro::InvertMassMatrixDecorator<Scalar>(
-      sublist(tempusPL,"Stratimikos", true), origModel, true, tempusPL->get("Lump Mass Matrix", false),false));
+      sublist(tempusPL,"Stratimikos", true), origModel, false, tempusPL->get("Lump Mass Matrix", false),false));
     }
 
     //Explicit time-integrators for 2nd order ODEs

--- a/packages/piro/src/Piro_TrapezoidRuleSolver_Def.hpp
+++ b/packages/piro/src/Piro_TrapezoidRuleSolver_Def.hpp
@@ -399,8 +399,7 @@ Piro::TrapezoidRuleSolver<Scalar>::getValidTrapezoidRuleParameters() const
   validPL->set<double>("Final Time", 1.0, "");
   validPL->set<double>("Initial Time", 0.0, "");
   validPL->set<std::string>("Verbosity Level", "", "");
-  validPL->set<bool>("Invert Mass Matrix", false, "");
-  validPL->set<bool>("Lump Mass Matrix", false, "");
+  validPL->set<bool>("Lump Mass Matrix", false, "Boolean to tell code to lump mass matrix");
   validPL->sublist("Stratimikos", false, "");
   validPL->sublist("NOX", false, "");
   return validPL;

--- a/packages/piro/src/Piro_TrapezoidRuleSolver_Def.hpp
+++ b/packages/piro/src/Piro_TrapezoidRuleSolver_Def.hpp
@@ -400,6 +400,7 @@ Piro::TrapezoidRuleSolver<Scalar>::getValidTrapezoidRuleParameters() const
   validPL->set<double>("Initial Time", 0.0, "");
   validPL->set<std::string>("Verbosity Level", "", "");
   validPL->set<bool>("Lump Mass Matrix", false, "Boolean to tell code to lump mass matrix");
+  validPL->set<bool>("Constant Mass Matrix", false, "Boolean to tell code to if mass matrix is constant in time");
   validPL->sublist("Stratimikos", false, "");
   validPL->sublist("NOX", false, "");
   return validPL;

--- a/packages/piro/src/Piro_VelocityVerletSolver_Def.hpp
+++ b/packages/piro/src/Piro_VelocityVerletSolver_Def.hpp
@@ -93,11 +93,12 @@ VelocityVerletSolver(const Teuchos::RCP<Teuchos::ParameterList> &appParams_,
   delta_t = t_final / numTimeSteps;
 
   Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > origModel = model;
-  bool lump=vvPL->get("Lump Mass Matrix", false);
+  bool lump = vvPL->get("Lump Mass Matrix", false);
+  bool isConstMass = vvPL->get("Constant Mass Matrix", false); 
   *out << "\nB) Using InvertMassMatrix Decorator\n";
   model = Teuchos::rcp(new Piro::InvertMassMatrixDecorator<Scalar>(
            sublist(vvPL,"Stratimikos", true), origModel,
-           true, lump, true));
+           isConstMass, lump, true));
 }
 
 template <typename Scalar>
@@ -373,6 +374,7 @@ Piro::VelocityVerletSolver<Scalar>::getValidVelocityVerletParameters() const
   validPL->set<double>("Initial Time", 0.0, "");
   validPL->set<std::string>("Verbosity Level", "", "");
   validPL->set<bool>("Lump Mass Matrix", false, "Boolean to tell code to lump mass matrix");
+  validPL->set<bool>("Constant Mass Matrix", false, "Boolean to tell code if mass matrix is constant in time");
   validPL->sublist("Stratimikos", false, "");
   return validPL;
 }

--- a/packages/piro/src/Piro_VelocityVerletSolver_Def.hpp
+++ b/packages/piro/src/Piro_VelocityVerletSolver_Def.hpp
@@ -92,14 +92,12 @@ VelocityVerletSolver(const Teuchos::RCP<Teuchos::ParameterList> &appParams_,
   t_init  = vvPL->get("Initial Time", 0.0);
   delta_t = t_final / numTimeSteps;
 
-  if (vvPL->get("Invert Mass Matrix", false)) {
-    Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > origModel = model;
-    bool lump=vvPL->get("Lump Mass Matrix", false);
-    *out << "\nB) Using InvertMassMatrix Decorator\n";
-    model = Teuchos::rcp(new Piro::InvertMassMatrixDecorator<Scalar>(
-             sublist(vvPL,"Stratimikos", true), origModel,
-             true, lump, true));
-  }
+  Teuchos::RCP<Thyra::ModelEvaluator<Scalar> > origModel = model;
+  bool lump=vvPL->get("Lump Mass Matrix", false);
+  *out << "\nB) Using InvertMassMatrix Decorator\n";
+  model = Teuchos::rcp(new Piro::InvertMassMatrixDecorator<Scalar>(
+           sublist(vvPL,"Stratimikos", true), origModel,
+           true, lump, true));
 }
 
 template <typename Scalar>
@@ -374,8 +372,7 @@ Piro::VelocityVerletSolver<Scalar>::getValidVelocityVerletParameters() const
   validPL->set<double>("Final Time", 1.0, "");
   validPL->set<double>("Initial Time", 0.0, "");
   validPL->set<std::string>("Verbosity Level", "", "");
-  validPL->set<bool>("Invert Mass Matrix", false, "");
-  validPL->set<bool>("Lump Mass Matrix", false, "");
+  validPL->set<bool>("Lump Mass Matrix", false, "Boolean to tell code to lump mass matrix");
   validPL->sublist("Stratimikos", false, "");
   return validPL;
 }


### PR DESCRIPTION
I recently discovered that the Piro wrapper to time-integration schemes and the time-integration schemes within Piro assumed that the mass matrix of a dynamic PDE was constant in time for explicit schemes.  This is not true in general and was causing incorrect behavior for Albany problems for which the mass matrix varies in time.  The correct thing to do is to assume the mass matrix varies in time, but to allow the user to tell the code it is temporally constant for certain problems to do an optimization in those cases (i.e., not recompute the mass matrix, but rather freeze it to be the first one computed).  I have added the relevant logic to do this, controlled by the 'Constant Mass Matrix' option (false by default).

I also made a few other cleanups such as removing the 'Invert Mass Matrix' option which is incorrect for most problems from all the steppers, and removing some unused variables.  