### PR TITLE
Framework: PR Driver Script Modification Detection

### DIFF
--- a/cmake/std/PullRequestLinuxDriver.sh
+++ b/cmake/std/PullRequestLinuxDriver.sh
@@ -91,7 +91,7 @@ echo -e ""
 echo -e "Execute Merge Command:"
 echo -e "${merge_cmd:?} 
 echo -e ""
-${merge_cmd:?}
+${merge_cmd:?} >& ${WORKSPACE:?}/merge_cmd_01.log
 
 
 # Get the md5 checksum of this script:

--- a/cmake/std/PullRequestLinuxDriver.sh
+++ b/cmake/std/PullRequestLinuxDriver.sh
@@ -91,7 +91,7 @@ echo -e ""
 echo -e "Execute Merge Command:"
 echo -e "${merge_cmd:?} 
 echo -e ""
-${merge_cmd:?} >& ${WORKSPACE:?}/merge_cmd_01.log
+${merge_cmd:?} >& ${WORKSPACE:?}/merge_cmd.log
 
 
 # Get the md5 checksum of this script:
@@ -111,6 +111,7 @@ then
     echo -e ""
     echo "Driver or Merge script change detected. Re-launching PR Driver"
     echo -e ""
+    mv ${WORKSPACE}/merge_cmd.log ${WORKSPACE}/merge_cmd.log.1
     ${merge_cmd:?}
     exit $?
 fi
@@ -137,6 +138,6 @@ echo -e ""
 echo -e "Execute Test Command:"
 echo -e "${test_cmd:?} 
 echo -e ""
-${test_cmd}
+${test_cmd} >& ${WORKSPACE:?}/test_cmd.log
 
 

--- a/cmake/std/PullRequestLinuxDriver.sh
+++ b/cmake/std/PullRequestLinuxDriver.sh
@@ -55,8 +55,8 @@ REPO_ROOT=`readlink -f ${SCRIPTPATH}/../..`
 echo -e "REPO_ROOT : ${REPO_ROOT}"
 
 # Get the md5 checksum of this script:
-sig_script_old=$(get_md5sum ${script_file:?})
-echo -e ">>> Old md5 checksum for '${script_file:?}' = ${sig_script_old}"
+sig_script_old=$(get_md5sum ${SCRIPTPATH:?})
+echo -e ">>> Old md5 checksum for '${SCRIPTPATH:?}' = ${sig_script_old}"
 
 # Get the md5 checksum of the Merge script
 sig_merge_old=$(get_md5sum ${SCRIPTPATH}/PullRequestLinuxDriverMerge.py)
@@ -81,8 +81,8 @@ ${merge_cmd}
 
 
 # Get the md5 checksum of this script:
-sig_script_new=$(get_md5sum ${script_file:?})
-echo -e ">>> New md5 checksum for '${script_file:?}' = ${sig_script_new}"
+sig_script_new=$(get_md5sum ${SCRIPTPATH:?})
+echo -e ">>> New md5 checksum for '${SCRIPTPATH:?}' = ${sig_script_new}"
 
 # Get the md5 checksum of the Merge script
 sig_merge_new=$(get_md5sum ${SCRIPTPATH}/PullRequestLinuxDriverMerge.py)

--- a/cmake/std/PullRequestLinuxDriver.sh
+++ b/cmake/std/PullRequestLinuxDriver.sh
@@ -138,6 +138,6 @@ echo -e ""
 echo -e "Execute Test Command:"
 echo -e "${test_cmd:?} 
 echo -e ""
-${test_cmd} >& ${WORKSPACE:?}/test_cmd.log
+# ${test_cmd}
 
 

--- a/cmake/std/PullRequestLinuxDriver.sh
+++ b/cmake/std/PullRequestLinuxDriver.sh
@@ -63,12 +63,15 @@ echo -e "REPO_ROOT : ${REPO_ROOT}"
 
 # Get the md5 checksum of this script:
 sig_script_old=$(get_md5sum ${script_file:?})
+echo -e ""
 echo -e ">>> Old md5 checksum for '${SCRIPTPATH:?}' = ${sig_script_old}"
+echo -e ""
 
 # Get the md5 checksum of the Merge script
 sig_merge_old=$(get_md5sum ${SCRIPTPATH}/PullRequestLinuxDriverMerge.py)
+echo -e ""
 echo -e ">>> Old md5 checksum for '${SCRIPTPATH}/PullRequestLinuxDriverMerge.py' = ${sig_merge_old}"
-
+echo -e ""
 
 # Prepare the command for the MERGE operation
 merge_cmd_options=(
@@ -84,20 +87,30 @@ merge_cmd=${SCRIPTPATH}/PullRequestLinuxDriverMerge.py ${merge_cmd_options[@]}
 
 # Call the script to handle merging the incoming branch into
 # the current trilinos/develop branch for testing.
-${merge_cmd}
+echo -e ""
+echo -e "Execute Merge Command:"
+echo -e "${merge_cmd:?} 
+echo -e ""
+${merge_cmd:?}
 
 
 # Get the md5 checksum of this script:
 sig_script_new=$(get_md5sum ${script_file:?})
+echo -e ""
 echo -e ">>> New md5 checksum for '${SCRIPTPATH:?}' = ${sig_script_new}"
+echo -e ""
 
 # Get the md5 checksum of the Merge script
 sig_merge_new=$(get_md5sum ${SCRIPTPATH}/PullRequestLinuxDriverMerge.py)
+echo -e ""
 echo -e ">>> New md5 checksum for '${SCRIPTPATH}/PullRequestLinuxDriverMerge.py' = ${sig_merge_new}"
+echo -e ""
 
 if [ "${sig_script_old:?}" != "${sig_script_new:?}" ] || [ "${sig_merge_old:?}" != "${sig_merge_new:?}"  ]
 then
+    echo -e ""
     echo "Driver or Merge script change detected. Re-launching PR Driver"
+    echo -e ""
     ${merge_cmd:?}
     exit $?
 fi
@@ -120,6 +133,10 @@ test_cmd_options=(
 test_cmd=${SCRIPTPATH}/PullRequestLinuxDriverTest.py ${test_cmd_options[@]}
 
 # Call the script to launch the tests
+echo -e ""
+echo -e "Execute Test Command:"
+echo -e "${test_cmd:?} 
+echo -e ""
 ${test_cmd}
 
 

--- a/cmake/std/PullRequestLinuxDriver.sh
+++ b/cmake/std/PullRequestLinuxDriver.sh
@@ -1,7 +1,34 @@
 #!/usr/bin/env bash
 # set -x  # echo commands
 
-#    make  sure we have a newer version of git/python
+function get_scriptname() {
+    # Get the full path to the current script
+    local script_name=`basename $0`
+    local script_path=$(dirname $(readlink -f $0))
+    local script_file="${script_path}/${script_name:?}"
+    echo "${script_file}"
+    #SCRIPTPATH="$(cd "$(dirname "$0")" ; pwd -P)"
+    #echo -e "SCRIPTPATH: ${SCRIPTPATH}"
+}
+
+# Get the md5sum of a filename.
+# param1: filename
+# returns: md5sum of the file.
+function get_md5sum() {
+    local filename=${1:?}
+    local sig=$(md5sum ${filename:?} | cut -d' ' -f1)
+    echo "${sig:?}"
+}
+
+
+# Set up Sandia PROXY environment vars
+export https_proxy=http://wwwproxy.sandia.gov:80
+export http_proxy=http://wwwproxy.sandia.gov:80
+export no_proxy='localhost,localnets,127.0.0.1,169.254.0.0/16,forge.sandia.gov'
+
+
+# Load the right version of Git / Python based on a regex 
+# match to the Jenkins job name.
 cuda_regex=".*(_cuda_).*"
 ride_regex=".*(ride).*"
 if [[ ${JOB_BASE_NAME:?} =~ ${cuda_regex} ]]; then
@@ -19,40 +46,73 @@ else
     module load sems-python/2.7.9
 fi
 
+
 # Identify the path to this script
-SCRIPTPATH="$(cd "$(dirname "$0")" ; pwd -P)"
-echo -e "SCRIPTPATH: ${SCRIPTPATH}"
+SCRIPTPATH=$(get_scriptname)
 
 # Identify the path to the trilinos repository root
 REPO_ROOT=`readlink -f ${SCRIPTPATH}/../..`
 echo -e "REPO_ROOT : ${REPO_ROOT}"
 
-# This is the old Linux Driver (deprecated)
-#${SCRIPTPATH}/PullRequestLinuxDriver-old.sh
+# Get the md5 checksum of this script:
+sig_script_old=$(get_md5sum ${script_file:?})
+echo -e ">>> Old md5 checksum for '${script_file:?}' = ${sig_script_old}"
 
-# Both scripts will need access through the sandia
-# proxies so set them here.
-export https_proxy=http://wwwproxy.sandia.gov:80
-export http_proxy=http://wwwproxy.sandia.gov:80
-export no_proxy='localhost,localnets,127.0.0.1,169.254.0.0/16,forge.sandia.gov'
+# Get the md5 checksum of the Merge script
+sig_merge_old=$(get_md5sum ${SCRIPTPATH}/PullRequestLinuxDriverMerge.py)
+echo -e ">>> Old md5 checksum for '${SCRIPTPATH}/PullRequestLinuxDriverMerge.py' = ${sig_merge_old}"
+
+
+# Prepare the command for the MERGE operation
+merge_cmd_options=( 
+    ${TRILINOS_SOURCE_REPO:?}
+    ${TRILINOS_SOURCE_BRANCH:?}
+    ${TRILINOS_TARGET_REPO:?}
+    ${TRILINOS_TARGET_BRANCH:?}
+    ${TRILINOS_SOURCE_SHA:?}
+    ${WORKSPACE:?}
+    )
+merge_cmd=${SCRIPTPATH}/PullRequestLinuxDriverMerge.py ${merge_cmd_options[@]}
 
 
 # Call the script to handle merging the incoming branch into
 # the current trilinos/develop branch for testing.
-${SCRIPTPATH}/PullRequestLinuxDriverMerge.py ${TRILINOS_SOURCE_REPO:?} \
-                                              ${TRILINOS_SOURCE_BRANCH:?} \
-                                              ${TRILINOS_TARGET_REPO:?} \
-                                              ${TRILINOS_TARGET_BRANCH:?} \
-                                              ${TRILINOS_SOURCE_SHA:?} \
-                                              ${WORKSPACE:?}
+${merge_cmd}
 
-# Call the script to handle driving the testing
-${SCRIPTPATH}/PullRequestLinuxDriverTest.py ${TRILINOS_SOURCE_REPO:?} \
-                                            ${TRILINOS_SOURCE_BRANCH:?} \
-                                            ${TRILINOS_TARGET_REPO:?} \
-                                            ${TRILINOS_TARGET_BRANCH:?} \
-                                            ${JOB_BASE_NAME:?} \
-                                            ${PULLREQUESTNUM:?} \
-                                            ${BUILD_NUMBER:?} \
-                                            ${WORKSPACE:?}
+
+# Get the md5 checksum of this script:
+sig_script_new=$(get_md5sum ${script_file:?})
+echo -e ">>> New md5 checksum for '${script_file:?}' = ${sig_script_new}"
+
+# Get the md5 checksum of the Merge script
+sig_merge_new=$(get_md5sum ${SCRIPTPATH}/PullRequestLinuxDriverMerge.py)
+echo -e ">>> New md5 checksum for '${SCRIPTPATH}/PullRequestLinuxDriverMerge.py' = ${sig_merge_new}"
+
+if [ "${sig_script_old:?}" != "${sig_script_new:?}" ] || [ "${sig_merge_old:?}" != "${sig_merge_new:?}"  ]
+then
+    echo "Driver or Merge script change detected. Re-launching PR Driver"
+    ${merge_cmd:?}
+    exit $?
+fi
+
+echo -e ""
+echo -e "Driver and Merge scripts unchaged, proceeding to TEST phase"
+echo -e ""
+
+# Prepare the command for the TEST operation
+test_cmd_options=(
+    ${TRILINOS_SOURCE_REPO:?}
+    ${TRILINOS_SOURCE_BRANCH:?}
+    ${TRILINOS_TARGET_REPO:?}
+    ${TRILINOS_TARGET_BRANCH:?}
+    ${JOB_BASE_NAME:?}
+    ${PULLREQUESTNUM:?}
+    ${BUILD_NUMBER:?}
+    ${WORKSPACE:?}
+    )
+test_cmd=${SCRIPTPATH}/PullRequestLinuxDriverTest.py ${test_cmd_options[@]}
+
+# Call the script to launch the tests
+${test_cmd}
+
 

--- a/cmake/std/PullRequestLinuxDriver.sh
+++ b/cmake/std/PullRequestLinuxDriver.sh
@@ -64,7 +64,7 @@ echo -e ">>> Old md5 checksum for '${SCRIPTPATH}/PullRequestLinuxDriverMerge.py'
 
 
 # Prepare the command for the MERGE operation
-merge_cmd_options=( 
+merge_cmd_options=(
     ${TRILINOS_SOURCE_REPO:?}
     ${TRILINOS_SOURCE_BRANCH:?}
     ${TRILINOS_TARGET_REPO:?}

--- a/cmake/std/PullRequestLinuxDriver.sh
+++ b/cmake/std/PullRequestLinuxDriver.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 # set -x  # echo commands
 
-function get_scriptname() {
+function get_scriptpath() {
     # Get the full path to the current script
     local script_name=`basename $0`
     local script_path=$(dirname $(readlink -f $0))
-    local script_file="${script_path}/${script_name:?}"
-    echo "${script_file}"
+    #local script_file="${script_path}/${script_name:?}"
+    echo "${script_path}"
     #SCRIPTPATH="$(cd "$(dirname "$0")" ; pwd -P)"
     #echo -e "SCRIPTPATH: ${SCRIPTPATH}"
 }
@@ -48,14 +48,16 @@ fi
 
 
 # Identify the path to this script
-SCRIPTPATH=$(get_scriptname)
+SCRIPTPATH=$(get_scriptpath)
+script_file="${SCRIPTPATH}/${script_name:?}"
+
 
 # Identify the path to the trilinos repository root
 REPO_ROOT=`readlink -f ${SCRIPTPATH}/../..`
 echo -e "REPO_ROOT : ${REPO_ROOT}"
 
 # Get the md5 checksum of this script:
-sig_script_old=$(get_md5sum ${SCRIPTPATH:?})
+sig_script_old=$(get_md5sum ${script_file:?})
 echo -e ">>> Old md5 checksum for '${SCRIPTPATH:?}' = ${sig_script_old}"
 
 # Get the md5 checksum of the Merge script
@@ -81,7 +83,7 @@ ${merge_cmd}
 
 
 # Get the md5 checksum of this script:
-sig_script_new=$(get_md5sum ${SCRIPTPATH:?})
+sig_script_new=$(get_md5sum ${script_file:?})
 echo -e ">>> New md5 checksum for '${SCRIPTPATH:?}' = ${sig_script_new}"
 
 # Get the md5 checksum of the Merge script

--- a/cmake/std/PullRequestLinuxDriver.sh
+++ b/cmake/std/PullRequestLinuxDriver.sh
@@ -1,14 +1,19 @@
 #!/usr/bin/env bash
 # set -x  # echo commands
 
+function get_scriptname() {
+    # Get the full path to the current script
+    local script_name=`basename $0`
+    local script_path=$(dirname $(readlink -f $0))
+    local script_file="${script_path}/${script_name:?}"
+    echo "${script_file}"
+}
+
 function get_scriptpath() {
     # Get the full path to the current script
     local script_name=`basename $0`
     local script_path=$(dirname $(readlink -f $0))
-    #local script_file="${script_path}/${script_name:?}"
     echo "${script_path}"
-    #SCRIPTPATH="$(cd "$(dirname "$0")" ; pwd -P)"
-    #echo -e "SCRIPTPATH: ${SCRIPTPATH}"
 }
 
 # Get the md5sum of a filename.
@@ -49,7 +54,7 @@ fi
 
 # Identify the path to this script
 SCRIPTPATH=$(get_scriptpath)
-script_file="${SCRIPTPATH}/${script_name:?}"
+script_file=$(get_scriptname)
 
 
 # Identify the path to the trilinos repository root

--- a/cmake/std/PullRequestLinuxDriver.sh
+++ b/cmake/std/PullRequestLinuxDriver.sh
@@ -64,7 +64,7 @@ echo -e "REPO_ROOT : ${REPO_ROOT}"
 # Get the md5 checksum of this script:
 sig_script_old=$(get_md5sum ${script_file:?})
 echo -e ""
-echo -e ">>> Old md5 checksum for '${SCRIPTPATH:?}' = ${sig_script_old}"
+echo -e ">>> Old md5 checksum for '${script_file:?}' = ${sig_script_old}"
 echo -e ""
 
 # Get the md5 checksum of the Merge script
@@ -96,15 +96,15 @@ ${merge_cmd:?}
 
 # Get the md5 checksum of this script:
 sig_script_new=$(get_md5sum ${script_file:?})
-echo -e ""
-echo -e ">>> New md5 checksum for '${SCRIPTPATH:?}' = ${sig_script_new}"
-echo -e ""
+echo ""
+echo -e ">>> New md5 checksum for '${script_file:?}' = ${sig_script_new}"
+echo ""
 
 # Get the md5 checksum of the Merge script
 sig_merge_new=$(get_md5sum ${SCRIPTPATH}/PullRequestLinuxDriverMerge.py)
-echo -e ""
+echo ""
 echo -e ">>> New md5 checksum for '${SCRIPTPATH}/PullRequestLinuxDriverMerge.py' = ${sig_merge_new}"
-echo -e ""
+echo ""
 
 if [ "${sig_script_old:?}" != "${sig_script_new:?}" ] || [ "${sig_merge_old:?}" != "${sig_merge_new:?}"  ]
 then

--- a/cmake/std/PullRequestLinuxDriverMerge.py
+++ b/cmake/std/PullRequestLinuxDriverMerge.py
@@ -52,8 +52,8 @@ def echoJenkinsVars(workspace):
               pwd = {cwd}
             ''').format(workspace=workspace, cwd=os.getcwd()))
 
-    for key in os.environ:
-        print(key +' = ' + os.environ[key])
+    #for key in os.environ:
+        #print(key +' = ' + os.environ[key])
 
     print('\n' + 80*"=")
 


### PR DESCRIPTION
@trilinos/framework 

This is a WORK IN PROGRESS
===============

## Motivation
The current set of scripts that drive the PR testing have a known issue that can cause problems when either of these two scripts are modified:
1. `cmake/std/PullRequestLinuxDriver.sh` - Top level script that is called by Jenkins in a PR test.
2. `cmake/std/PullRequestLinuxDriverMerge.py` - Python script that handles merging the incoming branch into the target branch.

When either of these two scripts are modified, the incoming changes do not actually get tested by the PR system since the scripts themselves are loaded into memory prior to the incoming changes being merged in. This can cause the PR system to become broken when we need to update these scripts in a manner that requires a @trilinos/framework team member to use special access to bypass the PR system to revert a change. Given that we really really really do not want to do that except in extraordinary circumstances (and even then, I treat this like using nuclear launch keys in the movies -- I will not do it without agreement from another Framework team member).

This modification adds a check step for scripts (1) and (2) to identify if either is changed during the _merge_ step. If so, the PR should re-launch the `PullRequestLinuxDriver.sh` script, which at that point should not have changes in the merge call.

## Testing

### Prototype Bash Script
I developed a prototype bash script to test the general process and ran it on an ascic build server as well as on ride:
```bash
#!/usr/bin/env bash

# Get the full path to the current script
script_name=`basename $0`
script_path=$(dirname $(readlink -f $0))
script_file="${script_path}/${script_name:?}"
echo -e "script_file = ${script_file}"

# Get MD5 checksum of the existing file
sig_old=$(md5sum ${script_file} | cut -d' ' -f1)
echo -e "sig_old = ${sig_old}"


# DO THE MERGE HERE
echo -e ">>> Execute merge operation"
sleep 10

# Get MD5 checksum of the file post-merge
sig_new=$(md5sum ${script_file} | cut -d' ' -f1)
echo -e "sig_new = ${sig_new}"

# if file is different, re-run it and exit, otherwise continue.
if [ "${sig_old}" != "${sig_new}" ] || [ "foo" != "foo" ]
then
    echo -e "CHANGED!"
    ${script_file:?}
    exit $?
fi

echo -e ">>> Driver script unchanged."
echo -e ">>>"
echo -e ">>> Execute post-merge operations"
```

### Manual execution of PR jobs on Jenkins
Once this PR is created, I will test the following:
1. Launch a manual PR job on Jenkins to test a merge of a trivial change into an existing commit of this branch to ensure the updated PR script runs without incident.
    1. Try on the python3 build
    2. Try on the gcc 7.2.0 build
2. Launch a manual PR job on Jenkins to test a merge of my branch into Trilinos/develop.
