### PR TITLE
Framework: PR Driver Script Change Detection

### DIFF
--- a/cmake/std/PullRequestLinuxDriver.sh
+++ b/cmake/std/PullRequestLinuxDriver.sh
@@ -143,5 +143,3 @@ echo -e "PRDriver> "
 ${test_cmd}
 exit $?
 
-
-

--- a/cmake/std/PullRequestLinuxDriver.sh
+++ b/cmake/std/PullRequestLinuxDriver.sh
@@ -143,3 +143,5 @@ echo -e "PRDriver> "
 ${test_cmd}
 exit $?
 
+
+

--- a/cmake/std/PullRequestLinuxDriver.sh
+++ b/cmake/std/PullRequestLinuxDriver.sh
@@ -1,7 +1,44 @@
 #!/usr/bin/env bash
 # set -x  # echo commands
 
-#    make  sure we have a newer version of git/python
+function get_scriptname() {
+    # Get the full path to the current script
+    local script_name=`basename $0`
+    local script_path=$(dirname $(readlink -f $0))
+    local script_file="${script_path}/${script_name:?}"
+    echo "${script_file}"
+}
+
+function get_scriptpath() {
+    # Get the full path to the current script
+    local script_name=`basename $0`
+    local script_path=$(dirname $(readlink -f $0))
+    echo "${script_path}"
+}
+
+# Get the md5sum of a filename.
+# param1: filename
+# returns: md5sum of the file.
+function get_md5sum() {
+    local filename=${1:?}
+    local sig=$(md5sum ${filename:?} | cut -d' ' -f1)
+    echo "${sig:?}"
+}
+
+echo -e "PRDRiver> ================================================="
+echo -e "PRDriver> ="
+echo -e "PRDriver> = PullRequestLinuxDriver.sh"
+echo -e "PRDriver> ="
+echo -e "PRDriver> ================================================="
+
+# Set up Sandia PROXY environment vars
+export https_proxy=http://wwwproxy.sandia.gov:80
+export http_proxy=http://wwwproxy.sandia.gov:80
+export no_proxy='localhost,localnets,127.0.0.1,169.254.0.0/16,forge.sandia.gov'
+
+
+# Load the right version of Git / Python based on a regex 
+# match to the Jenkins job name.
 cuda_regex=".*(_cuda_).*"
 ride_regex=".*(ride).*"
 if [[ ${JOB_BASE_NAME:?} =~ ${cuda_regex} ]]; then
@@ -19,40 +56,90 @@ else
     module load sems-python/2.7.9
 fi
 
+
 # Identify the path to this script
-SCRIPTPATH="$(cd "$(dirname "$0")" ; pwd -P)"
-echo -e "SCRIPTPATH: ${SCRIPTPATH}"
+SCRIPTPATH=$(get_scriptpath)
+script_file=$(get_scriptname)
 
 # Identify the path to the trilinos repository root
-REPO_ROOT=`readlink -f ${SCRIPTPATH}/../..`
-echo -e "REPO_ROOT : ${REPO_ROOT}"
+REPO_ROOT=`readlink -f ${SCRIPTPATH:?}/../..`
+echo -e "PRDriver> REPO_ROOT : ${REPO_ROOT}"
 
-# This is the old Linux Driver (deprecated)
-#${SCRIPTPATH}/PullRequestLinuxDriver-old.sh
+# Get the md5 checksum of this script:
+sig_script_old=$(get_md5sum ${script_file:?})
 
-# Both scripts will need access through the sandia
-# proxies so set them here.
-export https_proxy=http://wwwproxy.sandia.gov:80
-export http_proxy=http://wwwproxy.sandia.gov:80
-export no_proxy='localhost,localnets,127.0.0.1,169.254.0.0/16,forge.sandia.gov'
+# Get the md5 checksum of the Merge script
+sig_merge_old=$(get_md5sum ${SCRIPTPATH}/PullRequestLinuxDriverMerge.py)
+
+# Prepare the command for the MERGE operation
+merge_cmd_options=(
+    ${TRILINOS_SOURCE_REPO:?}
+    ${TRILINOS_SOURCE_BRANCH:?}
+    ${TRILINOS_TARGET_REPO:?}
+    ${TRILINOS_TARGET_BRANCH:?}
+    ${TRILINOS_SOURCE_SHA:?}
+    ${WORKSPACE:?}
+    )
+merge_cmd="${SCRIPTPATH}/PullRequestLinuxDriverMerge.py ${merge_cmd_options[@]}"
 
 
 # Call the script to handle merging the incoming branch into
 # the current trilinos/develop branch for testing.
-${SCRIPTPATH}/PullRequestLinuxDriverMerge.py ${TRILINOS_SOURCE_REPO:?} \
-                                              ${TRILINOS_SOURCE_BRANCH:?} \
-                                              ${TRILINOS_TARGET_REPO:?} \
-                                              ${TRILINOS_TARGET_BRANCH:?} \
-                                              ${TRILINOS_SOURCE_SHA:?} \
-                                              ${WORKSPACE:?}
+echo -e "PRDriver> "
+echo -e "PRDriver> Execute Merge Command: ${merge_cmd:?}" 
+echo -e "PRDriver> "
+${merge_cmd:?}
+err=$?
+if [ $err != 0 ]; then
+    echo -e "PRDriver> An error occurred during merge"
+    exit $err
+else
+    echo -e "PRDriver> Merge completed successfully."
+fi
+echo -e "PRDriver> "
 
-# Call the script to handle driving the testing
-${SCRIPTPATH}/PullRequestLinuxDriverTest.py ${TRILINOS_SOURCE_REPO:?} \
-                                            ${TRILINOS_SOURCE_BRANCH:?} \
-                                            ${TRILINOS_TARGET_REPO:?} \
-                                            ${TRILINOS_TARGET_BRANCH:?} \
-                                            ${JOB_BASE_NAME:?} \
-                                            ${PULLREQUESTNUM:?} \
-                                            ${BUILD_NUMBER:?} \
-                                            ${WORKSPACE:?}
+
+# Get the md5 checksum of this script:
+sig_script_new=$(get_md5sum ${script_file:?})
+echo -e "PRDriver> Old md5 checksum ${sig_script_old:?} for ${script_file:?}"
+echo -e "PRDriver> New md5 checksum ${sig_script_new:?} for ${script_file:?}"
+echo -e "PRDriver> "
+
+# Get the md5 checksum of the Merge script
+sig_merge_new=$(get_md5sum ${SCRIPTPATH}/PullRequestLinuxDriverMerge.py)
+echo -e "PRDriver> Old md5 checksum ${sig_merge_old:?} for ${SCRIPTPATH}/PullRequestLinuxDriverMerge.py"
+echo -e "PRDriver> New md5 checksum ${sig_merge_new:?} for ${SCRIPTPATH}/PullRequestLinuxDriverMerge.py"
+
+if [ "${sig_script_old:?}" != "${sig_script_new:?}" ] || [ "${sig_merge_old:?}" != "${sig_merge_new:?}"  ]
+then
+    echo -e "PRDriver> "
+    echo -e "PRDriver> Driver or Merge script change detected. Re-launching PR Driver"
+    echo -e "PRDriver> "
+    ${script_file:?}
+    exit $?
+fi
+
+echo -e "PRDriver> "
+echo -e "PRDriver> Driver and Merge scripts unchaged, proceeding to TEST phase"
+echo -e "PRDriver> "
+
+# Prepare the command for the TEST operation
+test_cmd_options=(
+    ${TRILINOS_SOURCE_REPO:?}
+    ${TRILINOS_SOURCE_BRANCH:?}
+    ${TRILINOS_TARGET_REPO:?}
+    ${TRILINOS_TARGET_BRANCH:?}
+    ${JOB_BASE_NAME:?}
+    ${PULLREQUESTNUM:?}
+    ${BUILD_NUMBER:?}
+    ${WORKSPACE:?}
+    )
+test_cmd="${SCRIPTPATH}/PullRequestLinuxDriverTest.py ${test_cmd_options[@]}"
+
+# Call the script to launch the tests
+echo -e "PRDriver> "
+echo -e "PRDriver> Execute Test Command: ${test_cmd:?}"
+echo -e "PRDriver> "
+${test_cmd}
+exit $?
 

--- a/cmake/std/PullRequestLinuxDriverMerge.py
+++ b/cmake/std/PullRequestLinuxDriverMerge.py
@@ -167,3 +167,5 @@ if __name__ == '__main__':  # pragma nocover
         exit(0)
     else:
         exit(1)
+
+


### PR DESCRIPTION
@trilinos/framework 

@prwolfe @jwillenbring Since this is messing with the top level .sh driver script, let's chat about this one before we merge it.  Manual testing looks ok but we'll want to merge this when we know we'll be around to monitor it in case we need to revert. 😉 

## Motivation
The current set of scripts that drive the PR testing have a known issue that can cause problems when either of these two scripts are modified:
1. `cmake/std/PullRequestLinuxDriver.sh` - Top level script that is called by Jenkins in a PR test.
2. `cmake/std/PullRequestLinuxDriverMerge.py` - Python script that handles merging the incoming branch into the target branch.

When either of these two scripts are modified, the incoming changes do not actually get tested by the PR system since the scripts themselves are loaded into memory prior to the incoming changes being merged in. This can cause the PR system to become broken when we need to update these scripts in a manner that requires a Framework team member to use special access to bypass the PR system to revert a change. Given that we really really really do not want to do that except in extraordinary circumstances (and even then, I treat this like using nuclear launch keys in the movies -- I will not do it without agreement from another Framework team member).

This modification adds a check step for scripts (1) and (2) to identify if either is changed during the _merge_ step. If so, the PR should re-launch the `PullRequestLinuxDriver.sh` script, which at that point should not have changes in the merge call.

## Testing

### Prototype Bash Script
I developed a prototype bash script to test the general process and ran it on an ascic build server as well as on ride:
```bash
#!/usr/bin/env bash

# Get the full path to the current script
script_name=`basename $0`
script_path=$(dirname $(readlink -f $0))
script_file="${script_path}/${script_name:?}"
echo -e "script_file = ${script_file}"

# Get MD5 checksum of the existing file
sig_old=$(md5sum ${script_file} | cut -d' ' -f1)
echo -e "sig_old = ${sig_old}"


# DO THE MERGE HERE
echo -e ">>> Execute merge operation"
sleep 10

# Get MD5 checksum of the file post-merge
sig_new=$(md5sum ${script_file} | cut -d' ' -f1)
echo -e "sig_new = ${sig_new}"

# if file is different, re-run it and exit, otherwise continue.
if [ "${sig_old}" != "${sig_new}" ] || [ "foo" != "foo" ]
then
    echo -e "CHANGED!"
    ${script_file:?}
    exit $?
fi

echo -e ">>> Driver script unchanged."
echo -e ">>>"
echo -e ">>> Execute post-merge operations"
```

### Manual execution of PR jobs on Jenkins
Once this PR is created, I will test the following:
1. Manual run with a 'change' detected in the PullRequestDriver.sh script [Jenkins Console Output][2]. This shows a detected change in the md5sum for just the PullRequestDriver.sh script and the driver.sh script is re-launched.
2. Manual run with a 'change' detected in the PullRequestDriverMerge.py script added [Jenkins Console Output][3]. This one shows a change in the md5sum for both scripts.

[CDash Output should be here][1] 

[1]: https://testing.sandia.gov/cdash/index.php?project=Trilinos&filtercount=1&showfilters=1&field1=buildname&compare1=63&value1=PR-7896
[2]: https://ascic-jenkins.sandia.gov/job/trilinos-folder/job/Trilinos_pullrequest_python_3/3245/console
[3]: https://ascic-jenkins.sandia.gov/job/trilinos-folder/job/Trilinos_pullrequest_python_3/3246/console