### PR TITLE
Muelu: guard Stratimikos test via CMake

### DIFF
--- a/packages/muelu/test/maxwell/CMakeLists.txt
+++ b/packages/muelu/test/maxwell/CMakeLists.txt
@@ -40,7 +40,7 @@ IF (${PACKAGE_NAME}_ENABLE_Belos AND ${PACKAGE_NAME}_ENABLE_Amesos2)
         )
     ENDIF()
 
-    IF (${PACKAGE_NAME}_INST_DOUBLE_INT_INT)
+    IF (${PACKAGE_NAME}_INST_DOUBLE_INT_INT AND ${PACKAGE_NAME}_ENABLE_Stratimikos)
       TRIBITS_ADD_TEST(
         Maxwell3D
         NAME "Maxwell3D-Tpetra-Stratimikos"


### PR DESCRIPTION
@trilinos/muelu 
@cgcgcg 

## Motivation

This PR adds a bit of CMake logic to enable a MueLu/Stratimikos test only, if Stratimikos is actually enabled in the CMake configuration.

## Stakeholder Feedback

None.

## Testing

When enabling `Stratimikos` in the build, the test `MueLu_Maxwell3D-Tpetra-Stratimikos_MPI_4` is executed and passes. If `Stratimikos` is disabled, the test is not executed and the test suite passes.
