### PR TITLE
Panzer: Protect evaluateFields with fence

### DIFF
--- a/packages/phalanx/src/Phalanx_DAG_Manager_Def.hpp
+++ b/packages/phalanx/src/Phalanx_DAG_Manager_Def.hpp
@@ -489,6 +489,8 @@ evaluateFields(typename Traits::EvalData d)
     using clock = std::chrono::steady_clock;
     std::chrono::time_point<clock> start = clock::now();
 
+    typename PHX::Device().fence(); // temporary fence until UVM in evaluateFields fixed
+
     nodes_[topoSortEvalIndex[n]].getNonConst()->evaluateFields(d);
 
     nodes_[topoSortEvalIndex[n]].sumIntoExecutionTime(clock::now()-start);


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/panzer

Adds fence before the call to evaluateFields. Note this is not exactly what we discussed (which was the fence afterwards) but I think this is more correct, and temporary anyways. Either way will pass the tests. I see many evaluateFields use UVM directly so I think we want to protect all of them before. It may be a coincidence it passes the other way.

I suggest we merge this fence which will complete panzer to pass all unit tests with CUDA_LAUNCH_BLOCKING=0. Then I will open a discussion PR which adds a tag on all fences. Refactoring each of the evaluateFields to not use UVM might be the next logical thing for me to work on. As a first step I think we may want to remove this fence and add it in every evaluateFields method that uses UVM. Then we can refactor one at a time and test.

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Fix panzer tests for CUDA_LAUNCH_BLOCKING=0

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

Cuda white panzer tests
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->