### PR TITLE
Panzer: add append to restart support for stk_interface and exodus

### DIFF
--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.cpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.cpp
@@ -556,10 +556,10 @@ stk::mesh::Entity STK_Interface::findConnectivityById(stk::mesh::Entity src, stk
 ///////////////////////////////////////////////////////////////////////////////
 void
 STK_Interface::
-writeToExodus(
-  const std::string& filename)
+writeToExodus(const std::string& filename,
+              const bool append)
 {
-  setupExodusFile(filename);
+  setupExodusFile(filename,append);
   writeToExodus(0.0);
 } // end of writeToExodus()
 
@@ -570,8 +570,8 @@ writeToExodus(
 ///////////////////////////////////////////////////////////////////////////////
 void
 STK_Interface::
-setupExodusFile(
-  const std::string& filename)
+setupExodusFile(const std::string& filename,
+                const bool append)
 {
   using std::runtime_error;
   using stk::io::StkMeshIoBroker;
@@ -584,7 +584,10 @@ setupExodusFile(
   ParallelMachine comm = *mpiComm_->getRawMpiComm();
   meshData_ = rcp(new StkMeshIoBroker(comm));
   meshData_->set_bulk_data(bulkData_);
-  meshIndex_ = meshData_->create_output_mesh(filename, stk::io::WRITE_RESULTS);
+  if (append)
+    meshIndex_ = meshData_->create_output_mesh(filename, stk::io::APPEND_RESULTS);
+  else
+    meshIndex_ = meshData_->create_output_mesh(filename, stk::io::WRITE_RESULTS);
   const FieldVector& fields = metaData_->get_fields();
   for (size_t i(0); i < fields.size(); ++i) {
     // Do NOT add MESH type stk fields to exodus io, but do add everything

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.hpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.hpp
@@ -328,10 +328,11 @@ public:
    *  \note This will only write a single timestep at time = 0.
    *
    *  \param[in] filename The name of the output Exodus file.
+   *  \param[in] append If set to true, the output will be appended to the output Exodus file. If set to false, output file will be overwritten. Default is false.
    */
   void
-  writeToExodus(
-    const std::string& filename);
+  writeToExodus(const std::string& filename,
+                const bool append = false);
 
   /**
    *  \brief Set up an output Exodus file for writing results.
@@ -343,13 +344,14 @@ public:
    *        call to `writeToExodus(double timestep)`.
    *
    *  \param[in] filename The name of the output Exodus file.
+   *  \param[in] append If set to true, the output will be appended to the output Exodus file. If set to false, output file will be overwritten. Default is false.
    *
    *  \throws `std::logic_error` If the `STK_Interface` does not yet have a MPI
    *                             communicator.
    */
   void
-  setupExodusFile(
-    const std::string& filename);
+  setupExodusFile(const std::string& filename,
+                  const bool append = false);
 
   /**
    *  \brief Write this mesh and associated fields at the given `timestep`.

--- a/packages/panzer/adapters-stk/test/stk_interface_test/CMakeLists.txt
+++ b/packages/panzer/adapters-stk/test/stk_interface_test/CMakeLists.txt
@@ -77,6 +77,13 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   COMM serial mpi
   )
 
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  tExodusRestartAndAppend
+  SOURCES tExodusRestartAndAppend.cpp ${UNIT_TEST_DRIVER}
+  NUM_MPI_PROCS 2
+  COMM serial mpi
+  )
+
 #TRIBITS_ADD_EXECUTABLE_AND_TEST(
 #  tSolutionReader
 #  SOURCES tSolutionReader.cpp ${UNIT_TEST_DRIVER}

--- a/packages/panzer/adapters-stk/test/stk_interface_test/tExodusRestartAndAppend.cpp
+++ b/packages/panzer/adapters-stk/test/stk_interface_test/tExodusRestartAndAppend.cpp
@@ -1,0 +1,187 @@
+// @HEADER
+// ***********************************************************************
+//
+//           Panzer: A partial differential equation assembly
+//       engine for strongly coupled complex multiphysics systems
+//                 Copyright (2011) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Roger P. Pawlowski (rppawlo@sandia.gov) and
+// Eric C. Cyr (eccyr@sandia.gov)
+// ***********************************************************************
+// @HEADER
+
+
+#include "Teuchos_ConfigDefs.hpp"
+#include "Teuchos_UnitTestHarness.hpp"
+
+#include "Panzer_STK_Version.hpp"
+#include "PanzerAdaptersSTK_config.hpp"
+#include "Panzer_STK_Interface.hpp"
+#include "Panzer_STK_ExodusReaderFactory.hpp"
+
+#include "Shards_BasicTopologies.hpp"
+
+#ifdef PANZER_HAVE_IOSS
+
+// for checking test correctness
+#include "Ioss_DBUsage.h"               // for DatabaseUsage::READ_MODEL
+#include "Ioss_ElementBlock.h"          // for ElementBlock
+#include "Ioss_Field.h"                 // for Field, etc
+#include "Ioss_IOFactory.h"             // for IOFactory
+#include "Ioss_NodeBlock.h"             // for NodeBlock
+#include "Ioss_Property.h"              // for Property
+#include "Ioss_Region.h"                // for Region, etc
+
+const std::string node_field_name = "DUMMY_NODAL_FIELD";
+const std::string cell_field_name = "DUMMY_CELL_FIELD";
+const std::string block_name_1 = "block_1";
+const std::string block_name_2 = "block_2";
+
+namespace panzer_stk {
+
+  void setValues(const Teuchos::RCP<panzer_stk::STK_Interface>& mesh,
+                 double value)
+  {
+    auto node_vals = mesh->getSolutionField(node_field_name,block_name_1);
+    auto cell_vals = mesh->getCellField(cell_field_name,block_name_1);
+
+    auto meta_data = mesh->getMetaData();
+    auto bulk_data = mesh->getBulkData();
+
+    auto node_buckets = bulk_data->get_buckets(stk::topology::NODE_RANK,meta_data->locally_owned_part());
+    for (size_t bucket_i=0 ; bucket_i<node_buckets.size() ; ++bucket_i) {
+      stk::mesh::Bucket &node_bucket = *node_buckets[bucket_i];
+      for (size_t node_i=0 ; node_i<node_bucket.size() ; ++node_i) {
+        double * node_data = stk::mesh::field_data(*node_vals,node_bucket.bucket_id(),node_i);
+        *node_data = value;
+      }
+    }
+
+    auto cell_buckets = bulk_data->get_buckets(stk::topology::ELEM_RANK,meta_data->locally_owned_part());
+    for (size_t bucket_i=0 ; bucket_i<cell_buckets.size() ; ++bucket_i) {
+      stk::mesh::Bucket &cell_bucket = *cell_buckets[bucket_i];
+      for (size_t cell_i=0 ; cell_i<cell_bucket.size() ; ++cell_i) {
+        double * cell_data = stk::mesh::field_data(*cell_vals,cell_bucket.bucket_id(),cell_i);
+        *cell_data = value + 0.5;
+      }
+    }
+  }
+
+TEUCHOS_UNIT_TEST(tExodusRestartAndAppend, Restart)
+{
+  int numprocs = stk::parallel_machine_size(MPI_COMM_WORLD);
+  int rank = stk::parallel_machine_rank(MPI_COMM_WORLD);
+  out << "Running numprocs = " << numprocs << " rank = " << rank << std::endl;
+
+  stk::ParallelMachine pm(MPI_COMM_WORLD);
+  const std::string restart_file = "exodus_restart.exo";
+
+  // Read in mesh and write out some fields for three time steps
+  {
+    STK_ExodusReaderFactory f("meshes/basic.gen");
+    auto mesh = f.buildUncommitedMesh(MPI_COMM_WORLD);
+
+    mesh->addSolutionField(node_field_name,block_name_1);
+    mesh->addSolutionField(node_field_name,block_name_2);
+    mesh->addCellField(cell_field_name,block_name_1);
+    mesh->addCellField(cell_field_name,block_name_2);
+
+    mesh->initialize(pm,true,false);
+
+    f.completeMeshConstruction(*mesh,MPI_COMM_WORLD);
+
+    mesh->setupExodusFile(restart_file);
+    setValues(mesh,0.0);
+    mesh->writeToExodus(0.0);
+    setValues(mesh,1.0);
+    mesh->writeToExodus(1.0);
+    setValues(mesh,2.0);
+    mesh->writeToExodus(2.0);
+  }
+
+  // Restart from mesh and append more time steps using original construction path
+  {
+    STK_ExodusReaderFactory f(restart_file);
+    auto mesh = f.buildUncommitedMesh(MPI_COMM_WORLD);
+    mesh->addSolutionField(node_field_name,block_name_1);
+    mesh->addSolutionField(node_field_name,block_name_2);
+    mesh->addCellField(cell_field_name,block_name_1);
+    mesh->addCellField(cell_field_name,block_name_2);
+    mesh->initialize(pm,true,false);
+    f.completeMeshConstruction(*mesh,MPI_COMM_WORLD);
+
+    bool appendToFile = true;
+    mesh->setupExodusFile(restart_file,appendToFile);
+    setValues(mesh,3.0);
+    mesh->writeToExodus(3.0);
+    setValues(mesh,4.0);
+    mesh->writeToExodus(4.0);
+    setValues(mesh,5.0);
+    mesh->writeToExodus(5.0);
+  }
+
+  // Read the final mesh from scratch and make sure the time steps were appended instead of overwritten
+  {
+    Ioss::DatabaseIO *resultsDb = Ioss::IOFactory::create("exodus", restart_file, Ioss::READ_MODEL, MPI_COMM_WORLD);
+    Ioss::Region results(resultsDb);
+
+    // Number of time steps
+    TEST_EQUALITY(results.get_property("state_count").get_int(),6);
+
+    // First time step value (ioss steps are 1 based)
+    int step = 1;
+    double db_time = results.begin_state(step);
+    TEST_EQUALITY(db_time,0.0);
+    results.end_state(step);
+
+    // Last time step value
+    step = 6;
+    db_time = results.begin_state(step);
+    TEST_EQUALITY(db_time,5.0);
+    results.end_state(step);
+
+    // Nodal field exists
+    Ioss::NodeBlock *nb = results.get_node_blocks()[0];
+    TEST_EQUALITY(nb->field_count(Ioss::Field::TRANSIENT), 1);
+    TEST_ASSERT(nb->field_exists(node_field_name));
+
+    // Cell field exists
+    Ioss::ElementBlock *eb = results.get_element_blocks()[0];
+    TEST_EQUALITY(eb->field_count(Ioss::Field::TRANSIENT), 3);
+    TEST_ASSERT(eb->field_exists(cell_field_name));
+  }
+}
+
+} // namespace panzer_stk
+
+#endif


### PR DESCRIPTION
@trilinos/panzer 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Exodus restarts always created a new file (different name or overwrite). This allows for appending directly to the restart file.

## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
This capability is required for EMPIRE FY20 milestone. Verified with the team that this meets requirements. See EMPIRE issue 1508.

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
New unit tests added to exercise capability:

```
9/13 Test #10: PanzerAdaptersSTK_tExodusRestartAndAppend_MPI_2 ..........   Passed    0.59 sec
```

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->