### PR TITLE
Sacado: Fence review

### DIFF
--- a/packages/sacado/src/KokkosExp_View_Fad.hpp
+++ b/packages/sacado/src/KokkosExp_View_Fad.hpp
@@ -366,7 +366,6 @@ struct SacadoViewFill
       const size_t n0 = output.extent(0);
       Kokkos::RangePolicy<execution_space> policy( 0, n0 );
       Kokkos::parallel_for( policy, *this );
-      execution_space().fence();
     }
 };
 

--- a/packages/sacado/src/KokkosExp_View_Fad_Contiguous.hpp
+++ b/packages/sacado/src/KokkosExp_View_Fad_Contiguous.hpp
@@ -374,7 +374,6 @@ struct SacadoViewFill<
       team_policy policy( (output.extent(0)+team_size-1)/team_size ,
                           team_size , stride );
       Kokkos::parallel_for( policy, *this );
-      execution_space().fence();
     }
 };
 #endif


### PR DESCRIPTION
@etphipp For Tpetra we removed fences after kernels and placed them before the actual UVM reads. Removing these fences will still pass all unit tests with CUDA_LAUNCH_BLOCKING=0. These are the only core fences in Sacado. I am not sure if we want to remove them.
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/sacado 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Removing fences from core code.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Sacado tests on white Cuda 
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->