### PR TITLE
keep TriBITS from double-installing Kokkos header files

### DIFF
--- a/packages/kokkos/cmake/kokkos_tribits.cmake
+++ b/packages/kokkos/cmake/kokkos_tribits.cmake
@@ -361,10 +361,11 @@ FUNCTION(KOKKOS_ADD_LIBRARY LIBRARY_NAME)
   CMAKE_PARSE_ARGUMENTS(PARSE
     "ADD_BUILD_OPTIONS"
     ""
-    ""
+    "HEADERS"
     ${ARGN}
   )
   IF (KOKKOS_HAS_TRILINOS)
+    # Pull out the headers, we will manually install them
     TRIBITS_ADD_LIBRARY(${LIBRARY_NAME} ${PARSE_UNPARSED_ARGUMENTS})
     #Stolen from Tribits - it can add prefixes
     SET(TRIBITS_LIBRARY_NAME_PREFIX "${${PROJECT_NAME}_LIBRARY_NAME_PREFIX}")
@@ -379,8 +380,10 @@ FUNCTION(KOKKOS_ADD_LIBRARY LIBRARY_NAME)
     #Do not set any transitive properties and keep everything working as before
     #KOKKOS_SET_LIBRARY_PROPERTIES(${TRIBITS_LIBRARY_NAME} PLAIN_STYLE)
   ELSE()
+    # Forward the headers, we want to know about all headers
+    # to make sure they appear correctly in IDEs
     KOKKOS_INTERNAL_ADD_LIBRARY(
-      ${LIBRARY_NAME} ${PARSE_UNPARSED_ARGUMENTS})
+      ${LIBRARY_NAME} ${PARSE_UNPARSED_ARGUMENTS} HEADERS ${PARSE_HEADERS})
     IF (PARSE_ADD_BUILD_OPTIONS)
       KOKKOS_SET_LIBRARY_PROPERTIES(${LIBRARY_NAME})
     ENDIF()


### PR DESCRIPTION
Avoids double header installation of Kokkos files through TriBITS

## Related Issues
Addresses header install issue in https://github.com/trilinos/Trilinos/issues/7907

