### PR TITLE
Piro: Add accessors needed for Arctic Coastal Erosion thermomechanical coupling in Albany

### DIFF
--- a/packages/piro/src/Piro_TrapezoidRuleSolver.hpp
+++ b/packages/piro/src/Piro_TrapezoidRuleSolver.hpp
@@ -146,6 +146,8 @@ class TrapezoidRuleSolver
   Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> > get_g_space(int j) const;
   /** \brief . */
   Teuchos::RCP<Piro::NOXSolver<Scalar> > getNOXSolver() const;
+  /** \brief . */
+  Teuchos::RCP<Piro::TrapezoidDecorator<Scalar> > getDecorator() const;
   //@}
 
 private:

--- a/packages/piro/src/Piro_TrapezoidRuleSolver.hpp
+++ b/packages/piro/src/Piro_TrapezoidRuleSolver.hpp
@@ -144,6 +144,8 @@ class TrapezoidRuleSolver
   Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> > get_p_space(int l) const;
   /** \brief . */
   Teuchos::RCP<const Thyra::VectorSpaceBase<Scalar> > get_g_space(int j) const;
+  /** \brief . */
+  Teuchos::RCP<Piro::NOXSolver<Scalar> > getNOXSolver() const;
   //@}
 
 private:

--- a/packages/piro/src/Piro_TrapezoidRuleSolver_Def.hpp
+++ b/packages/piro/src/Piro_TrapezoidRuleSolver_Def.hpp
@@ -406,6 +406,13 @@ Piro::TrapezoidRuleSolver<Scalar>::getValidTrapezoidRuleParameters() const
   return validPL;
 }
 
+template <typename Scalar>
+Teuchos::RCP<Piro::NOXSolver<Scalar> >
+Piro::TrapezoidRuleSolver<Scalar>::getNOXSolver() const
+{
+  return noxSolver;
+}
+
 /****************************************************************************/
 
 template <typename Scalar>

--- a/packages/piro/src/Piro_TrapezoidRuleSolver_Def.hpp
+++ b/packages/piro/src/Piro_TrapezoidRuleSolver_Def.hpp
@@ -413,6 +413,13 @@ Piro::TrapezoidRuleSolver<Scalar>::getNOXSolver() const
   return noxSolver;
 }
 
+template <typename Scalar>
+Teuchos::RCP<Piro::TrapezoidDecorator<Scalar> >
+Piro::TrapezoidRuleSolver<Scalar>::getDecorator() const
+{
+  return model;
+}
+
 /****************************************************************************/
 
 template <typename Scalar>


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/piro

## The Trapezoid Rule Piro Time integrator lacks accessors for velocity, acceleration and solver status needed for thermomechanical coupling in Albany.
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
