### PR TITLE
Framework: PullRequestLinuxDriverMerge.py py2-3 compatibility fix

### DIFF
--- a/cmake/std/PullRequestLinuxDriver.sh
+++ b/cmake/std/PullRequestLinuxDriver.sh
@@ -120,7 +120,7 @@ then
 fi
 
 echo -e "PRDriver> "
-echo -e "PRDriver> Driver and Merge scripts unchaged, proceeding to TEST phase"
+echo -e "PRDriver> Driver and Merge scripts unchanged, proceeding to TEST phase"
 echo -e "PRDriver> "
 
 # Prepare the command for the TEST operation

--- a/cmake/std/PullRequestLinuxDriverMerge.py
+++ b/cmake/std/PullRequestLinuxDriverMerge.py
@@ -91,9 +91,12 @@ def merge_branch(source_url, source_branch, target_branch, sourceSHA):
     sourceSHA     = sourceSHA.strip()
 
     remote_list = subprocess.check_output(['git', 'remote', '-v'])
+    remote_list = remote_list.decode('utf-8')
+
     if 'source_remote' in remote_list:
         print('git remote exists, removing it', file=sys.stdout)
         subprocess.check_call(['git', 'remote', 'rm', 'source_remote'])
+
     subprocess.check_call(['git', 'remote', 'add', 'source_remote', source_url])
 
     fetch_succeeded = False
@@ -104,6 +107,7 @@ def merge_branch(source_url, source_branch, target_branch, sourceSHA):
             break
         except subprocess.CalledProcessError:
             pass
+
     if not fetch_succeeded:
         raise SystemExit(12)
 
@@ -113,7 +117,7 @@ def merge_branch(source_url, source_branch, target_branch, sourceSHA):
     subprocess.check_call(['git', 'merge', '--no-edit', 'source_remote/' + source_branch]),
 
     actual_source_SHA = subprocess.check_output(['git', 'rev-parse', 'source_remote/' + source_branch])
-
+    actual_source_SHA = actual_source_SHA.decode('utf-8')
     actual_source_SHA = actual_source_SHA.strip()
 
     if actual_source_SHA != sourceSHA:

--- a/cmake/std/PullRequestLinuxDriverMerge.py
+++ b/cmake/std/PullRequestLinuxDriverMerge.py
@@ -91,7 +91,9 @@ def merge_branch(source_url, source_branch, target_branch, sourceSHA):
     sourceSHA     = sourceSHA.strip()
 
     remote_list = subprocess.check_output(['git', 'remote', '-v'])
-    remote_list = remote_list.decode('utf-8')
+
+    if isinstance(remote_list, bytes):
+        remote_list = remote_list.decode('utf-8')
 
     if 'source_remote' in remote_list:
         print('git remote exists, removing it', file=sys.stdout)
@@ -117,7 +119,10 @@ def merge_branch(source_url, source_branch, target_branch, sourceSHA):
     subprocess.check_call(['git', 'merge', '--no-edit', 'source_remote/' + source_branch]),
 
     actual_source_SHA = subprocess.check_output(['git', 'rev-parse', 'source_remote/' + source_branch])
-    actual_source_SHA = actual_source_SHA.decode('utf-8')
+
+    if isinstance(actual_source_SHA, bytes):
+        actual_source_SHA = actual_source_SHA.decode('utf-8')
+
     actual_source_SHA = actual_source_SHA.strip()
 
     if actual_source_SHA != sourceSHA:


### PR DESCRIPTION
@trilinos/framework 
@prwolfe 
@jwillenbring 

## Motivation
The calls to `subprocess.check_output()` in the Merge script do not return the same thing in python2 and python3 in this code:

https://github.com/trilinos/Trilinos/blob/6761d1a2013f02edd5dfbefbb3c7f2f1e7c62d9e/cmake/std/PullRequestLinuxDriverMerge.py#L93-L94

In python2 the output is a string object and the comparison in line 94 is valid, but in Python3 the type of `remote_list` will be a `bytes` object which throws a `TypeError` in the comparison in line 94.

The easiest way I know of to fix this that is both Python2 and 3 compatible is to `decode` the output from the `check_output()` call into a utf-8 object by adding `remote_list = remote_list.decode('utf-8')`. This will convert the `bytes` object into a `unicode` object in Python2 and a `str` object in Python3, which works with the string-comparison for both versions.

## Testing
For Example:

In this Python2 log:
```python
$ python2
Python 2.7.9 (default, Feb 14 2020, 08:39:29)
[GCC 4.8.5 20150623 (Red Hat 4.8.5-39)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import subprocess
>>> output = subprocess.check_output(['ls'])
>>> type(output)
<type 'str'>
>>> 'README' in output
True
>>> output = output.decode('utf-8')
>>> type(output)
<type 'unicode'>
>>> 'README' in output
True
>>>
```
The output is returned as a 'str' object and when we decode it it becomes a 'unicode' object but both can be string compared.

In Python3:
```python
$ python3
Python 3.5.2 (default, Feb 12 2020, 14:58:46)
[GCC 4.8.5 20150623 (Red Hat 4.8.5-39)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import subprocess
>>> output = subprocess.check_output(['ls'])
>>> type(output)
<class 'bytes'>
>>> 'README' in output
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: a bytes-like object is required, not 'str'
>>> output = output.decode('utf-8')
>>> 'README' in output
True
>>> type(output)
<class 'str'>
```
The output to `subprocess.check_output()` is a `bytes` object which will cause a `TypeError` if it's compared directly to a string, but decoding it converts it to a `str` object which is comparable.



