### PR TITLE
Intrepid2: enable interpolation with DerivedNodalBasis

### DIFF
--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasisFamily.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasisFamily.hpp
@@ -107,9 +107,15 @@ namespace Intrepid2
     
     // triangle bases
     using HGRAD_TRI = typename TriangleBasisFamily::HGRAD;
+    using HCURL_TRI = typename TriangleBasisFamily::HCURL;
+    using HDIV_TRI = typename TriangleBasisFamily::HDIV;
+    using HVOL_TRI = typename TriangleBasisFamily::HVOL;
     
     // tetrahedron bases
     using HGRAD_TET = typename TetrahedronBasisFamily::HGRAD;
+    using HCURL_TET = typename TetrahedronBasisFamily::HCURL;
+    using HDIV_TET = typename TetrahedronBasisFamily::HDIV;
+    using HVOL_TET = typename TetrahedronBasisFamily::HVOL;
   };
   
   /** \brief  Factory method for line bases in the given family.
@@ -218,9 +224,10 @@ namespace Intrepid2
     using Teuchos::rcp;
     switch (fs)
     {
-//      case FUNCTION_SPACE_HVOL:  return rcp(new typename BasisFamily::HVOL_TET (polyOrder));
-//      case FUNCTION_SPACE_HCURL: return rcp(new typename BasisFamily::HCURL_TET(polyOrder));
-//      case FUNCTION_SPACE_HDIV:  return rcp(new typename BasisFamily::HDIV_TET (polyOrder));
+      //Note: only HGRAD is available for Hierarchical basis at the moment
+      case FUNCTION_SPACE_HVOL:  return rcp(new typename BasisFamily::HVOL_TET (polyOrder));
+      case FUNCTION_SPACE_HCURL: return rcp(new typename BasisFamily::HCURL_TET(polyOrder));
+      case FUNCTION_SPACE_HDIV:  return rcp(new typename BasisFamily::HDIV_TET (polyOrder));
       case FUNCTION_SPACE_HGRAD: return rcp(new typename BasisFamily::HGRAD_TET(polyOrder));
       default:
         INTREPID2_TEST_FOR_EXCEPTION(true, std::invalid_argument, "Unsupported function space");
@@ -237,9 +244,10 @@ namespace Intrepid2
     using Teuchos::rcp;
     switch (fs)
     {
-//      case FUNCTION_SPACE_HVOL:  return rcp(new typename BasisFamily::HVOL_TRI (polyOrder));
-//      case FUNCTION_SPACE_HCURL: return rcp(new typename BasisFamily::HCURL_TRI(polyOrder));
-//      case FUNCTION_SPACE_HDIV:  return rcp(new typename BasisFamily::HDIV_TRI (polyOrder));
+      //Note: only HGRAD is available for Hierarchical basis at the moment
+      case FUNCTION_SPACE_HVOL:  return rcp(new typename BasisFamily::HVOL_TRI (polyOrder));
+      case FUNCTION_SPACE_HCURL: return rcp(new typename BasisFamily::HCURL_TRI(polyOrder));
+      case FUNCTION_SPACE_HDIV:  return rcp(new typename BasisFamily::HDIV_TRI (polyOrder));
       case FUNCTION_SPACE_HGRAD: return rcp(new typename BasisFamily::HGRAD_TRI(polyOrder));
       default:
         INTREPID2_TEST_FOR_EXCEPTION(true, std::invalid_argument, "Unsupported function space");

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HCURL_HEX.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HCURL_HEX.hpp
@@ -162,6 +162,24 @@ namespace Intrepid2
         INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"operator not yet supported");
       }
     }
+
+    /** \brief  Fills in coefficients of degrees of freedom for Lagrangian basis on the reference cell
+        \param [out] dofCoeffs - the container into which to place the degrees of freedom.
+
+     dofCoeffs have shape (F,D), field dimension matches the cardinality of the basis, and D is the
+     basis dimension.
+
+     Degrees of freedom coefficients are such that
+     \phi_i(dofCoords_(j)) \cdot dofCoeffs_(j)  = \delta_ij,
+     where \phi_i are the basis and \delta_ij the Kronecker delta.
+     Note that getDofCoeffs() is supported only for Lagrangian bases.
+     */
+    virtual void getDofCoeffs( ScalarViewType dofCoeffs ) const {
+      auto dofCoeffs1 = Kokkos::subview(dofCoeffs,Kokkos::ALL(),0);
+      auto dofCoeffs23 = Kokkos::subview(dofCoeffs,Kokkos::ALL(),std::make_pair(1,3));
+      this->TensorBasis3::getDofCoeffs(dofCoeffs1);
+      Kokkos::deep_copy(dofCoeffs23,0.0);
+    }
   };
 
   template<class HGRAD_LINE, class HVOL_LINE>
@@ -266,6 +284,28 @@ namespace Intrepid2
         INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"operator not yet supported");
       }
     }
+
+    /** \brief  Fills in coefficients of degrees of freedom for Lagrangian basis on the reference cell
+        \param [out] dofCoeffs - the container into which to place the degrees of freedom.
+
+     dofCoeffs have shape (F,D), field dimension matches the cardinality of the basis, and D is the
+     basis dimension.
+
+     Degrees of freedom coefficients are such that
+     \phi_i(dofCoords_(j)) \cdot dofCoeffs_(j)  = \delta_ij,
+     where \phi_i are the basis and \delta_ij the Kronecker delta.
+     Note that getDofCoeffs() is supported only for Lagrangian bases.
+     */
+    virtual void getDofCoeffs( ScalarViewType dofCoeffs ) const {
+      auto dofCoeffs1 = Kokkos::subview(dofCoeffs,Kokkos::ALL(),0);
+      auto dofCoeffs2 = Kokkos::subview(dofCoeffs,Kokkos::ALL(),1);
+      auto dofCoeffs3 = Kokkos::subview(dofCoeffs,Kokkos::ALL(),2);
+      Kokkos::deep_copy(dofCoeffs1,0.0);
+      this->TensorBasis3::getDofCoeffs(dofCoeffs2);
+      Kokkos::deep_copy(dofCoeffs3,0.0);
+    }
+
+
   };
   
   template<class HGRAD_LINE, class HVOL_LINE>
@@ -362,6 +402,24 @@ namespace Intrepid2
       {
         INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"operator not yet supported");
       }
+    }
+
+    /** \brief  Fills in coefficients of degrees of freedom for Lagrangian basis on the reference cell
+        \param [out] dofCoeffs - the container into which to place the degrees of freedom.
+
+     dofCoeffs have shape (F,D) field dimension matches the cardinality of the basis, and D is the
+     basis dimension.
+
+     Degrees of freedom coefficients are such that
+     \phi_i(dofCoords_(j)) \cdot dofCoeffs_(j)  = \delta_ij,
+     where \phi_i are the basis and \delta_ij the Kronecker delta.
+     Note that getDofCoeffs() is supported only for Lagrangian bases.
+     */
+    virtual void getDofCoeffs( ScalarViewType dofCoeffs ) const {
+      auto dofCoeffs12 = Kokkos::subview(dofCoeffs,Kokkos::ALL(),std::make_pair(0,2));
+      auto dofCoeffs3 = Kokkos::subview(dofCoeffs,Kokkos::ALL(),2);
+      Kokkos::deep_copy(dofCoeffs12,0.0);
+      this->TensorBasis3::getDofCoeffs(dofCoeffs3);
     }
   };
   

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HCURL_QUAD.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HCURL_QUAD.hpp
@@ -139,6 +139,24 @@ namespace Intrepid2
         INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"operator not yet supported");
       }
     }
+
+    /** \brief  Fills in coefficients of degrees of freedom for Lagrangian basis on the reference cell
+        \param [out] dofCoeffs - the container into which to place the degrees of freedom.
+
+     dofCoeffs have shape (F,D), field dimension matches the cardinality of the basis, and D is the
+     basis dimension.
+
+     Degrees of freedom coefficients are such that
+     \phi_i(dofCoords_(j)) \cdot dofCoeffs_(j)  = \delta_ij,
+     where \phi_i are the basis and \delta_ij the Kronecker delta.
+     Note that getDofCoeffs() is supported only for Lagrangian bases.
+     */
+    virtual void getDofCoeffs( ScalarViewType dofCoeffs ) const {
+      auto dofCoeffs1 = Kokkos::subview(dofCoeffs,Kokkos::ALL(),0);
+      auto dofCoeffs2 = Kokkos::subview(dofCoeffs,Kokkos::ALL(),1);
+      this->TensorBasis::getDofCoeffs(dofCoeffs1);
+      Kokkos::deep_copy(dofCoeffs2,0.0);
+    }
   };
 
   template<class HGRAD_LINE, class HVOL_LINE>
@@ -216,6 +234,24 @@ namespace Intrepid2
       {
         INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"operator not yet supported");
       }
+    }
+
+    /** \brief  Fills in coefficients of degrees of freedom for Lagrangian basis on the reference cell
+        \param [out] dofCoeffs - the container into which to place the degrees of freedom.
+
+     dofCoeffs have shape (F,D), field dimension matches the cardinality of the basis, and D is the
+     basis dimension.
+
+     Degrees of freedom coefficients are such that
+     \phi_i(dofCoords_(j)) \cdot dofCoeffs_(j)  = \delta_ij,
+     where \phi_i are the basis and \delta_ij the Kronecker delta.
+     Note that getDofCoeffs() is supported only for Lagrangian bases.
+     */
+    virtual void getDofCoeffs( ScalarViewType dofCoeffs ) const {
+      auto dofCoeffs1 = Kokkos::subview(dofCoeffs,Kokkos::ALL(),0);
+      auto dofCoeffs2 = Kokkos::subview(dofCoeffs,Kokkos::ALL(),1);
+      Kokkos::deep_copy(dofCoeffs1,0.0);
+      this->TensorBasis::getDofCoeffs(dofCoeffs2);
     }
   };
   

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HDIV_HEX.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HDIV_HEX.hpp
@@ -148,6 +148,24 @@ namespace Intrepid2
         INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"operator not yet supported");
       }
     }
+
+    /** \brief  Fills in coefficients of degrees of freedom for Lagrangian basis on the reference cell
+        \param [out] dofCoeffs - the container into which to place the degrees of freedom.
+
+     dofCoeffs have shape (F,D), field dimension matches the cardinality of the basis, and D is the
+     basis dimension.
+
+     Degrees of freedom coefficients are such that
+     \phi_i(dofCoords_(j)) \cdot dofCoeffs_(j)  = \delta_ij,
+     where \phi_i are the basis and \delta_ij the Kronecker delta.
+     Note that getDofCoeffs() is supported only for Lagrangian bases.
+     */
+    virtual void getDofCoeffs( ScalarViewType dofCoeffs ) const {
+      auto dofCoeffs1 = Kokkos::subview(dofCoeffs,Kokkos::ALL(),0);
+      auto dofCoeffs23 = Kokkos::subview(dofCoeffs,Kokkos::ALL(),std::make_pair(1,3));
+      this->TensorBasis3::getDofCoeffs(dofCoeffs1);
+      Kokkos::deep_copy(dofCoeffs23,0.0);
+    }
   };
 
   template<class HGRAD_LINE, class HVOL_LINE>
@@ -238,6 +256,26 @@ namespace Intrepid2
         INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"operator not yet supported");
       }
     }
+
+    /** \brief  Fills in coefficients of degrees of freedom for Lagrangian basis on the reference cell
+        \param [out] dofCoeffs - the container into which to place the degrees of freedom.
+
+     dofCoeffs have shape (F,D), field dimension matches the cardinality of the basis, and D is the
+     basis dimension.
+
+     Degrees of freedom coefficients are such that
+     \phi_i(dofCoords_(j)) \cdot dofCoeffs_(j)  = \delta_ij,
+     where \phi_i are the basis and \delta_ij the Kronecker delta.
+     Note that getDofCoeffs() is supported only for Lagrangian bases.
+     */
+    virtual void getDofCoeffs( ScalarViewType dofCoeffs ) const {
+      auto dofCoeffs1 = Kokkos::subview(dofCoeffs,Kokkos::ALL(),0);
+      auto dofCoeffs2 = Kokkos::subview(dofCoeffs,Kokkos::ALL(),1);
+      auto dofCoeffs3 = Kokkos::subview(dofCoeffs,Kokkos::ALL(),2);
+      Kokkos::deep_copy(dofCoeffs1,0.0);
+      this->TensorBasis3::getDofCoeffs(dofCoeffs2);
+      Kokkos::deep_copy(dofCoeffs3,0.0);
+    }
   };
   
   template<class HGRAD_LINE, class HVOL_LINE>
@@ -322,6 +360,25 @@ namespace Intrepid2
         INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"operator not yet supported");
       }
     }
+
+    /** \brief  Fills in coefficients of degrees of freedom for Lagrangian basis on the reference cell
+        \param [out] dofCoeffs - the container into which to place the degrees of freedom.
+
+     dofCoeffs have shape (F,D), field dimension matches the cardinality of the basis, and D is the
+     basis dimension.
+
+     Degrees of freedom coefficients are such that
+     \phi_i(dofCoords_(j)) \cdot dofCoeffs_(j)  = \delta_ij,
+     where \phi_i are the basis and \delta_ij the Kronecker delta.
+     Note that getDofCoeffs() is supported only for Lagrangian bases.
+     */
+    virtual void getDofCoeffs( ScalarViewType dofCoeffs ) const {
+      auto dofCoeffs12 = Kokkos::subview(dofCoeffs,Kokkos::ALL(),std::make_pair(0,2));
+      auto dofCoeffs3 = Kokkos::subview(dofCoeffs,Kokkos::ALL(),2);
+      Kokkos::deep_copy(dofCoeffs12,0.0);
+      this->TensorBasis3::getDofCoeffs(dofCoeffs3);
+    }
+
   };
   
   // ESEAS numbers its H(div) families differently, with the nonzero going in z, x, y for I,II,III.

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HDIV_QUAD.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DerivedBasis_HDIV_QUAD.hpp
@@ -138,6 +138,29 @@ namespace Intrepid2
         INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"operator not yet supported");
       }
     }
+
+    /** \brief  Fills in coefficients of degrees of freedom for Lagrangian basis on the reference cell
+        \param [out] dofCoeffs - the container into which to place the degrees of freedom.
+
+     dofCoeffs have shape (F,D), field dimension matches the cardinality of the basis, and D is the
+     basis dimension.
+
+     Degrees of freedom coefficients are such that
+     \phi_i(dofCoords_(j)) \cdot dofCoeffs_(j)  = \delta_ij,
+     where \phi_i are the basis and \delta_ij the Kronecker delta.
+     Note that getDofCoeffs() is supported only for Lagrangian bases.
+     */
+    virtual void getDofCoeffs( ScalarViewType dofCoeffs ) const {
+      auto dofCoeffs1 = Kokkos::subview(dofCoeffs,Kokkos::ALL(),0);
+      auto dofCoeffs2 = Kokkos::subview(dofCoeffs,Kokkos::ALL(),1);
+      Kokkos::deep_copy(dofCoeffs1,0.0);
+      this->TensorBasis::getDofCoeffs(dofCoeffs2);
+      //multiply by weight = -1.0
+      using ExecutionSpace = typename TensorBasis::ExecutionSpace;
+      Kokkos::parallel_for( Kokkos::RangePolicy<ExecutionSpace>(0, dofCoeffs2.extent(0)),
+          KOKKOS_LAMBDA (const int i){ dofCoeffs2(i) *= -1.0; });
+    }
+
   };
 
   template<class HGRAD_LINE, class HVOL_LINE>
@@ -210,6 +233,25 @@ namespace Intrepid2
         INTREPID2_TEST_FOR_EXCEPTION(true,std::invalid_argument,"operator not yet supported");
       }
     }
+
+    /** \brief  Fills in coefficients of degrees of freedom for Lagrangian basis on the reference cell
+        \param [out] dofCoeffs - the container into which to place the degrees of freedom.
+
+     dofCoeffs have shape (F,D), field dimension matches the cardinality of the basis, and D is the
+     basis dimension.
+
+     Degrees of freedom coefficients are such that
+     \phi_i(dofCoords_(j)) \cdot dofCoeffs_(j)  = \delta_ij,
+     where \phi_i are the basis and \delta_ij the Kronecker delta.
+     Note that getDofCoeffs() is supported only for Lagrangian bases.
+     */
+    virtual void getDofCoeffs( ScalarViewType dofCoeffs ) const {
+      auto dofCoeffs1 = Kokkos::subview(dofCoeffs,Kokkos::ALL(),0);
+      auto dofCoeffs2 = Kokkos::subview(dofCoeffs,Kokkos::ALL(),1);
+      this->TensorBasis::getDofCoeffs(dofCoeffs1);
+      Kokkos::deep_copy(dofCoeffs2,0.0);
+    }
+
   };
   
   template<class HGRAD_LINE, class HVOL_LINE>

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_DirectSumBasis.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_DirectSumBasis.hpp
@@ -222,6 +222,30 @@ namespace Intrepid2
       basis2_.getDofCoords(dofCoords2);
     }
     
+    /** \brief  Fills in coefficients of degrees of freedom for Lagrangian basis on the reference cell
+        \param [out] dofCoeffs - the container into which to place the degrees of freedom.
+
+     dofCoeffs have shape (F,D) or (F) if D=1, field dimension matches the cardinality of the basis, and D is the
+     basis dimension.
+
+     Degrees of freedom coefficients are such that
+     \phi_i(dofCoords_(j)) \cdot dofCoeffs_(j)  = \delta_ij,
+     where \phi_i are the basis and \delta_ij the Kronecker delta.
+     Note that getDofCoeffs() is supported only for Lagrangian bases.
+     */
+    virtual void getDofCoeffs( ScalarViewType dofCoeffs ) const override {
+      const int basisCardinality1 = basis1_.getCardinality();
+      const int basisCardinality2 = basis2_.getCardinality();
+      const int basisCardinality  = basisCardinality1 + basisCardinality2;
+
+      auto dofCoeffs1 = Kokkos::subview(dofCoeffs, std::make_pair(0,basisCardinality1), Kokkos::ALL());
+      auto dofCoeffs2 = Kokkos::subview(dofCoeffs, std::make_pair(basisCardinality1,basisCardinality), Kokkos::ALL());
+
+      basis1_.getDofCoeffs(dofCoeffs1);
+      basis2_.getDofCoeffs(dofCoeffs2);
+    }
+
+
     /** \brief  Returns basis name
      
      \return the name of the basis

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_HierarchicalBasisFamily.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_HierarchicalBasisFamily.hpp
@@ -57,9 +57,18 @@
 #include "Intrepid2_LegendreBasis_HVOL_LINE.hpp"
 
 namespace Intrepid2 {
-  // the following defines a family of hierarchical basis functions that matches the unpermuted ESEAS basis functions
-  // each basis member is associated with appropriate subcell topologies, making this suitable for continuous Galerkin finite elements.
   
+
+//Dummy basis to be temporarily used for Hierarchical bases that have not been implemented yet
+  template<typename ExecutionSpace, typename OutputScalar, typename PointScalar>
+  class dummyBasis
+  : public Basis<ExecutionSpace,OutputScalar,PointScalar> {
+  public:
+    dummyBasis(int /*order*/) {};
+  };
+
+// the following defines a family of hierarchical basis functions that matches the unpermuted ESEAS basis functions
+// each basis member is associated with appropriate subcell topologies, making this suitable for continuous Galerkin finite elements.
   template<typename ExecutionSpace=Kokkos::DefaultExecutionSpace,
            typename OutputScalar = double,
            typename PointScalar  = double,
@@ -69,9 +78,9 @@ namespace Intrepid2 {
   public:
     // we will fill these in as we implement them
     using HGRAD = IntegratedLegendreBasis_HGRAD_TRI<ExecutionSpace,OutputScalar,PointScalar,defineVertexFunctions>;
-    using HCURL = void;
-    using HDIV  = void;
-    using HVOL  = void;
+    using HCURL = dummyBasis<ExecutionSpace,OutputScalar,PointScalar>;
+    using HDIV  = dummyBasis<ExecutionSpace,OutputScalar,PointScalar>;
+    using HVOL  = dummyBasis<ExecutionSpace,OutputScalar,PointScalar>;
   };
   
   template<typename ExecutionSpace=Kokkos::DefaultExecutionSpace,
@@ -83,9 +92,9 @@ namespace Intrepid2 {
   public:
     // we will fill these in as we implement them
     using HGRAD = IntegratedLegendreBasis_HGRAD_TET<ExecutionSpace,OutputScalar,PointScalar,defineVertexFunctions>;
-    using HCURL = void;
-    using HDIV  = void;
-    using HVOL  = void;
+    using HCURL = dummyBasis<ExecutionSpace,OutputScalar,PointScalar>;
+    using HDIV  = dummyBasis<ExecutionSpace,OutputScalar,PointScalar>;
+    using HVOL  = dummyBasis<ExecutionSpace,OutputScalar,PointScalar>;
   };
   
   /** \class Intrepid2::HierarchicalBasisFamily

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_NodalBasisFamily.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_NodalBasisFamily.hpp
@@ -75,6 +75,36 @@
 #include <Intrepid2_HVOL_TET_Cn_FEM.hpp>
 
 namespace Intrepid2 {
+
+  // the following defines a family of nodal basis functions for the reference Triangle
+  template<typename ExecutionSpace=Kokkos::DefaultExecutionSpace,
+           typename OutputScalar = double,
+           typename PointScalar  = double,
+           bool defineVertexFunctions = true>
+  class NodalTriangleBasisFamily
+  {
+  public:
+    using HGRAD = Basis_HGRAD_TRI_Cn_FEM<ExecutionSpace,OutputScalar,PointScalar>;
+    using HCURL = Basis_HCURL_TRI_In_FEM<ExecutionSpace,OutputScalar,PointScalar>;
+    using HDIV  = Basis_HDIV_TRI_In_FEM<ExecutionSpace,OutputScalar,PointScalar>;
+    using HVOL  = Basis_HVOL_TRI_Cn_FEM<ExecutionSpace,OutputScalar,PointScalar>;
+  };
+
+  // the following defines a family of nodal basis functions for the reference Tetrahedron
+  template<typename ExecutionSpace=Kokkos::DefaultExecutionSpace,
+  typename OutputScalar = double,
+  typename PointScalar  = double,
+  bool defineVertexFunctions = true>
+  class NodalTetrahedronBasisFamily
+  {
+  public:
+    using HGRAD = Basis_HGRAD_TET_Cn_FEM<ExecutionSpace,OutputScalar,PointScalar>;
+    using HCURL = Basis_HCURL_TET_In_FEM<ExecutionSpace,OutputScalar,PointScalar>;
+    using HDIV  = Basis_HDIV_TET_In_FEM<ExecutionSpace,OutputScalar,PointScalar>;
+    using HVOL  = Basis_HVOL_TET_Cn_FEM<ExecutionSpace,OutputScalar,PointScalar>;
+  };
+
+
   // the following defines a family of nodal basis functions, derived from a the standard high-order Intrepid2 bases on the line
   // note that because the standard H(curl) basis uses a lower-order H(grad) basis in place of the H(vol) that is arguably more natural,
   // the following will *not* match the standard nodal basis declared below.  (Similarly for H(div).)
@@ -90,14 +120,14 @@ namespace Intrepid2 {
            typename OutputScalar = double,
            typename PointScalar  = double>
   using DerivedNodalBasisFamily = DerivedBasisFamily< Basis_HGRAD_LINE_Cn_FEM<ExecutionSpace,OutputScalar,PointScalar>,
-                                                      Basis_HVOL_LINE_Cn_FEM <ExecutionSpace,OutputScalar,PointScalar> >;
+                                                      Basis_HVOL_LINE_Cn_FEM<ExecutionSpace,OutputScalar,PointScalar>,
+                                                      NodalTriangleBasisFamily<ExecutionSpace,OutputScalar,PointScalar>,
+                                                      NodalTetrahedronBasisFamily<ExecutionSpace,OutputScalar,PointScalar> >;
   
   /** \class Intrepid2::NodalBasisFamily
       \brief A family of nodal basis functions representing the higher-order Lagrangian basis family that Intrepid2 has historically supported.
    
    This family is defined with reference to the higher-order implementations (the "Cn" and "In" bases).
-   
-   At present, only hypercube topologies (line, quadrilateral, hexahedron) are supported, but other topologies will be supported in the future.
   */
   template<typename ExecSpace=Kokkos::DefaultExecutionSpace,
            typename OutputScalar = double,

--- a/packages/intrepid2/src/Discretization/Basis/Intrepid2_TensorBasis.hpp
+++ b/packages/intrepid2/src/Discretization/Basis/Intrepid2_TensorBasis.hpp
@@ -527,32 +527,69 @@ namespace Intrepid2
       using DeviceType   = typename BasisSuper::ScalarViewType::device_type;
       using ViewType     = Kokkos::DynRankView<ValueType, ResultLayout, DeviceType >;
       
-      ViewType dofCoords1("dofCoords1",basis1_.getCardinality(),spaceDim1);
-      ViewType dofCoords2("dofCoords2",basis2_.getCardinality(),spaceDim2);
+      const ordinal_type basisCardinality1 = basis1_.getCardinality();
+      const ordinal_type basisCardinality2 = basis2_.getCardinality();
+
+      ViewType dofCoords1("dofCoords1",basisCardinality1,spaceDim1);
+      ViewType dofCoords2("dofCoords2",basisCardinality2,spaceDim2);
       
       basis1_.getDofCoords(dofCoords1);
       basis2_.getDofCoords(dofCoords2);
       
-      const ordinal_type basisCardinality1 = basis1_.getCardinality();
-      const ordinal_type basisCardinality2 = basis2_.getCardinality();
-      
-      Kokkos::parallel_for(basisCardinality2, KOKKOS_LAMBDA (const int fieldOrdinal2)
-                           {
-                             for (int fieldOrdinal1=0; fieldOrdinal1<basisCardinality1; fieldOrdinal1++)
-                             {
-                               const ordinal_type fieldOrdinal = fieldOrdinal1 + fieldOrdinal2 * basisCardinality1;
-                               for (int d1=0; d1<spaceDim1; d1++)
-                               {
-                                 dofCoords(fieldOrdinal,d1) = dofCoords1(fieldOrdinal1,d1);
-                               }
-                               for (int d2=0; d2<spaceDim2; d2++)
-                               {
-                                 dofCoords(fieldOrdinal,spaceDim1+d2) = dofCoords2(fieldOrdinal2,d2);
-                               }
-                             }
-                           });
+      Kokkos::RangePolicy<ExecutionSpace> policy(0, basisCardinality2);
+      Kokkos::parallel_for(policy, KOKKOS_LAMBDA (const int fieldOrdinal2)
+       {
+         for (int fieldOrdinal1=0; fieldOrdinal1<basisCardinality1; fieldOrdinal1++)
+         {
+           const ordinal_type fieldOrdinal = fieldOrdinal1 + fieldOrdinal2 * basisCardinality1;
+           for (int d1=0; d1<spaceDim1; d1++)
+           {
+             dofCoords(fieldOrdinal,d1) = dofCoords1(fieldOrdinal1,d1);
+           }
+           for (int d2=0; d2<spaceDim2; d2++)
+           {
+             dofCoords(fieldOrdinal,spaceDim1+d2) = dofCoords2(fieldOrdinal2,d2);
+           }
+         }
+       });
     }
     
+
+    /** \brief  Fills in coefficients of degrees of freedom on the reference cell
+        \param [out] dofCoeffs - the container into which to place the degrees of freedom.
+
+     dofCoeffs is a rank 1 with dimension equal to the cardinality of the basis.
+
+     Note that getDofCoeffs() is not supported by all bases; in particular, hierarchical bases do not generally support this.
+     */
+    virtual void getDofCoeffs( typename BasisSuper::ScalarViewType dofCoeffs ) const override
+    {
+      using ValueType    = typename BasisSuper::ScalarViewType::value_type;
+      using ResultLayout = typename DeduceLayout< typename BasisSuper::ScalarViewType >::result_layout;
+      using DeviceType   = typename BasisSuper::ScalarViewType::device_type;
+      using ViewType     = Kokkos::DynRankView<ValueType, ResultLayout, DeviceType >;
+
+      ViewType dofCoeffs1("dofCoeffs1",basis1_.getCardinality());
+      ViewType dofCoeffs2("dofCoeffs2",basis2_.getCardinality());
+
+      basis1_.getDofCoeffs(dofCoeffs1);
+      basis2_.getDofCoeffs(dofCoeffs2);
+
+      const ordinal_type basisCardinality1 = basis1_.getCardinality();
+      const ordinal_type basisCardinality2 = basis2_.getCardinality();
+
+      Kokkos::RangePolicy<ExecutionSpace> policy(0, basisCardinality2);
+      Kokkos::parallel_for(policy, KOKKOS_LAMBDA (const int fieldOrdinal2)
+       {
+         for (int fieldOrdinal1=0; fieldOrdinal1<basisCardinality1; fieldOrdinal1++)
+         {
+           const ordinal_type fieldOrdinal = fieldOrdinal1 + fieldOrdinal2 * basisCardinality1;
+           dofCoeffs(fieldOrdinal) = dofCoeffs1(fieldOrdinal1);
+           dofCoeffs(fieldOrdinal) = dofCoeffs2(fieldOrdinal2);
+         }
+       });
+    }
+
     /** \brief  Returns basis name
      
      \return the name of the basis

--- a/packages/intrepid2/unit-test/Orientation/test_orientation_HEX_newBasis.hpp
+++ b/packages/intrepid2/unit-test/Orientation/test_orientation_HEX_newBasis.hpp
@@ -518,6 +518,7 @@ int OrientationHexNewBasis(const bool verbose) {
         }
 
         using CG_NBasis = NodalBasisFamily<DeviceSpaceType,ValueType,ValueType>;
+        using CG_DNBasis = DerivedNodalBasisFamily<DeviceSpaceType,ValueType,ValueType>;
         using CG_HBasis = HierarchicalBasisFamily<DeviceSpaceType,ValueType,ValueType>;
         std::vector<basisType*> basis_set;
 
@@ -557,6 +558,7 @@ int OrientationHexNewBasis(const bool verbose) {
           }
 
           basis_set.push_back(new typename  CG_NBasis::HGRAD_HEX(order));
+          basis_set.push_back(new typename  CG_DNBasis::HGRAD_HEX(order));
           basis_set.push_back(new typename  CG_HBasis::HGRAD_HEX(order));
 
           for (auto basisPtr:basis_set) {
@@ -615,6 +617,7 @@ int OrientationHexNewBasis(const bool verbose) {
 
           basis_set.clear();
           basis_set.push_back(new typename  CG_NBasis::HCURL_HEX(order));
+          basis_set.push_back(new typename  CG_DNBasis::HCURL_HEX(order));
           basis_set.push_back(new typename  CG_HBasis::HCURL_HEX(order));
 
           for (auto basisPtr:basis_set) {
@@ -680,6 +683,7 @@ int OrientationHexNewBasis(const bool verbose) {
           }
           basis_set.clear();
           basis_set.push_back(new typename  CG_NBasis::HDIV_HEX(order));
+          basis_set.push_back(new typename  CG_DNBasis::HDIV_HEX(order));
           basis_set.push_back(new typename  CG_HBasis::HDIV_HEX(order));
 
           for (auto basisPtr:basis_set) {

--- a/packages/intrepid2/unit-test/Orientation/test_orientation_QUAD_newBasis.hpp
+++ b/packages/intrepid2/unit-test/Orientation/test_orientation_QUAD_newBasis.hpp
@@ -468,6 +468,7 @@ int OrientationQuadNewBasis(const bool verbose) {
         }
 
         using CG_NBasis = NodalBasisFamily<DeviceSpaceType,ValueType,ValueType>;
+        using CG_DNBasis = DerivedNodalBasisFamily<DeviceSpaceType,ValueType,ValueType>;
         using CG_HBasis = HierarchicalBasisFamily<DeviceSpaceType,ValueType,ValueType>;
         std::vector<basisType*> basis_set;
 
@@ -506,6 +507,7 @@ int OrientationQuadNewBasis(const bool verbose) {
           }
 
           basis_set.push_back(new typename  CG_NBasis::HGRAD_QUAD(order));
+          basis_set.push_back(new typename  CG_DNBasis::HGRAD_QUAD(order));
           basis_set.push_back(new typename  CG_HBasis::HGRAD_QUAD(order));
 
           for (auto basisPtr:basis_set) {
@@ -564,6 +566,7 @@ int OrientationQuadNewBasis(const bool verbose) {
 
           basis_set.clear();
           basis_set.push_back(new typename  CG_NBasis::HCURL_QUAD(order));
+          basis_set.push_back(new typename  CG_DNBasis::HCURL_QUAD(order));
           basis_set.push_back(new typename  CG_HBasis::HCURL_QUAD(order));
 
           for (auto basisPtr:basis_set) {
@@ -629,6 +632,7 @@ int OrientationQuadNewBasis(const bool verbose) {
           }
           basis_set.clear();
           basis_set.push_back(new typename  CG_NBasis::HDIV_QUAD(order));
+          basis_set.push_back(new typename  CG_DNBasis::HDIV_QUAD(order));
           basis_set.push_back(new typename  CG_HBasis::HDIV_QUAD(order));
 
           for (auto basisPtr:basis_set) {

--- a/packages/intrepid2/unit-test/Projection/test_convergence_HEX.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_convergence_HEX.hpp
@@ -370,8 +370,8 @@ int ConvergenceHex(const bool verbose) {
 
     using basisType = Basis<DeviceSpaceType,ValueType,ValueType>;
     using CG_NBasis = NodalBasisFamily<DeviceSpaceType,ValueType,ValueType>;
+    using CG_DNBasis = DerivedNodalBasisFamily<DeviceSpaceType,ValueType,ValueType>;
     using CG_HBasis = HierarchicalBasisFamily<DeviceSpaceType,ValueType,ValueType>;
-    //using CG_DNBasis = DerivedNodalBasisFamily<DeviceSpaceType,ValueType,ValueType>;
 
 
     *outStream
@@ -392,6 +392,7 @@ int ConvergenceHex(const bool verbose) {
 
       std::vector<basisType*> basis_set;
       basis_set.push_back(new typename  CG_NBasis::HGRAD_HEX(order));
+      basis_set.push_back(new typename  CG_DNBasis::HGRAD_HEX(order));
       basis_set.push_back(new typename  CG_HBasis::HGRAD_HEX(order));
 
       for (auto basisPtr:basis_set) {
@@ -598,6 +599,7 @@ int ConvergenceHex(const bool verbose) {
 
       std::vector<basisType*> basis_set;
       basis_set.push_back(new typename  CG_NBasis::HCURL_HEX(order));
+      basis_set.push_back(new typename  CG_DNBasis::HCURL_HEX(order));
       basis_set.push_back(new typename  CG_HBasis::HCURL_HEX(order));
 
       for (auto basisPtr:basis_set) {
@@ -818,6 +820,7 @@ int ConvergenceHex(const bool verbose) {
 
       std::vector<basisType*> basis_set;
       basis_set.push_back(new typename  CG_NBasis::HDIV_HEX(order));
+      basis_set.push_back(new typename  CG_DNBasis::HDIV_HEX(order));
       basis_set.push_back(new typename  CG_HBasis::HDIV_HEX(order));
 
       for (auto basisPtr:basis_set) {
@@ -1035,6 +1038,7 @@ int ConvergenceHex(const bool verbose) {
 
       std::vector<basisType*> basis_set;
       basis_set.push_back(new typename  CG_NBasis::HVOL_HEX(order-1));
+      basis_set.push_back(new typename  CG_DNBasis::HVOL_HEX(order-1));
       basis_set.push_back(new typename  CG_HBasis::HVOL_HEX(order-1));
 
       for (auto basisPtr:basis_set) {

--- a/packages/intrepid2/unit-test/Projection/test_convergence_TET.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_convergence_TET.hpp
@@ -399,9 +399,9 @@ int ConvergenceTet(const bool verbose) {
     cell_cub->getCubature(refPoints, weights);
 
     using basisType = Basis<DeviceSpaceType,ValueType,ValueType>;
-    using CG_NBasis = NodalBasisFamily<DeviceSpaceType,ValueType,ValueType>;
+    //using CG_NBasis = NodalBasisFamily<DeviceSpaceType,ValueType,ValueType>;
     using CG_HBasis = HierarchicalBasisFamily<DeviceSpaceType,ValueType,ValueType>;
-    //using CG_DNBasis = DerivedNodalBasisFamily<DeviceSpaceType,ValueType,ValueType>;
+    using CG_DNBasis = DerivedNodalBasisFamily<DeviceSpaceType,ValueType,ValueType>;
 
 
     *outStream
@@ -421,7 +421,8 @@ int ConvergenceTet(const bool verbose) {
       ots::getOrientation(elemOrts, elemNodes, tet);
 
       std::vector<basisType*> basis_set;
-      basis_set.push_back(new typename  CG_NBasis::HGRAD_TET(order));
+      //basis_set.push_back(new typename  CG_NBasis::HGRAD_TET(order));
+      basis_set.push_back(new typename  CG_DNBasis::HGRAD_TET(order));
       basis_set.push_back(new typename  CG_HBasis::HGRAD_TET(order));
 
       for (auto basisPtr:basis_set) {
@@ -626,7 +627,8 @@ int ConvergenceTet(const bool verbose) {
       ots::getOrientation(elemOrts, elemNodes, tet);
 
       std::vector<basisType*> basis_set;
-      basis_set.push_back(new typename  CG_NBasis::HCURL_TET(order));
+      //basis_set.push_back(new typename  CG_NBasis::HCURL_TET(order));
+      basis_set.push_back(new typename  CG_DNBasis::HCURL_TET(order));
       //basis_set.push_back(new typename  CG_HBasis::HCURL_TET(order));
 
       for (auto basisPtr:basis_set) {
@@ -844,7 +846,8 @@ int ConvergenceTet(const bool verbose) {
       ots::getOrientation(elemOrts, elemNodes, tet);
 
       std::vector<basisType*> basis_set;
-      basis_set.push_back(new typename  CG_NBasis::HDIV_TET(order));
+      //basis_set.push_back(new typename  CG_NBasis::HDIV_TET(order));
+      basis_set.push_back(new typename  CG_DNBasis::HDIV_TET(order));
       //basis_set.push_back(new typename  CG_HBasis::HDIV_TET(order));
 
       for (auto basisPtr:basis_set) {
@@ -1058,7 +1061,8 @@ int ConvergenceTet(const bool verbose) {
       ots::getOrientation(elemOrts, elemNodes, tet);
 
       std::vector<basisType*> basis_set;
-      basis_set.push_back(new typename  CG_NBasis::HVOL_TET(order-1));
+      //basis_set.push_back(new typename  CG_NBasis::HVOL_TET(order-1));
+      basis_set.push_back(new typename  CG_DNBasis::HVOL_TET(order-1));
       //basis_set.push_back(new typename  CG_HBasis::HVOL_TET(order-1));
 
       for (auto basisPtr:basis_set) {

--- a/packages/intrepid2/unit-test/Projection/test_convergence_TRI.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_convergence_TRI.hpp
@@ -340,7 +340,7 @@ int ConvergenceTri(const bool verbose) {
     using basisType = Basis<DeviceSpaceType,ValueType,ValueType>;
     using CG_NBasis = NodalBasisFamily<DeviceSpaceType,ValueType,ValueType>;
     using CG_HBasis = HierarchicalBasisFamily<DeviceSpaceType,ValueType,ValueType>;
-    //using CG_DNBasis = DerivedNodalBasisFamily<DeviceSpaceType,ValueType,ValueType>;
+    using CG_DNBasis = DerivedNodalBasisFamily<DeviceSpaceType,ValueType,ValueType>;
 
 
     *outStream
@@ -361,6 +361,7 @@ int ConvergenceTri(const bool verbose) {
 
       std::vector<basisType*> basis_set;
       basis_set.push_back(new typename  CG_NBasis::HGRAD_TRI(order));
+      basis_set.push_back(new typename  CG_DNBasis::HGRAD_TRI(order));
       basis_set.push_back(new typename  CG_HBasis::HGRAD_TRI(order));
 
       for (auto basisPtr:basis_set) {
@@ -566,6 +567,7 @@ int ConvergenceTri(const bool verbose) {
 
       std::vector<basisType*> basis_set;
       basis_set.push_back(new typename  CG_NBasis::HCURL_TRI(order));
+      basis_set.push_back(new typename  CG_DNBasis::HCURL_TRI(order));
       //basis_set.push_back(new typename  CG_HBasis::HCURL_TRI(order));
 
       for (auto basisPtr:basis_set) {
@@ -775,6 +777,7 @@ int ConvergenceTri(const bool verbose) {
 
       std::vector<basisType*> basis_set;
       basis_set.push_back(new typename  CG_NBasis::HDIV_TRI(order));
+      basis_set.push_back(new typename  CG_DNBasis::HDIV_TRI(order));
       //basis_set.push_back(new typename  CG_HBasis::HDIV_TRI(order));
 
       for (auto basisPtr:basis_set) {
@@ -991,6 +994,7 @@ int ConvergenceTri(const bool verbose) {
 
       std::vector<basisType*> basis_set;
       basis_set.push_back(new typename  CG_NBasis::HVOL_TRI(order-1));
+      basis_set.push_back(new typename  CG_DNBasis::HVOL_TRI(order-1));
       //basis_set.push_back(new typename  CG_HBasis::HVOL_TRI(order-1));
 
       for (auto basisPtr:basis_set) {

--- a/packages/intrepid2/unit-test/Projection/test_interpolation_projection_HEX.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_interpolation_projection_HEX.hpp
@@ -84,6 +84,9 @@
 
 #define Intrepid2_Experimental
 
+//this allows to reduce cost of the tests.
+//undefine when debugging/developing
+#define RANDOMLY_PICK_ELEM_PERMUTATION
 
 #include "Teuchos_oblackholestream.hpp"
 #include "Teuchos_RCP.hpp"
@@ -135,6 +138,19 @@ int InterpolationProjectionHex(const bool verbose) {
 
   int errorFlag = 0;
   const ValueType tol = tolerence();
+
+  bool pickTest = false;
+  int elemPermutation=0, sharedSidePermutation=0;
+
+#ifdef  RANDOMLY_PICK_ELEM_PERMUTATION
+  pickTest = true;
+  /* initialize random seed: */
+  std::srand (std::time(NULL));
+  int configuration = std::rand() % 24;
+  elemPermutation = configuration % 6;
+  sharedSidePermutation = configuration/6;
+  *outStream << "Randomly picked configuration (hex premutation, shared face permutation): (" << elemPermutation << ", " <<sharedSidePermutation << ")" << std::endl;
+#endif
 
   //target functions and their derivatives
 
@@ -199,6 +215,7 @@ int InterpolationProjectionHex(const bool verbose) {
   typedef Experimental::ProjectionTools<DeviceSpaceType> pts;
   typedef FunctionSpaceTools<DeviceSpaceType> fst;
   typedef Experimental::LagrangianInterpolation<DeviceSpaceType> li;
+  using  basisType = Basis<DeviceSpaceType,ValueType,ValueType>;
 
   constexpr ordinal_type dim = 3;
   constexpr ordinal_type numCells = 2;
@@ -219,6 +236,10 @@ int InterpolationProjectionHex(const bool verbose) {
   common_edges.insert(edgeType({{4,5}})); common_edges.insert(edgeType({{5,6}})); common_edges.insert(edgeType({{6,7}})); common_edges.insert(edgeType({{4,7}}));
   const ordinal_type max_degree = 4;
 
+  using CG_NBasis = NodalBasisFamily<DeviceSpaceType,ValueType,ValueType>;
+  using CG_DNBasis = DerivedNodalBasisFamily<DeviceSpaceType,ValueType,ValueType>;
+  std::vector<basisType*> basis_set;
+
   *outStream
   << "===============================================================================\n"
   << "|                                                                             |\n"
@@ -233,7 +254,11 @@ int InterpolationProjectionHex(const bool verbose) {
 
     ordinal_type reorder[numTotalVertexes] = {0,1,2,3,4,5,6,7,8,9,10,11};
 
+    int sharedSideCount = 0;
     do {
+      if((sharedSideCount++ != sharedSidePermutation) && pickTest)
+        continue;
+
       ordinal_type orderback[numTotalVertexes];
       for(ordinal_type i=0;i<numTotalVertexes;++i) {
         orderback[reorder[i]]=i;
@@ -241,7 +266,10 @@ int InterpolationProjectionHex(const bool verbose) {
       ValueType vertices[numTotalVertexes][dim];
       ordinal_type hexas[numCells][numElemVertexes];
       std::copy(&hexas_orig[0][0], &hexas_orig[0][0]+numCells*numElemVertexes, &hexas_rotated[0][0]);
-      for (ordinal_type shift=0; shift<1; ++shift) {
+      for (ordinal_type shift=0; shift<6; ++shift) {
+        if(pickTest && (shift != elemPermutation))
+          continue;
+
         if(shift <4){
           std::rotate_copy(faceLeft.begin(), faceLeft.begin()+shift, faceLeft.end(), faceLeftOriented.begin());
           std::rotate_copy(faceRight.begin(), faceRight.begin()+shift, faceRight.end(), faceRightOriented.begin());
@@ -327,323 +355,327 @@ int InterpolationProjectionHex(const bool verbose) {
         ots::getOrientation(elemOrts, elemNodes, hex);
 
         for (ordinal_type degree=1; degree <= max_degree; degree++) {
-
-          Teuchos::RCP<Basis<DeviceSpaceType,ValueType,ValueType>> basisPtr;
-
+          basis_set.clear();
           if(degree==1)
-            basisPtr = Teuchos::rcp(new Basis_HGRAD_HEX_C1_FEM<DeviceSpaceType,ValueType,ValueType>());
-          else
-            basisPtr = Teuchos::rcp(new Basis_HGRAD_HEX_Cn_FEM<DeviceSpaceType,ValueType,ValueType>(degree,POINTTYPE_WARPBLEND));
+            basis_set.push_back(new Basis_HGRAD_HEX_C1_FEM<DeviceSpaceType,ValueType,ValueType>());
+          basis_set.push_back(new typename  CG_NBasis::HGRAD_HEX(degree));
+          basis_set.push_back(new typename  CG_DNBasis::HGRAD_HEX(degree));
 
-          ordinal_type basisCardinality = basisPtr->getCardinality();
+          for (auto basisPtr:basis_set) {
 
-          //compute DofCoords Oriented
-          DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
-          DynRankView ConstructWithLabel(dofCoeffsPhys, numCells, basisCardinality);
-          DynRankView ConstructWithLabel(physDofCoords, numCells, basisCardinality, dim);
-          DynRankView ConstructWithLabel(funAtDofCoords, numCells, basisCardinality);
-          DynRankView ConstructWithLabel(basisCoeffsLI, numCells, basisCardinality);
+            auto name = basisPtr->getName();
+            *outStream << " " << name << std::endl;
+            ordinal_type basisCardinality = basisPtr->getCardinality();
 
-          //compute Lagrangian Interpolation of fun
-          {
-            li::getDofCoordsAndCoeffs(dofCoordsOriented,  dofCoeffsPhys, basisPtr.get(), POINTTYPE_WARPBLEND, elemOrts);
+            //compute DofCoords Oriented
+            DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
+            DynRankView ConstructWithLabel(dofCoeffsPhys, numCells, basisCardinality);
+            DynRankView ConstructWithLabel(physDofCoords, numCells, basisCardinality, dim);
+            DynRankView ConstructWithLabel(funAtDofCoords, numCells, basisCardinality);
+            DynRankView ConstructWithLabel(basisCoeffsLI, numCells, basisCardinality);
 
-            //Compute physical Dof Coordinates
+            //compute Lagrangian Interpolation of fun
             {
-              Basis_HGRAD_HEX_C1_FEM<DeviceSpaceType,ValueType,ValueType> hexLinearBasis; //used for computing physical coordinates
-              DynRankView ConstructWithLabel(hexLinearBasisValuesAtDofCoords, numCells, hex.getNodeCount(), basisCardinality);
-              for(ordinal_type i=0; i<numCells; ++i)
-                for(ordinal_type d=0; d<dim; ++d) {
-                  auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
-                  auto outView =Kokkos::subview( hexLinearBasisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
-                  hexLinearBasis.getValues(outView, inView);
-                  DeviceSpaceType().fence();
-                  for(ordinal_type j=0; j<basisCardinality; ++j)
-                    for(std::size_t k=0; k<hex.getNodeCount(); ++k)
-                      physDofCoords(i,j,d) += vertices[hexas[i][k]][d]*hexLinearBasisValuesAtDofCoords(i,k,j);
+              li::getDofCoordsAndCoeffs(dofCoordsOriented,  dofCoeffsPhys, basisPtr, POINTTYPE_EQUISPACED, elemOrts);
+
+              //Compute physical Dof Coordinates
+              {
+                Basis_HGRAD_HEX_C1_FEM<DeviceSpaceType,ValueType,ValueType> hexLinearBasis; //used for computing physical coordinates
+                DynRankView ConstructWithLabel(hexLinearBasisValuesAtDofCoords, numCells, hex.getNodeCount(), basisCardinality);
+                for(ordinal_type i=0; i<numCells; ++i)
+                  for(ordinal_type d=0; d<dim; ++d) {
+                    auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
+                    auto outView =Kokkos::subview( hexLinearBasisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+                    hexLinearBasis.getValues(outView, inView);
+                    DeviceSpaceType().fence();
+                    for(ordinal_type j=0; j<basisCardinality; ++j)
+                      for(std::size_t k=0; k<hex.getNodeCount(); ++k)
+                        physDofCoords(i,j,d) += vertices[hexas[i][k]][d]*hexLinearBasisValuesAtDofCoords(i,k,j);
+                  }
+              }
+
+              Fun fun;
+
+              for(ordinal_type i=0; i<numCells; ++i) {
+                for(ordinal_type j=0; j<basisCardinality; ++j)
+                  funAtDofCoords(i,j) += fun(degree, physDofCoords(i,j,0), physDofCoords(i,j,1), physDofCoords(i,j,2));
+              }
+
+              li::getBasisCoeffs(basisCoeffsLI, funAtDofCoords, dofCoeffsPhys);
+            }
+
+            //Testing Kronecker property of basis functions
+            {
+              for(ordinal_type i=0; i<numCells; ++i) {
+                DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality);
+                DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
+                DynRankView ConstructWithLabel(transformedBasisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
+                auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
+                auto outView =Kokkos::subview( basisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL());
+                basisPtr->getValues(outView, inView);
+
+                // modify basis values to account for orientations
+                ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
+                    basisValuesAtDofCoords,
+                    elemOrts,
+                    basisPtr);
+
+                // transform basis values
+                fst::HGRADtransformVALUE(transformedBasisValuesAtDofCoordsOriented,
+                    basisValuesAtDofCoordsOriented);
+
+
+                DeviceSpaceType().fence();
+                for(ordinal_type k=0; k<basisCardinality; ++k) {
+                  for(ordinal_type j=0; j<basisCardinality; ++j){
+                    ValueType dofValue = transformedBasisValuesAtDofCoordsOriented(i,k,j) * dofCoeffsPhys(i,j);
+                    if ( k==j && std::abs( dofValue - 1.0 ) > 100*tol ) {
+                      errorFlag++;
+                      *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                      *outStream << " Basis function " << k << " of cell " << i << " does not have unit value at its node (" << dofValue <<")\n";
+                    }
+                    if ( k!=j && std::abs( dofValue ) > tol ) {
+                      errorFlag++;
+                      *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                      *outStream << " Basis function " << k << " of cell " << i << " does not vanish at node " << j << "(" << dofValue <<")\n";
+                    }
+                  }
                 }
-            }
+              }
 
-            Fun fun;
+              //check that fun values are consistent on common face dofs
+              {
+                bool areDifferent(false);
+                auto numFaceDOFs = basisPtr->getDofCount(2,0);
+                for(ordinal_type j=0;j<numFaceDOFs && !areDifferent;j++) {
+                  areDifferent = std::abs(basisCoeffsLI(0,basisPtr->getDofOrdinal(2,faceIndex[0],j))
+                      - basisCoeffsLI(1,basisPtr->getDofOrdinal(2,faceIndex[1],j))) > 10*tol;
+                }
 
-            for(ordinal_type i=0; i<numCells; ++i) {
-              for(ordinal_type j=0; j<basisCardinality; ++j)
-                funAtDofCoords(i,j) += fun(degree, physDofCoords(i,j,0), physDofCoords(i,j,1), physDofCoords(i,j,2));
-            }
+                if(areDifferent) {
+                  errorFlag++;
+                  *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                  *outStream << "Function DOFs on common face computed using Hex 0 basis functions are not consistent with those computed using Hex 1\n";
+                  *outStream << "Function DOFs for Hex 0 are:";
+                  for(ordinal_type j=0;j<numFaceDOFs;j++)
+                    *outStream << " " << basisCoeffsLI(0,basisPtr->getDofOrdinal(2,faceIndex[0],j)) << " | (" << physDofCoords(0,basisPtr->getDofOrdinal(2,faceIndex[0],j),0) << "," << physDofCoords(0,basisPtr->getDofOrdinal(2,faceIndex[0],j),1) << ", " << physDofCoords(0,basisPtr->getDofOrdinal(2,faceIndex[0],j),2) << ") ||";
+                  *outStream << "\nFunction DOFs for Hex 1 are:";
+                  for(ordinal_type j=0;j<numFaceDOFs;j++)
+                    *outStream << " " << basisCoeffsLI(1,basisPtr->getDofOrdinal(2,faceIndex[1],j))<< " | (" << physDofCoords(1,basisPtr->getDofOrdinal(2,faceIndex[1],j),0) << "," << physDofCoords(1,basisPtr->getDofOrdinal(2,faceIndex[1],j),1) << ", " << physDofCoords(1,basisPtr->getDofOrdinal(2,faceIndex[1],j),2) << ") ||";
+                  *outStream << std::endl;
+                }
+              }
 
-            li::getBasisCoeffs(basisCoeffsLI, funAtDofCoords, dofCoeffsPhys);
-          }
+              //check that fun values are consistent on common edges dofs
+              {
+                bool areDifferent(false);
+                auto numEdgeDOFs = basisPtr->getDofCount(1,0);
+                for(std::size_t iEdge=0;iEdge<common_edges.size();iEdge++) {
+                  for(ordinal_type j=0;j<numEdgeDOFs && !areDifferent;j++) {
+                    areDifferent = std::abs(basisCoeffsLI(0,basisPtr->getDofOrdinal(1,edgeIndexes[0][iEdge],j))
+                        - basisCoeffsLI(1,basisPtr->getDofOrdinal(1,edgeIndexes[1][iEdge],j))) > 10*tol;
+                  }
+                  if(areDifferent) {
+                    errorFlag++;
+                    *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                    *outStream << "Function DOFs on common edge " << iEdge << " computed using Hex 0 basis functions are not consistent with those computed using Hex 1\n";
+                    *outStream << "Function DOFs for Hex 0 are:";
+                    for(ordinal_type j=0;j<numEdgeDOFs;j++)
+                      *outStream << " " << basisCoeffsLI(0,basisPtr->getDofOrdinal(1,edgeIndexes[0][iEdge],j));
+                    *outStream << "\nFunction DOFs for Hex 1 are:";
+                    for(ordinal_type j=0;j<numEdgeDOFs;j++)
+                      *outStream << " " << basisCoeffsLI(1,basisPtr->getDofOrdinal(1,edgeIndexes[1][iEdge],j));
+                    *outStream << std::endl;
+                  }
+                }
+              }
 
-          //Testing Kronecker property of basis functions
-          {
-            for(ordinal_type i=0; i<numCells; ++i) {
-              DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality);
+              //check that fun values at reference points coincide with those computed using basis functions
               DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
               DynRankView ConstructWithLabel(transformedBasisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
-              auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
-              auto outView =Kokkos::subview( basisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL());
-              basisPtr->getValues(outView, inView);
+              DynRankView basisValuesAtDofCoordsCells("inValues", numCells, basisCardinality, basisCardinality);
+
+              for (ordinal_type ic = 0; ic < numCells; ++ic)
+                basisPtr->getValues(Kokkos::subview(basisValuesAtDofCoordsCells, ic, Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(dofCoordsOriented, ic, Kokkos::ALL(), Kokkos::ALL()));
 
               // modify basis values to account for orientations
               ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
-                  basisValuesAtDofCoords,
+                  basisValuesAtDofCoordsCells,
                   elemOrts,
-                  basisPtr.get());
+                  basisPtr);
 
               // transform basis values
               fst::HGRADtransformVALUE(transformedBasisValuesAtDofCoordsOriented,
                   basisValuesAtDofCoordsOriented);
 
-              DeviceSpaceType().fence();
-              for(ordinal_type k=0; k<basisCardinality; ++k) {
-                for(ordinal_type j=0; j<basisCardinality; ++j){
-                  ValueType dofValue = transformedBasisValuesAtDofCoordsOriented(i,k,j) * dofCoeffsPhys(i,j);
-                  if ( k==j && std::abs( dofValue - 1.0 ) > 100*tol ) {
-                    errorFlag++;
-                    *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-                    *outStream << " Basis function " << k << " of cell " << i << " does not have unit value at its node (" << dofValue <<")\n";
+              DynRankView ConstructWithLabel(funAtDofCoordsOriented, numCells, basisCardinality);
+              for(ordinal_type i=0; i<numCells; ++i) {
+                ValueType error=0;
+                for(ordinal_type j=0; j<basisCardinality; ++j) {
+                  for(ordinal_type k=0; k<basisCardinality; ++k)
+                    funAtDofCoordsOriented(i,j) += basisCoeffsLI(i,k)*transformedBasisValuesAtDofCoordsOriented(i,k,j);
+
+                  error = std::max(std::abs( funAtDofCoords(i,j) - funAtDofCoordsOriented(i,j)), error);
+                }
+
+                if(error>100*tol) {
+                  errorFlag++;
+                  *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                  *outStream << "Function values at reference points differ from those computed using basis functions of Hex " << i << "\n";
+                  *outStream << "Function values at reference points are:\n";
+                  for(ordinal_type j=0; j<basisCardinality; ++j)
+                    *outStream << " (" << funAtDofCoords(i,j)  << ")";
+                  *outStream << "\nFunction values at reference points computed using basis functions are\n";
+                  for(ordinal_type j=0; j<basisCardinality; ++j)
+                    *outStream << " (" << funAtDofCoordsOriented(i,j)  << ")";
+                  *outStream << std::endl;
+                }
+              }
+
+              //compute projection-based interpolation of the Lagrangian interpolation
+              DynRankView ConstructWithLabel(basisCoeffsHGrad, numCells, basisCardinality);
+              {
+                ordinal_type targetCubDegree(basisPtr->getDegree()),targetDerivCubDegree(basisPtr->getDegree());
+
+                Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
+                projStruct.createHGradProjectionStruct(basisPtr, targetCubDegree, targetDerivCubDegree);
+
+                ordinal_type numPoints = projStruct.getNumTargetEvalPoints(), numGradPoints = projStruct.getNumTargetDerivEvalPoints();
+                DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
+                DynRankView ConstructWithLabel(evaluationGradPoints, numCells, numGradPoints, dim);
+
+
+                pts::getHGradEvaluationPoints(evaluationPoints,
+                    evaluationGradPoints,
+                    elemOrts,
+                    basisPtr,
+                    &projStruct);
+
+
+                DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints);
+                DynRankView ConstructWithLabel(targetGradAtEvalPoints, numCells, numGradPoints, dim);
+
+                DynRankView ConstructWithLabel(hgradBasisAtEvaluationPoints, numCells, basisCardinality , numPoints);
+                DynRankView ConstructWithLabel(hgradBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints);
+                for(int ic=0; ic<numCells; ic++)
+                  basisPtr->getValues(Kokkos::subview(hgradBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
+                ots::modifyBasisByOrientation(hgradBasisAtEvaluationPoints,
+                    hgradBasisAtEvaluationPointsNonOriented,
+                    elemOrts,
+                    basisPtr);
+
+                DynRankView ConstructWithLabel(gradOfHGradBasisAtEvaluationPoints, numCells, basisCardinality , numGradPoints, dim);
+                if(numGradPoints>0) {
+                  DynRankView ConstructWithLabel(gradOfHGradBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numGradPoints, dim);
+                  for(int ic=0; ic<numCells; ic++)
+                    basisPtr->getValues(Kokkos::subview(gradOfHGradBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationGradPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_GRAD);
+                  ots::modifyBasisByOrientation(gradOfHGradBasisAtEvaluationPoints,
+                      gradOfHGradBasisAtEvaluationPointsNonOriented,
+                      elemOrts,
+                      basisPtr);
+                }
+
+
+                for(int ic=0; ic<numCells; ic++) {
+                  for(int i=0;i<numPoints;i++) {
+                    for(int k=0;k<basisCardinality;k++)
+                      targetAtEvalPoints(ic,i) += basisCoeffsLI(ic,k)*hgradBasisAtEvaluationPoints(ic,k,i);
                   }
-                  if ( k!=j && std::abs( dofValue ) > tol ) {
-                    errorFlag++;
-                    *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-                    *outStream << " Basis function " << k << " of cell " << i << " does not vanish at node " << j << "(" << dofValue <<")\n";
+                  for(int i=0;i<numGradPoints;i++) {
+                    for(int k=0;k<basisCardinality;k++)
+                      for(int d=0;d<dim;d++)
+                        targetGradAtEvalPoints(ic,i,d) += basisCoeffsLI(ic,k)*gradOfHGradBasisAtEvaluationPoints(ic,k,i,d);//funHGradCoeffs(k)
                   }
+
+                }
+
+                pts::getHGradBasisCoeffs(basisCoeffsHGrad,
+                    targetAtEvalPoints,
+                    targetGradAtEvalPoints,
+                    evaluationPoints,
+                    evaluationGradPoints,
+                    elemOrts,
+                    basisPtr,
+                    &projStruct);
+              }
+
+              //check that the basis coefficients of the Lagrangian nterpolation are the same as those of the projection-based interpolation
+              {
+                ValueType diffErr(0);
+
+                for(int k=0;k<basisCardinality;k++) {
+                  for(int ic=0; ic<numCells; ic++)
+                    diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsHGrad(ic,k)));
+                }
+
+                if(diffErr > pow(7, degree-1)*tol) { //heuristic relation on how round-off error depends on degree
+                  errorFlag++;
+                  *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                  *outStream << "HGRAD_C" << degree << ": The weights recovered with the optimization are different than the one used for generating the functon."<<
+                      "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
+                }
+              }
+
+              //compute L2 projection of the Lagrangian interpolation
+              DynRankView ConstructWithLabel(basisCoeffsL2, numCells, basisCardinality);
+              {
+                ordinal_type targetCubDegree(basisPtr->getDegree());
+
+                Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
+                projStruct.createL2ProjectionStruct(basisPtr, targetCubDegree);
+
+                ordinal_type numPoints = projStruct.getNumTargetEvalPoints();
+                DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
+
+                pts::getL2EvaluationPoints(evaluationPoints,
+                    elemOrts,
+                    basisPtr,
+                    &projStruct);
+
+
+                DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints);
+                DynRankView ConstructWithLabel(hgradBasisAtEvaluationPoints, numCells, basisCardinality , numPoints);
+                DynRankView ConstructWithLabel(hgradBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints);
+                for(int ic=0; ic<numCells; ic++)
+                  basisPtr->getValues(Kokkos::subview(hgradBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
+                ots::modifyBasisByOrientation(hgradBasisAtEvaluationPoints,
+                    hgradBasisAtEvaluationPointsNonOriented,
+                    elemOrts,
+                    basisPtr);
+
+
+                for(int ic=0; ic<numCells; ic++) {
+                  for(int i=0;i<numPoints;i++) {
+                    for(int k=0;k<basisCardinality;k++)
+                      targetAtEvalPoints(ic,i) += basisCoeffsLI(ic,k)*hgradBasisAtEvaluationPoints(ic,k,i);
+                  }
+                }
+
+                pts::getL2BasisCoeffs(basisCoeffsL2,
+                    targetAtEvalPoints,
+                    evaluationPoints,
+                    elemOrts,
+                    basisPtr,
+                    &projStruct);
+              }
+
+              //check that the basis coefficients of the Lagrangian interpolation are the same as those of the L2 projection
+              {
+                ValueType diffErr =0;
+                for(int k=0;k<basisCardinality;k++) {
+                  for(int ic=0; ic<numCells; ic++)
+                    diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsL2(ic,k)));
+                }
+
+                if(diffErr > pow(7, degree-1)*tol) { //heuristic relation on how round-off error depends on degree
+                  errorFlag++;
+                  *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                  *outStream << "HGRAD_C" << degree << ": The weights recovered with the optimization are different than the one used for generating the functon."<<
+                      "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
                 }
               }
             }
-          }
-
-          //check that fun values are consistent on common face dofs
-          {
-            bool areDifferent(false);
-            auto numFaceDOFs = basisPtr->getDofCount(2,0);
-            for(ordinal_type j=0;j<numFaceDOFs && !areDifferent;j++) {
-              areDifferent = std::abs(basisCoeffsLI(0,basisPtr->getDofOrdinal(2,faceIndex[0],j))
-                  - basisCoeffsLI(1,basisPtr->getDofOrdinal(2,faceIndex[1],j))) > 10*tol;
-            }
-
-            if(areDifferent) {
-              errorFlag++;
-              *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-              *outStream << "Function DOFs on common face computed using Hex 0 basis functions are not consistent with those computed using Hex 1\n";
-              *outStream << "Function DOFs for Hex 0 are:";
-              for(ordinal_type j=0;j<numFaceDOFs;j++)
-                *outStream << " " << basisCoeffsLI(0,basisPtr->getDofOrdinal(2,faceIndex[0],j)) << " | (" << physDofCoords(0,basisPtr->getDofOrdinal(2,faceIndex[0],j),0) << "," << physDofCoords(0,basisPtr->getDofOrdinal(2,faceIndex[0],j),1) << ", " << physDofCoords(0,basisPtr->getDofOrdinal(2,faceIndex[0],j),2) << ") ||";
-              *outStream << "\nFunction DOFs for Hex 1 are:";
-              for(ordinal_type j=0;j<numFaceDOFs;j++)
-                *outStream << " " << basisCoeffsLI(1,basisPtr->getDofOrdinal(2,faceIndex[1],j))<< " | (" << physDofCoords(1,basisPtr->getDofOrdinal(2,faceIndex[1],j),0) << "," << physDofCoords(1,basisPtr->getDofOrdinal(2,faceIndex[1],j),1) << ", " << physDofCoords(1,basisPtr->getDofOrdinal(2,faceIndex[1],j),2) << ") ||";
-              *outStream << std::endl;
-            }
-          }
-
-          //check that fun values are consistent on common edges dofs
-          {
-            bool areDifferent(false);
-            auto numEdgeDOFs = basisPtr->getDofCount(1,0);
-            for(std::size_t iEdge=0;iEdge<common_edges.size();iEdge++) {
-              for(ordinal_type j=0;j<numEdgeDOFs && !areDifferent;j++) {
-                areDifferent = std::abs(basisCoeffsLI(0,basisPtr->getDofOrdinal(1,edgeIndexes[0][iEdge],j))
-                    - basisCoeffsLI(1,basisPtr->getDofOrdinal(1,edgeIndexes[1][iEdge],j))) > 10*tol;
-              }
-              if(areDifferent) {
-                errorFlag++;
-                *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-                *outStream << "Function DOFs on common edge " << iEdge << " computed using Hex 0 basis functions are not consistent with those computed using Hex 1\n";
-                *outStream << "Function DOFs for Hex 0 are:";
-                for(ordinal_type j=0;j<numEdgeDOFs;j++)
-                  *outStream << " " << basisCoeffsLI(0,basisPtr->getDofOrdinal(1,edgeIndexes[0][iEdge],j));
-                *outStream << "\nFunction DOFs for Hex 1 are:";
-                for(ordinal_type j=0;j<numEdgeDOFs;j++)
-                  *outStream << " " << basisCoeffsLI(1,basisPtr->getDofOrdinal(1,edgeIndexes[1][iEdge],j));
-                *outStream << std::endl;
-              }
-            }
-          }
-
-          //check that fun values at reference points coincide with those computed using basis functions
-          DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
-          DynRankView ConstructWithLabel(transformedBasisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
-          DynRankView basisValuesAtDofCoordsCells("inValues", numCells, basisCardinality, basisCardinality);
-
-          for (ordinal_type ic = 0; ic < numCells; ++ic)
-            basisPtr->getValues(Kokkos::subview(basisValuesAtDofCoordsCells, ic, Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(dofCoordsOriented, ic, Kokkos::ALL(), Kokkos::ALL()));
-
-          // modify basis values to account for orientations
-          ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
-              basisValuesAtDofCoordsCells,
-              elemOrts,
-              basisPtr.get());
-
-          // transform basis values
-          // transform basis values
-          fst::HGRADtransformVALUE(transformedBasisValuesAtDofCoordsOriented,
-              basisValuesAtDofCoordsOriented);
-
-          DynRankView ConstructWithLabel(funAtDofCoordsOriented, numCells, basisCardinality);
-          for(ordinal_type i=0; i<numCells; ++i) {
-            ValueType error=0;
-            for(ordinal_type j=0; j<basisCardinality; ++j) {
-              for(ordinal_type k=0; k<basisCardinality; ++k)
-                funAtDofCoordsOriented(i,j) += basisCoeffsLI(i,k)*transformedBasisValuesAtDofCoordsOriented(i,k,j);
-
-              error = std::max(std::abs( funAtDofCoords(i,j) - funAtDofCoordsOriented(i,j)), error);
-            }
-
-            if(error>100*tol) {
-              errorFlag++;
-              *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-              *outStream << "Function values at reference points differ from those computed using basis functions of Hex " << i << "\n";
-              *outStream << "Function values at reference points are:\n";
-              for(ordinal_type j=0; j<basisCardinality; ++j)
-                *outStream << " (" << funAtDofCoords(i,j)  << ")";
-              *outStream << "\nFunction values at reference points computed using basis functions are\n";
-              for(ordinal_type j=0; j<basisCardinality; ++j)
-                *outStream << " (" << funAtDofCoordsOriented(i,j)  << ")";
-              *outStream << std::endl;
-            }
-          }
-
-          //compute projection-based interpolation of the Lagrangian interpolation
-          DynRankView ConstructWithLabel(basisCoeffsHGrad, numCells, basisCardinality);
-          {
-            ordinal_type targetCubDegree(basisPtr->getDegree()),targetDerivCubDegree(basisPtr->getDegree());
-
-            Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
-            projStruct.createHGradProjectionStruct(basisPtr.get(), targetCubDegree, targetDerivCubDegree);
-
-            ordinal_type numPoints = projStruct.getNumTargetEvalPoints(), numGradPoints = projStruct.getNumTargetDerivEvalPoints();
-            DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
-            DynRankView ConstructWithLabel(evaluationGradPoints, numCells, numGradPoints, dim);
-
-
-            pts::getHGradEvaluationPoints(evaluationPoints,
-                evaluationGradPoints,
-                elemOrts,
-                basisPtr.get(),
-                &projStruct);
-
-
-            DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints);
-            DynRankView ConstructWithLabel(targetGradAtEvalPoints, numCells, numGradPoints, dim);
-
-            DynRankView ConstructWithLabel(hgradBasisAtEvaluationPoints, numCells, basisCardinality , numPoints);
-            DynRankView ConstructWithLabel(hgradBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints);
-            for(int ic=0; ic<numCells; ic++)
-              basisPtr->getValues(Kokkos::subview(hgradBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
-            ots::modifyBasisByOrientation(hgradBasisAtEvaluationPoints,
-                hgradBasisAtEvaluationPointsNonOriented,
-                elemOrts,
-                basisPtr.get());
-
-            DynRankView ConstructWithLabel(gradOfHGradBasisAtEvaluationPoints, numCells, basisCardinality , numGradPoints, dim);
-            if(numGradPoints>0) {
-              DynRankView ConstructWithLabel(gradOfHGradBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numGradPoints, dim);
-              for(int ic=0; ic<numCells; ic++)
-                basisPtr->getValues(Kokkos::subview(gradOfHGradBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationGradPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_GRAD);
-              ots::modifyBasisByOrientation(gradOfHGradBasisAtEvaluationPoints,
-                  gradOfHGradBasisAtEvaluationPointsNonOriented,
-                  elemOrts,
-                  basisPtr.get());
-            }
-
-
-            for(int ic=0; ic<numCells; ic++) {
-              for(int i=0;i<numPoints;i++) {
-                for(int k=0;k<basisCardinality;k++)
-                  targetAtEvalPoints(ic,i) += basisCoeffsLI(ic,k)*hgradBasisAtEvaluationPoints(ic,k,i);
-              }
-              for(int i=0;i<numGradPoints;i++) {
-                for(int k=0;k<basisCardinality;k++)
-                  for(int d=0;d<dim;d++)
-                    targetGradAtEvalPoints(ic,i,d) += basisCoeffsLI(ic,k)*gradOfHGradBasisAtEvaluationPoints(ic,k,i,d);//funHGradCoeffs(k)
-              }
-
-            }
-
-            pts::getHGradBasisCoeffs(basisCoeffsHGrad,
-                targetAtEvalPoints,
-                targetGradAtEvalPoints,
-                evaluationPoints,
-                evaluationGradPoints,
-                elemOrts,
-                basisPtr.get(),
-                &projStruct);
-          }
-
-          //check that the basis coefficients of the Lagrangian nterpolation are the same as those of the projection-based interpolation
-          {
-            ValueType diffErr(0);
-
-            for(int k=0;k<basisCardinality;k++) {
-              for(int ic=0; ic<numCells; ic++)
-                diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsHGrad(ic,k)));
-            }
-
-            if(diffErr > pow(7, degree-1)*tol) { //heuristic relation on how round-off error depends on degree
-              errorFlag++;
-              *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-              *outStream << "HGRAD_C" << degree << ": The weights recovered with the optimization are different than the one used for generating the functon."<<
-                  "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
-            }
-          }
-
-          //compute L2 projection of the Lagrangian interpolation
-          DynRankView ConstructWithLabel(basisCoeffsL2, numCells, basisCardinality);
-          {
-            ordinal_type targetCubDegree(basisPtr->getDegree());
-
-            Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
-            projStruct.createL2ProjectionStruct(basisPtr.get(), targetCubDegree);
-
-            ordinal_type numPoints = projStruct.getNumTargetEvalPoints();
-            DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
-
-            pts::getL2EvaluationPoints(evaluationPoints,
-                elemOrts,
-                basisPtr.get(),
-                &projStruct);
-
-
-            DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints);
-            DynRankView ConstructWithLabel(hgradBasisAtEvaluationPoints, numCells, basisCardinality , numPoints);
-            DynRankView ConstructWithLabel(hgradBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints);
-            for(int ic=0; ic<numCells; ic++)
-              basisPtr->getValues(Kokkos::subview(hgradBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
-            ots::modifyBasisByOrientation(hgradBasisAtEvaluationPoints,
-                hgradBasisAtEvaluationPointsNonOriented,
-                elemOrts,
-                basisPtr.get());
-
-
-            for(int ic=0; ic<numCells; ic++) {
-              for(int i=0;i<numPoints;i++) {
-                for(int k=0;k<basisCardinality;k++)
-                  targetAtEvalPoints(ic,i) += basisCoeffsLI(ic,k)*hgradBasisAtEvaluationPoints(ic,k,i);
-              }
-            }
-
-            pts::getL2BasisCoeffs(basisCoeffsL2,
-                targetAtEvalPoints,
-                evaluationPoints,
-                elemOrts,
-                basisPtr.get(),
-                &projStruct);
-          }
-
-          //check that the basis coefficients of the Lagrangian interpolation are the same as those of the L2 projection
-          {
-            ValueType diffErr =0;
-            for(int k=0;k<basisCardinality;k++) {
-              for(int ic=0; ic<numCells; ic++)
-                diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsL2(ic,k)));
-            }
-
-            if(diffErr > pow(7, degree-1)*tol) { //heuristic relation on how round-off error depends on degree
-              errorFlag++;
-              *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-              *outStream << "HGRAD_C" << degree << ": The weights recovered with the optimization are different than the one used for generating the functon."<<
-                  "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
-            }
+            delete basisPtr;
           }
         }
       }
@@ -670,7 +702,10 @@ int InterpolationProjectionHex(const bool verbose) {
 
     ordinal_type reorder[numTotalVertexes] = {0,1,2,3,4,5,6,7,8,9,10,11};
 
+    int sharedSideCount = 0;
     do {
+      if((sharedSideCount++ != sharedSidePermutation) && pickTest)
+        continue;
       ordinal_type orderback[numTotalVertexes];
       for(ordinal_type i=0;i<numTotalVertexes;++i) {
         orderback[reorder[i]]=i;
@@ -679,7 +714,9 @@ int InterpolationProjectionHex(const bool verbose) {
       ordinal_type hexas[numCells][numElemVertexes];
       std::copy(&hexas_orig[0][0], &hexas_orig[0][0]+numCells*numElemVertexes, &hexas_rotated[0][0]);
 
-      for (ordinal_type shift=0; shift<1; ++shift) {
+      for (ordinal_type shift=0; shift<6; ++shift) {
+        if(pickTest && (shift != elemPermutation))
+          continue;
         if(shift <4){
           std::rotate_copy(faceLeft.begin(), faceLeft.begin()+shift, faceLeft.end(), faceLeftOriented.begin());
           std::rotate_copy(faceRight.begin(), faceRight.begin()+shift, faceRight.end(), faceRightOriented.begin());
@@ -770,333 +807,340 @@ int InterpolationProjectionHex(const bool verbose) {
 
         for (ordinal_type degree=1; degree <= max_degree; degree++) {
 
-          Teuchos::RCP<Basis<DeviceSpaceType,ValueType,ValueType> > basisPtr;
+          basis_set.clear();
           if(degree==1)
-            basisPtr = Teuchos::rcp(new Basis_HCURL_HEX_I1_FEM<DeviceSpaceType,ValueType,ValueType>());
-          else
-            basisPtr = Teuchos::rcp(new Basis_HCURL_HEX_In_FEM<DeviceSpaceType,ValueType,ValueType>(degree));
+            basis_set.push_back(new Basis_HCURL_HEX_I1_FEM<DeviceSpaceType,ValueType,ValueType>());
+          basis_set.push_back(new typename  CG_NBasis::HCURL_HEX(degree));
+          basis_set.push_back(new typename  CG_DNBasis::HCURL_HEX(degree));
 
-          ordinal_type basisCardinality = basisPtr->getCardinality();
+          for (auto basisPtr:basis_set) {
 
-          //compute DofCoords Oriented
-          DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
-          DynRankView ConstructWithLabel(physDofCoords, numCells, basisCardinality, dim);
-          DynRankView ConstructWithLabel(funAtDofCoords, numCells, basisCardinality, dim);
-          DynRankView ConstructWithLabel(dofCoeffs, numCells, basisCardinality, dim);
-          DynRankView ConstructWithLabel(basisCoeffsLI, numCells, basisCardinality);
+            auto name = basisPtr->getName();
+            *outStream << " " << name << std::endl;
 
-          //compute Lagrangian Interpolation of fun
-          {
-            li::getDofCoordsAndCoeffs(dofCoordsOriented, dofCoeffs, basisPtr.get(),POINTTYPE_EQUISPACED, elemOrts);
+            ordinal_type basisCardinality = basisPtr->getCardinality();
 
-            //Compute physical Dof Coordinates
+            //compute DofCoords Oriented
+            DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
+            DynRankView ConstructWithLabel(physDofCoords, numCells, basisCardinality, dim);
+            DynRankView ConstructWithLabel(funAtDofCoords, numCells, basisCardinality, dim);
+            DynRankView ConstructWithLabel(dofCoeffs, numCells, basisCardinality, dim);
+            DynRankView ConstructWithLabel(basisCoeffsLI, numCells, basisCardinality);
 
+            //compute Lagrangian Interpolation of fun
             {
-              Basis_HGRAD_HEX_C1_FEM<DeviceSpaceType,ValueType,ValueType> hexLinearBasis; //used for computing physical coordinates
-              DynRankView ConstructWithLabel(hexLinearBasisValuesAtDofCoords, numCells, hex.getNodeCount(), basisCardinality);
-              for(ordinal_type i=0; i<numCells; ++i)
-                for(ordinal_type d=0; d<dim; ++d) {
-                  auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
-                  auto outView =Kokkos::subview( hexLinearBasisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
-                  hexLinearBasis.getValues(outView, inView);
-                  DeviceSpaceType().fence();
-                  for(ordinal_type j=0; j<basisCardinality; ++j)
-                    for(std::size_t k=0; k<hex.getNodeCount(); ++k)
-                      physDofCoords(i,j,d) += vertices[hexas[i][k]][d]*hexLinearBasisValuesAtDofCoords(i,k,j);
-                }
-            }
+              li::getDofCoordsAndCoeffs(dofCoordsOriented, dofCoeffs, basisPtr,POINTTYPE_EQUISPACED, elemOrts);
 
-            DynRankView ConstructWithLabel(jacobian, numCells, basisCardinality, dim, dim);
-            ct::setJacobian(jacobian, dofCoordsOriented, physVertexes, hex);
+              //Compute physical Dof Coordinates
 
-            FunCurl fun;
-            DynRankView ConstructWithLabel(fwdFunAtDofCoords, numCells, basisCardinality, dim);
-            for(ordinal_type i=0; i<numCells; ++i) {
-              for(ordinal_type j=0; j<basisCardinality; ++j) {
-                for(ordinal_type k=0; k<dim; ++k)
-                  funAtDofCoords(i,j,k) = fun(degree, physDofCoords(i,j,0), physDofCoords(i,j,1), physDofCoords(i,j,2), k);
-                for(ordinal_type k=0; k<dim; ++k)
-                  for(ordinal_type d=0; d<dim; ++d)
-                    fwdFunAtDofCoords(i,j,k) += jacobian(i,j,d,k)*funAtDofCoords(i,j,d);
+              {
+                Basis_HGRAD_HEX_C1_FEM<DeviceSpaceType,ValueType,ValueType> hexLinearBasis; //used for computing physical coordinates
+                DynRankView ConstructWithLabel(hexLinearBasisValuesAtDofCoords, numCells, hex.getNodeCount(), basisCardinality);
+                for(ordinal_type i=0; i<numCells; ++i)
+                  for(ordinal_type d=0; d<dim; ++d) {
+                    auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
+                    auto outView =Kokkos::subview( hexLinearBasisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+                    hexLinearBasis.getValues(outView, inView);
+                    DeviceSpaceType().fence();
+                    for(ordinal_type j=0; j<basisCardinality; ++j)
+                      for(std::size_t k=0; k<hex.getNodeCount(); ++k)
+                        physDofCoords(i,j,d) += vertices[hexas[i][k]][d]*hexLinearBasisValuesAtDofCoords(i,k,j);
+                  }
               }
-            }
 
-            li::getBasisCoeffs(basisCoeffsLI, fwdFunAtDofCoords, dofCoeffs);
-          }
+              DynRankView ConstructWithLabel(jacobian, numCells, basisCardinality, dim, dim);
+              ct::setJacobian(jacobian, dofCoordsOriented, physVertexes, hex);
 
-
-          //Testing Kronecker property of basis functions
-          {
-            for(ordinal_type i=0; i<numCells; ++i) {
-              DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality, dim);
-              DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
-              auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
-              auto outView =Kokkos::subview( basisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
-              basisPtr->getValues(outView, inView);
-
-              // modify basis values to account for orientations
-              ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
-                  basisValuesAtDofCoords,
-                  elemOrts,
-                  basisPtr.get());
-
-              for(ordinal_type k=0; k<basisCardinality; ++k) {
-                for(ordinal_type j=0; j<basisCardinality; ++j){
-                  ValueType dofValue=0;
-                  for(ordinal_type d=0; d<dim; ++d)
-                    dofValue += basisValuesAtDofCoordsOriented(i,k,j,d) * dofCoeffs(i,j,d);
-                  if ( k==j && std::abs( dofValue - 1.0 ) > 100*tol ) {
-                    errorFlag++;
-                    *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-                    *outStream << " Basis function " << k << " of cell " << i << " does not have unit value at its node (" << dofValue <<")\n";
-                  }
-                  if ( k!=j && std::abs( dofValue ) > tol ) {
-                    errorFlag++;
-                    *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-                    *outStream << " Basis function " << k << " of cell " << i << " does not vanish at node " << j << "(" << dofValue <<")\n";
-                  }
+              FunCurl fun;
+              DynRankView ConstructWithLabel(fwdFunAtDofCoords, numCells, basisCardinality, dim);
+              for(ordinal_type i=0; i<numCells; ++i) {
+                for(ordinal_type j=0; j<basisCardinality; ++j) {
+                  for(ordinal_type k=0; k<dim; ++k)
+                    funAtDofCoords(i,j,k) = fun(degree, physDofCoords(i,j,0), physDofCoords(i,j,1), physDofCoords(i,j,2), k);
+                  for(ordinal_type k=0; k<dim; ++k)
+                    for(ordinal_type d=0; d<dim; ++d)
+                      fwdFunAtDofCoords(i,j,k) += jacobian(i,j,d,k)*funAtDofCoords(i,j,d);
                 }
               }
-            }
-          }
 
-          //check that fun values are consistent on common edges dofs
-          {
-            bool areDifferent(false);
-            auto numEdgeDOFs = basisPtr->getDofCount(1,0);
-            for(std::size_t iEdge=0;iEdge<common_edges.size();iEdge++) {
-              for(ordinal_type j=0;j<numEdgeDOFs && !areDifferent;j++) {
-                areDifferent = std::abs(basisCoeffsLI(0,basisPtr->getDofOrdinal(1,edgeIndexes[0][iEdge],j))
-                    - basisCoeffsLI(1,basisPtr->getDofOrdinal(1,edgeIndexes[1][iEdge],j))) > 10*tol;
+              li::getBasisCoeffs(basisCoeffsLI, fwdFunAtDofCoords, dofCoeffs);
+            }
+
+
+            //Testing Kronecker property of basis functions
+            {
+              for(ordinal_type i=0; i<numCells; ++i) {
+                DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality, dim);
+                DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
+                auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
+                auto outView =Kokkos::subview( basisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+                basisPtr->getValues(outView, inView);
+
+                // modify basis values to account for orientations
+                ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
+                    basisValuesAtDofCoords,
+                    elemOrts,
+                    basisPtr);
+
+                for(ordinal_type k=0; k<basisCardinality; ++k) {
+                  for(ordinal_type j=0; j<basisCardinality; ++j){
+                    ValueType dofValue=0;
+                    for(ordinal_type d=0; d<dim; ++d)
+                      dofValue += basisValuesAtDofCoordsOriented(i,k,j,d) * dofCoeffs(i,j,d);
+                    if ( k==j && std::abs( dofValue - 1.0 ) > 100*tol ) {
+                      errorFlag++;
+                      *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                      *outStream << " Basis function " << k << " of cell " << i << " does not have unit value at its node (" << dofValue <<")\n";
+                    }
+                    if ( k!=j && std::abs( dofValue ) > tol ) {
+                      errorFlag++;
+                      *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                      *outStream << " Basis function " << k << " of cell " << i << " does not vanish at node " << j << "(" << dofValue <<")\n";
+                    }
+                  }
+                }
               }
+            }
+
+            //check that fun values are consistent on common edges dofs
+            {
+              bool areDifferent(false);
+              auto numEdgeDOFs = basisPtr->getDofCount(1,0);
+              for(std::size_t iEdge=0;iEdge<common_edges.size();iEdge++) {
+                for(ordinal_type j=0;j<numEdgeDOFs && !areDifferent;j++) {
+                  areDifferent = std::abs(basisCoeffsLI(0,basisPtr->getDofOrdinal(1,edgeIndexes[0][iEdge],j))
+                      - basisCoeffsLI(1,basisPtr->getDofOrdinal(1,edgeIndexes[1][iEdge],j))) > 10*tol;
+                }
+                if(areDifferent) {
+                  errorFlag++;
+                  *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                  *outStream << "Function DOFs on common edge " << iEdge << " computed using Hex 0 basis functions are not consistent with those computed using Hex 1\n";
+                  *outStream << "Function DOFs for Hex 0 are:";
+                  for(ordinal_type j=0;j<numEdgeDOFs;j++)
+                    *outStream << " " << basisCoeffsLI(0,basisPtr->getDofOrdinal(1,edgeIndexes[0][iEdge],j));
+                  *outStream << "\nFunction DOFs for Hex 1 are:";
+                  for(ordinal_type j=0;j<numEdgeDOFs;j++)
+                    *outStream << " " << basisCoeffsLI(1,basisPtr->getDofOrdinal(1,edgeIndexes[1][iEdge],j));
+                  *outStream << std::endl;
+                }
+              }
+            }
+
+            //check that fun values are consistent on common face dofs
+            {
+              bool areDifferent(false);
+              auto numFaceDOFs = basisPtr->getDofCount(2,0);
+              for(ordinal_type j=0;j<numFaceDOFs && !areDifferent;j++) {
+                areDifferent = std::abs(basisCoeffsLI(0,basisPtr->getDofOrdinal(2,faceIndex[0],j))
+                    - basisCoeffsLI(1,basisPtr->getDofOrdinal(2,faceIndex[1],j))) > 10*tol;
+              }
+
               if(areDifferent) {
                 errorFlag++;
                 *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-                *outStream << "Function DOFs on common edge " << iEdge << " computed using Hex 0 basis functions are not consistent with those computed using Hex 1\n";
+                *outStream << "Function DOFs on common face computed using Hex 0 basis functions are not consistent with those computed using Hex 1\n";
                 *outStream << "Function DOFs for Hex 0 are:";
-                for(ordinal_type j=0;j<numEdgeDOFs;j++)
-                  *outStream << " " << basisCoeffsLI(0,basisPtr->getDofOrdinal(1,edgeIndexes[0][iEdge],j));
+                for(ordinal_type j=0;j<numFaceDOFs;j++)
+                  *outStream << " " << basisCoeffsLI(0,basisPtr->getDofOrdinal(2,faceIndex[0],j)) << " | (" << physDofCoords(0,basisPtr->getDofOrdinal(2,faceIndex[0],j),0) << "," << physDofCoords(0,basisPtr->getDofOrdinal(2,faceIndex[0],j),1) << ", " << physDofCoords(0,basisPtr->getDofOrdinal(2,faceIndex[0],j),2) << ") ||";
                 *outStream << "\nFunction DOFs for Hex 1 are:";
-                for(ordinal_type j=0;j<numEdgeDOFs;j++)
-                  *outStream << " " << basisCoeffsLI(1,basisPtr->getDofOrdinal(1,edgeIndexes[1][iEdge],j));
+                for(ordinal_type j=0;j<numFaceDOFs;j++)
+                  *outStream << " " << basisCoeffsLI(1,basisPtr->getDofOrdinal(2,faceIndex[1],j))<< " | (" << physDofCoords(1,basisPtr->getDofOrdinal(2,faceIndex[1],j),0) << "," << physDofCoords(1,basisPtr->getDofOrdinal(2,faceIndex[1],j),1) << ", " << physDofCoords(1,basisPtr->getDofOrdinal(2,faceIndex[1],j),2) << ") ||";
                 *outStream << std::endl;
               }
             }
-          }
 
-          //check that fun values are consistent on common face dofs
-          {
-            bool areDifferent(false);
-            auto numFaceDOFs = basisPtr->getDofCount(2,0);
-            for(ordinal_type j=0;j<numFaceDOFs && !areDifferent;j++) {
-              areDifferent = std::abs(basisCoeffsLI(0,basisPtr->getDofOrdinal(2,faceIndex[0],j))
-                  - basisCoeffsLI(1,basisPtr->getDofOrdinal(2,faceIndex[1],j))) > 10*tol;
-            }
+            //check that fun values at reference points coincide with those computed using basis functions
+            DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
+            DynRankView ConstructWithLabel(transformedBasisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
+            DynRankView basisValuesAtDofCoordsCells("inValues", numCells, basisCardinality, basisCardinality, dim);
 
-            if(areDifferent) {
-              errorFlag++;
-              *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-              *outStream << "Function DOFs on common face computed using Hex 0 basis functions are not consistent with those computed using Hex 1\n";
-              *outStream << "Function DOFs for Hex 0 are:";
-              for(ordinal_type j=0;j<numFaceDOFs;j++)
-                *outStream << " " << basisCoeffsLI(0,basisPtr->getDofOrdinal(2,faceIndex[0],j)) << " | (" << physDofCoords(0,basisPtr->getDofOrdinal(2,faceIndex[0],j),0) << "," << physDofCoords(0,basisPtr->getDofOrdinal(2,faceIndex[0],j),1) << ", " << physDofCoords(0,basisPtr->getDofOrdinal(2,faceIndex[0],j),2) << ") ||";
-              *outStream << "\nFunction DOFs for Hex 1 are:";
-              for(ordinal_type j=0;j<numFaceDOFs;j++)
-                *outStream << " " << basisCoeffsLI(1,basisPtr->getDofOrdinal(2,faceIndex[1],j))<< " | (" << physDofCoords(1,basisPtr->getDofOrdinal(2,faceIndex[1],j),0) << "," << physDofCoords(1,basisPtr->getDofOrdinal(2,faceIndex[1],j),1) << ", " << physDofCoords(1,basisPtr->getDofOrdinal(2,faceIndex[1],j),2) << ") ||";
-              *outStream << std::endl;
-            }
-          }
+            for (ordinal_type ic = 0; ic < numCells; ++ic)
+              basisPtr->getValues(Kokkos::subview(basisValuesAtDofCoordsCells, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(dofCoordsOriented, ic, Kokkos::ALL(), Kokkos::ALL()));
 
-          //check that fun values at reference points coincide with those computed using basis functions
-          DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
-          DynRankView ConstructWithLabel(transformedBasisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
-          DynRankView basisValuesAtDofCoordsCells("inValues", numCells, basisCardinality, basisCardinality, dim);
+            // modify basis values to account for orientations
+            ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
+                basisValuesAtDofCoordsCells,
+                elemOrts,
+                basisPtr);
 
-          for (ordinal_type ic = 0; ic < numCells; ++ic)
-            basisPtr->getValues(Kokkos::subview(basisValuesAtDofCoordsCells, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(dofCoordsOriented, ic, Kokkos::ALL(), Kokkos::ALL()));
+            // transform basis values
+            DynRankView ConstructWithLabel(jacobianAtDofCoords, numCells, basisCardinality, dim, dim);
+            DynRankView ConstructWithLabel(jacobianAtDofCoords_inv, numCells, basisCardinality, dim, dim);
+            ct::setJacobian(jacobianAtDofCoords, dofCoordsOriented, physVertexes, hex);
+            ct::setJacobianInv (jacobianAtDofCoords_inv, jacobianAtDofCoords);
+            fst::HCURLtransformVALUE(transformedBasisValuesAtDofCoordsOriented,
+                jacobianAtDofCoords_inv,
+                basisValuesAtDofCoordsOriented);
+            DynRankView ConstructWithLabel(funAtDofCoordsOriented, numCells, basisCardinality, dim);
+            for(ordinal_type i=0; i<numCells; ++i) {
+              ValueType error=0;
+              for(ordinal_type j=0; j<basisCardinality; ++j)
+                for(ordinal_type d=0; d<dim; ++d) {
+                  for(ordinal_type k=0; k<basisCardinality; ++k)
+                    funAtDofCoordsOriented(i,j,d) += basisCoeffsLI(i,k)*transformedBasisValuesAtDofCoordsOriented(i,k,j,d);
 
-          // modify basis values to account for orientations
-          ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
-              basisValuesAtDofCoordsCells,
-              elemOrts,
-              basisPtr.get());
+                  error = std::max(std::abs( funAtDofCoords(i,j,d) - funAtDofCoordsOriented(i,j,d)), error);
+                }
 
-          // transform basis values
-          DynRankView ConstructWithLabel(jacobianAtDofCoords, numCells, basisCardinality, dim, dim);
-          DynRankView ConstructWithLabel(jacobianAtDofCoords_inv, numCells, basisCardinality, dim, dim);
-          ct::setJacobian(jacobianAtDofCoords, dofCoordsOriented, physVertexes, hex);
-          ct::setJacobianInv (jacobianAtDofCoords_inv, jacobianAtDofCoords);
-          fst::HCURLtransformVALUE(transformedBasisValuesAtDofCoordsOriented,
-              jacobianAtDofCoords_inv,
-              basisValuesAtDofCoordsOriented);
-          DynRankView ConstructWithLabel(funAtDofCoordsOriented, numCells, basisCardinality, dim);
-          for(ordinal_type i=0; i<numCells; ++i) {
-            ValueType error=0;
-            for(ordinal_type j=0; j<basisCardinality; ++j)
-              for(ordinal_type d=0; d<dim; ++d) {
-                for(ordinal_type k=0; k<basisCardinality; ++k)
-                  funAtDofCoordsOriented(i,j,d) += basisCoeffsLI(i,k)*transformedBasisValuesAtDofCoordsOriented(i,k,j,d);
-
-                error = std::max(std::abs( funAtDofCoords(i,j,d) - funAtDofCoordsOriented(i,j,d)), error);
+              if(error>100*tol) {
+                errorFlag++;
+                *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                *outStream << "Function values at reference points differ from those computed using basis functions of Hex " << i << "\n";
+                *outStream << "Function values at reference points are:\n";
+                for(ordinal_type j=0; j<basisCardinality; ++j)
+                  *outStream << " (" << funAtDofCoords(i,j,0) << "," << funAtDofCoords(i,j,1) << ", " << funAtDofCoords(i,j,2) << ")";
+                *outStream << "\nFunction values at reference points computed using basis functions are\n";
+                for(ordinal_type j=0; j<basisCardinality; ++j)
+                  *outStream << " (" << funAtDofCoordsOriented(i,j,0) << "," << funAtDofCoordsOriented(i,j,1) << ", " << funAtDofCoordsOriented(i,j,2) << ")";
+                *outStream << std::endl;
               }
-
-            if(error>100*tol) {
-              errorFlag++;
-              *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-              *outStream << "Function values at reference points differ from those computed using basis functions of Hex " << i << "\n";
-              *outStream << "Function values at reference points are:\n";
-              for(ordinal_type j=0; j<basisCardinality; ++j)
-                *outStream << " (" << funAtDofCoords(i,j,0) << "," << funAtDofCoords(i,j,1) << ", " << funAtDofCoords(i,j,2) << ")";
-              *outStream << "\nFunction values at reference points computed using basis functions are\n";
-              for(ordinal_type j=0; j<basisCardinality; ++j)
-                *outStream << " (" << funAtDofCoordsOriented(i,j,0) << "," << funAtDofCoordsOriented(i,j,1) << ", " << funAtDofCoordsOriented(i,j,2) << ")";
-              *outStream << std::endl;
             }
-          }
 
-          //compute projection-based interpolation of the Lagrangian interpolation
-          DynRankView ConstructWithLabel(basisCoeffsHCurl, numCells, basisCardinality);
-          {
-            ordinal_type targetCubDegree(basisPtr->getDegree()),targetDerivCubDegree(basisPtr->getDegree()-1);
+            //compute projection-based interpolation of the Lagrangian interpolation
+            DynRankView ConstructWithLabel(basisCoeffsHCurl, numCells, basisCardinality);
+            {
+              ordinal_type targetCubDegree(basisPtr->getDegree()),targetDerivCubDegree(basisPtr->getDegree()-1);
 
-            Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
-            projStruct.createHCurlProjectionStruct(basisPtr.get(), targetCubDegree, targetDerivCubDegree);
+              Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
+              projStruct.createHCurlProjectionStruct(basisPtr, targetCubDegree, targetDerivCubDegree);
 
-            ordinal_type numPoints = projStruct.getNumTargetEvalPoints(), numCurlPoints = projStruct.getNumTargetDerivEvalPoints();
-            DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
-            DynRankView ConstructWithLabel(evaluationCurlPoints, numCells, numCurlPoints, dim);
+              ordinal_type numPoints = projStruct.getNumTargetEvalPoints(), numCurlPoints = projStruct.getNumTargetDerivEvalPoints();
+              DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
+              DynRankView ConstructWithLabel(evaluationCurlPoints, numCells, numCurlPoints, dim);
 
-            pts::getHCurlEvaluationPoints(evaluationPoints,
-                evaluationCurlPoints,
-                elemOrts,
-                basisPtr.get(),
-                &projStruct);
-
-
-            DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints, dim);
-            DynRankView ConstructWithLabel(targetCurlAtEvalPoints, numCells, numCurlPoints, dim);
-
-            DynRankView ConstructWithLabel(hcurlBasisAtEvaluationPoints, numCells, basisCardinality , numPoints, dim);
-            DynRankView ConstructWithLabel(hcurlBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints, dim);
-            for(int ic=0; ic<numCells; ic++)
-              basisPtr->getValues(Kokkos::subview(hcurlBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
-            ots::modifyBasisByOrientation(hcurlBasisAtEvaluationPoints,
-                hcurlBasisAtEvaluationPointsNonOriented,
-                elemOrts,
-                basisPtr.get());
-
-            DynRankView ConstructWithLabel(curlOfHCurlBasisAtEvaluationPoints, numCells, basisCardinality , numCurlPoints, dim);
-            if(numCurlPoints>0) {
-              DynRankView ConstructWithLabel(curlOfHCurlBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numCurlPoints, dim);
-              for(int ic=0; ic<numCells; ic++)
-                basisPtr->getValues(Kokkos::subview(curlOfHCurlBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationCurlPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_CURL);
-              ots::modifyBasisByOrientation(curlOfHCurlBasisAtEvaluationPoints,
-                  curlOfHCurlBasisAtEvaluationPointsNonOriented,
+              pts::getHCurlEvaluationPoints(evaluationPoints,
+                  evaluationCurlPoints,
                   elemOrts,
-                  basisPtr.get());
-            }
+                  basisPtr,
+                  &projStruct);
 
 
-            for(int ic=0; ic<numCells; ic++){
-              for(int i=0;i<numPoints;i++) {
-                for(int k=0;k<basisCardinality;k++)
-                  for(int d=0;d<dim;d++)
-                    targetAtEvalPoints(ic,i,d) += basisCoeffsLI(ic,k)*hcurlBasisAtEvaluationPoints(ic,k,i,d);
-              }
-              for(int i=0;i<numCurlPoints;i++) {
-                for(int k=0;k<basisCardinality;k++)
-                  for(int d=0;d<dim;d++)
-                    targetCurlAtEvalPoints(ic,i,d) += basisCoeffsLI(ic,k)*curlOfHCurlBasisAtEvaluationPoints(ic,k,i,d);//funHCurlCoeffs(k)
-              }
-            }
+              DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints, dim);
+              DynRankView ConstructWithLabel(targetCurlAtEvalPoints, numCells, numCurlPoints, dim);
 
-            pts::getHCurlBasisCoeffs(basisCoeffsHCurl,
-                targetAtEvalPoints,
-                targetCurlAtEvalPoints,
-                evaluationPoints,
-                evaluationCurlPoints,
-                elemOrts,
-                basisPtr.get(),
-                &projStruct);
-          }
-
-          //check that the basis coefficients of the Lagrangian interpolation are the same as those of the projection-based interpolation
-          {
-            ValueType diffErr(0);
-
-            for(int k=0;k<basisCardinality;k++) {
+              DynRankView ConstructWithLabel(hcurlBasisAtEvaluationPoints, numCells, basisCardinality , numPoints, dim);
+              DynRankView ConstructWithLabel(hcurlBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints, dim);
               for(int ic=0; ic<numCells; ic++)
-                diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsHCurl(ic,k)));
+                basisPtr->getValues(Kokkos::subview(hcurlBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
+              ots::modifyBasisByOrientation(hcurlBasisAtEvaluationPoints,
+                  hcurlBasisAtEvaluationPointsNonOriented,
+                  elemOrts,
+                  basisPtr);
+
+              DynRankView ConstructWithLabel(curlOfHCurlBasisAtEvaluationPoints, numCells, basisCardinality , numCurlPoints, dim);
+              if(numCurlPoints>0) {
+                DynRankView ConstructWithLabel(curlOfHCurlBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numCurlPoints, dim);
+                for(int ic=0; ic<numCells; ic++)
+                  basisPtr->getValues(Kokkos::subview(curlOfHCurlBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationCurlPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_CURL);
+                ots::modifyBasisByOrientation(curlOfHCurlBasisAtEvaluationPoints,
+                    curlOfHCurlBasisAtEvaluationPointsNonOriented,
+                    elemOrts,
+                    basisPtr);
+              }
+
+
+              for(int ic=0; ic<numCells; ic++){
+                for(int i=0;i<numPoints;i++) {
+                  for(int k=0;k<basisCardinality;k++)
+                    for(int d=0;d<dim;d++)
+                      targetAtEvalPoints(ic,i,d) += basisCoeffsLI(ic,k)*hcurlBasisAtEvaluationPoints(ic,k,i,d);
+                }
+                for(int i=0;i<numCurlPoints;i++) {
+                  for(int k=0;k<basisCardinality;k++)
+                    for(int d=0;d<dim;d++)
+                      targetCurlAtEvalPoints(ic,i,d) += basisCoeffsLI(ic,k)*curlOfHCurlBasisAtEvaluationPoints(ic,k,i,d);//funHCurlCoeffs(k)
+                }
+              }
+
+              pts::getHCurlBasisCoeffs(basisCoeffsHCurl,
+                  targetAtEvalPoints,
+                  targetCurlAtEvalPoints,
+                  evaluationPoints,
+                  evaluationCurlPoints,
+                  elemOrts,
+                  basisPtr,
+                  &projStruct);
             }
 
+            //check that the basis coefficients of the Lagrangian interpolation are the same as those of the projection-based interpolation
+            {
+              ValueType diffErr(0);
 
-            if(diffErr > pow(7, degree-1)*tol) { //heuristic relation on how round-off error depends on degree
-              errorFlag++;
-              *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-              *outStream << "HCURL_I" << degree << ": The weights recovered with the optimization are different than the one used for generating the functon."<<
-                  "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
-            }
-          }
-
-
-          //compute L2 projection of the Lagrangian interpolation
-          DynRankView ConstructWithLabel(basisCoeffsL2, numCells, basisCardinality);
-          {
-            ordinal_type targetCubDegree(basisPtr->getDegree());
-
-            Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
-            projStruct.createL2ProjectionStruct(basisPtr.get(), targetCubDegree);
-
-            ordinal_type numPoints = projStruct.getNumTargetEvalPoints();
-            DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
-
-            pts::getL2EvaluationPoints(evaluationPoints,
-                elemOrts,
-                basisPtr.get(),
-                &projStruct);
+              for(int k=0;k<basisCardinality;k++) {
+                for(int ic=0; ic<numCells; ic++)
+                  diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsHCurl(ic,k)));
+              }
 
 
-            DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints, dim);
-
-            DynRankView ConstructWithLabel(hcurlBasisAtEvaluationPoints, numCells, basisCardinality , numPoints, dim);
-            DynRankView ConstructWithLabel(hcurlBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints, dim);
-            for(int ic=0; ic<numCells; ic++)
-              basisPtr->getValues(Kokkos::subview(hcurlBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
-            ots::modifyBasisByOrientation(hcurlBasisAtEvaluationPoints,
-                hcurlBasisAtEvaluationPointsNonOriented,
-                elemOrts,
-                basisPtr.get());
-
-            for(int ic=0; ic<numCells; ic++){
-              for(int i=0;i<numPoints;i++) {
-                for(int k=0;k<basisCardinality;k++)
-                  for(int d=0;d<dim;d++)
-                    targetAtEvalPoints(ic,i,d) += basisCoeffsLI(ic,k)*hcurlBasisAtEvaluationPoints(ic,k,i,d);
+              if(diffErr > pow(10, degree-1)*tol) { //heuristic relation on how round-off error depends on degree
+                errorFlag++;
+                *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                *outStream << "HCURL_I" << degree << ": The weights recovered with the optimization are different than the one used for generating the functon."<<
+                    "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << " " <<pow(7, degree-1)*tol <<  std::endl;
               }
             }
 
-            pts::getL2BasisCoeffs(basisCoeffsL2,
-                targetAtEvalPoints,
-                evaluationPoints,
-                elemOrts,
-                basisPtr.get(),
-                &projStruct);
-          }
 
-          //check that the basis coefficients of the Lagrangian interpolation are the same as those of the L2 projection
-          {
-            ValueType diffErr = 0;
-            for(int k=0;k<basisCardinality;k++) {
+            //compute L2 projection of the Lagrangian interpolation
+            DynRankView ConstructWithLabel(basisCoeffsL2, numCells, basisCardinality);
+            {
+              ordinal_type targetCubDegree(basisPtr->getDegree());
+
+              Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
+              projStruct.createL2ProjectionStruct(basisPtr, targetCubDegree);
+
+              ordinal_type numPoints = projStruct.getNumTargetEvalPoints();
+              DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
+
+              pts::getL2EvaluationPoints(evaluationPoints,
+                  elemOrts,
+                  basisPtr,
+                  &projStruct);
+
+
+              DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints, dim);
+
+              DynRankView ConstructWithLabel(hcurlBasisAtEvaluationPoints, numCells, basisCardinality , numPoints, dim);
+              DynRankView ConstructWithLabel(hcurlBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints, dim);
               for(int ic=0; ic<numCells; ic++)
-                diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsL2(ic,k)));
+                basisPtr->getValues(Kokkos::subview(hcurlBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
+              ots::modifyBasisByOrientation(hcurlBasisAtEvaluationPoints,
+                  hcurlBasisAtEvaluationPointsNonOriented,
+                  elemOrts,
+                  basisPtr);
+
+              for(int ic=0; ic<numCells; ic++){
+                for(int i=0;i<numPoints;i++) {
+                  for(int k=0;k<basisCardinality;k++)
+                    for(int d=0;d<dim;d++)
+                      targetAtEvalPoints(ic,i,d) += basisCoeffsLI(ic,k)*hcurlBasisAtEvaluationPoints(ic,k,i,d);
+                }
+              }
+
+              pts::getL2BasisCoeffs(basisCoeffsL2,
+                  targetAtEvalPoints,
+                  evaluationPoints,
+                  elemOrts,
+                  basisPtr,
+                  &projStruct);
             }
 
-            if(diffErr > pow(7, degree-1)*tol) { //heuristic relation on how round-off error depends on degree
-              errorFlag++;
-              *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-              *outStream << "HCURL_I" << degree << ": The weights recovered with the L2 optimization are different than the one used for generating the functon."<<
-                  "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
+            //check that the basis coefficients of the Lagrangian interpolation are the same as those of the L2 projection
+            {
+              ValueType diffErr = 0;
+              for(int k=0;k<basisCardinality;k++) {
+                for(int ic=0; ic<numCells; ic++)
+                  diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsL2(ic,k)));
+              }
+
+              if(diffErr > pow(7, degree-1)*tol) { //heuristic relation on how round-off error depends on degree
+                errorFlag++;
+                *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                *outStream << "HCURL_I" << degree << ": The weights recovered with the L2 optimization are different than the one used for generating the functon."<<
+                    "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
+              }
             }
+            delete basisPtr;
           }
         }
       }
@@ -1122,7 +1166,10 @@ int InterpolationProjectionHex(const bool verbose) {
 
     ordinal_type reorder[numTotalVertexes] = {0,1,2,3,4,5,6,7,8,9,10,11};
 
+    int sharedSideCount = 0;
     do {
+      if((sharedSideCount++ != sharedSidePermutation) && pickTest)
+        continue;
       ordinal_type orderback[numTotalVertexes];
       for(ordinal_type i=0;i<numTotalVertexes;++i) {
         orderback[reorder[i]]=i;
@@ -1131,7 +1178,9 @@ int InterpolationProjectionHex(const bool verbose) {
       ordinal_type hexas[numCells][numElemVertexes];
       std::copy(&hexas_orig[0][0], &hexas_orig[0][0]+numCells*numElemVertexes, &hexas_rotated[0][0]);
 
-      for (ordinal_type shift=0; shift<1; ++shift) {
+      for (ordinal_type shift=0; shift<6; ++shift) {
+        if(pickTest && (shift != elemPermutation))
+          continue;
         if(shift <4){
           std::rotate_copy(faceLeft.begin(), faceLeft.begin()+shift, faceLeft.end(), faceLeftOriented.begin());
           std::rotate_copy(faceRight.begin(), faceRight.begin()+shift, faceRight.end(), faceRightOriented.begin());
@@ -1206,341 +1255,347 @@ int InterpolationProjectionHex(const bool verbose) {
 
         for (ordinal_type degree=1; degree <= max_degree; degree++) {
 
-          Teuchos::RCP<Basis<DeviceSpaceType,ValueType,ValueType> > basisPtr;
+          basis_set.clear();
           if(degree==1)
-            basisPtr = Teuchos::rcp(new Basis_HDIV_HEX_I1_FEM<DeviceSpaceType,ValueType,ValueType>());
-          else
-            basisPtr = Teuchos::rcp(new Basis_HDIV_HEX_In_FEM<DeviceSpaceType,ValueType,ValueType>(degree));
+            basis_set.push_back(new Basis_HDIV_HEX_I1_FEM<DeviceSpaceType,ValueType,ValueType>());
+          basis_set.push_back(new typename  CG_NBasis::HDIV_HEX(degree));
+          basis_set.push_back(new typename  CG_DNBasis::HDIV_HEX(degree));
 
-          ordinal_type basisCardinality = basisPtr->getCardinality();
+          for (auto basisPtr:basis_set) {
 
-          //compute DofCoords Oriented
+            auto name = basisPtr->getName();
+            *outStream << " " << name << std::endl;
+            ordinal_type basisCardinality = basisPtr->getCardinality();
 
-          DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
-          DynRankView ConstructWithLabel(dofCoeffs, numCells, basisCardinality, dim);
-          DynRankView ConstructWithLabel(physDofCoords, numCells, basisCardinality, dim);
-          DynRankView ConstructWithLabel(funAtDofCoords, numCells, basisCardinality, dim);
-          DynRankView ConstructWithLabel(basisCoeffsLI, numCells, basisCardinality);
+            //compute DofCoords Oriented
 
-          //compute Lagrangian Interpolation of fun
-          {
+            DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
+            DynRankView ConstructWithLabel(dofCoeffs, numCells, basisCardinality, dim);
+            DynRankView ConstructWithLabel(physDofCoords, numCells, basisCardinality, dim);
+            DynRankView ConstructWithLabel(funAtDofCoords, numCells, basisCardinality, dim);
+            DynRankView ConstructWithLabel(basisCoeffsLI, numCells, basisCardinality);
 
-            li::getDofCoordsAndCoeffs(dofCoordsOriented,  dofCoeffs, basisPtr.get(), POINTTYPE_WARPBLEND, elemOrts);
+            //compute Lagrangian Interpolation of fun
+            {
 
-            //Compute physical Dof Coordinates
-            Basis_HGRAD_HEX_C1_FEM<DeviceSpaceType,ValueType,ValueType> hexLinearBasis; //used for computing physical coordinates
-            DynRankView ConstructWithLabel(hexLinearBasisValuesAtDofCoords, numCells, hex.getNodeCount(), basisCardinality);
-            for(ordinal_type i=0; i<numCells; ++i)
-              for(ordinal_type d=0; d<dim; ++d) {
-                auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
-                auto outView =Kokkos::subview( hexLinearBasisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
-                hexLinearBasis.getValues(outView, inView);
-                DeviceSpaceType().fence();
-                for(ordinal_type j=0; j<basisCardinality; ++j)
-                  for(std::size_t k=0; k<hex.getNodeCount(); ++k)
-                    physDofCoords(i,j,d) += vertices[hexas[i][k]][d]*hexLinearBasisValuesAtDofCoords(i,k,j);
-              }
+              li::getDofCoordsAndCoeffs(dofCoordsOriented,  dofCoeffs, basisPtr, POINTTYPE_EQUISPACED, elemOrts);
 
-            //need to transform dofCoeff to physical space (they transform as normals)
-            DynRankView ConstructWithLabel(jacobian, numCells, basisCardinality, dim, dim);
-            DynRankView ConstructWithLabel(jacobian_inv, numCells, basisCardinality, dim, dim);
-            DynRankView ConstructWithLabel(jacobian_det, numCells, basisCardinality);
-            ct::setJacobian(jacobian, dofCoordsOriented, physVertexes, hex);
-            ct::setJacobianInv (jacobian_inv, jacobian);
-            ct::setJacobianDet (jacobian_det, jacobian);
+              //Compute physical Dof Coordinates
+              Basis_HGRAD_HEX_C1_FEM<DeviceSpaceType,ValueType,ValueType> hexLinearBasis; //used for computing physical coordinates
+              DynRankView ConstructWithLabel(hexLinearBasisValuesAtDofCoords, numCells, hex.getNodeCount(), basisCardinality);
+              for(ordinal_type i=0; i<numCells; ++i)
+                for(ordinal_type d=0; d<dim; ++d) {
+                  auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
+                  auto outView =Kokkos::subview( hexLinearBasisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+                  hexLinearBasis.getValues(outView, inView);
+                  DeviceSpaceType().fence();
+                  for(ordinal_type j=0; j<basisCardinality; ++j)
+                    for(std::size_t k=0; k<hex.getNodeCount(); ++k)
+                      physDofCoords(i,j,d) += vertices[hexas[i][k]][d]*hexLinearBasisValuesAtDofCoords(i,k,j);
+                }
 
-
-            FunDiv fun;
-            DynRankView ConstructWithLabel(fwdFunAtDofCoords, numCells, basisCardinality, dim);
-            for(ordinal_type i=0; i<numCells; ++i) {
-              for(ordinal_type j=0; j<basisCardinality; ++j){
-                for(ordinal_type k=0; k<dim; ++k)
-                  funAtDofCoords(i,j,k) = fun(degree, physDofCoords(i,j,0), physDofCoords(i,j,1), physDofCoords(i,j,2), k);
-                for(ordinal_type k=0; k<dim; ++k)
-                  for(ordinal_type d=0; d<dim; ++d)
-                    fwdFunAtDofCoords(i,j,k) += jacobian_det(i,j)*jacobian_inv(i,j,k,d)*funAtDofCoords(i,j,d);
-
-              }
-            }
-            li::getBasisCoeffs(basisCoeffsLI, fwdFunAtDofCoords, dofCoeffs);
-          }
-
-          //Testing Kronecker property of basis functions
-          {
-            for(ordinal_type i=0; i<numCells; ++i) {
-              DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality, dim);
-              DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
-              auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
-              auto outView =Kokkos::subview( basisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
-              basisPtr->getValues(outView, inView);
-
-              // modify basis values to account for orientations
-              ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
-                  basisValuesAtDofCoords,
-                  elemOrts,
-                  basisPtr.get());
-
+              //need to transform dofCoeff to physical space (they transform as normals)
               DynRankView ConstructWithLabel(jacobian, numCells, basisCardinality, dim, dim);
+              DynRankView ConstructWithLabel(jacobian_inv, numCells, basisCardinality, dim, dim);
               DynRankView ConstructWithLabel(jacobian_det, numCells, basisCardinality);
               ct::setJacobian(jacobian, dofCoordsOriented, physVertexes, hex);
+              ct::setJacobianInv (jacobian_inv, jacobian);
               ct::setJacobianDet (jacobian_det, jacobian);
 
-              for(ordinal_type k=0; k<basisCardinality; ++k) {
+
+              FunDiv fun;
+              DynRankView ConstructWithLabel(fwdFunAtDofCoords, numCells, basisCardinality, dim);
+              for(ordinal_type i=0; i<numCells; ++i) {
                 for(ordinal_type j=0; j<basisCardinality; ++j){
-                  ValueType dofValue=0;
-                  for(ordinal_type d=0; d<dim; ++d)
-                    dofValue += basisValuesAtDofCoordsOriented(i,k,j,d) * dofCoeffs(i,j,d);
-                  if ( k==j && std::abs( dofValue - 1.0 ) > 100*tol ) {
-                    errorFlag++;
-                    *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-                    *outStream << " Basis function " << k << " of cell " << i << " does not have unit value at its node (" << dofValue <<")\n";
-                  }
-                  if ( k!=j && std::abs( dofValue ) > tol ) {
-                    errorFlag++;
-                    *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-                    *outStream << " Basis function " << k << " of cell " << i << " does not vanish at node " << j << "(" << dofValue <<")\n";
+                  for(ordinal_type k=0; k<dim; ++k)
+                    funAtDofCoords(i,j,k) = fun(degree, physDofCoords(i,j,0), physDofCoords(i,j,1), physDofCoords(i,j,2), k);
+                  for(ordinal_type k=0; k<dim; ++k)
+                    for(ordinal_type d=0; d<dim; ++d)
+                      fwdFunAtDofCoords(i,j,k) += jacobian_det(i,j)*jacobian_inv(i,j,k,d)*funAtDofCoords(i,j,d);
+
+                }
+              }
+              li::getBasisCoeffs(basisCoeffsLI, fwdFunAtDofCoords, dofCoeffs);
+            }
+
+            //Testing Kronecker property of basis functions
+            {
+              for(ordinal_type i=0; i<numCells; ++i) {
+                DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality, dim);
+                DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
+                auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
+                auto outView =Kokkos::subview( basisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+                basisPtr->getValues(outView, inView);
+
+                // modify basis values to account for orientations
+                ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
+                    basisValuesAtDofCoords,
+                    elemOrts,
+                    basisPtr);
+
+                DynRankView ConstructWithLabel(jacobian, numCells, basisCardinality, dim, dim);
+                DynRankView ConstructWithLabel(jacobian_det, numCells, basisCardinality);
+                ct::setJacobian(jacobian, dofCoordsOriented, physVertexes, hex);
+                ct::setJacobianDet (jacobian_det, jacobian);
+
+                for(ordinal_type k=0; k<basisCardinality; ++k) {
+                  for(ordinal_type j=0; j<basisCardinality; ++j){
+                    ValueType dofValue=0;
+                    for(ordinal_type d=0; d<dim; ++d)
+                      dofValue += basisValuesAtDofCoordsOriented(i,k,j,d) * dofCoeffs(i,j,d);
+                    if ( k==j && std::abs( dofValue - 1.0 ) > 100*tol ) {
+                      errorFlag++;
+                      *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                      *outStream << " Basis function " << k << " of cell " << i << " does not have unit value at its node (" << dofValue <<")\n";
+                    }
+                    if ( k!=j && std::abs( dofValue ) > tol ) {
+                      errorFlag++;
+                      *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                      *outStream << " Basis function " << k << " of cell " << i << " does not vanish at node " << j << "(" << dofValue <<")\n";
+                    }
                   }
                 }
               }
             }
-          }
 
-          //check that fun values are consistent on common face dofs
-          {
-            bool areDifferent(false);
-            auto numFaceDOFs = basisPtr->getDofCount(2,0);
-            for(ordinal_type j=0;j<numFaceDOFs && !areDifferent;j++) {
-              areDifferent = std::abs(basisCoeffsLI(0,basisPtr->getDofOrdinal(2,faceIndex[0],j))
-                  - basisCoeffsLI(1,basisPtr->getDofOrdinal(2,faceIndex[1],j))) > 10*tol;
-            }
-
-            if(areDifferent) {
-              errorFlag++;
-              *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-              *outStream << "Function DOFs on common face computed using Hex 0 basis functions are not consistent with those computed using Hex 1\n";
-              *outStream << "Function DOFs for Hex 0 are:";
-              for(ordinal_type j=0;j<numFaceDOFs;j++)
-                *outStream << " " << basisCoeffsLI(0,basisPtr->getDofOrdinal(2,faceIndex[0],j)) << " | (" << physDofCoords(0,basisPtr->getDofOrdinal(2,faceIndex[0],j),0) << "," << physDofCoords(0,basisPtr->getDofOrdinal(2,faceIndex[0],j),1) << ", " << physDofCoords(0,basisPtr->getDofOrdinal(2,faceIndex[0],j),2) << ") ||";
-              *outStream << "\nFunction DOFs for Hex 1 are:";
-              for(ordinal_type j=0;j<numFaceDOFs;j++)
-                *outStream << " " << basisCoeffsLI(1,basisPtr->getDofOrdinal(2,faceIndex[1],j))<< " | (" << physDofCoords(1,basisPtr->getDofOrdinal(2,faceIndex[1],j),0) << "," << physDofCoords(1,basisPtr->getDofOrdinal(2,faceIndex[1],j),1) << ", " << physDofCoords(1,basisPtr->getDofOrdinal(2,faceIndex[1],j),2) << ") ||";
-              *outStream << std::endl;
-            }
-          }
-
-          //check that fun values are consistent on common face dofs
-          {
-            bool areDifferent(false);
-            auto numFaceDOFs = basisPtr->getDofCount(2,0);
-            for(ordinal_type j=0;j<numFaceDOFs && !areDifferent;j++) {
-              areDifferent = std::abs(basisCoeffsLI(0,basisPtr->getDofOrdinal(2,faceIndex[0],j))
-                  - basisCoeffsLI(1,basisPtr->getDofOrdinal(2,faceIndex[1],j))) > 10*tol;
-            }
-
-            if(areDifferent) {
-              errorFlag++;
-              *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-              *outStream << "Function DOFs on common face computed using Hex 0 basis functions are not consistent with those computed using Hex 1\n";
-              *outStream << "Function DOFs for Hex 0 are:";
-              for(ordinal_type j=0;j<numFaceDOFs;j++)
-                *outStream << " " << basisCoeffsLI(0,basisPtr->getDofOrdinal(2,faceIndex[0],j)) << " | (" << physDofCoords(0,basisPtr->getDofOrdinal(2,faceIndex[0],j),0) << "," << physDofCoords(0,basisPtr->getDofOrdinal(2,faceIndex[0],j),1) << ", " << physDofCoords(0,basisPtr->getDofOrdinal(2,faceIndex[0],j),2) << ") ||";
-              *outStream << "\nFunction DOFs for Hex 1 are:";
-              for(ordinal_type j=0;j<numFaceDOFs;j++)
-                *outStream << " " << basisCoeffsLI(1,basisPtr->getDofOrdinal(2,faceIndex[1],j))<< " | (" << physDofCoords(1,basisPtr->getDofOrdinal(2,faceIndex[1],j),0) << "," << physDofCoords(1,basisPtr->getDofOrdinal(2,faceIndex[1],j),1) << ", " << physDofCoords(1,basisPtr->getDofOrdinal(2,faceIndex[1],j),2) << ") ||";
-              *outStream << std::endl;
-            }
-          }
-
-          //check that fun values at reference points coincide with those computed using basis functions
-          DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
-          DynRankView ConstructWithLabel(transformedBasisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
-          DynRankView basisValuesAtDofCoordsCells("inValues", numCells, basisCardinality, basisCardinality, dim);
-
-          for (ordinal_type ic = 0; ic < numCells; ++ic)
-            basisPtr->getValues(Kokkos::subview(basisValuesAtDofCoordsCells, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(dofCoordsOriented, ic, Kokkos::ALL(), Kokkos::ALL()));
-
-          // modify basis values to account for orientations
-          ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
-              basisValuesAtDofCoordsCells,
-              elemOrts,
-              basisPtr.get());
-
-          // transform basis values
-          DynRankView ConstructWithLabel(jacobianAtDofCoords, numCells, basisCardinality, dim, dim);
-          DynRankView ConstructWithLabel(jacobianAtDofCoords_det, numCells, basisCardinality);
-          ct::setJacobian(jacobianAtDofCoords, dofCoordsOriented, physVertexes, hex);
-          ct::setJacobianDet (jacobianAtDofCoords_det, jacobianAtDofCoords);
-          fst::HDIVtransformVALUE(transformedBasisValuesAtDofCoordsOriented,
-              jacobianAtDofCoords,
-              jacobianAtDofCoords_det,
-              basisValuesAtDofCoordsOriented);
-          DynRankView ConstructWithLabel(funAtDofCoordsOriented, numCells, basisCardinality, dim);
-          for(ordinal_type i=0; i<numCells; ++i) {
-            ValueType error=0;
-            for(ordinal_type j=0; j<basisCardinality; ++j)
-              for(ordinal_type d=0; d<dim; ++d) {
-                for(ordinal_type k=0; k<basisCardinality; ++k)
-                  funAtDofCoordsOriented(i,j,d) += basisCoeffsLI(i,k)*transformedBasisValuesAtDofCoordsOriented(i,k,j,d);
-
-                error = std::max(std::abs( funAtDofCoords(i,j,d) - funAtDofCoordsOriented(i,j,d)), error);
+            //check that fun values are consistent on common face dofs
+            {
+              bool areDifferent(false);
+              auto numFaceDOFs = basisPtr->getDofCount(2,0);
+              for(ordinal_type j=0;j<numFaceDOFs && !areDifferent;j++) {
+                areDifferent = std::abs(basisCoeffsLI(0,basisPtr->getDofOrdinal(2,faceIndex[0],j))
+                    - basisCoeffsLI(1,basisPtr->getDofOrdinal(2,faceIndex[1],j))) > 10*tol;
               }
 
-            if(error>100*tol) {
-              errorFlag++;
-              *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-              *outStream << "Function values at reference points differ from those computed using basis functions of Hex " << i << "\n";
-              *outStream << "Function values at reference points are:\n";
-              for(ordinal_type j=0; j<basisCardinality; ++j)
-                *outStream << " (" << funAtDofCoords(i,j,0) << "," << funAtDofCoords(i,j,1) << ", " << funAtDofCoords(i,j,2) << ")";
-              *outStream << "\nFunction values at reference points computed using basis functions are\n";
-              for(ordinal_type j=0; j<basisCardinality; ++j)
-                *outStream << " (" << funAtDofCoordsOriented(i,j,0) << "," << funAtDofCoordsOriented(i,j,1) << ", " << funAtDofCoordsOriented(i,j,2) << ")";
-              *outStream << std::endl;
+              if(areDifferent) {
+                errorFlag++;
+                *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                *outStream << "Function DOFs on common face computed using Hex 0 basis functions are not consistent with those computed using Hex 1\n";
+                *outStream << "Function DOFs for Hex 0 are:";
+                for(ordinal_type j=0;j<numFaceDOFs;j++)
+                  *outStream << " " << basisCoeffsLI(0,basisPtr->getDofOrdinal(2,faceIndex[0],j)) << " | (" << physDofCoords(0,basisPtr->getDofOrdinal(2,faceIndex[0],j),0) << "," << physDofCoords(0,basisPtr->getDofOrdinal(2,faceIndex[0],j),1) << ", " << physDofCoords(0,basisPtr->getDofOrdinal(2,faceIndex[0],j),2) << ") ||";
+                *outStream << "\nFunction DOFs for Hex 1 are:";
+                for(ordinal_type j=0;j<numFaceDOFs;j++)
+                  *outStream << " " << basisCoeffsLI(1,basisPtr->getDofOrdinal(2,faceIndex[1],j))<< " | (" << physDofCoords(1,basisPtr->getDofOrdinal(2,faceIndex[1],j),0) << "," << physDofCoords(1,basisPtr->getDofOrdinal(2,faceIndex[1],j),1) << ", " << physDofCoords(1,basisPtr->getDofOrdinal(2,faceIndex[1],j),2) << ") ||";
+                *outStream << std::endl;
+              }
             }
-          }
 
-          //compute projection-based interpolation of the Lagrangian interpolation
-          DynRankView ConstructWithLabel(basisCoeffsHDiv, numCells, basisCardinality);
-          {
-            ordinal_type targetCubDegree(basisPtr->getDegree()),targetDerivCubDegree(basisPtr->getDegree()-1);
+            //check that fun values are consistent on common face dofs
+            {
+              bool areDifferent(false);
+              auto numFaceDOFs = basisPtr->getDofCount(2,0);
+              for(ordinal_type j=0;j<numFaceDOFs && !areDifferent;j++) {
+                areDifferent = std::abs(basisCoeffsLI(0,basisPtr->getDofOrdinal(2,faceIndex[0],j))
+                    - basisCoeffsLI(1,basisPtr->getDofOrdinal(2,faceIndex[1],j))) > 10*tol;
+              }
 
-            Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
-            projStruct.createHDivProjectionStruct(basisPtr.get(), targetCubDegree, targetDerivCubDegree);
+              if(areDifferent) {
+                errorFlag++;
+                *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                *outStream << "Function DOFs on common face computed using Hex 0 basis functions are not consistent with those computed using Hex 1\n";
+                *outStream << "Function DOFs for Hex 0 are:";
+                for(ordinal_type j=0;j<numFaceDOFs;j++)
+                  *outStream << " " << basisCoeffsLI(0,basisPtr->getDofOrdinal(2,faceIndex[0],j)) << " | (" << physDofCoords(0,basisPtr->getDofOrdinal(2,faceIndex[0],j),0) << "," << physDofCoords(0,basisPtr->getDofOrdinal(2,faceIndex[0],j),1) << ", " << physDofCoords(0,basisPtr->getDofOrdinal(2,faceIndex[0],j),2) << ") ||";
+                *outStream << "\nFunction DOFs for Hex 1 are:";
+                for(ordinal_type j=0;j<numFaceDOFs;j++)
+                  *outStream << " " << basisCoeffsLI(1,basisPtr->getDofOrdinal(2,faceIndex[1],j))<< " | (" << physDofCoords(1,basisPtr->getDofOrdinal(2,faceIndex[1],j),0) << "," << physDofCoords(1,basisPtr->getDofOrdinal(2,faceIndex[1],j),1) << ", " << physDofCoords(1,basisPtr->getDofOrdinal(2,faceIndex[1],j),2) << ") ||";
+                *outStream << std::endl;
+              }
+            }
 
-            ordinal_type numPoints = projStruct.getNumTargetEvalPoints(), numDivPoints = projStruct.getNumTargetDerivEvalPoints();
+            //check that fun values at reference points coincide with those computed using basis functions
+            DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
+            DynRankView ConstructWithLabel(transformedBasisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
+            DynRankView basisValuesAtDofCoordsCells("inValues", numCells, basisCardinality, basisCardinality, dim);
 
-            DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
-            DynRankView ConstructWithLabel(evaluationDivPoints, numCells, numDivPoints, dim);
+            for (ordinal_type ic = 0; ic < numCells; ++ic)
+              basisPtr->getValues(Kokkos::subview(basisValuesAtDofCoordsCells, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(dofCoordsOriented, ic, Kokkos::ALL(), Kokkos::ALL()));
 
-            pts::getHDivEvaluationPoints(evaluationPoints,
-                evaluationDivPoints,
+            // modify basis values to account for orientations
+            ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
+                basisValuesAtDofCoordsCells,
                 elemOrts,
-                basisPtr.get(),
-                &projStruct);
+                basisPtr);
 
-            DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints, dim);
-            DynRankView ConstructWithLabel(targetDivAtEvalPoints, numCells, numDivPoints);
+            // transform basis values
+            DynRankView ConstructWithLabel(jacobianAtDofCoords, numCells, basisCardinality, dim, dim);
+            DynRankView ConstructWithLabel(jacobianAtDofCoords_det, numCells, basisCardinality);
+            ct::setJacobian(jacobianAtDofCoords, dofCoordsOriented, physVertexes, hex);
+            ct::setJacobianDet (jacobianAtDofCoords_det, jacobianAtDofCoords);
+            fst::HDIVtransformVALUE(transformedBasisValuesAtDofCoordsOriented,
+                jacobianAtDofCoords,
+                jacobianAtDofCoords_det,
+                basisValuesAtDofCoordsOriented);
+            DynRankView ConstructWithLabel(funAtDofCoordsOriented, numCells, basisCardinality, dim);
+            for(ordinal_type i=0; i<numCells; ++i) {
+              ValueType error=0;
+              for(ordinal_type j=0; j<basisCardinality; ++j)
+                for(ordinal_type d=0; d<dim; ++d) {
+                  for(ordinal_type k=0; k<basisCardinality; ++k)
+                    funAtDofCoordsOriented(i,j,d) += basisCoeffsLI(i,k)*transformedBasisValuesAtDofCoordsOriented(i,k,j,d);
 
-            DynRankView ConstructWithLabel(hdivBasisAtEvaluationPoints, numCells, basisCardinality , numPoints, dim);
-            DynRankView ConstructWithLabel(hdivBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints, dim);
-            for(ordinal_type ic=0; ic<numCells; ++ic)
-              basisPtr->getValues(Kokkos::subview(hdivBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
-            ots::modifyBasisByOrientation(hdivBasisAtEvaluationPoints,
-                hdivBasisAtEvaluationPointsNonOriented,
-                elemOrts,
-                basisPtr.get());
+                  error = std::max(std::abs( funAtDofCoords(i,j,d) - funAtDofCoordsOriented(i,j,d)), error);
+                }
 
-            DynRankView ConstructWithLabel(divOfHDivBasisAtEvaluationPoints, numCells, basisCardinality , numDivPoints);
-            if(numDivPoints>0) {
-              DynRankView ConstructWithLabel(divOfHDivBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numDivPoints);
-              for(ordinal_type ic=0; ic<numCells; ++ic)
-                basisPtr->getValues(Kokkos::subview(divOfHDivBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationDivPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_DIV);
-              ots::modifyBasisByOrientation(divOfHDivBasisAtEvaluationPoints,
-                  divOfHDivBasisAtEvaluationPointsNonOriented,
+              if(error>100*tol) {
+                errorFlag++;
+                *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                *outStream << "Function values at reference points differ from those computed using basis functions of Hex " << i << "\n";
+                *outStream << "Function values at reference points are:\n";
+                for(ordinal_type j=0; j<basisCardinality; ++j)
+                  *outStream << " (" << funAtDofCoords(i,j,0) << "," << funAtDofCoords(i,j,1) << ", " << funAtDofCoords(i,j,2) << ")";
+                *outStream << "\nFunction values at reference points computed using basis functions are\n";
+                for(ordinal_type j=0; j<basisCardinality; ++j)
+                  *outStream << " (" << funAtDofCoordsOriented(i,j,0) << "," << funAtDofCoordsOriented(i,j,1) << ", " << funAtDofCoordsOriented(i,j,2) << ")";
+                *outStream << std::endl;
+              }
+            }
+
+            //compute projection-based interpolation of the Lagrangian interpolation
+            DynRankView ConstructWithLabel(basisCoeffsHDiv, numCells, basisCardinality);
+            {
+              ordinal_type targetCubDegree(basisPtr->getDegree()),targetDerivCubDegree(basisPtr->getDegree()-1);
+
+              Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
+              projStruct.createHDivProjectionStruct(basisPtr, targetCubDegree, targetDerivCubDegree);
+
+              ordinal_type numPoints = projStruct.getNumTargetEvalPoints(), numDivPoints = projStruct.getNumTargetDerivEvalPoints();
+
+              DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
+              DynRankView ConstructWithLabel(evaluationDivPoints, numCells, numDivPoints, dim);
+
+              pts::getHDivEvaluationPoints(evaluationPoints,
+                  evaluationDivPoints,
                   elemOrts,
-                  basisPtr.get());
-            }
+                  basisPtr,
+                  &projStruct);
 
+              DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints, dim);
+              DynRankView ConstructWithLabel(targetDivAtEvalPoints, numCells, numDivPoints);
 
-
-            for(ordinal_type ic=0; ic<numCells; ++ic) {
-              for(int i=0;i<numPoints;i++) {
-                for(int k=0;k<basisCardinality;k++)
-                  for(int d=0;d<dim;d++)
-                    targetAtEvalPoints(ic,i,d) += basisCoeffsLI(ic,k)*hdivBasisAtEvaluationPoints(ic,k,i,d);
-              }
-              for(int i=0;i<numDivPoints;i++) {
-                for(int k=0;k<basisCardinality;k++)
-                  targetDivAtEvalPoints(ic,i) += basisCoeffsLI(ic,k)*divOfHDivBasisAtEvaluationPoints(ic,k,i);//basisCoeffsLI(k)
-              }
-            }
-
-            pts::getHDivBasisCoeffs(basisCoeffsHDiv,
-                targetAtEvalPoints,
-                targetDivAtEvalPoints,
-                evaluationPoints,
-                evaluationDivPoints,
-                elemOrts,
-                basisPtr.get(),
-                &projStruct);
-          }
-
-          //check that the basis coefficients of the Lagrangian interpolation are the same as those of the projection-based interpolation
-          {
-            ValueType diffErr(0);
-            for(int k=0;k<basisCardinality;k++) {
-              //std::cout << "["<< basisCoeffsLI(0,k) << " " <<  basisCoeffsHDiv(0,k) << "] [" << basisCoeffsLI(1,k) << " " <<  basisCoeffsHDiv(1,k) << "]" <<std::endl;
+              DynRankView ConstructWithLabel(hdivBasisAtEvaluationPoints, numCells, basisCardinality , numPoints, dim);
+              DynRankView ConstructWithLabel(hdivBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints, dim);
               for(ordinal_type ic=0; ic<numCells; ++ic)
-                diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsHDiv(ic,k)));
+                basisPtr->getValues(Kokkos::subview(hdivBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
+              ots::modifyBasisByOrientation(hdivBasisAtEvaluationPoints,
+                  hdivBasisAtEvaluationPointsNonOriented,
+                  elemOrts,
+                  basisPtr);
+
+              DynRankView ConstructWithLabel(divOfHDivBasisAtEvaluationPoints, numCells, basisCardinality , numDivPoints);
+              if(numDivPoints>0) {
+                DynRankView ConstructWithLabel(divOfHDivBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numDivPoints);
+                for(ordinal_type ic=0; ic<numCells; ++ic)
+                  basisPtr->getValues(Kokkos::subview(divOfHDivBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationDivPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_DIV);
+                ots::modifyBasisByOrientation(divOfHDivBasisAtEvaluationPoints,
+                    divOfHDivBasisAtEvaluationPointsNonOriented,
+                    elemOrts,
+                    basisPtr);
+              }
+
+
+
+              for(ordinal_type ic=0; ic<numCells; ++ic) {
+                for(int i=0;i<numPoints;i++) {
+                  for(int k=0;k<basisCardinality;k++)
+                    for(int d=0;d<dim;d++)
+                      targetAtEvalPoints(ic,i,d) += basisCoeffsLI(ic,k)*hdivBasisAtEvaluationPoints(ic,k,i,d);
+                }
+                for(int i=0;i<numDivPoints;i++) {
+                  for(int k=0;k<basisCardinality;k++)
+                    targetDivAtEvalPoints(ic,i) += basisCoeffsLI(ic,k)*divOfHDivBasisAtEvaluationPoints(ic,k,i);//basisCoeffsLI(k)
+                }
+              }
+
+              pts::getHDivBasisCoeffs(basisCoeffsHDiv,
+                  targetAtEvalPoints,
+                  targetDivAtEvalPoints,
+                  evaluationPoints,
+                  evaluationDivPoints,
+                  elemOrts,
+                  basisPtr,
+                  &projStruct);
             }
 
-            if(diffErr > pow(8, degree)*tol) { //heuristic relation on how round-off error depends on degree
-              errorFlag++;
-              *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-              *outStream << "HDIV_I" << degree << ": The weights recovered with the optimization are different than the one used for generating the functon."<<
-                  "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << " (tol: " << pow(8, degree)*tol << ")" << std::endl;
-            }
-          }
+            //check that the basis coefficients of the Lagrangian interpolation are the same as those of the projection-based interpolation
+            {
+              ValueType diffErr(0);
+              for(int k=0;k<basisCardinality;k++) {
+                //std::cout << "["<< basisCoeffsLI(0,k) << " " <<  basisCoeffsHDiv(0,k) << "] [" << basisCoeffsLI(1,k) << " " <<  basisCoeffsHDiv(1,k) << "]" <<std::endl;
+                for(ordinal_type ic=0; ic<numCells; ++ic)
+                  diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsHDiv(ic,k)));
+              }
 
-          //compute L2 projection interpolation of the Lagrangian interpolation
-          DynRankView ConstructWithLabel(basisCoeffsL2, numCells, basisCardinality);
-          {
-            ordinal_type targetCubDegree(basisPtr->getDegree());
-
-            Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
-            projStruct.createL2ProjectionStruct(basisPtr.get(), targetCubDegree);
-
-            ordinal_type numPoints = projStruct.getNumTargetEvalPoints();
-
-            DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
-
-            pts::getL2EvaluationPoints(evaluationPoints,
-                elemOrts,
-                basisPtr.get(),
-                &projStruct);
-
-            DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints, dim);
-
-            DynRankView ConstructWithLabel(hdivBasisAtEvaluationPoints, numCells, basisCardinality , numPoints, dim);
-            DynRankView ConstructWithLabel(hdivBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints, dim);
-            for(ordinal_type ic=0; ic<numCells; ++ic)
-              basisPtr->getValues(Kokkos::subview(hdivBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
-            ots::modifyBasisByOrientation(hdivBasisAtEvaluationPoints,
-                hdivBasisAtEvaluationPointsNonOriented,
-                elemOrts,
-                basisPtr.get());
-
-            for(ordinal_type ic=0; ic<numCells; ++ic) {
-              for(int i=0;i<numPoints;i++) {
-                for(int k=0;k<basisCardinality;k++)
-                  for(int d=0;d<dim;d++)
-                    targetAtEvalPoints(ic,i,d) += basisCoeffsLI(ic,k)*hdivBasisAtEvaluationPoints(ic,k,i,d);
+              if(diffErr > pow(8, degree)*tol) { //heuristic relation on how round-off error depends on degree
+                errorFlag++;
+                *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                *outStream << "HDIV_I" << degree << ": The weights recovered with the optimization are different than the one used for generating the functon."<<
+                    "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << " (tol: " << pow(8, degree)*tol << ")" << std::endl;
               }
             }
 
-            pts::getL2BasisCoeffs(basisCoeffsL2,
-                targetAtEvalPoints,
-                evaluationPoints,
-                elemOrts,
-                basisPtr.get(),
-                &projStruct);
-          }
+            //compute L2 projection interpolation of the Lagrangian interpolation
+            DynRankView ConstructWithLabel(basisCoeffsL2, numCells, basisCardinality);
+            {
+              ordinal_type targetCubDegree(basisPtr->getDegree());
 
-          //check that the basis coefficients of the Lagrangian interpolation are the same as those of the L2 projection
-          {
-            ValueType diffErr = 0;
-            for(int k=0;k<basisCardinality;k++) {
-              //std::cout << "["<< basisCoeffsLI(0,k) << " " <<  basisCoeffsHDiv(0,k) << "] [" << basisCoeffsLI(1,k) << " " <<  basisCoeffsHDiv(1,k) << "]" <<std::endl;
+              Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
+              projStruct.createL2ProjectionStruct(basisPtr, targetCubDegree);
+
+              ordinal_type numPoints = projStruct.getNumTargetEvalPoints();
+
+              DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
+
+              pts::getL2EvaluationPoints(evaluationPoints,
+                  elemOrts,
+                  basisPtr,
+                  &projStruct);
+
+              DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints, dim);
+
+              DynRankView ConstructWithLabel(hdivBasisAtEvaluationPoints, numCells, basisCardinality , numPoints, dim);
+              DynRankView ConstructWithLabel(hdivBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints, dim);
               for(ordinal_type ic=0; ic<numCells; ++ic)
-                diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsL2(ic,k)));
+                basisPtr->getValues(Kokkos::subview(hdivBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
+              ots::modifyBasisByOrientation(hdivBasisAtEvaluationPoints,
+                  hdivBasisAtEvaluationPointsNonOriented,
+                  elemOrts,
+                  basisPtr);
+
+              for(ordinal_type ic=0; ic<numCells; ++ic) {
+                for(int i=0;i<numPoints;i++) {
+                  for(int k=0;k<basisCardinality;k++)
+                    for(int d=0;d<dim;d++)
+                      targetAtEvalPoints(ic,i,d) += basisCoeffsLI(ic,k)*hdivBasisAtEvaluationPoints(ic,k,i,d);
+                }
+              }
+
+              pts::getL2BasisCoeffs(basisCoeffsL2,
+                  targetAtEvalPoints,
+                  evaluationPoints,
+                  elemOrts,
+                  basisPtr,
+                  &projStruct);
             }
 
-            if(diffErr > pow(7, degree-1)*tol) { //heuristic relation on how round-off error depends on degree
-              errorFlag++;
-              *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-              *outStream << "HDIV_I" << degree << ": The weights recovered with the L2 optimization are different than the one used for generating the function."<<
-                  "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
+            //check that the basis coefficients of the Lagrangian interpolation are the same as those of the L2 projection
+            {
+              ValueType diffErr = 0;
+              for(int k=0;k<basisCardinality;k++) {
+                //std::cout << "["<< basisCoeffsLI(0,k) << " " <<  basisCoeffsHDiv(0,k) << "] [" << basisCoeffsLI(1,k) << " " <<  basisCoeffsHDiv(1,k) << "]" <<std::endl;
+                for(ordinal_type ic=0; ic<numCells; ++ic)
+                  diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsL2(ic,k)));
+              }
+
+              if(diffErr > pow(7, degree-1)*tol) { //heuristic relation on how round-off error depends on degree
+                errorFlag++;
+                *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                *outStream << "HDIV_I" << degree << ": The weights recovered with the L2 optimization are different than the one used for generating the function."<<
+                    "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
+              }
             }
+            delete basisPtr;
           }
         }
       }
@@ -1601,257 +1656,265 @@ int InterpolationProjectionHex(const bool verbose) {
 
     for (ordinal_type degree=1; degree <= max_degree; degree++) {
 
-      Teuchos::RCP<Basis<DeviceSpaceType,ValueType,ValueType> > basisPtr;
+      basis_set.clear();
       if(degree==1)
-        basisPtr = Teuchos::rcp(new Basis_HVOL_C0_FEM<DeviceSpaceType,ValueType,ValueType>(hex));
-      else
-        basisPtr = Teuchos::rcp(new Basis_HVOL_HEX_Cn_FEM<DeviceSpaceType,ValueType,ValueType>(degree));
-      ordinal_type basisCardinality = basisPtr->getCardinality();
+        basis_set.push_back(new Basis_HVOL_C0_FEM<DeviceSpaceType,ValueType,ValueType>(hex));
+      basis_set.push_back(new typename  CG_NBasis::HVOL_HEX(degree));
+      basis_set.push_back(new typename  CG_DNBasis::HVOL_HEX(degree));
 
-      //compute DofCoords Oriented
-      DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
-      DynRankView ConstructWithLabel(dofCoeffsPhys, numCells, basisCardinality);
-      DynRankView ConstructWithLabel(physDofCoords, numCells, basisCardinality, dim);
-      DynRankView ConstructWithLabel(funAtDofCoords, numCells, basisCardinality);
-      DynRankView ConstructWithLabel(basisCoeffsLI, numCells, basisCardinality);
+      for (auto basisPtr:basis_set) {
 
-      //compute Lagrangian Interpolation of fun
-      {
-        li::getDofCoordsAndCoeffs(dofCoordsOriented,  dofCoeffsPhys, basisPtr.get(), POINTTYPE_EQUISPACED, elemOrts);
+        auto name = basisPtr->getName();
+        *outStream << " " << name << std::endl;
 
-        //Compute physical Dof Coordinates
+        ordinal_type basisCardinality = basisPtr->getCardinality();
+
+        //compute DofCoords Oriented
+        DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
+        DynRankView ConstructWithLabel(dofCoeffsPhys, numCells, basisCardinality);
+        DynRankView ConstructWithLabel(physDofCoords, numCells, basisCardinality, dim);
+        DynRankView ConstructWithLabel(funAtDofCoords, numCells, basisCardinality);
+        DynRankView ConstructWithLabel(basisCoeffsLI, numCells, basisCardinality);
+
+        //compute Lagrangian Interpolation of fun
         {
-          Basis_HGRAD_HEX_C1_FEM<DeviceSpaceType,ValueType,ValueType> hexLinearBasis; //used for computing physical coordinates
-          DynRankView ConstructWithLabel(hexLinearBasisValuesAtDofCoords, numCells, hex.getNodeCount(), basisCardinality);
+          li::getDofCoordsAndCoeffs(dofCoordsOriented,  dofCoeffsPhys, basisPtr, POINTTYPE_EQUISPACED, elemOrts);
+
+          //Compute physical Dof Coordinates
+          {
+            Basis_HGRAD_HEX_C1_FEM<DeviceSpaceType,ValueType,ValueType> hexLinearBasis; //used for computing physical coordinates
+            DynRankView ConstructWithLabel(hexLinearBasisValuesAtDofCoords, numCells, hex.getNodeCount(), basisCardinality);
+            for(ordinal_type i=0; i<numCells; ++i)
+              for(ordinal_type d=0; d<dim; ++d) {
+                auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
+                auto outView =Kokkos::subview( hexLinearBasisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+                hexLinearBasis.getValues(outView, inView);
+                DeviceSpaceType().fence();
+                for(ordinal_type j=0; j<basisCardinality; ++j)
+                  for(std::size_t k=0; k<hex.getNodeCount(); ++k)
+                    physDofCoords(i,j,d) += vertices[hexas[i][k]][d]*hexLinearBasisValuesAtDofCoords(i,k,j);
+              }
+          }
+
+          //need to transform dofCoeff to physical space (they transform as normals)
+          DynRankView ConstructWithLabel(jacobian, numCells, basisCardinality, dim, dim);
+          DynRankView ConstructWithLabel(jacobian_det, numCells, basisCardinality);
+          ct::setJacobian(jacobian, dofCoordsOriented, physVertexes, hex);
+          ct::setJacobianDet (jacobian_det, jacobian);
+
+          Fun fun;
+
+          DynRankView ConstructWithLabel(fwdFunAtDofCoords, numCells, basisCardinality);
           for(ordinal_type i=0; i<numCells; ++i)
-            for(ordinal_type d=0; d<dim; ++d) {
-              auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
-              auto outView =Kokkos::subview( hexLinearBasisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
-              hexLinearBasis.getValues(outView, inView);
-              DeviceSpaceType().fence();
-              for(ordinal_type j=0; j<basisCardinality; ++j)
-                for(std::size_t k=0; k<hex.getNodeCount(); ++k)
-                  physDofCoords(i,j,d) += vertices[hexas[i][k]][d]*hexLinearBasisValuesAtDofCoords(i,k,j);
+            for(ordinal_type j=0; j<basisCardinality; ++j) {
+              funAtDofCoords(i,j) = fun(degree, physDofCoords(i,j,0), physDofCoords(i,j,1), physDofCoords(i,j,2));
+              fwdFunAtDofCoords(i,j) = jacobian_det(i,j)*funAtDofCoords(i,j);
             }
+
+          li::getBasisCoeffs(basisCoeffsLI, fwdFunAtDofCoords, dofCoeffsPhys);
         }
 
-        //need to transform dofCoeff to physical space (they transform as normals)
+        //Testing Kronecker property of basis functions
+        {
+          for(ordinal_type i=0; i<numCells; ++i) {
+            DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality);
+            DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
+            auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
+            auto outView =Kokkos::subview( basisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL());
+            basisPtr->getValues(outView, inView);
+
+            // modify basis values to account for orientations
+            ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
+                basisValuesAtDofCoords,
+                elemOrts,
+                basisPtr);
+
+            for(ordinal_type k=0; k<basisCardinality; ++k) {
+              for(ordinal_type j=0; j<basisCardinality; ++j){
+                ValueType dofValue = basisValuesAtDofCoordsOriented(i,k,j) * dofCoeffsPhys(i,j);
+                if ( k==j && std::abs( dofValue - 1.0 ) > 100*tol ) {
+                  errorFlag++;
+                  *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                  *outStream << " Basis function " << k << " of cell " << i << " does not have unit value at its node (" << dofValue <<")\n";
+                }
+                if ( k!=j && std::abs( dofValue ) > tol ) {
+                  errorFlag++;
+                  *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                  *outStream << " Basis function " << k << " of cell " << i << " does not vanish at node " << j << "(" << dofValue <<")\n";
+                }
+              }
+            }
+          }
+        }
+
+        //check that fun values at reference points coincide with those computed using basis functions
+        DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
+        DynRankView ConstructWithLabel(transformedBasisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
+        DynRankView basisValuesAtDofCoordsCells("inValues", numCells, basisCardinality, basisCardinality);
+
+        for (ordinal_type ic = 0; ic < numCells; ++ic)
+          basisPtr->getValues(Kokkos::subview(basisValuesAtDofCoordsCells, ic, Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(dofCoordsOriented, ic, Kokkos::ALL(), Kokkos::ALL()));
+
+        // modify basis values to account for orientations
+        ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
+            basisValuesAtDofCoordsCells,
+            elemOrts,
+            basisPtr);
+
+        // transform basis values
         DynRankView ConstructWithLabel(jacobian, numCells, basisCardinality, dim, dim);
         DynRankView ConstructWithLabel(jacobian_det, numCells, basisCardinality);
         ct::setJacobian(jacobian, dofCoordsOriented, physVertexes, hex);
         ct::setJacobianDet (jacobian_det, jacobian);
+        fst::HVOLtransformVALUE(transformedBasisValuesAtDofCoordsOriented,
+            jacobian_det,
+            basisValuesAtDofCoordsOriented);
 
-        Fun fun;
-
-        DynRankView ConstructWithLabel(fwdFunAtDofCoords, numCells, basisCardinality);
-        for(ordinal_type i=0; i<numCells; ++i)
+        DynRankView ConstructWithLabel(funAtDofCoordsOriented, numCells, basisCardinality);
+        for(ordinal_type i=0; i<numCells; ++i) {
+          ValueType error=0;
           for(ordinal_type j=0; j<basisCardinality; ++j) {
-            funAtDofCoords(i,j) = fun(degree, physDofCoords(i,j,0), physDofCoords(i,j,1), physDofCoords(i,j,2));
-            fwdFunAtDofCoords(i,j) = jacobian_det(i,j)*funAtDofCoords(i,j);
+            for(ordinal_type k=0; k<basisCardinality; ++k)
+              funAtDofCoordsOriented(i,j) += basisCoeffsLI(i,k)*transformedBasisValuesAtDofCoordsOriented(i,k,j);
+
+            error = std::max(std::abs( funAtDofCoords(i,j) - funAtDofCoordsOriented(i,j)), error);
           }
 
-        li::getBasisCoeffs(basisCoeffsLI, fwdFunAtDofCoords, dofCoeffsPhys);
-      }
+          if(error>100*tol) {
+            errorFlag++;
+            *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+            *outStream << "Function values at reference points differ from those computed using basis functions of Hex " << i << "\n";
+            *outStream << "Function values at reference points are:\n";
+            for(ordinal_type j=0; j<basisCardinality; ++j)
+              *outStream << " (" << funAtDofCoords(i,j)  << ")";
+            *outStream << "\nFunction values at reference points computed using basis functions are\n";
+            for(ordinal_type j=0; j<basisCardinality; ++j)
+              *outStream << " (" << funAtDofCoordsOriented(i,j)  << ")";
+            *outStream << std::endl;
+          }
+        }
 
-      //Testing Kronecker property of basis functions
-      {
-        for(ordinal_type i=0; i<numCells; ++i) {
-          DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality);
-          DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
-          auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
-          auto outView =Kokkos::subview( basisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL());
-          basisPtr->getValues(outView, inView);
+        //compute projection-based interpolation of the Lagrangian interpolation
+        DynRankView ConstructWithLabel(basisCoeffsHVol, numCells, basisCardinality);
+        {
+          ordinal_type targetCubDegree(basisPtr->getDegree());
 
-          // modify basis values to account for orientations
-          ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
-              basisValuesAtDofCoords,
+          Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
+          projStruct.createHVolProjectionStruct(basisPtr, targetCubDegree);
+
+          ordinal_type numPoints = projStruct.getNumTargetEvalPoints();
+          DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
+
+
+          pts::getHVolEvaluationPoints(evaluationPoints,
               elemOrts,
-              basisPtr.get());
+              basisPtr,
+              &projStruct);
 
-          for(ordinal_type k=0; k<basisCardinality; ++k) {
-            for(ordinal_type j=0; j<basisCardinality; ++j){
-              ValueType dofValue = basisValuesAtDofCoordsOriented(i,k,j) * dofCoeffsPhys(i,j);
-              if ( k==j && std::abs( dofValue - 1.0 ) > 100*tol ) {
-                errorFlag++;
-                *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-                *outStream << " Basis function " << k << " of cell " << i << " does not have unit value at its node (" << dofValue <<")\n";
-              }
-              if ( k!=j && std::abs( dofValue ) > tol ) {
-                errorFlag++;
-                *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-                *outStream << " Basis function " << k << " of cell " << i << " does not vanish at node " << j << "(" << dofValue <<")\n";
-              }
+
+          DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints);
+
+          DynRankView ConstructWithLabel(hvolBasisAtEvaluationPoints, numCells, basisCardinality , numPoints);
+          DynRankView ConstructWithLabel(hvolBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints);
+          for(int ic=0; ic<numCells; ic++)
+            basisPtr->getValues(Kokkos::subview(hvolBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
+          ots::modifyBasisByOrientation(hvolBasisAtEvaluationPoints,
+              hvolBasisAtEvaluationPointsNonOriented,
+              elemOrts,
+              basisPtr);
+
+          for(int ic=0; ic<numCells; ic++) {
+            for(int i=0;i<numPoints;i++) {
+              for(int k=0;k<basisCardinality;k++)
+                targetAtEvalPoints(ic,i) += basisCoeffsLI(ic,k)*hvolBasisAtEvaluationPoints(ic,k,i);
             }
           }
-        }
-      }
 
-      //check that fun values at reference points coincide with those computed using basis functions
-      DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
-      DynRankView ConstructWithLabel(transformedBasisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
-      DynRankView basisValuesAtDofCoordsCells("inValues", numCells, basisCardinality, basisCardinality);
-
-      for (ordinal_type ic = 0; ic < numCells; ++ic)
-        basisPtr->getValues(Kokkos::subview(basisValuesAtDofCoordsCells, ic, Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(dofCoordsOriented, ic, Kokkos::ALL(), Kokkos::ALL()));
-
-      // modify basis values to account for orientations
-      ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
-          basisValuesAtDofCoordsCells,
-          elemOrts,
-          basisPtr.get());
-
-      // transform basis values
-      DynRankView ConstructWithLabel(jacobian, numCells, basisCardinality, dim, dim);
-      DynRankView ConstructWithLabel(jacobian_det, numCells, basisCardinality);
-      ct::setJacobian(jacobian, dofCoordsOriented, physVertexes, hex);
-      ct::setJacobianDet (jacobian_det, jacobian);
-      fst::HVOLtransformVALUE(transformedBasisValuesAtDofCoordsOriented,
-          jacobian_det,
-          basisValuesAtDofCoordsOriented);
-
-      DynRankView ConstructWithLabel(funAtDofCoordsOriented, numCells, basisCardinality);
-      for(ordinal_type i=0; i<numCells; ++i) {
-        ValueType error=0;
-        for(ordinal_type j=0; j<basisCardinality; ++j) {
-          for(ordinal_type k=0; k<basisCardinality; ++k)
-            funAtDofCoordsOriented(i,j) += basisCoeffsLI(i,k)*transformedBasisValuesAtDofCoordsOriented(i,k,j);
-
-          error = std::max(std::abs( funAtDofCoords(i,j) - funAtDofCoordsOriented(i,j)), error);
+          pts::getHVolBasisCoeffs(basisCoeffsHVol,
+              targetAtEvalPoints,
+              evaluationPoints,
+              elemOrts,
+              basisPtr,
+              &projStruct);
         }
 
-        if(error>100*tol) {
-          errorFlag++;
-          *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-          *outStream << "Function values at reference points differ from those computed using basis functions of Hex " << i << "\n";
-          *outStream << "Function values at reference points are:\n";
-          for(ordinal_type j=0; j<basisCardinality; ++j)
-            *outStream << " (" << funAtDofCoords(i,j)  << ")";
-          *outStream << "\nFunction values at reference points computed using basis functions are\n";
-          for(ordinal_type j=0; j<basisCardinality; ++j)
-            *outStream << " (" << funAtDofCoordsOriented(i,j)  << ")";
-          *outStream << std::endl;
-        }
-      }
+        //check that the basis coefficients of the Lagrangian interpolation are the same as those of the projection-based interpolation
+        {
+          ValueType diffErr(0);
+          for(int k=0;k<basisCardinality;k++) {
+            for(int ic=0; ic<numCells; ic++)
+              diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsHVol(ic,k)));
+          }
 
-      //compute projection-based interpolation of the Lagrangian interpolation
-      DynRankView ConstructWithLabel(basisCoeffsHVol, numCells, basisCardinality);
-      {
-        ordinal_type targetCubDegree(basisPtr->getDegree());
-
-        Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
-        projStruct.createHVolProjectionStruct(basisPtr.get(), targetCubDegree);
-
-        ordinal_type numPoints = projStruct.getNumTargetEvalPoints();
-        DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
-
-
-        pts::getHVolEvaluationPoints(evaluationPoints,
-            elemOrts,
-            basisPtr.get(),
-            &projStruct);
-
-
-        DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints);
-
-        DynRankView ConstructWithLabel(hvolBasisAtEvaluationPoints, numCells, basisCardinality , numPoints);
-        DynRankView ConstructWithLabel(hvolBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints);
-        for(int ic=0; ic<numCells; ic++)
-          basisPtr->getValues(Kokkos::subview(hvolBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
-        ots::modifyBasisByOrientation(hvolBasisAtEvaluationPoints,
-            hvolBasisAtEvaluationPointsNonOriented,
-            elemOrts,
-            basisPtr.get());
-
-        for(int ic=0; ic<numCells; ic++) {
-          for(int i=0;i<numPoints;i++) {
-            for(int k=0;k<basisCardinality;k++)
-              targetAtEvalPoints(ic,i) += basisCoeffsLI(ic,k)*hvolBasisAtEvaluationPoints(ic,k,i);
+          //Check that the two representations of the gradient of ifun are consistent
+          if(diffErr > pow(20, degree)*tol) { //heuristic relation on how round-off error depends on degree
+            errorFlag++;
+            *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+            *outStream << "HVOL_C" << degree << ": The weights recovered with the optimization are different than the one used for generating the functon."<<
+                "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
           }
         }
 
-        pts::getHVolBasisCoeffs(basisCoeffsHVol,
-            targetAtEvalPoints,
-            evaluationPoints,
-            elemOrts,
-            basisPtr.get(),
-            &projStruct);
-      }
+        //compute L2 projection of the Lagrangian interpolation
+        DynRankView ConstructWithLabel(basisCoeffsL2, numCells, basisCardinality);
+        {
+          ordinal_type targetCubDegree(basisPtr->getDegree());
 
-      //check that the basis coefficients of the Lagrangian interpolation are the same as those of the projection-based interpolation
-      {
-        ValueType diffErr(0);
-        for(int k=0;k<basisCardinality;k++) {
+          Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
+          projStruct.createL2ProjectionStruct(basisPtr, targetCubDegree);
+
+          ordinal_type numPoints = projStruct.getNumTargetEvalPoints();
+          DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
+
+
+          pts::getL2EvaluationPoints(evaluationPoints,
+              elemOrts,
+              basisPtr,
+              &projStruct);
+
+
+          DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints);
+
+          DynRankView ConstructWithLabel(hvolBasisAtEvaluationPoints, numCells, basisCardinality , numPoints);
+          DynRankView ConstructWithLabel(hvolBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints);
           for(int ic=0; ic<numCells; ic++)
-            diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsHVol(ic,k)));
+            basisPtr->getValues(Kokkos::subview(hvolBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
+          ots::modifyBasisByOrientation(hvolBasisAtEvaluationPoints,
+              hvolBasisAtEvaluationPointsNonOriented,
+              elemOrts,
+              basisPtr);
+
+          for(int ic=0; ic<numCells; ic++) {
+            for(int i=0;i<numPoints;i++) {
+              for(int k=0;k<basisCardinality;k++)
+                targetAtEvalPoints(ic,i) += basisCoeffsLI(ic,k)*hvolBasisAtEvaluationPoints(ic,k,i);
+            }
+          }
+
+          pts::getL2BasisCoeffs(basisCoeffsL2,
+              targetAtEvalPoints,
+              evaluationPoints,
+              elemOrts,
+              basisPtr,
+              &projStruct);
         }
 
-        //Check that the two representations of the gradient of ifun are consistent
-        if(diffErr > pow(20, degree)*tol) { //heuristic relation on how round-off error depends on degree
-          errorFlag++;
-          *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-          *outStream << "HVOL_C" << degree << ": The weights recovered with the optimization are different than the one used for generating the functon."<<
-              "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
-        }
-      }
+        //check that the basis coefficients of the Lagrangian interpolation are the same as those of the L2 projection
+        {
+          ValueType diffErr = 0;
+          for(int k=0;k<basisCardinality;k++) {
+            for(int ic=0; ic<numCells; ic++)
+              diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsL2(ic,k)));
+          }
 
-      //compute L2 projection of the Lagrangian interpolation
-      DynRankView ConstructWithLabel(basisCoeffsL2, numCells, basisCardinality);
-      {
-        ordinal_type targetCubDegree(basisPtr->getDegree());
-
-        Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
-        projStruct.createL2ProjectionStruct(basisPtr.get(), targetCubDegree);
-
-        ordinal_type numPoints = projStruct.getNumTargetEvalPoints();
-        DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
-
-
-        pts::getL2EvaluationPoints(evaluationPoints,
-            elemOrts,
-            basisPtr.get(),
-            &projStruct);
-
-
-        DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints);
-
-        DynRankView ConstructWithLabel(hvolBasisAtEvaluationPoints, numCells, basisCardinality , numPoints);
-        DynRankView ConstructWithLabel(hvolBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints);
-        for(int ic=0; ic<numCells; ic++)
-          basisPtr->getValues(Kokkos::subview(hvolBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
-        ots::modifyBasisByOrientation(hvolBasisAtEvaluationPoints,
-            hvolBasisAtEvaluationPointsNonOriented,
-            elemOrts,
-            basisPtr.get());
-
-        for(int ic=0; ic<numCells; ic++) {
-          for(int i=0;i<numPoints;i++) {
-            for(int k=0;k<basisCardinality;k++)
-              targetAtEvalPoints(ic,i) += basisCoeffsLI(ic,k)*hvolBasisAtEvaluationPoints(ic,k,i);
+          if(diffErr > pow(20, degree)*tol) { //heuristic relation on how round-off error depends on degree
+            errorFlag++;
+            *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+            *outStream << "HVOL_C" << degree << ": The weights recovered with the L2 optimization are different than the one used for generating the functon."<<
+                "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
           }
         }
-
-        pts::getL2BasisCoeffs(basisCoeffsL2,
-            targetAtEvalPoints,
-            evaluationPoints,
-            elemOrts,
-            basisPtr.get(),
-            &projStruct);
-      }
-
-      //check that the basis coefficients of the Lagrangian interpolation are the same as those of the L2 projection
-      {
-        ValueType diffErr = 0;
-        for(int k=0;k<basisCardinality;k++) {
-          for(int ic=0; ic<numCells; ic++)
-            diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsL2(ic,k)));
-        }
-
-        if(diffErr > pow(20, degree)*tol) { //heuristic relation on how round-off error depends on degree
-          errorFlag++;
-          *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-          *outStream << "HVOL_C" << degree << ": The weights recovered with the L2 optimization are different than the one used for generating the functon."<<
-              "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
-        }
+        delete basisPtr;
       }
     }
   } catch (std::exception &err) {

--- a/packages/intrepid2/unit-test/Projection/test_interpolation_projection_QUAD.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_interpolation_projection_QUAD.hpp
@@ -190,6 +190,7 @@ int InterpolationProjectionQuad(const bool verbose) {
   typedef Experimental::ProjectionTools<DeviceSpaceType> pts;
   typedef FunctionSpaceTools<DeviceSpaceType> fst;
   typedef Experimental::LagrangianInterpolation<DeviceSpaceType> li;
+  using  basisType = Basis<DeviceSpaceType,ValueType,ValueType>;
 
   constexpr ordinal_type dim = 2;
   constexpr ordinal_type numCells = 2;
@@ -202,6 +203,10 @@ int InterpolationProjectionQuad(const bool verbose) {
   ordinal_type quads_rotated[numCells][numElemVertexes];
 
   const ordinal_type max_degree = 4;
+
+  using CG_NBasis = NodalBasisFamily<DeviceSpaceType,ValueType,ValueType>;
+  using CG_DNBasis = DerivedNodalBasisFamily<DeviceSpaceType,ValueType,ValueType>;
+  std::vector<basisType*> basis_set;
 
   *outStream
   << "===============================================================================\n"
@@ -276,298 +281,303 @@ int InterpolationProjectionQuad(const bool verbose) {
         ots::getOrientation(elemOrts, elemNodes, quad);
 
         for (ordinal_type degree=1; degree <= max_degree; degree++) {
-
-          Teuchos::RCP<Basis<DeviceSpaceType,ValueType,ValueType>> basisPtr;
-
+          basis_set.clear();
           if(degree==1)
-            basisPtr = Teuchos::rcp(new Basis_HGRAD_QUAD_C1_FEM<DeviceSpaceType,ValueType,ValueType>());
-          else
-            basisPtr = Teuchos::rcp(new Basis_HGRAD_QUAD_Cn_FEM<DeviceSpaceType,ValueType,ValueType>(degree));
+            basis_set.push_back(new Basis_HGRAD_QUAD_C1_FEM<DeviceSpaceType,ValueType,ValueType>());
+          basis_set.push_back(new typename  CG_NBasis::HGRAD_QUAD(degree));
+          basis_set.push_back(new typename  CG_DNBasis::HGRAD_QUAD(degree));
 
-          ordinal_type basisCardinality = basisPtr->getCardinality();
+          for (auto basisPtr:basis_set) {
 
-          //compute DofCoords Oriented
-          DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
-          DynRankView ConstructWithLabel(dofCoeffsPhys, numCells, basisCardinality);
-          DynRankView ConstructWithLabel(physDofCoords, numCells, basisCardinality, dim);
-          DynRankView ConstructWithLabel(funAtDofCoords, numCells, basisCardinality);
-          DynRankView ConstructWithLabel(basisCoeffsLI, numCells, basisCardinality);
+            auto name = basisPtr->getName();
+            *outStream << " " << name << std::endl;
+            ordinal_type basisCardinality = basisPtr->getCardinality();
 
-          //compute Lagrangian Interpolation of fun
-          {
-            li::getDofCoordsAndCoeffs(dofCoordsOriented,  dofCoeffsPhys, basisPtr.get(), POINTTYPE_EQUISPACED, elemOrts);
+            //compute DofCoords Oriented
+            DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
+            DynRankView ConstructWithLabel(dofCoeffsPhys, numCells, basisCardinality);
+            DynRankView ConstructWithLabel(physDofCoords, numCells, basisCardinality, dim);
+            DynRankView ConstructWithLabel(funAtDofCoords, numCells, basisCardinality);
+            DynRankView ConstructWithLabel(basisCoeffsLI, numCells, basisCardinality);
 
-            //Compute physical Dof Coordinates
+            //compute Lagrangian Interpolation of fun
             {
-              Basis_HGRAD_QUAD_C1_FEM<DeviceSpaceType,ValueType,ValueType> quadLinearBasis; //used for computing physical coordinates
-              DynRankView ConstructWithLabel(quadLinearBasisValuesAtDofCoords, numCells, quad.getNodeCount(), basisCardinality);
-              for(ordinal_type i=0; i<numCells; ++i)
-                for(ordinal_type d=0; d<dim; ++d) {
-                  auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
-                  auto outView =Kokkos::subview( quadLinearBasisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
-                  quadLinearBasis.getValues(outView, inView);
-                  DeviceSpaceType().fence();
-                  for(ordinal_type j=0; j<basisCardinality; ++j)
-                    for(std::size_t k=0; k<quad.getNodeCount(); ++k)
-                      physDofCoords(i,j,d) += vertices[quads[i][k]][d]*quadLinearBasisValuesAtDofCoords(i,k,j);
-                }
-            }
+              li::getDofCoordsAndCoeffs(dofCoordsOriented, dofCoeffsPhys, basisPtr, POINTTYPE_EQUISPACED, elemOrts);
 
-            Fun fun;
-
-            for(ordinal_type i=0; i<numCells; ++i) {
-              for(ordinal_type j=0; j<basisCardinality; ++j)
-                funAtDofCoords(i,j) += fun(degree, physDofCoords(i,j,0), physDofCoords(i,j,1));
-            }
-
-            li::getBasisCoeffs(basisCoeffsLI, funAtDofCoords, dofCoeffsPhys);
-          }
-
-          //Testing Kronecker property of basis functions
-          {
-            for(ordinal_type i=0; i<numCells; ++i) {
-              DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality);
-              DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
-              DynRankView ConstructWithLabel(transformedBasisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
-              auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
-              auto outView =Kokkos::subview( basisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL());
-              basisPtr->getValues(outView, inView);
-
-              // modify basis values to account for orientations
-              ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
-                  basisValuesAtDofCoords,
-                  elemOrts,
-                  basisPtr.get());
-
-              // transform basis values
-              fst::HGRADtransformVALUE(transformedBasisValuesAtDofCoordsOriented,
-                  basisValuesAtDofCoordsOriented);
-
-              DeviceSpaceType().fence();
-              for(ordinal_type k=0; k<basisCardinality; ++k) {
-                for(ordinal_type j=0; j<basisCardinality; ++j){
-                  ValueType dofValue = transformedBasisValuesAtDofCoordsOriented(i,k,j) * dofCoeffsPhys(i,j);
-                  if ( k==j && std::abs( dofValue - 1.0 ) > 100*tol ) {
-                    errorFlag++;
-                    *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-                    *outStream << " Basis function " << k << " of cell " << i << " does not have unit value at its node (" << dofValue <<")\n";
+              //Compute physical Dof Coordinates
+              {
+                Basis_HGRAD_QUAD_C1_FEM<DeviceSpaceType,ValueType,ValueType> quadLinearBasis; //used for computing physical coordinates
+                DynRankView ConstructWithLabel(quadLinearBasisValuesAtDofCoords, numCells, quad.getNodeCount(), basisCardinality);
+                for(ordinal_type i=0; i<numCells; ++i)
+                  for(ordinal_type d=0; d<dim; ++d) {
+                    auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
+                    auto outView =Kokkos::subview( quadLinearBasisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+                    quadLinearBasis.getValues(outView, inView);
+                    DeviceSpaceType().fence();
+                    for(ordinal_type j=0; j<basisCardinality; ++j)
+                      for(std::size_t k=0; k<quad.getNodeCount(); ++k)
+                        physDofCoords(i,j,d) += vertices[quads[i][k]][d]*quadLinearBasisValuesAtDofCoords(i,k,j);
                   }
-                  if ( k!=j && std::abs( dofValue ) > tol ) {
-                    errorFlag++;
-                    *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-                    *outStream << " Basis function " << k << " of cell " << i << " does not vanish at node " << j << "(" << dofValue <<")\n";
+              }
+
+              Fun fun;
+
+              for(ordinal_type i=0; i<numCells; ++i) {
+                for(ordinal_type j=0; j<basisCardinality; ++j)
+                  funAtDofCoords(i,j) += fun(degree, physDofCoords(i,j,0), physDofCoords(i,j,1));
+              }
+
+              li::getBasisCoeffs(basisCoeffsLI, funAtDofCoords, dofCoeffsPhys);
+            }
+
+            //Testing Kronecker property of basis functions
+            {
+              for(ordinal_type i=0; i<numCells; ++i) {
+                DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality);
+                DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
+                DynRankView ConstructWithLabel(transformedBasisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
+                auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
+                auto outView =Kokkos::subview( basisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL());
+                basisPtr->getValues(outView, inView);
+
+                // modify basis values to account for orientations
+                ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
+                    basisValuesAtDofCoords,
+                    elemOrts,
+                    basisPtr);
+
+                // transform basis values
+                fst::HGRADtransformVALUE(transformedBasisValuesAtDofCoordsOriented,
+                    basisValuesAtDofCoordsOriented);
+
+
+                DeviceSpaceType().fence();
+                for(ordinal_type k=0; k<basisCardinality; ++k) {
+                  for(ordinal_type j=0; j<basisCardinality; ++j){
+                    ValueType dofValue = transformedBasisValuesAtDofCoordsOriented(i,k,j) * dofCoeffsPhys(i,j);
+                    if ( k==j && std::abs( dofValue - 1.0 ) > 100*tol ) {
+                      errorFlag++;
+                      *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                      *outStream << " Basis function " << k << " of cell " << i << " does not have unit value at its node (" << dofValue <<")\n";
+                    }
+                    if ( k!=j && std::abs( dofValue ) > tol ) {
+                      errorFlag++;
+                      *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                      *outStream << " Basis function " << k << " of cell " << i << " does not vanish at node " << j << "(" << dofValue <<")\n";
+                    }
                   }
                 }
               }
             }
-          }
 
-          //check that fun values are consistent on common edges dofs
-          {
-            bool areDifferent(false);
-            auto numEdgeDOFs = basisPtr->getDofCount(1,0);
+            //check that fun values are consistent on common edges dofs
+            {
+              bool areDifferent(false);
+              auto numEdgeDOFs = basisPtr->getDofCount(1,0);
 
-            for(ordinal_type j=0;j<numEdgeDOFs && !areDifferent;j++) {
-              areDifferent = std::abs(basisCoeffsLI(0,basisPtr->getDofOrdinal(1,edgeIndex[0],j))
-                  - basisCoeffsLI(1,basisPtr->getDofOrdinal(1,edgeIndex[1],j))) > 10*tol;
-            }
-            if(areDifferent) {
-              errorFlag++;
-              *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-              *outStream << "Function DOFs on common edge computed using Quad 0 basis functions are not consistent with those computed using Quad 1\n";
-              *outStream << "Function DOFs for Quad 0 are:";
-              for(ordinal_type j=0;j<numEdgeDOFs;j++)
-                *outStream << " " << basisCoeffsLI(0,basisPtr->getDofOrdinal(1,edgeIndex[0],j));
-              *outStream << "\nFunction DOFs for Quad 1 are:";
-              for(ordinal_type j=0;j<numEdgeDOFs;j++)
-                *outStream << " " << basisCoeffsLI(1,basisPtr->getDofOrdinal(1,edgeIndex[1],j));
-              *outStream << std::endl;
-            }
-          }
-
-          //check that fun values at reference points coincide with those computed using basis functions
-          DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
-          DynRankView ConstructWithLabel(transformedBasisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
-          DynRankView basisValuesAtDofCoordsCells("inValues", numCells, basisCardinality, basisCardinality);
-
-          for (ordinal_type ic = 0; ic < numCells; ++ic)
-            basisPtr->getValues(Kokkos::subview(basisValuesAtDofCoordsCells, ic, Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(dofCoordsOriented, ic, Kokkos::ALL(), Kokkos::ALL()));
-
-          // modify basis values to account for orientations
-          ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
-              basisValuesAtDofCoordsCells,
-              elemOrts,
-              basisPtr.get());
-
-          // transform basis values
-          fst::HGRADtransformVALUE(transformedBasisValuesAtDofCoordsOriented,
-              basisValuesAtDofCoordsOriented);
-
-          DynRankView ConstructWithLabel(funAtDofCoordsOriented, numCells, basisCardinality);
-          for(ordinal_type i=0; i<numCells; ++i) {
-            ValueType error=0;
-            for(ordinal_type j=0; j<basisCardinality; ++j) {
-              for(ordinal_type k=0; k<basisCardinality; ++k)
-                funAtDofCoordsOriented(i,j) += basisCoeffsLI(i,k)*transformedBasisValuesAtDofCoordsOriented(i,k,j);
-
-              error = std::max(std::abs( funAtDofCoords(i,j) - funAtDofCoordsOriented(i,j)), error);
+              for(ordinal_type j=0;j<numEdgeDOFs && !areDifferent;j++) {
+                areDifferent = std::abs(basisCoeffsLI(0,basisPtr->getDofOrdinal(1,edgeIndex[0],j))
+                    - basisCoeffsLI(1,basisPtr->getDofOrdinal(1,edgeIndex[1],j))) > 10*tol;
+              }
+              if(areDifferent) {
+                errorFlag++;
+                *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                *outStream << "Function DOFs on common edge computed using Quad 0 basis functions are not consistent with those computed using Quad 1\n";
+                *outStream << "Function DOFs for Quad 0 are:";
+                for(ordinal_type j=0;j<numEdgeDOFs;j++)
+                  *outStream << " " << basisCoeffsLI(0,basisPtr->getDofOrdinal(1,edgeIndex[0],j));
+                *outStream << "\nFunction DOFs for Quad 1 are:";
+                for(ordinal_type j=0;j<numEdgeDOFs;j++)
+                  *outStream << " " << basisCoeffsLI(1,basisPtr->getDofOrdinal(1,edgeIndex[1],j));
+                *outStream << std::endl;
+              }
             }
 
-            if(error>100*tol) {
-              errorFlag++;
-              *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-              *outStream << "Function values at reference points differ from those computed using basis functions of Quad " << i << "\n";
-              *outStream << "Function values at reference points are:\n";
-              for(ordinal_type j=0; j<basisCardinality; ++j)
-                *outStream << " (" << funAtDofCoords(i,j)  << ")";
-              *outStream << "\nFunction values at reference points computed using basis functions are\n";
-              for(ordinal_type j=0; j<basisCardinality; ++j)
-                *outStream << " (" << funAtDofCoordsOriented(i,j)  << ")";
-              *outStream << std::endl;
-            }
-          }
+            //check that fun values at reference points coincide with those computed using basis functions
+            DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
+            DynRankView ConstructWithLabel(transformedBasisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
+            DynRankView basisValuesAtDofCoordsCells("inValues", numCells, basisCardinality, basisCardinality);
 
+            for (ordinal_type ic = 0; ic < numCells; ++ic)
+              basisPtr->getValues(Kokkos::subview(basisValuesAtDofCoordsCells, ic, Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(dofCoordsOriented, ic, Kokkos::ALL(), Kokkos::ALL()));
 
-          //compute projection-based interpolation of the Lagrangian interpolation
-          DynRankView ConstructWithLabel(basisCoeffsHGrad, numCells, basisCardinality);
-          {
-            ordinal_type targetCubDegree(basisPtr->getDegree()),targetDerivCubDegree(basisPtr->getDegree());
-
-            Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
-            projStruct.createHGradProjectionStruct(basisPtr.get(), targetCubDegree, targetDerivCubDegree);
-
-            ordinal_type numPoints = projStruct.getNumTargetEvalPoints(), numGradPoints = projStruct.getNumTargetDerivEvalPoints();
-            DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
-            DynRankView ConstructWithLabel(evaluationGradPoints, numCells, numGradPoints, dim);
-
-
-            pts::getHGradEvaluationPoints(evaluationPoints,
-                evaluationGradPoints,
+            // modify basis values to account for orientations
+            ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
+                basisValuesAtDofCoordsCells,
                 elemOrts,
-                basisPtr.get(),
-                &projStruct);
+                basisPtr);
+
+            // transform basis values
+            fst::HGRADtransformVALUE(transformedBasisValuesAtDofCoordsOriented,
+                basisValuesAtDofCoordsOriented);
+
+            DynRankView ConstructWithLabel(funAtDofCoordsOriented, numCells, basisCardinality);
+            for(ordinal_type i=0; i<numCells; ++i) {
+              ValueType error=0;
+              for(ordinal_type j=0; j<basisCardinality; ++j) {
+                for(ordinal_type k=0; k<basisCardinality; ++k)
+                  funAtDofCoordsOriented(i,j) += basisCoeffsLI(i,k)*transformedBasisValuesAtDofCoordsOriented(i,k,j);
+
+                error = std::max(std::abs( funAtDofCoords(i,j) - funAtDofCoordsOriented(i,j)), error);
+              }
+
+              if(error>100*tol) {
+                errorFlag++;
+                *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                *outStream << "Function values at reference points differ from those computed using basis functions of Quad " << i << "\n";
+                *outStream << "Function values at reference points are:\n";
+                for(ordinal_type j=0; j<basisCardinality; ++j)
+                  *outStream << " (" << funAtDofCoords(i,j)  << ")";
+                *outStream << "\nFunction values at reference points computed using basis functions are\n";
+                for(ordinal_type j=0; j<basisCardinality; ++j)
+                  *outStream << " (" << funAtDofCoordsOriented(i,j)  << ")";
+                *outStream << std::endl;
+              }
+            }
 
 
-            DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints);
-            DynRankView ConstructWithLabel(targetGradAtEvalPoints, numCells, numGradPoints, dim);
+            //compute projection-based interpolation of the Lagrangian interpolation
+            DynRankView ConstructWithLabel(basisCoeffsHGrad, numCells, basisCardinality);
+            {
+              ordinal_type targetCubDegree(basisPtr->getDegree()),targetDerivCubDegree(basisPtr->getDegree());
 
-            DynRankView ConstructWithLabel(hgradBasisAtEvaluationPoints, numCells, basisCardinality , numPoints);
-            DynRankView ConstructWithLabel(hgradBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints);
-            for(int ic=0; ic<numCells; ic++)
-              basisPtr->getValues(Kokkos::subview(hgradBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
-            ots::modifyBasisByOrientation(hgradBasisAtEvaluationPoints,
-                hgradBasisAtEvaluationPointsNonOriented,
-                elemOrts,
-                basisPtr.get());
+              Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
+              projStruct.createHGradProjectionStruct(basisPtr, targetCubDegree, targetDerivCubDegree);
 
-            DynRankView ConstructWithLabel(gradOfHGradBasisAtEvaluationPoints, numCells, basisCardinality , numGradPoints, dim);
-            if(numGradPoints>0) {
-              DynRankView ConstructWithLabel(gradOfHGradBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numGradPoints, dim);
-              for(int ic=0; ic<numCells; ic++)
-                basisPtr->getValues(Kokkos::subview(gradOfHGradBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationGradPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_GRAD);
-              ots::modifyBasisByOrientation(gradOfHGradBasisAtEvaluationPoints,
-                  gradOfHGradBasisAtEvaluationPointsNonOriented,
+              ordinal_type numPoints = projStruct.getNumTargetEvalPoints(), numGradPoints = projStruct.getNumTargetDerivEvalPoints();
+              DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
+              DynRankView ConstructWithLabel(evaluationGradPoints, numCells, numGradPoints, dim);
+
+
+              pts::getHGradEvaluationPoints(evaluationPoints,
+                  evaluationGradPoints,
                   elemOrts,
-                  basisPtr.get());
-            }
+                  basisPtr,
+                  &projStruct);
 
-            for(int ic=0; ic<numCells; ic++) {
-              for(int i=0;i<numPoints;i++) {
-                for(int k=0;k<basisCardinality;k++)
-                  targetAtEvalPoints(ic,i) += basisCoeffsLI(ic,k)*hgradBasisAtEvaluationPoints(ic,k,i);
-              }
-              for(int i=0;i<numGradPoints;i++) {
-                for(int k=0;k<basisCardinality;k++)
-                  for(int d=0;d<dim;d++)
-                    targetGradAtEvalPoints(ic,i,d) += basisCoeffsLI(ic,k)*gradOfHGradBasisAtEvaluationPoints(ic,k,i,d);//funHGradCoeffs(k)
-              }
 
-            }
+              DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints);
+              DynRankView ConstructWithLabel(targetGradAtEvalPoints, numCells, numGradPoints, dim);
 
-            pts::getHGradBasisCoeffs(basisCoeffsHGrad,
-                targetAtEvalPoints,
-                targetGradAtEvalPoints,
-                evaluationPoints,
-                evaluationGradPoints,
-                elemOrts,
-                basisPtr.get(),
-                &projStruct);
-          }
-
-          //check that the basis coefficients of the Lagrangian nterpolation are the same as those of the projection-based interpolation
-          {
-            ValueType diffErr(0);
-
-            for(int k=0;k<basisCardinality;k++) {
+              DynRankView ConstructWithLabel(hgradBasisAtEvaluationPoints, numCells, basisCardinality , numPoints);
+              DynRankView ConstructWithLabel(hgradBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints);
               for(int ic=0; ic<numCells; ic++)
-                diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsHGrad(ic,k)));
+                basisPtr->getValues(Kokkos::subview(hgradBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
+              ots::modifyBasisByOrientation(hgradBasisAtEvaluationPoints,
+                  hgradBasisAtEvaluationPointsNonOriented,
+                  elemOrts,
+                  basisPtr);
+
+              DynRankView ConstructWithLabel(gradOfHGradBasisAtEvaluationPoints, numCells, basisCardinality , numGradPoints, dim);
+              if(numGradPoints>0) {
+                DynRankView ConstructWithLabel(gradOfHGradBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numGradPoints, dim);
+                for(int ic=0; ic<numCells; ic++)
+                  basisPtr->getValues(Kokkos::subview(gradOfHGradBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationGradPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_GRAD);
+                ots::modifyBasisByOrientation(gradOfHGradBasisAtEvaluationPoints,
+                    gradOfHGradBasisAtEvaluationPointsNonOriented,
+                    elemOrts,
+                    basisPtr);
+              }
+
+              for(int ic=0; ic<numCells; ic++) {
+                for(int i=0;i<numPoints;i++) {
+                  for(int k=0;k<basisCardinality;k++)
+                    targetAtEvalPoints(ic,i) += basisCoeffsLI(ic,k)*hgradBasisAtEvaluationPoints(ic,k,i);
+                }
+                for(int i=0;i<numGradPoints;i++) {
+                  for(int k=0;k<basisCardinality;k++)
+                    for(int d=0;d<dim;d++)
+                      targetGradAtEvalPoints(ic,i,d) += basisCoeffsLI(ic,k)*gradOfHGradBasisAtEvaluationPoints(ic,k,i,d);//funHGradCoeffs(k)
+                }
+
+              }
+
+              pts::getHGradBasisCoeffs(basisCoeffsHGrad,
+                  targetAtEvalPoints,
+                  targetGradAtEvalPoints,
+                  evaluationPoints,
+                  evaluationGradPoints,
+                  elemOrts,
+                  basisPtr,
+                  &projStruct);
             }
 
-            if(diffErr > pow(7, degree-1)*tol) { //heuristic relation on how round-off error depends on degree
-              errorFlag++;
-              *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-              *outStream << "HGRAD_C" << degree << ": The weights recovered with the optimization are different than the one used for generating the functon."<<
-                  "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
-            }
-          }
+            //check that the basis coefficients of the Lagrangian nterpolation are the same as those of the projection-based interpolation
+            {
+              ValueType diffErr(0);
 
-          //compute L2 projection of the Lagrangian interpolation
-          DynRankView ConstructWithLabel(basisCoeffsL2, numCells, basisCardinality);
-          {
-            ordinal_type targetCubDegree(basisPtr->getDegree());
+              for(int k=0;k<basisCardinality;k++) {
+                for(int ic=0; ic<numCells; ic++)
+                  diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsHGrad(ic,k)));
+              }
 
-            Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
-            projStruct.createL2ProjectionStruct(basisPtr.get(), targetCubDegree);
-
-            ordinal_type numPoints = projStruct.getNumTargetEvalPoints();
-            DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
-
-            pts::getL2EvaluationPoints(evaluationPoints,
-                elemOrts,
-                basisPtr.get(),
-                &projStruct);
-
-
-            DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints);
-            DynRankView ConstructWithLabel(hgradBasisAtEvaluationPoints, numCells, basisCardinality , numPoints);
-            DynRankView ConstructWithLabel(hgradBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints);
-            for(int ic=0; ic<numCells; ic++)
-              basisPtr->getValues(Kokkos::subview(hgradBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
-            ots::modifyBasisByOrientation(hgradBasisAtEvaluationPoints,
-                hgradBasisAtEvaluationPointsNonOriented,
-                elemOrts,
-                basisPtr.get());
-
-
-            for(int ic=0; ic<numCells; ic++) {
-              for(int i=0;i<numPoints;i++) {
-                for(int k=0;k<basisCardinality;k++)
-                  targetAtEvalPoints(ic,i) += basisCoeffsLI(ic,k)*hgradBasisAtEvaluationPoints(ic,k,i);
+              if(diffErr > pow(7, degree-1)*tol) { //heuristic relation on how round-off error depends on degree
+                errorFlag++;
+                *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                *outStream << "HGRAD_C" << degree << ": The weights recovered with the optimization are different than the one used for generating the functon."<<
+                    "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
               }
             }
 
-            pts::getL2BasisCoeffs(basisCoeffsL2,
-                targetAtEvalPoints,
-                evaluationPoints,
-                elemOrts,
-                basisPtr.get(),
-                &projStruct);
-          }
+            //compute L2 projection of the Lagrangian interpolation
+            DynRankView ConstructWithLabel(basisCoeffsL2, numCells, basisCardinality);
+            {
+              ordinal_type targetCubDegree(basisPtr->getDegree());
 
-          //check that the basis coefficients of the Lagrangian interpolation are the same as those of the L2 projection
-          {
-            ValueType diffErr =0;
-            for(int k=0;k<basisCardinality;k++) {
+              Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
+              projStruct.createL2ProjectionStruct(basisPtr, targetCubDegree);
+
+              ordinal_type numPoints = projStruct.getNumTargetEvalPoints();
+              DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
+
+              pts::getL2EvaluationPoints(evaluationPoints,
+                  elemOrts,
+                  basisPtr,
+                  &projStruct);
+
+
+              DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints);
+              DynRankView ConstructWithLabel(hgradBasisAtEvaluationPoints, numCells, basisCardinality , numPoints);
+              DynRankView ConstructWithLabel(hgradBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints);
               for(int ic=0; ic<numCells; ic++)
-                diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsL2(ic,k)));
+                basisPtr->getValues(Kokkos::subview(hgradBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
+              ots::modifyBasisByOrientation(hgradBasisAtEvaluationPoints,
+                  hgradBasisAtEvaluationPointsNonOriented,
+                  elemOrts,
+                  basisPtr);
+
+
+              for(int ic=0; ic<numCells; ic++) {
+                for(int i=0;i<numPoints;i++) {
+                  for(int k=0;k<basisCardinality;k++)
+                    targetAtEvalPoints(ic,i) += basisCoeffsLI(ic,k)*hgradBasisAtEvaluationPoints(ic,k,i);
+                }
+              }
+
+              pts::getL2BasisCoeffs(basisCoeffsL2,
+                  targetAtEvalPoints,
+                  evaluationPoints,
+                  elemOrts,
+                  basisPtr,
+                  &projStruct);
             }
 
-            if(diffErr > pow(7, degree-1)*tol) { //heuristic relation on how round-off error depends on degree
-              errorFlag++;
-              *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-              *outStream << "HGRAD_C" << degree << ": The weights recovered with the optimization are different than the one used for generating the functon."<<
-                  "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
+            //check that the basis coefficients of the Lagrangian interpolation are the same as those of the L2 projection
+            {
+              ValueType diffErr =0;
+              for(int k=0;k<basisCardinality;k++) {
+                for(int ic=0; ic<numCells; ic++)
+                  diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsL2(ic,k)));
+              }
+
+              if(diffErr > pow(7, degree-1)*tol) { //heuristic relation on how round-off error depends on degree
+                errorFlag++;
+                *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                *outStream << "HGRAD_C" << degree << ": The weights recovered with the optimization are different than the one used for generating the functon."<<
+                    "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
+              }
             }
+            delete basisPtr;
           }
         }
       }
@@ -656,305 +666,312 @@ int InterpolationProjectionQuad(const bool verbose) {
 
         for (ordinal_type degree=1; degree <= max_degree; degree++) {
 
-          Teuchos::RCP<Basis<DeviceSpaceType,ValueType,ValueType> > basisPtr;
+          basis_set.clear();
           if(degree==1)
-            basisPtr = Teuchos::rcp(new Basis_HCURL_QUAD_I1_FEM<DeviceSpaceType,ValueType,ValueType>());
-          else
-            basisPtr = Teuchos::rcp(new Basis_HCURL_QUAD_In_FEM<DeviceSpaceType,ValueType,ValueType>(degree, POINTTYPE_WARPBLEND));
+            basis_set.push_back(new Basis_HCURL_QUAD_I1_FEM<DeviceSpaceType,ValueType,ValueType>());
+          basis_set.push_back(new typename  CG_NBasis::HCURL_QUAD(degree));
+          basis_set.push_back(new typename  CG_DNBasis::HCURL_QUAD(degree));
 
-          ordinal_type basisCardinality = basisPtr->getCardinality();
+          for (auto basisPtr:basis_set) {
 
-          //compute DofCoords Oriented
-          DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
-          DynRankView ConstructWithLabel(physDofCoords, numCells, basisCardinality, dim);
-          DynRankView ConstructWithLabel(funAtDofCoords, numCells, basisCardinality, dim);
-          DynRankView ConstructWithLabel(dofCoeffs, numCells, basisCardinality, dim);
-          DynRankView ConstructWithLabel(basisCoeffsLI, numCells, basisCardinality);
+            auto name = basisPtr->getName();
+            *outStream << " " << name << std::endl;
 
-          //compute Lagrangian Interpolation of fun
-          {
-            li::getDofCoordsAndCoeffs(dofCoordsOriented, dofCoeffs, basisPtr.get(), POINTTYPE_WARPBLEND, elemOrts);
+            ordinal_type basisCardinality = basisPtr->getCardinality();
 
-            //Compute physical Dof Coordinates
+            //compute DofCoords Oriented
+            DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
+            DynRankView ConstructWithLabel(physDofCoords, numCells, basisCardinality, dim);
+            DynRankView ConstructWithLabel(funAtDofCoords, numCells, basisCardinality, dim);
+            DynRankView ConstructWithLabel(dofCoeffs, numCells, basisCardinality, dim);
+            DynRankView ConstructWithLabel(basisCoeffsLI, numCells, basisCardinality);
 
+            //compute Lagrangian Interpolation of fun
             {
-              Basis_HGRAD_QUAD_C1_FEM<DeviceSpaceType,ValueType,ValueType> quadLinearBasis; //used for computing physical coordinates
-              DynRankView ConstructWithLabel(quadLinearBasisValuesAtDofCoords, numCells, quad.getNodeCount(), basisCardinality);
-              for(ordinal_type i=0; i<numCells; ++i)
+              li::getDofCoordsAndCoeffs(dofCoordsOriented, dofCoeffs, basisPtr, POINTTYPE_WARPBLEND, elemOrts);
+
+              //Compute physical Dof Coordinates
+
+              {
+                Basis_HGRAD_QUAD_C1_FEM<DeviceSpaceType,ValueType,ValueType> quadLinearBasis; //used for computing physical coordinates
+                DynRankView ConstructWithLabel(quadLinearBasisValuesAtDofCoords, numCells, quad.getNodeCount(), basisCardinality);
+                for(ordinal_type i=0; i<numCells; ++i)
+                  for(ordinal_type d=0; d<dim; ++d) {
+                    auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
+                    auto outView =Kokkos::subview( quadLinearBasisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+                    quadLinearBasis.getValues(outView, inView);
+                    DeviceSpaceType().fence();
+                    for(ordinal_type j=0; j<basisCardinality; ++j)
+                      for(std::size_t k=0; k<quad.getNodeCount(); ++k)
+                        physDofCoords(i,j,d) += vertices[quads[i][k]][d]*quadLinearBasisValuesAtDofCoords(i,k,j);
+                  }
+              }
+
+              DynRankView ConstructWithLabel(jacobian, numCells, basisCardinality, dim, dim);
+              ct::setJacobian(jacobian, dofCoordsOriented, physVertexes, quad);
+
+              FunCurl fun;
+              DynRankView ConstructWithLabel(fwdFunAtDofCoords, numCells, basisCardinality, dim);
+              for(ordinal_type i=0; i<numCells; ++i) {
+                for(ordinal_type j=0; j<basisCardinality; ++j) {
+                  for(ordinal_type k=0; k<dim; ++k)
+                    funAtDofCoords(i,j,k) = fun(degree, physDofCoords(i,j,0), physDofCoords(i,j,1), k);
+                  for(ordinal_type k=0; k<dim; ++k)
+                    for(ordinal_type d=0; d<dim; ++d)
+                      fwdFunAtDofCoords(i,j,k) += jacobian(i,j,d,k)*funAtDofCoords(i,j,d);
+                }
+              }
+
+              li::getBasisCoeffs(basisCoeffsLI, fwdFunAtDofCoords, dofCoeffs);
+            }
+
+
+            //Testing Kronecker property of basis functions
+            {
+              for(ordinal_type i=0; i<numCells; ++i) {
+                DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality, dim);
+                DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
+                auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
+                auto outView =Kokkos::subview( basisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+                basisPtr->getValues(outView, inView);
+
+                // modify basis values to account for orientations
+                ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
+                    basisValuesAtDofCoords,
+                    elemOrts,
+                    basisPtr);
+
+                for(ordinal_type k=0; k<basisCardinality; ++k) {
+                  for(ordinal_type j=0; j<basisCardinality; ++j){
+                    ValueType dofValue=0;
+                    for(ordinal_type d=0; d<dim; ++d)
+                      dofValue += basisValuesAtDofCoordsOriented(i,k,j,d) * dofCoeffs(i,j,d);
+                    if ( k==j && std::abs( dofValue - 1.0 ) > 100*tol ) {
+                      errorFlag++;
+                      *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                      *outStream << " Basis function " << k << " of cell " << i << " does not have unit value at its node (" << dofValue <<")\n";
+                    }
+                    if ( k!=j && std::abs( dofValue ) > tol ) {
+                      errorFlag++;
+                      *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                      *outStream << " Basis function " << k << " of cell " << i << " does not vanish at node " << j << "(" << dofValue <<")\n";
+                    }
+                  }
+                }
+              }
+            }
+
+            //check that fun values are consistent on common edges dofs
+            {
+              bool areDifferent(false);
+              auto numEdgeDOFs = basisPtr->getDofCount(1,0);
+
+              for(ordinal_type j=0;j<numEdgeDOFs && !areDifferent;j++) {
+                areDifferent = std::abs(basisCoeffsLI(0,basisPtr->getDofOrdinal(1,edgeIndex[0],j))
+                    - basisCoeffsLI(1,basisPtr->getDofOrdinal(1,edgeIndex[1],j))) > 10*tol;
+              }
+              if(areDifferent) {
+                errorFlag++;
+                *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                *outStream << "Function DOFs on the common edge computed using Quad 0 basis functions are not consistent with those computed using Quad 1\n";
+                *outStream << "Function DOFs for Quad 0 are:";
+                for(ordinal_type j=0;j<numEdgeDOFs;j++)
+                  *outStream << " " << basisCoeffsLI(0,basisPtr->getDofOrdinal(1,edgeIndex[0],j));
+                *outStream << "\nFunction DOFs for Quad 1 are:";
+                for(ordinal_type j=0;j<numEdgeDOFs;j++)
+                  *outStream << " " << basisCoeffsLI(1,basisPtr->getDofOrdinal(1,edgeIndex[1],j));
+                *outStream << std::endl;
+              }
+            }
+
+            //check that fun values at reference points coincide with those computed using basis functions
+            DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
+            DynRankView ConstructWithLabel(transformedBasisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
+            DynRankView basisValuesAtDofCoordsCells("inValues", numCells, basisCardinality, basisCardinality, dim);
+
+            for (ordinal_type ic = 0; ic < numCells; ++ic)
+              basisPtr->getValues(Kokkos::subview(basisValuesAtDofCoordsCells, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(dofCoordsOriented, ic, Kokkos::ALL(), Kokkos::ALL()));
+
+            // modify basis values to account for orientations
+            ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
+                basisValuesAtDofCoordsCells,
+                elemOrts,
+                basisPtr);
+
+            // transform basis values
+            DynRankView ConstructWithLabel(jacobianAtDofCoords, numCells, basisCardinality, dim, dim);
+            DynRankView ConstructWithLabel(jacobianAtDofCoords_inv, numCells, basisCardinality, dim, dim);
+            ct::setJacobian(jacobianAtDofCoords, dofCoordsOriented, physVertexes, quad);
+            ct::setJacobianInv (jacobianAtDofCoords_inv, jacobianAtDofCoords);
+            fst::HCURLtransformVALUE(transformedBasisValuesAtDofCoordsOriented,
+                jacobianAtDofCoords_inv,
+                basisValuesAtDofCoordsOriented);
+            DynRankView ConstructWithLabel(funAtDofCoordsOriented, numCells, basisCardinality, dim);
+            for(ordinal_type i=0; i<numCells; ++i) {
+              ValueType error=0;
+              for(ordinal_type j=0; j<basisCardinality; ++j)
                 for(ordinal_type d=0; d<dim; ++d) {
-                  auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
-                  auto outView =Kokkos::subview( quadLinearBasisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
-                  quadLinearBasis.getValues(outView, inView);
-                  DeviceSpaceType().fence();
-                  for(ordinal_type j=0; j<basisCardinality; ++j)
-                    for(std::size_t k=0; k<quad.getNodeCount(); ++k)
-                      physDofCoords(i,j,d) += vertices[quads[i][k]][d]*quadLinearBasisValuesAtDofCoords(i,k,j);
+                  for(ordinal_type k=0; k<basisCardinality; ++k)
+                    funAtDofCoordsOriented(i,j,d) += basisCoeffsLI(i,k)*transformedBasisValuesAtDofCoordsOriented(i,k,j,d);
+
+                  error = std::max(std::abs( funAtDofCoords(i,j,d) - funAtDofCoordsOriented(i,j,d)), error);
                 }
-            }
 
-            DynRankView ConstructWithLabel(jacobian, numCells, basisCardinality, dim, dim);
-            ct::setJacobian(jacobian, dofCoordsOriented, physVertexes, quad);
-
-            FunCurl fun;
-            DynRankView ConstructWithLabel(fwdFunAtDofCoords, numCells, basisCardinality, dim);
-            for(ordinal_type i=0; i<numCells; ++i) {
-              for(ordinal_type j=0; j<basisCardinality; ++j) {
-                for(ordinal_type k=0; k<dim; ++k)
-                  funAtDofCoords(i,j,k) = fun(degree, physDofCoords(i,j,0), physDofCoords(i,j,1), k);
-                for(ordinal_type k=0; k<dim; ++k)
-                  for(ordinal_type d=0; d<dim; ++d)
-                    fwdFunAtDofCoords(i,j,k) += jacobian(i,j,d,k)*funAtDofCoords(i,j,d);
+              if(error>100*tol) {
+                errorFlag++;
+                *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                *outStream << "Function values at reference points differ from those computed using basis functions of Quad " << i << "\n";
+                *outStream << "Function values at reference points are:\n";
+                for(ordinal_type j=0; j<basisCardinality; ++j)
+                  *outStream << " (" << funAtDofCoords(i,j,0) << "," << funAtDofCoords(i,j,1) << ", " << funAtDofCoords(i,j,2) << ")";
+                *outStream << "\nFunction values at reference points computed using basis functions are\n";
+                for(ordinal_type j=0; j<basisCardinality; ++j)
+                  *outStream << " (" << funAtDofCoordsOriented(i,j,0) << "," << funAtDofCoordsOriented(i,j,1) << ", " << funAtDofCoordsOriented(i,j,2) << ")";
+                *outStream << std::endl;
               }
             }
 
-            li::getBasisCoeffs(basisCoeffsLI, fwdFunAtDofCoords, dofCoeffs);
-          }
+            //compute projection-based interpolation of the Lagrangian interpolation
+            DynRankView ConstructWithLabel(basisCoeffsHCurl, numCells, basisCardinality);
+            {
+              ordinal_type targetCubDegree(basisPtr->getDegree()),targetDerivCubDegree(basisPtr->getDegree()-1);
 
+              Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
+              projStruct.createHCurlProjectionStruct(basisPtr, targetCubDegree, targetDerivCubDegree);
 
-          //Testing Kronecker property of basis functions
-          {
-            for(ordinal_type i=0; i<numCells; ++i) {
-              DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality, dim);
-              DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
-              auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
-              auto outView =Kokkos::subview( basisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
-              basisPtr->getValues(outView, inView);
+              ordinal_type numPoints = projStruct.getNumTargetEvalPoints(), numCurlPoints = projStruct.getNumTargetDerivEvalPoints();
+              DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
+              DynRankView ConstructWithLabel(evaluationCurlPoints, numCells, numCurlPoints, dim);
 
-              // modify basis values to account for orientations
-              ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
-                  basisValuesAtDofCoords,
+              pts::getHCurlEvaluationPoints(evaluationPoints,
+                  evaluationCurlPoints,
                   elemOrts,
-                  basisPtr.get());
+                  basisPtr,
+                  &projStruct);
 
-              for(ordinal_type k=0; k<basisCardinality; ++k) {
-                for(ordinal_type j=0; j<basisCardinality; ++j){
-                  ValueType dofValue=0;
-                  for(ordinal_type d=0; d<dim; ++d)
-                    dofValue += basisValuesAtDofCoordsOriented(i,k,j,d) * dofCoeffs(i,j,d);
-                  if ( k==j && std::abs( dofValue - 1.0 ) > 100*tol ) {
-                    errorFlag++;
-                    *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-                    *outStream << " Basis function " << k << " of cell " << i << " does not have unit value at its node (" << dofValue <<")\n";
-                  }
-                  if ( k!=j && std::abs( dofValue ) > tol ) {
-                    errorFlag++;
-                    *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-                    *outStream << " Basis function " << k << " of cell " << i << " does not vanish at node " << j << "(" << dofValue <<")\n";
-                  }
+
+              DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints, dim);
+              DynRankView ConstructWithLabel(targetCurlAtEvalPoints, numCells, numCurlPoints);
+
+              DynRankView ConstructWithLabel(hcurlBasisAtEvaluationPoints, numCells, basisCardinality , numPoints, dim);
+              DynRankView ConstructWithLabel(hcurlBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints, dim);
+              for(int ic=0; ic<numCells; ic++)
+                basisPtr->getValues(Kokkos::subview(hcurlBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
+              ots::modifyBasisByOrientation(hcurlBasisAtEvaluationPoints,
+                  hcurlBasisAtEvaluationPointsNonOriented,
+                  elemOrts,
+                  basisPtr);
+
+              DynRankView ConstructWithLabel(curlOfHCurlBasisAtEvaluationPoints, numCells, basisCardinality , numCurlPoints);
+              if(numCurlPoints>0) {
+                DynRankView ConstructWithLabel(curlOfHCurlBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numCurlPoints);
+                for(int ic=0; ic<numCells; ic++)
+                  basisPtr->getValues(Kokkos::subview(curlOfHCurlBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationCurlPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_CURL);
+                ots::modifyBasisByOrientation(curlOfHCurlBasisAtEvaluationPoints,
+                    curlOfHCurlBasisAtEvaluationPointsNonOriented,
+                    elemOrts,
+                    basisPtr);
+              }
+
+
+              for(int ic=0; ic<numCells; ic++){
+                for(int i=0;i<numPoints;i++) {
+                  for(int k=0;k<basisCardinality;k++)
+                    for(int d=0;d<dim;d++)
+                      targetAtEvalPoints(ic,i,d) += basisCoeffsLI(ic,k)*hcurlBasisAtEvaluationPoints(ic,k,i,d);
+                }
+                for(int i=0;i<numCurlPoints;i++) {
+                  for(int k=0;k<basisCardinality;k++)
+                    targetCurlAtEvalPoints(ic,i) += basisCoeffsLI(ic,k)*curlOfHCurlBasisAtEvaluationPoints(ic,k,i);//funHCurlCoeffs(k)
                 }
               }
-            }
-          }
 
-          //check that fun values are consistent on common edges dofs
-          {
-            bool areDifferent(false);
-            auto numEdgeDOFs = basisPtr->getDofCount(1,0);
-
-            for(ordinal_type j=0;j<numEdgeDOFs && !areDifferent;j++) {
-              areDifferent = std::abs(basisCoeffsLI(0,basisPtr->getDofOrdinal(1,edgeIndex[0],j))
-                  - basisCoeffsLI(1,basisPtr->getDofOrdinal(1,edgeIndex[1],j))) > 10*tol;
-            }
-            if(areDifferent) {
-              errorFlag++;
-              *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-              *outStream << "Function DOFs on the common edge computed using Quad 0 basis functions are not consistent with those computed using Quad 1\n";
-              *outStream << "Function DOFs for Quad 0 are:";
-              for(ordinal_type j=0;j<numEdgeDOFs;j++)
-                *outStream << " " << basisCoeffsLI(0,basisPtr->getDofOrdinal(1,edgeIndex[0],j));
-              *outStream << "\nFunction DOFs for Quad 1 are:";
-              for(ordinal_type j=0;j<numEdgeDOFs;j++)
-                *outStream << " " << basisCoeffsLI(1,basisPtr->getDofOrdinal(1,edgeIndex[1],j));
-              *outStream << std::endl;
-            }
-          }
-
-          //check that fun values at reference points coincide with those computed using basis functions
-          DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
-          DynRankView ConstructWithLabel(transformedBasisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
-          DynRankView basisValuesAtDofCoordsCells("inValues", numCells, basisCardinality, basisCardinality, dim);
-
-          for (ordinal_type ic = 0; ic < numCells; ++ic)
-            basisPtr->getValues(Kokkos::subview(basisValuesAtDofCoordsCells, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(dofCoordsOriented, ic, Kokkos::ALL(), Kokkos::ALL()));
-
-          // modify basis values to account for orientations
-          ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
-              basisValuesAtDofCoordsCells,
-              elemOrts,
-              basisPtr.get());
-
-          // transform basis values
-          DynRankView ConstructWithLabel(jacobianAtDofCoords, numCells, basisCardinality, dim, dim);
-          DynRankView ConstructWithLabel(jacobianAtDofCoords_inv, numCells, basisCardinality, dim, dim);
-          ct::setJacobian(jacobianAtDofCoords, dofCoordsOriented, physVertexes, quad);
-          ct::setJacobianInv (jacobianAtDofCoords_inv, jacobianAtDofCoords);
-          fst::HCURLtransformVALUE(transformedBasisValuesAtDofCoordsOriented,
-              jacobianAtDofCoords_inv,
-              basisValuesAtDofCoordsOriented);
-          DynRankView ConstructWithLabel(funAtDofCoordsOriented, numCells, basisCardinality, dim);
-          for(ordinal_type i=0; i<numCells; ++i) {
-            ValueType error=0;
-            for(ordinal_type j=0; j<basisCardinality; ++j)
-              for(ordinal_type d=0; d<dim; ++d) {
-                for(ordinal_type k=0; k<basisCardinality; ++k)
-                  funAtDofCoordsOriented(i,j,d) += basisCoeffsLI(i,k)*transformedBasisValuesAtDofCoordsOriented(i,k,j,d);
-
-                error = std::max(std::abs( funAtDofCoords(i,j,d) - funAtDofCoordsOriented(i,j,d)), error);
-              }
-
-            if(error>100*tol) {
-              errorFlag++;
-              *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-              *outStream << "Function values at reference points differ from those computed using basis functions of Quad " << i << "\n";
-              *outStream << "Function values at reference points are:\n";
-              for(ordinal_type j=0; j<basisCardinality; ++j)
-                *outStream << " (" << funAtDofCoords(i,j,0) << "," << funAtDofCoords(i,j,1) << ", " << funAtDofCoords(i,j,2) << ")";
-              *outStream << "\nFunction values at reference points computed using basis functions are\n";
-              for(ordinal_type j=0; j<basisCardinality; ++j)
-                *outStream << " (" << funAtDofCoordsOriented(i,j,0) << "," << funAtDofCoordsOriented(i,j,1) << ", " << funAtDofCoordsOriented(i,j,2) << ")";
-              *outStream << std::endl;
-            }
-          }
-
-          //compute projection-based interpolation of the Lagrangian interpolation
-          DynRankView ConstructWithLabel(basisCoeffsHCurl, numCells, basisCardinality);
-          {
-            ordinal_type targetCubDegree(basisPtr->getDegree()),targetDerivCubDegree(basisPtr->getDegree()-1);
-
-            Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
-            projStruct.createHCurlProjectionStruct(basisPtr.get(), targetCubDegree, targetDerivCubDegree);
-
-            ordinal_type numPoints = projStruct.getNumTargetEvalPoints(), numCurlPoints = projStruct.getNumTargetDerivEvalPoints();
-            DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
-            DynRankView ConstructWithLabel(evaluationCurlPoints, numCells, numCurlPoints, dim);
-
-            pts::getHCurlEvaluationPoints(evaluationPoints,
-                evaluationCurlPoints,
-                elemOrts,
-                basisPtr.get(),
-                &projStruct);
-
-
-            DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints, dim);
-            DynRankView ConstructWithLabel(targetCurlAtEvalPoints, numCells, numCurlPoints);
-
-            DynRankView ConstructWithLabel(hcurlBasisAtEvaluationPoints, numCells, basisCardinality , numPoints, dim);
-            DynRankView ConstructWithLabel(hcurlBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints, dim);
-            for(int ic=0; ic<numCells; ic++)
-              basisPtr->getValues(Kokkos::subview(hcurlBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
-            ots::modifyBasisByOrientation(hcurlBasisAtEvaluationPoints,
-                hcurlBasisAtEvaluationPointsNonOriented,
-                elemOrts,
-                basisPtr.get());
-
-            DynRankView ConstructWithLabel(curlOfHCurlBasisAtEvaluationPoints, numCells, basisCardinality , numCurlPoints);
-            if(numCurlPoints>0) {
-              DynRankView ConstructWithLabel(curlOfHCurlBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numCurlPoints);
-              for(int ic=0; ic<numCells; ic++)
-                basisPtr->getValues(Kokkos::subview(curlOfHCurlBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationCurlPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_CURL);
-              ots::modifyBasisByOrientation(curlOfHCurlBasisAtEvaluationPoints,
-                  curlOfHCurlBasisAtEvaluationPointsNonOriented,
+              pts::getHCurlBasisCoeffs(basisCoeffsHCurl,
+                  targetAtEvalPoints,
+                  targetCurlAtEvalPoints,
+                  evaluationPoints,
+                  evaluationCurlPoints,
                   elemOrts,
-                  basisPtr.get());
+                  basisPtr,
+                  &projStruct);
             }
 
-
-            for(int ic=0; ic<numCells; ic++){
-              for(int i=0;i<numPoints;i++) {
-                for(int k=0;k<basisCardinality;k++)
-                  for(int d=0;d<dim;d++)
-                    targetAtEvalPoints(ic,i,d) += basisCoeffsLI(ic,k)*hcurlBasisAtEvaluationPoints(ic,k,i,d);
+            //check that the basis coefficients of the Lagrangian interpolation are the same as those of the projection-based interpolation
+            {
+              ValueType diffErr(0);
+              for(int k=0;k<basisCardinality;k++) {
+                for(int ic=0; ic<numCells; ic++)
+                  diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsHCurl(ic,k)));
               }
-              for(int i=0;i<numCurlPoints;i++) {
-                for(int k=0;k<basisCardinality;k++)
-                  targetCurlAtEvalPoints(ic,i) += basisCoeffsLI(ic,k)*curlOfHCurlBasisAtEvaluationPoints(ic,k,i);//funHCurlCoeffs(k)
+
+              if(diffErr > pow(7, degree-1)*tol) { //heuristic relation on how round-off error depends on degree
+                errorFlag++;
+                *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                *outStream << "HCURL_I" << degree << ": The weights recovered with the optimization are different than the one used for generating the functon."<<
+                    "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
               }
             }
 
-            pts::getHCurlBasisCoeffs(basisCoeffsHCurl,
-                targetAtEvalPoints,
-                targetCurlAtEvalPoints,
-                evaluationPoints,
-                evaluationCurlPoints,
-                elemOrts,
-                basisPtr.get(),
-                &projStruct);
-          }
+            //compute L2 projection of the Lagrangian interpolation
+            DynRankView ConstructWithLabel(basisCoeffsL2, numCells, basisCardinality);
+            {
+              ordinal_type targetCubDegree(basisPtr->getDegree());
 
-          //check that the basis coefficients of the Lagrangian interpolation are the same as those of the projection-based interpolation
-          {
-            ValueType diffErr(0);
-            for(int k=0;k<basisCardinality;k++) {
+              Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
+              projStruct.createL2ProjectionStruct(basisPtr, targetCubDegree);
+
+              ordinal_type numPoints = projStruct.getNumTargetEvalPoints();
+              DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
+
+              pts::getL2EvaluationPoints(evaluationPoints,
+                  elemOrts,
+                  basisPtr,
+                  &projStruct);
+
+
+              DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints, dim);
+
+              DynRankView ConstructWithLabel(hcurlBasisAtEvaluationPoints, numCells, basisCardinality , numPoints, dim);
+              DynRankView ConstructWithLabel(hcurlBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints, dim);
               for(int ic=0; ic<numCells; ic++)
-                diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsHCurl(ic,k)));
+                basisPtr->getValues(Kokkos::subview(hcurlBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
+              ots::modifyBasisByOrientation(hcurlBasisAtEvaluationPoints,
+                  hcurlBasisAtEvaluationPointsNonOriented,
+                  elemOrts,
+                  basisPtr);
+
+              for(int ic=0; ic<numCells; ic++){
+                for(int i=0;i<numPoints;i++) {
+                  for(int k=0;k<basisCardinality;k++)
+                    for(int d=0;d<dim;d++)
+                      targetAtEvalPoints(ic,i,d) += basisCoeffsLI(ic,k)*hcurlBasisAtEvaluationPoints(ic,k,i,d);
+                }
+              }
+
+              pts::getL2BasisCoeffs(basisCoeffsL2,
+                  targetAtEvalPoints,
+                  evaluationPoints,
+                  elemOrts,
+                  basisPtr,
+                  &projStruct);
             }
 
-            if(diffErr > pow(7, degree-1)*tol) { //heuristic relation on how round-off error depends on degree
-              errorFlag++;
-              *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-              *outStream << "HCURL_I" << degree << ": The weights recovered with the optimization are different than the one used for generating the functon."<<
-                  "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
-            }
-          }
+            //check that the basis coefficients of the Lagrangian interpolation are the same as those of the L2 projection
+            {
+              ValueType diffErr = 0;
+              for(int k=0;k<basisCardinality;k++) {
+                for(int ic=0; ic<numCells; ic++)
+                  diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsL2(ic,k)));
+              }
 
-          //compute L2 projection of the Lagrangian interpolation
-          DynRankView ConstructWithLabel(basisCoeffsL2, numCells, basisCardinality);
-          {
-            ordinal_type targetCubDegree(basisPtr->getDegree());
-
-            Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
-            projStruct.createL2ProjectionStruct(basisPtr.get(), targetCubDegree);
-
-            ordinal_type numPoints = projStruct.getNumTargetEvalPoints();
-            DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
-
-            pts::getL2EvaluationPoints(evaluationPoints,
-                elemOrts,
-                basisPtr.get(),
-                &projStruct);
-
-
-            DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints, dim);
-
-            DynRankView ConstructWithLabel(hcurlBasisAtEvaluationPoints, numCells, basisCardinality , numPoints, dim);
-            DynRankView ConstructWithLabel(hcurlBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints, dim);
-            for(int ic=0; ic<numCells; ic++)
-              basisPtr->getValues(Kokkos::subview(hcurlBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
-            ots::modifyBasisByOrientation(hcurlBasisAtEvaluationPoints,
-                hcurlBasisAtEvaluationPointsNonOriented,
-                elemOrts,
-                basisPtr.get());
-
-            for(int ic=0; ic<numCells; ic++){
-              for(int i=0;i<numPoints;i++) {
-                for(int k=0;k<basisCardinality;k++)
-                  for(int d=0;d<dim;d++)
-                    targetAtEvalPoints(ic,i,d) += basisCoeffsLI(ic,k)*hcurlBasisAtEvaluationPoints(ic,k,i,d);
+              if(diffErr > pow(7, degree-1)*tol) { //heuristic relation on how round-off error depends on degree
+                errorFlag++;
+                *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                *outStream << "HCURL_I" << degree << ": The weights recovered with the L2 optimization are different than the one used for generating the functon."<<
+                    "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
               }
             }
-
-            pts::getL2BasisCoeffs(basisCoeffsL2,
-                targetAtEvalPoints,
-                evaluationPoints,
-                elemOrts,
-                basisPtr.get(),
-                &projStruct);
-          }
-
-          //check that the basis coefficients of the Lagrangian interpolation are the same as those of the L2 projection
-          {
-            ValueType diffErr = 0;
-            for(int k=0;k<basisCardinality;k++) {
-              for(int ic=0; ic<numCells; ic++)
-                diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsL2(ic,k)));
-            }
-
-            if(diffErr > pow(7, degree-1)*tol) { //heuristic relation on how round-off error depends on degree
-              errorFlag++;
-              *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-              *outStream << "HCURL_I" << degree << ": The weights recovered with the L2 optimization are different than the one used for generating the functon."<<
-                  "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
-            }
+            delete basisPtr;
           }
         }
       }
@@ -1039,318 +1056,324 @@ int InterpolationProjectionQuad(const bool verbose) {
 
         for (ordinal_type degree=1; degree <= max_degree; degree++) {
 
-          Teuchos::RCP<Basis<DeviceSpaceType,ValueType,ValueType> > basisPtr;
+          basis_set.clear();
           if(degree==1)
-            basisPtr = Teuchos::rcp(new Basis_HDIV_QUAD_I1_FEM<DeviceSpaceType,ValueType,ValueType>());
-          else
-            basisPtr = Teuchos::rcp(new Basis_HDIV_QUAD_In_FEM<DeviceSpaceType,ValueType,ValueType>(degree));
+            basis_set.push_back(new Basis_HDIV_QUAD_I1_FEM<DeviceSpaceType,ValueType,ValueType>());
+          basis_set.push_back(new typename  CG_NBasis::HDIV_QUAD(degree));
+          basis_set.push_back(new typename  CG_DNBasis::HDIV_QUAD(degree));
 
-          ordinal_type basisCardinality = basisPtr->getCardinality();
+          for (auto basisPtr:basis_set) {
 
-          //compute DofCoords Oriented
+            auto name = basisPtr->getName();
+            *outStream << " " << name << std::endl;
+            ordinal_type basisCardinality = basisPtr->getCardinality();
 
-          DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
-          DynRankView ConstructWithLabel(dofCoeffs, numCells, basisCardinality, dim);
-          DynRankView ConstructWithLabel(physDofCoords, numCells, basisCardinality, dim);
-          DynRankView ConstructWithLabel(funAtDofCoords, numCells, basisCardinality, dim);
-          DynRankView ConstructWithLabel(basisCoeffsLI, numCells, basisCardinality);
+            //compute DofCoords Oriented
 
-          //compute Lagrangian Interpolation of fun
-          {
+            DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
+            DynRankView ConstructWithLabel(dofCoeffs, numCells, basisCardinality, dim);
+            DynRankView ConstructWithLabel(physDofCoords, numCells, basisCardinality, dim);
+            DynRankView ConstructWithLabel(funAtDofCoords, numCells, basisCardinality, dim);
+            DynRankView ConstructWithLabel(basisCoeffsLI, numCells, basisCardinality);
 
-            li::getDofCoordsAndCoeffs(dofCoordsOriented,  dofCoeffs, basisPtr.get(), POINTTYPE_EQUISPACED, elemOrts);
+            //compute Lagrangian Interpolation of fun
+            {
 
-            //Compute physical Dof Coordinates
-            Basis_HGRAD_QUAD_C1_FEM<DeviceSpaceType,ValueType,ValueType> quadLinearBasis; //used for computing physical coordinates
-            DynRankView ConstructWithLabel(quadLinearBasisValuesAtDofCoords, numCells, quad.getNodeCount(), basisCardinality);
-            for(ordinal_type i=0; i<numCells; ++i)
-              for(ordinal_type d=0; d<dim; ++d) {
-                auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
-                auto outView =Kokkos::subview( quadLinearBasisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
-                quadLinearBasis.getValues(outView, inView);
-                DeviceSpaceType().fence();
-                for(ordinal_type j=0; j<basisCardinality; ++j)
-                  for(std::size_t k=0; k<quad.getNodeCount(); ++k)
-                    physDofCoords(i,j,d) += vertices[quads[i][k]][d]*quadLinearBasisValuesAtDofCoords(i,k,j);
-              }
+              li::getDofCoordsAndCoeffs(dofCoordsOriented,  dofCoeffs, basisPtr, POINTTYPE_EQUISPACED, elemOrts);
 
-            //need to transform dofCoeff to physical space (they transform as normals)
-            DynRankView ConstructWithLabel(jacobian, numCells, basisCardinality, dim, dim);
-            DynRankView ConstructWithLabel(jacobian_inv, numCells, basisCardinality, dim, dim);
-            DynRankView ConstructWithLabel(jacobian_det, numCells, basisCardinality);
-            ct::setJacobian(jacobian, dofCoordsOriented, physVertexes, quad);
-            ct::setJacobianInv (jacobian_inv, jacobian);
-            ct::setJacobianDet (jacobian_det, jacobian);
+              //Compute physical Dof Coordinates
+              Basis_HGRAD_QUAD_C1_FEM<DeviceSpaceType,ValueType,ValueType> quadLinearBasis; //used for computing physical coordinates
+              DynRankView ConstructWithLabel(quadLinearBasisValuesAtDofCoords, numCells, quad.getNodeCount(), basisCardinality);
+              for(ordinal_type i=0; i<numCells; ++i)
+                for(ordinal_type d=0; d<dim; ++d) {
+                  auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
+                  auto outView =Kokkos::subview( quadLinearBasisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+                  quadLinearBasis.getValues(outView, inView);
+                  DeviceSpaceType().fence();
+                  for(ordinal_type j=0; j<basisCardinality; ++j)
+                    for(std::size_t k=0; k<quad.getNodeCount(); ++k)
+                      physDofCoords(i,j,d) += vertices[quads[i][k]][d]*quadLinearBasisValuesAtDofCoords(i,k,j);
+                }
 
-
-            FunDiv fun;
-            DynRankView ConstructWithLabel(fwdFunAtDofCoords, numCells, basisCardinality, dim);
-            for(ordinal_type i=0; i<numCells; ++i) {
-              for(ordinal_type j=0; j<basisCardinality; ++j){
-                for(ordinal_type k=0; k<dim; ++k)
-                  funAtDofCoords(i,j,k) = fun(degree, physDofCoords(i,j,0), physDofCoords(i,j,1), k);
-                for(ordinal_type k=0; k<dim; ++k)
-                  for(ordinal_type d=0; d<dim; ++d)
-                    fwdFunAtDofCoords(i,j,k) += jacobian_det(i,j)*jacobian_inv(i,j,k,d)*funAtDofCoords(i,j,d);
-
-              }
-            }
-            li::getBasisCoeffs(basisCoeffsLI, fwdFunAtDofCoords, dofCoeffs);
-          }
-
-          //Testing Kronecker property of basis functions
-          {
-            for(ordinal_type i=0; i<numCells; ++i) {
-              DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality, dim);
-              DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
-              auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
-              auto outView =Kokkos::subview( basisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
-              basisPtr->getValues(outView, inView);
-
-              // modify basis values to account for orientations
-              ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
-                  basisValuesAtDofCoords,
-                  elemOrts,
-                  basisPtr.get());
-
+              //need to transform dofCoeff to physical space (they transform as normals)
               DynRankView ConstructWithLabel(jacobian, numCells, basisCardinality, dim, dim);
+              DynRankView ConstructWithLabel(jacobian_inv, numCells, basisCardinality, dim, dim);
               DynRankView ConstructWithLabel(jacobian_det, numCells, basisCardinality);
               ct::setJacobian(jacobian, dofCoordsOriented, physVertexes, quad);
+              ct::setJacobianInv (jacobian_inv, jacobian);
               ct::setJacobianDet (jacobian_det, jacobian);
 
-              for(ordinal_type k=0; k<basisCardinality; ++k) {
+
+              FunDiv fun;
+              DynRankView ConstructWithLabel(fwdFunAtDofCoords, numCells, basisCardinality, dim);
+              for(ordinal_type i=0; i<numCells; ++i) {
                 for(ordinal_type j=0; j<basisCardinality; ++j){
-                  ValueType dofValue=0;
-                  for(ordinal_type d=0; d<dim; ++d)
-                    dofValue += basisValuesAtDofCoordsOriented(i,k,j,d) * dofCoeffs(i,j,d);
-                  if ( k==j && std::abs( dofValue - 1.0 ) > 100*tol ) {
-                    errorFlag++;
-                    *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-                    *outStream << " Basis function " << k << " of cell " << i << " does not have unit value at its node (" << dofValue <<")\n";
-                  }
-                  if ( k!=j && std::abs( dofValue ) > tol ) {
-                    errorFlag++;
-                    *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-                    *outStream << " Basis function " << k << " of cell " << i << " does not vanish at node " << j << "(" << dofValue <<")\n";
+                  for(ordinal_type k=0; k<dim; ++k)
+                    funAtDofCoords(i,j,k) = fun(degree, physDofCoords(i,j,0), physDofCoords(i,j,1), k);
+                  for(ordinal_type k=0; k<dim; ++k)
+                    for(ordinal_type d=0; d<dim; ++d)
+                      fwdFunAtDofCoords(i,j,k) += jacobian_det(i,j)*jacobian_inv(i,j,k,d)*funAtDofCoords(i,j,d);
+
+                }
+              }
+              li::getBasisCoeffs(basisCoeffsLI, fwdFunAtDofCoords, dofCoeffs);
+            }
+
+            //Testing Kronecker property of basis functions
+            {
+              for(ordinal_type i=0; i<numCells; ++i) {
+                DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality, dim);
+                DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
+                auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
+                auto outView =Kokkos::subview( basisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+                basisPtr->getValues(outView, inView);
+
+                // modify basis values to account for orientations
+                ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
+                    basisValuesAtDofCoords,
+                    elemOrts,
+                    basisPtr);
+
+                DynRankView ConstructWithLabel(jacobian, numCells, basisCardinality, dim, dim);
+                DynRankView ConstructWithLabel(jacobian_det, numCells, basisCardinality);
+                ct::setJacobian(jacobian, dofCoordsOriented, physVertexes, quad);
+                ct::setJacobianDet (jacobian_det, jacobian);
+
+                for(ordinal_type k=0; k<basisCardinality; ++k) {
+                  for(ordinal_type j=0; j<basisCardinality; ++j){
+                    ValueType dofValue=0;
+                    for(ordinal_type d=0; d<dim; ++d)
+                      dofValue += basisValuesAtDofCoordsOriented(i,k,j,d) * dofCoeffs(i,j,d);
+                    if ( k==j && std::abs( dofValue - 1.0 ) > 100*tol ) {
+                      errorFlag++;
+                      *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                      *outStream << " Basis function " << k << " of cell " << i << " does not have unit value at its node (" << dofValue <<")\n";
+                    }
+                    if ( k!=j && std::abs( dofValue ) > tol ) {
+                      errorFlag++;
+                      *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                      *outStream << " Basis function " << k << " of cell " << i << " does not vanish at node " << j << "(" << dofValue <<")\n";
+                    }
                   }
                 }
               }
             }
-          }
 
-          //check that fun values are consistent on common edge dofs
-          {
-            bool areDifferent(false);
-            auto numEdgeDOFs = basisPtr->getDofCount(dim-1,0);
-            for(ordinal_type j=0;j<numEdgeDOFs && !areDifferent;j++) {
-              areDifferent = std::abs(basisCoeffsLI(0,basisPtr->getDofOrdinal(dim-1,edgeIndex[0],j))
-                  - basisCoeffsLI(1,basisPtr->getDofOrdinal(dim-1,edgeIndex[1],j))) > 10*tol;
-            }
-
-            if(areDifferent) {
-              errorFlag++;
-              *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-              *outStream << "Function DOFs on common edge computed using Quad 0 basis functions are not consistent with those computed using Quad 1\n";
-              *outStream << "Function DOFs for Quad 0 are:";
-              for(ordinal_type j=0;j<numEdgeDOFs;j++)
-                *outStream << " " << basisCoeffsLI(0,basisPtr->getDofOrdinal(dim-1,edgeIndex[0],j)) << " | (" << physDofCoords(0,basisPtr->getDofOrdinal(dim-1,edgeIndex[0],j),0) << "," << physDofCoords(0,basisPtr->getDofOrdinal(dim-1,edgeIndex[0],j),1) << ") ||";
-              *outStream << "\nFunction DOFs for Quad 1 are:";
-              for(ordinal_type j=0;j<numEdgeDOFs;j++)
-                *outStream << " " << basisCoeffsLI(1,basisPtr->getDofOrdinal(dim-1,edgeIndex[1],j))<< " | (" << physDofCoords(1,basisPtr->getDofOrdinal(dim-1,edgeIndex[1],j),0) << "," << physDofCoords(1,basisPtr->getDofOrdinal(dim-1,edgeIndex[1],j),1)  << ") ||";
-              *outStream << std::endl;
-            }
-          }
-
-          //check that fun values at reference points coincide with those computed using basis functions
-          DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
-          DynRankView ConstructWithLabel(transformedBasisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
-          DynRankView basisValuesAtDofCoordsCells("inValues", numCells, basisCardinality, basisCardinality, dim);
-
-          for (ordinal_type ic = 0; ic < numCells; ++ic)
-            basisPtr->getValues(Kokkos::subview(basisValuesAtDofCoordsCells, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(dofCoordsOriented, ic, Kokkos::ALL(), Kokkos::ALL()));
-
-          // modify basis values to account for orientations
-          ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
-              basisValuesAtDofCoordsCells,
-              elemOrts,
-              basisPtr.get());
-
-          // transform basis values
-          DynRankView ConstructWithLabel(jacobianAtDofCoords, numCells, basisCardinality, dim, dim);
-          DynRankView ConstructWithLabel(jacobianAtDofCoords_det, numCells, basisCardinality);
-          ct::setJacobian(jacobianAtDofCoords, dofCoordsOriented, physVertexes, quad);
-          ct::setJacobianDet (jacobianAtDofCoords_det, jacobianAtDofCoords);
-          fst::HDIVtransformVALUE(transformedBasisValuesAtDofCoordsOriented,
-              jacobianAtDofCoords,
-              jacobianAtDofCoords_det,
-              basisValuesAtDofCoordsOriented);
-          DynRankView ConstructWithLabel(funAtDofCoordsOriented, numCells, basisCardinality, dim);
-          for(ordinal_type i=0; i<numCells; ++i) {
-            ValueType error=0;
-            for(ordinal_type j=0; j<basisCardinality; ++j)
-              for(ordinal_type d=0; d<dim; ++d) {
-                for(ordinal_type k=0; k<basisCardinality; ++k)
-                  funAtDofCoordsOriented(i,j,d) += basisCoeffsLI(i,k)*transformedBasisValuesAtDofCoordsOriented(i,k,j,d);
-
-                error = std::max(std::abs( funAtDofCoords(i,j,d) - funAtDofCoordsOriented(i,j,d)), error);
+            //check that fun values are consistent on common edge dofs
+            {
+              bool areDifferent(false);
+              auto numEdgeDOFs = basisPtr->getDofCount(dim-1,0);
+              for(ordinal_type j=0;j<numEdgeDOFs && !areDifferent;j++) {
+                areDifferent = std::abs(basisCoeffsLI(0,basisPtr->getDofOrdinal(dim-1,edgeIndex[0],j))
+                    - basisCoeffsLI(1,basisPtr->getDofOrdinal(dim-1,edgeIndex[1],j))) > 10*tol;
               }
 
-            if(error>100*tol) {
-              errorFlag++;
-              *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-              *outStream << "Function values at reference points differ from those computed using basis functions of Quad " << i << "\n";
-              *outStream << "Function values at reference points are:\n";
-              for(ordinal_type j=0; j<basisCardinality; ++j)
-                *outStream << " (" << funAtDofCoords(i,j,0) << "," << funAtDofCoords(i,j,1) << ", " << funAtDofCoords(i,j,2) << ")";
-              *outStream << "\nFunction values at reference points computed using basis functions are\n";
-              for(ordinal_type j=0; j<basisCardinality; ++j)
-                *outStream << " (" << funAtDofCoordsOriented(i,j,0) << "," << funAtDofCoordsOriented(i,j,1) << ", " << funAtDofCoordsOriented(i,j,2) << ")";
-              *outStream << std::endl;
+              if(areDifferent) {
+                errorFlag++;
+                *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                *outStream << "Function DOFs on common edge computed using Quad 0 basis functions are not consistent with those computed using Quad 1\n";
+                *outStream << "Function DOFs for Quad 0 are:";
+                for(ordinal_type j=0;j<numEdgeDOFs;j++)
+                  *outStream << " " << basisCoeffsLI(0,basisPtr->getDofOrdinal(dim-1,edgeIndex[0],j)) << " | (" << physDofCoords(0,basisPtr->getDofOrdinal(dim-1,edgeIndex[0],j),0) << "," << physDofCoords(0,basisPtr->getDofOrdinal(dim-1,edgeIndex[0],j),1) << ") ||";
+                *outStream << "\nFunction DOFs for Quad 1 are:";
+                for(ordinal_type j=0;j<numEdgeDOFs;j++)
+                  *outStream << " " << basisCoeffsLI(1,basisPtr->getDofOrdinal(dim-1,edgeIndex[1],j))<< " | (" << physDofCoords(1,basisPtr->getDofOrdinal(dim-1,edgeIndex[1],j),0) << "," << physDofCoords(1,basisPtr->getDofOrdinal(dim-1,edgeIndex[1],j),1)  << ") ||";
+                *outStream << std::endl;
+              }
             }
-          }
 
-          //compute projection-based interpolation of the Lagrangian interpolation
-          DynRankView ConstructWithLabel(basisCoeffsHDiv, numCells, basisCardinality);
-          {
-            ordinal_type targetCubDegree(basisPtr->getDegree()),targetDerivCubDegree(basisPtr->getDegree()-1);
+            //check that fun values at reference points coincide with those computed using basis functions
+            DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
+            DynRankView ConstructWithLabel(transformedBasisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
+            DynRankView basisValuesAtDofCoordsCells("inValues", numCells, basisCardinality, basisCardinality, dim);
 
-            Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
-            projStruct.createHDivProjectionStruct(basisPtr.get(), targetCubDegree, targetDerivCubDegree);
+            for (ordinal_type ic = 0; ic < numCells; ++ic)
+              basisPtr->getValues(Kokkos::subview(basisValuesAtDofCoordsCells, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(dofCoordsOriented, ic, Kokkos::ALL(), Kokkos::ALL()));
 
-            ordinal_type numPoints = projStruct.getNumTargetEvalPoints(), numDivPoints = projStruct.getNumTargetDerivEvalPoints();
-
-            DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
-            DynRankView ConstructWithLabel(evaluationDivPoints, numCells, numDivPoints, dim);
-
-            pts::getHDivEvaluationPoints(evaluationPoints,
-                evaluationDivPoints,
+            // modify basis values to account for orientations
+            ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
+                basisValuesAtDofCoordsCells,
                 elemOrts,
-                basisPtr.get(),
-                &projStruct);
+                basisPtr);
 
-            DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints, dim);
-            DynRankView ConstructWithLabel(targetDivAtEvalPoints, numCells, numDivPoints);
+            // transform basis values
+            DynRankView ConstructWithLabel(jacobianAtDofCoords, numCells, basisCardinality, dim, dim);
+            DynRankView ConstructWithLabel(jacobianAtDofCoords_det, numCells, basisCardinality);
+            ct::setJacobian(jacobianAtDofCoords, dofCoordsOriented, physVertexes, quad);
+            ct::setJacobianDet (jacobianAtDofCoords_det, jacobianAtDofCoords);
+            fst::HDIVtransformVALUE(transformedBasisValuesAtDofCoordsOriented,
+                jacobianAtDofCoords,
+                jacobianAtDofCoords_det,
+                basisValuesAtDofCoordsOriented);
+            DynRankView ConstructWithLabel(funAtDofCoordsOriented, numCells, basisCardinality, dim);
+            for(ordinal_type i=0; i<numCells; ++i) {
+              ValueType error=0;
+              for(ordinal_type j=0; j<basisCardinality; ++j)
+                for(ordinal_type d=0; d<dim; ++d) {
+                  for(ordinal_type k=0; k<basisCardinality; ++k)
+                    funAtDofCoordsOriented(i,j,d) += basisCoeffsLI(i,k)*transformedBasisValuesAtDofCoordsOriented(i,k,j,d);
 
-            DynRankView ConstructWithLabel(hdivBasisAtEvaluationPoints, numCells, basisCardinality , numPoints, dim);
-            DynRankView ConstructWithLabel(hdivBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints, dim);
-            for(ordinal_type ic=0; ic<numCells; ++ic)
-              basisPtr->getValues(Kokkos::subview(hdivBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
-            ots::modifyBasisByOrientation(hdivBasisAtEvaluationPoints,
-                hdivBasisAtEvaluationPointsNonOriented,
-                elemOrts,
-                basisPtr.get());
+                  error = std::max(std::abs( funAtDofCoords(i,j,d) - funAtDofCoordsOriented(i,j,d)), error);
+                }
 
-            DynRankView ConstructWithLabel(divOfHDivBasisAtEvaluationPoints, numCells, basisCardinality , numDivPoints);
-            if(numDivPoints>0) {
-              DynRankView ConstructWithLabel(divOfHDivBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numDivPoints);
-              for(ordinal_type ic=0; ic<numCells; ++ic)
-                basisPtr->getValues(Kokkos::subview(divOfHDivBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationDivPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_DIV);
-              ots::modifyBasisByOrientation(divOfHDivBasisAtEvaluationPoints,
-                  divOfHDivBasisAtEvaluationPointsNonOriented,
+              if(error>100*tol) {
+                errorFlag++;
+                *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                *outStream << "Function values at reference points differ from those computed using basis functions of Quad " << i << "\n";
+                *outStream << "Function values at reference points are:\n";
+                for(ordinal_type j=0; j<basisCardinality; ++j)
+                  *outStream << " (" << funAtDofCoords(i,j,0) << "," << funAtDofCoords(i,j,1) << ", " << funAtDofCoords(i,j,2) << ")";
+                *outStream << "\nFunction values at reference points computed using basis functions are\n";
+                for(ordinal_type j=0; j<basisCardinality; ++j)
+                  *outStream << " (" << funAtDofCoordsOriented(i,j,0) << "," << funAtDofCoordsOriented(i,j,1) << ", " << funAtDofCoordsOriented(i,j,2) << ")";
+                *outStream << std::endl;
+              }
+            }
+
+            //compute projection-based interpolation of the Lagrangian interpolation
+            DynRankView ConstructWithLabel(basisCoeffsHDiv, numCells, basisCardinality);
+            {
+              ordinal_type targetCubDegree(basisPtr->getDegree()),targetDerivCubDegree(basisPtr->getDegree()-1);
+
+              Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
+              projStruct.createHDivProjectionStruct(basisPtr, targetCubDegree, targetDerivCubDegree);
+
+              ordinal_type numPoints = projStruct.getNumTargetEvalPoints(), numDivPoints = projStruct.getNumTargetDerivEvalPoints();
+
+              DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
+              DynRankView ConstructWithLabel(evaluationDivPoints, numCells, numDivPoints, dim);
+
+              pts::getHDivEvaluationPoints(evaluationPoints,
+                  evaluationDivPoints,
                   elemOrts,
-                  basisPtr.get());
-            }
+                  basisPtr,
+                  &projStruct);
 
+              DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints, dim);
+              DynRankView ConstructWithLabel(targetDivAtEvalPoints, numCells, numDivPoints);
 
-
-            for(ordinal_type ic=0; ic<numCells; ++ic) {
-              for(int i=0;i<numPoints;i++) {
-                for(int k=0;k<basisCardinality;k++)
-                  for(int d=0;d<dim;d++)
-                    targetAtEvalPoints(ic,i,d) += basisCoeffsLI(ic,k)*hdivBasisAtEvaluationPoints(ic,k,i,d);
-              }
-              for(int i=0;i<numDivPoints;i++) {
-                for(int k=0;k<basisCardinality;k++)
-                  targetDivAtEvalPoints(ic,i) += basisCoeffsLI(ic,k)*divOfHDivBasisAtEvaluationPoints(ic,k,i);//basisCoeffsLI(k)
-              }
-            }
-
-            pts::getHDivBasisCoeffs(basisCoeffsHDiv,
-                targetAtEvalPoints,
-                targetDivAtEvalPoints,
-                evaluationPoints,
-                evaluationDivPoints,
-                elemOrts,
-                basisPtr.get(),
-                &projStruct);
-          }
-
-          //check that the basis coefficients of the Lagrangian interpolation are the same as those of the projection-based interpolation
-          {
-            ValueType diffErr(0);
-            for(int k=0;k<basisCardinality;k++) {
-              //std::cout << "["<< basisCoeffsLI(0,k) << " " <<  basisCoeffsHDiv(0,k) << "] [" << basisCoeffsLI(1,k) << " " <<  basisCoeffsHDiv(1,k) << "]" <<std::endl;
+              DynRankView ConstructWithLabel(hdivBasisAtEvaluationPoints, numCells, basisCardinality , numPoints, dim);
+              DynRankView ConstructWithLabel(hdivBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints, dim);
               for(ordinal_type ic=0; ic<numCells; ++ic)
-                diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsHDiv(ic,k)));
+                basisPtr->getValues(Kokkos::subview(hdivBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
+              ots::modifyBasisByOrientation(hdivBasisAtEvaluationPoints,
+                  hdivBasisAtEvaluationPointsNonOriented,
+                  elemOrts,
+                  basisPtr);
+
+              DynRankView ConstructWithLabel(divOfHDivBasisAtEvaluationPoints, numCells, basisCardinality , numDivPoints);
+              if(numDivPoints>0) {
+                DynRankView ConstructWithLabel(divOfHDivBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numDivPoints);
+                for(ordinal_type ic=0; ic<numCells; ++ic)
+                  basisPtr->getValues(Kokkos::subview(divOfHDivBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationDivPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_DIV);
+                ots::modifyBasisByOrientation(divOfHDivBasisAtEvaluationPoints,
+                    divOfHDivBasisAtEvaluationPointsNonOriented,
+                    elemOrts,
+                    basisPtr);
+              }
+
+
+
+              for(ordinal_type ic=0; ic<numCells; ++ic) {
+                for(int i=0;i<numPoints;i++) {
+                  for(int k=0;k<basisCardinality;k++)
+                    for(int d=0;d<dim;d++)
+                      targetAtEvalPoints(ic,i,d) += basisCoeffsLI(ic,k)*hdivBasisAtEvaluationPoints(ic,k,i,d);
+                }
+                for(int i=0;i<numDivPoints;i++) {
+                  for(int k=0;k<basisCardinality;k++)
+                    targetDivAtEvalPoints(ic,i) += basisCoeffsLI(ic,k)*divOfHDivBasisAtEvaluationPoints(ic,k,i);//basisCoeffsLI(k)
+                }
+              }
+
+              pts::getHDivBasisCoeffs(basisCoeffsHDiv,
+                  targetAtEvalPoints,
+                  targetDivAtEvalPoints,
+                  evaluationPoints,
+                  evaluationDivPoints,
+                  elemOrts,
+                  basisPtr,
+                  &projStruct);
             }
 
-            if(diffErr > pow(7, degree-1)*tol) { //heuristic relation on how round-off error depends on degree
-              errorFlag++;
-              *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-              *outStream << "HDIV_I" << degree << ": The weights recovered with the optimization are different than the one used for generating the functon."<<
-                  "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
-            }
-          }
+            //check that the basis coefficients of the Lagrangian interpolation are the same as those of the projection-based interpolation
+            {
+              ValueType diffErr(0);
+              for(int k=0;k<basisCardinality;k++) {
+                //std::cout << "["<< basisCoeffsLI(0,k) << " " <<  basisCoeffsHDiv(0,k) << "] [" << basisCoeffsLI(1,k) << " " <<  basisCoeffsHDiv(1,k) << "]" <<std::endl;
+                for(ordinal_type ic=0; ic<numCells; ++ic)
+                  diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsHDiv(ic,k)));
+              }
 
-          //compute L2 projection interpolation of the Lagrangian interpolation
-          DynRankView ConstructWithLabel(basisCoeffsL2, numCells, basisCardinality);
-          {
-            ordinal_type targetCubDegree(basisPtr->getDegree());
-
-            Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
-            projStruct.createL2ProjectionStruct(basisPtr.get(), targetCubDegree);
-
-            ordinal_type numPoints = projStruct.getNumTargetEvalPoints();
-
-            DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
-
-            pts::getL2EvaluationPoints(evaluationPoints,
-                elemOrts,
-                basisPtr.get(),
-                &projStruct);
-
-            DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints, dim);
-
-            DynRankView ConstructWithLabel(hdivBasisAtEvaluationPoints, numCells, basisCardinality , numPoints, dim);
-            DynRankView ConstructWithLabel(hdivBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints, dim);
-            for(ordinal_type ic=0; ic<numCells; ++ic)
-              basisPtr->getValues(Kokkos::subview(hdivBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
-            ots::modifyBasisByOrientation(hdivBasisAtEvaluationPoints,
-                hdivBasisAtEvaluationPointsNonOriented,
-                elemOrts,
-                basisPtr.get());
-
-            for(ordinal_type ic=0; ic<numCells; ++ic) {
-              for(int i=0;i<numPoints;i++) {
-                for(int k=0;k<basisCardinality;k++)
-                  for(int d=0;d<dim;d++)
-                    targetAtEvalPoints(ic,i,d) += basisCoeffsLI(ic,k)*hdivBasisAtEvaluationPoints(ic,k,i,d);
+              if(diffErr > pow(7, degree-1)*tol) { //heuristic relation on how round-off error depends on degree
+                errorFlag++;
+                *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                *outStream << "HDIV_I" << degree << ": The weights recovered with the optimization are different than the one used for generating the functon."<<
+                    "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
               }
             }
 
-            pts::getL2BasisCoeffs(basisCoeffsL2,
-                targetAtEvalPoints,
-                evaluationPoints,
-                elemOrts,
-                basisPtr.get(),
-                &projStruct);
-          }
+            //compute L2 projection interpolation of the Lagrangian interpolation
+            DynRankView ConstructWithLabel(basisCoeffsL2, numCells, basisCardinality);
+            {
+              ordinal_type targetCubDegree(basisPtr->getDegree());
 
-          //check that the basis coefficients of the Lagrangian interpolation are the same as those of the L2 projection
-          {
-            ValueType diffErr = 0;
-            for(int k=0;k<basisCardinality;k++) {
-              //std::cout << "["<< basisCoeffsLI(0,k) << " " <<  basisCoeffsHDiv(0,k) << "] [" << basisCoeffsLI(1,k) << " " <<  basisCoeffsHDiv(1,k) << "]" <<std::endl;
+              Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
+              projStruct.createL2ProjectionStruct(basisPtr, targetCubDegree);
+
+              ordinal_type numPoints = projStruct.getNumTargetEvalPoints();
+
+              DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
+
+              pts::getL2EvaluationPoints(evaluationPoints,
+                  elemOrts,
+                  basisPtr,
+                  &projStruct);
+
+              DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints, dim);
+
+              DynRankView ConstructWithLabel(hdivBasisAtEvaluationPoints, numCells, basisCardinality , numPoints, dim);
+              DynRankView ConstructWithLabel(hdivBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints, dim);
               for(ordinal_type ic=0; ic<numCells; ++ic)
-                diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsL2(ic,k)));
+                basisPtr->getValues(Kokkos::subview(hdivBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
+              ots::modifyBasisByOrientation(hdivBasisAtEvaluationPoints,
+                  hdivBasisAtEvaluationPointsNonOriented,
+                  elemOrts,
+                  basisPtr);
+
+              for(ordinal_type ic=0; ic<numCells; ++ic) {
+                for(int i=0;i<numPoints;i++) {
+                  for(int k=0;k<basisCardinality;k++)
+                    for(int d=0;d<dim;d++)
+                      targetAtEvalPoints(ic,i,d) += basisCoeffsLI(ic,k)*hdivBasisAtEvaluationPoints(ic,k,i,d);
+                }
+              }
+
+              pts::getL2BasisCoeffs(basisCoeffsL2,
+                  targetAtEvalPoints,
+                  evaluationPoints,
+                  elemOrts,
+                  basisPtr,
+                  &projStruct);
             }
 
-            if(diffErr > pow(7, degree-1)*tol) { //heuristic relation on how round-off error depends on degree
-              errorFlag++;
-              *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-              *outStream << "HDIV_I" << degree << ": The weights recovered with the L2 optimization are different than the one used for generating the function."<<
-                  "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
+            //check that the basis coefficients of the Lagrangian interpolation are the same as those of the L2 projection
+            {
+              ValueType diffErr = 0;
+              for(int k=0;k<basisCardinality;k++) {
+                //std::cout << "["<< basisCoeffsLI(0,k) << " " <<  basisCoeffsHDiv(0,k) << "] [" << basisCoeffsLI(1,k) << " " <<  basisCoeffsHDiv(1,k) << "]" <<std::endl;
+                for(ordinal_type ic=0; ic<numCells; ++ic)
+                  diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsL2(ic,k)));
+              }
+
+              if(diffErr > pow(7, degree-1)*tol) { //heuristic relation on how round-off error depends on degree
+                errorFlag++;
+                *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                *outStream << "HDIV_I" << degree << ": The weights recovered with the L2 optimization are different than the one used for generating the function."<<
+                    "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
+              }
             }
+            delete basisPtr;
           }
         }
       }
@@ -1410,254 +1433,262 @@ int InterpolationProjectionQuad(const bool verbose) {
 
     for (ordinal_type degree=1; degree <= max_degree; degree++) {
 
-      Teuchos::RCP<Basis<DeviceSpaceType,ValueType,ValueType> > basisPtr;
+      basis_set.clear();
       if(degree==1)
-        basisPtr = Teuchos::rcp(new Basis_HVOL_C0_FEM<DeviceSpaceType,ValueType,ValueType>(quad));
-      else
-        basisPtr = Teuchos::rcp(new Basis_HVOL_QUAD_Cn_FEM<DeviceSpaceType,ValueType,ValueType>(degree, POINTTYPE_WARPBLEND));
-      ordinal_type basisCardinality = basisPtr->getCardinality();
+        basis_set.push_back(new Basis_HVOL_C0_FEM<DeviceSpaceType,ValueType,ValueType>(quad));
+      basis_set.push_back(new typename  CG_NBasis::HVOL_QUAD(degree));
+      basis_set.push_back(new typename  CG_DNBasis::HVOL_QUAD(degree));
 
-      //compute DofCoords Oriented
-      DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
-      DynRankView ConstructWithLabel(dofCoeffsPhys, numCells, basisCardinality);
-      DynRankView ConstructWithLabel(physDofCoords, numCells, basisCardinality, dim);
-      DynRankView ConstructWithLabel(funAtDofCoords, numCells, basisCardinality);
-      DynRankView ConstructWithLabel(basisCoeffsLI, numCells, basisCardinality);
-      {
-        li::getDofCoordsAndCoeffs(dofCoordsOriented,  dofCoeffsPhys, basisPtr.get(), POINTTYPE_WARPBLEND, elemOrts);
+      for (auto basisPtr:basis_set) {
 
-        //Compute physical Dof Coordinates
+        auto name = basisPtr->getName();
+        *outStream << " " << name << std::endl;
+
+        ordinal_type basisCardinality = basisPtr->getCardinality();
+
+        //compute DofCoords Oriented
+        DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
+        DynRankView ConstructWithLabel(dofCoeffsPhys, numCells, basisCardinality);
+        DynRankView ConstructWithLabel(physDofCoords, numCells, basisCardinality, dim);
+        DynRankView ConstructWithLabel(funAtDofCoords, numCells, basisCardinality);
+        DynRankView ConstructWithLabel(basisCoeffsLI, numCells, basisCardinality);
         {
-          Basis_HGRAD_QUAD_C1_FEM<DeviceSpaceType,ValueType,ValueType> quadLinearBasis; //used for computing physical coordinates
-          DynRankView ConstructWithLabel(quadLinearBasisValuesAtDofCoords, numCells, quad.getNodeCount(), basisCardinality);
+          li::getDofCoordsAndCoeffs(dofCoordsOriented,  dofCoeffsPhys, basisPtr, POINTTYPE_WARPBLEND, elemOrts);
+
+          //Compute physical Dof Coordinates
+          {
+            Basis_HGRAD_QUAD_C1_FEM<DeviceSpaceType,ValueType,ValueType> quadLinearBasis; //used for computing physical coordinates
+            DynRankView ConstructWithLabel(quadLinearBasisValuesAtDofCoords, numCells, quad.getNodeCount(), basisCardinality);
+            for(ordinal_type i=0; i<numCells; ++i)
+              for(ordinal_type d=0; d<dim; ++d) {
+                auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
+                auto outView =Kokkos::subview( quadLinearBasisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+                quadLinearBasis.getValues(outView, inView);
+                DeviceSpaceType().fence();
+                for(ordinal_type j=0; j<basisCardinality; ++j)
+                  for(std::size_t k=0; k<quad.getNodeCount(); ++k)
+                    physDofCoords(i,j,d) += vertices[quads[i][k]][d]*quadLinearBasisValuesAtDofCoords(i,k,j);
+              }
+          }
+
+          //need to transform dofCoeff to physical space (they transform as normals)
+          DynRankView ConstructWithLabel(jacobian, numCells, basisCardinality, dim, dim);
+          DynRankView ConstructWithLabel(jacobian_det, numCells, basisCardinality);
+          ct::setJacobian(jacobian, dofCoordsOriented, physVertexes, quad);
+          ct::setJacobianDet (jacobian_det, jacobian);
+
+          Fun fun;
+
+          DynRankView ConstructWithLabel(fwdFunAtDofCoords, numCells, basisCardinality);
           for(ordinal_type i=0; i<numCells; ++i)
-            for(ordinal_type d=0; d<dim; ++d) {
-              auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
-              auto outView =Kokkos::subview( quadLinearBasisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
-              quadLinearBasis.getValues(outView, inView);
-              DeviceSpaceType().fence();
-              for(ordinal_type j=0; j<basisCardinality; ++j)
-                for(std::size_t k=0; k<quad.getNodeCount(); ++k)
-                  physDofCoords(i,j,d) += vertices[quads[i][k]][d]*quadLinearBasisValuesAtDofCoords(i,k,j);
+            for(ordinal_type j=0; j<basisCardinality; ++j) {
+              funAtDofCoords(i,j) = fun(degree, physDofCoords(i,j,0), physDofCoords(i,j,1));
+              fwdFunAtDofCoords(i,j) = jacobian_det(i,j)*funAtDofCoords(i,j);
             }
+
+          li::getBasisCoeffs(basisCoeffsLI, fwdFunAtDofCoords, dofCoeffsPhys);
         }
 
-        //need to transform dofCoeff to physical space (they transform as normals)
+        //Testing Kronecker property of basis functions
+        {
+          for(ordinal_type i=0; i<numCells; ++i) {
+            DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality);
+            DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
+            auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
+            auto outView =Kokkos::subview( basisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL());
+            basisPtr->getValues(outView, inView);
+
+            // modify basis values to account for orientations
+            ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
+                basisValuesAtDofCoords,
+                elemOrts,
+                basisPtr);
+
+            for(ordinal_type k=0; k<basisCardinality; ++k) {
+              for(ordinal_type j=0; j<basisCardinality; ++j){
+                ValueType dofValue = basisValuesAtDofCoordsOriented(i,k,j) * dofCoeffsPhys(i,j);
+                if ( k==j && std::abs( dofValue - 1.0 ) > 100*tol ) {
+                  errorFlag++;
+                  *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                  *outStream << " Basis function " << k << " of cell " << i << " does not have unit value at its node (" << dofValue <<")\n";
+                }
+                if ( k!=j && std::abs( dofValue ) > tol ) {
+                  errorFlag++;
+                  *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                  *outStream << " Basis function " << k << " of cell " << i << " does not vanish at node " << j << "(" << dofValue <<")\n";
+                }
+              }
+            }
+          }
+        }
+
+        //check that fun values at reference points coincide with those computed using basis functions
+        DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
+        DynRankView ConstructWithLabel(transformedBasisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
+        DynRankView basisValuesAtDofCoordsCells("inValues", numCells, basisCardinality, basisCardinality);
+
+        for (ordinal_type ic = 0; ic < numCells; ++ic)
+          basisPtr->getValues(Kokkos::subview(basisValuesAtDofCoordsCells, ic, Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(dofCoordsOriented, ic, Kokkos::ALL(), Kokkos::ALL()));
+
+        // modify basis values to account for orientations
+        ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
+            basisValuesAtDofCoordsCells,
+            elemOrts,
+            basisPtr);
+
+        // transform basis values
         DynRankView ConstructWithLabel(jacobian, numCells, basisCardinality, dim, dim);
         DynRankView ConstructWithLabel(jacobian_det, numCells, basisCardinality);
         ct::setJacobian(jacobian, dofCoordsOriented, physVertexes, quad);
         ct::setJacobianDet (jacobian_det, jacobian);
+        fst::HVOLtransformVALUE(transformedBasisValuesAtDofCoordsOriented,
+            jacobian_det,
+            basisValuesAtDofCoordsOriented);
 
-        Fun fun;
-
-        DynRankView ConstructWithLabel(fwdFunAtDofCoords, numCells, basisCardinality);
-        for(ordinal_type i=0; i<numCells; ++i)
+        DynRankView ConstructWithLabel(funAtDofCoordsOriented, numCells, basisCardinality);
+        for(ordinal_type i=0; i<numCells; ++i) {
+          ValueType error=0;
           for(ordinal_type j=0; j<basisCardinality; ++j) {
-            funAtDofCoords(i,j) = fun(degree, physDofCoords(i,j,0), physDofCoords(i,j,1));
-            fwdFunAtDofCoords(i,j) = jacobian_det(i,j)*funAtDofCoords(i,j);
+            for(ordinal_type k=0; k<basisCardinality; ++k)
+              funAtDofCoordsOriented(i,j) += basisCoeffsLI(i,k)*transformedBasisValuesAtDofCoordsOriented(i,k,j);
+
+            error = std::max(std::abs( funAtDofCoords(i,j) - funAtDofCoordsOriented(i,j)), error);
           }
 
-        li::getBasisCoeffs(basisCoeffsLI, fwdFunAtDofCoords, dofCoeffsPhys);
-      }
+          if(error>100*tol) {
+            errorFlag++;
+            *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+            *outStream << "Function values at reference points differ from those computed using basis functions of Quad " << i << "\n";
+            *outStream << "Function values at reference points are:\n";
+            for(ordinal_type j=0; j<basisCardinality; ++j)
+              *outStream << " (" << funAtDofCoords(i,j)  << ")";
+            *outStream << "\nFunction values at reference points computed using basis functions are\n";
+            for(ordinal_type j=0; j<basisCardinality; ++j)
+              *outStream << " (" << funAtDofCoordsOriented(i,j)  << ")";
+            *outStream << std::endl;
+          }
+        }
 
-      //Testing Kronecker property of basis functions
-      {
-        for(ordinal_type i=0; i<numCells; ++i) {
-          DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality);
-          DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
-          auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
-          auto outView =Kokkos::subview( basisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL());
-          basisPtr->getValues(outView, inView);
+        //compute projection-based interpolation of the Lagrangian interpolation
+        DynRankView ConstructWithLabel(basisCoeffsHVol, numCells, basisCardinality);
+        {
+          ordinal_type targetCubDegree(basisPtr->getDegree());
 
-          // modify basis values to account for orientations
-          ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
-              basisValuesAtDofCoords,
+          Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
+          projStruct.createHVolProjectionStruct(basisPtr, targetCubDegree);
+
+          ordinal_type numPoints = projStruct.getNumTargetEvalPoints();
+          DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
+
+
+          pts::getHVolEvaluationPoints(evaluationPoints,
               elemOrts,
-              basisPtr.get());
+              basisPtr,
+              &projStruct);
 
-          for(ordinal_type k=0; k<basisCardinality; ++k) {
-            for(ordinal_type j=0; j<basisCardinality; ++j){
-              ValueType dofValue = basisValuesAtDofCoordsOriented(i,k,j) * dofCoeffsPhys(i,j);
-              if ( k==j && std::abs( dofValue - 1.0 ) > 100*tol ) {
-                errorFlag++;
-                *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-                *outStream << " Basis function " << k << " of cell " << i << " does not have unit value at its node (" << dofValue <<")\n";
-              }
-              if ( k!=j && std::abs( dofValue ) > tol ) {
-                errorFlag++;
-                *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-                *outStream << " Basis function " << k << " of cell " << i << " does not vanish at node " << j << "(" << dofValue <<")\n";
-              }
+
+          DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints);
+
+          DynRankView ConstructWithLabel(hvolBasisAtEvaluationPoints, numCells, basisCardinality , numPoints);
+          DynRankView ConstructWithLabel(hvolBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints);
+          for(int ic=0; ic<numCells; ic++)
+            basisPtr->getValues(Kokkos::subview(hvolBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
+          ots::modifyBasisByOrientation(hvolBasisAtEvaluationPoints,
+              hvolBasisAtEvaluationPointsNonOriented,
+              elemOrts,
+              basisPtr);
+
+          for(int ic=0; ic<numCells; ic++) {
+            for(int i=0;i<numPoints;i++) {
+              for(int k=0;k<basisCardinality;k++)
+                targetAtEvalPoints(ic,i) += basisCoeffsLI(ic,k)*hvolBasisAtEvaluationPoints(ic,k,i);
             }
           }
-        }
-      }
 
-      //check that fun values at reference points coincide with those computed using basis functions
-      DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
-      DynRankView ConstructWithLabel(transformedBasisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
-      DynRankView basisValuesAtDofCoordsCells("inValues", numCells, basisCardinality, basisCardinality);
-
-      for (ordinal_type ic = 0; ic < numCells; ++ic)
-        basisPtr->getValues(Kokkos::subview(basisValuesAtDofCoordsCells, ic, Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(dofCoordsOriented, ic, Kokkos::ALL(), Kokkos::ALL()));
-
-      // modify basis values to account for orientations
-      ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
-          basisValuesAtDofCoordsCells,
-          elemOrts,
-          basisPtr.get());
-
-      // transform basis values
-      DynRankView ConstructWithLabel(jacobian, numCells, basisCardinality, dim, dim);
-      DynRankView ConstructWithLabel(jacobian_det, numCells, basisCardinality);
-      ct::setJacobian(jacobian, dofCoordsOriented, physVertexes, quad);
-      ct::setJacobianDet (jacobian_det, jacobian);
-      fst::HVOLtransformVALUE(transformedBasisValuesAtDofCoordsOriented,
-          jacobian_det,
-          basisValuesAtDofCoordsOriented);
-
-      DynRankView ConstructWithLabel(funAtDofCoordsOriented, numCells, basisCardinality);
-      for(ordinal_type i=0; i<numCells; ++i) {
-        ValueType error=0;
-        for(ordinal_type j=0; j<basisCardinality; ++j) {
-          for(ordinal_type k=0; k<basisCardinality; ++k)
-            funAtDofCoordsOriented(i,j) += basisCoeffsLI(i,k)*transformedBasisValuesAtDofCoordsOriented(i,k,j);
-
-          error = std::max(std::abs( funAtDofCoords(i,j) - funAtDofCoordsOriented(i,j)), error);
+          pts::getHVolBasisCoeffs(basisCoeffsHVol,
+              targetAtEvalPoints,
+              evaluationPoints,
+              elemOrts,
+              basisPtr,
+              &projStruct);
         }
 
-        if(error>100*tol) {
-          errorFlag++;
-          *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-          *outStream << "Function values at reference points differ from those computed using basis functions of Quad " << i << "\n";
-          *outStream << "Function values at reference points are:\n";
-          for(ordinal_type j=0; j<basisCardinality; ++j)
-            *outStream << " (" << funAtDofCoords(i,j)  << ")";
-          *outStream << "\nFunction values at reference points computed using basis functions are\n";
-          for(ordinal_type j=0; j<basisCardinality; ++j)
-            *outStream << " (" << funAtDofCoordsOriented(i,j)  << ")";
-          *outStream << std::endl;
-        }
-      }
+        //check that the basis coefficients of the Lagrangian interpolation are the same as those of the projection-based interpolation
+        {
+          ValueType diffErr(0);
+          for(int k=0;k<basisCardinality;k++) {
+            for(int ic=0; ic<numCells; ic++)
+              diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsHVol(ic,k)));
+          }
 
-      //compute projection-based interpolation of the Lagrangian interpolation
-      DynRankView ConstructWithLabel(basisCoeffsHVol, numCells, basisCardinality);
-      {
-        ordinal_type targetCubDegree(basisPtr->getDegree());
-
-        Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
-        projStruct.createHVolProjectionStruct(basisPtr.get(), targetCubDegree);
-
-        ordinal_type numPoints = projStruct.getNumTargetEvalPoints();
-        DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
-
-
-        pts::getHVolEvaluationPoints(evaluationPoints,
-            elemOrts,
-            basisPtr.get(),
-            &projStruct);
-
-
-        DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints);
-
-        DynRankView ConstructWithLabel(hvolBasisAtEvaluationPoints, numCells, basisCardinality , numPoints);
-        DynRankView ConstructWithLabel(hvolBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints);
-        for(int ic=0; ic<numCells; ic++)
-          basisPtr->getValues(Kokkos::subview(hvolBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
-        ots::modifyBasisByOrientation(hvolBasisAtEvaluationPoints,
-            hvolBasisAtEvaluationPointsNonOriented,
-            elemOrts,
-            basisPtr.get());
-
-        for(int ic=0; ic<numCells; ic++) {
-          for(int i=0;i<numPoints;i++) {
-            for(int k=0;k<basisCardinality;k++)
-              targetAtEvalPoints(ic,i) += basisCoeffsLI(ic,k)*hvolBasisAtEvaluationPoints(ic,k,i);
+          if(diffErr > pow(16, degree)*tol) { //heuristic relation on how round-off error depends on degree
+            errorFlag++;
+            *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+            *outStream << "HVOL_C" << degree << ": The weights recovered with the optimization are different than the one used for generating the functon."<<
+                "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
           }
         }
 
-        pts::getHVolBasisCoeffs(basisCoeffsHVol,
-            targetAtEvalPoints,
-            evaluationPoints,
-            elemOrts,
-            basisPtr.get(),
-            &projStruct);
-      }
+        //compute L2 projection of the Lagrangian interpolation
+        DynRankView ConstructWithLabel(basisCoeffsL2, numCells, basisCardinality);
+        {
+          ordinal_type targetCubDegree(basisPtr->getDegree());
 
-      //check that the basis coefficients of the Lagrangian interpolation are the same as those of the projection-based interpolation
-      {
-        ValueType diffErr(0);
-        for(int k=0;k<basisCardinality;k++) {
+          Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
+          projStruct.createL2ProjectionStruct(basisPtr, targetCubDegree);
+
+          ordinal_type numPoints = projStruct.getNumTargetEvalPoints();
+          DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
+
+
+          pts::getL2EvaluationPoints(evaluationPoints,
+              elemOrts,
+              basisPtr,
+              &projStruct);
+
+
+          DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints);
+
+          DynRankView ConstructWithLabel(hvolBasisAtEvaluationPoints, numCells, basisCardinality , numPoints);
+          DynRankView ConstructWithLabel(hvolBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints);
           for(int ic=0; ic<numCells; ic++)
-            diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsHVol(ic,k)));
+            basisPtr->getValues(Kokkos::subview(hvolBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
+          ots::modifyBasisByOrientation(hvolBasisAtEvaluationPoints,
+              hvolBasisAtEvaluationPointsNonOriented,
+              elemOrts,
+              basisPtr);
+
+          for(int ic=0; ic<numCells; ic++) {
+            for(int i=0;i<numPoints;i++) {
+              for(int k=0;k<basisCardinality;k++)
+                targetAtEvalPoints(ic,i) += basisCoeffsLI(ic,k)*hvolBasisAtEvaluationPoints(ic,k,i);
+            }
+          }
+
+          pts::getL2BasisCoeffs(basisCoeffsL2,
+              targetAtEvalPoints,
+              evaluationPoints,
+              elemOrts,
+              basisPtr,
+              &projStruct);
         }
 
-        if(diffErr > pow(16, degree)*tol) { //heuristic relation on how round-off error depends on degree
-          errorFlag++;
-          *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-          *outStream << "HVOL_C" << degree << ": The weights recovered with the optimization are different than the one used for generating the functon."<<
-              "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
-        }
-      }
+        //check that the basis coefficients of the Lagrangian interpolation are the same as those of the L2 projection
+        {
+          ValueType diffErr = 0;
+          for(int k=0;k<basisCardinality;k++) {
+            for(int ic=0; ic<numCells; ic++)
+              diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsL2(ic,k)));
+          }
 
-      //compute L2 projection of the Lagrangian interpolation
-      DynRankView ConstructWithLabel(basisCoeffsL2, numCells, basisCardinality);
-      {
-        ordinal_type targetCubDegree(basisPtr->getDegree());
-
-        Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
-        projStruct.createL2ProjectionStruct(basisPtr.get(), targetCubDegree);
-
-        ordinal_type numPoints = projStruct.getNumTargetEvalPoints();
-        DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
-
-
-        pts::getL2EvaluationPoints(evaluationPoints,
-            elemOrts,
-            basisPtr.get(),
-            &projStruct);
-
-
-        DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints);
-
-        DynRankView ConstructWithLabel(hvolBasisAtEvaluationPoints, numCells, basisCardinality , numPoints);
-        DynRankView ConstructWithLabel(hvolBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints);
-        for(int ic=0; ic<numCells; ic++)
-          basisPtr->getValues(Kokkos::subview(hvolBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
-        ots::modifyBasisByOrientation(hvolBasisAtEvaluationPoints,
-            hvolBasisAtEvaluationPointsNonOriented,
-            elemOrts,
-            basisPtr.get());
-
-        for(int ic=0; ic<numCells; ic++) {
-          for(int i=0;i<numPoints;i++) {
-            for(int k=0;k<basisCardinality;k++)
-              targetAtEvalPoints(ic,i) += basisCoeffsLI(ic,k)*hvolBasisAtEvaluationPoints(ic,k,i);
+          if(diffErr > pow(16, degree)*tol) { //heuristic relation on how round-off error depends on degree
+            errorFlag++;
+            *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+            *outStream << "HVOL_C" << degree << ": The weights recovered with the L2 optimization are different than the one used for generating the functon."<<
+                "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
           }
         }
-
-        pts::getL2BasisCoeffs(basisCoeffsL2,
-            targetAtEvalPoints,
-            evaluationPoints,
-            elemOrts,
-            basisPtr.get(),
-            &projStruct);
-      }
-
-      //check that the basis coefficients of the Lagrangian interpolation are the same as those of the L2 projection
-      {
-        ValueType diffErr = 0;
-        for(int k=0;k<basisCardinality;k++) {
-          for(int ic=0; ic<numCells; ic++)
-            diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsL2(ic,k)));
-        }
-
-        if(diffErr > pow(16, degree)*tol) { //heuristic relation on how round-off error depends on degree
-          errorFlag++;
-          *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-          *outStream << "HVOL_C" << degree << ": The weights recovered with the L2 optimization are different than the one used for generating the functon."<<
-              "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
-        }
+        delete basisPtr;
       }
     }
   } catch (std::exception &err) {

--- a/packages/intrepid2/unit-test/Projection/test_interpolation_projection_TET.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_interpolation_projection_TET.hpp
@@ -84,6 +84,9 @@
 
 #define Intrepid2_Experimental
 
+//this allows to reduce cost of the tests.
+//undefine when debugging/developing
+#define RANDOMLY_PICK_ELEM_PERMUTATION
 
 #include "Teuchos_oblackholestream.hpp"
 #include "Teuchos_RCP.hpp"
@@ -347,6 +350,7 @@ int InterpolationProjectionTet(const bool verbose) {
             }
 
             li::getBasisCoeffs(basisCoeffsLI, funAtDofCoords, dofCoeffsPhys);
+            Kokkos::fence();
           }
 
           //Testing Kronecker property of basis functions

--- a/packages/intrepid2/unit-test/Projection/test_interpolation_projection_TRI.hpp
+++ b/packages/intrepid2/unit-test/Projection/test_interpolation_projection_TRI.hpp
@@ -190,6 +190,7 @@ int InterpolationProjectionTri(const bool verbose) {
   typedef Experimental::ProjectionTools<DeviceSpaceType> pts;
   typedef FunctionSpaceTools<DeviceSpaceType> fst;
   typedef Experimental::LagrangianInterpolation<DeviceSpaceType> li;
+  using  basisType = Basis<DeviceSpaceType,ValueType,ValueType>;
 
   constexpr ordinal_type dim = 2;
   constexpr ordinal_type numCells = 2;
@@ -202,6 +203,10 @@ int InterpolationProjectionTri(const bool verbose) {
   ordinal_type tris_rotated[numCells][numElemVertexes];
 
   const ordinal_type max_degree = 4;
+
+  using CG_NBasis = NodalBasisFamily<DeviceSpaceType,ValueType,ValueType>;
+  using CG_DNBasis = DerivedNodalBasisFamily<DeviceSpaceType,ValueType,ValueType>;
+  std::vector<basisType*> basis_set;
 
   *outStream
   << "===============================================================================\n"
@@ -275,299 +280,304 @@ int InterpolationProjectionTri(const bool verbose) {
         ots::getOrientation(elemOrts, elemNodes, tri);
 
         for (ordinal_type degree=1; degree <= max_degree; degree++) {
-
-          Teuchos::RCP<Basis<DeviceSpaceType,ValueType,ValueType>> basisPtr;
-
+          basis_set.clear();
           if(degree==1)
-            basisPtr = Teuchos::rcp(new Basis_HGRAD_TRI_C1_FEM<DeviceSpaceType,ValueType,ValueType>());
-          else
-            basisPtr = Teuchos::rcp(new Basis_HGRAD_TRI_Cn_FEM<DeviceSpaceType,ValueType,ValueType>(degree, POINTTYPE_WARPBLEND));
+            basis_set.push_back(new Basis_HGRAD_TRI_C1_FEM<DeviceSpaceType,ValueType,ValueType>());
+          basis_set.push_back(new typename  CG_NBasis::HGRAD_TRI(degree));
+          basis_set.push_back(new typename  CG_DNBasis::HGRAD_TRI(degree));
 
-          ordinal_type basisCardinality = basisPtr->getCardinality();
+          for (auto basisPtr:basis_set) {
 
-          //allocate views
-          DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
-          DynRankView ConstructWithLabel(dofCoeffsPhys, numCells, basisCardinality);
-          DynRankView ConstructWithLabel(physDofCoords, numCells, basisCardinality, dim);
-          DynRankView ConstructWithLabel(funAtDofCoords, numCells, basisCardinality);
-          DynRankView ConstructWithLabel(basisCoeffsLI, numCells, basisCardinality);
+            auto name = basisPtr->getName();
+            *outStream << " " << name << std::endl;
+            ordinal_type basisCardinality = basisPtr->getCardinality();
 
-          //compute Lagrangian Interpolation of fun
-          {
-            li::getDofCoordsAndCoeffs(dofCoordsOriented, dofCoeffsPhys, basisPtr.get(), POINTTYPE_WARPBLEND, elemOrts);
+            //compute DofCoords Oriented
+            DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
+            DynRankView ConstructWithLabel(dofCoeffsPhys, numCells, basisCardinality);
+            DynRankView ConstructWithLabel(physDofCoords, numCells, basisCardinality, dim);
+            DynRankView ConstructWithLabel(funAtDofCoords, numCells, basisCardinality);
+            DynRankView ConstructWithLabel(basisCoeffsLI, numCells, basisCardinality);
 
-            //Compute physical Dof Coordinates
+            //compute Lagrangian Interpolation of fun
             {
-              Basis_HGRAD_TRI_C1_FEM<DeviceSpaceType,ValueType,ValueType> triLinearBasis; //used for computing physical coordinates
-              DynRankView ConstructWithLabel(triLinearBasisValuesAtDofCoords, numCells, tri.getNodeCount(), basisCardinality);
-              for(ordinal_type i=0; i<numCells; ++i)
-                for(ordinal_type d=0; d<dim; ++d) {
-                  auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
-                  auto outView =Kokkos::subview( triLinearBasisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
-                  triLinearBasis.getValues(outView, inView);
-                  DeviceSpaceType().fence();
-                  for(ordinal_type j=0; j<basisCardinality; ++j)
-                    for(std::size_t k=0; k<tri.getNodeCount(); ++k)
-                      physDofCoords(i,j,d) += vertices[tris[i][k]][d]*triLinearBasisValuesAtDofCoords(i,k,j);
+              li::getDofCoordsAndCoeffs(dofCoordsOriented, dofCoeffsPhys, basisPtr, POINTTYPE_EQUISPACED, elemOrts);
+
+              //Compute physical Dof Coordinates
+              {
+                Basis_HGRAD_TRI_C1_FEM<DeviceSpaceType,ValueType,ValueType> triLinearBasis; //used for computing physical coordinates
+                DynRankView ConstructWithLabel(triLinearBasisValuesAtDofCoords, numCells, tri.getNodeCount(), basisCardinality);
+                for(ordinal_type i=0; i<numCells; ++i)
+                  for(ordinal_type d=0; d<dim; ++d) {
+                    auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
+                    auto outView =Kokkos::subview( triLinearBasisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+                    triLinearBasis.getValues(outView, inView);
+                    DeviceSpaceType().fence();
+                    for(ordinal_type j=0; j<basisCardinality; ++j)
+                      for(std::size_t k=0; k<tri.getNodeCount(); ++k)
+                        physDofCoords(i,j,d) += vertices[tris[i][k]][d]*triLinearBasisValuesAtDofCoords(i,k,j);
+                  }
+              }
+
+              Fun fun;
+
+              for(ordinal_type i=0; i<numCells; ++i) {
+                for(ordinal_type j=0; j<basisCardinality; ++j)
+                  funAtDofCoords(i,j) += fun(degree, physDofCoords(i,j,0), physDofCoords(i,j,1));
+              }
+
+              li::getBasisCoeffs(basisCoeffsLI, funAtDofCoords, dofCoeffsPhys);
+            }
+
+            //Testing Kronecker property of basis functions
+            {
+              for(ordinal_type i=0; i<numCells; ++i) {
+                DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality);
+                DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
+                DynRankView ConstructWithLabel(transformedBasisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
+                auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
+                auto outView =Kokkos::subview( basisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL());
+                basisPtr->getValues(outView, inView);
+
+                // modify basis values to account for orientations
+                ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
+                    basisValuesAtDofCoords,
+                    elemOrts,
+                    basisPtr);
+
+                // transform basis values
+                fst::HGRADtransformVALUE(transformedBasisValuesAtDofCoordsOriented,
+                    basisValuesAtDofCoordsOriented);
+
+
+                DeviceSpaceType().fence();
+                for(ordinal_type k=0; k<basisCardinality; ++k) {
+                  for(ordinal_type j=0; j<basisCardinality; ++j){
+                    ValueType dofValue = transformedBasisValuesAtDofCoordsOriented(i,k,j) * dofCoeffsPhys(i,j);
+                    if ( k==j && std::abs( dofValue - 1.0 ) > 100*tol ) {
+                      errorFlag++;
+                      *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                      *outStream << " Basis function " << k << " of cell " << i << " does not have unit value at its node (" << dofValue <<")\n";
+                    }
+                    if ( k!=j && std::abs( dofValue ) > tol ) {
+                      errorFlag++;
+                      *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                      *outStream << " Basis function " << k << " of cell " << i << " does not vanish at node " << j << "(" << dofValue <<")\n";
+                    }
+                  }
                 }
-            }
+              }
 
-            Fun fun;
+              //check that fun values are consistent on common edges dofs
+              {
+                bool areDifferent(false);
+                auto numEdgeDOFs = basisPtr->getDofCount(1,0);
 
-            for(ordinal_type i=0; i<numCells; ++i) {
-              for(ordinal_type j=0; j<basisCardinality; ++j)
-                funAtDofCoords(i,j) += fun(degree, physDofCoords(i,j,0), physDofCoords(i,j,1));
-            }
+                for(ordinal_type j=0;j<numEdgeDOFs && !areDifferent;j++) {
+                  areDifferent = std::abs(basisCoeffsLI(0,basisPtr->getDofOrdinal(1,edgeIndex[0],j))
+                      - basisCoeffsLI(1,basisPtr->getDofOrdinal(1,edgeIndex[1],j))) > 10*tol;
+                }
+                if(areDifferent) {
+                  errorFlag++;
+                  *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                  *outStream << "Function DOFs on common edge computed using Tri 0 basis functions are not consistent with those computed using Tri 1\n";
+                  *outStream << "Function DOFs for Tri 0 are:";
+                  for(ordinal_type j=0;j<numEdgeDOFs;j++)
+                    *outStream << " " << basisCoeffsLI(0,basisPtr->getDofOrdinal(1,edgeIndex[0],j));
+                  *outStream << "\nFunction DOFs for Tri 1 are:";
+                  for(ordinal_type j=0;j<numEdgeDOFs;j++)
+                    *outStream << " " << basisCoeffsLI(1,basisPtr->getDofOrdinal(1,edgeIndex[1],j));
+                  *outStream << std::endl;
+                }
+              }
 
-            li::getBasisCoeffs(basisCoeffsLI, funAtDofCoords, dofCoeffsPhys);
-          }
+              //check that fun values at reference points coincide with those computed using basis functions
+              {
+                DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
+                DynRankView ConstructWithLabel(transformedBasisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
+                DynRankView basisValuesAtDofCoordsCells("inValues", numCells, basisCardinality, basisCardinality);
 
-          //Testing Kronecker property of basis functions
-          {
-            for(ordinal_type i=0; i<numCells; ++i) {
-              DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality);
-              DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
-              DynRankView ConstructWithLabel(transformedBasisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
-              auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
-              auto outView =Kokkos::subview( basisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL());
-              basisPtr->getValues(outView, inView);
+                for (ordinal_type ic = 0; ic < numCells; ++ic)
+                  basisPtr->getValues(Kokkos::subview(basisValuesAtDofCoordsCells, ic, Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(dofCoordsOriented, ic, Kokkos::ALL(), Kokkos::ALL()));
 
-              // modify basis values to account for orientations
-              ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
-                  basisValuesAtDofCoords,
-                  elemOrts,
-                  basisPtr.get());
+                // modify basis values to account for orientations
+                ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
+                    basisValuesAtDofCoordsCells,
+                    elemOrts,
+                    basisPtr);
 
-              // transform basis values
-              fst::HGRADtransformVALUE(transformedBasisValuesAtDofCoordsOriented,
-                  basisValuesAtDofCoordsOriented);
+                // transform basis (pullback)
+                fst::HGRADtransformVALUE(transformedBasisValuesAtDofCoordsOriented,
+                    basisValuesAtDofCoordsOriented);
 
-              DeviceSpaceType().fence();
-              for(ordinal_type k=0; k<basisCardinality; ++k) {
-                for(ordinal_type j=0; j<basisCardinality; ++j){
-                  ValueType dofValue = transformedBasisValuesAtDofCoordsOriented(i,k,j) * dofCoeffsPhys(i,j);
-                  if ( k==j && std::abs( dofValue - 1.0 ) > 100*tol ) {
+                DynRankView ConstructWithLabel(funAtDofCoordsOriented, numCells, basisCardinality);
+                for(ordinal_type i=0; i<numCells; ++i) {
+                  ValueType error=0;
+                  for(ordinal_type j=0; j<basisCardinality; ++j) {
+                    for(ordinal_type k=0; k<basisCardinality; ++k)
+                      funAtDofCoordsOriented(i,j) += basisCoeffsLI(i,k)*transformedBasisValuesAtDofCoordsOriented(i,k,j);
+
+                    error = std::max(std::abs( funAtDofCoords(i,j) - funAtDofCoordsOriented(i,j)), error);
+                  }
+
+                  if(error>100*tol) {
                     errorFlag++;
                     *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-                    *outStream << " Basis function " << k << " of cell " << i << " does not have unit value at its node (" << dofValue <<")\n";
-                  }
-                  if ( k!=j && std::abs( dofValue ) > tol ) {
-                    errorFlag++;
-                    *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-                    *outStream << " Basis function " << k << " of cell " << i << " does not vanish at node " << j << "(" << dofValue <<")\n";
+                    *outStream << "Function values at reference points differ from those computed using basis functions of Tri " << i << "\n";
+                    *outStream << "Function values at reference points are:\n";
+                    for(ordinal_type j=0; j<basisCardinality; ++j)
+                      *outStream << " (" << funAtDofCoords(i,j)  << ")";
+                    *outStream << "\nFunction values at reference points computed using basis functions are\n";
+                    for(ordinal_type j=0; j<basisCardinality; ++j)
+                      *outStream << " (" << funAtDofCoordsOriented(i,j)  << ")";
+                    *outStream << std::endl;
                   }
                 }
               }
-            }
-          }
 
-          //check that fun values are consistent on common edges dofs
-          {
-            bool areDifferent(false);
-            auto numEdgeDOFs = basisPtr->getDofCount(1,0);
+              //compute projection-based interpolation of the Lagrangian interpolation
+              DynRankView ConstructWithLabel(basisCoeffsHGrad, numCells, basisCardinality);
+              {
+                ordinal_type targetCubDegree(basisPtr->getDegree()),targetDerivCubDegree(basisPtr->getDegree());
 
-            for(ordinal_type j=0;j<numEdgeDOFs && !areDifferent;j++) {
-              areDifferent = std::abs(basisCoeffsLI(0,basisPtr->getDofOrdinal(1,edgeIndex[0],j))
-                  - basisCoeffsLI(1,basisPtr->getDofOrdinal(1,edgeIndex[1],j))) > 10*tol;
-            }
-            if(areDifferent) {
-              errorFlag++;
-              *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-              *outStream << "Function DOFs on common edge computed using Tri 0 basis functions are not consistent with those computed using Tri 1\n";
-              *outStream << "Function DOFs for Tri 0 are:";
-              for(ordinal_type j=0;j<numEdgeDOFs;j++)
-                *outStream << " " << basisCoeffsLI(0,basisPtr->getDofOrdinal(1,edgeIndex[0],j));
-              *outStream << "\nFunction DOFs for Tri 1 are:";
-              for(ordinal_type j=0;j<numEdgeDOFs;j++)
-                *outStream << " " << basisCoeffsLI(1,basisPtr->getDofOrdinal(1,edgeIndex[1],j));
-              *outStream << std::endl;
-            }
-          }
+                Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
+                projStruct.createHGradProjectionStruct(basisPtr, targetCubDegree, targetDerivCubDegree);
 
-          //check that fun values at reference points coincide with those computed using basis functions
-          {
-            DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
-            DynRankView ConstructWithLabel(transformedBasisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
-            DynRankView basisValuesAtDofCoordsCells("inValues", numCells, basisCardinality, basisCardinality);
+                ordinal_type numPoints = projStruct.getNumTargetEvalPoints(), numGradPoints = projStruct.getNumTargetDerivEvalPoints();
+                DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
+                DynRankView ConstructWithLabel(evaluationGradPoints, numCells, numGradPoints, dim);
 
-            for (ordinal_type ic = 0; ic < numCells; ++ic)
-              basisPtr->getValues(Kokkos::subview(basisValuesAtDofCoordsCells, ic, Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(dofCoordsOriented, ic, Kokkos::ALL(), Kokkos::ALL()));
 
-            // modify basis values to account for orientations
-            ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
-                basisValuesAtDofCoordsCells,
-                elemOrts,
-                basisPtr.get());
+                pts::getHGradEvaluationPoints(evaluationPoints,
+                    evaluationGradPoints,
+                    elemOrts,
+                    basisPtr,
+                    &projStruct);
 
-            // transform basis (pullback)
-            fst::HGRADtransformVALUE(transformedBasisValuesAtDofCoordsOriented,
-                basisValuesAtDofCoordsOriented);
 
-            DynRankView ConstructWithLabel(funAtDofCoordsOriented, numCells, basisCardinality);
-            for(ordinal_type i=0; i<numCells; ++i) {
-              ValueType error=0;
-              for(ordinal_type j=0; j<basisCardinality; ++j) {
-                for(ordinal_type k=0; k<basisCardinality; ++k)
-                  funAtDofCoordsOriented(i,j) += basisCoeffsLI(i,k)*transformedBasisValuesAtDofCoordsOriented(i,k,j);
+                DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints);
+                DynRankView ConstructWithLabel(targetGradAtEvalPoints, numCells, numGradPoints, dim);
 
-                error = std::max(std::abs( funAtDofCoords(i,j) - funAtDofCoordsOriented(i,j)), error);
+                DynRankView ConstructWithLabel(hgradBasisAtEvaluationPoints, numCells, basisCardinality , numPoints);
+                DynRankView ConstructWithLabel(hgradBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints);
+                for(int ic=0; ic<numCells; ic++)
+                  basisPtr->getValues(Kokkos::subview(hgradBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
+                ots::modifyBasisByOrientation(hgradBasisAtEvaluationPoints,
+                    hgradBasisAtEvaluationPointsNonOriented,
+                    elemOrts,
+                    basisPtr);
+
+                DynRankView ConstructWithLabel(gradOfHGradBasisAtEvaluationPoints, numCells, basisCardinality , numGradPoints, dim);
+                if(numGradPoints>0) {
+                  DynRankView ConstructWithLabel(gradOfHGradBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numGradPoints, dim);
+                  for(int ic=0; ic<numCells; ic++)
+                    basisPtr->getValues(Kokkos::subview(gradOfHGradBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationGradPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_GRAD);
+                  ots::modifyBasisByOrientation(gradOfHGradBasisAtEvaluationPoints,
+                      gradOfHGradBasisAtEvaluationPointsNonOriented,
+                      elemOrts,
+                      basisPtr);
+                }
+
+                for(int ic=0; ic<numCells; ic++) {
+                  for(int i=0;i<numPoints;i++) {
+                    for(int k=0;k<basisCardinality;k++)
+                      targetAtEvalPoints(ic,i) += basisCoeffsLI(ic,k)*hgradBasisAtEvaluationPoints(ic,k,i);
+                  }
+                  for(int i=0;i<numGradPoints;i++) {
+                    for(int k=0;k<basisCardinality;k++)
+                      for(int d=0;d<dim;d++)
+                        targetGradAtEvalPoints(ic,i,d) += basisCoeffsLI(ic,k)*gradOfHGradBasisAtEvaluationPoints(ic,k,i,d);
+                  }
+
+                }
+
+                pts::getHGradBasisCoeffs(basisCoeffsHGrad,
+                    targetAtEvalPoints,
+                    targetGradAtEvalPoints,
+                    evaluationPoints,
+                    evaluationGradPoints,
+                    elemOrts,
+                    basisPtr,
+                    &projStruct);
               }
 
-              if(error>100*tol) {
-                errorFlag++;
-                *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-                *outStream << "Function values at reference points differ from those computed using basis functions of Tri " << i << "\n";
-                *outStream << "Function values at reference points are:\n";
-                for(ordinal_type j=0; j<basisCardinality; ++j)
-                  *outStream << " (" << funAtDofCoords(i,j)  << ")";
-                *outStream << "\nFunction values at reference points computed using basis functions are\n";
-                for(ordinal_type j=0; j<basisCardinality; ++j)
-                  *outStream << " (" << funAtDofCoordsOriented(i,j)  << ")";
-                *outStream << std::endl;
-              }
-            }
-          }
+              //check that the basis coefficients of the Lagrangian nterpolation are the same as those of the projection-based interpolation
+              {
+                ValueType diffErr(0);
 
-          //compute projection-based interpolation of the Lagrangian interpolation
-          DynRankView ConstructWithLabel(basisCoeffsHGrad, numCells, basisCardinality);
-          {
-            ordinal_type targetCubDegree(basisPtr->getDegree()),targetDerivCubDegree(basisPtr->getDegree());
+                for(int k=0;k<basisCardinality;k++) {
+                  for(int ic=0; ic<numCells; ic++)
+                    diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsHGrad(ic,k)));
+                }
 
-            Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
-            projStruct.createHGradProjectionStruct(basisPtr.get(), targetCubDegree, targetDerivCubDegree);
-
-            ordinal_type numPoints = projStruct.getNumTargetEvalPoints(), numGradPoints = projStruct.getNumTargetDerivEvalPoints();
-            DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
-            DynRankView ConstructWithLabel(evaluationGradPoints, numCells, numGradPoints, dim);
-
-
-            pts::getHGradEvaluationPoints(evaluationPoints,
-                evaluationGradPoints,
-                elemOrts,
-                basisPtr.get(),
-                &projStruct);
-
-
-            DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints);
-            DynRankView ConstructWithLabel(targetGradAtEvalPoints, numCells, numGradPoints, dim);
-
-            DynRankView ConstructWithLabel(hgradBasisAtEvaluationPoints, numCells, basisCardinality , numPoints);
-            DynRankView ConstructWithLabel(hgradBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints);
-            for(int ic=0; ic<numCells; ic++)
-              basisPtr->getValues(Kokkos::subview(hgradBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
-            ots::modifyBasisByOrientation(hgradBasisAtEvaluationPoints,
-                hgradBasisAtEvaluationPointsNonOriented,
-                elemOrts,
-                basisPtr.get());
-
-            DynRankView ConstructWithLabel(gradOfHGradBasisAtEvaluationPoints, numCells, basisCardinality , numGradPoints, dim);
-            if(numGradPoints>0) {
-              DynRankView ConstructWithLabel(gradOfHGradBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numGradPoints, dim);
-              for(int ic=0; ic<numCells; ic++)
-                basisPtr->getValues(Kokkos::subview(gradOfHGradBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationGradPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_GRAD);
-              ots::modifyBasisByOrientation(gradOfHGradBasisAtEvaluationPoints,
-                  gradOfHGradBasisAtEvaluationPointsNonOriented,
-                  elemOrts,
-                  basisPtr.get());
-            }
-
-            for(int ic=0; ic<numCells; ic++) {
-              for(int i=0;i<numPoints;i++) {
-                for(int k=0;k<basisCardinality;k++)
-                  targetAtEvalPoints(ic,i) += basisCoeffsLI(ic,k)*hgradBasisAtEvaluationPoints(ic,k,i);
-              }
-              for(int i=0;i<numGradPoints;i++) {
-                for(int k=0;k<basisCardinality;k++)
-                  for(int d=0;d<dim;d++)
-                    targetGradAtEvalPoints(ic,i,d) += basisCoeffsLI(ic,k)*gradOfHGradBasisAtEvaluationPoints(ic,k,i,d);
+                if(diffErr > pow(7, degree-1)*tol) { //heuristic relation on how round-off error depends on degree
+                  errorFlag++;
+                  *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                  *outStream << "HGRAD_C" << degree << ": The weights recovered with the optimization are different than the one used for generating the functon."<<
+                      "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
+                }
               }
 
-            }
+              //compute L2 projection of the Lagrangian interpolation
+              DynRankView ConstructWithLabel(basisCoeffsL2, numCells, basisCardinality);
+              {
+                ordinal_type targetCubDegree(basisPtr->getDegree());
 
-            pts::getHGradBasisCoeffs(basisCoeffsHGrad,
-                targetAtEvalPoints,
-                targetGradAtEvalPoints,
-                evaluationPoints,
-                evaluationGradPoints,
-                elemOrts,
-                basisPtr.get(),
-                &projStruct);
-          }
+                Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
+                projStruct.createL2ProjectionStruct(basisPtr, targetCubDegree);
 
-          //check that the basis coefficients of the Lagrangian nterpolation are the same as those of the projection-based interpolation
-          {
-            ValueType diffErr(0);
+                ordinal_type numPoints = projStruct.getNumTargetEvalPoints();
+                DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
 
-            for(int k=0;k<basisCardinality;k++) {
-              for(int ic=0; ic<numCells; ic++)
-                diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsHGrad(ic,k)));
-            }
-
-            if(diffErr > pow(7, degree-1)*tol) { //heuristic relation on how round-off error depends on degree
-              errorFlag++;
-              *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-              *outStream << "HGRAD_C" << degree << ": The weights recovered with the optimization are different than the one used for generating the functon."<<
-                  "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
-            }
-          }
-
-          //compute L2 projection of the Lagrangian interpolation
-          DynRankView ConstructWithLabel(basisCoeffsL2, numCells, basisCardinality);
-          {
-            ordinal_type targetCubDegree(basisPtr->getDegree());
-
-            Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
-            projStruct.createL2ProjectionStruct(basisPtr.get(), targetCubDegree);
-
-            ordinal_type numPoints = projStruct.getNumTargetEvalPoints();
-            DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
-
-            pts::getL2EvaluationPoints(evaluationPoints,
-                elemOrts,
-                basisPtr.get(),
-                &projStruct);
+                pts::getL2EvaluationPoints(evaluationPoints,
+                    elemOrts,
+                    basisPtr,
+                    &projStruct);
 
 
-            DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints);
-            DynRankView ConstructWithLabel(hgradBasisAtEvaluationPoints, numCells, basisCardinality , numPoints);
-            DynRankView ConstructWithLabel(hgradBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints);
-            for(int ic=0; ic<numCells; ic++)
-              basisPtr->getValues(Kokkos::subview(hgradBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
-            ots::modifyBasisByOrientation(hgradBasisAtEvaluationPoints,
-                hgradBasisAtEvaluationPointsNonOriented,
-                elemOrts,
-                basisPtr.get());
+                DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints);
+                DynRankView ConstructWithLabel(hgradBasisAtEvaluationPoints, numCells, basisCardinality , numPoints);
+                DynRankView ConstructWithLabel(hgradBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints);
+                for(int ic=0; ic<numCells; ic++)
+                  basisPtr->getValues(Kokkos::subview(hgradBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
+                ots::modifyBasisByOrientation(hgradBasisAtEvaluationPoints,
+                    hgradBasisAtEvaluationPointsNonOriented,
+                    elemOrts,
+                    basisPtr);
 
 
-            for(int ic=0; ic<numCells; ic++) {
-              for(int i=0;i<numPoints;i++) {
-                for(int k=0;k<basisCardinality;k++)
-                  targetAtEvalPoints(ic,i) += basisCoeffsLI(ic,k)*hgradBasisAtEvaluationPoints(ic,k,i);
+                for(int ic=0; ic<numCells; ic++) {
+                  for(int i=0;i<numPoints;i++) {
+                    for(int k=0;k<basisCardinality;k++)
+                      targetAtEvalPoints(ic,i) += basisCoeffsLI(ic,k)*hgradBasisAtEvaluationPoints(ic,k,i);
+                  }
+                }
+
+                pts::getL2BasisCoeffs(basisCoeffsL2,
+                    targetAtEvalPoints,
+                    evaluationPoints,
+                    elemOrts,
+                    basisPtr,
+                    &projStruct);
+              }
+
+              //check that the basis coefficients of the Lagrangian interpolation are the same as those of the L2 projection
+              {
+                ValueType diffErr =0;
+                for(int k=0;k<basisCardinality;k++) {
+                  for(int ic=0; ic<numCells; ic++)
+                    diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsL2(ic,k)));
+                }
+
+                if(diffErr > pow(7, degree-1)*tol) { //heuristic relation on how round-off error depends on degree
+                  errorFlag++;
+                  *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                  *outStream << "HGRAD_C" << degree << ": The weights recovered with the optimization are different than the one used for generating the functon."<<
+                      "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
+                }
               }
             }
-
-            pts::getL2BasisCoeffs(basisCoeffsL2,
-                targetAtEvalPoints,
-                evaluationPoints,
-                elemOrts,
-                basisPtr.get(),
-                &projStruct);
-          }
-
-          //check that the basis coefficients of the Lagrangian interpolation are the same as those of the L2 projection
-          {
-            ValueType diffErr =0;
-            for(int k=0;k<basisCardinality;k++) {
-              for(int ic=0; ic<numCells; ic++)
-                diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsL2(ic,k)));
-            }
-
-            if(diffErr > pow(7, degree-1)*tol) { //heuristic relation on how round-off error depends on degree
-              errorFlag++;
-              *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-              *outStream << "HGRAD_C" << degree << ": The weights recovered with the optimization are different than the one used for generating the functon."<<
-                  "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
-            }
+            delete basisPtr;
           }
         }
       }
@@ -655,304 +665,311 @@ int InterpolationProjectionTri(const bool verbose) {
 
         for (ordinal_type degree=1; degree <= max_degree; degree++) {
 
-          Teuchos::RCP<Basis<DeviceSpaceType,ValueType,ValueType> > basisPtr;
+          basis_set.clear();
           if(degree==1)
-            basisPtr = Teuchos::rcp(new Basis_HCURL_TRI_I1_FEM<DeviceSpaceType,ValueType,ValueType>());
-          else
-            basisPtr = Teuchos::rcp(new Basis_HCURL_TRI_In_FEM<DeviceSpaceType,ValueType,ValueType>(degree));
+            basis_set.push_back(new Basis_HCURL_TRI_I1_FEM<DeviceSpaceType,ValueType,ValueType>());
+          basis_set.push_back(new typename  CG_NBasis::HCURL_TRI(degree));
+          basis_set.push_back(new typename  CG_DNBasis::HCURL_TRI(degree));
 
-          ordinal_type basisCardinality = basisPtr->getCardinality();
+          for (auto basisPtr:basis_set) {
 
-          //compute DofCoords Oriented
-          DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
-          DynRankView ConstructWithLabel(physDofCoords, numCells, basisCardinality, dim);
-          DynRankView ConstructWithLabel(funAtDofCoords, numCells, basisCardinality, dim);
-          DynRankView ConstructWithLabel(dofCoeffs, numCells, basisCardinality, dim);
-          DynRankView ConstructWithLabel(basisCoeffsLI, numCells, basisCardinality);
+            auto name = basisPtr->getName();
+            *outStream << " " << name << std::endl;
 
-          //compute Lagrangian Interpolation of fun
-          {
-            li::getDofCoordsAndCoeffs(dofCoordsOriented, dofCoeffs, basisPtr.get(),POINTTYPE_EQUISPACED, elemOrts);
+            ordinal_type basisCardinality = basisPtr->getCardinality();
 
-            //Compute physical Dof Coordinates
+            //compute DofCoords Oriented
+            DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
+            DynRankView ConstructWithLabel(physDofCoords, numCells, basisCardinality, dim);
+            DynRankView ConstructWithLabel(funAtDofCoords, numCells, basisCardinality, dim);
+            DynRankView ConstructWithLabel(dofCoeffs, numCells, basisCardinality, dim);
+            DynRankView ConstructWithLabel(basisCoeffsLI, numCells, basisCardinality);
+
+            //compute Lagrangian Interpolation of fun
             {
-              Basis_HGRAD_TRI_C1_FEM<DeviceSpaceType,ValueType,ValueType> triLinearBasis; //used for computing physical coordinates
-              DynRankView ConstructWithLabel(triLinearBasisValuesAtDofCoords, numCells, tri.getNodeCount(), basisCardinality);
-              for(ordinal_type i=0; i<numCells; ++i)
+              li::getDofCoordsAndCoeffs(dofCoordsOriented, dofCoeffs, basisPtr,POINTTYPE_EQUISPACED, elemOrts);
+
+              //Compute physical Dof Coordinates
+              {
+                Basis_HGRAD_TRI_C1_FEM<DeviceSpaceType,ValueType,ValueType> triLinearBasis; //used for computing physical coordinates
+                DynRankView ConstructWithLabel(triLinearBasisValuesAtDofCoords, numCells, tri.getNodeCount(), basisCardinality);
+                for(ordinal_type i=0; i<numCells; ++i)
+                  for(ordinal_type d=0; d<dim; ++d) {
+                    auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
+                    auto outView =Kokkos::subview( triLinearBasisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+                    triLinearBasis.getValues(outView, inView);
+                    DeviceSpaceType().fence();
+                    for(ordinal_type j=0; j<basisCardinality; ++j)
+                      for(std::size_t k=0; k<tri.getNodeCount(); ++k)
+                        physDofCoords(i,j,d) += vertices[tris[i][k]][d]*triLinearBasisValuesAtDofCoords(i,k,j);
+                  }
+              }
+
+              DynRankView ConstructWithLabel(jacobian, numCells, basisCardinality, dim, dim);
+              ct::setJacobian(jacobian, dofCoordsOriented, physVertexes, tri);
+
+              FunCurl fun;
+              DynRankView ConstructWithLabel(fwdFunAtDofCoords, numCells, basisCardinality, dim);
+              for(ordinal_type i=0; i<numCells; ++i) {
+                for(ordinal_type j=0; j<basisCardinality; ++j) {
+                  for(ordinal_type k=0; k<dim; ++k)
+                    funAtDofCoords(i,j,k) = fun(degree, physDofCoords(i,j,0), physDofCoords(i,j,1), k);
+                  for(ordinal_type k=0; k<dim; ++k)
+                    for(ordinal_type d=0; d<dim; ++d)
+                      fwdFunAtDofCoords(i,j,k) += jacobian(i,j,d,k)*funAtDofCoords(i,j,d);
+                }
+              }
+
+              li::getBasisCoeffs(basisCoeffsLI, fwdFunAtDofCoords, dofCoeffs);
+            }
+
+
+            //Testing Kronecker property of basis functions
+            {
+              for(ordinal_type i=0; i<numCells; ++i) {
+                DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality, dim);
+                DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
+                auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
+                auto outView =Kokkos::subview( basisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+                basisPtr->getValues(outView, inView);
+
+                // modify basis values to account for orientations
+                ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
+                    basisValuesAtDofCoords,
+                    elemOrts,
+                    basisPtr);
+
+                for(ordinal_type k=0; k<basisCardinality; ++k) {
+                  for(ordinal_type j=0; j<basisCardinality; ++j){
+                    ValueType dofValue=0;
+                    for(ordinal_type d=0; d<dim; ++d)
+                      dofValue += basisValuesAtDofCoordsOriented(i,k,j,d) * dofCoeffs(i,j,d);
+                    if ( k==j && std::abs( dofValue - 1.0 ) > 100*tol ) {
+                      errorFlag++;
+                      *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                      *outStream << " Basis function " << k << " of cell " << i << " does not have unit value at its node (" << dofValue <<")\n";
+                    }
+                    if ( k!=j && std::abs( dofValue ) > tol ) {
+                      errorFlag++;
+                      *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                      *outStream << " Basis function " << k << " of cell " << i << " does not vanish at node " << j << "(" << dofValue <<")\n";
+                    }
+                  }
+                }
+              }
+            }
+
+            //check that fun values are consistent on common edges dofs
+            {
+              bool areDifferent(false);
+              auto numEdgeDOFs = basisPtr->getDofCount(1,0);
+
+              for(ordinal_type j=0;j<numEdgeDOFs && !areDifferent;j++) {
+                areDifferent = std::abs(basisCoeffsLI(0,basisPtr->getDofOrdinal(1,edgeIndex[0],j))
+                    - basisCoeffsLI(1,basisPtr->getDofOrdinal(1,edgeIndex[1],j))) > 10*tol;
+              }
+              if(areDifferent) {
+                errorFlag++;
+                *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                *outStream << "Function DOFs on the common edge computed using Tri 0 basis functions are not consistent with those computed using Tri 1\n";
+                *outStream << "Function DOFs for Tri 0 are:";
+                for(ordinal_type j=0;j<numEdgeDOFs;j++)
+                  *outStream << " " << basisCoeffsLI(0,basisPtr->getDofOrdinal(1,edgeIndex[0],j));
+                *outStream << "\nFunction DOFs for Tri 1 are:";
+                for(ordinal_type j=0;j<numEdgeDOFs;j++)
+                  *outStream << " " << basisCoeffsLI(1,basisPtr->getDofOrdinal(1,edgeIndex[1],j));
+                *outStream << std::endl;
+              }
+            }
+
+            //check that fun values at reference points coincide with those computed using basis functions
+            DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
+            DynRankView ConstructWithLabel(transformedBasisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
+            DynRankView basisValuesAtDofCoordsCells("inValues", numCells, basisCardinality, basisCardinality, dim);
+
+            for (ordinal_type ic = 0; ic < numCells; ++ic)
+              basisPtr->getValues(Kokkos::subview(basisValuesAtDofCoordsCells, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(dofCoordsOriented, ic, Kokkos::ALL(), Kokkos::ALL()));
+
+            // modify basis values to account for orientations
+            ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
+                basisValuesAtDofCoordsCells,
+                elemOrts,
+                basisPtr);
+
+            // transform basis values
+            DynRankView ConstructWithLabel(jacobianAtDofCoords, numCells, basisCardinality, dim, dim);
+            DynRankView ConstructWithLabel(jacobianAtDofCoords_inv, numCells, basisCardinality, dim, dim);
+            ct::setJacobian(jacobianAtDofCoords, dofCoordsOriented, physVertexes, tri);
+            ct::setJacobianInv (jacobianAtDofCoords_inv, jacobianAtDofCoords);
+            fst::HCURLtransformVALUE(transformedBasisValuesAtDofCoordsOriented,
+                jacobianAtDofCoords_inv,
+                basisValuesAtDofCoordsOriented);
+            DynRankView ConstructWithLabel(funAtDofCoordsOriented, numCells, basisCardinality, dim);
+            for(ordinal_type i=0; i<numCells; ++i) {
+              ValueType error=0;
+              for(ordinal_type j=0; j<basisCardinality; ++j)
                 for(ordinal_type d=0; d<dim; ++d) {
-                  auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
-                  auto outView =Kokkos::subview( triLinearBasisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
-                  triLinearBasis.getValues(outView, inView);
-                  DeviceSpaceType().fence();
-                  for(ordinal_type j=0; j<basisCardinality; ++j)
-                    for(std::size_t k=0; k<tri.getNodeCount(); ++k)
-                      physDofCoords(i,j,d) += vertices[tris[i][k]][d]*triLinearBasisValuesAtDofCoords(i,k,j);
+                  for(ordinal_type k=0; k<basisCardinality; ++k)
+                    funAtDofCoordsOriented(i,j,d) += basisCoeffsLI(i,k)*transformedBasisValuesAtDofCoordsOriented(i,k,j,d);
+
+                  error = std::max(std::abs( funAtDofCoords(i,j,d) - funAtDofCoordsOriented(i,j,d)), error);
                 }
-            }
 
-            DynRankView ConstructWithLabel(jacobian, numCells, basisCardinality, dim, dim);
-            ct::setJacobian(jacobian, dofCoordsOriented, physVertexes, tri);
-
-            FunCurl fun;
-            DynRankView ConstructWithLabel(fwdFunAtDofCoords, numCells, basisCardinality, dim);
-            for(ordinal_type i=0; i<numCells; ++i) {
-              for(ordinal_type j=0; j<basisCardinality; ++j) {
-                for(ordinal_type k=0; k<dim; ++k)
-                  funAtDofCoords(i,j,k) = fun(degree, physDofCoords(i,j,0), physDofCoords(i,j,1), k);
-                for(ordinal_type k=0; k<dim; ++k)
-                  for(ordinal_type d=0; d<dim; ++d)
-                    fwdFunAtDofCoords(i,j,k) += jacobian(i,j,d,k)*funAtDofCoords(i,j,d);
+              if(error>100*tol) {
+                errorFlag++;
+                *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                *outStream << "Function values at reference points differ from those computed using basis functions of Tri " << i << "\n";
+                *outStream << "Function values at reference points are:\n";
+                for(ordinal_type j=0; j<basisCardinality; ++j)
+                  *outStream << " (" << funAtDofCoords(i,j,0) << "," << funAtDofCoords(i,j,1) << ", " << funAtDofCoords(i,j,2) << ")";
+                *outStream << "\nFunction values at reference points computed using basis functions are\n";
+                for(ordinal_type j=0; j<basisCardinality; ++j)
+                  *outStream << " (" << funAtDofCoordsOriented(i,j,0) << "," << funAtDofCoordsOriented(i,j,1) << ", " << funAtDofCoordsOriented(i,j,2) << ")";
+                *outStream << std::endl;
               }
             }
 
-            li::getBasisCoeffs(basisCoeffsLI, fwdFunAtDofCoords, dofCoeffs);
-          }
+            //compute projection-based interpolation of the Lagrangian interpolation
+            DynRankView ConstructWithLabel(basisCoeffsHCurl, numCells, basisCardinality);
+            {
+              ordinal_type targetCubDegree(basisPtr->getDegree()),targetDerivCubDegree(basisPtr->getDegree()-1);
 
+              Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
+              projStruct.createHCurlProjectionStruct(basisPtr, targetCubDegree, targetDerivCubDegree);
 
-          //Testing Kronecker property of basis functions
-          {
-            for(ordinal_type i=0; i<numCells; ++i) {
-              DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality, dim);
-              DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
-              auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
-              auto outView =Kokkos::subview( basisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
-              basisPtr->getValues(outView, inView);
+              ordinal_type numPoints = projStruct.getNumTargetEvalPoints(), numCurlPoints = projStruct.getNumTargetDerivEvalPoints();
+              DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
+              DynRankView ConstructWithLabel(evaluationCurlPoints, numCells, numCurlPoints, dim);
 
-              // modify basis values to account for orientations
-              ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
-                  basisValuesAtDofCoords,
+              pts::getHCurlEvaluationPoints(evaluationPoints,
+                  evaluationCurlPoints,
                   elemOrts,
-                  basisPtr.get());
+                  basisPtr,
+                  &projStruct);
 
-              for(ordinal_type k=0; k<basisCardinality; ++k) {
-                for(ordinal_type j=0; j<basisCardinality; ++j){
-                  ValueType dofValue=0;
-                  for(ordinal_type d=0; d<dim; ++d)
-                    dofValue += basisValuesAtDofCoordsOriented(i,k,j,d) * dofCoeffs(i,j,d);
-                  if ( k==j && std::abs( dofValue - 1.0 ) > 100*tol ) {
-                    errorFlag++;
-                    *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-                    *outStream << " Basis function " << k << " of cell " << i << " does not have unit value at its node (" << dofValue <<")\n";
-                  }
-                  if ( k!=j && std::abs( dofValue ) > tol ) {
-                    errorFlag++;
-                    *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-                    *outStream << " Basis function " << k << " of cell " << i << " does not vanish at node " << j << "(" << dofValue <<")\n";
-                  }
+
+              DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints, dim);
+              DynRankView ConstructWithLabel(targetCurlAtEvalPoints, numCells, numCurlPoints);
+
+              DynRankView ConstructWithLabel(hcurlBasisAtEvaluationPoints, numCells, basisCardinality , numPoints, dim);
+              DynRankView ConstructWithLabel(hcurlBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints, dim);
+              for(int ic=0; ic<numCells; ic++)
+                basisPtr->getValues(Kokkos::subview(hcurlBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
+              ots::modifyBasisByOrientation(hcurlBasisAtEvaluationPoints,
+                  hcurlBasisAtEvaluationPointsNonOriented,
+                  elemOrts,
+                  basisPtr);
+
+              DynRankView ConstructWithLabel(curlOfHCurlBasisAtEvaluationPoints, numCells, basisCardinality , numCurlPoints);
+              if(numCurlPoints>0) {
+                DynRankView ConstructWithLabel(curlOfHCurlBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numCurlPoints);
+                for(int ic=0; ic<numCells; ic++)
+                  basisPtr->getValues(Kokkos::subview(curlOfHCurlBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationCurlPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_CURL);
+                ots::modifyBasisByOrientation(curlOfHCurlBasisAtEvaluationPoints,
+                    curlOfHCurlBasisAtEvaluationPointsNonOriented,
+                    elemOrts,
+                    basisPtr);
+              }
+
+
+              for(int ic=0; ic<numCells; ic++){
+                for(int i=0;i<numPoints;i++) {
+                  for(int k=0;k<basisCardinality;k++)
+                    for(int d=0;d<dim;d++)
+                      targetAtEvalPoints(ic,i,d) += basisCoeffsLI(ic,k)*hcurlBasisAtEvaluationPoints(ic,k,i,d);
+                }
+                for(int i=0;i<numCurlPoints;i++) {
+                  for(int k=0;k<basisCardinality;k++)
+                    targetCurlAtEvalPoints(ic,i) += basisCoeffsLI(ic,k)*curlOfHCurlBasisAtEvaluationPoints(ic,k,i);//funHCurlCoeffs(k)
                 }
               }
-            }
-          }
 
-          //check that fun values are consistent on common edges dofs
-          {
-            bool areDifferent(false);
-            auto numEdgeDOFs = basisPtr->getDofCount(1,0);
-
-            for(ordinal_type j=0;j<numEdgeDOFs && !areDifferent;j++) {
-              areDifferent = std::abs(basisCoeffsLI(0,basisPtr->getDofOrdinal(1,edgeIndex[0],j))
-                  - basisCoeffsLI(1,basisPtr->getDofOrdinal(1,edgeIndex[1],j))) > 10*tol;
-            }
-            if(areDifferent) {
-              errorFlag++;
-              *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-              *outStream << "Function DOFs on the common edge computed using Tri 0 basis functions are not consistent with those computed using Tri 1\n";
-              *outStream << "Function DOFs for Tri 0 are:";
-              for(ordinal_type j=0;j<numEdgeDOFs;j++)
-                *outStream << " " << basisCoeffsLI(0,basisPtr->getDofOrdinal(1,edgeIndex[0],j));
-              *outStream << "\nFunction DOFs for Tri 1 are:";
-              for(ordinal_type j=0;j<numEdgeDOFs;j++)
-                *outStream << " " << basisCoeffsLI(1,basisPtr->getDofOrdinal(1,edgeIndex[1],j));
-              *outStream << std::endl;
-            }
-          }
-
-          //check that fun values at reference points coincide with those computed using basis functions
-          DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
-          DynRankView ConstructWithLabel(transformedBasisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
-          DynRankView basisValuesAtDofCoordsCells("inValues", numCells, basisCardinality, basisCardinality, dim);
-
-          for (ordinal_type ic = 0; ic < numCells; ++ic)
-            basisPtr->getValues(Kokkos::subview(basisValuesAtDofCoordsCells, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(dofCoordsOriented, ic, Kokkos::ALL(), Kokkos::ALL()));
-
-          // modify basis values to account for orientations
-          ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
-              basisValuesAtDofCoordsCells,
-              elemOrts,
-              basisPtr.get());
-
-          // transform basis values
-          DynRankView ConstructWithLabel(jacobianAtDofCoords, numCells, basisCardinality, dim, dim);
-          DynRankView ConstructWithLabel(jacobianAtDofCoords_inv, numCells, basisCardinality, dim, dim);
-          ct::setJacobian(jacobianAtDofCoords, dofCoordsOriented, physVertexes, tri);
-          ct::setJacobianInv (jacobianAtDofCoords_inv, jacobianAtDofCoords);
-          fst::HCURLtransformVALUE(transformedBasisValuesAtDofCoordsOriented,
-              jacobianAtDofCoords_inv,
-              basisValuesAtDofCoordsOriented);
-          DynRankView ConstructWithLabel(funAtDofCoordsOriented, numCells, basisCardinality, dim);
-          for(ordinal_type i=0; i<numCells; ++i) {
-            ValueType error=0;
-            for(ordinal_type j=0; j<basisCardinality; ++j)
-              for(ordinal_type d=0; d<dim; ++d) {
-                for(ordinal_type k=0; k<basisCardinality; ++k)
-                  funAtDofCoordsOriented(i,j,d) += basisCoeffsLI(i,k)*transformedBasisValuesAtDofCoordsOriented(i,k,j,d);
-
-                error = std::max(std::abs( funAtDofCoords(i,j,d) - funAtDofCoordsOriented(i,j,d)), error);
-              }
-
-            if(error>100*tol) {
-              errorFlag++;
-              *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-              *outStream << "Function values at reference points differ from those computed using basis functions of Tri " << i << "\n";
-              *outStream << "Function values at reference points are:\n";
-              for(ordinal_type j=0; j<basisCardinality; ++j)
-                *outStream << " (" << funAtDofCoords(i,j,0) << "," << funAtDofCoords(i,j,1) << ", " << funAtDofCoords(i,j,2) << ")";
-              *outStream << "\nFunction values at reference points computed using basis functions are\n";
-              for(ordinal_type j=0; j<basisCardinality; ++j)
-                *outStream << " (" << funAtDofCoordsOriented(i,j,0) << "," << funAtDofCoordsOriented(i,j,1) << ", " << funAtDofCoordsOriented(i,j,2) << ")";
-              *outStream << std::endl;
-            }
-          }
-
-          //compute projection-based interpolation of the Lagrangian interpolation
-          DynRankView ConstructWithLabel(basisCoeffsHCurl, numCells, basisCardinality);
-          {
-            ordinal_type targetCubDegree(basisPtr->getDegree()),targetDerivCubDegree(basisPtr->getDegree()-1);
-
-            Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
-            projStruct.createHCurlProjectionStruct(basisPtr.get(), targetCubDegree, targetDerivCubDegree);
-
-            ordinal_type numPoints = projStruct.getNumTargetEvalPoints(), numCurlPoints = projStruct.getNumTargetDerivEvalPoints();
-            DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
-            DynRankView ConstructWithLabel(evaluationCurlPoints, numCells, numCurlPoints, dim);
-
-            pts::getHCurlEvaluationPoints(evaluationPoints,
-                evaluationCurlPoints,
-                elemOrts,
-                basisPtr.get(),
-                &projStruct);
-
-
-            DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints, dim);
-            DynRankView ConstructWithLabel(targetCurlAtEvalPoints, numCells, numCurlPoints);
-
-            DynRankView ConstructWithLabel(hcurlBasisAtEvaluationPoints, numCells, basisCardinality , numPoints, dim);
-            DynRankView ConstructWithLabel(hcurlBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints, dim);
-            for(int ic=0; ic<numCells; ic++)
-              basisPtr->getValues(Kokkos::subview(hcurlBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
-            ots::modifyBasisByOrientation(hcurlBasisAtEvaluationPoints,
-                hcurlBasisAtEvaluationPointsNonOriented,
-                elemOrts,
-                basisPtr.get());
-
-            DynRankView ConstructWithLabel(curlOfHCurlBasisAtEvaluationPoints, numCells, basisCardinality , numCurlPoints);
-            if(numCurlPoints>0) {
-              DynRankView ConstructWithLabel(curlOfHCurlBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numCurlPoints);
-              for(int ic=0; ic<numCells; ic++)
-                basisPtr->getValues(Kokkos::subview(curlOfHCurlBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationCurlPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_CURL);
-              ots::modifyBasisByOrientation(curlOfHCurlBasisAtEvaluationPoints,
-                  curlOfHCurlBasisAtEvaluationPointsNonOriented,
+              pts::getHCurlBasisCoeffs(basisCoeffsHCurl,
+                  targetAtEvalPoints,
+                  targetCurlAtEvalPoints,
+                  evaluationPoints,
+                  evaluationCurlPoints,
                   elemOrts,
-                  basisPtr.get());
+                  basisPtr,
+                  &projStruct);
             }
 
-
-            for(int ic=0; ic<numCells; ic++){
-              for(int i=0;i<numPoints;i++) {
-                for(int k=0;k<basisCardinality;k++)
-                  for(int d=0;d<dim;d++)
-                    targetAtEvalPoints(ic,i,d) += basisCoeffsLI(ic,k)*hcurlBasisAtEvaluationPoints(ic,k,i,d);
+            //check that the basis coefficients of the Lagrangian interpolation are the same as those of the projection-based interpolation
+            {
+              ValueType diffErr(0);
+              for(int k=0;k<basisCardinality;k++) {
+                for(int ic=0; ic<numCells; ic++)
+                  diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsHCurl(ic,k)));
               }
-              for(int i=0;i<numCurlPoints;i++) {
-                for(int k=0;k<basisCardinality;k++)
-                  targetCurlAtEvalPoints(ic,i) += basisCoeffsLI(ic,k)*curlOfHCurlBasisAtEvaluationPoints(ic,k,i);//funHCurlCoeffs(k)
+
+              if(diffErr > pow(7, degree-1)*tol) { //heuristic relation on how round-off error depends on degree
+                errorFlag++;
+                *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                *outStream << "HCURL_I" << degree << ": The weights recovered with the optimization are different than the one used for generating the functon."<<
+                    "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
               }
             }
 
-            pts::getHCurlBasisCoeffs(basisCoeffsHCurl,
-                targetAtEvalPoints,
-                targetCurlAtEvalPoints,
-                evaluationPoints,
-                evaluationCurlPoints,
-                elemOrts,
-                basisPtr.get(),
-                &projStruct);
-          }
+            //compute L2 projection of the Lagrangian interpolation
+            DynRankView ConstructWithLabel(basisCoeffsL2, numCells, basisCardinality);
+            {
+              ordinal_type targetCubDegree(basisPtr->getDegree());
 
-          //check that the basis coefficients of the Lagrangian interpolation are the same as those of the projection-based interpolation
-          {
-            ValueType diffErr(0);
-            for(int k=0;k<basisCardinality;k++) {
+              Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
+              projStruct.createL2ProjectionStruct(basisPtr, targetCubDegree);
+
+              ordinal_type numPoints = projStruct.getNumTargetEvalPoints();
+              DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
+
+              pts::getL2EvaluationPoints(evaluationPoints,
+                  elemOrts,
+                  basisPtr,
+                  &projStruct);
+
+
+              DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints, dim);
+
+              DynRankView ConstructWithLabel(hcurlBasisAtEvaluationPoints, numCells, basisCardinality , numPoints, dim);
+              DynRankView ConstructWithLabel(hcurlBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints, dim);
               for(int ic=0; ic<numCells; ic++)
-                diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsHCurl(ic,k)));
+                basisPtr->getValues(Kokkos::subview(hcurlBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
+              ots::modifyBasisByOrientation(hcurlBasisAtEvaluationPoints,
+                  hcurlBasisAtEvaluationPointsNonOriented,
+                  elemOrts,
+                  basisPtr);
+
+              for(int ic=0; ic<numCells; ic++){
+                for(int i=0;i<numPoints;i++) {
+                  for(int k=0;k<basisCardinality;k++)
+                    for(int d=0;d<dim;d++)
+                      targetAtEvalPoints(ic,i,d) += basisCoeffsLI(ic,k)*hcurlBasisAtEvaluationPoints(ic,k,i,d);
+                }
+              }
+
+              pts::getL2BasisCoeffs(basisCoeffsL2,
+                  targetAtEvalPoints,
+                  evaluationPoints,
+                  elemOrts,
+                  basisPtr,
+                  &projStruct);
             }
 
-            if(diffErr > pow(7, degree-1)*tol) { //heuristic relation on how round-off error depends on degree
-              errorFlag++;
-              *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-              *outStream << "HCURL_I" << degree << ": The weights recovered with the optimization are different than the one used for generating the functon."<<
-                  "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
-            }
-          }
+            //check that the basis coefficients of the Lagrangian interpolation are the same as those of the L2 projection
+            {
+              ValueType diffErr = 0;
+              for(int k=0;k<basisCardinality;k++) {
+                for(int ic=0; ic<numCells; ic++)
+                  diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsL2(ic,k)));
+              }
 
-          //compute L2 projection of the Lagrangian interpolation
-          DynRankView ConstructWithLabel(basisCoeffsL2, numCells, basisCardinality);
-          {
-            ordinal_type targetCubDegree(basisPtr->getDegree());
-
-            Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
-            projStruct.createL2ProjectionStruct(basisPtr.get(), targetCubDegree);
-
-            ordinal_type numPoints = projStruct.getNumTargetEvalPoints();
-            DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
-
-            pts::getL2EvaluationPoints(evaluationPoints,
-                elemOrts,
-                basisPtr.get(),
-                &projStruct);
-
-
-            DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints, dim);
-
-            DynRankView ConstructWithLabel(hcurlBasisAtEvaluationPoints, numCells, basisCardinality , numPoints, dim);
-            DynRankView ConstructWithLabel(hcurlBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints, dim);
-            for(int ic=0; ic<numCells; ic++)
-              basisPtr->getValues(Kokkos::subview(hcurlBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
-            ots::modifyBasisByOrientation(hcurlBasisAtEvaluationPoints,
-                hcurlBasisAtEvaluationPointsNonOriented,
-                elemOrts,
-                basisPtr.get());
-
-            for(int ic=0; ic<numCells; ic++){
-              for(int i=0;i<numPoints;i++) {
-                for(int k=0;k<basisCardinality;k++)
-                  for(int d=0;d<dim;d++)
-                    targetAtEvalPoints(ic,i,d) += basisCoeffsLI(ic,k)*hcurlBasisAtEvaluationPoints(ic,k,i,d);
+              if(diffErr > pow(7, degree-1)*tol) { //heuristic relation on how round-off error depends on degree
+                errorFlag++;
+                *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                *outStream << "HCURL_I" << degree << ": The weights recovered with the L2 optimization are different than the one used for generating the functon."<<
+                    "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
               }
             }
-
-            pts::getL2BasisCoeffs(basisCoeffsL2,
-                targetAtEvalPoints,
-                evaluationPoints,
-                elemOrts,
-                basisPtr.get(),
-                &projStruct);
-          }
-
-          //check that the basis coefficients of the Lagrangian interpolation are the same as those of the L2 projection
-          {
-            ValueType diffErr = 0;
-            for(int k=0;k<basisCardinality;k++) {
-              for(int ic=0; ic<numCells; ic++)
-                diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsL2(ic,k)));
-            }
-
-            if(diffErr > pow(7, degree-1)*tol) { //heuristic relation on how round-off error depends on degree
-              errorFlag++;
-              *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-              *outStream << "HCURL_I" << degree << ": The weights recovered with the L2 optimization are different than the one used for generating the functon."<<
-                  "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
-            }
+            delete basisPtr;
           }
         }
       }
@@ -1037,317 +1054,323 @@ int InterpolationProjectionTri(const bool verbose) {
 
         for (ordinal_type degree=1; degree <= max_degree; degree++) {
 
-          Teuchos::RCP<Basis<DeviceSpaceType,ValueType,ValueType> > basisPtr;
+          basis_set.clear();
           if(degree==1)
-            basisPtr = Teuchos::rcp(new Basis_HDIV_TRI_I1_FEM<DeviceSpaceType,ValueType,ValueType>());
-          else
-            basisPtr = Teuchos::rcp(new Basis_HDIV_TRI_In_FEM<DeviceSpaceType,ValueType,ValueType>(degree, POINTTYPE_WARPBLEND));
+            basis_set.push_back(new Basis_HDIV_TRI_I1_FEM<DeviceSpaceType,ValueType,ValueType>());
+          basis_set.push_back(new typename  CG_NBasis::HDIV_TRI(degree));
+          basis_set.push_back(new typename  CG_DNBasis::HDIV_TRI(degree));
 
-          ordinal_type basisCardinality = basisPtr->getCardinality();
+          for (auto basisPtr:basis_set) {
 
-          //compute DofCoords Oriented
+            auto name = basisPtr->getName();
+            *outStream << " " << name << std::endl;
+            ordinal_type basisCardinality = basisPtr->getCardinality();
 
-          DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
-          DynRankView ConstructWithLabel(dofCoeffs, numCells, basisCardinality, dim);
-          DynRankView ConstructWithLabel(physDofCoords, numCells, basisCardinality, dim);
-          DynRankView ConstructWithLabel(funAtDofCoords, numCells, basisCardinality, dim);
-          DynRankView ConstructWithLabel(basisCoeffsLI, numCells, basisCardinality);
+            //compute DofCoords Oriented
 
-          //compute Lagrangian Interpolation of fun
-          {
-            li::getDofCoordsAndCoeffs(dofCoordsOriented,  dofCoeffs, basisPtr.get(), POINTTYPE_WARPBLEND, elemOrts);
+            DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
+            DynRankView ConstructWithLabel(dofCoeffs, numCells, basisCardinality, dim);
+            DynRankView ConstructWithLabel(physDofCoords, numCells, basisCardinality, dim);
+            DynRankView ConstructWithLabel(funAtDofCoords, numCells, basisCardinality, dim);
+            DynRankView ConstructWithLabel(basisCoeffsLI, numCells, basisCardinality);
 
-            //Compute physical Dof Coordinates
-            Basis_HGRAD_TRI_C1_FEM<DeviceSpaceType,ValueType,ValueType> triLinearBasis; //used for computing physical coordinates
-            DynRankView ConstructWithLabel(triLinearBasisValuesAtDofCoords, numCells, tri.getNodeCount(), basisCardinality);
-            for(ordinal_type i=0; i<numCells; ++i)
-              for(ordinal_type d=0; d<dim; ++d) {
-                auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
-                auto outView =Kokkos::subview( triLinearBasisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
-                triLinearBasis.getValues(outView, inView);
-                DeviceSpaceType().fence();
-                for(ordinal_type j=0; j<basisCardinality; ++j)
-                  for(std::size_t k=0; k<tri.getNodeCount(); ++k)
-                    physDofCoords(i,j,d) += vertices[tris[i][k]][d]*triLinearBasisValuesAtDofCoords(i,k,j);
-              }
+            //compute Lagrangian Interpolation of fun
+            {
+              li::getDofCoordsAndCoeffs(dofCoordsOriented,  dofCoeffs, basisPtr, POINTTYPE_EQUISPACED, elemOrts);
 
-            //need to transform dofCoeff to physical space (they transform as normals)
-            DynRankView ConstructWithLabel(jacobian, numCells, basisCardinality, dim, dim);
-            DynRankView ConstructWithLabel(jacobian_inv, numCells, basisCardinality, dim, dim);
-            DynRankView ConstructWithLabel(jacobian_det, numCells, basisCardinality);
-            ct::setJacobian(jacobian, dofCoordsOriented, physVertexes, tri);
-            ct::setJacobianInv (jacobian_inv, jacobian);
-            ct::setJacobianDet (jacobian_det, jacobian);
+              //Compute physical Dof Coordinates
+              Basis_HGRAD_TRI_C1_FEM<DeviceSpaceType,ValueType,ValueType> triLinearBasis; //used for computing physical coordinates
+              DynRankView ConstructWithLabel(triLinearBasisValuesAtDofCoords, numCells, tri.getNodeCount(), basisCardinality);
+              for(ordinal_type i=0; i<numCells; ++i)
+                for(ordinal_type d=0; d<dim; ++d) {
+                  auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
+                  auto outView =Kokkos::subview( triLinearBasisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+                  triLinearBasis.getValues(outView, inView);
+                  DeviceSpaceType().fence();
+                  for(ordinal_type j=0; j<basisCardinality; ++j)
+                    for(std::size_t k=0; k<tri.getNodeCount(); ++k)
+                      physDofCoords(i,j,d) += vertices[tris[i][k]][d]*triLinearBasisValuesAtDofCoords(i,k,j);
+                }
 
-
-            FunDiv fun;
-            DynRankView ConstructWithLabel(fwdFunAtDofCoords, numCells, basisCardinality, dim);
-            for(ordinal_type i=0; i<numCells; ++i) {
-              for(ordinal_type j=0; j<basisCardinality; ++j){
-                for(ordinal_type k=0; k<dim; ++k)
-                  funAtDofCoords(i,j,k) = fun(degree, physDofCoords(i,j,0), physDofCoords(i,j,1), k);
-                for(ordinal_type k=0; k<dim; ++k)
-                  for(ordinal_type d=0; d<dim; ++d)
-                    fwdFunAtDofCoords(i,j,k) += jacobian_det(i,j)*jacobian_inv(i,j,k,d)*funAtDofCoords(i,j,d);
-
-              }
-            }
-            li::getBasisCoeffs(basisCoeffsLI, fwdFunAtDofCoords, dofCoeffs);
-          }
-
-          //Testing Kronecker property of basis functions
-          {
-            for(ordinal_type i=0; i<numCells; ++i) {
-              DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality, dim);
-              DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
-              auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
-              auto outView =Kokkos::subview( basisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
-              basisPtr->getValues(outView, inView);
-
-              // modify basis values to account for orientations
-              ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
-                  basisValuesAtDofCoords,
-                  elemOrts,
-                  basisPtr.get());
-
+              //need to transform dofCoeff to physical space (they transform as normals)
               DynRankView ConstructWithLabel(jacobian, numCells, basisCardinality, dim, dim);
+              DynRankView ConstructWithLabel(jacobian_inv, numCells, basisCardinality, dim, dim);
               DynRankView ConstructWithLabel(jacobian_det, numCells, basisCardinality);
               ct::setJacobian(jacobian, dofCoordsOriented, physVertexes, tri);
+              ct::setJacobianInv (jacobian_inv, jacobian);
               ct::setJacobianDet (jacobian_det, jacobian);
 
-              for(ordinal_type k=0; k<basisCardinality; ++k) {
+
+              FunDiv fun;
+              DynRankView ConstructWithLabel(fwdFunAtDofCoords, numCells, basisCardinality, dim);
+              for(ordinal_type i=0; i<numCells; ++i) {
                 for(ordinal_type j=0; j<basisCardinality; ++j){
-                  ValueType dofValue=0;
-                  for(ordinal_type d=0; d<dim; ++d)
-                    dofValue += basisValuesAtDofCoordsOriented(i,k,j,d) * dofCoeffs(i,j,d);
-                  if ( k==j && std::abs( dofValue - 1.0 ) > 100*tol ) {
-                    errorFlag++;
-                    *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-                    *outStream << " Basis function " << k << " of cell " << i << " does not have unit value at its node (" << dofValue <<")\n";
-                  }
-                  if ( k!=j && std::abs( dofValue ) > tol ) {
-                    errorFlag++;
-                    *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-                    *outStream << " Basis function " << k << " of cell " << i << " does not vanish at node " << j << "(" << dofValue <<")\n";
+                  for(ordinal_type k=0; k<dim; ++k)
+                    funAtDofCoords(i,j,k) = fun(degree, physDofCoords(i,j,0), physDofCoords(i,j,1), k);
+                  for(ordinal_type k=0; k<dim; ++k)
+                    for(ordinal_type d=0; d<dim; ++d)
+                      fwdFunAtDofCoords(i,j,k) += jacobian_det(i,j)*jacobian_inv(i,j,k,d)*funAtDofCoords(i,j,d);
+
+                }
+              }
+              li::getBasisCoeffs(basisCoeffsLI, fwdFunAtDofCoords, dofCoeffs);
+            }
+
+            //Testing Kronecker property of basis functions
+            {
+              for(ordinal_type i=0; i<numCells; ++i) {
+                DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality, dim);
+                DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
+                auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
+                auto outView =Kokkos::subview( basisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+                basisPtr->getValues(outView, inView);
+
+                // modify basis values to account for orientations
+                ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
+                    basisValuesAtDofCoords,
+                    elemOrts,
+                    basisPtr);
+
+                DynRankView ConstructWithLabel(jacobian, numCells, basisCardinality, dim, dim);
+                DynRankView ConstructWithLabel(jacobian_det, numCells, basisCardinality);
+                ct::setJacobian(jacobian, dofCoordsOriented, physVertexes, tri);
+                ct::setJacobianDet (jacobian_det, jacobian);
+
+                for(ordinal_type k=0; k<basisCardinality; ++k) {
+                  for(ordinal_type j=0; j<basisCardinality; ++j){
+                    ValueType dofValue=0;
+                    for(ordinal_type d=0; d<dim; ++d)
+                      dofValue += basisValuesAtDofCoordsOriented(i,k,j,d) * dofCoeffs(i,j,d);
+                    if ( k==j && std::abs( dofValue - 1.0 ) > 100*tol ) {
+                      errorFlag++;
+                      *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                      *outStream << " Basis function " << k << " of cell " << i << " does not have unit value at its node (" << dofValue <<")\n";
+                    }
+                    if ( k!=j && std::abs( dofValue ) > tol ) {
+                      errorFlag++;
+                      *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                      *outStream << " Basis function " << k << " of cell " << i << " does not vanish at node " << j << "(" << dofValue <<")\n";
+                    }
                   }
                 }
               }
             }
-          }
 
-          //check that fun values are consistent on common edge dofs
-          {
-            bool areDifferent(false);
-            auto numEdgeDOFs = basisPtr->getDofCount(dim-1,0);
-            for(ordinal_type j=0;j<numEdgeDOFs && !areDifferent;j++) {
-              areDifferent = std::abs(basisCoeffsLI(0,basisPtr->getDofOrdinal(dim-1,edgeIndex[0],j))
-                  - basisCoeffsLI(1,basisPtr->getDofOrdinal(dim-1,edgeIndex[1],j))) > 10*tol;
-            }
-
-            if(areDifferent) {
-              errorFlag++;
-              *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-              *outStream << "Function DOFs on common edge computed using Tri 0 basis functions are not consistent with those computed using Tri 1\n";
-              *outStream << "Function DOFs for Tri 0 are:";
-              for(ordinal_type j=0;j<numEdgeDOFs;j++)
-                *outStream << " " << basisCoeffsLI(0,basisPtr->getDofOrdinal(dim-1,edgeIndex[0],j)) << " | (" << physDofCoords(0,basisPtr->getDofOrdinal(dim-1,edgeIndex[0],j),0) << "," << physDofCoords(0,basisPtr->getDofOrdinal(dim-1,edgeIndex[0],j),1) << ") ||";
-              *outStream << "\nFunction DOFs for Tri 1 are:";
-              for(ordinal_type j=0;j<numEdgeDOFs;j++)
-                *outStream << " " << basisCoeffsLI(1,basisPtr->getDofOrdinal(dim-1,edgeIndex[1],j))<< " | (" << physDofCoords(1,basisPtr->getDofOrdinal(dim-1,edgeIndex[1],j),0) << "," << physDofCoords(1,basisPtr->getDofOrdinal(dim-1,edgeIndex[1],j),1)  << ") ||";
-              *outStream << std::endl;
-            }
-          }
-
-          //check that fun values at reference points coincide with those computed using basis functions
-          DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
-          DynRankView ConstructWithLabel(transformedBasisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
-          DynRankView basisValuesAtDofCoordsCells("inValues", numCells, basisCardinality, basisCardinality, dim);
-
-          for (ordinal_type ic = 0; ic < numCells; ++ic)
-            basisPtr->getValues(Kokkos::subview(basisValuesAtDofCoordsCells, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(dofCoordsOriented, ic, Kokkos::ALL(), Kokkos::ALL()));
-
-          // modify basis values to account for orientations
-          ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
-              basisValuesAtDofCoordsCells,
-              elemOrts,
-              basisPtr.get());
-
-          // transform basis values
-          DynRankView ConstructWithLabel(jacobianAtDofCoords, numCells, basisCardinality, dim, dim);
-          DynRankView ConstructWithLabel(jacobianAtDofCoords_det, numCells, basisCardinality);
-          ct::setJacobian(jacobianAtDofCoords, dofCoordsOriented, physVertexes, tri);
-          ct::setJacobianDet (jacobianAtDofCoords_det, jacobianAtDofCoords);
-          fst::HDIVtransformVALUE(transformedBasisValuesAtDofCoordsOriented,
-              jacobianAtDofCoords,
-              jacobianAtDofCoords_det,
-              basisValuesAtDofCoordsOriented);
-          DynRankView ConstructWithLabel(funAtDofCoordsOriented, numCells, basisCardinality, dim);
-          for(ordinal_type i=0; i<numCells; ++i) {
-            ValueType error=0;
-            for(ordinal_type j=0; j<basisCardinality; ++j)
-              for(ordinal_type d=0; d<dim; ++d) {
-                for(ordinal_type k=0; k<basisCardinality; ++k)
-                  funAtDofCoordsOriented(i,j,d) += basisCoeffsLI(i,k)*transformedBasisValuesAtDofCoordsOriented(i,k,j,d);
-
-                error = std::max(std::abs( funAtDofCoords(i,j,d) - funAtDofCoordsOriented(i,j,d)), error);
+            //check that fun values are consistent on common edge dofs
+            {
+              bool areDifferent(false);
+              auto numEdgeDOFs = basisPtr->getDofCount(dim-1,0);
+              for(ordinal_type j=0;j<numEdgeDOFs && !areDifferent;j++) {
+                areDifferent = std::abs(basisCoeffsLI(0,basisPtr->getDofOrdinal(dim-1,edgeIndex[0],j))
+                    - basisCoeffsLI(1,basisPtr->getDofOrdinal(dim-1,edgeIndex[1],j))) > 10*tol;
               }
 
-            if(error>100*tol) {
-              errorFlag++;
-              *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-              *outStream << "Function values at reference points differ from those computed using basis functions of Tri " << i << "\n";
-              *outStream << "Function values at reference points are:\n";
-              for(ordinal_type j=0; j<basisCardinality; ++j)
-                *outStream << " (" << funAtDofCoords(i,j,0) << "," << funAtDofCoords(i,j,1) << ", " << funAtDofCoords(i,j,2) << ")";
-              *outStream << "\nFunction values at reference points computed using basis functions are\n";
-              for(ordinal_type j=0; j<basisCardinality; ++j)
-                *outStream << " (" << funAtDofCoordsOriented(i,j,0) << "," << funAtDofCoordsOriented(i,j,1) << ", " << funAtDofCoordsOriented(i,j,2) << ")";
-              *outStream << std::endl;
+              if(areDifferent) {
+                errorFlag++;
+                *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                *outStream << "Function DOFs on common edge computed using Tri 0 basis functions are not consistent with those computed using Tri 1\n";
+                *outStream << "Function DOFs for Tri 0 are:";
+                for(ordinal_type j=0;j<numEdgeDOFs;j++)
+                  *outStream << " " << basisCoeffsLI(0,basisPtr->getDofOrdinal(dim-1,edgeIndex[0],j)) << " | (" << physDofCoords(0,basisPtr->getDofOrdinal(dim-1,edgeIndex[0],j),0) << "," << physDofCoords(0,basisPtr->getDofOrdinal(dim-1,edgeIndex[0],j),1) << ") ||";
+                *outStream << "\nFunction DOFs for Tri 1 are:";
+                for(ordinal_type j=0;j<numEdgeDOFs;j++)
+                  *outStream << " " << basisCoeffsLI(1,basisPtr->getDofOrdinal(dim-1,edgeIndex[1],j))<< " | (" << physDofCoords(1,basisPtr->getDofOrdinal(dim-1,edgeIndex[1],j),0) << "," << physDofCoords(1,basisPtr->getDofOrdinal(dim-1,edgeIndex[1],j),1)  << ") ||";
+                *outStream << std::endl;
+              }
             }
-          }
 
-          //compute projection-based interpolation of the Lagrangian interpolation
-          DynRankView ConstructWithLabel(basisCoeffsHDiv, numCells, basisCardinality);
-          {
-            ordinal_type targetCubDegree(basisPtr->getDegree()),targetDerivCubDegree(basisPtr->getDegree()-1);
+            //check that fun values at reference points coincide with those computed using basis functions
+            DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
+            DynRankView ConstructWithLabel(transformedBasisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality, dim);
+            DynRankView basisValuesAtDofCoordsCells("inValues", numCells, basisCardinality, basisCardinality, dim);
 
-            Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
-            projStruct.createHDivProjectionStruct(basisPtr.get(), targetCubDegree, targetDerivCubDegree);
+            for (ordinal_type ic = 0; ic < numCells; ++ic)
+              basisPtr->getValues(Kokkos::subview(basisValuesAtDofCoordsCells, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(dofCoordsOriented, ic, Kokkos::ALL(), Kokkos::ALL()));
 
-            ordinal_type numPoints = projStruct.getNumTargetEvalPoints(), numDivPoints = projStruct.getNumTargetDerivEvalPoints();
-
-            DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
-            DynRankView ConstructWithLabel(evaluationDivPoints, numCells, numDivPoints, dim);
-
-            pts::getHDivEvaluationPoints(evaluationPoints,
-                evaluationDivPoints,
+            // modify basis values to account for orientations
+            ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
+                basisValuesAtDofCoordsCells,
                 elemOrts,
-                basisPtr.get(),
-                &projStruct);
+                basisPtr);
 
-            DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints, dim);
-            DynRankView ConstructWithLabel(targetDivAtEvalPoints, numCells, numDivPoints);
+            // transform basis values
+            DynRankView ConstructWithLabel(jacobianAtDofCoords, numCells, basisCardinality, dim, dim);
+            DynRankView ConstructWithLabel(jacobianAtDofCoords_det, numCells, basisCardinality);
+            ct::setJacobian(jacobianAtDofCoords, dofCoordsOriented, physVertexes, tri);
+            ct::setJacobianDet (jacobianAtDofCoords_det, jacobianAtDofCoords);
+            fst::HDIVtransformVALUE(transformedBasisValuesAtDofCoordsOriented,
+                jacobianAtDofCoords,
+                jacobianAtDofCoords_det,
+                basisValuesAtDofCoordsOriented);
+            DynRankView ConstructWithLabel(funAtDofCoordsOriented, numCells, basisCardinality, dim);
+            for(ordinal_type i=0; i<numCells; ++i) {
+              ValueType error=0;
+              for(ordinal_type j=0; j<basisCardinality; ++j)
+                for(ordinal_type d=0; d<dim; ++d) {
+                  for(ordinal_type k=0; k<basisCardinality; ++k)
+                    funAtDofCoordsOriented(i,j,d) += basisCoeffsLI(i,k)*transformedBasisValuesAtDofCoordsOriented(i,k,j,d);
 
-            DynRankView ConstructWithLabel(hdivBasisAtEvaluationPoints, numCells, basisCardinality , numPoints, dim);
-            DynRankView ConstructWithLabel(hdivBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints, dim);
-            for(ordinal_type ic=0; ic<numCells; ++ic)
-              basisPtr->getValues(Kokkos::subview(hdivBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
-            ots::modifyBasisByOrientation(hdivBasisAtEvaluationPoints,
-                hdivBasisAtEvaluationPointsNonOriented,
-                elemOrts,
-                basisPtr.get());
+                  error = std::max(std::abs( funAtDofCoords(i,j,d) - funAtDofCoordsOriented(i,j,d)), error);
+                }
 
-            DynRankView ConstructWithLabel(divOfHDivBasisAtEvaluationPoints, numCells, basisCardinality , numDivPoints);
-            if(numDivPoints>0) {
-              DynRankView ConstructWithLabel(divOfHDivBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numDivPoints);
-              for(ordinal_type ic=0; ic<numCells; ++ic)
-                basisPtr->getValues(Kokkos::subview(divOfHDivBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationDivPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_DIV);
-              ots::modifyBasisByOrientation(divOfHDivBasisAtEvaluationPoints,
-                  divOfHDivBasisAtEvaluationPointsNonOriented,
+              if(error>100*tol) {
+                errorFlag++;
+                *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                *outStream << "Function values at reference points differ from those computed using basis functions of Tri " << i << "\n";
+                *outStream << "Function values at reference points are:\n";
+                for(ordinal_type j=0; j<basisCardinality; ++j)
+                  *outStream << " (" << funAtDofCoords(i,j,0) << "," << funAtDofCoords(i,j,1) << ", " << funAtDofCoords(i,j,2) << ")";
+                *outStream << "\nFunction values at reference points computed using basis functions are\n";
+                for(ordinal_type j=0; j<basisCardinality; ++j)
+                  *outStream << " (" << funAtDofCoordsOriented(i,j,0) << "," << funAtDofCoordsOriented(i,j,1) << ", " << funAtDofCoordsOriented(i,j,2) << ")";
+                *outStream << std::endl;
+              }
+            }
+
+            //compute projection-based interpolation of the Lagrangian interpolation
+            DynRankView ConstructWithLabel(basisCoeffsHDiv, numCells, basisCardinality);
+            {
+              ordinal_type targetCubDegree(basisPtr->getDegree()),targetDerivCubDegree(basisPtr->getDegree()-1);
+
+              Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
+              projStruct.createHDivProjectionStruct(basisPtr, targetCubDegree, targetDerivCubDegree);
+
+              ordinal_type numPoints = projStruct.getNumTargetEvalPoints(), numDivPoints = projStruct.getNumTargetDerivEvalPoints();
+
+              DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
+              DynRankView ConstructWithLabel(evaluationDivPoints, numCells, numDivPoints, dim);
+
+              pts::getHDivEvaluationPoints(evaluationPoints,
+                  evaluationDivPoints,
                   elemOrts,
-                  basisPtr.get());
-            }
+                  basisPtr,
+                  &projStruct);
 
+              DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints, dim);
+              DynRankView ConstructWithLabel(targetDivAtEvalPoints, numCells, numDivPoints);
 
-
-            for(ordinal_type ic=0; ic<numCells; ++ic) {
-              for(int i=0;i<numPoints;i++) {
-                for(int k=0;k<basisCardinality;k++)
-                  for(int d=0;d<dim;d++)
-                    targetAtEvalPoints(ic,i,d) += basisCoeffsLI(ic,k)*hdivBasisAtEvaluationPoints(ic,k,i,d);
-              }
-              for(int i=0;i<numDivPoints;i++) {
-                for(int k=0;k<basisCardinality;k++)
-                  targetDivAtEvalPoints(ic,i) += basisCoeffsLI(ic,k)*divOfHDivBasisAtEvaluationPoints(ic,k,i);//basisCoeffsLI(k)
-              }
-            }
-
-            pts::getHDivBasisCoeffs(basisCoeffsHDiv,
-                targetAtEvalPoints,
-                targetDivAtEvalPoints,
-                evaluationPoints,
-                evaluationDivPoints,
-                elemOrts,
-                basisPtr.get(),
-                &projStruct);
-          }
-
-          //check that the basis coefficients of the Lagrangian interpolation are the same as those of the projection-based interpolation
-          {
-            ValueType diffErr(0);
-            for(int k=0;k<basisCardinality;k++) {
-              //std::cout << "["<< basisCoeffsLI(0,k) << " " <<  basisCoeffsHDiv(0,k) << "] [" << basisCoeffsLI(1,k) << " " <<  basisCoeffsHDiv(1,k) << "]" <<std::endl;
+              DynRankView ConstructWithLabel(hdivBasisAtEvaluationPoints, numCells, basisCardinality , numPoints, dim);
+              DynRankView ConstructWithLabel(hdivBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints, dim);
               for(ordinal_type ic=0; ic<numCells; ++ic)
-                diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsHDiv(ic,k)));
+                basisPtr->getValues(Kokkos::subview(hdivBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
+              ots::modifyBasisByOrientation(hdivBasisAtEvaluationPoints,
+                  hdivBasisAtEvaluationPointsNonOriented,
+                  elemOrts,
+                  basisPtr);
+
+              DynRankView ConstructWithLabel(divOfHDivBasisAtEvaluationPoints, numCells, basisCardinality , numDivPoints);
+              if(numDivPoints>0) {
+                DynRankView ConstructWithLabel(divOfHDivBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numDivPoints);
+                for(ordinal_type ic=0; ic<numCells; ++ic)
+                  basisPtr->getValues(Kokkos::subview(divOfHDivBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationDivPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_DIV);
+                ots::modifyBasisByOrientation(divOfHDivBasisAtEvaluationPoints,
+                    divOfHDivBasisAtEvaluationPointsNonOriented,
+                    elemOrts,
+                    basisPtr);
+              }
+
+
+
+              for(ordinal_type ic=0; ic<numCells; ++ic) {
+                for(int i=0;i<numPoints;i++) {
+                  for(int k=0;k<basisCardinality;k++)
+                    for(int d=0;d<dim;d++)
+                      targetAtEvalPoints(ic,i,d) += basisCoeffsLI(ic,k)*hdivBasisAtEvaluationPoints(ic,k,i,d);
+                }
+                for(int i=0;i<numDivPoints;i++) {
+                  for(int k=0;k<basisCardinality;k++)
+                    targetDivAtEvalPoints(ic,i) += basisCoeffsLI(ic,k)*divOfHDivBasisAtEvaluationPoints(ic,k,i);//basisCoeffsLI(k)
+                }
+              }
+
+              pts::getHDivBasisCoeffs(basisCoeffsHDiv,
+                  targetAtEvalPoints,
+                  targetDivAtEvalPoints,
+                  evaluationPoints,
+                  evaluationDivPoints,
+                  elemOrts,
+                  basisPtr,
+                  &projStruct);
             }
 
-            if(diffErr > pow(7, degree-1)*tol) { //heuristic relation on how round-off error depends on degree
-              errorFlag++;
-              *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-              *outStream << "HDIV_I" << degree << ": The weights recovered with the optimization are different than the one used for generating the functon."<<
-                  "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
-            }
-          }
+            //check that the basis coefficients of the Lagrangian interpolation are the same as those of the projection-based interpolation
+            {
+              ValueType diffErr(0);
+              for(int k=0;k<basisCardinality;k++) {
+                //std::cout << "["<< basisCoeffsLI(0,k) << " " <<  basisCoeffsHDiv(0,k) << "] [" << basisCoeffsLI(1,k) << " " <<  basisCoeffsHDiv(1,k) << "]" <<std::endl;
+                for(ordinal_type ic=0; ic<numCells; ++ic)
+                  diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsHDiv(ic,k)));
+              }
 
-          //compute L2 projection interpolation of the Lagrangian interpolation
-          DynRankView ConstructWithLabel(basisCoeffsL2, numCells, basisCardinality);
-          {
-            ordinal_type targetCubDegree(basisPtr->getDegree());
-
-            Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
-            projStruct.createL2ProjectionStruct(basisPtr.get(), targetCubDegree);
-
-            ordinal_type numPoints = projStruct.getNumTargetEvalPoints();
-
-            DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
-
-            pts::getL2EvaluationPoints(evaluationPoints,
-                elemOrts,
-                basisPtr.get(),
-                &projStruct);
-
-            DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints, dim);
-
-            DynRankView ConstructWithLabel(hdivBasisAtEvaluationPoints, numCells, basisCardinality , numPoints, dim);
-            DynRankView ConstructWithLabel(hdivBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints, dim);
-            for(ordinal_type ic=0; ic<numCells; ++ic)
-              basisPtr->getValues(Kokkos::subview(hdivBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
-            ots::modifyBasisByOrientation(hdivBasisAtEvaluationPoints,
-                hdivBasisAtEvaluationPointsNonOriented,
-                elemOrts,
-                basisPtr.get());
-
-            for(ordinal_type ic=0; ic<numCells; ++ic) {
-              for(int i=0;i<numPoints;i++) {
-                for(int k=0;k<basisCardinality;k++)
-                  for(int d=0;d<dim;d++)
-                    targetAtEvalPoints(ic,i,d) += basisCoeffsLI(ic,k)*hdivBasisAtEvaluationPoints(ic,k,i,d);
+              if(diffErr > pow(7, degree-1)*tol) { //heuristic relation on how round-off error depends on degree
+                errorFlag++;
+                *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                *outStream << "HDIV_I" << degree << ": The weights recovered with the optimization are different than the one used for generating the functon."<<
+                    "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
               }
             }
 
-            pts::getL2BasisCoeffs(basisCoeffsL2,
-                targetAtEvalPoints,
-                evaluationPoints,
-                elemOrts,
-                basisPtr.get(),
-                &projStruct);
-          }
+            //compute L2 projection interpolation of the Lagrangian interpolation
+            DynRankView ConstructWithLabel(basisCoeffsL2, numCells, basisCardinality);
+            {
+              ordinal_type targetCubDegree(basisPtr->getDegree());
 
-          //check that the basis coefficients of the Lagrangian interpolation are the same as those of the L2 projection
-          {
-            ValueType diffErr = 0;
-            for(int k=0;k<basisCardinality;k++) {
-              //std::cout << "["<< basisCoeffsLI(0,k) << " " <<  basisCoeffsHDiv(0,k) << "] [" << basisCoeffsLI(1,k) << " " <<  basisCoeffsHDiv(1,k) << "]" <<std::endl;
+              Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
+              projStruct.createL2ProjectionStruct(basisPtr, targetCubDegree);
+
+              ordinal_type numPoints = projStruct.getNumTargetEvalPoints();
+
+              DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
+
+              pts::getL2EvaluationPoints(evaluationPoints,
+                  elemOrts,
+                  basisPtr,
+                  &projStruct);
+
+              DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints, dim);
+
+              DynRankView ConstructWithLabel(hdivBasisAtEvaluationPoints, numCells, basisCardinality , numPoints, dim);
+              DynRankView ConstructWithLabel(hdivBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints, dim);
               for(ordinal_type ic=0; ic<numCells; ++ic)
-                diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsL2(ic,k)));
+                basisPtr->getValues(Kokkos::subview(hdivBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
+              ots::modifyBasisByOrientation(hdivBasisAtEvaluationPoints,
+                  hdivBasisAtEvaluationPointsNonOriented,
+                  elemOrts,
+                  basisPtr);
+
+              for(ordinal_type ic=0; ic<numCells; ++ic) {
+                for(int i=0;i<numPoints;i++) {
+                  for(int k=0;k<basisCardinality;k++)
+                    for(int d=0;d<dim;d++)
+                      targetAtEvalPoints(ic,i,d) += basisCoeffsLI(ic,k)*hdivBasisAtEvaluationPoints(ic,k,i,d);
+                }
+              }
+
+              pts::getL2BasisCoeffs(basisCoeffsL2,
+                  targetAtEvalPoints,
+                  evaluationPoints,
+                  elemOrts,
+                  basisPtr,
+                  &projStruct);
             }
 
-            if(diffErr > pow(7, degree-1)*tol) { //heuristic relation on how round-off error depends on degree
-              errorFlag++;
-              *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-              *outStream << "HDIV_I" << degree << ": The weights recovered with the L2 optimization are different than the one used for generating the function."<<
-                  "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
+            //check that the basis coefficients of the Lagrangian interpolation are the same as those of the L2 projection
+            {
+              ValueType diffErr = 0;
+              for(int k=0;k<basisCardinality;k++) {
+                //std::cout << "["<< basisCoeffsLI(0,k) << " " <<  basisCoeffsHDiv(0,k) << "] [" << basisCoeffsLI(1,k) << " " <<  basisCoeffsHDiv(1,k) << "]" <<std::endl;
+                for(ordinal_type ic=0; ic<numCells; ++ic)
+                  diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsL2(ic,k)));
+              }
+
+              if(diffErr > pow(7, degree-1)*tol) { //heuristic relation on how round-off error depends on degree
+                errorFlag++;
+                *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                *outStream << "HDIV_I" << degree << ": The weights recovered with the L2 optimization are different than the one used for generating the function."<<
+                    "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
+              }
             }
+            delete basisPtr;
           }
         }
       }
@@ -1407,256 +1430,264 @@ int InterpolationProjectionTri(const bool verbose) {
 
     for (ordinal_type degree=1; degree <= max_degree; degree++) {
 
-      Teuchos::RCP<Basis<DeviceSpaceType,ValueType,ValueType> > basisPtr;
+      basis_set.clear();
       if(degree==1)
-        basisPtr = Teuchos::rcp(new Basis_HVOL_C0_FEM<DeviceSpaceType,ValueType,ValueType>(tri));
-      else
-        basisPtr = Teuchos::rcp(new Basis_HVOL_TRI_Cn_FEM<DeviceSpaceType,ValueType,ValueType>(degree));
-      ordinal_type basisCardinality = basisPtr->getCardinality();
+        basis_set.push_back(new Basis_HVOL_C0_FEM<DeviceSpaceType,ValueType,ValueType>(tri));
+      basis_set.push_back(new typename  CG_NBasis::HVOL_TRI(degree));
+      basis_set.push_back(new typename  CG_DNBasis::HVOL_TRI(degree));
 
-      //compute DofCoords Oriented
-      DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
-      DynRankView ConstructWithLabel(dofCoeffsPhys, numCells, basisCardinality);
-      DynRankView ConstructWithLabel(physDofCoords, numCells, basisCardinality, dim);
-      DynRankView ConstructWithLabel(funAtDofCoords, numCells, basisCardinality);
-      DynRankView ConstructWithLabel(basisCoeffsLI, numCells, basisCardinality);
+      for (auto basisPtr:basis_set) {
 
-      //compute Lagrangian Interpolation of fun
-      {
-        li::getDofCoordsAndCoeffs(dofCoordsOriented,  dofCoeffsPhys, basisPtr.get(), POINTTYPE_EQUISPACED, elemOrts);
+        auto name = basisPtr->getName();
+        *outStream << " " << name << std::endl;
 
-        //Compute physical Dof Coordinates
+        ordinal_type basisCardinality = basisPtr->getCardinality();
+
+        //compute DofCoords Oriented
+        DynRankView ConstructWithLabel(dofCoordsOriented, numCells, basisCardinality, dim);
+        DynRankView ConstructWithLabel(dofCoeffsPhys, numCells, basisCardinality);
+        DynRankView ConstructWithLabel(physDofCoords, numCells, basisCardinality, dim);
+        DynRankView ConstructWithLabel(funAtDofCoords, numCells, basisCardinality);
+        DynRankView ConstructWithLabel(basisCoeffsLI, numCells, basisCardinality);
+
+        //compute Lagrangian Interpolation of fun
         {
-          Basis_HGRAD_TRI_C1_FEM<DeviceSpaceType,ValueType,ValueType> triLinearBasis; //used for computing physical coordinates
-          DynRankView ConstructWithLabel(triLinearBasisValuesAtDofCoords, numCells, tri.getNodeCount(), basisCardinality);
+          li::getDofCoordsAndCoeffs(dofCoordsOriented,  dofCoeffsPhys, basisPtr, POINTTYPE_EQUISPACED, elemOrts);
+
+          //Compute physical Dof Coordinates
+          {
+            Basis_HGRAD_TRI_C1_FEM<DeviceSpaceType,ValueType,ValueType> triLinearBasis; //used for computing physical coordinates
+            DynRankView ConstructWithLabel(triLinearBasisValuesAtDofCoords, numCells, tri.getNodeCount(), basisCardinality);
+            for(ordinal_type i=0; i<numCells; ++i)
+              for(ordinal_type d=0; d<dim; ++d) {
+                auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
+                auto outView =Kokkos::subview( triLinearBasisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
+                triLinearBasis.getValues(outView, inView);
+                DeviceSpaceType().fence();
+                for(ordinal_type j=0; j<basisCardinality; ++j)
+                  for(std::size_t k=0; k<tri.getNodeCount(); ++k)
+                    physDofCoords(i,j,d) += vertices[tris[i][k]][d]*triLinearBasisValuesAtDofCoords(i,k,j);
+              }
+          }
+
+          //need to transform dofCoeff to physical space (they transform as normals)
+          DynRankView ConstructWithLabel(jacobian, numCells, basisCardinality, dim, dim);
+          DynRankView ConstructWithLabel(jacobian_det, numCells, basisCardinality);
+          ct::setJacobian(jacobian, dofCoordsOriented, physVertexes, tri);
+          ct::setJacobianDet (jacobian_det, jacobian);
+
+          Fun fun;
+
+          DynRankView ConstructWithLabel(fwdFunAtDofCoords, numCells, basisCardinality);
           for(ordinal_type i=0; i<numCells; ++i)
-            for(ordinal_type d=0; d<dim; ++d) {
-              auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
-              auto outView =Kokkos::subview( triLinearBasisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL(),Kokkos::ALL());
-              triLinearBasis.getValues(outView, inView);
-              DeviceSpaceType().fence();
-              for(ordinal_type j=0; j<basisCardinality; ++j)
-                for(std::size_t k=0; k<tri.getNodeCount(); ++k)
-                  physDofCoords(i,j,d) += vertices[tris[i][k]][d]*triLinearBasisValuesAtDofCoords(i,k,j);
+            for(ordinal_type j=0; j<basisCardinality; ++j) {
+              funAtDofCoords(i,j) = fun(degree, physDofCoords(i,j,0), physDofCoords(i,j,1));
+              fwdFunAtDofCoords(i,j) = jacobian_det(i,j)*funAtDofCoords(i,j);
             }
+
+          li::getBasisCoeffs(basisCoeffsLI, fwdFunAtDofCoords, dofCoeffsPhys);
         }
 
-        //need to transform dofCoeff to physical space (they transform as normals)
+        //Testing Kronecker property of basis functions
+        {
+          for(ordinal_type i=0; i<numCells; ++i) {
+            DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality);
+            DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
+            auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
+            auto outView =Kokkos::subview( basisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL());
+            basisPtr->getValues(outView, inView);
+
+            // modify basis values to account for orientations
+            ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
+                basisValuesAtDofCoords,
+                elemOrts,
+                basisPtr);
+
+            for(ordinal_type k=0; k<basisCardinality; ++k) {
+              for(ordinal_type j=0; j<basisCardinality; ++j){
+                ValueType dofValue = basisValuesAtDofCoordsOriented(i,k,j) * dofCoeffsPhys(i,j);
+                if ( k==j && std::abs( dofValue - 1.0 ) > 100*tol ) {
+                  errorFlag++;
+                  *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                  *outStream << " Basis function " << k << " of cell " << i << " does not have unit value at its node (" << dofValue <<")\n";
+                }
+                if ( k!=j && std::abs( dofValue ) > tol ) {
+                  errorFlag++;
+                  *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+                  *outStream << " Basis function " << k << " of cell " << i << " does not vanish at node " << j << "(" << dofValue <<")\n";
+                }
+              }
+            }
+          }
+        }
+
+        //check that fun values at reference points coincide with those computed using basis functions
+        DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
+        DynRankView ConstructWithLabel(transformedBasisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
+        DynRankView basisValuesAtDofCoordsCells("inValues", numCells, basisCardinality, basisCardinality);
+
+        for (ordinal_type ic = 0; ic < numCells; ++ic)
+          basisPtr->getValues(Kokkos::subview(basisValuesAtDofCoordsCells, ic, Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(dofCoordsOriented, ic, Kokkos::ALL(), Kokkos::ALL()));
+
+        // modify basis values to account for orientations
+        ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
+            basisValuesAtDofCoordsCells,
+            elemOrts,
+            basisPtr);
+
+        // transform basis values
         DynRankView ConstructWithLabel(jacobian, numCells, basisCardinality, dim, dim);
         DynRankView ConstructWithLabel(jacobian_det, numCells, basisCardinality);
         ct::setJacobian(jacobian, dofCoordsOriented, physVertexes, tri);
         ct::setJacobianDet (jacobian_det, jacobian);
+        fst::HVOLtransformVALUE(transformedBasisValuesAtDofCoordsOriented,
+            jacobian_det,
+            basisValuesAtDofCoordsOriented);
 
-        Fun fun;
-
-        DynRankView ConstructWithLabel(fwdFunAtDofCoords, numCells, basisCardinality);
-        for(ordinal_type i=0; i<numCells; ++i)
+        DynRankView ConstructWithLabel(funAtDofCoordsOriented, numCells, basisCardinality);
+        for(ordinal_type i=0; i<numCells; ++i) {
+          ValueType error=0;
           for(ordinal_type j=0; j<basisCardinality; ++j) {
-            funAtDofCoords(i,j) = fun(degree, physDofCoords(i,j,0), physDofCoords(i,j,1));
-            fwdFunAtDofCoords(i,j) = jacobian_det(i,j)*funAtDofCoords(i,j);
+            for(ordinal_type k=0; k<basisCardinality; ++k)
+              funAtDofCoordsOriented(i,j) += basisCoeffsLI(i,k)*transformedBasisValuesAtDofCoordsOriented(i,k,j);
+
+            error = std::max(std::abs( funAtDofCoords(i,j) - funAtDofCoordsOriented(i,j)), error);
           }
 
-        li::getBasisCoeffs(basisCoeffsLI, fwdFunAtDofCoords, dofCoeffsPhys);
-      }
+          if(error>100*tol) {
+            errorFlag++;
+            *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+            *outStream << "Function values at reference points differ from those computed using basis functions of Tri " << i << "\n";
+            *outStream << "Function values at reference points are:\n";
+            for(ordinal_type j=0; j<basisCardinality; ++j)
+              *outStream << " (" << funAtDofCoords(i,j)  << ")";
+            *outStream << "\nFunction values at reference points computed using basis functions are\n";
+            for(ordinal_type j=0; j<basisCardinality; ++j)
+              *outStream << " (" << funAtDofCoordsOriented(i,j)  << ")";
+            *outStream << std::endl;
+          }
+        }
 
-      //Testing Kronecker property of basis functions
-      {
-        for(ordinal_type i=0; i<numCells; ++i) {
-          DynRankView ConstructWithLabel(basisValuesAtDofCoords, numCells, basisCardinality, basisCardinality);
-          DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
-          auto inView = Kokkos::subview( dofCoordsOriented,i,Kokkos::ALL(),Kokkos::ALL());
-          auto outView =Kokkos::subview( basisValuesAtDofCoords,i,Kokkos::ALL(),Kokkos::ALL());
-          basisPtr->getValues(outView, inView);
+        //compute projection-based interpolation of the Lagrangian interpolation
+        DynRankView ConstructWithLabel(basisCoeffsHVol, numCells, basisCardinality);
+        {
+          ordinal_type targetCubDegree(basisPtr->getDegree());
 
-          // modify basis values to account for orientations
-          ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
-              basisValuesAtDofCoords,
+          Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
+          projStruct.createHVolProjectionStruct(basisPtr, targetCubDegree);
+
+          ordinal_type numPoints = projStruct.getNumTargetEvalPoints();
+          DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
+
+
+          pts::getHVolEvaluationPoints(evaluationPoints,
               elemOrts,
-              basisPtr.get());
+              basisPtr,
+              &projStruct);
 
-          for(ordinal_type k=0; k<basisCardinality; ++k) {
-            for(ordinal_type j=0; j<basisCardinality; ++j){
-              ValueType dofValue = basisValuesAtDofCoordsOriented(i,k,j) * dofCoeffsPhys(i,j);
-              if ( k==j && std::abs( dofValue - 1.0 ) > 100*tol ) {
-                errorFlag++;
-                *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-                *outStream << " Basis function " << k << " of cell " << i << " does not have unit value at its node (" << dofValue <<")\n";
-              }
-              if ( k!=j && std::abs( dofValue ) > tol ) {
-                errorFlag++;
-                *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-                *outStream << " Basis function " << k << " of cell " << i << " does not vanish at node " << j << "(" << dofValue <<")\n";
-              }
+
+          DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints);
+
+          DynRankView ConstructWithLabel(hvolBasisAtEvaluationPoints, numCells, basisCardinality , numPoints);
+          DynRankView ConstructWithLabel(hvolBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints);
+          for(int ic=0; ic<numCells; ic++)
+            basisPtr->getValues(Kokkos::subview(hvolBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
+          ots::modifyBasisByOrientation(hvolBasisAtEvaluationPoints,
+              hvolBasisAtEvaluationPointsNonOriented,
+              elemOrts,
+              basisPtr);
+
+          for(int ic=0; ic<numCells; ic++) {
+            for(int i=0;i<numPoints;i++) {
+              for(int k=0;k<basisCardinality;k++)
+                targetAtEvalPoints(ic,i) += basisCoeffsLI(ic,k)*hvolBasisAtEvaluationPoints(ic,k,i);
             }
           }
-        }
-      }
 
-      //check that fun values at reference points coincide with those computed using basis functions
-      DynRankView ConstructWithLabel(basisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
-      DynRankView ConstructWithLabel(transformedBasisValuesAtDofCoordsOriented, numCells, basisCardinality, basisCardinality);
-      DynRankView basisValuesAtDofCoordsCells("inValues", numCells, basisCardinality, basisCardinality);
-
-      for (ordinal_type ic = 0; ic < numCells; ++ic)
-        basisPtr->getValues(Kokkos::subview(basisValuesAtDofCoordsCells, ic, Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(dofCoordsOriented, ic, Kokkos::ALL(), Kokkos::ALL()));
-
-      // modify basis values to account for orientations
-      ots::modifyBasisByOrientation(basisValuesAtDofCoordsOriented,
-          basisValuesAtDofCoordsCells,
-          elemOrts,
-          basisPtr.get());
-
-      // transform basis values
-      DynRankView ConstructWithLabel(jacobian, numCells, basisCardinality, dim, dim);
-      DynRankView ConstructWithLabel(jacobian_det, numCells, basisCardinality);
-      ct::setJacobian(jacobian, dofCoordsOriented, physVertexes, tri);
-      ct::setJacobianDet (jacobian_det, jacobian);
-      fst::HVOLtransformVALUE(transformedBasisValuesAtDofCoordsOriented,
-          jacobian_det,
-          basisValuesAtDofCoordsOriented);
-
-      DynRankView ConstructWithLabel(funAtDofCoordsOriented, numCells, basisCardinality);
-      for(ordinal_type i=0; i<numCells; ++i) {
-        ValueType error=0;
-        for(ordinal_type j=0; j<basisCardinality; ++j) {
-          for(ordinal_type k=0; k<basisCardinality; ++k)
-            funAtDofCoordsOriented(i,j) += basisCoeffsLI(i,k)*transformedBasisValuesAtDofCoordsOriented(i,k,j);
-
-          error = std::max(std::abs( funAtDofCoords(i,j) - funAtDofCoordsOriented(i,j)), error);
+          pts::getHVolBasisCoeffs(basisCoeffsHVol,
+              targetAtEvalPoints,
+              evaluationPoints,
+              elemOrts,
+              basisPtr,
+              &projStruct);
         }
 
-        if(error>100*tol) {
-          errorFlag++;
-          *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-          *outStream << "Function values at reference points differ from those computed using basis functions of Tri " << i << "\n";
-          *outStream << "Function values at reference points are:\n";
-          for(ordinal_type j=0; j<basisCardinality; ++j)
-            *outStream << " (" << funAtDofCoords(i,j)  << ")";
-          *outStream << "\nFunction values at reference points computed using basis functions are\n";
-          for(ordinal_type j=0; j<basisCardinality; ++j)
-            *outStream << " (" << funAtDofCoordsOriented(i,j)  << ")";
-          *outStream << std::endl;
-        }
-      }
+        //check that the basis coefficients of the Lagrangian interpolation are the same as those of the projection-based interpolation
+        {
+          ValueType diffErr(0);
+          for(int k=0;k<basisCardinality;k++) {
+            for(int ic=0; ic<numCells; ic++)
+              diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsHVol(ic,k)));
+          }
 
-      //compute projection-based interpolation of the Lagrangian interpolation
-      DynRankView ConstructWithLabel(basisCoeffsHVol, numCells, basisCardinality);
-      {
-        ordinal_type targetCubDegree(basisPtr->getDegree());
-
-        Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
-        projStruct.createHVolProjectionStruct(basisPtr.get(), targetCubDegree);
-
-        ordinal_type numPoints = projStruct.getNumTargetEvalPoints();
-        DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
-
-
-        pts::getHVolEvaluationPoints(evaluationPoints,
-            elemOrts,
-            basisPtr.get(),
-            &projStruct);
-
-
-        DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints);
-
-        DynRankView ConstructWithLabel(hvolBasisAtEvaluationPoints, numCells, basisCardinality , numPoints);
-        DynRankView ConstructWithLabel(hvolBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints);
-        for(int ic=0; ic<numCells; ic++)
-          basisPtr->getValues(Kokkos::subview(hvolBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
-        ots::modifyBasisByOrientation(hvolBasisAtEvaluationPoints,
-            hvolBasisAtEvaluationPointsNonOriented,
-            elemOrts,
-            basisPtr.get());
-
-        for(int ic=0; ic<numCells; ic++) {
-          for(int i=0;i<numPoints;i++) {
-            for(int k=0;k<basisCardinality;k++)
-              targetAtEvalPoints(ic,i) += basisCoeffsLI(ic,k)*hvolBasisAtEvaluationPoints(ic,k,i);
+          if(diffErr > pow(16, degree)*tol) { //heuristic relation on how round-off error depends on degree
+            errorFlag++;
+            *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+            *outStream << "HVOL_C" << degree << ": The weights recovered with the optimization are different than the one used for generating the functon."<<
+                "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
           }
         }
 
-        pts::getHVolBasisCoeffs(basisCoeffsHVol,
-            targetAtEvalPoints,
-            evaluationPoints,
-            elemOrts,
-            basisPtr.get(),
-            &projStruct);
-      }
+        //compute L2 projection of the Lagrangian interpolation
+        DynRankView ConstructWithLabel(basisCoeffsL2, numCells, basisCardinality);
+        {
+          ordinal_type targetCubDegree(basisPtr->getDegree());
 
-      //check that the basis coefficients of the Lagrangian interpolation are the same as those of the projection-based interpolation
-      {
-        ValueType diffErr(0);
-        for(int k=0;k<basisCardinality;k++) {
+          Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
+          projStruct.createL2ProjectionStruct(basisPtr, targetCubDegree);
+
+          ordinal_type numPoints = projStruct.getNumTargetEvalPoints();
+          DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
+
+
+          pts::getL2EvaluationPoints(evaluationPoints,
+              elemOrts,
+              basisPtr,
+              &projStruct);
+
+
+          DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints);
+
+          DynRankView ConstructWithLabel(hvolBasisAtEvaluationPoints, numCells, basisCardinality , numPoints);
+          DynRankView ConstructWithLabel(hvolBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints);
           for(int ic=0; ic<numCells; ic++)
-            diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsHVol(ic,k)));
+            basisPtr->getValues(Kokkos::subview(hvolBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
+          ots::modifyBasisByOrientation(hvolBasisAtEvaluationPoints,
+              hvolBasisAtEvaluationPointsNonOriented,
+              elemOrts,
+              basisPtr);
+
+          for(int ic=0; ic<numCells; ic++) {
+            for(int i=0;i<numPoints;i++) {
+              for(int k=0;k<basisCardinality;k++)
+                targetAtEvalPoints(ic,i) += basisCoeffsLI(ic,k)*hvolBasisAtEvaluationPoints(ic,k,i);
+            }
+          }
+
+          pts::getL2BasisCoeffs(basisCoeffsL2,
+              targetAtEvalPoints,
+              evaluationPoints,
+              elemOrts,
+              basisPtr,
+              &projStruct);
         }
 
-        if(diffErr > pow(16, degree)*tol) { //heuristic relation on how round-off error depends on degree
-          errorFlag++;
-          *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-          *outStream << "HVOL_C" << degree << ": The weights recovered with the optimization are different than the one used for generating the functon."<<
-              "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
-        }
-      }
+        //check that the basis coefficients of the Lagrangian interpolation are the same as those of the L2 projection
+        {
+          ValueType diffErr = 0;
+          for(int k=0;k<basisCardinality;k++) {
+            for(int ic=0; ic<numCells; ic++)
+              diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsL2(ic,k)));
+          }
 
-      //compute L2 projection of the Lagrangian interpolation
-      DynRankView ConstructWithLabel(basisCoeffsL2, numCells, basisCardinality);
-      {
-        ordinal_type targetCubDegree(basisPtr->getDegree());
-
-        Experimental::ProjectionStruct<DeviceSpaceType,ValueType> projStruct;
-        projStruct.createL2ProjectionStruct(basisPtr.get(), targetCubDegree);
-
-        ordinal_type numPoints = projStruct.getNumTargetEvalPoints();
-        DynRankView ConstructWithLabel(evaluationPoints, numCells, numPoints, dim);
-
-
-        pts::getL2EvaluationPoints(evaluationPoints,
-            elemOrts,
-            basisPtr.get(),
-            &projStruct);
-
-
-        DynRankView ConstructWithLabel(targetAtEvalPoints, numCells, numPoints);
-
-        DynRankView ConstructWithLabel(hvolBasisAtEvaluationPoints, numCells, basisCardinality , numPoints);
-        DynRankView ConstructWithLabel(hvolBasisAtEvaluationPointsNonOriented, numCells, basisCardinality , numPoints);
-        for(int ic=0; ic<numCells; ic++)
-          basisPtr->getValues(Kokkos::subview(hvolBasisAtEvaluationPointsNonOriented, ic, Kokkos::ALL(), Kokkos::ALL()), Kokkos::subview(evaluationPoints, ic, Kokkos::ALL(), Kokkos::ALL()), OPERATOR_VALUE);
-        ots::modifyBasisByOrientation(hvolBasisAtEvaluationPoints,
-            hvolBasisAtEvaluationPointsNonOriented,
-            elemOrts,
-            basisPtr.get());
-
-        for(int ic=0; ic<numCells; ic++) {
-          for(int i=0;i<numPoints;i++) {
-            for(int k=0;k<basisCardinality;k++)
-              targetAtEvalPoints(ic,i) += basisCoeffsLI(ic,k)*hvolBasisAtEvaluationPoints(ic,k,i);
+          if(diffErr > pow(16, degree)*tol) { //heuristic relation on how round-off error depends on degree
+            errorFlag++;
+            *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
+            *outStream << "HVOL_C" << degree << ": The weights recovered with the L2 optimization are different than the one used for generating the functon."<<
+                "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
           }
         }
-
-        pts::getL2BasisCoeffs(basisCoeffsL2,
-            targetAtEvalPoints,
-            evaluationPoints,
-            elemOrts,
-            basisPtr.get(),
-            &projStruct);
-      }
-
-      //check that the basis coefficients of the Lagrangian interpolation are the same as those of the L2 projection
-      {
-        ValueType diffErr = 0;
-        for(int k=0;k<basisCardinality;k++) {
-          for(int ic=0; ic<numCells; ic++)
-            diffErr = std::max(diffErr, std::abs(basisCoeffsLI(ic,k) - basisCoeffsL2(ic,k)));
-        }
-
-        if(diffErr > pow(16, degree)*tol) { //heuristic relation on how round-off error depends on degree
-          errorFlag++;
-          *outStream << std::setw(70) << "^^^^----FAILURE!" << "\n";
-          *outStream << "HVOL_C" << degree << ": The weights recovered with the L2 optimization are different than the one used for generating the functon."<<
-              "\nThe max The infinite norm of the difference between the weights is: " <<  diffErr << std::endl;
-        }
+        delete basisPtr;
       }
     }
   } catch (std::exception &err) {


### PR DESCRIPTION
With this addition it is possible to use the new basis framework and in particular the Derived Nodal Basis similarly to the legacy basis
  - added getDofCoeffs to the new basis famework
  - added (legacy) triangle and tet basis to the DerivedNodalBasis
  - added testing for interpolation/projection of DerivedNodalBasis

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/intrepid2

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->