### PR TITLE
Zoltan2: allow scalar_type = long long when Tpetra instantiates it

### DIFF
--- a/packages/zoltan2/core/src/input/Zoltan2_InputTraits.hpp
+++ b/packages/zoltan2/core/src/input/Zoltan2_InputTraits.hpp
@@ -226,7 +226,7 @@ struct InputTraits {
   Z2_ISSAME(g,unsigned int) || Z2_ISSAME(g,unsigned long) || \
   Z2_ISSAME(g,unsigned long long) || Z2_ISSAME(g,size_t) )
 
-#define Z2_SERROR "Invalid scalar type. It must be float, double, or int."
+#define Z2_SERROR "Invalid scalar type. It must be float, double, int, or long long."
 
 #define Z2_LERROR "Invalid local ordinal type. It must be int, long, " \
   "long long, or ssize_t."

--- a/packages/zoltan2/core/src/input/Zoltan2_InputTraits.hpp
+++ b/packages/zoltan2/core/src/input/Zoltan2_InputTraits.hpp
@@ -216,7 +216,8 @@ struct InputTraits {
 #define Z2_ISSAME(s,type) (std::is_same< s, type >::value)
 
 #define Z2_STYPES(s) ( Z2_ISSAME(s,float) || \
-  Z2_ISSAME(s,double) || Z2_ISSAME(s,int) || Z2_ISSAME(s,long long))
+  Z2_ISSAME(s,double) || Z2_ISSAME(s,int) || Z2_ISSAME(s,long) || \
+  Z2_ISSAME(s,long long) || Z2_ISSAME(s, int64_t) || Z2_ISSAME(s, int32_t))
 
 #define Z2_LTYPES(l) ( Z2_ISSAME(l,int) ||  \
   Z2_ISSAME(l,long) || Z2_ISSAME(l,long long) || Z2_ISSAME(l,ssize_t) )
@@ -226,7 +227,7 @@ struct InputTraits {
   Z2_ISSAME(g,unsigned int) || Z2_ISSAME(g,unsigned long) || \
   Z2_ISSAME(g,unsigned long long) || Z2_ISSAME(g,size_t) )
 
-#define Z2_SERROR "Invalid scalar type. It must be float, double, int, or long long."
+#define Z2_SERROR "Invalid scalar type. It must be float, double, int, long, long long, int32_t, or int64_t."
 
 #define Z2_LERROR "Invalid local ordinal type. It must be int, long, " \
   "long long, or ssize_t."

--- a/packages/zoltan2/core/src/input/Zoltan2_InputTraits.hpp
+++ b/packages/zoltan2/core/src/input/Zoltan2_InputTraits.hpp
@@ -216,7 +216,7 @@ struct InputTraits {
 #define Z2_ISSAME(s,type) (std::is_same< s, type >::value)
 
 #define Z2_STYPES(s) ( Z2_ISSAME(s,float) || \
-  Z2_ISSAME(s,double) || Z2_ISSAME(s,int) )
+  Z2_ISSAME(s,double) || Z2_ISSAME(s,int) || Z2_ISSAME(s,long long))
 
 #define Z2_LTYPES(l) ( Z2_ISSAME(l,int) ||  \
   Z2_ISSAME(l,long) || Z2_ISSAME(l,long long) || Z2_ISSAME(l,ssize_t) )

--- a/packages/zoltan2/test/core/unit/input/InputTraitsBad.cpp
+++ b/packages/zoltan2/test/core/unit/input/InputTraitsBad.cpp
@@ -67,14 +67,13 @@ int main(int argc, char *argv[])
   // would fail - the #define above inverts the status of the static_asserts
   // that means these should all compile but only in this test and nowhere else
 
-  // scalar ordinal (first slot) must be float, double, or int
+  // scalar ordinal (first slot) must be float, double, int, or long long
   // this validates we would fail for any
   BEGIN_CHECK    Zoltan2::BasicUserTypes<unsigned int, int, long>                       END_CHECK
   BEGIN_CHECK    Zoltan2::BasicUserTypes<unsigned long, int, long>                      END_CHECK
   BEGIN_CHECK    Zoltan2::BasicUserTypes<uint32_t, int, long>                           END_CHECK
   BEGIN_CHECK    Zoltan2::BasicUserTypes<unsigned long long, int, long>                 END_CHECK
   BEGIN_CHECK    Zoltan2::BasicUserTypes<uint64_t, int, long>                           END_CHECK
-  BEGIN_CHECK    Zoltan2::BasicUserTypes<int64_t, int, long>                            END_CHECK
   BEGIN_CHECK    Zoltan2::BasicUserTypes<size_t, int, long>                             END_CHECK
   BEGIN_CHECK    Zoltan2::BasicUserTypes<std::complex<int>, int, long>                  END_CHECK
   BEGIN_CHECK    Zoltan2::BasicUserTypes<std::complex<double>, int, long>               END_CHECK
@@ -112,10 +111,8 @@ int main(int argc, char *argv[])
   typedef float user_float_t;
   typedef double user_double_t;
   typedef uint32_t user_uint32_t;
-  typedef int64_t user_int64_t;
   typedef uint64_t user_uint64_t;
   typedef signed long user_long_t;
-  typedef signed long long user_long_long_t;
   typedef unsigned long user_unsigned_long_t;
   typedef unsigned long long user_unsigned_long_long_t;
   typedef size_t user_size_t;
@@ -132,11 +129,8 @@ int main(int argc, char *argv[])
   BEGIN_CHECK    Zoltan2::BasicUserTypes<std::complex<user_int_t>, user_int_t, user_long_t>                                 END_CHECK
   BEGIN_CHECK    Zoltan2::BasicUserTypes<SomeBadType<user_int_t,user_long_t, user_int_t>, user_int_t, user_long_t>          END_CHECK
   BEGIN_CHECK    Zoltan2::BasicUserTypes<user_uint32_t, user_int_t, user_long_t>                                            END_CHECK
-  BEGIN_CHECK    Zoltan2::BasicUserTypes<int64_t, user_int_t, user_long_t>                                                  END_CHECK
   BEGIN_CHECK    Zoltan2::BasicUserTypes<user_some_bad_t, user_int_t, user_long_t>                                          END_CHECK
   BEGIN_CHECK    Zoltan2::BasicUserTypes<user_ssize_t, user_int_t, user_long_t>                                             END_CHECK
-  BEGIN_CHECK    Zoltan2::BasicUserTypes<user_long_long_t, user_int_t, user_long_t>                                         END_CHECK
-  BEGIN_CHECK    Zoltan2::BasicUserTypes<user_int64_t, user_int_t, user_long_t>                                             END_CHECK
 
   // local ordinal (second slot) must always be signed
   BEGIN_CHECK    Zoltan2::BasicUserTypes<user_float_t, user_unsigned_int_t, user_long_t>                                    END_CHECK
@@ -162,15 +156,12 @@ int main(int argc, char *argv[])
   // some more checks that should all fail - this doesn't check all
   // combinations but just tries a bunch of things on different class types
   BEGIN_CHECK    Zoltan2::BasicUserTypes<long, int, long long>                          END_CHECK
-  BEGIN_CHECK    Zoltan2::BasicUserTypes<long long, long, unsigned int>                 END_CHECK
   BEGIN_CHECK    Zoltan2::BasicUserTypes<unsigned int, unsigned int, unsigned long>     END_CHECK
   BEGIN_CHECK    Zoltan2::BasicUserTypes<unsigned long, unsigned long, long>            END_CHECK
-  BEGIN_CHECK    Zoltan2::BasicUserTypes<long long, long long, unsigned int>            END_CHECK
   BEGIN_CHECK    Xpetra::CrsMatrix<double, float, long long>                            END_CHECK
   BEGIN_CHECK    Xpetra::CrsMatrix<float, long, float>                                  END_CHECK
   BEGIN_CHECK    Xpetra::CrsMatrix<float, double, unsigned long>                        END_CHECK
   BEGIN_CHECK    Xpetra::CrsMatrix<float, unsigned long, double>                        END_CHECK
-  BEGIN_CHECK    Xpetra::CrsMatrix<long long, long long, unsigned int>                  END_CHECK
   BEGIN_CHECK    Tpetra::CrsMatrix<SomeBadType<int, int, int>, int, long long>          END_CHECK
   BEGIN_CHECK    Xpetra::CrsGraph<int, SomeBadType<int, double, float>>                 END_CHECK
   BEGIN_CHECK    Xpetra::CrsGraph<SomeBadType<int, long long, int>, unsigned int>       END_CHECK

--- a/packages/zoltan2/test/core/unit/input/InputTraitsBad.cpp
+++ b/packages/zoltan2/test/core/unit/input/InputTraitsBad.cpp
@@ -116,7 +116,6 @@ int main(int argc, char *argv[])
   typedef unsigned long user_unsigned_long_t;
   typedef unsigned long long user_unsigned_long_long_t;
   typedef size_t user_size_t;
-  typedef ssize_t user_ssize_t;
   typedef SomeBadType<int,int, int> user_some_bad_t;
 
   // scalar ordinal (first slot) must be float, double, or int
@@ -130,7 +129,6 @@ int main(int argc, char *argv[])
   BEGIN_CHECK    Zoltan2::BasicUserTypes<SomeBadType<user_int_t,user_long_t, user_int_t>, user_int_t, user_long_t>          END_CHECK
   BEGIN_CHECK    Zoltan2::BasicUserTypes<user_uint32_t, user_int_t, user_long_t>                                            END_CHECK
   BEGIN_CHECK    Zoltan2::BasicUserTypes<user_some_bad_t, user_int_t, user_long_t>                                          END_CHECK
-  BEGIN_CHECK    Zoltan2::BasicUserTypes<user_ssize_t, user_int_t, user_long_t>                                             END_CHECK
 
   // local ordinal (second slot) must always be signed
   BEGIN_CHECK    Zoltan2::BasicUserTypes<user_float_t, user_unsigned_int_t, user_long_t>                                    END_CHECK
@@ -155,7 +153,6 @@ int main(int argc, char *argv[])
 
   // some more checks that should all fail - this doesn't check all
   // combinations but just tries a bunch of things on different class types
-  BEGIN_CHECK    Zoltan2::BasicUserTypes<long, int, long long>                          END_CHECK
   BEGIN_CHECK    Zoltan2::BasicUserTypes<unsigned int, unsigned int, unsigned long>     END_CHECK
   BEGIN_CHECK    Zoltan2::BasicUserTypes<unsigned long, unsigned long, long>            END_CHECK
   BEGIN_CHECK    Xpetra::CrsMatrix<double, float, long long>                            END_CHECK

--- a/packages/zoltan2/test/core/unit/input/InputTraitsGood.cpp
+++ b/packages/zoltan2/test/core/unit/input/InputTraitsGood.cpp
@@ -141,6 +141,7 @@ int main(int argc, char *argv[])
   // so it can be scalar + local + global or it can be just local + global.
 
   // validate Zoltan2::BasicUserTypes
+  BEGIN_CHECK    Zoltan2::BasicUserTypes<long, int, long long>                    END_CHECK
   BEGIN_CHECK    Zoltan2::BasicUserTypes<double, signed int, long long>           END_CHECK
   BEGIN_CHECK    Zoltan2::BasicUserTypes<double, int, long long>                  END_CHECK
   BEGIN_CHECK    Zoltan2::BasicUserTypes<float, signed long, unsigned int>        END_CHECK

--- a/packages/zoltan2/test/core/unit/input/InputTraitsGood.cpp
+++ b/packages/zoltan2/test/core/unit/input/InputTraitsGood.cpp
@@ -55,12 +55,14 @@ using Zoltan2::InputTraits;
 
 int main(int argc, char *argv[])
 {
-  // scalar ordinal (first slot) must be float, double, or int
+  // scalar ordinal (first slot) must be float, double, int or long long
   // this validates they all work
   BEGIN_CHECK    Zoltan2::BasicUserTypes<float, signed int, long>                 END_CHECK
   BEGIN_CHECK    Zoltan2::BasicUserTypes<double, long>                            END_CHECK
   BEGIN_CHECK    Zoltan2::BasicUserTypes<int, int, long>                          END_CHECK
   BEGIN_CHECK    Zoltan2::BasicUserTypes<int32_t, int, long>                      END_CHECK
+  BEGIN_CHECK    Zoltan2::BasicUserTypes<long long, int, long>                    END_CHECK
+  BEGIN_CHECK    Zoltan2::BasicUserTypes<int64_t, int, long>                      END_CHECK
 
   // local ordinal (second slot) must always be signed
   // this validates they all work
@@ -104,10 +106,12 @@ int main(int argc, char *argv[])
   typedef ssize_t user_ssize_t;
 
   // scalar ordinal (first slot) must be float, double, or int
-  BEGIN_CHECK    Zoltan2::BasicUserTypes<user_float_t, user_int_t, user_long_t>                 END_CHECK
-  BEGIN_CHECK    Zoltan2::BasicUserTypes<user_double_t, user_long_t>                            END_CHECK
-  BEGIN_CHECK    Zoltan2::BasicUserTypes<user_int_t, user_int_t, user_long_t>                   END_CHECK
-  BEGIN_CHECK    Zoltan2::BasicUserTypes<user_int32_t, user_int_t, user_long_t>                 END_CHECK
+  BEGIN_CHECK  Zoltan2::BasicUserTypes<user_float_t, user_int_t, user_long_t>                  END_CHECK
+  BEGIN_CHECK  Zoltan2::BasicUserTypes<user_double_t, user_long_t>                             END_CHECK
+  BEGIN_CHECK  Zoltan2::BasicUserTypes<user_int_t, user_int_t, user_long_t>                    END_CHECK
+  BEGIN_CHECK  Zoltan2::BasicUserTypes<user_int32_t, user_int_t, user_long_t>                  END_CHECK
+  BEGIN_CHECK  Zoltan2::BasicUserTypes<user_long_long_t, user_int_t, user_long_t>              END_CHECK
+  BEGIN_CHECK  Zoltan2::BasicUserTypes<user_int64_t, user_int_t, user_long_t>                  END_CHECK
 
   // local ordinal (second slot) must always be signed
   BEGIN_CHECK    Zoltan2::BasicUserTypes<user_float_t, user_int_t, user_long_t>                 END_CHECK


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/zoltan2 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Zoltan2 has tests to ensure scalar_type is usable by Zoltan2.
It had previously excluded scalar_type = long long.
But now Tpetra's default global ordinal type is long long.  So if we want to apply geometric partitioning to matrix / tensor indices as coordinates, we need to allow scalar_type long long.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Tested on mac with clang.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->