### PR TITLE
Panzer: restart append can now overwrite previous exodus steps

### DIFF
--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.cpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.cpp
@@ -571,7 +571,9 @@ writeToExodus(const std::string& filename,
 void
 STK_Interface::
 setupExodusFile(const std::string& filename,
-                const bool append)
+                const bool append,
+                const bool append_after_restart_time,
+                const double restart_time)
 {
   using std::runtime_error;
   using stk::io::StkMeshIoBroker;
@@ -584,8 +586,15 @@ setupExodusFile(const std::string& filename,
   ParallelMachine comm = *mpiComm_->getRawMpiComm();
   meshData_ = rcp(new StkMeshIoBroker(comm));
   meshData_->set_bulk_data(bulkData_);
-  if (append)
-    meshIndex_ = meshData_->create_output_mesh(filename, stk::io::APPEND_RESULTS);
+  if (append) {
+    if (append_after_restart_time) {
+      Ioss::PropertyManager props;
+      meshIndex_ = meshData_->create_output_mesh(filename, stk::io::APPEND_RESULTS,
+                                                 props, restart_time);
+    }
+    else // Append results to the end of the file
+      meshIndex_ = meshData_->create_output_mesh(filename, stk::io::APPEND_RESULTS);
+  }
   else
     meshIndex_ = meshData_->create_output_mesh(filename, stk::io::WRITE_RESULTS);
   const FieldVector& fields = metaData_->get_fields();

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.hpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.hpp
@@ -345,13 +345,17 @@ public:
    *
    *  \param[in] filename The name of the output Exodus file.
    *  \param[in] append If set to true, the output will be appended to the output Exodus file. If set to false, output file will be overwritten. Default is false.
+   *  \param[in] append_after_restart_time If set to true, instead of appending to the end of the Exodus file, this option will append new writes after a specified time and overwrite subsequent time steps that were in the file. Allows users to restart anywhere in the exodus file and write consistently. If set to false, the next write will append to the end of the file. Default is false.
+   *  \param[in] restart_time If append_after_restart_time is true, this is the time value to append after. Otherwise this value is ignored.
    *
    *  \throws `std::logic_error` If the `STK_Interface` does not yet have a MPI
    *                             communicator.
    */
   void
   setupExodusFile(const std::string& filename,
-                  const bool append = false);
+                  const bool append = false,
+                  const bool append_after_restart_time = false,
+                  const double restart_time = 0.0);
 
   /**
    *  \brief Write this mesh and associated fields at the given `timestep`.


### PR DESCRIPTION
## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
append only added new steps to the end of the file. apps requested ability to append anywhere in the file.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
Approved by empire team in EMPIRE MR 1221.

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Added unit tests in test/stk_interface_test/tExodusRestartAndAppend.cpp

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->