### PR TITLE
Tpetra: Convert deep_copy to 3-arg and add temporary comments.

### DIFF
--- a/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_def.hpp
@@ -681,6 +681,8 @@ public:
     localError_ (new bool (false)),
     errs_ (new Teuchos::RCP<std::ostringstream> ()) // ptr to a null ptr
   {
+    using execution_space = typename Node::execution_space;
+
     TEUCHOS_TEST_FOR_EXCEPTION(
       ! graph_.isSorted (), std::invalid_argument, "Tpetra::"
       "BlockCrsMatrix constructor: The input CrsGraph does not have sorted "
@@ -715,7 +717,9 @@ public:
 
       row_map_type ptr_d = graph.getLocalGraph ().row_map;
       nc_host_row_map_type ptr_h_nc = Kokkos::create_mirror_view (ptr_d);
-      Kokkos::deep_copy (ptr_h_nc, ptr_d);
+
+      // DEEP_COPY REVIEW - DEVICE-TO-HOSTMIRROR
+      Kokkos::deep_copy (execution_space(), ptr_h_nc, ptr_d);
       ptrHost_ = ptr_h_nc;
     }
     {
@@ -724,7 +728,8 @@ public:
 
       entries_type ind_d = graph.getLocalGraph ().entries;
       nc_host_entries_type ind_h_nc = Kokkos::create_mirror_view (ind_d);
-      Kokkos::deep_copy (ind_h_nc, ind_d);
+      // DEEP_COPY REVIEW - DEVICE-TO-HOSTMIRROR
+      Kokkos::deep_copy (execution_space(), ind_h_nc, ind_d);
       indHost_ = ind_h_nc;
     }
 
@@ -751,6 +756,8 @@ public:
     localError_ (new bool (false)),
     errs_ (new Teuchos::RCP<std::ostringstream> ()) // ptr to a null ptr
   {
+    using execution_space = typename Node::execution_space;
+
     TEUCHOS_TEST_FOR_EXCEPTION(
       ! graph_.isSorted (), std::invalid_argument, "Tpetra::"
       "BlockCrsMatrix constructor: The input CrsGraph does not have sorted "
@@ -781,7 +788,8 @@ public:
 
       row_map_type ptr_d = graph.getLocalGraph ().row_map;
       nc_host_row_map_type ptr_h_nc = Kokkos::create_mirror_view (ptr_d);
-      Kokkos::deep_copy (ptr_h_nc, ptr_d);
+      // DEEP_COPY REVIEW - DEVICE-TO-HOSTMIRROR
+      Kokkos::deep_copy (execution_space(), ptr_h_nc, ptr_d);
       ptrHost_ = ptr_h_nc;
     }
     {
@@ -790,7 +798,8 @@ public:
 
       entries_type ind_d = graph.getLocalGraph ().entries;
       nc_host_entries_type ind_h_nc = Kokkos::create_mirror_view (ind_d);
-      Kokkos::deep_copy (ind_h_nc, ind_d);
+      // DEEP_COPY REVIEW - DEVICE-TO-HOSTMIRROR
+      Kokkos::deep_copy (execution_space(), ind_h_nc, ind_d);
       indHost_ = ind_h_nc;
     }
 
@@ -968,6 +977,7 @@ public:
          prefix << "The matrix's values need sync on both device and host.");
 #endif // HAVE_TPETRA_DEBUG
       this->modify_host ();
+      // DEEP_COPY REVIEW - NOT TESTED
       Kokkos::deep_copy (getValuesHost (), alpha);
     }
     else {
@@ -976,7 +986,9 @@ public:
       // device.  Also, prefer modifying on device if neither side is
       // marked as modified.
       this->modify_device ();
-      Kokkos::deep_copy (this->getValuesDevice (), alpha);
+      // DEEP_COPY REVIEW - VALUE-TO-DEVICE
+      using execution_space = typename device_type::execution_space;
+      Kokkos::deep_copy (execution_space(), this->getValuesDevice (), alpha);
     }
   }
 
@@ -3755,7 +3767,9 @@ public:
 
     // The code below works on host, so use a host View.
     auto diagOffsetsHost = Kokkos::create_mirror_view (diagOffsets);
-    Kokkos::deep_copy (diagOffsetsHost, diagOffsets);
+    // DEEP_COPY REVIEW - DEVICE-TO-HOSTMIRROR
+    using execution_space = typename device_type::execution_space;
+    Kokkos::deep_copy (execution_space(), diagOffsetsHost, diagOffsets);
     // We're filling diag on host for now.
     diag.template modify<typename decltype (diagOffsetsHost)::memory_space> ();
 

--- a/packages/tpetra/core/src/Tpetra_BlockMultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockMultiVector_def.hpp
@@ -305,7 +305,9 @@ replaceLocalValuesImpl (const LO localRowIndex,
   auto X_dst = getLocalBlock (localRowIndex, colIndex);
   typename const_little_vec_type::HostMirror::const_type X_src (reinterpret_cast<const impl_scalar_type*> (vals),
                                                                 getBlockSize ());
-  Kokkos::deep_copy (X_dst, X_src);
+  // DEEP_COPY REVIEW - HOSTMIRROR-TO-DEVICE
+  using execution_space = typename device_type::execution_space;
+  Kokkos::deep_copy (execution_space(), X_dst, X_src);
 }
 
 

--- a/packages/tpetra/core/src/Tpetra_Details_DualViewUtil.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_DualViewUtil.hpp
@@ -71,6 +71,7 @@ makeDualViewFromOwningHostView
   (Kokkos::DualView<ElementType*, DeviceType>& dv,
    const typename Kokkos::DualView<ElementType*, DeviceType>::t_host& hostView)
 {
+  using execution_space = typename DeviceType::execution_space;
   using dual_view_type = Kokkos::DualView<ElementType*, DeviceType>;
 
   if (dv.extent (0) == hostView.extent (0)) {
@@ -82,7 +83,8 @@ makeDualViewFromOwningHostView
   }
   else {
     auto devView = Kokkos::create_mirror_view (DeviceType (), hostView);
-    Kokkos::deep_copy (devView, hostView);
+    // DEEP_COPY REVIEW - DEVICE-TO-HOSTMIRROR
+    Kokkos::deep_copy (execution_space(), devView, hostView);
     dv = dual_view_type (devView, hostView);
   }
 }
@@ -93,6 +95,7 @@ makeDualViewFromArrayView (Kokkos::DualView<ElementType*, DeviceType>& dv,
                            const Teuchos::ArrayView<const ElementType>& av,
                            const std::string& label)
 {
+  using execution_space = typename DeviceType::execution_space;
   using dual_view_type = Kokkos::DualView<ElementType*, DeviceType>;
   using host_view_type = typename dual_view_type::t_host;
   using const_host_view_type = typename host_view_type::const_type;
@@ -101,7 +104,8 @@ makeDualViewFromArrayView (Kokkos::DualView<ElementType*, DeviceType>& dv,
   const ElementType* ptr = (size == 0) ? nullptr : av.getRawPtr ();
   const_host_view_type inView (ptr, size);
   host_view_type hostView (view_alloc_no_init (label), size);
-  Kokkos::deep_copy (hostView, inView);
+  // DEEP_COPY REVIEW - DEVICE-TO-HOSTMIRROR
+  Kokkos::deep_copy (execution_space(), hostView, inView);
 
   makeDualViewFromOwningHostView (dv, hostView);
 }
@@ -113,6 +117,7 @@ makeDualViewFromVector (Kokkos::DualView<ElementType*, DeviceType>& dv,
                         const std::string& label)
 {
   using dual_view_type = Kokkos::DualView<ElementType*, DeviceType>;
+  using execution_space = typename DeviceType::execution_space;
   using host_view_type = typename dual_view_type::t_host;
   using const_host_view_type = typename host_view_type::const_type;
 
@@ -120,7 +125,8 @@ makeDualViewFromVector (Kokkos::DualView<ElementType*, DeviceType>& dv,
   const ElementType* ptr = (size == 0) ? nullptr : vec.data ();
   const_host_view_type inView (ptr, size);
   host_view_type hostView (view_alloc_no_init (label), size);
-  Kokkos::deep_copy (hostView, inView);
+  // DEEP_COPY REVIEW - DEVICE-TO-HOSTMIRROR
+  Kokkos::deep_copy (execution_space(), hostView, inView);
 
   makeDualViewFromOwningHostView (dv, hostView);
 }

--- a/packages/tpetra/core/src/Tpetra_Details_EquilibrationInfo.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_EquilibrationInfo.hpp
@@ -138,22 +138,28 @@ struct EquilibrationInfo {
   void
   assign (const EquilibrationInfo<ScalarType, SrcDeviceType>& src)
   {
-    Kokkos::deep_copy (rowNorms, src.rowNorms);
-    Kokkos::deep_copy (rowDiagonalEntries, src.rowDiagonalEntries);
-    Kokkos::deep_copy (colNorms, src.colNorms);
+    using execution_space = typename device_type::execution_space;
+    // DEEP_COPY REVIEW - DEVICE-TO-DEVICE
+    Kokkos::deep_copy (execution_space(), rowNorms, src.rowNorms);
+    // DEEP_COPY REVIEW - DEVICE-TO-DEVICE
+    Kokkos::deep_copy (execution_space(), rowDiagonalEntries, src.rowDiagonalEntries);
+    // DEEP_COPY REVIEW - DEVICE-TO-DEVICE
+    Kokkos::deep_copy (execution_space(), colNorms, src.colNorms);
     if (src.colDiagonalEntries.extent (0) == 0) {
       colDiagonalEntries =
         Kokkos::View<val_type*, device_type> ("colDiagonalEntries", 0);
     }
     else {
-      Kokkos::deep_copy (colDiagonalEntries, src.colDiagonalEntries);
+      // DEEP_COPY REVIEW - DEVICE-TO-DEVICE
+      Kokkos::deep_copy (execution_space(), colDiagonalEntries, src.colDiagonalEntries);
     }
     if (src.rowScaledColNorms.extent (0) == 0) {
       rowScaledColNorms =
         Kokkos::View<mag_type*, device_type> ("rowScaledColNorms", 0);
     }
     else {
-      Kokkos::deep_copy (rowScaledColNorms, src.rowScaledColNorms);
+      // DEEP_COPY REVIEW - DEVICE-TO-DEVICE
+      Kokkos::deep_copy (execution_space(), rowScaledColNorms, src.rowScaledColNorms);
     }
 
     assumeSymmetric = src.assumeSymmetric;

--- a/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_decl.hpp
@@ -283,7 +283,8 @@ public:
                            src.val_.extent (0));
     // val and src.val_ have the same entry types, unlike (possibly)
     // ptr and src.ptr_.  Thus, we can use Kokkos::deep_copy here.
-    Kokkos::deep_copy (val, src.val_);
+    // DEEP_COPY REVIEW - DEVICE-TO-DEVICE
+    Kokkos::deep_copy (execution_space(), val, src.val_);
 
     this->ptr_ = ptr;
     this->val_ = val;

--- a/packages/tpetra/core/src/Tpetra_Details_computeOffsets.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_computeOffsets.hpp
@@ -306,7 +306,7 @@ computeOffsetsFromCounts (const ExecutionSpace& execSpace,
       using Kokkos::WithoutInitializing;
       counts_copy = counts_copy_type
         (view_alloc ("counts_copy", WithoutInitializing), numCounts);
-      Kokkos::deep_copy (counts_copy, counts);
+      Kokkos::deep_copy (execSpace, counts_copy, counts);
       counts_a = counts_copy;
     }
 

--- a/packages/tpetra/core/src/Tpetra_Details_copyConvert.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_copyConvert.hpp
@@ -279,11 +279,15 @@ namespace { // (anonymous)
         // it's cheaper to allocate.  Hopefully users aren't doing
         // aliased copies in a tight loop.
         auto src_copy = Kokkos::create_mirror (Kokkos::HostSpace (), src);
+        // DEEP_COPY REVIEW - NOT TESTED
         Kokkos::deep_copy (src_copy, src);
+        // DEEP_COPY REVIEW - NOT TESTED
         Kokkos::deep_copy (dst, src_copy);
       }
       else { // no aliasing
-        Kokkos::deep_copy (dst, src);
+        // DEEP_COPY REVIEW - DEVICE-TO-DEVICE
+        using execution_space = typename OutputViewType::execution_space;
+        Kokkos::deep_copy (execution_space(), dst, src);
       }
     }
   };
@@ -326,9 +330,11 @@ namespace { // (anonymous)
          const InputViewType& src)
     {
       using output_memory_space = typename OutputViewType::memory_space;
+      using output_execution_space = typename OutputViewType::execution_space;
       auto src_outputSpaceCopy =
         Kokkos::create_mirror_view (output_memory_space (), src);
-      Kokkos::deep_copy (src_outputSpaceCopy, src);
+      // DEEP_COPY REVIEW - DEVICE-TO-HOSTMIRROR
+      Kokkos::deep_copy (output_execution_space(), src_outputSpaceCopy, src);
 
       // The output View's execution space can access
       // outputSpaceCopy's data, so we can run the functor now.

--- a/packages/tpetra/core/src/Tpetra_Details_copyOffsets.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_copyOffsets.hpp
@@ -172,7 +172,9 @@ namespace { // (anonymous)
       if (srcLen <= maxNumToPrint) {
         auto dst_h = Kokkos::create_mirror_view (dst);
         auto src_h = Kokkos::create_mirror_view (src);
+        // DEEP_COPY REVIEW - NOT TESTED
         Kokkos::deep_copy (src_h, src);
+        // DEEP_COPY REVIEW - NOT TESTED
         Kokkos::deep_copy (dst_h, dst);
 
         os << "  src: [";
@@ -387,7 +389,9 @@ namespace { // (anonymous)
                      "CopyOffsetsImpl (implementation of copyOffsets): In order"
                      " to call this specialization, src and dst must have the "
                      "the same array_layout.");
-      Kokkos::deep_copy (dst, src);
+      // DEEP_COPY REVIEW - DEVICE-TO-DEVICE
+      using execution_space = typename OutputViewType::execution_space;
+      Kokkos::deep_copy (execution_space(), dst, src);
     }
   };
 
@@ -495,16 +499,17 @@ namespace { // (anonymous)
           Kokkos::LayoutLeft, typename OutputViewType::device_type>;
       using Kokkos::view_alloc;
       using Kokkos::WithoutInitializing;
+      using execution_space = typename OutputViewType::execution_space;
       output_space_copy_type
         outputSpaceCopy (view_alloc ("outputSpace", WithoutInitializing),
                          src.extent (0));
-      Kokkos::deep_copy (outputSpaceCopy, src);
+      // DEEP_COPY REVIEW - DEVICE-TO-DEVICE
+      Kokkos::deep_copy (execution_space(), outputSpaceCopy, src);
 
       // The output View's execution space can access
       // outputSpaceCopy's data, so we can run the functor now.
       using functor_type =
         CopyOffsetsFunctor<OutputViewType, output_space_copy_type>;
-      using execution_space = typename OutputViewType::execution_space;
       using size_type = typename OutputViewType::size_type;
       using range_type = Kokkos::RangePolicy<execution_space, size_type>;
 

--- a/packages/tpetra/core/src/Tpetra_Details_createMirrorView.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_createMirrorView.hpp
@@ -148,7 +148,9 @@ public:
     else {
       // No need to initialize, if we're going to copy into it anyway.
       outView_nc = nc_output_view_type (view_alloc (std::string (label), WithoutInitializing), inSize);
-      Kokkos::deep_copy (outView_nc, inView);
+      // DEEP_COPY REVIEW - HOST-TO-DEVICE
+      using execution_space = typename nc_output_view_type::execution_space;
+      Kokkos::deep_copy (execution_space(), outView_nc, inView);
     }
     return outView_nc; // this casts back to const
   }
@@ -170,6 +172,7 @@ public:
         const char label[] = "")
   {
     typedef typename OutputDeviceType::memory_space out_mem_space;
+    typedef typename OutputDeviceType::execution_space out_exec_space;
     static_assert (! std::is_const<ValueType>::value, "ValueType must not be "
                    "const in order to use this specialization.  Please report "
                    "this bug to the Tpetra developers.");
@@ -181,7 +184,8 @@ public:
     output_view_type outView =
       Kokkos::create_mirror_view (out_mem_space (), inView);
     if (copy) {
-      Kokkos::deep_copy (outView, inView);
+      // DEEP_COPY REVIEW - DEVICE-TO-HOSTMIRROR
+      Kokkos::deep_copy (out_exec_space(), outView, inView);
     }
     return outView;
   }

--- a/packages/tpetra/core/src/Tpetra_Details_crsUtils.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_crsUtils.hpp
@@ -156,6 +156,7 @@ pad_crs_arrays(
   const int my_rank,
   const bool verbose)
 {
+  using execution_space = typename RowPtr::execution_space;
   using Kokkos::view_alloc;
   using Kokkos::WithoutInitializing;
   using std::endl;
@@ -177,12 +178,14 @@ pad_crs_arrays(
     os << *prefix << "On input: ";
     auto row_ptr_beg_h =
       Kokkos::create_mirror_view(hostSpace, row_ptr_beg);
+    // DEEP_COPY REVIEW - NOT TESTED
     Kokkos::deep_copy(row_ptr_beg_h, row_ptr_beg);
     verbosePrintArray(os, row_ptr_beg_h, "row_ptr_beg before scan",
                       maxNumToPrint);
     os << ", ";
     auto row_ptr_end_h =
       Kokkos::create_mirror_view(hostSpace, row_ptr_end);
+    // DEEP_COPY REVIEW - NOT TESTED
     Kokkos::deep_copy(row_ptr_end_h, row_ptr_end);
     verbosePrintArray(os, row_ptr_end_h, "row_ptr_end before scan",
                       maxNumToPrint);
@@ -216,10 +219,12 @@ pad_crs_arrays(
   {
     auto row_ptr_end_h = create_mirror_view(
       hostSpace, row_ptr_end, verbose, prefix.get());
-    Kokkos::deep_copy(row_ptr_end_h, row_ptr_end);
+    // DEEP_COPY REVIEW - DEVICE-TO-HOSTMIRROR
+    Kokkos::deep_copy(execution_space(), row_ptr_end_h, row_ptr_end);
     auto row_ptr_beg_h = create_mirror_view(
       hostSpace, row_ptr_beg, verbose, prefix.get());
-    Kokkos::deep_copy(row_ptr_beg_h, row_ptr_beg);
+    // DEEP_COPY REVIEW - DEVICE-TO-HOSTMIRROR
+    Kokkos::deep_copy(execution_space(), row_ptr_beg_h, row_ptr_beg);
 
     auto newAllocPerRow_h = create_mirror_view(
       hostSpace, newAllocPerRow, verbose, prefix.get());
@@ -264,7 +269,8 @@ pad_crs_arrays(
     if (increase == 0) {
       return;
     }
-    Kokkos::deep_copy(newAllocPerRow, newAllocPerRow_h);
+    // DEEP_COPY REVIEW - HOSTMIRROR-TO-DEVICE
+    Kokkos::deep_copy(execution_space(), newAllocPerRow, newAllocPerRow_h);
   }
 
   using inds_value_type = typename Indices::non_const_value_type;
@@ -289,7 +295,6 @@ pad_crs_arrays(
     os << *prefix << "Repack" << endl;
     std::cerr << os.str();
   }
-  using execution_space = typename Indices::execution_space;
   using range_type = Kokkos::RangePolicy<execution_space, size_t>;
   Kokkos::parallel_scan(
     "Tpetra::CrsGraph or CrsMatrix repack",
@@ -340,6 +345,7 @@ pad_crs_arrays(
     os << *prefix;
     auto row_ptr_beg_h =
       Kokkos::create_mirror_view(hostSpace, row_ptr_beg);
+    // DEEP_COPY REVIEW - NOT TESTED
     Kokkos::deep_copy(row_ptr_beg_h, row_ptr_beg);
     verbosePrintArray(os, row_ptr_beg_h, "row_ptr_beg after scan",
                       maxNumToPrint);
@@ -348,6 +354,7 @@ pad_crs_arrays(
     os << *prefix;
     auto row_ptr_end_h =
       Kokkos::create_mirror_view(hostSpace, row_ptr_end);
+    // DEEP_COPY REVIEW - NOT TESTED
     Kokkos::deep_copy(row_ptr_end_h, row_ptr_end);
     verbosePrintArray(os, row_ptr_end_h, "row_ptr_end after scan",
                       maxNumToPrint);
@@ -365,8 +372,10 @@ pad_crs_arrays(
 
   if (verbose) {
     auto indices_h = Kokkos::create_mirror_view(hostSpace, indices);
+    // DEEP_COPY REVIEW - NOT TESTED
     Kokkos::deep_copy(indices_h, indices);
     auto values_h = Kokkos::create_mirror_view(hostSpace, values);
+    // DEEP_COPY REVIEW - NOT TESTED
     Kokkos::deep_copy(values_h, values);
     std::ostringstream os;
     os << "On output: ";

--- a/packages/tpetra/core/src/Tpetra_Details_fill.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_fill.hpp
@@ -83,6 +83,7 @@ public:
   {
     static_assert (std::is_integral<IndexType>::value,
                    "IndexType must be a built-in integer type.");
+    // DEEP_COPY REVIEW - NOT TESTED
     Kokkos::deep_copy (execSpace, X, alpha);
   }
 };
@@ -256,11 +257,14 @@ struct Fill<ViewType,
         }
       }
       else {
+        // DEEP_COPY REVIEW - NOT TESTED
         Kokkos::deep_copy (X, view_value_type (0.0));
       }
     }
     else {
-      Kokkos::deep_copy (X, alpha);
+      // DEEP_COPY REVIEW - VALUE-TO-DEVICE
+      using execution_space = typename ViewType::execution_space;
+      Kokkos::deep_copy (execution_space(), X, alpha);
     }
   }
 };

--- a/packages/tpetra/core/src/Tpetra_Details_get1DConstView.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_get1DConstView.hpp
@@ -1,0 +1,117 @@
+// @HEADER
+// ***********************************************************************
+//
+//          Tpetra: Templated Linear Algebra Services Package
+//                 Copyright (2008) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Michael A. Heroux (maherou@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+
+#ifndef TPETRA_DETAILS_GET1DCONSTVIEW_HPP
+#define TPETRA_DETAILS_GET1DCONSTVIEW_HPP
+
+///
+/// \file Tpetra_Details_get1DConstView.hpp
+/// \brief Create a Kokkos::View from a raw host array.
+///
+
+#include "Tpetra_ConfigDefs.hpp"
+#include "Tpetra_Util.hpp"
+#include "Kokkos_DualView.hpp"
+#include <Teuchos_Array.hpp>
+#include <utility>
+
+namespace Tpetra {
+namespace Details {
+
+// mfh 28 Apr 2016: Sometimes we have a raw host array, and we need
+// to make a Kokkos::View out of it that lives in a certain memory
+// space.  We don't want to make a deep copy of the input array if
+// we don't need to, but if the memory spaces are different, we need
+// to.  The following code does that.  The struct is an
+// implementation detail, and the "free" function
+// get1DConstViewOfUnmanagedArray is the interface to call.
+
+template<class ST, class DT,
+         const bool outputIsHostMemory =
+           std::is_same<typename DT::memory_space, Kokkos::HostSpace>::value>
+struct Get1DConstViewOfUnmanagedHostArray {};
+
+template<class ST, class DT>
+struct Get1DConstViewOfUnmanagedHostArray<ST, DT, true> {
+  typedef Kokkos::View<const ST*, Kokkos::HostSpace, Kokkos::MemoryUnmanaged> output_view_type;
+
+  static output_view_type
+    getView (const char /* label */ [], const ST* x_raw, const size_t x_len)
+    {
+      // We can return the input array, wrapped as an unmanaged View.
+      // Ignore the label, since unmanaged Views don't have labels.
+      return output_view_type (x_raw, x_len);
+    }
+};
+
+template<class ST, class DT>
+struct Get1DConstViewOfUnmanagedHostArray<ST, DT, false> {
+  typedef Kokkos::View<const ST*, Kokkos::HostSpace, Kokkos::MemoryUnmanaged> input_view_type;
+  typedef Kokkos::View<const ST*, DT> output_view_type;
+
+  static output_view_type
+    getView (const char label[], const ST* x_raw, const size_t x_len)
+    {
+      input_view_type x_in (x_raw, x_len);
+      // The memory spaces are different, so we have to create a new
+      // View which is a deep copy of the input array.
+      //
+      // FIXME (mfh 28 Apr 2016) This needs to be converted to
+      // std::string, else the compiler can't figure out what
+      // constructor we're calling.
+      Kokkos::View<ST*, DT> x_out (std::string (label), x_len);
+      // DEEP_COPY REVIEW - NOT TESTED
+      Kokkos::deep_copy (x_out, x_in);
+      return x_out;
+    }
+};
+
+template<class ST, class DT>
+  typename Get1DConstViewOfUnmanagedHostArray<ST, DT>::output_view_type
+get1DConstViewOfUnmanagedHostArray (const char label[], const ST* x_raw, const size_t x_len)
+{
+  return Get1DConstViewOfUnmanagedHostArray<ST, DT>::getView (label, x_raw, x_len);
+}
+
+} // namespace Details
+} // namespace Tpetra
+
+#endif // TPETRA_DETAILS_GET1DCONSTVIEW_HPP

--- a/packages/tpetra/core/src/Tpetra_Details_getEntryOnHost.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_getEntryOnHost.hpp
@@ -60,10 +60,12 @@ typename ViewType::non_const_value_type
 getEntryOnHost (const ViewType& x,
                 const IndexType ind)
 {
+  using execution_space = typename ViewType::execution_space;
   static_assert (ViewType::Rank == 1, "x must be a rank-1 Kokkos::View.");
   // Get a 0-D subview of the entry of the array, and copy to host scalar.
   typename ViewType::non_const_value_type val;
-  Kokkos::deep_copy(val, Kokkos::subview(x, ind));
+  // DEEP_COPY REVIEW - DEVICE-TO-VALUE
+  Kokkos::deep_copy(execution_space(), val, Kokkos::subview(x, ind));
   return val;
 }
 

--- a/packages/tpetra/core/src/Tpetra_Details_iallreduce.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_iallreduce.hpp
@@ -712,7 +712,9 @@ struct Iallreduce<PacketType,
     // MPI is disabled, so comm is a SerialComm.
     // Avoid needing to check the SerialComm case in Impl::iallreduce.
     // That lets Impl::iallreduce not need to know about DeviceType.
-    ::Kokkos::deep_copy (recvbuf, sendbuf);
+    // DEEP_COPY REVIEW - DEVICE-TO-DEVICE - NOT TESTED FOR MPI BUILD
+    using execution_space = typename RecvDeviceType::execution_space; // what if it's device to host?
+    ::Kokkos::deep_copy (execution_space(), recvbuf, sendbuf);
     // This request has already finished.  There's nothing more to do.
     return Impl::emptyCommRequest ();
 #endif // HAVE_TPETRACORE_MPI
@@ -774,7 +776,9 @@ struct Iallreduce<PacketType,
     // MPI is disabled, so comm is a SerialComm.
     // Avoid needing to check the SerialComm case in Impl::iallreduce.
     // That lets Impl::iallreduce not need to know about DeviceType.
-    ::Kokkos::deep_copy (recvbuf, sendbuf);
+    // DEEP_COPY REVIEW - DEVICE-TO-DEVICE - NOT TESTED FOR MPI BUILD
+    using execution_space = typename RecvDeviceType::execution_space; // what if it's device to host?
+    ::Kokkos::deep_copy (execution_space(), recvbuf, sendbuf);
     // This request has already finished.  There's nothing more to do.
     return Impl::emptyCommRequest ();
 #endif // HAVE_TPETRACORE_MPI

--- a/packages/tpetra/core/src/Tpetra_Details_lclDot.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_lclDot.hpp
@@ -145,6 +145,7 @@ lclDot (const RV& dotsOut,
 
   if (lclNumRows == 0) {
     const dot_type zero = Kokkos::Details::ArithTraits<dot_type>::zero ();
+    // DEEP_COPY REVIEW - NOT TESTED
     Kokkos::deep_copy (theDots, zero);
   }
   else { // lclNumRows != 0
@@ -152,6 +153,7 @@ lclDot (const RV& dotsOut,
       if (X.extent (1) == 1) {
         typename RV::non_const_value_type result =
           KokkosBlas::dot (subview (X, ALL (), 0), subview (Y, ALL (), 0));
+        // DEEP_COPY REVIEW - NOT TESTED
         Kokkos::deep_copy (theDots, result);
       }
       else {

--- a/packages/tpetra/core/src/Tpetra_Details_localDeepCopyRowMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_localDeepCopyRowMatrix_def.hpp
@@ -134,8 +134,12 @@ localDeepCopyLocallyIndexedRowMatrix
     std::copy (inVals, inVals + numEnt, val_h.data () + curPos);
     curPos += offset_type (numEnt);
   }
-  Kokkos::deep_copy (ind, ind_h);
-  Kokkos::deep_copy (val, val_h);
+
+  using execution_space = typename inds_type::execution_space;
+  // DEEP_COPY REVIEW - HOSTMIRROR-TO-DEVICE
+  Kokkos::deep_copy (execution_space(), ind, ind_h);
+  // DEEP_COPY REVIEW - HOSTMIRROR-TO-DEVICE
+  Kokkos::deep_copy (execution_space(), val, val_h);
 
   local_graph_type lclGraph (ind, ptr);
   const size_t numCols = A.getColMap ()->getNodeNumElements ();

--- a/packages/tpetra/core/src/Tpetra_Details_localRowOffsets_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_localRowOffsets_def.hpp
@@ -84,7 +84,9 @@ localRowCounts (const RowGraph<LO, GO, NT>& G)
     entPerRow_h[i] = offset_type (lclNumEnt);
     maxNumEnt = maxNumEnt < lclNumEnt ? lclNumEnt : maxNumEnt;
   }
-  Kokkos::deep_copy (entPerRow, entPerRow_h);
+  // DEEP_COPY REVIEW - HOSTMIRROR-TO-DEVICE
+  using execution_space = typename NT::execution_space;
+  Kokkos::deep_copy (execution_space(), entPerRow, entPerRow_h);
   return {entPerRow, maxNumEnt};
 }
 
@@ -131,6 +133,7 @@ localRowOffsetsFromFillCompleteCrsGraph (const CrsGraph<LO, GO, NT>& G)
   auto G_lcl = G.getLocalGraph ();
   offsets_type ptr (view_alloc ("ptr", WithoutInitializing),
                     G_lcl.row_map.extent (0));
+  // DEEP_COPY REVIEW - NOT TESTED
   Kokkos::deep_copy (ptr, G_lcl.row_map);
 
   const offset_type nnz = G.getNodeNumEntries ();

--- a/packages/tpetra/core/src/Tpetra_Details_makeColMap_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_makeColMap_def.hpp
@@ -627,13 +627,17 @@ makeColMap (Teuchos::RCP<const Tpetra::Map<LO, GO, NT>>& colMap,
   //Pull down the sizes
   GO numLocalColGIDs = 0;
   GO numRemoteColGIDs = 0;
-  Kokkos::deep_copy(numLocalColGIDs, numLocals);
-  Kokkos::deep_copy(numRemoteColGIDs, numRemotes);
+  // DEEP_COPY REVIEW - DEVICE-TO-VALUE
+  Kokkos::deep_copy(exec_space(), numLocalColGIDs, numLocals);
+  // DEEP_COPY REVIEW - DEVICE-TO-numLocalColGIDs
+  Kokkos::deep_copy(exec_space(), numRemoteColGIDs, numRemotes);
   //Pull down the remote lists
   auto localsHost = Kokkos::create_mirror_view(localGIDView);
   auto remotesHost = Kokkos::create_mirror_view(remoteGIDView);
-  Kokkos::deep_copy(localsHost, localGIDView);
-  Kokkos::deep_copy(remotesHost, remoteGIDView);
+  // DEEP_COPY REVIEW - DEVICE-TO-HOSTMIRROR
+  Kokkos::deep_copy(exec_space(), localsHost, localGIDView);
+  // DEEP_COPY REVIEW - DEVICE-TO-HOSTMIRROR
+  Kokkos::deep_copy(exec_space(), remotesHost, remoteGIDView);
   //Finally, populate the STL structures which hold the index lists
   std::set<GO> RemoteGIDSet;
   std::vector<GO> RemoteGIDUnorderedVector;

--- a/packages/tpetra/core/src/Tpetra_Details_normImpl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_normImpl.hpp
@@ -147,7 +147,9 @@ lclNormImpl (const RV& normsOut,
 
   if (lclNumRows == 0) {
     const mag_type zeroMag = Kokkos::ArithTraits<mag_type>::zero ();
-    Kokkos::deep_copy (normsOut, zeroMag);
+    // DEEP_COPY REVIEW - VALUE-TO-DEVICE
+    using execution_space = typename RV::execution_space;
+    Kokkos::deep_copy (execution_space(), normsOut, zeroMag);
   }
   else { // lclNumRows != 0
     if (constantStride) {
@@ -252,7 +254,9 @@ gblNormImpl (const RV& normsOut,
     // MPI doesn't allow aliasing of arguments, so we have to make
     // a copy of the local sum.
     RV lclNorms ("MV::normImpl lcl", numVecs);
-    Kokkos::deep_copy (lclNorms, normsOut);
+    // DEEP_COPY REVIEW - DEVICE-TO-DEVICE
+    using execution_space = typename RV::execution_space;
+    Kokkos::deep_copy (execution_space(), lclNorms, normsOut);
     const mag_type* const lclSum = lclNorms.data ();
     mag_type* const gblSum = normsOut.data ();
     const int nv = static_cast<int> (numVecs);

--- a/packages/tpetra/core/src/Tpetra_Details_packCrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_packCrsGraph_def.hpp
@@ -229,7 +229,9 @@ public:
   //! Host function for getting the error.
   int getError () const {
     auto error_h = Kokkos::create_mirror_view (error_);
-    Kokkos::deep_copy (error_h, error_);
+    // DEEP_COPY REVIEW - DEVICE-TO-HOSTMIRROR
+    using execution_space = typename device_type::execution_space;
+    Kokkos::deep_copy (execution_space(), error_h, error_);
     return error_h ();
   }
 
@@ -835,7 +837,10 @@ packCrsGraph (const CrsGraph<LO, GO, NT>& sourceGraph,
   View<size_t*, HostSpace, MemoryUnmanaged>
     num_packets_per_lid_h (numPacketsPerLID.getRawPtr (),
                            numPacketsPerLID.size ());
-  Kokkos::deep_copy (num_packets_per_lid_h, num_packets_per_lid_d);
+
+  // DEEP_COPY REVIEW - DEVICE-TO-HOST
+  using execution_space = typename BDT::execution_space;
+  Kokkos::deep_copy (execution_space(), num_packets_per_lid_h, num_packets_per_lid_d);
 
   // FIXME (mfh 23 Aug 2017) If we're forced to use a DualView for
   // exports_dv above, then we have two host copies for exports_h.
@@ -848,7 +853,8 @@ packCrsGraph (const CrsGraph<LO, GO, NT>& sourceGraph,
   }
   View<packet_type*, HostSpace, MemoryUnmanaged>
     exports_h (exports.getRawPtr (), exports.size ());
-  Kokkos::deep_copy (exports_h, exports_dv.d_view);
+  // DEEP_COPY REVIEW - DEVICE-TO-HOST
+  Kokkos::deep_copy (execution_space(), exports_h, exports_dv.d_view);
 }
 
 /// \brief Pack specified entries of the given local sparse graph for
@@ -1004,7 +1010,10 @@ packCrsGraphWithOwningPIDs
   // have to copy them back to host.
   View<size_t*, HostSpace, MemoryUnmanaged> num_packets_per_lid_h
     (numPacketsPerLID.getRawPtr (), numPacketsPerLID.size ());
-  Kokkos::deep_copy (num_packets_per_lid_h, num_packets_per_lid_d);
+  // DEEP_COPY REVIEW - DEVICE-TO-HOST
+  using execution_space = typename buffer_device_type::execution_space;
+  Kokkos::deep_copy (execution_space(),
+    num_packets_per_lid_h, num_packets_per_lid_d);
 }
 
 } // namespace Details

--- a/packages/tpetra/core/src/Tpetra_Details_packCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_packCrsMatrix_def.hpp
@@ -244,8 +244,10 @@ public:
 
   //! Host function for getting the error.
   int getError () const {
+    typedef typename device_type::execution_space execution_space;
     auto error_h = Kokkos::create_mirror_view (error_);
-    Kokkos::deep_copy (error_h, error_);
+    // DEEP_COPY REVIEW - DEVICE-TO-HOSTMIRROR
+    Kokkos::deep_copy (execution_space(), error_h, error_);
     return error_h ();
   }
 
@@ -869,6 +871,7 @@ packCrsMatrix (const CrsMatrix<ST, LO, GO, NT>& sourceMatrix,
 {
   using local_matrix_type = typename CrsMatrix<ST,LO,GO,NT>::local_matrix_type;
   using device_type = typename local_matrix_type::device_type;
+  using execution_space = typename device_type::execution_space;
   using buffer_device_type = typename DistObject<char, LO, GO, NT>::buffer_device_type;
   using host_exec_space = typename Kokkos::View<size_t*, device_type>::HostMirror::execution_space;
   using host_dev_type = Kokkos::Device<host_exec_space, Kokkos::HostSpace>;
@@ -906,7 +909,8 @@ packCrsMatrix (const CrsMatrix<ST, LO, GO, NT>& sourceMatrix,
   Kokkos::View<size_t*, host_dev_type> num_packets_per_lid_h
     (numPacketsPerLID.getRawPtr (),
      numPacketsPerLID.size ());
-  Kokkos::deep_copy (num_packets_per_lid_h, num_packets_per_lid_d);
+  // DEEP_COPY REVIEW - DEVICE-TO-HOST
+  Kokkos::deep_copy (execution_space(), num_packets_per_lid_h, num_packets_per_lid_d);
 
   // FIXME (mfh 23 Aug 2017) If we're forced to use a DualView for
   // exports_dv above, then we have two host copies for exports_h.
@@ -919,7 +923,8 @@ packCrsMatrix (const CrsMatrix<ST, LO, GO, NT>& sourceMatrix,
   }
   Kokkos::View<char*, host_dev_type> exports_h (exports.getRawPtr (),
                                                 exports.size ());
-  Kokkos::deep_copy (exports_h, exports_dv.d_view);
+  // DEEP_COPY REVIEW - DEVICE-TO-HOST
+  Kokkos::deep_copy (execution_space(), exports_h, exports_dv.d_view);
 }
 
 template<typename ST, typename LO, typename GO, typename NT>
@@ -975,6 +980,7 @@ packCrsMatrixWithOwningPIDs (const CrsMatrix<ST, LO, GO, NT>& sourceMatrix,
   typedef Kokkos::Device<host_exec_space, Kokkos::HostSpace> host_dev_type;
 
   typename local_matrix_type::device_type outputDevice;
+  typedef typename NT::execution_space execution_space;
 
   const bool verbose = ::Tpetra::Details::Behavior::verbose ();
   std::unique_ptr<std::string> prefix;
@@ -1054,7 +1060,8 @@ packCrsMatrixWithOwningPIDs (const CrsMatrix<ST, LO, GO, NT>& sourceMatrix,
       // so we have to copy them back to host.
       Kokkos::View<size_t*, host_dev_type> num_packets_per_lid_h
         (numPacketsPerLID.getRawPtr (), numPacketsPerLID.size ());
-      Kokkos::deep_copy (num_packets_per_lid_h, num_packets_per_lid_d);
+      // DEEP_COPY REVIEW - DEVICE-TO-HOST
+      Kokkos::deep_copy (execution_space(), num_packets_per_lid_h, num_packets_per_lid_d);
     }
     catch (std::exception& e) {
       if (verbose) {

--- a/packages/tpetra/core/src/Tpetra_Details_unpackCrsMatrixAndCombine_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_unpackCrsMatrixAndCombine_def.hpp
@@ -678,12 +678,14 @@ unpackAndCombineIntoCrsMatrix(
 
   Kokkos::HostSpace host_space;
   auto batches_per_lid_h = Kokkos::create_mirror_view(host_space, batches_per_lid);
-  Kokkos::deep_copy(batches_per_lid_h, batches_per_lid);
+  // DEEP_COPY REVIEW - DEVICE-TO-HOSTMIRROR
+  Kokkos::deep_copy(XS(), batches_per_lid_h, batches_per_lid);
 
   auto batch_info_h = Kokkos::create_mirror_view(host_space, batch_info);
 
   (void) compute_batch_info(batches_per_lid_h, batch_info_h);
-  Kokkos::deep_copy(batch_info, batch_info_h);
+  // DEEP_COPY REVIEW - HOSTMIRROR-TO-DEVICE
+  Kokkos::deep_copy(XS(), batch_info, batch_info_h);
 
   // FIXME (TJF SEP 2017)
   // The scalar type is not necessarily default constructible
@@ -1437,6 +1439,7 @@ unpackAndCombineIntoCrsArrays (
     const Teuchos::ArrayView<const int>& SourcePids,
     Teuchos::Array<int>& TargetPids)
 {
+  using execution_space = typename Node::execution_space;
   using Tpetra::Details::PackTraits;
 
   using Kokkos::View;
@@ -1592,20 +1595,23 @@ unpackAndCombineIntoCrsArrays (
   // Copy outputs back to host
   typename decltype(crs_rowptr_d)::HostMirror crs_rowptr_h(
       CRS_rowptr.getRawPtr(), CRS_rowptr.size());
-  deep_copy(crs_rowptr_h, crs_rowptr_d);
+  // DEEP_COPY REVIEW - DEVICE-TO-HOSTMIRROR
+  deep_copy(execution_space(), crs_rowptr_h, crs_rowptr_d);
 
   typename decltype(crs_colind_d)::HostMirror crs_colind_h(
       CRS_colind.getRawPtr(), CRS_colind.size());
-  deep_copy(crs_colind_h, crs_colind_d);
+  // DEEP_COPY REVIEW - DEVICE-TO-HOSTMIRROR
+  deep_copy(execution_space(), crs_colind_h, crs_colind_d);
 
   typename decltype(crs_vals_d)::HostMirror crs_vals_h(
       CRS_vals.getRawPtr(), CRS_vals.size());
-  deep_copy(crs_vals_h, crs_vals_d);
+  // DEEP_COPY REVIEW - DEVICE-TO-HOSTMIRROR
+  deep_copy(execution_space(), crs_vals_h, crs_vals_d);
 
   typename decltype(tgt_pids_d)::HostMirror tgt_pids_h(
       TargetPids.getRawPtr(), TargetPids.size());
-  deep_copy(tgt_pids_h, tgt_pids_d);
-
+  // DEEP_COPY REVIEW - DEVICE-TO-HOSTMIRROR
+  deep_copy(execution_space(), tgt_pids_h, tgt_pids_d);
 }
 
 } // namespace Details

--- a/packages/tpetra/core/src/Tpetra_Map_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Map_def.hpp
@@ -699,7 +699,9 @@ namespace Tpetra {
         View<GO*, LayoutLeft, device_type>
           nonContigGids (view_alloc ("nonContigGids", WithoutInitializing),
                          nonContigGids_host.size ());
-        Kokkos::deep_copy (nonContigGids, nonContigGids_host);
+        // DEEP_COPY REVIEW - HOST-TO-DEVICE
+        Kokkos::deep_copy (execution_space(), nonContigGids, nonContigGids_host);
+        Kokkos::fence(); // for UVM issues below - which will be refatored soon so FixedHashTable can build as pure CudaSpace - then I think remove this fence
 
         // FixedHashTable currently cannot be built on CudaSpace due to UVM
         // dependence so copy back to device_type (CudaUVMSpace).
@@ -738,7 +740,8 @@ namespace Tpetra {
       }
 
       // We filled lgMap on host above; now sync back to device.
-      Kokkos::deep_copy (lgMap, lgMap_host);
+      // DEEP_COPY REVIEW - HOST-TO-DEVICE
+      Kokkos::deep_copy (execution_space(), lgMap, lgMap_host);
 
       // "Commit" the local-to-global lookup table we filled in above.
       lgMap_ = lgMap;
@@ -1043,8 +1046,9 @@ namespace Tpetra {
       View<GO*, array_layout, Kokkos::HostSpace> entryList_host
         (view_alloc ("entryList_host", WithoutInitializing),
          entryList.extent(0));
-      Kokkos::deep_copy (entryList_host, entryList);
-
+      // DEEP_COPY REVIEW - DEVICE-TO-HOST
+      Kokkos::deep_copy (execution_space(), entryList_host, entryList);
+      Kokkos::fence(); // UVM follows
       firstContiguousGID_ = entryList_host[0];
       lastContiguousGID_ = firstContiguousGID_+1;
 
@@ -1132,7 +1136,8 @@ namespace Tpetra {
       }
 
       // We filled lgMap on host above; now sync back to device.
-      Kokkos::deep_copy (lgMap, lgMap_host);
+      // DEEP_COPY REVIEW - HOST-TO-DEVICE
+      Kokkos::deep_copy (execution_space(), lgMap, lgMap_host);
 
       // "Commit" the local-to-global lookup table we filled in above.
       lgMap_ = lgMap;
@@ -1727,7 +1732,8 @@ namespace Tpetra {
 
       auto lgMapHost =
         Kokkos::create_mirror_view (Kokkos::HostSpace (), lgMap);
-      Kokkos::deep_copy (lgMapHost, lgMap);
+      // DEEP_COPY REVIEW - DEVICE-TO-HOST
+      Kokkos::deep_copy (execution_space(), lgMapHost, lgMap);
 
       // "Commit" the local-to-global lookup table we filled in above.
       lgMap_ = lgMap;

--- a/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_decl.hpp
@@ -1604,6 +1604,7 @@ namespace Tpetra {
          const ViewType& dots) const {
       const Kokkos::View<dot_type*, Kokkos::HostSpace> h_dots("Tpetra::Dots",dots.extent(0));
       this->dot (A, h_dots);
+      // DEEP_COPY REVIEW - NOT TESTED
       Kokkos::deep_copy(dots,h_dots);
     }
 
@@ -1635,6 +1636,7 @@ namespace Tpetra {
       // std::complex conversions, but those two implementations
       // should generally be bitwise compatible.
       // CT: no this can't possible work .....
+      // DEEP_COPY REVIEW - NOT TESTED
       Kokkos::deep_copy (dots, dts);
     }
 
@@ -1733,7 +1735,8 @@ namespace Tpetra {
       using host_norms_view_type = Kokkos::View<mag_type*, Kokkos::HostSpace>;
       host_norms_view_type h_norms ("Tpetra::MV::h_norms", norms.extent (0));
       this->norm1 (h_norms);
-      Kokkos::deep_copy (norms, h_norms);
+      // DEEP_COPY REVIEW - HOST-TO-DEVICE
+      Kokkos::deep_copy (execution_space(), norms, h_norms);
     }
 
     /// \brief Compute the one-norm of each vector (column), storing
@@ -1764,6 +1767,7 @@ namespace Tpetra {
       // Sacado and Stokhos packages are likely to care about this use
       // case.  It could also come up with Kokkos::complex ->
       // std::complex conversion.
+      // DEEP_COPY REVIEW - NOT TESTED
       Kokkos::deep_copy (norms, tmpNorms);
     }
 
@@ -1825,6 +1829,7 @@ namespace Tpetra {
       using host_norms_view_type = Kokkos::View<mag_type*, Kokkos::HostSpace>;
       host_norms_view_type h_norms ("Tpetra::MV::h_norms", norms.extent (0));
       this->norm2 (h_norms);
+      // DEEP_COPY REVIEW - NOT TESTED
       Kokkos::deep_copy (norms, h_norms);
     }
 
@@ -1854,6 +1859,7 @@ namespace Tpetra {
       // Sacado and Stokhos packages are likely to care about this use
       // case.  This could also come up with Kokkos::complex ->
       // std::complex conversion.
+      // DEEP_COPY REVIEW - NOT TESTED
       Kokkos::deep_copy (norms, theNorms);
     }
 
@@ -1908,7 +1914,8 @@ namespace Tpetra {
       using host_norms_view_type = Kokkos::View<mag_type*, Kokkos::HostSpace>;
       host_norms_view_type h_norms ("Tpetra::MV::h_norms", norms.extent (0));
       this->normInf (h_norms);
-      Kokkos::deep_copy (norms, h_norms);
+      // DEEP_COPY REVIEW - HOST-TO-DEVICE
+      Kokkos::deep_copy (execution_space(), norms, h_norms);
     }
 
     /// \brief Compute the infinity-norm of each vector (column),
@@ -1937,6 +1944,7 @@ namespace Tpetra {
       // Sacado and Stokhos packages are likely to care about this use
       // case.  This could also come up with Kokkos::complex ->
       // std::complex conversion.
+      // DEEP_COPY REVIEW - NOT TESTED
       Kokkos::deep_copy (norms, theNorms);
     }
 

--- a/packages/tpetra/core/src/Tpetra_Util.hpp
+++ b/packages/tpetra/core/src/Tpetra_Util.hpp
@@ -919,6 +919,7 @@ namespace Tpetra {
     {
       using Kokkos::MemoryUnmanaged;
       typedef typename DT::memory_space DMS;
+      typedef typename DT::execution_space execution_space;
       typedef Kokkos::HostSpace HMS;
 
       const size_t len = static_cast<size_t> (x_av.size ());
@@ -926,11 +927,13 @@ namespace Tpetra {
       Kokkos::DualView<T*, DT> x_out (label, len);
       if (leaveOnHost) {
         x_out.modify_host ();
+        // DEEP_COPY REVIEW - NOT TESTED FOR CUDA BUILD
         Kokkos::deep_copy (x_out.view_host (), x_in);
       }
       else {
         x_out.template modify<DMS> ();
-        Kokkos::deep_copy (x_out.template view<DMS> (), x_in);
+        // DEEP_COPY REVIEW - HOST-TO-DEVICE
+        Kokkos::deep_copy (execution_space(), x_out.template view<DMS> (), x_in);
       }
       return x_out;
     }

--- a/packages/tpetra/core/src/Tpetra_computeRowAndColumnOneNorms_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_computeRowAndColumnOneNorms_def.hpp
@@ -127,6 +127,8 @@ computeLocalRowScaledColumnNorms_RowMatrix (EquilibrationInfo<typename Kokkos::A
   using mag_type = typename KAT::mag_type;
 
   auto rowNorms_h = Kokkos::create_mirror_view (result.rowNorms);
+
+  // DEEP_COPY REVIEW - NOT TESTED
   Kokkos::deep_copy (rowNorms_h, result.rowNorms);
   auto rowScaledColNorms_h = Kokkos::create_mirror_view (result.rowScaledColNorms);
 
@@ -143,6 +145,8 @@ computeLocalRowScaledColumnNorms_RowMatrix (EquilibrationInfo<typename Kokkos::A
         rowScaledColNorms_h[lclCol] += matrixAbsVal / rowNorm;
       }
     });
+
+  // DEEP_COPY REVIEW - NOT TESTED
   Kokkos::deep_copy (result.rowScaledColNorms, rowScaledColNorms_h);
 }
 

--- a/packages/tpetra/core/src/Tpetra_createDeepCopy_CrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_createDeepCopy_CrsMatrix_def.hpp
@@ -17,6 +17,7 @@ template<class SC, class LO, class GO, class NT>
 typename CrsMatrix<SC, LO, GO, NT>::local_matrix_type
 localDeepCopyFillCompleteCrsMatrix (const CrsMatrix<SC, LO, GO, NT>& A)
 {
+  using execution_space = typename NT::execution_space;
   using Kokkos::view_alloc;
   using Kokkos::WithoutInitializing;
   using crs_matrix_type = CrsMatrix<SC, LO, GO, NT>;
@@ -28,19 +29,23 @@ localDeepCopyFillCompleteCrsMatrix (const CrsMatrix<SC, LO, GO, NT>& A)
   using inds_type = typename local_graph_type::entries_type;
   inds_type ind (view_alloc ("ind", WithoutInitializing),
                  A_lcl.graph.entries.extent (0));
-  Kokkos::deep_copy (ind, A_lcl.graph.entries);
+
+  // DEEP_COPY REVIEW - DEVICE-TO-DEVICE
+  Kokkos::deep_copy (execution_space(), ind, A_lcl.graph.entries);
 
   using offsets_type =
     typename local_graph_type::row_map_type::non_const_type;
   offsets_type ptr (view_alloc ("ptr", WithoutInitializing),
                     A_lcl.graph.row_map.extent (0));
-  Kokkos::deep_copy (ptr, A_lcl.graph.row_map);
+
+  // DEEP_COPY REVIEW - DEVICE-TO-DEVICE
+  Kokkos::deep_copy (execution_space(), ptr, A_lcl.graph.row_map);
 
   using values_type = typename local_matrix_type::values_type;
   values_type val (view_alloc ("val", WithoutInitializing),
                    A_lcl.values.extent (0));
-  Kokkos::deep_copy (val, A_lcl.values);
-
+  // DEEP_COPY REVIEW - DEVICE-TO-DEVICE
+  Kokkos::deep_copy (execution_space(), val, A_lcl.values);
   local_graph_type lclGraph (ind, ptr);
   const size_t numCols = A.getColMap ()->getNodeNumElements ();
   return local_matrix_type (A.getObjectLabel (), numCols, val, lclGraph);

--- a/packages/tpetra/core/src/kokkos_refactor/Tpetra_KokkosRefactor_Details_MultiVectorDistObjectKernels.hpp
+++ b/packages/tpetra/core/src/kokkos_refactor/Tpetra_KokkosRefactor_Details_MultiVectorDistObjectKernels.hpp
@@ -245,6 +245,8 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
         // array.  Performance doesn't matter since we are already in
         // an error state, so we can do this sequentially, on host.
         auto idx_h = Kokkos::create_mirror_view (idx);
+
+        // DEEP_COPY REVIEW - NOT TESTED
         Kokkos::deep_copy (idx_h, idx);
 
         std::vector<index_type> badIndices;
@@ -421,6 +423,8 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
         // array.  Performance doesn't matter since we are already in
         // an error state, so we can do this sequentially, on host.
         auto idx_h = Kokkos::create_mirror_view (idx);
+
+        // DEEP_COPY REVIEW - NOT TESTED
         Kokkos::deep_copy (idx_h, idx);
 
         std::vector<index_type> badIndices;
@@ -623,6 +627,8 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
         // row indices.  Performance doesn't matter since we are already
         // in an error state, so we can do this sequentially, on host.
         auto idx_h = Kokkos::create_mirror_view (idx);
+
+        // DEEP_COPY REVIEW - NOT TESTED
         Kokkos::deep_copy (idx_h, idx);
 
         std::vector<row_index_type> badRows;
@@ -657,6 +663,8 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
         // Go back and find any out-of-bounds entries in the array
         // of column indices.
         auto col_h = Kokkos::create_mirror_view (col);
+
+        // DEEP_COPY REVIEW - NOT TESTED
         Kokkos::deep_copy (col_h, col);
 
         std::vector<col_index_type> badCols;
@@ -1021,6 +1029,8 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
         // array.  Performance doesn't matter since we are already in
         // an error state, so we can do this sequentially, on host.
         auto idx_h = Kokkos::create_mirror_view (idx);
+
+        // DEEP_COPY REVIEW - NOT TESTED
         Kokkos::deep_copy (idx_h, idx);
 
         std::vector<index_type> badIndices;
@@ -1350,6 +1360,8 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
         // already in an error state, so we can do this sequentially,
         // on host.
         auto idx_h = Kokkos::create_mirror_view (idx);
+
+        // DEEP_COPY REVIEW - NOT TESTED
         Kokkos::deep_copy (idx_h, idx);
 
         std::vector<row_index_type> badRows;
@@ -1385,6 +1397,8 @@ outOfBounds (const IntegerType x, const IntegerType exclusiveUpperBound)
         // Go back and find any out-of-bounds entries in the array
         // of column indices.
         auto col_h = Kokkos::create_mirror_view (col);
+
+        // DEEP_COPY REVIEW - NOT TESTED
         Kokkos::deep_copy (col_h, col);
 
         std::vector<col_index_type> badCols;

--- a/packages/tpetra/core/src/kokkos_refactor/Tpetra_KokkosRefactor_Details_MultiVectorLocalDeepCopy.hpp
+++ b/packages/tpetra/core/src/kokkos_refactor/Tpetra_KokkosRefactor_Details_MultiVectorLocalDeepCopy.hpp
@@ -84,6 +84,8 @@ copyConvertResolvingPossibleAliasing (const DstViewType& dst,
     // allocate.  Hopefully users aren't doing aliased copies in a
     // tight loop.
     auto src_copy = Kokkos::create_mirror (Kokkos::HostSpace (), src);
+
+    // DEEP_COPY REVIEW - NOT TESTED
     Kokkos::deep_copy (src_copy, src);
     ::Tpetra::Details::copyConvert (dst, src_copy);
   }

--- a/packages/tpetra/core/test/MatrixMatrix/FECrs_MatrixMatrix_UnitTests.cpp
+++ b/packages/tpetra/core/test/MatrixMatrix/FECrs_MatrixMatrix_UnitTests.cpp
@@ -278,6 +278,9 @@ bool compare_matrices (const Tpetra::CrsMatrix<ST,LO,GO,NT>& A,
   const LO invLO = Teuchos::OrdinalTraits<LO>::invalid();
   const auto& colMapA = *gA.getColMap();
   const auto& colMapB = *gB.getColMap();
+
+  Kokkos::fence(); // must protect UVM access
+
   for (LO irow=0; irow<num_my_rows; ++irow) {
     const GO grow = gA.getRowMap()->getGlobalElement(irow);
 


### PR DESCRIPTION
Note: This PR passed on white's Pascal node with CUDA_LAUNCH_BLOCKING off. However it needs further review. Specifically any deep_copy which potentially has HostSpace on one side and CudaSpace or CudaUVMSpace on the other side can be a failure point since nothing will be protecting access to the host data after the async deep_copy.

Since the tests are all passing it's likely that many of these are fine but the logic of each needs to be checked. 

The PR also adds some comments to identify the kind of deep_copy:
```
DEVICE - means CudaSpace, CudaUVMSpace, or HostSpace - depends on the setup
HOSTMIRROR - means CudaUVMSpace or HostSpace - depending on what was mirrored.
HOST - always means HostSpace
```

@trilinos/tpetra 

