### PR TITLE
Teko: Fix tests to run on ride/white

### DIFF
--- a/packages/teko/tests/testdriver.cpp
+++ b/packages/teko/tests/testdriver.cpp
@@ -106,11 +106,11 @@ void gdbIn()
 int main(int argc,char * argv[])
 {
    bool status = false;
-   Kokkos::initialize(argc,argv);
 
    {
      // calls MPI_Init and MPI_Finalize
      Teuchos::GlobalMPISession mpiSession(&argc,&argv);
+     Kokkos::initialize(argc,argv);
 
      // build MPI/Serial communicator
      #ifdef HAVE_MPI

--- a/packages/teko/tests/testdriver_tpetra.cpp
+++ b/packages/teko/tests/testdriver_tpetra.cpp
@@ -108,13 +108,13 @@ void gdbIn()
 int main(int argc,char * argv[])
 {
    bool status = false;
-   Kokkos::initialize(argc,argv);
 
    { 
      // need to protect kokkos and MPI
      // calls MPI_Init and MPI_Finalize
      Teuchos::GlobalMPISession mpiSession(&argc,&argv);
-  
+     Kokkos::initialize(argc,argv);
+
      // build MPI/Serial communicators
      #ifdef HAVE_MPI
         Epetra_MpiComm Comm_epetra(MPI_COMM_WORLD);


### PR DESCRIPTION
@rppawlo I was cleaning up and checking Teko as a dependence of Panzer. This is the same issue as the Panzer examples we just merged.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/teko 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Some Teko tests would not pass on ride/white due to Kokkos::initialize out of order with the GlobalMPISession.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Teko tests for CUDA build on white
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->