### PR TITLE
Teko: fix tests cuda launch blocking off

### DIFF
--- a/packages/teko/src/Teko_Utilities.cpp
+++ b/packages/teko/src/Teko_Utilities.cpp
@@ -696,6 +696,7 @@ ModifiableLinearOp getAbsRowSumMatrix(const LinearOp & op)
 
      // compute absolute value row sum
      diag.putScalar(0.0);
+     diag.sync_host(); // UVM read of getLocalRowView
      for(LO i=0;i<(LO) tCrsOp->getNodeNumRows();i++) {
         LO numEntries = tCrsOp->getNumEntriesInLocalRow (i); 
         std::vector<LO> indices(numEntries);
@@ -757,6 +758,7 @@ ModifiableLinearOp getAbsRowSumInvMatrix(const LinearOp & op)
 
      // compute absolute value row sum
      diag.putScalar(0.0);
+     diag.sync_host(); // UVM read of getLocalRowView
      for(LO i=0;i<(LO) tCrsOp->getNodeNumRows();i++) {
         LO numEntries = tCrsOp->getNumEntriesInLocalRow (i); 
         std::vector<LO> indices(numEntries);
@@ -2126,6 +2128,7 @@ double infNorm(const LinearOp & op)
 
     // compute absolute value row sum
     diag.putScalar(0.0);
+    diag.sync_host(); // UVM read of getLocalRowView
     for(LO i=0;i<(LO) tCrsOp->getNodeNumRows();i++) {
        LO numEntries = tCrsOp->getNumEntriesInLocalRow (i);
        std::vector<LO> indices(numEntries);


### PR DESCRIPTION
Resolves Teko to pass with CUDA_LAUNCH_BLOCKING=0

@rppawlo This gets Teko passing with launch blocking off and also resolves that one panzer example that was failing. We may want to refactor this code as a kernel in the next phase when we remove UVM usage.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/teko 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Get Teko passing with CUDA_LAUNCH_BOCKING=0

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Teko tests on white CUDA build
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->