### PR TITLE
Fix CDash test output truncation for ATDM Trilinos builds

### DIFF
--- a/cmake/tribits/ReleaseNotes.txt
+++ b/cmake/tribits/ReleaseNotes.txt
@@ -6,7 +6,7 @@ Release Notes for TriBITS
 
 (*) MINOR: The variables <Package>_FORTRAN_COMPILER and
     <Package>_FORTRAN_FLAGS in the <Package>Config.cmake files (in the build
-    dir and the install dir) are deprecated.  Plese use the new varibles
+    dir and the install dir) are deprecated.  Please use the new variables
     <Package>_Fortran_COMPILER and <Package>_Fortran_FLAGS.  (Justification:
     In raw CMake, the compiler is called 'Fortran', not 'FORTRAN'.  Also, the
     name 'Fortran' is already used in the <Project>Config.cmake file.)

--- a/cmake/tribits/ctest_driver/TribitsCTestDriverCore.cmake
+++ b/cmake/tribits/ctest_driver/TribitsCTestDriverCore.cmake
@@ -1013,15 +1013,15 @@ INCLUDE(${CMAKE_CURRENT_LIST_DIR}/TribitsCTestDriverCoreHelpers.cmake)
 #
 #     Determines the model for build.  This value is passed in as the first
 #     argument to the built-in CTest function ``CTEST_START()``.  Valid values
-#     include ``Nightly``, ``Continuous``, and ``Experimental``.  As far a
+#     include ``Nightly``, ``Continuous``, and ``Experimental``.  As far as
 #     CTest is concerned, the only real impact this CTest "Model" has is on
-#     setting the time stamp in the build stamp (which is stored in the file
-#     ``Testing/TAG``).  For the model ``Nightly``, the time stamp in the
+#     setting the time stamp in the build stamp field (which is stored in the
+#     file ``Testing/TAG``).  For the model ``Nightly``, the time stamp in the
 #     build stamp is taken from the variable ``CTEST_NIGHTLY_START_TIME`` read
 #     in from the file `<projectDir>/CTestConfig.cmake`_ file.  Otherwise, the
 #     time stamp used is the current build start time.  (The reason this is
 #     significant is that builds on CDash that have the same site, buildname,
-#     and buildstamp are considered the same build and will combine results.)
+#     and build stamp are considered the same build and will combine results.)
 #     This also defines the default value for `${PROJECT_NAME}_TRACK`_ (see
 #     below) as well as defines the default value for
 #     ``${PROJECT_NAME}_ENABLE_KNOWN_EXTERNAL_REPOS_TYPE``.  The default value
@@ -1039,11 +1039,10 @@ INCLUDE(${CMAKE_CURRENT_LIST_DIR}/TribitsCTestDriverCoreHelpers.cmake)
 #     However, if ``CTEST_TEST_TYPE==Experimental`` (or ``EXPERIMENTAL``),
 #     then ``${PROJECT_NAME}_TRACK`` is forced to ``Experimental``, even if it
 #     was set to a different value.  The default value can also be set in the
-#     ctest -S driver script itself by setting by setting
-#     ``SET(${PROJECT_NAME}_TRACK <cdash-group>)``.  And, of course, if the
-#     environment variable ``export <Project>_TRACK=<cdash-group>`` is set,
-#     then that value will be used for the CDash Track/Group to submit results
-#     to.
+#     ctest -S driver script itself by setting ``SET(${PROJECT_NAME}_TRACK
+#     <cdash-group>)``.  And, of course, if the environment variable ``export
+#     <Project>_TRACK=<cdash-group>`` is set, then that value will be used for
+#     the CDash Track/Group to submit results to.
 #
 #   .. _CTEST_SITE:
 #

--- a/cmake/tribits/ctest_driver/TribitsCTestDriverCore.cmake
+++ b/cmake/tribits/ctest_driver/TribitsCTestDriverCore.cmake
@@ -354,7 +354,7 @@ INCLUDE(${CMAKE_CURRENT_LIST_DIR}/TribitsCTestDriverCoreHelpers.cmake)
 # * ``${PROJECT_NAME}_REPOSITORY_BRANCH`` (`Repository Updates (TRIBITS_CTEST_DRIVER())`_)
 # * ``${PROJECT_NAME}_REPOSITORY_LOCATION`` (`Repository Updates (TRIBITS_CTEST_DRIVER())`_)
 # * ``${PROJECT_NAME}_SKIP_CTEST_ADD_TEST`` (`Determining what testing-related actions are performed (TRIBITS_CTEST_DRIVER())`_)
-# * ``${PROJECT_NAME}_TESTING_TRACK`` (`Determining how the results are displayed on CDash (TRIBITS_CTEST_DRIVER())`_)
+# * ``${PROJECT_NAME}_TRACK`` (`Determining how the results are displayed on CDash (TRIBITS_CTEST_DRIVER())`_)
 # * ``${PROJECT_NAME}_TRIBITS_DIR`` (`Source and Binary Directory Locations (TRIBITS_CTEST_DRIVER())`_)
 # * ``${PROJECT_NAME}_VERBOSE_CONFIGURE`` (`Other CTest Driver options (TRIBITS_CTEST_DRIVER())`_)
 # * ``COMPILER_VERSION`` (`Determining how the results are displayed on CDash (TRIBITS_CTEST_DRIVER())`_)
@@ -1004,31 +1004,46 @@ INCLUDE(${CMAKE_CURRENT_LIST_DIR}/TribitsCTestDriverCoreHelpers.cmake)
 # and other results and submitted and displayed on CDash (but not what CDash
 # site(s) or project(s) they are submitted to).  These options can all be set
 # in the CTest -S script using ``SET()`` statements before
-# ``TRIBITS_CTEST_DRIVER()`` is called and can be overridden in the env.
+# ``TRIBITS_CTEST_DRIVER()`` is called and can be overridden in the env when
+# running the CTest -S driver script.
 #
 #   .. _CTEST_TEST_TYPE:
 #
 #   ``CTEST_TEST_TYPE=[Nightly|Continuous|Experimental]``
 #
-#     Determines the type of build.  This value is passed in as the first
+#     Determines the model for build.  This value is passed in as the first
 #     argument to the built-in CTest function ``CTEST_START()``.  Valid values
-#     include ``Nightly``, ``Continuous``, and ``Experimental``.  This also
-#     defines the default value for `${PROJECT_NAME}_TESTING_TRACK`_ as well
-#     as defines the default value for
+#     include ``Nightly``, ``Continuous``, and ``Experimental``.  As far a
+#     CTest is concerned, the only real impact this CTest "Model" has is on
+#     setting the time stamp in the build stamp (which is stored in the file
+#     ``Testing/TAG``).  For the model ``Nightly``, the time stamp in the
+#     build stamp is taken from the variable ``CTEST_NIGHTLY_START_TIME`` read
+#     in from the file `<projectDir>/CTestConfig.cmake`_ file.  Otherwise, the
+#     time stamp used is the current build start time.  (The reason this is
+#     significant is that builds on CDash that have the same site, buildname,
+#     and buildstamp are considered the same build and will combine results.)
+#     This also defines the default value for `${PROJECT_NAME}_TRACK`_ (see
+#     below) as well as defines the default value for
 #     ``${PROJECT_NAME}_ENABLE_KNOWN_EXTERNAL_REPOS_TYPE``.  The default value
 #     is ``Experimental``.
 #
-#   .. _${PROJECT_NAME}_TESTING_TRACK:
+#   .. _${PROJECT_NAME}_TRACK:
 #
-#   ``${PROJECT_NAME}_TESTING_TRACK=<track-name>``
+#   ``${PROJECT_NAME}_TRACK=<cdash-group>``
 #
-#     Specifies the testing track on CDash for which results are displayed
-#     under (i.e. the "Group" filter field on CDash).  This is the value used
-#     for the ``TRACK`` argument of the built-in CTest function
-#     ``CTEST_START()``.  It is given the default value of
-#     ``${CTEST_TEST_TYPE}``.  However, if ``CTEST_TEST_TYPE==Experimental``
-#     (or ``EXPERIMENTAL``), then ``${PROJECT_NAME}_TESTING_TRACK`` is forced
-#     to ``Experimental``, even if it was set to a different value.
+#     Specifies the testing track that specifies the CDash group for which
+#     results are displayed under (i.e. the "Group" filter field on CDash).
+#     This is the value used for the (deprecated) ``TRACK`` argument (renamed
+#     ``GROUP`` in CMake/CTest versions 3.16+) of the built-in CTest function
+#     ``CTEST_START()``.  The default value is set to ``${CTEST_TEST_TYPE}``.
+#     However, if ``CTEST_TEST_TYPE==Experimental`` (or ``EXPERIMENTAL``),
+#     then ``${PROJECT_NAME}_TRACK`` is forced to ``Experimental``, even if it
+#     was set to a different value.  The default value can also be set in the
+#     ctest -S driver script itself by setting by setting
+#     ``SET(${PROJECT_NAME}_TRACK <cdash-group>)``.  And, of course, if the
+#     environment variable ``export <Project>_TRACK=<cdash-group>`` is set,
+#     then that value will be used for the CDash Track/Group to submit results
+#     to.
 #
 #   .. _CTEST_SITE:
 #

--- a/cmake/tribits/ctest_driver/TribitsCTestDriverCoreHelpers.cmake
+++ b/cmake/tribits/ctest_driver/TribitsCTestDriverCoreHelpers.cmake
@@ -1019,6 +1019,10 @@ MACRO(TRIBITS_CTEST_PACKAGE_BY_PACKAGE)
 
     ENDIF()
 
+    # Print out values read from project CTestCustom.cmake file!
+    PRINT_VAR(CTEST_CUSTOM_MAXIMUM_PASSED_TEST_OUTPUT_SIZE)
+    PRINT_VAR(CTEST_CUSTOM_MAXIMUM_FAILED_TEST_OUTPUT_SIZE)
+
     #
     # C) Build the library and then ALL
     #
@@ -1368,10 +1372,6 @@ MACRO(TRIBITS_CTEST_ALL_AT_ONCE)
     ELSE()
       MESSAGE("Configure PASSED!")
       SET(AAO_CONFIGURE_PASSED TRUE)
-      # Load target properties and test keywords
-      CTEST_READ_CUSTOM_FILES(BUILD "${CTEST_BINARY_DIRECTORY}")
-      # Overridde from this file!
-      INCLUDE("${TRIBITS_PROJECT_ROOT}/CTestConfig.cmake")
     ENDIF()
 
     IF (AAO_CONFIGURE_PASSED)
@@ -1397,6 +1397,19 @@ MACRO(TRIBITS_CTEST_ALL_AT_ONCE)
     ENDIF()
 
   ENDIF()
+
+  # Read in configured CTestCustom.cmake
+  CTEST_READ_CUSTOM_FILES(BUILD "${CTEST_BINARY_DIRECTORY}")
+  # NOTE: Above, it is safe to call CTEST_READ_CUSTOM_FILES() even if the
+  # configure failed and the file CTestCustom.cmake does exist.  In this case,
+  # CTest will just do nothing.
+
+  # Overridde any values by loading <projectDir>/CTestConfig.cmake
+  INCLUDE("${TRIBITS_PROJECT_ROOT}/CTestConfig.cmake")
+
+  # Print out values read from project CTestCustom.cmake file
+  PRINT_VAR(CTEST_CUSTOM_MAXIMUM_PASSED_TEST_OUTPUT_SIZE)
+  PRINT_VAR(CTEST_CUSTOM_MAXIMUM_FAILED_TEST_OUTPUT_SIZE)
 
   #
   # C) Do the build

--- a/cmake/tribits/doc/developers_guide/TribitsDevelopersGuide.rst
+++ b/cmake/tribits/doc/developers_guide/TribitsDevelopersGuide.rst
@@ -6304,6 +6304,41 @@ The following steps describe how to submit results to a CDash site using the
   .. the other cloned and updated by the CTest driver script.
 
 
+How to submit testing results to a custom CDash Group
+-----------------------------------------------------
+
+Following up on `How to submit testing results to a CDash site`_, to submit
+build and test results to a custom "Group" on CDash (instead of just
+"Nightly", "Continuous" or "Experimental"), one just has to create the new
+group on CDash using the CDash GUI interface and then tell the ctest -S local
+driver to submit results to that CDash group.  The steps for doing this are
+given below.
+
+1) Create the new CDash group ``<special_group>`` for CDash project
+``<ProjectName>`` on the targeted CDash site.
+
+  If the CDash group ``<special_group>`` is not already created, then one can
+  create it by first logging into CDash with an account that can modify the
+  CDash project ``<ProjectName>``.  Once logged in, go to the project edit
+  page and select "Settings" and "Groups".  From there, create the new group
+  ``<special_group>``.  Set the "Build Type" to either "Daily" or "Latest".
+
+2) Set ``${PROJECT_NAME}_TRACK=<special_group>`` with the CTest -S driver
+script.
+
+  One can either do that by setting ``SET(${PROJECT_NAME}_TRACK
+  <special_group>)`` in the CTest -S ``*.cmake`` driver script itself or can
+  set it in the environment when running the ctest -S driver script.  For
+  example::
+
+    $ env <Project>_TRACK=<special_group> ... \
+      ctest -V -S <ctest_driver>.cmake
+
+  If the "build type" for the CDash group ``<special_group>`` was set to
+  "Daily", then set `CTEST_TEST_TYPE`_ to ``Nightly``.  Otherwise,
+  ``CTEST_TEST_TYPE`` can be set to ``Continuous`` or ``Experimental``.
+
+
 Additional Topics
 =================
 
@@ -6581,8 +6616,8 @@ One can also change what compilers are written into the generated
 ``<Project>Config.cmake`` and ``<Package>Config.cmake`` files for the build
 and the install trees.  By default, the compilers pointed to in these
 ``Config.cmake`` files will be ``CMAKE_<LANG>_COMPILER`` where ``<LANG>`` =
-``CXX``, ``C``, and ``Fortran``.  But if can change this by setting any of the
-following::
+``CXX``, ``C``, and ``Fortran``.  But if one can change this by setting any of
+the following::
 
   SET(CMAKE_CXX_COMPILER_FOR_CONFIG_FILE_BUILD_DIR <path>)
   SET(CMAKE_C_COMPILER_FOR_CONFIG_FILE_BUILD_DIR <path>)
@@ -6596,7 +6631,7 @@ CMake cache using, for example,
 ``-DCMAKE_CXX_COMPILER_FOR_CONFIG_FILE_INSTALL_DIR:FILEPATH=<path>``.
 
 This is used, for example, when compiler wrappers are used for the build tree
-and are set to ``CMAKE_<LANG>_COMPILER`` but when one wants to point the
+and are set to ``CMAKE_<LANG>_COMPILER`` but when one wants to point to the
 original underlying compilers for the installed ``Config.cmake`` files.
 
 

--- a/cmake/tribits/doc/developers_guide/TribitsDevelopersGuide.rst
+++ b/cmake/tribits/doc/developers_guide/TribitsDevelopersGuide.rst
@@ -6314,29 +6314,29 @@ group on CDash using the CDash GUI interface and then tell the ctest -S local
 driver to submit results to that CDash group.  The steps for doing this are
 given below.
 
-1) Create the new CDash group ``<special_group>`` for CDash project
-``<ProjectName>`` on the targeted CDash site.
+1. Create the new CDash group ``<special_group>`` for CDash project
+   ``<ProjectName>`` on the targeted CDash site.
 
-  If the CDash group ``<special_group>`` is not already created, then one can
-  create it by first logging into CDash with an account that can modify the
-  CDash project ``<ProjectName>``.  Once logged in, go to the project edit
-  page and select "Settings" and "Groups".  From there, create the new group
-  ``<special_group>``.  Set the "Build Type" to either "Daily" or "Latest".
+   If the CDash group ``<special_group>`` is not already created, then one can
+   create it by first logging into CDash with an account that can modify the
+   CDash project ``<ProjectName>``.  Once logged in, go to the project edit
+   page and select "Settings" and "Groups".  From there, create the new group
+   ``<special_group>``.  Set the "Build Type" to either "Daily" or "Latest".
 
-2) Set ``${PROJECT_NAME}_TRACK=<special_group>`` with the CTest -S driver
-script.
+2. Set ``${PROJECT_NAME}_TRACK=<special_group>`` with the CTest -S driver
+   script.
 
-  One can either do that by setting ``SET(${PROJECT_NAME}_TRACK
-  <special_group>)`` in the CTest -S ``*.cmake`` driver script itself or can
-  set it in the environment when running the ctest -S driver script.  For
-  example::
-
-    $ env <Project>_TRACK=<special_group> ... \
-      ctest -V -S <ctest_driver>.cmake
-
-  If the "build type" for the CDash group ``<special_group>`` was set to
-  "Daily", then set `CTEST_TEST_TYPE`_ to ``Nightly``.  Otherwise,
-  ``CTEST_TEST_TYPE`` can be set to ``Continuous`` or ``Experimental``.
+   One can either do that by setting ``SET(${PROJECT_NAME}_TRACK
+   <special_group>)`` in the CTest -S ``*.cmake`` driver script itself or can
+   set it in the environment when running the ctest -S driver script.  For
+   example::
+ 
+     $ env <Project>_TRACK=<special_group> ... \
+       ctest -V -S <ctest_driver>.cmake
+ 
+   If the "build type" for the CDash group ``<special_group>`` was set to
+   "Daily", then set `CTEST_TEST_TYPE`_ to ``Nightly``.  Otherwise,
+   ``CTEST_TEST_TYPE`` can be set to ``Continuous`` or ``Experimental``.
 
 
 Additional Topics
@@ -6616,8 +6616,8 @@ One can also change what compilers are written into the generated
 ``<Project>Config.cmake`` and ``<Package>Config.cmake`` files for the build
 and the install trees.  By default, the compilers pointed to in these
 ``Config.cmake`` files will be ``CMAKE_<LANG>_COMPILER`` where ``<LANG>`` =
-``CXX``, ``C``, and ``Fortran``.  But if one can change this by setting any of
-the following::
+``CXX``, ``C``, and ``Fortran``, but one can change this by setting any of the
+following::
 
   SET(CMAKE_CXX_COMPILER_FOR_CONFIG_FILE_BUILD_DIR <path>)
   SET(CMAKE_C_COMPILER_FOR_CONFIG_FILE_BUILD_DIR <path>)
@@ -6633,7 +6633,6 @@ CMake cache using, for example,
 This is used, for example, when compiler wrappers are used for the build tree
 and are set to ``CMAKE_<LANG>_COMPILER`` but when one wants to point to the
 original underlying compilers for the installed ``Config.cmake`` files.
-
 
 
 RPATH Handling

--- a/cmake/tribits/examples/TribitsExampleProject/cmake/ctest/CTestCustom.cmake.in
+++ b/cmake/tribits/examples/TribitsExampleProject/cmake/ctest/CTestCustom.cmake.in
@@ -1,5 +1,9 @@
-# Allow full output to go to CDash
-SET(CTEST_CUSTOM_MAXIMUM_PASSED_TEST_OUTPUT_SIZE 0)
-SET(CTEST_CUSTOM_MAXIMUM_FAILED_TEST_OUTPUT_SIZE 0)
-# WARNING!  This could be a lot of output and could overwhelm CDash and the
-# MySQL DB so this might not be a good idea!
+# Increase the amount of output being produced
+SET(CTEST_CUSTOM_MAXIMUM_PASSED_TEST_OUTPUT_SIZE 54321)
+SET(CTEST_CUSTOM_MAXIMUM_FAILED_TEST_OUTPUT_SIZE 123456)
+# NOTE: Above, we use these numbers to make it easy to determine that these
+# values are getting read correctly in various modes of running
+# tribits_ctest_driver().  In a real project, you could set something like:
+#
+#   SET(CTEST_CUSTOM_MAXIMUM_PASSED_TEST_OUTPUT_SIZE 50000)
+#   SET(CTEST_CUSTOM_MAXIMUM_FAILED_TEST_OUTPUT_SIZE 5000000)

--- a/cmake/tribits/python_utils/gitdist-setup.sh
+++ b/cmake/tribits/python_utils/gitdist-setup.sh
@@ -40,7 +40,7 @@ SCRIPT_DIR=`echo $BASH_SOURCE | sed "s/\(.*\)\/.*\.sh/\1/g"`
 
 existing_gitdist=`which gitdist 2> /dev/null`
 if [[ "${existing_gitdist}" == "" ]] ; then
-  echo "Setting alias gitdist=${SCRIPT_DIR}/gitdist"
+  #echo "Setting alias gitdist=${SCRIPT_DIR}/gitdist"
   alias gitdist=${SCRIPT_DIR}/gitdist
 fi
 

--- a/cmake/tribits/python_utils/gitdist-setup.sh
+++ b/cmake/tribits/python_utils/gitdist-setup.sh
@@ -40,7 +40,6 @@ SCRIPT_DIR=`echo $BASH_SOURCE | sed "s/\(.*\)\/.*\.sh/\1/g"`
 
 existing_gitdist=`which gitdist 2> /dev/null`
 if [[ "${existing_gitdist}" == "" ]] ; then
-  #echo "Setting alias gitdist=${SCRIPT_DIR}/gitdist"
   alias gitdist=${SCRIPT_DIR}/gitdist
 fi
 


### PR DESCRIPTION
This pulls in the TriBITS changes shown at:

* https://github.com/TriBITSPub/TriBITS/compare/6165385bda2cb968e036530f9718bbcecbef704f..d953bd2620f1c94e22b96a977797758e45396c0a?expand=1

The addresses TriBITSPub/TriBITS#326  and https://github.com/TriBITSPub/TriBITS/commit/990ebeeb60be76433c64888cc508937c314f51ca and otherwise little other issues.  See the list of commits at:

* https://github.com/TriBITSPub/TriBITS/commits/d953bd2620f1c94e22b96a977797758e45396c0a

after the commit https://github.com/TriBITSPub/TriBITS/commit/6165385bda2cb968e036530f9718bbcecbef704f.

Merging this will give us full build stats for platforms like 'ats2' and 'cts1' as part of #7376 and #7508.

## How was this tested?

The TriBITS test suite was run and 100% passed (see evidence in commit https://github.com/TriBITSPub/TriBITS/commit/d953bd2620f1c94e22b96a977797758e45396c0a).
