### PR TITLE
Zoltan2: Fix directory tests to run on ride/white with pascal node

### DIFF
--- a/packages/zoltan2/test/core/directory/directoryTest_Impl.hpp
+++ b/packages/zoltan2/test/core/directory/directoryTest_Impl.hpp
@@ -1389,9 +1389,6 @@ class TestManager {
 // gid lists for update, remove, find, as well as the user data and associated
 // lids after running find.
 int runDirectoryTests(int narg, char **arg) {
-
-  Kokkos::initialize(narg, arg);
-
 #ifndef HAVE_MPI
   // TODO what is cleanest way to support a serial test case?
   // We still have some non Teuchos MPI calls in the directory and this works
@@ -1400,6 +1397,7 @@ int runDirectoryTests(int narg, char **arg) {
 #endif
 
   Teuchos::GlobalMPISession mpiSession(&narg,&arg);
+  Kokkos::initialize(narg, arg);
   Teuchos::RCP<const Teuchos::Comm<int> > comm =
     Teuchos::DefaultComm<int>::getComm();
 

--- a/packages/zoltan2/test/core/directory/directoryTest_KokkosSimple.cpp
+++ b/packages/zoltan2/test/core/directory/directoryTest_KokkosSimple.cpp
@@ -492,8 +492,6 @@ int test_multiple_lid(Teuchos::RCP<const Teuchos::Comm<int> > comm) {
 }
 
 int main(int narg, char **arg) {
-  Kokkos::initialize(narg, arg);
-
 #ifndef HAVE_MPI
   // TODO what is cleanest way to support a serial test case?
   // We still have some non Teuchos MPI calls in the directory and this works
@@ -502,6 +500,7 @@ int main(int narg, char **arg) {
 #endif
 
   Teuchos::GlobalMPISession mpiSession(&narg,&arg);
+  Kokkos::initialize(narg, arg);
   Teuchos::RCP<const Teuchos::Comm<int> > comm =
     Teuchos::DefaultComm<int>::getComm();
 

--- a/packages/zoltan2/test/core/directory/directoryTest_findUniqueGids.cpp
+++ b/packages/zoltan2/test/core/directory/directoryTest_findUniqueGids.cpp
@@ -417,8 +417,6 @@ void test4(Teuchos::RCP<const Teuchos::Comm<int> > &comm)
 
 int main(int argc, char *argv[])
 {
-  Kokkos::initialize(argc, argv);
-
 #ifndef HAVE_MPI
   // TODO what is cleanest way to support a serial test case?
   // We still have some non Teuchos MPI calls in the directory and this works
@@ -427,6 +425,7 @@ int main(int argc, char *argv[])
 #endif
 
   Teuchos::GlobalMPISession mpiSession(&argc,&argv);
+  Kokkos::initialize(argc, argv);
   Teuchos::RCP<const Teuchos::Comm<int> > comm =
     Teuchos::DefaultComm<int>::getComm();
 


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/zoltan2 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Fix directory tests to run on white Cuda for Pascal nodes
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
white Cuda build

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->