### PR TITLE
MueLu: region structured unstructured interface aggregate fix

### DIFF
--- a/packages/muelu/src/Graph/HybridAggregation/MueLu_HybridAggregationFactory_def.hpp
+++ b/packages/muelu/src/Graph/HybridAggregation/MueLu_HybridAggregationFactory_def.hpp
@@ -496,7 +496,7 @@ namespace MueLu {
       for(int dim = 0; dim < 3; ++dim) {
         numInterfaceNodes *= fineNodesPerDim[dim];
         numCoarseNodes    *= coarseNodesPerDim[dim];
-        endRate[dim]       = fineNodesPerDim[dim] % coarseRate[dim];
+        endRate[dim]       = (fineNodesPerDim[dim]-1) % coarseRate[dim];
       }
       ArrayView<LO> interfaceNodes = nodesOnInterfaces(interfaceOffset, numInterfaceNodes);
 
@@ -554,9 +554,6 @@ namespace MueLu {
             rate = endRate[dim];
           }
           if(rem > (rate / 2)) {++coarseIJK[dim];}
-          if(coarseNodesPerDim[dim] - coarseIJK[dim] > fineNodesPerDim[dim]-nodeIJK[dim]){
-            ++coarseIJK[dim];
-          }
         }
 
         for(LO dim = 0; dim < 3; ++dim) {

--- a/packages/muelu/src/Smoothers/MueLu_TrilinosSmoother_def.hpp
+++ b/packages/muelu/src/Smoothers/MueLu_TrilinosSmoother_def.hpp
@@ -195,7 +195,7 @@ namespace MueLu {
       s_ = (useTpetra ? sTpetra_ : sEpetra_);
       if (s_.is_null()) {
         if (useTpetra) {
-#if not defined(HAVE_MUELU_IFPACK22)
+#if not defined(HAVE_MUELU_IFPACK2)
           TEUCHOS_TEST_FOR_EXCEPTION(true, Exceptions::RuntimeError,
                                      "Error: running in Tpetra mode, but MueLu with Ifpack2 was disabled during the configure stage.\n"
                                      "Please make sure that:\n"


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/muelu 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Fixes the interface aggregation for region structured-unstructured to allow for any structured coarsening rate. Before only a structured coarsening rate of 2 or 3 was supported.

Also fixes a typo in MueLu_TrilinosSmoother_def.hpp concerning a debugging message for Ifpack2.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Passes the region structured-unstructured tests.



## Additional Information

The typo in MueLu_TrilinosSmoother_def.hpp came up in a build with both Epetra and Tpetra enabled related to rppawlo/DrekarBase#468

<!--- 
Anything else we need to know in evaluating this merge request?
 -->