### PR TITLE
Tpetra: Fix initialize tests to call Kokkos::finalize

### DIFF
--- a/packages/tpetra/core/test/Core/ScopeGuard_user_inits_mpi.cpp
+++ b/packages/tpetra/core/test/Core/ScopeGuard_user_inits_mpi.cpp
@@ -181,6 +181,8 @@ void testMain (bool& success, int argc, char* argv[])
   }
 
   (void) MPI_Finalize ();
+
+  Kokkos::finalize ();
 }
 
 class CaptureOstream {

--- a/packages/tpetra/core/test/Core/initialize_user_inits_mpi.cpp
+++ b/packages/tpetra/core/test/Core/initialize_user_inits_mpi.cpp
@@ -179,6 +179,8 @@ void testMain (bool& success, int argc, char* argv[])
   }
 
   (void) MPI_Finalize ();
+
+  Kokkos::finalize();
 }
 
 class CaptureOstream {


### PR DESCRIPTION
These tests would have this output error:
Kokkos::Cuda ERROR: Failed to call Kokkos::Cuda::finalize()

If user called Kokkos::initialize user should also call Kokkos::finalize.
This will resolve the tests so they do not generate the above output.

Note this is not a pass/fail issue.
The test was passing but just had the error showing up in the log.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
This came up while doing some work to clean up these tests to pass for CUDA_LAUNCH_BLOCKING=0.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Cuda white Pascal Tpetra unit tests

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->