### PR TITLE
Tpetra: Fix initialize tests for Pascal node on ride/white

### DIFF
--- a/packages/tpetra/core/test/Core/ScopeGuard_tpetra_inits_mpi_user_inits_kokkos.cpp
+++ b/packages/tpetra/core/test/Core/ScopeGuard_tpetra_inits_mpi_user_inits_kokkos.cpp
@@ -89,6 +89,10 @@ void testMain (bool& success, int argc, char* argv[])
       "before Kokkos::initialize was called." << endl;
     return;
   }
+
+  { // GlobalMPISession is in local scope so we can check MPI_Finalize
+
+  Teuchos::GlobalMPISession mpiSession(&argc, &argv); // before Kokkos::initialize
   Kokkos::initialize (argc, argv);
   if (! Kokkos::is_initialized ()) {
     success = false;
@@ -162,13 +166,16 @@ void testMain (bool& success, int argc, char* argv[])
   if (myRank == 0) {
     cout << "Left Tpetra scope" << endl;
   }
-  // Since Tpetra::ScopeGuard's destructor was responsible for calling
-  // MPI_Finalize, the destructor MUST have called MPI_Finalize.
-  if (! isMpiFinalized ()) {
+
+  // Tpetra::ScopeGuard's destructor is not responsible for calling
+  // MPI_Finalize because GlobalMPISession was called first.
+  if (isMpiFinalized ()) {
     success = false;
-    cout << "Tpetra::ScopeGuard::~ScopeGuard did not call MPI_Finalize."
+    cout << "Tpetra::ScopeGuard::~ScopeGuard called MPI_Finalize "
+         << "but should not have since GlobalMPISession controlled it."
          << endl;
   }
+
   // Kokkos is like Tpetra; Kokkos::is_initialized() means "was
   // initialized and was not finalized."  That differs from MPI, where
   // MPI_Initialized only refers to MPI_Init and MPI_Finalized only
@@ -194,6 +201,16 @@ void testMain (bool& success, int argc, char* argv[])
     success = false;
     cout << "Kokkos::is_initialized() is false "
       "even after calling Kokkos::finalize." << endl;
+  }
+
+  } // end of GlobalMPISession scope
+
+  // Since GlobalMPISession's destructor was responsible for calling
+  // MPI_Finalize, the destructor MUST have called MPI_Finalize.
+  if (! isMpiFinalized ()) {
+    success = false;
+    cout << "GlobalMPISession::~GlobalMPISession did not call MPI_Finalize."
+         << endl;
   }
 }
 

--- a/packages/tpetra/core/test/Core/ScopeGuard_user_inits_kokkos.cpp
+++ b/packages/tpetra/core/test/Core/ScopeGuard_user_inits_kokkos.cpp
@@ -18,6 +18,8 @@ void testMain (bool& success, int argc, char* argv[])
       "even before Kokkos::initialize was called." << endl;
     return;
   }
+
+  Teuchos::GlobalMPISession mpiSession(&argc, &argv); // before Kokkos::initialize
   Kokkos::initialize (argc, argv);
   if (! Kokkos::is_initialized ()) {
     success = false;

--- a/packages/tpetra/core/test/Core/initialize_user_inits_kokkos.cpp
+++ b/packages/tpetra/core/test/Core/initialize_user_inits_kokkos.cpp
@@ -18,6 +18,8 @@ void testMain (bool& success, int argc, char* argv[])
       "even before Kokkos::initialize was called." << endl;
     return;
   }
+
+  Teuchos::GlobalMPISession mpiSession(&argc, &argv); // before Kokkos::initialize
   Kokkos::initialize (argc, argv);
   if (! Kokkos::is_initialized ()) {
     success = false;


### PR DESCRIPTION
@kddevin @csiefer2 I'd like to get the test suite all passing on white for the Pascal node with CUDA_LAUNCH_BLOCKING=0. The last thing remaining is to fix these Tpetra initialization tests. The first thing to resolve is that some don't pass on Pascal nodes for white, unrelated to the CUDA_LAUNCH_BLOCKING=0 issue.

The issue is that MPI is not setup before Kokkos::initialize in some cases.
I have been fixing other tests which have the same problem.

This PR is a working solution where I added a GlobalMPISession before the Kokkos::initialize. But then the GlobalMPISession is the part that actually calls MPI_Finalize, not say Tpetra:ScopeGuard.

I'm not sure we want to make changes like this though. Perhaps some of these tests have patterns which we don't really want to support anyways. Or perhaps we want to find a way so Kokkos can be 'updated' even if MPI inits after the Kokkos::initialize call. I hope this PR can be a discussion starter for this.

I also don't fully understand the underlying issue here. In Tpetra copyConvert.cpp we have this comment and code:
```
  // Initialize MPI (if enabled) before initializing Kokkos.  This
  // lets MPI control things like pinning processes to sockets.
  Teuchos::GlobalMPISession mpiSession (&argc, &argv);
  Kokkos::initialize (argc, argv);
```
So that I presume is why these are segfaulting when they are not setup in the right order. I could spend time to look into those details further.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Get the initialization tpetra tests to work on white's Pascal nodes.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->



## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Cuda white pascal unit tests for tpetra

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->