### PR TITLE
Xpetra: fix documentation

### DIFF
--- a/packages/xpetra/src/Utils/Xpetra_Parameters.hpp
+++ b/packages/xpetra/src/Utils/Xpetra_Parameters.hpp
@@ -80,10 +80,12 @@ namespace Xpetra {
       const char*           optionNames [maxOptions];  // Array that gives the name used in the commandline for each option.
 
       std::stringstream documentation; // documentation for the option
-      documentation << "linear algebra library (Epetra, Tpetra)";
+      //documentation << "linear algebra library (Epetra, Tpetra)";
+      documentation << "linear algebra library (";
 
       // Default is Tpetra if available. If not, default is Epetra
 #if defined(HAVE_XPETRA_EPETRA)
+      documentation << "Epetra";
       lib_ = Xpetra::UseEpetra; // set default (if Tpetra support is missing)
       optionValues[nOptions] = Xpetra::UseEpetra;
       //optionValues[nOptions] = "epetra"; //TODO: do not break compatibility right now
@@ -91,12 +93,17 @@ namespace Xpetra {
       nOptions++;
 #endif
 #if defined(HAVE_XPETRA_TPETRA)
+#  if defined(HAVE_XPETRA_EPETRA)
+      documentation << ", ";
+#  endif
+      documentation << "Tpetra";
       lib_ = Xpetra::UseTpetra; // set default
       optionValues[nOptions] = Xpetra::UseTpetra;
       //optionsValues[nOptions] = "tpetra"; //TODO: do not break compatibility right now
       optionNames[nOptions] = "Tpetra";
       nOptions++;
 #endif
+      documentation << ")";
 
       clp.setOption<Xpetra::UnderlyingLib>("linAlgebra", &lib_, nOptions, optionValues, optionNames, documentation.str().c_str());
 


### PR DESCRIPTION
@trilinos/xpetra 

Previously, --help showed Epetra and Tpetra as valid --linAlgebra
options, even if Epetra was disabled in Xpetra.  Now Epetra will
show as a valid "linAlgebra" option only if Epetra is enabled.

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/trilinos/trilinos/7970)
<!-- Reviewable:end -->
