### PR TITLE
Tpetra: Convert deep_copy to output view type exec space to use 3-arg

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_allReduceView.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_allReduceView.hpp
@@ -176,6 +176,7 @@ allReduceView (const OutputViewType& output,
   // contiguous buffer.  We use a host buffer for that, since device
   // buffers are slow to allocate.
 
+  using execution_space = typename OutputViewType::execution_space;
   const bool viewsAlias = output.data () == input.data ();
   if (comm.getSize () == 1) {
     if (! viewsAlias) {
@@ -220,7 +221,7 @@ allReduceView (const OutputViewType& output,
     // ValueType instances.
     allReduceRawContiguous (output_tmp.data (), input_tmp.data (),
                             output_tmp.span (), comm);
-    Kokkos::deep_copy (output, output_tmp);
+    Kokkos::deep_copy (execution_space(), output, output_tmp);
   }
   else {
     allReduceRawContiguous (output.data (), input.data (),

--- a/packages/tpetra/core/src/Tpetra_Details_copyConvert.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_copyConvert.hpp
@@ -283,7 +283,8 @@ namespace { // (anonymous)
         Kokkos::deep_copy (dst, src_copy);
       }
       else { // no aliasing
-        Kokkos::deep_copy (dst, src);
+        using execution_space = typename OutputViewType::execution_space;
+        Kokkos::deep_copy (execution_space(), dst, src);
       }
     }
   };

--- a/packages/tpetra/core/src/Tpetra_Details_copyOffsets.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_copyOffsets.hpp
@@ -387,7 +387,8 @@ namespace { // (anonymous)
                      "CopyOffsetsImpl (implementation of copyOffsets): In order"
                      " to call this specialization, src and dst must have the "
                      "the same array_layout.");
-      Kokkos::deep_copy (dst, src);
+      using execution_space = typename OutputViewType::execution_space;
+      Kokkos::deep_copy (execution_space(), dst, src);
     }
   };
 
@@ -495,16 +496,16 @@ namespace { // (anonymous)
           Kokkos::LayoutLeft, typename OutputViewType::device_type>;
       using Kokkos::view_alloc;
       using Kokkos::WithoutInitializing;
+      using execution_space = typename OutputViewType::execution_space;
       output_space_copy_type
         outputSpaceCopy (view_alloc ("outputSpace", WithoutInitializing),
                          src.extent (0));
-      Kokkos::deep_copy (outputSpaceCopy, src);
+      Kokkos::deep_copy (execution_space(), outputSpaceCopy, src);
 
       // The output View's execution space can access
       // outputSpaceCopy's data, so we can run the functor now.
       using functor_type =
         CopyOffsetsFunctor<OutputViewType, output_space_copy_type>;
-      using execution_space = typename OutputViewType::execution_space;
       using size_type = typename OutputViewType::size_type;
       using range_type = Kokkos::RangePolicy<execution_space, size_type>;
 


### PR DESCRIPTION
@csiefer2 These are cases where I get the execution space from the output view. I am not certain if this is always what we want. In some of these cases we could have device-to-host. Would we potentially want to queue device-to-host deep_copy on the device execution space in some cases and would we want user to control that?

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Convert deep_copy to 3-arg forms
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Cuda on white pascal node - Tpetra unit tests

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->