### PR TITLE
Adjust runKernelOnHost threshold

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_Behavior.cpp
+++ b/packages/tpetra/core/src/Tpetra_Details_Behavior.cpp
@@ -418,7 +418,7 @@ bool Behavior::useMergePathMultiVector()
   size_t Behavior::multivectorKernelLocationThreshold ()
 {
   constexpr char envVarName[] = "TPETRA_VECTOR_DEVICE_THRESHOLD";
-  constexpr size_t defaultValue (10000);
+  constexpr size_t defaultValue (22000);
 
   static size_t value_ = defaultValue;
   static bool initialized_ = false;

--- a/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_MultiVector_def.hpp
@@ -351,7 +351,7 @@ namespace { // (anonymous)
       return false; // most up-to-date on device
     }
     else { // most up-to-date on host
-      constexpr size_t localLengthThreshold = 10000;
+      size_t localLengthThreshold = Tpetra::Details::Behavior::multivectorKernelLocationThreshold();
       return X.getLocalLength () <= localLengthThreshold;
     }
   }


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
This adjustment is based on experimental observations of kernel behaviors on vortex.  The performance inflection point between running on host and device is about 22,000.

## Related Issues

* Follows https://github.com/trilinos/Trilinos/pull/7387

## Testing
This touches nothing that isn't already unit-tested.

Experimental data, using thresholds of 0 and 1,000,000,000:
<img width="1024" alt="xoverpoint" src="https://user-images.githubusercontent.com/12186471/92282729-79530380-eebb-11ea-9fe9-bc99c4d5bc9e.png">
