### PR TITLE
Stokhos: Add 3-arg deep_copy specializations.

### DIFF
--- a/packages/stokhos/src/sacado/kokkos/pce/KokkosExp_View_UQ_PCE_Contiguous.hpp
+++ b/packages/stokhos/src/sacado/kokkos/pce/KokkosExp_View_UQ_PCE_Contiguous.hpp
@@ -187,6 +187,20 @@ void deep_copy( const View<DT,DP...> & dst ,
               , Kokkos::Experimental::Impl::ViewPCEContiguous >::value
                   )>::type * = 0 );
 
+/* Specialize for deep copy of UQ::PCE */
+template< class ExecSpace, class DT , class ... DP , class ST , class ... SP >
+inline
+void deep_copy( const ExecSpace &,
+                const View<DT,DP...> & dst ,
+                const View<ST,SP...> & src
+  , typename std::enable_if<(
+  std::is_same< typename ViewTraits<DT,DP...>::specialize
+              , Kokkos::Experimental::Impl::ViewPCEContiguous >::value
+  &&
+  std::is_same< typename ViewTraits<ST,SP...>::specialize
+              , Kokkos::Experimental::Impl::ViewPCEContiguous >::value
+                  )>::type * = 0 );
+
 template <typename T, typename ... P>
 struct is_view_uq_pce< View<T,P...> > {
   typedef View<T,P...> view_type;
@@ -643,6 +657,153 @@ void deep_copy( const View<DT,DP...> & dst ,
         tmp_dst_array_type dst_array = dst_tmp ;
         tmp_src_array_type src_array = src_tmp ;
         deep_copy( dst_array , src_array );
+        Experimental::Impl::DeepCopyNonContiguous< dst_type , tmp_dst_type >( dst , dst_tmp );
+      }
+    }
+  }
+}
+
+template< class ExecSpace, class DT , class ... DP , class ST , class ... SP >
+inline
+void deep_copy( const ExecSpace &,
+                const View<DT,DP...> & dst ,
+                const View<ST,SP...> & src
+  , typename std::enable_if<(
+  std::is_same< typename ViewTraits<DT,DP...>::specialize
+              , Kokkos::Experimental::Impl::ViewPCEContiguous >::value
+  &&
+  std::is_same< typename ViewTraits<ST,SP...>::specialize
+              , Kokkos::Experimental::Impl::ViewPCEContiguous >::value
+  )>::type * )
+{
+  static_assert(
+    std::is_same< typename ViewTraits<DT,DP...>::value_type ,
+                  typename ViewTraits<DT,DP...>::non_const_value_type >::value
+    , "Deep copy destination must be non-const" );
+
+  static_assert(
+    ( unsigned(ViewTraits<DT,DP...>::rank) ==
+      unsigned(ViewTraits<ST,SP...>::rank) )
+    , "Deep copy destination and source must have same rank" );
+
+  typedef View<DT,DP...> dst_type ;
+  typedef View<ST,SP...> src_type ;
+  typedef typename dst_type::array_type dst_array_type ;
+  typedef typename src_type::array_type src_array_type ;
+
+  if ( is_allocation_contiguous(dst) && is_allocation_contiguous(src) ) {
+    dst_array_type dst_array = dst ;
+    src_array_type src_array = src ;
+    deep_copy( ExecSpace(), dst_array , src_array );
+  }
+
+  // otherwise, use a custom kernel
+  else {
+
+    // If views are in the same memory space, copy component-wise
+    if ( std::is_same< typename dst_type::memory_space ,
+                        typename src_type::memory_space >::value ) {
+      Experimental::Impl::DeepCopyNonContiguous< dst_type , src_type >( dst , src );
+    }
+
+    else {
+
+      typedef View< typename src_type::non_const_data_type ,
+                    typename src_type::array_layout ,
+                    typename src_type::execution_space > tmp_src_type;
+      typedef typename tmp_src_type::array_type tmp_src_array_type;
+      typedef View< typename dst_type::non_const_data_type ,
+                    typename dst_type::array_layout ,
+                    typename dst_type::execution_space > tmp_dst_type;
+      typedef typename tmp_dst_type::array_type tmp_dst_array_type;
+
+      // Copy src into a contiguous view in src's memory space,
+      // then copy to dst
+      if (  is_allocation_contiguous(dst) &&
+           !is_allocation_contiguous(src) ) {
+        size_t src_dims[8];
+        //src.dimensions(src_dims);
+        src_dims[0] = src.extent(0);
+        src_dims[1] = src.extent(1);
+        src_dims[2] = src.extent(2);
+        src_dims[3] = src.extent(3);
+        src_dims[4] = src.extent(4);
+        src_dims[5] = src.extent(5);
+        src_dims[6] = src.extent(6);
+        src_dims[7] = src.extent(7);
+        src_dims[src_type::Rank] = dimension_scalar(src);
+        tmp_src_type src_tmp(
+          view_alloc("src_tmp" , WithoutInitializing, cijk(src) ) ,
+          src_dims[0], src_dims[1], src_dims[2], src_dims[3],
+          src_dims[4], src_dims[5], src_dims[6], src_dims[7] );
+        Experimental::Impl::DeepCopyNonContiguous< tmp_src_type , src_type >( src_tmp , src );
+        dst_array_type dst_array = dst ;
+        tmp_src_array_type src_array = src_tmp ;
+        deep_copy( ExecSpace(), dst_array , src_array );
+      }
+
+      // Copy src into a contiguous view in dst's memory space,
+      // then copy to dst
+      else if ( !is_allocation_contiguous(dst) &&
+                 is_allocation_contiguous(src) ) {
+        size_t dst_dims[8];
+        //dst.dimensions(dst_dims);
+        dst_dims[0] = dst.extent(0);
+        dst_dims[1] = dst.extent(1);
+        dst_dims[2] = dst.extent(2);
+        dst_dims[3] = dst.extent(3);
+        dst_dims[4] = dst.extent(4);
+        dst_dims[5] = dst.extent(5);
+        dst_dims[6] = dst.extent(6);
+        dst_dims[7] = dst.extent(7);
+        dst_dims[dst_type::Rank] = dimension_scalar(dst);
+        tmp_dst_type dst_tmp(
+          view_alloc("dst_tmp" , WithoutInitializing, cijk(dst) ) ,
+          dst_dims[0], dst_dims[1], dst_dims[2], dst_dims[3],
+          dst_dims[4], dst_dims[5], dst_dims[6], dst_dims[7] );
+        tmp_dst_array_type dst_array = dst_tmp ;
+        src_array_type src_array = src ;
+        deep_copy( ExecSpace(), dst_array , src_array );
+        Experimental::Impl::DeepCopyNonContiguous< dst_type , tmp_dst_type >( dst , dst_tmp );
+      }
+
+      // Copy src into a contiguous view in src's memory space,
+      // copy to a continugous view in dst's memory space, then copy to dst
+      else {
+        size_t src_dims[8];
+        //src.dimensions(src_dims);
+        src_dims[0] = src.extent(0);
+        src_dims[1] = src.extent(1);
+        src_dims[2] = src.extent(2);
+        src_dims[3] = src.extent(3);
+        src_dims[4] = src.extent(4);
+        src_dims[5] = src.extent(5);
+        src_dims[6] = src.extent(6);
+        src_dims[7] = src.extent(7);
+        src_dims[src_type::Rank] = dimension_scalar(src);
+        tmp_src_type src_tmp(
+          view_alloc("src_tmp" , WithoutInitializing, cijk(src) ) ,
+          src_dims[0], src_dims[1], src_dims[2], src_dims[3],
+          src_dims[4], src_dims[5], src_dims[6], src_dims[7] );
+        Experimental::Impl::DeepCopyNonContiguous< tmp_src_type , src_type >( src_tmp , src );
+        size_t dst_dims[8];
+        //dst.dimensions(dst_dims);
+        dst_dims[0] = dst.extent(0);
+        dst_dims[1] = dst.extent(1);
+        dst_dims[2] = dst.extent(2);
+        dst_dims[3] = dst.extent(3);
+        dst_dims[4] = dst.extent(4);
+        dst_dims[5] = dst.extent(5);
+        dst_dims[6] = dst.extent(6);
+        dst_dims[7] = dst.extent(7);
+        dst_dims[dst_type::Rank] = dimension_scalar(dst);
+        tmp_dst_type dst_tmp(
+          view_alloc("dst_tmp" , WithoutInitializing, cijk(dst) ) ,
+          dst_dims[0], dst_dims[1], dst_dims[2], dst_dims[3],
+          dst_dims[4], dst_dims[5], dst_dims[6], dst_dims[7] );
+        tmp_dst_array_type dst_array = dst_tmp ;
+        tmp_src_array_type src_array = src_tmp ;
+        deep_copy( ExecSpace(), dst_array , src_array );
         Experimental::Impl::DeepCopyNonContiguous< dst_type , tmp_dst_type >( dst , dst_tmp );
       }
     }

--- a/packages/stokhos/src/sacado/kokkos/vector/KokkosExp_View_MP_Vector_Contiguous.hpp
+++ b/packages/stokhos/src/sacado/kokkos/vector/KokkosExp_View_MP_Vector_Contiguous.hpp
@@ -198,6 +198,20 @@ void deep_copy( const View<DT,DP...> & dst ,
               , Kokkos::Experimental::Impl::ViewMPVectorContiguous >::value
     )>::type * = 0 );
 
+/* Specialize for deep copy of MP::Vector */
+template< class ExecSpace, class DT , class ... DP , class ST , class ... SP >
+inline
+void deep_copy( const ExecSpace &,
+                const View<DT,DP...> & dst ,
+                const View<ST,SP...> & src
+  , typename std::enable_if<(
+  std::is_same< typename ViewTraits<DT,DP...>::specialize
+              , Kokkos::Experimental::Impl::ViewMPVectorContiguous >::value
+  &&
+  std::is_same< typename ViewTraits<ST,SP...>::specialize
+              , Kokkos::Experimental::Impl::ViewMPVectorContiguous >::value
+    )>::type * = 0 );
+
 } // namespace Kokkos
 
 //----------------------------------------------------------------------------
@@ -418,6 +432,47 @@ void deep_copy( const View<DT,DP...> & dst ,
   //   typename View<ST,SP...>::array_type( src ) );
 
   Kokkos::deep_copy(
+    typename FlatArrayType< View<DT,DP...> >::type( dst ) ,
+    typename FlatArrayType< View<ST,SP...> >::type( src ) );
+}
+
+/* Specialize for deep copy of MP::Vector */
+template< class ExecSpace, class DT , class ... DP , class ST , class ... SP >
+inline
+void deep_copy( const ExecSpace &,
+                const View<DT,DP...> & dst ,
+                const View<ST,SP...> & src
+  , typename std::enable_if<(
+  std::is_same< typename ViewTraits<DT,DP...>::specialize
+              , Kokkos::Experimental::Impl::ViewMPVectorContiguous >::value
+  &&
+  std::is_same< typename ViewTraits<ST,SP...>::specialize
+              , Kokkos::Experimental::Impl::ViewMPVectorContiguous >::value
+  )>::type * )
+{
+  static_assert(
+    std::is_same< typename ViewTraits<DT,DP...>::value_type ,
+                  typename ViewTraits<DT,DP...>::non_const_value_type >::value
+    , "Deep copy destination must be non-const" );
+
+  static_assert(
+    ( unsigned(ViewTraits<DT,DP...>::rank) ==
+      unsigned(ViewTraits<ST,SP...>::rank) )
+    , "Deep copy destination and source must have same rank" );
+
+  // Note ETP 09/29/2016:  Use FlatArrayType instead of array_type to work
+  // around issue where dst and src are rank-1, but have differing layouts.
+  // Kokkos' deep_copy() doesn't work in this case because the array_type
+  // will be rank-2.  It should be possible to make deep_copy() work there,
+  // but this seems easier.
+
+  // Kokkos::deep_copy(
+  //   ExecSpace() ,
+  //   typename View<DT,DP...>::array_type( dst ) ,
+  //   typename View<ST,SP...>::array_type( src ) );
+
+  Kokkos::deep_copy(
+    ExecSpace() ,
     typename FlatArrayType< View<DT,DP...> >::type( dst ) ,
     typename FlatArrayType< View<ST,SP...> >::type( src ) );
 }


### PR DESCRIPTION
@csiefer2 @kddevin Just FYI

@etphipp Adds 3-arg deep_copy specializations for Stokhos. This is needed for current work to refactor Tpetra to use 3-arg deep_copy. (#7975 #7971 for example).

2 questions for this:

(1) I duplicated a chunk of code which is not desirable. I can fix this but wanted to get some rough guidance from you first how you'd like this organized. If we accept this PR I could work on fixing that and proceed with Tpetra work in parallel.

(2) I see some other 3-arg deep_copy overloads for Stokhos don't use the ExecSpace.  For the new methods I added, I just changed all internal deep_copy calls to 3-arg using the ExecSpace. I wasn't sure if there might be reasons not to do this.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/stokhos 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Refactor Tpetra deep_copy calls to use 3-arg deep_copy.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Mac serial build and cuda white parallel build.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->