### PR TITLE
Muelu: regionMG add rebalance before coarse AMG iterations

### DIFF
--- a/packages/muelu/research/regionMG/src/SetupRegionHierarchy_def.hpp
+++ b/packages/muelu/research/regionMG/src/SetupRegionHierarchy_def.hpp
@@ -63,8 +63,6 @@
 #include <MueLu_CreateXpetraPreconditioner.hpp>
 #include <MueLu_Utilities.hpp>
 
-//#include <MueLu_RebalanceAcFactory_decl.hpp>
-//#include <MueLu_RepartitionHeuristicFactory.hpp>
 #include <MueLu_RepartitionFactory.hpp>
 #include <MueLu_Zoltan2Interface.hpp>
 
@@ -1281,6 +1279,7 @@ void vCycle(const int l, ///< ID of current level
         } else {
           RCP<const Import> rebalanceImporter = coarseSolverData->get<RCP<const Import> >("rebalanceImporter");
 
+          // TODO: These vectors could be cached to improve performance
           RCP<Vector> rebalancedRhs = VectorFactory::Build(rebalanceImporter->getTargetMap());
           RCP<Vector> rebalancedX = VectorFactory::Build(rebalanceImporter->getTargetMap(), true);
           rebalancedRhs->doImport(*compRhs, *rebalanceImporter, Xpetra::INSERT);

--- a/packages/muelu/research/regionMG/src/SetupRegionHierarchy_def.hpp
+++ b/packages/muelu/research/regionMG/src/SetupRegionHierarchy_def.hpp
@@ -1277,7 +1277,7 @@ void vCycle(const int l, ///< ID of current level
 
         // Run a single V-cycle
         if(coarseSolverRebalance==false){
-          amgHierarchy->Iterate(*compRhs, *compX, true, 1);
+          amgHierarchy->Iterate(*compRhs, *compX, 1, true);
 
         } else {
           RCP<const Import> rebalanceImporter = coarseSolverData->get<RCP<const Import> >("rebalanceImporter");
@@ -1287,7 +1287,7 @@ void vCycle(const int l, ///< ID of current level
           rebalancedRhs->doImport(*compRhs, *rebalanceImporter, Xpetra::INSERT);
           rebalancedX->doImport(*compX, *rebalanceImporter, Xpetra::INSERT);
 
-          amgHierarchy->Iterate(*rebalancedRhs, *rebalancedX, true, 1);
+          amgHierarchy->Iterate(*rebalancedRhs, *rebalancedX, 1, true);
 
           compRhs->doExport(*rebalancedRhs, *rebalanceImporter, Xpetra::INSERT);
           compX->doExport(*rebalancedX, *rebalanceImporter, Xpetra::INSERT);

--- a/packages/muelu/research/regionMG/src/SetupRegionHierarchy_def.hpp
+++ b/packages/muelu/research/regionMG/src/SetupRegionHierarchy_def.hpp
@@ -465,6 +465,7 @@ MakeCompositeDirectSolver(RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal
  */
 template<class Scalar, class LocalOrdinal, class GlobalOrdinal, class Node>
 void RebalanceCoarseCompositeOperator(const int maxRegPerProc,
+              const int rebalanceNumPartitions,
               RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& coarseCompOp,
               RCP<Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::coordinateType, LocalOrdinal, GlobalOrdinal, Node> >& compCoarseCoordinates,
               RCP<Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> >& rebalancedCompOp,
@@ -482,7 +483,7 @@ void RebalanceCoarseCompositeOperator(const int maxRegPerProc,
 
   RCP<Xpetra::Vector<GlobalOrdinal,LocalOrdinal,GlobalOrdinal,Node> > decomposition = Xpetra::VectorFactory<GlobalOrdinal,LocalOrdinal,GlobalOrdinal,Node>::Build(map, true);
 
-  const int numPartitions = 2;
+  const int numPartitions = rebalanceNumPartitions;
 
   // We build a fake level
   Level level;
@@ -972,7 +973,9 @@ void createRegionHierarchy(const int maxRegPerProc,
         RCP<Xpetra::MultiVector<typename Teuchos::ScalarTraits<Scalar>::coordinateType, LocalOrdinal, GlobalOrdinal, Node> > rebalancedCoordinates;
         RCP<const Import> rebalanceImporter;
 
+        const int rebalanceNumPartitions = coarseSolverData->get<int>("coarse rebalance num partitions");
         RebalanceCoarseCompositeOperator(maxRegPerProc,
+                                    rebalanceNumPartitions,
                                     coarseCompOp,
                                     compCoarseCoordinates,
                                     rebalancedCompOp,

--- a/packages/muelu/research/regionMG/test/structured/CMakeLists.txt
+++ b/packages/muelu/research/regionMG/test/structured/CMakeLists.txt
@@ -122,8 +122,24 @@ IF (${PACKAGE_NAME}_ENABLE_Tpetra AND ${PACKAGE_NAME}_ENABLE_Amesos2)
 
   TRIBITS_ADD_TEST(
     StructuredRegionDriver
+    NAME "Structured_Region_Star2D_AMG_CoarseSolver_coarseRepartition_Tpetra"
+    ARGS "--linAlgebra=Tpetra --xml=structured_1dof_3level.xml --matrixType=Star2D --nx=50 --ny=50 --smootherIts=2 --coarseSolverType=amg --coarseAmgXml=amg_1dof.xml --rebalance-coarse --keep-coarse-coords --numPartitions=1"
+    COMM serial mpi
+    NUM_MPI_PROCS 4
+    )
+
+  TRIBITS_ADD_TEST(
+    StructuredRegionDriver
     NAME "Structured_Region_Star2D_AMG_CoarseSolver_repartitioning_Tpetra"
     ARGS "--linAlgebra=Tpetra --xml=structured_1dof_3level.xml --matrixType=Star2D --nx=50 --ny=50 --smootherIts=2 --coarseSolverType=amg --keep-coarse-coords --coarseAmgXml=amg_1dof_rebalance.xml"
+    COMM serial mpi
+    NUM_MPI_PROCS 4
+    )
+
+  TRIBITS_ADD_TEST(
+    StructuredRegionDriver
+    NAME "Structured_Region_Star2D_AMG_CoarseSolver_coarseRepartition_repartitioning_Tpetra"
+    ARGS "--linAlgebra=Tpetra --xml=structured_1dof_3level.xml --matrixType=Star2D --nx=50 --ny=50 --smootherIts=2 --coarseSolverType=amg --keep-coarse-coords --coarseAmgXml=amg_1dof_rebalance.xml --rebalance-coarse --numPartitions=1"
     COMM serial mpi
     NUM_MPI_PROCS 4
     )
@@ -220,6 +236,14 @@ IF (${PACKAGE_NAME}_ENABLE_Tpetra AND ${PACKAGE_NAME}_ENABLE_Amesos2)
     StructuredRegionDriver
     NAME "Structured_Region_Linear_Elasticity3D_repartitioning_Tpetra"
     ARGS "--linAlgebra=Tpetra --xml=structured_linear_3dof.xml --matrixType=Elasticity3D --nx=10 --ny=10 --nz=10 --smootherIts=2 --tol=1.0e-8  --coarseSolverType=amg --keep-coarse-coords --coarseAmgXml=amg_3dof_rebalance.xml"
+    COMM serial mpi
+    NUM_MPI_PROCS 4
+    )
+
+  TRIBITS_ADD_TEST(
+    StructuredRegionDriver
+    NAME "Structured_Region_Linear_Elasticity3D_coarseRepartition_repartitioning_Tpetra"
+    ARGS "--linAlgebra=Tpetra --xml=structured_linear_3dof.xml --matrixType=Elasticity3D --nx=10 --ny=10 --nz=10 --smootherIts=2 --tol=1.0e-8  --coarseSolverType=amg --keep-coarse-coords --rebalance-coarse --numPartitions=2 --coarseAmgXml=amg_3dof_rebalance.xml"
     COMM serial mpi
     NUM_MPI_PROCS 4
     )

--- a/packages/muelu/research/regionMG/test/structured/Driver_Structured_Regions.cpp
+++ b/packages/muelu/research/regionMG/test/structured/Driver_Structured_Regions.cpp
@@ -176,7 +176,7 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
   bool        serialRandom          = false;               clp.setOption("use-serial-random", "no-use-serial-random", &serialRandom, "generate the random vector serially and then broadcast it");
   bool        keepCoarseCoords      = false;               clp.setOption("keep-coarse-coords", "no-keep-coarse-coords", &keepCoarseCoords, "keep coordinates on coarsest level of region hierarchy");
   bool        coarseSolverRebalance = false;               clp.setOption("rebalance-coarse", "no-rebalance-coarse", &coarseSolverRebalance, "rebalance before AMG coarse grid solve");
-  int         rebalanceNumPartitions = 2;                   clp.setOption("numPartitions",         &rebalanceNumPartitions, "number of partitions for rebalancing the coarse grid AMG solve");
+  int         rebalanceNumPartitions = 1;                   clp.setOption("numPartitions",         &rebalanceNumPartitions, "number of partitions for rebalancing the coarse grid AMG solve");
   std::string coarseSolverType      = "direct";            clp.setOption("coarseSolverType",      &coarseSolverType,      "Type of solver for (composite) coarse level operator (smoother | direct | amg)");
   std::string unstructured          = "{}";                clp.setOption("unstructured",          &unstructured,          "List of ranks to be treated as unstructured, e.g. {0, 2, 5}");
   std::string coarseAmgXmlFile      = "";                  clp.setOption("coarseAmgXml",          &coarseAmgXmlFile,      "Read parameters for AMG as coarse level solve from this xml file.");

--- a/packages/muelu/research/regionMG/test/structured/Driver_Structured_Regions.cpp
+++ b/packages/muelu/research/regionMG/test/structured/Driver_Structured_Regions.cpp
@@ -175,6 +175,8 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
   bool        scaleResidualHist     = true;                clp.setOption("scale", "noscale",      &scaleResidualHist,     "scaled Krylov residual history");
   bool        serialRandom          = false;               clp.setOption("use-serial-random", "no-use-serial-random", &serialRandom, "generate the random vector serially and then broadcast it");
   bool        keepCoarseCoords      = false;               clp.setOption("keep-coarse-coords", "no-keep-coarse-coords", &keepCoarseCoords, "keep coordinates on coarsest level of region hierarchy");
+  bool        coarseSolverRebalance = false;               clp.setOption("rebalance-coarse", "no-rebalance-coarse", &coarseSolverRebalance, "rebalance before AMG coarse grid solve");
+  int         rebalanceNumPartitions = 2;                   clp.setOption("numPartitions",         &rebalanceNumPartitions, "number of partitions for rebalancing the coarse grid AMG solve");
   std::string coarseSolverType      = "direct";            clp.setOption("coarseSolverType",      &coarseSolverType,      "Type of solver for (composite) coarse level operator (smoother | direct | amg)");
   std::string unstructured          = "{}";                clp.setOption("unstructured",          &unstructured,          "List of ranks to be treated as unstructured, e.g. {0, 2, 5}");
   std::string coarseAmgXmlFile      = "";                  clp.setOption("coarseAmgXml",          &coarseAmgXmlFile,      "Read parameters for AMG as coarse level solve from this xml file.");
@@ -675,6 +677,8 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
   regionInterfaceImporterPerLevel[0] = regionInterfaceImporter;
   RCP<ParameterList> coarseSolverData = rcp(new ParameterList());
   coarseSolverData->set<std::string>("coarse solver type", coarseSolverType);
+  coarseSolverData->set<bool>("coarse solver rebalance", coarseSolverRebalance);
+  coarseSolverData->set<int>("coarse rebalance num partitions", rebalanceNumPartitions);
   coarseSolverData->set<std::string>("amg xml file", coarseAmgXmlFile);
   coarseSolverData->set<std::string>("smoother xml file", coarseSmootherXMLFile);
   RCP<ParameterList> hierarchyData = rcp(new ParameterList());


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/muelu 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Following structured coarsening in the region format, each rank may only own a few dofs. Here we rebalance the coarse grid operator before constructing the coarser grid AMG hierarchy in an attempt to reduce communication.

Also, fixes the call to iterate on the coarse AMG hierarchy.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Tests have been added to the regionMG tests that utilize this rebalancing. 


## Additional Information
The number of partitions for the coarse gird repartitioning is an input (default is 1).

When more than one iteration of the coarse grid AMG iteration are used (so deviating from a V-cycle structure, and approaching the AMG as a coarse level solve), the convergence of rebalancing before building the coarse AMG is nearly identical to the converge of not rebalancing (convergence is not identical since different partitions result in different AMG iterations).