### PR TITLE
Sacado:  Allow copy-assign of ViewStorage<T,...> to ViewStorage<const T,...>

### DIFF
--- a/packages/sacado/src/mpl/Sacado_mpl_is_convertible.hpp
+++ b/packages/sacado/src/mpl/Sacado_mpl_is_convertible.hpp
@@ -30,6 +30,19 @@
 #ifndef SACADO_MPL_IS_CONVERTIBLE_HPP
 #define SACADO_MPL_IS_CONVERTIBLE_HPP
 
+#include "Sacado_ConfigDefs.h"
+
+#ifdef HAVE_SACADO_CXX11
+
+#include <type_traits>
+namespace Sacado {
+  namespace mpl {
+    using std::is_convertible;
+  }
+}
+
+#else
+
 namespace Sacado {
 
   namespace mpl {
@@ -68,5 +81,7 @@ namespace Sacado {
   }
 
 }
+
+#endif
 
 #endif // SACADO_MPL_IS_CONVERTIBLE_HPP

--- a/packages/sacado/src/new_design/Sacado_Fad_Exp_ViewStorage.hpp
+++ b/packages/sacado/src/new_design/Sacado_Fad_Exp_ViewStorage.hpp
@@ -36,6 +36,7 @@
 
 #include "Sacado_DynamicArrayTraits.hpp"
 #include "Sacado_mpl_integral_nonzero_constant.hpp"
+#include "Sacado_mpl_apply.hpp"
 
 namespace Sacado {
 
@@ -78,7 +79,10 @@ namespace Sacado {
       //! Turn ViewStorage into a meta-function class usable with mpl::apply
       template <typename TT>
       struct apply {
-        typedef ViewStorage<TT,static_length,static_stride,U> type;
+        typedef typename std::remove_cv<TT>::type non_const_TT;
+        typedef typename BaseExprType<non_const_TT>::type base_expr_TT;
+        typedef typename mpl::apply<U,base_expr_TT>::type UU;
+        typedef ViewStorage<TT,static_length,static_stride,UU> type;
       };
 
       //! Replace static derivative length

--- a/packages/sacado/src/new_design/Sacado_Fad_Exp_ViewStorage.hpp
+++ b/packages/sacado/src/new_design/Sacado_Fad_Exp_ViewStorage.hpp
@@ -104,9 +104,19 @@ namespace Sacado {
         sz_(arg_size), stride_(arg_stride), val_(arg_val), dx_(arg_dx) {}
 
       //! Copy constructor
+      /*!
+        Allow, e.g., ViewStorage<double,...>(ViewStorage<double,...>),
+        ViewStorage<const double,...>(ViewStorage<double,...>), and
+        ViewStorage<const double,...>(ViewStorage<const double,...>) but not
+        ViewStorage<double,...>(ViewStorage<const double,...>).
+      */
+      template <typename TT>
       SACADO_INLINE_FUNCTION
-      ViewStorage(const ViewStorage& x) :
-        sz_(x.sz_), stride_(x.stride_), val_(x.val_), dx_(x.dx_) {}
+      ViewStorage(
+        const ViewStorage<TT,static_length,static_stride,U>& x,
+        typename std::enable_if< std::is_same<TT,T>::value ||
+                                 std::is_same<const TT,T>::value >::type* = 0)
+        : sz_(x.sz_), stride_(x.stride_), val_(x.val_), dx_(x.dx_) {}
 
       // Move does not make sense for this storage since it is always tied to
       // some preallocated data.  Don't define move constructor so compiler will
@@ -217,6 +227,9 @@ namespace Sacado {
       }
 
     protected:
+
+      template <typename, unsigned, unsigned, typename>
+      friend class ViewStorage;
 
       //! Derivative array size
       const mpl::integral_nonzero_constant< int, static_length > sz_;


### PR DESCRIPTION
Requested by Nate Roberts.  This was only done for the new design.
Supporting this in the old design would be very painful.  Added a unit
test to verify it works.