### PR TITLE
tpetra: workaround gcc/7.2.0 bug with c++14

### DIFF
--- a/packages/tpetra/core/test/CrsMatrix/Equilibration.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/Equilibration.cpp
@@ -1395,11 +1395,13 @@ makeMatrixTestWithExplicitZeroDiag (Teuchos::FancyOStream& out,
     Kokkos::deep_copy (ptr_h, A_lcl.graph.row_map);
     auto ind_h = Kokkos::create_mirror_view (A_lcl.graph.entries);
     Kokkos::deep_copy (ind_h, A_lcl.graph.entries);
+    // Work-around gcc/7.2.0 bug
+    const int myRank_ = myRank;
 
     for (LO lclRow = 0; lclRow < lclNumRows; ++lclRow) {
       using size_type = typename decltype (A_lcl.graph)::size_type;
       for (size_type k = ptr_h[lclRow]; k < ptr_h[lclRow+1]; ++k) {
-        const val_type expectedUnscaledVal = myRank == 1 ? 0.0 : 1.0;
+        const val_type expectedUnscaledVal = myRank_ == 1 ? 0.0 : 1.0;
         const mag_type rowNorm = gblRowNorms[lclRow];
         const mag_type scalingFactor = assumeSymmetric ?
           KAM::sqrt (rowNorm) : rowNorm;
@@ -1880,15 +1882,17 @@ makeMatrixTestWithExplicitInfAndNan (Teuchos::FancyOStream& out,
     Kokkos::deep_copy (ptr_h, A_lcl.graph.row_map);
     auto ind_h = Kokkos::create_mirror_view (A_lcl.graph.entries);
     Kokkos::deep_copy (ind_h, A_lcl.graph.entries);
+    // Work-around gcc/7.2.0 bug
+    const int myRank_ = myRank;
 
     for (LO lclRow = 0; lclRow < lclNumRows; ++lclRow) {
       using size_type = typename decltype (A_lcl.graph)::size_type;
       for (size_type k = ptr_h[lclRow]; k < ptr_h[lclRow+1]; ++k) {
         val_type expectedUnscaledVal = 1.0;
-        if (myRank == 1) {
+        if (myRank_ == 1) {
           expectedUnscaledVal = NaughtyValues<val_type>::infinity ();
         }
-        else if (myRank == 2) {
+        else if (myRank_ == 2) {
           expectedUnscaledVal = NaughtyValues<val_type>::quiet_NaN ();
         }
         const mag_type rowNorm = gblRowNorms[lclRow];

--- a/packages/tpetra/core/test/CrsMatrix/Equilibration.cpp
+++ b/packages/tpetra/core/test/CrsMatrix/Equilibration.cpp
@@ -1395,7 +1395,8 @@ makeMatrixTestWithExplicitZeroDiag (Teuchos::FancyOStream& out,
     Kokkos::deep_copy (ptr_h, A_lcl.graph.row_map);
     auto ind_h = Kokkos::create_mirror_view (A_lcl.graph.entries);
     Kokkos::deep_copy (ind_h, A_lcl.graph.entries);
-    // Work-around gcc/7.2.0 bug
+    // Work-around gcc/7.2.0 bug, see PR
+    // https://github.com/trilinos/Trilinos/pull/8031
     const int myRank_ = myRank;
 
     for (LO lclRow = 0; lclRow < lclNumRows; ++lclRow) {
@@ -1882,7 +1883,8 @@ makeMatrixTestWithExplicitInfAndNan (Teuchos::FancyOStream& out,
     Kokkos::deep_copy (ptr_h, A_lcl.graph.row_map);
     auto ind_h = Kokkos::create_mirror_view (A_lcl.graph.entries);
     Kokkos::deep_copy (ind_h, A_lcl.graph.entries);
-    // Work-around gcc/7.2.0 bug
+    // Work-around gcc/7.2.0 bug, see PR
+    // https://github.com/trilinos/Trilinos/pull/8031
     const int myRank_ = myRank;
 
     for (LO lclRow = 0; lclRow < lclNumRows; ++lclRow) {


### PR DESCRIPTION
Add work-around in unit test
tpetra/core/test/CrsMatrix/Equilibration.cpp
to resolve internal compiler errors of type
`internal compiler error: in maybe_undo_parenthesized_ref, at cp/semantics.c:1705`

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
Workaround compilation error with cuda/9.2+gcc/7.2 with c++14 support enabled


## Related Issues
This is an internal gcc compiler error that pops up with c++14 support, see for example
https://github.com/kokkos/kokkos-kernels/issues/349


## Testing
Tested with a contributed atdm script I am working (essentially the same as sems-rhel7 env instead of kokkos-dev-2)

```bash
export TRILINOS_DIR=${HOME}/Trilinos
export ATDM_CONFIG_REGISTER_CUSTOM_CONFIG_DIR=$TRILINOS_DIR/cmake/std/atdm/contributed/kokkos-dev-2
source ~/Trilinos/cmake/std/atdm/load-env.sh kokkos-dev-2-cuda-opt
#source ~/Trilinos/cmake/std/atdm/load-env.sh Trilinos-atdm-sems-rhel7-cuda-opt
 
cmake  \
  -GNinja  \
  -DTrilinos_CONFIGURE_OPTIONS_FILE:STRING=cmake/std/atdm/ATDMDevEnv.cmake  \
  -DTrilinos_ENABLE_TESTS=ON \
  -DTrilinos_ENABLE_Kokkos=ON \
  -DTrilinos_ENABLE_TpetraCore=ON \
  -DCMAKE_CXX_STANDARD=14 \
  $TRILINOS_DIR
```