### PR TITLE
Tpetra:  remove Kokkos::parallel_scan workaround implemented for 2019 parallel_scan bug

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_computeOffsets.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_computeOffsets.hpp
@@ -279,32 +279,6 @@ computeOffsetsFromCounts (const ExecutionSpace& execSpace,
        ": counts.size() = " << numCounts << " >= ptr.size() = " <<
        numOffsets << ".");
 
-#ifdef TPETRA_AVOID_PARALLEL_SCAN
-    // KDD 11/25/19  Temporary workaround to the one scan whose behavior
-    // makes a difference for GPU runs.  On the GPU platforms, serializing
-    // this scan (via Kokkos' magic) makes the code perform correctly.  
-    // This code serializes the scan, without the Kokkos magic, for debugging
-    // on stria.  #6345
-    // To use this code, add -DTPETRA_AVOID_PARALLEL_SCAN to CMAKE_CXX_FLAGS
-
-    Kokkos::View<offset_type*,Kokkos::HostSpace> 
-            ptrAPS(Kokkos::ViewAllocateWithoutInitializing("APS_offsets"),
-                   numOffsets);
-    Kokkos::View<count_type*,Kokkos::HostSpace> 
-            countsAPS(Kokkos::ViewAllocateWithoutInitializing("APS_counts"),
-                      numCounts);
-
-    Kokkos::deep_copy(countsAPS, counts);
-
-    ptrAPS(0) = 0;
-    for (size_t i = 0; i < numCounts; i++)
-      ptrAPS(i+1) = ptrAPS(i) + countsAPS(i);
-
-    total = ptrAPS(numCounts);
-
-    Kokkos::deep_copy(ptr, ptrAPS);
-
-#else
     using Kokkos::AnonymousSpace;
     using Kokkos::View;
     View<offset_type*, AnonymousSpace> ptr_a = ptr;
@@ -339,7 +313,6 @@ computeOffsetsFromCounts (const ExecutionSpace& execSpace,
     using functor_type =
       ComputeOffsetsFromCounts<offset_type, count_type, SizeType>;
     total = functor_type::run (execSpace, ptr_a, counts_a);
-#endif
   }
 
   return total;


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
This code existed as a workaround to a Kokkos::parallel_scan bug (the so-called "UVM bug" of 2019).
The bug is fixed so this workaround is no longer needed.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
cee-lan, gcc 7.3

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->