### PR TITLE
Zoltan2: Refactor directory to use Teuchos comm

### DIFF
--- a/packages/zoltan2/core/src/directory/Zoltan2_Directory.hpp
+++ b/packages/zoltan2/core/src/directory/Zoltan2_Directory.hpp
@@ -48,6 +48,7 @@
 #define ZOLTAN2_DIRECTORY_H_
 
 #include <Teuchos_DefaultComm.hpp> // currently using Teuchos comm throughout
+#include <Teuchos_CommHelpers.hpp>
 
 #ifndef HAVE_MPI
 // support mpi serial - directory currently has a mix of Teuchos mpi commands
@@ -214,7 +215,8 @@ class Zoltan2_Directory {
       typedef long long mpi_t;
       mpi_t nDDEntries = static_cast<mpi_t>(node_map.size());
       mpi_t firstIdx;
-      MPI_Scan(&nDDEntries, &firstIdx, 1, MPI_LONG_LONG, MPI_SUM, getRawComm());
+      Teuchos::scan(*comm, Teuchos::REDUCE_SUM,
+        1, &nDDEntries, &firstIdx);
       firstIdx -= nDDEntries;  // do not include this rank's entries in prefix sum
       size_t cnt = 0;
       for(size_t n = 0; n < node_map.capacity(); ++n) {
@@ -296,14 +298,6 @@ class Zoltan2_Directory {
       Zoltan2_DD_Find_Msg<gid_t,lid_t>* msg) const                    { return 0; };
 
   private:
-    MPI_Comm getRawComm() {
-    #ifdef HAVE_MPI
-      return Teuchos::getRawMpiComm(*comm);
-    #else
-      return MPI_COMM_WORLD;
-    #endif
-    }
-
     void rehash_node_map(size_t new_hash_size) {
       node_map.rehash(new_hash_size);
     }

--- a/packages/zoltan2/core/src/directory/Zoltan2_Directory_Comm.hpp
+++ b/packages/zoltan2/core/src/directory/Zoltan2_Directory_Comm.hpp
@@ -113,13 +113,7 @@ class Zoltan2_Directory_Plan {	/* data for mapping between decompositions */
     int       maxed_recvs;     /* use MPI_Alltoallv if too many receives */
     Teuchos::RCP<const Teuchos::Comm<int> > comm; /* communicator */
 
-    // making this ArrayRCP is causing issues with name() demangling for gcc
-    // sems build, but not clang... will need to work on this further
-    // back to std::vector for the moment
-    // there is probably an option in the sems building turning on
-    // something that creates this conflict
-    std::vector<MPI_Request> request;      /* MPI requests for posted recvs */
-    std::vector<MPI_Status> status;		     /* MPI status for those recvs */
+    Teuchos::ArrayRCP<Teuchos::RCP<Teuchos::CommRequest<int> > > request;      /* MPI requests for posted recvs */
 
     Zoltan2_Directory_Plan* plan_reverse;    /* to support POST & WAIT */
 
@@ -196,14 +190,6 @@ class Zoltan2_Directory_Comm {
     void free_reverse_plan(Zoltan2_Directory_Plan *plan);
 
     int create_reverse_plan(int tag, const Teuchos::ArrayRCP<int> &sizes);
-
-    MPI_Comm getRawComm() {
-    #ifdef HAVE_MPI
-      return Teuchos::getRawMpiComm(*comm_);
-    #else
-      return MPI_COMM_WORLD;
-    #endif
-    }
 
     Teuchos::RCP<const Teuchos::Comm<int> > comm_;
     Zoltan2_Directory_Plan * plan_forward; // for efficient MPI communication

--- a/packages/zoltan2/test/core/directory/directoryTest_Impl.hpp
+++ b/packages/zoltan2/test/core/directory/directoryTest_Impl.hpp
@@ -1389,15 +1389,7 @@ class TestManager {
 // gid lists for update, remove, find, as well as the user data and associated
 // lids after running find.
 int runDirectoryTests(int narg, char **arg) {
-#ifndef HAVE_MPI
-  // TODO what is cleanest way to support a serial test case?
-  // We still have some non Teuchos MPI calls in the directory and this works
-  // but I think if this all gets incorporated into Teuchos we can clean this up.
-  MPI_Init(NULL, NULL);
-#endif
-
-  Teuchos::GlobalMPISession mpiSession(&narg,&arg);
-  Kokkos::initialize(narg, arg);
+  Tpetra::ScopeGuard tscope(&narg, &arg);
   Teuchos::RCP<const Teuchos::Comm<int> > comm =
     Teuchos::DefaultComm<int>::getComm();
 
@@ -1472,8 +1464,6 @@ int runDirectoryTests(int narg, char **arg) {
   int errGlobal;
   Teuchos::reduceAll<int>(*comm,Teuchos::REDUCE_SUM, err,
     Teuchos::outArg(errGlobal));
-
-  Kokkos::finalize();
 
   return errGlobal; // only 0 if all tests and all proc return 0
 }

--- a/packages/zoltan2/test/core/directory/directoryTest_KokkosSimple.cpp
+++ b/packages/zoltan2/test/core/directory/directoryTest_KokkosSimple.cpp
@@ -44,6 +44,7 @@
 // @HEADER
 
 #include "Zoltan2_Directory_Impl.hpp"
+#include "Tpetra_Core.hpp"
 
 // This type will be used by some of these tests
 class gid_struct {
@@ -492,15 +493,7 @@ int test_multiple_lid(Teuchos::RCP<const Teuchos::Comm<int> > comm) {
 }
 
 int main(int narg, char **arg) {
-#ifndef HAVE_MPI
-  // TODO what is cleanest way to support a serial test case?
-  // We still have some non Teuchos MPI calls in the directory and this works
-  // but I think if this all gets incorporated into Teuchos we can clean this up.
-  MPI_Init(NULL, NULL);
-#endif
-
-  Teuchos::GlobalMPISession mpiSession(&narg,&arg);
-  Kokkos::initialize(narg, arg);
+  Tpetra::ScopeGuard tscope(&narg, &arg);
   Teuchos::RCP<const Teuchos::Comm<int> > comm =
     Teuchos::DefaultComm<int>::getComm();
 
@@ -528,8 +521,6 @@ int main(int narg, char **arg) {
       std::cout << "FAILED!" << std::endl;
     }
   }
-
-  Kokkos::finalize();
 
   return errGlobal;
 }

--- a/packages/zoltan2/test/core/directory/directoryTest_findUniqueGids.cpp
+++ b/packages/zoltan2/test/core/directory/directoryTest_findUniqueGids.cpp
@@ -417,15 +417,7 @@ void test4(Teuchos::RCP<const Teuchos::Comm<int> > &comm)
 
 int main(int argc, char *argv[])
 {
-#ifndef HAVE_MPI
-  // TODO what is cleanest way to support a serial test case?
-  // We still have some non Teuchos MPI calls in the directory and this works
-  // but I think if this all gets incorporated into Teuchos we can clean this up.
-  MPI_Init(NULL, NULL);
-#endif
-
-  Teuchos::GlobalMPISession mpiSession(&argc,&argv);
-  Kokkos::initialize(argc, argv);
+  Tpetra::ScopeGuard tscope(&argc, &argv);
   Teuchos::RCP<const Teuchos::Comm<int> > comm =
     Teuchos::DefaultComm<int>::getComm();
 
@@ -438,8 +430,6 @@ int main(int argc, char *argv[])
   Zoltan2::test2<long long>(comm);
   Zoltan2::test3<long long>(comm);
   Zoltan2::test4<long long>(comm);
-
-  Kokkos::finalize();
 
   return 0;
 }


### PR DESCRIPTION
@kddevin These are the conversions to Teuchos comm we discussed a while back. Most of this is just straight forward conversion from the MPI version to the Teuchos version.

Teuchos didn't have logical or (LOR) for reduce and I switched to bitwise (BOR). We're using int as 0 or 1 to represent bool logic in this case. I'm not sure it matters so much which we use but I could easily add LOR to Teuchos.

The only complication was Teuchos does not have waitAny. What I did as a short term fix was serialize that segment to just call wait on each request in order (would be some loss of performance) and left a note describing how we can convert this back to waitAny when available. I started looking at what Teuchos needs and it should be pretty easy to set up since we can just copy the waitAll method as a pattern for the setup. But there is a complication since the Teuchos request holds the MPI_Request internally. For waitAll, Teuchos releases all of them. For waitAny we want to release just the one that responds (but don't know this until after waitAny). Maybe we release all and restore all except the one we get. I tried a bit and had some bug with it so decided to leave it for a separate PR.

What I'm proposing is we accept the loss of performance for now so this PR doesn't spread too much. Then I or someone could work on adding the Teuchos::waitAny and restore that as a separate PR.

Other minor fixes: I switched to Tpetra::ScopeGuard and also cleaned up a hack I had in place so it runs on serial. I've preserved the serial tests, which we don't really need, just because it really helps with debugging. But it's in a much cleaner setup now.

There are some untested code blocks remaining and I cleaned up the throw comments I had left for that.
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/zoltan2  

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Clean up comm commands to use Teuchos instead of raw MPI calls.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Mac parallel and serial builds - Cuda on white - zoltan2 tests
