### PR TITLE
Tpetra - change the logic in set all to scalar

### DIFF
--- a/packages/tpetra/core/test/Block/BlockCrsMatrix.cpp
+++ b/packages/tpetra/core/test/Block/BlockCrsMatrix.cpp
@@ -1424,9 +1424,6 @@ namespace {
     // Fill all entries of the first matrix with 3.
     const Scalar three = STS::one () + STS::one () + STS::one ();
     A1.setAllToScalar (three);
-    // A1 must have been modified on exactly one side.
-    TEST_ASSERT( (! A1.need_sync_host () && A1.need_sync_device ()) ||
-                 (A1.need_sync_host () && ! A1.need_sync_device ()) );
 
     out << "The matrix A1, after construction:" << endl;
     A1.describe (out, Teuchos::VERB_EXTREME);


### PR DESCRIPTION
## Motivation

While reviewing deep copy in tpetra, I thought that this method does not have to be too complicated as previously. I also would like to discuss a couple of things

1. Do we really need to follow the last touch rule in dual view ? 
I believe that the dual view is for convenience to keep the data both places and communicate more easily. I do not think that using the host view of the dual view is for a performance reason. We probably may want to use devices as much as possible. However, the last touch rule makes the code complicated and it can result in using inefficient host kernels. As seen in #7985, we can get better performance when we select where to execute the kernel considering the problem size or other aspects. I also think that there is a reason that tpetra chose to follow the last touch rule which I do not know. How to you think @trilinos/tpetra ? 

This PR initialize both host and device views with a given scalar alpha. With async device kernels launch, both initialization can be done simultaneously and I am expecting that it does not cause overhead compared to the case that initialization happens either host or device.


## Related Issues

#7946 


## Testing

There is Tpetra unit test for this method and I changed the test with modified work scenario. This code passes on cuda.
