### PR TITLE
Minor tweak to van1-tx2 environment

### DIFF
--- a/cmake/std/atdm/van1-tx2/environment.sh
+++ b/cmake/std/atdm/van1-tx2/environment.sh
@@ -45,7 +45,7 @@ if [[ "$ATDM_CONFIG_COMPILER" == "ARM-20.0_OPENMPI-4.0.2" ]]; then
   module load devpack-arm
   module unload yaml-cpp
   # provides numpy module for empire
-  module load python/3.6.8
+  module load python/3.6.8-arm
   module load arm/20.0
   # Check if openmpi is already loaded. If it is, swap it. Otherwise, just load ompi4.
   if [[ ! -z $(module list openmpi | grep '1)' | awk -F ' ' '{print $2}') ]]; then


### PR DESCRIPTION
I would like to push a minor tweak to `cmake/std/atdm/van1-tx2/environment.sh` to load python/3.6.8-arm which provides a newer version of numpy that EMPIRE requires.  Previously, python/3.6.8 got loaded.