### PR TITLE
Set standard to C++14 on Clang builds

### DIFF
--- a/cmake/std/PullRequestLinuxClang10.0.0TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxClang10.0.0TestingSettings.cmake
@@ -15,6 +15,8 @@
 
 #set (TPL_Netcdf_LIBRARIES "-L$ENV{SEMS_NETCDF_ROOT}/lib;-L$ENV{SEMS_HDF5_ROOT}/lib;$ENV{SEMS_NETCDF_ROOT}/lib/libnetcdf.a;$ENV{SEMS_NETCDF_ROOT}/lib/libpnetcdf.a;$ENV{SEMS_HDF5_ROOT}/lib/libhdf5_hl.a;$ENV{SEMS_HDF5_ROOT}/lib/libhdf5.a;-lz;-ldl;-lcurl" CACHE STRING "Set by default for CUDA PR testing")
 
+set (CMAKE_CXX_STANDARD "14" CACHE STRING "Set C++ standard to C++14")
+
 set (MPI_EXEC_PRE_NUMPROCS_FLAGS "--bind-to;none" CACHE STRING "Set by default for PR testing")
 # NOTE: The above is a workaround for the problem of having threads on MPI
 # ranks bind to the same cores (see #2422).
@@ -37,3 +39,5 @@ set(FEI_multifield_vbr_az_MPI_2_DISABLE ON CACHE BOOL "Temporarily disabled in P
 set(FEI_multifield_vbr_az_MPI_3_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
 set(ROL_example_PinT_parabolic-control_example_01_MPI_1_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
 set(Rythmos_StepperBuilder_UnitTest_MPI_1_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
+
+set(CMAKE_CXX_FLAGS "-std=c++14" CACHE STRING "Set standard to C++14")

--- a/cmake/std/PullRequestLinuxClang9.0.0TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxClang9.0.0TestingSettings.cmake
@@ -6,6 +6,8 @@
 
 # Usage: cmake -C PullRequestLinuxClang9.0.0TestingSettings.cmake
 
+set (CMAKE_CXX_STANDARD "14" CACHE STRING "Set C++ standard to C++14")
+
 # Misc options typically added by CI testing mode in TriBITS
 
 # Use the below option only when submitting to the dashboard
@@ -37,3 +39,5 @@ set(FEI_multifield_vbr_az_MPI_2_DISABLE ON CACHE BOOL "Temporarily disabled in P
 set(FEI_multifield_vbr_az_MPI_3_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
 set(ROL_example_PinT_parabolic-control_example_01_MPI_1_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
 set(Rythmos_StepperBuilder_UnitTest_MPI_1_DISABLE ON CACHE BOOL "Temporarily disabled in PR testing")
+
+set(CMAKE_CXX_FLAGS "-std=c++14" CACHE STRING "Set C++ standard to C++14")


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework 

## Motivation
A coming release of Kokkos will require C++14.
This will test that requirement in the builds for Clang 9.0.0 & 10.0.0 used in PR & Dev to Master testing.

## Related Issues
This closes #8017

## Testing
This has been manually run though the clang 9 & 10 PR tests.
[CDash](https://testing.sandia.gov/cdash/index.php?project=Trilinos&display=project&filtercount=4&showfilters=1&filtercombine=and&field1=buildname&compare1=63&value1=c14&field2=buildname&compare2=63&value2=clang&field3=buildstamp&compare3=63&value3=Experimental&field4=buildstarttime&compare4=83&value4=2020%2F09%2F15)

<!--- 
## Additional Information

 -->