### PR TITLE
Panzer/edge block updates

### DIFF
--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_CubeHexMeshFactory.cpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_CubeHexMeshFactory.cpp
@@ -171,6 +171,7 @@ void CubeHexMeshFactory::completeMeshConstruction(STK_Interface & mesh,stk::Para
    }
 
    mesh.buildLocalElementIDs();
+   mesh.buildLocalEdgeIDs();
 
    // now that edges are built, side and node sets can be added
    addSideSets(mesh);

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_CubeTetMeshFactory.cpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_CubeTetMeshFactory.cpp
@@ -156,6 +156,7 @@ void CubeTetMeshFactory::completeMeshConstruction(STK_Interface & mesh,stk::Para
    // finish up the edges and faces
    mesh.buildSubcells();
    mesh.buildLocalElementIDs();
+   mesh.buildLocalEdgeIDs();
 
    // now that edges are built, sidets can be added
    addSideSets(mesh);

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.cpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.cpp
@@ -1322,6 +1322,21 @@ std::size_t STK_Interface::elementLocalId(stk::mesh::EntityId gid) const
    return itr->second;
 }
 
+bool STK_Interface::isEdgeLocal(stk::mesh::Entity edge) const
+{
+   return isEdgeLocal(bulkData_->identifier(edge));
+}
+
+bool STK_Interface::isEdgeLocal(stk::mesh::EntityId gid) const
+{
+   std::unordered_map<stk::mesh::EntityId,std::size_t>::const_iterator itr = localEdgeIDHash_.find(gid);
+   if (itr==localEdgeIDHash_.end()) {
+     return false;
+   }
+   return true;
+}
+
+
 std::size_t STK_Interface::edgeLocalId(stk::mesh::Entity edge) const
 {
    return edgeLocalId(bulkData_->identifier(edge));

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.cpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.cpp
@@ -301,8 +301,8 @@ void STK_Interface::initialize(stk::ParallelMachine parallelMach,bool setupIO,
       {
          std::map<std::string, stk::mesh::Part*>::iterator itr;
          for(itr=edgeBlocks_.begin();itr!=edgeBlocks_.end();++itr)
-            if(!stk::io::is_part_io_part(*itr->second)) {
-               stk::io::put_io_part_attribute(*itr->second); // this can only be called once per part
+            if(!stk::io::is_part_edge_block_io_part(*itr->second)) {
+               stk::io::put_edge_block_io_part_attribute(*itr->second); // this can only be called once per part
             }
       }
 
@@ -324,12 +324,12 @@ void STK_Interface::initialize(stk::ParallelMachine parallelMach,bool setupIO,
 
       // add nodes
       if(!stk::io::is_part_io_part(*nodesPart_))
-	stk::io::put_io_part_attribute(*nodesPart_);
+         stk::io::put_io_part_attribute(*nodesPart_);
 
       stk::io::set_field_role(*coordinatesField_, Ioss::Field::MESH);
       stk::io::set_field_role(*edgesField_, Ioss::Field::MESH);
       if (dimension_ > 2)
-        stk::io::set_field_role(*facesField_, Ioss::Field::MESH);
+         stk::io::set_field_role(*facesField_, Ioss::Field::MESH);
       stk::io::set_field_role(*processorIdField_, Ioss::Field::TRANSIENT);
       // stk::io::set_field_role(*loadBalField_, Ioss::Field::TRANSIENT);
    }

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.hpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.hpp
@@ -663,6 +663,14 @@ public:
    inline stk::mesh::EntityId elementGlobalId(stk::mesh::Entity elmt) const
    { return bulkData_->identifier(elmt); }
 
+   /** Is an edge local to this processor?
+     */
+   bool isEdgeLocal(stk::mesh::Entity edge) const;
+
+   /** Is an edge local to this processor?
+     */
+   bool isEdgeLocal(stk::mesh::EntityId gid) const;
+
    /** Get an edge's local index
      */
    std::size_t edgeLocalId(stk::mesh::Entity elmt) const;

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_SculptMeshFactory.cpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_SculptMeshFactory.cpp
@@ -238,6 +238,7 @@ void SculptMeshFactory::completeMeshConstruction(STK_Interface & mesh,stk::Paral
 
    mesh.buildSubcells();
    mesh.buildLocalElementIDs();
+   mesh.buildLocalEdgeIDs();
 
    addSideSets(mesh);
    addNodeSets(mesh);


### PR DESCRIPTION
@trilinos/panzer

## Motivation

This PR updates the edge block and edge field features of Panzer::STK_Interface.

* fix a bug that prevented edge ID initialization in the 3D mesh factories
* add an isEdgeLocal() method
* use put_edge_block_io_part_attribute() to differentiate edge blocks from sidesets

Closes #8072 

## Testing

These changes are generally covered by the PanzerAdaptersSTK test set.  isEdgeLocal() is tested by PanzerAdaptersSTK _tExodusEdgeBlock.exe.
