### PR TITLE
MueLu: free fine-level composite operator as soon as possible

### DIFF
--- a/packages/muelu/research/regionMG/test/structured/Driver_Structured_Regions.cpp
+++ b/packages/muelu/research/regionMG/test/structured/Driver_Structured_Regions.cpp
@@ -617,6 +617,9 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
                      revisedRowMapPerGrp, revisedColMapPerGrp,
                      rowImportPerGrp, maxRegPerProc, quasiRegionGrpMats, regionGrpMats);
 
+  // We don't need the composite operator on the fine level anymore. Free it!
+  A = Teuchos::null;
+
   comm->barrier();
   tmLocal = Teuchos::null;
 
@@ -763,10 +766,6 @@ int main_(Teuchos::CommandLineProcessor &clp, Xpetra::UnderlyingLib& lib, int ar
 
     // Composite residual vector
     RCP<Vector> compRes = VectorFactory::Build(dofMap, true);
-    {
-      A->apply(*X, *compRes, Teuchos::NO_TRANS);
-      compRes->update(one, *B, -one);
-    }
 
     // transform composite vectors to regional layout
     Array<Teuchos::RCP<Vector> > quasiRegX(maxRegPerProc);


### PR DESCRIPTION
@trilinos/muelu 

## Motivation

This frees some memory, as we don't need the composite operator on the fine level anymore, once we have created the region matrix.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing

Tests pass locally.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->