### PR TITLE
Create new Serial GCC7.2.0 PR build with C++14 set

### DIFF
--- a/cmake/std/PullRequestLinuxDriverTest.py
+++ b/cmake/std/PullRequestLinuxDriverTest.py
@@ -207,6 +207,20 @@ def setBuildEnviron(arguments):
                      "sems-cmake/3.10.3",
                      "atdm-env",
                      "atdm-ninja_fortran/1.7.2"],
+                "Trilinos_pullrequest_gcc_7.2.0_serial":
+                     ["sems-env",
+                     "sems-git/2.10.1",
+                     "sems-gcc/7.2.0",
+                     "sems-python/2.7.9",
+                     "sems-boost/1.63.0/base",
+                     "sems-zlib/1.2.8/base",
+                     "sems-hdf5/1.10.6/base",
+                     "sems-netcdf/4.7.3/base",
+                     "sems-metis/5.1.0/base",
+                     "sems-superlu/4.3/base",
+                     "sems-cmake/3.10.3",
+                     "atdm-env",
+                     "atdm-ninja_fortran/1.7.2"],
                 "Trilinos_pullrequest_gcc_8.3.0":
                      ["sems-env",
                      "sems-git/2.10.1",
@@ -381,6 +395,9 @@ def setBuildEnviron(arguments):
                       {"SEMS_FORCE_LOCAL_COMPILER_VERSION": "4.9.3",
                        "OMP_NUM_THREADS": "2"},
                  "Trilinos_pullrequest_gcc_7.2.0_debug":
+                      {"SEMS_FORCE_LOCAL_COMPILER_VERSION": "4.9.3",
+                       "OMP_NUM_THREADS": "2"},
+                 "Trilinos_pullrequest_gcc_7.2.0_serial":
                       {"SEMS_FORCE_LOCAL_COMPILER_VERSION": "4.9.3",
                        "OMP_NUM_THREADS": "2"},
                  "Trilinos_pullrequest_gcc_8.3.0":
@@ -652,6 +669,7 @@ config_map = {
     'Trilinos_pullrequest_gcc_4.9.3_SERIAL': 'PullRequestLinuxGCC4.9.3TestingSettingsSERIAL.cmake',
     'Trilinos_pullrequest_gcc_7.2.0':        'PullRequestLinuxGCC7.2.0TestingSettings.cmake',
     'Trilinos_pullrequest_gcc_7.2.0_debug':  'PullRequestLinuxGCC7.2.0DebugTestingSettings.cmake',
+    'Trilinos_pullrequest_gcc_7.2.0_serial': 'PullRequestLinuxGCC7.2.0SerialTestingSettings.cmake',
     'Trilinos_pullrequest_gcc_8.3.0':        'PullRequestLinuxGCC8.3.0TestingSettings.cmake',
     'Trilinos_pullrequest_clang_7.0.1':      'PullRequestLinuxClang7.0.1TestingSettings.cmake',
     'Trilinos_pullrequest_clang_9.0.0':      'PullRequestLinuxClang9.0.0TestingSettings.cmake',

--- a/cmake/std/PullRequestLinuxGCC7.2.0SerialTestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxGCC7.2.0SerialTestingSettings.cmake
@@ -16,14 +16,7 @@ set (CMAKE_CXX_STANDARD "14" CACHE STRING "Set C++ standard to C++14")
 # Disabling fortran for this build as that is a customer use case
 set (Trilinos_ENABLE_Fortran OFF CACHE BOOL "Set by default for SERIAL PR test")
 
-set (MPI_EXEC_PRE_NUMPROCS_FLAGS "--bind-to;none" CACHE STRING "Set by default for PR testing")
-# NOTE: The above is a workaround for the problem of having threads on MPI
-# ranks bind to the same cores (see #2422).
-
 set (Trilinos_ENABLE_COMPLEX_DOUBLE ON CACHE BOOL "Set by default for PR testing to exercise complex doubles case")
-
-# Disable just one Teko sub-unit test that fails with openmpi 1.10 (#2712)
-set (Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D ON CACHE BOOL "Temporarily disabled in PR testing")
 
 include("${CMAKE_CURRENT_LIST_DIR}/PullRequestLinuxCommonTestingSettingsSERIAL.cmake")
 

--- a/cmake/std/PullRequestLinuxGCC7.2.0SerialTestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxGCC7.2.0SerialTestingSettings.cmake
@@ -1,0 +1,31 @@
+# This file contains the options needed to both run the pull request testing
+# for Trilinos for the Linux GCC 7.2.0 pull request testing builds, and to reproduce
+# the errors reported by those builds. Prior to using this this file, the
+# appropriate set of SEMS modules must be loaded and accessible through the
+# SEMS NFS mount. (See the sems/PullRequestGCC*TestingEnv.sh files.)
+
+# Usage: cmake -C PullRequestLinuxGCC7.2.0TestingSettings.cmake
+
+set (CMAKE_CXX_STANDARD "14" CACHE STRING "Set C++ standard to C++14")
+
+# Misc options typically added by CI testing mode in TriBITS
+
+# Use the below option only when submitting to the dashboard
+#set (CTEST_USE_LAUNCHERS ON CACHE BOOL "Set by default for PR testing")
+
+# Disabling fortran for this build as that is a customer use case
+set (Trilinos_ENABLE_Fortran OFF CACHE BOOL "Set by default for SERIAL PR test")
+
+set (MPI_EXEC_PRE_NUMPROCS_FLAGS "--bind-to;none" CACHE STRING "Set by default for PR testing")
+# NOTE: The above is a workaround for the problem of having threads on MPI
+# ranks bind to the same cores (see #2422).
+
+set (Trilinos_ENABLE_COMPLEX_DOUBLE ON CACHE BOOL "Set by default for PR testing to exercise complex doubles case")
+
+# Disable just one Teko sub-unit test that fails with openmpi 1.10 (#2712)
+set (Teko_DISABLE_LSCSTABALIZED_TPETRA_ALPAH_INV_D ON CACHE BOOL "Temporarily disabled in PR testing")
+
+include("${CMAKE_CURRENT_LIST_DIR}/PullRequestLinuxCommonTestingSettingsSERIAL.cmake")
+
+# Adding warnings as errors flags to this PR build
+set(CMAKE_CXX_FLAGS "-std=c++14 -Wall -Wno-clobbered -Wno-vla -Wno-pragmas -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-literal-suffix -Wno-deprecated-declarations -Wno-misleading-indentation -Wno-int-in-bool-context -Wno-maybe-uninitialized -Wno-nonnull-compare -Wno-address -Wno-inline -Wno-unused-but-set-variable -Wno-unused-variable -Wno-unused-label -DTRILINOS_HIDE_DEPRECATED_HEADER_WARNINGS -Werror" CACHE STRING "Warnings as errors settings")

--- a/cmake/std/sems/PullRequestGCC7.2.0SerialTestingEnv.sh
+++ b/cmake/std/sems/PullRequestGCC7.2.0SerialTestingEnv.sh
@@ -1,0 +1,22 @@
+# This script can be used to load the appropriate environment for the
+# GCC 7.2.0 Pull Request testing build on a Linux machine that has access to
+# the SEMS NFS mount.
+
+# usage: $ source PullRequestGCC7.2.0TestingEnv.sh
+
+source /projects/sems/modulefiles/utils/sems-modules-init.sh
+
+module load sems-gcc/7.2.0
+module load sems-python/2.7.9
+module load sems-git/2.10.1
+module load sems-boost/1.63.0/base
+module load sems-zlib/1.2.8/base
+module load sems-hdf5/1.10.6/base
+module load sems-netcdf/4.7.3/base
+module load sems-metis/5.1.0/base
+module load sems-superlu/4.3/base
+module load sems-cmake/3.12.2
+module load sems-ninja_fortran/1.8.2
+
+# add the OpenMP environment variable we need
+export OMP_NUM_THREADS=2

--- a/cmake/std/unittests/TestPullRequestLinuxDriverTest.py
+++ b/cmake/std/unittests/TestPullRequestLinuxDriverTest.py
@@ -646,6 +646,28 @@ class Test_setEnviron(unittest.TestCase):
                              test_ENV={'OMP_NUM_THREADS': '2'})
 
 
+    def test_buildEnv_passes_with_gcc_720_serial(self):
+        """Find the function"""
+        PR_name = 'Trilinos_pullrequest_gcc_7.2.0_serial'
+        expected_list = [mock.call('use', '/projects/sems/modulefiles/projects'),
+                         mock.call('load', 'sems-env'),
+                         mock.call('load', 'sems-git/2.10.1'),
+                         mock.call('load', 'sems-gcc/7.2.0'),
+                         mock.call('load', 'sems-python/2.7.9'),
+                         mock.call('load', 'sems-boost/1.63.0/base'),
+                         mock.call('load', 'sems-zlib/1.2.8/base'),
+                         mock.call('load', 'sems-hdf5/1.10.6/base'),
+                         mock.call('load', 'sems-netcdf/4.7.3/base'),
+                         mock.call('load', 'sems-metis/5.1.0/base'),
+                         mock.call('load', 'sems-superlu/4.3/base'),
+                         mock.call('load', 'sems-cmake/3.10.3'),
+                         mock.call('load', 'atdm-env'),
+                         mock.call('load', 'atdm-ninja_fortran/1.7.2'),
+                         ]
+        self.buildEnv_passes(PR_name, expected_list,
+                             test_ENV={'OMP_NUM_THREADS': '2'})
+
+
     def test_buildEnv_passes_with_gcc_830(self):
         """Find the function"""
         PR_name = 'Trilinos_pullrequest_gcc_8.3.0'


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
This will add the needed code for a new Serial GCC 7.2.0 C++14 PR build.
This addresses and closes #8071 
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
This is work moves to a configuration that is c++14 ready making the PR testing scheme ready for Kokkos 3.3 to be merged in.
## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
A new Jenkins job was created and tested building with this new code.
[CDash](https://testing.sandia.gov/cdash/index.php?project=Trilinos&display=project&filtercount=3&showfilters=1&filtercombine=and&field1=site&compare1=61&value1=ascic158&field2=buildname&compare2=61&value2=PR-gcc72c14serial-test-Trilinos_pullrequest_gcc_7.2.0_serial-1&field3=buildstamp&compare3=61&value3=20200922-1624-Experimental)


## Additional Information
A few WError flags had to be turned off to get a clean build.
```
-Wno-unused-but-set-variable
-Wno-unused-variable
-Wno-unused-label
```
This shouldn't be an issue since these warning are still protected against with the GCC 8.3.0 [Parallel] PR build.