### PR TITLE
Tpetra:  workarounds to compiler bug in #8047

### DIFF
--- a/packages/tpetra/tsqr/src/Tsqr_FullTsqrTest.hpp
+++ b/packages/tpetra/tsqr/src/Tsqr_FullTsqrTest.hpp
@@ -808,8 +808,11 @@ namespace TSQR {
         const ordinal_type numCols =
           testParams->get<ordinal_type>("numCols");
         const int numTrials = testParams->get<int>("numTrials");
-        const bool contiguousCacheBlocks =
+        /* const */ bool contiguousCacheBlocks =
           testParams->get<bool>("contiguousCacheBlocks");
+          // 9/2020  contiguousCacheBlocks should be const, but
+          // gcc7.2+cuda9 with std=c++14 fails when const is used;
+          // see https://github.com/trilinos/Trilinos/pull/8047
         const bool testFactorExplicit =
           testParams->get<bool>("testFactorExplicit");
         const bool testRankRevealing =

--- a/packages/tpetra/tsqr/test/Tsqr_TestNodeTsqr.cpp
+++ b/packages/tpetra/tsqr/test/Tsqr_TestNodeTsqr.cpp
@@ -428,8 +428,12 @@ namespace TSQR {
 
       bool success = true;
 
-      const int nrows = params.numRows;
-      const int ncols = params.numCols;
+      /* const */ int nrows = params.numRows;
+      /* const */ int ncols = params.numCols;
+      // 9/2020  nrows and ncols should be const, but
+      // gcc7.2+cuda9 with std=c++14 fails when const is used; 
+      // see https://github.com/trilinos/Trilinos/pull/8047
+
 
       Matrix<int, Scalar> A(nrows, ncols);
       Matrix<int, Scalar> A_copy(nrows, ncols);
@@ -817,8 +821,11 @@ namespace TSQR {
                << endl;
         }
       }
-      const int nrows = params.numRows;
-      const int ncols = params.numCols;
+      /* const */ int nrows = params.numRows;
+      /* const */ int ncols = params.numCols;
+      // 9/2020  nrows and ncols should be const, but
+      // gcc7.2+cuda9 with std=c++14 fails when const is used; 
+      // see https://github.com/trilinos/Trilinos/pull/8047
 
       Matrix<int, Scalar> A(nrows, ncols);
       Matrix<int, Scalar> A_copy(nrows, ncols);


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

Apparently some gcc compilers with std=c++14 don't handle usage of const variables inside lambda expressions well.
See details in #8047 and https://github.com/kokkos/kokkos-kernels/issues/349

This PR works around such errors in three cases.  I remove the const specification from variables used inside the lambdas.
A better solution would have been to rewrite the code not to use lambdas (the same can be said for #8031).  The lambdas aren't in a parallel_for; they are just for convenience.  This code is primarily test code, though, so it didn't seem worth the time to rewrite.  



## Related Issues

* Closes #8047 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
@ZUUL42  Let me know whether this works for you.

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

Compiled Tpetra on ride with Trilinos' PR CUDA build and extra CMake instructions to set std=c++14 (see #8047 for details).
Confirmed failure without this PR's changes and success with the PR's changes.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->