### PR TITLE
Phalanx: fix for gcc 5/6 lambda bug on cuda

### DIFF
--- a/packages/phalanx/example/FiniteElementAssembly/evaluators/GatherSolution_Def.hpp
+++ b/packages/phalanx/example/FiniteElementAssembly/evaluators/GatherSolution_Def.hpp
@@ -82,7 +82,8 @@ operator()(const Kokkos::TeamPolicy<PHX::exec_space>::member_type& team) const
 {
   const int cell = team.league_rank();
   if (team.team_rank() == 0) {
-    Kokkos::parallel_for(Kokkos::ThreadVectorRange(team,field.extent(1)), [&] (const int& node) {
+    // Fix gcc 5/6 lambda bug by changing to capture by value (potentially less efficient)
+    Kokkos::parallel_for(Kokkos::ThreadVectorRange(team,field.extent(1)), [=] (const int& node) {
       field(cell,node) = x( gids(cell_global_offset_index+cell,node) * num_equations + field_index);
     });
   }
@@ -125,7 +126,8 @@ operator()(const Kokkos::TeamPolicy<PHX::exec_space>::member_type& team) const
 {
   const int cell = team.league_rank();
   if (team.team_rank() == 0) {
-    Kokkos::parallel_for(Kokkos::ThreadVectorRange(team,field.extent(1)), [&] (const int& node) {
+    // Fix gcc 5/6 lambda bug by changing to capture by value (potentially less efficient)
+    Kokkos::parallel_for(Kokkos::ThreadVectorRange(team,field.extent(1)), [=] (const int& node) {
       field(cell,node).val() = x(gids(cell_global_offset_index+cell,node) * num_equations + field_index);
       field(cell,node).fastAccessDx(num_equations * node + field_index) = 1.0;
     });

--- a/packages/phalanx/example/FiniteElementAssembly_MixedFieldTypes/evaluators/GatherSolution_Def.hpp
+++ b/packages/phalanx/example/FiniteElementAssembly_MixedFieldTypes/evaluators/GatherSolution_Def.hpp
@@ -82,7 +82,8 @@ operator()(const Kokkos::TeamPolicy<PHX::exec_space>::member_type& team) const
 {
   const int cell = team.league_rank();
   if (team.team_rank() == 0) {
-    Kokkos::parallel_for(Kokkos::ThreadVectorRange(team,field.extent(1)), [&] (const int& node) {
+    // Fix gcc 5/6 lambda bug by changing to capture by value (potentially less efficient)
+    Kokkos::parallel_for(Kokkos::ThreadVectorRange(team,field.extent(1)), [=] (const int& node) {
       field(cell,node) = x( gids(cell_global_offset_index+cell,node) * num_equations + field_index);
     });
   }
@@ -125,7 +126,8 @@ operator()(const Kokkos::TeamPolicy<PHX::exec_space>::member_type& team) const
 {
   const int cell = team.league_rank();
   if (team.team_rank() == 0) {
-    Kokkos::parallel_for(Kokkos::ThreadVectorRange(team,field.extent(1)), [&] (const int& node) {
+    // Fix gcc 5/6 lambda bug by changing to capture by value (potentially less efficient)
+    Kokkos::parallel_for(Kokkos::ThreadVectorRange(team,field.extent(1)), [=] (const int& node) {
       field(cell,node).val() = x(gids(cell_global_offset_index+cell,node) * num_equations + field_index);
       field(cell,node).fastAccessDx(num_equations * node + field_index) = 1.0;
     });


### PR DESCRIPTION

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
c++14 builds are broken with intel that uses gcc 5/6 due to lambda capture bug.



<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->
Closes https://github.com/trilinos/Trilinos/issues/8048

## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
c++14 PR testing will cover this.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->