### PR TITLE
Geminga: Remove valgrind option

### DIFF
--- a/cmake/ctest/drivers/geminga/TrilinosCTestDriverCore.geminga.gcc.cmake
+++ b/cmake/ctest/drivers/geminga/TrilinosCTestDriverCore.geminga.gcc.cmake
@@ -105,7 +105,7 @@ MACRO(TRILINOS_SYSTEM_SPECIFIC_CTEST_DRIVER)
 
   # Options for valgrind, if needed
   SET(CTEST_MEMORYCHECK_COMMAND_OPTIONS
-      "--leak-check=full --gen-suppressions=all --error-limit=no --log-file=nightly_suppressions.txt" ${CTEST_MEMORYCHECK_COMMAND_OPTIONS} )
+      "--leak-check=full --gen-suppressions=all --error-limit=no" ${CTEST_MEMORYCHECK_COMMAND_OPTIONS} )
 
 
   # Ensure that MPI is on for all parallel builds that might be run.


### PR DESCRIPTION
@trilinos/muelu 

## Motivation
The option redirects valgrind output to file. I'm hoping this is the reason why not valgrind results are getting posted.