### PR TITLE
Seacas fix symmetric communication

### DIFF
--- a/packages/seacas/libraries/ioss/src/cgns/Iocgns_StructuredZoneData.C
+++ b/packages/seacas/libraries/ioss/src/cgns/Iocgns_StructuredZoneData.C
@@ -25,7 +25,7 @@ namespace {
 
   bool overlaps(const Range &a, const Range &b)
   {
-    return a.begin() <= b.end() && b.begin() <= a.end();
+    return a.m_beg <= b.m_end && b.m_beg <= a.m_end;
   }
 
   bool zgc_overlaps(const Iocgns::StructuredZoneData *zone, const Ioss::ZoneConnectivity &zgc)
@@ -403,6 +403,7 @@ namespace Iocgns {
       }
     }
   } // namespace
+
   // If a zgc points to a donor zone which was split (has non-null children),
   // then create two zgc that point to each child.  Update range and donor_range
   void StructuredZoneData::resolve_zgc_split_donor(

--- a/packages/seacas/libraries/ioss/src/main/cgns_decomp.C
+++ b/packages/seacas/libraries/ioss/src/main/cgns_decomp.C
@@ -306,6 +306,42 @@ namespace {
     }
   }
 
+  bool validate_symmetric_communications(std::vector<Iocgns::StructuredZoneData *> &zones, int proc_count)
+  {
+    std::set<std::pair<std::pair<std::string,int>, std::pair<std::string, int>>> comms;
+    for (const auto &adam_zone : zones) {
+      if (adam_zone->m_parent == nullptr) {
+        // Iterate children (or self) of the adam_zone.
+        for (const auto zone : zones) {
+          if (zone->is_active() && zone->m_adam == adam_zone) {
+            for (auto &zgc : zone->m_zoneConnectivity) {
+	      if (zgc.is_active()) {
+		int p1 = zgc.m_ownerProcessor;
+		int p2 = zgc.m_donorProcessor;
+		comms.emplace(std::make_pair(std::make_pair(adam_zone->m_name, p1), std::make_pair(zgc.m_donorName, p2)));
+	      }
+	    }
+	  }
+	}
+      }
+    }
+
+    // Now iterate map and for each key->value, make sure value->key is in map...
+    bool valid = true;
+    for (const auto &key_value : comms) {
+      const auto &key = key_value.first;
+      const auto &value = key_value.second;
+      auto search = comms.find(std::make_pair(value,key));
+      if (search == comms.end()) {
+	valid = false;
+	fmt::print(stderr, fg(fmt::color::red), "ERROR: Could not find matching ZGC for {}, proc {} -> {}, proc {}\n",
+		   key.first, key.second, value.first, value.second);
+      }
+    }
+    return valid;
+  }
+
+
   void output_communications(std::vector<Iocgns::StructuredZoneData *> &zones, int proc_count)
   {
     fmt::print("Communication Map: [] is from decomposition; () is from zone-to-zone; omits "
@@ -318,17 +354,19 @@ namespace {
         for (const auto zone : zones) {
           if (zone->is_active() && zone->m_adam == adam_zone) {
             for (auto &zgc : zone->m_zoneConnectivity) {
-              int p1 = zgc.m_ownerProcessor;
-              int p2 = zgc.m_donorProcessor;
-              if (p1 != p2) {
-                int pmin = std::min(p1, p2);
-                int pmax = std::max(p1, p2);
-                if (zgc.is_from_decomp()) {
-                  comms.emplace_back(pmin, -pmax);
-                }
-                else {
-                  comms.emplace_back(pmin, pmax);
-                }
+	      if (zgc.is_active()) {
+		int p1 = zgc.m_ownerProcessor;
+		int p2 = zgc.m_donorProcessor;
+		if (p1 != p2) {
+		  int pmin = std::min(p1, p2);
+		  int pmax = std::max(p1, p2);
+		  if (zgc.is_from_decomp()) {
+		    comms.emplace_back(pmin, -pmax);
+		  }
+		  else {
+		    comms.emplace_back(pmin, pmax);
+		  }
+		}
               }
             }
           }
@@ -676,7 +714,14 @@ int main(int argc, char *argv[])
   update_zgc_data(zones, interFace.proc_count);
   double end2 = Ioss::Utils::timer();
 
+
   describe_decomposition(zones, orig_zone_count, interFace);
+
+  auto valid = validate_symmetric_communications(zones, interFace.proc_count);
+  if (!valid) {
+    fmt::print(stderr, fg(fmt::color::red),
+	       "\nERROR: Zone Grid Communication interfaces are not symmetric.  There is an error in the decomposition.\n");
+  }
 
   validate_decomposition(zones, interFace.proc_count);
 
@@ -685,6 +730,12 @@ int main(int argc, char *argv[])
              "\nTotal Execution time = {:.5} seconds to decompose for {:n} processors. (decomp: "
              "{:.5}, resolve_zgc: {:.5})\n",
              end2 - begin, interFace.proc_count, end1 - begin, end2 - end1);
+  if (valid) {
+    exit(EXIT_SUCCESS);
+  }
+  else {
+    exit(EXIT_FAILURE);
+  }
 }
 
 #if defined(_MSC_VER)


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/seacas 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Fixes error in last seacas snapshot which resulted in non-symmetric ZGC (communication interfaces) between zones.  This fixes the issue and adds a `validate_symmetric_communication` function to the `cgns_decomp` program which will catch this in the future.  Verified that the validate function correctly found the 4 bad interfaces prior to the fix and found no problems after the fix.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->