### PR TITLE
Panzer/add face block

### DIFF
--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_CubeHexMeshFactory.cpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_CubeHexMeshFactory.cpp
@@ -172,12 +172,13 @@ void CubeHexMeshFactory::completeMeshConstruction(STK_Interface & mesh,stk::Para
 
    mesh.buildLocalElementIDs();
    mesh.buildLocalEdgeIDs();
+   mesh.buildLocalFaceIDs();
 
    // now that edges are built, side and node sets can be added
    addSideSets(mesh);
    addNodeSets(mesh);
-
    addEdgeBlocks(mesh);
+   addFaceBlocks(mesh);
    
    // calls Stk_MeshFactory::rebalance
    this->rebalance(mesh);
@@ -273,6 +274,9 @@ void CubeHexMeshFactory::buildMetaData(stk::ParallelMachine /* parallelMach */, 
    const CellTopologyData * ctd = shards::getCellTopologyData<HexTopo>();
    const CellTopologyData * side_ctd = shards::CellTopology(ctd).getBaseCellTopologyData(2,0);
 
+   const CellTopologyData * edge_ctd = shards::CellTopology(ctd).getBaseCellTopologyData(1,0);
+   const CellTopologyData * face_ctd = shards::CellTopology(ctd).getBaseCellTopologyData(2,0);
+
    // build meta data
    //mesh.setDimension(2);
    for(int bx=0;bx<xBlocks_;bx++) {
@@ -317,7 +321,8 @@ void CubeHexMeshFactory::buildMetaData(stk::ParallelMachine /* parallelMach */, 
    // add nodesets
    mesh.addNodeset("origin");
 
-   mesh.addEdgeBlock(panzer_stk::STK_Interface::edgeBlockString);
+   mesh.addEdgeBlock(panzer_stk::STK_Interface::edgeBlockString, edge_ctd);
+   mesh.addFaceBlock(panzer_stk::STK_Interface::faceBlockString, face_ctd);
 }
 
 void CubeHexMeshFactory::buildElements(stk::ParallelMachine parallelMach,STK_Interface & mesh) const
@@ -722,6 +727,24 @@ void CubeHexMeshFactory::addEdgeBlocks(STK_Interface & mesh) const
    bulkData->get_entities(mesh.getEdgeRank(),metaData->locally_owned_part(),edges);
    for(auto edge : edges) {
       mesh.addEntityToEdgeBlock(edge, edge_block);
+   }
+
+   mesh.endModification();
+}
+
+void CubeHexMeshFactory::addFaceBlocks(STK_Interface & mesh) const
+{
+   mesh.beginModification();
+
+   stk::mesh::Part * face_block = mesh.getFaceBlock(panzer_stk::STK_Interface::faceBlockString);
+
+   Teuchos::RCP<stk::mesh::BulkData> bulkData = mesh.getBulkData();
+   Teuchos::RCP<stk::mesh::MetaData> metaData = mesh.getMetaData();
+
+   std::vector<stk::mesh::Entity> faces;
+   bulkData->get_entities(mesh.getFaceRank(),metaData->locally_owned_part(),faces);
+   for(auto face : faces) {
+      mesh.addEntityToFaceBlock(face, face_block);
    }
 
    mesh.endModification();

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_CubeHexMeshFactory.hpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_CubeHexMeshFactory.hpp
@@ -94,6 +94,7 @@ protected:
    void addSideSets(STK_Interface & mesh) const;
    void addNodeSets(STK_Interface & mesh) const;
    void addEdgeBlocks(STK_Interface & mesh) const;
+   void addFaceBlocks(STK_Interface & mesh) const;
 
    double x0_, y0_, z0_;
    double xf_, yf_, zf_;

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_CubeTetMeshFactory.cpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_CubeTetMeshFactory.cpp
@@ -157,11 +157,13 @@ void CubeTetMeshFactory::completeMeshConstruction(STK_Interface & mesh,stk::Para
    mesh.buildSubcells();
    mesh.buildLocalElementIDs();
    mesh.buildLocalEdgeIDs();
+   mesh.buildLocalFaceIDs();
 
    // now that edges are built, sidets can be added
    addSideSets(mesh);
    addNodeSets(mesh);
    addEdgeBlocks(mesh);
+   addFaceBlocks(mesh);
 
    // calls Stk_MeshFactory::rebalance
    this->rebalance(mesh);
@@ -249,6 +251,9 @@ void CubeTetMeshFactory::buildMetaData(stk::ParallelMachine /* parallelMach */, 
    const CellTopologyData * ctd = shards::getCellTopologyData<TetTopo>();
    const CellTopologyData * side_ctd = shards::CellTopology(ctd).getBaseCellTopologyData(2,0);
 
+   const CellTopologyData * edge_ctd = shards::CellTopology(ctd).getBaseCellTopologyData(1,0);
+   const CellTopologyData * face_ctd = shards::CellTopology(ctd).getBaseCellTopologyData(2,0);
+
    // build meta data
    //mesh.setDimension(2);
    for(int bx=0;bx<xBlocks_;bx++) {
@@ -274,7 +279,8 @@ void CubeTetMeshFactory::buildMetaData(stk::ParallelMachine /* parallelMach */, 
 
    mesh.addNodeset("origin");
    
-   mesh.addEdgeBlock(panzer_stk::STK_Interface::edgeBlockString);
+   mesh.addEdgeBlock(panzer_stk::STK_Interface::edgeBlockString, edge_ctd);
+   mesh.addFaceBlock(panzer_stk::STK_Interface::faceBlockString, face_ctd);
 }
 
 void CubeTetMeshFactory::buildElements(stk::ParallelMachine parallelMach,STK_Interface & mesh) const
@@ -610,6 +616,24 @@ void CubeTetMeshFactory::addEdgeBlocks(STK_Interface & mesh) const
    bulkData->get_entities(mesh.getEdgeRank(),metaData->locally_owned_part(),edges);
    for(auto edge : edges) {
       mesh.addEntityToEdgeBlock(edge, edge_block);
+   }
+
+   mesh.endModification();
+}
+
+void CubeTetMeshFactory::addFaceBlocks(STK_Interface & mesh) const
+{
+   mesh.beginModification();
+
+   stk::mesh::Part * face_block = mesh.getFaceBlock(panzer_stk::STK_Interface::faceBlockString);
+
+   Teuchos::RCP<stk::mesh::BulkData> bulkData = mesh.getBulkData();
+   Teuchos::RCP<stk::mesh::MetaData> metaData = mesh.getMetaData();
+
+   std::vector<stk::mesh::Entity> faces;
+   bulkData->get_entities(mesh.getFaceRank(),metaData->locally_owned_part(),faces);
+   for(auto face : faces) {
+      mesh.addEntityToFaceBlock(face, face_block);
    }
 
    mesh.endModification();

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_CubeTetMeshFactory.hpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_CubeTetMeshFactory.hpp
@@ -92,6 +92,7 @@ protected:
    void addSideSets(STK_Interface & mesh) const;
    void addNodeSets(STK_Interface & mesh) const;
    void addEdgeBlocks(STK_Interface & mesh) const;
+   void addFaceBlocks(STK_Interface & mesh) const;
 
    void buildTetsOnHex(const Teuchos::Tuple<int,3> & meshDesc,
                        const Teuchos::Tuple<int,3> & element,

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.cpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.cpp
@@ -101,6 +101,7 @@ const std::string STK_Interface::nodesString = "nodes";
 const std::string STK_Interface::edgesString = "edges";
 const std::string STK_Interface::facesString = "faces";
 const std::string STK_Interface::edgeBlockString = "edge_block";
+const std::string STK_Interface::faceBlockString = "face_block";
 
 STK_Interface::STK_Interface()
    : dimension_(0), initialized_(false), currentLocalId_(0), initialStateTime_(0.0), currentStateTime_(0.0), useFieldCoordinates_(false)
@@ -214,6 +215,28 @@ void STK_Interface::addEdgeField(const std::string & fieldName,const std::string
    }
 }
 
+void STK_Interface::addFaceField(const std::string & fieldName,const std::string & blockId)
+{
+   TEUCHOS_TEST_FOR_EXCEPTION(!validBlockId(blockId),ElementBlockException,
+                      "Unknown element block \"" << blockId << "\"");
+   std::pair<std::string,std::string> key = std::make_pair(fieldName,blockId);
+
+   // add & declare field if not already added...currently assuming linears
+   if(fieldNameToFaceField_.find(key)==fieldNameToFaceField_.end()) {
+      SolutionFieldType * field = metaData_->get_field<SolutionFieldType>(stk::topology::FACE_RANK, fieldName);
+      if(field==0) {
+         field = &metaData_->declare_field<SolutionFieldType>(stk::topology::FACE_RANK, fieldName);
+      }
+
+      if ( initialized_ )  {
+        metaData_->enable_late_fields();
+        stk::mesh::FieldTraits<SolutionFieldType>::data_type* init_sol = nullptr;
+        stk::mesh::put_field_on_mesh(*field, metaData_->universal_part(),init_sol );
+      }
+      fieldNameToFaceField_[key] = field;
+   }
+}
+
 void STK_Interface::addMeshCoordFields(const std::string & blockId,
                                        const std::vector<std::string> & coordNames,
                                        const std::string & dispPrefix)
@@ -283,6 +306,7 @@ void STK_Interface::initialize(stk::ParallelMachine parallelMach,bool setupIO,
    initializeFieldsInSTK(fieldNameToSolution_, setupIO);
    initializeFieldsInSTK(fieldNameToCellField_, setupIO);
    initializeFieldsInSTK(fieldNameToEdgeField_, setupIO);
+   initializeFieldsInSTK(fieldNameToFaceField_, setupIO);
 
 #ifdef PANZER_HAVE_IOSS
    if(setupIO) {
@@ -303,6 +327,15 @@ void STK_Interface::initialize(stk::ParallelMachine parallelMach,bool setupIO,
          for(itr=edgeBlocks_.begin();itr!=edgeBlocks_.end();++itr)
             if(!stk::io::is_part_edge_block_io_part(*itr->second)) {
                stk::io::put_edge_block_io_part_attribute(*itr->second); // this can only be called once per part
+            }
+      }
+
+      // add face blocks
+      {
+         std::map<std::string, stk::mesh::Part*>::iterator itr;
+         for(itr=faceBlocks_.begin();itr!=faceBlocks_.end();++itr)
+            if(!stk::io::is_part_face_block_io_part(*itr->second)) {
+               stk::io::put_face_block_io_part_attribute(*itr->second); // this can only be called once per part
             }
       }
 
@@ -496,6 +529,14 @@ void STK_Interface::addEntityToEdgeBlock(stk::mesh::Entity entity,stk::mesh::Par
    bulkData_->change_entity_parts(entity,edgeblockV);
 }
 
+void STK_Interface::addEntityToFaceBlock(stk::mesh::Entity entity,stk::mesh::Part * faceblock)
+{
+   std::vector<stk::mesh::Part*> faceblockV;
+   faceblockV.push_back(faceblock);
+
+   bulkData_->change_entity_parts(entity,faceblockV);
+}
+
 void STK_Interface::addElement(const Teuchos::RCP<ElementDescriptor> & ed,stk::mesh::Part * block)
 {
    std::vector<stk::mesh::Part*> blockVec;
@@ -629,7 +670,6 @@ setupExodusFile(const std::string& filename,
   ParallelMachine comm = *mpiComm_->getRawMpiComm();
   meshData_ = rcp(new StkMeshIoBroker(comm));
   meshData_->set_bulk_data(bulkData_);
-  meshData_->enable_edge_io();
   Ioss::PropertyManager props;
   props.add(Ioss::Property("LOWER_CASE_VARIABLE_NAMES", "FALSE"));
   if (append) {
@@ -1195,6 +1235,75 @@ void STK_Interface::getAllEdges(const std::string & edgeBlockName,const std::str
    stk::mesh::get_selected_entities(element_edge_block,bulkData_->buckets(getEdgeRank()),edges);
 }
 
+void STK_Interface::getMyFaces(std::vector<stk::mesh::Entity> & faces) const
+{
+   // setup local ownership
+   stk::mesh::Selector ownedPart = metaData_->locally_owned_part();
+
+   // grab elements
+   stk::mesh::EntityRank faceRank = getFaceRank();
+   stk::mesh::get_selected_entities(ownedPart,bulkData_->buckets(faceRank),faces);
+}
+
+void STK_Interface::getMyFaces(const std::string & faceBlockName,std::vector<stk::mesh::Entity> & faces) const
+{
+   stk::mesh::Part * faceBlockPart = getFaceBlock(faceBlockName);
+   TEUCHOS_TEST_FOR_EXCEPTION(faceBlockPart==0,std::logic_error,
+                      "Unknown face block \"" << faceBlockName << "\"");
+
+   stk::mesh::Selector face_block = *faceBlockPart;
+   stk::mesh::Selector owned_block = metaData_->locally_owned_part() & face_block;
+
+   // grab elements
+   stk::mesh::get_selected_entities(owned_block,bulkData_->buckets(getFaceRank()),faces);
+}
+
+void STK_Interface::getMyFaces(const std::string & faceBlockName,const std::string & blockName,std::vector<stk::mesh::Entity> & faces) const
+{
+   stk::mesh::Part * faceBlockPart = getFaceBlock(faceBlockName);
+   stk::mesh::Part * elmtPart = getElementBlockPart(blockName);
+   TEUCHOS_TEST_FOR_EXCEPTION(faceBlockPart==0,FaceBlockException,
+                      "Unknown face block \"" << faceBlockName << "\"");
+   TEUCHOS_TEST_FOR_EXCEPTION(elmtPart==0,ElementBlockException,
+                      "Unknown element block \"" << blockName << "\"");
+
+   stk::mesh::Selector face_block = *faceBlockPart;
+   stk::mesh::Selector element_block = *elmtPart;
+   stk::mesh::Selector owned_block = metaData_->locally_owned_part() & element_block & face_block;
+
+   // grab elements
+   stk::mesh::get_selected_entities(owned_block,bulkData_->buckets(getFaceRank()),faces);
+}
+
+void STK_Interface::getAllFaces(const std::string & faceBlockName,std::vector<stk::mesh::Entity> & faces) const
+{
+   stk::mesh::Part * faceBlockPart = getFaceBlock(faceBlockName);
+   TEUCHOS_TEST_FOR_EXCEPTION(faceBlockPart==0,std::logic_error,
+                      "Unknown face block \"" << faceBlockName << "\"");
+
+   stk::mesh::Selector face_block = *faceBlockPart;
+
+   // grab elements
+   stk::mesh::get_selected_entities(face_block,bulkData_->buckets(getFaceRank()),faces);
+}
+
+void STK_Interface::getAllFaces(const std::string & faceBlockName,const std::string & blockName,std::vector<stk::mesh::Entity> & faces) const
+{
+   stk::mesh::Part * faceBlockPart = getFaceBlock(faceBlockName);
+   stk::mesh::Part * elmtPart = getElementBlockPart(blockName);
+   TEUCHOS_TEST_FOR_EXCEPTION(faceBlockPart==0,FaceBlockException,
+                      "Unknown face block \"" << faceBlockName << "\"");
+   TEUCHOS_TEST_FOR_EXCEPTION(elmtPart==0,ElementBlockException,
+                      "Unknown element block \"" << blockName << "\"");
+
+   stk::mesh::Selector face_block = *faceBlockPart;
+   stk::mesh::Selector element_block = *elmtPart;
+   stk::mesh::Selector element_face_block = element_block & face_block;
+
+   // grab elements
+   stk::mesh::get_selected_entities(element_face_block,bulkData_->buckets(getFaceRank()),faces);
+}
+
 void STK_Interface::getMySides(const std::string & sideName,std::vector<stk::mesh::Entity> & sides) const
 {
    stk::mesh::Part * sidePart = getSideset(sideName);
@@ -1337,7 +1446,6 @@ bool STK_Interface::isEdgeLocal(stk::mesh::EntityId gid) const
    return true;
 }
 
-
 std::size_t STK_Interface::edgeLocalId(stk::mesh::Entity edge) const
 {
    return edgeLocalId(bulkData_->identifier(edge));
@@ -1347,6 +1455,32 @@ std::size_t STK_Interface::edgeLocalId(stk::mesh::EntityId gid) const
 {
    std::unordered_map<stk::mesh::EntityId,std::size_t>::const_iterator itr = localEdgeIDHash_.find(gid);
    TEUCHOS_ASSERT(itr!=localEdgeIDHash_.end());
+   return itr->second;
+}
+
+bool STK_Interface::isFaceLocal(stk::mesh::Entity face) const
+{
+   return isFaceLocal(bulkData_->identifier(face));
+}
+
+bool STK_Interface::isFaceLocal(stk::mesh::EntityId gid) const
+{
+   std::unordered_map<stk::mesh::EntityId,std::size_t>::const_iterator itr = localFaceIDHash_.find(gid);
+   if (itr==localFaceIDHash_.end()) {
+     return false;
+   }
+   return true;
+}
+
+std::size_t STK_Interface::faceLocalId(stk::mesh::Entity face) const
+{
+   return faceLocalId(bulkData_->identifier(face));
+}
+
+std::size_t STK_Interface::faceLocalId(stk::mesh::EntityId gid) const
+{
+   std::unordered_map<stk::mesh::EntityId,std::size_t>::const_iterator itr = localFaceIDHash_.find(gid);
+   TEUCHOS_ASSERT(itr!=localFaceIDHash_.end());
    return itr->second;
 }
 
@@ -1401,6 +1535,20 @@ stk::mesh::Field<double> * STK_Interface::getEdgeField(const std::string & field
    return iter->second;
 }
 
+stk::mesh::Field<double> * STK_Interface::getFaceField(const std::string & fieldName,
+                                                       const std::string & blockId) const
+{
+   // look up field in map
+   std::map<std::pair<std::string,std::string>, SolutionFieldType*>::const_iterator
+         iter = fieldNameToFaceField_.find(std::make_pair(fieldName,blockId));
+
+   // check to make sure field was actually found
+   TEUCHOS_TEST_FOR_EXCEPTION(iter==fieldNameToFaceField_.end(),std::runtime_error,
+                      "Face field named \"" << fieldName << "\" in block ID \"" << blockId << "\" was not found");
+
+   return iter->second;
+}
+
 Teuchos::RCP<const std::vector<stk::mesh::Entity> > STK_Interface::getElementsOrderedByLID() const
 {
    using Teuchos::RCP;
@@ -1445,17 +1593,53 @@ Teuchos::RCP<const std::vector<stk::mesh::Entity> > STK_Interface::getEdgesOrder
    return orderedEdgeVector_.getConst();
 }
 
-void STK_Interface::addEdgeBlock(const std::string & name)
+void STK_Interface::addEdgeBlock(const std::string & name,const CellTopologyData * ctData)
 {
    TEUCHOS_ASSERT(not initialized_);
 
    stk::mesh::Part * block = metaData_->get_part(name);
    if(block==0) {
-     block = &metaData_->declare_part_with_topology(name, stk::topology::LINE_2);
+     block = &metaData_->declare_part_with_topology(name, stk::mesh::get_topology(shards::CellTopology(ctData), dimension_));
    }
+
+   // construct cell topology object for this block
+   Teuchos::RCP<shards::CellTopology> ct
+         = Teuchos::rcp(new shards::CellTopology(ctData));
 
    // add edge block part
    edgeBlocks_.insert(std::make_pair(name,block));
+   edgeBlockCT_.insert(std::make_pair(name,ct));
+}
+
+Teuchos::RCP<const std::vector<stk::mesh::Entity> > STK_Interface::getFacesOrderedByLID() const
+{
+   using Teuchos::RCP;
+   using Teuchos::rcp;
+
+   if(orderedFaceVector_==Teuchos::null) {
+      // safe because essentially this is a call to modify a mutable object
+      const_cast<STK_Interface*>(this)->buildLocalFaceIDs();
+   }
+
+   return orderedFaceVector_.getConst();
+}
+
+void STK_Interface::addFaceBlock(const std::string & name,const CellTopologyData * ctData)
+{
+   TEUCHOS_ASSERT(not initialized_);
+
+   stk::mesh::Part * block = metaData_->get_part(name);
+   if(block==0) {
+     block = &metaData_->declare_part_with_topology(name, stk::mesh::get_topology(shards::CellTopology(ctData), dimension_));
+   }
+
+   // construct cell topology object for this block
+   Teuchos::RCP<shards::CellTopology> ct
+         = Teuchos::rcp(new shards::CellTopology(ctData));
+
+   // add face block part
+   faceBlocks_.insert(std::make_pair(name,block));
+   faceBlockCT_.insert(std::make_pair(name,ct));
 }
 
 void STK_Interface::initializeFromMetaData()
@@ -1564,6 +1748,26 @@ void STK_Interface::buildLocalEdgeIDs()
 
    // copy edges into the ordered edge vector
    orderedEdgeVector_ = Teuchos::rcp(new std::vector<stk::mesh::Entity>(edges));
+}
+
+void STK_Interface::buildLocalFaceIDs()
+{
+   currentLocalId_ = 0;
+
+   orderedFaceVector_ = Teuchos::null; // forces rebuild of ordered lists
+
+   // might be better (faster) to do this by buckets
+   std::vector<stk::mesh::Entity> faces;
+   getMyFaces(faces);
+
+   for(std::size_t index=0;index<faces.size();++index) {
+      stk::mesh::Entity face = faces[index];
+      localFaceIDHash_[bulkData_->identifier(face)] = currentLocalId_;
+      currentLocalId_++;
+   }
+
+   // copy faces into the ordered face vector
+   orderedFaceVector_ = Teuchos::rcp(new std::vector<stk::mesh::Entity>(faces));
 }
 
 bool

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.hpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_Interface.hpp
@@ -118,6 +118,9 @@ public:
    struct EdgeBlockException : public std::logic_error
    { EdgeBlockException(const std::string & what) : std::logic_error(what) {} };
 
+   struct FaceBlockException : public std::logic_error
+   { FaceBlockException(const std::string & what) : std::logic_error(what) {} };
+
    STK_Interface();
 
    /** Default constructor
@@ -135,7 +138,11 @@ public:
 
    /** Add an edge block with a string name
      */
-   void addEdgeBlock(const std::string & name);
+   void addEdgeBlock(const std::string & name,const CellTopologyData * ctData);
+
+   /** Add a face block with a string name
+     */
+   void addFaceBlock(const std::string & name,const CellTopologyData * ctData);
 
    /** Add a side set with a string name
      */
@@ -153,7 +160,13 @@ public:
      */
    void addCellField(const std::string & fieldName,const std::string & blockId);
 
+   /** Add an edge field
+     */
    void addEdgeField(const std::string & fieldName,const std::string & blockId);
+
+   /** Add a face field
+     */
+   void addFaceField(const std::string & fieldName,const std::string & blockId);
 
    /** Add a solution field for coordinates with a particular prefix, force it
      * to be outputed as a to be mesh displacement field. This
@@ -214,17 +227,21 @@ public:
 
    void addFaces();
 
-   /** Addes an entity to a specified side set.
+   /** Adds an entity to a specified side set.
      */
    void addEntityToSideset(stk::mesh::Entity entity,stk::mesh::Part * sideset);
 
-   /** Addes an entity to a specified node set.
+   /** Adds an entity to a specified node set.
      */
    void addEntityToNodeset(stk::mesh::Entity entity,stk::mesh::Part * nodeset);
 
-   /** Addes an entity to a specified edge block.
+   /** Adds an entity to a specified edge block.
      */
    void addEntityToEdgeBlock(stk::mesh::Entity entity,stk::mesh::Part * edgeblock);
+
+   /** Adds an entity to a specified face block.
+     */
+   void addEntityToFaceBlock(stk::mesh::Entity entity,stk::mesh::Part * faceblock);
 
    // Methods to interrogate the mesh topology and structure
    //////////////////////////////////////////
@@ -313,6 +330,48 @@ public:
      * \param[in,out] edges Vector of entities containing the requested edges.
      */
    void getAllEdges(const std::string & edgeBlockName,const std::string & blockName,std::vector<stk::mesh::Entity> & edges) const;
+
+   /** Get a vector of faces owned by this processor
+     */
+   void getMyFaces(std::vector<stk::mesh::Entity> & faces) const;
+   
+   /** Get Entities corresponding to the face block requested.
+     * The Entites in the vector should be a dimension
+     * lower than <code>getDimension()</code>.
+     *
+     * \param[in] faceBlockName Name of face block
+     * \param[in,out] faces Vector of entities containing the requested faces.
+     */
+   void getMyFaces(const std::string & faceBlockName,std::vector<stk::mesh::Entity> & faces) const;
+
+   /** Get Entities corresponding to the locally owned part of the face block requested. This also limits
+     * the entities to be in a particular element block. The Entites in the vector should be a dimension
+     * lower than <code>getDimension()</code>.
+     *
+     * \param[in] faceBlockName Name of face block
+     * \param[in] blockName Name of block
+     * \param[in,out] faces Vector of entities containing the requested faces.
+     */
+   void getMyFaces(const std::string & faceBlockName,const std::string & blockName,std::vector<stk::mesh::Entity> & faces) const;
+
+   /** Get Entities corresponding to the locally owned part of the face block requested.
+     * The Entites in the vector should be a dimension
+     * lower than <code>getDimension()</code>.
+     *
+     * \param[in] faceBlockName Name of face block
+     * \param[in,out] faces Vector of entities containing the requested faces.
+     */
+   void getAllFaces(const std::string & faceBlockName,std::vector<stk::mesh::Entity> & faces) const;
+
+   /** Get Entities corresponding to the face block requested. This also limits the entities
+     * to be in a particular element block. The Entites in the vector should be a dimension
+     * lower than <code>getDimension()</code>.
+     *
+     * \param[in] faceBlockName Name of face block
+     * \param[in] blockName Name of block
+     * \param[in,out] faces Vector of entities containing the requested faces.
+     */
+   void getAllFaces(const std::string & faceBlockName,const std::string & blockName,std::vector<stk::mesh::Entity> & faces) const;
 
    /** Get Entities corresponding to the side set requested.
      * The Entites in the vector should be a dimension
@@ -588,8 +647,16 @@ public:
    //! get the block part
    stk::mesh::Part * getEdgeBlock(const std::string & name) const
    {
-      std::map<std::string, stk::mesh::Part*>::const_iterator itr = edgeBlocks_.find(name);   // Element blocks
+      std::map<std::string, stk::mesh::Part*>::const_iterator itr = edgeBlocks_.find(name);   // edge blocks
       if(itr==edgeBlocks_.end()) return 0;
+      return itr->second;
+   }
+
+   //! get the block part
+   stk::mesh::Part * getFaceBlock(const std::string & name) const
+   {
+      std::map<std::string, stk::mesh::Part*>::const_iterator itr = faceBlocks_.find(name);   // face blocks
+      if(itr==faceBlocks_.end()) return 0;
       return itr->second;
    }
 
@@ -679,7 +746,7 @@ public:
      */
    std::size_t edgeLocalId(stk::mesh::EntityId gid) const;
 
-   /** Get an edges global index
+   /** Get an edge's global index
      */
    inline stk::mesh::EntityId edgeGlobalId(std::size_t lid) const
    { return bulkData_->identifier((*orderedEdgeVector_)[lid]); }
@@ -687,6 +754,32 @@ public:
    /** Get an edge's global index
      */
    inline stk::mesh::EntityId edgeGlobalId(stk::mesh::Entity edge) const
+   { return bulkData_->identifier(edge); }
+
+   /** Is a face local to this processor?
+     */
+   bool isFaceLocal(stk::mesh::Entity face) const;
+
+   /** Is a face local to this processor?
+     */
+   bool isFaceLocal(stk::mesh::EntityId gid) const;
+
+   /** Get a face's local index
+     */
+   std::size_t faceLocalId(stk::mesh::Entity elmt) const;
+
+   /** Get a face's local index
+     */
+   std::size_t faceLocalId(stk::mesh::EntityId gid) const;
+
+   /** Get a face's global index
+     */
+   inline stk::mesh::EntityId faceGlobalId(std::size_t lid) const
+   { return bulkData_->identifier((*orderedEdgeVector_)[lid]); }
+
+   /** Get a face's global index
+     */
+   inline stk::mesh::EntityId faceGlobalId(stk::mesh::Entity edge) const
    { return bulkData_->identifier(edge); }
 
   /** Get an Entity's parallel owner (process rank)
@@ -722,6 +815,13 @@ public:
      * is found an exception (std::runtime_error) is raised.
      */
    stk::mesh::Field<double> * getEdgeField(const std::string & fieldName,
+                                           const std::string & blockId) const;
+
+   /** Get the stk mesh field pointer associated with a particular value
+     * Assumes there is a field associated with "fieldName,blockId" pair. If none
+     * is found an exception (std::runtime_error) is raised.
+     */
+   stk::mesh::Field<double> * getFaceField(const std::string & fieldName,
                                            const std::string & blockId) const;
 
    ProcIdFieldType * getProcessorIdField() { return processorIdField_; }
@@ -792,14 +892,19 @@ public:
      * it is easily stored by the caller.
      */
    Teuchos::RCP<const std::vector<stk::mesh::Entity> > getEdgesOrderedByLID() const;
-   
+
+   /** Get Vector of face entities ordered by their LID, returns an RCP so that
+     * it is easily stored by the caller.
+     */
+   Teuchos::RCP<const std::vector<stk::mesh::Entity> > getFacesOrderedByLID() const;
+
    /** Writes a particular field to an edge array. Notice this is setup to work with
      * the worksets associated with Panzer.
      *
      * \param[in] fieldName Name of field to be filled
      * \param[in] blockId Name of block this set of elements belongs to
-     * \param[in] localElementIds Local element IDs for this set of solution values
-     * \param[in] solutionValues A one dimensional array object sized by (Edges)
+     * \param[in] localEdgeIds Local edge IDs for this set of solution values
+     * \param[in] edgeValues A one dimensional array object sized by (edges)
      *
      * \note The block ID is not strictly needed in this context. However forcing the
      *       user to provide it does permit an additional level of safety. The implicit
@@ -809,7 +914,25 @@ public:
      */
    template <typename ArrayT>
    void setEdgeFieldData(const std::string & fieldName,const std::string & blockId,
-                         const std::vector<std::size_t> & localElementIds,const ArrayT & solutionValues,double scaleValue=1.0);
+                         const std::vector<std::size_t> & localEdgeIds,const ArrayT & edgeValues,double scaleValue=1.0);
+
+   /** Writes a particular field to a face array. Notice this is setup to work with
+     * the worksets associated with Panzer.
+     *
+     * \param[in] fieldName Name of field to be filled
+     * \param[in] blockId Name of block this set of elements belongs to
+     * \param[in] localFaceIds Local face IDs for this set of solution values
+     * \param[in] faceValues A one dimensional array object sized by (faces)
+     *
+     * \note The block ID is not strictly needed in this context. However forcing the
+     *       user to provide it does permit an additional level of safety. The implicit
+     *       assumption is that the elements being "set" are part of the specified block.
+     *       This prevents the need to perform a null pointer check on the field data, because
+     *       the STK_Interface construction of the fields should force it to be nonnull...
+     */
+   template <typename ArrayT>
+   void setFaceFieldData(const std::string & fieldName,const std::string & blockId,
+                         const std::vector<std::size_t> & localFaceIds,const ArrayT & faceValues,double scaleValue=1.0);
 
    /** Get vertices associated with a number of elements of the same geometry.
      *
@@ -920,8 +1043,14 @@ public:
      */
    void buildLocalElementIDs();
 
+   /** Setup local edge IDs
+     */
    void buildLocalEdgeIDs();
-   
+
+   /** Setup local face IDs
+     */
+   void buildLocalFaceIDs();
+
    /** Return a vector containing all the periodic boundary conditions.
      */
    const std::vector<Teuchos::RCP<const PeriodicBC_MatcherBase> > &
@@ -1063,6 +1192,7 @@ public: // static operations
    static const std::string nodesString;
    static const std::string edgesString;
    static const std::string edgeBlockString;
+   static const std::string faceBlockString;
    static const std::string facesString;
 
 protected:
@@ -1127,12 +1257,15 @@ protected:
   Teuchos::RCP<percept::URP_Heterogeneous_3D> breakPattern_;
 #endif
 
-   std::map<std::string, stk::mesh::Part*> elementBlocks_;   // Element blocks
-   std::map<std::string, stk::mesh::Part*> sidesets_; // Side sets
-   std::map<std::string, stk::mesh::Part*> nodesets_; // Node sets
-   std::map<std::string, stk::mesh::Part*> edgeBlocks_;   // Edge blocks
+   std::map<std::string, stk::mesh::Part*> elementBlocks_;  // Element blocks
+   std::map<std::string, stk::mesh::Part*> sidesets_;       // Side sets
+   std::map<std::string, stk::mesh::Part*> nodesets_;       // Node sets
+   std::map<std::string, stk::mesh::Part*> edgeBlocks_;     // Edge blocks
+   std::map<std::string, stk::mesh::Part*> faceBlocks_;     // Face blocks
 
    std::map<std::string, Teuchos::RCP<shards::CellTopology> > elementBlockCT_;
+   std::map<std::string, Teuchos::RCP<shards::CellTopology> > edgeBlockCT_;
+   std::map<std::string, Teuchos::RCP<shards::CellTopology> > faceBlockCT_;
 
    // for storing/accessing nodes
    stk::mesh::Part * nodesPart_;
@@ -1152,6 +1285,7 @@ protected:
    std::map<std::pair<std::string,std::string>,SolutionFieldType*> fieldNameToSolution_;
    std::map<std::pair<std::string,std::string>,SolutionFieldType*> fieldNameToCellField_;
    std::map<std::pair<std::string,std::string>,SolutionFieldType*> fieldNameToEdgeField_;
+   std::map<std::pair<std::string,std::string>,SolutionFieldType*> fieldNameToFaceField_;
 
    unsigned dimension_;
 
@@ -1218,11 +1352,15 @@ protected:
    // uses lazy evaluation
    mutable Teuchos::RCP<std::vector<stk::mesh::Entity> > orderedEdgeVector_;
 
+   // uses lazy evaluation
+   mutable Teuchos::RCP<std::vector<stk::mesh::Entity> > orderedFaceVector_;
+
    // for element block weights
    std::map<std::string,double> blockWeights_;
 
    std::unordered_map<stk::mesh::EntityId,std::size_t> localIDHash_;
    std::unordered_map<stk::mesh::EntityId,std::size_t> localEdgeIDHash_;
+   std::unordered_map<stk::mesh::EntityId,std::size_t> localFaceIDHash_;
 
    // Store mesh displacement fields by element block. This map
    // goes like this meshCoordFields_[eBlock][axis_index] => coordinate FieldName
@@ -1359,7 +1497,7 @@ void STK_Interface::setCellFieldData(const std::string & fieldName,const std::st
 
 template <typename ArrayT>
 void STK_Interface::setEdgeFieldData(const std::string & fieldName,const std::string & blockId,
-                                     const std::vector<std::size_t> & localEdgeIds,const ArrayT & solutionValues,double scaleValue)
+                                     const std::vector<std::size_t> & localEdgeIds,const ArrayT & edgeValues,double scaleValue)
 {
    const std::vector<stk::mesh::Entity> & edges = *(this->getEdgesOrderedByLID());
 
@@ -1371,7 +1509,25 @@ void STK_Interface::setEdgeFieldData(const std::string & fieldName,const std::st
 
       double * solnData = stk::mesh::field_data(*field,edge);
       TEUCHOS_ASSERT(solnData!=0); // only needed if blockId is not specified
-      solnData[0] = scaleValue*solutionValues.access(idx,0);
+      solnData[0] = scaleValue*edgeValues.access(idx,0);
+   }
+}
+
+template <typename ArrayT>
+void STK_Interface::setFaceFieldData(const std::string & fieldName,const std::string & blockId,
+                                     const std::vector<std::size_t> & localFaceIds,const ArrayT & faceValues,double scaleValue)
+{
+   const std::vector<stk::mesh::Entity> & faces = *(this->getFacesOrderedByLID());
+
+   SolutionFieldType * field = this->getFaceField(fieldName,blockId);
+
+   for(std::size_t idx=0;idx<localFaceIds.size();idx++) {
+      std::size_t localId = localFaceIds[idx];
+      stk::mesh::Entity face = faces[localId];
+
+      double * solnData = stk::mesh::field_data(*field,face);
+      TEUCHOS_ASSERT(solnData!=0); // only needed if blockId is not specified
+      solnData[0] = scaleValue*faceValues.access(idx,0);
    }
 }
 

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_SculptMeshFactory.hpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_SculptMeshFactory.hpp
@@ -95,6 +95,7 @@ protected:
    void addSideSets(STK_Interface & mesh) const;
    void addNodeSets(STK_Interface & mesh) const;
    void addEdgeBlocks(STK_Interface & mesh) const;
+   void addFaceBlocks(STK_Interface & mesh) const;
 
    // search through relations for the one matching the ID
    const stk::mesh::Relation * getRelationByID(unsigned ID,stk::mesh::PairIterRelation edges) const;

--- a/packages/panzer/adapters-stk/test/stk_interface_test/CMakeLists.txt
+++ b/packages/panzer/adapters-stk/test/stk_interface_test/CMakeLists.txt
@@ -91,6 +91,13 @@ TRIBITS_ADD_EXECUTABLE_AND_TEST(
   COMM serial mpi
   )
 
+TRIBITS_ADD_EXECUTABLE_AND_TEST(
+  tExodusFaceBlock
+  SOURCES tExodusFaceBlock.cpp ${UNIT_TEST_DRIVER}
+  NUM_MPI_PROCS 2
+  COMM serial mpi
+  )
+
 #TRIBITS_ADD_EXECUTABLE_AND_TEST(
 #  tSolutionReader
 #  SOURCES tSolutionReader.cpp ${UNIT_TEST_DRIVER}

--- a/packages/panzer/adapters-stk/test/stk_interface_test/tExodusEdgeBlock.cpp
+++ b/packages/panzer/adapters-stk/test/stk_interface_test/tExodusEdgeBlock.cpp
@@ -121,8 +121,8 @@ TEUCHOS_UNIT_TEST(tExodusEdgeBlock, edge_count)
    }
    else if(numprocs==2 && rank==0) {
      // rank0 owns all edges in it's half of the mesh including the 
-     // edges on the face shared with rank1
-     std::size_t my_xelems=xelems-1;
+     // edges on the plane shared with rank1
+     std::size_t my_xelems=xelems/2;
      std::size_t my_yelems=yelems;
      std::size_t my_zelems=zelems;
      mesh->getMyEdges(panzer_stk::STK_Interface::edgeBlockString, my_edges);
@@ -131,8 +131,8 @@ TEUCHOS_UNIT_TEST(tExodusEdgeBlock, edge_count)
                                   +my_zelems*(my_xelems+1)*(my_yelems+1));
    }
    else if(numprocs==2 && rank==1) {
-     // rank1 doesn't own the edges on the face shared with rank0
-     std::size_t my_xelems=xelems-1;
+     // rank1 doesn't own the edges on the plane shared with rank0
+     std::size_t my_xelems=xelems/2;
      std::size_t my_yelems=yelems;
      std::size_t my_zelems=zelems;
      mesh->getMyEdges(panzer_stk::STK_Interface::edgeBlockString, my_edges);
@@ -173,9 +173,9 @@ TEUCHOS_UNIT_TEST(tExodusEdgeBlock, is_edge_local)
    factory.setParameterList(pl);
    RCP<STK_Interface> mesh = factory.buildMesh(MPI_COMM_WORLD);
    TEST_ASSERT(mesh!=Teuchos::null);
- 
+
    if(mesh->isWritable())
-      mesh->writeToExodus("EdgeBlock1.exo");
+      mesh->writeToExodus("EdgeBlock2.exo");
 
    // minimal requirements
    TEST_ASSERT(not mesh->isModifiable());
@@ -187,15 +187,15 @@ TEUCHOS_UNIT_TEST(tExodusEdgeBlock, is_edge_local)
    TEST_EQUALITY(mesh->getEntityCounts(mesh->getSideRank()),xelems*yelems*(zelems+1)+xelems*zelems*(yelems+1)+yelems*zelems*(xelems+1));
    TEST_EQUALITY(mesh->getEntityCounts(mesh->getEdgeRank()),xelems*(yelems+1)*(zelems+1)+yelems*(xelems+1)*(zelems+1)+zelems*(xelems+1)*(yelems+1));
    TEST_EQUALITY(mesh->getEntityCounts(mesh->getNodeRank()),(yelems+1)*(xelems+1)*(zelems+1));
-   
+
    std::vector<stk::mesh::Entity> my_edges;
    mesh->getMyEdges(panzer_stk::STK_Interface::edgeBlockString, my_edges);
    for ( auto edge : my_edges ) {
       TEST_ASSERT(mesh->isEdgeLocal(edge));
    }
-     
+
    std::vector<stk::mesh::Entity> all_edges;
-   mesh->getMyEdges(panzer_stk::STK_Interface::edgeBlockString, all_edges);
+   mesh->getAllEdges(panzer_stk::STK_Interface::edgeBlockString, all_edges);
    for ( auto edge : all_edges ) {
       if (mesh->getBulkData()->parallel_owner_rank(edge)==rank) {
         TEST_ASSERT(mesh->isEdgeLocal(edge));
@@ -244,7 +244,7 @@ TEUCHOS_UNIT_TEST(tExodusEdgeBlock, add_edge_field)
    }
 
    if(mesh->isWritable())
-      mesh->writeToExodus("EdgeBlock2.exo");
+      mesh->writeToExodus("EdgeBlock3.exo");
 
    // minimal requirements
    TEST_ASSERT(not mesh->isModifiable());
@@ -316,7 +316,7 @@ TEUCHOS_UNIT_TEST(tExodusEdgeBlock, set_edge_field_data)
                           edgeValues);
 
    if(mesh->isWritable())
-      mesh->writeToExodus("EdgeBlock3.exo");
+      mesh->writeToExodus("EdgeBlock4.exo");
 
    // minimal requirements
    TEST_ASSERT(not mesh->isModifiable());

--- a/packages/panzer/adapters-stk/test/stk_interface_test/tExodusFaceBlock.cpp
+++ b/packages/panzer/adapters-stk/test/stk_interface_test/tExodusFaceBlock.cpp
@@ -1,0 +1,331 @@
+// @HEADER
+// ***********************************************************************
+//
+//           Panzer: A partial differential equation assembly
+//       engine for strongly coupled complex multiphysics systems
+//                 Copyright (2011) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Roger P. Pawlowski (rppawlo@sandia.gov) and
+// Eric C. Cyr (eccyr@sandia.gov)
+// ***********************************************************************
+// @HEADER
+
+#include <Teuchos_ConfigDefs.hpp>
+#include <Teuchos_UnitTestHarness.hpp>
+#include "Teuchos_DefaultComm.hpp"
+#include "Teuchos_GlobalMPISession.hpp"
+#include "Teuchos_ParameterList.hpp"
+
+#include "Panzer_STK_Version.hpp"
+#include "PanzerAdaptersSTK_config.hpp"
+#include "Panzer_STK_Interface.hpp"
+#include "Panzer_STK_CubeHexMeshFactory.hpp"
+#include "Panzer_STK_SetupUtilities.hpp"
+
+#include "Shards_BasicTopologies.hpp"
+
+#include "Kokkos_DynRankView.hpp"
+
+#ifdef HAVE_MPI
+   #include "Epetra_MpiComm.h"
+#else
+   #include "Epetra_SerialComm.h"
+#endif
+
+namespace panzer_stk {
+
+TEUCHOS_UNIT_TEST(tExodusFaceBlock, face_count)
+{
+   using Teuchos::RCP;
+   using Teuchos::rcp;
+   using Teuchos::rcpFromRef;
+
+   int numprocs = stk::parallel_machine_size(MPI_COMM_WORLD);
+   int rank = stk::parallel_machine_rank(MPI_COMM_WORLD);
+   out << "Running numprocs = " << numprocs << " rank = " << rank << std::endl;
+
+   std::size_t xelems=2;
+   std::size_t yelems=4;
+   std::size_t zelems=5;
+   RCP<Teuchos::ParameterList> pl = rcp(new Teuchos::ParameterList);
+   pl->set("X Blocks",1);
+   pl->set("Y Blocks",1);
+   pl->set("Z Blocks",1);
+   pl->set("X Elements",(int)xelems);
+   pl->set("Y Elements",(int)yelems);
+   pl->set("Z Elements",(int)zelems);
+
+   CubeHexMeshFactory factory; 
+   factory.setParameterList(pl);
+   RCP<STK_Interface> mesh = factory.buildMesh(MPI_COMM_WORLD);
+   TEST_ASSERT(mesh!=Teuchos::null);
+
+   if(mesh->isWritable())
+      mesh->writeToExodus("FaceBlock1.exo");
+
+   // minimal requirements
+   TEST_ASSERT(not mesh->isModifiable());
+
+   TEST_EQUALITY(mesh->getDimension(),3);
+   TEST_EQUALITY(mesh->getNumElementBlocks(),1);
+   TEST_EQUALITY(mesh->getNumSidesets(),6);
+   TEST_EQUALITY(mesh->getEntityCounts(mesh->getElementRank()),xelems*yelems*zelems);
+   TEST_EQUALITY(mesh->getEntityCounts(mesh->getSideRank()),xelems*yelems*(zelems+1)+xelems*zelems*(yelems+1)+yelems*zelems*(xelems+1));
+   TEST_EQUALITY(mesh->getEntityCounts(mesh->getEdgeRank()),xelems*(yelems+1)*(zelems+1)+yelems*(xelems+1)*(zelems+1)+zelems*(xelems+1)*(yelems+1));
+   TEST_EQUALITY(mesh->getEntityCounts(mesh->getNodeRank()),(yelems+1)*(xelems+1)*(zelems+1));
+
+   std::vector<stk::mesh::Entity> all_faces;
+   mesh->getAllFaces(panzer_stk::STK_Interface::faceBlockString, all_faces);
+   TEST_EQUALITY(all_faces.size(),xelems*yelems*(zelems+1)
+                                 +xelems*zelems*(yelems+1)
+                                 +yelems*zelems*(xelems+1));
+
+   std::vector<stk::mesh::Entity> my_faces;
+   if (numprocs==1) {
+     // all faces belong to rank0, so getMyFaces() is equivalent to getAllFaces()
+     mesh->getMyFaces(panzer_stk::STK_Interface::faceBlockString, my_faces);
+     TEST_EQUALITY(my_faces.size(),all_faces.size());
+     TEST_EQUALITY(my_faces.size(),xelems*yelems*(zelems+1)
+                                  +xelems*zelems*(yelems+1)
+                                  +yelems*zelems*(xelems+1));
+   }
+   else if(numprocs==2 && rank==0) {
+     // rank0 owns all faces in it's half of the mesh including the 
+     // faces on the plane shared with rank1
+     std::size_t my_xelems=xelems/2;
+     std::size_t my_yelems=yelems;
+     std::size_t my_zelems=zelems;
+     mesh->getMyFaces(panzer_stk::STK_Interface::faceBlockString, my_faces);
+     TEST_EQUALITY(my_faces.size(),my_xelems*my_yelems*(my_zelems+1)
+                                  +my_xelems*my_zelems*(my_yelems+1)
+                                  +my_yelems*my_zelems*(my_xelems+1));
+   }
+   else if(numprocs==2 && rank==1) {
+     // rank1 doesn't own the faces on the plane shared with rank0
+     std::size_t my_xelems=xelems/2;
+     std::size_t my_yelems=yelems;
+     std::size_t my_zelems=zelems;
+     mesh->getMyFaces(panzer_stk::STK_Interface::faceBlockString, my_faces);
+     TEST_EQUALITY(my_faces.size(),my_xelems*my_yelems*(my_zelems+1)
+                                  +my_xelems*my_zelems*(my_yelems+1)
+                                  +my_yelems*my_zelems*(my_xelems+1)
+                                  -my_yelems*my_zelems);             // remove faces owned by rank0
+   }
+   else {
+     // fail!
+     TEST_ASSERT(false && "This test must run with either 1 or 2 ranks.");
+   }
+}
+
+TEUCHOS_UNIT_TEST(tExodusFaceBlock, is_face_local)
+{
+   using Teuchos::RCP;
+   using Teuchos::rcp;
+   using Teuchos::rcpFromRef;
+
+   int numprocs = stk::parallel_machine_size(MPI_COMM_WORLD);
+   int rank = stk::parallel_machine_rank(MPI_COMM_WORLD);
+   out << "Running numprocs = " << numprocs << " rank = " << rank << std::endl;
+
+   std::size_t xelems=2;
+   std::size_t yelems=4;
+   std::size_t zelems=5;
+   RCP<Teuchos::ParameterList> pl = rcp(new Teuchos::ParameterList);
+   pl->set("X Blocks",1);
+   pl->set("Y Blocks",1);
+   pl->set("Z Blocks",1);
+   pl->set("X Elements",(int)xelems);
+   pl->set("Y Elements",(int)yelems);
+   pl->set("Z Elements",(int)zelems);
+
+   CubeHexMeshFactory factory; 
+   factory.setParameterList(pl);
+   RCP<STK_Interface> mesh = factory.buildMesh(MPI_COMM_WORLD);
+   TEST_ASSERT(mesh!=Teuchos::null);
+
+   if(mesh->isWritable())
+      mesh->writeToExodus("FaceBlock2.exo");
+
+   // minimal requirements
+   TEST_ASSERT(not mesh->isModifiable());
+
+   TEST_EQUALITY(mesh->getDimension(),3);
+   TEST_EQUALITY(mesh->getNumElementBlocks(),1);
+   TEST_EQUALITY(mesh->getNumSidesets(),6);
+   TEST_EQUALITY(mesh->getEntityCounts(mesh->getElementRank()),xelems*yelems*zelems);
+   TEST_EQUALITY(mesh->getEntityCounts(mesh->getSideRank()),xelems*yelems*(zelems+1)+xelems*zelems*(yelems+1)+yelems*zelems*(xelems+1));
+   TEST_EQUALITY(mesh->getEntityCounts(mesh->getEdgeRank()),xelems*(yelems+1)*(zelems+1)+yelems*(xelems+1)*(zelems+1)+zelems*(xelems+1)*(yelems+1));
+   TEST_EQUALITY(mesh->getEntityCounts(mesh->getNodeRank()),(yelems+1)*(xelems+1)*(zelems+1));
+
+   std::vector<stk::mesh::Entity> my_faces;
+   mesh->getMyFaces(panzer_stk::STK_Interface::faceBlockString, my_faces);
+   for ( auto face : my_faces ) {
+      TEST_ASSERT(mesh->isFaceLocal(face));
+   }
+
+   std::vector<stk::mesh::Entity> all_faces;
+   mesh->getAllFaces(panzer_stk::STK_Interface::faceBlockString, all_faces);
+   for ( auto face : all_faces ) {
+      if (mesh->getBulkData()->parallel_owner_rank(face)==rank) {
+        TEST_ASSERT(mesh->isFaceLocal(face));
+      } else {
+        TEST_ASSERT(not mesh->isFaceLocal(face));
+      }
+   }
+}
+
+TEUCHOS_UNIT_TEST(tExodusFaceBlock, add_face_field)
+{
+   using Teuchos::RCP;
+   using Teuchos::rcp;
+   using Teuchos::rcpFromRef;
+
+   RCP<Teuchos::ParameterList> pl = rcp(new Teuchos::ParameterList);
+   pl->set("X Blocks",1);
+   pl->set("Y Blocks",1);
+   pl->set("Z Blocks",1);
+   pl->set("X Elements",2);
+   pl->set("Y Elements",4);
+   pl->set("Z Elements",5);
+
+   CubeHexMeshFactory factory; 
+   factory.setParameterList(pl);
+   RCP<STK_Interface> mesh = factory.buildMesh(MPI_COMM_WORLD);
+   TEST_ASSERT(mesh!=Teuchos::null);
+
+   mesh->addFaceField("face_field_1", "eblock-0_0_0");
+   mesh->addFaceField("face_field_2", "eblock-0_0_0");
+
+   stk::mesh::Field<double> * face_field_1 = mesh->getFaceField("face_field_1", "eblock-0_0_0");
+   stk::mesh::Field<double> * face_field_2 = mesh->getFaceField("face_field_2", "eblock-0_0_0");
+
+   std::vector<stk::mesh::Entity> faces;
+   mesh->getAllFaces(panzer_stk::STK_Interface::faceBlockString, faces);
+   for(auto face : faces) {
+     double* data = stk::mesh::field_data(*face_field_1, face);
+     // set the face's field value to face's entity ID
+     *data = mesh->getBulkData()->identifier(face);
+   }
+   for(auto face : faces) {
+     double* data = stk::mesh::field_data(*face_field_2, face);
+     // set the face's field value to face's entity ID * 2
+     *data = 2*mesh->getBulkData()->identifier(face);
+   }
+
+   if(mesh->isWritable())
+      mesh->writeToExodus("FaceBlock3.exo");
+
+   // minimal requirements
+   TEST_ASSERT(not mesh->isModifiable());
+
+   TEST_EQUALITY(mesh->getDimension(),3);
+   TEST_EQUALITY(mesh->getNumElementBlocks(),1);
+   TEST_EQUALITY(mesh->getNumSidesets(),6);
+   TEST_EQUALITY(mesh->getEntityCounts(mesh->getElementRank()),4*2*5);
+   TEST_EQUALITY(mesh->getEntityCounts(mesh->getSideRank()),2*4*(5+1)+2*5*(4+1)+4*5*(2+1));
+   TEST_EQUALITY(mesh->getEntityCounts(mesh->getEdgeRank()),2*(4+1)*(5+1)+4*(2+1)*(5+1)+5*(2+1)*(4+1));
+   TEST_EQUALITY(mesh->getEntityCounts(mesh->getNodeRank()),(4+1)*(2+1)*(5+1));
+
+   mesh->getAllFaces(panzer_stk::STK_Interface::faceBlockString, faces);
+   TEST_EQUALITY(faces.size(),2*4*(5+1)+4*5*(2+1)+5*2*(4+1));
+}
+
+TEUCHOS_UNIT_TEST(tExodusFaceBlock, set_face_field_data)
+{
+   using Teuchos::RCP;
+   using Teuchos::rcp;
+   using Teuchos::rcpFromRef;
+
+   RCP<Teuchos::ParameterList> pl = rcp(new Teuchos::ParameterList);
+   pl->set("X Blocks",1);
+   pl->set("Y Blocks",1);
+   pl->set("Z Blocks",1);
+   pl->set("X Elements",2);
+   pl->set("Y Elements",4);
+   pl->set("Z Elements",5);
+
+   CubeHexMeshFactory factory; 
+   factory.setParameterList(pl);
+   RCP<STK_Interface> mesh = factory.buildMesh(MPI_COMM_WORLD);
+   TEST_ASSERT(mesh!=Teuchos::null);
+
+   mesh->addFaceField("face_field_3", "eblock-0_0_0");
+   mesh->addFaceField("face_field_4", "eblock-0_0_0");
+
+   std::vector<stk::mesh::Entity> faces;
+   mesh->getMyFaces(panzer_stk::STK_Interface::faceBlockString, faces);
+
+   Kokkos::DynRankView<double,PHX::Device> faceValues;
+   faceValues = Kokkos::createDynRankView(faceValues,"faceValues",faces.size());
+
+   std::vector<std::size_t> faceIds;
+   for(auto face : faces) {
+     faceIds.push_back(mesh->faceLocalId(face));
+   }
+   sort(faceIds.begin(),faceIds.end());
+
+   for(std::size_t i=0;i<faceIds.size();i++) {
+     faceValues(i) = 3*mesh->faceGlobalId(faceIds[i]);
+   }
+   mesh->setFaceFieldData("face_field_3",
+                          "eblock-0_0_0",
+                          faceIds,
+                          faceValues);
+
+   for(std::size_t i=0;i<faceIds.size();i++) {
+     faceValues(i) = 4*mesh->faceGlobalId(faceIds[i]);
+   }
+   mesh->setFaceFieldData("face_field_4",
+                          "eblock-0_0_0",
+                          faceIds,
+                          faceValues);
+
+   if(mesh->isWritable())
+      mesh->writeToExodus("FaceBlock4.exo");
+
+   // minimal requirements
+   TEST_ASSERT(not mesh->isModifiable());
+
+   TEST_EQUALITY(mesh->getDimension(),3);
+   TEST_EQUALITY(mesh->getNumElementBlocks(),1);
+   TEST_EQUALITY(mesh->getNumSidesets(),6);
+   TEST_EQUALITY(mesh->getEntityCounts(mesh->getElementRank()),4*2*5);
+   TEST_EQUALITY(mesh->getEntityCounts(mesh->getSideRank()),2*4*(5+1)+2*5*(4+1)+4*5*(2+1));
+   TEST_EQUALITY(mesh->getEntityCounts(mesh->getEdgeRank()),2*(4+1)*(5+1)+4*(2+1)*(5+1)+5*(2+1)*(4+1));
+   TEST_EQUALITY(mesh->getEntityCounts(mesh->getNodeRank()),(4+1)*(2+1)*(5+1));
+
+   mesh->getAllFaces(panzer_stk::STK_Interface::faceBlockString, faces);
+   TEST_EQUALITY(faces.size(),2*4*(5+1)+4*5*(2+1)+5*2*(4+1));
+}
+
+}


### PR DESCRIPTION
@trilinos/panzer

## Motivation

This PR adds face block and face field features of STK-IO to Panzer::STK_Interface.  Features include a method to create a new face block, a method to add fields to a face block and get methods to retrieve faces from a face block.  The 3D mesh factories have been updated to create a face block named "face_block" that is populated with all faces in the new mesh.

Closes #8077 

## Testing

These changes are generally covered by the PanzerAdaptersSTK test set.  The new features are tested by PanzerAdaptersSTK _tExodusFaceBlock.exe.
