### PR TITLE
Tpetra: Allows FixedHashTable to build on CudaSpace

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_def.hpp
@@ -1233,7 +1233,7 @@ init (const keys_type& keys,
 
       // Return the old count; decrement afterwards.
       //
-      // Assumes UVM but this code should not execute for Cuda since buildInParallel is true
+      // Assumes UVM but this code should not execute for Cuda since buildInParallel is false
       const offset_type count = counts[hashVal];
       --counts[hashVal];
       if (count == 0) {
@@ -1241,7 +1241,7 @@ init (const keys_type& keys,
         break;
       }
       else {
-        // Assumes UVM but this code should not execute for Cuda since buildInParallel is true
+        // Assumes UVM but this code should not execute for Cuda since buildInParallel is false
         const offset_type curPos = ptr[hashVal+1] - count;
 
         // NOTE (mfh 28 Mar 2016) This assumes UVM.

--- a/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_def.hpp
@@ -1233,8 +1233,7 @@ init (const keys_type& keys,
 
       // Return the old count; decrement afterwards.
       //
-      // NOTE (mfh 28 Mar 2016) This assumes UVM.  It might make more
-      // sense to use a host mirror here, due to the access pattern.
+      // Assumes UVM but this code should not execute for Cuda since buildInParallel is true
       const offset_type count = counts[hashVal];
       --counts[hashVal];
       if (count == 0) {
@@ -1242,7 +1241,7 @@ init (const keys_type& keys,
         break;
       }
       else {
-        // NOTE (mfh 28 Mar 2016) This assumes UVM.
+        // Assumes UVM but this code should not execute for Cuda since buildInParallel is true
         const offset_type curPos = ptr[hashVal+1] - count;
 
         // NOTE (mfh 28 Mar 2016) This assumes UVM.

--- a/packages/tpetra/core/src/Tpetra_Map_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Map_def.hpp
@@ -701,20 +701,12 @@ namespace Tpetra {
                          nonContigGids_host.size ());
         Kokkos::deep_copy (nonContigGids, nonContigGids_host);
 
-        // FixedHashTable currently cannot be built on CudaSpace due to UVM
-        // dependence so copy back to device_type (CudaUVMSpace).
-        // This can go away when FixedHashTable is modified to run on CudaSpace.
-        typedef ::Tpetra::Details::FixedHashTable<global_ordinal_type,
-          local_ordinal_type, device_type> global_to_local_table_device_type;
-        global_to_local_table_device_type glMap(nonContigGids,
-                                                firstContiguousGID_,
-                                                lastContiguousGID_,
-                                                static_cast<LO> (i));
-
-        // Now copy to CudaSpace and also make the host version
-        // Note when memory spaces match these just do trivial assignment
-        glMap_ = global_to_local_table_type(glMap);
-        glMapHost_ = global_to_local_table_host_type(glMap);
+        glMap_ = global_to_local_table_type(nonContigGids,
+                                            firstContiguousGID_,
+                                            lastContiguousGID_,
+                                            static_cast<LO> (i));
+        // Make host version - when memory spaces match these just do trivial assignment
+        glMapHost_ = global_to_local_table_host_type(glMap_);
       }
 
       // FIXME (mfh 10 Oct 2016) When we construct the global-to-local
@@ -1093,22 +1085,12 @@ namespace Tpetra {
            << entryList.extent (0) << " - " << i
            << ".  Please report this bug to the Tpetra developers.");
 
-        // FixedHashTable currently cannot be built on CudaSpace due to UVM
-        // dependence so copy back to device_type (CudaUVMSpace).
-        // This can go away when FixedHashTable is modified to run on CudaSpace.
-        typedef ::Tpetra::Details::FixedHashTable<global_ordinal_type,
-          local_ordinal_type, device_type> global_to_local_table_device_type;
-        auto device_nonContigGids =
-          Kokkos::create_mirror_view_and_copy(device_type(), nonContigGids);
-        global_to_local_table_device_type glMap(device_nonContigGids,
-                                                firstContiguousGID_,
-                                                lastContiguousGID_,
-                                                static_cast<LO> (i));
-
-        // Now copy to CudaSpace and also make the host version
-        // Note when memory spaces match these just do trivial assignment
-        glMap_ = global_to_local_table_type(glMap);
-        glMapHost_ = global_to_local_table_host_type(glMap);
+        glMap_ = global_to_local_table_type(nonContigGids,
+                                            firstContiguousGID_,
+                                            lastContiguousGID_,
+                                            static_cast<LO> (i));
+        // Make host version - when memory spaces match these just do trivial assignment
+        glMapHost_ = global_to_local_table_host_type(glMap_);
       }
 
       // FIXME (mfh 10 Oct 2016) When we construct the global-to-local


### PR DESCRIPTION
@kddevin @csiefer2 Resolves FixedHashTable so it can construct on CudaSpace. Previously it assumed UVM. This is the repair we discussed earlier and it cleans up the setup in Map.

The next step would be to write a parallel kernel version of the search for the first non-continuous key. We may not want to merge this PR until that is resolved since my change can impact performance. But I think it's ok to treat that as a separate issue because even though I added a copy in FixedHashTable, I was able to remove the extra copy in Map.

I could start working on a parallel kernel version. I am wondering if a simple parallel for loop with atomic comparison checks for non-contiguous neighbors might actually do unexpectedly well, based on prior experience with Multijagged kernels.  That would be much simpler but I'm not sure yet exactly what kind of distributions we are dealing with.

Note there was another potential UVM read I did not fix because it's in a block for buildInParallel false, which would never be the case currently for Cuda. I changed those comments to reflect this. 

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Map currently builds FixedHashTable on CudaUVMSpace because FixedHashTable had UVM dependencies. This change allows Map to directly work with CudaSpace and avoid an extra copy of the hash.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
white Cuda build

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->