### PR TITLE
Tempus: Identify usage of FSAL

### DIFF
--- a/packages/tempus/src/Tempus_Integrator.hpp
+++ b/packages/tempus/src/Tempus_Integrator.hpp
@@ -79,7 +79,7 @@ public:
     /// Get the stepper
     virtual Teuchos::RCP<Stepper<Scalar> > getStepper() const = 0;
     /// Return a copy of the Tempus ParameterList
-    virtual Teuchos::RCP<Teuchos::ParameterList> getTempusParameterList()	= 0;
+    virtual Teuchos::RCP<Teuchos::ParameterList> getTempusParameterList() = 0;
     virtual void setTempusParameterList(Teuchos::RCP<Teuchos::ParameterList> pl) = 0;
     /// Returns the SolutionHistory for this Integrator
     virtual Teuchos::RCP<const SolutionHistory<Scalar> > getSolutionHistory() const = 0;

--- a/packages/tempus/src/Tempus_StepperBDF2_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperBDF2_decl.hpp
@@ -43,7 +43,7 @@ namespace Tempus {
  *                -  \frac{\tau_n}{\tau_n + \tau_{n-1}}
  *                   \left[ \frac{x_{n-1}-x_{n-2}}{\tau_{n-1}}\right], \f$
  *
- *  The First-Same-As-Last (FSAL) principle is not needed BDF2.
+ *  The First-Same-As-Last (FSAL) principle is not needed for BDF2.
  *  The default is to set useFSAL=false, however useFSAL=true will also work
  *  but have no affect (i.e., no-op).
  *
@@ -136,7 +136,6 @@ public:
       {return isExplicit() and isImplicit();}
     virtual bool isOneStepMethod()   const {return false;}
     virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
-
     virtual OrderODE getOrderODE()   const {return FIRST_ORDER_ODE;}
   //@}
 
@@ -151,7 +150,6 @@ public:
   virtual void computeStartUp(
     const Teuchos::RCP<SolutionHistory<Scalar> >& solutionHistory);
 
-  virtual bool getICConsistencyCheckDefault() const { return false; }
   Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
 
   /// \name Overridden from Teuchos::Describable

--- a/packages/tempus/src/Tempus_StepperBDF2_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperBDF2_impl.hpp
@@ -26,9 +26,9 @@ template<class Scalar>
 StepperBDF2<Scalar>::StepperBDF2()
 {
   this->setStepperType(        "BDF2");
-  this->setUseFSAL(            this->getUseFSALDefault());
-  this->setICConsistency(      this->getICConsistencyDefault());
-  this->setICConsistencyCheck( this->getICConsistencyCheckDefault());
+  this->setUseFSAL(            false);
+  this->setICConsistency(      "None");
+  this->setICConsistencyCheck( false);
   this->setZeroInitialGuess(   false);
 
   this->setObserver();
@@ -333,8 +333,7 @@ StepperBDF2<Scalar>::getValidParameters() const
 {
   Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
   getValidParametersBasic(pl, this->getStepperType());
-  pl->set<bool>("Initial Condition Consistency Check",
-                this->getICConsistencyCheckDefault());
+  pl->set<bool>("Initial Condition Consistency Check", false);
   pl->set<std::string>("Solver Name", "Default Solver");
   pl->set<bool>("Zero Initial Guess", false);
   pl->set<std::string>("Start Up Stepper Type", "DIRK 1 Stage Theta Method");

--- a/packages/tempus/src/Tempus_StepperBackwardEuler_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperBackwardEuler_decl.hpp
@@ -146,7 +146,6 @@ public:
       {return isExplicit() and isImplicit();}
     virtual bool isOneStepMethod()   const {return true;}
     virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
-
     virtual OrderODE getOrderODE()   const {return FIRST_ORDER_ODE;}
   //@}
 

--- a/packages/tempus/src/Tempus_StepperBackwardEuler_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperBackwardEuler_impl.hpp
@@ -27,9 +27,9 @@ template<class Scalar>
 StepperBackwardEuler<Scalar>::StepperBackwardEuler()
 {
   this->setStepperType(        "Backward Euler");
-  this->setUseFSAL(            this->getUseFSALDefault());
-  this->setICConsistency(      this->getICConsistencyDefault());
-  this->setICConsistencyCheck( this->getICConsistencyCheckDefault());
+  this->setUseFSAL(            false);
+  this->setICConsistency(      "None");
+  this->setICConsistencyCheck( false);
   this->setZeroInitialGuess(   false);
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
@@ -204,15 +204,6 @@ void StepperBackwardEuler<Scalar>::setInitialConditions(
     this->setStepperXDot(initialState->getXDot());
 
   StepperImplicit<Scalar>::setInitialConditions(solutionHistory);
-
-  if (this->getUseFSAL()) {
-    RCP<Teuchos::FancyOStream> out = this->getOStream();
-    Teuchos::OSTab ostab(out,1,"StepperBackwardEuler::setInitialConditions()");
-    *out << "\nWarning -- The First-Same-As-Last (FSAL) principle is not "
-         << "needed with Backward Euler.  The default is to set useFSAL=false, "
-         << "however useFSAL=true will also work but have no affect "
-         << "(i.e., no-op).\n" << std::endl;
-  }
 }
 
 

--- a/packages/tempus/src/Tempus_StepperDIRK_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperDIRK_impl.hpp
@@ -25,12 +25,8 @@ template<class Scalar> class StepperFactory;
 template<class Scalar>
 void StepperDIRK<Scalar>::setupDefault()
 {
-  this->setUseFSAL(            this->getUseFSALDefault());
-  this->setICConsistency(      this->getICConsistencyDefault());
-  this->setICConsistencyCheck( this->getICConsistencyCheckDefault());
-  this->setUseEmbedded(        this->getUseEmbeddedDefault());
+  this->setUseEmbedded(        false);
   this->setZeroInitialGuess(   false);
-
   this->setStageNumber(-1);
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE

--- a/packages/tempus/src/Tempus_StepperExplicitRK_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperExplicitRK_impl.hpp
@@ -21,11 +21,7 @@ namespace Tempus {
 template<class Scalar>
 void StepperExplicitRK<Scalar>::setupDefault()
 {
-  this->setUseFSAL(            this->getUseFSALDefault());
-  this->setICConsistency(      this->getICConsistencyDefault());
-  this->setICConsistencyCheck( this->getICConsistencyCheckDefault());
-  this->setUseEmbedded(        this->getUseEmbeddedDefault());
-
+  this->setUseEmbedded(false);
   this->setStageNumber(-1);
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE

--- a/packages/tempus/src/Tempus_StepperExplicit_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperExplicit_impl.hpp
@@ -184,15 +184,24 @@ void StepperExplicit<Scalar>::setInitialConditions(
       else reldiff = Thyra::norm(*f)/normX;
 
       Scalar eps = Scalar(100.0)*std::abs(Teuchos::ScalarTraits<Scalar>::eps());
-      if (reldiff > eps) {
-        RCP<Teuchos::FancyOStream> out = this->getOStream();
-        Teuchos::OSTab ostab(out,1,"StepperExplicit::setInitialConditions()");
-        *out << "Warning -- Failed consistency check but continuing!\n"
-           << "  ||xDot-f(x,t)||/||x|| > eps" << std::endl
-           << "  ||xDot-f(x,t)||       = " << Thyra::norm(*f) << std::endl
-           << "  ||x||                 = " << Thyra::norm(*x) << std::endl
-           << "  ||xDot-f(x,t)||/||x|| = " << reldiff         << std::endl
-           << "                    eps = " << eps             << std::endl;
+      RCP<Teuchos::FancyOStream> out = this->getOStream();
+      Teuchos::OSTab ostab(out,1,"StepperExplicit::setInitialConditions()");
+      if (reldiff < eps) {
+        *out << "\n---------------------------------------------------\n"
+           << "Info -- Stepper = " << this->getStepperType() << "\n"
+           << "  Initial condition PASSED consistency check!\n"
+           << "  (||xDot-f(x,t)||/||x|| = " << reldiff << ") < "
+           << "(eps = " << eps << ")" << std::endl
+           << "---------------------------------------------------\n"<<std::endl;
+      } else {
+        *out << "\n---------------------------------------------------\n"
+           << "Info -- Stepper = " << this->getStepperType() << "\n"
+           << "  Initial condition FAILED consistency check but continuing!\n"
+           << "  (||xDot-f(x,t)||/||x|| = " << reldiff << ") > "
+           << "(eps = " << eps << ")" << std::endl
+           << "  ||xDot-f(x,t)|| = " << Thyra::norm(*f) << std::endl
+           << "  ||x||           = " << Thyra::norm(*x) << std::endl
+           << "---------------------------------------------------\n"<<std::endl;
       }
     }
     else if (this->getOrderODE() == SECOND_ORDER_ODE) {
@@ -208,17 +217,24 @@ void StepperExplicit<Scalar>::setInitialConditions(
       else reldiff = Thyra::norm(*f)/normX;
 
       Scalar eps = Scalar(100.0)*std::abs(Teuchos::ScalarTraits<Scalar>::eps());
-      if (reldiff > eps) {
-        RCP<Teuchos::FancyOStream> out = this->getOStream();
-        Teuchos::OSTab ostab(out,1,"StepperExplicit::setInitialConditions()");
-        *out << "Warning -- Failed consistency check but continuing!\n"
-           << "  ||xDotDot-f(x,xDot,t)||/||x|| > eps" << std::endl
-           << "  ||xDotDot-f(x,xDot,t)||       = " << Thyra::norm(*f)
-           << std::endl
-           << "  ||x||                         = " << Thyra::norm(*x)
-           << std::endl
-           << "  ||xDotDot-f(x,xDot,t)||/||x|| = " << reldiff << std::endl
-           << "                            eps = " << eps     << std::endl;
+      RCP<Teuchos::FancyOStream> out = this->getOStream();
+      Teuchos::OSTab ostab(out,1,"StepperExplicit::setInitialConditions()");
+      if (reldiff < eps) {
+        *out << "\n---------------------------------------------------\n"
+           << "Info -- Stepper = " << this->getStepperType() << "\n"
+           << "  Initial condition PASSED consistency check!\n"
+           << "  (||xDotDot-f(x,xDot,t)||/||x|| = " << reldiff << ") > "
+           << "(eps = " << eps << ")" << std::endl
+           << "---------------------------------------------------\n"<<std::endl;
+      } else {
+        *out << "\n---------------------------------------------------\n"
+            << "Info -- Stepper = " << this->getStepperType() << "\n"
+           << "Initial condition FAILED consistency check but continuing!\n"
+           << "  (||xDotDot-f(x,xDot,t)||/||x|| = " << reldiff << ") > "
+           << "(eps = " << eps << ")" << std::endl
+           << "  ||xDotDot-f(x,xDot,t)|| = " << Thyra::norm(*f) << std::endl
+           << "  ||x||                   = " << Thyra::norm(*x) << std::endl
+           << "---------------------------------------------------\n"<<std::endl;
       }
     }
   }

--- a/packages/tempus/src/Tempus_StepperFactory_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperFactory_impl.hpp
@@ -1419,16 +1419,16 @@ setStepperValues(
       + stepper->getStepperType() + "').");
     stepper->setStepperType(stepperType);
 
-    stepper->setUseFSAL(
-      stepperPL->get<bool>("Use FSAL", stepper->getUseFSALDefault()));
+    if ( stepperPL->isParameter("Use FSAL") )
+      stepper->setUseFSAL(stepperPL->get<bool>("Use FSAL"));
 
-    stepper->setICConsistency(
-      stepperPL->get<std::string>("Initial Condition Consistency",
-                                  stepper->getICConsistencyDefault()));
+    if ( stepperPL->isParameter("Initial Condition Consistency") )
+      stepper->setICConsistency(
+        stepperPL->get<std::string>("Initial Condition Consistency"));
 
-    stepper->setICConsistencyCheck(
-      stepperPL->get<bool>("Initial Condition Consistency Check",
-                           stepper->getICConsistencyCheckDefault()));
+    if ( stepperPL->isParameter("Initial Condition Consistency Check") )
+      stepper->setICConsistencyCheck(
+        stepperPL->get<bool>("Initial Condition Consistency Check"));
   }
 }
 
@@ -1598,8 +1598,8 @@ setStepperRKValues(
     stepperPL->validateParametersAndSetDefaults(
                                             *stepper->getValidParameters());
     setStepperValues(stepper, stepperPL);
-    stepper->setUseEmbedded(
-      stepperPL->get<bool>("Use Embedded",stepper->getUseEmbeddedDefault()));
+    if ( stepperPL->isParameter("Use Embedded") )
+      stepper->setUseEmbedded(stepperPL->get<bool>("Use Embedded"));
   }
 }
 
@@ -1646,10 +1646,10 @@ setStepperDIRKValues(
     //stepperPL->validateParametersAndSetDefaults(
     //                                      *stepper->getValidParameters());
     setStepperValues(stepper, stepperPL);
-    stepper->setUseEmbedded(
-      stepperPL->get<bool>("Use Embedded",stepper->getUseEmbeddedDefault()));
-    stepper->setZeroInitialGuess(
-      stepperPL->get<bool>("Zero Initial Guess", false));
+    if ( stepperPL->isParameter("Use Embedded") )
+      stepper->setUseEmbedded(stepperPL->get<bool>("Use Embedded"));
+    if ( stepperPL->isParameter("Zero Initial Guess") )
+      stepper->setZeroInitialGuess(stepperPL->get<bool>("Zero Initial Guess"));
   }
 }
 

--- a/packages/tempus/src/Tempus_StepperForwardEuler_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperForwardEuler_decl.hpp
@@ -35,21 +35,41 @@ namespace Tempus {
  *  \f]
  *
  *  <b> Algorithm </b>
- *  The single-timestep algorithm for Forward Euler is simply,
- *   - \f$\dot{x}_{n-1} \leftarrow \bar{f}(x_{n-1},t_{n-1})\f$
- *   - \f$x_{n} \leftarrow x_{n-1} + \Delta t\, \dot{x}_{n-1}\f$
+ *  The single-timestep algorithm for Forward Euler is
+ *  \f{algorithm}{
+ *  \renewcommand{\thealgorithm}{}
+ *  \caption{Forward Euler}
+ *  \begin{algorithmic}[1]
+ *    \State {\it appAction.execute(solutionHistory, stepper, BEGIN\_STEP)}
+ *    \If { Not ``Use FSAL'' or (previous step failed)}
+ *      \State {\it appAction.execute(solutionHistory, stepper, BEFORE\_EXPLICIT\_EVAL)}
+ *      \State $\dot{x}_{n-1} \leftarrow \bar{f}(x_{n-1},t_{n-1})$
+ *    \EndIf
+ *    \State $x_{n} \leftarrow x_{n-1} + \Delta t\, \dot{x}_{n-1}$
+ *        \Comment{Forward Euler update.}
+ *    \If { ``Use FSAL'' }
+ *      \State {\it appAction.execute(solutionHistory, stepper, BEFORE\_EXPLICIT\_EVAL)}
+ *      \State $\dot{x}_n \leftarrow \bar{f}(x_{n},t_{n})$
+ *    \EndIf
+ *    \State {\it appAction.execute(solutionHistory, stepper, END\_STEP)}
+ *  \end{algorithmic}
+ *  \f}
  *
- *  Note that \f$x_n\f$ and \f$\dot{x}_{n-1}\f$ are not at the same time
- *  level at the end of the time step (i.e., they are not sync'ed).
+ *  Note that with useFSAL=false \f$x_n\f$ and \f$\dot{x}_{n-1}\f$ are not
+ *  at the same time level at the end of the time step (i.e., they are not
+ *  sync'ed).
  *
  *  To have them at the same time level, we can use the First-Same-As-Last
  *  (FSAL) principle where the function evaulation from the last time step
  *  can be used as the first function evalulation of the current step.
- *  For the Forward Euler, the FSAL algorithm is
- *   - \f$x_{n} \leftarrow x_{n-1} + \Delta t\, \dot{x}_{n-1}\f$
- *   - \f$\dot{x}_n \leftarrow \bar{f}(x_{n},t_{n})\f$
  *
- *  The default for Forward Euler is to use FSAL (useFSAL=true).
+ *  The default for Forward Euler is to use FSAL (useFSAL=true), but will
+ *  also work with useFSAL=false.  Using useFSAL=true does assume that the
+ *  solution, \f$x\f$, and its time derivative, \f$\dot{x}\f$, are consistent
+ *  at the initial conditions (ICs), i.e.,
+ *  \f$\dot{x}_{0} = \bar{f}(x_{0},t_{0})\f$.  This can be ensured by setting
+ *  setICConsistency("Consistent"), and checked with
+ *  setICConsistencyCheck(true).
  */
 template<class Scalar>
 class StepperForwardEuler : virtual public Tempus::StepperExplicit<Scalar>
@@ -110,7 +130,7 @@ public:
     virtual Scalar getOrder() const {return 1.0;}
     virtual Scalar getOrderMin() const {return 1.0;}
     virtual Scalar getOrderMax() const {return 1.0;}
-
+    virtual void setUseFSAL(bool a) { this->useFSAL_ = a; this->isInitialized_ = false; }
     virtual OrderODE getOrderODE()   const {return FIRST_ORDER_ODE;}
   //@}
 

--- a/packages/tempus/src/Tempus_StepperForwardEuler_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperForwardEuler_impl.hpp
@@ -19,9 +19,9 @@ template<class Scalar>
 StepperForwardEuler<Scalar>::StepperForwardEuler()
 {
   this->setStepperType(        "Forward Euler");
-  this->setUseFSAL(            this->getUseFSALDefault());
-  this->setICConsistency(      this->getICConsistencyDefault());
-  this->setICConsistencyCheck( this->getICConsistencyCheckDefault());
+  this->setUseFSAL(            true);
+  this->setICConsistency(      "Consistent");
+  this->setICConsistencyCheck( false);
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
   this->setObserver();
 #endif
@@ -159,13 +159,13 @@ void StepperForwardEuler<Scalar>::takeStep(
     RCP<Thyra::VectorBase<Scalar> > xDot = this->getStepperXDot();
     const Scalar dt = workingState->getTimeStep();
 
-    if ( !(this->getUseFSAL()) ) {
+    if (!(this->getUseFSAL()) || workingState->getNConsecutiveFailures() != 0) {
       // Need to compute XDotOld.
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
       if (!Teuchos::is_null(stepperFEObserver_))
         stepperFEObserver_->observeBeforeExplicit(solutionHistory, *this);
 #endif
-     stepperFEAppAction_->execute(solutionHistory, thisStepper,
+      stepperFEAppAction_->execute(solutionHistory, thisStepper,
         StepperForwardEulerAppAction<Scalar>::ACTION_LOCATION::BEFORE_EXPLICIT_EVAL);
 
       auto p = Teuchos::rcp(new ExplicitODEParameters<Scalar>(dt));

--- a/packages/tempus/src/Tempus_StepperHHTAlpha_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperHHTAlpha_decl.hpp
@@ -127,7 +127,6 @@ public:
       {return isExplicit() and isImplicit();}
     virtual bool isOneStepMethod()   const {return true;}
     virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
-
     virtual OrderODE getOrderODE()   const {return SECOND_ORDER_ODE;}
   //@}
 

--- a/packages/tempus/src/Tempus_StepperHHTAlpha_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperHHTAlpha_impl.hpp
@@ -248,9 +248,9 @@ StepperHHTAlpha<Scalar>::StepperHHTAlpha() :
 #endif
 
   this->setStepperType(        "HHT-Alpha");
-  this->setUseFSAL(            this->getUseFSALDefault());
-  this->setICConsistency(      this->getICConsistencyDefault());
-  this->setICConsistencyCheck( this->getICConsistencyCheckDefault());
+  this->setUseFSAL(            false);
+  this->setICConsistency(      "None");
+  this->setICConsistencyCheck( false);
   this->setZeroInitialGuess(   false);
   this->setSchemeName(         "Newmark Beta Average Acceleration");
   this->setAlphaF(             0.0);

--- a/packages/tempus/src/Tempus_StepperIMEX_RK_Partition_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RK_Partition_decl.hpp
@@ -304,7 +304,7 @@ namespace Tempus {
  *
  *  The First-Same-As-Last (FSAL) principle is not valid for IMEX RK Partition.
  *  The default is to set useFSAL=false, and useFSAL=true will result
- *  in an error.
+ *  in a warning.
  *
  *  #### References
  *  -# Shadid, Cyr, Pawlowski, Widley, Scovazzi, Zeng, Phillips, Conde,
@@ -425,7 +425,6 @@ public:
       {return isExplicit() and isImplicit();}
     virtual bool isOneStepMethod()   const {return true;}
     virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
-
     virtual OrderODE getOrderODE()   const {return FIRST_ORDER_ODE;}
   //@}
 

--- a/packages/tempus/src/Tempus_StepperIMEX_RK_Partition_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RK_Partition_impl.hpp
@@ -27,9 +27,9 @@ template<class Scalar>
 StepperIMEX_RK_Partition<Scalar>::StepperIMEX_RK_Partition()
 {
   this->setStepperType(        "Partitioned IMEX RK SSP2");
-  this->setUseFSAL(            this->getUseFSALDefault());
-  this->setICConsistency(      this->getICConsistencyDefault());
-  this->setICConsistencyCheck( this->getICConsistencyCheckDefault());
+  this->setUseFSAL(            false);
+  this->setICConsistency(      "None");
+  this->setICConsistencyCheck( false);
   this->setZeroInitialGuess(   false);
 
   this->setStageNumber(-1);
@@ -875,8 +875,7 @@ StepperIMEX_RK_Partition<Scalar>::getValidParameters() const
   pl->setName("Default Stepper - Partitioned IMEX RK SSP2");
   pl->set<std::string>("Stepper Type", "Partitioned IMEX RK SSP2");
   getValidParametersBasic(pl, this->getStepperType());
-  pl->set<bool>("Initial Condition Consistency Check",
-                this->getICConsistencyCheckDefault());
+  pl->set<bool>("Initial Condition Consistency Check", false);
   pl->set<std::string>("Solver Name", "Default Solver");
   pl->set<bool>       ("Zero Initial Guess", false);
   Teuchos::RCP<Teuchos::ParameterList> solverPL = defaultSolverParameters();

--- a/packages/tempus/src/Tempus_StepperIMEX_RK_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RK_decl.hpp
@@ -268,7 +268,7 @@ namespace Tempus {
  *
  *  The First-Same-As-Last (FSAL) principle is not valid for IMEX RK.
  *  The default is to set useFSAL=false, and useFSAL=true will result
- *  in an error.
+ *  in a warning.
  *
  *
  *  #### References
@@ -393,7 +393,6 @@ public:
       {return isExplicit() and isImplicit();}
     virtual bool isOneStepMethod()   const {return true;}
     virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
-
     virtual OrderODE getOrderODE()   const {return FIRST_ORDER_ODE;}
   //@}
 
@@ -429,8 +428,6 @@ public:
     const Teuchos::RCP<const Thyra::VectorBase<Scalar> > & X,
     Scalar time, Scalar stepSize, Scalar stageNumber,
     const Teuchos::RCP<Thyra::VectorBase<Scalar> > & F) const;
-
-  virtual bool getICConsistencyCheckDefault() const { return false; }
 
   void setOrder(Scalar order) { order_ = order; }
 

--- a/packages/tempus/src/Tempus_StepperIMEX_RK_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperIMEX_RK_impl.hpp
@@ -27,9 +27,9 @@ template<class Scalar>
 StepperIMEX_RK<Scalar>::StepperIMEX_RK()
 {
   this->setStepperType(        "IMEX RK SSP2");
-  this->setUseFSAL(            this->getUseFSALDefault());
-  this->setICConsistency(      this->getICConsistencyDefault());
-  this->setICConsistencyCheck( this->getICConsistencyCheckDefault());
+  this->setUseFSAL(            false);
+  this->setICConsistency(      "None");
+  this->setICConsistencyCheck( false);
   this->setZeroInitialGuess(   false);
 
   this->setStageNumber(-1);
@@ -910,8 +910,7 @@ StepperIMEX_RK<Scalar>::getValidParameters() const
 {
   Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
   getValidParametersBasic(pl, this->getStepperType());
-  pl->set<bool>("Initial Condition Consistency Check",
-                this->getICConsistencyCheckDefault());
+  pl->set<bool>("Initial Condition Consistency Check", false);
   pl->set<std::string>("Solver Name", "Default Solver");
   pl->set<bool>       ("Zero Initial Guess", false);
   Teuchos::RCP<Teuchos::ParameterList> solverPL = defaultSolverParameters();

--- a/packages/tempus/src/Tempus_StepperImplicit_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperImplicit_impl.hpp
@@ -185,15 +185,24 @@ void StepperImplicit<Scalar>::setInitialConditions(
     else reldiff = Thyra::norm(*f)/normX;
 
     Scalar eps = Scalar(100.0)*std::abs(Teuchos::ScalarTraits<Scalar>::eps());
-    if (reldiff > eps) {
-      RCP<Teuchos::FancyOStream> out = this->getOStream();
-      Teuchos::OSTab ostab(out,1,"StepperImplicit::setInitialConditions()");
-      *out << "Info -- Failed consistency check but continuing!\n"
-         << "  ||f(x,xDot,t)||/||x|| > eps" << std::endl
-         << "  ||f(x,xDot,t)||       = " << Thyra::norm(*f) << std::endl
-         << "  ||x||                 = " << Thyra::norm(*x) << std::endl
-         << "  ||f(x,xDot,t)||/||x|| = " << reldiff         << std::endl
-         << "                    eps = " << eps             << std::endl;
+    RCP<Teuchos::FancyOStream> out = this->getOStream();
+    Teuchos::OSTab ostab(out,1,"StepperImplicit::setInitialConditions()");
+    if (reldiff < eps) {
+      *out << "\n---------------------------------------------------\n"
+           << "Info -- Stepper = " << this->getStepperType() << "\n"
+           << "  Initial condition PASSED consistency check!\n"
+           << "  (||f(x,xDot,t)||/||x|| = " << reldiff << ") < "
+           << "(eps = " << eps << ")"            << std::endl
+           << "---------------------------------------------------\n"<<std::endl;
+    } else {
+      *out << "\n---------------------------------------------------\n"
+           << "Info -- Stepper = " << this->getStepperType() << "\n"
+           << "  Initial condition FAILED consistency check but continuing!\n"
+           << "  (||f(x,xDot,t)||/||x|| = " << reldiff << ") > "
+           << "(eps = " << eps << ")" << std::endl
+           << "  ||f(x,xDot,t)|| = " << Thyra::norm(*f) << std::endl
+           << "  ||x||           = " << Thyra::norm(*x) << std::endl
+           << "---------------------------------------------------\n"<<std::endl;
     }
   }
 }

--- a/packages/tempus/src/Tempus_StepperLeapfrog_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperLeapfrog_decl.hpp
@@ -74,8 +74,8 @@ namespace Tempus {
  *
  *  The First-Same-As-Last (FSAL) principle is not used with Leapfrog
  *  because of the algorithm's prescribed order of solution update.
- *  The default is to set useFSAL=false, however useFSAL=true will also
- *  work (i.e., no-op), but issue a warning that it will have no affect.
+ *  The default is to set useFSAL=false, and useFSAL=true will
+ *  issue a warning that it will have no affect.
  */
 template<class Scalar>
 class StepperLeapfrog : virtual public Tempus::StepperExplicit<Scalar>
@@ -146,13 +146,10 @@ public:
       {return isExplicit() and isImplicit();}
     virtual bool isOneStepMethod()   const {return true;}
     virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
-
     virtual OrderODE getOrderODE()   const {return SECOND_ORDER_ODE;}
   //@}
 
   Teuchos::RCP<const Teuchos::ParameterList> getValidParameters() const;
-
-  std::string getICConsistencyDefault() const { return "Consistent"; }
 
   /// \name Overridden from Teuchos::Describable
   //@{

--- a/packages/tempus/src/Tempus_StepperLeapfrog_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperLeapfrog_impl.hpp
@@ -20,9 +20,9 @@ template<class Scalar>
 StepperLeapfrog<Scalar>::StepperLeapfrog()
 {
   this->setStepperType(        "Leapfrog");
-  this->setUseFSAL(            this->getUseFSALDefault());
-  this->setICConsistency(      this->getICConsistencyDefault());
-  this->setICConsistencyCheck( this->getICConsistencyCheckDefault());
+  this->setUseFSAL(            false);
+  this->setICConsistency(      "Consistent");
+  this->setICConsistencyCheck( false);
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
   this->setObserver();
@@ -298,8 +298,7 @@ StepperLeapfrog<Scalar>::getValidParameters() const
 {
   Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
   getValidParametersBasic(pl, this->getStepperType());
-  pl->set<std::string>("Initial Condition Consistency",
-                       this->getICConsistencyDefault());
+  pl->set<std::string>("Initial Condition Consistency", "Consistent");
   return pl;
 }
 

--- a/packages/tempus/src/Tempus_StepperNewmarkExplicitAForm_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkExplicitAForm_impl.hpp
@@ -63,12 +63,10 @@ StepperNewmarkExplicitAForm<Scalar>::StepperNewmarkExplicitAForm()
   : gammaDefault_(Scalar(0.5)), gamma_(Scalar(0.5))
 {
   this->setStepperType(        "Newmark Explicit a-Form");
-  this->setUseFSAL(            this->getUseFSALDefault());
-  this->setICConsistency(      this->getICConsistencyDefault());
-  this->setICConsistencyCheck( this->getICConsistencyCheckDefault());
+  this->setUseFSAL(            true);
+  this->setICConsistency(      "Consistent");
+  this->setICConsistencyCheck( false);
   this->setAppAction(Teuchos::null);
-
-  //this->setObserver();
 }
 
 
@@ -88,8 +86,6 @@ StepperNewmarkExplicitAForm<Scalar>::StepperNewmarkExplicitAForm(
   this->setICConsistency(      ICConsistency);
   this->setICConsistencyCheck( ICConsistencyCheck);
   this->setAppAction(Teuchos::null);
-
-  //this->setObserver(obs);
 
   setGamma(gamma);
 
@@ -240,17 +236,24 @@ void StepperNewmarkExplicitAForm<Scalar>::setInitialConditions(
     Scalar eps = Scalar(100.0)*std::abs(Teuchos::ScalarTraits<Scalar>::eps());
     if (normxDotDot > eps*reldiff) reldiff /= normxDotDot;
 
+    RCP<Teuchos::FancyOStream> out = this->getOStream();
+    Teuchos::OSTab ostab(out,1,"StepperNewmarkExplicitAForm::setInitialConditions()");
     if (reldiff > eps) {
-      RCP<Teuchos::FancyOStream> out = this->getOStream();
-      Teuchos::OSTab ostab(out,1,"StepperForwardEuler::setInitialConditions()");
-      *out << "Warning -- Failed consistency check but continuing!\n"
-         << "  ||xDotDot-f(x,t)||/||xDotDot|| > eps" << std::endl
-         << "  ||xDotDot-f(x,t)||             = " << Thyra::norm(*f)
-         << std::endl
-         << "  ||xDotDot||                    = " << Thyra::norm(*xDotDot)
-         << std::endl
-         << "  ||xDotDot-f(x,t)||/||xDotDot|| = " << reldiff << std::endl
-         << "                             eps = " << eps     << std::endl;
+      *out << "\n---------------------------------------------------\n"
+         << "Info -- Stepper = " << this->getStepperType() << "\n"
+         << "  Initial condition PASSED consistency check!\n"
+         << "  (||xDotDot-f(x,xDot,t)||/||x|| = " << reldiff << ") > "
+         << "(eps = " << eps << ")" << std::endl
+         << "---------------------------------------------------\n"<<std::endl;
+    } else {
+      *out << "\n---------------------------------------------------\n"
+          << "Info -- Stepper = " << this->getStepperType() << "\n"
+         << "Initial condition FAILED consistency check but continuing!\n"
+         << "  (||xDotDot-f(x,xDot,t)||/||x|| = " << reldiff << ") > "
+         << "(eps = " << eps << ")" << std::endl
+         << "  ||xDotDot-f(x,xDot,t)|| = " << Thyra::norm(*f) << std::endl
+         << "  ||x||                   = " << Thyra::norm(*x) << std::endl
+         << "---------------------------------------------------\n"<<std::endl;
     }
   }
 }
@@ -291,7 +294,7 @@ void StepperNewmarkExplicitAForm<Scalar>::takeStep(
     const Scalar time_old = currentState->getTime();
 
     auto p = Teuchos::rcp(new ExplicitODEParameters<Scalar>(dt));
-    if ( !(this->getUseFSAL()) ) {
+    if (!(this->getUseFSAL()) || workingState->getNConsecutiveFailures() != 0) {
       // Evaluate xDotDot = f(x, xDot, t).
       this->evaluateExplicitODE(a_old, d_old, v_old, time_old, p);
 
@@ -394,30 +397,29 @@ StepperNewmarkExplicitAForm<Scalar>::getValidParameters() const
 {
   Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
   getValidParametersBasic(pl, this->getStepperType());
-  pl->set<bool>("Use FSAL", this->getUseFSALDefault());
-  pl->set<std::string>("Initial Condition Consistency",
-                       this->getICConsistencyDefault());
+  pl->set<bool>("Use FSAL", true);
+  pl->set<std::string>("Initial Condition Consistency", "Consistent");
   pl->sublist("Newmark Explicit Parameters", false, "");
   pl->sublist("Newmark Explicit Parameters", false, "").set("Gamma",
                0.5, "Newmark Explicit parameter");
   return pl;
 }
 
-template<class Scalar>                                                          
-void StepperNewmarkExplicitAForm<Scalar>::setAppAction(                                                                                                                                                                                                                                                                                                                           
-    Teuchos::RCP<StepperNewmarkExplicitAFormAppAction<Scalar> > appAction)               
-{                                                                               
+template<class Scalar>
+void StepperNewmarkExplicitAForm<Scalar>::setAppAction(
+    Teuchos::RCP<StepperNewmarkExplicitAFormAppAction<Scalar> > appAction)
+{
 
-  if (appAction == Teuchos::null) {                                             
-    // Create default appAction                                                 
-    stepperNewmarkExpAppAction_ =                                                       
-	Teuchos::rcp(new StepperNewmarkExplicitAFormModifierDefault<Scalar>());          
-  } else {                                                                      
-    stepperNewmarkExpAppAction_ = appAction;                                            
-  }                                                                             
+  if (appAction == Teuchos::null) {
+    // Create default appAction
+    stepperNewmarkExpAppAction_ =
+      Teuchos::rcp(new StepperNewmarkExplicitAFormModifierDefault<Scalar>());
+  } else {
+    stepperNewmarkExpAppAction_ = appAction;
+  }
 
-  this->isInitialized_ = false;                                                 
-} 
+  this->isInitialized_ = false;
+}
 
 } // namespace Tempus
 #endif // Tempus_StepperNewmarkExplicitAForm_impl_hpp

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_decl.hpp
@@ -65,10 +65,10 @@ namespace Tempus {
  *     - \f$\mathbf{d}^n = \mathbf{d}^{\ast} + \beta \Delta t^2 \mathbf{a}^n\f$
  *     - \f$\mathbf{v}^n = \mathbf{v}^{\ast} + \gamma \Delta t \mathbf{a}^n\f$
  *
- *  The First-Same-As-Last (FSAL) principle is part of the Newmark
- *  implicit A-Form as the acceleration from the previous time step is
- *  used for the predictors.  The default is to set useFSAL=true,
- *  and useFSAL=false will be ignored.
+ *  The First-Same-As-Last (FSAL) principle is not needed with Newmark
+ *  Implicit A-Form.  The default is to set useFSAL=false, however
+ *  useFSAL=true will also work but have no affect (i.e., no-op).
+ *
  */
 template<class Scalar>
 class StepperNewmarkImplicitAForm
@@ -83,7 +83,7 @@ public:
   */
   StepperNewmarkImplicitAForm();
 
- #ifndef TEMPUS_HIDE_DEPRECATED_CODE 
+ #ifndef TEMPUS_HIDE_DEPRECATED_CODE
   /// Constructor
   StepperNewmarkImplicitAForm(
     const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
@@ -151,7 +151,7 @@ public:
       {return isExplicit() and isImplicit();}
     virtual bool isOneStepMethod()   const {return true;}
     virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
-
+    virtual void setUseFSAL(bool a) { this->setUseFSALTrueOnly(a); }
     virtual OrderODE getOrderODE()   const {return SECOND_ORDER_ODE;}
   //@}
 
@@ -194,14 +194,11 @@ public:
                              const Scalar dt) const;
 
   virtual void setAppAction(
-      Teuchos::RCP<StepperNewmarkImplicitAFormAppAction<Scalar> > appAction); 
+      Teuchos::RCP<StepperNewmarkImplicitAFormAppAction<Scalar> > appAction);
 
   void setSchemeName(std::string schemeName);
   void setBeta(Scalar beta);
   void setGamma(Scalar gamma);
-
-  virtual bool getUseFSALDefault() const { return true; }
-  virtual std::string getICConsistencyDefault() const { return "Consistent"; }
 
 private:
 

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitAForm_impl.hpp
@@ -165,21 +165,21 @@ void StepperNewmarkImplicitAForm<Scalar>::setSchemeName(
   this->isInitialized_ = false;
 }
 
-template<class Scalar>                                                          
-void StepperNewmarkImplicitAForm<Scalar>::setAppAction(                                                                                                                                                                                                                                                                                                                           
-    Teuchos::RCP<StepperNewmarkImplicitAFormAppAction<Scalar> > appAction)               
-{                                                                               
+template<class Scalar>
+void StepperNewmarkImplicitAForm<Scalar>::setAppAction(
+    Teuchos::RCP<StepperNewmarkImplicitAFormAppAction<Scalar> > appAction)
+{
 
-  if (appAction == Teuchos::null) {                                             
-    // Create default appAction                                                 
-    stepperNewmarkImpAppAction_ =                                                       
-	Teuchos::rcp(new StepperNewmarkImplicitAFormModifierDefault<Scalar>());          
-  } else {                                                                      
-    stepperNewmarkImpAppAction_ = appAction;                                            
-  }                                                                             
+  if (appAction == Teuchos::null) {
+    // Create default appAction
+    stepperNewmarkImpAppAction_ =
+      Teuchos::rcp(new StepperNewmarkImplicitAFormModifierDefault<Scalar>());
+  } else {
+    stepperNewmarkImpAppAction_ = appAction;
+  }
 
-  this->isInitialized_ = false;                                                 
-} 
+  this->isInitialized_ = false;
+}
 
 
 template<class Scalar>
@@ -191,9 +191,9 @@ StepperNewmarkImplicitAForm<Scalar>::StepperNewmarkImplicitAForm() :
 #endif
 
   this->setStepperType(        "Newmark Implicit a-Form");
-  this->setUseFSAL(            this->getUseFSALDefault());
-  this->setICConsistency(      this->getICConsistencyDefault());
-  this->setICConsistencyCheck( this->getICConsistencyCheckDefault());
+  this->setUseFSAL(            true);
+  this->setICConsistency(      "Consistent");
+  this->setICConsistencyCheck( false);
   this->setZeroInitialGuess(   false);
   this->setSchemeName(         "Average Acceleration");
 
@@ -507,16 +507,6 @@ void StepperNewmarkImplicitAForm<Scalar>::takeStep(
     const Scalar dt = workingState->getTimeStep();
     Scalar t = time+dt;
 
-    // Compute acceleration, a_old, using displacement (d_old) and
-    // velocity (v_old), if needed.
-    if (!(this->getUseFSAL()) && workingState->getNConsecutiveFailures() == 0) {
-      wrapperModel->initializeNewmark(v_old, d_old, dt, time,
-                                      Scalar(0.0), Scalar(0.0));
-      const Thyra::SolveStatus<Scalar> sStatus = this->solveImplicitODE(a_old);
-
-      workingState->setSolutionStatus(sStatus);  // Converged --> pass.
-    }
-
     // Compute displacement and velocity predictors
     predictDisplacement(*d_new, *d_old, *v_old, *a_old, dt);
     predictVelocity(*v_new, *v_old, *a_old, dt);
@@ -634,9 +624,8 @@ StepperNewmarkImplicitAForm<Scalar>::getValidParameters() const
   pl->set<std::string>("Scheme Name", "Average Acceleration");
   pl->set<double>     ("Beta" , 0.25);
   pl->set<double>     ("Gamma", 0.5 );
-  pl->set<bool>       ("Use FSAL", this->getUseFSALDefault());
-  pl->set<std::string>("Initial Condition Consistency",
-                       this->getICConsistencyDefault());
+  pl->set<bool>       ("Use FSAL", true);
+  pl->set<std::string>("Initial Condition Consistency", "Consistent");
   pl->set<std::string>("Solver Name", "Default Solver");
   pl->set<bool>       ("Zero Initial Guess", false);
   Teuchos::RCP<Teuchos::ParameterList> solverPL = defaultSolverParameters();

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitDForm_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitDForm_decl.hpp
@@ -35,7 +35,9 @@ namespace Tempus {
  *  <a href="http://opensees.berkeley.edu/wiki/index.php/Newmark_Method">here</a>.
  *
  *  The First-Same-As-Last (FSAL) principle is not used with the
- *  Newmark implicit D-Form method.
+ *  Newmark implicit D-Form method.  The default is to set useFSAL=false,
+ *  however useFSAL=true will also work but have no affect (i.e., no-op).
+ *
  */
 template <class Scalar>
 class StepperNewmarkImplicitDForm : virtual public Tempus::StepperImplicit<Scalar> {
@@ -125,7 +127,6 @@ class StepperNewmarkImplicitDForm : virtual public Tempus::StepperImplicit<Scala
       {return isExplicit() and isImplicit();}
     virtual bool isOneStepMethod()   const {return true;}
     virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
-
     virtual OrderODE getOrderODE()   const {return SECOND_ORDER_ODE;}
   //@}
 

--- a/packages/tempus/src/Tempus_StepperNewmarkImplicitDForm_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperNewmarkImplicitDForm_impl.hpp
@@ -182,9 +182,9 @@ StepperNewmarkImplicitDForm<Scalar>::StepperNewmarkImplicitDForm()
 #endif
 
   this->setStepperType(        "Newmark Implicit d-Form");
-  this->setUseFSAL(            this->getUseFSALDefault());
-  this->setICConsistency(      this->getICConsistencyDefault());
-  this->setICConsistencyCheck( this->getICConsistencyCheckDefault());
+  this->setUseFSAL(            false);
+  this->setICConsistency(      "None");
+  this->setICConsistencyCheck( false);
   this->setZeroInitialGuess(   false);
   this->setSchemeName(         "Average Acceleration");
 

--- a/packages/tempus/src/Tempus_StepperOperatorSplitModifierBase.hpp
+++ b/packages/tempus/src/Tempus_StepperOperatorSplitModifierBase.hpp
@@ -44,16 +44,16 @@ class StepperOperatorSplitModifierBase
      *  For the Modifier interface, this adaptor is a "simple pass through".
      */
     void execute(
-		 Teuchos::RCP<SolutionHistory<Scalar> > sh,
-		 Teuchos::RCP<StepperOperatorSplit<Scalar> > stepper,
-		 const typename StepperOperatorSplitAppAction<Scalar>::ACTION_LOCATION actLoc)
+      Teuchos::RCP<SolutionHistory<Scalar> > sh,
+      Teuchos::RCP<StepperOperatorSplit<Scalar> > stepper,
+      const typename StepperOperatorSplitAppAction<Scalar>::ACTION_LOCATION actLoc)
     { this->modify(sh, stepper, actLoc); }
   public:
     /// Modify OperatorSplit Stepper.
     virtual void modify(
-			Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
-			Teuchos::RCP<StepperOperatorSplit<Scalar> > /* stepper */,
-			const typename StepperOperatorSplitAppAction<Scalar>::ACTION_LOCATION actLoc) = 0;
+      Teuchos::RCP<SolutionHistory<Scalar> > /* sh */,
+      Teuchos::RCP<StepperOperatorSplit<Scalar> > /* stepper */,
+      const typename StepperOperatorSplitAppAction<Scalar>::ACTION_LOCATION actLoc) = 0;
 
   };
 

--- a/packages/tempus/src/Tempus_StepperOperatorSplit_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperOperatorSplit_decl.hpp
@@ -63,7 +63,7 @@ public:
     int orderMax);
 #endif
 
-  /// Constructor                                                                                               
+  /// Constructor
   StepperOperatorSplit(
     std::vector<Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> > > appModels,
     std::vector<Teuchos::RCP<Stepper<Scalar> > > subStepperList,
@@ -166,7 +166,7 @@ public:
       return isOneStepMethod;
     }
     virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
-
+    virtual void setUseFSAL(bool a) { this->useFSAL_ = a; this->isInitialized_ = false; }
     virtual OrderODE getOrderODE()   const {return FIRST_ORDER_ODE;}
    //@}
 

--- a/packages/tempus/src/Tempus_StepperOperatorSplit_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperOperatorSplit_impl.hpp
@@ -21,9 +21,9 @@ template<class Scalar>
 StepperOperatorSplit<Scalar>::StepperOperatorSplit()
 {
   this->setStepperType(        "Operator Split");
-  this->setUseFSAL(            this->getUseFSALDefault());
-  this->setICConsistency(      this->getICConsistencyDefault());
-  this->setICConsistencyCheck( this->getICConsistencyCheckDefault());
+  this->setUseFSAL(            false);
+  this->setICConsistency(      "None");
+  this->setICConsistencyCheck( false);
 
   this->setOrder   (1);
   this->setOrderMin(1);

--- a/packages/tempus/src/Tempus_StepperRKBase.hpp
+++ b/packages/tempus/src/Tempus_StepperRKBase.hpp
@@ -44,7 +44,6 @@ public:
 
   virtual void setUseEmbedded(bool a) { useEmbedded_ = a; }
   virtual bool getUseEmbedded() const { return useEmbedded_; }
-  virtual bool getUseEmbeddedDefault() const { return false; }
 
   virtual void setAppAction(Teuchos::RCP<StepperRKAppAction<Scalar> > appAction)
   {

--- a/packages/tempus/src/Tempus_StepperRKButcherTableau.hpp
+++ b/packages/tempus/src/Tempus_StepperRKButcherTableau.hpp
@@ -51,6 +51,9 @@ public:
     this->setStepperType("RK Forward Euler");
     this->setupTableau();
     this->setupDefault();
+    this->setUseFSAL(            true);
+    this->setICConsistency(      "Consistent");
+    this->setICConsistencyCheck( false);
   }
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
@@ -92,8 +95,7 @@ public:
     return Description.str();
   }
 
-  bool getUseFSALDefault() const { return true; }
-
+  void setUseFSAL(bool a) { this->useFSAL_ = a; this->isInitialized_ = false; }
 
 protected:
 
@@ -148,6 +150,9 @@ public:
     this->setStepperType("RK Explicit 4 Stage");
     this->setupTableau();
     this->setupDefault();
+    this->setUseFSAL(            false);
+    this->setICConsistency(      "None");
+    this->setICConsistencyCheck( false);
   }
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
@@ -268,6 +273,9 @@ public:
     this->setStepperType("Bogacki-Shampine 3(2) Pair");
     this->setupTableau();
     this->setupDefault();
+    this->setUseFSAL(            true);
+    this->setICConsistency(      "Consistent");
+    this->setICConsistencyCheck( false);
   }
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
@@ -315,6 +323,8 @@ public:
                 << "bstar = [ 7/24  1/4  1/3  1/8 ]'";
     return Description.str();
   }
+
+  void setUseFSAL(bool a) { this->useFSAL_ = a; this->isInitialized_ = false; }
 
 protected:
 
@@ -401,6 +411,9 @@ public:
     this->setStepperType("Merson 4(5) Pair");
     this->setupTableau();
     this->setupDefault();
+    this->setUseFSAL(            false);
+    this->setICConsistency(      "None");
+    this->setICConsistencyCheck( false);
   }
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
@@ -537,6 +550,9 @@ public:
     this->setStepperType("RK Explicit 3/8 Rule");
     this->setupTableau();
     this->setupDefault();
+    this->setUseFSAL(            false);
+    this->setICConsistency(      "None");
+    this->setICConsistencyCheck( false);
   }
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
@@ -660,6 +676,9 @@ public:
     this->setStepperType("RK Explicit 4 Stage 3rd order by Runge");
     this->setupTableau();
     this->setupDefault();
+    this->setUseFSAL(            false);
+    this->setICConsistency(      "None");
+    this->setICConsistencyCheck( false);
   }
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
@@ -778,6 +797,9 @@ public:
     this->setStepperType("RK Explicit 5 Stage 3rd order by Kinnmark and Gray");
     this->setupTableau();
     this->setupDefault();
+    this->setUseFSAL(            false);
+    this->setICConsistency(      "None");
+    this->setICConsistencyCheck( false);
   }
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
@@ -896,6 +918,9 @@ public:
     this->setStepperType("RK Explicit 3 Stage 3rd order");
     this->setupTableau();
     this->setupDefault();
+    this->setUseFSAL(            false);
+    this->setICConsistency(      "None");
+    this->setICConsistencyCheck( false);
   }
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
@@ -1017,6 +1042,9 @@ public:
     this->setStepperType("RK Explicit 3 Stage 3rd order TVD");
     this->setupTableau();
     this->setupDefault();
+    this->setUseFSAL(            false);
+    this->setICConsistency(      "None");
+    this->setICConsistencyCheck( false);
   }
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
@@ -1149,6 +1177,9 @@ public:
     this->setStepperType("RK Explicit 3 Stage 3rd order by Heun");
     this->setupTableau();
     this->setupDefault();
+    this->setUseFSAL(            false);
+    this->setICConsistency(      "None");
+    this->setICConsistencyCheck( false);
   }
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
@@ -1266,6 +1297,9 @@ public:
     this->setStepperType("RK Explicit Midpoint");
     this->setupTableau();
     this->setupDefault();
+    this->setUseFSAL(            false);
+    this->setICConsistency(      "None");
+    this->setICConsistencyCheck( false);
   }
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
@@ -1374,6 +1408,9 @@ public:
     this->setStepperType("RK Explicit Ralston");
     this->setupTableau();
     this->setupDefault();
+    this->setUseFSAL(            false);
+    this->setICConsistency(      "None");
+    this->setICConsistencyCheck( false);
   }
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
@@ -1483,6 +1520,9 @@ public:
     this->setStepperType("RK Explicit Trapezoidal");
     this->setupTableau();
     this->setupDefault();
+    this->setUseFSAL(            false);
+    this->setICConsistency(      "None");
+    this->setICConsistencyCheck( false);
   }
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
@@ -1595,6 +1635,9 @@ class StepperERK_SSPERK54 :
     this->setStepperType("SSPERK54");
     this->setupTableau();
     this->setupDefault();
+    this->setUseFSAL(            false);
+    this->setICConsistency(      "None");
+    this->setICConsistencyCheck( false);
   }
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
@@ -1739,6 +1782,9 @@ public:
     this->setStepperType("General ERK");
     this->setupTableau();
     this->setupDefault();
+    this->setUseFSAL(            false);
+    this->setICConsistency(      "None");
+    this->setICConsistencyCheck( false);
   }
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
@@ -1900,6 +1946,9 @@ public:
     this->setStepperType("RK Backward Euler");
     this->setupTableau();
     this->setupDefault();
+    this->setUseFSAL(            false);
+    this->setICConsistency(      "None");
+    this->setICConsistencyCheck( false);
   }
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
@@ -1945,15 +1994,11 @@ public:
     return Description.str();
   }
 
-  virtual bool getICConsistencyCheckDefault() const { return false; }
-
   Teuchos::RCP<const Teuchos::ParameterList>
   getValidParameters() const
   {
     Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
     this->getValidParametersBasicDIRK(pl);
-    pl->set<bool>("Initial Condition Consistency Check",
-                  this->getICConsistencyCheckDefault());
     return pl;
   }
 
@@ -2030,6 +2075,9 @@ public:
     this->setGamma(gammaDefault_);
     this->setupTableau();
     this->setupDefault();
+    this->setUseFSAL(            false);
+    this->setICConsistency(      "None");
+    this->setICConsistencyCheck( false);
   }
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
@@ -2101,15 +2149,11 @@ public:
     return Description.str();
   }
 
-  virtual bool getICConsistencyCheckDefault() const { return false; }
-
   Teuchos::RCP<const Teuchos::ParameterList>
   getValidParameters() const
   {
     Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
     this->getValidParametersBasicDIRK(pl);
-    pl->set<bool>("Initial Condition Consistency Check",
-                  this->getICConsistencyCheckDefault());
     pl->set<double>("gamma",gammaDefault_,
       "The default value is gamma = (2-sqrt(2))/2. "
       "This will produce an L-stable 2nd order method with the stage "
@@ -2167,7 +2211,7 @@ protected:
  *  \;\;\;\;\mbox{ where }\;\;\;\;
  *  \begin{array}{c|ccc}  \gamma  & \gamma      &         &        \\
  *                       1-\gamma & 1-2\gamma   & \gamma  &        \\
- *                       1-2      & 1/2 -\gamma & 0       & \gamma \\ \hline
+ *                       1/2      & 1/2 -\gamma & 0       & \gamma \\ \hline
  *                                & 1/6         & 1/6     & 2/3
  *  \end{array}
  *  \f]
@@ -2197,6 +2241,9 @@ public:
     this->setStepperType("SDIRK 3 Stage 2nd order");
     this->setupTableau();
     this->setupDefault();
+    this->setUseFSAL(            false);
+    this->setICConsistency(      "None");
+    this->setICConsistencyCheck( false);
   }
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
   StepperSDIRK_3Stage2ndOrder(
@@ -2256,8 +2303,6 @@ public:
   {
     Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
     this->getValidParametersBasicDIRK(pl);
-    pl->set<bool>("Initial Condition Consistency Check",
-                  this->getICConsistencyCheckDefault());
     return pl;
   }
 
@@ -2351,6 +2396,9 @@ public:
     this->setGamma(gammaDefault_);
     this->setupTableau();
     this->setupDefault();
+    this->setUseFSAL(            false);
+    this->setICConsistency(      "None");
+    this->setICConsistencyCheck( false);
   }
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
@@ -2551,6 +2599,9 @@ public:
     this->setStepperType("EDIRK 2 Stage 3rd order");
     this->setupTableau();
     this->setupDefault();
+    this->setUseFSAL(            false);
+    this->setICConsistency(      "None");
+    this->setICConsistencyCheck( false);
   }
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
@@ -2602,15 +2653,11 @@ public:
     return Description.str();
   }
 
-  virtual bool getICConsistencyCheckDefault() const { return false; }
-
   Teuchos::RCP<const Teuchos::ParameterList>
   getValidParameters() const
   {
     Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
     this->getValidParametersBasicDIRK(pl);
-    pl->set<bool>("Initial Condition Consistency Check",
-                  this->getICConsistencyCheckDefault());
     return pl;
   }
 
@@ -2647,7 +2694,7 @@ protected:
 
 
 // ----------------------------------------------------------------------------
-/** \brief SDIRK 1 Stage Theta
+/** \brief DIRK 1 Stage Theta
  *
  *  The tableau (order = 1 or 2) is
  *  \f[
@@ -2656,7 +2703,7 @@ protected:
  *      & b^T
  *  \end{array}
  *  \;\;\;\;\mbox{ where }\;\;\;\;
- *  \begin{array}{c|c} \theta  & \theta  \\
+ *  \begin{array}{c|c} \theta  & \theta  \\  \hline
  *                             & 1       \end{array}
  *  \f]
  *  Valid values are \f$0 < \theta \leq 1\f$, where \f$\theta\f$ = 0
@@ -2691,6 +2738,9 @@ public:
     this->setTheta(thetaDefault_);
     this->setupTableau();
     this->setupDefault();
+    this->setUseFSAL(            false);
+    this->setICConsistency(      "None");
+    this->setICConsistencyCheck( false);
   }
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
@@ -2763,16 +2813,12 @@ public:
     return Description.str();
   }
 
-  virtual bool getICConsistencyCheckDefault() const { return false; }
-
   Teuchos::RCP<const Teuchos::ParameterList>
   getValidParameters() const
   {
     Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
     this->getValidParametersBasicDIRK(pl);
 
-    pl->set<bool>("Initial Condition Consistency Check",
-                  this->getICConsistencyCheckDefault());
     pl->set<double>("theta",thetaDefault_,
       "Valid values are 0 <= theta <= 1, where theta = 0 "
       "implies Forward Euler, theta = 1/2 implies implicit midpoint "
@@ -2856,6 +2902,9 @@ public:
     this->setTheta(thetaDefault_);
     this->setupTableau();
     this->setupDefault();
+    this->setUseFSAL(            true);
+    this->setICConsistency(      "Consistent");
+    this->setICConsistencyCheck( false);
   }
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
@@ -2928,15 +2977,12 @@ public:
     return Description.str();
   }
 
-  virtual bool getICConsistencyCheckDefault() const { return false; }
-
   Teuchos::RCP<const Teuchos::ParameterList>
   getValidParameters() const
   {
     Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
     this->getValidParametersBasicDIRK(pl);
 
-    pl->set<bool>("Initial Condition Consistency Check", false);
     pl->set<double>("theta",thetaDefault_,
       "Valid values are 0 < theta <= 1, where theta = 0 "
       "implies Forward Euler, theta = 1/2 implies trapezoidal "
@@ -2947,6 +2993,8 @@ public:
 
     return pl;
   }
+
+  void setUseFSAL(bool a) { this->useFSAL_ = a; this->isInitialized_ = false; }
 
 protected:
 
@@ -3022,6 +3070,9 @@ public:
     this->setStepperType("RK Trapezoidal Rule");
     this->setupTableau();
     this->setupDefault();
+    this->setUseFSAL(            true);
+    this->setICConsistency(      "Consistent");
+    this->setICConsistencyCheck( false);
   }
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
@@ -3069,17 +3120,15 @@ public:
     return Description.str();
   }
 
-  virtual bool getICConsistencyCheckDefault() const { return false; }
-
   Teuchos::RCP<const Teuchos::ParameterList>
   getValidParameters() const
   {
     Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
     this->getValidParametersBasicDIRK(pl);
-    pl->set<bool>("Initial Condition Consistency Check",
-                  this->getICConsistencyCheckDefault());
     return pl;
   }
+
+  void setUseFSAL(bool a) { this->useFSAL_ = a; this->isInitialized_ = false; }
 
 protected:
 
@@ -3157,6 +3206,9 @@ public:
     this->setStepperType("RK Implicit Midpoint");
     this->setupTableau();
     this->setupDefault();
+    this->setUseFSAL(            false);
+    this->setICConsistency(      "None");
+    this->setICConsistencyCheck( false);
   }
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
@@ -3212,15 +3264,11 @@ public:
     return Description.str();
   }
 
-  virtual bool getICConsistencyCheckDefault() const { return false; }
-
   Teuchos::RCP<const Teuchos::ParameterList>
   getValidParameters() const
   {
     Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
     this->getValidParametersBasicDIRK(pl);
-    pl->set<bool>("Initial Condition Consistency Check",
-                  this->getICConsistencyCheckDefault());
     return pl;
   }
 
@@ -3284,6 +3332,9 @@ class StepperSDIRK_SSPDIRK22 :
     this->setStepperType("SSPDIRK22");
     this->setupTableau();
     this->setupDefault();
+    this->setUseFSAL(            false);
+    this->setICConsistency(      "None");
+    this->setICConsistencyCheck( false);
   }
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
@@ -3332,15 +3383,11 @@ class StepperSDIRK_SSPDIRK22 :
     return Description.str();
   }
 
-  virtual bool getICConsistencyCheckDefault() const { return false; }
-
   Teuchos::RCP<const Teuchos::ParameterList>
   getValidParameters() const
   {
     Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
     this->getValidParametersBasicDIRK(pl);
-    pl->set<bool>("Initial Condition Consistency Check",
-                  this->getICConsistencyCheckDefault());
     return pl;
   }
 
@@ -3411,6 +3458,9 @@ class StepperSDIRK_SSPDIRK32 :
     this->setStepperType("SSPDIRK32");
     this->setupTableau();
     this->setupDefault();
+    this->setUseFSAL(            false);
+    this->setICConsistency(      "None");
+    this->setICConsistencyCheck( false);
   }
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
@@ -3460,15 +3510,11 @@ class StepperSDIRK_SSPDIRK32 :
     return Description.str();
   }
 
-  virtual bool getICConsistencyCheckDefault() const { return false; }
-
   Teuchos::RCP<const Teuchos::ParameterList>
   getValidParameters() const
   {
     Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
     this->getValidParametersBasicDIRK(pl);
-    pl->set<bool>("Initial Condition Consistency Check",
-                  this->getICConsistencyCheckDefault());
     return pl;
   }
 
@@ -3540,6 +3586,9 @@ class StepperSDIRK_SSPDIRK23 :
     this->setStepperType("SSPDIRK23");
     this->setupTableau();
     this->setupDefault();
+    this->setUseFSAL(            false);
+    this->setICConsistency(      "None");
+    this->setICConsistencyCheck( false);
   }
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
@@ -3589,15 +3638,11 @@ class StepperSDIRK_SSPDIRK23 :
     return Description.str();
   }
 
-  virtual bool getICConsistencyCheckDefault() const { return false; }
-
   Teuchos::RCP<const Teuchos::ParameterList>
   getValidParameters() const
   {
     Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
     this->getValidParametersBasicDIRK(pl);
-    pl->set<bool>("Initial Condition Consistency Check",
-                  this->getICConsistencyCheckDefault());
     return pl;
   }
 
@@ -3670,6 +3715,9 @@ class StepperSDIRK_SSPDIRK33 :
     this->setStepperType("SSPDIRK33");
     this->setupTableau();
     this->setupDefault();
+    this->setUseFSAL(            false);
+    this->setICConsistency(      "None");
+    this->setICConsistencyCheck( false);
   }
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
@@ -3720,15 +3768,11 @@ class StepperSDIRK_SSPDIRK33 :
     return Description.str();
   }
 
-  virtual bool getICConsistencyCheckDefault() const { return false; }
-
   Teuchos::RCP<const Teuchos::ParameterList>
   getValidParameters() const
   {
     Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
     this->getValidParametersBasicDIRK(pl);
-    pl->set<bool>("Initial Condition Consistency Check",
-                  this->getICConsistencyCheckDefault());
     return pl;
   }
 
@@ -3806,6 +3850,9 @@ public:
     this->setStepperType("RK Implicit 1 Stage 1st order Radau IA");
     this->setupTableau();
     this->setupDefault();
+    this->setUseFSAL(            false);
+    this->setICConsistency(      "None");
+    this->setICConsistencyCheck( false);
   }
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
@@ -3857,15 +3904,11 @@ public:
     return Description.str();
   }
 
-  virtual bool getICConsistencyCheckDefault() const { return false; }
-
   Teuchos::RCP<const Teuchos::ParameterList>
   getValidParameters() const
   {
     Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
     this->getValidParametersBasicDIRK(pl);
-    pl->set<bool>("Initial Condition Consistency Check",
-                  this->getICConsistencyCheckDefault());
     return pl;
   }
 
@@ -3928,6 +3971,9 @@ public:
     this->setStepperType("RK Implicit 2 Stage 2nd order Lobatto IIIB");
     this->setupTableau();
     this->setupDefault();
+    this->setUseFSAL(            false);
+    this->setICConsistency(      "None");
+    this->setICConsistencyCheck( false);
   }
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
@@ -3980,15 +4026,11 @@ public:
     return Description.str();
   }
 
-  virtual bool getICConsistencyCheckDefault() const { return false; }
-
   Teuchos::RCP<const Teuchos::ParameterList>
   getValidParameters() const
   {
     Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
     this->getValidParametersBasicDIRK(pl);
-    pl->set<bool>("Initial Condition Consistency Check",
-                  this->getICConsistencyCheckDefault());
     return pl;
   }
 
@@ -4070,6 +4112,9 @@ public:
     this->setStepperType("SDIRK 5 Stage 4th order");
     this->setupTableau();
     this->setupDefault();
+    this->setUseFSAL(            false);
+    this->setICConsistency(      "None");
+    this->setICConsistencyCheck( false);
   }
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
@@ -4126,15 +4171,11 @@ public:
     return Description.str();
   }
 
-  virtual bool getICConsistencyCheckDefault() const { return false; }
-
   Teuchos::RCP<const Teuchos::ParameterList>
   getValidParameters() const
   {
     Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
     this->getValidParametersBasicDIRK(pl);
-    pl->set<bool>("Initial Condition Consistency Check",
-                  this->getICConsistencyCheckDefault());
     return pl;
   }
 
@@ -4252,6 +4293,9 @@ public:
     this->setStepperType("SDIRK 3 Stage 4th order");
     this->setupTableau();
     this->setupDefault();
+    this->setUseFSAL(            false);
+    this->setICConsistency(      "None");
+    this->setICConsistencyCheck( false);
   }
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
@@ -4307,15 +4351,11 @@ public:
     return Description.str();
   }
 
-  virtual bool getICConsistencyCheckDefault() const { return false; }
-
   Teuchos::RCP<const Teuchos::ParameterList>
   getValidParameters() const
   {
     Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
     this->getValidParametersBasicDIRK(pl);
-    pl->set<bool>("Initial Condition Consistency Check",
-                  this->getICConsistencyCheckDefault());
     return pl;
   }
 
@@ -4405,6 +4445,9 @@ public:
     this->setStepperType("SDIRK 5 Stage 5th order");
     this->setupTableau();
     this->setupDefault();
+    this->setUseFSAL(            false);
+    this->setICConsistency(      "None");
+    this->setICConsistencyCheck( false);
   }
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
@@ -4488,15 +4531,11 @@ public:
     return Description.str();
   }
 
-  virtual bool getICConsistencyCheckDefault() const { return false; }
-
   Teuchos::RCP<const Teuchos::ParameterList>
   getValidParameters() const
   {
     Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
     this->getValidParametersBasicDIRK(pl);
-    pl->set<bool>("Initial Condition Consistency Check",
-                  this->getICConsistencyCheckDefault());
     return pl;
   }
 
@@ -4600,6 +4639,9 @@ public:
     this->setStepperType("SDIRK 2(1) Pair");
     this->setupTableau();
     this->setupDefault();
+    this->setUseFSAL(            false);
+    this->setICConsistency(      "None");
+    this->setICConsistencyCheck( false);
   }
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
@@ -4647,15 +4689,11 @@ public:
     return Description.str();
   }
 
-  virtual bool getICConsistencyCheckDefault() const { return false; }
-
   Teuchos::RCP<const Teuchos::ParameterList>
   getValidParameters() const
   {
     Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
     this->getValidParametersBasicDIRK(pl);
-    pl->set<bool>("Initial Condition Consistency Check",
-                  this->getICConsistencyCheckDefault());
     return pl;
   }
 
@@ -4743,6 +4781,9 @@ public:
     this->setStepperType("General DIRK");
     this->setupTableau();
     this->setupDefault();
+    this->setUseFSAL(            false);
+    this->setICConsistency(      "None");
+    this->setICConsistencyCheck( false);
   }
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
@@ -4827,8 +4868,6 @@ public:
     return Description.str();
   }
 
-  virtual bool getICConsistencyCheckDefault() const { return false; }
-
   void setupTableau()
   {
     if (this->tableau_ == Teuchos::null) {
@@ -4863,8 +4902,6 @@ public:
   {
     Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
     this->getValidParametersBasicDIRK(pl);
-    pl->set<bool>("Initial Condition Consistency Check",
-                  this->getICConsistencyCheckDefault());
 
     // Tableau ParameterList
     Teuchos::RCP<Teuchos::ParameterList> tableauPL = Teuchos::parameterList();

--- a/packages/tempus/src/Tempus_StepperSubcycling_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperSubcycling_decl.hpp
@@ -58,7 +58,7 @@ public:
     bool ICConsistencyCheck);
 #endif
 
-  /// Constructor                                                                       
+  /// Constructor
   StepperSubcycling(
     const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
     const Teuchos::RCP<IntegratorBasic<Scalar> >& integrator,
@@ -78,7 +78,7 @@ public:
     virtual Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >
       getModel(){return scIntegrator_->getStepper()->getModel();}
 
-#ifndef TEMPUS_HIDE_DEPRECATED_CODE    
+#ifndef TEMPUS_HIDE_DEPRECATED_CODE
     virtual void setObserver(
       Teuchos::RCP<StepperObserver<Scalar> > obs = Teuchos::null);
 
@@ -127,7 +127,6 @@ public:
     virtual Scalar getOrder() const;
     virtual Scalar getOrderMin() const;
     virtual Scalar getOrderMax() const;
-
     virtual OrderODE getOrderODE()   const;
   //@}
 

--- a/packages/tempus/src/Tempus_StepperSubcycling_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperSubcycling_impl.hpp
@@ -30,9 +30,9 @@ StepperSubcycling<Scalar>::StepperSubcycling()
   using Teuchos::ParameterList;
 
   this->setStepperType(        "Subcycling");
-  this->setUseFSAL(            this->getUseFSALDefault());
-  this->setICConsistency(      this->getICConsistencyDefault());
-  this->setICConsistencyCheck( this->getICConsistencyCheckDefault());
+  this->setUseFSAL(            false);
+  this->setICConsistency(      "None");
+  this->setICConsistencyCheck( false);
 
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
   this->setObserver(Teuchos::rcp(new StepperSubcyclingObserver<Scalar>()));
@@ -610,8 +610,8 @@ StepperSubcycling<Scalar>::getValidParameters() const
 
   Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
   getValidParametersBasic(pl, this->getStepperType());
-  pl->set<bool>("Use FSAL", true);
-  pl->set<std::string>("Initial Condition Consistency", "Consistent");
+  pl->set<bool>("Use FSAL", false);
+  pl->set<std::string>("Initial Condition Consistency", "None");
   return pl;
 }
 

--- a/packages/tempus/src/Tempus_StepperTrapezoidal_decl.hpp
+++ b/packages/tempus/src/Tempus_StepperTrapezoidal_decl.hpp
@@ -27,19 +27,28 @@ namespace Tempus {
  *  solver (e.g., a non-linear solver, like NOX).
  *
  *  <b> Algorithm </b>
- *  The single-timestep algorithm for Trapezoidal method is simply,
- *   - Solve \f$\mathcal{F}_n(\dot{x}=(x_n-x_{n-1})/(\Delta t_n/2) - \dot{x}_{n-1}, x_n, t_n)=0\f$ for \f$x_n\f$
- *   - \f$\dot{x}_n \leftarrow (x_n-x_{n-1})/(\Delta t_n/2) - \dot{x}_{n-1}\f$
+ *  The single-timestep algorithm for Forward Euler is
+ *  \f{algorithm}{
+ *  \renewcommand{\thealgorithm}{}
+ *  \caption{Forward Euler}
+ *  \begin{algorithmic}[1]
+ *    \State {\it appAction.execute(solutionHistory, stepper, BEGIN\_STEP)}
+ *    \State {Get $\dot{x}$ from SolutionHistory or from Stepper}
+ *    \State {\it appAction.execute(solutionHistory, stepper, BEFORE\_SOLVE)}
+ *    \State $\mathcal{F}_n(\dot{x}=(x_n-x_{n-1})/(\Delta t_n/2) - \dot{x}_{n-1}, x_n, t_n)=0\f$ for \f$x_n$
+ *    \State {\it appAction.execute(solutionHistory, stepper, AFTER\_SOLVE)}
+ *    \State $\dot{x}_n \leftarrow (x_n-x_{n-1})/(\Delta t_n/2) - \dot{x}_{n-1}$
+ *    \State {\it appAction.execute(solutionHistory, stepper, END\_STEP)}
+ *  \end{algorithmic}
+ *  \f}
  *
- *   The First-Same-As-Last (FSAL) principle is required for the Trapezoidal
- *   Stepper (i.e., useFSAL=true)!  There are at least two ways around this,
- *   but are not implemented.
- *    - Do a solve for xDotOld, xDot_{n-1}, at each time step as for the
- *      initial conditions.  This is expensive since you would be doing
- *      two solves every time step.
- *    - Use evaluateExplicitODE to get xDot_{n-1} if the application
- *      provides it.  Explicit evaluations are cheaper but requires the
- *      application to implement xDot = f(x,t).
+ *  The First-Same-As-Last (FSAL) principle is required for the Trapezoidal
+ *  Stepper (i.e., useFSAL=true)!  With useFSAL=true does assume that the
+ *  solution, \f$x\f$, and its time derivative, \f$\dot{x}\f$, are consistent
+ *  at the initial conditions (ICs), i.e.,
+ *  \f$\dot{x}_{0} = \bar{f}(x_{0},t_{0})\f$.  This can be ensured by setting
+ *  setICConsistency("Consistent"), and checked with
+ *  setICConsistencyCheck(true).
  *
  *  <b> Iteration Matrix, \f$W\f$.</b>
  *  Recalling that the definition of the iteration matrix, \f$W\f$, is
@@ -86,14 +95,14 @@ public:
     bool zeroInitialGuess);
 #endif
 
-  /// Constructor                                                                                                                  
+  /// Constructor
   StepperTrapezoidal(
     const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel,
     const Teuchos::RCP<Thyra::NonlinearSolverBase<Scalar> >& solver,
     bool useFSAL,
     std::string ICConsistency,
     bool ICConsistencyCheck,
-    bool zeroInitialGuess, 
+    bool zeroInitialGuess,
     const Teuchos::RCP<StepperTrapezoidalAppAction<Scalar> >& stepperTrapAppAction);
 
   /// \name Basic stepper methods
@@ -132,6 +141,7 @@ public:
       {return isExplicit() and isImplicit();}
     virtual bool isOneStepMethod()   const {return true;}
     virtual bool isMultiStepMethod() const {return !isOneStepMethod();}
+    virtual void setUseFSAL(bool a) { this->setUseFSALTrueOnly(a); }
     virtual OrderODE getOrderODE()   const {return FIRST_ORDER_ODE;}
   //@}
 
@@ -150,8 +160,6 @@ public:
 
   virtual bool isValidSetup(Teuchos::FancyOStream & out) const;
 
-  virtual bool getUseFSALDefault() const { return true; }
-  virtual std::string getICConsistencyDefault() const { return "Consistent"; }
 
 private:
 

--- a/packages/tempus/src/Tempus_StepperTrapezoidal_impl.hpp
+++ b/packages/tempus/src/Tempus_StepperTrapezoidal_impl.hpp
@@ -27,9 +27,9 @@ template<class Scalar>
 StepperTrapezoidal<Scalar>::StepperTrapezoidal()
 {
   this->setStepperType(        "Trapezoidal Method");
-  this->setUseFSAL(            this->getUseFSALDefault());
-  this->setICConsistency(      this->getICConsistencyDefault());
-  this->setICConsistencyCheck( this->getICConsistencyCheckDefault());
+  this->setUseFSAL(            true);
+  this->setICConsistency(      "Consistent");
+  this->setICConsistencyCheck( false);
   this->setZeroInitialGuess(   false);
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
   this->setObserver();
@@ -77,7 +77,7 @@ StepperTrapezoidal<Scalar>::StepperTrapezoidal(
   bool ICConsistencyCheck,
   bool zeroInitialGuess,
   const Teuchos::RCP<StepperTrapezoidalAppAction<Scalar> >& stepperTrapAppAction)
-  {
+{
   this->setStepperType(        "Trapezoidal");
   this->setUseFSAL(            useFSAL);
   this->setICConsistency(      ICConsistency);
@@ -127,7 +127,7 @@ void StepperTrapezoidal<Scalar>::setAppAction(
   Teuchos::RCP<StepperTrapezoidalAppAction<Scalar> > appAction)
 {
   if (appAction == Teuchos::null) {
-    // Create default appAction                                           
+    // Create default appAction
     stepperTrapAppAction_ =
     Teuchos::rcp(new StepperTrapezoidalModifierDefault<Scalar>());
   } else {
@@ -189,7 +189,7 @@ void StepperTrapezoidal<Scalar>::takeStep(
     RCP<StepperTrapezoidal<Scalar> > thisStepper = Teuchos::rcpFromRef(*this);
     stepperTrapAppAction_->execute(solutionHistory, thisStepper,
       StepperTrapezoidalAppAction<Scalar>::ACTION_LOCATION::BEGIN_STEP);
- 
+
     RCP<SolutionState<Scalar> > workingState=solutionHistory->getWorkingState();
     RCP<SolutionState<Scalar> > currentState=solutionHistory->getCurrentState();
 
@@ -306,9 +306,9 @@ StepperTrapezoidal<Scalar>::getValidParameters() const
 {
   Teuchos::RCP<Teuchos::ParameterList> pl = Teuchos::parameterList();
   getValidParametersBasic(pl, this->getStepperType());
-  pl->set<bool>       ("Use FSAL", this->getUseFSALDefault());
-  pl->set<std::string>("Initial Condition Consistency",
-                       this->getICConsistencyDefault());
+  pl->set<bool>       ("Use FSAL", true);
+  pl->set<std::string>("Initial Condition Consistency", "Consistent");
+  pl->set<bool>       ("Initial Condition Consistency Check", false);
   pl->set<std::string>("Solver Name", "Default Solver");
   pl->set<bool>       ("Zero Initial Guess", false);
   Teuchos::RCP<Teuchos::ParameterList> solverPL = defaultSolverParameters();

--- a/packages/tempus/src/Tempus_Stepper_decl.hpp
+++ b/packages/tempus/src/Tempus_Stepper_decl.hpp
@@ -133,19 +133,18 @@ public:
       isInitialized_ = false; }
     std::string getStepperType() const { return stepperType_; }
 
-    void setUseFSAL(bool a) { useFSAL_ = a; isInitialized_ = false; }
+    virtual void setUseFSAL(bool a) { setUseFSALFalseOnly(a); }
+    void setUseFSALTrueOnly(bool a);
+    void setUseFSALFalseOnly(bool a);
     bool getUseFSAL() const { return useFSAL_; }
-    virtual bool getUseFSALDefault() const { return false; }
 
     void setICConsistency(std::string s) { ICConsistency_ = s;
       isInitialized_ = false; }
     std::string getICConsistency() const { return ICConsistency_; }
-    virtual std::string getICConsistencyDefault() const { return "None"; }
 
     void setICConsistencyCheck(bool c) {ICConsistencyCheck_ = c;
       isInitialized_ = false; }
     bool getICConsistencyCheck() const { return ICConsistencyCheck_; }
-    virtual bool getICConsistencyCheckDefault() const { return false; }
 
     virtual OrderODE getOrderODE() const = 0;
 
@@ -187,9 +186,8 @@ public:
 private:
 
   std::string stepperType_;        ///< Name of stepper type
-  bool useFSAL_ = false;           ///< Use First-Same-As-Last (FSAL) principle
   std::string ICConsistency_ = std::string("None");  ///< Type of consistency to apply to ICs.
-  bool ICConsistencyCheck_ = true; ///< Check if the initial condition is consistent
+  bool ICConsistencyCheck_ = false; ///< Check if the initial condition is consistent
 
   // RCP to SolutionState memory or Stepper temporary memory (if needed).
   Teuchos::RCP<Thyra::VectorBase<Scalar> > stepperX_;
@@ -210,6 +208,7 @@ protected:
   virtual void setStepperXDotDot(Teuchos::RCP<Thyra::VectorBase<Scalar> > xDotDot)
   { stepperXDotDot_ = xDotDot; }
 
+  bool useFSAL_ = false;       ///< Use First-Same-As-Last (FSAL) principle
   bool isInitialized_ = false; ///< True if stepper's member data is initialized.
 };
 

--- a/packages/tempus/src/Tempus_Stepper_impl.hpp
+++ b/packages/tempus/src/Tempus_Stepper_impl.hpp
@@ -65,7 +65,7 @@ void getValidParametersBasic(
     "another Jacobian from the application.  Individual steppers may\n"
     "override these defaults.");
 
-  pl->set<bool>("Initial Condition Consistency Check", true,
+  pl->set<bool>("Initial Condition Consistency Check", false,
     "Check if the initial condition, x and xDot, is consistent with the\n"
     "governing equations, xDot = f(x,t), or f(x, xDot, t) = 0.\n"
     "\n"
@@ -169,6 +169,32 @@ void Stepper<Scalar>::checkInitialized()
     TEUCHOS_TEST_FOR_EXCEPTION( !this->isInitialized(), std::logic_error,
       "Error - " << this->description() << " is not initialized!");
   }
+}
+
+
+template<class Scalar>
+void Stepper<Scalar>::setUseFSALTrueOnly(bool a)
+{
+  if (a == false) {
+    Teuchos::RCP<Teuchos::FancyOStream> out = this->getOStream();
+    Teuchos::OSTab ostab(out,1,"Stepper::setUseFSALTrueOnly()");
+    *out << "Warning -- useFSAL for '" << this->getStepperType() << "'\n"
+         << "can only be set to true.  Leaving set to true." << std::endl;
+  }
+  useFSAL_ = true;
+}
+
+
+template<class Scalar>
+void Stepper<Scalar>::setUseFSALFalseOnly(bool a)
+{
+  if (a == true) {
+    Teuchos::RCP<Teuchos::FancyOStream> out = this->getOStream();
+    Teuchos::OSTab ostab(out,1,"Stepper::setUseFSALFalseOnly()");
+    *out << "Warning -- useFSAL for '" << this->getStepperType() << "'\n"
+         << "can only be set to false.  Leaving set to false." << std::endl;
+  }
+  useFSAL_ = false;
 }
 
 

--- a/packages/tempus/src/Tempus_String_Utilities.cpp
+++ b/packages/tempus/src/Tempus_String_Utilities.cpp
@@ -14,7 +14,7 @@ namespace Tempus {
   void trim(std::string& str)
   {
     const std::string whitespace(" \t\n");
-    
+
     const auto strBegin = str.find_first_not_of(whitespace);
     if (strBegin == std::string::npos) {
       str = "";
@@ -27,10 +27,10 @@ namespace Tempus {
     str = str.substr(strBegin, strRange);
     return;
   }
-  
+
   void StringTokenizer(std::vector<std::string>& tokens,
-		       const std::string& str,
-		       const std::string delimiters,bool trim)
+                       const std::string& str,
+                       const std::string delimiters,bool trim)
   {
     using std::string;
 
@@ -38,13 +38,12 @@ namespace Tempus {
     string::size_type lastPos = str.find_first_not_of(delimiters, 0);
     // Find first "non-delimiter".
     string::size_type pos     = str.find_first_of(delimiters, lastPos);
-    
+
     while (string::npos != pos || string::npos != lastPos) {
 
       // grab token, trim if desired
       std::string token = str.substr(lastPos,pos-lastPos);
-      if(trim)
-	Tempus::trim(token);
+      if(trim) Tempus::trim(token);
 
       // Found a token, add it to the vector.
       tokens.push_back(token);
@@ -57,7 +56,7 @@ namespace Tempus {
       // Find next "non-delimiter"
       pos = str.find_first_of(delimiters, lastPos);
     }
-    
+
   }
 
   void TokensToDoubles(std::vector<double> & values,
@@ -68,8 +67,8 @@ namespace Tempus {
         double value = 0.0;
         std::stringstream ss;
         ss << tokens[i];
-        ss >> value; 
-      
+        ss >> value;
+
         values.push_back(value);
      }
   }
@@ -82,8 +81,8 @@ namespace Tempus {
         int value = 0;
         std::stringstream ss;
         ss << tokens[i];
-        ss >> value; 
-      
+        ss >> value;
+
         values.push_back(value);
      }
   }

--- a/packages/tempus/src/Tempus_String_Utilities.hpp
+++ b/packages/tempus/src/Tempus_String_Utilities.hpp
@@ -21,8 +21,8 @@ namespace Tempus {
 
   //! Tokenize a string, put tokens in a vector
   void StringTokenizer(std::vector<std::string>& tokens,
-		       const std::string& str,
-		       const std::string delimiter = ",",bool trim=false);
+                       const std::string& str,
+                       const std::string delimiter = ",",bool trim=false);
 
   //! Turn a vector of tokens into a vector of doubles
   void TokensToDoubles(std::vector<double> & values,

--- a/packages/tempus/test/BDF2/Tempus_BDF2Test.cpp
+++ b/packages/tempus/test/BDF2/Tempus_BDF2Test.cpp
@@ -104,93 +104,104 @@ TEUCHOS_UNIT_TEST(BDF2, ParameterList)
 TEUCHOS_UNIT_TEST(BDF2, ConstructingFromDefaults)
 {
   double dt = 0.1;
+  std::vector<std::string> options;
+  options.push_back("Default Parameters");
+  options.push_back("ICConsistency and Check");
 
-  // Read params from .xml file
-  RCP<ParameterList> pList =
-    getParametersFromXmlFile("Tempus_BDF2_SinCos.xml");
-  RCP<ParameterList> pl = sublist(pList, "Tempus", true);
+  for(const auto& option: options) {
 
-  // Setup the SinCosModel
-  RCP<ParameterList> scm_pl = sublist(pList, "SinCosModel", true);
-  //RCP<SinCosModel<double> > model = sineCosineModel(scm_pl);
-  auto model = rcp(new SinCosModel<double>(scm_pl));
+    // Read params from .xml file
+    RCP<ParameterList> pList =
+      getParametersFromXmlFile("Tempus_BDF2_SinCos.xml");
+    RCP<ParameterList> pl = sublist(pList, "Tempus", true);
 
-  // Setup Stepper for field solve ----------------------------
-  auto stepper = rcp(new Tempus::StepperBDF2<double>());
-  stepper->setModel(model);
-  stepper->initialize();
+    // Setup the SinCosModel
+    RCP<ParameterList> scm_pl = sublist(pList, "SinCosModel", true);
+    //RCP<SinCosModel<double> > model = sineCosineModel(scm_pl);
+    auto model = rcp(new SinCosModel<double>(scm_pl));
 
-  // Setup TimeStepControl ------------------------------------
-  auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
-  ParameterList tscPL = pl->sublist("Default Integrator")
-                           .sublist("Time Step Control");
-  timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
-  timeStepControl->setInitIndex(tscPL.get<int>   ("Initial Time Index"));
-  timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
-  timeStepControl->setFinalTime(tscPL.get<double>("Final Time"));
-  timeStepControl->setInitTimeStep(dt);
-  timeStepControl->initialize();
+    // Setup Stepper for field solve ----------------------------
+    auto stepper = rcp(new Tempus::StepperBDF2<double>());
+    stepper->setModel(model);
+    if ( option == "ICConsistency and Check") {
+      stepper->setICConsistency("Consistent");
+      stepper->setICConsistencyCheck(true);
+    }
+    stepper->initialize();
 
-  // Setup initial condition SolutionState --------------------
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-    stepper->getModel()->getNominalValues();
-  auto icSolution = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
-  auto icState = Tempus::createSolutionStateX(icSolution);
-  icState->setTime    (timeStepControl->getInitTime());
-  icState->setIndex   (timeStepControl->getInitIndex());
-  icState->setTimeStep(0.0);
-  icState->setOrder   (stepper->getOrder());
-  icState->setSolutionStatus(Tempus::Status::PASSED);  // ICs are passing.
+    // Setup TimeStepControl ------------------------------------
+    auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
+    ParameterList tscPL = pl->sublist("Default Integrator")
+                             .sublist("Time Step Control");
+    timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
+    timeStepControl->setInitIndex(tscPL.get<int>   ("Initial Time Index"));
+    timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
+    timeStepControl->setFinalTime(tscPL.get<double>("Final Time"));
+    timeStepControl->setInitTimeStep(dt);
+    timeStepControl->initialize();
 
-  // Setup SolutionHistory ------------------------------------
-  auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());
-  solutionHistory->setName("Forward States");
-  solutionHistory->setStorageType(Tempus::STORAGE_TYPE_STATIC);
-  solutionHistory->setStorageLimit(3);
-  solutionHistory->addState(icState);
+    // Setup initial condition SolutionState --------------------
+    Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
+      stepper->getModel()->getNominalValues();
+    auto icSolution = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
+    auto icState = Tempus::createSolutionStateX(icSolution);
+    icState->setTime    (timeStepControl->getInitTime());
+    icState->setIndex   (timeStepControl->getInitIndex());
+    icState->setTimeStep(0.0);
+    icState->setOrder   (stepper->getOrder());
+    icState->setSolutionStatus(Tempus::Status::PASSED);  // ICs are passing.
 
-  // Setup Integrator -----------------------------------------
-  RCP<Tempus::IntegratorBasic<double> > integrator =
-    Tempus::integratorBasic<double>();
-  integrator->setStepperWStepper(stepper);
-  integrator->setTimeStepControl(timeStepControl);
-  integrator->setSolutionHistory(solutionHistory);
-  //integrator->setObserver(...);
-  integrator->initialize();
+    // Setup SolutionHistory ------------------------------------
+    auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());
+    solutionHistory->setName("Forward States");
+    solutionHistory->setStorageType(Tempus::STORAGE_TYPE_STATIC);
+    solutionHistory->setStorageLimit(3);
+    solutionHistory->addState(icState);
+
+    // Setup Integrator -----------------------------------------
+    RCP<Tempus::IntegratorBasic<double> > integrator =
+      Tempus::integratorBasic<double>();
+    integrator->setStepperWStepper(stepper);
+    integrator->setTimeStepControl(timeStepControl);
+    integrator->setSolutionHistory(solutionHistory);
+    //integrator->setObserver(...);
+    integrator->initialize();
 
 
-  // Integrate to timeMax
-  bool integratorStatus = integrator->advanceTime();
-  TEST_ASSERT(integratorStatus)
+    // Integrate to timeMax
+    bool integratorStatus = integrator->advanceTime();
+    TEST_ASSERT(integratorStatus)
 
 
-  // Test if at 'Final Time'
-  double time = integrator->getTime();
-  double timeFinal =pl->sublist("Default Integrator")
-     .sublist("Time Step Control").get<double>("Final Time");
-  TEST_FLOATING_EQUALITY(time, timeFinal, 1.0e-14);
+    // Test if at 'Final Time'
+    double time = integrator->getTime();
+    double timeFinal =pl->sublist("Default Integrator")
+       .sublist("Time Step Control").get<double>("Final Time");
+    TEST_FLOATING_EQUALITY(time, timeFinal, 1.0e-14);
 
-  // Time-integrated solution and the exact solution
-  RCP<Thyra::VectorBase<double> > x = integrator->getX();
-  RCP<const Thyra::VectorBase<double> > x_exact =
-    model->getExactSolution(time).get_x();
+    // Time-integrated solution and the exact solution
+    RCP<Thyra::VectorBase<double> > x = integrator->getX();
+    RCP<const Thyra::VectorBase<double> > x_exact =
+      model->getExactSolution(time).get_x();
 
-  // Calculate the error
-  RCP<Thyra::VectorBase<double> > xdiff = x->clone_v();
-  Thyra::V_StVpStV(xdiff.ptr(), 1.0, *x_exact, -1.0, *(x));
+    // Calculate the error
+    RCP<Thyra::VectorBase<double> > xdiff = x->clone_v();
+    Thyra::V_StVpStV(xdiff.ptr(), 1.0, *x_exact, -1.0, *(x));
 
-  // Check the order and intercept
-  std::cout << "  Stepper = BDF2" << std::endl;
-  std::cout << "  =========================" << std::endl;
-  std::cout << "  Exact solution   : " << get_ele(*(x_exact), 0) << "   "
-                                       << get_ele(*(x_exact), 1) << std::endl;
-  std::cout << "  Computed solution: " << get_ele(*(x      ), 0) << "   "
-                                       << get_ele(*(x      ), 1) << std::endl;
-  std::cout << "  Difference       : " << get_ele(*(xdiff  ), 0) << "   "
-                                       << get_ele(*(xdiff  ), 1) << std::endl;
-  std::cout << "  =========================" << std::endl;
-  TEST_FLOATING_EQUALITY(get_ele(*(x), 0), 0.839732, 1.0e-4 );
-  TEST_FLOATING_EQUALITY(get_ele(*(x), 1), 0.542663, 1.0e-4 );
+    // Check the order and intercept
+    std::cout << "  Stepper = " << stepper->description()
+              << "\n            with " << option << std::endl;
+    std::cout << "  =========================" << std::endl;
+    std::cout << "  Exact solution   : " << get_ele(*(x_exact), 0) << "   "
+                                         << get_ele(*(x_exact), 1) << std::endl;
+    std::cout << "  Computed solution: " << get_ele(*(x      ), 0) << "   "
+                                         << get_ele(*(x      ), 1) << std::endl;
+    std::cout << "  Difference       : " << get_ele(*(xdiff  ), 0) << "   "
+                                         << get_ele(*(xdiff  ), 1) << std::endl;
+    std::cout << "  =========================" << std::endl;
+    TEST_FLOATING_EQUALITY(get_ele(*(x), 0), 0.839732, 1.0e-4 );
+    TEST_FLOATING_EQUALITY(get_ele(*(x), 1), 0.542663, 1.0e-4 );
+  }
 }
 
 

--- a/packages/tempus/test/BackwardEuler/Tempus_BackwardEulerTest.cpp
+++ b/packages/tempus/test/BackwardEuler/Tempus_BackwardEulerTest.cpp
@@ -107,94 +107,105 @@ TEUCHOS_UNIT_TEST(BackwardEuler, ParameterList)
 TEUCHOS_UNIT_TEST(BackwardEuler, ConstructingFromDefaults)
 {
   double dt = 0.1;
+  std::vector<std::string> options;
+  options.push_back("Default Parameters");
+  options.push_back("ICConsistency and Check");
 
-  // Read params from .xml file
-  RCP<ParameterList> pList =
-    getParametersFromXmlFile("Tempus_BackwardEuler_SinCos.xml");
-  RCP<ParameterList> pl = sublist(pList, "Tempus", true);
+  for(const auto& option: options) {
 
-  // Setup the SinCosModel
-  RCP<ParameterList> scm_pl = sublist(pList, "SinCosModel", true);
-  //RCP<SinCosModel<double> > model = sineCosineModel(scm_pl);
-  auto model = rcp(new SinCosModel<double>(scm_pl));
+    // Read params from .xml file
+    RCP<ParameterList> pList =
+      getParametersFromXmlFile("Tempus_BackwardEuler_SinCos.xml");
+    RCP<ParameterList> pl = sublist(pList, "Tempus", true);
 
-  // Setup Stepper for field solve ----------------------------
-  auto stepper = rcp(new Tempus::StepperBackwardEuler<double>());
-  stepper->setModel(model);
-  stepper->initialize();
+    // Setup the SinCosModel
+    RCP<ParameterList> scm_pl = sublist(pList, "SinCosModel", true);
+    //RCP<SinCosModel<double> > model = sineCosineModel(scm_pl);
+    auto model = rcp(new SinCosModel<double>(scm_pl));
 
-  // Setup TimeStepControl ------------------------------------
-  auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
-  ParameterList tscPL = pl->sublist("Default Integrator")
-                           .sublist("Time Step Control");
-  timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
-  timeStepControl->setInitIndex(tscPL.get<int>   ("Initial Time Index"));
-  timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
-  timeStepControl->setFinalTime(tscPL.get<double>("Final Time"));
-  timeStepControl->setInitTimeStep(dt);
-  timeStepControl->initialize();
+    // Setup Stepper for field solve ----------------------------
+    auto stepper = rcp(new Tempus::StepperBackwardEuler<double>());
+    stepper->setModel(model);
+    if ( option == "ICConsistency and Check") {
+      stepper->setICConsistency("Consistent");
+      stepper->setICConsistencyCheck(true);
+    }
+    stepper->initialize();
 
-  // Setup initial condition SolutionState --------------------
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-    stepper->getModel()->getNominalValues();
-  auto icSolution =
-    rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
-  auto icState = Tempus::createSolutionStateX(icSolution);
-  icState->setTime    (timeStepControl->getInitTime());
-  icState->setIndex   (timeStepControl->getInitIndex());
-  icState->setTimeStep(0.0);
-  icState->setOrder   (stepper->getOrder());
-  icState->setSolutionStatus(Tempus::Status::PASSED);  // ICs are passing.
+    // Setup TimeStepControl ------------------------------------
+    auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
+    ParameterList tscPL = pl->sublist("Default Integrator")
+                             .sublist("Time Step Control");
+    timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
+    timeStepControl->setInitIndex(tscPL.get<int>   ("Initial Time Index"));
+    timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
+    timeStepControl->setFinalTime(tscPL.get<double>("Final Time"));
+    timeStepControl->setInitTimeStep(dt);
+    timeStepControl->initialize();
 
-  // Setup SolutionHistory ------------------------------------
-  auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());
-  solutionHistory->setName("Forward States");
-  solutionHistory->setStorageType(Tempus::STORAGE_TYPE_STATIC);
-  solutionHistory->setStorageLimit(2);
-  solutionHistory->addState(icState);
+    // Setup initial condition SolutionState --------------------
+    Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
+      stepper->getModel()->getNominalValues();
+    auto icSolution =
+      rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
+    auto icState = Tempus::createSolutionStateX(icSolution);
+    icState->setTime    (timeStepControl->getInitTime());
+    icState->setIndex   (timeStepControl->getInitIndex());
+    icState->setTimeStep(0.0);
+    icState->setOrder   (stepper->getOrder());
+    icState->setSolutionStatus(Tempus::Status::PASSED);  // ICs are passing.
 
-  // Setup Integrator -----------------------------------------
-  RCP<Tempus::IntegratorBasic<double> > integrator =
-    Tempus::integratorBasic<double>();
-  integrator->setStepperWStepper(stepper);
-  integrator->setTimeStepControl(timeStepControl);
-  integrator->setSolutionHistory(solutionHistory);
-  //integrator->setObserver(...);
-  integrator->initialize();
+    // Setup SolutionHistory ------------------------------------
+    auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());
+    solutionHistory->setName("Forward States");
+    solutionHistory->setStorageType(Tempus::STORAGE_TYPE_STATIC);
+    solutionHistory->setStorageLimit(2);
+    solutionHistory->addState(icState);
+
+    // Setup Integrator -----------------------------------------
+    RCP<Tempus::IntegratorBasic<double> > integrator =
+      Tempus::integratorBasic<double>();
+    integrator->setStepperWStepper(stepper);
+    integrator->setTimeStepControl(timeStepControl);
+    integrator->setSolutionHistory(solutionHistory);
+    //integrator->setObserver(...);
+    integrator->initialize();
 
 
-  // Integrate to timeMax
-  bool integratorStatus = integrator->advanceTime();
-  TEST_ASSERT(integratorStatus)
+    // Integrate to timeMax
+    bool integratorStatus = integrator->advanceTime();
+    TEST_ASSERT(integratorStatus)
 
 
-  // Test if at 'Final Time'
-  double time = integrator->getTime();
-  double timeFinal =pl->sublist("Default Integrator")
-     .sublist("Time Step Control").get<double>("Final Time");
-  TEST_FLOATING_EQUALITY(time, timeFinal, 1.0e-14);
+    // Test if at 'Final Time'
+    double time = integrator->getTime();
+    double timeFinal =pl->sublist("Default Integrator")
+       .sublist("Time Step Control").get<double>("Final Time");
+    TEST_FLOATING_EQUALITY(time, timeFinal, 1.0e-14);
 
-  // Time-integrated solution and the exact solution
-  RCP<Thyra::VectorBase<double> > x = integrator->getX();
-  RCP<const Thyra::VectorBase<double> > x_exact =
-    model->getExactSolution(time).get_x();
+    // Time-integrated solution and the exact solution
+    RCP<Thyra::VectorBase<double> > x = integrator->getX();
+    RCP<const Thyra::VectorBase<double> > x_exact =
+      model->getExactSolution(time).get_x();
 
-  // Calculate the error
-  RCP<Thyra::VectorBase<double> > xdiff = x->clone_v();
-  Thyra::V_StVpStV(xdiff.ptr(), 1.0, *x_exact, -1.0, *(x));
+    // Calculate the error
+    RCP<Thyra::VectorBase<double> > xdiff = x->clone_v();
+    Thyra::V_StVpStV(xdiff.ptr(), 1.0, *x_exact, -1.0, *(x));
 
-  // Check the order and intercept
-  std::cout << "  Stepper = BackwardEuler" << std::endl;
-  std::cout << "  =========================" << std::endl;
-  std::cout << "  Exact solution   : " << get_ele(*(x_exact), 0) << "   "
-                                       << get_ele(*(x_exact), 1) << std::endl;
-  std::cout << "  Computed solution: " << get_ele(*(x      ), 0) << "   "
-                                       << get_ele(*(x      ), 1) << std::endl;
-  std::cout << "  Difference       : " << get_ele(*(xdiff  ), 0) << "   "
-                                       << get_ele(*(xdiff  ), 1) << std::endl;
-  std::cout << "  =========================" << std::endl;
-  TEST_FLOATING_EQUALITY(get_ele(*(x), 0), 0.798923, 1.0e-4 );
-  TEST_FLOATING_EQUALITY(get_ele(*(x), 1), 0.516729, 1.0e-4 );
+    // Check the order and intercept
+    std::cout << "  Stepper = " << stepper->description()
+              << " with " << option << std::endl;
+    std::cout << "  =========================" << std::endl;
+    std::cout << "  Exact solution   : " << get_ele(*(x_exact), 0) << "   "
+                                         << get_ele(*(x_exact), 1) << std::endl;
+    std::cout << "  Computed solution: " << get_ele(*(x      ), 0) << "   "
+                                         << get_ele(*(x      ), 1) << std::endl;
+    std::cout << "  Difference       : " << get_ele(*(xdiff  ), 0) << "   "
+                                         << get_ele(*(xdiff  ), 1) << std::endl;
+    std::cout << "  =========================" << std::endl;
+    TEST_FLOATING_EQUALITY(get_ele(*(x), 0), 0.798923, 1.0e-4 );
+    TEST_FLOATING_EQUALITY(get_ele(*(x), 1), 0.516729, 1.0e-4 );
+  }
 }
 
 

--- a/packages/tempus/test/BackwardEuler/Tempus_BackwardEuler_SinCos.xml
+++ b/packages/tempus/test/BackwardEuler/Tempus_BackwardEuler_SinCos.xml
@@ -49,7 +49,7 @@
       <Parameter name="Stepper Type"   type="string" value="Backward Euler"/>
       <Parameter name="Use FSAL"       type="bool" value="false"/>
       <Parameter name="Initial Condition Consistency" type="string" value="None"/>
-      <Parameter name="Initial Condition Consistency Check" type="bool" value="true"/>
+      <Parameter name="Initial Condition Consistency Check" type="bool" value="false"/>
       <Parameter name="Solver Name"    type="string" value="Default Solver"/>
       <Parameter name="Zero Initial Guess" type="bool" value="0"/>
       <Parameter name="Predictor Stepper Type" type="string" value="Forward Euler"/>

--- a/packages/tempus/test/DIRK/Tempus_DIRKTest.cpp
+++ b/packages/tempus/test/DIRK/Tempus_DIRKTest.cpp
@@ -180,96 +180,200 @@ TEUCHOS_UNIT_TEST(DIRK, ParameterList)
 TEUCHOS_UNIT_TEST(DIRK, ConstructingFromDefaults)
 {
   double dt = 0.025;
+  std::vector<std::string> options;
+  options.push_back("Default Parameters");
+  options.push_back("ICConsistency and Check");
 
-  // Read params from .xml file
-  RCP<ParameterList> pList =
-    getParametersFromXmlFile("Tempus_DIRK_SinCos.xml");
-  RCP<ParameterList> pl = sublist(pList, "Tempus", true);
+  for(const auto& option: options) {
 
-  // Setup the SinCosModel
-  RCP<ParameterList> scm_pl = sublist(pList, "SinCosModel", true);
-  //RCP<SinCosModel<double> > model = sineCosineModel(scm_pl);
-  auto model = rcp(new SinCosModel<double>(scm_pl));
+    // Read params from .xml file
+    RCP<ParameterList> pList =
+      getParametersFromXmlFile("Tempus_DIRK_SinCos.xml");
+    RCP<ParameterList> pl = sublist(pList, "Tempus", true);
 
-  // Setup Stepper for field solve ----------------------------
-  RCP<Tempus::StepperFactory<double> > sf =
-    Teuchos::rcp(new Tempus::StepperFactory<double>());
-  RCP<Tempus::Stepper<double> > stepper =
-    sf->createStepper("SDIRK 2 Stage 2nd order");
-  stepper->setModel(model);
-  stepper->initialize();
+    // Setup the SinCosModel
+    RCP<ParameterList> scm_pl = sublist(pList, "SinCosModel", true);
+    //RCP<SinCosModel<double> > model = sineCosineModel(scm_pl);
+    auto model = rcp(new SinCosModel<double>(scm_pl));
 
-  // Setup TimeStepControl ------------------------------------
-  auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
-  ParameterList tscPL = pl->sublist("Default Integrator")
-                           .sublist("Time Step Control");
-  timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
-  timeStepControl->setInitIndex(tscPL.get<int>   ("Initial Time Index"));
-  timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
-  timeStepControl->setFinalTime(tscPL.get<double>("Final Time"));
-  timeStepControl->setInitTimeStep(dt);
-  timeStepControl->initialize();
+    // Setup Stepper for field solve ----------------------------
+    RCP<Tempus::StepperFactory<double> > sf =
+      Teuchos::rcp(new Tempus::StepperFactory<double>());
+    RCP<Tempus::Stepper<double> > stepper =
+      sf->createStepper("SDIRK 2 Stage 2nd order");
+    stepper->setModel(model);
+    if ( option == "ICConsistency and Check") {
+      stepper->setICConsistency("Consistent");
+      stepper->setICConsistencyCheck(true);
+    }
+    stepper->initialize();
 
-  // Setup initial condition SolutionState --------------------
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-    stepper->getModel()->getNominalValues();
-  auto icSolution = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
-  auto icState = Tempus::createSolutionStateX(icSolution);
-  icState->setTime    (timeStepControl->getInitTime());
-  icState->setIndex   (timeStepControl->getInitIndex());
-  icState->setTimeStep(0.0);
-  icState->setOrder   (stepper->getOrder());
-  icState->setSolutionStatus(Tempus::Status::PASSED);  // ICs are passing.
+    // Setup TimeStepControl ------------------------------------
+    auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
+    ParameterList tscPL = pl->sublist("Default Integrator")
+                             .sublist("Time Step Control");
+    timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
+    timeStepControl->setInitIndex(tscPL.get<int>   ("Initial Time Index"));
+    timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
+    timeStepControl->setFinalTime(tscPL.get<double>("Final Time"));
+    timeStepControl->setInitTimeStep(dt);
+    timeStepControl->initialize();
 
-  // Setup SolutionHistory ------------------------------------
-  auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());
-  solutionHistory->setName("Forward States");
-  solutionHistory->setStorageType(Tempus::STORAGE_TYPE_STATIC);
-  solutionHistory->setStorageLimit(2);
-  solutionHistory->addState(icState);
+    // Setup initial condition SolutionState --------------------
+    Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
+      stepper->getModel()->getNominalValues();
+    auto icSolution = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
+    auto icState = Tempus::createSolutionStateX(icSolution);
+    icState->setTime    (timeStepControl->getInitTime());
+    icState->setIndex   (timeStepControl->getInitIndex());
+    icState->setTimeStep(0.0);
+    icState->setOrder   (stepper->getOrder());
+    icState->setSolutionStatus(Tempus::Status::PASSED);  // ICs are passing.
 
-  // Setup Integrator -----------------------------------------
-  RCP<Tempus::IntegratorBasic<double> > integrator =
-    Tempus::integratorBasic<double>();
-  integrator->setStepperWStepper(stepper);
-  integrator->setTimeStepControl(timeStepControl);
-  integrator->setSolutionHistory(solutionHistory);
-  //integrator->setObserver(...);
-  integrator->initialize();
+    // Setup SolutionHistory ------------------------------------
+    auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());
+    solutionHistory->setName("Forward States");
+    solutionHistory->setStorageType(Tempus::STORAGE_TYPE_STATIC);
+    solutionHistory->setStorageLimit(2);
+    solutionHistory->addState(icState);
+
+    // Setup Integrator -----------------------------------------
+    RCP<Tempus::IntegratorBasic<double> > integrator =
+      Tempus::integratorBasic<double>();
+    integrator->setStepperWStepper(stepper);
+    integrator->setTimeStepControl(timeStepControl);
+    integrator->setSolutionHistory(solutionHistory);
+    //integrator->setObserver(...);
+    integrator->initialize();
 
 
-  // Integrate to timeMax
-  bool integratorStatus = integrator->advanceTime();
-  TEST_ASSERT(integratorStatus)
+    // Integrate to timeMax
+    bool integratorStatus = integrator->advanceTime();
+    TEST_ASSERT(integratorStatus)
 
 
-  // Test if at 'Final Time'
-  double time = integrator->getTime();
-  double timeFinal =pl->sublist("Default Integrator")
-     .sublist("Time Step Control").get<double>("Final Time");
-  TEST_FLOATING_EQUALITY(time, timeFinal, 1.0e-14);
+    // Test if at 'Final Time'
+    double time = integrator->getTime();
+    double timeFinal =pl->sublist("Default Integrator")
+       .sublist("Time Step Control").get<double>("Final Time");
+    TEST_FLOATING_EQUALITY(time, timeFinal, 1.0e-14);
 
-  // Time-integrated solution and the exact solution
-  RCP<Thyra::VectorBase<double> > x = integrator->getX();
-  RCP<const Thyra::VectorBase<double> > x_exact =
-    model->getExactSolution(time).get_x();
+    // Time-integrated solution and the exact solution
+    RCP<Thyra::VectorBase<double> > x = integrator->getX();
+    RCP<const Thyra::VectorBase<double> > x_exact =
+      model->getExactSolution(time).get_x();
 
-  // Calculate the error
-  RCP<Thyra::VectorBase<double> > xdiff = x->clone_v();
-  Thyra::V_StVpStV(xdiff.ptr(), 1.0, *x_exact, -1.0, *(x));
+    // Calculate the error
+    RCP<Thyra::VectorBase<double> > xdiff = x->clone_v();
+    Thyra::V_StVpStV(xdiff.ptr(), 1.0, *x_exact, -1.0, *(x));
 
-  // Check the order and intercept
-  std::cout << "  Stepper = SDIRK 2 Stage 2nd order" << std::endl;
-  std::cout << "  =========================" << std::endl;
-  std::cout << "  Exact solution   : " << get_ele(*(x_exact), 0) << "   "
-                                       << get_ele(*(x_exact), 1) << std::endl;
-  std::cout << "  Computed solution: " << get_ele(*(x      ), 0) << "   "
-                                       << get_ele(*(x      ), 1) << std::endl;
-  std::cout << "  Difference       : " << get_ele(*(xdiff  ), 0) << "   "
-                                       << get_ele(*(xdiff  ), 1) << std::endl;
-  std::cout << "  =========================" << std::endl;
-  TEST_FLOATING_EQUALITY(get_ele(*(x), 0), 0.841470, 1.0e-4 );
-  TEST_FLOATING_EQUALITY(get_ele(*(x), 1), 0.540304, 1.0e-4 );
+    // Check the order and intercept
+    std::cout << "  Stepper = " << stepper->description()
+              << " with " << option << std::endl;
+    std::cout << "  =========================" << std::endl;
+    std::cout << "  Exact solution   : " << get_ele(*(x_exact), 0) << "   "
+                                         << get_ele(*(x_exact), 1) << std::endl;
+    std::cout << "  Computed solution: " << get_ele(*(x      ), 0) << "   "
+                                         << get_ele(*(x      ), 1) << std::endl;
+    std::cout << "  Difference       : " << get_ele(*(xdiff  ), 0) << "   "
+                                         << get_ele(*(xdiff  ), 1) << std::endl;
+    std::cout << "  =========================" << std::endl;
+    TEST_FLOATING_EQUALITY(get_ele(*(x), 0), 0.841470, 1.0e-4 );
+    TEST_FLOATING_EQUALITY(get_ele(*(x), 1), 0.540304, 1.0e-4 );
+  }
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(DIRK, useFSAL_false)
+{
+  double dt = 0.1;
+  std::vector<std::string> RKMethods;
+  RKMethods.push_back("EDIRK 2 Stage Theta Method");
+  RKMethods.push_back("RK Trapezoidal Rule");
+
+  for(std::vector<std::string>::size_type m = 0; m != RKMethods.size(); m++) {
+
+    // Setup the SinCosModel ------------------------------------
+    auto model = rcp(new SinCosModel<double>());
+
+    // Setup Stepper for field solve ----------------------------
+    auto sf = Teuchos::rcp(new Tempus::StepperFactory<double>());
+    auto stepper = sf->createStepper(RKMethods[m]);
+    stepper->setModel(model);
+    stepper->setUseFSAL(false);
+    stepper->initialize();
+
+    // Setup TimeStepControl ------------------------------------
+    auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
+    timeStepControl->setStepType ("Constant");
+    timeStepControl->setInitTime (0.0);
+    timeStepControl->setFinalTime(1.0);
+    timeStepControl->setInitTimeStep(dt);
+    timeStepControl->initialize();
+
+    // Setup initial condition SolutionState --------------------
+    auto inArgsIC = stepper->getModel()->getNominalValues();
+    auto icSolution = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
+    auto icState = Tempus::createSolutionStateX(icSolution);
+    icState->setTime    (timeStepControl->getInitTime());
+    icState->setIndex   (timeStepControl->getInitIndex());
+    icState->setTimeStep(0.0);
+    icState->setOrder   (stepper->getOrder());
+    icState->setSolutionStatus(Tempus::Status::PASSED);  // ICs are passing.
+
+    // Setup SolutionHistory ------------------------------------
+    auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());
+    solutionHistory->setName("Forward States");
+    solutionHistory->setStorageType(Tempus::STORAGE_TYPE_STATIC);
+    solutionHistory->setStorageLimit(2);
+    solutionHistory->addState(icState);
+
+    // Setup Integrator -----------------------------------------
+    auto integrator = Tempus::integratorBasic<double>();
+    integrator->setStepperWStepper(stepper);
+    integrator->setTimeStepControl(timeStepControl);
+    integrator->setSolutionHistory(solutionHistory);
+    integrator->initialize();
+
+
+    // Integrate to timeMax
+    bool integratorStatus = integrator->advanceTime();
+    TEST_ASSERT(integratorStatus)
+
+
+    // Test if at 'Final Time'
+    double time = integrator->getTime();
+    TEST_FLOATING_EQUALITY(time, 1.0, 1.0e-14);
+
+    // Time-integrated solution and the exact solution
+    auto x = integrator->getX();
+    auto x_exact = model->getExactSolution(time).get_x();
+
+    // Calculate the error
+    RCP<Thyra::VectorBase<double> > xdiff = x->clone_v();
+    Thyra::V_StVpStV(xdiff.ptr(), 1.0, *x_exact, -1.0, *(x));
+
+    // Check the order and intercept
+     std::cout << "  Stepper = " << stepper->description()
+               << "\n            with " << "useFSAL=false" << std::endl;
+    std::cout << "  =========================" << std::endl;
+    std::cout << "  Exact solution   : " << get_ele(*(x_exact), 0) << "   "
+                                         << get_ele(*(x_exact), 1) << std::endl;
+    std::cout << "  Computed solution: " << get_ele(*(x      ), 0) << "   "
+                                         << get_ele(*(x      ), 1) << std::endl;
+    std::cout << "  Difference       : " << get_ele(*(xdiff  ), 0) << "   "
+                                         << get_ele(*(xdiff  ), 1) << std::endl;
+    std::cout << "  =========================" << std::endl;
+    if (RKMethods[m] == "EDIRK 2 Stage Theta Method") {
+      TEST_FLOATING_EQUALITY(get_ele(*(x), 0), 0.841021, 1.0e-4 );
+      TEST_FLOATING_EQUALITY(get_ele(*(x), 1), 0.541002, 1.0e-4 );
+    } else if (RKMethods[m] == "RK Trapezoidal Rule") {
+      TEST_FLOATING_EQUALITY(get_ele(*(x), 0), 0.841021, 1.0e-4 );
+      TEST_FLOATING_EQUALITY(get_ele(*(x), 1), 0.541002, 1.0e-4 );
+    }
+  }
 }
 
 

--- a/packages/tempus/test/ExplicitRK/Tempus_ExplicitRKTest.cpp
+++ b/packages/tempus/test/ExplicitRK/Tempus_ExplicitRKTest.cpp
@@ -135,96 +135,200 @@ TEUCHOS_UNIT_TEST(ExplicitRK, ParameterList)
 TEUCHOS_UNIT_TEST(ExplicitRK, ConstructingFromDefaults)
 {
   double dt = 0.1;
+  std::vector<std::string> options;
+  options.push_back("Default Parameters");
+  options.push_back("ICConsistency and Check");
 
-  // Read params from .xml file
-  RCP<ParameterList> pList =
-    getParametersFromXmlFile("Tempus_ExplicitRK_SinCos.xml");
-  RCP<ParameterList> pl = sublist(pList, "Tempus", true);
+  for(const auto& option: options) {
 
-  // Setup the SinCosModel
-  RCP<ParameterList> scm_pl = sublist(pList, "SinCosModel", true);
-  //RCP<SinCosModel<double> > model = sineCosineModel(scm_pl);
-  auto model = rcp(new SinCosModel<double>(scm_pl));
+    // Read params from .xml file
+    RCP<ParameterList> pList =
+      getParametersFromXmlFile("Tempus_ExplicitRK_SinCos.xml");
+    RCP<ParameterList> pl = sublist(pList, "Tempus", true);
 
-  // Setup Stepper for field solve ----------------------------
-  RCP<Tempus::StepperFactory<double> > sf =
-    Teuchos::rcp(new Tempus::StepperFactory<double>());
-  RCP<Tempus::Stepper<double> > stepper =
-    sf->createStepper("RK Explicit 4 Stage");
-  stepper->setModel(model);
-  stepper->initialize();
+    // Setup the SinCosModel
+    RCP<ParameterList> scm_pl = sublist(pList, "SinCosModel", true);
+    //RCP<SinCosModel<double> > model = sineCosineModel(scm_pl);
+    auto model = rcp(new SinCosModel<double>(scm_pl));
 
-  // Setup TimeStepControl ------------------------------------
-  auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
-  ParameterList tscPL = pl->sublist("Demo Integrator")
-                           .sublist("Time Step Control");
-  timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
-  timeStepControl->setInitIndex(tscPL.get<int>   ("Initial Time Index"));
-  timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
-  timeStepControl->setFinalTime(tscPL.get<double>("Final Time"));
-  timeStepControl->setInitTimeStep(dt);
-  timeStepControl->initialize();
+    // Setup Stepper for field solve ----------------------------
+    RCP<Tempus::StepperFactory<double> > sf =
+      Teuchos::rcp(new Tempus::StepperFactory<double>());
+    RCP<Tempus::Stepper<double> > stepper =
+      sf->createStepper("RK Explicit 4 Stage");
+    stepper->setModel(model);
+    if ( option == "ICConsistency and Check") {
+      stepper->setICConsistency("Consistent");
+      stepper->setICConsistencyCheck(true);
+    }
+    stepper->initialize();
 
-  // Setup initial condition SolutionState --------------------
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-    stepper->getModel()->getNominalValues();
-  auto icSolution = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
-  auto icState = Tempus::createSolutionStateX(icSolution);
-  icState->setTime    (timeStepControl->getInitTime());
-  icState->setIndex   (timeStepControl->getInitIndex());
-  icState->setTimeStep(0.0);
-  icState->setOrder   (stepper->getOrder());
-  icState->setSolutionStatus(Tempus::Status::PASSED);  // ICs are passing.
+    // Setup TimeStepControl ------------------------------------
+    auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
+    ParameterList tscPL = pl->sublist("Demo Integrator")
+                             .sublist("Time Step Control");
+    timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
+    timeStepControl->setInitIndex(tscPL.get<int>   ("Initial Time Index"));
+    timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
+    timeStepControl->setFinalTime(tscPL.get<double>("Final Time"));
+    timeStepControl->setInitTimeStep(dt);
+    timeStepControl->initialize();
 
-  // Setup SolutionHistory ------------------------------------
-  auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());
-  solutionHistory->setName("Forward States");
-  solutionHistory->setStorageType(Tempus::STORAGE_TYPE_STATIC);
-  solutionHistory->setStorageLimit(2);
-  solutionHistory->addState(icState);
+    // Setup initial condition SolutionState --------------------
+    Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
+      stepper->getModel()->getNominalValues();
+    auto icSolution = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
+    auto icState = Tempus::createSolutionStateX(icSolution);
+    icState->setTime    (timeStepControl->getInitTime());
+    icState->setIndex   (timeStepControl->getInitIndex());
+    icState->setTimeStep(0.0);
+    icState->setOrder   (stepper->getOrder());
+    icState->setSolutionStatus(Tempus::Status::PASSED);  // ICs are passing.
 
-  // Setup Integrator -----------------------------------------
-  RCP<Tempus::IntegratorBasic<double> > integrator =
-    Tempus::integratorBasic<double>();
-  integrator->setStepperWStepper(stepper);
-  integrator->setTimeStepControl(timeStepControl);
-  integrator->setSolutionHistory(solutionHistory);
-  //integrator->setObserver(...);
-  integrator->initialize();
+    // Setup SolutionHistory ------------------------------------
+    auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());
+    solutionHistory->setName("Forward States");
+    solutionHistory->setStorageType(Tempus::STORAGE_TYPE_STATIC);
+    solutionHistory->setStorageLimit(2);
+    solutionHistory->addState(icState);
+
+    // Setup Integrator -----------------------------------------
+    RCP<Tempus::IntegratorBasic<double> > integrator =
+      Tempus::integratorBasic<double>();
+    integrator->setStepperWStepper(stepper);
+    integrator->setTimeStepControl(timeStepControl);
+    integrator->setSolutionHistory(solutionHistory);
+    //integrator->setObserver(...);
+    integrator->initialize();
 
 
-  // Integrate to timeMax
-  bool integratorStatus = integrator->advanceTime();
-  TEST_ASSERT(integratorStatus)
+    // Integrate to timeMax
+    bool integratorStatus = integrator->advanceTime();
+    TEST_ASSERT(integratorStatus)
 
 
-  // Test if at 'Final Time'
-  double time = integrator->getTime();
-  double timeFinal =pl->sublist("Demo Integrator")
-     .sublist("Time Step Control").get<double>("Final Time");
-  TEST_FLOATING_EQUALITY(time, timeFinal, 1.0e-14);
+    // Test if at 'Final Time'
+    double time = integrator->getTime();
+    double timeFinal =pl->sublist("Demo Integrator")
+       .sublist("Time Step Control").get<double>("Final Time");
+    TEST_FLOATING_EQUALITY(time, timeFinal, 1.0e-14);
 
-  // Time-integrated solution and the exact solution
-  RCP<Thyra::VectorBase<double> > x = integrator->getX();
-  RCP<const Thyra::VectorBase<double> > x_exact =
-    model->getExactSolution(time).get_x();
+    // Time-integrated solution and the exact solution
+    RCP<Thyra::VectorBase<double> > x = integrator->getX();
+    RCP<const Thyra::VectorBase<double> > x_exact =
+      model->getExactSolution(time).get_x();
 
-  // Calculate the error
-  RCP<Thyra::VectorBase<double> > xdiff = x->clone_v();
-  Thyra::V_StVpStV(xdiff.ptr(), 1.0, *x_exact, -1.0, *(x));
+    // Calculate the error
+    RCP<Thyra::VectorBase<double> > xdiff = x->clone_v();
+    Thyra::V_StVpStV(xdiff.ptr(), 1.0, *x_exact, -1.0, *(x));
 
-  // Check the order and intercept
-  std::cout << "  Stepper = RK Explicit 4 Stage" << std::endl;
-  std::cout << "  =========================" << std::endl;
-  std::cout << "  Exact solution   : " << get_ele(*(x_exact), 0) << "   "
-                                       << get_ele(*(x_exact), 1) << std::endl;
-  std::cout << "  Computed solution: " << get_ele(*(x      ), 0) << "   "
-                                       << get_ele(*(x      ), 1) << std::endl;
-  std::cout << "  Difference       : " << get_ele(*(xdiff  ), 0) << "   "
-                                       << get_ele(*(xdiff  ), 1) << std::endl;
-  std::cout << "  =========================" << std::endl;
-  TEST_FLOATING_EQUALITY(get_ele(*(x), 0), 0.841470, 1.0e-4 );
-  TEST_FLOATING_EQUALITY(get_ele(*(x), 1), 0.540303, 1.0e-4 );
+    // Check the order and intercept
+    std::cout << "  Stepper = " << stepper->description()
+              << "\n            with " << option << std::endl;
+    std::cout << "  =========================" << std::endl;
+    std::cout << "  Exact solution   : " << get_ele(*(x_exact), 0) << "   "
+                                         << get_ele(*(x_exact), 1) << std::endl;
+    std::cout << "  Computed solution: " << get_ele(*(x      ), 0) << "   "
+                                         << get_ele(*(x      ), 1) << std::endl;
+    std::cout << "  Difference       : " << get_ele(*(xdiff  ), 0) << "   "
+                                         << get_ele(*(xdiff  ), 1) << std::endl;
+    std::cout << "  =========================" << std::endl;
+    TEST_FLOATING_EQUALITY(get_ele(*(x), 0), 0.841470, 1.0e-4 );
+    TEST_FLOATING_EQUALITY(get_ele(*(x), 1), 0.540303, 1.0e-4 );
+  }
+}
+
+
+// ************************************************************
+// ************************************************************
+TEUCHOS_UNIT_TEST(ExplicitRK, useFSAL_false)
+{
+  double dt = 0.1;
+  std::vector<std::string> RKMethods;
+  RKMethods.push_back("RK Forward Euler");
+  RKMethods.push_back("Bogacki-Shampine 3(2) Pair");
+
+  for(std::vector<std::string>::size_type m = 0; m != RKMethods.size(); m++) {
+
+    // Setup the SinCosModel ------------------------------------
+    auto model = rcp(new SinCosModel<double>());
+
+    // Setup Stepper for field solve ----------------------------
+    auto sf = Teuchos::rcp(new Tempus::StepperFactory<double>());
+    auto stepper = sf->createStepper(RKMethods[m]);
+    stepper->setModel(model);
+    stepper->setUseFSAL(false);
+    stepper->initialize();
+
+    // Setup TimeStepControl ------------------------------------
+    auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
+    timeStepControl->setStepType ("Constant");
+    timeStepControl->setInitTime (0.0);
+    timeStepControl->setFinalTime(1.0);
+    timeStepControl->setInitTimeStep(dt);
+    timeStepControl->initialize();
+
+    // Setup initial condition SolutionState --------------------
+    auto inArgsIC = stepper->getModel()->getNominalValues();
+    auto icSolution = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
+    auto icState = Tempus::createSolutionStateX(icSolution);
+    icState->setTime    (timeStepControl->getInitTime());
+    icState->setIndex   (timeStepControl->getInitIndex());
+    icState->setTimeStep(0.0);
+    icState->setOrder   (stepper->getOrder());
+    icState->setSolutionStatus(Tempus::Status::PASSED);  // ICs are passing.
+
+    // Setup SolutionHistory ------------------------------------
+    auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());
+    solutionHistory->setName("Forward States");
+    solutionHistory->setStorageType(Tempus::STORAGE_TYPE_STATIC);
+    solutionHistory->setStorageLimit(2);
+    solutionHistory->addState(icState);
+
+    // Setup Integrator -----------------------------------------
+    auto integrator = Tempus::integratorBasic<double>();
+    integrator->setStepperWStepper(stepper);
+    integrator->setTimeStepControl(timeStepControl);
+    integrator->setSolutionHistory(solutionHistory);
+    integrator->initialize();
+
+
+    // Integrate to timeMax
+    bool integratorStatus = integrator->advanceTime();
+    TEST_ASSERT(integratorStatus)
+
+
+    // Test if at 'Final Time'
+    double time = integrator->getTime();
+    TEST_FLOATING_EQUALITY(time, 1.0, 1.0e-14);
+
+    // Time-integrated solution and the exact solution
+    auto x = integrator->getX();
+    auto x_exact = model->getExactSolution(time).get_x();
+
+    // Calculate the error
+    RCP<Thyra::VectorBase<double> > xdiff = x->clone_v();
+    Thyra::V_StVpStV(xdiff.ptr(), 1.0, *x_exact, -1.0, *(x));
+
+    // Check the order and intercept
+     std::cout << "  Stepper = " << stepper->description()
+               << "\n            with " << "useFSAL=false" << std::endl;
+    std::cout << "  =========================" << std::endl;
+    std::cout << "  Exact solution   : " << get_ele(*(x_exact), 0) << "   "
+                                         << get_ele(*(x_exact), 1) << std::endl;
+    std::cout << "  Computed solution: " << get_ele(*(x      ), 0) << "   "
+                                         << get_ele(*(x      ), 1) << std::endl;
+    std::cout << "  Difference       : " << get_ele(*(xdiff  ), 0) << "   "
+                                         << get_ele(*(xdiff  ), 1) << std::endl;
+    std::cout << "  =========================" << std::endl;
+    if (RKMethods[m] == "RK Forward Euler") {
+      TEST_FLOATING_EQUALITY(get_ele(*(x), 0), 0.882508, 1.0e-4 );
+      TEST_FLOATING_EQUALITY(get_ele(*(x), 1), 0.570790, 1.0e-4 );
+    } else if (RKMethods[m] == "Bogacki-Shampine 3(2) Pair") {
+      TEST_FLOATING_EQUALITY(get_ele(*(x), 0), 0.841438, 1.0e-4 );
+      TEST_FLOATING_EQUALITY(get_ele(*(x), 1), 0.540277, 1.0e-4 );
+    }
+  }
 }
 
 
@@ -251,7 +355,7 @@ TEUCHOS_UNIT_TEST(ExplicitRK, SinCos)
   RKMethods.push_back("SSPERK22");
   RKMethods.push_back("SSPERK33");
   RKMethods.push_back("SSPERK54");  // slope = 3.94129
-  RKMethods.push_back("RK2"); 
+  RKMethods.push_back("RK2");
 
   std::vector<double> RKMethodErrors;
   RKMethodErrors.push_back(8.33251e-07);
@@ -272,7 +376,7 @@ TEUCHOS_UNIT_TEST(ExplicitRK, SinCos)
   RKMethodErrors.push_back(0.00166645);
   RKMethodErrors.push_back(4.16603e-05);
   RKMethodErrors.push_back(3.85613e-07); // SSPERK54
-  RKMethodErrors.push_back(0.00166644); 
+  RKMethodErrors.push_back(0.00166644);
 
 
   TEST_ASSERT(RKMethods.size() == RKMethodErrors.size() );

--- a/packages/tempus/test/ExplicitRK/Tempus_ExplicitRK_SinCos.xml
+++ b/packages/tempus/test/ExplicitRK/Tempus_ExplicitRK_SinCos.xml
@@ -48,7 +48,7 @@
         <Parameter name="Stepper Type" type="string" value="RK Forward Euler"/>
         <Parameter name="Use FSAL" type="bool" value="false"/>
         <Parameter name="Initial Condition Consistency" type="string" value="Consistent"/>
-        <Parameter name="Initial Condition Consistency Check" type="bool" value="true"/>
+        <Parameter name="Initial Condition Consistency Check" type="bool" value="false"/>
         <Parameter name="Use Embedded" type="bool" value="false"/>
     </ParameterList>
 
@@ -56,7 +56,7 @@
         <Parameter name="Stepper Type" type="string" value="General ERK"/>
         <Parameter name="Use FSAL" type="bool" value="false"/>
         <Parameter name="Initial Condition Consistency" type="string" value="Consistent"/>
-        <Parameter name="Initial Condition Consistency Check" type="bool" value="true"/>
+        <Parameter name="Initial Condition Consistency Check" type="bool" value="false"/>
         <Parameter name="Use Embedded" type="bool" value="false"/>
         <ParameterList name="Tableau">
             <Parameter name="A" type="string"
@@ -74,7 +74,7 @@
         <Parameter name="Stepper Type" type="string" value="General ERK"/>
         <Parameter name="Use FSAL" type="bool" value="false"/>
         <Parameter name="Initial Condition Consistency" type="string" value="Consistent"/>
-        <Parameter name="Initial Condition Consistency Check" type="bool" value="true"/>
+        <Parameter name="Initial Condition Consistency Check" type="bool" value="false"/>
         <Parameter name="Use Embedded" type="bool" value="false"/>
         <ParameterList name="Tableau">
             <Parameter name="A" type="string"

--- a/packages/tempus/test/ForwardEuler/Tempus_ForwardEulerTest.cpp
+++ b/packages/tempus/test/ForwardEuler/Tempus_ForwardEulerTest.cpp
@@ -99,92 +99,106 @@ TEUCHOS_UNIT_TEST(ForwardEuler, ParameterList)
 TEUCHOS_UNIT_TEST(ForwardEuler, ConstructingFromDefaults)
 {
   double dt = 0.1;
+  std::vector<std::string> options;
+  options.push_back("useFSAL=true");
+  options.push_back("useFSAL=false");
+  options.push_back("ICConsistency and Check");
 
-  // Read params from .xml file
-  RCP<ParameterList> pList =
-    getParametersFromXmlFile("Tempus_ForwardEuler_SinCos.xml");
-  RCP<ParameterList> pl = sublist(pList, "Tempus", true);
+  for(const auto& option: options) {
 
-  // Setup the SinCosModel
-  RCP<ParameterList> scm_pl = sublist(pList, "SinCosModel", true);
-  //RCP<SinCosModel<double> > model = sineCosineModel(scm_pl);
-  auto model = rcp(new SinCosModel<double>(scm_pl));
+    // Read params from .xml file
+    RCP<ParameterList> pList =
+      getParametersFromXmlFile("Tempus_ForwardEuler_SinCos.xml");
+    RCP<ParameterList> pl = sublist(pList, "Tempus", true);
 
-  // Setup Stepper for field solve ----------------------------
-  auto stepper = rcp(new Tempus::StepperForwardEuler<double>());
-  stepper->setModel(model);
-  stepper->initialize();
+    // Setup the SinCosModel
+    RCP<ParameterList> scm_pl = sublist(pList, "SinCosModel", true);
+    //RCP<SinCosModel<double> > model = sineCosineModel(scm_pl);
+    auto model = rcp(new SinCosModel<double>(scm_pl));
 
-  // Setup TimeStepControl ------------------------------------
-  auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
-  ParameterList tscPL = pl->sublist("Demo Integrator")
-                           .sublist("Time Step Control");
-  timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
-  timeStepControl->setInitIndex(tscPL.get<int>   ("Initial Time Index"));
-  timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
-  timeStepControl->setFinalTime(tscPL.get<double>("Final Time"));
-  timeStepControl->setInitTimeStep(dt);
-  timeStepControl->initialize();
+    // Setup Stepper for field solve ----------------------------
+    auto stepper = rcp(new Tempus::StepperForwardEuler<double>());
+    stepper->setModel(model);
+    if (option == "useFSAL=true") stepper->setUseFSAL(true);
+    else if (option == "useFSAL=false") stepper->setUseFSAL(false);
+    else if ( option == "ICConsistency and Check") {
+      stepper->setICConsistency("Consistent");
+      stepper->setICConsistencyCheck(true);
+    }
+    stepper->initialize();
 
-  // Setup initial condition SolutionState --------------------
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-    stepper->getModel()->getNominalValues();
-  auto icSolution = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
-  auto icState = Tempus::createSolutionStateX(icSolution);
-  icState->setTime    (timeStepControl->getInitTime());
-  icState->setIndex   (timeStepControl->getInitIndex());
-  icState->setTimeStep(0.0);
-  icState->setSolutionStatus(Tempus::Status::PASSED);  // ICs are passing.
+    // Setup TimeStepControl ------------------------------------
+    auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
+    ParameterList tscPL = pl->sublist("Demo Integrator")
+                             .sublist("Time Step Control");
+    timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
+    timeStepControl->setInitIndex(tscPL.get<int>   ("Initial Time Index"));
+    timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
+    timeStepControl->setFinalTime(tscPL.get<double>("Final Time"));
+    timeStepControl->setInitTimeStep(dt);
+    timeStepControl->initialize();
 
-  // Setup SolutionHistory ------------------------------------
-  auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());
-  solutionHistory->setName("Forward States");
-  solutionHistory->setStorageType(Tempus::STORAGE_TYPE_STATIC);
-  solutionHistory->setStorageLimit(2);
-  solutionHistory->addState(icState);
+    // Setup initial condition SolutionState --------------------
+    Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
+      stepper->getModel()->getNominalValues();
+    auto icSolution = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
+    auto icState = Tempus::createSolutionStateX(icSolution);
+    icState->setTime    (timeStepControl->getInitTime());
+    icState->setIndex   (timeStepControl->getInitIndex());
+    icState->setTimeStep(0.0);
+    icState->setSolutionStatus(Tempus::Status::PASSED);  // ICs are passing.
 
-  // Setup Integrator -----------------------------------------
-  RCP<Tempus::IntegratorBasic<double> > integrator =
-    Tempus::integratorBasic<double>();
-  integrator->setStepperWStepper(stepper);
-  integrator->setTimeStepControl(timeStepControl);
-  integrator->setSolutionHistory(solutionHistory);
-  //integrator->setObserver(...);
-  integrator->initialize();
+    // Setup SolutionHistory ------------------------------------
+    auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());
+    solutionHistory->setName("Forward States");
+    solutionHistory->setStorageType(Tempus::STORAGE_TYPE_STATIC);
+    solutionHistory->setStorageLimit(2);
+    solutionHistory->addState(icState);
+
+    // Setup Integrator -----------------------------------------
+    RCP<Tempus::IntegratorBasic<double> > integrator =
+      Tempus::integratorBasic<double>();
+    integrator->setStepperWStepper(stepper);
+    integrator->setTimeStepControl(timeStepControl);
+    integrator->setSolutionHistory(solutionHistory);
+    //integrator->setObserver(...);
+    integrator->initialize();
 
 
-  // Integrate to timeMax
-  bool integratorStatus = integrator->advanceTime();
-  TEST_ASSERT(integratorStatus)
+    // Integrate to timeMax
+    bool integratorStatus = integrator->advanceTime();
+    TEST_ASSERT(integratorStatus)
 
 
-  // Test if at 'Final Time'
-  double time = integrator->getTime();
-  double timeFinal =pl->sublist("Demo Integrator")
-     .sublist("Time Step Control").get<double>("Final Time");
-  TEST_FLOATING_EQUALITY(time, timeFinal, 1.0e-14);
+    // Test if at 'Final Time'
+    double time = integrator->getTime();
+    double timeFinal =pl->sublist("Demo Integrator")
+       .sublist("Time Step Control").get<double>("Final Time");
+    TEST_FLOATING_EQUALITY(time, timeFinal, 1.0e-14);
 
-  // Time-integrated solution and the exact solution
-  RCP<Thyra::VectorBase<double> > x = integrator->getX();
-  RCP<const Thyra::VectorBase<double> > x_exact =
-    model->getExactSolution(time).get_x();
+    // Time-integrated solution and the exact solution
+    RCP<Thyra::VectorBase<double> > x = integrator->getX();
+    RCP<const Thyra::VectorBase<double> > x_exact =
+      model->getExactSolution(time).get_x();
 
-  // Calculate the error
-  RCP<Thyra::VectorBase<double> > xdiff = x->clone_v();
-  Thyra::V_StVpStV(xdiff.ptr(), 1.0, *x_exact, -1.0, *(x));
+    // Calculate the error
+    RCP<Thyra::VectorBase<double> > xdiff = x->clone_v();
+    Thyra::V_StVpStV(xdiff.ptr(), 1.0, *x_exact, -1.0, *(x));
 
-  // Check the order and intercept
-  std::cout << "  Stepper = ForwardEuler" << std::endl;
-  std::cout << "  =========================" << std::endl;
-  std::cout << "  Exact solution   : " << get_ele(*(x_exact), 0) << "   "
-                                       << get_ele(*(x_exact), 1) << std::endl;
-  std::cout << "  Computed solution: " << get_ele(*(x      ), 0) << "   "
-                                       << get_ele(*(x      ), 1) << std::endl;
-  std::cout << "  Difference       : " << get_ele(*(xdiff  ), 0) << "   "
-                                       << get_ele(*(xdiff  ), 1) << std::endl;
-  std::cout << "  =========================" << std::endl;
-  TEST_FLOATING_EQUALITY(get_ele(*(x), 0), 0.882508, 1.0e-4 );
-  TEST_FLOATING_EQUALITY(get_ele(*(x), 1), 0.570790, 1.0e-4 );
+    // Check the order and intercept
+    std::cout << "  Stepper = " << stepper->description()
+              << "\n            with " << option << std::endl;
+    std::cout << "  =========================" << std::endl;
+    std::cout << "  Exact solution   : " << get_ele(*(x_exact), 0) << "   "
+                                         << get_ele(*(x_exact), 1) << std::endl;
+    std::cout << "  Computed solution: " << get_ele(*(x      ), 0) << "   "
+                                         << get_ele(*(x      ), 1) << std::endl;
+    std::cout << "  Difference       : " << get_ele(*(xdiff  ), 0) << "   "
+                                         << get_ele(*(xdiff  ), 1) << std::endl;
+    std::cout << "  =========================" << std::endl;
+    TEST_FLOATING_EQUALITY(get_ele(*(x), 0), 0.882508, 1.0e-4 );
+    TEST_FLOATING_EQUALITY(get_ele(*(x), 1), 0.570790, 1.0e-4 );
+  }
 }
 
 

--- a/packages/tempus/test/ForwardEuler/Tempus_ForwardEuler_SinCos.xml
+++ b/packages/tempus/test/ForwardEuler/Tempus_ForwardEuler_SinCos.xml
@@ -48,7 +48,7 @@
       <Parameter name="Stepper Type" type="string" value="Forward Euler"/>
       <Parameter name="Use FSAL" type="bool" value="true"/>
       <Parameter name="Initial Condition Consistency" type="string" value="Consistent"/>
-      <Parameter name="Initial Condition Consistency Check" type="bool" value="true"/>
+      <Parameter name="Initial Condition Consistency Check" type="bool" value="false"/>
     </ParameterList>
 
   </ParameterList>

--- a/packages/tempus/test/Integrator/Tempus_IntegratorBasic_ref.xml
+++ b/packages/tempus/test/Integrator/Tempus_IntegratorBasic_ref.xml
@@ -43,7 +43,7 @@
     <Parameter docString="" id="29" isDefault="false" isUsed="true" name="Stepper Type" type="string" value="Forward Euler"/>
     <Parameter docString="" id="34" isDefault="false" isUsed="true" name="Use FSAL" type="bool" value="true"/>
     <Parameter docString="" id="35" isDefault="false" isUsed="true" name="Initial Condition Consistency" type="string" value="Consistent"/>
-    <Parameter docString="" id="36" isDefault="false" isUsed="true" name="Initial Condition Consistency Check" type="bool" value="true"/>
+    <Parameter docString="" id="36" isDefault="false" isUsed="true" name="Initial Condition Consistency Check" type="bool" value="false"/>
   </ParameterList>
   <Validators/>
 </ParameterList>

--- a/packages/tempus/test/Integrator/Tempus_IntegratorBasic_ref2.xml
+++ b/packages/tempus/test/Integrator/Tempus_IntegratorBasic_ref2.xml
@@ -43,7 +43,7 @@
     <Parameter docString="" id="29" isDefault="false" isUsed="true" name="Stepper Type" type="string" value="Forward Euler"/>
     <Parameter docString="" id="34" isDefault="false" isUsed="true" name="Use FSAL" type="bool" value="true"/>
     <Parameter docString="" id="35" isDefault="false" isUsed="true" name="Initial Condition Consistency" type="string" value="Consistent"/>
-    <Parameter docString="" id="36" isDefault="false" isUsed="true" name="Initial Condition Consistency Check" type="bool" value="true"/>
+    <Parameter docString="" id="36" isDefault="false" isUsed="true" name="Initial Condition Consistency Check" type="bool" value="false"/>
   </ParameterList>
   <Validators/>
 </ParameterList>

--- a/packages/tempus/test/Leapfrog/Tempus_LeapfrogTest.cpp
+++ b/packages/tempus/test/Leapfrog/Tempus_LeapfrogTest.cpp
@@ -51,90 +51,101 @@ using Tempus::SolutionState;
 TEUCHOS_UNIT_TEST(Leapfrog, ConstructingFromDefaults)
 {
   double dt = 0.1;
+  std::vector<std::string> options;
+  options.push_back("Default Parameters");
+  options.push_back("ICConsistency and Check");
 
-  // Read params from .xml file
-  RCP<ParameterList> pList =
-    getParametersFromXmlFile("Tempus_Leapfrog_SinCos.xml");
-  RCP<ParameterList> pl = sublist(pList, "Tempus", true);
+  for(const auto& option: options) {
 
-  // Setup the HarmonicOscillatorModel
-  RCP<ParameterList> hom_pl = sublist(pList, "HarmonicOscillatorModel", true);
-  auto model = rcp(new HarmonicOscillatorModel<double>(hom_pl));
+    // Read params from .xml file
+    RCP<ParameterList> pList =
+      getParametersFromXmlFile("Tempus_Leapfrog_SinCos.xml");
+    RCP<ParameterList> pl = sublist(pList, "Tempus", true);
 
-  // Setup Stepper for field solve ----------------------------
-  auto stepper = rcp(new Tempus::StepperLeapfrog<double>());
-  stepper->setModel(model);
-  stepper->initialize();
+    // Setup the HarmonicOscillatorModel
+    RCP<ParameterList> hom_pl = sublist(pList, "HarmonicOscillatorModel", true);
+    auto model = rcp(new HarmonicOscillatorModel<double>(hom_pl));
 
-  // Setup TimeStepControl ------------------------------------
-  auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
-  ParameterList tscPL = pl->sublist("Default Integrator")
-                           .sublist("Time Step Control");
-  timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
-  timeStepControl->setInitIndex(tscPL.get<int>   ("Initial Time Index"));
-  timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
-  timeStepControl->setFinalTime(tscPL.get<double>("Final Time"));
-  timeStepControl->setInitTimeStep(dt);
-  timeStepControl->initialize();
+    // Setup Stepper for field solve ----------------------------
+    auto stepper = rcp(new Tempus::StepperLeapfrog<double>());
+    stepper->setModel(model);
+    if ( option == "ICConsistency and Check") {
+      stepper->setICConsistency("Consistent");
+      stepper->setICConsistencyCheck(true);
+    }
+    stepper->initialize();
 
-  // Setup initial condition SolutionState --------------------
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-    stepper->getModel()->getNominalValues();
-  auto icX = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
-  auto icXDot = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x_dot());
-  auto icXDotDot = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x_dot_dot());
-  auto icState = Tempus::createSolutionStateX<double>(icX, icXDot, icXDotDot);
-  icState->setTime    (timeStepControl->getInitTime());
-  icState->setIndex   (timeStepControl->getInitIndex());
-  icState->setTimeStep(0.0);
-  icState->setOrder   (stepper->getOrder());
-  icState->setSolutionStatus(Tempus::Status::PASSED);  // ICs are passing.
+    // Setup TimeStepControl ------------------------------------
+    auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
+    ParameterList tscPL = pl->sublist("Default Integrator")
+                             .sublist("Time Step Control");
+    timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
+    timeStepControl->setInitIndex(tscPL.get<int>   ("Initial Time Index"));
+    timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
+    timeStepControl->setFinalTime(tscPL.get<double>("Final Time"));
+    timeStepControl->setInitTimeStep(dt);
+    timeStepControl->initialize();
 
-  // Setup SolutionHistory ------------------------------------
-  auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());
-  solutionHistory->setName("Forward States");
-  solutionHistory->setStorageType(Tempus::STORAGE_TYPE_STATIC);
-  solutionHistory->setStorageLimit(2);
-  solutionHistory->addState(icState);
+    // Setup initial condition SolutionState --------------------
+    Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
+      stepper->getModel()->getNominalValues();
+    auto icX = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
+    auto icXDot = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x_dot());
+    auto icXDotDot = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x_dot_dot());
+    auto icState = Tempus::createSolutionStateX<double>(icX, icXDot, icXDotDot);
+    icState->setTime    (timeStepControl->getInitTime());
+    icState->setIndex   (timeStepControl->getInitIndex());
+    icState->setTimeStep(0.0);
+    icState->setOrder   (stepper->getOrder());
+    icState->setSolutionStatus(Tempus::Status::PASSED);  // ICs are passing.
 
-  // Setup Integrator -----------------------------------------
-  RCP<Tempus::IntegratorBasic<double> > integrator =
-    Tempus::integratorBasic<double>();
-  integrator->setStepperWStepper(stepper);
-  integrator->setTimeStepControl(timeStepControl);
-  integrator->setSolutionHistory(solutionHistory);
-  //integrator->setObserver(...);
-  integrator->initialize();
+    // Setup SolutionHistory ------------------------------------
+    auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());
+    solutionHistory->setName("Forward States");
+    solutionHistory->setStorageType(Tempus::STORAGE_TYPE_STATIC);
+    solutionHistory->setStorageLimit(2);
+    solutionHistory->addState(icState);
+
+    // Setup Integrator -----------------------------------------
+    RCP<Tempus::IntegratorBasic<double> > integrator =
+      Tempus::integratorBasic<double>();
+    integrator->setStepperWStepper(stepper);
+    integrator->setTimeStepControl(timeStepControl);
+    integrator->setSolutionHistory(solutionHistory);
+    //integrator->setObserver(...);
+    integrator->initialize();
 
 
-  // Integrate to timeMax
-  bool integratorStatus = integrator->advanceTime();
-  TEST_ASSERT(integratorStatus)
+    // Integrate to timeMax
+    bool integratorStatus = integrator->advanceTime();
+    TEST_ASSERT(integratorStatus)
 
 
-  // Test if at 'Final Time'
-  double time = integrator->getTime();
-  double timeFinal =pl->sublist("Default Integrator")
-     .sublist("Time Step Control").get<double>("Final Time");
-  TEST_FLOATING_EQUALITY(time, timeFinal, 1.0e-14);
+    // Test if at 'Final Time'
+    double time = integrator->getTime();
+    double timeFinal =pl->sublist("Default Integrator")
+       .sublist("Time Step Control").get<double>("Final Time");
+    TEST_FLOATING_EQUALITY(time, timeFinal, 1.0e-14);
 
-  // Time-integrated solution and the exact solution
-  RCP<Thyra::VectorBase<double> > x = integrator->getX();
-  RCP<const Thyra::VectorBase<double> > x_exact =
-    model->getExactSolution(time).get_x();
+    // Time-integrated solution and the exact solution
+    RCP<Thyra::VectorBase<double> > x = integrator->getX();
+    RCP<const Thyra::VectorBase<double> > x_exact =
+      model->getExactSolution(time).get_x();
 
-  // Calculate the error
-  RCP<Thyra::VectorBase<double> > xdiff = x->clone_v();
-  Thyra::V_StVpStV(xdiff.ptr(), 1.0, *x_exact, -1.0, *(x));
+    // Calculate the error
+    RCP<Thyra::VectorBase<double> > xdiff = x->clone_v();
+    Thyra::V_StVpStV(xdiff.ptr(), 1.0, *x_exact, -1.0, *(x));
 
-  // Check the order and intercept
-  std::cout << "  Stepper = " << stepper->description() << std::endl;
-  std::cout << "  =========================" << std::endl;
-  std::cout << "  Exact solution   : " << get_ele(*(x_exact), 0) << std::endl;
-  std::cout << "  Computed solution: " << get_ele(*(x      ), 0) << std::endl;
-  std::cout << "  Difference       : " << get_ele(*(xdiff  ), 0) << std::endl;
-  std::cout << "  =========================" << std::endl;
-  TEST_FLOATING_EQUALITY(get_ele(*(x), 0), 0.167158, 1.0e-4 );
+    // Check the order and intercept
+    std::cout << "  Stepper = " << stepper->description()
+              << "\n            with " << option << std::endl;
+    std::cout << "  =========================" << std::endl;
+    std::cout << "  Exact solution   : " << get_ele(*(x_exact), 0) << std::endl;
+    std::cout << "  Computed solution: " << get_ele(*(x      ), 0) << std::endl;
+    std::cout << "  Difference       : " << get_ele(*(xdiff  ), 0) << std::endl;
+    std::cout << "  =========================" << std::endl;
+    TEST_FLOATING_EQUALITY(get_ele(*(x), 0), 0.167158, 1.0e-4 );
+  }
 }
 
 

--- a/packages/tempus/test/Newmark/Tempus_NewmarkTest.cpp
+++ b/packages/tempus/test/Newmark/Tempus_NewmarkTest.cpp
@@ -52,64 +52,88 @@ TEUCHOS_UNIT_TEST(NewmarkExplicitAForm, BallParabolic)
 {
   //Tolerance to check if test passed
   double tolerance = 1.0e-14;
-  // Read params from .xml file
-  RCP<ParameterList> pList =
-    getParametersFromXmlFile("Tempus_NewmarkExplicitAForm_BallParabolic.xml");
+  std::vector<std::string> options;
+  options.push_back("useFSAL=true");
+  options.push_back("useFSAL=false");
+  options.push_back("ICConsistency and Check");
 
-  // Setup the HarmonicOscillatorModel
-  RCP<ParameterList> hom_pl = sublist(pList, "HarmonicOscillatorModel", true);
-  RCP<HarmonicOscillatorModel<double> > model =
-    Teuchos::rcp(new HarmonicOscillatorModel<double>(hom_pl));
+  for(const auto& option: options) {
 
-  // Setup the Integrator and reset initial time step
-  RCP<ParameterList> pl = sublist(pList, "Tempus", true);
-  RCP<ParameterList> stepperPL = sublist(pl, "Default Stepper", true);
-  stepperPL->remove("Zero Initial Guess");
+    // Read params from .xml file
+    RCP<ParameterList> pList =
+      getParametersFromXmlFile("Tempus_NewmarkExplicitAForm_BallParabolic.xml");
 
-  RCP<Tempus::IntegratorBasic<double> > integrator =
-    Tempus::integratorBasic<double>(pl, model);
+    // Setup the HarmonicOscillatorModel
+    RCP<ParameterList> hom_pl = sublist(pList, "HarmonicOscillatorModel", true);
+    RCP<HarmonicOscillatorModel<double> > model =
+      Teuchos::rcp(new HarmonicOscillatorModel<double>(hom_pl));
 
-  // Integrate to timeMax
-  bool integratorStatus = integrator->advanceTime();
-  TEST_ASSERT(integratorStatus)
+    // Setup the Integrator and reset initial time step
+    RCP<ParameterList> pl = sublist(pList, "Tempus", true);
+    RCP<ParameterList> stepperPL = sublist(pl, "Default Stepper", true);
+    stepperPL->remove("Zero Initial Guess");
+    if (option == "useFSAL=true") stepperPL->set("Use FSAL", true);
+    else if (option == "useFSAL=false") stepperPL->set("Use FSAL", false);
+    else if (option == "ICConsistency and Check") {
+      stepperPL->set("Initial Condition Consistency", "Consistent");
+      stepperPL->set("Initial Condition Consistency Check", true);
+    }
 
-// Test if at 'Final Time'
-  double time = integrator->getTime();
-  double timeFinal =pl->sublist("Default Integrator")
-     .sublist("Time Step Control").get<double>("Final Time");
-  TEST_FLOATING_EQUALITY(time, timeFinal, 1.0e-14);
+    RCP<Tempus::IntegratorBasic<double> > integrator =
+      Tempus::integratorBasic<double>(pl, model);
 
-  // Time-integrated solution and the exact solution
-  RCP<Thyra::VectorBase<double> > x = integrator->getX();
-  RCP<const Thyra::VectorBase<double> > x_exact =
-    model->getExactSolution(time).get_x();
+    // Integrate to timeMax
+    bool integratorStatus = integrator->advanceTime();
+    TEST_ASSERT(integratorStatus)
 
-  // Plot sample solution and exact solution
-  std::ofstream ftmp("Tempus_NewmarkExplicitAForm_BallParabolic.dat");
-  ftmp.precision(16);
-  RCP<const SolutionHistory<double> > solutionHistory =
-    integrator->getSolutionHistory();
-  bool passed = true;
-  double err = 0.0;
-  RCP<const Thyra::VectorBase<double> > x_exact_plot;
-  for (int i=0; i<solutionHistory->getNumStates(); i++) {
-    RCP<const SolutionState<double> > solutionState = (*solutionHistory)[i];
-    double time_i = solutionState->getTime();
-    RCP<const Thyra::VectorBase<double> > x_plot = solutionState->getX();
-    x_exact_plot = model->getExactSolution(time_i).get_x();
-    ftmp << time_i << "   "
-         << get_ele(*(x_plot), 0) << "   "
-         << get_ele(*(x_exact_plot), 0) << std::endl;
-    if (abs(get_ele(*(x_plot),0) - get_ele(*(x_exact_plot), 0)) > err)
-      err = abs(get_ele(*(x_plot),0) - get_ele(*(x_exact_plot), 0));
+//   Test if at 'Final Time'
+    double time = integrator->getTime();
+    double timeFinal =pl->sublist("Default Integrator")
+       .sublist("Time Step Control").get<double>("Final Time");
+    TEST_FLOATING_EQUALITY(time, timeFinal, 1.0e-14);
+
+    // Time-integrated solution and the exact solution
+    RCP<Thyra::VectorBase<double> > x = integrator->getX();
+    RCP<const Thyra::VectorBase<double> > x_exact =
+      model->getExactSolution(time).get_x();
+
+    // Plot sample solution and exact solution
+    std::ofstream ftmp("Tempus_NewmarkExplicitAForm_BallParabolic.dat");
+    ftmp.precision(16);
+    RCP<const SolutionHistory<double> > solutionHistory =
+      integrator->getSolutionHistory();
+    bool passed = true;
+    double err = 0.0;
+    RCP<const Thyra::VectorBase<double> > x_exact_plot;
+    for (int i=0; i<solutionHistory->getNumStates(); i++) {
+      RCP<const SolutionState<double> > solutionState = (*solutionHistory)[i];
+      double time_i = solutionState->getTime();
+      RCP<const Thyra::VectorBase<double> > x_plot = solutionState->getX();
+      x_exact_plot = model->getExactSolution(time_i).get_x();
+      ftmp << time_i << "   "
+           << get_ele(*(x_plot), 0) << "   "
+           << get_ele(*(x_exact_plot), 0) << std::endl;
+      if (abs(get_ele(*(x_plot),0) - get_ele(*(x_exact_plot), 0)) > err)
+        err = abs(get_ele(*(x_plot),0) - get_ele(*(x_exact_plot), 0));
+    }
+    ftmp.close();
+    std::cout << "Max error = " << err << "\n \n";
+    if (err > tolerance)
+      passed = false;
+
+    TEUCHOS_TEST_FOR_EXCEPTION(!passed, std::logic_error,
+      "\n Test failed!  Max error = " << err << " > tolerance = " << tolerance << "\n!");
+
+    // Check the order and intercept
+    RCP<Tempus::Stepper<double> > stepper = integrator->getStepper();
+    std::cout << "  Stepper = " << stepper->description()
+              << "\n            with " << option << std::endl;
+    std::cout << "  =========================" << std::endl;
+    std::cout << "  Exact solution   : " << get_ele(*(x_exact), 0) << std::endl;
+    std::cout << "  Computed solution: " << get_ele(*(x      ), 0) << std::endl;
+    std::cout << "  =========================" << std::endl;
+    TEST_ASSERT(std::abs(get_ele(*(x), 0)) < 1.0e-14);
   }
-  ftmp.close();
-  std::cout << "Max error = " << err << "\n \n";
-  if (err > tolerance)
-    passed = false;
-
-  TEUCHOS_TEST_FOR_EXCEPTION(!passed, std::logic_error,
-    "\n Test failed!  Max error = " << err << " > tolerance = " << tolerance << "\n!");
 }
 
 
@@ -345,103 +369,115 @@ TEUCHOS_UNIT_TEST(NewmarkExplicitAForm, HarmonicOscillatorDamped)
 TEUCHOS_UNIT_TEST(NewmarkImplicitAForm, ConstructingFromDefaults)
 {
   double dt = 1.0;
+  std::vector<std::string> options;
+  options.push_back("Default Parameters");
+  options.push_back("ICConsistency and Check");
 
-  // Read params from .xml file
-  RCP<ParameterList> pList = getParametersFromXmlFile(
-    "Tempus_NewmarkImplicitAForm_HarmonicOscillator_Damped_SecondOrder.xml");
-  RCP<ParameterList> pl = sublist(pList, "Tempus", true);
+  for(const auto& option: options) {
 
-  // Setup the HarmonicOscillatorModel
-  RCP<ParameterList> hom_pl = sublist(pList, "HarmonicOscillatorModel", true);
-  RCP<HarmonicOscillatorModel<double> > model =
-    Teuchos::rcp(new HarmonicOscillatorModel<double>(hom_pl));
+    // Read params from .xml file
+    RCP<ParameterList> pList = getParametersFromXmlFile(
+      "Tempus_NewmarkImplicitAForm_HarmonicOscillator_Damped_SecondOrder.xml");
+    RCP<ParameterList> pl = sublist(pList, "Tempus", true);
 
-  // Setup Stepper for field solve ----------------------------
-  auto sf = Teuchos::rcp(new Tempus::StepperFactory<double>());
-  RCP<Tempus::StepperNewmarkImplicitAForm<double> > stepper =
-    sf->createStepperNewmarkImplicitAForm(model, Teuchos::null);
+    // Setup the HarmonicOscillatorModel
+    RCP<ParameterList> hom_pl = sublist(pList, "HarmonicOscillatorModel", true);
+    RCP<HarmonicOscillatorModel<double> > model =
+      Teuchos::rcp(new HarmonicOscillatorModel<double>(hom_pl));
 
-  // Setup TimeStepControl ------------------------------------
-  RCP<Tempus::TimeStepControl<double> > timeStepControl =
-    Teuchos::rcp(new Tempus::TimeStepControl<double>());
-  ParameterList tscPL = pl->sublist("Default Integrator")
-                           .sublist("Time Step Control");
-  timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
-  timeStepControl->setInitIndex(tscPL.get<int>   ("Initial Time Index"));
-  timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
-  timeStepControl->setFinalTime(tscPL.get<double>("Final Time"));
-  timeStepControl->setInitTimeStep(dt);
-  timeStepControl->initialize();
+    // Setup Stepper for field solve ----------------------------
+    auto sf = Teuchos::rcp(new Tempus::StepperFactory<double>());
+    RCP<Tempus::StepperNewmarkImplicitAForm<double> > stepper =
+      sf->createStepperNewmarkImplicitAForm(model, Teuchos::null);
+    if (option == "ICConsistency and Check") {
+      stepper->setICConsistency("Consistent");
+      stepper->setICConsistencyCheck(true);
+    }
+    stepper->initialize();
 
-  // Setup initial condition SolutionState --------------------
-  using Teuchos::rcp_const_cast;
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-    stepper->getModel()->getNominalValues();
-  RCP<Thyra::VectorBase<double> > icX =
-    rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
-  RCP<Thyra::VectorBase<double> > icXDot =
-    rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x_dot());
-  RCP<Thyra::VectorBase<double> > icXDotDot =
-    rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x_dot_dot());
-  RCP<Tempus::SolutionState<double> > icState =
-    Tempus::createSolutionStateX(icX, icXDot, icXDotDot);
-  icState->setTime    (timeStepControl->getInitTime());
-  icState->setIndex   (timeStepControl->getInitIndex());
-  icState->setTimeStep(0.0);
-  icState->setOrder   (stepper->getOrder());
-  icState->setSolutionStatus(Tempus::Status::PASSED);  // ICs are passing.
+    // Setup TimeStepControl ------------------------------------
+    RCP<Tempus::TimeStepControl<double> > timeStepControl =
+      Teuchos::rcp(new Tempus::TimeStepControl<double>());
+    ParameterList tscPL = pl->sublist("Default Integrator")
+                             .sublist("Time Step Control");
+    timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
+    timeStepControl->setInitIndex(tscPL.get<int>   ("Initial Time Index"));
+    timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
+    timeStepControl->setFinalTime(tscPL.get<double>("Final Time"));
+    timeStepControl->setInitTimeStep(dt);
+    timeStepControl->initialize();
 
-  // Setup SolutionHistory ------------------------------------
-  RCP<Tempus::SolutionHistory<double> > solutionHistory =
-    Teuchos::rcp(new Tempus::SolutionHistory<double>());
-  solutionHistory->setName("Forward States");
-  solutionHistory->setStorageType(Tempus::STORAGE_TYPE_STATIC);
-  solutionHistory->setStorageLimit(2);
-  solutionHistory->addState(icState);
+    // Setup initial condition SolutionState --------------------
+    using Teuchos::rcp_const_cast;
+    Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
+      stepper->getModel()->getNominalValues();
+    RCP<Thyra::VectorBase<double> > icX =
+      rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
+    RCP<Thyra::VectorBase<double> > icXDot =
+      rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x_dot());
+    RCP<Thyra::VectorBase<double> > icXDotDot =
+      rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x_dot_dot());
+    RCP<Tempus::SolutionState<double> > icState =
+      Tempus::createSolutionStateX(icX, icXDot, icXDotDot);
+    icState->setTime    (timeStepControl->getInitTime());
+    icState->setIndex   (timeStepControl->getInitIndex());
+    icState->setTimeStep(0.0);
+    icState->setOrder   (stepper->getOrder());
+    icState->setSolutionStatus(Tempus::Status::PASSED);  // ICs are passing.
 
-  // Setup Integrator -----------------------------------------
-  RCP<Tempus::IntegratorBasic<double> > integrator =
-    Tempus::integratorBasic<double>();
-  integrator->setStepperWStepper(stepper);
-  integrator->setTimeStepControl(timeStepControl);
-  integrator->setSolutionHistory(solutionHistory);
-  //integrator->setObserver(...);
-  integrator->initialize();
+    // Setup SolutionHistory ------------------------------------
+    RCP<Tempus::SolutionHistory<double> > solutionHistory =
+      Teuchos::rcp(new Tempus::SolutionHistory<double>());
+    solutionHistory->setName("Forward States");
+    solutionHistory->setStorageType(Tempus::STORAGE_TYPE_STATIC);
+    solutionHistory->setStorageLimit(2);
+    solutionHistory->addState(icState);
+
+    // Setup Integrator -----------------------------------------
+    RCP<Tempus::IntegratorBasic<double> > integrator =
+      Tempus::integratorBasic<double>();
+    integrator->setStepperWStepper(stepper);
+    integrator->setTimeStepControl(timeStepControl);
+    integrator->setSolutionHistory(solutionHistory);
+    //integrator->setObserver(...);
+    integrator->initialize();
 
 
-  // Integrate to timeMax
-  bool integratorStatus = integrator->advanceTime();
-  TEST_ASSERT(integratorStatus)
+    // Integrate to timeMax
+    bool integratorStatus = integrator->advanceTime();
+    TEST_ASSERT(integratorStatus)
 
 
-  // Test if at 'Final Time'
-  double time = integrator->getTime();
-  double timeFinal =pl->sublist("Default Integrator")
-     .sublist("Time Step Control").get<double>("Final Time");
-  TEST_FLOATING_EQUALITY(time, timeFinal, 1.0e-14);
+    // Test if at 'Final Time'
+    double time = integrator->getTime();
+    double timeFinal =pl->sublist("Default Integrator")
+       .sublist("Time Step Control").get<double>("Final Time");
+    TEST_FLOATING_EQUALITY(time, timeFinal, 1.0e-14);
 
-  // Time-integrated solution and the exact solution
-  RCP<Thyra::VectorBase<double> > x = integrator->getX();
-  RCP<const Thyra::VectorBase<double> > x_exact =
-    model->getExactSolution(time).get_x();
+    // Time-integrated solution and the exact solution
+    RCP<Thyra::VectorBase<double> > x = integrator->getX();
+    RCP<const Thyra::VectorBase<double> > x_exact =
+      model->getExactSolution(time).get_x();
 
-  // Calculate the error
-  RCP<Thyra::VectorBase<double> > xdiff = x->clone_v();
-  Thyra::V_StVpStV(xdiff.ptr(), 1.0, *x_exact, -1.0, *(x));
+    // Calculate the error
+    RCP<Thyra::VectorBase<double> > xdiff = x->clone_v();
+    Thyra::V_StVpStV(xdiff.ptr(), 1.0, *x_exact, -1.0, *(x));
 
-  // Check the order and intercept
-  std::cout << "  Stepper = " << stepper->description() << std::endl;
-  std::cout << "  =========================" << std::endl;
-  std::cout << "  Exact solution   : " << get_ele(*(x_exact), 0) << std::endl;
-  std::cout << "  Computed solution: " << get_ele(*(x      ), 0) << std::endl;
-  std::cout << "  Difference       : " << get_ele(*(xdiff  ), 0) << std::endl;
-  std::cout << "  =========================" << std::endl;
-  TEST_FLOATING_EQUALITY(get_ele(*(x), 0), -0.222222, 1.0e-4 );
+    // Check the order and intercept
+    std::cout << "  Stepper = " << stepper->description()
+              << "\n            with " << option << std::endl;
+    std::cout << "  =========================" << std::endl;
+    std::cout << "  Exact solution   : " << get_ele(*(x_exact), 0) << std::endl;
+    std::cout << "  Computed solution: " << get_ele(*(x      ), 0) << std::endl;
+    std::cout << "  Difference       : " << get_ele(*(xdiff  ), 0) << std::endl;
+    std::cout << "  =========================" << std::endl;
+    TEST_FLOATING_EQUALITY(get_ele(*(x), 0), -0.222222, 1.0e-4 );
+  }
 }
 
 
 // ************************************************************
-TEUCHOS_UNIT_TEST(NewmarkImplicitDForm, ConstructingFromDefaults)
+TEUCHOS_UNIT_TEST(NewmarkImplicitDForm, Constructing_From_Defaults)
 {
   double dt = 1.0;
 

--- a/packages/tempus/test/PhysicsState/Tempus_PhysicsStateTest_StepperForwardEuler.hpp
+++ b/packages/tempus/test/PhysicsState/Tempus_PhysicsStateTest_StepperForwardEuler.hpp
@@ -32,9 +32,9 @@ public:
     const Teuchos::RCP<const Thyra::ModelEvaluator<Scalar> >& appModel)
   {
     this->setStepperType(        this->description());
-    this->setUseFSAL(            this->getUseFSALDefault());
-    this->setICConsistency(      this->getICConsistencyDefault());
-    this->setICConsistencyCheck( this->getICConsistencyCheckDefault());
+    this->setUseFSAL(            false);
+    this->setICConsistency(      "None");
+    this->setICConsistencyCheck( false);
 
     this->setModel(appModel);
   }

--- a/packages/tempus/test/Subcycling/Tempus_Subcycling_SinCos.xml
+++ b/packages/tempus/test/Subcycling/Tempus_Subcycling_SinCos.xml
@@ -48,7 +48,7 @@
       <Parameter name="Stepper Type" type="string" value="Forward Euler"/>
       <Parameter name="Use FSAL" type="bool" value="true"/>
       <Parameter name="Initial Condition Consistency" type="string" value="Consistent"/>
-      <Parameter name="Initial Condition Consistency Check" type="bool" value="true"/>
+      <Parameter name="Initial Condition Consistency Check" type="bool" value="false"/>
     </ParameterList>
 
   </ParameterList>

--- a/packages/tempus/test/Trapezoidal/Tempus_TrapezoidalTest.cpp
+++ b/packages/tempus/test/Trapezoidal/Tempus_TrapezoidalTest.cpp
@@ -104,108 +104,119 @@ TEUCHOS_UNIT_TEST(Trapezoidal, ParameterList)
 TEUCHOS_UNIT_TEST(Trapezoidal, ConstructingFromDefaults)
 {
   double dt = 0.1;
+  std::vector<std::string> options;
+  options.push_back("Default Parameters");
+  options.push_back("ICConsistency and Check");
 
-  // Read params from .xml file
-  RCP<ParameterList> pList =
-    getParametersFromXmlFile("Tempus_Trapezoidal_SinCos.xml");
-  RCP<ParameterList> pl = sublist(pList, "Tempus", true);
+  for(const auto& option: options) {
 
-  // Setup the SinCosModel
-  RCP<ParameterList> scm_pl = sublist(pList, "SinCosModel", true);
-  //RCP<SinCosModel<double> > model = sineCosineModel(scm_pl);
-  auto model = rcp(new SinCosModel<double>(scm_pl));
+    // Read params from .xml file
+    RCP<ParameterList> pList =
+      getParametersFromXmlFile("Tempus_Trapezoidal_SinCos.xml");
+    RCP<ParameterList> pl = sublist(pList, "Tempus", true);
 
-  // Setup Stepper for field solve ----------------------------
-  auto stepper = rcp(new Tempus::StepperTrapezoidal<double>());
-  //{
-  //  // Turn on NOX output.
-  //  RCP<ParameterList> sPL = stepper->getNonconstParameterList();
-  //  std::string solverName = sPL->get<std::string>("Solver Name");
-  //  RCP<ParameterList> solverPL = Teuchos::sublist(sPL, solverName, true);
-  //  solverPL->sublist("NOX").sublist("Printing").sublist("Output Information")
-  //           .set("Outer Iteration", true);
-  //  solverPL->sublist("NOX").sublist("Printing").sublist("Output Information")
-  //           .set("Parameters", true);
-  //  solverPL->sublist("NOX").sublist("Printing").sublist("Output Information")
-  //           .set("Details", true);
-  //  stepper->setSolver(solverPL);
-  //}
-  stepper->setModel(model);
-  stepper->initialize();
+    // Setup the SinCosModel
+    RCP<ParameterList> scm_pl = sublist(pList, "SinCosModel", true);
+    //RCP<SinCosModel<double> > model = sineCosineModel(scm_pl);
+    auto model = rcp(new SinCosModel<double>(scm_pl));
 
-  // Setup TimeStepControl ------------------------------------
-  auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
-  ParameterList tscPL = pl->sublist("Default Integrator")
-                           .sublist("Time Step Control");
-  timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
-  timeStepControl->setInitIndex(tscPL.get<int>   ("Initial Time Index"));
-  timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
-  timeStepControl->setFinalTime(tscPL.get<double>("Final Time"));
-  timeStepControl->setInitTimeStep(dt);
-  timeStepControl->initialize();
+    // Setup Stepper for field solve ----------------------------
+    auto stepper = rcp(new Tempus::StepperTrapezoidal<double>());
+    //{
+    //  // Turn on NOX output.
+    //  RCP<ParameterList> sPL = stepper->getNonconstParameterList();
+    //  std::string solverName = sPL->get<std::string>("Solver Name");
+    //  RCP<ParameterList> solverPL = Teuchos::sublist(sPL, solverName, true);
+    //  solverPL->sublist("NOX").sublist("Printing")
+    //           .sublist("Output Information").set("Outer Iteration", true);
+    //  solverPL->sublist("NOX").sublist("Printing")
+    //           .sublist("Output Information").set("Parameters", true);
+    //  solverPL->sublist("NOX").sublist("Printing")
+    //           .sublist("Output Information").set("Details", true);
+    //  stepper->setSolver(solverPL);
+    //}
+    stepper->setModel(model);
+    if ( option == "ICConsistency and Check") {
+      stepper->setICConsistency("Consistent");
+      stepper->setICConsistencyCheck(true);
+    }
+    stepper->initialize();
 
-  // Setup initial condition SolutionState --------------------
-  Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
-    stepper->getModel()->getNominalValues();
-  auto icSoln = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
-  auto icSolnDot =
-    rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x_dot());
-  auto icState = Tempus::createSolutionStateX(icSoln,icSolnDot);
-  icState->setTime    (timeStepControl->getInitTime());
-  icState->setIndex   (timeStepControl->getInitIndex());
-  icState->setTimeStep(0.0);
-  icState->setOrder   (stepper->getOrder());
-  icState->setSolutionStatus(Tempus::Status::PASSED);  // ICs are passing.
+    // Setup TimeStepControl ------------------------------------
+    auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
+    ParameterList tscPL = pl->sublist("Default Integrator")
+                             .sublist("Time Step Control");
+    timeStepControl->setStepType (tscPL.get<std::string>("Integrator Step Type"));
+    timeStepControl->setInitIndex(tscPL.get<int>   ("Initial Time Index"));
+    timeStepControl->setInitTime (tscPL.get<double>("Initial Time"));
+    timeStepControl->setFinalTime(tscPL.get<double>("Final Time"));
+    timeStepControl->setInitTimeStep(dt);
+    timeStepControl->initialize();
 
-  // Setup SolutionHistory ------------------------------------
-  auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());
-  solutionHistory->setName("Forward States");
-  solutionHistory->setStorageType(Tempus::STORAGE_TYPE_STATIC);
-  solutionHistory->setStorageLimit(2);
-  solutionHistory->addState(icState);
+    // Setup initial condition SolutionState --------------------
+    Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
+      stepper->getModel()->getNominalValues();
+    auto icSoln = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
+    auto icSolnDot =
+      rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x_dot());
+    auto icState = Tempus::createSolutionStateX(icSoln,icSolnDot);
+    icState->setTime    (timeStepControl->getInitTime());
+    icState->setIndex   (timeStepControl->getInitIndex());
+    icState->setTimeStep(0.0);
+    icState->setOrder   (stepper->getOrder());
+    icState->setSolutionStatus(Tempus::Status::PASSED);  // ICs are passing.
 
-  // Setup Integrator -----------------------------------------
-  RCP<Tempus::IntegratorBasic<double> > integrator =
-    Tempus::integratorBasic<double>();
-  integrator->setStepperWStepper(stepper);
-  integrator->setTimeStepControl(timeStepControl);
-  integrator->setSolutionHistory(solutionHistory);
-  //integrator->setObserver(...);
-  integrator->initialize();
+    // Setup SolutionHistory ------------------------------------
+    auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());
+    solutionHistory->setName("Forward States");
+    solutionHistory->setStorageType(Tempus::STORAGE_TYPE_STATIC);
+    solutionHistory->setStorageLimit(2);
+    solutionHistory->addState(icState);
+
+    // Setup Integrator -----------------------------------------
+    RCP<Tempus::IntegratorBasic<double> > integrator =
+      Tempus::integratorBasic<double>();
+    integrator->setStepperWStepper(stepper);
+    integrator->setTimeStepControl(timeStepControl);
+    integrator->setSolutionHistory(solutionHistory);
+    //integrator->setObserver(...);
+    integrator->initialize();
 
 
-  // Integrate to timeMax
-  bool integratorStatus = integrator->advanceTime();
-  TEST_ASSERT(integratorStatus)
+    // Integrate to timeMax
+    bool integratorStatus = integrator->advanceTime();
+    TEST_ASSERT(integratorStatus)
 
 
-  // Test if at 'Final Time'
-  double time = integrator->getTime();
-  double timeFinal =pl->sublist("Default Integrator")
-     .sublist("Time Step Control").get<double>("Final Time");
-  TEST_FLOATING_EQUALITY(time, timeFinal, 1.0e-14);
+    // Test if at 'Final Time'
+    double time = integrator->getTime();
+    double timeFinal =pl->sublist("Default Integrator")
+       .sublist("Time Step Control").get<double>("Final Time");
+    TEST_FLOATING_EQUALITY(time, timeFinal, 1.0e-14);
 
-  // Time-integrated solution and the exact solution
-  RCP<Thyra::VectorBase<double> > x = integrator->getX();
-  RCP<const Thyra::VectorBase<double> > x_exact =
-    model->getExactSolution(time).get_x();
+    // Time-integrated solution and the exact solution
+    RCP<Thyra::VectorBase<double> > x = integrator->getX();
+    RCP<const Thyra::VectorBase<double> > x_exact =
+      model->getExactSolution(time).get_x();
 
-  // Calculate the error
-  RCP<Thyra::VectorBase<double> > xdiff = x->clone_v();
-  Thyra::V_StVpStV(xdiff.ptr(), 1.0, *x_exact, -1.0, *(x));
+    // Calculate the error
+    RCP<Thyra::VectorBase<double> > xdiff = x->clone_v();
+    Thyra::V_StVpStV(xdiff.ptr(), 1.0, *x_exact, -1.0, *(x));
 
-  // Check the order and intercept
-  std::cout << "  Stepper = Trapezoidal" << std::endl;
-  std::cout << "  =========================" << std::endl;
-  std::cout << "  Exact solution   : " << get_ele(*(x_exact), 0) << "   "
-                                       << get_ele(*(x_exact), 1) << std::endl;
-  std::cout << "  Computed solution: " << get_ele(*(x      ), 0) << "   "
-                                       << get_ele(*(x      ), 1) << std::endl;
-  std::cout << "  Difference       : " << get_ele(*(xdiff  ), 0) << "   "
-                                       << get_ele(*(xdiff  ), 1) << std::endl;
-  std::cout << "  =========================" << std::endl;
-  TEST_FLOATING_EQUALITY(get_ele(*(x), 0), 0.841021, 1.0e-4 );
-  TEST_FLOATING_EQUALITY(get_ele(*(x), 1), 0.541002, 1.0e-4 );
+    // Check the order and intercept
+    std::cout << "  Stepper = " << stepper->description()
+              << "\n            with " << option << std::endl;
+    std::cout << "  =========================" << std::endl;
+    std::cout << "  Exact solution   : " << get_ele(*(x_exact), 0) << "   "
+                                         << get_ele(*(x_exact), 1) << std::endl;
+    std::cout << "  Computed solution: " << get_ele(*(x      ), 0) << "   "
+                                         << get_ele(*(x      ), 1) << std::endl;
+    std::cout << "  Difference       : " << get_ele(*(xdiff  ), 0) << "   "
+                                         << get_ele(*(xdiff  ), 1) << std::endl;
+    std::cout << "  =========================" << std::endl;
+    TEST_FLOATING_EQUALITY(get_ele(*(x), 0), 0.841021, 1.0e-4 );
+    TEST_FLOATING_EQUALITY(get_ele(*(x), 1), 0.541002, 1.0e-4 );
+  }
 }
 
 

--- a/packages/tempus/test/Trapezoidal/Tempus_Trapezoidal_SinCos.xml
+++ b/packages/tempus/test/Trapezoidal/Tempus_Trapezoidal_SinCos.xml
@@ -49,7 +49,7 @@
       <Parameter name="Stepper Type"  type="string" value="Trapezoidal Method"/>
       <Parameter name="Use FSAL"       type="bool" value="true"/>
       <Parameter name="Initial Condition Consistency" type="string" value="Consistent"/>
-      <Parameter name="Initial Condition Consistency Check" type="bool" value="true"/>
+      <Parameter name="Initial Condition Consistency Check" type="bool" value="false"/>
 
       <Parameter name="Solver Name"    type="string" value="Default Solver"/>
       <Parameter name="Zero Initial Guess" type="bool" value="0"/>

--- a/packages/tempus/unit_test/Tempus_UnitTest_BDF2.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_BDF2.cpp
@@ -67,9 +67,9 @@ TEUCHOS_UNIT_TEST(BDF2, Default_Construction)
   startUpStepper->initialize();
 
   auto defaultStepper = rcp(new Tempus::StepperBDF2<double>());
-  bool useFSAL              = defaultStepper->getUseFSALDefault();
-  std::string ICConsistency = defaultStepper->getICConsistencyDefault();
-  bool ICConsistencyCheck   = defaultStepper->getICConsistencyCheckDefault();
+  bool useFSAL              = defaultStepper->getUseFSAL();
+  std::string ICConsistency = defaultStepper->getICConsistency();
+  bool ICConsistencyCheck   = defaultStepper->getICConsistencyCheck();
   bool zeroInitialGuess     = defaultStepper->getZeroInitialGuess();
 
   // Test the set functions.

--- a/packages/tempus/unit_test/Tempus_UnitTest_BackwardEuler.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_BackwardEuler.cpp
@@ -68,9 +68,9 @@ TEUCHOS_UNIT_TEST(BackwardEuler, Default_Construction)
   predictorStepper->initialize();
 
   auto defaultStepper = rcp(new Tempus::StepperBackwardEuler<double>());
-  bool useFSAL              = defaultStepper->getUseFSALDefault();
-  std::string ICConsistency = defaultStepper->getICConsistencyDefault();
-  bool ICConsistencyCheck   = defaultStepper->getICConsistencyCheckDefault();
+  bool useFSAL              = defaultStepper->getUseFSAL();
+  std::string ICConsistency = defaultStepper->getICConsistency();
+  bool ICConsistencyCheck   = defaultStepper->getICConsistencyCheck();
   bool zeroInitialGuess     = defaultStepper->getZeroInitialGuess();
 
   // Test the set functions.

--- a/packages/tempus/unit_test/Tempus_UnitTest_DIRK_General.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_DIRK_General.cpp
@@ -56,10 +56,10 @@ TEUCHOS_UNIT_TEST(DIRK_General, Default_Construction)
   auto solver    = rcp(new Thyra::NOXNonlinearSolver());
   solver->setParameterList(Tempus::defaultSolverParameters());
 
-  bool useFSAL              = stepper->getUseFSALDefault();
-  std::string ICConsistency = stepper->getICConsistencyDefault();
-  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
-  bool useEmbedded          = stepper->getUseEmbeddedDefault();
+  bool useFSAL              = stepper->getUseFSAL();
+  std::string ICConsistency = stepper->getICConsistency();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheck();
+  bool useEmbedded          = stepper->getUseEmbedded();
   bool zeroInitialGuess     = stepper->getZeroInitialGuess();
 
   using Teuchos::as;

--- a/packages/tempus/unit_test/Tempus_UnitTest_ERK_General.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_ERK_General.cpp
@@ -37,10 +37,10 @@ TEUCHOS_UNIT_TEST(ERK_General, Default_Construction)
   auto modifier  = rcp(new Tempus::StepperRKModifierDefault<double>());
   auto modifierX = rcp(new Tempus::StepperRKModifierXDefault<double>());
   auto observer  = rcp(new Tempus::StepperRKObserverDefault<double>());
-  bool useFSAL              = stepper->getUseFSALDefault();
-  std::string ICConsistency = stepper->getICConsistencyDefault();
-  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
-  bool useEmbedded          = stepper->getUseEmbeddedDefault();
+  bool useFSAL              = stepper->getUseFSAL();
+  std::string ICConsistency = stepper->getICConsistency();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheck();
+  bool useEmbedded          = stepper->getUseEmbedded();
 
   int NumStages = 4;
   Teuchos::SerialDenseMatrix<int,double> A(NumStages,NumStages);

--- a/packages/tempus/unit_test/Tempus_UnitTest_ForwardEuler.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_ForwardEuler.cpp
@@ -62,9 +62,9 @@ TEUCHOS_UNIT_TEST(ForwardEuler, Default_Construction)
   stepper->initialize();
   TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
   // Default values for construction.
-  bool useFSAL              = stepper->getUseFSALDefault();
-  std::string ICConsistency = stepper->getICConsistencyDefault();
-  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool useFSAL              = stepper->getUseFSAL();
+  std::string ICConsistency = stepper->getICConsistency();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheck();
 
   // Test the set functions.
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE

--- a/packages/tempus/unit_test/Tempus_UnitTest_HHTAlpha.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_HHTAlpha.cpp
@@ -60,9 +60,9 @@ TEUCHOS_UNIT_TEST(HHTAlpha, Default_Construction)
   auto solver = rcp(new Thyra::NOXNonlinearSolver());
   solver->setParameterList(Tempus::defaultSolverParameters());
 
-  bool useFSAL              = stepper->getUseFSALDefault();
-  std::string ICConsistency = stepper->getICConsistencyDefault();
-  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool useFSAL              = stepper->getUseFSAL();
+  std::string ICConsistency = stepper->getICConsistency();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheck();
   bool zeroInitialGuess     = stepper->getZeroInitialGuess();
   std::string schemeName    = "Newmark Beta User Defined";
   double beta               = 0.25;

--- a/packages/tempus/unit_test/Tempus_UnitTest_IMEX_RK.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_IMEX_RK.cpp
@@ -61,9 +61,9 @@ TEUCHOS_UNIT_TEST(IMEX_RK, Default_Construction)
   auto solver = rcp(new Thyra::NOXNonlinearSolver());
   solver->setParameterList(Tempus::defaultSolverParameters());
 
-  bool useFSAL              = stepper->getUseFSALDefault();
-  std::string ICConsistency = stepper->getICConsistencyDefault();
-  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool useFSAL              = stepper->getUseFSAL();
+  std::string ICConsistency = stepper->getICConsistency();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheck();
   bool zeroInitialGuess     = stepper->getZeroInitialGuess();
   std::string stepperType   = "IMEX RK SSP2";
   auto stepperERK = Teuchos::rcp(new Tempus::StepperERK_Trapezoidal<double>());

--- a/packages/tempus/unit_test/Tempus_UnitTest_IMEX_RK_Partition.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_IMEX_RK_Partition.cpp
@@ -68,9 +68,9 @@ TEUCHOS_UNIT_TEST(IMEX_RK_Partition, Default_Construction)
   auto solver = rcp(new Thyra::NOXNonlinearSolver());
   solver->setParameterList(Tempus::defaultSolverParameters());
 
-  bool useFSAL              = stepper->getUseFSALDefault();
-  std::string ICConsistency = stepper->getICConsistencyDefault();
-  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool useFSAL              = stepper->getUseFSAL();
+  std::string ICConsistency = stepper->getICConsistency();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheck();
   bool zeroInitialGuess     = stepper->getZeroInitialGuess();
   std::string stepperType   = "IMEX RK SSP2";
   auto stepperERK = Teuchos::rcp(new Tempus::StepperERK_Trapezoidal<double>());

--- a/packages/tempus/unit_test/Tempus_UnitTest_Leapfrog.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_Leapfrog.cpp
@@ -61,9 +61,9 @@ TEUCHOS_UNIT_TEST(Leapfrog, Default_Construction)
 #endif
   auto modifier = rcp(new Tempus::StepperLeapfrogModifierDefault<double>());
   stepper->setAppAction(modifier);
-  bool useFSAL              = stepper->getUseFSALDefault();
-  std::string ICConsistency = stepper->getICConsistencyDefault();
-  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool useFSAL              = stepper->getUseFSAL();
+  std::string ICConsistency = stepper->getICConsistency();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheck();
 
 
   // Test the set functions.
@@ -98,24 +98,24 @@ TEUCHOS_UNIT_TEST(Leapfrog, StepperFactory_Construction)
   testFactoryConstruction("Leapfrog", model);
 }
 
-// ************************************************************                                                                                         
-// ************************************************************                                                                                         
+// ************************************************************
+// ************************************************************
 class StepperLeapfrogModifierTest
   : virtual public Tempus::StepperLeapfrogModifierBase<double>
 {
 public:
 
-  /// Constructor                                                                                                                                       
+  /// Constructor
   StepperLeapfrogModifierTest()
     : testBEGIN_STEP(false), testBEFORE_X_UPDATE(false),testBEFORE_EXPLICIT_EVAL(false),
       testBEFORE_XDOT_UPDATE(false), testCurrentValue(-0.99), testWorkingValue(-0.99),
       testDt(-1.5), testType("")
   {}
 
-  /// Destructor                                                                                                                                        
+  /// Destructor
   virtual ~StepperLeapfrogModifierTest(){}
 
-  /// Observe Leapfrog Stepper at end of takeStep.                                                                                                  
+  /// Observe Leapfrog Stepper at end of takeStep.
   virtual void modify(
                       Teuchos::RCP<Tempus::SolutionHistory<double> > sh,
                       Teuchos::RCP<Tempus::StepperLeapfrog<double> > stepper,
@@ -169,19 +169,19 @@ TEUCHOS_UNIT_TEST(Leapfrog, AppAction_Modifier)
 {
   auto model = rcp(new Tempus_Test::HarmonicOscillatorModel<double>());
 
-  // Setup Stepper for field solve ----------------------------                               
+  // Setup Stepper for field solve ----------------------------
   auto stepper = rcp(new Tempus::StepperLeapfrog<double>());
   stepper->setModel(model);
   auto modifier = rcp(new StepperLeapfrogModifierTest());
   stepper->setAppAction(modifier);
   stepper->initialize();
 
-  // Setup TimeStepControl ------------------------------------                                             
+  // Setup TimeStepControl ------------------------------------
   auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
   timeStepControl->setInitTimeStep(15.0);
   timeStepControl->initialize();
 
-  // Setup initial condition SolutionState --------------------                                                                
+  // Setup initial condition SolutionState --------------------
   Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
     stepper->getModel()->getNominalValues();
   auto icX = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
@@ -192,16 +192,16 @@ TEUCHOS_UNIT_TEST(Leapfrog, AppAction_Modifier)
   icState->setIndex   (timeStepControl->getInitIndex());
   icState->setTimeStep(15.0);
   icState->setOrder   (stepper->getOrder());
-  icState->setSolutionStatus(Tempus::Status::PASSED);  // ICs are passing.                                          
+  icState->setSolutionStatus(Tempus::Status::PASSED);  // ICs are passing.
 
-  // Setup SolutionHistory ------------------------------------                                                 
+  // Setup SolutionHistory ------------------------------------
   auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());
   solutionHistory->setName("Forward States");
   solutionHistory->setStorageType(Tempus::STORAGE_TYPE_STATIC);
   solutionHistory->setStorageLimit(2);
   solutionHistory->addState(icState);
 
-  // Take one time step.                                                                    
+  // Take one time step.
   stepper->setInitialConditions(solutionHistory);
   solutionHistory->initWorkingState();
   solutionHistory->getWorkingState()->setTimeStep(15.0);
@@ -221,24 +221,24 @@ TEUCHOS_UNIT_TEST(Leapfrog, AppAction_Modifier)
 
   TEST_COMPARE(modifier->testType, ==, "Leapfrog - Modifier");
 }
-// ************************************************************                                                                                       
-// ************************************************************                                                                                       
+// ************************************************************
+// ************************************************************
 class StepperLeapfrogModifierXTest
   : virtual public Tempus::StepperLeapfrogModifierXBase<double>
 {
 public:
 
-  /// Constructor                                                                                                                                       
+  /// Constructor
   StepperLeapfrogModifierXTest()
     : testX_BEGIN_STEP(false), testX_BEFORE_EXPLICIT_EVAL(false),
       testX_BEFORE_X_UPDATE(false), testX_BEFORE_XDOT_UPDATE(false),
       testX(0.0), testDt(-1.25), testTime(-1.25),testType("")
   {}
 
-  /// Destructor                                                                                                                                      
+  /// Destructor
   virtual ~StepperLeapfrogModifierXTest(){}
 
-  /// Observe Leapfrog Stepper at end of takeStep.                                                                                                 
+  /// Observe Leapfrog Stepper at end of takeStep.
   virtual void modify(
     Teuchos::RCP<Thyra::VectorBase<double> > x,
     const double time, const double dt,
@@ -288,19 +288,19 @@ TEUCHOS_UNIT_TEST(LeapFrog, AppAction_ModifierX)
 {
   auto model = rcp(new Tempus_Test::HarmonicOscillatorModel<double>());
 
-  // Setup Stepper for field solve ----------------------------                             
+  // Setup Stepper for field solve ----------------------------
   auto stepper = rcp(new Tempus::StepperLeapfrog<double>());
   stepper->setModel(model);
   auto modifierX = rcp(new StepperLeapfrogModifierXTest());
   stepper->setAppAction(modifierX);
    stepper->initialize();
 
-  // Setup TimeStepControl ------------------------------------                               
+  // Setup TimeStepControl ------------------------------------
   auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
   timeStepControl->setInitTimeStep(15.0);
   timeStepControl->initialize();
 
-  // Setup initial condition SolutionState --------------------                                                
+  // Setup initial condition SolutionState --------------------
   Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
     stepper->getModel()->getNominalValues();
   auto icX = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
@@ -311,16 +311,16 @@ TEUCHOS_UNIT_TEST(LeapFrog, AppAction_ModifierX)
   icState->setIndex   (timeStepControl->getInitIndex());
   icState->setTimeStep(15.0);
   icState->setOrder   (stepper->getOrder());
-  icState->setSolutionStatus(Tempus::Status::PASSED);  // ICs are passing.                            
+  icState->setSolutionStatus(Tempus::Status::PASSED);  // ICs are passing.
 
-  // Setup SolutionHistory ------------------------------------                                            
+  // Setup SolutionHistory ------------------------------------
   auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());
   solutionHistory->setName("Forward States");
   solutionHistory->setStorageType(Tempus::STORAGE_TYPE_STATIC);
   solutionHistory->setStorageLimit(2);
   solutionHistory->addState(icState);
 
-  // Take one time step.                                                                                   
+  // Take one time step.
   stepper->setInitialConditions(solutionHistory);
   solutionHistory->initWorkingState();
   solutionHistory->getWorkingState()->setTimeStep(15.0);
@@ -334,30 +334,30 @@ TEUCHOS_UNIT_TEST(LeapFrog, AppAction_ModifierX)
   auto x = solutionHistory->getCurrentState()->getX();
   TEST_FLOATING_EQUALITY(modifierX->testX, get_ele(*(x), 0), 1.0e-15);
   auto Dt = solutionHistory->getWorkingState()->getTimeStep();
-  TEST_FLOATING_EQUALITY(modifierX->testDt, Dt, 1.0e-15); 
+  TEST_FLOATING_EQUALITY(modifierX->testDt, Dt, 1.0e-15);
   auto time = solutionHistory->getWorkingState()->getTime();
   TEST_FLOATING_EQUALITY(modifierX->testTime, time, 1.0e-15);
   TEST_COMPARE(modifierX->testType, ==, "Leapfrog - ModifierX");
 
 }
 
-// ************************************************************                                                 
-// ************************************************************                                           
+// ************************************************************
+// ************************************************************
 class StepperLeapfrogObserverTest
   : virtual public Tempus::StepperLeapfrogObserverBase<double>
 {
 public:
-  /// Constructor                                                                                                          
+  /// Constructor
   StepperLeapfrogObserverTest()
     : testBEGIN_STEP(false), testBEFORE_EXPLICIT_EVAL(false),
       testBEFORE_X_UPDATE(false), testBEFORE_XDOT_UPDATE(false),
       testCurrentValue(-0.99), testWorkingValue(-0.99),
       testDt(-1.5), testType("")
   {}
-  /// Destructor                                                                                                         
+  /// Destructor
   virtual ~StepperLeapfrogObserverTest(){}
 
-  /// Observe Leapfrog Stepper at action location.                                                                
+  /// Observe Leapfrog Stepper at action location.
   virtual void observe(
 		       Teuchos::RCP<const Tempus::SolutionHistory<double> > sh,
 		       Teuchos::RCP<const Tempus::StepperLeapfrog<double> > stepper,
@@ -409,20 +409,20 @@ TEUCHOS_UNIT_TEST(Leapfrog, AppAction_Observer)
 {
   auto model = rcp(new Tempus_Test::HarmonicOscillatorModel<double>());
 
-  // Setup Stepper for field solve ----------------------------                                                              
+  // Setup Stepper for field solve ----------------------------
   auto stepper = rcp(new Tempus::StepperLeapfrog<double>());
   stepper->setModel(model);
   auto observer = rcp(new StepperLeapfrogObserverTest());
   stepper->setAppAction(observer);
   stepper->initialize();
 
-  // Setup TimeStepControl ------------------------------------                                                             
+  // Setup TimeStepControl ------------------------------------
   auto timeStepControl = rcp(new Tempus::TimeStepControl<double>());
   double dt = 0.173;
   timeStepControl->setInitTimeStep(dt);
   timeStepControl->initialize();
 
-  // Setup initial condition SolutionState --------------------                                                              
+  // Setup initial condition SolutionState --------------------
   Thyra::ModelEvaluatorBase::InArgs<double> inArgsIC =
     stepper->getModel()->getNominalValues();
   auto icX = rcp_const_cast<Thyra::VectorBase<double> > (inArgsIC.get_x());
@@ -433,22 +433,22 @@ TEUCHOS_UNIT_TEST(Leapfrog, AppAction_Observer)
   icState->setIndex   (timeStepControl->getInitIndex());
   icState->setTimeStep(dt);
   icState->setOrder   (stepper->getOrder());
-  icState->setSolutionStatus(Tempus::Status::PASSED);  // ICs are passing.                                                   
+  icState->setSolutionStatus(Tempus::Status::PASSED);  // ICs are passing.
 
-  // Setup SolutionHistory ------------------------------------                                                              
+  // Setup SolutionHistory ------------------------------------
   auto solutionHistory = rcp(new Tempus::SolutionHistory<double>());
   solutionHistory->setName("Forward States");
   solutionHistory->setStorageType(Tempus::STORAGE_TYPE_STATIC);
   solutionHistory->setStorageLimit(2);
   solutionHistory->addState(icState);
 
-  // Take one time step.                                                                                                     
+  // Take one time step.
   stepper->setInitialConditions(solutionHistory);
   solutionHistory->initWorkingState();
   solutionHistory->getWorkingState()->setTimeStep(dt);
   stepper->takeStep(solutionHistory);
 
-  // Testing that values can be observed through the observer.                                                             
+  // Testing that values can be observed through the observer.
   auto x = solutionHistory->getCurrentState()->getX();
   TEST_FLOATING_EQUALITY(observer->testCurrentValue, get_ele(*(x), 0), 1.0e-15);
   x = solutionHistory->getWorkingState()->getX();

--- a/packages/tempus/unit_test/Tempus_UnitTest_NewmarkImplicitAForm.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_NewmarkImplicitAForm.cpp
@@ -62,9 +62,9 @@ TEUCHOS_UNIT_TEST(NewmarkImplicitAForm, Default_Construction)
   auto solver = rcp(new Thyra::NOXNonlinearSolver());
   solver->setParameterList(Tempus::defaultSolverParameters());
 
-  bool useFSAL              = stepper->getUseFSALDefault();
-  std::string ICConsistency = stepper->getICConsistencyDefault();
-  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool useFSAL              = stepper->getUseFSAL();
+  std::string ICConsistency = stepper->getICConsistency();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheck();
   bool zeroInitialGuess     = stepper->getZeroInitialGuess();
   std::string schemeName    = "Average Acceleration";
   double beta               = 0.25;

--- a/packages/tempus/unit_test/Tempus_UnitTest_NewmarkImplicitDForm.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_NewmarkImplicitDForm.cpp
@@ -194,9 +194,9 @@ TEUCHOS_UNIT_TEST(NewmarkImplicitDForm, Default_Construction)
   auto solver = rcp(new Thyra::NOXNonlinearSolver());
   solver->setParameterList(Tempus::defaultSolverParameters());
 
-  bool useFSAL              = stepper->getUseFSALDefault();
-  std::string ICConsistency = stepper->getICConsistencyDefault();
-  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool useFSAL              = stepper->getUseFSAL();
+  std::string ICConsistency = stepper->getICConsistency();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheck();
   bool zeroInitialGuess     = stepper->getZeroInitialGuess();
   std::string schemeName    = "Average Acceleration";
   double beta               = 0.25;

--- a/packages/tempus/unit_test/Tempus_UnitTest_OperatorSplit.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_OperatorSplit.cpp
@@ -72,9 +72,9 @@ TEUCHOS_UNIT_TEST(OperatorSplit, Default_Construction)
   auto modifier  = rcp(new Tempus::StepperOperatorSplitModifierDefault<double>());
   auto modifierX = rcp(new Tempus::StepperOperatorSplitModifierXDefault<double>());
   auto observer  = rcp(new Tempus::StepperOperatorSplitObserverDefault<double>());
-  bool useFSAL              = stepper->getUseFSALDefault();
-  std::string ICConsistency = stepper->getICConsistencyDefault();
-  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool useFSAL              = stepper->getUseFSAL();
+  std::string ICConsistency = stepper->getICConsistency();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheck();
   int order = 1;
 
   // Test the set functions.

--- a/packages/tempus/unit_test/Tempus_UnitTest_Subcycling.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_Subcycling.cpp
@@ -65,9 +65,9 @@ TEUCHOS_UNIT_TEST(Subcycling, Default_Construction)
   auto solver    = rcp(new Thyra::NOXNonlinearSolver());
   solver->setParameterList(Tempus::defaultSolverParameters());
 
-  bool useFSAL              = stepper->getUseFSALDefault();
-  std::string ICConsistency = stepper->getICConsistencyDefault();
-  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool useFSAL              = stepper->getUseFSAL();
+  std::string ICConsistency = stepper->getICConsistency();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheck();
 
   // Test the set functions
   stepper->setSolver(solver);                          stepper->initialize();  TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());

--- a/packages/tempus/unit_test/Tempus_UnitTest_Trapezoidal.cpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_Trapezoidal.cpp
@@ -63,9 +63,9 @@ TEUCHOS_UNIT_TEST(Trapezoidal, Default_Construction)
   auto solver    = rcp(new Thyra::NOXNonlinearSolver());
   solver->setParameterList(Tempus::defaultSolverParameters());
 
-  bool useFSAL              = stepper->getUseFSALDefault();
-  std::string ICConsistency = stepper->getICConsistencyDefault();
-  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
+  bool useFSAL              = stepper->getUseFSAL();
+  std::string ICConsistency = stepper->getICConsistency();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheck();
   bool zeroInitialGuess     = stepper->getZeroInitialGuess();
 
   // Test the set functions.
@@ -88,7 +88,7 @@ TEUCHOS_UNIT_TEST(Trapezoidal, Default_Construction)
   TEUCHOS_TEST_FOR_EXCEPT(!stepper->isInitialized());
 #endif
 
-// Full argument list construction.                                                                                                             
+// Full argument list construction.
 stepper = rcp(new Tempus::StepperTrapezoidal<double>(
 model, solver, useFSAL,
   ICConsistency, ICConsistencyCheck, zeroInitialGuess, modifier));
@@ -106,13 +106,13 @@ TEUCHOS_UNIT_TEST(Trapezoidal, StepperFactory_Construction)
   auto model = rcp(new Tempus_Test::SinCosModel<double>());
   testFactoryConstruction("Trapezoidal Method", model);
 }
-  // ************************************************************                                                   
-  // ************************************************************                        
+  // ************************************************************
+  // ************************************************************
 class StepperTrapezoidalModifierTest
   : virtual public Tempus::StepperTrapezoidalModifierBase<double>
 {
 public:
-  /// Constructor                                                                          
+  /// Constructor
   StepperTrapezoidalModifierTest()
     : testBEGIN_STEP(false), testBEFORE_SOLVE(false),
       testAFTER_SOLVE(false), testEND_STEP(false),
@@ -120,10 +120,10 @@ public:
       testDt(-1.5), testType("")
   {}
 
-  /// Destructor                                                                 
+  /// Destructor
   virtual ~StepperTrapezoidalModifierTest(){}
 
-  /// Modify Trapezoidal Stepper at action location.             
+  /// Modify Trapezoidal Stepper at action location.
   virtual void modify(
 		      Teuchos::RCP<Tempus::SolutionHistory<double> > sh,
 		      Teuchos::RCP<Tempus::StepperTrapezoidal<double> > stepper,
@@ -179,30 +179,30 @@ TEUCHOS_UNIT_TEST(Trapezoidal, AppAction_Modifier)
   Teuchos::RCP<const Thyra::ModelEvaluator<double> >
     model = rcp(new Tempus_Test::SinCosModel<double>());
 
-  // Setup Stepper for field solve ----------------------------                                                          
+  // Setup Stepper for field solve ----------------------------
   auto stepper = rcp(new Tempus::StepperTrapezoidal<double>());
   stepper->setModel(model);
   auto modifier = rcp(new StepperTrapezoidalModifierTest());
   stepper->setAppAction(modifier);
   stepper->initialize();
 
-  // Create a SolutionHistory.                                                                             
+  // Create a SolutionHistory.
   auto solutionHistory = Tempus::createSolutionHistoryME(model);
 
-  // Take one time step.                                                                                              
+  // Take one time step.
   stepper->setInitialConditions(solutionHistory);
   solutionHistory->initWorkingState();
   double dt = 0.1;
   solutionHistory->getWorkingState()->setTimeStep(dt);
   stepper->takeStep(solutionHistory);
 
-  // Testing that each ACTION_LOCATION has been called.                                                                 
+  // Testing that each ACTION_LOCATION has been called.
   TEST_COMPARE(modifier->testBEGIN_STEP, ==, true);
   TEST_COMPARE(modifier->testBEFORE_SOLVE, ==, true);
   TEST_COMPARE(modifier->testAFTER_SOLVE, ==, true);
   TEST_COMPARE(modifier->testEND_STEP, ==, true);
 
-  // Testing that values can be set through the Modifier.                                                              
+  // Testing that values can be set through the Modifier.
   auto x = solutionHistory->getCurrentState()->getX();
   TEST_FLOATING_EQUALITY(modifier->testCurrentValue, get_ele(*(x), 0), 1.0e-14);
   x = solutionHistory->getWorkingState()->getX();
@@ -212,14 +212,14 @@ TEUCHOS_UNIT_TEST(Trapezoidal, AppAction_Modifier)
   TEST_COMPARE(modifier->testType, ==, "Trapezoidal - Modifier");
 }
 
-// ************************************************************                                                        
-// ************************************************************                                                      
+// ************************************************************
+// ************************************************************
 class StepperTrapezoidalObserverTest
   : virtual public Tempus::StepperTrapezoidalObserverBase<double>
 {
 public:
 
-  /// Constructor                                                                                             
+  /// Constructor
   StepperTrapezoidalObserverTest()
     : testBEGIN_STEP(false), testBEFORE_SOLVE(false),
       testAFTER_SOLVE(false), testEND_STEP(false),
@@ -227,10 +227,10 @@ public:
       testDt(-1.5), testType("")
   {}
 
-  /// Destructor                                                                                                      
+  /// Destructor
   virtual ~StepperTrapezoidalObserverTest(){}
 
-  /// Observe Trapezoidal Stepper at action location.                                                       
+  /// Observe Trapezoidal Stepper at action location.
   virtual void observe(
     Teuchos::RCP<const Tempus::SolutionHistory<double> > sh,
     Teuchos::RCP<const Tempus::StepperTrapezoidal<double> > stepper,
@@ -283,30 +283,30 @@ TEUCHOS_UNIT_TEST(Trapezoidal, AppAction_Observer)
   Teuchos::RCP<const Thyra::ModelEvaluator<double> >
     model = rcp(new Tempus_Test::SinCosModel<double>());
 
-  // Setup Stepper for field solve ----------------------------                                                         
+  // Setup Stepper for field solve ----------------------------
   auto stepper = rcp(new Tempus::StepperTrapezoidal<double>());
   stepper->setModel(model);
   auto observer = rcp(new StepperTrapezoidalObserverTest());
   stepper->setAppAction(observer);
   stepper->initialize();
 
-  // Setup a SolutionHistory.                                                                                        
+  // Setup a SolutionHistory.
   auto solutionHistory = Tempus::createSolutionHistoryME(model);
 
-  // Take one time step.                                                                                                
+  // Take one time step.
   stepper->setInitialConditions(solutionHistory);
   solutionHistory->initWorkingState();
   double dt = 0.1;
   solutionHistory->getWorkingState()->setTimeStep(dt);
   stepper->takeStep(solutionHistory);
 
-  // Testing that each ACTION_LOCATION has been called.                                                              
+  // Testing that each ACTION_LOCATION has been called.
   TEST_COMPARE(observer->testBEGIN_STEP, ==, true);
   TEST_COMPARE(observer->testBEFORE_SOLVE, ==, true);
   TEST_COMPARE(observer->testAFTER_SOLVE, ==, true);
   TEST_COMPARE(observer->testEND_STEP, ==, true);
 
-  // Testing that values can be observed through the observer.                                                            
+  // Testing that values can be observed through the observer.
   auto x = solutionHistory->getCurrentState()->getX();
   TEST_FLOATING_EQUALITY(observer->testCurrentValue, get_ele(*(x), 0), 1.0e-14);
   x = solutionHistory->getWorkingState()->getX();
@@ -315,14 +315,14 @@ TEUCHOS_UNIT_TEST(Trapezoidal, AppAction_Observer)
   TEST_COMPARE(observer->testType, ==, "Trapezoidal Method");
 }
 
-// ************************************************************                                       
-// ************************************************************                                                      
+// ************************************************************
+// ************************************************************
 class StepperTrapezoidalModifierXTest
   : virtual public Tempus::StepperTrapezoidalModifierXBase<double>
 {
 public:
 
-  /// Constructor                                                                                                        
+  /// Constructor
   StepperTrapezoidalModifierXTest()
     : testX_BEGIN_STEP(false), testX_BEFORE_SOLVE(false),
       testX_AFTER_SOLVE(false), testXDOT_END_STEP(false),
@@ -330,9 +330,9 @@ public:
       testDt(-1.5), testTime(-1.5)
   {}
 
-  /// Destructor                                                                                                          
+  /// Destructor
   virtual ~StepperTrapezoidalModifierXTest(){}
-  /// Modify Trapezoidal Stepper at action location.                                                               
+  /// Modify Trapezoidal Stepper at action location.
   virtual void modify(
     Teuchos::RCP<Thyra::VectorBase<double> > x,
     const double time, const double dt,
@@ -383,33 +383,33 @@ TEUCHOS_UNIT_TEST(Trapezoidal, AppAction_ModifierX)
   Teuchos::RCP<const Thyra::ModelEvaluator<double> >
     model = rcp(new Tempus_Test::SinCosModel<double>());
 
-  // Setup Stepper for field solve ----------------------------                                                           
+  // Setup Stepper for field solve ----------------------------
   auto stepper = rcp(new Tempus::StepperTrapezoidal<double>());
   stepper->setModel(model);
   auto modifierX = rcp(new StepperTrapezoidalModifierXTest());
   stepper->setAppAction(modifierX);
   stepper->initialize();
 
-  // Setup a SolutionHistory.                                                                                   
+  // Setup a SolutionHistory.
   auto solutionHistory = Tempus::createSolutionHistoryME(model);
 
-  // Take one time step.                                                                                                   
+  // Take one time step.
   stepper->setInitialConditions(solutionHistory);
   solutionHistory->initWorkingState();
   double dt = 0.1;
   solutionHistory->getWorkingState()->setTimeStep(dt);
   stepper->takeStep(solutionHistory);
 
-  // Testing that each ACTION_LOCATION has been called.                                                                    
+  // Testing that each ACTION_LOCATION has been called.
   TEST_COMPARE(modifierX->testX_BEGIN_STEP, ==, true);
   TEST_COMPARE(modifierX->testX_BEFORE_SOLVE, ==, true);
   TEST_COMPARE(modifierX->testX_AFTER_SOLVE, ==, true);
   TEST_COMPARE(modifierX->testXDOT_END_STEP, ==, true);
 
-  // Testing that values can be set through the Modifier.                                                                  
+  // Testing that values can be set through the Modifier.
   auto x = solutionHistory->getCurrentState()->getX();
   TEST_FLOATING_EQUALITY(modifierX->testX, get_ele(*(x), 0), 1.0e-14);
-  // Temporary memory for xDot is not guarranteed to exist outside the Stepper.                                            
+  // Temporary memory for xDot is not guarranteed to exist outside the Stepper.
   auto xDot = solutionHistory->getWorkingState()->getXDot();
   if (xDot == Teuchos::null) xDot = stepper->getStepperXDot();
 

--- a/packages/tempus/unit_test/Tempus_UnitTest_Utils.hpp
+++ b/packages/tempus/unit_test/Tempus_UnitTest_Utils.hpp
@@ -76,10 +76,10 @@ void testExplicitRKAccessorsFullConstruction(
   auto modifier  = rcp(new Tempus::StepperRKModifierDefault<double>());
   auto modifierX = rcp(new Tempus::StepperRKModifierXDefault<double>());
   auto observer  = rcp(new Tempus::StepperRKObserverDefault<double>());
-  bool useFSAL              = stepper->getUseFSALDefault();
-  std::string ICConsistency = stepper->getICConsistencyDefault();
-  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
-  bool useEmbedded          = stepper->getUseEmbeddedDefault();
+  bool useFSAL              = stepper->getUseFSAL();
+  std::string ICConsistency = stepper->getICConsistency();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheck();
+  bool useEmbedded          = stepper->getUseEmbedded();
 
   // Test the set functions.
 #ifndef TEMPUS_HIDE_DEPRECATED_CODE
@@ -227,10 +227,10 @@ void testDIRKAccessorsFullConstruction(
   auto solver    = rcp(new Thyra::NOXNonlinearSolver());
   solver->setParameterList(Tempus::defaultSolverParameters());
 
-  bool useFSAL              = stepper->getUseFSALDefault();
-  std::string ICConsistency = stepper->getICConsistencyDefault();
-  bool ICConsistencyCheck   = stepper->getICConsistencyCheckDefault();
-  bool useEmbedded          = stepper->getUseEmbeddedDefault();
+  bool useFSAL              = stepper->getUseFSAL();
+  std::string ICConsistency = stepper->getICConsistency();
+  bool ICConsistencyCheck   = stepper->getICConsistencyCheck();
+  bool useEmbedded          = stepper->getUseEmbedded();
   bool zeroInitialGuess     = stepper->getZeroInitialGuess();
 
   // Test the set functions.
@@ -914,11 +914,11 @@ void testRKAppAction(
         TEST_FLOATING_EQUALITY(modifierX->testStageX,    0.04987531172069826, relTol);
         TEST_FLOATING_EQUALITY(modifierX->testEndStageX, 0.04987531172069826, relTol);
       } else if (rcp_dynamic_cast<Tempus::StepperEDIRK_2StageTheta<double>>(stepper) != Teuchos::null) {
-        TEST_FLOATING_EQUALITY(modifierX->testStageX,    0.09975062344139651, relTol);
-        TEST_FLOATING_EQUALITY(modifierX->testEndStageX, 0.09975062344139651, relTol);
+        TEST_FLOATING_EQUALITY(modifierX->testStageX,    0.04987531172069826, relTol);
+        TEST_FLOATING_EQUALITY(modifierX->testEndStageX, 0.04987531172069826, relTol);
       } else if (rcp_dynamic_cast<Tempus::StepperEDIRK_TrapezoidalRule<double>>(stepper) != Teuchos::null) {
-        TEST_FLOATING_EQUALITY(modifierX->testStageX,    0.09975062344139651, relTol);
-        TEST_FLOATING_EQUALITY(modifierX->testEndStageX, 0.09975062344139651, relTol);
+        TEST_FLOATING_EQUALITY(modifierX->testStageX,    0.04987531172069826, relTol);
+        TEST_FLOATING_EQUALITY(modifierX->testEndStageX, 0.04987531172069826, relTol);
       } else if (rcp_dynamic_cast<Tempus::StepperSDIRK_ImplicitMidpoint<double>>(stepper) != Teuchos::null) {
         TEST_FLOATING_EQUALITY(modifierX->testStageX,    0.04987531172069826, relTol);
         TEST_FLOATING_EQUALITY(modifierX->testEndStageX, 0.04987531172069826, relTol);
@@ -1128,11 +1128,11 @@ void testRKAppAction(
         TEST_FLOATING_EQUALITY(modifierX->testStageX,    0.04987531172069826, relTol);
         TEST_FLOATING_EQUALITY(modifierX->testEndStageX, 0.04987531172069826, relTol);
       } else if (rcp_dynamic_cast<Tempus::StepperEDIRK_2StageTheta<double>>(stepper) != Teuchos::null) {
-        TEST_FLOATING_EQUALITY(modifierX->testStageX,    0.09975062344139651, relTol);
-        TEST_FLOATING_EQUALITY(modifierX->testEndStageX, 0.09975062344139651, relTol);
+        TEST_FLOATING_EQUALITY(modifierX->testStageX,    0.04987531172069826, relTol);
+        TEST_FLOATING_EQUALITY(modifierX->testEndStageX, 0.04987531172069826, relTol);
       } else if (rcp_dynamic_cast<Tempus::StepperEDIRK_TrapezoidalRule<double>>(stepper) != Teuchos::null) {
-        TEST_FLOATING_EQUALITY(modifierX->testStageX,    0.09975062344139651, relTol);
-        TEST_FLOATING_EQUALITY(modifierX->testEndStageX, 0.09975062344139651, relTol);
+        TEST_FLOATING_EQUALITY(modifierX->testStageX,    0.04987531172069826, relTol);
+        TEST_FLOATING_EQUALITY(modifierX->testEndStageX, 0.04987531172069826, relTol);
       } else if (rcp_dynamic_cast<Tempus::StepperSDIRK_ImplicitMidpoint<double>>(stepper) != Teuchos::null) {
         TEST_FLOATING_EQUALITY(modifierX->testStageX,    0.04987531172069826, relTol);
         TEST_FLOATING_EQUALITY(modifierX->testEndStageX, 0.04987531172069826, relTol);


### PR DESCRIPTION
 * Identify a Stepper as able to use FSAL (useFSAL=true), not use
   FSAL (useFSAL=false), or both, through the set functions
   setUseFSALTrueOnly(), setUseFSALFalseOnly(), or setUseFSAL(),
   respectively.
 * There are just two Steppers that only use useFSAL=true, Trapezoidal
   and NewmarkImplicitAForm.  This is primarily due to wanting to only
   have one ODE evaluation per time step.
 * Most Steppers have useFSAL=false as they do not meet the
   requirements for FSAL.  If the application tries to set
   it to true, a warning is given but will remain useFSAL=false.
 * Currently we have 6 Steppers that can set useFSAL to either
   true or false:
    - ForwardEuler
    - NewmarkExplicitAForm
    - RK Forward Euler
    - Bogacki-Shampine
    - EDIRK 2-Stage Theta
    - RK Trapezoidal Rule

   There are two advantages for useFSAL=true:
    - x and xDot are at the same time level at the end of the timestep
    - Save an evaulation of the ODE
   However this does require the ICs to be consistent, i.e., x and
   xDot satisfy xDot_0 = f(x_0,t=0).  By default these Steppers have
   useFSAL=true.  This is why these Steppers have the IC consistency
   turned on by default (ICConsistency = "Consistent").
 * OperatorSplit should, in general, set useFSAL=false as each operator
   will change xDot, but there can be situations where useFSAL=true could
   be useful.  So it can be set to either true or false.
 * Removed getUseFSALDefault(), getICConsistencyDefault() and
   getICConsistencyCheckDefault().  Defaults are now set explicitly
   in the Stepper constructors.
 * Fixed a few situations where FSAL should not be used if the previous
   time step failed.
 * Changed and added tests to explicitly test (previous testing was
   "hidden").
   - useFSAL = true and false
   - ICConsistency = "Consistent" and ICConsistencyCheck = true

Miscellaneous
 * Removed tabs from files.

@trilinos/tempus 

## Motivation
Better identify each Steppers FSAL capabilities.

* Closes #8105 

## Stakeholder Feedback
This was a request from @ikalash. 

## Testing
All current tests passes, and additional tests added to cover FSAL settings.
