### PR TITLE
Framework/ifpack2/kokkos-kernels: Set standard to C++14 for CUDA 9.2 PR build

### DIFF
--- a/cmake/std/PullRequestLinuxCuda9.2TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxCuda9.2TestingSettings.cmake
@@ -123,6 +123,4 @@ set (KokkosCore_UnitTest_Cuda_MPI_1_EXTRA_ARGS
   "--gtest_filter=-cuda.debug_pin_um_to_host:cuda.debug_serial_execution"
   CACHE STRING "Temporary disable for CUDA PR testing")
 
-set(CMAKE_CXX_FLAGS "-std=c++14" CACHE STRING "Set standard to C++14")
-
 include("${CMAKE_CURRENT_LIST_DIR}/PullRequestLinuxCommonTestingSettings.cmake")

--- a/cmake/std/PullRequestLinuxCuda9.2TestingSettings.cmake
+++ b/cmake/std/PullRequestLinuxCuda9.2TestingSettings.cmake
@@ -6,6 +6,8 @@
 
 # Usage: cmake -C PullRequestLinuxCUDA9.2TestingSettings.cmake
 
+set (CMAKE_CXX_STANDARD "14" CACHE STRING "Set C++ standard to C++14")
+
 # Misc options typically added by CI testing mode in TriBITS
 
 # Use the below option only when submitting to the dashboard
@@ -120,5 +122,7 @@ set (ROL_example_PDE-OPT_poisson-boltzmann_example_01_MPI_4_DISABLE ON CACHE BOO
 set (KokkosCore_UnitTest_Cuda_MPI_1_EXTRA_ARGS
   "--gtest_filter=-cuda.debug_pin_um_to_host:cuda.debug_serial_execution"
   CACHE STRING "Temporary disable for CUDA PR testing")
+
+set(CMAKE_CXX_FLAGS "-std=c++14" CACHE STRING "Set standard to C++14")
 
 include("${CMAKE_CURRENT_LIST_DIR}/PullRequestLinuxCommonTestingSettings.cmake")

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestBlockTriDiContainerUtil.hpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestBlockTriDiContainerUtil.hpp
@@ -242,7 +242,7 @@ struct BlockTriDiContainerTester {
         T_bare->initialize();
         T_bare->compute(T_bare->createDefaultComputeParameters());
       }
-      auto apply = [&] (const Tpetra_MultiVector& B, Tpetra_MultiVector& X,
+      auto apply = [=] (const Tpetra_MultiVector& B, Tpetra_MultiVector& X,
                         const bool norm_based) -> int {
         if ( ! T_br.is_null()) {
           T_br->apply(B, X);

--- a/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestOverlappingRowMatrix.cpp
+++ b/packages/ifpack2/test/unit_tests/Ifpack2_UnitTestOverlappingRowMatrix.cpp
@@ -184,7 +184,7 @@ void localReducedMatvec(const MatrixClass & A_lcl,
         // NOTE: It looks like I should be able to get this data up above, but if I try to
         // we get internal compiler errors.  Who knew that gcc tried to "gimplify"?
         const LO numVectors = static_cast<LO>(X_lcl.extent(1));
-        Kokkos::parallel_for(Kokkos::TeamThreadRange (dev, 0, rows_per_team),[&] (const LO loop) {
+        Kokkos::parallel_for(Kokkos::TeamThreadRange (dev, 0, rows_per_team),[=] (const LO loop) {
             const LO lclRow = static_cast<LO> (dev.league_rank ()) * rows_per_team + loop;
             
             if (lclRow >= numLocalRows) {

--- a/packages/kokkos-kernels/src/batched/KokkosBatched_SetTriangular_Internal.hpp
+++ b/packages/kokkos-kernels/src/batched/KokkosBatched_SetTriangular_Internal.hpp
@@ -50,7 +50,7 @@ namespace KokkosBatched {
 	   const int jdist = j+ dist;
 	   Kokkos::parallel_for
 	     (Kokkos::ThreadVectorRange(member, m),
-	      [&](const int &i) {
+	      [=](const int &i) {
 		if (i >= jdist)
 		  A[i*as0+j*as1] = alpha;
 	      });

--- a/packages/kokkos-kernels/unit_test/batched/Test_Batched_TeamVectorSolveUTV.hpp
+++ b/packages/kokkos-kernels/unit_test/batched/Test_Batched_TeamVectorSolveUTV.hpp
@@ -74,7 +74,7 @@ namespace Test {
       } else {
 	Kokkos::parallel_for
 	  (Kokkos::TeamVectorRange(member, m*m),
-	   [&](const int &ij) {
+	   [=](const int &ij) {
             const int i = ij/m, j = ij%m;
             value_type tmp(0);
             for (int l=0;l<r;++l)

--- a/packages/kokkos-kernels/unit_test/batched/Test_Batched_TeamVectorSolveUTV2.hpp
+++ b/packages/kokkos-kernels/unit_test/batched/Test_Batched_TeamVectorSolveUTV2.hpp
@@ -75,7 +75,7 @@ namespace Test {
       } else {
 	Kokkos::parallel_for
 	  (Kokkos::TeamVectorRange(member, m*m),
-	   [&](const int &ij) {
+	   [=](const int &ij) {
             const int i = ij/m, j = ij%m;
             value_type tmp(0);
             for (int l=0;l<r;++l)

--- a/packages/kokkos-kernels/unit_test/batched/Test_Batched_TeamVectorUTV.hpp
+++ b/packages/kokkos-kernels/unit_test/batched/Test_Batched_TeamVectorUTV.hpp
@@ -73,7 +73,7 @@ namespace Test {
       } else {
 	Kokkos::parallel_for
 	  (Kokkos::TeamVectorRange(member, m*m),
-	   [&](const int &ij) {
+	   [=](const int &ij) {
             const int i = ij/m, j = ij%m;
             value_type tmp(0);
             for (int l=0;l<r;++l)


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/framework
@trilinos/ifpack2
@trilinos/kokkos-kernels

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
This will add the needed flags to set the standard to C++14 for the CUDA 9.2.88 build.
It also fixes a few build errors that come up in ifpack2 and kokkos-kernels.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->
Associated with #6260
Closes #8016

## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
This work moves to a configuration that is c++14 ready making the PR testing scheme ready for Kokkos 3.3 to be merged in.
## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Tested by running the CUDA 9.2.88 PR build job manually, merging this branch into develop.
Results: [CDash](https://testing.sandia.gov/cdash/index.php?project=Trilinos&display=project&filtercount=3&showfilters=1&filtercombine=and&field1=site&compare1=61&value1=ride12&field2=buildname&compare2=61&value2=PR-cuda9c14fix-test-Trilinos_pullrequest_cuda_9.2-5629&field3=buildstamp&compare3=61&value3=20200928-0300-Experimental)
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->