### PR TITLE
Tpetra: Rollback #7972

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_computeOffsets.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_computeOffsets.hpp
@@ -306,7 +306,7 @@ computeOffsetsFromCounts (const ExecutionSpace& execSpace,
       using Kokkos::WithoutInitializing;
       counts_copy = counts_copy_type
         (view_alloc ("counts_copy", WithoutInitializing), numCounts);
-      Kokkos::deep_copy (execSpace, counts_copy, counts);
+      Kokkos::deep_copy (counts_copy, counts);
       counts_a = counts_copy;
     }
 


### PR DESCRIPTION
@csiefer2 I plan to put all the 3-arg deep_copy comments and current refactor work in a single PR which I think will make it easier for someone to continue in the future, either by using it as a reference or a starting point for a submission.

This PR rolls back the one 3-arg conversion we actually merged: #7972. I'm realizing now this is probably not safe for CUDA_LAUNCH_BLOCKING=0 and HostSpace inputs. I'll send some further notes on this.

Since it's the only one we merged, I think rolling it back would make sense so I can leave things in a well-defined state for future work.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Leave Tpetra in a well-defined state with no 3-arg deep_copy conversions until other issues are resolved.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Mac parallel build - this rolls back a prior change
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->