### PR TITLE
Teuchos: Add Git SHA as Watchr metadata

### DIFF
--- a/packages/teuchos/comm/src/Teuchos_StackedTimer.cpp
+++ b/packages/teuchos/comm/src/Teuchos_StackedTimer.cpp
@@ -744,6 +744,7 @@ std::string
 StackedTimer::reportWatchrXML(const std::string& name, Teuchos::RCP<const Teuchos::Comm<int> > comm) {
   const char* rawWatchrDir = getenv("WATCHR_PERF_DIR");
   const char* rawBuildName = getenv("WATCHR_BUILD_NAME");
+  const char* rawGitSHA = getenv("TRILINOS_GIT_SHA");
   //WATCHR_PERF_DIR is required (will also check nonempty below)
   if(!rawWatchrDir)
     return "";
@@ -798,6 +799,14 @@ StackedTimer::reportWatchrXML(const std::string& name, Teuchos::RCP<const Teucho
     std::vector<bool> printed(flat_names_.size(), false);
     os << "<?xml version=\"1.0\"?>\n";
     os << "<performance-report date=\"" << timestamp << "\" name=\"nightly_run_" << datestamp << "\" time-units=\"seconds\">\n";
+    if(rawGitSHA)
+    {
+      std::string gitSHA(rawGitSHA);
+      //Output the first 10 (hex) characters
+      if(gitSHA.length() > 10)
+        gitSHA = gitSHA.substr(0, 10);
+      os << "  <metadata key=\"Trilinos Version\" value=\"" << gitSHA << "\"/>\n";
+    }
     printLevelXML("", 0, os, printed, 0.0, buildName + ": " + name);
     os << "</performance-report>\n";
   }


### PR DESCRIPTION
This will show up in the mouseover for each datapoint, making it much
easier to match performance changes with code changes.

This is used by setting environment variable ``TRILINOS_GIT_SHA`` to `` `git rev-parse HEAD` `` in the testing scripts.
This is optional - if the variable is not set, the XML files just won't contain this metadata.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/teuchos

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
This will increase the usability of the Jenkins performance dashboards. Right now, if there's a big swing in some measurement, you have to manually look at the date/time the build ran and find it in the git history. With this change, the chart will already have that info (e.g. for bisecting, datapoints N-1 and N will give the start and end).
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
This idea came from Tpetra meetings where we were trying to figure out which code changes caused big performance changes.
## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".
-->
Tested by doing a PERFORMANCE category build and run on my workstation, with and without setting TRILINOS_GIT_SHA. Elliott Ridgway (who just added this feature to Watchr) confirmed that the metadata line looks correct. This won't start showing up on the dashboard until Jenkins updates its plugins.
<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->