### PR TITLE
Intrepid2 - uvm removal on test

### DIFF
--- a/packages/intrepid2/src/Shared/Intrepid2_ArrayToolsDefCloneScale.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_ArrayToolsDefCloneScale.hpp
@@ -149,10 +149,10 @@ namespace Intrepid2 {
 
     typedef Kokkos::DynRankView<outputValueType,outputProperties...> OutputViewType;
     typedef Kokkos::DynRankView<inputValueType, inputProperties...>  inputViewType; 
-    typedef typename ExecSpace< typename inputViewType::execution_space , SpT >::ExecSpaceType ExecSpaceType;
+    typedef typename SpT::execution_space ExecSpaceType;
     
-    using range_policy_type = Kokkos::Experimental::MDRangePolicy
-      < ExecSpaceType, Kokkos::Experimental::Rank<3>, Kokkos::IndexType<ordinal_type> >;
+    using range_policy_type = Kokkos::MDRangePolicy
+      < ExecSpaceType, Kokkos::Rank<3>, Kokkos::IndexType<ordinal_type> >;
 
     range_policy_type policy( { 0, 0, 0 },
                               { /*C*/ output.extent(0), /*F*/ output.extent(1), /*P*/ output.extent(2) } );
@@ -197,10 +197,10 @@ namespace Intrepid2 {
 
     typedef Kokkos::DynRankView<outputValueType,outputProperties...> OutputViewType;
     typedef Kokkos::DynRankView<inputValueType, inputProperties...>  inputViewType; 
-    typedef typename ExecSpace< typename inputViewType::execution_space , SpT >::ExecSpaceType ExecSpaceType;
+    typedef typename SpT::execution_space ExecSpaceType;
     
-    using range_policy_type = Kokkos::Experimental::MDRangePolicy
-      < ExecSpaceType, Kokkos::Experimental::Rank<2>, Kokkos::IndexType<ordinal_type> >;
+    using range_policy_type = Kokkos::MDRangePolicy
+      < ExecSpaceType, Kokkos::Rank<2>, Kokkos::IndexType<ordinal_type> >;
     
     range_policy_type policy( { 0, 0 },
                               { /*C*/ output.extent(0), /*P*/ output.extent(1) } );

--- a/packages/intrepid2/src/Shared/Intrepid2_ArrayToolsDefContractions.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_ArrayToolsDefContractions.hpp
@@ -112,8 +112,7 @@ namespace Intrepid2 {
     typedef Kokkos::DynRankView<leftFieldValueType,leftFieldProperties...> leftFieldViewType;
     typedef Kokkos::DynRankView<rightFieldValueType,rightFieldProperties...> rightFieldViewType;
     typedef FunctorArrayTools::F_contractFieldField<outFieldViewType, leftFieldViewType, rightFieldViewType> FunctorType;
-    typedef typename ExecSpace< typename outFieldViewType::execution_space, SpT >::ExecSpaceType ExecSpaceType;
-
+    typedef typename SpT::execution_space ExecSpaceType;
 
     const size_type loopSize = leftFields.extent(0)*leftFields.extent(1)*rightFields.extent(1);
     Kokkos::RangePolicy<ExecSpaceType,Kokkos::Schedule<Kokkos::Static> > policy(0, loopSize);
@@ -196,7 +195,7 @@ namespace Intrepid2 {
     typedef Kokkos::DynRankView<inputDataValueType,  inputDataProperties...>                   inputDataViewType;
     typedef Kokkos::DynRankView<inputFieldValueType, inputFieldProperties...>                  inputFieldsViewType;
     typedef FunctorArrayTools::F_contractDataField<outputFieldsViewType, inputDataViewType, inputFieldsViewType>  FunctorType;
-    typedef typename ExecSpace< typename inputFieldsViewType::execution_space , SpT >::ExecSpaceType               ExecSpaceType;
+    typedef typename SpT::execution_space ExecSpaceType;
 
     const size_type loopSize = inputFields.extent(0)*inputFields.extent(1);
     Kokkos::RangePolicy<ExecSpaceType,Kokkos::Schedule<Kokkos::Static> > policy(0, loopSize);
@@ -266,7 +265,7 @@ namespace Intrepid2 {
     typedef Kokkos::DynRankView<inputDataLeftValueType, inputDataLeftProperties...>    inputDataLeftViewType;
     typedef Kokkos::DynRankView<inputDataRightValueType,inputDataRightProperties...>   inputDataRightViewType;
     typedef FunctorArrayTools::F_contractDataData<outputDataViewType, inputDataLeftViewType, inputDataRightViewType> FunctorType;
-    typedef typename ExecSpace< typename inputDataLeftViewType::execution_space , SpT>::ExecSpaceType  ExecSpaceType;
+    typedef typename SpT::execution_space ExecSpaceType;
 
     const size_type loopSize = inputDataLeft.extent(0);
     Kokkos::RangePolicy<ExecSpaceType,Kokkos::Schedule<Kokkos::Static> > policy(0, loopSize);

--- a/packages/intrepid2/src/Shared/Intrepid2_ArrayToolsDefDot.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_ArrayToolsDefDot.hpp
@@ -128,7 +128,7 @@ namespace Intrepid2 {
     typedef Kokkos::DynRankView<leftInputValueType, leftInputProperties...>   leftInputViewType;
     typedef Kokkos::DynRankView<rightInputValueType,rightInputProperties...>  rightInputViewType;
     typedef FunctorArrayTools::F_dotMultiply<OutputViewType, leftInputViewType, rightInputViewType> FunctorType;
-    typedef typename ExecSpace< typename leftInputViewType::execution_space , SpT >::ExecSpaceType ExecSpaceType;
+    typedef typename SpT::execution_space ExecSpaceType; 
 
     const size_type loopSize = ( hasField ? output.extent(0)*output.extent(1)*output.extent(2) :
                                             output.extent(0)*output.extent(1) );

--- a/packages/intrepid2/src/Shared/Intrepid2_ArrayToolsDefScalar.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_ArrayToolsDefScalar.hpp
@@ -175,10 +175,10 @@ namespace Intrepid2 {
     typedef Kokkos::DynRankView<inputDataValueType,inputDataProperties...> inputDataViewType;
     typedef Kokkos::DynRankView<inputFieldValueType,inputFieldProperties...> inputFieldViewType;
 
-    typedef typename ExecSpace< typename inputDataViewType::execution_space , SpT >::ExecSpaceType ExecSpaceType;
+    typedef typename SpT::execution_space ExecSpaceType;
     
-    using range_policy_type = Kokkos::Experimental::MDRangePolicy
-        < ExecSpaceType, Kokkos::Experimental::Rank<3>, Kokkos::IndexType<ordinal_type> >;
+    using range_policy_type = Kokkos::MDRangePolicy
+        < ExecSpaceType, Kokkos::Rank<3>, Kokkos::IndexType<ordinal_type> >;
 
     const range_policy_type policy( { 0, 0, 0 },
                                     { /*C*/ outputFields.extent(0), /*F*/ outputFields.extent(1), /*P*/ outputFields.extent(2) } );
@@ -255,11 +255,10 @@ namespace Intrepid2 {
     typedef Kokkos::DynRankView<inputDataLeftValueType,inputDataLeftProperties...> inputDataLeftViewType;
     typedef Kokkos::DynRankView<inputDataRightValueType,inputDataRightProperties...> inputDataRightViewType;
 
-    typedef typename ExecSpace< typename inputDataLeftViewType::execution_space , SpT >::ExecSpaceType ExecSpaceType;
-
+    typedef typename SpT::execution_space ExecSpaceType;
     
-    using range_policy_type = Kokkos::Experimental::MDRangePolicy
-      < ExecSpaceType, Kokkos::Experimental::Rank<2>, Kokkos::IndexType<ordinal_type> >;
+    using range_policy_type = Kokkos::MDRangePolicy
+      < ExecSpaceType, Kokkos::Rank<2>, Kokkos::IndexType<ordinal_type> >;
 
     const range_policy_type policy( { 0, 0 },
                                     { /*C*/ outputData.extent(0), /*P*/ outputData.extent(1) } );

--- a/packages/intrepid2/src/Shared/Intrepid2_RealSpaceToolsDef.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_RealSpaceToolsDef.hpp
@@ -258,7 +258,7 @@ namespace Intrepid2 {
     typedef          Kokkos::DynRankView<outputValueType,outputProperties...> OutputViewType;
     typedef          Kokkos::DynRankView<inputValueType,inputProperties...> inputViewType;
     typedef          FunctorRealSpaceTools::F_extractScalarValues<OutputViewType,inputViewType> FunctorType;
-    typedef typename ExecSpace<typename inputViewType::execution_space,SpT>::ExecSpaceType ExecSpaceType;
+    typedef typename SpT::execution_space ExecSpaceType;
     
     const auto loopSize = input.extent(0);
     Kokkos::RangePolicy<ExecSpaceType,Kokkos::Schedule<Kokkos::Static> > policy(0, loopSize);
@@ -351,7 +351,7 @@ namespace Intrepid2 {
     typedef          Kokkos::DynRankView<outputValueType,outputProperties...>     OutputViewType;
     typedef          Kokkos::DynRankView<inputValueType,inputProperties...>       inputViewType;
     typedef          FunctorRealSpaceTools::F_clone<OutputViewType,inputViewType> FunctorType;
-    typedef typename ExecSpace<typename inputViewType::execution_space,SpT>::ExecSpaceType ExecSpaceType;
+    typedef typename SpT::execution_space ExecSpaceType;
 
     size_type loopSize = 1;
     const ordinal_type out_rank = output.rank();
@@ -421,7 +421,7 @@ namespace Intrepid2 {
     typedef          Kokkos::DynRankView<absArrayValueType,absArrayProperties...>            absArrayViewType;
     typedef          Kokkos::DynRankView<inArrayValueType, inArrayProperties...>             inArrayViewType;
     typedef          FunctorRealSpaceTools::F_absval<absArrayViewType,inArrayViewType>       FunctorType;
-    typedef typename ExecSpace<typename inArrayViewType::execution_space,SpT>::ExecSpaceType ExecSpaceType;
+    typedef typename SpT::execution_space ExecSpaceType;
 
     const auto loopSize = inArray.extent(0);
     Kokkos::RangePolicy<ExecSpaceType,Kokkos::Schedule<Kokkos::Static> > policy(0, loopSize);
@@ -497,7 +497,7 @@ namespace Intrepid2 {
     typedef          Kokkos::DynRankView<normArrayValueType,normArrayProperties...>        normArrayViewType;
     typedef          Kokkos::DynRankView<inVecValueType,    inVecProperties...>            inVecViewType;
     typedef          FunctorRealSpaceTools::F_vectorNorm<normArrayViewType,inVecViewType>  FunctorType;
-    typedef typename ExecSpace<typename inVecViewType::execution_space,SpT>::ExecSpaceType ExecSpaceType;
+    typedef typename SpT::execution_space ExecSpaceType;
 
     // normArray rank is either 1 or 2
     const auto loopSize = normArray.extent(0)*normArray.extent(1);
@@ -580,7 +580,7 @@ namespace Intrepid2 {
     typedef          Kokkos::DynRankView<transposeMatValueType,transposeMatProperties...>   transposeMatViewType;
     typedef          Kokkos::DynRankView<inMatValueType,       inMatProperties...>          inMatViewType;
     typedef          FunctorRealSpaceTools::F_transpose<transposeMatViewType,inMatViewType> FunctorType;
-    typedef typename ExecSpace<typename inMatViewType::execution_space,SpT>::ExecSpaceType  ExecSpaceType;
+    typedef typename SpT::execution_space ExecSpaceType;
 
     const auto r = transposeMats.rank();
     const auto loopSize = ( r == 2 ? 1 :
@@ -721,7 +721,7 @@ namespace Intrepid2 {
     typedef          Kokkos::DynRankView<inverseMatValueType,inverseMatProperties...>      inverseMatViewType;
     typedef          Kokkos::DynRankView<inMatValueType,     inMatProperties...>           inMatViewType;
     typedef          FunctorRealSpaceTools::F_inverse<inverseMatViewType,inMatViewType>    FunctorType;
-    typedef typename ExecSpace<typename inMatViewType::execution_space,SpT>::ExecSpaceType ExecSpaceType;
+    typedef typename SpT::execution_space ExecSpaceType;
 
     switch (inMats.rank()) {
     case 3: { // output P,D,D and input P,D,D
@@ -731,8 +731,8 @@ namespace Intrepid2 {
       break;
     }
     case 4: { // output C,P,D,D and input C,P,D,D
-      using range_policy_type = Kokkos::Experimental::MDRangePolicy
-        < ExecSpaceType, Kokkos::Experimental::Rank<2>, Kokkos::IndexType<ordinal_type> >;
+      using range_policy_type = Kokkos::MDRangePolicy
+        < ExecSpaceType, Kokkos::Rank<2>, Kokkos::IndexType<ordinal_type> >;
       range_policy_type policy( { 0, 0 },
                                 { inverseMats.extent(0), inverseMats.extent(1) } );
       Kokkos::parallel_for( policy, FunctorType(inverseMats, inMats) );
@@ -805,7 +805,7 @@ namespace Intrepid2 {
     typedef          Kokkos::DynRankView<detArrayValueType,detArrayProperties...>          detArrayViewType;
     typedef          Kokkos::DynRankView<inMatValueType,   inMatProperties...>             inMatViewType;
     typedef          FunctorRealSpaceTools::F_det<detArrayViewType,inMatViewType>          FunctorType;
-    typedef typename ExecSpace<typename inMatViewType::execution_space,SpT>::ExecSpaceType ExecSpaceType;
+    typedef typename SpT::execution_space ExecSpaceType;
 
     switch (detArray.rank()) {
     case 1: { // output P and input P,D,D
@@ -815,8 +815,8 @@ namespace Intrepid2 {
       break;
     }
     case 2: { // output C,P and input C,P,D,D
-      using range_policy_type = Kokkos::Experimental::MDRangePolicy
-        < ExecSpaceType, Kokkos::Experimental::Rank<2>, Kokkos::IndexType<ordinal_type> >;
+      using range_policy_type = Kokkos::MDRangePolicy
+        < ExecSpaceType, Kokkos::Rank<2>, Kokkos::IndexType<ordinal_type> >;
       range_policy_type policy( { 0, 0 },
                                 { detArray.extent(0), detArray.extent(1) } );
       Kokkos::parallel_for( policy, FunctorType(detArray, inMats) );
@@ -892,7 +892,7 @@ namespace Intrepid2 {
     typedef          Kokkos::DynRankView<inArray1ValueType,inArray1Properties...>                     inArray1ViewType;
     typedef          Kokkos::DynRankView<inArray2ValueType,inArray2Properties...>                     inArray2ViewType;
     typedef          FunctorRealSpaceTools::F_add<sumArrayViewType,inArray1ViewType,inArray2ViewType> FunctorType;
-    typedef typename ExecSpace<typename inArray1ViewType::execution_space,SpT>::ExecSpaceType         ExecSpaceType;
+    typedef typename SpT::execution_space ExecSpaceType;
 
     const auto loopSize = sumArray.extent(0);
     Kokkos::RangePolicy<ExecSpaceType,Kokkos::Schedule<Kokkos::Static> > policy(0, loopSize);
@@ -985,7 +985,7 @@ namespace Intrepid2 {
     typedef          Kokkos::DynRankView<inArray1ValueType, inArray1Properties...>                          inArray1ViewType;
     typedef          Kokkos::DynRankView<inArray2ValueType, inArray2Properties...>                          inArray2ViewType;
     typedef          FunctorRealSpaceTools::F_subtract<diffArrayViewType,inArray1ViewType,inArray2ViewType> FunctorType;
-    typedef typename ExecSpace<typename inArray1ViewType::execution_space,SpT>::ExecSpaceType               ExecSpaceType;
+    typedef typename SpT::execution_space ExecSpaceType;
 
     const size_type loopSize = diffArray.extent(0);
     Kokkos::RangePolicy<ExecSpaceType,Kokkos::Schedule<Kokkos::Static> > policy(0, loopSize);
@@ -1077,7 +1077,7 @@ namespace Intrepid2 {
     typedef          Kokkos::DynRankView<scaledArrayValueType,scaledArrayProperties...>               scaledArrayViewtype;
     typedef          Kokkos::DynRankView<inArrayValueType,    inArrayProperties...>                   inArrayViewType;
     typedef          FunctorRealSpaceTools::F_scale<ValueType,scaledArrayViewtype,inArrayViewType> FunctorType;
-    typedef typename ExecSpace<typename inArrayViewType::execution_space,SpT>::ExecSpaceType          ExecSpaceType;
+    typedef typename SpT::execution_space ExecSpaceType;
 
     const auto loopSize = scaledArray.extent(0);
     Kokkos::RangePolicy<ExecSpaceType,Kokkos::Schedule<Kokkos::Static> > policy(0, loopSize);
@@ -1170,7 +1170,7 @@ namespace Intrepid2 {
     typedef          Kokkos::DynRankView<inVec1ValueType,  inVec1Properties...>                   inVec1ViewType;
     typedef          Kokkos::DynRankView<inVec2ValueType,  inVec2Properties...>                   inVec2ViewType;
     typedef          FunctorRealSpaceTools::F_dot<dotArrayViewType,inVec1ViewType,inVec2ViewType> FunctorType;
-    typedef typename ExecSpace<typename inVec1ViewType::execution_space,SpT>::ExecSpaceType       ExecSpaceType;
+    typedef typename SpT::execution_space ExecSpaceType;
 
     const auto loopSize = dotArray.extent(0)*dotArray.extent(1);
     Kokkos::RangePolicy<ExecSpaceType,Kokkos::Schedule<Kokkos::Static> > policy(0, loopSize);
@@ -1297,7 +1297,7 @@ namespace Intrepid2 {
     typedef          Kokkos::DynRankView<inMatValueType, inMatProperties...>                     inMatViewType;
     typedef          Kokkos::DynRankView<inVecValueType, inVecProperties...>                     inVecViewType;
     typedef          FunctorRealSpaceTools::F_matvec<matVecViewType,inMatViewType,inVecViewType> FunctorType;
-    typedef typename ExecSpace<typename inMatViewType::execution_space,SpT>::ExecSpaceType       ExecSpaceType;
+    typedef typename SpT::execution_space ExecSpaceType;
 
     size_type loopSize = 1;
     const ordinal_type r = matVecs.rank() - 1;
@@ -1406,7 +1406,7 @@ namespace Intrepid2 {
     typedef          Kokkos::DynRankView<inLeftValueType, inLeftProperties...>                        inLeftViewType;
     typedef          Kokkos::DynRankView<inRightValueType, inRightProperties...>                      inRightViewType;
     typedef          FunctorRealSpaceTools::F_vecprod<vecProdViewType,inLeftViewType,inRightViewType> FunctorType;
-    typedef typename ExecSpace<typename inLeftViewType::execution_space,SpT>::ExecSpaceType           ExecSpaceType;
+    typedef typename SpT::execution_space ExecSpaceType;
 
     const auto r = inLeft.rank();
     const auto loopSize = ( r == 1 ? 1 :

--- a/packages/intrepid2/src/Shared/Intrepid2_Utils.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_Utils.hpp
@@ -54,6 +54,7 @@
 
 #include "Kokkos_Core.hpp"
 #include "Kokkos_Macros.hpp" // provides some preprocessor values used in definitions of INTREPID2_DEPRECATED, etc.
+#include "Kokkos_Random.hpp"
 
 #ifdef HAVE_INTREPID2_SACADO
 #include "Kokkos_LayoutNatural.hpp"

--- a/packages/intrepid2/unit-test/Shared/ArrayTools/Cuda/test_01.cpp
+++ b/packages/intrepid2/unit-test/Shared/ArrayTools/Cuda/test_01.cpp
@@ -54,7 +54,8 @@ int main(int argc, char *argv[]) {
   const bool verbose = (argc-1) > 0;
   Kokkos::initialize();
 
-  const int r_val = Intrepid2::Test::ArrayTools_Test01<double,Kokkos::Cuda>(verbose);
+  const int r_val = Intrepid2::Test::ArrayTools_Test01
+    <double,Kokkos::Device<Kokkos::Cuda,Kokkos::CudaSpace> >(verbose);
   
   Kokkos::finalize();
   return r_val;

--- a/packages/intrepid2/unit-test/Shared/ArrayTools/Cuda/test_02.cpp
+++ b/packages/intrepid2/unit-test/Shared/ArrayTools/Cuda/test_02.cpp
@@ -54,7 +54,8 @@ int main(int argc, char *argv[]) {
   const bool verbose = (argc-1) > 0;
   Kokkos::initialize();
 
-  const int r_val = Intrepid2::Test::ArrayTools_Test02<double,Kokkos::Cuda>(verbose);
+  const int r_val = Intrepid2::Test::ArrayTools_Test02
+    <double,Kokkos::Cuda/* Kokkos::Device<Kokkos::Cuda,Kokkos::CudaSpace>*/ >(verbose);
   
   Kokkos::finalize();
   return r_val;

--- a/packages/intrepid2/unit-test/Shared/ArrayTools/Cuda/test_03.cpp
+++ b/packages/intrepid2/unit-test/Shared/ArrayTools/Cuda/test_03.cpp
@@ -54,7 +54,8 @@ int main(int argc, char *argv[]) {
   const bool verbose = (argc-1) > 0;
   Kokkos::initialize();
 
-  const int r_val = Intrepid2::Test::ArrayTools_Test03<double,Kokkos::Cuda>(verbose);
+  const int r_val = Intrepid2::Test::ArrayTools_Test03
+    <double,Kokkos::Cuda /* Kokkos::Device<Kokkos::Cuda,Kokkos::CudaSpace>*/ >(verbose);
   
   Kokkos::finalize();
   return r_val;

--- a/packages/intrepid2/unit-test/Shared/ArrayTools/test_01.hpp
+++ b/packages/intrepid2/unit-test/Shared/ArrayTools/test_01.hpp
@@ -75,7 +75,7 @@ namespace Intrepid2 {
       };                                                                \
     }
     
-    template<typename ValueType, typename DeviceSpaceType>
+    template<typename ValueType, typename DeviceType>
     int ArrayTools_Test01(const bool verbose) {
       
       typedef ValueType value_type;
@@ -91,11 +91,11 @@ namespace Intrepid2 {
       Teuchos::oblackholestream oldFormatState;
       oldFormatState.copyfmt(std::cout);
 
-      typedef typename
-        Kokkos::Impl::is_space<DeviceSpaceType>::host_mirror_space::execution_space HostSpaceType ;
+      using DeviceExecSpaceType = typename DeviceType::execution_space;
+      using HostExecSpaceType = Kokkos::DefaultExecutionSpace;
 
-      *outStream << "DeviceSpace::  "; DeviceSpaceType::print_configuration(std::cout, false);
-      *outStream << "HostSpace::    ";   HostSpaceType::print_configuration(std::cout, false);
+      *outStream << "DeviceSpace::  "; DeviceExecSpaceType::print_configuration(std::cout, false);
+      *outStream << "HostSpace::    ";   HostExecSpaceType::print_configuration(std::cout, false);
 
       *outStream      \
         << "===============================================================================\n" \
@@ -112,9 +112,9 @@ namespace Intrepid2 {
         << "|                                                                             |\n" \
         << "===============================================================================\n";      
       
-      typedef RealSpaceTools<DeviceSpaceType> rst;
-      typedef ArrayTools<DeviceSpaceType> art; 
-      typedef Kokkos::DynRankView<value_type,DeviceSpaceType> DynRankView;
+      typedef RealSpaceTools<DeviceType> rst;
+      typedef ArrayTools<DeviceType> art; 
+      typedef Kokkos::DynRankView<value_type,DeviceType> DynRankView;
 
 #define ConstructWithLabel(obj, ...) obj(#obj, __VA_ARGS__)
       
@@ -141,8 +141,6 @@ namespace Intrepid2 {
         DynRankView ConstructWithLabel(a_10_3_2, 10, 3, 2);
         DynRankView ConstructWithLabel(a_9_2_2, 9, 2, 2);
 
-        std::cout << "Line: " << __LINE__ <<std::endl;
-    
         *outStream << "-> contractFieldFieldScalar:\n";
         INTREPID2_TEST_ERROR_EXPECTED( art::contractFieldFieldScalar(a_2_2, a_2_2, a_2_2) );
         INTREPID2_TEST_ERROR_EXPECTED( art::contractFieldFieldScalar(a_2_2, a_10_2_2, a_2_2) );
@@ -155,21 +153,11 @@ namespace Intrepid2 {
         INTREPID2_TEST_ERROR_EXPECTED( art::contractFieldFieldScalar(a_10_2_3, a_10_2_2, a_10_3_2) );
         INTREPID2_TEST_ERROR_EXPECTED( art::contractFieldFieldScalar(a_10_2_3, a_10_2_2, a_10_3_2) );
 
-        std::cout << "Line: " << __LINE__ <<std::endl;
-
-
         DynRankView ConstructWithLabel(a_10_2_2_2, 10, 2, 2, 2);
-        std::cout << "Line: " << __LINE__ <<std::endl;
         DynRankView ConstructWithLabel(a_9_2_2_2, 9, 2, 2, 2);
-        std::cout << "Line: " << __LINE__ <<std::endl;
         DynRankView ConstructWithLabel(a_10_3_2_2, 10, 3, 2, 2);
-        std::cout << "Line: " << __LINE__ <<std::endl;
         DynRankView ConstructWithLabel(a_10_2_3_2, 10, 2, 3, 2);
-        std::cout << "Line: " << __LINE__ <<std::endl;
         DynRankView ConstructWithLabel(a_10_2_2_3, 10, 2, 2, 3);
-
-        std::cout << "Line: " << __LINE__ <<std::endl;
-
 
         *outStream << "-> contractFieldFieldVector:\n";
         INTREPID2_TEST_ERROR_EXPECTED( art::contractFieldFieldVector(a_2_2, a_2_2, a_2_2) );
@@ -184,17 +172,12 @@ namespace Intrepid2 {
         INTREPID2_TEST_ERROR_EXPECTED( art::contractFieldFieldVector(a_10_2_3, a_10_2_2_2, a_10_3_2_2) );
         INTREPID2_TEST_ERROR_EXPECTED( art::contractFieldFieldVector(a_10_2_3, a_10_2_2_2, a_10_3_2_2) );
 
-        std::cout << "Line: " << __LINE__ <<std::endl;
-
-
         DynRankView ConstructWithLabel(a_10_2_2_2_2, 10, 2, 2, 2, 2);
         DynRankView ConstructWithLabel(a_9_2_2_2_2, 9, 2, 2, 2, 2);
         DynRankView ConstructWithLabel(a_10_3_2_2_2, 10, 3, 2, 2, 2);
         DynRankView ConstructWithLabel(a_10_2_3_2_2, 10, 2, 3, 2, 2);
         DynRankView ConstructWithLabel(a_10_2_2_3_2, 10, 2, 2, 3, 2);
         DynRankView ConstructWithLabel(a_10_2_2_2_3, 10, 2, 2, 2, 3);
-
-        std::cout << "Line: " << __LINE__ <<std::endl;
 
         *outStream << "-> contractFieldFieldTensor:\n";
         INTREPID2_TEST_ERROR_EXPECTED( art::contractFieldFieldTensor(a_2_2, a_2_2, a_2_2) );
@@ -210,13 +193,8 @@ namespace Intrepid2 {
         INTREPID2_TEST_ERROR_EXPECTED( art::contractFieldFieldTensor(a_10_2_3, a_10_2_2_2_2, a_10_3_2_2_2) );
         INTREPID2_TEST_ERROR_EXPECTED( art::contractFieldFieldTensor(a_10_2_3, a_10_2_2_2_2, a_10_3_2_2_2) );
 
-        std::cout << "Line: " << __LINE__ <<std::endl;
-
-
         DynRankView ConstructWithLabel(a_9_2, 9, 2);
         DynRankView ConstructWithLabel(a_10_1, 10, 1);
-
-        std::cout << "Line: " << __LINE__ <<std::endl;
 
         *outStream << "-> contractDataFieldScalar:\n";
         INTREPID2_TEST_ERROR_EXPECTED( art::contractDataFieldScalar(a_2_2, a_2_2, a_2_2) );
@@ -230,13 +208,8 @@ namespace Intrepid2 {
         INTREPID2_TEST_ERROR_EXPECTED( art::contractDataFieldScalar(a_10_2, a_10_2, a_10_2_2) );
         INTREPID2_TEST_ERROR_EXPECTED( art::contractDataFieldScalar(a_10_2, a_10_1, a_10_2_2) );
 
-        std::cout << "Line: " << __LINE__ <<std::endl;
-
-
         DynRankView ConstructWithLabel(a_10_1_2, 10, 1, 2);
         DynRankView ConstructWithLabel(a_10_1_3, 10, 1, 3);
-
-        std::cout << "Line: " << __LINE__ <<std::endl;
 
         *outStream << "-> contractDataFieldVector:\n";
         INTREPID2_TEST_ERROR_EXPECTED( art::contractDataFieldVector(a_2_2, a_2_2, a_2_2) );
@@ -251,12 +224,7 @@ namespace Intrepid2 {
         INTREPID2_TEST_ERROR_EXPECTED( art::contractDataFieldVector(a_10_2, a_10_2_2, a_10_2_2_2) );
         INTREPID2_TEST_ERROR_EXPECTED( art::contractDataFieldVector(a_10_2, a_10_1_2, a_10_2_2_2) );
 
-        std::cout << "Line: " << __LINE__ <<std::endl;
-
-
         DynRankView ConstructWithLabel(a_10_1_2_2, 10, 1, 2, 2);
-
-        std::cout << "Line: " << __LINE__ <<std::endl;
 
         *outStream << "-> contractDataFieldTensor:\n";
         INTREPID2_TEST_ERROR_EXPECTED( art::contractDataFieldTensor(a_2_2, a_2_2, a_2_2) );
@@ -272,13 +240,8 @@ namespace Intrepid2 {
         INTREPID2_TEST_ERROR_EXPECTED( art::contractDataFieldTensor(a_10_2, a_10_2_2_2, a_10_2_2_2_2) );
         INTREPID2_TEST_ERROR_EXPECTED( art::contractDataFieldTensor(a_10_2, a_10_1_2_2, a_10_2_2_2_2) );
 
-        std::cout << "Line: " << __LINE__ <<std::endl;
-
-
         DynRankView ConstructWithLabel(a_2, 2);
         DynRankView ConstructWithLabel(a_10, 10);
-
-        std::cout << "Line: " << __LINE__ <<std::endl;
 
         *outStream << "-> contractDataDataScalar:\n";
         INTREPID2_TEST_ERROR_EXPECTED( art::contractDataDataScalar(a_2_2, a_10_2_2, a_10_2_2) );
@@ -289,9 +252,6 @@ namespace Intrepid2 {
         INTREPID2_TEST_ERROR_EXPECTED( art::contractDataDataScalar(a_2, a_10_2, a_10_2) );
         INTREPID2_TEST_ERROR_EXPECTED( art::contractDataDataScalar(a_10, a_10_2, a_10_2) );
         INTREPID2_TEST_ERROR_EXPECTED( art::contractDataDataScalar(a_10, a_10_2, a_10_2) );
-
-        std::cout << "Line: " << __LINE__ <<std::endl;
-
 
         *outStream << "-> contractDataDataVector:\n";
         INTREPID2_TEST_ERROR_EXPECTED( art::contractDataDataVector(a_2_2, a_2_2, a_2_2) );
@@ -304,9 +264,6 @@ namespace Intrepid2 {
         INTREPID2_TEST_ERROR_EXPECTED( art::contractDataDataVector(a_10, a_10_2_2, a_10_2_2) );
         INTREPID2_TEST_ERROR_EXPECTED( art::contractDataDataVector(a_10, a_10_2_2, a_10_2_2) );
 
-        std::cout << "Line: " << __LINE__ <<std::endl;
-
-
         *outStream << "-> contractDataDataTensor:\n";
         INTREPID2_TEST_ERROR_EXPECTED( art::contractDataDataTensor(a_2_2, a_2_2, a_2_2) );
         INTREPID2_TEST_ERROR_EXPECTED( art::contractDataDataTensor(a_2_2, a_10_2_2_2, a_2_2) );
@@ -318,9 +275,6 @@ namespace Intrepid2 {
         INTREPID2_TEST_ERROR_EXPECTED( art::contractDataDataTensor(a_2, a_10_2_2_2, a_10_2_2_2) );
         INTREPID2_TEST_ERROR_EXPECTED( art::contractDataDataTensor(a_10, a_10_2_2_2, a_10_2_2_2) );
         INTREPID2_TEST_ERROR_EXPECTED( art::contractDataDataTensor(a_10, a_10_2_2_2, a_10_2_2_2) );
-
-        std::cout << "Line: " << __LINE__ <<std::endl;
-
 
     #endif
 
@@ -351,42 +305,54 @@ namespace Intrepid2 {
           DynRankView ConstructWithLabel(in_c_r_p, c, r, p);
           DynRankView ConstructWithLabel(out1_c_l_r, c, l, r);
           DynRankView ConstructWithLabel(out2_c_l_r, c, l, r);
+          
+
+          const auto in_c_l_p_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), in_c_l_p);
+          const auto in_c_r_p_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), in_c_r_p);
+          const auto out1_c_l_r_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), out1_c_l_r);
+          const auto out2_c_l_r_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), out2_c_l_r);
+          
+          // fill with random numbers
+          //Kokkos::Random_XorShift64_Pool<DeviceExecSpaceType> random(13718); 
+          //Kokkos::fill_random(in_c_l_p, random, value_type(1));
+          //Kokkos::fill_random(in_c_r_p, random, value_type(1));
 
           // fill with random numbers
           for (auto i=0;i<c;++i) {
             for (auto j=0;j<l;++j)
               for (auto k=0;k<p;++k)
-                  in_c_l_p(i,j,k) = Teuchos::ScalarTraits<value_type>::random();
+                in_c_l_p_host(i,j,k) = Teuchos::ScalarTraits<value_type>::random();
             for (auto j=0;j<r;++j)
-               for (auto k=0;k<p;++k)
-                   in_c_r_p(i,j,k) = Teuchos::ScalarTraits<value_type>::random();
+              for (auto k=0;k<p;++k)
+                in_c_r_p_host(i,j,k) = Teuchos::ScalarTraits<value_type>::random();
           }
-
+          
+          Kokkos::deep_copy(in_c_l_p, in_c_l_p_host);
+          Kokkos::deep_copy(in_c_r_p, in_c_r_p_host);
+          
           art::contractFieldFieldScalar(out1_c_l_r, in_c_l_p, in_c_r_p);
           art::contractFieldFieldScalar(out2_c_l_r, in_c_l_p, in_c_r_p);
           rst::subtract(out1_c_l_r, out2_c_l_r);
-          auto out1_c_l_r_h = Kokkos::create_mirror_view(out1_c_l_r);
-          Kokkos::deep_copy(out1_c_l_r_h, out1_c_l_r);
-          if (rst::Serial::vectorNorm(out1_c_l_r_h, NORM_ONE) > tol) {
+          
+          Kokkos::deep_copy(out1_c_l_r_host, out1_c_l_r);
+          if (rst::Serial::vectorNorm(out1_c_l_r_host, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT contractFieldFieldScalar (1): check COMP_CPP vs. COMP_BLAS; "
-                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_r_h, NORM_ONE) << "\n\n";
+                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_r_host, NORM_ONE) << "\n\n";
             errorFlag = -1000;
           }
           // with sumInto:
-
+          
           //fill with 2.0
-          for (auto i=0;i<c;++i)
-            for (auto j=0;j<l;++j)
-              for (auto k=0;k<r;++k)
-                out1_c_l_r(i,j,k) = out2_c_l_r(i,j,k) = 2.0;
+          Kokkos::deep_copy(out1_c_l_r, value_type(2));
+          Kokkos::deep_copy(out2_c_l_r, value_type(2));
 
           art::contractFieldFieldScalar(out1_c_l_r, in_c_l_p, in_c_r_p, true);
           art::contractFieldFieldScalar(out2_c_l_r, in_c_l_p, in_c_r_p, true);
           rst::subtract(out1_c_l_r, out2_c_l_r);
-          Kokkos::deep_copy(out1_c_l_r_h, out1_c_l_r);
-          if (rst::Serial::vectorNorm(out1_c_l_r_h, NORM_ONE) > tol) {
+          Kokkos::deep_copy(out1_c_l_r_host, out1_c_l_r);
+          if (rst::Serial::vectorNorm(out1_c_l_r_host, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT contractFieldFieldScalar (1): check COMP_CPP vs. COMP_BLAS; "
-                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_r_h, NORM_ONE) << "\n\n";
+                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_r_host, NORM_ONE) << "\n\n";
             errorFlag = -1000;
           }
           } // end scope
@@ -401,47 +367,53 @@ namespace Intrepid2 {
           DynRankView ConstructWithLabel(out1_c_l_r, c, l, r);
           DynRankView ConstructWithLabel(out2_c_l_r, c, l, r);
 
+          const auto in_c_l_p_d_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), in_c_l_p_d);
+          const auto in_c_r_p_d_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), in_c_r_p_d);
+          const auto out1_c_l_r_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), out1_c_l_r);
+          const auto out2_c_l_r_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), out2_c_l_r);
+
           // fill with random numbers
           for (auto i=0;i<c;++i) {
             for (auto j=0;j<l;++j)
               for (auto k=0;k<p;++k)
                 for (auto m=0;m<d;++m)
-                  in_c_l_p_d(i,j,k,m) = Teuchos::ScalarTraits<value_type>::random();
+                  in_c_l_p_d_host(i,j,k,m) = Teuchos::ScalarTraits<value_type>::random();
             for (auto j=0;j<r;++j)
               for (auto k=0;k<p;++k)
                 for (auto m=0;m<d;++m)
-                  in_c_r_p_d(i,j,k,m) = Teuchos::ScalarTraits<value_type>::random();
+                  in_c_r_p_d_host(i,j,k,m) = Teuchos::ScalarTraits<value_type>::random();
           }
 
+          Kokkos::deep_copy(in_c_l_p_d, in_c_l_p_d_host);
+          Kokkos::deep_copy(in_c_r_p_d, in_c_r_p_d_host);
 
           art::contractFieldFieldVector(out1_c_l_r, in_c_l_p_d, in_c_r_p_d);
           art::contractFieldFieldVector(out2_c_l_r, in_c_l_p_d, in_c_r_p_d);
 
           rst::subtract(out1_c_l_r, out2_c_l_r);
-          auto out1_c_l_r_h = Kokkos::create_mirror_view(out1_c_l_r);
-          Kokkos::deep_copy(out1_c_l_r_h, out1_c_l_r);
-          if (rst::Serial::vectorNorm(out1_c_l_r_h, NORM_ONE) > tol) {
+          Kokkos::deep_copy(out1_c_l_r_host, out1_c_l_r);
+
+          if (rst::Serial::vectorNorm(out1_c_l_r_host, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT contractFieldFieldVector (1): check COMP_CPP vs. COMP_BLAS; "
-                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_r_h, NORM_ONE) << "\n\n";
+                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_r_host, NORM_ONE) << "\n\n";
             errorFlag = -1000;
           }
-
+          
           // with sumInto:
 
           //fill with 2.0
-          for (auto i=0;i<c;++i)
-            for (auto j=0;j<l;++j)
-              for (auto k=0;k<r;++k)
-                out1_c_l_r(i,j,k) = out2_c_l_r(i,j,k) = 2.0;
+          Kokkos::deep_copy(out1_c_l_r, value_type(2));
+          Kokkos::deep_copy(out2_c_l_r, value_type(2));
 
           art::contractFieldFieldVector(out1_c_l_r, in_c_l_p_d, in_c_r_p_d, true);
           art::contractFieldFieldVector(out2_c_l_r, in_c_l_p_d, in_c_r_p_d, true);
 
           rst::subtract(out1_c_l_r, out2_c_l_r);
-          Kokkos::deep_copy(out1_c_l_r_h, out1_c_l_r);
-          if (rst::Serial::vectorNorm(out1_c_l_r_h, NORM_ONE) > tol) {
+          Kokkos::deep_copy(out1_c_l_r_host, out1_c_l_r);
+
+          if (rst::Serial::vectorNorm(out1_c_l_r_host, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT contractFieldFieldVector (1): check COMP_CPP vs. COMP_BLAS; "
-                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_r_h, NORM_ONE) << "\n\n";
+                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_r_host, NORM_ONE) << "\n\n";
             errorFlag = -1000;
           }
           } // end scope
@@ -456,48 +428,53 @@ namespace Intrepid2 {
           DynRankView ConstructWithLabel(out1_c_l_r, c, l, r);
           DynRankView ConstructWithLabel(out2_c_l_r, c, l, r);
 
+          const auto in_c_l_p_d_d_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), in_c_l_p_d_d);
+          const auto in_c_r_p_d_d_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), in_c_r_p_d_d);
+          const auto out1_c_l_r_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), out1_c_l_r);
+          const auto out2_c_l_r_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), out2_c_l_r);
+
           // fill with random numbers
           for (auto i=0;i<c;++i) {
             for (auto j=0;j<l;++j)
               for (auto k=0;k<p;++k)
                 for (auto m=0;m<d1;++m)
                   for (auto n=0;n<d2;++n)
-                    in_c_l_p_d_d(i,j,k,m,n) = Teuchos::ScalarTraits<value_type>::random();
+                    in_c_l_p_d_d_host(i,j,k,m,n) = Teuchos::ScalarTraits<value_type>::random();
             for (auto j=0;j<r;++j)
               for (auto k=0;k<p;++k)
                 for (auto m=0;m<d1;++m)
                   for (auto n=0;n<d2;++n)
-                    in_c_r_p_d_d(i,j,k,m,n) = Teuchos::ScalarTraits<value_type>::random();
+                    in_c_r_p_d_d_host(i,j,k,m,n) = Teuchos::ScalarTraits<value_type>::random();
           }
+
+          Kokkos::deep_copy(in_c_l_p_d_d, in_c_l_p_d_d_host);
+          Kokkos::deep_copy(in_c_r_p_d_d, in_c_r_p_d_d_host);
 
           art::contractFieldFieldTensor(out1_c_l_r, in_c_l_p_d_d, in_c_r_p_d_d);
           art::contractFieldFieldTensor(out2_c_l_r, in_c_l_p_d_d, in_c_r_p_d_d);
 
           rst::subtract(out1_c_l_r, out2_c_l_r);
-          auto out1_c_l_r_h = Kokkos::create_mirror_view(out1_c_l_r);
-          Kokkos::deep_copy(out1_c_l_r_h, out1_c_l_r);
-          if (rst::Serial::vectorNorm(out1_c_l_r_h, NORM_ONE) > tol) {
+          Kokkos::deep_copy(out1_c_l_r_host, out1_c_l_r);
+          if (rst::Serial::vectorNorm(out1_c_l_r_host, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT contractFieldFieldTensor (1): check COMP_CPP vs. COMP_BLAS; "
-                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_r_h, NORM_ONE) << "\n\n";
+                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_r_host, NORM_ONE) << "\n\n";
             errorFlag = -1000;
           }
 
           // with sumInto:
 
           //fill with 2.0
-          for (auto i=0;i<c;++i)
-            for (auto j=0;j<l;++j)
-              for (auto k=0;k<r;++k)
-                out1_c_l_r(i,j,k) = out2_c_l_r(i,j,k) = 2.0;
+          Kokkos::deep_copy(out1_c_l_r, value_type(2));
+          Kokkos::deep_copy(out2_c_l_r, value_type(2));
 
           art::contractFieldFieldTensor(out1_c_l_r, in_c_l_p_d_d, in_c_r_p_d_d, true);
           art::contractFieldFieldTensor(out2_c_l_r, in_c_l_p_d_d, in_c_r_p_d_d, true);
 
           rst::subtract(out1_c_l_r, out2_c_l_r);
-          Kokkos::deep_copy(out1_c_l_r_h, out1_c_l_r);
-          if (rst::Serial::vectorNorm(out1_c_l_r_h, NORM_ONE) > tol) {
+          Kokkos::deep_copy(out1_c_l_r_host, out1_c_l_r);
+          if (rst::Serial::vectorNorm(out1_c_l_r_host, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT contractFieldFieldTensor (1): check COMP_CPP vs. COMP_BLAS; "
-                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_r_h, NORM_ONE) << "\n\n";
+                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_r_host, NORM_ONE) << "\n\n";
             errorFlag = -1000;
           }
           } // end scope
@@ -513,50 +490,56 @@ namespace Intrepid2 {
           DynRankView ConstructWithLabel(out1_c_l, c, l);
           DynRankView ConstructWithLabel(out2_c_l, c, l);
 
+          const auto in_c_l_p_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), in_c_l_p);
+          const auto data_c_p_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), data_c_p);
+          const auto data_c_1_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), data_c_1);
+          const auto out1_c_l_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), out1_c_l);
+          const auto out2_c_l_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), out2_c_l);
 
           // fill with random numbers
           for (auto i=0;i<c;++i) {
             for (auto j=0;j<l;++j)
               for (auto k=0;k<p;++k)
-                in_c_l_p(i,j,k) = Teuchos::ScalarTraits<value_type>::random();
+                in_c_l_p_host(i,j,k) = Teuchos::ScalarTraits<value_type>::random();
             for (auto j=0;j<p;++j)
-              data_c_p(i,j) = Teuchos::ScalarTraits<value_type>::random();
-            data_c_1(i,0) = Teuchos::ScalarTraits<value_type>::random();
+              data_c_p_host(i,j) = Teuchos::ScalarTraits<value_type>::random();
+            data_c_1_host(i,0) = Teuchos::ScalarTraits<value_type>::random();
           }
 
           // nonconstant data
           art::contractDataFieldScalar(out1_c_l, data_c_p, in_c_l_p);
           art::contractDataFieldScalar(out2_c_l, data_c_p, in_c_l_p);
           rst::subtract(out1_c_l, out2_c_l);
-          auto out1_c_l_h = Kokkos::create_mirror_view(out1_c_l);
-          Kokkos::deep_copy(out1_c_l_h, out1_c_l);
-          if (rst::Serial::vectorNorm(out1_c_l_h, NORM_ONE) > tol) {
+
+          Kokkos::deep_copy(out1_c_l_host, out1_c_l);
+          if (rst::Serial::vectorNorm(out1_c_l_host, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT contractDataFieldScalar (1): check COMP_CPP vs. COMP_BLAS; "
-                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_h, NORM_ONE) << "\n\n";
+                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_host, NORM_ONE) << "\n\n";
             errorFlag = -1000;
           }
           // constant data
           art::contractDataFieldScalar(out1_c_l, data_c_1, in_c_l_p);
           art::contractDataFieldScalar(out2_c_l, data_c_1, in_c_l_p);
           rst::subtract(out1_c_l, out2_c_l);
-          Kokkos::deep_copy(out1_c_l_h, out1_c_l);
-          if (rst::Serial::vectorNorm(out1_c_l_h, NORM_ONE) > tol) {
+          Kokkos::deep_copy(out1_c_l_host, out1_c_l);
+          if (rst::Serial::vectorNorm(out1_c_l_host, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT contractDataFieldScalar (2): check COMP_CPP vs. COMP_BLAS; "
-                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_h, NORM_ONE) << "\n\n";
+                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_host, NORM_ONE) << "\n\n";
             errorFlag = -1000;
           }
+
           // nonconstant data with sumInto
-          for (auto i=0;i<c;++i)
-            for (auto j=0;j<l;++j)
-              out1_c_l(i,j) = out2_c_l(i,j) = 2.0;
+          Kokkos::deep_copy(out1_c_l, value_type(2));
+          Kokkos::deep_copy(out2_c_l, value_type(2));
 
           art::contractDataFieldScalar(out1_c_l, data_c_p, in_c_l_p, true);
           art::contractDataFieldScalar(out2_c_l, data_c_p, in_c_l_p, true);
           rst::subtract(out1_c_l, out2_c_l);
-          Kokkos::deep_copy(out1_c_l_h, out1_c_l);
-          if (rst::Serial::vectorNorm(out1_c_l_h, NORM_ONE) > tol) {
+
+          Kokkos::deep_copy(out1_c_l_host, out1_c_l);
+          if (rst::Serial::vectorNorm(out1_c_l_host, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT contractDataFieldScalar (1): check COMP_CPP vs. COMP_BLAS; "
-                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_h, NORM_ONE) << "\n\n";
+                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_host, NORM_ONE) << "\n\n";
             errorFlag = -1000;
           }
           } // end scope
@@ -572,57 +555,63 @@ namespace Intrepid2 {
           DynRankView ConstructWithLabel(out1_c_l, c, l);
           DynRankView ConstructWithLabel(out2_c_l, c, l);
 
+          const auto in_c_l_p_d_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), in_c_l_p_d);
+          const auto data_c_p_d_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), data_c_p_d);
+          const auto data_c_1_d_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), data_c_1_d);
+          const auto out1_c_l_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), out1_c_l);
+          const auto out2_c_l_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), out2_c_l);
+
           // fill with random numbers
           for (auto i=0;i<c;++i) {
             for (auto j=0;j<l;++j)
               for (auto k=0;k<p;++k)
                 for (auto m=0;m<d;++m)
-                  in_c_l_p_d(i,j,k,m) = Teuchos::ScalarTraits<value_type>::random();
+                  in_c_l_p_d_host(i,j,k,m) = Teuchos::ScalarTraits<value_type>::random();
             for (auto j=0;j<p;++j)
               for (auto k=0;k<d;++k)
-                data_c_p_d(i,j,k) = Teuchos::ScalarTraits<value_type>::random();
+                data_c_p_d_host(i,j,k) = Teuchos::ScalarTraits<value_type>::random();
             for (auto k=0;k<d;++k)
-              data_c_1_d(i,0,k) = Teuchos::ScalarTraits<value_type>::random();
+              data_c_1_d_host(i,0,k) = Teuchos::ScalarTraits<value_type>::random();
           }
 
+          Kokkos::deep_copy(in_c_l_p_d, in_c_l_p_d_host);
+          Kokkos::deep_copy(data_c_p_d, data_c_p_d_host);
+          Kokkos::deep_copy(data_c_1_d, data_c_1_d_host);
 
           // nonconstant data
           art::contractDataFieldVector(out1_c_l, data_c_p_d, in_c_l_p_d);
           art::contractDataFieldVector(out2_c_l, data_c_p_d, in_c_l_p_d);
           rst::subtract(out1_c_l, out2_c_l);
-          auto out1_c_l_h = Kokkos::create_mirror_view(out1_c_l);
-          Kokkos::deep_copy(out1_c_l_h, out1_c_l);
-          if (rst::Serial::vectorNorm(out1_c_l_h, NORM_ONE) > tol) {
+
+          Kokkos::deep_copy(out1_c_l_host, out1_c_l);
+          if (rst::Serial::vectorNorm(out1_c_l_host, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT contractDataFieldVector (1): check COMP_CPP vs. COMP_BLAS; "
-                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_h, NORM_ONE) << "\n\n";
+                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_host, NORM_ONE) << "\n\n";
             errorFlag = -1000;
           }
           // constant data
           art::contractDataFieldVector(out1_c_l, data_c_1_d, in_c_l_p_d);
           art::contractDataFieldVector(out2_c_l, data_c_1_d, in_c_l_p_d);
           rst::subtract(out1_c_l, out2_c_l);
-          Kokkos::deep_copy(out1_c_l_h, out1_c_l);
-          if (rst::Serial::vectorNorm(out1_c_l_h, NORM_ONE) > tol) {
+          Kokkos::deep_copy(out1_c_l_host, out1_c_l);
+          if (rst::Serial::vectorNorm(out1_c_l_host, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT contractDataFieldVector (2): check COMP_CPP vs. COMP_BLAS; "
-                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_h, NORM_ONE) << "\n\n";
+                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_host, NORM_ONE) << "\n\n";
             errorFlag = -1000;
           }
           // nonconstant data with sumInto
 
           //fill with 2.0
-          value_type two=2.0;
-          deep_copy(out1_c_l, two);
-          for (auto i=0;i<c;++i)
-            for (auto j=0;j<l;++j)
-              out1_c_l(i,j) = out2_c_l(i,j) = 2.0;
-
+          Kokkos::deep_copy(out1_c_l, value_type(2));
+          Kokkos::deep_copy(out2_c_l, value_type(2));
+          
           art::contractDataFieldVector(out1_c_l, data_c_p_d, in_c_l_p_d, true);
           art::contractDataFieldVector(out2_c_l, data_c_p_d, in_c_l_p_d, true);
           rst::subtract(out1_c_l, out2_c_l);
-          Kokkos::deep_copy(out1_c_l_h, out1_c_l);
-          if (rst::Serial::vectorNorm(out1_c_l_h,NORM_ONE) > tol) {
+          Kokkos::deep_copy(out1_c_l_host, out1_c_l);
+          if (rst::Serial::vectorNorm(out1_c_l_host,NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT contractDataFieldVector (3): check COMP_CPP vs. COMP_BLAS; "
-                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_h, NORM_ONE) << "\n\n";
+                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_host, NORM_ONE) << "\n\n";
             errorFlag = -1000;
           }
           } // end scope
@@ -638,6 +627,11 @@ namespace Intrepid2 {
           DynRankView ConstructWithLabel(out1_c_l, c, l);
           DynRankView ConstructWithLabel(out2_c_l, c, l);
 
+          const auto in_c_l_p_d_d_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), in_c_l_p_d_d);          
+          const auto data_c_p_d_d_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), data_c_p_d_d);          
+          const auto data_c_1_d_d_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), data_c_1_d_d);          
+          const auto out1_c_l_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), out1_c_l);          
+          const auto out2_c_l_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), out2_c_l);          
 
           // fill with random numbers
           for (auto i=0;i<c;++i) {
@@ -645,25 +639,24 @@ namespace Intrepid2 {
               for (auto k=0;k<p;++k)
                 for (auto m=0;m<d1;++m)
                   for (auto n=0;n<d2;++n)
-                    in_c_l_p_d_d(i,j,k,m,n) = Teuchos::ScalarTraits<value_type>::random();
+                    in_c_l_p_d_d_host(i,j,k,m,n) = Teuchos::ScalarTraits<value_type>::random();
             for (auto j=0;j<p;++j)
               for (auto k=0;k<d1;++k)
                 for (auto m=0;m<d2;++m)
-                  data_c_p_d_d(i,j,k,m) = Teuchos::ScalarTraits<value_type>::random();
+                  data_c_p_d_d_host(i,j,k,m) = Teuchos::ScalarTraits<value_type>::random();
             for (auto k=0;k<d1;++k)
               for (auto m=0;m<d2;++m)
-                data_c_1_d_d(i,0,k,m) = Teuchos::ScalarTraits<value_type>::random();
+                data_c_1_d_d_host(i,0,k,m) = Teuchos::ScalarTraits<value_type>::random();
           }
 
           // nonconstant data
           art::contractDataFieldTensor(out1_c_l, data_c_p_d_d, in_c_l_p_d_d);
           art::contractDataFieldTensor(out2_c_l, data_c_p_d_d, in_c_l_p_d_d);
           rst::subtract(out1_c_l, out2_c_l);
-          auto out1_c_l_h = Kokkos::create_mirror_view(out1_c_l);
-          Kokkos::deep_copy(out1_c_l_h, out1_c_l);
-          if (rst::Serial::vectorNorm(out1_c_l_h, NORM_ONE) > tol) {
+          Kokkos::deep_copy(out1_c_l_host, out1_c_l);
+          if (rst::Serial::vectorNorm(out1_c_l_host, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT contractDataFieldTensor (1): check COMP_CPP vs. COMP_BLAS; "
-                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_h, NORM_ONE) << "\n\n";
+                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_host, NORM_ONE) << "\n\n";
             errorFlag = -1000;
           }
 
@@ -671,27 +664,26 @@ namespace Intrepid2 {
           art::contractDataFieldTensor(out1_c_l, data_c_1_d_d, in_c_l_p_d_d);
           art::contractDataFieldTensor(out2_c_l, data_c_1_d_d, in_c_l_p_d_d);
           rst::subtract(out1_c_l, out2_c_l);
-          Kokkos::deep_copy(out1_c_l_h, out1_c_l);
-          if (rst::Serial::vectorNorm(out1_c_l_h, NORM_ONE) > tol) {
+          Kokkos::deep_copy(out1_c_l_host, out1_c_l);
+          if (rst::Serial::vectorNorm(out1_c_l_host, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT contractDataFieldTensor (2): check COMP_CPP vs. COMP_BLAS; "
-                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_h, NORM_ONE) << "\n\n";
+                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_host, NORM_ONE) << "\n\n";
             errorFlag = -1000;
           }
 
           // nonconstant data with sumInto
 
           //fill with 2.0
-          for (auto i=0;i<c;++i)
-            for (auto j=0;j<l;++j)
-              out1_c_l(i,j) = out2_c_l(i,j) = 2.0;
+          Kokkos::deep_copy(out1_c_l, value_type(2));
+          Kokkos::deep_copy(out2_c_l, value_type(2));
 
           art::contractDataFieldTensor(out1_c_l, data_c_p_d_d, in_c_l_p_d_d, true);
           art::contractDataFieldTensor(out2_c_l, data_c_p_d_d, in_c_l_p_d_d, true);
           rst::subtract(out1_c_l, out2_c_l);
-          Kokkos::deep_copy(out1_c_l_h, out1_c_l);
-          if (rst::Serial::vectorNorm(out1_c_l_h, NORM_ONE) > tol) {
+          Kokkos::deep_copy(out1_c_l_host, out1_c_l);
+          if (rst::Serial::vectorNorm(out1_c_l_host, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT contractDataFieldTensor (3): check COMP_CPP vs. COMP_BLAS; "
-                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_h, NORM_ONE) << "\n\n";
+                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_l_host, NORM_ONE) << "\n\n";
             errorFlag = -1000;
           }
           } // end scope
@@ -706,36 +698,44 @@ namespace Intrepid2 {
           DynRankView ConstructWithLabel(out1_c, c);
           DynRankView ConstructWithLabel(out2_c, c);
 
+          const auto inl_c_p_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), inl_c_p);
+          const auto inr_c_p_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), inr_c_p);
+          const auto out1_c_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), out1_c);
+          const auto out2_c_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), out2_c);
+
           // fill with random numbers
           for (auto i=0;i<c;++i)
             for (auto j=0;j<p;++j) {
-              inl_c_p(i,j) = Teuchos::ScalarTraits<value_type>::random();
-              inr_c_p(i,j) = Teuchos::ScalarTraits<value_type>::random();
+              inl_c_p_host(i,j) = Teuchos::ScalarTraits<value_type>::random();
+              inr_c_p_host(i,j) = Teuchos::ScalarTraits<value_type>::random();
             }
+
+          Kokkos::deep_copy(inl_c_p, inl_c_p_host);
+          Kokkos::deep_copy(inr_c_p, inr_c_p_host);
 
           art::contractDataDataScalar(out1_c, inl_c_p, inr_c_p);
           art::contractDataDataScalar(out2_c, inl_c_p, inr_c_p);
           rst::subtract(out1_c, out2_c);
-          auto out1_c_h = Kokkos::create_mirror_view(out1_c);
-          Kokkos::deep_copy(out1_c_h, out1_c);
-          if (rst::Serial::vectorNorm(out1_c_h, NORM_ONE) > tol) {
+
+          Kokkos::deep_copy(out1_c_host, out1_c);
+          if (rst::Serial::vectorNorm(out1_c_host, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT contractDataDataScalar (1): check COMP_CPP vs. COMP_BLAS; "
-                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_h, NORM_ONE) << "\n\n";
+                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_host, NORM_ONE) << "\n\n";
             errorFlag = -1000;
           }
           // with sumInto:
 
           //fill with 2.0
-          for (auto i=0;i<c;++i)
-            out1_c(i) = out2_c(i) = 2.0;
+          Kokkos::deep_copy(out1_c, value_type(2));
+          Kokkos::deep_copy(out2_c, value_type(2));
 
           art::contractDataDataScalar(out1_c, inl_c_p, inr_c_p, true);
           art::contractDataDataScalar(out2_c, inl_c_p, inr_c_p, true);
           rst::subtract(out1_c, out2_c);
-          Kokkos::deep_copy(out1_c_h, out1_c);
-          if (rst::Serial::vectorNorm(out1_c_h, NORM_ONE) > tol) {
+          Kokkos::deep_copy(out1_c_host, out1_c);
+          if (rst::Serial::vectorNorm(out1_c_host, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT contractDataDataScalar (1): check COMP_CPP vs. COMP_BLAS; "
-                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_h, NORM_ONE) << "\n\n";
+                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_host, NORM_ONE) << "\n\n";
             errorFlag = -1000;
           }
           } // end scope
@@ -750,40 +750,45 @@ namespace Intrepid2 {
           DynRankView ConstructWithLabel(out1_c, c);
           DynRankView ConstructWithLabel(out2_c, c);
 
+          const auto inl_c_p_d_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), inl_c_p_d);
+          const auto inr_c_p_d_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), inr_c_p_d);
+          const auto out1_c_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), out1_c);
+          const auto out2_c_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), out2_c);
+
           // fill with random numbers
           for (auto i=0;i<c;++i)
             for (auto j=0;j<p;++j)
               for (auto k=0;k<d;++k) {
-              inl_c_p_d(i,j,k) = Teuchos::ScalarTraits<value_type>::random();
-              inr_c_p_d(i,j,k) = Teuchos::ScalarTraits<value_type>::random();
+              inl_c_p_d_host(i,j,k) = Teuchos::ScalarTraits<value_type>::random();
+              inr_c_p_d_host(i,j,k) = Teuchos::ScalarTraits<value_type>::random();
             }
 
           art::contractDataDataVector(out1_c, inl_c_p_d, inr_c_p_d);
           art::contractDataDataVector(out2_c, inl_c_p_d, inr_c_p_d);
 
           rst::subtract(out1_c, out2_c);
-          auto out1_c_h = Kokkos::create_mirror_view(out1_c);
-          Kokkos::deep_copy(out1_c_h, out1_c);
-          if (rst::Serial::vectorNorm(out1_c_h, NORM_ONE) > tol) {
+
+          Kokkos::deep_copy(out1_c_host, out1_c);
+          if (rst::Serial::vectorNorm(out1_c_host, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT contractDataDataVector (1): check COMP_CPP vs. COMP_BLAS; "
-                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_h, NORM_ONE) << "\n\n";
+                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_host, NORM_ONE) << "\n\n";
             errorFlag = -1000;
           }
 
           // with sumInto:
 
           //fill with 2.0
-          for (auto i=0;i<c;++i)
-            out1_c(i) = out2_c(i) = 2.0;
-
+          Kokkos::deep_copy(out1_c, value_type(2));
+          Kokkos::deep_copy(out2_c, value_type(2));
+          
           art::contractDataDataVector(out1_c, inl_c_p_d, inr_c_p_d, true);
           art::contractDataDataVector(out2_c, inl_c_p_d, inr_c_p_d, true);
 
           rst::subtract(out1_c, out2_c);
-          Kokkos::deep_copy(out1_c_h, out1_c);
-          if (rst::Serial::vectorNorm(out1_c_h, NORM_ONE) > tol) {
+          Kokkos::deep_copy(out1_c_host, out1_c);
+          if (rst::Serial::vectorNorm(out1_c_host, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT contractDataDataVector (1): check COMP_CPP vs. COMP_BLAS; "
-                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_h, NORM_ONE) << "\n\n";
+                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_host, NORM_ONE) << "\n\n";
             errorFlag = -1000;
           }
           } // end scope
@@ -798,41 +803,46 @@ namespace Intrepid2 {
           DynRankView ConstructWithLabel(out1_c, c);
           DynRankView ConstructWithLabel(out2_c, c);
 
+          const auto inl_c_p_d_d_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), inl_c_p_d_d);
+          const auto inr_c_p_d_d_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), inr_c_p_d_d);
+          const auto out1_c_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), out1_c);
+          const auto out2_c_host = Kokkos::create_mirror_view(Kokkos::HostSpace(), out2_c);
+
           // fill with random numbers
           for (auto i=0;i<c;++i)
             for (auto j=0;j<p;++j)
               for (auto k=0;k<d1;++k)
                 for (auto m=0;m<d2;++m) {
-                  inl_c_p_d_d(i,j,k,m) = Teuchos::ScalarTraits<value_type>::random();
-                  inr_c_p_d_d(i,j,k,m) = Teuchos::ScalarTraits<value_type>::random();
+                  inl_c_p_d_d_host(i,j,k,m) = Teuchos::ScalarTraits<value_type>::random();
+                  inr_c_p_d_d_host(i,j,k,m) = Teuchos::ScalarTraits<value_type>::random();
                 }
 
           art::contractDataDataTensor(out1_c, inl_c_p_d_d, inr_c_p_d_d);
           art::contractDataDataTensor(out2_c, inl_c_p_d_d, inr_c_p_d_d);
 
           rst::subtract(out1_c, out2_c);
-          auto out1_c_h = Kokkos::create_mirror_view(out1_c);
-          Kokkos::deep_copy(out1_c_h, out1_c);
-          if (rst::Serial::vectorNorm(out1_c_h, NORM_ONE) > tol) {
+
+          Kokkos::deep_copy(out1_c_host, out1_c);
+          if (rst::Serial::vectorNorm(out1_c_host, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT contractDataDataTensor (1): check COMP_CPP vs. COMP_BLAS; "
-                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_h, NORM_ONE) << "\n\n";
+                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_host, NORM_ONE) << "\n\n";
             errorFlag = -1000;
           }
 
           // with sumInto:
 
           //fill with 2.0
-          for (auto i=0;i<c;++i)
-            out1_c[i] = out2_c[i] = 2.0;
+          Kokkos::deep_copy(out1_c, value_type(2));
+          Kokkos::deep_copy(out2_c, value_type(2));
 
           art::contractDataDataTensor(out1_c, inl_c_p_d_d, inr_c_p_d_d, true);
           art::contractDataDataTensor(out2_c, inl_c_p_d_d, inr_c_p_d_d, true);
 
           rst::subtract(out1_c, out2_c);
-          Kokkos::deep_copy(out1_c_h, out1_c);
-          if (rst::Serial::vectorNorm(out1_c_h, NORM_ONE) > tol) {
+          Kokkos::deep_copy(out1_c_host, out1_c);
+          if (rst::Serial::vectorNorm(out1_c_host, NORM_ONE) > tol) {
             *outStream << "\n\nINCORRECT contractDataDataTensor (1): check COMP_CPP vs. COMP_BLAS; "
-                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_h, NORM_ONE) << "\n\n";
+                       << " diff-1norm = " << rst::Serial::vectorNorm(out1_c_host, NORM_ONE) << "\n\n";
             errorFlag = -1000;
           }
           } // end scope

--- a/packages/intrepid2/unit-test/Shared/ArrayTools/test_01.hpp
+++ b/packages/intrepid2/unit-test/Shared/ArrayTools/test_01.hpp
@@ -92,7 +92,7 @@ namespace Intrepid2 {
       oldFormatState.copyfmt(std::cout);
 
       using DeviceExecSpaceType = typename DeviceType::execution_space;
-      using HostExecSpaceType = Kokkos::DefaultExecutionSpace;
+      using HostExecSpaceType = Kokkos::DefaultHostExecutionSpace;
 
       *outStream << "DeviceSpace::  "; DeviceExecSpaceType::print_configuration(std::cout, false);
       *outStream << "HostSpace::    ";   HostExecSpaceType::print_configuration(std::cout, false);

--- a/packages/intrepid2/unit-test/Shared/ArrayTools/test_02.hpp
+++ b/packages/intrepid2/unit-test/Shared/ArrayTools/test_02.hpp
@@ -75,7 +75,7 @@ namespace Intrepid2 {
       };                                                                \
     }
     
-    template<typename ValueType, typename DeviceSpaceType>
+    template<typename ValueType, typename DeviceType>
     int ArrayTools_Test02(const bool verbose) {
       
       typedef ValueType value_type;
@@ -91,11 +91,11 @@ namespace Intrepid2 {
       Teuchos::oblackholestream oldFormatState;
       oldFormatState.copyfmt(std::cout);
 
-      typedef typename
-        Kokkos::Impl::is_space<DeviceSpaceType>::host_mirror_space::execution_space HostSpaceType ;
+      using DeviceExecSpaceType = typename DeviceType::execution_space;
+      using HostExecSpaceType = Kokkos::DefaultExecutionSpace;
 
-      *outStream << "DeviceSpace::  "; DeviceSpaceType::print_configuration(std::cout, false);
-      *outStream << "HostSpace::    ";   HostSpaceType::print_configuration(std::cout, false);
+      *outStream << "DeviceSpace::  "; DeviceExecSpaceType::print_configuration(std::cout, false);
+      *outStream << "HostSpace::    ";   HostExecSpaceType::print_configuration(std::cout, false);
 
       *outStream                                                        \
         << "===============================================================================\n" \
@@ -112,9 +112,9 @@ namespace Intrepid2 {
         << "|                                                                             |\n" \
         << "===============================================================================\n";      
       
-      typedef RealSpaceTools<DeviceSpaceType> rst;
-      typedef ArrayTools<DeviceSpaceType> art; 
-      typedef Kokkos::DynRankView<value_type,DeviceSpaceType> DynRankView;
+      typedef RealSpaceTools<DeviceType> rst;
+      typedef ArrayTools<DeviceType> art; 
+      typedef Kokkos::DynRankView<value_type,DeviceType> DynRankView;
 #define ConstructWithLabel(obj, ...) obj(#obj, __VA_ARGS__)
       
       const value_type tol = tolerence()*10000.0;

--- a/packages/intrepid2/unit-test/Shared/ArrayTools/test_02.hpp
+++ b/packages/intrepid2/unit-test/Shared/ArrayTools/test_02.hpp
@@ -92,7 +92,7 @@ namespace Intrepid2 {
       oldFormatState.copyfmt(std::cout);
 
       using DeviceExecSpaceType = typename DeviceType::execution_space;
-      using HostExecSpaceType = Kokkos::DefaultExecutionSpace;
+      using HostExecSpaceType = Kokkos::DefaultHostExecutionSpace;
 
       *outStream << "DeviceSpace::  "; DeviceExecSpaceType::print_configuration(std::cout, false);
       *outStream << "HostSpace::    ";   HostExecSpaceType::print_configuration(std::cout, false);

--- a/packages/intrepid2/unit-test/Shared/ArrayTools/test_03.hpp
+++ b/packages/intrepid2/unit-test/Shared/ArrayTools/test_03.hpp
@@ -75,7 +75,7 @@ namespace Intrepid2 {
       };                                                                \
     }
     
-    template<typename ValueType, typename DeviceSpaceType>
+    template<typename ValueType, typename DeviceType>
     int ArrayTools_Test03(const bool verbose) {
       
       typedef ValueType value_type;
@@ -91,11 +91,11 @@ namespace Intrepid2 {
       Teuchos::oblackholestream oldFormatState;
       oldFormatState.copyfmt(std::cout);
 
-      typedef typename
-        Kokkos::Impl::is_space<DeviceSpaceType>::host_mirror_space::execution_space HostSpaceType ;
+      using DeviceExecSpaceType = typename DeviceType::execution_space;
+      using HostExecSpaceType = Kokkos::DefaultExecutionSpace;
 
-      *outStream << "DeviceSpace::  "; DeviceSpaceType::print_configuration(std::cout, false);
-      *outStream << "HostSpace::    ";   HostSpaceType::print_configuration(std::cout, false);
+      *outStream << "DeviceSpace::  "; DeviceExecSpaceType::print_configuration(std::cout, false);
+      *outStream << "HostSpace::    ";   HostExecSpaceType::print_configuration(std::cout, false);
 
       *outStream                                                        \
         << "===============================================================================\n" \
@@ -112,9 +112,9 @@ namespace Intrepid2 {
         << "|                                                                             |\n" \
         << "===============================================================================\n";      
       
-      typedef RealSpaceTools<DeviceSpaceType> rst;
-      typedef ArrayTools<DeviceSpaceType> art; 
-      typedef Kokkos::DynRankView<value_type,DeviceSpaceType> DynRankView;
+      typedef RealSpaceTools<DeviceType> rst;
+      typedef ArrayTools<DeviceType> art; 
+      typedef Kokkos::DynRankView<value_type,DeviceType> DynRankView;
 
 #define ConstructWithLabel(obj, ...) obj(#obj, __VA_ARGS__)
       const value_type tol = tolerence()*10000.0;

--- a/packages/intrepid2/unit-test/Shared/ArrayTools/test_03.hpp
+++ b/packages/intrepid2/unit-test/Shared/ArrayTools/test_03.hpp
@@ -92,7 +92,7 @@ namespace Intrepid2 {
       oldFormatState.copyfmt(std::cout);
 
       using DeviceExecSpaceType = typename DeviceType::execution_space;
-      using HostExecSpaceType = Kokkos::DefaultExecutionSpace;
+      using HostExecSpaceType = Kokkos::DefaultHostExecutionSpace;
 
       *outStream << "DeviceSpace::  "; DeviceExecSpaceType::print_configuration(std::cout, false);
       *outStream << "HostSpace::    ";   HostExecSpaceType::print_configuration(std::cout, false);


### PR DESCRIPTION

## Motivation

We do not like uvm. This is a first test modification from using Kokkos::Cuda to Kokkos::Device<Kokkos::Cuda, Kokkos::CudaSpace>. There are lots of places to change the tests where they assume uvm. This seems to take more time. 

## Testing

Tested on weaver.
