### PR TITLE
MueLu: Correct logic in RegionRFactory and update MakeRegionMatrices to not forget block size

### DIFF
--- a/packages/muelu/research/regionMG/src/SetupRegionMatrix_def.hpp
+++ b/packages/muelu/research/regionMG/src/SetupRegionMatrix_def.hpp
@@ -598,6 +598,8 @@ void MakeRegionMatrices(const RCP<Xpetra::CrsMatrixWrap<Scalar, LocalOrdinal, Gl
 
     regCorrection[j] = VectorFactory::Build(revisedRowMapPerGrp[j], true);
     regionGrpMats[j]->apply(*regNsp[j], *regCorrection[j]);
+    regionGrpMats[j]->SetFixedBlockSize(AComp->GetFixedBlockSize());
+
   }
 
   RCP<Vector> regDiag = Teuchos::null;

--- a/packages/muelu/src/Transfers/GeneralGeometric/MueLu_RegionRFactory_def.hpp
+++ b/packages/muelu/src/Transfers/GeneralGeometric/MueLu_RegionRFactory_def.hpp
@@ -313,13 +313,13 @@ namespace MueLu {
     {
       // Corner 1
       LO coordRowIdx = 0, rowIdx = 0, coordColumnOffset = 0, columnOffset = 0, entryOffset = 0;
-      for(LO k = 0; k < 3; ++k) {
-        for(LO j = 0; j < 3; ++j) {
-          for(LO i = 0; i < 3; ++i) {
-            for(LO l = 0; l < blkSize; ++l) {
-              entries_h(entryOffset + (k*9 + j*3 + i)*blkSize + l) = columnOffset
+      for(LO l = 0; l < blkSize; ++l) {
+        for(LO k = 0; k < 3; ++k) {
+          for(LO j = 0; j < 3; ++j) {
+            for(LO i = 0; i < 3; ++i) {
+              entries_h(entryOffset + k*9 + j*3 + i + cornerStencilLength*l) = columnOffset
                 + (k*lFineNodesPerDim[1]*lFineNodesPerDim[0] + j*lFineNodesPerDim[0] + i)*blkSize + l;
-              values_h(entryOffset + (k*9 + j*3 + i)*blkSize + l)  = coeffs[k + 2]*coeffs[j + 2]*coeffs[i + 2];
+              values_h(entryOffset + k*9 + j*3 + i + cornerStencilLength*l)  = coeffs[k + 2]*coeffs[j + 2]*coeffs[i + 2];
 	    }
           }
         }
@@ -337,13 +337,13 @@ namespace MueLu {
       coordColumnOffset += (lFineNodesPerDim[2] - 1)*lFineNodesPerDim[1]*lFineNodesPerDim[0];
       columnOffset = coordColumnOffset*blkSize;
       entryOffset += (facePlaneOffset + (lCoarseNodesPerDim[2] - 2)*interiorPlaneOffset)*blkSize;
-      for(LO k = 0; k < 3; ++k) {
-        for(LO j = 0; j < 3; ++j) {
-          for(LO i = 0; i < 3; ++i) {
-            for(LO l = 0; l < blkSize; ++l) {
-              entries_h(entryOffset + (k*9 + j*3 + i)*blkSize + l) = columnOffset
+      for(LO l = 0; l < blkSize; ++l) {
+        for(LO k = 0; k < 3; ++k) {
+          for(LO j = 0; j < 3; ++j) {
+            for(LO i = 0; i < 3; ++i) {
+              entries_h(entryOffset + k*9 + j*3 + i + cornerStencilLength*l) = columnOffset
                 + ((k - 2)*lFineNodesPerDim[1]*lFineNodesPerDim[0] + j*lFineNodesPerDim[0] + i)*blkSize + l;
-              values_h(entryOffset + (k*9 + j*3 + i)*blkSize + l)  = coeffs[k]*coeffs[j + 2]*coeffs[i + 2];
+              values_h(entryOffset + k*9 + j*3 + i + cornerStencilLength*l)  = coeffs[k]*coeffs[j + 2]*coeffs[i + 2];
 	    }
           }
         }
@@ -361,14 +361,14 @@ namespace MueLu {
       coordColumnOffset = (lFineNodesPerDim[0] - 1);
       columnOffset = coordColumnOffset*blkSize;
       entryOffset = (cornerStencilLength + (lCoarseNodesPerDim[0] - 2)*edgeStencilLength)*blkSize;
-      for(LO k = 0; k < 3; ++k) {
-        for(LO j = 0; j < 3; ++j) {
-          for(LO i = 0; i < 3; ++i) {
-            for(LO l = 0; l < blkSize; ++l) {
-              entries_h(entryOffset + (k*9 + j*3 + i)*blkSize + l) = columnOffset
+      for(LO l = 0; l < blkSize; ++l) {
+        for(LO k = 0; k < 3; ++k) {
+          for(LO j = 0; j < 3; ++j) {
+            for(LO i = 0; i < 3; ++i) {
+              entries_h(entryOffset + k*9 + j*3 + i + cornerStencilLength*l) = columnOffset
                 + (k*lFineNodesPerDim[1]*lFineNodesPerDim[0]
                   + j*lFineNodesPerDim[0] + (i - 2))*blkSize + l;
-              values_h(entryOffset + (k*9 + j*3 + i)*blkSize + l)  = coeffs[k + 2]*coeffs[j + 2]*coeffs[i];
+              values_h(entryOffset + k*9 + j*3 + i + cornerStencilLength*l)  = coeffs[k + 2]*coeffs[j + 2]*coeffs[i];
             }
           }
         }
@@ -386,13 +386,13 @@ namespace MueLu {
       coordColumnOffset += (lFineNodesPerDim[2] - 1)*lFineNodesPerDim[1]*lFineNodesPerDim[0];
       columnOffset = coordColumnOffset*blkSize;
       entryOffset += (facePlaneOffset + (lCoarseNodesPerDim[2] - 2)*interiorPlaneOffset)*blkSize;
-      for(LO k = 0; k < 3; ++k) {
-        for(LO j = 0; j < 3; ++j) {
-          for(LO i = 0; i < 3; ++i) {
-            for(LO l = 0; l < blkSize; ++l) {
-              entries_h(entryOffset + (k*9 + j*3 + i)*blkSize + l) = columnOffset
+      for(LO l = 0; l < blkSize; ++l) {
+        for(LO k = 0; k < 3; ++k) {
+          for(LO j = 0; j < 3; ++j) {
+            for(LO i = 0; i < 3; ++i) {
+              entries_h(entryOffset + k*9 + j*3 + i + cornerStencilLength*l) = columnOffset
                 + ((k - 2)*lFineNodesPerDim[1]*lFineNodesPerDim[0] + j*lFineNodesPerDim[0] + i - 2)*blkSize + l;
-              values_h(entryOffset + (k*9 + j*3 + i)*blkSize + l)  = coeffs[k]*coeffs[j + 2]*coeffs[i];
+              values_h(entryOffset + k*9 + j*3 + i + cornerStencilLength*l)  = coeffs[k]*coeffs[j + 2]*coeffs[i];
             }
           }
         }
@@ -410,14 +410,14 @@ namespace MueLu {
       coordColumnOffset = (lFineNodesPerDim[1] - 1)*lFineNodesPerDim[0];
       columnOffset = coordColumnOffset*blkSize;
       entryOffset = (edgeLineOffset + (lCoarseNodesPerDim[1] - 2)*faceLineOffset)*blkSize;
-      for(LO k = 0; k < 3; ++k) {
-        for(LO j = 0; j < 3; ++j) {
-          for(LO i = 0; i < 3; ++i) {
-            for(LO l = 0; l < blkSize; ++l) {
-              entries_h(entryOffset + (k*9 + j*3 + i)*blkSize + l) = columnOffset
+      for(LO l = 0; l < blkSize; ++l) {
+        for(LO k = 0; k < 3; ++k) {
+          for(LO j = 0; j < 3; ++j) {
+            for(LO i = 0; i < 3; ++i) {
+              entries_h(entryOffset + k*9 + j*3 + i + cornerStencilLength*l) = columnOffset
                 + (k*lFineNodesPerDim[1]*lFineNodesPerDim[0]
 	          + (j - 2)*lFineNodesPerDim[0] + i)*blkSize + l;
-              values_h(entryOffset + (k*9 + j*3 + i)*blkSize + l)  = coeffs[k + 2]*coeffs[j]*coeffs[i + 2];
+              values_h(entryOffset + k*9 + j*3 + i + cornerStencilLength*l)  = coeffs[k + 2]*coeffs[j]*coeffs[i + 2];
             }
           }
         }
@@ -435,13 +435,13 @@ namespace MueLu {
       coordColumnOffset += (lFineNodesPerDim[2] - 1)*lFineNodesPerDim[1]*lFineNodesPerDim[0];
       columnOffset = coordColumnOffset*blkSize;
       entryOffset += (facePlaneOffset + (lCoarseNodesPerDim[2] - 2)*interiorPlaneOffset)*blkSize;
-      for(LO k = 0; k < 3; ++k) {
-        for(LO j = 0; j < 3; ++j) {
-          for(LO i = 0; i < 3; ++i) {
-            for(LO l = 0; l < blkSize; ++l) {
-              entries_h(entryOffset + (k*9 + j*3 + i)*blkSize + l) = columnOffset
+      for(LO l = 0; l < blkSize; ++l) {
+        for(LO k = 0; k < 3; ++k) {
+          for(LO j = 0; j < 3; ++j) {
+            for(LO i = 0; i < 3; ++i) {
+              entries_h(entryOffset + k*9 + j*3 + i + cornerStencilLength*l) = columnOffset
                 + ((k - 2)*lFineNodesPerDim[1]*lFineNodesPerDim[0] + (j - 2)*lFineNodesPerDim[0] + i)*blkSize + l;
-              values_h(entryOffset + (k*9 + j*3 + i)*blkSize + l)  = coeffs[k]*coeffs[j]*coeffs[i + 2];
+              values_h(entryOffset + k*9 + j*3 + i + cornerStencilLength*l)  = coeffs[k]*coeffs[j]*coeffs[i + 2];
             }
           }
         }
@@ -460,14 +460,14 @@ namespace MueLu {
       columnOffset = coordColumnOffset*blkSize;
       entryOffset = (edgeLineOffset + (lCoarseNodesPerDim[1] - 2)*faceLineOffset +
         cornerStencilLength + (lCoarseNodesPerDim[0] - 2)*edgeStencilLength)*blkSize;
-      for(LO k = 0; k < 3; ++k) {
-        for(LO j = 0; j < 3; ++j) {
-          for(LO i = 0; i < 3; ++i) {
-            for(LO l = 0; l < blkSize; ++l) {
-              entries_h(entryOffset + (k*9 + j*3 + i)*blkSize + l) = columnOffset
+      for(LO l = 0; l < blkSize; ++l) {
+        for(LO k = 0; k < 3; ++k) {
+          for(LO j = 0; j < 3; ++j) {
+            for(LO i = 0; i < 3; ++i) {
+              entries_h(entryOffset + k*9 + j*3 + i + cornerStencilLength*l) = columnOffset
                 + (k*lFineNodesPerDim[1]*lFineNodesPerDim[0]
 	          + (j - 2)*lFineNodesPerDim[0] + (i - 2))*blkSize + l;
-              values_h(entryOffset + (k*9 + j*3 + i)*blkSize + l)  = coeffs[k + 2]*coeffs[j]*coeffs[i];
+              values_h(entryOffset + k*9 + j*3 + i + cornerStencilLength*l)  = coeffs[k + 2]*coeffs[j]*coeffs[i];
             }
           }
         }
@@ -485,13 +485,13 @@ namespace MueLu {
       coordColumnOffset += (lFineNodesPerDim[2] - 1)*lFineNodesPerDim[1]*lFineNodesPerDim[0];
       columnOffset = coordColumnOffset*blkSize;
       entryOffset += (facePlaneOffset + (lCoarseNodesPerDim[2] - 2)*interiorPlaneOffset)*blkSize;
-      for(LO k = 0; k < 3; ++k) {
-        for(LO j = 0; j < 3; ++j) {
-          for(LO i = 0; i < 3; ++i) {
-            for(LO l = 0; l < blkSize; ++l) {
-              entries_h(entryOffset + (k*9 + j*3 + i)*blkSize + l) = columnOffset
+      for(LO l = 0; l < blkSize; ++l) {
+        for(LO k = 0; k < 3; ++k) {
+          for(LO j = 0; j < 3; ++j) {
+            for(LO i = 0; i < 3; ++i) {
+              entries_h(entryOffset + k*9 + j*3 + i + cornerStencilLength*l) = columnOffset
                 + ((k - 2)*lFineNodesPerDim[1]*lFineNodesPerDim[0] + (j - 2)*lFineNodesPerDim[0] + (i - 2))*blkSize + l;
-              values_h(entryOffset + (k*9 + j*3 + i)*blkSize + l)  = coeffs[k]*coeffs[j]*coeffs[i];
+              values_h(entryOffset + k*9 + j*3 + i + cornerStencilLength*l)  = coeffs[k]*coeffs[j]*coeffs[i];
             }
           }
         }
@@ -516,13 +516,13 @@ namespace MueLu {
         coordColumnOffset = (edgeIdx + 1)*3;
         columnOffset = coordColumnOffset*blkSize;
         entryOffset  = (cornerStencilLength + edgeIdx*edgeStencilLength)*blkSize;
-        for(LO k = 0; k < 3; ++k) {
-          for(LO j = 0; j < 3; ++j) {
-            for(LO i = 0; i < 5; ++i) {
-              for(LO l = 0; l < blkSize; ++l) {
-                entries_h(entryOffset + (k*15 + j*5 + i)*blkSize + l) = columnOffset
+        for(LO l = 0; l < blkSize; ++l) {
+          for(LO k = 0; k < 3; ++k) {
+            for(LO j = 0; j < 3; ++j) {
+              for(LO i = 0; i < 5; ++i) {
+                entries_h(entryOffset + k*15 + j*5 + i + edgeStencilLength*l) = columnOffset
                   + (k*lFineNodesPerDim[1]*lFineNodesPerDim[0] + j*lFineNodesPerDim[0] + i - 2)*blkSize + l;
-                values_h(entryOffset + (k*15 + j*5 + i)*blkSize + l)  = coeffs[k + 2]*coeffs[j + 2]*coeffs[i];
+                values_h(entryOffset + k*15 + j*5 + i + edgeStencilLength*l)  = coeffs[k + 2]*coeffs[j + 2]*coeffs[i];
               }
             }
           }
@@ -541,13 +541,13 @@ namespace MueLu {
         columnOffset = coordColumnOffset*blkSize;
         entryOffset  = (edgeLineOffset + (lCoarseNodesPerDim[1] - 2)*faceLineOffset
 	  + cornerStencilLength + edgeIdx*edgeStencilLength)*blkSize;
-        for(LO k = 0; k < 3; ++k) {
-          for(LO j = 0; j < 3; ++j) {
-            for(LO i = 0; i < 5; ++i) {
-              for(LO l = 0; l < blkSize; ++l) {
-                entries_h(entryOffset + (k*15 + j*5 + i)*blkSize + l) = columnOffset
+        for(LO l = 0; l < blkSize; ++l) {
+          for(LO k = 0; k < 3; ++k) {
+            for(LO j = 0; j < 3; ++j) {
+              for(LO i = 0; i < 5; ++i) {
+                entries_h(entryOffset + k*15 + j*5 + i + edgeStencilLength*l) = columnOffset
                   + (k*lFineNodesPerDim[1]*lFineNodesPerDim[0] + (j - 2)*lFineNodesPerDim[0] + i - 2)*blkSize + l;
-                values_h(entryOffset + (k*15 + j*5 + i)*blkSize + l)  = coeffs[k + 2]*coeffs[j]*coeffs[i];
+                values_h(entryOffset + k*15 + j*5 + i + edgeStencilLength*l)  = coeffs[k + 2]*coeffs[j]*coeffs[i];
               }
             }
           }
@@ -568,13 +568,13 @@ namespace MueLu {
         columnOffset = coordColumnOffset*blkSize;
         entryOffset  = (facePlaneOffset + (lCoarseNodesPerDim[2] - 2)*interiorPlaneOffset
 	  + cornerStencilLength + edgeIdx*edgeStencilLength)*blkSize;
-        for(LO k = 0; k < 3; ++k) {
-          for(LO j = 0; j < 3; ++j) {
-            for(LO i = 0; i < 5; ++i) {
-              for(LO l = 0; l < blkSize; ++l) {
-                entries_h(entryOffset + (k*15 + j*5 + i)*blkSize + l) = columnOffset
+        for(LO l = 0; l < blkSize; ++l) {
+          for(LO k = 0; k < 3; ++k) {
+            for(LO j = 0; j < 3; ++j) {
+              for(LO i = 0; i < 5; ++i) {
+                entries_h(entryOffset + k*15 + j*5 + i + edgeStencilLength*l) = columnOffset
                   + ((k - 2)*lFineNodesPerDim[1]*lFineNodesPerDim[0] + j*lFineNodesPerDim[0] + i - 2)*blkSize + l;
-                values_h(entryOffset + (k*15 + j*5 + i)*blkSize + l)  = coeffs[k]*coeffs[j + 2]*coeffs[i];
+                values_h(entryOffset + k*15 + j*5 + i + edgeStencilLength*l)  = coeffs[k]*coeffs[j + 2]*coeffs[i];
               }
             }
           }
@@ -596,14 +596,14 @@ namespace MueLu {
         entryOffset  =  (facePlaneOffset + (lCoarseNodesPerDim[2] - 2)*interiorPlaneOffset
           + edgeLineOffset + (lCoarseNodesPerDim[1] - 2)*faceLineOffset
 	  + cornerStencilLength + edgeIdx*edgeStencilLength)*blkSize;
-        for(LO k = 0; k < 3; ++k) {
-          for(LO j = 0; j < 3; ++j) {
-            for(LO i = 0; i < 5; ++i) {
-              for(LO l = 0; l < blkSize; ++l) {
-                entries_h(entryOffset + (k*15 + j*5 + i)*blkSize + l) = columnOffset
+        for(LO l = 0; l < blkSize; ++l) {
+          for(LO k = 0; k < 3; ++k) {
+            for(LO j = 0; j < 3; ++j) {
+              for(LO i = 0; i < 5; ++i) {
+                entries_h(entryOffset + k*15 + j*5 + i + edgeStencilLength*l) = columnOffset
                   + ((k - 2)*lFineNodesPerDim[1]*lFineNodesPerDim[0]
 		     + (j - 2)*lFineNodesPerDim[0] + i - 2)*blkSize + l;
-                values_h(entryOffset + (k*15 + j*5 + i)*blkSize + l)  = coeffs[k]*coeffs[j]*coeffs[i];
+                values_h(entryOffset + k*15 + j*5 + i + edgeStencilLength*l)  = coeffs[k]*coeffs[j]*coeffs[i];
               }
             }
           }
@@ -629,13 +629,13 @@ namespace MueLu {
         coordColumnOffset = (edgeIdx + 1)*3*lFineNodesPerDim[0];
         columnOffset = coordColumnOffset*blkSize;
         entryOffset  = (edgeLineOffset + edgeIdx*faceLineOffset)*blkSize;
-        for(LO k = 0; k < 3; ++k) {
-          for(LO j = 0; j < 5; ++j) {
-            for(LO i = 0; i < 3; ++i) {
-              for(LO l = 0; l < blkSize; ++l) {
-                entries_h(entryOffset + (k*15 + j*3 + i)*blkSize + l) = columnOffset
+        for(LO l = 0; l < blkSize; ++l) {
+          for(LO k = 0; k < 3; ++k) {
+            for(LO j = 0; j < 5; ++j) {
+              for(LO i = 0; i < 3; ++i) {
+                entries_h(entryOffset + k*15 + j*3 + i + edgeStencilLength*l) = columnOffset
                   + (k*lFineNodesPerDim[1]*lFineNodesPerDim[0] + (j - 2)*lFineNodesPerDim[0] + i)*blkSize + l;
-                values_h(entryOffset + (k*15 + j*3 + i)*blkSize + l)  = coeffs[k + 2]*coeffs[j]*coeffs[i + 2];
+                values_h(entryOffset + k*15 + j*3 + i + edgeStencilLength*l)  = coeffs[k + 2]*coeffs[j]*coeffs[i + 2];
               }
             }
           }
@@ -654,13 +654,13 @@ namespace MueLu {
         columnOffset = coordColumnOffset*blkSize;
         entryOffset  = (edgeLineOffset + edgeIdx*faceLineOffset
 	  + edgeStencilLength + (lCoarseNodesPerDim[0] - 2)*faceStencilLength)*blkSize;
-        for(LO k = 0; k < 3; ++k) {
-          for(LO j = 0; j < 5; ++j) {
-            for(LO i = 0; i < 3; ++i) {
-              for(LO l = 0; l < blkSize; ++l) {
-                entries_h(entryOffset + (k*15 + j*3 + i)*blkSize + l) = columnOffset
+        for(LO l = 0; l < blkSize; ++l) {
+          for(LO k = 0; k < 3; ++k) {
+            for(LO j = 0; j < 5; ++j) {
+              for(LO i = 0; i < 3; ++i) {
+                entries_h(entryOffset + k*15 + j*3 + i + edgeStencilLength*l) = columnOffset
                   + (k*lFineNodesPerDim[1]*lFineNodesPerDim[0] + (j - 2)*lFineNodesPerDim[0] + i - 2)*blkSize + l;
-                values_h(entryOffset + (k*15 + j*3 + i)*blkSize + l)  = coeffs[k + 2]*coeffs[j]*coeffs[i];
+                values_h(entryOffset + k*15 + j*3 + i + edgeStencilLength*l)  = coeffs[k + 2]*coeffs[j]*coeffs[i];
               }
             }
           }
@@ -681,13 +681,13 @@ namespace MueLu {
         columnOffset = coordColumnOffset*blkSize;
         entryOffset  = (facePlaneOffset + (lCoarseNodesPerDim[2] - 2)*interiorPlaneOffset
           + edgeLineOffset + edgeIdx*faceLineOffset)*blkSize;
-        for(LO k = 0; k < 3; ++k) {
-          for(LO j = 0; j < 5; ++j) {
-            for(LO i = 0; i < 3; ++i) {
-              for(LO l = 0; l < blkSize; ++l) {
-                entries_h(entryOffset + (k*15 + j*3 + i)*blkSize + l) = columnOffset
+        for(LO l = 0; l < blkSize; ++l) {
+          for(LO k = 0; k < 3; ++k) {
+            for(LO j = 0; j < 5; ++j) {
+              for(LO i = 0; i < 3; ++i) {
+                entries_h(entryOffset + k*15 + j*3 + i + edgeStencilLength*l) = columnOffset
                   + ((k - 2)*lFineNodesPerDim[1]*lFineNodesPerDim[0] + (j - 2)*lFineNodesPerDim[0] + i)*blkSize + l;
-                values_h(entryOffset + (k*15 + j*3 + i)*blkSize + l)  = coeffs[k]*coeffs[j]*coeffs[i + 2];
+                values_h(entryOffset + k*15 + j*3 + i + edgeStencilLength*l)  = coeffs[k]*coeffs[j]*coeffs[i + 2];
               }
             }
           }
@@ -709,14 +709,14 @@ namespace MueLu {
         entryOffset  = (facePlaneOffset + (lCoarseNodesPerDim[2] - 2)*interiorPlaneOffset
           + edgeLineOffset + edgeIdx*faceLineOffset
           + edgeStencilLength + (lCoarseNodesPerDim[0] - 2)*faceStencilLength)*blkSize;
-        for(LO k = 0; k < 3; ++k) {
-          for(LO j = 0; j < 5; ++j) {
-            for(LO i = 0; i < 3; ++i) {
-              for(LO l = 0; l < blkSize; ++l) {
-                entries_h(entryOffset + (k*15 + j*3 + i)*blkSize + l) = columnOffset
+        for(LO l = 0; l < blkSize; ++l) {
+          for(LO k = 0; k < 3; ++k) {
+            for(LO j = 0; j < 5; ++j) {
+              for(LO i = 0; i < 3; ++i) {
+                entries_h(entryOffset + k*15 + j*3 + i + edgeStencilLength*l) = columnOffset
                   + ((k - 2)*lFineNodesPerDim[1]*lFineNodesPerDim[0]
                   + (j - 2)*lFineNodesPerDim[0] + i - 2)*blkSize + l;
-                values_h(entryOffset + (k*15 + j*3 + i)*blkSize + l)  = coeffs[k]*coeffs[j]*coeffs[i];
+                values_h(entryOffset + k*15 + j*3 + i + edgeStencilLength*l)  = coeffs[k]*coeffs[j]*coeffs[i];
               }
             }
           }
@@ -742,13 +742,13 @@ namespace MueLu {
         coordColumnOffset = (edgeIdx + 1)*3*lFineNodesPerDim[1]*lFineNodesPerDim[0];
         columnOffset = coordColumnOffset*blkSize;
         entryOffset  = (facePlaneOffset + edgeIdx*interiorPlaneOffset)*blkSize;
-        for(LO k = 0; k < 5; ++k) {
-          for(LO j = 0; j < 3; ++j) {
-            for(LO i = 0; i < 3; ++i) {
-              for(LO l = 0; l < blkSize; ++l) {
-                entries_h(entryOffset + (k*9 + j*3 + i)*blkSize + l) = columnOffset
+        for(LO l = 0; l < blkSize; ++l) {
+          for(LO k = 0; k < 5; ++k) {
+            for(LO j = 0; j < 3; ++j) {
+              for(LO i = 0; i < 3; ++i) {
+                entries_h(entryOffset + k*9 + j*3 + i + edgeStencilLength*l) = columnOffset
                   + ((k - 2)*lFineNodesPerDim[1]*lFineNodesPerDim[0] + j*lFineNodesPerDim[0] + i)*blkSize + l;
-                values_h(entryOffset + (k*9 + j*3 + i)*blkSize + l)  = coeffs[k]*coeffs[j + 2]*coeffs[i + 2];
+                values_h(entryOffset + k*9 + j*3 + i + edgeStencilLength*l)  = coeffs[k]*coeffs[j + 2]*coeffs[i + 2];
               }
             }
           }
@@ -769,13 +769,13 @@ namespace MueLu {
         columnOffset = coordColumnOffset*blkSize;
         entryOffset  = (facePlaneOffset + faceLineOffset - edgeStencilLength
  	  + edgeIdx*interiorPlaneOffset)*blkSize;
-        for(LO k = 0; k < 5; ++k) {
-          for(LO j = 0; j < 3; ++j) {
-            for(LO i = 0; i < 3; ++i) {
-              for(LO l = 0; l < blkSize; ++l) {
-                entries_h(entryOffset + (k*9 + j*3 + i)*blkSize + l) = columnOffset
+        for(LO l = 0; l < blkSize; ++l) {
+          for(LO k = 0; k < 5; ++k) {
+            for(LO j = 0; j < 3; ++j) {
+              for(LO i = 0; i < 3; ++i) {
+                entries_h(entryOffset + k*9 + j*3 + i + edgeStencilLength*l) = columnOffset
                   + ((k - 2)*lFineNodesPerDim[1]*lFineNodesPerDim[0] + j*lFineNodesPerDim[0] + i - 2)*blkSize + l;
-                values_h(entryOffset + (k*9 + j*3 + i)*blkSize + l)  = coeffs[k]*coeffs[j + 2]*coeffs[i];
+                values_h(entryOffset + k*9 + j*3 + i + edgeStencilLength*l)  = coeffs[k]*coeffs[j + 2]*coeffs[i];
               }
             }
           }
@@ -796,13 +796,13 @@ namespace MueLu {
         columnOffset = coordColumnOffset*blkSize;
         entryOffset  = (facePlaneOffset + edgeIdx*interiorPlaneOffset + faceLineOffset
 	  + (lCoarseNodesPerDim[1] - 2)*interiorLineOffset)*blkSize;
-        for(LO k = 0; k < 5; ++k) {
-          for(LO j = 0; j < 3; ++j) {
-            for(LO i = 0; i < 3; ++i) {
-              for(LO l = 0; l < blkSize; ++l) {
-                entries_h(entryOffset + (k*9 + j*3 + i)*blkSize + l) = columnOffset
+        for(LO l = 0; l < blkSize; ++l) {
+          for(LO k = 0; k < 5; ++k) {
+            for(LO j = 0; j < 3; ++j) {
+              for(LO i = 0; i < 3; ++i) {
+                entries_h(entryOffset + k*9 + j*3 + i + edgeStencilLength*l) = columnOffset
                   + ((k - 2)*lFineNodesPerDim[1]*lFineNodesPerDim[0] + (j - 2)*lFineNodesPerDim[0] + i)*blkSize + l;
-                values_h(entryOffset + (k*9 + j*3 + i)*blkSize + l)  = coeffs[k]*coeffs[j]*coeffs[i + 2];
+                values_h(entryOffset + k*9 + j*3 + i + edgeStencilLength*l)  = coeffs[k]*coeffs[j]*coeffs[i + 2];
               }
             }
           }
@@ -821,14 +821,14 @@ namespace MueLu {
           + lFineNodesPerDim[1]*lFineNodesPerDim[0] - 1);
 	columnOffset = coordColumnOffset*blkSize;
         entryOffset  = (facePlaneOffset + (edgeIdx + 1)*interiorPlaneOffset - edgeStencilLength)*blkSize;
-        for(LO k = 0; k < 5; ++k) {
-          for(LO j = 0; j < 3; ++j) {
-            for(LO i = 0; i < 3; ++i) {
-              for(LO l = 0; l < blkSize; ++l) {
-                entries_h(entryOffset + (k*9 + j*3 + i)*blkSize + l) = columnOffset
+        for(LO l = 0; l < blkSize; ++l) {
+          for(LO k = 0; k < 5; ++k) {
+            for(LO j = 0; j < 3; ++j) {
+              for(LO i = 0; i < 3; ++i) {
+                entries_h(entryOffset + k*9 + j*3 + i + edgeStencilLength*l) = columnOffset
                   + ((k - 2)*lFineNodesPerDim[1]*lFineNodesPerDim[0]
 		     + (j - 2)*lFineNodesPerDim[0] + i - 2)*blkSize + l;
-                values_h(entryOffset + (k*9 + j*3 + i)*blkSize + l)  = coeffs[k]*coeffs[j]*coeffs[i];
+                values_h(entryOffset + k*9 + j*3 + i + edgeStencilLength*l)  = coeffs[k]*coeffs[j]*coeffs[i];
               }
             }
           }
@@ -856,13 +856,13 @@ namespace MueLu {
         columnOffset = coordColumnOffset*blkSize;
         entryOffset  = (edgeLineOffset + edgeStencilLength
 	  + gridIdx[1]*faceLineOffset + gridIdx[0]*faceStencilLength)*blkSize;
-        for(LO k = 0; k < 3; ++k) {
-          for(LO j = 0; j < 5; ++j) {
-            for(LO i = 0; i < 5; ++i) {
-              for(LO l = 0; l < blkSize; ++l) {
-                entries_h(entryOffset + (k*25 + j*5 + i)*blkSize + l) = columnOffset
+        for(LO l = 0; l < blkSize; ++l) {
+          for(LO k = 0; k < 3; ++k) {
+            for(LO j = 0; j < 5; ++j) {
+              for(LO i = 0; i < 5; ++i) {
+                entries_h(entryOffset + k*25 + j*5 + i + faceStencilLength*l) = columnOffset
                   + (k*lFineNodesPerDim[1]*lFineNodesPerDim[0] + (j - 2)*lFineNodesPerDim[0] + i - 2)*blkSize + l;
-                values_h(entryOffset + (k*25 + j*5 + i)*blkSize + l)  = coeffs[k + 2]*coeffs[j]*coeffs[i];
+                values_h(entryOffset + k*25 + j*5 + i + faceStencilLength*l)  = coeffs[k + 2]*coeffs[j]*coeffs[i];
               }
             }
           }
@@ -880,14 +880,14 @@ namespace MueLu {
         coordColumnOffset += (lFineNodesPerDim[2] - 1)*lFineNodesPerDim[1]*lFineNodesPerDim[0];
         columnOffset = coordColumnOffset*blkSize;
         entryOffset  += (facePlaneOffset + (lCoarseNodesPerDim[2] - 2)*interiorPlaneOffset)*blkSize;
-        for(LO k = 0; k < 3; ++k) {
-          for(LO j = 0; j < 5; ++j) {
-            for(LO i = 0; i < 5; ++i) {
-              for(LO l = 0; l < blkSize; ++l) {
-                entries_h(entryOffset + (k*25 + j*5 + i)*blkSize + l) = columnOffset
+        for(LO l = 0; l < blkSize; ++l) {
+          for(LO k = 0; k < 3; ++k) {
+            for(LO j = 0; j < 5; ++j) {
+              for(LO i = 0; i < 5; ++i) {
+                entries_h(entryOffset + k*25 + j*5 + i + faceStencilLength*l) = columnOffset
                   + ((k - 2)*lFineNodesPerDim[1]*lFineNodesPerDim[0]
 	          + (j - 2)*lFineNodesPerDim[0] + i - 2)*blkSize + l;
-                values_h(entryOffset + (k*25 + j*5 + i)*blkSize + l)  = coeffs[k]*coeffs[j]*coeffs[i];
+                values_h(entryOffset + k*25 + j*5 + i + faceStencilLength*l)  = coeffs[k]*coeffs[j]*coeffs[i];
               }
             }
           }
@@ -925,13 +925,13 @@ namespace MueLu {
         columnOffset = coordColumnOffset*blkSize;
         entryOffset  = (facePlaneOffset + gridIdx[2]*interiorPlaneOffset + edgeStencilLength
 	  + gridIdx[0]*faceStencilLength)*blkSize;
-        for(LO k = 0; k < 5; ++k) {
-          for(LO j = 0; j < 3; ++j) {
-            for(LO i = 0; i < 5; ++i) {
-              for(LO l = 0; l < blkSize; ++l) {
-                entries_h(entryOffset + (k*15 + j*5 + i)*blkSize + l) = columnOffset
+        for(LO l = 0; l < blkSize; ++l) {
+          for(LO k = 0; k < 5; ++k) {
+            for(LO j = 0; j < 3; ++j) {
+              for(LO i = 0; i < 5; ++i) {
+                entries_h(entryOffset + k*15 + j*5 + i + faceStencilLength*l) = columnOffset
                   + ((k - 2)*lFineNodesPerDim[1]*lFineNodesPerDim[0] + j*lFineNodesPerDim[0] + i - 2)*blkSize + l;
-                values_h(entryOffset + (k*15 + j*5 + i)*blkSize + l)  = coeffs[k]*coeffs[j + 2]*coeffs[i];
+                values_h(entryOffset + k*15 + j*5 + i + faceStencilLength*l)  = coeffs[k]*coeffs[j + 2]*coeffs[i];
               }
             }
           }
@@ -949,14 +949,14 @@ namespace MueLu {
         coordColumnOffset += (lFineNodesPerDim[1] - 1)*lFineNodesPerDim[0];
         columnOffset = coordColumnOffset*blkSize;
         entryOffset  += (faceLineOffset + (lCoarseNodesPerDim[1] - 2)*interiorLineOffset)*blkSize;
-        for(LO k = 0; k < 5; ++k) {
-          for(LO j = 0; j < 3; ++j) {
-            for(LO i = 0; i < 5; ++i) {
-              for(LO l = 0; l < blkSize; ++l) {
-                entries_h(entryOffset + (k*15 + j*5 + i)*blkSize + l) = columnOffset
+        for(LO l = 0; l < blkSize; ++l) {
+          for(LO k = 0; k < 5; ++k) {
+            for(LO j = 0; j < 3; ++j) {
+              for(LO i = 0; i < 5; ++i) {
+                entries_h(entryOffset + k*15 + j*5 + i + faceStencilLength*l) = columnOffset
                   + ((k - 2)*lFineNodesPerDim[1]*lFineNodesPerDim[0]
                   + (j - 2)*lFineNodesPerDim[0] + i - 2)*blkSize + l;
-                values_h(entryOffset + (k*15 + j*5 + i)*blkSize + l)  = coeffs[k]*coeffs[j]*coeffs[i];
+                values_h(entryOffset + k*15 + j*5 + i + faceStencilLength*l)  = coeffs[k]*coeffs[j]*coeffs[i];
               }
             }
           }
@@ -995,13 +995,13 @@ namespace MueLu {
 	columnOffset = coordColumnOffset*blkSize;
         entryOffset  = (facePlaneOffset + gridIdx[2]*interiorPlaneOffset + faceLineOffset
 	  + gridIdx[1]*interiorLineOffset)*blkSize;
-        for(LO k = 0; k < 5; ++k) {
-          for(LO j = 0; j < 5; ++j) {
-            for(LO i = 0; i < 3; ++i) {
-              for(LO l = 0; l < blkSize; ++l) {
-                entries_h(entryOffset + (k*15 + j*3 + i)*blkSize + l) = columnOffset
+        for(LO l = 0; l < blkSize; ++l) {
+          for(LO k = 0; k < 5; ++k) {
+            for(LO j = 0; j < 5; ++j) {
+              for(LO i = 0; i < 3; ++i) {
+                entries_h(entryOffset + k*15 + j*3 + i + faceStencilLength*l) = columnOffset
                   + ((k - 2)*lFineNodesPerDim[1]*lFineNodesPerDim[0] + (j - 2)*lFineNodesPerDim[0] + i)*blkSize + l;
-                values_h(entryOffset + (k*15 + j*3 + i)*blkSize + l)  = coeffs[k]*coeffs[j]*coeffs[i + 2];
+                values_h(entryOffset + k*15 + j*3 + i + faceStencilLength*l)  = coeffs[k]*coeffs[j]*coeffs[i + 2];
               }
             }
           }
@@ -1019,14 +1019,14 @@ namespace MueLu {
         coordColumnOffset += (lFineNodesPerDim[0] - 1);
         columnOffset = coordColumnOffset*blkSize;
         entryOffset  += (faceStencilLength + (lCoarseNodesPerDim[0] - 2)*interiorStencilLength)*blkSize;
-        for(LO k = 0; k < 5; ++k) {
-          for(LO j = 0; j < 5; ++j) {
-            for(LO i = 0; i < 3; ++i) {
-              for(LO l = 0; l < blkSize; ++l) {
-                entries_h(entryOffset + (k*15 + j*3 + i)*blkSize + l) = columnOffset
+        for(LO l = 0; l < blkSize; ++l) {
+          for(LO k = 0; k < 5; ++k) {
+            for(LO j = 0; j < 5; ++j) {
+              for(LO i = 0; i < 3; ++i) {
+                entries_h(entryOffset + k*15 + j*3 + i + faceStencilLength*l) = columnOffset
                   + ((k - 2)*lFineNodesPerDim[1]*lFineNodesPerDim[0]
   	          + (j - 2)*lFineNodesPerDim[0] + i - 2)*blkSize + l;
-                values_h(entryOffset + (k*15 + j*3 + i)*blkSize + l)  = coeffs[k]*coeffs[j]*coeffs[i];
+                values_h(entryOffset + k*15 + j*3 + i + faceStencilLength*l)  = coeffs[k]*coeffs[j]*coeffs[i];
               }
             }
           }
@@ -1096,10 +1096,10 @@ namespace MueLu {
           // Fill the column indices
           // and values in the approproate
           // views.
-        for(LO entryIdx = 0; entryIdx < interiorStencilLength; ++entryIdx) {
-          for(LO l = 0; l < blkSize; ++l) {
-            entries_h(entryOffset + entryIdx*blkSize + l) = columnOffset + coordColumnOffsets[entryIdx]*blkSize + l;
-            values_h(entryOffset + entryIdx*blkSize + l) = interiorValues[entryIdx];
+        for(LO l = 0; l < blkSize; ++l) {
+          for(LO entryIdx = 0; entryIdx < interiorStencilLength; ++entryIdx) {
+            entries_h(entryOffset + entryIdx + interiorStencilLength*l) = columnOffset + coordColumnOffsets[entryIdx]*blkSize + l;
+            values_h(entryOffset + entryIdx + interiorStencilLength*l) = interiorValues[entryIdx];
 	  }
         }
         for(int dim = 0; dim <numDimensions; ++dim) {

--- a/packages/muelu/test/unit_tests/RegionRFactory.cpp
+++ b/packages/muelu/test/unit_tests/RegionRFactory.cpp
@@ -568,14 +568,17 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionRFactory, RegionRFactElasticity3D, Scala
   // R->describe(out, Teuchos::VERB_EXTREME);
 
   if(numRanks == 1) {
-    TEST_EQUALITY(R->getGlobalNumRows(),                 18);
+    TEST_EQUALITY(R->getGlobalNumRows(),                 54);
     TEST_EQUALITY(R->getGlobalNumCols(),                588);
-    TEST_EQUALITY(R->getNodeNumRows(),                   18);
+    TEST_EQUALITY(R->getNodeNumRows(),                   54);
     TEST_EQUALITY(R->getCrsGraph()->getNodeNumCols(),   588);
-    TEST_EQUALITY(R->getNodeNumEntries(),               726);
+    TEST_EQUALITY(R->getNodeNumEntries(),              2178);
 
-    Array<LO> rowLength = {{27, 45, 27, 45, 75, 45, 27, 45, 27,
-                            27, 45, 27, 45, 75, 45, 27, 45, 27}};
+    Array<LO> rowLength = {{27, 27, 27, 45, 45, 45, 27, 27, 27, 45, 45, 45, 
+                            75, 75, 75, 45, 45, 45, 27, 27, 27, 45, 45, 45, 
+                            27, 27, 27, 27, 27, 27, 45, 45, 45, 27, 27, 27, 
+                            45, 45, 45, 75, 75, 75, 45, 45, 45, 27, 27, 27, 
+                            45, 45, 45, 27, 27, 27}};
     ArrayView<const LO> rowEntries;
     ArrayView<const SC> rowValues;
     for(int rowIdx = 0; rowIdx < static_cast<int>(R->getNodeNumRows()); ++rowIdx) {
@@ -584,48 +587,56 @@ TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL(RegionRFactory, RegionRFactElasticity3D, Scala
     }
 
   } else { // Running with 4 ranks
-    TEST_EQUALITY(R->getGlobalNumRows(),               32);
+    TEST_EQUALITY(R->getGlobalNumRows(),               96);
     TEST_EQUALITY(R->getCrsGraph()->getNodeNumCols(), 192);
-    TEST_EQUALITY(R->getNodeNumEntries(),             216);
+    TEST_EQUALITY(R->getNodeNumEntries(),             648);
 
     ArrayView<const LO> rowEntries;
     ArrayView<const SC> rowValues;
     if(myRank == 0) {
-      TEST_EQUALITY(R->getNodeNumRows(),                  8);
+      TEST_EQUALITY(R->getNodeNumRows(),                 24);
       TEST_EQUALITY(R->getCrsGraph()->getNodeNumCols(), 192);
-      TEST_EQUALITY(R->getNodeNumEntries(),             216);
+      TEST_EQUALITY(R->getNodeNumEntries(),             648);
 
-      Array<LO> rowLength = {{27, 27, 27, 27, 27, 27, 27, 27}};
+      Array<LO> rowLength = {{27, 27, 27, 27, 27, 27, 27, 27,
+                              27, 27, 27, 27, 27, 27, 27, 27,
+                              27, 27, 27, 27, 27, 27, 27, 27}};
       for(int rowIdx = 0; rowIdx < static_cast<int>(R->getNodeNumRows()); ++rowIdx) {
         R->getLocalRowView(rowIdx, rowEntries, rowValues);
         TEST_EQUALITY(static_cast<LO>(rowEntries.size()), rowLength[rowIdx]);
       }
     } else if(myRank == 1) {
-      TEST_EQUALITY(R->getNodeNumRows(),                  8);
+      TEST_EQUALITY(R->getNodeNumRows(),                 24);
       TEST_EQUALITY(R->getCrsGraph()->getNodeNumCols(), 192);
-      TEST_EQUALITY(R->getNodeNumEntries(),             216);
+      TEST_EQUALITY(R->getNodeNumEntries(),             648);
 
-      Array<LO> rowLength = {{27, 27, 27, 27, 27, 27, 27, 27}};
+      Array<LO> rowLength = {{27, 27, 27, 27, 27, 27, 27, 27,
+                              27, 27, 27, 27, 27, 27, 27, 27,
+                              27, 27, 27, 27, 27, 27, 27, 27}};
       for(int rowIdx = 0; rowIdx < static_cast<int>(R->getNodeNumRows()); ++rowIdx) {
         R->getLocalRowView(rowIdx, rowEntries, rowValues);
         TEST_EQUALITY(static_cast<LO>(rowEntries.size()), rowLength[rowIdx]);
       }
     } else if(myRank == 2) {
-      TEST_EQUALITY(R->getNodeNumRows(),                  8);
+      TEST_EQUALITY(R->getNodeNumRows(),                 24);
       TEST_EQUALITY(R->getCrsGraph()->getNodeNumCols(), 192);
-      TEST_EQUALITY(R->getNodeNumEntries(),             216);
+      TEST_EQUALITY(R->getNodeNumEntries(),             648);
 
-      Array<LO> rowLength = {{27, 27, 27, 27, 27, 27, 27, 27}};
+      Array<LO> rowLength = {{27, 27, 27, 27, 27, 27, 27, 27,
+                              27, 27, 27, 27, 27, 27, 27, 27,
+                              27, 27, 27, 27, 27, 27, 27, 27}};
       for(int rowIdx = 0; rowIdx < static_cast<int>(R->getNodeNumRows()); ++rowIdx) {
         R->getLocalRowView(rowIdx, rowEntries, rowValues);
         TEST_EQUALITY(static_cast<LO>(rowEntries.size()), rowLength[rowIdx]);
       }
     } else if(myRank == 3) {
-      TEST_EQUALITY(R->getNodeNumRows(),                  8);
+      TEST_EQUALITY(R->getNodeNumRows(),                 24);
       TEST_EQUALITY(R->getCrsGraph()->getNodeNumCols(), 192);
-      TEST_EQUALITY(R->getNodeNumEntries(),             216);
+      TEST_EQUALITY(R->getNodeNumEntries(),             648);
 
-      Array<LO> rowLength = {{27, 27, 27, 27, 27, 27, 27, 27}};
+      Array<LO> rowLength = {{27, 27, 27, 27, 27, 27, 27, 27,
+                              27, 27, 27, 27, 27, 27, 27, 27,
+                              27, 27, 27, 27, 27, 27, 27, 27}};
       for(int rowIdx = 0; rowIdx < static_cast<int>(R->getNodeNumRows()); ++rowIdx) {
         R->getLocalRowView(rowIdx, rowEntries, rowValues);
         TEST_EQUALITY(static_cast<LO>(rowEntries.size()), rowLength[rowIdx]);


### PR DESCRIPTION
~~Please do not merge this yet. I want to squash the commits down, but I don't want to do so until I see how it turns out.~~
Edit: everything has been squashed.
@trilinos/muelu 

There was a flaw in the logic in `RegionRFactory` that was the source of the issue. For a restrictor, the block size should be the outer loop. In addition, `MakeRegionMatrices` was throwing away the block size of the matrix A from which it was created, which caused some region tests to look like they were correctly preparing the 3 DOF per node version, when in fact the matrices in `regionGrpMats` were not treated as having 3 DOFs per node.

## Testing
I noticed a significant improvement in the iterations to solve the related regression tests. ~~I haven't run other tests yet because I want to see how this impacts the repartitioning, in particular.~~
Edit: all MueLu experimental tests pass.

~~@pohm01 can you please test your repartitioning examples based off this branch? I see an error when I try to run the repartitioning example you sent, but I also see the same error when I change the input xml from the `linear_R` flavor to the `linear` flavor.~~
Edit: I confirmed with Peter, and everything looks good when combined with his PR now.