### PR TITLE
Intrepid2: modifications to avoid unnecessary copies of Fad types during test comparisons.

### DIFF
--- a/packages/intrepid2/src/Shared/Intrepid2_TestUtils.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_TestUtils.hpp
@@ -67,7 +67,7 @@ template<typename ScalarType>
 using ViewType = Kokkos::DynRankView<ScalarType,Kokkos::DefaultExecutionSpace>;
 
 template<typename ScalarType>
-inline bool valuesAreSmall(ScalarType a, ScalarType b, double epsilon)
+inline bool valuesAreSmall(const ScalarType &a, const ScalarType &b, const double &epsilon)
 {
   using std::abs;
   return (abs(a) < epsilon) && (abs(b) < epsilon);

--- a/packages/intrepid2/unit-test/Discretization/Basis/HierarchicalBases/AnalyticPolynomialsMatchTests.cpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HierarchicalBases/AnalyticPolynomialsMatchTests.cpp
@@ -896,8 +896,8 @@ namespace
         int fieldOrdinalDerived = dofMapToDerivedHost(fieldOrdinalStandard);
         if (scalarValued)
         {
-          OutputScalar standardValue = standardOutputViewHost(fieldOrdinalStandard,pointOrdinal);
-          OutputScalar derivedValue  =  derivedOutputViewHost(fieldOrdinalDerived, pointOrdinal);
+          const OutputScalar & standardValue = standardOutputViewHost(fieldOrdinalStandard,pointOrdinal);
+          const OutputScalar & derivedValue  =  derivedOutputViewHost(fieldOrdinalDerived, pointOrdinal);
           
           bool valuesMatch = true;
           bool valuesAreBothSmall = valuesAreSmall(standardValue, derivedValue, tol);
@@ -940,8 +940,8 @@ namespace
           int dkcard = standardOutputView.extent_int(2);
           for (int d=0; d<dkcard; d++)
           {
-            OutputScalar standardValue = standardOutputViewHost(fieldOrdinalStandard,pointOrdinal,d);
-            OutputScalar derivedValue  =  derivedOutputViewHost(fieldOrdinalDerived, pointOrdinal,d);
+            const OutputScalar & standardValue = standardOutputViewHost(fieldOrdinalStandard,pointOrdinal,d);
+            const OutputScalar & derivedValue  =  derivedOutputViewHost(fieldOrdinalDerived, pointOrdinal,d);
             
             bool valuesAreBothSmall = valuesAreSmall(standardValue, derivedValue, tol);
             if (!valuesAreBothSmall)


### PR DESCRIPTION
Intrepid2: modifications to avoid unnecessary copies of Fad types during test comparisons.

See #8148.