### PR TITLE
Intrepid2: prototype faster Fad comparisons for tests

### DIFF
--- a/packages/intrepid2/src/Shared/Intrepid2_TestUtils.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_TestUtils.hpp
@@ -74,17 +74,18 @@ namespace Intrepid2
   //! Adapted from Teuchos::relErr(); for use in code that may be executed on device.
   template <class Scalar1, class Scalar2>
   KOKKOS_INLINE_FUNCTION
-  typename Teuchos::ScalarTraits< typename std::common_type<Scalar1,Scalar2>::type >::magnitudeType
-  relErr( const Scalar1 &s1, const Scalar2 &s2, const typename Teuchos::ScalarTraits< typename std::common_type<Scalar1,Scalar2>::type >::magnitudeType &smallNumber )
+  bool
+  relErrMeetsTol( const Scalar1 &s1, const Scalar2 &s2, const typename Teuchos::ScalarTraits< typename std::common_type<Scalar1,Scalar2>::type >::magnitudeType &smallNumber, const double &tol )
   {
-    typedef typename std::common_type<Scalar1,Scalar2>::type Scalar;
-    typedef Teuchos::ScalarTraits<Scalar> ST;
-    return
-      ST::magnitude( s1 - s2 )
+    using std::max;
+    using std::fabs;
+    auto relErr =
+      fabs( s1 - s2 )
       / (
         smallNumber
-        + std::max( ST::magnitude(s1), ST::magnitude(s2) )
+        + max( fabs(s1), fabs(s2) )
         );
+    return relErr < tol;
   }
 
   template <class SomeViewType>

--- a/packages/intrepid2/src/Shared/Intrepid2_TestUtils.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_TestUtils.hpp
@@ -67,7 +67,7 @@ template<typename ScalarType>
 using ViewType = Kokkos::DynRankView<ScalarType,Kokkos::DefaultExecutionSpace>;
 
 template<typename ScalarType>
-inline bool valuesAreSmall(ScalarType a, ScalarType b, double epsilon)
+inline bool valuesAreSmall(const ScalarType &a, const ScalarType &b, const double &epsilon)
 {
   using std::abs;
   return (abs(a) < epsilon) && (abs(b) < epsilon);

--- a/packages/intrepid2/src/Shared/Intrepid2_TestUtils.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_TestUtils.hpp
@@ -77,9 +77,7 @@ namespace Intrepid2
   bool
   relErrMeetsTol( const Scalar1 &s1, const Scalar2 &s2, const typename Teuchos::ScalarTraits< typename std::common_type<Scalar1,Scalar2>::type >::magnitudeType &smallNumber, const double &tol )
   {
-#ifndef CUDA
     using std::fabs;
-#endif
     const auto s1Abs = fabs(s1);
     const auto s2Abs = fabs(s2);
     const auto maxAbs = (s1Abs > s2Abs) ? s1Abs : s2Abs;

--- a/packages/intrepid2/src/Shared/Intrepid2_TestUtils.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_TestUtils.hpp
@@ -78,10 +78,11 @@ namespace Intrepid2
   relErrMeetsTol( const Scalar1 &s1, const Scalar2 &s2, const typename Teuchos::ScalarTraits< typename std::common_type<Scalar1,Scalar2>::type >::magnitudeType &smallNumber, const double &tol )
   {
     using std::fabs;
-    const auto s1Abs = fabs(s1);
-    const auto s2Abs = fabs(s2);
-    const auto maxAbs = (s1Abs > s2Abs) ? s1Abs : s2Abs;
-    auto relErr = fabs( s1 - s2 ) / ( smallNumber + maxAbs );
+    using Scalar        = typename std::common_type<Scalar1,Scalar2>::type;
+    const Scalar s1Abs  = fabs(s1);
+    const Scalar s2Abs  = fabs(s2);
+    const Scalar maxAbs = (s1Abs > s2Abs) ? s1Abs : s2Abs;
+    const Scalar relErr = fabs( s1 - s2 ) / ( smallNumber + maxAbs );
     return relErr < tol;
   }
 

--- a/packages/intrepid2/src/Shared/Intrepid2_TestUtils.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_TestUtils.hpp
@@ -77,14 +77,13 @@ namespace Intrepid2
   bool
   relErrMeetsTol( const Scalar1 &s1, const Scalar2 &s2, const typename Teuchos::ScalarTraits< typename std::common_type<Scalar1,Scalar2>::type >::magnitudeType &smallNumber, const double &tol )
   {
-    using std::max;
+#ifndef CUDA
     using std::fabs;
-    auto relErr =
-      fabs( s1 - s2 )
-      / (
-        smallNumber
-        + max( fabs(s1), fabs(s2) )
-        );
+#endif
+    const auto s1Abs = fabs(s1);
+    const auto s2Abs = fabs(s2);
+    const auto maxAbs = (s1Abs > s2Abs) ? s1Abs : s2Abs;
+    auto relErr = fabs( s1 - s2 ) / ( smallNumber + maxAbs );
     return relErr < tol;
   }
 

--- a/packages/intrepid2/src/Shared/Intrepid2_TestUtils.hpp
+++ b/packages/intrepid2/src/Shared/Intrepid2_TestUtils.hpp
@@ -85,11 +85,6 @@ namespace Intrepid2
     return relErr < tol;
   }
 
-  template <class SomeViewType>
-  size_t extraViewDimensionForAllocation(SomeViewType &someView)
-  {
-    
-  }
 // TODO: include the rest of this file in the Intrepid2 namespace
 }
 

--- a/packages/intrepid2/unit-test/Discretization/Basis/HierarchicalBases/AnalyticPolynomialsMatchTests.cpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HierarchicalBases/AnalyticPolynomialsMatchTests.cpp
@@ -787,6 +787,7 @@ namespace
   {
     using namespace Intrepid2;
     using BasisPtr = typename DerivedNodalBasisFamily::BasisPtr;
+    using ExecutionSpace = typename DerivedNodalBasisFamily::ExecutionSpace;
     using Teuchos::rcp;
     
     BasisPtr derivedBasis, standardBasis;
@@ -829,10 +830,10 @@ namespace
     using ValueType    = typename ScalarViewType::value_type;
     using ResultLayout = typename DeduceLayout< ScalarViewType >::result_layout;
     using DeviceType = typename ScalarViewType::device_type;
-    using ViewType = Kokkos::DynRankView<ValueType, ResultLayout, DeviceType >;
+    using AllocatableScalarViewType = Kokkos::DynRankView<ValueType, ResultLayout, DeviceType >;
     
-    ViewType dofCoordsStandard("dofCoordsStandard", standardCardinality, spaceDim);
-    ViewType dofCoordsDerived ("dofCoordsDerived",  standardCardinality, spaceDim);
+    AllocatableScalarViewType dofCoordsStandard ("dofCoordsStandard", standardCardinality, spaceDim);
+    AllocatableScalarViewType dofCoordsDerived  ("dofCoordsDerived",  standardCardinality, spaceDim);
     standardBasis->getDofCoords(dofCoordsStandard);
     derivedBasis-> getDofCoords(dofCoordsDerived );
     
@@ -882,9 +883,61 @@ namespace
     standardBasis->getValues(standardOutputView, inputPointsView, op);
     derivedBasis->getValues(derivedOutputView, inputPointsView, op);
     
-    auto standardOutputViewHost = getHostCopy(standardOutputView);
-    auto derivedOutputViewHost  = getHostCopy(derivedOutputView);
-    auto inputPointsViewHost    = getHostCopy(inputPointsView);
+    ViewType<bool> valuesAreBothSmall;
+    auto smallNumber = Intrepid2::smallNumber<OutputScalar>();
+    using magnitude_type = decltype(smallNumber);
+    ViewType<bool> relativeErrorsMeetTol;
+    if (standardOutputView.rank() == 2)
+    {
+      valuesAreBothSmall    = getView<bool>("valuesAreBothSmall",    standardCardinality, numPoints);
+      relativeErrorsMeetTol = getView<bool>("relativeErrorsMeetTol", standardCardinality, numPoints);
+      
+      using RangePolicy = Kokkos::MDRangePolicy < ExecutionSpace, Kokkos::Rank<2>, Kokkos::IndexType<ordinal_type> >;
+      RangePolicy policy( { 0, 0 }, { standardCardinality, numPoints} );
+      
+      Kokkos::parallel_for( policy,
+      KOKKOS_LAMBDA (const int &fieldOrdinalStandard, const int &pointOrdinal )
+      {
+        const int & fieldOrdinalDerived = dofMapToDerived(fieldOrdinalStandard);
+        
+        const OutputScalar & standardValue = standardOutputView(fieldOrdinalStandard, pointOrdinal);
+        const OutputScalar & derivedValue  =  derivedOutputView(fieldOrdinalDerived,  pointOrdinal);
+
+        valuesAreBothSmall(fieldOrdinalStandard, pointOrdinal) = valuesAreSmall(standardValue, derivedValue, tol);
+        auto relError = relErr(standardValue, derivedValue, smallNumber);
+        relativeErrorsMeetTol(fieldOrdinalStandard, pointOrdinal) = relError < tol;
+      }
+      );
+    }
+    else
+    {
+      const int valuesPerPoint = standardOutputView.extent_int(2);
+      valuesAreBothSmall    = getView<bool>("valuesAreBothSmall",    standardCardinality, numPoints, valuesPerPoint);
+      relativeErrorsMeetTol = getView<bool>("relativeErrorsMeetTol", standardCardinality, numPoints, valuesPerPoint);
+      
+      using RangePolicy = Kokkos::MDRangePolicy < ExecutionSpace, Kokkos::Rank<3>, Kokkos::IndexType<ordinal_type> >;
+      RangePolicy policy( { 0, 0, 0 }, { standardCardinality, numPoints,  valuesPerPoint} );
+      
+      Kokkos::parallel_for( policy,
+      KOKKOS_LAMBDA (const int &fieldOrdinalStandard, const int &pointOrdinal, const int &valueOrdinal )
+      {
+        const int & fieldOrdinalDerived = dofMapToDerived(fieldOrdinalStandard);
+        
+        const OutputScalar & standardValue = standardOutputView(fieldOrdinalStandard, pointOrdinal, valueOrdinal);
+        const OutputScalar & derivedValue  =  derivedOutputView(fieldOrdinalDerived,  pointOrdinal, valueOrdinal);
+
+        valuesAreBothSmall(fieldOrdinalStandard, pointOrdinal, valueOrdinal) = valuesAreSmall(standardValue, derivedValue, tol);
+        auto relError = relErr(standardValue, derivedValue, smallNumber);
+        relativeErrorsMeetTol(fieldOrdinalStandard, pointOrdinal, valueOrdinal) = relError < tol;
+      }
+      );
+    }
+    
+    auto relativeErrorsMeetTolHost = getHostCopy(relativeErrorsMeetTol);
+    auto valuesAreBothSmallHost    = getHostCopy(valuesAreBothSmall);
+    auto standardOutputViewHost    = getHostCopy(standardOutputView);
+    auto derivedOutputViewHost     = getHostCopy(derivedOutputView);
+    auto inputPointsViewHost       = getHostCopy(inputPointsView);
     
     bool scalarValued = (standardOutputView.rank() == 2); // F,P -- if vector-valued, F,P,D or F,P,Dk
     
@@ -896,18 +949,17 @@ namespace
         int fieldOrdinalDerived = dofMapToDerivedHost(fieldOrdinalStandard);
         if (scalarValued)
         {
-          const OutputScalar & standardValue = standardOutputViewHost(fieldOrdinalStandard,pointOrdinal);
-          const OutputScalar & derivedValue  =  derivedOutputViewHost(fieldOrdinalDerived, pointOrdinal);
-          
           bool valuesMatch = true;
-          bool valuesAreBothSmall = valuesAreSmall(standardValue, derivedValue, tol);
-          if (!valuesAreBothSmall)
+          if (!valuesAreBothSmall(fieldOrdinalStandard,pointOrdinal))
           {
-            TEUCHOS_TEST_FLOATING_EQUALITY(standardValue, derivedValue, tol, out, valuesMatch);
+            valuesMatch = relativeErrorsMeetTolHost(fieldOrdinalStandard,pointOrdinal);
           }
           
           if (!valuesMatch)
           {
+            const OutputScalar & standardValue = standardOutputViewHost(fieldOrdinalStandard,pointOrdinal);
+            const OutputScalar & derivedValue  =  derivedOutputViewHost(fieldOrdinalDerived, pointOrdinal);
+            
             pointPassed = false;
             if (fs == Intrepid2::FUNCTION_SPACE_HCURL)
             {
@@ -940,13 +992,9 @@ namespace
           int dkcard = standardOutputView.extent_int(2);
           for (int d=0; d<dkcard; d++)
           {
-            const OutputScalar & standardValue = standardOutputViewHost(fieldOrdinalStandard,pointOrdinal,d);
-            const OutputScalar & derivedValue  =  derivedOutputViewHost(fieldOrdinalDerived, pointOrdinal,d);
-            
-            bool valuesAreBothSmall = valuesAreSmall(standardValue, derivedValue, tol);
-            if (!valuesAreBothSmall)
+            if (!valuesAreBothSmall(fieldOrdinalStandard,pointOrdinal,d))
             {
-              TEUCHOS_TEST_FLOATING_EQUALITY(standardValue, derivedValue, tol, out, valuesMatch);
+              valuesMatch = valuesMatch && relativeErrorsMeetTolHost(fieldOrdinalStandard,pointOrdinal,d);
             }
           }
           

--- a/packages/intrepid2/unit-test/Discretization/Basis/HierarchicalBases/AnalyticPolynomialsMatchTests.cpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HierarchicalBases/AnalyticPolynomialsMatchTests.cpp
@@ -885,7 +885,6 @@ namespace
     
     ViewType<bool> valuesAreBothSmall;
     auto smallNumber = Intrepid2::smallNumber<OutputScalar>();
-    using magnitude_type = decltype(smallNumber);
     ViewType<bool> relativeErrorsMeetTol;
     if (standardOutputView.rank() == 2)
     {

--- a/packages/intrepid2/unit-test/Discretization/Basis/HierarchicalBases/AnalyticPolynomialsMatchTests.cpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HierarchicalBases/AnalyticPolynomialsMatchTests.cpp
@@ -946,9 +946,6 @@ namespace
         int fieldOrdinalDerived = dofMapToDerivedHost(fieldOrdinalStandard);
         if (scalarValued)
         {
-          const OutputScalar & standardValue = standardOutputViewHost(fieldOrdinalStandard,pointOrdinal);
-          const OutputScalar & derivedValue  =  derivedOutputViewHost(fieldOrdinalDerived, pointOrdinal);
-          
           bool valuesMatch = true;
           if (!valuesAreBothSmall(fieldOrdinalStandard,pointOrdinal))
           {

--- a/packages/intrepid2/unit-test/Discretization/Basis/HierarchicalBases/AnalyticPolynomialsMatchTests.cpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HierarchicalBases/AnalyticPolynomialsMatchTests.cpp
@@ -903,9 +903,8 @@ namespace
         const OutputScalar & standardValue = standardOutputView(fieldOrdinalStandard, pointOrdinal);
         const OutputScalar & derivedValue  =  derivedOutputView(fieldOrdinalDerived,  pointOrdinal);
 
-        valuesAreBothSmall(fieldOrdinalStandard, pointOrdinal) = valuesAreSmall(standardValue, derivedValue, tol);
-        auto relError = relErr(standardValue, derivedValue, smallNumber);
-        relativeErrorsMeetTol(fieldOrdinalStandard, pointOrdinal) = relError < tol;
+        valuesAreBothSmall   (fieldOrdinalStandard, pointOrdinal) = valuesAreSmall(standardValue, derivedValue, tol);
+        relativeErrorsMeetTol(fieldOrdinalStandard, pointOrdinal) = relErrMeetsTol(standardValue, derivedValue, smallNumber, tol);;
       }
       );
     }
@@ -926,9 +925,8 @@ namespace
         const OutputScalar & standardValue = standardOutputView(fieldOrdinalStandard, pointOrdinal, valueOrdinal);
         const OutputScalar & derivedValue  =  derivedOutputView(fieldOrdinalDerived,  pointOrdinal, valueOrdinal);
 
-        valuesAreBothSmall(fieldOrdinalStandard, pointOrdinal, valueOrdinal) = valuesAreSmall(standardValue, derivedValue, tol);
-        auto relError = relErr(standardValue, derivedValue, smallNumber);
-        relativeErrorsMeetTol(fieldOrdinalStandard, pointOrdinal, valueOrdinal) = relError < tol;
+        valuesAreBothSmall   (fieldOrdinalStandard, pointOrdinal, valueOrdinal) = valuesAreSmall(standardValue, derivedValue, tol);
+        relativeErrorsMeetTol(fieldOrdinalStandard, pointOrdinal, valueOrdinal) = relErrMeetsTol(standardValue, derivedValue, smallNumber, tol);;
       }
       );
     }

--- a/packages/intrepid2/unit-test/Discretization/Basis/HierarchicalBases/AnalyticPolynomialsMatchTests.cpp
+++ b/packages/intrepid2/unit-test/Discretization/Basis/HierarchicalBases/AnalyticPolynomialsMatchTests.cpp
@@ -896,8 +896,8 @@ namespace
         int fieldOrdinalDerived = dofMapToDerivedHost(fieldOrdinalStandard);
         if (scalarValued)
         {
-          OutputScalar standardValue = standardOutputViewHost(fieldOrdinalStandard,pointOrdinal);
-          OutputScalar derivedValue  =  derivedOutputViewHost(fieldOrdinalDerived, pointOrdinal);
+          const OutputScalar & standardValue = standardOutputViewHost(fieldOrdinalStandard,pointOrdinal);
+          const OutputScalar & derivedValue  =  derivedOutputViewHost(fieldOrdinalDerived, pointOrdinal);
           
           bool valuesMatch = true;
           bool valuesAreBothSmall = valuesAreSmall(standardValue, derivedValue, tol);
@@ -940,8 +940,8 @@ namespace
           int dkcard = standardOutputView.extent_int(2);
           for (int d=0; d<dkcard; d++)
           {
-            OutputScalar standardValue = standardOutputViewHost(fieldOrdinalStandard,pointOrdinal,d);
-            OutputScalar derivedValue  =  derivedOutputViewHost(fieldOrdinalDerived, pointOrdinal,d);
+            const OutputScalar & standardValue = standardOutputViewHost(fieldOrdinalStandard,pointOrdinal,d);
+            const OutputScalar & derivedValue  =  derivedOutputViewHost(fieldOrdinalDerived, pointOrdinal,d);
             
             bool valuesAreBothSmall = valuesAreSmall(standardValue, derivedValue, tol);
             if (!valuesAreBothSmall)


### PR DESCRIPTION
@trilinos/intrepid2

## Motivation
Following on #8148, this PR prototypes a new mechanism for performing error measurements, shifting more of the burden to the device.  In the Fad test we're working with, this reduced the runtime on ride by a factor of about 6.  (#8148 itself had reduced the runtime by about a factor of 5, so this represents a cumulative 30x speedup.)

The ultimate idea is to revise the testFloatingEquality() methods that we define in TestUtils to take advantage of this new mechanism, thereby speeding up all tests that take advantage of those.