### PR TITLE
Panzer: add option to shift mesh gids above 32-bit int limit for testing

### DIFF
--- a/packages/panzer/adapters-stk/example/main_driver/energy-ss-blocked.xml
+++ b/packages/panzer/adapters-stk/example/main_driver/energy-ss-blocked.xml
@@ -19,6 +19,7 @@
                 <Parameter name="Y0" type="double" value="0.0" />
                 <Parameter name="Xf" type="double" value="1.0" />
                 <Parameter name="Yf" type="double" value="1.0" />
+                <Parameter name="Offset mesh GIDs above 32-bit int limit" type="string" value="ON" />
             </ParameterList>
         </ParameterList>
 

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_SquareQuadMeshFactory.cpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_SquareQuadMeshFactory.cpp
@@ -43,6 +43,7 @@
 #include <Panzer_STK_SquareQuadMeshFactory.hpp>
 #include <Teuchos_TimeMonitor.hpp>
 #include <PanzerAdaptersSTK_config.hpp>
+#include "Teuchos_StandardParameterEntryValidators.hpp" // for plist validation
 
 // #define ENABLE_UNIFORM
 
@@ -194,6 +195,8 @@ void SquareQuadMeshFactory::setParameterList(const Teuchos::RCP<Teuchos::Paramet
    xProcs_ = paramList->get<int>("X Procs");
    yProcs_ = paramList->get<int>("Y Procs");
 
+   offsetGIDs_ = (paramList->get<std::string>("Offset mesh GIDs above 32-bit int limit") == "ON") ? true : false;
+
    // read in periodic boundary conditions
    parsePeriodicBCList(Teuchos::rcpFromRef(paramList->sublist("Periodic BCs")),periodicBCVec_);
 }
@@ -221,6 +224,13 @@ Teuchos::RCP<const Teuchos::ParameterList> SquareQuadMeshFactory::getValidParame
 
       defaultParams->set<int>("X Elements",5);
       defaultParams->set<int>("Y Elements",5);
+
+      Teuchos::setStringToIntegralParameter<int>(
+        "Offset mesh GIDs above 32-bit int limit",
+        "OFF",
+        "If 64-bit GIDs are supported, the mesh element and node global indices will start at a value greater than 32-bit limit.",
+        Teuchos::tuple<std::string>("OFF", "ON"),
+        defaultParams.get());
 
       Teuchos::ParameterList & bcs = defaultParams->sublist("Periodic BCs");
       bcs.set<int>("Count",0); // no default periodic boundary conditions
@@ -315,13 +325,19 @@ void SquareQuadMeshFactory::buildBlock(stk::ParallelMachine /* parallelMach */,i
  
    std::vector<double> coord(2,0.0);
 
+   offset_ = 0;
+   if (offsetGIDs_) {
+     if (std::numeric_limits<panzer::GlobalOrdinal>::max() > std::numeric_limits<panzer::LocalOrdinal>::max())
+       offset_ = panzer::GlobalOrdinal(std::numeric_limits<panzer::LocalOrdinal>::max()) + 1;
+   }
+
    // build the nodes
    for(int nx=myXElems_start;nx<myXElems_end+1;++nx) {
       coord[0] = this->getMeshCoord(nx, deltaX, x0_);
       for(int ny=myYElems_start;ny<myYElems_end+1;++ny) {
          coord[1] = this->getMeshCoord(ny, deltaY, y0_);
 
-         mesh.addNode(ny*(totalXElems+1)+nx+1,coord);
+         mesh.addNode(ny*(totalXElems+1)+nx+1+offset_,coord);
       }
    }
 
@@ -332,12 +348,15 @@ void SquareQuadMeshFactory::buildBlock(stk::ParallelMachine /* parallelMach */,i
    // build the elements
    for(int nx=myXElems_start;nx<myXElems_end;++nx) {
       for(int ny=myYElems_start;ny<myYElems_end;++ny) {
-         stk::mesh::EntityId gid = totalXElems*ny+nx+1;
+         stk::mesh::EntityId gid = totalXElems*ny+nx+1 + offset_;
          std::vector<stk::mesh::EntityId> nodes(4);
          nodes[0] = nx+1+ny*(totalXElems+1);
          nodes[1] = nodes[0]+1;
          nodes[2] = nodes[1]+(totalXElems+1);
          nodes[3] = nodes[2]-1;
+
+         for (int i=0; i < 4; ++i)
+           nodes[i] += offset_;
 
          RCP<ElementDescriptor> ed = rcp(new ElementDescriptor(gid,nodes));
          mesh.addElement(ed,block);
@@ -425,6 +444,9 @@ void SquareQuadMeshFactory::addSideSets(STK_Interface & mesh) const
    for(itr=localElmts.begin();itr!=localElmts.end();++itr) {
       stk::mesh::Entity element = (*itr);
       stk::mesh::EntityId gid = mesh.elementGlobalId(element);
+
+      // reverse the offset for local gid numbering scheme
+      gid -= offset_;
 
       std::size_t nx,ny;
       ny = (gid-1) / totalXElems;
@@ -527,7 +549,7 @@ void SquareQuadMeshFactory::addNodeSets(STK_Interface & mesh) const
    if(machRank_==0) 
    {
       // add zero node to lower_left node set
-      stk::mesh::Entity node = bulkData->get_entity(mesh.getNodeRank(),1);
+      stk::mesh::Entity node = bulkData->get_entity(mesh.getNodeRank(),1 + offset_);
       mesh.addEntityToNodeset(node,lower_left);
 
       // add zero node to origin node set

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_SquareQuadMeshFactory.hpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_SquareQuadMeshFactory.hpp
@@ -107,6 +107,10 @@ protected:
 
    mutable unsigned int machRank_, machSize_;
    mutable Teuchos::Tuple<std::size_t,2> procTuple_;
+
+  /// If true, offset mesh GIDs to exercise 32-bit limits.
+  bool offsetGIDs_;
+  mutable stk::mesh::EntityId offset_;
 };
 
 }


### PR DESCRIPTION
Added an option to the inline quad mesh generator to shift the element
and node gids in stk to all be greater than the 32-bit int limit. This
allows small meshes to be used to test certain code paths "at scale"
for ordinal type issues.

<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/panzer 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Help debug an issue an application is seeing for large problems.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Changed the main_driver/energy steady state problem to exercise this capability.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->