### PR TITLE
MueLu: Don't throw when rebalancing is enabled in serial run, just warn

### DIFF
--- a/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
+++ b/packages/muelu/src/Interface/MueLu_ParameterListInterpreter_def.hpp
@@ -1516,7 +1516,8 @@ namespace MueLu {
       // NOTE: This really needs to be set on the *NullSpaceFactory*, not manager.get("Nullspace").
       nullSpaceFactory->SetFactory("Nullspace", newP);
 #else
-      throw Exceptions::RuntimeError("No repartitioning available for a serial run");
+      paramList.set("repartition: enable",false);
+      this->GetOStream(Warnings0) << "No repartitioning available for a serial run\n";
 #endif
     }
   }

--- a/packages/muelu/test/maxwell/CMakeLists.txt
+++ b/packages/muelu/test/maxwell/CMakeLists.txt
@@ -17,25 +17,17 @@ IF (${PACKAGE_NAME}_ENABLE_Belos)
   TRIBITS_ADD_EXECUTABLE(
     Maxwell3D
     SOURCES Maxwell3D.cpp
-    COMM mpi
+    COMM serial mpi
     )
 
   IF (${PACKAGE_NAME}_ENABLE_Tpetra)
-    TRIBITS_ADD_TEST(
-      Maxwell3D
-      NAME "Maxwell3D-Tpetra"
-      ARGS "--linAlgebra=Tpetra --reuse --xml=Maxwell.xml"
-      ARGS "--linAlgebra=Tpetra --reuse --xml=Maxwell2.xml"
-      COMM mpi
-      NUM_MPI_PROCS 1
-      )
 
     TRIBITS_ADD_TEST(
       Maxwell3D
       NAME "Maxwell3D-Tpetra"
       ARGS "--linAlgebra=Tpetra --reuse --xml=Maxwell.xml"
       ARGS "--linAlgebra=Tpetra --reuse --xml=Maxwell2.xml"
-      COMM mpi
+      COMM serial mpi
       NUM_MPI_PROCS 4
       )
 
@@ -44,15 +36,7 @@ IF (${PACKAGE_NAME}_ENABLE_Belos)
         Maxwell3D
         NAME "Maxwell3D-Tpetra-ML-list"
         ARGS "--linAlgebra=Tpetra --xml=Maxwell_ML_MueLu.xml"
-        COMM mpi
-        NUM_MPI_PROCS 1
-        )
-
-      TRIBITS_ADD_TEST(
-        Maxwell3D
-        NAME "Maxwell3D-Tpetra-ML-list"
-        ARGS "--linAlgebra=Tpetra --xml=Maxwell_ML_MueLu.xml"
-        COMM mpi
+        COMM serial mpi
         NUM_MPI_PROCS 4
         )
     ENDIF()
@@ -63,52 +47,29 @@ IF (${PACKAGE_NAME}_ENABLE_Belos)
         NAME "Maxwell3D-Tpetra-Stratimikos"
         ARGS "--linAlgebra=Tpetra --solverName=Stratimikos --instantiation=DOUBLE_INT_INT --reuse --xml=Maxwell.xml"
         ARGS "--linAlgebra=Tpetra --solverName=Stratimikos --instantiation=DOUBLE_INT_INT --reuse --xml=Maxwell2.xml"
-        COMM mpi
-        NUM_MPI_PROCS 1
-        )
-
-      TRIBITS_ADD_TEST(
-        Maxwell3D
-        NAME "Maxwell3D-Tpetra-Stratimikos"
-        ARGS "--linAlgebra=Tpetra --solverName=Stratimikos --instantiation=DOUBLE_INT_INT --reuse --xml=Maxwell.xml"
-        ARGS "--linAlgebra=Tpetra --solverName=Stratimikos --instantiation=DOUBLE_INT_INT --reuse --xml=Maxwell2.xml"
-        COMM mpi
+        COMM serial mpi
         NUM_MPI_PROCS 4
         )
     ENDIF()
   ENDIF()
 
   IF (${PACKAGE_NAME}_ENABLE_Epetra)
-    TRIBITS_ADD_TEST(
-      Maxwell3D
-      NAME "Maxwell3D-Epetra"
-      ARGS "--linAlgebra=Epetra --reuse --xml=Maxwell.xml"
-      COMM mpi
-      NUM_MPI_PROCS 1
-      )
 
     TRIBITS_ADD_TEST(
       Maxwell3D
       NAME "Maxwell3D-Epetra"
       ARGS "--linAlgebra=Epetra --reuse --xml=Maxwell.xml"
-      COMM mpi
+      COMM serial mpi
       NUM_MPI_PROCS 4
       )
 
     IF (${PACKAGE_NAME}_ENABLE_ML)
-      TRIBITS_ADD_TEST(
-        Maxwell3D
-        NAME "Maxwell3D-ML"
-        ARGS "--linAlgebra=Epetra --precType=ML-RefMaxwell  --xml=Maxwell_ML.xml"
-        COMM mpi
-        NUM_MPI_PROCS 1
-        )
 
       TRIBITS_ADD_TEST(
         Maxwell3D
         NAME "Maxwell3D-ML"
         ARGS "--linAlgebra=Epetra --precType=ML-RefMaxwell  --xml=Maxwell_ML.xml"
-        COMM mpi
+        COMM serial mpi
         NUM_MPI_PROCS 4
         )
     ENDIF()


### PR DESCRIPTION
@trilinos/muelu 

## Motivation
Instead of throwing when rebalancing is enabled in a serial run, just warn about it.
This allows running XMLs that have rebalancing enabled in serial.