### PR TITLE
Tpetra: Allow configuration without UVM

### DIFF
--- a/cmake/ctest/drivers/geminga/ctest_linux_nightly_mpi_release_muelu_cuda_no_uvm_geminga.cmake
+++ b/cmake/ctest/drivers/geminga/ctest_linux_nightly_mpi_release_muelu_cuda_no_uvm_geminga.cmake
@@ -97,6 +97,7 @@ SET(EXTRA_CONFIGURE_OPTIONS
 
   ### Disable UVM ###
   "-DKokkos_ENABLE_CUDA_UVM:BOOL=OFF"
+  "-DTpetra_ENABLE_CUDA_UVM:BOOL=OFF"
 )
 
 #

--- a/packages/tpetra/core/CMakeLists.txt
+++ b/packages/tpetra/core/CMakeLists.txt
@@ -24,11 +24,23 @@ TRIBITS_ADD_OPTION_AND_DEFINE(
   ${${PACKAGE_NAME}_ENABLE_EXPLICIT_INSTANTIATION}
   )
 
+
+TRIBITS_ADD_OPTION_AND_DEFINE(
+  ${PACKAGE_NAME}_ENABLE_CUDA_UVM
+  HAVE_TPETRA_ENABLE_CUDA_UVM
+  "Build Tpetra with UVM."
+  ON
+  )
+
 ASSERT_DEFINED(Kokkos_ENABLE_CUDA)
 ASSERT_DEFINED(Kokkos_ENABLE_CUDA_UVM)
 ASSERT_DEFINED(Tpetra_ENABLE_CUDA)
 IF (Kokkos_ENABLE_CUDA AND NOT Kokkos_ENABLE_CUDA_UVM AND Tpetra_ENABLE_CUDA)
-  MESSAGE (FATAL_ERROR "If CUDA is enabled in Kokkos, Tpetra requires that Kokkos' UVM support be enabled.  You may do this by setting the CMake option Kokkos_ENABLE_CUDA_UVM:BOOL=ON (WARNING: IT IS CASE SENSITIVE!) and running CMake again.\n\nDetails for developers: UVM stands for \"Unified Virtual Memory\".  It lets code running on the host processor access GPU memory.  There is a difference between CUDA's support for UVM, and Kokkos' support for UVM.  Versions of CUDA >= 6 have UVM support built in by default.  Kokkos always supports this.  In particular, Kokkos always has a memory space for UVM allocations, called Kokkos::CudaUVMSpace.  \"Turning on UVM support in Kokkos\" means two things:\n\n1. Kokkos::Cuda::memory_space (the CUDA execution space's default memory space) is Kokkos::CudaUVMSpace, rather than Kokkos::CudaSpace.\n\n2. Kokkos::DualView<T, Kokkos::Cuda> only uses a single allocation, in the Kokkos::CudaUVMSpace memory space.")
+  IF (Tpetra_ENABLE_CUDA_UVM)
+    MESSAGE (FATAL_ERROR "If CUDA is enabled in Kokkos, Tpetra requires that Kokkos' UVM support be enabled.  You may do this by setting the CMake option Kokkos_ENABLE_CUDA_UVM:BOOL=ON (WARNING: IT IS CASE SENSITIVE!) and running CMake again.\n\nDetails for developers: UVM stands for \"Unified Virtual Memory\".  It lets code running on the host processor access GPU memory.  There is a difference between CUDA's support for UVM, and Kokkos' support for UVM.  Versions of CUDA >= 6 have UVM support built in by default.  Kokkos always supports this.  In particular, Kokkos always has a memory space for UVM allocations, called Kokkos::CudaUVMSpace.  \"Turning on UVM support in Kokkos\" means two things:\n\n1. Kokkos::Cuda::memory_space (the CUDA execution space's default memory space) is Kokkos::CudaUVMSpace, rather than Kokkos::CudaSpace.\n\n2. Kokkos::DualView<T, Kokkos::Cuda> only uses a single allocation, in the Kokkos::CudaUVMSpace memory space.")
+  ELSE ()
+    MESSAGE (WARNING "CUDA UVM is disabled in Kokkos and in Tpetra. THERE IS NO GUARANTEE THAT THIS WORKS!")
+  ENDIF ()
 ENDIF ()
 
 SET(Tpetra_MACHINE_XML_FILE_DIR


### PR DESCRIPTION
@trilinos/tpetra 

## Motivation
Allow to configure Tpetra without UVM by setting `Kokkos_ENABLE_CUDA_UVM` and `Tpetra_ENABLE_NO_UVM`.
This is only so that we can start working on removing UVM. Building without UVM does currently not work.