### PR TITLE
Tpetra: Fix compile-time issues with using Kokkos::CudaSpace as the default Cuda memory space

### DIFF
--- a/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_decl.hpp
@@ -201,6 +201,8 @@ public:
                        device_type,
                        Kokkos::MemoryTraits<Kokkos::Unmanaged> >
           little_vec_type;
+  typedef typename little_vec_type::HostMirror
+          little_host_vec_type;
   //! The type used to access const vector blocks.
   typedef Kokkos::View<const impl_scalar_type*,
                        Kokkos::LayoutRight,

--- a/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockCrsMatrix_def.hpp
@@ -1085,7 +1085,7 @@ public:
     const LO blockSize = getBlockSize ();
     Teuchos::Array<impl_scalar_type> localMem (blockSize);
     Teuchos::Array<impl_scalar_type> localMat (blockSize*blockSize);
-    little_vec_type X_lcl (localMem.getRawPtr (), blockSize);
+    little_host_vec_type X_lcl (localMem.getRawPtr (), blockSize);
 
     // FIXME (mfh 12 Aug 2014) This probably won't work if LO is unsigned.
     LO rowBegin = 0, rowEnd = 0, rowStride = 0;
@@ -1114,7 +1114,7 @@ public:
       for (LO lclRow = rowBegin; lclRow != rowEnd; lclRow += rowStride) {
         const LO actlRow = lclRow - 1;
 
-        little_vec_type B_cur = B.getLocalBlock (actlRow, 0);
+        little_host_vec_type B_cur = B.getLocalBlock (actlRow, 0);
         COPY (B_cur, X_lcl);
         SCAL (static_cast<impl_scalar_type> (omega), X_lcl);
 
@@ -1124,7 +1124,7 @@ public:
           const LO meshCol = indHost_[absBlkOff];
           const_little_block_type A_cur =
             getConstLocalBlockFromAbsOffset (absBlkOff);
-          little_vec_type X_cur = X.getLocalBlock (meshCol, 0);
+          little_host_vec_type X_cur = X.getLocalBlock (meshCol, 0);
 
           // X_lcl += alpha*A_cur*X_cur
           const Scalar alpha = meshCol == actlRow ? one_minus_omega : minus_omega;
@@ -1136,7 +1136,7 @@ public:
         // unmanaged already, so we don't have to take unmanaged
         // subviews first.
         auto D_lcl = Kokkos::subview (D_inv, actlRow, ALL (), ALL ());
-        little_vec_type X_update = X.getLocalBlock (actlRow, 0);
+        little_host_vec_type X_update = X.getLocalBlock (actlRow, 0);
         FILL (X_update, zero);
         GEMV (one, D_lcl, X_lcl, X_update); // overwrite X_update
       } // for each local row of the matrix
@@ -1146,7 +1146,7 @@ public:
         for (LO j = 0; j < numVecs; ++j) {
           LO actlRow = lclRow-1;
 
-          little_vec_type B_cur = B.getLocalBlock (actlRow, j);
+          little_host_vec_type B_cur = B.getLocalBlock (actlRow, j);
           COPY (B_cur, X_lcl);
           SCAL (static_cast<impl_scalar_type> (omega), X_lcl);
 
@@ -1156,7 +1156,7 @@ public:
             const LO meshCol = indHost_[absBlkOff];
             const_little_block_type A_cur =
               getConstLocalBlockFromAbsOffset (absBlkOff);
-            little_vec_type X_cur = X.getLocalBlock (meshCol, j);
+            little_host_vec_type X_cur = X.getLocalBlock (meshCol, j);
 
             // X_lcl += alpha*A_cur*X_cur
             const Scalar alpha = meshCol == actlRow ? one_minus_omega : minus_omega;

--- a/packages/tpetra/core/src/Tpetra_BlockMultiVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockMultiVector_decl.hpp
@@ -198,6 +198,8 @@ public:
                        device_type,
                        Kokkos::MemoryTraits<Kokkos::Unmanaged> >
           little_vec_type;
+  typedef typename little_vec_type::HostMirror
+          little_host_vec_type;
 
   /// \brief "Const block view" of all degrees of freedom at a mesh point,
   ///   for a single column of the MultiVector.
@@ -604,8 +606,7 @@ public:
   /// future.  If you insist not to use \c auto, then please use the
   /// \c little_vec_type typedef to deduce the correct return type;
   /// don't try to hard-code the return type yourself.
-  typename little_vec_type::HostMirror
-  getLocalBlock (const LO localRowIndex, const LO colIndex) const;
+  little_host_vec_type getLocalBlock (const LO localRowIndex, const LO colIndex) const;
   //@}
 
 protected:

--- a/packages/tpetra/core/src/Tpetra_BlockMultiVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockMultiVector_def.hpp
@@ -414,7 +414,7 @@ getGlobalRowView (const GO globalRowIndex, const LO colIndex, Scalar*& vals) con
 }
 
 template<class Scalar, class LO, class GO, class Node>
-typename BlockMultiVector<Scalar, LO, GO, Node>::little_vec_type::HostMirror
+typename BlockMultiVector<Scalar, LO, GO, Node>::little_host_vec_type
 BlockMultiVector<Scalar, LO, GO, Node>::
 getLocalBlock (const LO localRowIndex,
                const LO colIndex) const
@@ -432,13 +432,13 @@ getLocalBlock (const LO localRowIndex,
 // #endif // HAVE_TPETRA_DEBUG
 
   if (! isValidLocalMeshIndex (localRowIndex)) {
-    return typename little_vec_type::HostMirror ();
+    return little_host_vec_type ();
   } else {
     const size_t blockSize = getBlockSize ();
     const size_t offset = colIndex * this->getStrideY () +
       localRowIndex * blockSize;
     impl_scalar_type* blockRaw = this->getRawPtr () + offset;
-    return typename little_vec_type::HostMirror (blockRaw, blockSize);
+    return little_host_vec_type (blockRaw, blockSize);
   }
 }
 

--- a/packages/tpetra/core/src/Tpetra_BlockVector_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockVector_decl.hpp
@@ -125,6 +125,8 @@ public:
                        device_type,
                        Kokkos::MemoryTraits<Kokkos::Unmanaged> >
           little_vec_type;
+  typedef typename little_vec_type::HostMirror
+          little_host_vec_type;
 
   /// \brief "Const block view" of all degrees of freedom at a mesh point.
   ///
@@ -353,7 +355,7 @@ public:
   /// different types to implement little_vec_type.  This gives us a
   /// porting strategy to move from "classic" Tpetra to the Kokkos
   /// refactor version.
-  little_vec_type getLocalBlock (const LO localRowIndex) const;
+  little_host_vec_type getLocalBlock (const LO localRowIndex) const;
   //@}
 };
 

--- a/packages/tpetra/core/src/Tpetra_BlockVector_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_BlockVector_def.hpp
@@ -159,17 +159,17 @@ namespace Tpetra {
   }
 
   template<class Scalar, class LO, class GO, class Node>
-  typename BlockVector<Scalar, LO, GO, Node>::little_vec_type
+  typename BlockVector<Scalar, LO, GO, Node>::little_host_vec_type
   BlockVector<Scalar, LO, GO, Node>::
   getLocalBlock (const LO localRowIndex) const
   {
     if (! this->isValidLocalMeshIndex (localRowIndex)) {
-      return little_vec_type ();
+      return little_host_vec_type ();
     }
     else {
       const size_t blockSize = this->getBlockSize ();
       const size_t offset = localRowIndex * blockSize;
-      return little_vec_type (this->getRawPtr () + offset, blockSize);
+      return little_host_vec_type (this->getRawPtr () + offset, blockSize);
     }
   }
 

--- a/packages/tpetra/core/src/Tpetra_idot.hpp
+++ b/packages/tpetra/core/src/Tpetra_idot.hpp
@@ -203,7 +203,7 @@ void blockingDotImpl(
   {
     //compute local result on temporary device view, then copy that to host.
     result_dev_view_type localDeviceResult(Kokkos::ViewAllocateWithoutInitializing("DeviceLocalDotResult"), numVecs);
-    idotLocal<SC, LO, GO, NT, result_dev_view_type, mirror_mem_space>(localDeviceResult, X, Y);
+    idotLocal<SC, LO, GO, NT, result_dev_view_type, dev_mem_space>(localDeviceResult, X, Y);
     //NOTE: no fence is required: deep_copy will fence.
     Kokkos::deep_copy(localHostResult, localDeviceResult);
   }

--- a/packages/tpetra/core/test/Block/BlockCrsMatrix.cpp
+++ b/packages/tpetra/core/test/Block/BlockCrsMatrix.cpp
@@ -161,7 +161,7 @@ namespace {
     // The typedef below is also a test.  BlockCrsMatrix must have
     // this typedef, or this test won't compile.
     typedef typename BCM::little_block_type little_block_type;
-    typedef typename BV::little_vec_type little_vec_type;
+    typedef typename BV::little_host_vec_type little_host_vec_type;
     typedef Teuchos::ScalarTraits<Scalar> STS;
     typedef typename STS::magnitudeType MT;
 
@@ -434,7 +434,7 @@ namespace {
       const map_type& meshDomainMap = * (graph.getDomainMap ());
       for (LO lclDomIdx = meshDomainMap.getMinLocalIndex ();
            lclDomIdx <= meshDomainMap.getMaxLocalIndex (); ++lclDomIdx) {
-        little_vec_type X_lcl = X.getLocalBlock (lclDomIdx);
+        little_host_vec_type X_lcl = X.getLocalBlock (lclDomIdx);
         TEST_ASSERT( X_lcl.data () != NULL );
         TEST_ASSERT( static_cast<size_t> (X_lcl.extent (0)) == static_cast<size_t> (blockSize) );
         for (LO i = 0; i < blockSize; ++i) {
@@ -448,7 +448,7 @@ namespace {
       const map_type& meshRangeMap = * (graph.getRangeMap ());
       for (LO lclRanIdx = meshRangeMap.getMinLocalIndex ();
            lclRanIdx <= meshRangeMap.getMaxLocalIndex (); ++lclRanIdx) {
-        little_vec_type Y_lcl = Y.getLocalBlock (lclRanIdx);
+        little_host_vec_type Y_lcl = Y.getLocalBlock (lclRanIdx);
         TEST_ASSERT( Y_lcl.data () != NULL );
         TEST_ASSERT( static_cast<size_t> (Y_lcl.extent (0)) == static_cast<size_t> (blockSize) );
 
@@ -480,7 +480,7 @@ namespace {
 
       for (LO lclRanIdx = meshRangeMap.getMinLocalIndex ();
            lclRanIdx <= meshRangeMap.getMaxLocalIndex (); ++lclRanIdx) {
-        little_vec_type Y_lcl = Y.getLocalBlock (lclRanIdx);
+        little_host_vec_type Y_lcl = Y.getLocalBlock (lclRanIdx);
         TEST_ASSERT( Y_lcl.data () != NULL );
         TEST_ASSERT( static_cast<size_t> (Y_lcl.extent (0)) == static_cast<size_t> (blockSize) );
 
@@ -545,7 +545,7 @@ namespace {
       for (LO lclDomIdx = meshDomainMap.getMinLocalIndex ();
            lclDomIdx <= meshDomainMap.getMaxLocalIndex (); ++lclDomIdx) {
         for (LO j = 0; j < numVecs; ++j) {
-          little_vec_type X_lcl = X.getLocalBlock (lclDomIdx, j);
+          little_host_vec_type X_lcl = X.getLocalBlock (lclDomIdx, j);
           TEST_ASSERT( X_lcl.data () != NULL );
           TEST_ASSERT( static_cast<size_t> (X_lcl.extent (0)) == static_cast<size_t> (blockSize) );
           for (LO i = 0; i < blockSize; ++i) {
@@ -561,7 +561,7 @@ namespace {
       for (LO lclRanIdx = meshRangeMap.getMinLocalIndex ();
            lclRanIdx <= meshRangeMap.getMaxLocalIndex (); ++lclRanIdx) {
         for (LO col = 0; col < numVecs; ++col) {
-          little_vec_type Y_lcl = Y.getLocalBlock (lclRanIdx, col);
+          little_host_vec_type Y_lcl = Y.getLocalBlock (lclRanIdx, col);
           TEST_ASSERT( Y_lcl.data () != NULL );
           TEST_ASSERT( static_cast<size_t> (Y_lcl.extent (0)) == static_cast<size_t> (blockSize) );
 
@@ -596,7 +596,7 @@ namespace {
       for (LO lclRanIdx = meshRangeMap.getMinLocalIndex ();
            lclRanIdx <= meshRangeMap.getMaxLocalIndex (); ++lclRanIdx) {
         for (LO col = 0; col < numVecs; ++col) {
-          little_vec_type Y_lcl = Y.getLocalBlock (lclRanIdx, col);
+          little_host_vec_type Y_lcl = Y.getLocalBlock (lclRanIdx, col);
           TEST_ASSERT( Y_lcl.data () != NULL );
           TEST_ASSERT( static_cast<size_t> (Y_lcl.extent (0)) == static_cast<size_t> (blockSize) );
 
@@ -657,7 +657,7 @@ namespace {
       const map_type& meshDomainMap = * (graph.getDomainMap ());
       for (LO lclDomIdx = meshDomainMap.getMinLocalIndex ();
            lclDomIdx <= meshDomainMap.getMaxLocalIndex (); ++lclDomIdx) {
-        little_vec_type X_lcl = X.getLocalBlock (lclDomIdx);
+        little_host_vec_type X_lcl = X.getLocalBlock (lclDomIdx);
         TEST_ASSERT( X_lcl.data () != NULL );
         TEST_ASSERT( static_cast<size_t> (X_lcl.extent (0)) == static_cast<size_t> (blockSize) );
         for (LO i = 0; i < blockSize; ++i) {
@@ -678,7 +678,7 @@ namespace {
       const map_type& meshRangeMap = * (graph.getRangeMap ());
       for (LO lclRanIdx = meshRangeMap.getMinLocalIndex ();
            lclRanIdx <= meshRangeMap.getMaxLocalIndex (); ++lclRanIdx) {
-        little_vec_type Y_lcl = Y.getLocalBlock (lclRanIdx);
+        little_host_vec_type Y_lcl = Y.getLocalBlock (lclRanIdx);
         TEST_ASSERT( Y_lcl.data () != NULL );
         TEST_ASSERT( static_cast<size_t> (Y_lcl.extent (0)) == static_cast<size_t> (blockSize) );
 
@@ -710,7 +710,7 @@ namespace {
 
       for (LO lclRanIdx = meshRangeMap.getMinLocalIndex ();
            lclRanIdx <= meshRangeMap.getMaxLocalIndex (); ++lclRanIdx) {
-        little_vec_type Y_lcl = Y.getLocalBlock (lclRanIdx);
+        little_host_vec_type Y_lcl = Y.getLocalBlock (lclRanIdx);
         TEST_ASSERT( Y_lcl.data () != NULL );
         TEST_ASSERT( static_cast<size_t> (Y_lcl.extent (0)) == static_cast<size_t> (blockSize) );
 
@@ -775,7 +775,7 @@ namespace {
       for (LO lclDomIdx = meshDomainMap.getMinLocalIndex ();
            lclDomIdx <= meshDomainMap.getMaxLocalIndex (); ++lclDomIdx) {
         for (LO j = 0; j < numVecs; ++j) {
-          little_vec_type X_lcl = X.getLocalBlock (lclDomIdx, j);
+          little_host_vec_type X_lcl = X.getLocalBlock (lclDomIdx, j);
           TEST_ASSERT( X_lcl.data () != NULL );
           TEST_ASSERT( static_cast<size_t> (X_lcl.extent (0)) == static_cast<size_t> (blockSize) );
           for (LO i = 0; i < blockSize; ++i) {
@@ -798,7 +798,7 @@ namespace {
       for (LO lclRanIdx = meshRangeMap.getMinLocalIndex ();
            lclRanIdx <= meshRangeMap.getMaxLocalIndex (); ++lclRanIdx) {
         for (LO col = 0; col < numVecs; ++col) {
-          little_vec_type Y_lcl = Y.getLocalBlock (lclRanIdx, col);
+          little_host_vec_type Y_lcl = Y.getLocalBlock (lclRanIdx, col);
           TEST_ASSERT( Y_lcl.data () != NULL );
           TEST_ASSERT( static_cast<size_t> (Y_lcl.extent (0)) == static_cast<size_t> (blockSize) );
 
@@ -833,7 +833,7 @@ namespace {
       for (LO lclRanIdx = meshRangeMap.getMinLocalIndex ();
            lclRanIdx <= meshRangeMap.getMaxLocalIndex (); ++lclRanIdx) {
         for (LO col = 0; col < numVecs; ++col) {
-          little_vec_type Y_lcl = Y.getLocalBlock (lclRanIdx, col);
+          little_host_vec_type Y_lcl = Y.getLocalBlock (lclRanIdx, col);
           TEST_ASSERT( Y_lcl.data () != NULL );
           TEST_ASSERT( static_cast<size_t> (Y_lcl.extent (0)) == static_cast<size_t> (blockSize) );
 
@@ -1341,7 +1341,7 @@ namespace {
     const LO myMinLclMeshRow = Y.getMap ()->getMinLocalIndex ();
     const LO myMaxLclMeshRow = Y.getMap ()->getMaxLocalIndex ();
     for (LO lclMeshRow = myMinLclMeshRow; lclMeshRow <= myMaxLclMeshRow; ++lclMeshRow) {
-      typename BMV::little_vec_type Y_lcl = Y.getLocalBlock (lclMeshRow, 0);
+      typename BMV::little_host_vec_type Y_lcl = Y.getLocalBlock (lclMeshRow, 0);
       for (LO i = 0; i < blockSize; ++i) {
         TEST_EQUALITY( static_cast<Scalar> (Y_lcl(i)), requiredValue );
       }
@@ -1352,7 +1352,7 @@ namespace {
     Kokkos::fence ();
 
     for (LO lclMeshRow = myMinLclMeshRow; lclMeshRow <= myMaxLclMeshRow; ++lclMeshRow) {
-      typename BMV::little_vec_type Y_lcl = Y.getLocalBlock (lclMeshRow, 0);
+      typename BMV::little_host_vec_type Y_lcl = Y.getLocalBlock (lclMeshRow, 0);
       for (LO i = 0; i < blockSize; ++i) {
         TEST_EQUALITY( static_cast<Scalar> (Y_lcl(i)), STS::zero () );
       }
@@ -1504,7 +1504,7 @@ namespace {
     const LO myMaxLclMeshRow = Y.getMap ()->getMaxLocalIndex ();
     bool valsMatch = true;
     for (LO lclMeshRow = myMinLclMeshRow; lclMeshRow <= myMaxLclMeshRow; ++lclMeshRow) {
-      typename BMV::little_vec_type Y_lcl = Y.getLocalBlock (lclMeshRow, 0);
+      typename BMV::little_host_vec_type Y_lcl = Y.getLocalBlock (lclMeshRow, 0);
       for (LO i = 0; i < blockSize; ++i) {
         if (static_cast<Scalar> (Y_lcl(i)) != requiredValue) {
           valsMatch = false;
@@ -1932,7 +1932,7 @@ namespace {
 
     for (LO lclRowInd = meshRowMap.getMinLocalIndex ();
          lclRowInd <= meshRowMap.getMaxLocalIndex (); ++lclRowInd) {
-      typename BV::little_vec_type xlcl = solution.getLocalBlock (lclRowInd);
+      typename BV::little_host_vec_type xlcl = solution.getLocalBlock (lclRowInd);
       ST* x = reinterpret_cast<ST*> (xlcl.data ());
       out << "row = " << lclRowInd << endl;
       for (LO k = 0; k < blockSize; ++k) {
@@ -1945,7 +1945,7 @@ namespace {
                                STS::one (), Tpetra::Backward);
     for (LO lclRowInd = meshRowMap.getMinLocalIndex ();
          lclRowInd <= meshRowMap.getMaxLocalIndex (); ++lclRowInd) {
-      typename BV::little_vec_type xlcl = solution.getLocalBlock (lclRowInd);
+      typename BV::little_host_vec_type xlcl = solution.getLocalBlock (lclRowInd);
       ST* x = reinterpret_cast<ST*> (xlcl.data ());
       for (LO k = 0; k < blockSize; ++k) {
         TEST_FLOATING_EQUALITY( x[k], exactSolution[k], tol );
@@ -2130,7 +2130,7 @@ namespace {
     for (LO lclRowInd = meshRowMap.getMinLocalIndex ();
          lclRowInd <= meshRowMap.getMaxLocalIndex(); ++lclRowInd) {
       const LO rowOffset = lclRowInd - meshRowMap.getMinLocalIndex ();
-      typename BV::little_vec_type xlcl = solution.getLocalBlock (lclRowInd);
+      typename BV::little_host_vec_type xlcl = solution.getLocalBlock (lclRowInd);
       ST* x = reinterpret_cast<ST*> (xlcl.data ());
       for (LO k = 0; k < blockSize; ++k) {
         TEST_FLOATING_EQUALITY( x[k], exactSolution[rowOffset], tol );
@@ -2197,7 +2197,7 @@ namespace {
     for (LO lclRowInd = meshRowMap.getMinLocalIndex ();
          lclRowInd <= meshRowMap.getMaxLocalIndex(); ++lclRowInd) {
       const LO rowOffset = lclRowInd - meshRowMap.getMinLocalIndex ();
-      typename BV::little_vec_type xlcl = solution.getLocalBlock (lclRowInd);
+      typename BV::little_host_vec_type xlcl = solution.getLocalBlock (lclRowInd);
       ST* x = reinterpret_cast<ST*> (xlcl.data ());
       for (LO k = 0; k < blockSize; ++k) {
         TEST_FLOATING_EQUALITY( x[k], exactSolution[rowOffset], tol );


### PR DESCRIPTION
@trilinos/tpetra @cgcgcg 

## Motivation

Tpetra currently fails to build when the default memory space for `Kokkos::Cuda` is `Kokkos::CudaSpace`.  Fixing the build issues is the first step towards removal of the requirement that the default Cuda memory space be `Kokkos::CudaUVMSpace`.

## Related Issues

Closes #8151, #8164

## Testing

Using `Kokkos::CudaSpace` as the default Cuda memory space will currently cause failing tests, and this is documented in the configure script.  Future PR's will fix the failing tests so we can guarantee support for this memory space.