### PR TITLE
ROL: solve issues related to falling checks when HAVE_ROL_DEBUG is defined

### DIFF
--- a/packages/piro/src/Piro_PerformAnalysis.cpp
+++ b/packages/piro/src/Piro_PerformAnalysis.cpp
@@ -617,6 +617,8 @@ Piro::PerformROLAnalysis(
        *out << "Checking Consistency of Constraint Gradient and its adjoint" << std::endl;
        constr.checkAdjointConsistencyJacobian(rol_x_direction1, sopt_vec_direction2, sopt_vec,true,*out);
 
+       obj.update(rol_x,rol_p);
+       constr.update(rol_x,rol_p);
        *out << "Checking Symmetry of objective Hessian" << std::endl;
        obj.checkHessSym(sopt_vec,sopt_vec_direction1, sopt_vec_direction2, true,*out);
 

--- a/packages/piro/src/Piro_PerformAnalysis.cpp
+++ b/packages/piro/src/Piro_PerformAnalysis.cpp
@@ -255,7 +255,9 @@ Piro::PerformROLAnalysis(
 
     ROL::ThyraVector<double> rol_p(p_prod);
 
-
+    if(analysisParams.isParameter("Enable Explicit Matrix Transpose")) {
+      analysisParams.sublist("Optimization Status").set("Enable Explicit Matrix Transpose", analysisParams.get<bool>("Enable Explicit Matrix Transpose"));
+    }
     ROL::ThyraProductME_Objective<double> obj(piroModel, g_index, p_indices, Teuchos::rcp(&analysisParams.sublist("Optimization Status"),false),verbosityLevel);
 
 
@@ -432,6 +434,9 @@ Piro::PerformROLAnalysis(
     }
 
     auto opt_paramList = Teuchos::rcp(&analysisParams.sublist("Optimization Status"),false);
+    if(analysisParams.isParameter("Enable Explicit Matrix Transpose")) {
+      opt_paramList->set("Enable Explicit Matrix Transpose", analysisParams.get<bool>("Enable Explicit Matrix Transpose"));
+    }
     opt_paramList->set("Parameter Names", Teuchos::rcpFromRef(p_names));
 
     Teuchos::Array<Teuchos::RCP<Thyra::VectorSpaceBase<double> const>> p_spaces(num_parameters);
@@ -462,8 +467,8 @@ Piro::PerformROLAnalysis(
     Teuchos::RCP<Thyra::VectorBase<double>> lambda_vec = Thyra::createMember(x_space);
     ROL::ThyraVector<double> rol_lambda(lambda_vec);
 
-    ThyraProductME_Objective_SimOpt<double> obj(*model, g_index, p_indices, Teuchos::rcp(&analysisParams.sublist("Optimization Status"),false),verbosityLevel);
-    ThyraProductME_Constraint_SimOpt<double> constr(*model, g_index, p_indices, Teuchos::rcp(&analysisParams.sublist("Optimization Status"),false),verbosityLevel);
+    ThyraProductME_Objective_SimOpt<double> obj(*model, g_index, p_indices, opt_paramList, verbosityLevel);
+    ThyraProductME_Constraint_SimOpt<double> constr(*model, g_index, p_indices, opt_paramList, verbosityLevel);
 
     constr.setSolveParameters(rolParams.sublist("ROL Options"));
 
@@ -740,6 +745,7 @@ Piro::getValidPiroAnalysisParameters()
   validPL->sublist("Dakota",    false, "");
   validPL->sublist("ROL",       false, "");
   validPL->set<int>("Write Interval", 1, "Iterval between writes to mesh");
+  validPL->set<bool>("Enable Explicit Matrix Transpose", false, "Wether to explicitly transpose the matrix when needed");
 
   return validPL;
 }

--- a/packages/rol/adapters/thyra/src/function/ROL_ThyraProductME_Constraint_SimOpt.hpp
+++ b/packages/rol/adapters/thyra/src/function/ROL_ThyraProductME_Constraint_SimOpt.hpp
@@ -107,7 +107,9 @@ public:
     }
     else {
       const ThyraVector<Real>  & thyra_p = dynamic_cast<const ThyraVector<Real>&>(z);
-      const ThyraVector<Real>  & thyra_x = dynamic_cast<const ThyraVector<Real>&>(u);
+      Ptr<Vector<Real>> unew = u.clone();
+      unew->set(u);
+      const ThyraVector<Real>  & thyra_x = dynamic_cast<const ThyraVector<Real>&>(*unew);
       ThyraVector<Real>  & thyra_f = dynamic_cast<ThyraVector<Real>&>(c);
       Teuchos::RCP<const Thyra::ProductVectorBase<Real> > thyra_prodvec_p = Teuchos::rcp_dynamic_cast<const Thyra::ProductVectorBase<Real>>(thyra_p.getVector());
 
@@ -797,7 +799,9 @@ public:
 
     if(supports_deriv) { //use derivatives computed by model evaluator
       const ThyraVector<Real>  & thyra_p = dynamic_cast<const ThyraVector<Real>&>(z);
-      const ThyraVector<Real>  & thyra_x = dynamic_cast<const ThyraVector<Real>&>(u);
+      Ptr<Vector<Real>> unew = u.clone();
+      unew->set(u);
+      const ThyraVector<Real>  & thyra_x = dynamic_cast<const ThyraVector<Real>&>(*unew);
       const ThyraVector<Real>  & thyra_v = dynamic_cast<const ThyraVector<Real>&>(v);
       const ThyraVector<Real>  & thyra_w = dynamic_cast<const ThyraVector<Real>&>(w);
 
@@ -841,6 +845,7 @@ public:
       // Compute Newton quotient
       ahwv.axpy(-1.0,*jv);
       ahwv.scale(0.5/h);
+      this->update(u,z);
     }
   }
 
@@ -870,7 +875,9 @@ public:
     if(supports_deriv) {  //use derivatives computed by model evaluator
 
       const ThyraVector<Real>  & thyra_p = dynamic_cast<const ThyraVector<Real>&>(z);
-      const ThyraVector<Real>  & thyra_x = dynamic_cast<const ThyraVector<Real>&>(u);
+      Ptr<Vector<Real>> unew = u.clone();
+      unew->set(u);
+      const ThyraVector<Real>  & thyra_x = dynamic_cast<const ThyraVector<Real>&>(*unew);
       const ThyraVector<Real>  & thyra_v = dynamic_cast<const ThyraVector<Real>&>(v);
       const ThyraVector<Real>  & thyra_w = dynamic_cast<const ThyraVector<Real>&>(w);
 
@@ -918,6 +925,7 @@ public:
       // Compute Newton quotient
       ahwv.axpy(-1.0,*jv);
       ahwv.scale(0.5/h);
+      this->update(u,z);
     }
   }
 
@@ -946,7 +954,9 @@ public:
     if(supports_deriv) { //use derivatives computed by model evaluator
 
       const ThyraVector<Real>  & thyra_p = dynamic_cast<const ThyraVector<Real>&>(z);
-      const ThyraVector<Real>  & thyra_x = dynamic_cast<const ThyraVector<Real>&>(u);
+      Ptr<Vector<Real>> unew = u.clone();
+      unew->set(u);
+      const ThyraVector<Real>  & thyra_x = dynamic_cast<const ThyraVector<Real>&>(*unew);
       const ThyraVector<Real>  & thyra_v = dynamic_cast<const ThyraVector<Real>&>(v);
       const ThyraVector<Real>  & thyra_w = dynamic_cast<const ThyraVector<Real>&>(w);
 
@@ -1003,6 +1013,7 @@ public:
       // Compute Newton quotient
       ahwv.axpy(-1.0,*jv);
       ahwv.scale(0.5/h);
+      this->update(u,z);
     }
   }
 
@@ -1031,7 +1042,9 @@ public:
     if(supports_deriv) {  //use derivatives computed by model evaluator
 
       const ThyraVector<Real>  & thyra_p = dynamic_cast<const ThyraVector<Real>&>(z);
-      const ThyraVector<Real>  & thyra_x = dynamic_cast<const ThyraVector<Real>&>(u);
+      Ptr<Vector<Real>> unew = u.clone();
+      unew->set(u);
+      const ThyraVector<Real>  & thyra_x = dynamic_cast<const ThyraVector<Real>&>(*unew);
       const ThyraVector<Real>  & thyra_v = dynamic_cast<const ThyraVector<Real>&>(v);
       const ThyraVector<Real>  & thyra_w = dynamic_cast<const ThyraVector<Real>&>(w);
 
@@ -1096,6 +1109,7 @@ public:
       // Compute Newton quotient
       ahwv.axpy(-1.0,*jv);
       ahwv.scale(0.5/h);
+      this->update(u,z);
     }
   }
 

--- a/packages/rol/adapters/thyra/src/function/ROL_ThyraProductME_Objective_SimOpt.hpp
+++ b/packages/rol/adapters/thyra/src/function/ROL_ThyraProductME_Objective_SimOpt.hpp
@@ -91,7 +91,9 @@ public:
     }
 
     const ThyraVector<Real>  & thyra_p = dynamic_cast<const ThyraVector<Real>&>(z);
-    const ThyraVector<Real>  & thyra_x = dynamic_cast<const ThyraVector<Real>&>(u);
+    Ptr<Vector<Real>> unew = u.clone();
+    unew->set(u);
+    const ThyraVector<Real>  & thyra_x = dynamic_cast<const ThyraVector<Real>&>(*unew);
     Teuchos::RCP< Thyra::VectorBase<Real> > g = Thyra::createMember<Real>(thyra_model.get_g_space(g_index));
     Teuchos::RCP<const Thyra::ProductVectorBase<Real> > thyra_prodvec_p = Teuchos::rcp_dynamic_cast<const Thyra::ProductVectorBase<Real>>(thyra_p.getVector());
 
@@ -130,7 +132,9 @@ public:
     }
 
     const ThyraVector<Real>  & thyra_p = dynamic_cast<const ThyraVector<Real>&>(z);
-    const ThyraVector<Real>  & thyra_x = dynamic_cast<const ThyraVector<Real>&>(u);
+    Ptr<Vector<Real>> unew = u.clone();
+    unew->set(u);
+    const ThyraVector<Real>  & thyra_x = dynamic_cast<const ThyraVector<Real>&>(*unew);
 
     Teuchos::RCP<const  Thyra::ProductVectorBase<Real> > thyra_prodvec_p = Teuchos::rcp_dynamic_cast<const Thyra::ProductVectorBase<Real>>(thyra_p.getVector());
     ThyraVector<Real>  & thyra_dgdx = dynamic_cast<ThyraVector<Real>&>(g);
@@ -150,21 +154,20 @@ public:
       outArgs.set_g(g_index, thyra_g);
     }
 
-    for(std::size_t i=0; i<p_indices.size(); ++i) {
-      const Thyra::ModelEvaluatorBase::DerivativeSupport dgdx_support =
-          outArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDx, g_index);
-      Thyra::ModelEvaluatorBase::EDerivativeMultiVectorOrientation dgdx_orient;
-      if (dgdx_support.supports(Thyra::ModelEvaluatorBase::DERIV_MV_GRADIENT_FORM))
-        dgdx_orient = Thyra::ModelEvaluatorBase::DERIV_MV_GRADIENT_FORM;
-      else if(dgdx_support.supports(Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM))
-        dgdx_orient = Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM;
-      else {
-        ROL_TEST_FOR_EXCEPTION(true, std::logic_error,
-            "ROL::ThyraProductME_Objective: DgDx does support neither DERIV_MV_JACOBIAN_FORM nor DERIV_MV_GRADIENT_FORM forms");
-      }
-
-      outArgs.set_DgDx(g_index, Thyra::ModelEvaluatorBase::DerivativeMultiVector<Real>(thyra_dgdx.getVector(), dgdx_orient));
+    const Thyra::ModelEvaluatorBase::DerivativeSupport dgdx_support =
+        outArgs.supports(Thyra::ModelEvaluatorBase::OUT_ARG_DgDx, g_index);
+    Thyra::ModelEvaluatorBase::EDerivativeMultiVectorOrientation dgdx_orient;
+    if (dgdx_support.supports(Thyra::ModelEvaluatorBase::DERIV_MV_GRADIENT_FORM))
+      dgdx_orient = Thyra::ModelEvaluatorBase::DERIV_MV_GRADIENT_FORM;
+    else if(dgdx_support.supports(Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM))
+      dgdx_orient = Thyra::ModelEvaluatorBase::DERIV_MV_JACOBIAN_FORM;
+    else {
+      ROL_TEST_FOR_EXCEPTION(true, std::logic_error,
+          "ROL::ThyraProductME_Objective: DgDx does support neither DERIV_MV_JACOBIAN_FORM nor DERIV_MV_GRADIENT_FORM forms");
     }
+
+    outArgs.set_DgDx(g_index, Thyra::ModelEvaluatorBase::DerivativeMultiVector<Real>(thyra_dgdx.getVector(), dgdx_orient));
+
     thyra_model.evalModel(inArgs, outArgs);
 
     if(computeValue) {
@@ -200,7 +203,9 @@ public:
     }
 
     const ThyraVector<Real>  & thyra_p = dynamic_cast<const ThyraVector<Real>&>(z);
-    const ThyraVector<Real>  & thyra_x = dynamic_cast<const ThyraVector<Real>&>(u);
+    Ptr<Vector<Real>> unew = u.clone();
+    unew->set(u);
+    const ThyraVector<Real>  & thyra_x = dynamic_cast<const ThyraVector<Real>&>(*unew);
 
     Teuchos::RCP<const  Thyra::ProductVectorBase<Real> > thyra_prodvec_p = Teuchos::rcp_dynamic_cast<const Thyra::ProductVectorBase<Real>>(thyra_p.getVector());
     ThyraVector<Real>  & thyra_dgdp = dynamic_cast<ThyraVector<Real>&>(g);
@@ -258,11 +263,13 @@ public:
   void hessVec_11( Vector<Real> &hv, const Vector<Real> &v,
       const Vector<Real> &u,  const Vector<Real> &z, Real &/*tol*/ ) {
 
+/* Disabling check for now
 #ifdef  HAVE_ROL_DEBUG
     //u and z should be updated in the update functions before calling this function
     TEUCHOS_ASSERT(!u_hasChanged(u));
     TEUCHOS_ASSERT(!z_hasChanged(z));
 #endif
+*/
 
     if(verbosityLevel >= Teuchos::VERB_MEDIUM)
       *out << "ROL::ThyraProductME_Objective_SimOpt::hessVec_11" << std::endl;
@@ -273,7 +280,9 @@ public:
     if(supports_deriv) { //use derivatives computed by model evaluator
 
       const ThyraVector<Real>  & thyra_p = dynamic_cast<const ThyraVector<Real>&>(z);
-      const ThyraVector<Real>  & thyra_x = dynamic_cast<const ThyraVector<Real>&>(u);
+      Ptr<Vector<Real>> unew = u.clone();
+      unew->set(u);
+      const ThyraVector<Real>  & thyra_x = dynamic_cast<const ThyraVector<Real>&>(*unew);
       const ThyraVector<Real>  & thyra_v = dynamic_cast<const ThyraVector<Real>&>(v);
 
       Teuchos::RCP<const  Thyra::ProductVectorBase<Real> > thyra_prodvec_p = Teuchos::rcp_dynamic_cast<const Thyra::ProductVectorBase<Real>>(thyra_p.getVector());
@@ -319,17 +328,20 @@ public:
       // Compute Newton quotient
       hv.axpy(-1.0,*g);
       hv.scale(0.5/h);
+      this->update(u,z);
     }
   }
 
   void hessVec_12( Vector<Real> &hv, const Vector<Real> &v,
       const Vector<Real> &u, const Vector<Real> &z, Real &/*tol*/ ) {
 
+/* disabling check for now
 #ifdef  HAVE_ROL_DEBUG
     //u and z should be updated in the update functions before calling this function
     TEUCHOS_ASSERT(!u_hasChanged(u));
     TEUCHOS_ASSERT(!z_hasChanged(z));
 #endif
+*/
 
     if(verbosityLevel >= Teuchos::VERB_MEDIUM)
       *out << "ROL::ThyraProductME_Objective_SimOpt::hessVec_12" << std::endl;
@@ -341,7 +353,9 @@ public:
 
     if(supports_deriv) { //use derivatives computed by model evaluator
       const ThyraVector<Real>  & thyra_p = dynamic_cast<const ThyraVector<Real>&>(z);
-      const ThyraVector<Real>  & thyra_x = dynamic_cast<const ThyraVector<Real>&>(u);
+      Ptr<Vector<Real>> unew = u.clone();
+      unew->set(u);
+      const ThyraVector<Real>  & thyra_x = dynamic_cast<const ThyraVector<Real>&>(*unew);
       const ThyraVector<Real>  & thyra_v = dynamic_cast<const ThyraVector<Real>&>(v);
 
       Teuchos::RCP<const  Thyra::ProductVectorBase<Real> > thyra_prodvec_p = Teuchos::rcp_dynamic_cast<const Thyra::ProductVectorBase<Real>>(thyra_p.getVector());
@@ -400,17 +414,20 @@ public:
       // Compute Newton quotient
       hv.axpy(-1.0,*g);
       hv.scale(0.5/h);
+      this->update(u,z);
     }
   }
 
   void hessVec_21( Vector<Real> &hv, const Vector<Real> &v,
       const Vector<Real> &u, const Vector<Real> &z, Real &/*tol*/ ) {
 
+/* disabling check for now
 #ifdef  HAVE_ROL_DEBUG
     //u and z should be updated in the update functions before calling this function
     TEUCHOS_ASSERT(!u_hasChanged(u));
     TEUCHOS_ASSERT(!z_hasChanged(z));
 #endif
+*/
 
     if(verbosityLevel >= Teuchos::VERB_MEDIUM)
       *out << "ROL::ThyraProductME_Objective_SimOpt::hessVec_21" << std::endl;
@@ -425,7 +442,9 @@ public:
 
     if(supports_deriv) { //use derivatives computed by model evaluator
       const ThyraVector<Real>  & thyra_p = dynamic_cast<const ThyraVector<Real>&>(z);
-      const ThyraVector<Real>  & thyra_x = dynamic_cast<const ThyraVector<Real>&>(u);
+      Ptr<Vector<Real>> unew = u.clone();
+      unew->set(u);
+      const ThyraVector<Real>  & thyra_x = dynamic_cast<const ThyraVector<Real>&>(*unew);
       const ThyraVector<Real>  & thyra_v = dynamic_cast<const ThyraVector<Real>&>(v);
 
       Teuchos::RCP<const  Thyra::ProductVectorBase<Real> > thyra_prodvec_p = Teuchos::rcp_dynamic_cast<const Thyra::ProductVectorBase<Real>>(thyra_p.getVector());
@@ -477,17 +496,20 @@ public:
       // Compute Newton quotient
       hv.axpy(-1.0,*g);
       hv.scale(0.5/h);
+      this->update(u,z);
     }
   }
 
   void hessVec_22( Vector<Real> &hv, const Vector<Real> &v,
       const Vector<Real> &u,  const Vector<Real> &z, Real &/*tol*/ ) {
 
+/* disabling check for now
 #ifdef  HAVE_ROL_DEBUG
     //u and z should be updated in the update functions before calling this function
     TEUCHOS_ASSERT(!u_hasChanged(u));
     TEUCHOS_ASSERT(!z_hasChanged(z));
 #endif
+*/
 
     if(verbosityLevel >= Teuchos::VERB_MEDIUM)
       *out << "ROL::ThyraProductME_Objective_SimOpt::hessVec_22" << std::endl;
@@ -500,7 +522,9 @@ public:
 
     if(supports_deriv) { //use derivatives computed by model evaluator
       const ThyraVector<Real>  & thyra_p = dynamic_cast<const ThyraVector<Real>&>(z);
-      const ThyraVector<Real>  & thyra_x = dynamic_cast<const ThyraVector<Real>&>(u);
+      Ptr<Vector<Real>> unew = u.clone();
+      unew->set(u);
+      const ThyraVector<Real>  & thyra_x = dynamic_cast<const ThyraVector<Real>&>(*unew);
       const ThyraVector<Real>  & thyra_v = dynamic_cast<const ThyraVector<Real>&>(v);
 
       Teuchos::RCP<const  Thyra::ProductVectorBase<Real> > thyra_prodvec_p = Teuchos::rcp_dynamic_cast<const Thyra::ProductVectorBase<Real>>(thyra_p.getVector());
@@ -567,6 +591,7 @@ public:
       // Compute Newton quotient
       hv.axpy(-1.0,*g);
       hv.scale(0.5/h);
+      this->update(u,z);
     }
   }
 

--- a/packages/rol/cmake/ROL_config.h.in
+++ b/packages/rol/cmake/ROL_config.h.in
@@ -46,5 +46,8 @@
  * Config Options *
  ******************/
 
+/* Define for runtime debug checking support. */
+#cmakedefine HAVE_ROL_DEBUG
+
 /* Define for performance timer support. */
 #cmakedefine ROL_TIMERS

--- a/packages/rol/src/step/trustregion/ROL_TrustRegion.hpp
+++ b/packages/rol/src/step/trustregion/ROL_TrustRegion.hpp
@@ -319,6 +319,7 @@ public:
         // Compute new gradient
         xtmp_->set(x); xtmp_->plus(s);
         bnd.project(*xtmp_);
+        obj.update(*xtmp_);
         obj.gradient(*dual_,*xtmp_,tol); // MUST DO SOMETHING HERE WITH TOL
         ngrad++;
         // Compute smoothed step


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/rol 
@mperego 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

The initial goal of this PR was to configure the definition of the HAVE_ROL_DEBUG macro using cmake.
After that, when running ctest with HAVE_ROL_DEBUG defined, some issues in Piro_PerformAnalysis with Thyra adapters have been observed.

It has been observed that, in at least some optimization algorithm implementations, the update function is not always called before the computation of the Hessian or the gradient when either x (called u in ROL) or p (called z in ROL) has been updated.
There were two options to overcome this:
1. To revisit ROL functions and add update if required,
2. To add a check at the beginning of the Thyra adapters to test if x or p has changed, if it is the case, the values are updated.

It is the latest solution which is implemented in this PR.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

I tested the branch on Blake and I tested Albany tests built against this branch.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->