### PR TITLE
Panzer: fix periodic bc matcher for 32 bit int limit

### DIFF
--- a/packages/panzer/adapters-stk/example/main_driver/CMakeLists.txt
+++ b/packages/panzer/adapters-stk/example/main_driver/CMakeLists.txt
@@ -31,6 +31,7 @@ TRIBITS_COPY_FILES_TO_BINARY_DIR(main_driver_files
     meshmotion.xml
     periodic_wedge.xml
     periodic_wedge.pam
+    energy-periodic-32bit-limit.xml
   EXEDEPS main_driver
   )
 
@@ -43,7 +44,6 @@ TRIBITS_ADD_ADVANCED_TEST(
   TEST_1 EXEC main_driver 
     ARGS  --i=energy-ss-tp.xml
     PASS_REGULAR_EXPRESSION "panzer::MainDriver run completed."
-    XHOST trilinos-test.sandia.gov trilinos-test2.sandia.gov zan.sandia.gov
   )
 
 TRIBITS_ADD_ADVANCED_TEST(
@@ -51,7 +51,6 @@ TRIBITS_ADD_ADVANCED_TEST(
   TEST_0 EXEC main_driver 
     ARGS  --i=energy-transient.xml
     PASS_REGULAR_EXPRESSION "panzer::MainDriver run completed."
-    XHOST trilinos-test.sandia.gov trilinos-test2.sandia.gov zan.sandia.gov
   )
 
 TRIBITS_ADD_ADVANCED_TEST(
@@ -59,7 +58,6 @@ TRIBITS_ADD_ADVANCED_TEST(
   TEST_0 EXEC main_driver 
     ARGS  --i=energy-ss-blocked.xml
     PASS_REGULAR_EXPRESSION "panzer::MainDriver run completed."
-    XHOST trilinos-test.sandia.gov trilinos-test2.sandia.gov zan.sandia.gov
   )
 
 TRIBITS_ADD_ADVANCED_TEST(
@@ -67,7 +65,6 @@ TRIBITS_ADD_ADVANCED_TEST(
   TEST_0 EXEC main_driver 
     ARGS  --i=energy-ss-loca-eigenvalue.xml
     PASS_REGULAR_EXPRESSION "panzer::MainDriver run completed."
-    XHOST trilinos-test.sandia.gov trilinos-test2.sandia.gov zan.sandia.gov
   )
 
 TRIBITS_ADD_ADVANCED_TEST(
@@ -75,7 +72,13 @@ TRIBITS_ADD_ADVANCED_TEST(
   TEST_0 EXEC main_driver 
     ARGS  --i=energy-ss-blocked-tp.xml
     PASS_REGULAR_EXPRESSION "panzer::MainDriver run completed."
-    XHOST trilinos-test.sandia.gov trilinos-test2.sandia.gov zan.sandia.gov
+  )
+
+TRIBITS_ADD_ADVANCED_TEST(
+  main_driver_energy-periodic-32bit-limit
+  TEST_0 EXEC main_driver
+    ARGS  --i=energy-periodic-32bit-limit.xml
+    PASS_REGULAR_EXPRESSION "panzer::MainDriver run completed."
   )
 
 TRIBITS_ADD_ADVANCED_TEST(
@@ -84,7 +87,6 @@ TRIBITS_ADD_ADVANCED_TEST(
     ARGS  --i=energy-neumann.xml --flux-calc
     PASS_REGULAR_EXPRESSION "panzer::MainDriver run completed."
     NUM_MPI_PROCS 1
-    XHOST trilinos-test.sandia.gov trilinos-test2.sandia.gov zan.sandia.gov
   )
 
 TRIBITS_ADD_ADVANCED_TEST(
@@ -101,7 +103,6 @@ IF(${PACKAGE_NAME}_ENABLE_Teko)
     TEST_0 EXEC main_driver 
       ARGS  --i=energy-transient-blocked.xml
       PASS_REGULAR_EXPRESSION "panzer::MainDriver run completed."
-      XHOST trilinos-test.sandia.gov trilinos-test2.sandia.gov zan.sandia.gov
     )
 ENDIF()
 

--- a/packages/panzer/adapters-stk/example/main_driver/energy-periodic-32bit-limit.xml
+++ b/packages/panzer/adapters-stk/example/main_driver/energy-periodic-32bit-limit.xml
@@ -1,0 +1,326 @@
+<ParameterList name="Drekar">
+
+    <ParameterList name="Mesh">
+       
+        <Parameter name="Source" type="string" value="Inline Mesh" />
+
+        <ParameterList name="Inline Mesh">
+            <Parameter name="Mesh Dimension" type="int" value="2" />
+            <ParameterList name="Mesh Factory Parameter List">
+                <Parameter name="X Blocks" type="int" value="1" />
+                <Parameter name="Y Blocks" type="int" value="1" />
+                <Parameter name="X Elements" type="int" value="20" />
+                <Parameter name="Y Elements" type="int" value="20" />
+                <Parameter name="X0" type="double" value="0.0" />
+                <Parameter name="Y0" type="double" value="0.0" />
+                <Parameter name="Xf" type="double" value="1.0" />
+                <Parameter name="Yf" type="double" value="1.0" />
+                <Parameter name="Offset mesh GIDs above 32-bit int limit" type="string" value="ON" />
+                <ParameterList name="Periodic BCs">
+                  <Parameter name="Count" type="int" value="1" />
+                  <Parameter name="Periodic Condition 1" type="string" value="y-all 1.0e-8: left;right"/>
+                </ParameterList>
+            </ParameterList>
+        </ParameterList>
+
+    </ParameterList>
+
+    <ParameterList name="Initial Conditions">
+        <ParameterList name="eblock-0_0">
+            <ParameterList name="TEMPERATURE">
+                <Parameter name="Value" type="double" value="0.0"/>
+            </ParameterList>
+        </ParameterList>
+    </ParameterList>
+
+    <ParameterList name="Responses">
+      <ParameterList name="Volume Integral">
+         <Parameter name="Type" type="string" value="Functional"/>
+         <Parameter name="Field Name" type="string" value="Volume_Integral"/>
+         <Parameter name="Element Blocks" type="string" value="eblock-0_0"/>
+         <Parameter name="Evaluation Types" type="string" value="Residual"/>
+      </ParameterList>
+      <ParameterList name="Volume Integral2">
+         <Parameter name="Type" type="string" value="Functional"/>
+         <Parameter name="Field Name" type="string" value="Volume_Integral"/>
+         <Parameter name="Element Blocks" type="string" value="eblock-0_0"/>
+         <Parameter name="Evaluation Types" type="string" value="Residual"/>
+      </ParameterList>
+    </ParameterList>
+
+    <ParameterList name="Block ID to Physics ID Mapping">
+        <Parameter name="eblock-0_0" type="string" value="solid"/>
+    </ParameterList>
+
+    <ParameterList name="Assembly">
+        <Parameter name="Workset Size" type="int" value="1"/>
+    </ParameterList>
+
+    <ParameterList name="Physics Blocks">
+
+        <ParameterList name="solid">
+
+            <ParameterList name="EQ 0">
+                <Parameter name="Type" type="string" value="Energy"/> 
+                <Parameter name="Basis Type" type="string" value="HGrad"/> 
+                <Parameter name="Basis Order" type="int" value="1"/> 
+                <Parameter name="Integration Order" type="int" value="2"/> 
+                <Parameter name="Model ID" type="string" value="fluid model"/> 
+                <Parameter name="Prefix" type="string" value=""/>
+            </ParameterList>
+
+        </ParameterList>
+
+    </ParameterList>
+
+    <ParameterList name="Closure Models">
+ 
+        <ParameterList name="fluid model">
+
+            <ParameterList name="Volume Integral">
+            </ParameterList>
+
+            <ParameterList name="SOURCE_TEMPERATURE">
+                <Parameter name="Type" type="string" value="Parameter"/>
+            </ParameterList>
+            <ParameterList name="Heat Capacity">
+                <Parameter name="Value" type="double" value="1.0"/>
+            </ParameterList>
+            <ParameterList name="Thermal Conductivity">
+                <Parameter name="Value" type="double" value="1.0"/>
+            </ParameterList>
+            <ParameterList name="DENSITY">
+                <Parameter name="Value" type="double" value="1.0"/>
+            </ParameterList>
+            <ParameterList name="HEAT_CAPACITY">
+                <Parameter name="Value" type="double" value="1.0"/>
+            </ParameterList>
+            <ParameterList name="Global Statistics">
+                <Parameter name="Value" type="string" value="TEMPERATURE,DENSITY"/>
+            </ParameterList>
+
+        </ParameterList>
+
+    </ParameterList>
+
+    <ParameterList name="User Data">
+
+        <ParameterList name="function data one">
+
+        </ParameterList>
+
+        <ParameterList name="IP Coordinates">
+            <Parameter name="Integration Order" type="int" value="2"/> 
+        </ParameterList>
+
+
+    </ParameterList>
+
+    <ParameterList name="Boundary Conditions">
+
+        <ParameterList>
+            <Parameter name="Type" type="string" value="Dirichlet"/> 
+            <Parameter name="Sideset ID" type="string" value="left"/> 
+            <Parameter name="Element Block ID" type="string" value="eblock-0_0"/> 
+            <Parameter name="Equation Set Name" type="string" value="TEMPERATURE"/> 
+            <Parameter name="Strategy" type="string" value="Constant"/>
+            <ParameterList name="Data">
+                <Parameter name="Value" type="double" value="0.0"/>
+            </ParameterList>
+        </ParameterList>
+<!--
+        <ParameterList>
+            <Parameter name="Type" type="string" value="Dirichlet"/> 
+            <Parameter name="Sideset ID" type="string" value="right"/> 
+            <Parameter name="Element Block ID" type="string" value="eblock-0_0"/> 
+            <Parameter name="Equation Set Name" type="string" value="TEMPERATURE"/> 
+            <Parameter name="Strategy" type="string" value="Constant"/>
+            <ParameterList name="Data">
+                <Parameter name="Value" type="double" value="0.0"/>
+            </ParameterList>
+        </ParameterList>
+-->    
+
+    </ParameterList>
+
+    <ParameterList name="Output">
+        <Parameter name="File Name" type="string" value="energy-periodic-32bit-limit.exo"/>
+    </ParameterList>
+
+    <ParameterList name="Options">
+        <Parameter name="Write Volume Assembly Graphs" type="bool" value="true"/>
+        <Parameter name="Volume Assembly Graph Prefix" type="string" value="energy-ss"/> 
+        <Parameter name="Write Field Manager Files" type="bool" value="true"/>
+        <Parameter name="Field Manager File Prefix" type="string" value="energy-ss"/> 
+    </ParameterList>
+
+    <ParameterList name="Active Parameters">
+        <Parameter name="Number of Parameter Vectors" type="int" value="1"/>
+        <ParameterList name="Parameter Vector 0">
+            <Parameter name="Number" type="int" value="1"/>
+            <Parameter name="Parameter 0" type="string" value="SOURCE_TEMPERATURE"/>
+            <Parameter name="Initial Value 0" type="double" value="1.0"/>
+        </ParameterList>
+    </ParameterList>
+
+<ParameterList name="Solution Control">
+  <Parameter name="Piro Solver" type="string" value="NOX"/>
+  <Parameter name="Compute Sensitivities" type="bool" value="0"/>
+  <Parameter name="Jacobian Operator" type="string" value="Have Jacobian"/>
+  <ParameterList name="LOCA">
+    <ParameterList name="Bifurcation"/>
+    <ParameterList name="Constraints"/>
+    <ParameterList name="Predictor">
+      <Parameter  name="Method" type="string" value="Constant"/>
+    </ParameterList>
+    <ParameterList name="Stepper">
+      <Parameter  name="Continuation Method" type="string" value="Natural"/>
+      <Parameter  name="Initial Value" type="double" value="1.0"/>
+      <Parameter  name="Continuation Parameter" type="string" value="Parameter 0"/>
+      <Parameter  name="Max Steps" type="int" value="6"/>
+      <Parameter  name="Max Value" type="double" value="12.25"/>
+      <Parameter  name="Min Value" type="double" value="0.5"/>
+      <Parameter  name="Compute Eigenvalues" type="bool" value="1"/>
+      <ParameterList name="Eigensolver">
+        <Parameter name="Method" type="string" value="Anasazi"/>
+        <Parameter name="Operator" type="string" value="Shift-Invert"/>
+        <Parameter name="Num Blocks" type="int" value="3"/>
+        <Parameter name="Num Eigenvalues" type="int" value="1"/>
+        <Parameter name="Block Size" type="int" value="1"/>
+        <Parameter name="Maximum Restarts" type="int" value="0"/>
+        <Parameter name="Shift" type="double" value="1.0"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Step Size">
+      <Parameter  name="Initial Step Size" type="double" value="0.5"/>
+      <Parameter  name="Aggressiveness" type="double" value="2.0"/>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="NOX">
+    <ParameterList name="Direction">
+      <Parameter name="Method" type="string" value="Newton"/>
+      <ParameterList name="Newton">
+        <Parameter name="Forcing Term Method" type="string" value="Constant"/>
+        <Parameter name="Rescue Bad Newton Solve" type="bool" value="1"/>
+        <ParameterList name="Stratimikos Linear Solver">
+          <ParameterList name="NOX Stratimikos Options">
+          </ParameterList>
+          <ParameterList name="Stratimikos">
+            <Parameter name="Linear Solver Type" type="string" value="AztecOO"/>
+            <ParameterList name="Linear Solver Types">
+              <ParameterList name="AztecOO">
+                <ParameterList name="Forward Solve"> 
+                  <ParameterList name="AztecOO Settings">
+                    <Parameter name="Aztec Solver" type="string" value="GMRES"/>
+                    <Parameter name="Convergence Test" type="string" value="r0"/>
+                    <Parameter name="Size of Krylov Subspace" type="int" value="200"/>
+                    <Parameter name="Output Frequency" type="int" value="10"/>
+                  </ParameterList>
+                  <Parameter name="Max Iterations" type="int" value="200"/>
+                  <Parameter name="Tolerance" type="double" value="1e-5"/>
+                </ParameterList>
+              </ParameterList>
+              <ParameterList name="Belos">
+                <Parameter name="Solver Type" type="string" value="Block GMRES"/>
+                <ParameterList name="Solver Types">
+                  <ParameterList name="Block GMRES">
+                    <Parameter name="Convergence Tolerance" type="double" value="1e-5"/>
+                    <Parameter name="Output Frequency" type="int" value="10"/>
+                    <Parameter name="Output Style" type="int" value="1"/>
+                    <Parameter name="Verbosity" type="int" value="33"/>
+                    <Parameter name="Maximum Iterations" type="int" value="100"/>
+                    <Parameter name="Block Size" type="int" value="1"/>
+                    <Parameter name="Num Blocks" type="int" value="20"/>
+                    <Parameter name="Flexible Gmres" type="bool" value="0"/>
+                  </ParameterList>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+            <Parameter name="Preconditioner Type" type="string" value="Ifpack"/>
+            <ParameterList name="Preconditioner Types">
+              <ParameterList name="Ifpack">
+                <Parameter name="Overlap" type="int" value="1"/>
+                <Parameter name="Prec Type" type="string" value="ILU"/>
+                <ParameterList name="Ifpack Settings">
+                  <Parameter name="fact: drop tolerance" type="double" value="0"/>
+                  <Parameter name="fact: ilut level-of-fill" type="double" value="1"/>
+                  <Parameter name="fact: level-of-fill" type="int" value="1"/>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Line Search">
+      <ParameterList name="Full Step">
+        <Parameter name="Full Step" type="double" value="1"/>
+      </ParameterList>
+      <Parameter name="Method" type="string" value="Full Step"/>
+    </ParameterList>
+    <Parameter name="Nonlinear Solver" type="string" value="Line Search Based"/>
+    <ParameterList name="Printing">
+      <Parameter name="Output Precision" type="int" value="3"/>
+      <Parameter name="Output Processor" type="int" value="0"/>
+      <ParameterList name="Output Information">
+        <Parameter name="Error" type="bool" value="1"/>
+        <Parameter name="Warning" type="bool" value="1"/>
+        <Parameter name="Outer Iteration" type="bool" value="1"/>
+        <Parameter name="Parameters" type="bool" value="1"/>
+        <Parameter name="Details" type="bool" value="1"/>
+        <Parameter name="Linear Solver Details" type="bool" value="1"/>
+        <Parameter name="Stepper Iteration" type="bool" value="1"/>
+        <Parameter name="Stepper Details" type="bool" value="1"/>
+        <Parameter name="Stepper Parameters" type="bool" value="1"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Solver Options">
+      <Parameter name="Status Test Check Type" type="string" value="Minimal"/>
+    </ParameterList>
+    <ParameterList name="Status Tests">
+      <Parameter name="Test Type" type="string" value="Combo"/>
+      <Parameter name="Combo Type" type="string" value="OR"/>
+      <Parameter name="Number of Tests" type="int" value="2"/>
+      <ParameterList name="Test 0">
+        <Parameter name="Test Type" type="string" value="Combo"/>
+        <Parameter name="Combo Type" type="string" value="AND"/>
+        <Parameter name="Number of Tests" type="int" value="2"/>
+        <ParameterList name="Test 0">
+          <Parameter name="Test Type" type="string" value="NormF"/>
+          <Parameter name="Tolerance" type="double" value="1.0e-8"/>
+        </ParameterList>
+        <ParameterList name="Test 1">
+          <Parameter name="Test Type" type="string" value="RelativeNormF"/>
+          <Parameter name="Tolerance" type="double" value="1.0e-4"/>
+        </ParameterList>
+      </ParameterList>
+      <ParameterList name="Test 1">
+        <Parameter name="Test Type" type="string" value="MaxIters"/>
+        <Parameter name="Maximum Iterations" type="int" value="10"/>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Rythmos">
+    <Parameter name="Num Time Steps" type="int" value="10"/>
+    <Parameter name="Final Time" type="double" value="0.1"/>
+    <Parameter name="Stepper Type" type="string" value="Backward Euler"/>
+    <ParameterList name="Rythmos Stepper">
+      <ParameterList name="VerboseObject">
+        <Parameter name="Verbosity Level" type="string" value="medium"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Stratimikos">
+    </ParameterList>
+    <ParameterList name="Rythmos Integration Control">
+    </ParameterList>
+    <ParameterList name="Rythmos Integrator">
+      <ParameterList name="VerboseObject">
+        <Parameter name="Verbosity Level" type="string" value="medium"/>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+</ParameterList>
+
+
+</ParameterList>
+

--- a/packages/panzer/adapters-stk/src/Panzer_STKConnManager.cpp
+++ b/packages/panzer/adapters-stk/src/Panzer_STKConnManager.cpp
@@ -354,7 +354,7 @@ void STKConnManager::applyPeriodicBCs(const panzer::FieldPattern & fp, GlobalOrd
         TEUCHOS_ASSERT(false);
 
       // get relevent elements and node IDs
-      stkMeshDB_->getOwnedElementsSharingNode(oldNodeId-offset0,elements,localIds,(*matchTypes)[m]);
+      stkMeshDB_->getOwnedElementsSharingNode(stk::mesh::EntityId(oldNodeId-offset0),elements,localIds,(*matchTypes)[m]);
 
       // modify global numbering already built for each element
       for(std::size_t e=0;e<elements.size();e++){

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_PeriodicBC_Matcher.cpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_PeriodicBC_Matcher.cpp
@@ -135,7 +135,7 @@ getLocalSideIds(const STK_Interface & mesh,
    stk::mesh::Selector mySides = *side & (metaData->locally_owned_part() | metaData->globally_shared_part());
 
    stk::mesh::EntityRank rank;
-   unsigned int offset = 0; // offset to avoid giving nodes, edges, faces the same sideId 
+   panzer::GlobalOrdinal offset = 0; // offset to avoid giving nodes, edges, faces the same sideId
    if(type_ == "coord"){
      rank = mesh.getNodeRank();
    } else if(type_ == "edge"){

--- a/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_SquareQuadMeshFactory.cpp
+++ b/packages/panzer/adapters-stk/src/stk_interface/Panzer_STK_SquareQuadMeshFactory.cpp
@@ -327,8 +327,8 @@ void SquareQuadMeshFactory::buildBlock(stk::ParallelMachine /* parallelMach */,i
 
    offset_ = 0;
    if (offsetGIDs_) {
-     if (std::numeric_limits<panzer::GlobalOrdinal>::max() > std::numeric_limits<panzer::LocalOrdinal>::max())
-       offset_ = panzer::GlobalOrdinal(std::numeric_limits<panzer::LocalOrdinal>::max()) + 1;
+     if (std::numeric_limits<panzer::GlobalOrdinal>::max() > std::numeric_limits<unsigned int>::max())
+       offset_ = panzer::GlobalOrdinal(std::numeric_limits<unsigned int>::max()) + 1;
    }
 
    // build the nodes


### PR DESCRIPTION
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/panzer 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
FEM^3 reported seg fault for large scale problems using periodic bcs.

<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->
Application now passes at scale.

## Testing
New test added that shifts mesh GIDs above 32-bit int limit to reproduce failure. Test is:
 
panzer/adapters-stk/example/main_driver/energy-periodic-32bit-limit.xml

