### PR TITLE
MueLu: Print stack traces

### DIFF
--- a/cmake/ctest/drivers/geminga/ctest_linux_nightly_mpi_release_muelu_cuda_no_uvm_geminga.cmake
+++ b/cmake/ctest/drivers/geminga/ctest_linux_nightly_mpi_release_muelu_cuda_no_uvm_geminga.cmake
@@ -64,7 +64,7 @@ INCLUDE("${CTEST_SCRIPT_DIRECTORY}/TrilinosCTestDriverCore.geminga.gcc-cuda.cmak
 # Tribits creates the variable listed under "Build Name" by prepending the OS type and compiler
 # details to BUILD_DIR_NAME.
 SET(COMM_TYPE MPI)
-SET(BUILD_TYPE RELEASE)
+SET(BUILD_TYPE RELWITHDEBINFO)
 SET(BUILD_NAME_DETAILS KOKKOS-REFACTOR_EXPERIMENTAL_CUDA-$ENV{SEMS_CUDA_VERSION}_NO_UVM)
 
 SET(CTEST_PARALLEL_LEVEL 8)
@@ -84,6 +84,7 @@ SET(EXTRA_CONFIGURE_OPTIONS
 
   ### TPLS ###
   "-DTPL_ENABLE_SuperLU:BOOL=ON"
+  "-DTPL_ENABLE_BinUtils:BOOL=ON"
 
   ### PACKAGES CONFIGURATION ###
       "-DMueLu_ENABLE_Experimental:BOOL=ON"

--- a/packages/muelu/test/unit_tests/MueLu_Test_ETI.hpp
+++ b/packages/muelu/test/unit_tests/MueLu_Test_ETI.hpp
@@ -102,6 +102,9 @@ bool Automatic_Test_ETI(int argc, char *argv[]) {
     Teuchos::CommandLineProcessor clp(false);
     std::string node   = "";    clp.setOption("node",               &node,   "node type (serial | openmp | cuda)");
     bool        config = false; clp.setOption("config", "noconfig", &config, "display kokkos configuration");
+#ifdef HAVE_TEUCHOS_STACKTRACE
+    bool stacktrace = true;     clp.setOption("stacktrace", "nostacktrace", &stacktrace, "display stacktrace");
+#endif
     Xpetra::Parameters xpetraParameters(clp);
 
     clp.recogniseAllOptions(false);
@@ -111,6 +114,11 @@ bool Automatic_Test_ETI(int argc, char *argv[]) {
       case Teuchos::CommandLineProcessor::PARSE_SUCCESSFUL:
       case Teuchos::CommandLineProcessor::PARSE_HELP_PRINTED:         break;
     }
+
+#ifdef HAVE_TEUCHOS_STACKTRACE
+    if (stacktrace)
+      Teuchos::print_stack_on_segfault();
+#endif
 
     auto lib = xpetraParameters.GetLib();
     if (lib == Xpetra::UseEpetra) {

--- a/packages/muelu/test/unit_tests_kokkos/MueLu_UnitTests_kokkos.cpp
+++ b/packages/muelu/test/unit_tests_kokkos/MueLu_UnitTests_kokkos.cpp
@@ -105,6 +105,10 @@ int main(int argc, char* argv[]) {
     comm->barrier();
 #endif
 
+#ifdef HAVE_TEUCHOS_STACKTRACE
+    Teuchos::print_stack_on_segfault();
+#endif
+
     // Comment this line to get rid of MueLu output
     MueLu::VerboseObject::SetDefaultVerbLevel(MueLu::High);
 


### PR DESCRIPTION
@trilinos/muelu 

## Motivation
Add printing of stack traces to MueLu test ETI. (Requires TPL BinUtils.)

Use it in the no-UVM nightly build to get spots with inaccessible memory spaces.