### PR TITLE
MueLu: removing a UVM access from MueLu_Aggregates_kokkos_def.hpp

### DIFF
--- a/packages/muelu/src/Graph/Containers/MueLu_Aggregates_kokkos_def.hpp
+++ b/packages/muelu/src/Graph/Containers/MueLu_Aggregates_kokkos_def.hpp
@@ -126,8 +126,9 @@ namespace MueLu {
   template <class LocalOrdinal, class GlobalOrdinal, class DeviceType>
   typename Aggregates_kokkos<LocalOrdinal, GlobalOrdinal, Kokkos::Compat::KokkosDeviceWrapperNode<DeviceType> >::local_graph_type
   Aggregates_kokkos<LocalOrdinal, GlobalOrdinal, Kokkos::Compat::KokkosDeviceWrapperNode<DeviceType> >::GetGraph() const {
-    typedef typename local_graph_type::row_map_type row_map_type;
-    typedef typename local_graph_type::entries_type entries_type;
+    using row_map_type = typename local_graph_type::row_map_type;
+    using entries_type = typename local_graph_type::entries_type;
+    using size_type    = typename local_graph_type::size_type;
 
     auto numAggregates = numAggregates_;
 
@@ -154,7 +155,13 @@ namespace MueLu {
 
     int myPID = GetMap()->getComm()->getRank();
 
-    typename entries_type::non_const_type cols(Kokkos::ViewAllocateWithoutInitializing("Agg_cols"), rows(numAggregates));
+    size_type numNNZ;
+    {
+      Kokkos::View<size_type, device_type> numNNZ_device = Kokkos::subview(rows, numAggregates);
+      typename Kokkos::View<size_type, device_type>::HostMirror numNNZ_host = Kokkos::create_mirror_view(numNNZ_device);
+      numNNZ = numNNZ_host();
+    }
+    typename entries_type::non_const_type cols(Kokkos::ViewAllocateWithoutInitializing("Agg_cols"), numNNZ);
     size_t realnnz = 0;
     Kokkos::parallel_reduce("MueLu:Aggregates:GetGraph:compute_cols", range_type(0, procWinner.size()),
       KOKKOS_LAMBDA(const LO i, size_t& nnz) {
@@ -165,7 +172,7 @@ namespace MueLu {
           nnz++;
         }
       }, realnnz);
-    TEUCHOS_TEST_FOR_EXCEPTION(realnnz != rows(numAggregates), Exceptions::RuntimeError,
+    TEUCHOS_TEST_FOR_EXCEPTION(realnnz != numNNZ, Exceptions::RuntimeError,
         "MueLu: Internal error: Something is wrong with aggregates graph construction");
 
     graph_ = local_graph_type(cols, rows);


### PR DESCRIPTION
Small modifcation that extracts the number of nnz from the row_map
view to then allocate column_indices view.

@trilinos/muelu

## Motivation
Removing UVM is good for the moral

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 


## Stakeholder Feedback


## Testing
Locally tested on my workstation

## Additional Information
