### PR TITLE
Teuchos: fix Doxygen group in ParameterList

### DIFF
--- a/packages/teuchos/parameterlist/src/Teuchos_ParameterList.hpp
+++ b/packages/teuchos/parameterlist/src/Teuchos_ParameterList.hpp
@@ -185,9 +185,6 @@ public:
   //! Destructor
   virtual ~ParameterList();
 
-  //! Get the number of stored parameters.
-  Ordinal numParams () const;
-
   //@}
   //! @name Set Functions 
   //@{
@@ -576,6 +573,9 @@ public:
   template<typename T>
   bool isType(const std::string& name, T* ptr) const;
 #endif
+
+  //! Get the number of stored parameters.
+  Ordinal numParams () const;
 
   //@}
   


### PR DESCRIPTION
@trilinos/teuchos 

## Motivation

This changes fixes the false assignment of the method to Doxygen groups. Move the method `numParams()` to the Doxygen group "Attribute Functions", where it fits in better than in the "Constructors" group.

## Testing

Existing `Teuchos` unit tests are passing.