### PR TITLE
Tpetra:  remove check of Kokkos warning output in Tpetra tests

### DIFF
--- a/packages/tpetra/core/test/Core/ScopeGuard_tpetra_inits_kokkos.cpp
+++ b/packages/tpetra/core/test/Core/ScopeGuard_tpetra_inits_kokkos.cpp
@@ -3,10 +3,6 @@
 #include "Tpetra_Core.hpp"
 #include "Kokkos_Core.hpp"
 
-namespace { // (anonymous)
-
-// NOTE TO TEST AUTHORS: The code that calls this function captures
-// std::cerr, so don't write to std::cerr on purpose in this function.
 void testMain (bool& success, int argc, char* argv[])
 {
   using std::cout;
@@ -62,30 +58,6 @@ void testMain (bool& success, int argc, char* argv[])
   }
 }
 
-class CaptureOstream {
-public:
-  CaptureOstream (std::ostream& stream) :
-    originalStream_ (stream),
-    originalBuffer_ (stream.rdbuf ())
-  {
-    originalStream_.rdbuf (tempStream_.rdbuf ());
-  }
-
-  std::string getCapturedOutput () const {
-    return tempStream_.str ();
-  }
-
-  ~CaptureOstream () {
-    originalStream_.rdbuf (originalBuffer_);
-  }
-private:
-  std::ostream& originalStream_;
-  std::ostringstream tempStream_;
-  using buf_ptr_type = decltype (originalStream_.rdbuf ());
-  buf_ptr_type originalBuffer_;
-};
-
-} // namespace (anonymous)
 
 int main (int argc, char* argv[])
 {
@@ -93,18 +65,7 @@ int main (int argc, char* argv[])
   using std::endl;
 
   bool success = true;
-  {
-    // Capture std::cerr output, so we can tell if Tpetra::initialize
-    // printed a warning message.
-    CaptureOstream captureCerr (std::cerr);
-    testMain (success, argc, argv);
-    const std::string capturedOutput = captureCerr.getCapturedOutput ();
-    cout << "Captured output: " << capturedOutput << endl;
-    if (capturedOutput.size () != 0) {
-      success = false; // should NOT have printed in this case
-      cout << "Captured output is empty!" << endl;
-    }
-  }
+  testMain (success, argc, argv);
 
   cout << "End Result: TEST " << (success ? "PASSED" : "FAILED") << endl;
   return EXIT_SUCCESS;

--- a/packages/tpetra/core/test/Core/ScopeGuard_tpetra_inits_mpi.cpp
+++ b/packages/tpetra/core/test/Core/ScopeGuard_tpetra_inits_mpi.cpp
@@ -9,7 +9,6 @@
 #include "mpi.h"
 #include "Tpetra_Details_extractMpiCommFromTeuchos.hpp"
 
-namespace { // (anonymous)
 
 bool isMpiInitialized ()
 {
@@ -177,49 +176,13 @@ void testMain (bool& success, int argc, char* argv[])
   }
 }
 
-class CaptureOstream {
-public:
-  CaptureOstream (std::ostream& stream) :
-    originalStream_ (stream),
-    originalBuffer_ (stream.rdbuf ())
-  {
-    originalStream_.rdbuf (tempStream_.rdbuf ());
-  }
-
-  std::string getCapturedOutput () const {
-    return tempStream_.str ();
-  }
-
-  ~CaptureOstream () {
-    originalStream_.rdbuf (originalBuffer_);
-  }
-private:
-  std::ostream& originalStream_;
-  std::ostringstream tempStream_;
-  using buf_ptr_type = decltype (originalStream_.rdbuf ());
-  buf_ptr_type originalBuffer_;
-};
-
-} // namespace (anonymous)
-
 int main (int argc, char* argv[])
 {
   using std::cout;
   using std::endl;
 
   bool success = true;
-  {
-    // Capture std::cerr output, so we can tell if Tpetra::initialize
-    // printed a warning message.
-    CaptureOstream captureCerr (std::cerr);
-    testMain (success, argc, argv);
-    const std::string capturedOutput = captureCerr.getCapturedOutput ();
-    cout << "Captured output: " << capturedOutput << endl;
-    if (capturedOutput.size () != 0) {
-      success = false; // should NOT have printed in this case
-      cout << "Captured output is empty!" << endl;
-    }
-  }
+  testMain (success, argc, argv);
 
   cout << "End Result: TEST " << (success ? "PASSED" : "FAILED") << endl;
   return EXIT_SUCCESS;

--- a/packages/tpetra/core/test/Core/ScopeGuard_tpetra_inits_mpi_user_inits_kokkos.cpp
+++ b/packages/tpetra/core/test/Core/ScopeGuard_tpetra_inits_mpi_user_inits_kokkos.cpp
@@ -10,7 +10,6 @@
 #include "mpi.h"
 #include "Tpetra_Details_extractMpiCommFromTeuchos.hpp"
 
-namespace { // (anonymous)
 
 bool isMpiInitialized ()
 {
@@ -214,49 +213,13 @@ void testMain (bool& success, int argc, char* argv[])
   }
 }
 
-class CaptureOstream {
-public:
-  CaptureOstream (std::ostream& stream) :
-    originalStream_ (stream),
-    originalBuffer_ (stream.rdbuf ())
-  {
-    originalStream_.rdbuf (tempStream_.rdbuf ());
-  }
-
-  std::string getCapturedOutput () const {
-    return tempStream_.str ();
-  }
-
-  ~CaptureOstream () {
-    originalStream_.rdbuf (originalBuffer_);
-  }
-private:
-  std::ostream& originalStream_;
-  std::ostringstream tempStream_;
-  using buf_ptr_type = decltype (originalStream_.rdbuf ());
-  buf_ptr_type originalBuffer_;
-};
-
-} // namespace (anonymous)
-
 int main (int argc, char* argv[])
 {
   using std::cout;
   using std::endl;
 
   bool success = true;
-  {
-    // Capture std::cerr output, so we can tell if Tpetra::initialize
-    // printed a warning message.
-    CaptureOstream captureCerr (std::cerr);
-    testMain (success, argc, argv);
-    const std::string capturedOutput = captureCerr.getCapturedOutput ();
-    cout << "Captured output: " << capturedOutput << endl;
-    if (capturedOutput.size () != 0) {
-      success = false; // should NOT have printed in this case
-      cout << "Captured output is empty!" << endl;
-    }
-  }
+  testMain (success, argc, argv);
 
   cout << "End Result: TEST " << (success ? "PASSED" : "FAILED") << endl;
   return EXIT_SUCCESS;

--- a/packages/tpetra/core/test/Core/ScopeGuard_user_inits_kokkos.cpp
+++ b/packages/tpetra/core/test/Core/ScopeGuard_user_inits_kokkos.cpp
@@ -3,10 +3,6 @@
 #include "Tpetra_Core.hpp"
 #include "Kokkos_Core.hpp"
 
-namespace { // (anonymous)
-
-// NOTE TO TEST AUTHORS: The code that calls this function captures
-// std::cerr, so don't write to std::cerr on purpose in this function.
 void testMain (bool& success, int argc, char* argv[])
 {
   using std::cout;
@@ -73,49 +69,13 @@ void testMain (bool& success, int argc, char* argv[])
   }
 }
 
-class CaptureOstream {
-public:
-  CaptureOstream (std::ostream& stream) :
-    originalStream_ (stream),
-    originalBuffer_ (stream.rdbuf ())
-  {
-    originalStream_.rdbuf (tempStream_.rdbuf ());
-  }
-
-  std::string getCapturedOutput () const {
-    return tempStream_.str ();
-  }
-
-  ~CaptureOstream () {
-    originalStream_.rdbuf (originalBuffer_);
-  }
-private:
-  std::ostream& originalStream_;
-  std::ostringstream tempStream_;
-  using buf_ptr_type = decltype (originalStream_.rdbuf ());
-  buf_ptr_type originalBuffer_;
-};
-
-} // namespace (anonymous)
-
 int main (int argc, char* argv[])
 {
   using std::cout;
   using std::endl;
 
   bool success = true;
-  {
-    // Capture std::cerr output, so we can tell if Tpetra::initialize
-    // printed a warning message.
-    CaptureOstream captureCerr (std::cerr);
-    testMain (success, argc, argv);
-    const std::string capturedOutput = captureCerr.getCapturedOutput ();
-    cout << "Captured output: " << capturedOutput << endl;
-    if (capturedOutput.size () != 0) {
-      success = false; // should NOT have printed in this case
-      cout << "Captured output is empty!" << endl;
-    }
-  }
+  testMain (success, argc, argv);
 
   cout << "End Result: TEST " << (success ? "PASSED" : "FAILED") << endl;
   return EXIT_SUCCESS;

--- a/packages/tpetra/core/test/Core/ScopeGuard_user_inits_mpi.cpp
+++ b/packages/tpetra/core/test/Core/ScopeGuard_user_inits_mpi.cpp
@@ -9,7 +9,6 @@
 #include "mpi.h"
 #include "Tpetra_Details_extractMpiCommFromTeuchos.hpp"
 
-namespace { // (anonymous)
 
 bool isMpiInitialized ()
 {
@@ -185,49 +184,13 @@ void testMain (bool& success, int argc, char* argv[])
   Kokkos::finalize ();
 }
 
-class CaptureOstream {
-public:
-  CaptureOstream (std::ostream& stream) :
-    originalStream_ (stream),
-    originalBuffer_ (stream.rdbuf ())
-  {
-    originalStream_.rdbuf (tempStream_.rdbuf ());
-  }
-
-  std::string getCapturedOutput () const {
-    return tempStream_.str ();
-  }
-
-  ~CaptureOstream () {
-    originalStream_.rdbuf (originalBuffer_);
-  }
-private:
-  std::ostream& originalStream_;
-  std::ostringstream tempStream_;
-  using buf_ptr_type = decltype (originalStream_.rdbuf ());
-  buf_ptr_type originalBuffer_;
-};
-
-} // namespace (anonymous)
-
 int main (int argc, char* argv[])
 {
   using std::cout;
   using std::endl;
 
   bool success = true;
-  {
-    // Capture std::cerr output, so we can tell if Tpetra::initialize
-    // printed a warning message.
-    CaptureOstream captureCerr (std::cerr);
-    testMain (success, argc, argv);
-    const std::string capturedOutput = captureCerr.getCapturedOutput ();
-    cout << "Captured output: " << capturedOutput << endl;
-    if (capturedOutput.size () != 0) {
-      success = false; // should NOT have printed in this case
-      cout << "Captured output is empty!" << endl;
-    }
-  }
+  testMain (success, argc, argv);
 
   cout << "End Result: TEST " << (success ? "PASSED" : "FAILED") << endl;
   return EXIT_SUCCESS;

--- a/packages/tpetra/core/test/Core/ScopeGuard_user_inits_mpi_and_provides_comm.cpp
+++ b/packages/tpetra/core/test/Core/ScopeGuard_user_inits_mpi_and_provides_comm.cpp
@@ -8,7 +8,6 @@
 #include "mpi.h"
 #include "Tpetra_Details_extractMpiCommFromTeuchos.hpp"
 
-namespace { // (anonymous)
 
 bool isMpiInitialized ()
 {
@@ -195,49 +194,13 @@ void testMain (bool& success, int argc, char* argv[])
   (void) MPI_Finalize ();
 }
 
-class CaptureOstream {
-public:
-  CaptureOstream (std::ostream& stream) :
-    originalStream_ (stream),
-    originalBuffer_ (stream.rdbuf ())
-  {
-    originalStream_.rdbuf (tempStream_.rdbuf ());
-  }
-
-  std::string getCapturedOutput () const {
-    return tempStream_.str ();
-  }
-
-  ~CaptureOstream () {
-    originalStream_.rdbuf (originalBuffer_);
-  }
-private:
-  std::ostream& originalStream_;
-  std::ostringstream tempStream_;
-  using buf_ptr_type = decltype (originalStream_.rdbuf ());
-  buf_ptr_type originalBuffer_;
-};
-
-} // namespace (anonymous)
-
 int main (int argc, char* argv[])
 {
   using std::cout;
   using std::endl;
 
   bool success = true;
-  {
-    // Capture std::cerr output, so we can tell if Tpetra::initialize
-    // printed a warning message.
-    CaptureOstream captureCerr (std::cerr);
-    testMain (success, argc, argv);
-    const std::string capturedOutput = captureCerr.getCapturedOutput ();
-    cout << "Captured output: " << capturedOutput << endl;
-    if (capturedOutput.size () != 0) {
-      success = false; // should NOT have printed in this case
-      cout << "Captured output is empty!" << endl;
-    }
-  }
+  testMain (success, argc, argv);
 
   cout << "End Result: TEST " << (success ? "PASSED" : "FAILED") << endl;
   return EXIT_SUCCESS;

--- a/packages/tpetra/core/test/Core/ScopeGuard_user_inits_mpi_tpetra_inits_kokkos.cpp
+++ b/packages/tpetra/core/test/Core/ScopeGuard_user_inits_mpi_tpetra_inits_kokkos.cpp
@@ -9,7 +9,6 @@
 #include "mpi.h"
 #include "Tpetra_Details_extractMpiCommFromTeuchos.hpp"
 
-namespace { // (anonymous)
 
 bool isMpiInitialized ()
 {
@@ -184,49 +183,13 @@ void testMain (bool& success, int argc, char* argv[])
   (void) MPI_Finalize ();
 }
 
-class CaptureOstream {
-public:
-  CaptureOstream (std::ostream& stream) :
-    originalStream_ (stream),
-    originalBuffer_ (stream.rdbuf ())
-  {
-    originalStream_.rdbuf (tempStream_.rdbuf ());
-  }
-
-  std::string getCapturedOutput () const {
-    return tempStream_.str ();
-  }
-
-  ~CaptureOstream () {
-    originalStream_.rdbuf (originalBuffer_);
-  }
-private:
-  std::ostream& originalStream_;
-  std::ostringstream tempStream_;
-  using buf_ptr_type = decltype (originalStream_.rdbuf ());
-  buf_ptr_type originalBuffer_;
-};
-
-} // namespace (anonymous)
-
 int main (int argc, char* argv[])
 {
   using std::cout;
   using std::endl;
 
   bool success = true;
-  {
-    // Capture std::cerr output, so we can tell if Tpetra::initialize
-    // printed a warning message.
-    CaptureOstream captureCerr (std::cerr);
-    testMain (success, argc, argv);
-    const std::string capturedOutput = captureCerr.getCapturedOutput ();
-    cout << "Captured output: " << capturedOutput << endl;
-    if (capturedOutput.size () != 0) {
-      success = false; // should NOT have printed in this case
-      cout << "Captured output is empty!" << endl;
-    }
-  }
+  testMain (success, argc, argv);
 
   cout << "End Result: TEST " << (success ? "PASSED" : "FAILED") << endl;
   return EXIT_SUCCESS;

--- a/packages/tpetra/core/test/Core/initialize_tpetra_inits_kokkos.cpp
+++ b/packages/tpetra/core/test/Core/initialize_tpetra_inits_kokkos.cpp
@@ -3,10 +3,6 @@
 #include "Tpetra_Core.hpp"
 #include "Kokkos_Core.hpp"
 
-namespace { // (anonymous)
-
-// NOTE TO TEST AUTHORS: The code that calls this function captures
-// std::cerr, so don't write to std::cerr on purpose in this function.
 void testMain (bool& success, int argc, char* argv[])
 {
   using std::cout;
@@ -61,49 +57,13 @@ void testMain (bool& success, int argc, char* argv[])
   }
 }
 
-class CaptureOstream {
-public:
-  CaptureOstream (std::ostream& stream) :
-    originalStream_ (stream),
-    originalBuffer_ (stream.rdbuf ())
-  {
-    originalStream_.rdbuf (tempStream_.rdbuf ());
-  }
-
-  std::string getCapturedOutput () const {  
-    return tempStream_.str ();
-  }
-
-  ~CaptureOstream () {
-    originalStream_.rdbuf (originalBuffer_);
-  }
-private:
-  std::ostream& originalStream_;
-  std::ostringstream tempStream_;
-  using buf_ptr_type = decltype (originalStream_.rdbuf ());  
-  buf_ptr_type originalBuffer_;
-};
-
-} // namespace (anonymous)  
-
 int main (int argc, char* argv[])
 {
   using std::cout;
   using std::endl;
  
   bool success = true;
-  {
-    // Capture std::cerr output, so we can tell if Tpetra::initialize
-    // printed a warning message.
-    CaptureOstream captureCerr (std::cerr);
-    testMain (success, argc, argv);
-    const std::string capturedOutput = captureCerr.getCapturedOutput ();
-    cout << "Captured output: " << capturedOutput << endl;
-    if (capturedOutput.size () != 0) {
-      success = false; // should NOT have printed in this case
-      cout << "Captured output is empty!" << endl;
-    }
-  }
+  testMain (success, argc, argv);
   
   cout << "End Result: TEST " << (success ? "PASSED" : "FAILED") << endl;
   return EXIT_SUCCESS;

--- a/packages/tpetra/core/test/Core/initialize_tpetra_inits_mpi.cpp
+++ b/packages/tpetra/core/test/Core/initialize_tpetra_inits_mpi.cpp
@@ -9,8 +9,6 @@
 #include "mpi.h"
 #include "Tpetra_Details_extractMpiCommFromTeuchos.hpp"
 
-namespace { // (anonymous)
-
 bool isMpiInitialized ()
 {
   int mpiInitializedInt = 0;
@@ -172,49 +170,13 @@ void testMain (bool& success, int argc, char* argv[])
   }
 }
 
-class CaptureOstream {
-public:
-  CaptureOstream (std::ostream& stream) :
-    originalStream_ (stream),
-    originalBuffer_ (stream.rdbuf ())
-  {
-    originalStream_.rdbuf (tempStream_.rdbuf ());
-  }
-
-  std::string getCapturedOutput () const {  
-    return tempStream_.str ();
-  }
-
-  ~CaptureOstream () {
-    originalStream_.rdbuf (originalBuffer_);
-  }
-private:
-  std::ostream& originalStream_;
-  std::ostringstream tempStream_;
-  using buf_ptr_type = decltype (originalStream_.rdbuf ());  
-  buf_ptr_type originalBuffer_;
-};
-
-} // namespace (anonymous)  
-
 int main (int argc, char* argv[])
 {
   using std::cout;
   using std::endl;
  
   bool success = true;
-  {
-    // Capture std::cerr output, so we can tell if Tpetra::initialize
-    // printed a warning message.
-    CaptureOstream captureCerr (std::cerr);
-    testMain (success, argc, argv);
-    const std::string capturedOutput = captureCerr.getCapturedOutput ();
-    cout << "Captured output: " << capturedOutput << endl;
-    if (capturedOutput.size () != 0) {
-      success = false; // should NOT have printed in this case
-      cout << "Captured output is empty!" << endl;
-    }
-  }
+  testMain (success, argc, argv);
   
   cout << "End Result: TEST " << (success ? "PASSED" : "FAILED") << endl;
   return EXIT_SUCCESS;

--- a/packages/tpetra/core/test/Core/initialize_tpetra_inits_mpi_user_inits_kokkos.cpp
+++ b/packages/tpetra/core/test/Core/initialize_tpetra_inits_mpi_user_inits_kokkos.cpp
@@ -10,8 +10,6 @@
 #include "mpi.h"
 #include "Tpetra_Details_extractMpiCommFromTeuchos.hpp"
 
-namespace { // (anonymous)
-
 bool isMpiInitialized ()
 {
   int mpiInitializedInt = 0;
@@ -222,49 +220,13 @@ void testMain (bool& success, int argc, char* argv[])
   }
 }
 
-class CaptureOstream {
-public:
-  CaptureOstream (std::ostream& stream) :
-    originalStream_ (stream),
-    originalBuffer_ (stream.rdbuf ())
-  {
-    originalStream_.rdbuf (tempStream_.rdbuf ());
-  }
-
-  std::string getCapturedOutput () const {  
-    return tempStream_.str ();
-  }
-
-  ~CaptureOstream () {
-    originalStream_.rdbuf (originalBuffer_);
-  }
-private:
-  std::ostream& originalStream_;
-  std::ostringstream tempStream_;
-  using buf_ptr_type = decltype (originalStream_.rdbuf ());  
-  buf_ptr_type originalBuffer_;
-};
-
-} // namespace (anonymous)  
-
 int main (int argc, char* argv[])
 {
   using std::cout;
   using std::endl;
  
   bool success = true;
-  {
-    // Capture std::cerr output, so we can tell if Tpetra::initialize
-    // printed a warning message.
-    CaptureOstream captureCerr (std::cerr);
-    testMain (success, argc, argv);
-    const std::string capturedOutput = captureCerr.getCapturedOutput ();
-    cout << "Captured output: " << capturedOutput << endl;
-    if (capturedOutput.size () != 0) {
-      success = false; // should NOT have printed in this case
-      cout << "Captured output is empty!" << endl;
-    }
-  }
+  testMain (success, argc, argv);
   
   cout << "End Result: TEST " << (success ? "PASSED" : "FAILED") << endl;
   return EXIT_SUCCESS;

--- a/packages/tpetra/core/test/Core/initialize_user_inits_kokkos.cpp
+++ b/packages/tpetra/core/test/Core/initialize_user_inits_kokkos.cpp
@@ -3,10 +3,6 @@
 #include "Tpetra_Core.hpp"
 #include "Kokkos_Core.hpp"
 
-namespace { // (anonymous)
-
-// NOTE TO TEST AUTHORS: The code that calls this function captures
-// std::cerr, so don't write to std::cerr on purpose in this function.
 void testMain (bool& success, int argc, char* argv[])
 {
   using std::cout;
@@ -73,49 +69,13 @@ void testMain (bool& success, int argc, char* argv[])
   }
 }
 
-class CaptureOstream {
-public:
-  CaptureOstream (std::ostream& stream) :
-    originalStream_ (stream),
-    originalBuffer_ (stream.rdbuf ())
-  {
-    originalStream_.rdbuf (tempStream_.rdbuf ());
-  }
-
-  std::string getCapturedOutput () const {  
-    return tempStream_.str ();
-  }
-
-  ~CaptureOstream () {
-    originalStream_.rdbuf (originalBuffer_);
-  }
-private:
-  std::ostream& originalStream_;
-  std::ostringstream tempStream_;
-  using buf_ptr_type = decltype (originalStream_.rdbuf ());  
-  buf_ptr_type originalBuffer_;
-};
-
-} // namespace (anonymous)  
-
 int main (int argc, char* argv[])
 {
   using std::cout;
   using std::endl;
  
   bool success = true;
-  {
-    // Capture std::cerr output, so we can tell if Tpetra::initialize
-    // printed a warning message.
-    CaptureOstream captureCerr (std::cerr);
-    testMain (success, argc, argv);
-    const std::string capturedOutput = captureCerr.getCapturedOutput ();
-    cout << "Captured output: " << capturedOutput << endl;
-    if (capturedOutput.size () != 0) {
-      success = false; // should NOT have printed in this case
-      cout << "Captured output is empty!" << endl;
-    }
-  }
+  testMain (success, argc, argv);
   
   cout << "End Result: TEST " << (success ? "PASSED" : "FAILED") << endl;
   return EXIT_SUCCESS;

--- a/packages/tpetra/core/test/Core/initialize_user_inits_mpi.cpp
+++ b/packages/tpetra/core/test/Core/initialize_user_inits_mpi.cpp
@@ -9,8 +9,6 @@
 #include "mpi.h"
 #include "Tpetra_Details_extractMpiCommFromTeuchos.hpp"
 
-namespace { // (anonymous)
-
 bool isMpiInitialized ()
 {
   int mpiInitializedInt = 0;
@@ -183,49 +181,13 @@ void testMain (bool& success, int argc, char* argv[])
   Kokkos::finalize();
 }
 
-class CaptureOstream {
-public:
-  CaptureOstream (std::ostream& stream) :
-    originalStream_ (stream),
-    originalBuffer_ (stream.rdbuf ())
-  {
-    originalStream_.rdbuf (tempStream_.rdbuf ());
-  }
-
-  std::string getCapturedOutput () const {  
-    return tempStream_.str ();
-  }
-
-  ~CaptureOstream () {
-    originalStream_.rdbuf (originalBuffer_);
-  }
-private:
-  std::ostream& originalStream_;
-  std::ostringstream tempStream_;
-  using buf_ptr_type = decltype (originalStream_.rdbuf ());  
-  buf_ptr_type originalBuffer_;
-};
-
-} // namespace (anonymous)  
-
 int main (int argc, char* argv[])
 {
   using std::cout;
   using std::endl;
  
   bool success = true;
-  {
-    // Capture std::cerr output, so we can tell if Tpetra::initialize
-    // printed a warning message.
-    CaptureOstream captureCerr (std::cerr);
-    testMain (success, argc, argv);
-    const std::string capturedOutput = captureCerr.getCapturedOutput ();
-    cout << "Captured output: " << capturedOutput << endl;
-    if (capturedOutput.size () != 0) {
-      success = false; // should NOT have printed in this case
-      cout << "Captured output is empty!" << endl;
-    }
-  }
+  testMain (success, argc, argv);
   
   cout << "End Result: TEST " << (success ? "PASSED" : "FAILED") << endl;
   return EXIT_SUCCESS;

--- a/packages/tpetra/core/test/Core/initialize_user_inits_mpi_and_provides_comm.cpp
+++ b/packages/tpetra/core/test/Core/initialize_user_inits_mpi_and_provides_comm.cpp
@@ -8,8 +8,6 @@
 #include "mpi.h"
 #include "Tpetra_Details_extractMpiCommFromTeuchos.hpp"
 
-namespace { // (anonymous)
-
 bool isMpiInitialized ()
 {
   int mpiInitializedInt = 0;
@@ -189,49 +187,13 @@ void testMain (bool& success, int argc, char* argv[])
   (void) MPI_Finalize ();
 }
 
-class CaptureOstream {
-public:
-  CaptureOstream (std::ostream& stream) :
-    originalStream_ (stream),
-    originalBuffer_ (stream.rdbuf ())
-  {
-    originalStream_.rdbuf (tempStream_.rdbuf ());
-  }
-
-  std::string getCapturedOutput () const {  
-    return tempStream_.str ();
-  }
-
-  ~CaptureOstream () {
-    originalStream_.rdbuf (originalBuffer_);
-  }
-private:
-  std::ostream& originalStream_;
-  std::ostringstream tempStream_;
-  using buf_ptr_type = decltype (originalStream_.rdbuf ());  
-  buf_ptr_type originalBuffer_;
-};
-
-} // namespace (anonymous)  
-
 int main (int argc, char* argv[])
 {
   using std::cout;
   using std::endl;
  
   bool success = true;
-  {
-    // Capture std::cerr output, so we can tell if Tpetra::initialize
-    // printed a warning message.
-    CaptureOstream captureCerr (std::cerr);
-    testMain (success, argc, argv);
-    const std::string capturedOutput = captureCerr.getCapturedOutput ();
-    cout << "Captured output: " << capturedOutput << endl;
-    if (capturedOutput.size () != 0) {
-      success = false; // should NOT have printed in this case
-      cout << "Captured output is empty!" << endl;
-    }
-  }
+  testMain (success, argc, argv);
   
   cout << "End Result: TEST " << (success ? "PASSED" : "FAILED") << endl;
   return EXIT_SUCCESS;

--- a/packages/tpetra/core/test/Core/initialize_user_inits_mpi_tpetra_inits_kokkos.cpp
+++ b/packages/tpetra/core/test/Core/initialize_user_inits_mpi_tpetra_inits_kokkos.cpp
@@ -9,8 +9,6 @@
 #include "mpi.h"
 #include "Tpetra_Details_extractMpiCommFromTeuchos.hpp"
 
-namespace { // (anonymous)
-
 bool isMpiInitialized ()
 {
   int mpiInitializedInt = 0;
@@ -182,49 +180,13 @@ void testMain (bool& success, int argc, char* argv[])
   (void) MPI_Finalize ();
 }
 
-class CaptureOstream {
-public:
-  CaptureOstream (std::ostream& stream) :
-    originalStream_ (stream),
-    originalBuffer_ (stream.rdbuf ())
-  {
-    originalStream_.rdbuf (tempStream_.rdbuf ());
-  }
-
-  std::string getCapturedOutput () const {  
-    return tempStream_.str ();
-  }
-
-  ~CaptureOstream () {
-    originalStream_.rdbuf (originalBuffer_);
-  }
-private:
-  std::ostream& originalStream_;
-  std::ostringstream tempStream_;
-  using buf_ptr_type = decltype (originalStream_.rdbuf ());  
-  buf_ptr_type originalBuffer_;
-};
-
-} // namespace (anonymous)  
-
 int main (int argc, char* argv[])
 {
   using std::cout;
   using std::endl;
  
   bool success = true;
-  {
-    // Capture std::cerr output, so we can tell if Tpetra::initialize
-    // printed a warning message.
-    CaptureOstream captureCerr (std::cerr);
-    testMain (success, argc, argv);
-    const std::string capturedOutput = captureCerr.getCapturedOutput ();
-    cout << "Captured output: " << capturedOutput << endl;
-    if (capturedOutput.size () != 0) {
-      success = false; // should NOT have printed in this case
-      cout << "Captured output is empty!" << endl;
-    }
-  }
+  testMain (success, argc, argv);
   
   cout << "End Result: TEST " << (success ? "PASSED" : "FAILED") << endl;
   return EXIT_SUCCESS;

--- a/packages/tpetra/core/test/Core/issue_434_already_initialized.cpp
+++ b/packages/tpetra/core/test/Core/issue_434_already_initialized.cpp
@@ -54,8 +54,6 @@
 #include <cstdlib> // EXIT_SUCCESS, EXIT_FAILURE
 #include <iostream>
 
-namespace { // (anonymous)
-
   // Is Kokkos initialized?
   bool kokkosInitialized ()
   {
@@ -101,10 +99,7 @@ namespace { // (anonymous)
   }
 #endif // HAVE_TPETRACORE_MPI
 
-} // namespace (anonymous)
-
-int
-main (int argc, char* argv[])
+int main (int argc, char* argv[])
 {
   using std::endl;
   bool success = true;

--- a/packages/tpetra/core/test/Core/issue_434_not_yet_initialized.cpp
+++ b/packages/tpetra/core/test/Core/issue_434_not_yet_initialized.cpp
@@ -55,7 +55,6 @@
 #include <iostream>
 #include <stdexcept>
 
-namespace { // (anonymous)
 
   // Is Kokkos initialized?
   bool kokkosInitialized ()
@@ -65,7 +64,6 @@ namespace { // (anonymous)
     // space, so we can check that.
     return Kokkos::is_initialized ();
   }
-}
 
 int
 main (int argc, char* argv[])


### PR DESCRIPTION
@trilinos/tpetra 

Addressing #7966, #3453, #6748.

These tests exercises various combinations of MPI, Kokkos and Tpetra  initialization.  They checked the combinations for correctness (e.g., that Tpetra::ScopeGuard initialized TPLs if needed and finalized them upon destruction).  All good!

But the tests also captured warnings from Kokkos::initialize, and failed if Kokkos produced any warnings.  The problem is, we can't control what warnings Kokkos chooses to issue, and some Kokkos warnings had nothing to do with whether or not these tests worked correctly.  In particular, this check caused problems with CUDA_LAUNCH_BLOCKING=0 testing (see #7966).

I removed the check for output from Kokkos::initialize.  
All other checks (various combinations of initialized/finalized for MPI and Kokkos) in these tests remain.



## Motivation

These tests were holding up CUDA_LAUNCH_BLOCKING=0 testing.
Also, having a check of stderr from a TPL is bad form; we don't control what warnings Kokkos chooses to print.


<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->

## Related Issues

* Closes #7966, #3453
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to #6748
* Part of 
* Composed of 



## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->
Tested on Ride with and without CUDA_LAUNCH_BLOCKING (cuda 9.2, pascal, debug)
Also tested on mac with clang.

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->