### PR TITLE
Tpetra: Fix some illegal device accesses in FixedHashTable

### DIFF
--- a/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_decl.hpp
@@ -321,6 +321,7 @@ public:
     const typename hash_type::result_type hashVal =
       hash_type::hashFunc (key, size);
 
+    // FIXME: Is it worth it to launch a device kernel here to avoid the deep_copy?
     auto ptr_h = Kokkos::create_mirror_view(ptr_);
     Kokkos::deep_copy(ptr_h, ptr_);
     auto val_h = Kokkos::create_mirror_view(val_);

--- a/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_decl.hpp
@@ -321,17 +321,11 @@ public:
     const typename hash_type::result_type hashVal =
       hash_type::hashFunc (key, size);
 
-    // FIXME: Is it worth it to launch a device kernel here to avoid the deep_copy?
-    auto ptr_h = Kokkos::create_mirror_view(ptr_);
-    Kokkos::deep_copy(ptr_h, ptr_);
-    auto val_h = Kokkos::create_mirror_view(val_);
-    Kokkos::deep_copy(val_h, val_);
-
-    const offset_type start = ptr_h[hashVal];
-    const offset_type end = ptr_h[hashVal+1];
+    const offset_type start = ptr_[hashVal];
+    const offset_type end = ptr_[hashVal+1];
     for (offset_type k = start; k < end; ++k) {
-      if (val_h[k].first == key) {
-        return val_h[k].second;
+      if (val_[k].first == key) {
+        return val_[k].second;
       }
     }
 

--- a/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_decl.hpp
@@ -321,11 +321,16 @@ public:
     const typename hash_type::result_type hashVal =
       hash_type::hashFunc (key, size);
 
-    const offset_type start = ptr_[hashVal];
-    const offset_type end = ptr_[hashVal+1];
+    auto ptr_h = Kokkos::create_mirror_view(ptr_);
+    Kokkos::deep_copy(ptr_h, ptr_);
+    auto val_h = Kokkos::create_mirror_view(val_);
+    Kokkos::deep_copy(val_h, val_);
+
+    const offset_type start = ptr_h[hashVal];
+    const offset_type end = ptr_h[hashVal+1];
     for (offset_type k = start; k < end; ++k) {
-      if (val_[k].first == key) {
-        return val_[k].second;
+      if (val_h[k].first == key) {
+        return val_h[k].second;
       }
     }
 

--- a/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_def.hpp
@@ -1313,6 +1313,9 @@ init (const host_input_keys_type& keys,
   // FIXME: Investigate a couple options:
   // 1. Allocate ptr_h, val_h directly on host and only deep_copy to ptr_ and val_ once at the end
   // 2. Do all this work as a parallel kernel with the same execution/memory spaces as ptr_ and val_
+  // An old comment from MFH noted ptr_h should be zero-initialized, while val_h should not be initialized.
+  // It further noted that we shouldn't need a DualView type arrangement when all setup kernels have
+  // been "Kokkos-ized".
   typename ptr_type::non_const_type ptr ("FixedHashTable::ptr", size + 1);
   auto ptr_h = Kokkos::create_mirror_view(ptr);
   Kokkos::deep_copy(ptr_h, ptr);

--- a/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_FixedHashTable_def.hpp
@@ -1027,7 +1027,7 @@ init (const keys_type& keys,
     // out of Map's constructor here, so there is no loss in doing it
     // sequentially for now.  Later, we can work on parallelization.
     if (numKeys > 0) {
-      // TODO: make it a parallel kernel with no host copy
+      // FIXME: make it a parallel kernel with no host copy
       auto keys_h = Kokkos::create_mirror_view(keys);
       Kokkos::deep_copy(keys_h, keys);
       firstContigKey_ = keys_h[0];
@@ -1310,6 +1310,9 @@ init (const host_input_keys_type& keys,
     "Please report this bug to the Tpetra developers.");
 #endif // HAVE_TPETRA_DEBUG
 
+  // FIXME: Investigate a couple options:
+  // 1. Allocate ptr_h, val_h directly on host and only deep_copy to ptr_ and val_ once at the end
+  // 2. Do all this work as a parallel kernel with the same execution/memory spaces as ptr_ and val_
   typename ptr_type::non_const_type ptr ("FixedHashTable::ptr", size + 1);
   auto ptr_h = Kokkos::create_mirror_view(ptr);
   Kokkos::deep_copy(ptr_h, ptr);

--- a/packages/tpetra/core/src/Tpetra_DirectoryImpl_decl.hpp
+++ b/packages/tpetra/core/src/Tpetra_DirectoryImpl_decl.hpp
@@ -415,18 +415,36 @@ namespace Tpetra {
       /// This hash table implements a mapping from an LID in the
       /// Directory Map (corresponding to a GID in the input Map) to
       /// the GID's owning PID in the input Map.
-      Teuchos::RCP<Details::FixedHashTable<LocalOrdinal, int,
-                                           Kokkos::Device<typename NodeType::execution_space,
-                                                          typename NodeType::memory_space> > > lidToPidTable_;
+      ///
+      /// At present, this hash table is accessed only on the host.
+      /// Previous implementations that exploited UVM may have constructed
+      /// the hash table on device, but then accessed it on host.
+      /// The current implementation constructs the hash table on host.
+      /// Future implementations could construct the hash table on device
+      /// and copy it to host, or modify the directory to access the hash table
+      /// on device.
+      typedef typename Details::FixedHashTable<LocalOrdinal, int,
+                                               Kokkos::HostSpace::device_type> 
+                       lidToPidTable_type;
+      Teuchos::RCP<lidToPidTable_type> lidToPidTable_;
 
       /// \brief Mapping from Directory Map LID to input Map LID.
       ///
       /// This hash table implements a mapping from an LID in the
       /// Directory Map (corresponding to a GID in the input Map), to
       /// the GID's LID in the input Map on the GID's owning process.
-      Teuchos::RCP<Details::FixedHashTable<LocalOrdinal, LocalOrdinal,
-                                           Kokkos::Device<typename NodeType::execution_space,
-                                                          typename NodeType::memory_space> > > lidToLidTable_;
+      ///
+      /// At present, this hash table is accessed only on the host.
+      /// Previous implementations that exploited UVM may have constructed
+      /// the hash table on device, but then accessed it on host.
+      /// The current implementation constructs the hash table on host.
+      /// Future implementations could construct the hash table on device
+      /// and copy it to host, or modify the directory to access the hash table
+      /// on device.
+      typedef typename Details::FixedHashTable<LocalOrdinal, LocalOrdinal,
+                                           Kokkos::HostSpace::device_type>
+                       lidToLidTable_type;
+      Teuchos::RCP<lidToLidTable_type> lidToLidTable_;
       //@}
 
       /// \brief The result of the first call to isOneToOne() on this object.

--- a/packages/tpetra/core/src/Tpetra_DirectoryImpl_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_DirectoryImpl_def.hpp
@@ -768,15 +768,11 @@ namespace Tpetra {
           // Set up the hash tables.  The hash tables' constructor
           // detects whether there are duplicates, so that we can set
           // locallyOneToOne_.
-          typedef Kokkos::Device<typename NT::execution_space,
-            typename NT::memory_space> DT;
           lidToPidTable_ =
-            rcp (new Details::FixedHashTable<LO, int, DT> (tableKeys (),
-                                                           tablePids ()));
+            rcp (new lidToPidTable_type (tableKeys (), tablePids ()));
           locallyOneToOne_ = ! (lidToPidTable_->hasDuplicateKeys ());
           lidToLidTable_ =
-            rcp (new Details::FixedHashTable<LO, LO, DT> (tableKeys (),
-                                                          tableLids ()));
+            rcp (new lidToLidTable_type (tableKeys (), tableLids ()));
         }
         else { // tie_break is NOT null
 
@@ -849,14 +845,10 @@ namespace Tpetra {
           }
 
           // Set up the hash tables.
-          typedef Kokkos::Device<typename NT::execution_space,
-            typename NT::memory_space> DT;
           lidToPidTable_ =
-            rcp (new Details::FixedHashTable<LO, int, DT> (tableKeys (),
-                                                           tablePids ()));
+            rcp (new lidToPidTable_type (tableKeys (), tablePids ()));
           lidToLidTable_ =
-            rcp (new Details::FixedHashTable<LO, LO, DT> (tableKeys (),
-                                                          tableLids ()));
+            rcp (new lidToLidTable_type (tableKeys (), tableLids ()));
         }
       }
       else {


### PR DESCRIPTION
@trilinos/tpetra 

## Motivation

Some functions in FixedHashTable assumed UVM.  This commit follows what @MicheldeMessieres did in #8104 by adding mirror views.  @MicheldeMessieres did suggest in a code comment that we might want an alternative solution to host copies, but this does get more tests passing with no UVM.

## Related Issues

* Closes #8261
* Related to #8209

## Testing

Previously failing tests that now pass without UVM are:
* TpetraCore_Map_Bug2431_MPI_4
* TpetraCore_Issue_607_MPI_4
* TpetraCore_Map_Bug5822_2_MPI_2
* TpetraCore_Map_Bug6051_MPI_2
* TpetraCore_CooMatrix_MPI_2
* TpetraCore_Map_OneToOne_MPI_2