### PR TITLE
MueLu RefMaxwell: Make nullspace normalization optional

### DIFF
--- a/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_def.hpp
+++ b/packages/muelu/adapters/xpetra/MueLu_RefMaxwell_def.hpp
@@ -557,17 +557,6 @@ namespace MueLu {
       TEUCHOS_ASSERT(Nullspace_->getMap()->isCompatible(*(SM_Matrix_->getRowMap())));
     }
     else if(Nullspace_ == null && Coords_ != null) {
-      // normalize coordinates
-      Array<coordinateType> norms(Coords_->getNumVectors());
-      Coords_->norm2(norms);
-      for (size_t i=0;i<Coords_->getNumVectors();i++)
-        norms[i] = ((coordinateType)1.0)/norms[i];
-      Nullspace_ = MultiVectorFactory::Build(SM_Matrix_->getRowMap(),Coords_->getNumVectors());
-
-      // Cast coordinates to Scalar so they can be multiplied against D0
-      Array<Scalar> normsSC(Coords_->getNumVectors());
-      for (size_t i=0;i<Coords_->getNumVectors();i++)
-        normsSC[i] = (SC) norms[i];
 #ifdef HAVE_MUELU_KOKKOS_REFACTOR
       RCP<MultiVector> CoordsSC;
       if (useKokkos_)
@@ -577,7 +566,9 @@ namespace MueLu {
 #else
       RCP<MultiVector> CoordsSC = Utilities::RealValuedToScalarMultiVector(Coords_);
 #endif
+      Nullspace_ = MultiVectorFactory::Build(SM_Matrix_->getRowMap(),Coords_->getNumVectors());
       D0_Matrix_->apply(*CoordsSC,*Nullspace_);
+
       if (IsPrint(Statistics2)) {
         // compute edge lengths
         ArrayRCP<ArrayRCP<const Scalar> > localNullspace(Nullspace_->getNumVectors());
@@ -603,7 +594,22 @@ namespace MueLu {
         meanLen /= Nullspace_->getMap()->getGlobalNumElements();
         GetOStream(Statistics0) << "Edge length (min/mean/max): " << minLen << " / " << meanLen << " / " << maxLen << std::endl;
       }
-      Nullspace_->scale(normsSC());
+
+      bool normalize = parameterList_.get<bool>("refmaxwell: normalize nullspace", MasterList::getDefault<bool>("refmaxwell: normalize nullspace"));
+      if (normalize) {
+        // normalize the nullspace
+        GetOStream(Runtime0) << "RefMaxwell::compute(): normalizing nullspace" << std::endl;
+
+        const Scalar one = Teuchos::ScalarTraits<Scalar>::one();
+        Array<coordinateType> norms(Coords_->getNumVectors());
+        Coords_->normInf(norms);
+
+        // Cast coordinates to Scalar so they can be multiplied against the nullspace
+        Array<Scalar> normsSC(Coords_->getNumVectors());
+        for (size_t i=0; i < Coords_->getNumVectors(); i++)
+          normsSC[i] = one / Teuchos::as<Scalar>(norms[i]);
+        Nullspace_->scale(normsSC());
+      }
     }
     else {
       GetOStream(Errors) << "MueLu::RefMaxwell::compute(): either the nullspace or the nodal coordinates must be provided." << std::endl;

--- a/packages/muelu/doc/UsersGuide/masterList.xml
+++ b/packages/muelu/doc/UsersGuide/masterList.xml
@@ -1727,6 +1727,14 @@ optimized neighbor discovery for Importer construction.</description>
       <visible>false</visible>
     </parameter>
 
+    <parameter>
+      <name>refmaxwell: normalize nullspace</name>
+      <type>bool</type>
+      <default>false</default>
+      <description>Normalize the nullspace.</description>
+      <visible>false</visible>
+    </parameter>
+
   </refmaxwell>
 
 

--- a/packages/muelu/doc/UsersGuide/paramlist_hidden.tex
+++ b/packages/muelu/doc/UsersGuide/paramlist_hidden.tex
@@ -383,3 +383,5 @@ optimized neighbor discovery for Importer construction.}
         
 \cbb{refmaxwell: skip first (1,1) level}{bool}{true}{Skip the first level of the (1,1) hierarchy.}
         
+\cbb{refmaxwell: normalize nullspace}{bool}{false}{Normalize the nullspace.}
+        

--- a/packages/muelu/src/MueCentral/MueLu_MasterList.cpp
+++ b/packages/muelu/src/MueCentral/MueLu_MasterList.cpp
@@ -156,6 +156,7 @@ namespace MueLu {
     if (name == "refmaxwell: subsolves on subcommunicators") { ss << "<Parameter name=\"refmaxwell: subsolves on subcommunicators\" type=\"bool\" value=" << value << "/>"; return ss.str(); }      
     if (name == "refmaxwell: enable reuse") { ss << "<Parameter name=\"refmaxwell: enable reuse\" type=\"bool\" value=" << value << "/>"; return ss.str(); }      
     if (name == "refmaxwell: skip first (1,1) level") { ss << "<Parameter name=\"refmaxwell: skip first (1,1) level\" type=\"bool\" value=" << value << "/>"; return ss.str(); }      
+    if (name == "refmaxwell: normalize nullspace") { ss << "<Parameter name=\"refmaxwell: normalize nullspace\" type=\"bool\" value=" << value << "/>"; return ss.str(); }      
     return "";
   }
 
@@ -340,6 +341,7 @@ namespace MueLu {
   "<Parameter name=\"refmaxwell: subsolves on subcommunicators\" type=\"bool\" value=\"false\"/>"
   "<Parameter name=\"refmaxwell: enable reuse\" type=\"bool\" value=\"false\"/>"
   "<Parameter name=\"refmaxwell: skip first (1,1) level\" type=\"bool\" value=\"true\"/>"
+  "<Parameter name=\"refmaxwell: normalize nullspace\" type=\"bool\" value=\"false\"/>"
 "</ParameterList>"
 ;
   std::map<std::string,std::string> MasterList::DefaultProblemTypeLists_ = DefaultProblemStrings<std::string,std::string>
@@ -875,6 +877,8 @@ namespace MueLu {
          ("refmaxwell: enable reuse","refmaxwell: enable reuse")
       
          ("refmaxwell: skip first (1,1) level","refmaxwell: skip first (1,1) level")
+      
+         ("refmaxwell: normalize nullspace","refmaxwell: normalize nullspace")
       ;
 
 }


### PR DESCRIPTION
@trilinos/muelu 

## Motivation
Make nullspace normalization in RefMaxwell optional.
It seems to be more harmful to convergence to normalize.

@csiefer2 @rstumin 