### PR TITLE
Reduce clang warning from Teuchos

### DIFF
--- a/packages/teuchos/core/src/Teuchos_ScalarTraits.hpp
+++ b/packages/teuchos/core/src/Teuchos_ScalarTraits.hpp
@@ -649,7 +649,7 @@ struct ScalarTraits<float>
     random();
 #endif
   }
-  static inline float random() { float rnd = (float) std::rand() / RAND_MAX; return (-1.0f + 2.0f * rnd); }
+  static inline float random() { float rnd = (float) std::rand() / static_cast<float>(RAND_MAX); return (-1.0f + 2.0f * rnd); }
   static inline std::string name() { return "float"; }
   static inline float squareroot(float x)
     {

--- a/packages/teuchos/core/src/Teuchos_as.hpp
+++ b/packages/teuchos/core/src/Teuchos_as.hpp
@@ -1339,7 +1339,7 @@ public:
     const unsigned long maxVal = std::numeric_limits<unsigned long>::max ();
 
     TEUCHOS_TEST_FOR_EXCEPTION(
-      t < minVal || t > maxVal,
+      t < minVal || t > static_cast<double>(maxVal),
       std::range_error,
       "Teuchos::ValueTypeConversionTraits<unsigned long, double>::safeConvert: "
       "Input double t = " << t << " is out of the valid range [" << minVal
@@ -1394,7 +1394,7 @@ public:
     const unsigned long long maxVal = std::numeric_limits<unsigned long long>::max ();
 
     TEUCHOS_TEST_FOR_EXCEPTION(
-      t < minVal || t > maxVal,
+      t < minVal || t > static_cast<double>(maxVal),
       std::range_error,
       "Teuchos::ValueTypeConversionTraits<unsigned long long, double>::safeConvert: "
       "Input double t = " << t << " is out of the valid range [" << minVal
@@ -1544,7 +1544,7 @@ public:
     const unsigned int maxVal = std::numeric_limits<unsigned int>::max ();
 
     TEUCHOS_TEST_FOR_EXCEPTION(
-      t < minVal || t > maxVal,
+      t < minVal || t > static_cast<float>(maxVal),
       std::range_error,
       "Teuchos::ValueTypeConversionTraits<unsigned int, float>::safeConvert: "
       "Input double t = " << t << " is out of the valid range [" << minVal
@@ -1593,7 +1593,7 @@ public:
     // GNU/Linux and other operating systems).
     if (sizeof (long) < sizeof (float)) {
       TEUCHOS_TEST_FOR_EXCEPTION(
-        t < minVal || t > maxVal,
+        t < minVal || t > static_cast<float>(maxVal),
         std::range_error,
         "Teuchos::ValueTypeConversionTraits<long, float>::safeConvert: "
         "Input float t = " << t << " is out of the valid range ["
@@ -1621,7 +1621,7 @@ public:
     const unsigned long maxVal = std::numeric_limits<unsigned long>::max ();
 
     TEUCHOS_TEST_FOR_EXCEPTION(
-      t < minVal || t > maxVal,
+      t < minVal || t > static_cast<float>(maxVal),
       std::range_error,
       "Teuchos::ValueTypeConversionTraits<unsigned long, float>::safeConvert: "
       << "Input float t = " << t << " is out of the valid range [" << minVal
@@ -1664,7 +1664,7 @@ public:
     const unsigned long long maxVal = std::numeric_limits<unsigned long long>::max ();
 
     TEUCHOS_TEST_FOR_EXCEPTION(
-      t < minVal || t > maxVal,
+      t < minVal || t > static_cast<float>(maxVal),
       std::range_error,
       "Teuchos::ValueTypeConversionTraits<unsigned long long, float>::safeConvert: "
       "Input float t = " << t << " is out of the valid range [" << minVal

--- a/packages/teuchos/core/test/TypeConversions/TypeConversions_UnitTest.cpp
+++ b/packages/teuchos/core/test/TypeConversions/TypeConversions_UnitTest.cpp
@@ -568,7 +568,7 @@ TEUCHOS_UNIT_TEST_TEMPLATE_2_DECL( asSafe, realToUnsignedIntTypeOverflow, RealTy
   TEST_THROW(val = asSafe<UnsignedIntType> (minusOne), std::range_error);
 
   // Only test overflow checks if overflow can actually take place.
-  if (maxUnsignedIntVal < maxVal) {
+  if (static_cast<RealType>(maxUnsignedIntVal) < maxVal) {
     TEST_THROW(val = asSafe<UnsignedIntType> (maxVal), std::range_error);
     try {
       std::cerr << std::endl


### PR DESCRIPTION
This is to resolve issue #8210

@trilinos/teuchos 

## Motivation
The clang compiler issues a significant number of warnings due to the implicit casts in these files. This makes those casts explicit to handle this warnings

## Related Issues

* Closes #8210 

## Testing
Teuchos was built against GCC7.2 and Clang 10 and all tests passed
