### PR TITLE
Fix for #8258.  (Fixing typo in TypeMap declaration.)

### DIFF
--- a/packages/amesos2/src/Amesos2_Superludist_TypeMap.hpp
+++ b/packages/amesos2/src/Amesos2_Superludist_TypeMap.hpp
@@ -247,7 +247,7 @@ struct TypeMap<Superludist,double>
   typedef SLUD::D::dSOLVEstruct_t SOLVEstruct_t;
   typedef SLUD::D::dScalePermstruct_t ScalePermstruct_t;
 #else
-  typedef SLUD::D::LUstruct_tdLUstruct_t;
+  typedef SLUD::D::LUstruct_t LUstruct_t;
   typedef SLUD::D::SOLVEstruct_t SOLVEstruct_t;
   typedef SLUD::ScalePermstruct_t ScalePermstruct_t;
 #endif


### PR DESCRIPTION
@trilinos/amesos2 

This is a fix for bug #8258.  When SuperLU_DIST-6.2 or earlier is set, it picks up wrong TypeMap declaration. (See line 252 of Amesos2_Superludist_TypeMap.hpp )
