### PR TITLE
Fix for #8258. (Fixing typo in TypeMap declaration.) in 13.x release

### DIFF
--- a/packages/amesos2/src/Amesos2_Superludist_TypeMap.hpp
+++ b/packages/amesos2/src/Amesos2_Superludist_TypeMap.hpp
@@ -249,7 +249,7 @@ struct TypeMap<Superludist,double>
   typedef SLUD::D::dSOLVEstruct_t SOLVEstruct_t;
   typedef SLUD::D::dScalePermstruct_t ScalePermstruct_t;
 #else
-  typedef SLUD::D::LUstruct_tdLUstruct_t;
+  typedef SLUD::D::LUstruct_t LUstruct_t;
   typedef SLUD::D::SOLVEstruct_t SOLVEstruct_t;
   typedef SLUD::ScalePermstruct_t ScalePermstruct_t;
 #endif


### PR DESCRIPTION
This is a fix for #8258. There is a typo in the TypeMap declaration for older SuperLU_DIST (6.2 or earlier).  See the line 252 of Amesos2_Superlumt_TypeMap.hpp.

