### PR TITLE
Framework: PR Configuration fix for Clang 7.0.1 build

### DIFF
--- a/cmake/std/pr_config/pullrequest.ini
+++ b/cmake/std/pr_config/pullrequest.ini
@@ -274,6 +274,7 @@ module-load sems-gcc: 5.3.0
 module-load sems-clang: 7.0.1
 use SEMS-DEFAULT:
 use ATDM-DEFAULT:
+module-remove sems-cmake:
 module-load sems-cmake: 3.12.2
 setenv SEMS_FORCE_LOCAL_COMPILER_VERSION: 5.3.0
 


### PR DESCRIPTION
The clang 7.0.1 build loads `sems-cmake/3.10.3` from the SEMS-DEFAULT section but then it tries to load
`sems-cmake/3.12.2` which will fail because a `sems-cmake` module is already loaded.

I added a `module-remove sems-cmake:` rule prior to loading the changed version. This should fix that issue.

@trilinos/framework 
@prwolfe 