### PR TITLE
Framework: PR Driver Console Log Cleanup

### DIFF
--- a/cmake/std/PullRequestLinuxDriverTest.py
+++ b/cmake/std/PullRequestLinuxDriverTest.py
@@ -247,8 +247,10 @@ def main(args):
         raise KeyError("ERROR: Unknown test mode, {}, was provided.".format(args.test_mode))
 
     pr_config.prepare_test()
-    pr_config.execute_test()
-    return 0
+
+    status = pr_config.execute_test()
+
+    return status
 
 
 

--- a/cmake/std/common.bash
+++ b/cmake/std/common.bash
@@ -3,6 +3,29 @@
 # Common bash functions that we use in several scripts.
 #
 
+# Set some color codes if we're on a terminal that supports colors
+if test -t 1; then
+    # see if it supports colors...
+    ncolors=$(tput colors)
+    if test -n "$ncolors" && test $ncolors -ge 8; then
+        export bold="$(tput bold)"
+        export underline="$(tput smul)"
+        export standout="$(tput smso)"
+        export standout_end="$(tput rmso)"
+        export normal="$(tput sgr0)"
+        export dim="$(tput dim)"
+        export black="$(tput setaf 0)"
+        export red="$(tput setaf 1)"
+        export green="$(tput setaf 2)"
+        export yellow="$(tput setaf 3)"
+        export blue="$(tput setaf 4)"
+        export magenta="$(tput setaf 5)"
+        export cyan="$(tput setaf 6)"
+        export white="$(tput setaf 7)"
+    fi
+fi
+
+
 
 # message_std
 #

--- a/cmake/std/trilinosprhelpers/TrilinosPRConfigurationBase.py
+++ b/cmake/std/trilinosprhelpers/TrilinosPRConfigurationBase.py
@@ -429,9 +429,9 @@ class TrilinosPRConfigurationBase(object):
                 if not dryrun:
                     subprocess.check_call(cmd)
                 else:
-                    print("---")
+                    print("")
                     print("--- SKIPPED DUE TO DRYRUN")
-                    print("---")
+                    print("")
             else:
                 # Use the values in the PACKAGE_ENABLES section of the .ini file
                 with open('packageEnables.cmake',  'w') as f_out:
@@ -459,9 +459,9 @@ class TrilinosPRConfigurationBase(object):
             if not dryrun:
                 cmake_rstring = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
             else:
-                print("---")
+                print("")
                 print("--- SKIPPED DUE TO DRYRUN")
-                print("---")
+                print("")
                 cmake_rstring = str.encode("")
             cmake_rstring = cmake_rstring.decode('utf-8')
             print(cmake_rstring)
@@ -529,7 +529,7 @@ class TrilinosPRConfigurationBase(object):
         print("--- arg_pullrequest_cdash_track = {}".format(self.arg_pullrequest_cdash_track))
         print("--- arg_req_mem_per_core        = {}".format(self.arg_req_mem_per_core))
         print("--- arg_workspace_dir           = {}".format(self.arg_workspace_dir))
-        print("---")
+        print("")
         print("--- concurrency_build           = {}".format(self.concurrency_build))
         print("--- concurrency_test            = {}".format(self.concurrency_test))
         print("--- config_script               = {}".format(self.config_script))
@@ -552,9 +552,9 @@ class TrilinosPRConfigurationBase(object):
             print("apply() rval: {}".format(rval))
         else:
             tr_config.pretty_print()
-            print("---")
+            print("")
             print("--- NOTICE: ENVVARS not set due to dry-run flag.")
-            print("---")
+            print("")
 
         if rval:
             msg = "ERROR: There was a problem configuring the environment."

--- a/cmake/std/trilinosprhelpers/TrilinosPRConfigurationBase.py
+++ b/cmake/std/trilinosprhelpers/TrilinosPRConfigurationBase.py
@@ -483,11 +483,11 @@ class TrilinosPRConfigurationBase(object):
         """
         print("")
         print("Validate target branch constraints:")
-        print("- Target branch is '{}'".format(self.args.target_branch_name))
+        print("--- Target branch is '{}'".format(self.args.target_branch_name))
 
         re_master_merge_source = "master_merge_[0-9]{8}_[0-9]{6}"
         if "master" == self.args.target_branch_name:
-            print("- Target branch is 'master'. Checking source branch constraints...")
+            print("--- Target branch is 'master'. Checking source branch constraints...")
             if not re.match(re_master_merge_source, self.args.source_branch_name):
                 message  = "+" + "="*78 + "+\n"
                 message += "ERROR: Source branch is NOT trilinos/Trilinos::master_merge_YYYYMMDD_HHMMSS\n"

--- a/cmake/std/trilinosprhelpers/TrilinosPRConfigurationInstallation.py
+++ b/cmake/std/trilinosprhelpers/TrilinosPRConfigurationInstallation.py
@@ -65,8 +65,12 @@ class TrilinosPRConfigurationInstallation(TrilinosPRConfigurationBase):
         print("--- ")
 
         if not self.args.dry_run:
-            subprocess.check_call(cmd)
-            # Note: check_call will throw an exception if there's a problem.
+            try:
+                subprocess.check_call(cmd)
+                # Note: check_call will throw an exception if there's a problem.
+            except:
+                print("--- ctest command failed!")
+                return 1
         else:
             print("--- SKIPPED DUE TO DRYRUN")
         print("")

--- a/cmake/std/trilinosprhelpers/TrilinosPRConfigurationInstallation.py
+++ b/cmake/std/trilinosprhelpers/TrilinosPRConfigurationInstallation.py
@@ -69,7 +69,7 @@ class TrilinosPRConfigurationInstallation(TrilinosPRConfigurationBase):
             # Note: check_call will throw an exception if there's a problem.
         else:
             print("--- SKIPPED DUE TO DRYRUN")
-        print("---")
+        print("")
 
         return 0
 

--- a/cmake/std/trilinosprhelpers/TrilinosPRConfigurationStandard.py
+++ b/cmake/std/trilinosprhelpers/TrilinosPRConfigurationStandard.py
@@ -65,8 +65,12 @@ class TrilinosPRConfigurationStandard(TrilinosPRConfigurationBase):
         print("")
 
         if not self.args.dry_run:
-            subprocess.check_call(cmd)
-            # Note: check_call will throw an exception if there's a problem.
+            try:
+                subprocess.check_call(cmd)
+                # Note: check_call will throw an exception if there's a problem.
+            except:
+                print("--- ctest command failed!")
+                return 1
         else:
             print("--- SKIPPED DUE TO DRYRUN")
         print("")

--- a/cmake/std/trilinosprhelpers/TrilinosPRConfigurationStandard.py
+++ b/cmake/std/trilinosprhelpers/TrilinosPRConfigurationStandard.py
@@ -62,14 +62,14 @@ class TrilinosPRConfigurationStandard(TrilinosPRConfigurationBase):
 
         print("--- ctest command:")
         print("--- cmd = {}".format(" \\\n   ".join(cmd)))
-        print("--- ")
+        print("")
 
         if not self.args.dry_run:
             subprocess.check_call(cmd)
             # Note: check_call will throw an exception if there's a problem.
         else:
             print("--- SKIPPED DUE TO DRYRUN")
-        print("---")
+        print("")
 
         return 0
 

--- a/cmake/std/trilinosprhelpers/setenvironment/SetEnvironment.py
+++ b/cmake/std/trilinosprhelpers/setenvironment/SetEnvironment.py
@@ -267,7 +267,7 @@ class SetEnvironment(object):
                 elif matched_key:
                     print(" = {}".format(v), end="")
                 print("")
-        print("---")
+        print("")
         return 0
 
 

--- a/cmake/std/trilinosprhelpers/setenvironment/unittests/test_SetEnvironment.py
+++ b/cmake/std/trilinosprhelpers/setenvironment/unittests/test_SetEnvironment.py
@@ -327,9 +327,9 @@ class SetEnvironmentTest(TestCase):
         # Verify that TEST_ENVVAR_002 was expanded properly
         expected_test_envvar_002 = "TEST_ENVVAR_002_VALUE/TEST_ENVVAR_001_VALUE"
         actual_test_envvar_002   = os.environ['TEST_ENVVAR_002']
-        print("---")
+        print("")
         print("--- {}".format(actual_test_envvar_002))
-        print("---")
+        print("")
         self.assertEqual(expected_test_envvar_002, actual_test_envvar_002)
 
 


### PR DESCRIPTION
@trilinos/framework 

Clean up Markdown Interpretation of Console Log Output
--------
This is a style update for the PR scripts. Mostly changing occurrences of `print("---")` lines because when this part of the console log gets put into a PR job it causes the Markdown generator in github to generate a header out of the previous line.

Better Messaging when CTest Fails
---------
The 2nd thing here is a change to how the exit status is handled from the ctest run.
In the `TrilinosPRConfigurationStandard.py` file we add a `try ... except` block around the `subprocess.checked_call()` call to catch the error that is thrown when the exit status is not zero from the ctest call.

https://github.com/william76/Trilinos/blob/8f3d7d78b09fa4462b1341d90869609b7d8c3a51/cmake/std/trilinosprhelpers/TrilinosPRConfigurationStandard.py#L67-L78

The exception is handled by printing a message and passing a nonzero return value out. This gets handled in `main()` and is ultimately returned by the top level application.
 
https://github.com/william76/Trilinos/blob/8f3d7d78b09fa4462b1341d90869609b7d8c3a51/cmake/std/PullRequestLinuxDriverTest.py#L249-L253

The nonzero return code will trigger a failure in Jenkins but will also print a 'normal looking' error message rather than a traceback which is better since users often see the traceback and assume that there's a problem with the driver script when, in fact, it means that their ctest operation failed due to failed tests.

Add Color Codes for Bash Scripts Run in Terminals
--------
added some `tput` based color codes to `common.bash` which can be used in `echo` commands by scripts that source this. They should only be available if the script is run in interactive terminals.  Currently nothing in the repository uses these but in the future we may leverage them in interactive scripts for tasks such as replicating PR runs, etc.

FYI @prwolfe @jwillenbring @ZUUL42 @jmgate (when you're back from your time off)

