### PR TITLE
Tacho - customer feature request for ordering connected graph separately.

### DIFF
--- a/packages/shylu/shylu_node/tacho/example/Tacho_ExampleSolver.hpp
+++ b/packages/shylu/shylu_node/tacho/example/Tacho_ExampleSolver.hpp
@@ -184,6 +184,9 @@ int driver (int argc, char *argv[]) {
     solver.setSmallProblemThresholdsize(small_problem_thres);
     solver.setVerbose(verbose);
 
+    /// graph options
+    solver.setOrderConnectedGraphSeparately();
+
     /// tasking options
     solver.setMaxNumberOfSuperblocks(max_num_superblocks);
     solver.setBlocksize(mb);

--- a/packages/shylu/shylu_node/tacho/src/Tacho_Solver.hpp
+++ b/packages/shylu/shylu_node/tacho/src/Tacho_Solver.hpp
@@ -78,6 +78,9 @@ namespace Tacho {
     bool _transpose;
     ordinal_type _mode;
 
+    // ** ordering options
+    ordinal_type _order_connected_graph_separately;
+
     // ** problem
     ordinal_type _m;
     size_type _nnz;
@@ -169,6 +172,11 @@ namespace Tacho {
     void setTransposeSolve(const bool transpose);
     void setMatrixType(const int symmetric, // 0 - unsymmetric, 1 - structure sym, 2 - symmetric, 3 - hermitian
                        const bool is_positive_definite);
+
+    ///
+    /// Graph options
+    ///
+    void setOrderConnectedGraphSeparately(const ordinal_type order_connected_graph_separately = 1);
 
     ///
     /// tasking options

--- a/packages/shylu/shylu_node/tacho/src/impl/Tacho_Solver_Impl.hpp
+++ b/packages/shylu/shylu_node/tacho/src/impl/Tacho_Solver_Impl.hpp
@@ -108,6 +108,13 @@ namespace Tacho {
     TACHO_TEST_FOR_EXCEPTION(_mode != Cholesky, std::logic_error, "Cholesky is only supported now");
   }
 
+  template<typename VT, typename ST>
+  void
+  Solver<VT,ST>
+  ::setOrderConnectedGraphSeparately(const ordinal_type order_connected_graph_separately) {
+    _order_connected_graph_separately = order_connected_graph_separately;
+  }
+
   ///
   /// tasking options
   ///
@@ -243,6 +250,11 @@ namespace Tacho {
       if (use_condensed_graph) {
         Graph graph(_m_graph, _nnz_graph, _h_ap_graph, _h_aj_graph);
         graph_tools_type G(graph);
+#if defined(TACHO_HAVE_METIS)
+        if (_order_connected_graph_separately) {
+          G.setOption(METIS_OPTION_CCORDER, 1);
+        }
+#endif
         G.reorder(_verbose);
         
         _h_perm_graph = G.PermVector();
@@ -254,6 +266,11 @@ namespace Tacho {
 	if (use_graph_partitioner) {
 	  Graph graph(_m, _nnz, _h_ap, _h_aj);
 	  graph_tools_type G(graph);
+#if defined(TACHO_HAVE_METIS)
+        if (_order_connected_graph_separately) {
+          G.setOption(METIS_OPTION_CCORDER, 1);          
+        }
+#endif
 	  G.reorder(_verbose);
 	  
 	  _h_perm = G.PermVector(); 


### PR DESCRIPTION
## Motivation

For solving multiple problems in parallel, we want to try a different ordering strategy which maintain independent graphs separately. This PR allows the option.

## Stakeholder Feedback

This is requested from ASC customer. 

## Testing

This option is the default ordering option now for testing and it passes the unit test.
