### PR TITLE
Tpetra: CrsGraph: stop trying to read row pointers on host

### DIFF
--- a/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
+++ b/packages/tpetra/core/src/Tpetra_CrsGraph_def.hpp
@@ -1577,8 +1577,9 @@ namespace Tpetra {
         ret.allocSize = 0;
       }
       else {
-        ret.offset1D  = this->k_rowPtrs_(myRow);
-        ret.allocSize = this->k_rowPtrs_(myRow+1) - this->k_rowPtrs_(myRow);
+        auto lclRowPtrs = ::Tpetra::Details::getEntriesOnHost(this->k_rowPtrs_, myRow, 2);
+        ret.offset1D  = lclRowPtrs(0);
+        ret.allocSize = lclRowPtrs(1) - lclRowPtrs(0);
       }
 
       ret.numEntries = (this->k_numRowEntries_.extent (0) == 0) ?
@@ -1633,8 +1634,9 @@ namespace Tpetra {
         ret.allocSize = 0;
       }
       else {
-        ret.offset1D  = this->k_rowPtrs_(myRow);
-        ret.allocSize = this->k_rowPtrs_(myRow+1) - this->k_rowPtrs_(myRow);
+        auto lclRowPtrs = ::Tpetra::Details::getEntriesOnHost(this->k_rowPtrs_, myRow, 2);
+        ret.offset1D  = lclRowPtrs(0);
+        ret.allocSize = lclRowPtrs(1) - lclRowPtrs(0);
       }
 
       ret.numEntries = (this->k_numRowEntries_.extent (0) == 0) ?
@@ -2195,7 +2197,7 @@ namespace Tpetra {
         (this->isLocallyIndexed () &&
          this->k_rowPtrs_.extent (0) != 0 &&
          (static_cast<size_t> (k_rowPtrs_.extent (0)) != static_cast<size_t> (lclNumRows + 1) ||
-          this->k_rowPtrs_(lclNumRows) != static_cast<size_t> (this->k_lclInds1D_.extent (0))),
+          ::Tpetra::Details::getEntryOnHost(this->k_rowPtrs_, lclNumRows) != static_cast<size_t> (this->k_lclInds1D_.extent (0))),
          std::logic_error, "If k_rowPtrs_ has nonzero size and "
          "the graph is locally indexed, then "
          "k_rowPtrs_ must have N+1 rows, and "
@@ -3084,8 +3086,9 @@ namespace Tpetra {
         // We have to iterate through the row offsets anyway, so we
         // might as well check whether all rows' bounds are the same.
         bool allRowsReallySame = false;
+        auto k_rowPtrs_h = ::Tpetra::Details::getEntriesOnHost(this->k_rowPtrs_, 0, numRows);
         for (ptrdiff_t i = 0; i < numRows; ++i) {
-          numEnt[i] = this->k_rowPtrs_(i+1) - this->k_rowPtrs_(i);
+          numEnt[i] = k_rowPtrs_h(i+1) - k_rowPtrs_h(i);
           if (i != 0 && numEnt[i] != numEnt[i-1]) {
             allRowsReallySame = false;
           }

--- a/packages/tpetra/core/src/Tpetra_Details_getEntryOnHost.hpp
+++ b/packages/tpetra/core/src/Tpetra_Details_getEntryOnHost.hpp
@@ -67,6 +67,19 @@ getEntryOnHost (const ViewType& x,
   return val;
 }
 
+template<class ViewType,
+         class IndexType>
+typename ViewType::HostMirror::const_type
+getEntriesOnHost (const ViewType& x,
+                  const IndexType ind,
+                  const int count)
+{
+  static_assert (ViewType::Rank == 1, "x must be a rank-1 Kokkos::View.");
+  // Get a 1-D subview of the entry of the array, and copy to host.
+  auto subview = Kokkos::subview(x, Kokkos::make_pair(ind, ind + count));
+  return Kokkos::create_mirror_view_and_copy(typename ViewType::HostMirror::memory_space(), subview);
+}
+
 } // namespace Details
 } // namespace Tpetra
 


### PR DESCRIPTION
@trilinos/tpetra @cgcgcg @lucbv 

## Motivation
CrsGraph was reading the row pointers on host, which leads to segfaults when CudaSpace is the device memory space.

## Related Issues

* Closes #8286 

## Testing
Tests still pass locally in a UVM build.  The particular segfault no longer occurs in a non-UVM build.