### PR TITLE
Tpetra: fix typo in test instantiation

### DIFF
--- a/packages/tpetra/core/test/MultiVector/Vector_offsetViewCtor.cpp
+++ b/packages/tpetra/core/test/MultiVector/Vector_offsetViewCtor.cpp
@@ -190,7 +190,7 @@ namespace { // (anonymous)
 //
 
 #define UNIT_TEST_GROUP( SCALAR, LO, GO, NODE ) \
-  TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL( Vector, OffsetViewCtor, ST, LO, GO, NT )
+  TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT( Vector, OffsetViewCtor, ST, LO, GO, NT )
 
   TPETRA_ETI_MANGLING_TYPEDEFS()
 


### PR DESCRIPTION
Replace TEUCHOS_UNIT_TEST_TEMPLATE_4_DECL with TEUCHOS_UNIT_TEST_TEMPLATE_4_INSTANT
at the bottom of Vector_offsetViewCtor.cpp. the ...DECL macro is already called for this test above, at the bottom it needs to be instantiated with the ...INSTANT macro. Note that this file is not actually compiled (@mhoemmen had commented out it in CMakeLists.txt) but it's tripping up the automatic LO/GO removal script.
<!---
Be sure to select `develop` as the `base` branch against which to create this
pull request.  Only pull requests against `develop` will undergo Trilinos'
automated testing.  Pull requests against `master` will be ignored.

Provide a general summary of your changes in the Title above.  If this pull
request pertains to a particular package in Trilinos, it's worthwhile to start
the title with "PackageName:  ".

Note that anything between these delimiters is a comment that will not appear
in the pull request description once created. Most areas in this message are
commented out and can be easily added by removing the comment delimiters.

Please make sure to mark:
* Reviewers
* Assignees
* Labels

Replace <teamName> below with the appropriate Trilinos package/team name.
-->
@trilinos/tpetra 

## Motivation
<!--- 
Why is this change required?  What problem does it solve? Please link to a github 
issue that describes the problem/issue/bug this PR solves.
-->
Just allows the LO removal script to run on this file. It doesn't change any behavior or affect testing, since this file is never compiled.
<!---
If applicable, let us know how this merge request is related to any other open
issues or pull requests:

## Related Issues

* Closes 
* Blocks 
* Is blocked by 
* Follows 
* Precedes 
* Related to 
* Part of 
* Composed of 
-->


## Stakeholder Feedback
<!--- 
If a github issue includes feedback from the relevant stakeholder(s), please link it.  
If the stakeholder(s) communicated that feedback through a different medium, please note that you did so.
-->

## Testing
<!---
Please confirm that any classes or functions in the Trilinos library that this PR touches are 
exercised by at least one test in Trilinos.  Please specify which test that is.  For untestable 
changes (e.g. changes to the nightly testing system) or changes to Trilinos tests, please say "N/A".

-->

<!--- 
## Additional Information
Anything else we need to know in evaluating this merge request?
 -->